### PR TITLE
docs: harden repository engineering skills

### DIFF
--- a/.codex/skills/fixing-regressions-with-ci/SKILL.md
+++ b/.codex/skills/fixing-regressions-with-ci/SKILL.md
@@ -35,6 +35,11 @@ Turn every confirmed regression into a CI-owned behavior before changing product
 6. **Verify GREEN**
    - Run the focused test, `npm run test:behavior-contracts`, the affected layered suite, and the relevant platform/environment gate.
    - Review the final diff and run the branch-level CI equivalent before push or PR.
+7. **Maintain audit currency**
+   - In every automated owner file, use literal behavior IDs for the behaviors it owns. After any implementation, owner, catalog, or audit change, run `npm run test:behavior-contracts`.
+   - Classify commits by changed paths and protected behavior, never by a subject prefix. Treat `.codex/skills/` and skill-owner tests as implementation paths: tests and owner-marker commits remain implementation evidence even with a `docs:` subject.
+   - Advance `audit.head` only after every implementation commit has a complete main-capability assignment with CI-reachable behavior ownership. Only genuine documentation-only commits may remain after the audit head.
+   - Treat audit-currency failures as immediate failures. A later audit commit cannot create missing RED evidence or retroactively make an implementation commit documentation-only.
 
 ## Automation Boundary
 

--- a/.codex/skills/installing-vscode-extensions-locally/SKILL.md
+++ b/.codex/skills/installing-vscode-extensions-locally/SKILL.md
@@ -17,26 +17,62 @@ Build and install the Project Steward extension that matches the current VS Code
 
 2. Identify the active VS Code host before installing:
    - inspect environment hints such as `REMOTE_CONTAINERS`, `CODESPACES`, `SSH_CONNECTION`, and `VSCODE_IPC_HOOK_CLI`
-   - run `which -a code` and `code --version` when manual CLI install may be needed
+   - validate `VSCODE_IPC_HOOK_CLI` before trusting it: an unset value or a path that is not a reachable Unix socket is stale `VSCODE_IPC_HOOK_CLI`, not evidence of an active host
+   - run `which -a code` and `code --version` only to inventory candidates; do not select the first `code` on `PATH`
    - prefer the repo install script if it already selects the correct local, SSH, or Dev Container CLI
    - if multiple `code` CLIs exist and the target host is unclear, ask before installing
 
-3. Run relevant checks first when the build is not already fresh:
+3. Use a deterministic remote fallback when the IPC socket is stale or the
+   target is a Dev Container/SSH workspace:
+   - discover the active `code-server` process, its executable or arguments,
+     and its active Server commit; do not guess a commit or reuse an arbitrary
+     `code` binary
+   - derive the remote CLI belonging to that active code-server installation
+     (for example by resolving the discovered Server installation and its
+     `remote-cli` sibling), then confirm its reported version/commit matches
+     the active Server commit
+   - discover any Server data and extensions directories from that active
+     process, CLI configuration, or environment. Do not hard-code a home
+     directory, Server root, extension directory, version, or commit.
+   - if the active process, matching CLI, or installed-extension location
+     cannot be discovered, stop short of claiming a verified remote install
+     and report the missing evidence
+
+4. Run relevant checks first when the build is not already fresh:
    - compile or test scripts used by the repo
    - packaging checks if the extension has release packaging tests
 
-4. Package and install through the repo's script when available.
+5. Package and route each extension through the host that owns it.
    - Example: `npm run install-local`
-   - If manual install is needed, use `code --install-extension <file>.vsix` or the environment-specific VS Code CLI in the repo docs.
+   - If manual installation is needed, use the discovered active Server CLI to
+     install the workspace extension into the active remote Server host, for
+     example: `<active-server-cli> --install-extension <workspace.vsix>`.
+     Never substitute a local or arbitrary PATH CLI for this step.
+   - A UI-only bridge belongs to the local UI host. When that host is
+     unreachable from the remote environment, report it as **packaged but not
+     installed** and provide the artifact and required local-host handoff; do
+     not treat the workspace extension's remote installation as bridge
+     installation.
 
-5. Distinguish extension host compatibility.
+6. Distinguish extension host compatibility.
    - Workspace extensions can install into Dev Containers/SSH workspaces.
    - UI-only extensions may need the local UI host and can fail from inside a remote extension host.
    - Report this as an environment limitation, not as a successful install.
 
-6. Verify the result:
-   - list installed extensions if practical
-   - record VSIX path(s), version, and command output status
+7. Verify installed bytes, not just command exit status:
+   - read the extension ID and version from the packaged VSIX manifest, then
+     use the **same active Server CLI** to list the installed extension ID and
+     version. A matching list entry alone is insufficient.
+   - locate the installed directory for that ID/version in the discovered
+     active Server extension location. Select representative files that exist
+     in both the VSIX and installed directory (the manifest plus the main
+     runtime bundle or another packaged executable asset).
+   - calculate SHA-256 hashes for those representative packaged and installed
+     files. Require every selected pair to match before reporting the main
+     workspace extension as installed from this build; retain the paths and
+     hashes in the report.
+   - a packaging success, a zero exit status, or an extension-list entry can
+     establish only packaging or attempted installation, never verified bytes.
    - if a script exits 0 with warnings, report warnings separately from failure
 
 ## Reporting
@@ -45,6 +81,10 @@ Always tell the user:
 - which VSIX artifact was built
 - which extension id/version was installed
 - which host received it, if known
+- whether `VSCODE_IPC_HOOK_CLI` was usable or stale, and how the active
+  code-server CLI and extension directory were discovered
+- representative VSIX-to-installed file hash evidence for the workspace
+  extension, or why that evidence could not be collected
 - which checks were run
 - any extension that was packaged but not installable in the current host
 
@@ -52,5 +92,9 @@ Always tell the user:
 
 - Do not assume a UI bridge extension can install in a Dev Container just because the main workspace extension can.
 - Do not use the first `code` binary on PATH when multiple hosts are present and the target host is unclear.
+- Do not use a stale IPC socket or an arbitrary VS Code Server commit as proof
+  of the active remote host.
+- Do not claim that the current VSIX was installed without ID/version and
+  representative hash comparison against the active Server installation.
 - Do not claim install success from packaging success alone.
 - Do not skip the repo's packaging script in favor of a generic VSIX command unless the repo lacks one.

--- a/.codex/skills/installing-vscode-extensions-locally/SKILL.md
+++ b/.codex/skills/installing-vscode-extensions-locally/SKILL.md
@@ -24,19 +24,24 @@ Build and install the Project Steward extension that matches the current VS Code
 
 3. Use a deterministic remote fallback when the IPC socket is stale or the
    target is a Dev Container/SSH workspace:
-   - discover the active `code-server` process, its executable or arguments,
+   - discover the active code-server process, its executable or arguments,
      and its active Server commit; do not guess a commit or reuse an arbitrary
      `code` binary
-   - derive the remote CLI belonging to that active code-server installation
-     (for example by resolving the discovered Server installation and its
-     `remote-cli` sibling), then confirm its reported version/commit matches
-     the active Server commit
    - discover any Server data and extensions directories from that active
      process, CLI configuration, or environment. Do not hard-code a home
      directory, Server root, extension directory, version, or commit.
