### PR TITLE
fix: stabilize AI Conversation reading and stage comment batches

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -3635,7 +3635,7 @@
   {
     "id": "CONVERSATION-COMMENTS-SUBMIT-001",
     "domain": "session",
-    "title": "One comment batch targets the exact idle runtime or resumes the exact stopped session with its prompt",
+    "title": "One complete comment batch targets the exact idle runtime input without submitting, resuming the exact stopped session first",
     "priority": "P0",
     "status": "automated",
     "owners": [
@@ -3651,7 +3651,7 @@
   {
     "id": "CONVERSATION-COMMENTS-UI-001",
     "domain": "webview",
-    "title": "AI Conversation collects multiple text selections and submits one correlated comment batch",
+    "title": "AI Conversation collects multiple text selections and stages one correlated comment batch in the session input",
     "priority": "P0",
     "status": "automated",
     "owners": [
@@ -3665,7 +3665,7 @@
   {
     "id": "CONVERSATION-COMMENTS-REVIEW-001",
     "domain": "webview",
-    "title": "AI Conversation comments support keyboard saving, retain Host-authoritative review states, locate exact sources, and focus the session after sending",
+    "title": "AI Conversation comments support keyboard saving, retain Host-authoritative review states, locate exact sources, and focus the session after staging",
     "priority": "P0",
     "status": "automated",
     "owners": [

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "0b1a72a4df82c1bfc595d63b52e85d2aacd753de",
+        "head": "e997c332681215bd153addfad07b98539c36b6d7",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -963,7 +963,8 @@
                 "aff1912fb00297609b99b5a2c9affede9c7f707f",
                 "53443dc749dbe3fe6fa19612d6d8afc4788158b5",
                 "ce7fbe690477a7d5fad214bcabd8170c3d181f62",
-                "291ca2e95a50e6417d61d610df95274b10672222"
+                "291ca2e95a50e6417d61d610df95274b10672222",
+                "e997c332681215bd153addfad07b98539c36b6d7"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",

--- a/media/conversationViewerScripts.js
+++ b/media/conversationViewerScripts.js
@@ -760,7 +760,7 @@
             || !!state.pendingLocateRequest;
         var summary = [];
         if (counts.open) summary.push(counts.open + ' open');
-        if (counts.sent) summary.push(counts.sent + ' sent');
+        if (counts.sent) summary.push(counts.sent + ' added');
         if (counts.resolved) summary.push(counts.resolved + ' resolved');
         commentSummary.textContent = summary.length
             ? summary.join(' · ')
@@ -788,11 +788,11 @@
 
     function commentErrorMessage(error) {
         if (error === 'stale') return 'Comments changed. Review the latest draft and try again.';
-        if (error === 'limit') return 'A maximum of 20 comments can be sent at once.';
+        if (error === 'limit') return 'A maximum of 20 comments can be added at once.';
         if (error === 'tooLarge') return 'The combined comments are too large to send.';
         if (error === 'busy') return 'Wait for the current AI response to finish, then send again.';
         if (error === 'conflict') return 'Multiple runtimes match this session. Resolve the conflict first.';
-        if (error === 'unavailable') return 'This session is unavailable and the comments were not sent.';
+        if (error === 'unavailable') return 'This session is unavailable and the comments were not added.';
         return 'The comment action failed. Your comments were kept.';
     }
 
@@ -820,7 +820,7 @@
         state.pendingCommentRequest = { requestId: requestId, operation: operation };
         setCommentPending(true);
         status.textContent = operation === 'sendComments'
-            ? 'Sending comments to this session…'
+            ? 'Adding comments to session input…'
             : operation === 'clearSent'
                 || operation === 'clearResolved'
                 || operation === 'clearAll'
@@ -908,7 +908,7 @@
             statusLabel.setAttribute('data-comment-status-label', '');
             statusLabel.textContent = comment.status === 'open'
                 ? 'Open'
-                : comment.status === 'sent' ? 'Sent' : 'Resolved';
+                : comment.status === 'sent' ? 'Added' : 'Resolved';
             identity.append(label, statusLabel);
             var locate = document.createElement('button');
             locate.type = 'button';
@@ -1086,9 +1086,9 @@
         setCommentPending(false);
         if (message.success) {
             status.textContent = operation === 'sendComments'
-                ? 'Comments sent to this session.'
+                ? 'Comments added to session input. Review and press Enter to send.'
                 : operation === 'clearSent'
-                    ? 'Sent comments cleared.'
+                    ? 'Added comments cleared.'
                     : operation === 'clearResolved'
                         ? 'Resolved comments cleared.'
                         : operation === 'clearAll'
@@ -1659,6 +1659,15 @@
         var oldMessages = Array.prototype.slice.call(
             messages.querySelectorAll(conversationMessageSelector())
         );
+        var unchanged = oldMessages.length === candidates.length
+            && candidates.every(function (candidate, index) {
+                var id = conversationMessageId(candidate);
+                return conversationMessageId(oldMessages[index]) === id
+                    && previousSignatures.get(id) === candidate.outerHTML;
+            });
+        if (unchanged) {
+            return { ids: nextIds, signatures: nextSignatures };
+        }
         var oldById = new Map();
         oldMessages.forEach(function (message) {
             var id = conversationMessageId(message);
@@ -1716,6 +1725,14 @@
                     messageId: message
                         ? conversationMessageId(message)
                         : null,
+                    blockIndex: message
+                        ? Array.prototype.indexOf.call(
+                            message.querySelectorAll(
+                                '.conversation-markdown > *'
+                            ),
+                            blockCandidates[blockIndex]
+                        )
+                        : -1,
                     top: blockBounds.top - scrollBounds.top,
                     viewportTop: blockBounds.top,
                 };
@@ -1731,6 +1748,14 @@
                 messageId: crossingMessage
                     ? conversationMessageId(crossingMessage)
                     : null,
+                blockIndex: crossingMessage
+                    ? Array.prototype.indexOf.call(
+                        crossingMessage.querySelectorAll(
+                            '.conversation-markdown > *'
+                        ),
+                        crossingBlock
+                    )
+                    : -1,
                 top: crossingBounds.top - scrollBounds.top,
                 viewportTop: crossingBounds.top,
             };
@@ -1756,14 +1781,23 @@
 
     function readingAnchorElement(anchor) {
         if (!anchor) return null;
-        return anchor.element && anchor.element.isConnected
-            ? anchor.element
-            : Array.prototype.find.call(
-                messages.querySelectorAll(conversationMessageSelector()),
-                function (message) {
-                    return conversationMessageId(message) === anchor.messageId;
-                }
-            );
+        if (anchor.element && anchor.element.isConnected) {
+            return anchor.element;
+        }
+        var message = Array.prototype.find.call(
+            messages.querySelectorAll(conversationMessageSelector()),
+            function (candidate) {
+                return conversationMessageId(candidate) === anchor.messageId;
+            }
+        );
+        if (!message) return null;
+        if (Number.isSafeInteger(anchor.blockIndex)
+            && anchor.blockIndex >= 0) {
+            return message.querySelectorAll(
+                '.conversation-markdown > *'
+            )[anchor.blockIndex] || message;
+        }
+        return message;
     }
 
     function restoreReadingPosition(anchor, fallbackScrollTop) {
@@ -1870,7 +1904,10 @@
                 candidate.classList.remove('conversation-selected-interaction');
             }, 1600);
         });
-        if (isLiveRefresh && focusedMessageId) {
+        if (isLiveRefresh
+            && focusedMessageId
+            && (!focusedMessage.isConnected
+                || !focusedMessage.contains(document.activeElement))) {
             var restoredFocus = Array.prototype.find.call(
                 messages.querySelectorAll(conversationMessageSelector()),
                 function (candidate) {
@@ -1883,12 +1920,7 @@
                 restoredFocus.focus({ preventScroll: true });
             }
         }
-        renderMermaidDiagrams(renderGeneration).then(function () {
-            if (renderGeneration !== state.renderGeneration) return;
-            if (isLiveRefresh) {
-                restoreReadingPosition(readingAnchor, previousScrollTop);
-            }
-        });
+        renderMermaidDiagrams(renderGeneration);
 
         if (!isLiveRefresh) {
             state.firstNewMessageId = null;

--- a/src/aiSessions/conversation/submission.ts
+++ b/src/aiSessions/conversation/submission.ts
@@ -22,7 +22,7 @@ export interface ConversationPromptSubmissionOptions<
         provider: AiSessionProviderId,
         sessionId: string,
         rootId: string | undefined,
-        prompt: string
+        prompt?: string
     ): Promise<AiSessionRuntimeActionResult<TTerminal> | undefined>;
 }
 
@@ -53,7 +53,7 @@ export async function submitConversationPrompt<
         throw new ConversationCommentError('conflict');
     }
     if (existing?.state === 'active' && existing.terminal) {
-        existing.terminal.sendText(prompt, true);
+        existing.terminal.sendText(prompt, false);
         return;
     }
     const result = await options.resume(
@@ -61,15 +61,13 @@ export async function submitConversationPrompt<
         target.provider,
         target.sessionId,
         session.primaryRootId,
-        prompt
+        undefined
     );
-    if (result?.status === 'started') {
-        return;
-    }
-    if (result?.status === 'focused') {
-        const focused = options.getRuntime(target.provider, target.sessionId);
-        if (focused?.terminal) {
-            focused.terminal.sendText(prompt, true);
+    if (result?.status === 'started' || result?.status === 'focused') {
+        const runtime = result.runtime
+            || options.getRuntime(target.provider, target.sessionId);
+        if (runtime?.terminal) {
+            runtime.terminal.sendText(prompt, false);
             return;
         }
         throw new ConversationCommentError('unavailable');

--- a/src/aiSessions/conversation/viewer.ts
+++ b/src/aiSessions/conversation/viewer.ts
@@ -1082,6 +1082,12 @@ export class ConversationViewer implements ConversationViewerApi {
             const selectedInteractionId = updateKind === 'initial'
                 ? target.interactionId
                 : previousSelectedInteractionId as string;
+            if (updateKind === 'refresh'
+                && !this.stale
+                && this.outline?.sourceRevision === outline.sourceRevision) {
+                void this.refreshTelemetry(target, generation);
+                return true;
+            }
             let page: ConversationPage;
             try {
                 page = await this.options.readPage({
@@ -1828,7 +1834,8 @@ export class ConversationViewer implements ConversationViewerApi {
                     aria-label="Comment actions">
                     <button class="conversation-comments-clear" type="button"
                         data-comment-action="clearSent"
-                        title="Clear sent comments" disabled>Clear sent</button>
+                        title="Clear comments added to the session input"
+                        disabled>Clear added</button>
                     <button class="conversation-comments-clear" type="button"
                         data-comment-action="clearResolved"
                         title="Clear resolved comments"
@@ -1838,7 +1845,7 @@ export class ConversationViewer implements ConversationViewerApi {
                         title="Clear all comments" disabled>Clear all</button>
                     <button class="conversation-comments-send" type="button"
                         data-comment-action="send" disabled
-                        title="Send open comments to this session">Send open comments to this session</button>
+                        title="Add open comments to the session input">Add open comments to session input</button>
                 </div>
             </section>
         </aside>

--- a/src/webview/conversationViewerScripts.js
+++ b/src/webview/conversationViewerScripts.js
@@ -760,7 +760,7 @@
             || !!state.pendingLocateRequest;
         var summary = [];
         if (counts.open) summary.push(counts.open + ' open');
-        if (counts.sent) summary.push(counts.sent + ' sent');
+        if (counts.sent) summary.push(counts.sent + ' added');
         if (counts.resolved) summary.push(counts.resolved + ' resolved');
         commentSummary.textContent = summary.length
             ? summary.join(' · ')
@@ -788,11 +788,11 @@
 
     function commentErrorMessage(error) {
         if (error === 'stale') return 'Comments changed. Review the latest draft and try again.';
-        if (error === 'limit') return 'A maximum of 20 comments can be sent at once.';
+        if (error === 'limit') return 'A maximum of 20 comments can be added at once.';
         if (error === 'tooLarge') return 'The combined comments are too large to send.';
         if (error === 'busy') return 'Wait for the current AI response to finish, then send again.';
         if (error === 'conflict') return 'Multiple runtimes match this session. Resolve the conflict first.';
-        if (error === 'unavailable') return 'This session is unavailable and the comments were not sent.';
+        if (error === 'unavailable') return 'This session is unavailable and the comments were not added.';
         return 'The comment action failed. Your comments were kept.';
     }
 
@@ -820,7 +820,7 @@
         state.pendingCommentRequest = { requestId: requestId, operation: operation };
         setCommentPending(true);
         status.textContent = operation === 'sendComments'
-            ? 'Sending comments to this session…'
+            ? 'Adding comments to session input…'
             : operation === 'clearSent'
                 || operation === 'clearResolved'
                 || operation === 'clearAll'
@@ -908,7 +908,7 @@
             statusLabel.setAttribute('data-comment-status-label', '');
             statusLabel.textContent = comment.status === 'open'
                 ? 'Open'
-                : comment.status === 'sent' ? 'Sent' : 'Resolved';
+                : comment.status === 'sent' ? 'Added' : 'Resolved';
             identity.append(label, statusLabel);
             var locate = document.createElement('button');
             locate.type = 'button';
@@ -1086,9 +1086,9 @@
         setCommentPending(false);
         if (message.success) {
             status.textContent = operation === 'sendComments'
-                ? 'Comments sent to this session.'
+                ? 'Comments added to session input. Review and press Enter to send.'
                 : operation === 'clearSent'
-                    ? 'Sent comments cleared.'
+                    ? 'Added comments cleared.'
                     : operation === 'clearResolved'
                         ? 'Resolved comments cleared.'
                         : operation === 'clearAll'
@@ -1659,6 +1659,15 @@
         var oldMessages = Array.prototype.slice.call(
             messages.querySelectorAll(conversationMessageSelector())
         );
+        var unchanged = oldMessages.length === candidates.length
+            && candidates.every(function (candidate, index) {
+                var id = conversationMessageId(candidate);
+                return conversationMessageId(oldMessages[index]) === id
+                    && previousSignatures.get(id) === candidate.outerHTML;
+            });
+        if (unchanged) {
+            return { ids: nextIds, signatures: nextSignatures };
+        }
         var oldById = new Map();
         oldMessages.forEach(function (message) {
             var id = conversationMessageId(message);
@@ -1716,6 +1725,14 @@
                     messageId: message
                         ? conversationMessageId(message)
                         : null,
+                    blockIndex: message
+                        ? Array.prototype.indexOf.call(
+                            message.querySelectorAll(
+                                '.conversation-markdown > *'
+                            ),
+                            blockCandidates[blockIndex]
+                        )
+                        : -1,
                     top: blockBounds.top - scrollBounds.top,
                     viewportTop: blockBounds.top,
                 };
@@ -1731,6 +1748,14 @@
                 messageId: crossingMessage
                     ? conversationMessageId(crossingMessage)
                     : null,
+                blockIndex: crossingMessage
+                    ? Array.prototype.indexOf.call(
+                        crossingMessage.querySelectorAll(
+                            '.conversation-markdown > *'
+                        ),
+                        crossingBlock
+                    )
+                    : -1,
                 top: crossingBounds.top - scrollBounds.top,
                 viewportTop: crossingBounds.top,
             };
@@ -1756,14 +1781,23 @@
 
     function readingAnchorElement(anchor) {
         if (!anchor) return null;
-        return anchor.element && anchor.element.isConnected
-            ? anchor.element
-            : Array.prototype.find.call(
-                messages.querySelectorAll(conversationMessageSelector()),
-                function (message) {
-                    return conversationMessageId(message) === anchor.messageId;
-                }
-            );
+        if (anchor.element && anchor.element.isConnected) {
+            return anchor.element;
+        }
+        var message = Array.prototype.find.call(
+            messages.querySelectorAll(conversationMessageSelector()),
+            function (candidate) {
+                return conversationMessageId(candidate) === anchor.messageId;
+            }
+        );
+        if (!message) return null;
+        if (Number.isSafeInteger(anchor.blockIndex)
+            && anchor.blockIndex >= 0) {
+            return message.querySelectorAll(
+                '.conversation-markdown > *'
+            )[anchor.blockIndex] || message;
+        }
+        return message;
     }
 
     function restoreReadingPosition(anchor, fallbackScrollTop) {
@@ -1870,7 +1904,10 @@
                 candidate.classList.remove('conversation-selected-interaction');
             }, 1600);
         });
-        if (isLiveRefresh && focusedMessageId) {
+        if (isLiveRefresh
+            && focusedMessageId
+            && (!focusedMessage.isConnected
+                || !focusedMessage.contains(document.activeElement))) {
             var restoredFocus = Array.prototype.find.call(
                 messages.querySelectorAll(conversationMessageSelector()),
                 function (candidate) {
@@ -1883,12 +1920,7 @@
                 restoredFocus.focus({ preventScroll: true });
             }
         }
-        renderMermaidDiagrams(renderGeneration).then(function () {
-            if (renderGeneration !== state.renderGeneration) return;
-            if (isLiveRefresh) {
-                restoreReadingPosition(readingAnchor, previousScrollTop);
-            }
-        });
+        renderMermaidDiagrams(renderGeneration);
 
         if (!isLiveRefresh) {
             state.firstNewMessageId = null;

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -1440,7 +1440,7 @@ test('CONVERSATION-COMMENTS-UI-001 CONVERSATION-COMMENTS-REVIEW-001 CONVERSATION
     assert.equal(await page.locator('[data-comment-id]').count(), 2);
     assert.deepEqual(
         await page.locator('[data-comment-status-label]').allTextContents(),
-        ['Sent', 'Sent']
+        ['Added', 'Added']
     );
     assert.equal(
         await page.locator('[data-comment-action="send"]').isDisabled(),
@@ -1448,7 +1448,7 @@ test('CONVERSATION-COMMENTS-UI-001 CONVERSATION-COMMENTS-REVIEW-001 CONVERSATION
     );
     assert.equal(
         await page.locator('[data-conversation-status]').textContent(),
-        'Comments sent to this session.'
+        'Comments added to session input. Review and press Enter to send.'
     );
 
     await page.locator('[data-comment-id="comment-1"]')
@@ -2258,6 +2258,196 @@ test('CONVERSATION-READING-FOCUS-001 preserves an unchanged Mermaid block while 
     assert.match(
         await page.locator('[data-message-id="streaming"]').textContent(),
         /more streamed text/
+    );
+});
+
+test('CONVERSATION-READING-FOCUS-001 leaves an identical refresh DOM and descendant focus untouched', async t => {
+    const page = await openViewerPage(t);
+    const html = `<article data-message-id="stable-refresh"
+        data-interaction-id="input-4">
+        <section class="conversation-markdown">
+            <p><a href="https://example.com/stable">Stable reading link</a></p>
+        </section>
+    </article>` + messageHtml('stable-refresh-tail', 50);
+    await sendPage(page, {
+        ...hostileConversationPage,
+        html,
+        selectedInput: 25,
+        totalInputs: 25,
+        updateKind: 'initial',
+    });
+    const link = page.getByRole('link', { name: 'Stable reading link' });
+    await link.focus();
+    await page.evaluate(() => {
+        window.__conversationMessageMutations = 0;
+        window.__conversationMessageObserver = new MutationObserver(records => {
+            window.__conversationMessageMutations += records.filter(record =>
+                record.type === 'childList'
+            ).length;
+        });
+        window.__conversationMessageObserver.observe(
+            document.querySelector('[data-conversation-messages]'),
+            { childList: true, subtree: true }
+        );
+    });
+
+    await sendPage(page, {
+        ...hostileConversationPage,
+        requestId: 2,
+        html,
+        selectedInput: 25,
+        totalInputs: 25,
+        updateKind: 'refresh',
+    });
+    await page.evaluate(() => new Promise(resolve => {
+        requestAnimationFrame(() => requestAnimationFrame(resolve));
+    }));
+
+    assert.equal(await page.evaluate(
+        () => window.__conversationMessageMutations
+    ), 0);
+    assert.equal(
+        await page.evaluate(() => document.activeElement?.textContent),
+        'Stable reading link'
+    );
+});
+
+test('CONVERSATION-READING-FOCUS-001 never restores a stale refresh anchor after the reader scrolls during Mermaid rendering', async t => {
+    const page = await openViewerPage(t, { controlledMermaid: true });
+    await page.addStyleTag({ content: viewerCss });
+    const initialHead = `<article data-message-id="changing-head"
+        data-interaction-id="input-4">
+        <section class="conversation-markdown">
+            <p>Response before the diagram arrives.</p>
+        </section>
+    </article>`;
+    const refreshedHead = `<article data-message-id="changing-head"
+        data-interaction-id="input-4">
+        <section class="conversation-markdown">
+            <p>Response before the diagram arrives.</p>
+            <pre><code class="language-mermaid">flowchart TB
+                A[Delayed diagram] --&gt; B[Must respect later reading]</code></pre>
+        </section>
+    </article>`;
+    const tail = messageHtml('reader-tail', 24);
+    await sendPage(page, {
+        ...hostileConversationPage,
+        html: initialHead + tail,
+        selectedInput: 12,
+        totalInputs: 12,
+        updateKind: 'initial',
+    });
+    const scroll = page.locator('[data-conversation-scroll]');
+    await scroll.evaluate(element => {
+        element.style.overflowAnchor = 'none';
+    });
+    const refreshAnchor = page.locator('[data-message-id="reader-tail-4"]');
+    await refreshAnchor.evaluate(element => element.scrollIntoView({
+        block: 'center',
+    }));
+
+    await sendPage(page, {
+        ...hostileConversationPage,
+        requestId: 2,
+        html: refreshedHead + tail,
+        selectedInput: 12,
+        totalInputs: 12,
+        updateKind: 'refresh',
+    });
+    await page.waitForFunction(() => window.__mermaidRenders.length === 1);
+    const readerAnchor = page.locator('[data-message-id="reader-tail-18"]');
+    await readerAnchor.evaluate(element => element.scrollIntoView({
+        block: 'center',
+    }));
+    const readerTopBefore = await readerAnchor.evaluate(element => {
+        const scrollElement = document.querySelector(
+            '[data-conversation-scroll]'
+        );
+        return element.getBoundingClientRect().top
+            - scrollElement.getBoundingClientRect().top;
+    });
+
+    await page.evaluate(() => {
+        window.__mermaidRenders[0].resolve({
+            svg: `<svg xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 600 1800">
+                <rect width="600" height="1800" fill="#246"></rect>
+            </svg>`,
+        });
+    });
+    await page.locator('.conversation-mermaid-image').waitFor();
+    await page.evaluate(() => new Promise(resolve => {
+        requestAnimationFrame(() => requestAnimationFrame(resolve));
+    }));
+    const readerTopAfter = await readerAnchor.evaluate(element => {
+        const scrollElement = document.querySelector(
+            '[data-conversation-scroll]'
+        );
+        return element.getBoundingClientRect().top
+            - scrollElement.getBoundingClientRect().top;
+    });
+
+    assert.ok(
+        Math.abs(readerTopAfter - readerTopBefore) <= 1,
+        `reader-selected anchor moved from ${readerTopBefore} to `
+            + readerTopAfter
+    );
+});
+
+test('CONVERSATION-READING-FOCUS-001 preserves the visible block inside a changed Assistant message', async t => {
+    const page = await openViewerPage(t);
+    await page.addStyleTag({ content: viewerCss });
+    const response = suffix => `<article data-message-id="changing-response"
+        data-interaction-id="input-4">
+        <section class="conversation-markdown">
+            ${Array.from({ length: 18 }, (_, index) =>
+                `<p>Response block ${index + 1}`
+                    + `${index === 0 ? suffix : ''}</p>`
+            ).join('')}
+        </section>
+    </article>`;
+    await sendPage(page, {
+        ...hostileConversationPage,
+        html: response(''),
+        updateKind: 'initial',
+    });
+    const scroll = page.locator('[data-conversation-scroll]');
+    await scroll.evaluate(element => {
+        element.style.overflowAnchor = 'none';
+    });
+    const anchor = page.getByText('Response block 12', { exact: true });
+    await anchor.evaluate(element => element.scrollIntoView({
+        block: 'center',
+    }));
+    const anchorTopBefore = await anchor.evaluate(element => {
+        const scrollElement = document.querySelector(
+            '[data-conversation-scroll]'
+        );
+        return element.getBoundingClientRect().top
+            - scrollElement.getBoundingClientRect().top;
+    });
+
+    await sendPage(page, {
+        ...hostileConversationPage,
+        requestId: 2,
+        html: response(' with newly streamed text'),
+        updateKind: 'refresh',
+    });
+    const anchorTopAfter = await page.getByText(
+        'Response block 12',
+        { exact: true }
+    ).evaluate(element => {
+        const scrollElement = document.querySelector(
+            '[data-conversation-scroll]'
+        );
+        return element.getBoundingClientRect().top
+            - scrollElement.getBoundingClientRect().top;
+    });
+
+    assert.ok(
+        Math.abs(anchorTopAfter - anchorTopBefore) <= 1,
+        `intra-message reading block moved from ${anchorTopBefore} to `
+            + anchorTopAfter
     );
 });
 

--- a/tests/integration/dashboard/conversationRouting.test.js
+++ b/tests/integration/dashboard/conversationRouting.test.js
@@ -808,8 +808,11 @@ test('PRODUCTION-CONVERSATION-LIFECYCLE-001 hidden sidebar keeps the exact viewe
     await harness.reconcile();
     const readsAfterStopped = harness.events.filter(event =>
         event === 'read-outline:codex' || event === 'read-page:codex'
-    ).length;
-    assert.equal(readsAfterStopped, readsBeforeLifecycle + 2);
+    );
+    assert.deepEqual(
+        readsAfterStopped.slice(readsBeforeLifecycle),
+        ['read-outline:codex']
+    );
     assert.equal(harness.panels.length, 1);
 
     targetAvailable = false;

--- a/tests/integration/dashboard/conversationViewer.test.js
+++ b/tests/integration/dashboard/conversationViewer.test.js
@@ -677,9 +677,12 @@ test('CONVERSATION-VIEWER-REFRESH-001 retains stale content after a watched fail
             return outline(
                 sessionId,
                 outlineCount < 3 ? ['input-1'] : ['input-1', 'input-2'],
-                outlineCount < 3
-                    ? {}
-                    : { totalInteractions: 2_001, partial: true }
+                {
+                    sourceRevision: outlineCount === 1 ? 'r1' : 'r2',
+                    ...(outlineCount < 3
+                        ? {}
+                        : { totalInteractions: 2_001, partial: true }),
+                }
             );
         },
         readPage: request => {
@@ -690,7 +693,8 @@ test('CONVERSATION-VIEWER-REFRESH-001 retains stale content after a watched fail
             return Promise.resolve(page(
                 request.sessionId,
                 request.anchorInteractionId,
-                readCount === 1 ? 'visible-initial' : 'visible-recovered'
+                readCount === 1 ? 'visible-initial' : 'visible-recovered',
+                { sourceRevision: request.expectedRevision }
             ));
         },
     });
@@ -713,6 +717,43 @@ test('CONVERSATION-VIEWER-REFRESH-001 retains stale content after a watched fail
     assert.equal(publication.html.includes('visible-recovered'), true);
     assert.equal(publication.totalInputs, 2_000);
     assert.equal(publication.partial, true);
+});
+
+test('CONVERSATION-READING-FOCUS-001 ignores watched refreshes when the authoritative source revision is unchanged', async () => {
+    let onChange;
+    let outlineReads = 0;
+    let pageReads = 0;
+    const { viewer, panel } = createViewer({
+        watch: (_provider, _sessionId, callback) => {
+            onChange = callback;
+            return { dispose() {} };
+        },
+        readOutline: async (_provider, sessionId) => {
+            outlineReads += 1;
+            return outline(sessionId, ['input-1'], { sourceRevision: 'stable-r1' });
+        },
+        readPage: async request => {
+            pageReads += 1;
+            return page(
+                request.sessionId,
+                request.anchorInteractionId,
+                `visible-${pageReads}`,
+                { sourceRevision: request.expectedRevision }
+            );
+        },
+    });
+
+    await viewer.open(target('session-a', 'input-1', {
+        expectedRevision: 'stable-r1',
+    }));
+    onChange();
+    await new Promise(resolve => setImmediate(resolve));
+
+    assert.equal(outlineReads, 2);
+    assert.equal(pageReads, 1);
+    assert.equal(panel.postedMessages.filter(message =>
+        message.type === 'conversation-viewer-page').length, 0);
+    assert.equal(panel.webview.html.includes('visible-1'), true);
 });
 
 test('CONVERSATION-VIEWER-LOADING-001 coalesces watched invalidations without starving the initial publication', async t => {
@@ -929,9 +970,9 @@ test('CONVERSATION-VIEWER-AUTHORITY-005 keeps a failed watch rebuild suspended a
     publication = panel.postedMessages.filter(message =>
         message.type === 'conversation-viewer-page').at(-1);
     assert.equal(outlineReads, readsBeforeFailedResume.outline + 2);
-    assert.equal(pageReads, readsBeforeFailedResume.page + 2);
+    assert.equal(pageReads, readsBeforeFailedResume.page + 1);
     assert.equal(publication.stale, false);
-    assert.equal(publication.html.includes('visible-3'), true);
+    assert.equal(publication.html.includes('visible-2'), true);
 });
 
 test('CONVERSATION-VIEWER-AUTHORITY-004 reconciliation after panel close is an idempotent no-op', async () => {

--- a/tests/unit/aiSessions/conversationSubmission.test.js
+++ b/tests/unit/aiSessions/conversationSubmission.test.js
@@ -35,7 +35,7 @@ function activeRuntime(terminal) {
     };
 }
 
-test('CONVERSATION-COMMENTS-SUBMIT-001 writes one batch to an idle attached runtime', async () => {
+test('CONVERSATION-COMMENTS-SUBMIT-001 stages one complete batch in an idle attached runtime without submitting it', async () => {
     const writes = [];
     let resumes = 0;
     await submitConversationPrompt({
@@ -49,27 +49,34 @@ test('CONVERSATION-COMMENTS-SUBMIT-001 writes one batch to an idle attached runt
         },
     }, target, 'Batch prompt');
 
-    assert.deepEqual(writes, [{ text: 'Batch prompt', newline: true }]);
+    assert.deepEqual(writes, [{ text: 'Batch prompt', newline: false }]);
     assert.equal(resumes, 0);
 });
 
-test('CONVERSATION-COMMENTS-SUBMIT-002 resumes a stopped runtime with the prompt in its launch', async () => {
+test('CONVERSATION-COMMENTS-SUBMIT-002 resumes a stopped runtime before staging the batch without submitting it', async () => {
     const resumes = [];
+    const writes = [];
     await submitConversationPrompt({
         getWorkspaceTarget: () => workspace(),
         getRuntime: () => null,
         resume: async (...args) => {
             resumes.push(args);
-            return { status: 'started' };
+            return {
+                status: 'started',
+                runtime: activeRuntime({
+                    sendText: (text, newline) => writes.push({ text, newline }),
+                }),
+            };
         },
     }, target, 'Resume prompt');
 
     assert.deepEqual(resumes, [[
-        'project-a', 'codex', 'session-a', 'root-a', 'Resume prompt',
+        'project-a', 'codex', 'session-a', 'root-a', undefined,
     ]]);
+    assert.deepEqual(writes, [{ text: 'Resume prompt', newline: false }]);
 });
 
-test('CONVERSATION-COMMENTS-SUBMIT-003 sends after an existing detached runtime is focused', async () => {
+test('CONVERSATION-COMMENTS-SUBMIT-003 stages after an existing detached runtime is focused', async () => {
     const writes = [];
     let runtimeRead = 0;
     await submitConversationPrompt({
@@ -85,7 +92,7 @@ test('CONVERSATION-COMMENTS-SUBMIT-003 sends after an existing detached runtime 
         resume: async () => ({ status: 'focused' }),
     }, target, 'Focused prompt');
 
-    assert.deepEqual(writes, [{ text: 'Focused prompt', newline: true }]);
+    assert.deepEqual(writes, [{ text: 'Focused prompt', newline: false }]);
 });
 
 test('CONVERSATION-COMMENTS-SUBMIT-004 rejects busy and conflicting targets before dispatch', async () => {


### PR DESCRIPTION
## Summary
- skip authoritative page publication when a watched session revision is unchanged, preventing unrelated Codex session activity from refreshing a stable AI Conversation
- preserve paragraph-level reading anchors and descendant focus across real updates, and stop stale Mermaid completions from restoring obsolete scroll positions
- stage the complete numbered open-comment batch in the target session input without automatically submitting it
- update comment UI copy from Sent to Added and add regression coverage for stable refreshes, Mermaid timing, changed assistant messages, and comment staging

## Verification
- `npm run test:ci:linux`
- `npm run test-compile`
- 4 comment submission unit tests
- 45 Conversation routing/viewer integration tests
- 28 Conversation browser tests
- `npm run test:behavior-contracts`
- release package build and installed-byte verification in the active Dev Container Extension Host

## Workflow lessons
Reviewed the task-local retry and CI evidence. No skill change is justified: existing regression, PR, and local-install skills already cover failure classification, audit sequencing, and active VS Code Server identity verification.

## Release
No version bump, tag, marketplace publication, or GitHub release is included or requested.