### PR TITLE
feat: configure global skills location

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ navigates to that input. Agent Pivot reads the provider-local session metadata
 and transcript only when needed for its session and conversation views.
 
 The AI tab's SKILLS subtab organizes skills as the on-disk folder tree of the
-shared stores (`~/.skills` globally, `<project>/.skills` per project) —
+shared stores (`~/.skills` globally by default, configurable from Settings or the
+Global section menu; `<project>/.skills` per project) —
 folders are real directories you can also manage with shell or git, never
 extension state. Scope is positional: skills in the global store are enabled
 into the user-level agent directories (`~/.kimi/skills` and friends), skills

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -3709,5 +3709,25 @@
       "src/webview/webviewSkillContent.ts",
       "src/webview/webviewDashboardScripts.js"
     ]
+  },
+  {
+    "id": "PERSIST-AI-SKILL-GLOBAL-STORE-LOCATION-001",
+    "domain": "persistence",
+    "title": "Configurable Global Skills store relocation safety",
+    "priority": "P1",
+    "status": "automated",
+    "owners": [
+      "scripts/run-skill-management-checks.js",
+      "tests/contract/skills/globalStoreLocationController.test.js"
+    ],
+    "evidence": [
+      "package.json",
+      "src/skills/globalStoreService.ts",
+      "src/skills/globalStoreLocationController.ts",
+      "src/skills/discovery.ts",
+      "src/skills/dashboardController.ts",
+      "src/dashboard.ts",
+      "src/webview/webviewDashboardScripts.js"
+    ]
   }
 ]

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -966,8 +966,8 @@
         },
         {
             "id": "MAIN-AI-SKILL-MANAGEMENT",
-            "title": "Central AI skill store with scoped agent links",
-            "requirement": "Skills live in a central on-disk store with folder trees; per-agent enablement is symlink-based per scope, and every mutation (centralize, migrate, sync, delete, folder batch) enforces containment and survives authoritative webview refreshes.",
+            "title": "Configurable central AI skill store with scoped agent links",
+            "requirement": "Skills live in a configurable Global on-disk store or project-relative store with folder trees; per-agent enablement is symlink-based per scope, and every mutation (centralize, migrate, relocate, sync, delete, folder batch) enforces containment and survives authoritative webview refreshes.",
             "commits": [
                 "b50fcc95bdd5cc05af97ce227389c9ade3bc37bf",
                 "c44ce9548239bf376c85c652f875ee471dd85be9",
@@ -1022,10 +1022,12 @@
                 "PERSIST-AI-SKILL-CENTRAL-STORE-001",
                 "PERSIST-AI-SKILL-DISCOVERY-001",
                 "WEBVIEW-AI-SKILL-PANEL-001",
-                "PERSIST-AI-SKILL-SCOPE-ACTION-001"
+                "PERSIST-AI-SKILL-SCOPE-ACTION-001",
+                "PERSIST-AI-SKILL-GLOBAL-STORE-LOCATION-001"
             ],
             "prGates": [
                 "test:skills",
+                "test:contract",
                 "test:browser:run",
                 "test:safety:run"
             ],

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "9f88b5972cbfd8e712186652a99d162a669575f8",
+        "head": "6056ad799f05619a93fabe4af56e5955246e2231",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -1016,7 +1016,9 @@
                 "e4b885de35211191473f72c0bb27a95ce72eb921",
                 "4a6149ea6edf8607a488aed01c72d4463f069f61",
                 "a732939522c647edf588f29c0f9cbc6e8fa87077",
-                "9f88b5972cbfd8e712186652a99d162a669575f8"
+                "9f88b5972cbfd8e712186652a99d162a669575f8",
+                "75f261ee54b28569284b15e6260576831f7b2e81",
+                "6056ad799f05619a93fabe4af56e5955246e2231"
             ],
             "behaviors": [
                 "PERSIST-AI-SKILL-CENTRAL-STORE-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "6056ad799f05619a93fabe4af56e5955246e2231",
+        "head": "7ebe4973e9fed30042171f08f8048e142f2a2f49",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -1018,7 +1018,8 @@
                 "a732939522c647edf588f29c0f9cbc6e8fa87077",
                 "9f88b5972cbfd8e712186652a99d162a669575f8",
                 "75f261ee54b28569284b15e6260576831f7b2e81",
-                "6056ad799f05619a93fabe4af56e5955246e2231"
+                "6056ad799f05619a93fabe4af56e5955246e2231",
+                "7ebe4973e9fed30042171f08f8048e142f2a2f49"
             ],
             "behaviors": [
                 "PERSIST-AI-SKILL-CENTRAL-STORE-001",

--- a/media/webviewDashboardScripts.js
+++ b/media/webviewDashboardScripts.js
@@ -1165,7 +1165,7 @@ function initDashboard(options) {
         skillFolderMenu = menu;
     }
 
-    // Section (global / project) ⋯ menu: store-level actions, currently New folder.
+    // Section (global / project) ⋯ menu: store-level actions.
     function openSkillSectionMenu(button) {
         closeSkillFolderMenu();
         var scope = button.getAttribute('data-section-menu') || 'user';
@@ -1181,6 +1181,14 @@ function initDashboard(options) {
         newItem.setAttribute('data-folder-scope', scope);
         var migrateItem = appendMenuAction(menu, 'skill-folder-menu-migrate', 'Migrate to central…');
         migrateItem.setAttribute('data-skill-menu-migrate', scope);
+        if (scope === 'user') {
+            var locationItem = appendMenuAction(
+                menu,
+                'skill-folder-menu-location',
+                'Change Global Skills Location…'
+            );
+            locationItem.setAttribute('data-change-global-skills-location', '');
+        }
         document.body.appendChild(menu);
         positionSkillFolderMenu(menu, button);
         menu.__sourceButton = button;
@@ -1542,6 +1550,16 @@ function initDashboard(options) {
             event.stopPropagation();
             closeSkillFolderMenu();
             options.postMessage({ type: 'migrate-skills-to-central', scope: migrateCentral.getAttribute('data-skill-menu-migrate') });
+            return;
+        }
+        var changeGlobalSkillsLocation = event.target && event.target.closest
+            ? event.target.closest('[data-change-global-skills-location]')
+            : null;
+        if (changeGlobalSkillsLocation) {
+            event.preventDefault();
+            event.stopPropagation();
+            closeSkillFolderMenu();
+            options.postMessage({ type: 'change-global-skills-location' });
             return;
         }
         var sync = event.target && event.target.closest ? event.target.closest('[data-skill-sync]') : null;

--- a/package.json
+++ b/package.json
@@ -91,6 +91,10 @@
                 "title": "Agent Pivot: Migrate Skills to Central Store"
             },
             {
+                "command": "agentPivot.changeGlobalSkillsLocation",
+                "title": "Agent Pivot: Change Global Skills Location"
+            },
+            {
                 "command": "agentPivot.openCurrentAiSessionConversation",
                 "title": "Agent Pivot: Open Current AI Session Conversation"
             }
@@ -303,6 +307,12 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Show attention indicators when Agent Pivot AI sessions finish or may need input."
+                },
+                "agentPivot.skills.globalStorePath": {
+                    "type": "string",
+                    "default": "~/.skills",
+                    "scope": "machine",
+                    "markdownDescription": "Location of the Global Skills store. Use `~` or an absolute path. Agent Pivot can safely move existing skills when this changes. Project Skills remain in each project's `.skills` folder."
                 },
                 "agentPivot.displayProjectPath": {
                     "type": "boolean",

--- a/scripts/run-dashboard-webview-checks.js
+++ b/scripts/run-dashboard-webview-checks.js
@@ -3586,6 +3586,7 @@ async function runDashboardCommandRegistrationChecks() {
         'addFileToActiveTerminal',
         'insertPromptToActiveTerminal',
         'migrateSkillsToCentral',
+        'changeGlobalSkillsLocation',
         'openCurrentAiSessionConversation',
     ];
     const registration = new DashboardCommandRegistration({
@@ -3612,6 +3613,7 @@ async function runDashboardCommandRegistrationChecks() {
         'agentPivot.addFileToActiveTerminal',
         'agentPivot.insertPromptToActiveTerminal',
         'agentPivot.migrateSkillsToCentral',
+        'agentPivot.changeGlobalSkillsLocation',
         'agentPivot.openCurrentAiSessionConversation',
     ]);
     assert.deepStrictEqual(subscriptions.map(disposable => disposable.command), registered.map(([command]) => command));
@@ -3641,6 +3643,7 @@ async function runDashboardCommandRegistrationChecks() {
         'addFileToActiveTerminal',
         'insertPromptToActiveTerminal',
         'migrateSkillsToCentral',
+        'changeGlobalSkillsLocation',
         'openCurrentAiSessionConversation',
     ]);
 

--- a/scripts/run-skill-management-checks.js
+++ b/scripts/run-skill-management-checks.js
@@ -5,6 +5,7 @@
 // PERSIST-AI-SKILL-GLOBAL-STORE-LOCATION-001.
 
 const assert = require('assert');
+const childProcess = require('child_process');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
@@ -611,6 +612,135 @@ function runGlobalStoreLocationChecks() {
     assert.strictEqual(recoveredLock.ok, true,
         'an abandoned lock owned by a dead Extension Host is recovered');
     recoveredLock.lock.release();
+    const raceTarget = path.join(home, 'stale-lock-race-target');
+    const raceSeed = globalStore.acquireTargetMutationLock(raceTarget);
+    assert.strictEqual(raceSeed.ok, true);
+    const raceLockPath = raceSeed.lock.lockPath;
+    raceSeed.lock.release();
+    fs.writeFileSync(raceLockPath, JSON.stringify({
+        pid: 2_147_483_647,
+        createdAt: Date.now() - 60_000,
+    }));
+    const raceState = path.join(home, 'stale-lock-race-state');
+    fs.mkdirSync(raceState, { recursive: true });
+    const childSource = String.raw`
+        const fs = require('fs');
+        const [modulePath, targetPath, lockPath, statePath, id] = process.argv.slice(1);
+        const service = require(modulePath);
+        const pause = milliseconds => Atomics.wait(
+            new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
+        const waitFor = (predicate, timeout = 5000) => {
+            const deadline = Date.now() + timeout;
+            while (!predicate()) {
+                if (Date.now() >= deadline) {
+                    throw new Error('barrier timeout for ' + id);
+                }
+                pause(5);
+            }
+        };
+        waitFor(() => fs.existsSync(statePath + '/start'));
+        const realLstat = fs.lstatSync;
+        const realUnlink = fs.unlinkSync;
+        let observed = false;
+        let delayedDelete = false;
+        fs.lstatSync = candidate => {
+            if (candidate === lockPath && !observed) {
+                const staleStats = realLstat(candidate);
+                observed = true;
+                fs.writeFileSync(statePath + '/seen-' + id, '');
+                try {
+                    waitFor(() => fs.existsSync(statePath + '/seen-B')
+                        && fs.existsSync(statePath + '/seen-C'), 750);
+                } catch (_error) {
+                    // With the recovery guard only one process reaches the
+                    // stale main lock; without it both cross this barrier.
+                }
+                return staleStats;
+            }
+            return realLstat(candidate);
+        };
+        fs.unlinkSync = candidate => {
+            if (candidate === lockPath && id === 'C' && !delayedDelete
+                && fs.existsSync(statePath + '/seen-B')
+                && fs.existsSync(statePath + '/seen-C')) {
+                delayedDelete = true;
+                waitFor(() => fs.existsSync(statePath + '/acquired-B'));
+            }
+            return realUnlink(candidate);
+        };
+        try {
+            const result = service.acquireTargetMutationLock(targetPath);
+            const outcome = result.ok ? 'acquired' : 'blocked';
+            fs.writeFileSync(statePath + '/' + outcome + '-' + id, '');
+            fs.writeFileSync(statePath + '/result-' + id, outcome);
+            if (result.ok) {
+                waitFor(() => fs.existsSync(statePath + '/result-B')
+                    && fs.existsSync(statePath + '/result-C'));
+                pause(100);
+                result.lock.release();
+            }
+        } catch (error) {
+            fs.writeFileSync(statePath + '/result-' + id, 'error:' + error.message);
+        } finally {
+            fs.writeFileSync(statePath + '/done-' + id, '');
+        }
+    `;
+    const modulePath = require.resolve('../out/skills/globalStoreService');
+    const children = ['B', 'C'].map(id => childProcess.spawn(
+        process.execPath,
+        ['-e', childSource, modulePath, raceTarget, raceLockPath, raceState, id],
+        { stdio: 'ignore' },
+    ));
+    fs.writeFileSync(path.join(raceState, 'start'), '');
+    const waitForRace = (predicate, message) => {
+        const deadline = Date.now() + 10_000;
+        while (!predicate()) {
+            assert.ok(Date.now() < deadline, message);
+            Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 5);
+        }
+    };
+    waitForRace(
+        () => fs.existsSync(path.join(raceState, 'result-B'))
+            && fs.existsSync(path.join(raceState, 'result-C')),
+        'stale lock recovery children timed out',
+    );
+    const raceOutcomes = ['B', 'C'].map(id =>
+        fs.readFileSync(path.join(raceState, `result-${id}`), 'utf8'));
+    assert.strictEqual(
+        raceOutcomes.filter(outcome => outcome === 'acquired').length,
+        1,
+        `exactly one stale-lock recovery contender acquires: ${raceOutcomes.join(', ')}`,
+    );
+    waitForRace(
+        () => fs.existsSync(path.join(raceState, 'done-B'))
+            && fs.existsSync(path.join(raceState, 'done-C')),
+        'stale lock recovery children did not finish',
+    );
+    for (const child of children) {
+        if (child.exitCode === null) {
+            child.kill();
+        }
+    }
+    const crashedGuardPath = `${raceLockPath}.guard`;
+    fs.mkdirSync(crashedGuardPath);
+    fs.writeFileSync(path.join(crashedGuardPath, 'owner.json'), JSON.stringify({
+        pid: 2_147_483_647,
+        createdAt: Date.now() - 60_000,
+    }));
+    const recoveredGuard = globalStore.acquireTargetMutationLock(raceTarget);
+    assert.strictEqual(recoveredGuard.ok, true,
+        'a recovery guard abandoned by a dead Extension Host is recovered');
+    recoveredGuard.lock.release();
+    const crashedQuarantinePath = `${crashedGuardPath}.quarantine`;
+    fs.mkdirSync(crashedQuarantinePath);
+    fs.writeFileSync(path.join(crashedQuarantinePath, 'owner.json'), JSON.stringify({
+        pid: 2_147_483_647,
+        createdAt: Date.now() - 60_000,
+    }));
+    const recoveredQuarantine = globalStore.acquireTargetMutationLock(raceTarget);
+    assert.strictEqual(recoveredQuarantine.ok, true,
+        'a guard crash during quarantine is normalized and recovered');
+    recoveredQuarantine.lock.release();
     const sharedSource = path.join(home, 'shared-source-lock');
     const sourceAndTargetLock = globalStore.acquireSkillsMutationLocks([
         sharedSource,

--- a/scripts/run-skill-management-checks.js
+++ b/scripts/run-skill-management-checks.js
@@ -601,7 +601,16 @@ function runGlobalStoreLocationChecks() {
     firstLock.lock.release();
     const releasedLock = globalStore.acquireTargetMutationLock(lockedTarget);
     assert.strictEqual(releasedLock.ok, true, 'a completed mutation releases its target lock');
+    const staleLockPath = releasedLock.lock.lockPath;
     releasedLock.lock.release();
+    fs.writeFileSync(staleLockPath, JSON.stringify({
+        pid: 2_147_483_647,
+        createdAt: Date.now() - 60_000,
+    }));
+    const recoveredLock = globalStore.acquireTargetMutationLock(lockedTarget);
+    assert.strictEqual(recoveredLock.ok, true,
+        'an abandoned lock owned by a dead Extension Host is recovered');
+    recoveredLock.lock.release();
     const sharedSource = path.join(home, 'shared-source-lock');
     const sourceAndTargetLock = globalStore.acquireSkillsMutationLocks([
         sharedSource,
@@ -623,7 +632,7 @@ function runGlobalStoreLocationChecks() {
     fs.mkdirSync(agentRoot, { recursive: true });
     fs.symlinkSync(path.join(sourceRoot, 'pack', 'alpha'), path.join(agentRoot, 'alpha'), 'dir');
     const moved = globalStore.relocateGlobalSkillsStore(sourceRoot, targetRoot);
-    assert.strictEqual(moved.ok, true);
+    assert.strictEqual(moved.ok, true, moved.error);
     assert.strictEqual(moved.moved, true);
     assert.strictEqual(moved.aliasCreated, true);
     assert.ok(fs.lstatSync(sourceRoot).isSymbolicLink(), 'old root becomes a compatibility alias');
@@ -1166,6 +1175,16 @@ function runSkillCentralChecks() {
     const claudSolo = beforeCentralize.find(record => record.name === 'solo' && record.source === 'claude');
     const soloDuplicates = beforeCentralize.filter(record =>
         record.scope === claudSolo.scope && record.name === claudSolo.name && record.dirPath !== claudSolo.dirPath);
+    const relocatingStoreLock = globalStore.acquireSkillsMutationLocks([
+        path.join(home, '.skills'),
+    ]);
+    assert.strictEqual(relocatingStoreLock.ok, true);
+    assert.strictEqual(
+        centralService.centralizeSkill(claudSolo, soloDuplicates, home, ws).ok,
+        false,
+        'a Global store relocation lock blocks child centralization',
+    );
+    relocatingStoreLock.lock.release();
     const centralized = centralService.centralizeSkill(claudSolo, soloDuplicates, home, ws);
     assert.strictEqual(centralized.ok, true);
     assert.strictEqual(centralized.dirPath, path.join(home, '.skills', 'solo'));

--- a/scripts/run-skill-management-checks.js
+++ b/scripts/run-skill-management-checks.js
@@ -1,7 +1,8 @@
 'use strict';
 
 // Covers PERSIST-AI-SKILL-CENTRAL-STORE-001, PERSIST-AI-SKILL-DISCOVERY-001,
-// and PERSIST-AI-SKILL-SCOPE-ACTION-001.
+// PERSIST-AI-SKILL-SCOPE-ACTION-001, and
+// PERSIST-AI-SKILL-GLOBAL-STORE-LOCATION-001.
 
 const assert = require('assert');
 const fs = require('fs');
@@ -10,6 +11,7 @@ const path = require('path');
 
 const frontmatter = require('../out/skills/frontmatter');
 const roots = require('../out/skills/roots');
+const globalStore = require('../out/skills/globalStoreService');
 const discovery = require('../out/skills/discovery');
 const effectiveness = require('../out/skills/effectiveness');
 
@@ -533,6 +535,7 @@ function runSkillWiringChecks() {
 
 runFrontmatterChecks();
 runRootsChecks();
+runGlobalStoreLocationChecks();
 runDiscoveryChecks();
 runEffectivenessChecks();
 runSkillRenderingChecks();
@@ -551,6 +554,330 @@ runSkillFolderServiceChecks();
 runSkillFolderControllerChecks();
 runSkillFolderMutationChecks();
 console.log('Skill management checks passed.');
+
+function runGlobalStoreLocationChecks() {
+    const real = dirPath => fs.realpathSync(dirPath);
+    const home = real(fs.mkdtempSync(path.join(os.tmpdir(), 'skills-global-store-')));
+    const workspace = real(fs.mkdtempSync(path.join(os.tmpdir(), 'skills-global-workspace-')));
+    const resolve = value => globalStore.resolveGlobalSkillsLocation(value, {
+        homeDir: home,
+        workspaceRoots: [workspace],
+    });
+
+    assert.deepStrictEqual(resolve('~/.skills'), {
+        ok: true,
+        configuredPath: path.join(home, '.skills'),
+        rootPath: path.join(home, '.skills'),
+    });
+    assert.deepStrictEqual(resolve('~/shared/agent-skills'), {
+        ok: true,
+        configuredPath: path.join(home, 'shared', 'agent-skills'),
+        rootPath: path.join(home, 'shared', 'agent-skills'),
+    });
+    assert.strictEqual(resolve('relative/skills').ok, false, 'relative paths are rejected');
+    assert.strictEqual(resolve('~other/skills').ok, false, 'other-user tilde paths are rejected');
+    assert.strictEqual(resolve(path.parse(home).root).ok, false, 'filesystem root is rejected');
+    assert.strictEqual(resolve(home).ok, false, 'home directory itself is rejected');
+    assert.strictEqual(resolve(workspace).ok, false, 'workspace root itself is rejected');
+    assert.strictEqual(resolve(path.join(home, '.codex', 'skills', 'central')).ok, false,
+        'a store inside an agent root is rejected');
+    assert.strictEqual(resolve(path.join(home, '.codex')).ok, false,
+        'an ancestor of an agent root is rejected');
+    assert.strictEqual(resolve(path.join(workspace, '.skills')).ok, false,
+        'the project central store cannot also be the global store');
+
+    const sourceRoot = path.join(home, '.skills');
+    const targetRoot = path.join(home, 'shared', 'skills');
+    const write = (filePath, content) => {
+        fs.mkdirSync(path.dirname(filePath), { recursive: true });
+        fs.writeFileSync(filePath, content);
+    };
+    const lockedTarget = path.join(home, 'locked-target');
+    const firstLock = globalStore.acquireTargetMutationLock(lockedTarget);
+    assert.strictEqual(firstLock.ok, true);
+    const competingLock = globalStore.acquireTargetMutationLock(lockedTarget);
+    assert.strictEqual(competingLock.ok, false,
+        'cooperating windows cannot mutate the same target concurrently');
+    firstLock.lock.release();
+    const releasedLock = globalStore.acquireTargetMutationLock(lockedTarget);
+    assert.strictEqual(releasedLock.ok, true, 'a completed mutation releases its target lock');
+    releasedLock.lock.release();
+    const sharedSource = path.join(home, 'shared-source-lock');
+    const sourceAndTargetLock = globalStore.acquireSkillsMutationLocks([
+        sharedSource,
+        path.join(home, 'target-a'),
+    ]);
+    assert.strictEqual(sourceAndTargetLock.ok, true);
+    const splitBrainLock = globalStore.acquireSkillsMutationLocks([
+        sharedSource,
+        path.join(home, 'target-b'),
+    ]);
+    assert.strictEqual(splitBrainLock.ok, false,
+        'one source cannot be migrated concurrently to two different targets');
+    sourceAndTargetLock.lock.release();
+
+    write(path.join(sourceRoot, 'pack', 'alpha', 'SKILL.md'),
+        '---\nname: alpha\ndescription: A\n---\n');
+    assert.strictEqual(globalStore.hasGlobalSkillsStoreContent(sourceRoot), true);
+    const agentRoot = path.join(home, '.codex', 'skills');
+    fs.mkdirSync(agentRoot, { recursive: true });
+    fs.symlinkSync(path.join(sourceRoot, 'pack', 'alpha'), path.join(agentRoot, 'alpha'), 'dir');
+    const moved = globalStore.relocateGlobalSkillsStore(sourceRoot, targetRoot);
+    assert.strictEqual(moved.ok, true);
+    assert.strictEqual(moved.moved, true);
+    assert.strictEqual(moved.aliasCreated, true);
+    assert.ok(fs.lstatSync(sourceRoot).isSymbolicLink(), 'old root becomes a compatibility alias');
+    assert.strictEqual(real(sourceRoot), real(targetRoot));
+    assert.ok(fs.existsSync(path.join(targetRoot, 'pack', 'alpha', 'SKILL.md')));
+    assert.strictEqual(
+        fs.readdirSync(targetRoot).some(name => name.startsWith('.agent-pivot-owner-')),
+        false,
+        'a committed relocation releases its ownership marker',
+    );
+    assert.strictEqual(real(path.join(agentRoot, 'alpha')), real(path.join(targetRoot, 'pack', 'alpha')),
+        'an existing agent link through the old root remains valid');
+
+    const aliasResolution = resolve('~/.skills');
+    assert.strictEqual(aliasResolution.ok, true);
+    assert.strictEqual(aliasResolution.configuredPath, sourceRoot);
+    assert.strictEqual(aliasResolution.rootPath, real(targetRoot),
+        'configured aliases resolve to the physical managed store');
+
+    const occupiedSource = path.join(home, 'occupied-source');
+    const occupiedTarget = path.join(home, 'occupied-target');
+    write(path.join(occupiedSource, 'beta', 'SKILL.md'), 'beta');
+    write(path.join(occupiedTarget, 'foreign.txt'), 'foreign');
+    const occupied = globalStore.relocateGlobalSkillsStore(occupiedSource, occupiedTarget);
+    assert.strictEqual(occupied.ok, false, 'non-empty targets are never merged or overwritten');
+    assert.ok(fs.existsSync(path.join(occupiedSource, 'beta', 'SKILL.md')));
+    assert.strictEqual(fs.readFileSync(path.join(occupiedTarget, 'foreign.txt'), 'utf8'), 'foreign');
+
+    const crossSource = path.join(home, 'cross-source');
+    const crossTarget = path.join(home, 'cross-target');
+    write(path.join(crossSource, 'nested', 'gamma', 'SKILL.md'), 'gamma');
+    const cross = globalStore.relocateGlobalSkillsStore(crossSource, crossTarget);
+    assert.strictEqual(cross.ok, true, 'migration uses a verified copy protocol');
+    assert.ok(fs.lstatSync(crossSource).isSymbolicLink());
+    assert.ok(fs.existsSync(path.join(crossTarget, 'nested', 'gamma', 'SKILL.md')));
+
+    const lateSource = path.join(home, 'late-source');
+    const lateTarget = path.join(home, 'late-target');
+    write(path.join(lateSource, 'epsilon', 'SKILL.md'), 'epsilon');
+    const late = globalStore.relocateGlobalSkillsStore(lateSource, lateTarget, {
+        renameSync(from, to) {
+            if (path.basename(from) === path.basename(lateSource)
+                && to.includes(`${path.sep}.agent-pivot-global-store-`)) {
+                write(path.join(from, 'late.txt'), 'arrived during migration');
+            }
+            fs.renameSync(from, to);
+        },
+    });
+    assert.strictEqual(late.ok, false,
+        'a write that arrives after the first verification aborts migration');
+    assert.strictEqual(
+        fs.readFileSync(path.join(lateSource, 'late.txt'), 'utf8'),
+        'arrived during migration',
+        'the late write remains authoritative at the source',
+    );
+    assert.strictEqual(late.recoveryPath, lateTarget);
+    assert.ok(fs.existsSync(lateTarget),
+        'a failed public target is retained for safe recovery');
+
+    const occupiedRollbackSource = path.join(home, 'occupied-rollback-source');
+    const occupiedRollbackTarget = path.join(home, 'occupied-rollback-target');
+    write(path.join(occupiedRollbackSource, 'zeta', 'SKILL.md'), 'zeta');
+    const occupiedRollback = globalStore.relocateGlobalSkillsStore(
+        occupiedRollbackSource,
+        occupiedRollbackTarget,
+        {
+            renameSync(from, to) {
+                fs.renameSync(from, to);
+                if (path.basename(from) === path.basename(occupiedRollbackSource)
+                    && to.includes(`${path.sep}.agent-pivot-global-store-`)) {
+                    fs.mkdirSync(from);
+                    write(path.join(from, 'concurrent.txt'), 'do not overwrite');
+                }
+            },
+        },
+    );
+    assert.strictEqual(occupiedRollback.ok, false);
+    assert.strictEqual(
+        fs.readFileSync(path.join(occupiedRollbackSource, 'concurrent.txt'), 'utf8'),
+        'do not overwrite',
+        'rollback never overwrites a concurrently occupied source slot',
+    );
+    assert.ok(occupiedRollback.recoveryPath);
+    assert.ok(occupiedRollback.error.includes(occupiedRollback.recoveryPath));
+    assert.ok(fs.existsSync(path.join(occupiedRollback.recoveryPath, 'zeta', 'SKILL.md')),
+        'the original store remains recoverable at the reported path');
+    assert.ok(fs.existsSync(occupiedRollbackTarget),
+        'the incomplete target is retained without touching the concurrent source');
+
+    const rollbackSource = path.join(home, 'rollback-source');
+    const rollbackTarget = path.join(home, 'rollback-target');
+    write(path.join(rollbackSource, 'delta', 'SKILL.md'), 'delta');
+    const rollback = globalStore.relocateGlobalSkillsStore(rollbackSource, rollbackTarget, {
+        copyFileSync() {
+            throw new Error('copy failed');
+        },
+    });
+    assert.strictEqual(rollback.ok, false);
+    assert.ok(fs.existsSync(path.join(rollbackSource, 'delta', 'SKILL.md')),
+        'failed copy leaves the source authoritative');
+    assert.strictEqual(rollback.recoveryPath, rollbackTarget);
+    assert.ok(fs.existsSync(rollbackTarget), 'failed target is retained for safe recovery');
+
+    const destinationRaceSource = path.join(home, 'destination-race-source');
+    const destinationRaceTarget = path.join(home, 'destination-race-target');
+    write(path.join(destinationRaceSource, 'eta', 'SKILL.md'), 'eta');
+    const destinationRace = globalStore.relocateGlobalSkillsStore(
+        destinationRaceSource,
+        destinationRaceTarget,
+        {
+            mkdirSync(candidate, options) {
+                if (candidate === destinationRaceTarget) {
+                    fs.mkdirSync(destinationRaceTarget);
+                }
+                return fs.mkdirSync(candidate, options);
+            },
+        },
+    );
+    assert.strictEqual(destinationRace.ok, false,
+        'a destination claimed by another window aborts relocation');
+    assert.ok(fs.existsSync(path.join(destinationRaceSource, 'eta', 'SKILL.md')));
+    assert.ok(fs.existsSync(destinationRaceTarget),
+        'the concurrently claimed destination is not removed');
+    assert.deepStrictEqual(fs.readdirSync(destinationRaceTarget), []);
+
+    const replacedTargetSource = path.join(home, 'replaced-target-source');
+    const replacedTarget = path.join(home, 'replaced-target');
+    write(path.join(replacedTargetSource, 'theta', 'SKILL.md'), 'theta');
+    const replaced = globalStore.relocateGlobalSkillsStore(
+        replacedTargetSource,
+        replacedTarget,
+        {
+            copyFileSync() {
+                fs.rmSync(replacedTarget, { recursive: true, force: true });
+                fs.mkdirSync(replacedTarget);
+                write(path.join(replacedTarget, 'foreign.txt'), 'foreign owner');
+                throw new Error('copy lost ownership');
+            },
+        },
+    );
+    assert.strictEqual(replaced.ok, false);
+    assert.strictEqual(replaced.recoveryPath, replacedTarget);
+    assert.ok(replaced.error.includes(replacedTarget));
+    assert.strictEqual(
+        fs.readFileSync(path.join(replacedTarget, 'foreign.txt'), 'utf8'),
+        'foreign owner',
+        'failed relocation never deletes a target replaced after the atomic claim',
+    );
+    assert.ok(fs.existsSync(path.join(replacedTargetSource, 'theta', 'SKILL.md')));
+
+    const preCaptureSource = path.join(home, 'pre-capture-source');
+    const preCaptureTarget = path.join(home, 'pre-capture-target');
+    write(path.join(preCaptureSource, 'iota', 'SKILL.md'), 'iota');
+    const preCapture = globalStore.relocateGlobalSkillsStore(
+        preCaptureSource,
+        preCaptureTarget,
+        {
+            mkdirSync(candidate, options) {
+                const result = fs.mkdirSync(candidate, options);
+                if (candidate === preCaptureTarget) {
+                    fs.rmSync(preCaptureTarget, { recursive: true, force: true });
+                    fs.mkdirSync(preCaptureTarget);
+                    write(path.join(preCaptureTarget, 'iota', 'SKILL.md'), 'foreign before marker');
+                }
+                return result;
+            },
+        },
+    );
+    assert.strictEqual(preCapture.ok, false);
+    assert.strictEqual(preCapture.recoveryPath, preCaptureTarget);
+    assert.strictEqual(
+        fs.readFileSync(path.join(preCaptureTarget, 'iota', 'SKILL.md'), 'utf8'),
+        'foreign before marker',
+        'relocation preserves a target replaced before identity capture',
+    );
+    assert.ok(fs.existsSync(path.join(preCaptureSource, 'iota', 'SKILL.md')));
+
+    const customRoot = path.join(home, 'configured-global-skills');
+    write(path.join(customRoot, 'custom', 'SKILL.md'),
+        '---\nname: custom\ndescription: Custom\n---\n');
+    fs.symlinkSync(path.join(customRoot, 'custom'), path.join(agentRoot, 'custom'), 'dir');
+    const scan = discovery.scanSkills({
+        homeDir: home,
+        workspaceRoot: workspace,
+        globalSkillsRoot: customRoot,
+    });
+    const custom = scan.find(record => record.name === 'custom');
+    assert.ok(custom?.central, 'configured Global root is discovered as central');
+    assert.strictEqual(custom.dirPath, path.join(customRoot, 'custom'));
+    assert.strictEqual(custom.central.links.user.codex, path.join(agentRoot, 'custom'));
+
+    assert.strictEqual(
+        roots.getCentralSkillsRoot(home, 'user', undefined, customRoot),
+        customRoot,
+        'all Global central root resolution accepts the configured root'
+    );
+    assert.strictEqual(
+        roots.getCentralSkillsRoot(home, 'project', workspace, customRoot),
+        path.join(workspace, '.skills'),
+        'Project central root stays fixed even when Global is configured'
+    );
+
+    write(path.join(home, '.kimi', 'skills', 'configured-destination', 'SKILL.md'),
+        '---\nname: configured-destination\ndescription: Destination\n---\n');
+    const controller = new SkillDashboardController({
+        getHomeDir: () => home,
+        getWorkspaceRoot: () => workspace,
+        getGlobalSkillsRoot: () => customRoot,
+        postMessage: () => Promise.resolve(true),
+        isVisible: () => false,
+        logError: () => undefined,
+    });
+    controller.start();
+    assert.deepStrictEqual(controller.getStoreRoots(), {
+        user: customRoot,
+        project: path.join(workspace, '.skills'),
+    });
+    assert.strictEqual(
+        controller.handleCentralize(
+            path.join(home, '.kimi', 'skills', 'configured-destination'),
+        ).ok,
+        true,
+        'controller mutations use the configured Global root',
+    );
+    assert.ok(fs.existsSync(path.join(customRoot, 'configured-destination', 'SKILL.md')));
+    controller.dispose();
+
+    const sourceScript = fs.readFileSync(
+        path.join(__dirname, '..', 'src', 'webview', 'webviewDashboardScripts.js'),
+        'utf8',
+    );
+    assert.ok(sourceScript.includes('Change Global Skills Location…'));
+    assert.ok(sourceScript.includes("if (scope === 'user')"),
+        'the location action is only added to the Global section');
+    assert.ok(sourceScript.includes("type: 'change-global-skills-location'"));
+    const dashboard = fs.readFileSync(path.join(__dirname, '..', 'src', 'dashboard.ts'), 'utf8');
+    assert.ok(dashboard.includes("'change-global-skills-location'"));
+    assert.ok(dashboard.includes(
+        'globalStoreLocationController.changeInteractively()',
+    ));
+    const packageJson = JSON.parse(
+        fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8'),
+    );
+    const setting = packageJson.contributes.configuration.properties[
+        'agentPivot.skills.globalStorePath'
+    ];
+    assert.deepStrictEqual(
+        { type: setting.type, default: setting.default, scope: setting.scope },
+        { type: 'string', default: '~/.skills', scope: 'machine' },
+    );
+    assert.ok(packageJson.contributes.commands.some(
+        command => command.command === 'agentPivot.changeGlobalSkillsLocation',
+    ));
+}
 
 function runSkillFixChecks() {
     const fixService = require('../out/skills/fixService');
@@ -843,6 +1170,12 @@ function runSkillCentralChecks() {
     assert.strictEqual(centralized.ok, true);
     assert.strictEqual(centralized.dirPath, path.join(home, '.skills', 'solo'));
     assert.ok(fs.existsSync(path.join(home, '.skills', 'solo', 'SKILL.md')), 'skill content moved into the store');
+    assert.strictEqual(
+        fs.readdirSync(path.join(home, '.skills', 'solo'))
+            .some(name => name.startsWith('.agent-pivot-owner-')),
+        false,
+        'a committed centralize releases its ownership marker',
+    );
     assert.ok(fs.lstatSync(path.join(home, '.claude', 'skills', 'solo')).isSymbolicLink(), 'original root links back');
     assert.strictEqual(fs.realpathSync(path.join(home, '.claude', 'skills', 'solo')), path.join(home, '.skills', 'solo'));
     assert.ok(!fs.existsSync(path.join(home, '.codex', 'skills', 'solo')), 'losing copy left its root');
@@ -852,6 +1185,216 @@ function runSkillCentralChecks() {
     const soloRecords = rescanned.filter(record => record.name === 'solo');
     assert.strictEqual(soloRecords.length, 1, 'centralized skill merges into one record');
     assert.strictEqual(soloRecords[0].source, 'central');
+
+    const crossHome = real(fs.mkdtempSync(path.join(os.tmpdir(), 'skills-central-cross-')));
+    const crossStore = path.join(crossHome, 'configured-global');
+    const crossSource = path.join(crossHome, '.kimi', 'skills', 'cross');
+    fs.mkdirSync(crossSource, { recursive: true });
+    fs.writeFileSync(path.join(crossSource, 'SKILL.md'),
+        '---\nname: cross\ndescription: Cross-device\n---\n');
+    const crossRecord = discovery.scanSkills({ homeDir: crossHome })
+        .find(record => record.name === 'cross');
+    const crossCentralized = centralService.centralizeSkill(
+        crossRecord,
+        [],
+        crossHome,
+        undefined,
+        {
+            globalSkillsRoot: crossStore,
+        },
+    );
+    assert.strictEqual(crossCentralized.ok, true,
+        'centralize uses a verified copy protocol across configured roots');
+    assert.ok(fs.existsSync(path.join(crossStore, 'cross', 'SKILL.md')));
+    assert.strictEqual(
+        fs.realpathSync(crossSource),
+        path.join(crossStore, 'cross'),
+        'cross-device centralize links the original agent slot to the configured store',
+    );
+
+    const changingSource = path.join(crossHome, '.claude', 'skills', 'changing');
+    fs.mkdirSync(changingSource, { recursive: true });
+    fs.writeFileSync(path.join(changingSource, 'SKILL.md'),
+        '---\nname: changing\ndescription: Changing\n---\n');
+    const changingRecord = discovery.scanSkills({
+        homeDir: crossHome,
+        globalSkillsRoot: crossStore,
+    }).find(record => record.name === 'changing');
+    const changing = centralService.centralizeSkill(
+        changingRecord,
+        [],
+        crossHome,
+        undefined,
+        {
+            globalSkillsRoot: crossStore,
+            renameSync(from, to) {
+                if (path.basename(from) === path.basename(changingSource)
+                    && to.includes(`${path.sep}.agent-pivot-centralize-`)) {
+                    fs.writeFileSync(path.join(from, 'late.txt'), 'late');
+                }
+                fs.renameSync(from, to);
+            },
+        },
+    );
+    assert.strictEqual(changing.ok, false,
+        'cross-device centralize aborts when the source changes before commit');
+    assert.strictEqual(fs.readFileSync(path.join(changingSource, 'late.txt'), 'utf8'), 'late');
+    assert.strictEqual(changing.recoveryPath, path.join(crossStore, 'changing'));
+    assert.ok(fs.existsSync(path.join(crossStore, 'changing')));
+
+    const occupiedSource = path.join(crossHome, '.codex', 'skills', 'occupied');
+    fs.mkdirSync(occupiedSource, { recursive: true });
+    fs.writeFileSync(path.join(occupiedSource, 'SKILL.md'),
+        '---\nname: occupied\ndescription: Occupied rollback\n---\n');
+    const occupiedRecord = discovery.scanSkills({
+        homeDir: crossHome,
+        globalSkillsRoot: crossStore,
+    }).find(record => record.name === 'occupied');
+    const occupiedCentralize = centralService.centralizeSkill(
+        occupiedRecord,
+        [],
+        crossHome,
+        undefined,
+        {
+            globalSkillsRoot: crossStore,
+            renameSync(from, to) {
+                fs.renameSync(from, to);
+                if (path.basename(from) === path.basename(occupiedSource)
+                    && to.includes(`${path.sep}.agent-pivot-centralize-`)) {
+                    fs.mkdirSync(from);
+                    fs.writeFileSync(path.join(from, 'concurrent.txt'), 'concurrent');
+                }
+            },
+        },
+    );
+    assert.strictEqual(occupiedCentralize.ok, false);
+    assert.ok(occupiedCentralize.recoveryPath,
+        'an incomplete centralize rollback reports the authoritative recovery path');
+    assert.ok(occupiedCentralize.error.includes(occupiedCentralize.recoveryPath));
+    assert.ok(fs.existsSync(path.join(occupiedCentralize.recoveryPath, 'SKILL.md')));
+    assert.strictEqual(
+        fs.readFileSync(path.join(occupiedSource, 'concurrent.txt'), 'utf8'),
+        'concurrent',
+        'centralize rollback never overwrites a concurrently occupied source slot',
+    );
+
+    const destinationRaceSource = path.join(crossHome, '.kimi', 'skills', 'destination-race');
+    fs.mkdirSync(destinationRaceSource, { recursive: true });
+    fs.writeFileSync(path.join(destinationRaceSource, 'SKILL.md'),
+        '---\nname: destination-race\ndescription: Destination race\n---\n');
+    const destinationRaceRecord = discovery.scanSkills({
+        homeDir: crossHome,
+        globalSkillsRoot: crossStore,
+    }).find(record => record.name === 'destination-race');
+    const destinationRaceTarget = path.join(crossStore, 'destination-race');
+    const destinationRaceCentralize = centralService.centralizeSkill(
+        destinationRaceRecord,
+        [],
+        crossHome,
+        undefined,
+        {
+            globalSkillsRoot: crossStore,
+            mkdirSync(candidate, options) {
+                if (candidate === destinationRaceTarget) {
+                    fs.mkdirSync(destinationRaceTarget);
+                }
+                return fs.mkdirSync(candidate, options);
+            },
+        },
+    );
+    assert.strictEqual(destinationRaceCentralize.ok, false,
+        'centralize aborts when another window claims the destination');
+    assert.ok(fs.existsSync(path.join(destinationRaceSource, 'SKILL.md')));
+    assert.ok(fs.existsSync(destinationRaceTarget),
+        'centralize does not remove a concurrently claimed destination');
+    assert.deepStrictEqual(fs.readdirSync(destinationRaceTarget), []);
+
+    const replacedDestinationSource = path.join(
+        crossHome,
+        '.claude',
+        'skills',
+        'replaced-destination',
+    );
+    fs.mkdirSync(replacedDestinationSource, { recursive: true });
+    fs.writeFileSync(path.join(replacedDestinationSource, 'SKILL.md'),
+        '---\nname: replaced-destination\ndescription: Replaced destination\n---\n');
+    const replacedDestinationRecord = discovery.scanSkills({
+        homeDir: crossHome,
+        globalSkillsRoot: crossStore,
+    }).find(record => record.name === 'replaced-destination');
+    const replacedDestinationTarget = path.join(crossStore, 'replaced-destination');
+    const replacedDestination = centralService.centralizeSkill(
+        replacedDestinationRecord,
+        [],
+        crossHome,
+        undefined,
+        {
+            globalSkillsRoot: crossStore,
+            copyFileSync() {
+                fs.rmSync(replacedDestinationTarget, { recursive: true, force: true });
+                fs.mkdirSync(replacedDestinationTarget);
+                fs.writeFileSync(
+                    path.join(replacedDestinationTarget, 'foreign.txt'),
+                    'foreign owner',
+                );
+                throw new Error('copy lost ownership');
+            },
+        },
+    );
+    assert.strictEqual(replacedDestination.ok, false);
+    assert.strictEqual(replacedDestination.recoveryPath, replacedDestinationTarget);
+    assert.ok(replacedDestination.error.includes(replacedDestinationTarget));
+    assert.strictEqual(
+        fs.readFileSync(path.join(replacedDestinationTarget, 'foreign.txt'), 'utf8'),
+        'foreign owner',
+        'failed centralization never deletes a target replaced after the atomic claim',
+    );
+    assert.ok(fs.existsSync(path.join(replacedDestinationSource, 'SKILL.md')));
+
+    const preCaptureDestinationSource = path.join(
+        crossHome,
+        '.codex',
+        'skills',
+        'pre-capture-destination',
+    );
+    fs.mkdirSync(preCaptureDestinationSource, { recursive: true });
+    fs.writeFileSync(path.join(preCaptureDestinationSource, 'SKILL.md'),
+        '---\nname: pre-capture-destination\ndescription: Pre-capture destination\n---\n');
+    const preCaptureDestinationRecord = discovery.scanSkills({
+        homeDir: crossHome,
+        globalSkillsRoot: crossStore,
+    }).find(record => record.name === 'pre-capture-destination');
+    const preCaptureDestinationTarget = path.join(crossStore, 'pre-capture-destination');
+    const preCaptureDestination = centralService.centralizeSkill(
+        preCaptureDestinationRecord,
+        [],
+        crossHome,
+        undefined,
+        {
+            globalSkillsRoot: crossStore,
+            mkdirSync(candidate, options) {
+                const result = fs.mkdirSync(candidate, options);
+                if (candidate === preCaptureDestinationTarget) {
+                    fs.rmSync(preCaptureDestinationTarget, { recursive: true, force: true });
+                    fs.mkdirSync(preCaptureDestinationTarget);
+                    fs.writeFileSync(
+                        path.join(preCaptureDestinationTarget, 'SKILL.md'),
+                        'foreign before marker',
+                    );
+                }
+                return result;
+            },
+        },
+    );
+    assert.strictEqual(preCaptureDestination.ok, false);
+    assert.strictEqual(preCaptureDestination.recoveryPath, preCaptureDestinationTarget);
+    assert.strictEqual(
+        fs.readFileSync(path.join(preCaptureDestinationTarget, 'SKILL.md'), 'utf8'),
+        'foreign before marker',
+        'centralize preserves a target replaced before identity capture',
+    );
+    assert.ok(fs.existsSync(path.join(preCaptureDestinationSource, 'SKILL.md')));
+
     assert.deepStrictEqual(soloRecords[0].central.links, { user: { claude: path.join(home, '.claude', 'skills', 'solo') } });
     assert.strictEqual(centralService.centralizeSkill(soloRecords[0], [], home, ws).ok, false, 'already centralized is refused');
 

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -27,6 +27,7 @@ import { initializePromptMementoStore, PromptService } from './prompts/service';
 import { PromptTerminalCommandController } from './prompts/terminalCommandController';
 import { getAiPanelContent, getPromptSurfaceContent } from './prompts/webviewContent';
 import { SkillDashboardController } from './skills/dashboardController';
+import { GlobalStoreLocationController } from './skills/globalStoreLocationController';
 import { skillDirectoriesEqual } from './skills/scopeService';
 import { SkillGroupStore } from './skills/skillGroupStore';
 import {
@@ -436,6 +437,30 @@ async function initializeDashboard(
         createId: () => randomBytes(16).toString('hex'),
         logDiagnostic: event => logDashboardDiagnostic({ event: 'prompt-store', ...event }),
     });
+    const getWorkspaceRootPaths = (): string[] =>
+        (vscode.workspace.workspaceFolders || []).map(folder => folder.uri.fsPath);
+    const globalStoreLocationController = new GlobalStoreLocationController({
+        homeDir: os.homedir(),
+        getWorkspaceRoots: getWorkspaceRootPaths,
+        readSetting: () => getAgentPivotConfiguration().get<string>(
+            'skills.globalStorePath',
+            '~/.skills',
+        ),
+        writeSetting: value => getAgentPivotConfiguration().update(
+            'skills.globalStorePath',
+            value,
+            vscode.ConfigurationTarget.Global,
+        ),
+        showInputBox: options => vscode.window.showInputBox(options),
+        showWarningMessage: (message, options, ...items) => options
+            ? vscode.window.showWarningMessage(message, options, ...items)
+            : vscode.window.showWarningMessage(message),
+        showErrorMessage: message => vscode.window.showErrorMessage(message),
+        refresh: () => skillDashboardController.refresh(
+            'global-skills-location-changed',
+        ),
+        logError,
+    });
     const promptDashboardController = new PromptDashboardController({
         service: promptService,
         confirmDelete: async prompt => {
@@ -458,6 +483,7 @@ async function initializeDashboard(
     const skillDashboardController = ownResource(() => new SkillDashboardController({
         getHomeDir: () => os.homedir(),
         getWorkspaceRoot: () => vscode.workspace.workspaceFolders?.[0]?.uri.fsPath,
+        getGlobalSkillsRoot: () => globalStoreLocationController.getActiveRoot(),
         postMessage: message => provider.postMessage(message),
         isVisible: () => provider.visible,
         logError,
@@ -515,7 +541,10 @@ async function initializeDashboard(
         const projectNames = new Set(migratable.filter(record => record.scope === 'project').map(record => record.name));
         const segments: string[] = [];
         if (userNames.size) {
-            segments.push(`${userNames.size} user skill(s) into ~/.skills`);
+            segments.push(
+                `${userNames.size} user skill(s) into `
+                + skillDashboardController.getStoreRoots().user,
+            );
         }
         if (hasWorkspace && projectNames.size) {
             segments.push(`${projectNames.size} project skill(s) into this project's .skills`);
@@ -1727,6 +1756,9 @@ async function initializeDashboard(
             'migrate-skills-to-central': e => {
                 void runSkillMigrationToCentral(e.scope === 'project' ? 'project' : e.scope === 'user' ? 'user' : undefined);
             },
+            'change-global-skills-location': () => {
+                void globalStoreLocationController.changeInteractively();
+            },
             'fix-skill-diagnostic': e => {
                 const result = skillDashboardController.handleFixSkillDiagnostic(
                     String(e.dirPath || ''),
@@ -2390,6 +2422,11 @@ async function initializeDashboard(
     });
     const dashboardLifecycleController = new DashboardLifecycleController({
         prepareConfigurationChange: async event => {
+            if (event.affectsConfiguration(
+                `${AGENT_PIVOT_CONFIG_SECTION}.skills.globalStorePath`,
+            )) {
+                await globalStoreLocationController.handleConfigurationChange();
+            }
             if (event.affectsConfiguration(`${AGENT_PIVOT_CONFIG_SECTION}.aiSessionTerminalMode`)
                 || event.affectsConfiguration(`${AGENT_PIVOT_CONFIG_SECTION}.aiSessionTmuxLayout`)
                 || event.affectsConfiguration(`${AGENT_PIVOT_CONFIG_SECTION}.aiSessionTmuxPath`)) {
@@ -2459,6 +2496,8 @@ async function initializeDashboard(
         addFileToActiveTerminal: () => activeTerminalFileReferenceController.addFileToActiveTerminal(),
         insertPromptToActiveTerminal: () => promptTerminalCommandController.insertPromptToActiveTerminal(),
         migrateSkillsToCentral: () => runSkillMigrationToCentral(),
+        changeGlobalSkillsLocation: () =>
+            globalStoreLocationController.changeInteractively(),
         openCurrentAiSessionConversation: () => openCurrentAiSessionConversation(),
     };
 

--- a/src/dashboard/commandRegistration.ts
+++ b/src/dashboard/commandRegistration.ts
@@ -18,6 +18,7 @@ export interface DashboardCommandHandlers {
     addFileToActiveTerminal: DashboardCommandHandler;
     insertPromptToActiveTerminal: DashboardCommandHandler;
     migrateSkillsToCentral: DashboardCommandHandler;
+    changeGlobalSkillsLocation: DashboardCommandHandler;
     openCurrentAiSessionConversation: DashboardCommandHandler;
 }
 
@@ -44,6 +45,7 @@ const DASHBOARD_COMMANDS: ReadonlyArray<readonly [string, DashboardCommandName]>
     ['agentPivot.addFileToActiveTerminal', 'addFileToActiveTerminal'],
     ['agentPivot.insertPromptToActiveTerminal', 'insertPromptToActiveTerminal'],
     ['agentPivot.migrateSkillsToCentral', 'migrateSkillsToCentral'],
+    ['agentPivot.changeGlobalSkillsLocation', 'changeGlobalSkillsLocation'],
     ['agentPivot.openCurrentAiSessionConversation', 'openCurrentAiSessionConversation'],
 ];
 

--- a/src/dashboard/lifecycleController.ts
+++ b/src/dashboard/lifecycleController.ts
@@ -16,6 +16,7 @@ const NON_TODO_DASHBOARD_CONFIGURATION_SECTIONS = [
     'aiSessionTmuxPath',
     'aiSessionRunningCardAnimation',
     'aiSessionRunningIconAnimation',
+    'skills.globalStorePath',
     'maxVisibleTodosPerGroup',
     'maxVisibleProjectsPerGroup',
     'aiSessionAttention.enabled',

--- a/src/skills/centralService.ts
+++ b/src/skills/centralService.ts
@@ -3,12 +3,24 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
+import {
+    acquireSkillsMutationLocks,
+    captureDirectoryIdentity,
+    copyDirectoryContents,
+    DirectoryIdentity,
+    directoryTreesEqual,
+    releaseDirectoryIdentity,
+    retainFailedTarget,
+    restoreDirectoryWithoutOverwrite,
+    TargetMutationLock,
+} from './globalStoreService';
 import { getCentralSkillsRoot, getProjectSkillsRoots, getUserSkillsRoots, SkillsRoot } from './roots';
 import type { SkillAgentId, SkillRecord, SkillScope, SkillSourceDir } from './types';
 
 export interface CentralResult {
     ok: boolean;
     dirPath?: string;
+    recoveryPath?: string;
     error?: string;
 }
 
@@ -88,6 +100,16 @@ function deleteRealDir(dirPath: string): CentralResult {
     }
 }
 
+function pathSlotOccupied(candidate: string): boolean {
+    try {
+        fs.lstatSync(candidate);
+        return true;
+    } catch (error) {
+        return !(error instanceof Error) || !('code' in error)
+            || (error as NodeJS.ErrnoException).code !== 'ENOENT';
+    }
+}
+
 /**
  * Move a real-directory skill into the central store and link it back from
  * its original root. Duplicate real-dir copies (same scope + name) are
@@ -100,24 +122,76 @@ export function centralizeSkill(
     workspaceRoot?: string,
     options: CentralizeOptions = {},
 ): CentralResult {
+    const renameSync = options.renameSync || fs.renameSync;
+    const copyFileSync = options.copyFileSync || fs.copyFileSync;
+    const mkdirSync = options.mkdirSync || fs.mkdirSync;
+    let destination = '';
+    let ownRoot: SkillsRoot | undefined;
+    let destinationCreated = false;
+    let destinationIdentity: DirectoryIdentity | undefined;
+    let targetLock: TargetMutationLock | undefined;
+    let linkCreated = false;
+    let asideContainer: string | undefined;
+    let aside: string | undefined;
     try {
         if (record.central) {
             return { ok: false, error: 'Skill is already centralized.' };
         }
-        const centralRoot = getCentralSkillsRoot(homeDir, record.scope, workspaceRoot);
-        const destination = path.join(centralRoot, record.name);
-        if (fs.existsSync(destination)) {
+        const centralRoot = getCentralSkillsRoot(
+            homeDir,
+            record.scope,
+            workspaceRoot,
+            options.globalSkillsRoot,
+        );
+        destination = path.join(centralRoot, record.name);
+        fs.mkdirSync(centralRoot, { recursive: true });
+        const lockResult = acquireSkillsMutationLocks([record.dirPath, destination]);
+        if (lockResult.ok === false) {
+            return { ok: false, error: lockResult.error };
+        }
+        targetLock = lockResult.lock;
+        if (pathSlotOccupied(destination)) {
             return { ok: false, error: `Central store already has ${record.name}: ${destination}` };
         }
-        fs.mkdirSync(centralRoot, { recursive: true });
-        fs.renameSync(record.dirPath, destination);
+        // mkdir is the atomic no-overwrite claim on every filesystem. A direct
+        // rename could replace a concurrently created empty destination.
+        mkdirSync(destination, { recursive: false });
+        destinationCreated = true;
+        destinationIdentity = captureDirectoryIdentity(destination);
+        copyDirectoryContents(record.dirPath, destination, copyFileSync);
+        if (!directoryTreesEqual(record.dirPath, destination, destinationIdentity)) {
+            throw new Error('Copied skill content did not verify.');
+        }
+        asideContainer = fs.mkdtempSync(
+            path.join(path.dirname(record.dirPath), '.agent-pivot-centralize-'),
+        );
+        aside = path.join(asideContainer, path.basename(record.dirPath));
+        renameSync(record.dirPath, aside);
+        if (!directoryTreesEqual(aside, destination, destinationIdentity)) {
+            throw new Error('The skill changed during centralization.');
+        }
         // Link back from the record's original root so current effectiveness holds.
-        const ownRoot = knownBrandRoots(homeDir, workspaceRoot)
+        ownRoot = knownBrandRoots(homeDir, workspaceRoot)
             .find(root => root.source === record.source && root.scope === record.scope);
         if (options.linkBack !== false && ownRoot) {
             const link = setCentralLink(destination, ownRoot.dirPath, true);
             if (!link.ok) {
-                return link;
+                throw new Error(link.error || 'Could not link the centralized skill.');
+            }
+            linkCreated = link.changed === true;
+        }
+        const released = releaseDirectoryIdentity(destination, destinationIdentity);
+        if (!released.ok) {
+            throw new Error(released.error);
+        }
+        if (asideContainer) {
+            try {
+                fs.rmSync(asideContainer, { recursive: true, force: true });
+                aside = undefined;
+                asideContainer = undefined;
+            } catch (_error) {
+                // The verified destination and link are authoritative. Retaining
+                // the hidden backup is safer than rolling back a committed move.
             }
         }
         // Delete duplicate real-dir copies now that the winner is secured.
@@ -132,13 +206,66 @@ export function centralizeSkill(
         }
         return { ok: true, dirPath: destination };
     } catch (error) {
-        return { ok: false, error: error instanceof Error ? error.message : String(error) };
+        const rollbackErrors: string[] = [];
+        let targetRecoveryPath: string | undefined;
+        if (linkCreated && ownRoot) {
+            const removed = setCentralLink(destination, ownRoot.dirPath, false);
+            if (!removed.ok) {
+                rollbackErrors.push(removed.error || 'Could not remove the new agent link.');
+            }
+        }
+        if (aside) {
+            const cleanup = retainFailedTarget(destination, destinationIdentity);
+            if (cleanup.ok) {
+                destinationCreated = false;
+            } else {
+                rollbackErrors.push(cleanup.error || 'Could not safely remove the target.');
+                targetRecoveryPath = cleanup.recoveryPath;
+            }
+            const restored = restoreDirectoryWithoutOverwrite(
+                aside,
+                record.dirPath,
+                copyFileSync,
+            );
+            if (restored.ok) {
+                aside = undefined;
+            } else {
+                rollbackErrors.push(restored.error || 'Could not restore the original skill.');
+            }
+        } else if (destinationCreated && destination) {
+            const cleanup = retainFailedTarget(destination, destinationIdentity);
+            if (!cleanup.ok) {
+                rollbackErrors.push(cleanup.error || 'Could not safely remove the target.');
+                targetRecoveryPath = cleanup.recoveryPath;
+            }
+        }
+        if (!aside && asideContainer) {
+            try { fs.rmSync(asideContainer, { recursive: true, force: true }); } catch (_error) { /* best effort */ }
+        }
+        const message = error instanceof Error ? error.message : String(error);
+        const recoveryPath = aside || targetRecoveryPath;
+        return {
+            ok: false,
+            error: rollbackErrors.length
+                ? `${message} Rollback was incomplete: ${rollbackErrors.join(' ')}`
+                    + (recoveryPath ? ` Recovery data is at ${recoveryPath}.` : '')
+                : message,
+            recoveryPath,
+        };
+    } finally {
+        targetLock?.release();
     }
 }
 
 export interface CentralizeOptions {
     /** Link the centralized skill back from its original root (default true). */
     linkBack?: boolean;
+    /** Active physical Global store root. Project stores remain workspace-relative. */
+    globalSkillsRoot?: string;
+    /** Injectable filesystem operations used by cross-device safety tests. */
+    renameSync?: typeof fs.renameSync;
+    copyFileSync?: typeof fs.copyFileSync;
+    mkdirSync?: typeof fs.mkdirSync;
 }
 
 function walkSkillDirs(dirPath: string, found: string[]): string[] {
@@ -235,7 +362,11 @@ function sanitizeFolder(targetFolder: string): string | null {
  * re-point every existing link (both scopes) at the new location.
  */
 export function moveSkillToFolder(
-    record: SkillRecord, targetFolder: string, homeDir: string, workspaceRoot?: string,
+    record: SkillRecord,
+    targetFolder: string,
+    homeDir: string,
+    workspaceRoot?: string,
+    globalSkillsRoot?: string,
 ): CentralResult {
     try {
         if (!record.central) {
@@ -245,7 +376,7 @@ export function moveSkillToFolder(
         if (folder === null) {
             return { ok: false, error: `Invalid folder: ${targetFolder}` };
         }
-        const storeRoot = getCentralSkillsRoot(homeDir, record.scope, workspaceRoot);
+        const storeRoot = getCentralSkillsRoot(homeDir, record.scope, workspaceRoot, globalSkillsRoot);
         const destination = folder ? path.join(storeRoot, folder, record.name) : path.join(storeRoot, record.name);
         if (destination === record.dirPath) {
             return { ok: true, dirPath: destination };

--- a/src/skills/centralService.ts
+++ b/src/skills/centralService.ts
@@ -145,7 +145,7 @@ export function centralizeSkill(
         );
         destination = path.join(centralRoot, record.name);
         fs.mkdirSync(centralRoot, { recursive: true });
-        const lockResult = acquireSkillsMutationLocks([record.dirPath, destination]);
+        const lockResult = acquireSkillsMutationLocks([centralRoot, record.dirPath, destination]);
         if (lockResult.ok === false) {
             return { ok: false, error: lockResult.error };
         }
@@ -326,20 +326,32 @@ export function setFolderLinks(
     const roots = scope === 'user' ? getUserSkillsRoots(homeDir) : getProjectSkillsRoots(workspaceRoot as string);
     const agentRoots = roots.filter(root => agents.includes(root.source as SkillAgentId)
         && (root.source === 'kimi' || root.source === 'claude' || root.source === 'codex'));
-    for (const skillDir of walkSkillDirs(path.join(storeRoot, safeFolder), [])) {
-        for (const root of agentRoots) {
-            const link = setCentralLink(skillDir, root.dirPath, enable);
-            if (link.ok) {
-                if (link.changed) {
-                    result.changed += 1;
+    const lockResult = acquireSkillsMutationLocks([storeRoot]);
+    if (lockResult.ok === false) {
+        return {
+            ok: false,
+            changed: 0,
+            errors: [{ name: folder || '.', error: lockResult.error }],
+        };
+    }
+    try {
+        for (const skillDir of walkSkillDirs(path.join(storeRoot, safeFolder), [])) {
+            for (const root of agentRoots) {
+                const link = setCentralLink(skillDir, root.dirPath, enable);
+                if (link.ok) {
+                    if (link.changed) {
+                        result.changed += 1;
+                    }
+                } else {
+                    result.ok = false;
+                    result.errors.push({ name: path.basename(skillDir), error: link.error || 'unknown error' });
                 }
-            } else {
-                result.ok = false;
-                result.errors.push({ name: path.basename(skillDir), error: link.error || 'unknown error' });
             }
         }
+        return result;
+    } finally {
+        lockResult.lock.release();
     }
-    return result;
 }
 
 function sanitizeFolder(targetFolder: string): string | null {
@@ -368,6 +380,7 @@ export function moveSkillToFolder(
     workspaceRoot?: string,
     globalSkillsRoot?: string,
 ): CentralResult {
+    let storeLock: TargetMutationLock | undefined;
     try {
         if (!record.central) {
             return { ok: false, error: 'Only centralized skills can be moved between folders.' };
@@ -378,6 +391,13 @@ export function moveSkillToFolder(
         }
         const storeRoot = getCentralSkillsRoot(homeDir, record.scope, workspaceRoot, globalSkillsRoot);
         const destination = folder ? path.join(storeRoot, folder, record.name) : path.join(storeRoot, record.name);
+        // The store-root lock serializes every destination below it, including
+        // nested folders whose parent does not exist yet.
+        const lockResult = acquireSkillsMutationLocks([storeRoot, record.dirPath]);
+        if (lockResult.ok === false) {
+            return { ok: false, error: lockResult.error };
+        }
+        storeLock = lockResult.lock;
         if (destination === record.dirPath) {
             return { ok: true, dirPath: destination };
         }
@@ -405,6 +425,8 @@ export function moveSkillToFolder(
         return { ok: true, dirPath: destination };
     } catch (error) {
         return { ok: false, error: error instanceof Error ? error.message : String(error) };
+    } finally {
+        storeLock?.release();
     }
 }
 
@@ -415,12 +437,18 @@ export type { SkillScope, SkillSourceDir };
  * plain directories; creating them on demand is how the panel's "+" works.
  */
 export function createSkillFolder(storeRoot: string, targetFolder: string): CentralResult {
+    let storeLock: TargetMutationLock | undefined;
     try {
         const folder = sanitizeFolder(targetFolder);
         if (folder === null || folder === '') {
             return { ok: false, error: `Invalid folder: ${targetFolder}` };
         }
         const destination = path.join(storeRoot, folder);
+        const lockResult = acquireSkillsMutationLocks([storeRoot]);
+        if (lockResult.ok === false) {
+            return { ok: false, error: lockResult.error };
+        }
+        storeLock = lockResult.lock;
         if (fs.existsSync(destination)) {
             return { ok: false, error: `Folder already exists: ${destination}` };
         }
@@ -428,6 +456,8 @@ export function createSkillFolder(storeRoot: string, targetFolder: string): Cent
         return { ok: true, dirPath: destination };
     } catch (error) {
         return { ok: false, error: error instanceof Error ? error.message : String(error) };
+    } finally {
+        storeLock?.release();
     }
 }
 
@@ -438,12 +468,18 @@ export function createSkillFolder(storeRoot: string, targetFolder: string): Cent
  * delete escape onto the rest of the disk.
  */
 export function removeSkillFolder(storeRoot: string, targetFolder: string): CentralResult {
+    let storeLock: TargetMutationLock | undefined;
     try {
         const folder = sanitizeFolder(targetFolder);
         if (folder === null || folder === '') {
             return { ok: false, error: `Invalid folder: ${targetFolder}` };
         }
         const destination = path.join(storeRoot, folder);
+        const lockResult = acquireSkillsMutationLocks([storeRoot]);
+        if (lockResult.ok === false) {
+            return { ok: false, error: lockResult.error };
+        }
+        storeLock = lockResult.lock;
         let rootReal: string;
         let destReal: string;
         try {
@@ -465,5 +501,7 @@ export function removeSkillFolder(storeRoot: string, targetFolder: string): Cent
         return { ok: true };
     } catch (error) {
         return { ok: false, error: error instanceof Error ? error.message : String(error) };
+    } finally {
+        storeLock?.release();
     }
 }

--- a/src/skills/dashboardController.ts
+++ b/src/skills/dashboardController.ts
@@ -19,6 +19,7 @@ import type { SkillAgentId, SkillDiagnostic, SkillRecord, SkillScope } from './t
 export interface SkillDashboardControllerOptions {
     getHomeDir: () => string;
     getWorkspaceRoot: () => string | undefined;
+    getGlobalSkillsRoot?: () => string;
     postMessage: (message: unknown) => Thenable<boolean>;
     isVisible: () => boolean;
     logError: (message: string, error: unknown) => void;
@@ -94,7 +95,7 @@ export class SkillDashboardController {
     getStoreRoots(): { user: string; project?: string } {
         const workspaceRoot = this.options.getWorkspaceRoot();
         return {
-            user: getCentralSkillsRoot(this.options.getHomeDir(), 'user'),
+            user: this.getGlobalSkillsRoot(),
             project: workspaceRoot ? getCentralSkillsRoot(this.options.getHomeDir(), 'project', workspaceRoot) : undefined,
         };
     }
@@ -114,7 +115,7 @@ export class SkillDashboardController {
         const workspaceRoot = this.options.getWorkspaceRoot();
         const storeRoot = scope === 'project'
             ? (workspaceRoot ? getCentralSkillsRoot(this.options.getHomeDir(), 'project', workspaceRoot) : null)
-            : getCentralSkillsRoot(this.options.getHomeDir(), 'user');
+            : this.getGlobalSkillsRoot();
         if (!storeRoot) {
             return { ok: false, error: 'No workspace is open for project folders.' };
         }
@@ -202,7 +203,13 @@ export class SkillDashboardController {
                 ? 'Open a project before applying a global skill.'
                 : `Unknown global skill: ${dirPath}`, code: 'invalid' };
         }
-        const result = setGlobalSkillProjectAgents(record, agents, this.options.getHomeDir(), workspaceRoot);
+        const result = setGlobalSkillProjectAgents(
+            record,
+            agents,
+            this.options.getHomeDir(),
+            workspaceRoot,
+            this.getGlobalSkillsRoot(),
+        );
         if (!result.ok) {
             this.options.logError('Failed to apply the global skill to the project.', new Error(result.error || 'unknown error'));
         }
@@ -215,6 +222,7 @@ export class SkillDashboardController {
             ? scanSkillsDetailed({
                 homeDir: this.options.getHomeDir(),
                 workspaceRoot,
+                globalSkillsRoot: this.getGlobalSkillsRoot(),
             }).records
             : [];
         const record = freshRecords.find(candidate =>
@@ -235,7 +243,12 @@ export class SkillDashboardController {
         }
         const existingGlobal = globalMatches[0];
         const result = moveProjectSkillToGlobal(
-            record, existingGlobal, this.options.getHomeDir(), workspaceRoot);
+            record,
+            existingGlobal,
+            this.options.getHomeDir(),
+            workspaceRoot,
+            this.getGlobalSkillsRoot(),
+        );
         if (!result.ok) {
             this.options.logError('Failed to move the project skill to Global.', new Error(result.error || 'unknown error'));
         }
@@ -260,7 +273,13 @@ export class SkillDashboardController {
         if (!record) {
             return { ok: false, error: `Unknown centralized skill: ${dirPath}` };
         }
-        const result = moveSkillToFolder(record, folder, this.options.getHomeDir(), this.options.getWorkspaceRoot());
+        const result = moveSkillToFolder(
+            record,
+            folder,
+            this.options.getHomeDir(),
+            this.options.getWorkspaceRoot(),
+            this.getGlobalSkillsRoot(),
+        );
         if (!result.ok) {
             this.options.logError('Failed to move the skill.', new Error(result.error || 'unknown error'));
         }
@@ -278,7 +297,13 @@ export class SkillDashboardController {
             && !candidate.central
             && (candidate.source === 'kimi' || candidate.source === 'claude' || candidate.source === 'codex')
         );
-        const result = centralizeSkill(record, duplicates, this.options.getHomeDir(), this.options.getWorkspaceRoot());
+        const result = centralizeSkill(
+            record,
+            duplicates,
+            this.options.getHomeDir(),
+            this.options.getWorkspaceRoot(),
+            { globalSkillsRoot: this.getGlobalSkillsRoot() },
+        );
         if (!result.ok) {
             this.options.logError('Failed to centralize the skill.', new Error(result.error || 'unknown error'));
         }
@@ -289,7 +314,13 @@ export class SkillDashboardController {
     handleMigrateToCentral(scope?: SkillScope): SkillMigrationReport {
         const report = scope === 'project'
             ? migrateSkillsToCentral(this.records, this.options.getHomeDir(), 'project', this.options.getWorkspaceRoot())
-            : migrateSkillsToCentral(this.records, this.options.getHomeDir(), 'user');
+            : migrateSkillsToCentral(
+                this.records,
+                this.options.getHomeDir(),
+                'user',
+                undefined,
+                this.getGlobalSkillsRoot(),
+            );
         if (!scope && this.options.getWorkspaceRoot()) {
             const projectReport = migrateSkillsToCentral(this.records, this.options.getHomeDir(), 'project', this.options.getWorkspaceRoot());
             report.ok = report.ok && projectReport.ok;
@@ -322,7 +353,9 @@ export class SkillDashboardController {
                 const duplicates = this.records.filter(candidate =>
                     candidate.scope === record.scope && candidate.name === record.name
                     && candidate.dirPath !== record.dirPath);
-                const centralized = centralizeSkill(record, duplicates, homeDir, workspaceRoot);
+                const centralized = centralizeSkill(record, duplicates, homeDir, workspaceRoot, {
+                    globalSkillsRoot: this.getGlobalSkillsRoot(),
+                });
                 if (!centralized.ok) {
                     failures.push(`${record.name}: ${centralized.error}`);
                     continue;
@@ -335,7 +368,13 @@ export class SkillDashboardController {
                 failures.push(`${record.name}: lost after centralizing`);
                 continue;
             }
-            const moved = moveSkillToFolder(current, collection.name, homeDir, workspaceRoot);
+            const moved = moveSkillToFolder(
+                current,
+                collection.name,
+                homeDir,
+                workspaceRoot,
+                this.getGlobalSkillsRoot(),
+            );
             if (!moved.ok) {
                 failures.push(`${record.name}: ${moved.error}`);
             }
@@ -368,6 +407,7 @@ export class SkillDashboardController {
             const scan = scanSkillsDetailed({
                 homeDir: this.options.getHomeDir(),
                 workspaceRoot: this.options.getWorkspaceRoot(),
+                globalSkillsRoot: this.getGlobalSkillsRoot(),
             });
             this.records = scan.records;
             this.storeFolders = scan.storeFolders;
@@ -423,6 +463,11 @@ export class SkillDashboardController {
             .map(root => root.dirPath);
     }
 
+    private getGlobalSkillsRoot(): string {
+        return this.options.getGlobalSkillsRoot?.()
+            || getCentralSkillsRoot(this.options.getHomeDir(), 'user');
+    }
+
     private checkDeleteContainment(dirPath: string): string | null {
         if (!dirPath) {
             return 'Missing skill path.';
@@ -471,6 +516,7 @@ export class SkillDashboardController {
         const roots = getUserSkillsRoots(this.options.getHomeDir())
             .concat(workspaceRoot ? getProjectSkillsRoots(workspaceRoot) : []);
         const dirs = roots.map(root => root.dirPath)
+            .concat(this.getGlobalSkillsRoot())
             .concat(this.records.map(record => record.dirPath));
         for (const dirPath of dirs) {
             try {

--- a/src/skills/dashboardController.ts
+++ b/src/skills/dashboardController.ts
@@ -7,6 +7,7 @@ import { centralizeSkill, createSkillFolder, FolderLinkResult, moveSkillToFolder
 import { migrateSkillsToCentral, SkillMigrationReport } from './migrateService';
 import { scanSkillsDetailed } from './discovery';
 import { getCollectionSuggestions, KNOWN_SKILL_COLLECTIONS, SkillCollectionSuggestion } from './knownCollections';
+import { acquireSkillsMutationLocks } from './globalStoreService';
 import { getCentralSkillsRoot, getKimiBrandCandidates, getProjectSkillsRoots, getUserSkillsRoots } from './roots';
 import { computeSkillCopyTargets, copySkillDir, SkillCopyTarget, syncSkillDir } from './syncService';
 import { fixSkillDiagnostic } from './fixService';
@@ -141,29 +142,58 @@ export class SkillDashboardController {
     }
 
     handleSyncSkill(sourceDir: string, targetDir: string): { ok: boolean; error?: string } {
-        const known = new Set(this.records.map(record => record.dirPath));
-        if (!known.has(sourceDir) || !known.has(targetDir)) {
+        const sourceRecord = this.records.find(record => record.dirPath === sourceDir);
+        const targetRecord = this.records.find(record => record.dirPath === targetDir);
+        if (!sourceRecord || !targetRecord) {
             return { ok: false, error: 'Sync is only allowed between discovered skill copies.' };
         }
-        const result = syncSkillDir(sourceDir, targetDir);
-        if (!result.ok) {
-            this.options.logError('Failed to sync skills.', new Error(result.error || 'unknown error'));
+        const lockPaths = [sourceDir, targetDir];
+        for (const record of [sourceRecord, targetRecord]) {
+            const storeRoot = this.getCentralStoreRoot(record);
+            if (storeRoot) {
+                lockPaths.push(storeRoot);
+            }
         }
-        this.refresh('sync-skill');
-        return result;
+        const lockResult = acquireSkillsMutationLocks(lockPaths);
+        if (lockResult.ok === false) {
+            return { ok: false, error: lockResult.error };
+        }
+        try {
+            const result = syncSkillDir(sourceDir, targetDir);
+            if (!result.ok) {
+                this.options.logError('Failed to sync skills.', new Error(result.error || 'unknown error'));
+            }
+            this.refresh('sync-skill');
+            return result;
+        } finally {
+            lockResult.lock.release();
+        }
     }
 
     handleCopySkill(sourceDir: string, targetRoot: string): { ok: boolean; error?: string } {
-        const known = new Set(this.records.map(record => record.dirPath));
-        if (!known.has(sourceDir) || !this.getKnownRootDirs().includes(targetRoot)) {
+        const sourceRecord = this.records.find(record => record.dirPath === sourceDir);
+        if (!sourceRecord || !this.getKnownRootDirs().includes(targetRoot)) {
             return { ok: false, error: 'Copy is only allowed from a discovered skill into a known skills root.' };
         }
-        const result = copySkillDir(sourceDir, targetRoot);
-        if (!result.ok) {
-            this.options.logError('Failed to copy the skill.', new Error(result.error || 'unknown error'));
+        const storeRoot = this.getCentralStoreRoot(sourceRecord);
+        const lockPaths = storeRoot ? [storeRoot, sourceDir] : [sourceDir];
+        if (Object.values(this.getStoreRoots()).filter(Boolean).includes(targetRoot)) {
+            lockPaths.push(targetRoot);
         }
-        this.refresh('copy-skill');
-        return result;
+        const lockResult = acquireSkillsMutationLocks(lockPaths);
+        if (lockResult.ok === false) {
+            return { ok: false, error: lockResult.error };
+        }
+        try {
+            const result = copySkillDir(sourceDir, targetRoot);
+            if (!result.ok) {
+                this.options.logError('Failed to copy the skill.', new Error(result.error || 'unknown error'));
+            }
+            this.refresh('copy-skill');
+            return result;
+        } finally {
+            lockResult.lock.release();
+        }
     }
 
     handleCentralToggle(dirPath: string, scope: SkillScope, agent: SkillAgentId, enabled: boolean): { ok: boolean; error?: string } {
@@ -185,13 +215,22 @@ export class SkillDashboardController {
         if (!root) {
             return { ok: false, error: `Unknown ${scope} skills root for ${agent}.` };
         }
-        // enabled === true means the link currently exists → remove it; false → create it.
-        const result = setCentralLink(dirPath, root.dirPath, !enabled);
-        if (!result.ok) {
-            this.options.logError('Failed to toggle the skill link.', new Error(result.error || 'unknown error'));
+        const storeRoot = this.getCentralStoreRoot(record);
+        const lockResult = acquireSkillsMutationLocks(storeRoot ? [storeRoot] : [dirPath]);
+        if (lockResult.ok === false) {
+            return { ok: false, error: lockResult.error };
         }
-        this.refresh('central-toggle-skill');
-        return result;
+        try {
+            // enabled === true means the link currently exists → remove it; false → create it.
+            const result = setCentralLink(dirPath, root.dirPath, !enabled);
+            if (!result.ok) {
+                this.options.logError('Failed to toggle the skill link.', new Error(result.error || 'unknown error'));
+            }
+            this.refresh('central-toggle-skill');
+            return result;
+        } finally {
+            lockResult.lock.release();
+        }
     }
 
     handleSetGlobalSkillProjectAgents(dirPath: string, agents: SkillAgentId[]): SkillScopeActionResult {
@@ -431,6 +470,16 @@ export class SkillDashboardController {
         if (containmentError) {
             return { ok: false, error: containmentError };
         }
+        const record = this.records.find(candidate => candidate.dirPath === dirPath);
+        const lockPaths = [dirPath];
+        const storeRoot = record ? this.getCentralStoreRoot(record) : null;
+        if (storeRoot) {
+            lockPaths.push(storeRoot);
+        }
+        const lockResult = acquireSkillsMutationLocks(lockPaths);
+        if (lockResult.ok === false) {
+            return { ok: false, error: lockResult.error };
+        }
         try {
             fs.rmSync(dirPath, { recursive: true, force: true });
         } catch (error) {
@@ -438,6 +487,8 @@ export class SkillDashboardController {
             this.options.logError('Failed to delete the skill.', new Error(message));
             this.refresh('delete-skill');
             return { ok: false, error: message };
+        } finally {
+            lockResult.lock.release();
         }
         this.refresh('delete-skill');
         return { ok: true };
@@ -448,12 +499,23 @@ export class SkillDashboardController {
         if (!record) {
             return { ok: false, error: `Unknown skill: ${dirPath}` };
         }
-        const result = fixSkillDiagnostic(record, code);
-        if (!result.ok) {
-            this.options.logError('Failed to fix the skill diagnostic.', new Error(result.error || 'unknown error'));
+        const storeRoot = this.getCentralStoreRoot(record);
+        const lockResult = acquireSkillsMutationLocks(
+            storeRoot ? [storeRoot, dirPath] : [dirPath],
+        );
+        if (lockResult.ok === false) {
+            return { ok: false, error: lockResult.error };
         }
-        this.refresh('fix-skill-diagnostic');
-        return result;
+        try {
+            const result = fixSkillDiagnostic(record, code);
+            if (!result.ok) {
+                this.options.logError('Failed to fix the skill diagnostic.', new Error(result.error || 'unknown error'));
+            }
+            this.refresh('fix-skill-diagnostic');
+            return result;
+        } finally {
+            lockResult.lock.release();
+        }
     }
 
     private getKnownRootDirs(): string[] {
@@ -466,6 +528,19 @@ export class SkillDashboardController {
     private getGlobalSkillsRoot(): string {
         return this.options.getGlobalSkillsRoot?.()
             || getCentralSkillsRoot(this.options.getHomeDir(), 'user');
+    }
+
+    private getCentralStoreRoot(record: SkillRecord): string | null {
+        if (!record.central) {
+            return null;
+        }
+        if (record.scope === 'user') {
+            return this.getGlobalSkillsRoot();
+        }
+        const workspaceRoot = this.options.getWorkspaceRoot();
+        return workspaceRoot
+            ? getCentralSkillsRoot(this.options.getHomeDir(), 'project', workspaceRoot)
+            : null;
     }
 
     private checkDeleteContainment(dirPath: string): string | null {

--- a/src/skills/discovery.ts
+++ b/src/skills/discovery.ts
@@ -18,6 +18,7 @@ import type { SkillDiagnostic, SkillRecord, SkillScope, SkillSourceDir } from '.
 export interface ScanSkillsInput {
     homeDir: string;
     workspaceRoot?: string;
+    globalSkillsRoot?: string;
 }
 
 function readSkillFile(dirPath: string): { fileName: string; content: string } | null {
@@ -96,7 +97,7 @@ function scanDir(
             }
             // A symlink into the central store is an agent link, not a copy:
             // the record comes from the central-root scan, the link is noted.
-            if (isUnderCentralRoot(dirPath, input.homeDir, input.workspaceRoot)) {
+            if (isUnderCentralRoot(dirPath, input.homeDir, input.workspaceRoot, input.globalSkillsRoot)) {
                 links.push({
                     source: root.source,
                     scope: root.scope,
@@ -192,7 +193,11 @@ export function scanSkillsDetailed(input: ScanSkillsInput): ScanSkillsResult {
 
 function centralRoots(input: ScanSkillsInput): SkillsRoot[] {
     const roots: SkillsRoot[] = [
-        { source: 'central', scope: 'user', dirPath: getCentralSkillsRoot(input.homeDir, 'user') },
+        {
+            source: 'central',
+            scope: 'user',
+            dirPath: getCentralSkillsRoot(input.homeDir, 'user', undefined, input.globalSkillsRoot),
+        },
     ];
     if (input.workspaceRoot) {
         roots.push({ source: 'central', scope: 'project', dirPath: getCentralSkillsRoot(input.homeDir, 'project', input.workspaceRoot) });
@@ -204,13 +209,19 @@ function mergeCentralRecords(records: SkillRecord[], links: SkillLink[], input: 
     const byDir = new Map<string, SkillRecord>();
     const merged: SkillRecord[] = [];
     for (const record of records) {
-        if (record.source === 'central' || isUnderCentralRoot(record.dirPath, input.homeDir, input.workspaceRoot)) {
+        const centralScope = isUnderCentralRoot(
+            record.dirPath,
+            input.homeDir,
+            input.workspaceRoot,
+            input.globalSkillsRoot,
+        )?.scope;
+        if (record.source === 'central' || centralScope) {
             let existing = byDir.get(record.dirPath);
             if (!existing) {
                 existing = {
                     ...record,
                     source: 'central',
-                    scope: isUnderCentralRoot(record.dirPath, input.homeDir, input.workspaceRoot)?.scope || record.scope,
+                    scope: centralScope || record.scope,
                     central: { dirPath: record.dirPath, links: {} },
                 };
                 byDir.set(record.dirPath, existing);

--- a/src/skills/globalStoreLocationController.ts
+++ b/src/skills/globalStoreLocationController.ts
@@ -1,0 +1,234 @@
+'use strict';
+
+import * as path from 'path';
+
+import {
+    DEFAULT_GLOBAL_SKILLS_LOCATION,
+    hasGlobalSkillsStoreContent,
+    relocateGlobalSkillsStore,
+    RelocateGlobalSkillsStoreResult,
+    resolveGlobalSkillsLocation,
+} from './globalStoreService';
+
+export interface GlobalSkillsLocationInputOptions {
+    prompt: string;
+    value: string;
+    validateInput: (candidate: string) => string | undefined;
+}
+
+export interface GlobalStoreLocationControllerOptions {
+    homeDir: string;
+    getWorkspaceRoots: () => readonly string[];
+    readSetting: () => string;
+    writeSetting: (value: string) => PromiseLike<void>;
+    showInputBox: (
+        options: GlobalSkillsLocationInputOptions,
+    ) => PromiseLike<string | undefined>;
+    showWarningMessage: (
+        message: string,
+        options?: { modal: true },
+        ...items: string[]
+    ) => PromiseLike<string | undefined>;
+    showErrorMessage: (message: string) => unknown;
+    refresh: () => PromiseLike<unknown>;
+    logError: (message: string, error: unknown) => void;
+    relocate?: (
+        sourceRoot: string,
+        targetRoot: string,
+    ) => RelocateGlobalSkillsStoreResult;
+}
+
+export class GlobalStoreLocationController {
+    private activeValue: string;
+    private activeRoot: string;
+    private commandFlight: Promise<boolean> | null = null;
+    private mutationQueue: Promise<void> = Promise.resolve();
+
+    constructor(private readonly options: GlobalStoreLocationControllerOptions) {
+        const configuredValue = options.readSetting();
+        const configured = this.resolve(configuredValue);
+        const fallback = this.resolve(DEFAULT_GLOBAL_SKILLS_LOCATION);
+        this.activeValue = configured.ok
+            ? configuredValue
+            : DEFAULT_GLOBAL_SKILLS_LOCATION;
+        this.activeRoot = configured.rootPath
+            || fallback.rootPath
+            || path.join(options.homeDir, '.skills');
+        if (!configured.ok) {
+            void options.showWarningMessage(
+                `Agent Pivot ignored the invalid Global Skills Location and is using ~/.skills: `
+                + configured.error,
+            );
+        }
+    }
+
+    getActiveRoot(): string {
+        return this.activeRoot;
+    }
+
+    getActiveValue(): string {
+        return this.activeValue;
+    }
+
+    changeInteractively(): Promise<boolean> {
+        if (this.commandFlight) {
+            return this.commandFlight;
+        }
+        this.commandFlight = this.runInteractiveChange();
+        const clearFlight = (): void => {
+            this.commandFlight = null;
+        };
+        void this.commandFlight.then(clearFlight, clearFlight);
+        return this.commandFlight;
+    }
+
+    handleConfigurationChange(): Promise<boolean> {
+        return this.enqueue(async () => {
+            // Read inside the queue so coalesced Settings events apply only the
+            // latest effective machine value.
+            const requestedValue = this.options.readSetting();
+            const previousValue = this.activeValue;
+            if (await this.apply(requestedValue)) {
+                return true;
+            }
+            if (this.options.readSetting() !== requestedValue) {
+                // A newer Settings event is already queued. Never overwrite it
+                // while undoing a cancelled or invalid older request.
+                return false;
+            }
+            try {
+                await this.options.writeSetting(previousValue);
+            } catch (error) {
+                this.options.logError(
+                    'Failed to restore the previous Global Skills Location.',
+                    error,
+                );
+            }
+            return false;
+        });
+    }
+
+    private async runInteractiveChange(): Promise<boolean> {
+        const value = await this.options.showInputBox({
+            prompt: 'Change Global Skills Location. Use ~ or an absolute path; Project .skills folders are not changed.',
+            value: this.activeValue,
+            validateInput: candidate => {
+                const result = this.resolve(candidate);
+                return result.ok ? undefined : result.error;
+            },
+        });
+        if (value === undefined) {
+            return false;
+        }
+        const normalized = value.trim();
+        if (!await this.enqueue(() => this.apply(normalized))) {
+            return false;
+        }
+        try {
+            await this.options.writeSetting(normalized);
+            return true;
+        } catch (error) {
+            this.options.logError('Failed to save the Global Skills Location.', error);
+            this.options.showErrorMessage(
+                'The Global Skills Location changed for this session, but the setting could not be saved.',
+            );
+            return false;
+        }
+    }
+
+    private async apply(requestedValue: string): Promise<boolean> {
+        const currentResolved = this.resolve(this.activeRoot);
+        if (currentResolved.ok && currentResolved.rootPath) {
+            // Another Extension Host may have relocated the machine-wide store
+            // and left our lexical root as a compatibility alias.
+            this.activeRoot = currentResolved.rootPath;
+        }
+        const resolved = this.resolve(requestedValue);
+        if (!resolved.ok || !resolved.rootPath) {
+            void this.options.showWarningMessage(
+                `Could not use that Global Skills Location: ${resolved.error}`,
+            );
+            return false;
+        }
+        if (resolved.rootPath === this.activeRoot) {
+            this.activeValue = requestedValue;
+            return true;
+        }
+        if (this.locationsOverlap(this.activeRoot, resolved.rootPath)) {
+            void this.options.showWarningMessage(
+                'The old and new Global Skills locations cannot contain each other.',
+            );
+            return false;
+        }
+
+        if (hasGlobalSkillsStoreContent(this.activeRoot)) {
+            const choice = await this.options.showWarningMessage(
+                `Change the Global Skills Location from ${this.activeRoot} `
+                + `to ${resolved.rootPath}? Existing skills can be moved safely, `
+                + 'or left in the old location.',
+                { modal: true },
+                'Move Existing Skills',
+                'Use New Location',
+            );
+            if (choice === 'Move Existing Skills') {
+                const relocation = (this.options.relocate || relocateGlobalSkillsStore)(
+                    this.activeRoot,
+                    resolved.rootPath,
+                );
+                if (!relocation.ok) {
+                    this.options.showErrorMessage(
+                        `Could not move the Global Skills store. The old location is still active. `
+                        + `${relocation.error || 'Unknown error.'}`
+                        + (relocation.recoveryPath
+                            ? ` Recovery data is at ${relocation.recoveryPath}.`
+                            : ''),
+                    );
+                    return false;
+                }
+                if (relocation.warning) {
+                    void this.options.showWarningMessage(relocation.warning);
+                }
+            } else if (choice !== 'Use New Location') {
+                return false;
+            }
+        }
+
+        this.activeValue = requestedValue;
+        this.activeRoot = resolved.rootPath;
+        try {
+            await this.options.refresh();
+        } catch (error) {
+            // Persistence and filesystem authority must not depend on a visible
+            // Webview accepting an incremental refresh.
+            this.options.logError(
+                'Failed to refresh Skills after changing the Global Skills Location.',
+                error,
+            );
+        }
+        return true;
+    }
+
+    private resolve(value: string) {
+        return resolveGlobalSkillsLocation(value, {
+            homeDir: this.options.homeDir,
+            workspaceRoots: this.options.getWorkspaceRoots(),
+        });
+    }
+
+    private locationsOverlap(left: string, right: string): boolean {
+        const isStrictDescendant = (parent: string, candidate: string): boolean => {
+            const relative = path.relative(parent, candidate);
+            return Boolean(relative)
+                && relative !== '..'
+                && !relative.startsWith(`..${path.sep}`)
+                && !path.isAbsolute(relative);
+        };
+        return isStrictDescendant(left, right) || isStrictDescendant(right, left);
+    }
+
+    private enqueue<T>(operation: () => Promise<T>): Promise<T> {
+        const result = this.mutationQueue.then(operation, operation);
+        this.mutationQueue = result.then(() => undefined, () => undefined);
+        return result;
+    }
+}

--- a/src/skills/globalStoreLocationController.ts
+++ b/src/skills/globalStoreLocationController.ts
@@ -88,7 +88,10 @@ export class GlobalStoreLocationController {
             // latest effective machine value.
             const requestedValue = this.options.readSetting();
             const previousValue = this.activeValue;
-            if (await this.apply(requestedValue)) {
+            // A configuration event is already persisted machine authority,
+            // possibly confirmed in another window. Adopt it without opening
+            // a second relocation prompt that could write the old value back.
+            if (await this.apply(requestedValue, false)) {
                 return true;
             }
             if (this.options.readSetting() !== requestedValue) {
@@ -136,7 +139,7 @@ export class GlobalStoreLocationController {
         }
     }
 
-    private async apply(requestedValue: string): Promise<boolean> {
+    private async apply(requestedValue: string, offerRelocation = true): Promise<boolean> {
         const currentResolved = this.resolve(this.activeRoot);
         if (currentResolved.ok && currentResolved.rootPath) {
             // Another Extension Host may have relocated the machine-wide store
@@ -161,7 +164,7 @@ export class GlobalStoreLocationController {
             return false;
         }
 
-        if (hasGlobalSkillsStoreContent(this.activeRoot)) {
+        if (offerRelocation && hasGlobalSkillsStoreContent(this.activeRoot)) {
             const choice = await this.options.showWarningMessage(
                 `Change the Global Skills Location from ${this.activeRoot} `
                 + `to ${resolved.rootPath}? Existing skills can be moved safely, `

--- a/src/skills/globalStoreService.ts
+++ b/src/skills/globalStoreService.ts
@@ -195,6 +195,55 @@ export interface TargetMutationLock {
     release: () => void;
 }
 
+function isProcessAlive(pid: number): boolean {
+    try {
+        process.kill(pid, 0);
+        return true;
+    } catch (error) {
+        return !(error instanceof Error) || !('code' in error)
+            || (error as NodeJS.ErrnoException).code !== 'ESRCH';
+    }
+}
+
+function recoverStaleMutationLock(lockPath: string): boolean {
+    let descriptor: number | undefined;
+    try {
+        descriptor = fs.openSync(lockPath, 'r');
+        const identity = fs.fstatSync(descriptor);
+        const raw = fs.readFileSync(descriptor, 'utf8');
+        let stale = false;
+        try {
+            const owner = JSON.parse(raw) as { pid?: unknown; createdAt?: unknown };
+            stale = Number.isInteger(owner.pid) && (owner.pid as number) > 0
+                ? !isProcessAlive(owner.pid as number)
+                : Date.now() - identity.mtimeMs > 30_000;
+        } catch (_error) {
+            // A creator can crash between exclusive open and metadata write.
+            // Give an active creator a grace period before recovering it.
+            stale = Date.now() - identity.mtimeMs > 30_000;
+        }
+        fs.closeSync(descriptor);
+        descriptor = undefined;
+        if (!stale) {
+            return false;
+        }
+        const current = fs.lstatSync(lockPath);
+        if (!current.isFile()
+            || current.dev !== identity.dev
+            || current.ino !== identity.ino) {
+            return false;
+        }
+        fs.unlinkSync(lockPath);
+        return true;
+    } catch (_error) {
+        return false;
+    } finally {
+        if (descriptor !== undefined) {
+            try { fs.closeSync(descriptor); } catch (_error) { /* best effort */ }
+        }
+    }
+}
+
 export function acquireTargetMutationLock(
     targetPath: string,
 ): { ok: true; lock: TargetMutationLock } | { ok: false; error: string } {
@@ -202,9 +251,46 @@ export function acquireTargetMutationLock(
     const digest = createHash('sha256').update(absolute).digest('hex').slice(0, 24);
     const lockPath = path.join(path.dirname(absolute), `.agent-pivot-target-${digest}.lock`);
     let descriptor: number | undefined;
-    try {
-        descriptor = fs.openSync(lockPath, 'wx', 0o600);
-        const identity = fs.fstatSync(descriptor);
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+        try {
+            descriptor = fs.openSync(lockPath, 'wx', 0o600);
+        } catch (error) {
+            if (attempt === 0 && recoverStaleMutationLock(lockPath)) {
+                continue;
+            }
+            return {
+                ok: false,
+                error: `Another Agent Pivot window is already changing this Skills location: ${
+                    lockPath}. ${error instanceof Error ? error.message : String(error)}`,
+            };
+        }
+        let identity: fs.Stats | undefined;
+        try {
+            identity = fs.fstatSync(descriptor);
+            fs.writeFileSync(descriptor, JSON.stringify({
+                pid: process.pid,
+                createdAt: Date.now(),
+            }), 'utf8');
+            fs.fsyncSync(descriptor);
+        } catch (error) {
+            try { fs.closeSync(descriptor); } catch (_closeError) { /* best effort */ }
+            descriptor = undefined;
+            try {
+                const current = fs.lstatSync(lockPath);
+                if (identity && current.isFile()
+                    && current.dev === identity.dev
+                    && current.ino === identity.ino) {
+                    fs.unlinkSync(lockPath);
+                }
+            } catch (_cleanupError) {
+                // A missing or replaced lock must never be deleted by this owner.
+            }
+            return {
+                ok: false,
+                error: `Could not initialize the Skills mutation lock: ${
+                    error instanceof Error ? error.message : String(error)}`,
+            };
+        }
         let released = false;
         return {
             ok: true,
@@ -233,16 +319,8 @@ export function acquireTargetMutationLock(
                 },
             },
         };
-    } catch (error) {
-        if (descriptor !== undefined) {
-            try { fs.closeSync(descriptor); } catch (_closeError) { /* best effort */ }
-        }
-        return {
-            ok: false,
-            error: `Another Agent Pivot window is already changing this Skills location: ${
-                lockPath}. ${error instanceof Error ? error.message : String(error)}`,
-        };
     }
+    return { ok: false, error: `Could not acquire the Skills mutation lock: ${lockPath}` };
 }
 
 export function acquireSkillsMutationLocks(

--- a/src/skills/globalStoreService.ts
+++ b/src/skills/globalStoreService.ts
@@ -205,6 +205,207 @@ function isProcessAlive(pid: number): boolean {
     }
 }
 
+interface MutationGuardState {
+    identity: fs.Stats;
+    stale: boolean;
+}
+
+function ownerIsStale(raw: string, mtimeMs: number): boolean {
+    try {
+        const owner = JSON.parse(raw) as { pid?: unknown };
+        return Number.isInteger(owner.pid) && (owner.pid as number) > 0
+            ? !isProcessAlive(owner.pid as number)
+            : Date.now() - mtimeMs > 30_000;
+    } catch (_error) {
+        // A creator can crash between the atomic directory claim and metadata
+        // initialization. Keep a grace period for a live initializer.
+        return Date.now() - mtimeMs > 30_000;
+    }
+}
+
+function inspectMutationGuard(guardPath: string): MutationGuardState | null {
+    try {
+        const identity = fs.lstatSync(guardPath);
+        if (!identity.isDirectory() || identity.isSymbolicLink()) {
+            return null;
+        }
+        let raw = '';
+        try {
+            raw = fs.readFileSync(path.join(guardPath, 'owner.json'), 'utf8');
+        } catch (_error) {
+            // An empty directory is a potentially live initializer until its
+            // grace period expires.
+        }
+        return { identity, stale: ownerIsStale(raw, identity.mtimeMs) };
+    } catch (_error) {
+        return null;
+    }
+}
+
+function sameIdentity(left: fs.Stats, right: fs.Stats): boolean {
+    return left.dev === right.dev && left.ino === right.ino;
+}
+
+function moveGuardIfUnchanged(
+    sourcePath: string,
+    destinationPath: string,
+    expected: fs.Stats,
+): boolean {
+    try {
+        fs.renameSync(sourcePath, destinationPath);
+        const moved = fs.lstatSync(destinationPath);
+        if (sameIdentity(moved, expected)) {
+            return true;
+        }
+        // A delayed stale observer moved a newer live guard. Keep the fixed
+        // quarantine occupied while restoring it so no third process can
+        // acquire through the temporary gap.
+        try {
+            fs.renameSync(destinationPath, sourcePath);
+        } catch (_restoreError) {
+            // The owner or another contender will reconcile the quarantine.
+        }
+        return false;
+    } catch (_error) {
+        return false;
+    }
+}
+
+function releaseMutationGuard(
+    guardPath: string,
+    quarantinePath: string,
+    identity: fs.Stats,
+): void {
+    for (const candidate of [guardPath, quarantinePath]) {
+        let current: fs.Stats;
+        try {
+            current = fs.lstatSync(candidate);
+        } catch (_error) {
+            continue;
+        }
+        if (!sameIdentity(current, identity)) {
+            continue;
+        }
+        const cleanupPath = `${quarantinePath}.cleanup-${
+            process.pid}-${randomBytes(8).toString('hex')}`;
+        if (!moveGuardIfUnchanged(candidate, cleanupPath, identity)) {
+            continue;
+        }
+        try {
+            fs.rmSync(cleanupPath, { recursive: true, force: true });
+        } catch (_error) {
+            // The unique cleanup path cannot affect later lock ownership.
+        }
+        return;
+    }
+}
+
+function acquireMutationRecoveryGuard(
+    lockPath: string,
+): { ok: true; lock: TargetMutationLock } | { ok: false; error: string } {
+    const guardPath = `${lockPath}.guard`;
+    const quarantinePath = `${guardPath}.quarantine`;
+    for (let attempt = 0; attempt < 8; attempt += 1) {
+        // A crashed or delayed observer may leave the live guard in the fixed
+        // quarantine. Normalize it before anybody can create a new guard.
+        if (fs.existsSync(quarantinePath)) {
+            if (!fs.existsSync(guardPath)) {
+                try {
+                    fs.renameSync(quarantinePath, guardPath);
+                    continue;
+                } catch (_error) {
+                    continue;
+                }
+            }
+            return { ok: false, error: `Skills mutation recovery is already in progress: ${quarantinePath}` };
+        }
+
+        try {
+            fs.mkdirSync(guardPath, { mode: 0o700 });
+        } catch (error) {
+            const observed = inspectMutationGuard(guardPath);
+            if (!observed || !observed.stale) {
+                return {
+                    ok: false,
+                    error: `Another Agent Pivot window is already acquiring this Skills lock: ${
+                        guardPath}. ${error instanceof Error ? error.message : String(error)}`,
+                };
+            }
+            if (!moveGuardIfUnchanged(guardPath, quarantinePath, observed.identity)) {
+                continue;
+            }
+            // The fixed quarantine prevents an old observer from deleting a
+            // newer guard. Move the verified stale generation to a unique path
+            // before removal; new acquisitions may proceed once this rename
+            // succeeds without being touched by the cleanup.
+            const cleanupPath = `${quarantinePath}.cleanup-${
+                process.pid}-${randomBytes(8).toString('hex')}`;
+            if (!moveGuardIfUnchanged(quarantinePath, cleanupPath, observed.identity)) {
+                continue;
+            }
+            try {
+                fs.rmSync(cleanupPath, { recursive: true, force: true });
+            } catch (_error) {
+                // The unique cleanup path no longer participates in locking.
+            }
+            continue;
+        }
+
+        const identity = fs.lstatSync(guardPath);
+        try {
+            const ownerPath = path.join(guardPath, 'owner.json');
+            const descriptor = fs.openSync(ownerPath, 'wx', 0o600);
+            try {
+                fs.writeFileSync(descriptor, JSON.stringify({
+                    pid: process.pid,
+                    createdAt: Date.now(),
+                    token: randomBytes(16).toString('hex'),
+                }), 'utf8');
+                fs.fsyncSync(descriptor);
+            } finally {
+                fs.closeSync(descriptor);
+            }
+        } catch (error) {
+            releaseMutationGuard(guardPath, quarantinePath, identity);
+            return {
+                ok: false,
+                error: `Could not initialize the Skills recovery guard: ${
+                    error instanceof Error ? error.message : String(error)}`,
+            };
+        }
+
+        // A delayed observer can move this generation only into quarantine.
+        // If that happened, release our exact identity and retry instead of
+        // proceeding without a canonical guard.
+        let current: fs.Stats | undefined;
+        try {
+            current = fs.lstatSync(guardPath);
+        } catch (_error) {
+            current = undefined;
+        }
+        if (!current || !sameIdentity(current, identity) || fs.existsSync(quarantinePath)) {
+            releaseMutationGuard(guardPath, quarantinePath, identity);
+            continue;
+        }
+
+        let released = false;
+        return {
+            ok: true,
+            lock: {
+                lockPath: guardPath,
+                release: () => {
+                    if (released) {
+                        return;
+                    }
+                    released = true;
+                    releaseMutationGuard(guardPath, quarantinePath, identity);
+                },
+            },
+        };
+    }
+    return { ok: false, error: `Could not acquire the Skills recovery guard: ${guardPath}` };
+}
+
 function recoverStaleMutationLock(lockPath: string): boolean {
     let descriptor: number | undefined;
     try {
@@ -213,10 +414,7 @@ function recoverStaleMutationLock(lockPath: string): boolean {
         const raw = fs.readFileSync(descriptor, 'utf8');
         let stale = false;
         try {
-            const owner = JSON.parse(raw) as { pid?: unknown; createdAt?: unknown };
-            stale = Number.isInteger(owner.pid) && (owner.pid as number) > 0
-                ? !isProcessAlive(owner.pid as number)
-                : Date.now() - identity.mtimeMs > 30_000;
+            stale = ownerIsStale(raw, identity.mtimeMs);
         } catch (_error) {
             // A creator can crash between exclusive open and metadata write.
             // Give an active creator a grace period before recovering it.
@@ -250,77 +448,86 @@ export function acquireTargetMutationLock(
     const absolute = path.resolve(targetPath);
     const digest = createHash('sha256').update(absolute).digest('hex').slice(0, 24);
     const lockPath = path.join(path.dirname(absolute), `.agent-pivot-target-${digest}.lock`);
-    let descriptor: number | undefined;
-    for (let attempt = 0; attempt < 2; attempt += 1) {
-        try {
-            descriptor = fs.openSync(lockPath, 'wx', 0o600);
-        } catch (error) {
-            if (attempt === 0 && recoverStaleMutationLock(lockPath)) {
-                continue;
-            }
-            return {
-                ok: false,
-                error: `Another Agent Pivot window is already changing this Skills location: ${
-                    lockPath}. ${error instanceof Error ? error.message : String(error)}`,
-            };
-        }
-        let identity: fs.Stats | undefined;
-        try {
-            identity = fs.fstatSync(descriptor);
-            fs.writeFileSync(descriptor, JSON.stringify({
-                pid: process.pid,
-                createdAt: Date.now(),
-            }), 'utf8');
-            fs.fsyncSync(descriptor);
-        } catch (error) {
-            try { fs.closeSync(descriptor); } catch (_closeError) { /* best effort */ }
-            descriptor = undefined;
-            try {
-                const current = fs.lstatSync(lockPath);
-                if (identity && current.isFile()
-                    && current.dev === identity.dev
-                    && current.ino === identity.ino) {
-                    fs.unlinkSync(lockPath);
-                }
-            } catch (_cleanupError) {
-                // A missing or replaced lock must never be deleted by this owner.
-            }
-            return {
-                ok: false,
-                error: `Could not initialize the Skills mutation lock: ${
-                    error instanceof Error ? error.message : String(error)}`,
-            };
-        }
-        let released = false;
-        return {
-            ok: true,
-            lock: {
-                lockPath,
-                release: () => {
-                    if (released) {
-                        return;
-                    }
-                    released = true;
-                    try {
-                        fs.closeSync(descriptor as number);
-                    } catch (_error) {
-                        // Continue with identity-checked cleanup.
-                    }
-                    try {
-                        const current = fs.lstatSync(lockPath);
-                        if (current.isFile()
-                            && current.dev === identity.dev
-                            && current.ino === identity.ino) {
-                            fs.unlinkSync(lockPath);
-                        }
-                    } catch (_error) {
-                        // A missing or replaced lock must never be deleted by this owner.
-                    }
-                },
-            },
-        };
+    const guardResult = acquireMutationRecoveryGuard(lockPath);
+    if (guardResult.ok === false) {
+        return { ok: false, error: guardResult.error };
     }
-    return { ok: false, error: `Could not acquire the Skills mutation lock: ${lockPath}` };
+    try {
+        let descriptor: number | undefined;
+        for (let attempt = 0; attempt < 2; attempt += 1) {
+            try {
+                descriptor = fs.openSync(lockPath, 'wx', 0o600);
+            } catch (error) {
+                if (attempt === 0 && recoverStaleMutationLock(lockPath)) {
+                    continue;
+                }
+                return {
+                    ok: false,
+                    error: `Another Agent Pivot window is already changing this Skills location: ${
+                        lockPath}. ${error instanceof Error ? error.message : String(error)}`,
+                };
+            }
+            let identity: fs.Stats | undefined;
+            try {
+                identity = fs.fstatSync(descriptor);
+                fs.writeFileSync(descriptor, JSON.stringify({
+                    pid: process.pid,
+                    createdAt: Date.now(),
+                }), 'utf8');
+                fs.fsyncSync(descriptor);
+            } catch (error) {
+                try { fs.closeSync(descriptor); } catch (_closeError) { /* best effort */ }
+                descriptor = undefined;
+                try {
+                    const current = fs.lstatSync(lockPath);
+                    if (identity && current.isFile()
+                        && current.dev === identity.dev
+                        && current.ino === identity.ino) {
+                        fs.unlinkSync(lockPath);
+                    }
+                } catch (_cleanupError) {
+                    // The recovery guard prevents a cooperating owner from
+                    // replacing this path before cleanup.
+                }
+                return {
+                    ok: false,
+                    error: `Could not initialize the Skills mutation lock: ${
+                        error instanceof Error ? error.message : String(error)}`,
+                };
+            }
+            let released = false;
+            return {
+                ok: true,
+                lock: {
+                    lockPath,
+                    release: () => {
+                        if (released) {
+                            return;
+                        }
+                        released = true;
+                        try {
+                            fs.closeSync(descriptor as number);
+                        } catch (_error) {
+                            // Continue with identity-checked cleanup.
+                        }
+                        try {
+                            const current = fs.lstatSync(lockPath);
+                            if (current.isFile()
+                                && current.dev === identity.dev
+                                && current.ino === identity.ino) {
+                                fs.unlinkSync(lockPath);
+                            }
+                        } catch (_error) {
+                            // A missing or replaced lock must never be deleted by this owner.
+                        }
+                    },
+                },
+            };
+        }
+        return { ok: false, error: `Could not acquire the Skills mutation lock: ${lockPath}` };
+    } finally {
+        guardResult.lock.release();
+    }
 }
 
 export function acquireSkillsMutationLocks(

--- a/src/skills/globalStoreService.ts
+++ b/src/skills/globalStoreService.ts
@@ -1,0 +1,608 @@
+'use strict';
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { createHash, randomBytes } from 'crypto';
+
+import { getProjectSkillsRoots, getUserSkillsRoots } from './roots';
+
+export const DEFAULT_GLOBAL_SKILLS_LOCATION = '~/.skills';
+
+export interface GlobalSkillsLocationResult {
+    ok: boolean;
+    /** Absolute path represented by the setting, before following a final symlink. */
+    configuredPath?: string;
+    /** Physical root used by discovery and every managed mutation. */
+    rootPath?: string;
+    error?: string;
+}
+
+export interface ResolveGlobalSkillsLocationOptions {
+    homeDir: string;
+    workspaceRoots?: readonly string[];
+}
+
+export interface RelocateGlobalSkillsStoreResult {
+    ok: boolean;
+    moved?: boolean;
+    aliasCreated?: boolean;
+    warning?: string;
+    recoveryPath?: string;
+    error?: string;
+}
+
+export interface RelocateGlobalSkillsStoreOptions {
+    renameSync?: typeof fs.renameSync;
+    copyFileSync?: typeof fs.copyFileSync;
+    mkdirSync?: typeof fs.mkdirSync;
+}
+
+function isMissing(error: unknown): boolean {
+    return error instanceof Error && 'code' in error
+        && (error as NodeJS.ErrnoException).code === 'ENOENT';
+}
+
+function resolveFuturePath(candidate: string): string | null {
+    const absolute = path.resolve(candidate);
+    let existing = absolute;
+    while (true) {
+        try {
+            fs.lstatSync(existing);
+        } catch (error) {
+            if (!isMissing(error)) {
+                return null;
+            }
+            const parent = path.dirname(existing);
+            if (parent === existing) {
+                return null;
+            }
+            existing = parent;
+            continue;
+        }
+        try {
+            const realExisting = fs.realpathSync(existing);
+            return path.resolve(realExisting, path.relative(existing, absolute));
+        } catch (_error) {
+            return null;
+        }
+    }
+}
+
+function overlaps(left: string, right: string): boolean {
+    const contains = (parent: string, candidate: string): boolean => {
+        const relative = path.relative(parent, candidate);
+        return relative === '' || (relative !== '..'
+            && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative));
+    };
+    return contains(left, right) || contains(right, left);
+}
+
+function expandConfiguredPath(value: unknown, homeDir: string): GlobalSkillsLocationResult {
+    if (typeof value !== 'string' || !value.trim()) {
+        return { ok: false, error: 'Global Skills Location must be a non-empty path.' };
+    }
+    const raw = value.trim();
+    let expanded: string;
+    if (raw === '~') {
+        expanded = homeDir;
+    } else if (raw.startsWith(`~${path.sep}`) || raw.startsWith('~/')) {
+        expanded = path.join(homeDir, raw.slice(2));
+    } else if (raw.startsWith('~')) {
+        return { ok: false, error: 'Only the current user’s ~ path is supported.' };
+    } else if (path.isAbsolute(raw)) {
+        expanded = raw;
+    } else {
+        return { ok: false, error: 'Global Skills Location must use ~ or an absolute path.' };
+    }
+    const configuredPath = path.resolve(expanded);
+    const rootPath = resolveFuturePath(configuredPath);
+    if (!rootPath) {
+        return { ok: false, error: `Cannot resolve Global Skills Location: ${configuredPath}` };
+    }
+    return { ok: true, configuredPath, rootPath };
+}
+
+/**
+ * Resolve and validate a configured Global store without creating anything.
+ * Project stores remain positional at <workspace>/.skills and are explicitly
+ * excluded from the allowed Global location.
+ */
+export function resolveGlobalSkillsLocation(
+    value: unknown,
+    options: ResolveGlobalSkillsLocationOptions,
+): GlobalSkillsLocationResult {
+    const expanded = expandConfiguredPath(value, options.homeDir);
+    if (!expanded.ok || !expanded.configuredPath || !expanded.rootPath) {
+        return expanded;
+    }
+    const configuredPath = expanded.configuredPath;
+    const rootPath = expanded.rootPath;
+    const filesystemRoot = path.parse(configuredPath).root;
+    if (configuredPath === filesystemRoot || rootPath === path.parse(rootPath).root) {
+        return { ok: false, error: 'The filesystem root cannot be used as Global Skills Location.' };
+    }
+    const homeRoot = resolveFuturePath(options.homeDir) || path.resolve(options.homeDir);
+    if (configuredPath === path.resolve(options.homeDir) || rootPath === homeRoot) {
+        return { ok: false, error: 'The home directory itself cannot be used as Global Skills Location.' };
+    }
+
+    const forbidden = getUserSkillsRoots(options.homeDir).map(item => item.dirPath);
+    for (const workspaceRoot of options.workspaceRoots || []) {
+        forbidden.push(
+            path.resolve(workspaceRoot),
+            path.join(workspaceRoot, '.skills'),
+            ...getProjectSkillsRoots(workspaceRoot).map(item => item.dirPath),
+        );
+    }
+    for (const candidate of forbidden) {
+        const lexical = path.resolve(candidate);
+        const physical = resolveFuturePath(candidate) || lexical;
+        if (overlaps(configuredPath, lexical) || overlaps(rootPath, physical)) {
+            return {
+                ok: false,
+                error: `Global Skills Location overlaps a managed Agent or project path: ${candidate}`,
+            };
+        }
+    }
+    try {
+        const stat = fs.statSync(rootPath);
+        if (!stat.isDirectory()) {
+            return { ok: false, error: `Global Skills Location is not a directory: ${configuredPath}` };
+        }
+    } catch (error) {
+        if (!isMissing(error)) {
+            return {
+                ok: false,
+                error: error instanceof Error ? error.message : String(error),
+            };
+        }
+    }
+    return { ok: true, configuredPath, rootPath };
+}
+
+function pathExists(candidate: string): boolean {
+    try {
+        fs.lstatSync(candidate);
+        return true;
+    } catch (error) {
+        return !isMissing(error);
+    }
+}
+
+export function copyDirectoryContents(
+    sourceDir: string,
+    targetDir: string,
+    copyFileSync: typeof fs.copyFileSync,
+): void {
+    for (const entry of fs.readdirSync(sourceDir, { withFileTypes: true })) {
+        const source = path.join(sourceDir, entry.name);
+        const target = path.join(targetDir, entry.name);
+        if (entry.isDirectory()) {
+            fs.mkdirSync(target, { recursive: false });
+            copyDirectoryContents(source, target, copyFileSync);
+        } else if (entry.isFile()) {
+            copyFileSync(source, target, fs.constants.COPYFILE_EXCL);
+        } else if (entry.isSymbolicLink()) {
+            fs.symlinkSync(fs.readlinkSync(source), target);
+        } else {
+            throw new Error(`Unsupported entry in the Global Skills store: ${source}`);
+        }
+    }
+}
+
+export interface TargetMutationLock {
+    lockPath: string;
+    release: () => void;
+}
+
+export function acquireTargetMutationLock(
+    targetPath: string,
+): { ok: true; lock: TargetMutationLock } | { ok: false; error: string } {
+    const absolute = path.resolve(targetPath);
+    const digest = createHash('sha256').update(absolute).digest('hex').slice(0, 24);
+    const lockPath = path.join(path.dirname(absolute), `.agent-pivot-target-${digest}.lock`);
+    let descriptor: number | undefined;
+    try {
+        descriptor = fs.openSync(lockPath, 'wx', 0o600);
+        const identity = fs.fstatSync(descriptor);
+        let released = false;
+        return {
+            ok: true,
+            lock: {
+                lockPath,
+                release: () => {
+                    if (released) {
+                        return;
+                    }
+                    released = true;
+                    try {
+                        fs.closeSync(descriptor as number);
+                    } catch (_error) {
+                        // Continue with identity-checked cleanup.
+                    }
+                    try {
+                        const current = fs.lstatSync(lockPath);
+                        if (current.isFile()
+                            && current.dev === identity.dev
+                            && current.ino === identity.ino) {
+                            fs.unlinkSync(lockPath);
+                        }
+                    } catch (_error) {
+                        // A missing or replaced lock must never be deleted by this owner.
+                    }
+                },
+            },
+        };
+    } catch (error) {
+        if (descriptor !== undefined) {
+            try { fs.closeSync(descriptor); } catch (_closeError) { /* best effort */ }
+        }
+        return {
+            ok: false,
+            error: `Another Agent Pivot window is already changing this Skills location: ${
+                lockPath}. ${error instanceof Error ? error.message : String(error)}`,
+        };
+    }
+}
+
+export function acquireSkillsMutationLocks(
+    paths: readonly string[],
+): { ok: true; lock: TargetMutationLock } | { ok: false; error: string } {
+    const normalized = [...new Set(paths.map(candidate => path.resolve(candidate)))].sort();
+    const acquired: TargetMutationLock[] = [];
+    for (const candidate of normalized) {
+        const result = acquireTargetMutationLock(candidate);
+        if (result.ok === false) {
+            for (const lock of acquired.reverse()) {
+                lock.release();
+            }
+            return result;
+        }
+        acquired.push(result.lock);
+    }
+    let released = false;
+    return {
+        ok: true,
+        lock: {
+            lockPath: acquired.map(lock => lock.lockPath).join(', '),
+            release: () => {
+                if (released) {
+                    return;
+                }
+                released = true;
+                for (const lock of acquired.reverse()) {
+                    lock.release();
+                }
+            },
+        },
+    };
+}
+
+export function directoryTreesEqual(
+    leftDir: string,
+    rightDir: string,
+    rightIdentity?: DirectoryIdentity,
+): boolean {
+    try {
+        const compare = (left: string, right: string, root: boolean): boolean => {
+            const leftEntries = fs.readdirSync(left, { withFileTypes: true })
+                .sort((a, b) => a.name.localeCompare(b.name));
+            const rightEntries = fs.readdirSync(right, { withFileTypes: true })
+                .filter(entry => !root || entry.name !== rightIdentity?.markerName)
+                .sort((a, b) => a.name.localeCompare(b.name));
+            if (leftEntries.length !== rightEntries.length) {
+                return false;
+            }
+            for (let index = 0; index < leftEntries.length; index += 1) {
+                const leftEntry = leftEntries[index];
+                const rightEntry = rightEntries[index];
+                if (leftEntry.name !== rightEntry.name
+                    || leftEntry.isDirectory() !== rightEntry.isDirectory()
+                    || leftEntry.isFile() !== rightEntry.isFile()
+                    || leftEntry.isSymbolicLink() !== rightEntry.isSymbolicLink()) {
+                    return false;
+                }
+                const leftPath = path.join(left, leftEntry.name);
+                const rightPath = path.join(right, rightEntry.name);
+                if (leftEntry.isDirectory() && !compare(leftPath, rightPath, false)) {
+                    return false;
+                }
+                if (leftEntry.isFile()
+                    && !fs.readFileSync(leftPath).equals(fs.readFileSync(rightPath))) {
+                    return false;
+                }
+                if (leftEntry.isSymbolicLink()
+                    && fs.readlinkSync(leftPath) !== fs.readlinkSync(rightPath)) {
+                    return false;
+                }
+            }
+            return true;
+        };
+        return compare(leftDir, rightDir, true);
+    } catch (_error) {
+        return false;
+    }
+}
+
+export interface DirectoryIdentity {
+    dev: number;
+    ino: number;
+    markerName: string;
+    markerToken: string;
+}
+
+export function captureDirectoryIdentity(targetRoot: string): DirectoryIdentity {
+    const stat = fs.lstatSync(targetRoot);
+    if (!stat.isDirectory() || stat.isSymbolicLink()) {
+        throw new Error(`The claimed target is no longer a real directory: ${targetRoot}`);
+    }
+    const markerToken = randomBytes(24).toString('hex');
+    const markerName = `.agent-pivot-owner-${markerToken}`;
+    fs.writeFileSync(path.join(targetRoot, markerName), markerToken, {
+        encoding: 'utf8',
+        flag: 'wx',
+        mode: 0o600,
+    });
+    return { dev: stat.dev, ino: stat.ino, markerName, markerToken };
+}
+
+function ownsDirectory(targetRoot: string, identity: DirectoryIdentity): boolean {
+    try {
+        const current = fs.lstatSync(targetRoot);
+        return current.isDirectory()
+            && !current.isSymbolicLink()
+            && current.dev === identity.dev
+            && current.ino === identity.ino
+            && fs.readFileSync(path.join(targetRoot, identity.markerName), 'utf8')
+                === identity.markerToken;
+    } catch (_error) {
+        return false;
+    }
+}
+
+export function releaseDirectoryIdentity(
+    targetRoot: string,
+    identity: DirectoryIdentity,
+): { ok: boolean; error?: string; recoveryPath?: string } {
+    if (!ownsDirectory(targetRoot, identity)) {
+        return {
+            ok: false,
+            error: `Target ownership changed; retained data at ${targetRoot}.`,
+            recoveryPath: targetRoot,
+        };
+    }
+    try {
+        fs.unlinkSync(path.join(targetRoot, identity.markerName));
+        return { ok: true };
+    } catch (error) {
+        return {
+            ok: false,
+            error: `Could not release the target ownership marker: ${
+                error instanceof Error ? error.message : String(error)} `
+                + `Recovery data is at ${targetRoot}.`,
+            recoveryPath: targetRoot,
+        };
+    }
+}
+
+export function retainFailedTarget(
+    targetRoot: string,
+    identity: DirectoryIdentity | undefined,
+): { ok: boolean; error?: string; recoveryPath?: string } {
+    try {
+        if (!pathExists(targetRoot)) {
+            return { ok: true };
+        }
+        // Never delete a failed public target. There is no portable filesystem
+        // primitive that atomically creates a directory and returns a durable
+        // ownership handle; an external process can replace the path before
+        // identity capture. Retaining the target is the only way to guarantee
+        // that rollback cannot delete data written by another owner.
+        const ownership = identity && ownsDirectory(targetRoot, identity)
+            ? 'The incomplete target'
+            : 'Target ownership changed; the target';
+        return {
+            ok: false,
+            error: `${ownership} was retained at ${targetRoot}.`,
+            recoveryPath: targetRoot,
+        };
+    } catch (error) {
+        return {
+            ok: false,
+            error: `Could not inspect the failed target: ${
+                error instanceof Error ? error.message : String(error)} `
+                + `Recovery data is at ${targetRoot}.`,
+            recoveryPath: targetRoot,
+        };
+    }
+}
+
+export function restoreDirectoryWithoutOverwrite(
+    recoveryRoot: string,
+    sourceRoot: string,
+    copyFileSync: typeof fs.copyFileSync,
+): { ok: boolean; error?: string } {
+    try {
+        // mkdir is the atomic no-overwrite claim. A concurrent writer wins
+        // cleanly instead of being replaced by rename(2).
+        fs.mkdirSync(sourceRoot, { recursive: false });
+        copyDirectoryContents(recoveryRoot, sourceRoot, copyFileSync);
+        if (!directoryTreesEqual(recoveryRoot, sourceRoot)) {
+            throw new Error('Restored Global Skills content did not verify.');
+        }
+        fs.rmSync(recoveryRoot, { recursive: true, force: true });
+        return { ok: true };
+    } catch (error) {
+        return { ok: false, error: error instanceof Error ? error.message : String(error) };
+    }
+}
+
+/**
+ * Move the complete physical Global store and leave the old root as a stable
+ * compatibility symlink. The alias keeps links in projects that are not
+ * currently open valid after the setting changes.
+ */
+export function relocateGlobalSkillsStore(
+    sourceRoot: string,
+    targetRoot: string,
+    options: RelocateGlobalSkillsStoreOptions = {},
+): RelocateGlobalSkillsStoreResult {
+    const source = path.resolve(sourceRoot);
+    const target = path.resolve(targetRoot);
+    const renameSync = options.renameSync || fs.renameSync;
+    const copyFileSync = options.copyFileSync || fs.copyFileSync;
+    const mkdirSync = options.mkdirSync || fs.mkdirSync;
+    if (overlaps(source, target)) {
+        return { ok: false, error: 'The old and new Global Skills locations overlap.' };
+    }
+    try {
+        const sourceStat = fs.lstatSync(source);
+        if (!sourceStat.isDirectory() || sourceStat.isSymbolicLink()) {
+            return { ok: false, error: `The current Global Skills store is not a real directory: ${source}` };
+        }
+    } catch (error) {
+        return { ok: false, error: error instanceof Error ? error.message : String(error) };
+    }
+
+    try {
+        fs.mkdirSync(path.dirname(target), { recursive: true });
+    } catch (error) {
+        return { ok: false, error: error instanceof Error ? error.message : String(error) };
+    }
+    const lockResult = acquireSkillsMutationLocks([source, target]);
+    if (lockResult.ok === false) {
+        return { ok: false, error: lockResult.error };
+    }
+
+    try {
+        if (pathExists(target)) {
+            try {
+                const targetStat = fs.lstatSync(target);
+                if (!targetStat.isDirectory() || targetStat.isSymbolicLink()) {
+                    return { ok: false, error: `The new Global Skills location is already occupied: ${target}` };
+                }
+                if (fs.readdirSync(target).length) {
+                    return { ok: false, error: `The new Global Skills location is not empty: ${target}` };
+                }
+                fs.rmdirSync(target);
+            } catch (error) {
+                return { ok: false, error: error instanceof Error ? error.message : String(error) };
+            }
+        }
+
+        let asideContainer: string;
+        let targetCreated = false;
+        let targetIdentity: DirectoryIdentity | undefined;
+        try {
+        // mkdir is the portable atomic no-overwrite claim. Always using the
+        // verified copy protocol also avoids rename replacing a destination
+        // created after the earlier inspection.
+        mkdirSync(target, { recursive: false });
+        targetCreated = true;
+        targetIdentity = captureDirectoryIdentity(target);
+        copyDirectoryContents(source, target, copyFileSync);
+        if (!directoryTreesEqual(source, target, targetIdentity)) {
+            throw new Error('Copied Global Skills content did not verify.');
+        }
+        asideContainer = fs.mkdtempSync(path.join(path.dirname(source), '.agent-pivot-global-store-'));
+        } catch (error) {
+            const cleanup = targetCreated
+                ? retainFailedTarget(target, targetIdentity)
+                : { ok: true };
+            const message = error instanceof Error ? error.message : String(error);
+            if (!cleanup.ok) {
+                return {
+                    ok: false,
+                    error: `${message} ${cleanup.error}`,
+                    recoveryPath: cleanup.recoveryPath,
+                };
+            }
+            return { ok: false, error: message };
+        }
+
+        const aside = path.join(asideContainer, path.basename(source));
+        let sourceAtAside = false;
+        let sourceAliasCreated = false;
+        try {
+        renameSync(source, aside);
+        sourceAtAside = true;
+        if (!directoryTreesEqual(aside, target, targetIdentity)) {
+            throw new Error('The Global Skills store changed during migration.');
+        }
+        fs.symlinkSync(target, source, 'dir');
+        sourceAliasCreated = true;
+        const released = releaseDirectoryIdentity(target, targetIdentity);
+        if (!released.ok) {
+            throw new Error(released.error);
+        }
+        } catch (error) {
+            let rollbackError: unknown;
+        if (sourceAliasCreated) {
+            try {
+                const stat = fs.lstatSync(source);
+                if (stat.isSymbolicLink() && fs.readlinkSync(source) === target) {
+                    fs.unlinkSync(source);
+                }
+            } catch (unlinkError) {
+                if (!isMissing(unlinkError)) {
+                    rollbackError = unlinkError;
+                }
+            }
+        }
+        if (sourceAtAside) {
+            const rollback = restoreDirectoryWithoutOverwrite(aside, source, copyFileSync);
+            if (rollback.ok) {
+                sourceAtAside = false;
+            } else {
+                rollbackError = rollbackError || new Error(rollback.error);
+            }
+        }
+            const targetCleanup = retainFailedTarget(target, targetIdentity);
+            if (rollbackError) {
+                const recoveryPath = aside;
+                return {
+                    ok: false,
+                    error: `${error instanceof Error ? error.message : String(error)} `
+                        + `Rollback failed: ${rollbackError instanceof Error
+                            ? rollbackError.message : String(rollbackError)} `
+                        + `Recovery data is at ${recoveryPath}.`
+                        + (!targetCleanup.ok ? ` ${targetCleanup.error}` : ''),
+                    recoveryPath,
+                };
+            }
+            try { fs.rmSync(asideContainer, { recursive: true, force: true }); } catch (_error) { /* best effort */ }
+            const message = error instanceof Error ? error.message : String(error);
+            return targetCleanup.ok
+                ? { ok: false, error: message }
+                : {
+                    ok: false,
+                    error: `${message} ${targetCleanup.error}`,
+                    recoveryPath: targetCleanup.recoveryPath,
+                };
+        }
+
+        try {
+            fs.rmSync(asideContainer, { recursive: true, force: true });
+            return { ok: true, moved: true, aliasCreated: true };
+        } catch (error) {
+            return {
+                ok: true,
+                moved: true,
+                aliasCreated: true,
+                warning: `Migration succeeded, but the backup could not be removed: ${
+                    error instanceof Error ? error.message : String(error)}`,
+                recoveryPath: aside,
+            };
+        }
+    } finally {
+        lockResult.lock.release();
+    }
+}
+
+export function hasGlobalSkillsStoreContent(rootDir: string): boolean {
+    try {
+        return fs.readdirSync(rootDir).length > 0;
+    } catch (_error) {
+        return false;
+    }
+}

--- a/src/skills/migrateService.ts
+++ b/src/skills/migrateService.ts
@@ -28,8 +28,8 @@ function priorityOf(record: SkillRecord): number {
 
 /**
  * One-shot migration of every skill living in the three brand agent
- * roots at one scope into that scope's central store (`~/.skills` for user,
- * `<project>/.skills` for project). The highest priority copy
+ * roots at one scope into that scope's central store (the configured Global
+ * store for user, `<project>/.skills` for project). The highest priority copy
  * (kimi > claude > codex) wins; all other real-directory copies are
  * deleted once the winner is secured. No agent links are created —
  * users enable agents per card afterwards.
@@ -39,6 +39,7 @@ export function migrateSkillsToCentral(
     homeDir: string,
     scope: SkillScope,
     workspaceRoot?: string,
+    globalSkillsRoot?: string,
 ): SkillMigrationReport {
     const report: SkillMigrationReport = {
         ok: true, migrated: [], drifted: [], deleted: [], skipped: [], errors: [],
@@ -57,7 +58,7 @@ export function migrateSkillsToCentral(
         list.push(record);
         groups.set(record.name, list);
     }
-    const centralRoot = getCentralSkillsRoot(homeDir, scope, workspaceRoot);
+    const centralRoot = getCentralSkillsRoot(homeDir, scope, workspaceRoot, globalSkillsRoot);
     for (const [name, copies] of [...groups.entries()].sort(([a], [b]) => a.localeCompare(b))) {
         const realDirs = copies.filter(copy => !copy.central);
         if (!realDirs.length) {
@@ -76,7 +77,10 @@ export function migrateSkillsToCentral(
         const winner = [...migratable].sort((a, b) => priorityOf(a) - priorityOf(b))[0];
         const losers = migratable.filter(copy => copy.dirPath !== winner.dirPath);
         const loserDirs = losers.map(copy => copy.dirPath);
-        const result = centralizeSkill(winner, losers, homeDir, workspaceRoot, { linkBack: false });
+        const result = centralizeSkill(winner, losers, homeDir, workspaceRoot, {
+            linkBack: false,
+            globalSkillsRoot,
+        });
         if (!result.ok) {
             report.ok = false;
             report.errors.push({ name, error: result.error || 'unknown error' });
@@ -91,7 +95,11 @@ export function migrateSkillsToCentral(
     return report;
 }
 
-/** Back-compat wrapper: migrate the user scope (`~/.skills`). */
-export function migrateUserSkillsToCentral(records: SkillRecord[], homeDir: string): SkillMigrationReport {
-    return migrateSkillsToCentral(records, homeDir, 'user');
+/** Back-compat wrapper: migrate the user scope into its Global store. */
+export function migrateUserSkillsToCentral(
+    records: SkillRecord[],
+    homeDir: string,
+    globalSkillsRoot?: string,
+): SkillMigrationReport {
+    return migrateSkillsToCentral(records, homeDir, 'user', undefined, globalSkillsRoot);
 }

--- a/src/skills/roots.ts
+++ b/src/skills/roots.ts
@@ -12,20 +12,37 @@ export interface SkillsRoot {
 
 export const CENTRAL_DIR_NAME = '.skills';
 
-export function getCentralSkillsRoot(homeDir: string, scope: SkillScope, workspaceRoot?: string): string {
+export function getCentralSkillsRoot(
+    homeDir: string,
+    scope: SkillScope,
+    workspaceRoot?: string,
+    globalSkillsRoot?: string,
+): string {
     return scope === 'user'
-        ? path.join(homeDir, CENTRAL_DIR_NAME)
+        ? (globalSkillsRoot || path.join(homeDir, CENTRAL_DIR_NAME))
         : path.join(workspaceRoot as string, CENTRAL_DIR_NAME);
 }
 
-export function isUnderCentralRoot(dirPath: string, homeDir: string, workspaceRoot?: string): { scope: SkillScope } | null {
-    const userCentral = getCentralSkillsRoot(homeDir, 'user');
-    if (dirPath.startsWith(userCentral + path.sep)) {
+export function isUnderCentralRoot(
+    dirPath: string,
+    homeDir: string,
+    workspaceRoot?: string,
+    globalSkillsRoot?: string,
+): { scope: SkillScope } | null {
+    const isDescendant = (root: string): boolean => {
+        const relative = path.relative(path.resolve(root), path.resolve(dirPath));
+        return Boolean(relative)
+            && relative !== '..'
+            && !relative.startsWith(`..${path.sep}`)
+            && !path.isAbsolute(relative);
+    };
+    const userCentral = getCentralSkillsRoot(homeDir, 'user', undefined, globalSkillsRoot);
+    if (isDescendant(userCentral)) {
         return { scope: 'user' };
     }
     if (workspaceRoot) {
         const projectCentral = getCentralSkillsRoot(homeDir, 'project', workspaceRoot);
-        if (dirPath.startsWith(projectCentral + path.sep)) {
+        if (isDescendant(projectCentral)) {
             return { scope: 'project' };
         }
     }

--- a/src/skills/scopeService.ts
+++ b/src/skills/scopeService.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 import { setCentralLink } from './centralService';
+import { acquireSkillsMutationLocks } from './globalStoreService';
 import { getCentralSkillsRoot, getProjectSkillsRoots } from './roots';
 import type { SkillAgentId, SkillRecord } from './types';
 
@@ -235,15 +236,21 @@ export function setGlobalSkillProjectAgents(
     if (!record.central || record.scope !== 'user') {
         return fail('Only a centralized global skill can be applied to a project.', 'invalid');
     }
+    const globalStore = getCentralSkillsRoot(homeDir, 'user', undefined, globalSkillsRoot);
     if (!isManagedDescendant(
         record.dirPath,
-        getCentralSkillsRoot(homeDir, 'user', undefined, globalSkillsRoot),
+        globalStore,
     )) {
         return fail('The global skill resolves outside the managed Global store.', 'invalid');
     }
     if (!isReadableSkillDirectory(record.dirPath)) {
         return fail('The global skill source is missing or unreadable.', 'invalid');
     }
+    const lockResult = acquireSkillsMutationLocks([globalStore]);
+    if (lockResult.ok === false) {
+        return fail(lockResult.error);
+    }
+    try {
     const desired = new Set(agents);
     if (agents.some(agent => !AGENTS.includes(agent)) || desired.size !== agents.length) {
         return fail('Unknown or duplicate project agent.', 'invalid');
@@ -298,6 +305,9 @@ export function setGlobalSkillProjectAgents(
             return fail(`${message} Rollback was incomplete. ${rollbackErrors.join(' ')}`, 'rollback');
         }
         return fail(message, message.includes('already exists') || message.includes('points elsewhere') ? 'conflict' : 'io');
+    }
+    } finally {
+        lockResult.lock.release();
     }
 }
 
@@ -355,18 +365,27 @@ export function moveProjectSkillToGlobal(
         return fail('The Global destination escapes the managed store.', 'invalid');
     }
 
-    const removed: SkillAgentId[] = [];
-    const created: SkillAgentId[] = [];
-    let asideContainer: string;
-    try {
-        asideContainer = fs.mkdtempSync(path.join(path.dirname(record.dirPath), '.agent-pivot-scope-'));
-    } catch (error) {
-        return fail(error instanceof Error ? error.message : String(error));
+    const lockResult = acquireSkillsMutationLocks([
+        projectStore,
+        globalStore,
+        record.dirPath,
+    ]);
+    if (lockResult.ok === false) {
+        return fail(lockResult.error);
     }
-    const aside = path.join(asideContainer, path.basename(record.dirPath));
-    let sourceAtAside = false;
-    let destinationCreated = false;
     try {
+        const removed: SkillAgentId[] = [];
+        const created: SkillAgentId[] = [];
+        let asideContainer: string;
+        try {
+            asideContainer = fs.mkdtempSync(path.join(path.dirname(record.dirPath), '.agent-pivot-scope-'));
+        } catch (error) {
+            return fail(error instanceof Error ? error.message : String(error));
+        }
+        const aside = path.join(asideContainer, path.basename(record.dirPath));
+        let sourceAtAside = false;
+        let destinationCreated = false;
+        try {
         for (const agent of projectAgents) {
             const root = roots.get(agent);
             if (!root) {
@@ -429,8 +448,8 @@ export function moveProjectSkillToGlobal(
             // container is safer than rolling back a completed migration.
         }
         return { ok: true, dirPath: destination };
-    } catch (error) {
-        const rollbackErrors: string[] = [];
+        } catch (error) {
+            const rollbackErrors: string[] = [];
         for (const agent of created.reverse()) {
             const result = setCentralLink(destination, roots.get(agent) as string, false);
             if (!result.ok) {
@@ -492,6 +511,9 @@ export function moveProjectSkillToGlobal(
                 + rollbackErrors.join(' '),
                 'rollback');
         }
-        return fail(message, message.includes('already exists') || message.includes('points elsewhere') ? 'conflict' : 'io');
+            return fail(message, message.includes('already exists') || message.includes('points elsewhere') ? 'conflict' : 'io');
+        }
+    } finally {
+        lockResult.lock.release();
     }
 }

--- a/src/skills/scopeService.ts
+++ b/src/skills/scopeService.ts
@@ -230,11 +230,15 @@ export function setGlobalSkillProjectAgents(
     agents: SkillAgentId[],
     homeDir: string,
     workspaceRoot: string,
+    globalSkillsRoot?: string,
 ): SkillScopeActionResult {
     if (!record.central || record.scope !== 'user') {
         return fail('Only a centralized global skill can be applied to a project.', 'invalid');
     }
-    if (!isManagedDescendant(record.dirPath, getCentralSkillsRoot(homeDir, 'user'))) {
+    if (!isManagedDescendant(
+        record.dirPath,
+        getCentralSkillsRoot(homeDir, 'user', undefined, globalSkillsRoot),
+    )) {
         return fail('The global skill resolves outside the managed Global store.', 'invalid');
     }
     if (!isReadableSkillDirectory(record.dirPath)) {
@@ -307,12 +311,13 @@ export function moveProjectSkillToGlobal(
     existingGlobal: SkillRecord | undefined,
     homeDir: string,
     workspaceRoot: string,
+    globalSkillsRoot?: string,
 ): SkillScopeActionResult {
     if (!record.central || record.scope !== 'project') {
         return fail('Only a centralized project skill can be moved to Global.', 'invalid');
     }
     const projectStore = getCentralSkillsRoot(homeDir, 'project', workspaceRoot);
-    const globalStore = getCentralSkillsRoot(homeDir, 'user');
+    const globalStore = getCentralSkillsRoot(homeDir, 'user', undefined, globalSkillsRoot);
     if (!isManagedDescendant(record.dirPath, projectStore)) {
         return fail('The project skill resolves outside this project’s managed store.', 'invalid');
     }

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -35,7 +35,7 @@ export interface SkillRecord {
 }
 
 export interface SkillCentralInfo {
-    /** Real directory inside the central store (`~/.skills` or `<project>/.skills`). */
+    /** Real directory inside the configured Global store or `<project>/.skills`. */
     dirPath: string;
     /** Which agent/generic skills roots link to the central directory, by scope. */
     links: SkillLinkMap;

--- a/src/webview/webviewDashboardScripts.js
+++ b/src/webview/webviewDashboardScripts.js
@@ -1165,7 +1165,7 @@ function initDashboard(options) {
         skillFolderMenu = menu;
     }
 
-    // Section (global / project) ⋯ menu: store-level actions, currently New folder.
+    // Section (global / project) ⋯ menu: store-level actions.
     function openSkillSectionMenu(button) {
         closeSkillFolderMenu();
         var scope = button.getAttribute('data-section-menu') || 'user';
@@ -1181,6 +1181,14 @@ function initDashboard(options) {
         newItem.setAttribute('data-folder-scope', scope);
         var migrateItem = appendMenuAction(menu, 'skill-folder-menu-migrate', 'Migrate to central…');
         migrateItem.setAttribute('data-skill-menu-migrate', scope);
+        if (scope === 'user') {
+            var locationItem = appendMenuAction(
+                menu,
+                'skill-folder-menu-location',
+                'Change Global Skills Location…'
+            );
+            locationItem.setAttribute('data-change-global-skills-location', '');
+        }
         document.body.appendChild(menu);
         positionSkillFolderMenu(menu, button);
         menu.__sourceButton = button;
@@ -1542,6 +1550,16 @@ function initDashboard(options) {
             event.stopPropagation();
             closeSkillFolderMenu();
             options.postMessage({ type: 'migrate-skills-to-central', scope: migrateCentral.getAttribute('data-skill-menu-migrate') });
+            return;
+        }
+        var changeGlobalSkillsLocation = event.target && event.target.closest
+            ? event.target.closest('[data-change-global-skills-location]')
+            : null;
+        if (changeGlobalSkillsLocation) {
+            event.preventDefault();
+            event.stopPropagation();
+            closeSkillFolderMenu();
+            options.postMessage({ type: 'change-global-skills-location' });
             return;
         }
         var sync = event.target && event.target.closest ? event.target.closest('[data-skill-sync]') : null;

--- a/tests/contract/aiSessions/runtimeComposition.test.js
+++ b/tests/contract/aiSessions/runtimeComposition.test.js
@@ -150,6 +150,7 @@ test('WEBVIEW-DASHBOARD-COMMAND-AVAILABILITY-001 production activation exposes s
         'agentPivot.addFileToActiveTerminal',
         'agentPivot.insertPromptToActiveTerminal',
         'agentPivot.migrateSkillsToCentral',
+        'agentPivot.changeGlobalSkillsLocation',
         'agentPivot.openCurrentAiSessionConversation',
     ]);
     assert.equal(result.dashboardCommandRegistrationInvocations, 1);

--- a/tests/contract/dashboardBoundaries.test.js
+++ b/tests/contract/dashboardBoundaries.test.js
@@ -327,7 +327,8 @@ const DASHBOARD_COMMANDS = [
     'agentPivot.removeProject', 'agentPivot.editProjects', 'agentPivot.addGroup',
     'agentPivot.removeGroup', 'agentPivot.addProjectsFromFolder',
     'agentPivot.addFileToActiveTerminal', 'agentPivot.insertPromptToActiveTerminal',
-    'agentPivot.migrateSkillsToCentral', 'agentPivot.openCurrentAiSessionConversation',
+    'agentPivot.migrateSkillsToCentral', 'agentPivot.changeGlobalSkillsLocation',
+    'agentPivot.openCurrentAiSessionConversation',
 ];
 
 test('WEBVIEW-DASHBOARD-COMMAND-REGISTRATION-001 WEBVIEW-DASHBOARD-COMMAND-AVAILABILITY-001 registers once and switches generation handlers safely', async () => {
@@ -337,7 +338,8 @@ test('WEBVIEW-DASHBOARD-COMMAND-REGISTRATION-001 WEBVIEW-DASHBOARD-COMMAND-AVAIL
     const handlerNames = [
         'open', 'addProject', 'saveProject', 'removeProject', 'editProjects', 'addGroup', 'removeGroup',
         'addProjectsFromFolder', 'addFileToActiveTerminal', 'insertPromptToActiveTerminal',
-        'migrateSkillsToCentral', 'openCurrentAiSessionConversation',
+        'migrateSkillsToCentral', 'changeGlobalSkillsLocation',
+        'openCurrentAiSessionConversation',
     ];
     const facade = new DashboardCommandRegistration({
         registerCommand: (command, callback) => {

--- a/tests/contract/skills/globalStoreLocationController.test.js
+++ b/tests/contract/skills/globalStoreLocationController.test.js
@@ -1,0 +1,211 @@
+'use strict';
+
+// Covers PERSIST-AI-SKILL-GLOBAL-STORE-LOCATION-001.
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const {
+    GlobalStoreLocationController,
+} = require('../../../out/skills/globalStoreLocationController');
+const {
+    relocateGlobalSkillsStore,
+} = require('../../../out/skills/globalStoreService');
+
+function fixture(t) {
+    const homeDir = fs.realpathSync(fs.mkdtempSync(
+        path.join(os.tmpdir(), 'global-store-controller-'),
+    ));
+    t.after(() => fs.rmSync(homeDir, { recursive: true, force: true }));
+    let setting = '~/.skills';
+    const writes = [];
+    const warnings = [];
+    const errors = [];
+    let refreshes = 0;
+    let input = undefined;
+    let warningChoice = undefined;
+    const options = {
+        homeDir,
+        getWorkspaceRoots: () => [],
+        readSetting: () => setting,
+        writeSetting: async value => {
+            writes.push(value);
+            setting = value;
+        },
+        showInputBox: async () => input,
+        showWarningMessage: async (message, _options, ...items) => {
+            warnings.push({ message, items });
+            return warningChoice;
+        },
+        showErrorMessage: message => errors.push(message),
+        refresh: async () => { refreshes += 1; },
+        logError: (message, error) => errors.push(`${message} ${error}`),
+    };
+    return {
+        homeDir,
+        options,
+        writes,
+        warnings,
+        errors,
+        setSetting(value) { setting = value; },
+        setInput(value) { input = value; },
+        setWarningChoice(value) { warningChoice = value; },
+        getRefreshes() { return refreshes; },
+    };
+}
+
+function writeSkill(root, name = 'demo') {
+    const dirPath = path.join(root, name);
+    fs.mkdirSync(dirPath, { recursive: true });
+    fs.writeFileSync(path.join(dirPath, 'SKILL.md'), `---\nname: ${name}\n---\n`);
+}
+
+test('PERSIST-AI-SKILL-GLOBAL-STORE-LOCATION-001 command cancellation has no effects', async t => {
+    const state = fixture(t);
+    const controller = new GlobalStoreLocationController(state.options);
+
+    assert.equal(await controller.changeInteractively(), false);
+    assert.deepEqual(state.writes, []);
+    assert.equal(state.getRefreshes(), 0);
+    assert.equal(controller.getActiveRoot(), path.join(state.homeDir, '.skills'));
+});
+
+test('PERSIST-AI-SKILL-GLOBAL-STORE-LOCATION-001 command moves, persists, and refreshes once', async t => {
+    const state = fixture(t);
+    const oldRoot = path.join(state.homeDir, '.skills');
+    const newRoot = path.join(state.homeDir, 'shared', 'skills');
+    writeSkill(oldRoot);
+    state.setInput(newRoot);
+    state.setWarningChoice('Move Existing Skills');
+    const controller = new GlobalStoreLocationController(state.options);
+
+    assert.equal(await controller.changeInteractively(), true);
+    assert.equal(controller.getActiveRoot(), newRoot);
+    assert.deepEqual(state.writes, [newRoot]);
+    assert.equal(state.getRefreshes(), 1);
+    assert.ok(fs.lstatSync(oldRoot).isSymbolicLink());
+    assert.ok(fs.existsSync(path.join(newRoot, 'demo', 'SKILL.md')));
+});
+
+test('PERSIST-AI-SKILL-GLOBAL-STORE-LOCATION-001 direct cancellation restores the previous setting', async t => {
+    const state = fixture(t);
+    writeSkill(path.join(state.homeDir, '.skills'));
+    const controller = new GlobalStoreLocationController(state.options);
+    state.setSetting(path.join(state.homeDir, 'other-skills'));
+    state.setWarningChoice(undefined);
+
+    assert.equal(await controller.handleConfigurationChange(), false);
+    assert.deepEqual(state.writes, ['~/.skills']);
+    assert.equal(controller.getActiveRoot(), path.join(state.homeDir, '.skills'));
+});
+
+test('PERSIST-AI-SKILL-GLOBAL-STORE-LOCATION-001 accepts a cross-window compatibility alias without prompting or rollback', async t => {
+    const state = fixture(t);
+    const oldRoot = path.join(state.homeDir, '.skills');
+    const newRoot = path.join(state.homeDir, 'new-global-skills');
+    writeSkill(oldRoot);
+    const controller = new GlobalStoreLocationController(state.options);
+
+    assert.equal(relocateGlobalSkillsStore(oldRoot, newRoot).ok, true);
+    state.setSetting(newRoot);
+    assert.equal(await controller.handleConfigurationChange(), true);
+    assert.equal(controller.getActiveRoot(), newRoot);
+    assert.deepEqual(state.writes, []);
+    assert.equal(state.warnings.length, 0);
+});
+
+test('PERSIST-AI-SKILL-GLOBAL-STORE-LOCATION-001 serializes coalesced direct configuration changes', async t => {
+    const state = fixture(t);
+    writeSkill(path.join(state.homeDir, '.skills'));
+    let releaseFirst;
+    let warningCalls = 0;
+    state.options.showWarningMessage = async (_message, options) => {
+        if (!options) {
+            return undefined;
+        }
+        warningCalls += 1;
+        if (warningCalls === 1) {
+            await new Promise(resolve => { releaseFirst = resolve; });
+        }
+        return 'Use New Location';
+    };
+    const controller = new GlobalStoreLocationController(state.options);
+    const firstRoot = path.join(state.homeDir, 'first');
+    const secondRoot = path.join(state.homeDir, 'second');
+    state.setSetting(firstRoot);
+    const first = controller.handleConfigurationChange();
+    while (!releaseFirst) {
+        await new Promise(resolve => setImmediate(resolve));
+    }
+    state.setSetting(secondRoot);
+    const second = controller.handleConfigurationChange();
+    releaseFirst();
+
+    assert.equal(await first, true);
+    assert.equal(await second, true);
+    assert.equal(controller.getActiveRoot(), secondRoot);
+    assert.equal(warningCalls, 1);
+});
+
+test('PERSIST-AI-SKILL-GLOBAL-STORE-LOCATION-001 cancelling an older prompt never overwrites a newer setting', async t => {
+    const state = fixture(t);
+    writeSkill(path.join(state.homeDir, '.skills'));
+    let releaseFirst;
+    let warningCalls = 0;
+    state.options.showWarningMessage = async (_message, options) => {
+        if (!options) {
+            return undefined;
+        }
+        warningCalls += 1;
+        if (warningCalls === 1) {
+            await new Promise(resolve => { releaseFirst = resolve; });
+            return undefined;
+        }
+        return 'Use New Location';
+    };
+    const controller = new GlobalStoreLocationController(state.options);
+    const firstRoot = path.join(state.homeDir, 'cancelled');
+    const secondRoot = path.join(state.homeDir, 'newer');
+    state.setSetting(firstRoot);
+    const first = controller.handleConfigurationChange();
+    while (!releaseFirst) {
+        await new Promise(resolve => setImmediate(resolve));
+    }
+    state.setSetting(secondRoot);
+    const second = controller.handleConfigurationChange();
+    releaseFirst();
+
+    assert.equal(await first, false);
+    assert.equal(await second, true);
+    assert.equal(controller.getActiveRoot(), secondRoot);
+    assert.deepEqual(state.writes, []);
+});
+
+test('PERSIST-AI-SKILL-GLOBAL-STORE-LOCATION-001 save failure keeps the safe session root and reports it', async t => {
+    const state = fixture(t);
+    const newRoot = path.join(state.homeDir, 'session-only');
+    state.setInput(newRoot);
+    state.options.writeSetting = async () => { throw new Error('settings unavailable'); };
+    const controller = new GlobalStoreLocationController(state.options);
+
+    assert.equal(await controller.changeInteractively(), false);
+    assert.equal(controller.getActiveRoot(), newRoot);
+    assert.equal(state.getRefreshes(), 1);
+    assert.ok(state.errors.some(message => message.includes('could not be saved')));
+});
+
+test('PERSIST-AI-SKILL-GLOBAL-STORE-LOCATION-001 refresh failure cannot block persistence', async t => {
+    const state = fixture(t);
+    const newRoot = path.join(state.homeDir, 'refresh-failed');
+    state.setInput(newRoot);
+    state.options.refresh = async () => { throw new Error('webview closed'); };
+    const controller = new GlobalStoreLocationController(state.options);
+
+    assert.equal(await controller.changeInteractively(), true);
+    assert.equal(controller.getActiveRoot(), newRoot);
+    assert.deepEqual(state.writes, [newRoot]);
+    assert.ok(state.errors.some(message => message.includes('Failed to refresh Skills')));
+});

--- a/tests/contract/skills/globalStoreLocationController.test.js
+++ b/tests/contract/skills/globalStoreLocationController.test.js
@@ -90,16 +90,16 @@ test('PERSIST-AI-SKILL-GLOBAL-STORE-LOCATION-001 command moves, persists, and re
     assert.ok(fs.existsSync(path.join(newRoot, 'demo', 'SKILL.md')));
 });
 
-test('PERSIST-AI-SKILL-GLOBAL-STORE-LOCATION-001 direct cancellation restores the previous setting', async t => {
+test('PERSIST-AI-SKILL-GLOBAL-STORE-LOCATION-001 adopts a persisted cross-window setting without rollback', async t => {
     const state = fixture(t);
     writeSkill(path.join(state.homeDir, '.skills'));
     const controller = new GlobalStoreLocationController(state.options);
     state.setSetting(path.join(state.homeDir, 'other-skills'));
-    state.setWarningChoice(undefined);
 
-    assert.equal(await controller.handleConfigurationChange(), false);
-    assert.deepEqual(state.writes, ['~/.skills']);
-    assert.equal(controller.getActiveRoot(), path.join(state.homeDir, '.skills'));
+    assert.equal(await controller.handleConfigurationChange(), true);
+    assert.deepEqual(state.writes, []);
+    assert.equal(controller.getActiveRoot(), path.join(state.homeDir, 'other-skills'));
+    assert.equal(state.warnings.length, 0);
 });
 
 test('PERSIST-AI-SKILL-GLOBAL-STORE-LOCATION-001 accepts a cross-window compatibility alias without prompting or rollback', async t => {
@@ -121,16 +121,12 @@ test('PERSIST-AI-SKILL-GLOBAL-STORE-LOCATION-001 serializes coalesced direct con
     const state = fixture(t);
     writeSkill(path.join(state.homeDir, '.skills'));
     let releaseFirst;
-    let warningCalls = 0;
-    state.options.showWarningMessage = async (_message, options) => {
-        if (!options) {
-            return undefined;
-        }
-        warningCalls += 1;
-        if (warningCalls === 1) {
+    let refreshCalls = 0;
+    state.options.refresh = async () => {
+        refreshCalls += 1;
+        if (refreshCalls === 1) {
             await new Promise(resolve => { releaseFirst = resolve; });
         }
-        return 'Use New Location';
     };
     const controller = new GlobalStoreLocationController(state.options);
     const firstRoot = path.join(state.homeDir, 'first');
@@ -147,10 +143,11 @@ test('PERSIST-AI-SKILL-GLOBAL-STORE-LOCATION-001 serializes coalesced direct con
     assert.equal(await first, true);
     assert.equal(await second, true);
     assert.equal(controller.getActiveRoot(), secondRoot);
-    assert.equal(warningCalls, 1);
+    assert.equal(refreshCalls, 2);
+    assert.deepEqual(state.writes, []);
 });
 
-test('PERSIST-AI-SKILL-GLOBAL-STORE-LOCATION-001 cancelling an older prompt never overwrites a newer setting', async t => {
+test('PERSIST-AI-SKILL-GLOBAL-STORE-LOCATION-001 cancelling an interactive prompt never overwrites a newer setting', async t => {
     const state = fixture(t);
     writeSkill(path.join(state.homeDir, '.skills'));
     let releaseFirst;
@@ -169,8 +166,8 @@ test('PERSIST-AI-SKILL-GLOBAL-STORE-LOCATION-001 cancelling an older prompt neve
     const controller = new GlobalStoreLocationController(state.options);
     const firstRoot = path.join(state.homeDir, 'cancelled');
     const secondRoot = path.join(state.homeDir, 'newer');
-    state.setSetting(firstRoot);
-    const first = controller.handleConfigurationChange();
+    state.setInput(firstRoot);
+    const first = controller.changeInteractively();
     while (!releaseFirst) {
         await new Promise(resolve => setImmediate(resolve));
     }

--- a/tests/extension-host/suite/index.js
+++ b/tests/extension-host/suite/index.js
@@ -17,6 +17,7 @@ const PUBLIC_COMMANDS = [
     'agentPivot.addFileToActiveTerminal',
     'agentPivot.insertPromptToActiveTerminal',
     'agentPivot.migrateSkillsToCentral',
+    'agentPivot.changeGlobalSkillsLocation',
     'agentPivot.openCurrentAiSessionConversation',
 ];
 

--- a/tests/unit/tooling/extensionHostSuite.test.js
+++ b/tests/unit/tooling/extensionHostSuite.test.js
@@ -21,6 +21,7 @@ const publicCommands = [
     'agentPivot.addFileToActiveTerminal',
     'agentPivot.insertPromptToActiveTerminal',
     'agentPivot.migrateSkillsToCentral',
+    'agentPivot.changeGlobalSkillsLocation',
     'agentPivot.openCurrentAiSessionConversation',
 ];
 


### PR DESCRIPTION
## Summary
- add a machine-scoped configurable Global Skills location, defaulting to ~/.skills
- provide guided relocation with compatibility aliases and cross-window-safe configuration handling
- serialize Global store mutations and safely recover stale Extension Host locks
- add deterministic, browser, safety, and capability-audit coverage

## Verification
- npm run test:ci:linux
- final whole-branch review: Critical 0, Important 0

No version, tag, release, or publication is included.