### PR TITLE
Fix conversation loading starvation

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -3482,6 +3482,19 @@
     ]
   },
   {
+    "id": "SESSION-CONVERSATION-LOADING-001",
+    "domain": "session",
+    "title": "Repeated dashboard reconciliation cannot starve an in-flight conversation outline",
+    "priority": "P0",
+    "status": "automated",
+    "owners": [
+      "tests/contract/aiSessions/conversationCoordinator.test.js"
+    ],
+    "evidence": [
+      "src/aiSessions/conversation/conversationHostController.ts"
+    ]
+  },
+  {
     "id": "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",
     "domain": "session",
     "title": "Codex, Kimi, and Claude normalize only visible user and assistant conversation content",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "bf0174af2b1ad9d80cad458cabca60e7407f5c62",
+        "head": "b41bf2baa668c1a44a25037035d4190bc95bd5d0",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -922,14 +922,16 @@
                 "b193a307ba6f58ac63ea1fa05d86df694d14cf44",
                 "2cbb52127b26cd424bc4efe4ff6bf844f8203359",
                 "6e0502b98be239953d740213f9e3da5e1fa5317a",
-                "96f2033d1a1e5427c733ce22ca0402d62011d342"
+                "96f2033d1a1e5427c733ce22ca0402d62011d342",
+                "b41bf2baa668c1a44a25037035d4190bc95bd5d0"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",
                 "WEBVIEW-AI-SESSION-CONVERSATION-OUTLINE-001",
                 "WEBVIEW-AI-SESSION-CONVERSATION-VIEWER-001",
                 "SECURITY-AI-SESSION-CONVERSATION-SOURCE-001",
-                "ACTIVE-SESSION-CONVERSATION-RESTORE-001"
+                "ACTIVE-SESSION-CONVERSATION-RESTORE-001",
+                "SESSION-CONVERSATION-LOADING-001"
             ],
             "prGates": [
                 "test:ci:linux"

--- a/src/aiSessions/conversation/conversationHostController.ts
+++ b/src/aiSessions/conversation/conversationHostController.ts
@@ -95,6 +95,8 @@ interface OutlineSubscriptionState {
     request: AiSessionConversationOutlineRequestMessage;
     readSequence: number;
     abortController: ConversationAbortController;
+    refreshInFlight?: Promise<boolean>;
+    refreshPending: boolean;
     subscription?: ConversationCoordinatorSubscription;
     outline?: ConversationOutline;
 }
@@ -153,6 +155,7 @@ export class ConversationHostController {
             request,
             readSequence: 0,
             abortController: new ConversationAbortController(),
+            refreshPending: false,
         };
         this.states.set(identity, state);
 
@@ -276,13 +279,38 @@ export class ConversationHostController {
         this.generationFloors.clear();
     }
 
-    private async refreshState(
+    private refreshState(
         state: OutlineSubscriptionState,
         initial: boolean
     ): Promise<boolean> {
         if (!this.isCurrent(state)) {
-            return false;
+            return Promise.resolve(false);
         }
+        if (state.refreshInFlight) {
+            state.refreshPending = true;
+            return state.refreshInFlight;
+        }
+        let refreshInFlight: Promise<boolean>;
+        refreshInFlight = this.performRefreshState(state, initial)
+            .finally(() => {
+                if (state.refreshInFlight !== refreshInFlight) {
+                    return;
+                }
+                state.refreshInFlight = undefined;
+                if (!state.refreshPending || !this.isCurrent(state)) {
+                    return;
+                }
+                state.refreshPending = false;
+                void this.refreshState(state, false);
+            });
+        state.refreshInFlight = refreshInFlight;
+        return refreshInFlight;
+    }
+
+    private async performRefreshState(
+        state: OutlineSubscriptionState,
+        initial: boolean
+    ): Promise<boolean> {
         state.abortController.abort();
         const abortController = new ConversationAbortController();
         state.abortController = abortController;
@@ -308,6 +336,9 @@ export class ConversationHostController {
                 state.request.sessionId,
                 target.executionState === 'stopped'
             );
+            if (state.outline && state.refreshPending) {
+                return true;
+            }
             const delivered = await this.publishIfCurrent(state, outline, readSequence);
             if (!delivered) {
                 if (initial && this.isCurrent(state, readSequence)) {
@@ -328,6 +359,9 @@ export class ConversationHostController {
             if (!this.resolveFocusedTarget(state.request)) {
                 this.removeStateIfCurrent(state);
                 return false;
+            }
+            if (state.outline && state.refreshPending) {
+                return true;
             }
             const delivered = await this.publishErrorIfCurrent(
                 state,
@@ -456,6 +490,7 @@ export class ConversationHostController {
             this.states.delete(state.identity);
         }
         state.abortController.abort();
+        state.refreshPending = false;
         if (state.subscription) {
             this.options.coordinator.releaseSubscription(state.subscription);
             state.subscription = undefined;

--- a/tests/contract/aiSessions/conversationCoordinator.test.js
+++ b/tests/contract/aiSessions/conversationCoordinator.test.js
@@ -790,6 +790,66 @@ test('SESSION-CONVERSATION-HOST-LIFECYCLE-002 a later reconcile suppresses an ol
     );
 });
 
+test('SESSION-CONVERSATION-LOADING-001 coalesces repeated reconciliation behind the in-flight initial outline', async t => {
+    const pendingReads = [];
+    const harness = createControllerHarness({
+        readOutline: async (_sessionId) => {
+            const pending = deferred();
+            pendingReads.push(pending);
+            return pending.promise;
+        },
+    });
+    t.after(() => harness.controller.dispose());
+
+    const initialRequest = harness.controller.handleOutline(
+        makeOutlineRequest()
+    );
+    await settle();
+    assert.equal(pendingReads.length, 1);
+
+    for (let refresh = 0; refresh < 10; refresh += 1) {
+        harness.controller.reconcile();
+    }
+    await settle();
+
+    assert.equal(
+        pendingReads.length,
+        1,
+        'reconcile must not restart and starve the initial outline'
+    );
+    pendingReads[0].resolve(makeOutline(
+        'codex',
+        'session-a',
+        'native-initial'
+    ));
+    await initialRequest;
+    await settle();
+
+    assert.equal(harness.publications.length, 1);
+    assert.equal(
+        harness.publications[0].payload.sourceRevision,
+        'r1'
+    );
+    assert.equal(
+        pendingReads.length,
+        2,
+        'the reconciliations must coalesce into one follow-up read'
+    );
+
+    pendingReads[1].resolve(makeOutline(
+        'codex',
+        'session-a',
+        'native-follow-up'
+    ));
+    await settle();
+
+    assert.equal(harness.publications.length, 2);
+    assert.equal(
+        harness.publications[1].payload.sourceRevision,
+        'r2'
+    );
+});
+
 test('SESSION-CONVERSATION-HOST-LIFECYCLE-001 reconcile retries a missing state watch without duplicating recovery', async t => {
     let watchAttempts = 0;
     let activeInvalidation;


### PR DESCRIPTION
## Summary
- coalesce repeated Active Session conversation refreshes behind one in-flight read
- allow the initial outline to publish instead of being repeatedly cancelled by dashboard reconciliation
- retain latest lifecycle-state behavior with one queued follow-up refresh
- add P0 regression coverage and main capability audit ownership

## Verification
- `npm run test:ci:linux`
- 1077 coverage tests passed
- 84 browser tests passed
- compile, behavior catalog, lint, remote sources, performance, safety, dashboard, architecture, packaging, and coverage gates passed

No version bump, tag, or release is included.