### PR TITLE
fix: release Claude sessions stuck running after tool-use interrupts

### DIFF
--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "af19b2c9fbab071d6e8004846bff1cdd810836bc",
+        "head": "f2a66bf31f9e478e1c66f7db4643d09bc3406aea",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -709,7 +709,8 @@
                 "8e7a9c2a3885d2a3e6a1ad783cc867fc2e70815c",
                 "f11aca71aab64a08dddb0f1028809c0e0d52f0ab",
                 "2bc4a8a330bc498ffafe5df92ed807b27e0b8e79",
-                "c97615cee3b2629102643cf3f4560f98201e49d4"
+                "c97615cee3b2629102643cf3f4560f98201e49d4",
+                "f2a66bf31f9e478e1c66f7db4643d09bc3406aea"
             ],
             "behaviors": [
                 "RUNTIME-TMUX-BACKEND-001",

--- a/src/aiSessions/conversation/claudeAdapter.ts
+++ b/src/aiSessions/conversation/claudeAdapter.ts
@@ -128,8 +128,10 @@ function isUserInterrupt(value: unknown): boolean {
             return typeof block?.text === 'string' ? block.text : '';
         })
         : [typeof value === 'string' ? value : ''];
+    // Claude Code emits sentinel variants such as '[Request interrupted by
+    // user for tool use]' when a tool call is interrupted, so match the prefix.
     return textParts.some(
-        text => text.trim() === '[Request interrupted by user]'
+        text => text.trim().startsWith('[Request interrupted by user')
     );
 }
 

--- a/src/aiSessions/executionMonitor.ts
+++ b/src/aiSessions/executionMonitor.ts
@@ -16,17 +16,22 @@ export interface AiSessionExecutionSnapshot {
     stateChangedAt: number;
 }
 
