### PR TITLE
fix: retain pending AI sessions until terminal close

### DIFF
--- a/docs/superpowers/plans/2026-07-18-new-session-pending-lifecycle.md
+++ b/docs/superpowers/plans/2026-07-18-new-session-pending-lifecycle.md
@@ -1,0 +1,204 @@
+# New Session Pending Lifecycle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep a newly created AI session in the ACTIVE tab while its Terminal remains open, then bind it when the provider session becomes discoverable.
+
+**Architecture:** Remove elapsed-time ownership from `AiSessionCreationController`; the terminal service remains the sole owner of pending lifetimes, with resolver promotion and Terminal-close cleanup as the two live transitions. Keep the existing pending persistence, 24-hour restored-record TTL, matching rules, and `Starting` projection unchanged.
+
+**Tech Stack:** TypeScript, VS Code extension API, Node.js safety-check harness using `assert`.
+
+## Global Constraints
+
+- A NEW session remains `Starting` in ACTIVE for as long as its Terminal is open.
+- Elapsed time alone must never remove a live pending record or emit `Could not detect the new session`.
+- Do not add a new UI status or change provider matching, completion, persistence, or the 24-hour restored-record TTL.
+- Keep all changes on `fix/new-session-pending-lifecycle` in `.worktrees/fix-new-session-pending-lifecycle`; do not modify the main checkout.
+- Add no dependencies.
+
+---
+
+### Task 1: Make pending lifetime follow Terminal ownership
+
+**Files:**
+- Modify: `scripts/run-ai-session-safety-checks.js:559-621,1051-1188,1854-1981`
+- Modify: `src/aiSessions/creationController.ts:31-219`
+- Modify: `src/dashboard.ts:51-52,363-400,958-960,979`
+
+**Interfaces:**
+- Consumes: `trackPendingTerminal(pending)`, the existing pending resolver, and `AiSessionTerminalService.handleClosedTerminal(terminal)`.
+- Produces: `AiSessionCreationController.createSession(projectId: string): Promise<void>` without a binding-timeout lifecycle; pending promotion and close cleanup retain their existing interfaces.
+
+- [ ] **Step 1: Rewrite the creation-controller safety check to express the retained-pending behavior**
+
+Keep the injected timer and removal spies temporarily so the test can prove they are not called. Delete the invalid-timestamp `controller.watchPending(...)` setup, replace both timeout expectations, and remove the timeout callback and `controller.dispose()` assertions. After the first successful Codex creation, use:
+
+```js
+    assert.deepStrictEqual(activeTabRequests, ['project-a']);
+    assert.strictEqual(refreshes.length, 1);
+    assert.strictEqual(timeoutQueue.length, 0, 'creating a session must not schedule pending removal');
+    assert.strictEqual(pendingKeys.has(`codex:${tracked[0].createdAt}`), true);
+```
+
+After the Kimi creation, use:
+
+```js
+    assert.strictEqual(timeoutQueue.length, 0, 'elapsed time must not own the pending lifecycle');
+    assert.strictEqual(pendingKeys.has(`kimi:${tracked[1].createdAt}`), true);
+    assert.deepStrictEqual(removed, []);
+    assert.deepStrictEqual(announcements, []);
+    assert.deepStrictEqual(warnings, [['Open project not found.', []]]);
+    assert.strictEqual(terminals[1].terminal.showCalls, 1);
+    assert.strictEqual(terminals[1].terminal.disposeCalls, 0);
+    assert.strictEqual(refreshes.length, 2);
+```
+
+This is the regression assertion: with the current implementation, `timeoutQueue.length` is `1` after the first creation.
+
+- [ ] **Step 2: Make the delayed resolver and Terminal-close boundaries explicit in safety checks**
+
+In `runPendingTerminalResolverChecks()`, make the matched session appear 56 seconds after the pending creation:
+
+```js
+                    { id: 'new', cwd: '/work/app', updatedAt: '2026-07-15T10:00:56Z' },
+```
+
+Keep the existing assertions that the resolver tracks `codex:new`, preserves the same pending Terminal and marker, applies the alias, and leaves only the unmatched pending record.
+
+In `runAiSessionTerminalResolutionChecks()`, create a pending Terminal before the existing close assertions:
+
+```js
+        const pending = { name: 'Codex: Pending', creationOptions: {}, processId: Promise.resolve(42099) };
+        service.trackPending({
+            provider: 'codex',
+            terminal: pending,
+            markerPath: path.join(tempRoot, 'pending.done'),
+            cwd: '/work/app',
+            createdAt: new Date().toISOString(),
+            excludedSessionIds: [],
+        }, false);
+        assert.strictEqual(service.getPendingTerminals().length, 1);
+        assert.deepStrictEqual(service.handleClosedTerminal(pending), []);
+        assert.strictEqual(service.getPendingTerminals().length, 0, 'closing a Terminal removes its unresolved pending row');
+```
+
+- [ ] **Step 3: Run the safety suite and verify the new creation assertion fails**
+
+Run:
+
+```bash
+npm run test:safety
+```
+
+Expected: FAIL in `runAiSessionCreationControllerChecks()` with `creating a session must not schedule pending removal`, showing actual timeout count `1` instead of expected `0`. Compilation and the added delayed-resolver and close-boundary assertions must not error.
+
+- [ ] **Step 4: Remove the creation controller's elapsed-time lifecycle**
+
+In `src/aiSessions/creationController.ts`, delete:
+
+- `AI_SESSION_CREATION_BIND_TIMEOUT_MS`;
+- option fields `announceStatus`, `isPending`, `removePending`, `normalizeProjectPath`, `setTimeout`, `clearTimeout`, and `bindingTimeoutMs`;
+- `pendingTimeouts`;
+- methods `watchPending`, `dispose`, `handlePendingTimeout`, `findPendingProjectId`, and `getPendingKey`;
+- the `this.watchPending(pending, project.id)` call.
+
+Retain `nowMs`, because it supplies the pending record's creation timestamp. The final tail of `AiSessionCreationControllerOptions` must be:
+
+```ts
+    sendNewSessionCommand: (
+        providerId: AiSessionProviderId,
+        terminal: vscode.Terminal,
+        cwd: string | null,
+        title: string,
+        markerPath: string
+    ) => Thenable<unknown>;
+    scheduleNewSessionRefresh: (providerId: AiSessionProviderId) => void;
+    nowMs: () => number;
+}
+```
+
+The final pending handoff in `createProviderSession` must be:
+
+```ts
+        this.options.trackPendingTerminal({
+            provider: providerId,
+            terminal,
+            markerPath,
+            cwd: pendingTerminalCwd,
+            createdAt,
+            excludedSessionIds: existingSessionIds,
+            title: fields.title,
+        });
+
+        await this.options.showActiveTab(project.id);
+        this.options.refresh();
+        terminal.show();
+        await this.options.sendNewSessionCommand(providerId, terminal, cwd, fields.title, markerPath);
+        this.options.scheduleNewSessionRefresh(providerId);
+```
+
+- [ ] **Step 5: Remove obsolete dashboard wiring**
+
+In `src/dashboard.ts`:
+
+- keep only `import { AiSessionCreationController } from './aiSessions/creationController';` and remove the timeout-constant import;
+- remove the `announceStatus` callback from the controller options;
+- remove option fields `isPending`, `removePending`, `normalizeProjectPath`, `setTimeout`, `clearTimeout`, and `bindingTimeoutMs`;
+- keep `nowMs: () => Date.now()`;
+- remove the startup loop that calls `aiSessionCreationController.watchPending(pending)`;
+- remove `context.subscriptions.push(aiSessionCreationController)` because the controller is no longer disposable.
+
+Do not remove the Webview's generic `ai-session-status-announcement` receiver; this fix only removes the creation controller as a sender.
+
+- [ ] **Step 6: Run focused verification and confirm GREEN**
+
+Run:
+
+```bash
+npm run test:safety
+```
+
+Expected:
+
+```text
+AI session safety checks passed.
+Open project safety checks passed.
+```
+
+- [ ] **Step 7: Run static checks and inspect the exact diff**
+
+Run:
+
+```bash
+npm run lint
+git diff --check
+git diff --stat main...HEAD
+git status -sb
+```
+
+Expected: lint and `git diff --check` exit `0`; only the design, plan, safety-check harness, creation controller, and dashboard are changed on the feature branch.
+
+- [ ] **Step 8: Commit the behavior fix**
+
+```bash
+git add src/aiSessions/creationController.ts src/dashboard.ts scripts/run-ai-session-safety-checks.js
+git commit -m "fix: retain pending AI sessions until terminal close"
+```
+
+- [ ] **Step 9: Review the committed fix and rerun fresh verification**
+
+Inspect:
+
+```bash
+git diff main...HEAD -- src/aiSessions/creationController.ts src/dashboard.ts scripts/run-ai-session-safety-checks.js
+```
+
+Then rerun:
+
+```bash
+npm run test:safety
+npm run lint
+git status -sb
+```
+
+Expected: all checks exit `0`, the worktree is clean, and the branch contains the documentation commit plus the behavior-fix commit.

