### PR TITLE
fix: survive an unreachable attention bridge, and stop stat'ing session files twice

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -1056,6 +1056,19 @@
     ]
   },
   {
+    "id": "SESSION-CODEX-SESSION-SERVICE-001",
+    "domain": "session",
+    "title": "Codex change polling reuses discovery stats instead of stat'ing every file twice",
+    "priority": "P1",
+    "status": "automated",
+    "owners": [
+      "tests/contract/aiSessions/providerSpecificBehavior.test.js"
+    ],
+    "evidence": [
+      "src/services/codexSessionService.ts"
+    ]
+  },
+  {
     "id": "SESSION-CLAUDE-SESSION-SERVICE-001",
     "domain": "session",
     "title": "Claude session listing stats each file once instead of once per sort comparison",

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -1056,6 +1056,19 @@
     ]
   },
   {
+    "id": "SESSION-CLAUDE-SESSION-SERVICE-001",
+    "domain": "session",
+    "title": "Claude session listing stats each file once instead of once per sort comparison",
+    "priority": "P1",
+    "status": "automated",
+    "owners": [
+      "tests/contract/aiSessions/providerSpecificBehavior.test.js"
+    ],
+    "evidence": [
+      "src/services/claudeSessionService.ts"
+    ]
+  },
+  {
     "id": "ATTENTION-BRIDGE-STALENESS-001",
     "domain": "attention",
     "title": "A locally cleared session never stays lit on a frozen bridge aggregate",

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -1056,6 +1056,20 @@
     ]
   },
   {
+    "id": "ATTENTION-BRIDGE-STALENESS-001",
+    "domain": "attention",
+    "title": "A locally cleared session never stays lit on a frozen bridge aggregate",
+    "priority": "P0",
+    "status": "automated",
+    "owners": [
+      "tests/contract/aiSessions/attention.test.js"
+    ],
+    "evidence": [
+      "src/aiSessions/attentionAggregate.ts",
+      "src/aiSessions/attentionController.ts"
+    ]
+  },
+  {
     "id": "SESSION-AI-SESSION-EXECUTION-MONITOR-001",
     "domain": "session",
     "title": "AI Session Execution Monitor behavior",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "59ef5de5b9c2105c28c046ad1ff173f191746b21",
+        "head": "289779463fe347fba05bd3655ceded5189612f44",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -594,7 +594,12 @@
                 "82849460b41370f3b63bd9d86b18fef39f68233a",
                 "67e214e00533e4e267b3a7da55b08fcc09627488",
                 "65af1454e3c69afe0269c8d5dfcf955012981c72",
-                "7e81fe4e46bc9eada5969bc7f473e58555d273a1"
+                "7e81fe4e46bc9eada5969bc7f473e58555d273a1",
+                "31e9379591e2e2a3d5fbb3418a87d889951e32cd",
+                "c1f661c546f87c8fefcb17d4d3929d9adc46cd35",
+                "2bb3a1c255c2bb97809889d9d879d135b371e2ce",
+                "f51aa569d4adb1dd750947181008c3764dbe6163",
+                "289779463fe347fba05bd3655ceded5189612f44"
             ],
             "behaviors": [
                 "ATTENTION-ACTIVE-UNREGISTER-ON-DEACTIVATE-001",
@@ -604,7 +609,10 @@
                 "ATTENTION-USER-TERMINAL-CLOSE-001",
                 "ATTENTION-SINGLE-RUN-COMPLETION-DEDUP-001",
                 "ATTENTION-PRODUCTION-ATTENTION-STORE-LIFECYCLE-001",
-                "ATTENTION-EXECUTION-STATE-SYNC-001"
+                "ATTENTION-EXECUTION-STATE-SYNC-001",
+                "ATTENTION-BRIDGE-STALENESS-001",
+                "SESSION-CLAUDE-SESSION-SERVICE-001",
+                "SESSION-CODEX-SESSION-SERVICE-001"
             ],
             "prGates": [
                 "test:deterministic:run"

--- a/scripts/run-ai-session-safety-checks.js
+++ b/scripts/run-ai-session-safety-checks.js
@@ -5184,18 +5184,21 @@ function runWebviewContentChecks() {
     assert.ok(dashboard.includes('new WorkspaceSessionHydrationController<vscode.Terminal>({'));
     assert.ok(dashboard.includes('getExecutionSnapshot: () => aiSessionExecutionController.getSnapshot()'));
     assert.ok(dashboard.includes('getActiveSessions: () => aiSessionRuntimeCoordinator.getActive()'));
-    // The tick reads provider signals once and drives both the execution and the
-    // attention pass from that single observation, so the running animation and
-    // the attention dot can never be derived from two different reads.
+    // The cadence itself lives in createAiSessionStatusCapability and is covered
+    // behaviourally by ATTENTION-EXECUTION-STATE-SYNC-001; assert only that the
+    // dashboard hands it both consumers and routes the tick through it.
+    assert.ok(dashboard.includes(
+        "import { createAiSessionStatusCapability } from './aiSessions/statusCapability';"
+    ));
     assert.match(dashboard,
-        /const evaluateAiSessionLifecycleTick = \(\): void => \{\s*const signals = aiSessionLifecycleSignals\.read\(\);\s*aiSessionExecutionController\.evaluate\(signals\);\s*void aiSessionAttentionEvaluations\.request\('signals', signals\);\s*\}/);
+        /getLifecycleRequests: \(\) => \[\s*aiSessionExecutionController\.getLifecycleRequests\(\),\s*aiSessionAttentionController\.getLifecycleRequests\(\),\s*\]/);
     assert.match(dashboard,
-        /ownTimer\(\s*\(\) => setInterval\(evaluateAiSessionLifecycleTick, 1_000\),\s*handle => clearInterval\(handle\),\s*\)/);
+        /evaluateExecution: signals => aiSessionExecutionController\.evaluate\(signals\)/);
     assert.match(dashboard,
-        /ownTimer\(\s*\(\) => setTimeout\(evaluateAiSessionLifecycleTick, 0\),\s*handle => clearTimeout\(handle\),\s*\)/);
+        /evaluateAttentionSignals: signals => aiSessionAttentionController\.evaluate\(\[\], signals\)/);
+    assert.match(dashboard,
+        /const evaluateAiSessionLifecycleTick = \(\): void => aiSessionStatus\.tick\(\);/);
     assert.match(dashboard, /onDidCloseTerminal\(terminal => \{[\s\S]*?handleClosedTerminal\(terminal\);[\s\S]*?evaluateAiSessionLifecycleTick\(\);/);
-    assert.match(dashboard,
-        /getRequests: \(\) => \[\s*aiSessionExecutionController\.getLifecycleRequests\(\),\s*aiSessionAttentionController\.getLifecycleRequests\(\),\s*\]/);
     assert.ok(!evaluateExecutionFunction.includes('isEnabled'));
     assert.ok(!evaluateExecutionFunction.includes('attention'));
     assert.ok(evaluateAttentionFunction.includes('if (!this.options.isEnabled())'));

--- a/src/aiSessions/attentionAggregate.ts
+++ b/src/aiSessions/attentionAggregate.ts
@@ -146,3 +146,27 @@ export function filterAcknowledgedAttentionAggregate(
         sessions,
     };
 }
+
+/**
+ * Drops sessions the owning window has already cleared.
+ *
+ * The aggregate is the only source for sessions owned by other windows, but for
+ * its own sessions this window's monitor is both authoritative and fresher. If
+ * the bridge stops broadcasting, the last aggregate would otherwise keep a dot
+ * lit forever with no recovery path. Filtering only ever removes a session, so
+ * a cross-window acknowledgement can never be undone by local state.
+ */
+export function filterLocallyClearedAttentionAggregate(
+    aggregate: AttentionAggregate,
+    isLocallyCleared: (sessionKey: string) => boolean
+): AttentionAggregate {
+    const sessions = aggregate.sessions.filter(session => !isLocallyCleared(session.sessionKey));
+    if (sessions.length === aggregate.sessions.length) {
+        return aggregate;
+    }
+    return {
+        ...aggregate,
+        aggregateRevision: createAggregateRevision(sessions),
+        sessions,
+    };
+}

--- a/src/aiSessions/attentionController.ts
+++ b/src/aiSessions/attentionController.ts
@@ -2,7 +2,11 @@
 
 import type { AiSessionProviderId, CodexSession } from '../models';
 import type { AttentionAggregate } from './attentionAggregate';
-import { aggregateAttentionSnapshots, filterAcknowledgedAttentionAggregate } from './attentionAggregate';
+import {
+    aggregateAttentionSnapshots,
+    filterAcknowledgedAttentionAggregate,
+    filterLocallyClearedAttentionAggregate,
+} from './attentionAggregate';
 import { MAX_ATTENTION_ITEMS } from './attentionPayload';
 import type { AttentionPayloadItem } from './attentionPayload';
 import AiSessionAttentionMonitor from './attentionMonitor';
@@ -185,7 +189,26 @@ export class AiSessionAttentionController<TRuntime extends AiSessionAttentionRun
                 heartbeat: 0,
             }], new Set<string>(), now);
         })();
