### PR TITLE
Add active terminal file reference command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the "Project Steward" extension will be documented in thi
 
 ## [Unreleased]
 
+### Added
+
+-   Add a command to append the active editor file reference, including selected line ranges, to the active terminal and focus it for CLI discussions.
+
+### Fixed
+
+-   Recover the Open Projects `OTHER WINDOWS` group if an incremental webview update drops the expected navigation cards.
+
 ## [2.0.1] 2026-07-16
 
 ### Changed

--- a/media/webviewProjectScripts.js
+++ b/media/webviewProjectScripts.js
@@ -18,6 +18,9 @@ function applyOpenProjectsUpdate(message) {
     }
 
     wrapper.innerHTML = message.html;
+    if (!isOpenProjectsUpdateDomConsistent(message)) {
+        return false;
+    }
     if (window.__projectStewardDashboard) {
         window.__projectStewardDashboard.replaceSearchCatalog(message.searchCatalog);
     }
@@ -25,6 +28,40 @@ function applyOpenProjectsUpdate(message) {
         window.__projectStewardSyncCollapseButton();
     }
     return true;
+}
+
+function getOpenProjectsUpdateCatalogCounts(searchCatalog) {
+    var openProjects = searchCatalog && Array.isArray(searchCatalog.openProjects)
+        ? searchCatalog.openProjects
+        : [];
+    return {
+        projectCount: openProjects.length,
+        navigationProjectCount: openProjects.filter(project => project && project.action !== 'open-current').length,
+    };
+}
+
+function getOpenProjectsUpdateDomState() {
+    return {
+        projectCount: document.querySelectorAll('.sticky-groups-wrapper .project[data-id]').length,
+        navigationProjectCount: document.querySelectorAll('.sticky-groups-wrapper .project[data-project-navigation][data-id]').length,
+        hasOtherWindowsGroup: document.querySelectorAll('.sticky-groups-wrapper .open-other-windows-group').length > 0,
+    };
+}
+
+function isOpenProjectsUpdateDomConsistent(message) {
+    var expected = getOpenProjectsUpdateCatalogCounts(message.searchCatalog);
+    if (!expected.projectCount) {
+        return true;
+    }
+
+    var rendered = getOpenProjectsUpdateDomState();
+    if (rendered.projectCount !== expected.projectCount) {
+        return false;
+    }
+    if (rendered.navigationProjectCount !== expected.navigationProjectCount) {
+        return false;
+    }
+    return expected.navigationProjectCount === 0 || rendered.hasOtherWindowsGroup;
 }
 
 function getCollapseButtonState(tab, collapsedStates) {
@@ -923,10 +960,14 @@ function initProjects() {
             }
             syncActiveAiSessionTerminalDom();
             updateStickyGroupHeaderOffset();
+            var renderedOpenProjectsState = getOpenProjectsUpdateDomState();
             window.vscode.postMessage({
                 type: 'open-projects-rendered',
                 semanticRevision: message.semanticRevision,
                 projectCount: message.projectCount,
+                renderedProjectCount: renderedOpenProjectsState.projectCount,
+                renderedNavigationProjectCount: renderedOpenProjectsState.navigationProjectCount,
+                hasOtherWindowsGroup: renderedOpenProjectsState.hasOtherWindowsGroup,
             });
             return;
         }

--- a/media/webviewProjectScripts.js
+++ b/media/webviewProjectScripts.js
@@ -17,8 +17,10 @@ function applyOpenProjectsUpdate(message) {
         return false;
     }
 
