### PR TITLE
fix: synchronise AI session status surfaces

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -1042,6 +1042,20 @@
     ]
   },
   {
+    "id": "ATTENTION-EXECUTION-STATE-SYNC-001",
+    "domain": "attention",
+    "title": "Attention settles on the same lifecycle edge that starts the running animation",
+    "priority": "P0",
+    "status": "automated",
+    "owners": [
+      "tests/contract/aiSessions/attention.test.js"
+    ],
+    "evidence": [
+      "src/aiSessions/attentionEvaluationQueue.ts",
+      "src/aiSessions/executionController.ts"
+    ]
+  },
+  {
     "id": "SESSION-AI-SESSION-EXECUTION-MONITOR-001",
     "domain": "session",
     "title": "AI Session Execution Monitor behavior",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "14622809706f9e9c792d6e3413869b5627490b44",
+        "head": "7e81fe4e46bc9eada5969bc7f473e58555d273a1",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -591,7 +591,10 @@
                 "6917f663c6aa86a279ba7b5e5465ce18aa26c8e8",
                 "abda678bf58b78ee0af1ef9830560dd4166e8995",
                 "982dc5ff95e038718389bb28f6c367e271de7a10",
-                "82849460b41370f3b63bd9d86b18fef39f68233a"
+                "82849460b41370f3b63bd9d86b18fef39f68233a",
+                "67e214e00533e4e267b3a7da55b08fcc09627488",
+                "65af1454e3c69afe0269c8d5dfcf955012981c72",
+                "7e81fe4e46bc9eada5969bc7f473e58555d273a1"
             ],
             "behaviors": [
                 "ATTENTION-ACTIVE-UNREGISTER-ON-DEACTIVATE-001",
@@ -600,7 +603,8 @@
                 "ATTENTION-EXPLICIT-SESSION-CLOSE-001",
                 "ATTENTION-USER-TERMINAL-CLOSE-001",
                 "ATTENTION-SINGLE-RUN-COMPLETION-DEDUP-001",
-                "ATTENTION-PRODUCTION-ATTENTION-STORE-LIFECYCLE-001"
+                "ATTENTION-PRODUCTION-ATTENTION-STORE-LIFECYCLE-001",
+                "ATTENTION-EXECUTION-STATE-SYNC-001"
             ],
             "prGates": [
                 "test:deterministic:run"
@@ -820,7 +824,8 @@
                 "63ef8eb965b1a37f956ceaf5eacc11b25baa014e",
                 "57f42aa6a293f77b0a27b5114f56d7c29cae2b5a",
                 "fed784c668dc7cf1dade22270d23565e485751a4",
-                "14622809706f9e9c792d6e3413869b5627490b44"
+                "14622809706f9e9c792d6e3413869b5627490b44",
+                "0251b56e920c011368e6f71425f9c852c7da0f38"
             ],
             "behaviors": [
                 "ARCH-CI-QUALITY-GATE-001",

--- a/scripts/check-changed-coverage.js
+++ b/scripts/check-changed-coverage.js
@@ -6,6 +6,26 @@ const path = require('node:path');
 
 const ELIGIBLE_CODE_PATH = /^(?:src|scripts|shared|extensions\/[^/]+\/src)\/.*\.(?:js|ts)$/;
 
+// Paths the deterministic suite structurally cannot instrument. Everything else
+// that is eligible but absent from the coverage report is still a hard failure,
+// because that means a test stopped exercising it.
+const UNINSTRUMENTED_BY_DESIGN = [
+    // The activation entry point. Only tests/integration/dashboard/helpers load it,
+    // and they compile out/dashboard.js in a child process started with
+    // NODE_V8_COVERAGE disabled, so no counters ever reach the report.
+    'src/dashboard.ts',
+    // Standalone check scripts are spawned with execFile rather than required, so
+    // their statements are attributed to the child process instead of the run.
+    // Their extracted helpers under scripts/lib stay instrumented and enforced.
+    /^scripts\/run-[^/]+\.js$/,
+];
+
+function isUninstrumentedByDesign(file) {
+    return UNINSTRUMENTED_BY_DESIGN.some(pattern => typeof pattern === 'string'
+        ? pattern === file
+        : pattern.test(file));
+}
+
 function parseChangedLines(diff) {
     const changed = new Map();
     let file;
@@ -80,7 +100,8 @@ function collectChangedLineCoverage(root, coverage, changed) {
     let total = 0;
     let covered = 0;
     for (const [file, changedLines] of changed) {
-        if (!ELIGIBLE_CODE_PATH.test(file) || changedLines.size === 0) {
+        if (!ELIGIBLE_CODE_PATH.test(file) || changedLines.size === 0
+            || isUninstrumentedByDesign(file)) {
             continue;
         }
         const entry = entries.get(file);
@@ -250,6 +271,7 @@ module.exports = {
     addUntrackedChangedLines,
     changedCoveragePercentage,
     collectChangedLineCoverage,
+    isUninstrumentedByDesign,
     listUntrackedFiles,
     main,
     parseChangedLines,

--- a/scripts/run-ai-session-safety-checks.js
+++ b/scripts/run-ai-session-safety-checks.js
@@ -7799,15 +7799,25 @@ function runAiSessionDashboardWatcherCoalescingChecks() {
     assert.strictEqual(scheduled[1].delayMs, 800);
     nowMs = 1300;
     controller.scheduleRefresh('watcher');
-    assert.deepStrictEqual(cleared, [scheduled[1]]);
-    assert.strictEqual(scheduled[2].delayMs, 700);
-    scheduled[2].callback();
+    assert.deepStrictEqual(cleared, [], 'a repeat watcher event keeps the pending deadline instead of re-arming');
+    assert.strictEqual(scheduled.length, 2, 'coalesced watcher events must not stack extra timers');
+    scheduled[1].callback();
     assert.deepStrictEqual(refreshReasons, ['watcher', 'watcher']);
     assert.strictEqual(messages.length, 1, 'unchanged coalesced watcher refreshes may be skipped after build');
 
     nowMs = 1350;
     controller.scheduleRefresh('attention');
-    assert.strictEqual(scheduled[3].delayMs, 100, 'non-watcher refreshes should not be throttled by watcher coalescing');
+    assert.strictEqual(scheduled[2].delayMs, 100, 'non-watcher refreshes should not be throttled by watcher coalescing');
+
+    // An urgent repaint already pending must never be pushed out to the watcher
+    // interval by the JSONL poller, or the attention dot lags the running animation.
+    nowMs = 1400;
+    controller.scheduleRefresh('watcher');
+    assert.deepStrictEqual(cleared, [], 'a watcher event must not postpone a pending status refresh');
+    assert.strictEqual(scheduled.length, 3);
+    scheduled[2].callback();
+    assert.deepStrictEqual(refreshReasons, ['watcher', 'watcher', 'attention'],
+        'a coalesced status refresh keeps its urgent reason');
 }
 
 async function runAiSessionDashboardUnchangedMessageSkipChecks() {

--- a/scripts/run-ai-session-safety-checks.js
+++ b/scripts/run-ai-session-safety-checks.js
@@ -111,6 +111,7 @@ const AiSessionCreationController = require('../out/aiSessions/creationControlle
 const AiSessionResumeController = require('../out/aiSessions/resumeController').AiSessionResumeController;
 const AiSessionAttentionController = require('../out/aiSessions/attentionController').AiSessionAttentionController;
 const AiSessionExecutionController = require('../out/aiSessions/executionController').AiSessionExecutionController;
+const AiSessionLifecycleSignalReader = require('../out/aiSessions/lifecycleSignalReader').AiSessionLifecycleSignalReader;
 const TmuxFocusedRuntimeMonitor = require('../out/aiSessions/tmuxFocusedRuntimeMonitor')
     .TmuxFocusedRuntimeMonitor;
 const settleAiSessionRuntimeLifecycles = require('../out/aiSessions/attentionController').settleAiSessionRuntimeLifecycles;
@@ -3264,22 +3265,28 @@ async function runAiSessionExecutionControllerChecks() {
     const scheduled = [];
     const options = {
         getActiveSessions: () => activeSessions,
-        getProviders: () => providersForTest,
         getSessionKey: (providerId, sessionId) => `${providerId}:${sessionId}`,
         scheduleRefresh: reason => scheduled.push(reason),
         nowMs: () => 1000,
     };
     assert.strictEqual(Object.prototype.hasOwnProperty.call(options, 'isEnabled'), false);
     const controller = new AiSessionExecutionController(options);
+    // Signals arrive from the shared reader so one consumer cannot evict another's
+    // cursor, and both passes observe the same read.
+    const reader = new AiSessionLifecycleSignalReader({
+        getProviders: () => providersForTest,
+        getRequests: () => [controller.getLifecycleRequests()],
+    });
+    const evaluate = () => controller.evaluate(reader.read());
 
-    await controller.evaluate();
+    evaluate();
     assert.deepStrictEqual(scheduled, ['execution']);
     assert.deepStrictEqual(providerCalls.codex, [[{ sessionId: 'session-a', runStartedAtMs: 900 }]]);
     assert.deepStrictEqual(providerCalls.kimi, []);
     assert.deepStrictEqual(providerCalls.claude, []);
     assert.strictEqual(controller.getSnapshot()['codex:session-a'].state, 'running');
 
-    await controller.evaluate();
+    evaluate();
     assert.deepStrictEqual(scheduled, ['execution'], 'repeating a signal does not schedule a refresh');
 
     signal = {
@@ -3289,12 +3296,12 @@ async function runAiSessionExecutionControllerChecks() {
         executionState: 'stopped',
         occurredAtMs: 1200,
     };
-    await controller.evaluate();
+    evaluate();
     assert.deepStrictEqual(scheduled, ['execution', 'execution']);
     assert.strictEqual(controller.getSnapshot()['codex:session-a'].state, 'stopped');
 
     activeSessions = [];
-    await controller.evaluate();
+    evaluate();
     assert.deepStrictEqual(controller.getSnapshot(), {});
     assert.deepStrictEqual(scheduled, ['execution', 'execution', 'execution'],
         'removing a tracked session must publish the stopped cross-window state');
@@ -3305,6 +3312,8 @@ async function runAiSessionExecutionControllerChecks() {
     const source = fs.readFileSync(path.join(__dirname, '..', 'src', 'aiSessions', 'executionController.ts'), 'utf8');
     assert.ok(!source.includes('isEnabled'), 'execution controller has no attention enablement option');
     assert.ok(!source.toLowerCase().includes('attention'), 'execution controller never reads attention configuration');
+    assert.ok(!source.includes('getLifecycleSignals('),
+        'execution controller consumes the shared read instead of querying providers itself');
 }
 
 async function runAgentPivotViewProviderOrderingChecks() {
@@ -5175,11 +5184,18 @@ function runWebviewContentChecks() {
     assert.ok(dashboard.includes('new WorkspaceSessionHydrationController<vscode.Terminal>({'));
     assert.ok(dashboard.includes('getExecutionSnapshot: () => aiSessionExecutionController.getSnapshot()'));
     assert.ok(dashboard.includes('getActiveSessions: () => aiSessionRuntimeCoordinator.getActive()'));
+    // The tick reads provider signals once and drives both the execution and the
+    // attention pass from that single observation, so the running animation and
+    // the attention dot can never be derived from two different reads.
     assert.match(dashboard,
-        /ownTimer\(\s*\(\) => setInterval\(\(\) => \{\s*aiSessionExecutionController\.evaluate\(\);\s*\}, 1_000\),\s*handle => clearInterval\(handle\),\s*\)/);
+        /const evaluateAiSessionLifecycleTick = \(\): void => \{\s*const signals = aiSessionLifecycleSignals\.read\(\);\s*aiSessionExecutionController\.evaluate\(signals\);\s*void aiSessionAttentionEvaluations\.request\('signals', signals\);\s*\}/);
     assert.match(dashboard,
-        /ownTimer\(\s*\(\) => setTimeout\(\(\) => \{\s*aiSessionExecutionController\.evaluate\(\);\s*\}, 0\),\s*handle => clearTimeout\(handle\),\s*\)/);
-    assert.match(dashboard, /onDidCloseTerminal\(terminal => \{[\s\S]*?handleClosedTerminal\(terminal\);[\s\S]*?aiSessionExecutionController\.evaluate\(\);/);
+        /ownTimer\(\s*\(\) => setInterval\(evaluateAiSessionLifecycleTick, 1_000\),\s*handle => clearInterval\(handle\),\s*\)/);
+    assert.match(dashboard,
+        /ownTimer\(\s*\(\) => setTimeout\(evaluateAiSessionLifecycleTick, 0\),\s*handle => clearTimeout\(handle\),\s*\)/);
+    assert.match(dashboard, /onDidCloseTerminal\(terminal => \{[\s\S]*?handleClosedTerminal\(terminal\);[\s\S]*?evaluateAiSessionLifecycleTick\(\);/);
+    assert.match(dashboard,
+        /getRequests: \(\) => \[\s*aiSessionExecutionController\.getLifecycleRequests\(\),\s*aiSessionAttentionController\.getLifecycleRequests\(\),\s*\]/);
     assert.ok(!evaluateExecutionFunction.includes('isEnabled'));
     assert.ok(!evaluateExecutionFunction.includes('attention'));
     assert.ok(evaluateAttentionFunction.includes('if (!this.options.isEnabled())'));

--- a/src/aiSessions/attentionController.ts
+++ b/src/aiSessions/attentionController.ts
@@ -8,6 +8,10 @@ import type { AttentionPayloadItem } from './attentionPayload';
 import AiSessionAttentionMonitor from './attentionMonitor';
 import type { AiSessionAttentionSnapshot } from './attentionMonitor';
 import type { AiSessionLifecycleRequest, AiSessionLifecycleSignal } from './lifecycle';
+import type {
+    AiSessionLifecycleRequestsByProvider,
+    AiSessionLifecycleSignals,
+} from './lifecycleSignalReader';
 import { getAttentionProjectKeys, getLogicalAttentionSessionKey } from './attentionProject';
 import { getAiSessionKey } from './sessionHelpers';
 import type { WorkspaceAiSessionActionTarget, WorkspaceAiSessionViewModel } from './types';
@@ -62,7 +66,8 @@ export class AiSessionAttentionController<TRuntime extends AiSessionAttentionRun
     }
 
     async evaluate(
-        runtimeOverrides: readonly AiSessionAttentionRuntimeOverride<TRuntime>[] = []
+        runtimeOverrides: readonly AiSessionAttentionRuntimeOverride<TRuntime>[] = [],
+        signals?: AiSessionLifecycleSignals
     ): Promise<AiSessionAttentionEvaluation> {
         if (!this.options.isEnabled()) {
             this.monitor.clear();
@@ -92,7 +97,7 @@ export class AiSessionAttentionController<TRuntime extends AiSessionAttentionRun
             }
             this.attentionKeysBySession.set(owned.baseSessionKey, keys);
         }
-        const signalsByProvider = this.getSignalsByProvider(providers, ownedSessions);
+        const signalsByProvider = signals || this.readSignals(providers, ownedSessions);
         const runningAttentionKeysBySession = new Map<string, string>();
         const inputs = Array.from(ownedSessions, ([key, owned]) => {
             const signal = signalsByProvider[owned.providerId][owned.session.id];
@@ -284,7 +289,31 @@ export class AiSessionAttentionController<TRuntime extends AiSessionAttentionRun
         return ownedSessions;
     }
 
-    private getSignalsByProvider(
+    /** The sessions this controller needs signals for, for the shared reader to merge. */
+    getLifecycleRequests(
+        runtimeOverrides: readonly AiSessionAttentionRuntimeOverride<TRuntime>[] = []
+    ): AiSessionLifecycleRequestsByProvider {
+        if (!this.options.isEnabled()) {
+            return {};
+        }
+        const requests: Partial<Record<AiSessionProviderId, AiSessionLifecycleRequest[]>> = {};
+        const ownedSessions = this.getOwnedSessions(
+            this.options.getWorkspaceTarget()?.sessions || null,
+            this.options.getProviders(),
+            runtimeOverrides
+        );
+        for (const owned of ownedSessions.values()) {
+            const owning = requests[owned.providerId] || [];
+            owning.push({
+                sessionId: owned.session.id,
+                runStartedAtMs: owned.runtime.runStartedAtMs,
+            });
+            requests[owned.providerId] = owning;
+        }
+        return requests;
+    }
+
+    private readSignals(
         providers: AiSessionAttentionProvider[],
         ownedSessions: Map<string, {
             providerId: AiSessionProviderId;

--- a/src/aiSessions/attentionEvaluationQueue.ts
+++ b/src/aiSessions/attentionEvaluationQueue.ts
@@ -1,43 +1,60 @@
 'use strict';
 
+import type { AiSessionLifecycleSignals } from './lifecycleSignalReader';
+
 /**
  * How much work an attention evaluation should do.
  *
  * - `signals` recomputes attention from provider lifecycle signals that have
- *   already been read. It is cheap enough to run on every lifecycle edge.
+ *   already been read. It is cheap enough to run on every lifecycle tick.
  * - `runtimes` additionally reconciles persisted runtime ownership from disk,
  *   which costs a directory scan and is only affordable on a slow interval.
  */
 export type AttentionEvaluationScope = 'signals' | 'runtimes';
 
+export interface AttentionEvaluationRequest {
+    scope: AttentionEvaluationScope;
+    /**
+     * The observation the execution pass used. Passing it through is what keeps
+     * the running animation and the attention dot derived from the same read
+     * rather than from two reads taken moments apart.
+     */
+    signals?: AiSessionLifecycleSignals;
+}
+
 export interface AttentionEvaluationQueueOptions {
-    evaluate: (scope: AttentionEvaluationScope) => Promise<unknown>;
+    evaluate: (request: AttentionEvaluationRequest) => Promise<unknown>;
     onFailure?: (error: unknown) => void;
 }
 
 /**
  * Coalesces attention evaluation requests into a single in-flight run.
  *
- * Attention used to be recomputed only by a slow fallback interval, which let the
- * red dot survive for seconds after the running animation had already started.
- * Edge triggers fix that, but they also arrive in bursts, so requests are folded
- * into one drain loop that always ends with an evaluation newer than the last
- * request instead of stacking overlapping evaluations. A batch runs at the widest
- * scope anyone asked for, so a cheap edge request never downgrades a pending
- * runtime reconciliation.
+ * Requests arrive in bursts, so they are folded into one drain loop that always
+ * ends with an evaluation newer than the last request instead of stacking
+ * overlapping evaluations. A batch runs at the widest scope anyone asked for, so
+ * a cheap tick request never downgrades a pending runtime reconciliation, and it
+ * carries the freshest signals offered so a coalesced batch never replays a
+ * stale observation.
  */
 export class AttentionEvaluationQueue {
     private draining: Promise<void> | null = null;
-    private pendingScope: AttentionEvaluationScope | null = null;
+    private pending: AttentionEvaluationRequest | null = null;
 
     constructor(private readonly options: AttentionEvaluationQueueOptions) {
     }
 
     /** Resolves once an evaluation that observed this request has finished. */
-    request(scope: AttentionEvaluationScope = 'signals'): Promise<void> {
-        if (scope === 'runtimes' || this.pendingScope === null) {
-            this.pendingScope = scope;
-        }
+    request(
+        scope: AttentionEvaluationScope = 'signals',
+        signals?: AiSessionLifecycleSignals
+    ): Promise<void> {
+        this.pending = {
+            scope: scope === 'runtimes' || this.pending?.scope === 'runtimes' ? 'runtimes' : 'signals',
+            ...(signals || this.pending?.signals
+                ? { signals: signals || this.pending?.signals }
+                : {}),
+        };
         if (!this.draining) {
             this.draining = this.drain();
         }
@@ -50,11 +67,11 @@ export class AttentionEvaluationQueue {
 
     private async drain(): Promise<void> {
         try {
-            while (this.pendingScope !== null) {
-                const scope = this.pendingScope;
-                this.pendingScope = null;
+            while (this.pending !== null) {
+                const request = this.pending;
+                this.pending = null;
                 try {
-                    await this.options.evaluate(scope);
+                    await this.options.evaluate(request);
                 } catch (error) {
                     this.options.onFailure?.(error);
                 }

--- a/src/aiSessions/attentionEvaluationQueue.ts
+++ b/src/aiSessions/attentionEvaluationQueue.ts
@@ -1,0 +1,66 @@
+'use strict';
+
+/**
+ * How much work an attention evaluation should do.
+ *
+ * - `signals` recomputes attention from provider lifecycle signals that have
+ *   already been read. It is cheap enough to run on every lifecycle edge.
+ * - `runtimes` additionally reconciles persisted runtime ownership from disk,
+ *   which costs a directory scan and is only affordable on a slow interval.
+ */
+export type AttentionEvaluationScope = 'signals' | 'runtimes';
+
+export interface AttentionEvaluationQueueOptions {
+    evaluate: (scope: AttentionEvaluationScope) => Promise<unknown>;
+    onFailure?: (error: unknown) => void;
+}
+
+/**
+ * Coalesces attention evaluation requests into a single in-flight run.
+ *
+ * Attention used to be recomputed only by a slow fallback interval, which let the
+ * red dot survive for seconds after the running animation had already started.
+ * Edge triggers fix that, but they also arrive in bursts, so requests are folded
+ * into one drain loop that always ends with an evaluation newer than the last
+ * request instead of stacking overlapping evaluations. A batch runs at the widest
+ * scope anyone asked for, so a cheap edge request never downgrades a pending
+ * runtime reconciliation.
+ */
+export class AttentionEvaluationQueue {
+    private draining: Promise<void> | null = null;
+    private pendingScope: AttentionEvaluationScope | null = null;
+
+    constructor(private readonly options: AttentionEvaluationQueueOptions) {
+    }
+
+    /** Resolves once an evaluation that observed this request has finished. */
+    request(scope: AttentionEvaluationScope = 'signals'): Promise<void> {
+        if (scope === 'runtimes' || this.pendingScope === null) {
+            this.pendingScope = scope;
+        }
+        if (!this.draining) {
+            this.draining = this.drain();
+        }
+        return this.draining;
+    }
+
+    isIdle(): boolean {
+        return !this.draining;
+    }
+
+    private async drain(): Promise<void> {
+        try {
+            while (this.pendingScope !== null) {
+                const scope = this.pendingScope;
+                this.pendingScope = null;
+                try {
+                    await this.options.evaluate(scope);
+                } catch (error) {
+                    this.options.onFailure?.(error);
+                }
+            }
+        } finally {
+            this.draining = null;
+        }
+    }
+}

--- a/src/aiSessions/attentionMonitor.ts
+++ b/src/aiSessions/attentionMonitor.ts
@@ -2,6 +2,10 @@
 
 import * as crypto from 'crypto';
 import type { AiSessionAttentionReason, AiSessionLifecycleSignal } from './lifecycle';
+import {
+    acceptsLifecycleSignal,
+    recordAcceptedLifecycleSignal,
+} from './lifecycleSignalAcceptance';
 
 export { AiSessionAttentionReason } from './lifecycle';
 export type AiSessionAttentionState = 'pending' | 'running' | 'idle' | 'needsAttention' | 'acknowledged';
@@ -29,6 +33,7 @@ export interface AiSessionAttentionSnapshot {
 
 interface Entry extends AiSessionAttentionSnapshot {
     lastSignalToken?: string;
+    lastOccurredAtMs?: number;
     generation: number;
 }
 
@@ -61,10 +66,10 @@ export default class AiSessionAttentionMonitor {
             }
 
             let signal = input.signal;
-            if (!signal?.token || signal.token === entry.lastSignalToken) {
+            if (!acceptsLifecycleSignal(entry, signal)) {
                 continue;
             }
-            entry.lastSignalToken = signal.token;
+            recordAcceptedLifecycleSignal(entry, signal);
             entry.stateChangedAt = observedAt;
 
             if (signal.phase === 'running' || signal.phase === 'idle') {

--- a/src/aiSessions/dashboardController.ts
+++ b/src/aiSessions/dashboardController.ts
@@ -44,6 +44,7 @@ export class AiSessionDashboardController {
     private newSessionRefreshTimeouts: NodeJS.Timeout[] = [];
     private watcherDisposables: DisposableLike[] = [];
     private pendingRefreshReason = 'refresh';
+    private pendingRefreshDueAtMs = 0;
     private lastWatcherRefreshAtMs: number | null = null;
     private lastPostedIncrementalMessageSignature: string | null = null;
 
@@ -55,7 +56,17 @@ export class AiSessionDashboardController {
             return;
         }
 
+        const dueAtMs = this.nowMs() + this.getRefreshDelayMs(reason);
+        // A later request never postpones an already pending refresh. Watcher events
+        // arrive continuously while a session streams, and re-arming on the newest
+        // reason used to push an urgent status repaint out to the watcher interval
+        // and relabel it, so the attention dot lagged the running animation.
+        if (this.refreshTimeout !== null && dueAtMs >= this.pendingRefreshDueAtMs) {
+            return;
+        }
+
         this.pendingRefreshReason = reason;
+        this.pendingRefreshDueAtMs = dueAtMs;
         if (this.refreshTimeout) {
             this.options.clearTimeout(this.refreshTimeout);
         }

--- a/src/aiSessions/executionController.ts
+++ b/src/aiSessions/executionController.ts
@@ -1,22 +1,18 @@
 'use strict';
 
 import type { AiSessionProviderId } from '../models';
-import type { AiSessionLifecycleRequest, AiSessionLifecycleSignal } from './lifecycle';
+import type { AiSessionLifecycleRequest } from './lifecycle';
 import AiSessionExecutionMonitor from './executionMonitor';
 import type { AiSessionExecutionSnapshot } from './executionMonitor';
+import type {
+    AiSessionLifecycleRequestsByProvider,
+    AiSessionLifecycleSignals,
+} from './lifecycleSignalReader';
 import { getAiSessionKey } from './sessionHelpers';
 import type { AiSessionActiveTerminalRuntime } from './types';
 
-export interface AiSessionExecutionProvider {
-    id: AiSessionProviderId;
-    service: {
-        getLifecycleSignals(requests: readonly AiSessionLifecycleRequest[]): Record<string, AiSessionLifecycleSignal>;
-    };
-}
-
 export interface AiSessionExecutionControllerOptions {
     getActiveSessions: () => AiSessionActiveTerminalRuntime[];
-    getProviders: () => AiSessionExecutionProvider[];
     getSessionKey?: (providerId: AiSessionProviderId, sessionId: string) => string;
     scheduleRefresh: (reason: string) => void;
     nowMs: () => number;
@@ -29,31 +25,21 @@ export class AiSessionExecutionController {
         this.monitor = new AiSessionExecutionMonitor({ now: options.nowMs });
     }
 
-    evaluate(): void {
-        const activeSessions = this.options.getActiveSessions();
-        const providers = this.options.getProviders();
-        const requestsByProvider = new Map<AiSessionProviderId, AiSessionLifecycleRequest[]>(
-            providers.map(provider => [provider.id, []])
-        );
-        for (const session of activeSessions) {
-            requestsByProvider.get(session.provider)?.push({
-                sessionId: session.sessionId,
-                runStartedAtMs: session.runStartedAtMs,
-            });
+    /** The sessions this controller needs signals for, for the shared reader to merge. */
+    getLifecycleRequests(): AiSessionLifecycleRequestsByProvider {
+        const requests: Partial<Record<AiSessionProviderId, AiSessionLifecycleRequest[]>> = {};
+        for (const session of this.options.getActiveSessions()) {
+            const owned = requests[session.provider] || [];
+            owned.push({ sessionId: session.sessionId, runStartedAtMs: session.runStartedAtMs });
+            requests[session.provider] = owned;
         }
+        return requests;
+    }
 
-        const signalsByProvider = new Map<AiSessionProviderId, Record<string, AiSessionLifecycleSignal>>();
-        for (const provider of providers) {
-            const requests = requestsByProvider.get(provider.id) || [];
-            signalsByProvider.set(
-                provider.id,
-                requests.length ? provider.service.getLifecycleSignals(requests) : {}
-            );
-        }
-
-        const changedKeys = this.monitor.evaluate(activeSessions.map(session => ({
+    evaluate(signals: AiSessionLifecycleSignals): void {
+        const changedKeys = this.monitor.evaluate(this.options.getActiveSessions().map(session => ({
             key: this.getSessionKey(session.provider, session.sessionId),
-            signal: signalsByProvider.get(session.provider)?.[session.sessionId],
+            signal: signals?.[session.provider]?.[session.sessionId],
         })));
         if (changedKeys.length) {
             this.options.scheduleRefresh('execution');

--- a/src/aiSessions/executionMonitor.ts
+++ b/src/aiSessions/executionMonitor.ts
@@ -1,6 +1,10 @@
 'use strict';
 
 import type { AiSessionExecutionState, AiSessionLifecycleSignal } from './lifecycle';
+import {
+    acceptsLifecycleSignal,
+    recordAcceptedLifecycleSignal,
+} from './lifecycleSignalAcceptance';
 
 export interface AiSessionExecutionInput {
     key: string;
@@ -40,12 +44,10 @@ export default class AiSessionExecutionMonitor {
             }
 
             const signal = input.signal;
-            if (!signal?.token || signal.token === entry.lastSignalToken
-                || (entry.lastOccurredAtMs !== undefined && signal.occurredAtMs < entry.lastOccurredAtMs)) {
+            if (!acceptsLifecycleSignal(entry, signal)) {
                 continue;
             }
-            entry.lastSignalToken = signal.token;
-            entry.lastOccurredAtMs = signal.occurredAtMs;
+            recordAcceptedLifecycleSignal(entry, signal);
             if (entry.state === signal.executionState) {
                 continue;
             }

--- a/src/aiSessions/lifecycleSignalAcceptance.ts
+++ b/src/aiSessions/lifecycleSignalAcceptance.ts
@@ -1,0 +1,36 @@
+'use strict';
+
+import type { AiSessionLifecycleSignal } from './lifecycle';
+
+export interface AcceptedLifecycleSignal {
+    lastSignalToken?: string;
+    lastOccurredAtMs?: number;
+}
+
+/**
+ * Whether a monitor should act on a lifecycle signal.
+ *
+ * Both status surfaces read the same signal, so they have to agree on which
+ * ones count. A signal is new when its token differs from the last accepted
+ * one, and current when it is no older than the last accepted one. The second
+ * rule matters because a provider cursor rebuilt from the start of a transcript
+ * replays earlier events: without it the attention dot could be raised again by
+ * a completion the running animation had already moved past.
+ */
+export function acceptsLifecycleSignal(
+    entry: AcceptedLifecycleSignal,
+    signal: AiSessionLifecycleSignal | undefined
+): signal is AiSessionLifecycleSignal {
+    return Boolean(signal?.token)
+        && signal.token !== entry.lastSignalToken
+        && (entry.lastOccurredAtMs === undefined || signal.occurredAtMs >= entry.lastOccurredAtMs);
+}
+
+/** Records a signal the caller accepted, so later replays are rejected. */
+export function recordAcceptedLifecycleSignal(
+    entry: AcceptedLifecycleSignal,
+    signal: AiSessionLifecycleSignal
+): void {
+    entry.lastSignalToken = signal.token;
+    entry.lastOccurredAtMs = signal.occurredAtMs;
+}

--- a/src/aiSessions/lifecycleSignalReader.ts
+++ b/src/aiSessions/lifecycleSignalReader.ts
@@ -1,0 +1,71 @@
+'use strict';
+
+import type { AiSessionProviderId } from '../models';
+import type { AiSessionLifecycleRequest, AiSessionLifecycleSignal } from './lifecycle';
+
+export interface AiSessionLifecycleSignalProvider {
+    id: AiSessionProviderId;
+    service: {
+        getLifecycleSignals(
+            requests: readonly AiSessionLifecycleRequest[]
+        ): Record<string, AiSessionLifecycleSignal>;
+    };
+}
+
+export type AiSessionLifecycleRequestsByProvider =
+    Readonly<Partial<Record<AiSessionProviderId, readonly AiSessionLifecycleRequest[]>>>;
+
+export type AiSessionLifecycleSignals =
+    Readonly<Record<AiSessionProviderId, Readonly<Record<string, AiSessionLifecycleSignal>>>>;
+
+export interface AiSessionLifecycleSignalReaderOptions {
+    getProviders: () => readonly AiSessionLifecycleSignalProvider[];
+    /**
+     * Every consumer's requests, already attributed to the owning provider. The
+     * reader merges them per provider, keeping the first run start seen for a
+     * session so a stale duplicate cannot re-seek a cursor.
+     */
+    getRequests: () => readonly AiSessionLifecycleRequestsByProvider[];
+}
+
+/**
+ * Reads provider lifecycle signals once for the union of every consumer.
+ *
+ * Provider services keep an incremental JSONL cursor per session and end
+ * getLifecycleSignals by retaining only the sessions named in that call. When
+ * the execution and attention passes each read on their own, whichever ran last
+ * evicted the other's cursors and forced a full re-read of the session
+ * transcript on the next pass. Merging the request sets keeps every cursor
+ * alive, and handing one result to both passes means the running animation and
+ * the attention dot are derived from the same observation rather than from two
+ * reads taken moments apart.
+ */
+export class AiSessionLifecycleSignalReader {
+    constructor(private readonly options: AiSessionLifecycleSignalReaderOptions) {
+    }
+
+    read(): AiSessionLifecycleSignals {
+        const merged = new Map<AiSessionProviderId, Map<string, AiSessionLifecycleRequest>>();
+        for (const byProvider of this.options.getRequests()) {
+            for (const [providerId, requests] of Object.entries(byProvider || {})) {
+                const owned = merged.get(providerId as AiSessionProviderId)
+                    || new Map<string, AiSessionLifecycleRequest>();
+                for (const request of requests || []) {
+                    if (request?.sessionId && !owned.has(request.sessionId)) {
+                        owned.set(request.sessionId, request);
+                    }
+                }
+                merged.set(providerId as AiSessionProviderId, owned);
+            }
+        }
+
+        const signals: Partial<Record<AiSessionProviderId, Record<string, AiSessionLifecycleSignal>>> = {};
+        for (const provider of this.options.getProviders()) {
+            const requests = [...(merged.get(provider.id)?.values() || [])];
+            signals[provider.id] = requests.length
+                ? provider.service.getLifecycleSignals(requests)
+                : {};
+        }
+        return signals as AiSessionLifecycleSignals;
+    }
+}

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -124,6 +124,7 @@ import type {
     AiSessionAttentionEvaluation,
     AiSessionRuntimeLifecycleCandidate,
 } from './aiSessions/attentionController';
+import { AttentionEvaluationQueue } from './aiSessions/attentionEvaluationQueue';
 import {
     getLastPartOfPath,
     isUriString,
@@ -1210,6 +1211,18 @@ async function initializeDashboard(
         scheduleRefresh: reason => scheduleAiSessionRefresh(reason),
         nowMs: () => Date.now(),
     });
+    const aiSessionAttentionEvaluations = new AttentionEvaluationQueue({
+        // Lifecycle edges only need the signal pass. Reconciling persisted runtime
+        // ownership scans the tmux binding directory, so it stays on the interval.
+        evaluate: scope => scope === 'runtimes'
+            ? evaluateAiSessionAttention()
+            : aiSessionAttentionController.evaluate(),
+        onFailure: () => logAiSessionDiagnostic({
+            event: 'runtime-lifecycle-task-failed',
+            operation: 'evaluate-attention-lifecycle-edge',
+            category: 'unexpected',
+        }),
+    });
     const aiSessionExecutionController = new AiSessionExecutionController({
         getActiveSessions: () => aiSessionRuntimeCoordinator.getActive()
             .filter(runtime => runtimeBelongsToCurrentWorkspace(runtime)
@@ -1228,6 +1241,11 @@ async function initializeDashboard(
             if (openWorkspaceController) {
                 openWorkspaceController.publish();
             }
+            // Attention and execution read the same provider signal, so an execution
+            // edge is exactly when the attention dot has to be recomputed too.
+            // Without this the dot only moves on the fallback interval below and
+            // lingers for seconds after the running animation has started.
+            void aiSessionAttentionEvaluations.request('signals');
         },
         nowMs: () => Date.now(),
     });
@@ -1385,10 +1403,11 @@ async function initializeDashboard(
     });
     activeAiSessionAttentionBridgeClient = aiSessionAttentionBridgeClient;
     ownTimer(
+        // Fallback heartbeat. Attention normally settles on the execution edge that
+        // the 1s tick below detects; this covers signals that never change the
+        // execution state and reconciles persisted runtime ownership from disk.
         () => setInterval(() => {
-            void runSafeAiSessionRuntimeLifecycleTask(
-                'evaluate-attention-interval', evaluateAiSessionAttention
-            );
+            void aiSessionAttentionEvaluations.request('runtimes');
         }, 10_000),
         handle => clearInterval(handle),
     );

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -125,6 +125,7 @@ import type {
     AiSessionRuntimeLifecycleCandidate,
 } from './aiSessions/attentionController';
 import { AttentionEvaluationQueue } from './aiSessions/attentionEvaluationQueue';
+import { AiSessionLifecycleSignalReader } from './aiSessions/lifecycleSignalReader';
 import {
     getLastPartOfPath,
     isUriString,
@@ -915,7 +916,7 @@ async function initializeDashboard(
             setAlias: (providerId, sessionId, alias) =>
                 aiSessionAliasController.set(providerId, sessionId, alias),
             syncActiveRuntime: () => activeAiSessionTerminalHighlighter.sync(),
-            evaluateExecution: () => aiSessionExecutionController.evaluate(),
+            evaluateExecution: () => evaluateAiSessionLifecycleTick(),
             scheduleRefresh: () => refreshAiSessionViewsIncrementally(),
             logDiagnostic: logAiSessionDiagnostic,
         });
@@ -1212,11 +1213,15 @@ async function initializeDashboard(
         nowMs: () => Date.now(),
     });
     const aiSessionAttentionEvaluations = new AttentionEvaluationQueue({
-        // Lifecycle edges only need the signal pass. Reconciling persisted runtime
-        // ownership scans the tmux binding directory, so it stays on the interval.
-        evaluate: scope => scope === 'runtimes'
+        // The tick pass reuses the observation the execution pass already made.
+        // Reconciling persisted runtime ownership scans the tmux binding directory,
+        // so it stays on the slow interval and reads for itself.
+        evaluate: request => request.scope === 'runtimes'
             ? evaluateAiSessionAttention()
-            : aiSessionAttentionController.evaluate(),
+            : aiSessionAttentionController.evaluate(
+                [],
+                request.signals || aiSessionLifecycleSignals.read()
+            ),
         onFailure: () => logAiSessionDiagnostic({
             event: 'runtime-lifecycle-task-failed',
             operation: 'evaluate-attention-lifecycle-edge',
@@ -1234,23 +1239,31 @@ async function initializeDashboard(
                 cwd: runtime.identity.cwd,
                 runStartedAtMs: runtime.runStartedAtMs,
             })),
-        getProviders: getRegisteredAiSessionProviders,
         getSessionKey: getAiSessionKey,
         scheduleRefresh: reason => {
             scheduleAiSessionRefresh(reason);
             if (openWorkspaceController) {
                 openWorkspaceController.publish();
             }
-            // Attention and execution read the same provider signal, so an execution
-            // edge is exactly when the attention dot has to be recomputed too.
-            // Without this the dot only moves on the fallback interval below and
-            // lingers for seconds after the running animation has started.
-            void aiSessionAttentionEvaluations.request('signals');
         },
         nowMs: () => Date.now(),
     });
-    const getAiSessionAttentionEventIds = (identity: ActiveAiSessionTerminalIdentity): string[] => {
-        const sessionKey = getAiSessionKey(identity.provider, identity.sessionId);
+    // One read per tick, shared by both passes. Reading per consumer let whichever
+    // ran last evict the other's incremental cursors, and left the animation and
+    // the attention dot derived from two observations taken moments apart.
+    const aiSessionLifecycleSignals = new AiSessionLifecycleSignalReader({
+        getProviders: getRegisteredAiSessionProviders,
+        getRequests: () => [
+            aiSessionExecutionController.getLifecycleRequests(),
+            aiSessionAttentionController.getLifecycleRequests(),
+        ],
+    });
+    const evaluateAiSessionLifecycleTick = (): void => {
+        const signals = aiSessionLifecycleSignals.read();
+        aiSessionExecutionController.evaluate(signals);
+        void aiSessionAttentionEvaluations.request('signals', signals);
+    };
+    const getAiSessionAttentionEventIds = (identity: ActiveAiSessionTerminalIdentity): string[] => {        const sessionKey = getAiSessionKey(identity.provider, identity.sessionId);
         return aiSessionAttentionController.getRecoverySessionEvents()
             .find(session => session.sessionKey === sessionKey)?.eventIds || [];
     };
@@ -1420,15 +1433,11 @@ async function initializeDashboard(
         handle => clearTimeout(handle),
     );
     ownTimer(
-        () => setInterval(() => {
-            aiSessionExecutionController.evaluate();
-        }, 1_000),
+        () => setInterval(evaluateAiSessionLifecycleTick, 1_000),
         handle => clearInterval(handle),
     );
     ownTimer(
-        () => setTimeout(() => {
-            aiSessionExecutionController.evaluate();
-        }, 0),
+        () => setTimeout(evaluateAiSessionLifecycleTick, 0),
         handle => clearTimeout(handle),
     );
     let conversationCapability: ConversationCapability;
@@ -2427,7 +2436,7 @@ async function initializeDashboard(
             const hadRuntimeClient = [...aiSessionRuntimeCoordinator.getActive(), ...aiSessionRuntimeCoordinator.getPending()]
                 .some(runtime => runtime.terminal === terminal);
             aiSessionRuntimeCoordinator.handleClosedTerminal(terminal);
-            aiSessionExecutionController.evaluate();
+            evaluateAiSessionLifecycleTick();
             activeAiSessionTerminalHighlighter.handleTerminalClosed(terminal);
             if (closedSessions.length || hadRuntimeClient) {
                 refreshAiSessionViewsIncrementally();

--- a/tests/contract/aiSessions/attention.test.js
+++ b/tests/contract/aiSessions/attention.test.js
@@ -17,6 +17,12 @@ const {
     settleAiSessionRuntimeLifecycles,
 } = require('../../../out/aiSessions/attentionController');
 const {
+    AttentionEvaluationQueue,
+} = require('../../../out/aiSessions/attentionEvaluationQueue');
+const {
+    AiSessionExecutionController,
+} = require('../../../out/aiSessions/executionController');
+const {
     aggregateAttentionSnapshots,
     filterAcknowledgedAttentionAggregate,
 } = require('../../../out/aiSessions/attentionAggregate');
@@ -928,4 +934,150 @@ test('ATTENTION-ACTIVE-UNREGISTER-ON-DEACTIVATE-001 exposes an awaitable active 
     unregisterReleased.resolve();
     await shutdown;
     assert.equal(settled, true);
+});
+
+test('ATTENTION-EXECUTION-STATE-SYNC-001 clears attention on the same lifecycle edge that starts the running animation', async () => {
+    const workspace = {
+        navigationIdentity: 'navigation:fixture', scopeIdentity: 'scope:fixture',
+        kind: 'singleFolder', displayName: 'Fixture', navigationUri: 'file:///fixtures/project',
+        environment: 'local', roots: [{
+            id: 'root:fixture', name: 'Fixture', uri: 'file:///fixtures/project',
+            hostPath: '/fixtures/project', ordinal: 0,
+        }],
+    };
+    const workspaceSessions = {
+        sessionsByProvider: {
+            codex: [{ id: 'session', primaryRootId: 'root:fixture' }],
+            kimi: [],
+            claude: [],
+        },
+    };
+
+    let nowMs = 1000;
+    // Both surfaces read the same provider signal; only the cadence differed.
+    let signal = {
+        token: 'task-complete:1000',
+        phase: 'needsAttention',
+        reason: 'completed',
+        executionState: 'stopped',
+        occurredAtMs: 1000,
+    };
+    const providers = [{
+        id: 'codex',
+        service: { getLifecycleSignals: () => ({ session: signal }) },
+    }];
+
+    const attentionController = new AiSessionAttentionController({
+        isEnabled: () => true,
+        getWorkspaceTarget: () => ({
+            cardId: 'workspace:fixture', workspace, sessions: workspaceSessions,
+        }),
+        getProviders: () => providers,
+        getRuntimeById: () => ({ state: 'active', runStartedAtMs: 0 }),
+        publish: async () => true,
+        scheduleRefresh: () => undefined,
+        nowMs: () => nowMs,
+    });
+    const evaluatedScopes = [];
+    const attentionEvaluations = new AttentionEvaluationQueue({
+        evaluate: scope => {
+            evaluatedScopes.push(scope);
+            return attentionController.evaluate();
+        },
+    });
+    const executionController = new AiSessionExecutionController({
+        getActiveSessions: () => [{
+            provider: 'codex', sessionId: 'session',
+            workspaceScopeIdentity: 'scope:fixture',
+            cwd: '/fixtures/project', runStartedAtMs: 0,
+        }],
+        getProviders: () => providers,
+        // dashboard.ts routes every execution edge back into attention evaluation.
+        scheduleRefresh: () => { void attentionEvaluations.request('signals'); },
+        nowMs: () => nowMs,
+    });
+
+    // What the session row renders: data-execution-state and the attention dot.
+    const surface = () => ({
+        animation: executionController.getSnapshot()['codex:session']?.state === 'running',
+        redDot: attentionController.getEffectiveAggregate().sessions.length > 0,
+    });
+    // One second of wall clock, matching the production execution tick.
+    const tick = async () => {
+        nowMs += 1000;
+        executionController.evaluate();
+        await flushAsync();
+    };
+
+    await tick();
+    await attentionEvaluations.request('runtimes');
+    assert.deepEqual(surface(), { animation: false, redDot: true }, 'a completed turn raises the dot');
+
+    // The user replies in the terminal and the provider starts a new turn.
+    signal = {
+        token: 'task-started:2000',
+        phase: 'running',
+        executionState: 'running',
+        occurredAtMs: 2000,
+    };
+    await tick();
+
+    assert.deepEqual(
+        surface(),
+        { animation: true, redDot: false },
+        'the dot must clear on the same tick the animation starts, without waiting for the fallback interval'
+    );
+    assert.ok(
+        evaluatedScopes.includes('signals'),
+        'a lifecycle edge must settle attention without the disk-scanning runtime pass'
+    );
+});
+
+test('ATTENTION-EXECUTION-STATE-SYNC-001 coalesces attention requests and never downgrades a pending runtime pass', async () => {
+    const scopes = [];
+    let release;
+    const queue = new AttentionEvaluationQueue({
+        evaluate: async scope => {
+            scopes.push(scope);
+            await new Promise(resolve => { release = resolve; });
+        },
+    });
+
+    const first = queue.request('signals');
+    await flushAsync();
+    assert.deepEqual(scopes, ['signals'], 'the first request starts immediately');
+    assert.equal(queue.isIdle(), false);
+
+    // A burst arriving mid-flight collapses into one trailing run at the widest scope.
+    queue.request('signals');
+    queue.request('runtimes');
+    queue.request('signals');
+    release();
+    await flushAsync();
+    assert.deepEqual(scopes, ['signals', 'runtimes'],
+        'a cheap edge request must not downgrade a pending runtime reconciliation');
+
+    release();
+    await first;
+    assert.equal(queue.isIdle(), true);
+});
+
+test('ATTENTION-EXECUTION-STATE-SYNC-001 keeps draining after an evaluation throws', async () => {
+    const scopes = [];
+    const failures = [];
+    const queue = new AttentionEvaluationQueue({
+        evaluate: async scope => {
+            scopes.push(scope);
+            throw new Error(`boom:${scope}`);
+        },
+        onFailure: error => failures.push(error instanceof Error ? error.message : String(error)),
+    });
+
+    await queue.request('signals');
+    assert.deepEqual(scopes, ['signals']);
+    assert.deepEqual(failures, ['boom:signals']);
+    assert.equal(queue.isIdle(), true, 'a failed evaluation must not wedge the queue');
+
+    await queue.request('runtimes');
+    assert.deepEqual(scopes, ['signals', 'runtimes']);
 });

--- a/tests/contract/aiSessions/attention.test.js
+++ b/tests/contract/aiSessions/attention.test.js
@@ -23,6 +23,9 @@ const {
     AiSessionExecutionController,
 } = require('../../../out/aiSessions/executionController');
 const {
+    AiSessionLifecycleSignalReader,
+} = require('../../../out/aiSessions/lifecycleSignalReader');
+const {
     aggregateAttentionSnapshots,
     filterAcknowledgedAttentionAggregate,
 } = require('../../../out/aiSessions/attentionAggregate');
@@ -954,7 +957,8 @@ test('ATTENTION-EXECUTION-STATE-SYNC-001 clears attention on the same lifecycle 
     };
 
     let nowMs = 1000;
-    // Both surfaces read the same provider signal; only the cadence differed.
+    let reads = 0;
+    // A completed turn is pending until the user replies in the terminal.
     let signal = {
         token: 'task-complete:1000',
         phase: 'needsAttention',
@@ -964,7 +968,12 @@ test('ATTENTION-EXECUTION-STATE-SYNC-001 clears attention on the same lifecycle 
     };
     const providers = [{
         id: 'codex',
-        service: { getLifecycleSignals: () => ({ session: signal }) },
+        service: {
+            getLifecycleSignals: requests => {
+                reads += 1;
+                return Object.fromEntries(requests.map(request => [request.sessionId, signal]));
+            },
+        },
     }];
 
     const attentionController = new AiSessionAttentionController({
@@ -978,23 +987,28 @@ test('ATTENTION-EXECUTION-STATE-SYNC-001 clears attention on the same lifecycle 
         scheduleRefresh: () => undefined,
         nowMs: () => nowMs,
     });
-    const evaluatedScopes = [];
-    const attentionEvaluations = new AttentionEvaluationQueue({
-        evaluate: scope => {
-            evaluatedScopes.push(scope);
-            return attentionController.evaluate();
-        },
-    });
     const executionController = new AiSessionExecutionController({
         getActiveSessions: () => [{
             provider: 'codex', sessionId: 'session',
             workspaceScopeIdentity: 'scope:fixture',
             cwd: '/fixtures/project', runStartedAtMs: 0,
         }],
-        getProviders: () => providers,
-        // dashboard.ts routes every execution edge back into attention evaluation.
-        scheduleRefresh: () => { void attentionEvaluations.request('signals'); },
+        scheduleRefresh: () => undefined,
         nowMs: () => nowMs,
+    });
+    const reader = new AiSessionLifecycleSignalReader({
+        getProviders: () => providers,
+        getRequests: () => [
+            executionController.getLifecycleRequests(),
+            attentionController.getLifecycleRequests(),
+        ],
+    });
+    const observed = [];
+    const attentionEvaluations = new AttentionEvaluationQueue({
+        evaluate: request => {
+            observed.push(request.scope);
+            return attentionController.evaluate([], request.signals || reader.read());
+        },
     });
 
     // What the session row renders: data-execution-state and the attention dot.
@@ -1002,16 +1016,17 @@ test('ATTENTION-EXECUTION-STATE-SYNC-001 clears attention on the same lifecycle 
         animation: executionController.getSnapshot()['codex:session']?.state === 'running',
         redDot: attentionController.getEffectiveAggregate().sessions.length > 0,
     });
-    // One second of wall clock, matching the production execution tick.
+    // The production tick: read once, then drive both passes from that observation.
     const tick = async () => {
         nowMs += 1000;
-        executionController.evaluate();
-        await flushAsync();
+        const signals = reader.read();
+        executionController.evaluate(signals);
+        await attentionEvaluations.request('signals', signals);
     };
 
     await tick();
-    await attentionEvaluations.request('runtimes');
     assert.deepEqual(surface(), { animation: false, redDot: true }, 'a completed turn raises the dot');
+    assert.equal(reads, 1, 'one tick reads each provider once, not once per consumer');
 
     // The user replies in the terminal and the provider starts a new turn.
     signal = {
@@ -1027,25 +1042,23 @@ test('ATTENTION-EXECUTION-STATE-SYNC-001 clears attention on the same lifecycle 
         { animation: true, redDot: false },
         'the dot must clear on the same tick the animation starts, without waiting for the fallback interval'
     );
-    assert.ok(
-        evaluatedScopes.includes('signals'),
-        'a lifecycle edge must settle attention without the disk-scanning runtime pass'
-    );
+    assert.equal(reads, 2, 'the attention pass reuses the execution pass observation');
+    assert.deepEqual(observed, ['signals', 'signals']);
 });
 
 test('ATTENTION-EXECUTION-STATE-SYNC-001 coalesces attention requests and never downgrades a pending runtime pass', async () => {
-    const scopes = [];
+    const observed = [];
     let release;
     const queue = new AttentionEvaluationQueue({
-        evaluate: async scope => {
-            scopes.push(scope);
+        evaluate: async request => {
+            observed.push(request.scope);
             await new Promise(resolve => { release = resolve; });
         },
     });
 
     const first = queue.request('signals');
     await flushAsync();
-    assert.deepEqual(scopes, ['signals'], 'the first request starts immediately');
+    assert.deepEqual(observed, ['signals'], 'the first request starts immediately');
     assert.equal(queue.isIdle(), false);
 
     // A burst arriving mid-flight collapses into one trailing run at the widest scope.
@@ -1054,30 +1067,55 @@ test('ATTENTION-EXECUTION-STATE-SYNC-001 coalesces attention requests and never 
     queue.request('signals');
     release();
     await flushAsync();
-    assert.deepEqual(scopes, ['signals', 'runtimes'],
-        'a cheap edge request must not downgrade a pending runtime reconciliation');
+    assert.deepEqual(observed, ['signals', 'runtimes'],
+        'a cheap tick request must not downgrade a pending runtime reconciliation');
 
     release();
     await first;
     assert.equal(queue.isIdle(), true);
 });
 
+test('ATTENTION-EXECUTION-STATE-SYNC-001 carries the freshest observation into a coalesced batch', async () => {
+    const observed = [];
+    let release;
+    const queue = new AttentionEvaluationQueue({
+        evaluate: async request => {
+            observed.push(request.signals);
+            await new Promise(resolve => { release = resolve; });
+        },
+    });
+    const stale = { codex: { s: { token: 'stale' } } };
+    const fresh = { codex: { s: { token: 'fresh' } } };
+
+    const first = queue.request('signals', stale);
+    await flushAsync();
+    queue.request('signals', stale);
+    queue.request('signals', fresh);
+    release();
+    await flushAsync();
+    release();
+    await first;
+
+    assert.deepEqual(observed, [stale, fresh],
+        'a coalesced batch replays the newest observation rather than the one it queued behind');
+});
+
 test('ATTENTION-EXECUTION-STATE-SYNC-001 keeps draining after an evaluation throws', async () => {
-    const scopes = [];
+    const observed = [];
     const failures = [];
     const queue = new AttentionEvaluationQueue({
-        evaluate: async scope => {
-            scopes.push(scope);
-            throw new Error(`boom:${scope}`);
+        evaluate: async request => {
+            observed.push(request.scope);
+            throw new Error(`boom:${request.scope}`);
         },
         onFailure: error => failures.push(error instanceof Error ? error.message : String(error)),
     });
 
     await queue.request('signals');
-    assert.deepEqual(scopes, ['signals']);
+    assert.deepEqual(observed, ['signals']);
     assert.deepEqual(failures, ['boom:signals']);
     assert.equal(queue.isIdle(), true, 'a failed evaluation must not wedge the queue');
 
     await queue.request('runtimes');
-    assert.deepEqual(scopes, ['signals', 'runtimes']);
+    assert.deepEqual(observed, ['signals', 'runtimes']);
 });

--- a/tests/contract/aiSessions/attention.test.js
+++ b/tests/contract/aiSessions/attention.test.js
@@ -12,6 +12,7 @@ const {
     loadFreshWithFakeVscode,
 } = require('../../helpers/runtimeContract');
 const AttentionMonitor = require('../../../out/aiSessions/attentionMonitor').default;
+const ExecutionMonitor = require('../../../out/aiSessions/executionMonitor').default;
 const {
     AiSessionAttentionController,
     settleAiSessionRuntimeLifecycles,
@@ -1118,4 +1119,39 @@ test('ATTENTION-EXECUTION-STATE-SYNC-001 keeps draining after an evaluation thro
 
     await queue.request('runtimes');
     assert.deepEqual(observed, ['signals', 'runtimes']);
+});
+
+test('ATTENTION-EXECUTION-STATE-SYNC-001 rejects an out-of-order signal in both monitors alike', () => {
+    const key = 'codex:session';
+    const running = {
+        token: 'codex:task-started:2000',
+        phase: 'running',
+        executionState: 'running',
+        occurredAtMs: 2000,
+    };
+    // A replay of an older completion, e.g. after a cursor was rebuilt from the
+    // start of the transcript. The execution monitor already ignores it.
+    const staleCompletion = {
+        token: 'codex:task-complete:1000',
+        phase: 'needsAttention',
+        reason: 'completed',
+        executionState: 'stopped',
+        occurredAtMs: 1000,
+    };
+
+    const execution = new ExecutionMonitor({ now: () => 3000 });
+    execution.evaluate([{ key, signal: running }]);
+    execution.evaluate([{ key, signal: staleCompletion }]);
+    assert.equal(execution.getSnapshot()[key].state, 'running');
+
+    const attention = new AttentionMonitor({ now: () => 3000 });
+    attention.evaluate([{ key, signal: running, observedAt: running.occurredAtMs }]);
+    const replayed = attention.evaluate([
+        { key, signal: staleCompletion, observedAt: staleCompletion.occurredAtMs },
+    ]);
+
+    assert.deepEqual(replayed, [],
+        'a signal older than the last accepted one must not raise attention');
+    assert.equal(attention.getSnapshot()[key].state, 'running',
+        'both monitors must reach the same conclusion from the same signal order');
 });

--- a/tests/contract/aiSessions/sessionControllers.test.js
+++ b/tests/contract/aiSessions/sessionControllers.test.js
@@ -6,6 +6,9 @@ const { AiSessionCreationController } = require('../../../out/aiSessions/creatio
 const { AiSessionResumeController } = require('../../../out/aiSessions/resumeController');
 const { AiSessionTerminalCommandController } = require('../../../out/aiSessions/terminalCommandController');
 const { AiSessionExecutionController } = require('../../../out/aiSessions/executionController');
+const {
+    AiSessionLifecycleSignalReader,
+} = require('../../../out/aiSessions/lifecycleSignalReader');
 
 const workspace = {
     navigationIdentity: 'navigation:fixture',
@@ -424,15 +427,88 @@ test('SESSION-AI-SESSION-EXECUTION-CONTROLLER-001 schedules one refresh only whe
     let token = 'one';
     const controller = new AiSessionExecutionController({
         getActiveSessions: () => [{ provider: 'codex', sessionId: 's', runStartedAtMs: 1 }],
-        getProviders: () => [{ id: 'codex', service: { getLifecycleSignals: () => ({ s: {
-            token, occurredAtMs: token === 'one' ? 2 : 3, executionState: token === 'one' ? 'running' : 'stopped',
-        } }) } }],
         scheduleRefresh: reason => refreshes.push(reason), nowMs: () => 1,
     });
-    controller.evaluate();
-    controller.evaluate();
+    const signals = () => ({ codex: { s: {
+        token, occurredAtMs: token === 'one' ? 2 : 3, executionState: token === 'one' ? 'running' : 'stopped',
+    } } });
+    controller.evaluate(signals());
+    controller.evaluate(signals());
     token = 'two';
-    controller.evaluate();
+    controller.evaluate(signals());
     assert.deepEqual(refreshes, ['execution', 'execution']);
     assert.equal(controller.getSnapshot()['codex:s'].state, 'stopped');
+
+    assert.deepEqual(controller.getLifecycleRequests(), {
+        codex: [{ sessionId: 's', runStartedAtMs: 1 }],
+    }, 'the controller publishes its request set for the shared reader to merge');
+});
+
+test('SESSION-AI-SESSION-EXECUTION-MONITOR-001 reads lifecycle signals once for the union of every consumer', () => {
+    const calls = [];
+    const service = providerId => ({
+        getLifecycleSignals: requests => {
+            calls.push({
+                provider: providerId,
+                requests: requests.map(request => request.sessionId).sort(),
+            });
+            return Object.fromEntries(requests.map(request => [request.sessionId, {
+                token: `${providerId}:${request.sessionId}`,
+                phase: 'running',
+                executionState: 'running',
+                occurredAtMs: 10,
+            }]));
+        },
+    });
+    const providers = [
+        { id: 'codex', service: service('codex') },
+        { id: 'claude', service: service('claude') },
+    ];
+
+    // Execution tracks the live runtimes; attention additionally keeps a session
+    // whose runtime is settling. Each provider must see one merged request set
+    // covering only its own sessions.
+    const reader = new AiSessionLifecycleSignalReader({
+        getProviders: () => providers,
+        getRequests: () => [
+            { codex: [{ sessionId: 'shared', runStartedAtMs: 0 }] },
+            {
+                codex: [
+                    { sessionId: 'shared', runStartedAtMs: 0 },
+                    { sessionId: 'settling', runStartedAtMs: 0 },
+                ],
+            },
+        ],
+    });
+    const signals = reader.read();
+
+    assert.deepEqual(calls, [{ provider: 'codex', requests: ['settling', 'shared'] }],
+        'the owning provider is asked once for the union and foreign providers are not asked');
+    assert.equal(signals.codex.shared.token, 'codex:shared');
+    assert.equal(signals.codex.settling.token, 'codex:settling');
+    assert.deepEqual(signals.claude, {}, 'a provider with no requested session still reports an empty map');
+});
+
+test('SESSION-AI-SESSION-EXECUTION-MONITOR-001 keeps the first run start when consumers disagree', () => {
+    const calls = [];
+    const providers = [{
+        id: 'codex',
+        service: {
+            getLifecycleSignals: requests => {
+                calls.push(requests.map(request => `${request.sessionId}@${request.runStartedAtMs}`));
+                return {};
+            },
+        },
+    }];
+    const reader = new AiSessionLifecycleSignalReader({
+        getProviders: () => providers,
+        getRequests: () => [
+            { codex: [{ sessionId: 'a', runStartedAtMs: 100 }] },
+            // A stale duplicate must not add a second request for the same session,
+            // which would make the provider rebuild its cursor every read.
+            { codex: [{ sessionId: 'a', runStartedAtMs: 200 }] },
+        ],
+    });
+    reader.read();
+    assert.deepEqual(calls, [['a@100']]);
 });

--- a/tests/integration/dashboard/sessionRuntimeFlow.test.js
+++ b/tests/integration/dashboard/sessionRuntimeFlow.test.js
@@ -245,6 +245,71 @@ test('WEBVIEW-AI-SESSION-DASHBOARD-WATCHER-COALESCING-001 coalesces watcher refr
     assert.deepEqual(reasons, ['watcher', 'watcher', 'attention']);
 });
 
+test('WEBVIEW-AI-SESSION-DASHBOARD-WATCHER-COALESCING-001 never postpones a pending status refresh behind later watcher events', async () => {
+    const clock = createFakeClock(1000);
+    const reasons = [];
+    const { AiSessionDashboardController } = loadFreshWithFakeVscode(
+        '../../../out/aiSessions/dashboardController', {}, __dirname
+    );
+    let cardRevision = 0;
+    const controller = new AiSessionDashboardController({
+        providerIds: ['codex'],
+        isVisible: () => true,
+        invalidateCache: () => undefined,
+        watchSessionChanges: () => ({ dispose() {} }),
+        getGroups: () => [], getTodoSearchItems: () => [],
+        // A live session keeps mutating, so no refresh is ever skipped as unchanged.
+        getCards: () => { cardRevision += 1; return []; },
+        getRunningCardAnimation: () => `revision-${cardRevision}`,
+        getRunningIconAnimation: () => undefined,
+        nextSequence: () => reasons.length + 1,
+        postMessage: () => Promise.resolve(true),
+        refresh: () => undefined,
+        logError: (_message, error) => { throw error; },
+        beforeRefresh: reason => reasons.push({ reason, atMs: clock.nowMs }),
+        afterRefresh: () => undefined,
+        nowMs: () => clock.nowMs,
+        debounceMs: 100,
+        watcherRefreshMinIntervalMs: 1000,
+        newSessionRefreshDelaysMs: [],
+        setTimeout: (callback, delay) => clock.setTimeout(callback, delay),
+        clearTimeout: handle => clock.clearTimeout(handle),
+    });
+
+    // Establish lastWatcherRefreshAtMs, exactly as a live session does.
+    controller.scheduleRefresh('watcher');
+    clock.advanceBy(100);
+    await new Promise(resolve => setImmediate(resolve));
+    assert.equal(reasons.length, 1);
+
+    // The execution monitor observes a state change and asks for a prompt repaint.
+    const requestedAtMs = clock.nowMs;
+    controller.scheduleRefresh('execution');
+
+    // The provider JSONL poller keeps firing while the session streams output.
+    // Each watcher event must not push the pending execution refresh further out.
+    for (let index = 0; index < 4; index += 1) {
+        clock.advanceBy(90);
+        controller.scheduleRefresh('watcher');
+        await new Promise(resolve => setImmediate(resolve));
+    }
+    clock.advanceBy(1000);
+    await new Promise(resolve => setImmediate(resolve));
+
+    const settled = reasons.find(entry => entry.atMs > requestedAtMs);
+    assert.ok(settled, 'the pending status refresh must eventually run');
+    assert.equal(
+        settled.atMs - requestedAtMs,
+        100,
+        'a status refresh must land on its own debounce deadline, not the watcher interval'
+    );
+    assert.equal(
+        settled.reason,
+        'execution',
+        'a coalesced status refresh must keep the urgent reason instead of being downgraded'
+    );
+});
+
 test('WEBVIEW-AI-SESSION-DASHBOARD-CONTROLLER-001 invalidates and refreshes for every new-session delay', async () => {
     const invalidated = [];
     const messages = [];

--- a/tests/unit/tooling/changedCoverage.test.js
+++ b/tests/unit/tooling/changedCoverage.test.js
@@ -9,6 +9,7 @@ const {
     addUntrackedChangedLines,
     changedCoveragePercentage,
     collectChangedLineCoverage,
+    isUninstrumentedByDesign,
     listUntrackedFiles,
     main,
     parseChangedLines,
@@ -79,6 +80,42 @@ test('COVERAGE-CHANGED-CODE-001 reports uncovered executable changed lines and m
         missingFiles: ['src/missing.ts'],
     });
     assert.equal(changedCoveragePercentage(result), 50);
+});
+
+test('COVERAGE-CHANGED-CODE-001 exempts only the paths the suite structurally cannot instrument', () => {
+    assert.equal(isUninstrumentedByDesign('src/dashboard.ts'), true);
+    assert.equal(isUninstrumentedByDesign('scripts/run-ai-session-safety-checks.js'), true);
+    assert.equal(isUninstrumentedByDesign('src/aiSessions/dashboardController.ts'), false);
+    assert.equal(isUninstrumentedByDesign('scripts/lib/behaviorCatalog.js'), false);
+    assert.equal(isUninstrumentedByDesign('scripts/run-nested/helper.js'), false);
+
+    const root = path.resolve('/repo');
+    const diff = [
+        'diff --git a/src/dashboard.ts b/src/dashboard.ts',
+        '--- a/src/dashboard.ts',
+        '+++ b/src/dashboard.ts',
+        '@@ -1,0 +1,1 @@',
+        '+wireController();',
+        'diff --git a/src/missing.ts b/src/missing.ts',
+        '--- a/src/missing.ts',
+        '+++ b/src/missing.ts',
+        '@@ -1,0 +1,1 @@',
+        '+untested();',
+    ].join('\n');
+    const exempt = collectChangedLineCoverage(root, {}, parseChangedLines(diff));
+    assert.deepEqual(exempt.missingFiles, ['src/missing.ts'],
+        'an exempt path is skipped while a genuinely uninstrumented one still fails');
+
+    const output = [];
+    const logger = { error: message => output.push(message), log: () => undefined };
+    assert.equal(main({
+        root,
+        coverage: {},
+        threshold: 80,
+        base: 'base',
+        diff: diff.split('\n').slice(0, 5).join('\n'),
+        logger,
+    }), 0, 'a wiring-only dashboard change must not fail the gate');
 });
 
 test('COVERAGE-CHANGED-CODE-001 treats type-only diffs as fully covered and validates thresholds', () => {


### PR DESCRIPTION
The running animation and the attention dot are two views of one thing — the
provider lifecycle signal — but they were produced by two independent pipelines
at different rates and reconciled only by luck. The reported symptom was a red
dot that survived for seconds after the animation had already started.

## What was wrong

Measured on the real controllers driven at production cadences:

```
t= 10000ms  session completed -> dot        animation=off  redDot=YES
t= 10000ms  >>> user replies, provider emits phase=running
t= 11000ms                                  animation=ON   redDot=YES  <- animation starts
t= 20000ms                                  animation=ON   redDot=no   <- 9s later
```

Three independent causes, each sufficient on its own:

1. **Cadence.** Execution evaluated every 1s; attention only on a 10s interval.
   The JSONL watcher — the one thing that knows a session changed — only
   triggered a repaint, never an attention re-evaluation.
2. **Refresh scheduling.** `scheduleRefresh` re-armed its single timer on the
   newest reason. With the provider poller firing every 3s, an urgent repaint
   was pushed out to the watcher interval and relabelled: measured at 14.6s.
3. **Two reads.** Each pass called `getLifecycleSignals` for its own session
   set. That method retains only the sessions named in the call, so whichever
   ran last evicted the other's incremental JSONL cursors and forced a full
   transcript re-read — a synchronous `fs.readSync` on the extension host, once
   a second. It also left the two surfaces derived from reads taken moments
   apart.

Plus a genuine defect: the attention monitor deduplicated only by token while
the execution monitor also rejected signals older than the last accepted one.
Fed a replayed completion — which a rebuilt cursor does produce — the animation
kept running while the dot was raised again for a superseded turn.

## What changed

- Execution edges request an attention evaluation through a coalescing queue.
- The 1s tick reads provider signals **once** for the union of both consumers
  and hands the same object to both passes, so they cannot disagree.
- `scheduleRefresh` never postpones a pending refresh or downgrades its reason.
- Both monitors share one `acceptsLifecycleSignal` rule.
- The expensive tmux ownership reconciliation stays on the 10s interval, which
  is now a fallback heartbeat rather than the primary path.

## Not included, deliberately

Merging the two monitors into one snapshot. The remaining differences are one
narrow (run-scoped keys exist only transiently during settlement) and one
intentional (the dot must outlive runtime teardown). With shared inputs and a
shared acceptance rule, the structural win no longer justifies touching the
settlement override path.

Still open: when the bridge extension stops broadcasting, `getEffectiveAggregate`
keeps returning the last remote aggregate forever, freezing the dot with no
recovery path. Independent of this change; needs cross-window ack semantics.

## Incidental

`check-changed-coverage.js` hard-failed on any diff touching `src/dashboard.ts`
or a standalone `scripts/run-*.js`, neither of which the suite can instrument —
the entry point is only loaded by a harness that disables `NODE_V8_COVERAGE`,
and the check scripts are spawned with `execFile`. Nothing had changed those
paths since the gate landed, so the first such change would have blocked CI.
Now exempted with the reason recorded, composing with the untracked-file
handling added by #61.

The watcher-coalescing safety check asserted the old clear-and-re-arm mechanics;
it now asserts the deadline semantics it was protecting.

## Verification

Both behaviours were driven red before the fix — the attention test reproduces
`{ animation: true, redDot: true }` exactly when the wiring is removed, and the
scheduling test measured 1000ms against an expected 100ms.

Rebased onto #61 and re-verified: 1181 tests, browser 121, safety, guards,
dashboard, release notes, remote sources, conversation performance, behaviour
contracts, lint. Changed-line coverage 99.30%. Also validated in a real session
by the author against a packaged build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)