### PR TITLE
Fix GitHub release notes

### DIFF
--- a/.github/workflows/release-vsix.yml
+++ b/.github/workflows/release-vsix.yml
@@ -76,6 +76,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Verify release notes
+        run: npm run test:release-notes
+
       - name: Compile
         run: npm run test-compile
 
@@ -117,7 +120,9 @@ jobs:
             args+=(--prerelease)
           fi
 
+          node scripts/extract-release-notes.js "$VERSION" > release-notes.md
+
           gh release create "$TAG" "$VSIX_FILE" \
             --title "Project Steward ${VERSION}" \
-            --notes "VSIX package for Project Steward ${VERSION}." \
+            --notes-file release-notes.md \
             "${args[@]}"

--- a/docs/superpowers/plans/2026-07-13-release-notes.md
+++ b/docs/superpowers/plans/2026-07-13-release-notes.md
@@ -1,0 +1,83 @@
+# GitHub Release Notes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Generate each GitHub Release body from the matching curated `CHANGELOG.md` section and repair the existing v1.1.8 body.
+
+**Architecture:** A dependency-free Node.js CLI extracts one exact changelog version section and fails closed when it is absent or empty. The GitHub Actions workflow writes that output to a file and supplies it to `gh release create --notes-file`.
+
+**Tech Stack:** Node.js 22 in CI, CommonJS, GitHub Actions, GitHub CLI, Node.js `assert`
+
+## Global Constraints
+
+- Use the exact `CHANGELOG.md` version section as the GitHub Release body.
+- Fail the release job if the requested version section is missing or empty.
+- Keep existing tag, title, VSIX asset, draft, and prerelease behavior unchanged.
+- Add no runtime dependency.
+- Preserve and do not stage `.vscode/settings.json`.
+
+---
+
+### Task 1: Changelog Extraction and Workflow Integration
+
+**Files:**
+
+- Create: `scripts/extract-release-notes.js`
+- Create: `scripts/run-release-notes-checks.js`
+- Modify: `.github/workflows/release-vsix.yml`
+- Modify: `package.json`
+
+**Interfaces:**
+
+- Produces: `extractReleaseNotes(changelog, version): string` and CLI usage `node scripts/extract-release-notes.js <version> [changelog-path]`.
+- Consumes: `CHANGELOG.md` and the workflow's existing `VERSION` environment variable.
+
+- [x] **Step 1: Write the failing regression check**
+
+Create a temporary changelog containing versions `1.2.3` and `1.2.2`. Invoke the not-yet-existing CLI for `1.2.3` and assert exit status `0`, output containing only that section body, and no `1.2.2` content. Invoke it for `9.9.9` and assert a non-zero status with a precise missing-version message. Assert the workflow contains `--notes-file release-notes.md` and does not contain the fixed `VSIX package for` placeholder.
+
+- [x] **Step 2: Verify RED**
+
+Run `node scripts/run-release-notes-checks.js`.
+
+Expected: FAIL because `scripts/extract-release-notes.js` does not exist and the workflow still uses the placeholder `--notes` argument.
+
+- [x] **Step 3: Implement the minimal extractor**
+
+Parse level-two headings line by line, match `## [${version}]` with optional trailing date/text, collect until the next `## ` heading, trim the body, and throw when no non-empty body exists. The CLI reads the supplied path or root `CHANGELOG.md`, prints the body, and reports errors to stderr with exit status `1`.
+
+- [x] **Step 4: Integrate the notes file into the workflow**
+
+Before `gh release create`, run:
+
+```bash
+node scripts/extract-release-notes.js "$VERSION" > release-notes.md
+```
+
+Replace the placeholder with:
+
+```bash
+--notes-file release-notes.md
+```
+
+Expose the regression check as `npm run test:release-notes` and run it in the release workflow after installing dependencies.
+
+- [x] **Step 5: Verify GREEN and repository checks**
+
+Run:
+
+```bash
+npm run test:release-notes
+npm run test:safety
+npm run lint
+```
+
+Expected: all commands exit `0` with no assertion, compilation, or lint failures.
+
+- [x] **Step 6: Repair v1.1.8 release metadata**
+
+Generate the body with `node scripts/extract-release-notes.js 1.1.8` and update release ID `353047493` through `gh api --method PATCH`, because the installed GitHub CLI has no `release edit` command. Verify the release API body exactly contains the changelog body.
+
+- [ ] **Step 7: Submit the workflow fix**
+
+Review the diff, commit only the design, plan, workflow, extractor, test, and package script; push `fix/release-notes`; open and merge a PR into `main`; then switch back to `feat/ai-session-attention-monitor`.

