### PR TITLE
fix: prioritize active session execution status

### DIFF
--- a/docs/superpowers/plans/2026-07-20-active-session-status-priority.md
+++ b/docs/superpowers/plans/2026-07-20-active-session-status-priority.md
@@ -1,0 +1,121 @@
+# Active Session Status Priority Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the redundant visible `Needs attention` label and guarantee that execution state is the first item on every Active Session card's second line.
+
+**Architecture:** Keep attention and execution data unchanged and adjust only `getActiveAiSessionRow`'s presentation-level metadata composition. Extend the existing rendered-HTML safety checks to verify status priority, attention-dot accessibility, absence of duplicate visible text, and preservation of runtime diagnostics.
+
+**Tech Stack:** TypeScript, server-rendered Webview HTML, Node.js `assert`, existing AI session safety and Dashboard test scripts.
+
+## Global Constraints
+
+- Keep the red attention dot as the sole visible attention indicator.
+- Keep the dot's tooltip and accessible label `AI session needs attention`.
+- Never render the visible text `Needs attention` on an Active Session card.
+- Always place `Running`, `Stopped`, or `Starting` first on the second line.
+- Preserve `stale` and `Runtime conflict` diagnostics after the execution state.
+- Do not change attention acknowledgement, runtime state, focus, tmux, or VS Code terminal behavior.
+
+---
+
+### Task 1: Prioritize Active Session execution metadata
+
+**Files:**
+- Modify: `scripts/run-ai-session-safety-checks.js:4660`
+- Modify: `src/webview/webviewContent.ts:770`
+- Verify: `docs/superpowers/specs/2026-07-20-active-session-status-priority-design.md`
+
+**Interfaces:**
+- Consumes: `ActiveAiSessionViewModel.executionState`, `.needsAttention`, `.status`, `.conflict`, and `.stale`.
+- Produces: Active Session HTML whose `.codex-session-meta` begins with `.ai-session-execution-status`; attention remains represented by `.ai-session-attention-indicator`.
+
+- [x] **Step 1: Write the failing rendered-HTML regression checks**
+
+Add a stale conflict fixture without changing the existing attention fixture:
+
+```js
+{
+    key: 'claude:c3', provider: 'claude', sessionId: 'c3', name: 'Claude running',
+    executionState: 'running', focused: false, needsAttention: false, pending: false,
+    backend: 'vscode', attached: true, status: 'conflict', conflict: true, stale: true,
+},
+```
+
+After extracting `activeMetadata`, assert the intended visible and accessible behavior:
+
+```js
+assert.ok(activeMetadata.every(metadata => metadata.startsWith(
+    '<span class="ai-session-execution-status"'
+)), 'every Active Session metadata line must begin with execution state');
+assert.ok(activeMetadata.every(metadata => !metadata.includes('Needs attention')),
+    'the attention dot must not be duplicated by visible metadata text');
+assert.ok(sessionTabsHtml.includes(
+    '<span class="ai-session-attention-indicator" title="AI session needs attention" aria-label="AI session needs attention"></span>'
+), 'the attention dot must retain its tooltip and accessible label');
+assert.ok(activeMetadata.some(metadata =>
+    metadata.includes('Running</span> · <span class="ai-session-stale-status"')
+    && metadata.includes('</span> · Runtime conflict · ')
+), 'stale and conflict diagnostics must follow execution state');
+```
+
+- [x] **Step 2: Run the safety suite and verify the regression fails for the intended reasons**
+
+Run:
+
+```bash
+npm run test:safety
+```
+
+Expected: FAIL because current attention metadata contains `Needs attention` and current metadata begins with stale/runtime status rather than execution state.
+
+- [x] **Step 3: Make the minimal renderer change**
+
+Replace the attention-aware runtime label with a conflict-only diagnostic and reorder metadata:
+
+```ts
+var runtimeStatusLabel = model.status === 'conflict' || model.conflict ? 'Runtime conflict' : '';
+// Keep runtimeBadge, staleStatus, and attentionIndicator construction unchanged.
+var metadata = [executionStatus, staleStatus, runtimeStatusLabel, createdAt, shortSessionId]
+    .filter(Boolean)
+    .join(' · ');
+```
+
+- [x] **Step 4: Run the focused suites and verify green**
+
+Run:
+
+```bash
+npm run test:safety
+npm run test:dashboard
+```
+
+Expected: AI session safety, tmux, open-project, and Dashboard Webview checks all pass.
+
+- [x] **Step 5: Run final repository verification**
+
+Run:
+
+```bash
+npm run test-compile
+npm run lint
+npm run test:architecture-baseline
+npm run test:release-notes
+npm run test:release-packaging
+git diff --check
+```
+
+Expected: all commands exit zero; existing lint warnings may remain, but the modified files add no lint errors.
+
+- [x] **Step 6: Commit the implementation intentionally**
+
+Run:
+
+```bash
+git add docs/superpowers/plans/2026-07-20-active-session-status-priority.md \
+    scripts/run-ai-session-safety-checks.js \
+    src/webview/webviewContent.ts
+git commit -m "fix: prioritize active session execution status"
+```
+
+Expected: one implementation commit following the already committed design document.

