### PR TITLE
fix: prevent conversation viewer loading starvation

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -3574,6 +3574,19 @@
     ]
   },
   {
+    "id": "CONVERSATION-VIEWER-LOADING-001",
+    "domain": "webview",
+    "title": "Watched invalidations cannot starve an in-flight conversation viewer publication",
+    "priority": "P0",
+    "status": "automated",
+    "owners": [
+      "tests/integration/dashboard/conversationViewer.test.js"
+    ],
+    "evidence": [
+      "src/aiSessions/conversation/viewer.ts"
+    ]
+  },
+  {
     "id": "CONVERSATION-VIEWER-USER-EMPHASIS-001",
     "domain": "webview",
     "title": "AI Conversation presents User prompts as dominant full-width blocks",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "c97615cee3b2629102643cf3f4560f98201e49d4",
+        "head": "e5e0c103006ab7f37b57b61c670e062e1e2b909f",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -941,7 +941,8 @@
                 "938905c3ad8bca127535c1188d5c65f2d0a21d1a",
                 "bb74e5abcaafcbf29d31361b95f4e647958169dd",
                 "846a5727a5d36b74f91aa20076eb51d8fe77fdf9",
-                "571270717cff080db395df2ce0393624d1ed12ee"
+                "571270717cff080db395df2ce0393624d1ed12ee",
+                "e5e0c103006ab7f37b57b61c670e062e1e2b909f"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",
@@ -950,6 +951,7 @@
                 "SECURITY-AI-SESSION-CONVERSATION-SOURCE-001",
                 "ACTIVE-SESSION-CONVERSATION-RESTORE-001",
                 "SESSION-CONVERSATION-LOADING-001",
+                "CONVERSATION-VIEWER-LOADING-001",
                 "CONVERSATION-VIEWER-USER-EMPHASIS-001",
                 "WEBVIEW-STYLES-ARTIFACT-001",
                 "CONVERSATION-OPEN-LATEST-001"

--- a/src/aiSessions/conversation/viewer.ts
+++ b/src/aiSessions/conversation/viewer.ts
@@ -122,6 +122,8 @@ export class ConversationViewer implements ConversationViewerApi {
     private latestPublication?: ConversationViewerPageMessage;
     private panelWasVisible = false;
     private suspended = false;
+    private authoritativeLoadInFlight?: Promise<boolean>;
+    private authoritativeRefreshPending = false;
 
     constructor(private readonly options: ConversationViewerOptions) {}
 
@@ -166,6 +168,8 @@ export class ConversationViewer implements ConversationViewerApi {
                 return;
             }
             this.suspended = true;
+            this.authoritativeLoadInFlight = undefined;
+            this.authoritativeRefreshPending = false;
             this.abortController?.abort();
             this.abortController = undefined;
             this.watch?.dispose();
@@ -205,6 +209,8 @@ export class ConversationViewer implements ConversationViewerApi {
     }
 
     private replaceTarget(target: ConversationViewerTarget): number {
+        this.authoritativeLoadInFlight = undefined;
+        this.authoritativeRefreshPending = false;
         this.abortController?.abort();
         this.abortController = undefined;
         this.watch?.dispose();
@@ -270,6 +276,8 @@ export class ConversationViewer implements ConversationViewerApi {
     }
 
     private clear(_restoreTarget: ConversationViewerTarget | undefined): void {
+        this.authoritativeLoadInFlight = undefined;
+        this.authoritativeRefreshPending = false;
         this.abortController?.abort();
         this.abortController = undefined;
         this.watch?.dispose();
@@ -403,7 +411,37 @@ export class ConversationViewer implements ConversationViewerApi {
         }, 'replace', false, 'navigation', latestInteractionId);
     }
 
-    private async loadAuthoritative(
+    private loadAuthoritative(
+        updateKind: 'initial' | 'refresh',
+        replaceDocument: boolean
+    ): Promise<boolean> {
+        if (this.authoritativeLoadInFlight) {
+            this.authoritativeRefreshPending = true;
+            return this.authoritativeLoadInFlight;
+        }
+        let loadInFlight: Promise<boolean>;
+        loadInFlight = this.performAuthoritativeLoad(
+            updateKind,
+            replaceDocument
+        ).finally(() => {
+            if (this.authoritativeLoadInFlight !== loadInFlight) {
+                return;
+            }
+            this.authoritativeLoadInFlight = undefined;
+            if (!this.authoritativeRefreshPending
+                || !this.target
+                || !this.panel
+                || this.suspended) {
+                return;
+            }
+            this.authoritativeRefreshPending = false;
+            void this.loadAuthoritative('refresh', false);
+        });
+        this.authoritativeLoadInFlight = loadInFlight;
+        return loadInFlight;
+    }
+
+    private async performAuthoritativeLoad(
         updateKind: 'initial' | 'refresh',
         replaceDocument: boolean
     ): Promise<boolean> {

--- a/tests/integration/dashboard/conversationViewer.test.js
+++ b/tests/integration/dashboard/conversationViewer.test.js
@@ -612,6 +612,64 @@ test('CONVERSATION-VIEWER-REFRESH-001 retains stale content after a watched fail
     assert.equal(publication.partial, true);
 });
 
+test('CONVERSATION-VIEWER-LOADING-001 coalesces watched invalidations without starving the initial publication', async t => {
+    let onChange;
+    let outlineReads = 0;
+    let initialSignal;
+    const initialOutline = deferred();
+    const { viewer, panel } = createViewer({
+        watch: (_provider, _sessionId, callback) => {
+            onChange = callback;
+            return { dispose() {} };
+        },
+        readOutline: async (_provider, sessionId, signal) => {
+            outlineReads += 1;
+            if (outlineReads === 1) {
+                initialSignal = signal;
+                return initialOutline.promise;
+            }
+            return outline(sessionId, ['input-1'], {
+                sourceRevision: `r${outlineReads}`,
+            });
+        },
+        readPage: async request => page(
+            request.sessionId,
+            request.anchorInteractionId,
+            `visible-${request.expectedRevision}`,
+            { sourceRevision: request.expectedRevision }
+        ),
+    });
+    t.after(() => viewer.dispose());
+
+    const opening = viewer.open(target('session-a', 'input-1'));
+    await new Promise(resolve => setImmediate(resolve));
+    assert.equal(outlineReads, 1);
+
+    onChange();
+    onChange();
+    onChange();
+    await new Promise(resolve => setImmediate(resolve));
+    const initialWasAborted = initialSignal.aborted;
+    const readsBeforeInitialSettled = outlineReads;
+
+    initialOutline.resolve(outline('session-a', ['input-1'], {
+        sourceRevision: 'r1',
+    }));
+    await opening;
+    await new Promise(resolve => setImmediate(resolve));
+
+    assert.equal(initialWasAborted, false);
+    assert.equal(readsBeforeInitialSettled, 1);
+    assert.equal(outlineReads, 2);
+    const publications = panel.postedMessages.filter(message =>
+        message.type === 'conversation-viewer-page');
+    assert.equal(panel.webview.html.includes('visible-r1'), true);
+    assert.equal(publications.length, 1);
+    assert.equal(publications[0].updateKind, 'refresh');
+    assert.equal(publications[0].html.includes('visible-r2'), true);
+    assert.equal(panel.webview.html.includes('Loading conversation…'), false);
+});
+
 test('CONVERSATION-VIEWER-AUTHORITY-003 suspends exact authority without clearing the snapshot and resumes with a fresh watch/read', async () => {
     let outlineReads = 0;
     let pageReads = 0;


### PR DESCRIPTION
## Summary
- serialize authoritative Conversation Viewer reads with a single-flight guard
- coalesce repeated watcher invalidations into one trailing refresh
- preserve cancellation on target replacement, disposal, and authority loss
- add P0 regression coverage and main-capability audit evidence

## Verification
- `npm run test:ci:linux` (1091 coverage tests, 96 browser tests, all gates passed)
- `npm run test:integration` (264 passed)
- `npm run test:behavior-contracts`
- focused `CONVERSATION-VIEWER-LOADING-001` regression test
- `git diff --check`

No version, changelog, tag, release, or publishing changes.
