### PR TITLE
feat: add AI session YOLO mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Common options:
 AI runtime options (all machine-scoped):
 
 - `projectSteward.aiSessionTerminalMode`: `vscode` (default) or `tmux`; affects creation only and never migrates a live runtime.
+- `projectSteward.aiSessionYoloMode`: `false` by default. When `true`, newly created and resumed Codex, Kimi, and Claude processes bypass their normal approval protections. This is dangerous, affects only the next process launch, and never changes an already live runtime.
 - `projectSteward.aiSessionTmuxLayout`: `project` (default, one project session with AI windows) or `session` (one tmux session per AI session).
 - `projectSteward.aiSessionTmuxPath`: one executable name resolved through the extension host's `PATH`, or one absolute executable path. Do not add arguments or shell syntax.
 - `projectSteward.aiSessionRunningCardAnimation`: animation shown on a workspace card while an AI session executes: `current` (default), `sweep`, `orbit`, `halo`, `sharingan-itachi`, `sharingan-obito-kakashi`, `sharingan-sasuke`, `sharingan-shisui`, `sharingan-madara`, `sharingan-madara-eternal`, `ripple`, `breath`, or `none`.
@@ -191,7 +192,8 @@ Example:
 {
   "projectSteward.aiSessionTerminalMode": "tmux",
   "projectSteward.aiSessionTmuxLayout": "project",
-  "projectSteward.aiSessionTmuxPath": "/usr/bin/tmux"
+  "projectSteward.aiSessionTmuxPath": "/usr/bin/tmux",
+  "projectSteward.aiSessionYoloMode": false
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Common options:
 AI runtime options (all machine-scoped):
 
 - `projectSteward.aiSessionTerminalMode`: `vscode` (default) or `tmux`; affects creation only and never migrates a live runtime.
-- `projectSteward.aiSessionYoloMode`: `false` by default. When `true`, newly created and resumed Codex, Kimi, and Claude processes bypass their normal approval protections. This is dangerous, affects only the next process launch, and never changes an already live runtime.
+- `projectSteward.aiSessionYoloMode`: `false` by default. When `true`, newly created and resumed Codex, Kimi, and Claude processes bypass their normal approval protections. This is dangerous, affects every process launched after the change while enabled, and never changes an already live runtime.
 - `projectSteward.aiSessionTmuxLayout`: `project` (default, one project session with AI windows) or `session` (one tmux session per AI session).
 - `projectSteward.aiSessionTmuxPath`: one executable name resolved through the extension host's `PATH`, or one absolute executable path. Do not add arguments or shell syntax.
 - `projectSteward.aiSessionRunningCardAnimation`: animation shown on a workspace card while an AI session executes: `current` (default), `sweep`, `orbit`, `halo`, `sharingan-itachi`, `sharingan-obito-kakashi`, `sharingan-sasuke`, `sharingan-shisui`, `sharingan-madara`, `sharingan-madara-eternal`, `ripple`, `breath`, or `none`.

--- a/docs/superpowers/plans/2026-07-25-ai-session-yolo-mode.md
+++ b/docs/superpowers/plans/2026-07-25-ai-session-yolo-mode.md
@@ -4,7 +4,7 @@
 
 **Goal:** Add a safe-by-default machine setting that applies each provider's approval-bypassing CLI argument whenever Project Steward creates or resumes an AI session process.
 
-**Architecture:** A focused configuration reader converts VS Code settings into a provider-neutral `AiSessionLaunchOptions` snapshot. Creation and resume controllers inject that snapshot into pure provider launch-spec builders, so Direct Terminal and tmux keep sharing the same serialized launch request and already-live runtimes remain unchanged.
+**Architecture:** A focused reader accesses `projectSteward` directly and converts the literal setting into provider-neutral `AiSessionLaunchOptions`. Creation and resume controllers carry a single-use launch-spec factory through the coordinator. Direct Terminal or tmux evaluates that factory exactly once at its final provider-dispatch boundary, so no-dispatch branches never read the setting or build a launch, both backends still share `AiSessionLaunchSpec`, and already-live runtimes remain unchanged.
 
 **Tech Stack:** TypeScript, VS Code extension configuration, Node.js 22.12 test runner, POSIX/PowerShell command serialization, npm scripts.
 
@@ -12,11 +12,13 @@
 
 - Add `projectSteward.aiSessionYoloMode` as a machine-scoped boolean with default `false`.
 - Only the literal boolean value `true` enables YOLO mode; missing or malformed values fail closed to `false`.
+- Read the security-sensitive option directly from `vscode.workspace.getConfiguration('projectSteward')`; the legacy `dashboard.*` fallback must never enable it.
 - Apply the setting to both New and Resume process launches for Codex, Kimi, and Claude.
 - Use `--dangerously-bypass-approvals-and-sandbox` for Codex, `--yolo` for Kimi, and `--dangerously-skip-permissions` for Claude.
 - Do not add a per-launch picker, per-session persistence, runtime badge, intermediate permission preset, or live-runtime migration.
-- Changing the setting affects the next process launch without requiring a VS Code reload.
+- Changing the setting affects every process launched after the change while enabled, without requiring a VS Code reload.
 - Keep Direct Terminal and tmux behavior unified through `AiSessionLaunchSpec`.
+- Read launch configuration and call a provider builder exactly once on provider dispatch and zero times for focused, blocked, conflict, cancelled, settings, duplicate, unavailable, or collision exits.
 - Work only in `.worktree/ai-session-yolo-mode` on `feat/ai-session-yolo-mode`; do not modify the primary checkout.
 
 ## File Structure
@@ -25,9 +27,15 @@
 - Modify `src/aiSessions/commandBuilders.ts`: translate the provider-neutral YOLO value into provider-specific argv.
 - Modify `src/aiSessions/types.ts`: expose launch options in provider New and Resume launch-spec contracts.
 - Modify `src/aiSessions/providers.ts`: forward launch options through provider-specific wrappers.
-- Modify `src/aiSessions/creationController.ts`: snapshot and pass launch options for New.
-- Modify `src/aiSessions/resumeController.ts`: snapshot and pass launch options for Resume.
-- Modify `src/dashboard.ts`: read the current Project Steward configuration for each actual controller launch.
+- Create `src/aiSessions/runtimeLaunch.ts`: snapshot deferred launch intent, enforce single use, and materialize a common launch spec.
+- Modify `src/aiSessions/runtimeTypes.ts`: represent deferred and materialized runtime launch requests.
+- Modify `src/aiSessions/creationController.ts`: capture a defensive New launch factory.
+- Modify `src/aiSessions/resumeController.ts`: capture a defensive Resume launch factory.
+- Modify `src/aiSessions/runtimeCoordinator.ts`: snapshot and route the factory without evaluating it.
+- Modify `src/aiSessions/directTerminalRuntimeBackend.ts`: materialize only at direct provider dispatch.
+- Modify `src/aiSessions/tmuxRuntimeBackend.ts`: materialize after final target checks and make pending ambiguity identity launch-option-independent.
+- Modify `src/aiSessions/tmuxRuntimeBindingStore.ts`: accept new `v3` and legacy pending fingerprints.
+- Modify `src/dashboard.ts`: supply the VS Code workspace so the reader accesses `projectSteward` directly.
 - Modify `package.json`: declare the public setting contract.
 - Modify `README.md`: document risk, scope, and next-launch semantics.
 - Modify `tests/contract/aiSessions/runtimePrimitives.test.js`: verify configuration and serialized launch boundaries.
@@ -36,6 +44,10 @@
 - Modify `tests/contract/aiSessions/sessionControllers.test.js`: verify New and Resume propagate a launch-options snapshot.
 - Modify `scripts/run-ai-session-safety-checks.js`: preserve production-wiring guards and supply safe launch options in controller fixtures.
 - Modify `scripts/run-ai-session-tmux-checks.js`: supply safe launch options in tmux controller fixtures and retain backend parity coverage.
+
+Tasks 1–4 preserve the original implementation sequence. Task 5 is the
+binding post-review correction and supersedes any earlier eager-construction
+snippet.
 
 ---
 
@@ -48,8 +60,8 @@
 - Test: `tests/contract/aiSessions/runtimePrimitives.test.js`
 
 **Interfaces:**
-- Consumes: a VS Code-compatible configuration reader with `get<T>(key: string, fallback: T): T`.
-- Produces: `AiSessionLaunchOptions { yolo: boolean }` and `readAiSessionLaunchOptions(configuration): AiSessionLaunchOptions`.
+- Consumes: a VS Code-compatible workspace configuration provider with `getConfiguration(section)`.
+- Produces: `AiSessionLaunchOptions { yolo: boolean }` and `readAiSessionLaunchOptions(workspace): AiSessionLaunchOptions`, reading only `projectSteward`.
 
 - [ ] **Step 1: Write the failing configuration contract test**
 
@@ -66,19 +78,29 @@ Add this test immediately after
 ```js
 test('SESSION-AI-SESSION-YOLO-CONFIGURATION-001 reads only literal true and declares a safe machine setting', () => {
     assert.deepEqual(
-        launchOptions.readAiSessionLaunchOptions(configuration({})),
+        launchOptions.readAiSessionLaunchOptions(workspaceConfiguration({})),
         { yolo: false }
     );
     assert.deepEqual(
-        launchOptions.readAiSessionLaunchOptions(configuration({ aiSessionYoloMode: true })),
+        launchOptions.readAiSessionLaunchOptions(
+            workspaceConfiguration({ aiSessionYoloMode: true })
+        ),
         { yolo: true }
     );
     for (const invalid of [false, null, 1, 'true', 'false', {}]) {
         assert.deepEqual(
-            launchOptions.readAiSessionLaunchOptions(configuration({ aiSessionYoloMode: invalid })),
+            launchOptions.readAiSessionLaunchOptions(
+                workspaceConfiguration({ aiSessionYoloMode: invalid })
+            ),
             { yolo: false }
         );
     }
+    assert.deepEqual(
+        launchOptions.readAiSessionLaunchOptions(
+            workspaceConfiguration({}, { aiSessionYoloMode: true })
+        ),
+        { yolo: false }
+    );
 
     const manifest = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../../../package.json'), 'utf8'));
     const setting = manifest.contributes.configuration.properties[
@@ -119,9 +141,14 @@ interface ConfigurationReader {
     get<T>(key: string, fallback: T): T;
 }
 
+interface WorkspaceConfigurationProvider {
+    getConfiguration(section: string): ConfigurationReader;
+}
+
 export function readAiSessionLaunchOptions(
-    configuration: ConfigurationReader
+    workspace: WorkspaceConfigurationProvider
 ): AiSessionLaunchOptions {
+    const configuration = workspace.getConfiguration('projectSteward');
     return {
         yolo: configuration.get<unknown>('aiSessionYoloMode', false) === true,
     };
@@ -146,7 +173,7 @@ Add this bullet under `AI runtime options (all machine-scoped)` in
 `README.md`:
 
 ```markdown
-- `projectSteward.aiSessionYoloMode`: `false` by default. When `true`, newly created and resumed Codex, Kimi, and Claude processes bypass their normal approval protections. This is dangerous, affects only the next process launch, and never changes an already live runtime.
+- `projectSteward.aiSessionYoloMode`: `false` by default. When `true`, newly created and resumed Codex, Kimi, and Claude processes bypass their normal approval protections. This is dangerous, affects every process launched after the change while enabled, and never changes an already live runtime.
 ```
 
 Extend the nearby JSON example:
@@ -306,7 +333,7 @@ Add a safe default and helper:
 const SAFE_LAUNCH_OPTIONS: AiSessionLaunchOptions = Object.freeze({ yolo: false });
 
 function yoloArg(options: AiSessionLaunchOptions, argument: string): string[] {
-    return options.yolo ? [argument] : [];
+    return options?.yolo === true ? [argument] : [];
 }
 ```
 
@@ -406,8 +433,8 @@ git commit -m "feat: add provider yolo launch arguments"
 - Test: `scripts/run-ai-session-tmux-checks.js`
 
 **Interfaces:**
-- Consumes: `readAiSessionLaunchOptions(getStewardConfiguration())` and the optional fourth builder argument introduced in Task 2.
-- Produces: both controller option types require `getLaunchOptions: () => AiSessionLaunchOptions`, and both provider launch-spec contracts require an explicit `AiSessionLaunchOptions` value.
+- Consumes: `readAiSessionLaunchOptions(vscode.workspace)` and the optional fourth builder argument introduced in Task 2.
+- Produces: both controller option types require `getLaunchOptions: () => AiSessionLaunchOptions`; controllers close over it in a single-use factory, and provider launch-spec contracts require an explicit `AiSessionLaunchOptions` value.
 
 - [ ] **Step 1: Write failing controller propagation assertions**
 
@@ -459,6 +486,10 @@ After the resume request assertions, add:
 assert.deepEqual(receivedLaunchOptions, [{ yolo: true }]);
 ```
 
+For a stub that returns `started`, invoke `request.createLaunchSpec()` once to
+model the backend's final dispatch. Stubs returning `focused`, `blocked`,
+`conflict`, `cancelled`, or `settings` must not invoke it.
+
 - [ ] **Step 2: Run the focused controller contract to verify it fails**
 
 Run:
@@ -493,33 +524,31 @@ Add `launchOptions: AiSessionLaunchOptions` as the fourth parameter of
 `AiSessionCreationProvider.buildNewSessionLaunchSpec`, and
 `AiSessionResumeProvider.buildResumeLaunchSpec`.
 
-In `AiSessionCreationController.createRuntimeSession`, snapshot once and pass
-the snapshot to the builder:
+In `AiSessionCreationController.createRuntimeSession`, capture a single-use
+factory over a defensive scope snapshot:
 
 ```ts
-const launchOptions = options.getLaunchOptions();
-const launch = cloneLaunchSpec(
+launchMarkerPath: markerPath,
+createLaunchSpec: createSingleUseLaunchSpecFactory(() =>
     sessionProvider.buildNewSessionLaunchSpec(
-        directoryScope,
+        launchScope,
         fields.title,
         markerPath,
-        launchOptions
-    )
-);
+        options.getLaunchOptions()
+    )),
 ```
 
 In `AiSessionResumeController.resumeRuntime`, do the same:
 
 ```ts
-const launchOptions = options.getLaunchOptions();
-const launch = cloneLaunchSpec(
+launchMarkerPath: markerPath,
+createLaunchSpec: createSingleUseLaunchSpecFactory(() =>
     sessionProvider.buildResumeLaunchSpec(
         session.id,
-        directoryScope,
+        launchScope,
         markerPath,
-        launchOptions
-    )
-);
+        options.getLaunchOptions()
+    )),
 ```
 
 Require `getLaunchOptions` in both `validateControllerOptions` functions:
@@ -559,7 +588,7 @@ Add this dependency to both `AiSessionCreationController` and
 
 ```ts
 getLaunchOptions: () =>
-    readAiSessionLaunchOptions(getStewardConfiguration()),
+    readAiSessionLaunchOptions(vscode.workspace),
 ```
 
 Do not add `projectSteward.aiSessionYoloMode` to the runtime-configuration
@@ -597,7 +626,8 @@ assert.strictEqual(
     (dashboard.match(/getLaunchOptions: \(\) =>/g) || []).length,
     2
 );
-assert.ok(dashboard.includes(
+assert.ok(dashboard.includes('readAiSessionLaunchOptions(vscode.workspace)'));
+assert.ok(!dashboard.includes(
     'readAiSessionLaunchOptions(getStewardConfiguration())'
 ));
 ```
