### PR TITLE
refactor: isolate conversation outline, telemetry, and comments webview controllers

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -30,6 +30,7 @@ media/brand/**
 !media/conversationMermaidScripts.js
 !media/conversationReadingAnchorScripts.js
 !media/conversationOutlineScripts.js
+!media/conversationTelemetryScripts.js
 !media/conversationViewerScripts.js
 !media/conversationViewer.css
 !media/conversationTelemetry.css

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -29,6 +29,7 @@ media/brand/**
 !media/webviewTodoScripts.js
 !media/conversationMermaidScripts.js
 !media/conversationReadingAnchorScripts.js
+!media/conversationOutlineScripts.js
 !media/conversationViewerScripts.js
 !media/conversationViewer.css
 !media/conversationTelemetry.css

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -31,6 +31,7 @@ media/brand/**
 !media/conversationReadingAnchorScripts.js
 !media/conversationOutlineScripts.js
 !media/conversationTelemetryScripts.js
+!media/conversationCommentsScripts.js
 !media/conversationViewerScripts.js
 !media/conversationViewer.css
 !media/conversationTelemetry.css

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "f2a66bf31f9e478e1c66f7db4643d09bc3406aea",
+        "head": "c8a7eed9ea72dac0c99c8aadfa4c32ac153adb06",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -1004,16 +1004,19 @@
                 "805e4c404de5931b99e8e9280b67bdf62004a910",
                 "d1c8ac78fb80482b5752764a871d7c9917d597df",
                 "731a2b5e6edc5e1679a85040b15ea2ddb24f703a",
-        "2083ec487f4e3bd894614cb2bac3053e9c020636",
-        "e2c8e97cc289445e9506364a6e44f012c9dbf0bc",
-        "b9a911e41f924864633f0e7b9c4552e1405b534c",
+                "2083ec487f4e3bd894614cb2bac3053e9c020636",
+                "e2c8e97cc289445e9506364a6e44f012c9dbf0bc",
+                "b9a911e41f924864633f0e7b9c4552e1405b534c",
                 "cc399e86dc85f92bad836769bd93c420e08695e3",
                 "33b7f5ae707f757762878bf4c5f24342c2fdb321",
                 "9cd6c9716c7e9f27f41bbe0968f6f126e6717e5d",
                 "39bbfcebb2bf0b28e21513e905aa620d7b6eab83",
                 "7d98f9e23c4fcad345ed0782d41e24870ff80f6e",
                 "3ea5525ab3adc9fb69f5bc35895c74940361f4ac",
-                "94a109ca547e411f37a8adccdaead0e930241258"
+                "94a109ca547e411f37a8adccdaead0e930241258",
+                "2a6a5d33e7d9310f6a54958ebcea2a7a2e53813b",
+                "fb4eb73240af85e949a39723fc5c8a7be367ac22",
+                "c8a7eed9ea72dac0c99c8aadfa4c32ac153adb06"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",

--- a/media/conversationCommentsScripts.js
+++ b/media/conversationCommentsScripts.js
@@ -1,0 +1,862 @@
+(function () {
+    'use strict';
+
+    function create(options) {
+        var commentUiAvailable = options.available;
+        var commentTarget = options.target;
+        var subscriptionGeneration = options.subscriptionGeneration;
+        var status = options.status;
+        var messages = options.messages;
+        var scroll = options.scroll;
+        var addComment = options.addComment;
+        var commentsRoot = options.commentsRoot;
+        var commentCount = options.commentCount;
+        var commentSummary = options.commentSummary;
+        var commentComposer = options.commentComposer;
+        var commentSelection = options.commentSelection;
+        var commentInput = options.commentInput;
+        var commentList = options.commentList;
+        var commentEmpty = options.commentEmpty;
+        var commentNew = options.commentNew;
+        var commentSend = options.commentSend;
+        var commentClearSent = options.commentClearSent;
+        var commentClearResolved = options.commentClearResolved;
+        var commentClearAll = options.commentClearAll;
+        var post = options.post;
+        var conversationMessageSelector = options.messageSelector;
+        var conversationMessageId = options.messageId;
+        var setSidebarView = options.setSidebarView;
+        var updateToggle = options.updateToggle;
+        var state = {
+            comments: [],
+            commentRevision: 0,
+            commentRequestSequence: 0,
+            pendingCommentRequest: null,
+            pendingLocateRequest: null,
+            clearAllConfirmation: false,
+            selectedCommentText: null,
+        };
+
+        function readJsonAttribute(name) {
+            var value = document.body.getAttribute(name);
+            if (!value) return null;
+            document.body.removeAttribute(name);
+            try {
+                return JSON.parse(value);
+            } catch (_error) {
+                return null;
+            }
+        }
+
+        function validComment(value) {
+            if (!value || typeof value !== 'object' || Array.isArray(value)) {
+                return false;
+            }
+            var keys = [
+                'id', 'messageId', 'interactionId', 'role',
+                'quote', 'prefix', 'suffix', 'comment', 'status',
+            ];
+            var actualKeys = Object.keys(value);
+            var hasSessionScope = value.scope === 'session';
+            return actualKeys.length === keys.length + (hasSessionScope ? 1 : 0)
+                && keys.every(function (key) {
+                    return Object.prototype.hasOwnProperty.call(value, key);
+                })
+                && (value.scope === undefined || hasSessionScope)
+                && typeof value.id === 'string'
+                && typeof value.messageId === 'string'
+                && typeof value.interactionId === 'string'
+                && (value.role === 'user' || value.role === 'assistant')
+                && typeof value.quote === 'string'
+                && typeof value.prefix === 'string'
+                && typeof value.suffix === 'string'
+                && typeof value.comment === 'string'
+                && (!hasSessionScope
+                    || (value.messageId === ''
+                        && value.interactionId === ''
+                        && value.role === 'user'
+                        && value.quote === ''
+                        && value.prefix === ''
+                        && value.suffix === ''))
+                && (value.status === 'open'
+                    || value.status === 'sent'
+                    || value.status === 'resolved');
+        }
+
+        function validInitialComments(value) {
+            return value && typeof value === 'object' && !Array.isArray(value)
+                && Object.keys(value).length === 2
+                && Number.isSafeInteger(value.revision)
+                && value.revision >= 0
+                && Array.isArray(value.comments)
+                && value.comments.length <= 20
+                && value.comments.every(validComment);
+        }
+
+        function validCommentsResult(value) {
+            if (!value || typeof value !== 'object' || Array.isArray(value)) {
+                return false;
+            }
+            var required = [
+                'type', 'version', 'requestId', 'subscriptionGeneration',
+                'projectId', 'provider', 'sessionId', 'operation', 'success',
+                'revision', 'comments',
+            ];
+            var allowed = new Set(required.concat(['error']));
+            return Object.keys(value).every(function (key) {
+                return allowed.has(key);
+            }) && required.every(function (key) {
+                return Object.prototype.hasOwnProperty.call(value, key);
+            })
+                && value.type === 'conversation-viewer-comments-result'
+                && value.version === 1
+                && typeof value.requestId === 'string'
+                && Number.isSafeInteger(value.subscriptionGeneration)
+                && typeof value.projectId === 'string'
+                && (value.provider === 'codex'
+                    || value.provider === 'kimi'
+                    || value.provider === 'claude')
+                && typeof value.sessionId === 'string'
+                && (value.operation === 'add'
+                    || value.operation === 'update'
+                    || value.operation === 'delete'
+                    || value.operation === 'resolve'
+                    || value.operation === 'reopen'
+                    || value.operation === 'clearSent'
+                    || value.operation === 'clearResolved'
+                    || value.operation === 'clearAll'
+                    || value.operation === 'sendComments')
+                && typeof value.success === 'boolean'
+                && Number.isSafeInteger(value.revision)
+                && value.revision >= 0
+                && Array.isArray(value.comments)
+                && value.comments.length <= 20
+                && value.comments.every(validComment)
+                && (value.error === undefined || [
+                    'invalid', 'stale', 'limit', 'tooLarge',
+                    'unavailable', 'busy', 'conflict', 'failed',
+                ].includes(value.error));
+        }
+
+        function validLocateResult(value) {
+            if (!value || typeof value !== 'object' || Array.isArray(value)) {
+                return false;
+            }
+            var required = [
+                'type', 'version', 'requestId', 'subscriptionGeneration',
+                'projectId', 'provider', 'sessionId', 'commentId', 'success',
+            ];
+            var allowed = new Set(required.concat(['error']));
+            return Object.keys(value).every(function (key) {
+                return allowed.has(key);
+            }) && required.every(function (key) {
+                return Object.prototype.hasOwnProperty.call(value, key);
+            })
+                && value.type === 'conversation-viewer-locate-comment-result'
+                && value.version === 1
+                && typeof value.requestId === 'string'
+                && Number.isSafeInteger(value.subscriptionGeneration)
+                && typeof value.projectId === 'string'
+                && (value.provider === 'codex'
+                    || value.provider === 'kimi'
+                    || value.provider === 'claude')
+                && typeof value.sessionId === 'string'
+                && typeof value.commentId === 'string'
+                && typeof value.success === 'boolean'
+                && (value.error === undefined || value.error === 'stale');
+        }
+
+        function openCommentCount() {
+            return state.comments.filter(function (comment) {
+                return comment.status === 'open';
+            }).length;
+        }
+
+        function commentStatusCounts() {
+            return state.comments.reduce(function (counts, comment) {
+                counts[comment.status] += 1;
+                return counts;
+            }, { open: 0, sent: 0, resolved: 0 });
+        }
+
+        function resetClearAllConfirmation() {
+            if (!commentUiAvailable) return;
+            state.clearAllConfirmation = false;
+            commentClearAll.textContent = 'Clear all';
+            commentClearAll.removeAttribute('data-confirming');
+            commentClearAll.setAttribute('aria-label', 'Clear all comments');
+        }
+
+        function updateCommentControls() {
+            if (!commentUiAvailable) return;
+            var counts = commentStatusCounts();
+            var pending = !!state.pendingCommentRequest
+                || !!state.pendingLocateRequest;
+            var summary = [];
+            if (counts.open) summary.push(counts.open + ' open');
+            if (counts.sent) summary.push(counts.sent + ' added');
+            if (counts.resolved) summary.push(counts.resolved + ' resolved');
+            commentSummary.textContent = summary.length
+                ? summary.join(' · ')
+                : 'No comments yet';
+            commentCount.textContent = String(state.comments.length);
+            commentCount.setAttribute(
+                'aria-label',
+                state.comments.length + ' comment'
+                    + (state.comments.length === 1 ? '' : 's')
+            );
+            commentSend.disabled = counts.open === 0 || pending;
+            commentNew.disabled = pending;
+            commentClearSent.disabled = counts.sent === 0 || pending;
+            commentClearResolved.disabled = counts.resolved === 0 || pending;
+            commentClearAll.disabled = state.comments.length === 0 || pending;
+        }
+
+        function nextCommentRequestId() {
+            state.commentRequestSequence += 1;
+            return [
+                'conversation-comment',
+                Date.now().toString(36),
+                state.commentRequestSequence.toString(36),
+            ].join(':');
+        }
+
+        function commentErrorMessage(error) {
+            if (error === 'stale') return 'Comments changed. Review the latest draft and try again.';
+            if (error === 'limit') return 'A maximum of 20 comments can be added at once.';
+            if (error === 'tooLarge') return 'The combined comments are too large to send.';
+            if (error === 'busy') return 'Wait for the current AI response to finish, then send again.';
+            if (error === 'conflict') return 'Multiple runtimes match this session. Resolve the conflict first.';
+            if (error === 'unavailable') return 'This session is unavailable and the comments were not added.';
+            return 'The comment action failed. Your comments were kept.';
+        }
+
+        function setCommentPending(pending) {
+            if (!commentUiAvailable) return;
+            Array.prototype.forEach.call(
+                commentsRoot.querySelectorAll('button, textarea'),
+                function (control) {
+                    control.disabled = pending;
+                }
+            );
+            addComment.disabled = pending;
+            if (!pending) {
+                updateCommentControls();
+            }
+            commentsRoot.setAttribute('aria-busy', pending ? 'true' : 'false');
+        }
+
+        function postCommentOperation(operation, payload) {
+            if (!commentUiAvailable
+                || state.pendingCommentRequest
+                || state.pendingLocateRequest) return;
+            var requestId = nextCommentRequestId();
+            resetClearAllConfirmation();
+            state.pendingCommentRequest = { requestId: requestId, operation: operation };
+            setCommentPending(true);
+            status.textContent = operation === 'sendComments'
+                ? 'Adding comments to session input…'
+                : operation === 'clearSent'
+                    || operation === 'clearResolved'
+                    || operation === 'clearAll'
+                    ? 'Clearing comments…'
+                    : 'Saving comment…';
+            post({
+                type: operation === 'sendComments'
+                    ? 'conversation-viewer-send-comments'
+                    : 'conversation-viewer-comment-mutation',
+                version: 1,
+                requestId: requestId,
+                subscriptionGeneration: subscriptionGeneration,
+                projectId: commentTarget.projectId,
+                provider: commentTarget.provider,
+                sessionId: commentTarget.sessionId,
+                operation: operation,
+                expectedRevision: state.commentRevision,
+                payload: payload,
+            });
+        }
+
+        function locateComment(comment) {
+            if (comment.scope === 'session') return false;
+            var message = Array.prototype.find.call(
+                messages.querySelectorAll(conversationMessageSelector()),
+                function (candidate) {
+                    return conversationMessageId(candidate) === comment.messageId;
+                }
+            );
+            if (!message) {
+                return false;
+            }
+            message.scrollIntoView({ block: 'center' });
+            message.tabIndex = -1;
+            message.focus({ preventScroll: true });
+            message.classList.add('conversation-comment-located');
+            window.setTimeout(function () {
+                message.classList.remove('conversation-comment-located');
+            }, 1600);
+            return true;
+        }
+
+        function requestCommentLocation(comment) {
+            if (locateComment(comment)) {
+                status.textContent = 'Comment source located.';
+                return;
+            }
+            if (state.pendingLocateRequest || state.pendingCommentRequest) return;
+            var requestId = nextCommentRequestId();
+            state.pendingLocateRequest = {
+                requestId: requestId,
+                commentId: comment.id,
+            };
+            setCommentPending(true);
+            status.textContent = 'Loading the commented message…';
+            post({
+                type: 'conversation-viewer-locate-comment',
+                version: 1,
+                requestId: requestId,
+                subscriptionGeneration: subscriptionGeneration,
+                projectId: commentTarget.projectId,
+                provider: commentTarget.provider,
+                sessionId: commentTarget.sessionId,
+                commentId: comment.id,
+            });
+        }
+
+        function renderComments() {
+            if (!commentUiAvailable) return;
+            resetClearAllConfirmation();
+            commentList.replaceChildren();
+            state.comments.forEach(function (comment, index) {
+                var item = document.createElement('article');
+                item.className = 'conversation-comment';
+                item.setAttribute('data-comment-id', comment.id);
+                item.setAttribute('data-comment-status', comment.status);
+                item.setAttribute(
+                    'data-comment-scope',
+                    comment.scope === 'session' ? 'session' : 'selection'
+                );
+
+                var heading = document.createElement('div');
+                heading.className = 'conversation-comment-heading';
+                var identity = document.createElement('div');
+                identity.className = 'conversation-comment-identity';
+                var label = document.createElement('strong');
+                label.textContent = 'Comment ' + (index + 1);
+                if (comment.scope === 'session') {
+                    var scope = document.createElement('span');
+                    scope.className = 'conversation-comment-scope';
+                    scope.textContent = 'Session note';
+                    identity.append(label, scope);
+                } else {
+                    identity.appendChild(label);
+                }
+                var statusLabel = document.createElement('span');
+                statusLabel.className = 'conversation-comment-status';
+                statusLabel.setAttribute('data-comment-status-label', '');
+                statusLabel.textContent = comment.status === 'open'
+                    ? 'Open'
+                    : comment.status === 'sent' ? 'Added' : 'Resolved';
+                identity.appendChild(statusLabel);
+                heading.appendChild(identity);
+                if (comment.scope !== 'session') {
+                    var locate = document.createElement('button');
+                    locate.type = 'button';
+                    locate.className = 'conversation-comment-locate';
+                    locate.setAttribute('data-comment-action', 'locate');
+                    locate.textContent = 'Show text';
+                    heading.appendChild(locate);
+                }
+
+                var quoteGroup = document.createElement('div');
+                quoteGroup.className = 'conversation-comment-quote';
+                var quoteLabel = document.createElement('span');
+                quoteLabel.className = 'conversation-comment-quote-label';
+                quoteLabel.textContent = 'Selected text';
+                var quote = document.createElement('blockquote');
+                quote.textContent = comment.quote;
+                quoteGroup.append(quoteLabel, quote);
+                var input = document.createElement('textarea');
+                input.rows = 2;
+                input.maxLength = 4000;
+                input.value = comment.comment;
+                input.readOnly = comment.status !== 'open';
+                input.setAttribute('aria-label', 'Comment ' + (index + 1));
+                input.setAttribute(
+                    'aria-keyshortcuts',
+                    'Control+Enter Meta+Enter'
+                );
+                input.setAttribute('data-comment-edit', '');
+                var actions = document.createElement('div');
+                actions.className = 'conversation-comment-actions';
+                var remove = document.createElement('button');
+                remove.type = 'button';
+                remove.className = 'conversation-comment-delete';
+                remove.setAttribute('data-comment-action', 'delete');
+                remove.textContent = 'Delete';
+                actions.appendChild(remove);
+                if (comment.status === 'open') {
+                    var save = document.createElement('button');
+                    save.type = 'button';
+                    save.setAttribute('data-comment-action', 'update');
+                    save.title = 'Save comment (Ctrl+Enter or Cmd+Enter)';
+                    save.textContent = 'Save';
+                    actions.appendChild(save);
+                }
+                var review = document.createElement('button');
+                review.type = 'button';
+                if (comment.status === 'resolved') {
+                    review.setAttribute('data-comment-action', 'reopen');
+                    review.textContent = 'Reopen';
+                } else if (comment.status === 'sent') {
+                    review.setAttribute('data-comment-action', 'resolve');
+                    review.textContent = 'Resolve';
+                    var reopen = document.createElement('button');
+                    reopen.type = 'button';
+                    reopen.setAttribute('data-comment-action', 'reopen');
+                    reopen.textContent = 'Reopen';
+                    actions.appendChild(reopen);
+                } else {
+                    review.setAttribute('data-comment-action', 'resolve');
+                    review.textContent = 'Resolve';
+                }
+                actions.appendChild(review);
+                item.appendChild(heading);
+                if (comment.scope !== 'session') {
+                    item.appendChild(quoteGroup);
+                }
+                item.append(input, actions);
+                commentList.appendChild(item);
+            });
+            updateToggle();
+            commentEmpty.hidden = state.comments.length > 0;
+            var openCount = openCommentCount();
+            commentSend.textContent = 'Send ' + openCount + ' open comment'
+                + (openCount === 1 ? '' : 's') + ' to this session';
+            updateCommentControls();
+            updateCommentHighlights();
+        }
+
+        function findQuoteRange(root, comment) {
+            var walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+            var nodes = [];
+            var combined = '';
+            var node;
+            while ((node = walker.nextNode())) {
+                nodes.push({ node: node, start: combined.length });
+                combined += node.nodeValue || '';
+            }
+            var candidates = [];
+            var candidate = combined.indexOf(comment.quote);
+            while (candidate >= 0) {
+                candidates.push(candidate);
+                candidate = combined.indexOf(
+                    comment.quote,
+                    candidate + 1
+                );
+            }
+            var start = candidates.find(function (offset) {
+                var before = combined.slice(
+                    Math.max(0, offset - comment.prefix.length),
+                    offset
+                );
+                var after = combined.slice(
+                    offset + comment.quote.length,
+                    offset + comment.quote.length + comment.suffix.length
+                );
+                return before === comment.prefix && after === comment.suffix;
+            });
+            if (start === undefined) start = candidates[0];
+            if (start === undefined) return null;
+            var end = start + comment.quote.length;
+            var startRecord = nodes.find(function (record) {
+                return start >= record.start
+                    && start <= record.start + (record.node.nodeValue || '').length;
+            });
+            var endRecord = nodes.find(function (record) {
+                return end >= record.start
+                    && end <= record.start + (record.node.nodeValue || '').length;
+            });
+            if (!startRecord || !endRecord) return null;
+            var range = document.createRange();
+            range.setStart(startRecord.node, start - startRecord.start);
+            range.setEnd(endRecord.node, end - endRecord.start);
+            return range;
+        }
+
+        function updateCommentHighlights() {
+            if (!commentUiAvailable) return;
+            Array.prototype.forEach.call(
+                messages.querySelectorAll('.conversation-has-comment'),
+                function (message) {
+                    message.classList.remove('conversation-has-comment');
+                }
+            );
+            var ranges = [];
+            state.comments.forEach(function (comment) {
+                if (comment.status === 'resolved'
+                    || comment.scope === 'session') return;
+                var message = Array.prototype.find.call(
+                    messages.querySelectorAll(conversationMessageSelector()),
+                    function (candidate) {
+                        return conversationMessageId(candidate)
+                            === comment.messageId;
+                    }
+                );
+                if (!message) return;
+                message.classList.add('conversation-has-comment');
+                var markdown = message.querySelector('.conversation-markdown');
+                var range = markdown && findQuoteRange(markdown, comment);
+                if (range) ranges.push(range);
+            });
+            if (window.CSS && CSS.highlights && typeof Highlight === 'function') {
+                CSS.highlights.delete('conversation-comments');
+                if (ranges.length) {
+                    CSS.highlights.set(
+                        'conversation-comments',
+                        new Highlight(...ranges)
+                    );
+                }
+            }
+        }
+
+        function applyCommentsResult(message) {
+            if (!commentUiAvailable
+                || !validCommentsResult(message)
+                || message.subscriptionGeneration !== subscriptionGeneration
+                || message.projectId !== commentTarget.projectId
+                || message.provider !== commentTarget.provider
+                || message.sessionId !== commentTarget.sessionId
+                || !state.pendingCommentRequest
+                || message.requestId !== state.pendingCommentRequest.requestId
+                || message.operation !== state.pendingCommentRequest.operation) {
+                return false;
+            }
+            state.commentRevision = message.revision;
+            state.comments = message.comments.map(function (comment) {
+                return Object.assign({}, comment);
+            });
+            renderComments();
+            var operation = state.pendingCommentRequest.operation;
+            state.pendingCommentRequest = null;
+            setCommentPending(false);
+            if (message.success) {
+                status.textContent = operation === 'sendComments'
+                    ? 'Comments added to session input. Review and press Enter to send.'
+                    : operation === 'clearSent'
+                        ? 'Added comments cleared.'
+                        : operation === 'clearResolved'
+                            ? 'Resolved comments cleared.'
+                            : operation === 'clearAll'
+                                ? 'All comments cleared.'
+                                : 'Comments saved.';
+            } else {
+                status.textContent = commentErrorMessage(message.error);
+            }
+            return true;
+        }
+
+        function applyLocateResult(message) {
+            if (!commentUiAvailable
+                || !validLocateResult(message)
+                || message.subscriptionGeneration !== subscriptionGeneration
+                || message.projectId !== commentTarget.projectId
+                || message.provider !== commentTarget.provider
+                || message.sessionId !== commentTarget.sessionId
+                || !state.pendingLocateRequest
+                || message.requestId !== state.pendingLocateRequest.requestId
+                || message.commentId !== state.pendingLocateRequest.commentId) {
+                return false;
+            }
+            var comment = state.comments.find(function (candidate) {
+                return candidate.id === message.commentId;
+            });
+            state.pendingLocateRequest = null;
+            setCommentPending(false);
+            if (message.success && comment && locateComment(comment)) {
+                status.textContent = 'Comment source located.';
+            } else {
+                status.textContent = 'The commented message is no longer available.';
+            }
+            return true;
+        }
+
+        function selectionContext(range, markdown) {
+            var before = document.createRange();
+            before.selectNodeContents(markdown);
+            before.setEnd(range.startContainer, range.startOffset);
+            var after = document.createRange();
+            after.selectNodeContents(markdown);
+            after.setStart(range.endContainer, range.endOffset);
+            return {
+                prefix: before.toString().slice(-240),
+                suffix: after.toString().slice(0, 240),
+            };
+        }
+
+        function captureCommentSelection() {
+            if (!commentUiAvailable || state.pendingCommentRequest) return;
+            var selection = window.getSelection();
+            if (!selection || selection.rangeCount !== 1 || selection.isCollapsed) {
+                addComment.hidden = true;
+                state.selectedCommentText = null;
+                return;
+            }
+            var range = selection.getRangeAt(0);
+            var startElement = range.startContainer.nodeType === Node.ELEMENT_NODE
+                ? range.startContainer
+                : range.startContainer.parentElement;
+            var endElement = range.endContainer.nodeType === Node.ELEMENT_NODE
+                ? range.endContainer
+                : range.endContainer.parentElement;
+            var startMessage = startElement && startElement.closest
+                ? startElement.closest(conversationMessageSelector())
+                : null;
+            var endMessage = endElement && endElement.closest
+                ? endElement.closest(conversationMessageSelector())
+                : null;
+            var markdown = startElement && startElement.closest
+                ? startElement.closest('.conversation-markdown')
+                : null;
+            var quote = selection.toString().trim();
+            if (!startMessage || startMessage !== endMessage || !markdown
+                || !messages.contains(startMessage) || !quote
+                || Array.from(quote).length > 4000) {
+                addComment.hidden = true;
+                state.selectedCommentText = null;
+                return;
+            }
+            var context = selectionContext(range, markdown);
+            state.selectedCommentText = {
+                messageId: conversationMessageId(startMessage),
+                interactionId: startMessage.getAttribute('data-interaction-id'),
+                quote: quote,
+                prefix: context.prefix,
+                suffix: context.suffix,
+            };
+            var rect = range.getBoundingClientRect();
+            addComment.style.left = Math.max(
+                8,
+                Math.min(window.innerWidth - 120, rect.left)
+            ) + 'px';
+            addComment.style.top = Math.max(8, rect.bottom + 6) + 'px';
+            addComment.hidden = false;
+        }
+
+        function openCommentComposer() {
+            if (!state.selectedCommentText) return;
+            setSidebarView('comments', true, true);
+            addComment.hidden = true;
+            commentSelection.textContent = state.selectedCommentText.quote;
+            commentComposer.setAttribute('data-comment-composer-scope', 'selection');
+            commentInput.value = '';
+            commentComposer.hidden = false;
+            commentInput.focus();
+        }
+
+        function openSessionCommentComposer() {
+            if (!commentUiAvailable
+                || state.pendingCommentRequest
+                || state.pendingLocateRequest) return;
+            setSidebarView('comments', true, true);
+            addComment.hidden = true;
+            state.selectedCommentText = { scope: 'session' };
+            commentSelection.textContent = 'Session note';
+            commentComposer.setAttribute('data-comment-composer-scope', 'session');
+            commentInput.value = '';
+            commentComposer.hidden = false;
+            commentInput.focus();
+        }
+
+        function closeCommentComposer() {
+            commentComposer.hidden = true;
+            commentComposer.removeAttribute('data-comment-composer-scope');
+            commentInput.value = '';
+            state.selectedCommentText = null;
+            addComment.hidden = true;
+        }
+
+        function attach() {
+            if (!commentUiAvailable) return;
+            messages.addEventListener('mouseup', function () {
+                window.setTimeout(captureCommentSelection, 0);
+            });
+            messages.addEventListener('keyup', function (event) {
+                if (event.key === 'Shift'
+                    || event.key.startsWith('Arrow')
+                    || event.key === 'Home'
+                    || event.key === 'End') {
+                    window.setTimeout(captureCommentSelection, 0);
+                }
+            });
+            scroll.addEventListener('scroll', function () {
+                addComment.hidden = true;
+            });
+            addComment.addEventListener('click', openCommentComposer);
+            commentsRoot.addEventListener('click', function (event) {
+                var button = event.target && event.target.closest
+                    ? event.target.closest('[data-comment-action]')
+                    : null;
+                if (!button || !commentsRoot.contains(button)
+                    || state.pendingCommentRequest
+                    || state.pendingLocateRequest) {
+                    return;
+                }
+                var action = button.getAttribute('data-comment-action');
+                if (action !== 'clearAll' && state.clearAllConfirmation) {
+                    resetClearAllConfirmation();
+                }
+                if (action === 'new') {
+                    openSessionCommentComposer();
+                    return;
+                }
+                if (action === 'cancel-add') {
+                    closeCommentComposer();
+                    return;
+                }
+                if (action === 'confirm-add') {
+                    var text = commentInput.value.trim();
+                    if (!state.selectedCommentText || !text) {
+                        status.textContent = 'Enter a comment before adding it.';
+                        commentInput.focus();
+                        return;
+                    }
+                    var payload = Object.assign(
+                        {},
+                        state.selectedCommentText,
+                        { comment: text }
+                    );
+                    closeCommentComposer();
+                    postCommentOperation('add', payload);
+                    return;
+                }
+                if (action === 'send') {
+                    postCommentOperation('sendComments', {});
+                    return;
+                }
+                if (action === 'clearSent' || action === 'clearResolved') {
+                    postCommentOperation(action, {});
+                    return;
+                }
+                if (action === 'clearAll') {
+                    if (!state.clearAllConfirmation) {
+                        state.clearAllConfirmation = true;
+                        commentClearAll.textContent = 'Confirm clear all';
+                        commentClearAll.setAttribute('data-confirming', 'true');
+                        commentClearAll.setAttribute(
+                            'aria-label',
+                            'Confirm clearing all comments'
+                        );
+                        status.textContent =
+                            'Select Clear all again to remove every comment.';
+                        return;
+                    }
+                    postCommentOperation('clearAll', {});
+                    return;
+                }
+                var item = button.closest('[data-comment-id]');
+                var commentId = item && item.getAttribute('data-comment-id');
+                var comment = state.comments.find(function (candidate) {
+                    return candidate.id === commentId;
+                });
+                if (!item || !comment) return;
+                if (action === 'locate') {
+                    requestCommentLocation(comment);
+                    return;
+                }
+                if (action === 'delete') {
+                    postCommentOperation('delete', { commentId: comment.id });
+                    return;
+                }
+                if (action === 'resolve' || action === 'reopen') {
+                    postCommentOperation(action, { commentId: comment.id });
+                    return;
+                }
+                if (action === 'update') {
+                    var edit = item.querySelector('[data-comment-edit]');
+                    var updated = edit ? edit.value.trim() : '';
+                    if (!updated) {
+                        status.textContent = 'A comment cannot be empty.';
+                        if (edit) edit.focus();
+                        return;
+                    }
+                    postCommentOperation('update', {
+                        commentId: comment.id,
+                        comment: updated,
+                    });
+                }
+            });
+        }
+
+        function handleEnterShortcut(event) {
+            if (!commentUiAvailable
+                || event.key !== 'Enter'
+                || (!event.ctrlKey && !event.metaKey)
+                || event.altKey) {
+                return false;
+            }
+            var target = event.target;
+            if (target === commentInput && !commentComposer.hidden) {
+                event.preventDefault();
+                commentComposer.querySelector(
+                    '[data-comment-action="confirm-add"]'
+                )?.click();
+                return true;
+            }
+            if (target && target.matches?.('[data-comment-edit]')) {
+                var item = target.closest('[data-comment-id]');
+                var save = item?.querySelector(
+                    '[data-comment-action="update"]'
+                );
+                if (save) {
+                    event.preventDefault();
+                    save.click();
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        function handleEscape(event) {
+            if (commentUiAvailable && state.clearAllConfirmation) {
+                event.preventDefault();
+                resetClearAllConfirmation();
+                status.textContent = 'Clear all cancelled.';
+                commentClearAll.focus();
+                return true;
+            }
+            if (commentUiAvailable && !commentComposer.hidden) {
+                event.preventDefault();
+                closeCommentComposer();
+                return true;
+            }
+            return false;
+        }
+
+        function initializeComments() {
+            var initialComments = readJsonAttribute('data-initial-comments');
+            if (validInitialComments(initialComments)) {
+                state.commentRevision = initialComments.revision;
+                state.comments = initialComments.comments.map(function (comment) {
+                    return Object.assign({}, comment);
+                });
+                renderComments();
+            } else {
+                status.textContent = 'Comment drafts are unavailable.';
+            }
+        }
+
+        return Object.freeze({
+            applyCommentsResult: applyCommentsResult,
+            applyLocateResult: applyLocateResult,
+            attach: attach,
+            handleEnterShortcut: handleEnterShortcut,
+            handleEscape: handleEscape,
+            initializeComments: initializeComments,
+            openCount: openCommentCount,
+            updateHighlights: updateCommentHighlights,
+        });
+    }
+
+    window.__agentPivotConversationComments = Object.freeze({ create: create });
+}());

--- a/media/conversationOutlineScripts.js
+++ b/media/conversationOutlineScripts.js
@@ -1,0 +1,462 @@
+(function () {
+    'use strict';
+
+    function create(options) {
+        var sidebarUiAvailable = options.available;
+        var bookmarkUiAvailable = options.bookmarkAvailable;
+        var commentTarget = options.target;
+        var subscriptionGeneration = options.subscriptionGeneration;
+        var status = options.status;
+        var outlineCount = options.outlineCount;
+        var outlineSummary = options.outlineSummary;
+        var outlineSearch = options.outlineSearch;
+        var outlineList = options.outlineList;
+        var outlineEmpty = options.outlineEmpty;
+        var outlinePartial = options.outlinePartial;
+        var outlineBookmarksOnly = options.outlineBookmarksOnly;
+        var post = options.post;
+        var outlinePanelActive = options.outlinePanelActive;
+        var persistPanelState = options.persistPanelState;
+        var updateToggle = options.updateToggle;
+        var state = {
+            outline: [],
+            outlineSelectedInteractionId: '',
+            outlineSelectedInput: 0,
+            outlineTotalInputs: 0,
+            outlinePartial: false,
+            outlineQuery: '',
+            bookmarkIds: new Set(),
+            bookmarkRevision: 0,
+            bookmarkRequestSequence: 0,
+            pendingBookmarkRequest: null,
+            bookmarksOnly: false,
+        };
+
+        function readJsonAttribute(name) {
+            var value = document.body.getAttribute(name);
+            if (!value) return null;
+            document.body.removeAttribute(name);
+            try {
+                return JSON.parse(value);
+            } catch (_error) {
+                return null;
+            }
+        }
+
+        function validBookmarkSnapshot(value) {
+            return value && typeof value === 'object' && !Array.isArray(value)
+                && Object.keys(value).length === 2
+                && Number.isSafeInteger(value.revision)
+                && value.revision >= 0
+                && Array.isArray(value.interactionIds)
+                && value.interactionIds.length <= 2000
+                && value.interactionIds.every(function (id) {
+                    return typeof id === 'string'
+                        && id.length > 0
+                        && id.length <= 512
+                        && !/[\u0000-\u001f\u007f]/.test(id);
+                })
+                && new Set(value.interactionIds).size
+                    === value.interactionIds.length;
+        }
+
+        function validBookmarksResult(value) {
+            if (!value || typeof value !== 'object' || Array.isArray(value)) {
+                return false;
+            }
+            var required = [
+                'type', 'version', 'requestId', 'subscriptionGeneration',
+                'projectId', 'provider', 'sessionId', 'operation', 'success',
+                'revision', 'interactionIds',
+            ];
+            var allowed = new Set(required.concat(['error']));
+            return Object.keys(value).every(function (key) {
+                return allowed.has(key);
+            }) && required.every(function (key) {
+                return Object.prototype.hasOwnProperty.call(value, key);
+            })
+                && value.type === 'conversation-viewer-bookmarks-result'
+                && value.version === 1
+                && typeof value.requestId === 'string'
+                && Number.isSafeInteger(value.subscriptionGeneration)
+                && typeof value.projectId === 'string'
+                && ['codex', 'kimi', 'claude'].includes(value.provider)
+                && typeof value.sessionId === 'string'
+                && value.operation === 'set'
+                && typeof value.success === 'boolean'
+                && validBookmarkSnapshot({
+                    revision: value.revision,
+                    interactionIds: value.interactionIds,
+                })
+                && (value.error === undefined
+                    || ['invalid', 'stale', 'failed', 'limit']
+                        .includes(value.error));
+        }
+
+        function nextBookmarkRequestId() {
+            state.bookmarkRequestSequence += 1;
+            return [
+                'conversation-bookmark',
+                Date.now().toString(36),
+                state.bookmarkRequestSequence.toString(36),
+            ].join(':');
+        }
+
+        function postBookmarkMutation(interactionId, bookmarked) {
+            if (!bookmarkUiAvailable
+                || state.pendingBookmarkRequest) return;
+            var requestId = nextBookmarkRequestId();
+            state.pendingBookmarkRequest = { requestId: requestId, interactionId: interactionId };
+            renderBookmarkState();
+            post({
+                type: 'conversation-viewer-bookmark-mutation',
+                version: 1,
+                requestId: requestId,
+                subscriptionGeneration: subscriptionGeneration,
+                projectId: commentTarget.projectId,
+                provider: commentTarget.provider,
+                sessionId: commentTarget.sessionId,
+                operation: 'set',
+                expectedRevision: state.bookmarkRevision,
+                payload: {
+                    interactionId: interactionId,
+                    bookmarked: bookmarked,
+                },
+            });
+        }
+
+        function applyBookmarksResult(message) {
+            if (!bookmarkUiAvailable
+                || !validBookmarksResult(message)
+                || !state.pendingBookmarkRequest
+                || message.requestId !== state.pendingBookmarkRequest.requestId
+                || message.subscriptionGeneration !== subscriptionGeneration
+                || message.projectId !== commentTarget.projectId
+                || message.provider !== commentTarget.provider
+                || message.sessionId !== commentTarget.sessionId) {
+                return false;
+            }
+            var focusedId = state.pendingBookmarkRequest.interactionId;
+            state.pendingBookmarkRequest = null;
+            state.bookmarkRevision = message.revision;
+            state.bookmarkIds = new Set(message.interactionIds);
+            renderBookmarkState();
+            filterOutline();
+            status.textContent = message.success
+                ? (state.bookmarkIds.has(focusedId)
+                    ? 'Input bookmarked.'
+                    : 'Bookmark removed.')
+                : 'Bookmark could not be updated.';
+            var focused = outlineList.querySelector(
+                '[data-outline-bookmark-id="' + CSS.escape(focusedId) + '"]'
+            );
+            if (focused) focused.focus();
+            return true;
+        }
+
+        function renderBookmarkState() {
+            if (!sidebarUiAvailable) return;
+            Array.prototype.forEach.call(
+                outlineList.querySelectorAll('[data-outline-bookmark-id]'),
+                function (button) {
+                    var interactionId = button.getAttribute(
+                        'data-outline-bookmark-id'
+                    );
+                    var bookmarked = state.bookmarkIds.has(interactionId);
+                    var entry = state.outline.find(function (candidate) {
+                        return candidate.interactionId === interactionId;
+                    });
+                    var inputNumber = entry ? entry.inputNumber : '';
+                    button.textContent = bookmarked ? '★' : '☆';
+                    button.classList.toggle('is-bookmarked', bookmarked);
+                    button.setAttribute('aria-pressed',
+                        bookmarked ? 'true' : 'false');
+                    button.setAttribute(
+                        'aria-label',
+                        (bookmarked ? 'Remove bookmark from input ' : 'Bookmark input ')
+                            + inputNumber
+                    );
+                    button.title = button.getAttribute('aria-label');
+                    button.disabled = !!state.pendingBookmarkRequest;
+                }
+            );
+            var count = state.bookmarkIds.size;
+            outlineBookmarksOnly.textContent = (state.bookmarksOnly ? '★' : '☆')
+                + ' Bookmarks (' + count + ')';
+            outlineBookmarksOnly.setAttribute(
+                'aria-pressed',
+                state.bookmarksOnly ? 'true' : 'false'
+            );
+        }
+
+        function outlineChanged(entries) {
+            return entries.length !== state.outline.length
+                || entries.some(function (entry, index) {
+                    var current = state.outline[index];
+                    return !current
+                        || current.interactionId !== entry.interactionId
+                        || current.userPreview !== entry.userPreview
+                        || current.responseState !== entry.responseState;
+                });
+        }
+
+        function responseStateLabel(value) {
+            if (value === 'inProgress') return 'Response in progress';
+            if (value === 'interrupted') return 'Response interrupted';
+            if (value === 'unknown') return 'Response state unknown';
+            return 'Response complete';
+        }
+
+        function buildOutlineList() {
+            var fragment = document.createDocumentFragment();
+            state.outline.forEach(function (entry) {
+                var item = document.createElement('li');
+                item.className = 'conversation-outline-item';
+                var bookmark = document.createElement('button');
+                bookmark.type = 'button';
+                bookmark.className = 'conversation-outline-bookmark';
+                bookmark.setAttribute(
+                    'data-outline-bookmark-id',
+                    entry.interactionId
+                );
+                var button = document.createElement('button');
+                button.type = 'button';
+                button.setAttribute('data-outline-interaction-id',
+                    entry.interactionId);
+                button.setAttribute('data-outline-filter-text',
+                    entry.userPreview.toLocaleLowerCase());
+                button.tabIndex = -1;
+
+                var number = document.createElement('span');
+                number.className = 'conversation-outline-number';
+                number.textContent = String(entry.inputNumber);
+                var preview = document.createElement('span');
+                preview.className = 'conversation-outline-preview';
+                preview.textContent = entry.userPreview || '(empty input)';
+                var responseState = document.createElement('span');
+                responseState.className = 'conversation-outline-state'
+                    + ' conversation-outline-state-' + entry.responseState;
+                responseState.title = responseStateLabel(entry.responseState);
+                responseState.setAttribute(
+                    'aria-label',
+                    responseStateLabel(entry.responseState)
+                );
+
+                button.appendChild(number);
+                button.appendChild(preview);
+                button.appendChild(responseState);
+                item.appendChild(bookmark);
+                item.appendChild(button);
+                fragment.appendChild(item);
+            });
+            outlineList.replaceChildren(fragment);
+            renderBookmarkState();
+        }
+
+        function visibleOutlineButtons() {
+            return Array.prototype.filter.call(
+                outlineList.querySelectorAll('[data-outline-interaction-id]'),
+                function (button) {
+                    return !button.closest('li').hidden;
+                }
+            );
+        }
+
+        function updateOutlineSelection(scrollSelected) {
+            var selected;
+            Array.prototype.forEach.call(
+                outlineList.querySelectorAll('[data-outline-interaction-id]'),
+                function (button) {
+                    var current = button.getAttribute(
+                        'data-outline-interaction-id'
+                    ) === state.outlineSelectedInteractionId;
+                    button.classList.toggle('is-selected', current);
+                    if (current) {
+                        button.setAttribute('aria-current', 'location');
+                        selected = button;
+                    } else {
+                        button.removeAttribute('aria-current');
+                    }
+                    button.tabIndex = current ? 0 : -1;
+                }
+            );
+            var visible = visibleOutlineButtons();
+            if (!visible.some(function (button) {
+                return button.tabIndex === 0;
+            }) && visible[0]) {
+                visible[0].tabIndex = 0;
+            }
+            if (scrollSelected
+                && selected
+                && outlinePanelActive()
+                && !selected.closest('li').hidden) {
+                selected.scrollIntoView({ block: 'nearest' });
+            }
+        }
+
+        function filterOutline() {
+            var query = state.outlineQuery.trim().toLocaleLowerCase();
+            var visibleCount = 0;
+            Array.prototype.forEach.call(
+                outlineList.querySelectorAll('.conversation-outline-item'),
+                function (item) {
+                    var button = item.querySelector(
+                        '[data-outline-interaction-id]'
+                    );
+                    var visible = !query
+                        || (button.getAttribute('data-outline-filter-text') || '')
+                            .includes(query);
+                    if (visible && state.bookmarksOnly) {
+                        visible = state.bookmarkIds.has(button.getAttribute(
+                            'data-outline-interaction-id'
+                        ));
+                    }
+                    item.hidden = !visible;
+                    if (visible) visibleCount += 1;
+                }
+            );
+            outlineEmpty.hidden = visibleCount > 0;
+            outlineEmpty.textContent = state.bookmarksOnly
+                ? 'No bookmarked inputs match this view.'
+                : 'No inputs match this search.';
+            updateOutlineSelection(false);
+        }
+
+        function applyOutline(message) {
+            if (!sidebarUiAvailable) return;
+            var selectedIndex = message.outline.findIndex(function (entry) {
+                return entry.interactionId === message.selectedInteractionId;
+            });
+            var offset = Math.max(
+                0,
+                message.selectedInput - selectedIndex - 1
+            );
+            var nextOutline = message.outline.map(function (entry, index) {
+                return Object.assign({}, entry, {
+                    inputNumber: offset + index + 1,
+                });
+            });
+            var changed = outlineChanged(nextOutline);
+            state.outline = nextOutline;
+            state.outlineSelectedInteractionId = message.selectedInteractionId;
+            state.outlineSelectedInput = message.selectedInput;
+            state.outlineTotalInputs = message.totalInputs;
+            state.outlinePartial = message.partial;
+            if (changed) buildOutlineList();
+            outlineCount.textContent = String(message.outline.length);
+            outlineCount.setAttribute(
+                'aria-label',
+                message.outline.length + ' inputs'
+            );
+            outlineSummary.textContent = message.partial
+                ? message.outline.length.toLocaleString() + '+ latest inputs'
+                : message.outline.length.toLocaleString() + ' inputs';
+            outlinePartial.hidden = !message.partial;
+            filterOutline();
+            renderBookmarkState();
+            updateOutlineSelection(changed || message.updateKind !== 'refresh');
+            updateToggle();
+        }
+
+        function attach() {
+            if (!sidebarUiAvailable) return;
+            outlineSearch.addEventListener('input', function () {
+                state.outlineQuery = outlineSearch.value;
+                filterOutline();
+                persistPanelState();
+            });
+            outlineBookmarksOnly.addEventListener('click', function () {
+                state.bookmarksOnly = !state.bookmarksOnly;
+                renderBookmarkState();
+                filterOutline();
+            });
+            outlineList.addEventListener('click', function (event) {
+                var bookmark = event.target.closest
+                    ? event.target.closest('[data-outline-bookmark-id]')
+                    : null;
+                if (bookmark && outlineList.contains(bookmark)) {
+                    var bookmarkId = bookmark.getAttribute(
+                        'data-outline-bookmark-id'
+                    );
+                    postBookmarkMutation(
+                        bookmarkId,
+                        !state.bookmarkIds.has(bookmarkId)
+                    );
+                    return;
+                }
+                var button = event.target.closest
+                    ? event.target.closest('[data-outline-interaction-id]')
+                    : null;
+                if (!button || !outlineList.contains(button)) return;
+                post({
+                    type: 'conversation-viewer-select-interaction',
+                    version: 1,
+                    interactionId: button.getAttribute(
+                        'data-outline-interaction-id'
+                    ),
+                });
+            });
+            outlineList.addEventListener('keydown', function (event) {
+                if (!['ArrowUp', 'ArrowDown', 'Home', 'End']
+                    .includes(event.key)) return;
+                var visible = visibleOutlineButtons();
+                if (!visible.length) return;
+                var current = event.target.closest
+                    ? event.target.closest('[data-outline-interaction-id]')
+                    : null;
+                var index = visible.indexOf(current);
+                if (event.key === 'Home') index = 0;
+                else if (event.key === 'End') index = visible.length - 1;
+                else if (event.key === 'ArrowUp') {
+                    index = Math.max(0, index - 1);
+                } else {
+                    index = Math.min(visible.length - 1, index + 1);
+                }
+                event.preventDefault();
+                visible.forEach(function (button) {
+                    button.tabIndex = -1;
+                });
+                visible[index].tabIndex = 0;
+                visible[index].focus();
+            });
+        }
+
+        function initializeBookmarks() {
+            var initialBookmarks = readJsonAttribute('data-initial-bookmarks');
+            if (validBookmarkSnapshot(initialBookmarks)) {
+                state.bookmarkRevision = initialBookmarks.revision;
+                state.bookmarkIds = new Set(initialBookmarks.interactionIds);
+                renderBookmarkState();
+            } else {
+                status.textContent = 'Conversation bookmarks are unavailable.';
+            }
+        }
+
+        function restoreQuery(value) {
+            if (typeof value !== 'string') return;
+            state.outlineQuery = value.slice(0, 4096);
+            outlineSearch.value = state.outlineQuery;
+        }
+
+        function query() {
+            return state.outlineQuery;
+        }
+
+        function size() {
+            return state.outline.length;
+        }
+
+        return Object.freeze({
+            applyBookmarksResult: applyBookmarksResult,
+            applyOutline: applyOutline,
+            attach: attach,
+            filter: filterOutline,
+            initializeBookmarks: initializeBookmarks,
+            query: query,
+            restoreQuery: restoreQuery,
+            size: size,
+        });
+    }
+
+    window.__agentPivotConversationOutline = Object.freeze({ create: create });
+}());

--- a/media/conversationTelemetryScripts.js
+++ b/media/conversationTelemetryScripts.js
@@ -1,0 +1,190 @@
+(function () {
+    'use strict';
+
+    function create(options) {
+        var commentTarget = options.target;
+        var subscriptionGeneration = options.subscriptionGeneration;
+        var latestRequestId = options.latestRequestId;
+        var telemetryRoot = options.telemetryRoot;
+        var telemetryModel = options.telemetryModel;
+        var telemetryModelValue = options.telemetryModelValue;
+        var telemetryContext = options.telemetryContext;
+        var telemetryContextProgress = options.telemetryContextProgress;
+        var telemetryContextValue = options.telemetryContextValue;
+        var telemetryLimits = options.telemetryLimits;
+        var scroll = options.scroll;
+        var captureAnchor = options.captureAnchor;
+        var restoreViewport = options.restoreViewport;
+        var state = {
+            latestTelemetryRequestId: 0,
+        };
+
+        function exactKeys(value, required, optional) {
+            if (!value || typeof value !== 'object' || Array.isArray(value)) {
+                return false;
+            }
+            var keys = Object.keys(value);
+            var allowed = new Set(required.concat(optional || []));
+            return required.every(function (key) {
+                return Object.prototype.hasOwnProperty.call(value, key);
+            }) && keys.every(function (key) {
+                return allowed.has(key);
+            });
+        }
+
+        function validTelemetry(value) {
+            if (!exactKeys(
+                value,
+                ['provider', 'sessionId', 'rateLimits'],
+                ['model', 'context']
+            )) return false;
+            if (!['codex', 'kimi', 'claude'].includes(value.provider)
+                || typeof value.sessionId !== 'string'
+                || !value.sessionId
+                || value.sessionId.length > 256
+                || (value.model !== undefined
+                    && (typeof value.model !== 'string'
+                        || !value.model
+                        || value.model.length > 128))
+                || !Array.isArray(value.rateLimits)
+                || value.rateLimits.length > 4) {
+                return false;
+            }
+            if (value.context !== undefined
+                && (!exactKeys(value.context, ['usedTokens', 'maxTokens'])
+                    || !Number.isSafeInteger(value.context.usedTokens)
+                    || value.context.usedTokens < 0
+                    || !Number.isSafeInteger(value.context.maxTokens)
+                    || value.context.maxTokens <= 0)) {
+                return false;
+            }
+            return value.rateLimits.every(function (limit) {
+                return exactKeys(
+                    limit,
+                    ['id', 'label', 'usedPercent'],
+                    ['windowDurationMins', 'resetsAt']
+                )
+                    && typeof limit.id === 'string'
+                    && limit.id.length > 0
+                    && limit.id.length <= 256
+                    && typeof limit.label === 'string'
+                    && limit.label.length > 0
+                    && limit.label.length <= 64
+                    && Number.isFinite(limit.usedPercent)
+                    && limit.usedPercent >= 0
+                    && limit.usedPercent <= 100
+                    && (limit.windowDurationMins === undefined
+                        || (Number.isSafeInteger(limit.windowDurationMins)
+                            && limit.windowDurationMins > 0))
+                    && (limit.resetsAt === undefined
+                        || (Number.isSafeInteger(limit.resetsAt)
+                            && limit.resetsAt > 0));
+            });
+        }
+
+        function compactTokens(value) {
+            if (value >= 1000000) {
+                return (value / 1000000).toFixed(value >= 10000000 ? 0 : 1) + 'm';
+            }
+            if (value >= 1000) {
+                return (value / 1000).toFixed(value >= 100000 ? 0 : 1) + 'k';
+            }
+            return String(value);
+        }
+
+        function compactResetTime(resetsAt) {
+            var remainingMinutes = Math.max(
+                1,
+                Math.ceil((resetsAt * 1000 - Date.now()) / 60000)
+            );
+            if (remainingMinutes < 60) return remainingMinutes + 'm';
+            var remainingHours = Math.ceil(remainingMinutes / 60);
+            if (remainingHours < 48) return remainingHours + 'h';
+            return Math.ceil(remainingHours / 24) + 'd';
+        }
+
+        function applyTelemetry(message) {
+            if (!exactKeys(
+                message,
+                ['type', 'version', 'requestId', 'subscriptionGeneration', 'telemetry']
+            )
+                || message.type !== 'conversation-viewer-telemetry'
+                || message.version !== 1
+                || !Number.isSafeInteger(message.requestId)
+                || message.requestId < latestRequestId()
+                || message.requestId < state.latestTelemetryRequestId
+                || message.subscriptionGeneration !== subscriptionGeneration
+                || (message.telemetry !== null
+                    && !validTelemetry(message.telemetry))
+                || (message.telemetry !== null
+                    && (!commentTarget
+                        || message.telemetry.provider !== commentTarget.provider
+                        || message.telemetry.sessionId !== commentTarget.sessionId))
+                || !telemetryRoot || !telemetryModel || !telemetryModelValue
+                || !telemetryContext || !telemetryContextProgress
+                || !telemetryContextValue || !telemetryLimits) {
+                return false;
+            }
+            state.latestTelemetryRequestId = message.requestId;
+            var readingAnchor = captureAnchor();
+            var previousScrollTop = scroll.scrollTop;
+            var telemetry = message.telemetry;
+            if (!telemetry) {
+                telemetryRoot.hidden = true;
+                restoreViewport(
+                    readingAnchor,
+                    previousScrollTop
+                );
+                return true;
+            }
+            telemetryModel.hidden = !telemetry.model;
+            telemetryModelValue.textContent = telemetry.model || '';
+            telemetryContext.hidden = !telemetry.context;
+            if (telemetry.context) {
+                var percent = Math.max(0, Math.min(
+                    100,
+                    telemetry.context.usedTokens
+                        / telemetry.context.maxTokens * 100
+                ));
+                telemetryContextProgress.max = telemetry.context.maxTokens;
+                telemetryContextProgress.value = telemetry.context.usedTokens;
+                telemetryContextValue.textContent = Math.round(percent) + '% · '
+                    + compactTokens(telemetry.context.usedTokens) + ' / '
+                    + compactTokens(telemetry.context.maxTokens);
+            }
+            telemetryLimits.replaceChildren();
+            telemetry.rateLimits.forEach(function (limit) {
+                var meter = document.createElement('div');
+                meter.className = 'conversation-telemetry-meter';
+                var label = document.createElement('span');
+                label.textContent = limit.label;
+                var progress = document.createElement('progress');
+                progress.max = 100;
+                progress.value = limit.usedPercent;
+                progress.setAttribute('aria-label', limit.label + ' usage');
+                var value = document.createElement('span');
+                var text = Math.round(100 - limit.usedPercent) + '% left';
+                if (limit.resetsAt) {
+                    text += ' · resets in ' + compactResetTime(limit.resetsAt);
+                    value.title = new Date(
+                        limit.resetsAt * 1000
+                    ).toLocaleString();
+                }
+                value.textContent = text;
+                meter.append(label, progress, value);
+                telemetryLimits.appendChild(meter);
+            });
+            telemetryRoot.hidden = !telemetry.model
+                && !telemetry.context
+                && telemetry.rateLimits.length === 0;
+            restoreViewport(readingAnchor, previousScrollTop);
+            return true;
+        }
+
+        return Object.freeze({
+            apply: applyTelemetry,
+        });
+    }
+
+    window.__agentPivotConversationTelemetry = Object.freeze({ create: create });
+}());

--- a/media/conversationViewerScripts.js
+++ b/media/conversationViewerScripts.js
@@ -122,13 +122,6 @@
         messageSignatures: new Map(),
         firstNewMessageId: null,
         renderGeneration: 0,
-        comments: [],
-        commentRevision: 0,
-        commentRequestSequence: 0,
-        pendingCommentRequest: null,
-        pendingLocateRequest: null,
-        clearAllConfirmation: false,
-        selectedCommentText: null,
         commentsPanelOpen: true,
         commentsPanelWidth: 240,
         sidebarView: 'outline',
@@ -192,6 +185,33 @@
         scroll: scroll,
         captureAnchor: captureReadingAnchor,
         restoreViewport: restoreViewportReadingPosition,
+    });
+    var commentsController = window.__agentPivotConversationComments.create({
+        available: commentUiAvailable,
+        target: commentTarget,
+        subscriptionGeneration: state.subscriptionGeneration,
+        status: status,
+        messages: messages,
+        scroll: scroll,
+        addComment: addComment,
+        commentsRoot: commentsRoot,
+        commentCount: commentCount,
+        commentSummary: commentSummary,
+        commentComposer: commentComposer,
+        commentSelection: commentSelection,
+        commentInput: commentInput,
+        commentList: commentList,
+        commentEmpty: commentEmpty,
+        commentNew: commentNew,
+        commentSend: commentSend,
+        commentClearSent: commentClearSent,
+        commentClearResolved: commentClearResolved,
+        commentClearAll: commentClearAll,
+        post: post,
+        messageSelector: conversationMessageSelector,
+        messageId: conversationMessageId,
+        setSidebarView: setSidebarView,
+        updateToggle: updateCommentsToggle,
     });
 
     if (!scroll || !messages || !position || !status || !newResponse
@@ -273,7 +293,8 @@
                 ? 'true'
                 : 'false'
         );
-        commentsToggle.textContent = 'Comments (' + openCommentCount()
+        commentsToggle.textContent = 'Comments ('
+            + commentsController.openCount()
             + ' open)';
         commentsToggle.setAttribute(
             'aria-expanded',
@@ -475,634 +496,6 @@
                 || value.provider === 'claude')
             && typeof value.sessionId === 'string'
             && value.sessionId.length > 0;
-    }
-
-    function validComment(value) {
-        if (!value || typeof value !== 'object' || Array.isArray(value)) {
-            return false;
-        }
-        var keys = [
-            'id', 'messageId', 'interactionId', 'role',
-            'quote', 'prefix', 'suffix', 'comment', 'status',
-        ];
-        var actualKeys = Object.keys(value);
-        var hasSessionScope = value.scope === 'session';
-        return actualKeys.length === keys.length + (hasSessionScope ? 1 : 0)
-            && keys.every(function (key) {
-                return Object.prototype.hasOwnProperty.call(value, key);
-            })
-            && (value.scope === undefined || hasSessionScope)
-            && typeof value.id === 'string'
-            && typeof value.messageId === 'string'
-            && typeof value.interactionId === 'string'
-            && (value.role === 'user' || value.role === 'assistant')
-            && typeof value.quote === 'string'
-            && typeof value.prefix === 'string'
-            && typeof value.suffix === 'string'
-            && typeof value.comment === 'string'
-            && (!hasSessionScope
-                || (value.messageId === ''
-                    && value.interactionId === ''
-                    && value.role === 'user'
-                    && value.quote === ''
-                    && value.prefix === ''
-                    && value.suffix === ''))
-            && (value.status === 'open'
-                || value.status === 'sent'
-                || value.status === 'resolved');
-    }
-
-    function validInitialComments(value) {
-        return value && typeof value === 'object' && !Array.isArray(value)
-            && Object.keys(value).length === 2
-            && Number.isSafeInteger(value.revision)
-            && value.revision >= 0
-            && Array.isArray(value.comments)
-            && value.comments.length <= 20
-            && value.comments.every(validComment);
-    }
-
-    function validCommentsResult(value) {
-        if (!value || typeof value !== 'object' || Array.isArray(value)) {
-            return false;
-        }
-        var required = [
-            'type', 'version', 'requestId', 'subscriptionGeneration',
-            'projectId', 'provider', 'sessionId', 'operation', 'success',
-            'revision', 'comments',
-        ];
-        var allowed = new Set(required.concat(['error']));
-        return Object.keys(value).every(function (key) {
-            return allowed.has(key);
-        }) && required.every(function (key) {
-            return Object.prototype.hasOwnProperty.call(value, key);
-        })
-            && value.type === 'conversation-viewer-comments-result'
-            && value.version === 1
-            && typeof value.requestId === 'string'
-            && Number.isSafeInteger(value.subscriptionGeneration)
-            && typeof value.projectId === 'string'
-            && (value.provider === 'codex'
-                || value.provider === 'kimi'
-                || value.provider === 'claude')
-            && typeof value.sessionId === 'string'
-            && (value.operation === 'add'
-                || value.operation === 'update'
-                || value.operation === 'delete'
-                || value.operation === 'resolve'
-                || value.operation === 'reopen'
-                || value.operation === 'clearSent'
-                || value.operation === 'clearResolved'
-                || value.operation === 'clearAll'
-                || value.operation === 'sendComments')
-            && typeof value.success === 'boolean'
-            && Number.isSafeInteger(value.revision)
-            && value.revision >= 0
-            && Array.isArray(value.comments)
-            && value.comments.length <= 20
-            && value.comments.every(validComment)
-            && (value.error === undefined || [
-                'invalid', 'stale', 'limit', 'tooLarge',
-                'unavailable', 'busy', 'conflict', 'failed',
-            ].includes(value.error));
-    }
-
-    function validLocateResult(value) {
-        if (!value || typeof value !== 'object' || Array.isArray(value)) {
-            return false;
-        }
-        var required = [
-            'type', 'version', 'requestId', 'subscriptionGeneration',
-            'projectId', 'provider', 'sessionId', 'commentId', 'success',
-        ];
-        var allowed = new Set(required.concat(['error']));
-        return Object.keys(value).every(function (key) {
-            return allowed.has(key);
-        }) && required.every(function (key) {
-            return Object.prototype.hasOwnProperty.call(value, key);
-        })
-            && value.type === 'conversation-viewer-locate-comment-result'
-            && value.version === 1
-            && typeof value.requestId === 'string'
-            && Number.isSafeInteger(value.subscriptionGeneration)
-            && typeof value.projectId === 'string'
-            && (value.provider === 'codex'
-                || value.provider === 'kimi'
-                || value.provider === 'claude')
-            && typeof value.sessionId === 'string'
-            && typeof value.commentId === 'string'
-            && typeof value.success === 'boolean'
-            && (value.error === undefined || value.error === 'stale');
-    }
-
-    function openCommentCount() {
-        return state.comments.filter(function (comment) {
-            return comment.status === 'open';
-        }).length;
-    }
-
-    function commentStatusCounts() {
-        return state.comments.reduce(function (counts, comment) {
-            counts[comment.status] += 1;
-            return counts;
-        }, { open: 0, sent: 0, resolved: 0 });
-    }
-
-    function resetClearAllConfirmation() {
-        if (!commentUiAvailable) return;
-        state.clearAllConfirmation = false;
-        commentClearAll.textContent = 'Clear all';
-        commentClearAll.removeAttribute('data-confirming');
-        commentClearAll.setAttribute('aria-label', 'Clear all comments');
-    }
-
-    function updateCommentControls() {
-        if (!commentUiAvailable) return;
-        var counts = commentStatusCounts();
-        var pending = !!state.pendingCommentRequest
-            || !!state.pendingLocateRequest;
-        var summary = [];
-        if (counts.open) summary.push(counts.open + ' open');
-        if (counts.sent) summary.push(counts.sent + ' added');
-        if (counts.resolved) summary.push(counts.resolved + ' resolved');
-        commentSummary.textContent = summary.length
-            ? summary.join(' · ')
-            : 'No comments yet';
-        commentCount.textContent = String(state.comments.length);
-        commentCount.setAttribute(
-            'aria-label',
-            state.comments.length + ' comment'
-                + (state.comments.length === 1 ? '' : 's')
-        );
-        commentSend.disabled = counts.open === 0 || pending;
-        commentNew.disabled = pending;
-        commentClearSent.disabled = counts.sent === 0 || pending;
-        commentClearResolved.disabled = counts.resolved === 0 || pending;
-        commentClearAll.disabled = state.comments.length === 0 || pending;
-    }
-
-    function nextCommentRequestId() {
-        state.commentRequestSequence += 1;
-        return [
-            'conversation-comment',
-            Date.now().toString(36),
-            state.commentRequestSequence.toString(36),
-        ].join(':');
-    }
-
-    function commentErrorMessage(error) {
-        if (error === 'stale') return 'Comments changed. Review the latest draft and try again.';
-        if (error === 'limit') return 'A maximum of 20 comments can be added at once.';
-        if (error === 'tooLarge') return 'The combined comments are too large to send.';
-        if (error === 'busy') return 'Wait for the current AI response to finish, then send again.';
-        if (error === 'conflict') return 'Multiple runtimes match this session. Resolve the conflict first.';
-        if (error === 'unavailable') return 'This session is unavailable and the comments were not added.';
-        return 'The comment action failed. Your comments were kept.';
-    }
-
-    function setCommentPending(pending) {
-        if (!commentUiAvailable) return;
-        Array.prototype.forEach.call(
-            commentsRoot.querySelectorAll('button, textarea'),
-            function (control) {
-                control.disabled = pending;
-            }
-        );
-        addComment.disabled = pending;
-        if (!pending) {
-            updateCommentControls();
-        }
-        commentsRoot.setAttribute('aria-busy', pending ? 'true' : 'false');
-    }
-
-    function postCommentOperation(operation, payload) {
-        if (!commentUiAvailable
-            || state.pendingCommentRequest
-            || state.pendingLocateRequest) return;
-        var requestId = nextCommentRequestId();
-        resetClearAllConfirmation();
-        state.pendingCommentRequest = { requestId: requestId, operation: operation };
-        setCommentPending(true);
-        status.textContent = operation === 'sendComments'
-            ? 'Adding comments to session input…'
-            : operation === 'clearSent'
-                || operation === 'clearResolved'
-                || operation === 'clearAll'
-                ? 'Clearing comments…'
-                : 'Saving comment…';
-        post({
-            type: operation === 'sendComments'
-                ? 'conversation-viewer-send-comments'
-                : 'conversation-viewer-comment-mutation',
-            version: 1,
-            requestId: requestId,
-            subscriptionGeneration: state.subscriptionGeneration,
-            projectId: commentTarget.projectId,
-            provider: commentTarget.provider,
-            sessionId: commentTarget.sessionId,
-            operation: operation,
-            expectedRevision: state.commentRevision,
-            payload: payload,
-        });
-    }
-
-    function locateComment(comment) {
-        if (comment.scope === 'session') return false;
-        var message = Array.prototype.find.call(
-            messages.querySelectorAll(conversationMessageSelector()),
-            function (candidate) {
-                return conversationMessageId(candidate) === comment.messageId;
-            }
-        );
-        if (!message) {
-            return false;
-        }
-        message.scrollIntoView({ block: 'center' });
-        message.tabIndex = -1;
-        message.focus({ preventScroll: true });
-        message.classList.add('conversation-comment-located');
-        window.setTimeout(function () {
-            message.classList.remove('conversation-comment-located');
-        }, 1600);
-        return true;
-    }
-
-    function requestCommentLocation(comment) {
-        if (locateComment(comment)) {
-            status.textContent = 'Comment source located.';
-            return;
-        }
-        if (state.pendingLocateRequest || state.pendingCommentRequest) return;
-        var requestId = nextCommentRequestId();
-        state.pendingLocateRequest = {
-            requestId: requestId,
-            commentId: comment.id,
-        };
-        setCommentPending(true);
-        status.textContent = 'Loading the commented message…';
-        post({
-            type: 'conversation-viewer-locate-comment',
-            version: 1,
-            requestId: requestId,
-            subscriptionGeneration: state.subscriptionGeneration,
-            projectId: commentTarget.projectId,
-            provider: commentTarget.provider,
-            sessionId: commentTarget.sessionId,
-            commentId: comment.id,
-        });
-    }
-
-    function renderComments() {
-        if (!commentUiAvailable) return;
-        resetClearAllConfirmation();
-        commentList.replaceChildren();
-        state.comments.forEach(function (comment, index) {
-            var item = document.createElement('article');
-            item.className = 'conversation-comment';
-            item.setAttribute('data-comment-id', comment.id);
-            item.setAttribute('data-comment-status', comment.status);
-            item.setAttribute(
-                'data-comment-scope',
-                comment.scope === 'session' ? 'session' : 'selection'
-            );
-
-            var heading = document.createElement('div');
-            heading.className = 'conversation-comment-heading';
-            var identity = document.createElement('div');
-            identity.className = 'conversation-comment-identity';
-            var label = document.createElement('strong');
-            label.textContent = 'Comment ' + (index + 1);
-            if (comment.scope === 'session') {
-                var scope = document.createElement('span');
-                scope.className = 'conversation-comment-scope';
-                scope.textContent = 'Session note';
-                identity.append(label, scope);
-            } else {
-                identity.appendChild(label);
-            }
-            var statusLabel = document.createElement('span');
-            statusLabel.className = 'conversation-comment-status';
-            statusLabel.setAttribute('data-comment-status-label', '');
-            statusLabel.textContent = comment.status === 'open'
-                ? 'Open'
-                : comment.status === 'sent' ? 'Added' : 'Resolved';
-            identity.appendChild(statusLabel);
-            heading.appendChild(identity);
-            if (comment.scope !== 'session') {
-                var locate = document.createElement('button');
-                locate.type = 'button';
-                locate.className = 'conversation-comment-locate';
-                locate.setAttribute('data-comment-action', 'locate');
-                locate.textContent = 'Show text';
-                heading.appendChild(locate);
-            }
-
-            var quoteGroup = document.createElement('div');
-            quoteGroup.className = 'conversation-comment-quote';
-            var quoteLabel = document.createElement('span');
-            quoteLabel.className = 'conversation-comment-quote-label';
-            quoteLabel.textContent = 'Selected text';
-            var quote = document.createElement('blockquote');
-            quote.textContent = comment.quote;
-            quoteGroup.append(quoteLabel, quote);
-            var input = document.createElement('textarea');
-            input.rows = 2;
-            input.maxLength = 4000;
-            input.value = comment.comment;
-            input.readOnly = comment.status !== 'open';
-            input.setAttribute('aria-label', 'Comment ' + (index + 1));
-            input.setAttribute(
-                'aria-keyshortcuts',
-                'Control+Enter Meta+Enter'
-            );
-            input.setAttribute('data-comment-edit', '');
-            var actions = document.createElement('div');
-            actions.className = 'conversation-comment-actions';
-            var remove = document.createElement('button');
-            remove.type = 'button';
-            remove.className = 'conversation-comment-delete';
-            remove.setAttribute('data-comment-action', 'delete');
-            remove.textContent = 'Delete';
-            actions.appendChild(remove);
-            if (comment.status === 'open') {
-                var save = document.createElement('button');
-                save.type = 'button';
-                save.setAttribute('data-comment-action', 'update');
-                save.title = 'Save comment (Ctrl+Enter or Cmd+Enter)';
-                save.textContent = 'Save';
-                actions.appendChild(save);
-            }
-            var review = document.createElement('button');
-            review.type = 'button';
-            if (comment.status === 'resolved') {
-                review.setAttribute('data-comment-action', 'reopen');
-                review.textContent = 'Reopen';
-            } else if (comment.status === 'sent') {
-                review.setAttribute('data-comment-action', 'resolve');
-                review.textContent = 'Resolve';
-                var reopen = document.createElement('button');
-                reopen.type = 'button';
-                reopen.setAttribute('data-comment-action', 'reopen');
-                reopen.textContent = 'Reopen';
-                actions.appendChild(reopen);
-            } else {
-                review.setAttribute('data-comment-action', 'resolve');
-                review.textContent = 'Resolve';
-            }
-            actions.appendChild(review);
-            item.appendChild(heading);
-            if (comment.scope !== 'session') {
-                item.appendChild(quoteGroup);
-            }
-            item.append(input, actions);
-            commentList.appendChild(item);
-        });
-        updateCommentsToggle();
-        commentEmpty.hidden = state.comments.length > 0;
-        var openCount = openCommentCount();
-        commentSend.textContent = 'Send ' + openCount + ' open comment'
-            + (openCount === 1 ? '' : 's') + ' to this session';
-        updateCommentControls();
-        updateCommentHighlights();
-    }
-
-    function findQuoteRange(root, comment) {
-        var walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
-        var nodes = [];
-        var combined = '';
-        var node;
-        while ((node = walker.nextNode())) {
-            nodes.push({ node: node, start: combined.length });
-            combined += node.nodeValue || '';
-        }
-        var candidates = [];
-        var candidate = combined.indexOf(comment.quote);
-        while (candidate >= 0) {
-            candidates.push(candidate);
-            candidate = combined.indexOf(
-                comment.quote,
-                candidate + 1
-            );
-        }
-        var start = candidates.find(function (offset) {
-            var before = combined.slice(
-                Math.max(0, offset - comment.prefix.length),
-                offset
-            );
-            var after = combined.slice(
-                offset + comment.quote.length,
-                offset + comment.quote.length + comment.suffix.length
-            );
-            return before === comment.prefix && after === comment.suffix;
-        });
-        if (start === undefined) start = candidates[0];
-        if (start === undefined) return null;
-        var end = start + comment.quote.length;
-        var startRecord = nodes.find(function (record) {
-            return start >= record.start
-                && start <= record.start + (record.node.nodeValue || '').length;
-        });
-        var endRecord = nodes.find(function (record) {
-            return end >= record.start
-                && end <= record.start + (record.node.nodeValue || '').length;
-        });
-        if (!startRecord || !endRecord) return null;
-        var range = document.createRange();
-        range.setStart(startRecord.node, start - startRecord.start);
-        range.setEnd(endRecord.node, end - endRecord.start);
-        return range;
-    }
-
-    function updateCommentHighlights() {
-        if (!commentUiAvailable) return;
-        Array.prototype.forEach.call(
-            messages.querySelectorAll('.conversation-has-comment'),
-            function (message) {
-                message.classList.remove('conversation-has-comment');
-            }
-        );
-        var ranges = [];
-        state.comments.forEach(function (comment) {
-            if (comment.status === 'resolved'
-                || comment.scope === 'session') return;
-            var message = Array.prototype.find.call(
-                messages.querySelectorAll(conversationMessageSelector()),
-                function (candidate) {
-                    return conversationMessageId(candidate)
-                        === comment.messageId;
-                }
-            );
-            if (!message) return;
-            message.classList.add('conversation-has-comment');
-            var markdown = message.querySelector('.conversation-markdown');
-            var range = markdown && findQuoteRange(markdown, comment);
-            if (range) ranges.push(range);
-        });
-        if (window.CSS && CSS.highlights && typeof Highlight === 'function') {
-            CSS.highlights.delete('conversation-comments');
-            if (ranges.length) {
-                CSS.highlights.set(
-                    'conversation-comments',
-                    new Highlight(...ranges)
-                );
-            }
-        }
-    }
-
-    function applyCommentsResult(message) {
-        if (!commentUiAvailable
-            || !validCommentsResult(message)
-            || message.subscriptionGeneration !== state.subscriptionGeneration
-            || message.projectId !== commentTarget.projectId
-            || message.provider !== commentTarget.provider
-            || message.sessionId !== commentTarget.sessionId
-            || !state.pendingCommentRequest
-            || message.requestId !== state.pendingCommentRequest.requestId
-            || message.operation !== state.pendingCommentRequest.operation) {
-            return false;
-        }
-        state.commentRevision = message.revision;
-        state.comments = message.comments.map(function (comment) {
-            return Object.assign({}, comment);
-        });
-        renderComments();
-        var operation = state.pendingCommentRequest.operation;
-        state.pendingCommentRequest = null;
-        setCommentPending(false);
-        if (message.success) {
-            status.textContent = operation === 'sendComments'
-                ? 'Comments added to session input. Review and press Enter to send.'
-                : operation === 'clearSent'
-                    ? 'Added comments cleared.'
-                    : operation === 'clearResolved'
-                        ? 'Resolved comments cleared.'
-                        : operation === 'clearAll'
-                            ? 'All comments cleared.'
-                            : 'Comments saved.';
-        } else {
-            status.textContent = commentErrorMessage(message.error);
-        }
-        return true;
-    }
-
-    function applyLocateResult(message) {
-        if (!commentUiAvailable
-            || !validLocateResult(message)
-            || message.subscriptionGeneration !== state.subscriptionGeneration
-            || message.projectId !== commentTarget.projectId
-            || message.provider !== commentTarget.provider
-            || message.sessionId !== commentTarget.sessionId
-            || !state.pendingLocateRequest
-            || message.requestId !== state.pendingLocateRequest.requestId
-            || message.commentId !== state.pendingLocateRequest.commentId) {
-            return false;
-        }
-        var comment = state.comments.find(function (candidate) {
-            return candidate.id === message.commentId;
-        });
-        state.pendingLocateRequest = null;
-        setCommentPending(false);
-        if (message.success && comment && locateComment(comment)) {
-            status.textContent = 'Comment source located.';
-        } else {
-            status.textContent = 'The commented message is no longer available.';
-        }
-        return true;
-    }
-
-    function selectionContext(range, markdown) {
-        var before = document.createRange();
-        before.selectNodeContents(markdown);
-        before.setEnd(range.startContainer, range.startOffset);
-        var after = document.createRange();
-        after.selectNodeContents(markdown);
-        after.setStart(range.endContainer, range.endOffset);
-        return {
-            prefix: before.toString().slice(-240),
-            suffix: after.toString().slice(0, 240),
-        };
-    }
-
-    function captureCommentSelection() {
-        if (!commentUiAvailable || state.pendingCommentRequest) return;
-        var selection = window.getSelection();
-        if (!selection || selection.rangeCount !== 1 || selection.isCollapsed) {
-            addComment.hidden = true;
-            state.selectedCommentText = null;
-            return;
-        }
-        var range = selection.getRangeAt(0);
-        var startElement = range.startContainer.nodeType === Node.ELEMENT_NODE
-            ? range.startContainer
-            : range.startContainer.parentElement;
-        var endElement = range.endContainer.nodeType === Node.ELEMENT_NODE
-            ? range.endContainer
-            : range.endContainer.parentElement;
-        var startMessage = startElement && startElement.closest
-            ? startElement.closest(conversationMessageSelector())
-            : null;
-        var endMessage = endElement && endElement.closest
-            ? endElement.closest(conversationMessageSelector())
-            : null;
-        var markdown = startElement && startElement.closest
-            ? startElement.closest('.conversation-markdown')
-            : null;
-        var quote = selection.toString().trim();
-        if (!startMessage || startMessage !== endMessage || !markdown
-            || !messages.contains(startMessage) || !quote
-            || Array.from(quote).length > 4000) {
-            addComment.hidden = true;
-            state.selectedCommentText = null;
-            return;
-        }
-        var context = selectionContext(range, markdown);
-        state.selectedCommentText = {
-            messageId: conversationMessageId(startMessage),
-            interactionId: startMessage.getAttribute('data-interaction-id'),
-            quote: quote,
-            prefix: context.prefix,
-            suffix: context.suffix,
-        };
-        var rect = range.getBoundingClientRect();
-        addComment.style.left = Math.max(
-            8,
-            Math.min(window.innerWidth - 120, rect.left)
-        ) + 'px';
-        addComment.style.top = Math.max(8, rect.bottom + 6) + 'px';
-        addComment.hidden = false;
-    }
-
-    function openCommentComposer() {
-        if (!state.selectedCommentText) return;
-        setSidebarView('comments', true, true);
-        addComment.hidden = true;
-        commentSelection.textContent = state.selectedCommentText.quote;
-        commentComposer.setAttribute('data-comment-composer-scope', 'selection');
-        commentInput.value = '';
-        commentComposer.hidden = false;
-        commentInput.focus();
-    }
-
-    function openSessionCommentComposer() {
-        if (!commentUiAvailable
-            || state.pendingCommentRequest
-            || state.pendingLocateRequest) return;
-        setSidebarView('comments', true, true);
-        addComment.hidden = true;
-        state.selectedCommentText = { scope: 'session' };
-        commentSelection.textContent = 'Session note';
-        commentComposer.setAttribute('data-comment-composer-scope', 'session');
-        commentInput.value = '';
-        commentComposer.hidden = false;
-        commentInput.focus();
-    }
-
-    function closeCommentComposer() {
-        commentComposer.hidden = true;
-        commentComposer.removeAttribute('data-comment-composer-scope');
-        commentInput.value = '';
-        state.selectedCommentText = null;
-        addComment.hidden = true;
     }
 
     function validOutlineEntry(entry) {
@@ -1324,7 +717,7 @@
         state.atLatest = message.atLatest;
         state.initialized = true;
         outlineController.applyOutline(message);
-        updateCommentHighlights();
+        commentsController.updateHighlights();
         updatePosition(message);
         previous.disabled = message.previousCursor === undefined;
         next.disabled = message.nextCursor === undefined;
@@ -1556,153 +949,12 @@
         });
     });
     if (commentUiAvailable) {
-        messages.addEventListener('mouseup', function () {
-            window.setTimeout(captureCommentSelection, 0);
-        });
-        messages.addEventListener('keyup', function (event) {
-            if (event.key === 'Shift'
-                || event.key.startsWith('Arrow')
-                || event.key === 'Home'
-                || event.key === 'End') {
-                window.setTimeout(captureCommentSelection, 0);
-            }
-        });
-        scroll.addEventListener('scroll', function () {
-            addComment.hidden = true;
-        });
-        addComment.addEventListener('click', openCommentComposer);
-        commentsRoot.addEventListener('click', function (event) {
-            var button = event.target && event.target.closest
-                ? event.target.closest('[data-comment-action]')
-                : null;
-            if (!button || !commentsRoot.contains(button)
-                || state.pendingCommentRequest
-                || state.pendingLocateRequest) {
-                return;
-            }
-            var action = button.getAttribute('data-comment-action');
-            if (action !== 'clearAll' && state.clearAllConfirmation) {
-                resetClearAllConfirmation();
-            }
-            if (action === 'new') {
-                openSessionCommentComposer();
-                return;
-            }
-            if (action === 'cancel-add') {
-                closeCommentComposer();
-                return;
-            }
-            if (action === 'confirm-add') {
-                var text = commentInput.value.trim();
-                if (!state.selectedCommentText || !text) {
-                    status.textContent = 'Enter a comment before adding it.';
-                    commentInput.focus();
-                    return;
-                }
-                var payload = Object.assign(
-                    {},
-                    state.selectedCommentText,
-                    { comment: text }
-                );
-                closeCommentComposer();
-                postCommentOperation('add', payload);
-                return;
-            }
-            if (action === 'send') {
-                postCommentOperation('sendComments', {});
-                return;
-            }
-            if (action === 'clearSent' || action === 'clearResolved') {
-                postCommentOperation(action, {});
-                return;
-            }
-            if (action === 'clearAll') {
-                if (!state.clearAllConfirmation) {
-                    state.clearAllConfirmation = true;
-                    commentClearAll.textContent = 'Confirm clear all';
-                    commentClearAll.setAttribute('data-confirming', 'true');
-                    commentClearAll.setAttribute(
-                        'aria-label',
-                        'Confirm clearing all comments'
-                    );
-                    status.textContent =
-                        'Select Clear all again to remove every comment.';
-                    return;
-                }
-                postCommentOperation('clearAll', {});
-                return;
-            }
-            var item = button.closest('[data-comment-id]');
-            var commentId = item && item.getAttribute('data-comment-id');
-            var comment = state.comments.find(function (candidate) {
-                return candidate.id === commentId;
-            });
-            if (!item || !comment) return;
-            if (action === 'locate') {
-                requestCommentLocation(comment);
-                return;
-            }
-            if (action === 'delete') {
-                postCommentOperation('delete', { commentId: comment.id });
-                return;
-            }
-            if (action === 'resolve' || action === 'reopen') {
-                postCommentOperation(action, { commentId: comment.id });
-                return;
-            }
-            if (action === 'update') {
-                var edit = item.querySelector('[data-comment-edit]');
-                var updated = edit ? edit.value.trim() : '';
-                if (!updated) {
-                    status.textContent = 'A comment cannot be empty.';
-                    if (edit) edit.focus();
-                    return;
-                }
-                postCommentOperation('update', {
-                    commentId: comment.id,
-                    comment: updated,
-                });
-            }
-        });
+        commentsController.attach();
     }
     document.addEventListener('keydown', function (event) {
-        if (commentUiAvailable
-            && event.key === 'Enter'
-            && (event.ctrlKey || event.metaKey)
-            && !event.altKey) {
-            var target = event.target;
-            if (target === commentInput && !commentComposer.hidden) {
-                event.preventDefault();
-                commentComposer.querySelector(
-                    '[data-comment-action="confirm-add"]'
-                )?.click();
-                return;
-            }
-            if (target && target.matches?.('[data-comment-edit]')) {
-                var item = target.closest('[data-comment-id]');
-                var save = item?.querySelector(
-                    '[data-comment-action="update"]'
-                );
-                if (save) {
-                    event.preventDefault();
-                    save.click();
-                    return;
-                }
-            }
-        }
+        if (commentsController.handleEnterShortcut(event)) return;
         if (event.key !== 'Escape') return;
-        if (commentUiAvailable && state.clearAllConfirmation) {
-            event.preventDefault();
-            resetClearAllConfirmation();
-            status.textContent = 'Clear all cancelled.';
-            commentClearAll.focus();
-            return;
-        }
-        if (commentUiAvailable && !commentComposer.hidden) {
-            event.preventDefault();
-            closeCommentComposer();
-            return;
-        }
+        if (commentsController.handleEscape(event)) return;
         if (sidebarUiAvailable
             && state.commentsPanelOpen
             && sidebarRoot.contains(document.activeElement)) {
@@ -1717,8 +969,8 @@
     });
     window.addEventListener('message', function (event) {
         if (outlineController.applyBookmarksResult(event.data)) return;
-        if (applyCommentsResult(event.data)) return;
-        if (applyLocateResult(event.data)) return;
+        if (commentsController.applyCommentsResult(event.data)) return;
+        if (commentsController.applyLocateResult(event.data)) return;
         if (telemetryController.apply(event.data)) return;
         applyPage(event.data);
     });
@@ -1755,15 +1007,6 @@
         outlineController.filter();
     }
     if (commentUiAvailable) {
-        var initialComments = readJsonAttribute('data-initial-comments');
-        if (validInitialComments(initialComments)) {
-            state.commentRevision = initialComments.revision;
-            state.comments = initialComments.comments.map(function (comment) {
-                return Object.assign({}, comment);
-            });
-            renderComments();
-        } else {
-            status.textContent = 'Comment drafts are unavailable.';
-        }
+        commentsController.initializeComments();
     }
 }());

--- a/media/conversationViewerScripts.js
+++ b/media/conversationViewerScripts.js
@@ -115,7 +115,6 @@
         followingEnd: false,
         initialized: false,
         latestRequestId: 0,
-        latestTelemetryRequestId: 0,
         subscriptionGeneration: Number(document.body.getAttribute(
             'data-subscription-generation'
         )),
@@ -176,6 +175,23 @@
         },
         persistPanelState: saveCommentsPanelState,
         updateToggle: updateCommentsToggle,
+    });
+    var telemetryController = window.__agentPivotConversationTelemetry.create({
+        target: commentTarget,
+        subscriptionGeneration: state.subscriptionGeneration,
+        latestRequestId: function () {
+            return state.latestRequestId;
+        },
+        telemetryRoot: telemetryRoot,
+        telemetryModel: telemetryModel,
+        telemetryModelValue: telemetryModelValue,
+        telemetryContext: telemetryContext,
+        telemetryContextProgress: telemetryContextProgress,
+        telemetryContextValue: telemetryContextValue,
+        telemetryLimits: telemetryLimits,
+        scroll: scroll,
+        captureAnchor: captureReadingAnchor,
+        restoreViewport: restoreViewportReadingPosition,
     });
 
     if (!scroll || !messages || !position || !status || !newResponse
@@ -1166,168 +1182,6 @@
             && typeof message.stale === 'boolean';
     }
 
-    function exactKeys(value, required, optional) {
-        if (!value || typeof value !== 'object' || Array.isArray(value)) {
-            return false;
-        }
-        var keys = Object.keys(value);
-        var allowed = new Set(required.concat(optional || []));
-        return required.every(function (key) {
-            return Object.prototype.hasOwnProperty.call(value, key);
-        }) && keys.every(function (key) {
-            return allowed.has(key);
-        });
-    }
-
-    function validTelemetry(value) {
-        if (!exactKeys(
-            value,
-            ['provider', 'sessionId', 'rateLimits'],
-            ['model', 'context']
-        )) return false;
-        if (!['codex', 'kimi', 'claude'].includes(value.provider)
-            || typeof value.sessionId !== 'string'
-            || !value.sessionId
-            || value.sessionId.length > 256
-            || (value.model !== undefined
-                && (typeof value.model !== 'string'
-                    || !value.model
-                    || value.model.length > 128))
-            || !Array.isArray(value.rateLimits)
-            || value.rateLimits.length > 4) {
-            return false;
-        }
-        if (value.context !== undefined
-            && (!exactKeys(value.context, ['usedTokens', 'maxTokens'])
-                || !Number.isSafeInteger(value.context.usedTokens)
-                || value.context.usedTokens < 0
-                || !Number.isSafeInteger(value.context.maxTokens)
-                || value.context.maxTokens <= 0)) {
-            return false;
-        }
-        return value.rateLimits.every(function (limit) {
-            return exactKeys(
-                limit,
-                ['id', 'label', 'usedPercent'],
-                ['windowDurationMins', 'resetsAt']
-            )
-                && typeof limit.id === 'string'
-                && limit.id.length > 0
-                && limit.id.length <= 256
-                && typeof limit.label === 'string'
-                && limit.label.length > 0
-                && limit.label.length <= 64
-                && Number.isFinite(limit.usedPercent)
-                && limit.usedPercent >= 0
-                && limit.usedPercent <= 100
-                && (limit.windowDurationMins === undefined
-                    || (Number.isSafeInteger(limit.windowDurationMins)
-                        && limit.windowDurationMins > 0))
-                && (limit.resetsAt === undefined
-                    || (Number.isSafeInteger(limit.resetsAt)
-                        && limit.resetsAt > 0));
-        });
-    }
-
-    function compactTokens(value) {
-        if (value >= 1000000) {
-            return (value / 1000000).toFixed(value >= 10000000 ? 0 : 1) + 'm';
-        }
-        if (value >= 1000) {
-            return (value / 1000).toFixed(value >= 100000 ? 0 : 1) + 'k';
-        }
-        return String(value);
-    }
-
-    function compactResetTime(resetsAt) {
-        var remainingMinutes = Math.max(
-            1,
-            Math.ceil((resetsAt * 1000 - Date.now()) / 60000)
-        );
-        if (remainingMinutes < 60) return remainingMinutes + 'm';
-        var remainingHours = Math.ceil(remainingMinutes / 60);
-        if (remainingHours < 48) return remainingHours + 'h';
-        return Math.ceil(remainingHours / 24) + 'd';
-    }
-
-    function applyTelemetry(message) {
-        if (!exactKeys(
-            message,
-            ['type', 'version', 'requestId', 'subscriptionGeneration', 'telemetry']
-        )
-            || message.type !== 'conversation-viewer-telemetry'
-            || message.version !== 1
-            || !Number.isSafeInteger(message.requestId)
-            || message.requestId < state.latestRequestId
-            || message.requestId < state.latestTelemetryRequestId
-            || message.subscriptionGeneration !== state.subscriptionGeneration
-            || (message.telemetry !== null
-                && !validTelemetry(message.telemetry))
-            || (message.telemetry !== null
-                && (!commentTarget
-                    || message.telemetry.provider !== commentTarget.provider
-                    || message.telemetry.sessionId !== commentTarget.sessionId))
-            || !telemetryRoot || !telemetryModel || !telemetryModelValue
-            || !telemetryContext || !telemetryContextProgress
-            || !telemetryContextValue || !telemetryLimits) {
-            return false;
-        }
-        state.latestTelemetryRequestId = message.requestId;
-        var readingAnchor = captureReadingAnchor();
-        var previousScrollTop = scroll.scrollTop;
-        var telemetry = message.telemetry;
-        if (!telemetry) {
-            telemetryRoot.hidden = true;
-            restoreViewportReadingPosition(
-                readingAnchor,
-                previousScrollTop
-            );
-            return true;
-        }
-        telemetryModel.hidden = !telemetry.model;
-        telemetryModelValue.textContent = telemetry.model || '';
-        telemetryContext.hidden = !telemetry.context;
-        if (telemetry.context) {
-            var percent = Math.max(0, Math.min(
-                100,
-                telemetry.context.usedTokens
-                    / telemetry.context.maxTokens * 100
-            ));
-            telemetryContextProgress.max = telemetry.context.maxTokens;
-            telemetryContextProgress.value = telemetry.context.usedTokens;
-            telemetryContextValue.textContent = Math.round(percent) + '% · '
-                + compactTokens(telemetry.context.usedTokens) + ' / '
-                + compactTokens(telemetry.context.maxTokens);
-        }
-        telemetryLimits.replaceChildren();
-        telemetry.rateLimits.forEach(function (limit) {
-            var meter = document.createElement('div');
-            meter.className = 'conversation-telemetry-meter';
-            var label = document.createElement('span');
-            label.textContent = limit.label;
-            var progress = document.createElement('progress');
-            progress.max = 100;
-            progress.value = limit.usedPercent;
-            progress.setAttribute('aria-label', limit.label + ' usage');
-            var value = document.createElement('span');
-            var text = Math.round(100 - limit.usedPercent) + '% left';
-            if (limit.resetsAt) {
-                text += ' · resets in ' + compactResetTime(limit.resetsAt);
-                value.title = new Date(
-                    limit.resetsAt * 1000
-                ).toLocaleString();
-            }
-            value.textContent = text;
-            meter.append(label, progress, value);
-            telemetryLimits.appendChild(meter);
-        });
-        telemetryRoot.hidden = !telemetry.model
-            && !telemetry.context
-            && telemetry.rateLimits.length === 0;
-        restoreViewportReadingPosition(readingAnchor, previousScrollTop);
-        return true;
-    }
-
     function reconcileMessages(clean, preserveUnchanged, previousSignatures) {
         var template = document.createElement('template');
         template.innerHTML = clean;
@@ -1865,7 +1719,7 @@
         if (outlineController.applyBookmarksResult(event.data)) return;
         if (applyCommentsResult(event.data)) return;
         if (applyLocateResult(event.data)) return;
-        if (applyTelemetry(event.data)) return;
+        if (telemetryController.apply(event.data)) return;
         applyPage(event.data);
     });
     window.addEventListener('unload', releaseMermaidObjectUrls);

--- a/media/conversationViewerScripts.js
+++ b/media/conversationViewerScripts.js
@@ -133,17 +133,6 @@
         commentsPanelOpen: true,
         commentsPanelWidth: 240,
         sidebarView: 'outline',
-        outline: [],
-        outlineSelectedInteractionId: '',
-        outlineSelectedInput: 0,
-        outlineTotalInputs: 0,
-        outlinePartial: false,
-        outlineQuery: '',
-        bookmarkIds: new Set(),
-        bookmarkRevision: 0,
-        bookmarkRequestSequence: 0,
-        pendingBookmarkRequest: null,
-        bookmarksOnly: false,
     };
     var readingAnchorController =
         window.__agentPivotConversationReadingAnchor.create({
@@ -168,6 +157,26 @@
     var releaseMermaidObjectUrls = mermaidRenderer.release;
     var renderMermaidDiagrams = mermaidRenderer.render;
     var preserveMermaidContent = mermaidRenderer.preserve;
+    var outlineController = window.__agentPivotConversationOutline.create({
+        available: sidebarUiAvailable,
+        bookmarkAvailable: bookmarkUiAvailable,
+        target: commentTarget,
+        subscriptionGeneration: state.subscriptionGeneration,
+        status: status,
+        outlineCount: outlineCount,
+        outlineSummary: outlineSummary,
+        outlineSearch: outlineSearch,
+        outlineList: outlineList,
+        outlineEmpty: outlineEmpty,
+        outlinePartial: outlinePartial,
+        outlineBookmarksOnly: outlineBookmarksOnly,
+        post: post,
+        outlinePanelActive: function () {
+            return state.commentsPanelOpen && state.sidebarView === 'outline';
+        },
+        persistPanelState: saveCommentsPanelState,
+        updateToggle: updateCommentsToggle,
+    });
 
     if (!scroll || !messages || !position || !status || !newResponse
         || !previous || !next || !latest || !close || !window.DOMPurify) {
@@ -212,7 +221,7 @@
                 open: state.commentsPanelOpen,
                 width: state.commentsPanelWidth,
                 view: state.sidebarView,
-                query: state.outlineQuery,
+                query: outlineController.query(),
             };
             delete next.conversationCommentsPanel;
             vscodeApi.setState(next);
@@ -240,7 +249,8 @@
 
     function updateCommentsToggle() {
         if (!sidebarUiAvailable) return;
-        outlineToggle.textContent = 'Outline (' + state.outline.length + ')';
+        outlineToggle.textContent = 'Outline ('
+            + outlineController.size() + ')';
         outlineToggle.setAttribute(
             'aria-expanded',
             state.commentsPanelOpen && state.sidebarView === 'outline'
@@ -1098,152 +1108,6 @@
                 .includes(entry.responseState);
     }
 
-    function validBookmarkSnapshot(value) {
-        return value && typeof value === 'object' && !Array.isArray(value)
-            && Object.keys(value).length === 2
-            && Number.isSafeInteger(value.revision)
-            && value.revision >= 0
-            && Array.isArray(value.interactionIds)
-            && value.interactionIds.length <= 2000
-            && value.interactionIds.every(function (id) {
-                return typeof id === 'string'
-                    && id.length > 0
-                    && id.length <= 512
-                    && !/[\u0000-\u001f\u007f]/.test(id);
-            })
-            && new Set(value.interactionIds).size
-                === value.interactionIds.length;
-    }
-
-    function validBookmarksResult(value) {
-        if (!value || typeof value !== 'object' || Array.isArray(value)) {
-            return false;
-        }
-        var required = [
-            'type', 'version', 'requestId', 'subscriptionGeneration',
-            'projectId', 'provider', 'sessionId', 'operation', 'success',
-            'revision', 'interactionIds',
-        ];
-        var allowed = new Set(required.concat(['error']));
-        return Object.keys(value).every(function (key) {
-            return allowed.has(key);
-        }) && required.every(function (key) {
-            return Object.prototype.hasOwnProperty.call(value, key);
-        })
-            && value.type === 'conversation-viewer-bookmarks-result'
-            && value.version === 1
-            && typeof value.requestId === 'string'
-            && Number.isSafeInteger(value.subscriptionGeneration)
-            && typeof value.projectId === 'string'
-            && ['codex', 'kimi', 'claude'].includes(value.provider)
-            && typeof value.sessionId === 'string'
-            && value.operation === 'set'
-            && typeof value.success === 'boolean'
-            && validBookmarkSnapshot({
-                revision: value.revision,
-                interactionIds: value.interactionIds,
-            })
-            && (value.error === undefined
-                || ['invalid', 'stale', 'failed', 'limit']
-                    .includes(value.error));
-    }
-
-    function nextBookmarkRequestId() {
-        state.bookmarkRequestSequence += 1;
-        return [
-            'conversation-bookmark',
-            Date.now().toString(36),
-            state.bookmarkRequestSequence.toString(36),
-        ].join(':');
-    }
-
-    function postBookmarkMutation(interactionId, bookmarked) {
-        if (!bookmarkUiAvailable
-            || state.pendingBookmarkRequest) return;
-        var requestId = nextBookmarkRequestId();
-        state.pendingBookmarkRequest = { requestId: requestId, interactionId: interactionId };
-        renderBookmarkState();
-        post({
-            type: 'conversation-viewer-bookmark-mutation',
-            version: 1,
-            requestId: requestId,
-            subscriptionGeneration: state.subscriptionGeneration,
-            projectId: commentTarget.projectId,
-            provider: commentTarget.provider,
-            sessionId: commentTarget.sessionId,
-            operation: 'set',
-            expectedRevision: state.bookmarkRevision,
-            payload: {
-                interactionId: interactionId,
-                bookmarked: bookmarked,
-            },
-        });
-    }
-
-    function applyBookmarksResult(message) {
-        if (!bookmarkUiAvailable
-            || !validBookmarksResult(message)
-            || !state.pendingBookmarkRequest
-            || message.requestId !== state.pendingBookmarkRequest.requestId
-            || message.subscriptionGeneration !== state.subscriptionGeneration
-            || message.projectId !== commentTarget.projectId
-            || message.provider !== commentTarget.provider
-            || message.sessionId !== commentTarget.sessionId) {
-            return false;
-        }
-        var focusedId = state.pendingBookmarkRequest.interactionId;
-        state.pendingBookmarkRequest = null;
-        state.bookmarkRevision = message.revision;
-        state.bookmarkIds = new Set(message.interactionIds);
-        renderBookmarkState();
-        filterOutline();
-        status.textContent = message.success
-            ? (state.bookmarkIds.has(focusedId)
-                ? 'Input bookmarked.'
-                : 'Bookmark removed.')
-            : 'Bookmark could not be updated.';
-        var focused = outlineList.querySelector(
-            '[data-outline-bookmark-id="' + CSS.escape(focusedId) + '"]'
-        );
-        if (focused) focused.focus();
-        return true;
-    }
-
-    function renderBookmarkState() {
-        if (!sidebarUiAvailable) return;
-        Array.prototype.forEach.call(
-            outlineList.querySelectorAll('[data-outline-bookmark-id]'),
-            function (button) {
-                var interactionId = button.getAttribute(
-                    'data-outline-bookmark-id'
-                );
-                var bookmarked = state.bookmarkIds.has(interactionId);
-                var entry = state.outline.find(function (candidate) {
-                    return candidate.interactionId === interactionId;
-                });
-                var inputNumber = entry ? entry.inputNumber : '';
-                button.textContent = bookmarked ? '★' : '☆';
-                button.classList.toggle('is-bookmarked', bookmarked);
-                button.setAttribute('aria-pressed',
-                    bookmarked ? 'true' : 'false');
-                button.setAttribute(
-                    'aria-label',
-                    (bookmarked ? 'Remove bookmark from input ' : 'Bookmark input ')
-                        + inputNumber
-                );
-                button.title = button.getAttribute('aria-label');
-                button.disabled = !!state.pendingBookmarkRequest;
-            }
-        );
-        var count = state.bookmarkIds.size;
-        outlineBookmarksOnly.textContent = (state.bookmarksOnly ? '★' : '☆')
-            + ' Bookmarks (' + count + ')';
-        outlineBookmarksOnly.setAttribute(
-            'aria-pressed',
-            state.bookmarksOnly ? 'true' : 'false'
-        );
-    }
-
     function validOutline(value, selectedInteractionId) {
         if (!Array.isArray(value)
             || value.length < 1
@@ -1256,176 +1120,6 @@
         }));
         return identities.size === value.length
             && identities.has(selectedInteractionId);
-    }
-
-    function outlineChanged(entries) {
-        return entries.length !== state.outline.length
-            || entries.some(function (entry, index) {
-                var current = state.outline[index];
-                return !current
-                    || current.interactionId !== entry.interactionId
-                    || current.userPreview !== entry.userPreview
-                    || current.responseState !== entry.responseState;
-            });
-    }
-
-    function responseStateLabel(value) {
-        if (value === 'inProgress') return 'Response in progress';
-        if (value === 'interrupted') return 'Response interrupted';
-        if (value === 'unknown') return 'Response state unknown';
-        return 'Response complete';
-    }
-
-    function buildOutlineList() {
-        var fragment = document.createDocumentFragment();
-        state.outline.forEach(function (entry) {
-            var item = document.createElement('li');
-            item.className = 'conversation-outline-item';
-            var bookmark = document.createElement('button');
-            bookmark.type = 'button';
-            bookmark.className = 'conversation-outline-bookmark';
-            bookmark.setAttribute(
-                'data-outline-bookmark-id',
-                entry.interactionId
-            );
-            var button = document.createElement('button');
-            button.type = 'button';
-            button.setAttribute('data-outline-interaction-id',
-                entry.interactionId);
-            button.setAttribute('data-outline-filter-text',
-                entry.userPreview.toLocaleLowerCase());
-            button.tabIndex = -1;
-
-            var number = document.createElement('span');
-            number.className = 'conversation-outline-number';
-            number.textContent = String(entry.inputNumber);
-            var preview = document.createElement('span');
-            preview.className = 'conversation-outline-preview';
-            preview.textContent = entry.userPreview || '(empty input)';
-            var responseState = document.createElement('span');
-            responseState.className = 'conversation-outline-state'
-                + ' conversation-outline-state-' + entry.responseState;
-            responseState.title = responseStateLabel(entry.responseState);
-            responseState.setAttribute(
-                'aria-label',
-                responseStateLabel(entry.responseState)
-            );
-
-            button.appendChild(number);
-            button.appendChild(preview);
-            button.appendChild(responseState);
-            item.appendChild(bookmark);
-            item.appendChild(button);
-            fragment.appendChild(item);
-        });
-        outlineList.replaceChildren(fragment);
-        renderBookmarkState();
-    }
-
-    function visibleOutlineButtons() {
-        return Array.prototype.filter.call(
-            outlineList.querySelectorAll('[data-outline-interaction-id]'),
-            function (button) {
-                return !button.closest('li').hidden;
-            }
-        );
-    }
-
-    function updateOutlineSelection(scrollSelected) {
-        var selected;
-        Array.prototype.forEach.call(
-            outlineList.querySelectorAll('[data-outline-interaction-id]'),
-            function (button) {
-                var current = button.getAttribute(
-                    'data-outline-interaction-id'
-                ) === state.outlineSelectedInteractionId;
-                button.classList.toggle('is-selected', current);
-                if (current) {
-                    button.setAttribute('aria-current', 'location');
-                    selected = button;
-                } else {
-                    button.removeAttribute('aria-current');
-                }
-                button.tabIndex = current ? 0 : -1;
-            }
-        );
-        var visible = visibleOutlineButtons();
-        if (!visible.some(function (button) {
-            return button.tabIndex === 0;
-        }) && visible[0]) {
-            visible[0].tabIndex = 0;
-        }
-        if (scrollSelected
-            && selected
-            && state.commentsPanelOpen
-            && state.sidebarView === 'outline'
-            && !selected.closest('li').hidden) {
-            selected.scrollIntoView({ block: 'nearest' });
-        }
-    }
-
-    function filterOutline() {
-        var query = state.outlineQuery.trim().toLocaleLowerCase();
-        var visibleCount = 0;
-        Array.prototype.forEach.call(
-            outlineList.querySelectorAll('.conversation-outline-item'),
-            function (item) {
-                var button = item.querySelector(
-                    '[data-outline-interaction-id]'
-                );
-                var visible = !query
-                    || (button.getAttribute('data-outline-filter-text') || '')
-                        .includes(query);
-                if (visible && state.bookmarksOnly) {
-                    visible = state.bookmarkIds.has(button.getAttribute(
-                        'data-outline-interaction-id'
-                    ));
-                }
-                item.hidden = !visible;
-                if (visible) visibleCount += 1;
-            }
-        );
-        outlineEmpty.hidden = visibleCount > 0;
-        outlineEmpty.textContent = state.bookmarksOnly
-            ? 'No bookmarked inputs match this view.'
-            : 'No inputs match this search.';
-        updateOutlineSelection(false);
-    }
-
-    function applyOutline(message) {
-        if (!sidebarUiAvailable) return;
-        var selectedIndex = message.outline.findIndex(function (entry) {
-            return entry.interactionId === message.selectedInteractionId;
-        });
-        var offset = Math.max(
-            0,
-            message.selectedInput - selectedIndex - 1
-        );
-        var nextOutline = message.outline.map(function (entry, index) {
-            return Object.assign({}, entry, {
-                inputNumber: offset + index + 1,
-            });
-        });
-        var changed = outlineChanged(nextOutline);
-        state.outline = nextOutline;
-        state.outlineSelectedInteractionId = message.selectedInteractionId;
-        state.outlineSelectedInput = message.selectedInput;
-        state.outlineTotalInputs = message.totalInputs;
-        state.outlinePartial = message.partial;
-        if (changed) buildOutlineList();
-        outlineCount.textContent = String(message.outline.length);
-        outlineCount.setAttribute(
-            'aria-label',
-            message.outline.length + ' inputs'
-        );
-        outlineSummary.textContent = message.partial
-            ? message.outline.length.toLocaleString() + '+ latest inputs'
-            : message.outline.length.toLocaleString() + ' inputs';
-        outlinePartial.hidden = !message.partial;
-        filterOutline();
-        renderBookmarkState();
-        updateOutlineSelection(changed || message.updateKind !== 'refresh');
-        updateCommentsToggle();
     }
 
     function validPage(message) {
@@ -1775,7 +1469,7 @@
         state.messageSignatures = nextSignatures;
         state.atLatest = message.atLatest;
         state.initialized = true;
-        applyOutline(message);
+        outlineController.applyOutline(message);
         updateCommentHighlights();
         updatePosition(message);
         previous.disabled = message.previousCursor === undefined;
@@ -1933,65 +1627,7 @@
                 commentsToggle.focus();
             }
         });
-        outlineSearch.addEventListener('input', function () {
-            state.outlineQuery = outlineSearch.value;
-            filterOutline();
-            saveCommentsPanelState();
-        });
-        outlineBookmarksOnly.addEventListener('click', function () {
-            state.bookmarksOnly = !state.bookmarksOnly;
-            renderBookmarkState();
-            filterOutline();
-        });
-        outlineList.addEventListener('click', function (event) {
-            var bookmark = event.target.closest
-                ? event.target.closest('[data-outline-bookmark-id]')
-                : null;
-            if (bookmark && outlineList.contains(bookmark)) {
-                var bookmarkId = bookmark.getAttribute(
-                    'data-outline-bookmark-id'
-                );
-                postBookmarkMutation(
-                    bookmarkId,
-                    !state.bookmarkIds.has(bookmarkId)
-                );
-                return;
-            }
-            var button = event.target.closest
-                ? event.target.closest('[data-outline-interaction-id]')
-                : null;
-            if (!button || !outlineList.contains(button)) return;
-            post({
-                type: 'conversation-viewer-select-interaction',
-                version: 1,
-                interactionId: button.getAttribute(
-                    'data-outline-interaction-id'
-                ),
-            });
-        });
-        outlineList.addEventListener('keydown', function (event) {
-            if (!['ArrowUp', 'ArrowDown', 'Home', 'End']
-                .includes(event.key)) return;
-            var visible = visibleOutlineButtons();
-            if (!visible.length) return;
-            var current = event.target.closest
-                ? event.target.closest('[data-outline-interaction-id]')
-                : null;
-            var index = visible.indexOf(current);
-            if (event.key === 'Home') index = 0;
-            else if (event.key === 'End') index = visible.length - 1;
-            else if (event.key === 'ArrowUp') {
-                index = Math.max(0, index - 1);
-            } else {
-                index = Math.min(visible.length - 1, index + 1);
-            }
-            event.preventDefault();
-            visible.forEach(function (button) {
-                button.tabIndex = -1;
-            });
-            visible[index].tabIndex = 0;
-            visible[index].focus();
-        });
+        outlineController.attach();
         var resizingPointerId = null;
         commentsResizer.addEventListener('pointerdown', function (event) {
             if (event.button !== 0) return;
@@ -2226,7 +1862,7 @@
         postNavigation('conversation-viewer-closed');
     });
     window.addEventListener('message', function (event) {
-        if (applyBookmarksResult(event.data)) return;
+        if (outlineController.applyBookmarksResult(event.data)) return;
         if (applyCommentsResult(event.data)) return;
         if (applyLocateResult(event.data)) return;
         if (applyTelemetry(event.data)) return;
@@ -2244,14 +1880,7 @@
         }
     }
     if (sidebarUiAvailable) {
-        var initialBookmarks = readJsonAttribute('data-initial-bookmarks');
-        if (validBookmarkSnapshot(initialBookmarks)) {
-            state.bookmarkRevision = initialBookmarks.revision;
-            state.bookmarkIds = new Set(initialBookmarks.interactionIds);
-            renderBookmarkState();
-        } else {
-            status.textContent = 'Conversation bookmarks are unavailable.';
-        }
+        outlineController.initializeBookmarks();
         var savedCommentsPanel = readCommentsPanelState();
         if (savedCommentsPanel) {
             if (typeof savedCommentsPanel.open === 'boolean') {
@@ -2266,13 +1895,10 @@
                 || savedCommentsPanel.view === 'comments') {
                 state.sidebarView = savedCommentsPanel.view;
             }
-            if (typeof savedCommentsPanel.query === 'string') {
-                state.outlineQuery = savedCommentsPanel.query.slice(0, 4096);
-                outlineSearch.value = state.outlineQuery;
-            }
+            outlineController.restoreQuery(savedCommentsPanel.query);
         }
         applyCommentsPanelLayout();
-        filterOutline();
+        outlineController.filter();
     }
     if (commentUiAvailable) {
         var initialComments = readJsonAttribute('data-initial-comments');

--- a/scripts/run-release-packaging-checks.js
+++ b/scripts/run-release-packaging-checks.js
@@ -51,6 +51,7 @@ const EXPECTED_MAIN_ENTRIES = Object.freeze([
     'extension/media/conversationReadingAnchorScripts.js',
     'extension/media/conversationOutlineScripts.js',
     'extension/media/conversationTelemetryScripts.js',
+    'extension/media/conversationCommentsScripts.js',
     'extension/media/conversationTelemetry.css',
     'extension/media/conversationViewer.css',
     'extension/media/conversationViewerScripts.js',

--- a/scripts/run-release-packaging-checks.js
+++ b/scripts/run-release-packaging-checks.js
@@ -50,6 +50,7 @@ const EXPECTED_MAIN_ENTRIES = Object.freeze([
     'extension/media/conversationMermaidScripts.js',
     'extension/media/conversationReadingAnchorScripts.js',
     'extension/media/conversationOutlineScripts.js',
+    'extension/media/conversationTelemetryScripts.js',
     'extension/media/conversationTelemetry.css',
     'extension/media/conversationViewer.css',
     'extension/media/conversationViewerScripts.js',

--- a/scripts/run-release-packaging-checks.js
+++ b/scripts/run-release-packaging-checks.js
@@ -49,6 +49,7 @@ const EXPECTED_MAIN_ENTRIES = Object.freeze([
     'extension/licenses/Mermaid-MIT.txt',
     'extension/media/conversationMermaidScripts.js',
     'extension/media/conversationReadingAnchorScripts.js',
+    'extension/media/conversationOutlineScripts.js',
     'extension/media/conversationTelemetry.css',
     'extension/media/conversationViewer.css',
     'extension/media/conversationViewerScripts.js',

--- a/src/aiSessions/conversation/viewer.ts
+++ b/src/aiSessions/conversation/viewer.ts
@@ -1169,6 +1169,9 @@ export class ConversationViewer implements ConversationViewerApi {
         const telemetryScript = panel.webview.asWebviewUri(
             this.options.mediaUri('conversationTelemetryScripts.js')
         );
+        const commentsScript = panel.webview.asWebviewUri(
+            this.options.mediaUri('conversationCommentsScripts.js')
+        );
         const script = panel.webview.asWebviewUri(
             this.options.mediaUri('conversationViewerScripts.js')
         );
@@ -1357,6 +1360,9 @@ export class ConversationViewer implements ConversationViewerApi {
     )}"></script>
     <script nonce="${escapeAttribute(nonce)}" src="${escapeAttribute(
         telemetryScript.toString()
+    )}"></script>
+    <script nonce="${escapeAttribute(nonce)}" src="${escapeAttribute(
+        commentsScript.toString()
     )}"></script>
     <script nonce="${escapeAttribute(nonce)}" src="${escapeAttribute(
         script.toString()

--- a/src/aiSessions/conversation/viewer.ts
+++ b/src/aiSessions/conversation/viewer.ts
@@ -1163,6 +1163,9 @@ export class ConversationViewer implements ConversationViewerApi {
         const mermaidScript = panel.webview.asWebviewUri(
             this.options.mediaUri('conversationMermaidScripts.js')
         );
+        const outlineScript = panel.webview.asWebviewUri(
+            this.options.mediaUri('conversationOutlineScripts.js')
+        );
         const script = panel.webview.asWebviewUri(
             this.options.mediaUri('conversationViewerScripts.js')
         );
@@ -1345,6 +1348,9 @@ export class ConversationViewer implements ConversationViewerApi {
     )}"></script>
     <script nonce="${escapeAttribute(nonce)}" src="${escapeAttribute(
         mermaidScript.toString()
+    )}"></script>
+    <script nonce="${escapeAttribute(nonce)}" src="${escapeAttribute(
+        outlineScript.toString()
     )}"></script>
     <script nonce="${escapeAttribute(nonce)}" src="${escapeAttribute(
         script.toString()

--- a/src/aiSessions/conversation/viewer.ts
+++ b/src/aiSessions/conversation/viewer.ts
@@ -1166,6 +1166,9 @@ export class ConversationViewer implements ConversationViewerApi {
         const outlineScript = panel.webview.asWebviewUri(
             this.options.mediaUri('conversationOutlineScripts.js')
         );
+        const telemetryScript = panel.webview.asWebviewUri(
+            this.options.mediaUri('conversationTelemetryScripts.js')
+        );
         const script = panel.webview.asWebviewUri(
             this.options.mediaUri('conversationViewerScripts.js')
         );
@@ -1351,6 +1354,9 @@ export class ConversationViewer implements ConversationViewerApi {
     )}"></script>
     <script nonce="${escapeAttribute(nonce)}" src="${escapeAttribute(
         outlineScript.toString()
+    )}"></script>
+    <script nonce="${escapeAttribute(nonce)}" src="${escapeAttribute(
+        telemetryScript.toString()
     )}"></script>
     <script nonce="${escapeAttribute(nonce)}" src="${escapeAttribute(
         script.toString()

--- a/src/webview/conversationCommentsScripts.js
+++ b/src/webview/conversationCommentsScripts.js
@@ -1,0 +1,862 @@
+(function () {
+    'use strict';
+
+    function create(options) {
+        var commentUiAvailable = options.available;
+        var commentTarget = options.target;
+        var subscriptionGeneration = options.subscriptionGeneration;
+        var status = options.status;
+        var messages = options.messages;
+        var scroll = options.scroll;
+        var addComment = options.addComment;
+        var commentsRoot = options.commentsRoot;
+        var commentCount = options.commentCount;
+        var commentSummary = options.commentSummary;
+        var commentComposer = options.commentComposer;
+        var commentSelection = options.commentSelection;
+        var commentInput = options.commentInput;
+        var commentList = options.commentList;
+        var commentEmpty = options.commentEmpty;
+        var commentNew = options.commentNew;
+        var commentSend = options.commentSend;
+        var commentClearSent = options.commentClearSent;
+        var commentClearResolved = options.commentClearResolved;
+        var commentClearAll = options.commentClearAll;
+        var post = options.post;
+        var conversationMessageSelector = options.messageSelector;
+        var conversationMessageId = options.messageId;
+        var setSidebarView = options.setSidebarView;
+        var updateToggle = options.updateToggle;
+        var state = {
+            comments: [],
+            commentRevision: 0,
+            commentRequestSequence: 0,
+            pendingCommentRequest: null,
+            pendingLocateRequest: null,
+            clearAllConfirmation: false,
+            selectedCommentText: null,
+        };
+
+        function readJsonAttribute(name) {
+            var value = document.body.getAttribute(name);
+            if (!value) return null;
+            document.body.removeAttribute(name);
+            try {
+                return JSON.parse(value);
+            } catch (_error) {
+                return null;
+            }
+        }
+
+        function validComment(value) {
+            if (!value || typeof value !== 'object' || Array.isArray(value)) {
+                return false;
+            }
+            var keys = [
+                'id', 'messageId', 'interactionId', 'role',
+                'quote', 'prefix', 'suffix', 'comment', 'status',
+            ];
+            var actualKeys = Object.keys(value);
+            var hasSessionScope = value.scope === 'session';
+            return actualKeys.length === keys.length + (hasSessionScope ? 1 : 0)
+                && keys.every(function (key) {
+                    return Object.prototype.hasOwnProperty.call(value, key);
+                })
+                && (value.scope === undefined || hasSessionScope)
+                && typeof value.id === 'string'
+                && typeof value.messageId === 'string'
+                && typeof value.interactionId === 'string'
+                && (value.role === 'user' || value.role === 'assistant')
+                && typeof value.quote === 'string'
+                && typeof value.prefix === 'string'
+                && typeof value.suffix === 'string'
+                && typeof value.comment === 'string'
+                && (!hasSessionScope
+                    || (value.messageId === ''
+                        && value.interactionId === ''
+                        && value.role === 'user'
+                        && value.quote === ''
+                        && value.prefix === ''
+                        && value.suffix === ''))
+                && (value.status === 'open'
+                    || value.status === 'sent'
+                    || value.status === 'resolved');
+        }
+
+        function validInitialComments(value) {
+            return value && typeof value === 'object' && !Array.isArray(value)
+                && Object.keys(value).length === 2
+                && Number.isSafeInteger(value.revision)
+                && value.revision >= 0
+                && Array.isArray(value.comments)
+                && value.comments.length <= 20
+                && value.comments.every(validComment);
+        }
+
+        function validCommentsResult(value) {
+            if (!value || typeof value !== 'object' || Array.isArray(value)) {
+                return false;
+            }
+            var required = [
+                'type', 'version', 'requestId', 'subscriptionGeneration',
+                'projectId', 'provider', 'sessionId', 'operation', 'success',
+                'revision', 'comments',
+            ];
+            var allowed = new Set(required.concat(['error']));
+            return Object.keys(value).every(function (key) {
+                return allowed.has(key);
+            }) && required.every(function (key) {
+                return Object.prototype.hasOwnProperty.call(value, key);
+            })
+                && value.type === 'conversation-viewer-comments-result'
+                && value.version === 1
+                && typeof value.requestId === 'string'
+                && Number.isSafeInteger(value.subscriptionGeneration)
+                && typeof value.projectId === 'string'
+                && (value.provider === 'codex'
+                    || value.provider === 'kimi'
+                    || value.provider === 'claude')
+                && typeof value.sessionId === 'string'
+                && (value.operation === 'add'
+                    || value.operation === 'update'
+                    || value.operation === 'delete'
+                    || value.operation === 'resolve'
+                    || value.operation === 'reopen'
+                    || value.operation === 'clearSent'
+                    || value.operation === 'clearResolved'
+                    || value.operation === 'clearAll'
+                    || value.operation === 'sendComments')
+                && typeof value.success === 'boolean'
+                && Number.isSafeInteger(value.revision)
+                && value.revision >= 0
+                && Array.isArray(value.comments)
+                && value.comments.length <= 20
+                && value.comments.every(validComment)
+                && (value.error === undefined || [
+                    'invalid', 'stale', 'limit', 'tooLarge',
+                    'unavailable', 'busy', 'conflict', 'failed',
+                ].includes(value.error));
+        }
+
+        function validLocateResult(value) {
+            if (!value || typeof value !== 'object' || Array.isArray(value)) {
+                return false;
+            }
+            var required = [
+                'type', 'version', 'requestId', 'subscriptionGeneration',
+                'projectId', 'provider', 'sessionId', 'commentId', 'success',
+            ];
+            var allowed = new Set(required.concat(['error']));
+            return Object.keys(value).every(function (key) {
+                return allowed.has(key);
+            }) && required.every(function (key) {
+                return Object.prototype.hasOwnProperty.call(value, key);
+            })
+                && value.type === 'conversation-viewer-locate-comment-result'
+                && value.version === 1
+                && typeof value.requestId === 'string'
+                && Number.isSafeInteger(value.subscriptionGeneration)
+                && typeof value.projectId === 'string'
+                && (value.provider === 'codex'
+                    || value.provider === 'kimi'
+                    || value.provider === 'claude')
+                && typeof value.sessionId === 'string'
+                && typeof value.commentId === 'string'
+                && typeof value.success === 'boolean'
+                && (value.error === undefined || value.error === 'stale');
+        }
+
+        function openCommentCount() {
+            return state.comments.filter(function (comment) {
+                return comment.status === 'open';
+            }).length;
+        }
+
+        function commentStatusCounts() {
+            return state.comments.reduce(function (counts, comment) {
+                counts[comment.status] += 1;
+                return counts;
+            }, { open: 0, sent: 0, resolved: 0 });
+        }
+
+        function resetClearAllConfirmation() {
+            if (!commentUiAvailable) return;
+            state.clearAllConfirmation = false;
+            commentClearAll.textContent = 'Clear all';
+            commentClearAll.removeAttribute('data-confirming');
+            commentClearAll.setAttribute('aria-label', 'Clear all comments');
+        }
+
+        function updateCommentControls() {
+            if (!commentUiAvailable) return;
+            var counts = commentStatusCounts();
+            var pending = !!state.pendingCommentRequest
+                || !!state.pendingLocateRequest;
+            var summary = [];
+            if (counts.open) summary.push(counts.open + ' open');
+            if (counts.sent) summary.push(counts.sent + ' added');
+            if (counts.resolved) summary.push(counts.resolved + ' resolved');
+            commentSummary.textContent = summary.length
+                ? summary.join(' · ')
+                : 'No comments yet';
+            commentCount.textContent = String(state.comments.length);
+            commentCount.setAttribute(
+                'aria-label',
+                state.comments.length + ' comment'
+                    + (state.comments.length === 1 ? '' : 's')
+            );
+            commentSend.disabled = counts.open === 0 || pending;
+            commentNew.disabled = pending;
+            commentClearSent.disabled = counts.sent === 0 || pending;
+            commentClearResolved.disabled = counts.resolved === 0 || pending;
+            commentClearAll.disabled = state.comments.length === 0 || pending;
+        }
+
+        function nextCommentRequestId() {
+            state.commentRequestSequence += 1;
+            return [
+                'conversation-comment',
+                Date.now().toString(36),
+                state.commentRequestSequence.toString(36),
+            ].join(':');
+        }
+
+        function commentErrorMessage(error) {
+            if (error === 'stale') return 'Comments changed. Review the latest draft and try again.';
+            if (error === 'limit') return 'A maximum of 20 comments can be added at once.';
+            if (error === 'tooLarge') return 'The combined comments are too large to send.';
+            if (error === 'busy') return 'Wait for the current AI response to finish, then send again.';
+            if (error === 'conflict') return 'Multiple runtimes match this session. Resolve the conflict first.';
+            if (error === 'unavailable') return 'This session is unavailable and the comments were not added.';
+            return 'The comment action failed. Your comments were kept.';
+        }
+
+        function setCommentPending(pending) {
+            if (!commentUiAvailable) return;
+            Array.prototype.forEach.call(
+                commentsRoot.querySelectorAll('button, textarea'),
+                function (control) {
+                    control.disabled = pending;
+                }
+            );
+            addComment.disabled = pending;
+            if (!pending) {
+                updateCommentControls();
+            }
+            commentsRoot.setAttribute('aria-busy', pending ? 'true' : 'false');
+        }
+
+        function postCommentOperation(operation, payload) {
+            if (!commentUiAvailable
+                || state.pendingCommentRequest
+                || state.pendingLocateRequest) return;
+            var requestId = nextCommentRequestId();
+            resetClearAllConfirmation();
+            state.pendingCommentRequest = { requestId: requestId, operation: operation };
+            setCommentPending(true);
+            status.textContent = operation === 'sendComments'
+                ? 'Adding comments to session input…'
+                : operation === 'clearSent'
+                    || operation === 'clearResolved'
+                    || operation === 'clearAll'
+                    ? 'Clearing comments…'
+                    : 'Saving comment…';
+            post({
+                type: operation === 'sendComments'
+                    ? 'conversation-viewer-send-comments'
+                    : 'conversation-viewer-comment-mutation',
+                version: 1,
+                requestId: requestId,
+                subscriptionGeneration: subscriptionGeneration,
+                projectId: commentTarget.projectId,
+                provider: commentTarget.provider,
+                sessionId: commentTarget.sessionId,
+                operation: operation,
+                expectedRevision: state.commentRevision,
+                payload: payload,
+            });
+        }
+
+        function locateComment(comment) {
+            if (comment.scope === 'session') return false;
+            var message = Array.prototype.find.call(
+                messages.querySelectorAll(conversationMessageSelector()),
+                function (candidate) {
+                    return conversationMessageId(candidate) === comment.messageId;
+                }
+            );
+            if (!message) {
+                return false;
+            }
+            message.scrollIntoView({ block: 'center' });
+            message.tabIndex = -1;
+            message.focus({ preventScroll: true });
+            message.classList.add('conversation-comment-located');
+            window.setTimeout(function () {
+                message.classList.remove('conversation-comment-located');
+            }, 1600);
+            return true;
+        }
+
+        function requestCommentLocation(comment) {
+            if (locateComment(comment)) {
+                status.textContent = 'Comment source located.';
+                return;
+            }
+            if (state.pendingLocateRequest || state.pendingCommentRequest) return;
+            var requestId = nextCommentRequestId();
+            state.pendingLocateRequest = {
+                requestId: requestId,
+                commentId: comment.id,
+            };
+            setCommentPending(true);
+            status.textContent = 'Loading the commented message…';
+            post({
+                type: 'conversation-viewer-locate-comment',
+                version: 1,
+                requestId: requestId,
+                subscriptionGeneration: subscriptionGeneration,
+                projectId: commentTarget.projectId,
+                provider: commentTarget.provider,
+                sessionId: commentTarget.sessionId,
+                commentId: comment.id,
+            });
+        }
+
+        function renderComments() {
+            if (!commentUiAvailable) return;
+            resetClearAllConfirmation();
+            commentList.replaceChildren();
+            state.comments.forEach(function (comment, index) {
+                var item = document.createElement('article');
+                item.className = 'conversation-comment';
+                item.setAttribute('data-comment-id', comment.id);
+                item.setAttribute('data-comment-status', comment.status);
+                item.setAttribute(
+                    'data-comment-scope',
+                    comment.scope === 'session' ? 'session' : 'selection'
+                );
+
+                var heading = document.createElement('div');
+                heading.className = 'conversation-comment-heading';
+                var identity = document.createElement('div');
+                identity.className = 'conversation-comment-identity';
+                var label = document.createElement('strong');
+                label.textContent = 'Comment ' + (index + 1);
+                if (comment.scope === 'session') {
+                    var scope = document.createElement('span');
+                    scope.className = 'conversation-comment-scope';
+                    scope.textContent = 'Session note';
+                    identity.append(label, scope);
+                } else {
+                    identity.appendChild(label);
+                }
+                var statusLabel = document.createElement('span');
+                statusLabel.className = 'conversation-comment-status';
+                statusLabel.setAttribute('data-comment-status-label', '');
+                statusLabel.textContent = comment.status === 'open'
+                    ? 'Open'
+                    : comment.status === 'sent' ? 'Added' : 'Resolved';
+                identity.appendChild(statusLabel);
+                heading.appendChild(identity);
+                if (comment.scope !== 'session') {
+                    var locate = document.createElement('button');
+                    locate.type = 'button';
+                    locate.className = 'conversation-comment-locate';
+                    locate.setAttribute('data-comment-action', 'locate');
+                    locate.textContent = 'Show text';
+                    heading.appendChild(locate);
+                }
+
+                var quoteGroup = document.createElement('div');
+                quoteGroup.className = 'conversation-comment-quote';
+                var quoteLabel = document.createElement('span');
+                quoteLabel.className = 'conversation-comment-quote-label';
+                quoteLabel.textContent = 'Selected text';
+                var quote = document.createElement('blockquote');
+                quote.textContent = comment.quote;
+                quoteGroup.append(quoteLabel, quote);
+                var input = document.createElement('textarea');
+                input.rows = 2;
+                input.maxLength = 4000;
+                input.value = comment.comment;
+                input.readOnly = comment.status !== 'open';
+                input.setAttribute('aria-label', 'Comment ' + (index + 1));
+                input.setAttribute(
+                    'aria-keyshortcuts',
+                    'Control+Enter Meta+Enter'
+                );
+                input.setAttribute('data-comment-edit', '');
+                var actions = document.createElement('div');
+                actions.className = 'conversation-comment-actions';
+                var remove = document.createElement('button');
+                remove.type = 'button';
+                remove.className = 'conversation-comment-delete';
+                remove.setAttribute('data-comment-action', 'delete');
+                remove.textContent = 'Delete';
+                actions.appendChild(remove);
+                if (comment.status === 'open') {
+                    var save = document.createElement('button');
+                    save.type = 'button';
+                    save.setAttribute('data-comment-action', 'update');
+                    save.title = 'Save comment (Ctrl+Enter or Cmd+Enter)';
+                    save.textContent = 'Save';
+                    actions.appendChild(save);
+                }
+                var review = document.createElement('button');
+                review.type = 'button';
+                if (comment.status === 'resolved') {
+                    review.setAttribute('data-comment-action', 'reopen');
+                    review.textContent = 'Reopen';
+                } else if (comment.status === 'sent') {
+                    review.setAttribute('data-comment-action', 'resolve');
+                    review.textContent = 'Resolve';
+                    var reopen = document.createElement('button');
+                    reopen.type = 'button';
+                    reopen.setAttribute('data-comment-action', 'reopen');
+                    reopen.textContent = 'Reopen';
+                    actions.appendChild(reopen);
+                } else {
+                    review.setAttribute('data-comment-action', 'resolve');
+                    review.textContent = 'Resolve';
+                }
+                actions.appendChild(review);
+                item.appendChild(heading);
+                if (comment.scope !== 'session') {
+                    item.appendChild(quoteGroup);
+                }
+                item.append(input, actions);
+                commentList.appendChild(item);
+            });
+            updateToggle();
+            commentEmpty.hidden = state.comments.length > 0;
+            var openCount = openCommentCount();
+            commentSend.textContent = 'Send ' + openCount + ' open comment'
+                + (openCount === 1 ? '' : 's') + ' to this session';
+            updateCommentControls();
+            updateCommentHighlights();
+        }
+
+        function findQuoteRange(root, comment) {
+            var walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+            var nodes = [];
+            var combined = '';
+            var node;
+            while ((node = walker.nextNode())) {
+                nodes.push({ node: node, start: combined.length });
+                combined += node.nodeValue || '';
+            }
+            var candidates = [];
+            var candidate = combined.indexOf(comment.quote);
+            while (candidate >= 0) {
+                candidates.push(candidate);
+                candidate = combined.indexOf(
+                    comment.quote,
+                    candidate + 1
+                );
+            }
+            var start = candidates.find(function (offset) {
+                var before = combined.slice(
+                    Math.max(0, offset - comment.prefix.length),
+                    offset
+                );
+                var after = combined.slice(
+                    offset + comment.quote.length,
+                    offset + comment.quote.length + comment.suffix.length
+                );
+                return before === comment.prefix && after === comment.suffix;
+            });
+            if (start === undefined) start = candidates[0];
+            if (start === undefined) return null;
+            var end = start + comment.quote.length;
+            var startRecord = nodes.find(function (record) {
+                return start >= record.start
+                    && start <= record.start + (record.node.nodeValue || '').length;
+            });
+            var endRecord = nodes.find(function (record) {
+                return end >= record.start
+                    && end <= record.start + (record.node.nodeValue || '').length;
+            });
+            if (!startRecord || !endRecord) return null;
+            var range = document.createRange();
+            range.setStart(startRecord.node, start - startRecord.start);
+            range.setEnd(endRecord.node, end - endRecord.start);
+            return range;
+        }
+
+        function updateCommentHighlights() {
+            if (!commentUiAvailable) return;
+            Array.prototype.forEach.call(
+                messages.querySelectorAll('.conversation-has-comment'),
+                function (message) {
+                    message.classList.remove('conversation-has-comment');
+                }
+            );
+            var ranges = [];
+            state.comments.forEach(function (comment) {
+                if (comment.status === 'resolved'
+                    || comment.scope === 'session') return;
+                var message = Array.prototype.find.call(
+                    messages.querySelectorAll(conversationMessageSelector()),
+                    function (candidate) {
+                        return conversationMessageId(candidate)
+                            === comment.messageId;
+                    }
+                );
+                if (!message) return;
+                message.classList.add('conversation-has-comment');
+                var markdown = message.querySelector('.conversation-markdown');
+                var range = markdown && findQuoteRange(markdown, comment);
+                if (range) ranges.push(range);
+            });
+            if (window.CSS && CSS.highlights && typeof Highlight === 'function') {
+                CSS.highlights.delete('conversation-comments');
+                if (ranges.length) {
+                    CSS.highlights.set(
+                        'conversation-comments',
+                        new Highlight(...ranges)
+                    );
+                }
+            }
+        }
+
+        function applyCommentsResult(message) {
+            if (!commentUiAvailable
+                || !validCommentsResult(message)
+                || message.subscriptionGeneration !== subscriptionGeneration
+                || message.projectId !== commentTarget.projectId
+                || message.provider !== commentTarget.provider
+                || message.sessionId !== commentTarget.sessionId
+                || !state.pendingCommentRequest
+                || message.requestId !== state.pendingCommentRequest.requestId
+                || message.operation !== state.pendingCommentRequest.operation) {
+                return false;
+            }
+            state.commentRevision = message.revision;
+            state.comments = message.comments.map(function (comment) {
+                return Object.assign({}, comment);
+            });
+            renderComments();
+            var operation = state.pendingCommentRequest.operation;
+            state.pendingCommentRequest = null;
+            setCommentPending(false);
+            if (message.success) {
+                status.textContent = operation === 'sendComments'
+                    ? 'Comments added to session input. Review and press Enter to send.'
+                    : operation === 'clearSent'
+                        ? 'Added comments cleared.'
+                        : operation === 'clearResolved'
+                            ? 'Resolved comments cleared.'
+                            : operation === 'clearAll'
+                                ? 'All comments cleared.'
+                                : 'Comments saved.';
+            } else {
+                status.textContent = commentErrorMessage(message.error);
+            }
+            return true;
+        }
+
+        function applyLocateResult(message) {
+            if (!commentUiAvailable
+                || !validLocateResult(message)
+                || message.subscriptionGeneration !== subscriptionGeneration
+                || message.projectId !== commentTarget.projectId
+                || message.provider !== commentTarget.provider
+                || message.sessionId !== commentTarget.sessionId
+                || !state.pendingLocateRequest
+                || message.requestId !== state.pendingLocateRequest.requestId
+                || message.commentId !== state.pendingLocateRequest.commentId) {
+                return false;
+            }
+            var comment = state.comments.find(function (candidate) {
+                return candidate.id === message.commentId;
+            });
+            state.pendingLocateRequest = null;
+            setCommentPending(false);
+            if (message.success && comment && locateComment(comment)) {
+                status.textContent = 'Comment source located.';
+            } else {
+                status.textContent = 'The commented message is no longer available.';
+            }
+            return true;
+        }
+
+        function selectionContext(range, markdown) {
+            var before = document.createRange();
+            before.selectNodeContents(markdown);
+            before.setEnd(range.startContainer, range.startOffset);
+            var after = document.createRange();
+            after.selectNodeContents(markdown);
+            after.setStart(range.endContainer, range.endOffset);
+            return {
+                prefix: before.toString().slice(-240),
+                suffix: after.toString().slice(0, 240),
+            };
+        }
+
+        function captureCommentSelection() {
+            if (!commentUiAvailable || state.pendingCommentRequest) return;
+            var selection = window.getSelection();
+            if (!selection || selection.rangeCount !== 1 || selection.isCollapsed) {
+                addComment.hidden = true;
+                state.selectedCommentText = null;
+                return;
+            }
+            var range = selection.getRangeAt(0);
+            var startElement = range.startContainer.nodeType === Node.ELEMENT_NODE
+                ? range.startContainer
+                : range.startContainer.parentElement;
+            var endElement = range.endContainer.nodeType === Node.ELEMENT_NODE
+                ? range.endContainer
+                : range.endContainer.parentElement;
+            var startMessage = startElement && startElement.closest
+                ? startElement.closest(conversationMessageSelector())
+                : null;
+            var endMessage = endElement && endElement.closest
+                ? endElement.closest(conversationMessageSelector())
+                : null;
+            var markdown = startElement && startElement.closest
+                ? startElement.closest('.conversation-markdown')
+                : null;
+            var quote = selection.toString().trim();
+            if (!startMessage || startMessage !== endMessage || !markdown
+                || !messages.contains(startMessage) || !quote
+                || Array.from(quote).length > 4000) {
+                addComment.hidden = true;
+                state.selectedCommentText = null;
+                return;
+            }
+            var context = selectionContext(range, markdown);
+            state.selectedCommentText = {
+                messageId: conversationMessageId(startMessage),
+                interactionId: startMessage.getAttribute('data-interaction-id'),
+                quote: quote,
+                prefix: context.prefix,
+                suffix: context.suffix,
+            };
+            var rect = range.getBoundingClientRect();
+            addComment.style.left = Math.max(
+                8,
+                Math.min(window.innerWidth - 120, rect.left)
+            ) + 'px';
+            addComment.style.top = Math.max(8, rect.bottom + 6) + 'px';
+            addComment.hidden = false;
+        }
+
+        function openCommentComposer() {
+            if (!state.selectedCommentText) return;
+            setSidebarView('comments', true, true);
+            addComment.hidden = true;
+            commentSelection.textContent = state.selectedCommentText.quote;
+            commentComposer.setAttribute('data-comment-composer-scope', 'selection');
+            commentInput.value = '';
+            commentComposer.hidden = false;
+            commentInput.focus();
+        }
+
+        function openSessionCommentComposer() {
+            if (!commentUiAvailable
+                || state.pendingCommentRequest
+                || state.pendingLocateRequest) return;
+            setSidebarView('comments', true, true);
+            addComment.hidden = true;
+            state.selectedCommentText = { scope: 'session' };
+            commentSelection.textContent = 'Session note';
+            commentComposer.setAttribute('data-comment-composer-scope', 'session');
+            commentInput.value = '';
+            commentComposer.hidden = false;
+            commentInput.focus();
+        }
+
+        function closeCommentComposer() {
+            commentComposer.hidden = true;
+            commentComposer.removeAttribute('data-comment-composer-scope');
+            commentInput.value = '';
+            state.selectedCommentText = null;
+            addComment.hidden = true;
+        }
+
+        function attach() {
+            if (!commentUiAvailable) return;
+            messages.addEventListener('mouseup', function () {
+                window.setTimeout(captureCommentSelection, 0);
+            });
+            messages.addEventListener('keyup', function (event) {
+                if (event.key === 'Shift'
+                    || event.key.startsWith('Arrow')
+                    || event.key === 'Home'
+                    || event.key === 'End') {
+                    window.setTimeout(captureCommentSelection, 0);
+                }
+            });
+            scroll.addEventListener('scroll', function () {
+                addComment.hidden = true;
+            });
+            addComment.addEventListener('click', openCommentComposer);
+            commentsRoot.addEventListener('click', function (event) {
+                var button = event.target && event.target.closest
+                    ? event.target.closest('[data-comment-action]')
+                    : null;
+                if (!button || !commentsRoot.contains(button)
+                    || state.pendingCommentRequest
+                    || state.pendingLocateRequest) {
+                    return;
+                }
+                var action = button.getAttribute('data-comment-action');
+                if (action !== 'clearAll' && state.clearAllConfirmation) {
+                    resetClearAllConfirmation();
+                }
+                if (action === 'new') {
+                    openSessionCommentComposer();
+                    return;
+                }
+                if (action === 'cancel-add') {
+                    closeCommentComposer();
+                    return;
+                }
+                if (action === 'confirm-add') {
+                    var text = commentInput.value.trim();
+                    if (!state.selectedCommentText || !text) {
+                        status.textContent = 'Enter a comment before adding it.';
+                        commentInput.focus();
+                        return;
+                    }
+                    var payload = Object.assign(
+                        {},
+                        state.selectedCommentText,
+                        { comment: text }
+                    );
+                    closeCommentComposer();
+                    postCommentOperation('add', payload);
+                    return;
+                }
+                if (action === 'send') {
+                    postCommentOperation('sendComments', {});
+                    return;
+                }
+                if (action === 'clearSent' || action === 'clearResolved') {
+                    postCommentOperation(action, {});
+                    return;
+                }
+                if (action === 'clearAll') {
+                    if (!state.clearAllConfirmation) {
+                        state.clearAllConfirmation = true;
+                        commentClearAll.textContent = 'Confirm clear all';
+                        commentClearAll.setAttribute('data-confirming', 'true');
+                        commentClearAll.setAttribute(
+                            'aria-label',
+                            'Confirm clearing all comments'
+                        );
+                        status.textContent =
+                            'Select Clear all again to remove every comment.';
+                        return;
+                    }
+                    postCommentOperation('clearAll', {});
+                    return;
+                }
+                var item = button.closest('[data-comment-id]');
+                var commentId = item && item.getAttribute('data-comment-id');
+                var comment = state.comments.find(function (candidate) {
+                    return candidate.id === commentId;
+                });
+                if (!item || !comment) return;
+                if (action === 'locate') {
+                    requestCommentLocation(comment);
+                    return;
+                }
+                if (action === 'delete') {
+                    postCommentOperation('delete', { commentId: comment.id });
+                    return;
+                }
+                if (action === 'resolve' || action === 'reopen') {
+                    postCommentOperation(action, { commentId: comment.id });
+                    return;
+                }
+                if (action === 'update') {
+                    var edit = item.querySelector('[data-comment-edit]');
+                    var updated = edit ? edit.value.trim() : '';
+                    if (!updated) {
+                        status.textContent = 'A comment cannot be empty.';
+                        if (edit) edit.focus();
+                        return;
+                    }
+                    postCommentOperation('update', {
+                        commentId: comment.id,
+                        comment: updated,
+                    });
+                }
+            });
+        }
+
+        function handleEnterShortcut(event) {
+            if (!commentUiAvailable
+                || event.key !== 'Enter'
+                || (!event.ctrlKey && !event.metaKey)
+                || event.altKey) {
+                return false;
+            }
+            var target = event.target;
+            if (target === commentInput && !commentComposer.hidden) {
+                event.preventDefault();
+                commentComposer.querySelector(
+                    '[data-comment-action="confirm-add"]'
+                )?.click();
+                return true;
+            }
+            if (target && target.matches?.('[data-comment-edit]')) {
+                var item = target.closest('[data-comment-id]');
+                var save = item?.querySelector(
+                    '[data-comment-action="update"]'
+                );
+                if (save) {
+                    event.preventDefault();
+                    save.click();
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        function handleEscape(event) {
+            if (commentUiAvailable && state.clearAllConfirmation) {
+                event.preventDefault();
+                resetClearAllConfirmation();
+                status.textContent = 'Clear all cancelled.';
+                commentClearAll.focus();
+                return true;
+            }
+            if (commentUiAvailable && !commentComposer.hidden) {
+                event.preventDefault();
+                closeCommentComposer();
+                return true;
+            }
+            return false;
+        }
+
+        function initializeComments() {
+            var initialComments = readJsonAttribute('data-initial-comments');
+            if (validInitialComments(initialComments)) {
+                state.commentRevision = initialComments.revision;
+                state.comments = initialComments.comments.map(function (comment) {
+                    return Object.assign({}, comment);
+                });
+                renderComments();
+            } else {
+                status.textContent = 'Comment drafts are unavailable.';
+            }
+        }
+
+        return Object.freeze({
+            applyCommentsResult: applyCommentsResult,
+            applyLocateResult: applyLocateResult,
+            attach: attach,
+            handleEnterShortcut: handleEnterShortcut,
+            handleEscape: handleEscape,
+            initializeComments: initializeComments,
+            openCount: openCommentCount,
+            updateHighlights: updateCommentHighlights,
+        });
+    }
+
+    window.__agentPivotConversationComments = Object.freeze({ create: create });
+}());

--- a/src/webview/conversationOutlineScripts.js
+++ b/src/webview/conversationOutlineScripts.js
@@ -1,0 +1,462 @@
+(function () {
+    'use strict';
+
+    function create(options) {
+        var sidebarUiAvailable = options.available;
+        var bookmarkUiAvailable = options.bookmarkAvailable;
+        var commentTarget = options.target;
+        var subscriptionGeneration = options.subscriptionGeneration;
+        var status = options.status;
+        var outlineCount = options.outlineCount;
+        var outlineSummary = options.outlineSummary;
+        var outlineSearch = options.outlineSearch;
+        var outlineList = options.outlineList;
+        var outlineEmpty = options.outlineEmpty;
+        var outlinePartial = options.outlinePartial;
+        var outlineBookmarksOnly = options.outlineBookmarksOnly;
+        var post = options.post;
+        var outlinePanelActive = options.outlinePanelActive;
+        var persistPanelState = options.persistPanelState;
+        var updateToggle = options.updateToggle;
+        var state = {
+            outline: [],
+            outlineSelectedInteractionId: '',
+            outlineSelectedInput: 0,
+            outlineTotalInputs: 0,
+            outlinePartial: false,
+            outlineQuery: '',
+            bookmarkIds: new Set(),
+            bookmarkRevision: 0,
+            bookmarkRequestSequence: 0,
+            pendingBookmarkRequest: null,
+            bookmarksOnly: false,
+        };
+
+        function readJsonAttribute(name) {
+            var value = document.body.getAttribute(name);
+            if (!value) return null;
+            document.body.removeAttribute(name);
+            try {
+                return JSON.parse(value);
+            } catch (_error) {
+                return null;
+            }
+        }
+
+        function validBookmarkSnapshot(value) {
+            return value && typeof value === 'object' && !Array.isArray(value)
+                && Object.keys(value).length === 2
+                && Number.isSafeInteger(value.revision)
+                && value.revision >= 0
+                && Array.isArray(value.interactionIds)
+                && value.interactionIds.length <= 2000
+                && value.interactionIds.every(function (id) {
+                    return typeof id === 'string'
+                        && id.length > 0
+                        && id.length <= 512
+                        && !/[\u0000-\u001f\u007f]/.test(id);
+                })
+                && new Set(value.interactionIds).size
+                    === value.interactionIds.length;
+        }
+
+        function validBookmarksResult(value) {
+            if (!value || typeof value !== 'object' || Array.isArray(value)) {
+                return false;
+            }
+            var required = [
+                'type', 'version', 'requestId', 'subscriptionGeneration',
+                'projectId', 'provider', 'sessionId', 'operation', 'success',
+                'revision', 'interactionIds',
+            ];
+            var allowed = new Set(required.concat(['error']));
+            return Object.keys(value).every(function (key) {
+                return allowed.has(key);
+            }) && required.every(function (key) {
+                return Object.prototype.hasOwnProperty.call(value, key);
+            })
+                && value.type === 'conversation-viewer-bookmarks-result'
+                && value.version === 1
+                && typeof value.requestId === 'string'
+                && Number.isSafeInteger(value.subscriptionGeneration)
+                && typeof value.projectId === 'string'
+                && ['codex', 'kimi', 'claude'].includes(value.provider)
+                && typeof value.sessionId === 'string'
+                && value.operation === 'set'
+                && typeof value.success === 'boolean'
+                && validBookmarkSnapshot({
+                    revision: value.revision,
+                    interactionIds: value.interactionIds,
+                })
+                && (value.error === undefined
+                    || ['invalid', 'stale', 'failed', 'limit']
+                        .includes(value.error));
+        }
+
+        function nextBookmarkRequestId() {
+            state.bookmarkRequestSequence += 1;
+            return [
+                'conversation-bookmark',
+                Date.now().toString(36),
+                state.bookmarkRequestSequence.toString(36),
+            ].join(':');
+        }
+
+        function postBookmarkMutation(interactionId, bookmarked) {
+            if (!bookmarkUiAvailable
+                || state.pendingBookmarkRequest) return;
+            var requestId = nextBookmarkRequestId();
+            state.pendingBookmarkRequest = { requestId: requestId, interactionId: interactionId };
+            renderBookmarkState();
+            post({
+                type: 'conversation-viewer-bookmark-mutation',
+                version: 1,
+                requestId: requestId,
+                subscriptionGeneration: subscriptionGeneration,
+                projectId: commentTarget.projectId,
+                provider: commentTarget.provider,
+                sessionId: commentTarget.sessionId,
+                operation: 'set',
+                expectedRevision: state.bookmarkRevision,
+                payload: {
+                    interactionId: interactionId,
+                    bookmarked: bookmarked,
+                },
+            });
+        }
+
+        function applyBookmarksResult(message) {
+            if (!bookmarkUiAvailable
+                || !validBookmarksResult(message)
+                || !state.pendingBookmarkRequest
+                || message.requestId !== state.pendingBookmarkRequest.requestId
+                || message.subscriptionGeneration !== subscriptionGeneration
+                || message.projectId !== commentTarget.projectId
+                || message.provider !== commentTarget.provider
+                || message.sessionId !== commentTarget.sessionId) {
+                return false;
+            }
+            var focusedId = state.pendingBookmarkRequest.interactionId;
+            state.pendingBookmarkRequest = null;
+            state.bookmarkRevision = message.revision;
+            state.bookmarkIds = new Set(message.interactionIds);
+            renderBookmarkState();
+            filterOutline();
+            status.textContent = message.success
+                ? (state.bookmarkIds.has(focusedId)
+                    ? 'Input bookmarked.'
+                    : 'Bookmark removed.')
+                : 'Bookmark could not be updated.';
+            var focused = outlineList.querySelector(
+                '[data-outline-bookmark-id="' + CSS.escape(focusedId) + '"]'
+            );
+            if (focused) focused.focus();
+            return true;
+        }
+
+        function renderBookmarkState() {
+            if (!sidebarUiAvailable) return;
+            Array.prototype.forEach.call(
+                outlineList.querySelectorAll('[data-outline-bookmark-id]'),
+                function (button) {
+                    var interactionId = button.getAttribute(
+                        'data-outline-bookmark-id'
+                    );
+                    var bookmarked = state.bookmarkIds.has(interactionId);
+                    var entry = state.outline.find(function (candidate) {
+                        return candidate.interactionId === interactionId;
+                    });
+                    var inputNumber = entry ? entry.inputNumber : '';
+                    button.textContent = bookmarked ? '★' : '☆';
+                    button.classList.toggle('is-bookmarked', bookmarked);
+                    button.setAttribute('aria-pressed',
+                        bookmarked ? 'true' : 'false');
+                    button.setAttribute(
+                        'aria-label',
+                        (bookmarked ? 'Remove bookmark from input ' : 'Bookmark input ')
+                            + inputNumber
+                    );
+                    button.title = button.getAttribute('aria-label');
+                    button.disabled = !!state.pendingBookmarkRequest;
+                }
+            );
+            var count = state.bookmarkIds.size;
+            outlineBookmarksOnly.textContent = (state.bookmarksOnly ? '★' : '☆')
+                + ' Bookmarks (' + count + ')';
+            outlineBookmarksOnly.setAttribute(
+                'aria-pressed',
+                state.bookmarksOnly ? 'true' : 'false'
+            );
+        }
+
+        function outlineChanged(entries) {
+            return entries.length !== state.outline.length
+                || entries.some(function (entry, index) {
+                    var current = state.outline[index];
+                    return !current
+                        || current.interactionId !== entry.interactionId
+                        || current.userPreview !== entry.userPreview
+                        || current.responseState !== entry.responseState;
+                });
+        }
+
+        function responseStateLabel(value) {
+            if (value === 'inProgress') return 'Response in progress';
+            if (value === 'interrupted') return 'Response interrupted';
+            if (value === 'unknown') return 'Response state unknown';
+            return 'Response complete';
+        }
+
+        function buildOutlineList() {
+            var fragment = document.createDocumentFragment();
+            state.outline.forEach(function (entry) {
+                var item = document.createElement('li');
+                item.className = 'conversation-outline-item';
+                var bookmark = document.createElement('button');
+                bookmark.type = 'button';
+                bookmark.className = 'conversation-outline-bookmark';
+                bookmark.setAttribute(
+                    'data-outline-bookmark-id',
+                    entry.interactionId
+                );
+                var button = document.createElement('button');
+                button.type = 'button';
+                button.setAttribute('data-outline-interaction-id',
+                    entry.interactionId);
+                button.setAttribute('data-outline-filter-text',
+                    entry.userPreview.toLocaleLowerCase());
+                button.tabIndex = -1;
+
+                var number = document.createElement('span');
+                number.className = 'conversation-outline-number';
+                number.textContent = String(entry.inputNumber);
+                var preview = document.createElement('span');
+                preview.className = 'conversation-outline-preview';
+                preview.textContent = entry.userPreview || '(empty input)';
+                var responseState = document.createElement('span');
+                responseState.className = 'conversation-outline-state'
+                    + ' conversation-outline-state-' + entry.responseState;
+                responseState.title = responseStateLabel(entry.responseState);
+                responseState.setAttribute(
+                    'aria-label',
+                    responseStateLabel(entry.responseState)
+                );
+
+                button.appendChild(number);
+                button.appendChild(preview);
+                button.appendChild(responseState);
+                item.appendChild(bookmark);
+                item.appendChild(button);
+                fragment.appendChild(item);
+            });
+            outlineList.replaceChildren(fragment);
+            renderBookmarkState();
+        }
+
+        function visibleOutlineButtons() {
+            return Array.prototype.filter.call(
+                outlineList.querySelectorAll('[data-outline-interaction-id]'),
+                function (button) {
+                    return !button.closest('li').hidden;
+                }
+            );
+        }
+
+        function updateOutlineSelection(scrollSelected) {
+            var selected;
+            Array.prototype.forEach.call(
+                outlineList.querySelectorAll('[data-outline-interaction-id]'),
+                function (button) {
+                    var current = button.getAttribute(
+                        'data-outline-interaction-id'
+                    ) === state.outlineSelectedInteractionId;
+                    button.classList.toggle('is-selected', current);
+                    if (current) {
+                        button.setAttribute('aria-current', 'location');
+                        selected = button;
+                    } else {
+                        button.removeAttribute('aria-current');
+                    }
+                    button.tabIndex = current ? 0 : -1;
+                }
+            );
+            var visible = visibleOutlineButtons();
+            if (!visible.some(function (button) {
+                return button.tabIndex === 0;
+            }) && visible[0]) {
+                visible[0].tabIndex = 0;
+            }
+            if (scrollSelected
+                && selected
+                && outlinePanelActive()
+                && !selected.closest('li').hidden) {
+                selected.scrollIntoView({ block: 'nearest' });
+            }
+        }
+
+        function filterOutline() {
+            var query = state.outlineQuery.trim().toLocaleLowerCase();
+            var visibleCount = 0;
+            Array.prototype.forEach.call(
+                outlineList.querySelectorAll('.conversation-outline-item'),
+                function (item) {
+                    var button = item.querySelector(
+                        '[data-outline-interaction-id]'
+                    );
+                    var visible = !query
+                        || (button.getAttribute('data-outline-filter-text') || '')
+                            .includes(query);
+                    if (visible && state.bookmarksOnly) {
+                        visible = state.bookmarkIds.has(button.getAttribute(
+                            'data-outline-interaction-id'
+                        ));
+                    }
+                    item.hidden = !visible;
+                    if (visible) visibleCount += 1;
+                }
+            );
+            outlineEmpty.hidden = visibleCount > 0;
+            outlineEmpty.textContent = state.bookmarksOnly
+                ? 'No bookmarked inputs match this view.'
+                : 'No inputs match this search.';
+            updateOutlineSelection(false);
+        }
+
+        function applyOutline(message) {
+            if (!sidebarUiAvailable) return;
+            var selectedIndex = message.outline.findIndex(function (entry) {
+                return entry.interactionId === message.selectedInteractionId;
+            });
+            var offset = Math.max(
+                0,
+                message.selectedInput - selectedIndex - 1
+            );
+            var nextOutline = message.outline.map(function (entry, index) {
+                return Object.assign({}, entry, {
+                    inputNumber: offset + index + 1,
+                });
+            });
+            var changed = outlineChanged(nextOutline);
+            state.outline = nextOutline;
+            state.outlineSelectedInteractionId = message.selectedInteractionId;
+            state.outlineSelectedInput = message.selectedInput;
+            state.outlineTotalInputs = message.totalInputs;
+            state.outlinePartial = message.partial;
+            if (changed) buildOutlineList();
+            outlineCount.textContent = String(message.outline.length);
+            outlineCount.setAttribute(
+                'aria-label',
+                message.outline.length + ' inputs'
+            );
+            outlineSummary.textContent = message.partial
+                ? message.outline.length.toLocaleString() + '+ latest inputs'
+                : message.outline.length.toLocaleString() + ' inputs';
+            outlinePartial.hidden = !message.partial;
+            filterOutline();
+            renderBookmarkState();
+            updateOutlineSelection(changed || message.updateKind !== 'refresh');
+            updateToggle();
+        }
+
+        function attach() {
+            if (!sidebarUiAvailable) return;
+            outlineSearch.addEventListener('input', function () {
+                state.outlineQuery = outlineSearch.value;
+                filterOutline();
+                persistPanelState();
+            });
+            outlineBookmarksOnly.addEventListener('click', function () {
+                state.bookmarksOnly = !state.bookmarksOnly;
+                renderBookmarkState();
+                filterOutline();
+            });
+            outlineList.addEventListener('click', function (event) {
+                var bookmark = event.target.closest
+                    ? event.target.closest('[data-outline-bookmark-id]')
+                    : null;
+                if (bookmark && outlineList.contains(bookmark)) {
+                    var bookmarkId = bookmark.getAttribute(
+                        'data-outline-bookmark-id'
+                    );
+                    postBookmarkMutation(
+                        bookmarkId,
+                        !state.bookmarkIds.has(bookmarkId)
+                    );
+                    return;
+                }
+                var button = event.target.closest
+                    ? event.target.closest('[data-outline-interaction-id]')
+                    : null;
+                if (!button || !outlineList.contains(button)) return;
+                post({
+                    type: 'conversation-viewer-select-interaction',
+                    version: 1,
+                    interactionId: button.getAttribute(
+                        'data-outline-interaction-id'
+                    ),
+                });
+            });
+            outlineList.addEventListener('keydown', function (event) {
+                if (!['ArrowUp', 'ArrowDown', 'Home', 'End']
+                    .includes(event.key)) return;
+                var visible = visibleOutlineButtons();
+                if (!visible.length) return;
+                var current = event.target.closest
+                    ? event.target.closest('[data-outline-interaction-id]')
+                    : null;
+                var index = visible.indexOf(current);
+                if (event.key === 'Home') index = 0;
+                else if (event.key === 'End') index = visible.length - 1;
+                else if (event.key === 'ArrowUp') {
+                    index = Math.max(0, index - 1);
+                } else {
+                    index = Math.min(visible.length - 1, index + 1);
+                }
+                event.preventDefault();
+                visible.forEach(function (button) {
+                    button.tabIndex = -1;
+                });
+                visible[index].tabIndex = 0;
+                visible[index].focus();
+            });
+        }
+
+        function initializeBookmarks() {
+            var initialBookmarks = readJsonAttribute('data-initial-bookmarks');
+            if (validBookmarkSnapshot(initialBookmarks)) {
+                state.bookmarkRevision = initialBookmarks.revision;
+                state.bookmarkIds = new Set(initialBookmarks.interactionIds);
+                renderBookmarkState();
+            } else {
+                status.textContent = 'Conversation bookmarks are unavailable.';
+            }
+        }
+
+        function restoreQuery(value) {
+            if (typeof value !== 'string') return;
+            state.outlineQuery = value.slice(0, 4096);
+            outlineSearch.value = state.outlineQuery;
+        }
+
+        function query() {
+            return state.outlineQuery;
+        }
+
+        function size() {
+            return state.outline.length;
+        }
+
+        return Object.freeze({
+            applyBookmarksResult: applyBookmarksResult,
+            applyOutline: applyOutline,
+            attach: attach,
+            filter: filterOutline,
+            initializeBookmarks: initializeBookmarks,
+            query: query,
+            restoreQuery: restoreQuery,
+            size: size,
+        });
+    }
+
+    window.__agentPivotConversationOutline = Object.freeze({ create: create });
+}());

--- a/src/webview/conversationTelemetryScripts.js
+++ b/src/webview/conversationTelemetryScripts.js
@@ -1,0 +1,190 @@
+(function () {
+    'use strict';
+
+    function create(options) {
+        var commentTarget = options.target;
+        var subscriptionGeneration = options.subscriptionGeneration;
+        var latestRequestId = options.latestRequestId;
+        var telemetryRoot = options.telemetryRoot;
+        var telemetryModel = options.telemetryModel;
+        var telemetryModelValue = options.telemetryModelValue;
+        var telemetryContext = options.telemetryContext;
+        var telemetryContextProgress = options.telemetryContextProgress;
+        var telemetryContextValue = options.telemetryContextValue;
+        var telemetryLimits = options.telemetryLimits;
+        var scroll = options.scroll;
+        var captureAnchor = options.captureAnchor;
+        var restoreViewport = options.restoreViewport;
+        var state = {
+            latestTelemetryRequestId: 0,
+        };
+
+        function exactKeys(value, required, optional) {
+            if (!value || typeof value !== 'object' || Array.isArray(value)) {
+                return false;
+            }
+            var keys = Object.keys(value);
+            var allowed = new Set(required.concat(optional || []));
+            return required.every(function (key) {
+                return Object.prototype.hasOwnProperty.call(value, key);
+            }) && keys.every(function (key) {
+                return allowed.has(key);
+            });
+        }
+
+        function validTelemetry(value) {
+            if (!exactKeys(
+                value,
+                ['provider', 'sessionId', 'rateLimits'],
+                ['model', 'context']
+            )) return false;
+            if (!['codex', 'kimi', 'claude'].includes(value.provider)
+                || typeof value.sessionId !== 'string'
+                || !value.sessionId
+                || value.sessionId.length > 256
+                || (value.model !== undefined
+                    && (typeof value.model !== 'string'
+                        || !value.model
+                        || value.model.length > 128))
+                || !Array.isArray(value.rateLimits)
+                || value.rateLimits.length > 4) {
+                return false;
+            }
+            if (value.context !== undefined
+                && (!exactKeys(value.context, ['usedTokens', 'maxTokens'])
+                    || !Number.isSafeInteger(value.context.usedTokens)
+                    || value.context.usedTokens < 0
+                    || !Number.isSafeInteger(value.context.maxTokens)
+                    || value.context.maxTokens <= 0)) {
+                return false;
+            }
+            return value.rateLimits.every(function (limit) {
+                return exactKeys(
+                    limit,
+                    ['id', 'label', 'usedPercent'],
+                    ['windowDurationMins', 'resetsAt']
+                )
+                    && typeof limit.id === 'string'
+                    && limit.id.length > 0
+                    && limit.id.length <= 256
+                    && typeof limit.label === 'string'
+                    && limit.label.length > 0
+                    && limit.label.length <= 64
+                    && Number.isFinite(limit.usedPercent)
+                    && limit.usedPercent >= 0
+                    && limit.usedPercent <= 100
+                    && (limit.windowDurationMins === undefined
+                        || (Number.isSafeInteger(limit.windowDurationMins)
+                            && limit.windowDurationMins > 0))
+                    && (limit.resetsAt === undefined
+                        || (Number.isSafeInteger(limit.resetsAt)
+                            && limit.resetsAt > 0));
+            });
+        }
+
+        function compactTokens(value) {
+            if (value >= 1000000) {
+                return (value / 1000000).toFixed(value >= 10000000 ? 0 : 1) + 'm';
+            }
+            if (value >= 1000) {
+                return (value / 1000).toFixed(value >= 100000 ? 0 : 1) + 'k';
+            }
+            return String(value);
+        }
+
+        function compactResetTime(resetsAt) {
+            var remainingMinutes = Math.max(
+                1,
+                Math.ceil((resetsAt * 1000 - Date.now()) / 60000)
+            );
+            if (remainingMinutes < 60) return remainingMinutes + 'm';
+            var remainingHours = Math.ceil(remainingMinutes / 60);
+            if (remainingHours < 48) return remainingHours + 'h';
+            return Math.ceil(remainingHours / 24) + 'd';
+        }
+
+        function applyTelemetry(message) {
+            if (!exactKeys(
+                message,
+                ['type', 'version', 'requestId', 'subscriptionGeneration', 'telemetry']
+            )
+                || message.type !== 'conversation-viewer-telemetry'
+                || message.version !== 1
+                || !Number.isSafeInteger(message.requestId)
+                || message.requestId < latestRequestId()
+                || message.requestId < state.latestTelemetryRequestId
+                || message.subscriptionGeneration !== subscriptionGeneration
+                || (message.telemetry !== null
+                    && !validTelemetry(message.telemetry))
+                || (message.telemetry !== null
+                    && (!commentTarget
+                        || message.telemetry.provider !== commentTarget.provider
+                        || message.telemetry.sessionId !== commentTarget.sessionId))
+                || !telemetryRoot || !telemetryModel || !telemetryModelValue
+                || !telemetryContext || !telemetryContextProgress
+                || !telemetryContextValue || !telemetryLimits) {
+                return false;
+            }
+            state.latestTelemetryRequestId = message.requestId;
+            var readingAnchor = captureAnchor();
+            var previousScrollTop = scroll.scrollTop;
+            var telemetry = message.telemetry;
+            if (!telemetry) {
+                telemetryRoot.hidden = true;
+                restoreViewport(
+                    readingAnchor,
+                    previousScrollTop
+                );
+                return true;
+            }
+            telemetryModel.hidden = !telemetry.model;
+            telemetryModelValue.textContent = telemetry.model || '';
+            telemetryContext.hidden = !telemetry.context;
+            if (telemetry.context) {
+                var percent = Math.max(0, Math.min(
+                    100,
+                    telemetry.context.usedTokens
+                        / telemetry.context.maxTokens * 100
+                ));
+                telemetryContextProgress.max = telemetry.context.maxTokens;
+                telemetryContextProgress.value = telemetry.context.usedTokens;
+                telemetryContextValue.textContent = Math.round(percent) + '% · '
+                    + compactTokens(telemetry.context.usedTokens) + ' / '
+                    + compactTokens(telemetry.context.maxTokens);
+            }
+            telemetryLimits.replaceChildren();
+            telemetry.rateLimits.forEach(function (limit) {
+                var meter = document.createElement('div');
+                meter.className = 'conversation-telemetry-meter';
+                var label = document.createElement('span');
+                label.textContent = limit.label;
+                var progress = document.createElement('progress');
+                progress.max = 100;
+                progress.value = limit.usedPercent;
+                progress.setAttribute('aria-label', limit.label + ' usage');
+                var value = document.createElement('span');
+                var text = Math.round(100 - limit.usedPercent) + '% left';
+                if (limit.resetsAt) {
+                    text += ' · resets in ' + compactResetTime(limit.resetsAt);
+                    value.title = new Date(
+                        limit.resetsAt * 1000
+                    ).toLocaleString();
+                }
+                value.textContent = text;
+                meter.append(label, progress, value);
+                telemetryLimits.appendChild(meter);
+            });
+            telemetryRoot.hidden = !telemetry.model
+                && !telemetry.context
+                && telemetry.rateLimits.length === 0;
+            restoreViewport(readingAnchor, previousScrollTop);
+            return true;
+        }
+
+        return Object.freeze({
+            apply: applyTelemetry,
+        });
+    }
+
+    window.__agentPivotConversationTelemetry = Object.freeze({ create: create });
+}());

--- a/src/webview/conversationViewerScripts.js
+++ b/src/webview/conversationViewerScripts.js
@@ -122,13 +122,6 @@
         messageSignatures: new Map(),
         firstNewMessageId: null,
         renderGeneration: 0,
-        comments: [],
-        commentRevision: 0,
-        commentRequestSequence: 0,
-        pendingCommentRequest: null,
-        pendingLocateRequest: null,
-        clearAllConfirmation: false,
-        selectedCommentText: null,
         commentsPanelOpen: true,
         commentsPanelWidth: 240,
         sidebarView: 'outline',
@@ -192,6 +185,33 @@
         scroll: scroll,
         captureAnchor: captureReadingAnchor,
         restoreViewport: restoreViewportReadingPosition,
+    });
+    var commentsController = window.__agentPivotConversationComments.create({
+        available: commentUiAvailable,
+        target: commentTarget,
+        subscriptionGeneration: state.subscriptionGeneration,
+        status: status,
+        messages: messages,
+        scroll: scroll,
+        addComment: addComment,
+        commentsRoot: commentsRoot,
+        commentCount: commentCount,
+        commentSummary: commentSummary,
+        commentComposer: commentComposer,
+        commentSelection: commentSelection,
+        commentInput: commentInput,
+        commentList: commentList,
+        commentEmpty: commentEmpty,
+        commentNew: commentNew,
+        commentSend: commentSend,
+        commentClearSent: commentClearSent,
+        commentClearResolved: commentClearResolved,
+        commentClearAll: commentClearAll,
+        post: post,
+        messageSelector: conversationMessageSelector,
+        messageId: conversationMessageId,
+        setSidebarView: setSidebarView,
+        updateToggle: updateCommentsToggle,
     });
 
     if (!scroll || !messages || !position || !status || !newResponse
@@ -273,7 +293,8 @@
                 ? 'true'
                 : 'false'
         );
-        commentsToggle.textContent = 'Comments (' + openCommentCount()
+        commentsToggle.textContent = 'Comments ('
+            + commentsController.openCount()
             + ' open)';
         commentsToggle.setAttribute(
             'aria-expanded',
@@ -475,634 +496,6 @@
                 || value.provider === 'claude')
             && typeof value.sessionId === 'string'
             && value.sessionId.length > 0;
-    }
-
-    function validComment(value) {
-        if (!value || typeof value !== 'object' || Array.isArray(value)) {
-            return false;
-        }
-        var keys = [
-            'id', 'messageId', 'interactionId', 'role',
-            'quote', 'prefix', 'suffix', 'comment', 'status',
-        ];
-        var actualKeys = Object.keys(value);
-        var hasSessionScope = value.scope === 'session';
-        return actualKeys.length === keys.length + (hasSessionScope ? 1 : 0)
-            && keys.every(function (key) {
-                return Object.prototype.hasOwnProperty.call(value, key);
-            })
-            && (value.scope === undefined || hasSessionScope)
-            && typeof value.id === 'string'
-            && typeof value.messageId === 'string'
-            && typeof value.interactionId === 'string'
-            && (value.role === 'user' || value.role === 'assistant')
-            && typeof value.quote === 'string'
-            && typeof value.prefix === 'string'
-            && typeof value.suffix === 'string'
-            && typeof value.comment === 'string'
-            && (!hasSessionScope
-                || (value.messageId === ''
-                    && value.interactionId === ''
-                    && value.role === 'user'
-                    && value.quote === ''
-                    && value.prefix === ''
-                    && value.suffix === ''))
-            && (value.status === 'open'
-                || value.status === 'sent'
-                || value.status === 'resolved');
-    }
-
-    function validInitialComments(value) {
-        return value && typeof value === 'object' && !Array.isArray(value)
-            && Object.keys(value).length === 2
-            && Number.isSafeInteger(value.revision)
-            && value.revision >= 0
-            && Array.isArray(value.comments)
-            && value.comments.length <= 20
-            && value.comments.every(validComment);
-    }
-
-    function validCommentsResult(value) {
-        if (!value || typeof value !== 'object' || Array.isArray(value)) {
-            return false;
-        }
-        var required = [
-            'type', 'version', 'requestId', 'subscriptionGeneration',
-            'projectId', 'provider', 'sessionId', 'operation', 'success',
-            'revision', 'comments',
-        ];
-        var allowed = new Set(required.concat(['error']));
-        return Object.keys(value).every(function (key) {
-            return allowed.has(key);
-        }) && required.every(function (key) {
-            return Object.prototype.hasOwnProperty.call(value, key);
-        })
-            && value.type === 'conversation-viewer-comments-result'
-            && value.version === 1
-            && typeof value.requestId === 'string'
-            && Number.isSafeInteger(value.subscriptionGeneration)
-            && typeof value.projectId === 'string'
-            && (value.provider === 'codex'
-                || value.provider === 'kimi'
-                || value.provider === 'claude')
-            && typeof value.sessionId === 'string'
-            && (value.operation === 'add'
-                || value.operation === 'update'
-                || value.operation === 'delete'
-                || value.operation === 'resolve'
-                || value.operation === 'reopen'
-                || value.operation === 'clearSent'
-                || value.operation === 'clearResolved'
-                || value.operation === 'clearAll'
-                || value.operation === 'sendComments')
-            && typeof value.success === 'boolean'
-            && Number.isSafeInteger(value.revision)
-            && value.revision >= 0
-            && Array.isArray(value.comments)
-            && value.comments.length <= 20
-            && value.comments.every(validComment)
-            && (value.error === undefined || [
-                'invalid', 'stale', 'limit', 'tooLarge',
-                'unavailable', 'busy', 'conflict', 'failed',
-            ].includes(value.error));
-    }
-
-    function validLocateResult(value) {
-        if (!value || typeof value !== 'object' || Array.isArray(value)) {
-            return false;
-        }
-        var required = [
-            'type', 'version', 'requestId', 'subscriptionGeneration',
-            'projectId', 'provider', 'sessionId', 'commentId', 'success',
-        ];
-        var allowed = new Set(required.concat(['error']));
-        return Object.keys(value).every(function (key) {
-            return allowed.has(key);
-        }) && required.every(function (key) {
-            return Object.prototype.hasOwnProperty.call(value, key);
-        })
-            && value.type === 'conversation-viewer-locate-comment-result'
-            && value.version === 1
-            && typeof value.requestId === 'string'
-            && Number.isSafeInteger(value.subscriptionGeneration)
-            && typeof value.projectId === 'string'
-            && (value.provider === 'codex'
-                || value.provider === 'kimi'
-                || value.provider === 'claude')
-            && typeof value.sessionId === 'string'
-            && typeof value.commentId === 'string'
-            && typeof value.success === 'boolean'
-            && (value.error === undefined || value.error === 'stale');
-    }
-
-    function openCommentCount() {
-        return state.comments.filter(function (comment) {
-            return comment.status === 'open';
-        }).length;
-    }
-
-    function commentStatusCounts() {
-        return state.comments.reduce(function (counts, comment) {
-            counts[comment.status] += 1;
-            return counts;
-        }, { open: 0, sent: 0, resolved: 0 });
-    }
-
-    function resetClearAllConfirmation() {
-        if (!commentUiAvailable) return;
-        state.clearAllConfirmation = false;
-        commentClearAll.textContent = 'Clear all';
-        commentClearAll.removeAttribute('data-confirming');
-        commentClearAll.setAttribute('aria-label', 'Clear all comments');
-    }
-
-    function updateCommentControls() {
-        if (!commentUiAvailable) return;
-        var counts = commentStatusCounts();
-        var pending = !!state.pendingCommentRequest
-            || !!state.pendingLocateRequest;
-        var summary = [];
-        if (counts.open) summary.push(counts.open + ' open');
-        if (counts.sent) summary.push(counts.sent + ' added');
-        if (counts.resolved) summary.push(counts.resolved + ' resolved');
-        commentSummary.textContent = summary.length
-            ? summary.join(' · ')
-            : 'No comments yet';
-        commentCount.textContent = String(state.comments.length);
-        commentCount.setAttribute(
-            'aria-label',
-            state.comments.length + ' comment'
-                + (state.comments.length === 1 ? '' : 's')
-        );
-        commentSend.disabled = counts.open === 0 || pending;
-        commentNew.disabled = pending;
-        commentClearSent.disabled = counts.sent === 0 || pending;
-        commentClearResolved.disabled = counts.resolved === 0 || pending;
-        commentClearAll.disabled = state.comments.length === 0 || pending;
-    }
-
-    function nextCommentRequestId() {
-        state.commentRequestSequence += 1;
-        return [
-            'conversation-comment',
-            Date.now().toString(36),
-            state.commentRequestSequence.toString(36),
-        ].join(':');
-    }
-
-    function commentErrorMessage(error) {
-        if (error === 'stale') return 'Comments changed. Review the latest draft and try again.';
-        if (error === 'limit') return 'A maximum of 20 comments can be added at once.';
-        if (error === 'tooLarge') return 'The combined comments are too large to send.';
-        if (error === 'busy') return 'Wait for the current AI response to finish, then send again.';
-        if (error === 'conflict') return 'Multiple runtimes match this session. Resolve the conflict first.';
-        if (error === 'unavailable') return 'This session is unavailable and the comments were not added.';
-        return 'The comment action failed. Your comments were kept.';
-    }
-
-    function setCommentPending(pending) {
-        if (!commentUiAvailable) return;
-        Array.prototype.forEach.call(
-            commentsRoot.querySelectorAll('button, textarea'),
-            function (control) {
-                control.disabled = pending;
-            }
-        );
-        addComment.disabled = pending;
-        if (!pending) {
-            updateCommentControls();
-        }
-        commentsRoot.setAttribute('aria-busy', pending ? 'true' : 'false');
-    }
-
-    function postCommentOperation(operation, payload) {
-        if (!commentUiAvailable
-            || state.pendingCommentRequest
-            || state.pendingLocateRequest) return;
-        var requestId = nextCommentRequestId();
-        resetClearAllConfirmation();
-        state.pendingCommentRequest = { requestId: requestId, operation: operation };
-        setCommentPending(true);
-        status.textContent = operation === 'sendComments'
-            ? 'Adding comments to session input…'
-            : operation === 'clearSent'
-                || operation === 'clearResolved'
-                || operation === 'clearAll'
-                ? 'Clearing comments…'
-                : 'Saving comment…';
-        post({
-            type: operation === 'sendComments'
-                ? 'conversation-viewer-send-comments'
-                : 'conversation-viewer-comment-mutation',
-            version: 1,
-            requestId: requestId,
-            subscriptionGeneration: state.subscriptionGeneration,
-            projectId: commentTarget.projectId,
-            provider: commentTarget.provider,
-            sessionId: commentTarget.sessionId,
-            operation: operation,
-            expectedRevision: state.commentRevision,
-            payload: payload,
-        });
-    }
-
-    function locateComment(comment) {
-        if (comment.scope === 'session') return false;
-        var message = Array.prototype.find.call(
-            messages.querySelectorAll(conversationMessageSelector()),
-            function (candidate) {
-                return conversationMessageId(candidate) === comment.messageId;
-            }
-        );
-        if (!message) {
-            return false;
-        }
-        message.scrollIntoView({ block: 'center' });
-        message.tabIndex = -1;
-        message.focus({ preventScroll: true });
-        message.classList.add('conversation-comment-located');
-        window.setTimeout(function () {
-            message.classList.remove('conversation-comment-located');
-        }, 1600);
-        return true;
-    }
-
-    function requestCommentLocation(comment) {
-        if (locateComment(comment)) {
-            status.textContent = 'Comment source located.';
-            return;
-        }
-        if (state.pendingLocateRequest || state.pendingCommentRequest) return;
-        var requestId = nextCommentRequestId();
-        state.pendingLocateRequest = {
-            requestId: requestId,
-            commentId: comment.id,
-        };
-        setCommentPending(true);
-        status.textContent = 'Loading the commented message…';
-        post({
-            type: 'conversation-viewer-locate-comment',
-            version: 1,
-            requestId: requestId,
-            subscriptionGeneration: state.subscriptionGeneration,
-            projectId: commentTarget.projectId,
-            provider: commentTarget.provider,
-            sessionId: commentTarget.sessionId,
-            commentId: comment.id,
-        });
-    }
-
-    function renderComments() {
-        if (!commentUiAvailable) return;
-        resetClearAllConfirmation();
-        commentList.replaceChildren();
-        state.comments.forEach(function (comment, index) {
-            var item = document.createElement('article');
-            item.className = 'conversation-comment';
-            item.setAttribute('data-comment-id', comment.id);
-            item.setAttribute('data-comment-status', comment.status);
-            item.setAttribute(
-                'data-comment-scope',
-                comment.scope === 'session' ? 'session' : 'selection'
-            );
-
-            var heading = document.createElement('div');
-            heading.className = 'conversation-comment-heading';
-            var identity = document.createElement('div');
-            identity.className = 'conversation-comment-identity';
-            var label = document.createElement('strong');
-            label.textContent = 'Comment ' + (index + 1);
-            if (comment.scope === 'session') {
-                var scope = document.createElement('span');
-                scope.className = 'conversation-comment-scope';
-                scope.textContent = 'Session note';
-                identity.append(label, scope);
-            } else {
-                identity.appendChild(label);
-            }
-            var statusLabel = document.createElement('span');
-            statusLabel.className = 'conversation-comment-status';
-            statusLabel.setAttribute('data-comment-status-label', '');
-            statusLabel.textContent = comment.status === 'open'
-                ? 'Open'
-                : comment.status === 'sent' ? 'Added' : 'Resolved';
-            identity.appendChild(statusLabel);
-            heading.appendChild(identity);
-            if (comment.scope !== 'session') {
-                var locate = document.createElement('button');
-                locate.type = 'button';
-                locate.className = 'conversation-comment-locate';
-                locate.setAttribute('data-comment-action', 'locate');
-                locate.textContent = 'Show text';
-                heading.appendChild(locate);
-            }
-
-            var quoteGroup = document.createElement('div');
-            quoteGroup.className = 'conversation-comment-quote';
-            var quoteLabel = document.createElement('span');
-            quoteLabel.className = 'conversation-comment-quote-label';
-            quoteLabel.textContent = 'Selected text';
-            var quote = document.createElement('blockquote');
-            quote.textContent = comment.quote;
-            quoteGroup.append(quoteLabel, quote);
-            var input = document.createElement('textarea');
-            input.rows = 2;
-            input.maxLength = 4000;
-            input.value = comment.comment;
-            input.readOnly = comment.status !== 'open';
-            input.setAttribute('aria-label', 'Comment ' + (index + 1));
-            input.setAttribute(
-                'aria-keyshortcuts',
-                'Control+Enter Meta+Enter'
-            );
-            input.setAttribute('data-comment-edit', '');
-            var actions = document.createElement('div');
-            actions.className = 'conversation-comment-actions';
-            var remove = document.createElement('button');
-            remove.type = 'button';
-            remove.className = 'conversation-comment-delete';
-            remove.setAttribute('data-comment-action', 'delete');
-            remove.textContent = 'Delete';
-            actions.appendChild(remove);
-            if (comment.status === 'open') {
-                var save = document.createElement('button');
-                save.type = 'button';
-                save.setAttribute('data-comment-action', 'update');
-                save.title = 'Save comment (Ctrl+Enter or Cmd+Enter)';
-                save.textContent = 'Save';
-                actions.appendChild(save);
-            }
-            var review = document.createElement('button');
-            review.type = 'button';
-            if (comment.status === 'resolved') {
-                review.setAttribute('data-comment-action', 'reopen');
-                review.textContent = 'Reopen';
-            } else if (comment.status === 'sent') {
-                review.setAttribute('data-comment-action', 'resolve');
-                review.textContent = 'Resolve';
-                var reopen = document.createElement('button');
-                reopen.type = 'button';
-                reopen.setAttribute('data-comment-action', 'reopen');
-                reopen.textContent = 'Reopen';
-                actions.appendChild(reopen);
-            } else {
-                review.setAttribute('data-comment-action', 'resolve');
-                review.textContent = 'Resolve';
-            }
-            actions.appendChild(review);
-            item.appendChild(heading);
-            if (comment.scope !== 'session') {
-                item.appendChild(quoteGroup);
-            }
-            item.append(input, actions);
-            commentList.appendChild(item);
-        });
-        updateCommentsToggle();
-        commentEmpty.hidden = state.comments.length > 0;
-        var openCount = openCommentCount();
-        commentSend.textContent = 'Send ' + openCount + ' open comment'
-            + (openCount === 1 ? '' : 's') + ' to this session';
-        updateCommentControls();
-        updateCommentHighlights();
-    }
-
-    function findQuoteRange(root, comment) {
-        var walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
-        var nodes = [];
-        var combined = '';
-        var node;
-        while ((node = walker.nextNode())) {
-            nodes.push({ node: node, start: combined.length });
-            combined += node.nodeValue || '';
-        }
-        var candidates = [];
-        var candidate = combined.indexOf(comment.quote);
-        while (candidate >= 0) {
-            candidates.push(candidate);
-            candidate = combined.indexOf(
-                comment.quote,
-                candidate + 1
-            );
-        }
-        var start = candidates.find(function (offset) {
-            var before = combined.slice(
-                Math.max(0, offset - comment.prefix.length),
-                offset
-            );
-            var after = combined.slice(
-                offset + comment.quote.length,
-                offset + comment.quote.length + comment.suffix.length
-            );
-            return before === comment.prefix && after === comment.suffix;
-        });
-        if (start === undefined) start = candidates[0];
-        if (start === undefined) return null;
-        var end = start + comment.quote.length;
-        var startRecord = nodes.find(function (record) {
-            return start >= record.start
-                && start <= record.start + (record.node.nodeValue || '').length;
-        });
-        var endRecord = nodes.find(function (record) {
-            return end >= record.start
-                && end <= record.start + (record.node.nodeValue || '').length;
-        });
-        if (!startRecord || !endRecord) return null;
-        var range = document.createRange();
-        range.setStart(startRecord.node, start - startRecord.start);
-        range.setEnd(endRecord.node, end - endRecord.start);
-        return range;
-    }
-
-    function updateCommentHighlights() {
-        if (!commentUiAvailable) return;
-        Array.prototype.forEach.call(
-            messages.querySelectorAll('.conversation-has-comment'),
-            function (message) {
-                message.classList.remove('conversation-has-comment');
-            }
-        );
-        var ranges = [];
-        state.comments.forEach(function (comment) {
-            if (comment.status === 'resolved'
-                || comment.scope === 'session') return;
-            var message = Array.prototype.find.call(
-                messages.querySelectorAll(conversationMessageSelector()),
-                function (candidate) {
-                    return conversationMessageId(candidate)
-                        === comment.messageId;
-                }
-            );
-            if (!message) return;
-            message.classList.add('conversation-has-comment');
-            var markdown = message.querySelector('.conversation-markdown');
-            var range = markdown && findQuoteRange(markdown, comment);
-            if (range) ranges.push(range);
-        });
-        if (window.CSS && CSS.highlights && typeof Highlight === 'function') {
-            CSS.highlights.delete('conversation-comments');
-            if (ranges.length) {
-                CSS.highlights.set(
-                    'conversation-comments',
-                    new Highlight(...ranges)
-                );
-            }
-        }
-    }
-
-    function applyCommentsResult(message) {
-        if (!commentUiAvailable
-            || !validCommentsResult(message)
-            || message.subscriptionGeneration !== state.subscriptionGeneration
-            || message.projectId !== commentTarget.projectId
-            || message.provider !== commentTarget.provider
-            || message.sessionId !== commentTarget.sessionId
-            || !state.pendingCommentRequest
-            || message.requestId !== state.pendingCommentRequest.requestId
-            || message.operation !== state.pendingCommentRequest.operation) {
-            return false;
-        }
-        state.commentRevision = message.revision;
-        state.comments = message.comments.map(function (comment) {
-            return Object.assign({}, comment);
-        });
-        renderComments();
-        var operation = state.pendingCommentRequest.operation;
-        state.pendingCommentRequest = null;
-        setCommentPending(false);
-        if (message.success) {
-            status.textContent = operation === 'sendComments'
-                ? 'Comments added to session input. Review and press Enter to send.'
-                : operation === 'clearSent'
-                    ? 'Added comments cleared.'
-                    : operation === 'clearResolved'
-                        ? 'Resolved comments cleared.'
-                        : operation === 'clearAll'
-                            ? 'All comments cleared.'
-                            : 'Comments saved.';
-        } else {
-            status.textContent = commentErrorMessage(message.error);
-        }
-        return true;
-    }
-
-    function applyLocateResult(message) {
-        if (!commentUiAvailable
-            || !validLocateResult(message)
-            || message.subscriptionGeneration !== state.subscriptionGeneration
-            || message.projectId !== commentTarget.projectId
-            || message.provider !== commentTarget.provider
-            || message.sessionId !== commentTarget.sessionId
-            || !state.pendingLocateRequest
-            || message.requestId !== state.pendingLocateRequest.requestId
-            || message.commentId !== state.pendingLocateRequest.commentId) {
-            return false;
-        }
-        var comment = state.comments.find(function (candidate) {
-            return candidate.id === message.commentId;
-        });
-        state.pendingLocateRequest = null;
-        setCommentPending(false);
-        if (message.success && comment && locateComment(comment)) {
-            status.textContent = 'Comment source located.';
-        } else {
-            status.textContent = 'The commented message is no longer available.';
-        }
-        return true;
-    }
-
-    function selectionContext(range, markdown) {
-        var before = document.createRange();
-        before.selectNodeContents(markdown);
-        before.setEnd(range.startContainer, range.startOffset);
-        var after = document.createRange();
-        after.selectNodeContents(markdown);
-        after.setStart(range.endContainer, range.endOffset);
-        return {
-            prefix: before.toString().slice(-240),
-            suffix: after.toString().slice(0, 240),
-        };
-    }
-
-    function captureCommentSelection() {
-        if (!commentUiAvailable || state.pendingCommentRequest) return;
-        var selection = window.getSelection();
-        if (!selection || selection.rangeCount !== 1 || selection.isCollapsed) {
-            addComment.hidden = true;
-            state.selectedCommentText = null;
-            return;
-        }
-        var range = selection.getRangeAt(0);
-        var startElement = range.startContainer.nodeType === Node.ELEMENT_NODE
-            ? range.startContainer
-            : range.startContainer.parentElement;
-        var endElement = range.endContainer.nodeType === Node.ELEMENT_NODE
-            ? range.endContainer
-            : range.endContainer.parentElement;
-        var startMessage = startElement && startElement.closest
-            ? startElement.closest(conversationMessageSelector())
-            : null;
-        var endMessage = endElement && endElement.closest
-            ? endElement.closest(conversationMessageSelector())
-            : null;
-        var markdown = startElement && startElement.closest
-            ? startElement.closest('.conversation-markdown')
-            : null;
-        var quote = selection.toString().trim();
-        if (!startMessage || startMessage !== endMessage || !markdown
-            || !messages.contains(startMessage) || !quote
-            || Array.from(quote).length > 4000) {
-            addComment.hidden = true;
-            state.selectedCommentText = null;
-            return;
-        }
-        var context = selectionContext(range, markdown);
-        state.selectedCommentText = {
-            messageId: conversationMessageId(startMessage),
-            interactionId: startMessage.getAttribute('data-interaction-id'),
-            quote: quote,
-            prefix: context.prefix,
-            suffix: context.suffix,
-        };
-        var rect = range.getBoundingClientRect();
-        addComment.style.left = Math.max(
-            8,
-            Math.min(window.innerWidth - 120, rect.left)
-        ) + 'px';
-        addComment.style.top = Math.max(8, rect.bottom + 6) + 'px';
-        addComment.hidden = false;
-    }
-
-    function openCommentComposer() {
-        if (!state.selectedCommentText) return;
-        setSidebarView('comments', true, true);
-        addComment.hidden = true;
-        commentSelection.textContent = state.selectedCommentText.quote;
-        commentComposer.setAttribute('data-comment-composer-scope', 'selection');
-        commentInput.value = '';
-        commentComposer.hidden = false;
-        commentInput.focus();
-    }
-
-    function openSessionCommentComposer() {
-        if (!commentUiAvailable
-            || state.pendingCommentRequest
-            || state.pendingLocateRequest) return;
-        setSidebarView('comments', true, true);
-        addComment.hidden = true;
-        state.selectedCommentText = { scope: 'session' };
-        commentSelection.textContent = 'Session note';
-        commentComposer.setAttribute('data-comment-composer-scope', 'session');
-        commentInput.value = '';
-        commentComposer.hidden = false;
-        commentInput.focus();
-    }
-
-    function closeCommentComposer() {
-        commentComposer.hidden = true;
-        commentComposer.removeAttribute('data-comment-composer-scope');
-        commentInput.value = '';
-        state.selectedCommentText = null;
-        addComment.hidden = true;
     }
 
     function validOutlineEntry(entry) {
@@ -1324,7 +717,7 @@
         state.atLatest = message.atLatest;
         state.initialized = true;
         outlineController.applyOutline(message);
-        updateCommentHighlights();
+        commentsController.updateHighlights();
         updatePosition(message);
         previous.disabled = message.previousCursor === undefined;
         next.disabled = message.nextCursor === undefined;
@@ -1556,153 +949,12 @@
         });
     });
     if (commentUiAvailable) {
-        messages.addEventListener('mouseup', function () {
-            window.setTimeout(captureCommentSelection, 0);
-        });
-        messages.addEventListener('keyup', function (event) {
-            if (event.key === 'Shift'
-                || event.key.startsWith('Arrow')
-                || event.key === 'Home'
-                || event.key === 'End') {
-                window.setTimeout(captureCommentSelection, 0);
-            }
-        });
-        scroll.addEventListener('scroll', function () {
-            addComment.hidden = true;
-        });
-        addComment.addEventListener('click', openCommentComposer);
-        commentsRoot.addEventListener('click', function (event) {
-            var button = event.target && event.target.closest
-                ? event.target.closest('[data-comment-action]')
-                : null;
-            if (!button || !commentsRoot.contains(button)
-                || state.pendingCommentRequest
-                || state.pendingLocateRequest) {
-                return;
-            }
-            var action = button.getAttribute('data-comment-action');
-            if (action !== 'clearAll' && state.clearAllConfirmation) {
-                resetClearAllConfirmation();
-            }
-            if (action === 'new') {
-                openSessionCommentComposer();
-                return;
-            }
-            if (action === 'cancel-add') {
-                closeCommentComposer();
-                return;
-            }
-            if (action === 'confirm-add') {
-                var text = commentInput.value.trim();
-                if (!state.selectedCommentText || !text) {
-                    status.textContent = 'Enter a comment before adding it.';
-                    commentInput.focus();
-                    return;
-                }
-                var payload = Object.assign(
-                    {},
-                    state.selectedCommentText,
-                    { comment: text }
-                );
-                closeCommentComposer();
-                postCommentOperation('add', payload);
-                return;
-            }
-            if (action === 'send') {
-                postCommentOperation('sendComments', {});
-                return;
-            }
-            if (action === 'clearSent' || action === 'clearResolved') {
-                postCommentOperation(action, {});
-                return;
-            }
-            if (action === 'clearAll') {
-                if (!state.clearAllConfirmation) {
-                    state.clearAllConfirmation = true;
-                    commentClearAll.textContent = 'Confirm clear all';
-                    commentClearAll.setAttribute('data-confirming', 'true');
-                    commentClearAll.setAttribute(
-                        'aria-label',
-                        'Confirm clearing all comments'
-                    );
-                    status.textContent =
-                        'Select Clear all again to remove every comment.';
-                    return;
-                }
-                postCommentOperation('clearAll', {});
-                return;
-            }
-            var item = button.closest('[data-comment-id]');
-            var commentId = item && item.getAttribute('data-comment-id');
-            var comment = state.comments.find(function (candidate) {
-                return candidate.id === commentId;
-            });
-            if (!item || !comment) return;
-            if (action === 'locate') {
-                requestCommentLocation(comment);
-                return;
-            }
-            if (action === 'delete') {
-                postCommentOperation('delete', { commentId: comment.id });
-                return;
-            }
-            if (action === 'resolve' || action === 'reopen') {
-                postCommentOperation(action, { commentId: comment.id });
-                return;
-            }
-            if (action === 'update') {
-                var edit = item.querySelector('[data-comment-edit]');
-                var updated = edit ? edit.value.trim() : '';
-                if (!updated) {
-                    status.textContent = 'A comment cannot be empty.';
-                    if (edit) edit.focus();
-                    return;
-                }
-                postCommentOperation('update', {
-                    commentId: comment.id,
-                    comment: updated,
-                });
-            }
-        });
+        commentsController.attach();
     }
     document.addEventListener('keydown', function (event) {
-        if (commentUiAvailable
-            && event.key === 'Enter'
-            && (event.ctrlKey || event.metaKey)
-            && !event.altKey) {
-            var target = event.target;
-            if (target === commentInput && !commentComposer.hidden) {
-                event.preventDefault();
-                commentComposer.querySelector(
-                    '[data-comment-action="confirm-add"]'
-                )?.click();
-                return;
-            }
-            if (target && target.matches?.('[data-comment-edit]')) {
-                var item = target.closest('[data-comment-id]');
-                var save = item?.querySelector(
-                    '[data-comment-action="update"]'
-                );
-                if (save) {
-                    event.preventDefault();
-                    save.click();
-                    return;
-                }
-            }
-        }
+        if (commentsController.handleEnterShortcut(event)) return;
         if (event.key !== 'Escape') return;
-        if (commentUiAvailable && state.clearAllConfirmation) {
-            event.preventDefault();
-            resetClearAllConfirmation();
-            status.textContent = 'Clear all cancelled.';
-            commentClearAll.focus();
-            return;
-        }
-        if (commentUiAvailable && !commentComposer.hidden) {
-            event.preventDefault();
-            closeCommentComposer();
-            return;
-        }
+        if (commentsController.handleEscape(event)) return;
         if (sidebarUiAvailable
             && state.commentsPanelOpen
             && sidebarRoot.contains(document.activeElement)) {
@@ -1717,8 +969,8 @@
     });
     window.addEventListener('message', function (event) {
         if (outlineController.applyBookmarksResult(event.data)) return;
-        if (applyCommentsResult(event.data)) return;
-        if (applyLocateResult(event.data)) return;
+        if (commentsController.applyCommentsResult(event.data)) return;
+        if (commentsController.applyLocateResult(event.data)) return;
         if (telemetryController.apply(event.data)) return;
         applyPage(event.data);
     });
@@ -1755,15 +1007,6 @@
         outlineController.filter();
     }
     if (commentUiAvailable) {
-        var initialComments = readJsonAttribute('data-initial-comments');
-        if (validInitialComments(initialComments)) {
-            state.commentRevision = initialComments.revision;
-            state.comments = initialComments.comments.map(function (comment) {
-                return Object.assign({}, comment);
-            });
-            renderComments();
-        } else {
-            status.textContent = 'Comment drafts are unavailable.';
-        }
+        commentsController.initializeComments();
     }
 }());

--- a/src/webview/conversationViewerScripts.js
+++ b/src/webview/conversationViewerScripts.js
@@ -115,7 +115,6 @@
         followingEnd: false,
         initialized: false,
         latestRequestId: 0,
-        latestTelemetryRequestId: 0,
         subscriptionGeneration: Number(document.body.getAttribute(
             'data-subscription-generation'
         )),
@@ -176,6 +175,23 @@
         },
         persistPanelState: saveCommentsPanelState,
         updateToggle: updateCommentsToggle,
+    });
+    var telemetryController = window.__agentPivotConversationTelemetry.create({
+        target: commentTarget,
+        subscriptionGeneration: state.subscriptionGeneration,
+        latestRequestId: function () {
+            return state.latestRequestId;
+        },
+        telemetryRoot: telemetryRoot,
+        telemetryModel: telemetryModel,
+        telemetryModelValue: telemetryModelValue,
+        telemetryContext: telemetryContext,
+        telemetryContextProgress: telemetryContextProgress,
+        telemetryContextValue: telemetryContextValue,
+        telemetryLimits: telemetryLimits,
+        scroll: scroll,
+        captureAnchor: captureReadingAnchor,
+        restoreViewport: restoreViewportReadingPosition,
     });
 
     if (!scroll || !messages || !position || !status || !newResponse
@@ -1166,168 +1182,6 @@
             && typeof message.stale === 'boolean';
     }
 
-    function exactKeys(value, required, optional) {
-        if (!value || typeof value !== 'object' || Array.isArray(value)) {
-            return false;
-        }
-        var keys = Object.keys(value);
-        var allowed = new Set(required.concat(optional || []));
-        return required.every(function (key) {
-            return Object.prototype.hasOwnProperty.call(value, key);
-        }) && keys.every(function (key) {
-            return allowed.has(key);
-        });
-    }
-
-    function validTelemetry(value) {
-        if (!exactKeys(
-            value,
-            ['provider', 'sessionId', 'rateLimits'],
-            ['model', 'context']
-        )) return false;
-        if (!['codex', 'kimi', 'claude'].includes(value.provider)
-            || typeof value.sessionId !== 'string'
-            || !value.sessionId
-            || value.sessionId.length > 256
-            || (value.model !== undefined
-                && (typeof value.model !== 'string'
-                    || !value.model
-                    || value.model.length > 128))
-            || !Array.isArray(value.rateLimits)
-            || value.rateLimits.length > 4) {
-            return false;
-        }
-        if (value.context !== undefined
-            && (!exactKeys(value.context, ['usedTokens', 'maxTokens'])
-                || !Number.isSafeInteger(value.context.usedTokens)
-                || value.context.usedTokens < 0
-                || !Number.isSafeInteger(value.context.maxTokens)
-                || value.context.maxTokens <= 0)) {
-            return false;
-        }
-        return value.rateLimits.every(function (limit) {
-            return exactKeys(
-                limit,
-                ['id', 'label', 'usedPercent'],
-                ['windowDurationMins', 'resetsAt']
-            )
-                && typeof limit.id === 'string'
-                && limit.id.length > 0
-                && limit.id.length <= 256
-                && typeof limit.label === 'string'
-                && limit.label.length > 0
-                && limit.label.length <= 64
-                && Number.isFinite(limit.usedPercent)
-                && limit.usedPercent >= 0
-                && limit.usedPercent <= 100
-                && (limit.windowDurationMins === undefined
-                    || (Number.isSafeInteger(limit.windowDurationMins)
-                        && limit.windowDurationMins > 0))
-                && (limit.resetsAt === undefined
-                    || (Number.isSafeInteger(limit.resetsAt)
-                        && limit.resetsAt > 0));
-        });
-    }
-
-    function compactTokens(value) {
-        if (value >= 1000000) {
-            return (value / 1000000).toFixed(value >= 10000000 ? 0 : 1) + 'm';
-        }
-        if (value >= 1000) {
-            return (value / 1000).toFixed(value >= 100000 ? 0 : 1) + 'k';
-        }
-        return String(value);
-    }
-
-    function compactResetTime(resetsAt) {
-        var remainingMinutes = Math.max(
-            1,
-            Math.ceil((resetsAt * 1000 - Date.now()) / 60000)
-        );
-        if (remainingMinutes < 60) return remainingMinutes + 'm';
-        var remainingHours = Math.ceil(remainingMinutes / 60);
-        if (remainingHours < 48) return remainingHours + 'h';
-        return Math.ceil(remainingHours / 24) + 'd';
-    }
-
-    function applyTelemetry(message) {
-        if (!exactKeys(
-            message,
-            ['type', 'version', 'requestId', 'subscriptionGeneration', 'telemetry']
-        )
-            || message.type !== 'conversation-viewer-telemetry'
-            || message.version !== 1
-            || !Number.isSafeInteger(message.requestId)
-            || message.requestId < state.latestRequestId
-            || message.requestId < state.latestTelemetryRequestId
-            || message.subscriptionGeneration !== state.subscriptionGeneration
-            || (message.telemetry !== null
-                && !validTelemetry(message.telemetry))
-            || (message.telemetry !== null
-                && (!commentTarget
-                    || message.telemetry.provider !== commentTarget.provider
-                    || message.telemetry.sessionId !== commentTarget.sessionId))
-            || !telemetryRoot || !telemetryModel || !telemetryModelValue
-            || !telemetryContext || !telemetryContextProgress
-            || !telemetryContextValue || !telemetryLimits) {
-            return false;
-        }
-        state.latestTelemetryRequestId = message.requestId;
-        var readingAnchor = captureReadingAnchor();
-        var previousScrollTop = scroll.scrollTop;
-        var telemetry = message.telemetry;
-        if (!telemetry) {
-            telemetryRoot.hidden = true;
-            restoreViewportReadingPosition(
-                readingAnchor,
-                previousScrollTop
-            );
-            return true;
-        }
-        telemetryModel.hidden = !telemetry.model;
-        telemetryModelValue.textContent = telemetry.model || '';
-        telemetryContext.hidden = !telemetry.context;
-        if (telemetry.context) {
-            var percent = Math.max(0, Math.min(
-                100,
-                telemetry.context.usedTokens
-                    / telemetry.context.maxTokens * 100
-            ));
-            telemetryContextProgress.max = telemetry.context.maxTokens;
-            telemetryContextProgress.value = telemetry.context.usedTokens;
-            telemetryContextValue.textContent = Math.round(percent) + '% · '
-                + compactTokens(telemetry.context.usedTokens) + ' / '
-                + compactTokens(telemetry.context.maxTokens);
-        }
-        telemetryLimits.replaceChildren();
-        telemetry.rateLimits.forEach(function (limit) {
-            var meter = document.createElement('div');
-            meter.className = 'conversation-telemetry-meter';
-            var label = document.createElement('span');
-            label.textContent = limit.label;
-            var progress = document.createElement('progress');
-            progress.max = 100;
-            progress.value = limit.usedPercent;
-            progress.setAttribute('aria-label', limit.label + ' usage');
-            var value = document.createElement('span');
-            var text = Math.round(100 - limit.usedPercent) + '% left';
-            if (limit.resetsAt) {
-                text += ' · resets in ' + compactResetTime(limit.resetsAt);
-                value.title = new Date(
-                    limit.resetsAt * 1000
-                ).toLocaleString();
-            }
-            value.textContent = text;
-            meter.append(label, progress, value);
-            telemetryLimits.appendChild(meter);
-        });
-        telemetryRoot.hidden = !telemetry.model
-            && !telemetry.context
-            && telemetry.rateLimits.length === 0;
-        restoreViewportReadingPosition(readingAnchor, previousScrollTop);
-        return true;
-    }
-
     function reconcileMessages(clean, preserveUnchanged, previousSignatures) {
         var template = document.createElement('template');
         template.innerHTML = clean;
@@ -1865,7 +1719,7 @@
         if (outlineController.applyBookmarksResult(event.data)) return;
         if (applyCommentsResult(event.data)) return;
         if (applyLocateResult(event.data)) return;
-        if (applyTelemetry(event.data)) return;
+        if (telemetryController.apply(event.data)) return;
         applyPage(event.data);
     });
     window.addEventListener('unload', releaseMermaidObjectUrls);

--- a/src/webview/conversationViewerScripts.js
+++ b/src/webview/conversationViewerScripts.js
@@ -133,17 +133,6 @@
         commentsPanelOpen: true,
         commentsPanelWidth: 240,
         sidebarView: 'outline',
-        outline: [],
-        outlineSelectedInteractionId: '',
-        outlineSelectedInput: 0,
-        outlineTotalInputs: 0,
-        outlinePartial: false,
-        outlineQuery: '',
-        bookmarkIds: new Set(),
-        bookmarkRevision: 0,
-        bookmarkRequestSequence: 0,
-        pendingBookmarkRequest: null,
-        bookmarksOnly: false,
     };
     var readingAnchorController =
         window.__agentPivotConversationReadingAnchor.create({
@@ -168,6 +157,26 @@
     var releaseMermaidObjectUrls = mermaidRenderer.release;
     var renderMermaidDiagrams = mermaidRenderer.render;
     var preserveMermaidContent = mermaidRenderer.preserve;
+    var outlineController = window.__agentPivotConversationOutline.create({
+        available: sidebarUiAvailable,
+        bookmarkAvailable: bookmarkUiAvailable,
+        target: commentTarget,
+        subscriptionGeneration: state.subscriptionGeneration,
+        status: status,
+        outlineCount: outlineCount,
+        outlineSummary: outlineSummary,
+        outlineSearch: outlineSearch,
+        outlineList: outlineList,
+        outlineEmpty: outlineEmpty,
+        outlinePartial: outlinePartial,
+        outlineBookmarksOnly: outlineBookmarksOnly,
+        post: post,
+        outlinePanelActive: function () {
+            return state.commentsPanelOpen && state.sidebarView === 'outline';
+        },
+        persistPanelState: saveCommentsPanelState,
+        updateToggle: updateCommentsToggle,
+    });
 
     if (!scroll || !messages || !position || !status || !newResponse
         || !previous || !next || !latest || !close || !window.DOMPurify) {
@@ -212,7 +221,7 @@
                 open: state.commentsPanelOpen,
                 width: state.commentsPanelWidth,
                 view: state.sidebarView,
-                query: state.outlineQuery,
+                query: outlineController.query(),
             };
             delete next.conversationCommentsPanel;
             vscodeApi.setState(next);
@@ -240,7 +249,8 @@
 
     function updateCommentsToggle() {
         if (!sidebarUiAvailable) return;
-        outlineToggle.textContent = 'Outline (' + state.outline.length + ')';
+        outlineToggle.textContent = 'Outline ('
+            + outlineController.size() + ')';
         outlineToggle.setAttribute(
             'aria-expanded',
             state.commentsPanelOpen && state.sidebarView === 'outline'
@@ -1098,152 +1108,6 @@
                 .includes(entry.responseState);
     }
 
-    function validBookmarkSnapshot(value) {
-        return value && typeof value === 'object' && !Array.isArray(value)
-            && Object.keys(value).length === 2
-            && Number.isSafeInteger(value.revision)
-            && value.revision >= 0
-            && Array.isArray(value.interactionIds)
-            && value.interactionIds.length <= 2000
-            && value.interactionIds.every(function (id) {
-                return typeof id === 'string'
-                    && id.length > 0
-                    && id.length <= 512
-                    && !/[\u0000-\u001f\u007f]/.test(id);
-            })
-            && new Set(value.interactionIds).size
-                === value.interactionIds.length;
-    }
-
-    function validBookmarksResult(value) {
-        if (!value || typeof value !== 'object' || Array.isArray(value)) {
-            return false;
-        }
-        var required = [
-            'type', 'version', 'requestId', 'subscriptionGeneration',
-            'projectId', 'provider', 'sessionId', 'operation', 'success',
-            'revision', 'interactionIds',
-        ];
-        var allowed = new Set(required.concat(['error']));
-        return Object.keys(value).every(function (key) {
-            return allowed.has(key);
-        }) && required.every(function (key) {
-            return Object.prototype.hasOwnProperty.call(value, key);
-        })
-            && value.type === 'conversation-viewer-bookmarks-result'
-            && value.version === 1
-            && typeof value.requestId === 'string'
-            && Number.isSafeInteger(value.subscriptionGeneration)
-            && typeof value.projectId === 'string'
-            && ['codex', 'kimi', 'claude'].includes(value.provider)
-            && typeof value.sessionId === 'string'
-            && value.operation === 'set'
-            && typeof value.success === 'boolean'
-            && validBookmarkSnapshot({
-                revision: value.revision,
-                interactionIds: value.interactionIds,
-            })
-            && (value.error === undefined
-                || ['invalid', 'stale', 'failed', 'limit']
-                    .includes(value.error));
-    }
-
-    function nextBookmarkRequestId() {
-        state.bookmarkRequestSequence += 1;
-        return [
-            'conversation-bookmark',
-            Date.now().toString(36),
-            state.bookmarkRequestSequence.toString(36),
-        ].join(':');
-    }
-
-    function postBookmarkMutation(interactionId, bookmarked) {
-        if (!bookmarkUiAvailable
-            || state.pendingBookmarkRequest) return;
-        var requestId = nextBookmarkRequestId();
-        state.pendingBookmarkRequest = { requestId: requestId, interactionId: interactionId };
-        renderBookmarkState();
-        post({
-            type: 'conversation-viewer-bookmark-mutation',
-            version: 1,
-            requestId: requestId,
-            subscriptionGeneration: state.subscriptionGeneration,
-            projectId: commentTarget.projectId,
-            provider: commentTarget.provider,
-            sessionId: commentTarget.sessionId,
-            operation: 'set',
-            expectedRevision: state.bookmarkRevision,
-            payload: {
-                interactionId: interactionId,
-                bookmarked: bookmarked,
-            },
-        });
-    }
-
-    function applyBookmarksResult(message) {
-        if (!bookmarkUiAvailable
-            || !validBookmarksResult(message)
-            || !state.pendingBookmarkRequest
-            || message.requestId !== state.pendingBookmarkRequest.requestId
-            || message.subscriptionGeneration !== state.subscriptionGeneration
-            || message.projectId !== commentTarget.projectId
-            || message.provider !== commentTarget.provider
-            || message.sessionId !== commentTarget.sessionId) {
-            return false;
-        }
-        var focusedId = state.pendingBookmarkRequest.interactionId;
-        state.pendingBookmarkRequest = null;
-        state.bookmarkRevision = message.revision;
-        state.bookmarkIds = new Set(message.interactionIds);
-        renderBookmarkState();
-        filterOutline();
-        status.textContent = message.success
-            ? (state.bookmarkIds.has(focusedId)
-                ? 'Input bookmarked.'
-                : 'Bookmark removed.')
-            : 'Bookmark could not be updated.';
-        var focused = outlineList.querySelector(
-            '[data-outline-bookmark-id="' + CSS.escape(focusedId) + '"]'
-        );
-        if (focused) focused.focus();
-        return true;
-    }
-
-    function renderBookmarkState() {
-        if (!sidebarUiAvailable) return;
-        Array.prototype.forEach.call(
-            outlineList.querySelectorAll('[data-outline-bookmark-id]'),
-            function (button) {
-                var interactionId = button.getAttribute(
-                    'data-outline-bookmark-id'
-                );
-                var bookmarked = state.bookmarkIds.has(interactionId);
-                var entry = state.outline.find(function (candidate) {
-                    return candidate.interactionId === interactionId;
-                });
-                var inputNumber = entry ? entry.inputNumber : '';
-                button.textContent = bookmarked ? '★' : '☆';
-                button.classList.toggle('is-bookmarked', bookmarked);
-                button.setAttribute('aria-pressed',
-                    bookmarked ? 'true' : 'false');
-                button.setAttribute(
-                    'aria-label',
-                    (bookmarked ? 'Remove bookmark from input ' : 'Bookmark input ')
-                        + inputNumber
-                );
-                button.title = button.getAttribute('aria-label');
-                button.disabled = !!state.pendingBookmarkRequest;
-            }
-        );
-        var count = state.bookmarkIds.size;
-        outlineBookmarksOnly.textContent = (state.bookmarksOnly ? '★' : '☆')
-            + ' Bookmarks (' + count + ')';
-        outlineBookmarksOnly.setAttribute(
-            'aria-pressed',
-            state.bookmarksOnly ? 'true' : 'false'
-        );
-    }
-
     function validOutline(value, selectedInteractionId) {
         if (!Array.isArray(value)
             || value.length < 1
@@ -1256,176 +1120,6 @@
         }));
         return identities.size === value.length
             && identities.has(selectedInteractionId);
-    }
-
-    function outlineChanged(entries) {
-        return entries.length !== state.outline.length
-            || entries.some(function (entry, index) {
-                var current = state.outline[index];
-                return !current
-                    || current.interactionId !== entry.interactionId
-                    || current.userPreview !== entry.userPreview
-                    || current.responseState !== entry.responseState;
-            });
-    }
-
-    function responseStateLabel(value) {
-        if (value === 'inProgress') return 'Response in progress';
-        if (value === 'interrupted') return 'Response interrupted';
-        if (value === 'unknown') return 'Response state unknown';
-        return 'Response complete';
-    }
-
-    function buildOutlineList() {
-        var fragment = document.createDocumentFragment();
-        state.outline.forEach(function (entry) {
-            var item = document.createElement('li');
-            item.className = 'conversation-outline-item';
-            var bookmark = document.createElement('button');
-            bookmark.type = 'button';
-            bookmark.className = 'conversation-outline-bookmark';
-            bookmark.setAttribute(
-                'data-outline-bookmark-id',
-                entry.interactionId
-            );
-            var button = document.createElement('button');
-            button.type = 'button';
-            button.setAttribute('data-outline-interaction-id',
-                entry.interactionId);
-            button.setAttribute('data-outline-filter-text',
-                entry.userPreview.toLocaleLowerCase());
-            button.tabIndex = -1;
-
-            var number = document.createElement('span');
-            number.className = 'conversation-outline-number';
-            number.textContent = String(entry.inputNumber);
-            var preview = document.createElement('span');
-            preview.className = 'conversation-outline-preview';
-            preview.textContent = entry.userPreview || '(empty input)';
-            var responseState = document.createElement('span');
-            responseState.className = 'conversation-outline-state'
-                + ' conversation-outline-state-' + entry.responseState;
-            responseState.title = responseStateLabel(entry.responseState);
-            responseState.setAttribute(
-                'aria-label',
-                responseStateLabel(entry.responseState)
-            );
-
-            button.appendChild(number);
-            button.appendChild(preview);
-            button.appendChild(responseState);
-            item.appendChild(bookmark);
-            item.appendChild(button);
-            fragment.appendChild(item);
-        });
-        outlineList.replaceChildren(fragment);
-        renderBookmarkState();
-    }
-
-    function visibleOutlineButtons() {
-        return Array.prototype.filter.call(
-            outlineList.querySelectorAll('[data-outline-interaction-id]'),
-            function (button) {
-                return !button.closest('li').hidden;
-            }
-        );
-    }
-
-    function updateOutlineSelection(scrollSelected) {
-        var selected;
-        Array.prototype.forEach.call(
-            outlineList.querySelectorAll('[data-outline-interaction-id]'),
-            function (button) {
-                var current = button.getAttribute(
-                    'data-outline-interaction-id'
-                ) === state.outlineSelectedInteractionId;
-                button.classList.toggle('is-selected', current);
-                if (current) {
-                    button.setAttribute('aria-current', 'location');
-                    selected = button;
-                } else {
-                    button.removeAttribute('aria-current');
-                }
-                button.tabIndex = current ? 0 : -1;
-            }
-        );
-        var visible = visibleOutlineButtons();
-        if (!visible.some(function (button) {
-            return button.tabIndex === 0;
-        }) && visible[0]) {
-            visible[0].tabIndex = 0;
-        }
-        if (scrollSelected
-            && selected
-            && state.commentsPanelOpen
-            && state.sidebarView === 'outline'
-            && !selected.closest('li').hidden) {
-            selected.scrollIntoView({ block: 'nearest' });
-        }
-    }
-
-    function filterOutline() {
-        var query = state.outlineQuery.trim().toLocaleLowerCase();
-        var visibleCount = 0;
-        Array.prototype.forEach.call(
-            outlineList.querySelectorAll('.conversation-outline-item'),
-            function (item) {
-                var button = item.querySelector(
-                    '[data-outline-interaction-id]'
-                );
-                var visible = !query
-                    || (button.getAttribute('data-outline-filter-text') || '')
-                        .includes(query);
-                if (visible && state.bookmarksOnly) {
-                    visible = state.bookmarkIds.has(button.getAttribute(
-                        'data-outline-interaction-id'
-                    ));
-                }
-                item.hidden = !visible;
-                if (visible) visibleCount += 1;
-            }
-        );
-        outlineEmpty.hidden = visibleCount > 0;
-        outlineEmpty.textContent = state.bookmarksOnly
-            ? 'No bookmarked inputs match this view.'
-            : 'No inputs match this search.';
-        updateOutlineSelection(false);
-    }
-
-    function applyOutline(message) {
-        if (!sidebarUiAvailable) return;
-        var selectedIndex = message.outline.findIndex(function (entry) {
-            return entry.interactionId === message.selectedInteractionId;
-        });
-        var offset = Math.max(
-            0,
-            message.selectedInput - selectedIndex - 1
-        );
-        var nextOutline = message.outline.map(function (entry, index) {
-            return Object.assign({}, entry, {
-                inputNumber: offset + index + 1,
-            });
-        });
-        var changed = outlineChanged(nextOutline);
-        state.outline = nextOutline;
-        state.outlineSelectedInteractionId = message.selectedInteractionId;
-        state.outlineSelectedInput = message.selectedInput;
-        state.outlineTotalInputs = message.totalInputs;
-        state.outlinePartial = message.partial;
-        if (changed) buildOutlineList();
-        outlineCount.textContent = String(message.outline.length);
-        outlineCount.setAttribute(
-            'aria-label',
-            message.outline.length + ' inputs'
-        );
-        outlineSummary.textContent = message.partial
-            ? message.outline.length.toLocaleString() + '+ latest inputs'
-            : message.outline.length.toLocaleString() + ' inputs';
-        outlinePartial.hidden = !message.partial;
-        filterOutline();
-        renderBookmarkState();
-        updateOutlineSelection(changed || message.updateKind !== 'refresh');
-        updateCommentsToggle();
     }
 
     function validPage(message) {
@@ -1775,7 +1469,7 @@
         state.messageSignatures = nextSignatures;
         state.atLatest = message.atLatest;
         state.initialized = true;
-        applyOutline(message);
+        outlineController.applyOutline(message);
         updateCommentHighlights();
         updatePosition(message);
         previous.disabled = message.previousCursor === undefined;
@@ -1933,65 +1627,7 @@
                 commentsToggle.focus();
             }
         });
-        outlineSearch.addEventListener('input', function () {
-            state.outlineQuery = outlineSearch.value;
-            filterOutline();
-            saveCommentsPanelState();
-        });
-        outlineBookmarksOnly.addEventListener('click', function () {
-            state.bookmarksOnly = !state.bookmarksOnly;
-            renderBookmarkState();
-            filterOutline();
-        });
-        outlineList.addEventListener('click', function (event) {
-            var bookmark = event.target.closest
-                ? event.target.closest('[data-outline-bookmark-id]')
-                : null;
-            if (bookmark && outlineList.contains(bookmark)) {
-                var bookmarkId = bookmark.getAttribute(
-                    'data-outline-bookmark-id'
-                );
-                postBookmarkMutation(
-                    bookmarkId,
-                    !state.bookmarkIds.has(bookmarkId)
-                );
-                return;
-            }
-            var button = event.target.closest
-                ? event.target.closest('[data-outline-interaction-id]')
-                : null;
-            if (!button || !outlineList.contains(button)) return;
-            post({
-                type: 'conversation-viewer-select-interaction',
-                version: 1,
-                interactionId: button.getAttribute(
-                    'data-outline-interaction-id'
-                ),
-            });
-        });
-        outlineList.addEventListener('keydown', function (event) {
-            if (!['ArrowUp', 'ArrowDown', 'Home', 'End']
-                .includes(event.key)) return;
-            var visible = visibleOutlineButtons();
-            if (!visible.length) return;
-            var current = event.target.closest
-                ? event.target.closest('[data-outline-interaction-id]')
-                : null;
-            var index = visible.indexOf(current);
-            if (event.key === 'Home') index = 0;
-            else if (event.key === 'End') index = visible.length - 1;
-            else if (event.key === 'ArrowUp') {
-                index = Math.max(0, index - 1);
-            } else {
-                index = Math.min(visible.length - 1, index + 1);
-            }
-            event.preventDefault();
-            visible.forEach(function (button) {
-                button.tabIndex = -1;
-            });
-            visible[index].tabIndex = 0;
-            visible[index].focus();
-        });
+        outlineController.attach();
         var resizingPointerId = null;
         commentsResizer.addEventListener('pointerdown', function (event) {
             if (event.button !== 0) return;
@@ -2226,7 +1862,7 @@
         postNavigation('conversation-viewer-closed');
     });
     window.addEventListener('message', function (event) {
-        if (applyBookmarksResult(event.data)) return;
+        if (outlineController.applyBookmarksResult(event.data)) return;
         if (applyCommentsResult(event.data)) return;
         if (applyLocateResult(event.data)) return;
         if (applyTelemetry(event.data)) return;
@@ -2244,14 +1880,7 @@
         }
     }
     if (sidebarUiAvailable) {
-        var initialBookmarks = readJsonAttribute('data-initial-bookmarks');
-        if (validBookmarkSnapshot(initialBookmarks)) {
-            state.bookmarkRevision = initialBookmarks.revision;
-            state.bookmarkIds = new Set(initialBookmarks.interactionIds);
-            renderBookmarkState();
-        } else {
-            status.textContent = 'Conversation bookmarks are unavailable.';
-        }
+        outlineController.initializeBookmarks();
         var savedCommentsPanel = readCommentsPanelState();
         if (savedCommentsPanel) {
             if (typeof savedCommentsPanel.open === 'boolean') {
@@ -2266,13 +1895,10 @@
                 || savedCommentsPanel.view === 'comments') {
                 state.sidebarView = savedCommentsPanel.view;
             }
-            if (typeof savedCommentsPanel.query === 'string') {
-                state.outlineQuery = savedCommentsPanel.query.slice(0, 4096);
-                outlineSearch.value = state.outlineQuery;
-            }
+            outlineController.restoreQuery(savedCommentsPanel.query);
         }
         applyCommentsPanelLayout();
-        filterOutline();
+        outlineController.filter();
     }
     if (commentUiAvailable) {
         var initialComments = readJsonAttribute('data-initial-comments');

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -30,6 +30,10 @@ const conversationMermaidScript = fs.readFileSync(
     path.join(__dirname, '../../src/webview/conversationMermaidScripts.js'),
     'utf8'
 );
+const conversationOutlineScript = fs.readFileSync(
+    path.join(__dirname, '../../src/webview/conversationOutlineScripts.js'),
+    'utf8'
+);
 const viewerCss = fs.readFileSync(
     path.join(__dirname, '../../media/conversationViewer.css'),
     'utf8'
@@ -240,6 +244,7 @@ async function openViewerPage(t, options = {}) {
     }
     await page.addScriptTag({ content: readingAnchorScript });
     await page.addScriptTag({ content: conversationMermaidScript });
+    await page.addScriptTag({ content: conversationOutlineScript });
     await page.addScriptTag({ content: viewerScript });
     await page.locator('script').evaluateAll(elements =>
         elements.forEach(element => element.remove()));
@@ -590,6 +595,13 @@ async function openHostViewerDocument(t, options = {}) {
             await route.fulfill({
                 contentType: 'text/javascript',
                 body: conversationMermaidScript,
+            });
+            return;
+        }
+        if (pathname === '/conversationOutlineScripts.js') {
+            await route.fulfill({
+                contentType: 'text/javascript',
+                body: conversationOutlineScript,
             });
             return;
         }

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -38,6 +38,10 @@ const conversationTelemetryScript = fs.readFileSync(
     path.join(__dirname, '../../src/webview/conversationTelemetryScripts.js'),
     'utf8'
 );
+const conversationCommentsScript = fs.readFileSync(
+    path.join(__dirname, '../../src/webview/conversationCommentsScripts.js'),
+    'utf8'
+);
 const viewerCss = fs.readFileSync(
     path.join(__dirname, '../../media/conversationViewer.css'),
     'utf8'
@@ -250,6 +254,7 @@ async function openViewerPage(t, options = {}) {
     await page.addScriptTag({ content: conversationMermaidScript });
     await page.addScriptTag({ content: conversationOutlineScript });
     await page.addScriptTag({ content: conversationTelemetryScript });
+    await page.addScriptTag({ content: conversationCommentsScript });
     await page.addScriptTag({ content: viewerScript });
     await page.locator('script').evaluateAll(elements =>
         elements.forEach(element => element.remove()));
@@ -614,6 +619,13 @@ async function openHostViewerDocument(t, options = {}) {
             await route.fulfill({
                 contentType: 'text/javascript',
                 body: conversationTelemetryScript,
+            });
+            return;
+        }
+        if (pathname === '/conversationCommentsScripts.js') {
+            await route.fulfill({
+                contentType: 'text/javascript',
+                body: conversationCommentsScript,
             });
             return;
         }

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -34,6 +34,10 @@ const conversationOutlineScript = fs.readFileSync(
     path.join(__dirname, '../../src/webview/conversationOutlineScripts.js'),
     'utf8'
 );
+const conversationTelemetryScript = fs.readFileSync(
+    path.join(__dirname, '../../src/webview/conversationTelemetryScripts.js'),
+    'utf8'
+);
 const viewerCss = fs.readFileSync(
     path.join(__dirname, '../../media/conversationViewer.css'),
     'utf8'
@@ -245,6 +249,7 @@ async function openViewerPage(t, options = {}) {
     await page.addScriptTag({ content: readingAnchorScript });
     await page.addScriptTag({ content: conversationMermaidScript });
     await page.addScriptTag({ content: conversationOutlineScript });
+    await page.addScriptTag({ content: conversationTelemetryScript });
     await page.addScriptTag({ content: viewerScript });
     await page.locator('script').evaluateAll(elements =>
         elements.forEach(element => element.remove()));
@@ -602,6 +607,13 @@ async function openHostViewerDocument(t, options = {}) {
             await route.fulfill({
                 contentType: 'text/javascript',
                 body: conversationOutlineScript,
+            });
+            return;
+        }
+        if (pathname === '/conversationTelemetryScripts.js') {
+            await route.fulfill({
+                contentType: 'text/javascript',
+                body: conversationTelemetryScript,
             });
             return;
         }

--- a/tests/integration/dashboard/conversationViewer.test.js
+++ b/tests/integration/dashboard/conversationViewer.test.js
@@ -789,12 +789,16 @@ test('CONVERSATION-VIEWER-SECURITY-001 emits a nonce-only CSP and opens only HTT
     const mermaidControllerIndex = panel.webview.html.indexOf(
         'conversationMermaidScripts.js'
     );
+    const outlineControllerIndex = panel.webview.html.indexOf(
+        'conversationOutlineScripts.js'
+    );
     const viewerIndex = panel.webview.html.indexOf(
         'conversationViewerScripts.js'
     );
     assert.ok(purifyIndex >= 0 && purifyIndex < readingAnchorIndex);
     assert.ok(readingAnchorIndex < mermaidControllerIndex);
-    assert.ok(mermaidControllerIndex < viewerIndex);
+    assert.ok(mermaidControllerIndex < outlineControllerIndex);
+    assert.ok(outlineControllerIndex < viewerIndex);
 
     for (const href of [
         'javascript:alert(1)',
@@ -818,6 +822,7 @@ test('CONVERSATION-READING-FOCUS-001 keeps modular Webview controllers byte-iden
     for (const fileName of [
         'conversationReadingAnchorScripts.js',
         'conversationMermaidScripts.js',
+        'conversationOutlineScripts.js',
         'conversationViewerScripts.js',
     ]) {
         assert.equal(

--- a/tests/integration/dashboard/conversationViewer.test.js
+++ b/tests/integration/dashboard/conversationViewer.test.js
@@ -792,13 +792,17 @@ test('CONVERSATION-VIEWER-SECURITY-001 emits a nonce-only CSP and opens only HTT
     const outlineControllerIndex = panel.webview.html.indexOf(
         'conversationOutlineScripts.js'
     );
+    const telemetryControllerIndex = panel.webview.html.indexOf(
+        'conversationTelemetryScripts.js'
+    );
     const viewerIndex = panel.webview.html.indexOf(
         'conversationViewerScripts.js'
     );
     assert.ok(purifyIndex >= 0 && purifyIndex < readingAnchorIndex);
     assert.ok(readingAnchorIndex < mermaidControllerIndex);
     assert.ok(mermaidControllerIndex < outlineControllerIndex);
-    assert.ok(outlineControllerIndex < viewerIndex);
+    assert.ok(outlineControllerIndex < telemetryControllerIndex);
+    assert.ok(telemetryControllerIndex < viewerIndex);
 
     for (const href of [
         'javascript:alert(1)',
@@ -823,6 +827,7 @@ test('CONVERSATION-READING-FOCUS-001 keeps modular Webview controllers byte-iden
         'conversationReadingAnchorScripts.js',
         'conversationMermaidScripts.js',
         'conversationOutlineScripts.js',
+        'conversationTelemetryScripts.js',
         'conversationViewerScripts.js',
     ]) {
         assert.equal(

--- a/tests/integration/dashboard/conversationViewer.test.js
+++ b/tests/integration/dashboard/conversationViewer.test.js
@@ -795,6 +795,9 @@ test('CONVERSATION-VIEWER-SECURITY-001 emits a nonce-only CSP and opens only HTT
     const telemetryControllerIndex = panel.webview.html.indexOf(
         'conversationTelemetryScripts.js'
     );
+    const commentsControllerIndex = panel.webview.html.indexOf(
+        'conversationCommentsScripts.js'
+    );
     const viewerIndex = panel.webview.html.indexOf(
         'conversationViewerScripts.js'
     );
@@ -802,7 +805,8 @@ test('CONVERSATION-VIEWER-SECURITY-001 emits a nonce-only CSP and opens only HTT
     assert.ok(readingAnchorIndex < mermaidControllerIndex);
     assert.ok(mermaidControllerIndex < outlineControllerIndex);
     assert.ok(outlineControllerIndex < telemetryControllerIndex);
-    assert.ok(telemetryControllerIndex < viewerIndex);
+    assert.ok(telemetryControllerIndex < commentsControllerIndex);
+    assert.ok(commentsControllerIndex < viewerIndex);
 
     for (const href of [
         'javascript:alert(1)',
@@ -828,6 +832,7 @@ test('CONVERSATION-READING-FOCUS-001 keeps modular Webview controllers byte-iden
         'conversationMermaidScripts.js',
         'conversationOutlineScripts.js',
         'conversationTelemetryScripts.js',
+        'conversationCommentsScripts.js',
         'conversationViewerScripts.js',
     ]) {
         assert.equal(


### PR DESCRIPTION
## Summary

Continues the Conversation modularization roadmap with three behavior-preserving webview extractions from `conversationViewerScripts.js` (2289 → 1012 lines), following the established `window.__agentPivot*` controller pattern:

- **Outline + bookmarks** → `conversationOutlineScripts.js` (462 lines): searchable input outline, star/bookmark state, keyboard navigation, panel-state query restore
- **Telemetry** → `conversationTelemetryScripts.js` (236 lines): model label, context-window progress, weekly quota meters, stale-request guards
- **Comments UI** → `conversationCommentsScripts.js` (862 lines): selection capture, composer, review states, locate, highlights, keyboard shortcuts

No UI, protocol, or behavior changes: every moved function and event listener was verified textually identical to the original (only injected shared dependencies are renamed), and the full behavior suite passes.

## Wiring

- `viewer.ts` injects the new scripts in order: purify → reading-anchor → mermaid → outline → telemetry → comments → viewer
- Registered in `.vscodeignore`, release packaging manifest, browser test script loading/routes, and the integration script-order + media/src byte-identity gates
- `docs: audit` commit covers all three implementation commits in the capability coverage manifest

## Verification

- Unit 396 ✓ · integration conversationViewer 30 ✓ · browser conversationViewer 39 ✓ · browser activeSession outline 21 ✓
- Behavior-contracts gate ✓ · release packaging (VSIX build) ✓ · TSLint baseline ✓ · conversation performance gate ✓