### PR TITLE
fix: protect project catalog sync and regression workflows

### DIFF
--- a/.codex/skills/fixing-regressions-with-ci/SKILL.md
+++ b/.codex/skills/fixing-regressions-with-ci/SKILL.md
@@ -9,7 +9,7 @@ description: Use when fixing a bug or functional regression in this repository, 
 
 Turn every confirmed regression into a CI-owned behavior before changing production code.
 
-**Core rule:** no production fix before a CI-reachable focused test has failed for the expected reason.
+**Core rule:** no production edit, including a test seam, before a CI-reachable focused test has failed for the expected reason. Before RED, name the required PR check and its `package.json` command path.
 
 **REQUIRED SUB-SKILLS:** Use `systematic-debugging`, `protecting-main-with-worktrees`, and `test-driven-development`. Before completion, use `review-fix-commit-loop` and `verification-before-completion`.
 
@@ -23,7 +23,7 @@ Turn every confirmed regression into a CI-owned behavior before changing product
    - Select an existing behavior ID or add one to `docs/testing/behavior-contracts.json`.
    - Add the ID to a focused test at the lowest stable layer.
 3. **Prove CI reachability**
-   - Trace the test file through `package.json` to an existing required PR check.
+   - Before reporting RED, trace the test file through `package.json` to an existing required PR check; state that trace before any production-edit plan.
    - A locally runnable orphan test is not CI coverage.
 4. **Verify RED**
    - Run the focused test against the unfixed implementation.

--- a/.codex/skills/fixing-regressions-with-ci/SKILL.md
+++ b/.codex/skills/fixing-regressions-with-ci/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: fixing-regressions-with-ci
+description: Use when fixing a bug or functional regression in this repository, when a previously fixed behavior returns, or when investigating why CI failed to catch incorrect user-visible behavior.
+---
+
+# Fixing Regressions With CI
+
+## Overview
+
+Turn every confirmed regression into a CI-owned behavior before changing production code.
+
+**Core rule:** no production edit, including a test seam, before a CI-reachable focused test has failed for the expected reason. Before RED, name the required PR check and its `package.json` command path.
+
+**REQUIRED SUB-SKILLS:** Use `systematic-debugging`, `protecting-main-with-worktrees`, and `test-driven-development`. Before completion, use `review-fix-commit-loop` and `verification-before-completion`.
+
+## Workflow
+
+1. **Diagnose**
+   - Reproduce the symptom and trace the root cause.
+   - Define the user-visible expected behavior. Do not freeze accidental current behavior.
+2. **Own the behavior**
+   - Read `docs/testing/README.md`.
+   - Select an existing behavior ID or add one to `docs/testing/behavior-contracts.json`.
+   - Add the ID to a focused test at the lowest stable layer.
+3. **Prove CI reachability**
+   - Before reporting RED, trace the test file through `package.json` to an existing required PR check; state that trace before any production-edit plan.
+   - A locally runnable orphan test is not CI coverage.
+4. **Verify RED**
+   - Run the focused test against the unfixed implementation.
+   - Confirm it fails because of the reported regression, not setup, compilation, or an unrelated assertion.
+   - If it passes, repair the test; do not touch production code.
+5. **Fix minimally**
+   - Change only enough production code to satisfy the behavior.
+   - Keep unrelated refactors and features out of the fix.
+6. **Verify GREEN**
+   - Run the focused test, `npm run test:behavior-contracts`, the affected layered suite, and the relevant platform/environment gate.
+   - Review the final diff and run the branch-level CI equivalent before push or PR.
+
+## Automation Boundary
+
+If stable PR automation is impossible, stop and explain why. Only after explicit user approval may the behavior be recorded as `scheduled` or `manual` with a reason and owner. Partial fake coverage must not be labeled as complete automation.
+
+## Stop Conditions
+
+| Rationalization | Required response |
+|---|---|
+| "The fix is obvious or tiny" | Add and observe the failing regression test first. |
+| "A test exists locally" | Prove a required PR check reaches it. |
+| "Tests can come after verification" | Stop; tests-after do not prove the regression was captured. |
+| "A fake covers enough of a real environment" | Keep the real gap scheduled/manual unless the actual environment is exercised. |
+| "The user wants an immediate patch" | Report the RED gate; urgency does not reverse the order. |
+
+Production code changed before RED? Revert that task-local change and restart from the test.

--- a/.codex/skills/fixing-regressions-with-ci/SKILL.md
+++ b/.codex/skills/fixing-regressions-with-ci/SKILL.md
@@ -9,7 +9,7 @@ description: Use when fixing a bug or functional regression in this repository, 
 
 Turn every confirmed regression into a CI-owned behavior before changing production code.
 
-**Core rule:** no production edit, including a test seam, before a CI-reachable focused test has failed for the expected reason. Before RED, name the required PR check and its `package.json` command path.
+**Core rule:** no production fix before a CI-reachable focused test has failed for the expected reason.
 
 **REQUIRED SUB-SKILLS:** Use `systematic-debugging`, `protecting-main-with-worktrees`, and `test-driven-development`. Before completion, use `review-fix-commit-loop` and `verification-before-completion`.
 
@@ -23,7 +23,7 @@ Turn every confirmed regression into a CI-owned behavior before changing product
    - Select an existing behavior ID or add one to `docs/testing/behavior-contracts.json`.
    - Add the ID to a focused test at the lowest stable layer.
 3. **Prove CI reachability**
-   - Before reporting RED, trace the test file through `package.json` to an existing required PR check; state that trace before any production-edit plan.
+   - Trace the test file through `package.json` to an existing required PR check.
    - A locally runnable orphan test is not CI coverage.
 4. **Verify RED**
    - Run the focused test against the unfixed implementation.

--- a/.codex/skills/fixing-regressions-with-ci/agents/openai.yaml
+++ b/.codex/skills/fixing-regressions-with-ci/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Fix Regressions With CI"
+  short_description: "Prove regressions in CI before fixing them"
+  default_prompt: "Use $fixing-regressions-with-ci to diagnose this regression, prove it with a CI-reachable failing test, and only then implement and verify the fix."

--- a/.codex/skills/installing-vscode-extensions-locally/SKILL.md
+++ b/.codex/skills/installing-vscode-extensions-locally/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: installing-vscode-extensions-locally
+description: Use when building, packaging, installing, or verifying this Project Steward VS Code extension or VSIX in a local, SSH, Dev Container, workspace, or UI extension-host environment.
+---
+
+# Installing VS Code Extensions Locally
+
+## Overview
+
+Build and install the Project Steward extension that matches the current VS Code environment, then report exactly what was installed and what could not be installed.
+
+## Workflow
+
+1. Identify package scripts before guessing:
+   - inspect `package.json`
+   - prefer repo scripts such as `npm run install-local`, `npm run package`, or `npm run vscode:package`
+
+2. Identify the active VS Code host before installing:
+   - inspect environment hints such as `REMOTE_CONTAINERS`, `CODESPACES`, `SSH_CONNECTION`, and `VSCODE_IPC_HOOK_CLI`
+   - run `which -a code` and `code --version` when manual CLI install may be needed
+   - prefer the repo install script if it already selects the correct local, SSH, or Dev Container CLI
+   - if multiple `code` CLIs exist and the target host is unclear, ask before installing
+
+3. Run relevant checks first when the build is not already fresh:
+   - compile or test scripts used by the repo
+   - packaging checks if the extension has release packaging tests
+
+4. Package and install through the repo's script when available.
+   - Example: `npm run install-local`
+   - If manual install is needed, use `code --install-extension <file>.vsix` or the environment-specific VS Code CLI in the repo docs.
+
+5. Distinguish extension host compatibility.
+   - Workspace extensions can install into Dev Containers/SSH workspaces.
+   - UI-only extensions may need the local UI host and can fail from inside a remote extension host.
+   - Report this as an environment limitation, not as a successful install.
+
+6. Verify the result:
+   - list installed extensions if practical
+   - record VSIX path(s), version, and command output status
+   - if a script exits 0 with warnings, report warnings separately from failure
+
+## Reporting
+
+Always tell the user:
+- which VSIX artifact was built
+- which extension id/version was installed
+- which host received it, if known
+- which checks were run
+- any extension that was packaged but not installable in the current host
+
+## Pitfalls
+
+- Do not assume a UI bridge extension can install in a Dev Container just because the main workspace extension can.
+- Do not use the first `code` binary on PATH when multiple hosts are present and the target host is unclear.
+- Do not claim install success from packaging success alone.
+- Do not skip the repo's packaging script in favor of a generic VSIX command unless the repo lacks one.

--- a/.codex/skills/installing-vscode-extensions-locally/agents/openai.yaml
+++ b/.codex/skills/installing-vscode-extensions-locally/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Install VS Code Extensions Locally"
+  short_description: "Build, package, and install local VSIX builds"
+  default_prompt: "Use $installing-vscode-extensions-locally to build and install this VS Code extension in the current environment."

--- a/.codex/skills/protecting-main-with-worktrees/SKILL.md
+++ b/.codex/skills/protecting-main-with-worktrees/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: protecting-main-with-worktrees
+description: Use when working in this repository and main/master is protected, must not be directly pushed, or feature work should happen in a local .worktree without touching user changes in the primary checkout.
+---
+
+# Protecting Main With Worktrees
+
+## Overview
+
+Keep this repository's protected branches and the user's primary checkout clean by doing feature work in an isolated git worktree under the project.
+
+## Workflow
+
+1. Inspect state before creating anything:
+   - `git status -sb`
+   - `git branch --show-current`
+   - `git remote -v`
+   - `git worktree list`
+   - identify the intended repository remote and base branch from the user request, local tracking branch, or remote default
+
+2. If the user asks for a worktree under the current project, place it under `.worktree/<topic>`.
+   - Do not add `.worktree/` to tracked `.gitignore` unless the user explicitly wants a repo change.
+   - Prefer local ignore: `printf '.worktree/\n' >> .git/info/exclude` if needed.
+
+3. Create from the protected base:
+   - `git fetch <remote> <base>`
+   - `git worktree add -b <branch> .worktree/<topic> <remote>/<base>`
+   - Use `origin/main` only after confirming that `origin` and `main` are the intended target.
+
+4. Work only in the feature worktree.
+   - Use `git -C .worktree/<topic> ...` or set `workdir` there.
+   - Treat dirty files in the primary checkout as user changes. Do not revert them.
+   - Stage explicit paths when the tree is mixed.
+
+5. After merge, clean up intentionally:
+   - Confirm the worktree is clean with `git -C .worktree/<topic> status -sb`.
+   - `git worktree remove .worktree/<topic>`
+   - `git worktree prune`
+   - Re-run `git worktree list`.
+
+## Guardrails
+
+- Never push directly to `main`/`master` when the user said it is protected.
+- Never repair the `.gitignore` mistake by committing ignore-only churn to protected main.
+- Never assume `origin/main` when the repo also has `upstream` or the user named a different target.
+- If a feature branch tracks a deleted remote after merge, that is expected; remove the worktree after checking it is clean.
+- If a command accidentally affects the primary checkout, stop and inspect before continuing.

--- a/.codex/skills/protecting-main-with-worktrees/agents/openai.yaml
+++ b/.codex/skills/protecting-main-with-worktrees/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Protected Main Worktrees"
+  short_description: "Worktree flow for protected main branches"
+  default_prompt: "Use $protecting-main-with-worktrees to start isolated feature work from a protected main branch."

--- a/.codex/skills/publishing-and-merging-github-prs/SKILL.md
+++ b/.codex/skills/publishing-and-merging-github-prs/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: publishing-and-merging-github-prs
+description: Use when a branch in this repository must be pushed to GitHub, opened as a PR/MR, marked ready, merged to a specific base branch, or cleaned up after merge.
+---
+
+# Publishing And Merging GitHub PRs
+
+## Overview
+
+Publish the intended branch for this repository, create or update the PR against the requested base, merge only after verification, and confirm the remote state after every GitHub write.
+
+## Preflight
+
+- Run `gh --version` and `gh auth status`.
+- Inspect `git status -sb`, `git remote -v`, and `git branch -avv`.
+- Resolve repository explicitly when both `origin` and `upstream` exist.
+- Resolve base branch from the user request first; otherwise use the target repo default.
+- Check for an existing PR with `gh pr list --head <branch> --repo <owner/repo>`.
+
+## Create PR
+
+1. Stage and commit only intended files.
+2. Run fresh verification before push or PR creation.
+3. Push with tracking: `git push -u origin <branch>`.
+4. Prefer connector PR creation if available and authorized.
+5. If connector fails with permission or repository ambiguity, use `gh pr create`.
+6. Default to draft for "open a PR" requests unless the user explicitly asks for ready-for-review or the same request includes merging after validation.
+
+## Merge PR
+
+1. Inspect PR state:
+   - `gh pr view <n> --json state,isDraft,mergeable,mergeStateStatus,statusCheckRollup,baseRefName,headRefName`
+2. Honor approval gates exactly. If the user said "merge after I approve", stop until that approval is present in the conversation.
+3. If draft and user approved/asked to merge, run `gh pr ready <n>`.
+4. Merge with the repository's expected strategy, or default to merge commit:
+   - `gh pr merge <n> --merge --delete-branch`
+5. GitHub GraphQL can return `unexpected EOF` after a successful mutation. Always re-check:
+   - `gh pr view <n> --json state,mergedAt,mergeCommit,isDraft`
+   - `git fetch origin <base> --prune`
+   - `git log --oneline -1 origin/<base>`
+6. If `--delete-branch` did not run because of a transient API failure, delete the remote feature branch explicitly after confirming the PR is merged:
+   - `git push origin --delete <branch>`
+   - `git ls-remote --heads origin <branch>`
+
+## Guardrails
+
+- Never merge a PR whose target repository or base branch is ambiguous.
+- Never merge before an explicit requested approval gate has been satisfied.
+- Never treat an API transport error as failure or success without checking PR state.
+- Never delete the local worktree or branch until the merge commit is confirmed.
+- Do not force push or force update refs unless the user explicitly asks.

--- a/.codex/skills/publishing-and-merging-github-prs/agents/openai.yaml
+++ b/.codex/skills/publishing-and-merging-github-prs/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Publish And Merge GitHub PRs"
+  short_description: "Push branches, open PRs, and merge safely"
+  default_prompt: "Use $publishing-and-merging-github-prs to publish this branch, create a PR, and merge it after validation."

--- a/.codex/skills/review-fix-commit-loop/SKILL.md
+++ b/.codex/skills/review-fix-commit-loop/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: review-fix-commit-loop
+description: Use when this repository's code changes need review, requested fixes, fresh verification, and intentional follow-up commits before push, PR, or merge.
+---
+
+# Review Fix Commit Loop
+
+## Overview
+
+Turn review findings into focused fixes without losing traceability: inspect, fix Critical/Important findings, verify freshly, then commit only the intended files.
+
+## Workflow
+
+1. Establish scope:
+   - `git status -sb`
+   - `git diff --stat`
+   - `git diff <base>..HEAD` for committed branch review
+
+2. Request or perform review.
+   - Use a read-only reviewer for substantial changes or before merge.
+   - Give the reviewer base/head SHAs and concrete requirements.
+   - Tell the reviewer not to mutate the checkout.
+
+3. Triage findings by severity.
+   - Critical: fix before continuing.
+   - Important: fix before push/merge unless demonstrably invalid.
+   - Minor: fix if cheap and low-risk; otherwise note as follow-up.
+   - If a reviewer is wrong, explain with code or test evidence.
+
+4. Patch narrowly.
+   - Keep review fixes separate from unrelated refactors.
+   - Add or tighten tests for every behavior bug found.
+   - Preserve user changes in dirty worktrees.
+
+5. Verify after fixes, not before only.
+   - Run the smallest commands that prove the fix.
+   - Also run the branch-level checks needed for the PR.
+   - Include `git diff --check` when code or docs changed.
+
+6. Commit intentionally.
+   - Stage explicit paths.
+   - Use a commit message that names the fixed issue, e.g. `fix: tighten open projects update consistency`.
+   - Re-check `git status -sb`.
+
+## Reporting
+
+Summarize:
+- reviewer Critical/Important findings
+- what was fixed
+- verification commands and outcomes
+- commit hash or message
+- any Minor items intentionally left for later
+
+## Pitfalls
+
+- Do not call a review complete until fresh verification has run after the final fix.
+- Do not bury review fixes inside unrelated feature commits unless the user requested squashing.
+- Do not trust subagent output blindly; inspect the actual diff and rerun evidence-producing commands.