--- a/docs/superpowers/specs/2026-07-13-release-notes-design.md
+++ b/docs/superpowers/specs/2026-07-13-release-notes-design.md
@@ -1,0 +1,29 @@
+# GitHub Release Notes Design
+
+**Date:** 2026-07-13
+
+## Goal
+
+Publish useful GitHub Release notes from the matching `CHANGELOG.md` version section instead of a fixed placeholder sentence.
+
+## Design
+
+- Add a small Node.js command that accepts a version and optional changelog path, then prints only that version's body.
+- Match an exact `## [version]` heading and stop at the next level-two heading so neighboring releases cannot leak into the output.
+- Treat a missing version or an empty section as an error with a non-zero exit status.
+- Have the release workflow write the extracted content to `release-notes.md` and pass it to `gh release create --notes-file`.
+- Keep `CHANGELOG.md` as the single curated source; do not combine it with GitHub-generated commit notes.
+
+## Current Release Repair
+
+Update the existing `v1.1.8` GitHub Release body from the already-published `CHANGELOG.md` section. This changes release metadata only and does not replace the VSIX asset or tag.
+
+## Testing
+
+An executable Node.js regression check will use temporary changelog fixtures to verify exact extraction, heading boundaries, and failure for a missing or empty version. It will also assert that the workflow runs the check and uses the generated notes file rather than inline placeholder text.
+
+## Constraints
+
+- Add no runtime dependency.
+- Preserve the release title, draft/prerelease behavior, tag, and VSIX upload behavior.
+- Preserve the user's local `.vscode/settings.json` modification and exclude it from all commits.

--- a/package.json
+++ b/package.json
@@ -187,6 +187,7 @@
         "webpack-dev": "webpack --mode development --watch",
         "test-compile": "tsc -p ./",
         "test:safety": "npm run test-compile && node scripts/run-ai-session-safety-checks.js",
+        "test:release-notes": "node scripts/run-release-notes-checks.js",
         "lint": "tslint -p ./",
         "install-local": "./scripts/build-test-package-install.sh",
         "publish-marketplace": "./scripts/publish-marketplace.sh"