--- a/docs/superpowers/plans/2026-07-20-active-session-status-priority.md
+++ b/docs/superpowers/plans/2026-07-20-active-session-status-priority.md
@@ -50,9 +50,15 @@ assert.ok(activeMetadata.every(metadata => metadata.startsWith(
 )), 'every Active Session metadata line must begin with execution state');
 assert.ok(activeMetadata.every(metadata => !metadata.includes('Needs attention')),
     'the attention dot must not be duplicated by visible metadata text');
-assert.ok(sessionTabsHtml.includes(
+const activeRows = Array.from(sessionTabsHtml.matchAll(
+    /<div class="codex-session-row active-ai-session-row"[\s\S]*?<\/div>/g
+), match => match[0]);
+const attentionRows = activeRows.filter(row => row.includes('data-session-needs-attention'));
+assert.strictEqual(attentionRows.length, 1,
+    'the fixture must render one attention Active Session row');
+assert.ok(attentionRows[0].includes(
     '<span class="ai-session-attention-indicator" title="AI session needs attention" aria-label="AI session needs attention"></span>'
-), 'the attention dot must retain its tooltip and accessible label');
+), 'the attention Active Session row must retain the dot, tooltip, and accessible label');
 assert.ok(activeMetadata.some(metadata =>
     metadata.includes('Running</span> · <span class="ai-session-stale-status"')
     && metadata.includes('</span> · Runtime conflict · ')

--- a/docs/superpowers/specs/2026-07-20-active-session-status-priority-design.md
+++ b/docs/superpowers/specs/2026-07-20-active-session-status-priority-design.md
@@ -1,0 +1,47 @@
+# Active Session Status Priority Design
+
+## Goal
+
+Make the Active Session card's second line prioritize execution state and avoid duplicating the attention indicator in text.
+
+## Current Behavior and Root Cause
+
+An Active Session with unread attention renders both a red attention dot and the text `Needs attention`. The metadata builder also places stale/runtime status before execution state, so `Running`, `Stopped`, or `Starting` can be pushed out of view on narrow cards.
+
+The attention state itself is correct. The duplication and ordering come from `getActiveAiSessionRow` composing metadata as stale status, runtime status, execution status, time, and short Session ID.
+
+## Display Rules
+
+- Keep the red attention dot as the sole visible attention indicator.
+- Keep the dot's tooltip and accessible label `AI session needs attention`.
+- Never render the visible text `Needs attention` on an Active Session card.
+- Always place `Running`, `Stopped`, or `Starting` first on the second line.
+- Preserve `stale` and `Runtime conflict` diagnostics after the execution state.
+- Preserve the existing timestamp and short Session ID after diagnostic metadata.
+- Do not change attention acknowledgement, runtime state, focus, tmux, or VS Code terminal behavior.
+
+The resulting metadata order is:
+
+```text
+Execution state · stale · Runtime conflict · timestamp · short Session ID
+```
+
+Only populated fields are included, so ordinary rows remain compact, for example:
+
+```text
+Stopped · 2 minutes ago · #abc12345
+```
+
+## Implementation Boundary
+
+Update only the Active Session row renderer in `src/webview/webviewContent.ts` and its existing safety checks in `scripts/run-ai-session-safety-checks.js`. No view-model or attention lifecycle change is required because the renderer already receives separate `executionState` and `needsAttention` values.
+
+## Verification
+
+Regression checks will verify that:
+
+- all Active Session metadata lines begin with their execution state;
+- an attention row still renders the red dot and its accessible description;
+- Active Session metadata never contains `Needs attention`;
+- `Runtime conflict` and `stale` remain available after execution state;
+- existing safety and Dashboard test suites continue to pass.

--- a/scripts/run-ai-session-safety-checks.js
+++ b/scripts/run-ai-session-safety-checks.js
@@ -4675,7 +4675,7 @@ function runWebviewContentChecks() {
             {
                 key: 'claude:c3', provider: 'claude', sessionId: 'c3', name: 'Claude running',
                 executionState: 'running', focused: false, needsAttention: false, pending: false,
-                backend: 'vscode', attached: true,
+                backend: 'vscode', attached: true, status: 'conflict', conflict: true, stale: true,
             },
             {
                 key: 'pending:claude:2026-07-18T03:00:00Z', provider: 'claude', name: 'New Claude',
@@ -4713,11 +4713,23 @@ function runWebviewContentChecks() {
         '<span class="codex-session-title-line"><span class="ai-session-runtime-badge" title="Managed tmux runtime" aria-label="Managed tmux runtime">tmux</span><span class="codex-session-name">Kimi waiting</span></span>'
     ), 'a tmux backend badge must appear before the Session name');
     const activeMetadata = Array.from(sessionTabsHtml.matchAll(
-        /<span class="codex-session-meta">([\s\S]*?)<\/span>\s*<\/span>/g
+        /<div class="codex-session-row active-ai-session-row"[\s\S]*?<span class="codex-session-meta">([\s\S]*?)<\/span>\s*<\/span>/g
     ), match => match[1]);
     assert.ok(activeMetadata.length >= 4, 'every Active Session fixture must expose a metadata line');
     assert.ok(activeMetadata.every(metadata => !/Codex|Kimi|Claude|Focused/.test(metadata)),
         'Active Session metadata must omit redundant Provider and Focused labels');
+    assert.ok(activeMetadata.every(metadata => metadata.startsWith(
+        '<span class="ai-session-execution-status"'
+    )), 'every Active Session metadata line must begin with execution state');
+    assert.ok(activeMetadata.every(metadata => !metadata.includes('Needs attention')),
+        'the attention dot must not be duplicated by visible metadata text');
+    assert.ok(sessionTabsHtml.includes(
+        '<span class="ai-session-attention-indicator" title="AI session needs attention" aria-label="AI session needs attention"></span>'
+    ), 'the attention dot must retain its tooltip and accessible label');
+    assert.ok(activeMetadata.some(metadata =>
+        metadata.includes('Running</span> · <span class="ai-session-stale-status"')
+        && metadata.includes('</span> · Runtime conflict · ')
+    ), 'stale and conflict diagnostics must follow execution state');
     assert.ok(sessionTabsHtml.includes('data-session-needs-attention'));
     assert.ok(!sessionTabsHtml.includes('data-session-status='));
     assert.ok(sessionTabsHtml.includes('data-session-pending'));

--- a/scripts/run-ai-session-safety-checks.js
+++ b/scripts/run-ai-session-safety-checks.js
@@ -4723,14 +4723,19 @@ function runWebviewContentChecks() {
     )), 'every Active Session metadata line must begin with execution state');
     assert.ok(activeMetadata.every(metadata => !metadata.includes('Needs attention')),
         'the attention dot must not be duplicated by visible metadata text');
-    assert.ok(sessionTabsHtml.includes(
+    const activeRows = Array.from(sessionTabsHtml.matchAll(
+        /<div class="codex-session-row active-ai-session-row"[\s\S]*?<\/div>/g
+    ), match => match[0]);
+    const attentionRows = activeRows.filter(row => row.includes('data-session-needs-attention'));
+    assert.strictEqual(attentionRows.length, 1, 'the fixture must render one attention Active Session row');
+    assert.ok(attentionRows[0].includes(
         '<span class="ai-session-attention-indicator" title="AI session needs attention" aria-label="AI session needs attention"></span>'
-    ), 'the attention dot must retain its tooltip and accessible label');
+    ), 'the attention Active Session row must retain the dot, tooltip, and accessible label');
     assert.ok(activeMetadata.some(metadata =>
         metadata.includes('Running</span> · <span class="ai-session-stale-status"')
         && metadata.includes('</span> · Runtime conflict · ')
     ), 'stale and conflict diagnostics must follow execution state');
-    assert.ok(sessionTabsHtml.includes('data-session-needs-attention'));
+    assert.ok(attentionRows[0].includes('data-session-needs-attention'));
     assert.ok(!sessionTabsHtml.includes('data-session-status='));
     assert.ok(sessionTabsHtml.includes('data-session-pending'));
     assert.ok(sessionTabsHtml.includes('data-session-active'));

--- a/src/webview/webviewContent.ts
+++ b/src/webview/webviewContent.ts
@@ -781,9 +781,7 @@ function getActiveAiSessionRow(model: ActiveAiSessionViewModel): string {
         : model.executionState === 'starting' ? 'Waiting for AI activity'
             : 'AI is not currently executing';
     var executionStatus = `<span class="ai-session-execution-status" aria-label="${executionAriaLabel}"><span class="ai-session-execution-dot" aria-hidden="true"></span>${executionLabel}</span>`;
-    var runtimeStatusLabel = model.status === 'conflict' || model.conflict ? 'Runtime conflict'
-        : model.status === 'needsAttention' ? 'Needs attention'
-            : '';
+    var runtimeStatusLabel = model.status === 'conflict' || model.conflict ? 'Runtime conflict' : '';
     var runtimeBadgeDescription = model.backend === 'tmux'
         ? 'Managed tmux runtime'
         : 'Direct VS Code terminal';
@@ -791,7 +789,7 @@ function getActiveAiSessionRow(model: ActiveAiSessionViewModel): string {
     var staleStatus = model.stale
         ? '<span class="ai-session-stale-status" title="Runtime status is stale">stale</span>'
         : '';
-    var metadata = [staleStatus, runtimeStatusLabel, executionStatus, createdAt, shortSessionId].filter(Boolean).join(' · ');
+    var metadata = [executionStatus, staleStatus, runtimeStatusLabel, createdAt, shortSessionId].filter(Boolean).join(' · ');
     var attentionIndicator = model.needsAttention
         ? '<span class="ai-session-attention-indicator" title="AI session needs attention" aria-label="AI session needs attention"></span>'
         : '';


### PR DESCRIPTION
## Summary
- remove the redundant visible Needs attention label while preserving the red attention indicator and accessibility text
- place Running, Stopped, or Starting first in Active Session metadata
- preserve stale and runtime conflict diagnostics after execution state
- add rendered HTML regression coverage scoped to the attention Active Session row

## Verification
- npm run test:safety
- npm run test:dashboard
- npm run test:release-packaging
- npm run test-compile
- npm run lint
- npm run test:architecture-baseline
- npm run test:release-notes
- git diff --check