### PR TITLE
fix: shorten macOS Extension Host socket paths

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -36,6 +36,8 @@ jobs:
         run: npx playwright install --with-deps chromium
       - name: Run Linux quality gate
         run: npm run test:ci:linux
+        env:
+          COVERAGE_DIFF_BASE: ${{ github.event.pull_request.base.sha }}
 
   platform-windows:
     name: platform-windows

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "7e81fe4e46bc9eada5969bc7f473e58555d273a1",
+        "head": "c329ea110bdb034df07fcbcfa182f336751b1f47",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -825,7 +825,8 @@
                 "57f42aa6a293f77b0a27b5114f56d7c29cae2b5a",
                 "fed784c668dc7cf1dade22270d23565e485751a4",
                 "14622809706f9e9c792d6e3413869b5627490b44",
-                "0251b56e920c011368e6f71425f9c852c7da0f38"
+                "0251b56e920c011368e6f71425f9c852c7da0f38",
+                "c329ea110bdb034df07fcbcfa182f336751b1f47"
             ],
             "behaviors": [
                 "ARCH-CI-QUALITY-GATE-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "c329ea110bdb034df07fcbcfa182f336751b1f47",
+        "head": "9f50c6b6c54e86279b88ba05207489e476613333",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -826,7 +826,8 @@
                 "fed784c668dc7cf1dade22270d23565e485751a4",
                 "14622809706f9e9c792d6e3413869b5627490b44",
                 "0251b56e920c011368e6f71425f9c852c7da0f38",
-                "c329ea110bdb034df07fcbcfa182f336751b1f47"
+                "c329ea110bdb034df07fcbcfa182f336751b1f47",
+                "9f50c6b6c54e86279b88ba05207489e476613333"
             ],
             "behaviors": [
                 "ARCH-CI-QUALITY-GATE-001",

--- a/scripts/lib/extensionHostLauncher.js
+++ b/scripts/lib/extensionHostLauncher.js
@@ -3,6 +3,7 @@
 const fs = require('node:fs');
 const crypto = require('node:crypto');
 const childProcess = require('node:child_process');
+const os = require('node:os');
 const path = require('node:path');
 const {
     resolveCliArgsFromVSCodeExecutablePath,
@@ -22,6 +23,14 @@ const OWNERSHIP_MARKER = '.agent-pivot-extension-host-test';
 const OWNERSHIP_VALUE = 'owned temporary extension host test directory\n';
 const MAIN_EXTENSION_ID = 'hzcheng.agent-pivot';
 const BRIDGE_EXTENSION_ID = 'hzcheng.agent-pivot-attention-ui-bridge';
+
+function extensionHostTemporaryRootPrefix(
+    platform = process.platform,
+    tempDirectory = os.tmpdir()
+) {
+    const parent = platform === 'darwin' ? '/tmp' : tempDirectory;
+    return path.join(parent, 'ap-eh-');
+}
 
 function readJson(filePath) {
     return JSON.parse(fs.readFileSync(filePath, 'utf8'));
@@ -390,6 +399,7 @@ module.exports = {
     createExtensionHostTestEnvironment,
     createExtensionPackagePlan,
     createRunTestsOptions,
+    extensionHostTemporaryRootPrefix,
     installPackagedExtensions,
     removeExtensionHostTestEnvironment,
     runWorkerWithWatchdog,

--- a/scripts/run-extension-host-tests.js
+++ b/scripts/run-extension-host-tests.js
@@ -7,19 +7,33 @@ const childProcess = require('node:child_process');
 const {
     EXTENSION_HOST_WORKER_TIMEOUT_MS,
     createExtensionHostTestEnvironment,
+    extensionHostTemporaryRootPrefix,
     removeExtensionHostTestEnvironment,
     runWorkerWithWatchdog,
     withSanitizedExtensionHostEnvironment,
 } = require('./lib/extensionHostLauncher');
 
-async function main() {
-    const repositoryRoot = path.resolve(__dirname, '..');
-    const isolatedRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-pivot-extension-host-'));
+async function main(options = {}) {
+    const repositoryRoot = options.repositoryRoot || path.resolve(__dirname, '..');
+    const isolatedRoot = (options.mkdtempSync || fs.mkdtempSync)(
+        extensionHostTemporaryRootPrefix(
+            options.platform || process.platform,
+            options.tempDirectory || os.tmpdir()
+        )
+    );
+    const createEnvironment = options.createExtensionHostTestEnvironment
+        || createExtensionHostTestEnvironment;
+    const sanitize = options.withSanitizedExtensionHostEnvironment
+        || withSanitizedExtensionHostEnvironment;
+    const runWorker = options.runWorkerWithWatchdog || runWorkerWithWatchdog;
+    const spawn = options.spawn || childProcess.spawn;
+    const removeEnvironment = options.removeExtensionHostTestEnvironment
+        || removeExtensionHostTestEnvironment;
     try {
-        const environment = createExtensionHostTestEnvironment(isolatedRoot);
+        const environment = createEnvironment(isolatedRoot);
         const workerPath = path.join(__dirname, 'run-extension-host-worker.js');
-        await withSanitizedExtensionHostEnvironment(() => runWorkerWithWatchdog(
-            () => childProcess.spawn(process.execPath, [
+        await sanitize(() => runWorker(
+            () => spawn(process.execPath, [
                 workerPath,
                 repositoryRoot,
                 JSON.stringify(environment),
@@ -31,11 +45,15 @@ async function main() {
             { timeoutMs: EXTENSION_HOST_WORKER_TIMEOUT_MS }
         ));
     } finally {
-        removeExtensionHostTestEnvironment(isolatedRoot);
+        removeEnvironment(isolatedRoot);
     }
 }
 
-main().catch(error => {
-    console.error(`Extension Host smoke failed: ${error && error.stack ? error.stack : error}`);
-    process.exitCode = 1;
-});
+if (require.main === module) {
+    main().catch(error => {
+        console.error(`Extension Host smoke failed: ${error && error.stack ? error.stack : error}`);
+        process.exitCode = 1;
+    });
+}
+
+module.exports = { main };

--- a/tests/unit/tooling/changedCoverage.test.js
+++ b/tests/unit/tooling/changedCoverage.test.js
@@ -197,6 +197,10 @@ test('COVERAGE-CHANGED-CODE-001 remains wired after JSON coverage production in 
     );
     assert.match(workflow, /fetch-depth: 0/);
     assert.match(workflow, /npm run test:ci:linux/);
+    assert.match(
+        workflow,
+        /COVERAGE_DIFF_BASE: \$\{\{ github\.event\.pull_request\.base\.sha \}\}/
+    );
     const releasePackagingGate = fs.readFileSync(
         path.join(root, 'scripts/run-release-packaging-checks.js'),
         'utf8'

--- a/tests/unit/tooling/extensionHostLauncher.test.js
+++ b/tests/unit/tooling/extensionHostLauncher.test.js
@@ -17,12 +17,24 @@ const {
     createExtensionHostTestEnvironment,
     createExtensionPackagePlan,
     createRunTestsOptions,
+    extensionHostTemporaryRootPrefix,
     installPackagedExtensions,
     removeExtensionHostTestEnvironment,
     runWorkerWithWatchdog,
     verifyInstalledExtensionBytes,
     withSanitizedExtensionHostEnvironment,
 } = require('../../../scripts/lib/extensionHostLauncher');
+
+test('RELEASE-SCHEDULED-EXTENSION-HOST-001 keeps macOS IPC paths below the Unix socket limit', () => {
+    assert.equal(
+        extensionHostTemporaryRootPrefix('darwin', '/var/folders/long/random/T'),
+        '/tmp/ap-eh-'
+    );
+    assert.equal(
+        extensionHostTemporaryRootPrefix('linux', '/custom/tmp'),
+        '/custom/tmp/ap-eh-'
+    );
+});
 
 function writeFile(filePath, value) {
     fs.mkdirSync(path.dirname(filePath), { recursive: true });

--- a/tests/unit/tooling/extensionHostRunner.test.js
+++ b/tests/unit/tooling/extensionHostRunner.test.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const test = require('node:test');
+
+const { main } = require('../../../scripts/run-extension-host-tests');
+
+// RELEASE-SCHEDULED-EXTENSION-HOST-001
+test('RELEASE-SCHEDULED-EXTENSION-HOST-001 runner uses the short macOS root and always cleans it', async () => {
+    const calls = [];
+    const isolatedRoot = '/tmp/ap-eh-fixture';
+    const environment = { workspace: `${isolatedRoot}/workspace` };
+    await main({
+        repositoryRoot: '/repository',
+        platform: 'darwin',
+        tempDirectory: '/var/folders/long/random/T',
+        mkdtempSync: prefix => {
+            calls.push(['mkdtemp', prefix]);
+            return isolatedRoot;
+        },
+        createExtensionHostTestEnvironment: root => {
+            calls.push(['environment', root]);
+            return environment;
+        },
+        withSanitizedExtensionHostEnvironment: async callback => {
+            calls.push(['sanitize']);
+            return callback();
+        },
+        runWorkerWithWatchdog: async (spawnWorker, options) => {
+            calls.push(['watchdog', options]);
+            spawnWorker();
+        },
+        spawn: (command, args, options) => {
+            calls.push(['spawn', command, args, options]);
+            return {};
+        },
+        removeExtensionHostTestEnvironment: root => {
+            calls.push(['remove', root]);
+        },
+    });
+
+    assert.deepEqual(calls.map(([kind]) => kind), [
+        'mkdtemp',
+        'environment',
+        'sanitize',
+        'watchdog',
+        'spawn',
+        'remove',
+    ]);
+    assert.equal(calls[0][1], '/tmp/ap-eh-');
+    assert.equal(calls[4][1], process.execPath);
+    assert.deepEqual(calls[4][2], [
+        path.resolve(__dirname, '../../../scripts/run-extension-host-worker.js'),
+        '/repository',
+        JSON.stringify(environment),
+    ]);
+    assert.equal(calls[4][3].detached, process.platform !== 'win32');
+    assert.equal(calls[5][1], isolatedRoot);
+});


### PR DESCRIPTION
## Summary
- use the short /tmp/ap-eh-* isolation prefix on macOS so VS Code IPC sockets stay below the 103-character Unix socket limit
- keep Linux and Windows temporary-root behavior unchanged
- make the Extension Host runner injectable and cover short-root selection, spawn arguments, watchdog wiring, and cleanup

## Root cause evidence
Scheduled Verification run 30639037452 packaged and installed both VSIX files, verified all representative SHA-256 hashes, then failed before activation with a 1.13-main.sock path longer than 103 characters and listen EINVAL.

## Verification
- npm run test:ci:linux
- npm run test:behavior-contracts
- 15 focused Extension Host tests
- changed line coverage: 87.18% (34/39)

## Workflow lesson review
- no skill text update; the reusable prevention is implemented and regression-tested directly in the Extension Host runner