### PR TITLE
Fix cross-window remote project switching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to the "Project Steward" extension will be documented in thi
 
 ## [Unreleased]
 
+## [2.1.2] 2026-07-19
+
+### Added
+
+-   Show live execution activity for Active Sessions while keeping attention indicators independent.
+
+### Changed
+
+-   Read AI session lifecycle logs incrementally and scope recovered lifecycle state to the current run.
+-   Route `OTHER WINDOWS` project cards through the same project-opening path as saved `PROJECTS` cards.
+
+### Fixed
+
+-   Keep newly created pending AI sessions visible until their terminal closes.
+-   Recover long-running AI session state without reviving stale lifecycle events after cursor resets or Extension Host reloads.
+-   Preserve the exact SSH and Dev Container authority published by each VS Code window so `OTHER WINDOWS` switches to the existing project window instead of opening the project in the wrong container.
+
 ## [2.1.1] 2026-07-18
 
 ### Added

--- a/extensions/attention-ui-bridge/package.json
+++ b/extensions/attention-ui-bridge/package.json
@@ -2,7 +2,7 @@
     "name": "project-steward-attention-ui-bridge",
     "displayName": "Project Steward Attention UI Bridge",
     "description": "Local UI-host bridge for Project Steward AI session attention.",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "publisher": "hzcheng",
     "license": "MIT",
     "repository": { "type": "git", "url": "https://github.com/hzcheng/project-steward.git" },

--- a/extensions/attention-ui-bridge/src/extension.ts
+++ b/extensions/attention-ui-bridge/src/extension.ts
@@ -6,6 +6,7 @@ import * as vscode from 'vscode';
 import { resolveBridgeStorageRoot } from './bridgeStorageRoot';
 import { LocalStore } from './localStore';
 import { OpenProjectCoordinator } from './openProjectCoordinator';