--- a/scripts/extract-release-notes.js
+++ b/scripts/extract-release-notes.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+function extractReleaseNotes(changelog, version) {
+    const lines = changelog.replace(/\r\n/g, '\n').split('\n');
+    const heading = `## [${version}]`;
+    const startIndex = lines.findIndex(line => line === heading || line.startsWith(`${heading} `));
+
+    if (startIndex === -1) {
+        throw new Error(`No non-empty CHANGELOG.md section found for version ${version}.`);
+    }
+
+    const nextHeadingOffset = lines
+        .slice(startIndex + 1)
+        .findIndex(line => /^##\s+/.test(line));
+    const endIndex = nextHeadingOffset === -1
+        ? lines.length
+        : startIndex + 1 + nextHeadingOffset;
+    const notes = lines.slice(startIndex + 1, endIndex).join('\n').trim();
+
+    if (!notes) {
+        throw new Error(`No non-empty CHANGELOG.md section found for version ${version}.`);
+    }
+
+    return notes;
+}
+
+function main() {
+    const version = process.argv[2];
+    const changelogPath = process.argv[3]
+        ? path.resolve(process.argv[3])
+        : path.resolve(__dirname, '..', 'CHANGELOG.md');
+
+    if (!version) {
+        throw new Error('Usage: node scripts/extract-release-notes.js <version> [changelog-path]');
+    }
+
+    const changelog = fs.readFileSync(changelogPath, 'utf8');
+    process.stdout.write(`${extractReleaseNotes(changelog, version)}\n`);
+}
+
+if (require.main === module) {
+    try {
+        main();
+    } catch (error) {
+        console.error(error instanceof Error ? error.message : String(error));
+        process.exitCode = 1;
+    }
+}
+
+module.exports = { extractReleaseNotes };

--- a/scripts/run-release-notes-checks.js
+++ b/scripts/run-release-notes-checks.js
@@ -1,0 +1,87 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const repositoryRoot = path.resolve(__dirname, '..');
+const extractorPath = path.join(__dirname, 'extract-release-notes.js');
+const workflowPath = path.join(repositoryRoot, '.github', 'workflows', 'release-vsix.yml');
+
+function runExtractor(version, changelogPath) {
+    return spawnSync(process.execPath, [extractorPath, version, changelogPath], {
+        cwd: repositoryRoot,
+        encoding: 'utf8',
+    });
+}
+
+function runExtractionChecks() {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'project-steward-release-notes-'));
+    const changelogPath = path.join(tempRoot, 'CHANGELOG.md');
+
+    try {
+        fs.writeFileSync(changelogPath, [
+            '# Changelog',
+            '',
+            '## [1.2.3] 2026-07-13',
+            '',
+            '### Added',
+            '',
+            '- Useful release note.',
+            '',
+            '## [1.2.2] 2026-07-12',
+            '',
+            '- Previous release.',
+            '',
+        ].join('\n'), 'utf8');
+
+        const success = runExtractor('1.2.3', changelogPath);
+        assert.strictEqual(success.status, 0, success.stderr);
+        assert.strictEqual(success.stdout, '### Added\n\n- Useful release note.\n');
+        assert.strictEqual(success.stdout.includes('Previous release'), false);
+
+        const missing = runExtractor('9.9.9', changelogPath);
+        assert.notStrictEqual(missing.status, 0);
+        assert.strictEqual(
+            missing.stderr.trim(),
+            `No non-empty CHANGELOG.md section found for version 9.9.9.`
+        );
+
+        fs.writeFileSync(changelogPath, [
+            '# Changelog',
+            '',
+            '## [2.0.0] 2026-07-13',
+            '',
+            '## [1.9.9] 2026-07-12',
+            '',
+            '- Previous release.',
+            '',
+        ].join('\n'), 'utf8');
+        const empty = runExtractor('2.0.0', changelogPath);
+        assert.notStrictEqual(empty.status, 0);
+        assert.strictEqual(
+            empty.stderr.trim(),
+            `No non-empty CHANGELOG.md section found for version 2.0.0.`
+        );
+    } finally {
+        fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+}
+
+function runWorkflowChecks() {
+    const workflow = fs.readFileSync(workflowPath, 'utf8');
+
+    assert.match(
+        workflow,
+        /node scripts\/extract-release-notes\.js "\$VERSION" > release-notes\.md/
+    );
+    assert.match(workflow, /--notes-file release-notes\.md/);
+    assert.strictEqual(workflow.includes('--notes "VSIX package for'), false);
+    assert.match(workflow, /- name: Verify release notes\n\s+run: npm run test:release-notes/);
+}
+
+runExtractionChecks();
+runWorkflowChecks();
+console.log('Release notes checks passed.');


### PR DESCRIPTION
## Summary
- generate GitHub Release notes from the matching CHANGELOG.md section
- fail releases when that section is missing or empty
- run release-note regression checks in the release workflow
- document and test the release-note workflow

## Verification
- npm run test:release-notes
- npm run test:safety
- npm run lint
- node syntax checks
- git diff --cached --check

The existing v1.1.8 GitHub Release body has also been updated to match CHANGELOG.md.