### PR TITLE
chore: release Agent Pivot 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to the "Agent Pivot" extension will be documented in this file. It follows the [Keep a Changelog](http://keepachangelog.com/) recommendations.
 
+## [1.0.1] - 2026-07-31
+
+### Added
+
+- Added an AI Skills workspace with global and project stores, folder
+  organization, scoped per-agent switches, migration, diagnostics, and a
+  configurable global store location.
+- Added a rich AI Conversation review workflow with Mermaid rendering,
+  persistent multi-comment batches, bulk actions, a resizable review panel,
+  current-session input navigation, and Active Session following.
+- Added model, context-window usage, and rate-limit telemetry to AI
+  Conversation.
+- Added pinning and stable ordering for other open workspace cards.
+
+### Changed
+
+- Kept AI Conversation reading position stable across live refreshes and large
+  Mermaid diagrams, while preserving focus, expanded content, and comment
+  drafts.
+- Improved provider discovery, session branding, tmux bootstrap diagnostics,
+  and bounded startup recovery across local and nested-container environments.
+
+### Fixed
+
+- Prevented AI Conversation loading starvation, repeated scroll jumps, hidden
+  Mermaid labels, obscured new-comment editors, and stale-session content after
+  switching Active Sessions.
+- Serialized Skills store mutations and hardened folder-name rendering,
+  filesystem containment, stale-lock recovery, and project-scope inheritance.
+
 ## [1.0.0] - 2026-07-26
 
 ### Added

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "291ca2e95a50e6417d61d610df95274b10672222",
+        "head": "0b1a72a4df82c1bfc595d63b52e85d2aacd753de",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -441,7 +441,8 @@
                 "4e0f247b2586894eef359fbe7fafac436d82ddf4",
                 "6e0c1fcd1201d469f55f57deb9bce134e556c683",
                 "07fefc21bb63bd8bde6192e30b3db4d9d13c642d",
-                "114e769d21182b614f213c35cdb9113f0305711b"
+                "114e769d21182b614f213c35cdb9113f0305711b",
+                "0b1a72a4df82c1bfc595d63b52e85d2aacd753de"
             ],
             "behaviors": [
                 "RELEASE-VSIX-PACKAGING-001",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "agent-pivot",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "agent-pivot",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "license": "MIT",
             "dependencies": {
                 "dom-autoscroller": "^2.3.4",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "agent-pivot",
     "displayName": "Agent Pivot",
     "description": "Switch, monitor, and resume Codex, Claude, and Kimi sessions across VS Code workspaces.",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "publisher": "hzcheng",
     "license": "MIT",
     "icon": "media/extension_icon.png",

--- a/scripts/lib/brandIdentity.js
+++ b/scripts/lib/brandIdentity.js
@@ -10,7 +10,7 @@ const BRAND_IDENTITY = Object.freeze({
     publisher: 'hzcheng',
     mainPackageName: 'agent-pivot',
     mainExtensionId: 'hzcheng.agent-pivot',
-    mainVersion: '1.0.0',
+    mainVersion: '1.0.1',
     bridgePackageName: 'agent-pivot-attention-ui-bridge',
     bridgeExtensionId: 'hzcheng.agent-pivot-attention-ui-bridge',
     commandPrefix: 'agentPivot.',

--- a/scripts/run-release-notes-checks.js
+++ b/scripts/run-release-notes-checks.js
@@ -14,19 +14,19 @@ const workflowPath = path.join(repositoryRoot, '.github', 'workflows', 'release-
 function validateReleaseContent({ readme, changelog, packageMetadata }) {
     assert.strictEqual(packageMetadata.displayName, 'Agent Pivot',
         'release metadata must use the Agent Pivot display name');
-    assert.strictEqual(packageMetadata.version, '1.0.0',
-        'the first Agent Pivot release must remain version 1.0.0');
+    assert.strictEqual(packageMetadata.version, '1.0.1',
+        'the current Agent Pivot release must be version 1.0.1');
     const currentRelease = extractReleaseNotes(changelog, packageMetadata.version);
     const requiredReleaseFacts = [
-        ['Agent Pivot identity', /Agent Pivot identity/i],
-        ['Pure Axis icon system', /Pure Axis icon system/i],
-        ['cross-workspace command center', /cross-workspace command center/i],
-        ['Codex, Claude, and Kimi providers', /Codex, Claude, and Kimi/i],
-        ['conversation navigation', /conversation navigation/i],
+        ['AI Skills management', /AI Skills workspace/i],
+        ['rich AI Conversation review', /rich AI Conversation review workflow/i],
+        ['conversation telemetry', /context-window usage/i],
+        ['other workspace pinning', /pinning.*other open workspace cards/i],
+        ['conversation reading stability', /reading position stable/i],
     ];
 
     for (const [label, pattern] of requiredReleaseFacts) {
-        assert.match(currentRelease, pattern, `1.0.0 CHANGELOG release must document ${label}`);
+        assert.match(currentRelease, pattern, `1.0.1 CHANGELOG release must document ${label}`);
     }
     assert.match(readme, /Agent Pivot/i, 'README must document the current product name');
     assert.match(packageMetadata.description, /workspace/i,

--- a/scripts/run-release-packaging-checks.js
+++ b/scripts/run-release-packaging-checks.js
@@ -340,7 +340,7 @@ function runRealVsixArchiveChecks(mainPackage, bridgePackage) {
     );
     assert.strictEqual(
         path.basename(mainArtifact),
-        'agent-pivot-1.0.0.vsix',
+        'agent-pivot-1.0.1.vsix',
         'main release artifact name must remain exact',
     );
     assert.strictEqual(

--- a/tests/unit/tooling/brandIdentity.test.js
+++ b/tests/unit/tooling/brandIdentity.test.js
@@ -50,7 +50,7 @@ function manifests() {
             name: 'agent-pivot',
             displayName: 'Agent Pivot',
             publisher: 'hzcheng',
-            version: '1.0.0',
+            version: '1.0.1',
             icon: 'media/extension_icon.png',
             repository: {
                 type: 'git',
@@ -294,7 +294,7 @@ test('brand identity exposes the exact approved public contract', () => {
         publisher: 'hzcheng',
         mainPackageName: 'agent-pivot',
         mainExtensionId: 'hzcheng.agent-pivot',
-        mainVersion: '1.0.0',
+        mainVersion: '1.0.1',
         bridgePackageName: 'agent-pivot-attention-ui-bridge',
         bridgeExtensionId: 'hzcheng.agent-pivot-attention-ui-bridge',
         commandPrefix: 'agentPivot.',

--- a/tests/unit/tooling/releaseNotes.test.js
+++ b/tests/unit/tooling/releaseNotes.test.js
@@ -14,15 +14,16 @@ test('release content validation cannot satisfy current facts from historical no
     const changelog = [
         '# Changelog',
         '',
+        '## [1.0.1] - 2026-07-31',
+        '',
+        '- Added a rich AI Conversation review workflow.',
+        '- Added context-window usage telemetry.',
+        '- Added pinning for other open workspace cards.',
+        '- Kept the AI Conversation reading position stable.',
+        '',
         '## [1.0.0] - 2026-07-26',
         '',
-        '- Established the Agent Pivot identity.',
-        '- Added a cross-workspace command center for Codex, Claude, and Kimi.',
-        '- Added conversation navigation.',
-        '',
-        '## Unpublished Project Steward development history',
-        '',
-        '- Established the Pure Axis icon system.',
+        '- Added an AI Skills workspace.',
         '',
     ].join('\n');
 
@@ -32,10 +33,10 @@ test('release content validation cannot satisfy current facts from historical no
             changelog,
             packageMetadata: {
                 displayName: 'Agent Pivot',
-                version: '1.0.0',
+                version: '1.0.1',
                 description: 'Workspace command center.',
             },
         }),
-        /1\.0\.0 CHANGELOG release must document Pure Axis icon system/,
+        /1\.0\.1 CHANGELOG release must document AI Skills management/,
     );
 });


### PR DESCRIPTION
## Summary

- bump the Agent Pivot workspace extension from 1.0.0 to 1.0.1
- keep the Attention UI Bridge at 1.0.0
- add 1.0.1 release notes for AI Skills, AI Conversation review/telemetry, open-window pinning, and stability fixes
- update exact brand, release-note, packaging, and capability audit contracts

## Verification

- `npm run test:ci:linux`
- `npm run test:release-notes`
- `npm run test:release-packaging`
- `npm run test:behavior-contracts`

## Local release artifacts

- `agent-pivot-1.0.1.vsix` — SHA-256 `3ac529103646f3db436d5bf1ab2118feb4daafc488e80b1d9cb53783bc88d51a`
- `agent-pivot-attention-ui-bridge-1.0.0.vsix` — SHA-256 `76064f211493e8dc8397559fe360f67bf260cf07256d0d93ba159b69f94458f7`

After merge, tag `v1.0.1` will trigger the release workflow to rebuild, verify, and publish both VSIX files.