-   - if the active process, matching CLI, or installed-extension location
-     cannot be discovered, stop short of claiming a verified remote install
-     and report the missing evidence
+   - from the active process or installation, discover a **socket-independent
+     extension-management entry point**. The installation's `bin/code-server`
+     command or an equivalent wrapper is common, but do not assume either a
+     fixed name or layout. Prove that the chosen entry point accepts extension
+     management without inheriting `VSCODE_IPC_HOOK_CLI`.
+   - use `remote-cli` only after replacing or validating its inherited hook
+     with a reachable socket and proving that request reaches the active host.
+     Matching `--version` output alone does not prove its socket target or make
+     `remote-cli` a stale-IPC fallback.
+   - if the active process, socket-independent entry point, Server data or
+     extensions directory cannot be discovered, stop short of claiming a
+     verified remote install and report the missing evidence
 
 4. Run relevant checks first when the build is not already fresh:
    - compile or test scripts used by the repo
@@ -44,10 +49,14 @@ Build and install the Project Steward extension that matches the current VS Code
 
 5. Package and route each extension through the host that owns it.
    - Example: `npm run install-local`
-   - If manual installation is needed, use the discovered active Server CLI to
-     install the workspace extension into the active remote Server host, for
-     example: `<active-server-cli> --install-extension <workspace.vsix>`.
-     Never substitute a local or arbitrary PATH CLI for this step.
+   - If manual installation is needed, use the discovered socket-independent
+     extension-management entry point to install the workspace extension into
+     the active remote Server host. Supply its discovered Server-data location
+     by that entry point's supported option or environment and explicitly
+     target the discovered extensions directory, for example:
+     `<verified-entry-point> --extensions-dir <active-extensions-dir>
+     --install-extension <workspace.vsix>`. Never substitute a local,
+     arbitrary PATH, or inherited-IPC CLI for this step.
    - A UI-only bridge belongs to the local UI host. When that host is
      unreachable from the remote environment, report it as **packaged but not
      installed** and provide the artifact and required local-host handoff; do
@@ -61,8 +70,9 @@ Build and install the Project Steward extension that matches the current VS Code
 
 7. Verify installed bytes, not just command exit status:
    - read the extension ID and version from the packaged VSIX manifest, then
