### PR TITLE
Fix remote session workspace host placement

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -2978,6 +2978,20 @@
     ]
   },
   {
+    "id": "ARCH-EXTENSION-HOST-PLACEMENT-001",
+    "domain": "architecture",
+    "title": "Session and filesystem ownership remains in the workspace extension host",
+    "priority": "P0",
+    "status": "automated",
+    "owners": [
+      "tests/unit/tooling/extensionHostPlacement.test.js"
+    ],
+    "evidence": [
+      "package.json",
+      "extensions/attention-ui-bridge/package.json"
+    ]
+  },
+  {
     "id": "OPEN-OTHER-WINDOWS-PRIVACY-001",
     "domain": "open-project",
     "title": "OTHER WINDOWS cards expose only privacy-bounded workspace summaries",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "846a5727a5d36b74f91aa20076eb51d8fe77fdf9",
+        "head": "a2c5c2d986c5fe2539a2f27369e5d9775dd4398b",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -52,7 +52,8 @@
             "994c0b5e608d015fa5fd566e475bfbc8b6857d73",
             "cd9e16d0f048928e904d7242f9c4fd5f34db2526",
             "f7a8438e0b189907048c7f652e0688d21e850fbb",
-            "a9618126564283fbf57d408541796ed41d6bdc68"
+            "a9618126564283fbf57d408541796ed41d6bdc68",
+            "024c6be9e460ac9ef3e80f40faef9488eb542fcb"
         ]
     },
     "capabilities": [
@@ -83,11 +84,13 @@
                 "4edd2ce42f4670ab1aaaf54c52fefe7b57f6909c",
                 "b150698874e8d16272975191d0411bd12642e122",
                 "c3ef7798505c31137311971ddfcb8f2fd0a3cee7",
-                "f895d42378fa3b2ab422bbf750558e045f57b533"
+                "f895d42378fa3b2ab422bbf750558e045f57b533",
+                "a2c5c2d986c5fe2539a2f27369e5d9775dd4398b"
             ],
             "behaviors": [
                 "PROJECT-ASSIGNMENT-001",
-                "SESSION-WORKSPACE-SCOPE-001"
+                "SESSION-WORKSPACE-SCOPE-001",
+                "ARCH-EXTENSION-HOST-PLACEMENT-001"
             ],
             "prGates": [
                 "test:deterministic:run"

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
         "vscode": "^1.51.0"
     },
     "extensionKind": [
-        "workspace",
-        "ui"
+        "workspace"
     ],
     "extensionDependencies": [
         "hzcheng.agent-pivot-attention-ui-bridge"

--- a/tests/unit/tooling/extensionHostPlacement.test.js
+++ b/tests/unit/tooling/extensionHostPlacement.test.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const test = require('node:test');
+
+const repositoryRoot = path.resolve(__dirname, '../../..');
+
+// ARCH-EXTENSION-HOST-PLACEMENT-001
+test('ARCH-EXTENSION-HOST-PLACEMENT-001 keeps filesystem/session ownership in the workspace host', () => {
+    const main = require(path.join(repositoryRoot, 'package.json'));
+    const bridge = require(path.join(
+        repositoryRoot,
+        'extensions',
+        'attention-ui-bridge',
+        'package.json'
+    ));
+
+    assert.deepEqual(
+        main.extensionKind,
+        ['workspace'],
+        'the main extension must not fall back to the UI host for remote workspaces'
+    );
+    assert.deepEqual(
+        bridge.extensionKind,
+        ['ui'],
+        'the companion bridge must remain in the desktop UI host'
+    );
+    assert.deepEqual(
+        main.extensionDependencies,
+        [`${bridge.publisher}.${bridge.name}`],
+        'the workspace extension must depend on the UI-host bridge'
+    );
+});


### PR DESCRIPTION
## Summary
- require the main Agent Pivot extension to run in the Workspace Extension Host
- keep the Attention UI Bridge UI-only and preserve the exact dependency
- add a P0 CI-owned regression contract and update capability audit coverage

## Root cause
When the main extension was absent from an SSH host, `extensionKind: ["workspace", "ui"]` allowed it to fall back to the desktop UI Host. The UI Host then treated the SSH workspace path as a local filesystem path and rejected session creation as unavailable.

## Verification
- `npm run test:ci:linux`
- final read-only integration review: no Critical, Important, or Minor findings

No version, tag, release, or Marketplace publication is included.