+const DEFAULT_STALE_RUNNING_TIMEOUT_MS = 30 * 60 * 1000;
+
 interface Entry extends AiSessionExecutionSnapshot {
     lastSignalToken?: string;
     lastOccurredAtMs?: number;
+    lastSignalAtMs: number;
 }
 
 export default class AiSessionExecutionMonitor {
     private readonly entries = new Map<string, Entry>();
     private readonly now: () => number;
+    private readonly staleRunningTimeoutMs: number;
 
-    constructor(options: { now?: () => number } = {}) {
+    constructor(options: { now?: () => number; staleRunningTimeoutMs?: number } = {}) {
         this.now = options.now ?? (() => Date.now());
+        this.staleRunningTimeoutMs = options.staleRunningTimeoutMs ?? DEFAULT_STALE_RUNNING_TIMEOUT_MS;
     }
 
     evaluate(inputs: AiSessionExecutionInput[]): string[] {
@@ -39,21 +44,31 @@ export default class AiSessionExecutionMonitor {
             seen.add(input.key);
             let entry = this.entries.get(input.key);
             if (!entry) {
-                entry = { state: 'stopped', stateChangedAt: this.now() };
+                entry = { state: 'stopped', stateChangedAt: this.now(), lastSignalAtMs: this.now() };
                 this.entries.set(input.key, entry);
             }
 
             const signal = input.signal;
-            if (!acceptsLifecycleSignal(entry, signal)) {
-                continue;
+            if (acceptsLifecycleSignal(entry, signal)) {
+                recordAcceptedLifecycleSignal(entry, signal);
+                entry.lastSignalAtMs = this.now();
+                if (entry.state !== signal.executionState) {
+                    entry.state = signal.executionState;
+                    entry.stateChangedAt = signal.occurredAtMs;
+                    changed.add(input.key);
+                }
             }
-            recordAcceptedLifecycleSignal(entry, signal);
-            if (entry.state === signal.executionState) {
-                continue;
+
+            // Backstop: without a fresh transcript signal for the whole stale
+            // window there is no evidence the session is still running. A
+            // missed terminal event (for example an unrecognised interrupt
+            // marker) would otherwise wedge the running state forever.
+            if (entry.state === 'running'
+                && this.now() - entry.lastSignalAtMs >= this.staleRunningTimeoutMs) {
+                entry.state = 'stopped';
+                entry.stateChangedAt = this.now();
+                changed.add(input.key);
             }
-            entry.state = signal.executionState;
-            entry.stateChangedAt = signal.occurredAtMs;
-            changed.add(input.key);
         }
 
         for (const key of this.entries.keys()) {

--- a/src/aiSessions/lifecycle.ts
+++ b/src/aiSessions/lifecycle.ts
@@ -169,7 +169,9 @@ function isClaudeUserInterrupt(event: JsonRecord): boolean {
             return typeof (part as JsonRecord)?.text === 'string' ? (part as JsonRecord).text : '';
         })
         : [typeof content === 'string' ? content : ''];
-    return textParts.some(text => text.trim() === '[Request interrupted by user]');
+    // Claude Code emits marker variants such as '[Request interrupted by user
+    // for tool use]' when a tool call is interrupted, so match the prefix.
+    return textParts.some(text => text.trim().startsWith('[Request interrupted by user'));
 }
 
 export function createClaudeLifecycleAccumulator(runStartedAtMs: number): AiSessionLifecycleAccumulator {

--- a/tests/contract/aiSessions/claudeConversationAdapter.test.js
+++ b/tests/contract/aiSessions/claudeConversationAdapter.test.js
@@ -319,6 +319,64 @@ test('SESSION-AI-SESSION-CONVERSATION-ADAPTER-001 Claude treats string and array
     );
 });
 
+test('SESSION-AI-SESSION-CONVERSATION-ADAPTER-001 Claude treats the tool-use interrupt sentinel variant as interaction state only', async t => {
+    const source = await createFixture(t);
+    const records = [
+        {
+            type: 'user',
+            uuid: 'real-request',
+            timestamp: '2026-08-01T02:00:00.000Z',
+            message: { role: 'user', content: 'Run the lint checks' },
+        },
+        {
+            type: 'assistant',
+            uuid: 'real-response',
+            message: { role: 'assistant', content: 'Running them now.' },
+        },
+        {
+            type: 'user',
+            uuid: 'interrupt-tool-use',
+            message: {
+                role: 'user',
+                content: [{ type: 'text', text: '[Request interrupted by user for tool use]' }],
+            },
+        },
+    ];
+    await fs.promises.writeFile(
+        source.sourcePath,
+        `${records.map(record => JSON.stringify(record)).join('\n')}\n`
+    );
+    const adapter = createAdapter(source);
+    t.after(() => adapter.dispose());
+
+    const { outline, page } = await readWholeConversation(adapter);
+    assert.deepEqual(
+        outline.interactions.map(interaction => [
+            interaction.id,
+            interaction.userPreview,
+            interaction.responseState,
+        ]),
+        [
+            [
+                'real-request',
+                'Run the lint checks',
+                'interrupted',
+            ],
+        ]
+    );
+    assert.deepEqual(
+        page.messages.map(message => [message.role, message.markdown]),
+        [
+            ['user', 'Run the lint checks'],
+            ['assistant', 'Running them now.'],
+        ]
+    );
+    assert.equal(
+        JSON.stringify({ outline, page }).includes('Request interrupted by user'),
+        false
+    );
+});
+
 test('SESSION-AI-SESSION-CLAUDE-CONVERSATION-002 excludes assistant tool blocks and synthetic user-role tool results', async t => {
     const source = await createFixture(t);
     const adapter = createAdapter(source);

--- a/tests/contract/aiSessions/controllerBoundaries.test.js
+++ b/tests/contract/aiSessions/controllerBoundaries.test.js
@@ -325,6 +325,41 @@ test('SESSION-AI-SESSION-EXECUTION-MONITOR-001 ignores duplicate and older event
     assert.deepEqual(monitor.getSnapshot(), {});
 });
 
+test('SESSION-AI-SESSION-EXECUTION-MONITOR-001 degrades running sessions whose transcript stays silent past the stale timeout', () => {
+    let now = 0;
+    const monitor = new AiSessionExecutionMonitor({ now: () => now, staleRunningTimeoutMs: 1000 });
+    const running = { token: 'run-1', occurredAtMs: 0, executionState: 'running' };
+    assert.deepEqual(monitor.evaluate([{ key: 'claude:a', signal: running }]), ['claude:a']);
+    assert.equal(monitor.getSnapshot()['claude:a'].state, 'running');
+
+    now = 500;
+    assert.deepEqual(monitor.evaluate([{ key: 'claude:a', signal: running }]), []);
+    assert.equal(monitor.getSnapshot()['claude:a'].state, 'running');
+
+    now = 1001;
+    assert.deepEqual(monitor.evaluate([{ key: 'claude:a', signal: running }]), ['claude:a']);
+    assert.deepEqual(monitor.getSnapshot()['claude:a'], { state: 'stopped', stateChangedAt: 1001 });
+    assert.deepEqual(monitor.evaluate([{ key: 'claude:a', signal: running }]), []);
+
+    now = 1500;
+    const resumed = { token: 'run-2', occurredAtMs: 1500, executionState: 'running' };
+    assert.deepEqual(monitor.evaluate([{ key: 'claude:a', signal: resumed }]), ['claude:a']);
+    now = 2000;
+    assert.deepEqual(monitor.evaluate([{ key: 'claude:a', signal: resumed }]), []);
+    assert.equal(monitor.getSnapshot()['claude:a'].state, 'running');
+
+    now = 2600;
+    assert.deepEqual(monitor.evaluate([{ key: 'claude:a' }]), ['claude:a']);
+    assert.equal(monitor.getSnapshot()['claude:a'].state, 'stopped');
+
+    now = 3000;
+    const settled = { token: 'done-1', occurredAtMs: 3000, executionState: 'stopped' };
+    assert.deepEqual(monitor.evaluate([{ key: 'claude:a' }, { key: 'codex:b', signal: settled }]), []);
+    now = 6000;
+    assert.deepEqual(monitor.evaluate([{ key: 'claude:a' }, { key: 'codex:b' }]), []);
+    assert.equal(monitor.getSnapshot()['codex:b'].state, 'stopped');
+});
+
 test('ARCH-AI-SESSION-READ-COORDINATOR-001 reads registered providers with bounded diagnostics and deepest assignments', () => {
     let now = 100;
     const diagnostics = [];

--- a/tests/unit/aiSessions/lifecycle.test.js
+++ b/tests/unit/aiSessions/lifecycle.test.js
@@ -101,3 +101,46 @@ test('PERSIST-LIFECYCLE-PARSER-001 [claude] treats the explicit user interrupt m
     assert.equal(signal.executionState, 'stopped');
     assert.match(signal.token, /^claude:user_interrupt:/);
 });
+
+test('PERSIST-LIFECYCLE-PARSER-001 [claude] treats the tool-use interrupt marker variant as stopped', () => {
+    const signal = lifecycle.parseClaudeLifecycleLines([
+        JSON.stringify({
+            type: 'assistant',
+            timestamp: '2026-08-01T02:35:56.958Z',
+            uuid: 'assistant-tool-use',
+            message: {
+                role: 'assistant',
+                stop_reason: 'tool_use',
+                content: [{ type: 'tool_use', id: 'toolu_1', name: 'Bash', input: { command: 'npm test' } }],
+            },
+        }),
+        JSON.stringify({
+            type: 'user',
+            timestamp: '2026-08-01T02:36:41.919Z',
+            uuid: 'user-tool-result-rejected',
+            message: {
+                role: 'user',
+                content: [{
+                    type: 'tool_result',
+                    tool_use_id: 'toolu_1',
+                    content: "The user doesn't want to proceed with this tool use.",
+                }],
+            },
+        }),
+        JSON.stringify({
+            type: 'user',
+            timestamp: '2026-08-01T02:36:41.920Z',
+            uuid: 'user-interrupt-tool-use',
+            message: {
+                role: 'user',
+                content: [{ type: 'text', text: '[Request interrupted by user for tool use]' }],
+            },
+        }),
+    ], runStartedAtMs);
+
+    assert.ok(signal);
+    assert.equal(signal.phase, 'idle');
+    assert.equal(signal.reason, undefined);
+    assert.equal(signal.executionState, 'stopped');
+    assert.match(signal.token, /^claude:user_interrupt:/);
+});


### PR DESCRIPTION
## Summary

- Claude Code writes a `[Request interrupted by user for tool use]` sentinel variant when a tool call is interrupted. The exact-match check in the lifecycle parser misclassified it as a fresh user (running) signal, so the session execution state wedged at `running` and the card animation never stopped — even across window reloads (cold replay re-read the same misclassified last event).
- Match the interrupt sentinel by prefix in both the lifecycle parser (`lifecycle.ts`) and the Claude conversation adapter (`claudeAdapter.ts`, which also leaked the marker as a fake user message).
- Add a stale-signal backstop to `AiSessionExecutionMonitor`: a `running` entry with no fresh transcript signal for 30 minutes degrades to `stopped`, so any future missed terminal event self-heals instead of wedging forever.

## Regression ownership (RED → GREEN)

- `PERSIST-LIFECYCLE-PARSER-001` — tests/unit/aiSessions/lifecycle.test.js: tool-use interrupt variant → stopped
- `SESSION-AI-SESSION-CONVERSATION-ADAPTER-001` — tests/contract/aiSessions/claudeConversationAdapter.test.js: sentinel variant stays interaction state only
- `SESSION-AI-SESSION-EXECUTION-MONITOR-001` — tests/contract/aiSessions/controllerBoundaries.test.js: stale running degrades to stopped
- All three failed for the expected reason before the fix and pass after. CI reachability: test:unit / test:contract → test:deterministic → test:ci:linux (`quality-linux` PR gate).

## Verification (post-rebase onto origin/main 67159d7)

- unit / contract / integration: 397 + 536 + 281 pass, 0 fail
- `npm run test:behavior-contracts` (incl. main-capability audit currency) ✅
- `npm run lint:ci` ✅
- `npm run package:release` ✅; built VSIX installed on the active remote VS Code Server and byte-verified (`dist/dashboard.js` SHA-256 match). The previously wedged session card stops animating after reload.

## Workflow harvest

No skill change justified: the only process correction (create the feature worktree before editing) is already covered by `protecting-main-with-worktrees` / `fixing-regressions-with-ci` — classified as a compliance gap, not an instruction gap.

## Notes

- Backstop trade-off: a healthy tool call producing no transcript events for 30+ minutes briefly shows stopped, then self-heals on the next event. Default raised from 15 to 30 minutes after integration review feedback.