-     use the **same active Server CLI** to list the installed extension ID and
-     version. A matching list entry alone is insufficient.
+     use the **same verified extension-management entry point** and the same
+     explicit discovered extensions directory to list the installed extension
+     ID and version. A matching list entry alone is insufficient.
    - locate the installed directory for that ID/version in the discovered
      active Server extension location. Select representative files that exist
      in both the VSIX and installed directory (the manifest plus the main
@@ -82,7 +92,8 @@ Always tell the user:
 - which extension id/version was installed
 - which host received it, if known
 - whether `VSCODE_IPC_HOOK_CLI` was usable or stale, and how the active
-  code-server CLI and extension directory were discovered
+  code-server process, socket-independent entry point, Server-data directory,
+  and extension directory were discovered
 - representative VSIX-to-installed file hash evidence for the workspace
   extension, or why that evidence could not be collected
 - which checks were run
@@ -94,6 +105,12 @@ Always tell the user:
 - Do not use the first `code` binary on PATH when multiple hosts are present and the target host is unclear.
 - Do not use a stale IPC socket or an arbitrary VS Code Server commit as proof
   of the active remote host.
+- Do not use `remote-cli` as the stale-IPC fallback merely because its version
+  matches; it is eligible only after its reachable socket is proven to reach
+  the active host.
+- Do not install through one entry point or extensions directory and list from
+  another; both commands must use the same verified entry point and explicit
+  discovered extensions directory.
 - Do not claim that the current VSIX was installed without ID/version and
   representative hash comparison against the active Server installation.
 - Do not claim install success from packaging success alone.

--- a/.codex/skills/installing-vscode-extensions-locally/SKILL.md
+++ b/.codex/skills/installing-vscode-extensions-locally/SKILL.md
@@ -35,6 +35,11 @@ Build and install the Project Steward extension that matches the current VS Code
      command or an equivalent wrapper is common, but do not assume either a
      fixed name or layout. Prove that the chosen entry point accepts extension
      management without inheriting `VSCODE_IPC_HOOK_CLI`.
+   - independently verify that the chosen extension-management entry point
+     reports a version/commit matching the active Server commit derived from
+     the running active code-server process. If it is a wrapper, resolve the
+     wrapper and verify that it invokes that active Server installation. This
+     installation-identity check is required in addition to IPC-host proof.
    - use `remote-cli` only after replacing or validating its inherited hook
      with a reachable socket and proving that request reaches the active host.
      Matching `--version` output alone does not prove its socket target or make

--- a/.codex/skills/resilient-webview-mutation-protocols/SKILL.md
+++ b/.codex/skills/resilient-webview-mutation-protocols/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: resilient-webview-mutation-protocols
+description: Use when VS Code Webviews submit Host-owned mutations or authoritative HTML replacement, mirrored persistence, stale acknowledgements, stuck pending UI, focus loss, or partial batch failures are in scope.
+---
+
+# Resilient Webview Mutation Protocols
+
+## Overview
+
+Treat a Webview mutation as one correlated lifecycle across protocol, Host
+persistence, authoritative DOM replacement, and UI recovery. Keep the Host
+authoritative; let the Webview submit intent and display only transient pending
+state until authoritative state is applied.
+
+## Core Invariants
+
+- Keep persistent state Host-authoritative. Never make optimistic Webview state
+  appear committed.
+- Define domain validity independently of current UI availability. Permit a
+  selected-but-unavailable provider when the domain permits it.
+- Correlate every request and settlement with a schema version, fresh
+  `requestId`, operation, and authoritative target identity.
+- Settle every recognized request exactly once. Clear success pending only
+  after its correlated authoritative replacement is applied; clear failure
+  pending only through its correlated failure.
+- Keep popup openness, focus, and scroll local to the Webview replacement.
+- Treat mirrored-state partial writes and composite-batch partial results as
+  explicit failures or partial outcomes, never full success.
+
+## Workflow
+
+Use this checklist for each Host-owned mutation:
+
+1. Define the versioned request, correlated settlements, authoritative target,
+   operation payload, and validation rules.
+2. Store the exact pending identity without changing persistent Webview state.
+3. Resolve identity and domain rules from Host state, not DOM labels,
+   availability, row indexes, or client snapshots.
+4. Route every Host validation, guard, persistence, execution, and refresh
+   outcome to exactly one settlement.
+5. Apply correlated authoritative HTML before clearing success pending; on a
+   correlated failure, clear only the matching pending entry.
+6. Capture and restore local popup, semantic focus, and scroll around DOM
+   replacement without sending them across the Host boundary.
+7. Snapshot, write, and repair all mirrored persistence records as one logical
+   mutation.
+8. Use composite identities for batch items, preserve explicit partial results,
+   refresh once, and settle aggregate pending once.
+9. Test correlation, every settlement path, replacement and focus recovery,
+   both mirrored writes and repair, composite collisions, partial results, and
+   accessible announcements.
+
+## Protocol Contract
+
+Require every request and settlement to carry:
+
+```ts
+type MutationEnvelope = {
+  version: 1;
+  requestId: string;
+  projectId: string;
+  operation: 'selectProviders' | 'archiveSessions';
+  payload: unknown;
+};
+```
+
+Generate a fresh `requestId` per intent. Use the authoritative target identity,
+such as `projectId`, plus exactly one operation-specific payload. Return the
+same schema version, `requestId`, target, and operation on success and failure.
+
+Validate the complete shape, bounds, and operation discriminant. Reject unknown
+fields when practical. Resolve targets and permissions from Host state. Never
+trust display labels, DOM data, or client-provided state as authority. Fail
+closed on malformed, wrong-target, stale, duplicate, or out-of-order messages.
+
+## Pending And Replacement Lifecycle
+
+- Key pending state by the full correlation identity. Do not let rapid input
+  overwrite an in-flight `requestId`; lock the control or represent later
+  intent with a separate correlated request.
+- Disable controls and announce pending without mutating persistent UI state.
+- Make every recognized Host request reach exactly one settlement, including
+  validation failures, guard failures, early returns, thrown errors,
+  persistence failures, and refresh failures.
+- Treat a standalone acknowledgement as progress, not success. Keep pending
+  until either a matching failure arrives or the matching authoritative
+  replacement has been validated and applied.
+- Before replacement, capture only local transient state: popup openness,
+  focused semantic item, and relevant scroll position. Apply authoritative
+  HTML first, then clear matching pending.
+- Restore popup state only if the matching control still exists and the pending
+  lifecycle permits reopening it. Restore focus by semantic key, never by a
+  detached node or row index. Keep transient popup state out of Host messages.
+- Ignore stale or duplicate settlements without changing current pending state.
+  On correlated failure, clear only the matching operation and leave or
+  restore the authoritative UI.
+
+## Mirrored Persistence
+
+Treat canonical and compatibility records as one logical write:
+
+1. Snapshot both authoritative records.
+2. Validate the complete intended state before writing.
+3. Write the canonical record, then the compatibility mirror.
+4. If either write fails, restore or repair both records from the snapshot when
+   possible.
+5. Report the mutation as failed, including repair failure without exposing
+   sensitive identity.
+6. Refresh from actual authoritative store state, not in-memory assumptions.
+
+A first-write failure, second-write failure, or repair failure is never full
+success. Ensure reload observes the same state the refreshed Webview renders.
+
+## Composite Batch Operations
+
+Use a composite identity such as `{ provider, sessionId }`; a bare `sessionId`
+is insufficient across providers. Bound and deduplicate inputs by the composite
+key, resolve each item against authoritative Host state, group execution by
+provider, and collect every group result. Refresh authoritative HTML once after
+all groups settle.
+
+Keep partial results explicit. Report bounded success and failure counts plus
+provider-safe summaries in logs and polite live-region announcements. Do not
+expose full session identifiers. Settle pending once for the aggregate request,
+not once per provider.
+
+## Verification Matrix
+
+| Exercise | Required assertion |
+|---|---|
+| Malformed, unknown, or wrong-target input | Reject closed; settle a recognized request exactly once |
+| Stale, duplicate, or out-of-order settlement | Preserve current pending and authoritative UI |
+| Every early return and thrown error | Emit one correlated failure; never leave stuck pending UI |
+| Success acknowledgement before replacement | Keep pending until correlated authoritative HTML is applied |
+| Replacement with open popup or focus | Keep popup state local; restore only an existing semantic target |
+| Selected provider currently unavailable | Accept it when domain rules allow selected-but-unavailable state |
+| First or second mirrored write fails | Repair from snapshot, report failure, and refresh actual store state |
+| Mirrored repair also fails | Expose failure safely and render observed authoritative state |
+| Duplicate session IDs across providers | Distinguish composite keys and execute the correct provider group |
+| Some batch groups fail | Preserve partial results, refresh once, and announce bounded counts |
+| Keyboard operation and status updates | Preserve focus-visible behavior and use a polite live region |
+
+## Common Mistakes
+
+| Mistake | Correction |
+|---|---|
+| Update persistent controls optimistically | Show pending only; render committed state from the Host |
+| Require every selected provider to be available | Enforce domain invariants, not transient availability |
+| Clear pending on a generic acknowledgement | Wait for correlated failure or applied authoritative replacement |
+| Send popup or focus state to the Host | Capture and restore it locally around replacement |
+| Reuse one mutable pending slot | Lock input or track each later intent with its own `requestId` |
+| Identify targets by label, row index, or bare session ID | Resolve Host identities and use semantic or composite keys |
+| Treat one successful mirrored write as success | Repair from the snapshot, fail the mutation, and refresh |
+| Collapse a partial batch into success or failure | Preserve per-group results and announce bounded totals |

--- a/.codex/skills/resilient-webview-mutation-protocols/agents/openai.yaml
+++ b/.codex/skills/resilient-webview-mutation-protocols/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Resilient Webview Mutation Protocols"
+  short_description: "Keep Host-owned Webview mutations consistent"
+  default_prompt: "Use $resilient-webview-mutation-protocols to design and verify this Host-owned Webview mutation."

--- a/.codex/skills/review-fix-commit-loop/SKILL.md
+++ b/.codex/skills/review-fix-commit-loop/SKILL.md
@@ -32,12 +32,34 @@ Turn review findings into focused fixes without losing traceability: inspect, fi
    - Add or tighten tests for every behavior bug found.
    - Preserve user changes in dirty worktrees.
 
-5. Verify after fixes, not before only.
-   - Run the smallest commands that prove the fix.
-   - Also run the branch-level checks needed for the PR.
+5. Reproduce and classify every failing check before deferring it.
+   - A failure is blocking until its result is reproduced and classified as a
+     behavior regression, test/harness problem, environment issue, or valid
+     audit-currency exception.
+   - Do not call a real harness or integration regression "audit currency".
+     That label requires matching audit-currency evidence, not an assertion or
+     a commit subject.
+   - Unexplained CI or harness failures block PR creation, push-for-review,
+     and merge.
+
+6. Verify after fixes, not before only.
+   - Run the smallest focused commands that prove each fix.
+   - Also run fresh branch-level checks needed for the PR; do not reuse results
+     from before the final fix.
    - Include `git diff --check` when code or docs changed.
 
-6. Commit intentionally.
+7. Complete final integration review after all task-level reviews.
+   - Run one final, read-only review of the complete merge-base-to-HEAD diff;
+     provide the merge base and HEAD to the reviewer and forbid checkout
+     mutations.
+   - Review cross-task protocols, shared state, partial failures, rollback
+     paths, accessibility announcements, and replacement lifecycles as well as
+     individual task changes.
+   - Critical and Important integration findings remain blocking until fixed.
+     After the final fix, run fresh focused and branch-level verification, then
+     re-review the complete merge-base-to-HEAD diff before PR creation or merge.
+
+8. Commit intentionally.
    - Stage explicit paths.
    - Use a commit message that names the fixed issue, e.g. `fix: tighten open projects update consistency`.
    - Re-check `git status -sb`.

--- a/docs/superpowers/plans/2026-07-25-repository-skill-hardening.md
+++ b/docs/superpowers/plans/2026-07-25-repository-skill-hardening.md
@@ -1,0 +1,408 @@
+# Repository Skill Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add one repository-local skill for reliable Host/Webview mutations and strengthen the regression, local-install, and review workflows with lessons proven by the multi-provider session work.
+
+**Architecture:** Keep protocol, pending lifecycle, authoritative DOM replacement, mirrored persistence, and composite batch rules together in one technique skill. Add only repository-specific audit, installation, and final-review rules to the existing skills that already own those workflows.
+
+**Tech Stack:** Markdown Agent Skills, YAML `agents/openai.yaml`, the skill-creator validation scripts, git worktrees, Node.js behavior-contract checks.
+
+## Global Constraints
+
+- Work only in `/home/hzcheng/projects/repos/vscode-dashboard/.worktree/skills-hardening` on `docs/skills-hardening`.
+- The approved design is `docs/superpowers/specs/2026-07-25-repository-skill-hardening-design.md`.
+- Add exactly one new skill: `resilient-webview-mutation-protocols`.
+- Strengthen exactly three existing skills: `fixing-regressions-with-ci`, `installing-vscode-extensions-locally`, and `review-fix-commit-loop`.
+- Use observed baseline omissions as the source of new guidance.
+- Complete RED, GREEN, validation, and review for one skill before editing the next skill.
+- Keep SKILL.md concise, imperative, and below 500 lines.
+- Add no runtime dependency and change no extension runtime source.
+- Do not change package versions, release notes, tags, artifacts, marketplace state, or publication scripts.
+- Own the guidance with `ARCH-REPOSITORY-SKILL-GUIDANCE-001` in a required-CI-reachable unit test.
+- Treat `.codex/skills/` and skill-owner tests as implementation paths for main-capability audit currency.
+- Stage explicit paths and keep each skill change in an intentional commit.
+
+---
+
+### Task 1: Register failing repository-skill guidance contracts
+
+**Files:**
+- Create: `tests/unit/tooling/repositorySkills.test.js`
+- Modify: `docs/testing/behavior-contracts.json`
+
+**Interfaces:**
+- Produces four focused tests sharing behavior ID
+  `ARCH-REPOSITORY-SKILL-GUIDANCE-001`.
+- Makes the guidance contract reachable through the existing
+  `tests/unit/**/*.test.js` Linux CI path.
+
+- [ ] **Step 1: Write four focused owner tests**
+
+Read each SKILL.md as UTF-8. Use separate tests for:
+
+1. versioned/correlated Host-authoritative Webview mutation and replacement,
+   mirrored persistence repair, composite identity, and partial result rules;
+2. path-based audit classification, literal owner IDs, behavior-contract
+   validation, and audit-head currency;
+3. stale `VSCODE_IPC_HOOK_CLI`, active `code-server`, host-specific
+   installation, and representative hash comparison; and
+4. merge-base-to-HEAD integration review plus blocking classification of
+   unexplained CI or harness failures.
+
+Every test title must contain
+`ARCH-REPOSITORY-SKILL-GUIDANCE-001`. Assert stable keywords or short semantic
+fragments, not complete paragraphs.
+
+- [ ] **Step 2: Register behavior ownership**
+
+Append one automated P0 architecture entry to
+`docs/testing/behavior-contracts.json`:
+
+```json
+{
+  "id": "ARCH-REPOSITORY-SKILL-GUIDANCE-001",
+  "domain": "architecture",
+  "title": "Repository skills retain validated engineering workflows",
+  "priority": "P0",
+  "status": "automated",
+  "owners": [
+    "tests/unit/tooling/repositorySkills.test.js"
+  ],
+  "evidence": [
+    ".codex/skills/resilient-webview-mutation-protocols/SKILL.md",
+    ".codex/skills/fixing-regressions-with-ci/SKILL.md",
+    ".codex/skills/installing-vscode-extensions-locally/SKILL.md",
+    ".codex/skills/review-fix-commit-loop/SKILL.md"
+  ]
+}
+```
+
+- [ ] **Step 3: Observe RED**
+
+Run:
+
+```bash
+node --test tests/unit/tooling/repositorySkills.test.js
+```
+
+Expected: all four focused tests fail because the new skill is missing and the
+three existing skills lack their required semantic anchors.
+
+`npm run test:behavior-contracts` is also expected to fail until the new
+evidence file exists. Do not weaken the catalog entry to make this temporary
+state green.
+
+- [ ] **Step 4: Commit the owner**
+
+```bash
+git add \
+  tests/unit/tooling/repositorySkills.test.js \
+  docs/testing/behavior-contracts.json
+git commit -m "test: register repository skill guidance"
+```
+
+---
+
+### Task 2: Add the resilient Webview mutation skill
+
+**Files:**
+- Create: `.codex/skills/resilient-webview-mutation-protocols/SKILL.md`
+- Create: `.codex/skills/resilient-webview-mutation-protocols/agents/openai.yaml`
+
+**Interfaces:**
+- Triggers when a VS Code Webview sends a Host-owned mutation, authoritative
+  HTML is replaced, state is mirrored for compatibility, or composite batch
+  work can partially fail.
+- Produces one checklist covering protocol correlation, exact pending
+  settlement, Host authority, DOM/focus restoration, persistence repair,
+  composite identities, partial results, and tests.
+
+- [ ] **Step 1: Preserve the RED evidence**
+
+Use the baseline Webview evaluation recorded in the design. Confirm its
+specific misses are: optimistic persistent UI, selected-provider availability
+as a false invariant, acknowledgement clearing before authoritative
+replacement, and transient popup state crossing the Host boundary.
+
+- [ ] **Step 2: Initialize the skill**
+
+Run the skill creator's `init_skill.py` with:
+
+```bash
+python /home/hzcheng/.codex/skills/.system/skill-creator/scripts/init_skill.py \
+  resilient-webview-mutation-protocols \
+  --path .codex/skills \
+  --interface 'display_name=Resilient Webview Mutation Protocols' \
+  --interface 'short_description=Keep Host-owned Webview mutations consistent' \
+  --interface 'default_prompt=Use $resilient-webview-mutation-protocols to design and verify this Host-owned Webview mutation.'
+```
+
+Do not create scripts, references, assets, examples, or placeholder files.
+
+- [ ] **Step 3: Write the minimal skill**
+
+Use this section order:
+
+1. `Overview`
+2. `Core Invariants`
+3. `Workflow`
+4. `Protocol Contract`
+5. `Pending And Replacement Lifecycle`
+6. `Mirrored Persistence`
+7. `Composite Batch Operations`
+8. `Verification Matrix`
+9. `Common Mistakes`
+
+The frontmatter description must start with `Use when` and mention VS Code
+Webviews, Host-owned mutations, authoritative HTML replacement, mirrored
+persistence, stale acknowledgements, stuck pending UI, focus loss, and partial
+batch failures without summarizing the workflow.
+
+- [ ] **Step 4: Validate GREEN**
+
+Run:
+
+```bash
+python /home/hzcheng/.codex/skills/.system/skill-creator/scripts/quick_validate.py \
+  .codex/skills/resilient-webview-mutation-protocols
+wc -l -w .codex/skills/resilient-webview-mutation-protocols/SKILL.md
+```
+
+Rerun the Webview scenario with only the new skill and verify it keeps the Host
+authoritative, settles pending only through correlated failure or applied
+authoritative replacement, keeps popup state local, permits unavailable
+selected providers when the domain permits it, and repairs partial persistence.
+
+Run only the Webview-focused owner test and verify it is now green while the
+three not-yet-edited skill tests remain red.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add \
+  .codex/skills/resilient-webview-mutation-protocols/SKILL.md \
+  .codex/skills/resilient-webview-mutation-protocols/agents/openai.yaml
+git commit -m "docs: add resilient webview mutation skill"
+```
+
+---
+
+### Task 3: Make behavior-audit currency explicit
+
+**Files:**
+- Modify: `.codex/skills/fixing-regressions-with-ci/SKILL.md`
+- Modify only if stale: `.codex/skills/fixing-regressions-with-ci/agents/openai.yaml`
+
+**Interfaces:**
+- Extends the existing behavior ownership and CI reachability workflow with
+  commit classification and main-capability audit currency.
+
+- [ ] **Step 1: Preserve the RED evidence**
+
+Use the baseline audit evaluation recorded in the design. The current skill
+does not itself say that changed paths override a `docs:` subject, owner-marker
+tests are implementation evidence, or the audit head advances only after all
+implementation commits have CI-reachable ownership.
+
+- [ ] **Step 2: Add an audit-currency workflow phase**
+
+Add concise rules requiring:
+
+- literal behavior IDs in automated owner files;
+- `npm run test:behavior-contracts` after implementation, owner, catalog, or
+  audit changes;
+- path-and-behavior commit classification instead of subject-prefix
+  classification;
+- tests and owner markers to remain implementation commits;
+- audit-head advancement only after complete capability assignment and
+  CI-reachable ownership; and
+- only genuine documentation commits after the audit head.
+
+State that a later audit commit cannot create missing RED evidence.
+
+- [ ] **Step 3: Validate GREEN**
+
+Run the skill validator and rerun the audit scenario with the updated skill.
+Verify that the agent treats audit-currency failures as immediate failures and
+does not accept the disguised `docs:` implementation commit.
+
+Run the audit-focused owner test and verify it is green before proceeding.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .codex/skills/fixing-regressions-with-ci/SKILL.md
+git commit -m "docs: harden regression audit currency workflow"
+```
+
+---
+
+### Task 4: Harden remote VS Code installation verification
+
+**Files:**
+- Modify: `.codex/skills/installing-vscode-extensions-locally/SKILL.md`
+- Modify only if stale: `.codex/skills/installing-vscode-extensions-locally/agents/openai.yaml`
+
+**Interfaces:**
+- Extends local installation with stale IPC diagnosis, active Server CLI
+  selection, host-specific VSIX routing, and installed-byte verification.
+
+- [ ] **Step 1: Preserve the RED evidence**
+
+Use the baseline installation evaluation recorded in the design. It did not
+compare the packaged build with installed files, and the current skill does not
+specify stale IPC or active Server CLI selection.
+
+- [ ] **Step 2: Add the deterministic fallback**
+
+Require:
+
+- validation of `VSCODE_IPC_HOOK_CLI` before trusting it;
+- selection of the CLI belonging to the active VS Code Server commit;
+- installation of the workspace extension into that Server host;
+- explicit reporting when the UI-only bridge cannot be installed from the
+  remote host; and
+- verification by extension ID/version plus representative file hashes from
+  the VSIX and installed extension directory.
+
+Keep environment-specific paths discoverable rather than hard-coded.
+
+- [ ] **Step 3: Validate GREEN**
+
+Run the skill validator and rerun the stale-IPC Dev Container scenario. Verify
+that the result separates packaging from both host installations and requires
+hash evidence for the main extension.
+
+Run the installation-focused owner test and verify it is green before
+proceeding.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .codex/skills/installing-vscode-extensions-locally/SKILL.md
+git commit -m "docs: verify remote VS Code extension installs"
+```
+
+---
+
+### Task 5: Require whole-branch integration review
+
+**Files:**
+- Modify: `.codex/skills/review-fix-commit-loop/SKILL.md`
+- Modify only if stale: `.codex/skills/review-fix-commit-loop/agents/openai.yaml`
+
+**Interfaces:**
+- Extends task-level review with one merge-base-to-HEAD integration review and
+  explicit classification of every failing check.
+
+- [ ] **Step 1: Preserve the RED evidence**
+
+Use the baseline review evaluation recorded in the design. The current skill
+does not explicitly make whole-branch integration review mandatory or forbid
+deferring a real harness regression as audit currency.
+
+- [ ] **Step 2: Add final integration and failure-classification gates**
+
+Require:
+
+- one final read-only review of the entire merge-base-to-HEAD diff;
+- explicit attention to cross-task protocols, shared state, partial failure,
+  rollback, accessibility announcements, and replacement lifecycles;
+- reproduction and classification of every failing check;
+- no audit-currency label without matching audit-currency evidence; and
+- fresh focused plus branch-level verification after the final fix.
+
+- [ ] **Step 3: Validate GREEN**
+
+Run the skill validator and rerun the nine-task integration scenario. Verify
+that the agent blocks PR creation on unexplained CI failures and requires the
+whole-branch review after task-level reviews.
+
+Run the review-focused owner test and then the complete owner file. All four
+tests must be green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .codex/skills/review-fix-commit-loop/SKILL.md
+git commit -m "docs: require final integration review"
+```
+
+---
+
+### Task 6: Audit, validate, and review the complete skill set
+
+**Files:**
+- Verify: `.codex/skills/*/SKILL.md`
+- Verify: `.codex/skills/*/agents/openai.yaml`
+- Modify: `docs/testing/main-capability-coverage.json`
+- Verify: `docs/superpowers/specs/2026-07-25-repository-skill-hardening-design.md`
+- Verify: `docs/superpowers/plans/2026-07-25-repository-skill-hardening.md`
+
+- [ ] **Step 1: Update main-capability audit currency**
+
+Collect every commit after the current audit head. For each commit that changes
+`.codex/skills/`, `tests/`, or `docs/testing/behavior-contracts.json`:
+
+- assign its full hash to `MAIN-REGRESSION-CI-CURRENCY`;
+- add `ARCH-REPOSITORY-SKILL-GUIDANCE-001` to that capability's behaviors; and
+- advance `audit.head` to the last implementation commit.
+
+Do not add the design/plan commits to `ignoredDocumentationCommits`; unassigned
+`docs/` paths are already treated as documentation. Commit the manifest-only
+audit update:
+
+```bash
+git add docs/testing/main-capability-coverage.json
+git commit -m "docs: audit repository skill guidance"
+```
+
+- [ ] **Step 2: Run all skill validators**
+
+```bash
+validator=/home/hzcheng/.codex/skills/.system/skill-creator/scripts/quick_validate.py
+for skill_dir in .codex/skills/*; do
+  python "$validator" "$skill_dir"
+done
+```
+
+- [ ] **Step 3: Run repository checks**
+
+```bash
+node --test tests/unit/tooling/repositorySkills.test.js
+npm run test:behavior-contracts
+git diff --check origin/main...HEAD
+```
+
+- [ ] **Step 4: Audit scope**
+
+Confirm:
+
+```bash
+git diff --name-only origin/main...HEAD
+git status -sb
+```
+
+The changed paths must be limited to the four skills, their owner and behavior
+catalog, the main-capability audit manifest, and the approved design and plan.
+No package version, release, runtime, artifact, or publication path may appear.
+
+- [ ] **Step 5: Request whole-branch review**
+
+Give a read-only reviewer the merge base, branch head, approved design, plan,
+and full diff. Fix every Critical or Important finding, rerun covering checks,
+and re-review before push.
+
+- [ ] **Step 6: Repair audit currency after review fixes**
+
+If review produces another implementation commit, add its full hash to the
+capability, move `audit.head` to it, commit a new manifest-only audit update,
+and rerun the complete repository checks.
+
+- [ ] **Step 7: Publish and merge**
+
+Push `docs/skills-hardening`, create a ready PR targeting `main`, wait for all
+required checks, merge with the repository's normal merge-commit strategy,
+delete the remote branch, and verify `origin/main` contains the merge. Do not
+publish a version.

--- a/docs/superpowers/plans/2026-07-25-repository-skill-hardening.md
+++ b/docs/superpowers/plans/2026-07-25-repository-skill-hardening.md
@@ -43,7 +43,7 @@ Read each SKILL.md as UTF-8. Use separate tests for:
 
 1. versioned/correlated Host-authoritative Webview mutation and replacement,
    mirrored persistence repair, composite identity, and partial result rules;
-2. path-based audit classification, literal owner IDs, behavior-contract
+2. path-based audit classification, literal behavior IDs, behavior-contract
    validation, and audit-head currency;
 3. stale `VSCODE_IPC_HOOK_CLI`, active `code-server`, host-specific
    installation, and representative hash comparison; and

--- a/docs/superpowers/specs/2026-07-25-repository-skill-hardening-design.md
+++ b/docs/superpowers/specs/2026-07-25-repository-skill-hardening-design.md
@@ -1,0 +1,261 @@
+# Repository Skill Hardening Design
+
+## Goal
+
+Capture the reusable engineering lessons from the multi-provider AI session
+work as repository-local skills without turning one feature's history into
+project folklore.
+
+The change adds one reusable Webview mutation skill and strengthens three
+existing workflow skills. It does not change extension runtime code, package
+versions, release notes, tags, artifacts, or marketplace state.
+
+## Skill portfolio
+
+Use one new technique skill rather than separate skills for request
+correlation, DOM replacement, mirrored persistence, and composite batch
+operations. Those concerns fail together at the same Host/Webview mutation
+boundary and should be reviewed as one lifecycle.
+
+Create:
+
+- `.codex/skills/resilient-webview-mutation-protocols/`
+
+Strengthen:
+
+- `.codex/skills/fixing-regressions-with-ci/`
+- `.codex/skills/installing-vscode-extensions-locally/`
+- `.codex/skills/review-fix-commit-loop/`
+
+Keep multi-provider list ordering and Sharingan rendering out of the new skill.
+They are feature decisions, not generally reusable protocol rules.
+
+Own the repository guidance with one CI-reachable behavior:
+
+- `ARCH-REPOSITORY-SKILL-GUIDANCE-001`
+- owner: `tests/unit/tooling/repositorySkills.test.js`
+
+The owner verifies the stable guidance contract for all four skills. External
+skill validation remains useful, but an absolute path under a developer's
+Codex installation is not a portable PR gate.
+
+## Baseline evaluation
+
+Read-only evaluations were run before editing the skills.
+
+The Webview protocol evaluation produced a strong design but still:
+
+- made persistent Webview state optimistic instead of Host-authoritative;
+- required selected providers to be available, which would reject a valid
+  selected-but-unavailable provider;
+- allowed an acknowledgement to clear pending before authoritative replacement
+  HTML was applied; and
+- sent transient popup state through the Host protocol instead of keeping it
+  local to DOM replacement.
+
+The regression workflow evaluation correctly classified implementation and
+audit commits only after reading repository testing documentation. The current
+skill itself does not explain audit-head currency, path-based documentation
+exemptions, or why a late owner marker cannot prove RED-before-fix.
+
+The local-install evaluation found the stale IPC and matching VS Code Server
+CLI fallback, but did not verify that installed bytes match the just-built
+VSIX. The current skill also does not make stale socket handling or the CLI
+selection procedure explicit.
+
+The review-loop evaluation required a final whole-branch integration review,
+but identified that the current skill does not require one and does not
+explicitly block on unexplained CI or harness failures.
+
+These observed gaps define the minimum additions. Do not add hypothetical
+rules that were not exercised by the feature or evaluations.
+
+## Resilient Webview mutation protocol
+
+The new skill applies when a VS Code Webview submits a Host-owned mutation,
+especially when the Host persists state, replaces authoritative HTML, or
+performs cross-scope batch work.
+
+### Protocol envelope
+
+Every request and settlement carries:
+
+- a schema `version`;
+- a fresh `requestId`;
+- the authoritative target identity such as `projectId`; and
+- one operation-specific payload.
+
+The Host validates the complete shape, rejects unknown fields when practical,
+resolves the target authoritatively, and never trusts DOM state or display
+labels as identity. Success and failure settlements use the same correlation
+fields. Stale, duplicate, malformed, or wrong-target settlements fail closed.
+
+### Host authority and pending lifecycle
+
+The Webview submits intent. It may disable controls and show pending feedback,
+but it does not commit persistent state optimistically.
+
+Every recognized request reaches exactly one settlement path, including
+validation failures, guard failures, thrown errors, persistence failures, and
+refresh failures. A success becomes visible only when the correlated
+authoritative replacement has been applied. A generic correlated failure
+clears only the matching pending operation and leaves or restores the
+authoritative UI.
+
+Fast repeated input must either be locked while pending or represented as
+explicitly correlated later intent. It must never overwrite the identity of an
+in-flight operation.
+
+### Authoritative replacement and focus
+
+Before replacing a card, capture only local transient state: popup openness,
+focused semantic item, and relevant scroll position. Apply the authoritative
+replacement first. Restore transient state only when the matching control
+still exists and no pending lifecycle forbids reopening it. Use semantic keys,
+not detached nodes or row indexes, for focus restoration.
+
+### Mirrored persistence
+
+When compatibility requires two state records:
+
+1. snapshot both authoritative records;
+2. validate the complete intended state;
+3. write the canonical record;
+4. write the compatibility mirror;
+5. if either write fails, restore or repair from the snapshot when possible;
+6. report the mutation as failed; and
+7. refresh from the actual authoritative store state.
+
+A partial write is not success. In-memory assumptions must not hide the state
+that will be observed after reload.
+
+### Composite batch operations
+
+Cross-provider or cross-scope identities use a composite key such as
+`{ provider, sessionId }`. The Host bounds and deduplicates items, resolves
+them against authoritative state, groups execution by provider, and refreshes
+once after all groups settle.
+
+Partial results remain explicit. UI announcements and logs report bounded
+counts and provider-safe summaries without exposing full session identifiers.
+Pending state settles once for the aggregate request.
+
+### Verification
+
+The skill requires mutation-sensitive coverage for:
+
+- malformed and wrong-target input;
+- stale, duplicate, and out-of-order settlements;
+- every early return and thrown error settling pending exactly once;
+- success waiting for correlated authoritative replacement;
+- replacement-time popup and focus restoration;
+- first-write and second-write persistence failures plus repair failure;
+- composite identity collisions, grouping, and partial results; and
+- keyboard, focus-visible, and polite live-region behavior.
+
+## Existing skill changes
+
+### Regression CI
+
+Add an audit-currency phase after behavior ownership:
+
+- classify commits by changed paths and behavior, never by subject prefix;
+- require automated owner files to literally reference their behavior IDs;
+- treat tests and owner-marker commits as implementation evidence, not
+  documentation exemptions;
+- run `npm run test:behavior-contracts` after every implementation or owner
+  change;
+- advance the main-capability audit head only after every implementation commit
+  is assigned to a capability with CI-reachable behavior ownership; and
+- permit only genuinely documentation-only commits after the audit head.
+
+An audit update cannot retroactively prove a missing RED observation.
+
+### Local VS Code installation
+
+Add a deterministic remote-host fallback:
+
+- treat a missing or unreachable `VSCODE_IPC_HOOK_CLI` socket as stale;
+- locate the CLI for the active VS Code Server commit instead of selecting an
+  arbitrary `code` from `PATH`;
+- install the workspace extension into the active remote Server host;
+- report a UI-only bridge as packaged but not installed when the local UI Host
+  is unreachable from the container; and
+- verify extension ID/version and compare representative packaged and installed
+  file hashes.
+
+Packaging success and extension-list output alone do not prove that the current
+build was installed.
+
+### Review/fix/commit loop
+
+Require a final review of the complete merge-base-to-HEAD diff after all
+task-level reviews. This review targets cross-task protocols, shared state,
+failure paths, accessibility announcements, and migration rollback.
+
+Every failing check must be reproduced and classified. A task agent may not
+defer a real harness or integration regression by calling it audit currency.
+Critical and Important findings remain blocking until fixed, freshly verified,
+and re-reviewed.
+
+## Behavior ownership and audit currency
+
+Add four focused tests to `tests/unit/tooling/repositorySkills.test.js`, one for
+each changed skill. Each test references
+`ARCH-REPOSITORY-SKILL-GUIDANCE-001` and checks durable semantic anchors rather
+than whole paragraphs:
+
+- the Webview skill requires versioned correlation, Host authority,
+  authoritative replacement, mirrored-state repair, composite identities, and
+  partial-result announcements;
+- the regression skill requires path-based classification, literal behavior
+  IDs, behavior-contract validation, and audit-head currency;
+- the installation skill requires stale IPC diagnosis, active `code-server`
+  selection, host-specific installation, and hash comparison; and
+- the review skill requires a merge-base-to-HEAD integration review and blocks
+  unexplained harness or CI failures.
+
+Register the behavior in `docs/testing/behavior-contracts.json` with the four
+SKILL.md files as evidence. The ordinary unit-test glob already reaches the
+owner through required Linux CI.
+
+Because `.codex/skills/` is not classified as a documentation path by
+`scripts/lib/mainCapabilityCoverage.js`, every skill and owner commit is an
+implementation commit for audit purposes. After all fixes are complete:
+
+1. assign those commits to `MAIN-REGRESSION-CI-CURRENCY`;
+2. add `ARCH-REPOSITORY-SKILL-GUIDANCE-001` to that capability;
+3. advance the audit head to the last implementation commit; and
+4. leave the manifest-only audit commit after that head.
+
+If review creates another implementation commit, repeat the audit update. Do
+not classify `.codex` changes by their `docs:` commit subjects.
+
+## Skill metadata
+
+The new skill includes `agents/openai.yaml` with only:
+
+- `interface.display_name`;
+- `interface.short_description`; and
+- `interface.default_prompt`, explicitly naming the skill.
+
+Existing metadata is regenerated only if its trigger or UI description becomes
+stale. SKILL.md files remain concise and keep detailed repository-specific
+commands in the workflow where they are needed.
+
+## Validation
+
+Before publication:
+
+1. observe each repository skill owner test fail before its corresponding
+   skill change;
+2. run the skill validator for every repository-local skill;
+3. rerun the baseline scenarios with the relevant updated skill loaded;
+4. inspect every evaluation for the observed omissions;
+5. run the focused owner, `npm run test:behavior-contracts`, and the affected
+   unit suite;
+6. update and revalidate main-capability audit currency;
+7. run `git diff --check`;
+8. perform a read-only whole-branch review; and
+9. confirm the diff contains no runtime, version, release, or publication
+   changes.

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -3152,5 +3152,21 @@
       "src/aiSessions/archiveController.ts",
       "scripts/run-ai-session-safety-checks.js"
     ]
