### PR TITLE
fix: route local installs to the running VS Code host

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -1056,6 +1056,21 @@
     ]
   },
   {
+    "id": "LOCAL-INSTALL-CLI-TARGET-001",
+    "domain": "release",
+    "title": "Local install routes to the running host with absolute artifacts and verified bytes",
+    "priority": "P1",
+    "status": "automated",
+    "owners": [
+      "tests/unit/tooling/vscodeCliTarget.test.js",
+      "tests/unit/tooling/installLocalExtensions.test.js"
+    ],
+    "evidence": [
+      "scripts/lib/vscodeCliTarget.js",
+      "scripts/install-local-extensions.js"
+    ]
+  },
+  {
     "id": "SESSION-CODEX-SESSION-SERVICE-001",
     "domain": "session",
     "title": "Codex change polling reuses discovery stats instead of stat'ing every file twice",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "b582d61f6bbe66a84bc9c4ad6b01c2e16eb95bf2",
+        "head": "af19b2c9fbab071d6e8004846bff1cdd810836bc",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -54,7 +54,8 @@
             "f7a8438e0b189907048c7f652e0688d21e850fbb",
             "a9618126564283fbf57d408541796ed41d6bdc68",
             "024c6be9e460ac9ef3e80f40faef9488eb542fcb",
-            "35a3e2e3a2bddc828277b30e94d5ecc5ce63a7aa"
+            "35a3e2e3a2bddc828277b30e94d5ecc5ce63a7aa",
+            "acbd2a3166504fc42fc20c8b0e1874f3ec09c092"
         ]
     },
     "capabilities": [
@@ -442,12 +443,16 @@
                 "6e0c1fcd1201d469f55f57deb9bce134e556c683",
                 "07fefc21bb63bd8bde6192e30b3db4d9d13c642d",
                 "114e769d21182b614f213c35cdb9113f0305711b",
-                "0b1a72a4df82c1bfc595d63b52e85d2aacd753de"
+                "0b1a72a4df82c1bfc595d63b52e85d2aacd753de",
+                "6a514e5499745fed0383e103cd302616d54ed67e",
+                "aa4652ce76238eefdbf73381da93f410e2db096d",
+                "af19b2c9fbab071d6e8004846bff1cdd810836bc"
             ],
             "behaviors": [
                 "RELEASE-VSIX-PACKAGING-001",
                 "ARCH-RELEASE-IDENTITY-001",
-                "RELEASE-ATTENTION-SPIKE-ARTIFACT-VERSION-001"
+                "RELEASE-ATTENTION-SPIKE-ARTIFACT-VERSION-001",
+                "LOCAL-INSTALL-CLI-TARGET-001"
             ],
             "prGates": [
                 "test:ci:linux"

--- a/scripts/build-test-package-install.sh
+++ b/scripts/build-test-package-install.sh
@@ -4,7 +4,6 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
-CODE_CMD="${CODE_CMD:-code}"
 SKIP_NPM_CI="${SKIP_NPM_CI:-0}"
 
 if ! command -v node >/dev/null 2>&1; then
@@ -17,19 +16,6 @@ if ! command -v npm >/dev/null 2>&1; then
     exit 1
 fi
 
-if ! command -v "$CODE_CMD" >/dev/null 2>&1; then
-    echo "error: '$CODE_CMD' is not installed or not on PATH" >&2
-    echo "hint: set CODE_CMD to another VS Code-compatible CLI, e.g. CODE_CMD=code-insiders $0" >&2
-    exit 1
-fi
-
-EXT_NAME="$(node -p "require('./package.json').name")"
-EXT_VERSION="$(node -p "require('./package.json').version")"
-VSIX_FILE="${EXT_NAME}-${EXT_VERSION}.vsix"
-BRIDGE_NAME="$(node -p "require('./extensions/attention-ui-bridge/package.json').name")"
-BRIDGE_VERSION="$(node -p "require('./extensions/attention-ui-bridge/package.json').version")"
-BRIDGE_VSIX="artifacts/${BRIDGE_NAME}-${BRIDGE_VERSION}.vsix"
-MAIN_VSIX="artifacts/${VSIX_FILE}"
 
 run_step() {
     echo
@@ -47,8 +33,6 @@ fi
 run_step npm run test-compile
 run_step npm run lint
 run_step npm run package:release
-run_step "$CODE_CMD" --install-extension "$BRIDGE_VSIX" --force
-run_step "$CODE_CMD" --install-extension "$MAIN_VSIX" --force
-
-echo
-echo "Installed $BRIDGE_VSIX and $MAIN_VSIX with $CODE_CMD."
+# Routing, absolute artifact paths and byte verification live in Node so they
+# can be tested; set CODE_CMD to override the chosen CLI.
+run_step node scripts/install-local-extensions.js

--- a/scripts/install-local-extensions.js
+++ b/scripts/install-local-extensions.js
@@ -1,0 +1,107 @@
+'use strict';
+
+const childProcess = require('child_process');
+const path = require('path');
+const {
+    createExtensionPackagePlan,
+    resolveInstalledExtensionRoots,
+    verifyInstalledExtensionBytes,
+} = require('./lib/extensionHostLauncher');
+const { resolveVSCodeCliTarget } = require('./lib/vscodeCliTarget');
+
+/**
+ * Arguments for installing one packaged extension into a live host.
+ *
+ * The artifact path is absolute because a relative one is resolved by the VS
+ * Code Server against its own working directory rather than the shell's, which
+ * made the previous script fail with ENOENT under a remote host. The extensions
+ * directory is pinned whenever it is known, so that installing and any later
+ * listing cannot disagree about where the bytes went. Unlike the Extension Host
+ * test harness this must not override the user data directory: it is installing
+ * into the host the user is actually running.
+ */
+function buildInstallArgs(artifactPath, extensionsDir) {
+    return [
+        ...(extensionsDir ? [`--extensions-dir=${extensionsDir}`] : []),
+        '--install-extension',
+        path.resolve(artifactPath),
+        '--force',
+    ];
+}
+
+function main(options = {}) {
+    const repositoryRoot = options.repositoryRoot || path.resolve(__dirname, '..');
+    const spawnSync = options.spawnSync || childProcess.spawnSync;
+    const logger = options.logger || console;
+    const target = options.target || resolveVSCodeCliTarget();
+
+    if (!target.command) {
+        logger.error(`error: ${target.error}`);
+        return 1;
+    }
+
+    const packagePlan = createExtensionPackagePlan(repositoryRoot);
+    logger.log(`==> installing with ${target.command} (${target.source})`);
+    if (target.extensionsDir) {
+        logger.log(`    extensions dir: ${target.extensionsDir}`);
+    }
+
+    for (const extensionPackage of packagePlan) {
+        const args = buildInstallArgs(extensionPackage.artifactPath, target.extensionsDir);
+        const result = spawnSync(target.command, args, {
+            encoding: 'utf8',
+            // A stale hook must not reach the CLI we deliberately chose.
+            env: withoutIpcHook(process.env),
+            stdio: 'inherit',
+            windowsHide: true,
+        });
+        if (result.error || result.status !== 0) {
+            logger.error(
+                `error: failed to install ${extensionPackage.id}: `
+                + `${result.error ? result.error.message : `status ${result.status}`}`
+            );
+            return 1;
+        }
+    }
+
+    if (!target.extensionsDir) {
+        logger.log(
+            'Installed, but the extensions directory is unknown for this host, '
+            + 'so installed bytes were not verified.'
+        );
+        return 0;
+    }
+
+    let evidence;
+    try {
+        evidence = verifyInstalledExtensionBytes(
+            packagePlan,
+            resolveInstalledExtensionRoots(packagePlan, target.extensionsDir)
+        );
+    } catch (error) {
+        logger.error(`error: ${error instanceof Error ? error.message : String(error)}`);
+        return 1;
+    }
+    for (const item of evidence) {
+        logger.log(`    ${item.extensionId} ${item.file} ${item.sha256.slice(0, 16)}…`);
+    }
+    logger.log(`Installed ${packagePlan.length} extensions and verified their bytes.`);
+    return 0;
+}
+
+function withoutIpcHook(environment) {
+    const copy = { ...environment };
+    delete copy.VSCODE_IPC_HOOK_CLI;
+    return copy;
+}
+
+if (require.main === module) {
+    try {
+        process.exitCode = main();
+    } catch (error) {
+        console.error(error instanceof Error ? error.message : String(error));
+        process.exitCode = 1;
+    }
+}
+
+module.exports = { buildInstallArgs, main, withoutIpcHook };

--- a/scripts/lib/vscodeCliTarget.js
+++ b/scripts/lib/vscodeCliTarget.js
@@ -1,0 +1,126 @@
+'use strict';
+
+const fs = require('fs');
+const net = require('net');
+const path = require('path');
+
+/**
+ * Whether a VS Code IPC socket actually accepts a connection.
+ *
+ * VSCODE_IPC_HOOK_CLI stays set in a shell long after the window that created it
+ * is gone, and the socket file survives too, so its presence proves nothing. A
+ * CLI that inherits a dead hook either fails or silently targets the wrong host.
+ */
+function isLiveIpcSocket(socketPath, probe = probeUnixSocket) {
+    return Boolean(socketPath) && probe(socketPath);
+}
+
+function probeUnixSocket(socketPath) {
+    try {
+        const socket = net.connect(socketPath);
+        socket.destroy();
+        return fs.statSync(socketPath).isSocket();
+    } catch (_error) {
+        return false;
+    }
+}
+
+/**
+ * The socket-independent entry point of a VS Code Server installation.
+ *
+ * `bin/code-server` runs the server's own `out/server-main.js` directly, so it
+ * manages extensions without consulting VSCODE_IPC_HOOK_CLI at all.
+ */
+function serverEntryPoint(serverRoot) {
+    return path.join(serverRoot, 'bin', 'code-server');
+}
+
+/**
+ * Resolves which VS Code CLI should receive an extension install, and where.
+ *
+ * Preference order:
+ *   1. An explicit CODE_CMD, which the caller is responsible for.
+ *   2. The running Server installation, when a remote Server is present. This is
+ *      required rather than merely preferred when the inherited IPC hook is
+ *      stale, because PATH's `code` is the Server's remote-cli wrapper and it
+ *      would inherit that dead hook.
+ *   3. PATH's `code`, for a plain local install.
+ */
+function resolveVSCodeCliTarget(options = {}) {
+    const environment = options.environment || process.env;
+    const exists = options.exists || (candidate => fs.existsSync(candidate));
+    const listServerRoots = options.listServerRoots || defaultListServerRoots;
+    const socketIsLive = options.isLiveIpcSocket || isLiveIpcSocket;
+
+    if (environment.CODE_CMD) {
+        return {
+            command: environment.CODE_CMD,
+            source: 'explicit',
+            extensionsDir: environment.VSCODE_EXTENSIONS || null,
+        };
+    }
+
+    const serverRoots = listServerRoots(environment);
+    const hookPath = environment.VSCODE_IPC_HOOK_CLI || '';
+    const hookIsLive = socketIsLive(hookPath);
+    for (const serverRoot of serverRoots) {
+        const command = serverEntryPoint(serverRoot);
+        if (!exists(command)) {
+            continue;
+        }
+        return {
+            command,
+            source: hookIsLive ? 'server' : 'server-stale-ipc',
+            extensionsDir: path.join(path.dirname(path.dirname(serverRoot)), 'extensions'),
+        };
+    }
+
+    if (hookPath && !hookIsLive) {
+        return {
+            command: null,
+            source: 'stale-ipc-without-server',
+            extensionsDir: null,
+            error: 'VSCODE_IPC_HOOK_CLI points at a socket that refuses connections and no '
+                + 'VS Code Server installation was found. Set CODE_CMD to a CLI that can '
+                + 'reach the intended host.',
+        };
+    }
+    return { command: 'code', source: 'path', extensionsDir: null };
+}
+
+/** Server installations under ~/.vscode-server/bin, newest mtime first. */
+function defaultListServerRoots(environment) {
+    const home = environment.HOME || environment.USERPROFILE;
+    if (!home) {
+        return [];
+    }
+    const binRoot = path.join(home, '.vscode-server', 'bin');
+    let entries;
+    try {
+        entries = fs.readdirSync(binRoot, { withFileTypes: true });
+    } catch (_error) {
+        return [];
+    }
+    return entries
+        .filter(entry => entry.isDirectory())
+        .map(entry => {
+            const directory = path.join(binRoot, entry.name);
+            let mtimeMs = 0;
+            try {
+                mtimeMs = fs.statSync(directory).mtimeMs;
+            } catch (_error) {
+                mtimeMs = 0;
+            }
+            return { directory, mtimeMs };
+        })
+        .sort((left, right) => right.mtimeMs - left.mtimeMs
+            || left.directory.localeCompare(right.directory))
+        .map(entry => entry.directory);
+}
+
+module.exports = {
+    defaultListServerRoots,
+    isLiveIpcSocket,
+    resolveVSCodeCliTarget,
+    serverEntryPoint,
+};

--- a/scripts/run-release-packaging-checks.js
+++ b/scripts/run-release-packaging-checks.js
@@ -778,10 +778,21 @@ function run() {
 
     const installScript = readText('scripts/build-test-package-install.sh');
     assertIncludes(installScript, 'npm run package:release', 'local install script');
-    assertIncludes(installScript, 'BRIDGE_VERSION', 'local install script');
-    assertIncludes(installScript, '--install-extension "$BRIDGE_VSIX" --force', 'local install script');
-    assertIncludes(installScript, '--install-extension "$MAIN_VSIX" --force', 'local install script');
+    assertIncludes(installScript, 'node scripts/install-local-extensions.js', 'local install script');
     assertNotIncludes(installScript, 'agent-pivot-attention-ui-bridge-0.1.3.vsix', 'local install script');
+
+    // Routing, artifact paths and byte verification moved into Node so they could
+    // be tested; the packaging invariants follow them there. Versions come from
+    // the extension manifests via the package plan, so none can be hardcoded.
+    const localInstaller = readText('scripts/install-local-extensions.js');
+    assertIncludes(localInstaller, 'createExtensionPackagePlan', 'local installer');
+    assertIncludes(localInstaller, 'verifyInstalledExtensionBytes', 'local installer');
+    assertIncludes(localInstaller, '--install-extension', 'local installer');
+    assertIncludes(localInstaller, 'path.resolve(artifactPath)', 'local installer');
+    assertNotIncludes(localInstaller, 'agent-pivot-attention-ui-bridge-0.1.3.vsix', 'local installer');
+    const packagePlanSource = readText('scripts/lib/extensionHostLauncher.js');
+    assertIncludes(packagePlanSource, 'attention-ui-bridge', 'local installer package plan');
+    assertIncludes(packagePlanSource, 'manifest.version', 'local installer package plan');
 
     const publishScript = readText('scripts/publish-marketplace.sh');
     assertIncludes(publishScript, 'BRIDGE_NAME', 'Marketplace publish script');

--- a/tests/unit/tooling/installLocalExtensions.test.js
+++ b/tests/unit/tooling/installLocalExtensions.test.js
@@ -1,8 +1,11 @@
 'use strict';
 
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
 const path = require('node:path');
 const test = require('node:test');
+const { makeTempDirectory } = require('../../helpers/tempDirectory');
+const { createExtensionPackagePlan } = require('../../../scripts/lib/extensionHostLauncher');
 const {
     buildInstallArgs,
     main,
@@ -77,4 +80,87 @@ test('LOCAL-INSTALL-CLI-TARGET-001 stops at the first failing install', () => {
     assert.equal(calls[0].command, '/srv/bin/code-server');
     assert.ok(calls[0].args.includes('--extensions-dir=/srv/ext'));
     assert.ok(path.isAbsolute(calls[0].args.at(-2)));
+});
+
+test('LOCAL-INSTALL-CLI-TARGET-001 installs without verifying when the host directory is unknown', () => {
+    const logger = collectLogger();
+    const calls = [];
+
+    const status = main({
+        repositoryRoot,
+        logger,
+        spawnSync: (command, args) => { calls.push(args); return { status: 0 }; },
+        target: { command: 'code', source: 'path', extensionsDir: null },
+    });
+
+    assert.equal(status, 0);
+    assert.equal(calls.length, 2, 'both extensions are installed');
+    assert.ok(calls.every(args => !args.some(arg => arg.startsWith('--extensions-dir'))));
+    assert.match(logger.out.join('\n'), /not verified/,
+        'skipping verification must be stated, not implied by silence');
+});
+
+test('LOCAL-INSTALL-CLI-TARGET-001 verifies installed bytes against the built extension', t => {
+    const extensionsDir = makeTempDirectory(t, 'local-install-verify-');
+    const packagePlan = createExtensionPackagePlan(repositoryRoot);
+    for (const extensionPackage of packagePlan) {
+        const installedRoot = path.join(
+            extensionsDir, `${extensionPackage.id}-${extensionPackage.version}`
+        );
+        fs.mkdirSync(installedRoot, { recursive: true });
+        // VS Code injects __metadata on install; verification must tolerate it.
+        fs.writeFileSync(path.join(installedRoot, 'package.json'), JSON.stringify({
+            ...extensionPackage.manifest,
+            __metadata: { installedTimestamp: 1 },
+        }), 'utf8');
+        for (const relativePath of extensionPackage.runtimeFiles) {
+            const target = path.join(installedRoot, relativePath);
+            fs.mkdirSync(path.dirname(target), { recursive: true });
+            fs.copyFileSync(path.join(extensionPackage.packageRoot, relativePath), target);
+        }
+    }
+
+    const logger = collectLogger();
+    const status = main({
+        repositoryRoot,
+        logger,
+        spawnSync: () => ({ status: 0 }),
+        target: { command: '/srv/bin/code-server', source: 'server', extensionsDir },
+    });
+
+    assert.equal(status, 0);
+    const output = logger.out.join('\n');
+    assert.match(output, /verified their bytes/);
+    for (const extensionPackage of packagePlan) {
+        assert.ok(output.includes(extensionPackage.id), `${extensionPackage.id} reported`);
+    }
+});
+
+test('LOCAL-INSTALL-CLI-TARGET-001 fails when installed bytes do not match the build', t => {
+    const extensionsDir = makeTempDirectory(t, 'local-install-mismatch-');
+    const [extensionPackage] = createExtensionPackagePlan(repositoryRoot);
+    const installedRoot = path.join(
+        extensionsDir, `${extensionPackage.id}-${extensionPackage.version}`
+    );
+    fs.mkdirSync(installedRoot, { recursive: true });
+    fs.writeFileSync(
+        path.join(installedRoot, 'package.json'),
+        JSON.stringify(extensionPackage.manifest), 'utf8'
+    );
+    for (const relativePath of extensionPackage.runtimeFiles) {
+        const target = path.join(installedRoot, relativePath);
+        fs.mkdirSync(path.dirname(target), { recursive: true });
+        fs.writeFileSync(target, 'tampered', 'utf8');
+    }
+
+    const logger = collectLogger();
+    const status = main({
+        repositoryRoot,
+        logger,
+        spawnSync: () => ({ status: 0 }),
+        target: { command: '/srv/bin/code-server', source: 'server', extensionsDir },
+    });
+
+    assert.equal(status, 1, 'a zero exit status from the CLI is not proof of installed bytes');
+    assert.match(logger.out.join('\n'), /ERR /);
 });

--- a/tests/unit/tooling/installLocalExtensions.test.js
+++ b/tests/unit/tooling/installLocalExtensions.test.js
@@ -1,0 +1,80 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const test = require('node:test');
+const {
+    buildInstallArgs,
+    main,
+    withoutIpcHook,
+} = require('../../../scripts/install-local-extensions');
+
+const repositoryRoot = path.resolve(__dirname, '../../..');
+
+function collectLogger() {
+    const out = [];
+    return { out, log: line => out.push(line), error: line => out.push(`ERR ${line}`) };
+}
+
+test('LOCAL-INSTALL-CLI-TARGET-001 passes an absolute artifact path and pins the extensions dir', () => {
+    const args = buildInstallArgs('artifacts/agent-pivot-1.0.1.vsix', '/srv/extensions');
+
+    assert.deepEqual(args, [
+        '--extensions-dir=/srv/extensions',
+        '--install-extension',
+        path.resolve('artifacts/agent-pivot-1.0.1.vsix'),
+        '--force',
+    ]);
+    assert.ok(path.isAbsolute(args[2]),
+        'a relative path would resolve against the Server working directory, not the shell');
+});
+
+test('LOCAL-INSTALL-CLI-TARGET-001 omits the extensions dir when the host default applies', () => {
+    assert.deepEqual(buildInstallArgs('/tmp/x.vsix', null), [
+        '--install-extension', '/tmp/x.vsix', '--force',
+    ]);
+});
+
+test('LOCAL-INSTALL-CLI-TARGET-001 never leaks a stale IPC hook to the chosen CLI', () => {
+    const cleaned = withoutIpcHook({ PATH: '/usr/bin', VSCODE_IPC_HOOK_CLI: '/tmp/stale.sock' });
+
+    assert.equal('VSCODE_IPC_HOOK_CLI' in cleaned, false);
+    assert.equal(cleaned.PATH, '/usr/bin');
+});
+
+test('LOCAL-INSTALL-CLI-TARGET-001 refuses to install when no CLI can be trusted', () => {
+    const logger = collectLogger();
+    let spawned = 0;
+
+    const status = main({
+        repositoryRoot,
+        logger,
+        spawnSync: () => { spawned += 1; return { status: 0 }; },
+        target: { command: null, source: 'stale-ipc-without-server', error: 'no reachable host' },
+    });
+
+    assert.equal(status, 1);
+    assert.equal(spawned, 0, 'nothing may be installed into an unknown host');
+    assert.match(logger.out.join('\n'), /no reachable host/);
+});
+
+test('LOCAL-INSTALL-CLI-TARGET-001 stops at the first failing install', () => {
+    const logger = collectLogger();
+    const calls = [];
+
+    const status = main({
+        repositoryRoot,
+        logger,
+        spawnSync: (command, args) => {
+            calls.push({ command, args });
+            return { status: 1 };
+        },
+        target: { command: '/srv/bin/code-server', source: 'server', extensionsDir: '/srv/ext' },
+    });
+
+    assert.equal(status, 1);
+    assert.equal(calls.length, 1, 'a failed install must not be followed by the next one');
+    assert.equal(calls[0].command, '/srv/bin/code-server');
+    assert.ok(calls[0].args.includes('--extensions-dir=/srv/ext'));
+    assert.ok(path.isAbsolute(calls[0].args.at(-2)));
+});

--- a/tests/unit/tooling/installLocalExtensions.test.js
+++ b/tests/unit/tooling/installLocalExtensions.test.js
@@ -5,7 +5,6 @@ const fs = require('node:fs');
 const path = require('node:path');
 const test = require('node:test');
 const { makeTempDirectory } = require('../../helpers/tempDirectory');
-const { createExtensionPackagePlan } = require('../../../scripts/lib/extensionHostLauncher');
 const {
     buildInstallArgs,
     main,
@@ -100,29 +99,73 @@ test('LOCAL-INSTALL-CLI-TARGET-001 installs without verifying when the host dire
         'skipping verification must be stated, not implied by silence');
 });
 
-test('LOCAL-INSTALL-CLI-TARGET-001 verifies installed bytes against the built extension', t => {
-    const extensionsDir = makeTempDirectory(t, 'local-install-verify-');
-    const packagePlan = createExtensionPackagePlan(repositoryRoot);
-    for (const extensionPackage of packagePlan) {
-        const installedRoot = path.join(
-            extensionsDir, `${extensionPackage.id}-${extensionPackage.version}`
+// Verification runs against a synthetic repository: the real runtime files are
+// untracked build outputs, and CI never builds the bridge dist, so copying the
+// working-tree bytes made this test pass only on machines with a local build.
+function makeSyntheticRepository(t) {
+    const syntheticRoot = makeTempDirectory(t, 'local-install-repo-');
+    const extensions = [
+        {
+            manifest: { publisher: 'hzcheng', name: 'agent-pivot-attention-ui-bridge', version: '1.0.0' },
+            packageRoot: path.join(syntheticRoot, 'extensions', 'attention-ui-bridge'),
+            runtimeFiles: { 'dist/extension.js': 'bridge-bytes' },
+        },
+        {
+            manifest: { publisher: 'hzcheng', name: 'agent-pivot', version: '1.0.0' },
+            packageRoot: syntheticRoot,
+            runtimeFiles: {
+                'dist/dashboard.js': 'main-bytes',
+                'media/conversationViewerScripts.js': 'viewer-bytes',
+                'media/conversationMermaidScripts.js': 'mermaid-bytes',
+            },
+        },
+    ];
+    for (const extension of extensions) {
+        fs.mkdirSync(extension.packageRoot, { recursive: true });
+        fs.writeFileSync(
+            path.join(extension.packageRoot, 'package.json'),
+            JSON.stringify(extension.manifest), 'utf8'
         );
+        for (const [relativePath, content] of Object.entries(extension.runtimeFiles)) {
+            const target = path.join(extension.packageRoot, relativePath);
+            fs.mkdirSync(path.dirname(target), { recursive: true });
+            fs.writeFileSync(target, content, 'utf8');
+        }
+    }
+    return { repositoryRoot: syntheticRoot, extensions };
+}
+
+function installSyntheticExtensions(t, extensions, { tamper = false } = {}) {
+    const extensionsDir = makeTempDirectory(t, 'local-install-verify-');
+    for (const extension of extensions) {
+        const id = `${extension.manifest.publisher}.${extension.manifest.name}`;
+        const installedRoot = path.join(extensionsDir, `${id}-${extension.manifest.version}`);
         fs.mkdirSync(installedRoot, { recursive: true });
         // VS Code injects __metadata on install; verification must tolerate it.
         fs.writeFileSync(path.join(installedRoot, 'package.json'), JSON.stringify({
-            ...extensionPackage.manifest,
+            ...extension.manifest,
             __metadata: { installedTimestamp: 1 },
         }), 'utf8');
-        for (const relativePath of extensionPackage.runtimeFiles) {
+        for (const relativePath of Object.keys(extension.runtimeFiles)) {
             const target = path.join(installedRoot, relativePath);
             fs.mkdirSync(path.dirname(target), { recursive: true });
-            fs.copyFileSync(path.join(extensionPackage.packageRoot, relativePath), target);
+            if (tamper) {
+                fs.writeFileSync(target, 'tampered', 'utf8');
+            } else {
+                fs.copyFileSync(path.join(extension.packageRoot, relativePath), target);
+            }
         }
     }
+    return extensionsDir;
+}
+
+test('LOCAL-INSTALL-CLI-TARGET-001 verifies installed bytes against the built extension', t => {
+    const { repositoryRoot: syntheticRoot, extensions } = makeSyntheticRepository(t);
+    const extensionsDir = installSyntheticExtensions(t, extensions);
 
     const logger = collectLogger();
     const status = main({
-        repositoryRoot,
+        repositoryRoot: syntheticRoot,
         logger,
         spawnSync: () => ({ status: 0 }),
         target: { command: '/srv/bin/code-server', source: 'server', extensionsDir },
@@ -130,37 +173,25 @@ test('LOCAL-INSTALL-CLI-TARGET-001 verifies installed bytes against the built ex
 
     assert.equal(status, 0);
     const output = logger.out.join('\n');
-    assert.match(output, /verified their bytes/);
-    for (const extensionPackage of packagePlan) {
-        assert.ok(output.includes(extensionPackage.id), `${extensionPackage.id} reported`);
-    }
+    assert.match(output, /Installed 2 extensions and verified their bytes/);
+    assert.ok(output.includes('hzcheng.agent-pivot-attention-ui-bridge dist/extension.js'),
+        'bridge runtime file reported');
+    assert.ok(output.includes('hzcheng.agent-pivot dist/dashboard.js'),
+        'main runtime file reported');
 });
 
 test('LOCAL-INSTALL-CLI-TARGET-001 fails when installed bytes do not match the build', t => {
-    const extensionsDir = makeTempDirectory(t, 'local-install-mismatch-');
-    const [extensionPackage] = createExtensionPackagePlan(repositoryRoot);
-    const installedRoot = path.join(
-        extensionsDir, `${extensionPackage.id}-${extensionPackage.version}`
-    );
-    fs.mkdirSync(installedRoot, { recursive: true });
-    fs.writeFileSync(
-        path.join(installedRoot, 'package.json'),
-        JSON.stringify(extensionPackage.manifest), 'utf8'
-    );
-    for (const relativePath of extensionPackage.runtimeFiles) {
-        const target = path.join(installedRoot, relativePath);
-        fs.mkdirSync(path.dirname(target), { recursive: true });
-        fs.writeFileSync(target, 'tampered', 'utf8');
-    }
+    const { repositoryRoot: syntheticRoot, extensions } = makeSyntheticRepository(t);
+    const extensionsDir = installSyntheticExtensions(t, extensions, { tamper: true });
 
     const logger = collectLogger();
     const status = main({
-        repositoryRoot,
+        repositoryRoot: syntheticRoot,
         logger,
         spawnSync: () => ({ status: 0 }),
         target: { command: '/srv/bin/code-server', source: 'server', extensionsDir },
     });
 
     assert.equal(status, 1, 'a zero exit status from the CLI is not proof of installed bytes');
-    assert.match(logger.out.join('\n'), /ERR /);
+    assert.match(logger.out.join('\n'), /ERR .*differs from built bytes/);
 });

--- a/tests/unit/tooling/vscodeCliTarget.test.js
+++ b/tests/unit/tooling/vscodeCliTarget.test.js
@@ -1,9 +1,13 @@
 'use strict';
 
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const net = require('node:net');
 const path = require('node:path');
 const test = require('node:test');
+const { makeTempDirectory } = require('../../helpers/tempDirectory');
 const {
+    defaultListServerRoots,
     isLiveIpcSocket,
     resolveVSCodeCliTarget,
     serverEntryPoint,
@@ -92,4 +96,40 @@ test('LOCAL-INSTALL-CLI-TARGET-001 treats an unreachable socket path as dead', (
     assert.equal(isLiveIpcSocket('', () => true), false, 'an unset hook is not live');
     assert.equal(isLiveIpcSocket('/tmp/whatever.sock', () => false), false);
     assert.equal(isLiveIpcSocket('/tmp/whatever.sock', () => true), true);
+});
+
+test('LOCAL-INSTALL-CLI-TARGET-001 lists Server installations newest first', t => {
+    const root = makeTempDirectory(t, 'vscode-cli-target-');
+    const binRoot = path.join(root, '.vscode-server', 'bin');
+    const older = path.join(binRoot, 'older');
+    const newer = path.join(binRoot, 'newer');
+    fs.mkdirSync(older, { recursive: true });
+    fs.mkdirSync(newer, { recursive: true });
+    fs.writeFileSync(path.join(binRoot, 'stray-file'), '', 'utf8');
+    fs.utimesSync(older, new Date(1_000_000), new Date(1_000_000));
+    fs.utimesSync(newer, new Date(2_000_000), new Date(2_000_000));
+
+    assert.deepEqual(defaultListServerRoots({ HOME: root }), [newer, older],
+        'the most recently used Server installation is the live one');
+    assert.deepEqual(defaultListServerRoots({ HOME: path.join(root, 'missing') }), [],
+        'a machine with no Server installation lists nothing');
+    assert.deepEqual(defaultListServerRoots({}), [], 'no home means no discovery');
+});
+
+test('LOCAL-INSTALL-CLI-TARGET-001 probes a real socket rather than trusting the path', async t => {
+    const root = makeTempDirectory(t, 'vscode-cli-socket-');
+    const livePath = path.join(root, 'live.sock');
+    const server = net.createServer(socket => socket.end());
+    await new Promise(resolve => server.listen(livePath, resolve));
+    t.after(() => new Promise(resolve => server.close(resolve)));
+
+    assert.equal(isLiveIpcSocket(livePath), true, 'a listening socket is live');
+    assert.equal(isLiveIpcSocket(path.join(root, 'absent.sock')), false,
+        'a path with no socket is dead');
+
+    // A leftover socket file with nothing listening is the stale case that made
+    // the previous script target the wrong host.
+    server.close();
+    await new Promise(resolve => setTimeout(resolve, 20));
+    assert.equal(isLiveIpcSocket(livePath), false, 'a leftover socket file is not live');
 });

--- a/tests/unit/tooling/vscodeCliTarget.test.js
+++ b/tests/unit/tooling/vscodeCliTarget.test.js
@@ -1,0 +1,95 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const test = require('node:test');
+const {
+    isLiveIpcSocket,
+    resolveVSCodeCliTarget,
+    serverEntryPoint,
+} = require('../../../scripts/lib/vscodeCliTarget');
+
+const SERVER_ROOT = '/home/dev/.vscode-server/bin/abc123';
+
+function resolve(overrides = {}) {
+    return resolveVSCodeCliTarget({
+        environment: {},
+        exists: () => true,
+        listServerRoots: () => [],
+        isLiveIpcSocket: () => false,
+        ...overrides,
+    });
+}
+
+test('LOCAL-INSTALL-CLI-TARGET-001 honours an explicit CODE_CMD before probing anything', () => {
+    let probed = false;
+    const target = resolve({
+        environment: { CODE_CMD: 'code-insiders' },
+        listServerRoots: () => { probed = true; return [SERVER_ROOT]; },
+    });
+
+    assert.equal(target.command, 'code-insiders');
+    assert.equal(target.source, 'explicit');
+    assert.equal(probed, false, 'an explicit choice must not be second-guessed');
+});
+
+test('LOCAL-INSTALL-CLI-TARGET-001 prefers the Server entry point over the inherited CLI', () => {
+    // PATH's `code` inside a Server is remote-cli, which inherits the IPC hook.
+    // bin/code-server talks to the Server installation directly instead.
+    const target = resolve({
+        environment: { VSCODE_IPC_HOOK_CLI: '/tmp/live.sock' },
+        listServerRoots: () => [SERVER_ROOT],
+        isLiveIpcSocket: () => true,
+    });
+
+    assert.equal(target.command, path.join(SERVER_ROOT, 'bin', 'code-server'));
+    assert.equal(target.source, 'server');
+    assert.equal(target.extensionsDir, '/home/dev/.vscode-server/extensions',
+        'install and list must name the same extensions directory');
+});
+
+test('LOCAL-INSTALL-CLI-TARGET-001 still resolves the Server when the inherited hook is dead', () => {
+    const target = resolve({
+        environment: { VSCODE_IPC_HOOK_CLI: '/tmp/stale.sock' },
+        listServerRoots: () => [SERVER_ROOT],
+        isLiveIpcSocket: () => false,
+    });
+
+    assert.equal(target.command, path.join(SERVER_ROOT, 'bin', 'code-server'));
+    assert.equal(target.source, 'server-stale-ipc');
+});
+
+test('LOCAL-INSTALL-CLI-TARGET-001 refuses to guess when the hook is dead and no Server exists', () => {
+    const target = resolve({
+        environment: { VSCODE_IPC_HOOK_CLI: '/tmp/stale.sock' },
+        listServerRoots: () => [],
+    });
+
+    assert.equal(target.command, null);
+    assert.match(target.error, /refuses connections/);
+    assert.match(target.error, /CODE_CMD/, 'the message must say how to proceed');
+});
+
+test('LOCAL-INSTALL-CLI-TARGET-001 falls back to PATH for a plain local install', () => {
+    const target = resolve({ environment: {} });
+
+    assert.equal(target.command, 'code');
+    assert.equal(target.source, 'path');
+    assert.equal(target.extensionsDir, null, 'a local install keeps its default directory');
+});
+
+test('LOCAL-INSTALL-CLI-TARGET-001 skips a Server directory with no entry point', () => {
+    const older = '/home/dev/.vscode-server/bin/older';
+    const target = resolve({
+        listServerRoots: () => [older, SERVER_ROOT],
+        exists: candidate => candidate === serverEntryPoint(SERVER_ROOT),
+    });
+
+    assert.equal(target.command, serverEntryPoint(SERVER_ROOT));
+});
+
+test('LOCAL-INSTALL-CLI-TARGET-001 treats an unreachable socket path as dead', () => {
+    assert.equal(isLiveIpcSocket('', () => true), false, 'an unset hook is not live');
+    assert.equal(isLiveIpcSocket('/tmp/whatever.sock', () => false), false);
+    assert.equal(isLiveIpcSocket('/tmp/whatever.sock', () => true), true);
+});


### PR DESCRIPTION
## 问题

`npm run install-local` 把相对路径的 VSIX 传给 PATH 上第一个 `code`。在 Dev Container / SSH workspace 里那是 Server 的 remote-cli wrapper（继承 `VSCODE_IPC_HOOK_CLI`），Server 会把相对的 `--install-extension` 路径解析到**自己的工作目录**而不是 shell 的 —— 安装对着无关的 Server 目录报 ENOENT 失败。这个仓库里的每次本地安装此前都得手动绕。

## 修复

- **路由**：解析正在运行的 Server 安装里与 socket 无关的 `bin/code-server`；只有普通本地安装才回退 PATH；继承的 hook 已死且没有 Server 时拒绝猜测 —— hook 未设置和 socket 拒连仅靠存在性无法区分，所以探测 socket 而不是假设。
- **路径**：artifact 一律绝对路径，extensions 目录显式 pin，安装和后续列举不会对字节去向产生分歧。
- **校验**：安装后用 Extension Host 测试套件同款的 `createExtensionPackagePlan` + `verifyInstalledExtensionBytes` 做 SHA-256 字节校验 —— 严格强于旧脚本唯一的检查（退出码为 0）。版本号全部来自扩展 manifest，无硬编码。
- **结构**：逻辑落在 Node（`scripts/lib/vscodeCliTarget.js`、`scripts/install-local-extensions.js`）所以可测；bash 脚本只保留构建步骤并委托。原来 pin 旧 shell 变量的 packaging 断言改为断言逻辑迁移后的同等不变量。

## 验证

- 端到端对着本 Dev Container 实测：选中正在运行的 Server 入口，装好两个扩展，6 个文件 SHA-256 全部匹配。
- 单测 1209 全过（新增发现/校验路径的真实用例：Server 安装按新到旧排序、残留死 socket 判死、容忍 VS Code 注入的 `__metadata`、篡改运行时文件即使 CLI 退出 0 也判失败）。
- changed-line coverage 96.14%；lint / deterministic(394+534+281) / safety / architecture guards / browser(124) / dashboard / release-notes / release-packaging / brand 全绿。

## Workflow-lesson harvest（本周期）

结论：**无 skill 变更**。覆盖缺口被 changed-coverage gate 拦住后补真测试，是机制正常工作；`gh auth status` 的 token 误报为机器特定现象，不可泛化；此前「CI 前合并」的教训在 publishing-and-merging-github-prs 的 guardrail 中已有明确条款，属合规问题而非规则缺失。

## 明确没做

指纹字符串 411KB/3s 分配、kimi 递归遍历、dashboard.ts 剩余接线 —— 各自单开分支。