+    var previousHtml = wrapper.innerHTML;
     wrapper.innerHTML = message.html;
     if (!isOpenProjectsUpdateDomConsistent(message)) {
+        wrapper.innerHTML = previousHtml;
         return false;
     }
     if (window.__projectStewardDashboard) {

--- a/media/webviewProjectScripts.js
+++ b/media/webviewProjectScripts.js
@@ -52,6 +52,9 @@ function getOpenProjectsUpdateDomState() {
 
 function isOpenProjectsUpdateDomConsistent(message) {
     var expected = getOpenProjectsUpdateCatalogCounts(message.searchCatalog);
+    if (message.projectCount !== expected.projectCount) {
+        return false;
+    }
     if (!expected.projectCount) {
         return true;
     }

--- a/package.json
+++ b/package.json
@@ -65,6 +65,10 @@
             {
                 "command": "projectSteward.addProjectsFromFolder",
                 "title": "Project Steward: Add Projects from Folder"
+            },
+            {
+                "command": "projectSteward.addFileToActiveTerminal",
+                "title": "Project Steward: Add File to Active Terminal"
             }
         ],
         "keybindings": [

--- a/scripts/run-dashboard-webview-checks.js
+++ b/scripts/run-dashboard-webview-checks.js
@@ -10,6 +10,7 @@ const dashboardStartup = require('../out/dashboard/startup');
 const { DashboardStartupController } = require('../out/dashboard/startupController');
 const { DashboardLifecycleController } = require('../out/dashboard/lifecycleController');
 const { DashboardCommandRegistration } = require('../out/dashboard/commandRegistration');
+const activeTerminalFileReference = require('../out/dashboard/activeTerminalFileReference');
 const dashboardWebviewOptions = require('../out/dashboard/webviewOptions');
 const { GroupCollapseController } = require('../out/dashboard/groupCollapseController');
 const { DashboardRuntimeController } = require('../out/dashboard/runtimeController');
@@ -704,6 +705,7 @@ async function runDashboardCommandRegistrationChecks() {
             addGroup: async () => calls.push('addGroup'),
             removeGroup: async () => calls.push('removeGroup'),
             addProjectsFromFolder: async () => calls.push('addProjectsFromFolder'),
+            addFileToActiveTerminal: async () => calls.push('addFileToActiveTerminal'),
         },
     });
 
@@ -718,6 +720,7 @@ async function runDashboardCommandRegistrationChecks() {
         'projectSteward.addGroup',
         'projectSteward.removeGroup',
         'projectSteward.addProjectsFromFolder',
+        'projectSteward.addFileToActiveTerminal',
     ]);
     assert.deepStrictEqual(subscriptions.map(disposable => disposable.command), registered.map(([command]) => command));
 
@@ -734,7 +737,95 @@ async function runDashboardCommandRegistrationChecks() {
         'addGroup',
         'removeGroup',
         'addProjectsFromFolder',
+        'addFileToActiveTerminal',
     ]);