@@ -678,5 +708,60 @@ git status -sb
 git log --oneline --decorate origin/main..HEAD
 ```
 
-Expected: no whitespace errors; the worktree is clean; the branch contains the
-design commit, plan commit, and three focused implementation commits only.
+Expected: no whitespace errors; the worktree is clean; the post-review fixes
+and documentation are contained in one focused review-fix commit after the
+previous implementation history.
+
+### Task 5: Binding Post-Review Lazy-Dispatch Fix
+
+**Files:**
+- Modify the configuration reader and dashboard wiring.
+- Add deferred launch request types and `runtimeLaunch.ts`.
+- Modify both controllers, the coordinator, and both runtime backends.
+- Modify tmux pending ambiguity fingerprint validation and recovery.
+- Extend focused contracts, safety checks, tmux checks, README, design, and this plan.
+
+**Interfaces:**
+- Controllers produce `launchMarkerPath` plus a single-use
+  `createLaunchSpec()` factory.
+- The coordinator and backends preserve that factory without reading a legacy
+  concrete `launch` property.
+- Only the final direct/tmux provider-dispatch boundary materializes
+  `AiSessionLaunchSpec`.
+- New pending ambiguity records use a stable, launch-option-independent `v3`
+  fingerprint; matching legacy hashes remain recoverable.
+
+- [ ] **Step 1: Record focused RED evidence**
+
+Add regressions for direct configuration reads, malformed truthy options,
+controller/coordinator/backend no-dispatch branches, fallback-time setting
+changes, stable pending fingerprints, and legacy ambiguity recovery. Run
+`npm run test-compile` followed by each focused command and retain the failing
+totals in the final review report.
+
+- [ ] **Step 2: Implement the final lazy boundary**
+
+Carry the single-use factory through immutable request snapshots. Materialize
+it once immediately before Direct Terminal sends the provider launch or tmux
+calls `create-session`/`create-window`, after every availability, ownership,
+lifecycle, duplicate, conflict, fallback, lock, and target check.
+
+- [ ] **Step 3: Run focused GREEN verification**
+
+Run the configuration/options, builder unit/contract/Windows,
+creation/resume-controller, coordinator-all-branches, and backend-boundary
+tests after `npm run test-compile`.
+
+- [ ] **Step 4: Run required regression verification**
+
+```bash
+node scripts/run-ai-session-safety-checks.js
+node scripts/run-ai-session-tmux-checks.js
+npm run test:deterministic
+```
+
+- [ ] **Step 5: Self-review and create one post-review commit**
+
+Inspect the complete diff, run `git diff --check`, write
+`.superpowers/sdd/final-review-fix-report.md`, stage all post-review code,
+tests, and documentation together, and create one focused review-fix commit.

--- a/docs/superpowers/plans/2026-07-25-ai-session-yolo-mode.md
+++ b/docs/superpowers/plans/2026-07-25-ai-session-yolo-mode.md
@@ -1,0 +1,682 @@
+# AI Session YOLO Mode Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a safe-by-default machine setting that applies each provider's approval-bypassing CLI argument whenever Project Steward creates or resumes an AI session process.
+
+**Architecture:** A focused configuration reader converts VS Code settings into a provider-neutral `AiSessionLaunchOptions` snapshot. Creation and resume controllers inject that snapshot into pure provider launch-spec builders, so Direct Terminal and tmux keep sharing the same serialized launch request and already-live runtimes remain unchanged.
+
+**Tech Stack:** TypeScript, VS Code extension configuration, Node.js 22.12 test runner, POSIX/PowerShell command serialization, npm scripts.
+
+## Global Constraints
+
+- Add `projectSteward.aiSessionYoloMode` as a machine-scoped boolean with default `false`.
+- Only the literal boolean value `true` enables YOLO mode; missing or malformed values fail closed to `false`.
+- Apply the setting to both New and Resume process launches for Codex, Kimi, and Claude.
+- Use `--dangerously-bypass-approvals-and-sandbox` for Codex, `--yolo` for Kimi, and `--dangerously-skip-permissions` for Claude.
+- Do not add a per-launch picker, per-session persistence, runtime badge, intermediate permission preset, or live-runtime migration.
+- Changing the setting affects the next process launch without requiring a VS Code reload.
+- Keep Direct Terminal and tmux behavior unified through `AiSessionLaunchSpec`.
+- Work only in `.worktree/ai-session-yolo-mode` on `feat/ai-session-yolo-mode`; do not modify the primary checkout.
+
+## File Structure
+
+- Create `src/aiSessions/launchOptions.ts`: own the provider-neutral launch options type and fail-closed VS Code configuration reader.
+- Modify `src/aiSessions/commandBuilders.ts`: translate the provider-neutral YOLO value into provider-specific argv.
+- Modify `src/aiSessions/types.ts`: expose launch options in provider New and Resume launch-spec contracts.
+- Modify `src/aiSessions/providers.ts`: forward launch options through provider-specific wrappers.
+- Modify `src/aiSessions/creationController.ts`: snapshot and pass launch options for New.
+- Modify `src/aiSessions/resumeController.ts`: snapshot and pass launch options for Resume.
+- Modify `src/dashboard.ts`: read the current Project Steward configuration for each actual controller launch.
+- Modify `package.json`: declare the public setting contract.
+- Modify `README.md`: document risk, scope, and next-launch semantics.
+- Modify `tests/contract/aiSessions/runtimePrimitives.test.js`: verify configuration and serialized launch boundaries.
+- Modify `tests/unit/aiSessions/commandBuilders.test.js`: verify all six provider/action YOLO argv variants.
+- Modify `tests/platform/windows/commandBuilders.test.js`: verify Windows serialization preserves the new flags as CLI syntax.
+- Modify `tests/contract/aiSessions/sessionControllers.test.js`: verify New and Resume propagate a launch-options snapshot.
+- Modify `scripts/run-ai-session-safety-checks.js`: preserve production-wiring guards and supply safe launch options in controller fixtures.
+- Modify `scripts/run-ai-session-tmux-checks.js`: supply safe launch options in tmux controller fixtures and retain backend parity coverage.
+
+---
+
+### Task 1: Safe Launch Configuration Contract
+
+**Files:**
+- Create: `src/aiSessions/launchOptions.ts`
+- Modify: `package.json`
+- Modify: `README.md`
+- Test: `tests/contract/aiSessions/runtimePrimitives.test.js`
+
+**Interfaces:**
+- Consumes: a VS Code-compatible configuration reader with `get<T>(key: string, fallback: T): T`.
+- Produces: `AiSessionLaunchOptions { yolo: boolean }` and `readAiSessionLaunchOptions(configuration): AiSessionLaunchOptions`.
+
+- [ ] **Step 1: Write the failing configuration contract test**
+
+Add the import beside the existing runtime configuration import in
+`tests/contract/aiSessions/runtimePrimitives.test.js`:
+
+```js
+const launchOptions = require('../../../out/aiSessions/launchOptions');
+```
+
+Add this test immediately after
+`RUNTIME-RUNTIME-CONFIGURATION-001`:
+
+```js
+test('SESSION-AI-SESSION-YOLO-CONFIGURATION-001 reads only literal true and declares a safe machine setting', () => {
+    assert.deepEqual(
+        launchOptions.readAiSessionLaunchOptions(configuration({})),
+        { yolo: false }
+    );
+    assert.deepEqual(
+        launchOptions.readAiSessionLaunchOptions(configuration({ aiSessionYoloMode: true })),
+        { yolo: true }
+    );
+    for (const invalid of [false, null, 1, 'true', 'false', {}]) {
+        assert.deepEqual(
+            launchOptions.readAiSessionLaunchOptions(configuration({ aiSessionYoloMode: invalid })),
+            { yolo: false }
+        );
+    }
+
+    const manifest = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../../../package.json'), 'utf8'));
+    const setting = manifest.contributes.configuration.properties[
+        'projectSteward.aiSessionYoloMode'
+    ];
+    assert.equal(setting.type, 'boolean');
+    assert.equal(setting.default, false);
+    assert.equal(setting.scope, 'machine');
+    assert.match(setting.description, /bypass/i);
+    assert.match(setting.description, /newly created and resumed/i);
+});
+```
+
+- [ ] **Step 2: Run the targeted contract test to verify it fails**
+
+Run:
+
+```bash
+npm run test-compile
+node --test tests/contract/aiSessions/runtimePrimitives.test.js
+```
+
+Expected: compilation succeeds, then the test process fails with
+`Cannot find module '../../../out/aiSessions/launchOptions'`.
+
+- [ ] **Step 3: Add the fail-closed launch-options reader**
+
+Create `src/aiSessions/launchOptions.ts`:
+
+```ts
+'use strict';
+
+export interface AiSessionLaunchOptions {
+    yolo: boolean;
+}
+
+interface ConfigurationReader {
+    get<T>(key: string, fallback: T): T;
+}
+
+export function readAiSessionLaunchOptions(
+    configuration: ConfigurationReader
+): AiSessionLaunchOptions {
+    return {
+        yolo: configuration.get<unknown>('aiSessionYoloMode', false) === true,
+    };
+}
+```
+
+- [ ] **Step 4: Declare and document the public setting**
+
+Add this property after `projectSteward.aiSessionTerminalMode` in
+`package.json`:
+
+```json
+"projectSteward.aiSessionYoloMode": {
+    "type": "boolean",
+    "default": false,
+    "scope": "machine",
+    "description": "Bypass provider approval and sandbox protections for newly created and resumed AI session processes. This is dangerous and does not change already running sessions."
+},
+```
+
+Add this bullet under `AI runtime options (all machine-scoped)` in
+`README.md`:
+
+```markdown
+- `projectSteward.aiSessionYoloMode`: `false` by default. When `true`, newly created and resumed Codex, Kimi, and Claude processes bypass their normal approval protections. This is dangerous, affects only the next process launch, and never changes an already live runtime.
+```
+
+Extend the nearby JSON example:
+
+```json
+{
+  "projectSteward.aiSessionTerminalMode": "tmux",
+  "projectSteward.aiSessionTmuxLayout": "project",
+  "projectSteward.aiSessionTmuxPath": "/usr/bin/tmux",
+  "projectSteward.aiSessionYoloMode": false
+}
+```
+
+- [ ] **Step 5: Run the targeted configuration contract**
+
+Run:
+
+```bash
+npm run test-compile
+node --test tests/contract/aiSessions/runtimePrimitives.test.js
+```
+
+Expected: all tests in `runtimePrimitives.test.js` pass, including
+`SESSION-AI-SESSION-YOLO-CONFIGURATION-001`.
+
+- [ ] **Step 6: Commit the configuration contract**
+
+```bash
+git add src/aiSessions/launchOptions.ts package.json README.md tests/contract/aiSessions/runtimePrimitives.test.js
+git diff --cached --check
+git commit -m "feat: add AI session yolo setting"
+```
+
+### Task 2: Provider-Specific YOLO Launch Arguments
+
+**Files:**
+- Modify: `src/aiSessions/commandBuilders.ts`
+- Test: `tests/unit/aiSessions/commandBuilders.test.js`
+- Test: `tests/contract/aiSessions/runtimePrimitives.test.js`
+- Test: `tests/platform/windows/commandBuilders.test.js`
+
+**Interfaces:**
+- Consumes: `AiSessionLaunchOptions` from `src/aiSessions/launchOptions.ts`.
+- Produces: all six `build{Codex,Kimi,Claude}{NewSession,Resume}LaunchSpec` functions accept an optional final `launchOptions` argument and preserve safe defaults when it is omitted.
+
+- [ ] **Step 1: Write failing argv tests for all providers and actions**
+
+Add this focused test to
+`tests/unit/aiSessions/commandBuilders.test.js`:
+
+```js
+test('SESSION-AI-SESSION-YOLO-LAUNCH-001 adds the exact provider flag to New and Resume argv', () => {
+    const yolo = { yolo: true };
+    assert.deepEqual(
+        commands.buildCodexNewSessionLaunchSpec(directoryScope, title, markerPath, yolo).args,
+        ['--dangerously-bypass-approvals-and-sandbox', '--cd', cwd, title]
+    );
+    assert.deepEqual(
+        commands.buildCodexResumeLaunchSpec(sessionId, directoryScope, markerPath, yolo).args,
+        ['resume', '--dangerously-bypass-approvals-and-sandbox', '--cd', cwd, sessionId]
+    );
+    assert.deepEqual(
+        commands.buildKimiNewSessionLaunchSpec(directoryScope, title, markerPath, yolo).args,
+        ['--work-dir', cwd, '--yolo', '--prompt', title]
+    );
+    assert.deepEqual(
+        commands.buildKimiResumeLaunchSpec(sessionId, directoryScope, markerPath, yolo).args,
+        ['--work-dir', cwd, '--yolo', '--resume', sessionId]
+    );
+    assert.deepEqual(
+        commands.buildClaudeNewSessionLaunchSpec(directoryScope, title, markerPath, yolo).args,
+        ['--dangerously-skip-permissions', '--name', title]
+    );
+    assert.deepEqual(
+        commands.buildClaudeResumeLaunchSpec(sessionId, directoryScope, markerPath, yolo).args,
+        ['--dangerously-skip-permissions', '--resume', sessionId]
+    );
+});
+```
+
+Add these assertions inside `RUNTIME-LAUNCH-SPEC-001` in
+`tests/contract/aiSessions/runtimePrimitives.test.js` after the existing
+safe Claude assertions:
+
+```js
+const yoloSpecs = [
+    commandBuilders.buildCodexNewSessionLaunchSpec(
+        directoryScope('/work/codex'), null, null, { yolo: true }
+    ),
+    commandBuilders.buildKimiResumeLaunchSpec(
+        'kimi-session', directoryScope('/work/kimi'), null, { yolo: true }
+    ),
+    commandBuilders.buildClaudeNewSessionLaunchSpec(
+        directoryScope('/work/claude'), null, null, { yolo: true }
+    ),
+];
+for (const spec of yoloSpecs) {
+    const direct = launchSpec.serializeDirectLaunchCommand(spec, 'linux');
+    const tmux = launchSpec.serializeTmuxLaunchCommand(spec);
+    assert.match(direct, /--(?:dangerously-bypass-approvals-and-sandbox|yolo|dangerously-skip-permissions)/);
+    assert.match(tmux, /--(?:dangerously-bypass-approvals-and-sandbox|yolo|dangerously-skip-permissions)/);
+}
+```
+
+Add this test to `tests/platform/windows/commandBuilders.test.js`, reusing
+that file's `directoryScope` and `decodePowerShellPayload` helpers. Add this
+import beside the command-builder import:
+
+```js
+const { serializeDirectLaunchCommand } = require('../../../out/aiSessions/launchSpec');
+```
+
+Then add:
+
+```js
+test('SESSION-AI-SESSION-YOLO-LAUNCH-001 serializes provider flags as Windows CLI syntax', () => {
+    const yolo = { yolo: true };
+    const specs = [
+        commands.buildCodexNewSessionLaunchSpec(directoryScope(cwd), null, null, yolo),
+        commands.buildKimiNewSessionLaunchSpec(directoryScope(cwd), null, null, yolo),
+        commands.buildClaudeNewSessionLaunchSpec(directoryScope(cwd), null, null, yolo),
+    ];
+    const payloads = specs.map(spec =>
+        decodePowerShellPayload(serializeDirectLaunchCommand(spec, 'win32'))
+    );
+    assert.match(payloads[0], /codex --dangerously-bypass-approvals-and-sandbox/);
+    assert.match(payloads[1], /kimi .*--yolo/);
+    assert.match(payloads[2], /claude --dangerously-skip-permissions/);
+});
+```
+
+- [ ] **Step 2: Run focused tests to verify the new assertions fail**
+
+Run:
+
+```bash
+npm run test-compile
+node --test tests/unit/aiSessions/commandBuilders.test.js
+node --test tests/contract/aiSessions/runtimePrimitives.test.js
+node --test tests/platform/windows/commandBuilders.test.js
+```
+
+Expected: the new YOLO tests fail because the fourth launch-spec argument is
+ignored and no provider-specific flag is present.
+
+- [ ] **Step 3: Extend the pure launch-spec builders**
+
+Import the type in `src/aiSessions/commandBuilders.ts`:
+
+```ts
+import type { AiSessionLaunchOptions } from './launchOptions';
+```
+
+Add a safe default and helper:
+
+```ts
+const SAFE_LAUNCH_OPTIONS: AiSessionLaunchOptions = Object.freeze({ yolo: false });
+
+function yoloArg(options: AiSessionLaunchOptions, argument: string): string[] {
+    return options.yolo ? [argument] : [];
+}
+```
+
+Change the six launch-spec signatures to accept:
+
+```ts
+launchOptions: AiSessionLaunchOptions = SAFE_LAUNCH_OPTIONS
+```
+
+Build the provider argv exactly as follows:
+
+```ts
+// Codex Resume
+args: [
+    'resume',
+    ...yoloArg(launchOptions, '--dangerously-bypass-approvals-and-sandbox'),
+    ...(scope?.primaryCwd ? ['--cd', scope.primaryCwd] : []),
+    ...buildRepeatedAdditionalDirectoryArgs(scope),
+    sessionId,
+],
+
+// Codex New
+args: [
+    ...yoloArg(launchOptions, '--dangerously-bypass-approvals-and-sandbox'),
+    ...(scope?.primaryCwd ? ['--cd', scope.primaryCwd] : []),
+    ...buildRepeatedAdditionalDirectoryArgs(scope),
+    ...(prompt ? [prompt] : []),
+],
+
+// Kimi Resume
+args: [
+    ...(scope?.primaryCwd ? ['--work-dir', scope.primaryCwd] : []),
+    ...buildRepeatedAdditionalDirectoryArgs(scope),
+    ...yoloArg(launchOptions, '--yolo'),
+    '--resume', sessionId,
+],
+
+// Kimi New
+args: [
+    ...(scope?.primaryCwd ? ['--work-dir', scope.primaryCwd] : []),
+    ...buildRepeatedAdditionalDirectoryArgs(scope),
+    ...yoloArg(launchOptions, '--yolo'),
+    ...(prompt ? ['--prompt', prompt] : []),
+],
+
+// Claude Resume
+args: [
+    ...buildClaudeAdditionalDirectoryArgs(scope),
+    ...yoloArg(launchOptions, '--dangerously-skip-permissions'),
+    '--resume', sessionId,
+],
+
+// Claude New
+args: [
+    ...buildClaudeAdditionalDirectoryArgs(scope),
+    ...yoloArg(launchOptions, '--dangerously-skip-permissions'),
+    ...(title ? ['--name', title] : []),
+],
+```
+
+Do not change the existing command wrapper signatures in this task. They omit
+the optional launch-options argument and therefore continue to serialize the
+safe default exactly as before.
+
+- [ ] **Step 4: Run provider and serializer tests**
+
+Run:
+
+```bash
+npm run test-compile
+node --test tests/unit/aiSessions/commandBuilders.test.js
+node --test tests/contract/aiSessions/runtimePrimitives.test.js
+node --test tests/platform/windows/commandBuilders.test.js
+```
+
+Expected: all three commands pass; existing non-YOLO exact argv and command
+strings remain unchanged.
+
+- [ ] **Step 5: Commit provider launch behavior**
+
+```bash
+git add src/aiSessions/commandBuilders.ts tests/unit/aiSessions/commandBuilders.test.js tests/contract/aiSessions/runtimePrimitives.test.js tests/platform/windows/commandBuilders.test.js
+git diff --cached --check
+git commit -m "feat: add provider yolo launch arguments"
+```
+
+### Task 3: Controller Propagation and Production Wiring
+
+**Files:**
+- Modify: `src/aiSessions/types.ts`
+- Modify: `src/aiSessions/providers.ts`
+- Modify: `src/aiSessions/creationController.ts`
+- Modify: `src/aiSessions/resumeController.ts`
+- Modify: `src/dashboard.ts`
+- Test: `tests/contract/aiSessions/sessionControllers.test.js`
+- Test: `scripts/run-ai-session-safety-checks.js`
+- Test: `scripts/run-ai-session-tmux-checks.js`
+
+**Interfaces:**
+- Consumes: `readAiSessionLaunchOptions(getStewardConfiguration())` and the optional fourth builder argument introduced in Task 2.
+- Produces: both controller option types require `getLaunchOptions: () => AiSessionLaunchOptions`, and both provider launch-spec contracts require an explicit `AiSessionLaunchOptions` value.
+
+- [ ] **Step 1: Write failing controller propagation assertions**
+
+In the creation-controller test in
+`tests/contract/aiSessions/sessionControllers.test.js`, declare:
+
+```js
+const receivedLaunchOptions = [];
+```
+
+Change its provider builder and add the reader:
+
+```js
+getLaunchOptions: () => ({ yolo: true }),
+getProvider: () => ({
+    label: 'Codex',
+    terminalNamePrefix: 'Codex',
+    buildNewSessionLaunchSpec: (_scope, _title, _markerPath, launchOptions) => {
+        receivedLaunchOptions.push(launchOptions);
+        return { executable: 'codex', args: ['--new'], cwd: '/work' };
+    },
+}),
+```
+
+After the request assertions, add:
+
+```js
+assert.deepEqual(receivedLaunchOptions, [{ yolo: true }]);
+```
+
+In the resume-controller test, declare another
+`receivedLaunchOptions` array and use:
+
+```js
+getLaunchOptions: () => ({ yolo: true }),
+getProvider: () => ({
+    label: 'Codex',
+    terminalEnvKey: 'CODEX',
+    buildResumeLaunchSpec: (_id, _scope, _markerPath, launchOptions) => {
+        receivedLaunchOptions.push(launchOptions);
+        return { executable: 'codex', args: ['resume', 's'], cwd: '/work' };
+    },
+}),
+```
+
+After the resume request assertions, add:
+
+```js
+assert.deepEqual(receivedLaunchOptions, [{ yolo: true }]);
+```
+
+- [ ] **Step 2: Run the focused controller contract to verify it fails**
+
+Run:
+
+```bash
+npm run test-compile
+node --test tests/contract/aiSessions/sessionControllers.test.js
+```
+
+Expected: both new assertions fail because the provider builders receive
+`undefined` as their fourth argument.
+
+- [ ] **Step 3: Extend provider and controller contracts**
+
+Import `AiSessionLaunchOptions` into `src/aiSessions/types.ts`,
+`src/aiSessions/creationController.ts`, and
+`src/aiSessions/resumeController.ts`:
+
+```ts
+import type { AiSessionLaunchOptions } from './launchOptions';
+```
+
+Add this required controller option to both common option interfaces:
+
+```ts
+getLaunchOptions: () => AiSessionLaunchOptions;
+```
+
+Add `launchOptions: AiSessionLaunchOptions` as the fourth parameter of
+`AiSessionProviderDefinition.buildResumeLaunchSpec`,
+`AiSessionProviderDefinition.buildNewSessionLaunchSpec`,
+`AiSessionCreationProvider.buildNewSessionLaunchSpec`, and
+`AiSessionResumeProvider.buildResumeLaunchSpec`.
+
+In `AiSessionCreationController.createRuntimeSession`, snapshot once and pass
+the snapshot to the builder:
+
+```ts
+const launchOptions = options.getLaunchOptions();
+const launch = cloneLaunchSpec(
+    sessionProvider.buildNewSessionLaunchSpec(
+        directoryScope,
+        fields.title,
+        markerPath,
+        launchOptions
+    )
+);
+```
+
+In `AiSessionResumeController.resumeRuntime`, do the same:
+
+```ts
+const launchOptions = options.getLaunchOptions();
+const launch = cloneLaunchSpec(
+    sessionProvider.buildResumeLaunchSpec(
+        session.id,
+        directoryScope,
+        markerPath,
+        launchOptions
+    )
+);
+```
+
+Require `getLaunchOptions` in both `validateControllerOptions` functions:
+
+```ts
+|| typeof options.getLaunchOptions !== 'function'
+```
+
+- [ ] **Step 4: Forward options through provider definitions**
+
+Update the Codex and Kimi New wrappers in `src/aiSessions/providers.ts`:
+
+```ts
+buildNewSessionLaunchSpec: (scope, _title, markerPath, launchOptions) =>
+    buildCodexNewSessionLaunchSpec(scope, null, markerPath, launchOptions),
+```
+
+```ts
+buildNewSessionLaunchSpec: (scope, _title, markerPath, launchOptions) =>
+    buildKimiNewSessionLaunchSpec(scope, null, markerPath, launchOptions),
+```
+
+The direct Codex/Kimi/Claude Resume functions and Claude New function already
+accept the compatible optional fourth argument from Task 2 and can remain
+direct references.
+
+- [ ] **Step 5: Wire current configuration into production**
+
+Import the reader in `src/dashboard.ts`:
+
+```ts
+import { readAiSessionLaunchOptions } from './aiSessions/launchOptions';
+```
+
+Add this dependency to both `AiSessionCreationController` and
+`AiSessionResumeController` construction:
+
+```ts
+getLaunchOptions: () =>
+    readAiSessionLaunchOptions(getStewardConfiguration()),
+```
+
+Do not add `projectSteward.aiSessionYoloMode` to the runtime-configuration
+change handler. The reader is evaluated on each launch, so toggling the setting
+requires neither backend rebuild nor dashboard refresh.
+
+- [ ] **Step 6: Update all controller fixtures with a safe reader**
+
+Use these searches to enumerate every fixture:
+
+```bash
+rg -n "new (AiSessionCreationController|CreationController)" tests scripts
+rg -n "new (AiSessionResumeController|ResumeController)" tests scripts
+```
+
+For every creation or resume controller fixture in
+`scripts/run-ai-session-safety-checks.js` and
+`scripts/run-ai-session-tmux-checks.js` that does not explicitly test YOLO
+propagation, add:
+
+```js
+getLaunchOptions: () => ({ yolo: false }),
+```
+
+Keep the two focused contract fixtures from Step 1 at `{ yolo: true }`.
+
+Extend the production wiring assertions near the existing constructor checks
+in `scripts/run-ai-session-safety-checks.js`:
+
+```js
+assert.ok(dashboard.includes(
+    "import { readAiSessionLaunchOptions } from './aiSessions/launchOptions';"
+));
+assert.strictEqual(
+    (dashboard.match(/getLaunchOptions: \(\) =>/g) || []).length,
+    2
+);
+assert.ok(dashboard.includes(
+    'readAiSessionLaunchOptions(getStewardConfiguration())'
+));
+```
+
+- [ ] **Step 7: Run controller, provider-contract, safety, and tmux checks**
+
+Run:
+
+```bash
+npm run test-compile
+node --test tests/contract/aiSessions/sessionControllers.test.js
+node --test tests/contract/aiSessions/providers.test.js
+node scripts/run-ai-session-safety-checks.js
+node scripts/run-ai-session-tmux-checks.js
+```
+
+Expected: all commands pass; safety checks confirm exactly two production
+launch-options readers, and tmux fixtures retain the same safe default.
+
+- [ ] **Step 8: Commit controller and production wiring**
+
+```bash
+git add src/aiSessions/types.ts src/aiSessions/providers.ts src/aiSessions/creationController.ts src/aiSessions/resumeController.ts src/dashboard.ts tests/contract/aiSessions/sessionControllers.test.js scripts/run-ai-session-safety-checks.js scripts/run-ai-session-tmux-checks.js
+git diff --cached --check
+git commit -m "feat: apply yolo mode to AI session launches"
+```
+
+### Task 4: Full Regression Verification
+
+**Files:**
+- Verify only; no source file should change.
+
+**Interfaces:**
+- Consumes: the three implementation commits from Tasks 1–3.
+- Produces: evidence that deterministic, safety, Windows, lint, architecture, and packaging checks still pass.
+
+- [ ] **Step 1: Run deterministic tests**
+
+```bash
+npm run test:deterministic
+```
+
+Expected: unit, contract, and integration suites pass.
+
+- [ ] **Step 2: Run AI runtime and workspace safety checks**
+
+```bash
+npm run test:safety
+```
+
+Expected: workspace parity, AI session tmux, AI session safety, and open-project
+safety checks pass.
+
+- [ ] **Step 3: Run Windows command-builder coverage**
+
+```bash
+npm run test:ci:windows
+```
+
+Expected: Windows project and AI session command tests pass.
+
+- [ ] **Step 4: Run static quality and production build checks**
+
+```bash
+npm run lint:ci
+npm run test:architecture-guards
+npm run vscode:prepublish
+```
+
+Expected: lint baseline, architecture guards, webpack, and production asset
+generation pass.
+
+- [ ] **Step 5: Inspect the final branch**
+
+```bash
+git diff --check origin/main...HEAD
+git status -sb
+git log --oneline --decorate origin/main..HEAD
+```
+
+Expected: no whitespace errors; the worktree is clean; the branch contains the
+design commit, plan commit, and three focused implementation commits only.

--- a/docs/superpowers/specs/2026-07-25-ai-session-yolo-mode-design.md
+++ b/docs/superpowers/specs/2026-07-25-ai-session-yolo-mode-design.md
@@ -1,0 +1,144 @@
+# AI Session YOLO Mode Design
+
+## Goal
+
+Let users configure whether Project Steward starts AI sessions in each
+provider's approval-bypassing mode. The setting applies consistently when
+creating a new session or resuming an inactive historical session.
+
+## Configuration
+
+Add the machine-scoped boolean setting
+`projectSteward.aiSessionYoloMode`.
+
+- The default is `false`.
+- Only the literal boolean value `true` enables YOLO mode. A missing or invalid
+  value falls back to the safe, provider-default launch behavior.
+- The setting is read for every new process launch, so changing it affects the
+  next New or Resume action without reloading VS Code.
+- The setting is machine-scoped to match the existing AI runtime settings and
+  to prevent Settings Sync from unintentionally enabling approval bypass on
+  another execution host.
+
+The setting description and README must make clear that YOLO mode bypasses
+provider safety checks and affects only runtimes started after the change.
+
+## Launch Behavior
+
+New and resumed sessions use one explicit launch-options value:
+
+```ts
+interface AiSessionLaunchOptions {
+    yolo: boolean;
+}
+```
+
+The creation and resume controllers obtain the current options immediately
+before building the provider launch specification. Each provider builder owns
+the translation from the provider-neutral option to its CLI argument:
+
+| Provider | YOLO argument |
+| --- | --- |
+| Codex | `--dangerously-bypass-approvals-and-sandbox` |
+| Kimi | `--yolo` |
+| Claude | `--dangerously-skip-permissions` |
+
+When `yolo` is false, builders produce the same arguments they produce today.
+When it is true, they add the provider argument in a position accepted by both
+new-session and resume forms.
+
+The launch specification remains the common boundary for Direct Terminal and
+tmux execution. Both runtime backends therefore receive identical provider
+semantics without backend-specific YOLO logic.
+
+## Existing Runtime Semantics
+
+The setting is a process-launch preference, not persistent session metadata.
+Project Steward does not store the selected mode on pending or established
+session records.
+
+If New or Resume resolves to an already live runtime, existing focus and attach
+behavior wins. Project Steward does not restart, migrate, or mutate that
+runtime, regardless of the current setting. Closing it and resuming the
+historical session starts a new process using the setting value at that time.
+
+Changing the setting does not trigger dashboard refresh, runtime discovery, or
+process restart.
+
+## Component Boundaries
+
+### Extension manifest and documentation
+
+`package.json` declares the boolean, default, machine scope, and explicit
+warning text. The README configuration reference describes the option and its
+new-launch-only behavior.
+
+### Controllers
+
+`AiSessionCreationController` and `AiSessionResumeController` receive an
+injected launch-options reader. They snapshot its result once for each actual
+launch and pass it to the selected provider builder.
+
+The reader is not called for an action that is cancelled during root, provider,
+title, or preflight selection. Existing-runtime focus or attach paths do not
+need the option because they do not launch a provider process.
+
+### Provider definitions and command builders
+
+Provider New and Resume builder signatures accept the explicit launch options.
+Provider definitions forward the value without reading VS Code configuration.
+Command builders remain pure and own provider-specific argument construction.
+
+This avoids hidden configuration dependencies and prevents the generic runtime
+backends from acquiring provider-specific branching.
+
+## Error Handling and Safety
+
+- Missing or malformed configuration is treated as `false`.
+- Existing workspace trust, provider availability, directory capability, and
+  runtime-conflict checks remain unchanged and run before process creation.
+- YOLO mode does not weaken Project Steward's own launch validation, command
+  serialization, tmux metadata checks, or workspace-scope enforcement.
+- Provider rejection of an unsupported argument follows the existing failed
+  launch behavior; Project Steward does not silently retry without YOLO because
+  that would violate the configured launch intent.
+- No additional prompt is shown when YOLO mode is enabled. The manifest and
+  README carry the persistent warning.
+
+## Testing
+
+Automated checks cover:
+
+- manifest type, `false` default, machine scope, and warning text;
+- safe fallback for missing, false, and malformed configuration values;
+- New and Resume launch specifications for Codex, Kimi, and Claude with YOLO
+  disabled and enabled;
+- unchanged non-YOLO argument order and exact provider-specific YOLO arguments;
+- creation and resume controller propagation of the current launch options;
+- Direct Terminal, tmux, POSIX, PowerShell, and Windows current-shell
+  serialization regressions;
+- no restart or mode mutation when an existing runtime is focused or attached;
+- existing workspace scope, provider contract, runtime safety, and compilation
+  checks.
+
+## Non-goals
+
+- A per-launch mode picker.
+- Remembering mode per provider, project, session, or workspace.
+- Displaying YOLO mode on session rows or runtime badges.
+- Changing a live runtime's approval or sandbox policy.
+- Adding intermediate permission presets beyond provider default and YOLO.
+
+## Acceptance Criteria
+
+- `projectSteward.aiSessionYoloMode` exists as a machine-scoped boolean and
+  defaults to `false`.
+- With the setting disabled, all New and Resume commands retain their existing
+  behavior.
+- With the setting enabled, newly created and newly resumed Codex, Kimi, and
+  Claude processes receive the correct provider YOLO argument in Direct
+  Terminal and tmux modes.
+- Toggling the setting affects the next process launch without a VS Code reload
+  and does not alter already live runtimes.
+- The main checkout and its existing user changes remain untouched; all work
+  occurs on `feat/ai-session-yolo-mode` in the isolated worktree.

--- a/docs/superpowers/specs/2026-07-25-ai-session-yolo-mode-design.md
+++ b/docs/superpowers/specs/2026-07-25-ai-session-yolo-mode-design.md
@@ -14,8 +14,11 @@ Add the machine-scoped boolean setting
 - The default is `false`.
 - Only the literal boolean value `true` enables YOLO mode. A missing or invalid
   value falls back to the safe, provider-default launch behavior.
-- The setting is read for every new process launch, so changing it affects the
-  next New or Resume action without reloading VS Code.
+- The setting is read directly from the `projectSteward` configuration
+  namespace for every provider process dispatch. It never passes through the
+  legacy `dashboard.*` compatibility fallback.
+- Changing the setting affects every process launched after the change while
+  it remains enabled, without reloading VS Code.
 - The setting is machine-scoped to match the existing AI runtime settings and
   to prevent Settings Sync from unintentionally enabling approval bypass on
   another execution host.
@@ -33,9 +36,11 @@ interface AiSessionLaunchOptions {
 }
 ```
 