-        return filterAcknowledgedAttentionAggregate(aggregate, this.locallyAcknowledgedEventIds);
+        return filterLocallyClearedAttentionAggregate(
+            filterAcknowledgedAttentionAggregate(aggregate, this.locallyAcknowledgedEventIds),
+            sessionKey => this.isLocallyCleared(sessionKey)
+        );
+    }
+
+    /**
+     * Whether this window owns the session and its monitor no longer reports
+     * attention. Sessions this window does not track are never claimed, because
+     * for those the aggregate is the only thing that knows anything.
+     */
+    private isLocallyCleared(sessionKey: string): boolean {
+        const attentionKeys = this.attentionKeysBySession.get(
+            getLogicalAttentionSessionKey(sessionKey)
+        );
+        if (!attentionKeys?.length) {
+            return false;
+        }
+        const snapshot = this.monitor.getSnapshot();
+        return !attentionKeys.some(key => snapshot[key]?.state === 'needsAttention');
     }
 
     getLocalSnapshot(): Record<string, AiSessionAttentionSnapshot> {

--- a/src/aiSessions/attentionController.ts
+++ b/src/aiSessions/attentionController.ts
@@ -20,6 +20,8 @@ import { getAttentionProjectKeys, getLogicalAttentionSessionKey } from './attent
 import { getAiSessionKey } from './sessionHelpers';
 import type { WorkspaceAiSessionActionTarget, WorkspaceAiSessionViewModel } from './types';
 
+const DEFAULT_BRIDGE_OUTAGE_MS = 10_000;
+
 export interface AiSessionAttentionRuntimeEntry {
     runStartedAtMs: number;
     state: 'pending' | 'active' | 'completed' | 'stopped' | 'conflict';
@@ -41,6 +43,8 @@ export interface AiSessionAttentionControllerOptions<TRuntime extends AiSessionA
     publish: (items: AttentionPayloadItem[], forceHeartbeat?: boolean) => Promise<boolean>;
     scheduleRefresh: (reason: string) => void;
     nowMs: () => number;
+    /** How long publishing must keep failing before the bridge counts as out. */
+    bridgeOutageMs?: number;
 }
 
 export interface AiSessionAttentionEvaluation {
@@ -64,6 +68,7 @@ export class AiSessionAttentionController<TRuntime extends AiSessionAttentionRun
     private localItems: AttentionPayloadItem[] = [];
     private attentionKeysBySession = new Map<string, string[]>();
     private locallyAcknowledgedEventIds = new Set<string>();
+    private publishFailingSinceMs: number | null = null;
 
     constructor(private readonly options: AiSessionAttentionControllerOptions<TRuntime>) {
         this.monitor = new AiSessionAttentionMonitor({ now: options.nowMs });
@@ -80,6 +85,7 @@ export class AiSessionAttentionController<TRuntime extends AiSessionAttentionRun
             this.attentionKeysBySession.clear();
             this.locallyAcknowledgedEventIds.clear();
             const published = await this.options.publish([], true);
+            this.recordPublishResult(published);
             this.options.scheduleRefresh('attention');
             return {
                 enabled: false,
@@ -138,6 +144,7 @@ export class AiSessionAttentionController<TRuntime extends AiSessionAttentionRun
         const localResult = this.buildLocalItems(workspaceTarget, providers);
         this.localItems = localResult.items;
         const published = await this.options.publish(this.localItems);
+        this.recordPublishResult(published);
         return {
             enabled: true,
             published,
@@ -178,7 +185,11 @@ export class AiSessionAttentionController<TRuntime extends AiSessionAttentionRun
     }
 
     getEffectiveAggregate(): AttentionAggregate {
-        const aggregate = this.remoteAggregate || (() => {
+        // A sustained publish outage means the bridge cannot be reached at all, so
+        // its last aggregate is unverifiable and no peer can be acknowledging our
+        // events either. Local state is then the only honest source.
+        const remote = this.isBridgeOut() ? null : this.remoteAggregate;
+        const aggregate = remote || (() => {
             const now = this.options.nowMs();
             return aggregateAttentionSnapshots([{
                 version: 1,
@@ -193,6 +204,29 @@ export class AiSessionAttentionController<TRuntime extends AiSessionAttentionRun
             filterAcknowledgedAttentionAggregate(aggregate, this.locallyAcknowledgedEventIds),
             sessionKey => this.isLocallyCleared(sessionKey)
         );
+    }
+
+    private recordPublishResult(published: boolean): void {
+        if (published) {
+            this.publishFailingSinceMs = null;
+            return;
+        }
+        if (this.publishFailingSinceMs === null) {
+            this.publishFailingSinceMs = this.options.nowMs();
+        }
+    }
+
+    /**
+     * Whether publishing has been failing long enough to call the bridge out.
+     * A single failure is not enough: the client retries at 100ms, 500ms and 2s,
+     * so a bridge restart would otherwise flicker peer windows off the view.
+     */
+    private isBridgeOut(): boolean {
+        if (this.publishFailingSinceMs === null) {
+            return false;
+        }
+        const outageMs = this.options.bridgeOutageMs ?? DEFAULT_BRIDGE_OUTAGE_MS;
+        return this.options.nowMs() - this.publishFailingSinceMs >= outageMs;
     }
 
     /**

--- a/src/aiSessions/statusCapability.ts
+++ b/src/aiSessions/statusCapability.ts
@@ -1,0 +1,78 @@
+'use strict';
+
+import { AttentionEvaluationQueue } from './attentionEvaluationQueue';
+import type { AttentionEvaluationScope } from './attentionEvaluationQueue';
+import { AiSessionLifecycleSignalReader } from './lifecycleSignalReader';
+import type {
+    AiSessionLifecycleRequestsByProvider,
+    AiSessionLifecycleSignalProvider,
+    AiSessionLifecycleSignals,
+} from './lifecycleSignalReader';
+
+const LIFECYCLE_TICK_MS = 1_000;
+const RUNTIME_RECONCILE_MS = 10_000;
+
+export interface AiSessionStatusCapabilityOptions {
+    getProviders: () => readonly AiSessionLifecycleSignalProvider[];
+    /** Sessions each consumer needs signals for, merged into one read. */
+    getLifecycleRequests: () => readonly AiSessionLifecycleRequestsByProvider[];
+    evaluateExecution: (signals: AiSessionLifecycleSignals) => void;
+    evaluateAttentionSignals: (signals: AiSessionLifecycleSignals) => Promise<unknown>;
+    /** Also reconciles persisted runtime ownership from disk. */
+    evaluateAttentionRuntimes: () => Promise<unknown>;
+    onFailure: () => void;
+    setInterval: (callback: () => void, intervalMs: number) => unknown;
+    clearInterval: (handle: unknown) => void;
+}
+
+export interface AiSessionStatusCapability {
+    /** Reads provider signals once and drives both status passes from them. */
+    tick(): void;
+    requestAttentionEvaluation(scope: AttentionEvaluationScope): Promise<void>;
+    dispose(): void;
+}
+
+/**
+ * Owns the cadence that keeps the running animation and the attention dot in
+ * step.
+ *
+ * Both surfaces are views of the same provider lifecycle signal, so they are
+ * driven from a single read per tick rather than reading independently. The
+ * slower interval carries the runtime reconciliation, which scans the tmux
+ * binding directory and is too expensive for the fast path; it doubles as the
+ * fallback for signals that never change the execution state.
+ */
+export function createAiSessionStatusCapability(
+    options: AiSessionStatusCapabilityOptions
+): AiSessionStatusCapability {
+    const reader = new AiSessionLifecycleSignalReader({
+        getProviders: options.getProviders,
+        getRequests: options.getLifecycleRequests,
+    });
+    const attentionEvaluations = new AttentionEvaluationQueue({
+        evaluate: request => request.scope === 'runtimes'
+            ? options.evaluateAttentionRuntimes()
+            : options.evaluateAttentionSignals(request.signals || reader.read()),
+        onFailure: options.onFailure,
+    });
+
+    const tick = (): void => {
+        const signals = reader.read();
+        options.evaluateExecution(signals);
+        void attentionEvaluations.request('signals', signals);
+    };
+
+    const handles = [
+        options.setInterval(tick, LIFECYCLE_TICK_MS),
+        options.setInterval(
+            () => { void attentionEvaluations.request('runtimes'); },
+            RUNTIME_RECONCILE_MS
+        ),
+    ];
+
+    return {
+        tick,
+        requestAttentionEvaluation: scope => attentionEvaluations.request(scope),
+        dispose: () => handles.forEach(handle => options.clearInterval(handle)),
+    };
+}

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -124,8 +124,7 @@ import type {
     AiSessionAttentionEvaluation,
     AiSessionRuntimeLifecycleCandidate,
 } from './aiSessions/attentionController';
-import { AttentionEvaluationQueue } from './aiSessions/attentionEvaluationQueue';
-import { AiSessionLifecycleSignalReader } from './aiSessions/lifecycleSignalReader';
+import { createAiSessionStatusCapability } from './aiSessions/statusCapability';
 import {
     getLastPartOfPath,
     isUriString,
@@ -1212,22 +1211,6 @@ async function initializeDashboard(
         scheduleRefresh: reason => scheduleAiSessionRefresh(reason),
         nowMs: () => Date.now(),
     });
-    const aiSessionAttentionEvaluations = new AttentionEvaluationQueue({
-        // The tick pass reuses the observation the execution pass already made.
-        // Reconciling persisted runtime ownership scans the tmux binding directory,
-        // so it stays on the slow interval and reads for itself.
-        evaluate: request => request.scope === 'runtimes'
-            ? evaluateAiSessionAttention()
-            : aiSessionAttentionController.evaluate(
-                [],
-                request.signals || aiSessionLifecycleSignals.read()
-            ),
-        onFailure: () => logAiSessionDiagnostic({
-            event: 'runtime-lifecycle-task-failed',
-            operation: 'evaluate-attention-lifecycle-edge',
-            category: 'unexpected',
-        }),
-    });
     const aiSessionExecutionController = new AiSessionExecutionController({
         getActiveSessions: () => aiSessionRuntimeCoordinator.getActive()
             .filter(runtime => runtimeBelongsToCurrentWorkspace(runtime)
@@ -1248,22 +1231,26 @@ async function initializeDashboard(
         },
         nowMs: () => Date.now(),
     });
-    // One read per tick, shared by both passes. Reading per consumer let whichever
-    // ran last evict the other's incremental cursors, and left the animation and
-    // the attention dot derived from two observations taken moments apart.
-    const aiSessionLifecycleSignals = new AiSessionLifecycleSignalReader({
+    const aiSessionStatus = ownResource(() => createAiSessionStatusCapability({
         getProviders: getRegisteredAiSessionProviders,
-        getRequests: () => [
+        getLifecycleRequests: () => [
             aiSessionExecutionController.getLifecycleRequests(),
             aiSessionAttentionController.getLifecycleRequests(),
         ],
-    });
-    const evaluateAiSessionLifecycleTick = (): void => {
-        const signals = aiSessionLifecycleSignals.read();
-        aiSessionExecutionController.evaluate(signals);
-        void aiSessionAttentionEvaluations.request('signals', signals);
-    };
-    const getAiSessionAttentionEventIds = (identity: ActiveAiSessionTerminalIdentity): string[] => {        const sessionKey = getAiSessionKey(identity.provider, identity.sessionId);
+        evaluateExecution: signals => aiSessionExecutionController.evaluate(signals),
+        evaluateAttentionSignals: signals => aiSessionAttentionController.evaluate([], signals),
+        evaluateAttentionRuntimes: () => evaluateAiSessionAttention(),
+        onFailure: () => logAiSessionDiagnostic({
+            event: 'runtime-lifecycle-task-failed',
+            operation: 'evaluate-attention-lifecycle-edge',
+            category: 'unexpected',
+        }),
+        setInterval: (callback, intervalMs) => setInterval(callback, intervalMs),
+        clearInterval: handle => clearInterval(handle as NodeJS.Timeout),
+    }));
+    const evaluateAiSessionLifecycleTick = (): void => aiSessionStatus.tick();
+    const getAiSessionAttentionEventIds = (identity: ActiveAiSessionTerminalIdentity): string[] => {
+        const sessionKey = getAiSessionKey(identity.provider, identity.sessionId);
         return aiSessionAttentionController.getRecoverySessionEvents()
             .find(session => session.sessionKey === sessionKey)?.eventIds || [];
     };
@@ -1416,25 +1403,12 @@ async function initializeDashboard(
     });
     activeAiSessionAttentionBridgeClient = aiSessionAttentionBridgeClient;
     ownTimer(
-        // Fallback heartbeat. Attention normally settles on the execution edge that
-        // the 1s tick below detects; this covers signals that never change the
-        // execution state and reconciles persisted runtime ownership from disk.
-        () => setInterval(() => {
-            void aiSessionAttentionEvaluations.request('runtimes');
-        }, 10_000),
-        handle => clearInterval(handle),
-    );
-    ownTimer(
         () => setTimeout(() => {
             void runSafeAiSessionRuntimeLifecycleTask(
                 'evaluate-attention-startup', evaluateAiSessionAttention
             );
         }, 0),
         handle => clearTimeout(handle),
-    );
-    ownTimer(
-        () => setInterval(evaluateAiSessionLifecycleTick, 1_000),
-        handle => clearInterval(handle),
     );
     ownTimer(
         () => setTimeout(evaluateAiSessionLifecycleTick, 0),

--- a/src/services/claudeSessionService.ts
+++ b/src/services/claudeSessionService.ts
@@ -315,9 +315,15 @@ export default class ClaudeSessionService {
         if (stats) {
             stats.discoveredFiles = files.length;
         }
+        // Stat once per file rather than once per comparison: a comparator that
+        // reads the filesystem turns an O(n) listing into O(n log n) syscalls, and
+        // this runs on every dashboard refresh and every change poll.
         files = files
-            .sort((a, b) => this.getFileMtimeMs(b) - this.getFileMtimeMs(a) || a.localeCompare(b))
-            .slice(0, maxFiles || undefined);
+            .map(filePath => ({ filePath, mtimeMs: this.getFileMtimeMs(filePath) }))
+            .sort((left, right) => right.mtimeMs - left.mtimeMs
+                || left.filePath.localeCompare(right.filePath))
+            .slice(0, maxFiles || undefined)
+            .map(entry => entry.filePath);
 
         for (let filePath of files) {
             let sessionId = this.getSessionIdFromFileName(path.basename(filePath));
@@ -355,10 +361,11 @@ export default class ClaudeSessionService {
                 && /^agent-[A-Za-z0-9_-]{1,128}\.jsonl$/.test(entry.name)
             ).map(entry =>
                 path.join(subagentDirectory, entry.name)
-            ).sort((a, b) =>
-                this.getFileMtimeMs(b) - this.getFileMtimeMs(a)
-                    || a.localeCompare(b)
-            ).slice(0, this.maxLifecycleSubagentFiles);
+            ).map(filePath => ({ filePath, mtimeMs: this.getFileMtimeMs(filePath) }))
+                .sort((left, right) => right.mtimeMs - left.mtimeMs
+                    || left.filePath.localeCompare(right.filePath))
+                .slice(0, this.maxLifecycleSubagentFiles)
+                .map(entry => entry.filePath);
         } catch (e) {
             return [];
         }

--- a/src/services/codexSessionService.ts
+++ b/src/services/codexSessionService.ts
@@ -24,6 +24,13 @@ interface CodexSessionMeta {
     isExcluded?: boolean;
 }
 
+interface CodexDiscoveredSessionFile {
+    id: string;
+    filePath: string;
+    mtimeMs: number;
+    sizeBytes: number;
+}
+
 export interface CodexSessionReadResult {
     available: boolean;
     sessions: CodexSession[];
@@ -279,9 +286,11 @@ export default class CodexSessionService {
     }
 
     private getSessionFilesSignature(codexHome: string): string {
-        let sessionFiles = this.getSessionFiles(codexHome);
-        return Array.from(sessionFiles.entries())
-            .map(([sessionId, filePath]) => `${sessionId}:${filePath}:${this.getFileSignature(filePath)}`)
+        // Discovery already stats every file to order by recency, so the change
+        // signature reuses that instead of stat'ing every path a second time.
+        return this.discoverSessionFiles(codexHome)
+            .map(entry =>
+                `${entry.id}:${entry.filePath}:${entry.filePath}:${entry.sizeBytes}:${entry.mtimeMs}`)
             .sort()
             .join(',');
     }
@@ -323,16 +332,24 @@ export default class CodexSessionService {
         return Number.isFinite(maxFiles) && maxFiles > 0 ? Math.floor(maxFiles) : 0;
     }
 
-    private getSessionFiles(codexHome: string, maxFiles = 0, stats?: { discoveredFiles: number }): Map<string, string> {
-        let discovered: Array<{ id: string; filePath: string; mtimeMs: number }> = [];
+    private discoverSessionFiles(
+        codexHome: string,
+        maxFiles = 0,
+        stats?: { discoveredFiles: number }
+    ): CodexDiscoveredSessionFile[] {
+        let discovered: CodexDiscoveredSessionFile[] = [];
         this.addSessionFiles(path.join(codexHome, 'sessions'), discovered, true);
         if (stats) {
             stats.discoveredFiles = discovered.length;
         }
-        let files = new Map<string, string>();
-        for (let entry of discovered
+        return discovered
             .sort((a, b) => b.mtimeMs - a.mtimeMs || a.filePath.localeCompare(b.filePath))
-            .slice(0, maxFiles || undefined)) {
+            .slice(0, maxFiles || undefined);
+    }
+
+    private getSessionFiles(codexHome: string, maxFiles = 0, stats?: { discoveredFiles: number }): Map<string, string> {
+        let files = new Map<string, string>();
+        for (let entry of this.discoverSessionFiles(codexHome, maxFiles, stats)) {
             files.set(entry.id, entry.filePath);
         }
         for (let [sessionId, filePath] of files) {
@@ -342,7 +359,7 @@ export default class CodexSessionService {
         return files;
     }
 
-    private addSessionFiles(sessionPath: string, files: Array<{ id: string; filePath: string; mtimeMs: number }>, recursive: boolean) {
+    private addSessionFiles(sessionPath: string, files: CodexDiscoveredSessionFile[], recursive: boolean) {
         if (!fs.existsSync(sessionPath)) {
             return;
         }
@@ -361,7 +378,7 @@ export default class CodexSessionService {
 
                 let id = this.getSessionIdFromFileName(entry.name);
                 if (id) {
-                    files.push({ id, filePath: entryPath, mtimeMs: this.getFileMtimeMs(entryPath) });
+                    files.push({ id, filePath: entryPath, ...this.getFileStat(entryPath) });
                 }
             }
         } catch (e) {
@@ -369,11 +386,13 @@ export default class CodexSessionService {
         }
     }
 
-    private getFileMtimeMs(filePath: string): number {
+    /** One stat carries both the ordering key and the change signature. */
+    private getFileStat(filePath: string): { mtimeMs: number; sizeBytes: number } {
         try {
-            return fs.statSync(filePath).mtimeMs;
+            let stat = fs.statSync(filePath);
+            return { mtimeMs: stat.mtimeMs, sizeBytes: stat.size };
         } catch (e) {
-            return 0;
+            return { mtimeMs: 0, sizeBytes: 0 };
         }
     }
 

--- a/tests/contract/aiSessions/attention.test.js
+++ b/tests/contract/aiSessions/attention.test.js
@@ -1371,3 +1371,61 @@ test('ATTENTION-BRIDGE-STALENESS-001 trusts the aggregate again once publishing 
     assert.deepEqual(f.dotSessions(), ['codex:peer'],
         'a recovered bridge is authoritative again, including peers we could not observe');
 });
+
+test('ATTENTION-EXECUTION-STATE-SYNC-001 drives both status passes from one read per tick', async () => {
+    const { createAiSessionStatusCapability } =
+        require('../../../out/aiSessions/statusCapability');
+    const reads = [];
+    const executionSignals = [];
+    const attentionSignals = [];
+    const runtimePasses = [];
+    const timers = [];
+    const signals = { codex: { session: { token: 'a', occurredAtMs: 1 } } };
+
+    const capability = createAiSessionStatusCapability({
+        getProviders: () => [{
+            id: 'codex',
+            service: {
+                getLifecycleSignals: requests => {
+                    reads.push(requests.map(request => request.sessionId));
+                    return signals.codex;
+                },
+            },
+        }],
+        getLifecycleRequests: () => [
+            { codex: [{ sessionId: 'session', runStartedAtMs: 0 }] },
+            { codex: [{ sessionId: 'settling', runStartedAtMs: 0 }] },
+        ],
+        evaluateExecution: observed => executionSignals.push(observed),
+        evaluateAttentionSignals: async observed => { attentionSignals.push(observed); },
+        evaluateAttentionRuntimes: async () => { runtimePasses.push(true); },
+        onFailure: () => { throw new Error('unexpected failure'); },
+        setInterval: (callback, intervalMs) => {
+            const handle = { callback, intervalMs };
+            timers.push(handle);
+            return handle;
+        },
+        clearInterval: handle => { handle.cleared = true; },
+    });
+
+    assert.deepEqual(timers.map(timer => timer.intervalMs), [1000, 10000],
+        'a fast signal tick and a slow runtime reconciliation');
+
+    capability.tick();
+    await flushAsync();
+    assert.deepEqual(reads, [['session', 'settling']],
+        'one merged read per tick, covering both consumers');
+    assert.equal(executionSignals.length, 1);
+    assert.equal(attentionSignals.length, 1);
+    assert.equal(attentionSignals[0], executionSignals[0],
+        'both passes must observe the very same read, not two reads moments apart');
+    assert.deepEqual(runtimePasses, [], 'the fast tick never pays for the disk scan');
+
+    timers[1].callback();
+    await flushAsync();
+    assert.deepEqual(runtimePasses, [true], 'the slow interval carries runtime reconciliation');
+    assert.equal(reads.length, 1, 'the runtime pass reads for itself, not through the tick reader');
+
+    capability.dispose();
+    assert.deepEqual(timers.map(timer => timer.cleared), [true, true]);
+});

--- a/tests/contract/aiSessions/attention.test.js
+++ b/tests/contract/aiSessions/attention.test.js
@@ -1155,3 +1155,140 @@ test('ATTENTION-EXECUTION-STATE-SYNC-001 rejects an out-of-order signal in both 
     assert.equal(attention.getSnapshot()[key].state, 'running',
         'both monitors must reach the same conclusion from the same signal order');
 });
+
+// ATTENTION-BRIDGE-STALENESS-001
+function makeStalenessFixture() {
+    const workspace = {
+        navigationIdentity: 'navigation:fixture', scopeIdentity: 'scope:fixture',
+        kind: 'singleFolder', displayName: 'Fixture', navigationUri: 'file:///fixtures/project',
+        environment: 'local', roots: [{
+            id: 'root:fixture', name: 'Fixture', uri: 'file:///fixtures/project',
+            hostPath: '/fixtures/project', ordinal: 0,
+        }],
+    };
+    const workspaceSessions = {
+        sessionsByProvider: {
+            codex: [{ id: 'session', primaryRootId: 'root:fixture' }],
+            kimi: [], claude: [],
+        },
+    };
+    let nowMs = 1000;
+    let signal;
+    const published = [];
+    const controller = new AiSessionAttentionController({
+        isEnabled: () => true,
+        getWorkspaceTarget: () => ({
+            cardId: 'workspace:fixture', workspace, sessions: workspaceSessions,
+        }),
+        getProviders: () => [{ id: 'codex', service: { getLifecycleSignals: () => ({}) } }],
+        getRuntimeById: () => ({ state: 'active', runStartedAtMs: 0 }),
+        publish: async items => { published.push(items.map(item => ({ ...item }))); return true; },
+        scheduleRefresh: () => undefined,
+        nowMs: () => nowMs,
+    });
+    const evaluate = () => controller.evaluate([], { codex: { session: signal } });
+    // The bridge echoes what this window published back as the aggregate.
+    const echoBridge = () => controller.setRemoteAggregate(aggregateAttentionSnapshots([{
+        version: 1,
+        generatedAtMs: nowMs,
+        items: published.at(-1),
+        instanceId: 'a'.repeat(32),
+        sequence: published.length,
+        heartbeat: published.length,
+    }], new Set(), nowMs));
+    return {
+        controller,
+        dotSessions: () => controller.getEffectiveAggregate().sessions.map(s => s.sessionKey),
+        setSignal: value => { signal = value; },
+        advance: ms => { nowMs += ms; },
+        evaluate,
+        echoBridge,
+        nowMs: () => nowMs,
+    };
+}
+
+test('ATTENTION-BRIDGE-STALENESS-001 clears a dot locally when the bridge stops broadcasting', async () => {
+    const f = makeStalenessFixture();
+    f.setSignal({
+        token: 'task-complete:1000', phase: 'needsAttention', reason: 'completed',
+        executionState: 'stopped', occurredAtMs: 1000,
+    });
+    await f.evaluate();
+    f.echoBridge();
+    assert.deepEqual(f.dotSessions(), ['codex:session'], 'a completed turn raises the dot');
+
+    // The bridge extension dies here: no further aggregate ever arrives.
+    f.advance(1000);
+    f.setSignal({
+        token: 'task-started:2000', phase: 'running',
+        executionState: 'running', occurredAtMs: 2000,
+    });
+    await f.evaluate();
+
+    assert.deepEqual(f.dotSessions(), [],
+        'a session this window owns and has locally cleared must not stay lit on a frozen aggregate');
+});
+
+test('ATTENTION-BRIDGE-STALENESS-001 never resurrects a dot another window acknowledged', async () => {
+    const f = makeStalenessFixture();
+    f.setSignal({
+        token: 'task-complete:1000', phase: 'needsAttention', reason: 'completed',
+        executionState: 'stopped', occurredAtMs: 1000,
+    });
+    await f.evaluate();
+    f.echoBridge();
+    assert.deepEqual(f.dotSessions(), ['codex:session']);
+
+    // Another window opens the project and acknowledges the event. The bridge
+    // drops the session while our local monitor still holds needsAttention.
+    f.advance(1000);
+    f.controller.setRemoteAggregate(
+        aggregateAttentionSnapshots([], new Set(), f.nowMs())
+    );
+    await f.evaluate();
+
+    assert.deepEqual(f.dotSessions(), [],
+        'a cross-window acknowledgement must stay acknowledged');
+});
+
+test('ATTENTION-BRIDGE-STALENESS-001 leaves sessions owned by other windows untouched', async () => {
+    const f = makeStalenessFixture();
+    f.setSignal({
+        token: 'task-complete:1000', phase: 'needsAttention', reason: 'completed',
+        executionState: 'stopped', occurredAtMs: 1000,
+    });
+    await f.evaluate();
+
+    // The aggregate also carries a peer window's session we know nothing about.
+    const projectId = attentionProject.getAttentionProjectKey('/fixtures/project');
+    f.controller.setRemoteAggregate(aggregateAttentionSnapshots([{
+        version: 1,
+        generatedAtMs: f.nowMs(),
+        items: [
+            ...f.controller.getEffectiveAggregate().sessions.map(session => ({
+                projectId: session.projectId,
+                sessionKey: session.sessionKey,
+                state: 'needsAttention',
+                eventId: session.eventIds[0],
+                reason: session.reasons[0],
+                observedAtMs: session.observedAtMs,
+            })),
+            {
+                projectId, sessionKey: 'codex:peer-window-session',
+                state: 'needsAttention', eventId: 'peer-event',
+                reason: 'completed', observedAtMs: 1000,
+            },
+        ],
+        instanceId: 'b'.repeat(32), sequence: 1, heartbeat: 1,
+    }], new Set(), f.nowMs()));
+
+    f.advance(1000);
+    f.setSignal({
+        token: 'task-started:2000', phase: 'running',
+        executionState: 'running', occurredAtMs: 2000,
+    });
+    await f.evaluate();
+
+    assert.deepEqual(f.dotSessions(), ['codex:peer-window-session'],
+        'clearing our own session must not clear a peer window we cannot observe');
+});

--- a/tests/contract/aiSessions/attention.test.js
+++ b/tests/contract/aiSessions/attention.test.js
@@ -1173,7 +1173,8 @@ function makeStalenessFixture() {
         },
     };
     let nowMs = 1000;
-    let signal;
+    const signals = {};
+    let publishSucceeds = true;
     const published = [];
     const controller = new AiSessionAttentionController({
         isEnabled: () => true,
@@ -1182,11 +1183,14 @@ function makeStalenessFixture() {
         }),
         getProviders: () => [{ id: 'codex', service: { getLifecycleSignals: () => ({}) } }],
         getRuntimeById: () => ({ state: 'active', runStartedAtMs: 0 }),
-        publish: async items => { published.push(items.map(item => ({ ...item }))); return true; },
+        publish: async items => {
+            published.push(items.map(item => ({ ...item })));
+            return publishSucceeds;
+        },
         scheduleRefresh: () => undefined,
         nowMs: () => nowMs,
     });
-    const evaluate = () => controller.evaluate([], { codex: { session: signal } });
+    const evaluate = () => controller.evaluate([], { codex: { ...signals } });
     // The bridge echoes what this window published back as the aggregate.
     const echoBridge = () => controller.setRemoteAggregate(aggregateAttentionSnapshots([{
         version: 1,
@@ -1199,11 +1203,16 @@ function makeStalenessFixture() {
     return {
         controller,
         dotSessions: () => controller.getEffectiveAggregate().sessions.map(s => s.sessionKey),
-        setSignal: value => { signal = value; },
+        setSignal: (value, sessionId = 'session') => { signals[sessionId] = value; },
         advance: ms => { nowMs += ms; },
         evaluate,
         echoBridge,
         nowMs: () => nowMs,
+        breakBridge: () => { publishSucceeds = false; },
+        healBridge: () => { publishSucceeds = true; },
+        addSession: id => workspaceSessions.sessionsByProvider.codex.push({
+            id, primaryRootId: 'root:fixture',
+        }),
     };
 }
 
@@ -1291,4 +1300,74 @@ test('ATTENTION-BRIDGE-STALENESS-001 leaves sessions owned by other windows unto
 
     assert.deepEqual(f.dotSessions(), ['codex:peer-window-session'],
         'clearing our own session must not clear a peer window we cannot observe');
+});
+
+test('ATTENTION-BRIDGE-STALENESS-001 falls back to local state once publishing keeps failing', async () => {
+    const f = makeStalenessFixture();
+    f.setSignal({
+        token: 'task-complete:1000', phase: 'needsAttention', reason: 'completed',
+        executionState: 'stopped', occurredAtMs: 1000,
+    });
+    await f.evaluate();
+    f.echoBridge();
+    assert.deepEqual(f.dotSessions(), ['codex:session']);
+
+    // The bridge dies. Its last aggregate stays frozen and every publish fails.
+    f.breakBridge();
+    f.addSession('later');
+    f.advance(1000);
+    f.setSignal({
+        token: 'later-complete:2000', phase: 'needsAttention', reason: 'completed',
+        executionState: 'stopped', occurredAtMs: 2000,
+    }, 'later');
+
+    // A transient failure must not immediately discard the aggregate: the bridge
+    // client retries at 100ms, 500ms and 2s before the outage is real.
+    await f.evaluate();
+    assert.deepEqual(f.dotSessions(), ['codex:session'],
+        'one failed publish is a blip, not an outage');
+
+    // Sustained failure is an outage; local state becomes authoritative and the
+    // dot raised while the bridge was down finally shows.
+    for (let i = 0; i < 12; i += 1) {
+        f.advance(1000);
+        await f.evaluate();
+    }
+    assert.deepEqual(f.dotSessions().sort(), ['codex:later', 'codex:session'],
+        'a dot raised during the outage must not be invisible behind a frozen aggregate');
+});
+
+test('ATTENTION-BRIDGE-STALENESS-001 trusts the aggregate again once publishing recovers', async () => {
+    const f = makeStalenessFixture();
+    f.setSignal({
+        token: 'task-complete:1000', phase: 'needsAttention', reason: 'completed',
+        executionState: 'stopped', occurredAtMs: 1000,
+    });
+    await f.evaluate();
+    f.echoBridge();
+
+    f.breakBridge();
+    for (let i = 0; i < 12; i += 1) {
+        f.advance(1000);
+        await f.evaluate();
+    }
+    assert.deepEqual(f.dotSessions(), ['codex:session'], 'local state still shows our own dot');
+
+    // The bridge comes back and republishes a peer window we could not see while
+    // it was down. The aggregate must become authoritative again.
+    f.healBridge();
+    f.advance(1000);
+    await f.evaluate();
+    const projectId = attentionProject.getAttentionProjectKey('/fixtures/project');
+    f.controller.setRemoteAggregate(aggregateAttentionSnapshots([{
+        version: 1, generatedAtMs: f.nowMs(),
+        items: [{
+            projectId, sessionKey: 'codex:peer', state: 'needsAttention',
+            eventId: 'peer-event', reason: 'completed', observedAtMs: f.nowMs(),
+        }],
+        instanceId: 'c'.repeat(32), sequence: 9, heartbeat: 9,
+    }], new Set(), f.nowMs()));
+
+    assert.deepEqual(f.dotSessions(), ['codex:peer'],
+        'a recovered bridge is authoritative again, including peers we could not observe');
 });

--- a/tests/contract/aiSessions/providerSpecificBehavior.test.js
+++ b/tests/contract/aiSessions/providerSpecificBehavior.test.js
@@ -383,3 +383,42 @@ test('SESSION-CLAUDE-SESSION-SERVICE-001 stats each session file once instead of
         `expected at most ${sessionCount * 2} statSync calls for ${sessionCount} sessions, saw ${stats}`
     );
 });
+
+test('SESSION-CODEX-SESSION-SERVICE-001 stats each session file once per change poll', t => {
+    const root = makeTempDirectory(t, 'provider-codex-fingerprint-');
+    setEnvironment(t, 'CODEX_HOME', root);
+    const sessionsDir = path.join(root, 'sessions', '2026', '07', '14');
+    fs.mkdirSync(sessionsDir, { recursive: true });
+
+    const sessionCount = 32;
+    for (let index = 0; index < sessionCount; index += 1) {
+        const sessionId = crypto.randomUUID();
+        writeCodexSessionMetaFile(sessionsDir, sessionId, {
+            id: sessionId, session_id: sessionId, cwd: '/work/app',
+            timestamp: '2026-07-14T01:00:00.000Z', source: 'vscode',
+        });
+    }
+    fs.writeFileSync(path.join(root, 'session_index.jsonl'), '', 'utf8');
+
+    let stats = 0;
+    const realStatSync = fs.statSync;
+    fs.statSync = function countingStatSync(...args) {
+        stats += 1;
+        return realStatSync.apply(fs, args);
+    };
+    t.after(() => { fs.statSync = realStatSync; });
+
+    const service = new CodexSessionService();
+    stats = 0;
+    // watchSessionChanges runs this every 3s per provider.
+    const fingerprint = service.getSessionFingerprint();
+
+    assert.ok(fingerprint.length > 0);
+    // Listing already stats every file to order by recency; the signature must
+    // reuse that instead of stat'ing the same paths a second time. One extra
+    // call covers session_index.jsonl.
+    assert.ok(
+        stats <= sessionCount + 4,
+        `expected at most ${sessionCount + 4} statSync calls for ${sessionCount} sessions, saw ${stats}`
+    );
+});

--- a/tests/contract/aiSessions/providerSpecificBehavior.test.js
+++ b/tests/contract/aiSessions/providerSpecificBehavior.test.js
@@ -339,3 +339,47 @@ test('SESSION-CLAUDE-SUBAGENT-LIFECYCLE-001 keeps Claude running while any backg
     assert.equal(completed.reason, 'completed');
     assert.equal(completed.executionState, 'stopped');
 });
+
+test('SESSION-CLAUDE-SESSION-SERVICE-001 stats each session file once instead of once per sort comparison', t => {
+    const root = makeTempDirectory(t, 'provider-claude-sort-');
+    setEnvironment(t, 'CLAUDE_HOME', root);
+    const sessionDir = path.join(root, 'projects', '-work-app');
+    fs.mkdirSync(sessionDir, { recursive: true });
+
+    // Enough files that an O(n log n) comparator is clearly distinguishable
+    // from an O(n) decorate-sort pass.
+    const sessionCount = 32;
+    const sessionIds = [];
+    for (let index = 0; index < sessionCount; index += 1) {
+        const sessionId = crypto.randomUUID();
+        sessionIds.push(sessionId);
+        fs.writeFileSync(
+            path.join(sessionDir, `${sessionId}.jsonl`),
+            `${JSON.stringify({
+                sessionId, cwd: '/work/app', timestamp: '2026-01-01T00:00:00.000Z',
+            })}\n`,
+            'utf8'
+        );
+    }
+
+    let stats = 0;
+    const realStatSync = fs.statSync;
+    fs.statSync = function countingStatSync(...args) {
+        stats += 1;
+        return realStatSync.apply(fs, args);
+    };
+    t.after(() => { fs.statSync = realStatSync; });
+
+    const service = new ClaudeSessionService();
+    stats = 0;
+    const result = service.getSessions({ forceRefresh: true, candidatePaths: ['/work/app'] });
+
+    assert.equal(result.available, true);
+    assert.equal(result.sessions.length, sessionCount);
+    // Ordering by recency must not cost a syscall per comparison. Allow a small
+    // constant of extra probes, but nothing that scales with log n.
+    assert.ok(
+        stats <= sessionCount * 2,
+        `expected at most ${sessionCount * 2} statSync calls for ${sessionCount} sessions, saw ${stats}`
+    );
+});


### PR DESCRIPTION
Four related pieces of AI session status work. They share a theme -- the status
surfaces must stay correct and cheap -- but are independent commits and can be
read in any order.

## 1. A frozen bridge aggregate could keep a dot lit forever

`getEffectiveAggregate` returned the remote aggregate wholesale, and the bridge
only re-broadcasts when its revision changes. If the bridge extension died or
wedged while a dot was lit, that last aggregate stayed authoritative forever:
the session could resume, the local monitor could clear it, and the dot still
would not go out until the window was reloaded. Aggregate age is not a liveness
signal either, since a healthy idle bridge legitimately stops broadcasting.

A session this window owns and whose monitor no longer reports attention is now
dropped from the effective aggregate. The override is deliberately asymmetric:
it only removes, never re-adds. Acknowledgement is genuinely cross-window --
opening a saved project acknowledges other windows' events -- so a local raise
would undo a peer's acknowledgement.

## 2. ...and a dot raised during an outage was invisible

Removal alone left the other direction broken: with the bridge down, a newly
completed turn raised attention locally, failed to publish, and never appeared.

The "local must not raise" objection only holds while the bridge works. If it is
unreachable, no peer can acknowledge our events and its last aggregate is
unverifiable, so local state is the only honest source. The bridge client
already reports this -- `publishNow` returns false when the command throws,
`enqueuePublication` when the handshake fails -- and the controller was
receiving it as `published` and ignoring it. It now treats the bridge as out
after ten seconds of continuous failure, past the client's 100ms/500ms/2s retry
ladder so a restart does not flicker peer windows off the view. Recovery is
immediate on the first successful publish.

Not covered: a bridge that still accepts publishes but whose broadcast loop is
wedged. Piece 1 still self-heals the stuck dot in that case.

## 3. Listing sessions cost O(n log n) syscalls

`claudeSessionService.getSessionFiles` ordered results with a comparator that
called `statSync` on both operands, so listing n sessions cost a syscall per
comparison. The same shape was in `getLifecycleSubagentFiles`, which the 1s
lifecycle tick reaches on every pass. Separately, Codex's change signature
discarded the mtime discovery had already collected and stat'd every path again.

Measured against a real store, per 3s change poll per provider:

| provider | before | after |
|---|---|---|
| claude (28 discovered) | 228 stat, 4.9ms | 56 stat, 1.2ms |
| codex (772 files) | 1545 stat, 8.3ms | 773 stat, 6.3ms |

The Claude amplification grows with log n, so a large history pays far more --
roughly 21x at 1600 files. Both services now match what kimi already did.

## 4. The status cadence left dashboard.ts

`initializeDashboard` is a 2785-line function with no test instrumentation, so
the cadence added by this work could only be pinned down by matching its source
text with regular expressions -- and this work had already broken those twice
while editing. `createAiSessionStatusCapability` now owns the signal reader,
the coalescing queue and both timers, following the existing
`createConversationCapability` pattern. The source-matching assertions are
replaced by a test that runs it.

This is one slice, not the wider untangling: session wiring still spans roughly
2000 lines of that function through the hydration controller, pending
promotion, terminal events and the webview message router.

## Verification

Every behaviour was driven red first. The outage test reproduces the invisible
dot exactly; the syscall tests measured 270 calls for 32 Claude sessions and 65
for 32 Codex sessions before the fix.

Full `test:ci:linux` equivalent green: 1191 tests, browser 121, safety, guards,
dashboard, release notes and packaging, remote sources, conversation
performance, behaviour contracts, brand, lint. Changed-line coverage 99.03%.

## Known remaining

Not addressed here, each wanting its own change: the 411KB/3s fingerprint string
churn across providers, kimi's 15ms recursive directory walk, the rest of
dashboard.ts, and the regex-parsed composite attention keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)