### PR TITLE
refactor: modularize AI Conversation viewer

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -27,6 +27,8 @@ media/brand/**
 !media/webviewProjectScripts.js
 !media/webviewPromptScripts.js
 !media/webviewTodoScripts.js
+!media/conversationMermaidScripts.js
+!media/conversationReadingAnchorScripts.js
 !media/conversationViewerScripts.js
 !media/conversationViewer.css
 !media/conversationTelemetry.css

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -3604,6 +3604,33 @@
     ]
   },
   {
+    "id": "CONVERSATION-PROTOCOL-VALIDATOR-001",
+    "domain": "webview",
+    "title": "AI Conversation accepts only exact bounded version-1 viewer intents through an isolated protocol validator",
+    "priority": "P0",
+    "status": "automated",
+    "owners": [
+      "tests/unit/aiSessions/conversationViewerProtocol.test.js"
+    ],
+    "evidence": [
+      "src/aiSessions/conversation/viewerProtocol.ts",
+      "src/aiSessions/conversation/viewer.ts"
+    ]
+  },
+  {
+    "id": "CONVERSATION-REFRESH-PERFORMANCE-001",
+    "domain": "webview",
+    "title": "One hundred identical AI Conversation refreshes preserve DOM identity, focus, Mermaid Blob URLs, and event listeners without growth",
+    "priority": "P0",
+    "status": "automated",
+    "owners": [
+      "tests/browser/conversationViewer.test.js"
+    ],
+    "evidence": [
+      "src/webview/conversationViewerScripts.js"
+    ]
+  },
+  {
     "id": "CONVERSATION-OUTLINE-DELIVERY-001",
     "domain": "webview",
     "title": "Undelivered initial conversation outline results remain retryable after authoritative Dashboard replacement instead of stranding Loading",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-    "head": "e2c8e97cc289445e9506364a6e44f012c9dbf0bc",
+    "head": "b9a911e41f924864633f0e7b9c4552e1405b534c",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -974,7 +974,8 @@
                 "d1c8ac78fb80482b5752764a871d7c9917d597df",
                 "731a2b5e6edc5e1679a85040b15ea2ddb24f703a",
         "2083ec487f4e3bd894614cb2bac3053e9c020636",
-        "e2c8e97cc289445e9506364a6e44f012c9dbf0bc"
+        "e2c8e97cc289445e9506364a6e44f012c9dbf0bc",
+        "b9a911e41f924864633f0e7b9c4552e1405b534c"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "2083ec487f4e3bd894614cb2bac3053e9c020636",
+    "head": "e2c8e97cc289445e9506364a6e44f012c9dbf0bc",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -973,7 +973,8 @@
                 "805e4c404de5931b99e8e9280b67bdf62004a910",
                 "d1c8ac78fb80482b5752764a871d7c9917d597df",
                 "731a2b5e6edc5e1679a85040b15ea2ddb24f703a",
-                "2083ec487f4e3bd894614cb2bac3053e9c020636"
+        "2083ec487f4e3bd894614cb2bac3053e9c020636",
+        "e2c8e97cc289445e9506364a6e44f012c9dbf0bc"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "731a2b5e6edc5e1679a85040b15ea2ddb24f703a",
+        "head": "2083ec487f4e3bd894614cb2bac3053e9c020636",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -972,7 +972,8 @@
                 "ac95c7ba1ca733cf568a883ad2679da21c04fac2",
                 "805e4c404de5931b99e8e9280b67bdf62004a910",
                 "d1c8ac78fb80482b5752764a871d7c9917d597df",
-                "731a2b5e6edc5e1679a85040b15ea2ddb24f703a"
+                "731a2b5e6edc5e1679a85040b15ea2ddb24f703a",
+                "2083ec487f4e3bd894614cb2bac3053e9c020636"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",
@@ -983,6 +984,8 @@
                 "ACTIVE-SESSION-CONVERSATION-RESTORE-001",
                 "SESSION-CONVERSATION-LOADING-001",
                 "CONVERSATION-VIEWER-LOADING-001",
+                "CONVERSATION-PROTOCOL-VALIDATOR-001",
+                "CONVERSATION-REFRESH-PERFORMANCE-001",
                 "CONVERSATION-OUTLINE-DELIVERY-001",
                 "CONVERSATION-VIEWER-USER-EMPHASIS-001",
                 "CONVERSATION-COMMENTS-001",

--- a/media/conversationMermaidScripts.js
+++ b/media/conversationMermaidScripts.js
@@ -1,0 +1,339 @@
+(function () {
+    'use strict';
+
+    function create(options) {
+        var objectUrls = [];
+        var sources = new WeakMap();
+        var initialized = false;
+        var loadPromise = null;
+
+        function release(root) {
+            var urls = root
+                ? Array.prototype.map.call(
+                    root.querySelectorAll(
+                        '.conversation-mermaid-image[src^="blob:"]'
+                    ),
+                    function (image) {
+                        return image.src;
+                    }
+                )
+                : objectUrls.slice();
+            var released = new Set(urls);
+            urls.forEach(function (url) {
+                try {
+                    URL.revokeObjectURL(url);
+                } catch (_error) {
+                    // Revocation is best-effort during document teardown.
+                }
+            });
+            objectUrls = objectUrls.filter(function (url) {
+                return !released.has(url);
+            });
+        }
+
+        function themeValue(name, fallback) {
+            var value = window.getComputedStyle(document.body)
+                .getPropertyValue(name)
+                .trim();
+            return value || fallback;
+        }
+
+        function initialize() {
+            if (initialized) return true;
+            if (!window.mermaid
+                || typeof window.mermaid.initialize !== 'function') {
+                return false;
+            }
+            try {
+                window.mermaid.initialize({
+                    startOnLoad: false,
+                    securityLevel: 'strict',
+                    suppressErrorRendering: true,
+                    maxTextSize: 50000,
+                    htmlLabels: false,
+                    theme: 'base',
+                    fontFamily: themeValue(
+                        '--vscode-font-family',
+                        'system-ui, sans-serif'
+                    ),
+                    flowchart: {
+                        htmlLabels: false,
+                    },
+                    themeVariables: {
+                        darkMode: document.body.classList.contains(
+                            'vscode-dark'
+                        ) || document.body.classList.contains(
+                            'vscode-high-contrast'
+                        ),
+                        background: themeValue(
+                            '--vscode-editor-background',
+                            '#1e1e1e'
+                        ),
+                        primaryColor: themeValue(
+                            '--vscode-textCodeBlock-background',
+                            '#252526'
+                        ),
+                        primaryTextColor: themeValue(
+                            '--vscode-editor-foreground',
+                            '#d4d4d4'
+                        ),
+                        primaryBorderColor: themeValue(
+                            '--vscode-panel-border',
+                            '#454545'
+                        ),
+                        lineColor: themeValue(
+                            '--vscode-descriptionForeground',
+                            '#a0a0a0'
+                        ),
+                        secondaryColor: themeValue(
+                            '--vscode-input-background',
+                            '#252526'
+                        ),
+                        tertiaryColor: themeValue(
+                            '--vscode-editor-background',
+                            '#1e1e1e'
+                        ),
+                    },
+                });
+                initialized = true;
+                return true;
+            } catch (_error) {
+                return false;
+            }
+        }
+
+        function load() {
+            if (window.mermaid) {
+                return Promise.resolve(initialize());
+            }
+            if (loadPromise) return loadPromise;
+            if (!options.source) return Promise.resolve(false);
+            loadPromise = new Promise(function (resolve) {
+                var script = document.createElement('script');
+                script.src = options.source;
+                if (options.nonce) script.nonce = options.nonce;
+                script.addEventListener('load', function () {
+                    resolve(initialize());
+                }, { once: true });
+                script.addEventListener('error', function () {
+                    resolve(false);
+                }, { once: true });
+                document.head.appendChild(script);
+            });
+            return loadPromise;
+        }
+
+        function alt(source) {
+            var summary = source.split(/\r?\n/).map(function (line) {
+                return line.trim();
+            }).find(function (line) {
+                return line.length > 0;
+            }) || 'diagram';
+            return 'Mermaid diagram: ' + summary.slice(0, 120);
+        }
+
+        function normalizeSvg(svg) {
+            var clean = window.DOMPurify.sanitize(svg, {
+                USE_PROFILES: {
+                    svg: true,
+                    svgFilters: true,
+                },
+                FORBID_TAGS: ['foreignObject', 'script'],
+                ALLOW_DATA_ATTR: false,
+            });
+            var documentValue = new DOMParser().parseFromString(
+                clean,
+                'image/svg+xml'
+            );
+            var root = documentValue.documentElement;
+            if (!root
+                || root.localName !== 'svg'
+                || documentValue.querySelector('parsererror')) {
+                throw new Error('Mermaid returned invalid SVG.');
+            }
+            var viewBox = (root.getAttribute('viewBox') || '')
+                .trim()
+                .split(/[\s,]+/)
+                .map(Number);
+            var width;
+            var height;
+            if (viewBox.length === 4
+                && viewBox.every(Number.isFinite)
+                && viewBox[2] > 0
+                && viewBox[3] > 0) {
+                var scale = Math.min(
+                    1,
+                    4096 / viewBox[2],
+                    4096 / viewBox[3]
+                );
+                width = Math.max(1, Math.round(viewBox[2] * scale));
+                height = Math.max(1, Math.round(viewBox[3] * scale));
+                root.setAttribute('width', String(width));
+                root.setAttribute('height', String(height));
+            }
+            return {
+                svg: new XMLSerializer().serializeToString(root),
+                width: width,
+                height: height,
+            };
+        }
+
+        function renderDiagram(pre, source, id) {
+            pre.setAttribute('aria-busy', 'true');
+            return Promise.resolve(window.mermaid.render(id, source))
+                .then(function (result) {
+                    if (!pre.isConnected) return;
+                    var normalized = normalizeSvg(result.svg);
+                    var objectUrl = URL.createObjectURL(new Blob([
+                        normalized.svg,
+                    ], { type: 'image/svg+xml' }));
+                    if (!pre.isConnected) {
+                        URL.revokeObjectURL(objectUrl);
+                        return;
+                    }
+                    var figure = document.createElement('figure');
+                    figure.className = 'conversation-mermaid';
+                    sources.set(figure, source);
+                    var image = document.createElement('img');
+                    image.className = 'conversation-mermaid-image';
+                    if (normalized.width && normalized.height) {
+                        image.width = normalized.width;
+                        image.height = normalized.height;
+                    }
+                    image.src = objectUrl;
+                    image.alt = alt(source);
+                    image.decoding = 'async';
+                    figure.appendChild(image);
+                    var decoded = typeof image.decode === 'function'
+                        ? image.decode().catch(function () {})
+                        : Promise.resolve();
+                    return decoded.then(function () {
+                        if (!pre.isConnected) {
+                            URL.revokeObjectURL(objectUrl);
+                            return;
+                        }
+                        objectUrls.push(objectUrl);
+                        var readingAnchor = options.captureAnchor(pre);
+                        var previousScrollTop = options.scroll.scrollTop;
+                        pre.replaceWith(figure);
+                        if (readingAnchor
+                            && readingAnchor.element === pre) {
+                            readingAnchor.element = figure;
+                        }
+                        options.restoreAnchor(
+                            readingAnchor,
+                            previousScrollTop
+                        );
+                    });
+                })
+                .catch(function () {
+                    if (!pre.isConnected) return;
+                    pre.removeAttribute('aria-busy');
+                    pre.classList.add('conversation-mermaid-error');
+                    var label = document.createElement('span');
+                    label.className = 'conversation-mermaid-error-label';
+                    label.setAttribute('role', 'status');
+                    label.textContent =
+                        'Mermaid diagram could not be rendered.';
+                    var readingAnchor = options.captureAnchor();
+                    var previousScrollTop = options.scroll.scrollTop;
+                    pre.parentNode.insertBefore(label, pre);
+                    options.restoreAnchor(readingAnchor, previousScrollTop);
+                    var temporary = document.getElementById(id);
+                    if (temporary) temporary.remove();
+                });
+        }
+
+        function render(generation) {
+            var codeBlocks = Array.prototype.slice.call(
+                options.messages.querySelectorAll(
+                    'pre > code.language-mermaid'
+                ),
+                0,
+                options.maxDiagrams
+            ).filter(function (code) {
+                return code.parentElement
+                    && code.parentElement.getAttribute('aria-busy') !== 'true';
+            });
+            if (!codeBlocks.length) return Promise.resolve();
+            codeBlocks.forEach(function (code) {
+                code.parentElement.setAttribute('aria-busy', 'true');
+            });
+            return load().then(function (available) {
+                if (!available) {
+                    codeBlocks.forEach(function (code) {
+                        if (code.parentElement) {
+                            code.parentElement.removeAttribute('aria-busy');
+                        }
+                    });
+                    return;
+                }
+                return codeBlocks.reduce(function (promise, code, index) {
+                    return promise.then(function () {
+                        if (!code.parentElement
+                            || !code.parentElement.isConnected) {
+                            return undefined;
+                        }
+                        return renderDiagram(
+                            code.parentElement,
+                            code.textContent || '',
+                            'conversation-mermaid-'
+                                + generation + '-' + index
+                        );
+                    });
+                }, Promise.resolve());
+            });
+        }
+
+        function preserve(oldMessage, candidate) {
+            var figuresBySource = new Map();
+            var pendingBySource = new Map();
+            Array.prototype.forEach.call(
+                oldMessage.querySelectorAll('.conversation-mermaid'),
+                function (figure) {
+                    var source = sources.get(figure);
+                    if (typeof source !== 'string') return;
+                    var figures = figuresBySource.get(source) || [];
+                    figures.push(figure);
+                    figuresBySource.set(source, figures);
+                }
+            );
+            Array.prototype.forEach.call(
+                oldMessage.querySelectorAll(
+                    'pre[aria-busy="true"] > code.language-mermaid'
+                ),
+                function (code) {
+                    var source = code.textContent || '';
+                    var blocks = pendingBySource.get(source) || [];
+                    blocks.push(code.parentElement);
+                    pendingBySource.set(source, blocks);
+                }
+            );
+            Array.prototype.forEach.call(
+                candidate.querySelectorAll('pre > code.language-mermaid'),
+                function (code) {
+                    var source = code.textContent || '';
+                    var figures = figuresBySource.get(source);
+                    var figure = figures && figures.shift();
+                    if (figure && code.parentElement) {
+                        code.parentElement.replaceWith(figure);
+                        return;
+                    }
+                    var blocks = pendingBySource.get(source);
+                    var block = blocks && blocks.shift();
+                    if (block && code.parentElement) {
+                        code.parentElement.replaceWith(block);
+                    }
+                }
+            );
+        }
+
+        return Object.freeze({
+            preserve: preserve,
+            release: release,
+            render: render,
+        });
+    }
+
+    window.__agentPivotConversationMermaid = Object.freeze({ create: create });
+})();

--- a/media/conversationReadingAnchorScripts.js
+++ b/media/conversationReadingAnchorScripts.js
@@ -1,0 +1,136 @@
+(function () {
+    'use strict';
+
+    function create(options) {
+        var scroll = options.scroll;
+        var messages = options.messages;
+        var messageSelector = options.messageSelector;
+        var messageId = options.messageId;
+
+        function capture(replacingElement) {
+            var scrollBounds = scroll.getBoundingClientRect();
+            var blockCandidates = messages.querySelectorAll(
+                '.conversation-markdown > *'
+            );
+            var crossingBlock = null;
+            for (var blockIndex = 0;
+                blockIndex < blockCandidates.length;
+                blockIndex += 1) {
+                var blockBounds = blockCandidates[blockIndex]
+                    .getBoundingClientRect();
+                if (!crossingBlock
+                    && blockBounds.bottom > scrollBounds.top
+                    && blockBounds.top < scrollBounds.bottom) {
+                    crossingBlock = blockCandidates[blockIndex];
+                }
+                if (blockCandidates[blockIndex] !== replacingElement
+                    && blockBounds.top >= scrollBounds.top
+                    && blockBounds.top < scrollBounds.bottom) {
+                    var message = blockCandidates[blockIndex].closest(
+                        messageSelector()
+                    );
+                    return {
+                        element: blockCandidates[blockIndex],
+                        messageId: message ? messageId(message) : null,
+                        blockIndex: message
+                            ? Array.prototype.indexOf.call(
+                                message.querySelectorAll(
+                                    '.conversation-markdown > *'
+                                ),
+                                blockCandidates[blockIndex]
+                            )
+                            : -1,
+                        top: blockBounds.top - scrollBounds.top,
+                        viewportTop: blockBounds.top,
+                    };
+                }
+            }
+            if (crossingBlock) {
+                var crossingMessage = crossingBlock.closest(
+                    messageSelector()
+                );
+                var crossingBounds = crossingBlock.getBoundingClientRect();
+                return {
+                    element: crossingBlock,
+                    messageId: crossingMessage
+                        ? messageId(crossingMessage)
+                        : null,
+                    blockIndex: crossingMessage
+                        ? Array.prototype.indexOf.call(
+                            crossingMessage.querySelectorAll(
+                                '.conversation-markdown > *'
+                            ),
+                            crossingBlock
+                        )
+                        : -1,
+                    top: crossingBounds.top - scrollBounds.top,
+                    viewportTop: crossingBounds.top,
+                };
+            }
+            var messageCandidates = messages.querySelectorAll(
+                messageSelector()
+            );
+            for (var index = 0; index < messageCandidates.length; index += 1) {
+                var bounds = messageCandidates[index].getBoundingClientRect();
+                if (bounds.bottom > scrollBounds.top) {
+                    return {
+                        element: messageCandidates[index],
+                        messageId: messageId(messageCandidates[index]),
+                        top: bounds.top - scrollBounds.top,
+                        viewportTop: bounds.top,
+                    };
+                }
+            }
+            return null;
+        }
+
+        function findElement(anchor) {
+            if (!anchor) return null;
+            if (anchor.element && anchor.element.isConnected) {
+                return anchor.element;
+            }
+            var message = Array.prototype.find.call(
+                messages.querySelectorAll(messageSelector()),
+                function (candidate) {
+                    return messageId(candidate) === anchor.messageId;
+                }
+            );
+            if (!message) return null;
+            if (Number.isSafeInteger(anchor.blockIndex)
+                && anchor.blockIndex >= 0) {
+                return message.querySelectorAll(
+                    '.conversation-markdown > *'
+                )[anchor.blockIndex] || message;
+            }
+            return message;
+        }
+
+        function restore(anchor, fallbackScrollTop) {
+            scroll.scrollTop = fallbackScrollTop;
+            var candidate = findElement(anchor);
+            if (!candidate) return;
+            var scrollBounds = scroll.getBoundingClientRect();
+            var currentTop = candidate.getBoundingClientRect().top
+                - scrollBounds.top;
+            scroll.scrollTop += currentTop - anchor.top;
+        }
+
+        function restoreViewport(anchor, fallbackScrollTop) {
+            scroll.scrollTop = fallbackScrollTop;
+            var candidate = findElement(anchor);
+            if (!candidate || typeof anchor.viewportTop !== 'number') return;
+            scroll.scrollTop += candidate.getBoundingClientRect().top
+                - anchor.viewportTop;
+        }
+
+        return Object.freeze({
+            capture: capture,
+            restore: restore,
+            restoreViewport: restoreViewport,
+        });
+    }
+
+    window.__agentPivotConversationReadingAnchor = Object.freeze({
+        create: create,
+    });
+})();

--- a/media/conversationViewerScripts.js
+++ b/media/conversationViewerScripts.js
@@ -121,10 +121,6 @@
         messageIds: [],
         messageSignatures: new Map(),
         firstNewMessageId: null,
-        mermaidInitialized: false,
-        mermaidObjectUrls: [],
-        mermaidSources: new WeakMap(),
-        mermaidLoad: null,
         renderGeneration: 0,
         comments: [],
         commentRevision: 0,
@@ -148,6 +144,29 @@
         pendingBookmarkRequest: null,
         bookmarksOnly: false,
     };
+    var readingAnchorController =
+        window.__agentPivotConversationReadingAnchor.create({
+            scroll: scroll,
+            messages: messages,
+            messageSelector: conversationMessageSelector,
+            messageId: conversationMessageId,
+        });
+    var captureReadingAnchor = readingAnchorController.capture;
+    var restoreReadingPosition = readingAnchorController.restore;
+    var restoreViewportReadingPosition =
+        readingAnchorController.restoreViewport;
+    var mermaidRenderer = window.__agentPivotConversationMermaid.create({
+        source: mermaidSource,
+        nonce: scriptNonce,
+        messages: messages,
+        scroll: scroll,
+        maxDiagrams: maxMermaidDiagrams,
+        captureAnchor: captureReadingAnchor,
+        restoreAnchor: restoreReadingPosition,
+    });
+    var releaseMermaidObjectUrls = mermaidRenderer.release;
+    var renderMermaidDiagrams = mermaidRenderer.render;
+    var preserveMermaidContent = mermaidRenderer.preserve;
 
     if (!scroll || !messages || !position || !status || !newResponse
         || !previous || !next || !latest || !close || !window.DOMPurify) {
@@ -314,280 +333,6 @@
             node.removeAttribute('src');
         }
     });
-
-    function releaseMermaidObjectUrls(root) {
-        var urls = root
-            ? Array.prototype.map.call(
-                root.querySelectorAll('.conversation-mermaid-image[src^="blob:"]'),
-                function (image) {
-                    return image.src;
-                }
-            )
-            : state.mermaidObjectUrls.slice();
-        var released = new Set(urls);
-        urls.forEach(function (url) {
-            try {
-                URL.revokeObjectURL(url);
-            } catch (_error) {
-                // Revocation is best-effort during document teardown.
-            }
-        });
-        state.mermaidObjectUrls = state.mermaidObjectUrls.filter(
-            function (url) {
-                return !released.has(url);
-            }
-        );
-    }
-
-    function themeValue(name, fallback) {
-        var value = window.getComputedStyle(document.body)
-            .getPropertyValue(name)
-            .trim();
-        return value || fallback;
-    }
-
-    function initializeMermaid() {
-        if (state.mermaidInitialized) return true;
-        if (!window.mermaid
-            || typeof window.mermaid.initialize !== 'function') {
-            return false;
-        }
-        try {
-            window.mermaid.initialize({
-                startOnLoad: false,
-                securityLevel: 'strict',
-                suppressErrorRendering: true,
-                maxTextSize: 50000,
-                htmlLabels: false,
-                theme: 'base',
-                fontFamily: themeValue(
-                    '--vscode-font-family',
-                    'system-ui, sans-serif'
-                ),
-                flowchart: {
-                    htmlLabels: false,
-                },
-                themeVariables: {
-                    darkMode: document.body.classList.contains('vscode-dark')
-                        || document.body.classList.contains(
-                            'vscode-high-contrast'
-                        ),
-                    background: themeValue(
-                        '--vscode-editor-background',
-                        '#1e1e1e'
-                    ),
-                    primaryColor: themeValue(
-                        '--vscode-textCodeBlock-background',
-                        '#252526'
-                    ),
-                    primaryTextColor: themeValue(
-                        '--vscode-editor-foreground',
-                        '#d4d4d4'
-                    ),
-                    primaryBorderColor: themeValue(
-                        '--vscode-panel-border',
-                        '#454545'
-                    ),
-                    lineColor: themeValue(
-                        '--vscode-descriptionForeground',
-                        '#a0a0a0'
-                    ),
-                    secondaryColor: themeValue(
-                        '--vscode-input-background',
-                        '#252526'
-                    ),
-                    tertiaryColor: themeValue(
-                        '--vscode-editor-background',
-                        '#1e1e1e'
-                    ),
-                },
-            });
-            state.mermaidInitialized = true;
-            return true;
-        } catch (_error) {
-            return false;
-        }
-    }
-
-    function loadMermaid() {
-        if (window.mermaid) {
-            return Promise.resolve(initializeMermaid());
-        }
-        if (state.mermaidLoad) return state.mermaidLoad;
-        if (!mermaidSource) return Promise.resolve(false);
-        state.mermaidLoad = new Promise(function (resolve) {
-            var script = document.createElement('script');
-            script.src = mermaidSource;
-            if (scriptNonce) script.nonce = scriptNonce;
-            script.addEventListener('load', function () {
-                resolve(initializeMermaid());
-            }, { once: true });
-            script.addEventListener('error', function () {
-                resolve(false);
-            }, { once: true });
-            document.head.appendChild(script);
-        });
-        return state.mermaidLoad;
-    }
-
-    function mermaidAlt(source) {
-        var summary = source.split(/\r?\n/).map(function (line) {
-            return line.trim();
-        }).find(function (line) {
-            return line.length > 0;
-        }) || 'diagram';
-        return 'Mermaid diagram: ' + summary.slice(0, 120);
-    }
-
-    function normalizeSvg(svg) {
-        var clean = window.DOMPurify.sanitize(svg, {
-            USE_PROFILES: {
-                svg: true,
-                svgFilters: true,
-            },
-            FORBID_TAGS: ['foreignObject', 'script'],
-            ALLOW_DATA_ATTR: false,
-        });
-        var documentValue = new DOMParser().parseFromString(
-            clean,
-            'image/svg+xml'
-        );
-        var root = documentValue.documentElement;
-        if (!root
-            || root.localName !== 'svg'
-            || documentValue.querySelector('parsererror')) {
-            throw new Error('Mermaid returned invalid SVG.');
-        }
-        var viewBox = (root.getAttribute('viewBox') || '')
-            .trim()
-            .split(/[\s,]+/)
-            .map(Number);
-        var width;
-        var height;
-        if (viewBox.length === 4
-            && viewBox.every(Number.isFinite)
-            && viewBox[2] > 0
-            && viewBox[3] > 0) {
-            var scale = Math.min(
-                1,
-                4096 / viewBox[2],
-                4096 / viewBox[3]
-            );
-            width = Math.max(1, Math.round(viewBox[2] * scale));
-            height = Math.max(1, Math.round(viewBox[3] * scale));
-            root.setAttribute('width', String(width));
-            root.setAttribute('height', String(height));
-        }
-        return {
-            svg: new XMLSerializer().serializeToString(root),
-            width: width,
-            height: height,
-        };
-    }
-
-    function renderMermaidDiagram(pre, source, id) {
-        pre.setAttribute('aria-busy', 'true');
-        return Promise.resolve(window.mermaid.render(id, source))
-            .then(function (result) {
-                if (!pre.isConnected) {
-                    return;
-                }
-                var normalized = normalizeSvg(result.svg);
-                var objectUrl = URL.createObjectURL(new Blob([normalized.svg], {
-                    type: 'image/svg+xml',
-                }));
-                if (!pre.isConnected) {
-                    URL.revokeObjectURL(objectUrl);
-                    return;
-                }
-                var figure = document.createElement('figure');
-                figure.className = 'conversation-mermaid';
-                state.mermaidSources.set(figure, source);
-                var image = document.createElement('img');
-                image.className = 'conversation-mermaid-image';
-                if (normalized.width && normalized.height) {
-                    image.width = normalized.width;
-                    image.height = normalized.height;
-                }
-                image.src = objectUrl;
-                image.alt = mermaidAlt(source);
-                image.decoding = 'async';
-                figure.appendChild(image);
-                var decoded = typeof image.decode === 'function'
-                    ? image.decode().catch(function () {})
-                    : Promise.resolve();
-                return decoded.then(function () {
-                    if (!pre.isConnected) {
-                        URL.revokeObjectURL(objectUrl);
-                        return;
-                    }
-                    state.mermaidObjectUrls.push(objectUrl);
-                    var readingAnchor = captureReadingAnchor(pre);
-                    var previousScrollTop = scroll.scrollTop;
-                    pre.replaceWith(figure);
-                    if (readingAnchor
-                        && readingAnchor.element === pre) {
-                        readingAnchor.element = figure;
-                    }
-                    restoreReadingPosition(readingAnchor, previousScrollTop);
-                });
-            })
-            .catch(function () {
-                if (!pre.isConnected) {
-                    return;
-                }
-                pre.removeAttribute('aria-busy');
-                pre.classList.add('conversation-mermaid-error');
-                var label = document.createElement('span');
-                label.className = 'conversation-mermaid-error-label';
-                label.setAttribute('role', 'status');
-                label.textContent = 'Mermaid diagram could not be rendered.';
-                var readingAnchor = captureReadingAnchor();
-                var previousScrollTop = scroll.scrollTop;
-                pre.parentNode.insertBefore(label, pre);
-                restoreReadingPosition(readingAnchor, previousScrollTop);
-                var temporary = document.getElementById(id);
-                if (temporary) temporary.remove();
-            });
-    }
-
-    function renderMermaidDiagrams(generation) {
-        var codeBlocks = Array.prototype.slice.call(
-            messages.querySelectorAll('pre > code.language-mermaid'),
-            0,
-            maxMermaidDiagrams
-        ).filter(function (code) {
-            return code.parentElement
-                && code.parentElement.getAttribute('aria-busy') !== 'true';
-        });
-        if (!codeBlocks.length) return Promise.resolve();
-        codeBlocks.forEach(function (code) {
-            code.parentElement.setAttribute('aria-busy', 'true');
-        });
-        return loadMermaid().then(function (available) {
-            if (!available) {
-                codeBlocks.forEach(function (code) {
-                    if (code.parentElement) {
-                        code.parentElement.removeAttribute('aria-busy');
-                    }
-                });
-                return;
-            }
-            return codeBlocks.reduce(function (promise, code, index) {
-                return promise.then(function () {
-                    if (!code.parentElement
-                        || !code.parentElement.isConnected) {
-                        return undefined;
-                    }
-                    return renderMermaidDiagram(
-                        code.parentElement,
-                        code.textContent || '',
-                        'conversation-mermaid-' + generation + '-' + index
-                    );
-                });
-            }, Promise.resolve());
-        });
-    }
 
     function codeIndentColumns(whitespace) {
         var columns = 0;
@@ -1888,49 +1633,6 @@
         return true;
     }
 
-    function preserveMermaidContent(oldMessage, candidate) {
-        var figuresBySource = new Map();
-        var pendingBySource = new Map();
-        Array.prototype.forEach.call(
-            oldMessage.querySelectorAll('.conversation-mermaid'),
-            function (figure) {
-                var source = state.mermaidSources.get(figure);
-                if (typeof source !== 'string') return;
-                var figures = figuresBySource.get(source) || [];
-                figures.push(figure);
-                figuresBySource.set(source, figures);
-            }
-        );
-        Array.prototype.forEach.call(
-            oldMessage.querySelectorAll(
-                'pre[aria-busy="true"] > code.language-mermaid'
-            ),
-            function (code) {
-                var source = code.textContent || '';
-                var blocks = pendingBySource.get(source) || [];
-                blocks.push(code.parentElement);
-                pendingBySource.set(source, blocks);
-            }
-        );
-        Array.prototype.forEach.call(
-            candidate.querySelectorAll('pre > code.language-mermaid'),
-            function (code) {
-                var source = code.textContent || '';
-                var figures = figuresBySource.get(source);
-                var figure = figures && figures.shift();
-                if (figure && code.parentElement) {
-                    code.parentElement.replaceWith(figure);
-                    return;
-                }
-                var blocks = pendingBySource.get(source);
-                var block = blocks && blocks.shift();
-                if (block && code.parentElement) {
-                    code.parentElement.replaceWith(block);
-                }
-            }
-        );
-    }
-
     function reconcileMessages(clean, preserveUnchanged, previousSignatures) {
         var template = document.createElement('template');
         template.innerHTML = clean;
@@ -1989,126 +1691,6 @@
         });
         messages.replaceChildren(template.content);
         return { ids: nextIds, signatures: nextSignatures };
-    }
-
-    function captureReadingAnchor(replacingElement) {
-        var scrollBounds = scroll.getBoundingClientRect();
-        var blockCandidates = messages.querySelectorAll(
-            '.conversation-markdown > *'
-        );
-        var crossingBlock = null;
-        for (var blockIndex = 0;
-            blockIndex < blockCandidates.length;
-            blockIndex += 1) {
-            var blockBounds = blockCandidates[blockIndex]
-                .getBoundingClientRect();
-            if (!crossingBlock
-                && blockBounds.bottom > scrollBounds.top
-                && blockBounds.top < scrollBounds.bottom) {
-                crossingBlock = blockCandidates[blockIndex];
-            }
-            if (blockCandidates[blockIndex] !== replacingElement
-                && blockBounds.top >= scrollBounds.top
-                && blockBounds.top < scrollBounds.bottom) {
-                var message = blockCandidates[blockIndex].closest(
-                    conversationMessageSelector()
-                );
-                return {
-                    element: blockCandidates[blockIndex],
-                    messageId: message
-                        ? conversationMessageId(message)
-                        : null,
-                    blockIndex: message
-                        ? Array.prototype.indexOf.call(
-                            message.querySelectorAll(
-                                '.conversation-markdown > *'
-                            ),
-                            blockCandidates[blockIndex]
-                        )
-                        : -1,
-                    top: blockBounds.top - scrollBounds.top,
-                    viewportTop: blockBounds.top,
-                };
-            }
-        }
-        if (crossingBlock) {
-            var crossingMessage = crossingBlock.closest(
-                conversationMessageSelector()
-            );
-            var crossingBounds = crossingBlock.getBoundingClientRect();
-            return {
-                element: crossingBlock,
-                messageId: crossingMessage
-                    ? conversationMessageId(crossingMessage)
-                    : null,
-                blockIndex: crossingMessage
-                    ? Array.prototype.indexOf.call(
-                        crossingMessage.querySelectorAll(
-                            '.conversation-markdown > *'
-                        ),
-                        crossingBlock
-                    )
-                    : -1,
-                top: crossingBounds.top - scrollBounds.top,
-                viewportTop: crossingBounds.top,
-            };
-        }
-        var messageCandidates = messages.querySelectorAll(
-            conversationMessageSelector()
-        );
-        for (var index = 0; index < messageCandidates.length; index += 1) {
-            var bounds = messageCandidates[index].getBoundingClientRect();
-            if (bounds.bottom > scrollBounds.top) {
-                return {
-                    element: messageCandidates[index],
-                    messageId: conversationMessageId(
-                        messageCandidates[index]
-                    ),
-                    top: bounds.top - scrollBounds.top,
-                    viewportTop: bounds.top,
-                };
-            }
-        }
-        return null;
-    }
-
-    function readingAnchorElement(anchor) {
-        if (!anchor) return null;
-        if (anchor.element && anchor.element.isConnected) {
-            return anchor.element;
-        }
-        var message = Array.prototype.find.call(
-            messages.querySelectorAll(conversationMessageSelector()),
-            function (candidate) {
-                return conversationMessageId(candidate) === anchor.messageId;
-            }
-        );
-        if (!message) return null;
-        if (Number.isSafeInteger(anchor.blockIndex)
-            && anchor.blockIndex >= 0) {
-            return message.querySelectorAll(
-                '.conversation-markdown > *'
-            )[anchor.blockIndex] || message;
-        }
-        return message;
-    }
-
-    function restoreReadingPosition(anchor, fallbackScrollTop) {
-        scroll.scrollTop = fallbackScrollTop;
-        var candidate = readingAnchorElement(anchor);
-        if (!candidate) return;
-        var scrollBounds = scroll.getBoundingClientRect();
-        var currentTop = candidate.getBoundingClientRect().top
-            - scrollBounds.top;
-        scroll.scrollTop += currentTop - anchor.top;
-    }
-
-    function restoreViewportReadingPosition(anchor, fallbackScrollTop) {
-        scroll.scrollTop = fallbackScrollTop;
-        var candidate = readingAnchorElement(anchor);
-        if (!candidate || typeof anchor.viewportTop !== 'number') return;
-        scroll.scrollTop += candidate.getBoundingClientRect().top
-            - anchor.viewportTop;
     }
 
     function updatePosition(message) {

--- a/scripts/run-release-packaging-checks.js
+++ b/scripts/run-release-packaging-checks.js
@@ -46,6 +46,8 @@ const EXPECTED_MAIN_ENTRIES = Object.freeze([
     'extension/dist/dashboard.js',
     'extension/licenses/DOMPurify-Apache-2.0.txt',
     'extension/licenses/Mermaid-MIT.txt',
+    'extension/media/conversationMermaidScripts.js',
+    'extension/media/conversationReadingAnchorScripts.js',
     'extension/media/conversationTelemetry.css',
     'extension/media/conversationViewer.css',
     'extension/media/conversationViewerScripts.js',

--- a/src/aiSessions/conversation/bookmarkController.ts
+++ b/src/aiSessions/conversation/bookmarkController.ts
@@ -1,0 +1,263 @@
+'use strict';
+
+import * as vscode from 'vscode';
+import {
+    ConversationBookmarkSnapshot,
+    ConversationBookmarkStore,
+    isConversationBookmarkSnapshot,
+    MAX_CONVERSATION_BOOKMARKS,
+} from './bookmarkStore';
+import type { ConversationOutline } from './types';
+import type { ConversationViewerTarget } from './viewerTarget';
+import type {
+    ConversationViewerBookmarkMutationMessage,
+} from './viewerProtocol';
+
+interface ConversationViewerBookmarksResultMessage {
+    type: 'conversation-viewer-bookmarks-result';
+    version: 1;
+    requestId: string;
+    subscriptionGeneration: number;
+    projectId: string;
+    provider: ConversationViewerTarget['provider'];
+    sessionId: string;
+    operation: 'set';
+    success: boolean;
+    revision: number;
+    interactionIds: string[];
+    error?: 'invalid' | 'stale' | 'failed' | 'limit';
+}
+
+export interface ConversationBookmarkControllerOptions {
+    bookmarkStore?: ConversationBookmarkStore;
+    getTarget: () => ConversationViewerTarget | undefined;
+    getSubscriptionGeneration: () => number;
+    getPanel: () => vscode.WebviewPanel | undefined;
+    getOutline: () => ConversationOutline | undefined;
+    rebuildLatestDocument: () => void;
+}
+
+export class ConversationBookmarkController {
+    private interactionIds = new Set<string>();
+    private revision = 0;
+    private operationQueue: Promise<void> = Promise.resolve();
+    private readonly settlements =
+        new Map<string, ConversationViewerBookmarksResultMessage>();
+
+    constructor(
+        private readonly options: ConversationBookmarkControllerOptions
+    ) {}
+
+    get snapshot(): ConversationBookmarkSnapshot {
+        return {
+            revision: this.revision,
+            interactionIds: [...this.interactionIds],
+        };
+    }
+
+    reset(): void {
+        this.interactionIds.clear();
+        this.revision = 0;
+        this.settlements.clear();
+    }
+
+    enqueue(
+        request: ConversationViewerBookmarkMutationMessage
+    ): Promise<void> {
+        const operation = () => this.handleOperation(request);
+        const queued = this.operationQueue.then(operation, operation);
+        this.operationQueue = queued.catch(() => undefined);
+        return queued;
+    }
+
+    async restore(
+        target: ConversationViewerTarget,
+        generation: number
+    ): Promise<void> {
+        if (!this.options.bookmarkStore) {
+            return;
+        }
+        let snapshot: ConversationBookmarkSnapshot;
+        try {
+            snapshot = await this.options.bookmarkStore.load(
+                toBookmarkTarget(target)
+            );
+            if (!isConversationBookmarkSnapshot(snapshot)) {
+                return;
+            }
+        } catch (_error) {
+            return;
+        }
+        if (this.options.getTarget() !== target
+            || this.options.getSubscriptionGeneration() !== generation) {
+            return;
+        }
+        this.interactionIds = new Set(snapshot.interactionIds);
+        this.revision = snapshot.revision;
+    }
+
+    private async handleOperation(
+        request: ConversationViewerBookmarkMutationMessage
+    ): Promise<void> {
+        const target = this.options.getTarget();
+        if (!target || !this.options.getPanel()) {
+            return;
+        }
+        const settlementKey = getSettlementKey(request);
+        const settled = this.settlements.get(settlementKey);
+        if (settled) {
+            await this.publishSettlement(settled);
+            return;
+        }
+        if (!requestTargetsViewer(
+            request,
+            target,
+            this.options.getSubscriptionGeneration()
+        ) || request.expectedRevision !== this.revision) {
+            await this.settleRequest(request, false, 'stale');
+            return;
+        }
+        const interactionExists = this.options.getOutline()?.interactions.some(
+            interaction => interaction.id === request.payload.interactionId
+        ) === true;
+        if (!interactionExists) {
+            await this.settleRequest(request, false, 'stale');
+            return;
+        }
+        const next = new Set(this.interactionIds);
+        if (request.payload.bookmarked) {
+            next.add(request.payload.interactionId);
+        } else {
+            next.delete(request.payload.interactionId);
+        }
+        if (next.size > MAX_CONVERSATION_BOOKMARKS) {
+            await this.settleRequest(request, false, 'limit');
+            return;
+        }
+        const changed = next.size !== this.interactionIds.size
+            || [...next].some(id => !this.interactionIds.has(id));
+        const snapshot = {
+            revision: this.revision + (changed ? 1 : 0),
+            interactionIds: [...next],
+        };
+        const previousSnapshot = this.snapshot;
+        try {
+            await this.persist(target, snapshot);
+            if (this.options.getTarget() !== target
+                || this.options.getSubscriptionGeneration()
+                    !== request.subscriptionGeneration
+                || this.revision !== request.expectedRevision) {
+                await this.persist(target, previousSnapshot);
+                throw new Error('stale');
+            }
+            this.interactionIds = next;
+            this.revision = snapshot.revision;
+            await this.settleRequest(request, true);
+        } catch (error) {
+            await this.settleRequest(
+                request,
+                false,
+                error instanceof Error && error.message === 'stale'
+                    ? 'stale'
+                    : 'failed'
+            );
+        }
+    }
+
+    private async persist(
+        target: ConversationViewerTarget,
+        snapshot: ConversationBookmarkSnapshot
+    ): Promise<void> {
+        if (!this.options.bookmarkStore) {
+            return;
+        }
+        await this.options.bookmarkStore.save(
+            toBookmarkTarget(target),
+            snapshot
+        );
+    }
+
+    private async settleRequest(
+        request: ConversationViewerBookmarkMutationMessage,
+        success: boolean,
+        error?: ConversationViewerBookmarksResultMessage['error']
+    ): Promise<void> {
+        const settlement: ConversationViewerBookmarksResultMessage = {
+            type: 'conversation-viewer-bookmarks-result',
+            version: 1,
+            requestId: request.requestId,
+            subscriptionGeneration: request.subscriptionGeneration,
+            projectId: request.projectId,
+            provider: request.provider,
+            sessionId: request.sessionId,
+            operation: 'set',
+            success,
+            revision: this.revision,
+            interactionIds: [...this.interactionIds],
+            ...(error ? { error } : {}),
+        };
+        this.settlements.set(getSettlementKey(request), settlement);
+        while (this.settlements.size > 100) {
+            const oldest = this.settlements.keys().next().value;
+            if (typeof oldest !== 'string') {
+                break;
+            }
+            this.settlements.delete(oldest);
+        }
+        await this.publishSettlement(settlement);
+    }
+
+    private async publishSettlement(
+        settlement: ConversationViewerBookmarksResultMessage
+    ): Promise<void> {
+        const panel = this.options.getPanel();
+        if (!panel) {
+            return;
+        }
+        let delivered = false;
+        try {
+            delivered = await panel.webview.postMessage(settlement);
+        } catch (_error) {
+            delivered = false;
+        }
+        if (!delivered && this.options.getPanel() === panel) {
+            this.options.rebuildLatestDocument();
+        }
+    }
+}
+
+function toBookmarkTarget(
+    target: ConversationViewerTarget
+): Pick<
+    ConversationViewerTarget,
+    'projectId' | 'provider' | 'sessionId'
+> {
+    return {
+        projectId: target.projectId,
+        provider: target.provider,
+        sessionId: target.sessionId,
+    };
+}
+
+function requestTargetsViewer(
+    request: ConversationViewerBookmarkMutationMessage,
+    target: ConversationViewerTarget,
+    subscriptionGeneration: number
+): boolean {
+    return request.subscriptionGeneration === subscriptionGeneration
+        && request.projectId === target.projectId
+        && request.provider === target.provider
+        && request.sessionId === target.sessionId;
+}
+
+function getSettlementKey(
+    request: ConversationViewerBookmarkMutationMessage
+): string {
+    return [
+        request.subscriptionGeneration,
+        request.projectId,
+        request.provider,
+        request.sessionId,
+        request.requestId,
+    ].join('\u0000');
+}

--- a/src/aiSessions/conversation/commentController.ts
+++ b/src/aiSessions/conversation/commentController.ts
@@ -1,0 +1,563 @@
+'use strict';
+
+import { randomBytes } from 'crypto';
+import * as vscode from 'vscode';
+import {
+    buildConversationCommentsPrompt,
+    clearConversationComments,
+    cloneConversationComments,
+    CONVERSATION_COMMENT_LIMITS,
+    ConversationCommentDraft,
+    ConversationCommentError,
+    ConversationCommentOperation,
+    ConversationCommentSelection,
+    ConversationCommentSessionNote,
+    ConversationCommentTarget,
+    createConversationComment,
+    createConversationSessionComment,
+    markConversationCommentsSent,
+    reopenConversationComment,
+    resolveConversationComment,
+    updateConversationComment,
+    validateConversationComments,
+} from './comments';
+import type {
+    ConversationCommentSnapshot,
+    ConversationCommentStore,
+} from './commentStore';
+import type { ConversationMessage } from './types';
+import type { ConversationViewerTarget } from './viewerTarget';
+import {
+    ConversationViewerCommentMutationMessage,
+    ConversationViewerLocateCommentMessage,
+    ConversationViewerSendCommentsMessage,
+    hasExactKeys,
+    isConversationViewerTargetId,
+} from './viewerProtocol';
+
+interface ConversationViewerLocateCommentResultMessage {
+    type: 'conversation-viewer-locate-comment-result';
+    version: 1;
+    requestId: string;
+    subscriptionGeneration: number;
+    projectId: string;
+    provider: ConversationViewerTarget['provider'];
+    sessionId: string;
+    commentId: string;
+    success: boolean;
+    error?: 'stale';
+}
+
+interface ConversationViewerCommentsResultMessage {
+    type: 'conversation-viewer-comments-result';
+    version: 1;
+    requestId: string;
+    subscriptionGeneration: number;
+    projectId: string;
+    provider: ConversationViewerTarget['provider'];
+    sessionId: string;
+    operation: ConversationCommentOperation;
+    success: boolean;
+    revision: number;
+    comments: ConversationCommentDraft[];
+    error?: ConversationCommentError['code'];
+}
+
+export interface ConversationCommentControllerOptions {
+    commentStore?: ConversationCommentStore;
+    submitPrompt: (
+        target: ConversationViewerTarget,
+        prompt: string
+    ) => PromiseLike<void> | Promise<void>;
+    focusSession?: (
+        target: Pick<
+            ConversationViewerTarget,
+            'projectId' | 'provider' | 'sessionId'
+        >
+    ) => PromiseLike<void> | Promise<void>;
+    getTarget: () => ConversationViewerTarget | undefined;
+    getSubscriptionGeneration: () => number;
+    getPanel: () => vscode.WebviewPanel | undefined;
+    getMessages: () => ConversationMessage[];
+    navigateToInteraction: (interactionId: string) => Promise<boolean>;
+    rebuildLatestDocument: () => void;
+}
+
+export class ConversationCommentController {
+    private comments: ConversationCommentDraft[] = [];
+    private revision = 0;
+    private operationQueue: Promise<void> = Promise.resolve();
+    private readonly settlements =
+        new Map<string, ConversationViewerCommentsResultMessage>();
+
+    constructor(
+        private readonly options: ConversationCommentControllerOptions
+    ) {}
+
+    get snapshot(): ConversationCommentSnapshot {
+        return {
+            revision: this.revision,
+            comments: cloneConversationComments(this.comments),
+        };
+    }
+
+    reset(): void {
+        this.comments = [];
+        this.revision = 0;
+        this.settlements.clear();
+    }
+
+    enqueue(
+        request: ConversationViewerCommentMutationMessage
+            | ConversationViewerSendCommentsMessage
+    ): Promise<void> {
+        const operation = () => this.handleOperation(request);
+        const queued = this.operationQueue.then(operation, operation);
+        this.operationQueue = queued.catch(() => undefined);
+        return queued;
+    }
+
+    async restore(
+        target: ConversationViewerTarget,
+        generation: number
+    ): Promise<void> {
+        if (!this.options.commentStore) {
+            return;
+        }
+        let snapshot: ConversationCommentSnapshot;
+        try {
+            snapshot = await this.options.commentStore.load(
+                toCommentTarget(target)
+            );
+            validateConversationComments(snapshot.comments);
+            if (!Number.isSafeInteger(snapshot.revision)
+                || snapshot.revision < 0) {
+                throw new ConversationCommentError('invalid');
+            }
+        } catch (_error) {
+            return;
+        }
+        if (this.options.getTarget() !== target
+            || this.options.getSubscriptionGeneration() !== generation) {
+            return;
+        }
+        this.comments = cloneConversationComments(snapshot.comments);
+        this.revision = snapshot.revision;
+    }
+
+    async locate(
+        request: ConversationViewerLocateCommentMessage
+    ): Promise<void> {
+        const target = this.options.getTarget();
+        const comment = this.comments.find(
+            candidate => candidate.id === request.commentId
+        );
+        const targetMatches = Boolean(target)
+            && request.subscriptionGeneration
+                === this.options.getSubscriptionGeneration()
+            && request.projectId === target?.projectId
+            && request.provider === target?.provider
+            && request.sessionId === target?.sessionId;
+        const success = targetMatches && comment
+            ? await this.options.navigateToInteraction(comment.interactionId)
+            : false;
+        await this.publishSettlement({
+            type: 'conversation-viewer-locate-comment-result',
+            version: 1,
+            requestId: request.requestId,
+            subscriptionGeneration: request.subscriptionGeneration,
+            projectId: request.projectId,
+            provider: request.provider,
+            sessionId: request.sessionId,
+            commentId: request.commentId,
+            success,
+            ...(success ? {} : { error: 'stale' }),
+        }, true);
+    }
+
+    private async handleOperation(
+        request: ConversationViewerCommentMutationMessage
+            | ConversationViewerSendCommentsMessage
+    ): Promise<void> {
+        const target = this.options.getTarget();
+        if (!target || !this.options.getPanel()) {
+            return;
+        }
+        const settlementKey = getSettlementKey(request);
+        const settled = this.settlements.get(settlementKey);
+        if (settled) {
+            await this.publishSettlement(
+                settled.operation === request.operation
+                    ? settled
+                    : {
+                        ...settled,
+                        operation: request.operation,
+                        success: false,
+                        revision: this.revision,
+                        comments: cloneConversationComments(this.comments),
+                        error: 'invalid',
+                    },
+                false
+            );
+            return;
+        }
+        if (!requestTargetsViewer(
+            request,
+            target,
+            this.options.getSubscriptionGeneration()
+        ) || request.expectedRevision !== this.revision) {
+            await this.settleRequest(request, false, 'stale');
+            return;
+        }
+        try {
+            if (request.operation === 'sendComments') {
+                await this.sendComments(
+                    target,
+                    this.options.getSubscriptionGeneration()
+                );
+            } else {
+                await this.mutateComments(
+                    request,
+                    target,
+                    this.options.getSubscriptionGeneration()
+                );
+            }
+            await this.settleRequest(request, true);
+            if (request.operation === 'sendComments') {
+                await this.focusSessionAfterSend(target);
+            }
+        } catch (error) {
+            await this.settleRequest(
+                request,
+                false,
+                toCommentErrorCode(error)
+            );
+        }
+    }
+
+    private async focusSessionAfterSend(
+        target: ConversationViewerTarget
+    ): Promise<void> {
+        try {
+            await Promise.resolve(this.options.focusSession?.({
+                projectId: target.projectId,
+                provider: target.provider,
+                sessionId: target.sessionId,
+            }));
+        } catch (_error) {
+            // The prompt is already staged and settled. Focus failure must not
+            // encourage a retry that stages the same batch twice.
+        }
+    }
+
+    private async mutateComments(
+        request: ConversationViewerCommentMutationMessage,
+        target: ConversationViewerTarget,
+        generation: number
+    ): Promise<void> {
+        let comments = cloneConversationComments(this.comments);
+        let revision = this.revision;
+        if (request.operation === 'add') {
+            if (comments.length >= CONVERSATION_COMMENT_LIMITS.maxComments) {
+                throw new ConversationCommentError('limit');
+            }
+            const payload = parseCommentInput(request.payload);
+            if (payload.scope === 'session') {
+                comments.push(createConversationSessionComment(
+                    randomBytes(16).toString('hex'),
+                    payload.comment
+                ));
+            } else {
+                const message = this.options.getMessages().find(candidate =>
+                    candidate.id === payload.messageId
+                    && candidate.interactionId === payload.interactionId
+                );
+                if (!message) {
+                    throw new ConversationCommentError('stale');
+                }
+                comments.push(createConversationComment(
+                    randomBytes(16).toString('hex'),
+                    payload,
+                    message
+                ));
+            }
+            revision += 1;
+        } else if (request.operation === 'clearSent'
+            || request.operation === 'clearResolved'
+            || request.operation === 'clearAll') {
+            if (!hasExactKeys(request.payload as object, [])) {
+                throw new ConversationCommentError('invalid');
+            }
+            const remainingComments = clearConversationComments(
+                comments,
+                request.operation
+            );
+            if (remainingComments.length !== comments.length) {
+                comments = remainingComments;
+                revision += 1;
+            }
+        } else {
+            const payload = parseExistingCommentPayload(
+                request.operation,
+                request.payload
+            );
+            const index = comments.findIndex(
+                comment => comment.id === payload.commentId
+            );
+            if (index < 0) {
+                throw new ConversationCommentError('stale');
+            }
+            if (request.operation === 'delete') {
+                comments.splice(index, 1);
+            } else if (request.operation === 'update') {
+                comments[index] = updateConversationComment(
+                    comments[index],
+                    payload.comment
+                );
+            } else if (request.operation === 'resolve') {
+                comments[index] = resolveConversationComment(comments[index]);
+            } else {
+                comments[index] = reopenConversationComment(comments[index]);
+            }
+            revision += 1;
+        }
+        const snapshot = { revision, comments };
+        await this.persist(target, snapshot);
+        this.commitPersisted(
+            target,
+            generation,
+            request.expectedRevision,
+            snapshot
+        );
+    }
+
+    private async sendComments(
+        target: ConversationViewerTarget,
+        generation: number
+    ): Promise<void> {
+        const prompt = buildConversationCommentsPrompt(
+            this.comments.filter(comment => comment.status === 'open')
+        );
+        const previousSnapshot = this.snapshot;
+        const sentSnapshot = {
+            revision: this.revision + 1,
+            comments: markConversationCommentsSent(this.comments),
+        };
+        await this.persist(target, sentSnapshot);
+        if (this.options.getTarget() !== target
+            || this.options.getSubscriptionGeneration() !== generation
+            || this.revision !== previousSnapshot.revision) {
+            await this.persist(target, previousSnapshot);
+            throw new ConversationCommentError('stale');
+        }
+        try {
+            await Promise.resolve(this.options.submitPrompt(
+                { ...target },
+                prompt
+            ));
+        } catch (error) {
+            await this.persist(target, previousSnapshot);
+            if (error instanceof ConversationCommentError) {
+                throw error;
+            }
+            throw new ConversationCommentError('failed');
+        }
+        if (this.options.getTarget() !== target) {
+            throw new ConversationCommentError('stale');
+        }
+        this.comments = sentSnapshot.comments;
+        this.revision = sentSnapshot.revision;
+    }
+
+    private async persist(
+        target: ConversationViewerTarget,
+        snapshot: ConversationCommentSnapshot
+    ): Promise<void> {
+        if (!this.options.commentStore) {
+            return;
+        }
+        try {
+            await this.options.commentStore.save(
+                toCommentTarget(target),
+                snapshot
+            );
+        } catch (_error) {
+            throw new ConversationCommentError('failed');
+        }
+    }
+
+    private commitPersisted(
+        target: ConversationViewerTarget,
+        generation: number,
+        expectedRevision: number,
+        snapshot: ConversationCommentSnapshot
+    ): void {
+        if (this.options.getTarget() !== target
+            || this.options.getSubscriptionGeneration() !== generation
+            || this.revision !== expectedRevision) {
+            throw new ConversationCommentError('stale');
+        }
+        this.comments = snapshot.comments;
+        this.revision = snapshot.revision;
+    }
+
+    private async settleRequest(
+        request: ConversationViewerCommentMutationMessage
+            | ConversationViewerSendCommentsMessage,
+        success: boolean,
+        error?: ConversationCommentError['code']
+    ): Promise<void> {
+        const settlement: ConversationViewerCommentsResultMessage = {
+            type: 'conversation-viewer-comments-result',
+            version: 1,
+            requestId: request.requestId,
+            subscriptionGeneration: request.subscriptionGeneration,
+            projectId: request.projectId,
+            provider: request.provider,
+            sessionId: request.sessionId,
+            operation: request.operation,
+            success,
+            revision: this.revision,
+            comments: cloneConversationComments(this.comments),
+            ...(error ? { error } : {}),
+        };
+        this.rememberSettlement(getSettlementKey(request), settlement);
+        await this.publishSettlement(settlement, true);
+    }
+
+    private rememberSettlement(
+        key: string,
+        settlement: ConversationViewerCommentsResultMessage
+    ): void {
+        this.settlements.set(key, settlement);
+        while (this.settlements.size > 100) {
+            const oldest = this.settlements.keys().next().value;
+            if (typeof oldest !== 'string') {
+                break;
+            }
+            this.settlements.delete(oldest);
+        }
+    }
+
+    private async publishSettlement(
+        settlement: ConversationViewerCommentsResultMessage
+            | ConversationViewerLocateCommentResultMessage,
+        rebuildOnFailure: boolean
+    ): Promise<void> {
+        const panel = this.options.getPanel();
+        if (!panel) {
+            return;
+        }
+        let delivered = false;
+        try {
+            delivered = await panel.webview.postMessage(settlement);
+        } catch (_error) {
+            delivered = false;
+        }
+        if (!delivered
+            && rebuildOnFailure
+            && this.options.getPanel() === panel) {
+            this.options.rebuildLatestDocument();
+        }
+    }
+}
+
+function toCommentTarget(
+    target: ConversationViewerTarget
+): ConversationCommentTarget {
+    return {
+        projectId: target.projectId,
+        provider: target.provider,
+        sessionId: target.sessionId,
+    };
+}
+
+function requestTargetsViewer(
+    request: ConversationViewerCommentMutationMessage
+        | ConversationViewerSendCommentsMessage,
+    target: ConversationViewerTarget,
+    subscriptionGeneration: number
+): boolean {
+    return request.subscriptionGeneration === subscriptionGeneration
+        && request.projectId === target.projectId
+        && request.provider === target.provider
+        && request.sessionId === target.sessionId;
+}
+
+function getSettlementKey(
+    request: ConversationViewerCommentMutationMessage
+        | ConversationViewerSendCommentsMessage
+): string {
+    return JSON.stringify([
+        request.projectId,
+        request.provider,
+        request.sessionId,
+        request.requestId,
+    ]);
+}
+
+function parseCommentInput(
+    payload: unknown
+): ConversationCommentSelection | ConversationCommentSessionNote {
+    if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+        throw new ConversationCommentError('invalid');
+    }
+    const value = payload as Record<string, unknown>;
+    if (hasExactKeys(value, ['scope', 'comment'])) {
+        if (value.scope !== 'session' || typeof value.comment !== 'string') {
+            throw new ConversationCommentError('invalid');
+        }
+        return value as unknown as ConversationCommentSessionNote;
+    }
+    if (!hasExactKeys(value, [
+        'messageId', 'interactionId', 'quote', 'prefix', 'suffix', 'comment',
+    ]) || typeof value.messageId !== 'string'
+        || typeof value.interactionId !== 'string'
+        || typeof value.quote !== 'string'
+        || typeof value.prefix !== 'string'
+        || typeof value.suffix !== 'string'
+        || typeof value.comment !== 'string') {
+        throw new ConversationCommentError('invalid');
+    }
+    return {
+        scope: 'selection',
+        messageId: value.messageId,
+        interactionId: value.interactionId,
+        quote: value.quote,
+        prefix: value.prefix,
+        suffix: value.suffix,
+        comment: value.comment,
+    };
+}
+
+function parseExistingCommentPayload(
+    operation: 'update' | 'delete' | 'resolve' | 'reopen',
+    payload: unknown
+): { commentId: string; comment?: string } {
+    if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+        throw new ConversationCommentError('invalid');
+    }
+    const value = payload as Record<string, unknown>;
+    const expected = operation === 'update'
+        ? ['commentId', 'comment']
+        : ['commentId'];
+    if (!hasExactKeys(value, expected)
+        || !isConversationViewerTargetId(value.commentId)
+        || (operation === 'update' && typeof value.comment !== 'string')) {
+        throw new ConversationCommentError('invalid');
+    }
+    return {
+        commentId: value.commentId,
+        ...(operation === 'update'
+            ? { comment: value.comment as string }
+            : {}),
+    };
+}
+
+function toCommentErrorCode(
+    error: unknown
+): ConversationCommentError['code'] {
+    return error instanceof ConversationCommentError
+        ? error.code
+        : 'failed';
+}

--- a/src/aiSessions/conversation/viewer.ts
+++ b/src/aiSessions/conversation/viewer.ts
@@ -37,6 +37,15 @@ import {
 } from './bookmarkStore';
 import { renderConversationMarkdown } from './markdown';
 import {
+    ConversationViewerBookmarkMutationMessage,
+    ConversationViewerCommentMutationMessage,
+    ConversationViewerLocateCommentMessage,
+    ConversationViewerSendCommentsMessage,
+    hasExactKeys,
+    isConversationViewerTargetId,
+    parseConversationViewerMessage,
+} from './viewerProtocol';
+import {
     CONVERSATION_LIMITS,
     ConversationAbortController,
     ConversationAbortSignal,
@@ -145,51 +154,6 @@ interface ConversationViewerOutlineEntry {
     responseState: ConversationResponseState;
 }
 
-interface ConversationViewerNavigationMessage {
-    type: 'conversation-viewer-previous'
-        | 'conversation-viewer-next'
-        | 'conversation-viewer-latest'
-        | 'conversation-viewer-closed';
-    version: 1;
-}
-
-interface ConversationViewerSelectInteractionMessage {
-    type: 'conversation-viewer-select-interaction';
-    version: 1;
-    interactionId: string;
-}
-
-interface ConversationViewerOpenLinkMessage {
-    type: 'conversation-viewer-open-link';
-    version: 1;
-    href: string;
-}
-
-interface ConversationViewerCommentMutationMessage {
-    type: 'conversation-viewer-comment-mutation';
-    version: 1;
-    requestId: string;
-    subscriptionGeneration: number;
-    projectId: string;
-    provider: AiSessionProviderId;
-    sessionId: string;
-    operation: 'add' | 'update' | 'delete' | 'resolve' | 'reopen'
-        | 'clearSent' | 'clearResolved' | 'clearAll';
-    expectedRevision: number;
-    payload: unknown;
-}
-
-interface ConversationViewerLocateCommentMessage {
-    type: 'conversation-viewer-locate-comment';
-    version: 1;
-    requestId: string;
-    subscriptionGeneration: number;
-    projectId: string;
-    provider: AiSessionProviderId;
-    sessionId: string;
-    commentId: string;
-}
-
 interface ConversationViewerLocateCommentResultMessage {
     type: 'conversation-viewer-locate-comment-result';
     version: 1;
@@ -201,19 +165,6 @@ interface ConversationViewerLocateCommentResultMessage {
     commentId: string;
     success: boolean;
     error?: 'stale';
-}
-
-interface ConversationViewerSendCommentsMessage {
-    type: 'conversation-viewer-send-comments';
-    version: 1;
-    requestId: string;
-    subscriptionGeneration: number;
-    projectId: string;
-    provider: AiSessionProviderId;
-    sessionId: string;
-    operation: 'sendComments';
-    expectedRevision: number;
-    payload: Record<string, never>;
 }
 
 interface ConversationViewerCommentsResultMessage {
@@ -231,22 +182,6 @@ interface ConversationViewerCommentsResultMessage {
     error?: ConversationCommentError['code'];
 }
 
-interface ConversationViewerBookmarkMutationMessage {
-    type: 'conversation-viewer-bookmark-mutation';
-    version: 1;
-    requestId: string;
-    subscriptionGeneration: number;
-    projectId: string;
-    provider: AiSessionProviderId;
-    sessionId: string;
-    operation: 'set';
-    expectedRevision: number;
-    payload: {
-        interactionId: string;
-        bookmarked: boolean;
-    };
-}
-
 interface ConversationViewerBookmarksResultMessage {
     type: 'conversation-viewer-bookmarks-result';
     version: 1;
@@ -261,22 +196,6 @@ interface ConversationViewerBookmarksResultMessage {
     interactionIds: string[];
     error?: 'invalid' | 'stale' | 'failed' | 'limit';
 }
-
-type ConversationViewerMessage =
-    ConversationViewerNavigationMessage
-    | ConversationViewerSelectInteractionMessage
-    | ConversationViewerOpenLinkMessage
-    | ConversationViewerCommentMutationMessage
-    | ConversationViewerSendCommentsMessage
-    | ConversationViewerLocateCommentMessage
-    | ConversationViewerBookmarkMutationMessage;
-
-const NAVIGATION_MESSAGE_TYPES = new Set([
-    'conversation-viewer-previous',
-    'conversation-viewer-next',
-    'conversation-viewer-latest',
-    'conversation-viewer-closed',
-]);
 
 export class ConversationViewer implements ConversationViewerApi {
     private panel?: vscode.WebviewPanel;
@@ -537,7 +456,7 @@ export class ConversationViewer implements ConversationViewerApi {
     }
 
     private async handleMessage(message: unknown): Promise<void> {
-        const parsed = parseViewerMessage(message);
+        const parsed = parseConversationViewerMessage(message);
         if (!parsed || !this.target || !this.panel) {
             return;
         }
@@ -2096,158 +2015,6 @@ export class ConversationViewer implements ConversationViewerApi {
     }
 }
 
-function parseViewerMessage(message: unknown): ConversationViewerMessage | undefined {
-    if (!message || typeof message !== 'object' || Array.isArray(message)) {
-        return undefined;
-    }
-    const value = message as { [key: string]: unknown };
-    if (value.version !== 1 || typeof value.type !== 'string') {
-        return undefined;
-    }
-    const keys = Object.keys(value);
-    if (NAVIGATION_MESSAGE_TYPES.has(value.type)) {
-        if (keys.length !== 2 || !hasOwn(value, 'type') || !hasOwn(value, 'version')) {
-            return undefined;
-        }
-        return value as unknown as ConversationViewerNavigationMessage;
-    }
-    if (value.type === 'conversation-viewer-select-interaction') {
-        if (!hasExactKeys(value, ['type', 'version', 'interactionId'])
-            || !isCommentTargetId(value.interactionId)) {
-            return undefined;
-        }
-        return value as unknown as
-            ConversationViewerSelectInteractionMessage;
-    }
-    if (value.type === 'conversation-viewer-open-link') {
-        if (keys.length !== 3
-            || !hasOwn(value, 'type')
-            || !hasOwn(value, 'version')
-            || !hasOwn(value, 'href')
-            || typeof value.href !== 'string') {
-            return undefined;
-        }
-        return value as unknown as ConversationViewerOpenLinkMessage;
-    }
-    if (value.type === 'conversation-viewer-locate-comment') {
-        if (!hasExactKeys(value, [
-            'type', 'version', 'requestId', 'subscriptionGeneration',
-            'projectId', 'provider', 'sessionId', 'commentId',
-        ])
-            || !isCommentRequestId(value.requestId)
-            || !Number.isSafeInteger(value.subscriptionGeneration)
-            || (value.subscriptionGeneration as number) < 1
-            || !isCommentTargetId(value.projectId)
-            || !isProvider(value.provider)
-            || !isCommentTargetId(value.sessionId)
-            || !isCommentTargetId(value.commentId)) {
-            return undefined;
-        }
-        return value as unknown as ConversationViewerLocateCommentMessage;
-    }
-    if (value.type === 'conversation-viewer-bookmark-mutation') {
-        if (!hasExactKeys(value, [
-            'type', 'version', 'requestId', 'subscriptionGeneration',
-            'projectId', 'provider', 'sessionId', 'operation',
-            'expectedRevision', 'payload',
-        ])
-            || !isCommentRequestId(value.requestId)
-            || !Number.isSafeInteger(value.subscriptionGeneration)
-            || (value.subscriptionGeneration as number) < 1
-            || !isCommentTargetId(value.projectId)
-            || !isProvider(value.provider)
-            || !isCommentTargetId(value.sessionId)
-            || value.operation !== 'set'
-            || !Number.isSafeInteger(value.expectedRevision)
-            || (value.expectedRevision as number) < 0
-            || !isRecord(value.payload)
-            || !hasExactKeys(value.payload, [
-                'interactionId', 'bookmarked',
-            ])
-            || !isCommentTargetId(value.payload.interactionId)
-            || typeof value.payload.bookmarked !== 'boolean') {
-            return undefined;
-        }
-        return value as unknown as ConversationViewerBookmarkMutationMessage;
-    }
-    if ((value.type !== 'conversation-viewer-comment-mutation'
-            && value.type !== 'conversation-viewer-send-comments')
-        || keys.length !== 10
-        || !hasExactKeys(value, [
-            'type', 'version', 'requestId', 'subscriptionGeneration',
-            'projectId', 'provider', 'sessionId', 'operation',
-            'expectedRevision', 'payload',
-        ])
-        || !isCommentRequestId(value.requestId)
-        || !Number.isSafeInteger(value.subscriptionGeneration)
-        || (value.subscriptionGeneration as number) < 1
-        || !isCommentTargetId(value.projectId)
-        || !isProvider(value.provider)
-        || !isCommentTargetId(value.sessionId)
-        || !Number.isSafeInteger(value.expectedRevision)
-        || (value.expectedRevision as number) < 0
-        || !value.payload
-        || typeof value.payload !== 'object'
-        || Array.isArray(value.payload)) {
-        return undefined;
-    }
-    if (value.type === 'conversation-viewer-comment-mutation') {
-        if (value.operation !== 'add'
-            && value.operation !== 'update'
-            && value.operation !== 'delete'
-            && value.operation !== 'resolve'
-            && value.operation !== 'reopen'
-            && value.operation !== 'clearSent'
-            && value.operation !== 'clearResolved'
-            && value.operation !== 'clearAll') {
-            return undefined;
-        }
-        return value as unknown as ConversationViewerCommentMutationMessage;
-    }
-    if (value.operation !== 'sendComments'
-        || Object.keys(value.payload as object).length !== 0) {
-        return undefined;
-    }
-    return value as unknown as ConversationViewerSendCommentsMessage;
-}
-
-function hasOwn(value: object, key: string): boolean {
-    return Object.prototype.hasOwnProperty.call(value, key);
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-    return Boolean(value)
-        && typeof value === 'object'
-        && !Array.isArray(value);
-}
-
-function hasExactKeys(
-    value: object,
-    expected: readonly string[]
-): boolean {
-    const keys = Object.keys(value);
-    return keys.length === expected.length
-        && expected.every(key => hasOwn(value, key));
-}
-
-function isCommentRequestId(value: unknown): value is string {
-    return typeof value === 'string'
-        && value.length > 0
-        && value.length <= 128
-        && /^[A-Za-z0-9._:-]+$/.test(value);
-}
-
-function isCommentTargetId(value: unknown): value is string {
-    return typeof value === 'string'
-        && value.length > 0
-        && value.length <= CONVERSATION_COMMENT_LIMITS.maxIdLength
-        && !/[\u0000-\u001f\u007f]/.test(value);
-}
-
-function isProvider(value: unknown): value is AiSessionProviderId {
-    return value === 'codex' || value === 'kimi' || value === 'claude';
-}
-
 function toCommentTarget(
     target: ConversationViewerTarget
 ): ConversationCommentTarget {
@@ -2367,7 +2134,7 @@ function parseExistingCommentPayload(
         ? ['commentId', 'comment']
         : ['commentId'];
     if (!hasExactKeys(value, expected)
-        || !isCommentTargetId(value.commentId)
+        || !isConversationViewerTargetId(value.commentId)
         || (operation === 'update' && typeof value.comment !== 'string')) {
         throw new ConversationCommentError('invalid');
     }

--- a/src/aiSessions/conversation/viewer.ts
+++ b/src/aiSessions/conversation/viewer.ts
@@ -6,45 +6,15 @@ import * as vscode from 'vscode';
 import { AGENT_PIVOT_CONVERSATION_VIEW_TYPE } from '../../constants';
 import type { AiSessionProviderId } from '../../models';
 import type { AiSessionDisposable } from '../types';
-import {
-    buildConversationCommentsPrompt,
-    clearConversationComments,
-    cloneConversationComments,
-    CONVERSATION_COMMENT_LIMITS,
-    ConversationCommentDraft,
-    ConversationCommentError,
-    ConversationCommentOperation,
-    ConversationCommentSelection,
-    ConversationCommentSessionNote,
-    ConversationCommentTarget,
-    createConversationComment,
-    createConversationSessionComment,
-    markConversationCommentsSent,
-    reopenConversationComment,
-    resolveConversationComment,
-    updateConversationComment,
-    validateConversationComments,
-} from './comments';
-import type {
-    ConversationCommentSnapshot,
-    ConversationCommentStore,
-} from './commentStore';
-import {
-    ConversationBookmarkSnapshot,
-    ConversationBookmarkStore,
-    isConversationBookmarkSnapshot,
-    MAX_CONVERSATION_BOOKMARKS,
-} from './bookmarkStore';
+import { CONVERSATION_COMMENT_LIMITS } from './comments';
+import type { ConversationCommentStore } from './commentStore';
+import type { ConversationBookmarkStore } from './bookmarkStore';
+import { ConversationCommentController } from './commentController';
+import { ConversationBookmarkController } from './bookmarkController';
 import { renderConversationMarkdown } from './markdown';
-import {
-    ConversationViewerBookmarkMutationMessage,
-    ConversationViewerCommentMutationMessage,
-    ConversationViewerLocateCommentMessage,
-    ConversationViewerSendCommentsMessage,
-    hasExactKeys,
-    isConversationViewerTargetId,
-    parseConversationViewerMessage,
-} from './viewerProtocol';
+import { parseConversationViewerMessage } from './viewerProtocol';
+import type { ConversationViewerTarget } from './viewerTarget';
+export type { ConversationViewerTarget } from './viewerTarget';
 import {
     CONVERSATION_LIMITS,
     ConversationAbortController,
@@ -57,16 +27,6 @@ import {
     ConversationResponseState,
     ConversationTelemetry,
 } from './types';
-
-export interface ConversationViewerTarget {
-    projectId: string;
-    provider: AiSessionProviderId;
-    sessionId: string;
-    interactionId: string;
-    expectedRevision: string;
-    displayName: string;
-    duplicateDisplayName: boolean;
-}
 
 export interface ConversationViewerOptions {
     createPanel: typeof vscode.window.createWebviewPanel;
@@ -154,49 +114,6 @@ interface ConversationViewerOutlineEntry {
     responseState: ConversationResponseState;
 }
 
-interface ConversationViewerLocateCommentResultMessage {
-    type: 'conversation-viewer-locate-comment-result';
-    version: 1;
-    requestId: string;
-    subscriptionGeneration: number;
-    projectId: string;
-    provider: AiSessionProviderId;
-    sessionId: string;
-    commentId: string;
-    success: boolean;
-    error?: 'stale';
-}
-
-interface ConversationViewerCommentsResultMessage {
-    type: 'conversation-viewer-comments-result';
-    version: 1;
-    requestId: string;
-    subscriptionGeneration: number;
-    projectId: string;
-    provider: AiSessionProviderId;
-    sessionId: string;
-    operation: ConversationCommentOperation;
-    success: boolean;
-    revision: number;
-    comments: ConversationCommentDraft[];
-    error?: ConversationCommentError['code'];
-}
-
-interface ConversationViewerBookmarksResultMessage {
-    type: 'conversation-viewer-bookmarks-result';
-    version: 1;
-    requestId: string;
-    subscriptionGeneration: number;
-    projectId: string;
-    provider: AiSessionProviderId;
-    sessionId: string;
-    operation: 'set';
-    success: boolean;
-    revision: number;
-    interactionIds: string[];
-    error?: 'invalid' | 'stale' | 'failed' | 'limit';
-}
-
 export class ConversationViewer implements ConversationViewerApi {
     private panel?: vscode.WebviewPanel;
     private target?: ConversationViewerTarget;
@@ -218,18 +135,31 @@ export class ConversationViewer implements ConversationViewerApi {
     private suspended = false;
     private authoritativeLoadInFlight?: Promise<boolean>;
     private authoritativeRefreshPending = false;
-    private comments: ConversationCommentDraft[] = [];
-    private commentRevision = 0;
-    private commentOperationQueue: Promise<void> = Promise.resolve();
-    private readonly commentSettlements =
-        new Map<string, ConversationViewerCommentsResultMessage>();
-    private bookmarkIds = new Set<string>();
-    private bookmarkRevision = 0;
-    private bookmarkOperationQueue: Promise<void> = Promise.resolve();
-    private readonly bookmarkSettlements =
-        new Map<string, ConversationViewerBookmarksResultMessage>();
+    private readonly commentController: ConversationCommentController;
+    private readonly bookmarkController: ConversationBookmarkController;
 
-    constructor(private readonly options: ConversationViewerOptions) {}
+    constructor(private readonly options: ConversationViewerOptions) {
+        this.commentController = new ConversationCommentController({
+            commentStore: options.commentStore,
+            submitPrompt: options.submitPrompt,
+            focusSession: options.focusSession,
+            getTarget: () => this.target,
+            getSubscriptionGeneration: () => this.subscriptionGeneration,
+            getPanel: () => this.panel,
+            getMessages: () => this.messages(),
+            navigateToInteraction: interactionId =>
+                this.navigateToInteraction(interactionId),
+            rebuildLatestDocument: () => this.rebuildLatestDocument(),
+        });
+        this.bookmarkController = new ConversationBookmarkController({
+            bookmarkStore: options.bookmarkStore,
+            getTarget: () => this.target,
+            getSubscriptionGeneration: () => this.subscriptionGeneration,
+            getPanel: () => this.panel,
+            getOutline: () => this.outline,
+            rebuildLatestDocument: () => this.rebuildLatestDocument(),
+        });
+    }
 
     get snapshotSize(): number {
         return this.interactionIds().length;
@@ -261,8 +191,8 @@ export class ConversationViewer implements ConversationViewerApi {
             return false;
         }
         await Promise.all([
-            this.restoreComments(activeTarget, generation),
-            this.restoreBookmarks(activeTarget, generation),
+            this.commentController.restore(activeTarget, generation),
+            this.bookmarkController.restore(activeTarget, generation),
         ]);
         if (this.target !== activeTarget
             || this.subscriptionGeneration !== generation) {
@@ -361,12 +291,8 @@ export class ConversationViewer implements ConversationViewerApi {
         this.stale = false;
         this.telemetry = undefined;
         this.latestPublication = undefined;
-        this.comments = [];
-        this.commentRevision = 0;
-        this.commentSettlements.clear();
-        this.bookmarkIds.clear();
-        this.bookmarkRevision = 0;
-        this.bookmarkSettlements.clear();
+        this.commentController.reset();
+        this.bookmarkController.reset();
         this.target = { ...target };
         this.selectedInteractionId = target.interactionId;
         this.suspended = false;
@@ -443,12 +369,8 @@ export class ConversationViewer implements ConversationViewerApi {
         this.stale = false;
         this.telemetry = undefined;
         this.latestPublication = undefined;
-        this.comments = [];
-        this.commentRevision = 0;
-        this.commentSettlements.clear();
-        this.bookmarkIds.clear();
-        this.bookmarkRevision = 0;
-        this.bookmarkSettlements.clear();
+        this.commentController.reset();
+        this.bookmarkController.reset();
         this.panelWasVisible = false;
         this.suspended = false;
         this.subscriptionGeneration += 1;
@@ -470,15 +392,15 @@ export class ConversationViewer implements ConversationViewerApi {
         }
         if (parsed.type === 'conversation-viewer-comment-mutation'
             || parsed.type === 'conversation-viewer-send-comments') {
-            await this.enqueueCommentOperation(parsed);
+            await this.commentController.enqueue(parsed);
             return;
         }
         if (parsed.type === 'conversation-viewer-bookmark-mutation') {
-            await this.enqueueBookmarkOperation(parsed);
+            await this.bookmarkController.enqueue(parsed);
             return;
         }
         if (parsed.type === 'conversation-viewer-locate-comment') {
-            await this.locateComment(parsed);
+            await this.commentController.locate(parsed);
             return;
         }
         if (parsed.type === 'conversation-viewer-select-interaction') {
@@ -494,541 +416,6 @@ export class ConversationViewer implements ConversationViewerApi {
             return;
         }
         await this.navigateLatest();
-    }
-
-    private enqueueCommentOperation(
-        request: ConversationViewerCommentMutationMessage
-            | ConversationViewerSendCommentsMessage
-    ): Promise<void> {
-        const operation = () => this.handleCommentOperation(request);
-        const queued = this.commentOperationQueue.then(operation, operation);
-        this.commentOperationQueue = queued.catch(() => undefined);
-        return queued;
-    }
-
-    private enqueueBookmarkOperation(
-        request: ConversationViewerBookmarkMutationMessage
-    ): Promise<void> {
-        const operation = () => this.handleBookmarkOperation(request);
-        const queued = this.bookmarkOperationQueue.then(operation, operation);
-        this.bookmarkOperationQueue = queued.catch(() => undefined);
-        return queued;
-    }
-
-    private async handleBookmarkOperation(
-        request: ConversationViewerBookmarkMutationMessage
-    ): Promise<void> {
-        const target = this.target;
-        const panel = this.panel;
-        if (!target || !panel) {
-            return;
-        }
-        const settlementKey = getBookmarkSettlementKey(request);
-        const settled = this.bookmarkSettlements.get(settlementKey);
-        if (settled) {
-            await this.publishTransientSettlement(settled);
-            return;
-        }
-        if (!bookmarkRequestTargetsViewer(
-            request,
-            target,
-            this.subscriptionGeneration
-        ) || request.expectedRevision !== this.bookmarkRevision) {
-            await this.settleBookmarkRequest(request, false, 'stale');
-            return;
-        }
-        const interactionExists = this.outline?.interactions.some(
-            interaction =>
-                interaction.id === request.payload.interactionId
-        ) === true;
-        if (!interactionExists) {
-            await this.settleBookmarkRequest(request, false, 'stale');
-            return;
-        }
-        const next = new Set(this.bookmarkIds);
-        if (request.payload.bookmarked) {
-            next.add(request.payload.interactionId);
-        } else {
-            next.delete(request.payload.interactionId);
-        }
-        if (next.size > MAX_CONVERSATION_BOOKMARKS) {
-            await this.settleBookmarkRequest(request, false, 'limit');
-            return;
-        }
-        const changed = next.size !== this.bookmarkIds.size
-            || [...next].some(id => !this.bookmarkIds.has(id));
-        const snapshot = {
-            revision: this.bookmarkRevision + (changed ? 1 : 0),
-            interactionIds: [...next],
-        };
-        const previousSnapshot = {
-            revision: this.bookmarkRevision,
-            interactionIds: [...this.bookmarkIds],
-        };
-        try {
-            await this.persistBookmarks(target, snapshot);
-            if (this.target !== target
-                || this.subscriptionGeneration
-                    !== request.subscriptionGeneration
-                || this.bookmarkRevision !== request.expectedRevision) {
-                await this.persistBookmarks(target, previousSnapshot);
-                throw new Error('stale');
-            }
-            this.bookmarkIds = next;
-            this.bookmarkRevision = snapshot.revision;
-            await this.settleBookmarkRequest(request, true);
-        } catch (error) {
-            await this.settleBookmarkRequest(
-                request,
-                false,
-                error instanceof Error && error.message === 'stale'
-                    ? 'stale'
-                    : 'failed'
-            );
-        }
-    }
-
-    private async settleBookmarkRequest(
-        request: ConversationViewerBookmarkMutationMessage,
-        success: boolean,
-        error?: ConversationViewerBookmarksResultMessage['error']
-    ): Promise<void> {
-        const settlement: ConversationViewerBookmarksResultMessage = {
-            type: 'conversation-viewer-bookmarks-result',
-            version: 1,
-            requestId: request.requestId,
-            subscriptionGeneration: request.subscriptionGeneration,
-            projectId: request.projectId,
-            provider: request.provider,
-            sessionId: request.sessionId,
-            operation: 'set',
-            success,
-            revision: this.bookmarkRevision,
-            interactionIds: [...this.bookmarkIds],
-            ...(error ? { error } : {}),
-        };
-        this.bookmarkSettlements.set(
-            getBookmarkSettlementKey(request),
-            settlement
-        );
-        while (this.bookmarkSettlements.size > 100) {
-            const oldest = this.bookmarkSettlements.keys().next().value;
-            if (typeof oldest !== 'string') {
-                break;
-            }
-            this.bookmarkSettlements.delete(oldest);
-        }
-        await this.publishTransientSettlement(settlement);
-    }
-
-    private async handleCommentOperation(
-        request: ConversationViewerCommentMutationMessage
-            | ConversationViewerSendCommentsMessage
-    ): Promise<void> {
-        const target = this.target;
-        if (!target || !this.panel) {
-            return;
-        }
-        const settlementKey = getCommentSettlementKey(request);
-        const settled = this.commentSettlements.get(settlementKey);
-        if (settled) {
-            await this.publishCommentSettlement(
-                settled.operation === request.operation
-                    ? settled
-                    : {
-                        ...settled,
-                        operation: request.operation,
-                        success: false,
-                        revision: this.commentRevision,
-                        comments: cloneConversationComments(this.comments),
-                        error: 'invalid',
-                    },
-                false
-            );
-            return;
-        }
-        if (!commentRequestTargetsViewer(
-            request,
-            target,
-            this.subscriptionGeneration
-        )) {
-            await this.settleCommentRequest(request, false, 'stale');
-            return;
-        }
-        if (request.expectedRevision !== this.commentRevision) {
-            await this.settleCommentRequest(request, false, 'stale');
-            return;
-        }
-        try {
-            if (request.operation === 'sendComments') {
-                await this.sendComments(
-                    target,
-                    this.subscriptionGeneration
-                );
-            } else {
-                await this.mutateComments(
-                    request,
-                    target,
-                    this.subscriptionGeneration
-                );
-            }
-            await this.settleCommentRequest(request, true);
-            if (request.operation === 'sendComments') {
-                await this.focusSessionAfterCommentSend(target);
-            }
-        } catch (error) {
-            await this.settleCommentRequest(
-                request,
-                false,
-                toConversationCommentErrorCode(error)
-            );
-        }
-    }
-
-    private async focusSessionAfterCommentSend(
-        target: ConversationViewerTarget
-    ): Promise<void> {
-        try {
-            await Promise.resolve(this.options.focusSession?.({
-                projectId: target.projectId,
-                provider: target.provider,
-                sessionId: target.sessionId,
-            }));
-        } catch (_error) {
-            // The prompt was already submitted and settled. A focus failure
-            // must not make the user retry and submit the same batch twice.
-        }
-    }
-
-    private async mutateComments(
-        request: ConversationViewerCommentMutationMessage,
-        target: ConversationViewerTarget,
-        generation: number
-    ): Promise<void> {
-        let comments = cloneConversationComments(this.comments);
-        let revision = this.commentRevision;
-        if (request.operation === 'add') {
-            if (comments.length
-                >= CONVERSATION_COMMENT_LIMITS.maxComments) {
-                throw new ConversationCommentError('limit');
-            }
-            const payload = parseCommentInput(request.payload);
-            if (payload.scope === 'session') {
-                comments.push(createConversationSessionComment(
-                    randomBytes(16).toString('hex'),
-                    payload.comment
-                ));
-            } else {
-                const message = this.messages().find(candidate =>
-                    candidate.id === payload.messageId
-                    && candidate.interactionId === payload.interactionId
-                );
-                if (!message) {
-                    throw new ConversationCommentError('stale');
-                }
-                comments.push(createConversationComment(
-                    randomBytes(16).toString('hex'),
-                    payload,
-                    message
-                ));
-            }
-            revision += 1;
-        } else if (request.operation === 'clearSent'
-            || request.operation === 'clearResolved'
-            || request.operation === 'clearAll') {
-            if (!hasExactKeys(request.payload as object, [])) {
-                throw new ConversationCommentError('invalid');
-            }
-            const remainingComments = clearConversationComments(
-                comments,
-                request.operation
-            );
-            if (remainingComments.length !== comments.length) {
-                comments = remainingComments;
-                revision += 1;
-            }
-        } else {
-            const payload = parseExistingCommentPayload(
-                request.operation,
-                request.payload
-            );
-            const index = comments.findIndex(
-                comment => comment.id === payload.commentId
-            );
-            if (index < 0) {
-                throw new ConversationCommentError('stale');
-            }
-            if (request.operation === 'delete') {
-                comments.splice(index, 1);
-            } else if (request.operation === 'update') {
-                comments[index] = updateConversationComment(
-                    comments[index],
-                    payload.comment
-                );
-            } else if (request.operation === 'resolve') {
-                comments[index] = resolveConversationComment(comments[index]);
-            } else {
-                comments[index] = reopenConversationComment(comments[index]);
-            }
-            revision += 1;
-        }
-        const snapshot = { revision, comments };
-        await this.persistComments(target, snapshot);
-        this.commitPersistedComments(
-            target,
-            generation,
-            request.expectedRevision,
-            snapshot
-        );
-    }
-
-    private async sendComments(
-        target: ConversationViewerTarget,
-        generation: number
-    ): Promise<void> {
-        const openComments = this.comments.filter(
-            comment => comment.status === 'open'
-        );
-        const prompt = buildConversationCommentsPrompt(openComments);
-        const previousSnapshot = {
-            revision: this.commentRevision,
-            comments: cloneConversationComments(this.comments),
-        };
-        const sentSnapshot = {
-            revision: this.commentRevision + 1,
-            comments: markConversationCommentsSent(this.comments),
-        };
-        await this.persistComments(target, sentSnapshot);
-        if (this.target !== target
-            || this.subscriptionGeneration !== generation
-            || this.commentRevision !== previousSnapshot.revision) {
-            await this.persistComments(target, previousSnapshot);
-            throw new ConversationCommentError('stale');
-        }
-        try {
-            await Promise.resolve(this.options.submitPrompt(
-                { ...target },
-                prompt
-            ));
-        } catch (error) {
-            await this.persistComments(target, previousSnapshot);
-            if (error instanceof ConversationCommentError) {
-                throw error;
-            }
-            throw new ConversationCommentError('failed');
-        }
-        if (this.target !== target) {
-            throw new ConversationCommentError('stale');
-        }
-        this.comments = sentSnapshot.comments;
-        this.commentRevision = sentSnapshot.revision;
-    }
-
-    private async restoreComments(
-        target: ConversationViewerTarget,
-        generation: number
-    ): Promise<void> {
-        if (!this.options.commentStore) {
-            return;
-        }
-        let snapshot: ConversationCommentSnapshot;
-        try {
-            snapshot = await this.options.commentStore.load(
-                toCommentTarget(target)
-            );
-            validateConversationComments(snapshot.comments);
-            if (!Number.isSafeInteger(snapshot.revision)
-                || snapshot.revision < 0) {
-                throw new ConversationCommentError('invalid');
-            }
-        } catch (_error) {
-            return;
-        }
-        if (this.target !== target
-            || this.subscriptionGeneration !== generation) {
-            return;
-        }
-        this.comments = cloneConversationComments(snapshot.comments);
-        this.commentRevision = snapshot.revision;
-    }
-
-    private async restoreBookmarks(
-        target: ConversationViewerTarget,
-        generation: number
-    ): Promise<void> {
-        if (!this.options.bookmarkStore) {
-            return;
-        }
-        let snapshot: ConversationBookmarkSnapshot;
-        try {
-            snapshot = await this.options.bookmarkStore.load(
-                toBookmarkTarget(target)
-            );
-            if (!isConversationBookmarkSnapshot(snapshot)) {
-                return;
-            }
-        } catch (_error) {
-            return;
-        }
-        if (this.target !== target
-            || this.subscriptionGeneration !== generation) {
-            return;
-        }
-        this.bookmarkIds = new Set(snapshot.interactionIds);
-        this.bookmarkRevision = snapshot.revision;
-    }
-
-    private async persistBookmarks(
-        target: ConversationViewerTarget,
-        snapshot: ConversationBookmarkSnapshot
-    ): Promise<void> {
-        if (!this.options.bookmarkStore) {
-            return;
-        }
-        await this.options.bookmarkStore.save(toBookmarkTarget(target), snapshot);
-    }
-
-    private async persistComments(
-        target: ConversationViewerTarget,
-        snapshot: ConversationCommentSnapshot
-    ): Promise<void> {
-        if (!this.options.commentStore) {
-            return;
-        }
-        try {
-            await this.options.commentStore.save(
-                toCommentTarget(target),
-                snapshot
-            );
-        } catch (_error) {
-            throw new ConversationCommentError('failed');
-        }
-    }
-
-    private commitPersistedComments(
-        target: ConversationViewerTarget,
-        generation: number,
-        expectedRevision: number,
-        snapshot: ConversationCommentSnapshot
-    ): void {
-        if (this.target !== target
-            || this.subscriptionGeneration !== generation
-            || this.commentRevision !== expectedRevision) {
-            throw new ConversationCommentError('stale');
-        }
-        this.comments = snapshot.comments;
-        this.commentRevision = snapshot.revision;
-    }
-
-    private async locateComment(
-        request: ConversationViewerLocateCommentMessage
-    ): Promise<void> {
-        const target = this.target;
-        const comment = this.comments.find(
-            candidate => candidate.id === request.commentId
-        );
-        const targetMatches = Boolean(target)
-            && request.subscriptionGeneration === this.subscriptionGeneration
-            && request.projectId === target?.projectId
-            && request.provider === target?.provider
-            && request.sessionId === target?.sessionId;
-        const success = targetMatches && comment
-            ? await this.navigateToInteraction(comment.interactionId)
-            : false;
-        const settlement: ConversationViewerLocateCommentResultMessage = {
-            type: 'conversation-viewer-locate-comment-result',
-            version: 1,
-            requestId: request.requestId,
-            subscriptionGeneration: request.subscriptionGeneration,
-            projectId: request.projectId,
-            provider: request.provider,
-            sessionId: request.sessionId,
-            commentId: request.commentId,
-            success,
-            ...(success ? {} : { error: 'stale' }),
-        };
-        await this.publishTransientSettlement(settlement);
-    }
-
-    private async settleCommentRequest(
-        request: ConversationViewerCommentMutationMessage
-            | ConversationViewerSendCommentsMessage,
-        success: boolean,
-        error?: ConversationCommentError['code']
-    ): Promise<void> {
-        const settlement: ConversationViewerCommentsResultMessage = {
-            type: 'conversation-viewer-comments-result',
-            version: 1,
-            requestId: request.requestId,
-            subscriptionGeneration: request.subscriptionGeneration,
-            projectId: request.projectId,
-            provider: request.provider,
-            sessionId: request.sessionId,
-            operation: request.operation,
-            success,
-            revision: this.commentRevision,
-            comments: cloneConversationComments(this.comments),
-            ...(error ? { error } : {}),
-        };
-        this.rememberCommentSettlement(
-            getCommentSettlementKey(request),
-            settlement
-        );
-        await this.publishCommentSettlement(settlement, true);
-    }
-
-    private rememberCommentSettlement(
-        key: string,
-        settlement: ConversationViewerCommentsResultMessage
-    ): void {
-        this.commentSettlements.set(key, settlement);
-        while (this.commentSettlements.size > 100) {
-            const oldest = this.commentSettlements.keys().next().value;
-            if (typeof oldest !== 'string') {
-                break;
-            }
-            this.commentSettlements.delete(oldest);
-        }
-    }
-
-    private async publishCommentSettlement(
-        settlement: ConversationViewerCommentsResultMessage,
-        rebuildOnFailure: boolean
-    ): Promise<void> {
-        const panel = this.panel;
-        if (!panel) {
-            return;
-        }
-        let delivered = false;
-        try {
-            delivered = await panel.webview.postMessage(settlement);
-        } catch (_error) {
-            delivered = false;
-        }
-        if (!delivered && rebuildOnFailure && this.panel === panel) {
-            this.rebuildLatestDocument();
-        }
-    }
-
-    private async publishTransientSettlement(
-        settlement: ConversationViewerLocateCommentResultMessage
-            | ConversationViewerBookmarksResultMessage
-    ): Promise<void> {
-        const panel = this.panel;
-        if (!panel) {
-            return;
-        }
-        let delivered = false;
-        try {
-            delivered = await panel.webview.postMessage(settlement);
-        } catch (_error) {
-            delivered = false;
-        }
-        if (!delivered && this.panel === panel) {
-            // Replacing the document clears Webview-owned pending state while
-            // preserving Host-owned comments, bookmarks, and the current page.
-            this.rebuildLatestDocument();
-        }
     }
 
     private async openLink(href: string): Promise<void> {
@@ -1824,6 +1211,12 @@ export class ConversationViewer implements ConversationViewerApi {
         const mermaid = panel.webview.asWebviewUri(
             this.options.mediaUri('mermaid.min.js')
         );
+        const readingAnchorScript = panel.webview.asWebviewUri(
+            this.options.mediaUri('conversationReadingAnchorScripts.js')
+        );
+        const mermaidScript = panel.webview.asWebviewUri(
+            this.options.mediaUri('conversationMermaidScripts.js')
+        );
         const script = panel.webview.asWebviewUri(
             this.options.mediaUri('conversationViewerScripts.js')
         );
@@ -1834,16 +1227,10 @@ export class ConversationViewer implements ConversationViewerApi {
             ? ` data-initial-page="${escapeAttribute(JSON.stringify(initialPage))}"`
             : '';
         const commentStateAttribute = ` data-initial-comments="${escapeAttribute(
-            JSON.stringify({
-                revision: this.commentRevision,
-                comments: cloneConversationComments(this.comments),
-            })
+            JSON.stringify(this.commentController.snapshot)
         )}"`;
         const bookmarkStateAttribute = ` data-initial-bookmarks="${escapeAttribute(
-            JSON.stringify({
-                revision: this.bookmarkRevision,
-                interactionIds: [...this.bookmarkIds],
-            })
+            JSON.stringify(this.bookmarkController.snapshot)
         )}"`;
         const targetAttribute = ` data-conversation-target="${escapeAttribute(
             JSON.stringify({
@@ -2008,150 +1395,17 @@ export class ConversationViewer implements ConversationViewerApi {
         purify.toString()
     )}"></script>
     <script nonce="${escapeAttribute(nonce)}" src="${escapeAttribute(
+        readingAnchorScript.toString()
+    )}"></script>
+    <script nonce="${escapeAttribute(nonce)}" src="${escapeAttribute(
+        mermaidScript.toString()
+    )}"></script>
+    <script nonce="${escapeAttribute(nonce)}" src="${escapeAttribute(
         script.toString()
     )}"></script>
 </body>
 </html>`;
     }
-}
-
-function toCommentTarget(
-    target: ConversationViewerTarget
-): ConversationCommentTarget {
-    return {
-        projectId: target.projectId,
-        provider: target.provider,
-        sessionId: target.sessionId,
-    };
-}
-
-function toBookmarkTarget(
-    target: ConversationViewerTarget
-): Pick<
-    ConversationViewerTarget,
-    'projectId' | 'provider' | 'sessionId'
-> {
-    return {
-        projectId: target.projectId,
-        provider: target.provider,
-        sessionId: target.sessionId,
-    };
-}
-
-function bookmarkRequestTargetsViewer(
-    request: ConversationViewerBookmarkMutationMessage,
-    target: ConversationViewerTarget,
-    subscriptionGeneration: number
-): boolean {
-    return request.subscriptionGeneration === subscriptionGeneration
-        && request.projectId === target.projectId
-        && request.provider === target.provider
-        && request.sessionId === target.sessionId;
-}
-
-function getBookmarkSettlementKey(
-    request: ConversationViewerBookmarkMutationMessage
-): string {
-    return [
-        request.subscriptionGeneration,
-        request.projectId,
-        request.provider,
-        request.sessionId,
-        request.requestId,
-    ].join('\u0000');
-}
-
-function commentRequestTargetsViewer(
-    request: ConversationViewerCommentMutationMessage
-        | ConversationViewerSendCommentsMessage,
-    target: ConversationViewerTarget,
-    subscriptionGeneration: number
-): boolean {
-    return request.subscriptionGeneration === subscriptionGeneration
-        && request.projectId === target.projectId
-        && request.provider === target.provider
-        && request.sessionId === target.sessionId;
-}
-
-function getCommentSettlementKey(
-    request: ConversationViewerCommentMutationMessage
-        | ConversationViewerSendCommentsMessage
-): string {
-    return JSON.stringify([
-        request.projectId,
-        request.provider,
-        request.sessionId,
-        request.requestId,
-    ]);
-}
-
-function parseCommentInput(
-    payload: unknown
-): ConversationCommentSelection | ConversationCommentSessionNote {
-    if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
-        throw new ConversationCommentError('invalid');
-    }
-    const value = payload as Record<string, unknown>;
-    if (hasExactKeys(value, ['scope', 'comment'])) {
-        if (value.scope !== 'session' || typeof value.comment !== 'string') {
-            throw new ConversationCommentError('invalid');
-        }
-        return value as unknown as ConversationCommentSessionNote;
-    }
-    if (!hasExactKeys(value, [
-        'messageId', 'interactionId', 'quote', 'prefix', 'suffix', 'comment',
-    ])) {
-        throw new ConversationCommentError('invalid');
-    }
-    if (typeof value.messageId !== 'string'
-        || typeof value.interactionId !== 'string'
-        || typeof value.quote !== 'string'
-        || typeof value.prefix !== 'string'
-        || typeof value.suffix !== 'string'
-        || typeof value.comment !== 'string') {
-        throw new ConversationCommentError('invalid');
-    }
-    return {
-        scope: 'selection',
-        messageId: value.messageId,
-        interactionId: value.interactionId,
-        quote: value.quote,
-        prefix: value.prefix,
-        suffix: value.suffix,
-        comment: value.comment,
-    } as ConversationCommentSelection;
-}
-
-function parseExistingCommentPayload(
-    operation: 'update' | 'delete' | 'resolve' | 'reopen',
-    payload: unknown
-): { commentId: string; comment?: string } {
-    if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
-        throw new ConversationCommentError('invalid');
-    }
-    const value = payload as Record<string, unknown>;
-    const expected = operation === 'update'
-        ? ['commentId', 'comment']
-        : ['commentId'];
-    if (!hasExactKeys(value, expected)
-        || !isConversationViewerTargetId(value.commentId)
-        || (operation === 'update' && typeof value.comment !== 'string')) {
-        throw new ConversationCommentError('invalid');
-    }
-    return {
-        commentId: value.commentId,
-        ...(operation === 'update'
-            ? { comment: value.comment as string }
-            : {}),
-    };
-}
-
-function toConversationCommentErrorCode(
-    error: unknown
-): ConversationCommentError['code'] {
-    return error instanceof ConversationCommentError
-        ? error.code
-        : 'failed';
 }
 
 function isStaleRevision(error: unknown): error is ConversationError {

--- a/src/aiSessions/conversation/viewerProtocol.ts
+++ b/src/aiSessions/conversation/viewerProtocol.ts
@@ -1,0 +1,255 @@
+'use strict';
+
+import type { AiSessionProviderId } from '../../models';
+import { CONVERSATION_COMMENT_LIMITS } from './comments';
+
+export interface ConversationViewerNavigationMessage {
+    type: 'conversation-viewer-previous'
+        | 'conversation-viewer-next'
+        | 'conversation-viewer-latest'
+        | 'conversation-viewer-closed';
+    version: 1;
+}
+
+export interface ConversationViewerSelectInteractionMessage {
+    type: 'conversation-viewer-select-interaction';
+    version: 1;
+    interactionId: string;
+}
+
+export interface ConversationViewerOpenLinkMessage {
+    type: 'conversation-viewer-open-link';
+    version: 1;
+    href: string;
+}
+
+export interface ConversationViewerCommentMutationMessage {
+    type: 'conversation-viewer-comment-mutation';
+    version: 1;
+    requestId: string;
+    subscriptionGeneration: number;
+    projectId: string;
+    provider: AiSessionProviderId;
+    sessionId: string;
+    operation: 'add' | 'update' | 'delete' | 'resolve' | 'reopen'
+        | 'clearSent' | 'clearResolved' | 'clearAll';
+    expectedRevision: number;
+    payload: unknown;
+}
+
+export interface ConversationViewerLocateCommentMessage {
+    type: 'conversation-viewer-locate-comment';
+    version: 1;
+    requestId: string;
+    subscriptionGeneration: number;
+    projectId: string;
+    provider: AiSessionProviderId;
+    sessionId: string;
+    commentId: string;
+}
+
+export interface ConversationViewerSendCommentsMessage {
+    type: 'conversation-viewer-send-comments';
+    version: 1;
+    requestId: string;
+    subscriptionGeneration: number;
+    projectId: string;
+    provider: AiSessionProviderId;
+    sessionId: string;
+    operation: 'sendComments';
+    expectedRevision: number;
+    payload: Record<string, never>;
+}
+
+export interface ConversationViewerBookmarkMutationMessage {
+    type: 'conversation-viewer-bookmark-mutation';
+    version: 1;
+    requestId: string;
+    subscriptionGeneration: number;
+    projectId: string;
+    provider: AiSessionProviderId;
+    sessionId: string;
+    operation: 'set';
+    expectedRevision: number;
+    payload: {
+        interactionId: string;
+        bookmarked: boolean;
+    };
+}
+
+export type ConversationViewerMessage =
+    ConversationViewerNavigationMessage
+    | ConversationViewerSelectInteractionMessage
+    | ConversationViewerOpenLinkMessage
+    | ConversationViewerCommentMutationMessage
+    | ConversationViewerSendCommentsMessage
+    | ConversationViewerLocateCommentMessage
+    | ConversationViewerBookmarkMutationMessage;
+
+const NAVIGATION_MESSAGE_TYPES = new Set([
+    'conversation-viewer-previous',
+    'conversation-viewer-next',
+    'conversation-viewer-latest',
+    'conversation-viewer-closed',
+]);
+
+export function parseConversationViewerMessage(
+    message: unknown
+): ConversationViewerMessage | undefined {
+    if (!message || typeof message !== 'object' || Array.isArray(message)) {
+        return undefined;
+    }
+    const value = message as { [key: string]: unknown };
+    if (value.version !== 1 || typeof value.type !== 'string') {
+        return undefined;
+    }
+    const keys = Object.keys(value);
+    if (NAVIGATION_MESSAGE_TYPES.has(value.type)) {
+        if (keys.length !== 2
+            || !hasOwn(value, 'type')
+            || !hasOwn(value, 'version')) {
+            return undefined;
+        }
+        return value as unknown as ConversationViewerNavigationMessage;
+    }
+    if (value.type === 'conversation-viewer-select-interaction') {
+        if (!hasExactKeys(value, ['type', 'version', 'interactionId'])
+            || !isConversationViewerTargetId(value.interactionId)) {
+            return undefined;
+        }
+        return value as unknown as
+            ConversationViewerSelectInteractionMessage;
+    }
+    if (value.type === 'conversation-viewer-open-link') {
+        if (keys.length !== 3
+            || !hasOwn(value, 'type')
+            || !hasOwn(value, 'version')
+            || !hasOwn(value, 'href')
+            || typeof value.href !== 'string') {
+            return undefined;
+        }
+        return value as unknown as ConversationViewerOpenLinkMessage;
+    }
+    if (value.type === 'conversation-viewer-locate-comment') {
+        if (!hasExactKeys(value, [
+            'type', 'version', 'requestId', 'subscriptionGeneration',
+            'projectId', 'provider', 'sessionId', 'commentId',
+        ])
+            || !isRequestId(value.requestId)
+            || !isPositiveSafeInteger(value.subscriptionGeneration)
+            || !isConversationViewerTargetId(value.projectId)
+            || !isProvider(value.provider)
+            || !isConversationViewerTargetId(value.sessionId)
+            || !isConversationViewerTargetId(value.commentId)) {
+            return undefined;
+        }
+        return value as unknown as ConversationViewerLocateCommentMessage;
+    }
+    if (value.type === 'conversation-viewer-bookmark-mutation') {
+        if (!hasExactKeys(value, [
+            'type', 'version', 'requestId', 'subscriptionGeneration',
+            'projectId', 'provider', 'sessionId', 'operation',
+            'expectedRevision', 'payload',
+        ])
+            || !isRequestId(value.requestId)
+            || !isPositiveSafeInteger(value.subscriptionGeneration)
+            || !isConversationViewerTargetId(value.projectId)
+            || !isProvider(value.provider)
+            || !isConversationViewerTargetId(value.sessionId)
+            || value.operation !== 'set'
+            || !isNonnegativeSafeInteger(value.expectedRevision)
+            || !isRecord(value.payload)
+            || !hasExactKeys(value.payload, [
+                'interactionId', 'bookmarked',
+            ])
+            || !isConversationViewerTargetId(value.payload.interactionId)
+            || typeof value.payload.bookmarked !== 'boolean') {
+            return undefined;
+        }
+        return value as unknown as ConversationViewerBookmarkMutationMessage;
+    }
+    if ((value.type !== 'conversation-viewer-comment-mutation'
+            && value.type !== 'conversation-viewer-send-comments')
+        || keys.length !== 10
+        || !hasExactKeys(value, [
+            'type', 'version', 'requestId', 'subscriptionGeneration',
+            'projectId', 'provider', 'sessionId', 'operation',
+            'expectedRevision', 'payload',
+        ])
+        || !isRequestId(value.requestId)
+        || !isPositiveSafeInteger(value.subscriptionGeneration)
+        || !isConversationViewerTargetId(value.projectId)
+        || !isProvider(value.provider)
+        || !isConversationViewerTargetId(value.sessionId)
+        || !isNonnegativeSafeInteger(value.expectedRevision)
+        || !value.payload
+        || typeof value.payload !== 'object'
+        || Array.isArray(value.payload)) {
+        return undefined;
+    }
+    if (value.type === 'conversation-viewer-comment-mutation') {
+        if (value.operation !== 'add'
+            && value.operation !== 'update'
+            && value.operation !== 'delete'
+            && value.operation !== 'resolve'
+            && value.operation !== 'reopen'
+            && value.operation !== 'clearSent'
+            && value.operation !== 'clearResolved'
+            && value.operation !== 'clearAll') {
+            return undefined;
+        }
+        return value as unknown as ConversationViewerCommentMutationMessage;
+    }
+    if (value.operation !== 'sendComments'
+        || Object.keys(value.payload as object).length !== 0) {
+        return undefined;
+    }
+    return value as unknown as ConversationViewerSendCommentsMessage;
+}
+
+export function hasExactKeys(
+    value: object,
+    expected: readonly string[]
+): boolean {
+    const keys = Object.keys(value);
+    return keys.length === expected.length
+        && expected.every(key => hasOwn(value, key));
+}
+
+export function isConversationViewerTargetId(
+    value: unknown
+): value is string {
+    return typeof value === 'string'
+        && value.length > 0
+        && value.length <= CONVERSATION_COMMENT_LIMITS.maxIdLength
+        && !/[\u0000-\u001f\u007f]/.test(value);
+}
+
+function hasOwn(value: object, key: string): boolean {
+    return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return Boolean(value)
+        && typeof value === 'object'
+        && !Array.isArray(value);
+}
+
+function isRequestId(value: unknown): value is string {
+    return typeof value === 'string'
+        && value.length > 0
+        && value.length <= 128
+        && /^[A-Za-z0-9._:-]+$/.test(value);
+}
+
+function isProvider(value: unknown): value is AiSessionProviderId {
+    return value === 'codex' || value === 'kimi' || value === 'claude';
+}
+
+function isPositiveSafeInteger(value: unknown): value is number {
+    return Number.isSafeInteger(value) && (value as number) >= 1;
+}
+
+function isNonnegativeSafeInteger(value: unknown): value is number {
+    return Number.isSafeInteger(value) && (value as number) >= 0;
+}

--- a/src/aiSessions/conversation/viewerTarget.ts
+++ b/src/aiSessions/conversation/viewerTarget.ts
@@ -1,0 +1,13 @@
+'use strict';
+
+import type { AiSessionProviderId } from '../../models';
+
+export interface ConversationViewerTarget {
+    projectId: string;
+    provider: AiSessionProviderId;
+    sessionId: string;
+    interactionId: string;
+    expectedRevision: string;
+    displayName: string;
+    duplicateDisplayName: boolean;
+}

--- a/src/webview/conversationMermaidScripts.js
+++ b/src/webview/conversationMermaidScripts.js
@@ -1,0 +1,339 @@
+(function () {
+    'use strict';
+
+    function create(options) {
+        var objectUrls = [];
+        var sources = new WeakMap();
+        var initialized = false;
+        var loadPromise = null;
+
+        function release(root) {
+            var urls = root
+                ? Array.prototype.map.call(
+                    root.querySelectorAll(
+                        '.conversation-mermaid-image[src^="blob:"]'
+                    ),
+                    function (image) {
+                        return image.src;
+                    }
+                )
+                : objectUrls.slice();
+            var released = new Set(urls);
+            urls.forEach(function (url) {
+                try {
+                    URL.revokeObjectURL(url);
+                } catch (_error) {
+                    // Revocation is best-effort during document teardown.
+                }
+            });
+            objectUrls = objectUrls.filter(function (url) {
+                return !released.has(url);
+            });
+        }
+
+        function themeValue(name, fallback) {
+            var value = window.getComputedStyle(document.body)
+                .getPropertyValue(name)
+                .trim();
+            return value || fallback;
+        }
+
+        function initialize() {
+            if (initialized) return true;
+            if (!window.mermaid
+                || typeof window.mermaid.initialize !== 'function') {
+                return false;
+            }
+            try {
+                window.mermaid.initialize({
+                    startOnLoad: false,
+                    securityLevel: 'strict',
+                    suppressErrorRendering: true,
+                    maxTextSize: 50000,
+                    htmlLabels: false,
+                    theme: 'base',
+                    fontFamily: themeValue(
+                        '--vscode-font-family',
+                        'system-ui, sans-serif'
+                    ),
+                    flowchart: {
+                        htmlLabels: false,
+                    },
+                    themeVariables: {
+                        darkMode: document.body.classList.contains(
+                            'vscode-dark'
+                        ) || document.body.classList.contains(
+                            'vscode-high-contrast'
+                        ),
+                        background: themeValue(
+                            '--vscode-editor-background',
+                            '#1e1e1e'
+                        ),
+                        primaryColor: themeValue(
+                            '--vscode-textCodeBlock-background',
+                            '#252526'
+                        ),
+                        primaryTextColor: themeValue(
+                            '--vscode-editor-foreground',
+                            '#d4d4d4'
+                        ),
+                        primaryBorderColor: themeValue(
+                            '--vscode-panel-border',
+                            '#454545'
+                        ),
+                        lineColor: themeValue(
+                            '--vscode-descriptionForeground',
+                            '#a0a0a0'
+                        ),
+                        secondaryColor: themeValue(
+                            '--vscode-input-background',
+                            '#252526'
+                        ),
+                        tertiaryColor: themeValue(
+                            '--vscode-editor-background',
+                            '#1e1e1e'
+                        ),
+                    },
+                });
+                initialized = true;
+                return true;
+            } catch (_error) {
+                return false;
+            }
+        }
+
+        function load() {
+            if (window.mermaid) {
+                return Promise.resolve(initialize());
+            }
+            if (loadPromise) return loadPromise;
+            if (!options.source) return Promise.resolve(false);
+            loadPromise = new Promise(function (resolve) {
+                var script = document.createElement('script');
+                script.src = options.source;
+                if (options.nonce) script.nonce = options.nonce;
+                script.addEventListener('load', function () {
+                    resolve(initialize());
+                }, { once: true });
+                script.addEventListener('error', function () {
+                    resolve(false);
+                }, { once: true });
+                document.head.appendChild(script);
+            });
+            return loadPromise;
+        }
+
+        function alt(source) {
+            var summary = source.split(/\r?\n/).map(function (line) {
+                return line.trim();
+            }).find(function (line) {
+                return line.length > 0;
+            }) || 'diagram';
+            return 'Mermaid diagram: ' + summary.slice(0, 120);
+        }
+
+        function normalizeSvg(svg) {
+            var clean = window.DOMPurify.sanitize(svg, {
+                USE_PROFILES: {
+                    svg: true,
+                    svgFilters: true,
+                },
+                FORBID_TAGS: ['foreignObject', 'script'],
+                ALLOW_DATA_ATTR: false,
+            });
+            var documentValue = new DOMParser().parseFromString(
+                clean,
+                'image/svg+xml'
+            );
+            var root = documentValue.documentElement;
+            if (!root
+                || root.localName !== 'svg'
+                || documentValue.querySelector('parsererror')) {
+                throw new Error('Mermaid returned invalid SVG.');
+            }
+            var viewBox = (root.getAttribute('viewBox') || '')
+                .trim()
+                .split(/[\s,]+/)
+                .map(Number);
+            var width;
+            var height;
+            if (viewBox.length === 4
+                && viewBox.every(Number.isFinite)
+                && viewBox[2] > 0
+                && viewBox[3] > 0) {
+                var scale = Math.min(
+                    1,
+                    4096 / viewBox[2],
+                    4096 / viewBox[3]
+                );
+                width = Math.max(1, Math.round(viewBox[2] * scale));
+                height = Math.max(1, Math.round(viewBox[3] * scale));
+                root.setAttribute('width', String(width));
+                root.setAttribute('height', String(height));
+            }
+            return {
+                svg: new XMLSerializer().serializeToString(root),
+                width: width,
+                height: height,
+            };
+        }
+
+        function renderDiagram(pre, source, id) {
+            pre.setAttribute('aria-busy', 'true');
+            return Promise.resolve(window.mermaid.render(id, source))
+                .then(function (result) {
+                    if (!pre.isConnected) return;
+                    var normalized = normalizeSvg(result.svg);
+                    var objectUrl = URL.createObjectURL(new Blob([
+                        normalized.svg,
+                    ], { type: 'image/svg+xml' }));
+                    if (!pre.isConnected) {
+                        URL.revokeObjectURL(objectUrl);
+                        return;
+                    }
+                    var figure = document.createElement('figure');
+                    figure.className = 'conversation-mermaid';
+                    sources.set(figure, source);
+                    var image = document.createElement('img');
+                    image.className = 'conversation-mermaid-image';
+                    if (normalized.width && normalized.height) {
+                        image.width = normalized.width;
+                        image.height = normalized.height;
+                    }
+                    image.src = objectUrl;
+                    image.alt = alt(source);
+                    image.decoding = 'async';
+                    figure.appendChild(image);
+                    var decoded = typeof image.decode === 'function'
+                        ? image.decode().catch(function () {})
+                        : Promise.resolve();
+                    return decoded.then(function () {
+                        if (!pre.isConnected) {
+                            URL.revokeObjectURL(objectUrl);
+                            return;
+                        }
+                        objectUrls.push(objectUrl);
+                        var readingAnchor = options.captureAnchor(pre);
+                        var previousScrollTop = options.scroll.scrollTop;
+                        pre.replaceWith(figure);
+                        if (readingAnchor
+                            && readingAnchor.element === pre) {
+                            readingAnchor.element = figure;
+                        }
+                        options.restoreAnchor(
+                            readingAnchor,
+                            previousScrollTop
+                        );
+                    });
+                })
+                .catch(function () {
+                    if (!pre.isConnected) return;
+                    pre.removeAttribute('aria-busy');
+                    pre.classList.add('conversation-mermaid-error');
+                    var label = document.createElement('span');
+                    label.className = 'conversation-mermaid-error-label';
+                    label.setAttribute('role', 'status');
+                    label.textContent =
+                        'Mermaid diagram could not be rendered.';
+                    var readingAnchor = options.captureAnchor();
+                    var previousScrollTop = options.scroll.scrollTop;
+                    pre.parentNode.insertBefore(label, pre);
+                    options.restoreAnchor(readingAnchor, previousScrollTop);
+                    var temporary = document.getElementById(id);
+                    if (temporary) temporary.remove();
+                });
+        }
+
+        function render(generation) {
+            var codeBlocks = Array.prototype.slice.call(
+                options.messages.querySelectorAll(
+                    'pre > code.language-mermaid'
+                ),
+                0,
+                options.maxDiagrams
+            ).filter(function (code) {
+                return code.parentElement
+                    && code.parentElement.getAttribute('aria-busy') !== 'true';
+            });
+            if (!codeBlocks.length) return Promise.resolve();
+            codeBlocks.forEach(function (code) {
+                code.parentElement.setAttribute('aria-busy', 'true');
+            });
+            return load().then(function (available) {
+                if (!available) {
+                    codeBlocks.forEach(function (code) {
+                        if (code.parentElement) {
+                            code.parentElement.removeAttribute('aria-busy');
+                        }
+                    });
+                    return;
+                }
+                return codeBlocks.reduce(function (promise, code, index) {
+                    return promise.then(function () {
+                        if (!code.parentElement
+                            || !code.parentElement.isConnected) {
+                            return undefined;
+                        }
+                        return renderDiagram(
+                            code.parentElement,
+                            code.textContent || '',
+                            'conversation-mermaid-'
+                                + generation + '-' + index
+                        );
+                    });
+                }, Promise.resolve());
+            });
+        }
+
+        function preserve(oldMessage, candidate) {
+            var figuresBySource = new Map();
+            var pendingBySource = new Map();
+            Array.prototype.forEach.call(
+                oldMessage.querySelectorAll('.conversation-mermaid'),
+                function (figure) {
+                    var source = sources.get(figure);
+                    if (typeof source !== 'string') return;
+                    var figures = figuresBySource.get(source) || [];
+                    figures.push(figure);
+                    figuresBySource.set(source, figures);
+                }
+            );
+            Array.prototype.forEach.call(
+                oldMessage.querySelectorAll(
+                    'pre[aria-busy="true"] > code.language-mermaid'
+                ),
+                function (code) {
+                    var source = code.textContent || '';
+                    var blocks = pendingBySource.get(source) || [];
+                    blocks.push(code.parentElement);
+                    pendingBySource.set(source, blocks);
+                }
+            );
+            Array.prototype.forEach.call(
+                candidate.querySelectorAll('pre > code.language-mermaid'),
+                function (code) {
+                    var source = code.textContent || '';
+                    var figures = figuresBySource.get(source);
+                    var figure = figures && figures.shift();
+                    if (figure && code.parentElement) {
+                        code.parentElement.replaceWith(figure);
+                        return;
+                    }
+                    var blocks = pendingBySource.get(source);
+                    var block = blocks && blocks.shift();
+                    if (block && code.parentElement) {
+                        code.parentElement.replaceWith(block);
+                    }
+                }
+            );
+        }
+
+        return Object.freeze({
+            preserve: preserve,
+            release: release,
+            render: render,
+        });
+    }
+
+    window.__agentPivotConversationMermaid = Object.freeze({ create: create });
+})();

--- a/src/webview/conversationReadingAnchorScripts.js
+++ b/src/webview/conversationReadingAnchorScripts.js
@@ -1,0 +1,136 @@
+(function () {
+    'use strict';
+
+    function create(options) {
+        var scroll = options.scroll;
+        var messages = options.messages;
+        var messageSelector = options.messageSelector;
+        var messageId = options.messageId;
+
+        function capture(replacingElement) {
+            var scrollBounds = scroll.getBoundingClientRect();
+            var blockCandidates = messages.querySelectorAll(
+                '.conversation-markdown > *'
+            );
+            var crossingBlock = null;
+            for (var blockIndex = 0;
+                blockIndex < blockCandidates.length;
+                blockIndex += 1) {
+                var blockBounds = blockCandidates[blockIndex]
+                    .getBoundingClientRect();
+                if (!crossingBlock
+                    && blockBounds.bottom > scrollBounds.top
+                    && blockBounds.top < scrollBounds.bottom) {
+                    crossingBlock = blockCandidates[blockIndex];
+                }
+                if (blockCandidates[blockIndex] !== replacingElement
+                    && blockBounds.top >= scrollBounds.top
+                    && blockBounds.top < scrollBounds.bottom) {
+                    var message = blockCandidates[blockIndex].closest(
+                        messageSelector()
+                    );
+                    return {
+                        element: blockCandidates[blockIndex],
+                        messageId: message ? messageId(message) : null,
+                        blockIndex: message
+                            ? Array.prototype.indexOf.call(
+                                message.querySelectorAll(
+                                    '.conversation-markdown > *'
+                                ),
+                                blockCandidates[blockIndex]
+                            )
+                            : -1,
+                        top: blockBounds.top - scrollBounds.top,
+                        viewportTop: blockBounds.top,
+                    };
+                }
+            }
+            if (crossingBlock) {
+                var crossingMessage = crossingBlock.closest(
+                    messageSelector()
+                );
+                var crossingBounds = crossingBlock.getBoundingClientRect();
+                return {
+                    element: crossingBlock,
+                    messageId: crossingMessage
+                        ? messageId(crossingMessage)
+                        : null,
+                    blockIndex: crossingMessage
+                        ? Array.prototype.indexOf.call(
+                            crossingMessage.querySelectorAll(
+                                '.conversation-markdown > *'
+                            ),
+                            crossingBlock
+                        )
+                        : -1,
+                    top: crossingBounds.top - scrollBounds.top,
+                    viewportTop: crossingBounds.top,
+                };
+            }
+            var messageCandidates = messages.querySelectorAll(
+                messageSelector()
+            );
+            for (var index = 0; index < messageCandidates.length; index += 1) {
+                var bounds = messageCandidates[index].getBoundingClientRect();
+                if (bounds.bottom > scrollBounds.top) {
+                    return {
+                        element: messageCandidates[index],
+                        messageId: messageId(messageCandidates[index]),
+                        top: bounds.top - scrollBounds.top,
+                        viewportTop: bounds.top,
+                    };
+                }
+            }
+            return null;
+        }
+
+        function findElement(anchor) {
+            if (!anchor) return null;
+            if (anchor.element && anchor.element.isConnected) {
+                return anchor.element;
+            }
+            var message = Array.prototype.find.call(
+                messages.querySelectorAll(messageSelector()),
+                function (candidate) {
+                    return messageId(candidate) === anchor.messageId;
+                }
+            );
+            if (!message) return null;
+            if (Number.isSafeInteger(anchor.blockIndex)
+                && anchor.blockIndex >= 0) {
+                return message.querySelectorAll(
+                    '.conversation-markdown > *'
+                )[anchor.blockIndex] || message;
+            }
+            return message;
+        }
+
+        function restore(anchor, fallbackScrollTop) {
+            scroll.scrollTop = fallbackScrollTop;
+            var candidate = findElement(anchor);
+            if (!candidate) return;
+            var scrollBounds = scroll.getBoundingClientRect();
+            var currentTop = candidate.getBoundingClientRect().top
+                - scrollBounds.top;
+            scroll.scrollTop += currentTop - anchor.top;
+        }
+
+        function restoreViewport(anchor, fallbackScrollTop) {
+            scroll.scrollTop = fallbackScrollTop;
+            var candidate = findElement(anchor);
+            if (!candidate || typeof anchor.viewportTop !== 'number') return;
+            scroll.scrollTop += candidate.getBoundingClientRect().top
+                - anchor.viewportTop;
+        }
+
+        return Object.freeze({
+            capture: capture,
+            restore: restore,
+            restoreViewport: restoreViewport,
+        });
+    }
+
+    window.__agentPivotConversationReadingAnchor = Object.freeze({
+        create: create,
+    });
+})();

--- a/src/webview/conversationViewerScripts.js
+++ b/src/webview/conversationViewerScripts.js
@@ -121,10 +121,6 @@
         messageIds: [],
         messageSignatures: new Map(),
         firstNewMessageId: null,
-        mermaidInitialized: false,
-        mermaidObjectUrls: [],
-        mermaidSources: new WeakMap(),
-        mermaidLoad: null,
         renderGeneration: 0,
         comments: [],
         commentRevision: 0,
@@ -148,6 +144,29 @@
         pendingBookmarkRequest: null,
         bookmarksOnly: false,
     };
+    var readingAnchorController =
+        window.__agentPivotConversationReadingAnchor.create({
+            scroll: scroll,
+            messages: messages,
+            messageSelector: conversationMessageSelector,
+            messageId: conversationMessageId,
+        });
+    var captureReadingAnchor = readingAnchorController.capture;
+    var restoreReadingPosition = readingAnchorController.restore;
+    var restoreViewportReadingPosition =
+        readingAnchorController.restoreViewport;
+    var mermaidRenderer = window.__agentPivotConversationMermaid.create({
+        source: mermaidSource,
+        nonce: scriptNonce,
+        messages: messages,
+        scroll: scroll,
+        maxDiagrams: maxMermaidDiagrams,
+        captureAnchor: captureReadingAnchor,
+        restoreAnchor: restoreReadingPosition,
+    });
+    var releaseMermaidObjectUrls = mermaidRenderer.release;
+    var renderMermaidDiagrams = mermaidRenderer.render;
+    var preserveMermaidContent = mermaidRenderer.preserve;
 
     if (!scroll || !messages || !position || !status || !newResponse
         || !previous || !next || !latest || !close || !window.DOMPurify) {
@@ -314,280 +333,6 @@
             node.removeAttribute('src');
         }
     });
-
-    function releaseMermaidObjectUrls(root) {
-        var urls = root
-            ? Array.prototype.map.call(
-                root.querySelectorAll('.conversation-mermaid-image[src^="blob:"]'),
-                function (image) {
-                    return image.src;
-                }
-            )
-            : state.mermaidObjectUrls.slice();
-        var released = new Set(urls);
-        urls.forEach(function (url) {
-            try {
-                URL.revokeObjectURL(url);
-            } catch (_error) {
-                // Revocation is best-effort during document teardown.
-            }
-        });
-        state.mermaidObjectUrls = state.mermaidObjectUrls.filter(
-            function (url) {
-                return !released.has(url);
-            }
-        );
-    }
-
-    function themeValue(name, fallback) {
-        var value = window.getComputedStyle(document.body)
-            .getPropertyValue(name)
-            .trim();
-        return value || fallback;
-    }
-
-    function initializeMermaid() {
-        if (state.mermaidInitialized) return true;
-        if (!window.mermaid
-            || typeof window.mermaid.initialize !== 'function') {
-            return false;
-        }
-        try {
-            window.mermaid.initialize({
-                startOnLoad: false,
-                securityLevel: 'strict',
-                suppressErrorRendering: true,
-                maxTextSize: 50000,
-                htmlLabels: false,
-                theme: 'base',
-                fontFamily: themeValue(
-                    '--vscode-font-family',
-                    'system-ui, sans-serif'
-                ),
-                flowchart: {
-                    htmlLabels: false,
-                },
-                themeVariables: {
-                    darkMode: document.body.classList.contains('vscode-dark')
-                        || document.body.classList.contains(
-                            'vscode-high-contrast'
-                        ),
-                    background: themeValue(
-                        '--vscode-editor-background',
-                        '#1e1e1e'
-                    ),
-                    primaryColor: themeValue(
-                        '--vscode-textCodeBlock-background',
-                        '#252526'
-                    ),
-                    primaryTextColor: themeValue(
-                        '--vscode-editor-foreground',
-                        '#d4d4d4'
-                    ),
-                    primaryBorderColor: themeValue(
-                        '--vscode-panel-border',
-                        '#454545'
-                    ),
-                    lineColor: themeValue(
-                        '--vscode-descriptionForeground',
-                        '#a0a0a0'
-                    ),
-                    secondaryColor: themeValue(
-                        '--vscode-input-background',
-                        '#252526'
-                    ),
-                    tertiaryColor: themeValue(
-                        '--vscode-editor-background',
-                        '#1e1e1e'
-                    ),
-                },
-            });
-            state.mermaidInitialized = true;
-            return true;
-        } catch (_error) {
-            return false;
-        }
-    }
-
-    function loadMermaid() {
-        if (window.mermaid) {
-            return Promise.resolve(initializeMermaid());
-        }
-        if (state.mermaidLoad) return state.mermaidLoad;
-        if (!mermaidSource) return Promise.resolve(false);
-        state.mermaidLoad = new Promise(function (resolve) {
-            var script = document.createElement('script');
-            script.src = mermaidSource;
-            if (scriptNonce) script.nonce = scriptNonce;
-            script.addEventListener('load', function () {
-                resolve(initializeMermaid());
-            }, { once: true });
-            script.addEventListener('error', function () {
-                resolve(false);
-            }, { once: true });
-            document.head.appendChild(script);
-        });
-        return state.mermaidLoad;
-    }
-
-    function mermaidAlt(source) {
-        var summary = source.split(/\r?\n/).map(function (line) {
-            return line.trim();
-        }).find(function (line) {
-            return line.length > 0;
-        }) || 'diagram';
-        return 'Mermaid diagram: ' + summary.slice(0, 120);
-    }
-
-    function normalizeSvg(svg) {
-        var clean = window.DOMPurify.sanitize(svg, {
-            USE_PROFILES: {
-                svg: true,
-                svgFilters: true,
-            },
-            FORBID_TAGS: ['foreignObject', 'script'],
-            ALLOW_DATA_ATTR: false,
-        });
-        var documentValue = new DOMParser().parseFromString(
-            clean,
-            'image/svg+xml'
-        );
-        var root = documentValue.documentElement;
-        if (!root
-            || root.localName !== 'svg'
-            || documentValue.querySelector('parsererror')) {
-            throw new Error('Mermaid returned invalid SVG.');
-        }
-        var viewBox = (root.getAttribute('viewBox') || '')
-            .trim()
-            .split(/[\s,]+/)
-            .map(Number);
-        var width;
-        var height;
-        if (viewBox.length === 4
-            && viewBox.every(Number.isFinite)
-            && viewBox[2] > 0
-            && viewBox[3] > 0) {
-            var scale = Math.min(
-                1,
-                4096 / viewBox[2],
-                4096 / viewBox[3]
-            );
-            width = Math.max(1, Math.round(viewBox[2] * scale));
-            height = Math.max(1, Math.round(viewBox[3] * scale));
-            root.setAttribute('width', String(width));
-            root.setAttribute('height', String(height));
-        }
-        return {
-            svg: new XMLSerializer().serializeToString(root),
-            width: width,
-            height: height,
-        };
-    }
-
-    function renderMermaidDiagram(pre, source, id) {
-        pre.setAttribute('aria-busy', 'true');
-        return Promise.resolve(window.mermaid.render(id, source))
-            .then(function (result) {
-                if (!pre.isConnected) {
-                    return;
-                }
-                var normalized = normalizeSvg(result.svg);
-                var objectUrl = URL.createObjectURL(new Blob([normalized.svg], {
-                    type: 'image/svg+xml',
-                }));
-                if (!pre.isConnected) {
-                    URL.revokeObjectURL(objectUrl);
-                    return;
-                }
-                var figure = document.createElement('figure');
-                figure.className = 'conversation-mermaid';
-                state.mermaidSources.set(figure, source);
-                var image = document.createElement('img');
-                image.className = 'conversation-mermaid-image';
-                if (normalized.width && normalized.height) {
-                    image.width = normalized.width;
-                    image.height = normalized.height;
-                }
-                image.src = objectUrl;
-                image.alt = mermaidAlt(source);
-                image.decoding = 'async';
-                figure.appendChild(image);
-                var decoded = typeof image.decode === 'function'
-                    ? image.decode().catch(function () {})
-                    : Promise.resolve();
-                return decoded.then(function () {
-                    if (!pre.isConnected) {
-                        URL.revokeObjectURL(objectUrl);
-                        return;
-                    }
-                    state.mermaidObjectUrls.push(objectUrl);
-                    var readingAnchor = captureReadingAnchor(pre);
-                    var previousScrollTop = scroll.scrollTop;
-                    pre.replaceWith(figure);
-                    if (readingAnchor
-                        && readingAnchor.element === pre) {
-                        readingAnchor.element = figure;
-                    }
-                    restoreReadingPosition(readingAnchor, previousScrollTop);
-                });
-            })
-            .catch(function () {
-                if (!pre.isConnected) {
-                    return;
-                }
-                pre.removeAttribute('aria-busy');
-                pre.classList.add('conversation-mermaid-error');
-                var label = document.createElement('span');
-                label.className = 'conversation-mermaid-error-label';
-                label.setAttribute('role', 'status');
-                label.textContent = 'Mermaid diagram could not be rendered.';
-                var readingAnchor = captureReadingAnchor();
-                var previousScrollTop = scroll.scrollTop;
-                pre.parentNode.insertBefore(label, pre);
-                restoreReadingPosition(readingAnchor, previousScrollTop);
-                var temporary = document.getElementById(id);
-                if (temporary) temporary.remove();
-            });
-    }
-
-    function renderMermaidDiagrams(generation) {
-        var codeBlocks = Array.prototype.slice.call(
-            messages.querySelectorAll('pre > code.language-mermaid'),
-            0,
-            maxMermaidDiagrams
-        ).filter(function (code) {
-            return code.parentElement
-                && code.parentElement.getAttribute('aria-busy') !== 'true';
-        });
-        if (!codeBlocks.length) return Promise.resolve();
-        codeBlocks.forEach(function (code) {
-            code.parentElement.setAttribute('aria-busy', 'true');
-        });
-        return loadMermaid().then(function (available) {
-            if (!available) {
-                codeBlocks.forEach(function (code) {
-                    if (code.parentElement) {
-                        code.parentElement.removeAttribute('aria-busy');
-                    }
-                });
-                return;
-            }
-            return codeBlocks.reduce(function (promise, code, index) {
-                return promise.then(function () {
-                    if (!code.parentElement
-                        || !code.parentElement.isConnected) {
-                        return undefined;
-                    }
-                    return renderMermaidDiagram(
-                        code.parentElement,
-                        code.textContent || '',
-                        'conversation-mermaid-' + generation + '-' + index
-                    );
-                });
-            }, Promise.resolve());
-        });
-    }
 
     function codeIndentColumns(whitespace) {
         var columns = 0;
@@ -1888,49 +1633,6 @@
         return true;
     }
 
-    function preserveMermaidContent(oldMessage, candidate) {
-        var figuresBySource = new Map();
-        var pendingBySource = new Map();
-        Array.prototype.forEach.call(
-            oldMessage.querySelectorAll('.conversation-mermaid'),
-            function (figure) {
-                var source = state.mermaidSources.get(figure);
-                if (typeof source !== 'string') return;
-                var figures = figuresBySource.get(source) || [];
-                figures.push(figure);
-                figuresBySource.set(source, figures);
-            }
-        );
-        Array.prototype.forEach.call(
-            oldMessage.querySelectorAll(
-                'pre[aria-busy="true"] > code.language-mermaid'
-            ),
-            function (code) {
-                var source = code.textContent || '';
-                var blocks = pendingBySource.get(source) || [];
-                blocks.push(code.parentElement);
-                pendingBySource.set(source, blocks);
-            }
-        );
-        Array.prototype.forEach.call(
-            candidate.querySelectorAll('pre > code.language-mermaid'),
-            function (code) {
-                var source = code.textContent || '';
-                var figures = figuresBySource.get(source);
-                var figure = figures && figures.shift();
-                if (figure && code.parentElement) {
-                    code.parentElement.replaceWith(figure);
-                    return;
-                }
-                var blocks = pendingBySource.get(source);
-                var block = blocks && blocks.shift();
-                if (block && code.parentElement) {
-                    code.parentElement.replaceWith(block);
-                }
-            }
-        );
-    }
-
     function reconcileMessages(clean, preserveUnchanged, previousSignatures) {
         var template = document.createElement('template');
         template.innerHTML = clean;
@@ -1989,126 +1691,6 @@
         });
         messages.replaceChildren(template.content);
         return { ids: nextIds, signatures: nextSignatures };
-    }
-
-    function captureReadingAnchor(replacingElement) {
-        var scrollBounds = scroll.getBoundingClientRect();
-        var blockCandidates = messages.querySelectorAll(
-            '.conversation-markdown > *'
-        );
-        var crossingBlock = null;
-        for (var blockIndex = 0;
-            blockIndex < blockCandidates.length;
-            blockIndex += 1) {
-            var blockBounds = blockCandidates[blockIndex]
-                .getBoundingClientRect();
-            if (!crossingBlock
-                && blockBounds.bottom > scrollBounds.top
-                && blockBounds.top < scrollBounds.bottom) {
-                crossingBlock = blockCandidates[blockIndex];
-            }
-            if (blockCandidates[blockIndex] !== replacingElement
-                && blockBounds.top >= scrollBounds.top
-                && blockBounds.top < scrollBounds.bottom) {
-                var message = blockCandidates[blockIndex].closest(
-                    conversationMessageSelector()
-                );
-                return {
-                    element: blockCandidates[blockIndex],
-                    messageId: message
-                        ? conversationMessageId(message)
-                        : null,
-                    blockIndex: message
-                        ? Array.prototype.indexOf.call(
-                            message.querySelectorAll(
-                                '.conversation-markdown > *'
-                            ),
-                            blockCandidates[blockIndex]
-                        )
-                        : -1,
-                    top: blockBounds.top - scrollBounds.top,
-                    viewportTop: blockBounds.top,
-                };
-            }
-        }
-        if (crossingBlock) {
-            var crossingMessage = crossingBlock.closest(
-                conversationMessageSelector()
-            );
-            var crossingBounds = crossingBlock.getBoundingClientRect();
-            return {
-                element: crossingBlock,
-                messageId: crossingMessage
-                    ? conversationMessageId(crossingMessage)
-                    : null,
-                blockIndex: crossingMessage
-                    ? Array.prototype.indexOf.call(
-                        crossingMessage.querySelectorAll(
-                            '.conversation-markdown > *'
-                        ),
-                        crossingBlock
-                    )
-                    : -1,
-                top: crossingBounds.top - scrollBounds.top,
-                viewportTop: crossingBounds.top,
-            };
-        }
-        var messageCandidates = messages.querySelectorAll(
-            conversationMessageSelector()
-        );
-        for (var index = 0; index < messageCandidates.length; index += 1) {
-            var bounds = messageCandidates[index].getBoundingClientRect();
-            if (bounds.bottom > scrollBounds.top) {
-                return {
-                    element: messageCandidates[index],
-                    messageId: conversationMessageId(
-                        messageCandidates[index]
-                    ),
-                    top: bounds.top - scrollBounds.top,
-                    viewportTop: bounds.top,
-                };
-            }
-        }
-        return null;
-    }
-
-    function readingAnchorElement(anchor) {
-        if (!anchor) return null;
-        if (anchor.element && anchor.element.isConnected) {
-            return anchor.element;
-        }
-        var message = Array.prototype.find.call(
-            messages.querySelectorAll(conversationMessageSelector()),
-            function (candidate) {
-                return conversationMessageId(candidate) === anchor.messageId;
-            }
-        );
-        if (!message) return null;
-        if (Number.isSafeInteger(anchor.blockIndex)
-            && anchor.blockIndex >= 0) {
-            return message.querySelectorAll(
-                '.conversation-markdown > *'
-            )[anchor.blockIndex] || message;
-        }
-        return message;
-    }
-
-    function restoreReadingPosition(anchor, fallbackScrollTop) {
-        scroll.scrollTop = fallbackScrollTop;
-        var candidate = readingAnchorElement(anchor);
-        if (!candidate) return;
-        var scrollBounds = scroll.getBoundingClientRect();
-        var currentTop = candidate.getBoundingClientRect().top
-            - scrollBounds.top;
-        scroll.scrollTop += currentTop - anchor.top;
-    }
-
-    function restoreViewportReadingPosition(anchor, fallbackScrollTop) {
-        scroll.scrollTop = fallbackScrollTop;
-        var candidate = readingAnchorElement(anchor);
-        if (!candidate || typeof anchor.viewportTop !== 'number') return;
-        scroll.scrollTop += candidate.getBoundingClientRect().top
-            - anchor.viewportTop;
     }
 
     function updatePosition(message) {

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -175,6 +175,38 @@ async function openViewerPage(t, options = {}) {
             },
         };
     });
+    if (options.trackResources) {
+        await page.evaluate(() => {
+            const metrics = {
+                addEventListenerCalls: 0,
+                removeEventListenerCalls: 0,
+                createdObjectUrls: 0,
+                revokedObjectUrls: 0,
+            };
+            const addEventListener = EventTarget.prototype.addEventListener;
+            const removeEventListener =
+                EventTarget.prototype.removeEventListener;
+            const createObjectURL = URL.createObjectURL.bind(URL);
+            const revokeObjectURL = URL.revokeObjectURL.bind(URL);
+            EventTarget.prototype.addEventListener = function (...args) {
+                metrics.addEventListenerCalls += 1;
+                return addEventListener.apply(this, args);
+            };
+            EventTarget.prototype.removeEventListener = function (...args) {
+                metrics.removeEventListenerCalls += 1;
+                return removeEventListener.apply(this, args);
+            };
+            URL.createObjectURL = function (blob) {
+                metrics.createdObjectUrls += 1;
+                return createObjectURL(blob);
+            };
+            URL.revokeObjectURL = function (url) {
+                metrics.revokedObjectUrls += 1;
+                return revokeObjectURL(url);
+            };
+            window.__conversationResourceMetrics = metrics;
+        });
+    }
     await page.addScriptTag({ content: purifyScript });
     if (options.controlledMermaid) {
         await page.evaluate(() => {
@@ -2673,6 +2705,102 @@ test('CONVERSATION-READING-FOCUS-001 leaves an identical refresh DOM and descend
     assert.equal(
         await page.evaluate(() => document.activeElement?.textContent),
         'Stable reading link'
+    );
+});
+
+test('CONVERSATION-REFRESH-PERFORMANCE-001 keeps DOM, Blob URLs, and listeners constant across 100 identical refreshes', async t => {
+    const page = await openViewerPage(t, {
+        controlledMermaid: true,
+        trackResources: true,
+    });
+    const html = `<article data-message-id="stable-performance"
+        data-interaction-id="input-4">
+        <section class="conversation-markdown">
+            <p><a href="https://example.com/stable-performance">
+                Stable performance anchor
+            </a></p>
+            <pre><code class="language-mermaid">flowchart LR
+                A[Stable] --&gt; B[No redraw]</code></pre>
+        </section>
+    </article>` + messageHtml('stable-performance-tail', 25);
+    await sendPage(page, {
+        ...hostileConversationPage,
+        html,
+        selectedInput: 25,
+        totalInputs: 25,
+        updateKind: 'initial',
+    });
+    await page.waitForFunction(() => window.__mermaidRenders.length === 1);
+    await page.evaluate(() => {
+        window.__mermaidRenders[0].resolve({
+            svg: `<svg xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 600 400">
+                <rect width="600" height="400" fill="#246"></rect>
+            </svg>`,
+        });
+    });
+    await page.locator('.conversation-mermaid-image').waitFor();
+    const link = page.getByRole('link', {
+        name: 'Stable performance anchor',
+    });
+    await link.focus();
+    const baseline = await page.evaluate(() => {
+        const root = document.querySelector('[data-conversation-messages]');
+        window.__stableConversationRoot = root;
+        window.__stableConversationNodes = Array.from(
+            root.querySelectorAll('*')
+        );
+        return {
+            nodeCount: root.querySelectorAll('*').length,
+            metrics: { ...window.__conversationResourceMetrics },
+        };
+    });
+
+    await page.evaluate(({ payload, refreshHtml }) => {
+        for (let index = 0; index < 100; index += 1) {
+            window.dispatchEvent(new MessageEvent('message', {
+                data: {
+                    ...payload,
+                    requestId: index + 2,
+                    html: refreshHtml,
+                    selectedInput: 25,
+                    totalInputs: 25,
+                    updateKind: 'refresh',
+                },
+            }));
+        }
+    }, {
+        payload: hostileConversationPage,
+        refreshHtml: html,
+    });
+    await page.evaluate(() => new Promise(resolve => {
+        requestAnimationFrame(() => requestAnimationFrame(resolve));
+    }));
+
+    assert.deepEqual(
+        await page.evaluate(() => {
+            const root = document.querySelector(
+                '[data-conversation-messages]'
+            );
+            const nodes = Array.from(root.querySelectorAll('*'));
+            return {
+                sameRoot: root === window.__stableConversationRoot,
+                sameNodes: nodes.length
+                    === window.__stableConversationNodes.length
+                    && nodes.every((node, index) =>
+                        node === window.__stableConversationNodes[index]),
+                nodeCount: nodes.length,
+                metrics: { ...window.__conversationResourceMetrics },
+                focusedText: document.activeElement?.textContent.trim(),
+            };
+        }),
+        {
+            sameRoot: true,
+            sameNodes: true,
+            nodeCount: baseline.nodeCount,
+            metrics: baseline.metrics,
+            focusedText: 'Stable performance anchor',
+        }
     );
 });
 

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -19,6 +19,17 @@ const viewerScript = fs.readFileSync(
     path.join(__dirname, '../../src/webview/conversationViewerScripts.js'),
     'utf8'
 );
+const readingAnchorScript = fs.readFileSync(
+    path.join(
+        __dirname,
+        '../../src/webview/conversationReadingAnchorScripts.js'
+    ),
+    'utf8'
+);
+const conversationMermaidScript = fs.readFileSync(
+    path.join(__dirname, '../../src/webview/conversationMermaidScripts.js'),
+    'utf8'
+);
 const viewerCss = fs.readFileSync(
     path.join(__dirname, '../../media/conversationViewer.css'),
     'utf8'
@@ -223,6 +234,8 @@ async function openViewerPage(t, options = {}) {
     } else if (options.includeMermaid) {
         await page.addScriptTag({ content: mermaidScript });
     }
+    await page.addScriptTag({ content: readingAnchorScript });
+    await page.addScriptTag({ content: conversationMermaidScript });
     await page.addScriptTag({ content: viewerScript });
     await page.locator('script').evaluateAll(elements =>
         elements.forEach(element => element.remove()));
@@ -514,6 +527,20 @@ async function openHostViewerDocument(t, options = {}) {
             await route.fulfill({
                 contentType: 'text/javascript',
                 body: viewerScript,
+            });
+            return;
+        }
+        if (pathname === '/conversationReadingAnchorScripts.js') {
+            await route.fulfill({
+                contentType: 'text/javascript',
+                body: readingAnchorScript,
+            });
+            return;
+        }
+        if (pathname === '/conversationMermaidScripts.js') {
+            await route.fulfill({
+                contentType: 'text/javascript',
+                body: conversationMermaidScript,
             });
             return;
         }

--- a/tests/integration/dashboard/conversationViewer.test.js
+++ b/tests/integration/dashboard/conversationViewer.test.js
@@ -782,6 +782,19 @@ test('CONVERSATION-VIEWER-SECURITY-001 emits a nonce-only CSP and opens only HTT
         panel.webview.html,
         /href="webview:\/\/fixture\/\/extension\/media\/conversationViewer\.css"/
     );
+    const purifyIndex = panel.webview.html.indexOf('purify.min.js');
+    const readingAnchorIndex = panel.webview.html.indexOf(
+        'conversationReadingAnchorScripts.js'
+    );
+    const mermaidControllerIndex = panel.webview.html.indexOf(
+        'conversationMermaidScripts.js'
+    );
+    const viewerIndex = panel.webview.html.indexOf(
+        'conversationViewerScripts.js'
+    );
+    assert.ok(purifyIndex >= 0 && purifyIndex < readingAnchorIndex);
+    assert.ok(readingAnchorIndex < mermaidControllerIndex);
+    assert.ok(mermaidControllerIndex < viewerIndex);
 
     for (const href of [
         'javascript:alert(1)',
@@ -799,6 +812,20 @@ test('CONVERSATION-VIEWER-SECURITY-001 emits a nonce-only CSP and opens only HTT
     }
 
     assert.deepEqual(openedUris, ['https://example.test/safe']);
+});
+
+test('CONVERSATION-READING-FOCUS-001 keeps modular Webview controllers byte-identical in packaged media', () => {
+    for (const fileName of [
+        'conversationReadingAnchorScripts.js',
+        'conversationMermaidScripts.js',
+        'conversationViewerScripts.js',
+    ]) {
+        assert.equal(
+            fs.readFileSync(path.join('media', fileName), 'utf8'),
+            fs.readFileSync(path.join('src', 'webview', fileName), 'utf8'),
+            `${fileName} is stale in media`
+        );
+    }
 });
 
 test('CONVERSATION-VIEWER-REFRESH-001 retains stale content after a watched failure and clears stale after recovery', async () => {

--- a/tests/unit/aiSessions/conversationViewerProtocol.test.js
+++ b/tests/unit/aiSessions/conversationViewerProtocol.test.js
@@ -1,0 +1,109 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {
+    parseConversationViewerMessage,
+} = require('../../../out/aiSessions/conversation/viewerProtocol');
+
+const target = Object.freeze({
+    requestId: 'request-1',
+    subscriptionGeneration: 1,
+    projectId: 'project-a',
+    provider: 'codex',
+    sessionId: 'session-a',
+});
+
+test('CONVERSATION-PROTOCOL-VALIDATOR-001 accepts every exact version-1 viewer intent', () => {
+    const messages = [{
+        type: 'conversation-viewer-previous',
+        version: 1,
+    }, {
+        type: 'conversation-viewer-select-interaction',
+        version: 1,
+        interactionId: 'input-1',
+    }, {
+        type: 'conversation-viewer-open-link',
+        version: 1,
+        href: 'https://example.test',
+    }, {
+        type: 'conversation-viewer-locate-comment',
+        version: 1,
+        ...target,
+        commentId: 'comment-1',
+    }, {
+        type: 'conversation-viewer-bookmark-mutation',
+        version: 1,
+        ...target,
+        operation: 'set',
+        expectedRevision: 2,
+        payload: {
+            interactionId: 'input-1',
+            bookmarked: true,
+        },
+    }, {
+        type: 'conversation-viewer-comment-mutation',
+        version: 1,
+        ...target,
+        operation: 'resolve',
+        expectedRevision: 2,
+        payload: { commentId: 'comment-1' },
+    }, {
+        type: 'conversation-viewer-send-comments',
+        version: 1,
+        ...target,
+        operation: 'sendComments',
+        expectedRevision: 2,
+        payload: {},
+    }];
+
+    assert.deepEqual(
+        messages.map(message => parseConversationViewerMessage(message)),
+        messages
+    );
+});
+
+test('CONVERSATION-PROTOCOL-VALIDATOR-001 rejects malformed, inherited, and over-posted viewer intents', () => {
+    const inheritedNavigation = Object.create({
+        type: 'conversation-viewer-next',
+        version: 1,
+    });
+    const malformed = [
+        null,
+        [],
+        inheritedNavigation,
+        {
+            type: 'conversation-viewer-latest',
+            version: 1,
+            extra: true,
+        },
+        {
+            type: 'conversation-viewer-select-interaction',
+            version: 1,
+            interactionId: 'input\u0000private',
+        },
+        {
+            type: 'conversation-viewer-bookmark-mutation',
+            version: 1,
+            ...target,
+            operation: 'set',
+            expectedRevision: 2,
+            payload: {
+                interactionId: 'input-1',
+                bookmarked: 'yes',
+            },
+        },
+        {
+            type: 'conversation-viewer-send-comments',
+            version: 1,
+            ...target,
+            operation: 'sendComments',
+            expectedRevision: 2,
+            payload: { submit: true },
+        },
+    ];
+
+    malformed.forEach(message => {
+        assert.equal(parseConversationViewerMessage(message), undefined);
+    });
+});


### PR DESCRIPTION
## Summary

- isolate and strictly validate the Conversation viewer protocol
- split host comment/bookmark ownership and Webview reading-anchor/Mermaid lifecycle
- add identity-preserving refresh performance coverage and exact release asset auditing

## Validation

- npm run test:deterministic (280 passed)
- npm run test:browser:run (119 passed)
- npm run test:behavior-contracts
- npm run test:release-packaging
- npm run vscode:prepublish
- npm run test:coverage:run && node scripts/check-coverage-baseline.js
- built and byte-verified hzcheng.agent-pivot@1.0.1 in the active Dev Container host

## Workflow harvest

No skill update is justified. Existing browser and release-packaging gates caught the two task-local extraction/packaging mistakes, and the applicable workflow already requires fresh full verification.