### PR TITLE
Release 1.1.8

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,5 +1,6 @@
 .vscode/**
 .vscode-test/**
+.superpowers/**
 out/**
 dist/**/*.map
 src/**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the "Project Steward" extension will be documented in this file. It follows the [Keep a Changelog](http://keepachangelog.com/) recommendations.
 
+## [1.1.8] 2026-07-13
+
+### Added
+
+-   Add batch management for archiving eligible AI sessions while protecting sessions that are still open in terminals.
+-   Highlight the visible AI session associated with the active running Codex, Kimi, or Claude terminal.
+
+### Fixed
+
+-   Preserve AI session aliases across provider refreshes.
+-   Exclude explicit Codex subagent sessions from project assignment, terminal matching, and Dashboard session lists.
+
 ## [1.1.7] 2026-07-10
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "project-steward",
-    "version": "1.1.7",
+    "version": "1.1.8",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "project-steward",
-            "version": "1.1.7",
+            "version": "1.1.8",
             "dependencies": {
                 "dragula": "^3.7.3",
                 "fitty": "^2.3.5"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "project-steward",
     "displayName": "Project Steward",
     "description": "Organize local, SSH, and Dev Container projects in a synchronized project steward.",
-    "version": "1.1.7",
+    "version": "1.1.8",
     "publisher": "hzcheng",
     "license": "MIT",
     "icon": "media/extension_icon.png",

--- a/scripts/run-ai-session-safety-checks.js
+++ b/scripts/run-ai-session-safety-checks.js
@@ -1678,6 +1678,14 @@ function runCommandBuilderChecks() {
     assert.strictEqual(commands.quotePowerShellArg("O'Brien"), "'O''Brien'");
 }
 
+function runVsixPackagingChecks() {
+    const vscodeIgnore = fs.readFileSync(path.join(__dirname, '..', '.vscodeignore'), 'utf8');
+    assert.ok(
+        vscodeIgnore.split(/\r?\n/).includes('.superpowers/**'),
+        'VSIX packaging must exclude local .superpowers artifacts'
+    );
+}
+
 async function main() {
     runPathChecks();
     runAssignmentChecks();
@@ -1703,6 +1711,7 @@ async function main() {
     runClaudeSessionChecks();
     runProviderChecks();
     runCommandBuilderChecks();
+    runVsixPackagingChecks();
 
     console.log('AI session safety checks passed.');
 }


### PR DESCRIPTION
## Release

- bump Project Steward to 1.1.8
- document AI session management and terminal-awareness changes
- exclude local `.superpowers` artifacts from VSIX packages
- add a packaging regression check

## Validation

- `npm run test:safety`
- `DRY_RUN=1 SKIP_NPM_CI=1 ./scripts/publish-marketplace.sh`
- verified the packaged file list contains no `.superpowers/` paths