-The creation and resume controllers obtain the current options immediately
-before building the provider launch specification. Each provider builder owns
-the translation from the provider-neutral option to its CLI argument:
+The creation and resume controllers capture a single-use launch-spec factory,
+not a concrete launch specification. The factory reads the current options and
+calls the provider builder only at the runtime backend's final provider
+dispatch boundary. Each provider builder owns the translation from the
+provider-neutral option to its CLI argument:
 
 | Provider | YOLO argument |
 | --- | --- |
@@ -50,6 +55,13 @@ new-session and resume forms.
 The launch specification remains the common boundary for Direct Terminal and
 tmux execution. Both runtime backends therefore receive identical provider
 semantics without backend-specific YOLO logic.
+
+The runtime coordinator snapshots identity, directory scope, marker path, and
+the factory without evaluating it. Focused, blocked, conflict, cancelled, and
+settings results therefore perform zero configuration reads and zero provider
+builder calls. A direct or tmux dispatch evaluates the factory exactly once.
+This also means a setting changed while a tmux fallback prompt is open is the
+value used by the eventual accepted direct launch.
 
 ## Existing Runtime Semantics
 
@@ -76,12 +88,23 @@ new-launch-only behavior.
 ### Controllers
 
 `AiSessionCreationController` and `AiSessionResumeController` receive an
-injected launch-options reader. They snapshot its result once for each actual
-launch and pass it to the selected provider builder.
+injected launch-options reader. They capture a defensive directory-scope
+snapshot and a single-use factory that will read the option and call the
+selected provider builder.
 
-The reader is not called for an action that is cancelled during root, provider,
-title, or preflight selection. Existing-runtime focus or attach paths do not
-need the option because they do not launch a provider process.
+The coordinator and both runtime backends carry that factory without invoking
+it through selection, refresh, lifecycle, duplicate, conflict, availability,
+fallback, lock, and tmux target-collision checks. Direct Terminal invokes it
+immediately before sending the provider launch. tmux invokes it after its final
+target-occupancy check and immediately before `create-session` or
+`create-window`.
+
+For pending tmux ambiguity recovery, the durable request fingerprint is
+versioned and deliberately excludes process launch options. YOLO is a launch
+preference, not pending-runtime identity. New records use the stable `v3`
+fingerprint; recovery still accepts legacy fingerprints after all non-launch
+identity, request, marker, and locator fields match, without rebuilding or
+redispatching the provider command.
 
 ### Provider definitions and command builders
 
@@ -95,6 +118,9 @@ backends from acquiring provider-specific branching.
 ## Error Handling and Safety
 
 - Missing or malformed configuration is treated as `false`.
+- The final provider-argument boundary also requires
+  `options?.yolo === true`; truthy malformed values such as `"true"` cannot add
+  a bypass flag.
 - Existing workspace trust, provider availability, directory capability, and
   runtime-conflict checks remain unchanged and run before process creation.
 - YOLO mode does not weaken Project Steward's own launch validation, command
@@ -111,10 +137,17 @@ Automated checks cover:
 
 - manifest type, `false` default, machine scope, and warning text;
 - safe fallback for missing, false, and malformed configuration values;
+- direct `projectSteward` namespace reads and proof that legacy
+  `dashboard.*` values cannot enable YOLO;
 - New and Resume launch specifications for Codex, Kimi, and Claude with YOLO
   disabled and enabled;
 - unchanged non-YOLO argument order and exact provider-specific YOLO arguments;
-- creation and resume controller propagation of the current launch options;
+- zero option reads and builder calls on every no-dispatch controller and
+  coordinator result, and exactly one of each on direct and tmux dispatch;
+- setting changes made while a tmux fallback choice is pending;
+- launch-option-independent pending ambiguity fingerprints plus legacy
+  recovery compatibility;
+- malformed truthy values rejected at the final flag boundary;
 - Direct Terminal, tmux, POSIX, PowerShell, and Windows current-shell
   serialization regressions;
 - no restart or mode mutation when an existing runtime is focused or attached;
@@ -140,5 +173,8 @@ Automated checks cover:
   Terminal and tmux modes.
 - Toggling the setting affects the next process launch without a VS Code reload
   and does not alter already live runtimes.