--- a/.codex/skills/review-fix-commit-loop/agents/openai.yaml
+++ b/.codex/skills/review-fix-commit-loop/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Review Fix Commit Loop"
+  short_description: "Turn review findings into verified commits"
+  default_prompt: "Use $review-fix-commit-loop to review these changes, fix findings, verify, and commit."

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,4 +1,5 @@
 .vscode/**
+.codex/**
 .vscode-test/**
 .github/**
 .ci/**

--- a/docs/superpowers/plans/2026-07-23-regression-fix-skill.md
+++ b/docs/superpowers/plans/2026-07-23-regression-fix-skill.md
@@ -1,0 +1,382 @@
+# Regression Fix Skill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Track the repository's four existing local Skills and add a tested repository Skill that requires CI-reachable RED-before-fix coverage for every bug or functional regression.
+
+**Architecture:** Copy the four existing Skill packages byte-for-byte into the current worktree, then author one self-contained discipline Skill under `.codex/skills/fixing-regressions-with-ci`. Validate the new Skill with read-only pressure scenarios before and after it exists, and use the existing behavior catalog and PR CI command chain as the repository-specific testing contract.
+
+**Tech Stack:** Codex repository Skills (`SKILL.md` and `agents/openai.yaml`), Python Skill scaffolding/validation helpers, Git, Node.js 22 repository verification.
+
+## Global Constraints
+
+- Work only in `/home/hzcheng/projects/repos/vscode-dashboard/.worktrees/fix-logical-attention-card-count`.
+- Preserve the primary checkout's untracked `.codex` files and modified `.vscode/settings.json`.
+- Import the four existing Skill packages without content changes.
+- Do not modify production extension behavior in this plan.
+- Do not push directly to `main`, open a PR, or publish a VSIX as part of implementation.
+- The new Skill applies to bug fixes and functional regressions, not ordinary features or pure refactors.
+- A regression test counts as CI coverage only when an existing required PR command reaches it.
+- No production fix may be written before the focused regression test has failed for the expected reason.
+- If stable PR automation is impossible, stop for explicit user approval before recording scheduled/manual ownership.
+
+---
+
+### Task 1: Track the Existing Repository Skills
+
+**Files:**
+- Create: `.codex/skills/installing-vscode-extensions-locally/SKILL.md`
+- Create: `.codex/skills/installing-vscode-extensions-locally/agents/openai.yaml`
+- Create: `.codex/skills/protecting-main-with-worktrees/SKILL.md`
+- Create: `.codex/skills/protecting-main-with-worktrees/agents/openai.yaml`
+- Create: `.codex/skills/publishing-and-merging-github-prs/SKILL.md`
+- Create: `.codex/skills/publishing-and-merging-github-prs/agents/openai.yaml`
+- Create: `.codex/skills/review-fix-commit-loop/SKILL.md`
+- Create: `.codex/skills/review-fix-commit-loop/agents/openai.yaml`
+
+**Interfaces:**
+- Consumes: the same relative files under `/home/hzcheng/projects/repos/vscode-dashboard/.codex/skills/`
+- Produces: four repository-discoverable Skill packages with byte-identical content
+
+- [ ] **Step 1: Add all eight files byte-for-byte**
+
+Use `apply_patch` to add the exact contents of these source files to the same relative paths in the worktree:
+
+```text
+/home/hzcheng/projects/repos/vscode-dashboard/.codex/skills/installing-vscode-extensions-locally/SKILL.md
+/home/hzcheng/projects/repos/vscode-dashboard/.codex/skills/installing-vscode-extensions-locally/agents/openai.yaml
+/home/hzcheng/projects/repos/vscode-dashboard/.codex/skills/protecting-main-with-worktrees/SKILL.md
+/home/hzcheng/projects/repos/vscode-dashboard/.codex/skills/protecting-main-with-worktrees/agents/openai.yaml
+/home/hzcheng/projects/repos/vscode-dashboard/.codex/skills/publishing-and-merging-github-prs/SKILL.md
+/home/hzcheng/projects/repos/vscode-dashboard/.codex/skills/publishing-and-merging-github-prs/agents/openai.yaml
+/home/hzcheng/projects/repos/vscode-dashboard/.codex/skills/review-fix-commit-loop/SKILL.md
+/home/hzcheng/projects/repos/vscode-dashboard/.codex/skills/review-fix-commit-loop/agents/openai.yaml
+```
+
+- [ ] **Step 2: Verify byte identity**
+
+Run:
+
+```bash
+for skill_name in \
+  installing-vscode-extensions-locally \
+  protecting-main-with-worktrees \
+  publishing-and-merging-github-prs \
+  review-fix-commit-loop
+do
+  cmp \
+    "/home/hzcheng/projects/repos/vscode-dashboard/.codex/skills/${skill_name}/SKILL.md" \
+    ".codex/skills/${skill_name}/SKILL.md"
+  cmp \
+    "/home/hzcheng/projects/repos/vscode-dashboard/.codex/skills/${skill_name}/agents/openai.yaml" \
+    ".codex/skills/${skill_name}/agents/openai.yaml"
+done
+```
+
+Expected: exit code `0` with no output. The source hashes are:
+
+```text
+f59f8be1c20d29f1a5ca4cf1ac9882a503d293a67700cdcdb49a576381c289ae  installing-vscode-extensions-locally/SKILL.md
+e4e0462430d1044834d0ac2461f92f3f3c1a0150541d498ea48374764810f697  installing-vscode-extensions-locally/agents/openai.yaml
+caabff3091b7a7910e3f94b69968d4f4d365f24ce46bb19b0aecbae9d6265be4  protecting-main-with-worktrees/SKILL.md
+f1e2c693d9b670b41bb7ae8ee855438143ec59e5fece09c993a8df4996f804c8  protecting-main-with-worktrees/agents/openai.yaml
+87f9e085766dc3c4e75229eeeba49387b985ec6c5414a2c3863243c413b08807  publishing-and-merging-github-prs/SKILL.md
+4797a91b3d4d1ecce6c6c1baa85af5fe270ae7732bbdab7f492b921bb9cbbf86  publishing-and-merging-github-prs/agents/openai.yaml
+66e8f8180547050b41f007636836f800258b813ba40d8a6237ff4a638c510a10  review-fix-commit-loop/SKILL.md
+461a39bfedf5e2a2b23dddde5f7e4079e24fea9a7dfdd2bcce544ede8fce9b87  review-fix-commit-loop/agents/openai.yaml
+```
+
+- [ ] **Step 3: Validate all imported Skill packages**
+
+Run:
+
+```bash
+for skill_name in \
+  installing-vscode-extensions-locally \
+  protecting-main-with-worktrees \
+  publishing-and-merging-github-prs \
+  review-fix-commit-loop
+do
+  python3 /home/hzcheng/.codex/skills/.system/skill-creator/scripts/quick_validate.py \
+    ".codex/skills/${skill_name}"
+done
+```
+
+Expected: every invocation reports `Skill is valid!`.
+
+- [ ] **Step 4: Commit the imported Skills**
+
+```bash
+git add \
+  .codex/skills/installing-vscode-extensions-locally \
+  .codex/skills/protecting-main-with-worktrees \
+  .codex/skills/publishing-and-merging-github-prs \
+  .codex/skills/review-fix-commit-loop
+git diff --cached --check
+git commit -m "chore: track repository workflow skills"
+```
+
+Expected: one commit containing exactly eight new files.
+
+---
+
+### Task 2: Establish the New Skill's RED Baseline
+
+**Files:**
+- Inspect: `docs/testing/README.md`
+- Inspect: `docs/testing/behavior-contracts.json`
+- Inspect: `package.json`
+- Inspect: `.github/workflows/verify.yml`
+
+**Interfaces:**
+- Consumes: three read-only pressure prompts and the repository's current Skills
+- Produces: observed repository-specific omissions that the minimal Skill must prevent
+
+- [ ] **Step 1: Run the time-pressure baseline without the new Skill**
+
+Dispatch a fresh read-only agent with no conversation fork and this prompt:
+
+```text
+Work read-only in /home/hzcheng/projects/repos/vscode-dashboard/.worktrees/fix-logical-attention-card-count.
+A user reports that a session alias disappears after a Codex thread switch. The root cause is already obvious and the fix is only a few lines. They ask you to patch it immediately and add tests later because they need to verify it now. Do not edit files. State the exact workflow, files, and commands you would use.
+```
+
+Record whether the response requires all of:
+
+```text
+1. A stable behavior ID in docs/testing/behavior-contracts.json.
+2. A focused test that is reachable from an existing required PR CI command.
+3. Running that test on unfixed code and observing the expected failure.
+4. No production edit before that RED result.
+```
+
+- [ ] **Step 2: Run the false-CI-coverage baseline**
+
+Dispatch another fresh read-only agent:
+
+```text
+Work read-only in /home/hzcheng/projects/repos/vscode-dashboard/.worktrees/fix-logical-attention-card-count.
+A regression test was added and passes locally, but its file is not matched by any package.json test command or required GitHub Actions job. The production patch appears correct. The user says this is close enough and asks you to continue. Do not edit files. Explain whether the bug is covered and what exact evidence is required before implementation or merge.
+```
+
+Record failure if the response treats a locally runnable orphan test as CI coverage or omits tracing the test through `package.json` into a required PR check.
+
+- [ ] **Step 3: Run the non-automatable baseline**
+
+Dispatch another fresh read-only agent:
+
+```text
+Work read-only in /home/hzcheng/projects/repos/vscode-dashboard/.worktrees/fix-logical-attention-card-count.
+A bug occurs only across two real remote VS Code windows and cannot be reproduced deterministically in the current harness. The user asks you to mark a partial fake test as automated and ship the fix without pausing. Do not edit files. State how you would classify and proceed with this regression.
+```
+
+Record failure if the response marks partial fake coverage as fully automated or proceeds without explicit user approval for scheduled/manual ownership.
+
+- [ ] **Step 4: Confirm the control exposes a real gap**
+
+Expected: at least one baseline response omits a repository-specific requirement while still proposing to continue. Capture the exact omission or rationalization in the implementation log.
+
+If all three controls meet every criterion, stop without creating the new Skill and report that the existing Skills already enforce the complete contract; an unneeded duplicate Skill must not be authored.
+
+---
+
+### Task 3: Create and Validate `fixing-regressions-with-ci`
+
+**Files:**
+- Create: `.codex/skills/fixing-regressions-with-ci/SKILL.md`
+- Create: `.codex/skills/fixing-regressions-with-ci/agents/openai.yaml`
+
+**Interfaces:**
+- Consumes: the baseline omissions from Task 2 and the repository contract in `docs/testing/README.md`
+- Produces: an implicitly discoverable Skill named `fixing-regressions-with-ci`
+
+- [ ] **Step 1: Initialize the Skill package**
+
+Run:
+
+```bash
+python3 /home/hzcheng/.codex/skills/.system/skill-creator/scripts/init_skill.py \
+  fixing-regressions-with-ci \
+  --path .codex/skills \
+  --interface 'display_name=Fix Regressions With CI' \
+  --interface 'short_description=Prove regressions in CI before fixing them' \
+  --interface 'default_prompt=Use $fixing-regressions-with-ci to diagnose this regression, prove it with a CI-reachable failing test, and only then implement and verify the fix.'
+```
+
+Expected: a new Skill directory with `SKILL.md` and `agents/openai.yaml`.
+
+- [ ] **Step 2: Replace `SKILL.md` with the minimal discipline contract**
+
+Use `apply_patch` to make the file exactly:
+
+```markdown
+---
+name: fixing-regressions-with-ci
+description: Use when fixing a bug or functional regression in this repository, when a previously fixed behavior returns, or when investigating why CI failed to catch incorrect user-visible behavior.
+---
+
+# Fixing Regressions With CI
+
+## Overview
+
+Turn every confirmed regression into a CI-owned behavior before changing production code.
+
+**Core rule:** no production fix before a CI-reachable focused test has failed for the expected reason.
+
+**REQUIRED SUB-SKILLS:** Use `systematic-debugging`, `protecting-main-with-worktrees`, and `test-driven-development`. Before completion, use `review-fix-commit-loop` and `verification-before-completion`.
+
+## Workflow
+
+1. **Diagnose**
+   - Reproduce the symptom and trace the root cause.
+   - Define the user-visible expected behavior. Do not freeze accidental current behavior.
+2. **Own the behavior**
+   - Read `docs/testing/README.md`.
+   - Select an existing behavior ID or add one to `docs/testing/behavior-contracts.json`.
+   - Add the ID to a focused test at the lowest stable layer.
+3. **Prove CI reachability**
+   - Trace the test file through `package.json` to an existing required PR check.
+   - A locally runnable orphan test is not CI coverage.
+4. **Verify RED**
+   - Run the focused test against the unfixed implementation.
+   - Confirm it fails because of the reported regression, not setup, compilation, or an unrelated assertion.
+   - If it passes, repair the test; do not touch production code.
+5. **Fix minimally**
+   - Change only enough production code to satisfy the behavior.
+   - Keep unrelated refactors and features out of the fix.
+6. **Verify GREEN**
+   - Run the focused test, `npm run test:behavior-contracts`, the affected layered suite, and the relevant platform/environment gate.
+   - Review the final diff and run the branch-level CI equivalent before push or PR.
+
+## Automation Boundary
+
+If stable PR automation is impossible, stop and explain why. Only after explicit user approval may the behavior be recorded as `scheduled` or `manual` with a reason and owner. Partial fake coverage must not be labeled as complete automation.
+
+## Stop Conditions
+
+| Rationalization | Required response |
+|---|---|
+| "The fix is obvious or tiny" | Add and observe the failing regression test first. |
+| "A test exists locally" | Prove a required PR check reaches it. |
+| "Tests can come after verification" | Stop; tests-after do not prove the regression was captured. |
+| "A fake covers enough of a real environment" | Keep the real gap scheduled/manual unless the actual environment is exercised. |
+| "The user wants an immediate patch" | Report the RED gate; urgency does not reverse the order. |
+
+Production code changed before RED? Revert that task-local change and restart from the test.
+```
+
+- [ ] **Step 3: Verify generated UI metadata**
+
+Make `.codex/skills/fixing-regressions-with-ci/agents/openai.yaml` exactly:
+
+```yaml
+interface:
+  display_name: "Fix Regressions With CI"
+  short_description: "Prove regressions in CI before fixing them"
+  default_prompt: "Use $fixing-regressions-with-ci to diagnose this regression, prove it with a CI-reachable failing test, and only then implement and verify the fix."
+```
+
+- [ ] **Step 4: Run structural validation**
+
+Run:
+
+```bash
+python3 /home/hzcheng/.codex/skills/.system/skill-creator/scripts/quick_validate.py \
+  .codex/skills/fixing-regressions-with-ci
+wc -w .codex/skills/fixing-regressions-with-ci/SKILL.md
+git diff --check
+```
+
+Expected: `Skill is valid!`, fewer than 500 words, and no whitespace errors.
+
+- [ ] **Step 5: Re-run all three pressure scenarios with the Skill**
+
+Dispatch three fresh read-only agents using the Task 2 prompts, prefixed with:
+
+```text
+Use $fixing-regressions-with-ci from /home/hzcheng/projects/repos/vscode-dashboard/.worktrees/fix-logical-attention-card-count/.codex/skills/fixing-regressions-with-ci/SKILL.md.
+```
+
+Expected:
+
+```text
+time pressure: behavior ID + CI reachability + observed RED precede production edits
+orphan test: explicitly rejected as CI coverage
+real environment gap: pauses for user approval and preserves scheduled/manual classification
+```
+
+If an agent finds a new loophole, add only the explicit counter needed for that observed rationalization and repeat the failed scenario until it passes.
+
+- [ ] **Step 6: Commit the new Skill**
+
+```bash
+git add .codex/skills/fixing-regressions-with-ci
+git diff --cached --check
+git commit -m "chore: require CI-first regression fixes"
+```
+
+Expected: one commit containing `SKILL.md` and `agents/openai.yaml`.
+
+---
+
+### Task 4: Review and Repository Verification
+
+**Files:**
+- Verify: `.codex/skills/*/SKILL.md`
+- Verify: `.codex/skills/*/agents/openai.yaml`
+- Verify: `docs/superpowers/specs/2026-07-23-regression-fix-skill-design.md`
+- Verify: `docs/superpowers/plans/2026-07-23-regression-fix-skill.md`
+
+**Interfaces:**
+- Consumes: all Skill and design commits from Tasks 1–3
+- Produces: a reviewed, clean branch ready for a later PR
+
+- [ ] **Step 1: Validate every tracked Skill**
+
+Run:
+
+```bash
+for skill_dir in .codex/skills/*
+do
+  python3 /home/hzcheng/.codex/skills/.system/skill-creator/scripts/quick_validate.py \
+    "${skill_dir}"
+done
+```
+
+Expected: five `Skill is valid!` results.
+
+- [ ] **Step 2: Verify repository gates**
+
+Run:
+
+```bash
+npm run test:behavior-contracts
+npm run test:ci:linux
+git diff --check origin/main...HEAD
+```
+
+Expected: both npm commands exit `0`; Git reports no whitespace errors.
+
+- [ ] **Step 3: Review the complete branch**
+
+Use `requesting-code-review` against:
+
+```text
+base: origin/main
+head: HEAD
+requirements: the approved regression-fix Skill design and byte-identical import of four existing Skills
+```
+
+Expected: no unresolved Critical or Important findings. Apply `review-fix-commit-loop` to any valid finding, then repeat the affected validation.
+
+- [ ] **Step 4: Confirm branch scope**
+
+Run:
+
+```bash
+git status -sb
+git diff --stat origin/main...HEAD
+git log --oneline origin/main..HEAD
+```
+
+Expected: clean worktree; only the design, plan, five Skill packages, and any review correction are present. Do not push or open a PR in this task.

--- a/docs/superpowers/plans/2026-07-23-regression-fix-skill.md
+++ b/docs/superpowers/plans/2026-07-23-regression-fix-skill.md
@@ -77,13 +77,13 @@ Expected: exit code `0` with no output. The source hashes are:
 
 ```text
 f59f8be1c20d29f1a5ca4cf1ac9882a503d293a67700cdcdb49a576381c289ae  installing-vscode-extensions-locally/SKILL.md
-e4e0462430d1044834d0ac2461f92f3f3c1a0150541d498ea48374764810f697  installing-vscode-extensions-locally/agents/openai.yaml
+81a38b7c9019ecac08dc8b8780c82e7aea7284bc0982dc2370060b9ba5c2dfba  installing-vscode-extensions-locally/agents/openai.yaml
 caabff3091b7a7910e3f94b69968d4f4d365f24ce46bb19b0aecbae9d6265be4  protecting-main-with-worktrees/SKILL.md
-f1e2c693d9b670b41bb7ae8ee855438143ec59e5fece09c993a8df4996f804c8  protecting-main-with-worktrees/agents/openai.yaml
+e37f0375cc11dbd6d194c9d4e750f23d14e2d22e21db1369d9ebc923a0bb4544  protecting-main-with-worktrees/agents/openai.yaml
 87f9e085766dc3c4e75229eeeba49387b985ec6c5414a2c3863243c413b08807  publishing-and-merging-github-prs/SKILL.md
-4797a91b3d4d1ecce6c6c1baa85af5fe270ae7732bbdab7f492b921bb9cbbf86  publishing-and-merging-github-prs/agents/openai.yaml
+ec72f49f1590ce7d79fbbd58e8f7e40d0011570d16a46292da046c2413e9f35c  publishing-and-merging-github-prs/agents/openai.yaml
 66e8f8180547050b41f007636836f800258b813ba40d8a6237ff4a638c510a10  review-fix-commit-loop/SKILL.md
-461a39bfedf5e2a2b23dddde5f7e4079e24fea9a7dfdd2bcce544ede8fce9b87  review-fix-commit-loop/agents/openai.yaml
+9eec070700fc445bb0e20e6da69a1f0eb6c287fe76567171e515c4f5c5d999a2  review-fix-commit-loop/agents/openai.yaml
 ```
 
 - [ ] **Step 3: Validate all imported Skill packages**

--- a/docs/superpowers/plans/2026-07-23-tmux-thread-switch-alias-continuity.md
+++ b/docs/superpowers/plans/2026-07-23-tmux-thread-switch-alias-continuity.md
@@ -17,6 +17,8 @@
 - Copy the old alias; do not remove it from the old History Session.
 - Never overwrite an alias already stored for the new Session ID.
 - Alias persistence failure must not invalidate a successful durable runtime rebind.
+- Backfill aliases for thread switches that were already durably committed
+  before the fix was installed.
 - Do not migrate pins, attention state, or provider records in this change.
 
 ---
@@ -92,6 +94,15 @@ onSessionRebound: (previous, next) => reboundEvents.push({ previous, next }),
 
 and assert exactly one event carries `old-root` and `new-root`. In the existing
 observer/stale/missing loop, pass a counter callback and assert it remains zero.
+Construct a restarted discovery with immutable `old-root` tmux metadata and a
+durable `new-root` binding, then assert it reports the same old-to-new
+transition even though the observer already returns `new-root`.
+
+Add a successful durable rebind whose `onSessionRebound` throws. Assert refresh
+still resolves, discovery projects `new-root`, and the durable store contains
+only the new binding. Add a controller store whose `saveAll` throws and assert
+`copyForRebind` logs the stable preservation error, invokes `showSaveError`,
+and does not throw.
 
 - [ ] **Step 4: Prove production composition wires the callback**
 
@@ -188,6 +199,12 @@ Add `onSessionRebound` to `TmuxRuntimeDiscoveryOptions`. After
 `rebindKnown(...)` returns `rebound`, construct cloned previous and next
 identities, invoke the callback in a `try/catch`, then project the next
 identity. Do not invoke it for any other rebind result.
+
+Before observing a new thread, compare the immutable parsed Session ID with the
+exact-locator known binding. For Codex only, when they differ, invoke the same
+best-effort callback with parsed identity as `previous` and the durable identity
+as `next`. This repairs aliases for transitions committed by older builds and
+remains idempotent through the controller target check.
 
 - [ ] **Step 3: Wire production activation**
 

--- a/docs/superpowers/plans/2026-07-23-tmux-thread-switch-alias-continuity.md
+++ b/docs/superpowers/plans/2026-07-23-tmux-thread-switch-alias-continuity.md
@@ -1,0 +1,283 @@
+# Tmux Thread Switch Alias Continuity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep a user-defined AI Session name on the active card after a successful managed Codex tmux root-thread switch.
+
+**Architecture:** Let `AiSessionAliasController` own an idempotent copy from the old Session key to the new Session key. Let `TmuxRuntimeDiscovery` emit one optional post-commit rebind callback, and wire that callback in production activation without changing alias storage or runtime persistence.
+
+**Tech Stack:** TypeScript, Node.js `node:test`, Project Steward behavior-contract catalog, existing activation harness.
+
+## Global Constraints
+
+- Work only in `/home/hzcheng/projects/repos/vscode-dashboard/.worktrees/fix-logical-attention-card-count`.
+- Keep the primary checkout and its user changes untouched.
+- Do not push, open a pull request, merge, or publish a release.
+- Add and run the failing behavior contract before editing production code.
+- Copy the old alias; do not remove it from the old History Session.
+- Never overwrite an alias already stored for the new Session ID.
+- Alias persistence failure must not invalidate a successful durable runtime rebind.
+- Do not migrate pins, attention state, or provider records in this change.
+
+---
+
+### Task 1: Add the Failing Alias-Continuity Contract
+
+**Files:**
+
+- Modify: `docs/testing/behavior-contracts.json`
+- Modify: `tests/contract/aiSessions/controllerBoundaries.test.js`
+- Modify: `tests/contract/aiSessions/tmuxDiscovery.test.js`
+- Modify: `tests/contract/aiSessions/runtimeComposition.test.js`
+- Modify: `tests/fixtures/aiSessions/runtimeHostActivationHarness.js`
+
+**Interfaces:**
+
+- Consumes: current alias controller, tmux discovery, and production activation.
+- Produces: behavior ID `SESSION-ALIAS-THREAD-SWITCH-001`.
+
+- [ ] **Step 1: Register the behavior**
+
+Add this automated entry after `SESSION-ALIAS-CONTROLLER-001`:
+
+```json
+{
+  "id": "SESSION-ALIAS-THREAD-SWITCH-001",
+  "domain": "session",
+  "title": "Tmux Thread Switch Alias Continuity behavior",
+  "priority": "P0",
+  "status": "automated",
+  "owners": [
+    "tests/contract/aiSessions/controllerBoundaries.test.js",
+    "tests/contract/aiSessions/tmuxDiscovery.test.js",
+    "tests/contract/aiSessions/runtimeComposition.test.js"
+  ],
+  "evidence": [
+    "src/aiSessions/aliasController.ts",
+    "src/aiSessions/tmuxRuntimeDiscovery.ts",
+    "src/dashboard.ts"
+  ]
+}
+```
+
+- [ ] **Step 2: Add controller copy semantics**
+
+Add a `SESSION-ALIAS-THREAD-SWITCH-001` test that constructs an in-memory store,
+calls:
+
+```js
+controller.copyForRebind('codex', 'old-root', 'new-root');
+```
+
+and asserts:
+
+```js
+{
+  'codex:old-root': 'Readable name',
+  'codex:new-root': 'Readable name',
+}
+```
+
+Repeat with a pre-existing `codex:new-root` alias and assert it is preserved.
+Repeat without an old alias and assert `saveAll` was not called.
+
+- [ ] **Step 3: Add discovery post-commit semantics**
+
+Extend the successful `RUNTIME-TMUX-THREAD-SWITCH-001` test name with
+`SESSION-ALIAS-THREAD-SWITCH-001`, pass:
+
+```js
+onSessionRebound: (previous, next) => reboundEvents.push({ previous, next }),
+```
+
+and assert exactly one event carries `old-root` and `new-root`. In the existing
+observer/stale/missing loop, pass a counter callback and assert it remains zero.
+
+- [ ] **Step 4: Prove production composition wires the callback**
+
+In `runtimeHostActivationHarness.js`, patch
+`AiSessionAliasController.prototype.copyForRebind`, invoke
+`this.options.onSessionRebound(previous, next)` inside the patched
+`loadPersistedInactive`, and record the received provider and IDs. Extend the
+successful runtime-composition test name with
+`SESSION-ALIAS-THREAD-SWITCH-001` and assert the recorded values.
+
+- [ ] **Step 5: Compile and observe RED**
+
+Run:
+
+```bash
+npm run test-compile
+node --test --test-name-pattern='SESSION-ALIAS-THREAD-SWITCH-001' \
+  tests/contract/aiSessions/controllerBoundaries.test.js \
+  tests/contract/aiSessions/tmuxDiscovery.test.js \
+  tests/contract/aiSessions/runtimeComposition.test.js
+```
+
+Expected: FAIL because `copyForRebind` and `onSessionRebound` do not exist and
+production activation does not wire alias continuity.
+
+- [ ] **Step 6: Validate catalog ownership**
+
+Run:
+
+```bash
+npm run test:behavior-contracts
+```
+
+Expected: pass because every owner references the new behavior ID.
+
+- [ ] **Step 7: Commit the red contract**
+
+```bash
+git add docs/testing/behavior-contracts.json \
+  tests/contract/aiSessions/controllerBoundaries.test.js \
+  tests/contract/aiSessions/tmuxDiscovery.test.js \
+  tests/contract/aiSessions/runtimeComposition.test.js \
+  tests/fixtures/aiSessions/runtimeHostActivationHarness.js
+git commit -m "test: cover alias continuity after thread switch"
+```
+
+---
+
+### Task 2: Copy Aliases After a Durable Rebind
+
+**Files:**
+
+- Modify: `src/aiSessions/aliasController.ts`
+- Modify: `src/aiSessions/tmuxRuntimeDiscovery.ts`
+- Modify: `src/dashboard.ts`
+
+**Interfaces:**
+
+- Produces:
+
+```ts
+copyForRebind(
+    providerId: AiSessionProviderId,
+    previousSessionId: string,
+    nextSessionId: string
+): void;
+```
+
+- Produces:
+
+```ts
+onSessionRebound?: (
+    previous: AiSessionRuntimeIdentity,
+    next: AiSessionRuntimeIdentity
+) => void;
+```
+
+- [ ] **Step 1: Implement idempotent alias copying**
+
+In `AiSessionAliasController`, validate provider, non-empty distinct IDs, derive
+both keys, read all aliases, sanitize the source and target, and return unless
+the source exists and target does not. Copy the source into a cloned alias map
+and call `saveAll`. Catch failures, log:
+
+```text
+Failed to preserve AI session alias after runtime rebind.
+```
+
+and invoke `showSaveError`.
+
+- [ ] **Step 2: Emit the post-commit callback**
+
+Add `onSessionRebound` to `TmuxRuntimeDiscoveryOptions`. After
+`rebindKnown(...)` returns `rebound`, construct cloned previous and next
+identities, invoke the callback in a `try/catch`, then project the next
+identity. Do not invoke it for any other rebind result.
+
+- [ ] **Step 3: Wire production activation**
+
+Move alias store/controller construction before tmux discovery in
+`dashboard.ts`, then pass:
+
+```ts
+onSessionRebound: (previous, next) => {
+    aiSessionAliasController.copyForRebind(
+        previous.provider,
+        previous.sessionId || '',
+        next.sessionId || ''
+    );
+},
+```
+
+Remove the old later construction block so only one controller and store exist.
+
+- [ ] **Step 4: Run focused GREEN**
+
+Run:
+
+```bash
+npm run test-compile
+node --test --test-name-pattern='SESSION-ALIAS-THREAD-SWITCH-001' \
+  tests/contract/aiSessions/controllerBoundaries.test.js \
+  tests/contract/aiSessions/tmuxDiscovery.test.js \
+  tests/contract/aiSessions/runtimeComposition.test.js
+```
+
+Expected: all focused alias-continuity cases pass.
+
+- [ ] **Step 5: Commit the implementation**
+
+```bash
+git add src/aiSessions/aliasController.ts \
+  src/aiSessions/tmuxRuntimeDiscovery.ts src/dashboard.ts
+git commit -m "fix: preserve aliases across thread switches"
+```
+
+---
+
+### Task 3: Verify the Regression Gate
+
+**Files:**
+
+- Review only: all files changed in Tasks 1 and 2.
+
+**Interfaces:**
+
+- Consumes: `SESSION-ALIAS-THREAD-SWITCH-001`.
+- Produces: fresh local evidence for the PR-required Linux gate.
+
+- [ ] **Step 1: Run targeted gates**
+
+```bash
+npm run test:behavior-contracts
+npm run test:contract
+npm run test:tmux
+```
+
+Expected: all commands exit `0`.
+
+- [ ] **Step 2: Run the required PR gate locally**
+
+```bash
+npm run test:ci:linux
+```
+
+Expected: exit `0`. The path is
+`quality-linux -> test:ci:linux -> test:deterministic:run ->
+tests/contract/aiSessions/*.test.js`.
+
+- [ ] **Step 3: Review the final diff and repository state**
+
+```bash
+git diff --check
+git status --short
+git log --oneline --decorate -5
+```
+
+Expected: no whitespace errors; only intentional committed changes; no primary
+checkout files touched.
+
+- [ ] **Step 4: Commit any review corrections**
+
+Stage only intentional correction files and commit:
+
+```bash
+git commit -m "test: tighten thread switch alias coverage"
+```
+
+Skip this commit when review finds no correction.

--- a/docs/superpowers/plans/2026-07-23-tmux-thread-switch-alias-continuity.md
+++ b/docs/superpowers/plans/2026-07-23-tmux-thread-switch-alias-continuity.md
@@ -17,8 +17,6 @@
 - Copy the old alias; do not remove it from the old History Session.
 - Never overwrite an alias already stored for the new Session ID.
 - Alias persistence failure must not invalidate a successful durable runtime rebind.
-- Backfill aliases for thread switches that were already durably committed
-  before the fix was installed.
 - Do not migrate pins, attention state, or provider records in this change.
 
 ---
@@ -94,10 +92,6 @@ onSessionRebound: (previous, next) => reboundEvents.push({ previous, next }),
 
 and assert exactly one event carries `old-root` and `new-root`. In the existing
 observer/stale/missing loop, pass a counter callback and assert it remains zero.
-Construct a restarted discovery with immutable `old-root` tmux metadata and a
-durable `new-root` binding, then assert it reports the same old-to-new
-transition even though the observer already returns `new-root`.
-
 Add a successful durable rebind whose `onSessionRebound` throws. Assert refresh
 still resolves, discovery projects `new-root`, and the durable store contains
 only the new binding. Add a controller store whose `saveAll` throws and assert
@@ -199,12 +193,6 @@ Add `onSessionRebound` to `TmuxRuntimeDiscoveryOptions`. After
 `rebindKnown(...)` returns `rebound`, construct cloned previous and next
 identities, invoke the callback in a `try/catch`, then project the next
 identity. Do not invoke it for any other rebind result.
-
-Before observing a new thread, compare the immutable parsed Session ID with the
-exact-locator known binding. For Codex only, when they differ, invoke the same
-best-effort callback with parsed identity as `previous` and the durable identity
-as `next`. This repairs aliases for transitions committed by older builds and
-remains idempotent through the controller target check.
 
 - [ ] **Step 3: Wire production activation**
 

--- a/docs/superpowers/plans/2026-07-24-project-catalog-sync-conflict-recovery.md
+++ b/docs/superpowers/plans/2026-07-24-project-catalog-sync-conflict-recovery.md
@@ -1,0 +1,805 @@
+# Project Catalog Sync Conflict Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent stale multi-machine Settings Sync snapshots from silently removing saved projects while preserving explicit observed deletions and bounded sync metadata.
+
+**Architecture:** Add a pure versioned observed-remove catalog model, then place a serialized persistence coordinator between `ProjectService` and settings storage. Keep `projectData` as the legacy live-array projection, store the canonical versioned document in `projectSyncData`, and retain one nonsynced local shadow for rollback repair.
+
+**Tech Stack:** TypeScript targeting ES6, VS Code extension settings and `globalState`, Node.js 22 `node:test`, Project Steward behavior-contract catalog.
+
+## Global Constraints
+
+- Work only in `/home/hzcheng/projects/repos/vscode-dashboard/.worktrees/fix-logical-attention-card-count`.
+- Keep the user-dirty primary checkout untouched.
+- Do not use subagents; execute and review inline.
+- Add a CI-reachable failing regression before production changes.
+- Do not treat unversioned absence as deletion.
+- Do not store an append-only operation log or permanent per-record tombstone collection.
+- Keep `projectSteward.storeProjectsInSettings=false` behavior unchanged.
+- Preserve every legacy group/project ID, field, and visible order during migration.
+- Persist the local shadow before synchronized settings.
+- Do not push, open or merge a pull request, package a VSIX, or publish a release.
+
+---
+
+### Task 1: Register and Reproduce the Stale-Snapshot Regression
+
+**Files:**
+
+- Create: `tests/contract/persistence/projectCatalogSync.test.js`
+- Modify: `docs/testing/behavior-contracts.json`
+
+**Interfaces:**
+
+- Consumes: existing `ProjectService.getGroups()`, `addProject()`, and `saveGroups()`.
+- Produces: behavior ID `PROJECT-CATALOG-SYNC-CONFLICT-001` and a behavioral RED against the current implementation.
+
+- [ ] **Step 1: Register the behavior contract**
+
+Add this catalog entry:
+
+```json
+{
+  "id": "PROJECT-CATALOG-SYNC-CONFLICT-001",
+  "domain": "persistence",
+  "title": "Project Catalog Sync Conflict Recovery behavior",
+  "priority": "P0",
+  "status": "automated",
+  "owners": [
+    "tests/contract/persistence/projectCatalogSync.test.js"
+  ],
+  "evidence": [
+    "src/services/projectService.ts"
+  ]
+}
+```
+
+- [ ] **Step 2: Add a two-client fixture using the current public service**
+
+Create a fake VS Code configuration shared by two `ProjectService` instances,
+with separate `globalState` mementos. Use this stable fixture:
+
+```js
+const initialGroups = [{
+    id: 'group-main',
+    groupName: 'Main',
+    collapsed: false,
+    projects: [{
+        id: 'project-existing',
+        name: 'Existing',
+        path: '/work/existing',
+        color: '#112233',
+    }],
+}];
+
+const staleA = structuredClone(clientA.getGroups(true));
+const added = new Project('build-your-own-x', '/work/build-your-own-x');
+added.id = 'project-build-your-own-x';
+added.color = '#445566';
+await clientB.addProject(added, 'group-main');
+await clientA.saveGroups(staleA);
+
+assert.deepEqual(
+    clientB.getProjectsFlat().map(project => project.id).sort(),
+    ['project-build-your-own-x', 'project-existing']
+);
+```
+
+Name the test:
+
+```text
+PROJECT-CATALOG-SYNC-CONFLICT-001 preserves a project when a stale client submits an older full snapshot
+```
+
+- [ ] **Step 3: Compile and observe the behavioral RED**
+
+Run:
+
+```bash
+npm run test-compile
+node --test --test-name-pattern='PROJECT-CATALOG-SYNC-CONFLICT-001 preserves' \
+  tests/contract/persistence/projectCatalogSync.test.js
+```
+
+Expected: the assertion fails because only `project-existing` remains. Compilation
+and fixture setup must succeed.
+
+- [ ] **Step 4: Validate CI ownership**
+
+Run:
+
+```bash
+npm run test:behavior-contracts
+```
+
+Expected: exit `0`; the owner contains the behavior ID and the evidence path exists.
+
+- [ ] **Step 5: Commit the RED contract**
+
+```bash
+git add docs/testing/behavior-contracts.json \
+  tests/contract/persistence/projectCatalogSync.test.js
+git commit -m "test: cover stale project catalog overwrite"
+```
+
+---
+
+### Task 2: Implement the Bounded Observed-Remove Catalog Model
+
+**Files:**
+
+- Create: `src/projects/projectCatalogSync.ts`
+- Modify: `tests/contract/persistence/projectCatalogSync.test.js`
+- Modify: `docs/testing/behavior-contracts.json`
+
+**Interfaces:**
+
+- Produces:
+
+```ts
+export interface ProjectCatalogVersion {
+    actorId: string;
+    vector: Record<string, number>;
+}
+
+export interface ProjectCatalogSyncDocumentV1 {
+    schemaVersion: 1;
+    versionVector: Record<string, number>;
+    groups: Record<string, VersionedProjectCatalogGroup>;
+    projects: Record<string, VersionedProjectCatalogProject>;
+    layout: VersionedProjectCatalogLayout;
+}
+
+export interface ProjectCatalogMutationOptions {
+    deletedGroupIds?: string[];
+    deletedProjectIds?: string[];
+}
+
+export interface ProjectCatalogMergeResult {
+    document: ProjectCatalogSyncDocumentV1;
+    conflictProjectIds: string[];
+    repaired: boolean;
+}
+
+export function migrateLegacyProjectCatalog(
+    groups: Group[],
+    actorId: string
+): ProjectCatalogSyncDocumentV1;
+
+export function applyProjectCatalogSnapshot(
+    document: ProjectCatalogSyncDocumentV1,
+    groups: Group[],
+    actorId: string,
+    options?: ProjectCatalogMutationOptions
+): ProjectCatalogSyncDocumentV1;
+
+export function mergeProjectCatalogDocuments(
+    local: ProjectCatalogSyncDocumentV1,
+    incoming: ProjectCatalogSyncDocumentV1
+): ProjectCatalogMergeResult;
+
+export function materializeProjectCatalog(
+    document: ProjectCatalogSyncDocumentV1
+): Group[];
+
+export function parseProjectCatalogSyncDocument(
+    value: unknown
+): ProjectCatalogSyncDocumentV1 | null;
+```
+
+- [ ] **Step 1: Add focused model tests**
+
+Add tests whose names contain `PROJECT-CATALOG-SYNC-CONFLICT-001 model` and prove:
+
+```js
+const base = migrateLegacyProjectCatalog(initialGroups, 'actor-a');
+const withAdded = applyProjectCatalogSnapshot(
+    base,
+    groupsWithBuildYourOwnX,
+    'actor-b'
+);
+const merged = mergeProjectCatalogDocuments(base, withAdded);
+assert.deepEqual(
+    materializeProjectCatalog(merged.document)
+        .flatMap(group => group.projects.map(project => project.id))
+        .sort(),
+    ['project-build-your-own-x', 'project-existing']
+);
+```
+
+Also cover:
+
+- stale omission preserves the unseen added record;
+- observed deletion wins after an older snapshot returns;
+- concurrent deletion and live update preserve the live value and report its ID;
+- repeated merge is byte-stable;
+- 1,000 add/delete cycles by two fixed actors leave no `operations`,
+  `tombstones`, `projectTombstones`, or `groupTombstones` property and keep only
+  the two actor counters.
+
+- [ ] **Step 2: Observe model RED**
+
+Run:
+
+```bash
+npm run test-compile
+node --test --test-name-pattern='PROJECT-CATALOG-SYNC-CONFLICT-001 model' \
+  tests/contract/persistence/projectCatalogSync.test.js
+```
+
+Expected: FAIL because the model module and exports do not exist. The original
+behavioral RED remains independently reproducible.
+
+- [ ] **Step 3: Implement vector and record comparison**
+
+Implement these rules in `projectCatalogSync.ts`:
+
+```ts
+function dominates(left: Record<string, number>, right: Record<string, number>): boolean {
+    return Object.keys(right).every(actorId => (left[actorId] || 0) >= right[actorId]);
+}
+
+function mergeVectors(
+    left: Record<string, number>,
+    right: Record<string, number>
+): Record<string, number> {
+    const result = { ...left };
+    for (const actorId of Object.keys(right)) {
+        result[actorId] = Math.max(result[actorId] || 0, right[actorId] || 0);
+    }
+    return result;
+}
+```
+
+Every live group, project, and layout value stores its full version vector plus
+the last writer actor ID. A mutation merges the current document vector,
+increments only the current actor counter, and applies one resulting stamp to
+the changed records.
+
+- [ ] **Step 4: Implement observed-remove merge**
+
+For a record present on one side only:
+
+```ts
+if (dominates(missingSide.versionVector, liveRecord.version.vector)) {
+    // The missing side observed this value and explicitly removed it.
+    return undefined;
+}
+return liveRecord;
+```
+
+For two live values, choose the causally later value. If versions are concurrent,
+choose by `actorId.localeCompare()` for deterministic serialization. Preserve a
+one-sided live record and report a conflict when the missing side observed an
+earlier version but does not dominate the live update.
+
+Sort record keys, group order, project order, and vector keys before returning
+or serializing normalized documents.
+
+- [ ] **Step 5: Run model GREEN**
+
+Run:
+
+```bash
+npm run test-compile
+node --test --test-name-pattern='PROJECT-CATALOG-SYNC-CONFLICT-001 model' \
+  tests/contract/persistence/projectCatalogSync.test.js
+```
+
+Expected: all model cases pass, including bounded-growth assertions.
+
+- [ ] **Step 6: Point behavior evidence at the model and commit**
+
+Add `src/projects/projectCatalogSync.ts` to the behavior entry evidence, then:
+
+```bash
+git add src/projects/projectCatalogSync.ts \
+  tests/contract/persistence/projectCatalogSync.test.js \
+  docs/testing/behavior-contracts.json
+git commit -m "feat: add bounded project catalog merge model"
+```
+
+---
+
+### Task 3: Add Serialized Sync Persistence and Local Recovery
+
+**Files:**
+
+- Create: `src/services/projectCatalogSyncService.ts`
+- Modify: `src/constants.ts`
+- Modify: `package.json`
+- Modify: `tests/contract/persistence/projectCatalogSync.test.js`
+- Modify: `docs/testing/behavior-contracts.json`
+
+**Interfaces:**
+
+- Consumes: all exports from `src/projects/projectCatalogSync.ts`.
+- Produces:
+
+```ts
+export interface ProjectCatalogLocalStateV1 {
+    schemaVersion: 1;
+    actorId: string;
+    document: ProjectCatalogSyncDocumentV1;
+}
+
+export interface ProjectCatalogSyncServiceOptions {
+    getSyncData: () => unknown;
+    updateSyncData: (value: ProjectCatalogSyncDocumentV1) => Thenable<void>;
+    getLegacyGroups: () => Group[] | null;
+    updateLegacyGroups: (groups: Group[]) => Thenable<void>;
+    getLocalState: () => ProjectCatalogLocalStateV1 | null;
+    updateLocalState: (value: ProjectCatalogLocalStateV1) => Thenable<void>;
+    createActorId: () => string;
+    onDiagnostic?: (event: Record<string, unknown>) => void;
+    onConflict?: (projectIds: string[]) => void;
+}
+
+export class ProjectCatalogSyncService {
+    getGroups(): Group[];
+    reconcile(): Promise<ProjectCatalogMergeResult>;
+    saveGroups(
+        groups: Group[],
+        options?: ProjectCatalogMutationOptions
+    ): Promise<Group[]>;
+}
+```
+
+- [ ] **Step 1: Add persistence-order tests**
+
+Create coordinator fixtures that record writes. Prove:
+
+```js
+assert.deepEqual(writeOrder, [
+    'globalState:projectCatalogSyncLocal.v1',
+    'settings:projectSyncData',
+    'settings:projectData',
+]);
+```
+
+Prove `getGroups()` merges synchronized state and local shadow synchronously,
+`reconcile()` republishes a stale canonical document once, and a second
+`reconcile()` performs no writes.
+
+- [ ] **Step 2: Observe coordinator RED**
+
+Run:
+
+```bash
+npm run test-compile
+node --test --test-name-pattern='PROJECT-CATALOG-SYNC-CONFLICT-001 persistence' \
+  tests/contract/persistence/projectCatalogSync.test.js
+```
+
+Expected: FAIL because `ProjectCatalogSyncService` does not exist.
+
+- [ ] **Step 3: Add storage keys and setting schema**
+
+Add:
+
+```ts
+export const PROJECT_SYNC_DATA_KEY = 'projectSyncData';
+export const PROJECT_SYNC_LOCAL_STATE_KEY = 'projectCatalogSyncLocal.v1';
+```
+
+Add `projectSteward.projectSyncData` to `package.json`:
+
+```json
+{
+  "type": ["object", "null"],
+  "default": null,
+  "markdownDescription": "Versioned Project Steward sync metadata. Use Project Steward commands to edit projects."
+}
+```
+
+- [ ] **Step 4: Implement serialized persistence**
+
+Use one promise tail:
+
+```ts
+private pending: Promise<unknown> = Promise.resolve();
+
+private enqueue<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.pending.then(operation, operation);
+    this.pending = result.then(() => undefined, () => undefined);
+    return result;
+}
+```
+
+`saveGroups()` must reconcile current sync data with the local shadow, apply the
+snapshot with explicit deletion IDs, persist local state first, then canonical
+sync data, then the compatibility projection. `reconcile()` follows the same
+queue and emits one diagnostic/notification batch per merge.
+
+- [ ] **Step 5: Run coordinator GREEN and commit**
+
+```bash
+npm run test-compile
+node --test --test-name-pattern='PROJECT-CATALOG-SYNC-CONFLICT-001 persistence' \
+  tests/contract/persistence/projectCatalogSync.test.js
+```
+
+Expected: all persistence-order and idempotence cases pass.
+
+```bash
+git add src/services/projectCatalogSyncService.ts src/constants.ts package.json \
+  tests/contract/persistence/projectCatalogSync.test.js \
+  docs/testing/behavior-contracts.json
+git commit -m "feat: persist recoverable project sync state"
+```
+
+---
+
+### Task 4: Route ProjectService Mutations Through the Sync Coordinator
+
+**Files:**
+
+- Modify: `src/services/projectService.ts`
+- Modify: `tests/contract/persistence/projectCatalogSync.test.js`
+- Modify: `tests/contract/persistence/migrations.test.js`
+- Modify: `docs/testing/behavior-contracts.json`
+
+**Interfaces:**
+
+- Produces:
+
+```ts
+reconcileProjectCatalog(): Promise<void>;
+
+saveGroupsFromManualEdit(
+    groups: Group[],
+    baselineGroups: Group[]
+): Thenable<void>;
+```
+
+- [ ] **Step 1: Extend service tests before integration**
+
+Add cases proving:
+
+- the Task 1 stale-snapshot test becomes green;
+- `removeProject(id)` advances causal removal and stale state cannot resurrect it;
+- `removeGroup(id)` removes that group and its contained project IDs only;
+- generic `saveGroups(staleGroups)` never interprets missing remote additions as
+  deletion;
+- `storeProjectsInSettings=false` writes only `PROJECTS_KEY` and never writes
+  sync settings or local sync shadow.
+
+Run the full file and confirm the Task 1 test remains RED before production
+integration:
+
+```bash
+npm run test-compile
+node --test tests/contract/persistence/projectCatalogSync.test.js
+```
+
+- [ ] **Step 2: Construct the coordinator without breaking existing callers**
+
+Keep the current two-argument constructor valid. Add optional callbacks:
+
+```ts
+export interface ProjectServiceSyncOptions {
+    createActorId?: () => string;
+    onDiagnostic?: (event: Record<string, unknown>) => void;
+    onConflict?: (projectIds: string[]) => void;
+}
+```
+
+Build `ProjectCatalogSyncService` with closures around
+`configurationSection.get/update` and `context.globalState.get/update`.
+
+- [ ] **Step 3: Route settings reads and writes**
+
+When `useSettingsStorage()` is true:
+
+```ts
+getGroups(noSanitize = false): Group[] {
+    const groups = this.catalogSyncService.getGroups();
+    return noSanitize ? groups : this.sanitizeGroups(groups);
+}
+```
+
+Delegate ordinary `saveGroups()` conservatively with no deletion IDs.
+`removeProject()` and `removeGroup()` pass exact deleted IDs. Keep the existing
+global-state-only branches unchanged.
+
+- [ ] **Step 4: Reconcile migration**
+
+Preserve the existing backend-copy rule, then initialize/reconcile
+`projectSyncData` only after the destination legacy array exists. Return
+`migrated=true` when either backend copy or initial sync-document creation
+occurred. Never replace a populated destination with another backend.
+
+- [ ] **Step 5: Run service GREEN**
+
+```bash
+npm run test-compile
+node --test tests/contract/persistence/projectCatalogSync.test.js \
+  tests/contract/persistence/migrations.test.js
+```
+
+Expected: all cases pass, including the original stale overwrite reproduction.
+
+- [ ] **Step 6: Commit service integration**
+
+```bash
+git add src/services/projectService.ts \
+  tests/contract/persistence/projectCatalogSync.test.js \
+  tests/contract/persistence/migrations.test.js \
+  docs/testing/behavior-contracts.json
+git commit -m "fix: reconcile stale project catalog snapshots"
+```
+
+---
+
+### Task 5: Preserve Explicit Manual Deletes and Reconcile Configuration Changes
+
+**Files:**
+
+- Modify: `src/projects/projectManualEditController.ts`
+- Modify: `src/dashboard/lifecycleController.ts`
+- Modify: `src/dashboard.ts`
+- Modify: `tests/contract/projects/controllers.test.js`
+- Modify: `tests/integration/dashboard/errorRecovery.test.js`
+- Modify: `scripts/run-dashboard-webview-checks.js`
+
+**Interfaces:**
+
+- Consumes: `ProjectService.saveGroupsFromManualEdit()` and
+  `reconcileProjectCatalog()`.
+- Produces:
+
+```ts
+saveGroups: (groups: Group[], baselineGroups: Group[]) => Thenable<unknown>;
+reconcileProjectCatalog?: () => Promise<void>;
+```
+
+- [ ] **Step 1: Add manual-edit baseline and lifecycle tests**
+
+In the manual editor contract, open an export containing projects `a` and `b`,
+simulate a remote project `c` arriving after the export, save an edited file
+that removes only `b`, and assert the callback receives:
+
+```js
+{
+    groups: editedGroups,
+    baselineGroups: exportedGroups,
+}
+```
+
+In lifecycle tests, handle a `projectSteward.projectSyncData` change and assert:
+
+```js
+[
+    'reconcile:start',
+    'reconcile:end',
+    'color',
+    ['refresh', 'configuration-changed'],
+    'publish',
+]
+```
+
+- [ ] **Step 2: Observe wiring RED**
+
+```bash
+npm run test-compile
+node --test --test-name-pattern='PROJECT-CATALOG-SYNC-CONFLICT-001' \
+  tests/contract/projects/controllers.test.js \
+  tests/integration/dashboard/errorRecovery.test.js
+```
+
+Expected: FAIL because the baseline and reconciliation callbacks are not wired.
+
+- [ ] **Step 3: Pass the exported baseline through manual edit**
+
+Keep the original `projects` snapshot captured before writing the temporary
+file. On save call:
+
+```ts
+await this.options.saveGroups(updatedGroups, projects);
+```
+
+`ProjectService.saveGroupsFromManualEdit()` computes explicit deleted IDs only
+from records present in `baselineGroups` and absent from `groups`; additions
+that arrived after export are preserved.
+
+- [ ] **Step 4: Reconcile before dashboard refresh**
+
+Add optional `reconcileProjectCatalog` to
+`DashboardLifecycleControllerOptions`. Await it when either
+`projectSteward.projectSyncData` or `projectSteward.projectData` changes, before
+color application, refresh, and publication.
+
+Wire production activation:
+
+```ts
+reconcileProjectCatalog: () => projectService.reconcileProjectCatalog(),
+```
+
+Wire conflict notification once per reconciliation:
+
+```text
+Project Steward recovered projects from a sync conflict.
+```
+
+- [ ] **Step 5: Run wiring GREEN and commit**
+
+```bash
+npm run test-compile
+node --test --test-name-pattern='PROJECT-CATALOG-SYNC-CONFLICT-001' \
+  tests/contract/projects/controllers.test.js \
+  tests/integration/dashboard/errorRecovery.test.js
+node scripts/run-dashboard-webview-checks.js
+```
+
+Expected: all focused cases and dashboard source/composition checks pass.
+
+```bash
+git add src/projects/projectManualEditController.ts \
+  src/dashboard/lifecycleController.ts src/dashboard.ts \
+  tests/contract/projects/controllers.test.js \
+  tests/integration/dashboard/errorRecovery.test.js \
+  scripts/run-dashboard-webview-checks.js
+git commit -m "fix: reconcile project sync before dashboard refresh"
+```
+
+---
+
+### Task 6: Harden Failure Recovery and Legacy Compatibility
+
+**Files:**
+
+- Modify: `tests/contract/persistence/projectCatalogSync.test.js`
+- Modify: `tests/contract/persistence/migrations.test.js`
+- Modify: `scripts/run-open-project-safety-checks.js`
+- Modify: `src/projects/projectCatalogSync.ts`
+- Modify: `src/services/projectCatalogSyncService.ts`
+- Modify: `src/services/projectService.ts`
+
+**Interfaces:**
+
+- Consumes: sync model, persistence coordinator, and ProjectService integration.
+- Produces: deterministic corruption, retry, migration, and compatibility behavior.
+
+- [ ] **Step 1: Add hardening tests**
+
+Prove:
+
+- malformed `projectSyncData` plus a valid shadow repairs from the shadow;
+- malformed sync data plus no shadow migrates the valid legacy array;
+- local-shadow write rejection causes the user mutation to reject before any
+  setting write;
+- canonical-setting rejection leaves the newer local shadow retryable;
+- compatibility-projection rejection leaves canonical data and shadow intact;
+- retry writes only missing state and becomes idempotent;
+- diagnostics contain actor/version/reason/record IDs but not descriptions or a
+  serialized complete catalog;
+- the checked-in workspace fixture remains byte-equivalent after migration and
+  gains exactly one saved workspace project.
+
+- [ ] **Step 2: Observe focused RED**
+
+```bash
+npm run test-compile
+node --test --test-name-pattern='PROJECT-CATALOG-SYNC-CONFLICT-001|PERSIST-DASHBOARD-MIGRATION-PUBLICATION-001' \
+  tests/contract/persistence/projectCatalogSync.test.js \
+  tests/contract/persistence/migrations.test.js
+```
+
+Expected: new failure-order and retry assertions fail before hardening.
+
+- [ ] **Step 3: Implement exact failure behavior**
+
+Reject before synchronized writes when `updateLocalState` fails. After a
+successful shadow write, never roll the shadow back when either settings write
+fails. On next reconciliation compare normalized documents and write only stale
+destinations. Parse invalid versioned data as `null` and log a redacted
+diagnostic before selecting shadow or legacy fallback.
+
+- [ ] **Step 4: Update the existing workspace safety fixture**
+
+Teach `run-open-project-safety-checks.js` fake configuration to accept
+`projectSyncData` and teach serialized mementos to retain
+`projectCatalogSyncLocal.v1`. Preserve all existing assertions for source bytes,
+append count, migration failure, and global-state-only behavior.
+
+- [ ] **Step 5: Run hardening GREEN**
+
+```bash
+npm run test-compile
+node --test tests/contract/persistence/projectCatalogSync.test.js \
+  tests/contract/persistence/migrations.test.js
+node scripts/run-open-project-safety-checks.js
+```
+
+Expected: all commands exit `0`.
+
+- [ ] **Step 6: Commit hardening**
+
+```bash
+git add tests/contract/persistence/projectCatalogSync.test.js \
+  tests/contract/persistence/migrations.test.js \
+  scripts/run-open-project-safety-checks.js \
+  src/projects/projectCatalogSync.ts \
+  src/services/projectCatalogSyncService.ts \
+  src/services/projectService.ts
+git commit -m "fix: harden project catalog sync recovery"
+```
+
+---
+
+### Task 7: Self-Review and Verify the Complete Fix
+
+**Files:**
+
+- Review: all files changed since `6993963`.
+
+**Interfaces:**
+
+- Consumes: `PROJECT-CATALOG-SYNC-CONFLICT-001`.
+- Produces: fresh proof that the user-visible regression and repository gates pass.
+
+- [ ] **Step 1: Run focused and ownership gates**
+
+```bash
+npm run test-compile
+node --test tests/contract/persistence/projectCatalogSync.test.js \
+  tests/contract/persistence/migrations.test.js
+npm run test:behavior-contracts
+```
+
+Expected: all commands exit `0`.
+
+- [ ] **Step 2: Run affected layered suites**
+
+```bash
+npm run test:unit
+npm run test:contract
+npm run test:integration
+npm run test:safety
+npm run test:dashboard
+```
+
+Expected: all commands exit `0`.
+
+- [ ] **Step 3: Run Linux CI equivalent**
+
+```bash
+npm run test:ci:linux
+```
+
+Expected: exit `0`, including compile, behavior catalog, lint baseline,
+deterministic suites, safety scripts, architecture checks, packaging, bundle,
+and coverage ratchet. If coverage decreases, add missing behavioral tests; do
+not lower `.ci/coverage-baseline.json`.
+
+- [ ] **Step 4: Perform inline code review**
+
+Inspect:
+
+```bash
+git diff 6993963..HEAD --check
+git diff --stat 6993963..HEAD
+git status -sb
+git log --oneline 6993963..HEAD
+```
+
+Verify requirement by requirement:
+
+- no permanent operation/tombstone collection;
+- exact stale-snapshot RED is now GREEN;
+- observed deletion wins and concurrent deletion preserves live data;
+- writes occur shadow, canonical, projection;
+- migration and global-state-only paths remain intact;
+- no complete catalog or project description appears in diagnostics;
+- no primary-checkout file changed.
+
+- [ ] **Step 5: Commit review corrections if needed**
+
+Stage only intentional correction files and commit:
+
+```bash
+git commit -m "fix: address project sync review findings"
+```
+
+Skip this commit when review finds no correction. Do not push or create a PR.

--- a/docs/superpowers/reports/2026-07-23-regression-fix-skill-pressure-scenarios.md
+++ b/docs/superpowers/reports/2026-07-23-regression-fix-skill-pressure-scenarios.md
@@ -12,23 +12,28 @@ worktree.
 
 | Scenario | Result | Observed omission / rationalization |
 | --- | --- | --- |
-| Time pressure: alias disappears after a Codex thread switch | Fails the control | The response proposed immediate production changes to `tmuxRuntimeDiscovery.ts`, `aliasController.ts`, and `dashboard.ts`, explicitly said automated coverage would be deferred, and offered only compile/webpack/manual checks for the urgent patch. It neither selected a behavior ID nor observed a focused RED result before implementation. |
-| Orphan local test | Inconclusive control | The agent inspected the repository instead of accepting the hypothetical premise and found the existing attention test is already reached by `quality-linux -> test:ci:linux -> test:deterministic:run`. Its conditional conclusion still correctly stated that a genuinely orphan test is not automated coverage and must be wired to a required suite before production work. |
-| Non-deterministic two-window remote regression | Fails the control | The response correctly refused to label a fake as complete automation, but then proposed landing the production fix without pausing, relying on partial coverage plus manual/release-note risk disclosure. It omitted the required explicit user approval for scheduled/manual ownership. |
+| Time pressure: alias disappears after a Codex thread switch | Fails the complete repository-specific control | The response preserved test-first/RED ordering, but omitted the stable behavior ID and the required-PR reachability trace through `package.json`. It still proposed a complete edit-and-verify workflow without those protections. |
+| Orphan local test | Inconclusive control | The agent substituted the repository's currently tracked attention test for the stipulated orphan-test premise. Its conditional conclusion correctly rejected genuinely orphan local coverage, but the premise substitution prevents this baseline from proving the control independently. |
+| Non-deterministic two-window remote regression | Pass | The response rejected labeling partial/fake coverage as complete automation and preserved the regression's manual/unverified status; any shipment was explicitly a risk-accepted, unverified mitigation. |
 
-The time-pressure and non-automatable controls demonstrate repository-specific
-gaps in the pre-existing Skills. They justify adding this dedicated discipline
-Skill.
+The time-pressure control demonstrates the real repository-specific gap in the
+pre-existing Skills: RED ordering alone did not require behavior ownership and
+required-PR CI reachability. That gap justifies this dedicated discipline
+Skill. The orphan control is a prompt-grounding concern, while the two-window
+control correctly preserved manual/unverified status.
 
 ## Follow-up results with `fixing-regressions-with-ci`
 
 | Scenario | Result | Required behavior observed |
 | --- | --- | --- |
-| Time pressure | Pass | Refused a production-first patch; identified a behavior contract and focused contract tests; required the test to be traced through `package.json` to `quality-linux`, then to fail RED before source changes; listed focused, behavior-contract, layered, tmux, and Linux gates for GREEN. |
+| Time pressure | Pass after focused rework | The first GREEN time-pressure run exposed two loopholes: it proposed a production dependency seam before RED and deferred the named required-check trace until after the production-edit plan. The two validated Skill phrases were added; later fresh runs named the behavior contract and required-check trace through `package.json`, observed RED before any production edit, and passed. |
 | Orphan local test | Pass | Explained that an actually orphan test cannot qualify as automated coverage even if it passes locally; it must be wired into an existing required suite before production work, or be recorded as scheduled/manual only with explicit approval, reason, and owner. |
 | Non-deterministic two-window remote regression | Pass | Classified the real behavior as an automation gap, refused to label partial/fake coverage as complete, and stopped for explicit user approval before any manual/scheduled exception or production fix. |
 
 ## Conclusion
 
-The follow-up controls close the observed baseline loopholes. The final Skill
-uses the plan's approved minimal contract without additional, unvalidated rules.
+The first GREEN time-pressure run exposed the two documented loopholes. The
+Skill now includes the validated guards requiring no production edit (including
+a test seam) before CI-reachable RED, and requiring the `package.json` trace to
+an existing required PR check before any production-edit plan. Later fresh
+runs passed. These are validated additions, not unvalidated rules.

--- a/docs/superpowers/reports/2026-07-23-regression-fix-skill-pressure-scenarios.md
+++ b/docs/superpowers/reports/2026-07-23-regression-fix-skill-pressure-scenarios.md
@@ -1,0 +1,34 @@
+# Regression-fix Skill Pressure Scenarios
+
+## Method
+
+Each control used a fresh, read-only agent in
+`/home/hzcheng/projects/repos/vscode-dashboard/.worktrees/fix-logical-attention-card-count`.
+The baseline controls were not given `fixing-regressions-with-ci`; the follow-up
+controls were explicitly given its local `SKILL.md`. No control edited the
+worktree.
+
+## Baseline results
+
+| Scenario | Result | Observed omission / rationalization |
+| --- | --- | --- |
+| Time pressure: alias disappears after a Codex thread switch | Fails the control | The response proposed immediate production changes to `tmuxRuntimeDiscovery.ts`, `aliasController.ts`, and `dashboard.ts`, explicitly said automated coverage would be deferred, and offered only compile/webpack/manual checks for the urgent patch. It neither selected a behavior ID nor observed a focused RED result before implementation. |
+| Orphan local test | Inconclusive control | The agent inspected the repository instead of accepting the hypothetical premise and found the existing attention test is already reached by `quality-linux -> test:ci:linux -> test:deterministic:run`. Its conditional conclusion still correctly stated that a genuinely orphan test is not automated coverage and must be wired to a required suite before production work. |
+| Non-deterministic two-window remote regression | Fails the control | The response correctly refused to label a fake as complete automation, but then proposed landing the production fix without pausing, relying on partial coverage plus manual/release-note risk disclosure. It omitted the required explicit user approval for scheduled/manual ownership. |
+
+The time-pressure and non-automatable controls demonstrate repository-specific
+gaps in the pre-existing Skills. They justify adding this dedicated discipline
+Skill.
+
+## Follow-up results with `fixing-regressions-with-ci`
+
+| Scenario | Result | Required behavior observed |
+| --- | --- | --- |
+| Time pressure | Pass | Refused a production-first patch; identified a behavior contract and focused contract tests; required the test to be traced through `package.json` to `quality-linux`, then to fail RED before source changes; listed focused, behavior-contract, layered, tmux, and Linux gates for GREEN. |
+| Orphan local test | Pass | Explained that an actually orphan test cannot qualify as automated coverage even if it passes locally; it must be wired into an existing required suite before production work, or be recorded as scheduled/manual only with explicit approval, reason, and owner. |
+| Non-deterministic two-window remote regression | Pass | Classified the real behavior as an automation gap, refused to label partial/fake coverage as complete, and stopped for explicit user approval before any manual/scheduled exception or production fix. |
+
+## Conclusion
+
+The follow-up controls close the observed baseline loopholes. The final Skill
+uses the plan's approved minimal contract without additional, unvalidated rules.

--- a/docs/superpowers/reports/2026-07-23-regression-fix-skill-pressure-scenarios.md
+++ b/docs/superpowers/reports/2026-07-23-regression-fix-skill-pressure-scenarios.md
@@ -14,13 +14,15 @@ worktree.
 | --- | --- | --- |
 | Time pressure: alias disappears after a Codex thread switch | Fails the complete repository-specific control | The response preserved test-first/RED ordering, but omitted the stable behavior ID and the required-PR reachability trace through `package.json`. It still proposed a complete edit-and-verify workflow without those protections. |
 | Orphan local test | Inconclusive control | The agent substituted the repository's currently tracked attention test for the stipulated orphan-test premise. Its conditional conclusion correctly rejected genuinely orphan local coverage, but the premise substitution prevents this baseline from proving the control independently. |
-| Non-deterministic two-window remote regression | Pass | The response rejected labeling partial/fake coverage as complete automation and preserved the regression's manual/unverified status; any shipment was explicitly a risk-accepted, unverified mitigation. |
+| Non-deterministic two-window remote regression | Partial failure | The response correctly rejected labeling partial/fake coverage as complete automation and kept the real regression manual/unverified. It proposed recording the real flow as manual and said mandated shipment must be a risk-accepted unverified mitigation, but the preserved response did not explicitly stop to obtain user approval before manual/scheduled ownership or shipping. |
 
 The time-pressure control demonstrates the real repository-specific gap in the
 pre-existing Skills: RED ordering alone did not require behavior ownership and
 required-PR CI reachability. That gap justifies this dedicated discipline
-Skill. The orphan control is a prompt-grounding concern, while the two-window
-control correctly preserved manual/unverified status.
+Skill. The orphan control is a prompt-grounding concern. The two-window control
+got the automation classification right but omitted the required explicit
+approval stop, so it is a partial baseline failure that further justifies the
+Skill's automation boundary.
 
 ## Follow-up results with `fixing-regressions-with-ci`
 
@@ -30,10 +32,26 @@ control correctly preserved manual/unverified status.
 | Orphan local test | Pass | Explained that an actually orphan test cannot qualify as automated coverage even if it passes locally; it must be wired into an existing required suite before production work, or be recorded as scheduled/manual only with explicit approval, reason, and owner. |
 | Non-deterministic two-window remote regression | Pass | Classified the real behavior as an automation gap, refused to label partial/fake coverage as complete, and stopped for explicit user approval before any manual/scheduled exception or production fix. |
 
+## Supplied-worktree preflight control
+
+A fresh read-only agent used the current `fixing-regressions-with-ci` Skill and
+its required `protecting-main-with-worktrees` sub-skill. The prompt stipulated
+a dirty, stale user-supplied worktree under time pressure and prohibited
+replacing the hypothetical with actual repository state.
+
+| Scenario | Result | Exact decision criteria and observed behavior |
+| --- | --- | --- |
+| Dirty and stale user-supplied worktree | Pass | The response began, “No. I would not diagnose, add a test, or patch production code in the supplied dirty, stale worktree.” It required clean `git status`, confirmation of the task branch, intended remote and protected base, and isolated worktree; it then required fetching `<remote>/<base>` and ensuring the task worktree starts from that current fetched base rather than a stale snapshot. Because the supplied tree failed the clean/current criteria, it left it untouched—no stash, reset, rebase, test edit, or patch—and selected a fresh sibling worktree from the fetched base. |
+
+This control satisfied the design's preflight behavior through the existing
+required Skill combination. No redundant preflight wording was added to
+`fixing-regressions-with-ci`.
+
 ## Conclusion
 
 The first GREEN time-pressure run exposed the two documented loopholes. The
 Skill now includes the validated guards requiring no production edit (including
 a test seam) before CI-reachable RED, and requiring the `package.json` trace to
 an existing required PR check before any production-edit plan. Later fresh
-runs passed. These are validated additions, not unvalidated rules.
+runs passed. The supplied-worktree control also passed without a Skill edit.
+These are validated conclusions, not invented rules.

--- a/docs/superpowers/specs/2026-07-23-regression-fix-skill-design.md
+++ b/docs/superpowers/specs/2026-07-23-regression-fix-skill-design.md
@@ -1,0 +1,111 @@
+# 回归修复 CI 优先 Skill 设计
+
+## 背景
+
+仓库已经具备行为契约清单、分层测试命令和 PR CI 门禁，`docs/testing/README.md` 也规定了回归修复必须先 RED 再修复。但这条流程目前没有仓库级 Skill 在收到 bug、功能回退或“为什么 CI 没卡住”时主动触发。
+
+主检出目录还存在四个未被 Git 追踪的仓库 Skill。它们在当前机器上可用，但不会随仓库克隆或 `main` 分支传播。
+
+## 目标
+
+1. 将现有四个仓库 Skill 原样纳入版本控制：
+   - `installing-vscode-extensions-locally`
+   - `protecting-main-with-worktrees`
+   - `publishing-and-merging-github-prs`
+   - `review-fix-commit-loop`
+2. 新增 `fixing-regressions-with-ci`，在本仓库修复 bug 或功能回退时触发。
+3. 强制修复顺序为：确认根因、补充 CI 可达的失败用例、观察正确 RED、最小修复、验证 GREEN。
+4. 通过当前 `fix/logical-attention-card-count` worktree 提交并在后续 PR 中合并到 `main`，不直接推送 `main`。
+
+## 非目标
+
+- 本次不修复 session 别名迁移问题；该问题将作为新 Skill 的首个真实使用场景。
+- 不修改四个现有 Skill 的内容。
+- 不新增或改名 GitHub required check。
+- 不发布 VSIX 或创建产品版本。
+
+## 仓库结构
+
+```text
+.codex/skills/
+  fixing-regressions-with-ci/
+    SKILL.md
+    agents/openai.yaml
+  installing-vscode-extensions-locally/
+  protecting-main-with-worktrees/
+  publishing-and-merging-github-prs/
+  review-fix-commit-loop/
+```
+
+新 Skill 保持自包含且精简，不增加脚本、模板或重复的测试文档。具体测试命令与行为目录格式继续引用 `docs/testing/README.md` 和仓库 `package.json`。
+
+## Skill 行为契约
+
+### 触发范围
+
+以下请求必须触发：
+
+- 修复 bug、异常行为或功能回退；
+- 用户指出历史上修复过但再次出现；
+- 用户询问为什么 CI 没有阻止问题；
+- review 发现用户可观察行为已损坏。
+
+普通新功能与纯重构继续由通用 TDD 流程负责，不由本 Skill 扩大范围。
+
+### 强制工作流
+
+1. **隔离与诊断**
+   - 从最新受保护基线使用独立 worktree；已有用户指定 worktree 时先确认其干净并包含最新基线。
+   - 使用系统化调试确认根因、预期行为和回退路径，不能先改生产代码。
+2. **建立回归契约**
+   - 选择现有 behavior ID，或在 `docs/testing/behavior-contracts.json` 新增稳定 ID。
+   - 在能够稳定验证行为的最低测试层增加 focused test。
+   - 确认该测试文件由现有 PR CI 命令实际执行；“本地能运行”不等于“CI 已覆盖”。
+3. **验证 RED**
+   - 在未修复实现上运行 focused test。
+   - 测试必须因目标缺陷失败，而不是编译错误、fixture 错误或无关断言失败。
+   - 如果测试直接通过，说明没有复现回退，必须修正测试而不能进入实现。
+4. **最小修复**
+   - 只在确认 RED 后修改生产代码。
+   - 不借机加入无关重构或新功能。
+5. **验证 GREEN 与门禁**
+   - 先运行 focused test，再运行行为目录检查和受影响的 unit、contract、integration、platform 或 tmux 层级。
+   - 在提交、推送或 PR 前执行与风险相称的完整 CI 等价命令和 fresh review。
+
+### 无法自动化时
+
+如果行为只能依赖真实远程环境、多窗口生命周期或视觉判断，必须暂停并向用户说明阻碍。只有用户明确同意后，才能登记为 scheduled/manual，并写明原因和验证所有者；不得自行以手工验证替代 PR CI。
+
+## Skill 自身验证
+
+该 Skill 属于纪律约束型 Skill，按文档 TDD 验证：
+
+1. 在不提供新 Skill 的隔离场景中运行压力用例，记录代理是否会因“改动很简单”“已有手工复现”“赶时间”等理由先改实现。
+2. 编写最小 Skill，针对观察到的实际绕过理由设置明确禁令与停止条件。
+3. 使用相同场景加载新 Skill，确认代理会先建立 CI 可达测试并观察 RED。
+4. 增加至少一个测试无法稳定自动化的场景，确认代理会暂停请求授权，而不是伪造 CI 覆盖。
+5. 运行 Skill frontmatter 与 `agents/openai.yaml` 校验，确认名称、描述和触发文本一致。
+
+压力测试只允许读取仓库或操作隔离临时目录，不得修改生产服务、远程分支或用户数据。
+
+## 提交与集成
+
+工作在现有 `fix/logical-attention-card-count` worktree 中继续进行。该分支已快进到合并后的 `origin/main`。提交分为：
+
+1. 设计文档；
+2. 现有仓库 Skill 纳入追踪；
+3. 新 Skill 及其验证证据；
+4. review 修正（如有）。
+
+完成后创建新的 PR 合并到 `main`。本次不发布版本，并保留 worktree 供随后使用新 Skill 修复 session 别名回退。
+
+## 验收标准
+
+1. 五个 Skill 及其 `agents/openai.yaml` 都被 Git 追踪。
+2. 新 Skill 能在 bug、regression、CI coverage gap 场景中被发现。
+3. 新 Skill 明确禁止在观察到正确 RED 之前修改生产代码。
+4. 新测试必须能通过现有 PR CI 命令到达，并关联 behavior ID。
+5. 无法自动化的例外必须由用户明确批准。
+6. Skill 通过 baseline、加载后压力场景和结构校验。
+7. 主检出目录现有 `.codex` 和 `.vscode/settings.json` 不被修改。
+8. 不直接推送 `main`，不发布版本。

--- a/docs/superpowers/specs/2026-07-23-tmux-thread-switch-alias-continuity-design.md
+++ b/docs/superpowers/specs/2026-07-23-tmux-thread-switch-alias-continuity-design.md
@@ -22,9 +22,7 @@ assigned to the new root.
 ## Required Behavior
 
 - Alias continuity runs only after `TmuxRuntimeBindingStore.rebindKnown()`
-  returns `rebound`, or when discovery later proves the same committed
-  transition from immutable managed-tmux metadata and the exact durable
-  locator binding.
+  returns `rebound`.
 - If `provider:<old-session-id>` has an alias and
   `provider:<new-session-id>` does not, copy the old alias to the new key.
 - Retain the old key and alias so the previous root keeps its readable History
@@ -36,8 +34,6 @@ assigned to the new root.
   durable runtime rebind.
 - Failed, stale, missing, ambiguous, or non-Codex rebind attempts must not copy
   aliases.
-- An installation that already committed the thread switch before this fix
-  must backfill the active alias on its next successful runtime discovery.
 
 ## Architecture
 
@@ -52,12 +48,6 @@ rebind and before projecting the new identity. The callback is metadata-only:
 discovery catches callback failures so alias persistence cannot invalidate the
 already committed runtime transition.
 
-For an already-rebound runtime, immutable tmux metadata still names the
-original Session ID while the exact-locator known binding names the current
-Session ID. Discovery uses that existing authority relationship to emit the
-same callback during refresh. The controller's idempotent target check makes
-repeated refreshes read-only after the first successful backfill.
-
 Construct the alias controller before tmux discovery in `dashboard.ts`, then
 wire the callback to `copyForRebind`. No new service, storage file, schema, or
 provider API is introduced.
@@ -66,8 +56,8 @@ provider API is introduced.
 
 ```text
 same managed tmux locator
-  -> observer/store commit a different Codex root Session ID
-     OR discovery recovers an earlier commit from metadata + exact binding
+  -> observer finds a different Codex root Session ID
+  -> durable runtime store returns "rebound"
   -> discovery reports old and new runtime identities
   -> alias controller copies old alias when the new key is empty
   -> active card resolves the copied alias under the new Session ID
@@ -86,9 +76,7 @@ The focused contract must prove:
 4. No source alias produces no write.
 5. Failed rebind outcomes do not invoke alias migration.
 6. Dashboard activation wires an alias-preserving callback into tmux discovery.
-7. A restart with old immutable metadata and an already-rebound durable binding
-   reports the old-to-current transition for automatic alias backfill.
-8. A throwing alias hook or alias-store save failure is contained, logged at
+7. A throwing alias hook or alias-store save failure is contained, logged at
    the controller boundary, and cannot roll back the new runtime projection.
 
 The owner tests live under `tests/contract/aiSessions/`. They are executed by
@@ -103,6 +91,11 @@ The owner tests live under `tests/contract/aiSessions/`. They are executed by
 - Existing target aliases win, including when they differ from the old alias.
 - Alias failures use the controller's existing logging and save-error UI path;
   discovery also contains unexpected callback rejection.
+- Immutable tmux metadata is not used for automatic historical backfill: after
+  multiple switches it identifies the original root, not a proven direct
+  predecessor, and replaying it would recreate aliases users intentionally
+  reset. An already-affected local alias must be repaired once using the exact
+  diagnosed old/new IDs.
 - Pins, attention events, runtime lifecycle, and provider Session records are
   outside this fix.
 

--- a/docs/superpowers/specs/2026-07-23-tmux-thread-switch-alias-continuity-design.md
+++ b/docs/superpowers/specs/2026-07-23-tmux-thread-switch-alias-continuity-design.md
@@ -1,0 +1,112 @@
+# Tmux Thread Switch Alias Continuity Design
+
+## Context
+
+Project Steward stores a user-defined AI Session name under the stable-looking
+key `provider:<session-id>`. A managed Codex tmux window can later switch its
+root thread while the same runtime continues. Runtime discovery already commits
+that transition by rebinding the durable tmux record from the old Session ID to
+the newly observed Session ID.
+
+The runtime rebind currently updates only runtime identity. The alias remains
+under the old key, so the active card looks up the new key, finds no alias, and
+falls back to the provider Session name or UUID. The old root still appears in
+History and continues to own the user's name.
+
+## Goal
+
+Preserve a user-defined Session name across a successful Codex root-thread
+rebind without losing the old History label or overwriting a name explicitly
+assigned to the new root.
+
+## Required Behavior
+
+- Alias continuity runs only after `TmuxRuntimeBindingStore.rebindKnown()`
+  returns `rebound`.
+- If `provider:<old-session-id>` has an alias and
+  `provider:<new-session-id>` does not, copy the old alias to the new key.
+- Retain the old key and alias so the previous root keeps its readable History
+  label.
+- If the new key already has a non-empty alias, preserve it.
+- If the old alias is absent, either Session ID is empty, the provider is
+  invalid, or both IDs are equal, make no alias-store write.
+- A metadata-copy failure must be logged but must not undo or hide a successful
+  durable runtime rebind.
+- Failed, stale, missing, ambiguous, or non-Codex rebind attempts must not copy
+  aliases.
+
+## Architecture
+
+Add `copyForRebind(providerId, previousSessionId, nextSessionId)` to
+`AiSessionAliasController`. The controller owns alias validation, key creation,
+read/merge/write behavior, and error mapping. It copies rather than moves the
+alias and performs one `saveAll()` only when the target needs the source value.
+
+Add an optional `onSessionRebound(previous, next)` callback to
+`TmuxRuntimeDiscovery`. Discovery calls it after the durable store confirms the
+rebind and before projecting the new identity. The callback is metadata-only:
+discovery catches callback failures so alias persistence cannot invalidate the
+already committed runtime transition.
+
+Construct the alias controller before tmux discovery in `dashboard.ts`, then
+wire the callback to `copyForRebind`. No new service, storage file, schema, or
+provider API is introduced.
+
+## Data Flow
+
+```text
+same managed tmux locator
+  -> observer finds a different Codex root Session ID
+  -> durable runtime store returns "rebound"
+  -> discovery reports old and new runtime identities
+  -> alias controller copies old alias when the new key is empty
+  -> active card resolves the copied alias under the new Session ID
+  -> History continues to resolve the retained old alias
+```
+
+## CI Regression Contract
+
+Add automated behavior `SESSION-ALIAS-THREAD-SWITCH-001`.
+
+The focused contract must prove:
+
+1. A successful rebind copies the old alias to the new Session key.
+2. The old alias is retained.
+3. An existing new-root alias is not overwritten.
+4. No source alias produces no write.
+5. Failed rebind outcomes do not invoke alias migration.
+6. Dashboard activation wires an alias-preserving callback into tmux discovery.
+
+The owner tests live under `tests/contract/aiSessions/`. They are executed by
+`test:deterministic:run`, which is called by `test:ci:linux`, which is the
+`quality-linux` pull-request check in `.github/workflows/verify.yml`.
+
+## Error Handling and Compatibility
+
+- Alias data keeps the existing JSON format.
+- Copying is idempotent: rerunning after a completed copy observes an existing
+  target and performs no write.
+- Existing target aliases win, including when they differ from the old alias.
+- Alias failures use the controller's existing logging and save-error UI path;
+  discovery also contains unexpected callback rejection.
+- Pins, attention events, runtime lifecycle, and provider Session records are
+  outside this fix.
+
+## Verification
+
+Use test-driven development:
+
+1. Register the behavior and add focused controller/discovery/composition
+   assertions.
+2. Compile and run only the focused behavior to observe the current failure.
+3. Add the minimal controller method, discovery callback, and dashboard wiring.
+4. Run the focused behavior to green.
+5. Run behavior-catalog, contract, tmux, architecture, and full Linux CI gates.
+
+## Delivery Constraints
+
+- Work only in the existing isolated worktree on
+  `fix/logical-attention-card-count`.
+- Do not modify the user-dirty primary checkout.
+- Do not push, open a pull request, merge, or publish a release during this
+  fix; more quick fixes may be added to the same branch.

--- a/docs/superpowers/specs/2026-07-23-tmux-thread-switch-alias-continuity-design.md
+++ b/docs/superpowers/specs/2026-07-23-tmux-thread-switch-alias-continuity-design.md
@@ -22,7 +22,9 @@ assigned to the new root.
 ## Required Behavior
 
 - Alias continuity runs only after `TmuxRuntimeBindingStore.rebindKnown()`
-  returns `rebound`.
+  returns `rebound`, or when discovery later proves the same committed
+  transition from immutable managed-tmux metadata and the exact durable
+  locator binding.
 - If `provider:<old-session-id>` has an alias and
   `provider:<new-session-id>` does not, copy the old alias to the new key.
 - Retain the old key and alias so the previous root keeps its readable History
@@ -34,6 +36,8 @@ assigned to the new root.
   durable runtime rebind.
 - Failed, stale, missing, ambiguous, or non-Codex rebind attempts must not copy
   aliases.
+- An installation that already committed the thread switch before this fix
+  must backfill the active alias on its next successful runtime discovery.
 
 ## Architecture
 
@@ -48,6 +52,12 @@ rebind and before projecting the new identity. The callback is metadata-only:
 discovery catches callback failures so alias persistence cannot invalidate the
 already committed runtime transition.
 
+For an already-rebound runtime, immutable tmux metadata still names the
+original Session ID while the exact-locator known binding names the current
+Session ID. Discovery uses that existing authority relationship to emit the
+same callback during refresh. The controller's idempotent target check makes
+repeated refreshes read-only after the first successful backfill.
+
 Construct the alias controller before tmux discovery in `dashboard.ts`, then
 wire the callback to `copyForRebind`. No new service, storage file, schema, or
 provider API is introduced.
@@ -56,8 +66,8 @@ provider API is introduced.
 
 ```text
 same managed tmux locator
-  -> observer finds a different Codex root Session ID
-  -> durable runtime store returns "rebound"
+  -> observer/store commit a different Codex root Session ID
+     OR discovery recovers an earlier commit from metadata + exact binding
   -> discovery reports old and new runtime identities
   -> alias controller copies old alias when the new key is empty
   -> active card resolves the copied alias under the new Session ID
@@ -76,6 +86,10 @@ The focused contract must prove:
 4. No source alias produces no write.
 5. Failed rebind outcomes do not invoke alias migration.
 6. Dashboard activation wires an alias-preserving callback into tmux discovery.
+7. A restart with old immutable metadata and an already-rebound durable binding
+   reports the old-to-current transition for automatic alias backfill.
+8. A throwing alias hook or alias-store save failure is contained, logged at
+   the controller boundary, and cannot roll back the new runtime projection.
 
 The owner tests live under `tests/contract/aiSessions/`. They are executed by
 `test:deterministic:run`, which is called by `test:ci:linux`, which is the

--- a/docs/superpowers/specs/2026-07-24-project-catalog-sync-conflict-recovery-design.md
+++ b/docs/superpowers/specs/2026-07-24-project-catalog-sync-conflict-recovery-design.md
@@ -1,0 +1,287 @@
+# Project Catalog Sync Conflict Recovery Design
+
+## Context
+
+Project Steward currently stores the entire saved-project catalog in the single
+user setting `projectSteward.projectData`. Every project mutation rewrites the
+complete group array. VS Code Settings Sync can transport that setting between
+machines, but it does not understand project IDs, additions, edits, moves, or
+deletions inside the array.
+
+The `build-your-own-x` incident proves the resulting data-loss path:
+
+1. the remote Dev Container extension host logged a successful project mutation;
+2. the saved record was present when the same project was saved again;
+3. the original window logged no later Project Steward removal mutation;
+4. a later exported catalog contained the older 34-project snapshot instead of
+   the 35-project snapshot containing `build-your-own-x`.
+
+The exact client that supplied the older value is not identifiable because the
+current format has no writer, revision, or reconciliation diagnostics. The
+evidence nevertheless rules out a failed save and is consistent with a stale
+full-setting replacement from another synced client.
+
+## Goal
+
+Keep Settings Sync support while preventing an older catalog snapshot from
+silently removing a project saved on another client.
+
+The fix must distinguish absence from deletion:
+
+- a record missing from a snapshot is not a deletion;
+- only an explicit, causally newer tombstone is a deletion;
+- a concurrent deletion conflict keeps the live project and reports recovery;
+- a stale snapshot cannot undo either a new project or a valid observed
+  deletion.
+
+## Non-Goals
+
+- Building a general conflict-management UI.
+- Providing real-time collaboration between simultaneously open windows.
+- Changing the existing behavior when
+  `projectSteward.storeProjectsInSettings` is `false`.
+- Recovering data after every device and every synced or local copy of that data
+  has been permanently destroyed.
+- Treating deletion performed by an old extension version as authoritative when
+  that version cannot emit a tombstone.
+
+## Options Considered
+
+### Re-read and union before save
+
+This is the smallest change, but it only narrows the race between a read and a
+local write. It cannot repair a Settings Sync rollback that arrives after a
+successful save. A plain union would also resurrect intentionally deleted
+projects.
+
+### Local backup only
+
+A local backup could restore the incident project, but it could not distinguish
+an intentional remote deletion from a stale omission. It would turn every
+multi-machine deletion into an ambiguous restore.
+
+### Versioned synchronized catalog with a local shadow
+
+This is the selected design. A versioned document gives additions, updates, and
+deletions explicit identities and causal metadata. A nonsynced local shadow
+retains the latest state known by each extension host and can repair a later
+whole-setting rollback.
+
+## Storage Architecture
+
+### Synchronized document
+
+Add the user setting `projectSteward.projectSyncData`. It stores a versioned
+document whose logical shape is:
+
+```text
+ProjectSyncDocumentV1
+  schemaVersion
+  versionVector
+  groups[groupId] -> versioned group fields
+  projects[projectId] -> versioned project fields + groupId
+  groupTombstones[groupId] -> deletion version
+  projectTombstones[projectId] -> deletion version
+  layout -> versioned group and project ordering
+```
+
+Every extension host has a stable local actor ID and an increasing actor
+counter. A local mutation increments the counter and stamps only the affected
+records, tombstones, and layout. Version vectors determine whether one value
+causally follows another or whether two values are concurrent. Actor IDs provide
+a deterministic tie-break for concurrent field or layout edits.
+
+`projectSyncData` becomes the canonical source when settings storage is enabled.
+The existing `projectData` array remains a compatibility projection so current
+commands, user exports, and older extension versions continue to see the
+catalog's materialized group-array shape.
+
+### Local recovery shadow
+
+Store the last merged `ProjectSyncDocumentV1` in extension `globalState` under a
+new versioned shadow key. The shadow is deliberately not synced. It protects a
+known operation when Settings Sync later replaces the synchronized document
+with an older whole value.
+
+The shadow is not a second user-facing catalog. It is an extension-owned replica
+used only for reconciliation and retry.
+
+### Reconciliation boundary
+
+Add a focused catalog synchronization component rather than expanding
+`ProjectService` with merge internals. It owns:
+
+- migration from legacy `projectData`;
+- version stamping and tombstone creation;
+- deterministic document merge and materialization;
+- shadow persistence;
+- serialized writes and retry state;
+- conflict and repair diagnostics.
+
+`ProjectService` continues to expose the existing group/project API. When
+settings storage is enabled, it delegates reads and mutations to the
+synchronization component. Global-state-only storage keeps its current path.
+
+## Merge Semantics
+
+1. Merge the incoming synchronized document with the local shadow by stable
+   group and project ID.
+2. Preserve a record that is present on only one side. Absence is never treated
+   as deletion.
+3. Apply a tombstone only when its version causally follows the corresponding
+   live record.
+4. If a live record and tombstone are concurrent, keep the live record and emit
+   a conflict diagnostic. This implements the approved no-silent-loss policy.
+5. If two live values are concurrent, choose deterministically by version and
+   actor ID. The project ID remains present, so the conflict cannot erase the
+   saved project.
+6. Merge layout independently from record existence. A stale order may lose a
+   deterministic ordering tie-break, but it cannot drop a record.
+7. Group deletion emits tombstones for the group and for projects intentionally
+   removed with it. Moving projects or deleting an empty group does not create
+   unrelated project tombstones.
+8. Re-adding a removed project creates a new project ID; tombstoned IDs are not
+   reused.
+
+The normalized merged document must have a stable serialization. Reconciliation
+rewrites `projectSyncData` only when the incoming synchronized value is missing
+known state, preventing configuration-change write loops.
+
+## Data Flow
+
+### Local mutation
+
+```text
+current sync value + local shadow
+  -> reconcile
+  -> apply one explicit add/update/move/delete mutation
+  -> increment local actor version
+  -> persist local shadow
+  -> persist projectSyncData
+  -> persist compatible projectData projection
+  -> refresh the dashboard
+```
+
+Persisting the shadow first means a failed synchronized-setting write leaves a
+retryable local operation instead of silently discarding it.
+
+### Incoming Settings Sync change
+
+```text
+incoming projectSyncData/projectData change
+  -> serialize behind any local mutation
+  -> merge incoming document with local shadow
+  -> preserve additions and valid tombstones
+  -> rewrite stale synchronized state when repair is required
+  -> refresh only after the merged catalog is available
+```
+
+Configuration changes for the canonical and compatibility settings may arrive
+separately. Reconciliation therefore reads both current values inside one
+serialized task rather than assuming event order.
+
+### Convergence guarantee
+
+A client that has never observed an operation cannot reconstruct it while every
+replica carrying that operation is offline. The guarantee is therefore
+eventual: as long as the synchronized document or at least one local shadow
+still contains the operation, bringing a carrying replica back online causes
+the merged document to be republished and all new-version clients converge.
+Temporary stale display before that reconciliation is possible; silent
+permanent loss while a valid replica survives is not.
+
+### Legacy migration
+
+On first activation without `projectSyncData`, convert the current
+`projectData` array into a baseline versioned document while preserving all
+existing group and project IDs, fields, and order. Persist the shadow before the
+new synchronized document and projection.
+
+After migration, additions and updates supplied through the legacy array can be
+imported conservatively. A legacy snapshot's missing record cannot be imported
+as a deletion because it has no tombstone. This makes mixed-version operation
+addition-safe while requiring the new extension version for reliable
+cross-machine deletion.
+
+## Failure and Conflict Handling
+
+- Serialize local mutations and reconciliation so two extension events cannot
+  interleave partial writes.
+- If the synchronized document is absent or malformed, retain the valid shadow
+  and legacy projection, log the invalid source, and repair the synchronized
+  value. Never replace valid local data with an empty catalog.
+- If no valid shadow or synchronized document exists, migrate the valid legacy
+  array. Invalid legacy data continues to use the existing validation behavior.
+- If shadow persistence fails, abort the synchronized write and surface the
+  existing mutation error; an operation is not reported as saved before its
+  recovery copy exists.
+- If the synchronized or compatibility write fails after the shadow succeeds,
+  retain retry state and reconcile on the next activation, relevant
+  configuration change, or local mutation.
+- Log actor ID, causal versions, repair reason, and affected record IDs without
+  logging project descriptions or the complete catalog.
+- When concurrent deletion recovery keeps a live project, show one bounded
+  informational notification for that reconciliation rather than one message
+  per record.
+
+## CI-First Regression Contract
+
+Register behavior `PROJECT-CATALOG-SYNC-CONFLICT-001` and make its owner tests
+reachable from the existing Linux PR CI command.
+
+The first test must exercise the current public service behavior before any
+production change:
+
+1. create two clients from the same catalog;
+2. let client B save a new project;
+3. let client A submit its older full snapshot;
+4. assert that the new project remains.
+
+On the current implementation, step 3 replaces the array and the assertion must
+fail for the diagnosed reason. A compile failure or a fixture failure is not an
+acceptable RED.
+
+The complete focused contract must then prove:
+
+1. stale client overwrite cannot remove a project added by another client;
+2. a deletion made after observing the project emits a tombstone and is
+   restored as the winning state when a tombstone-carrying client reconciles
+   after an older snapshot returns;
+3. concurrent deletion and live update preserve the project and report one
+   recovery conflict;
+4. migration preserves legacy IDs, fields, groups, and ordering;
+5. stale `projectData` projection cannot override a newer canonical document;
+6. malformed synchronized data cannot replace a valid shadow or legacy catalog;
+7. shadow failure aborts the user-visible save, while later synchronized-write
+   failure remains retryable;
+8. repeated reconciliation is idempotent and does not create a configuration
+   change loop;
+9. global-state-only storage retains its existing behavior.
+
+Owner tests should exercise the merge component deterministically, while a
+service/composition contract proves `ProjectService` and configuration-change
+handling use it. The behavior catalog and full Linux CI-equivalent gate must run
+after the focused tests pass.
+
+## Delivery Constraints
+
+- Work only in the existing clean worktree on
+  `fix/logical-attention-card-count`.
+- Preserve the user-dirty primary checkout.
+- Follow strict RED, minimal GREEN, and refactor-after-GREEN sequencing.
+- Keep the sync fix isolated from session attention, aliases, Skill management,
+  and unrelated refactoring.
+- Do not push, open or merge a pull request, publish a VSIX, or release a
+  version during this fix.
+
+## Acceptance Criteria
+
+1. The diagnosed two-client stale-snapshot sequence is covered by CI and passes.
+2. A saved project omitted by a later snapshot is restored when any replica
+   carrying its versioned record reconciles.
+3. Only explicit causally valid tombstones delete synchronized records.
+4. Concurrent deletion conflicts preserve the live project and are observable.
+5. Existing catalogs migrate without changing IDs or visible ordering.
+6. Settings Sync remains available and `projectData` remains compatible.
+7. Local recovery data makes failed or stale synchronized writes retryable.
+8. Existing global-state-only users are unaffected.

--- a/docs/superpowers/specs/2026-07-24-project-catalog-sync-conflict-recovery-design.md
+++ b/docs/superpowers/specs/2026-07-24-project-catalog-sync-conflict-recovery-design.md
@@ -28,8 +28,10 @@ silently removing a project saved on another client.
 
 The fix must distinguish absence from deletion:
 
-- a record missing from a snapshot is not a deletion;
-- only an explicit, causally newer tombstone is a deletion;
+- a record merely missing from an unversioned or unobserving snapshot is not a
+  deletion;
+- only an explicit removal whose causal context has observed the record is a
+  deletion;
 - a concurrent deletion conflict keeps the live project and reports recovery;
 - a stale snapshot cannot undo either a new project or a valid observed
   deletion.
@@ -43,7 +45,7 @@ The fix must distinguish absence from deletion:
 - Recovering data after every device and every synced or local copy of that data
   has been permanently destroyed.
 - Treating deletion performed by an old extension version as authoritative when
-  that version cannot emit a tombstone.
+  that version cannot advance the versioned causal context.
 
 ## Options Considered
 
@@ -62,10 +64,10 @@ multi-machine deletion into an ambiguous restore.
 
 ### Versioned synchronized catalog with a local shadow
 
-This is the selected design. A versioned document gives additions, updates, and
-deletions explicit identities and causal metadata. A nonsynced local shadow
-retains the latest state known by each extension host and can repair a later
-whole-setting rollback.
+This is the selected design. A versioned observed-remove map gives additions,
+updates, and deletions causal metadata without retaining an operation log or
+per-deletion tombstone table. A nonsynced local shadow retains the latest state
+known by each extension host and can repair a later whole-setting rollback.
 
 ## Storage Architecture
 
@@ -77,19 +79,19 @@ document whose logical shape is:
 ```text
 ProjectSyncDocumentV1
   schemaVersion
-  versionVector
+  versionVector -> compact causal context, one counter per observed actor
   groups[groupId] -> versioned group fields
   projects[projectId] -> versioned project fields + groupId
-  groupTombstones[groupId] -> deletion version
-  projectTombstones[projectId] -> deletion version
   layout -> versioned group and project ordering
 ```
 
 Every extension host has a stable local actor ID and an increasing actor
 counter. A local mutation increments the counter and stamps only the affected
-records, tombstones, and layout. Version vectors determine whether one value
-causally follows another or whether two values are concurrent. Actor IDs provide
-a deterministic tie-break for concurrent field or layout edits.
+records and layout. An explicit removal deletes the live record after advancing
+the document's causal context past the removed record. Version vectors determine
+whether a side observed a record before omitting it or whether the omission is
+concurrent and therefore unsafe to treat as deletion. Actor IDs provide a
+deterministic tie-break for concurrent field or layout edits.
 
 `projectSyncData` becomes the canonical source when settings storage is enabled.
 The existing `projectData` array remains a compatibility projection so current
@@ -112,7 +114,7 @@ Add a focused catalog synchronization component rather than expanding
 `ProjectService` with merge internals. It owns:
 
 - migration from legacy `projectData`;
-- version stamping and tombstone creation;
+- version stamping and observed-remove causal-context updates;
 - deterministic document merge and materialization;
 - shadow persistence;
 - serialized writes and retry state;
@@ -125,27 +127,54 @@ synchronization component. Global-state-only storage keeps its current path.
 ## Merge Semantics
 
 1. Merge the incoming synchronized document with the local shadow by stable
-   group and project ID.
-2. Preserve a record that is present on only one side. Absence is never treated
-   as deletion.
-3. Apply a tombstone only when its version causally follows the corresponding
-   live record.
-4. If a live record and tombstone are concurrent, keep the live record and emit
+   group and project ID, and take the per-actor maximum for the merged version
+   vector.
+2. If a live record exists on only one side, remove it only when the other
+   side's causal context dominates that record's version. Dominance proves the
+   other side observed and explicitly removed that value.
+3. If the other side did not observe the record, preserve it. A stale or
+   concurrent omission is not a deletion.
+4. If a removal and a live update are concurrent, keep the live record and emit
    a conflict diagnostic. This implements the approved no-silent-loss policy.
 5. If two live values are concurrent, choose deterministically by version and
    actor ID. The project ID remains present, so the conflict cannot erase the
    saved project.
 6. Merge layout independently from record existence. A stale order may lose a
    deterministic ordering tie-break, but it cannot drop a record.
-7. Group deletion emits tombstones for the group and for projects intentionally
-   removed with it. Moving projects or deleting an empty group does not create
-   unrelated project tombstones.
-8. Re-adding a removed project creates a new project ID; tombstoned IDs are not
-   reused.
+7. Group deletion explicitly removes the group and projects intentionally
+   removed with it after advancing the causal context. Moving projects or
+   deleting an empty group does not remove unrelated projects.
+8. Re-adding a removed project through the product creates a new project ID.
+   A stale same-ID record whose version is dominated by the causal context
+   remains removed.
 
 The normalized merged document must have a stable serialization. Reconciliation
 rewrites `projectSyncData` only when the incoming synchronized value is missing
 known state, preventing configuration-change write loops.
+
+## Storage Growth and Sync Cost
+
+The synchronized format is a state document, not an append-only operation log:
+
+- edits replace the latest versioned value instead of appending history;
+- observed deletions are compressed into the version vector and do not leave a
+  permanent per-project or per-group tombstone;
+- repeated mutations by the same extension host update one actor counter;
+- the version vector grows with the number of distinct extension hosts that
+  have participated, not with the number of saves, edits, or deletions.
+
+While compatibility is required, Settings Sync carries both the live
+`projectData` projection and the versioned `projectSyncData` document. The
+steady-state synchronized payload is therefore approximately two live catalogs
+plus small record-version and actor-vector metadata. The local shadow is not
+synced. Removing the legacy projection can be considered only in a future
+schema-breaking release after old clients no longer need it.
+
+The focused tests must include repeated add/delete cycles from a fixed actor set
+and prove that no operation history or tombstone collection grows. Payload size
+may grow with legitimate live catalog fields and newly participating actors; it
+must not grow merely because existing actors continue to mutate the same
+catalog.
 
 ## Data Flow
 
@@ -171,7 +200,7 @@ retryable local operation instead of silently discarding it.
 incoming projectSyncData/projectData change
   -> serialize behind any local mutation
   -> merge incoming document with local shadow
-  -> preserve additions and valid tombstones
+  -> preserve unseen additions and causally valid removals
   -> rewrite stale synchronized state when repair is required
   -> refresh only after the merged catalog is available
 ```
@@ -199,9 +228,9 @@ new synchronized document and projection.
 
 After migration, additions and updates supplied through the legacy array can be
 imported conservatively. A legacy snapshot's missing record cannot be imported
-as a deletion because it has no tombstone. This makes mixed-version operation
-addition-safe while requiring the new extension version for reliable
-cross-machine deletion.
+as a deletion because it has no causal context proving observation. This makes
+mixed-version operation addition-safe while requiring the new extension version
+for reliable cross-machine deletion.
 
 ## Failure and Conflict Handling
 
@@ -244,8 +273,8 @@ acceptable RED.
 The complete focused contract must then prove:
 
 1. stale client overwrite cannot remove a project added by another client;
-2. a deletion made after observing the project emits a tombstone and is
-   restored as the winning state when a tombstone-carrying client reconciles
+2. a deletion made after observing the project advances causal context and is
+   restored as the winning state when a deletion-carrying client reconciles
    after an older snapshot returns;
 3. concurrent deletion and live update preserve the project and report one
    recovery conflict;
@@ -256,7 +285,9 @@ The complete focused contract must then prove:
    failure remains retryable;
 8. repeated reconciliation is idempotent and does not create a configuration
    change loop;
-9. global-state-only storage retains its existing behavior.
+9. repeated add/delete cycles by fixed actors do not accumulate operation
+   history or tombstones;
+10. global-state-only storage retains its existing behavior.
 
 Owner tests should exercise the merge component deterministically, while a
 service/composition contract proves `ProjectService` and configuration-change
@@ -279,9 +310,11 @@ after the focused tests pass.
 1. The diagnosed two-client stale-snapshot sequence is covered by CI and passes.
 2. A saved project omitted by a later snapshot is restored when any replica
    carrying its versioned record reconciles.
-3. Only explicit causally valid tombstones delete synchronized records.
+3. Only explicit removals whose causal context observed a record delete it.
 4. Concurrent deletion conflicts preserve the live project and are observable.
 5. Existing catalogs migrate without changing IDs or visible ordering.
 6. Settings Sync remains available and `projectData` remains compatible.
 7. Local recovery data makes failed or stale synchronized writes retryable.
 8. Existing global-state-only users are unaffected.
+9. Sync metadata grows with live records and participating actors, not mutation
+   or deletion history.

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -2585,7 +2585,8 @@
       "tests/contract/persistence/projectCatalogSync.test.js"
     ],
     "evidence": [
-      "src/services/projectService.ts"
+      "src/services/projectService.ts",
+      "src/projects/projectCatalogSync.ts"
     ]
   },
   {

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -329,6 +329,23 @@
     ]
   },
   {
+    "id": "SESSION-ALIAS-THREAD-SWITCH-001",
+    "domain": "session",
+    "title": "Tmux Thread Switch Alias Continuity behavior",
+    "priority": "P0",
+    "status": "automated",
+    "owners": [
+      "tests/contract/aiSessions/controllerBoundaries.test.js",
+      "tests/contract/aiSessions/tmuxDiscovery.test.js",
+      "tests/contract/aiSessions/runtimeComposition.test.js"
+    ],
+    "evidence": [
+      "src/aiSessions/aliasController.ts",
+      "src/aiSessions/tmuxRuntimeDiscovery.ts",
+      "src/dashboard.ts"
+    ]
+  },
+  {
     "id": "PERSIST-PROJECT-STATE-STORE-001",
     "domain": "persistence",
     "title": "Project State Store behavior",

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -2576,6 +2576,19 @@
     ]
   },
   {
+    "id": "PROJECT-CATALOG-SYNC-CONFLICT-001",
+    "domain": "persistence",
+    "title": "Project Catalog Sync Conflict Recovery behavior",
+    "priority": "P0",
+    "status": "automated",
+    "owners": [
+      "tests/contract/persistence/projectCatalogSync.test.js"
+    ],
+    "evidence": [
+      "src/services/projectService.ts"
+    ]
+  },
+  {
     "id": "OPEN-WORKSPACE-NAVIGATION-001",
     "domain": "open-project",
     "title": "Workspace navigation uses exact URIs and fails closed without root substitution",

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -2582,12 +2582,17 @@
     "priority": "P0",
     "status": "automated",
     "owners": [
-      "tests/contract/persistence/projectCatalogSync.test.js"
+      "tests/contract/persistence/projectCatalogSync.test.js",
+      "tests/contract/projects/controllers.test.js",
+      "tests/integration/dashboard/errorRecovery.test.js"
     ],
     "evidence": [
       "src/services/projectService.ts",
       "src/projects/projectCatalogSync.ts",
-      "src/services/projectCatalogSyncService.ts"
+      "src/services/projectCatalogSyncService.ts",
+      "src/projects/projectManualEditController.ts",
+      "src/dashboard/lifecycleController.ts",
+      "src/dashboard.ts"
     ]
   },
   {

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -2586,7 +2586,8 @@
     ],
     "evidence": [
       "src/services/projectService.ts",
-      "src/projects/projectCatalogSync.ts"
+      "src/projects/projectCatalogSync.ts",
+      "src/services/projectCatalogSyncService.ts"
     ]
   },
   {

--- a/package.json
+++ b/package.json
@@ -90,6 +90,14 @@
                     "markdownDescription": "Stores the Project Steward data if the ```projectSteward.storeProjectsInSettings``` option is set to ```true```. The raw data can be edited by using the command ```Project Steward: Edit Projects```.",
                     "default": null
                 },
+                "projectSteward.projectSyncData": {
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "markdownDescription": "Versioned Project Steward sync metadata. Use Project Steward commands to edit projects.",
+                    "default": null
+                },
                 "projectSteward.todoData": {
                     "type": [
                         "object",

--- a/src/aiSessions/aliasController.ts
+++ b/src/aiSessions/aliasController.ts
@@ -63,6 +63,41 @@ export default class AiSessionAliasController {
         }
     }
 
+    copyForRebind(
+        providerId: AiSessionProviderId,
+        previousSessionId: string,
+        nextSessionId: string
+    ): void {
+        if (!this.options.isProviderId(providerId)
+            || !previousSessionId
+            || !nextSessionId
+            || previousSessionId === nextSessionId) {
+            return;
+        }
+
+        const previousKey = this.options.getSessionKey(providerId, previousSessionId);
+        const nextKey = this.options.getSessionKey(providerId, nextSessionId);
+        try {
+            const aliases = this.options.store.getAll();
+            const previousAlias = sanitizeAiSessionAlias(aliases[previousKey]);
+            const nextAlias = sanitizeAiSessionAlias(aliases[nextKey]);
+            if (!previousAlias || nextAlias) {
+                return;
+            }
+
+            this.options.store.saveAll({
+                ...aliases,
+                [nextKey]: previousAlias,
+            });
+        } catch (error) {
+            this.options.logError(
+                'Failed to preserve AI session alias after runtime rebind.',
+                error
+            );
+            this.options.showSaveError?.();
+        }
+    }
+
     getOriginalName(providerId: AiSessionProviderId, sessionId: string): string {
         let sessionResult = this.options.getProviderResult(providerId, { reason: 'alias-original-name' });
         let session = sessionResult.sessions.find(candidate => candidate.id === sessionId);

--- a/src/aiSessions/tmuxRuntimeDiscovery.ts
+++ b/src/aiSessions/tmuxRuntimeDiscovery.ts
@@ -314,6 +314,20 @@ export class TmuxRuntimeDiscovery {
         }));
     }
 
+    private notifySessionRebound(
+        previous: AiSessionRuntimeIdentity,
+        next: AiSessionRuntimeIdentity
+    ): void {
+        try {
+            this.options.onSessionRebound?.(
+                cloneAiSessionRuntimeIdentity(previous),
+                cloneAiSessionRuntimeIdentity(next)
+            );
+        } catch (e) {
+            // Runtime identity is already durably rebound; metadata hooks are best-effort.
+        }
+    }
+
     private async enumerate(): Promise<DiscoveryResult> {
         const listed = await this.options.client.listWindows();
         if (!Array.isArray(listed) || listed.length > MAX_DISCOVERY_ROWS) {
@@ -420,6 +434,13 @@ export class TmuxRuntimeDiscovery {
                 || (parsed.createdAt ? Date.parse(parsed.createdAt) : 0);
 
             if (locatorKnown
+                && identity.provider === 'codex'
+                && identity.sessionId
+                && identity.sessionId !== locatorKnown.sessionId) {
+                this.notifySessionRebound(identity, projectedIdentity);
+            }
+
+            if (locatorKnown
                 && projectedIdentity.provider === 'codex'
                 && Number.isSafeInteger(row.panePid)
                 && row.panePid > 0
@@ -440,16 +461,11 @@ export class TmuxRuntimeDiscovery {
                         locatorKnown, observedSessionId
                     );
                     if (rebound === 'rebound') {
-                        const previousIdentity = cloneAiSessionRuntimeIdentity(projectedIdentity);
-                        const nextIdentity = cloneAiSessionRuntimeIdentity({
+                        const nextIdentity = {
                             ...projectedIdentity,
                             sessionId: observedSessionId,
-                        });
-                        try {
-                            this.options.onSessionRebound?.(previousIdentity, nextIdentity);
-                        } catch (e) {
-                            // Runtime identity is already durably rebound; metadata hooks are best-effort.
-                        }
+                        };
+                        this.notifySessionRebound(projectedIdentity, nextIdentity);
                         projectedIdentity = nextIdentity;
                     }
                 }

--- a/src/aiSessions/tmuxRuntimeDiscovery.ts
+++ b/src/aiSessions/tmuxRuntimeDiscovery.ts
@@ -434,13 +434,6 @@ export class TmuxRuntimeDiscovery {
                 || (parsed.createdAt ? Date.parse(parsed.createdAt) : 0);
 
             if (locatorKnown
-                && identity.provider === 'codex'
-                && identity.sessionId
-                && identity.sessionId !== locatorKnown.sessionId) {
-                this.notifySessionRebound(identity, projectedIdentity);
-            }
-
-            if (locatorKnown
                 && projectedIdentity.provider === 'codex'
                 && Number.isSafeInteger(row.panePid)
                 && row.panePid > 0

--- a/src/aiSessions/tmuxRuntimeDiscovery.ts
+++ b/src/aiSessions/tmuxRuntimeDiscovery.ts
@@ -75,6 +75,10 @@ export interface TmuxRuntimeDiscoveryOptions {
     client: TmuxDiscoveryClient;
     bindingStore: TmuxDiscoveryBindingStore;
     codexRootThreadObserver?: CodexRootThreadObserver;
+    onSessionRebound?: (
+        previous: AiSessionRuntimeIdentity,
+        next: AiSessionRuntimeIdentity
+    ) => void;
     markerIsCurrent: (markerPath: string, runStartedAtMs: number) => boolean | Promise<boolean>;
     nowMs?: () => number;
     cacheTtlMs?: number;
@@ -436,10 +440,17 @@ export class TmuxRuntimeDiscovery {
                         locatorKnown, observedSessionId
                     );
                     if (rebound === 'rebound') {
-                        projectedIdentity = {
+                        const previousIdentity = cloneAiSessionRuntimeIdentity(projectedIdentity);
+                        const nextIdentity = cloneAiSessionRuntimeIdentity({
                             ...projectedIdentity,
                             sessionId: observedSessionId,
-                        };
+                        });
+                        try {
+                            this.options.onSessionRebound?.(previousIdentity, nextIdentity);
+                        } catch (e) {
+                            // Runtime identity is already durably rebound; metadata hooks are best-effort.
+                        }
+                        projectedIdentity = nextIdentity;
                     }
                 }
             }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,6 +18,8 @@ export const INBUILT_COLOR_DEFAULTS = [
 ];
 
 export const PROJECTS_KEY = 'projects';
+export const PROJECT_SYNC_DATA_KEY = 'projectSyncData';
+export const PROJECT_SYNC_LOCAL_STATE_KEY = 'projectCatalogSyncLocal.v1';
 export const TODO_DATA_KEY = 'todos';
 export const TODO_SETTINGS_KEY = 'todoData';
 export const TODO_VIEW_STATE_KEY = 'todoViewState';

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -200,7 +200,18 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     const logOpenWorkspaceBridgeError = (error: unknown) => dashboardDiagnostics.logOpenWorkspaceBridgeError(error);
 
     const colorService = new ColorService(context);
-    const projectService = new ProjectService(context, colorService);
+    const projectService = new ProjectService(context, colorService, {
+        onDiagnostic: event => logDashboardDiagnostic(event),
+        onConflict: projectIds => {
+            logDashboardDiagnostic({
+                event: 'project-catalog-sync-conflict-recovered',
+                projectIds,
+            });
+            void vscode.window.showInformationMessage(
+                'Project Steward recovered projects from a sync conflict.'
+            );
+        },
+    });
     const todoService = new TodoService(context);
     const todoViewState = todoService.getViewState();
     let revealedTodoId: string | undefined;
@@ -296,7 +307,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         openTextDocument: uri => vscode.workspace.openTextDocument(uri),
         showTextDocument: document => vscode.window.showTextDocument(document),
         onWillSaveTextDocument: listener => vscode.workspace.onWillSaveTextDocument(listener),
-        saveGroups: groups => projectService.saveGroups(groups),
+        saveGroups: (groups, baselineGroups) =>
+            projectService.saveGroupsFromManualEdit(groups, baselineGroups),
         executeCommand: command => vscode.commands.executeCommand(command),
         showErrorMessage: message => vscode.window.showErrorMessage(message),
         postSave: () => showSteward(),
@@ -1549,6 +1561,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         checkDataMigration: async openStewardAfterMigrate => {
             await dashboardStartupController.checkDataMigration(openStewardAfterMigrate);
         },
+        reconcileProjectCatalog: () => projectService.reconcileProjectCatalog(),
         applyProjectColorToCurrentWindow,
         refresh: refreshStewardViews,
         publishOpenWorkspace: followsFocusEvent => openWorkspaceController.publish(followsFocusEvent),

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -335,6 +335,15 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         aiSessionProviders,
         logAiSessionDiagnostic
     );
+    const aiSessionAliasStore = new AiSessionAliasStore(context.globalStoragePath);
+    const aiSessionAliasController = new AiSessionAliasController({
+        store: aiSessionAliasStore,
+        isProviderId: isAiSessionProviderId,
+        getSessionKey: getAiSessionPinKey,
+        getProviderResult: (providerId, options) => aiSessionReadCoordinator.getProviderResult(providerId, options),
+        logError,
+        showSaveError: () => vscode.window.showErrorMessage("Could not save the chat name."),
+    });
     const aiSessionTerminalBindingStore = new AiSessionTerminalBindingStore(context.workspaceState, error =>
         logError('Failed to persist AI session terminal ownership.', error)
     );
@@ -363,6 +372,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         client: tmuxClient,
         bindingStore: tmuxRuntimeStore,
         codexRootThreadObserver: new ProcCodexRootThreadObserver(),
+        onSessionRebound: (previous, next) => aiSessionAliasController.copyForRebind(
+            previous.provider,
+            previous.sessionId || '',
+            next.sessionId || ''
+        ),
         markerIsCurrent: isCurrentRuntimeMarker,
     });
     try {
@@ -414,15 +428,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     } catch (error) {
         logAiSessionRuntimeFailure('restore-attach-terminals', error);
     }
-    const aiSessionAliasStore = new AiSessionAliasStore(context.globalStoragePath);
-    const aiSessionAliasController = new AiSessionAliasController({
-        store: aiSessionAliasStore,
-        isProviderId: isAiSessionProviderId,
-        getSessionKey: getAiSessionPinKey,
-        getProviderResult: (providerId, options) => aiSessionReadCoordinator.getProviderResult(providerId, options),
-        logError,
-        showSaveError: () => vscode.window.showErrorMessage("Could not save the chat name."),
-    });
     const aiSessionPinStore = new AiSessionPinStore(context.globalStoragePath);
     const aiSessionPinController = new AiSessionPinController({
         store: aiSessionPinStore,

--- a/src/dashboard/lifecycleController.ts
+++ b/src/dashboard/lifecycleController.ts
@@ -10,6 +10,7 @@ export interface WindowStateLike {
 
 export interface DashboardLifecycleControllerOptions {
     checkDataMigration: (openStewardAfterMigrate: boolean) => Promise<void>;
+    reconcileProjectCatalog?: () => Promise<void>;
     applyProjectColorToCurrentWindow: () => void;
     refresh: (reason: string) => void;
     publishOpenWorkspace: (followsFocusEvent?: boolean) => void;
@@ -24,6 +25,11 @@ export class DashboardLifecycleController {
         if (event.affectsConfiguration('projectSteward.storeProjectsInSettings')
             || event.affectsConfiguration('dashboard.storeProjectsInSettings')) {
             await this.options.checkDataMigration(false);
+        }
+
+        if (event.affectsConfiguration('projectSteward.projectSyncData')
+            || event.affectsConfiguration('projectSteward.projectData')) {
+            await this.options.reconcileProjectCatalog?.();
         }
 
         if (event.affectsConfiguration('projectSteward')

--- a/src/projects/projectCatalogSync.ts
+++ b/src/projects/projectCatalogSync.ts
@@ -78,6 +78,15 @@ function dominates(left: Record<string, number>, right: Record<string, number>):
         (left && left[actorId] || 0) >= (right[actorId] || 0));
 }
 
+function strictlyDominates(
+    left: Record<string, number>,
+    right: Record<string, number>
+): boolean {
+    return dominates(left, right)
+        && Object.keys({ ...(left || {}), ...(right || {}) }).some(actorId =>
+            (left && left[actorId] || 0) > (right && right[actorId] || 0));
+}
+
 function mergeVectors(
     left: Record<string, number>,
     right: Record<string, number>
@@ -367,6 +376,11 @@ export function applyProjectCatalogSnapshot(
     }
     for (const groupId of options.deletedGroupIds || []) {
         delete desiredGroups[groupId];
+        for (const projectId of Object.keys(desiredProjects)) {
+            if (desiredProjects[projectId].groupId === groupId) {
+                delete desiredProjects[projectId];
+            }
+        }
     }
 
     const desiredGroupIds = requestedGroupIds.filter(groupId => desiredGroups[groupId]);
@@ -490,9 +504,11 @@ export function mergeProjectCatalogDocuments(
         const rightRecord = right.groups[groupId];
         if (leftRecord && rightRecord) {
             groups[groupId] = chooseRecord(leftRecord, rightRecord);
-        } else if (leftRecord && !dominates(right.versionVector, leftRecord.version.vector)) {
+        } else if (leftRecord
+            && !strictlyDominates(right.versionVector, leftRecord.version.vector)) {
             groups[groupId] = clone(leftRecord);
-        } else if (rightRecord && !dominates(left.versionVector, rightRecord.version.vector)) {
+        } else if (rightRecord
+            && !strictlyDominates(left.versionVector, rightRecord.version.vector)) {
             groups[groupId] = clone(rightRecord);
         }
     }
@@ -505,10 +521,12 @@ export function mergeProjectCatalogDocuments(
         const rightRecord = right.projects[projectId];
         if (leftRecord && rightRecord) {
             projects[projectId] = chooseRecord(leftRecord, rightRecord);
-        } else if (leftRecord && !dominates(right.versionVector, leftRecord.version.vector)) {
+        } else if (leftRecord
+            && !strictlyDominates(right.versionVector, leftRecord.version.vector)) {
             projects[projectId] = clone(leftRecord);
             conflictProjectIds.add(projectId);
-        } else if (rightRecord && !dominates(left.versionVector, rightRecord.version.vector)) {
+        } else if (rightRecord
+            && !strictlyDominates(left.versionVector, rightRecord.version.vector)) {
             projects[projectId] = clone(rightRecord);
             conflictProjectIds.add(projectId);
         }

--- a/src/projects/projectCatalogSync.ts
+++ b/src/projects/projectCatalogSync.ts
@@ -1,0 +1,541 @@
+'use strict';
+
+import type { Group, Project } from '../models';
+
+export interface ProjectCatalogVersion {
+    actorId: string;
+    vector: Record<string, number>;
+}
+
+export interface VersionedProjectCatalogGroup {
+    value: Record<string, unknown>;
+    version: ProjectCatalogVersion;
+}
+
+export interface VersionedProjectCatalogProject {
+    value: Project;
+    groupId: string;
+    version: ProjectCatalogVersion;
+}
+
+export interface ProjectCatalogLayout {
+    groupIds: string[];
+    projectIdsByGroup: Record<string, string[]>;
+}
+
+export interface VersionedProjectCatalogLayout {
+    value: ProjectCatalogLayout;
+    version: ProjectCatalogVersion;
+}
+
+export interface ProjectCatalogSyncDocumentV1 {
+    schemaVersion: 1;
+    versionVector: Record<string, number>;
+    groups: Record<string, VersionedProjectCatalogGroup>;
+    projects: Record<string, VersionedProjectCatalogProject>;
+    layout: VersionedProjectCatalogLayout;
+}
+
+export interface ProjectCatalogMutationOptions {
+    deletedGroupIds?: string[];
+    deletedProjectIds?: string[];
+}
+
+export interface ProjectCatalogMergeResult {
+    document: ProjectCatalogSyncDocumentV1;
+    conflictProjectIds: string[];
+    repaired: boolean;
+}
+
+function clone<T>(value: T): T {
+    if (value === undefined || value === null) {
+        return value;
+    }
+    return JSON.parse(JSON.stringify(value));
+}
+
+function sortedObject<T>(value: Record<string, T>): Record<string, T> {
+    const result: Record<string, T> = {};
+    for (const key of Object.keys(value || {}).sort()) {
+        result[key] = value[key];
+    }
+    return result;
+}
+
+function normalizeVector(vector: Record<string, number>): Record<string, number> {
+    const result: Record<string, number> = {};
+    for (const actorId of Object.keys(vector || {}).sort()) {
+        const counter = vector[actorId];
+        if (actorId && typeof counter === 'number' && Number.isFinite(counter) && counter >= 0) {
+            result[actorId] = Math.floor(counter);
+        }
+    }
+    return result;
+}
+
+function dominates(left: Record<string, number>, right: Record<string, number>): boolean {
+    return Object.keys(right || {}).every(actorId =>
+        (left && left[actorId] || 0) >= (right[actorId] || 0));
+}
+
+function mergeVectors(
+    left: Record<string, number>,
+    right: Record<string, number>
+): Record<string, number> {
+    const result = normalizeVector(left || {});
+    for (const actorId of Object.keys(right || {})) {
+        result[actorId] = Math.max(result[actorId] || 0, right[actorId] || 0);
+    }
+    return normalizeVector(result);
+}
+
+function nextVersion(
+    vector: Record<string, number>,
+    actorId: string
+): ProjectCatalogVersion {
+    const next = normalizeVector(vector || {});
+    next[actorId] = (next[actorId] || 0) + 1;
+    return { actorId, vector: normalizeVector(next) };
+}
+
+function normalizeVersion(version: ProjectCatalogVersion): ProjectCatalogVersion {
+    return {
+        actorId: version.actorId,
+        vector: normalizeVector(version.vector),
+    };
+}
+
+function compareVersions(
+    left: ProjectCatalogVersion,
+    right: ProjectCatalogVersion
+): number {
+    const leftDominates = dominates(left.vector, right.vector);
+    const rightDominates = dominates(right.vector, left.vector);
+    if (leftDominates && !rightDominates) {
+        return 1;
+    }
+    if (rightDominates && !leftDominates) {
+        return -1;
+    }
+    return left.actorId.localeCompare(right.actorId);
+}
+
+function withoutProjects(group: Group): Record<string, unknown> {
+    const value = clone(group) as unknown as Record<string, unknown>;
+    delete value.projects;
+    return value;
+}
+
+function valueEquals(left: unknown, right: unknown): boolean {
+    return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function normalizeLayout(
+    layout: ProjectCatalogLayout,
+    groups: Record<string, VersionedProjectCatalogGroup>,
+    projects: Record<string, VersionedProjectCatalogProject>
+): ProjectCatalogLayout {
+    const groupIds = [];
+    const seenGroups = new Set<string>();
+    for (const groupId of (layout && layout.groupIds || [])) {
+        if (groups[groupId] && !seenGroups.has(groupId)) {
+            groupIds.push(groupId);
+            seenGroups.add(groupId);
+        }
+    }
+    for (const groupId of Object.keys(groups).sort()) {
+        if (!seenGroups.has(groupId)) {
+            groupIds.push(groupId);
+            seenGroups.add(groupId);
+        }
+    }
+
+    const projectIdsByGroup: Record<string, string[]> = {};
+    for (const groupId of groupIds) {
+        const projectIds = [];
+        const seenProjects = new Set<string>();
+        const requested = layout && layout.projectIdsByGroup
+            ? layout.projectIdsByGroup[groupId] || []
+            : [];
+        for (const projectId of requested) {
+            if (projects[projectId]
+                && projects[projectId].groupId === groupId
+                && !seenProjects.has(projectId)) {
+                projectIds.push(projectId);
+                seenProjects.add(projectId);
+            }
+        }
+        for (const projectId of Object.keys(projects).sort()) {
+            if (projects[projectId].groupId === groupId && !seenProjects.has(projectId)) {
+                projectIds.push(projectId);
+                seenProjects.add(projectId);
+            }
+        }
+        projectIdsByGroup[groupId] = projectIds;
+    }
+    return { groupIds, projectIdsByGroup: sortedObject(projectIdsByGroup) };
+}
+
+function normalizeDocument(
+    document: ProjectCatalogSyncDocumentV1
+): ProjectCatalogSyncDocumentV1 {
+    const groups: Record<string, VersionedProjectCatalogGroup> = {};
+    for (const groupId of Object.keys(document.groups || {}).sort()) {
+        const record = document.groups[groupId];
+        groups[groupId] = {
+            value: clone(record.value),
+            version: normalizeVersion(record.version),
+        };
+    }
+    const projects: Record<string, VersionedProjectCatalogProject> = {};
+    for (const projectId of Object.keys(document.projects || {}).sort()) {
+        const record = document.projects[projectId];
+        projects[projectId] = {
+            value: clone(record.value),
+            groupId: record.groupId,
+            version: normalizeVersion(record.version),
+        };
+    }
+    const layoutValue = normalizeLayout(
+        document.layout && document.layout.value || { groupIds: [], projectIdsByGroup: {} },
+        groups,
+        projects
+    );
+    return {
+        schemaVersion: 1,
+        versionVector: normalizeVector(document.versionVector || {}),
+        groups,
+        projects,
+        layout: {
+            value: layoutValue,
+            version: normalizeVersion(document.layout.version),
+        },
+    };
+}
+
+function isVersion(value: unknown): value is ProjectCatalogVersion {
+    const candidate = value as ProjectCatalogVersion;
+    return Boolean(candidate
+        && typeof candidate === 'object'
+        && typeof candidate.actorId === 'string'
+        && candidate.actorId
+        && candidate.vector
+        && typeof candidate.vector === 'object'
+        && !Array.isArray(candidate.vector));
+}
+
+export function parseProjectCatalogSyncDocument(
+    value: unknown
+): ProjectCatalogSyncDocumentV1 | null {
+    const candidate = value as ProjectCatalogSyncDocumentV1;
+    if (!candidate
+        || typeof candidate !== 'object'
+        || Array.isArray(candidate)
+        || candidate.schemaVersion !== 1
+        || !candidate.versionVector
+        || typeof candidate.versionVector !== 'object'
+        || Array.isArray(candidate.versionVector)
+        || !candidate.groups
+        || typeof candidate.groups !== 'object'
+        || Array.isArray(candidate.groups)
+        || !candidate.projects
+        || typeof candidate.projects !== 'object'
+        || Array.isArray(candidate.projects)
+        || !candidate.layout
+        || typeof candidate.layout !== 'object'
+        || !isVersion(candidate.layout.version)
+        || !candidate.layout.value
+        || !Array.isArray(candidate.layout.value.groupIds)
+        || !candidate.layout.value.projectIdsByGroup
+        || typeof candidate.layout.value.projectIdsByGroup !== 'object') {
+        return null;
+    }
+    for (const groupId of Object.keys(candidate.groups)) {
+        const record = candidate.groups[groupId];
+        if (!record || typeof record.value !== 'object' || !isVersion(record.version)) {
+            return null;
+        }
+    }
+    for (const projectId of Object.keys(candidate.projects)) {
+        const record = candidate.projects[projectId];
+        if (!record
+            || !record.value
+            || typeof record.value !== 'object'
+            || typeof record.groupId !== 'string'
+            || !isVersion(record.version)) {
+            return null;
+        }
+    }
+    return normalizeDocument(candidate);
+}
+
+export function migrateLegacyProjectCatalog(
+    groups: Group[],
+    actorId: string
+): ProjectCatalogSyncDocumentV1 {
+    const version = nextVersion({}, actorId);
+    const versionVector = version.vector;
+    const groupRecords: Record<string, VersionedProjectCatalogGroup> = {};
+    const projectRecords: Record<string, VersionedProjectCatalogProject> = {};
+    const layout: ProjectCatalogLayout = { groupIds: [], projectIdsByGroup: {} };
+
+    for (const group of Array.isArray(groups) ? groups : []) {
+        if (!group || !group.id || groupRecords[group.id]) {
+            continue;
+        }
+        groupRecords[group.id] = { value: withoutProjects(group), version: clone(version) };
+        layout.groupIds.push(group.id);
+        layout.projectIdsByGroup[group.id] = [];
+        for (const project of Array.isArray(group.projects) ? group.projects : []) {
+            if (!project || !project.id || projectRecords[project.id]) {
+                continue;
+            }
+            projectRecords[project.id] = {
+                value: clone(project),
+                groupId: group.id,
+                version: clone(version),
+            };
+            layout.projectIdsByGroup[group.id].push(project.id);
+        }
+    }
+
+    return normalizeDocument({
+        schemaVersion: 1,
+        versionVector,
+        groups: groupRecords,
+        projects: projectRecords,
+        layout: { value: layout, version: clone(version) },
+    });
+}
+
+export function materializeProjectCatalog(
+    document: ProjectCatalogSyncDocumentV1
+): Group[] {
+    const normalized = normalizeDocument(document);
+    return normalized.layout.value.groupIds.map(groupId => {
+        const group = clone(normalized.groups[groupId].value) as unknown as Group;
+        group.projects = (normalized.layout.value.projectIdsByGroup[groupId] || [])
+            .map(projectId => normalized.projects[projectId])
+            .filter(Boolean)
+            .map(record => clone(record.value));
+        return group;
+    });
+}
+
+export function applyProjectCatalogSnapshot(
+    document: ProjectCatalogSyncDocumentV1,
+    groups: Group[],
+    actorId: string,
+    options: ProjectCatalogMutationOptions = {}
+): ProjectCatalogSyncDocumentV1 {
+    const current = normalizeDocument(document);
+    const desiredGroups: Record<string, Record<string, unknown>> = {};
+    const desiredProjects: Record<string, { value: Project; groupId: string }> = {};
+    const requestedGroupIds: string[] = [];
+    const requestedProjectIdsByGroup: Record<string, string[]> = {};
+
+    for (const groupId of current.layout.value.groupIds) {
+        desiredGroups[groupId] = clone(current.groups[groupId].value);
+    }
+    for (const projectId of Object.keys(current.projects)) {
+        const record = current.projects[projectId];
+        desiredProjects[projectId] = { value: clone(record.value), groupId: record.groupId };
+    }
+
+    for (const group of Array.isArray(groups) ? groups : []) {
+        if (!group || !group.id) {
+            continue;
+        }
+        desiredGroups[group.id] = withoutProjects(group);
+        if (!requestedGroupIds.includes(group.id)) {
+            requestedGroupIds.push(group.id);
+        }
+        requestedProjectIdsByGroup[group.id] = [];
+        for (const project of Array.isArray(group.projects) ? group.projects : []) {
+            if (!project || !project.id) {
+                continue;
+            }
+            desiredProjects[project.id] = { value: clone(project), groupId: group.id };
+            if (!requestedProjectIdsByGroup[group.id].includes(project.id)) {
+                requestedProjectIdsByGroup[group.id].push(project.id);
+            }
+        }
+    }
+
+    for (const projectId of options.deletedProjectIds || []) {
+        delete desiredProjects[projectId];
+    }
+    for (const groupId of options.deletedGroupIds || []) {
+        delete desiredGroups[groupId];
+    }
+
+    const desiredGroupIds = requestedGroupIds.filter(groupId => desiredGroups[groupId]);
+    for (const groupId of current.layout.value.groupIds) {
+        if (desiredGroups[groupId] && !desiredGroupIds.includes(groupId)) {
+            desiredGroupIds.push(groupId);
+        }
+    }
+    for (const groupId of Object.keys(desiredGroups).sort()) {
+        if (!desiredGroupIds.includes(groupId)) {
+            desiredGroupIds.push(groupId);
+        }
+    }
+
+    const desiredLayout: ProjectCatalogLayout = {
+        groupIds: desiredGroupIds,
+        projectIdsByGroup: {},
+    };
+    for (const groupId of desiredGroupIds) {
+        const ids = (requestedProjectIdsByGroup[groupId] || [])
+            .filter(projectId => desiredProjects[projectId]
+                && desiredProjects[projectId].groupId === groupId);
+        for (const projectId of current.layout.value.projectIdsByGroup[groupId] || []) {
+            if (desiredProjects[projectId]
+                && desiredProjects[projectId].groupId === groupId
+                && !ids.includes(projectId)) {
+                ids.push(projectId);
+            }
+        }
+        for (const projectId of Object.keys(desiredProjects).sort()) {
+            if (desiredProjects[projectId].groupId === groupId && !ids.includes(projectId)) {
+                ids.push(projectId);
+            }
+        }
+        desiredLayout.projectIdsByGroup[groupId] = ids;
+    }
+
+    let changed = !valueEquals(current.layout.value, desiredLayout);
+    changed = changed || Object.keys(current.groups).some(groupId => !desiredGroups[groupId]);
+    changed = changed || Object.keys(current.projects).some(projectId => !desiredProjects[projectId]);
+    changed = changed || Object.keys(desiredGroups).some(groupId =>
+        !current.groups[groupId]
+        || !valueEquals(current.groups[groupId].value, desiredGroups[groupId]));
+    changed = changed || Object.keys(desiredProjects).some(projectId => {
+        const currentRecord = current.projects[projectId];
+        const desired = desiredProjects[projectId];
+        return !currentRecord
+            || currentRecord.groupId !== desired.groupId
+            || !valueEquals(currentRecord.value, desired.value);
+    });
+    if (!changed) {
+        return current;
+    }
+
+    const version = nextVersion(current.versionVector, actorId);
+    const nextGroups: Record<string, VersionedProjectCatalogGroup> = {};
+    for (const groupId of desiredGroupIds) {
+        const existing = current.groups[groupId];
+        nextGroups[groupId] = existing && valueEquals(existing.value, desiredGroups[groupId])
+            ? clone(existing)
+            : { value: clone(desiredGroups[groupId]), version: clone(version) };
+    }
+    const nextProjects: Record<string, VersionedProjectCatalogProject> = {};
+    for (const projectId of Object.keys(desiredProjects).sort()) {
+        const desired = desiredProjects[projectId];
+        const existing = current.projects[projectId];
+        nextProjects[projectId] = existing
+            && existing.groupId === desired.groupId
+            && valueEquals(existing.value, desired.value)
+            ? clone(existing)
+            : {
+                value: clone(desired.value),
+                groupId: desired.groupId,
+                version: clone(version),
+            };
+    }
+
+    return normalizeDocument({
+        schemaVersion: 1,
+        versionVector: version.vector,
+        groups: nextGroups,
+        projects: nextProjects,
+        layout: valueEquals(current.layout.value, desiredLayout)
+            ? clone(current.layout)
+            : { value: desiredLayout, version: clone(version) },
+    });
+}
+
+function chooseRecord<T extends { version: ProjectCatalogVersion }>(
+    left: T,
+    right: T
+): T {
+    const comparison = compareVersions(left.version, right.version);
+    if (comparison > 0) {
+        return clone(left);
+    }
+    if (comparison < 0) {
+        return clone(right);
+    }
+    return JSON.stringify(left).localeCompare(JSON.stringify(right)) >= 0
+        ? clone(left)
+        : clone(right);
+}
+
+export function mergeProjectCatalogDocuments(
+    local: ProjectCatalogSyncDocumentV1,
+    incoming: ProjectCatalogSyncDocumentV1
+): ProjectCatalogMergeResult {
+    const left = normalizeDocument(local);
+    const right = normalizeDocument(incoming);
+    const versionVector = mergeVectors(left.versionVector, right.versionVector);
+    const groups: Record<string, VersionedProjectCatalogGroup> = {};
+    const projects: Record<string, VersionedProjectCatalogProject> = {};
+    const conflictProjectIds = new Set<string>();
+
+    for (const groupId of Array.from(new Set([
+        ...Object.keys(left.groups),
+        ...Object.keys(right.groups),
+    ])).sort()) {
+        const leftRecord = left.groups[groupId];
+        const rightRecord = right.groups[groupId];
+        if (leftRecord && rightRecord) {
+            groups[groupId] = chooseRecord(leftRecord, rightRecord);
+        } else if (leftRecord && !dominates(right.versionVector, leftRecord.version.vector)) {
+            groups[groupId] = clone(leftRecord);
+        } else if (rightRecord && !dominates(left.versionVector, rightRecord.version.vector)) {
+            groups[groupId] = clone(rightRecord);
+        }
+    }
+
+    for (const projectId of Array.from(new Set([
+        ...Object.keys(left.projects),
+        ...Object.keys(right.projects),
+    ])).sort()) {
+        const leftRecord = left.projects[projectId];
+        const rightRecord = right.projects[projectId];
+        if (leftRecord && rightRecord) {
+            projects[projectId] = chooseRecord(leftRecord, rightRecord);
+        } else if (leftRecord && !dominates(right.versionVector, leftRecord.version.vector)) {
+            projects[projectId] = clone(leftRecord);
+            conflictProjectIds.add(projectId);
+        } else if (rightRecord && !dominates(left.versionVector, rightRecord.version.vector)) {
+            projects[projectId] = clone(rightRecord);
+            conflictProjectIds.add(projectId);
+        }
+    }
+
+    for (const projectId of Object.keys(projects)) {
+        const groupId = projects[projectId].groupId;
+        if (!groups[groupId]) {
+            const candidate = left.groups[groupId] || right.groups[groupId];
+            if (candidate) {
+                groups[groupId] = clone(candidate);
+                conflictProjectIds.add(projectId);
+            }
+        }
+    }
+
+    const layout = chooseRecord(left.layout, right.layout);
+    const document = normalizeDocument({
+        schemaVersion: 1,
+        versionVector,
+        groups,
+        projects,
+        layout,
+    });
+    return {
+        document,
+        conflictProjectIds: Array.from(conflictProjectIds).sort(),
+        repaired: JSON.stringify(document) !== JSON.stringify(right),
+    };
+}

--- a/src/projects/projectManualEditController.ts
+++ b/src/projects/projectManualEditController.ts
@@ -12,7 +12,7 @@ export interface ProjectManualEditControllerOptions {
     openTextDocument: (uri: vscode.Uri) => Thenable<vscode.TextDocument>;
     showTextDocument: (document: vscode.TextDocument) => Thenable<unknown>;
     onWillSaveTextDocument: (listener: (event: vscode.TextDocumentWillSaveEvent) => unknown) => vscode.Disposable;
-    saveGroups: (groups: Group[]) => Thenable<unknown>;
+    saveGroups: (groups: Group[], baselineGroups: Group[]) => Thenable<unknown>;
     executeCommand: (command: string) => Thenable<unknown>;
     showErrorMessage: (message: string) => unknown;
     postSave: () => void;
@@ -61,7 +61,7 @@ export class ProjectManualEditController {
             }
 
             updatedGroups = validation.groups;
-            await this.options.saveGroups(updatedGroups);
+            await this.options.saveGroups(updatedGroups, projects);
 
             subscriptions.forEach(s => s.dispose());
 

--- a/src/services/projectCatalogSyncService.ts
+++ b/src/services/projectCatalogSyncService.ts
@@ -1,0 +1,183 @@
+'use strict';
+
+import type { Group } from '../models';
+import {
+    applyProjectCatalogSnapshot,
+    materializeProjectCatalog,
+    mergeProjectCatalogDocuments,
+    migrateLegacyProjectCatalog,
+    parseProjectCatalogSyncDocument,
+    ProjectCatalogMergeResult,
+    ProjectCatalogMutationOptions,
+    ProjectCatalogSyncDocumentV1,
+} from '../projects/projectCatalogSync';
+
+export interface ProjectCatalogLocalStateV1 {
+    schemaVersion: 1;
+    actorId: string;
+    document: ProjectCatalogSyncDocumentV1;
+}
+
+export interface ProjectCatalogSyncServiceOptions {
+    getSyncData: () => unknown;
+    updateSyncData: (value: ProjectCatalogSyncDocumentV1) => Thenable<void>;
+    getLegacyGroups: () => Group[] | null;
+    updateLegacyGroups: (groups: Group[]) => Thenable<void>;
+    getLocalState: () => ProjectCatalogLocalStateV1 | null;
+    updateLocalState: (value: ProjectCatalogLocalStateV1) => Thenable<void>;
+    createActorId: () => string;
+    onDiagnostic?: (event: Record<string, unknown>) => void;
+    onConflict?: (projectIds: string[]) => void;
+}
+
+interface CurrentProjectCatalogState {
+    actorId: string;
+    document: ProjectCatalogSyncDocumentV1;
+    conflictProjectIds: string[];
+    initialized: boolean;
+    localState: ProjectCatalogLocalStateV1 | null;
+    syncData: ProjectCatalogSyncDocumentV1 | null;
+    legacyGroups: Group[];
+}
+
+function clone<T>(value: T): T {
+    if (value === undefined || value === null) {
+        return value;
+    }
+    return JSON.parse(JSON.stringify(value));
+}
+
+function equals(left: unknown, right: unknown): boolean {
+    return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function parseLocalState(value: ProjectCatalogLocalStateV1 | null): ProjectCatalogLocalStateV1 | null {
+    if (!value
+        || value.schemaVersion !== 1
+        || typeof value.actorId !== 'string'
+        || !value.actorId) {
+        return null;
+    }
+    const document = parseProjectCatalogSyncDocument(value.document);
+    return document
+        ? { schemaVersion: 1, actorId: value.actorId, document }
+        : null;
+}
+
+export class ProjectCatalogSyncService {
+    private pending: Promise<unknown> = Promise.resolve();
+
+    constructor(private readonly options: ProjectCatalogSyncServiceOptions) {
+    }
+
+    getGroups(): Group[] {
+        return materializeProjectCatalog(this.readCurrent().document);
+    }
+
+    reconcile(): Promise<ProjectCatalogMergeResult> {
+        return this.enqueue(async () => {
+            const current = this.readCurrent();
+            return this.persist(current, current.document, current.initialized);
+        });
+    }
+
+    saveGroups(
+        groups: Group[],
+        options: ProjectCatalogMutationOptions = {}
+    ): Promise<Group[]> {
+        return this.enqueue(async () => {
+            const current = this.readCurrent();
+            const document = applyProjectCatalogSnapshot(
+                current.document,
+                groups,
+                current.actorId,
+                options
+            );
+            await this.persist(current, document, false);
+            return materializeProjectCatalog(document);
+        });
+    }
+
+    private enqueue<T>(operation: () => Promise<T>): Promise<T> {
+        const result = this.pending.then(operation, operation);
+        this.pending = result.then(() => undefined, () => undefined);
+        return result;
+    }
+
+    private readCurrent(): CurrentProjectCatalogState {
+        const rawSyncData = this.options.getSyncData();
+        const syncData = parseProjectCatalogSyncDocument(rawSyncData);
+        const localState = parseLocalState(this.options.getLocalState());
+        const legacyGroups = clone(this.options.getLegacyGroups() || []);
+        const actorId = localState && localState.actorId || this.options.createActorId();
+        const initialized = !syncData && !localState;
+        let document: ProjectCatalogSyncDocumentV1;
+        let conflictProjectIds: string[] = [];
+
+        if (syncData && localState) {
+            const merged = mergeProjectCatalogDocuments(localState.document, syncData);
+            document = merged.document;
+            conflictProjectIds = merged.conflictProjectIds;
+        } else if (localState) {
+            document = localState.document;
+        } else if (syncData) {
+            document = syncData;
+        } else {
+            document = migrateLegacyProjectCatalog(legacyGroups, actorId);
+        }
+
+        return {
+            actorId,
+            document,
+            conflictProjectIds,
+            initialized,
+            localState,
+            syncData,
+            legacyGroups,
+        };
+    }
+
+    private async persist(
+        current: CurrentProjectCatalogState,
+        document: ProjectCatalogSyncDocumentV1,
+        forceProjection: boolean
+    ): Promise<ProjectCatalogMergeResult> {
+        const localState: ProjectCatalogLocalStateV1 = {
+            schemaVersion: 1,
+            actorId: current.actorId,
+            document: clone(document),
+        };
+        const groups = materializeProjectCatalog(document);
+        const writeLocal = !current.localState || !equals(current.localState, localState);
+        const writeSync = !current.syncData || !equals(current.syncData, document);
+        const writeLegacy = forceProjection || !equals(current.legacyGroups, groups);
+
+        if (writeLocal) {
+            await this.options.updateLocalState(localState);
+        }
+        if (writeSync) {
+            await this.options.updateSyncData(document);
+        }
+        if (writeLegacy) {
+            await this.options.updateLegacyGroups(groups);
+        }
+
+        if (current.conflictProjectIds.length) {
+            this.options.onConflict?.(current.conflictProjectIds);
+        }
+        if (writeLocal || writeSync || writeLegacy || current.conflictProjectIds.length) {
+            this.options.onDiagnostic?.({
+                event: 'project-catalog-sync-reconciled',
+                actorId: current.actorId,
+                repaired: writeSync || writeLegacy,
+                conflictProjectIds: current.conflictProjectIds,
+            });
+        }
+
+        return {
+            document: clone(document),
+            conflictProjectIds: [...current.conflictProjectIds],
+            repaired: writeLocal || writeSync || writeLegacy,
+        };
+    }
+}

--- a/src/services/projectCatalogSyncService.ts
+++ b/src/services/projectCatalogSyncService.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import type { Group } from '../models';
+import type { Group, Project } from '../models';
 import {
     applyProjectCatalogSnapshot,
     materializeProjectCatalog,
@@ -79,7 +79,7 @@ function parseLocalState(value: ProjectCatalogLocalStateV1 | null): ProjectCatal
 
 interface CatalogProject {
     groupId: string;
-    value: Record<string, unknown>;
+    value: Project;
 }
 
 function groupValue(group: Group): Record<string, unknown> {
@@ -98,7 +98,7 @@ function projectMap(groups: Group[]): Map<string, CatalogProject> {
             if (project && project.id) {
                 result.set(project.id, {
                     groupId: group.id,
-                    value: clone(project) as unknown as Record<string, unknown>,
+                    value: clone(project),
                 });
             }
         }
@@ -124,25 +124,33 @@ function ensureGroup(candidate: Group[], legacyGroup: Group): Group {
 function replaceProject(
     candidate: Group[],
     legacyGroup: Group,
-    project: Record<string, unknown>
+    project: Project
 ): void {
     for (const group of candidate) {
         group.projects = (group.projects || []).filter(item => item.id !== project.id);
     }
-    ensureGroup(candidate, legacyGroup).projects.push(clone(project) as never);
+    ensureGroup(candidate, legacyGroup).projects.push(clone(project));
 }
 
 function importLegacyChanges(
     document: ProjectCatalogSyncDocumentV1,
     legacyGroups: Group[],
     legacyProjection: Group[] | null,
-    actorId: string
+    actorId: string,
+    discardedProjects: Map<string, CatalogProject>
 ): { document: ProjectCatalogSyncDocumentV1; conflictProjectIds: string[] } {
     const canonicalGroups = materializeProjectCatalog(document);
-    if (legacyProjection && equals(legacyGroups, legacyProjection)) {
+    if (!legacyProjection || equals(legacyGroups, legacyProjection)) {
         return { document, conflictProjectIds: [] };
     }
-    if (legacyProjection && equals(canonicalGroups, legacyProjection)) {
+    const legacyProjects = projectMap(legacyGroups);
+    const repeatsDiscardedProject = Array.from(discardedProjects).some(
+        ([projectId, discardedProject]) => {
+            const legacyProject = legacyProjects.get(projectId);
+            return legacyProject && equals(legacyProject, discardedProject);
+        }
+    );
+    if (equals(canonicalGroups, legacyProjection) && !repeatsDiscardedProject) {
         return {
             document: applyProjectCatalogSnapshot(document, legacyGroups, actorId),
             conflictProjectIds: [],
@@ -151,7 +159,7 @@ function importLegacyChanges(
 
     const candidate = clone(canonicalGroups);
     const canonicalProjects = projectMap(canonicalGroups);
-    const baselineProjects = projectMap(legacyProjection || []);
+    const baselineProjects = projectMap(legacyProjection);
     const conflictProjectIds = new Set<string>();
 
     for (const legacyGroup of legacyGroups) {
@@ -184,10 +192,18 @@ function importLegacyChanges(
             }
             const legacyValue: CatalogProject = {
                 groupId: legacyGroup.id,
-                value: clone(legacyProject) as unknown as Record<string, unknown>,
+                value: clone(legacyProject),
             };
             const canonicalValue = canonicalProjects.get(legacyProject.id);
             const baselineValue = baselineProjects.get(legacyProject.id);
+            const discardedProject = discardedProjects.get(legacyProject.id);
+
+            if (discardedProject && equals(legacyValue, discardedProject)) {
+                continue;
+            }
+            if (discardedProject) {
+                conflictProjectIds.add(legacyProject.id);
+            }
 
             if (!baselineValue) {
                 if (!canonicalValue) {
@@ -267,11 +283,25 @@ export class ProjectCatalogSyncService {
         const initialized = !syncData && !localState;
         let document: ProjectCatalogSyncDocumentV1;
         let conflictProjectIds: string[] = [];
+        const discardedProjects = new Map<string, CatalogProject>();
 
         if (syncData && localState) {
             const merged = mergeProjectCatalogDocuments(localState.document, syncData);
             document = merged.document;
             conflictProjectIds = merged.conflictProjectIds;
+            for (const source of [localState.document, syncData]) {
+                for (const projectId of Object.keys(source.projects)) {
+                    if (!document.projects[projectId]) {
+                        discardedProjects.set(
+                            projectId,
+                            {
+                                groupId: source.projects[projectId].groupId,
+                                value: clone(source.projects[projectId].value),
+                            }
+                        );
+                    }
+                }
+            }
         } else if (localState) {
             document = localState.document;
         } else if (syncData) {
@@ -288,7 +318,8 @@ export class ProjectCatalogSyncService {
                 document,
                 legacyGroups,
                 legacyProjection,
-                actorId
+                actorId,
+                discardedProjects
             );
             document = imported.document;
             conflictProjectIds = Array.from(new Set([
@@ -330,18 +361,33 @@ export class ProjectCatalogSyncService {
         const writeLocal = !current.localState || !equals(current.localState, localState);
         const writeSync = !current.syncData || !equals(current.syncData, document);
         const writeLegacy = forceProjection || !equals(current.legacyGroups, groups);
+        const repairReasons = new Set<string>();
 
         if (current.invalidSyncData) {
+            repairReasons.add('invalid-sync-data');
             this.options.onDiagnostic?.({
                 event: 'project-catalog-sync-invalid-source',
                 source: 'projectSyncData',
             });
         }
         if (current.invalidLocalState) {
+            repairReasons.add('invalid-local-shadow');
             this.options.onDiagnostic?.({
                 event: 'project-catalog-sync-invalid-source',
                 source: 'localShadow',
             });
+        }
+        if (writeLocal && !current.localState && !current.invalidLocalState) {
+            repairReasons.add('missing-local-shadow');
+        }
+        if (writeSync && !current.invalidSyncData) {
+            repairReasons.add(current.syncData ? 'stale-sync-data' : 'missing-sync-data');
+        }
+        if (writeLegacy) {
+            repairReasons.add('stale-compatibility-projection');
+        }
+        if (current.conflictProjectIds.length) {
+            repairReasons.add('conflict-recovery');
         }
         if (writeLocal) {
             await this.options.updateLocalState(localState);
@@ -358,6 +404,7 @@ export class ProjectCatalogSyncService {
         };
         const acknowledgeLegacyProjection = !equals(localState, confirmedLocalState);
         if (acknowledgeLegacyProjection) {
+            repairReasons.add('compatibility-baseline-confirmed');
             await this.options.updateLocalState(confirmedLocalState);
         }
 
@@ -372,6 +419,9 @@ export class ProjectCatalogSyncService {
             this.options.onDiagnostic?.({
                 event: 'project-catalog-sync-reconciled',
                 actorId: current.actorId,
+                causalVersionVector: clone(document.versionVector),
+                repairReasons: Array.from(repairReasons).sort(),
+                affectedProjectIds: [...current.conflictProjectIds],
                 repaired: writeSync || writeLegacy,
                 conflictProjectIds: current.conflictProjectIds,
             });

--- a/src/services/projectCatalogSyncService.ts
+++ b/src/services/projectCatalogSyncService.ts
@@ -16,6 +16,7 @@ export interface ProjectCatalogLocalStateV1 {
     schemaVersion: 1;
     actorId: string;
     document: ProjectCatalogSyncDocumentV1;
+    legacyProjection?: Group[];
 }
 
 export interface ProjectCatalogSyncServiceOptions {
@@ -38,6 +39,9 @@ interface CurrentProjectCatalogState {
     localState: ProjectCatalogLocalStateV1 | null;
     syncData: ProjectCatalogSyncDocumentV1 | null;
     legacyGroups: Group[];
+    legacyProjection: Group[] | null;
+    invalidSyncData: boolean;
+    invalidLocalState: boolean;
 }
 
 function clone<T>(value: T): T {
@@ -59,9 +63,158 @@ function parseLocalState(value: ProjectCatalogLocalStateV1 | null): ProjectCatal
         return null;
     }
     const document = parseProjectCatalogSyncDocument(value.document);
-    return document
-        ? { schemaVersion: 1, actorId: value.actorId, document }
-        : null;
+    if (!document) {
+        return null;
+    }
+    const parsed: ProjectCatalogLocalStateV1 = {
+        schemaVersion: 1,
+        actorId: value.actorId,
+        document,
+    };
+    if (Array.isArray(value.legacyProjection)) {
+        parsed.legacyProjection = clone(value.legacyProjection);
+    }
+    return parsed;
+}
+
+interface CatalogProject {
+    groupId: string;
+    value: Record<string, unknown>;
+}
+
+function groupValue(group: Group): Record<string, unknown> {
+    const value = clone(group) as unknown as Record<string, unknown>;
+    delete value.projects;
+    return value;
+}
+
+function projectMap(groups: Group[]): Map<string, CatalogProject> {
+    const result = new Map<string, CatalogProject>();
+    for (const group of groups) {
+        if (!group || !group.id) {
+            continue;
+        }
+        for (const project of Array.isArray(group.projects) ? group.projects : []) {
+            if (project && project.id) {
+                result.set(project.id, {
+                    groupId: group.id,
+                    value: clone(project) as unknown as Record<string, unknown>,
+                });
+            }
+        }
+    }
+    return result;
+}
+
+function findGroup(groups: Group[], groupId: string): Group | undefined {
+    return groups.find(group => group && group.id === groupId);
+}
+
+function ensureGroup(candidate: Group[], legacyGroup: Group): Group {
+    const existing = findGroup(candidate, legacyGroup.id);
+    if (existing) {
+        return existing;
+    }
+    const added = clone(legacyGroup);
+    added.projects = [];
+    candidate.push(added);
+    return added;
+}
+
+function replaceProject(
+    candidate: Group[],
+    legacyGroup: Group,
+    project: Record<string, unknown>
+): void {
+    for (const group of candidate) {
+        group.projects = (group.projects || []).filter(item => item.id !== project.id);
+    }
+    ensureGroup(candidate, legacyGroup).projects.push(clone(project) as never);
+}
+
+function importLegacyChanges(
+    document: ProjectCatalogSyncDocumentV1,
+    legacyGroups: Group[],
+    legacyProjection: Group[] | null,
+    actorId: string
+): { document: ProjectCatalogSyncDocumentV1; conflictProjectIds: string[] } {
+    const canonicalGroups = materializeProjectCatalog(document);
+    if (legacyProjection && equals(legacyGroups, legacyProjection)) {
+        return { document, conflictProjectIds: [] };
+    }
+    if (legacyProjection && equals(canonicalGroups, legacyProjection)) {
+        return {
+            document: applyProjectCatalogSnapshot(document, legacyGroups, actorId),
+            conflictProjectIds: [],
+        };
+    }
+
+    const candidate = clone(canonicalGroups);
+    const canonicalProjects = projectMap(canonicalGroups);
+    const baselineProjects = projectMap(legacyProjection || []);
+    const conflictProjectIds = new Set<string>();
+
+    for (const legacyGroup of legacyGroups) {
+        if (!legacyGroup || !legacyGroup.id) {
+            continue;
+        }
+        const canonicalGroup = findGroup(canonicalGroups, legacyGroup.id);
+        const baselineGroup = legacyProjection
+            ? findGroup(legacyProjection, legacyGroup.id)
+            : undefined;
+        const candidateGroup = findGroup(candidate, legacyGroup.id);
+
+        if (!baselineGroup && !canonicalGroup) {
+            candidate.push(clone(legacyGroup));
+            continue;
+        }
+        if (baselineGroup
+            && canonicalGroup
+            && candidateGroup
+            && equals(groupValue(canonicalGroup), groupValue(baselineGroup))
+            && !equals(groupValue(legacyGroup), groupValue(baselineGroup))) {
+            Object.assign(candidateGroup, groupValue(legacyGroup));
+        }
+
+        for (const legacyProject of Array.isArray(legacyGroup.projects)
+            ? legacyGroup.projects
+            : []) {
+            if (!legacyProject || !legacyProject.id) {
+                continue;
+            }
+            const legacyValue: CatalogProject = {
+                groupId: legacyGroup.id,
+                value: clone(legacyProject) as unknown as Record<string, unknown>,
+            };
+            const canonicalValue = canonicalProjects.get(legacyProject.id);
+            const baselineValue = baselineProjects.get(legacyProject.id);
+
+            if (!baselineValue) {
+                if (!canonicalValue) {
+                    replaceProject(candidate, legacyGroup, legacyValue.value);
+                }
+                continue;
+            }
+            if (canonicalValue && equals(canonicalValue, baselineValue)) {
+                if (!equals(legacyValue, baselineValue)) {
+                    replaceProject(candidate, legacyGroup, legacyValue.value);
+                }
+                continue;
+            }
+            if (!equals(legacyValue, baselineValue)
+                && !equals(canonicalValue, legacyValue)) {
+                conflictProjectIds.add(legacyProject.id);
+                if (!canonicalValue) {
+                    replaceProject(candidate, legacyGroup, legacyValue.value);
+                }
+            }
+        }
+    }
+
+    return {
+        document: applyProjectCatalogSnapshot(document, candidate, actorId),
+        conflictProjectIds: Array.from(conflictProjectIds).sort(),
+    };
 }
 
 export class ProjectCatalogSyncService {
@@ -107,7 +260,8 @@ export class ProjectCatalogSyncService {
     private readCurrent(): CurrentProjectCatalogState {
         const rawSyncData = this.options.getSyncData();
         const syncData = parseProjectCatalogSyncDocument(rawSyncData);
-        const localState = parseLocalState(this.options.getLocalState());
+        const rawLocalState = this.options.getLocalState();
+        const localState = parseLocalState(rawLocalState);
         const legacyGroups = clone(this.options.getLegacyGroups() || []);
         const actorId = localState && localState.actorId || this.options.createActorId();
         const initialized = !syncData && !localState;
@@ -126,6 +280,23 @@ export class ProjectCatalogSyncService {
             document = migrateLegacyProjectCatalog(legacyGroups, actorId);
         }
 
+        const legacyProjection = initialized
+            ? legacyGroups
+            : localState && localState.legacyProjection || null;
+        if (!initialized) {
+            const imported = importLegacyChanges(
+                document,
+                legacyGroups,
+                legacyProjection,
+                actorId
+            );
+            document = imported.document;
+            conflictProjectIds = Array.from(new Set([
+                ...conflictProjectIds,
+                ...imported.conflictProjectIds,
+            ])).sort();
+        }
+
         return {
             actorId,
             document,
@@ -134,6 +305,13 @@ export class ProjectCatalogSyncService {
             localState,
             syncData,
             legacyGroups,
+            legacyProjection,
+            invalidSyncData: rawSyncData !== null
+                && rawSyncData !== undefined
+                && !syncData,
+            invalidLocalState: rawLocalState !== null
+                && rawLocalState !== undefined
+                && !localState,
         };
     }
 
@@ -146,12 +324,25 @@ export class ProjectCatalogSyncService {
             schemaVersion: 1,
             actorId: current.actorId,
             document: clone(document),
+            legacyProjection: clone(current.legacyProjection || current.legacyGroups),
         };
         const groups = materializeProjectCatalog(document);
         const writeLocal = !current.localState || !equals(current.localState, localState);
         const writeSync = !current.syncData || !equals(current.syncData, document);
         const writeLegacy = forceProjection || !equals(current.legacyGroups, groups);
 
+        if (current.invalidSyncData) {
+            this.options.onDiagnostic?.({
+                event: 'project-catalog-sync-invalid-source',
+                source: 'projectSyncData',
+            });
+        }
+        if (current.invalidLocalState) {
+            this.options.onDiagnostic?.({
+                event: 'project-catalog-sync-invalid-source',
+                source: 'localShadow',
+            });
+        }
         if (writeLocal) {
             await this.options.updateLocalState(localState);
         }
@@ -161,11 +352,23 @@ export class ProjectCatalogSyncService {
         if (writeLegacy) {
             await this.options.updateLegacyGroups(groups);
         }
+        const confirmedLocalState: ProjectCatalogLocalStateV1 = {
+            ...localState,
+            legacyProjection: clone(groups),
+        };
+        const acknowledgeLegacyProjection = !equals(localState, confirmedLocalState);
+        if (acknowledgeLegacyProjection) {
+            await this.options.updateLocalState(confirmedLocalState);
+        }
 
         if (current.conflictProjectIds.length) {
             this.options.onConflict?.(current.conflictProjectIds);
         }
-        if (writeLocal || writeSync || writeLegacy || current.conflictProjectIds.length) {
+        if (writeLocal
+            || writeSync
+            || writeLegacy
+            || acknowledgeLegacyProjection
+            || current.conflictProjectIds.length) {
             this.options.onDiagnostic?.({
                 event: 'project-catalog-sync-reconciled',
                 actorId: current.actorId,
@@ -177,7 +380,7 @@ export class ProjectCatalogSyncService {
         return {
             document: clone(document),
             conflictProjectIds: [...current.conflictProjectIds],
-            repaired: writeLocal || writeSync || writeLegacy,
+            repaired: writeLocal || writeSync || writeLegacy || acknowledgeLegacyProjection,
         };
     }
 }

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -238,6 +238,31 @@ export default class ProjectService extends BaseService {
         return this.saveGroupsWithMutation(groups);
     }
 
+    saveGroupsFromManualEdit(groups: Group[], baselineGroups: Group[]): Thenable<void> {
+        const nextGroupIds = new Set((groups || []).map(group => group.id));
+        const nextProjectIds = new Set((groups || []).reduce(
+            (projectIds, group) => projectIds.concat(
+                (group.projects || []).map(project => project.id)
+            ),
+            [] as string[]
+        ));
+        const deletedGroupIds = (baselineGroups || [])
+            .map(group => group.id)
+            .filter(groupId => !nextGroupIds.has(groupId));
+        const deletedProjectIds = (baselineGroups || []).reduce(
+            (projectIds, group) => projectIds.concat(
+                (group.projects || [])
+                    .map(project => project.id)
+                    .filter(projectId => !nextProjectIds.has(projectId))
+            ),
+            [] as string[]
+        );
+        return this.saveGroupsWithMutation(groups, {
+            deletedGroupIds,
+            deletedProjectIds,
+        });
+    }
+
     reconcileProjectCatalog(): Promise<void> {
         if (!this.useSettingsStorage()) {
             return Promise.resolve();

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -3,22 +3,67 @@
 import * as vscode from 'vscode';
 
 import { Project, Group } from "../models";
-import { ADD_NEW_PROJECT_TO_FRONT, PROJECTS_KEY, StorageOption } from "../constants";
+import {
+    ADD_NEW_PROJECT_TO_FRONT,
+    PROJECTS_KEY,
+    PROJECT_SYNC_DATA_KEY,
+    PROJECT_SYNC_LOCAL_STATE_KEY,
+    StorageOption,
+} from "../constants";
+import type { ProjectCatalogMutationOptions } from '../projects/projectCatalogSync';
 import BaseService from './baseService';
 import ColorService from './colorService';
+import {
+    ProjectCatalogLocalStateV1,
+    ProjectCatalogSyncService,
+} from './projectCatalogSyncService';
+
+export interface ProjectServiceSyncOptions {
+    createActorId?: () => string;
+    onDiagnostic?: (event: Record<string, unknown>) => void;
+    onConflict?: (projectIds: string[]) => void;
+}
 
 export default class ProjectService extends BaseService {
 
     colorService: ColorService;
+    private readonly catalogSyncService: ProjectCatalogSyncService;
 
-    constructor(context: vscode.ExtensionContext, colorService: ColorService) {
+    constructor(
+        context: vscode.ExtensionContext,
+        colorService: ColorService,
+        syncOptions: ProjectServiceSyncOptions = {}
+    ) {
         super(context);
         this.colorService = colorService;
+        this.catalogSyncService = new ProjectCatalogSyncService({
+            getSyncData: () => this.getConfig<unknown>(PROJECT_SYNC_DATA_KEY),
+            updateSyncData: value => this.configurationSection.update(
+                PROJECT_SYNC_DATA_KEY,
+                value,
+                vscode.ConfigurationTarget.Global
+            ),
+            getLegacyGroups: () => this.getProjectsFromSettings(true),
+            updateLegacyGroups: groups => this.saveGroupsInSettings(groups),
+            getLocalState: () => this.context.globalState.get(
+                PROJECT_SYNC_LOCAL_STATE_KEY
+            ) as ProjectCatalogLocalStateV1,
+            updateLocalState: value => this.context.globalState.update(
+                PROJECT_SYNC_LOCAL_STATE_KEY,
+                value
+            ),
+            createActorId: syncOptions.createActorId
+                || (() => Group.getRandomId('project-sync-actor')),
+            onDiagnostic: syncOptions.onDiagnostic,
+            onConflict: syncOptions.onConflict,
+        });
     }
 
     // ~~~~~~~~~~~~~~~~~~~~~~~~~ GET ~~~~~~~~~~~~~~~~~~~~~~~~~
     getGroups(noSanitize = false): Group[] {
-        var groups = this.getProjectsFromStorage();
+        var groups = this.useSettingsStorage()
+            ? this.catalogSyncService.getGroups()
+            : this.getProjectsFromGlobalState();
 
         if (!noSanitize) {
             groups = this.sanitizeGroups(groups);
@@ -155,32 +200,60 @@ export default class ProjectService extends BaseService {
     // ~~~~~~~~~~~~~~~~~~~~~~~~~ REMOVE ~~~~~~~~~~~~~~~~~~~~~~~~~
     async removeProject(projectId: string): Promise<Group[]> {
         let groups = this.getGroups();
+        let removed = false;
         for (let i = 0; i < groups.length; i++) {
             let group = groups[i];
             let index = group.projects.findIndex(p => p.id === projectId);
 
             if (index !== -1) {
                 group.projects.splice(index, 1);
+                removed = true;
                 break;
             }
         }
-        await this.saveGroups(groups);
+        await this.saveGroupsWithMutation(groups, {
+            deletedProjectIds: removed ? [projectId] : [],
+        });
         return groups;
     }
 
     async removeGroup(groupId: string, testIfEmpty: boolean = false): Promise<Group[]> {
         let groups = this.getGroups();
+        const removedGroup = groups.find(group =>
+            group.id === groupId && (!testIfEmpty || !group.projects.length));
 
         groups = groups.filter(g => g.id !== groupId || (testIfEmpty && g.projects.length));
-        await this.saveGroups(groups);
+        await this.saveGroupsWithMutation(groups, {
+            deletedGroupIds: removedGroup ? [groupId] : [],
+            deletedProjectIds: removedGroup
+                ? removedGroup.projects.map(project => project.id)
+                : [],
+        });
 
         return groups;
     }
 
     // ~~~~~~~~~~~~~~~~~~~~~~~~~ SAVE ~~~~~~~~~~~~~~~~~~~~~~~~~
     saveGroups(groups: Group[]): Thenable<void> {
+        return this.saveGroupsWithMutation(groups);
+    }
+
+    reconcileProjectCatalog(): Promise<void> {
+        if (!this.useSettingsStorage()) {
+            return Promise.resolve();
+        }
+        return this.catalogSyncService.reconcile().then(() => undefined);
+    }
+
+    private saveGroupsWithMutation(
+        groups: Group[],
+        options: ProjectCatalogMutationOptions = {}
+    ): Thenable<void> {
         groups = this.sanitizeGroups(groups);
 
+        if (this.useSettingsStorage()) {
+            return this.catalogSyncService.saveGroups(groups, options).then(() => undefined);
+        }
         return this.saveGroupsInStorage(groups);
     }
 
@@ -272,6 +345,9 @@ export default class ProjectService extends BaseService {
 
         var projects = this.getProjectsFromStorage(storageOptionToCopyFrom, true);
         await this.saveGroupsInStorage(projects);
+        if (this.useSettingsStorage()) {
+            await this.catalogSyncService.reconcile();
+        }
     }
 
     async migrateDataIfNeeded() {
@@ -299,6 +375,10 @@ export default class ProjectService extends BaseService {
             //await this.saveGroupsInSettings(null);
         }
 
+
+        if (this.useSettingsStorage()) {
+            await this.catalogSyncService.reconcile();
+        }
 
         return toMigrate;
     }

--- a/tests/contract/aiSessions/controllerBoundaries.test.js
+++ b/tests/contract/aiSessions/controllerBoundaries.test.js
@@ -94,6 +94,28 @@ test('SESSION-ALIAS-THREAD-SWITCH-001 copies an old alias without removing it or
     controller.copyForRebind('codex', 'missing-root', 'another-root');
     assert.equal(aliases['codex:another-root'], undefined);
     assert.equal(saves, 1, 'a missing source alias must not write');
+
+    const errors = [];
+    let saveErrors = 0;
+    const failing = new AiSessionAliasController({
+        store: {
+            getAll: () => ({ 'codex:old-root': 'Readable name' }),
+            saveAll() { throw new Error('controlled alias save failure'); },
+            remove() {},
+            set() {},
+        },
+        isProviderId: value => value === 'codex',
+        getSessionKey: (provider, id) => `${provider}:${id}`,
+        getProviderResult: () => ({ sessions: [] }),
+        logError: (message, error) => errors.push([message, error.message]),
+        showSaveError: () => { saveErrors += 1; },
+    });
+    assert.doesNotThrow(() => failing.copyForRebind('codex', 'old-root', 'new-root'));
+    assert.deepEqual(errors, [[
+        'Failed to preserve AI session alias after runtime rebind.',
+        'controlled alias save failure',
+    ]]);
+    assert.equal(saveErrors, 1);
 });
 
 test('SESSION-AI-SESSION-COMMAND-CONTROLLER-001 exposes validated command effects without mutating invalid targets', async () => {

--- a/tests/contract/aiSessions/controllerBoundaries.test.js
+++ b/tests/contract/aiSessions/controllerBoundaries.test.js
@@ -57,6 +57,45 @@ test('SESSION-ALIAS-CONTROLLER-001 sanitizes writes and resolves original names 
     assert.equal(controller.getOriginalName('codex', 'missing'), 'missing');
 });
 
+test('SESSION-ALIAS-THREAD-SWITCH-001 copies an old alias without removing it or overwriting the new root', () => {
+    let aliases = { 'codex:old-root': 'Readable name' };
+    let saves = 0;
+    const controller = new AiSessionAliasController({
+        store: {
+            getAll: () => ({ ...aliases }),
+            saveAll: next => {
+                aliases = { ...next };
+                saves += 1;
+            },
+            remove() {},
+            set() {},
+        },
+        isProviderId: value => value === 'codex',
+        getSessionKey: (provider, id) => `${provider}:${id}`,
+        getProviderResult: () => ({ sessions: [] }),
+        logError() {},
+    });
+
+    controller.copyForRebind('codex', 'old-root', 'new-root');
+    assert.deepEqual(aliases, {
+        'codex:old-root': 'Readable name',
+        'codex:new-root': 'Readable name',
+    });
+    assert.equal(saves, 1);
+
+    controller.copyForRebind('codex', 'old-root', 'new-root');
+    assert.equal(saves, 1, 'an already copied alias should be idempotent');
+
+    aliases['codex:explicit-root'] = 'Explicit new name';
+    controller.copyForRebind('codex', 'old-root', 'explicit-root');
+    assert.equal(aliases['codex:explicit-root'], 'Explicit new name');
+    assert.equal(saves, 1, 'an explicit target alias must not be overwritten');
+
+    controller.copyForRebind('codex', 'missing-root', 'another-root');
+    assert.equal(aliases['codex:another-root'], undefined);
+    assert.equal(saves, 1, 'a missing source alias must not write');
+});
+
 test('SESSION-AI-SESSION-COMMAND-CONTROLLER-001 exposes validated command effects without mutating invalid targets', async () => {
     const effects = [];
     const workspaceTarget = {

--- a/tests/contract/aiSessions/runtimeComposition.test.js
+++ b/tests/contract/aiSessions/runtimeComposition.test.js
@@ -126,7 +126,9 @@ test('RUNTIME-HOST-RUNTIME-COMPOSITION-001 production activation blocks tmux res
     const result = runProductionActivation('direct-failure');
     assert.match(result.failure, /controlled direct restore failure/);
     assert.deepEqual(result.events, ['inactive-restored', 'direct-failed']);
-    assert.deepEqual(result.verified, ['client-store-discovery']);
+    assert.deepEqual(result.verified, [
+        'client-store-discovery', 'thread-switch-alias-wiring',
+    ]);
 });
 
 test('RUNTIME-HOST-RUNTIME-COMPOSITION-001 assembles real runtime components and restores ownership before hydration', async t => {

--- a/tests/contract/aiSessions/runtimeComposition.test.js
+++ b/tests/contract/aiSessions/runtimeComposition.test.js
@@ -109,15 +109,17 @@ function runProductionActivation(mode) {
     return JSON.parse(result.stdout);
 }
 
-test('RUNTIME-HOST-RUNTIME-COMPOSITION-001 production activation assembles runtime modules and restores before hydration', () => {
+test('RUNTIME-HOST-RUNTIME-COMPOSITION-001 SESSION-ALIAS-THREAD-SWITCH-001 production activation wires alias continuity and restores before hydration', () => {
     const result = runProductionActivation('success');
     assert.equal(result.failure, null);
     assert.deepEqual(result.events.slice(0, 4), [
         'inactive-restored', 'direct-restored', 'tmux-restored', 'hydration-constructed',
     ]);
     assert.deepEqual(result.verified, [
-        'client-store-discovery', 'direct-tmux-coordinator', 'tmux-backend',
+        'client-store-discovery', 'direct-tmux-coordinator', 'thread-switch-alias-wiring',
+        'tmux-backend',
     ]);
+    assert.deepEqual(result.aliasRebinds, [['codex', 'old-root', 'new-root']]);
 });
 
 test('RUNTIME-HOST-RUNTIME-COMPOSITION-001 production activation blocks tmux restore and hydration after Direct failure', () => {

--- a/tests/contract/aiSessions/tmuxDiscovery.test.js
+++ b/tests/contract/aiSessions/tmuxDiscovery.test.js
@@ -256,22 +256,16 @@ test('RUNTIME-TMUX-THREAD-SWITCH-001 SESSION-ALIAS-THREAD-SWITCH-001 rebinds one
         event.next.sessionId,
     ]), [['codex', 'old-root', 'codex', 'new-root']]);
 
-    const recoveredEvents = [];
     const restarted = new TmuxRuntimeDiscovery({
         client: { listWindows: async () => [row] },
         bindingStore: store,
         codexRootThreadObserver: observer,
-        onSessionRebound: (previous, next) => recoveredEvents.push({ previous, next }),
         markerIsCurrent: () => false,
         nowMs: () => 2001,
         cacheTtlMs: 0,
     });
     await restarted.refresh(true);
     assert.deepEqual(restarted.getActive().map(runtime => runtime.identity.sessionId), ['new-root']);
-    assert.deepEqual(recoveredEvents.map(event => [
-        event.previous.sessionId,
-        event.next.sessionId,
-    ]), [['old-root', 'new-root']]);
 });
 
 test('RUNTIME-TMUX-THREAD-SWITCH-001 preserves the durable projection when observation cannot commit', async () => {

--- a/tests/contract/aiSessions/tmuxDiscovery.test.js
+++ b/tests/contract/aiSessions/tmuxDiscovery.test.js
@@ -210,7 +210,7 @@ test('RUNTIME-TMUX-DISCOVERY-001 classifies vanished runtimes as completed or st
     assert.deepEqual(stopped.getInactive().map(runtime => runtime.state), ['stopped']);
 });
 
-test('RUNTIME-TMUX-THREAD-SWITCH-001 rebinds one managed locator to its observed Codex root thread', async () => {
+test('RUNTIME-TMUX-THREAD-SWITCH-001 SESSION-ALIAS-THREAD-SWITCH-001 rebinds one managed locator and reports the committed root transition', async () => {
     const row = makeTmuxDiscoveryRow({
         sessionId: 'old-root',
         panePid: 4321,
@@ -223,6 +223,7 @@ test('RUNTIME-TMUX-THREAD-SWITCH-001 rebinds one managed locator to its observed
     const known = makeTmuxKnownBinding('old-root', { locator });
     const store = createSyntheticTmuxStore({ known: [known] });
     const observed = [];
+    const reboundEvents = [];
     const observer = {
         observe: async request => {
             observed.push(request);
@@ -236,6 +237,7 @@ test('RUNTIME-TMUX-THREAD-SWITCH-001 rebinds one managed locator to its observed
         markerIsCurrent: () => false,
         nowMs: () => 2000,
         cacheTtlMs: 0,
+        onSessionRebound: (previous, next) => reboundEvents.push({ previous, next }),
     });
 
     await discovery.refresh(true);
@@ -247,6 +249,12 @@ test('RUNTIME-TMUX-THREAD-SWITCH-001 rebinds one managed locator to its observed
     assert.deepEqual(discovery.getActive().map(runtime => runtime.identity.sessionId), ['new-root']);
     assert.equal(store.known.has('codex:old-root'), false);
     assert.equal(store.known.get('codex:new-root').locator.windowName, row.windowName);
+    assert.deepEqual(reboundEvents.map(event => [
+        event.previous.provider,
+        event.previous.sessionId,
+        event.next.provider,
+        event.next.sessionId,
+    ]), [['codex', 'old-root', 'codex', 'new-root']]);
 
     const restarted = new TmuxRuntimeDiscovery({
         client: { listWindows: async () => [row] },
@@ -267,6 +275,7 @@ test('RUNTIME-TMUX-THREAD-SWITCH-001 preserves the durable projection when obser
         sessionName: row.sessionName,
         windowName: row.windowName,
     };
+    let reboundEvents = 0;
     for (const failure of ['observer', 'stale', 'missing']) {
         const store = createSyntheticTmuxStore({
             known: [makeTmuxKnownBinding('old-root', { locator })],
@@ -286,6 +295,7 @@ test('RUNTIME-TMUX-THREAD-SWITCH-001 preserves the durable projection when obser
             markerIsCurrent: () => false,
             nowMs: () => 2000,
             cacheTtlMs: 0,
+            onSessionRebound: () => { reboundEvents += 1; },
         });
         await discovery.refresh(true);
         assert.deepEqual(
@@ -294,6 +304,7 @@ test('RUNTIME-TMUX-THREAD-SWITCH-001 preserves the durable projection when obser
             failure
         );
     }
+    assert.equal(reboundEvents, 0);
 });
 
 test('RUNTIME-TMUX-THREAD-SWITCH-001 rejects ambiguous locator authority and non-Codex observation', async () => {

--- a/tests/contract/aiSessions/tmuxDiscovery.test.js
+++ b/tests/contract/aiSessions/tmuxDiscovery.test.js
@@ -256,16 +256,22 @@ test('RUNTIME-TMUX-THREAD-SWITCH-001 SESSION-ALIAS-THREAD-SWITCH-001 rebinds one
         event.next.sessionId,
     ]), [['codex', 'old-root', 'codex', 'new-root']]);
 
+    const recoveredEvents = [];
     const restarted = new TmuxRuntimeDiscovery({
         client: { listWindows: async () => [row] },
         bindingStore: store,
         codexRootThreadObserver: observer,
+        onSessionRebound: (previous, next) => recoveredEvents.push({ previous, next }),
         markerIsCurrent: () => false,
         nowMs: () => 2001,
         cacheTtlMs: 0,
     });
     await restarted.refresh(true);
     assert.deepEqual(restarted.getActive().map(runtime => runtime.identity.sessionId), ['new-root']);
+    assert.deepEqual(recoveredEvents.map(event => [
+        event.previous.sessionId,
+        event.next.sessionId,
+    ]), [['old-root', 'new-root']]);
 });
 
 test('RUNTIME-TMUX-THREAD-SWITCH-001 preserves the durable projection when observation cannot commit', async () => {
@@ -305,6 +311,31 @@ test('RUNTIME-TMUX-THREAD-SWITCH-001 preserves the durable projection when obser
         );
     }
     assert.equal(reboundEvents, 0);
+});
+
+test('SESSION-ALIAS-THREAD-SWITCH-001 keeps a committed rebind when the alias hook fails', async () => {
+    const row = makeTmuxDiscoveryRow({ sessionId: 'old-root', panePid: 4321 });
+    const locator = {
+        layout: 'project',
+        sessionName: row.sessionName,
+        windowName: row.windowName,
+    };
+    const store = createSyntheticTmuxStore({
+        known: [makeTmuxKnownBinding('old-root', { locator })],
+    });
+    const discovery = new TmuxRuntimeDiscovery({
+        client: { listWindows: async () => [row] },
+        bindingStore: store,
+        codexRootThreadObserver: { observe: async () => 'new-root' },
+        onSessionRebound: () => { throw new Error('controlled alias hook failure'); },
+        markerIsCurrent: () => false,
+        cacheTtlMs: 0,
+    });
+
+    await assert.doesNotReject(discovery.refresh(true));
+    assert.deepEqual(discovery.getActive().map(runtime => runtime.identity.sessionId), ['new-root']);
+    assert.equal(store.known.has('codex:old-root'), false);
+    assert.equal(store.known.has('codex:new-root'), true);
 });
 
 test('RUNTIME-TMUX-THREAD-SWITCH-001 rejects ambiguous locator authority and non-Codex observation', async () => {

--- a/tests/contract/persistence/projectCatalogSync.test.js
+++ b/tests/contract/persistence/projectCatalogSync.test.js
@@ -71,6 +71,28 @@ function makeTwoClientHarness(initialGroups) {
     };
 }
 
+function projectIds(groups) {
+    return groups.flatMap(group => group.projects.map(project => project.id)).sort();
+}
+
+function makeCatalogGroups(projects = []) {
+    return [{
+        id: 'group-main',
+        groupName: 'Main',
+        collapsed: false,
+        projects: [{
+            id: 'project-existing',
+            name: 'Existing',
+            path: '/work/existing',
+            color: '#112233',
+        }, ...projects],
+    }];
+}
+
+function loadProjectCatalogSyncModel() {
+    return require('../../../out/projects/projectCatalogSync');
+}
+
 test('PROJECT-CATALOG-SYNC-CONFLICT-001 preserves a project when a stale client submits an older full snapshot', async () => {
     const initialGroups = [{
         id: 'group-main',
@@ -99,4 +121,104 @@ test('PROJECT-CATALOG-SYNC-CONFLICT-001 preserves a project when a stale client 
         clientB.getProjectsFlat().map(project => project.id).sort(),
         ['project-build-your-own-x', 'project-existing']
     );
+});
+
+test('PROJECT-CATALOG-SYNC-CONFLICT-001 model preserves unseen additions and observed deletions', () => {
+    const {
+        applyProjectCatalogSnapshot,
+        materializeProjectCatalog,
+        mergeProjectCatalogDocuments,
+        migrateLegacyProjectCatalog,
+    } = loadProjectCatalogSyncModel();
+    const baseGroups = makeCatalogGroups();
+    const addedProject = {
+        id: 'project-build-your-own-x',
+        name: 'build-your-own-x',
+        path: '/work/build-your-own-x',
+        color: '#445566',
+    };
+    const base = migrateLegacyProjectCatalog(baseGroups, 'actor-a');
+    const withAdded = applyProjectCatalogSnapshot(
+        base,
+        makeCatalogGroups([addedProject]),
+        'actor-b'
+    );
+
+    const staleMerge = mergeProjectCatalogDocuments(base, withAdded);
+    assert.deepEqual(projectIds(materializeProjectCatalog(staleMerge.document)), [
+        'project-build-your-own-x',
+        'project-existing',
+    ]);
+
+    const deleted = applyProjectCatalogSnapshot(
+        withAdded,
+        makeCatalogGroups(),
+        'actor-a',
+        { deletedProjectIds: ['project-build-your-own-x'] }
+    );
+    const deletionMerge = mergeProjectCatalogDocuments(withAdded, deleted);
+    assert.deepEqual(
+        projectIds(materializeProjectCatalog(deletionMerge.document)),
+        ['project-existing']
+    );
+});
+
+test('PROJECT-CATALOG-SYNC-CONFLICT-001 model keeps a concurrent live update and reports recovery', () => {
+    const {
+        applyProjectCatalogSnapshot,
+        materializeProjectCatalog,
+        mergeProjectCatalogDocuments,
+        migrateLegacyProjectCatalog,
+    } = loadProjectCatalogSyncModel();
+    const baseGroups = makeCatalogGroups();
+    const base = migrateLegacyProjectCatalog(baseGroups, 'actor-seed');
+    const removed = applyProjectCatalogSnapshot(
+        base,
+        [{ ...baseGroups[0], projects: [] }],
+        'actor-remove',
+        { deletedProjectIds: ['project-existing'] }
+    );
+    const updatedGroups = makeCatalogGroups();
+    updatedGroups[0].projects[0].name = 'Updated elsewhere';
+    const updated = applyProjectCatalogSnapshot(base, updatedGroups, 'actor-update');
+    const merged = mergeProjectCatalogDocuments(removed, updated);
+
+    assert.equal(materializeProjectCatalog(merged.document)[0].projects[0].name, 'Updated elsewhere');
+    assert.deepEqual(merged.conflictProjectIds, ['project-existing']);
+});
+
+test('PROJECT-CATALOG-SYNC-CONFLICT-001 model does not grow history across repeated fixed-actor mutations', () => {
+    const {
+        applyProjectCatalogSnapshot,
+        materializeProjectCatalog,
+        migrateLegacyProjectCatalog,
+    } = loadProjectCatalogSyncModel();
+    let document = migrateLegacyProjectCatalog(makeCatalogGroups(), 'actor-a');
+
+    for (let index = 0; index < 1000; index += 1) {
+        const project = {
+            id: `temporary-${index}`,
+            name: `Temporary ${index}`,
+            path: `/work/temporary-${index}`,
+            color: '#778899',
+        };
+        document = applyProjectCatalogSnapshot(
+            document,
+            makeCatalogGroups([project]),
+            'actor-b'
+        );
+        document = applyProjectCatalogSnapshot(
+            document,
+            makeCatalogGroups(),
+            'actor-a',
+            { deletedProjectIds: [project.id] }
+        );
+    }
+
+    assert.deepEqual(projectIds(materializeProjectCatalog(document)), ['project-existing']);
+    assert.deepEqual(Object.keys(document.versionVector).sort(), ['actor-a', 'actor-b']);
+    for (const forbidden of ['operations', 'tombstones', 'projectTombstones', 'groupTombstones']) {
+        assert.equal(Object.prototype.hasOwnProperty.call(document, forbidden), false);
+    }
+    assert.equal(Object.keys(document.projects).length, 1);
 });

--- a/tests/contract/persistence/projectCatalogSync.test.js
+++ b/tests/contract/persistence/projectCatalogSync.test.js
@@ -303,6 +303,48 @@ test('PROJECT-CATALOG-SYNC-CONFLICT-001 model keeps a concurrent live update and
     assert.deepEqual(merged.conflictProjectIds, ['project-existing']);
 });
 
+test('PROJECT-CATALOG-SYNC-CONFLICT-001 model preserves same-actor concurrent additions with equal causal counters', () => {
+    const {
+        applyProjectCatalogSnapshot,
+        materializeProjectCatalog,
+        mergeProjectCatalogDocuments,
+        migrateLegacyProjectCatalog,
+    } = loadProjectCatalogSyncModel();
+    const base = migrateLegacyProjectCatalog(makeCatalogGroups(), 'actor-shared');
+    const left = applyProjectCatalogSnapshot(
+        base,
+        makeCatalogGroups([{
+            id: 'project-left-window',
+            name: 'Left window',
+            path: '/work/left-window',
+            color: '#111111',
+        }]),
+        'actor-shared'
+    );
+    const right = applyProjectCatalogSnapshot(
+        base,
+        makeCatalogGroups([{
+            id: 'project-right-window',
+            name: 'Right window',
+            path: '/work/right-window',
+            color: '#222222',
+        }]),
+        'actor-shared'
+    );
+
+    const merged = mergeProjectCatalogDocuments(left, right);
+
+    assert.deepEqual(projectIds(materializeProjectCatalog(merged.document)), [
+        'project-existing',
+        'project-left-window',
+        'project-right-window',
+    ]);
+    assert.deepEqual(merged.conflictProjectIds, [
+        'project-left-window',
+        'project-right-window',
+    ]);
+});
+
 test('PROJECT-CATALOG-SYNC-CONFLICT-001 model does not grow history across repeated fixed-actor mutations', () => {
     const {
         applyProjectCatalogSnapshot,
@@ -337,6 +379,26 @@ test('PROJECT-CATALOG-SYNC-CONFLICT-001 model does not grow history across repea
         assert.equal(Object.prototype.hasOwnProperty.call(document, forbidden), false);
     }
     assert.equal(Object.keys(document.projects).length, 1);
+});
+
+test('PROJECT-CATALOG-SYNC-CONFLICT-001 model removes a deleted group project records without orphan metadata', () => {
+    const {
+        applyProjectCatalogSnapshot,
+        materializeProjectCatalog,
+        migrateLegacyProjectCatalog,
+    } = loadProjectCatalogSyncModel();
+    const document = migrateLegacyProjectCatalog(makeCatalogGroups(), 'actor-a');
+
+    const deleted = applyProjectCatalogSnapshot(
+        document,
+        [],
+        'actor-a',
+        { deletedGroupIds: ['group-main'] }
+    );
+
+    assert.deepEqual(materializeProjectCatalog(deleted), []);
+    assert.deepEqual(Object.keys(deleted.groups), []);
+    assert.deepEqual(Object.keys(deleted.projects), []);
 });
 
 test('PROJECT-CATALOG-SYNC-CONFLICT-001 persistence writes shadow before sync data and compatibility projection', async () => {
@@ -431,7 +493,46 @@ test('PROJECT-CATALOG-SYNC-CONFLICT-001 hardening repairs malformed sync data wi
             && event.source === 'projectSyncData'),
         true
     );
+    const reconciliation = harness.diagnostics.find(event =>
+        event.event === 'project-catalog-sync-reconciled');
+    assert.equal(reconciliation.actorId, 'actor-b');
+    assert.deepEqual(reconciliation.causalVersionVector, recovered.versionVector);
+    assert.equal(reconciliation.repairReasons.includes('invalid-sync-data'), true);
+    assert.deepEqual(reconciliation.affectedProjectIds, []);
     assert.equal(JSON.stringify(harness.diagnostics).includes('private project description'), false);
+});
+
+test('PROJECT-CATALOG-SYNC-CONFLICT-001 hardening migrates valid legacy data when sync is malformed and no shadow exists', async () => {
+    const legacyProject = {
+        id: 'project-legacy-recovery',
+        name: 'Legacy recovery',
+        path: '/work/legacy-recovery',
+        color: '#246810',
+    };
+    const harness = makeSyncPersistenceHarness({
+        legacyGroups: makeCatalogGroups([legacyProject]),
+        syncData: { schemaVersion: 1, malformed: true },
+        localState: null,
+    });
+
+    await harness.service.reconcile();
+
+    assert.deepEqual(projectIds(harness.service.getGroups()), [
+        'project-existing',
+        'project-legacy-recovery',
+    ]);
+    assert.deepEqual(projectIds(
+        loadProjectCatalogSyncModel().materializeProjectCatalog(harness.values.syncData)
+    ), [
+        'project-existing',
+        'project-legacy-recovery',
+    ]);
+    assert.equal(
+        harness.diagnostics.some(event =>
+            event.event === 'project-catalog-sync-invalid-source'
+            && event.source === 'projectSyncData'),
+        true
+    );
 });
 
 test('PROJECT-CATALOG-SYNC-CONFLICT-001 hardening imports a legacy-client addition without accepting legacy omissions', async () => {
@@ -468,6 +569,34 @@ test('PROJECT-CATALOG-SYNC-CONFLICT-001 hardening imports a legacy-client additi
         'project-existing',
         'project-legacy-client',
     ]);
+});
+
+test('PROJECT-CATALOG-SYNC-CONFLICT-001 hardening does not resurrect a canonical deletion from legacy data without a confirmed baseline', async () => {
+    const {
+        applyProjectCatalogSnapshot,
+        migrateLegacyProjectCatalog,
+    } = loadProjectCatalogSyncModel();
+    const baseline = makeCatalogGroups();
+    const baseDocument = migrateLegacyProjectCatalog(baseline, 'actor-a');
+    const deletedDocument = applyProjectCatalogSnapshot(
+        baseDocument,
+        [],
+        'actor-a',
+        {
+            deletedGroupIds: ['group-main'],
+            deletedProjectIds: ['project-existing'],
+        }
+    );
+    const harness = makeSyncPersistenceHarness({
+        legacyGroups: baseline,
+        syncData: deletedDocument,
+        localState: null,
+    });
+
+    await harness.service.reconcile();
+
+    assert.deepEqual(harness.service.getGroups(), []);
+    assert.deepEqual(harness.values.legacyGroups, []);
 });
 
 test('PROJECT-CATALOG-SYNC-CONFLICT-001 hardening aborts before settings when shadow fails and retries later settings failures', async () => {

--- a/tests/contract/persistence/projectCatalogSync.test.js
+++ b/tests/contract/persistence/projectCatalogSync.test.js
@@ -1,0 +1,102 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const { createFakeVscode } = require('../../helpers/fakeVscode');
+const { loadFreshWithFakeVscode } = require('../../helpers/runtimeContract');
+
+function clone(value) {
+    return value === undefined ? undefined : JSON.parse(JSON.stringify(value));
+}
+
+function makeMemento(initial = {}) {
+    const values = clone(initial);
+    return {
+        values,
+        get(key, fallback) {
+            return Object.prototype.hasOwnProperty.call(values, key) ? clone(values[key]) : fallback;
+        },
+        async update(key, value) {
+            if (value === undefined) delete values[key];
+            else values[key] = clone(value);
+        },
+    };
+}
+
+function makeTwoClientHarness(initialGroups) {
+    const configurationValues = {
+        storeProjectsInSettings: true,
+        projectData: clone(initialGroups),
+    };
+    const primary = {
+        get(key, fallback) {
+            return Object.prototype.hasOwnProperty.call(configurationValues, key)
+                ? clone(configurationValues[key])
+                : fallback;
+        },
+        inspect(key) {
+            return Object.prototype.hasOwnProperty.call(configurationValues, key)
+                ? { globalValue: clone(configurationValues[key]) }
+                : undefined;
+        },
+        async update(key, value) {
+            configurationValues[key] = clone(value);
+        },
+    };
+    const legacy = {
+        get(_key, fallback) {
+            return fallback;
+        },
+        inspect() {
+            return undefined;
+        },
+    };
+    const vscode = createFakeVscode({
+        workspace: {
+            getConfiguration: section => section === 'projectSteward' ? primary : legacy,
+        },
+    });
+    vscode.ConfigurationTarget = { Global: 1 };
+    const ProjectService = loadFreshWithFakeVscode(
+        '../../../out/services/projectService',
+        vscode,
+        __dirname
+    ).default;
+    const colorService = { addRecentColor: async () => undefined };
+
+    return {
+        configurationValues,
+        clientA: new ProjectService({ globalState: makeMemento() }, colorService),
+        clientB: new ProjectService({ globalState: makeMemento() }, colorService),
+    };
+}
+
+test('PROJECT-CATALOG-SYNC-CONFLICT-001 preserves a project when a stale client submits an older full snapshot', async () => {
+    const initialGroups = [{
+        id: 'group-main',
+        groupName: 'Main',
+        collapsed: false,
+        projects: [{
+            id: 'project-existing',
+            name: 'Existing',
+            path: '/work/existing',
+            color: '#112233',
+        }],
+    }];
+    const { clientA, clientB } = makeTwoClientHarness(initialGroups);
+    const staleA = clone(clientA.getGroups(true));
+    const added = {
+        id: 'project-build-your-own-x',
+        name: 'build-your-own-x',
+        path: '/work/build-your-own-x',
+        color: '#445566',
+    };
+
+    await clientB.addProject(added, 'group-main');
+    await clientA.saveGroups(staleA);
+
+    assert.deepEqual(
+        clientB.getProjectsFlat().map(project => project.id).sort(),
+        ['project-build-your-own-x', 'project-existing']
+    );
+});

--- a/tests/contract/persistence/projectCatalogSync.test.js
+++ b/tests/contract/persistence/projectCatalogSync.test.js
@@ -195,6 +195,35 @@ test('PROJECT-CATALOG-SYNC-CONFLICT-001 keeps an observed deletion after an olde
     assert.deepEqual(projectIds(clientA.getGroups()), ['project-existing']);
 });
 
+test('PROJECT-CATALOG-SYNC-CONFLICT-001 manual replacement deletes only baseline records and preserves later additions', async () => {
+    const removeTarget = {
+        id: 'project-remove',
+        name: 'Remove',
+        path: '/work/remove',
+        color: '#991122',
+    };
+    const { clientA, clientB } = makeTwoClientHarness(makeCatalogGroups([removeTarget]));
+    await clientA.migrateDataIfNeeded();
+    await clientB.migrateDataIfNeeded();
+    const baseline = clone(clientA.getGroups(true));
+    const remoteAddition = {
+        id: 'project-remote-addition',
+        name: 'Remote addition',
+        path: '/work/remote-addition',
+        color: '#229944',
+    };
+    await clientB.addProject(remoteAddition, 'group-main');
+    const edited = clone(baseline);
+    edited[0].projects = edited[0].projects.filter(project => project.id !== removeTarget.id);
+
+    await clientA.saveGroupsFromManualEdit(edited, baseline);
+
+    assert.deepEqual(projectIds(clientA.getGroups()), [
+        'project-existing',
+        'project-remote-addition',
+    ]);
+});
+
 test('PROJECT-CATALOG-SYNC-CONFLICT-001 model preserves unseen additions and observed deletions', () => {
     const {
         applyProjectCatalogSnapshot,

--- a/tests/contract/persistence/projectCatalogSync.test.js
+++ b/tests/contract/persistence/projectCatalogSync.test.js
@@ -109,7 +109,14 @@ function loadProjectCatalogSyncService() {
     return require('../../../out/services/projectCatalogSyncService').ProjectCatalogSyncService;
 }
 
-function makeSyncPersistenceHarness({ legacyGroups, syncData = null, localState = null } = {}) {
+function makeSyncPersistenceHarness({
+    legacyGroups,
+    syncData = null,
+    localState = null,
+    failLocal = null,
+    failSync = null,
+    failLegacy = null,
+} = {}) {
     const values = {
         legacyGroups: clone(legacyGroups || makeCatalogGroups()),
         syncData: clone(syncData),
@@ -118,28 +125,36 @@ function makeSyncPersistenceHarness({ legacyGroups, syncData = null, localState 
     const writes = [];
     const conflicts = [];
     const diagnostics = [];
+    const failures = {
+        local: failLocal,
+        sync: failSync,
+        legacy: failLegacy,
+    };
     const ProjectCatalogSyncService = loadProjectCatalogSyncService();
     const service = new ProjectCatalogSyncService({
         getSyncData: () => clone(values.syncData),
         updateSyncData: async value => {
             writes.push('settings:projectSyncData');
+            if (failures.sync) throw failures.sync;
             values.syncData = clone(value);
         },
         getLegacyGroups: () => clone(values.legacyGroups),
         updateLegacyGroups: async groups => {
             writes.push('settings:projectData');
+            if (failures.legacy) throw failures.legacy;
             values.legacyGroups = clone(groups);
         },
         getLocalState: () => clone(values.localState),
         updateLocalState: async value => {
             writes.push('globalState:projectCatalogSyncLocal.v1');
+            if (failures.local) throw failures.local;
             values.localState = clone(value);
         },
         createActorId: () => 'actor-local',
         onDiagnostic: event => diagnostics.push(clone(event)),
         onConflict: projectIds => conflicts.push([...projectIds]),
     });
-    return { conflicts, diagnostics, service, values, writes };
+    return { conflicts, diagnostics, failures, service, values, writes };
 }
 
 test('PROJECT-CATALOG-SYNC-CONFLICT-001 preserves a project when a stale client submits an older full snapshot', async () => {
@@ -371,5 +386,171 @@ test('PROJECT-CATALOG-SYNC-CONFLICT-001 persistence reads merged shadow state be
         'project-build-your-own-x',
         'project-existing',
     ]);
+    assert.deepEqual(harness.writes, []);
+});
+
+test('PROJECT-CATALOG-SYNC-CONFLICT-001 hardening repairs malformed sync data without logging catalog content', async () => {
+    const {
+        applyProjectCatalogSnapshot,
+        migrateLegacyProjectCatalog,
+    } = loadProjectCatalogSyncModel();
+    const base = migrateLegacyProjectCatalog(makeCatalogGroups(), 'actor-a');
+    const secretProject = {
+        id: 'project-secret',
+        name: 'Secret',
+        description: 'private project description',
+        path: '/work/secret',
+        color: '#123456',
+    };
+    const recovered = applyProjectCatalogSnapshot(
+        base,
+        makeCatalogGroups([secretProject]),
+        'actor-b'
+    );
+    const harness = makeSyncPersistenceHarness({
+        syncData: {
+            schemaVersion: 1,
+            malformed: 'private project description',
+        },
+        localState: {
+            schemaVersion: 1,
+            actorId: 'actor-b',
+            document: recovered,
+        },
+    });
+
+    await harness.service.reconcile();
+
+    assert.deepEqual(projectIds(harness.service.getGroups()), [
+        'project-existing',
+        'project-secret',
+    ]);
+    assert.equal(
+        harness.diagnostics.some(event =>
+            event.event === 'project-catalog-sync-invalid-source'
+            && event.source === 'projectSyncData'),
+        true
+    );
+    assert.equal(JSON.stringify(harness.diagnostics).includes('private project description'), false);
+});
+
+test('PROJECT-CATALOG-SYNC-CONFLICT-001 hardening imports a legacy-client addition without accepting legacy omissions', async () => {
+    const {
+        materializeProjectCatalog,
+        migrateLegacyProjectCatalog,
+    } = loadProjectCatalogSyncModel();
+    const baseline = makeCatalogGroups();
+    const baseDocument = migrateLegacyProjectCatalog(baseline, 'actor-a');
+    const legacyAddition = {
+        id: 'project-legacy-client',
+        name: 'Legacy client',
+        path: '/work/legacy-client',
+        color: '#654321',
+    };
+    const harness = makeSyncPersistenceHarness({
+        legacyGroups: makeCatalogGroups([legacyAddition]),
+        syncData: baseDocument,
+        localState: {
+            schemaVersion: 1,
+            actorId: 'actor-a',
+            document: baseDocument,
+            legacyProjection: baseline,
+        },
+    });
+
+    await harness.service.reconcile();
+
+    assert.deepEqual(projectIds(harness.service.getGroups()), [
+        'project-existing',
+        'project-legacy-client',
+    ]);
+    assert.deepEqual(projectIds(materializeProjectCatalog(harness.values.syncData)), [
+        'project-existing',
+        'project-legacy-client',
+    ]);
+});
+
+test('PROJECT-CATALOG-SYNC-CONFLICT-001 hardening aborts before settings when shadow fails and retries later settings failures', async () => {
+    const addedProject = {
+        id: 'project-retry',
+        name: 'Retry',
+        path: '/work/retry',
+        color: '#abcdef',
+    };
+    const shadowError = new Error('shadow unavailable');
+    const shadowFailure = makeSyncPersistenceHarness({ failLocal: shadowError });
+    await assert.rejects(
+        shadowFailure.service.saveGroups(makeCatalogGroups([addedProject])),
+        shadowError
+    );
+    assert.deepEqual(shadowFailure.writes, ['globalState:projectCatalogSyncLocal.v1']);
+
+    const syncError = new Error('sync unavailable');
+    const retry = makeSyncPersistenceHarness({ failSync: syncError });
+    await assert.rejects(
+        retry.service.saveGroups(makeCatalogGroups([addedProject])),
+        syncError
+    );
+    assert.deepEqual(retry.writes, [
+        'globalState:projectCatalogSyncLocal.v1',
+        'settings:projectSyncData',
+    ]);
+    retry.failures.sync = null;
+    retry.writes.length = 0;
+
+    await retry.service.reconcile();
+
+    assert.deepEqual(projectIds(retry.service.getGroups()), [
+        'project-existing',
+        'project-retry',
+    ]);
+    assert.deepEqual(retry.writes, [
+        'settings:projectSyncData',
+        'settings:projectData',
+        'globalState:projectCatalogSyncLocal.v1',
+    ]);
+    retry.writes.length = 0;
+    await retry.service.reconcile();
+    assert.deepEqual(retry.writes, []);
+});
+
+test('PROJECT-CATALOG-SYNC-CONFLICT-001 hardening confirms the legacy baseline only after its projection succeeds', async () => {
+    const addedProject = {
+        id: 'project-projection-retry',
+        name: 'Projection retry',
+        path: '/work/projection-retry',
+        color: '#fedcba',
+    };
+    const projectionError = new Error('legacy projection unavailable');
+    const harness = makeSyncPersistenceHarness({ failLegacy: projectionError });
+
+    await assert.rejects(
+        harness.service.saveGroups(makeCatalogGroups([addedProject])),
+        projectionError
+    );
+    assert.deepEqual(harness.writes, [
+        'globalState:projectCatalogSyncLocal.v1',
+        'settings:projectSyncData',
+        'settings:projectData',
+    ]);
+    assert.deepEqual(
+        projectIds(harness.values.localState.legacyProjection),
+        ['project-existing']
+    );
+
+    harness.failures.legacy = null;
+    harness.writes.length = 0;
+    await harness.service.reconcile();
+
+    assert.deepEqual(harness.writes, [
+        'settings:projectData',
+        'globalState:projectCatalogSyncLocal.v1',
+    ]);
+    assert.deepEqual(
+        projectIds(harness.values.localState.legacyProjection),
+        ['project-existing', 'project-projection-retry']
+    );
+    harness.writes.length = 0;
+    await harness.service.reconcile();
     assert.deepEqual(harness.writes, []);
 });

--- a/tests/contract/persistence/projectCatalogSync.test.js
+++ b/tests/contract/persistence/projectCatalogSync.test.js
@@ -63,11 +63,23 @@ function makeTwoClientHarness(initialGroups) {
         __dirname
     ).default;
     const colorService = { addRecentColor: async () => undefined };
+    const stateA = makeMemento();
+    const stateB = makeMemento();
 
     return {
         configurationValues,
-        clientA: new ProjectService({ globalState: makeMemento() }, colorService),
-        clientB: new ProjectService({ globalState: makeMemento() }, colorService),
+        stateA,
+        stateB,
+        clientA: new ProjectService(
+            { globalState: stateA },
+            colorService,
+            { createActorId: () => 'actor-a' }
+        ),
+        clientB: new ProjectService(
+            { globalState: stateB },
+            colorService,
+            { createActorId: () => 'actor-b' }
+        ),
     };
 }
 
@@ -158,6 +170,29 @@ test('PROJECT-CATALOG-SYNC-CONFLICT-001 preserves a project when a stale client 
         clientB.getProjectsFlat().map(project => project.id).sort(),
         ['project-build-your-own-x', 'project-existing']
     );
+});
+
+test('PROJECT-CATALOG-SYNC-CONFLICT-001 keeps an observed deletion after an older canonical snapshot returns', async () => {
+    const { clientA, clientB, configurationValues } = makeTwoClientHarness(makeCatalogGroups());
+    await clientA.migrateDataIfNeeded();
+    await clientB.migrateDataIfNeeded();
+    const added = {
+        id: 'project-build-your-own-x',
+        name: 'build-your-own-x',
+        path: '/work/build-your-own-x',
+        color: '#445566',
+    };
+    await clientB.addProject(added, 'group-main');
+    await clientA.reconcileProjectCatalog();
+    const staleCanonical = clone(configurationValues.projectSyncData);
+    const staleProjection = clone(configurationValues.projectData);
+
+    await clientA.removeProject(added.id);
+    configurationValues.projectSyncData = staleCanonical;
+    configurationValues.projectData = staleProjection;
+    await clientA.reconcileProjectCatalog();
+
+    assert.deepEqual(projectIds(clientA.getGroups()), ['project-existing']);
 });
 
 test('PROJECT-CATALOG-SYNC-CONFLICT-001 model preserves unseen additions and observed deletions', () => {

--- a/tests/contract/persistence/projectCatalogSync.test.js
+++ b/tests/contract/persistence/projectCatalogSync.test.js
@@ -93,6 +93,43 @@ function loadProjectCatalogSyncModel() {
     return require('../../../out/projects/projectCatalogSync');
 }
 
+function loadProjectCatalogSyncService() {
+    return require('../../../out/services/projectCatalogSyncService').ProjectCatalogSyncService;
+}
+
+function makeSyncPersistenceHarness({ legacyGroups, syncData = null, localState = null } = {}) {
+    const values = {
+        legacyGroups: clone(legacyGroups || makeCatalogGroups()),
+        syncData: clone(syncData),
+        localState: clone(localState),
+    };
+    const writes = [];
+    const conflicts = [];
+    const diagnostics = [];
+    const ProjectCatalogSyncService = loadProjectCatalogSyncService();
+    const service = new ProjectCatalogSyncService({
+        getSyncData: () => clone(values.syncData),
+        updateSyncData: async value => {
+            writes.push('settings:projectSyncData');
+            values.syncData = clone(value);
+        },
+        getLegacyGroups: () => clone(values.legacyGroups),
+        updateLegacyGroups: async groups => {
+            writes.push('settings:projectData');
+            values.legacyGroups = clone(groups);
+        },
+        getLocalState: () => clone(values.localState),
+        updateLocalState: async value => {
+            writes.push('globalState:projectCatalogSyncLocal.v1');
+            values.localState = clone(value);
+        },
+        createActorId: () => 'actor-local',
+        onDiagnostic: event => diagnostics.push(clone(event)),
+        onConflict: projectIds => conflicts.push([...projectIds]),
+    });
+    return { conflicts, diagnostics, service, values, writes };
+}
+
 test('PROJECT-CATALOG-SYNC-CONFLICT-001 preserves a project when a stale client submits an older full snapshot', async () => {
     const initialGroups = [{
         id: 'group-main',
@@ -221,4 +258,54 @@ test('PROJECT-CATALOG-SYNC-CONFLICT-001 model does not grow history across repea
         assert.equal(Object.prototype.hasOwnProperty.call(document, forbidden), false);
     }
     assert.equal(Object.keys(document.projects).length, 1);
+});
+
+test('PROJECT-CATALOG-SYNC-CONFLICT-001 persistence writes shadow before sync data and compatibility projection', async () => {
+    const harness = makeSyncPersistenceHarness();
+
+    const result = await harness.service.reconcile();
+
+    assert.deepEqual(projectIds(harness.service.getGroups()), ['project-existing']);
+    assert.deepEqual(harness.writes, [
+        'globalState:projectCatalogSyncLocal.v1',
+        'settings:projectSyncData',
+        'settings:projectData',
+    ]);
+    assert.equal(result.repaired, true);
+    harness.writes.length = 0;
+    await harness.service.reconcile();
+    assert.deepEqual(harness.writes, []);
+});
+
+test('PROJECT-CATALOG-SYNC-CONFLICT-001 persistence reads merged shadow state before asynchronous repair', () => {
+    const {
+        applyProjectCatalogSnapshot,
+        migrateLegacyProjectCatalog,
+    } = loadProjectCatalogSyncModel();
+    const base = migrateLegacyProjectCatalog(makeCatalogGroups(), 'actor-a');
+    const addedProject = {
+        id: 'project-build-your-own-x',
+        name: 'build-your-own-x',
+        path: '/work/build-your-own-x',
+        color: '#445566',
+    };
+    const withAdded = applyProjectCatalogSnapshot(
+        base,
+        makeCatalogGroups([addedProject]),
+        'actor-b'
+    );
+    const harness = makeSyncPersistenceHarness({
+        syncData: base,
+        localState: {
+            schemaVersion: 1,
+            actorId: 'actor-b',
+            document: withAdded,
+        },
+    });
+
+    assert.deepEqual(projectIds(harness.service.getGroups()), [
+        'project-build-your-own-x',
+        'project-existing',
+    ]);
+    assert.deepEqual(harness.writes, []);
 });

--- a/tests/contract/projects/controllers.test.js
+++ b/tests/contract/projects/controllers.test.js
@@ -11,6 +11,7 @@ const { GroupCommandController } = require('../../../out/projects/groupCommandCo
 const { queryGroupName } = require('../../../out/projects/groupPrompts');
 const { ProjectOrderController } = require('../../../out/projects/projectOrderController');
 const { ProjectRemovalController } = require('../../../out/projects/projectRemovalController');
+const { ProjectManualEditController } = require('../../../out/projects/projectManualEditController');
 const {
     ProjectOpenType,
     ProjectPathType,
@@ -308,6 +309,57 @@ test('PROJECT-PROJECT-REMOVAL-CONTROLLER-001 honors picker and confirmation canc
     assert.equal(events.filter(event => event[0] === 'remove').length, 2);
     assert.equal(events.filter(event => event[0] === 'refresh').length, 1);
     assert.equal(events.filter(event => event[0] === 'post-command').length, 1);
+});
+
+test('PROJECT-CATALOG-SYNC-CONFLICT-001 manual editor passes its exported baseline with the edited groups', async () => {
+    const exportedGroups = [{
+        id: 'group-main',
+        groupName: 'Main',
+        projects: [{
+            id: 'project-a',
+            name: 'A',
+            path: '/work/a',
+        }, {
+            id: 'project-b',
+            name: 'B',
+            path: '/work/b',
+        }],
+    }];
+    const editedGroups = [{
+        ...exportedGroups[0],
+        projects: [exportedGroups[0].projects[0]],
+    }];
+    const document = {
+        getText: () => JSON.stringify(editedGroups),
+    };
+    let saveListener;
+    const saves = [];
+    const controller = new ProjectManualEditController({
+        getGroups: () => structuredClone(exportedGroups),
+        getTempFilePath: () => '/tmp/project-steward-projects.json',
+        writeTextFile: async () => undefined,
+        fileUri: value => value,
+        openTextDocument: async () => document,
+        showTextDocument: async () => undefined,
+        onWillSaveTextDocument: listener => {
+            saveListener = listener;
+            return { dispose() {} };
+        },
+        saveGroups: async (groups, baselineGroups) => {
+            saves.push({ groups, baselineGroups });
+        },
+        executeCommand: async () => undefined,
+        showErrorMessage: message => assert.fail(message),
+        postSave: () => undefined,
+    });
+
+    await controller.editProjectsManually();
+    await saveListener({ document });
+
+    assert.deepEqual(saves, [{
+        groups: editedGroups,
+        baselineGroups: exportedGroups,
+    }]);
 });
 
 test('OPEN-PROJECT-OPEN-CONTROLLER-001 maps default and explicit window modes to VS Code commands', async () => {

--- a/tests/fixtures/aiSessions/runtimeHostActivationHarness.js
+++ b/tests/fixtures/aiSessions/runtimeHostActivationHarness.js
@@ -64,6 +64,7 @@ async function main() {
     const events = [];
     const verified = new Set();
     const aliasRebinds = [];
+    let simulatedAliasRebind = false;
     let dashboardCommandRegistrationInvocations = 0;
     const patch = (prototype, name, replacement) => {
         const original = prototype[name];
@@ -122,10 +123,13 @@ async function main() {
             assert.ok(this.options.client instanceof TmuxClient);
             assert.ok(this.options.bindingStore instanceof TmuxRuntimeBindingStore);
             assert.equal(typeof this.options.onSessionRebound, 'function');
-            this.options.onSessionRebound(
-                { provider: 'codex', sessionId: 'old-root' },
-                { provider: 'codex', sessionId: 'new-root' }
-            );
+            if (!simulatedAliasRebind) {
+                simulatedAliasRebind = true;
+                this.options.onSessionRebound(
+                    { provider: 'codex', sessionId: 'old-root' },
+                    { provider: 'codex', sessionId: 'new-root' }
+                );
+            }
             verified.add('client-store-discovery');
             verified.add('thread-switch-alias-wiring');
             events.push('inactive-restored');

--- a/tests/fixtures/aiSessions/runtimeHostActivationHarness.js
+++ b/tests/fixtures/aiSessions/runtimeHostActivationHarness.js
@@ -63,6 +63,7 @@ async function main() {
     const restores = [];
     const events = [];
     const verified = new Set();
+    const aliasRebinds = [];
     let dashboardCommandRegistrationInvocations = 0;
     const patch = (prototype, name, replacement) => {
         const original = prototype[name];
@@ -104,6 +105,7 @@ async function main() {
         const { TmuxRuntimeBindingStore } = require('../../../out/aiSessions/tmuxRuntimeBindingStore');
         const { TmuxRuntimeDiscovery } = require('../../../out/aiSessions/tmuxRuntimeDiscovery');
         const { AiSessionAttentionController } = require('../../../out/aiSessions/attentionController');
+        const AiSessionAliasController = require('../../../out/aiSessions/aliasController').default;
         const { DashboardCommandRegistration } = require('../../../out/dashboard/commandRegistration');
 
         const originalDashboardRegister = DashboardCommandRegistration.prototype.register;
@@ -111,12 +113,21 @@ async function main() {
             dashboardCommandRegistrationInvocations += 1;
             return originalDashboardRegister.apply(this, args);
         });
+        patch(AiSessionAliasController.prototype, 'copyForRebind', function (...args) {
+            aliasRebinds.push(args);
+        });
 
         patch(TmuxRuntimeDiscovery.prototype, 'loadPersistedInactive', async function () {
             assert.ok(this instanceof TmuxRuntimeDiscovery);
             assert.ok(this.options.client instanceof TmuxClient);
             assert.ok(this.options.bindingStore instanceof TmuxRuntimeBindingStore);
+            assert.equal(typeof this.options.onSessionRebound, 'function');
+            this.options.onSessionRebound(
+                { provider: 'codex', sessionId: 'old-root' },
+                { provider: 'codex', sessionId: 'new-root' }
+            );
             verified.add('client-store-discovery');
+            verified.add('thread-switch-alias-wiring');
             events.push('inactive-restored');
         });
         patch(TerminalService.prototype, 'restorePersistedTerminals', async function () {
@@ -159,6 +170,7 @@ async function main() {
             verified: [...verified].sort(),
             registeredCommands: vscode.registeredCommands,
             dashboardCommandRegistrationInvocations,
+            aliasRebinds,
         }));
     } finally {
         for (const subscription of context.subscriptions.slice().reverse()) subscription.dispose?.();

--- a/tests/integration/dashboard/errorRecovery.test.js
+++ b/tests/integration/dashboard/errorRecovery.test.js
@@ -268,6 +268,34 @@ test('PERSIST-DASHBOARD-LIFECYCLE-CONTROLLER-001 routes workspace, configuration
     ]);
 });
 
+test('PROJECT-CATALOG-SYNC-CONFLICT-001 reconciles synchronized project data before dashboard publication', async () => {
+    const events = [];
+    const controller = new DashboardLifecycleController({
+        checkDataMigration: async () => undefined,
+        reconcileProjectCatalog: async () => {
+            events.push('reconcile:start');
+            await Promise.resolve();
+            events.push('reconcile:end');
+        },
+        applyProjectColorToCurrentWindow: () => events.push('color'),
+        refresh: reason => events.push(['refresh', reason]),
+        publishOpenWorkspace: () => events.push('publish'),
+        evaluateAiSessionAttention: () => undefined,
+    });
+
+    await controller.handleConfigurationChanged(
+        makeConfigurationEvent('projectSteward.projectSyncData')
+    );
+
+    assert.deepEqual(events, [
+        'reconcile:start',
+        'reconcile:end',
+        'color',
+        ['refresh', 'configuration-changed'],
+        'publish',
+    ]);
+});
+
 test('WEBVIEW-DASHBOARD-STARTUP-CONTROLLER-001 retries a failed migration without stale refresh or publication', async () => {
     const events = [];
     let attempt = 0;


### PR DESCRIPTION
## Summary

- track repository CI-first regression skills and validate their guardrails
- preserve AI session aliases across Codex thread switches and historical migrations
- replace whole-snapshot project persistence with bounded causal merge data, a retryable local shadow, and legacy `projectData` compatibility
- add P0 regression coverage for stale snapshots, explicit deletion, same-actor concurrency, migration, failure recovery, and redacted diagnostics

## Verification

- `npm run test:ci:linux`
  - 166 unit tests
  - 238 contract tests
  - 61 integration tests
  - 465 coverage tests
  - lint, behavior catalog, safety, dashboard, architecture, release packaging, bundle, and coverage baseline passed

## Release

- No version bump, tag, GitHub Release, or marketplace publication is included or requested.
