### PR TITLE
Prefer workspace extension host

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "project-steward",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "project-steward",
-            "version": "1.1.0",
+            "version": "1.1.1",
             "dependencies": {
                 "dragula": "^3.7.3",
                 "fitty": "^2.3.5"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "project-steward",
     "displayName": "Project Steward",
     "description": "Organize local, SSH, and Dev Container projects in a synchronized project steward.",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "publisher": "hzcheng",
     "license": "MIT",
     "icon": "media/extension_icon.png",
@@ -10,8 +10,8 @@
         "vscode": "^1.51.0"
     },
     "extensionKind": [
-        "ui",
-        "workspace"
+        "workspace",
+        "ui"
     ],
     "categories": [
         "Other"


### PR DESCRIPTION
## Summary

- Prefer the workspace extension host before the UI extension host.
- Bump the extension version to `1.1.1`.

## Why

Project Steward reads Codex session files from the extension host environment. In remote and Dev Container workspaces, preferring the workspace host lets the extension see the remote/container Codex data when it is installed there.

## Validation

- `npm run test-compile`