+- Focus, block, conflict, cancel, settings, duplicate, unavailable, and target
+  collision paths do not read launch configuration or build a provider launch
+  specification.
 - The main checkout and its existing user changes remain untouched; all work
   occurs on `feat/ai-session-yolo-mode` in the isolated worktree.

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "d80ae0dbd5bdc362216c9f5614b887f6a43b8373",
+        "head": "bfc9591242d7a1aaeef0287ffbe30af1cbb35beb",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -518,7 +518,7 @@
         {
             "id": "MAIN-RUNTIME-SESSION-RECOVERY",
             "title": "Runtime session recovery and activation",
-            "requirement": "Direct, tmux, pending, aliased, and resumed AI sessions preserve identity and can be activated from their cards.",
+            "requirement": "Direct, tmux, pending, aliased, and resumed AI sessions preserve identity, apply configured launch policy, and can be activated from their cards.",
             "commits": [
                 "4e69826dd7f4da3776e0b550e5cfe802af39e108",
                 "d5b2cd4449555bc67eff6d5074372f2de3fa0ba4",
@@ -588,7 +588,11 @@
                 "b61e031d86fb859ae7e2a7d0176dbae5a253b01e",
                 "90302c5c0a9e8794174955368d72307c2303abd1",
                 "883616d8f0cd5edad7eca71553afedcbee560604",
-                "d80ae0dbd5bdc362216c9f5614b887f6a43b8373"
+                "d80ae0dbd5bdc362216c9f5614b887f6a43b8373",
+                "a7201b8107f6b9f42862a77f8264f8ee5b361192",
+                "b8e0f8039c4927fc2783951e9d5759ab73b0494d",
+                "37aa1c0a06466d3ae7be3e66af50c1dc71f19508",
+                "bfc9591242d7a1aaeef0287ffbe30af1cbb35beb"
             ],
             "behaviors": [
                 "RUNTIME-TMUX-BACKEND-001",
@@ -596,13 +600,18 @@
                 "RUNTIME-TMUX-DISCOVERY-001",
                 "SESSION-AI-SESSION-TERMINAL-COMMAND-CONTROLLER-001",
                 "SESSION-ALIAS-THREAD-SWITCH-001",
+                "SESSION-COMMAND-BUILDER-001",
+                "SESSION-AI-SESSION-CREATION-CONTROLLER-001",
+                "SESSION-AI-SESSION-RESUME-CONTROLLER-001",
+                "RUNTIME-AI-SESSION-RUNTIME-CONTROLLER-001",
                 "WEBVIEW-AI-SESSION-CARD-ACTIVATION-001",
                 "ACTIVE-SESSION-ICON-ANIMATION-001",
                 "WEBVIEW-MULTI-PROVIDER-SESSION-HISTORY-001",
                 "PERSIST-MULTI-PROVIDER-BATCH-ARCHIVE-001"
             ],
             "prGates": [
-                "test:ci:linux"
+                "test:ci:linux",
+                "test:ci:windows"
             ],
             "scheduledJobs": [
                 "tmux-smoke-linux"

--- a/package.json
+++ b/package.json
@@ -141,6 +141,12 @@
                     "scope": "machine",
                     "description": "Choose whether new AI sessions run in VS Code terminals or managed tmux sessions. tmux preserves a process only while its execution host remains awake and running."
                 },
+                "projectSteward.aiSessionYoloMode": {
+                    "type": "boolean",
+                    "default": false,
+                    "scope": "machine",
+                    "description": "Bypass provider approval and sandbox protections for newly created and resumed AI session processes. This is dangerous and does not change already running sessions."
+                },
                 "projectSteward.aiSessionTmuxLayout": {
                     "type": "string",
                     "enum": [

--- a/scripts/run-ai-session-safety-checks.js
+++ b/scripts/run-ai-session-safety-checks.js
@@ -2219,6 +2219,7 @@ async function runWorkspaceCreationDirectoryFirstChecks() {
         runtimeCoordinator: {
             create: async request => {
                 requests.push(request);
+                request.launch = request.createLaunchSpec();
                 return { status: 'started', runtime: {} };
             },
             getActive: () => [],
@@ -2317,6 +2318,7 @@ async function runWorkspaceScopeControllerLaunchChecks() {
             nowMs: () => Date.parse('2026-07-20T10:00:00.000Z'),
             runtimeCoordinator: {
                 create: async request => {
+                    request.launch = request.createLaunchSpec();
                     createRequests.push(request);
                     return { status: 'started', runtime: {} };
                 },
@@ -2325,8 +2327,10 @@ async function runWorkspaceScopeControllerLaunchChecks() {
             },
         });
         await creation.createSession(workspaceTarget.cardId);
-        assert.strictEqual(createScopes[0], scope,
-            `${providerId} creation must pass the injected complete scope unchanged to its builder`);
+        assert.deepStrictEqual(createScopes[0], scope,
+            `${providerId} creation must pass the complete scope snapshot to its builder`);
+        assert.notStrictEqual(createScopes[0], scope,
+            `${providerId} creation must defensively snapshot the builder scope`);
         assert.deepStrictEqual(createRequests[0].launch, {
             executable: providerId,
             args: ['create', providerId],
@@ -2375,14 +2379,17 @@ async function runWorkspaceScopeControllerLaunchChecks() {
             showActiveTab: async () => undefined,
             runtimeCoordinator: {
                 resume: async request => {
+                    request.launch = request.createLaunchSpec();
                     resumeRequests.push(request);
                     return { status: 'started', runtime: {} };
                 },
             },
         });
         await resume.resumeProjectSession(workspaceTarget.cardId, providerId, session.id);
-        assert.strictEqual(resumeScopes[0], scope,
-            `${providerId} resume must pass the injected complete scope unchanged to its builder`);
+        assert.deepStrictEqual(resumeScopes[0], scope,
+            `${providerId} resume must pass the complete scope snapshot to its builder`);
+        assert.notStrictEqual(resumeScopes[0], scope,
+            `${providerId} resume must defensively snapshot the builder scope`);
         assert.deepStrictEqual(resumeRequests[0].launch, {
             executable: providerId,
             args: ['resume', session.id],
@@ -2513,6 +2520,9 @@ async function runWorkspaceLaunchPreflightControllerChecks() {
                     createError = null;
                     throw error;
                 }
+                if (createResult.status === 'started') {
+                    request.launch = request.createLaunchSpec();
+                }
                 return createResult;
             },
             getActive: () => [],
@@ -2537,7 +2547,8 @@ async function runWorkspaceLaunchPreflightControllerChecks() {
     await creation.createSession(workspaceTarget.cardId);
     assert.deepStrictEqual(createRequests[0].directoryScope, activeEditorScope);
     assert.strictEqual(createRequests[0].identity.cwd, activeEditorScope.primaryCwd);
-    assert.strictEqual(createScopes[0], createRequests[0].directoryScope);
+    assert.deepStrictEqual(createScopes[0], createRequests[0].directoryScope);
+    assert.notStrictEqual(createScopes[0], createRequests[0].directoryScope);
     assert.deepStrictEqual(primaryRootWrites, [[workspace.scopeIdentity, activeEditorScope.primaryRootId]]);
 
     creationRootId = 'root-web';
@@ -2592,6 +2603,9 @@ async function runWorkspaceLaunchPreflightControllerChecks() {
                     resumeError = null;
                     throw error;
                 }
+                if (resumeResult.status === 'started') {
+                    request.launch = request.createLaunchSpec();
+                }
                 return resumeResult;
             },
         },
@@ -2622,7 +2636,8 @@ async function runWorkspaceLaunchPreflightControllerChecks() {
     assert.strictEqual(resumeRequests[0].launch.cwd, '/work/api/packages/service',
         'the provider launch spec must consume the same exact historical cwd');
     assert.strictEqual(resumeRequests[0].identity.cwd, resumeRequests[0].directoryScope.primaryCwd);
-    assert.strictEqual(resumeScopes[0], resumeRequests[0].directoryScope);
+    assert.deepStrictEqual(resumeScopes[0], resumeRequests[0].directoryScope);
+    assert.notStrictEqual(resumeScopes[0], resumeRequests[0].directoryScope);
     assert.deepStrictEqual(primaryRootWrites[2], [workspace.scopeIdentity, 'root-api']);
 
     session.cwd = '/historical/outside-workspace';
@@ -3595,7 +3610,11 @@ async function runWorkspaceCardActionControllerIntegrationChecks() {
         resolveDirectoryScope: () => { throw new Error('must not resolve a root Project'); },
         resolveWorkspaceDirectoryScope: (resolved, providerId, rootId) =>
             commandController.resolveWorkspaceDirectoryScope(resolved.workspace, providerId, undefined, rootId),
-        runtimeCoordinator: { create: async request => { createRequests.push(request); return { status: 'started', runtime: {} }; },
+        runtimeCoordinator: { create: async request => {
+            request.launch = request.createLaunchSpec();
+            createRequests.push(request);
+            return { status: 'started', runtime: {} };
+        },
             getActive: () => [], getPending: () => [] },
         createPendingId: () => 'pending-workspace-card',
         showInputBox: async () => 'Investigate replication',
@@ -3620,7 +3639,11 @@ async function runWorkspaceCardActionControllerIntegrationChecks() {
         resolveDirectoryScope: () => { throw new Error('must not resolve a root Project'); },
         resolveWorkspaceDirectoryScope: (resolved, resolvedSession, providerId, rootId) =>
             commandController.resolveWorkspaceDirectoryScope(resolved.workspace, providerId, resolvedSession, rootId),
-        runtimeCoordinator: { resume: async request => { resumeRequests.push(request); return { status: 'started', runtime: {} }; } },
+        runtimeCoordinator: { resume: async request => {
+            request.launch = request.createLaunchSpec();
+            resumeRequests.push(request);
+            return { status: 'started', runtime: {} };
+        } },
         getTerminalName: () => 'Codex: Card Session', getMarkerPath: () => '/tmp/card.marker',
         showWarningMessage: () => undefined, refresh: () => undefined,
         showActiveTab: async () => undefined, announceStatus: async () => undefined,
@@ -5174,8 +5197,11 @@ function runWebviewContentChecks() {
         2
     );
     assert.ok(dashboard.includes(
-        'readAiSessionLaunchOptions(getStewardConfiguration())'
+        'readAiSessionLaunchOptions(vscode.workspace)'
     ));
+    assert.ok(!dashboard.includes(
+        'readAiSessionLaunchOptions(getStewardConfiguration())'
+    ), 'YOLO configuration must not pass through the legacy dashboard fallback');
     assert.ok(dashboard.includes('new AiSessionPinController({'));
     assert.ok(dashboard.includes('aiSessionPinController.getAll()'));
     assert.ok(dashboard.includes('aiSessionPinController.toggle('));

--- a/scripts/run-ai-session-safety-checks.js
+++ b/scripts/run-ai-session-safety-checks.js
@@ -2194,6 +2194,7 @@ async function runWorkspaceCreationDirectoryFirstChecks() {
             return 'codex';
         },
         getProviderLabel: () => 'Codex',
+        getLaunchOptions: () => ({ yolo: false }),
         getProvider: () => ({
             label: 'Codex',
             terminalNamePrefix: 'Codex',
@@ -2291,6 +2292,7 @@ async function runWorkspaceScopeControllerLaunchChecks() {
             pickWorkspaceRoot: async () => undefined,
             pickProvider: async () => providerId,
             getProviderLabel: () => providerId,
+            getLaunchOptions: () => ({ yolo: false }),
             getProvider: () => ({
                 label: providerId,
                 terminalNamePrefix: providerId,
@@ -2350,6 +2352,7 @@ async function runWorkspaceScopeControllerLaunchChecks() {
         });
         const resume = new AiSessionResumeController({
             getWorkspaceTarget: cardId => cardId === workspaceTarget.cardId ? workspaceTarget : null,
+            getLaunchOptions: () => ({ yolo: false }),
             getProvider: () => ({
                 label: providerId,
                 terminalEnvKey: `${providerId}_SESSION_ID`,
@@ -2486,6 +2489,7 @@ async function runWorkspaceLaunchPreflightControllerChecks() {
         pickWorkspaceRoot: async () => creationRootId,
         pickProvider: async () => 'codex',
         getProviderLabel: () => 'Codex',
+        getLaunchOptions: () => ({ yolo: false }),
         getProvider: () => ({
             label: 'Codex',
             terminalNamePrefix: 'Codex',
@@ -2564,6 +2568,7 @@ async function runWorkspaceLaunchPreflightControllerChecks() {
     let resumeError = null;
     const resume = new AiSessionResumeController({
         getWorkspaceTarget: cardId => cardId === workspaceTarget.cardId ? workspaceTarget : null,
+        getLaunchOptions: () => ({ yolo: false }),
         getProvider: () => providerPresent ? ({
             label: 'Codex',
             terminalEnvKey: 'CODEX_SESSION_ID',
@@ -3584,6 +3589,7 @@ async function runWorkspaceCardActionControllerIntegrationChecks() {
         getWorkspaceTarget: cardId => cardId === target.cardId ? target : null,
         pickWorkspaceRoot: async () => 'root-web',
         pickProvider: async () => 'codex', getProviderLabel: () => 'Codex',
+        getLaunchOptions: () => ({ yolo: false }),
         getProvider: () => ({ label: 'Codex', terminalNamePrefix: 'Codex',
             buildNewSessionLaunchSpec: scope => ({ executable: 'codex', args: [], cwd: scope.primaryCwd }) }),
         resolveDirectoryScope: () => { throw new Error('must not resolve a root Project'); },
@@ -3607,6 +3613,7 @@ async function runWorkspaceCardActionControllerIntegrationChecks() {
     const resume = new AiSessionResumeController({
         getOpenProjects: () => { legacyProjectReads++; return []; },
         getWorkspaceTarget: cardId => cardId === target.cardId ? target : null,
+        getLaunchOptions: () => ({ yolo: false }),
         getProvider: () => ({ label: 'Codex', terminalEnvKey: 'CODEX_SESSION_ID',
             buildResumeLaunchSpec: (_id, scope) => ({ executable: 'codex', args: [], cwd: scope.primaryCwd }) }),
         getProjectSession: () => { throw new Error('must not select a root Project session'); },
@@ -5159,6 +5166,16 @@ function runWebviewContentChecks() {
     assert.ok(dashboard.includes('const aiSessionCommandController = new AiSessionCommandController({'));
     assert.ok(dashboard.includes('const aiSessionCreationController = new AiSessionCreationController({'));
     assert.ok(dashboard.includes('const aiSessionResumeController = new AiSessionResumeController<vscode.Terminal>({'));
+    assert.ok(dashboard.includes(
+        "import { readAiSessionLaunchOptions } from './aiSessions/launchOptions';"
+    ));
+    assert.strictEqual(
+        (dashboard.match(/getLaunchOptions: \(\) =>/g) || []).length,
+        2
+    );
+    assert.ok(dashboard.includes(
+        'readAiSessionLaunchOptions(getStewardConfiguration())'
+    ));
     assert.ok(dashboard.includes('new AiSessionPinController({'));
     assert.ok(dashboard.includes('aiSessionPinController.getAll()'));
     assert.ok(dashboard.includes('aiSessionPinController.toggle('));

--- a/scripts/run-ai-session-tmux-checks.js
+++ b/scripts/run-ai-session-tmux-checks.js
@@ -47,6 +47,26 @@ function config(values) {
     return { get: (key, fallback) => Object.prototype.hasOwnProperty.call(values, key) ? values[key] : fallback };
 }
 
+function legacyPendingRequestFingerprint(request, launch) {
+    return crypto.createHash('sha256').update(JSON.stringify([
+        2,
+        request.identity.provider,
+        request.identity.workspaceScopeIdentity,
+        request.identity.workspaceNavigationIdentity,
+        request.identity.workspaceRootHostPaths.slice().sort(),
+        request.identity.pendingId,
+        request.identity.cwd,
+        request.createdAt,
+        request.excludedSessionIds,
+        request.title ?? null,
+        launch.executable,
+        launch.args,
+        launch.cwd ?? null,
+        launch.markerPath ?? null,
+        launch.windowsDirectShell ?? null,
+    ]), 'utf8').digest('hex');
+}
+
 function decodePowerShellPayload(command) {
     const prefix = 'powershell -NoProfile -ExecutionPolicy Bypass -EncodedCommand ';
     assert.ok(command.startsWith(prefix));
@@ -3576,6 +3596,17 @@ async function runTmuxStoreChecks() {
         await store.setAmbiguous(pendingAmbiguousRecord);
         assert.deepStrictEqual(await restartedStore.getAmbiguous(pendingIdentity(pendingAmbiguousRecord)),
             pendingAmbiguousRecord);
+        const stablePendingAmbiguousRecord = {
+            ...pendingAmbiguousRecord,
+            pendingId: 'stable-ambiguous-fingerprint',
+            requestFingerprint: `v3:${'c'.repeat(64)}`,
+        };
+        await store.setAmbiguous(stablePendingAmbiguousRecord);
+        assert.deepStrictEqual(await restartedStore.getAmbiguous(
+            pendingIdentity(stablePendingAmbiguousRecord)
+        ), stablePendingAmbiguousRecord,
+        'stable launch-option-independent ambiguity fingerprints must persist');
+        await store.removeAmbiguous(pendingIdentity(stablePendingAmbiguousRecord));
         await assert.rejects(store.setAmbiguous({
             ...pendingAmbiguousRecord, pendingId: 'oversized-project-name',
             projectName: 'p'.repeat(201),
@@ -5932,6 +5963,114 @@ async function runTmuxBackendChecks() {
     assert.strictEqual(pendingRecoveryHarness.ambiguous.size, 0);
     assert.strictEqual(pendingRecoveryHarness.operations.filter(item => item.type === 'new-session').length, 1);
 
+    const stableFingerprints = [];
+    for (const [suffix, args] of [
+        ['safe', ['new']],
+        ['yolo', ['--yolo', 'new']],
+    ]) {
+        const stableHarness = createTmuxBackendHarness({ failSetPendingCount: 1 });
+        let builds = 0;
+        const stableRequest = {
+            identity: {
+                provider: 'kimi',
+                workspaceScopeIdentity: 'stable-pending-fingerprint',
+                workspaceNavigationIdentity: 'nav-stable-pending-fingerprint',
+                workspaceRootHostPaths: ['/work'],
+                cwd: '/work',
+                pendingId: 'stable-pending-fingerprint-id',
+            },
+            projectName: 'Stable',
+            terminalName: `Kimi: Stable ${suffix}`,
+            createdAt: '2026-07-18T09:59:00Z',
+            excludedSessionIds: ['old'],
+            title: 'Stable launch intent',
+            launchMarkerPath: '/tmp/stable-pending-fingerprint',
+            createLaunchSpec: () => {
+                builds += 1;
+                return {
+                    executable: 'kimi',
+                    args: [...args],
+                    markerPath: '/tmp/stable-pending-fingerprint',
+                };
+            },
+        };
+        await assert.rejects(
+            new backendModule.TmuxRuntimeBackend(stableHarness.dependencies)
+                .ensurePending(stableRequest, 'session'),
+            /pending persistence failed/
+        );
+        assert.strictEqual(builds, 1);
+        const ambiguous = Array.from(stableHarness.ambiguous.values())[0];
+        assert.match(ambiguous.requestFingerprint, /^v3:[a-f0-9]{64}$/);
+        stableFingerprints.push(ambiguous.requestFingerprint);
+    }
+    assert.strictEqual(
+        stableFingerprints[0],
+        stableFingerprints[1],
+        'pending recovery identity must not depend on process-launch YOLO options'
+    );
+
+    const legacyRecoveryHarness = createTmuxBackendHarness({ failSetPendingCount: 1 });
+    const legacyLaunch = {
+        executable: 'kimi',
+        args: ['new'],
+        markerPath: '/tmp/legacy-pending-fingerprint',
+    };
+    let initialLegacyBuilds = 0;
+    const legacyRecoveryRequest = {
+        identity: {
+            provider: 'kimi',
+            workspaceScopeIdentity: 'legacy-pending-fingerprint',
+            workspaceNavigationIdentity: 'nav-legacy-pending-fingerprint',
+            workspaceRootHostPaths: ['/work'],
+            cwd: '/work',
+            pendingId: 'legacy-pending-fingerprint-id',
+        },
+        projectName: 'Legacy',
+        terminalName: 'Kimi: Legacy',
+        createdAt: '2026-07-18T09:59:00Z',
+        excludedSessionIds: ['old'],
+        title: 'Legacy launch intent',
+        launchMarkerPath: legacyLaunch.markerPath,
+        createLaunchSpec: () => {
+            initialLegacyBuilds += 1;
+            return { ...legacyLaunch, args: [...legacyLaunch.args] };
+        },
+    };
+    await assert.rejects(
+        new backendModule.TmuxRuntimeBackend(legacyRecoveryHarness.dependencies)
+            .ensurePending(legacyRecoveryRequest, 'session'),
+        /pending persistence failed/
+    );
+    assert.strictEqual(initialLegacyBuilds, 1);
+    const legacyAmbiguous = Array.from(legacyRecoveryHarness.ambiguous.values())[0];
+    legacyAmbiguous.requestFingerprint = legacyPendingRequestFingerprint(
+        legacyRecoveryRequest, legacyLaunch
+    );
+    let legacyRecoveryBuilds = 0;
+    const legacyRecovered = await new backendModule.TmuxRuntimeBackend(
+        legacyRecoveryHarness.dependencies
+    ).ensurePending({
+        ...legacyRecoveryRequest,
+        createLaunchSpec: () => {
+            legacyRecoveryBuilds += 1;
+            return {
+                ...legacyLaunch,
+                args: ['--yolo', ...legacyLaunch.args],
+            };
+        },
+    }, 'session');
+    assert.strictEqual(legacyRecovered.identity.pendingId, 'legacy-pending-fingerprint-id');
+    assert.strictEqual(
+        legacyRecoveryBuilds, 0,
+        'legacy ambiguity recovery must not read current process-launch options'
+    );
+    assert.strictEqual(
+        legacyRecoveryHarness.operations.filter(item => item.type === 'new-session').length,
+        1,
+        'legacy ambiguity recovery must not redispatch the provider command'
+    );
+
     const projectPromotionHarness = createTmuxBackendHarness();
     const projectPromotionBackend = new backendModule.TmuxRuntimeBackend(projectPromotionHarness.dependencies);
     const projectPending = await projectPromotionBackend.ensurePending({
@@ -7270,7 +7409,8 @@ function createFakeRuntimeBackend(backend, options = {}) {
     fake.detach = async runtime => { fake.detachCalls.push(runtime); };
     fake.ensureResume = async (request, layout) => {
         fake.ensureResumeCalls++;
-        fake.ensureResumeRequests.push(request);
+        const capturedRequest = { ...request };
+        fake.ensureResumeRequests.push(capturedRequest);
         fake.ensureResumeLayouts.push(layout);
         if (options.resumeGate) await options.resumeGate.promise;
         if (remainingEnsureErrors > 0) {
@@ -7278,6 +7418,10 @@ function createFakeRuntimeBackend(backend, options = {}) {
             throw options.ensureError || new Error('ensure failed');
         }
         if (options.ensureError && options.ensureErrorCount === undefined) throw options.ensureError;
+        const launch = typeof request.createLaunchSpec === 'function'
+            ? request.createLaunchSpec()
+            : request.launch;
+        capturedRequest.launch = { ...launch, args: [...launch.args] };
         const runtime = fakeRuntime(backend, request.identity.sessionId,
             backend === 'tmux' ? { tmux: { layout, sessionName: 'managed' } } : {});
         fake.active.push(runtime);
@@ -7291,6 +7435,9 @@ function createFakeRuntimeBackend(backend, options = {}) {
             throw options.ensureError || new Error('ensure failed');
         }
         if (options.ensureError && options.ensureErrorCount === undefined) throw options.ensureError;
+        if (typeof request.createLaunchSpec === 'function') {
+            request.createLaunchSpec();
+        }
         const runtime = {
             ...fakeRuntime(backend, undefined),
             identity: { ...request.identity },
@@ -9160,11 +9307,12 @@ async function runRuntimeControllerChecks() {
         runtimeCoordinator: {
             create: async request => {
                 createRequests.push(request);
+                const launch = request.createLaunchSpec();
                 return {
                     status: 'started',
                     runtime: {
                         identity: { ...request.identity }, backend: 'tmux', state: 'pending',
-                        markerPath: request.launch.markerPath, runStartedAtMs: Date.parse(request.createdAt),
+                        markerPath: launch.markerPath, runStartedAtMs: Date.parse(request.createdAt),
                         attached: false, createdAt: request.createdAt,
                         excludedSessionIds: [...request.excludedSessionIds], title: request.title,
                     },
@@ -9404,9 +9552,10 @@ async function runRuntimeControllerChecks() {
         nowMs: () => Date.parse(createdAt),
         runtimeCoordinator: {
             create: async request => {
+                const launch = request.createLaunchSpec();
                 retainedPending = {
                     identity: { ...request.identity }, backend: 'tmux', state: 'pending',
-                    markerPath: request.launch.markerPath, runStartedAtMs: Date.parse(request.createdAt),
+                    markerPath: launch.markerPath, runStartedAtMs: Date.parse(request.createdAt),
                     attached: false, createdAt: request.createdAt, excludedSessionIds: [],
                     tmux: { layout: 'session', sessionName: 'pending-timeout' },
                 };

--- a/scripts/run-ai-session-tmux-checks.js
+++ b/scripts/run-ai-session-tmux-checks.js
@@ -7854,6 +7854,7 @@ async function runRuntimeCoordinatorChecks() {
         getWorkspaceTarget: cardId => cardId === scopedWorkspaceTarget.cardId
             ? scopedWorkspaceTarget
             : null,
+        getLaunchOptions: () => ({ yolo: false }),
         getProvider: () => ({
             label: 'Codex',
             terminalEnvKey: 'CODEX_SESSION_ID',
@@ -9133,6 +9134,7 @@ async function runRuntimeControllerChecks() {
         pickWorkspaceRoot: async () => undefined,
         pickProvider: async () => 'codex',
         getProviderLabel: () => 'Codex',
+        getLaunchOptions: () => ({ yolo: false }),
         getProvider: () => ({
             label: 'Codex', terminalNamePrefix: 'Codex',
             buildNewSessionLaunchSpec: (scope, title, markerPath) => ({
@@ -9182,6 +9184,7 @@ async function runRuntimeControllerChecks() {
     const resume = new ResumeController({
         getWorkspaceTarget: cardId => cardId === project.id
             ? createWorkspaceActionTarget(project, 'pk') : null,
+        getLaunchOptions: () => ({ yolo: false }),
         getProvider: () => ({
             label: 'Codex', terminalEnvKey: 'CODEX_SESSION_ID',
             buildResumeLaunchSpec: (sessionId, scope, markerPath) => ({
@@ -9222,6 +9225,7 @@ async function runRuntimeControllerChecks() {
     const collisionResume = new ResumeController({
         getWorkspaceTarget: cardId => cardId === project.id
             ? createWorkspaceActionTarget(project, 'pk') : null,
+        getLaunchOptions: () => ({ yolo: false }),
         getProvider: () => ({
             label: 'Codex', terminalEnvKey: 'CODEX_SESSION_ID',
             buildResumeLaunchSpec: (sessionId, scope, markerPath) => ({
@@ -9299,6 +9303,7 @@ async function runRuntimeControllerChecks() {
             ? createWorkspaceActionTarget(project, 'pk') : null,
         pickWorkspaceRoot: async () => undefined,
         pickProvider: async () => 'codex', getProviderLabel: () => 'Codex',
+        getLaunchOptions: () => ({ yolo: false }),
         getProvider: () => ({
             label: 'Codex', terminalNamePrefix: 'Codex',
             buildNewSessionLaunchSpec: (scope, title, markerPath) => ({
@@ -9339,6 +9344,7 @@ async function runRuntimeControllerChecks() {
                     id: 'rejected', name: 'Rejected', cwd: '/work', updatedAt: createdAt,
                 }),
             }, 'pk') : null,
+        getLaunchOptions: () => ({ yolo: false }),
         getProvider: () => ({
             label: 'Codex', terminalEnvKey: 'CODEX_SESSION_ID',
             buildResumeLaunchSpec: (sessionId, scope, markerPath) => ({
@@ -9374,6 +9380,7 @@ async function runRuntimeControllerChecks() {
             ? createWorkspaceActionTarget(project, 'pk') : null,
         pickWorkspaceRoot: async () => undefined,
         pickProvider: async () => 'codex', getProviderLabel: () => 'Codex',
+        getLaunchOptions: () => ({ yolo: false }),
         getProvider: () => ({
             label: 'Codex', terminalNamePrefix: 'Codex',
             buildNewSessionLaunchSpec: (scope, title, markerPath) => ({

--- a/src/aiSessions/commandBuilders.ts
+++ b/src/aiSessions/commandBuilders.ts
@@ -5,9 +5,16 @@ import {
     quotePosixShellArg,
     serializeDirectLaunchCommand,
 } from './launchSpec';
+import type { AiSessionLaunchOptions } from './launchOptions';
 import type { AiSessionDirectoryScope } from './types';
 
 export type AiSessionCommandPlatform = NodeJS.Platform;
+
+const SAFE_LAUNCH_OPTIONS: AiSessionLaunchOptions = Object.freeze({ yolo: false });
+
+function yoloArg(options: AiSessionLaunchOptions, argument: string): string[] {
+    return options.yolo ? [argument] : [];
+}
 
 function buildRepeatedAdditionalDirectoryArgs(scope: AiSessionDirectoryScope): string[] {
     return (scope?.additionalDirectories || []).reduce((args, directory) => [
@@ -22,11 +29,12 @@ function buildClaudeAdditionalDirectoryArgs(scope: AiSessionDirectoryScope): str
     return additionalDirectories.length ? ['--add-dir', ...additionalDirectories] : [];
 }
 
-export function buildCodexResumeLaunchSpec(sessionId: string, scope: AiSessionDirectoryScope, markerPath: string = null): AiSessionLaunchSpec {
+export function buildCodexResumeLaunchSpec(sessionId: string, scope: AiSessionDirectoryScope, markerPath: string = null, launchOptions: AiSessionLaunchOptions = SAFE_LAUNCH_OPTIONS): AiSessionLaunchSpec {
     return {
         executable: 'codex',
         args: [
             'resume',
+            ...yoloArg(launchOptions, '--dangerously-bypass-approvals-and-sandbox'),
             ...(scope?.primaryCwd ? ['--cd', scope.primaryCwd] : []),
             ...buildRepeatedAdditionalDirectoryArgs(scope),
             sessionId,
@@ -36,10 +44,11 @@ export function buildCodexResumeLaunchSpec(sessionId: string, scope: AiSessionDi
     };
 }
 
-export function buildCodexNewSessionLaunchSpec(scope: AiSessionDirectoryScope, prompt: string = null, markerPath: string = null): AiSessionLaunchSpec {
+export function buildCodexNewSessionLaunchSpec(scope: AiSessionDirectoryScope, prompt: string = null, markerPath: string = null, launchOptions: AiSessionLaunchOptions = SAFE_LAUNCH_OPTIONS): AiSessionLaunchSpec {
     return {
         executable: 'codex',
         args: [
+            ...yoloArg(launchOptions, '--dangerously-bypass-approvals-and-sandbox'),
             ...(scope?.primaryCwd ? ['--cd', scope.primaryCwd] : []),
             ...buildRepeatedAdditionalDirectoryArgs(scope),
             ...(prompt ? [prompt] : []),
@@ -49,12 +58,13 @@ export function buildCodexNewSessionLaunchSpec(scope: AiSessionDirectoryScope, p
     };
 }
 
-export function buildKimiResumeLaunchSpec(sessionId: string, scope: AiSessionDirectoryScope, markerPath: string = null): AiSessionLaunchSpec {
+export function buildKimiResumeLaunchSpec(sessionId: string, scope: AiSessionDirectoryScope, markerPath: string = null, launchOptions: AiSessionLaunchOptions = SAFE_LAUNCH_OPTIONS): AiSessionLaunchSpec {
     return {
         executable: 'kimi',
         args: [
             ...(scope?.primaryCwd ? ['--work-dir', scope.primaryCwd] : []),
             ...buildRepeatedAdditionalDirectoryArgs(scope),
+            ...yoloArg(launchOptions, '--yolo'),
             '--resume', sessionId,
         ],
         markerPath,
@@ -62,12 +72,13 @@ export function buildKimiResumeLaunchSpec(sessionId: string, scope: AiSessionDir
     };
 }
 
-export function buildKimiNewSessionLaunchSpec(scope: AiSessionDirectoryScope, prompt: string = null, markerPath: string = null): AiSessionLaunchSpec {
+export function buildKimiNewSessionLaunchSpec(scope: AiSessionDirectoryScope, prompt: string = null, markerPath: string = null, launchOptions: AiSessionLaunchOptions = SAFE_LAUNCH_OPTIONS): AiSessionLaunchSpec {
     return {
         executable: 'kimi',
         args: [
             ...(scope?.primaryCwd ? ['--work-dir', scope.primaryCwd] : []),
             ...buildRepeatedAdditionalDirectoryArgs(scope),
+            ...yoloArg(launchOptions, '--yolo'),
             ...(prompt ? ['--prompt', prompt] : []),
         ],
         markerPath,
@@ -75,20 +86,28 @@ export function buildKimiNewSessionLaunchSpec(scope: AiSessionDirectoryScope, pr
     };
 }
 
-export function buildClaudeResumeLaunchSpec(sessionId: string, scope: AiSessionDirectoryScope, markerPath: string = null): AiSessionLaunchSpec {
+export function buildClaudeResumeLaunchSpec(sessionId: string, scope: AiSessionDirectoryScope, markerPath: string = null, launchOptions: AiSessionLaunchOptions = SAFE_LAUNCH_OPTIONS): AiSessionLaunchSpec {
     return {
         executable: 'claude',
-        args: [...buildClaudeAdditionalDirectoryArgs(scope), '--resume', sessionId],
+        args: [
+            ...buildClaudeAdditionalDirectoryArgs(scope),
+            ...yoloArg(launchOptions, '--dangerously-skip-permissions'),
+            '--resume', sessionId,
+        ],
         cwd: scope?.primaryCwd || undefined,
         markerPath,
         windowsDirectShell: 'current',
     };
 }
 
-export function buildClaudeNewSessionLaunchSpec(scope: AiSessionDirectoryScope, title: string = null, markerPath: string = null): AiSessionLaunchSpec {
+export function buildClaudeNewSessionLaunchSpec(scope: AiSessionDirectoryScope, title: string = null, markerPath: string = null, launchOptions: AiSessionLaunchOptions = SAFE_LAUNCH_OPTIONS): AiSessionLaunchSpec {
     return {
         executable: 'claude',
-        args: [...buildClaudeAdditionalDirectoryArgs(scope), ...(title ? ['--name', title] : [])],
+        args: [
+            ...buildClaudeAdditionalDirectoryArgs(scope),
+            ...yoloArg(launchOptions, '--dangerously-skip-permissions'),
+            ...(title ? ['--name', title] : []),
+        ],
         cwd: scope?.primaryCwd || undefined,
         markerPath,
         windowsDirectShell: 'powershell',

--- a/src/aiSessions/commandBuilders.ts
+++ b/src/aiSessions/commandBuilders.ts
@@ -13,7 +13,7 @@ export type AiSessionCommandPlatform = NodeJS.Platform;
 const SAFE_LAUNCH_OPTIONS: AiSessionLaunchOptions = Object.freeze({ yolo: false });
 
 function yoloArg(options: AiSessionLaunchOptions, argument: string): string[] {
-    return options.yolo ? [argument] : [];
+    return options?.yolo === true ? [argument] : [];
 }
 
 function buildRepeatedAdditionalDirectoryArgs(scope: AiSessionDirectoryScope): string[] {

--- a/src/aiSessions/creationController.ts
+++ b/src/aiSessions/creationController.ts
@@ -6,6 +6,7 @@ import type { AiSessionProviderId } from '../models';
 import { sanitizeAiSessionAlias } from './aliasStore';
 import type { AiSessionLaunchOptions } from './launchOptions';
 import type { AiSessionLaunchSpec } from './launchSpec';
+import { createSingleUseLaunchSpecFactory } from './runtimeLaunch';
 import { isValidAiSessionRuntimeIdentityId } from './runtimeTypes';
 import type {
     AiSessionCreateRuntimeRequest,
@@ -187,15 +188,7 @@ export class AiSessionCreationController {
         const createdAt = new Date(options.nowMs()).toISOString();
         const markerPath = options.getPendingMarkerPath(providerId);
         const terminalName = `${sessionProvider.terminalNamePrefix}: ${target.name || 'New Session'}`;
-        const launchOptions = options.getLaunchOptions();
-        const launch = cloneLaunchSpec(
-            sessionProvider.buildNewSessionLaunchSpec(
-                directoryScope,
-                fields.title,
-                markerPath,
-                launchOptions
-            )
-        );
+        const launchScope = cloneDirectoryScope(directoryScope);
         const request: AiSessionCreateRuntimeRequest = {
             identity: {
                 provider: providerId,
@@ -210,7 +203,14 @@ export class AiSessionCreationController {
             createdAt,
             excludedSessionIds: existingSessionIds,
             title: fields.title,
-            launch,
+            launchMarkerPath: markerPath,
+            createLaunchSpec: createSingleUseLaunchSpecFactory(() =>
+                sessionProvider.buildNewSessionLaunchSpec!(
+                    launchScope,
+                    fields.title,
+                    markerPath,
+                    options.getLaunchOptions()
+                )),
             directoryScope,
         };
         let result: AiSessionRuntimeActionResult<vscode.Terminal>;
@@ -251,10 +251,11 @@ export class AiSessionCreationController {
     }
 }
 
-function cloneLaunchSpec(launch: AiSessionLaunchSpec): AiSessionLaunchSpec {
+function cloneDirectoryScope(scope: AiSessionDirectoryScope): AiSessionDirectoryScope {
     return {
-        ...launch,
-        args: [...launch.args],
+        ...scope,
+        workspaceRootHostPaths: [...scope.workspaceRootHostPaths],
+        additionalDirectories: [...scope.additionalDirectories],
     };
 }
 

--- a/src/aiSessions/creationController.ts
+++ b/src/aiSessions/creationController.ts
@@ -4,6 +4,7 @@ import type * as vscode from 'vscode';
 
 import type { AiSessionProviderId } from '../models';
 import { sanitizeAiSessionAlias } from './aliasStore';
+import type { AiSessionLaunchOptions } from './launchOptions';
 import type { AiSessionLaunchSpec } from './launchSpec';
 import { isValidAiSessionRuntimeIdentityId } from './runtimeTypes';
 import type {
@@ -30,7 +31,8 @@ export interface AiSessionCreationProvider {
     buildNewSessionLaunchSpec?: (
         scope: AiSessionDirectoryScope,
         title: string,
-        markerPath: string
+        markerPath: string,
+        launchOptions: AiSessionLaunchOptions
     ) => AiSessionLaunchSpec;
 }
 
@@ -48,6 +50,7 @@ export interface AiSessionCreationControllerCommonOptions {
     ) => Thenable<string | undefined> | Promise<string | undefined>;
     pickProvider: () => Thenable<AiSessionProviderId | undefined>;
     getProviderLabel: (providerId: AiSessionProviderId) => string;
+    getLaunchOptions: () => AiSessionLaunchOptions;
     getProvider: (providerId: AiSessionProviderId) => AiSessionCreationProvider;
     resolveWorkspaceDirectoryScope: (
         target: WorkspaceAiSessionActionTarget,
@@ -184,8 +187,14 @@ export class AiSessionCreationController {
         const createdAt = new Date(options.nowMs()).toISOString();
         const markerPath = options.getPendingMarkerPath(providerId);
         const terminalName = `${sessionProvider.terminalNamePrefix}: ${target.name || 'New Session'}`;
+        const launchOptions = options.getLaunchOptions();
         const launch = cloneLaunchSpec(
-            sessionProvider.buildNewSessionLaunchSpec(directoryScope, fields.title, markerPath)
+            sessionProvider.buildNewSessionLaunchSpec(
+                directoryScope,
+                fields.title,
+                markerPath,
+                launchOptions
+            )
         );
         const request: AiSessionCreateRuntimeRequest = {
             identity: {
@@ -257,6 +266,7 @@ function validateControllerOptions(options: AiSessionCreationControllerOptions):
         || typeof options.getWorkspaceTarget !== 'function'
         || typeof options.pickWorkspaceRoot !== 'function'
         || typeof options.resolveWorkspaceDirectoryScope !== 'function'
+        || typeof options.getLaunchOptions !== 'function'
         || typeof options.createPendingId !== 'function'
         || typeof options.announceStatus !== 'function') {
         throw new Error('AI session creation runtime controller options are invalid.');

--- a/src/aiSessions/directTerminalRuntimeBackend.ts
+++ b/src/aiSessions/directTerminalRuntimeBackend.ts
@@ -5,12 +5,20 @@ import type { AiSessionProviderId } from '../models';
 import type { AiSessionLaunchSpec } from './launchSpec';
 import type {
     AiSessionCreateRuntimeRequest,
+    AiSessionDeferredCreateRuntimeRequest,
+    AiSessionDeferredResumeRuntimeRequest,
     AiSessionExecutableRuntimeBackend,
+    AiSessionMaterializedCreateRuntimeRequest,
+    AiSessionMaterializedResumeRuntimeRequest,
     AiSessionPendingRuntimeSnapshot,
     AiSessionResumeRuntimeRequest,
     AiSessionRuntimeIdentity,
     AiSessionRuntimeSnapshot,
 } from './runtimeTypes';
+import {
+    materializeAiSessionLaunchSpec,
+    snapshotAiSessionRuntimeLaunch,
+} from './runtimeLaunch';
 import { AiSessionRuntimeLifecycleBlockedError } from './runtimeTypes';
 import {
     cloneAiSessionRuntimeIdentity,
@@ -150,10 +158,11 @@ implements AiSessionExecutableRuntimeBackend<TTerminal> {
                 return cloneRuntime(runtime);
             }
             this.terminalService.focusTerminal(existing.terminal);
-            await this.terminalService.sendRuntimeLaunch(existing.terminal, input.launch, {
+            const dispatched = materializeResumeRequest(input);
+            await this.terminalService.sendRuntimeLaunch(existing.terminal, dispatched.launch, {
                 deleteMarkerBeforeLaunch: true,
             });
-            return this.retrackResume(input, existing.terminal);
+            return this.retrackResume(dispatched, existing.terminal);
         }
 
         const created = this.terminalService.createTerminal({
@@ -167,15 +176,16 @@ implements AiSessionExecutableRuntimeBackend<TTerminal> {
             logError: () => undefined,
         });
         this.terminalService.focusTerminal(created.terminal);
+        const dispatched = materializeResumeRequest(input);
         await this.terminalService.sendRuntimeLaunch(created.terminal,
-            input.launch, {
+            dispatched.launch, {
             deleteMarkerBeforeLaunch: true,
         });
-        return this.retrackResume(input, created.terminal);
+        return this.retrackResume(dispatched, created.terminal);
     }
 
     private retrackResume(
-        input: AiSessionResumeRuntimeRequest,
+        input: AiSessionMaterializedResumeRuntimeRequest,
         terminal: TTerminal
     ): AiSessionRuntimeSnapshot<TTerminal> {
         const runStartedAtMs = this.nowMs();
@@ -217,22 +227,23 @@ implements AiSessionExecutableRuntimeBackend<TTerminal> {
             cwdWarningMessage: 'Could not open the AI session terminal at the project directory. Starting without a working directory.',
             logError: () => undefined,
         });
+        const dispatched = materializeCreateRequest(input);
         const pending: DirectPendingTerminalEntry<TTerminal> = {
-            provider: input.identity.provider,
+            provider: dispatched.identity.provider,
             terminal: created.terminal,
-            markerPath: input.launch.markerPath || '',
-            cwd: input.identity.cwd,
-            createdAt: input.createdAt,
-            excludedSessionIds: input.excludedSessionIds.slice(),
-            projectName: input.projectName,
-            ...(input.title === undefined ? {} : { title: input.title }),
-            runtimeIdentity: cloneAiSessionRuntimeIdentity(input.identity),
+            markerPath: dispatched.launch.markerPath || '',
+            cwd: dispatched.identity.cwd,
+            createdAt: dispatched.createdAt,
+            excludedSessionIds: dispatched.excludedSessionIds.slice(),
+            projectName: dispatched.projectName,
+            ...(dispatched.title === undefined ? {} : { title: dispatched.title }),
+            runtimeIdentity: cloneAiSessionRuntimeIdentity(dispatched.identity),
         };
-        this.pendingMetadata.set(created.terminal, cloneAiSessionRuntimeIdentity(input.identity));
+        this.pendingMetadata.set(created.terminal, cloneAiSessionRuntimeIdentity(dispatched.identity));
         this.terminalService.trackPending(pending);
         this.terminalService.focusTerminal(created.terminal);
         await this.terminalService.sendRuntimeLaunch(created.terminal,
-            input.launch, {
+            dispatched.launch, {
             persistPendingBeforeLaunch: true,
         });
         return this.pendingSnapshot(pending);
@@ -374,22 +385,65 @@ function finiteDate(value: string): number {
     return Number.isFinite(parsed) ? parsed : 0;
 }
 
-function snapshotResumeRequest(request: AiSessionResumeRuntimeRequest): AiSessionResumeRuntimeRequest {
+function snapshotResumeRequest(
+    request: AiSessionResumeRuntimeRequest
+): AiSessionDeferredResumeRuntimeRequest {
+    const launch = snapshotAiSessionRuntimeLaunch(request);
     return {
-        ...request,
         identity: cloneAiSessionRuntimeIdentity(request.identity),
+        projectName: request.projectName,
+        sessionName: request.sessionName,
+        terminalName: request.terminalName,
         directoryScope: cloneDirectoryScope(request.directoryScope),
-        launch: { ...request.launch, args: [...request.launch.args] },
+        launchMarkerPath: launch.launchMarkerPath,
+        createLaunchSpec: launch.createLaunchSpec,
     };
 }
 
-function snapshotCreateRequest(request: AiSessionCreateRuntimeRequest): AiSessionCreateRuntimeRequest {
+function snapshotCreateRequest(
+    request: AiSessionCreateRuntimeRequest
+): AiSessionDeferredCreateRuntimeRequest {
+    const launch = snapshotAiSessionRuntimeLaunch(request);
     return {
-        ...request,
         identity: cloneAiSessionRuntimeIdentity(request.identity),
+        projectName: request.projectName,
+        terminalName: request.terminalName,
+        createdAt: request.createdAt,
         directoryScope: cloneDirectoryScope(request.directoryScope),
         excludedSessionIds: [...request.excludedSessionIds],
-        launch: { ...request.launch, args: [...request.launch.args] },
+        ...(request.title === undefined ? {} : { title: request.title }),
+        launchMarkerPath: launch.launchMarkerPath,
+        createLaunchSpec: launch.createLaunchSpec,
+    };
+}
+
+function materializeResumeRequest(
+    request: AiSessionDeferredResumeRuntimeRequest
+): AiSessionMaterializedResumeRuntimeRequest {
+    return {
+        identity: cloneAiSessionRuntimeIdentity(request.identity),
+        projectName: request.projectName,
+        sessionName: request.sessionName,
+        terminalName: request.terminalName,
+        directoryScope: cloneDirectoryScope(request.directoryScope),
+        launchMarkerPath: request.launchMarkerPath,
+        launch: materializeAiSessionLaunchSpec(request),
+    };
+}
+
+function materializeCreateRequest(
+    request: AiSessionDeferredCreateRuntimeRequest
+): AiSessionMaterializedCreateRuntimeRequest {
+    return {
+        identity: cloneAiSessionRuntimeIdentity(request.identity),
+        projectName: request.projectName,
+        terminalName: request.terminalName,
+        createdAt: request.createdAt,
+        excludedSessionIds: [...request.excludedSessionIds],
+        ...(request.title === undefined ? {} : { title: request.title }),
+        directoryScope: cloneDirectoryScope(request.directoryScope),
+        launchMarkerPath: request.launchMarkerPath,
+        launch: materializeAiSessionLaunchSpec(request),
     };
 }
 

--- a/src/aiSessions/launchOptions.ts
+++ b/src/aiSessions/launchOptions.ts
@@ -1,0 +1,17 @@
+'use strict';
+
+export interface AiSessionLaunchOptions {
+    yolo: boolean;
+}
+
+interface ConfigurationReader {
+    get<T>(key: string, fallback: T): T;
+}
+
+export function readAiSessionLaunchOptions(
+    configuration: ConfigurationReader
+): AiSessionLaunchOptions {
+    return {
+        yolo: configuration.get<unknown>('aiSessionYoloMode', false) === true,
+    };
+}

--- a/src/aiSessions/launchOptions.ts
+++ b/src/aiSessions/launchOptions.ts
@@ -8,9 +8,14 @@ interface ConfigurationReader {
     get<T>(key: string, fallback: T): T;
 }
 
+interface WorkspaceConfigurationProvider {
+    getConfiguration(section: string): ConfigurationReader;
+}
+
 export function readAiSessionLaunchOptions(
-    configuration: ConfigurationReader
+    workspace: WorkspaceConfigurationProvider
 ): AiSessionLaunchOptions {
+    const configuration = workspace.getConfiguration('projectSteward');
     return {
         yolo: configuration.get<unknown>('aiSessionYoloMode', false) === true,
     };

--- a/src/aiSessions/providers.ts
+++ b/src/aiSessions/providers.ts
@@ -31,7 +31,8 @@ export const AI_SESSION_PROVIDER_DEFINITIONS: Record<AiSessionProviderId, AiSess
         projectSessionsUnavailableKey: 'codexSessionsUnavailable',
         terminalCwdFields: ['cwd'],
         buildResumeLaunchSpec: buildCodexResumeLaunchSpec,
-        buildNewSessionLaunchSpec: (scope, _title, markerPath) => buildCodexNewSessionLaunchSpec(scope, null, markerPath),
+        buildNewSessionLaunchSpec: (scope, _title, markerPath, launchOptions) =>
+            buildCodexNewSessionLaunchSpec(scope, null, markerPath, launchOptions),
         buildResumeCommand: buildCodexResumeCommand,
         buildNewSessionCommand: (scope, _title, markerPath) => buildCodexNewSessionCommand(scope, null, markerPath),
     },
@@ -46,7 +47,8 @@ export const AI_SESSION_PROVIDER_DEFINITIONS: Record<AiSessionProviderId, AiSess
         projectSessionsUnavailableKey: 'kimiSessionsUnavailable',
         terminalCwdFields: ['workDir', 'cwd'],
         buildResumeLaunchSpec: buildKimiResumeLaunchSpec,
-        buildNewSessionLaunchSpec: (scope, _title, markerPath) => buildKimiNewSessionLaunchSpec(scope, null, markerPath),
+        buildNewSessionLaunchSpec: (scope, _title, markerPath, launchOptions) =>
+            buildKimiNewSessionLaunchSpec(scope, null, markerPath, launchOptions),
         buildResumeCommand: buildKimiResumeCommand,
         buildNewSessionCommand: (scope, _title, markerPath) => buildKimiNewSessionCommand(scope, null, markerPath),
     },

--- a/src/aiSessions/resumeController.ts
+++ b/src/aiSessions/resumeController.ts
@@ -3,6 +3,7 @@
 import type { AiSessionProviderId, CodexSession } from '../models';
 import type { AiSessionLaunchOptions } from './launchOptions';
 import type { AiSessionLaunchSpec } from './launchSpec';
+import { createSingleUseLaunchSpecFactory } from './runtimeLaunch';
 import type {
     AiSessionResumeRuntimeRequest,
     AiSessionRuntimeActionResult,
@@ -145,15 +146,7 @@ export class AiSessionResumeController<
         }
         const cwd = directoryScope.primaryCwd;
         const markerPath = options.getMarkerPath(providerId, session.id);
-        const launchOptions = options.getLaunchOptions();
-        const launch = cloneLaunchSpec(
-            sessionProvider.buildResumeLaunchSpec(
-                session.id,
-                directoryScope,
-                markerPath,
-                launchOptions
-            )
-        );
+        const launchScope = cloneDirectoryScope(directoryScope);
         const request: AiSessionResumeRuntimeRequest = {
             identity: {
                 provider: providerId,
@@ -166,7 +159,14 @@ export class AiSessionResumeController<
             projectName: target.name || 'AI Session',
             sessionName: session.name || session.id,
             terminalName: options.getTerminalName(providerId, session),
-            launch,
+            launchMarkerPath: markerPath,
+            createLaunchSpec: createSingleUseLaunchSpecFactory(() =>
+                sessionProvider.buildResumeLaunchSpec!(
+                    session.id,
+                    launchScope,
+                    markerPath,
+                    options.getLaunchOptions()
+                )),
             directoryScope,
         };
         let result: AiSessionRuntimeActionResult<TTerminal>;
@@ -209,10 +209,11 @@ export class AiSessionResumeController<
     }
 }
 
-function cloneLaunchSpec(launch: AiSessionLaunchSpec): AiSessionLaunchSpec {
+function cloneDirectoryScope(scope: AiSessionDirectoryScope): AiSessionDirectoryScope {
     return {
-        ...launch,
-        args: [...launch.args],
+        ...scope,
+        workspaceRootHostPaths: [...scope.workspaceRootHostPaths],
+        additionalDirectories: [...scope.additionalDirectories],
     };
 }
 

--- a/src/aiSessions/resumeController.ts
+++ b/src/aiSessions/resumeController.ts
@@ -1,6 +1,7 @@
 'use strict';
 
 import type { AiSessionProviderId, CodexSession } from '../models';
+import type { AiSessionLaunchOptions } from './launchOptions';
 import type { AiSessionLaunchSpec } from './launchSpec';
 import type {
     AiSessionResumeRuntimeRequest,
@@ -26,7 +27,8 @@ export interface AiSessionResumeProvider {
     buildResumeLaunchSpec?: (
         sessionId: string,
         scope: AiSessionDirectoryScope,
-        markerPath: string
+        markerPath: string,
+        launchOptions: AiSessionLaunchOptions
     ) => AiSessionLaunchSpec;
 }
 
@@ -36,6 +38,7 @@ export interface AiSessionResumeRuntimeCoordinator<TTerminal> {
 
 export interface AiSessionResumeControllerCommonOptions {
     getWorkspaceTarget: (cardId: string) => WorkspaceAiSessionActionTarget | null;
+    getLaunchOptions: () => AiSessionLaunchOptions;
     getProvider: (providerId: AiSessionProviderId) => AiSessionResumeProvider | null;
     resolveWorkspaceDirectoryScope: (
         target: WorkspaceAiSessionActionTarget,
@@ -142,8 +145,14 @@ export class AiSessionResumeController<
         }
         const cwd = directoryScope.primaryCwd;
         const markerPath = options.getMarkerPath(providerId, session.id);
+        const launchOptions = options.getLaunchOptions();
         const launch = cloneLaunchSpec(
-            sessionProvider.buildResumeLaunchSpec(session.id, directoryScope, markerPath)
+            sessionProvider.buildResumeLaunchSpec(
+                session.id,
+                directoryScope,
+                markerPath,
+                launchOptions
+            )
         );
         const request: AiSessionResumeRuntimeRequest = {
             identity: {
@@ -213,6 +222,7 @@ function validateControllerOptions<TTerminal extends AiSessionResumeTerminal>(
     if (typeof options?.runtimeCoordinator?.resume !== 'function'
         || typeof options.getWorkspaceTarget !== 'function'
         || typeof options.resolveWorkspaceDirectoryScope !== 'function'
+        || typeof options.getLaunchOptions !== 'function'
         || typeof options.announceStatus !== 'function') {
         throw new Error('AI session resume runtime controller options are invalid.');
     }

--- a/src/aiSessions/runtimeCoordinator.ts
+++ b/src/aiSessions/runtimeCoordinator.ts
@@ -4,6 +4,8 @@ import type * as vscode from 'vscode';
 import type { AiSessionProviderId } from '../models';
 import type {
     AiSessionCreateRuntimeRequest,
+    AiSessionDeferredCreateRuntimeRequest,
+    AiSessionDeferredResumeRuntimeRequest,
     AiSessionDurablePendingPromotionCandidate,
     AiSessionExecutableRuntimeBackend,
     AiSessionPendingPromotionCandidate,
@@ -14,6 +16,7 @@ import type {
     AiSessionRuntimeIdentity,
     AiSessionRuntimeSnapshot,
 } from './runtimeTypes';
+import { snapshotAiSessionRuntimeLaunch } from './runtimeLaunch';
 import {
     aiSessionRuntimeIdentitiesEqual,
     AiSessionRuntimeConflictError,
@@ -587,22 +590,35 @@ function snapshotConfiguration(configuration: AiSessionRuntimeConfiguration): Ai
     };
 }
 
-function snapshotResumeRequest(request: AiSessionResumeRuntimeRequest): AiSessionResumeRuntimeRequest {
+function snapshotResumeRequest(
+    request: AiSessionResumeRuntimeRequest
+): AiSessionDeferredResumeRuntimeRequest {
+    const launch = snapshotAiSessionRuntimeLaunch(request);
     return {
-        ...request,
         identity: cloneAiSessionRuntimeIdentity(request.identity),
+        projectName: request.projectName,
+        sessionName: request.sessionName,
+        terminalName: request.terminalName,
         directoryScope: cloneDirectoryScope(request.directoryScope),
-        launch: { ...request.launch, args: [...request.launch.args] },
+        launchMarkerPath: launch.launchMarkerPath,
+        createLaunchSpec: launch.createLaunchSpec,
     };
 }
 
-function snapshotCreateRequest(request: AiSessionCreateRuntimeRequest): AiSessionCreateRuntimeRequest {
+function snapshotCreateRequest(
+    request: AiSessionCreateRuntimeRequest
+): AiSessionDeferredCreateRuntimeRequest {
+    const launch = snapshotAiSessionRuntimeLaunch(request);
     return {
-        ...request,
         identity: cloneAiSessionRuntimeIdentity(request.identity),
+        projectName: request.projectName,
+        terminalName: request.terminalName,
+        createdAt: request.createdAt,
         directoryScope: cloneDirectoryScope(request.directoryScope),
         excludedSessionIds: [...request.excludedSessionIds],
-        launch: { ...request.launch, args: [...request.launch.args] },
+        ...(request.title === undefined ? {} : { title: request.title }),
+        launchMarkerPath: launch.launchMarkerPath,
+        createLaunchSpec: launch.createLaunchSpec,
     };
 }
 

--- a/src/aiSessions/runtimeLaunch.ts
+++ b/src/aiSessions/runtimeLaunch.ts
@@ -1,0 +1,93 @@
+'use strict';
+
+import type { AiSessionLaunchSpec } from './launchSpec';
+import type {
+    AiSessionLazyRuntimeLaunch,
+    AiSessionRuntimeLaunchInput,
+} from './runtimeTypes';
+
+export function createSingleUseLaunchSpecFactory(
+    createLaunchSpec: () => AiSessionLaunchSpec
+): () => AiSessionLaunchSpec {
+    let used = false;
+    return () => {
+        if (used) {
+            throw new Error('The AI session launch specification was already created.');
+        }
+        used = true;
+        return cloneAiSessionLaunchSpec(createLaunchSpec());
+    };
+}
+
+export function snapshotAiSessionRuntimeLaunch(
+    request: AiSessionRuntimeLaunchInput
+): AiSessionLazyRuntimeLaunch {
+    const candidate = request as unknown as Record<string, unknown>;
+    if (typeof candidate.createLaunchSpec === 'function') {
+        if (typeof candidate.launchMarkerPath !== 'string') {
+            throw new Error('The AI session runtime launch marker is invalid.');
+        }
+        return {
+            launchMarkerPath: candidate.launchMarkerPath,
+            createLaunchSpec: candidate.createLaunchSpec as () => AiSessionLaunchSpec,
+        };
+    }
+
+    const launch = cloneAiSessionLaunchSpec(candidate.launch);
+    const launchMarkerPath = candidate.launchMarkerPath === undefined
+        ? launch.markerPath || ''
+        : candidate.launchMarkerPath;
+    if (typeof launchMarkerPath !== 'string') {
+        throw new Error('The AI session runtime launch marker is invalid.');
+    }
+    return {
+        launchMarkerPath,
+        createLaunchSpec: () => cloneAiSessionLaunchSpec(launch),
+    };
+}
+
+export function materializeAiSessionLaunchSpec(
+    launch: AiSessionLazyRuntimeLaunch
+): AiSessionLaunchSpec {
+    const specification = cloneAiSessionLaunchSpec(launch.createLaunchSpec());
+    if ((specification.markerPath || '') !== launch.launchMarkerPath) {
+        throw new Error('The AI session runtime launch marker changed before dispatch.');
+    }
+    return specification;
+}
+
+export function cloneAiSessionLaunchSpec(value: unknown): AiSessionLaunchSpec {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        throw new Error('The AI session launch specification is invalid.');
+    }
+    const launch = value as Record<string, unknown>;
+    const launchArgs = launch.args;
+    if (typeof launch.executable !== 'string'
+        || !Array.isArray(launchArgs)
+        || (launch.cwd !== undefined && typeof launch.cwd !== 'string')
+        || (launch.markerPath !== undefined && typeof launch.markerPath !== 'string')
+        || (launch.windowsDirectShell !== undefined
+            && launch.windowsDirectShell !== 'current'
+            && launch.windowsDirectShell !== 'powershell')) {
+        throw new Error('The AI session launch specification is invalid.');
+    }
+    const args: string[] = [];
+    for (let index = 0; index < launchArgs.length; index++) {
+        if (!Object.prototype.hasOwnProperty.call(launchArgs, index)
+            || typeof launchArgs[index] !== 'string') {
+            throw new Error('The AI session launch specification is invalid.');
+        }
+        args.push(launchArgs[index] as string);
+    }
+    return {
+        executable: launch.executable,
+        args,
+        ...(launch.cwd === undefined ? {} : { cwd: launch.cwd as string }),
+        ...(launch.markerPath === undefined
+            ? {}
+            : { markerPath: launch.markerPath as string }),
+        ...(launch.windowsDirectShell === undefined
+            ? {}
+            : { windowsDirectShell: launch.windowsDirectShell as 'current' | 'powershell' }),
+    };
+}

--- a/src/aiSessions/runtimeTypes.ts
+++ b/src/aiSessions/runtimeTypes.ts
@@ -291,25 +291,63 @@ export interface AiSessionRuntimeBackend<TTerminal = unknown> {
     detach(runtime: AiSessionRuntimeSnapshot<TTerminal>): Promise<void>;
 }
 
-export interface AiSessionResumeRuntimeRequest {
+interface AiSessionResumeRuntimeRequestBase {
     identity: AiSessionRuntimeIdentity & { sessionId: string };
     projectName: string;
     sessionName: string;
     terminalName: string;
-    launch: AiSessionLaunchSpec;
     directoryScope: AiSessionDirectoryScope;
 }
 
-export interface AiSessionCreateRuntimeRequest {
+interface AiSessionCreateRuntimeRequestBase {
     identity: AiSessionRuntimeIdentity & { pendingId: string };
     projectName: string;
     terminalName: string;
     createdAt: string;
     excludedSessionIds: string[];
     title?: string;
-    launch: AiSessionLaunchSpec;
     directoryScope: AiSessionDirectoryScope;
 }
+
+export interface AiSessionLazyRuntimeLaunch {
+    launchMarkerPath: string;
+    createLaunchSpec: () => AiSessionLaunchSpec;
+    launch?: never;
+}
+
+export interface AiSessionLegacyRuntimeLaunch {
+    launch: AiSessionLaunchSpec;
+    launchMarkerPath?: string;
+    createLaunchSpec?: never;
+}
+
+export type AiSessionRuntimeLaunchInput =
+    | AiSessionLazyRuntimeLaunch
+    | AiSessionLegacyRuntimeLaunch;
+
+export type AiSessionResumeRuntimeRequest =
+    AiSessionResumeRuntimeRequestBase & AiSessionRuntimeLaunchInput;
+
+export type AiSessionCreateRuntimeRequest =
+    AiSessionCreateRuntimeRequestBase & AiSessionRuntimeLaunchInput;
+
+export type AiSessionDeferredResumeRuntimeRequest =
+    AiSessionResumeRuntimeRequestBase & AiSessionLazyRuntimeLaunch;
+
+export type AiSessionDeferredCreateRuntimeRequest =
+    AiSessionCreateRuntimeRequestBase & AiSessionLazyRuntimeLaunch;
+
+export type AiSessionMaterializedResumeRuntimeRequest =
+    AiSessionResumeRuntimeRequestBase & {
+        launchMarkerPath: string;
+        launch: AiSessionLaunchSpec;
+    };
+
+export type AiSessionMaterializedCreateRuntimeRequest =
+    AiSessionCreateRuntimeRequestBase & {
+        launchMarkerPath: string;
+        launch: AiSessionLaunchSpec;
+    };
 
 export interface AiSessionRuntimeActionResult<TTerminal = unknown> {
     status: 'started' | 'focused' | 'cancelled' | 'settings' | 'conflict' | 'blocked';

--- a/src/aiSessions/terminalService.ts
+++ b/src/aiSessions/terminalService.ts
@@ -120,16 +120,24 @@ export default class AiSessionTerminalService {
 
     async sendNewSessionCommand(providerId: AiSessionProviderId, terminal: vscode.Terminal, scope: AiSessionDirectoryScope, title: string, markerPath: string) {
         let provider = this.getProvider(providerId);
-        await this.sendRuntimeLaunch(terminal, provider.buildNewSessionLaunchSpec(scope, title, markerPath), {
-            persistPendingBeforeLaunch: true,
-        });
+        await this.sendRuntimeLaunch(
+            terminal,
+            provider.buildNewSessionLaunchSpec(scope, title, markerPath, { yolo: false }),
+            {
+                persistPendingBeforeLaunch: true,
+            }
+        );
     }
 
     async sendResumeCommand(providerId: AiSessionProviderId, terminal: vscode.Terminal, sessionId: string, scope: AiSessionDirectoryScope, markerPath: string) {
         let provider = this.getProvider(providerId);
-        await this.sendRuntimeLaunch(terminal, provider.buildResumeLaunchSpec(sessionId, scope, markerPath), {
-            deleteMarkerBeforeLaunch: true,
-        });
+        await this.sendRuntimeLaunch(
+            terminal,
+            provider.buildResumeLaunchSpec(sessionId, scope, markerPath, { yolo: false }),
+            {
+                deleteMarkerBeforeLaunch: true,
+            }
+        );
     }
 
     async sendRuntimeLaunch(

--- a/src/aiSessions/tmuxRuntimeBackend.ts
+++ b/src/aiSessions/tmuxRuntimeBackend.ts
@@ -3,11 +3,17 @@
 import { createHash, randomBytes } from 'crypto';
 import type * as vscode from 'vscode';
 import { serializeTmuxLaunchCommand } from './launchSpec';
+import type { AiSessionLaunchSpec } from './launchSpec';
 import type {
     AiSessionCreateRuntimeRequest,
+    AiSessionDeferredCreateRuntimeRequest,
+    AiSessionDeferredResumeRuntimeRequest,
     AiSessionDurablePendingPromotionCandidate,
     AiSessionExecutableRuntimeBackend,
+    AiSessionLazyRuntimeLaunch,
     AiSessionManagedTmuxMetadata,
+    AiSessionMaterializedCreateRuntimeRequest,
+    AiSessionMaterializedResumeRuntimeRequest,
     AiSessionPendingRuntimeSnapshot,
     AiSessionResumeRuntimeRequest,
     AiSessionRuntimeIdentity,
@@ -16,6 +22,10 @@ import type {
     AiSessionTmuxLocator,
     TmuxRuntimeUnavailableReason,
 } from './runtimeTypes';
+import {
+    materializeAiSessionLaunchSpec,
+    snapshotAiSessionRuntimeLaunch,
+} from './runtimeLaunch';
 import {
     aiSessionRuntimeIdentitiesEqual,
     AiSessionRuntimeConflictError,
@@ -177,14 +187,14 @@ implements AiSessionExecutableRuntimeBackend<TTerminal> {
         request: AiSessionResumeRuntimeRequest,
         layout: AiSessionTmuxLayout = 'project'
     ): Promise<AiSessionRuntimeSnapshot<TTerminal>> {
-        request = snapshotResumeRequest(request);
+        const input = snapshotResumeRequest(request);
         requireLayout(layout);
-        validateDispatchInputs(request.identity, request.launch);
+        validateDispatchIdentity(input.identity);
         await this.requireAvailable();
-        const identity = finalIdentity(request.identity);
+        const identity = finalIdentity(input.identity);
         const preferredLocator = buildReadableTmuxLocator(identity, layout, {
-            projectName: request.projectName,
-            sessionName: request.sessionName,
+            projectName: input.projectName,
+            sessionName: input.sessionName,
         });
         const lockKey = getTmuxRuntimeKey(identity);
         const runtime = await this.withCreationLocks(identity, layout, lockKey, async () => {
@@ -201,7 +211,7 @@ implements AiSessionExecutableRuntimeBackend<TTerminal> {
                 throw new Error('The prior tmux creation result is ambiguous; the provider command was not sent again.');
             }
             const locator = await this.resolveCreationLocator(identity, preferredLocator);
-            return this.createFinalRuntime(request, layout, locator);
+            return this.createFinalRuntime(input, layout, locator);
         });
         return this.attachAndFocus(runtime, this.getAttachTerminalName(runtime));
     }
@@ -210,14 +220,14 @@ implements AiSessionExecutableRuntimeBackend<TTerminal> {
         request: AiSessionCreateRuntimeRequest,
         layout: AiSessionTmuxLayout = 'project'
     ): Promise<AiSessionPendingRuntimeSnapshot<TTerminal>> {
-        request = snapshotPendingRequest(request);
+        const input = snapshotPendingRequest(request);
         requireLayout(layout);
-        validateDispatchInputs(request.identity, request.launch);
-        const identity = pendingIdentity(request.identity);
+        validateDispatchIdentity(input.identity);
+        const identity = pendingIdentity(input.identity);
         await this.auditPendingId(identity);
         const preferredLocator = buildReadableTmuxLocator(identity, layout, {
-            projectName: request.projectName,
-            sessionName: request.title?.trim() || 'new-session',
+            projectName: input.projectName,
+            sessionName: input.title?.trim() || 'new-session',
         });
         const binding = validateTmuxPendingRuntimeBinding({
             version: 2,
@@ -228,11 +238,11 @@ implements AiSessionExecutableRuntimeBackend<TTerminal> {
             workspaceNavigationIdentity: identity.workspaceNavigationIdentity,
             workspaceRootHostPaths: [...identity.workspaceRootHostPaths],
             cwd: identity.cwd,
-            createdAt: request.createdAt,
-            excludedSessionIds: request.excludedSessionIds,
-            projectName: request.projectName,
-            ...(request.title === undefined ? {} : { title: request.title }),
-            acceptedAtMs: Date.parse(request.createdAt),
+            createdAt: input.createdAt,
+            excludedSessionIds: input.excludedSessionIds,
+            projectName: input.projectName,
+            ...(input.title === undefined ? {} : { title: input.title }),
+            acceptedAtMs: Date.parse(input.createdAt),
             layout,
             locator: preferredLocator,
         }, this.dependencies.nowMs());
@@ -263,7 +273,7 @@ implements AiSessionExecutableRuntimeBackend<TTerminal> {
                     throw new Error('The prior pending runtime binding is invalid or expired.');
                 }
                 return this.recoverPendingAmbiguity(
-                    request, acceptedBinding, acceptedBinding.locator, pendingAmbiguous
+                    input, acceptedBinding, acceptedBinding.locator, pendingAmbiguous
                 );
             }
             const locator = await this.resolveCreationLocator(identity, preferredLocator);
@@ -275,7 +285,7 @@ implements AiSessionExecutableRuntimeBackend<TTerminal> {
             if (!dispatchBinding) {
                 throw new Error('The pending runtime request expired before provider dispatch.');
             }
-            return this.createPendingRuntime(request, dispatchBinding, locator);
+            return this.createPendingRuntime(input, dispatchBinding, locator);
         });
         return this.attachAndFocus(
             runtime, this.getAttachTerminalName(runtime)
@@ -913,26 +923,37 @@ implements AiSessionExecutableRuntimeBackend<TTerminal> {
     }
 
     private async createFinalRuntime(
-        request: AiSessionResumeRuntimeRequest,
+        request: AiSessionDeferredResumeRuntimeRequest,
         layout: AiSessionTmuxLayout,
         locator: AiSessionTmuxLocator
     ): Promise<AiSessionRuntimeSnapshot> {
         const createdAt = new Date(this.dependencies.nowMs()).toISOString();
         let providerLaunchAttempted = false;
+        let dispatched: AiSessionMaterializedResumeRuntimeRequest | undefined;
         try {
             await this.createTarget(layout, locator, request.identity.cwd,
-                serializeTmuxLaunchCommand(request.launch), request.identity,
+                request.identity,
                 async () => {
                     await this.persistAmbiguous(request.identity, locator);
+                    try {
+                        dispatched = materializeResumeRequest(request);
+                    } catch (error) {
+                        await this.dependencies.runtimeStore.removeAmbiguous(request.identity);
+                        throw error;
+                    }
                     providerLaunchAttempted = true;
+                    return serializeTmuxLaunchCommand(dispatched.launch);
                 });
+            if (!dispatched) {
+                throw new Error('The provider launch was not prepared.');
+            }
             await this.writeFinalMetadata(request.identity, locator, {
                 createdAt,
-                markerPath: request.launch.markerPath || '',
+                markerPath: dispatched.launch.markerPath || '',
             });
             await this.persistKnown(request.identity, locator, {
                 identity: request.identity,
-                markerPath: request.launch.markerPath || '',
+                markerPath: dispatched.launch.markerPath || '',
                 runStartedAtMs: Date.parse(createdAt),
             });
         } catch (error) {
@@ -947,22 +968,33 @@ implements AiSessionExecutableRuntimeBackend<TTerminal> {
     }
 
     private async createPendingRuntime(
-        request: AiSessionCreateRuntimeRequest,
+        request: AiSessionDeferredCreateRuntimeRequest,
         binding: TmuxPendingRuntimeBinding,
         locator: AiSessionTmuxLocator
     ): Promise<AiSessionPendingRuntimeSnapshot> {
         let providerLaunchAttempted = false;
+        let dispatched: AiSessionMaterializedCreateRuntimeRequest | undefined;
         try {
             await this.createTarget(binding.layout, locator, request.identity.cwd,
-                serializeTmuxLaunchCommand(request.launch), request.identity,
+                request.identity,
                 async () => {
                     await this.persistAmbiguous(request.identity, locator, request, binding);
+                    try {
+                        dispatched = materializePendingRequest(request);
+                    } catch (error) {
+                        await this.dependencies.runtimeStore.removeAmbiguous(request.identity);
+                        throw error;
+                    }
                     providerLaunchAttempted = true;
+                    return serializeTmuxLaunchCommand(dispatched.launch);
                 });
+            if (!dispatched) {
+                throw new Error('The provider launch was not prepared.');
+            }
             await this.writePendingMetadata(request.identity, locator, request.createdAt,
-                request.launch.markerPath || '');
+                dispatched.launch.markerPath || '');
             await this.verifyPendingMetadata(request.identity, locator, request.createdAt,
-                request.launch.markerPath || '');
+                dispatched.launch.markerPath || '');
             if (await this.dependencies.runtimeStore.setPending(binding) !== true) {
                 throw new Error('The pending tmux binding could not be persisted.');
             }
@@ -981,16 +1013,15 @@ implements AiSessionExecutableRuntimeBackend<TTerminal> {
         layout: AiSessionTmuxLayout,
         locator: AiSessionTmuxLocator,
         cwd: string,
-        command: string,
         identity: AiSessionRuntimeIdentity,
-        onProviderLaunch: () => Promise<void>
+        prepareProviderCommand: () => Promise<string>
     ): Promise<void> {
         if (layout === 'session') {
             if (await this.dependencies.client.hasSession(locator.sessionName)) {
                 throw new Error('The requested tmux session name is already occupied by an unverified target.');
             }
             const windowName = locator.windowName || SESSION_WINDOW;
-            await onProviderLaunch();
+            const command = await prepareProviderCommand();
             await this.dependencies.client.createSession(locator.sessionName, windowName, cwd, command);
             await this.dependencies.client.configureManagedWindow(locator.sessionName, windowName);
             return;
@@ -1012,7 +1043,7 @@ implements AiSessionExecutableRuntimeBackend<TTerminal> {
             throw new Error('The requested project tmux session is occupied by an unverified target.');
         }
         if (!hasSession) {
-            await onProviderLaunch();
+            const command = await prepareProviderCommand();
             await this.dependencies.client.createSession(
                 locator.sessionName, locator.windowName, cwd, command
             );
@@ -1024,7 +1055,7 @@ implements AiSessionExecutableRuntimeBackend<TTerminal> {
         if (await this.locatorIsOccupied(locator)) {
             throw new Error('The requested project tmux window is occupied by an unverified target.');
         }
-        await onProviderLaunch();
+        const command = await prepareProviderCommand();
         await this.dependencies.client.createWindow(locator.sessionName, locator.windowName, cwd, command);
         await this.dependencies.client.configureManagedWindow(locator.sessionName, locator.windowName);
     }
@@ -1204,7 +1235,7 @@ implements AiSessionExecutableRuntimeBackend<TTerminal> {
     private async persistAmbiguous(
         identity: AiSessionRuntimeIdentity,
         locator: AiSessionTmuxLocator,
-        pendingRequest?: AiSessionCreateRuntimeRequest,
+        pendingRequest?: AiSessionDeferredCreateRuntimeRequest,
         pendingBinding?: TmuxPendingRuntimeBinding
     ): Promise<void> {
         if (identity.sessionId === undefined && (!pendingRequest || !pendingBinding)) {
@@ -1227,10 +1258,12 @@ implements AiSessionExecutableRuntimeBackend<TTerminal> {
                     ...(pendingBinding?.projectName === undefined
                         ? {} : { projectName: pendingBinding.projectName }),
                     ...(pendingBinding?.title === undefined ? {} : { title: pendingBinding.title }),
-                    ...(pendingRequest?.launch.markerPath
-                        ? { markerPath: pendingRequest.launch.markerPath }
+                    ...(pendingRequest?.launchMarkerPath
+                        ? { markerPath: pendingRequest.launchMarkerPath }
                         : {}),
-                    requestFingerprint: pendingRequestFingerprint(pendingRequest as AiSessionCreateRuntimeRequest),
+                    requestFingerprint: pendingRequestFingerprint(
+                        pendingRequest as AiSessionDeferredCreateRuntimeRequest
+                    ),
                 }),
             layout: locator.layout,
             locator: { ...locator },
@@ -1240,7 +1273,7 @@ implements AiSessionExecutableRuntimeBackend<TTerminal> {
     }
 
     private async recoverPendingAmbiguity(
-        request: AiSessionCreateRuntimeRequest,
+        request: AiSessionDeferredCreateRuntimeRequest,
         binding: TmuxPendingRuntimeBinding,
         locator: AiSessionTmuxLocator,
         ambiguous: TmuxAmbiguousRuntimeBinding
@@ -1251,7 +1284,7 @@ implements AiSessionExecutableRuntimeBackend<TTerminal> {
             throw new Error('The prior pending runtime request is ambiguous and does not match this request.');
         }
         await this.verifyPendingMetadata(request.identity, locator, request.createdAt,
-            request.launch.markerPath || '');
+            request.launchMarkerPath);
         if (await this.dependencies.runtimeStore.setPending({
             ...binding,
             acceptedAtMs: ambiguous.acceptedAtMs,
@@ -1268,7 +1301,7 @@ implements AiSessionExecutableRuntimeBackend<TTerminal> {
     }
 
     private async recoverPendingCreation(
-        request: AiSessionCreateRuntimeRequest,
+        request: AiSessionDeferredCreateRuntimeRequest,
         binding: TmuxPendingRuntimeBinding,
         locator: AiSessionTmuxLocator,
         error: unknown
@@ -1662,7 +1695,9 @@ function isSafeAttachTerminalName(value: unknown): value is string {
         && !LOCAL_CONTROL_CHARACTERS.test(value);
 }
 
-function snapshotResumeRequest(request: AiSessionResumeRuntimeRequest): AiSessionResumeRuntimeRequest {
+function snapshotResumeRequest(
+    request: AiSessionResumeRuntimeRequest
+): AiSessionDeferredResumeRuntimeRequest {
     if (!isRecordShape(request)) {
         throw new Error('The tmux runtime request shape is invalid.');
     }
@@ -1672,18 +1707,21 @@ function snapshotResumeRequest(request: AiSessionResumeRuntimeRequest): AiSessio
         request.sessionName, identity.sessionId, 'The tmux runtime request'
     );
     const terminalName = snapshotRequiredString(request.terminalName, 'The tmux runtime request');
-    const launch = snapshotLaunch(request.launch);
+    const launch = snapshotTmuxRuntimeLaunch(request, identity);
     return {
         identity,
         projectName,
         sessionName,
         terminalName,
-        launch,
+        launchMarkerPath: launch.launchMarkerPath,
+        createLaunchSpec: launch.createLaunchSpec,
         directoryScope: request.directoryScope,
     };
 }
 
-function snapshotPendingRequest(request: AiSessionCreateRuntimeRequest): AiSessionCreateRuntimeRequest {
+function snapshotPendingRequest(
+    request: AiSessionCreateRuntimeRequest
+): AiSessionDeferredCreateRuntimeRequest {
     if (!isRecordShape(request)) {
         throw new Error('The pending runtime request shape is invalid.');
     }
@@ -1694,7 +1732,7 @@ function snapshotPendingRequest(request: AiSessionCreateRuntimeRequest): AiSessi
     const excludedSessionIds = snapshotDenseStringArray(request.excludedSessionIds,
         MAX_EXCLUDED_SESSION_IDS, 'excluded session IDs', 'The pending runtime request');
     const title = snapshotOptionalString(request.title, 'The pending runtime request');
-    const launch = snapshotLaunch(request.launch);
+    const launch = snapshotTmuxRuntimeLaunch(request, identity);
     return {
         identity,
         projectName,
@@ -1702,14 +1740,15 @@ function snapshotPendingRequest(request: AiSessionCreateRuntimeRequest): AiSessi
         createdAt,
         excludedSessionIds,
         ...(title === undefined ? {} : { title }),
-        launch,
+        launchMarkerPath: launch.launchMarkerPath,
+        createLaunchSpec: launch.createLaunchSpec,
         directoryScope: request.directoryScope,
     };
 }
 
 function snapshotLaunch(
     launch: unknown
-): AiSessionResumeRuntimeRequest['launch'] {
+): AiSessionLaunchSpec {
     if (!isRecordShape(launch)) {
         throw new Error('The tmux runtime request shape is invalid.');
     }
@@ -1731,6 +1770,59 @@ function snapshotLaunch(
         ...(windowsDirectShell === undefined
             ? {}
             : { windowsDirectShell: windowsDirectShell as 'current' | 'powershell' }),
+    };
+}
+
+function snapshotTmuxRuntimeLaunch(
+    request: AiSessionCreateRuntimeRequest | AiSessionResumeRuntimeRequest,
+    identity: AiSessionRuntimeIdentity
+): AiSessionLazyRuntimeLaunch {
+    const candidate = request as unknown as Record<string, unknown>;
+    if (typeof candidate.createLaunchSpec === 'function') {
+        return snapshotAiSessionRuntimeLaunch(request);
+    }
+    const launch = snapshotLaunch(candidate.launch);
+    validateDispatchInputs(identity, launch);
+    const launchMarkerPath = candidate.launchMarkerPath === undefined
+        ? launch.markerPath || ''
+        : snapshotRequiredString(candidate.launchMarkerPath, 'The tmux runtime request');
+    return {
+        launchMarkerPath,
+        createLaunchSpec: () => launch,
+    };
+}
+
+function materializeResumeRequest(
+    request: AiSessionDeferredResumeRuntimeRequest
+): AiSessionMaterializedResumeRuntimeRequest {
+    const launch = snapshotLaunch(materializeAiSessionLaunchSpec(request));
+    validateDispatchInputs(request.identity, launch);
+    return {
+        identity: cloneAiSessionRuntimeIdentity(request.identity),
+        projectName: request.projectName,
+        sessionName: request.sessionName,
+        terminalName: request.terminalName,
+        launchMarkerPath: request.launchMarkerPath,
+        launch,
+        directoryScope: request.directoryScope,
+    };
+}
+
+function materializePendingRequest(
+    request: AiSessionDeferredCreateRuntimeRequest
+): AiSessionMaterializedCreateRuntimeRequest {
+    const launch = snapshotLaunch(materializeAiSessionLaunchSpec(request));
+    validateDispatchInputs(request.identity, launch);
+    return {
+        identity: cloneAiSessionRuntimeIdentity(request.identity),
+        projectName: request.projectName,
+        terminalName: request.terminalName,
+        createdAt: request.createdAt,
+        excludedSessionIds: [...request.excludedSessionIds],
+        ...(request.title === undefined ? {} : { title: request.title }),
+        launchMarkerPath: request.launchMarkerPath,
+        launch,
+        directoryScope: request.directoryScope,
     };
 }
 
@@ -1880,8 +1972,13 @@ function requireLayout(value: unknown): asserts value is AiSessionTmuxLayout {
 
 function validateDispatchInputs(
     identity: AiSessionRuntimeIdentity,
-    launch: AiSessionResumeRuntimeRequest['launch']
+    launch: AiSessionLaunchSpec
 ): void {
+    validateDispatchIdentity(identity);
+    validateLaunchInputs(identity, launch);
+}
+
+function validateDispatchIdentity(identity: AiSessionRuntimeIdentity): void {
     if (!identity || !isValidAiSessionRuntimeIdentity(identity)) {
         throw new Error('The tmux runtime cwd is invalid.');
     }
@@ -1892,6 +1989,12 @@ function validateDispatchInputs(
         || !isIdentityField(hasSessionId ? identity.sessionId : identity.pendingId)) {
         throw new Error('The tmux runtime identity is invalid.');
     }
+}
+
+function validateLaunchInputs(
+    identity: AiSessionRuntimeIdentity,
+    launch: AiSessionLaunchSpec
+): void {
     if (!launch || typeof launch.executable !== 'string' || !launch.executable
         || launch.executable.length > MAX_EXECUTABLE_LENGTH
         || LOCAL_CONTROL_CHARACTERS.test(launch.executable)) {
@@ -2120,9 +2223,9 @@ function recordsEqual(left: Record<string, string>, right: Record<string, string
         && leftKeys.every((key, index) => key === rightKeys[index] && left[key] === right[key]);
 }
 
-function pendingRequestFingerprint(request: AiSessionCreateRuntimeRequest): string {
-    return createHash('sha256').update(JSON.stringify([
-        2,
+function pendingRequestFingerprint(request: AiSessionDeferredCreateRuntimeRequest): string {
+    const digest = createHash('sha256').update(JSON.stringify([
+        3,
         request.identity.provider,
         request.identity.workspaceScopeIdentity,
         request.identity.workspaceNavigationIdentity,
@@ -2132,12 +2235,9 @@ function pendingRequestFingerprint(request: AiSessionCreateRuntimeRequest): stri
         request.createdAt,
         request.excludedSessionIds,
         request.title ?? null,
-        request.launch.executable,
-        request.launch.args,
-        request.launch.cwd ?? null,
-        request.launch.markerPath ?? null,
-        request.launch.windowsDirectShell ?? null,
+        request.launchMarkerPath,
     ]), 'utf8').digest('hex');
+    return `v3:${digest}`;
 }
 
 function identityFromPendingBinding(binding: TmuxPendingRuntimeBinding): AiSessionRuntimeIdentity {
@@ -2304,22 +2404,30 @@ type PendingAmbiguousRuntimeBinding = TmuxAmbiguousRuntimeBinding & {
 
 function pendingAmbiguityMatches(
     ambiguous: PendingAmbiguousRuntimeBinding,
-    request: AiSessionCreateRuntimeRequest,
+    request: AiSessionDeferredCreateRuntimeRequest,
     binding: TmuxPendingRuntimeBinding,
     locator: AiSessionTmuxLocator
 ): boolean {
     return ambiguous.provider === binding.provider
         && ambiguous.workspaceScopeIdentity === binding.workspaceScopeIdentity
+        && ambiguous.workspaceNavigationIdentity === binding.workspaceNavigationIdentity
+        && JSON.stringify(ambiguous.workspaceRootHostPaths.slice().sort())
+            === JSON.stringify(binding.workspaceRootHostPaths.slice().sort())
         && ambiguous.pendingId === binding.pendingId
         && ambiguous.cwd === binding.cwd
         && ambiguous.createdAt === binding.createdAt
         && ambiguous.title === binding.title
-        && (ambiguous.markerPath || '') === (request.launch.markerPath || '')
+        && (ambiguous.markerPath || '') === request.launchMarkerPath
         && ambiguous.layout === binding.layout
         && locatorsEqual(ambiguous.locator, locator)
         && ambiguous.excludedSessionIds.length === binding.excludedSessionIds.length
         && ambiguous.excludedSessionIds.every((value, index) => value === binding.excludedSessionIds[index])
-        && ambiguous.requestFingerprint === pendingRequestFingerprint(request);
+        && (isLegacyPendingRequestFingerprint(ambiguous.requestFingerprint)
+            || ambiguous.requestFingerprint === pendingRequestFingerprint(request));
+}
+
+function isLegacyPendingRequestFingerprint(value: string): boolean {
+    return /^[a-f0-9]{64}$/.test(value);
 }
 
 function isProvenNoCreate(error: unknown): boolean {

--- a/src/aiSessions/tmuxRuntimeBindingStore.ts
+++ b/src/aiSessions/tmuxRuntimeBindingStore.ts
@@ -1193,7 +1193,7 @@ function validateAmbiguousRecord(value: unknown): TmuxAmbiguousRuntimeBinding | 
             || (record.markerPath !== undefined
                 && !isBoundedString(record.markerPath, MAX_PATH_LENGTH))
             || typeof record.requestFingerprint !== 'string'
-            || !/^[a-f0-9]{64}$/.test(record.requestFingerprint)))) {
+            || !/^(?:v3:)?[a-f0-9]{64}$/.test(record.requestFingerprint)))) {
         return null;
     }
     return {

--- a/src/aiSessions/types.ts
+++ b/src/aiSessions/types.ts
@@ -10,6 +10,7 @@ import type {
     AiSessionLifecycleSignal,
 } from './lifecycle';
 import type { DashboardWorkspaceSearchCatalog } from '../webview/dashboardViewModel';
+import type { AiSessionLaunchOptions } from './launchOptions';
 import type { AiSessionLaunchSpec } from './launchSpec';
 import type { AiSessionRuntimeBackendId, AiSessionRuntimeIdentity, AiSessionTmuxLayout } from './runtimeTypes';
 
@@ -103,8 +104,18 @@ export interface AiSessionProviderDefinition {
     projectSessionsKey: 'codexSessions' | 'kimiSessions' | 'claudeSessions';
     projectSessionsUnavailableKey: 'codexSessionsUnavailable' | 'kimiSessionsUnavailable' | 'claudeSessionsUnavailable';
     terminalCwdFields: Array<'cwd' | 'workDir'>;
-    buildResumeLaunchSpec: (sessionId: string, scope: AiSessionDirectoryScope, markerPath: string) => AiSessionLaunchSpec;
-    buildNewSessionLaunchSpec: (scope: AiSessionDirectoryScope, title: string, markerPath: string) => AiSessionLaunchSpec;
+    buildResumeLaunchSpec: (
+        sessionId: string,
+        scope: AiSessionDirectoryScope,
+        markerPath: string,
+        launchOptions: AiSessionLaunchOptions
+    ) => AiSessionLaunchSpec;
+    buildNewSessionLaunchSpec: (
+        scope: AiSessionDirectoryScope,
+        title: string,
+        markerPath: string,
+        launchOptions: AiSessionLaunchOptions
+    ) => AiSessionLaunchSpec;
     buildResumeCommand: (sessionId: string, scope: AiSessionDirectoryScope, markerPath: string) => string;
     buildNewSessionCommand: (scope: AiSessionDirectoryScope, title: string, markerPath: string) => string;
 }

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -51,6 +51,7 @@ import { getAiSessionTerminalCandidates } from './aiSessions/terminalCandidates'
 import { AiSessionReadCoordinator } from './aiSessions/readCoordinator';
 import AiSessionTerminalService from './aiSessions/terminalService';
 import AiSessionTerminalBindingStore from './aiSessions/terminalBindingStore';
+import { readAiSessionLaunchOptions } from './aiSessions/launchOptions';
 import { readAiSessionRuntimeConfiguration } from './aiSessions/runtimeConfiguration';
 import { DirectTerminalRuntimeBackend } from './aiSessions/directTerminalRuntimeBackend';
 import { AiSessionRuntimeCoordinator } from './aiSessions/runtimeCoordinator';
@@ -646,6 +647,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         pickWorkspaceRoot: workspace => pickAiSessionWorkspaceRoot(workspace, 'create'),
         pickProvider: pickAiSessionProvider,
         getProviderLabel: getAiSessionProviderLabel,
+        getLaunchOptions: () =>
+            readAiSessionLaunchOptions(getStewardConfiguration()),
         getProvider: getRegisteredAiSessionProvider,
         resolveWorkspaceDirectoryScope: (target, providerId, explicitRootId) =>
             aiSessionCommandController.resolveWorkspaceDirectoryScope(
@@ -773,6 +776,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     });
     const aiSessionResumeController = new AiSessionResumeController<vscode.Terminal>({
         getWorkspaceTarget: getCurrentWorkspaceActionTarget,
+        getLaunchOptions: () =>
+            readAiSessionLaunchOptions(getStewardConfiguration()),
         getProvider: getRegisteredAiSessionProvider,
         resolveWorkspaceDirectoryScope: (target, session, providerId, explicitRootId) =>
             aiSessionCommandController.resolveWorkspaceDirectoryScope(

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -648,7 +648,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         pickProvider: pickAiSessionProvider,
         getProviderLabel: getAiSessionProviderLabel,
         getLaunchOptions: () =>
-            readAiSessionLaunchOptions(getStewardConfiguration()),
+            readAiSessionLaunchOptions(vscode.workspace),
         getProvider: getRegisteredAiSessionProvider,
         resolveWorkspaceDirectoryScope: (target, providerId, explicitRootId) =>
             aiSessionCommandController.resolveWorkspaceDirectoryScope(
@@ -777,7 +777,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     const aiSessionResumeController = new AiSessionResumeController<vscode.Terminal>({
         getWorkspaceTarget: getCurrentWorkspaceActionTarget,
         getLaunchOptions: () =>
-            readAiSessionLaunchOptions(getStewardConfiguration()),
+            readAiSessionLaunchOptions(vscode.workspace),
         getProvider: getRegisteredAiSessionProvider,
         resolveWorkspaceDirectoryScope: (target, session, providerId, explicitRootId) =>
             aiSessionCommandController.resolveWorkspaceDirectoryScope(

--- a/tests/contract/aiSessions/runtimeBackends.test.js
+++ b/tests/contract/aiSessions/runtimeBackends.test.js
@@ -6,8 +6,35 @@ const {
     createDirectRuntimeHarness,
     createTmuxRuntimeHarness,
     defineRuntimeContract,
+    fakeCreateRequest,
     fakeResumeRequest,
 } = require('../../helpers/runtimeContract');
+
+function createLaunchProbe(request) {
+    const { launch, ...requestWithoutLaunch } = request;
+    let builds = 0;
+    let eagerReads = 0;
+    const probedRequest = {
+        ...requestWithoutLaunch,
+        launchMarkerPath: launch.markerPath || '',
+        createLaunchSpec: () => {
+            builds += 1;
+            return { ...launch, args: [...launch.args] };
+        },
+    };
+    Object.defineProperty(probedRequest, 'launch', {
+        enumerable: true,
+        get: () => {
+            eagerReads += 1;
+            return { ...launch, args: [...launch.args] };
+        },
+    });
+    return {
+        request: probedRequest,
+        builds: () => builds,
+        eagerReads: () => eagerReads,
+    };
+}
 
 // SESSION-DIRECT-BACKEND-001
 defineRuntimeContract({
@@ -173,3 +200,70 @@ test('RUNTIME-TMUX-PROJECT-FIRST-WINDOW-001 creates the first project runtime in
     assert.equal(newSessionOperations[0].windowName, runtime.tmux.windowName);
     assert.notEqual(harness.windows[0].windowName, 'project-steward');
 });
+
+for (const runtime of [{
+    label: 'Direct',
+    layout: 'direct',
+    createHarness: createDirectRuntimeHarness,
+}, {
+    label: 'tmux project',
+    layout: 'project',
+    createHarness: () => createTmuxRuntimeHarness('project'),
+}, {
+    label: 'tmux session',
+    layout: 'session',
+    createHarness: () => createTmuxRuntimeHarness('session'),
+}]) {
+    const invoke = (backend, method, request) => runtime.layout === 'direct'
+        ? backend[method](request)
+        : backend[method](request, runtime.layout);
+
+    test(`SESSION-AI-SESSION-YOLO-LAZY-005 [${runtime.label}] materializes at final provider dispatch only`, async () => {
+        const resumeHarness = runtime.createHarness();
+        const firstResume = createLaunchProbe(fakeResumeRequest(`lazy-backend-${runtime.layout}`));
+        await invoke(resumeHarness.backend, 'ensureResume', firstResume.request);
+        assert.equal(firstResume.builds(), 1);
+        assert.equal(firstResume.eagerReads(), 0);
+        const reusedResume = createLaunchProbe(fakeResumeRequest(`lazy-backend-${runtime.layout}`));
+        await invoke(resumeHarness.backend, 'ensureResume', reusedResume.request);
+        assert.equal(reusedResume.builds(), 0, 'runtime reuse must not build a provider spec');
+        assert.equal(reusedResume.eagerReads(), 0);
+
+        const pendingHarness = runtime.createHarness();
+        const firstPending = createLaunchProbe(fakeCreateRequest(`lazy-pending-${runtime.layout}`));
+        await invoke(pendingHarness.backend, 'ensurePending', firstPending.request);
+        assert.equal(firstPending.builds(), 1);
+        assert.equal(firstPending.eagerReads(), 0);
+        const reusedPending = createLaunchProbe(fakeCreateRequest(`lazy-pending-${runtime.layout}`));
+        await invoke(pendingHarness.backend, 'ensurePending', reusedPending.request);
+        assert.equal(reusedPending.builds(), 0, 'pending reuse must not build a provider spec');
+        assert.equal(reusedPending.eagerReads(), 0);
+
+        const collisionHarness = runtime.createHarness();
+        const collision = createLaunchProbe(fakeResumeRequest(`lazy-collision-${runtime.layout}`));
+        collisionHarness.installCollision(collision.request.identity);
+        await assert.rejects(
+            invoke(collisionHarness.backend, 'ensureResume', collision.request),
+            /conflict|multiple/i
+        );
+        assert.equal(collision.builds(), 0, 'collision preflight must not build a provider spec');
+        assert.equal(collision.eagerReads(), 0);
+
+        if (runtime.layout !== 'direct') {
+            const unavailableHarness = runtime.createHarness();
+            unavailableHarness.setUnavailable();
+            const unavailable = createLaunchProbe(fakeResumeRequest(
+                `lazy-unavailable-${runtime.layout}`
+            ));
+            await assert.rejects(
+                invoke(unavailableHarness.backend, 'ensureResume', unavailable.request),
+                error => error?.name === 'TmuxRuntimeUnavailableError'
+            );
+            assert.equal(
+                unavailable.builds(), 0,
+                'tmux availability preflight must not build a provider spec'
+            );
+            assert.equal(unavailable.eagerReads(), 0);
+        }
+    });
+}

--- a/tests/contract/aiSessions/runtimeCoordinator.test.js
+++ b/tests/contract/aiSessions/runtimeCoordinator.test.js
@@ -26,6 +26,39 @@ function createCoordinator(direct, tmux, overrides = {}) {
     });
 }
 
+function createLaunchProbe(request, buildLaunchSpec) {
+    const { launch, ...requestWithoutLaunch } = request;
+    let builds = 0;
+    let eagerReads = 0;
+    const probedRequest = {
+        ...requestWithoutLaunch,
+        launchMarkerPath: launch.markerPath || '',
+        createLaunchSpec: () => {
+            builds += 1;
+            return buildLaunchSpec
+                ? buildLaunchSpec(launch)
+                : { ...launch, args: [...launch.args] };
+        },
+    };
+    Object.defineProperty(probedRequest, 'launch', {
+        enumerable: true,
+        get: () => {
+            eagerReads += 1;
+            return { ...launch, args: [...launch.args] };
+        },
+    });
+    return {
+        request: probedRequest,
+        builds: () => builds,
+        eagerReads: () => eagerReads,
+    };
+}
+
+function assertLaunchProbe(probe, expectedBuilds) {
+    assert.equal(probe.eagerReads(), 0, 'identity/preflight must not read an eager launch value');
+    assert.equal(probe.builds(), expectedBuilds);
+}
+
 test('RUNTIME-RUNTIME-COORDINATOR-001 RUNTIME-AI-SESSION-RUNTIME-CONTROLLER-001 RUNTIME-RUNTIME-CONTROLLER-001 single-flights concurrent resume and create requests', async () => {
     const resumeGate = createDeferred();
     const pendingGate = createDeferred();
@@ -96,6 +129,170 @@ test('RUNTIME-RUNTIME-COORDINATOR-001 maps tmux unavailable choices without hidi
         createFakeRuntimeBackend('tmux', { refreshError: unexpected })
     );
     await assert.rejects(failing.resume(fakeResumeRequest('fail-closed')), error => error === unexpected);
+});
+
+test('SESSION-AI-SESSION-YOLO-LAZY-002 materializes resume specs once only on provider-dispatch branches', async () => {
+    const focusedDirect = createFakeRuntimeBackend('vscode');
+    focusedDirect.active.push(fakeRuntime('vscode', 'lazy-focused'));
+    const focused = createLaunchProbe(fakeResumeRequest('lazy-focused'));
+    assert.equal((await createCoordinator(
+        focusedDirect, createFakeRuntimeBackend('tmux')
+    ).resume(focused.request)).status, 'focused');
+    assertLaunchProbe(focused, 0);
+
+    const blockedDirect = createFakeRuntimeBackend('vscode');
+    blockedDirect.lifecycleBlockers.push(fakeRuntime('vscode', 'lazy-blocked', {
+        state: 'completed',
+    }));
+    const blocked = createLaunchProbe(fakeResumeRequest('lazy-blocked'));
+    assert.equal((await createCoordinator(
+        blockedDirect, createFakeRuntimeBackend('tmux')
+    ).resume(blocked.request)).status, 'blocked');
+    assertLaunchProbe(blocked, 0);
+
+    const conflictDirect = createFakeRuntimeBackend('vscode');
+    const conflictTmux = createFakeRuntimeBackend('tmux');
+    conflictDirect.active.push(fakeRuntime('vscode', 'lazy-conflict'));
+    conflictTmux.active.push(fakeRuntime('tmux', 'lazy-conflict', {
+        attached: false,
+        tmux: { layout: 'project', sessionName: 'managed', windowName: 'lazy-conflict' },
+    }));
+    const conflict = createLaunchProbe(fakeResumeRequest('lazy-conflict'));
+    assert.equal((await createCoordinator(
+        conflictDirect, conflictTmux
+    ).resume(conflict.request)).status, 'conflict');
+    assertLaunchProbe(conflict, 0);
+
+    for (const choice of ['cancel', 'settings']) {
+        const unavailable = new TmuxRuntimeUnavailableError('not-found', 'tmux unavailable');
+        const noDispatch = createLaunchProbe(fakeResumeRequest(`lazy-${choice}`));
+        const result = await createCoordinator(
+            createFakeRuntimeBackend('vscode'),
+            createFakeRuntimeBackend('tmux', { refreshError: unavailable }),
+            { chooseTmuxFallback: async () => choice }
+        ).resume(noDispatch.request);
+        assert.equal(result.status, choice === 'settings' ? 'settings' : 'cancelled');
+        assertLaunchProbe(noDispatch, 0);
+    }
+
+    const direct = createLaunchProbe(fakeResumeRequest('lazy-direct'));
+    assert.equal((await createCoordinator(
+        createFakeRuntimeBackend('vscode'),
+        createFakeRuntimeBackend('tmux'),
+        {
+            getConfiguration: () => ({
+                mode: 'vscode', tmuxLayout: 'project', tmuxPath: 'tmux',
+            }),
+        }
+    ).resume(direct.request)).status, 'started');
+    assertLaunchProbe(direct, 1);
+
+    const tmux = createLaunchProbe(fakeResumeRequest('lazy-tmux'));
+    assert.equal((await createCoordinator(
+        createFakeRuntimeBackend('vscode'), createFakeRuntimeBackend('tmux')
+    ).resume(tmux.request)).status, 'started');
+    assertLaunchProbe(tmux, 1);
+});
+
+test('SESSION-AI-SESSION-YOLO-LAZY-003 materializes create specs once only on provider-dispatch branches', async () => {
+    const focusedDirect = createFakeRuntimeBackend('vscode');
+    focusedDirect.pending.push(fakeRuntime('vscode', undefined, {
+        identity: workspaceIdentity({ pendingId: 'lazy-pending-focused' }),
+        state: 'pending',
+        createdAt: '2026-07-18T10:00:00.000Z',
+        excludedSessionIds: [],
+    }));
+    const focused = createLaunchProbe(fakeCreateRequest('lazy-pending-focused'));
+    assert.equal((await createCoordinator(
+        focusedDirect, createFakeRuntimeBackend('tmux')
+    ).create(focused.request)).status, 'focused');
+    assertLaunchProbe(focused, 0);
+
+    const conflictDirect = createFakeRuntimeBackend('vscode');
+    const conflictTmux = createFakeRuntimeBackend('tmux');
+    for (const [backend, runtimeBackend] of [
+        ['vscode', conflictDirect],
+        ['tmux', conflictTmux],
+    ]) {
+        runtimeBackend.pending.push(fakeRuntime(backend, undefined, {
+            identity: workspaceIdentity({ pendingId: 'lazy-pending-conflict' }),
+            state: 'pending',
+            createdAt: '2026-07-18T10:00:00.000Z',
+            excludedSessionIds: [],
+            ...(backend === 'tmux' ? {
+                attached: false,
+                tmux: {
+                    layout: 'project', sessionName: 'managed',
+                    windowName: 'lazy-pending-conflict',
+                },
+            } : {}),
+        }));
+    }
+    const conflict = createLaunchProbe(fakeCreateRequest('lazy-pending-conflict'));
+    assert.equal((await createCoordinator(
+        conflictDirect, conflictTmux
+    ).create(conflict.request)).status, 'conflict');
+    assertLaunchProbe(conflict, 0);
+
+    for (const choice of ['cancel', 'settings']) {
+        const unavailable = new TmuxRuntimeUnavailableError('not-found', 'tmux unavailable');
+        const noDispatch = createLaunchProbe(fakeCreateRequest(`lazy-pending-${choice}`));
+        const result = await createCoordinator(
+            createFakeRuntimeBackend('vscode'),
+            createFakeRuntimeBackend('tmux', { refreshError: unavailable }),
+            { chooseTmuxFallback: async () => choice }
+        ).create(noDispatch.request);
+        assert.equal(result.status, choice === 'settings' ? 'settings' : 'cancelled');
+        assertLaunchProbe(noDispatch, 0);
+    }
+
+    const direct = createLaunchProbe(fakeCreateRequest('lazy-pending-direct'));
+    assert.equal((await createCoordinator(
+        createFakeRuntimeBackend('vscode'),
+        createFakeRuntimeBackend('tmux'),
+        {
+            getConfiguration: () => ({
+                mode: 'vscode', tmuxLayout: 'project', tmuxPath: 'tmux',
+            }),
+        }
+    ).create(direct.request)).status, 'started');
+    assertLaunchProbe(direct, 1);
+
+    const tmux = createLaunchProbe(fakeCreateRequest('lazy-pending-tmux'));
+    assert.equal((await createCoordinator(
+        createFakeRuntimeBackend('vscode'), createFakeRuntimeBackend('tmux')
+    ).create(tmux.request)).status, 'started');
+    assertLaunchProbe(tmux, 1);
+});
+
+test('SESSION-AI-SESSION-YOLO-LAZY-004 reads changed launch configuration after a pending tmux fallback choice', async () => {
+    const fallbackChoice = createDeferred();
+    const unavailable = new TmuxRuntimeUnavailableError('not-found', 'tmux unavailable');
+    const direct = createFakeRuntimeBackend('vscode');
+    let yoloEnabled = false;
+    const launch = createLaunchProbe(fakeResumeRequest('lazy-live-fallback'), original => ({
+        ...original,
+        args: yoloEnabled
+            ? ['resume', '--dangerously-bypass-approvals-and-sandbox', 'lazy-live-fallback']
+            : ['resume', 'lazy-live-fallback'],
+    }));
+    const coordinator = createCoordinator(
+        direct,
+        createFakeRuntimeBackend('tmux', { refreshError: unavailable }),
+        { chooseTmuxFallback: async () => fallbackChoice.promise }
+    );
+
+    const pending = coordinator.resume(launch.request);
+    await new Promise(resolve => setImmediate(resolve));
+    assertLaunchProbe(launch, 0);
+    yoloEnabled = true;
+    fallbackChoice.resolve('direct');
+
+    assert.equal((await pending).status, 'started');
+    assertLaunchProbe(launch, 1);
+    assert.deepEqual(direct.launches[0].args, [
+        'resume', '--dangerously-bypass-approvals-and-sandbox', 'lazy-live-fallback',
+    ]);
 });
 
 test('RUNTIME-RUNTIME-COORDINATOR-001 promotes the unique pending backend and preserves conflicts', async () => {

--- a/tests/contract/aiSessions/runtimePrimitives.test.js
+++ b/tests/contract/aiSessions/runtimePrimitives.test.js
@@ -7,6 +7,7 @@ const test = require('node:test');
 const commandBuilders = require('../../../out/aiSessions/commandBuilders');
 const launchSpec = require('../../../out/aiSessions/launchSpec');
 const runtimeConfiguration = require('../../../out/aiSessions/runtimeConfiguration');
+const launchOptions = require('../../../out/aiSessions/launchOptions');
 const runtimeTypes = require('../../../out/aiSessions/runtimeTypes');
 const tmuxLayout = require('../../../out/aiSessions/tmuxLayout');
 
@@ -58,6 +59,33 @@ test('RUNTIME-RUNTIME-CONFIGURATION-001 reads supported settings and fails close
     assert.equal(layout.scope, 'machine');
     assert.equal(executable.scope, 'machine');
     assert.equal(mode.enum.includes('remote'), false);
+});
+
+test('SESSION-AI-SESSION-YOLO-CONFIGURATION-001 reads only literal true and declares a safe machine setting', () => {
+    assert.deepEqual(
+        launchOptions.readAiSessionLaunchOptions(configuration({})),
+        { yolo: false }
+    );
+    assert.deepEqual(
+        launchOptions.readAiSessionLaunchOptions(configuration({ aiSessionYoloMode: true })),
+        { yolo: true }
+    );
+    for (const invalid of [false, null, 1, 'true', 'false', {}]) {
+        assert.deepEqual(
+            launchOptions.readAiSessionLaunchOptions(configuration({ aiSessionYoloMode: invalid })),
+            { yolo: false }
+        );
+    }
+
+    const manifest = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../../../package.json'), 'utf8'));
+    const setting = manifest.contributes.configuration.properties[
+        'projectSteward.aiSessionYoloMode'
+    ];
+    assert.equal(setting.type, 'boolean');
+    assert.equal(setting.default, false);
+    assert.equal(setting.scope, 'machine');
+    assert.match(setting.description, /bypass/i);
+    assert.match(setting.description, /newly created and resumed/i);
 });
 
 test('RUNTIME-LAUNCH-SPEC-001 preserves argv boundaries and renders hostile values as inert shell data', () => {

--- a/tests/contract/aiSessions/runtimePrimitives.test.js
+++ b/tests/contract/aiSessions/runtimePrimitives.test.js
@@ -136,6 +136,23 @@ test('RUNTIME-LAUNCH-SPEC-001 preserves argv boundaries and renders hostile valu
         executable: 'claude', args: ['--name', 'Title'], cwd: '/work/app',
         markerPath: '/tmp/claude-new.done', windowsDirectShell: 'powershell',
     });
+    const yoloSpecs = [
+        commandBuilders.buildCodexNewSessionLaunchSpec(
+            directoryScope('/work/codex'), null, null, { yolo: true }
+        ),
+        commandBuilders.buildKimiResumeLaunchSpec(
+            'kimi-session', directoryScope('/work/kimi'), null, { yolo: true }
+        ),
+        commandBuilders.buildClaudeNewSessionLaunchSpec(
+            directoryScope('/work/claude'), null, null, { yolo: true }
+        ),
+    ];
+    for (const spec of yoloSpecs) {
+        const direct = launchSpec.serializeDirectLaunchCommand(spec, 'linux');
+        const tmux = launchSpec.serializeTmuxLaunchCommand(spec);
+        assert.match(direct, /--(?:dangerously-bypass-approvals-and-sandbox|yolo|dangerously-skip-permissions)/);
+        assert.match(tmux, /--(?:dangerously-bypass-approvals-and-sandbox|yolo|dangerously-skip-permissions)/);
+    }
 
     const hostile = `Prompt "quoted"; Set-Content C:\\tmp\\pwned 1; #`;
     const windows = launchSpec.serializeDirectLaunchCommand(

--- a/tests/contract/aiSessions/runtimePrimitives.test.js
+++ b/tests/contract/aiSessions/runtimePrimitives.test.js
@@ -15,6 +15,25 @@ function configuration(values) {
     return { get: (key, fallback) => Object.prototype.hasOwnProperty.call(values, key) ? values[key] : fallback };
 }
 
+function workspaceConfiguration(primaryValues, legacyValues = {}) {
+    const requestedSections = [];
+    return {
+        requestedSections,
+        get: (key, fallback) => {
+            if (Object.prototype.hasOwnProperty.call(primaryValues, key)) {
+                return primaryValues[key];
+            }
+            return Object.prototype.hasOwnProperty.call(legacyValues, key)
+                ? legacyValues[key]
+                : fallback;
+        },
+        getConfiguration: section => {
+            requestedSections.push(section);
+            return configuration(section === 'projectSteward' ? primaryValues : legacyValues);
+        },
+    };
+}
+
 function directoryScope(primaryCwd) {
     return {
         workspaceNavigationIdentity: 'navigation:fixture', workspaceScopeIdentity: 'scope:fixture',
@@ -63,19 +82,28 @@ test('RUNTIME-RUNTIME-CONFIGURATION-001 reads supported settings and fails close
 
 test('SESSION-AI-SESSION-YOLO-CONFIGURATION-001 reads only literal true and declares a safe machine setting', () => {
     assert.deepEqual(
-        launchOptions.readAiSessionLaunchOptions(configuration({})),
+        launchOptions.readAiSessionLaunchOptions(workspaceConfiguration({})),
         { yolo: false }
     );
     assert.deepEqual(
-        launchOptions.readAiSessionLaunchOptions(configuration({ aiSessionYoloMode: true })),
+        launchOptions.readAiSessionLaunchOptions(workspaceConfiguration({ aiSessionYoloMode: true })),
         { yolo: true }
     );
     for (const invalid of [false, null, 1, 'true', 'false', {}]) {
         assert.deepEqual(
-            launchOptions.readAiSessionLaunchOptions(configuration({ aiSessionYoloMode: invalid })),
+            launchOptions.readAiSessionLaunchOptions(workspaceConfiguration({
+                aiSessionYoloMode: invalid,
+            })),
             { yolo: false }
         );
     }
+    const legacyOnly = workspaceConfiguration({}, { aiSessionYoloMode: true });
+    assert.deepEqual(
+        launchOptions.readAiSessionLaunchOptions(legacyOnly),
+        { yolo: false },
+        'legacy dashboard user/workspace values must not enable YOLO'
+    );
+    assert.deepEqual(legacyOnly.requestedSections, ['projectSteward']);
 
     const manifest = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../../../package.json'), 'utf8'));
     const setting = manifest.contributes.configuration.properties[

--- a/tests/contract/aiSessions/sessionControllers.test.js
+++ b/tests/contract/aiSessions/sessionControllers.test.js
@@ -41,15 +41,20 @@ function makeWorkspaceTarget(sessions = []) {
 test('SESSION-AI-SESSION-CREATION-CONTROLLER-001 creates one tracked pending terminal from validated public input', async () => {
     const effects = [];
     const requests = [];
+    const receivedLaunchOptions = [];
     const controller = new AiSessionCreationController({
         isProviderId: value => value === 'codex',
         getWorkspaceTarget: id => id === 'p' ? makeWorkspaceTarget() : null,
         pickWorkspaceRoot: async () => undefined,
         pickProvider: async () => 'codex', getProviderLabel: () => 'Codex',
+        getLaunchOptions: () => ({ yolo: true }),
         getProvider: () => ({
             label: 'Codex',
             terminalNamePrefix: 'Codex',
-            buildNewSessionLaunchSpec: () => ({ executable: 'codex', args: ['--new'], cwd: '/work' }),
+            buildNewSessionLaunchSpec: (_scope, _title, _markerPath, launchOptions) => {
+                receivedLaunchOptions.push(launchOptions);
+                return { executable: 'codex', args: ['--new'], cwd: '/work' };
+            },
         }),
         resolveWorkspaceDirectoryScope: () => directoryScope,
         showInputBox: async () => '  Fixture title  ', showActiveTab: async id => effects.push(['tab', id]),
@@ -70,6 +75,7 @@ test('SESSION-AI-SESSION-CREATION-CONTROLLER-001 creates one tracked pending ter
     assert.equal(requests[0].identity.provider, 'codex');
     assert.equal(requests[0].identity.workspaceScopeIdentity, 'scope:fixture');
     assert.deepEqual(requests[0].excludedSessionIds, ['existing']);
+    assert.deepEqual(receivedLaunchOptions, [{ yolo: true }]);
     const before = effects.length;
     await controller.createSession('missing');
     assert.equal(effects.length, before + 1);
@@ -79,14 +85,19 @@ test('SESSION-AI-SESSION-CREATION-CONTROLLER-001 creates one tracked pending ter
 test('SESSION-AI-SESSION-RESUME-CONTROLLER-001 delegates scoped resume and reveals successful runtime results', async () => {
     const effects = [];
     const requests = [];
+    const receivedLaunchOptions = [];
     const controller = new AiSessionResumeController({
         getWorkspaceTarget: id => id === 'p'
             ? makeWorkspaceTarget([{ id: 's', name: 'Session', cwd: '/work' }])
             : null,
+        getLaunchOptions: () => ({ yolo: true }),
         getProvider: () => ({
             label: 'Codex',
             terminalEnvKey: 'CODEX',
-            buildResumeLaunchSpec: () => ({ executable: 'codex', args: ['resume', 's'], cwd: '/work' }),
+            buildResumeLaunchSpec: (_id, _scope, _markerPath, launchOptions) => {
+                receivedLaunchOptions.push(launchOptions);
+                return { executable: 'codex', args: ['resume', 's'], cwd: '/work' };
+            },
         }),
         resolveWorkspaceDirectoryScope: () => directoryScope,
         getTerminalName: () => 'Codex: Session', getMarkerPath: () => '/tmp/new', showWarningMessage: message => effects.push(message),
@@ -101,6 +112,7 @@ test('SESSION-AI-SESSION-RESUME-CONTROLLER-001 delegates scoped resume and revea
     assert.equal(requests.length, 1);
     assert.equal(requests[0].identity.sessionId, 's');
     assert.equal(requests[0].identity.workspaceScopeIdentity, 'scope:fixture');
+    assert.deepEqual(receivedLaunchOptions, [{ yolo: true }]);
 });
 
 test('SESSION-AI-SESSION-TERMINAL-COMMAND-CONTROLLER-001 ATTENTION-EXPLICIT-SESSION-CLOSE-001 focuses and closes only project-owned terminals', async () => {

--- a/tests/contract/aiSessions/sessionControllers.test.js
+++ b/tests/contract/aiSessions/sessionControllers.test.js
@@ -41,13 +41,18 @@ function makeWorkspaceTarget(sessions = []) {
 test('SESSION-AI-SESSION-CREATION-CONTROLLER-001 creates one tracked pending terminal from validated public input', async () => {
     const effects = [];
     const requests = [];
+    const launchSpecs = [];
     const receivedLaunchOptions = [];
+    let launchOptionReads = 0;
     const controller = new AiSessionCreationController({
         isProviderId: value => value === 'codex',
         getWorkspaceTarget: id => id === 'p' ? makeWorkspaceTarget() : null,
         pickWorkspaceRoot: async () => undefined,
         pickProvider: async () => 'codex', getProviderLabel: () => 'Codex',
-        getLaunchOptions: () => ({ yolo: true }),
+        getLaunchOptions: () => {
+            launchOptionReads += 1;
+            return { yolo: true };
+        },
         getProvider: () => ({
             label: 'Codex',
             terminalNamePrefix: 'Codex',
@@ -64,7 +69,13 @@ test('SESSION-AI-SESSION-CREATION-CONTROLLER-001 creates one tracked pending ter
         createPendingId: () => 'pending-fixture',
         announceStatus: async () => undefined,
         runtimeCoordinator: {
-            create: async request => { requests.push(request); return { status: 'started', backend: 'vscode' }; },
+            create: async request => {
+                requests.push(request);
+                if (typeof request.createLaunchSpec === 'function') {
+                    launchSpecs.push(request.createLaunchSpec());
+                }
+                return { status: 'started', backend: 'vscode' };
+            },
             getActive: () => [],
             getPending: () => [],
         },
@@ -75,6 +86,12 @@ test('SESSION-AI-SESSION-CREATION-CONTROLLER-001 creates one tracked pending ter
     assert.equal(requests[0].identity.provider, 'codex');
     assert.equal(requests[0].identity.workspaceScopeIdentity, 'scope:fixture');
     assert.deepEqual(requests[0].excludedSessionIds, ['existing']);
+    assert.equal(requests[0].launch, undefined);
+    assert.equal(typeof requests[0].createLaunchSpec, 'function');
+    assert.deepEqual(launchSpecs, [{
+        executable: 'codex', args: ['--new'], cwd: '/work',
+    }]);
+    assert.equal(launchOptionReads, 1);
     assert.deepEqual(receivedLaunchOptions, [{ yolo: true }]);
     const before = effects.length;
     await controller.createSession('missing');
@@ -85,12 +102,17 @@ test('SESSION-AI-SESSION-CREATION-CONTROLLER-001 creates one tracked pending ter
 test('SESSION-AI-SESSION-RESUME-CONTROLLER-001 delegates scoped resume and reveals successful runtime results', async () => {
     const effects = [];
     const requests = [];
+    const launchSpecs = [];
     const receivedLaunchOptions = [];
+    let launchOptionReads = 0;
     const controller = new AiSessionResumeController({
         getWorkspaceTarget: id => id === 'p'
             ? makeWorkspaceTarget([{ id: 's', name: 'Session', cwd: '/work' }])
             : null,
-        getLaunchOptions: () => ({ yolo: true }),
+        getLaunchOptions: () => {
+            launchOptionReads += 1;
+            return { yolo: true };
+        },
         getProvider: () => ({
             label: 'Codex',
             terminalEnvKey: 'CODEX',
@@ -104,7 +126,13 @@ test('SESSION-AI-SESSION-RESUME-CONTROLLER-001 delegates scoped resume and revea
         refresh: () => effects.push('refresh'), showActiveTab: id => effects.push(`tab:${id}`),
         announceStatus: async () => undefined,
         runtimeCoordinator: {
-            resume: async request => { requests.push(request); return { status: 'started', backend: 'vscode' }; },
+            resume: async request => {
+                requests.push(request);
+                if (typeof request.createLaunchSpec === 'function') {
+                    launchSpecs.push(request.createLaunchSpec());
+                }
+                return { status: 'started', backend: 'vscode' };
+            },
         },
     });
     await controller.resumeProjectSession('p', 'codex', 's');
@@ -112,7 +140,105 @@ test('SESSION-AI-SESSION-RESUME-CONTROLLER-001 delegates scoped resume and revea
     assert.equal(requests.length, 1);
     assert.equal(requests[0].identity.sessionId, 's');
     assert.equal(requests[0].identity.workspaceScopeIdentity, 'scope:fixture');
+    assert.equal(requests[0].launch, undefined);
+    assert.equal(typeof requests[0].createLaunchSpec, 'function');
+    assert.deepEqual(launchSpecs, [{
+        executable: 'codex', args: ['resume', 's'], cwd: '/work',
+    }]);
+    assert.equal(launchOptionReads, 1);
     assert.deepEqual(receivedLaunchOptions, [{ yolo: true }]);
+});
+
+test('SESSION-AI-SESSION-YOLO-LAZY-001 does not read options or build specs for non-dispatch controller results', async () => {
+    for (const status of ['focused', 'blocked', 'conflict', 'cancelled', 'settings']) {
+        let creationReads = 0;
+        let creationBuilds = 0;
+        let creationRequest;
+        const creation = new AiSessionCreationController({
+            isProviderId: value => value === 'codex',
+            getWorkspaceTarget: id => id === 'p' ? makeWorkspaceTarget() : null,
+            pickWorkspaceRoot: async () => undefined,
+            pickProvider: async () => 'codex',
+            getProviderLabel: () => 'Codex',
+            getLaunchOptions: () => {
+                creationReads += 1;
+                return { yolo: true };
+            },
+            getProvider: () => ({
+                label: 'Codex',
+                terminalNamePrefix: 'Codex',
+                buildNewSessionLaunchSpec: () => {
+                    creationBuilds += 1;
+                    return { executable: 'codex', args: [] };
+                },
+            }),
+            resolveWorkspaceDirectoryScope: () => directoryScope,
+            showInputBox: async () => '',
+            showActiveTab: async () => undefined,
+            showWarningMessage: async () => undefined,
+            refresh: () => undefined,
+            getExistingSessionIdsForCwd: () => [],
+            getPendingMarkerPath: () => '/tmp/pending',
+            scheduleNewSessionRefresh: () => undefined,
+            nowMs: () => 1000,
+            createPendingId: () => `pending-${status}`,
+            announceStatus: async () => undefined,
+            runtimeCoordinator: {
+                create: async request => {
+                    creationRequest = request;
+                    return { status };
+                },
+                getActive: () => [],
+                getPending: () => [],
+            },
+        });
+
+        await creation.createSession('p');
+
+        assert.equal(typeof creationRequest.createLaunchSpec, 'function');
+        assert.equal(creationReads, 0, `creation ${status} must not read configuration`);
+        assert.equal(creationBuilds, 0, `creation ${status} must not build a launch spec`);
+
+        let resumeReads = 0;
+        let resumeBuilds = 0;
+        let resumeRequest;
+        const resume = new AiSessionResumeController({
+            getWorkspaceTarget: id => id === 'p'
+                ? makeWorkspaceTarget([{ id: 's', name: 'Session', cwd: '/work' }])
+                : null,
+            getLaunchOptions: () => {
+                resumeReads += 1;
+                return { yolo: true };
+            },
+            getProvider: () => ({
+                label: 'Codex',
+                terminalEnvKey: 'CODEX',
+                buildResumeLaunchSpec: () => {
+                    resumeBuilds += 1;
+                    return { executable: 'codex', args: ['resume', 's'] };
+                },
+            }),
+            resolveWorkspaceDirectoryScope: () => directoryScope,
+            getTerminalName: () => 'Codex: Session',
+            getMarkerPath: () => '/tmp/resume',
+            showWarningMessage: () => undefined,
+            refresh: () => undefined,
+            showActiveTab: () => undefined,
+            announceStatus: async () => undefined,
+            runtimeCoordinator: {
+                resume: async request => {
+                    resumeRequest = request;
+                    return { status };
+                },
+            },
+        });
+
+        await resume.resumeProjectSession('p', 'codex', 's');
+
+        assert.equal(typeof resumeRequest.createLaunchSpec, 'function');
+        assert.equal(resumeReads, 0, `resume ${status} must not read configuration`);
+        assert.equal(resumeBuilds, 0, `resume ${status} must not build a launch spec`);
+    }
 });
 
 test('SESSION-AI-SESSION-TERMINAL-COMMAND-CONTROLLER-001 ATTENTION-EXPLICIT-SESSION-CLOSE-001 focuses and closes only project-owned terminals', async () => {

--- a/tests/helpers/runtimeContract.js
+++ b/tests/helpers/runtimeContract.js
@@ -108,7 +108,7 @@ function createFakeRuntimeBackend(backend, options = {}) {
     const fake = {
         active: [], pending: [], conflicts: [], lifecycleBlockers: [],
         refreshCalls: [], focusCalls: [], detachCalls: [], promoted: [], closed: [],
-        ensureResumeCalls: 0, ensurePendingCalls: 0,
+        launches: [], ensureResumeCalls: 0, ensurePendingCalls: 0,
     };
     fake.refresh = async force => {
         fake.refreshCalls.push(force);
@@ -128,6 +128,10 @@ function createFakeRuntimeBackend(backend, options = {}) {
         fake.ensureResumeCalls += 1;
         if (options.resumeGate) await options.resumeGate.promise;
         if (options.ensureError) throw options.ensureError;
+        const launch = typeof request.createLaunchSpec === 'function'
+            ? request.createLaunchSpec()
+            : request.launch;
+        fake.launches.push({ ...launch, args: [...launch.args] });
         const runtime = fakeRuntime(backend, request.identity.sessionId, backend === 'tmux' ? {
             attached: false,
             tmux: layout === 'project'
@@ -141,6 +145,10 @@ function createFakeRuntimeBackend(backend, options = {}) {
         fake.ensurePendingCalls += 1;
         if (options.pendingGate) await options.pendingGate.promise;
         if (options.ensureError) throw options.ensureError;
+        const launch = typeof request.createLaunchSpec === 'function'
+            ? request.createLaunchSpec()
+            : request.launch;
+        fake.launches.push({ ...launch, args: [...launch.args] });
         const runtime = fakeRuntime(backend, undefined, {
             identity: { ...request.identity }, state: 'pending',
             createdAt: request.createdAt,

--- a/tests/platform/windows/commandBuilders.test.js
+++ b/tests/platform/windows/commandBuilders.test.js
@@ -3,6 +3,7 @@
 const assert = require('node:assert/strict');
 const test = require('node:test');
 const commands = require('../../../out/aiSessions/commandBuilders');
+const { serializeDirectLaunchCommand } = require('../../../out/aiSessions/launchSpec');
 
 // SESSION-COMMAND-BUILDER-001
 
@@ -110,6 +111,21 @@ for (const provider of providers) {
         );
     });
 }
+
+test('SESSION-AI-SESSION-YOLO-LAUNCH-001 serializes provider flags as Windows CLI syntax', () => {
+    const yolo = { yolo: true };
+    const specs = [
+        commands.buildCodexNewSessionLaunchSpec(directoryScope(cwd), null, null, yolo),
+        commands.buildKimiNewSessionLaunchSpec(directoryScope(cwd), null, null, yolo),
+        commands.buildClaudeNewSessionLaunchSpec(directoryScope(cwd), null, null, yolo),
+    ];
+    const payloads = specs.map(spec =>
+        decodePowerShellPayload(serializeDirectLaunchCommand(spec, 'win32'))
+    );
+    assert.match(payloads[0], /codex --dangerously-bypass-approvals-and-sandbox/);
+    assert.match(payloads[1], /kimi .*--yolo/);
+    assert.match(payloads[2], /claude --dangerously-skip-permissions/);
+});
 
 test('SESSION-COMMAND-BUILDER-001 doubles PowerShell single quotes alongside ampersands and percents', () => {
     assert.equal(commands.quotePowerShellArg(value), "'Owner''s \"quoted\" & 100%'");

--- a/tests/unit/aiSessions/commandBuilders.test.js
+++ b/tests/unit/aiSessions/commandBuilders.test.js
@@ -118,6 +118,20 @@ test('SESSION-AI-SESSION-YOLO-LAUNCH-001 adds the exact provider flag to New and
     );
 });
 
+test('SESSION-AI-SESSION-YOLO-LAUNCH-002 rejects malformed truthy launch options at the flag boundary', () => {
+    const malformed = { yolo: 'true' };
+    for (const provider of providers) {
+        assert.deepEqual(
+            provider.resumeSpec(sessionId, directoryScope, markerPath, malformed),
+            provider.expectedResume
+        );
+        assert.deepEqual(
+            provider.newSpec(directoryScope, title, markerPath, malformed),
+            provider.expectedNew
+        );
+    }
+});
+
 test('SESSION-COMMAND-BUILDER-001 quotes PowerShell single quotes without interpolation', () => {
     assert.equal(commands.quotePowerShellArg("O'Brien & 100%"), "'O''Brien & 100%'");
 });

--- a/tests/unit/aiSessions/commandBuilders.test.js
+++ b/tests/unit/aiSessions/commandBuilders.test.js
@@ -90,6 +90,34 @@ for (const provider of providers) {
     });
 }
 
+test('SESSION-AI-SESSION-YOLO-LAUNCH-001 adds the exact provider flag to New and Resume argv', () => {
+    const yolo = { yolo: true };
+    assert.deepEqual(
+        commands.buildCodexNewSessionLaunchSpec(directoryScope, title, markerPath, yolo).args,
+        ['--dangerously-bypass-approvals-and-sandbox', '--cd', cwd, title]
+    );
+    assert.deepEqual(
+        commands.buildCodexResumeLaunchSpec(sessionId, directoryScope, markerPath, yolo).args,
+        ['resume', '--dangerously-bypass-approvals-and-sandbox', '--cd', cwd, sessionId]
+    );
+    assert.deepEqual(
+        commands.buildKimiNewSessionLaunchSpec(directoryScope, title, markerPath, yolo).args,
+        ['--work-dir', cwd, '--yolo', '--prompt', title]
+    );
+    assert.deepEqual(
+        commands.buildKimiResumeLaunchSpec(sessionId, directoryScope, markerPath, yolo).args,
+        ['--work-dir', cwd, '--yolo', '--resume', sessionId]
+    );
+    assert.deepEqual(
+        commands.buildClaudeNewSessionLaunchSpec(directoryScope, title, markerPath, yolo).args,
+        ['--dangerously-skip-permissions', '--name', title]
+    );
+    assert.deepEqual(
+        commands.buildClaudeResumeLaunchSpec(sessionId, directoryScope, markerPath, yolo).args,
+        ['--dangerously-skip-permissions', '--resume', sessionId]
+    );
+});
+
 test('SESSION-COMMAND-BUILDER-001 quotes PowerShell single quotes without interpolation', () => {
     assert.equal(commands.quotePowerShellArg("O'Brien & 100%"), "'O''Brien & 100%'");
 });


### PR DESCRIPTION
## Summary

- Add a machine-scoped configuration option controlling whether AI sessions launch in YOLO mode.
- Apply provider-specific YOLO arguments to new and resumed sessions across direct and tmux launches.
- Preserve stable session identity and legacy resume compatibility while deferring launch options until final dispatch.
- Add deterministic, safety, Windows, architecture, lint, and integration coverage.

## Verification

- npm run test:deterministic
- npm run test:safety
- Windows test suite: 29 passed, 0 failed
- lint baseline and architecture guards
- production extension build

## Release

- No version bump, tag, Release, or publishing workflow is included or requested.