+  },
+  {
+    "id": "ARCH-REPOSITORY-SKILL-GUIDANCE-001",
+    "domain": "architecture",
+    "title": "Repository skills retain validated engineering workflows",
+    "priority": "P0",
+    "status": "automated",
+    "owners": [
+      "tests/unit/tooling/repositorySkills.test.js"
+    ],
+    "evidence": [
+      ".codex/skills/resilient-webview-mutation-protocols/SKILL.md",
+      ".codex/skills/fixing-regressions-with-ci/SKILL.md",
+      ".codex/skills/installing-vscode-extensions-locally/SKILL.md",
+      ".codex/skills/review-fix-commit-loop/SKILL.md"
+    ]
   }
 ]

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "bfc9591242d7a1aaeef0287ffbe30af1cbb35beb",
+        "head": "645442a9985995ee1b4d43b9fdeeb1a06352b478",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -665,12 +665,21 @@
                 "56b80868dca5092bc87813d2c8a8e400a93de436",
                 "d51fa0d228e381dafd213b07d8be858281a8d24b",
                 "e756a78e1fabdec0d7a811260505952c9ff0ba5b",
-                "7ac45e6c37e9aa3a6d1cabcffa0fe5a789a157dd"
+                "7ac45e6c37e9aa3a6d1cabcffa0fe5a789a157dd",
+                "ee48bb24cf4ebe7b08313d55d1ff0667a2b4b28c",
+                "1680e921be772f48e227b26af5dd80c7c2cef168",
+                "c037fc2c4626b4f1e8c06af9cc936cfd990799ac",
+                "4a7aeb1aba4bd38f3cdf2d6b21018bbe6a8f76ad",
+                "c50efdd2d8be54dcdba97fde56462a7bb9758bae",
+                "b978f6ba6a420048487654d1410d4d628f3ae096",
+                "6e9c3dc61843d13eac8b6d3327c3e2e0d8b07b5e",
+                "645442a9985995ee1b4d43b9fdeeb1a06352b478"
             ],
             "behaviors": [
                 "ARCH-CI-QUALITY-GATE-001",
                 "ARCH-MAIN-CAPABILITY-COVERAGE-001",
                 "ARCH-MAIN-CAPABILITY-CURRENCY-001",
+                "ARCH-REPOSITORY-SKILL-GUIDANCE-001",
                 "RELEASE-VSIX-PACKAGING-001"
             ],
             "prGates": [

--- a/tests/unit/tooling/repositorySkills.test.js
+++ b/tests/unit/tooling/repositorySkills.test.js
@@ -40,6 +40,7 @@ test('ARCH-REPOSITORY-SKILL-GUIDANCE-001 keeps regression audits path-based and 
         ['literal behavior IDs', /literal behavior IDs/i],
         ['behavior-contract validation', /npm run test:behavior-contracts/i],
         ['audit-head currency', /audit.head/i],
+        ['skill and owner-test implementation paths', /\.codex\/skills\/[\s\S]*skill-owner tests[\s\S]*implementation paths/i],
     ]);
 });
 

