### PR TITLE
Release 1.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to the "Project Steward" extension will be documented in this file. It follows the [Keep a Changelog](http://keepachangelog.com/) recommendations.
 
+## [1.1.7] 2026-07-10
+
+### Added
+
+-   Allow favorite project cards to be reordered by dragging within the `FAVORITES` group.
+
+### Changed
+
+-   Persist Favorites ordering in project data so it follows the existing Settings Sync behavior.
+-   Append newly favorited projects to the end of the Favorites list.
+
+### Fixed
+
+-   Keep Favorites-only drag operations isolated from ordinary Group and Open Project cards.
+
 ## [1.1.6] 2026-07-10
 
 ### Added

--- a/docs/superpowers/plans/2026-07-10-favorites-drag-order.md
+++ b/docs/superpowers/plans/2026-07-10-favorites-drag-order.md
@@ -1,0 +1,360 @@
+# Favorites Drag Ordering Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow users to reorder existing favorite project cards by dragging only within the `FAVORITES` group, while preserving ordinary Group order and synchronizing the result with project data.
+
+**Architecture:** Add a pure Favorites ordering module that owns sorting, normalization, and favorite toggling through cloned Group data. The Dashboard persists its output through the existing `ProjectService`, while Webview rendering consumes the same ordering helper and Dragula sends a dedicated `reordered-favorites` message for same-container Favorites drops.
+
+**Tech Stack:** TypeScript, VS Code Extension API, JavaScript Webview scripts, Dragula, Node `assert`/`vm` safety checks, Gulp asset generation.
+
+## Global Constraints
+
+- Create and work on `feat/favorites-order` from `main`; do not implement directly on `main`.
+- Allow only `FAVORITES` to `FAVORITES` reordering within the same group container.
+- Reject ordinary Group or `OPEN PROJECT` cards entering Favorites, and reject Favorites cards leaving Favorites.
+- Never change ordinary Group ordering or project ownership when Favorites is reordered.
+- Persist `favoriteOrder?: number` inside existing project data so it follows the current `storeProjectsInSettings` synchronization behavior.
+- Append newly favorited projects to the end; clear order when unfavorited; re-favoriting appends again.
+- Keep old data without `favoriteOrder` readable and stable.
+- Do not add a new configuration key, globalState key, dependency, polling loop, or optimistic Webview persistence.
+- Do not stage or commit implementation changes before user review.
+
+---
+
+### Task 1: Implement Pure Favorites Ordering Rules
+
+**Files:**
+- Create: `src/projects/favoriteProjectOrder.ts`
+- Modify: `src/models.ts`
+- Test: `scripts/run-ai-session-safety-checks.js`
+
+**Interfaces:**
+- Produces: `getFavoriteProjectsInOrder(projects: readonly Project[]): Project[]`.
+- Produces: `withFavoriteProjectOrder(groups: readonly Group[], projectIds: readonly string[]): Group[]`.
+- Produces: `withToggledProjectFavorite(groups: readonly Group[], projectId: string): Group[] | null`.
+- Adds: `Project.favoriteOrder?: number`.
+
+- [ ] **Step 1: Create the feature branch without touching local-only settings**
+
+Run:
+
+```bash
+git switch -c feat/favorites-order main
+git status --short
+```
+
+Expected: branch is `feat/favorites-order`; `.vscode/settings.json` and the untracked design/plan documents remain present; no source files are staged.
+
+- [ ] **Step 2: Write failing ordering tests**
+
+Import `../out/projects/favoriteProjectOrder` in `scripts/run-ai-session-safety-checks.js` and add tests covering:
+
+```js
+function runFavoriteProjectOrderChecks() {
+    const projects = [
+        { id: 'legacy-a', favorite: true },
+        { id: 'ordered', favorite: true, favoriteOrder: 0 },
+        { id: 'duplicate-a', favorite: true, favoriteOrder: 2 },
+        { id: 'duplicate-b', favorite: true, favoriteOrder: 2 },
+        { id: 'invalid', favorite: true, favoriteOrder: -1 },
+        { id: 'plain', favorite: false, favoriteOrder: 7 },
+    ];
+
+    assert.deepStrictEqual(
+        favoriteProjectOrder.getFavoriteProjectsInOrder(projects).map(project => project.id),
+        ['ordered', 'legacy-a', 'duplicate-a', 'duplicate-b', 'invalid']
+    );
+
+    const groups = [
+        { id: 'one', projects: [projects[0], projects[1], projects[5]] },
+        { id: 'two', projects: [projects[2], projects[3], projects[4]] },
+    ];
+    const reordered = favoriteProjectOrder.withFavoriteProjectOrder(
+        groups,
+        ['invalid', 'ordered', 'invalid', 'unknown']
+    );
+
+    assert.deepStrictEqual(
+        favoriteProjectOrder.getFavoriteProjectsInOrder(reordered.flatMap(group => group.projects)).map(project => project.id),
+        ['invalid', 'ordered', 'legacy-a', 'duplicate-a', 'duplicate-b']
+    );
+    assert.deepStrictEqual(reordered.map(group => group.projects.map(project => project.id)), [
+        ['legacy-a', 'ordered', 'plain'],
+        ['duplicate-a', 'duplicate-b', 'invalid'],
+    ]);
+    assert.strictEqual(reordered[0].projects[2].favoriteOrder, undefined);
+    assert.strictEqual(projects[0].favoriteOrder, undefined);
+}
+```
+
+Add separate assertions that toggling a non-favorite appends it after existing favorites, toggling a favorite removes `favoriteOrder`, re-favoriting appends it again, and an unknown ID returns `null`.
+
+- [ ] **Step 3: Run RED verification**
+
+Run `npm run test:safety`.
+
+Expected: failure because `out/projects/favoriteProjectOrder` does not exist.
+
+- [ ] **Step 4: Implement the pure module and model field**
+
+Add `favoriteOrder?: number` beside `favorite?: boolean` in `src/models.ts`.
+
+Create `src/projects/favoriteProjectOrder.ts` with these rules:
+
+```ts
+export function getFavoriteProjectsInOrder(projects: readonly Project[]): Project[] {
+    let favorites = (projects || []).filter(project => project.favorite);
+    let orderCounts = new Map<number, number>();
+    for (let project of favorites) {
+        if (isValidFavoriteOrder(project.favoriteOrder)) {
+            orderCounts.set(project.favoriteOrder, (orderCounts.get(project.favoriteOrder) || 0) + 1);
+        }
+    }
+
+    return favorites.map((project, sourceIndex) => ({ project, sourceIndex }))
+        .sort((left, right) => compareFavoriteEntries(left, right, orderCounts))
+        .map(entry => entry.project);
+}
+```
+
+`withFavoriteProjectOrder` must clone every Group and Project, deduplicate requested IDs, ignore unknown/non-favorite IDs, append omitted favorites using `getFavoriteProjectsInOrder`, assign continuous `0..n-1` values, and remove `favoriteOrder` from non-favorites.
+
+`withToggledProjectFavorite` must return `null` for unknown IDs, otherwise clone all data, derive the current display order before toggling, remove/append the target ID as appropriate, update `favorite`, and normalize through the same order application logic.
+
+- [ ] **Step 5: Run GREEN verification**
+
+Run `npm run test:safety`.
+
+Expected: all ordering, immutability, toggle, and existing safety checks pass.
+
+---
+
+### Task 2: Integrate Favorites Ordering with Rendering and Persistence
+
+**Files:**
+- Modify: `src/webview/webviewContent.ts`
+- Modify: `src/dashboard.ts`
+- Test: `scripts/run-ai-session-safety-checks.js`
+
+**Interfaces:**
+- Consumes: the three functions from `src/projects/favoriteProjectOrder.ts`.
+- Consumes Webview message: `{ type: 'reordered-favorites'; projectIds: string[] }`.
+- Persists through: `projectService.saveGroups(groups)`.
+
+- [ ] **Step 1: Write failing integration assertions**
+
+Extend safety checks to require:
+
+```js
+assert.ok(webviewContent.includes('getFavoriteProjectsInOrder('));
+assert.ok(dashboard.includes("case 'reordered-favorites':"));
+assert.ok(dashboard.includes('withFavoriteProjectOrder(groups, projectIds)'));
+assert.ok(dashboard.includes('withToggledProjectFavorite(groups, projectId)'));
+```
+
+Extend the real `getStewardContent()` rendering check with unordered favorite fixtures and assert that Favorites card opening tags occur in `favoriteOrder` order while the ordinary Group section remains in its original order.
+
+- [ ] **Step 2: Run RED verification**
+
+Run `npm run test:safety`.
+
+Expected: source/rendering assertions fail because rendering and Dashboard handlers do not use the new module.
+
+- [ ] **Step 3: Sort only the virtual Favorites projection**
+
+In `src/webview/webviewContent.ts`, import `getFavoriteProjectsInOrder` and change Favorites construction to:
+
+```ts
+var favoriteProjects = getFavoriteProjectsInOrder(
+    groups.reduce((projects, group) => projects.concat(group.projects || []), [] as Project[])
+);
+```
+
+Do not sort or replace `groups` or their `projects` arrays.
+
+- [ ] **Step 4: Add the dedicated Dashboard message handler**
+
+In `handleStewardMessage`, add:
+
+```ts
+case 'reordered-favorites':
+    await reorderFavoriteProjects(Array.isArray(e.projectIds) ? e.projectIds : []);
+    break;
+```
+
+Implement:
+
+```ts
+async function reorderFavoriteProjects(projectIds: string[]) {
+    let groups = projectService.getGroups();
+    let reorderedGroups = withFavoriteProjectOrder(groups, projectIds);
+    await projectService.saveGroups(reorderedGroups);
+    refreshAfterMutation();
+}
+```
+
+- [ ] **Step 5: Replace single-project favorite updates with normalized Group updates**
+
+Change `toggleProjectFavorite` to read all Groups, call `withToggledProjectFavorite`, return when it yields `null`, save the returned Groups once, and refresh. Remove the old `projectService.updateProject` path so append/cleanup normalization is atomic.
+
+- [ ] **Step 6: Run integration verification**
+
+Run `npm run test:safety`.
+
+Expected: sorted rendering and Dashboard source assertions pass; all existing project, window-color, and AI session checks remain green.
+
+---
+
+### Task 3: Restrict Dragula to Favorites Same-Group Reordering
+
+**Files:**
+- Modify: `src/webview/webviewContent.ts`
+- Modify: `src/webview/webviewDnDScripts.js`
+- Generate: `media/webviewDnDScripts.js`
+- Test: `scripts/run-ai-session-safety-checks.js`
+
+**Interfaces:**
+- Produces pure Webview predicates: `isFavoritesProjectContainer`, `canMoveProject`, and `canAcceptProject`.
+- Produces message: `{ type: 'reordered-favorites'; projectIds: string[] }`.
+- Keeps existing `{ type: 'reordered-projects'; groupOrders }` behavior for ordinary Groups.
+
+- [ ] **Step 1: Write failing executable Dragula predicate tests**
+
+Load `src/webview/webviewDnDScripts.js` with Node `vm` without calling `initDnD`. Use fake containers whose `closest()` reports ordinary, Favorites, or Open Project state, then assert:
+
+```js
+assert.strictEqual(dnd.canMoveProject(draggable, favorites), true);
+assert.strictEqual(dnd.canMoveProject(draggable, openProjects), false);
+assert.strictEqual(dnd.canMoveProject(draggable, ordinary), true);
+assert.strictEqual(dnd.canAcceptProject(favorites, favorites), true);
+assert.strictEqual(dnd.canAcceptProject(ordinary, favorites), false);
+assert.strictEqual(dnd.canAcceptProject(favorites, ordinary), false);
+assert.strictEqual(dnd.canAcceptProject(ordinaryTwo, ordinary), true);
+```
+
+Also assert the source script contains `type: 'reordered-favorites'` and that generated `media/webviewDnDScripts.js` is byte-for-byte identical after generation.
+
+- [ ] **Step 2: Run RED verification**
+
+Run `npm run test:safety`.
+
+Expected: executable checks fail because the named predicates and Favorites message do not exist.
+
+- [ ] **Step 3: Render Favorites cards as draggable virtual copies**
+
+Extend `getProjectDiv` with a boolean that controls whether a virtual card receives container-level `data-nodrag`. Pass `true` only for the Favorites group; preserve `data-virtual-project` so ordinary reorder serialization continues excluding Favorites copies. Open Project cards remain `data-nodrag`.
+
+- [ ] **Step 4: Implement Dragula predicates and specialized drop handling**
+
+At module scope in `src/webview/webviewDnDScripts.js`, implement:
+
+```js
+function isFavoritesProjectContainer(container) {
+    return Boolean(container && container.closest('[data-system-group="__favorites"]'));
+}
+
+function canMoveProject(el, source) {
+    if (!el || el.hasAttribute('data-nodrag')) {
+        return false;
+    }
+    return isFavoritesProjectContainer(source) || !source.closest('[data-virtual-group]');
+}
+
+function canAcceptProject(target, source) {
+    if (isFavoritesProjectContainer(source)) {
+        return target === source;
+    }
+    return !isFavoritesProjectContainer(target) && !target.closest('[data-virtual-group]');
+}
+```
+
+Use these predicates in Dragula. In the `drop` callback, route Favorites drops to `onFavoritesReordered(source)` and all other drops to the existing `onReordered()`.
+
+`onFavoritesReordered` must collect all Favorites `.project[data-id]` IDs in DOM order and post only `reordered-favorites`.
+
+- [ ] **Step 5: Generate the shipped Webview asset**
+
+Run `npx gulp copyWebviewAssets`.
+
+Expected: `media/webviewDnDScripts.js` exactly matches `src/webview/webviewDnDScripts.js`.
+
+- [ ] **Step 6: Run GREEN verification**
+
+Run `npm run test:safety`.
+
+Expected: all same-group/cross-group predicate checks, message checks, generated asset checks, and existing safety checks pass.
+
+---
+
+### Task 4: Production and Regression Verification
+
+**Files:**
+- Verify: `src/projects/favoriteProjectOrder.ts`
+- Verify: `src/models.ts`
+- Verify: `src/dashboard.ts`
+- Verify: `src/webview/webviewContent.ts`
+- Verify: `src/webview/webviewDnDScripts.js`
+- Verify: `media/webviewDnDScripts.js`
+- Verify: `scripts/run-ai-session-safety-checks.js`
+
+**Interfaces:**
+- Produces a reviewable, unstaged implementation and reproducible verification evidence.
+
+- [ ] **Step 1: Run static checks and production build**
+
+Run:
+
+```bash
+npm run test-compile
+npm run lint
+npm run vscode:prepublish
+npm run test:safety
+```
+
+Expected: every command exits `0`; lint may report only the repository's existing warning set; webpack and Gulp complete successfully.
+
+- [ ] **Step 2: Verify source/generated asset parity and persistence scope**
+
+Run:
+
+```bash
+cmp src/webview/webviewDnDScripts.js media/webviewDnDScripts.js
+git diff --check
+git status --short
+git diff --cached --name-only
+```
+
+Expected: scripts are identical, no whitespace errors, no staged files, and `.vscode/settings.json` remains an unrelated local modification.
+
+- [ ] **Step 3: Review the final diff against invariants**
+
+Confirm from the diff and tests:
+
+```text
+1. Ordinary Group arrays retain their original project ID order.
+2. Only favoriteOrder/favorite fields change during Favorites operations.
+3. Old projects without favoriteOrder remain visible.
+4. Unknown, duplicate, and omitted IDs cannot remove Favorites.
+5. Favorites drag cannot cross any group boundary.
+6. Ordinary Group drag and Open Project no-drag behavior remain unchanged.
+7. No new settings, globalState keys, dependencies, or polling were added.
+```
+
+- [ ] **Step 4: Manual Extension Development Host checks**
+
+Launch with `F5` and verify:
+
+```text
+1. Reorder several cards inside FAVORITES and reload the window; order persists.
+2. Original Groups do not move or reorder.
+3. Dragging Favorites out, ordinary cards in, or Open Project cards does nothing.
+4. A newly favorited card appears at the bottom.
+5. Unfavorite then re-favorite a card; it returns at the bottom.
+6. Escape cancels an active drag without saving.
+7. With Settings Sync/project settings storage enabled, favoriteOrder is present in projectData.
+```
+
+- [ ] **Step 5: Stop before staging**
+
+Do not run `git add` or `git commit`. Present changed files, automated results, review findings, and any manual-test limitation to the user.

--- a/docs/superpowers/specs/2026-07-10-favorites-drag-order-design.md
+++ b/docs/superpowers/specs/2026-07-10-favorites-drag-order-design.md
@@ -1,0 +1,118 @@
+# Favorites 组内拖拽排序设计
+
+## 目标
+
+允许用户在 Project Steward 的 `FAVORITES` 虚拟组内通过鼠标拖动重新排列已有收藏项目卡片。该顺序独立于普通 Group 的项目顺序，并跟随现有项目数据跨机器同步。
+
+## 产品行为
+
+- 只有 `FAVORITES` 组内的已有收藏卡片可以参与 Favorites 排序。
+- 卡片只能从 `FAVORITES` 拖到同一个 `FAVORITES` 组中的其他位置。
+- 不允许从普通 Group 或 `OPEN PROJECT` 拖入 `FAVORITES`。
+- 不允许把 Favorites 卡片拖到普通 Group、`OPEN PROJECT` 或其他区域。
+- Favorites 拖动不得改变项目在原始 Group 中的顺序或所属 Group。
+- 新收藏的项目默认追加到 Favorites 末尾。
+- 取消收藏后，该项目立即从 Favorites 消失；再次收藏时作为新收藏追加到末尾。
+- 按 Escape 取消拖动时不保存顺序。
+- 拖动后的顺序刷新侧边栏、重启 VS Code 和切换机器后保持一致，前提是项目数据使用 VS Code Settings 存储并参与 Settings Sync。
+
+## 数据模型
+
+在 `Project` 上增加可选字段：
+
+```ts
+favoriteOrder?: number;
+```
+
+该字段与现有 `favorite` 字段一起保存在 `projectData` 中：
+
+- 收藏项目使用从 `0` 开始的连续整数表示顺序。
+- 非收藏项目不保留 `favoriteOrder`。
+- 不新增独立配置键、globalState 键或 ID 顺序数组。
+- 当 `storeProjectsInSettings` 为 `true` 时，顺序自然参与 Settings Sync；为 `false` 时遵循现有项目数据的本机存储行为。
+
+## 兼容与规范化
+
+旧版本收藏项目没有 `favoriteOrder`，渲染时按以下规则处理：
+
+1. 有有效 `favoriteOrder` 的项目按数值升序排列。
+2. 没有有效顺序的收藏项目追加在已排序项目之后，并保持它们在原始 Group 汇总列表中的相对顺序。
+3. 第一次拖动或新增收藏时，把当前 Favorites 显示顺序规范化为连续整数。
+
+有效顺序必须是有限、非负整数。重复、负数、`NaN` 或非数字值按缺失顺序处理。保存一次新的顺序后会被规范化。
+
+## 拖拽交互
+
+继续使用现有 Dragula 实例，但为 Favorites 增加明确的源与目标判断：
+
+- 普通项目拖拽保持现有逻辑，只能在非虚拟 Group 之间移动。
+- `OPEN PROJECT` 继续禁止拖拽。
+- Favorites 项目允许开始拖动，但目标必须与源相同且属于 `FAVORITES`。
+- Favorites 拖动继续使用现有拖动透明度、占位和自动滚动反馈。
+- Favorites drop 不调用普通的 `onReordered()`，而是读取 Favorites 组内当前卡片 ID，并发送独立消息：
+
+```ts
+{
+    type: 'reordered-favorites',
+    projectIds: string[]
+}
+```
+
+Webview 不自行修改收藏状态或持久化数据。
+
+## Extension Host 处理
+
+Dashboard 收到 `reordered-favorites` 后：
+
+1. 读取当前 Groups 和所有收藏项目。
+2. 对消息中的 ID 去重，忽略未知 ID 和已经取消收藏的项目。
+3. 按消息顺序排列有效收藏项目。
+4. 将未出现在消息中的现有收藏项目追加到末尾，避免并发同步或刷新期间丢失项目。
+5. 为最终列表写入连续的 `favoriteOrder`。
+6. 清除所有非收藏项目残留的 `favoriteOrder`。
+7. 调用现有 `ProjectService.saveGroups()` 并刷新 Dashboard。
+
+普通 Group 数组和每个 Group 内的 `projects` 数组顺序均保持不变，只更新项目对象上的排序字段。
+
+## 收藏切换
+
+收藏一个项目时：
+
+1. 按当前 Favorites 显示规则取得已有收藏项目。
+2. 将已有项目规范化为连续顺序。
+3. 把新收藏项目追加到末尾并写入最后一个序号。
+
+取消收藏时清除 `favoriteOrder`。再次收藏会获得新的末尾序号，不恢复历史位置。
+
+## 模块边界
+
+新增一个纯逻辑模块负责 Favorites 排序，避免把排序规则散落在 Dashboard 和 Webview：
+
+- 判断 `favoriteOrder` 是否有效。
+- 根据原始项目列表生成稳定的 Favorites 显示顺序。
+- 根据拖拽 ID 列表生成规范化顺序。
+- 在不改变 Group/项目数组顺序的前提下更新项目排序字段。
+
+Dashboard 负责读取/保存数据和处理消息；Webview 负责渲染及发送拖拽结果；Dragula 只负责交互约束。
+
+## 错误处理
+
+- 空 ID 列表不会删除收藏项目；当前收藏项目按已有显示顺序保留并规范化。
+- 重复 ID 只采用第一次出现的位置。
+- 未知或非收藏 ID 被忽略。
+- 同步期间新增但未出现在 drop 消息里的收藏项目追加到末尾。
+- 保存失败沿用现有错误记录/提示路径，不在 Webview 中乐观持久化。
+
+## 测试
+
+- 旧数据没有 `favoriteOrder` 时保持原汇总顺序。
+- 有效顺序按数值排序，无效和重复顺序稳定追加。
+- 新收藏项目追加到末尾，取消收藏清除顺序，再收藏仍追加到末尾。
+- 拖拽 ID 中的重复、未知和非收藏项目被忽略。
+- drop 消息遗漏的现有收藏项目追加到末尾。
+- 排序后 `favoriteOrder` 为从 `0` 开始的连续整数。
+- Favorites 排序不改变普通 Group 或 Group 内项目数组顺序。
+- Favorites 只接受同组拖拽，拒绝所有跨组拖入和拖出。
+- Open Project 保持不可拖动，普通 Group 拖拽行为不回归。
+- Webview 发送 `reordered-favorites`，Dashboard 不把它交给普通 `reordered-projects` 处理器。
+- 编译后的 Webview 脚本与源脚本保持同步。

--- a/media/webviewDnDScripts.js
+++ b/media/webviewDnDScripts.js
@@ -1,3 +1,26 @@
+function isFavoritesProjectContainer(container) {
+    return Boolean(container && container.closest('[data-system-group="__favorites"]'));
+}
+
+function canMoveProject(el, source) {
+    if (!el || !source || el.hasAttribute('data-nodrag')) {
+        return false;
+    }
+
+    return isFavoritesProjectContainer(source) || !source.closest('[data-virtual-group]');
+}
+
+function canAcceptProject(target, source) {
+    if (!target || !source) {
+        return false;
+    }
+    if (isFavoritesProjectContainer(source)) {
+        return target === source;
+    }
+
+    return !isFavoritesProjectContainer(target) && !target.closest('[data-virtual-group]');
+}
+
 function initDnD() {
     const projectsContainerSelector = ".group-list";
     const groupsContainerSelector = ".groups-wrapper";
@@ -7,13 +30,19 @@ function initDnD() {
     var projectsContainers = document.querySelectorAll(projectsContainerSelector);
     var projectDrake = dragula([].slice.call(projectsContainers), {
         moves: function (el, source, handle, sibling) {
-            return !el.hasAttribute("data-nodrag") && !source.closest("[data-virtual-group]");
+            return canMoveProject(el, source);
         },
         accepts: function (el, target, source, sibling) {
-            return !target.closest("[data-virtual-group]");
+            return canAcceptProject(target, source);
         },
     });
-    projectDrake.on('drop', onReordered);
+    projectDrake.on('drop', function (el, target, source) {
+        if (isFavoritesProjectContainer(source)) {
+            onFavoritesReordered(source);
+            return;
+        }
+        onReordered();
+    });
     projectDrake.on('drag', () => document.body.classList.add('project-dragging'));
     projectDrake.on('dragend', () => document.body.classList.remove('project-dragging'));
 
@@ -61,6 +90,16 @@ function initDnD() {
         window.vscode.postMessage({
             type: 'reordered-projects',
             groupOrders,
+        });
+    }
+
+    function onFavoritesReordered(favoritesContainer) {
+        let projectIds = [].slice.call(favoritesContainer.querySelectorAll('.project[data-id]'))
+            .map(project => project.getAttribute('data-id'));
+
+        window.vscode.postMessage({
+            type: 'reordered-favorites',
+            projectIds,
         });
     }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "project-steward",
-    "version": "1.1.6",
+    "version": "1.1.7",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "project-steward",
-            "version": "1.1.6",
+            "version": "1.1.7",
             "dependencies": {
                 "dragula": "^3.7.3",
                 "fitty": "^2.3.5"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "project-steward",
     "displayName": "Project Steward",
     "description": "Organize local, SSH, and Dev Container projects in a synchronized project steward.",
-    "version": "1.1.6",
+    "version": "1.1.7",
     "publisher": "hzcheng",
     "license": "MIT",
     "icon": "media/extension_icon.png",

--- a/scripts/run-ai-session-safety-checks.js
+++ b/scripts/run-ai-session-safety-checks.js
@@ -5,6 +5,7 @@ const fs = require('fs');
 const Module = require('module');
 const os = require('os');
 const path = require('path');
+const vm = require('vm');
 const commands = require('../out/aiSessions/commandBuilders');
 const helpers = require('../out/aiSessions/sessionHelpers');
 const AiSessionPinStore = require('../out/aiSessions/pinStore').default;
@@ -13,6 +14,7 @@ const ClaudeSessionService = require('../out/services/claudeSessionService').def
 const GitRepositoryDetector = require('../out/projects/gitRepositoryDetector').default;
 const projectPathUtils = require('../out/projects/projectPathUtils');
 const currentWorkspaceState = require('../out/projects/currentWorkspaceState');
+const favoriteProjectOrder = require('../out/projects/favoriteProjectOrder');
 const originalModuleLoad = Module._load;
 Module._load = function (request, parent, isMain) {
     if (request === 'vscode') {
@@ -101,6 +103,83 @@ function runCurrentWorkspaceStateChecks() {
     assert.strictEqual(saved.isCurrentWorkspace, undefined);
     assert.strictEqual(openProjects[0].isCurrentWorkspace, undefined);
     assert.notStrictEqual(result.groups[0], groups[0]);
+}
+
+function runFavoriteProjectOrderChecks() {
+    const projects = [
+        { id: 'legacy-a', favorite: true },
+        { id: 'ordered', favorite: true, favoriteOrder: 0 },
+        { id: 'duplicate-a', favorite: true, favoriteOrder: 2 },
+        { id: 'duplicate-b', favorite: true, favoriteOrder: 2 },
+        { id: 'invalid', favorite: true, favoriteOrder: -1 },
+        { id: 'plain', favorite: false, favoriteOrder: 7 },
+    ];
+
+    assert.deepStrictEqual(
+        favoriteProjectOrder.getFavoriteProjectsInOrder(projects).map(project => project.id),
+        ['ordered', 'legacy-a', 'duplicate-a', 'duplicate-b', 'invalid']
+    );
+
+    const groups = [
+        { id: 'one', projects: [projects[0], projects[1], projects[5]] },
+        { id: 'two', projects: [projects[2], projects[3], projects[4]] },
+    ];
+    const reordered = favoriteProjectOrder.withFavoriteProjectOrder(
+        groups,
+        ['invalid', 'ordered', 'invalid', 'unknown', 'plain']
+    );
+    const reorderedProjects = reordered.reduce((all, group) => all.concat(group.projects), []);
+
+    assert.deepStrictEqual(
+        favoriteProjectOrder.getFavoriteProjectsInOrder(reorderedProjects).map(project => project.id),
+        ['invalid', 'ordered', 'legacy-a', 'duplicate-a', 'duplicate-b']
+    );
+    assert.deepStrictEqual(reordered.map(group => group.projects.map(project => project.id)), [
+        ['legacy-a', 'ordered', 'plain'],
+        ['duplicate-a', 'duplicate-b', 'invalid'],
+    ]);
+    assert.deepStrictEqual(
+        favoriteProjectOrder.getFavoriteProjectsInOrder(reorderedProjects).map(project => project.favoriteOrder),
+        [0, 1, 2, 3, 4]
+    );
+    assert.strictEqual(reordered[0].projects[2].favoriteOrder, undefined);
+    assert.strictEqual(projects[0].favoriteOrder, undefined);
+    assert.notStrictEqual(reordered[0], groups[0]);
+    assert.notStrictEqual(reordered[0].projects[0], groups[0].projects[0]);
+
+    const toggleGroups = [{
+        id: 'toggle',
+        projects: [
+            { id: 'a', favorite: true, favoriteOrder: 0 },
+            { id: 'b', favorite: true, favoriteOrder: 1 },
+            { id: 'c', favorite: false, favoriteOrder: 9 },
+        ],
+    }];
+    const added = favoriteProjectOrder.withToggledProjectFavorite(toggleGroups, 'c');
+    const addedProjects = added[0].projects;
+    assert.deepStrictEqual(
+        favoriteProjectOrder.getFavoriteProjectsInOrder(addedProjects).map(project => project.id),
+        ['a', 'b', 'c']
+    );
+    assert.strictEqual(addedProjects[2].favorite, true);
+    assert.strictEqual(addedProjects[2].favoriteOrder, 2);
+
+    const removed = favoriteProjectOrder.withToggledProjectFavorite(added, 'b');
+    assert.deepStrictEqual(
+        favoriteProjectOrder.getFavoriteProjectsInOrder(removed[0].projects).map(project => project.id),
+        ['a', 'c']
+    );
+    assert.strictEqual(removed[0].projects[1].favorite, false);
+    assert.strictEqual(removed[0].projects[1].favoriteOrder, undefined);
+
+    const readded = favoriteProjectOrder.withToggledProjectFavorite(removed, 'b');
+    assert.deepStrictEqual(
+        favoriteProjectOrder.getFavoriteProjectsInOrder(readded[0].projects).map(project => project.id),
+        ['a', 'c', 'b']
+    );
+    assert.strictEqual(favoriteProjectOrder.withToggledProjectFavorite(toggleGroups, 'missing'), null);
+    assert.strictEqual(toggleGroups[0].projects[2].favorite, false);
+    assert.strictEqual(toggleGroups[0].projects[2].favoriteOrder, 9);
 }
 
 function runCurrentWorkspaceMatchingChecks() {
@@ -282,6 +361,10 @@ function runWebviewContentChecks() {
     assert.ok(dashboard.includes('get currentWorkspaceProjectIds() { return getCurrentWorkspaceProjectIds() }'));
     assert.ok(webviewContent.includes('withCurrentWorkspaceState('));
     assert.ok(webviewContent.includes('infos.currentWorkspaceProjectIds || []'));
+    assert.ok(webviewContent.includes('getFavoriteProjectsInOrder('));
+    assert.ok(dashboard.includes("case 'reordered-favorites':"));
+    assert.ok(dashboard.includes('withFavoriteProjectOrder(groups, projectIds)'));
+    assert.ok(dashboard.includes('withToggledProjectFavorite(groups, projectId)'));
     assert.ok(dashboard.includes("function applyProjectColorToCurrentWindow(project: Project = null)"));
     assert.ok(dashboard.includes("project?.showSaveAction"));
     assert.ok(dashboard.includes("syncProjectColorToCurrentWindow(project)"));
@@ -380,6 +463,148 @@ function runCurrentWorkspaceRenderingChecks() {
     assert.ok(!otherTags[0].includes('data-current-workspace'));
     assert.strictEqual(openTags.length, 1);
     assert.ok(openTags[0].includes('data-current-workspace'));
+}
+
+function runFavoriteRenderingChecks() {
+    const config = {
+        get: (key, defaultValue) => defaultValue,
+        displayProjectPath: false,
+        searchIsActiveByDefault: false,
+        showAddGroupButtonTile: false,
+    };
+    const html = webviewContentModule.getStewardContent(
+        { extensionPath: '/extension' },
+        {
+            cspSource: 'test-source',
+            asWebviewUri: uri => uri.toString(),
+        },
+        [{
+            id: 'group',
+            groupName: 'Work',
+            collapsed: false,
+            projects: [
+                { id: 'favorite-a', name: 'Favorite A', path: '/work/a', color: '#00aacc', favorite: true, favoriteOrder: 1 },
+                { id: 'favorite-b', name: 'Favorite B', path: '/work/b', color: '#ccaa00', favorite: true, favoriteOrder: 0 },
+                { id: 'plain', name: 'Plain', path: '/work/plain', color: '#888888' },
+            ],
+        }],
+        {
+            config,
+            relevantExtensionsInstalls: { remoteSSH: false, remoteContainers: false },
+            otherStorageHasData: false,
+            openProjects: [],
+        },
+        true
+    );
+    const renderedProjectIds = Array.from(html.matchAll(/<div class="project"[^>]*data-id="([^"]+)"[^>]*>/g))
+        .map(match => match[1]);
+
+    assert.deepStrictEqual(renderedProjectIds, [
+        'favorite-b',
+        'favorite-a',
+        'favorite-a',
+        'favorite-b',
+        'plain',
+    ]);
+    const favoriteContainer = html.match(/<div class="project-container"([^>]*)>\s*<div class="project"[^>]*data-id="favorite-b"/);
+    assert.ok(favoriteContainer);
+    assert.ok(!favoriteContainer[1].includes('data-nodrag'));
+}
+
+function runFavoriteDndChecks() {
+    const sourcePath = path.join(__dirname, '..', 'src', 'webview', 'webviewDnDScripts.js');
+    const generatedPath = path.join(__dirname, '..', 'media', 'webviewDnDScripts.js');
+    const source = fs.readFileSync(sourcePath, 'utf8');
+    const context = {};
+    vm.runInNewContext(source, context);
+
+    const createContainer = kind => ({
+        closest: selector => {
+            if (selector === '[data-system-group="__favorites"]') {
+                return kind === 'favorites' ? {} : null;
+            }
+            if (selector === '[data-virtual-group]') {
+                return kind === 'favorites' || kind === 'open-projects' ? {} : null;
+            }
+            return null;
+        },
+    });
+    const draggable = { hasAttribute: () => false };
+    const noDrag = { hasAttribute: attribute => attribute === 'data-nodrag' };
+    const favorites = createContainer('favorites');
+    const otherFavorites = createContainer('favorites');
+    const openProjects = createContainer('open-projects');
+    const ordinary = createContainer('ordinary');
+    const ordinaryTwo = createContainer('ordinary');
+
+    assert.strictEqual(context.canMoveProject(draggable, favorites), true);
+    assert.strictEqual(context.canMoveProject(draggable, openProjects), false);
+    assert.strictEqual(context.canMoveProject(draggable, ordinary), true);
+    assert.strictEqual(context.canMoveProject(noDrag, favorites), false);
+    assert.strictEqual(context.canAcceptProject(favorites, favorites), true);
+    assert.strictEqual(context.canAcceptProject(otherFavorites, favorites), false);
+    assert.strictEqual(context.canAcceptProject(ordinary, favorites), false);
+    assert.strictEqual(context.canAcceptProject(favorites, ordinary), false);
+    assert.strictEqual(context.canAcceptProject(openProjects, ordinary), false);
+    assert.strictEqual(context.canAcceptProject(ordinaryTwo, ordinary), true);
+    assert.ok(source.includes("type: 'reordered-favorites'"));
+    assert.strictEqual(fs.readFileSync(generatedPath, 'utf8'), source);
+
+    const drakes = [];
+    const messages = [];
+    const ordinaryGroup = {
+        getAttribute: attribute => attribute === 'data-group-id' ? 'group-one' : null,
+        querySelectorAll: () => [
+            { getAttribute: () => 'ordinary-a' },
+            { getAttribute: () => 'ordinary-b' },
+        ],
+    };
+    const runtimeContext = {
+        document: {
+            body: { classList: { add: () => {}, remove: () => {} } },
+            querySelector: () => null,
+            querySelectorAll: selector => selector.startsWith('.groups-wrapper >') ? [ordinaryGroup] : [],
+        },
+        window: {
+            addEventListener: () => {},
+            vscode: { postMessage: message => messages.push(message) },
+        },
+        dragula: (containers, options) => {
+            const handlers = {};
+            const drake = {
+                dragging: false,
+                cancel: () => {},
+                on: (event, handler) => {
+                    handlers[event] = handler;
+                    return drake;
+                },
+            };
+            drakes.push({ containers, options, handlers, drake });
+            return drake;
+        },
+        autoScroll: () => ({}),
+    };
+    vm.runInNewContext(source, runtimeContext);
+    runtimeContext.initDnD();
+
+    assert.strictEqual(drakes.length, 2);
+    const favoriteSource = {
+        closest: selector => selector === '[data-system-group="__favorites"]' ? {} : null,
+        querySelectorAll: () => [
+            { getAttribute: () => 'favorite-b' },
+            { getAttribute: () => 'favorite-a' },
+        ],
+    };
+    drakes[0].handlers.drop({}, favoriteSource, favoriteSource);
+    drakes[0].handlers.drop({}, ordinary, ordinary);
+
+    assert.deepStrictEqual(JSON.parse(JSON.stringify(messages)), [
+        { type: 'reordered-favorites', projectIds: ['favorite-b', 'favorite-a'] },
+        {
+            type: 'reordered-projects',
+            groupOrders: [{ groupId: 'group-one', projectIds: ['ordinary-a', 'ordinary-b'] }],
+        },
+    ]);
 }
 
 function extractFunctionBody(source, functionName) {
@@ -602,6 +827,7 @@ function runCommandBuilderChecks() {
 runPathChecks();
 runAssignmentChecks();
 runCurrentWorkspaceStateChecks();
+runFavoriteProjectOrderChecks();
 runCurrentWorkspaceMatchingChecks();
 runCandidateFilterChecks();
 runDisplayChecks();
@@ -609,6 +835,8 @@ runPinStoreChecks();
 runKeyChecks();
 runWebviewContentChecks();
 runCurrentWorkspaceRenderingChecks();
+runFavoriteRenderingChecks();
+runFavoriteDndChecks();
 runGitRepositoryDetectorChecks();
 runClaudeSessionChecks();
 runProviderChecks();

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -23,6 +23,7 @@ import { getLastPartOfPath, getOpenProjectUri as resolveOpenProjectUri, getOpenP
 import RemoteProjectResolver from './projects/remoteProjectResolver';
 import GitRepositoryDetector from './projects/gitRepositoryDetector';
 import { getCurrentWorkspaceProjectIds as resolveCurrentWorkspaceProjectIds } from './projects/currentWorkspaceState';
+import { withFavoriteProjectOrder, withToggledProjectFavorite } from './projects/favoriteProjectOrder';
 
 type TerminalEntry = AiSessionTerminalEntry<vscode.Terminal>;
 
@@ -529,6 +530,9 @@ export function activate(context: vscode.ExtensionContext) {
             case 'reordered-projects':
                 let groupOrders = e.groupOrders as GroupOrder[];
                 await reorderGroups(groupOrders);
+                break;
+            case 'reordered-favorites':
+                await reorderFavoriteProjects(Array.isArray(e.projectIds) ? e.projectIds : []);
                 break;
             case 'remove-project':
                 projectId = e.projectId as string;
@@ -1317,13 +1321,13 @@ export function activate(context: vscode.ExtensionContext) {
     }
 
     async function toggleProjectFavorite(projectId: string) {
-        var project = projectService.getProject(projectId);
-        if (project == null) {
+        var groups = projectService.getGroups();
+        var updatedGroups = withToggledProjectFavorite(groups, projectId);
+        if (updatedGroups == null) {
             return;
         }
 
-        project.favorite = !project.favorite;
-        await projectService.updateProject(projectId, project);
+        await projectService.saveGroups(updatedGroups);
         refreshAfterMutation();
     }
 
@@ -1881,6 +1885,13 @@ export function activate(context: vscode.ExtensionContext) {
             reorderedGroups.push(group);
         }
 
+        await projectService.saveGroups(reorderedGroups);
+        refreshAfterMutation();
+    }
+
+    async function reorderFavoriteProjects(projectIds: string[]) {
+        var groups = projectService.getGroups();
+        var reorderedGroups = withFavoriteProjectOrder(groups, projectIds);
         await projectService.saveGroups(reorderedGroups);
         refreshAfterMutation();
     }

--- a/src/models.ts
+++ b/src/models.ts
@@ -27,6 +27,7 @@ export class Project {
     path: string;
     remoteType?: ProjectRemoteType;
     favorite?: boolean;
+    favoriteOrder?: number;
     showSaveAction?: boolean;
     isCurrentWorkspace?: boolean;
     codexSessions?: CodexSession[];

--- a/src/projects/favoriteProjectOrder.ts
+++ b/src/projects/favoriteProjectOrder.ts
@@ -1,0 +1,128 @@
+'use strict';
+
+import { Group, Project } from '../models';
+
+interface FavoriteProjectEntry {
+    project: Project;
+    sourceIndex: number;
+}
+
+export function getFavoriteProjectsInOrder(projects: readonly Project[]): Project[] {
+    let favorites = (projects || []).filter(project => project.favorite);
+    let orderCounts = new Map<number, number>();
+
+    for (let project of favorites) {
+        if (isValidFavoriteOrder(project.favoriteOrder)) {
+            orderCounts.set(project.favoriteOrder, (orderCounts.get(project.favoriteOrder) || 0) + 1);
+        }
+    }
+
+    return favorites
+        .map((project, sourceIndex) => ({ project, sourceIndex }))
+        .sort((left, right) => compareFavoriteEntries(left, right, orderCounts))
+        .map(entry => entry.project);
+}
+
+export function withFavoriteProjectOrder(groups: readonly Group[], projectIds: readonly string[]): Group[] {
+    let clonedGroups = cloneGroups(groups);
+    let projects = flattenProjects(clonedGroups);
+    let favorites = getFavoriteProjectsInOrder(projects);
+    let favoritesById = new Map<string, Project>();
+    for (let project of favorites) {
+        if (!favoritesById.has(project.id)) {
+            favoritesById.set(project.id, project);
+        }
+    }
+
+    let orderedIds: string[] = [];
+    let seenIds = new Set<string>();
+    for (let projectId of projectIds || []) {
+        if (!seenIds.has(projectId) && favoritesById.has(projectId)) {
+            orderedIds.push(projectId);
+            seenIds.add(projectId);
+        }
+    }
+    for (let project of favorites) {
+        if (!seenIds.has(project.id)) {
+            orderedIds.push(project.id);
+            seenIds.add(project.id);
+        }
+    }
+
+    let orderById = new Map<string, number>();
+    orderedIds.forEach((projectId, index) => orderById.set(projectId, index));
+    for (let project of projects) {
+        if (project.favorite && orderById.has(project.id)) {
+            project.favoriteOrder = orderById.get(project.id);
+        } else {
+            delete project.favoriteOrder;
+        }
+    }
+
+    return clonedGroups;
+}
+
+export function withToggledProjectFavorite(groups: readonly Group[], projectId: string): Group[] | null {
+    let sourceProjects = flattenProjects(groups);
+    let sourceProject = sourceProjects.find(project => project.id === projectId);
+    if (!sourceProject) {
+        return null;
+    }
+
+    let currentFavoriteIds = getFavoriteProjectsInOrder(sourceProjects).map(project => project.id);
+    let nextFavorite = !sourceProject.favorite;
+    let nextFavoriteIds = nextFavorite
+        ? currentFavoriteIds.filter(id => id !== projectId).concat(projectId)
+        : currentFavoriteIds.filter(id => id !== projectId);
+    let toggledGroups = cloneGroups(groups);
+    let toggledProject = flattenProjects(toggledGroups).find(project => project.id === projectId);
+    toggledProject.favorite = nextFavorite;
+    if (!nextFavorite) {
+        delete toggledProject.favoriteOrder;
+    }
+
+    return withFavoriteProjectOrder(toggledGroups, nextFavoriteIds);
+}
+
+function compareFavoriteEntries(
+    left: FavoriteProjectEntry,
+    right: FavoriteProjectEntry,
+    orderCounts: Map<number, number>
+): number {
+    let leftOrder = getUniqueFavoriteOrder(left.project, orderCounts);
+    let rightOrder = getUniqueFavoriteOrder(right.project, orderCounts);
+    if (leftOrder !== null && rightOrder !== null) {
+        return leftOrder - rightOrder;
+    }
+    if (leftOrder !== null) {
+        return -1;
+    }
+    if (rightOrder !== null) {
+        return 1;
+    }
+    return left.sourceIndex - right.sourceIndex;
+}
+
+function getUniqueFavoriteOrder(project: Project, orderCounts: Map<number, number>): number | null {
+    return isValidFavoriteOrder(project.favoriteOrder) && orderCounts.get(project.favoriteOrder) === 1
+        ? project.favoriteOrder
+        : null;
+}
+
+function isValidFavoriteOrder(value: number): boolean {
+    return Number.isFinite(value) && Number.isInteger(value) && value >= 0;
+}
+
+function cloneGroups(groups: readonly Group[]): Group[] {
+    return (groups || []).map(group => ({
+        ...group,
+        projects: (group.projects || []).map(project => ({ ...project } as Project)),
+    } as Group));
+}
+
+function flattenProjects(groups: readonly Group[]): Project[] {
+    return (groups || []).reduce(
+        (projects, group) => projects.concat(group.projects || []),
+        [] as Project[]
+    );
+}

--- a/src/webview/webviewContent.ts
+++ b/src/webview/webviewContent.ts
@@ -13,6 +13,7 @@ import {
 } from '../models';
 import { FAVORITES_GROUP_ID, FITTY_OPTIONS, INBUILT_COLOR_DEFAULTS, OPEN_PROJECTS_GROUP_ID } from '../constants';
 import { withCurrentWorkspaceState } from '../projects/currentWorkspaceState';
+import { getFavoriteProjectsInOrder } from '../projects/favoriteProjectOrder';
 import * as Icons from './webviewIcons';
 
 const FAVORITES_GROUP_NAME = 'FAVORITES';
@@ -54,9 +55,9 @@ export function getStewardContent(
     groups = workspaceState.groups;
     var openProjects = workspaceState.openProjects;
     var customCss = infos.config.get('customCss') || '';
-    var favoriteProjects = groups
-        .reduce((projects, group) => projects.concat(group.projects || []), [] as Project[])
-        .filter(project => project.favorite);
+    var favoriteProjects = getFavoriteProjectsInOrder(
+        groups.reduce((projects, group) => projects.concat(group.projects || []), [] as Project[])
+    );
     var favoritesGroupCollapsed = infos.favoritesGroupCollapsed !== undefined
         ? infos.favoritesGroupCollapsed
         : groups.every(group => group.collapsed);
@@ -238,6 +239,7 @@ function getGroupSection(
     // Apply changes to HTML here also to getTempGroupSection
 
     var isVirtualGroup = isVirtualGroupId(group.id);
+    var isFavoritesGroup = group.id === FAVORITES_GROUP_ID;
     var groupActions = isVirtualGroup
         ? ''
         : `<div class="group-actions right">
@@ -269,7 +271,7 @@ function getGroupSection(
     </div>
     <div class="group-list">
         <div class="drop-signal"></div>
-        ${group.projects.map((p) => getProjectDiv(p, isVirtualGroup, group.id === OPEN_PROJECTS_GROUP_ID)).join('\n')}
+        ${group.projects.map((p) => getProjectDiv(p, isVirtualGroup, group.id === OPEN_PROJECTS_GROUP_ID, isFavoritesGroup)).join('\n')}
     </div>       
 </div>`;
 }
@@ -308,7 +310,12 @@ function getTempGroupSection(totalGroupCount: number) {
 </div>`;
 }
 
-function getProjectDiv(project: Project, isVirtualProject: boolean = false, isReadOnlyProject: boolean = false) {
+function getProjectDiv(
+    project: Project,
+    isVirtualProject: boolean = false,
+    isReadOnlyProject: boolean = false,
+    isDraggableVirtualProject: boolean = false
+) {
     var borderStyle = `background: ${project.color};`;
     var projectStyle = project.color ? `--project-color: ${escapeStyleValue(project.color)};` : '';
     var remoteType = getRemoteType(project);
@@ -353,7 +360,7 @@ function getProjectDiv(project: Project, isVirtualProject: boolean = false, isRe
     var isRemote = remoteType !== ProjectRemoteType.None;
 
     return `
-<div class="project-container"${isVirtualProject ? ' data-nodrag' : ''}>
+<div class="project-container"${isVirtualProject && !isDraggableVirtualProject ? ' data-nodrag' : ''}>
     <div class="project" style="${projectStyle}" data-id="${project.id}" data-name="${searchText}"${isRemote ? ' data-is-remote' : ''
         }${isVirtualProject ? ' data-virtual-project' : ''
         }${isReadOnlyProject ? ' data-readonly-project' : ''

--- a/src/webview/webviewDnDScripts.js
+++ b/src/webview/webviewDnDScripts.js
@@ -1,3 +1,26 @@
+function isFavoritesProjectContainer(container) {
+    return Boolean(container && container.closest('[data-system-group="__favorites"]'));
+}
+
+function canMoveProject(el, source) {
+    if (!el || !source || el.hasAttribute('data-nodrag')) {
+        return false;
+    }
+
+    return isFavoritesProjectContainer(source) || !source.closest('[data-virtual-group]');
+}
+
+function canAcceptProject(target, source) {
+    if (!target || !source) {
+        return false;
+    }
+    if (isFavoritesProjectContainer(source)) {
+        return target === source;
+    }
+
+    return !isFavoritesProjectContainer(target) && !target.closest('[data-virtual-group]');
+}
+
 function initDnD() {
     const projectsContainerSelector = ".group-list";
     const groupsContainerSelector = ".groups-wrapper";
@@ -7,13 +30,19 @@ function initDnD() {
     var projectsContainers = document.querySelectorAll(projectsContainerSelector);
     var projectDrake = dragula([].slice.call(projectsContainers), {
         moves: function (el, source, handle, sibling) {
-            return !el.hasAttribute("data-nodrag") && !source.closest("[data-virtual-group]");
+            return canMoveProject(el, source);
         },
         accepts: function (el, target, source, sibling) {
-            return !target.closest("[data-virtual-group]");
+            return canAcceptProject(target, source);
         },
     });
-    projectDrake.on('drop', onReordered);
+    projectDrake.on('drop', function (el, target, source) {
+        if (isFavoritesProjectContainer(source)) {
+            onFavoritesReordered(source);
+            return;
+        }
+        onReordered();
+    });
     projectDrake.on('drag', () => document.body.classList.add('project-dragging'));
     projectDrake.on('dragend', () => document.body.classList.remove('project-dragging'));
 
@@ -61,6 +90,16 @@ function initDnD() {
         window.vscode.postMessage({
             type: 'reordered-projects',
             groupOrders,
+        });
+    }
+
+    function onFavoritesReordered(favoritesContainer) {
+        let projectIds = [].slice.call(favoritesContainer.querySelectorAll('.project[data-id]'))
+            .map(project => project.getAttribute('data-id'));
+
+        window.vscode.postMessage({
+            type: 'reordered-favorites',
+            projectIds,
         });
     }
 };


### PR DESCRIPTION
## Summary

- add drag-and-drop ordering within the FAVORITES group
- persist favorite ordering in project data for existing Settings Sync behavior
- keep ordinary Groups and OPEN PROJECT isolated from Favorites drag operations
- append newly favorited projects to the end

## Release

- bump extension version from 1.1.6 to 1.1.7
- document the release in CHANGELOG.md

## Validation

- npm run test-compile
- npm run lint (passes with existing warnings)
- npm run vscode:prepublish
- npm run test:safety