### PR TITLE
fix: recover long-running AI session state

### DIFF
--- a/docs/superpowers/plans/2026-07-19-ai-session-lifecycle-recovery.md
+++ b/docs/superpowers/plans/2026-07-19-ai-session-lifecycle-recovery.md
@@ -1,0 +1,469 @@
+# AI Session Lifecycle Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Recover accurate active-session execution state for Codex, Kimi, and Claude after reload without relying on a fixed JSONL tail window.
+
+**Architecture:** Provider lifecycle parsers become stateful accumulators that preserve event-time ordering and provider-specific state across batches. A shared incremental JSONL reader owns bounded chunk I/O, partial lines, file identity, byte offsets, resets, and cursor pruning; provider services supply only file lookup and accumulator factories.
+
+**Tech Stack:** TypeScript, Node.js `fs` and `string_decoder`, the existing compiled JavaScript safety-check harness, Git.
+
+## Global Constraints
+
+- Do not change user-visible execution states, labels, or card styling.
+- Apply the same reader architecture to Codex, Kimi, and Claude.
+- Keep steady-state reads proportional to appended bytes and memory bounded by chunk size plus the largest incomplete line.
+- Preserve event-time ordering and Codex `request_user_input` matching semantics.
+- Do not add dependencies or configuration.
+
+---
+
+### Task 1: Stateful Provider Lifecycle Accumulators
+
+**Files:**
+- Modify: `src/aiSessions/lifecycle.ts`
+- Test: `scripts/run-ai-session-safety-checks.js`
+
+**Interfaces:**
+- Produces: `AiSessionLifecycleAccumulator` with `addLines(lines: readonly string[]): void` and `getSignal(): AiSessionLifecycleSignal | null`.
+- Produces: `createCodexLifecycleAccumulator(runStartedAtMs)`, `createKimiLifecycleAccumulator(runStartedAtMs)`, and `createClaudeLifecycleAccumulator(runStartedAtMs)`.
+- Preserves: existing `parseCodexLifecycleLines`, `parseKimiLifecycleLines`, and `parseClaudeLifecycleLines` signatures.
+
+- [ ] **Step 1: Write failing cross-batch accumulator tests**
+
+Add assertions to `runLifecycleParserChecks()` that exercise the wished-for stateful API:
+
+```javascript
+const codexAccumulator = lifecycle.createCodexLifecycleAccumulator(runStartedAtMs);
+codexAccumulator.addLines([
+    JSON.stringify({
+        timestamp: '2026-07-15T00:00:10.000Z',
+        type: 'response_item',
+        payload: { type: 'custom_tool_call', name: 'request_user_input', call_id: 'cross-batch' },
+    }),
+]);
+assert.strictEqual(codexAccumulator.getSignal().reason, 'input-required');
+codexAccumulator.addLines([
+    JSON.stringify({
+        timestamp: '2026-07-15T00:00:11.000Z',
+        type: 'response_item',
+        payload: { type: 'custom_tool_call_output', call_id: 'cross-batch' },
+    }),
+]);
+assert.strictEqual(codexAccumulator.getSignal().executionState, 'running');
+
+const kimiAccumulator = lifecycle.createKimiLifecycleAccumulator(runStartedAtMs);
+kimiAccumulator.addLines([
+    JSON.stringify({ timestamp: 1784073612, message: { type: 'TurnEnd', payload: {} } }),
+]);
+kimiAccumulator.addLines([
+    JSON.stringify({ timestamp: 1784073611, message: { type: 'TurnBegin', payload: {} } }),
+]);
+assert.strictEqual(kimiAccumulator.getSignal().executionState, 'stopped');
+
+const claudeAccumulator = lifecycle.createClaudeLifecycleAccumulator(runStartedAtMs);
+claudeAccumulator.addLines([
+    JSON.stringify({ timestamp: '2026-07-15T00:00:12.000Z', type: 'user', message: { role: 'user' } }),
+]);
+assert.strictEqual(claudeAccumulator.getSignal().executionState, 'running');
+```
+
+- [ ] **Step 2: Compile and run the safety check to verify RED**
+
+Run:
+
+```bash
+npm run test-compile && node scripts/run-ai-session-safety-checks.js
+```
+
+Expected: FAIL because `createCodexLifecycleAccumulator`, `createKimiLifecycleAccumulator`, and `createClaudeLifecycleAccumulator` do not exist.
+
+- [ ] **Step 3: Implement the accumulator API and delegate batch parsers to it**
+
+Refactor `lifecycle.ts` around this interface and helper shape:
+
+```typescript
+export interface AiSessionLifecycleAccumulator {
+    addLines(lines: readonly string[]): void;
+    getSignal(): AiSessionLifecycleSignal | null;
+}
+
+function createAccumulator(
+    runStartedAtMs: number,
+    parseEvent: (event: JsonRecord, occurredAtMs: number) => AiSessionLifecycleSignal | null
+): AiSessionLifecycleAccumulator {
+    let latest: AiSessionLifecycleSignal | null = null;
+    return {
+        addLines(lines) {
+            for (const line of lines || []) {
+                let event: JsonRecord;
+                try {
+                    event = JSON.parse(line);
+                } catch (e) {
+                    continue;
+                }
+                const occurredAtMs = getOccurredAtMs(event?.timestamp);
+                if (!Number.isFinite(occurredAtMs) || occurredAtMs < runStartedAtMs) {
+                    continue;
+                }
+                const signal = parseEvent(event, occurredAtMs);
+                if (signal && (!latest || signal.occurredAtMs >= latest.occurredAtMs)) {
+                    latest = signal;
+                }
+            }
+        },
+        getSignal: () => latest,
+    };
+}
+```
+
+Move each current provider callback into its exported factory. Keep `pendingInputCallIds` inside the Codex factory closure. Implement existing batch functions by creating an accumulator, adding the supplied lines once, and returning `getSignal()`.
+
+- [ ] **Step 4: Run focused checks to verify GREEN**
+
+Run:
+
+```bash
+npm run test-compile && node scripts/run-ai-session-safety-checks.js
+```
+
+Expected: `AI session safety checks passed.`
+
+- [ ] **Step 5: Commit the accumulator refactor**
+
+```bash
+git add src/aiSessions/lifecycle.ts scripts/run-ai-session-safety-checks.js
+git commit -m "refactor: make AI lifecycle parsing incremental"
+```
+
+---
+
+### Task 2: Shared Incremental JSONL Lifecycle Reader
+
+**Files:**
+- Create: `src/aiSessions/incrementalJsonlLifecycleReader.ts`
+- Test: `scripts/run-ai-session-safety-checks.js`
+
+**Interfaces:**
+- Consumes: `AiSessionLifecycleAccumulator` and `AiSessionLifecycleSignal` from Task 1.
+- Produces: default class `IncrementalJsonlLifecycleReader`.
+- Produces: `read(key: string, filePath: string, runStartedAtMs: number, createAccumulator: () => AiSessionLifecycleAccumulator): AiSessionLifecycleSignal | null`.
+- Produces: `retain(keys: ReadonlySet<string>): void` and `delete(key: string): void` for bounded cache ownership.
+
+- [ ] **Step 1: Import the new module and write failing reader tests**
+
+Add the module import near the existing lifecycle imports:
+
+```javascript
+const IncrementalJsonlLifecycleReader = require('../out/aiSessions/incrementalJsonlLifecycleReader').default;
+```
+
+Add `runIncrementalJsonlLifecycleReaderChecks()` using a temporary directory and a small `64`-byte chunk size. Its core setup and assertions should be:
+
+```javascript
+const reader = new IncrementalJsonlLifecycleReader(64);
+const filePath = path.join(tempRoot, 'codex.jsonl');
+const started = JSON.stringify({
+    timestamp: '2026-07-15T00:00:01.000Z',
+    type: 'event_msg',
+    payload: { type: 'task_started', turn_id: 'long-turn' },
+});
+fs.writeFileSync(filePath, `${started}\n${Array.from({ length: 100 }, (_, index) =>
+    JSON.stringify({ timestamp: `2026-07-15T00:00:02.${String(index).padStart(3, '0')}Z`, type: 'event_msg', payload: { type: 'token_count' } })
+).join('\n')}\n`);
+
+let signal = reader.read(
+    'codex:long',
+    filePath,
+    runStartedAtMs,
+    () => lifecycle.createCodexLifecycleAccumulator(runStartedAtMs)
+);
+assert.strictEqual(signal.executionState, 'running', 'cold scan recovers starts beyond one chunk');
+
+fs.appendFileSync(filePath, JSON.stringify({
+    timestamp: '2026-07-15T00:00:03.000Z',
+    type: 'event_msg',
+    payload: { type: 'task_complete', turn_id: 'long-turn' },
+}) + '\n');
+signal = reader.read('codex:long', filePath, runStartedAtMs, () => lifecycle.createCodexLifecycleAccumulator(runStartedAtMs));
+assert.strictEqual(signal.executionState, 'stopped', 'appended completion updates cached state');
+```
+
+In the same function, add explicit cases for:
+
+- no additional `fs.readSync` call when file size is unchanged;
+- a Codex input request in one read and matching output in a later append;
+- a JSON line split across calls and completed with a newline;
+- malformed JSON followed by a valid event;
+- truncation to a shorter file resetting the old completion state;
+- a changed `runStartedAtMs` resetting the cursor;
+- `retain(...)` and `delete(...)` removing cursors, proven by rewriting the file before the next cold read.
+
+Call `runIncrementalJsonlLifecycleReaderChecks()` from `main()` immediately after `runLifecycleParserChecks()`.
+
+- [ ] **Step 2: Compile to verify RED**
+
+Run:
+
+```bash
+npm run test-compile && node scripts/run-ai-session-safety-checks.js
+```
+
+Expected: FAIL with `Cannot find module '../out/aiSessions/incrementalJsonlLifecycleReader'` because the reader source does not exist.
+
+- [ ] **Step 3: Implement bounded chunk reading and cursor reset logic**
+
+Create the reader with cursor state equivalent to:
+
+```typescript
+interface Cursor {
+    filePath: string;
+    runStartedAtMs: number;
+    dev: number;
+    ino: number;
+    birthtimeMs: number;
+    offset: number;
+    decoder: StringDecoder;
+    partialLine: string;
+    accumulator: AiSessionLifecycleAccumulator;
+}
+```
+
+`read(...)` must:
+
+1. `statSync` and reject non-files.
+2. reset when path/run start/identity differs or `stat.size < cursor.offset`;
+3. open the file and loop from `cursor.offset` to `stat.size` using `Buffer.alloc(Math.min(chunkBytes, remaining))`;
+4. decode with `StringDecoder('utf8')`, prepend `partialLine`, split complete `\n`-terminated lines, and retain the unfinished suffix;
+5. pass complete lines to `cursor.accumulator.addLines(...)`;
+6. close the descriptor in `finally` and return `cursor.accumulator.getSignal()`;
+7. catch stat/read failures and return the last cached signal when one exists, otherwise `null`.
+
+Validate constructor chunk size and fall back to `512 * 1024` for invalid input. Do not call `decoder.end()` while the cursor can receive appended bytes.
+
+- [ ] **Step 4: Run focused checks to verify GREEN**
+
+Run:
+
+```bash
+npm run test-compile && node scripts/run-ai-session-safety-checks.js
+```
+
+Expected: `AI session safety checks passed.`
+
+- [ ] **Step 5: Commit the shared reader**
+
+```bash
+git add src/aiSessions/incrementalJsonlLifecycleReader.ts scripts/run-ai-session-safety-checks.js
+git commit -m "feat: read AI lifecycle logs incrementally"
+```
+
+---
+
+### Task 3: Integrate Codex, Kimi, and Claude Services
+
+**Files:**
+- Modify: `src/services/codexSessionService.ts`
+- Modify: `src/services/kimiSessionService.ts`
+- Modify: `src/services/claudeSessionService.ts`
+- Test: `scripts/run-ai-session-safety-checks.js`
+
+**Interfaces:**
+- Consumes: `IncrementalJsonlLifecycleReader` from Task 2.
+- Consumes: the three accumulator factories from Task 1.
+- Preserves: `getLifecycleSignals(requests)` service contract used by execution and attention controllers.
+
+- [ ] **Step 1: Extend provider service tests with logs larger than the old tail window**
+
+In `runProviderLifecycleServiceChecks()`, construct each provider log with a start event, more than `512 * 1024` bytes of ignored JSONL events, and no stop event. Assert a new service instance recovers `executionState === 'running'`.
+
+Add this local helper at the start of `runProviderLifecycleServiceChecks()`:
+
+```javascript
+const writeLargeLifecycleLog = (filePath, firstEvent, fillerEvent) => {
+    const fillerLine = JSON.stringify(fillerEvent);
+    const fillerCount = Math.ceil((600 * 1024) / Buffer.byteLength(fillerLine + '\n'));
+    fs.writeFileSync(filePath, [
+        JSON.stringify(firstEvent),
+        ...Array.from({ length: fillerCount }, () => fillerLine),
+        '',
+    ].join('\n'));
+};
+```
+
+Use the helper in each existing provider fixture with these exact events:
+
+```javascript
+writeLargeLifecycleLog(sessionFile, {
+    timestamp: '2026-07-15T00:00:01.000Z',
+    type: 'event_msg',
+    payload: { type: 'task_started', turn_id: 'long-codex' },
+}, {
+    timestamp: '2026-07-15T00:00:02.000Z',
+    type: 'event_msg',
+    payload: { type: 'token_count' },
+});
+const codexService = new CodexSessionService();
+assert.strictEqual(
+    codexService.getLifecycleSignals([{ sessionId: codexId, runStartedAtMs }])[codexId].executionState,
+    'running'
+);
+fs.appendFileSync(sessionFile, JSON.stringify({
+    timestamp: '2026-07-15T00:00:03.000Z',
+    type: 'event_msg',
+    payload: { type: 'task_complete', turn_id: 'long-codex' },
+}) + '\n');
+assert.strictEqual(
+    codexService.getLifecycleSignals([{ sessionId: codexId, runStartedAtMs }])[codexId].executionState,
+    'stopped'
+);
+
+writeLargeLifecycleLog(path.join(sessionDir, 'wire.jsonl'), {
+    timestamp: runStartedAtMs / 1000 + 1,
+    message: { type: 'TurnBegin', payload: {} },
+}, {
+    timestamp: runStartedAtMs / 1000 + 2,
+    message: { type: 'StatusUpdate', payload: {} },
+});
+const kimiService = new KimiSessionService();
+assert.strictEqual(
+    kimiService.getLifecycleSignals([{ sessionId: kimiId, runStartedAtMs }])[kimiId].executionState,
+    'running'
+);
+fs.appendFileSync(path.join(sessionDir, 'wire.jsonl'), JSON.stringify({
+    timestamp: runStartedAtMs / 1000 + 3,
+    message: { type: 'TurnEnd', payload: {} },
+}) + '\n');
+assert.strictEqual(
+    kimiService.getLifecycleSignals([{ sessionId: kimiId, runStartedAtMs }])[kimiId].executionState,
+    'stopped'
+);
+
+const claudeFile = path.join(sessionDir, `${claudeId}.jsonl`);
+writeLargeLifecycleLog(claudeFile, {
+    timestamp: '2026-07-15T00:00:01.000Z',
+    type: 'user',
+    message: { role: 'user' },
+}, {
+    timestamp: '2026-07-15T00:00:02.000Z',
+    type: 'progress',
+});
+const claudeService = new ClaudeSessionService();
+assert.strictEqual(
+    claudeService.getLifecycleSignals([{ sessionId: claudeId, runStartedAtMs }])[claudeId].executionState,
+    'running'
+);
+fs.appendFileSync(claudeFile, JSON.stringify({
+    timestamp: '2026-07-15T00:00:03.000Z',
+    type: 'assistant',
+    message: { role: 'assistant', stop_reason: 'end_turn', content: [] },
+}) + '\n');
+assert.strictEqual(
+    claudeService.getLifecycleSignals([{ sessionId: claudeId, runStartedAtMs }])[claudeId].executionState,
+    'stopped'
+);
+```
+
+- [ ] **Step 2: Run the provider checks to verify RED**
+
+Run:
+
+```bash
+npm run test-compile && node scripts/run-ai-session-safety-checks.js
+```
+
+Expected: FAIL because each service still reads only the final 512 KiB and cannot see the start event.
+
+- [ ] **Step 3: Replace fixed-tail parsing in all provider services**
+
+For each service:
+
+1. replace `readJsonlTailLines` and batch parser imports with `IncrementalJsonlLifecycleReader` and the matching accumulator factory;
+2. add `private readonly lifecycleReader = new IncrementalJsonlLifecycleReader();`;
+3. call `lifecycleReader.read(...)` with `createCodexLifecycleAccumulator`, `createKimiLifecycleAccumulator`, or `createClaudeLifecycleAccumulator`, matching the service;
+4. collect valid request IDs and call `lifecycleReader.retain(activeSessionIds)` before returning;
+5. call `lifecycleReader.delete(sessionId)` when a cached file disappears or a session is archived.
+
+The Codex call should have this shape:
+
+```typescript
+const signal = this.lifecycleReader.read(
+    request.sessionId,
+    sessionFile,
+    request.runStartedAtMs,
+    () => createCodexLifecycleAccumulator(request.runStartedAtMs)
+);
+```
+
+Apply the equivalent Kimi and Claude factories without changing file discovery behavior.
+
+- [ ] **Step 4: Run all safety checks and lint**
+
+Run:
+
+```bash
+npm run test:safety
+npm run lint
+```
+
+Expected: both safety suites pass and TSLint exits successfully.
+
+- [ ] **Step 5: Commit provider integration**
+
+```bash
+git add src/services/codexSessionService.ts src/services/kimiSessionService.ts src/services/claudeSessionService.ts scripts/run-ai-session-safety-checks.js
+git commit -m "fix: recover long-running AI session state"
+```
+
+---
+
+### Task 4: Final Verification and Branch Review
+
+**Files:**
+- Verify: all files changed by Tasks 1-3
+- Update only if behavior differs: `docs/superpowers/specs/2026-07-19-ai-session-lifecycle-recovery-design.md`
+
+**Interfaces:**
+- Verifies the public behavior and packaging boundaries; produces no new API.
+
+- [ ] **Step 1: Run the full verification matrix**
+
+Run:
+
+```bash
+npm run test:safety
+npm run test:dashboard
+npm run test:architecture-baseline
+npm run test:release-packaging
+npm run lint
+git diff --check origin/main...HEAD
+```
+
+Expected: all commands exit `0`, both safety scripts report passed, and `git diff --check` prints nothing.
+
+- [ ] **Step 2: Review the branch diff for scope and generated artifacts**
+
+Run:
+
+```bash
+git status -sb
+git diff --stat origin/main...HEAD
+git diff origin/main...HEAD -- src/aiSessions src/services scripts/run-ai-session-safety-checks.js docs/superpowers
+```
+
+Confirm the diff contains only lifecycle recovery code, tests, the approved design, and this plan. Confirm `package-lock.json`, compiled `out/`, and packaging output are not tracked changes.
+
+- [ ] **Step 3: Make and verify any review-only correction as its own commit**
+
+If review finds a concrete defect, first add or tighten the failing safety assertion, run it to observe the expected failure, apply the smallest correction, rerun the focused and full checks, then commit explicit paths:
+
+```bash
+git add scripts/run-ai-session-safety-checks.js src/aiSessions/incrementalJsonlLifecycleReader.ts src/aiSessions/lifecycle.ts src/services/codexSessionService.ts src/services/kimiSessionService.ts src/services/claudeSessionService.ts
+git commit -m "fix: address lifecycle recovery review"
+```
+
+If review finds no defect, do not create an empty commit.
+
+- [ ] **Step 4: Report the ready branch**
+
+Report the worktree path, branch name, commits, changed files, and exact verification commands/results. Do not push or open a PR without a separate user request.

