### PR TITLE
fix: unblock macOS Extension Host verification

### DIFF
--- a/.github/workflows/release-vsix.yml
+++ b/.github/workflows/release-vsix.yml
@@ -31,7 +31,7 @@ jobs:
   release-extension-host:
     name: release-extension-host
     needs: verify
-    runs-on: macos-15-intel
+    runs-on: macos-15
     timeout-minutes: 15
     steps:
       - name: Checkout
@@ -41,8 +41,6 @@ jobs:
         with:
           node-version: 22.12.0
           cache: npm
-      - name: Verify Intel Extension Host runner
-        run: node -e "if (process.platform !== 'darwin' || process.arch !== 'x64') throw new Error(process.platform + '/' + process.arch); console.log(process.platform + '/' + process.arch)"
       - name: Install dependencies
         run: npm ci
       - name: Install and activate release VSIX files

--- a/.github/workflows/release-vsix.yml
+++ b/.github/workflows/release-vsix.yml
@@ -31,7 +31,7 @@ jobs:
   release-extension-host:
     name: release-extension-host
     needs: verify
-    runs-on: macos-latest
+    runs-on: macos-15
     timeout-minutes: 15
     steps:
       - name: Checkout

--- a/.github/workflows/release-vsix.yml
+++ b/.github/workflows/release-vsix.yml
@@ -31,7 +31,7 @@ jobs:
   release-extension-host:
     name: release-extension-host
     needs: verify
-    runs-on: macos-15
+    runs-on: macos-15-intel
     timeout-minutes: 15
     steps:
       - name: Checkout
@@ -41,6 +41,8 @@ jobs:
         with:
           node-version: 22.12.0
           cache: npm
+      - name: Verify Intel Extension Host runner
+        run: node -e "if (process.platform !== 'darwin' || process.arch !== 'x64') throw new Error(process.platform + '/' + process.arch); console.log(process.platform + '/' + process.arch)"
       - name: Install dependencies
         run: npm ci
       - name: Install and activate release VSIX files

--- a/.github/workflows/scheduled-verification.yml
+++ b/.github/workflows/scheduled-verification.yml
@@ -15,7 +15,7 @@ jobs:
   scheduled-macos:
     name: scheduled-macos
     needs: verify
-    runs-on: macos-15
+    runs-on: macos-15-intel
     timeout-minutes: 15
     steps:
       - name: Checkout
@@ -25,6 +25,8 @@ jobs:
         with:
           node-version: 22.12.0
           cache: npm
+      - name: Verify Intel Extension Host runner
+        run: node -e "if (process.platform !== 'darwin' || process.arch !== 'x64') throw new Error(process.platform + '/' + process.arch); console.log(process.platform + '/' + process.arch)"
       - name: Install dependencies
         run: npm ci
       - name: Verify conversation source identity

--- a/.github/workflows/scheduled-verification.yml
+++ b/.github/workflows/scheduled-verification.yml
@@ -15,7 +15,7 @@ jobs:
   scheduled-macos:
     name: scheduled-macos
     needs: verify
-    runs-on: macos-15-intel
+    runs-on: macos-15
     timeout-minutes: 15
     steps:
       - name: Checkout
@@ -25,8 +25,6 @@ jobs:
         with:
           node-version: 22.12.0
           cache: npm
-      - name: Verify Intel Extension Host runner
-        run: node -e "if (process.platform !== 'darwin' || process.arch !== 'x64') throw new Error(process.platform + '/' + process.arch); console.log(process.platform + '/' + process.arch)"
       - name: Install dependencies
         run: npm ci
       - name: Verify conversation source identity

--- a/.github/workflows/scheduled-verification.yml
+++ b/.github/workflows/scheduled-verification.yml
@@ -15,7 +15,7 @@ jobs:
   scheduled-macos:
     name: scheduled-macos
     needs: verify
-    runs-on: macos-latest
+    runs-on: macos-15
     timeout-minutes: 15
     steps:
       - name: Checkout

--- a/.github/workflows/scheduled-verification.yml
+++ b/.github/workflows/scheduled-verification.yml
@@ -4,15 +4,23 @@ on:
   schedule:
     - cron: "17 3 * * 1"
   workflow_dispatch:
+    inputs:
+      extension_host_only:
+        description: Run only the macOS Extension Host diagnostic
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
 
 jobs:
   verify:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.extension_host_only != true }}
     uses: ./.github/workflows/verify.yml
 
   scheduled-macos:
+    if: ${{ always() && (inputs.extension_host_only == true || needs.verify.result == 'success') }}
     name: scheduled-macos
     needs: verify
     runs-on: macos-15

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "82bd775b83c70deeb60a1bcf400d4d31cfb5612b",
+        "head": "b582d61f6bbe66a84bc9c4ad6b01c2e16eb95bf2",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -837,7 +837,11 @@
                 "c329ea110bdb034df07fcbcfa182f336751b1f47",
                 "9f50c6b6c54e86279b88ba05207489e476613333",
                 "59ef5de5b9c2105c28c046ad1ff173f191746b21",
-                "82bd775b83c70deeb60a1bcf400d4d31cfb5612b"
+                "82bd775b83c70deeb60a1bcf400d4d31cfb5612b",
+                "012f7c36e32b9f70d42c1679f9c2432b1ca50372",
+                "8ce06a6948bb7c7f8ed7359501d3e75dfccbe953",
+                "b24c9daacd6c4b37d9ccb696cbded22d60f5cc0c",
+                "b582d61f6bbe66a84bc9c4ad6b01c2e16eb95bf2"
             ],
             "behaviors": [
                 "ARCH-CI-QUALITY-GATE-001",

--- a/scripts/lib/ciContracts.js
+++ b/scripts/lib/ciContracts.js
@@ -3,6 +3,8 @@
 const assert = require('node:assert/strict');
 const yaml = require('js-yaml');
 
+const MACOS_INTEL_ARCHITECTURE_CHECK = "node -e \"if (process.platform !== 'darwin' || process.arch !== 'x64') throw new Error(process.platform + '/' + process.arch); console.log(process.platform + '/' + process.arch)\"";
+
 function isMapping(value) {
     return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
@@ -155,7 +157,8 @@ function validateScheduledWorkflow(scheduledWorkflow) {
     assert.equal(macos.name, 'scheduled-macos',
         'scheduled-macos must expose the stable check name scheduled-macos');
     assert.equal(macos.needs, 'verify', 'scheduled-macos must need verify');
-    assert.equal(macos['runs-on'], 'macos-15', 'scheduled-macos must use macos-15');
+    assert.equal(macos['runs-on'], 'macos-15-intel',
+        'scheduled-macos must use macos-15-intel');
     assert.equal(macos['timeout-minutes'], 15, 'scheduled-macos timeout-minutes must be 15');
     assert.ok(findStep(macos, step => isMapping(step) && step.uses === 'actions/checkout@v4'),
         'scheduled-macos must use actions/checkout@v4');
@@ -169,6 +172,10 @@ function validateScheduledWorkflow(scheduledWorkflow) {
         'scheduled-macos setup-node step must cache npm');
     assert.ok(findStep(macos, step => isMapping(step) && step.run === 'npm ci'),
         'scheduled-macos must run npm ci');
+    assert.ok(findStep(
+        macos,
+        step => isMapping(step) && step.run === MACOS_INTEL_ARCHITECTURE_CHECK
+    ), 'scheduled-macos must verify macOS Intel architecture');
     assert.ok(findStep(
         macos,
         step => isMapping(step) && step.run === 'npm run test:extension-host'
@@ -197,7 +204,7 @@ function validateReleaseWorkflow(releaseWorkflow) {
     validateJob(
         workflow.jobs,
         'release-extension-host',
-        'macos-15',
+        'macos-15-intel',
         'npm run test:extension-host',
         [],
         false,
@@ -205,6 +212,10 @@ function validateReleaseWorkflow(releaseWorkflow) {
     );
     assert.equal(workflow.jobs['release-extension-host'].needs, 'verify',
         'release-extension-host must need verify');
+    assert.ok(findStep(
+        workflow.jobs['release-extension-host'],
+        step => isMapping(step) && step.run === MACOS_INTEL_ARCHITECTURE_CHECK
+    ), 'release-extension-host must verify macOS Intel architecture');
     const release = workflow.jobs.release;
     assert.ok(isMapping(release), 'GitHub release workflow must define release');
     assert.deepEqual(release.needs, ['verify', 'release-extension-host'],

--- a/scripts/lib/ciContracts.js
+++ b/scripts/lib/ciContracts.js
@@ -155,7 +155,7 @@ function validateScheduledWorkflow(scheduledWorkflow) {
     assert.equal(macos.name, 'scheduled-macos',
         'scheduled-macos must expose the stable check name scheduled-macos');
     assert.equal(macos.needs, 'verify', 'scheduled-macos must need verify');
-    assert.equal(macos['runs-on'], 'macos-latest', 'scheduled-macos must use macos-latest');
+    assert.equal(macos['runs-on'], 'macos-15', 'scheduled-macos must use macos-15');
     assert.equal(macos['timeout-minutes'], 15, 'scheduled-macos timeout-minutes must be 15');
     assert.ok(findStep(macos, step => isMapping(step) && step.uses === 'actions/checkout@v4'),
         'scheduled-macos must use actions/checkout@v4');
@@ -197,7 +197,7 @@ function validateReleaseWorkflow(releaseWorkflow) {
     validateJob(
         workflow.jobs,
         'release-extension-host',
-        'macos-latest',
+        'macos-15',
         'npm run test:extension-host',
         [],
         false,

--- a/scripts/lib/ciContracts.js
+++ b/scripts/lib/ciContracts.js
@@ -137,6 +137,16 @@ function validateScheduledWorkflow(scheduledWorkflow) {
         'GitHub scheduled verification workflow must define a schedule');
     assert.ok(hasOwn(workflow.on, 'workflow_dispatch'),
         'GitHub scheduled verification workflow must define workflow_dispatch');
+    assert.deepEqual(workflow.on.workflow_dispatch, {
+        inputs: {
+            extension_host_only: {
+                description: 'Run only the macOS Extension Host diagnostic',
+                required: false,
+                type: 'boolean',
+                default: false,
+            },
+        },
+    }, 'scheduled workflow_dispatch must expose only the bounded Host diagnostic input');
     assert.deepEqual(workflow.permissions, { contents: 'read' },
         'GitHub scheduled verification workflow permissions must be exactly contents: read');
     assert.ok(isMapping(workflow.jobs),
@@ -146,12 +156,22 @@ function validateScheduledWorkflow(scheduledWorkflow) {
     assert.ok(isMapping(verify), 'GitHub scheduled verification workflow must define verify');
     assert.equal(verify.uses, './.github/workflows/verify.yml',
         'scheduled verify must reuse ./.github/workflows/verify.yml');
-    assert.deepEqual(Object.keys(verify), ['uses'],
-        'scheduled verify must contain only the reusable workflow reference');
+    assert.equal(
+        verify.if,
+        "${{ github.event_name != 'workflow_dispatch' || inputs.extension_host_only != true }}",
+        'scheduled verify may skip only for the explicit manual Host diagnostic'
+    );
+    assert.deepEqual(Object.keys(verify), ['if', 'uses'],
+        'scheduled verify must contain only its bounded condition and reusable workflow reference');
 
     const macos = workflow.jobs['scheduled-macos'];
     assert.ok(isMapping(macos),
         'GitHub scheduled verification workflow must define scheduled-macos');
+    assert.equal(
+        macos.if,
+        "${{ always() && (inputs.extension_host_only == true || needs.verify.result == 'success') }}",
+        'scheduled-macos must require Verify success except for the explicit manual diagnostic'
+    );
     assert.equal(macos.name, 'scheduled-macos',
         'scheduled-macos must expose the stable check name scheduled-macos');
     assert.equal(macos.needs, 'verify', 'scheduled-macos must need verify');

--- a/scripts/lib/ciContracts.js
+++ b/scripts/lib/ciContracts.js
@@ -3,8 +3,6 @@
 const assert = require('node:assert/strict');
 const yaml = require('js-yaml');
 
-const MACOS_INTEL_ARCHITECTURE_CHECK = "node -e \"if (process.platform !== 'darwin' || process.arch !== 'x64') throw new Error(process.platform + '/' + process.arch); console.log(process.platform + '/' + process.arch)\"";
-
 function isMapping(value) {
     return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
@@ -157,8 +155,8 @@ function validateScheduledWorkflow(scheduledWorkflow) {
     assert.equal(macos.name, 'scheduled-macos',
         'scheduled-macos must expose the stable check name scheduled-macos');
     assert.equal(macos.needs, 'verify', 'scheduled-macos must need verify');
-    assert.equal(macos['runs-on'], 'macos-15-intel',
-        'scheduled-macos must use macos-15-intel');
+    assert.equal(macos['runs-on'], 'macos-15',
+        'scheduled-macos must use macos-15');
     assert.equal(macos['timeout-minutes'], 15, 'scheduled-macos timeout-minutes must be 15');
     assert.ok(findStep(macos, step => isMapping(step) && step.uses === 'actions/checkout@v4'),
         'scheduled-macos must use actions/checkout@v4');
@@ -172,10 +170,6 @@ function validateScheduledWorkflow(scheduledWorkflow) {
         'scheduled-macos setup-node step must cache npm');
     assert.ok(findStep(macos, step => isMapping(step) && step.run === 'npm ci'),
         'scheduled-macos must run npm ci');
-    assert.ok(findStep(
-        macos,
-        step => isMapping(step) && step.run === MACOS_INTEL_ARCHITECTURE_CHECK
-    ), 'scheduled-macos must verify macOS Intel architecture');
     assert.ok(findStep(
         macos,
         step => isMapping(step) && step.run === 'npm run test:extension-host'
@@ -204,7 +198,7 @@ function validateReleaseWorkflow(releaseWorkflow) {
     validateJob(
         workflow.jobs,
         'release-extension-host',
-        'macos-15-intel',
+        'macos-15',
         'npm run test:extension-host',
         [],
         false,
@@ -212,10 +206,6 @@ function validateReleaseWorkflow(releaseWorkflow) {
     );
     assert.equal(workflow.jobs['release-extension-host'].needs, 'verify',
         'release-extension-host must need verify');
-    assert.ok(findStep(
-        workflow.jobs['release-extension-host'],
-        step => isMapping(step) && step.run === MACOS_INTEL_ARCHITECTURE_CHECK
-    ), 'release-extension-host must verify macOS Intel architecture');
     const release = workflow.jobs.release;
     assert.ok(isMapping(release), 'GitHub release workflow must define release');
     assert.deepEqual(release.needs, ['verify', 'release-extension-host'],

--- a/scripts/lib/extensionHostLauncher.js
+++ b/scripts/lib/extensionHostLauncher.js
@@ -324,6 +324,7 @@ function createRunTestsOptions(
             environment.workspace,
             `--user-data-dir=${environment.userData}`,
             `--extensions-dir=${environment.extensions}`,
+            '--use-inmemory-secretstorage',
         ],
         extensionTestsEnv: {
             HOME: environment.home,

--- a/scripts/run-release-packaging-checks.js
+++ b/scripts/run-release-packaging-checks.js
@@ -12,7 +12,6 @@ const {
 } = require('./lib/ciContracts');
 
 const repositoryRoot = path.resolve(__dirname, '..');
-const MACOS_INTEL_ARCHITECTURE_CHECK = "node -e \"if (process.platform !== 'darwin' || process.arch !== 'x64') throw new Error(process.platform + '/' + process.arch); console.log(process.platform + '/' + process.arch)\"";
 
 function readText(relativePath) {
     return fs.readFileSync(path.join(repositoryRoot, relativePath), 'utf8');
@@ -174,13 +173,13 @@ function validateScheduledWorkflow(workflow) {
         'scheduled-macos job');
     assert.strictEqual(job.name, 'scheduled-macos',
         'scheduled-macos must keep its stable job name');
-    assert.strictEqual(job['runs-on'], 'macos-15-intel',
-        'scheduled-macos must use macos-15-intel');
+    assert.strictEqual(job['runs-on'], 'macos-15',
+        'scheduled-macos must use macos-15');
     assert.strictEqual(job['timeout-minutes'], 15, 'scheduled-macos timeout must be 15 minutes');
     assert.strictEqual(containsKey(workflow, 'continue-on-error'), false,
         'scheduled verification must not define continue-on-error');
     assert.ok(Array.isArray(job.steps), 'scheduled-macos steps must be an array');
-    assert.strictEqual(job.steps.length, 6, 'scheduled-macos must define exactly six allowed steps');
+    assert.strictEqual(job.steps.length, 5, 'scheduled-macos must define exactly five allowed steps');
     const checkout = job.steps[0];
     assertExactKeys(checkout, ['name', 'uses'], 'scheduled-macos checkout step');
     assert.strictEqual(checkout.uses, 'actions/checkout@v4',
@@ -194,7 +193,6 @@ function validateScheduledWorkflow(workflow) {
         'scheduled-macos must use Node 22.12.0');
     assert.strictEqual(setupNode.with.cache, 'npm', 'scheduled-macos must cache npm');
     const commands = [
-        MACOS_INTEL_ARCHITECTURE_CHECK,
         'npm ci',
         'npm run test-compile && node --test tests/platform/macos/conversationSources.test.js',
         'npm run test:extension-host',

--- a/scripts/run-release-packaging-checks.js
+++ b/scripts/run-release-packaging-checks.js
@@ -173,7 +173,7 @@ function validateScheduledWorkflow(workflow) {
         'scheduled-macos job');
     assert.strictEqual(job.name, 'scheduled-macos',
         'scheduled-macos must keep its stable job name');
-    assert.strictEqual(job['runs-on'], 'macos-latest', 'scheduled-macos must use macos-latest');
+    assert.strictEqual(job['runs-on'], 'macos-15', 'scheduled-macos must use macos-15');
     assert.strictEqual(job['timeout-minutes'], 15, 'scheduled-macos timeout must be 15 minutes');
     assert.strictEqual(containsKey(workflow, 'continue-on-error'), false,
         'scheduled verification must not define continue-on-error');

--- a/scripts/run-release-packaging-checks.js
+++ b/scripts/run-release-packaging-checks.js
@@ -155,22 +155,36 @@ function validateScheduledWorkflow(workflow) {
     }
     assert.ok(Object.prototype.hasOwnProperty.call(workflow.on, 'workflow_dispatch'),
         'scheduled verification must define workflow_dispatch');
-    assert.ok(workflow.on.workflow_dispatch === null || isMapping(workflow.on.workflow_dispatch),
-        'scheduled verification workflow_dispatch must be empty or a mapping');
-    if (isMapping(workflow.on.workflow_dispatch)) {
-        assertExactKeys(workflow.on.workflow_dispatch, [],
-            'scheduled verification workflow_dispatch');
-    }
+    assert.deepStrictEqual(workflow.on.workflow_dispatch, {
+        inputs: {
+            extension_host_only: {
+                description: 'Run only the macOS Extension Host diagnostic',
+                required: false,
+                type: 'boolean',
+                default: false,
+            },
+        },
+    }, 'scheduled workflow_dispatch must expose only the bounded Host diagnostic input');
     assert.deepStrictEqual(workflow.permissions, { contents: 'read' },
         'scheduled verification permissions must be exactly contents: read');
     assert.ok(isMapping(workflow.jobs), 'scheduled verification jobs must be a mapping');
     assert.deepStrictEqual(Object.keys(workflow.jobs), ['verify', 'scheduled-macos'],
         'scheduled verification must contain only verify and scheduled-macos jobs');
-    assertExactKeys(workflow.jobs.verify, ['uses'], 'scheduled verify job');
+    assertExactKeys(workflow.jobs.verify, ['if', 'uses'], 'scheduled verify job');
+    assert.strictEqual(
+        workflow.jobs.verify.if,
+        "${{ github.event_name != 'workflow_dispatch' || inputs.extension_host_only != true }}",
+        'scheduled verify may skip only for the explicit manual Host diagnostic'
+    );
     const job = workflow.jobs['scheduled-macos'];
     assert.ok(isMapping(job), 'scheduled verification must define scheduled-macos');
-    assertExactKeys(job, ['name', 'needs', 'runs-on', 'timeout-minutes', 'steps'],
+    assertExactKeys(job, ['if', 'name', 'needs', 'runs-on', 'timeout-minutes', 'steps'],
         'scheduled-macos job');
+    assert.strictEqual(
+        job.if,
+        "${{ always() && (inputs.extension_host_only == true || needs.verify.result == 'success') }}",
+        'scheduled-macos must require Verify success except for the explicit manual diagnostic'
+    );
     assert.strictEqual(job.name, 'scheduled-macos',
         'scheduled-macos must keep its stable job name');
     assert.strictEqual(job['runs-on'], 'macos-15',

--- a/scripts/run-release-packaging-checks.js
+++ b/scripts/run-release-packaging-checks.js
@@ -12,6 +12,7 @@ const {
 } = require('./lib/ciContracts');
 
 const repositoryRoot = path.resolve(__dirname, '..');
+const MACOS_INTEL_ARCHITECTURE_CHECK = "node -e \"if (process.platform !== 'darwin' || process.arch !== 'x64') throw new Error(process.platform + '/' + process.arch); console.log(process.platform + '/' + process.arch)\"";
 
 function readText(relativePath) {
     return fs.readFileSync(path.join(repositoryRoot, relativePath), 'utf8');
@@ -173,12 +174,13 @@ function validateScheduledWorkflow(workflow) {
         'scheduled-macos job');
     assert.strictEqual(job.name, 'scheduled-macos',
         'scheduled-macos must keep its stable job name');
-    assert.strictEqual(job['runs-on'], 'macos-15', 'scheduled-macos must use macos-15');
+    assert.strictEqual(job['runs-on'], 'macos-15-intel',
+        'scheduled-macos must use macos-15-intel');
     assert.strictEqual(job['timeout-minutes'], 15, 'scheduled-macos timeout must be 15 minutes');
     assert.strictEqual(containsKey(workflow, 'continue-on-error'), false,
         'scheduled verification must not define continue-on-error');
     assert.ok(Array.isArray(job.steps), 'scheduled-macos steps must be an array');
-    assert.strictEqual(job.steps.length, 5, 'scheduled-macos must define exactly five allowed steps');
+    assert.strictEqual(job.steps.length, 6, 'scheduled-macos must define exactly six allowed steps');
     const checkout = job.steps[0];
     assertExactKeys(checkout, ['name', 'uses'], 'scheduled-macos checkout step');
     assert.strictEqual(checkout.uses, 'actions/checkout@v4',
@@ -192,6 +194,7 @@ function validateScheduledWorkflow(workflow) {
         'scheduled-macos must use Node 22.12.0');
     assert.strictEqual(setupNode.with.cache, 'npm', 'scheduled-macos must cache npm');
     const commands = [
+        MACOS_INTEL_ARCHITECTURE_CHECK,
         'npm ci',
         'npm run test-compile && node --test tests/platform/macos/conversationSources.test.js',
         'npm run test:extension-host',

--- a/tests/unit/tooling/ciContracts.test.js
+++ b/tests/unit/tooling/ciContracts.test.js
@@ -179,6 +179,14 @@ test('ARCH-CI-QUALITY-GATE-001 scheduled Extension Host gate is pinned and block
     }
 });
 
+test('RELEASE-SCHEDULED-EXTENSION-HOST-001 pins real Host gates to reviewed macOS 15', () => {
+    assert.match(scheduledWorkflow, /\n    runs-on: macos-15\n/);
+    assert.match(
+        releaseWorkflow,
+        /\n  release-extension-host:\n[\s\S]*?\n    runs-on: macos-15\n/
+    );
+});
+
 test('RELEASE-CONVERSATION-JOURNEYS-001 release publishing needs installed VSIX activation', () => {
     assert.doesNotThrow(() => validateReleaseWorkflow(releaseWorkflow));
     assert.throws(
@@ -197,10 +205,10 @@ test('RELEASE-CONVERSATION-JOURNEYS-001 release publishing needs installed VSIX 
     );
     assert.throws(
         () => validateReleaseWorkflow(releaseWorkflow.replace(
-            '    runs-on: macos-latest',
+            '    runs-on: macos-15',
             '    runs-on: ubuntu-latest'
         )),
-        /release-extension-host must use macos-latest/
+        /release-extension-host must use macos-15/
     );
     assert.throws(
         () => validateReleaseWorkflow(releaseWorkflow.replace(

--- a/tests/unit/tooling/ciContracts.test.js
+++ b/tests/unit/tooling/ciContracts.test.js
@@ -171,13 +171,6 @@ test('ARCH-CI-QUALITY-GATE-001 scheduled Extension Host gate is pinned and block
             /scheduled-macos must run npm ci/,
         ],
         [
-            scheduledWorkflow.replace(
-                "if (process.platform !== 'darwin' || process.arch !== 'x64')",
-                "if (process.platform !== 'darwin')"
-            ),
-            /scheduled-macos must verify macOS Intel architecture/,
-        ],
-        [
             `${scheduledWorkflow}\n    continue-on-error: true\n`,
             /must not define continue-on-error/,
         ],
@@ -186,15 +179,12 @@ test('ARCH-CI-QUALITY-GATE-001 scheduled Extension Host gate is pinned and block
     }
 });
 
-test('RELEASE-SCHEDULED-EXTENSION-HOST-001 pins real Host gates to reviewed macOS 15 Intel', () => {
-    const architectureCheck = "node -e \"if (process.platform !== 'darwin' || process.arch !== 'x64') throw new Error(process.platform + '/' + process.arch); console.log(process.platform + '/' + process.arch)\"";
-    assert.match(scheduledWorkflow, /\n    runs-on: macos-15-intel\n/);
-    assert.ok(scheduledWorkflow.includes(`        run: ${architectureCheck}`));
+test('RELEASE-SCHEDULED-EXTENSION-HOST-001 pins real Host gates to reviewed macOS 15', () => {
+    assert.match(scheduledWorkflow, /\n    runs-on: macos-15\n/);
     assert.match(
         releaseWorkflow,
-        /\n  release-extension-host:\n[\s\S]*?\n    runs-on: macos-15-intel\n/
+        /\n  release-extension-host:\n[\s\S]*?\n    runs-on: macos-15\n/
     );
-    assert.ok(releaseWorkflow.includes(`        run: ${architectureCheck}`));
 });
 
 test('RELEASE-CONVERSATION-JOURNEYS-001 release publishing needs installed VSIX activation', () => {
@@ -215,10 +205,10 @@ test('RELEASE-CONVERSATION-JOURNEYS-001 release publishing needs installed VSIX 
     );
     assert.throws(
         () => validateReleaseWorkflow(releaseWorkflow.replace(
-            '    runs-on: macos-15-intel',
+            '    runs-on: macos-15',
             '    runs-on: ubuntu-latest'
         )),
-        /release-extension-host must use macos-15-intel/
+        /release-extension-host must use macos-15/
     );
     assert.throws(
         () => validateReleaseWorkflow(releaseWorkflow.replace(
@@ -226,12 +216,5 @@ test('RELEASE-CONVERSATION-JOURNEYS-001 release publishing needs installed VSIX 
             '    needs: release'
         )),
         /release-extension-host must need verify/
-    );
-    assert.throws(
-        () => validateReleaseWorkflow(releaseWorkflow.replace(
-            "if (process.platform !== 'darwin' || process.arch !== 'x64')",
-            "if (process.platform !== 'darwin')"
-        )),
-        /release-extension-host must verify macOS Intel architecture/
     );
 });

--- a/tests/unit/tooling/ciContracts.test.js
+++ b/tests/unit/tooling/ciContracts.test.js
@@ -152,6 +152,14 @@ test('ARCH-CI-QUALITY-GATE-001 scheduled verification reuses the complete Verify
     );
 });
 
+test('RELEASE-SCHEDULED-EXTENSION-HOST-001 permits a manual Host-only diagnostic without weakening schedules', () => {
+    assert.match(scheduledWorkflow, /\n  workflow_dispatch:\n    inputs:\n      extension_host_only:\n/);
+    assert.match(scheduledWorkflow,
+        /\n  verify:\n    if: \$\{\{ github\.event_name != 'workflow_dispatch' \|\| inputs\.extension_host_only != true \}\}\n/);
+    assert.match(scheduledWorkflow,
+        /\n  scheduled-macos:\n    if: \$\{\{ always\(\) && \(inputs\.extension_host_only == true \|\| needs\.verify\.result == 'success'\) \}\}\n/);
+});
+
 test('ARCH-CI-QUALITY-GATE-001 scheduled Extension Host gate is pinned and blocking', () => {
     for (const [source, message] of [
         [

--- a/tests/unit/tooling/ciContracts.test.js
+++ b/tests/unit/tooling/ciContracts.test.js
@@ -171,6 +171,13 @@ test('ARCH-CI-QUALITY-GATE-001 scheduled Extension Host gate is pinned and block
             /scheduled-macos must run npm ci/,
         ],
         [
+            scheduledWorkflow.replace(
+                "if (process.platform !== 'darwin' || process.arch !== 'x64')",
+                "if (process.platform !== 'darwin')"
+            ),
+            /scheduled-macos must verify macOS Intel architecture/,
+        ],
+        [
             `${scheduledWorkflow}\n    continue-on-error: true\n`,
             /must not define continue-on-error/,
         ],
@@ -179,12 +186,15 @@ test('ARCH-CI-QUALITY-GATE-001 scheduled Extension Host gate is pinned and block
     }
 });
 
-test('RELEASE-SCHEDULED-EXTENSION-HOST-001 pins real Host gates to reviewed macOS 15', () => {
-    assert.match(scheduledWorkflow, /\n    runs-on: macos-15\n/);
+test('RELEASE-SCHEDULED-EXTENSION-HOST-001 pins real Host gates to reviewed macOS 15 Intel', () => {
+    const architectureCheck = "node -e \"if (process.platform !== 'darwin' || process.arch !== 'x64') throw new Error(process.platform + '/' + process.arch); console.log(process.platform + '/' + process.arch)\"";
+    assert.match(scheduledWorkflow, /\n    runs-on: macos-15-intel\n/);
+    assert.ok(scheduledWorkflow.includes(`        run: ${architectureCheck}`));
     assert.match(
         releaseWorkflow,
-        /\n  release-extension-host:\n[\s\S]*?\n    runs-on: macos-15\n/
+        /\n  release-extension-host:\n[\s\S]*?\n    runs-on: macos-15-intel\n/
     );
+    assert.ok(releaseWorkflow.includes(`        run: ${architectureCheck}`));
 });
 
 test('RELEASE-CONVERSATION-JOURNEYS-001 release publishing needs installed VSIX activation', () => {
@@ -205,10 +215,10 @@ test('RELEASE-CONVERSATION-JOURNEYS-001 release publishing needs installed VSIX 
     );
     assert.throws(
         () => validateReleaseWorkflow(releaseWorkflow.replace(
-            '    runs-on: macos-15',
+            '    runs-on: macos-15-intel',
             '    runs-on: ubuntu-latest'
         )),
-        /release-extension-host must use macos-15/
+        /release-extension-host must use macos-15-intel/
     );
     assert.throws(
         () => validateReleaseWorkflow(releaseWorkflow.replace(
@@ -216,5 +226,12 @@ test('RELEASE-CONVERSATION-JOURNEYS-001 release publishing needs installed VSIX 
             '    needs: release'
         )),
         /release-extension-host must need verify/
+    );
+    assert.throws(
+        () => validateReleaseWorkflow(releaseWorkflow.replace(
+            "if (process.platform !== 'darwin' || process.arch !== 'x64')",
+            "if (process.platform !== 'darwin')"
+        )),
+        /release-extension-host must verify macOS Intel architecture/
     );
 });

--- a/tests/unit/tooling/extensionHostLauncher.test.js
+++ b/tests/unit/tooling/extensionHostLauncher.test.js
@@ -157,6 +157,7 @@ test('RELEASE-SCHEDULED-EXTENSION-HOST-001 launches both extensions with pinned 
             environment.workspace,
             `--user-data-dir=${environment.userData}`,
             `--extensions-dir=${environment.extensions}`,
+            '--use-inmemory-secretstorage',
         ]);
         assert.equal(options.extensionTestsEnv.HOME, environment.home);
         assert.equal(options.extensionTestsEnv.XDG_CONFIG_HOME, path.join(isolatedRoot, 'xdg', 'config'));


### PR DESCRIPTION
## Summary

- pin release and scheduled Extension Host gates to the reviewed macOS 15 runner
- isolate VS Code Secret Storage with the in-memory backend so the unattended Extension Host cannot block on macOS Keychain
- add a bounded `extension_host_only` manual diagnostic path while preserving the complete Verify prerequisite for scheduled runs
- strengthen CI and packaging contracts for the new runner and workflow behavior

## Verification

- `npm run test:ci:linux`
  - 534 deterministic unit/contract/integration tests
  - 124 browser tests
  - changed line coverage: 100.00% (26/26) against `origin/main`
- focused macOS Host diagnostic: https://github.com/hzcheng/agent-pivot/actions/runs/30680373246
- complete scheduled workflow path: https://github.com/hzcheng/agent-pivot/actions/runs/30680633249
  - Linux quality, Windows platform, real tmux, and macOS Host jobs all passed
  - `RELEASE-SCHEDULED-EXTENSION-HOST-001 passed on VS Code 1.130.0.`