--- a/tests/unit/tooling/repositorySkills.test.js
+++ b/tests/unit/tooling/repositorySkills.test.js
@@ -52,6 +52,8 @@ test('ARCH-REPOSITORY-SKILL-GUIDANCE-001 verifies remote extension installation 
         ['active code-server selection', /active code-server/i],
         ['host-specific workspace installation', /workspace extension[\s\S]*active remote Server host/i],
         ['socket-independent extension-management entry point', /socket-independent[\s\S]*extension-management entry point/i],
+        ['entry point matches active Server commit', /extension-management entry point[\s\S]*reports? (?:a )?version\/commit[\s\S]*active Server commit/i],
+        ['wrapper resolves to active Server installation', /wrapper[\s\S]*resolve[\s\S]*verify[\s\S]*active Server installation/i],
         ['remote-cli active IPC gate', /remote-cli[\s\S]*(?:only|unless)[\s\S]*reachable[\s\S]*active host/i],
         ['representative hash comparison', /representative[\s\S]*hash/i],
     ]);

--- a/tests/unit/tooling/repositorySkills.test.js
+++ b/tests/unit/tooling/repositorySkills.test.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const repositoryRoot = path.resolve(__dirname, '../../..');
+
+function readSkill(relativePath) {
+    return fs.readFileSync(path.join(repositoryRoot, relativePath), 'utf8');
+}
+
+function assertSkillMentions(source, requirements) {
+    const missing = requirements
+        .filter(([, expression]) => !expression.test(source))
+        .map(([description]) => description);
+    assert.deepEqual(missing, []);
+}
+
+test('ARCH-REPOSITORY-SKILL-GUIDANCE-001 keeps Host-owned Webview mutations correlated and recoverable', () => {
+    const skill = readSkill('.codex/skills/resilient-webview-mutation-protocols/SKILL.md');
+
+    assertSkillMentions(skill, [
+        ['schema version', /schema version/i],
+        ['request correlation', /requestId/],
+        ['Host authority', /Host.*authoritative/i],
+        ['authoritative replacement', /authoritative replacement/i],
+        ['mirrored persistence repair', /mirrored persistence[\s\S]*repair/i],
+        ['composite identity', /composite (?:identity|key)/i],
+        ['partial results', /partial results?/i],
+    ]);
+});
+
+test('ARCH-REPOSITORY-SKILL-GUIDANCE-001 keeps regression audits path-based and current', () => {
+    const skill = readSkill('.codex/skills/fixing-regressions-with-ci/SKILL.md');
+
+    assertSkillMentions(skill, [
+        ['path-based classification', /changed paths/i],
+        ['literal behavior IDs', /literal behavior IDs/i],
+        ['behavior-contract validation', /npm run test:behavior-contracts/i],
+        ['audit-head currency', /audit.head/i],
+    ]);
+});
+
+test('ARCH-REPOSITORY-SKILL-GUIDANCE-001 verifies remote extension installation on the active host', () => {
+    const skill = readSkill('.codex/skills/installing-vscode-extensions-locally/SKILL.md');
+
+    assertSkillMentions(skill, [
+        ['stale VSCODE_IPC_HOOK_CLI handling', /stale[\s\S]*VSCODE_IPC_HOOK_CLI/i],
+        ['active code-server selection', /active code-server/i],
+        ['host-specific workspace installation', /workspace extension[\s\S]*active remote Server host/i],
+        ['representative hash comparison', /representative[\s\S]*hash/i],
+    ]);
+});
+
+test('ARCH-REPOSITORY-SKILL-GUIDANCE-001 requires whole-branch review and blocks unexplained failures', () => {
+    const skill = readSkill('.codex/skills/review-fix-commit-loop/SKILL.md');
+
+    assertSkillMentions(skill, [
+        ['merge-base-to-HEAD integration review', /merge-base-to-HEAD/i],
+        ['unexplained CI or harness failures', /unexplained[\s\S]*(?:CI|harness)[\s\S]*failures/i],
+        ['blocking failure classification', /blocking[\s\S]*classif|classif[\s\S]*blocking/i],
+    ]);
+});