--- a/docs/superpowers/specs/2026-07-19-ai-session-lifecycle-recovery-design.md
+++ b/docs/superpowers/specs/2026-07-19-ai-session-lifecycle-recovery-design.md
@@ -1,0 +1,93 @@
+# AI Session Lifecycle Recovery Design
+
+## Problem
+
+Active-session execution state is currently reconstructed by parsing only the final 512 KiB of each provider's JSONL log. A long-running turn can emit enough output to push its `task_started` or equivalent event outside that window. If the Extension Host then reloads, the in-memory execution monitor starts from `stopped`, the bounded tail contains no lifecycle signal, and an active turn is rendered as stopped.
+
+The same fixed-window reader is used by Codex, Kimi, and Claude, so the recovery gap applies to all three providers.
+
+## Goals
+
+- Recover the latest lifecycle signal after Extension Host reload even when the relevant start event is more than 512 KiB behind the end of the log.
+- Apply the fix consistently to Codex, Kimi, and Claude.
+- Keep steady-state work proportional to newly appended log data rather than total file size.
+- Keep memory bounded while reading large JSONL files.
+- Preserve current lifecycle semantics, including event-time ordering and Codex input-request matching.
+
+## Non-goals
+
+- Changing the user-visible execution states or card styling.
+- Persisting execution state independently of provider logs.
+- Reworking provider session discovery, terminal ownership, or attention aggregation.
+- Adding a configurable lifecycle scan size.
+
+## Chosen Approach
+
+Add a shared incremental JSONL lifecycle reader. Each provider service owns a reader cache for its active session logs.
+
+On the first request for a file and terminal run:
+
+1. Open the JSONL file and read it forward in bounded chunks.
+2. Split complete lines without retaining the full file.
+3. Feed parsed events into a provider-specific lifecycle accumulator.
+4. Ignore events earlier than `runStartedAtMs` while retaining the newest signal by event timestamp.
+5. Cache the byte offset, unfinished trailing line, parser state, and latest signal.
+
+On later requests, the reader processes only bytes appended after the cached offset and returns the cached latest signal when no new lifecycle event exists.
+
+The reader resets and performs a cold scan when the terminal run start changes, the file is truncated, or its filesystem identity changes. Malformed JSON lines remain ignored. A temporary read failure returns no new signal without inventing a stopped transition.
+
+## Components
+
+### Incremental JSONL reader
+
+A focused module under `src/aiSessions/` will own file offsets, bounded chunk reads, partial-line handling, file identity checks, and cursor reset behavior. It will not know provider event schemas.
+
+Its public API will accept a cache key, file path, `runStartedAtMs`, and a provider accumulator factory, and return the latest `AiSessionLifecycleSignal` when available. The cache will retain only keys supplied by the current provider request set so inactive sessions do not accumulate indefinitely.
+
+### Stateful lifecycle accumulators
+
+`src/aiSessions/lifecycle.ts` will expose accumulator factories for Codex, Kimi, and Claude. Each accumulator consumes complete JSONL lines or decoded records and tracks the latest signal using `occurredAtMs`, preserving the existing rule that event timestamps win over physical line order.
+
+The Codex accumulator will retain pending `request_user_input` call IDs across chunks and incremental reads. This ensures a later `custom_tool_call_output` restores `running` even when the request and output are separated by a chunk boundary.
+
+Existing `parseCodexLifecycleLines`, `parseKimiLifecycleLines`, and `parseClaudeLifecycleLines` functions will delegate to the same accumulators so existing callers and tests retain their API and semantics.
+
+### Provider integration
+
+Codex, Kimi, and Claude session services will replace direct `readJsonlTailLines(...)` lifecycle parsing with the shared incremental reader. Session discovery and provider-specific file lookup remain unchanged.
+
+Each service will prune reader cursors that are not present in its current lifecycle request list. Archiving or losing a session file will also discard its cursor.
+
+## Error and Reset Semantics
+
+- Invalid JSON lines are skipped and scanning continues.
+- A final incomplete JSON line is buffered until the next append.
+- File truncation or replacement discards the old cursor and parser state before rescanning.
+- A different `runStartedAtMs` for the same session starts a new parser state so prior terminal runs cannot leak execution state.
+- Read/stat failures do not manufacture a `stopped` signal; the caller keeps its last monitor state when possible.
+
+## Testing
+
+Automated safety checks will cover:
+
+- A lifecycle start event followed by more than 512 KiB of unrelated output is recovered after a cold reader start.
+- A completion appended after the cold scan updates the cached state to stopped without rescanning prior bytes.
+- Codex input request and matching output work across chunk boundaries.
+- Kimi and Claude recover long-running lifecycle starts through the shared reader.
+- Partial final lines are completed on a later append.
+- Truncation and a changed `runStartedAtMs` reset cached state.
+- Malformed lines do not prevent later valid lifecycle events from being processed.
+- Existing event-time ordering and provider lifecycle tests continue to pass.
+
+The full AI-session and Open Project safety suites, TypeScript compilation, lint, and relevant packaging checks will be run before completion.
+
+## Alternatives Rejected
+
+### Persist execution state
+
+Persisted state can become stale when provider activity occurs while the Extension Host is unavailable. Provider logs remain the source of truth, so recovery should be fixed at the log-reading boundary.
+
+### Increase the fixed tail size
+
+Any fixed limit can be exceeded by a sufficiently long turn. It delays recurrence without removing the blind spot and increases repeated read cost.