--- a/docs/superpowers/specs/2026-07-18-new-session-pending-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-07-18-new-session-pending-lifecycle-design.md
@@ -1,0 +1,69 @@
+# New Session Pending Lifecycle Design
+
+## Context
+
+Creating an AI session immediately adds a pending `Starting` row to the project's ACTIVE tab. The creation controller currently starts a 15-second binding timer. If the provider's session file is not discoverable before that timer expires, the controller removes the pending record and shows `Could not detect the new session`.
+
+Interactive providers may not write a session file until the user sends the first message. The observed Codex session started at `22:13:07`, while its JSONL file appeared at `22:14:03`, about 56 seconds later. The pending record was therefore removed before the existing resolver could bind it, even though the Terminal remained open and the eventual session had the correct project path.
+
+## Goal
+
+Keep a newly created session visible in the ACTIVE tab for as long as its Terminal remains open. When the provider session becomes discoverable, promote the pending runtime to the established session without losing Terminal ownership.
+
+## Non-goals
+
+- Add a new ACTIVE-tab status or change the existing `Starting` presentation.
+- Change provider session discovery, path normalization, or matching rules.
+- Change established-session completion behavior.
+- Keep pending records after their Terminal closes.
+
+## Lifecycle
+
+The pending Terminal becomes the authoritative runtime record until one of two events occurs:
+
+1. The session resolver finds a provider session created after the pending record, in the same normalized working directory, and not present in the creation-time exclusion set. The resolver replaces the pending record with a bound active-session entry.
+2. VS Code reports that the Terminal closed. The terminal service removes the pending record, and the ACTIVE projection removes its row.
+
+There is no elapsed-time transition while the Terminal remains open. Extension reload continues to restore persisted pending bindings. The terminal service's existing 24-hour TTL remains a recovery guard for stale persisted metadata; it is not a live creation timeout.
+
+## Component Changes
+
+### Creation controller
+
+Remove the 15-second binding timeout and all controller-owned pending timer state. Creating a session still tracks the pending Terminal, selects the ACTIVE tab, refreshes the projection, opens the Terminal, sends the provider command, and schedules provider refreshes.
+
+The controller no longer removes pending records or emits `Could not detect the new session`. Its lifecycle ends after launching the provider command.
+
+### Terminal service and resolver
+
+Keep their current responsibilities unchanged:
+
+- the terminal service owns pending records, persistence, close cleanup, and stale restored-record trimming;
+- the resolver promotes a pending record when a matching session appears;
+- the runtime projection displays every owned pending record as `Starting`.
+
+This avoids introducing a second lifetime policy alongside Terminal ownership.
+
+## Error Handling
+
+Provider picker cancellation, missing projects, unusable working directories, and Terminal creation warnings keep their current behavior. A provider process that stays open without creating a session remains visible as `Starting`, because it is still an active Terminal owned by the dashboard. The user can focus or close that Terminal from the existing ACTIVE controls.
+
+If the Terminal closes before a session is discovered, existing close handling removes the pending record. No detection warning is shown because the close event supplies a definitive lifecycle boundary.
+
+## Testing
+
+Safety checks will cover these behaviors:
+
+- creation tracks one pending record and does not schedule a binding timeout;
+- an unresolved pending record remains present beyond the former 15-second boundary without a warning or removal;
+- a session that becomes discoverable after a 56-second delay is matched and promoted to a bound active session;
+- closing a pending Terminal still removes its record;
+- existing creation, persistence, resolver, ACTIVE projection, compilation, and open-project safety checks continue to pass.
+
+## Acceptance Criteria
+
+- A session created from NEW remains in ACTIVE with `Starting` while its Terminal is open, regardless of how long session-file creation takes.
+- No `Could not detect the new session` warning appears solely because 15 seconds elapsed.
+- Once the session file is discoverable, the same Terminal is bound to the session and the ACTIVE row becomes an established session row.
+- Closing the Terminal removes an unresolved pending row.
+- Main checkout user changes remain untouched; all work occurs on `fix/new-session-pending-lifecycle` in its isolated worktree.

