### PR TITLE
fix: keep Kimi sessions visibly running through long subagent turns

### DIFF
--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "fa20cec02b26c0b779e823e26fba87a99c03edb3",
+        "head": "2b82dcf05ce93ddd73217a5309e4ed12464841f6",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -715,7 +715,8 @@
                 "f11aca71aab64a08dddb0f1028809c0e0d52f0ab",
                 "2bc4a8a330bc498ffafe5df92ed807b27e0b8e79",
                 "c97615cee3b2629102643cf3f4560f98201e49d4",
-                "f2a66bf31f9e478e1c66f7db4643d09bc3406aea"
+                "f2a66bf31f9e478e1c66f7db4643d09bc3406aea",
+                "2b82dcf05ce93ddd73217a5309e4ed12464841f6"
             ],
             "behaviors": [
                 "RUNTIME-TMUX-BACKEND-001",

--- a/scripts/run-ai-session-safety-checks.js
+++ b/scripts/run-ai-session-safety-checks.js
@@ -8920,6 +8920,24 @@ function runLifecycleParserChecks() {
         JSON.stringify({ timestamp: 1784073606, message: { type: 'QuestionRequest', payload: { id: 'question-2' } } }),
         JSON.stringify({ timestamp: 1784073607, message: { type: 'StatusUpdate', payload: { message_id: 'status-2' } } }),
     ], runStartedAtMs).reason, 'input-required', 'Kimi status updates do not answer a pending question');
