### PR TITLE
fix: count logical attention sessions on cards

### DIFF
--- a/docs/superpowers/plans/2026-07-23-logical-attention-card-count.md
+++ b/docs/superpowers/plans/2026-07-23-logical-attention-card-count.md
@@ -229,6 +229,7 @@ Add this private helper in `src/aiSessions/attentionProject.ts`:
 function summarizeAttentionSessions(
     sourceSessions: readonly AggregatedAttentionSession[]
 ): AttentionSummary {
+    const allEventIds = new Set<string>();
     const sessionEventIds = new Map<string, Set<string>>();
     for (const session of sourceSessions) {
         const sessionKey = getLogicalAttentionSessionKey(session.sessionKey);
@@ -240,6 +241,7 @@ function summarizeAttentionSessions(
         for (const eventId of session.eventIds || []) {
             if (eventId) {
                 events.add(eventId);
+                allEventIds.add(eventId);
             }
         }
     }
@@ -257,7 +259,7 @@ function summarizeAttentionSessions(
 
     return {
         attentionCount: sessions.length,
-        eventIds: Array.from(new Set(sessions.flatMap(session => session.eventIds))).sort(),
+        eventIds: Array.from(allEventIds).sort(),
         sessions,
     };
 }

--- a/docs/superpowers/plans/2026-07-23-logical-attention-card-count.md
+++ b/docs/superpowers/plans/2026-07-23-logical-attention-card-count.md
@@ -1,0 +1,464 @@
+# Logical Attention Card Count Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox items so progress and verification evidence stay explicit.
+
+**Goal:** Count unread attention on every dashboard card by logical AI session, retain every run-scoped event ID for acknowledgement, and lock Close/Detach cleanup into CI.
+
+**Architecture:** Keep attention payloads and aggregates run-scoped so lifecycle replay remains safe. Normalize run-scoped keys only when building UI-facing project/workspace summaries, through one shared helper in the AI-session attention domain. Keep the raw-key lookup index unchanged because controller recovery still needs exact aggregate records.
+
+**Tech Stack:** TypeScript, Node.js `node:test`, repository behavior-contract catalog, deterministic/safety CI scripts.
+
+## Global Constraints
+
+- Work only in `/home/hzcheng/projects/repos/vscode-dashboard/.worktrees/fix-logical-attention-card-count`.
+- Keep the primary checkout and its existing `.vscode/settings.json` and `.codex/` changes untouched.
+- Do not push the branch and do not create a PR.
+- Preserve the intentional lifecycle split:
+  - explicit UI Close/Detach acknowledges every unread run event for the logical session;
+  - natural terminal closure does not acknowledge unread attention;
+  - aggregate and persistence identities remain run-scoped.
+- Use TDD: observe the new contract fail for duplicate count before changing production code.
+- Use `apply_patch` for source and test edits.
+
+---
+
+## Task 1: Add a Failing Logical-Session Card Contract
+
+**Files:**
+
+- Modify: `tests/contract/aiSessions/attention.test.js`
+- Modify: `docs/testing/behavior-contracts.json`
+- Modify: `docs/testing/main-capability-coverage.json`
+
+- [ ] **Step 1: Import acknowledgement filtering and workspace projection**
+
+Update the aggregate import and add the workspace projection import:
+
+```js
+const {
+    aggregateAttentionSnapshots,
+    filterAcknowledgedAttentionAggregate,
+} = require('../../../out/aiSessions/attentionAggregate');
+const workspaceAttentionProjection = require('../../../out/workspaces/attentionProjection');
+```
+
+- [ ] **Step 2: Add the composition-level behavior contract**
+
+Immediately after `ATTENTION-ATTENTION-PROJECT-001`, add:
+
+```js
+test('ATTENTION-LOGICAL-SESSION-CARD-COUNT-001 counts logical sessions and retains every run event', () => {
+    const projectPath = 'file:///fixtures/project';
+    const projectKey = attentionProject.getAttentionProjectKey('/fixtures/project');
+    const sameLogicalSessionAggregate = {
+        protocolVersion: 1,
+        aggregateRevision: 'b'.repeat(64),
+        generatedAtMs: 300,
+        sessions: [{
+            projectId: projectKey,
+            sessionKey: 'codex:one:100:tmux',
+            reasons: ['completed'],
+            eventIds: ['event-old'],
+            observedAtMs: 100,
+        }, {
+            projectId: projectKey,
+            sessionKey: 'codex:one:200:vscode',
+            reasons: ['input-required'],
+            eventIds: ['event-new'],
+            observedAtMs: 200,
+        }],
+    };
+
+    assert.equal(
+        attentionProject.getLogicalAttentionSessionKey('codex:one:200:vscode'),
+        'codex:one'
+    );
+    assert.equal(
+        attentionProject.getLogicalAttentionSessionKey('opaque-session-key'),
+        'opaque-session-key'
+    );
+
+    const projectSummary = attentionProject.getAttentionProjectSummaries(
+        sameLogicalSessionAggregate
+    )[0];
+    assert.deepEqual(projectSummary, {
+        projectKey,
+        attentionCount: 1,
+        eventIds: ['event-new', 'event-old'],
+        sessions: [{
+            sessionKey: 'codex:one',
+            eventId: 'event-new',
+            eventIds: ['event-new', 'event-old'],
+        }],
+    });
+    assert.deepEqual(
+        attentionProject.withAttentionProject({ id: 'project', path: projectPath }, sameLogicalSessionAggregate),
+        {
+            id: 'project',
+            path: projectPath,
+            aiSessionAttentionCount: 1,
+            aiSessionAttentionEventIds: ['event-new', 'event-old'],
+        }
+    );
+    assert.deepEqual(
+        workspaceAttentionProjection.getWorkspaceAttentionSummary({
+            roots: [{ uri: projectPath }],
+        }, sameLogicalSessionAggregate),
+        {
+            attentionCount: 1,
+            eventIds: ['event-new', 'event-old'],
+            sessions: [{
+                sessionKey: 'codex:one',
+                eventId: 'event-new',
+                eventIds: ['event-new', 'event-old'],
+            }],
+        }
+    );
+
+    const acknowledged = filterAcknowledgedAttentionAggregate(
+        sameLogicalSessionAggregate,
+        new Set(['event-old', 'event-new'])
+    );
+    assert.equal(
+        workspaceAttentionProjection.getWorkspaceAttentionSummary({
+            roots: [{ uri: projectPath }],
+        }, acknowledged).attentionCount,
+        0
+    );
+
+    const twoLogicalSessions = {
+        ...sameLogicalSessionAggregate,
+        sessions: sameLogicalSessionAggregate.sessions.concat({
+            projectId: projectKey,
+            sessionKey: 'codex:two:300:tmux',
+            reasons: ['failed'],
+            eventIds: ['event-two'],
+            observedAtMs: 300,
+        }),
+    };
+    assert.equal(
+        attentionProject.getAttentionProjectSummaries(twoLogicalSessions)[0].attentionCount,
+        2
+    );
+});
+```
+
+This one contract covers saved-project cards (`withAttentionProject`), current/other workspace cards (`getWorkspaceAttentionSummary`), retained run events, acknowledgement-to-zero, distinct logical sessions, and opaque-key compatibility.
+
+- [ ] **Step 3: Register the behavior as a CI-owned main capability**
+
+Add this entry after `ATTENTION-ATTENTION-PROJECTION-001` in `docs/testing/behavior-contracts.json`:
+
+```json
+{
+  "id": "ATTENTION-LOGICAL-SESSION-CARD-COUNT-001",
+  "domain": "attention",
+  "title": "Logical Session Card Attention Count behavior",
+  "priority": "P0",
+  "status": "automated",
+  "owners": [
+    "tests/contract/aiSessions/attention.test.js"
+  ],
+  "evidence": [
+    "src/aiSessions/attentionProject.ts",
+    "src/workspaces/attentionProjection.ts"
+  ]
+}
+```
+
+Add `"ATTENTION-LOGICAL-SESSION-CARD-COUNT-001"` to the `MAIN-WORKSPACE-ATTENTION.behaviors` array in `docs/testing/main-capability-coverage.json`.
+
+- [ ] **Step 4: Compile and prove the old implementation is red**
+
+Run:
+
+```bash
+npm run test-compile
+node --test --test-name-pattern='ATTENTION-LOGICAL-SESSION-CARD-COUNT-001' tests/contract/aiSessions/attention.test.js
+```
+
+Expected: the test fails because the project summary reports `attentionCount: 2` and exposes two run-scoped sessions instead of one logical session.
+
+- [ ] **Step 5: Confirm metadata itself is valid**
+
+Run:
+
+```bash
+npm run test:behavior-contracts
+```
+
+Expected: pass. The behavior ID is owned by the new test and mapped to `MAIN-WORKSPACE-ATTENTION`.
+
+- [ ] **Step 6: Commit the red contract and metadata**
+
+```bash
+git add tests/contract/aiSessions/attention.test.js docs/testing/behavior-contracts.json docs/testing/main-capability-coverage.json
+git commit -m "test: cover logical attention card counting"
+```
+
+---
+
+## Task 2: Normalize Logical Sessions in the Shared Projection Layer
+
+**Files:**
+
+- Modify: `src/aiSessions/attentionProject.ts`
+- Modify: `src/aiSessions/attentionController.ts`
+- Modify: `src/workspaces/sessionAttention.ts`
+
+- [ ] **Step 1: Move the logical-key helper into the attention domain**
+
+Add to `src/aiSessions/attentionProject.ts` after `AttentionSummary`:
+
+```ts
+export function getLogicalAttentionSessionKey(sessionKey: string): string {
+    const match = /^(codex|kimi|claude):(.+):\d+:(?:vscode|tmux)$/.exec(sessionKey || '');
+    return match ? `${match[1]}:${match[2]}` : sessionKey;
+}
+```
+
+In `src/workspaces/sessionAttention.ts`, import `getLogicalAttentionSessionKey` from `../aiSessions/attentionProject` and remove the local exported implementation.
+
+In `src/aiSessions/attentionController.ts`, import both `getAttentionProjectKeys` and `getLogicalAttentionSessionKey` from `./attentionProject`, then remove the dependency on `../workspaces/sessionAttention`.
+
+- [ ] **Step 2: Add one summary builder that merges all run event IDs**
+
+Add this private helper in `src/aiSessions/attentionProject.ts`:
+
+```ts
+function summarizeAttentionSessions(
+    sourceSessions: readonly AggregatedAttentionSession[]
+): AttentionSummary {
+    const sessionEventIds = new Map<string, Set<string>>();
+    for (const session of sourceSessions) {
+        const sessionKey = getLogicalAttentionSessionKey(session.sessionKey);
+        let events = sessionEventIds.get(sessionKey);
+        if (!events) {
+            events = new Set<string>();
+            sessionEventIds.set(sessionKey, events);
+        }
+        for (const eventId of session.eventIds || []) {
+            if (eventId) {
+                events.add(eventId);
+            }
+        }
+    }
+
+    const sessions = Array.from(sessionEventIds.entries())
+        .map(([sessionKey, events]) => {
+            const eventIds = Array.from(events).sort();
+            return {
+                sessionKey,
+                eventId: eventIds[0] || sessionKey,
+                eventIds,
+            };
+        })
+        .sort((left, right) => left.sessionKey.localeCompare(right.sessionKey));
+
+    return {
+        attentionCount: sessions.length,
+        eventIds: Array.from(new Set(sessions.flatMap(session => session.eventIds))).sort(),
+        sessions,
+    };
+}
+```
+
+- [ ] **Step 3: Route workspace and project summaries through the same builder**
+
+Replace `getAttentionSummaryForProjectKeys` with:
+
+```ts
+export function getAttentionSummaryForProjectKeys(
+    projectKeys: readonly string[],
+    aggregate: AttentionAggregate | null
+): AttentionSummary {
+    const selectedProjectKeys = new Set((projectKeys || []).filter(Boolean));
+    return summarizeAttentionSessions(
+        (aggregate?.sessions || []).filter(session => selectedProjectKeys.has(session.projectId))
+    );
+}
+```
+
+Replace `getAttentionProjectSummaries` with:
+
+```ts
+export function getAttentionProjectSummaries(aggregate: AttentionAggregate | null): AttentionProjectSummary[] {
+    const sessionsByProject = new Map<string, AggregatedAttentionSession[]>();
+    for (const session of aggregate?.sessions || []) {
+        let projectSessions = sessionsByProject.get(session.projectId);
+        if (!projectSessions) {
+            projectSessions = [];
+            sessionsByProject.set(session.projectId, projectSessions);
+        }
+        projectSessions.push(session);
+    }
+
+    return Array.from(sessionsByProject.entries())
+        .map(([projectKey, sessions]) => ({
+            projectKey,
+            ...summarizeAttentionSessions(sessions),
+        }))
+        .sort((left, right) => left.projectKey.localeCompare(right.projectKey));
+}
+```
+
+Do not change `buildAttentionSessionIndex`; it intentionally indexes exact run-scoped aggregate keys.
+
+- [ ] **Step 4: Compile and make the new contract green**
+
+Run:
+
+```bash
+npm run test-compile
+node --test --test-name-pattern='ATTENTION-LOGICAL-SESSION-CARD-COUNT-001|ATTENTION-ATTENTION-PROJECT-001|ATTENTION-ATTENTION-PROJECTION-001' tests/contract/aiSessions/attention.test.js
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 5: Run all attention contracts**
+
+Run:
+
+```bash
+node --test tests/contract/aiSessions/attention.test.js
+```
+
+Expected: pass with no regression to raw aggregate identity, lifecycle replay, acknowledgement, or natural-close persistence.
+
+- [ ] **Step 6: Review the diff and commit the minimal fix**
+
+Run:
+
+```bash
+git diff --check
+git diff -- src/aiSessions/attentionProject.ts src/aiSessions/attentionController.ts src/workspaces/sessionAttention.ts
+```
+
+Then commit:
+
+```bash
+git add src/aiSessions/attentionProject.ts src/aiSessions/attentionController.ts src/workspaces/sessionAttention.ts
+git commit -m "fix: count logical attention sessions on cards"
+```
+
+---
+
+## Task 3: Lock Multi-Run Close/Detach Acknowledgement into Safety CI
+
+**Files:**
+
+- Modify: `scripts/run-ai-session-safety-checks.js`
+
+- [ ] **Step 1: Feed multiple recovered events to the existing Close/Detach harness**
+
+After `vm.runInNewContext(source, context);` in `runBatchAiSessionWebviewChecks`, initialize:
+
+```js
+context.window.__projectStewardAttentionSessionEvents = {
+    'codex:active-session': ['attention-active-old', 'attention-active-new'],
+    'kimi:tmux-session': ['attention-tmux-old', 'attention-tmux-new'],
+};
+```
+
+Keep each row's `data-session-event-id` fallback attribute so the test also proves that recovered full ownership takes precedence over the single rendered fallback.
+
+- [ ] **Step 2: Strengthen the explicit action expectations**
+
+Replace the Close acknowledgement expectation with:
+
+```js
+{
+    type: 'acknowledge-ai-session-attention',
+    eventIds: ['attention-active-old', 'attention-active-new'],
+}
+```
+
+Replace the Detach acknowledgement expectation with:
+
+```js
+{
+    type: 'acknowledge-ai-session-attention',
+    eventIds: ['attention-tmux-old', 'attention-tmux-new'],
+}
+```
+
+Leave the natural terminal-close contracts unchanged; they must continue to preserve unread attention.
+
+- [ ] **Step 3: Run the safety suite**
+
+Run:
+
+```bash
+npm run test-compile
+node scripts/run-ai-session-safety-checks.js
+```
+
+Expected: pass, proving explicit Close/Detach sends all recovered logical-session events before the lifecycle command.
+
+- [ ] **Step 4: Review and commit the regression protection**
+
+Run:
+
+```bash
+git diff --check
+git diff -- scripts/run-ai-session-safety-checks.js
+```
+
+Then commit:
+
+```bash
+git add scripts/run-ai-session-safety-checks.js
+git commit -m "test: preserve multi-run close acknowledgement"
+```
+
+---
+
+## Task 4: Verify the Local Branch Without Publishing
+
+**Files:**
+
+- Verify only; no expected source edits.
+
+- [ ] **Step 1: Run targeted attention and metadata gates**
+
+```bash
+npm run test-compile
+node --test tests/contract/aiSessions/attention.test.js
+npm run test:behavior-contracts
+npm run test:safety:run
+```
+
+Expected: all commands pass.
+
+- [ ] **Step 2: Run the full Linux CI gate**
+
+```bash
+npm run test:ci:linux
+```
+
+Expected: exit code `0`, including deterministic, safety, dashboard, architecture, packaging, webpack, and coverage checks.
+
+- [ ] **Step 3: Inspect final branch state**
+
+```bash
+git status --short --branch
+git log --oneline --decorate origin/main..HEAD
+git diff --check origin/main...HEAD
+```
+
+Expected:
+
+- branch is `fix/logical-attention-card-count`;
+- worktree is clean;
+- commits contain the design, test contract, minimal fix, and Close/Detach regression protection;
+- no remote push and no PR have been created.
+
+- [ ] **Step 4: Hand off the local worktree**
+
+Report:
+
+- root cause and why CI previously missed composition;
+- exact card-count and event-retention behavior now covered;
+- targeted and full CI results;
+- worktree path and local branch name;
+- confirmation that the branch remains local with no PR.

--- a/docs/superpowers/specs/2026-07-23-logical-attention-card-count-design.md
+++ b/docs/superpowers/specs/2026-07-23-logical-attention-card-count-design.md
@@ -1,0 +1,128 @@
+# Logical Attention Card Count Design
+
+## Context
+
+AI-session attention intentionally retains one event per runtime execution. A
+single logical Session can therefore own multiple unread aggregate entries with
+keys such as:
+
+```text
+codex:<session-id>:<run-started-at-ms>:tmux
+codex:<session-id>:<run-started-at-ms>:vscode
+```
+
+Session-row recovery already normalizes those keys to
+`provider:<session-id>` so one interaction can acknowledge every retained
+event. Card summaries do not perform the same normalization. They count raw
+aggregate entries, so two unread runs of one logical Session render a red
+attention count of `2`.
+
+## Goal
+
+Every Project Steward card must count distinct unread logical AI Sessions while
+retaining every underlying runtime event ID for acknowledgement.
+
+## Required Behavior
+
+- A logical Session is identified by `provider:<session-id>`.
+- A run-scoped key matching
+  `provider:<session-id>:<run-started-at-ms>:<backend>` normalizes to its
+  logical Session key.
+- Multiple unread runs of the same logical Session contribute exactly one card
+  attention count.
+- Every distinct event ID from those runs remains attached to the logical
+  Session summary.
+- CURRENT WORKSPACE, OTHER WINDOWS, and saved-project summaries use the same
+  logical counting rule.
+- Explicit Close or Detach acknowledges all retained event IDs for the logical
+  Session and makes its projected count disappear immediately.
+- A terminal that closes without the explicit Project Steward action continues
+  to preserve unread attention.
+
+## Architecture
+
+Keep the attention bridge and aggregate protocol run-scoped. Runtime identity is
+needed to prevent lifecycle replay and event collisions, so the aggregate must
+not discard or rewrite run keys.
+
+Move the existing run-key normalization helper into the AI-session attention
+domain, where both workspace Session projection and card projection can reuse
+it without a workspace-to-AI-session dependency cycle.
+
+Both project-summary entry points group aggregate records by the normalized
+logical Session key:
+
+- `getAttentionProjectSummaries()` for saved-project projection.
+- `getAttentionSummaryForProjectKeys()` for workspace/card projection.
+
+Each group uses a set for event IDs. The public summary exposes the logical
+Session key, the sorted complete event-ID list, and the first sorted event ID as
+the stable representative. Card count is the number of logical groups.
+
+The acknowledgement controller and bridge protocol remain unchanged. Explicit
+Close and Detach continue to use the recovery map, which already groups every
+retained run event under the logical Session key.
+
+## Data Flow
+
+```text
+runtime completions
+  -> run-scoped attention aggregate entries
+  -> logical Session normalization at projection
+  -> one card count + all event IDs
+  -> explicit Session interaction acknowledges all event IDs
+  -> effective aggregate filters the acknowledged Session
+  -> projected card count becomes zero
+```
+
+## CI Regression Contract
+
+Add an automated behavior contract named
+`ATTENTION-LOGICAL-SESSION-CARD-COUNT-001`.
+
+The focused contract must prove:
+
+1. Two run-scoped aggregate entries for one logical Session produce a project
+   attention count of `1`.
+2. The resulting logical Session summary retains both event IDs.
+3. Workspace attention projection produces a card attention count of `1` for
+   the same aggregate.
+4. Saved-project projection uses the same count.
+5. After both event IDs are acknowledged, projection produces count `0`.
+6. Different logical Session IDs still contribute separate counts.
+
+The existing Webview safety check for explicit Close and Detach must be
+strengthened so a row backed by multiple recovered event IDs emits one
+acknowledgement containing all IDs before the close/detach message.
+
+The new behavior ID is added to the behavior catalog and the existing
+`MAIN-WORKSPACE-ATTENTION` capability, so its owner remains reachable from the
+pull-request deterministic gate.
+
+## Error Handling and Compatibility
+
+- Malformed or unrecognized keys remain unchanged and continue to be treated as
+  distinct opaque Session keys.
+- Empty event IDs remain ignored by the existing summary logic.
+- No bridge protocol, persisted storage, release package, or setting changes
+  are required.
+- Existing event ordering remains deterministic.
+
+## Verification
+
+Use test-driven development:
+
+1. Add the focused behavior contract and run it against the current code to
+   record the expected `2 !== 1` failure.
+2. Apply the projection-only normalization change.
+3. Run the focused contract to green.
+4. Run attention, open-workspace, Webview safety, behavior-catalog, TypeScript,
+   and full Linux CI checks.
+
+## Delivery Constraints
+
+- Work is isolated on branch `fix/logical-attention-card-count` in a worktree
+  created from `origin/main`.
+- The primary checkout and its uncommitted files are not modified.
+- The completed local branch is not pushed and no pull request is opened,
+  because additional bugs may be investigated before publication.

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -104,6 +104,20 @@
     ]
   },
   {
+    "id": "ATTENTION-LOGICAL-SESSION-CARD-COUNT-001",
+    "domain": "attention",
+    "title": "Logical Session Card Attention Count behavior",
+    "priority": "P0",
+    "status": "automated",
+    "owners": [
+      "tests/contract/aiSessions/attention.test.js"
+    ],
+    "evidence": [
+      "src/aiSessions/attentionProject.ts",
+      "src/workspaces/attentionProjection.ts"
+    ]
+  },
+  {
     "id": "PROJECT-FAVORITE-PROJECT-ORDER-001",
     "domain": "project",
     "title": "Favorite Project Order behavior",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -239,6 +239,7 @@
             ],
             "behaviors": [
                 "ATTENTION-ATTENTION-PROJECTION-001",
+                "ATTENTION-LOGICAL-SESSION-CARD-COUNT-001",
                 "ATTENTION-ATTENTION-PROJECT-RENDERING-001"
             ],
             "prGates": [

--- a/scripts/run-ai-session-safety-checks.js
+++ b/scripts/run-ai-session-safety-checks.js
@@ -6453,6 +6453,10 @@ function runBatchAiSessionWebviewChecks() {
     activeRow.setAttribute('data-session-event-id', 'attention-active-session');
     tmuxRow.setAttribute('data-ai-session-attention', '');
     tmuxRow.setAttribute('data-session-event-id', 'attention-tmux-session');
+    context.window.__projectStewardAttentionSessionEvents = {
+        'codex:active-session': ['attention-active-old', 'attention-active-new'],
+        'kimi:tmux-session': ['attention-tmux-old', 'attention-tmux-new'],
+    };
     const detachTmuxTarget = {
         getAttribute: attribute => attribute === 'data-action' ? 'detach-ai-session-terminal' : null,
         closest: selector => {
@@ -6475,14 +6479,16 @@ function runBatchAiSessionWebviewChecks() {
     }, {
         type: 'create-ai-session', projectId: 'project-a',
     }, {
-        type: 'acknowledge-ai-session-attention', eventIds: ['attention-active-session'],
+        type: 'acknowledge-ai-session-attention',
+        eventIds: ['attention-active-old', 'attention-active-new'],
     }, {
         type: 'close-ai-session-terminal', projectId: 'project-a', provider: 'codex', sessionId: 'active-session',
     }, {
         type: 'close-ai-session-terminal', projectId: 'project-a', provider: 'claude',
         pendingCreatedAt: '2026-07-18T08:00:00Z',
     }, {
-        type: 'acknowledge-ai-session-attention', eventIds: ['attention-tmux-session'],
+        type: 'acknowledge-ai-session-attention',
+        eventIds: ['attention-tmux-old', 'attention-tmux-new'],
     }, {
         type: 'detach-ai-session-terminal', projectId: 'project-a', provider: 'kimi',
         sessionId: 'tmux-session',

--- a/src/aiSessions/attentionController.ts
+++ b/src/aiSessions/attentionController.ts
@@ -8,10 +8,9 @@ import type { AttentionPayloadItem } from './attentionPayload';
 import AiSessionAttentionMonitor from './attentionMonitor';
 import type { AiSessionAttentionSnapshot } from './attentionMonitor';
 import type { AiSessionLifecycleRequest, AiSessionLifecycleSignal } from './lifecycle';
-import { getAttentionProjectKeys } from './attentionProject';
+import { getAttentionProjectKeys, getLogicalAttentionSessionKey } from './attentionProject';
 import { getAiSessionKey } from './sessionHelpers';
 import type { WorkspaceAiSessionActionTarget, WorkspaceAiSessionViewModel } from './types';
-import { getLogicalAttentionSessionKey } from '../workspaces/sessionAttention';
 
 export interface AiSessionAttentionRuntimeEntry {
     runStartedAtMs: number;

--- a/src/aiSessions/attentionProject.ts
+++ b/src/aiSessions/attentionProject.ts
@@ -13,6 +13,49 @@ export interface AttentionProjectSummary {
 
 export type AttentionSummary = Pick<AttentionProjectSummary, 'attentionCount' | 'eventIds' | 'sessions'>;
 
+export function getLogicalAttentionSessionKey(sessionKey: string): string {
+    const match = /^(codex|kimi|claude):(.+):\d+:(?:vscode|tmux)$/.exec(sessionKey || '');
+    return match ? `${match[1]}:${match[2]}` : sessionKey;
+}
+
+function summarizeAttentionSessions(
+    sourceSessions: readonly AggregatedAttentionSession[]
+): AttentionSummary {
+    const allEventIds = new Set<string>();
+    const sessionEventIds = new Map<string, Set<string>>();
+    for (const session of sourceSessions) {
+        const sessionKey = getLogicalAttentionSessionKey(session.sessionKey);
+        let events = sessionEventIds.get(sessionKey);
+        if (!events) {
+            events = new Set<string>();
+            sessionEventIds.set(sessionKey, events);
+        }
+        for (const eventId of session.eventIds || []) {
+            if (eventId) {
+                events.add(eventId);
+                allEventIds.add(eventId);
+            }
+        }
+    }
+
+    const sessions = Array.from(sessionEventIds.entries())
+        .map(([sessionKey, events]) => {
+            const eventIds = Array.from(events).sort();
+            return {
+                sessionKey,
+                eventId: eventIds[0] || sessionKey,
+                eventIds,
+            };
+        })
+        .sort((left, right) => left.sessionKey.localeCompare(right.sessionKey));
+
+    return {
+        attentionCount: sessions.length,
+        eventIds: Array.from(allEventIds).sort(),
+        sessions,
+    };
+}
+
 export function getAttentionProjectKey(projectPath: string): string {
     const canonicalPath = normalizeAiSessionComparablePath(projectPath);
     if (!canonicalPath) {
@@ -53,65 +96,26 @@ export function getAttentionSummaryForProjectKeys(
     aggregate: AttentionAggregate | null
 ): AttentionSummary {
     const selectedProjectKeys = new Set((projectKeys || []).filter(Boolean));
-    const eventIds = new Set<string>();
-    const sessionEventIds = new Map<string, Set<string>>();
-    for (const session of aggregate?.sessions || []) {
-        if (!selectedProjectKeys.has(session.projectId)) {
-            continue;
-        }
-        let events = sessionEventIds.get(session.sessionKey);
-        if (!events) {
-            events = new Set<string>();
-            sessionEventIds.set(session.sessionKey, events);
-        }
-        for (const eventId of session.eventIds || []) {
-            if (!eventId) {
-                continue;
-            }
-            events.add(eventId);
-            eventIds.add(eventId);
-        }
-    }
-
-    const sessions = Array.from(sessionEventIds.entries())
-        .map(([sessionKey, events]) => {
-            const sortedEventIds = Array.from(events).sort();
-            return {
-                sessionKey,
-                eventId: sortedEventIds[0] || sessionKey,
-                eventIds: sortedEventIds,
-            };
-        })
-        .sort((left, right) => left.sessionKey.localeCompare(right.sessionKey));
-    return {
-        attentionCount: sessions.length,
-        eventIds: Array.from(eventIds).sort(),
-        sessions,
-    };
+    return summarizeAttentionSessions(
+        (aggregate?.sessions || []).filter(session => selectedProjectKeys.has(session.projectId))
+    );
 }
 
 export function getAttentionProjectSummaries(aggregate: AttentionAggregate | null): AttentionProjectSummary[] {
-    const summaries = new Map<string, AttentionProjectSummary>();
-    for (const item of aggregate?.sessions || []) {
-        let summary = summaries.get(item.projectId);
-        if (!summary) {
-            summary = { projectKey: item.projectId, attentionCount: 0, eventIds: [], sessions: [] };
-            summaries.set(item.projectId, summary);
+    const sessionsByProject = new Map<string, AggregatedAttentionSession[]>();
+    for (const session of aggregate?.sessions || []) {
+        let projectSessions = sessionsByProject.get(session.projectId);
+        if (!projectSessions) {
+            projectSessions = [];
+            sessionsByProject.set(session.projectId, projectSessions);
         }
-        summary.attentionCount += 1;
-        summary.eventIds.push(...item.eventIds);
-        summary.sessions.push({
-            sessionKey: item.sessionKey,
-            eventId: item.eventIds[0] || `${item.sessionKey}:${item.observedAtMs}`,
-            eventIds: item.eventIds.slice().sort(),
-        });
+        projectSessions.push(session);
     }
 
-    return Array.from(summaries.values())
-        .map(summary => ({
-            ...summary,
-            eventIds: summary.eventIds.sort(),
-            sessions: summary.sessions.sort((left, right) => left.sessionKey.localeCompare(right.sessionKey)),
+    return Array.from(sessionsByProject.entries())
+        .map(([projectKey, sessions]) => ({
+            projectKey,
+            ...summarizeAttentionSessions(sessions),
         }))
         .sort((left, right) => left.projectKey.localeCompare(right.projectKey));
 }

--- a/src/workspaces/sessionAttention.ts
+++ b/src/workspaces/sessionAttention.ts
@@ -4,6 +4,7 @@ import type { AttentionAggregate } from '../aiSessions/attentionAggregate';
 import {
     getAttentionProjectKeys,
     getAttentionSessionLookupKey,
+    getLogicalAttentionSessionKey,
 } from '../aiSessions/attentionProject';
 import { getAiSessionKey } from '../aiSessions/sessionHelpers';
 import type { AiSessionViewModel } from '../aiSessions/types';
@@ -15,11 +16,6 @@ type IndexedAttention = NonNullable<AiSessionViewModel['attention']> & {
 };
 
 export type WorkspaceSessionAttentionIndex = ReadonlyMap<string, IndexedAttention>;
-
-export function getLogicalAttentionSessionKey(sessionKey: string): string {
-    const match = /^(codex|kimi|claude):(.+):\d+:(?:vscode|tmux)$/.exec(sessionKey || '');
-    return match ? match[1] + ':' + match[2] : sessionKey;
-}
 
 export function buildWorkspaceSessionAttentionIndex(
     aggregate: AttentionAggregate | null

--- a/tests/contract/aiSessions/attention.test.js
+++ b/tests/contract/aiSessions/attention.test.js
@@ -18,10 +18,12 @@ const {
 } = require('../../../out/aiSessions/attentionController');
 const {
     aggregateAttentionSnapshots,
+    filterAcknowledgedAttentionAggregate,
 } = require('../../../out/aiSessions/attentionAggregate');
 const attentionPayload = require('../../../out/aiSessions/attentionPayload');
 const attentionProject = require('../../../out/aiSessions/attentionProject');
 const lifecycle = require('../../../out/aiSessions/lifecycle');
+const workspaceAttentionProjection = require('../../../out/workspaces/attentionProjection');
 
 const fixturesRoot = path.resolve(__dirname, '../../fixtures/providers');
 
@@ -151,6 +153,103 @@ test('ATTENTION-ATTENTION-PROJECT-001 ATTENTION-ATTENTION-PROJECTION-001 maps ag
             attentionProject.getAttentionSessionLookupKey(projectKey, 'codex:one')
         ).eventIds[0],
         'event-b'
+    );
+});
+
+test('ATTENTION-LOGICAL-SESSION-CARD-COUNT-001 counts logical sessions and retains every run event', () => {
+    const projectPath = 'file:///fixtures/project';
+    const projectKey = attentionProject.getAttentionProjectKey('/fixtures/project');
+    const sameLogicalSessionAggregate = {
+        protocolVersion: 1,
+        aggregateRevision: 'b'.repeat(64),
+        generatedAtMs: 300,
+        sessions: [{
+            projectId: projectKey,
+            sessionKey: 'codex:one:100:tmux',
+            reasons: ['completed'],
+            eventIds: ['event-old'],
+            observedAtMs: 100,
+        }, {
+            projectId: projectKey,
+            sessionKey: 'codex:one:200:vscode',
+            reasons: ['input-required'],
+            eventIds: ['event-new'],
+            observedAtMs: 200,
+        }],
+    };
+
+    const projectSummary = attentionProject.getAttentionProjectSummaries(
+        sameLogicalSessionAggregate
+    )[0];
+    assert.deepEqual(projectSummary, {
+        projectKey,
+        attentionCount: 1,
+        eventIds: ['event-new', 'event-old'],
+        sessions: [{
+            sessionKey: 'codex:one',
+            eventId: 'event-new',
+            eventIds: ['event-new', 'event-old'],
+        }],
+    });
+    assert.equal(
+        attentionProject.getLogicalAttentionSessionKey('codex:one:200:vscode'),
+        'codex:one'
+    );
+    assert.equal(
+        attentionProject.getLogicalAttentionSessionKey('opaque-session-key'),
+        'opaque-session-key'
+    );
+    assert.deepEqual(
+        attentionProject.withAttentionProject(
+            { id: 'project', path: projectPath },
+            sameLogicalSessionAggregate
+        ),
+        {
+            id: 'project',
+            path: projectPath,
+            aiSessionAttentionCount: 1,
+            aiSessionAttentionEventIds: ['event-new', 'event-old'],
+        }
+    );
+    assert.deepEqual(
+        workspaceAttentionProjection.getWorkspaceAttentionSummary({
+            roots: [{ uri: projectPath }],
+        }, sameLogicalSessionAggregate),
+        {
+            attentionCount: 1,
+            eventIds: ['event-new', 'event-old'],
+            sessions: [{
+                sessionKey: 'codex:one',
+                eventId: 'event-new',
+                eventIds: ['event-new', 'event-old'],
+            }],
+        }
+    );
+
+    const acknowledged = filterAcknowledgedAttentionAggregate(
+        sameLogicalSessionAggregate,
+        new Set(['event-old', 'event-new'])
+    );
+    assert.equal(
+        workspaceAttentionProjection.getWorkspaceAttentionSummary({
+            roots: [{ uri: projectPath }],
+        }, acknowledged).attentionCount,
+        0
+    );
+
+    const twoLogicalSessions = {
+        ...sameLogicalSessionAggregate,
+        sessions: sameLogicalSessionAggregate.sessions.concat({
+            projectId: projectKey,
+            sessionKey: 'codex:two:300:tmux',
+            reasons: ['failed'],
+            eventIds: ['event-two'],
+            observedAtMs: 300,
+        }),
+    };
+    assert.equal(
+        attentionProject.getAttentionProjectSummaries(twoLogicalSessions)[0].attentionCount,
+        2
     );
 });
 


### PR DESCRIPTION
## Summary

- count dashboard attention badges by logical AI session instead of run-scoped attention records
- retain all run event IDs so explicit Close/Detach clears every unread event immediately
- add the P0 `ATTENTION-LOGICAL-SESSION-CARD-COUNT-001` CI contract and strengthen multi-run Close/Detach safety coverage
- preserve unread attention for natural terminal closure

## Verification

- `npm run test:ci:linux`
- result: `CI_EXIT_CODE=0`
- local Dev Container installation verified against the packaged VSIX payload

## Release

No version bump, tag, marketplace publish, or release is included.
