### PR TITLE
fix: reveal the newest AI Conversation line in short viewports

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -3989,11 +3989,13 @@
     "priority": "P1",
     "status": "automated",
     "owners": [
-      "tests/integration/dashboard/conversationOpenLatest.test.js"
+      "tests/integration/dashboard/conversationOpenLatest.test.js",
+      "tests/browser/conversationViewer.test.js"
     ],
     "evidence": [
       "src/aiSessions/conversation/composition.ts",
-      "src/dashboard.ts"
+      "src/dashboard.ts",
+      "src/webview/conversationViewerScripts.js"
     ]
   },
   {

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "94a109ca547e411f37a8adccdaead0e930241258",
+        "head": "82bd775b83c70deeb60a1bcf400d4d31cfb5612b",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -836,7 +836,8 @@
                 "0251b56e920c011368e6f71425f9c852c7da0f38",
                 "c329ea110bdb034df07fcbcfa182f336751b1f47",
                 "9f50c6b6c54e86279b88ba05207489e476613333",
-                "59ef5de5b9c2105c28c046ad1ff173f191746b21"
+                "59ef5de5b9c2105c28c046ad1ff173f191746b21",
+                "82bd775b83c70deeb60a1bcf400d4d31cfb5612b"
             ],
             "behaviors": [
                 "ARCH-CI-QUALITY-GATE-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "289779463fe347fba05bd3655ceded5189612f44",
+        "head": "94a109ca547e411f37a8adccdaead0e930241258",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -1001,7 +1001,8 @@
                 "9cd6c9716c7e9f27f41bbe0968f6f126e6717e5d",
                 "39bbfcebb2bf0b28e21513e905aa620d7b6eab83",
                 "7d98f9e23c4fcad345ed0782d41e24870ff80f6e",
-                "3ea5525ab3adc9fb69f5bc35895c74940361f4ac"
+                "3ea5525ab3adc9fb69f5bc35895c74940361f4ac",
+                "94a109ca547e411f37a8adccdaead0e930241258"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",

--- a/media/conversationViewerScripts.js
+++ b/media/conversationViewerScripts.js
@@ -112,6 +112,7 @@
         && validCommentTarget(commentTarget);
     var state = {
         atLatest: false,
+        followingEnd: false,
         initialized: false,
         latestRequestId: 0,
         latestTelemetryRequestId: 0,
@@ -1699,6 +1700,28 @@
         position.textContent = 'Input ' + message.selectedInput + ' of ' + total;
     }
 
+    function scrollToConversationEnd() {
+        scroll.scrollTop = Math.max(
+            0,
+            scroll.scrollHeight - scroll.clientHeight
+        );
+        state.followingEnd = true;
+    }
+
+    function conversationAtEnd() {
+        var threshold = Number(
+            document.body.getAttribute('data-auto-scroll-threshold')
+        );
+        return Number.isFinite(threshold)
+            && threshold >= 0
+            && scroll.scrollHeight - scroll.clientHeight - scroll.scrollTop
+                <= threshold;
+    }
+
+    function trackConversationEnd() {
+        state.followingEnd = conversationAtEnd();
+    }
+
     function applyPage(message) {
         if (!validPage(message)
             || message.subscriptionGeneration !== state.subscriptionGeneration
@@ -1802,13 +1825,18 @@
             state.firstNewMessageId = null;
             newResponse.hidden = true;
             var selected = selectedMessages[0];
-            if (selected) {
+            var openingAtLatest = message.atLatest
+                && message.updateKind === 'initial';
+            if (openingAtLatest) {
+                scrollToConversationEnd();
+            } else if (selected) {
                 selected.scrollIntoView({ block: 'center' });
-                if (message.updateKind === 'navigation') {
-                    selected.tabIndex = -1;
-                    selected.focus({ preventScroll: true });
-                }
             }
+            if (selected && message.updateKind === 'navigation') {
+                selected.tabIndex = -1;
+                selected.focus({ preventScroll: true });
+            }
+            if (!openingAtLatest) trackConversationEnd();
             return;
         }
 
@@ -1821,10 +1849,22 @@
             state.firstNewMessageId = appendedOrChanged[0];
         }
         newResponse.hidden = !state.firstNewMessageId;
+        trackConversationEnd();
     }
 
     function postNavigation(type) {
         post({ type: type, version: 1 });
+    }
+
+    scroll.addEventListener('scroll', trackConversationEnd, { passive: true });
+    if (typeof ResizeObserver === 'function') {
+        var viewportObserver = new ResizeObserver(function () {
+            if (state.followingEnd) scrollToConversationEnd();
+        });
+        viewportObserver.observe(scroll);
+        window.addEventListener('unload', function () {
+            viewportObserver.disconnect();
+        });
     }
 
     previous.addEventListener('click', function () {

--- a/scripts/check-changed-coverage.js
+++ b/scripts/check-changed-coverage.js
@@ -18,6 +18,11 @@ const UNINSTRUMENTED_BY_DESIGN = [
     // their statements are attributed to the child process instead of the run.
     // Their extracted helpers under scripts/lib stay instrumented and enforced.
     /^scripts\/run-[^/]+\.js$/,
+    // Webview browser scripts are loaded by the Webview document itself, so the
+    // deterministic Node suites never require them. tests/browser exercises them
+    // in Chromium through Playwright, outside this c8 run. Their TypeScript
+    // siblings under src/webview stay instrumented and enforced.
+    /^src\/webview\/[^/]+\.js$/,
 ];
 
 function isUninstrumentedByDesign(file) {

--- a/src/webview/conversationViewerScripts.js
+++ b/src/webview/conversationViewerScripts.js
@@ -112,6 +112,7 @@
         && validCommentTarget(commentTarget);
     var state = {
         atLatest: false,
+        followingEnd: false,
         initialized: false,
         latestRequestId: 0,
         latestTelemetryRequestId: 0,
@@ -1699,6 +1700,28 @@
         position.textContent = 'Input ' + message.selectedInput + ' of ' + total;
     }
 
+    function scrollToConversationEnd() {
+        scroll.scrollTop = Math.max(
+            0,
+            scroll.scrollHeight - scroll.clientHeight
+        );
+        state.followingEnd = true;
+    }
+
+    function conversationAtEnd() {
+        var threshold = Number(
+            document.body.getAttribute('data-auto-scroll-threshold')
+        );
+        return Number.isFinite(threshold)
+            && threshold >= 0
+            && scroll.scrollHeight - scroll.clientHeight - scroll.scrollTop
+                <= threshold;
+    }
+
+    function trackConversationEnd() {
+        state.followingEnd = conversationAtEnd();
+    }
+
     function applyPage(message) {
         if (!validPage(message)
             || message.subscriptionGeneration !== state.subscriptionGeneration
@@ -1802,13 +1825,18 @@
             state.firstNewMessageId = null;
             newResponse.hidden = true;
             var selected = selectedMessages[0];
-            if (selected) {
+            var openingAtLatest = message.atLatest
+                && message.updateKind === 'initial';
+            if (openingAtLatest) {
+                scrollToConversationEnd();
+            } else if (selected) {
                 selected.scrollIntoView({ block: 'center' });
-                if (message.updateKind === 'navigation') {
-                    selected.tabIndex = -1;
-                    selected.focus({ preventScroll: true });
-                }
             }
+            if (selected && message.updateKind === 'navigation') {
+                selected.tabIndex = -1;
+                selected.focus({ preventScroll: true });
+            }
+            if (!openingAtLatest) trackConversationEnd();
             return;
         }
 
@@ -1821,10 +1849,22 @@
             state.firstNewMessageId = appendedOrChanged[0];
         }
         newResponse.hidden = !state.firstNewMessageId;
+        trackConversationEnd();
     }
 
     function postNavigation(type) {
         post({ type: type, version: 1 });
+    }
+
+    scroll.addEventListener('scroll', trackConversationEnd, { passive: true });
+    if (typeof ResizeObserver === 'function') {
+        var viewportObserver = new ResizeObserver(function () {
+            if (state.followingEnd) scrollToConversationEnd();
+        });
+        viewportObserver.observe(scroll);
+        window.addEventListener('unload', function () {
+            viewportObserver.disconnect();
+        });
     }
 
     previous.addEventListener('click', function () {

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -390,6 +390,51 @@ function messageHtml(prefix, count, start = 0) {
     }).join('');
 }
 
+function interactionHtml(prefix, count, responseLines, start = 0) {
+    return Array.from({ length: count }, (_item, index) => {
+        const interactionId = `${prefix}-${start + index}`;
+        const response = Array.from(
+            { length: responseLines },
+            (_line, line) => `<p>${interactionId} response line ${line}</p>`
+        ).join('');
+        return `<article data-message-id="${interactionId}-user"
+            data-interaction-id="${interactionId}">
+            <section><p>${interactionId} prompt</p></section>
+        </article>
+        <article data-message-id="${interactionId}-assistant"
+            data-interaction-id="${interactionId}">
+            <section>${response}</section>
+        </article>`;
+    }).join('');
+}
+
+async function measureConversationEnd(page, lastMessageId) {
+    return page.evaluate(messageId => {
+        const scroll = document.querySelector('[data-conversation-scroll]');
+        const last = document.querySelector(
+            `[data-message-id="${messageId}"]`
+        );
+        const selected = document.querySelector(
+            '.conversation-selected-interaction'
+        );
+        const bounds = scroll.getBoundingClientRect();
+        const selectedBounds = selected
+            ? selected.getBoundingClientRect()
+            : null;
+        return {
+            hiddenBelow: Math.round(
+                last.getBoundingClientRect().bottom - bounds.bottom
+            ),
+            distanceFromEnd: Math.round(
+                scroll.scrollHeight - scroll.clientHeight - scroll.scrollTop
+            ),
+            selectedVisible: !!selectedBounds
+                && selectedBounds.bottom > bounds.top
+                && selectedBounds.top < bounds.bottom,
+        };
+    }, lastMessageId);
+}
+
 function fakeHostUri(value) {
     return {
         scheme: value.split(':', 1)[0],
@@ -3181,6 +3226,154 @@ test('CONVERSATION-VIEWER-BROWSER-NAVIGATION-002 anchors and focuses the Host-se
         document.activeElement
             && document.activeElement.getAttribute('data-interaction-id')
     ), 'selected-2');
+});
+
+test('CONVERSATION-OPEN-LATEST-001 reveals the newest line when the viewer opens at the latest interaction inside a short viewport', async t => {
+    const page = await openViewerPage(t);
+    const outline = Array.from({ length: 5 }, (_item, index) => ({
+        interactionId: `latest-${index}`,
+        userPreview: `Latest input ${index + 1}`,
+        responseState: 'complete',
+    }));
+    await sendPage(page, {
+        ...hostileConversationPage,
+        html: interactionHtml('latest', 4, 3)
+            + interactionHtml('latest', 4, 40, 4),
+        outline,
+        selectedInteractionId: 'latest-4',
+        selectedInput: 5,
+        totalInputs: 5,
+        atLatest: true,
+        nextCursor: undefined,
+    });
+
+    const opened = await measureConversationEnd(page, 'latest-4-assistant');
+    assert.ok(
+        opened.hiddenBelow <= 0,
+        `newest line stayed ${opened.hiddenBelow}px below the viewport`
+    );
+    assert.equal(opened.distanceFromEnd, 0);
+
+    await sendPage(page, {
+        ...hostileConversationPage,
+        requestId: 2,
+        updateKind: 'navigation',
+        html: interactionHtml('latest', 4, 3)
+            + interactionHtml('latest', 4, 40, 4),
+        outline,
+        selectedInteractionId: 'latest-1',
+        selectedInput: 2,
+        totalInputs: 5,
+        atLatest: false,
+    });
+
+    const navigated = await measureConversationEnd(page, 'latest-4-assistant');
+    assert.ok(
+        navigated.distanceFromEnd > 0,
+        'navigating away from the latest input must not jump to the end'
+    );
+    assert.ok(
+        navigated.selectedVisible,
+        'navigation must keep the selected interaction inside the viewport'
+    );
+});
+
+test('CONVERSATION-OPEN-LATEST-001 keeps the newest line visible when the editor area shrinks and leaves a scrolled-up reader in place', async t => {
+    const page = await openViewerPage(t);
+    const outline = Array.from({ length: 5 }, (_item, index) => ({
+        interactionId: `shrink-${index}`,
+        userPreview: `Shrink input ${index + 1}`,
+        responseState: 'complete',
+    }));
+    await sendPage(page, {
+        ...hostileConversationPage,
+        html: interactionHtml('shrink', 4, 3)
+            + interactionHtml('shrink', 4, 40, 4),
+        outline,
+        selectedInteractionId: 'shrink-4',
+        selectedInput: 5,
+        totalInputs: 5,
+        atLatest: true,
+        nextCursor: undefined,
+    });
+    const scroll = page.locator('[data-conversation-scroll]');
+    const shrink = async height => {
+        await scroll.evaluate((element, value) => {
+            element.style.height = `${value}px`;
+        }, height);
+        await page.waitForTimeout(50);
+    };
+
+    await shrink(80);
+    const shrunk = await measureConversationEnd(page, 'shrink-4-assistant');
+    assert.ok(
+        shrunk.hiddenBelow <= 0,
+        `newest line stayed ${shrunk.hiddenBelow}px below the shrunk viewport`
+    );
+
+    await scroll.evaluate(element => { element.scrollTop = 40; });
+    await shrink(60);
+    assert.equal(await scroll.evaluate(element => element.scrollTop), 40);
+});
+
+test('CONVERSATION-OUTLINE-NAVIGATION-001 CONVERSATION-OPEN-LATEST-001 anchors outline navigation on the selected input even when it is the newest one', async t => {
+    const page = await openViewerPage(t);
+    const outline = Array.from({ length: 5 }, (_item, index) => ({
+        interactionId: `nav-${index}`,
+        userPreview: `Nav input ${index + 1}`,
+        responseState: 'complete',
+    }));
+    const html = interactionHtml('nav', 4, 40)
+        + interactionHtml('nav', 1, 40, 4);
+    const navigateTo = async (interactionId, requestId, atLatest) => {
+        await sendPage(page, {
+            ...hostileConversationPage,
+            requestId,
+            updateKind: 'navigation',
+            html,
+            outline,
+            selectedInteractionId: interactionId,
+            selectedInput: Number(interactionId.split('-')[1]) + 1,
+            totalInputs: 5,
+            atLatest,
+        });
+        return page.evaluate(id => {
+            const scroll = document.querySelector(
+                '[data-conversation-scroll]'
+            );
+            const prompt = document.querySelector(
+                `[data-message-id="${id}-user"]`
+            );
+            return Math.round(
+                prompt.getBoundingClientRect().top
+                - scroll.getBoundingClientRect().top
+            );
+        }, interactionId);
+    };
+
+    await sendPage(page, {
+        ...hostileConversationPage,
+        html,
+        outline,
+        selectedInteractionId: 'nav-4',
+        selectedInput: 5,
+        totalInputs: 5,
+        atLatest: true,
+        nextCursor: undefined,
+    });
+
+    const middleTop = await navigateTo('nav-2', 2, false);
+    const newestTop = await navigateTo('nav-4', 3, true);
+
+    assert.ok(
+        middleTop >= 0,
+        `middle input anchored ${middleTop}px above the viewport`
+    );
+    assert.ok(
+        newestTop >= 0,
+        `newest input anchored ${newestTop}px above the viewport`
+    );
+    assert.equal(newestTop, middleTop);
 });
 
 test('CONVERSATION-VIEWER-PARTIAL-001 labels capped input positions and partial history', async t => {

--- a/tests/unit/tooling/changedCoverage.test.js
+++ b/tests/unit/tooling/changedCoverage.test.js
@@ -85,6 +85,8 @@ test('COVERAGE-CHANGED-CODE-001 reports uncovered executable changed lines and m
 test('COVERAGE-CHANGED-CODE-001 exempts only the paths the suite structurally cannot instrument', () => {
     assert.equal(isUninstrumentedByDesign('src/dashboard.ts'), true);
     assert.equal(isUninstrumentedByDesign('scripts/run-ai-session-safety-checks.js'), true);
+    assert.equal(isUninstrumentedByDesign('src/webview/conversationViewerScripts.js'), true);
+    assert.equal(isUninstrumentedByDesign('src/webview/webviewContent.ts'), false);
     assert.equal(isUninstrumentedByDesign('src/aiSessions/dashboardController.ts'), false);
     assert.equal(isUninstrumentedByDesign('scripts/lib/behaviorCatalog.js'), false);
     assert.equal(isUninstrumentedByDesign('scripts/run-nested/helper.js'), false);


### PR DESCRIPTION
## Problem

Opening the AI Conversation while the terminal panel is open left the tail of the newest response below the fold — it looked like the terminal was covering the viewer.

The initial render centered the selected interaction's **User** article (`selectedMessages[0]`; each interaction renders a User plus an Assistant article sharing `data-interaction-id`). That lands scroll at `userCenter - viewportHeight/2`, so the newest line only appeared when the browser clamped the scroll to the end — which requires the content after the User article's center to fit in half a viewport. A tall editor area usually satisfied that; a terminal-shortened one did not.

Measured with the real viewer scripts and CSS in Chromium:

| Scenario | Viewport | scrollTop / max | Newest line |
| --- | --- | --- | --- |
| No terminal | 806px | 600 / 600 | visible |
| Terminal open | 246px | 987 / **1160** | **141px below the fold** |
| Terminal open, long reply | 246px | 987 / **1832** | **813px below the fold** |

`scrollTop` is identical in both terminal cases — the landing spot ignored how much content followed.

## Change

- Anchor the **initial** publication to the end of the scroll container instead of relying on the clamp.
- Re-pin a reader who is already at the end when the editor area shrinks afterwards (opening the terminal *after* the viewer). Guarded by the existing `data-auto-scroll-threshold`, so a reader scrolled up is left alone.
- Outline clicks, Latest, and Previous/Next keep anchoring on the selected input — including the newest one. `atLatest` only means "the selected input is the last one", so treating it as "the reader asked for the end" sent outline navigation to the bottom instead of to that input (measured 1234px off).

## Verification

- Three new tests under `CONVERSATION-OPEN-LATEST-001` / `CONVERSATION-OUTLINE-NAVIGATION-001`, each written failing first.
- `tests/browser/conversationViewer.test.js`: 39/39 pass.
- `lint:ci`, `test:behavior-contracts`, `test:architecture-guards`, `test:release-notes`, `test:dashboard:run`: pass.
- Packaged and installed into the running Dev Container server; verified the installed `media/conversationViewerScripts.js` and `dist/dashboard.js` sha256 match the VSIX, then confirmed the three scenarios by hand.

No version bump — not a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)