### PR TITLE
perf: hash session change fingerprints incrementally

### DIFF
--- a/.codex/skills/fixing-regressions-with-ci/SKILL.md
+++ b/.codex/skills/fixing-regressions-with-ci/SKILL.md
@@ -28,6 +28,7 @@ Turn every confirmed regression into a CI-owned behavior before changing product
 4. **Verify RED**
    - Run the focused test against the unfixed implementation.
    - Confirm it fails because of the reported regression, not setup, compilation, or an unrelated assertion.
+   - If the test reads repository working-tree files, confirm every path is git-tracked or produced by an earlier step of the CI job that runs it, and rerun the test with build outputs absent. A locally built artifact is not CI evidence.
    - If it passes, repair the test; do not touch production code.
 5. **Fix minimally**
    - Change only enough production code to satisfy the behavior.

--- a/.codex/skills/protecting-main-with-worktrees/SKILL.md
+++ b/.codex/skills/protecting-main-with-worktrees/SKILL.md
@@ -27,6 +27,7 @@ doing feature work in an isolated git worktree under the project.
    - `git fetch <remote> <base>`
    - `git worktree add -b <branch> .worktree/<topic> <remote>/<base>`
    - Use `origin/main` only after confirming that `origin` and `main` are the intended target.
+   - Install dependencies inside the new worktree (`npm ci`) before running verification. npm resolves binaries from a parent checkout's node_modules when the worktree has none, which masks the missing install until a check constructs `<worktree>/node_modules/...` paths directly.
 
 4. Work only in the feature worktree.
    - Use `git -C .worktree/<topic> ...` or set `workdir` there.

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -1097,6 +1097,22 @@
     ]
   },
   {
+    "id": "SESSION-FINGERPRINT-HASH-001",
+    "domain": "session",
+    "title": "Session change fingerprints are bounded incremental digests that stat each file once per poll",
+    "priority": "P1",
+    "status": "automated",
+    "owners": [
+      "tests/contract/aiSessions/providerSpecificBehavior.test.js"
+    ],
+    "evidence": [
+      "src/aiSessions/sessionFingerprint.ts",
+      "src/services/claudeSessionService.ts",
+      "src/services/codexSessionService.ts",
+      "src/services/kimiSessionService.ts"
+    ]
+  },
+  {
     "id": "ATTENTION-BRIDGE-STALENESS-001",
     "domain": "attention",
     "title": "A locally cleared session never stays lit on a frozen bridge aggregate",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "c8a7eed9ea72dac0c99c8aadfa4c32ac153adb06",
+        "head": "1bbfa2dfe4f33250279937843dd1a46bacdcba4d",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -55,7 +55,10 @@
             "a9618126564283fbf57d408541796ed41d6bdc68",
             "024c6be9e460ac9ef3e80f40faef9488eb542fcb",
             "35a3e2e3a2bddc828277b30e94d5ecc5ce63a7aa",
-            "acbd2a3166504fc42fc20c8b0e1874f3ec09c092"
+            "acbd2a3166504fc42fc20c8b0e1874f3ec09c092",
+            "87304b6b77e3d90d21019a80c43a60f2e3785fda",
+            "ee9a44d87a6ea423739c2781f913d276c369c48d",
+            "239f99c25af02e2176f9a5b6bd8ef7f5c8933495"
         ]
     },
     "capabilities": [
@@ -604,7 +607,8 @@
                 "c1f661c546f87c8fefcb17d4d3929d9adc46cd35",
                 "2bb3a1c255c2bb97809889d9d879d135b371e2ce",
                 "f51aa569d4adb1dd750947181008c3764dbe6163",
-                "289779463fe347fba05bd3655ceded5189612f44"
+                "289779463fe347fba05bd3655ceded5189612f44",
+                "eb60d0cc5b8aaa9e3f04d797f4d790f40999e378"
             ],
             "behaviors": [
                 "ATTENTION-ACTIVE-UNREGISTER-ON-DEACTIVATE-001",
@@ -617,7 +621,8 @@
                 "ATTENTION-EXECUTION-STATE-SYNC-001",
                 "ATTENTION-BRIDGE-STALENESS-001",
                 "SESSION-CLAUDE-SESSION-SERVICE-001",
-                "SESSION-CODEX-SESSION-SERVICE-001"
+                "SESSION-CODEX-SESSION-SERVICE-001",
+                "SESSION-FINGERPRINT-HASH-001"
             ],
             "prGates": [
                 "test:deterministic:run"
@@ -847,7 +852,8 @@
                 "012f7c36e32b9f70d42c1679f9c2432b1ca50372",
                 "8ce06a6948bb7c7f8ed7359501d3e75dfccbe953",
                 "b24c9daacd6c4b37d9ccb696cbded22d60f5cc0c",
-                "b582d61f6bbe66a84bc9c4ad6b01c2e16eb95bf2"
+                "b582d61f6bbe66a84bc9c4ad6b01c2e16eb95bf2",
+                "1bbfa2dfe4f33250279937843dd1a46bacdcba4d"
             ],
             "behaviors": [
                 "ARCH-CI-QUALITY-GATE-001",

--- a/src/aiSessions/sessionFingerprint.ts
+++ b/src/aiSessions/sessionFingerprint.ts
@@ -1,0 +1,26 @@
+'use strict';
+
+import * as crypto from 'crypto';
+
+/**
+ * Incremental change fingerprint for the provider watchers. watchSessionChanges
+ * recomputes a fingerprint every few seconds per provider only to answer "did
+ * anything change"; feeding each observed entry into one running digest avoids
+ * allocating, sorting, and joining a store-sized string on every poll.
+ *
+ * Callers must feed entries in a deterministic order (discovery already orders
+ * by recency, or sorts session ids), so an unchanged store always produces the
+ * same digest. The NUL separator keeps concatenation unambiguous.
+ */
+export default class SessionFingerprint {
+    private readonly hash = crypto.createHash('sha256');
+
+    addEntry(value: string): void {
+        this.hash.update(value);
+        this.hash.update('\0');
+    }
+
+    digest(): string {
+        return this.hash.digest('hex');
+    }
+}

--- a/src/services/claudeSessionService.ts
+++ b/src/services/claudeSessionService.ts
@@ -9,6 +9,7 @@ import { aiSessionPathContains, filterAiSessionsByCandidatePaths, normalizeAiSes
 import IncrementalJsonlLifecycleReader from '../aiSessions/incrementalJsonlLifecycleReader';
 import type { AiSessionConversationSourceCandidate, AiSessionQueryOptions } from '../aiSessions/types';
 import { createClaudeLifecycleAccumulator, AiSessionLifecycleRequest, AiSessionLifecycleSignal } from '../aiSessions/lifecycle';
+import SessionFingerprint from '../aiSessions/sessionFingerprint';
 import { Disposable } from './codexSessionService';
 
 interface ClaudeSessionEvent {
@@ -290,6 +291,10 @@ export default class ClaudeSessionService {
     }
 
     private getSessionFiles(projectRoot: string, maxFiles = 0, stats?: { discoveredFiles: number }): string[] {
+        return this.getSessionFileEntries(projectRoot, maxFiles, stats).map(entry => entry.filePath);
+    }
+
+    private getSessionFileEntries(projectRoot: string, maxFiles = 0, stats?: { discoveredFiles: number }): { filePath: string; mtimeMs: number; sizeBytes: number }[] {
         if (!fs.existsSync(projectRoot)) {
             return [];
         }
@@ -317,22 +322,32 @@ export default class ClaudeSessionService {
         }
         // Stat once per file rather than once per comparison: a comparator that
         // reads the filesystem turns an O(n) listing into O(n log n) syscalls, and
-        // this runs on every dashboard refresh and every change poll.
-        files = files
-            .map(filePath => ({ filePath, mtimeMs: this.getFileMtimeMs(filePath) }))
+        // this runs on every dashboard refresh and every change poll. The change
+        // fingerprint reuses the same stats instead of stat'ing every path again.
+        let entries = files
+            .map(filePath => ({ filePath, ...this.getFileStat(filePath) }))
             .sort((left, right) => right.mtimeMs - left.mtimeMs
                 || left.filePath.localeCompare(right.filePath))
-            .slice(0, maxFiles || undefined)
-            .map(entry => entry.filePath);
+            .slice(0, maxFiles || undefined);
 
-        for (let filePath of files) {
-            let sessionId = this.getSessionIdFromFileName(path.basename(filePath));
+        for (let entry of entries) {
+            let sessionId = this.getSessionIdFromFileName(path.basename(entry.filePath));
             if (sessionId) {
-                this.sessionFilesById.set(sessionId, filePath);
+                this.sessionFilesById.set(sessionId, entry.filePath);
             }
         }
 
-        return files;
+        return entries;
+    }
+
+    /** One stat carries both the ordering key and the change signature. */
+    private getFileStat(filePath: string): { mtimeMs: number; sizeBytes: number } {
+        try {
+            let stat = fs.statSync(filePath);
+            return { mtimeMs: stat.mtimeMs, sizeBytes: stat.size };
+        } catch (e) {
+            return { mtimeMs: 0, sizeBytes: 0 };
+        }
     }
 
     private getFileMtimeMs(filePath: string): number {
@@ -599,20 +614,12 @@ export default class ClaudeSessionService {
             return 'missing';
         }
 
-        let projectRoot = path.join(claudeHome, 'projects');
-        return [
-            claudeHome,
-            ...this.getSessionFiles(projectRoot).map(filePath => this.getFileSignature(filePath)).sort(),
-        ].join('|');
-    }
-
-    private getFileSignature(filePath: string): string {
-        try {
-            let stat = fs.statSync(filePath);
-            return `${filePath}:${this.getStatSignature(stat)}`;
-        } catch (e) {
-            return `${filePath}:missing`;
+        let fingerprint = new SessionFingerprint();
+        fingerprint.addEntry(claudeHome);
+        for (let entry of this.getSessionFileEntries(path.join(claudeHome, 'projects'))) {
+            fingerprint.addEntry(`${entry.filePath}:${entry.sizeBytes}:${entry.mtimeMs}`);
         }
+        return fingerprint.digest();
     }
 
     private getStatSignature(stat: fs.Stats): string {

--- a/src/services/codexSessionService.ts
+++ b/src/services/codexSessionService.ts
@@ -9,6 +9,7 @@ import IncrementalJsonlLifecycleReader from '../aiSessions/incrementalJsonlLifec
 import { filterAiSessionsByCandidatePaths, normalizeAiSessionCandidatePaths } from '../aiSessions/sessionHelpers';
 import type { AiSessionQueryOptions } from '../aiSessions/types';
 import { createCodexLifecycleAccumulator, AiSessionLifecycleRequest, AiSessionLifecycleSignal } from '../aiSessions/lifecycle';
+import SessionFingerprint from '../aiSessions/sessionFingerprint';
 
 interface CodexSessionIndexEntry {
     id?: string;
@@ -268,12 +269,15 @@ export default class CodexSessionService {
             return 'missing';
         }
 
-        let indexPath = path.join(codexHome, 'session_index.jsonl');
-        return [
-            codexHome,
-            this.getFileSignature(indexPath),
-            this.getSessionFilesSignature(codexHome),
-        ].join('|');
+        let fingerprint = new SessionFingerprint();
+        fingerprint.addEntry(codexHome);
+        fingerprint.addEntry(this.getFileSignature(path.join(codexHome, 'session_index.jsonl')));
+        // Discovery already stats every file to order by recency, so the change
+        // fingerprint reuses that instead of stat'ing every path a second time.
+        for (let entry of this.discoverSessionFiles(codexHome)) {
+            fingerprint.addEntry(`${entry.id}:${entry.filePath}:${entry.sizeBytes}:${entry.mtimeMs}`);
+        }
+        return fingerprint.digest();
     }
 
     private getFileSignature(filePath: string): string {
@@ -283,16 +287,6 @@ export default class CodexSessionService {
         } catch (e) {
             return `${filePath}:missing`;
         }
-    }
-
-    private getSessionFilesSignature(codexHome: string): string {
-        // Discovery already stats every file to order by recency, so the change
-        // signature reuses that instead of stat'ing every path a second time.
-        return this.discoverSessionFiles(codexHome)
-            .map(entry =>
-                `${entry.id}:${entry.filePath}:${entry.filePath}:${entry.sizeBytes}:${entry.mtimeMs}`)
-            .sort()
-            .join(',');
     }
 
     private readSessionIndex(indexPath: string): CodexSessionIndexEntry[] {

--- a/src/services/kimiSessionService.ts
+++ b/src/services/kimiSessionService.ts
@@ -10,6 +10,7 @@ import { aiSessionPathContains, filterAiSessionsByCandidatePaths, normalizeAiSes
 import IncrementalJsonlLifecycleReader from '../aiSessions/incrementalJsonlLifecycleReader';
 import type { AiSessionConversationSourceCandidate, AiSessionQueryOptions } from '../aiSessions/types';
 import { createKimiLifecycleAccumulator, AiSessionLifecycleRequest, AiSessionLifecycleSignal } from '../aiSessions/lifecycle';
+import SessionFingerprint from '../aiSessions/sessionFingerprint';
 import { Disposable } from './codexSessionService';
 
 interface KimiWorkDirEntry {
@@ -356,35 +357,36 @@ export default class KimiSessionService {
             return 'missing';
         }
 
-        let workDirs = this.getWorkDirs(kimiHome);
-        return [
-            kimiHome,
-            this.getFileSignature(path.join(kimiHome, 'kimi.json')),
-            ...workDirs.map(workDir => this.getWorkDirSignature(kimiHome, workDir)),
-        ].join('|');
+        let fingerprint = new SessionFingerprint();
+        fingerprint.addEntry(kimiHome);
+        fingerprint.addEntry(this.getFileSignature(path.join(kimiHome, 'kimi.json')));
+        for (let workDir of this.getWorkDirs(kimiHome)) {
+            this.addWorkDirFingerprint(fingerprint, kimiHome, workDir);
+        }
+        return fingerprint.digest();
     }
 
-    private getWorkDirSignature(kimiHome: string, workDir: string): string {
+    private addWorkDirFingerprint(fingerprint: SessionFingerprint, kimiHome: string, workDir: string): void {
         let sessionsDir = path.join(kimiHome, 'sessions', this.getWorkDirHash(workDir));
         if (!fs.existsSync(sessionsDir)) {
-            return `${workDir}:missing`;
+            fingerprint.addEntry(`${workDir}:missing`);
+            return;
         }
 
         try {
-            return `${workDir}:` + fs.readdirSync(sessionsDir, { withFileTypes: true })
+            let sessionIds = fs.readdirSync(sessionsDir, { withFileTypes: true })
                 .filter(entry => entry.isDirectory() && this.isSessionId(entry.name))
-                .map(entry => {
-                    let sessionDir = path.join(sessionsDir, entry.name);
-                    return [
-                        entry.name,
-                        this.getFileSignature(path.join(sessionDir, 'state.json')),
-                        this.getFileSignature(path.join(sessionDir, 'wire.jsonl')),
-                    ].join(':');
-                })
-                .sort()
-                .join(',');
+                .map(entry => entry.name)
+                .sort();
+            fingerprint.addEntry(workDir);
+            for (let sessionId of sessionIds) {
+                let sessionDir = path.join(sessionsDir, sessionId);
+                fingerprint.addEntry(sessionId);
+                fingerprint.addEntry(this.getFileSignature(path.join(sessionDir, 'state.json')));
+                fingerprint.addEntry(this.getFileSignature(path.join(sessionDir, 'wire.jsonl')));
+            }
         } catch (e) {
-            return `${workDir}:unreadable`;
+            fingerprint.addEntry(`${workDir}:unreadable`);
         }
     }
 

--- a/tests/contract/aiSessions/providerSpecificBehavior.test.js
+++ b/tests/contract/aiSessions/providerSpecificBehavior.test.js
@@ -422,3 +422,117 @@ test('SESSION-CODEX-SESSION-SERVICE-001 stats each session file once per change 
         `expected at most ${sessionCount + 4} statSync calls for ${sessionCount} sessions, saw ${stats}`
     );
 });
+
+function countingStats(t) {
+    const counter = { count: 0 };
+    const realStatSync = fs.statSync;
+    fs.statSync = function countingStatSync(...args) {
+        counter.count += 1;
+        return realStatSync.apply(fs, args);
+    };
+    t.after(() => { fs.statSync = realStatSync; });
+    return counter;
+}
+
+function makeClaudeStore(root, sessionCount) {
+    const sessionDir = path.join(root, 'projects', '-work-app');
+    fs.mkdirSync(sessionDir, { recursive: true });
+    for (let index = 0; index < sessionCount; index += 1) {
+        fs.writeFileSync(path.join(sessionDir, `${crypto.randomUUID()}.jsonl`), '{}\n', 'utf8');
+    }
+}
+
+function makeCodexStore(root, sessionCount) {
+    const sessionsDir = path.join(root, 'sessions', '2026', '07', '14');
+    fs.mkdirSync(sessionsDir, { recursive: true });
+    const files = [];
+    for (let index = 0; index < sessionCount; index += 1) {
+        const sessionId = crypto.randomUUID();
+        files.push(writeCodexSessionMetaFile(sessionsDir, sessionId, {
+            id: sessionId, session_id: sessionId, cwd: '/work/app',
+            timestamp: '2026-07-14T01:00:00.000Z', source: 'vscode',
+        }));
+    }
+    fs.writeFileSync(path.join(root, 'session_index.jsonl'), '', 'utf8');
+    return files;
+}
+
+function makeKimiStore(root, sessionCount) {
+    const workDir = '/work/app';
+    fs.writeFileSync(
+        path.join(root, 'kimi.json'),
+        JSON.stringify({ work_dirs: [{ path: workDir }] }),
+        'utf8'
+    );
+    const sessionsDir = path.join(
+        root, 'sessions', crypto.createHash('md5').update(workDir, 'utf8').digest('hex')
+    );
+    for (let index = 0; index < sessionCount; index += 1) {
+        const sessionDir = path.join(sessionsDir, crypto.randomUUID());
+        fs.mkdirSync(sessionDir, { recursive: true });
+        fs.writeFileSync(path.join(sessionDir, 'state.json'), '{}', 'utf8');
+        fs.writeFileSync(path.join(sessionDir, 'wire.jsonl'), '{}\n', 'utf8');
+    }
+}
+
+test('SESSION-FINGERPRINT-HASH-001 stats each Claude session file once per change poll', t => {
+    const root = makeTempDirectory(t, 'provider-claude-fingerprint-');
+    setEnvironment(t, 'CLAUDE_HOME', root);
+    const sessionCount = 32;
+    makeClaudeStore(root, sessionCount);
+
+    const counter = countingStats(t);
+    const service = new ClaudeSessionService();
+    counter.count = 0;
+    const fingerprint = service.getSessionFingerprint();
+
+    assert.ok(fingerprint.length > 0);
+    // The listing pass already stats every file to order by recency; the
+    // fingerprint must reuse that instead of stat'ing every path a second time.
+    assert.ok(
+        counter.count <= sessionCount + 2,
+        `expected at most ${sessionCount + 2} statSync calls for ${sessionCount} sessions, saw ${counter.count}`
+    );
+});
+
+test('SESSION-FINGERPRINT-HASH-001 fingerprints stay bounded as stores grow', t => {
+    const claudeRoot = makeTempDirectory(t, 'provider-claude-bounded-');
+    setEnvironment(t, 'CLAUDE_HOME', claudeRoot);
+    makeClaudeStore(claudeRoot, 32);
+
+    const codexRoot = makeTempDirectory(t, 'provider-codex-bounded-');
+    setEnvironment(t, 'CODEX_HOME', codexRoot);
+    makeCodexStore(codexRoot, 32);
+
+    const kimiRoot = makeTempDirectory(t, 'provider-kimi-bounded-');
+    setEnvironment(t, 'KIMI_SHARE_DIR', kimiRoot);
+    makeKimiStore(kimiRoot, 32);
+
+    // watchSessionChanges recomputes these every 3s per provider; the answer to
+    // "did anything change" must not be a store-sized string.
+    const limit = 128;
+    const claude = new ClaudeSessionService().getSessionFingerprint();
+    const codex = new CodexSessionService().getSessionFingerprint();
+    const kimi = new KimiSessionService().getSessionFingerprint();
+    assert.ok(claude.length > 0 && claude.length <= limit,
+        `claude fingerprint is ${claude.length} chars, limit ${limit}`);
+    assert.ok(codex.length > 0 && codex.length <= limit,
+        `codex fingerprint is ${codex.length} chars, limit ${limit}`);
+    assert.ok(kimi.length > 0 && kimi.length <= limit,
+        `kimi fingerprint is ${kimi.length} chars, limit ${limit}`);
+});
+
+test('SESSION-FINGERPRINT-HASH-001 fingerprints are stable without changes and move with content', t => {
+    const root = makeTempDirectory(t, 'provider-codex-stability-');
+    setEnvironment(t, 'CODEX_HOME', root);
+    const [sessionFile] = makeCodexStore(root, 4);
+
+    const service = new CodexSessionService();
+    const first = service.getSessionFingerprint();
+    assert.equal(service.getSessionFingerprint(), first,
+        'an unchanged store must keep its fingerprint between polls');
+
+    fs.appendFileSync(sessionFile, '{}\n', 'utf8');
+    assert.notEqual(service.getSessionFingerprint(), first,
+        'appending to a session file must change the fingerprint');
+});

--- a/tests/unit/tooling/repositorySkills.test.js
+++ b/tests/unit/tooling/repositorySkills.test.js
@@ -43,6 +43,8 @@ test('ARCH-REPOSITORY-SKILL-GUIDANCE-001 keeps regression audits path-based and 
         ['skill and owner-test implementation paths', /\.codex\/skills\/[\s\S]*skill-owner tests[\s\S]*implementation paths/i],
         ['post-commit SHA audit sequence', /final implementation commit[\s\S]*full SHA[\s\S]*assign it exactly once[\s\S]*audit\.head/i],
         ['explicit GitHub repository selection', /origin[\s\S]*upstream[\s\S]*--repo <owner\/name>/i],
+        ['tracked or CI-produced test inputs', /git-tracked or produced by an earlier step of the CI job/i],
+        ['build outputs absent rerun', /build outputs absent/i],
     ]);
 });
 
@@ -96,5 +98,15 @@ test('ARCH-REPOSITORY-SKILL-GUIDANCE-001 harvests evidence-backed workflow lesso
         ['implementation-path audit sequence', /\.codex\/skills\/[\s\S]*implementation paths[\s\S]*full commit SHA[\s\S]*audit\.head/i],
         ['valid no-change decision', /no skill change/i],
         ['bounded non-recursive pass', /only one harvest pass[\s\S]*do[\s\S]*not recursively trigger/i],
+    ]);
+});
+
+test('ARCH-REPOSITORY-SKILL-GUIDANCE-001 installs dependencies inside fresh worktrees before verification', () => {
+    const skill = readSkill('.codex/skills/protecting-main-with-worktrees/SKILL.md');
+
+    assertSkillMentions(skill, [
+        ['worktree-local dependency install', /npm ci/i],
+        ['parent node_modules masking', /parent checkout's node_modules/i],
+        ['path-constructed lookup failure', /constructs[\s\S]*node_modules\/\.\.\.[\s\S]*paths directly/i],
     ]);
 });


### PR DESCRIPTION
## 问题

`watchSessionChanges` 每 3 秒为每个 provider 重建一次全量指纹字符串：对每个文件 map 出签名小串 → sort → join 成一个与存储等大的字符串 → 比较。只为回答一个问题：「变了吗」。

## 修复

- **增量哈希替代大字符串**：每个条目（路径 + size + mtime）直接喂给单个运行中的 sha256，不再分配/排序/拼接。按确定性的发现顺序喂入（claude/codex 用 recency 排序、tiebreak 路径；kimi 按 session id 排序），存储不变则 digest 不变。
- **claude 顺带修掉每文件两次 stat**：排序 pass 已经 stat 过每个文件，指纹此前再 stat 一遍。与 codex 上一轮的做法对齐，复用同一份 stat。
- 新共享模块 `src/aiSessions/sessionFingerprint.ts`（约 20 行），三个 service 各自的面条串逻辑删除。

## 基准（合成存储，规模对齐本机真实存储：claude 280 / codex 772 / kimi 1601 文件）

| | stat/poll | ms/poll | 指纹大小 |
|---|---|---|---|
| claude | 560 → **280** | 2.3 → 1.9 | 34 KB → **64 chars** |
| codex | 773 → 773 | 4.7 → 4.5 | 199 KB → **64 chars** |
| kimi | 3203 → 3203 | 15.4 → 16.0 | 527 KB → **64 chars** |

每次轮询约 760 KB 的分配变成一个 64 字符 digest。延迟基本不变（瓶颈是 stat，字符串本来就不是大头）——**收益是 GC 压力，不是延迟**；kimi 的目录 walk 是下一个清单项。

## 验证

- 新契约 `SESSION-FINGERPRINT-HASH-001`（先红后绿）：claude 每轮 stat 预算、三个 provider 指纹长度上界、不变则等/变则异的语义。
- 完整 `test:ci:linux` 本地全绿（含 coverage gate、行为契约、release packaging）。

## Workflow-lesson harvest

本周期有两条教训落地为 skill 条款（各自带 owner 测试断言，归属 `MAIN-REGRESSION-CI-CURRENCY`）：

1. **`fixing-regressions-with-ci`**：读取仓库工作树文件的测试只能依赖 git 跟踪或 CI 前置步骤产出的路径，且要在构建产物缺失时复跑验证。——PR #67 的验证测试复制了未跟踪的 dist 产物，本地全绿、quality-linux 在干净检出上 ENOENT。（更正：#67 描述里「无 skill 变更」的结论写于 CI 失败之前，此条即该失败沉淀的教训。）
2. **`protecting-main-with-worktrees`**：新 worktree 先 `npm ci` 再验证。npm 会向上解析到主检出的 node_modules，编译能跑通，直到某个检查直接构造 `<worktree>/node_modules/...` 路径才暴露。

## 明确没做

kimi 的 15ms 目录递归遍历（清单第 3 项，需目录 mtime 缓存或 fs.watch，Linux 无 recursive watch）、dashboard.ts 剩余接线、复合 key 结构化、tmux 子系统阅读。