--- a/tests/unit/tooling/repositorySkills.test.js
+++ b/tests/unit/tooling/repositorySkills.test.js
@@ -51,6 +51,8 @@ test('ARCH-REPOSITORY-SKILL-GUIDANCE-001 verifies remote extension installation 
         ['stale VSCODE_IPC_HOOK_CLI handling', /stale[\s\S]*VSCODE_IPC_HOOK_CLI/i],
         ['active code-server selection', /active code-server/i],
         ['host-specific workspace installation', /workspace extension[\s\S]*active remote Server host/i],
+        ['socket-independent extension-management entry point', /socket-independent[\s\S]*extension-management entry point/i],
+        ['remote-cli active IPC gate', /remote-cli[\s\S]*(?:only|unless)[\s\S]*reachable[\s\S]*active host/i],
         ['representative hash comparison', /representative[\s\S]*hash/i],
     ]);
 });


### PR DESCRIPTION
## Summary
- add a repository-local skill for resilient Host/Webview mutation protocols
- harden regression audit currency, remote VS Code installation verification, and whole-branch review workflows
- add CI-owned guidance contracts and update main-capability audit currency

## Verification
- `npm run test:unit` — 188 passed
- `node --test tests/unit/tooling/repositorySkills.test.js` — 4 passed
- `npm run test:behavior-contracts` — 39 passed; catalog and capability audit passed
- all six repository skill folders pass `quick_validate.py`
- `git diff --check origin/main...HEAD`

No package version, release notes, tag, artifact, marketplace, or publication changes.