--- a/scripts/run-ai-session-safety-checks.js
+++ b/scripts/run-ai-session-safety-checks.js
@@ -600,7 +600,7 @@ function runPendingTerminalResolverChecks() {
                 sessions: [
                     { id: 'old', cwd: '/work/app', updatedAt: '2026-07-15T10:01:00Z' },
                     { id: 'claimed', cwd: '/work/app', updatedAt: '2026-07-15T10:02:00Z' },
-                    { id: 'new', cwd: '/work/app', updatedAt: '2026-07-15T10:03:00Z' },
+                    { id: 'new', cwd: '/work/app', updatedAt: '2026-07-15T10:00:56Z' },
                 ],
             },
         },
@@ -1131,12 +1131,6 @@ async function runAiSessionCreationControllerChecks() {
         nowMs: () => Date.parse('2026-07-18T04:00:00.000Z'),
     });
 
-    controller.watchPending({
-        provider: 'codex', terminal: { show() {} }, markerPath: '/tmp/invalid.marker',
-        cwd: '/work/a', createdAt: 'invalid', excludedSessionIds: [],
-    }, 'project-a');
-    assert.strictEqual(timeoutQueue.length, 0, 'an invalid restored timestamp must not schedule an immediate timeout');
-
     await controller.createSession('missing');
     assert.deepStrictEqual(warnings, [['Open project not found.', []]]);
     assert.strictEqual(terminals.length, 0);
