### PR TITLE
Improve session recovery and conversation access

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -3575,6 +3575,20 @@
     ]
   },
   {
+    "id": "CONVERSATION-OPEN-LATEST-001",
+    "domain": "session",
+    "title": "Open Current AI Session Conversation opens the viewer at the latest interaction of the focused or selected active session",
+    "priority": "P1",
+    "status": "automated",
+    "owners": [
+      "tests/integration/dashboard/conversationOpenLatest.test.js"
+    ],
+    "evidence": [
+      "src/aiSessions/conversation/composition.ts",
+      "src/dashboard.ts"
+    ]
+  },
+  {
     "id": "SECURITY-AI-SESSION-CONVERSATION-SOURCE-001",
     "domain": "session",
     "title": "Conversation history enforces canonical sources, opaque protocol tokens, and bounded private content",

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -1418,6 +1418,19 @@
     ]
   },
   {
+    "id": "RUNTIME-BOOTSTRAP-TMUX-RESTORE-DEFERRAL-001",
+    "domain": "runtime",
+    "title": "Slow tmux recovery does not block ready rendering and cannot publish after bootstrap disposal",
+    "priority": "P0",
+    "status": "automated",
+    "owners": [
+      "tests/contract/aiSessions/runtimeComposition.test.js"
+    ],
+    "evidence": [
+      "src/dashboard.ts"
+    ]
+  },
+  {
     "id": "RUNTIME-TMUX-WEBVIEW-EXPERIENCE-001",
     "domain": "runtime",
     "title": "Tmux Webview Experience behavior",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "adf59d17328ff629dece01d2dcb32953512995aa",
+        "head": "f11aca71aab64a08dddb0f1028809c0e0d52f0ab",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -678,7 +678,8 @@
                 "4225e99202541956076bd987af424dbf1ebb391a",
                 "973fd6b9f65c6011edea526b39c8524d605334ad",
                 "8bf513d4c673950b98efc1c30d7f288c9e79f196",
-                "8e7a9c2a3885d2a3e6a1ad783cc867fc2e70815c"
+                "8e7a9c2a3885d2a3e6a1ad783cc867fc2e70815c",
+                "f11aca71aab64a08dddb0f1028809c0e0d52f0ab"
             ],
             "behaviors": [
                 "RUNTIME-TMUX-BACKEND-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "f11aca71aab64a08dddb0f1028809c0e0d52f0ab",
+        "head": "c97615cee3b2629102643cf3f4560f98201e49d4",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -53,7 +53,8 @@
             "cd9e16d0f048928e904d7242f9c4fd5f34db2526",
             "f7a8438e0b189907048c7f652e0688d21e850fbb",
             "a9618126564283fbf57d408541796ed41d6bdc68",
-            "024c6be9e460ac9ef3e80f40faef9488eb542fcb"
+            "024c6be9e460ac9ef3e80f40faef9488eb542fcb",
+            "35a3e2e3a2bddc828277b30e94d5ecc5ce63a7aa"
         ]
     },
     "capabilities": [
@@ -679,7 +680,9 @@
                 "973fd6b9f65c6011edea526b39c8524d605334ad",
                 "8bf513d4c673950b98efc1c30d7f288c9e79f196",
                 "8e7a9c2a3885d2a3e6a1ad783cc867fc2e70815c",
-                "f11aca71aab64a08dddb0f1028809c0e0d52f0ab"
+                "f11aca71aab64a08dddb0f1028809c0e0d52f0ab",
+                "2bc4a8a330bc498ffafe5df92ed807b27e0b8e79",
+                "c97615cee3b2629102643cf3f4560f98201e49d4"
             ],
             "behaviors": [
                 "RUNTIME-TMUX-BACKEND-001",
@@ -747,6 +750,7 @@
                 "adf59d17328ff629dece01d2dcb32953512995aa"
             ],
             "behaviors": [
+                "RUNTIME-BOOTSTRAP-TMUX-RESTORE-DEFERRAL-001",
                 "RUNTIME-DASHBOARD-VISIBILITY-RESILIENCE-001",
                 "WEBVIEW-NONBLOCKING-FIRST-PAINT-001",
                 "WEBVIEW-TWO-STAGE-STARTUP-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "a732939522c647edf588f29c0f9cbc6e8fa87077",
+        "head": "adf59d17328ff629dece01d2dcb32953512995aa",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -742,7 +742,8 @@
                 "5eb992f8a150e1a40fdf485ceb0cb64363da7dbe",
                 "2f76bf86b88cda8d37f96fa77d9fdb17cb57a63f",
                 "cb99568a4be2da413d9c94a910701c6d94bea367",
-                "bf0174af2b1ad9d80cad458cabca60e7407f5c62"
+                "bf0174af2b1ad9d80cad458cabca60e7407f5c62",
+                "adf59d17328ff629dece01d2dcb32953512995aa"
             ],
             "behaviors": [
                 "RUNTIME-DASHBOARD-VISIBILITY-RESILIENCE-001",
@@ -934,7 +935,8 @@
                 "b41bf2baa668c1a44a25037035d4190bc95bd5d0",
                 "938905c3ad8bca127535c1188d5c65f2d0a21d1a",
                 "bb74e5abcaafcbf29d31361b95f4e647958169dd",
-                "846a5727a5d36b74f91aa20076eb51d8fe77fdf9"
+                "846a5727a5d36b74f91aa20076eb51d8fe77fdf9",
+                "571270717cff080db395df2ce0393624d1ed12ee"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",
@@ -944,7 +946,8 @@
                 "ACTIVE-SESSION-CONVERSATION-RESTORE-001",
                 "SESSION-CONVERSATION-LOADING-001",
                 "CONVERSATION-VIEWER-USER-EMPHASIS-001",
-                "WEBVIEW-STYLES-ARTIFACT-001"
+                "WEBVIEW-STYLES-ARTIFACT-001",
+                "CONVERSATION-OPEN-LATEST-001"
             ],
             "prGates": [
                 "test:ci:linux"

--- a/package.json
+++ b/package.json
@@ -89,6 +89,10 @@
             {
                 "command": "agentPivot.migrateSkillsToCentral",
                 "title": "Agent Pivot: Migrate Skills to Central Store"
+            },
+            {
+                "command": "agentPivot.openCurrentAiSessionConversation",
+                "title": "Agent Pivot: Open Current AI Session Conversation"
             }
         ],
         "keybindings": [

--- a/scripts/run-ai-session-safety-checks.js
+++ b/scripts/run-ai-session-safety-checks.js
@@ -5231,8 +5231,8 @@ function runWebviewContentChecks() {
     const terminalServiceSource = fs.readFileSync(path.join(__dirname, '..', 'src', 'aiSessions', 'terminalService.ts'), 'utf8');
     assert.ok(!terminalServiceSource.includes('AI_SESSION_PROVIDER_IDS'));
     assert.ok(dashboard.includes('const aiSessionProviders = aiSessionProviderRegistry.providers();'));
-    assert.ok(dashboard.includes('await aiSessionTerminalService.restorePersistedTerminals(vscode.window.terminals)'));
-    assert.ok(dashboard.includes('await tmuxRuntimeBackend.restoreAttachTerminals(vscode.window.terminals)'));
+    assert.ok(dashboard.includes('aiSessionTerminalService.restorePersistedTerminals(vscode.window.terminals)'));
+    assert.ok(dashboard.includes('tmuxRuntimeBackend.restoreAttachTerminals(vscode.window.terminals)'));
     assert.match(dashboard, /onDidOpenTerminal\(terminal => \{[\s\S]*?tmuxRuntimeBackend\.restoreAttachTerminals\(\[terminal\]\)/,
         'a terminal restored after extension activation must still recover its tmux attachment');
     assert.ok(dashboard.includes('new ActiveAiSessionTerminalHighlighter'));

--- a/scripts/run-ai-session-tmux-checks.js
+++ b/scripts/run-ai-session-tmux-checks.js
@@ -9663,16 +9663,29 @@ function runHostRuntimeCompositionChecks() {
     assert.ok(dashboardSource.includes("runtime.backend === 'tmux'"));
     assert.ok(dashboardSource.includes("runtime.attached ? 'attached' : 'detached'"));
     const directRestore = dashboardSource.indexOf(
-        'await aiSessionTerminalService.restorePersistedTerminals(vscode.window.terminals)'
+        'aiSessionTerminalService.restorePersistedTerminals(vscode.window.terminals)'
+    );
+    const tmuxRestoreTask = dashboardSource.indexOf(
+        'const tmuxRestoreTask = persistedInactiveRestoreTask.then'
     );
     const tmuxRestore = dashboardSource.indexOf(
-        'await tmuxRuntimeBackend.restoreAttachTerminals(vscode.window.terminals)'
+        'tmuxRuntimeBackend.restoreAttachTerminals(vscode.window.terminals)'
+    );
+    const tmuxRestoreBudgetWait = dashboardSource.indexOf(
+        'settlesWithinBudget(tmuxRestoreTask, AI_SESSION_TMUX_RESTORE_BUDGET_MS)'
     );
     const hydrationConstruction = dashboardSource.indexOf(
         'const workspaceSessionHydrationController = new WorkspaceSessionHydrationController'
     );
-    assert.ok(directRestore >= 0 && tmuxRestore > directRestore && hydrationConstruction > tmuxRestore,
-        'Direct and tmux attachment restoration must finish before first hydration is possible');
+    assert.ok(directRestore >= 0
+        && tmuxRestoreTask > directRestore
+        && tmuxRestore > tmuxRestoreTask
+        && tmuxRestoreBudgetWait > tmuxRestore
+        && hydrationConstruction > tmuxRestoreBudgetWait,
+    'Direct restoration and the bounded tmux wait must precede first hydration');
+    assert.ok(dashboardSource.includes(
+        "aiSessionDashboardController.refreshNow('tmux-bootstrap-restore')"
+    ), 'deferred tmux restoration must publish one incremental refresh path');
 }
 
 function runTmuxWebviewExperienceChecks() {

--- a/scripts/run-dashboard-webview-checks.js
+++ b/scripts/run-dashboard-webview-checks.js
@@ -3586,6 +3586,7 @@ async function runDashboardCommandRegistrationChecks() {
         'addFileToActiveTerminal',
         'insertPromptToActiveTerminal',
         'migrateSkillsToCentral',
+        'openCurrentAiSessionConversation',
     ];
     const registration = new DashboardCommandRegistration({
         registerCommand: (command, callback) => {
@@ -3611,6 +3612,7 @@ async function runDashboardCommandRegistrationChecks() {
         'agentPivot.addFileToActiveTerminal',
         'agentPivot.insertPromptToActiveTerminal',
         'agentPivot.migrateSkillsToCentral',
+        'agentPivot.openCurrentAiSessionConversation',
     ]);
     assert.deepStrictEqual(subscriptions.map(disposable => disposable.command), registered.map(([command]) => command));
 
@@ -3639,6 +3641,7 @@ async function runDashboardCommandRegistrationChecks() {
         'addFileToActiveTerminal',
         'insertPromptToActiveTerminal',
         'migrateSkillsToCentral',
+        'openCurrentAiSessionConversation',
     ]);
 
     registration.dispose();

--- a/scripts/run-open-project-safety-checks.js
+++ b/scripts/run-open-project-safety-checks.js
@@ -3289,8 +3289,11 @@ function runDashboardBridgeLifecycleChecks() {
         < startupWiring.indexOf('afterProjectMigrationSucceeded: async () => {'));
     assert.strictEqual((dashboard.match(/dashboardStartupController\.startUp\(\)/g) || []).length, 1,
         'activation must start one migration/pending-completion sequence');
-    assert.ok(dashboard.includes('await dashboardStartupController.startUp();'),
-        'activation must await the one ordered migration/pending-completion startup transaction');
+    assert.match(
+        dashboard,
+        /await timeBootstrapPhase\('startup-sequence', \(\) =>\s*dashboardStartupController\.startUp\(\)\);/,
+        'activation must await the one ordered migration/pending-completion startup transaction'
+    );
     assert.strictEqual(dashboard.includes('void dashboardStartupController.startUp();'), false);
     const saveAdapterWiring = dashboard.slice(
         dashboard.indexOf('const savedWorkspaceProjectAdapter = new SavedWorkspaceProjectAdapter({'),

--- a/src/aiSessions/conversation/composition.ts
+++ b/src/aiSessions/conversation/composition.ts
@@ -46,10 +46,22 @@ import {
     ConversationViewerOptions,
 } from './viewer';
 
+export interface ConversationSessionOpenTarget {
+    projectId: string;
+    provider: AiSessionProviderId;
+    sessionId: string;
+}
+
+export type OpenLatestConversationResult =
+    'opened' | 'unavailable' | 'empty' | 'unknownSession';
+
 export interface ConversationCapability {
     controller: ConversationHostController;
     viewer: ConversationViewerApi;
     availability: 'available' | 'unavailable';
+    openLatestConversation(
+        target: ConversationSessionOpenTarget
+    ): Promise<OpenLatestConversationResult>;
     reconcile(): Promise<void>;
     dispose(): void;
 }
@@ -215,6 +227,8 @@ function createAvailableConversationCapability(
         controller,
         viewer,
         availability: 'available',
+        openLatestConversation: target =>
+            openLatestConversation(options, coordinator, viewer, target),
         async reconcile(): Promise<void> {
             if (disposed) {
                 return;
@@ -280,6 +294,9 @@ function createUnavailableConversationCapability(
         controller,
         viewer,
         availability: 'unavailable',
+        async openLatestConversation(): Promise<OpenLatestConversationResult> {
+            return 'unavailable';
+        },
         async reconcile(): Promise<void> {
             if (!disposed) {
                 controller.reconcile();
@@ -294,6 +311,53 @@ function createUnavailableConversationCapability(
             viewer.dispose();
         },
     };
+}
+
+async function openLatestConversation(
+    options: ConversationCapabilityOptions,
+    coordinator: ConversationCoordinator,
+    viewer: ConversationViewerApi,
+    target: ConversationSessionOpenTarget
+): Promise<OpenLatestConversationResult> {
+    const authoritativeTarget = resolveExactTarget(options, target);
+    if (!authoritativeTarget) {
+        return 'unknownSession';
+    }
+    coordinator.setSessionStopped(
+        target.provider,
+        target.sessionId,
+        authoritativeTarget.executionState === 'stopped'
+    );
+    let outline;
+    try {
+        outline = await coordinator.readOutline(
+            target.provider,
+            target.sessionId
+        );
+    } catch (_error) {
+        return 'unavailable';
+    }
+    const latest = outline.interactions[outline.interactions.length - 1];
+    if (!latest) {
+        return 'empty';
+    }
+    const displayMetadata = authoritativeTarget as ActiveAiSessionViewModel & {
+        conversationDisplayName?: string;
+        duplicateConversationDisplayName?: boolean;
+    };
+    const trimmedName = String(authoritativeTarget.name || '').trim();
+    await viewer.open({
+        projectId: target.projectId,
+        provider: target.provider,
+        sessionId: target.sessionId,
+        interactionId: latest.id,
+        expectedRevision: outline.sourceRevision,
+        displayName: displayMetadata.conversationDisplayName
+            || (trimmedName || `${target.provider} conversation`),
+        duplicateDisplayName:
+            displayMetadata.duplicateConversationDisplayName === true,
+    });
+    return 'opened';
 }
 
 function resolveExactTarget(

--- a/src/aiSessions/tmuxRuntimeBindingStore.ts
+++ b/src/aiSessions/tmuxRuntimeBindingStore.ts
@@ -88,6 +88,12 @@ export interface TmuxInactiveRuntimeBinding {
 export type TmuxInactiveAcknowledgementResult = 'acknowledged' | 'stale' | 'missing';
 export type TmuxKnownRebindResult = 'rebound' | 'stale' | 'missing';
 
+export interface TmuxFinalBindingSnapshot {
+    pending: TmuxPendingRuntimeBinding[];
+    known: TmuxKnownRuntimeBinding[];
+    inactive: TmuxInactiveRuntimeBinding[];
+}
+
 interface TmuxKnownRebindIntent {
     version: 1;
     state: 'rebind-known';
@@ -200,6 +206,14 @@ export class TmuxRuntimeBindingStore {
 
     listInactive(): Promise<TmuxInactiveRuntimeBinding[]> {
         return this.serializeFinal(() => this.listInactiveUnlocked(true));
+    }
+
+    listFinalSnapshot(): Promise<TmuxFinalBindingSnapshot> {
+        return this.serializeFinal(async () => ({
+            pending: await this.listPendingUnlocked(),
+            known: await this.listKnownUnlocked(true),
+            inactive: await this.listInactiveUnlocked(true),
+        }));
     }
 
     getPending(identity: AiSessionRuntimeIdentity): Promise<TmuxPendingRuntimeBinding | null> {

--- a/src/aiSessions/tmuxRuntimeDiscovery.ts
+++ b/src/aiSessions/tmuxRuntimeDiscovery.ts
@@ -22,6 +22,7 @@ import {
     cloneAiSessionRuntimeIdentity,
 } from './runtimeTypes';
 import type {
+    TmuxFinalBindingSnapshot,
     TmuxInactiveAcknowledgementResult,
     TmuxInactiveRuntimeBinding,
     TmuxKnownRebindResult,
@@ -51,6 +52,7 @@ interface TmuxDiscoveryBindingStore {
     listPending(): Promise<TmuxPendingRuntimeBinding[]>;
     listKnown(): Promise<TmuxKnownRuntimeBinding[]>;
     listInactive?(): Promise<TmuxInactiveRuntimeBinding[]>;
+    listFinalSnapshot?(): Promise<TmuxFinalBindingSnapshot>;
     setInactive?(record: TmuxInactiveRuntimeBinding): Promise<void>;
     transitionKnownToInactive?(
         record: TmuxInactiveRuntimeBinding,
@@ -334,13 +336,18 @@ export class TmuxRuntimeDiscovery {
             throw new Error('The tmux window enumeration exceeded its bounded row limit.');
         }
         const rows = listed.slice();
-        const [pendingBindings, knownBindings, persistedInactiveBindings] = await Promise.all([
-            this.options.bindingStore.listPending(),
-            this.options.bindingStore.listKnown(),
-            this.options.bindingStore.listInactive
-                ? this.options.bindingStore.listInactive()
-                : Promise.resolve([] as TmuxInactiveRuntimeBinding[]),
-        ]);
+        const snapshot = this.options.bindingStore.listFinalSnapshot
+            ? await this.options.bindingStore.listFinalSnapshot()
+            : null;
+        const [pendingBindings, knownBindings, persistedInactiveBindings] = snapshot
+            ? [snapshot.pending, snapshot.known, snapshot.inactive]
+            : await Promise.all([
+                this.options.bindingStore.listPending(),
+                this.options.bindingStore.listKnown(),
+                this.options.bindingStore.listInactive
+                    ? this.options.bindingStore.listInactive()
+                    : Promise.resolve([] as TmuxInactiveRuntimeBinding[]),
+            ]);
         const pendingByLocator = groupPendingByLocator(pendingBindings);
         const previousActive = this.active.filter(runtime => runtime.state === 'active');
         const activeByKey = new Map<string, AiSessionRuntimeSnapshot>();

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -171,6 +171,15 @@ const NEW_AI_SESSION_REFRESH_DELAYS_MS = [250, 1000, 2500, 5000];
 const AI_SESSION_REFRESH_DEBOUNCE_MS = 3000;
 const AI_SESSION_WATCHER_REFRESH_MIN_INTERVAL_MS = 10000;
 const AI_SESSION_INCREMENTAL_SCAN_MAX_FILES = 2000;
+const AI_SESSION_TMUX_RESTORE_BUDGET_MS = 800;
+const DASHBOARD_BOOTSTRAP_PHASE_ORDER = [
+    'skill-scan',
+    'tmux-persisted-inactive-restore',
+    'direct-terminal-restore',
+    'tmux-attach-restore',
+    'tmux-restore-wait',
+    'startup-sequence',
+];
 // Mirrors vscode.TerminalExitReason.User. The extension's minimum VS Code typings
 // predate TerminalExitStatus.reason, while supported hosts expose it at runtime.
 const USER_TERMINAL_EXIT_REASON = 3;
@@ -198,6 +207,25 @@ function resolveAiProviderExecutable(commandName: string): string | null {
         }
     }
     return null;
+}
+
+async function settlesWithinBudget<T>(
+    task: Promise<T>,
+    budgetMs: number
+): Promise<boolean> {
+    let timeout: NodeJS.Timeout | undefined;
+    try {
+        return await Promise.race([
+            task.then(() => true),
+            new Promise<boolean>(resolve => {
+                timeout = setTimeout(() => resolve(false), budgetMs);
+            }),
+        ]);
+    } finally {
+        if (timeout) {
+            clearTimeout(timeout);
+        }
+    }
 }
 
 function runBoundedAiProviderHelp(
@@ -676,12 +704,14 @@ async function initializeDashboard(
         ),
         markerIsCurrent: isCurrentRuntimeMarker,
     });
-    try {
-        await timeBootstrapPhase('tmux-persisted-inactive-restore', () =>
-            tmuxRuntimeDiscovery.loadPersistedInactive());
-    } catch (error) {
-        logAiSessionRuntimeFailure('restore-inactive-runtimes', error);
-    }
+    const persistedInactiveRestoreTask = (async (): Promise<void> => {
+        try {
+            await timeBootstrapPhase('tmux-persisted-inactive-restore', () =>
+                tmuxRuntimeDiscovery.loadPersistedInactive());
+        } catch (error) {
+            logAiSessionRuntimeFailure('restore-inactive-runtimes', error);
+        }
+    })();
     resources.assertActive();
     const directTerminalRuntimeBackend = new DirectTerminalRuntimeBackend(aiSessionTerminalService);
     const tmuxRuntimeBackend = new TmuxRuntimeBackend<vscode.Terminal>({
@@ -725,13 +755,48 @@ async function initializeDashboard(
     await timeBootstrapPhase('direct-terminal-restore', () =>
         aiSessionTerminalService.restorePersistedTerminals(vscode.window.terminals));
     resources.assertActive();
-    try {
-        await timeBootstrapPhase('tmux-attach-restore', () =>
-            tmuxRuntimeBackend.restoreAttachTerminals(vscode.window.terminals));
-    } catch (error) {
-        logAiSessionRuntimeFailure('restore-attach-terminals', error);
-    }
+    const tmuxRestoreTask = persistedInactiveRestoreTask.then(async (): Promise<'restored' | 'failed' | 'disposed'> => {
+        try {
+            resources.assertActive();
+        } catch (_error) {
+            return 'disposed';
+        }
+        try {
+            await timeBootstrapPhase('tmux-attach-restore', () =>
+                tmuxRuntimeBackend.restoreAttachTerminals(vscode.window.terminals));
+            return 'restored';
+        } catch (error) {
+            logAiSessionRuntimeFailure('restore-attach-terminals', error);
+            return 'failed';
+        }
+    });
+    const tmuxRestoreCompleted = await timeBootstrapPhase('tmux-restore-wait', () =>
+        settlesWithinBudget(tmuxRestoreTask, AI_SESSION_TMUX_RESTORE_BUDGET_MS));
     resources.assertActive();
+    let deferredTmuxRestoreSettled = false;
+    let deferredTmuxRestoreRefreshReady = false;
+    let deferredTmuxRestoreRefreshPublished = false;
+    if (!tmuxRestoreCompleted) {
+        logDashboardDiagnostic({
+            event: 'agent-pivot-bootstrap-tmux-restore-deferred',
+            generation: bootstrapGeneration,
+            budgetMs: AI_SESSION_TMUX_RESTORE_BUDGET_MS,
+        });
+        void tmuxRestoreTask.then(outcome => {
+            try {
+                resources.assertActive();
+            } catch (_error) {
+                return;
+            }
+            deferredTmuxRestoreSettled = true;
+            logDashboardDiagnostic({
+                event: 'agent-pivot-bootstrap-tmux-restore-settled',
+                generation: bootstrapGeneration,
+                outcome,
+            });
+            publishDeferredTmuxRestoreIfReady();
+        });
+    }
     const aiSessionPinStore = new AiSessionPinStore(context.globalStoragePath);
     const aiSessionPinController = new AiSessionPinController({
         store: aiSessionPinStore,
@@ -1912,12 +1977,15 @@ async function initializeDashboard(
                 void tmuxFocusedRuntimeMonitor.request();
             }
             await dashboardRuntimeController.handleAiSessionViewVisibilityChanged(visible);
+            deferredTmuxRestoreRefreshReady = true;
+            publishDeferredTmuxRestoreIfReady();
         },
         onVisiblePrepared: () =>
             aiSessionDashboardController.refreshNow('dashboard-visible', {
                 fallbackToFullRefresh: false,
             }),
         onDisposed: () => {
+            deferredTmuxRestoreRefreshReady = false;
             conversationCapability.controller.resetView();
         },
         logError,
@@ -2259,10 +2327,16 @@ async function initializeDashboard(
     await timeBootstrapPhase('startup-sequence', () =>
         dashboardStartupController.startUp());
     resources.assertActive();
+    const orderedBootstrapPhaseTimings: Record<string, number> = {};
+    for (const phase of DASHBOARD_BOOTSTRAP_PHASE_ORDER) {
+        if (Object.prototype.hasOwnProperty.call(bootstrapPhaseTimings, phase)) {
+            orderedBootstrapPhaseTimings[phase] = bootstrapPhaseTimings[phase];
+        }
+    }
     logDashboardDiagnostic({
         event: 'agent-pivot-bootstrap-phases',
         generation: bootstrapGeneration,
-        phases: { ...bootstrapPhaseTimings },
+        phases: orderedBootstrapPhaseTimings,
     });
     if (!dashboardCommandRegistration.stage(bootstrapGeneration, commandHandlers)) {
         throw new Error('Agent Pivot dashboard commands rejected the bootstrap generation.');
@@ -2609,6 +2683,22 @@ async function initializeDashboard(
 
     function refreshAiSessionViewsIncrementally() {
         void aiSessionDashboardController.refreshNow();
+    }
+
+    function publishDeferredTmuxRestoreIfReady(): void {
+        if (!deferredTmuxRestoreSettled
+            || !deferredTmuxRestoreRefreshReady
+            || deferredTmuxRestoreRefreshPublished
+            || !provider.visible) {
+            return;
+        }
+        try {
+            resources.assertActive();
+        } catch (_error) {
+            return;
+        }
+        deferredTmuxRestoreRefreshPublished = true;
+        void aiSessionDashboardController.refreshNow('tmux-bootstrap-restore');
     }
 
     function postAiSessionAttentionState() {

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -2226,6 +2226,7 @@ async function initializeDashboard(
         addFileToActiveTerminal: () => activeTerminalFileReferenceController.addFileToActiveTerminal(),
         insertPromptToActiveTerminal: () => promptTerminalCommandController.insertPromptToActiveTerminal(),
         migrateSkillsToCentral: () => runSkillMigrationToCentral(),
+        openCurrentAiSessionConversation: () => openCurrentAiSessionConversation(),
     };
 
     ownResource(() => vscode.workspace.onDidChangeConfiguration(
@@ -2450,6 +2451,60 @@ async function initializeDashboard(
         return tmuxRuntime && runtimeBelongsToCurrentWorkspace(tmuxRuntime)
             ? tmuxRuntime.identity
             : activeAiSessionTerminalHighlighter.getIdentity();
+    }
+
+    async function openCurrentAiSessionConversation(): Promise<void> {
+        const target = getCurrentWorkspaceActionTargetWithoutCardId();
+        if (!target) {
+            void vscode.window.showInformationMessage(
+                'Agent Pivot: no current workspace with AI sessions.'
+            );
+            return;
+        }
+        const candidates = target.sessions.activeSessions
+            .filter(session => session.sessionId);
+        if (!candidates.length) {
+            void vscode.window.showInformationMessage(
+                'Agent Pivot: no active AI session in the current workspace.'
+            );
+            return;
+        }
+        let selected = candidates.find(session => session.focused);
+        if (!selected && candidates.length === 1) {
+            selected = candidates[0];
+        }
+        if (!selected) {
+            const picked = await vscode.window.showQuickPick(
+                candidates.map(session => ({
+                    label: session.name || session.sessionId as string,
+                    description: session.provider,
+                    session,
+                })),
+                { placeHolder: 'Select an AI session to open its conversation' }
+            );
+            selected = picked?.session;
+        }
+        if (!selected?.sessionId) {
+            return;
+        }
+        const result = await conversationCapability.openLatestConversation({
+            projectId: target.cardId,
+            provider: selected.provider,
+            sessionId: selected.sessionId,
+        });
+        if (result === 'empty') {
+            void vscode.window.showInformationMessage(
+                'Agent Pivot: this AI session has no conversation yet.'
+            );
+        } else if (result === 'unknownSession') {
+            void vscode.window.showWarningMessage(
+                'Agent Pivot: the selected AI session is no longer active.'
+            );
+        } else if (result === 'unavailable') {
+            void vscode.window.showWarningMessage(
+                'Agent Pivot: unable to read the AI session conversation.'
+            );
+        }
     }
 
     function runtimeBelongsToCurrentWorkspace(

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -367,6 +367,18 @@ async function initializeDashboard(
     const logDashboardDiagnostic = (event: Record<string, unknown>) => dashboardDiagnostics.logDashboardDiagnostic(event);
     const logOpenWorkspaceDiagnostic = (component: string, event: unknown) => dashboardDiagnostics.logOpenWorkspaceDiagnostic(component, event);
     const logOpenWorkspaceBridgeError = (error: unknown) => dashboardDiagnostics.logOpenWorkspaceBridgeError(error);
+    const bootstrapPhaseTimings: Record<string, number> = {};
+    const timeBootstrapPhase = async <T>(
+        phase: string,
+        run: () => T | Promise<T>
+    ): Promise<T> => {
+        const startedAtMs = Date.now();
+        try {
+            return await run();
+        } finally {
+            bootstrapPhaseTimings[phase] = Math.max(0, Date.now() - startedAtMs);
+        }
+    };
 
     const colorService = new ColorService(context);
     const projectService = new ProjectService(context, colorService, {
@@ -422,7 +434,7 @@ async function initializeDashboard(
         logError,
         groupStore: new SkillGroupStore(context.globalState),
     }));
-    skillDashboardController.start();
+    timeBootstrapPhase('skill-scan', () => skillDashboardController.start());
     const runSkillMigrationToCentral = async (scope?: 'user' | 'project'): Promise<void> => {
         const hasWorkspace = Boolean(vscode.workspace.workspaceFolders?.length);
         const migratable = skillDashboardController.getRecords()
@@ -665,7 +677,8 @@ async function initializeDashboard(
         markerIsCurrent: isCurrentRuntimeMarker,
     });
     try {
-        await tmuxRuntimeDiscovery.loadPersistedInactive();
+        await timeBootstrapPhase('tmux-persisted-inactive-restore', () =>
+            tmuxRuntimeDiscovery.loadPersistedInactive());
     } catch (error) {
         logAiSessionRuntimeFailure('restore-inactive-runtimes', error);
     }
@@ -709,10 +722,12 @@ async function initializeDashboard(
             }
         },
     });
-    await aiSessionTerminalService.restorePersistedTerminals(vscode.window.terminals);
+    await timeBootstrapPhase('direct-terminal-restore', () =>
+        aiSessionTerminalService.restorePersistedTerminals(vscode.window.terminals));
     resources.assertActive();
     try {
-        await tmuxRuntimeBackend.restoreAttachTerminals(vscode.window.terminals);
+        await timeBootstrapPhase('tmux-attach-restore', () =>
+            tmuxRuntimeBackend.restoreAttachTerminals(vscode.window.terminals));
     } catch (error) {
         logAiSessionRuntimeFailure('restore-attach-terminals', error);
     }
@@ -2241,8 +2256,14 @@ async function initializeDashboard(
         dashboardLifecycleController.handleWindowStateChanged(windowState);
     }));
 
-    await dashboardStartupController.startUp();
+    await timeBootstrapPhase('startup-sequence', () =>
+        dashboardStartupController.startUp());
     resources.assertActive();
+    logDashboardDiagnostic({
+        event: 'agent-pivot-bootstrap-phases',
+        generation: bootstrapGeneration,
+        phases: { ...bootstrapPhaseTimings },
+    });
     if (!dashboardCommandRegistration.stage(bootstrapGeneration, commandHandlers)) {
         throw new Error('Agent Pivot dashboard commands rejected the bootstrap generation.');
     }

--- a/src/dashboard/commandRegistration.ts
+++ b/src/dashboard/commandRegistration.ts
@@ -18,6 +18,7 @@ export interface DashboardCommandHandlers {
     addFileToActiveTerminal: DashboardCommandHandler;
     insertPromptToActiveTerminal: DashboardCommandHandler;
     migrateSkillsToCentral: DashboardCommandHandler;
+    openCurrentAiSessionConversation: DashboardCommandHandler;
 }
 
 export interface DashboardCommandRegistrationOptions<TDisposable extends DisposableLike = DisposableLike> {
@@ -43,6 +44,7 @@ const DASHBOARD_COMMANDS: ReadonlyArray<readonly [string, DashboardCommandName]>
     ['agentPivot.addFileToActiveTerminal', 'addFileToActiveTerminal'],
     ['agentPivot.insertPromptToActiveTerminal', 'insertPromptToActiveTerminal'],
     ['agentPivot.migrateSkillsToCentral', 'migrateSkillsToCentral'],
+    ['agentPivot.openCurrentAiSessionConversation', 'openCurrentAiSessionConversation'],
 ];
 
 interface DashboardCommandGeneration {

--- a/tests/contract/aiSessions/runtimeComposition.test.js
+++ b/tests/contract/aiSessions/runtimeComposition.test.js
@@ -150,6 +150,7 @@ test('WEBVIEW-DASHBOARD-COMMAND-AVAILABILITY-001 production activation exposes s
         'agentPivot.addFileToActiveTerminal',
         'agentPivot.insertPromptToActiveTerminal',
         'agentPivot.migrateSkillsToCentral',
+        'agentPivot.openCurrentAiSessionConversation',
     ]);
     assert.equal(result.dashboardCommandRegistrationInvocations, 1);
     assert.equal(result.pendingOpenRevealedBootShell, true);

--- a/tests/contract/aiSessions/runtimeComposition.test.js
+++ b/tests/contract/aiSessions/runtimeComposition.test.js
@@ -161,12 +161,27 @@ test('WEBVIEW-TWO-STAGE-STARTUP-001 production startup diagnostics preserve exac
     const result = runProductionActivation('diagnostics');
     assert.equal(result.failure, null);
     const normalizedDiagnostics = result.startupDiagnostics.map(diagnostic => {
-        if (!Object.hasOwn(diagnostic, 'durationMs')) {
-            return diagnostic;
+        let normalized = diagnostic;
+        if (Object.hasOwn(normalized, 'phases')) {
+            assert.deepEqual(Object.keys(normalized.phases), [
+                'skill-scan',
+                'tmux-persisted-inactive-restore',
+                'direct-terminal-restore',
+                'tmux-attach-restore',
+                'startup-sequence',
+            ]);
+            for (const value of Object.values(normalized.phases)) {
+                assert.equal(Number.isFinite(value), true);
+                assert.ok(value >= 0);
+            }
+            normalized = { ...normalized, phases: '<phases>' };
         }
-        assert.equal(Number.isFinite(diagnostic.durationMs), true);
-        assert.ok(diagnostic.durationMs >= 0);
-        return { ...diagnostic, durationMs: '<durationMs>' };
+        if (!Object.hasOwn(normalized, 'durationMs')) {
+            return normalized;
+        }
+        assert.equal(Number.isFinite(normalized.durationMs), true);
+        assert.ok(normalized.durationMs >= 0);
+        return { ...normalized, durationMs: '<durationMs>' };
     });
     assert.deepEqual(normalizedDiagnostics, [
         {
@@ -180,6 +195,11 @@ test('WEBVIEW-TWO-STAGE-STARTUP-001 production startup diagnostics preserve exac
             event: 'agent-pivot-browser-first-paint',
             generation: 1,
             durationMs: '<durationMs>',
+        },
+        {
+            event: 'agent-pivot-bootstrap-phases',
+            generation: 1,
+            phases: '<phases>',
         },
         {
             event: 'agent-pivot-bootstrap-ready',

--- a/tests/contract/aiSessions/runtimeComposition.test.js
+++ b/tests/contract/aiSessions/runtimeComposition.test.js
@@ -168,6 +168,7 @@ test('WEBVIEW-TWO-STAGE-STARTUP-001 production startup diagnostics preserve exac
                 'tmux-persisted-inactive-restore',
                 'direct-terminal-restore',
                 'tmux-attach-restore',
+                'tmux-restore-wait',
                 'startup-sequence',
             ]);
             for (const value of Object.values(normalized.phases)) {
@@ -260,6 +261,48 @@ test('RUNTIME-HOST-RUNTIME-COMPOSITION-001 production activation blocks tmux res
     assert.equal(result.rawDirectFailureExposedInHtml, false);
     assert.deepEqual(result.verified, [
         'client-store-discovery', 'thread-switch-alias-wiring',
+    ]);
+});
+
+test('RUNTIME-BOOTSTRAP-TMUX-RESTORE-DEFERRAL-001 slow tmux recovery does not block ready rendering and refreshes after settlement', () => {
+    const result = runProductionActivation('slow-tmux-restore');
+    assert.equal(result.failure, null);
+    assert.equal(result.pendingTmuxRestoreEntered, true);
+    assert.equal(result.readyBeforeTmuxRestoreSettled, true);
+    assert.deepEqual(result.events.filter(isRestoreEvent), [
+        'inactive-restored',
+        'direct-restored',
+        'hydration-constructed',
+        'tmux-restored',
+    ]);
+    assert.equal(result.tmuxRestoreRefreshCount, 1);
+    assert.deepEqual(result.tmuxRestoreDiagnostics, [
+        {
+            event: 'agent-pivot-bootstrap-tmux-restore-deferred',
+            generation: 1,
+            budgetMs: 800,
+        },
+        {
+            event: 'agent-pivot-bootstrap-tmux-restore-settled',
+            generation: 1,
+            outcome: 'restored',
+        },
+    ]);
+});
+
+test('RUNTIME-BOOTSTRAP-TMUX-RESTORE-DEFERRAL-001 disposed bootstrap ignores late tmux recovery settlement', () => {
+    const result = runProductionActivation('slow-tmux-restore-dispose');
+    assert.equal(result.failure, null);
+    assert.equal(result.readyBeforeTmuxRestoreSettled, true);
+    assert.deepEqual(result.postDisposePublications, []);
+    assert.deepEqual(result.postDisposeWebviewMessages, []);
+    assert.equal(result.tmuxRestoreRefreshCount, 0);
+    assert.deepEqual(result.tmuxRestoreDiagnostics, [
+        {
+            event: 'agent-pivot-bootstrap-tmux-restore-deferred',
+            generation: 1,
+            budgetMs: 800,
+        },
     ]);
 });
 

--- a/tests/contract/aiSessions/tmuxDiscovery.test.js
+++ b/tests/contract/aiSessions/tmuxDiscovery.test.js
@@ -42,6 +42,51 @@ test('RUNTIME-TMUX-DISCOVERY-001 RUNTIME-TMUX-FOCUSED-RUNTIME-MONITOR-001 caches
     assert.equal(lists, 3);
 });
 
+test('RUNTIME-TMUX-DISCOVERY-001 enumerate prefers one final snapshot read over separate binding lists', async () => {
+    const row = makeTmuxDiscoveryRow({ sessionId: 'snapshot-read' });
+    const store = createSyntheticTmuxStore();
+    let snapshotCalls = 0;
+    const separateCalls = [];
+    const baseSnapshot = store.listFinalSnapshot;
+    store.listFinalSnapshot = async () => {
+        snapshotCalls += 1;
+        return baseSnapshot();
+    };
+    for (const method of ['listPending', 'listKnown', 'listInactive']) {
+        const base = store[method];
+        store[method] = async () => {
+            separateCalls.push(method);
+            return base();
+        };
+    }
+    const discovery = new TmuxRuntimeDiscovery({
+        client: { listWindows: async () => [row] },
+        bindingStore: store,
+        markerIsCurrent: () => false,
+        cacheTtlMs: 0,
+    });
+
+    await discovery.refresh(true);
+    assert.equal(snapshotCalls, 1);
+    assert.deepEqual(separateCalls, []);
+    assert.equal(discovery.getActive().length, 1);
+});
+
+test('RUNTIME-TMUX-DISCOVERY-001 enumerate falls back to separate binding lists without snapshot support', async () => {
+    const row = makeTmuxDiscoveryRow({ sessionId: 'fallback-read' });
+    const store = createSyntheticTmuxStore();
+    delete store.listFinalSnapshot;
+    const discovery = new TmuxRuntimeDiscovery({
+        client: { listWindows: async () => [row] },
+        bindingStore: store,
+        markerIsCurrent: () => false,
+        cacheTtlMs: 0,
+    });
+
+    await discovery.refresh(true);
+    assert.equal(discovery.getActive().length, 1);
+});
+
 test('RUNTIME-TMUX-DISCOVERY-001 coalesces refreshes and marks retained state stale after failure', async () => {
     const first = createDeferred();
     let lists = 0;

--- a/tests/contract/dashboardBoundaries.test.js
+++ b/tests/contract/dashboardBoundaries.test.js
@@ -327,7 +327,7 @@ const DASHBOARD_COMMANDS = [
     'agentPivot.removeProject', 'agentPivot.editProjects', 'agentPivot.addGroup',
     'agentPivot.removeGroup', 'agentPivot.addProjectsFromFolder',
     'agentPivot.addFileToActiveTerminal', 'agentPivot.insertPromptToActiveTerminal',
-    'agentPivot.migrateSkillsToCentral',
+    'agentPivot.migrateSkillsToCentral', 'agentPivot.openCurrentAiSessionConversation',
 ];
 
 test('WEBVIEW-DASHBOARD-COMMAND-REGISTRATION-001 WEBVIEW-DASHBOARD-COMMAND-AVAILABILITY-001 registers once and switches generation handlers safely', async () => {
@@ -337,7 +337,7 @@ test('WEBVIEW-DASHBOARD-COMMAND-REGISTRATION-001 WEBVIEW-DASHBOARD-COMMAND-AVAIL
     const handlerNames = [
         'open', 'addProject', 'saveProject', 'removeProject', 'editProjects', 'addGroup', 'removeGroup',
         'addProjectsFromFolder', 'addFileToActiveTerminal', 'insertPromptToActiveTerminal',
-        'migrateSkillsToCentral',
+        'migrateSkillsToCentral', 'openCurrentAiSessionConversation',
     ];
     const facade = new DashboardCommandRegistration({
         registerCommand: (command, callback) => {

--- a/tests/extension-host/suite/index.js
+++ b/tests/extension-host/suite/index.js
@@ -17,6 +17,7 @@ const PUBLIC_COMMANDS = [
     'agentPivot.addFileToActiveTerminal',
     'agentPivot.insertPromptToActiveTerminal',
     'agentPivot.migrateSkillsToCentral',
+    'agentPivot.openCurrentAiSessionConversation',
 ];
 
 async function verifyExtensionHostLifecycle() {

--- a/tests/fixtures/aiSessions/runtimeHostActivationHarness.js
+++ b/tests/fixtures/aiSessions/runtimeHostActivationHarness.js
@@ -421,6 +421,7 @@ async function main() {
             'agent-pivot-activation-entered',
             'agent-pivot-boot-shell-assigned',
             'agent-pivot-browser-first-paint',
+            'agent-pivot-bootstrap-phases',
             'agent-pivot-bootstrap-ready',
             'agent-pivot-bootstrap-failed',
         ]);

--- a/tests/fixtures/aiSessions/runtimeHostActivationHarness.js
+++ b/tests/fixtures/aiSessions/runtimeHostActivationHarness.js
@@ -35,7 +35,13 @@ function createVscode(lifecycle) {
     const webview = {
         cspSource: 'fixture-webview',
         options: {},
-        postMessage: async () => true,
+        postMessage: async message => {
+            lifecycle.postedWebviewMessages.push(message);
+            if (lifecycle.activationDisposed) {
+                lifecycle.postDisposeWebviewMessages.push(message?.type || 'unknown');
+            }
+            return true;
+        },
         asWebviewUri: value => value,
         onDidReceiveMessage: callback => {
             bootWebviewMessageCallback = callback;
@@ -162,6 +168,8 @@ async function main() {
         openTerminalListenerDisposals: 0,
         outputLines: [],
         postDisposePublications: [],
+        postDisposeWebviewMessages: [],
+        postedWebviewMessages: [],
     };
     const vscode = createVscode(lifecycle);
     const previousLoad = Module._load;
@@ -177,6 +185,9 @@ async function main() {
     let initialInactiveRestoreRecorded = false;
     let pendingDirectRestoreEntered = false;
     let releasePendingDirectRestore;
+    let pendingTmuxRestoreEntered = false;
+    let tmuxRestoreSettled = false;
+    let releasePendingTmuxRestore;
     const synchronizedGlobalStateKeySets = [];
     const patch = (prototype, name, replacement) => {
         const original = prototype[name];
@@ -287,7 +298,14 @@ async function main() {
             assert.ok(this.dependencies.runtimeStore instanceof TmuxRuntimeBindingStore);
             assert.ok(this.dependencies.attachStore instanceof TmuxAttachBindingStore);
             verified.add('tmux-backend');
+            if (mode === 'slow-tmux-restore' || mode === 'slow-tmux-restore-dispose') {
+                pendingTmuxRestoreEntered = true;
+                await new Promise(resolve => {
+                    releasePendingTmuxRestore = resolve;
+                });
+            }
             events.push('tmux-restored');
+            tmuxRestoreSettled = true;
         });
         patch(AiSessionRuntimeCoordinator.prototype, 'getActive', function () {
             assert.ok(this.dependencies.direct instanceof DirectTerminalRuntimeBackend);
@@ -323,6 +341,8 @@ async function main() {
             events.push('activation-returned');
             activationSettled = true;
         })();
+        let dashboardDeactivated = false;
+        let readyBeforeTmuxRestoreSettled = false;
         if (mode === 'pending') {
             await waitFor(
                 () => pendingDirectRestoreEntered,
@@ -334,6 +354,42 @@ async function main() {
             );
         }
         await activationFlight;
+        if (mode === 'slow-tmux-restore' || mode === 'slow-tmux-restore-dispose') {
+            await waitFor(
+                () => pendingTmuxRestoreEntered,
+                'pending tmux restoration to begin'
+            );
+            const deadline = Date.now() + 1_500;
+            while (Date.now() < deadline
+                && vscode.registeredProvider?.lifecycle?.kind !== 'ready') {
+                await new Promise(resolve => setTimeout(resolve, 10));
+            }
+            readyBeforeTmuxRestoreSettled =
+                vscode.registeredProvider?.lifecycle?.kind === 'ready'
+                && !tmuxRestoreSettled;
+            if (mode === 'slow-tmux-restore-dispose' && readyBeforeTmuxRestoreSettled) {
+                await dashboard.deactivate();
+                events.push('dashboard-deactivated');
+                disposeContextSubscriptions();
+                dashboardDeactivated = true;
+            }
+            releasePendingTmuxRestore?.();
+            await waitFor(() => tmuxRestoreSettled, 'released tmux restoration to settle');
+            if (mode === 'slow-tmux-restore') {
+                const refreshDeadline = Date.now() + 1_500;
+                while (Date.now() < refreshDeadline
+                    && !lifecycle.outputLines.some(line =>
+                        line.includes('"reason":"tmux-bootstrap-restore"'))) {
+                    await new Promise(resolve => setTimeout(resolve, 10));
+                }
+                assert.equal(
+                    lifecycle.outputLines.some(line =>
+                        line.includes('"reason":"tmux-bootstrap-restore"')),
+                    true,
+                    'Timed out waiting for deferred tmux restoration refresh'
+                );
+            }
+        }
         let pendingOpenRevealedBootShell = false;
         let pendingUnavailableCommandError = null;
         if (failure === null && mode === 'pending') {
@@ -403,7 +459,7 @@ async function main() {
             await dashboard.deactivate();
             lateAttentionClientObserved =
                 attentionShutdownCalls > shutdownCallsBeforeDisposal;
-        } else if (failure === null) {
+        } else if (failure === null && !dashboardDeactivated) {
             await dashboard.deactivate();
             events.push('dashboard-deactivated');
         }
@@ -424,10 +480,15 @@ async function main() {
             'agent-pivot-bootstrap-phases',
             'agent-pivot-bootstrap-ready',
             'agent-pivot-bootstrap-failed',
+            'agent-pivot-bootstrap-tmux-restore-deferred',
+            'agent-pivot-bootstrap-tmux-restore-settled',
         ]);
         const startupDiagnostics = dashboardDiagnostics.filter(
             diagnostic => startupDiagnosticEvents.has(diagnostic.event)
         );
+        const aiSessionDiagnostics = lifecycle.outputLines
+            .filter(line => line.startsWith('[AiSessions] '))
+            .map(line => JSON.parse(line.slice('[AiSessions] '.length)));
         process.stdout.write(JSON.stringify({
             activationReturnedBeforeDirectRestoreSettled,
             providerRegistrations: vscode.providerRegistrations,
@@ -443,7 +504,17 @@ async function main() {
             openTerminalListenerDisposals: lifecycle.openTerminalListenerDisposals,
             lateResourceAcquisitions: lifecycle.lateResourceAcquisitions,
             postDisposePublications: lifecycle.postDisposePublications,
+            postDisposeWebviewMessages: lifecycle.postDisposeWebviewMessages,
             lateAttentionClientObserved,
+            pendingTmuxRestoreEntered,
+            readyBeforeTmuxRestoreSettled,
+            tmuxRestoreRefreshCount: aiSessionDiagnostics.filter(
+                diagnostic => diagnostic.event === 'ai-session-message-build'
+                    && diagnostic.reason === 'tmux-bootstrap-restore'
+            ).length,
+            tmuxRestoreDiagnostics: startupDiagnostics.filter(diagnostic =>
+                diagnostic.event === 'agent-pivot-bootstrap-tmux-restore-deferred'
+                    || diagnostic.event === 'agent-pivot-bootstrap-tmux-restore-settled'),
             rawDirectFailureExposedInHtml: vscode.webviewHtmlHistory.some(
                 html => privacyCanaries.some(canary => html.includes(canary))
             ),

--- a/tests/helpers/runtimeContract.js
+++ b/tests/helpers/runtimeContract.js
@@ -305,6 +305,11 @@ function createSyntheticTmuxStore(initial = {}) {
         },
         removeKnown: async (provider, sessionId) => { known.delete(`${provider}:${sessionId}`); },
         listInactive: async () => [...inactive.values()].map(cloneBinding),
+        listFinalSnapshot: async () => ({
+            pending: [...pending.values()].map(cloneBinding),
+            known: [...known.values()].map(cloneBinding),
+            inactive: [...inactive.values()].map(cloneBinding),
+        }),
         setInactive: async record => { inactive.set(`${record.provider}:${record.sessionId}`, cloneBinding(record)); },
         transitionKnownToInactive: async (record, expectedLastSeenAtMs) => {
             const key = `${record.provider}:${record.sessionId}`;

--- a/tests/integration/dashboard/conversationOpenLatest.test.js
+++ b/tests/integration/dashboard/conversationOpenLatest.test.js
@@ -1,0 +1,245 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const Module = require('node:module');
+const test = require('node:test');
+
+function fakeUri(value) {
+    return {
+        scheme: value.split(':', 1)[0],
+        path: value,
+        fsPath: value,
+        toString: () => value,
+    };
+}
+
+function loadConversationComposition() {
+    const fakeVscode = {
+        ViewColumn: { Beside: 2 },
+        Uri: {
+            file: value => fakeUri(`file://${value}`),
+            parse: value => fakeUri(value),
+        },
+        commands: {
+            async executeCommand() {},
+        },
+    };
+    const previousLoad = Module._load;
+    try {
+        Module._load = function (request, parent, isMain) {
+            if (request === 'vscode') return fakeVscode;
+            return previousLoad.call(this, request, parent, isMain);
+        };
+        return require('../../../out/aiSessions/conversation/composition');
+    } finally {
+        Module._load = previousLoad;
+    }
+}
+
+const {
+    createConversationCapability,
+} = loadConversationComposition();
+
+function makeService(provider) {
+    return {
+        getSessions: () => ({
+            available: true,
+            sessions: [],
+            scannedFiles: 0,
+            parsedFiles: 0,
+        }),
+        getLifecycleSignals: () => ({}),
+        watchSessionChanges: () => ({ dispose() {} }),
+        archiveSession: () => false,
+        invalidateCache() {},
+        resolveConversationSource: () => null,
+        provider,
+    };
+}
+
+function makeOutline(provider, sessionId, interactionIds) {
+    return {
+        provider,
+        sessionId,
+        sourceRevision: 'native-1',
+        interactions: interactionIds.map(id => ({
+            id,
+            userPreview: id,
+            userGraphemeCount: id.length,
+            responseState: 'complete',
+        })),
+        totalInteractions: interactionIds.length,
+        partial: false,
+    };
+}
+
+function makeSession(overrides = {}) {
+    return {
+        key: 'codex:session-a',
+        provider: 'codex',
+        sessionId: 'session-a',
+        name: 'Focused session',
+        executionState: 'stopped',
+        status: 'focused',
+        focused: true,
+        needsAttention: false,
+        pending: false,
+        backend: 'vscode',
+        attached: true,
+        ...overrides,
+    };
+}
+
+function createHarness(options = {}) {
+    const viewerTargets = [];
+    const session = 'session' in options ? options.session : makeSession({
+        conversationDisplayName: options.conversationDisplayName,
+        duplicateConversationDisplayName:
+            options.duplicateConversationDisplayName,
+    });
+    const fakeAdapter = provider => () => ({
+        async readOutline(sessionId) {
+            if (options.readOutlineError) {
+                throw options.readOutlineError;
+            }
+            return makeOutline(
+                provider,
+                sessionId,
+                options.interactionIds || ['input-a', 'input-b']
+            );
+        },
+        async readPage() {
+            throw new Error('readPage is not used by openLatestConversation');
+        },
+        watch() {
+            return { dispose() {} };
+        },
+        dispose() {},
+    });
+    const capability = createConversationCapability({
+        services: {
+            codex: makeService('codex'),
+            kimi: makeService('kimi'),
+            claude: makeService('claude'),
+        },
+        resolveTarget: () => session,
+        publish: async () => true,
+        createPanel: () => {
+            throw new Error('createPanel is not used by openLatestConversation');
+        },
+        openExternal: async () => true,
+        spawnCodex: () => {
+            throw new Error('spawnCodex is not used by openLatestConversation');
+        },
+        now: () => Date.now(),
+        setTimer: (callback, delayMs) => setTimeout(callback, delayMs),
+        clearTimer: handle => clearTimeout(handle),
+        onDiagnostic: () => {},
+    }, {
+        createCodexClient: options.createCodexClient || (() => ({ dispose() {} })),
+        createCodexAdapter: fakeAdapter('codex'),
+        createKimiAdapter: fakeAdapter('kimi'),
+        createClaudeAdapter: fakeAdapter('claude'),
+        createViewer: () => ({
+            open: async target => {
+                viewerTargets.push(target);
+            },
+            refresh: async () => undefined,
+            reconcileAuthority: async () => undefined,
+            dispose() {},
+        }),
+    });
+    return { capability, viewerTargets };
+}
+
+test('CONVERSATION-OPEN-LATEST-001 opens the latest interaction of the resolved session', async () => {
+    const { capability, viewerTargets } = createHarness();
+    const result = await capability.openLatestConversation({
+        projectId: 'project-a',
+        provider: 'codex',
+        sessionId: 'session-a',
+    });
+    assert.equal(result, 'opened');
+    assert.deepEqual(viewerTargets, [{
+        projectId: 'project-a',
+        provider: 'codex',
+        sessionId: 'session-a',
+        interactionId: 'input-b',
+        expectedRevision: 'r1',
+        displayName: 'Focused session',
+        duplicateDisplayName: false,
+    }]);
+    capability.dispose();
+});
+
+test('CONVERSATION-OPEN-LATEST-001 prefers conversation display metadata for the viewer target', async () => {
+    const { capability, viewerTargets } = createHarness({
+        conversationDisplayName: 'Renamed session',
+        duplicateConversationDisplayName: true,
+    });
+    const result = await capability.openLatestConversation({
+        projectId: 'project-a',
+        provider: 'codex',
+        sessionId: 'session-a',
+    });
+    assert.equal(result, 'opened');
+    assert.equal(viewerTargets.length, 1);
+    assert.equal(viewerTargets[0].displayName, 'Renamed session');
+    assert.equal(viewerTargets[0].duplicateDisplayName, true);
+    capability.dispose();
+});
+
+test('CONVERSATION-OPEN-LATEST-001 reports empty when the conversation has no interactions', async () => {
+    const { capability, viewerTargets } = createHarness({ interactionIds: [] });
+    const result = await capability.openLatestConversation({
+        projectId: 'project-a',
+        provider: 'codex',
+        sessionId: 'session-a',
+    });
+    assert.equal(result, 'empty');
+    assert.deepEqual(viewerTargets, []);
+    capability.dispose();
+});
+
+test('CONVERSATION-OPEN-LATEST-001 reports unavailable when the outline cannot be read', async () => {
+    const { capability, viewerTargets } = createHarness({
+        readOutlineError: new Error('boom'),
+    });
+    const result = await capability.openLatestConversation({
+        projectId: 'project-a',
+        provider: 'codex',
+        sessionId: 'session-a',
+    });
+    assert.equal(result, 'unavailable');
+    assert.deepEqual(viewerTargets, []);
+    capability.dispose();
+});
+
+test('CONVERSATION-OPEN-LATEST-001 reports unknownSession when the target is not authoritative', async () => {
+    const { capability, viewerTargets } = createHarness({ session: null });
+    const result = await capability.openLatestConversation({
+        projectId: 'project-a',
+        provider: 'codex',
+        sessionId: 'session-a',
+    });
+    assert.equal(result, 'unknownSession');
+    assert.deepEqual(viewerTargets, []);
+    capability.dispose();
+});
+
+test('CONVERSATION-OPEN-LATEST-001 unavailable capability rejects openLatestConversation', async () => {
+    const { capability, viewerTargets } = createHarness({
+        createCodexClient: () => {
+            throw new Error('construction failed');
+        },
+    });
+    assert.equal(capability.availability, 'unavailable');
+    const result = await capability.openLatestConversation({
+        projectId: 'project-a',
+        provider: 'codex',
+        sessionId: 'session-a',
+    });
+    assert.equal(result, 'unavailable');
+    assert.deepEqual(viewerTargets, []);
+    capability.dispose();
+});

--- a/tests/unit/tooling/extensionHostSuite.test.js
+++ b/tests/unit/tooling/extensionHostSuite.test.js
@@ -21,6 +21,7 @@ const publicCommands = [
     'agentPivot.addFileToActiveTerminal',
     'agentPivot.insertPromptToActiveTerminal',
     'agentPivot.migrateSkillsToCentral',
+    'agentPivot.openCurrentAiSessionConversation',
 ];
 
 function loadSuite(vscode) {


### PR DESCRIPTION
## Summary

- add a command that opens the current AI session conversation at its latest interaction
- add bootstrap phase diagnostics and defer slow tmux restoration after a bounded startup budget
- read tmux discovery bindings from one serialized final snapshot
- update regression contracts, safety checks, extension-host coverage, and capability audit metadata

## Why

Dashboard readiness was serialized behind persisted tmux recovery, so a slow inactive/attach restore could delay the sidebar for several seconds. Separate discovery list reads could also observe bindings across different lock epochs. This PR keeps Direct terminal restoration fail-fast, lets the dashboard become ready after a bounded tmux wait, publishes one generation-safe incremental refresh when recovery settles, and gives users a direct command for the latest active conversation.

## Impact

The dashboard becomes usable without waiting for a slow tmux attach pass, while late recovery cannot publish after disposal. Runtime discovery now observes pending, known, and inactive bindings consistently. No package version, tag, release, or publication change is included.

## Validation

- `npm run test:ci:linux`
- `npm run test:tmux:smoke`
- `git diff --check origin/main..HEAD`
- final merge-base-to-HEAD integration review: no Critical or Important findings
