### PR TITLE
test: add large conversation performance budgets

### DIFF
--- a/.ci/conversation-performance.json
+++ b/.ci/conversation-performance.json
@@ -1,0 +1,10 @@
+{
+  "adapterColdOutlineMs": 1500,
+  "adapterCachedOutlineMs": 100,
+  "adapterAppendMs": 250,
+  "hostInitialPublicationMs": 250,
+  "hostIncrementalRefreshMs": 150,
+  "hostSessionSwitchMs": 250,
+  "webviewInitialPublicationMs": 500,
+  "webviewIncrementalRefreshMs": 250
+}

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -3655,7 +3655,8 @@
     "status": "automated",
     "owners": [
       "scripts/run-conversation-performance-checks.js",
-      "tests/browser/conversationViewer.test.js"
+      "tests/browser/conversationViewer.test.js",
+      "tests/unit/tooling/conversationPerformance.test.js"
     ],
     "evidence": [
       ".ci/conversation-performance.json",

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -3648,6 +3648,22 @@
     ]
   },
   {
+    "id": "CONVERSATION-LARGE-SESSION-PERFORMANCE-001",
+    "domain": "webview",
+    "title": "Large AI Conversations keep Host initial publication, incremental refresh, Session switching, and Webview application within reviewed performance budgets",
+    "priority": "P0",
+    "status": "automated",
+    "owners": [
+      "scripts/run-conversation-performance-checks.js",
+      "tests/browser/conversationViewer.test.js"
+    ],
+    "evidence": [
+      ".ci/conversation-performance.json",
+      "src/aiSessions/conversation/viewer.ts",
+      "src/webview/conversationViewerScripts.js"
+    ]
+  },
+  {
     "id": "CONVERSATION-OUTLINE-DELIVERY-001",
     "domain": "webview",
     "title": "Undelivered initial conversation outline results remain retryable after authoritative Dashboard replacement instead of stranding Loading",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "fed784c668dc7cf1dade22270d23565e485751a4",
+        "head": "33b7f5ae707f757762878bf4c5f24342c2fdb321",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -979,7 +979,8 @@
         "2083ec487f4e3bd894614cb2bac3053e9c020636",
         "e2c8e97cc289445e9506364a6e44f012c9dbf0bc",
         "b9a911e41f924864633f0e7b9c4552e1405b534c",
-                "cc399e86dc85f92bad836769bd93c420e08695e3"
+                "cc399e86dc85f92bad836769bd93c420e08695e3",
+                "33b7f5ae707f757762878bf4c5f24342c2fdb321"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",
@@ -992,6 +993,7 @@
                 "CONVERSATION-VIEWER-LOADING-001",
                 "CONVERSATION-PROTOCOL-VALIDATOR-001",
                 "CONVERSATION-REFRESH-PERFORMANCE-001",
+                "CONVERSATION-LARGE-SESSION-PERFORMANCE-001",
                 "CONVERSATION-COMMENTS-DOM-STABILITY-001",
                 "CONVERSATION-OUTLINE-DELIVERY-001",
                 "CONVERSATION-VIEWER-USER-EMPHASIS-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "9cd6c9716c7e9f27f41bbe0968f6f126e6717e5d",
+        "head": "39bbfcebb2bf0b28e21513e905aa620d7b6eab83",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -981,7 +981,8 @@
         "b9a911e41f924864633f0e7b9c4552e1405b534c",
                 "cc399e86dc85f92bad836769bd93c420e08695e3",
                 "33b7f5ae707f757762878bf4c5f24342c2fdb321",
-                "9cd6c9716c7e9f27f41bbe0968f6f126e6717e5d"
+                "9cd6c9716c7e9f27f41bbe0968f6f126e6717e5d",
+                "39bbfcebb2bf0b28e21513e905aa620d7b6eab83"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "33b7f5ae707f757762878bf4c5f24342c2fdb321",
+        "head": "9cd6c9716c7e9f27f41bbe0968f6f126e6717e5d",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -980,7 +980,8 @@
         "e2c8e97cc289445e9506364a6e44f012c9dbf0bc",
         "b9a911e41f924864633f0e7b9c4552e1405b534c",
                 "cc399e86dc85f92bad836769bd93c420e08695e3",
-                "33b7f5ae707f757762878bf4c5f24342c2fdb321"
+                "33b7f5ae707f757762878bf4c5f24342c2fdb321",
+                "9cd6c9716c7e9f27f41bbe0968f6f126e6717e5d"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",

--- a/scripts/run-conversation-performance-checks.js
+++ b/scripts/run-conversation-performance-checks.js
@@ -22,6 +22,12 @@ const {
 
 const MIB = 1024 * 1024;
 const sessionId = '11111111-1111-4111-8111-111111111111';
+const PERFORMANCE_BUDGETS = JSON.parse(fs.readFileSync(path.join(
+    __dirname,
+    '..',
+    '.ci',
+    'conversation-performance.json'
+), 'utf8'));
 const canonicalKimiFixturePath = path.join(
     __dirname,
     '..',
@@ -121,7 +127,7 @@ function createKimiAdapter(providerHome, sourcePath) {
 
 function loadConversationViewer() {
     const fakeVscode = {
-        ViewColumn: { Beside: 2 },
+        ViewColumn: { Active: 1, Beside: 2 },
         Uri: { parse: value => ({ scheme: 'https', toString: () => value }) },
     };
     const previousLoad = Module._load;
@@ -141,7 +147,23 @@ function retainedViewerSnapshot() {
     const ConversationViewer = loadConversationViewer();
     const viewer = new ConversationViewer({});
     const padding = 'v'.repeat(48_000);
-    viewer.selectedInteractionId = 'retained-100';
+    const retainedInteractionIds = Array.from(
+        { length: 101 },
+        (_item, index) => `retained-${index}`
+    );
+    assert.equal(viewer.outlineController.replace({
+        provider: 'kimi',
+        sessionId,
+        sourceRevision: 'r1',
+        interactions: retainedInteractionIds.map(id => ({
+            id,
+            userPreview: id,
+            userGraphemeCount: id.length,
+            responseState: 'complete',
+        })),
+        totalInteractions: retainedInteractionIds.length,
+        partial: false,
+    }, 'retained-100'), true);
     viewer.pages = Array.from({ length: 101 }, (_item, index) => ({
         page: {
             provider: 'kimi',
@@ -166,7 +188,171 @@ function retainedViewerSnapshot() {
     return {
         retainedInteractions: viewer.snapshotSize,
         retainedBytes: viewer.snapshotBytes(),
+        retainedAnchor: viewer.interactionIds().includes('retained-100'),
     };
+}
+
+function assertBudget(name, measuredMs, budgetMs) {
+    assert.ok(Number.isFinite(budgetMs) && budgetMs > 0,
+        `${name} budget must be a positive finite number`);
+    assert.ok(measuredMs <= budgetMs,
+        `${name} ${measuredMs.toFixed(3)}ms exceeds ${budgetMs}ms`);
+}
+
+function viewerTarget(targetSessionId) {
+    return {
+        projectId: 'performance-project',
+        provider: 'kimi',
+        sessionId: targetSessionId,
+        interactionId: `${targetSessionId}-1999`,
+        expectedRevision: 'r1',
+        displayName: 'Performance Session',
+        duplicateDisplayName: false,
+    };
+}
+
+function performanceOutline(targetSessionId, revision) {
+    return {
+        provider: 'kimi',
+        sessionId: targetSessionId,
+        sourceRevision: revision,
+        interactions: Array.from({ length: 2_000 }, (_item, index) => ({
+            id: `${targetSessionId}-${index}`,
+            userPreview: `Performance prompt ${index}`,
+            userGraphemeCount: 23,
+            responseState: index === 1_999 ? 'inProgress' : 'complete',
+        })),
+        totalInteractions: 2_000,
+        partial: false,
+    };
+}
+
+function performancePage(request, revision) {
+    const firstIndex = 1_980;
+    const interactionIds = Array.from(
+        { length: CONVERSATION_LIMITS.maxPageInteractions },
+        (_item, index) => `${request.sessionId}-${firstIndex + index}`
+    );
+    return {
+        provider: 'kimi',
+        sessionId: request.sessionId,
+        sourceRevision: revision,
+        anchorInteractionId: request.anchorInteractionId,
+        messages: interactionIds.flatMap((interactionId, index) => [{
+            id: `${interactionId}:user`,
+            interactionId,
+            role: 'user',
+            markdown: `Performance prompt ${firstIndex + index}`,
+        }, {
+            id: `${interactionId}:assistant`,
+            interactionId,
+            role: 'assistant',
+            markdown: `Performance response ${firstIndex + index} ${'x'.repeat(2_000)}`,
+        }]),
+        interactionStates: interactionIds.map(interactionId => ({
+            interactionId,
+            responseState: interactionId === request.anchorInteractionId
+                ? 'inProgress'
+                : 'complete',
+        })),
+        isStart: false,
+        isEnd: true,
+    };
+}
+
+function performancePanel() {
+    const disposeListeners = new Set();
+    return {
+        visible: true,
+        title: '',
+        webview: {
+            html: '',
+            cspSource: 'performance-csp',
+            onDidReceiveMessage() {
+                return { dispose() {} };
+            },
+            postMessage() {
+                return Promise.resolve(true);
+            },
+            asWebviewUri(uri) {
+                return uri;
+            },
+        },
+        reveal() {},
+        onDidChangeViewState() {
+            return { dispose() {} };
+        },
+        onDidDispose(listener) {
+            disposeListeners.add(listener);
+            return { dispose: () => disposeListeners.delete(listener) };
+        },
+        dispose() {
+            Array.from(disposeListeners).forEach(listener => listener());
+            disposeListeners.clear();
+        },
+    };
+}
+
+async function measureViewerPublicationBudgets() {
+    // CONVERSATION-LARGE-SESSION-PERFORMANCE-001
+    const ConversationViewer = loadConversationViewer();
+    const panel = performancePanel();
+    const revisions = new Map([
+        ['large-session-a', 'r1'],
+        ['large-session-b', 'r1'],
+    ]);
+    const viewer = new ConversationViewer({
+        createPanel: () => panel,
+        readOutline: async (_provider, targetSessionId) =>
+            performanceOutline(targetSessionId, revisions.get(targetSessionId)),
+        readPage: async request => performancePage(
+            request,
+            revisions.get(request.sessionId)
+        ),
+        watch: () => ({ dispose() {} }),
+        restoreFocus() {},
+        openExternal: async () => true,
+        mediaUri: fileName => ({
+            toString: () => `file:///performance/${fileName}`,
+        }),
+        submitPrompt: async () => {},
+    });
+    try {
+        let startedAt = process.hrtime.bigint();
+        await viewer.open(viewerTarget('large-session-a'));
+        const hostInitialPublicationMs = elapsedMs(startedAt);
+        assertBudget(
+            'host initial publication',
+            hostInitialPublicationMs,
+            PERFORMANCE_BUDGETS.hostInitialPublicationMs
+        );
+
+        revisions.set('large-session-a', 'r2');
+        startedAt = process.hrtime.bigint();
+        await viewer.refresh();
+        const hostIncrementalRefreshMs = elapsedMs(startedAt);
+        assertBudget(
+            'host incremental refresh',
+            hostIncrementalRefreshMs,
+            PERFORMANCE_BUDGETS.hostIncrementalRefreshMs
+        );
+
+        startedAt = process.hrtime.bigint();
+        assert.equal(await viewer.follow(viewerTarget('large-session-b')), true);
+        const hostSessionSwitchMs = elapsedMs(startedAt);
+        assertBudget(
+            'host Session switch',
+            hostSessionSwitchMs,
+            PERFORMANCE_BUDGETS.hostSessionSwitchMs
+        );
+        return {
+            hostInitialPublicationMs,
+            hostIncrementalRefreshMs,
+            hostSessionSwitchMs,
+        };
+    } finally {
+        viewer.dispose();
+    }
 }
 
 async function run() {
@@ -194,15 +380,15 @@ async function run() {
             let outline = await adapter.readOutline(sessionId);
             const coldMs = elapsedMs(startedAt);
             assert.equal(outline.totalInteractions, 1_000);
-            assert.ok(coldMs <= 1500,
-                `cold outline ${coldMs}ms exceeds 1500ms`);
+            assertBudget('cold outline', coldMs,
+                PERFORMANCE_BUDGETS.adapterColdOutlineMs);
 
             startedAt = process.hrtime.bigint();
             outline = await adapter.readOutline(sessionId);
             const cachedOutlineReadMs = elapsedMs(startedAt);
             assert.equal(outline.totalInteractions, 1_000);
-            assert.ok(cachedOutlineReadMs <= 100,
-                `cached adapter outline read ${cachedOutlineReadMs}ms exceeds 100ms`);
+            assertBudget('cached adapter outline read', cachedOutlineReadMs,
+                PERFORMANCE_BUDGETS.adapterCachedOutlineMs);
 
             const append = paddedFixture([
                 interactionBytes(templates, 1_000, 60_000),
@@ -213,8 +399,8 @@ async function run() {
             outline = await adapter.readOutline(sessionId);
             const appendMs = elapsedMs(startedAt);
             assert.equal(outline.totalInteractions, 1_001);
-            assert.ok(appendMs <= 250,
-                `append ${appendMs}ms exceeds 250ms`);
+            assertBudget('append', appendMs,
+                PERFORMANCE_BUDGETS.adapterAppendMs);
             assert.ok(outline.interactions.length <= 2000);
 
             const page = await adapter.readPage({
@@ -308,6 +494,8 @@ async function run() {
             const retention = retainedViewerSnapshot();
             assert.ok(retention.retainedInteractions <= 100);
             assert.ok(retention.retainedBytes <= 4 * 1024 * 1024);
+            assert.equal(retention.retainedAnchor, true);
+            const viewerBudgets = await measureViewerPublicationBudgets();
 
             console.log(JSON.stringify({
                 coldMs: Number(coldMs.toFixed(3)),
@@ -326,6 +514,15 @@ async function run() {
                     boundaryOutline.totalInteractions,
                 oversizedOutlineInteractions:
                     oversizedOutline.totalInteractions,
+                hostInitialPublicationMs: Number(
+                    viewerBudgets.hostInitialPublicationMs.toFixed(3)
+                ),
+                hostIncrementalRefreshMs: Number(
+                    viewerBudgets.hostIncrementalRefreshMs.toFixed(3)
+                ),
+                hostSessionSwitchMs: Number(
+                    viewerBudgets.hostSessionSwitchMs.toFixed(3)
+                ),
                 ...retention,
             }));
         } finally {

--- a/scripts/run-conversation-performance-checks.js
+++ b/scripts/run-conversation-performance-checks.js
@@ -533,7 +533,15 @@ async function run() {
     }
 }
 
-run().catch(error => {
-    console.error(error && error.stack ? error.stack : error);
-    process.exitCode = 1;
-});
+if (require.main === module) {
+    run().catch(error => {
+        console.error(error && error.stack ? error.stack : error);
+        process.exitCode = 1;
+    });
+}
+
+module.exports = {
+    assertBudget,
+    measureViewerPublicationBudgets,
+    retainedViewerSnapshot,
+};

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -38,6 +38,10 @@ const telemetryCss = fs.readFileSync(
     path.join(__dirname, '../../media/conversationTelemetry.css'),
     'utf8'
 );
+const conversationPerformanceBudgets = JSON.parse(fs.readFileSync(
+    path.join(__dirname, '../../.ci/conversation-performance.json'),
+    'utf8'
+));
 const viewerThemeFixtures = Object.freeze([
     Object.freeze({
         name: 'dark',
@@ -2903,6 +2907,60 @@ test('CONVERSATION-REFRESH-PERFORMANCE-001 keeps DOM, Blob URLs, and listeners c
             metrics: baseline.metrics,
             focusedText: 'Stable performance anchor',
         }
+    );
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 bounds initial and incremental Webview publication work', async t => {
+    const page = await openViewerPage(t);
+    const largeMessageHtml = count => Array.from(
+        { length: count },
+        (_item, index) => `<article
+            class="conversation-message conversation-message-assistant"
+            data-message-id="large-${index}"
+            data-interaction-id="input-${index}">
+            <section class="conversation-markdown"><p>
+                Large response ${index} ${'x'.repeat(2_000)}
+            </p></section>
+        </article>`
+    ).join('');
+    const initialHtml = largeMessageHtml(100);
+    const measurePublication = payload => page.evaluate(message => {
+        const startedAt = performance.now();
+        window.dispatchEvent(new MessageEvent('message', { data: message }));
+        document.querySelector('[data-conversation-messages]').offsetHeight;
+        return performance.now() - startedAt;
+    }, payload);
+    const initialMs = await measurePublication({
+        ...hostileConversationPage,
+        html: initialHtml,
+        selectedInput: 100,
+        totalInputs: 2_000,
+        updateKind: 'initial',
+    });
+    assert.ok(
+        initialMs <= conversationPerformanceBudgets.webviewInitialPublicationMs,
+        `initial Webview publication ${initialMs}ms exceeds `
+            + `${conversationPerformanceBudgets.webviewInitialPublicationMs}ms`
+    );
+
+    const incrementalMs = await measurePublication({
+        ...hostileConversationPage,
+        requestId: 2,
+        html: initialHtml + largeMessageHtml(1).replaceAll('large-0', 'large-100')
+            .replaceAll('input-0', 'input-100'),
+        selectedInput: 100,
+        totalInputs: 2_000,
+        updateKind: 'refresh',
+    });
+    assert.ok(
+        incrementalMs
+            <= conversationPerformanceBudgets.webviewIncrementalRefreshMs,
+        `incremental Webview publication ${incrementalMs}ms exceeds `
+            + `${conversationPerformanceBudgets.webviewIncrementalRefreshMs}ms`
+    );
+    assert.equal(
+        await page.locator('[data-conversation-messages] > article').count(),
+        101
     );
 });
 

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -2912,16 +2912,19 @@ test('CONVERSATION-REFRESH-PERFORMANCE-001 keeps DOM, Blob URLs, and listeners c
 
 test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 bounds initial and incremental Webview publication work', async t => {
     const page = await openViewerPage(t);
-    const largeMessageHtml = count => Array.from(
+    const largeMessageHtml = (count, startIndex = 0) => Array.from(
         { length: count },
-        (_item, index) => `<article
+        (_item, offset) => {
+            const index = startIndex + offset;
+            return `<article
             class="conversation-message conversation-message-assistant"
             data-message-id="large-${index}"
             data-interaction-id="input-${index}">
             <section class="conversation-markdown"><p>
                 Large response ${index} ${'x'.repeat(2_000)}
             </p></section>
-        </article>`
+        </article>`;
+        }
     ).join('');
     const initialHtml = largeMessageHtml(100);
     const measurePublication = payload => page.evaluate(message => {
@@ -2946,8 +2949,7 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 bounds initial and incremental 
     const incrementalMs = await measurePublication({
         ...hostileConversationPage,
         requestId: 2,
-        html: initialHtml + largeMessageHtml(1).replaceAll('large-0', 'large-100')
-            .replaceAll('input-0', 'input-100'),
+        html: initialHtml + largeMessageHtml(1, 100),
         selectedInput: 100,
         totalInputs: 2_000,
         updateKind: 'refresh',

--- a/tests/unit/tooling/conversationPerformance.test.js
+++ b/tests/unit/tooling/conversationPerformance.test.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {
+    assertBudget,
+    measureViewerPublicationBudgets,
+    retainedViewerSnapshot,
+} = require('../../../scripts/run-conversation-performance-checks');
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 retains the reading anchor while enforcing viewer bounds', () => {
+    const snapshot = retainedViewerSnapshot();
+    assert.equal(snapshot.retainedAnchor, true);
+    assert.ok(snapshot.retainedInteractions <= 100);
+    assert.ok(snapshot.retainedBytes <= 4 * 1024 * 1024);
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 measures Host publication paths and rejects invalid budgets', async () => {
+    assert.doesNotThrow(() => assertBudget('fast path', 1, 2));
+    assert.throws(() => assertBudget('missing', 1, undefined), /positive/);
+    assert.throws(() => assertBudget('slow path', 3, 2), /exceeds/);
+
+    const measurements = await measureViewerPublicationBudgets();
+    assert.ok(measurements.hostInitialPublicationMs >= 0);
+    assert.ok(measurements.hostIncrementalRefreshMs >= 0);
+    assert.ok(measurements.hostSessionSwitchMs >= 0);
+});


### PR DESCRIPTION
## Summary
- centralize reviewed adapter, Host, and Webview conversation performance budgets
- gate 2,000-input initial publication, incremental refresh, Session switching, and 200 KB Webview updates
- retain the selected reading anchor under snapshot eviction and instrument the performance gate for changed-code coverage

## Verification
- npm run test:ci:linux
- changed line coverage: 89.86% (195/217)
- focused Conversation browser suite: 36/36 passed

No product runtime behavior or release version changes.