@@ -1164,8 +1158,8 @@ async function runAiSessionCreationControllerChecks() {
     assert.strictEqual(terminals[0].terminal.showCalls, 1);
     assert.deepStrictEqual(activeTabRequests, ['project-a']);
     assert.strictEqual(refreshes.length, 1);
-    assert.strictEqual(timeoutQueue[0].delayMs, 15_000);
-    pendingKeys.delete(`codex:${tracked[0].createdAt}`);
+    assert.strictEqual(timeoutQueue.length, 0, 'creating a session must not schedule pending removal');
+    assert.strictEqual(pendingKeys.has(`codex:${tracked[0].createdAt}`), true);
 
     usableCwd = null;
     nextProvider = 'kimi';
@@ -1174,21 +1168,14 @@ async function runAiSessionCreationControllerChecks() {
     assert.deepStrictEqual(existingSessionInputs[1], ['kimi', '/work/a']);
     assert.strictEqual(tracked[1].cwd, '/work/a');
     assert.deepStrictEqual(sent[1], ['kimi', terminals[1].terminal, null, '', '/tmp/kimi.marker']);
-    assert.strictEqual(timeoutQueue[1].delayMs, 15_000);
-
-    warningAction = 'Focus Terminal';
-    await timeoutQueue[1].callback();
-    assert.deepStrictEqual(removed, [['kimi', tracked[1].createdAt]]);
-    assert.deepStrictEqual(announcements, [['project-a', 'Could not detect the new session']]);
-    assert.deepStrictEqual(warnings[warnings.length - 1], [
-        'Could not detect the new session', ['Focus Terminal'],
-    ]);
-    assert.strictEqual(terminals[1].terminal.showCalls, 2);
+    assert.strictEqual(timeoutQueue.length, 0, 'elapsed time must not own the pending lifecycle');
+    assert.strictEqual(pendingKeys.has(`kimi:${tracked[1].createdAt}`), true);
+    assert.deepStrictEqual(removed, []);
+    assert.deepStrictEqual(announcements, []);
+    assert.deepStrictEqual(warnings, [['Open project not found.', []]]);
+    assert.strictEqual(terminals[1].terminal.showCalls, 1);
     assert.strictEqual(terminals[1].terminal.disposeCalls, 0);
-    assert.strictEqual(refreshes.length, 3);
-
-    controller.dispose();
-    assert.strictEqual(timeoutQueue[0].cleared, true, 'dispose clears an unresolved pending timeout');
+    assert.strictEqual(refreshes.length, 2);
 }
 
 function runAiSessionProviderAvailabilityChecks() {
@@ -1971,6 +1958,19 @@ function runAiSessionTerminalResolutionChecks() {
         candidateCalls.length = 0;
         assert.strictEqual(service.resolveTerminalSession(ordinary, getCandidates), null);
         assert.deepStrictEqual(candidateCalls, []);
+
+        const pending = { name: 'Codex: Pending', creationOptions: {}, processId: Promise.resolve(42099) };
+        service.trackPending({
+            provider: 'codex',
+            terminal: pending,
+            markerPath: path.join(tempRoot, 'pending.done'),
+            cwd: '/work/app',
+            createdAt: new Date().toISOString(),
+            excludedSessionIds: [],
+        }, false);
+        assert.strictEqual(service.getPendingTerminals().length, 1);
+        assert.deepStrictEqual(service.handleClosedTerminal(pending), []);
+        assert.strictEqual(service.getPendingTerminals().length, 0, 'closing a Terminal removes its unresolved pending row');
 
         assert.deepStrictEqual(
             service.handleClosedTerminal(tracked),

--- a/src/aiSessions/creationController.ts
+++ b/src/aiSessions/creationController.ts
@@ -28,8 +28,6 @@ export interface PendingAiSessionTerminal {
     title?: string;
 }
 
-export const AI_SESSION_CREATION_BIND_TIMEOUT_MS = 15_000;
-
 export interface AiSessionCreationControllerOptions {
     isProviderId: (value: string) => value is AiSessionProviderId;
     getOpenProjects: () => Project[];
@@ -40,7 +38,6 @@ export interface AiSessionCreationControllerOptions {
     getUsableTerminalCwd: (cwd: string) => string | null;
     showInputBox: (options: vscode.InputBoxOptions) => Thenable<string | undefined>;
     showActiveTab: (projectId: string) => Thenable<unknown> | Promise<unknown>;
-    announceStatus: (projectId: string, message: string) => Thenable<unknown> | Promise<unknown>;
     showWarningMessage: (message: string, ...items: string[]) => Thenable<string | undefined>;
     refresh: () => void;
     createTerminal: (options: {
@@ -60,18 +57,11 @@ export interface AiSessionCreationControllerOptions {
         markerPath: string
     ) => Thenable<unknown>;
     scheduleNewSessionRefresh: (providerId: AiSessionProviderId) => void;
-    isPending: (providerId: AiSessionProviderId, createdAt: string) => boolean;
-    removePending: (providerId: AiSessionProviderId, createdAt: string) => void;
-    normalizeProjectPath: (cwd: string) => string | null;
-    setTimeout: (callback: () => void, delayMs: number) => unknown;
-    clearTimeout: (handle: unknown) => void;
-    bindingTimeoutMs: number;
     nowMs: () => number;
 }
 
 export class AiSessionCreationController {
     private creating = false;
-    private readonly pendingTimeouts = new Map<string, unknown>();
 
     constructor(private readonly options: AiSessionCreationControllerOptions) {
     }
@@ -99,38 +89,6 @@ export class AiSessionCreationController {
         } finally {
             this.creating = false;
         }
-    }
-
-    watchPending(pending: PendingAiSessionTerminal, projectId?: string): void {
-        if (!pending || !this.options.isProviderId(pending.provider) || !pending.createdAt) {
-            return;
-        }
-        const key = this.getPendingKey(pending.provider, pending.createdAt);
-        if (this.pendingTimeouts.has(key)) {
-            return;
-        }
-        const resolvedProjectId = projectId || this.findPendingProjectId(pending.cwd);
-        if (!resolvedProjectId) {
-            return;
-        }
-        const createdAtMs = Date.parse(pending.createdAt);
-        if (!Number.isFinite(createdAtMs)) {
-            return;
-        }
-        const elapsedMs = Math.max(0, this.options.nowMs() - createdAtMs);
-        const delayMs = Math.max(0, this.options.bindingTimeoutMs - elapsedMs);
-        const handle = this.options.setTimeout(
-            () => this.handlePendingTimeout(pending, resolvedProjectId, key),
-            delayMs
-        );
-        this.pendingTimeouts.set(key, handle);
-    }
-
-    dispose(): void {
-        for (const handle of this.pendingTimeouts.values()) {
-            this.options.clearTimeout(handle);
-        }
-        this.pendingTimeouts.clear();
     }
 
     private async queryNewSessionFields(providerId: AiSessionProviderId): Promise<NewAiSessionFields | null> {
@@ -167,7 +125,7 @@ export class AiSessionCreationController {
         const existingSessionIds = this.options.getExistingSessionIdsForCwd(providerId, pendingTerminalCwd);
         const createdAt = new Date(this.options.nowMs()).toISOString();
         const markerPath = this.options.getPendingMarkerPath(providerId);
-        const pending = {
+        this.options.trackPendingTerminal({
             provider: providerId,
             terminal,
             markerPath,
@@ -175,45 +133,12 @@ export class AiSessionCreationController {
             createdAt,
             excludedSessionIds: existingSessionIds,
             title: fields.title,
-        };
-        this.options.trackPendingTerminal(pending);
-        this.watchPending(pending, project.id);
+        });
 
         await this.options.showActiveTab(project.id);
         this.options.refresh();
         terminal.show();
         await this.options.sendNewSessionCommand(providerId, terminal, cwd, fields.title, markerPath);
         this.options.scheduleNewSessionRefresh(providerId);
-    }
-
-    private async handlePendingTimeout(
-        pending: PendingAiSessionTerminal,
-        projectId: string,
-        key: string
-    ): Promise<void> {
-        this.pendingTimeouts.delete(key);
-        if (!this.options.isPending(pending.provider, pending.createdAt)) {
-            return;
-        }
-        this.options.removePending(pending.provider, pending.createdAt);
-        this.options.refresh();
-        const message = 'Could not detect the new session';
-        await this.options.announceStatus(projectId, message);
-        const action = await this.options.showWarningMessage(message, 'Focus Terminal');
-        if (action === 'Focus Terminal') {
-            pending.terminal.show();
-        }
-    }
-
-    private findPendingProjectId(cwd: string): string | null {
-        const targetCwd = this.options.normalizeProjectPath(cwd);
-        const project = this.options.getOpenProjects().find(candidate => {
-            return this.options.normalizeProjectPath(this.options.getTerminalCwd(candidate)) === targetCwd;
-        });
-        return project?.id || null;
-    }
-
-    private getPendingKey(providerId: AiSessionProviderId, createdAt: string): string {
-        return `${providerId}:${createdAt}`;
     }
 }

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -49,7 +49,6 @@ import type { AiSessionBatchArchiveCompletedMessage, AiSessionProvider, AiSessio
 import { AiSessionDashboardController } from './aiSessions/dashboardController';
 import { AiSessionCommandController } from './aiSessions/commandController';
 import { AiSessionCreationController } from './aiSessions/creationController';
-import { AI_SESSION_CREATION_BIND_TIMEOUT_MS } from './aiSessions/creationController';
 import { AiSessionArchiveController } from './aiSessions/archiveController';
 import { AiSessionResumeController } from './aiSessions/resumeController';
 import { AiSessionTerminalCommandController } from './aiSessions/terminalCommandController';
@@ -363,11 +362,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
             projectId,
             tab: 'active',
         }),
-        announceStatus: (projectId, message) => provider.postMessage({
-            type: 'ai-session-status-announcement',
-            projectId,
-            message,
-        }),
         showWarningMessage: (message, ...items) => vscode.window.showWarningMessage(message, ...items),
         refresh: refreshAiSessionViewsIncrementally,
         createTerminal: options => aiSessionTerminalService.createTerminal({
@@ -391,12 +385,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         ),
         sendNewSessionCommand: (providerId, terminal, cwd, title, markerPath) => aiSessionTerminalService.sendNewSessionCommand(providerId, terminal, cwd, title, markerPath),
         scheduleNewSessionRefresh: scheduleNewAiSessionRefresh,
-        isPending: (providerId, createdAt) => aiSessionTerminalService.hasPending(providerId, createdAt),
-        removePending: (providerId, createdAt) => aiSessionTerminalService.removePending(providerId, createdAt),
-        normalizeProjectPath: normalizeAiSessionProjectPath,
-        setTimeout: (callback, delayMs) => setTimeout(callback, delayMs),
-        clearTimeout: handle => clearTimeout(handle as NodeJS.Timeout),
-        bindingTimeoutMs: AI_SESSION_CREATION_BIND_TIMEOUT_MS,
         nowMs: () => Date.now(),
     });
     const aiSessionArchiveController = new AiSessionArchiveController<AiSessionTerminalEntry<vscode.Terminal>>({
@@ -955,10 +943,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         void aiSessionAttentionController.evaluate();
     }, 1_000);
 
-    aiSessionTerminalService.getPendingTerminals().forEach(pending => {
-        aiSessionCreationController.watchPending(pending);
-    });
-
     context.subscriptions.push(
         vscode.window.registerWebviewViewProvider(SidebarStewardViewProvider.viewType, provider));
     context.subscriptions.push(
@@ -980,7 +964,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
             }
         }));
     context.subscriptions.push(activeAiSessionTerminalHighlighter);
-    context.subscriptions.push(aiSessionCreationController);
     context.subscriptions.push(openProjectBridgeClient);
     context.subscriptions.push(aiSessionAttentionBridgeClient);
     context.subscriptions.push({


### PR DESCRIPTION
## Summary

- keep newly created AI sessions in ACTIVE while their Terminal remains open
- remove the 15-second binding timeout and false detection warning
- cover delayed session discovery and Terminal-close cleanup

## Verification

- npm run test:safety
- npm run lint
- npm run test:release-packaging
- local VSIX build and Dev Container installation

## Release

- no version bump, tag, GitHub Release, or marketplace publication