### PR TITLE
Fix Extension Host suite ownership

### DIFF
--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "9f50c6b6c54e86279b88ba05207489e476613333",
+        "head": "59ef5de5b9c2105c28c046ad1ff173f191746b21",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -827,7 +827,8 @@
                 "14622809706f9e9c792d6e3413869b5627490b44",
                 "0251b56e920c011368e6f71425f9c852c7da0f38",
                 "c329ea110bdb034df07fcbcfa182f336751b1f47",
-                "9f50c6b6c54e86279b88ba05207489e476613333"
+                "9f50c6b6c54e86279b88ba05207489e476613333",
+                "59ef5de5b9c2105c28c046ad1ff173f191746b21"
             ],
             "behaviors": [
                 "ARCH-CI-QUALITY-GATE-001",

--- a/scripts/lib/extensionHostLauncher.js
+++ b/scripts/lib/extensionHostLauncher.js
@@ -23,6 +23,7 @@ const OWNERSHIP_MARKER = '.agent-pivot-extension-host-test';
 const OWNERSHIP_VALUE = 'owned temporary extension host test directory\n';
 const MAIN_EXTENSION_ID = 'hzcheng.agent-pivot';
 const BRIDGE_EXTENSION_ID = 'hzcheng.agent-pivot-attention-ui-bridge';
+const TEST_HARNESS_EXTENSION_ID = 'hzcheng.agent-pivot-extension-host-tests';
 
 function extensionHostTemporaryRootPrefix(
     platform = process.platform,
@@ -240,6 +241,7 @@ function createExtensionHostTestEnvironment(isolatedRoot) {
         workspace: path.join(isolatedRoot, 'workspace'),
         userData: path.join(isolatedRoot, 'user-data'),
         extensions: path.join(isolatedRoot, 'extensions'),
+        testHarness: path.join(isolatedRoot, 'test-harness'),
         home: path.join(isolatedRoot, 'home'),
         xdgConfigHome: path.join(isolatedRoot, 'xdg', 'config'),
         xdgDataHome: path.join(isolatedRoot, 'xdg', 'data'),
@@ -254,17 +256,60 @@ function createExtensionHostTestEnvironment(isolatedRoot) {
     return environment;
 }
 
+function createExtensionHostTestHarness(repositoryRoot, harnessRoot) {
+    if (!path.isAbsolute(repositoryRoot || '') || !path.isAbsolute(harnessRoot || '')) {
+        throw new Error('Extension Host test harness paths must be absolute.');
+    }
+    const runnerSource = path.join(
+        repositoryRoot,
+        'tests',
+        'extension-host',
+        'suite',
+        'index.js'
+    );
+    const runnerPath = path.join(harnessRoot, 'index.js');
+    fs.mkdirSync(harnessRoot, { recursive: true });
+    fs.copyFileSync(runnerSource, runnerPath);
+    fs.writeFileSync(path.join(harnessRoot, 'extension.js'), [
+        "'use strict';",
+        'exports.activate = function activate() {};',
+        '',
+    ].join('\n'));
+    fs.writeFileSync(path.join(harnessRoot, 'package.json'), JSON.stringify({
+        name: TEST_HARNESS_EXTENSION_ID.slice(
+            TEST_HARNESS_EXTENSION_ID.indexOf('.') + 1
+        ),
+        publisher: TEST_HARNESS_EXTENSION_ID.slice(
+            0,
+            TEST_HARNESS_EXTENSION_ID.indexOf('.')
+        ),
+        version: '1.0.0',
+        engines: { vscode: `^${VSCODE_STABLE_VERSION}` },
+        main: './extension.js',
+        extensionKind: ['ui'],
+    }, null, 2));
+    return { root: harnessRoot, runnerPath };
+}
+
 function createRunTestsOptions(
     repositoryRoot,
     environment,
     vscodeExecutablePath,
-    installedRoots
+    installedRoots,
+    testHarness
 ) {
     const mainExtensionRoot = installedRoots && installedRoots[MAIN_EXTENSION_ID];
     const bridgeExtensionRoot = installedRoots && installedRoots[BRIDGE_EXTENSION_ID];
+    const harnessRoot = testHarness && testHarness.root;
+    const runnerPath = testHarness && testHarness.runnerPath;
+    const runnerRelativePath = path.relative(harnessRoot || '', runnerPath || '');
     if (!path.isAbsolute(vscodeExecutablePath || '')
         || !path.isAbsolute(mainExtensionRoot || '')
-        || !path.isAbsolute(bridgeExtensionRoot || '')) {
+        || !path.isAbsolute(bridgeExtensionRoot || '')
+        || !path.isAbsolute(harnessRoot || '')
+        || !path.isAbsolute(runnerPath || '')
+        || runnerRelativePath.startsWith('..')
+        || path.isAbsolute(runnerRelativePath)) {
         throw new Error('Extension Host test requires absolute installed extension paths.');
     }
     return {
@@ -272,8 +317,9 @@ function createRunTestsOptions(
         extensionDevelopmentPath: [
             mainExtensionRoot,
             bridgeExtensionRoot,
+            harnessRoot,
         ],
-        extensionTestsPath: path.join(repositoryRoot, 'tests', 'extension-host', 'suite', 'index.js'),
+        extensionTestsPath: runnerPath,
         launchArgs: [
             environment.workspace,
             `--user-data-dir=${environment.userData}`,
@@ -395,7 +441,9 @@ module.exports = {
     HOSTILE_EXTENSION_HOST_ENVIRONMENT_KEYS,
     BRIDGE_EXTENSION_ID,
     MAIN_EXTENSION_ID,
+    TEST_HARNESS_EXTENSION_ID,
     VSCODE_STABLE_VERSION,
+    createExtensionHostTestHarness,
     createExtensionHostTestEnvironment,
     createExtensionPackagePlan,
     createRunTestsOptions,

--- a/scripts/run-extension-host-worker.js
+++ b/scripts/run-extension-host-worker.js
@@ -6,6 +6,7 @@ const {
 } = require('@vscode/test-electron');
 const {
     VSCODE_STABLE_VERSION,
+    createExtensionHostTestHarness,
     createRunTestsOptions,
     installPackagedExtensions,
 } = require('./lib/extensionHostLauncher');
@@ -18,6 +19,8 @@ async function runExtensionHostWorker(repositoryRoot, environment, options = {})
     const download = options.downloadAndUnzipVSCode || downloadAndUnzipVSCode;
     const install = options.installPackagedExtensions || installPackagedExtensions;
     const createOptions = options.createRunTestsOptions || createRunTestsOptions;
+    const createHarness = options.createExtensionHostTestHarness
+        || createExtensionHostTestHarness;
     const executeTests = options.runTests || runTests;
     const logger = options.logger || console;
     logger.log(
@@ -37,6 +40,7 @@ async function runExtensionHostWorker(repositoryRoot, environment, options = {})
             `Verified installed ${item.extensionId} ${item.file} ${item.sha256}`
         );
     }
+    const testHarness = createHarness(repositoryRoot, environment.testHarness);
     logger.log(
         `Running installed Extension Host smoke with VS Code ${version}.`
     );
@@ -44,7 +48,8 @@ async function runExtensionHostWorker(repositoryRoot, environment, options = {})
         repositoryRoot,
         environment,
         vscodeExecutablePath,
-        installation.installedRoots
+        installation.installedRoots,
+        testHarness
     ));
 }
 

--- a/tests/unit/tooling/extensionHostLauncher.test.js
+++ b/tests/unit/tooling/extensionHostLauncher.test.js
@@ -13,8 +13,10 @@ const {
     HOSTILE_EXTENSION_HOST_ENVIRONMENT_KEYS,
     BRIDGE_EXTENSION_ID,
     MAIN_EXTENSION_ID,
+    TEST_HARNESS_EXTENSION_ID,
     VSCODE_STABLE_VERSION,
     createExtensionHostTestEnvironment,
+    createExtensionHostTestHarness,
     createExtensionPackagePlan,
     createRunTestsOptions,
     extensionHostTemporaryRootPrefix,
@@ -120,11 +122,16 @@ test('RELEASE-SCHEDULED-EXTENSION-HOST-001 launches both extensions with pinned 
             [MAIN_EXTENSION_ID]: path.join(environment.extensions, 'main'),
             [BRIDGE_EXTENSION_ID]: path.join(environment.extensions, 'bridge'),
         };
+        const testHarness = createExtensionHostTestHarness(
+            repositoryRoot,
+            environment.testHarness
+        );
         const options = createRunTestsOptions(
             repositoryRoot,
             environment,
             vscodeExecutablePath,
-            installedRoots
+            installedRoots,
+            testHarness
         );
         const packagePlan = createExtensionPackagePlan(repositoryRoot);
 
@@ -134,6 +141,7 @@ test('RELEASE-SCHEDULED-EXTENSION-HOST-001 launches both extensions with pinned 
         assert.deepEqual(options.extensionDevelopmentPath, [
             installedRoots[MAIN_EXTENSION_ID],
             installedRoots[BRIDGE_EXTENSION_ID],
+            environment.testHarness,
         ]);
         assert.deepEqual(packagePlan.map(item => item.id), [
             BRIDGE_EXTENSION_ID,
@@ -144,7 +152,7 @@ test('RELEASE-SCHEDULED-EXTENSION-HOST-001 launches both extensions with pinned 
             'agent-pivot-1.0.1.vsix',
         ]);
         assert.equal(options.extensionTestsPath,
-            path.join(repositoryRoot, 'tests', 'extension-host', 'suite', 'index.js'));
+            path.join(environment.testHarness, 'index.js'));
         assert.deepEqual(options.launchArgs, [
             environment.workspace,
             `--user-data-dir=${environment.userData}`,
@@ -172,6 +180,58 @@ test('RELEASE-SCHEDULED-EXTENSION-HOST-001 launches both extensions with pinned 
             assert.equal(fs.statSync(directory).isDirectory(), true);
             assert.equal(path.relative(isolatedRoot, directory).startsWith('..'), false);
         }
+    } finally {
+        removeExtensionHostTestEnvironment(isolatedRoot);
+    }
+});
+
+test('RELEASE-SCHEDULED-EXTENSION-HOST-001 binds the suite to a registered development host', () => {
+    const repositoryRoot = path.resolve(__dirname, '../../..');
+    const isolatedRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-pivot-hosted-suite-'));
+    try {
+        const environment = createExtensionHostTestEnvironment(isolatedRoot);
+        const harnessRoot = path.join(isolatedRoot, 'test-harness');
+        const testHarness = createExtensionHostTestHarness(
+            repositoryRoot,
+            harnessRoot
+        );
+        const installedRoots = {
+            [MAIN_EXTENSION_ID]: path.join(environment.extensions, 'main'),
+            [BRIDGE_EXTENSION_ID]: path.join(environment.extensions, 'bridge'),
+        };
+        const options = createRunTestsOptions(
+            repositoryRoot,
+            environment,
+            path.join(isolatedRoot, 'VS Code'),
+            installedRoots,
+            testHarness
+        );
+
+        assert.deepEqual(options.extensionDevelopmentPath, [
+            installedRoots[MAIN_EXTENSION_ID],
+            installedRoots[BRIDGE_EXTENSION_ID],
+            harnessRoot,
+        ]);
+        assert.equal(
+            path.relative(harnessRoot, options.extensionTestsPath).startsWith('..'),
+            false,
+            'the test path must be owned by a registered development extension'
+        );
+        const harnessManifest = JSON.parse(fs.readFileSync(
+            path.join(harnessRoot, 'package.json'),
+            'utf8'
+        ));
+        assert.equal(
+            `${harnessManifest.publisher}.${harnessManifest.name}`,
+            TEST_HARNESS_EXTENSION_ID
+        );
+        assert.equal(
+            fs.readFileSync(options.extensionTestsPath, 'utf8'),
+            fs.readFileSync(
+                path.join(repositoryRoot, 'tests', 'extension-host', 'suite', 'index.js'),
+                'utf8'
+            )
+        );
     } finally {
         removeExtensionHostTestEnvironment(isolatedRoot);
     }

--- a/tests/unit/tooling/extensionHostWorker.test.js
+++ b/tests/unit/tooling/extensionHostWorker.test.js
@@ -12,7 +12,10 @@ const {
 test('RELEASE-SCHEDULED-EXTENSION-HOST-001 installs verified VSIX bytes before Host activation', async () => {
     const calls = [];
     const logs = [];
-    const environment = { workspace: '/isolated/workspace' };
+    const environment = {
+        workspace: '/isolated/workspace',
+        testHarness: '/isolated/test-harness',
+    };
     const installedRoots = {
         'hzcheng.agent-pivot': '/isolated/extensions/main',
         'hzcheng.agent-pivot-attention-ui-bridge': '/isolated/extensions/bridge',
@@ -34,6 +37,13 @@ test('RELEASE-SCHEDULED-EXTENSION-HOST-001 installs verified VSIX bytes before H
                 installedRoots,
             };
         },
+        createExtensionHostTestHarness: (...args) => {
+            calls.push(['harness', ...args]);
+            return {
+                root: environment.testHarness,
+                runnerPath: `${environment.testHarness}/index.js`,
+            };
+        },
         createRunTestsOptions: (...args) => {
             calls.push(['options', ...args]);
             return { vscodeExecutablePath: '/downloaded/code' };
@@ -47,6 +57,7 @@ test('RELEASE-SCHEDULED-EXTENSION-HOST-001 installs verified VSIX bytes before H
     assert.deepEqual(calls.map(([kind]) => kind), [
         'download',
         'install',
+        'harness',
         'options',
         'run',
     ]);
@@ -61,9 +72,17 @@ test('RELEASE-SCHEDULED-EXTENSION-HOST-001 installs verified VSIX bytes before H
     ]);
     assert.deepEqual(calls[2].slice(1), [
         '/repository',
+        environment.testHarness,
+    ]);
+    assert.deepEqual(calls[3].slice(1), [
+        '/repository',
         environment,
         '/downloaded/code',
         installedRoots,
+        {
+            root: environment.testHarness,
+            runnerPath: `${environment.testHarness}/index.js`,
+        },
     ]);
     assert.match(logs.join('\n'), /Verified installed .* verified-sha/);
     assert.match(logs.join('\n'), /Running installed Extension Host smoke/);


### PR DESCRIPTION
## Summary
- create an isolated development-extension harness for the real Extension Host suite
- run the copied suite from that registered harness while preserving installed VSIX byte verification
- cover harness creation, launch ordering, and suite ownership with deterministic tests

## Root cause
VS Code 1.130.0 could load both installed development extensions, but the repository-level extensionTestsPath belonged to neither registered development extension. The test runner therefore had no Extension Host manager and returned without running or terminating.

## Verification
- focused launcher/worker/runner tests: 12 passed
- real Linux VS Code 1.130.0 Extension Host: RELEASE-SCHEDULED-EXTENSION-HOST-001 passed
- npm run test:behavior-contracts
- npm run test:ci:linux
- changed line coverage: 96.08% (49/51)

## Workflow lesson
No skill update: this is a gate-specific implementation constraint now enforced by the focused regression test.