+    assert.strictEqual(lifecycle.parseKimiLifecycleLines([
+        JSON.stringify({ timestamp: 1784073608, message: { type: 'ToolCall', payload: { id: 'Agent_1', name: 'Agent' } } }),
+        JSON.stringify({ timestamp: 1784073708, message: { type: 'SubagentEvent', payload: { parent_tool_call_id: 'Agent_1', agent_id: 'sub-1', event: { type: 'ToolResult', payload: {} } } } }),
+    ], runStartedAtMs).executionState, 'running', 'Kimi subagent progress keeps a long Agent tool call alive');
+    assert.strictEqual(lifecycle.parseKimiLifecycleLines([
+        JSON.stringify({ timestamp: 1784073800, message: { type: 'ToolCallPart', payload: { arguments_part: '{}' } } }),
+    ], runStartedAtMs).executionState, 'running', 'Kimi streaming tool call parts prove an active turn');
+    const kimiInterruptedTurnEnd = lifecycle.parseKimiLifecycleLines([
+        JSON.stringify({ timestamp: 1784073900, message: { type: 'StepInterrupted', payload: {} } }),
+        JSON.stringify({ timestamp: 1784073901, message: { type: 'TurnEnd', payload: {} } }),
+    ], runStartedAtMs);
+    assert.strictEqual(kimiInterruptedTurnEnd.phase, 'idle', 'Kimi TurnEnd trailing a StepInterrupted is an interruption, not a completion');
+    assert.strictEqual(kimiInterruptedTurnEnd.reason, undefined);
+    assert.strictEqual(lifecycle.parseKimiLifecycleLines([
+        JSON.stringify({ timestamp: 1784073902, message: { type: 'StepInterrupted', payload: {} } }),
+        JSON.stringify({ timestamp: 1784073903, message: { type: 'TurnBegin', payload: {} } }),
+        JSON.stringify({ timestamp: 1784073904, message: { type: 'TurnEnd', payload: {} } }),
+    ], runStartedAtMs).reason, 'completed', 'A new turn clears the trailing interrupt marker');
 
     const kimiAccumulator = lifecycle.createKimiLifecycleAccumulator(runStartedAtMs);
     kimiAccumulator.addLines([

--- a/src/aiSessions/lifecycle.ts
+++ b/src/aiSessions/lifecycle.ts
@@ -134,16 +134,44 @@ const KIMI_RUNNING_EVENTS = new Set([
 ]);
 
 export function createKimiLifecycleAccumulator(runStartedAtMs: number): AiSessionLifecycleAccumulator {
+    // Kimi emits a trailing TurnEnd when a turn exits via a fatal step error
+    // (StepInterrupted then TurnEnd) so the wire log stays balanced, not only
+    // on clean completion. A TurnEnd immediately following a StepInterrupted
+    // therefore means "interrupted", not "completed".
+    let interruptedTurnPending = false;
     return createAccumulator(runStartedAtMs, (event, occurredAtMs) => {
         let message = event?.message || {};
         let payload = message.payload || {};
         if (KIMI_RUNNING_EVENTS.has(message.type)) {
+            interruptedTurnPending = false;
             return running('kimi', message.type, occurredAtMs, payload.id || payload.tool_call_id || payload.message_id);
         }
+        // SubagentEvent relays a live subagent's progress and ToolCallPart is
+        // only emitted while a turn is actively streaming. Neither appears
+        // while a session is idle, so each one is proof of life that must
+        // keep the execution state alive; otherwise a long subagent run (the
+        // main loop only sees SubagentEvent entries until the Agent
+        // ToolResult lands) trips the stale-running backstop and the
+        // dashboard shows a working session as stopped. StatusUpdate is NOT
+        // proof of life: it keeps flowing while a question is pending and
+        // must not answer it.
+        if (message.type === 'SubagentEvent') {
+            let inner = payload.event || {};
+            return running('kimi', message.type, occurredAtMs,
+                [payload.parent_tool_call_id, payload.agent_id, inner.type].filter(Boolean).join(':'));
+        }
+        if (message.type === 'ToolCallPart') {
+            return running('kimi', message.type, occurredAtMs, payload.tool_call_id);
+        }
         if (message.type === 'TurnEnd') {
+            if (interruptedTurnPending) {
+                interruptedTurnPending = false;
+                return idle('kimi', 'TurnEndAfterInterrupt', occurredAtMs);
+            }
             return attention('kimi', message.type, occurredAtMs, 'completed');
         }
         if (message.type === 'StepInterrupted') {
+            interruptedTurnPending = true;
             return idle('kimi', message.type, occurredAtMs);
         }
         if (message.type === 'ApprovalRequest' || message.type === 'QuestionRequest') {

--- a/tests/unit/aiSessions/lifecycle.test.js
+++ b/tests/unit/aiSessions/lifecycle.test.js
@@ -72,6 +72,103 @@ for (const provider of providers) {
     });
 }
 
+test('PERSIST-LIFECYCLE-PARSER-001 [kimi] treats subagent progress events as running', () => {
+    const signal = lifecycle.parseKimiLifecycleLines([
+        JSON.stringify({
+            timestamp: Date.parse('2026-07-24T08:42:00.000Z') / 1000,
+            message: { type: 'ToolCall', payload: { id: 'Agent_25', name: 'Agent' } },
+        }),
+        JSON.stringify({
+            timestamp: Date.parse('2026-07-24T08:52:00.000Z') / 1000,
+            message: {
+                type: 'SubagentEvent',
+                payload: {
+                    parent_tool_call_id: 'Agent_25',
+                    agent_id: 'ab654f447',
+                    subagent_type: 'coder',
+                    event: { type: 'ToolResult', payload: { tool_call_id: 'call-1' } },
+                },
+            },
+        }),
+    ], runStartedAtMs);
+
+    assert.ok(signal);
+    assert.equal(signal.phase, 'running');
+    assert.equal(signal.executionState, 'running');
+    assert.match(signal.token, /^kimi:SubagentEvent:/);
+});
+
+test('PERSIST-LIFECYCLE-PARSER-001 [kimi] treats a TurnEnd trailing a StepInterrupted as interruption, not completion', () => {
+    const signal = lifecycle.parseKimiLifecycleLines([
+        JSON.stringify({
+            timestamp: Date.parse('2026-07-24T08:42:00.000Z') / 1000,
+            message: { type: 'StepInterrupted', payload: {} },
+        }),
+        JSON.stringify({
+            timestamp: Date.parse('2026-07-24T08:42:01.000Z') / 1000,
+            message: { type: 'TurnEnd', payload: {} },
+        }),
+    ], runStartedAtMs);
+
+    assert.ok(signal);
+    assert.equal(signal.phase, 'idle');
+    assert.equal(signal.reason, undefined);
+    assert.equal(signal.executionState, 'stopped');
+    assert.match(signal.token, /^kimi:TurnEndAfterInterrupt:/);
+});
+
+test('PERSIST-LIFECYCLE-PARSER-001 [kimi] a new turn clears the trailing interrupt marker', () => {
+    const signal = lifecycle.parseKimiLifecycleLines([
+        JSON.stringify({
+            timestamp: Date.parse('2026-07-24T08:42:00.000Z') / 1000,
+            message: { type: 'StepInterrupted', payload: {} },
+        }),
+        JSON.stringify({
+            timestamp: Date.parse('2026-07-24T08:43:00.000Z') / 1000,
+            message: { type: 'TurnBegin', payload: {} },
+        }),
+        JSON.stringify({
+            timestamp: Date.parse('2026-07-24T08:43:30.000Z') / 1000,
+            message: { type: 'TurnEnd', payload: {} },
+        }),
+    ], runStartedAtMs);
+
+    assert.ok(signal);
+    assert.equal(signal.phase, 'needsAttention');
+    assert.equal(signal.reason, 'completed');
+    assert.equal(signal.executionState, 'stopped');
+});
+
+test('PERSIST-LIFECYCLE-PARSER-001 [kimi] treats streaming tool call parts as running', () => {
+    const signal = lifecycle.parseKimiLifecycleLines([
+        JSON.stringify({
+            timestamp: Date.parse('2026-07-24T08:42:00.000Z') / 1000,
+            message: { type: 'ToolCallPart', payload: { arguments_part: '{}' } },
+        }),
+    ], runStartedAtMs);
+    assert.ok(signal, 'ToolCallPart must produce a signal');
+    assert.equal(signal.phase, 'running');
+    assert.equal(signal.executionState, 'running');
+    assert.match(signal.token, /^kimi:ToolCallPart:/);
+});
+
+test('PERSIST-LIFECYCLE-PARSER-001 [kimi] status updates stay invisible to execution state', () => {
+    const signal = lifecycle.parseKimiLifecycleLines([
+        JSON.stringify({
+            timestamp: Date.parse('2026-07-24T08:42:00.000Z') / 1000,
+            message: { type: 'QuestionRequest', payload: { id: 'question-1' } },
+        }),
+        JSON.stringify({
+            timestamp: Date.parse('2026-07-24T08:42:01.000Z') / 1000,
+            message: { type: 'StatusUpdate', payload: { message_id: 'status-1', context_usage: 0.5 } },
+        }),
+    ], runStartedAtMs);
+    assert.ok(signal);
+    assert.equal(signal.phase, 'needsAttention');
+    assert.equal(signal.reason, 'input-required');
+    assert.equal(signal.executionState, 'stopped');
+});
+
 test('PERSIST-LIFECYCLE-PARSER-001 [claude] treats the explicit user interrupt marker as stopped', () => {
     const signal = lifecycle.parseClaudeLifecycleLines([
         JSON.stringify({


### PR DESCRIPTION
## 问题

Kimi 会话在子代理(subagent)长时间运行期间,仪表盘动画错误地显示为 stopped。

**根因**:Kimi 生命周期解析器只把主循环事件(`TurnBegin`/`ToolCall`/`ToolResult` 等)当作活跃证据。子代理运行期间主 transcript(`wire.jsonl`)只写入被忽略的 `SubagentEvent` 条目(实测某会话 18 分钟内 1193 条),执行监控的 stale-running 兜底超时后把会话强制判为 stopped,直到子代理完成、主循环收到 `ToolResult` 才自愈。

**连带问题**:Kimi 在致命步骤错误后会补发一个保持 wire 日志平衡的 `TurnEnd`(紧跟着 `StepInterrupted`),此前被误判为"已完成",产生错误的 completed attention。

## 修复

- `SubagentEvent`(子代理进度转发)与 `ToolCallPart`(流式工具参数)视为 running 信号——两者只在会话活跃时出现在 transcript 中;
- `StatusUpdate` 明确排除:它在等待用户回答问题时仍会继续流动,不能冲掉 input-required 状态(既有契约,含安全脚本断言);
- 紧跟 `StepInterrupted` 的 `TurnEnd` 判为中断(idle)而非完成(completed);新一轮 turn 开始时重置该标记。

**已知边界**:纯 ESC 取消只补发无标记的 `TurnEnd`,transcript 层面无法与正常完成区分,需待 kimi-cli 上游补充中断 hook 事件后跟进。

## 测试

- `tests/unit/aiSessions/lifecycle.test.js`:+5 用例(子代理事件→running、ToolCallPart→running、StatusUpdate 不覆盖待回答问题、TurnEnd 跟随中断→idle、新 turn 清除中断标记);
- `scripts/run-ai-session-safety-checks.js`:+4 条行为契约断言;
- RED 证据:3 个回归测试在未修复实现上按预期失败(信号缺失/误分类),修复后全绿。

**CI 可追溯性**:`tests/unit/aiSessions/lifecycle.test.js` → `test:deterministic:run`/`test:coverage:run` → `test:ci:linux` → verify.yml `quality-linux` 必需检查;`run-ai-session-safety-checks.js` → `test:safety:run` → 同上。行为 ID:`PERSIST-LIFECYCLE-PARSER-001`(已有,owner 已包含本测试文件)。

**验证**:aiSessions 单测 92 ✅ / 完整单测 403 ✅ / AI session 安全检查 ✅ / tmux 检查 ✅ / 行为契约目录 ✅ / 主能力覆盖 ✅(rebase 到 origin/main ecfd647 后复验)。

**能力审计**:实现提交 `2b82dcf` 已指派到 `MAIN-RUNTIME-SESSION-RECOVERY`,`audit.head` 已推进(独立 docs 提交 `be303f7`)。

## 经验收割(harvesting-workflow-lessons)

- 主检出直接改代码、未先建 worktree:属**执行合规缺口**——`protecting-main-with-worktrees` 技能已明确规定,无需改技能,已纠正(全部工作在 .worktree 完成);
- 首版修复误将 `StatusUpdate` 当作活跃证据,被仓库既有安全脚本当场捕获:一次性事件,由既有检查覆盖,**无技能变更 justified**。