--- a/scripts/run-ai-session-safety-checks.js
+++ b/scripts/run-ai-session-safety-checks.js
@@ -5912,13 +5912,19 @@ function runIncrementalJsonlLifecycleReaderChecks() {
         signal = reader.read('codex:run-reset', runResetPath, runStartedAtMs, createAccumulator);
         assert.strictEqual(signal.executionState, 'stopped');
         const nextRunStartedAtMs = Date.parse('2026-07-15T00:00:12.000Z');
-        signal = reader.read(
-            'codex:run-reset',
-            runResetPath,
-            nextRunStartedAtMs,
-            () => lifecycle.createCodexLifecycleAccumulator(nextRunStartedAtMs)
-        );
-        assert.strictEqual(signal, null, 'a changed run start resets the cursor and filters the old event');
+        const originalOpenSync = fs.openSync;
+        fs.openSync = () => { throw new Error('forced open failure after cursor reset'); };
+        try {
+            signal = reader.read(
+                'codex:run-reset',
+                runResetPath,
+                nextRunStartedAtMs,
+                () => lifecycle.createCodexLifecycleAccumulator(nextRunStartedAtMs)
+            );
+            assert.strictEqual(signal, null, 'an open failure after reset cannot leak the old run signal');
+        } finally {
+            fs.openSync = originalOpenSync;
+        }
 
         const retainedPath = path.join(tempRoot, 'retained.jsonl');
         const retainedStarted = codexEvent('2026-07-15T00:00:13.000Z', 'task_started', 'retain-11');

--- a/scripts/run-ai-session-safety-checks.js
+++ b/scripts/run-ai-session-safety-checks.js
@@ -5573,6 +5573,15 @@ function runProviderChecks() {
 }
 
 function runProviderLifecycleServiceChecks() {
+    const writeLargeLifecycleLog = (filePath, firstEvent, fillerEvent) => {
+        const fillerLine = JSON.stringify(fillerEvent);
+        const fillerCount = Math.ceil((600 * 1024) / Buffer.byteLength(fillerLine + '\n'));
+        fs.writeFileSync(filePath, [
+            JSON.stringify(firstEvent),
+            ...Array.from({ length: fillerCount }, () => fillerLine),
+            '',
+        ].join('\n'));
+    };
     const runStartedAtMs = Date.parse('2026-07-15T00:00:00.000Z');
     const previousCodexHome = process.env.CODEX_HOME;
     const codexRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'project-steward-codex-lifecycle-'));