+import { replaceOpenProjectPublicationUris } from './openProjectPublication';
 import { ProductionAttentionStore } from './productionAttentionStore';
 import { aggregateAttentionSnapshots, validateAttentionAggregate } from '../../../src/aiSessions/attentionAggregate';
 import {
@@ -191,7 +192,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     });
     const openProjectPublishDisposable = vscode.commands.registerCommand(
         OPEN_PROJECT_BRIDGE_PUBLISH,
-        (raw: unknown) => openProjectCoordinator.publish(raw),
+        (raw: unknown) => {
+            const workspaceFile = vscode.workspace.workspaceFile;
+            const workspaceUris = workspaceFile && workspaceFile.scheme !== 'untitled'
+                ? [workspaceFile.toString()]
+                : (vscode.workspace.workspaceFolders || []).map(folder => folder.uri.toString());
+            return openProjectCoordinator.publish(replaceOpenProjectPublicationUris(raw, workspaceUris));
+        },
     );
     const openProjectUnregisterDisposable = vscode.commands.registerCommand(
         OPEN_PROJECT_BRIDGE_UNREGISTER,

--- a/extensions/attention-ui-bridge/src/openProjectPublication.ts
+++ b/extensions/attention-ui-bridge/src/openProjectPublication.ts
@@ -1,0 +1,18 @@
+import {
+    OpenProjectPublication,
+    validateOpenProjectPublication,
+} from '../../../src/openProjects/protocol';
+
+export function replaceOpenProjectPublicationUris(
+    raw: unknown,
+    workspaceUris: readonly string[],
+): OpenProjectPublication {
+    const publication = validateOpenProjectPublication(raw);
+    return validateOpenProjectPublication({
+        ...publication,
+        projects: publication.projects.map(project => ({
+            ...project,
+            uri: workspaceUris[project.ordinal] || project.uri,
+        })),
+    });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "project-steward",
-    "version": "2.1.1",
+    "version": "2.1.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "project-steward",
-            "version": "2.1.1",
+            "version": "2.1.2",
             "dependencies": {
                 "dragula": "^3.7.3",
                 "fitty": "^2.3.5"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "project-steward",
     "displayName": "Project Steward",
     "description": "Organize local, SSH, and Dev Container projects in a synchronized project steward.",
-    "version": "2.1.1",
+    "version": "2.1.2",
     "publisher": "hzcheng",
     "license": "MIT",
     "icon": "media/extension_icon.png",

--- a/scripts/package-attention-extensions.js
+++ b/scripts/package-attention-extensions.js
@@ -10,7 +10,7 @@ const artifactsDirectory = path.join(repositoryRoot, 'artifacts');
 const packages = [
     {
         extensionDirectory: path.join(repositoryRoot, 'extensions', 'attention-ui-bridge'),
-        artifactPath: 'artifacts/project-steward-attention-ui-bridge-0.1.2.vsix',
+        artifactPath: 'artifacts/project-steward-attention-ui-bridge-0.1.3.vsix',
     },
     {
         extensionDirectory: path.join(spikeRoot, 'workspace'),

--- a/scripts/run-attention-local-bridge-spike-checks.js
+++ b/scripts/run-attention-local-bridge-spike-checks.js
@@ -351,7 +351,7 @@ function readText(relativePath) {
 function runArtifactContractChecks() {
     const packageScript = readText('scripts/package-attention-extensions.js');
     const expectedArtifactPaths = [
-        'artifacts/project-steward-attention-ui-bridge-0.1.2.vsix',
+        'artifacts/project-steward-attention-ui-bridge-0.1.3.vsix',
         'artifacts/project-steward-attention-workspace-probe-0.0.5.vsix',
     ];
     const namedArtifactPaths = packageScript.match(/artifacts\/[^'"`\s]+\.vsix/g) || [];
@@ -366,7 +366,7 @@ function runArtifactContractChecks() {
         'same workspace',
         'different Profile',
         'Developer: Show Running Extensions',
-        'project-steward-attention-ui-bridge-0.1.2.vsix',
+        'project-steward-attention-ui-bridge-0.1.3.vsix',
         'project-steward-attention-workspace-probe-0.0.5.vsix',
     ]) {
         assert.ok(manualMatrix.includes(requiredText), `MANUAL-MATRIX.md must contain ${requiredText}`);
@@ -429,7 +429,7 @@ function runManifestChecks() {
     const workspace = readJson('spikes/attention-local-bridge/workspace/package.json');
     const bridge = readJson('extensions/attention-ui-bridge/package.json');
     assert.strictEqual(workspace.version, '0.0.5');
-    assert.strictEqual(bridge.version, '0.1.2');
+    assert.strictEqual(bridge.version, '0.1.3');
     assert.deepStrictEqual(workspace.extensionKind, ['workspace']);
     assert.deepStrictEqual(bridge.extensionKind, ['ui']);
     assert.strictEqual(bridge.api, 'none');

--- a/scripts/run-open-project-safety-checks.js
+++ b/scripts/run-open-project-safety-checks.js
@@ -27,6 +27,7 @@ const { DashboardStartupController } = require('../out/dashboard/startupControll
 const models = require('../out/models');
 const { OpenProjectStore } = require('../extensions/attention-ui-bridge/out/extensions/attention-ui-bridge/src/openProjectStore');
 const { OpenProjectCoordinator } = require('../extensions/attention-ui-bridge/out/extensions/attention-ui-bridge/src/openProjectCoordinator');
+const { replaceOpenProjectPublicationUris } = require('../extensions/attention-ui-bridge/out/extensions/attention-ui-bridge/src/openProjectPublication');
 Module._load = originalModuleLoad;
 
 const SELF = '1'.repeat(32);
@@ -114,7 +115,6 @@ function runProtocolChecks() {
     assert.deepStrictEqual(protocol.validateOpenProjectPublication(publication), publication);
     assert.deepStrictEqual(protocol.validateOpenProjectRegistration(registration), registration);
     assert.deepStrictEqual(protocol.validateOpenProjectAggregate(aggregate), aggregate);
-
     assertRejectsValidation(
         () => protocol.validateOpenProjectPublication({ ...publication, unexpected: true }),
         /unexpected fields/
@@ -271,6 +271,27 @@ function runProtocolChecks() {
             projects: [tiedProjectBeta, tiedProjectAlpha],
         })])
     );
+}
+
+function runOpenProjectPublicationChecks() {
+    const publication = {
+        protocolVersion: 1,
+        instanceId: SELF,
+        sequence: 1,
+        followsFocusEvent: false,
+        projects: [makeRecord({
+            ordinal: 0,
+            uri: 'vscode-remote://dev-container%2Bcurrent/workspaces/AiToEarn',
+            remoteType: 'devContainer',
+        })],
+    };
+    const exactWindowUri = 'vscode-remote://dev-container%2Btarget%40ssh-remote%2Bhome-book/workspaces/AiToEarn';
+
+    const replaced = replaceOpenProjectPublicationUris(publication, [exactWindowUri]);
+
+    assert.strictEqual(replaced.projects[0].uri, exactWindowUri);
+    assert.strictEqual(publication.projects[0].uri, 'vscode-remote://dev-container%2Bcurrent/workspaces/AiToEarn');
+    assert.deepStrictEqual(replaceOpenProjectPublicationUris(publication, []), publication);
 }
 
 function runIdentityChecks() {
@@ -2002,7 +2023,13 @@ async function runCoordinatorWiringChecks() {
                 };
             },
         },
-        workspace: { workspaceFolders: [] },
+        workspace: {
+            workspaceFolders: [{
+                uri: {
+                    toString: () => 'vscode-remote://dev-container%2Btarget%40ssh-remote%2Bhome-book/workspaces/AiToEarn',
+                },
+            }],
+        },
         commands: {
             registerCommand: (command, callback) => {
                 registeredCommands.set(command, callback);
@@ -2041,6 +2068,10 @@ async function runCoordinatorWiringChecks() {
         ).pop();
         assert.ok(aggregateDelivery, 'production wiring should deliver an open-project aggregate');
         assert.strictEqual(aggregateDelivery.argument.registrations[0].instanceId, SELF);
+        assert.strictEqual(
+            aggregateDelivery.argument.registrations[0].projects[0].uri,
+            'vscode-remote://dev-container%2Btarget%40ssh-remote%2Bhome-book/workspaces/AiToEarn'
+        );
         assert.ok(bridgeOutputLines.some(line =>
             line.startsWith('[OpenProjects] ')
             && line.includes('"event":"publish"')
@@ -2062,6 +2093,7 @@ async function runCoordinatorWiringChecks() {
 
 async function main() {
     runProtocolChecks();
+    runOpenProjectPublicationChecks();
     runIdentityChecks();
     runRecordChecks();
     runProjectionChecks();

--- a/scripts/run-release-packaging-checks.js
+++ b/scripts/run-release-packaging-checks.js
@@ -51,7 +51,7 @@ function run() {
     assertIncludes(installScript, 'BRIDGE_VERSION', 'local install script');
     assertIncludes(installScript, '--install-extension "$BRIDGE_VSIX" --force', 'local install script');
     assertIncludes(installScript, '--install-extension "$MAIN_VSIX" --force', 'local install script');
-    assertNotIncludes(installScript, 'project-steward-attention-ui-bridge-0.1.2.vsix', 'local install script');
+    assertNotIncludes(installScript, 'project-steward-attention-ui-bridge-0.1.3.vsix', 'local install script');
 
     const publishScript = readText('scripts/publish-marketplace.sh');
     assertIncludes(publishScript, 'BRIDGE_NAME', 'Marketplace publish script');

--- a/spikes/attention-local-bridge/MANUAL-MATRIX.md
+++ b/spikes/attention-local-bridge/MANUAL-MATRIX.md
@@ -6,8 +6,8 @@ These disposable probes must be installed manually. The packaging script never i
 
 Use this exact order for every fresh build and for each matrix row:
 
-1. Install the UI Bridge `0.1.2`; uninstall an older Workspace Probe from every tested Workspace host or force-install the new Workspace patch.
-2. Reload the local UI Bridge host after installing `artifacts/project-steward-attention-ui-bridge-0.1.2.vsix`.
+1. Install the UI Bridge `0.1.3`; uninstall an older Workspace Probe from every tested Workspace host or force-install the new Workspace patch.
+2. Reload the local UI Bridge host after installing `artifacts/project-steward-attention-ui-bridge-0.1.3.vsix`.
 3. Open the target Local, Remote SSH, WSL, or Dev Container fixture window.
 4. Install `artifacts/project-steward-attention-workspace-probe-0.0.5.vsix` in the Workspace host. For remote fixtures, use the remote `code-server --install-extension <absolute-vsix> --force`.
 5. Restart only the target fixture Extension Host after the Workspace install. In the Local row this is also the UI host, so do not perform an additional UI-host restart.


### PR DESCRIPTION
## Summary
- preserve the exact UI-window workspace URI when publishing OTHER WINDOWS projects
- reuse the existing Projects/openFolder navigation path for remote project switching
- prepare Project Steward 2.1.2 and UI Bridge 0.1.3 release metadata

## Verification
- npm run test:dashboard
- npm run test:safety
- npm run spike:attention:test
- npm run test:release-notes
- npm run test:release-packaging
- npm run lint
- npm run package:release
- git diff --check

Manual cross-machine Dev Container switching was confirmed by the user.