+}
+
+async function runActiveTerminalFileReferenceChecks() {
+    const sent = [];
+    const warnings = [];
+    let terminalShowCalls = 0;
+    const terminal = {
+        sendText: (text, addNewLine) => sent.push([text, addNewLine]),
+        show: () => { terminalShowCalls += 1; },
+    };
+    const controller = new activeTerminalFileReference.ActiveTerminalFileReferenceController({
+        getActiveTextEditor: () => ({
+            document: { uri: { scheme: 'file', fsPath: '/repo/src/dashboard.ts' } },
+            selection: {
+                isEmpty: false,
+                start: { line: 9 },
+                end: { line: 14 },
+            },
+        }),
+        getActiveTerminal: () => terminal,
+        asRelativePath: uri => uri.fsPath.replace('/repo/', ''),
+        showWarningMessage: message => warnings.push(message),
+    });
+
+    assert.strictEqual(activeTerminalFileReference.formatFileReference('src/dashboard.ts', null), 'src/dashboard.ts');
+    assert.strictEqual(activeTerminalFileReference.formatFileReference('src/dashboard.ts', { startLine: 10, endLine: 10 }), 'src/dashboard.ts:10');
+    assert.strictEqual(activeTerminalFileReference.formatFileReference('src/dashboard.ts', { startLine: 10, endLine: 15 }), 'src/dashboard.ts:10-15');
+    assert.deepStrictEqual(activeTerminalFileReference.getPrimarySelectionLineRange({
+        isEmpty: false,
+        start: { line: 14 },
+        end: { line: 9 },
+    }), { startLine: 10, endLine: 15 });
+
+    await controller.addFileToActiveTerminal();
+    assert.deepStrictEqual(sent, [['src/dashboard.ts:10-15', false]]);
+    assert.strictEqual(terminalShowCalls, 1);
+    assert.deepStrictEqual(warnings, []);
+
+    const emptySelectionController = new activeTerminalFileReference.ActiveTerminalFileReferenceController({
+        getActiveTextEditor: () => ({
+            document: { uri: { scheme: 'file', fsPath: '/repo/src/models.ts' } },
+            selection: { isEmpty: true, start: { line: 0 }, end: { line: 0 } },
+        }),
+        getActiveTerminal: () => terminal,
+        asRelativePath: uri => uri.fsPath.replace('/repo/', ''),
+        showWarningMessage: message => warnings.push(message),
+    });
+    await emptySelectionController.addFileToActiveTerminal();
+    assert.deepStrictEqual(sent[1], ['src/models.ts', false]);
+    assert.strictEqual(terminalShowCalls, 2);
+
+    const remoteFileController = new activeTerminalFileReference.ActiveTerminalFileReferenceController({
+        getActiveTextEditor: () => ({
+            document: { uri: { scheme: 'vscode-remote', fsPath: '/repo/src/remote.ts', path: '/repo/src/remote.ts' } },
+            selection: { isEmpty: true, start: { line: 0 }, end: { line: 0 } },
+        }),
+        getActiveTerminal: () => terminal,
+        asRelativePath: uri => uri.path.replace('/repo/', ''),
+        showWarningMessage: message => warnings.push(message),
+    });
+    await remoteFileController.addFileToActiveTerminal();
+    assert.deepStrictEqual(sent[2], ['src/remote.ts', false]);
+    assert.strictEqual(terminalShowCalls, 3);
+
+    const missingTerminalController = new activeTerminalFileReference.ActiveTerminalFileReferenceController({
+        getActiveTextEditor: () => ({
+            document: { uri: { scheme: 'file', fsPath: '/repo/src/models.ts' } },
+            selection: { isEmpty: true, start: { line: 0 }, end: { line: 0 } },
+        }),
+        getActiveTerminal: () => null,
+        asRelativePath: uri => uri.fsPath.replace('/repo/', ''),
+        showWarningMessage: message => warnings.push(message),
+    });
+    await missingTerminalController.addFileToActiveTerminal();
+    assert.ok(warnings.includes('No active terminal to receive the file reference.'));
+
+    const untitledController = new activeTerminalFileReference.ActiveTerminalFileReferenceController({
+        getActiveTextEditor: () => ({
+            document: { uri: { scheme: 'untitled', fsPath: '' } },
+            selection: { isEmpty: true, start: { line: 0 }, end: { line: 0 } },
+        }),
+        getActiveTerminal: () => terminal,
+        asRelativePath: uri => uri.fsPath,
+        showWarningMessage: message => warnings.push(message),
+    });
+    await untitledController.addFileToActiveTerminal();
+    assert.ok(warnings.includes('Open a saved file before adding it to the active terminal.'));
 }
 
 function createClassList() {
@@ -1137,6 +1228,7 @@ async function main() {
     await runDashboardStartupControllerChecks();
     await runDashboardLifecycleControllerChecks();
     await runDashboardCommandRegistrationChecks();
+    await runActiveTerminalFileReferenceChecks();
     runControllerChecks(source);
     runSourceContractChecks(source);
     await runDashboardMessageRouterChecks();

--- a/scripts/run-dashboard-webview-checks.js
+++ b/scripts/run-dashboard-webview-checks.js
@@ -814,6 +814,8 @@ async function runActiveTerminalFileReferenceChecks() {
     });
     await missingTerminalController.addFileToActiveTerminal();
     assert.ok(warnings.includes('No active terminal to receive the file reference.'));
+    assert.strictEqual(sent.length, 3);
+    assert.strictEqual(terminalShowCalls, 3);
 
     const untitledController = new activeTerminalFileReference.ActiveTerminalFileReferenceController({
         getActiveTextEditor: () => ({
@@ -826,6 +828,8 @@ async function runActiveTerminalFileReferenceChecks() {
     });
     await untitledController.addFileToActiveTerminal();
     assert.ok(warnings.includes('Open a saved file before adding it to the active terminal.'));
+    assert.strictEqual(sent.length, 3);
+    assert.strictEqual(terminalShowCalls, 3);
 }
 
 function createClassList() {

--- a/scripts/run-open-project-safety-checks.js
+++ b/scripts/run-open-project-safety-checks.js
@@ -1201,12 +1201,21 @@ function runOpenProjectIncrementalRenderingChecks() {
         type: 'open-projects-updated',
         version: 1,
         semanticRevision: 'revision-2',
-        projectCount: 3,
+        projectCount: 0,
         html: '<div data-group-id="__openProjects">new</div>',
         searchCatalog: { sessions: [], openProjects: [], savedProjects: [] },
     }), true);
     assert.strictEqual(wrapper.innerHTML, '<div data-group-id="__openProjects">new</div>');
     assert.strictEqual(catalogReplacements, 1);
+    assert.strictEqual(applyOpenProjectsUpdate({
+        type: 'open-projects-updated',
+        version: 1,
+        semanticRevision: 'revision-mismatched-count',
+        projectCount: 3,
+        html: '<div>bad count</div>',
+        searchCatalog: { sessions: [], openProjects: [], savedProjects: [] },
+    }), false, 'OPEN update must reject projectCount values that do not match the search catalog');
+    assert.strictEqual(wrapper.innerHTML, '<div data-group-id="__openProjects">new</div>');
     assert.strictEqual(applyOpenProjectsUpdate({ version: 2, html: '<div>bad</div>' }), false);
     assert.strictEqual(wrapper.innerHTML, '<div data-group-id="__openProjects">new</div>');
     assert.ok(webviewScript.includes("type: 'open-projects-rendered'"));

--- a/scripts/run-open-project-safety-checks.js
+++ b/scripts/run-open-project-safety-checks.js
@@ -1162,14 +1162,36 @@ function runOpenProjectIncrementalRenderingChecks() {
         'utf8'
     );
     const wrapper = { innerHTML: '<div>old</div>' };
+    const documentStub = {
+        querySelector: selector => selector === '.sticky-groups-wrapper' ? wrapper : null,
+        querySelectorAll: selector => {
+            const projectTags = wrapper.innerHTML.match(/<div class="project"[^>]*data-id=[^>]*>/g) || [];
+            if (selector === '.sticky-groups-wrapper .project[data-id]') {
+                return Array.from({ length: projectTags.length }, () => ({}));
+            }
+            if (selector === '.sticky-groups-wrapper .project[data-project-navigation][data-id]') {
+                const matches = projectTags.filter(tag => tag.includes('data-project-navigation'));
+                return Array.from({ length: matches.length }, () => ({}));
+            }
+            if (selector === '.sticky-groups-wrapper .open-other-windows-group') {
+                return wrapper.innerHTML.includes('open-other-windows-group') ? [{}] : [];
+            }
+            return [];
+        },
+    };
     let catalogReplacements = 0;
     const applyOpenProjectsUpdate = new Function(
         'document',
         'window',
         'normalizeDashboardSearchCatalog',
-        `return function applyOpenProjectsUpdate(message) {${extractFunctionBody(webviewScript, 'applyOpenProjectsUpdate')}};`
+        `
+        function getOpenProjectsUpdateCatalogCounts(searchCatalog) {${extractFunctionBody(webviewScript, 'getOpenProjectsUpdateCatalogCounts')}}
+        function getOpenProjectsUpdateDomState() {${extractFunctionBody(webviewScript, 'getOpenProjectsUpdateDomState')}}
+        function isOpenProjectsUpdateDomConsistent(message) {${extractFunctionBody(webviewScript, 'isOpenProjectsUpdateDomConsistent')}}
+        return function applyOpenProjectsUpdate(message) {${extractFunctionBody(webviewScript, 'applyOpenProjectsUpdate')}};
+        `
     )(
-        { querySelector: selector => selector === '.sticky-groups-wrapper' ? wrapper : null },
+        documentStub,
         { __projectStewardDashboard: { replaceSearchCatalog: () => { catalogReplacements += 1; } } },
         value => value && Array.isArray(value.sessions) && Array.isArray(value.openProjects) && Array.isArray(value.savedProjects)
             ? value
@@ -1188,6 +1210,39 @@ function runOpenProjectIncrementalRenderingChecks() {
     assert.strictEqual(applyOpenProjectsUpdate({ version: 2, html: '<div>bad</div>' }), false);
     assert.strictEqual(wrapper.innerHTML, '<div data-group-id="__openProjects">new</div>');
     assert.ok(webviewScript.includes("type: 'open-projects-rendered'"));
+    assert.strictEqual(applyOpenProjectsUpdate({
+        type: 'open-projects-updated',
+        version: 1,
+        semanticRevision: 'revision-valid-navigation',
+        projectCount: 2,
+        html: [
+            '<div class="group open-current-workspace-group"><div class="project" data-id="current"></div></div>',
+            '<div class="group open-other-windows-group"><div class="project" data-project-navigation data-id="other"></div></div>',
+        ].join(''),
+        searchCatalog: {
+            sessions: [],
+            openProjects: [
+                { projectId: 'current', action: 'open-current' },
+                { projectId: 'other', action: 'switch-open' },
+            ],
+            savedProjects: [],
+        },
+    }), true, 'OPEN update must accept DOM that keeps OTHER WINDOWS navigation cards');
+    assert.strictEqual(applyOpenProjectsUpdate({
+        type: 'open-projects-updated',
+        version: 1,
+        semanticRevision: 'revision-3',
+        projectCount: 2,
+        html: '<div class="group open-current-workspace-group"><div class="project" data-id="current"></div></div>',
+        searchCatalog: {
+            sessions: [],
+            openProjects: [
+                { projectId: 'current', action: 'open-current' },
+                { projectId: 'other', action: 'switch-open' },
+            ],
+            savedProjects: [],
+        },
+    }), false, 'OPEN update must reject DOM that loses OTHER WINDOWS navigation cards');
 
     const postOpenProjectsUpdated = extractFunctionBody(dashboard, 'postOpenProjectsUpdated');
     assert.ok(postOpenProjectsUpdated.includes('openProjectDashboardController.postUpdated()'));

--- a/scripts/run-open-project-safety-checks.js
+++ b/scripts/run-open-project-safety-checks.js
@@ -1210,15 +1210,16 @@ function runOpenProjectIncrementalRenderingChecks() {
     assert.strictEqual(applyOpenProjectsUpdate({ version: 2, html: '<div>bad</div>' }), false);
     assert.strictEqual(wrapper.innerHTML, '<div data-group-id="__openProjects">new</div>');
     assert.ok(webviewScript.includes("type: 'open-projects-rendered'"));
+    const validNavigationHtml = [
+        '<div class="group open-current-workspace-group"><div class="project" data-id="current"></div></div>',
+        '<div class="group open-other-windows-group"><div class="project" data-project-navigation data-id="other"></div></div>',
+    ].join('');
     assert.strictEqual(applyOpenProjectsUpdate({
         type: 'open-projects-updated',
         version: 1,
         semanticRevision: 'revision-valid-navigation',
         projectCount: 2,
-        html: [
-            '<div class="group open-current-workspace-group"><div class="project" data-id="current"></div></div>',
-            '<div class="group open-other-windows-group"><div class="project" data-project-navigation data-id="other"></div></div>',
-        ].join(''),
+        html: validNavigationHtml,
         searchCatalog: {
             sessions: [],
             openProjects: [
@@ -1243,6 +1244,7 @@ function runOpenProjectIncrementalRenderingChecks() {
             savedProjects: [],
         },
     }), false, 'OPEN update must reject DOM that loses OTHER WINDOWS navigation cards');
+    assert.strictEqual(wrapper.innerHTML, validNavigationHtml, 'OPEN update must restore previous DOM after rejecting an inconsistent update');
 
     const postOpenProjectsUpdated = extractFunctionBody(dashboard, 'postOpenProjectsUpdated');
     assert.ok(postOpenProjectsUpdated.includes('openProjectDashboardController.postUpdated()'));

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -58,6 +58,7 @@ import OpenProjectBridgeClient from './openProjects/bridgeClient';
 import { SidebarStewardViewProvider } from './dashboard/viewProvider';
 import { getStewardConfiguration } from './dashboard/configuration';
 import { DashboardCommandRegistration } from './dashboard/commandRegistration';
+import { ActiveTerminalFileReferenceController } from './dashboard/activeTerminalFileReference';
 import DashboardDiagnostics from './dashboard/diagnostics';
 import { getErrorContent } from './dashboard/errorContent';
 import { GroupCollapseController } from './dashboard/groupCollapseController';
@@ -708,6 +709,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         publishOpenProjects: followsFocusEvent => openProjectWorkspaceController.publish(followsFocusEvent),
         evaluateAiSessionAttention: () => aiSessionAttentionController.evaluate(),
     });
+    const activeTerminalFileReferenceController = new ActiveTerminalFileReferenceController({
+        getActiveTextEditor: () => vscode.window.activeTextEditor,
+        getActiveTerminal: () => vscode.window.activeTerminal,
+        asRelativePath: uri => vscode.workspace.asRelativePath(uri as vscode.Uri, false),
+        showWarningMessage: message => vscode.window.showWarningMessage(message),
+    });
 
     new DashboardCommandRegistration<vscode.Disposable>({
         registerCommand: (command, callback) => vscode.commands.registerCommand(command, callback),
@@ -721,6 +728,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
             addGroup: () => groupCommandController.addGroup(),
             removeGroup: () => groupCommandController.removeGroupPerCommand(),
             addProjectsFromFolder: () => addProjectsFromFolderController.addProjectsFromFolder(),
+            addFileToActiveTerminal: () => activeTerminalFileReferenceController.addFileToActiveTerminal(),
         },
     }).register();
 

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -519,6 +519,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
                     projectCount: Number.isSafeInteger(e.projectCount) && e.projectCount >= 0
                         ? e.projectCount as number
                         : -1,
+                    renderedProjectCount: Number.isSafeInteger(e.renderedProjectCount) && e.renderedProjectCount >= 0
+                        ? e.renderedProjectCount as number
+                        : -1,
+                    renderedNavigationProjectCount: Number.isSafeInteger(e.renderedNavigationProjectCount) && e.renderedNavigationProjectCount >= 0
+                        ? e.renderedNavigationProjectCount as number
+                        : -1,
+                    hasOtherWindowsGroup: e.hasOtherWindowsGroup === true,
                 });
             },
             'request-active-ai-session-terminal': () => {

--- a/src/dashboard/activeTerminalFileReference.ts
+++ b/src/dashboard/activeTerminalFileReference.ts
@@ -1,0 +1,89 @@
+'use strict';
+
+export interface FileReferenceUriLike {
+    scheme?: string;
+    fsPath?: string;
+    path?: string;
+}
+
+export interface TextEditorSelectionLike {
+    isEmpty: boolean;
+    start: { line: number };
+    end: { line: number };
+}
+
+export interface TextEditorLike {
+    document: {
+        uri: FileReferenceUriLike;
+    };
+    selection: TextEditorSelectionLike;
+}
+
+export interface TerminalLike {
+    sendText(text: string, addNewLine?: boolean): void;
+    show?(): void;
+}
+
+export interface FileLineRange {
+    startLine: number;
+    endLine: number;
+}
+
+export interface ActiveTerminalFileReferenceControllerOptions {
+    getActiveTextEditor: () => TextEditorLike | null | undefined;
+    getActiveTerminal: () => TerminalLike | null | undefined;
+    asRelativePath: (uri: FileReferenceUriLike) => string;
+    showWarningMessage: (message: string) => unknown;
+}
+
+export function formatFileReference(filePath: string, range: FileLineRange | null): string {
+    if (!range) {
+        return filePath;
+    }
+    if (range.startLine === range.endLine) {
+        return `${filePath}:${range.startLine}`;
+    }
+    return `${filePath}:${range.startLine}-${range.endLine}`;
+}
+
+export function getPrimarySelectionLineRange(selection: TextEditorSelectionLike | null | undefined): FileLineRange | null {
+    if (!selection || selection.isEmpty) {
+        return null;
+    }
+    const startLine = Math.min(selection.start.line, selection.end.line) + 1;
+    const endLine = Math.max(selection.start.line, selection.end.line) + 1;
+    return { startLine, endLine };
+}
+
+export class ActiveTerminalFileReferenceController {
+    constructor(private readonly options: ActiveTerminalFileReferenceControllerOptions) {
+    }
+
+    async addFileToActiveTerminal(): Promise<void> {
+        const editor = this.options.getActiveTextEditor();
+        if (!editor || !this.isSavedFile(editor.document.uri)) {
+            this.options.showWarningMessage('Open a saved file before adding it to the active terminal.');
+            return;
+        }
+
+        const terminal = this.options.getActiveTerminal();
+        if (!terminal) {
+            this.options.showWarningMessage('No active terminal to receive the file reference.');
+            return;
+        }
+
+        const filePath = this.getReferencePath(editor.document.uri);
+        const reference = formatFileReference(filePath, getPrimarySelectionLineRange(editor.selection));
+        terminal.sendText(reference, false);
+        terminal.show?.();
+    }
+
+    private isSavedFile(uri: FileReferenceUriLike): boolean {
+        return uri?.scheme !== 'untitled' && Boolean(uri?.fsPath || uri?.path);
+    }
+
+    private getReferencePath(uri: FileReferenceUriLike): string {
+        const relativePath = this.options.asRelativePath(uri);
+        return relativePath || uri.fsPath || uri.path || '';
+    }
+}

--- a/src/dashboard/commandRegistration.ts
+++ b/src/dashboard/commandRegistration.ts
@@ -13,6 +13,7 @@ export interface DashboardCommandHandlers {
     addGroup: () => unknown;
     removeGroup: () => unknown;
     addProjectsFromFolder: () => unknown;
+    addFileToActiveTerminal: () => unknown;
 }
 
 export interface DashboardCommandRegistrationOptions<TDisposable extends DisposableLike = DisposableLike> {
@@ -34,6 +35,7 @@ export class DashboardCommandRegistration<TDisposable extends DisposableLike = D
         this.registerCommand('projectSteward.addGroup', this.options.handlers.addGroup);
         this.registerCommand('projectSteward.removeGroup', this.options.handlers.removeGroup);
         this.registerCommand('projectSteward.addProjectsFromFolder', this.options.handlers.addProjectsFromFolder);
+        this.registerCommand('projectSteward.addFileToActiveTerminal', this.options.handlers.addFileToActiveTerminal);
     }
 
     private registerCommand(command: string, callback: () => unknown): void {

--- a/src/webview/webviewProjectScripts.js
+++ b/src/webview/webviewProjectScripts.js
@@ -18,6 +18,9 @@ function applyOpenProjectsUpdate(message) {
     }
 
     wrapper.innerHTML = message.html;
+    if (!isOpenProjectsUpdateDomConsistent(message)) {
+        return false;
+    }
     if (window.__projectStewardDashboard) {
         window.__projectStewardDashboard.replaceSearchCatalog(message.searchCatalog);
     }
@@ -25,6 +28,40 @@ function applyOpenProjectsUpdate(message) {
         window.__projectStewardSyncCollapseButton();
     }
     return true;
+}
+
+function getOpenProjectsUpdateCatalogCounts(searchCatalog) {
+    var openProjects = searchCatalog && Array.isArray(searchCatalog.openProjects)
+        ? searchCatalog.openProjects
+        : [];
+    return {
+        projectCount: openProjects.length,
+        navigationProjectCount: openProjects.filter(project => project && project.action !== 'open-current').length,
+    };
+}
+
+function getOpenProjectsUpdateDomState() {
+    return {
+        projectCount: document.querySelectorAll('.sticky-groups-wrapper .project[data-id]').length,
+        navigationProjectCount: document.querySelectorAll('.sticky-groups-wrapper .project[data-project-navigation][data-id]').length,
+        hasOtherWindowsGroup: document.querySelectorAll('.sticky-groups-wrapper .open-other-windows-group').length > 0,
+    };
+}
+
+function isOpenProjectsUpdateDomConsistent(message) {
+    var expected = getOpenProjectsUpdateCatalogCounts(message.searchCatalog);
+    if (!expected.projectCount) {
+        return true;
+    }
+
+    var rendered = getOpenProjectsUpdateDomState();
+    if (rendered.projectCount !== expected.projectCount) {
+        return false;
+    }
+    if (rendered.navigationProjectCount !== expected.navigationProjectCount) {
+        return false;
+    }
+    return expected.navigationProjectCount === 0 || rendered.hasOtherWindowsGroup;
 }
 
 function getCollapseButtonState(tab, collapsedStates) {
@@ -923,10 +960,14 @@ function initProjects() {
             }
             syncActiveAiSessionTerminalDom();
             updateStickyGroupHeaderOffset();
+            var renderedOpenProjectsState = getOpenProjectsUpdateDomState();
             window.vscode.postMessage({
                 type: 'open-projects-rendered',
                 semanticRevision: message.semanticRevision,
                 projectCount: message.projectCount,
+                renderedProjectCount: renderedOpenProjectsState.projectCount,
+                renderedNavigationProjectCount: renderedOpenProjectsState.navigationProjectCount,
+                hasOtherWindowsGroup: renderedOpenProjectsState.hasOtherWindowsGroup,
             });
             return;
         }

--- a/src/webview/webviewProjectScripts.js
+++ b/src/webview/webviewProjectScripts.js
@@ -17,8 +17,10 @@ function applyOpenProjectsUpdate(message) {
         return false;
     }
 
+    var previousHtml = wrapper.innerHTML;
     wrapper.innerHTML = message.html;
     if (!isOpenProjectsUpdateDomConsistent(message)) {
+        wrapper.innerHTML = previousHtml;
         return false;
     }
     if (window.__projectStewardDashboard) {

--- a/src/webview/webviewProjectScripts.js
+++ b/src/webview/webviewProjectScripts.js
@@ -52,6 +52,9 @@ function getOpenProjectsUpdateDomState() {
 
 function isOpenProjectsUpdateDomConsistent(message) {
     var expected = getOpenProjectsUpdateCatalogCounts(message.searchCatalog);
+    if (message.projectCount !== expected.projectCount) {
+        return false;
+    }
     if (!expected.projectCount) {
         return true;
     }


### PR DESCRIPTION
## Summary

- Add `Project Steward: Add File to Active Terminal` to append the active editor path to the active terminal without executing it.
- Include selected line ranges in the inserted reference and focus the terminal after insertion.
- Recover and harden the OPEN tab `OTHER WINDOWS` group when incremental webview updates lose expected navigation cards.
- Update the changelog for the new command and OPEN recovery fix.

## Impact

This lets Codex, Claude, Kimi, and other CLI workflows quickly receive references like `src/file.ts` or `src/file.ts:10-15` from the active editor, while keeping the terminal ready for the next prompt.

## Fix Details

The OPEN tab issue came from accepting incremental Open Projects DOM updates even when the rendered card counts or `OTHER WINDOWS` navigation group no longer matched the update catalog. The renderer now rejects inconsistent updates, restores the previous DOM, and requests a full refresh.

## Validation

- `npm run test:safety`
- `npm run test:dashboard`
- `npm run test:architecture-baseline`
- `npm run test:release-notes`
- `git diff --check`

## Review

- Independent reviewer reported no Critical issues.
- Addressed the Important consistency issue by requiring `message.projectCount`, search catalog count, and rendered DOM counts to agree before accepting an OPEN update.
- Added no-side-effect assertions for terminal warning paths.