@@ -5584,27 +5593,36 @@ function runProviderLifecycleServiceChecks() {
         const sessionFile = writeCodexSessionMetaFile(sessionDir, codexId, {
             id: codexId, session_id: codexId, cwd: '/work/app', timestamp: '2026-07-14T23:00:00.000Z', source: 'vscode',
         });
-        fs.appendFileSync(sessionFile, [
-            { timestamp: '2026-07-14T23:59:59.000Z', type: 'event_msg', payload: { type: 'task_complete', turn_id: 'old' } },
-            { timestamp: '2026-07-15T00:00:02.000Z', type: 'event_msg', payload: { type: 'task_complete', turn_id: 'new' } },
-        ].map(JSON.stringify).join('\n') + '\n');
-        const service = new CodexSessionService();
-        let signals = service.getLifecycleSignals([
+        writeLargeLifecycleLog(sessionFile, {
+            timestamp: '2026-07-15T00:00:01.000Z',
+            type: 'event_msg',
+            payload: { type: 'task_started', turn_id: 'long-codex' },
+        }, {
+            timestamp: '2026-07-15T00:00:02.000Z',
+            type: 'event_msg',
+            payload: { type: 'token_count' },
+        });
+        const codexService = new CodexSessionService();
+        let signals = codexService.getLifecycleSignals([
             { sessionId: codexId, runStartedAtMs },
             { sessionId: 'missing', runStartedAtMs },
         ]);
-        assert.strictEqual(signals[codexId].reason, 'completed');
+        assert.strictEqual(signals[codexId].executionState, 'running');
         assert.strictEqual(signals.missing, undefined);
-        fs.appendFileSync(sessionFile, JSON.stringify({ timestamp: '2026-07-15T00:00:03.000Z', type: 'event_msg', payload: { type: 'task_started', turn_id: 'next' } }) + '\n');
+        fs.appendFileSync(sessionFile, JSON.stringify({
+            timestamp: '2026-07-15T00:00:03.000Z',
+            type: 'event_msg',
+            payload: { type: 'task_complete', turn_id: 'long-codex' },
+        }) + '\n');
         const originalReaddirSync = fs.readdirSync;
         fs.readdirSync = () => { throw new Error('cached lifecycle lookup must not rescan provider roots'); };
         try {
-            signals = service.getLifecycleSignals([{ sessionId: codexId, runStartedAtMs }]);
+            signals = codexService.getLifecycleSignals([{ sessionId: codexId, runStartedAtMs }]);
         } finally {
             fs.readdirSync = originalReaddirSync;
         }
-        assert.strictEqual(signals[codexId].phase, 'running');
-        assert.deepStrictEqual(service.getLifecycleSignals([{ sessionId: codexId, runStartedAtMs: Date.parse('2026-07-16T00:00:00Z') }]), {});
+        assert.strictEqual(signals[codexId].executionState, 'stopped');
+        assert.deepStrictEqual(codexService.getLifecycleSignals([{ sessionId: codexId, runStartedAtMs: Date.parse('2026-07-16T00:00:00Z') }]), {});
     } finally {
         previousCodexHome === undefined ? delete process.env.CODEX_HOME : process.env.CODEX_HOME = previousCodexHome;
         fs.rmSync(codexRoot, { recursive: true, force: true });
@@ -5621,11 +5639,26 @@ function runProviderLifecycleServiceChecks() {
         const sessionDir = path.join(kimiRoot, 'sessions', workDirHash, kimiId);
         fs.mkdirSync(sessionDir, { recursive: true });
         fs.writeFileSync(path.join(sessionDir, 'state.json'), '{}');
-        fs.writeFileSync(path.join(sessionDir, 'wire.jsonl'), JSON.stringify({
-            timestamp: runStartedAtMs / 1000 + 2, message: { type: 'TurnEnd', payload: {} },
+        writeLargeLifecycleLog(path.join(sessionDir, 'wire.jsonl'), {
+            timestamp: runStartedAtMs / 1000 + 1,
+            message: { type: 'TurnBegin', payload: {} },
+        }, {
+            timestamp: runStartedAtMs / 1000 + 2,
+            message: { type: 'StatusUpdate', payload: {} },
+        });
+        const kimiService = new KimiSessionService();
+        assert.strictEqual(
+            kimiService.getLifecycleSignals([{ sessionId: kimiId, runStartedAtMs }])[kimiId].executionState,
+            'running'
+        );
+        fs.appendFileSync(path.join(sessionDir, 'wire.jsonl'), JSON.stringify({
+            timestamp: runStartedAtMs / 1000 + 3,
+            message: { type: 'TurnEnd', payload: {} },
         }) + '\n');
-        const signals = new KimiSessionService().getLifecycleSignals([{ sessionId: kimiId, runStartedAtMs }]);
-        assert.strictEqual(signals[kimiId].reason, 'completed');
+        assert.strictEqual(
+            kimiService.getLifecycleSignals([{ sessionId: kimiId, runStartedAtMs }])[kimiId].executionState,
+            'stopped'
+        );
     } finally {
         previousKimiHome === undefined ? delete process.env.KIMI_SHARE_DIR : process.env.KIMI_SHARE_DIR = previousKimiHome;
         fs.rmSync(kimiRoot, { recursive: true, force: true });
@@ -5638,12 +5671,29 @@ function runProviderLifecycleServiceChecks() {
         process.env.CLAUDE_HOME = claudeRoot;
         const sessionDir = path.join(claudeRoot, 'projects', '-work-app');
         fs.mkdirSync(sessionDir, { recursive: true });
-        fs.writeFileSync(path.join(sessionDir, `${claudeId}.jsonl`), JSON.stringify({
-            timestamp: '2026-07-15T00:00:02.000Z', type: 'assistant',
+        const claudeFile = path.join(sessionDir, `${claudeId}.jsonl`);
+        writeLargeLifecycleLog(claudeFile, {
+            timestamp: '2026-07-15T00:00:01.000Z',
+            type: 'user',
+            message: { role: 'user' },
+        }, {
+            timestamp: '2026-07-15T00:00:02.000Z',
+            type: 'progress',
+        });
+        const claudeService = new ClaudeSessionService();
+        assert.strictEqual(
+            claudeService.getLifecycleSignals([{ sessionId: claudeId, runStartedAtMs }])[claudeId].executionState,
+            'running'
+        );
+        fs.appendFileSync(claudeFile, JSON.stringify({
+            timestamp: '2026-07-15T00:00:03.000Z',
+            type: 'assistant',
             message: { role: 'assistant', stop_reason: 'end_turn', content: [] },
         }) + '\n');
-        const signals = new ClaudeSessionService().getLifecycleSignals([{ sessionId: claudeId, runStartedAtMs }]);
-        assert.strictEqual(signals[claudeId].reason, 'completed');
+        assert.strictEqual(
+            claudeService.getLifecycleSignals([{ sessionId: claudeId, runStartedAtMs }])[claudeId].executionState,
+            'stopped'
+        );
     } finally {
         previousClaudeHome === undefined ? delete process.env.CLAUDE_HOME : process.env.CLAUDE_HOME = previousClaudeHome;
         fs.rmSync(claudeRoot, { recursive: true, force: true });

--- a/scripts/run-ai-session-safety-checks.js
+++ b/scripts/run-ai-session-safety-checks.js
@@ -5715,6 +5715,24 @@ function runLifecycleParserChecks() {
         JSON.stringify({ timestamp: '2026-07-15T00:00:06.000Z', type: 'response_item', payload: { type: 'custom_tool_call_output', call_id: 'call-1' } }),
     ], runStartedAtMs).phase, 'running', 'matching Codex output resumes the turn');
 
+    const codexAccumulator = lifecycle.createCodexLifecycleAccumulator(runStartedAtMs);
+    codexAccumulator.addLines([
+        JSON.stringify({
+            timestamp: '2026-07-15T00:00:10.000Z',
+            type: 'response_item',
+            payload: { type: 'custom_tool_call', name: 'request_user_input', call_id: 'cross-batch' },
+        }),
+    ]);
+    assert.strictEqual(codexAccumulator.getSignal().reason, 'input-required');
+    codexAccumulator.addLines([
+        JSON.stringify({
+            timestamp: '2026-07-15T00:00:11.000Z',
+            type: 'response_item',
+            payload: { type: 'custom_tool_call_output', call_id: 'cross-batch' },
+        }),
+    ]);
+    assert.strictEqual(codexAccumulator.getSignal().executionState, 'running');
+
     const kimiSignal = lifecycle.parseKimiLifecycleLines([
         JSON.stringify({ timestamp: 1784073601, message: { type: 'TurnBegin', payload: {} } }),
         JSON.stringify({ timestamp: 1784073602, message: { type: 'QuestionRequest', payload: { id: 'question-1' } } }),
@@ -5740,6 +5758,15 @@ function runLifecycleParserChecks() {
         JSON.stringify({ timestamp: 1784073607, message: { type: 'StatusUpdate', payload: { message_id: 'status-2' } } }),
     ], runStartedAtMs).reason, 'input-required', 'Kimi status updates do not answer a pending question');
 
+    const kimiAccumulator = lifecycle.createKimiLifecycleAccumulator(runStartedAtMs);
+    kimiAccumulator.addLines([
+        JSON.stringify({ timestamp: 1784073612, message: { type: 'TurnEnd', payload: {} } }),
+    ]);
+    kimiAccumulator.addLines([
+        JSON.stringify({ timestamp: 1784073611, message: { type: 'TurnBegin', payload: {} } }),
+    ]);
+    assert.strictEqual(kimiAccumulator.getSignal().executionState, 'stopped');
+
     const claudeSignal = lifecycle.parseClaudeLifecycleLines([
         JSON.stringify({ timestamp: '2026-07-15T00:00:01.000Z', type: 'user', message: { role: 'user' } }),
         JSON.stringify({ timestamp: '2026-07-15T00:00:02.000Z', type: 'assistant', message: { role: 'assistant', stop_reason: 'end_turn', content: [] } }),
@@ -5759,6 +5786,12 @@ function runLifecycleParserChecks() {
         JSON.stringify({ timestamp: '2026-07-15T00:00:05.000Z', type: 'system', subtype: 'api_error' }),
     ], runStartedAtMs).reason, 'failed');
     assert.strictEqual(lifecycle.parseClaudeLifecycleLines(['{}', 'not-json'], runStartedAtMs), null);
+
+    const claudeAccumulator = lifecycle.createClaudeLifecycleAccumulator(runStartedAtMs);
+    claudeAccumulator.addLines([
+        JSON.stringify({ timestamp: '2026-07-15T00:00:12.000Z', type: 'user', message: { role: 'user' } }),
+    ]);
+    assert.strictEqual(claudeAccumulator.getSignal().executionState, 'running');
 
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'project-steward-jsonl-tail-'));
     try {

--- a/scripts/run-ai-session-safety-checks.js
+++ b/scripts/run-ai-session-safety-checks.js
@@ -5733,6 +5733,14 @@ function runLifecycleParserChecks() {
     ]);
     assert.strictEqual(codexAccumulator.getSignal().executionState, 'running');
 
+    const staleCodexAccumulator = lifecycle.createCodexLifecycleAccumulator(runStartedAtMs);
+    staleCodexAccumulator.addLines([
+        JSON.stringify({ timestamp: '2026-07-15T00:00:20.000Z', type: 'event_msg', payload: { type: 'task_complete', turn_id: 'completed' } }),
+        JSON.stringify({ timestamp: '2026-07-15T00:00:19.000Z', type: 'response_item', payload: { type: 'custom_tool_call', name: 'request_user_input', call_id: 'stale-input' } }),
+        JSON.stringify({ timestamp: '2026-07-15T00:00:21.000Z', type: 'response_item', payload: { type: 'custom_tool_call_output', call_id: 'stale-input' } }),
+    ]);
+    assert.strictEqual(staleCodexAccumulator.getSignal().executionState, 'stopped', 'stale events cannot mutate provider state');
+
     const kimiSignal = lifecycle.parseKimiLifecycleLines([
         JSON.stringify({ timestamp: 1784073601, message: { type: 'TurnBegin', payload: {} } }),
         JSON.stringify({ timestamp: 1784073602, message: { type: 'QuestionRequest', payload: { id: 'question-1' } } }),

--- a/scripts/run-ai-session-safety-checks.js
+++ b/scripts/run-ai-session-safety-checks.js
@@ -5976,6 +5976,45 @@ function runIncrementalJsonlLifecycleReaderChecks() {
             fs.openSync = originalOpenSync;
         }
 
+        const statFailurePath = path.join(tempRoot, 'stat-failure.jsonl');
+        fs.writeFileSync(statFailurePath, `${codexEvent('2026-07-15T00:00:11.000Z', 'task_complete', 'cached-old-run')}\n`);
+        signal = reader.read('codex:stat-failure', statFailurePath, runStartedAtMs, createAccumulator);
+        assert.strictEqual(signal.executionState, 'stopped');
+        const originalStatSync = fs.statSync;
+        fs.statSync = () => { throw new Error('forced stat failure'); };
+        try {
+            signal = reader.read(
+                'codex:stat-failure',
+                statFailurePath,
+                nextRunStartedAtMs,
+                () => lifecycle.createCodexLifecycleAccumulator(nextRunStartedAtMs)
+            );
+            assert.strictEqual(signal, null, 'a stat failure cannot leak a cached signal from another run');
+
+            signal = reader.read('codex:stat-failure', statFailurePath, runStartedAtMs, createAccumulator);
+            assert.strictEqual(
+                signal.executionState,
+                'stopped',
+                'a stat failure preserves the cached signal for the matching path and run'
+            );
+        } finally {
+            fs.statSync = originalStatSync;
+        }
+
+        const nonFileSourcePath = path.join(tempRoot, 'non-file-source.jsonl');
+        const nonFilePath = path.join(tempRoot, 'non-file-target');
+        fs.writeFileSync(nonFileSourcePath, `${codexEvent('2026-07-15T00:00:11.000Z', 'task_complete', 'cached-before-non-file')}\n`);
+        fs.mkdirSync(nonFilePath);
+        signal = reader.read('codex:non-file', nonFileSourcePath, runStartedAtMs, createAccumulator);
+        assert.strictEqual(signal.executionState, 'stopped');
+        signal = reader.read(
+            'codex:non-file',
+            nonFilePath,
+            nextRunStartedAtMs,
+            () => lifecycle.createCodexLifecycleAccumulator(nextRunStartedAtMs)
+        );
+        assert.strictEqual(signal, null, 'a non-file path cannot leak a cached signal from another path and run');
+
         const retainedPath = path.join(tempRoot, 'retained.jsonl');
         const retainedStarted = codexEvent('2026-07-15T00:00:13.000Z', 'task_started', 'retain-11');
         const retainedComplete = codexEvent('2026-07-15T00:00:13.000Z', 'task_complete', 'retain-1');

--- a/scripts/run-ai-session-safety-checks.js
+++ b/scripts/run-ai-session-safety-checks.js
@@ -13,6 +13,7 @@ const archiveBatch = require('../out/aiSessions/archiveBatch');
 const activeTerminalHighlight = require('../out/aiSessions/activeTerminalHighlight');
 const activeSessionProjection = require('../out/aiSessions/activeSessionProjection');
 const lifecycle = require('../out/aiSessions/lifecycle');
+const IncrementalJsonlLifecycleReader = require('../out/aiSessions/incrementalJsonlLifecycleReader').default;
 const jsonlTail = require('../out/aiSessions/jsonlTail');
 const terminalBindingStore = require('../out/aiSessions/terminalBindingStore');
 const AiSessionTerminalBindingStore = terminalBindingStore.default;
@@ -5812,6 +5813,141 @@ function runLifecycleParserChecks() {
     }
 }
 
+function runIncrementalJsonlLifecycleReaderChecks() {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'project-steward-incremental-jsonl-lifecycle-'));
+    const runStartedAtMs = Date.parse('2026-07-15T00:00:00.000Z');
+    const createAccumulator = () => lifecycle.createCodexLifecycleAccumulator(runStartedAtMs);
+    const codexEvent = (timestamp, type, turnId) => JSON.stringify({
+        timestamp,
+        type: 'event_msg',
+        payload: { type, turn_id: turnId },
+    });
+
+    try {
+        const reader = new IncrementalJsonlLifecycleReader(64);
+        const filePath = path.join(tempRoot, 'codex.jsonl');
+        const started = JSON.stringify({
+            timestamp: '2026-07-15T00:00:01.000Z',
+            type: 'event_msg',
+            payload: { type: 'task_started', turn_id: 'long-turn' },
+        });
+        fs.writeFileSync(filePath, `${started}\n${Array.from({ length: 100 }, (_, index) =>
+            JSON.stringify({ timestamp: `2026-07-15T00:00:02.${String(index).padStart(3, '0')}Z`, type: 'event_msg', payload: { type: 'token_count' } })
+        ).join('\n')}\n`);
+
+        let readCalls = 0;
+        const originalReadSync = fs.readSync;
+        fs.readSync = function (...args) {
+            readCalls++;
+            return originalReadSync.apply(this, args);
+        };
+        let signal;
+        try {
+            signal = reader.read(
+                'codex:long',
+                filePath,
+                runStartedAtMs,
+                createAccumulator
+            );
+            assert.strictEqual(signal.executionState, 'running', 'cold scan recovers starts beyond one chunk');
+
+            fs.appendFileSync(filePath, JSON.stringify({
+                timestamp: '2026-07-15T00:00:03.000Z',
+                type: 'event_msg',
+                payload: { type: 'task_complete', turn_id: 'long-turn' },
+            }) + '\n');
+            signal = reader.read('codex:long', filePath, runStartedAtMs, createAccumulator);
+            assert.strictEqual(signal.executionState, 'stopped', 'appended completion updates cached state');
+
+            const readsAfterAppend = readCalls;
+            signal = reader.read('codex:long', filePath, runStartedAtMs, createAccumulator);
+            assert.strictEqual(signal.executionState, 'stopped');
+            assert.strictEqual(readCalls, readsAfterAppend, 'unchanged file size performs no additional reads');
+        } finally {
+            fs.readSync = originalReadSync;
+        }
+
+        const inputPath = path.join(tempRoot, 'input.jsonl');
+        fs.writeFileSync(inputPath, JSON.stringify({
+            timestamp: '2026-07-15T00:00:04.000Z',
+            type: 'response_item',
+            payload: { type: 'custom_tool_call', name: 'request_user_input', call_id: 'later-answer' },
+        }) + '\n');
+        signal = reader.read('codex:input', inputPath, runStartedAtMs, createAccumulator);
+        assert.strictEqual(signal.reason, 'input-required');
+        fs.appendFileSync(inputPath, JSON.stringify({
+            timestamp: '2026-07-15T00:00:05.000Z',
+            type: 'response_item',
+            payload: { type: 'custom_tool_call_output', call_id: 'later-answer' },
+        }) + '\n');
+        signal = reader.read('codex:input', inputPath, runStartedAtMs, createAccumulator);
+        assert.strictEqual(signal.executionState, 'running', 'matching output in a later append resumes input request');
+
+        const splitPath = path.join(tempRoot, 'split.jsonl');
+        const splitLine = codexEvent('2026-07-15T00:00:06.000Z', 'task_started', 'split-line');
+        const splitAt = Math.floor(splitLine.length / 2);
+        fs.writeFileSync(splitPath, splitLine.slice(0, splitAt));
+        assert.strictEqual(reader.read('codex:split', splitPath, runStartedAtMs, createAccumulator), null);
+        fs.appendFileSync(splitPath, splitLine.slice(splitAt) + '\n');
+        signal = reader.read('codex:split', splitPath, runStartedAtMs, createAccumulator);
+        assert.strictEqual(signal.executionState, 'running', 'a line split across reads is parsed after its newline arrives');
+
+        const malformedPath = path.join(tempRoot, 'malformed.jsonl');
+        fs.writeFileSync(malformedPath, `{bad json\n${codexEvent('2026-07-15T00:00:07.000Z', 'task_started', 'after-bad')}\n`);
+        signal = reader.read('codex:malformed', malformedPath, runStartedAtMs, createAccumulator);
+        assert.strictEqual(signal.executionState, 'running', 'malformed JSON does not prevent a later valid event');
+
+        const truncatedPath = path.join(tempRoot, 'truncated.jsonl');
+        fs.writeFileSync(truncatedPath,
+            `${codexEvent('2026-07-15T00:00:08.000Z', 'task_started', 'truncate')}\n`
+            + `${codexEvent('2026-07-15T00:00:09.000Z', 'task_complete', 'truncate')}\n`);
+        signal = reader.read('codex:truncated', truncatedPath, runStartedAtMs, createAccumulator);
+        assert.strictEqual(signal.executionState, 'stopped');
+        fs.writeFileSync(truncatedPath, `${codexEvent('2026-07-15T00:00:10.000Z', 'task_started', 'new')}\n`);
+        signal = reader.read('codex:truncated', truncatedPath, runStartedAtMs, createAccumulator);
+        assert.strictEqual(signal.executionState, 'running', 'truncation resets the old completion state');
+
+        const runResetPath = path.join(tempRoot, 'run-reset.jsonl');
+        fs.writeFileSync(runResetPath, `${codexEvent('2026-07-15T00:00:11.000Z', 'task_complete', 'old-run')}\n`);
+        signal = reader.read('codex:run-reset', runResetPath, runStartedAtMs, createAccumulator);
+        assert.strictEqual(signal.executionState, 'stopped');
+        const nextRunStartedAtMs = Date.parse('2026-07-15T00:00:12.000Z');
+        signal = reader.read(
+            'codex:run-reset',
+            runResetPath,
+            nextRunStartedAtMs,
+            () => lifecycle.createCodexLifecycleAccumulator(nextRunStartedAtMs)
+        );
+        assert.strictEqual(signal, null, 'a changed run start resets the cursor and filters the old event');
+
+        const retainedPath = path.join(tempRoot, 'retained.jsonl');
+        const retainedStarted = codexEvent('2026-07-15T00:00:13.000Z', 'task_started', 'retain-11');
+        const retainedComplete = codexEvent('2026-07-15T00:00:13.000Z', 'task_complete', 'retain-1');
+        assert.strictEqual(retainedStarted.length, retainedComplete.length);
+        fs.writeFileSync(retainedPath, `${retainedStarted}\n`);
+        signal = reader.read('codex:retain-drop', retainedPath, runStartedAtMs, createAccumulator);
+        assert.strictEqual(signal.executionState, 'running');
+        fs.writeFileSync(retainedPath, `${retainedComplete}\n`);
+        reader.retain(new Set(['codex:long']));
+        signal = reader.read('codex:retain-drop', retainedPath, runStartedAtMs, createAccumulator);
+        assert.strictEqual(signal.executionState, 'stopped', 'retain removes unowned cursors before a same-size rewrite');
+
+        const deletedPath = path.join(tempRoot, 'deleted.jsonl');
+        const deletedStarted = codexEvent('2026-07-15T00:00:14.000Z', 'task_started', 'delete-11');
+        const deletedComplete = codexEvent('2026-07-15T00:00:14.000Z', 'task_complete', 'delete-1');
+        assert.strictEqual(deletedStarted.length, deletedComplete.length);
+        fs.writeFileSync(deletedPath, `${deletedStarted}\n`);
+        signal = reader.read('codex:delete', deletedPath, runStartedAtMs, createAccumulator);
+        assert.strictEqual(signal.executionState, 'running');
+        fs.writeFileSync(deletedPath, `${deletedComplete}\n`);
+        reader.delete('codex:delete');
+        signal = reader.read('codex:delete', deletedPath, runStartedAtMs, createAccumulator);
+        assert.strictEqual(signal.executionState, 'stopped', 'delete removes a cursor before a same-size rewrite');
+    } finally {
+        fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+}
+
 function runAttentionMonitorChecks() {
     let now = 0;
     const signal = (token, phase, reason, occurredAtMs = now) => ({ token, phase, reason, occurredAtMs });
@@ -6754,6 +6890,7 @@ async function main() {
     runProviderLifecycleServiceChecks();
     runCommandBuilderChecks();
     runLifecycleParserChecks();
+    runIncrementalJsonlLifecycleReaderChecks();
     runAttentionMonitorChecks();
     runAiSessionExecutionMonitorChecks();
     runAttentionPayloadChecks();

--- a/src/aiSessions/incrementalJsonlLifecycleReader.ts
+++ b/src/aiSessions/incrementalJsonlLifecycleReader.ts
@@ -1,0 +1,117 @@
+'use strict';
+
+import * as fs from 'fs';
+import { StringDecoder } from 'string_decoder';
+import { AiSessionLifecycleAccumulator, AiSessionLifecycleSignal } from './lifecycle';
+
+const DEFAULT_CHUNK_BYTES = 512 * 1024;
+
+interface Cursor {
+    filePath: string;
+    runStartedAtMs: number;
+    dev: number;
+    ino: number;
+    birthtimeMs: number;
+    offset: number;
+    decoder: StringDecoder;
+    partialLine: string;
+    accumulator: AiSessionLifecycleAccumulator;
+}
+
+export default class IncrementalJsonlLifecycleReader {
+    private readonly chunkBytes: number;
+    private readonly cursors = new Map<string, Cursor>();
+
+    constructor(chunkBytes = DEFAULT_CHUNK_BYTES) {
+        this.chunkBytes = Number.isFinite(chunkBytes) && chunkBytes >= 1
+            ? Math.floor(chunkBytes)
+            : DEFAULT_CHUNK_BYTES;
+    }
+
+    read(
+        key: string,
+        filePath: string,
+        runStartedAtMs: number,
+        createAccumulator: () => AiSessionLifecycleAccumulator
+    ): AiSessionLifecycleSignal | null {
+        let previousCursor = this.cursors.get(key);
+        let previousSignal = previousCursor ? previousCursor.accumulator.getSignal() : null;
+        let fd: number = null;
+
+        try {
+            let stat = fs.statSync(filePath);
+            if (!stat.isFile()) {
+                return previousSignal;
+            }
+
+            let cursor = previousCursor;
+            if (!cursor
+                || cursor.filePath !== filePath
+                || cursor.runStartedAtMs !== runStartedAtMs
+                || cursor.dev !== stat.dev
+                || cursor.ino !== stat.ino
+                || cursor.birthtimeMs !== stat.birthtimeMs
+                || stat.size < cursor.offset) {
+                cursor = {
+                    filePath,
+                    runStartedAtMs,
+                    dev: stat.dev,
+                    ino: stat.ino,
+                    birthtimeMs: stat.birthtimeMs,
+                    offset: 0,
+                    decoder: new StringDecoder('utf8'),
+                    partialLine: '',
+                    accumulator: createAccumulator(),
+                };
+                this.cursors.set(key, cursor);
+            }
+
+            if (cursor.offset >= stat.size) {
+                return cursor.accumulator.getSignal();
+            }
+
+            fd = fs.openSync(filePath, 'r');
+            while (cursor.offset < stat.size) {
+                let remaining = stat.size - cursor.offset;
+                let buffer = Buffer.alloc(Math.min(this.chunkBytes, remaining));
+                let bytesRead = fs.readSync(fd, buffer, 0, buffer.length, cursor.offset);
+                if (bytesRead <= 0) {
+                    break;
+                }
+
+                cursor.offset += bytesRead;
+                let decoded = cursor.partialLine + cursor.decoder.write(buffer.slice(0, bytesRead));
+                let lines = decoded.split('\n');
+                cursor.partialLine = lines.pop() || '';
+                if (lines.length) {
+                    cursor.accumulator.addLines(lines);
+                }
+            }
+
+            return cursor.accumulator.getSignal();
+        } catch (e) {
+            let currentCursor = this.cursors.get(key);
+            return (currentCursor && currentCursor.accumulator.getSignal()) || previousSignal || null;
+        } finally {
+            if (fd !== null) {
+                try {
+                    fs.closeSync(fd);
+                } catch (e) {
+                    // Best effort only.
+                }
+            }
+        }
+    }
+
+    retain(keys: ReadonlySet<string>): void {
+        for (let key of this.cursors.keys()) {
+            if (!keys.has(key)) {
+                this.cursors.delete(key);
+            }
+        }
+    }
+
+    delete(key: string): void {
+        this.cursors.delete(key);
+    }
+}

--- a/src/aiSessions/incrementalJsonlLifecycleReader.ts
+++ b/src/aiSessions/incrementalJsonlLifecycleReader.ts
@@ -35,8 +35,11 @@ export default class IncrementalJsonlLifecycleReader {
         createAccumulator: () => AiSessionLifecycleAccumulator
     ): AiSessionLifecycleSignal | null {
         let previousCursor = this.cursors.get(key);
-        let previousSignal = previousCursor ? previousCursor.accumulator.getSignal() : null;
-        let errorCursor = previousCursor;
+        let previousCursorMatchesRequest = previousCursor
+            && previousCursor.filePath === filePath
+            && previousCursor.runStartedAtMs === runStartedAtMs;
+        let previousSignal = previousCursorMatchesRequest ? previousCursor.accumulator.getSignal() : null;
+        let errorCursor = previousCursorMatchesRequest ? previousCursor : null;
         let fd: number = null;
 
         try {

--- a/src/aiSessions/incrementalJsonlLifecycleReader.ts
+++ b/src/aiSessions/incrementalJsonlLifecycleReader.ts
@@ -36,6 +36,7 @@ export default class IncrementalJsonlLifecycleReader {
     ): AiSessionLifecycleSignal | null {
         let previousCursor = this.cursors.get(key);
         let previousSignal = previousCursor ? previousCursor.accumulator.getSignal() : null;
+        let errorCursor = previousCursor;
         let fd: number = null;
 
         try {
@@ -52,6 +53,7 @@ export default class IncrementalJsonlLifecycleReader {
                 || cursor.ino !== stat.ino
                 || cursor.birthtimeMs !== stat.birthtimeMs
                 || stat.size < cursor.offset) {
+                errorCursor = null;
                 cursor = {
                     filePath,
                     runStartedAtMs,
@@ -64,6 +66,7 @@ export default class IncrementalJsonlLifecycleReader {
                     accumulator: createAccumulator(),
                 };
                 this.cursors.set(key, cursor);
+                errorCursor = cursor;
             }
 
             if (cursor.offset >= stat.size) {
@@ -90,8 +93,7 @@ export default class IncrementalJsonlLifecycleReader {
 
             return cursor.accumulator.getSignal();
         } catch (e) {
-            let currentCursor = this.cursors.get(key);
-            return (currentCursor && currentCursor.accumulator.getSignal()) || previousSignal || null;
+            return errorCursor ? errorCursor.accumulator.getSignal() : null;
         } finally {
             if (fd !== null) {
                 try {

--- a/src/aiSessions/lifecycle.ts
+++ b/src/aiSessions/lifecycle.ts
@@ -40,7 +40,8 @@ function createAccumulator(
                 }
 
                 let occurredAtMs = getOccurredAtMs(event?.timestamp);
-                if (!Number.isFinite(occurredAtMs) || occurredAtMs < runStartedAtMs) {
+                if (!Number.isFinite(occurredAtMs) || occurredAtMs < runStartedAtMs
+                    || (latest && occurredAtMs < latest.occurredAtMs)) {
                     continue;
                 }
 

--- a/src/aiSessions/lifecycle.ts
+++ b/src/aiSessions/lifecycle.ts
@@ -17,34 +17,41 @@ export interface AiSessionLifecycleSignal {
     occurredAtMs: number;
 }
 
+export interface AiSessionLifecycleAccumulator {
+    addLines(lines: readonly string[]): void;
+    getSignal(): AiSessionLifecycleSignal | null;
+}
+
 type JsonRecord = Record<string, any>;
 
-function parseLines(
-    lines: readonly string[],
+function createAccumulator(
     runStartedAtMs: number,
     parseEvent: (event: JsonRecord, occurredAtMs: number) => AiSessionLifecycleSignal | null
-): AiSessionLifecycleSignal | null {
+): AiSessionLifecycleAccumulator {
     let latest: AiSessionLifecycleSignal | null = null;
-    for (let line of lines || []) {
-        let event: JsonRecord;
-        try {
-            event = JSON.parse(line);
-        } catch (e) {
-            continue;
-        }
+    return {
+        addLines(lines) {
+            for (let line of lines || []) {
+                let event: JsonRecord;
+                try {
+                    event = JSON.parse(line);
+                } catch (e) {
+                    continue;
+                }
 
-        let occurredAtMs = getOccurredAtMs(event?.timestamp);
-        if (!Number.isFinite(occurredAtMs) || occurredAtMs < runStartedAtMs) {
-            continue;
-        }
+                let occurredAtMs = getOccurredAtMs(event?.timestamp);
+                if (!Number.isFinite(occurredAtMs) || occurredAtMs < runStartedAtMs) {
+                    continue;
+                }
 
-        let signal = parseEvent(event, occurredAtMs);
-        if (signal && (!latest || signal.occurredAtMs >= latest.occurredAtMs)) {
-            latest = signal;
-        }
-    }
-
-    return latest;
+                let signal = parseEvent(event, occurredAtMs);
+                if (signal && (!latest || signal.occurredAtMs >= latest.occurredAtMs)) {
+                    latest = signal;
+                }
+            }
+        },
+        getSignal: () => latest,
+    };
 }
 
 function getOccurredAtMs(value: unknown): number {
@@ -76,9 +83,9 @@ function attention(
     return { token: getToken(provider, eventType, occurredAtMs, id), phase: 'needsAttention', reason, executionState: 'stopped', occurredAtMs };
 }
 
-export function parseCodexLifecycleLines(lines: readonly string[], runStartedAtMs: number): AiSessionLifecycleSignal | null {
+export function createCodexLifecycleAccumulator(runStartedAtMs: number): AiSessionLifecycleAccumulator {
     let pendingInputCallIds = new Set<string>();
-    return parseLines(lines, runStartedAtMs, (event, occurredAtMs) => {
+    return createAccumulator(runStartedAtMs, (event, occurredAtMs) => {
         let payload = event?.payload || {};
         if (event?.type === 'event_msg') {
             switch (payload.type) {
@@ -110,13 +117,19 @@ export function parseCodexLifecycleLines(lines: readonly string[], runStartedAtM
     });
 }
 
+export function parseCodexLifecycleLines(lines: readonly string[], runStartedAtMs: number): AiSessionLifecycleSignal | null {
+    let accumulator = createCodexLifecycleAccumulator(runStartedAtMs);
+    accumulator.addLines(lines);
+    return accumulator.getSignal();
+}
+
 const KIMI_RUNNING_EVENTS = new Set([
     'TurnBegin', 'StepBegin', 'ContentPart', 'ToolCall', 'ToolResult',
     'StepRetry', 'ApprovalResponse',
 ]);
 
-export function parseKimiLifecycleLines(lines: readonly string[], runStartedAtMs: number): AiSessionLifecycleSignal | null {
-    return parseLines(lines, runStartedAtMs, (event, occurredAtMs) => {
+export function createKimiLifecycleAccumulator(runStartedAtMs: number): AiSessionLifecycleAccumulator {
+    return createAccumulator(runStartedAtMs, (event, occurredAtMs) => {
         let message = event?.message || {};
         let payload = message.payload || {};
         if (KIMI_RUNNING_EVENTS.has(message.type)) {
@@ -135,8 +148,14 @@ export function parseKimiLifecycleLines(lines: readonly string[], runStartedAtMs
     });
 }
 
-export function parseClaudeLifecycleLines(lines: readonly string[], runStartedAtMs: number): AiSessionLifecycleSignal | null {
-    return parseLines(lines, runStartedAtMs, (event, occurredAtMs) => {
+export function parseKimiLifecycleLines(lines: readonly string[], runStartedAtMs: number): AiSessionLifecycleSignal | null {
+    let accumulator = createKimiLifecycleAccumulator(runStartedAtMs);
+    accumulator.addLines(lines);
+    return accumulator.getSignal();
+}
+
+export function createClaudeLifecycleAccumulator(runStartedAtMs: number): AiSessionLifecycleAccumulator {
+    return createAccumulator(runStartedAtMs, (event, occurredAtMs) => {
         if (event?.type === 'system' && event?.subtype === 'api_error') {
             return attention('claude', 'api_error', occurredAtMs, 'failed');
         }
@@ -159,4 +178,10 @@ export function parseClaudeLifecycleLines(lines: readonly string[], runStartedAt
         }
         return running('claude', message.stop_reason || 'assistant', occurredAtMs, event.uuid);
     });
+}
+
+export function parseClaudeLifecycleLines(lines: readonly string[], runStartedAtMs: number): AiSessionLifecycleSignal | null {
+    let accumulator = createClaudeLifecycleAccumulator(runStartedAtMs);
+    accumulator.addLines(lines);
+    return accumulator.getSignal();
 }

--- a/src/services/claudeSessionService.ts
+++ b/src/services/claudeSessionService.ts
@@ -6,9 +6,9 @@ import * as path from 'path';
 
 import { CodexSession } from '../models';
 import { filterAiSessionsByCandidatePaths, normalizeAiSessionCandidatePaths } from '../aiSessions/sessionHelpers';
+import IncrementalJsonlLifecycleReader from '../aiSessions/incrementalJsonlLifecycleReader';
 import type { AiSessionQueryOptions } from '../aiSessions/types';
-import { parseClaudeLifecycleLines, AiSessionLifecycleRequest, AiSessionLifecycleSignal } from '../aiSessions/lifecycle';
-import { readJsonlTailLines } from '../aiSessions/jsonlTail';
+import { createClaudeLifecycleAccumulator, AiSessionLifecycleRequest, AiSessionLifecycleSignal } from '../aiSessions/lifecycle';
 import { Disposable } from './codexSessionService';
 
 interface ClaudeSessionEvent {
@@ -37,6 +37,7 @@ export default class ClaudeSessionService {
     private cachedAt = 0;
     private sessionCache = new Map<string, { signature: string; session: CodexSession }>();
     private readonly sessionFilesById = new Map<string, string>();
+    private readonly lifecycleReader = new IncrementalJsonlLifecycleReader();
     private readonly cacheTtlMs = 5000;
     private readonly changePollIntervalMs = 3000;
     private readonly cwdScanChunkBytes = 64 * 1024;
@@ -80,20 +81,27 @@ export default class ClaudeSessionService {
     }
 
     getLifecycleSignals(requests: readonly AiSessionLifecycleRequest[]): Record<string, AiSessionLifecycleSignal> {
+        let activeSessionIds = new Set<string>();
         let claudeHome = this.getClaudeHome();
         if (!claudeHome) {
+            this.lifecycleReader.retain(activeSessionIds);
             return {};
         }
         let projectRoot = path.join(claudeHome, 'projects');
         let signals: Record<string, AiSessionLifecycleSignal> = {};
         let discovered = false;
         for (let request of requests || []) {
-            if (!request?.sessionId || !Number.isFinite(request.runStartedAtMs) || signals[request.sessionId]) {
+            if (!request?.sessionId || !Number.isFinite(request.runStartedAtMs)) {
+                continue;
+            }
+            activeSessionIds.add(request.sessionId);
+            if (signals[request.sessionId]) {
                 continue;
             }
             let sessionFile = this.sessionFilesById.get(request.sessionId);
             if (sessionFile && !fs.existsSync(sessionFile)) {
                 this.sessionFilesById.delete(request.sessionId);
+                this.lifecycleReader.delete(request.sessionId);
                 sessionFile = null;
             }
             if (!sessionFile && !discovered) {
@@ -102,13 +110,20 @@ export default class ClaudeSessionService {
                 sessionFile = this.sessionFilesById.get(request.sessionId);
             }
             if (!sessionFile) {
+                this.lifecycleReader.delete(request.sessionId);
                 continue;
             }
-            let signal = parseClaudeLifecycleLines(readJsonlTailLines(sessionFile), request.runStartedAtMs);
+            let signal = this.lifecycleReader.read(
+                request.sessionId,
+                sessionFile,
+                request.runStartedAtMs,
+                () => createClaudeLifecycleAccumulator(request.runStartedAtMs)
+            );
             if (signal) {
                 signals[request.sessionId] = signal;
             }
         }
+        this.lifecycleReader.retain(activeSessionIds);
         return signals;
     }
 
@@ -133,6 +148,7 @@ export default class ClaudeSessionService {
             fs.mkdirSync(archivePath, { recursive: true });
             fs.renameSync(sessionFile, this.getAvailableArchivePath(archivePath, path.basename(sessionFile)));
             this.sessionFilesById.delete(sessionId);
+            this.lifecycleReader.delete(sessionId);
             this.invalidateCache();
             return true;
         } catch (e) {

--- a/src/services/codexSessionService.ts
+++ b/src/services/codexSessionService.ts
@@ -5,10 +5,10 @@ import * as os from 'os';
 import * as path from 'path';
 
 import { CodexSession } from '../models';
+import IncrementalJsonlLifecycleReader from '../aiSessions/incrementalJsonlLifecycleReader';
 import { filterAiSessionsByCandidatePaths, normalizeAiSessionCandidatePaths } from '../aiSessions/sessionHelpers';
 import type { AiSessionQueryOptions } from '../aiSessions/types';
-import { parseCodexLifecycleLines, AiSessionLifecycleRequest, AiSessionLifecycleSignal } from '../aiSessions/lifecycle';
-import { readJsonlTailLines } from '../aiSessions/jsonlTail';
+import { createCodexLifecycleAccumulator, AiSessionLifecycleRequest, AiSessionLifecycleSignal } from '../aiSessions/lifecycle';
 
 interface CodexSessionIndexEntry {
     id?: string;
@@ -41,6 +41,7 @@ export default class CodexSessionService {
     private readonly sessionMetaCache = new Map<string, { signature: string; meta: CodexSessionMeta }>();
     private readonly sessionIndexCache = new Map<string, { signature: string; entries: CodexSessionIndexEntry[] }>();
     private readonly lifecycleSessionFiles = new Map<string, string>();
+    private readonly lifecycleReader = new IncrementalJsonlLifecycleReader();
     private readonly cacheTtlMs = 5000;
     private readonly changePollIntervalMs = 3000;
 
@@ -113,19 +114,26 @@ export default class CodexSessionService {
     }
 
     getLifecycleSignals(requests: readonly AiSessionLifecycleRequest[]): Record<string, AiSessionLifecycleSignal> {
+        let activeSessionIds = new Set<string>();
         let codexHome = this.getCodexHome();
         if (!codexHome) {
+            this.lifecycleReader.retain(activeSessionIds);
             return {};
         }
         let signals: Record<string, AiSessionLifecycleSignal> = {};
         let discoveredFiles: Map<string, string> = null;
         for (let request of requests || []) {
-            if (!request?.sessionId || !Number.isFinite(request.runStartedAtMs) || signals[request.sessionId]) {
+            if (!request?.sessionId || !Number.isFinite(request.runStartedAtMs)) {
+                continue;
+            }
+            activeSessionIds.add(request.sessionId);
+            if (signals[request.sessionId]) {
                 continue;
             }
             let sessionFile = this.lifecycleSessionFiles.get(request.sessionId);
             if (sessionFile && !fs.existsSync(sessionFile)) {
                 this.lifecycleSessionFiles.delete(request.sessionId);
+                this.lifecycleReader.delete(request.sessionId);
                 sessionFile = null;
             }
             if (!sessionFile) {
@@ -133,13 +141,20 @@ export default class CodexSessionService {
                 sessionFile = discoveredFiles.get(request.sessionId);
             }
             if (!sessionFile) {
+                this.lifecycleReader.delete(request.sessionId);
                 continue;
             }
-            let signal = parseCodexLifecycleLines(readJsonlTailLines(sessionFile), request.runStartedAtMs);
+            let signal = this.lifecycleReader.read(
+                request.sessionId,
+                sessionFile,
+                request.runStartedAtMs,
+                () => createCodexLifecycleAccumulator(request.runStartedAtMs)
+            );
             if (signal) {
                 signals[request.sessionId] = signal;
             }
         }
+        this.lifecycleReader.retain(activeSessionIds);
         return signals;
     }
 
@@ -163,6 +178,7 @@ export default class CodexSessionService {
             fs.mkdirSync(archivePath, { recursive: true });
             fs.renameSync(sessionFile, this.getAvailableArchivePath(archivePath, path.basename(sessionFile)));
             this.lifecycleSessionFiles.delete(sessionId);
+            this.lifecycleReader.delete(sessionId);
             this.invalidateCache();
             return true;
         } catch (e) {

--- a/src/services/kimiSessionService.ts
+++ b/src/services/kimiSessionService.ts
@@ -7,9 +7,9 @@ import * as path from 'path';
 
 import { CodexSession } from '../models';
 import { aiSessionPathContains, filterAiSessionsByCandidatePaths, normalizeAiSessionCandidatePaths } from '../aiSessions/sessionHelpers';
+import IncrementalJsonlLifecycleReader from '../aiSessions/incrementalJsonlLifecycleReader';
 import type { AiSessionQueryOptions } from '../aiSessions/types';
-import { parseKimiLifecycleLines, AiSessionLifecycleRequest, AiSessionLifecycleSignal } from '../aiSessions/lifecycle';
-import { readJsonlTailLines } from '../aiSessions/jsonlTail';
+import { createKimiLifecycleAccumulator, AiSessionLifecycleRequest, AiSessionLifecycleSignal } from '../aiSessions/lifecycle';
 import { Disposable } from './codexSessionService';
 
 interface KimiWorkDirEntry {
@@ -47,6 +47,7 @@ export default class KimiSessionService {
     private cachedResult: KimiSessionReadResult = null;
     private cachedAt = 0;
     private readonly sessionDirsById = new Map<string, string>();
+    private readonly lifecycleReader = new IncrementalJsonlLifecycleReader();
     private readonly cacheTtlMs = 5000;
     private readonly changePollIntervalMs = 3000;
 
@@ -98,27 +99,42 @@ export default class KimiSessionService {
     }
 
     getLifecycleSignals(requests: readonly AiSessionLifecycleRequest[]): Record<string, AiSessionLifecycleSignal> {
+        let activeSessionIds = new Set<string>();
         let kimiHome = this.getKimiHome();
         if (!kimiHome) {
+            this.lifecycleReader.retain(activeSessionIds);
             return {};
         }
         let signals: Record<string, AiSessionLifecycleSignal> = {};
         for (let request of requests || []) {
-            if (!request?.sessionId || !Number.isFinite(request.runStartedAtMs) || signals[request.sessionId]) {
+            if (!request?.sessionId || !Number.isFinite(request.runStartedAtMs)) {
+                continue;
+            }
+            activeSessionIds.add(request.sessionId);
+            if (signals[request.sessionId]) {
                 continue;
             }
             let sessionDir = this.findSessionDir(kimiHome, request.sessionId);
             if (!sessionDir) {
+                this.lifecycleReader.delete(request.sessionId);
                 continue;
             }
-            let signal = parseKimiLifecycleLines(
-                readJsonlTailLines(path.join(sessionDir, 'wire.jsonl')),
-                request.runStartedAtMs
+            let sessionFile = path.join(sessionDir, 'wire.jsonl');
+            if (!fs.existsSync(sessionFile)) {
+                this.lifecycleReader.delete(request.sessionId);
+                continue;
+            }
+            let signal = this.lifecycleReader.read(
+                request.sessionId,
+                sessionFile,
+                request.runStartedAtMs,
+                () => createKimiLifecycleAccumulator(request.runStartedAtMs)
             );
             if (signal) {
                 signals[request.sessionId] = signal;
             }
         }
+        this.lifecycleReader.retain(activeSessionIds);
         return signals;
     }
 
@@ -143,6 +159,7 @@ export default class KimiSessionService {
             state.archived = true;
             state.archived_at = new Date().toISOString();
             fs.writeFileSync(statePath, JSON.stringify(state, null, 2));
+            this.lifecycleReader.delete(sessionId);
             this.invalidateCache();
             return true;
         } catch (e) {


### PR DESCRIPTION
## Summary

- replace fixed 512 KiB lifecycle tail reads with bounded incremental JSONL cursors
- preserve lifecycle parser state across chunks for Codex, Kimi, and Claude
- recover running/stopped state after Extension Host reload and cover reset/error isolation

## Verification

- npm run test:safety
- npm run test:dashboard
- npm run lint
- git diff --check origin/main...HEAD

## Release scope

This is a normal fix PR only. It does not change the version, create a tag, or publish a release.