### PR TITLE
refactor: extract todo panel and projects handler slices from dashboard.ts

### DIFF
--- a/.ci/tslint-warning-baseline.json
+++ b/.ci/tslint-warning-baseline.json
@@ -12,7 +12,9 @@
     "semicolon": 1
   },
   "src/dashboard.ts": {
-    "semicolon": 6,
+    "semicolon": 6
+  },
+  "src/projects/projectMessageHandlers.ts": {
     "triple-equals": 1
   },
   "src/services/colorService.ts": {

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -2187,10 +2187,12 @@
     "priority": "P1",
     "status": "automated",
     "owners": [
-      "tests/contract/todos/commandController.test.js"
+      "tests/contract/todos/commandController.test.js",
+      "tests/contract/todos/todoPanelCapability.test.js"
     ],
     "evidence": [
       "src/todos/commandController.ts",
+      "src/todos/todoPanelCapability.ts",
       "src/dashboard.ts"
     ]
   },
@@ -2208,6 +2210,7 @@
     "evidence": [
       "src/todos/service.ts",
       "src/dashboard/lifecycleController.ts",
+      "src/todos/todoPanelCapability.ts",
       "src/dashboard.ts",
       "src/webview/webviewTodoScripts.js",
       "src/webview/webviewDnDScripts.js"
@@ -2250,10 +2253,12 @@
     "status": "automated",
     "owners": [
       "tests/integration/dashboard/todoContent.test.js",
-      "tests/integration/dashboard/todoInteraction.test.js"
+      "tests/integration/dashboard/todoInteraction.test.js",
+      "tests/contract/todos/todoPanelCapability.test.js"
     ],
     "evidence": [
       "src/todos/webviewContent.ts",
+      "src/todos/todoPanelCapability.ts",
       "src/dashboard.ts",
       "src/webview/webviewTodoScripts.js",
       "media/styles.scss",
@@ -2495,10 +2500,13 @@
     "priority": "P1",
     "status": "automated",
     "owners": [
-      "tests/contract/persistence/migrations.test.js"
+      "tests/contract/persistence/migrations.test.js",
+      "tests/contract/todos/todoPanelCapability.test.js"
     ],
     "evidence": [
-      "scripts/run-dashboard-webview-checks.js"
+      "scripts/run-dashboard-webview-checks.js",
+      "src/todos/todoPanelCapability.ts",
+      "src/dashboard.ts"
     ]
   },
   {
@@ -2508,10 +2516,12 @@
     "priority": "P1",
     "status": "automated",
     "owners": [
-      "tests/contract/todos/service.test.js"
+      "tests/contract/todos/service.test.js",
+      "tests/contract/todos/todoPanelCapability.test.js"
     ],
     "evidence": [
-      "scripts/run-dashboard-webview-checks.js"
+      "scripts/run-dashboard-webview-checks.js",
+      "src/todos/todoPanelCapability.ts"
     ]
   },
   {
@@ -2912,9 +2922,11 @@
     "priority": "P0",
     "status": "automated",
     "owners": [
-      "tests/integration/dashboard/todoPanelFutureVersion.test.js"
+      "tests/integration/dashboard/todoPanelFutureVersion.test.js",
+      "tests/contract/todos/todoPanelCapability.test.js"
     ],
     "evidence": [
+      "src/todos/todoPanelCapability.ts",
       "src/dashboard.ts"
     ]
   },

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -2571,9 +2571,13 @@
     "status": "automated",
     "owners": [
       "tests/contract/projects/controllers.test.js"
+    ,
+      "tests/contract/projects/projectMessageHandlers.test.js"
     ],
     "evidence": [
       "scripts/run-dashboard-webview-checks.js"
+    ,
+      "src/projects/projectMessageHandlers.ts"
     ]
   },
   {
@@ -2584,9 +2588,13 @@
     "status": "automated",
     "owners": [
       "tests/contract/projects/controllers.test.js"
+    ,
+      "tests/contract/projects/projectMessageHandlers.test.js"
     ],
     "evidence": [
       "scripts/run-dashboard-webview-checks.js"
+    ,
+      "src/projects/projectMessageHandlers.ts"
     ]
   },
   {
@@ -2597,9 +2605,13 @@
     "status": "automated",
     "owners": [
       "tests/contract/projects/controllers.test.js"
+    ,
+      "tests/contract/projects/projectMessageHandlers.test.js"
     ],
     "evidence": [
       "scripts/run-dashboard-webview-checks.js"
+    ,
+      "src/projects/projectMessageHandlers.ts"
     ]
   },
   {
@@ -2995,9 +3007,13 @@
     "status": "automated",
     "owners": [
       "tests/integration/dashboard/messageRouter.test.js"
+    ,
+      "tests/contract/projects/projectMessageHandlers.test.js"
     ],
     "evidence": [
       "src/dashboard/messageRouter.ts"
+    ,
+      "src/projects/projectMessageHandlers.ts"
     ]
   },
   {
@@ -3223,6 +3239,8 @@
       "tests/contract/openProjects/dashboardController.test.js",
       "tests/integration/dashboard/errorRecovery.test.js",
       "tests/integration/dashboard/webviewState.test.js"
+    ,
+      "tests/contract/projects/projectMessageHandlers.test.js"
     ],
     "evidence": [
       "src/services/projectCatalogSyncService.ts",
@@ -3231,6 +3249,8 @@
       "src/openWorkspaces/dashboardController.ts",
       "src/webview/webviewDashboardScripts.js",
       "src/dashboard.ts"
+    ,
+      "src/projects/projectMessageHandlers.ts"
     ]
   },
   {
@@ -3256,11 +3276,15 @@
       "tests/contract/projects/controllers.test.js",
       "tests/contract/openProjects/workspaceController.test.js",
       "tests/integration/dashboard/productionAttentionBridge.test.js"
+    ,
+      "tests/contract/projects/projectMessageHandlers.test.js"
     ],
     "evidence": [
       "src/projects/projectOpenController.ts",
       "src/projects/projectNavigationProtocol.ts",
       "extensions/attention-ui-bridge/src/extension.ts"
+    ,
+      "src/projects/projectMessageHandlers.ts"
     ]
   },
   {

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -472,9 +472,13 @@
     "status": "automated",
     "owners": [
       "tests/contract/aiSessions/attention.test.js"
+    ,
+      "tests/contract/aiSessions/runtimeSettlement.test.js"
     ],
     "evidence": [
       "src/aiSessions/attentionController.ts"
+    ,
+      "src/aiSessions/runtimeSettlementCapability.ts"
     ]
   },
   {
@@ -1049,10 +1053,14 @@
     "status": "automated",
     "owners": [
       "tests/contract/aiSessions/attention.test.js"
+    ,
+      "tests/contract/aiSessions/runtimeSettlement.test.js"
     ],
     "evidence": [
       "src/aiSessions/attentionEvaluationQueue.ts",
       "src/aiSessions/executionController.ts"
+    ,
+      "src/aiSessions/runtimeSettlementCapability.ts"
     ]
   },
   {
@@ -2984,6 +2992,8 @@
       "src/aiSessions/attentionController.ts",
       "src/aiSessions/terminalCommandController.ts",
       "src/dashboard.ts"
+    ,
+      "src/aiSessions/runtimeSettlementCapability.ts"
     ]
   },
   {
@@ -2997,6 +3007,8 @@
     ],
     "evidence": [
       "src/dashboard.ts"
+    ,
+      "src/aiSessions/runtimeSettlementCapability.ts"
     ]
   },
   {

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -4136,12 +4136,16 @@
     "status": "automated",
     "owners": [
       "scripts/run-skill-management-checks.js"
+    ,
+      "tests/contract/skills/skillPanelCapability.test.js"
     ],
     "evidence": [
       "src/skills/centralService.ts",
       "src/skills/dashboardController.ts",
       "src/skills/migrateService.ts",
       "src/skills/syncService.ts"
+    ,
+      "src/skills/skillPanelCapability.ts"
     ]
   },
   {
@@ -4182,6 +4186,8 @@
     "owners": [
       "scripts/run-skill-management-checks.js",
       "tests/browser/skillsFolderTree.test.js"
+    ,
+      "tests/contract/skills/skillPanelCapability.test.js"
     ],
     "evidence": [
       "src/skills/scopeService.ts",
@@ -4189,6 +4195,8 @@
       "src/skills/dashboardController.ts",
       "src/webview/webviewSkillContent.ts",
       "src/webview/webviewDashboardScripts.js"
+    ,
+      "src/skills/skillPanelCapability.ts"
     ]
   },
   {
@@ -4200,6 +4208,8 @@
     "owners": [
       "scripts/run-skill-management-checks.js",
       "tests/contract/skills/globalStoreLocationController.test.js"
+    ,
+      "tests/contract/skills/skillPanelCapability.test.js"
     ],
     "evidence": [
       "package.json",
@@ -4209,6 +4219,8 @@
       "src/skills/dashboardController.ts",
       "src/dashboard.ts",
       "src/webview/webviewDashboardScripts.js"
+    ,
+      "src/skills/skillPanelCapability.ts"
     ]
   },
   {

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "9ceb5a4ca604119a69486449699c263f96218c21",
+        "head": "8335f4b0cd7dedd0b4ef2ee6f131cbe590a39ad5",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -60,7 +60,8 @@
             "ee9a44d87a6ea423739c2781f913d276c369c48d",
             "239f99c25af02e2176f9a5b6bd8ef7f5c8933495",
             "7f90f99570d56494b7c53153820e143d4ce6ebb8",
-            "05d9c57a32821b4df6bc044bfaf6122eedda4c6f"
+            "05d9c57a32821b4df6bc044bfaf6122eedda4c6f",
+            "3f110f9cfd3ffb9aabc3ed41336fdfdc68647399"
         ]
     },
     "capabilities": [
@@ -1129,7 +1130,8 @@
                 "9f88b5972cbfd8e712186652a99d162a669575f8",
                 "75f261ee54b28569284b15e6260576831f7b2e81",
                 "6056ad799f05619a93fabe4af56e5955246e2231",
-                "7ebe4973e9fed30042171f08f8048e142f2a2f49"
+                "7ebe4973e9fed30042171f08f8048e142f2a2f49",
+                "8335f4b0cd7dedd0b4ef2ee6f131cbe590a39ad5"
             ],
             "behaviors": [
                 "PERSIST-AI-SKILL-CENTRAL-STORE-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "dd561101bb195c5da5a3bed0acfcb3696dfbfcf4",
+        "head": "9ceb5a4ca604119a69486449699c263f96218c21",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -59,7 +59,8 @@
             "87304b6b77e3d90d21019a80c43a60f2e3785fda",
             "ee9a44d87a6ea423739c2781f913d276c369c48d",
             "239f99c25af02e2176f9a5b6bd8ef7f5c8933495",
-            "7f90f99570d56494b7c53153820e143d4ce6ebb8"
+            "7f90f99570d56494b7c53153820e143d4ce6ebb8",
+            "05d9c57a32821b4df6bc044bfaf6122eedda4c6f"
         ]
     },
     "capabilities": [
@@ -611,7 +612,8 @@
                 "2bb3a1c255c2bb97809889d9d879d135b371e2ce",
                 "f51aa569d4adb1dd750947181008c3764dbe6163",
                 "289779463fe347fba05bd3655ceded5189612f44",
-                "eb60d0cc5b8aaa9e3f04d797f4d790f40999e378"
+                "eb60d0cc5b8aaa9e3f04d797f4d790f40999e378",
+                "9ceb5a4ca604119a69486449699c263f96218c21"
             ],
             "behaviors": [
                 "ATTENTION-ACTIVE-UNREGISTER-ON-DEACTIVATE-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "404ab50e89380a9e8475d3e919efc650d6c6be60",
+        "head": "dd561101bb195c5da5a3bed0acfcb3696dfbfcf4",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -58,7 +58,8 @@
             "acbd2a3166504fc42fc20c8b0e1874f3ec09c092",
             "87304b6b77e3d90d21019a80c43a60f2e3785fda",
             "ee9a44d87a6ea423739c2781f913d276c369c48d",
-            "239f99c25af02e2176f9a5b6bd8ef7f5c8933495"
+            "239f99c25af02e2176f9a5b6bd8ef7f5c8933495",
+            "7f90f99570d56494b7c53153820e143d4ce6ebb8"
         ]
     },
     "capabilities": [
@@ -520,7 +521,8 @@
                 "fcb373a70078361ff5e40e627881489dffb3771d",
                 "b93fc82c2900eb2c693a2e1228784d26dda069b3",
                 "9e643c840db5ab634c1ef4815428617118b96ee7",
-                "6ef7ba4a0d078b6558ff16d99ed4ce13fd8a0cf4"
+                "6ef7ba4a0d078b6558ff16d99ed4ce13fd8a0cf4",
+                "905cdcd5c94a781e63764fb8d2eb766578601ddc"
             ],
             "behaviors": [
                 "TODO-COMPLETION-INCREMENTAL-001",
@@ -560,7 +562,8 @@
                 "3a3e07bc7fad01957dc6db1f505bb961efaf831f",
                 "ef5fc3170c0fe1a753b1c6313daa5d4a7cc40e2f",
                 "4ad7604bb9a4d4ff10f790486512c3313c351200",
-                "1f2baaa6b2a5c18bd80954be773c00968619d245"
+                "1f2baaa6b2a5c18bd80954be773c00968619d245",
+                "dd561101bb195c5da5a3bed0acfcb3696dfbfcf4"
             ],
             "behaviors": [
                 "PROJECT-CATALOG-SYNC-CONFLICT-001",

--- a/scripts/run-ai-session-safety-checks.js
+++ b/scripts/run-ai-session-safety-checks.js
@@ -4894,6 +4894,9 @@ function runWebviewContentChecks() {
     const projectMessageHandlers = fs.readFileSync(
         path.join(__dirname, '..', 'src', 'projects', 'projectMessageHandlers.ts'), 'utf8'
     );
+    const runtimeSettlement = fs.readFileSync(
+        path.join(__dirname, '..', 'src', 'aiSessions', 'runtimeSettlementCapability.ts'), 'utf8'
+    );
     const webviewProjectScripts = fs.readFileSync(path.join(__dirname, '..', 'src', 'webview', 'webviewProjectScripts.js'), 'utf8');
     const webviewIcons = fs.readFileSync(path.join(__dirname, '..', 'src', 'webview', 'webviewIcons.ts'), 'utf8');
     const styles = fs.readFileSync(path.join(__dirname, '..', 'media', 'styles.scss'), 'utf8');
@@ -5177,10 +5180,16 @@ function runWebviewContentChecks() {
     assert.ok(!dashboardRuntimeControllerSource.includes("type: 'ai-session-attention-projects-updated'"));
     assert.ok(dashboard.includes('sessionEvents: aiSessionAttentionController.getRecoverySessionEvents()'));
     assert.ok(webviewProjectScripts.includes('message.sessionEvents'));
-    assert.ok(dashboard.includes('settleAiSessionRuntimeLifecycles'));
-    assert.match(dashboard,
+    assert.ok(runtimeSettlement.includes('settleAiSessionRuntimeLifecycles'));
+    assert.ok(dashboard.includes('createAiSessionRuntimeSettlementCapability({'),
+        'the dashboard constructs the extracted runtime settlement capability');
+    assert.ok(dashboard.includes('const runSafeAiSessionRuntimeLifecycleTask = aiSessionRuntimeSettlement.runSafeLifecycleTask;'),
+        'the dashboard keeps one lifecycle task runner from the capability');
+    assert.ok(dashboard.includes('const queueAiSessionRuntimeSettlements = aiSessionRuntimeSettlement.queueSettlements;'),
+        'the dashboard keeps one settlement queue from the capability');
+    assert.match(runtimeSettlement,
         /for \(const runtime of runtimes\) \{\s*if \(!runtimeBelongsToCurrentWorkspace\(runtime\)\) \{\s*continue;\s*\}/,
-        'dashboard lifecycle attention collection must reject other scopes before session-key processing');
+        'runtime settlement collection must reject other scopes before session-key processing');
     assert.ok(dashboard.includes('const aiSessionAttentionController = new AiSessionAttentionController<AiSessionRuntimeSnapshot<vscode.Terminal>>({'));
     assert.ok(dashboard.includes("import { AiSessionExecutionController } from './aiSessions/executionController';"));
     assert.ok(dashboard.includes('const aiSessionExecutionController = new AiSessionExecutionController({'));
@@ -5313,7 +5322,7 @@ function runWebviewContentChecks() {
     );
     assert.ok(dashboard.includes('acknowledgeAiSessionAttentionEventIds,'),
         'the dashboard hands the extracted project handlers its attention acknowledgement');
-    const settlementCall = dashboard.match(/settleAiSessionRuntimeLifecycles\(\{[\s\S]*?\n\s*\}\);/)?.[0] || '';
+    const settlementCall = runtimeSettlement.match(/settleAiSessionRuntimeLifecycles\(\{[\s\S]*?\n\s*\}\);/)?.[0] || '';
     assert.ok(settlementCall.includes('attentionKey: candidate.key'));
     assert.ok(settlementCall.includes('release: async candidate =>'));
     assert.ok(!settlementCall.includes('acknowledgePublished'));
@@ -5324,9 +5333,9 @@ function runWebviewContentChecks() {
         'a later aggregate must not auto-acknowledge a delivered completion'
     );
     assert.match(dashboard, /onComplete: resolution => \{[\s\S]*?queueAiSessionRuntimeSettlements\(\[\{/);
-    const runtimeSettlementQueue = dashboard.slice(
-        dashboard.indexOf('const queueAiSessionRuntimeSettlements = ('),
-        dashboard.indexOf('const drainAiSessionRuntimeSettlements = async')
+    const runtimeSettlementQueue = runtimeSettlement.slice(
+        runtimeSettlement.indexOf('const queueAiSessionRuntimeSettlements = ('),
+        runtimeSettlement.indexOf('const drainAiSessionRuntimeSettlements = async')
     );
     assert.ok(
         runtimeSettlementQueue.includes('runtime.identity.workspaceScopeIdentity'),
@@ -5336,9 +5345,12 @@ function runWebviewContentChecks() {
         'lifecycle settlement scheduling must not create unhandled fire-and-forget rejections');
     assert.ok(dashboard.includes('getRuntimeById: getAiSessionRuntimeById'));
     assert.ok(!dashboard.includes('getTerminalById: (providerId, sessionId) => aiSessionTerminalService.getActiveById(providerId, sessionId)'));
-    assert.match(dashboard,
-        /ownTimer\(\s*\(\) => setInterval\(\(\) => \{[\s\S]*?getCompletedSessions\(\)[\s\S]*?tmuxRuntimeDiscovery\.getInactive\(\)[\s\S]*?\}, 1_000\),\s*handle => clearInterval\(handle\),\s*\)/);
-    assert.match(dashboard, /queueAiSessionRuntimeSettlements\(\[\.\.\.completedRuntimes, \.\.\.inactiveTmuxRuntimes\]\)/,
+    assert.match(runtimeSettlement,
+        /setInterval\(\(\) => \{[\s\S]*?getCompletedSessions\(\)[\s\S]*?tmuxRuntimeDiscovery\.getInactive\(\)[\s\S]*?\}, 1_000\)/,
+        'the capability keeps the 1s completed-runtime settlement scan');
+    assert.ok(dashboard.includes('aiSessionRuntimeSettlement.startSettlementScan();'),
+        'the dashboard starts the capability settlement scan in place of its old timer');
+    assert.match(runtimeSettlement, /queueAiSessionRuntimeSettlements\(\[\.\.\.completedRuntimes, \.\.\.inactiveTmuxRuntimes\]\)/,
         'one completion polling round must queue one structured batch');
     const closeTerminalHandlerStart = dashboard.indexOf('vscode.window.onDidCloseTerminal(terminal => {');
     const closeTerminalHandlerEnd = dashboard.indexOf(
@@ -5360,7 +5372,7 @@ function runWebviewContentChecks() {
     assert.match(dashboard, /onDidChangeActiveTerminal\(\(\) => \{[\s\S]*?activeAiSessionTerminalHighlighter\.sync\(\);[\s\S]*?runSafeAiSessionRuntimeLifecycleTask\([\s\S]*?'evaluate-attention-active-terminal'[\s\S]*?\}\)/);
     assert.ok(!dashboard.includes('void evaluateAiSessionAttention()'));
     assert.ok(!dashboard.includes('void acknowledgeAiSessionAttention('));
-    assert.ok(dashboard.includes('runAiSessionRuntimeLifecycleTask('));
+    assert.ok(runtimeSettlement.includes('runAiSessionRuntimeLifecycleTask('));
     assert.match(dashboard, /onDidChangeWindowState\(windowState => \{[\s\S]*?dashboardLifecycleController\.handleWindowStateChanged\(windowState\);[\s\S]*?\}\)/);
     assert.ok(dashboardLifecycleControllerSource.includes('this.options.evaluateAiSessionAttention();'));
     assert.ok(dashboardLifecycleControllerSource.includes('this.options.publishOpenWorkspace(true);'));

--- a/scripts/run-ai-session-safety-checks.js
+++ b/scripts/run-ai-session-safety-checks.js
@@ -4891,6 +4891,9 @@ async function runBatchAiSessionArchiveHostChecks() {
 
 function runWebviewContentChecks() {
     const webviewContent = fs.readFileSync(path.join(__dirname, '..', 'src', 'webview', 'webviewContent.ts'), 'utf8');
+    const projectMessageHandlers = fs.readFileSync(
+        path.join(__dirname, '..', 'src', 'projects', 'projectMessageHandlers.ts'), 'utf8'
+    );
     const webviewProjectScripts = fs.readFileSync(path.join(__dirname, '..', 'src', 'webview', 'webviewProjectScripts.js'), 'utf8');
     const webviewIcons = fs.readFileSync(path.join(__dirname, '..', 'src', 'webview', 'webviewIcons.ts'), 'utf8');
     const styles = fs.readFileSync(path.join(__dirname, '..', 'media', 'styles.scss'), 'utf8');
@@ -5299,15 +5302,17 @@ function runWebviewContentChecks() {
     assert.match(dashboard, /const acknowledgeAiSessionAttentionEventIds = async[\s\S]*?aiSessionAttentionController\.acknowledge\(uniqueEventIds\);\s*refreshAiSessionViewsIncrementally\(\);\s*await aiSessionAttentionBridgeClient\.acknowledge\(uniqueEventIds\)/,
         'attention acknowledgement must refresh the local view before waiting for the cross-window bridge');
     assert.match(dashboard, /const acknowledgeAiSessionAttention = async[\s\S]*?await acknowledgeAiSessionAttentionEventIds\(getAiSessionAttentionEventIds\(identity\)\)/);
-    const selectedProjectHandler = dashboard.slice(
-        dashboard.indexOf("'selected-project': async e =>"),
-        dashboard.indexOf("'add-project': async e =>")
+    const selectedProjectHandler = projectMessageHandlers.slice(
+        projectMessageHandlers.indexOf("'selected-project': async e =>"),
+        projectMessageHandlers.indexOf("'add-project': async e =>")
     );
     assert.match(
         selectedProjectHandler,
         /withAttentionProject\([\s\S]*?await acknowledgeAiSessionAttentionEventIds\(attentionProject\.aiSessionAttentionEventIds\)/,
         'clicking a project card must acknowledge all attention events represented by that card'
     );
+    assert.ok(dashboard.includes('acknowledgeAiSessionAttentionEventIds,'),
+        'the dashboard hands the extracted project handlers its attention acknowledgement');
     const settlementCall = dashboard.match(/settleAiSessionRuntimeLifecycles\(\{[\s\S]*?\n\s*\}\);/)?.[0] || '';
     assert.ok(settlementCall.includes('attentionKey: candidate.key'));
     assert.ok(settlementCall.includes('release: async candidate =>'));
@@ -5627,13 +5632,15 @@ function runWebviewContentChecks() {
     assert.ok(!webviewContent.includes('withCurrentWorkspaceState('));
     assert.ok(!webviewContent.includes('infos.currentWorkspaceProjectIds || []'));
     assert.ok(webviewContent.includes('getFavoriteProjectsInOrder('));
-    assert.ok(dashboard.includes("'reordered-favorites': async e =>"));
+    assert.ok(projectMessageHandlers.includes("'reordered-favorites': async e =>"));
+    assert.ok(dashboard.includes('...projectHandlers,'),
+        'the dashboard spreads the extracted project handlers into the message router');
     const favoriteProjectControllerSource = fs.readFileSync(path.join(__dirname, '..', 'src', 'projects', 'favoriteProjectController.ts'), 'utf8');
     assert.ok(!dashboard.includes('withFavoriteProjectOrder(groups, projectIds)'));
     assert.ok(!dashboard.includes('withToggledProjectFavorite(groups, projectId)'));
     assert.ok(favoriteProjectControllerSource.includes('withFavoriteProjectOrder(groups, projectIds)'));
     assert.ok(favoriteProjectControllerSource.includes('withToggledProjectFavorite(groups, projectId)'));
-    assert.ok(dashboard.includes("function applyProjectColorToCurrentWindow(project: Project = null)"));
+    assert.ok(projectMessageHandlers.includes("function applyProjectColorToCurrentWindow(project: Project = null)"));
     assert.ok(dashboardRuntimeControllerSource.includes('this.options.getCurrentSavedProject()'));
     assert.ok(dashboard.includes('dashboardRuntimeController.applyProjectColorToCurrentWindow(project)'));
     assert.ok(projectWindowColorService.includes("PROJECT_COLOR_TO_WINDOW_KEY = 'applyProjectColorToWindow'"));

--- a/scripts/run-dashboard-webview-checks.js
+++ b/scripts/run-dashboard-webview-checks.js
@@ -53,6 +53,7 @@ const projectScriptPath = path.join(root, 'src', 'webview', 'webviewProjectScrip
 const promptScriptPath = path.join(root, 'src', 'webview', 'webviewPromptScripts.js');
 const scrollStateScriptPath = path.join(root, 'src', 'webview', 'webviewScrollStateScripts.js');
 const extensionHostPath = path.join(root, 'src', 'dashboard.ts');
+const todoPanelCapabilityPath = path.join(root, 'src', 'todos', 'todoPanelCapability.ts');
 
 function compileDashboardStyles(source) {
     return sass.compileString(source, {
@@ -2177,16 +2178,19 @@ async function runTodoRevealSingleWriteChecks() {
 
 async function runDashboardTodoMigrationSequencingChecks() {
     const extensionHostSource = fs.readFileSync(extensionHostPath, 'utf8');
+    const todoPanelCapabilitySource = fs.readFileSync(todoPanelCapabilityPath, 'utf8');
     const migrationBody = extractAsyncArrowPropertyBody(extensionHostSource, 'migrateDataIfNeeded');
     const runMigrationBody = new AsyncFunction(
         'projectService',
         'todoService',
-        'todoStorageMigration',
+        'todoPanel',
         'settleMigration',
         migrationBody
     );
     const runMigration = (projectService, todoService, todoStorageMigration) =>
-        runMigrationBody(projectService, todoService, todoStorageMigration, settleMigration);
+        runMigrationBody(projectService, todoService, {
+            setStorageMigrationReady: ready => { todoStorageMigration.ready = ready; },
+        }, settleMigration);
     const events = [];
     let resolveProjectMigration;
     const projectMigration = new Promise(resolve => { resolveProjectMigration = resolve; });
@@ -2224,7 +2228,7 @@ async function runDashboardTodoMigrationSequencingChecks() {
         await migration;
     }
 
-    const todoPanelBody = extractFunctionBody(extensionHostSource, 'postTodoPanelContent');
+    const todoPanelBody = extractFunctionBody(todoPanelCapabilitySource, 'postTodoPanelContent');
     assert.ok(todoPanelBody.includes('await todoStorageMigration.ready;'),
         'TODO panel rendering must wait for the active TODO storage migration');
 
@@ -4373,11 +4377,12 @@ function runSourceContractChecks(source) {
     const dndSource = fs.readFileSync(path.join(root, 'src', 'webview', 'webviewDnDScripts.js'), 'utf8');
     const filterSource = fs.readFileSync(path.join(root, 'src', 'webview', 'webviewFilterScripts.js'), 'utf8');
     const extensionHostSource = fs.readFileSync(extensionHostPath, 'utf8');
+    const todoPanelCapabilitySource = fs.readFileSync(todoPanelCapabilityPath, 'utf8');
     assert.strictEqual(extensionHostSource.includes('buildTodoSearchItems(todoService.getData())'), false,
         'initial and incremental Dashboard catalogs must not parse unsupported TODO data directly');
     assert.ok(extensionHostSource.includes('todoService.getSearchItems()'),
         'Dashboard catalog call sites must use the future-version-safe TODO catalog');
-    const todoPanelBody = extractFunctionBody(extensionHostSource, 'postTodoPanelContent');
+    const todoPanelBody = extractFunctionBody(todoPanelCapabilitySource, 'postTodoPanelContent');
     assert.ok(todoPanelBody.includes('UnsupportedTodoDataVersionError'));
     assert.ok(todoPanelBody.includes('getUnsupportedTodoVersionPanelContent'));
     assert.ok(todoPanelBody.includes('todoService.getUnsupportedVersionError()'),
@@ -4462,19 +4467,27 @@ function runSourceContractChecks(source) {
     assert.ok(source.includes('acceptedProjectsRequestId'));
     assert.ok(source.includes('pendingScrollRestoreTab'));
     assert.ok(extensionHostSource.includes("'request-projects-panel': async e =>"));
-    assert.ok(extensionHostSource.includes("'request-todo-panel': async e =>"));
+    assert.ok(todoPanelCapabilitySource.includes("'request-todo-panel': async e =>"));
     assert.ok(packageJson.includes('"agentPivot.maxVisibleTodosPerGroup"'));
     assert.ok(packageJson.includes('Maximum number of TODO cards visible in each group before the group list scrolls.'));
     assert.ok(packageJson.includes('"agentPivot.maxVisibleProjectsPerGroup"'));
     assert.strictEqual(extensionHostSource.includes('function handleStewardMessage('), false);
     assert.ok(extensionHostSource.includes('getAiSessionProviderIds: () => getRegisteredAiSessionProviders().map(provider => provider.id)'));
     assert.ok(extensionHostSource.includes("type: 'projects-panel-content'"));
-    assert.ok(extensionHostSource.includes("type: 'todo-panel-content'"));
+    assert.ok(todoPanelCapabilitySource.includes("type: 'todo-panel-content'"));
     assert.ok(extensionHostSource.includes('getProjectsPanelContent(projectService.getGroups(), stewardInfos)'));
-    assert.ok(extensionHostSource.includes('getTodoPanelContent('));
-    assert.ok(extensionHostSource.includes('buildTodoViewModel(todoData, todoViewState, revealedTodoId)'));
-    assert.ok(extensionHostSource.includes('todoRenderOptions'));
-    assert.ok(extensionHostSource.includes('getMaxVisibleTodosPerGroup('));
+    assert.ok(todoPanelCapabilitySource.includes('getTodoPanelContent('));
+    assert.ok(todoPanelCapabilitySource.includes('buildTodoViewModel(todoData, todoViewState, revealedTodoId)'));
+    assert.ok(todoPanelCapabilitySource.includes('todoRenderOptions'));
+    assert.ok(todoPanelCapabilitySource.includes('getMaxVisibleTodosPerGroup('));
+    assert.ok(extensionHostSource.includes("from './todos/todoPanelCapability'"),
+        'dashboard must import the extracted TODO panel capability');
+    assert.ok(extensionHostSource.includes('createTodoPanelCapability({'),
+        'dashboard must construct the extracted TODO panel capability');
+    assert.ok(extensionHostSource.includes('...todoPanel.handlers,'),
+        'dashboard must spread the TODO panel handlers into the message router');
+    assert.ok(extensionHostSource.includes('todoPanel.setStorageMigrationReady('),
+        'dashboard must hand the TODO storage migration gate to the capability');
     assert.ok(webviewContentSource.includes("'maxVisibleProjectsPerGroup',"));
     assert.ok(webviewContentSource.includes('DEFAULT_MAX_VISIBLE_PROJECTS_PER_GROUP = 5'));
     assert.ok(webviewContentSource.includes('--steward-max-visible-projects-per-group: ${maxVisibleProjectsPerGroup};'));
@@ -4515,25 +4528,25 @@ function runSourceContractChecks(source) {
         'TODO add submissions must retain form values until the host refresh succeeds');
     assert.strictEqual(projectSource.includes(".querySelectorAll('[data-action=\"add-project\"]')"), false);
     assert.strictEqual(projectSource.includes(".querySelectorAll('[data-action=\"import-from-other-storage\"]')"), false);
-    assert.ok(extensionHostSource.includes("'todo-add': async e =>"));
-    assert.ok(extensionHostSource.includes("'todo-toggle': async e =>"));
-    assert.ok(extensionHostSource.includes("'todo-delete': async e =>"));
-    assert.ok(extensionHostSource.includes("'todo-delete-group': async e =>"));
-    assert.ok(extensionHostSource.includes("'todo-collapse-group': async e =>"));
-    assert.ok(extensionHostSource.includes("'todo-rename-group': async e =>"));
-    assert.ok(extensionHostSource.includes("'todo-reorder-groups': async e =>"));
-    assert.ok(extensionHostSource.includes("'todo-reorder-items': async e =>"));
-    assert.ok(extensionHostSource.includes("'todo-collapse-groups': async e =>"));
-    assert.ok(extensionHostSource.includes("'todo-sort-priority': async e =>"));
-    assert.ok(extensionHostSource.includes("'todo-toggle-show-completed': async e =>"));
-    assert.ok(extensionHostSource.includes("'todo-reveal': async e =>"));
-    const todoShowCompletedHandler = extensionHostSource.slice(
-        extensionHostSource.indexOf("'todo-toggle-show-completed': async e =>"),
-        extensionHostSource.indexOf("'todo-reveal': async e =>")
+    assert.ok(todoPanelCapabilitySource.includes("'todo-add': async e =>"));
+    assert.ok(todoPanelCapabilitySource.includes("'todo-toggle': async e =>"));
+    assert.ok(todoPanelCapabilitySource.includes("'todo-delete': async e =>"));
+    assert.ok(todoPanelCapabilitySource.includes("'todo-delete-group': async e =>"));
+    assert.ok(todoPanelCapabilitySource.includes("'todo-collapse-group': async e =>"));
+    assert.ok(todoPanelCapabilitySource.includes("'todo-rename-group': async e =>"));
+    assert.ok(todoPanelCapabilitySource.includes("'todo-reorder-groups': async e =>"));
+    assert.ok(todoPanelCapabilitySource.includes("'todo-reorder-items': async e =>"));
+    assert.ok(todoPanelCapabilitySource.includes("'todo-collapse-groups': async e =>"));
+    assert.ok(todoPanelCapabilitySource.includes("'todo-sort-priority': async e =>"));
+    assert.ok(todoPanelCapabilitySource.includes("'todo-toggle-show-completed': async e =>"));
+    assert.ok(todoPanelCapabilitySource.includes("'todo-reveal': async e =>"));
+    const todoShowCompletedHandler = todoPanelCapabilitySource.slice(
+        todoPanelCapabilitySource.indexOf("'todo-toggle-show-completed': async e =>"),
+        todoPanelCapabilitySource.indexOf("'todo-reveal': async e =>")
     );
-    const todoRevealHandler = extensionHostSource.slice(
-        extensionHostSource.indexOf("'todo-reveal': async e =>"),
-        extensionHostSource.indexOf("'todo-update': async e =>")
+    const todoRevealHandler = todoPanelCapabilitySource.slice(
+        todoPanelCapabilitySource.indexOf("'todo-reveal': async e =>"),
+        todoPanelCapabilitySource.indexOf("'todo-update': async e =>")
     );
     assert.ok(todoRevealHandler.includes('await todoService.revealTodo('),
         'host reveal must delegate parsing and the optional group write to one TodoService queue operation');
@@ -4547,28 +4560,28 @@ function runSourceContractChecks(source) {
     assert.ok(todoShowCompletedHandler.indexOf('await todoService.setShowCompleted(')
         < todoShowCompletedHandler.indexOf('revealedTodoId = undefined;'),
     'an explicit completed toggle must clear the temporary target only after persistence succeeds');
-    assert.strictEqual((extensionHostSource.match(/revealedTodoId = undefined;/g) || []).length, 2,
+    assert.strictEqual((todoPanelCapabilitySource.match(/revealedTodoId = undefined;/g) || []).length, 2,
         'only legacy and versioned completed-visibility controls may clear the temporary target');
-    assert.ok(extensionHostSource.includes('buildTodoViewModel(todoData, todoViewState, revealedTodoId)'),
+    assert.ok(todoPanelCapabilitySource.includes('buildTodoViewModel(todoData, todoViewState, revealedTodoId)'),
         'all TODO panel refreshes must project the temporary reveal target');
-    assert.ok(extensionHostSource.includes("'todo-update': async e =>"));
-    assert.ok(extensionHostSource.includes('async function postTodoPanelContent('));
-    assert.ok(extensionHostSource.includes("from './todos/hostMutation'"));
-    assert.ok(extensionHostSource.includes('const todoViewState = todoService.getViewState();'));
+    assert.ok(todoPanelCapabilitySource.includes("'todo-update': async e =>"));
+    assert.ok(todoPanelCapabilitySource.includes('async function postTodoPanelContent('));
+    assert.ok(todoPanelCapabilitySource.includes("from './hostMutation'"));
+    assert.ok(todoPanelCapabilitySource.includes('const todoViewState = todoService.getViewState();'));
     assert.ok(extensionHostSource.includes(
         'const projectMigration = settleMigration(() => projectService.migrateDataIfNeeded())'));
     assert.ok(extensionHostSource.includes(
         'const todoMigration = settleMigration(() => todoService.migrateDataIfNeeded())'));
     assert.strictEqual(
-        (extensionHostSource.match(/await runTodoPanelMutation\(/g) || []).length,
+        (todoPanelCapabilitySource.match(/await runTodoPanelMutation\(/g) || []).length,
         10,
         'every non-prompt direct TODO mutation handler must use the write-error boundary'
     );
-    assert.ok(extensionHostSource.includes('await runTodoRequestMutation({'),
+    assert.ok(todoPanelCapabilitySource.includes('await runTodoRequestMutation({'),
         'compose mutations must use the request-correlated write-error boundary');
-    assert.ok(extensionHostSource.includes('await runTodoPromptMutation({'),
+    assert.ok(todoPanelCapabilitySource.includes('await runTodoPromptMutation({'),
         'add-group mutations must use the retrying prompt error boundary');
-    assert.ok(extensionHostSource.includes('await renameTodoGroupWithPrompt({'),
+    assert.ok(todoPanelCapabilitySource.includes('await renameTodoGroupWithPrompt({'),
         'rename-group mutations must check group existence before entering the retrying prompt boundary');
     assert.ok(dndSource.includes('function initDnD(root)'));
     assert.ok(dndSource.includes('function disposeDnD(root)'));

--- a/scripts/run-open-project-safety-checks.js
+++ b/scripts/run-open-project-safety-checks.js
@@ -3167,12 +3167,15 @@ async function runProjectServiceWorkspaceSaveMigrationIntegrationChecks() {
 
 function runDashboardBridgeLifecycleChecks() {
     const dashboard = fs.readFileSync(path.join(__dirname, '..', 'src', 'dashboard.ts'), 'utf8');
-    const refreshAfterMutation = extractFunctionBody(dashboard, 'refreshAfterMutation');
+    const projectMessageHandlers = fs.readFileSync(
+        path.join(__dirname, '..', 'src', 'projects', 'projectMessageHandlers.ts'), 'utf8'
+    );
+    const refreshAfterMutation = extractFunctionBody(projectMessageHandlers, 'refreshAfterMutation');
     const showAgentPivot = extractFunctionBody(dashboard, 'showAgentPivot');
     const projectedOpenWorkspaces = extractFunctionBody(dashboard, 'getOpenWorkspaceCards');
-    const selectedProjectHandler = dashboard.slice(
-        dashboard.indexOf("'selected-project': async e =>"),
-        dashboard.indexOf("'add-project': async e =>")
+    const selectedProjectHandler = projectMessageHandlers.slice(
+        projectMessageHandlers.indexOf("'selected-project': async e =>"),
+        projectMessageHandlers.indexOf("'add-project': async e =>")
     );
     const openWorkspaceControllerWiring = dashboard.slice(
         dashboard.indexOf('openWorkspaceController = new OpenWorkspaceController({'),
@@ -3284,13 +3287,13 @@ function runDashboardBridgeLifecycleChecks() {
     assert.ok(!dashboard.includes('get openProjects()'));
     assert.ok(projectedOpenWorkspaces.includes('openWorkspaceDashboardController.getCards()'));
     assert.ok(selectedProjectHandler.includes("projectId.startsWith('__openWorkspaceNavigation-')"));
-    assert.ok(selectedProjectHandler.includes('await workspaceNavigationController.open(projectId);'));
+    assert.ok(selectedProjectHandler.includes('await getWorkspaceNavigationController().open(projectId);'));
     assert.strictEqual(selectedProjectHandler.includes('getNavigationWorkspace(projectId)'), false);
     assert.strictEqual(selectedProjectHandler.includes('openProjectDashboardController'), false);
     assert.ok(selectedProjectHandler.includes('projectService.getProject(projectId)'));
     assert.ok(!selectedProjectHandler.includes('getOpenProjects()'));
     assert.ok(selectedProjectHandler.includes('await projectOpenController.openProject(project, projectOpenType);'));
-    assert.ok(dashboard.includes('await projectMutationController.addProject('));
+    assert.ok(projectMessageHandlers.includes('await projectMutationController.addProject('));
     assert.ok(dashboard.includes('saveCurrentWorkspace: () => savedWorkspaceProjectAdapter.saveCurrentWorkspace()'));
     assert.strictEqual(dashboard.includes('saveUntitledWorkspace:'), false,
         'workspace card saves must reuse the complete SavedWorkspaceProjectAdapter flow');
@@ -3319,8 +3322,8 @@ function runDashboardBridgeLifecycleChecks() {
     );
     assert.ok(saveAdapterWiring.includes('getCurrentWorkspace: resolveCurrentOpenWorkspace'),
         'Save Workspace As must read a fresh resolved snapshot instead of a cached transient card/controller state');
-    assert.ok(dashboard.includes('await projectMutationController.editProject('));
-    assert.ok(dashboard.includes('await projectMutationController.editProjectColor('));
+    assert.ok(projectMessageHandlers.includes('await projectMutationController.editProject('));
+    assert.ok(projectMessageHandlers.includes('await projectMutationController.editProjectColor('));
     assert.ok(dashboard.includes('editProjects: () => projectManualEditController.editProjectsManually()'));
     assert.ok(dashboard.includes('removeProject: () => projectRemovalController.removeProjectPerCommand()'));
     assert.ok(dashboard.includes('removeGroup: () => groupCommandController.removeGroupPerCommand()'));
@@ -3352,8 +3355,14 @@ function runDashboardBridgeLifecycleChecks() {
     assert.ok(dashboardLifecycleControllerSource.includes('this.options.publishOpenWorkspace(true);'));
     assert.ok(refreshAfterMutation.includes('postProjectSurfacesUpdated(mode);'),
         'saved project metadata mutations must update Projects and OPEN surfaces directly');
-    assert.ok(refreshAfterMutation.includes('openWorkspaceController.publish();'),
+    assert.ok(refreshAfterMutation.includes('options.publishOpenWorkspace();'),
         'saved project metadata mutations must republish even when configuration storage is disabled');
+    assert.ok(dashboard.includes('publishOpenWorkspace: () => openWorkspaceController.publish()'),
+        'the dashboard wires the workspace publication into the extracted project surface refresh');
+    assert.ok(dashboard.includes('createProjectSurfaceRefresh({'),
+        'the dashboard constructs the extracted project surface refresh');
+    assert.ok(dashboard.includes('createProjectMessageHandlers({'),
+        'the dashboard constructs the extracted project message handlers');
     assert.strictEqual(
         refreshAfterMutation.includes('dashboardRuntimeController.refreshAfterMutation();'),
         false,

--- a/scripts/run-skill-management-checks.js
+++ b/scripts/run-skill-management-checks.js
@@ -517,17 +517,26 @@ function runSkillControllerChecks() {
 
 function runSkillWiringChecks() {
     const dashboard = fs.readFileSync(path.join(__dirname, '..', 'src', 'dashboard.ts'), 'utf8');
-    assert.ok(dashboard.includes('new SkillDashboardController('));
-    assert.ok(dashboard.includes("'delete-skill'"));
-    assert.ok(!dashboard.includes("'toggle-skill'"), 'toggle message retired');
-    assert.ok(dashboard.includes('permanently? This cannot be undone.'), 'delete confirmation modal wired');
-    assert.ok(dashboard.includes("'open-skill-file'"));
-    assert.ok(!dashboard.includes("'set-skill-group'"), 'virtual group messages removed');
-    assert.ok(!dashboard.includes("'toggle-skill-group'"));
-    assert.ok(dashboard.includes("'fix-skill-diagnostic'"));
-    assert.ok(dashboard.includes("'apply-skill-collection'"));
-    assert.ok(dashboard.includes("'dismiss-skill-collection'"));
-    assert.ok(dashboard.includes('skillDashboardController.getRecords()'));
+    const skillPanel = fs.readFileSync(
+        path.join(__dirname, '..', 'src', 'skills', 'skillPanelCapability.ts'), 'utf8'
+    );
+    assert.ok(skillPanel.includes('new SkillDashboardController('));
+    assert.ok(dashboard.includes('createSkillPanelCapability({'),
+        'the dashboard constructs the extracted skill panel capability');
+    assert.ok(dashboard.includes('...skillPanel.handlers,'),
+        'the dashboard spreads the extracted skill handlers into the message router');
+    assert.ok(skillPanel.includes("'delete-skill'"));
+    assert.ok(!skillPanel.includes("'toggle-skill'"), 'toggle message retired');
+    assert.ok(skillPanel.includes('permanently? This cannot be undone.'), 'delete confirmation modal wired');
+    assert.ok(skillPanel.includes("'open-skill-file'"));
+    assert.ok(!skillPanel.includes("'set-skill-group'"), 'virtual group messages removed');
+    assert.ok(!skillPanel.includes("'toggle-skill-group'"));
+    assert.ok(skillPanel.includes("'fix-skill-diagnostic'"));
+    assert.ok(skillPanel.includes("'apply-skill-collection'"));
+    assert.ok(skillPanel.includes("'dismiss-skill-collection'"));
+    assert.ok(skillPanel.includes('skillDashboardController.getRecords()'));
+    assert.ok(dashboard.includes('skillPanel.getRecords()'),
+        'cross-domain search catalogs keep reading skill records through the facade');
     const packageJson = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8'));
     assert.ok(packageJson.scripts['test:skills'].includes('run-skill-management-checks.js'));
     // test:safety delegates to test:safety:run, which owns the check-script chain.
@@ -999,8 +1008,11 @@ function runGlobalStoreLocationChecks() {
         'the location action is only added to the Global section');
     assert.ok(sourceScript.includes("type: 'change-global-skills-location'"));
     const dashboard = fs.readFileSync(path.join(__dirname, '..', 'src', 'dashboard.ts'), 'utf8');
-    assert.ok(dashboard.includes("'change-global-skills-location'"));
-    assert.ok(dashboard.includes(
+    const skillPanel = fs.readFileSync(
+        path.join(__dirname, '..', 'src', 'skills', 'skillPanelCapability.ts'), 'utf8'
+    );
+    assert.ok(skillPanel.includes("'change-global-skills-location'"));
+    assert.ok(skillPanel.includes(
         'globalStoreLocationController.changeInteractively()',
     ));
     const packageJson = JSON.parse(
@@ -2031,9 +2043,12 @@ function runSkillCentralChecks() {
     assert.ok(script.includes('data-central-toggle'));
     assert.ok(script.includes('data-central-source'));
     const dashboard = fs.readFileSync(path.join(__dirname, '..', 'src', 'dashboard.ts'), 'utf8');
-    assert.ok(dashboard.includes("'central-toggle-skill'"));
-    assert.ok(dashboard.includes("'centralize-skill'"));
-    assert.ok(dashboard.includes("'skill-scope-action'"));
+    const skillPanel = fs.readFileSync(
+        path.join(__dirname, '..', 'src', 'skills', 'skillPanelCapability.ts'), 'utf8'
+    );
+    assert.ok(skillPanel.includes("'central-toggle-skill'"));
+    assert.ok(skillPanel.includes("'centralize-skill'"));
+    assert.ok(skillPanel.includes("'skill-scope-action'"));
     const styles = fs.readFileSync(path.join(__dirname, '..', 'media', 'styles.scss'), 'utf8');
     const compiledCss = fs.readFileSync(path.join(__dirname, '..', 'media', 'styles.css'), 'utf8');
     assert.ok(styles.includes('.skill-chip.central'));
@@ -2410,8 +2425,11 @@ function runSkillMigrationChecks() {
     assert.ok(script.includes("'migrate-skills-to-central'"), 'webview posts migrate command');
     assert.ok(script.includes('data-skill-menu-migrate'), 'section ⋯ menu carries migrate');
     const dashboard = fs.readFileSync(path.join(__dirname, '..', 'src', 'dashboard.ts'), 'utf8');
-    assert.ok(dashboard.includes("'migrate-skills-to-central'"), 'dashboard handles migrate message');
-    assert.ok(dashboard.includes('migrateSkillsToCentral: () => runSkillMigrationToCentral(),'), 'palette command handler wired');
+    const skillPanel = fs.readFileSync(
+        path.join(__dirname, '..', 'src', 'skills', 'skillPanelCapability.ts'), 'utf8'
+    );
+    assert.ok(skillPanel.includes("'migrate-skills-to-central'"), 'dashboard handles migrate message');
+    assert.ok(dashboard.includes('migrateSkillsToCentral: () => skillPanel.migrateToCentral(),'), 'palette command handler wired');
     const reg = fs.readFileSync(path.join(__dirname, '..', 'src', 'dashboard', 'commandRegistration.ts'), 'utf8');
     assert.ok(reg.includes("'agentPivot.migrateSkillsToCentral'"), 'command id registered');
     assert.ok(reg.includes('migrateSkillsToCentral: DashboardCommandHandler'), 'handler type declared');
@@ -2585,9 +2603,12 @@ function runSkillFolderMutationChecks() {
     assert.ok(script.includes('data-section-menu'), 'section ⋯ menu wiring present');
     assert.ok(script.includes('data-skill-remove-folder'));
     const dashboard = fs.readFileSync(path.join(__dirname, '..', 'src', 'dashboard.ts'), 'utf8');
-    assert.ok(dashboard.includes("'create-skill-folder'"));
-    assert.ok(dashboard.includes("'remove-skill-folder'"));
-    assert.ok(dashboard.includes('showInputBox'), 'folder name prompted host-side');
+    const skillPanel = fs.readFileSync(
+        path.join(__dirname, '..', 'src', 'skills', 'skillPanelCapability.ts'), 'utf8'
+    );
+    assert.ok(skillPanel.includes("'create-skill-folder'"));
+    assert.ok(skillPanel.includes("'remove-skill-folder'"));
+    assert.ok(skillPanel.includes('showInputBox'), 'folder name prompted host-side');
     const styles = fs.readFileSync(path.join(__dirname, '..', 'media', 'styles.scss'), 'utf8');
     const compiledCss = fs.readFileSync(path.join(__dirname, '..', 'media', 'styles.css'), 'utf8');
     assert.ok(styles.includes('.skill-folder-add'));

--- a/src/aiSessions/runtimeSettlementCapability.ts
+++ b/src/aiSessions/runtimeSettlementCapability.ts
@@ -1,0 +1,232 @@
+'use strict';
+
+import type * as vscode from 'vscode';
+import type { AiSessionProviderId } from '../models';
+import {
+    runAiSessionRuntimeLifecycleTask,
+    settleAiSessionRuntimeLifecycles,
+} from './attentionController';
+import type {
+    AiSessionAttentionEvaluation,
+    AiSessionRuntimeLifecycleCandidate,
+} from './attentionController';
+import { getAttentionRuntimeSessionKey } from './attentionProject';
+import { cloneAiSessionRuntimeIdentity } from './runtimeTypes';
+import type { AiSessionRuntimeSnapshot } from './runtimeTypes';
+import type AiSessionTerminalService from './terminalService';
+import type { TmuxRuntimeDiscovery } from './tmuxRuntimeDiscovery';
+
+type RuntimeLifecycleCandidate = AiSessionRuntimeLifecycleCandidate & {
+    runtime: AiSessionRuntimeSnapshot<vscode.Terminal>;
+};
+
+export interface RuntimeSettlementAttentionOverride {
+    providerId: AiSessionProviderId;
+    sessionId: string;
+    attentionKey: string;
+    runtime: AiSessionRuntimeSnapshot<vscode.Terminal>;
+}
+
+export interface AiSessionRuntimeSettlementCapabilityOptions {
+    runtimeBelongsToCurrentWorkspace: (
+        runtime: AiSessionRuntimeSnapshot<vscode.Terminal>
+    ) => boolean;
+    evaluateAttention: (
+        runtimeOverrides: readonly RuntimeSettlementAttentionOverride[]
+    ) => Promise<AiSessionAttentionEvaluation>;
+    tmuxRuntimeDiscovery: TmuxRuntimeDiscovery;
+    aiSessionTerminalService: AiSessionTerminalService;
+    refreshAiSessionViewsIncrementally: () => void;
+    /** Late-bound: the highlighter is constructed after this capability. */
+    syncActiveTerminalHighlighter: () => void;
+    logDiagnostic: (event: Record<string, unknown>) => void;
+    setInterval: (callback: () => void, intervalMs: number) => unknown;
+    clearInterval: (handle: unknown) => void;
+}
+
+export interface AiSessionRuntimeSettlementCapability {
+    /** Runs a runtime lifecycle task with the shared named-reason failure reporting. */
+    runSafeLifecycleTask(
+        operation: string,
+        task: () => unknown | Promise<unknown>
+    ): Promise<void>;
+    /** Queues completed/stopped runtimes of the current workspace for settlement. */
+    queueSettlements(runtimes: readonly AiSessionRuntimeSnapshot<vscode.Terminal>[]): void;
+    /** Starts the 1s completed-runtime settlement scan. Idempotent. */
+    startSettlementScan(): void;
+    dispose(): void;
+}
+
+/**
+ * Owns the AI session runtime settlement queue: completed and stopped runtimes
+ * are coalesced by attention key, drained in key order through
+ * settleAiSessionRuntimeLifecycles, and released against their backend, while
+ * the 1s scan feeds the queue from the terminal service and tmux discovery.
+ *
+ * Extracted from `initializeDashboard` in src/dashboard.ts (see the session
+ * status capability for the cadence pattern). Behaviour is unchanged: the
+ * queue keys, drain order, in-flight semantics, failure reporting, and scan
+ * interval are the same; only their ownership moved.
+ */
+export function createAiSessionRuntimeSettlementCapability(
+    options: AiSessionRuntimeSettlementCapabilityOptions
+): AiSessionRuntimeSettlementCapability {
+    const runtimeBelongsToCurrentWorkspace = options.runtimeBelongsToCurrentWorkspace;
+    const evaluateAiSessionAttention = options.evaluateAttention;
+    const tmuxRuntimeDiscovery = options.tmuxRuntimeDiscovery;
+    const aiSessionTerminalService = options.aiSessionTerminalService;
+    const refreshAiSessionViewsIncrementally = options.refreshAiSessionViewsIncrementally;
+    const syncActiveTerminalHighlighter = options.syncActiveTerminalHighlighter;
+    const logAiSessionDiagnostic = options.logDiagnostic;
+
+    const queuedAiSessionRuntimeSettlements = new Map<string, RuntimeLifecycleCandidate>();
+    const settlingAiSessionRuntimeKeys = new Set<string>();
+    let aiSessionRuntimeSettlementInFlight: Promise<void> | null = null;
+    const runSafeAiSessionRuntimeLifecycleTask = (
+        operation: string,
+        task: () => unknown | Promise<unknown>
+    ): Promise<void> => runAiSessionRuntimeLifecycleTask(
+        operation,
+        task,
+        (failedOperation, category) => logAiSessionDiagnostic({
+            event: 'runtime-lifecycle-task-failed',
+            operation: failedOperation,
+            category,
+        })
+    );
+    const queueAiSessionRuntimeSettlements = (
+        runtimes: readonly AiSessionRuntimeSnapshot<vscode.Terminal>[]
+    ): void => {
+        for (const runtime of runtimes) {
+            if (!runtimeBelongsToCurrentWorkspace(runtime)) {
+                continue;
+            }
+            const sessionId = runtime.identity.sessionId;
+            if (!sessionId || (runtime.state !== 'completed' && runtime.state !== 'stopped')) {
+                continue;
+            }
+            const key = getAttentionRuntimeSessionKey({
+                workspaceScopeIdentity: runtime.identity.workspaceScopeIdentity,
+                provider: runtime.identity.provider,
+                sessionId,
+                runStartedAtMs: runtime.runStartedAtMs,
+                backend: runtime.backend,
+            });
+            if (settlingAiSessionRuntimeKeys.has(key)) {
+                continue;
+            }
+            queuedAiSessionRuntimeSettlements.set(key, {
+                key,
+                sessionKey: key,
+                state: runtime.state,
+                runtime: {
+                    ...runtime,
+                    identity: cloneAiSessionRuntimeIdentity(runtime.identity),
+                    ...(runtime.tmux ? { tmux: { ...runtime.tmux } } : {}),
+                },
+            });
+        }
+        if (!aiSessionRuntimeSettlementInFlight && queuedAiSessionRuntimeSettlements.size) {
+            aiSessionRuntimeSettlementInFlight = runSafeAiSessionRuntimeLifecycleTask(
+                'settle-runtime-lifecycles',
+                drainAiSessionRuntimeSettlements
+            );
+        }
+    };
+    const drainAiSessionRuntimeSettlements = async (): Promise<void> => {
+        try {
+            while (queuedAiSessionRuntimeSettlements.size) {
+                const candidates = [...queuedAiSessionRuntimeSettlements.values()]
+                    .sort((left, right) => left.key.localeCompare(right.key));
+                queuedAiSessionRuntimeSettlements.clear();
+                candidates.forEach(candidate => settlingAiSessionRuntimeKeys.add(candidate.key));
+                try {
+                    const settled = await settleAiSessionRuntimeLifecycles({
+                        candidates: candidates,
+                        evaluateAttention: () => evaluateAiSessionAttention(
+                            candidates.map(candidate => ({
+                                providerId: candidate.runtime.identity.provider,
+                                sessionId: candidate.runtime.identity.sessionId as string,
+                                attentionKey: candidate.key,
+                                runtime: candidate.runtime,
+                            }))
+                        ),
+                        release: async candidate => {
+                            if (candidate.runtime.backend === 'tmux') {
+                                const acknowledgement = await tmuxRuntimeDiscovery
+                                    .acknowledgeInactive(candidate.runtime);
+                                if (acknowledgement === 'stale') {
+                                    throw new Error('The tmux lifecycle acknowledgement became stale.');
+                                }
+                                return;
+                            }
+                            aiSessionTerminalService.releaseCompletedSession(
+                                candidate.runtime.identity.provider,
+                                candidate.runtime.identity.sessionId as string,
+                                candidate.runtime.identity.workspaceScopeIdentity
+                            );
+                        },
+                        reportFailure: (operation, category, key) => logAiSessionDiagnostic({
+                            event: 'runtime-lifecycle-settlement-failed',
+                            operation,
+                            category,
+                            hasRuntimeKey: Boolean(key),
+                        }),
+                    });
+                    if (settled.releasedKeys.length) {
+                        refreshAiSessionViewsIncrementally();
+                        syncActiveTerminalHighlighter();
+                    }
+                } finally {
+                    candidates.forEach(candidate => settlingAiSessionRuntimeKeys.delete(candidate.key));
+                }
+            }
+        } catch (_error) {
+            logAiSessionDiagnostic({
+                event: 'runtime-lifecycle-settlement-failed',
+                operation: 'drain',
+                category: 'unexpected',
+            });
+        } finally {
+            aiSessionRuntimeSettlementInFlight = null;
+            if (queuedAiSessionRuntimeSettlements.size) {
+                queueAiSessionRuntimeSettlements([]);
+            }
+        }
+    };
+
+    let settlementScanHandle: unknown;
+    const startSettlementScan = (): void => {
+        if (settlementScanHandle !== undefined) {
+            return;
+        }
+        settlementScanHandle = options.setInterval(() => {
+            const completedSessions = aiSessionTerminalService.getCompletedSessions();
+            const completedRuntimes = completedSessions.filter(resolution =>
+                !!resolution.entry.runtimeIdentity).map(resolution => ({
+                    identity: cloneAiSessionRuntimeIdentity(resolution.entry.runtimeIdentity),
+                    backend: 'vscode',
+                    state: 'completed',
+                    markerPath: resolution.entry.markerPath,
+                    runStartedAtMs: resolution.entry.runStartedAtMs,
+                    attached: true,
+                    terminal: resolution.terminal,
+                } as AiSessionRuntimeSnapshot<vscode.Terminal>));
+            const inactiveTmuxRuntimes = tmuxRuntimeDiscovery.getInactive()
+                .map(runtime => runtime as AiSessionRuntimeSnapshot<vscode.Terminal>);
+            queueAiSessionRuntimeSettlements([...completedRuntimes, ...inactiveTmuxRuntimes]);
+        }, 1_000);
+    };
+
+    return {
+        runSafeLifecycleTask: runSafeAiSessionRuntimeLifecycleTask,
+        queueSettlements: queueAiSessionRuntimeSettlements,
+        startSettlementScan,
+        dispose: () => {
+            if (settlementScanHandle !== undefined) {
+                options.clearInterval(settlementScanHandle);
+                settlementScanHandle = undefined;
+            }
+        },
+    };
+}

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -6,7 +6,7 @@ import { existsSync, statSync } from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { performance } from 'perf_hooks';
-import { Project, GroupOrder, ProjectRemoteType, StewardInfos, ProjectOpenType, ReopenStewardReason, AiSessionProviderId, isAiSessionProviderId } from './models';
+import { Project, ProjectRemoteType, StewardInfos, ReopenStewardReason, AiSessionProviderId, isAiSessionProviderId } from './models';
 import { getProjectsPanelContent, getStewardContent } from './webview/webviewContent';
 import { getSkillsPanelContent } from './webview/webviewSkillContent';
 import {
@@ -49,7 +49,7 @@ import {
 import AiSessionWorkspaceStateStore from './aiSessions/workspaceStateStore';
 import ActiveAiSessionTerminalHighlighter from './aiSessions/activeTerminalHighlight';
 import AttentionBridgeClient from './aiSessions/attentionBridgeClient';
-import { getAttentionRuntimeSessionKey, getLogicalAttentionSessionKey, withAttentionProject } from './aiSessions/attentionProject';
+import { getAttentionRuntimeSessionKey, getLogicalAttentionSessionKey } from './aiSessions/attentionProject';
 import type { ActiveAiSessionTerminalIdentity } from './aiSessions/activeTerminalHighlight';
 import { getAiSessionKey } from './aiSessions/sessionHelpers';
 import {
@@ -143,6 +143,7 @@ import { ProjectOpenController } from './projects/projectOpenController';
 import { ProjectOrderController } from './projects/projectOrderController';
 import { ProjectPromptController } from './projects/projectPromptController';
 import { ProjectRemovalController } from './projects/projectRemovalController';
+import { createProjectMessageHandlers, createProjectSurfaceRefresh } from './projects/projectMessageHandlers';
 import { AgentPivotViewProvider } from './dashboard/viewProvider';
 import type { AgentPivotViewProviderOptions } from './dashboard/viewProvider';
 import { DashboardBootstrapController } from './dashboard/bootstrapController';
@@ -161,7 +162,6 @@ import {
     DashboardRuntimeController,
     revealAgentPivotDashboard,
 } from './dashboard/runtimeController';
-import type { ProjectsPanelUpdateMode } from './dashboard/webviewUpdateMessages';
 import { DashboardStartupController, settleMigration } from './dashboard/startupController';
 import { getDashboardWebviewOptions } from './dashboard/webviewOptions';
 import OpenWorkspaceBridgeClient from './openWorkspaces/bridgeClient';
@@ -602,6 +602,13 @@ async function initializeDashboard(
         showErrorMessage: message => vscode.window.showErrorMessage(message),
         logError,
     }));
+    const projectSurface = createProjectSurfaceRefresh({
+        getProjectsPanelController: () => projectsPanelController,
+        getOpenWorkspaceDashboardController: () => openWorkspaceDashboardController,
+        publishOpenWorkspace: () => openWorkspaceController.publish(),
+        syncProjectColorToCurrentWindow: project =>
+            dashboardRuntimeController.applyProjectColorToCurrentWindow(project),
+    });
     const groupCollapseController = new GroupCollapseController({
         state: context.globalState,
         projectService,
@@ -612,7 +619,7 @@ async function initializeDashboard(
         promptGroupToRemove: () => projectPromptController.queryGroup(),
         confirmRemoveGroup: groupName => vscode.window.showWarningMessage(`Remove ${groupName}?`, { modal: true }, 'Remove'),
         showErrorMessage: message => vscode.window.showErrorMessage(message),
-        refreshAfterMutation,
+        refreshAfterMutation: projectSurface.refreshAfterMutation,
         userCanceledToken: USER_CANCELED,
     });
     const projectWindowColorService = new ProjectWindowColorService(context);
@@ -663,18 +670,18 @@ async function initializeDashboard(
         showWarningMessage: message => vscode.window.showWarningMessage(message),
         showInformationMessage: message => vscode.window.showInformationMessage(message),
         showErrorMessage: message => vscode.window.showErrorMessage(message),
-        refreshAfterMutation,
+        refreshAfterMutation: projectSurface.refreshAfterMutation,
     });
     const favoriteProjectController = new FavoriteProjectController({
         getGroups: () => projectService.getGroups(),
         saveGroups: groups => projectService.saveGroups(groups),
-        refreshAfterMutation,
+        refreshAfterMutation: projectSurface.refreshAfterMutation,
     });
     const projectOrderController = new ProjectOrderController({
         getGroups: () => projectService.getGroups(),
         saveGroups: groups => projectService.saveGroups(groups),
         showInformationMessage: message => vscode.window.showInformationMessage(message),
-        refreshAfterMutation,
+        refreshAfterMutation: projectSurface.refreshAfterMutation,
     });
     const projectRemovalController = new ProjectRemovalController({
         getProject: projectId => projectService.getProject(projectId),
@@ -682,7 +689,7 @@ async function initializeDashboard(
         showProjectPicker: projectPicks => vscode.window.showQuickPick(projectPicks),
         confirmRemoveProject: projectName => vscode.window.showWarningMessage(`Remove ${projectName}?`, { modal: true }, 'Remove'),
         removeProject: projectId => projectService.removeProject(projectId),
-        refreshAfterMutation,
+        refreshAfterMutation: projectSurface.refreshAfterMutation,
         postCommandRemoval: () => { void dashboardRuntimeController.revealAgentPivotDashboard(); },
     });
     const projectManualEditController = new ProjectManualEditController({
@@ -698,7 +705,7 @@ async function initializeDashboard(
         executeCommand: command => vscode.commands.executeCommand(command),
         showErrorMessage: message => vscode.window.showErrorMessage(message),
         postSave: () => {
-            refreshAfterMutation();
+            projectSurface.refreshAfterMutation();
             void dashboardRuntimeController.revealAgentPivotDashboard();
         },
     });
@@ -712,7 +719,7 @@ async function initializeDashboard(
         getRandomColor: () => colorService.getRandomColor(),
         isFolderGitRepo,
         showErrorMessage: message => vscode.window.showErrorMessage(message),
-        refreshAfterMutation,
+        refreshAfterMutation: projectSurface.refreshAfterMutation,
         userCanceledToken: USER_CANCELED,
     });
     const codexSessionService = new CodexSessionService();
@@ -1648,6 +1655,22 @@ async function initializeDashboard(
         'cancel-ai-session-conversation': message =>
             conversationCapability.controller.cancel(message),
     };
+    const projectHandlers = createProjectMessageHandlers({
+        projectService,
+        projectOpenController,
+        projectMutationController,
+        projectOrderController,
+        favoriteProjectController,
+        projectRemovalController,
+        groupCommandController,
+        groupCollapseController,
+        getWorkspaceNavigationController: () => workspaceNavigationController,
+        getOpenWorkspacePinController: () => openWorkspacePinController,
+        getAttentionAggregate: () => aiSessionAttentionController.getEffectiveAggregate(),
+        acknowledgeAiSessionAttentionEventIds,
+        refreshAfterMutation: projectSurface.refreshAfterMutation,
+        showWarningMessage: message => vscode.window.showWarningMessage(message),
+    });
 
     const dashboardMessageRouter = createDashboardMessageRouter({
         getAiSessionProviderIds: () => getRegisteredAiSessionProviders().map(provider => provider.id),
@@ -1655,6 +1678,7 @@ async function initializeDashboard(
         handlers: {
             ...conversationHandlers,
             ...todoPanel.handlers,
+            ...projectHandlers,
             'request-projects-panel': async e => {
                 if (e.version !== 1 || !Number.isSafeInteger(e.requestId) || e.requestId < 1) {
                     return;
@@ -1960,54 +1984,6 @@ async function initializeDashboard(
                     await provider.postMessage(result);
                 }
             },
-            'selected-project': async e => {
-                let projectId = e.projectId as string;
-                let projectOpenType = e.projectOpenType as ProjectOpenType;
-
-                if (projectId.startsWith('__openWorkspaceNavigation-')) {
-                    await workspaceNavigationController.open(projectId);
-                    return;
-                }
-
-                const project = projectService.getProject(projectId);
-                if (project == null) {
-                    vscode.window.showWarningMessage("Selected Project not found.");
-                    return;
-                }
-
-                const attentionProject = withAttentionProject(
-                    project,
-                    aiSessionAttentionController.getEffectiveAggregate()
-                );
-                await acknowledgeAiSessionAttentionEventIds(attentionProject.aiSessionAttentionEventIds);
-                await projectOpenController.openProject(project, projectOpenType);
-            },
-            'set-open-workspace-pin': e => openWorkspacePinController.handle(e),
-            'add-project': async e => {
-                await projectMutationController.addProject(e.groupId as string);
-            },
-            'import-from-other-storage': async () => {
-                await projectService.copyProjectsFromFilledStorageOptionToEmptyStorageOption();
-                refreshAfterMutation();
-            },
-            'reordered-projects': async e => {
-                await projectOrderController.reorderGroups(e.groupOrders as GroupOrder[]);
-            },
-            'reordered-favorites': async e => {
-                await favoriteProjectController.reorderFavoriteProjects(Array.isArray(e.projectIds) ? e.projectIds as string[] : []);
-            },
-            'remove-project': async e => {
-                await projectRemovalController.removeProject(e.projectId as string);
-            },
-            'edit-project': async e => {
-                await projectMutationController.editProject(e.projectId as string);
-            },
-            'color-project': async e => {
-                await projectMutationController.editProjectColor(e.projectId as string);
-            },
-            'favorite-project': async e => {
-                await favoriteProjectController.toggleProjectFavorite(e.projectId as string);
-            },
             'toggle-codex-sessions': async e => {
                 await aiSessionCommandController.toggleSessionsExpanded(e.projectId as string, Boolean(e.expanded));
             },
@@ -2126,20 +2102,6 @@ async function initializeDashboard(
                     e.version
                 );
             },
-            'edit-group': async e => {
-                await groupCommandController.editGroup(e.groupId as string);
-            },
-            'remove-group': async e => {
-                await groupCommandController.removeGroup(e.groupId as string);
-            },
-            'add-group': async () => {
-                await groupCommandController.addGroup();
-            },
-            'collapse-group': async e => {
-                await groupCollapseController.collapseGroup(e.groupId as string, e.collapsed as boolean);
-            },
-            // Collapse-all is a per-webview convenience action.
-            'toggle-all-groups': () => undefined,
         },
         createAiSession: async e => {
             await aiSessionCreationController.createSession(e.projectId as string);
@@ -2448,7 +2410,7 @@ async function initializeDashboard(
         showErrorMessage: message => vscode.window.showErrorMessage(message),
         logError,
         showAgentPivot,
-        applyProjectColorToCurrentWindow,
+        applyProjectColorToCurrentWindow: projectSurface.applyProjectColorToCurrentWindow,
         getReopenReason: () => context.globalState.get(REOPEN_KEY),
         updateReopenReason: reason => context.globalState.update(REOPEN_KEY, reason),
         reopenNoneValue: ReopenStewardReason.None,
@@ -2484,9 +2446,9 @@ async function initializeDashboard(
             projectService.consumeProjectCatalogWriteEcho(change),
         consumePromptDataWriteEcho: () =>
             promptService.consumeCurrentSettingsDataLocalWriteEcho(),
-        applyProjectColorToCurrentWindow,
+        applyProjectColorToCurrentWindow: projectSurface.applyProjectColorToCurrentWindow,
         refresh: refreshStewardViews,
-        refreshProjects: () => postProjectSurfacesUpdated('replace'),
+        refreshProjects: () => projectSurface.postProjectSurfacesUpdated('replace'),
         refreshPrompts: () => {
             void provider.postMessage(promptDashboardController.getRefreshContent());
         },
@@ -2957,21 +2919,6 @@ async function initializeDashboard(
 
     function invalidateAiSessionCache(providerId: AiSessionProviderId) {
         getRegisteredAiSessionProvider(providerId)?.service.invalidateCache();
-    }
-
-    function postProjectSurfacesUpdated(mode: ProjectsPanelUpdateMode): void {
-        projectsPanelController?.postUpdated(mode);
-        openWorkspaceDashboardController.postUpdated();
-    }
-
-    function refreshAfterMutation(mode: ProjectsPanelUpdateMode = 'replace') {
-        postProjectSurfacesUpdated(mode);
-        applyProjectColorToCurrentWindow();
-        openWorkspaceController.publish();
-    }
-
-    function applyProjectColorToCurrentWindow(project: Project = null) {
-        dashboardRuntimeController.applyProjectColorToCurrentWindow(project);
     }
 
     async function showAgentPivotSettings() {

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -26,9 +26,7 @@ import { PromptDashboardController } from './prompts/dashboardController';
 import { initializePromptMementoStore, PromptService } from './prompts/service';
 import { PromptTerminalCommandController } from './prompts/terminalCommandController';
 import { getAiPanelContent, getPromptSurfaceContent } from './prompts/webviewContent';
-import { SkillDashboardController } from './skills/dashboardController';
-import { GlobalStoreLocationController } from './skills/globalStoreLocationController';
-import { skillDirectoriesEqual } from './skills/scopeService';
+import { createSkillPanelCapability } from './skills/skillPanelCapability';
 import { SkillGroupStore } from './skills/skillGroupStore';
 import FileService from './services/fileService';
 import CodexSessionService from './services/codexSessionService';
@@ -446,28 +444,6 @@ async function initializeDashboard(
     });
     const getWorkspaceRootPaths = (): string[] =>
         (vscode.workspace.workspaceFolders || []).map(folder => folder.uri.fsPath);
-    const globalStoreLocationController = new GlobalStoreLocationController({
-        homeDir: os.homedir(),
-        getWorkspaceRoots: getWorkspaceRootPaths,
-        readSetting: () => getAgentPivotConfiguration().get<string>(
-            'skills.globalStorePath',
-            '~/.skills',
-        ),
-        writeSetting: value => getAgentPivotConfiguration().update(
-            'skills.globalStorePath',
-            value,
-            vscode.ConfigurationTarget.Global,
-        ),
-        showInputBox: options => vscode.window.showInputBox(options),
-        showWarningMessage: (message, options, ...items) => options
-            ? vscode.window.showWarningMessage(message, options, ...items)
-            : vscode.window.showWarningMessage(message),
-        showErrorMessage: message => vscode.window.showErrorMessage(message),
-        refresh: () => skillDashboardController.refresh(
-            'global-skills-location-changed',
-        ),
-        logError,
-    });
     const promptDashboardController = new PromptDashboardController({
         service: promptService,
         confirmDelete: async prompt => {
@@ -482,108 +458,46 @@ async function initializeDashboard(
         renderAiPanel: snapshot => getAiPanelContent(
             snapshot,
             getSkillsPanelContent(
-                skillDashboardController.getRecords(),
-                skillDashboardController.getPanelView(),
+                skillPanel.getRecords(),
+                skillPanel.getPanelView(),
             ),
         ),
     });
-    const skillDashboardController = ownResource(() => new SkillDashboardController({
+    const skillPanel = ownResource(() => createSkillPanelCapability({
         getHomeDir: () => os.homedir(),
         getWorkspaceRoot: () => vscode.workspace.workspaceFolders?.[0]?.uri.fsPath,
-        getGlobalSkillsRoot: () => globalStoreLocationController.getActiveRoot(),
-        postMessage: message => provider.postMessage(message),
-        isVisible: () => provider.visible,
-        logError,
+        getWorkspaceRoots: getWorkspaceRootPaths,
+        hasWorkspace: () => Boolean(vscode.workspace.workspaceFolders?.length),
         groupStore: new SkillGroupStore(context.globalState),
+        readGlobalStorePath: () => getAgentPivotConfiguration().get<string>(
+            'skills.globalStorePath',
+            '~/.skills',
+        ),
+        writeGlobalStorePath: value => getAgentPivotConfiguration().update(
+            'skills.globalStorePath',
+            value,
+            vscode.ConfigurationTarget.Global,
+        ),
+        postMessage: message => provider.postMessage(message),
+        refreshDashboard: () => provider.refresh(),
+        isVisible: () => provider.visible,
+        showInputBox: options => vscode.window.showInputBox(options),
+        showQuickPickMany: <T extends vscode.QuickPickItem>(
+            items: readonly T[],
+            quickPickOptions: vscode.QuickPickOptions
+        ) => vscode.window.showQuickPick(
+            [...items],
+            { ...quickPickOptions, canPickMany: true } as vscode.QuickPickOptions & { canPickMany: true }
+        ),
+        showWarningMessage: (message, messageOptions, ...items) => messageOptions
+            ? vscode.window.showWarningMessage(message, messageOptions, ...items)
+            : vscode.window.showWarningMessage(message),
+        showInformationMessage: message => vscode.window.showInformationMessage(message),
+        showErrorMessage: message => vscode.window.showErrorMessage(message),
+        openTextFile: fsPath => vscode.window.showTextDocument(vscode.Uri.file(fsPath)),
+        logError,
     }));
-    const completedSkillScopeActionRequests = new Set<string>();
-    const publishSkillScopeActionSettlement = async (settlement: {
-        version: 1;
-        requestId: string;
-        dirPath: string;
-        operation: 'apply-to-project' | 'move-to-global';
-        ok: boolean;
-        code?: string;
-        resultDirPath?: string;
-    }): Promise<void> => {
-        let delivered = false;
-        try {
-            delivered = await skillDashboardController.refresh('skill-scope-action', settlement);
-        } catch (error) {
-            logError('Failed to publish the authoritative Skill scope update.', error);
-        }
-        if (delivered) {
-            return;
-        }
-        try {
-            provider.refresh();
-        } catch (error) {
-            logError('Failed to refresh the dashboard after a Skill scope action.', error);
-        }
-        try {
-            await provider.postMessage({
-                type: 'skill-scope-action-result',
-                ...settlement,
-                ok: false,
-                code: 'refresh-failed',
-            });
-        } catch (error) {
-            logError('Failed to settle the Skill scope action.', error);
-        }
-    };
-    timeBootstrapPhase('skill-scan', () => skillDashboardController.start());
-    const runSkillMigrationToCentral = async (scope?: 'user' | 'project'): Promise<void> => {
-        const hasWorkspace = Boolean(vscode.workspace.workspaceFolders?.length);
-        const migratable = skillDashboardController.getRecords()
-            .filter(record => !record.central
-                && (!scope || record.scope === scope)
-                && (record.source === 'kimi' || record.source === 'claude' || record.source === 'codex'));
-        if (!migratable.length) {
-            void vscode.window.showInformationMessage(scope
-                ? `Every ${scope === 'user' ? 'user' : 'project'} skill is already centralized.`
-                : 'Every skill is already centralized.');
-            return;
-        }
-        const userNames = new Set(migratable.filter(record => record.scope === 'user').map(record => record.name));
-        const projectNames = new Set(migratable.filter(record => record.scope === 'project').map(record => record.name));
-        const segments: string[] = [];
-        if (userNames.size) {
-            segments.push(
-                `${userNames.size} user skill(s) into `
-                + skillDashboardController.getStoreRoots().user,
-            );
-        }
-        if (hasWorkspace && projectNames.size) {
-            segments.push(`${projectNames.size} project skill(s) into this project's .skills`);
-        }
-        const choice = await vscode.window.showWarningMessage(
-            `Migrate ${segments.join(' and ')}? `
-            + 'The kimi > claude > codex copy wins, other copies are deleted, '
-            + 'and no agent links are created — enable agents per card afterwards.',
-            { modal: true },
-            'Migrate',
-        );
-        if (choice !== 'Migrate') {
-            return;
-        }
-        const report = skillDashboardController.handleMigrateToCentral(scope);
-        const parts = [`Migrated ${report.migrated.length} skill(s) into the central stores`];
-        if (report.drifted.length) {
-            parts.push(`${report.drifted.length} had drift (brand-priority winner)`);
-        }
-        if (report.deleted.length) {
-            parts.push(`${report.deleted.length} duplicate(s) deleted`);
-        }
-        if (report.skipped.length) {
-            parts.push(`${report.skipped.length} skipped`);
-        }
-        const summary = `${parts.join('; ')}.`;
-        if (report.errors.length) {
-            void vscode.window.showWarningMessage(`${summary} ${report.errors.length} failed: ${report.errors[0].error}`);
-        } else {
-            void vscode.window.showInformationMessage(summary);
-        }
-    };
+    timeBootstrapPhase('skill-scan', () => skillPanel.start());
     const todoPanel = ownResource(() => createTodoPanelCapability({
         provider,
         todoService,
@@ -591,7 +505,7 @@ async function initializeDashboard(
             projectService.getGroups(),
             getOpenWorkspaceCards(),
             todoService.getSearchItems(),
-            skillDashboardController.getRecords(),
+            skillPanel.getRecords(),
         ),
         getConfiguration: () => getAgentPivotConfiguration(),
         showInputBox: options => vscode.window.showInputBox(options),
@@ -1462,7 +1376,7 @@ async function initializeDashboard(
         watchSessionChanges: (providerId, onDidChange) => getRegisteredAiSessionProvider(providerId).service.watchSessionChanges(onDidChange),
         getGroups: () => projectService.getGroups(),
         getTodoSearchItems: () => todoService.getSearchItems(),
-        getSkillRecords: () => skillDashboardController.getRecords(),
+        getSkillRecords: () => skillPanel.getRecords(),
         getCards: getOpenWorkspaceCards,
         getRunningCardAnimation: () => getAgentPivotConfiguration()
             .get<string>('aiSessionRunningCardAnimation', 'current'),
@@ -1572,6 +1486,7 @@ async function initializeDashboard(
             ...conversationHandlers,
             ...todoPanel.handlers,
             ...projectHandlers,
+            ...skillPanel.handlers,
             'request-projects-panel': async e => {
                 if (e.version !== 1 || !Number.isSafeInteger(e.requestId) || e.requestId < 1) {
                     return;
@@ -1595,275 +1510,6 @@ async function initializeDashboard(
                 await provider.postMessage(
                     promptDashboardController.getPanelContent(e.requestId)
                 );
-            },
-            'delete-skill': async e => {
-                const dirPath = String(e.dirPath || '');
-                const record = skillDashboardController.getRecords().find(candidate => candidate.dirPath === dirPath);
-                const label = record ? record.name : dirPath;
-                const choice = await vscode.window.showWarningMessage(
-                    `Delete skill "${label}" permanently? This cannot be undone.`,
-                    { modal: true },
-                    'Delete',
-                );
-                if (choice !== 'Delete') {
-                    return;
-                }
-                const result = skillDashboardController.handleDeleteSkill(dirPath);
-                if (!result.ok) {
-                    void vscode.window.showWarningMessage(`Could not delete the skill: ${result.error}`);
-                }
-            },
-            'apply-skill-collection': e => {
-                const result = skillDashboardController.handleApplyCollectionSuggestion(String(e.name || ''));
-                if (!result.ok) {
-                    void vscode.window.showWarningMessage(`Could not create the skill folder: ${result.error}`);
-                }
-            },
-            'dismiss-skill-collection': async e => {
-                await skillDashboardController.handleDismissCollectionSuggestion(String(e.name || ''));
-            },
-            'sync-skill': e => {
-                const result = skillDashboardController.handleSyncSkill(String(e.sourceDir || ''), String(e.targetDir || ''));
-                if (!result.ok) {
-                    void vscode.window.showWarningMessage(`Could not sync the skill: ${result.error}`);
-                }
-            },
-            'copy-skill': e => {
-                const result = skillDashboardController.handleCopySkill(String(e.sourceDir || ''), String(e.targetRoot || ''));
-                if (!result.ok) {
-                    void vscode.window.showWarningMessage(`Could not copy the skill: ${result.error}`);
-                }
-            },
-            'skill-scope-action': async e => {
-                const keys = Object.keys(e).sort().join(',');
-                if (keys !== 'dirPath,operation,requestId,type,version'
-                    || e.version !== 1
-                    || typeof e.requestId !== 'string'
-                    || e.requestId.length < 1
-                    || e.requestId.length > 128
-                    || typeof e.dirPath !== 'string'
-                    || e.dirPath.length < 1
-                    || e.dirPath.length > 4096
-                    || (e.operation !== 'apply-to-project' && e.operation !== 'move-to-global')
-                    || completedSkillScopeActionRequests.has(e.requestId)) {
-                    return;
-                }
-                completedSkillScopeActionRequests.add(e.requestId);
-                if (completedSkillScopeActionRequests.size > 256) {
-                    completedSkillScopeActionRequests.delete(completedSkillScopeActionRequests.values().next().value as string);
-                }
-                const settlement = {
-                    version: 1 as const,
-                    requestId: e.requestId,
-                    dirPath: e.dirPath,
-                    operation: e.operation as 'apply-to-project' | 'move-to-global',
-                    ok: false,
-                    code: 'cancelled',
-                    resultDirPath: undefined as string | undefined,
-                };
-                try {
-                    const record = skillDashboardController.getRecords().find(candidate =>
-                        candidate.central && candidate.dirPath === e.dirPath);
-                if (!record || (e.operation === 'apply-to-project' && record.scope !== 'user')
-                    || (e.operation === 'move-to-global' && record.scope !== 'project')) {
-                    settlement.code = 'invalid';
-                    await publishSkillScopeActionSettlement(settlement);
-                    return;
-                }
-                if (e.operation === 'apply-to-project') {
-                    const agents = ['kimi', 'claude', 'codex'] as const;
-                    const current = new Set(agents.filter(agent => Boolean(record.central?.links.project?.[agent])));
-                    const defaults = current.size
-                        ? current
-                        : new Set(agents.filter(agent => Boolean(record.central?.links.user?.[agent])));
-                    const items: Array<vscode.QuickPickItem & { agent: typeof agents[number] }> = agents.map(agent => ({
-                        label: agent === 'kimi' ? 'Kimi' : agent === 'claude' ? 'Claude' : 'Codex',
-                        description: current.has(agent) ? 'Currently available in this project' : undefined,
-                        picked: defaults.has(agent),
-                        agent,
-                    }));
-                    const selected = await vscode.window.showQuickPick(items, {
-                        canPickMany: true,
-                        placeHolder: current.size
-                            ? `Use "${record.name}": choose project agents; clear all to remove project access`
-                            : `Use "${record.name}": choose the agents that should use this global skill`,
-                    });
-                    if (selected === undefined) {
-                        await publishSkillScopeActionSettlement(settlement);
-                        return;
-                    }
-                    if (!current.size && !selected.length) {
-                        settlement.code = 'invalid';
-                        void vscode.window.showInformationMessage('Choose at least one project agent.');
-                        await publishSkillScopeActionSettlement(settlement);
-                        return;
-                    }
-                    const result = skillDashboardController.handleSetGlobalSkillProjectAgents(
-                        e.dirPath, selected.map(item => item.agent));
-                    settlement.ok = result.ok;
-                    settlement.code = result.ok ? 'applied' : (result.code || 'failed');
-                    settlement.resultDirPath = result.dirPath;
-                    if (!result.ok) {
-                        void vscode.window.showWarningMessage(`Could not apply the skill to this project: ${result.error}`);
-                    }
-                    await publishSkillScopeActionSettlement(settlement);
-                    return;
-                }
-
-                const existingGlobal = skillDashboardController.getRecords().find(candidate =>
-                    candidate.central && candidate.scope === 'user' && candidate.name === record.name);
-                if (existingGlobal && !skillDirectoriesEqual(record.dirPath, existingGlobal.dirPath)) {
-                    settlement.code = 'conflict';
-                    void vscode.window.showWarningMessage(
-                        `A different global skill named "${record.name}" already exists. Rename or reconcile it first.`);
-                    await publishSkillScopeActionSettlement(settlement);
-                    return;
-                }
-                const choice = await vscode.window.showWarningMessage(
-                    existingGlobal
-                        ? `Consolidate project skill "${record.name}" into the identical Global skill? `
-                            + 'The project source directory will be removed and its existing project links will be preserved.'
-                        : `Move project skill "${record.name}" to Global management? `
-                            + 'Its source directory will leave this project (and may appear deleted in Git), '
-                            + 'while its existing project links keep working. It will not be enabled globally.',
-                    { modal: true },
-                    existingGlobal ? 'Consolidate into Global' : 'Move to Global',
-                );
-                if (choice !== (existingGlobal ? 'Consolidate into Global' : 'Move to Global')) {
-                    await publishSkillScopeActionSettlement(settlement);
-                    return;
-                }
-                const result = skillDashboardController.handleMoveProjectSkillToGlobal(e.dirPath);
-                settlement.ok = result.ok;
-                settlement.code = result.ok ? 'moved' : (result.code || 'failed');
-                settlement.resultDirPath = result.dirPath;
-                if (!result.ok) {
-                    void vscode.window.showWarningMessage(`Could not move the skill to Global: ${result.error}`);
-                }
-                await publishSkillScopeActionSettlement(settlement);
-                } catch (error) {
-                    settlement.ok = false;
-                    settlement.code = 'failed';
-                    logError('Skill scope action failed unexpectedly.', error);
-                    await publishSkillScopeActionSettlement(settlement);
-                }
-            },
-            'central-toggle-skill': e => {
-                const result = skillDashboardController.handleCentralToggle(
-                    String(e.dirPath || ''),
-                    (e.scope === 'project' ? 'project' : 'user') as never,
-                    String(e.source || '') as never,
-                    e.enabled === true,
-                );
-                if (!result.ok) {
-                    void vscode.window.showWarningMessage(`Could not toggle the skill link: ${result.error}`);
-                }
-            },
-            'folder-toggle-skill-links': e => {
-                const result = skillDashboardController.handleFolderToggle(
-                    String(e.storeRoot || ''), String(e.folder || ''),
-                    (e.scope === 'project' ? 'project' : 'user') as never,
-                    String(e.agent || '') as never,
-                    e.enabled === true,
-                );
-                if (!result.ok) {
-                    void vscode.window.showWarningMessage(
-                        `Some folder links failed: ${result.errors.map(item => item.name).join(', ')}`);
-                }
-            },
-            'move-skill-to-folder': e => {
-                const result = skillDashboardController.handleMoveToFolder(String(e.dirPath || ''), String(e.folder || ''));
-                if (!result.ok) {
-                    void vscode.window.showWarningMessage(`Could not move the skill: ${result.error}`);
-                }
-            },
-            'create-skill-folder': async e => {
-                const parentFolder = String(e.parentFolder || '').replace(/^\/+|\/+$/g, '');
-                const folder = await vscode.window.showInputBox({
-                    prompt: parentFolder
-                        ? `New subfolder inside ${parentFolder} (use / for deeper nesting)`
-                        : 'New skill folder (use / for nesting, e.g. xiaohongshu/yunxiao)',
-                    placeHolder: 'folder or folder/subfolder',
-                });
-                if (!folder || !folder.trim()) {
-                    return;
-                }
-                const target = parentFolder ? `${parentFolder}/${folder.trim()}` : folder.trim();
-                const result = skillDashboardController.handleCreateFolder(
-                    e.scope === 'project' ? 'project' : 'user',
-                    target,
-                );
-                if (!result.ok) {
-                    void vscode.window.showWarningMessage(`Could not create the folder: ${result.error}`);
-                }
-            },
-            'remove-skill-folder': async e => {
-                const folderName = String(e.folder || '');
-                const choice = await vscode.window.showWarningMessage(
-                    `Delete the folder "${folderName}"? Only empty folders can be deleted.`,
-                    { modal: true },
-                    'Delete',
-                );
-                if (choice !== 'Delete') {
-                    return;
-                }
-                const result = skillDashboardController.handleRemoveFolder(String(e.storeRoot || ''), folderName);
-                if (!result.ok) {
-                    void vscode.window.showWarningMessage(`Could not delete the folder: ${result.error}`);
-                }
-            },
-            'centralize-skill': async e => {
-                const dirPath = String(e.dirPath || '');
-                const record = skillDashboardController.getRecords()
-                    .find(candidate => candidate.dirPath === dirPath && !candidate.central);
-                if (record) {
-                    // Centralize permanently deletes the losing duplicate copies;
-                    // confirm first, naming them and flagging content drift.
-                    const duplicates = skillDashboardController.getRecords().filter(candidate =>
-                        candidate.scope === record.scope && candidate.name === record.name
-                        && candidate.dirPath !== record.dirPath && !candidate.central
-                        && (candidate.source === 'kimi' || candidate.source === 'claude' || candidate.source === 'codex'));
-                    if (duplicates.length) {
-                        const drifted = new Set([record.contentHash || '', ...duplicates.map(copy => copy.contentHash || '')]).size > 1;
-                        const choice = await vscode.window.showWarningMessage(
-                            `Centralize "${record.name}" into the ${record.scope} store? `
-                            + `The other ${duplicates.length} ${record.scope} ${duplicates.length === 1 ? 'copy' : 'copies'} will be deleted permanently:\n`
-                            + duplicates.map(copy => copy.dirPath).join('\n')
-                            + (drifted ? '\nWarning: the copies have different content; only the clicked copy is kept.' : ''),
-                            { modal: true },
-                            'Centralize',
-                        );
-                        if (choice !== 'Centralize') {
-                            return;
-                        }
-                    }
-                }
-                const result = skillDashboardController.handleCentralize(dirPath);
-                if (!result.ok) {
-                    void vscode.window.showWarningMessage(`Could not centralize the skill: ${result.error}`);
-                }
-            },
-            'migrate-skills-to-central': e => {
-                void runSkillMigrationToCentral(e.scope === 'project' ? 'project' : e.scope === 'user' ? 'user' : undefined);
-            },
-            'change-global-skills-location': () => {
-                void globalStoreLocationController.changeInteractively();
-            },
-            'fix-skill-diagnostic': e => {
-                const result = skillDashboardController.handleFixSkillDiagnostic(
-                    String(e.dirPath || ''),
-                    String(e.code || '') as never,
-                );
-                if (!result.ok) {
-                    void vscode.window.showWarningMessage(`Could not fix the skill: ${result.error}`);
-                }
-            },
-            'open-skill-file': async e => {
-                const skillFilePath = String(e.skillFilePath || '');
-                if (!skillDashboardController.getRecords().some(record => record.skillFilePath === skillFilePath)) {
-                    return;
-                }
-                await vscode.window.showTextDocument(vscode.Uri.file(skillFilePath));
             },
             'prompt-command': async e => {
                 const result = await promptDashboardController.handle(e);
@@ -2094,7 +1740,7 @@ async function initializeDashboard(
         getCurrentWorkspaceAiSessions: workspace => workspaceSessionHydrationController.hydrate(workspace),
         getGroups: () => projectService.getGroups(),
         getTodoSearchItems: () => todoService.getSearchItems(),
-        getSkillRecords: () => skillDashboardController.getRecords(),
+        getSkillRecords: () => skillPanel.getRecords(),
         getCollapsed: () => Boolean(groupCollapseController.getOpenWorkspacesCollapsed()),
         getRunningCardAnimation: () => getAgentPivotConfiguration()
             .get<string>('aiSessionRunningCardAnimation', 'current'),
@@ -2251,7 +1897,7 @@ async function initializeDashboard(
         get favoritesGroupCollapsed() { return groupCollapseController.getFavoritesCollapsed() },
         get openWorkspacesGroupCollapsed() { return groupCollapseController.getOpenWorkspacesCollapsed() },
         get todoSearchItems() { return todoService.getSearchItems() },
-        get skills() { return skillDashboardController.getRecords() },
+        get skills() { return skillPanel.getRecords() },
     };
     projectsPanelController = new ProjectsPanelController({
         getGroups: () => projectService.getGroups(),
@@ -2259,7 +1905,7 @@ async function initializeDashboard(
             projectService.getGroups(),
             getOpenWorkspaceCards(),
             todoService.getSearchItems(),
-            skillDashboardController.getRecords(),
+            skillPanel.getRecords(),
         ),
         renderHtml: groups => getProjectsPanelContent(groups, stewardInfos),
         postMessage: message => provider.postMessage(message),
@@ -2304,7 +1950,7 @@ async function initializeDashboard(
             if (event.affectsConfiguration(
                 `${AGENT_PIVOT_CONFIG_SECTION}.skills.globalStorePath`,
             )) {
-                await globalStoreLocationController.handleConfigurationChange();
+                await skillPanel.handleGlobalStoreConfigurationChange();
             }
             if (event.affectsConfiguration(`${AGENT_PIVOT_CONFIG_SECTION}.aiSessionTerminalMode`)
                 || event.affectsConfiguration(`${AGENT_PIVOT_CONFIG_SECTION}.aiSessionTmuxLayout`)
@@ -2374,9 +2020,9 @@ async function initializeDashboard(
         addProjectsFromFolder: () => addProjectsFromFolderController.addProjectsFromFolder(),
         addFileToActiveTerminal: () => activeTerminalFileReferenceController.addFileToActiveTerminal(),
         insertPromptToActiveTerminal: () => promptTerminalCommandController.insertPromptToActiveTerminal(),
-        migrateSkillsToCentral: () => runSkillMigrationToCentral(),
+        migrateSkillsToCentral: () => skillPanel.migrateToCentral(),
         changeGlobalSkillsLocation: () =>
-            globalStoreLocationController.changeInteractively(),
+            skillPanel.changeGlobalStoreLocation(),
         openCurrentAiSessionConversation: () => openCurrentAiSessionConversation(),
     };
 

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -20,8 +20,8 @@ import {
 
 import ColorService from './services/colorService';
 import ProjectService from './services/projectService';
-import { TodoCommandController } from './todos/commandController';
 import { TodoService } from './todos/service';
+import { createTodoPanelCapability } from './todos/todoPanelCapability';
 import { PromptDashboardController } from './prompts/dashboardController';
 import { initializePromptMementoStore, PromptService } from './prompts/service';
 import { PromptTerminalCommandController } from './prompts/terminalCommandController';
@@ -30,16 +30,6 @@ import { SkillDashboardController } from './skills/dashboardController';
 import { GlobalStoreLocationController } from './skills/globalStoreLocationController';
 import { skillDirectoriesEqual } from './skills/scopeService';
 import { SkillGroupStore } from './skills/skillGroupStore';
-import {
-    deleteTodoWithConfirmation,
-    renameTodoGroupWithPrompt,
-    runTodoMutation,
-    runTodoPromptMutation,
-    runTodoRequestMutation,
-} from './todos/hostMutation';
-import { UnsupportedTodoDataVersionError } from './todos/types';
-import { buildTodoPanelSnapshot, buildTodoViewModel } from './todos/viewModel';
-import { getTodoPanelContent, getUnsupportedTodoVersionPanelContent } from './todos/webviewContent';
 import FileService from './services/fileService';
 import CodexSessionService from './services/codexSessionService';
 import { ProcCodexRootThreadObserver } from './aiSessions/codexRootThreadObserver';
@@ -596,20 +586,22 @@ async function initializeDashboard(
             void vscode.window.showInformationMessage(summary);
         }
     };
-    const todoViewState = todoService.getViewState();
-    let revealedTodoId: string | undefined;
-    const todoCommandController = new TodoCommandController({
-        service: todoService,
-        getViewState: () => todoViewState,
-        setShowCompleted: async showCompleted => {
-            const persistedViewState = await todoService.setShowCompleted(showCompleted);
-            todoViewState.showCompleted = persistedViewState.showCompleted;
-            return persistedViewState;
-        },
-        getRevealedTodoId: () => revealedTodoId,
-        clearRevealedTodoId: () => { revealedTodoId = undefined; },
-    });
-    const todoStorageMigration = { ready: Promise.resolve<unknown>(undefined) };
+    const todoPanel = ownResource(() => createTodoPanelCapability({
+        provider,
+        todoService,
+        getSearchCatalog: () => buildWorkspaceDashboardSearchCatalog(
+            projectService.getGroups(),
+            getOpenWorkspaceCards(),
+            todoService.getSearchItems(),
+            skillDashboardController.getRecords(),
+        ),
+        getConfiguration: () => getAgentPivotConfiguration(),
+        showInputBox: options => vscode.window.showInputBox(options),
+        showWarningMessage: (message, messageOptions, ...items) =>
+            vscode.window.showWarningMessage(message, messageOptions, ...items),
+        showErrorMessage: message => vscode.window.showErrorMessage(message),
+        logError,
+    }));
     const groupCollapseController = new GroupCollapseController({
         state: context.globalState,
         projectService,
@@ -1662,6 +1654,7 @@ async function initializeDashboard(
         saveCurrentWorkspace: () => savedWorkspaceProjectAdapter.saveCurrentWorkspace(),
         handlers: {
             ...conversationHandlers,
+            ...todoPanel.handlers,
             'request-projects-panel': async e => {
                 if (e.version !== 1 || !Number.isSafeInteger(e.requestId) || e.requestId < 1) {
                     return;
@@ -1672,12 +1665,6 @@ async function initializeDashboard(
                     requestId: e.requestId,
                     html: getProjectsPanelContent(projectService.getGroups(), stewardInfos),
                 });
-            },
-            'request-todo-panel': async e => {
-                if (e.version !== 1 || !Number.isSafeInteger(e.requestId) || e.requestId < 1) {
-                    return;
-                }
-                await postTodoPanelContent(e.requestId as number);
             },
             'request-ai-panel': async e => {
                 if (Object.keys(e).length !== 4
@@ -1972,167 +1959,6 @@ async function initializeDashboard(
                 if (result !== undefined) {
                     await provider.postMessage(result);
                 }
-            },
-            'todo-command': async e => {
-                await todoStorageMigration.ready;
-                const result = await todoCommandController.handle(e);
-                if (result) {
-                    await provider.postMessage({
-                        ...result,
-                        searchCatalog: buildWorkspaceDashboardSearchCatalog(
-                            projectService.getGroups(),
-                            getOpenWorkspaceCards(),
-                            todoService.getSearchItems(),
-                            skillDashboardController.getRecords(),
-                        ),
-                    });
-                }
-            },
-            'todo-add': async e => {
-                const valid = typeof e.title === 'string' && Boolean(e.title.trim());
-                await runTodoRequestMutation({
-                    requestId: e.requestId,
-                    valid,
-                    mutate: () => todoService.addTodo({
-                        title: e.title as string,
-                        notes: typeof e.notes === 'string' ? e.notes : '',
-                        priority: e.priority === 'high' || e.priority === 'medium' || e.priority === 'low' ? e.priority : 'medium',
-                        groupId: typeof e.groupId === 'string' ? e.groupId : undefined,
-                    }),
-                    onSuccess: () => postTodoPanelContent(),
-                    postResult: message => provider.postMessage(message),
-                    showErrorMessage: message => vscode.window.showErrorMessage(message),
-                    logError,
-                });
-            },
-            'todo-add-group': async () => {
-                await runTodoPromptMutation({
-                    prompt: value => vscode.window.showInputBox({
-                        prompt: 'Todo group title',
-                        placeHolder: 'Group name',
-                        value,
-                        ignoreFocusOut: true,
-                    }),
-                    mutate: title => todoService.addGroup(title),
-                    refreshPanel: () => postTodoPanelContent(),
-                    showErrorMessage: message => vscode.window.showErrorMessage(message),
-                    logError,
-                });
-            },
-            'todo-toggle': async e => {
-                if (typeof e.todoId !== 'string') {
-                    return;
-                }
-                await runTodoPanelMutation(() => todoService.completeTodo(e.todoId as string, e.completed === true));
-            },
-            'todo-delete': async e => {
-                if (typeof e.todoId !== 'string') {
-                    return;
-                }
-                await deleteTodoWithConfirmation({
-                    todoId: e.todoId,
-                    getData: () => todoService.getData(),
-                    confirm: title => vscode.window.showWarningMessage(
-                        `Delete TODO "${title}"?`,
-                        { modal: true },
-                        'Delete'
-                    ),
-                    deleteTodo: todoId => todoService.deleteTodo(todoId),
-                    refreshPanel: () => postTodoPanelContent(),
-                    showErrorMessage: message => vscode.window.showErrorMessage(message),
-                    logError,
-                });
-            },
-            'todo-delete-group': async e => {
-                if (typeof e.groupId !== 'string') {
-                    return;
-                }
-                const todoGroup = todoService.getData().groups.find(group => group.id === e.groupId);
-                if (!todoGroup) {
-                    return;
-                }
-                const confirmed = await vscode.window.showWarningMessage(
-                    `Delete TODO group "${todoGroup.title}" and all of its todos?`,
-                    { modal: true },
-                    'Delete'
-                );
-                if (confirmed !== 'Delete') {
-                    return;
-                }
-                await runTodoPanelMutation(() => todoService.deleteGroup(e.groupId as string));
-            },
-            'todo-rename-group': async e => {
-                if (typeof e.groupId !== 'string') {
-                    return;
-                }
-                await renameTodoGroupWithPrompt({
-                    groupId: e.groupId,
-                    getData: () => todoService.getData(),
-                    prompt: value => vscode.window.showInputBox({
-                        prompt: 'Todo group title',
-                        value,
-                        ignoreFocusOut: true,
-                    }),
-                    renameGroup: (groupId, title) => todoService.renameGroup(groupId, title),
-                    refreshPanel: () => postTodoPanelContent(),
-                    showErrorMessage: message => vscode.window.showErrorMessage(message),
-                    logError,
-                });
-            },
-            'todo-reorder-groups': async e => {
-                if (!Array.isArray(e.groupIds)) {
-                    return;
-                }
-                await runTodoPanelMutation(() => todoService.reorderGroups(e.groupIds as string[]));
-            },
-            'todo-reorder-items': async e => {
-                if (typeof e.groupId !== 'string' || !Array.isArray(e.todoIds)) {
-                    return;
-                }
-                await runTodoPanelMutation(() => todoService.reorderTodos(e.groupId as string, e.todoIds as string[]));
-            },
-            'todo-collapse-group': async e => {
-                if (typeof e.groupId !== 'string') {
-                    return;
-                }
-                await runTodoPanelMutation(() => todoService.setGroupCollapsed(e.groupId as string, e.collapsed === true));
-            },
-            'todo-collapse-groups': async e => {
-                await runTodoPanelMutation(() => todoService.setGroupsCollapsed(e.collapsed === true));
-            },
-            'todo-sort-priority': async e => {
-                if (typeof e.groupId !== 'string') {
-                    return;
-                }
-                await runTodoPanelMutation(() => todoService.sortGroupByPriority(e.groupId as string));
-            },
-            'todo-toggle-show-completed': async e => {
-                await runTodoPanelMutation(async () => {
-                    const persistedViewState = await todoService.setShowCompleted(e.showCompleted === true);
-                    todoViewState.showCompleted = persistedViewState.showCompleted;
-                    revealedTodoId = undefined;
-                });
-            },
-            'todo-reveal': async e => {
-                if (typeof e.todoId !== 'string' || typeof e.groupId !== 'string') {
-                    return;
-                }
-                await runTodoPanelMutation(async () => {
-                    const result = await todoService.revealTodo(e.todoId as string, e.groupId as string);
-                    if (result.revealed) {
-                        revealedTodoId = e.todoId as string;
-                    }
-                });
-            },
-            'todo-update': async e => {
-                if (typeof e.todoId !== 'string' || typeof e.title !== 'string') {
-                    return;
-                }
-                await runTodoPanelMutation(() => todoService.updateTodo(e.todoId as string, {
-                    title: e.title as string,
-                    notes: typeof e.notes === 'string' ? e.notes : '',
-                    priority: e.priority === 'high' || e.priority === 'medium' || e.priority === 'low' ? e.priority : 'medium',
-                }));
             },
             'selected-project': async e => {
                 let projectId = e.projectId as string;
@@ -2612,7 +2438,7 @@ async function initializeDashboard(
         migrateDataIfNeeded: async () => {
             const projectMigration = settleMigration(() => projectService.migrateDataIfNeeded());
             const todoMigration = settleMigration(() => todoService.migrateDataIfNeeded());
-            todoStorageMigration.ready = todoMigration.then(() => undefined, () => undefined);
+            todoPanel.setStorageMigrationReady(todoMigration.then(() => undefined, () => undefined));
             const [projects, todos] = await Promise.all([projectMigration, todoMigration]);
             return { projects, todos };
         },
@@ -3127,74 +2953,6 @@ async function initializeDashboard(
     function postActiveAiSessionTerminalChanged(identity: ActiveAiSessionTerminalIdentity | null) {
         void conversationCapability.reconcile();
         dashboardRuntimeController.postActiveAiSessionTerminalChanged(identity);
-    }
-
-    async function postTodoPanelContent(requestId?: number) {
-        let html: string;
-        let snapshot: ReturnType<typeof buildTodoPanelSnapshot> | undefined;
-        try {
-            await todoStorageMigration.ready;
-            const unsupportedVersionError = todoService.getUnsupportedVersionError();
-            if (unsupportedVersionError) {
-                throw unsupportedVersionError;
-            }
-            const todoData = todoService.getData();
-            const config = getAgentPivotConfiguration();
-            const todoRenderOptions = {
-                maxVisibleTodosPerGroup: getMaxVisibleTodosPerGroup(config),
-            };
-            snapshot = buildTodoPanelSnapshot(todoData, todoViewState, revealedTodoId);
-            html = getTodoPanelContent(
-                buildTodoViewModel(todoData, todoViewState, revealedTodoId),
-                todoRenderOptions,
-            );
-        } catch (error) {
-            if (!(error instanceof UnsupportedTodoDataVersionError)) {
-                throw error;
-            }
-            html = getUnsupportedTodoVersionPanelContent(error.version);
-        }
-        await provider.postMessage(requestId
-            ? {
-                type: 'todo-panel-content',
-                version: 1,
-                requestId,
-                html,
-                ...(snapshot ? { snapshot } : {}),
-                searchCatalog: buildWorkspaceDashboardSearchCatalog(
-                    projectService.getGroups(),
-                    getOpenWorkspaceCards(),
-                    todoService.getSearchItems(),
-                    skillDashboardController.getRecords(),
-                ),
-            }
-            : {
-                type: 'todo-panel-updated',
-                version: 1,
-                html,
-                ...(snapshot ? { snapshot } : {}),
-                searchCatalog: buildWorkspaceDashboardSearchCatalog(
-                    projectService.getGroups(),
-                    getOpenWorkspaceCards(),
-                    todoService.getSearchItems(),
-                    skillDashboardController.getRecords(),
-                ),
-            });
-    }
-
-    function getMaxVisibleTodosPerGroup(config: vscode.WorkspaceConfiguration): number {
-        const configuredItems = config.get('maxVisibleTodosPerGroup', 5);
-        const visibleItems = Math.floor(Number(configuredItems));
-        return Number.isFinite(visibleItems) && visibleItems > 0 ? visibleItems : 5;
-    }
-
-    async function runTodoPanelMutation(mutate: () => Promise<unknown>): Promise<boolean> {
-        return runTodoMutation({
-            mutate,
-            onSuccess: () => postTodoPanelContent(),
-            showErrorMessage: message => vscode.window.showErrorMessage(message),
-            logError,
-        });
     }
 
     function invalidateAiSessionCache(providerId: AiSessionProviderId) {

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -49,7 +49,7 @@ import {
 import AiSessionWorkspaceStateStore from './aiSessions/workspaceStateStore';
 import ActiveAiSessionTerminalHighlighter from './aiSessions/activeTerminalHighlight';
 import AttentionBridgeClient from './aiSessions/attentionBridgeClient';
-import { getAttentionRuntimeSessionKey, getLogicalAttentionSessionKey } from './aiSessions/attentionProject';
+import { getLogicalAttentionSessionKey } from './aiSessions/attentionProject';
 import type { ActiveAiSessionTerminalIdentity } from './aiSessions/activeTerminalHighlight';
 import { getAiSessionKey } from './aiSessions/sessionHelpers';
 import {
@@ -107,14 +107,12 @@ import { AiSessionTerminalCommandController } from './aiSessions/terminalCommand
 import { AiSessionExecutionController } from './aiSessions/executionController';
 import {
     AiSessionAttentionController,
-    runAiSessionRuntimeLifecycleTask,
-    settleAiSessionRuntimeLifecycles,
 } from './aiSessions/attentionController';
 import type {
     AiSessionAttentionEvaluation,
-    AiSessionRuntimeLifecycleCandidate,
 } from './aiSessions/attentionController';
 import { createAiSessionStatusCapability } from './aiSessions/statusCapability';
+import { createAiSessionRuntimeSettlementCapability } from './aiSessions/runtimeSettlementCapability';
 import { NotifyDispatcher } from './aiSessions/notify/dispatcher';
 import { createHttpsTransport } from './aiSessions/notify/httpClient';
 import { NotifiedEventStore } from './aiSessions/notify/store';
@@ -1415,124 +1413,19 @@ async function initializeDashboard(
     ): Promise<void> => {
         await acknowledgeAiSessionAttentionEventIds(getAiSessionAttentionEventIds(identity));
     };
-    type RuntimeLifecycleCandidate = AiSessionRuntimeLifecycleCandidate & {
-        runtime: AiSessionRuntimeSnapshot<vscode.Terminal>;
-    };
-    const queuedAiSessionRuntimeSettlements = new Map<string, RuntimeLifecycleCandidate>();
-    const settlingAiSessionRuntimeKeys = new Set<string>();
-    let aiSessionRuntimeSettlementInFlight: Promise<void> | null = null;
-    const runSafeAiSessionRuntimeLifecycleTask = (
-        operation: string,
-        task: () => unknown | Promise<unknown>
-    ): Promise<void> => runAiSessionRuntimeLifecycleTask(
-        operation,
-        task,
-        (failedOperation, category) => logAiSessionDiagnostic({
-            event: 'runtime-lifecycle-task-failed',
-            operation: failedOperation,
-            category,
-        })
-    );
-    const queueAiSessionRuntimeSettlements = (
-        runtimes: readonly AiSessionRuntimeSnapshot<vscode.Terminal>[]
-    ): void => {
-        for (const runtime of runtimes) {
-            if (!runtimeBelongsToCurrentWorkspace(runtime)) {
-                continue;
-            }
-            const sessionId = runtime.identity.sessionId;
-            if (!sessionId || (runtime.state !== 'completed' && runtime.state !== 'stopped')) {
-                continue;
-            }
-            const key = getAttentionRuntimeSessionKey({
-                workspaceScopeIdentity: runtime.identity.workspaceScopeIdentity,
-                provider: runtime.identity.provider,
-                sessionId,
-                runStartedAtMs: runtime.runStartedAtMs,
-                backend: runtime.backend,
-            });
-            if (settlingAiSessionRuntimeKeys.has(key)) {
-                continue;
-            }
-            queuedAiSessionRuntimeSettlements.set(key, {
-                key,
-                sessionKey: key,
-                state: runtime.state,
-                runtime: {
-                    ...runtime,
-                    identity: cloneAiSessionRuntimeIdentity(runtime.identity),
-                    ...(runtime.tmux ? { tmux: { ...runtime.tmux } } : {}),
-                },
-            });
-        }
-        if (!aiSessionRuntimeSettlementInFlight && queuedAiSessionRuntimeSettlements.size) {
-            aiSessionRuntimeSettlementInFlight = runSafeAiSessionRuntimeLifecycleTask(
-                'settle-runtime-lifecycles',
-                drainAiSessionRuntimeSettlements
-            );
-        }
-    };
-    const drainAiSessionRuntimeSettlements = async (): Promise<void> => {
-        try {
-            while (queuedAiSessionRuntimeSettlements.size) {
-                const candidates = [...queuedAiSessionRuntimeSettlements.values()]
-                    .sort((left, right) => left.key.localeCompare(right.key));
-                queuedAiSessionRuntimeSettlements.clear();
-                candidates.forEach(candidate => settlingAiSessionRuntimeKeys.add(candidate.key));
-                try {
-                    const settled = await settleAiSessionRuntimeLifecycles({
-                        candidates: candidates,
-                        evaluateAttention: () => evaluateAiSessionAttention(
-                            candidates.map(candidate => ({
-                                providerId: candidate.runtime.identity.provider,
-                                sessionId: candidate.runtime.identity.sessionId as string,
-                                attentionKey: candidate.key,
-                                runtime: candidate.runtime,
-                            }))
-                        ),
-                        release: async candidate => {
-                            if (candidate.runtime.backend === 'tmux') {
-                                const acknowledgement = await tmuxRuntimeDiscovery
-                                    .acknowledgeInactive(candidate.runtime);
-                                if (acknowledgement === 'stale') {
-                                    throw new Error('The tmux lifecycle acknowledgement became stale.');
-                                }
-                                return;
-                            }
-                            aiSessionTerminalService.releaseCompletedSession(
-                                candidate.runtime.identity.provider,
-                                candidate.runtime.identity.sessionId as string,
-                                candidate.runtime.identity.workspaceScopeIdentity
-                            );
-                        },
-                        reportFailure: (operation, category, key) => logAiSessionDiagnostic({
-                            event: 'runtime-lifecycle-settlement-failed',
-                            operation,
-                            category,
-                            hasRuntimeKey: Boolean(key),
-                        }),
-                    });
-                    if (settled.releasedKeys.length) {
-                        refreshAiSessionViewsIncrementally();
-                        activeAiSessionTerminalHighlighter.sync();
-                    }
-                } finally {
-                    candidates.forEach(candidate => settlingAiSessionRuntimeKeys.delete(candidate.key));
-                }
-            }
-        } catch (_error) {
-            logAiSessionDiagnostic({
-                event: 'runtime-lifecycle-settlement-failed',
-                operation: 'drain',
-                category: 'unexpected',
-            });
-        } finally {
-            aiSessionRuntimeSettlementInFlight = null;
-            if (queuedAiSessionRuntimeSettlements.size) {
-                queueAiSessionRuntimeSettlements([]);
-            }
-        }
-    };
+    const aiSessionRuntimeSettlement = ownResource(() => createAiSessionRuntimeSettlementCapability({
+        runtimeBelongsToCurrentWorkspace,
+        evaluateAttention: evaluateAiSessionAttention,
+        tmuxRuntimeDiscovery,
+        aiSessionTerminalService,
+        refreshAiSessionViewsIncrementally,
+        syncActiveTerminalHighlighter: () => activeAiSessionTerminalHighlighter.sync(),
+        logDiagnostic: logAiSessionDiagnostic,
+        setInterval: (callback, intervalMs) => setInterval(callback, intervalMs),
+        clearInterval: handle => clearInterval(handle as NodeJS.Timeout),
+    }));
+    const runSafeAiSessionRuntimeLifecycleTask = aiSessionRuntimeSettlement.runSafeLifecycleTask;
+    const queueAiSessionRuntimeSettlements = aiSessionRuntimeSettlement.queueSettlements;
     aiSessionAttentionBridgeClient = ownResource(() => new AttentionBridgeClient(
         aggregate => {
             if (aiSessionAttentionController.setRemoteAggregate(aggregate)) {
@@ -2301,25 +2194,7 @@ async function initializeDashboard(
     }));
     tmuxFocusedRuntimeMonitor.start();
     publishRestoredTmuxAttachTerminal = refreshAiSessionViewsIncrementally;
-    ownTimer(
-        () => setInterval(() => {
-            const completedSessions = aiSessionTerminalService.getCompletedSessions();
-            const completedRuntimes = completedSessions.filter(resolution =>
-                !!resolution.entry.runtimeIdentity).map(resolution => ({
-                    identity: cloneAiSessionRuntimeIdentity(resolution.entry.runtimeIdentity),
-                    backend: 'vscode',
-                    state: 'completed',
-                    markerPath: resolution.entry.markerPath,
-                    runStartedAtMs: resolution.entry.runStartedAtMs,
-                    attached: true,
-                    terminal: resolution.terminal,
-                } as AiSessionRuntimeSnapshot<vscode.Terminal>));
-            const inactiveTmuxRuntimes = tmuxRuntimeDiscovery.getInactive()
-                .map(runtime => runtime as AiSessionRuntimeSnapshot<vscode.Terminal>);
-            queueAiSessionRuntimeSettlements([...completedRuntimes, ...inactiveTmuxRuntimes]);
-        }, 1_000),
-        handle => clearInterval(handle),
-    );
+    aiSessionRuntimeSettlement.startSettlementScan();
 
     ownResource(() =>
         vscode.window.onDidChangeActiveTerminal(() => {

--- a/src/projects/projectMessageHandlers.ts
+++ b/src/projects/projectMessageHandlers.ts
@@ -1,0 +1,182 @@
+'use strict';
+
+import type { AttentionAggregate } from '../aiSessions/attentionAggregate';
+import { withAttentionProject } from '../aiSessions/attentionProject';
+import type { GroupCollapseController } from '../dashboard/groupCollapseController';
+import type { DashboardMessageHandler } from '../dashboard/messageRouter';
+import type { ProjectsPanelController } from '../dashboard/projectsPanelController';
+import type { ProjectsPanelUpdateMode } from '../dashboard/webviewUpdateMessages';
+import type { GroupOrder, Project, ProjectOpenType } from '../models';
+import type { OpenWorkspaceDashboardController } from '../openWorkspaces/dashboardController';
+import type { WorkspaceNavigationController } from '../openWorkspaces/navigationController';
+import type { OpenWorkspacePinController } from '../openWorkspaces/pinController';
+import type ProjectService from '../services/projectService';
+import type { FavoriteProjectController } from './favoriteProjectController';
+import type { GroupCommandController } from './groupCommandController';
+import type { ProjectMutationController } from './projectMutationController';
+import type { ProjectOpenController } from './projectOpenController';
+import type { ProjectOrderController } from './projectOrderController';
+import type { ProjectRemovalController } from './projectRemovalController';
+
+export interface ProjectSurfaceRefreshOptions {
+    getProjectsPanelController: () => ProjectsPanelController | undefined;
+    getOpenWorkspaceDashboardController: () => OpenWorkspaceDashboardController;
+    publishOpenWorkspace: () => void;
+    syncProjectColorToCurrentWindow: (project: Project | null) => void;
+}
+
+export interface ProjectSurfaceRefresh {
+    postProjectSurfacesUpdated: (mode: ProjectsPanelUpdateMode) => void;
+    refreshAfterMutation: (mode?: ProjectsPanelUpdateMode) => void;
+    applyProjectColorToCurrentWindow: (project?: Project | null) => void;
+}
+
+/**
+ * Owns the partial Projects/OPEN surface refresh shared by every saved-project
+ * mutation: the panel posts, the window colour sync, and the workspace
+ * republish -- never a full Dashboard rebuild.
+ *
+ * Extracted from `initializeDashboard` in src/dashboard.ts. The accessors are
+ * late-bound on purpose: the panels and controllers they read are constructed
+ * after the project controllers that consume `refreshAfterMutation`, so the
+ * refresh must resolve them at call time, exactly like the hoisted function
+ * declarations it replaces.
+ */
+export function createProjectSurfaceRefresh(
+    options: ProjectSurfaceRefreshOptions
+): ProjectSurfaceRefresh {
+    function postProjectSurfacesUpdated(mode: ProjectsPanelUpdateMode): void {
+        options.getProjectsPanelController()?.postUpdated(mode);
+        options.getOpenWorkspaceDashboardController().postUpdated();
+    }
+
+    function applyProjectColorToCurrentWindow(project: Project = null): void {
+        options.syncProjectColorToCurrentWindow(project);
+    }
+
+    function refreshAfterMutation(mode: ProjectsPanelUpdateMode = 'replace'): void {
+        postProjectSurfacesUpdated(mode);
+        applyProjectColorToCurrentWindow();
+        options.publishOpenWorkspace();
+    }
+
+    return {
+        postProjectSurfacesUpdated,
+        refreshAfterMutation,
+        applyProjectColorToCurrentWindow,
+    };
+}
+
+export interface ProjectMessageHandlersOptions {
+    projectService: ProjectService;
+    projectOpenController: ProjectOpenController;
+    projectMutationController: ProjectMutationController;
+    projectOrderController: ProjectOrderController;
+    favoriteProjectController: FavoriteProjectController;
+    projectRemovalController: ProjectRemovalController;
+    groupCommandController: GroupCommandController;
+    groupCollapseController: GroupCollapseController;
+    /** Late-bound: the navigation controller is constructed after the router. */
+    getWorkspaceNavigationController: () => WorkspaceNavigationController;
+    /** Late-bound: the pin controller is constructed after the router. */
+    getOpenWorkspacePinController: () => OpenWorkspacePinController;
+    getAttentionAggregate: () => AttentionAggregate;
+    /** Owned by the AI session attention slice; injected, not extracted here. */
+    acknowledgeAiSessionAttentionEventIds: (eventIds: string[]) => Promise<void>;
+    refreshAfterMutation: (mode?: ProjectsPanelUpdateMode) => void;
+    showWarningMessage: (message: string) => unknown;
+}
+
+/**
+ * Owns the Projects/Groups slice of the dashboard message router: the
+ * `selected-project` open flow (including its attention acknowledgement) and
+ * the thin project/group mutation delegates.
+ *
+ * Extracted from `initializeDashboard` in src/dashboard.ts (see the todo panel
+ * capability for the same slice pattern). Behaviour is unchanged: the handler
+ * bodies delegate to the same controllers with the same arguments; only their
+ * ownership moved.
+ */
+export function createProjectMessageHandlers(
+    options: ProjectMessageHandlersOptions
+): Record<string, DashboardMessageHandler> {
+    const projectService = options.projectService;
+    const projectOpenController = options.projectOpenController;
+    const projectMutationController = options.projectMutationController;
+    const projectOrderController = options.projectOrderController;
+    const favoriteProjectController = options.favoriteProjectController;
+    const projectRemovalController = options.projectRemovalController;
+    const groupCommandController = options.groupCommandController;
+    const groupCollapseController = options.groupCollapseController;
+    const getWorkspaceNavigationController = options.getWorkspaceNavigationController;
+    const getOpenWorkspacePinController = options.getOpenWorkspacePinController;
+    const getAttentionAggregate = options.getAttentionAggregate;
+    const acknowledgeAiSessionAttentionEventIds = options.acknowledgeAiSessionAttentionEventIds;
+    const refreshAfterMutation = options.refreshAfterMutation;
+    const showWarningMessage = options.showWarningMessage;
+
+    return {
+        'selected-project': async e => {
+            let projectId = e.projectId as string;
+            let projectOpenType = e.projectOpenType as ProjectOpenType;
+
+            if (projectId.startsWith('__openWorkspaceNavigation-')) {
+                await getWorkspaceNavigationController().open(projectId);
+                return;
+            }
+
+            const project = projectService.getProject(projectId);
+            if (project == null) {
+                showWarningMessage("Selected Project not found.");
+                return;
+            }
+
+            const attentionProject = withAttentionProject(
+                project,
+                getAttentionAggregate()
+            );
+            await acknowledgeAiSessionAttentionEventIds(attentionProject.aiSessionAttentionEventIds);
+            await projectOpenController.openProject(project, projectOpenType);
+        },
+        'set-open-workspace-pin': e => getOpenWorkspacePinController().handle(e),
+        'add-project': async e => {
+            await projectMutationController.addProject(e.groupId as string);
+        },
+        'import-from-other-storage': async () => {
+            await projectService.copyProjectsFromFilledStorageOptionToEmptyStorageOption();
+            refreshAfterMutation();
+        },
+        'reordered-projects': async e => {
+            await projectOrderController.reorderGroups(e.groupOrders as GroupOrder[]);
+        },
+        'reordered-favorites': async e => {
+            await favoriteProjectController.reorderFavoriteProjects(Array.isArray(e.projectIds) ? e.projectIds as string[] : []);
+        },
+        'remove-project': async e => {
+            await projectRemovalController.removeProject(e.projectId as string);
+        },
+        'edit-project': async e => {
+            await projectMutationController.editProject(e.projectId as string);
+        },
+        'color-project': async e => {
+            await projectMutationController.editProjectColor(e.projectId as string);
+        },
+        'favorite-project': async e => {
+            await favoriteProjectController.toggleProjectFavorite(e.projectId as string);
+        },
+        'edit-group': async e => {
+            await groupCommandController.editGroup(e.groupId as string);
+        },
+        'remove-group': async e => {
+            await groupCommandController.removeGroup(e.groupId as string);
+        },
+        'add-group': async () => {
+            await groupCommandController.addGroup();
+        },
+        'collapse-group': async e => {
+            await groupCollapseController.collapseGroup(e.groupId as string, e.collapsed as boolean);
+        },
+        // Collapse-all is a per-webview convenience action.
+        'toggle-all-groups': () => undefined,
+    };
+}

--- a/src/skills/skillPanelCapability.ts
+++ b/src/skills/skillPanelCapability.ts
@@ -1,0 +1,490 @@
+'use strict';
+
+import type * as vscode from 'vscode';
+import type { DashboardMessageHandler } from '../dashboard/messageRouter';
+import type { SkillPanelView } from '../webview/webviewSkillContent';
+import { SkillDashboardController } from './dashboardController';
+import type { SkillDashboardControllerOptions } from './dashboardController';
+import { GlobalStoreLocationController } from './globalStoreLocationController';
+import type { GlobalStoreLocationControllerOptions } from './globalStoreLocationController';
+import { skillDirectoriesEqual } from './scopeService';
+import type { SkillGroupStore } from './skillGroupStore';
+import type { SkillRecord } from './types';
+
+export interface SkillScopeActionSettlement {
+    version: 1;
+    requestId: string;
+    dirPath: string;
+    operation: 'apply-to-project' | 'move-to-global';
+    ok: boolean;
+    code?: string;
+    resultDirPath?: string;
+}
+
+export interface SkillPanelCapabilityOptions {
+    getHomeDir: () => string;
+    getWorkspaceRoot: () => string | undefined;
+    getWorkspaceRoots: () => readonly string[];
+    hasWorkspace: () => boolean;
+    groupStore: SkillGroupStore;
+    readGlobalStorePath: () => string;
+    writeGlobalStorePath: (value: string) => PromiseLike<void>;
+    postMessage: (message: unknown) => Thenable<boolean>;
+    refreshDashboard: () => void;
+    isVisible: () => boolean;
+    showInputBox: (options: vscode.InputBoxOptions) => Thenable<string | undefined>;
+    showQuickPickMany: <T extends vscode.QuickPickItem>(
+        items: readonly T[],
+        options: vscode.QuickPickOptions
+    ) => Thenable<readonly T[] | undefined>;
+    showWarningMessage: (
+        message: string,
+        options?: vscode.MessageOptions,
+        ...items: string[]
+    ) => Thenable<string | undefined>;
+    showInformationMessage: (message: string) => Thenable<string | undefined>;
+    showErrorMessage: (message: string) => Thenable<string | undefined>;
+    openTextFile: (fsPath: string) => Thenable<unknown>;
+    logError: (message: string, error: unknown) => void;
+}
+
+export interface SkillPanelCapability {
+    /** Dashboard message handlers, spread into the dashboard message router. */
+    handlers: Record<string, DashboardMessageHandler>;
+    /** Read facade for cross-domain consumers (search catalogs, the AI panel). */
+    getRecords: () => SkillRecord[];
+    getPanelView: () => SkillPanelView;
+    /** Starts the initial skill scan; the dashboard times it as a bootstrap phase. */
+    start: () => void;
+    /** Palette command and message handler: migrate non-central skills centrally. */
+    migrateToCentral: (scope?: 'user' | 'project') => Promise<void>;
+    /** Palette command and message handler: relocate the Global skills store. */
+    changeGlobalStoreLocation: () => Promise<boolean>;
+    /** Configuration-change hook for `agentPivot.skills.globalStorePath`. */
+    handleGlobalStoreConfigurationChange: () => Promise<boolean>;
+    dispose(): void;
+}
+
+/**
+ * Owns the Skills slice of the dashboard: the Global store location
+ * controller, the skill dashboard controller, the scope-action settlement
+ * pipeline with its request dedupe, the migrate-to-central flow, and every
+ * `*-skill*` message handler.
+ *
+ * Extracted from `initializeDashboard` in src/dashboard.ts (see the todo panel
+ * capability for the same slice pattern). Behaviour is unchanged: the handler
+ * bodies, validation order, settlement fallbacks, and migration prompts are
+ * the same; only their ownership moved.
+ */
+interface SkillPanelCapabilityInternalFactories {
+    createLocationController(
+        options: GlobalStoreLocationControllerOptions
+    ): GlobalStoreLocationController;
+    createDashboardController(
+        options: SkillDashboardControllerOptions
+    ): SkillDashboardController;
+}
+
+const DEFAULT_FACTORIES: SkillPanelCapabilityInternalFactories = {
+    createLocationController: options => new GlobalStoreLocationController(options),
+    createDashboardController: options => new SkillDashboardController(options),
+};
+
+export function createSkillPanelCapability(
+    options: SkillPanelCapabilityOptions,
+    internalFactories: Partial<SkillPanelCapabilityInternalFactories> = {}
+): SkillPanelCapability {
+    const factories = { ...DEFAULT_FACTORIES, ...internalFactories };
+    const showInputBox = options.showInputBox;
+    const showQuickPickMany = options.showQuickPickMany;
+    const showWarningMessage = options.showWarningMessage;
+    const showInformationMessage = options.showInformationMessage;
+    const showErrorMessage = options.showErrorMessage;
+    const logError = options.logError;
+
+    const globalStoreLocationController = factories.createLocationController({
+        homeDir: options.getHomeDir(),
+        getWorkspaceRoots: options.getWorkspaceRoots,
+        readSetting: options.readGlobalStorePath,
+        writeSetting: options.writeGlobalStorePath,
+        showInputBox: options.showInputBox,
+        showWarningMessage: (message, messageOptions, ...items) => messageOptions
+            ? options.showWarningMessage(message, messageOptions, ...items)
+            : options.showWarningMessage(message),
+        showErrorMessage: options.showErrorMessage,
+        refresh: () => skillDashboardController.refresh(
+            'global-skills-location-changed',
+        ),
+        logError,
+    });
+    const skillDashboardController = factories.createDashboardController({
+        getHomeDir: options.getHomeDir,
+        getWorkspaceRoot: options.getWorkspaceRoot,
+        getGlobalSkillsRoot: () => globalStoreLocationController.getActiveRoot(),
+        postMessage: message => options.postMessage(message),
+        isVisible: options.isVisible,
+        logError,
+        groupStore: options.groupStore,
+    });
+    const completedSkillScopeActionRequests = new Set<string>();
+    const publishSkillScopeActionSettlement = async (settlement: SkillScopeActionSettlement): Promise<void> => {
+        let delivered = false;
+        try {
+            delivered = await skillDashboardController.refresh('skill-scope-action', settlement);
+        } catch (error) {
+            logError('Failed to publish the authoritative Skill scope update.', error);
+        }
+        if (delivered) {
+            return;
+        }
+        try {
+            options.refreshDashboard();
+        } catch (error) {
+            logError('Failed to refresh the dashboard after a Skill scope action.', error);
+        }
+        try {
+            await options.postMessage({
+                type: 'skill-scope-action-result',
+                ...settlement,
+                ok: false,
+                code: 'refresh-failed',
+            });
+        } catch (error) {
+            logError('Failed to settle the Skill scope action.', error);
+        }
+    };
+    const runSkillMigrationToCentral = async (scope?: 'user' | 'project'): Promise<void> => {
+        const hasWorkspace = options.hasWorkspace();
+        const migratable = skillDashboardController.getRecords()
+            .filter(record => !record.central
+                && (!scope || record.scope === scope)
+                && (record.source === 'kimi' || record.source === 'claude' || record.source === 'codex'));
+        if (!migratable.length) {
+            void showInformationMessage(scope
+                ? `Every ${scope === 'user' ? 'user' : 'project'} skill is already centralized.`
+                : 'Every skill is already centralized.');
+            return;
+        }
+        const userNames = new Set(migratable.filter(record => record.scope === 'user').map(record => record.name));
+        const projectNames = new Set(migratable.filter(record => record.scope === 'project').map(record => record.name));
+        const segments: string[] = [];
+        if (userNames.size) {
+            segments.push(
+                `${userNames.size} user skill(s) into `
+                + skillDashboardController.getStoreRoots().user,
+            );
+        }
+        if (hasWorkspace && projectNames.size) {
+            segments.push(`${projectNames.size} project skill(s) into this project's .skills`);
+        }
+        const choice = await showWarningMessage(
+            `Migrate ${segments.join(' and ')}? `
+            + 'The kimi > claude > codex copy wins, other copies are deleted, '
+            + 'and no agent links are created — enable agents per card afterwards.',
+            { modal: true },
+            'Migrate',
+        );
+        if (choice !== 'Migrate') {
+            return;
+        }
+        const report = skillDashboardController.handleMigrateToCentral(scope);
+        const parts = [`Migrated ${report.migrated.length} skill(s) into the central stores`];
+        if (report.drifted.length) {
+            parts.push(`${report.drifted.length} had drift (brand-priority winner)`);
+        }
+        if (report.deleted.length) {
+            parts.push(`${report.deleted.length} duplicate(s) deleted`);
+        }
+        if (report.skipped.length) {
+            parts.push(`${report.skipped.length} skipped`);
+        }
+        const summary = `${parts.join('; ')}.`;
+        if (report.errors.length) {
+            void showWarningMessage(`${summary} ${report.errors.length} failed: ${report.errors[0].error}`);
+        } else {
+            void showInformationMessage(summary);
+        }
+    };
+
+    const handlers: Record<string, DashboardMessageHandler> = {
+        'delete-skill': async e => {
+            const dirPath = String(e.dirPath || '');
+            const record = skillDashboardController.getRecords().find(candidate => candidate.dirPath === dirPath);
+            const label = record ? record.name : dirPath;
+            const choice = await showWarningMessage(
+                `Delete skill "${label}" permanently? This cannot be undone.`,
+                { modal: true },
+                'Delete',
+            );
+            if (choice !== 'Delete') {
+                return;
+            }
+            const result = skillDashboardController.handleDeleteSkill(dirPath);
+            if (!result.ok) {
+                void showWarningMessage(`Could not delete the skill: ${result.error}`);
+            }
+        },
+        'apply-skill-collection': e => {
+            const result = skillDashboardController.handleApplyCollectionSuggestion(String(e.name || ''));
+            if (!result.ok) {
+                void showWarningMessage(`Could not create the skill folder: ${result.error}`);
+            }
+        },
+        'dismiss-skill-collection': async e => {
+            await skillDashboardController.handleDismissCollectionSuggestion(String(e.name || ''));
+        },
+        'sync-skill': e => {
+            const result = skillDashboardController.handleSyncSkill(String(e.sourceDir || ''), String(e.targetDir || ''));
+            if (!result.ok) {
+                void showWarningMessage(`Could not sync the skill: ${result.error}`);
+            }
+        },
+        'copy-skill': e => {
+            const result = skillDashboardController.handleCopySkill(String(e.sourceDir || ''), String(e.targetRoot || ''));
+            if (!result.ok) {
+                void showWarningMessage(`Could not copy the skill: ${result.error}`);
+            }
+        },
+        'skill-scope-action': async e => {
+            const keys = Object.keys(e).sort().join(',');
+            if (keys !== 'dirPath,operation,requestId,type,version'
+                || e.version !== 1
+                || typeof e.requestId !== 'string'
+                || e.requestId.length < 1
+                || e.requestId.length > 128
+                || typeof e.dirPath !== 'string'
+                || e.dirPath.length < 1
+                || e.dirPath.length > 4096
+                || (e.operation !== 'apply-to-project' && e.operation !== 'move-to-global')
+                || completedSkillScopeActionRequests.has(e.requestId)) {
+                return;
+            }
+            completedSkillScopeActionRequests.add(e.requestId);
+            if (completedSkillScopeActionRequests.size > 256) {
+                completedSkillScopeActionRequests.delete(completedSkillScopeActionRequests.values().next().value as string);
+            }
+            const settlement: SkillScopeActionSettlement = {
+                version: 1 as const,
+                requestId: e.requestId,
+                dirPath: e.dirPath,
+                operation: e.operation as 'apply-to-project' | 'move-to-global',
+                ok: false,
+                code: 'cancelled',
+                resultDirPath: undefined as string | undefined,
+            };
+            try {
+                const record = skillDashboardController.getRecords().find(candidate =>
+                    candidate.central && candidate.dirPath === e.dirPath);
+                if (!record || (e.operation === 'apply-to-project' && record.scope !== 'user')
+                    || (e.operation === 'move-to-global' && record.scope !== 'project')) {
+                    settlement.code = 'invalid';
+                    await publishSkillScopeActionSettlement(settlement);
+                    return;
+                }
+                if (e.operation === 'apply-to-project') {
+                    const agents = ['kimi', 'claude', 'codex'] as const;
+                    const current = new Set(agents.filter(agent => Boolean(record.central?.links.project?.[agent])));
+                    const defaults = current.size
+                        ? current
+                        : new Set(agents.filter(agent => Boolean(record.central?.links.user?.[agent])));
+                    const items: Array<vscode.QuickPickItem & { agent: typeof agents[number] }> = agents.map(agent => ({
+                        label: agent === 'kimi' ? 'Kimi' : agent === 'claude' ? 'Claude' : 'Codex',
+                        description: current.has(agent) ? 'Currently available in this project' : undefined,
+                        picked: defaults.has(agent),
+                        agent,
+                    }));
+                    const selected = await showQuickPickMany(items, {
+                        placeHolder: current.size
+                            ? `Use "${record.name}": choose project agents; clear all to remove project access`
+                            : `Use "${record.name}": choose the agents that should use this global skill`,
+                    });
+                    if (selected === undefined) {
+                        await publishSkillScopeActionSettlement(settlement);
+                        return;
+                    }
+                    if (!current.size && !selected.length) {
+                        settlement.code = 'invalid';
+                        void showInformationMessage('Choose at least one project agent.');
+                        await publishSkillScopeActionSettlement(settlement);
+                        return;
+                    }
+                    const result = skillDashboardController.handleSetGlobalSkillProjectAgents(
+                        e.dirPath, selected.map(item => item.agent));
+                    settlement.ok = result.ok;
+                    settlement.code = result.ok ? 'applied' : (result.code || 'failed');
+                    settlement.resultDirPath = result.dirPath;
+                    if (!result.ok) {
+                        void showWarningMessage(`Could not apply the skill to this project: ${result.error}`);
+                    }
+                    await publishSkillScopeActionSettlement(settlement);
+                    return;
+                }
+
+                const existingGlobal = skillDashboardController.getRecords().find(candidate =>
+                    candidate.central && candidate.scope === 'user' && candidate.name === record.name);
+                if (existingGlobal && !skillDirectoriesEqual(record.dirPath, existingGlobal.dirPath)) {
+                    settlement.code = 'conflict';
+                    void showWarningMessage(
+                        `A different global skill named "${record.name}" already exists. Rename or reconcile it first.`);
+                    await publishSkillScopeActionSettlement(settlement);
+                    return;
+                }
+                const choice = await showWarningMessage(
+                    existingGlobal
+                        ? `Consolidate project skill "${record.name}" into the identical Global skill? `
+                            + 'The project source directory will be removed and its existing project links will be preserved.'
+                        : `Move project skill "${record.name}" to Global management? `
+                            + 'Its source directory will leave this project (and may appear deleted in Git), '
+                            + 'while its existing project links keep working. It will not be enabled globally.',
+                    { modal: true },
+                    existingGlobal ? 'Consolidate into Global' : 'Move to Global',
+                );
+                if (choice !== (existingGlobal ? 'Consolidate into Global' : 'Move to Global')) {
+                    await publishSkillScopeActionSettlement(settlement);
+                    return;
+                }
+                const result = skillDashboardController.handleMoveProjectSkillToGlobal(e.dirPath);
+                settlement.ok = result.ok;
+                settlement.code = result.ok ? 'moved' : (result.code || 'failed');
+                settlement.resultDirPath = result.dirPath;
+                if (!result.ok) {
+                    void showWarningMessage(`Could not move the skill to Global: ${result.error}`);
+                }
+                await publishSkillScopeActionSettlement(settlement);
+            } catch (error) {
+                settlement.ok = false;
+                settlement.code = 'failed';
+                logError('Skill scope action failed unexpectedly.', error);
+                await publishSkillScopeActionSettlement(settlement);
+            }
+        },
+        'central-toggle-skill': e => {
+            const result = skillDashboardController.handleCentralToggle(
+                String(e.dirPath || ''),
+                (e.scope === 'project' ? 'project' : 'user') as never,
+                String(e.source || '') as never,
+                e.enabled === true,
+            );
+            if (!result.ok) {
+                void showWarningMessage(`Could not toggle the skill link: ${result.error}`);
+            }
+        },
+        'folder-toggle-skill-links': e => {
+            const result = skillDashboardController.handleFolderToggle(
+                String(e.storeRoot || ''), String(e.folder || ''),
+                (e.scope === 'project' ? 'project' : 'user') as never,
+                String(e.agent || '') as never,
+                e.enabled === true,
+            );
+            if (!result.ok) {
+                void showWarningMessage(
+                    `Some folder links failed: ${result.errors.map(item => item.name).join(', ')}`);
+            }
+        },
+        'move-skill-to-folder': e => {
+            const result = skillDashboardController.handleMoveToFolder(String(e.dirPath || ''), String(e.folder || ''));
+            if (!result.ok) {
+                void showWarningMessage(`Could not move the skill: ${result.error}`);
+            }
+        },
+        'create-skill-folder': async e => {
+            const parentFolder = String(e.parentFolder || '').replace(/^\/+|\/+$/g, '');
+            const folder = await showInputBox({
+                prompt: parentFolder
+                    ? `New subfolder inside ${parentFolder} (use / for deeper nesting)`
+                    : 'New skill folder (use / for nesting, e.g. xiaohongshu/yunxiao)',
+                placeHolder: 'folder or folder/subfolder',
+            });
+            if (!folder || !folder.trim()) {
+                return;
+            }
+            const target = parentFolder ? `${parentFolder}/${folder.trim()}` : folder.trim();
+            const result = skillDashboardController.handleCreateFolder(
+                e.scope === 'project' ? 'project' : 'user',
+                target,
+            );
+            if (!result.ok) {
+                void showWarningMessage(`Could not create the folder: ${result.error}`);
+            }
+        },
+        'remove-skill-folder': async e => {
+            const folderName = String(e.folder || '');
+            const choice = await showWarningMessage(
+                `Delete the folder "${folderName}"? Only empty folders can be deleted.`,
+                { modal: true },
+                'Delete',
+            );
+            if (choice !== 'Delete') {
+                return;
+            }
+            const result = skillDashboardController.handleRemoveFolder(String(e.storeRoot || ''), folderName);
+            if (!result.ok) {
+                void showWarningMessage(`Could not delete the folder: ${result.error}`);
+            }
+        },
+        'centralize-skill': async e => {
+            const dirPath = String(e.dirPath || '');
+            const record = skillDashboardController.getRecords()
+                .find(candidate => candidate.dirPath === dirPath && !candidate.central);
+            if (record) {
+                // Centralize permanently deletes the losing duplicate copies;
+                // confirm first, naming them and flagging content drift.
+                const duplicates = skillDashboardController.getRecords().filter(candidate =>
+                    candidate.scope === record.scope && candidate.name === record.name
+                    && candidate.dirPath !== record.dirPath && !candidate.central
+                    && (candidate.source === 'kimi' || candidate.source === 'claude' || candidate.source === 'codex'));
+                if (duplicates.length) {
+                    const drifted = new Set([record.contentHash || '', ...duplicates.map(copy => copy.contentHash || '')]).size > 1;
+                    const choice = await showWarningMessage(
+                        `Centralize "${record.name}" into the ${record.scope} store? `
+                        + `The other ${duplicates.length} ${record.scope} ${duplicates.length === 1 ? 'copy' : 'copies'} will be deleted permanently:\n`
+                        + duplicates.map(copy => copy.dirPath).join('\n')
+                        + (drifted ? '\nWarning: the copies have different content; only the clicked copy is kept.' : ''),
+                        { modal: true },
+                        'Centralize',
+                    );
+                    if (choice !== 'Centralize') {
+                        return;
+                    }
+                }
+            }
+            const result = skillDashboardController.handleCentralize(dirPath);
+            if (!result.ok) {
+                void showWarningMessage(`Could not centralize the skill: ${result.error}`);
+            }
+        },
+        'migrate-skills-to-central': e => {
+            void runSkillMigrationToCentral(e.scope === 'project' ? 'project' : e.scope === 'user' ? 'user' : undefined);
+        },
+        'change-global-skills-location': () => {
+            void globalStoreLocationController.changeInteractively();
+        },
+        'fix-skill-diagnostic': e => {
+            const result = skillDashboardController.handleFixSkillDiagnostic(
+                String(e.dirPath || ''),
+                String(e.code || '') as never,
+            );
+            if (!result.ok) {
+                void showWarningMessage(`Could not fix the skill: ${result.error}`);
+            }
+        },
+        'open-skill-file': async e => {
+            const skillFilePath = String(e.skillFilePath || '');
+            if (!skillDashboardController.getRecords().some(record => record.skillFilePath === skillFilePath)) {
+                return;
+            }
+            await options.openTextFile(skillFilePath);
+        },
+    };
+
+    return {
+        handlers,
+        getRecords: () => skillDashboardController.getRecords(),
+        getPanelView: () => skillDashboardController.getPanelView(),
+        start: () => skillDashboardController.start(),
+        migrateToCentral: runSkillMigrationToCentral,
+        changeGlobalStoreLocation: () => globalStoreLocationController.changeInteractively(),
+        handleGlobalStoreConfigurationChange: () => globalStoreLocationController.handleConfigurationChange(),
+        dispose: () => skillDashboardController.dispose(),
+    };
+}

--- a/src/todos/todoPanelCapability.ts
+++ b/src/todos/todoPanelCapability.ts
@@ -1,0 +1,309 @@
+'use strict';
+
+import type * as vscode from 'vscode';
+import type { DashboardMessageHandler } from '../dashboard/messageRouter';
+import type { DashboardWorkspaceSearchCatalog } from '../webview/dashboardViewModel';
+import { TodoCommandController } from './commandController';
+import {
+    deleteTodoWithConfirmation,
+    renameTodoGroupWithPrompt,
+    runTodoMutation,
+    runTodoPromptMutation,
+    runTodoRequestMutation,
+} from './hostMutation';
+import type { TodoService } from './service';
+import { UnsupportedTodoDataVersionError } from './types';
+import { buildTodoPanelSnapshot, buildTodoViewModel } from './viewModel';
+import { getTodoPanelContent, getUnsupportedTodoVersionPanelContent } from './webviewContent';
+
+export interface TodoPanelCapabilityOptions {
+    provider: {
+        postMessage: (message: unknown) => Thenable<unknown>;
+    };
+    todoService: TodoService;
+    /** Builds the full workspace search catalog (projects, workspaces, todos, skills). */
+    getSearchCatalog: () => DashboardWorkspaceSearchCatalog;
+    getConfiguration: () => vscode.WorkspaceConfiguration;
+    showInputBox: (options: vscode.InputBoxOptions) => Thenable<string | undefined>;
+    showWarningMessage: (
+        message: string,
+        options: vscode.MessageOptions,
+        ...items: string[]
+    ) => Thenable<string | undefined>;
+    showErrorMessage: (message: string) => Thenable<string | undefined>;
+    logError: (message: string, error: unknown) => void;
+}
+
+export interface TodoPanelCapability {
+    /** Dashboard message handlers, spread into the dashboard message router. */
+    handlers: Record<string, DashboardMessageHandler>;
+    /** Gates the first TODO render on the in-flight storage migration. */
+    setStorageMigrationReady: (ready: Promise<unknown>) => void;
+    dispose: () => void;
+}
+
+/**
+ * Owns the TODO panel slice of the dashboard: the view state, the temporary
+ * reveal target, the versioned command controller, the storage-migration
+ * render gate, and every `todo-*`/`request-todo-panel` message handler.
+ *
+ * Extracted from `initializeDashboard` in src/dashboard.ts (see PR #65 for the
+ * capability pattern). Behavior is unchanged: the handler bodies, validation
+ * order, and posted messages are the same; only their ownership moved.
+ */
+export function createTodoPanelCapability(options: TodoPanelCapabilityOptions): TodoPanelCapability {
+    const provider = options.provider;
+    const todoService = options.todoService;
+    const getSearchCatalog = options.getSearchCatalog;
+    const getConfiguration = options.getConfiguration;
+    const showInputBox = options.showInputBox;
+    const showWarningMessage = options.showWarningMessage;
+    const showErrorMessage = options.showErrorMessage;
+    const logError = options.logError;
+
+    const todoViewState = todoService.getViewState();
+    let revealedTodoId: string | undefined;
+    const todoCommandController = new TodoCommandController({
+        service: todoService,
+        getViewState: () => todoViewState,
+        setShowCompleted: async showCompleted => {
+            const persistedViewState = await todoService.setShowCompleted(showCompleted);
+            todoViewState.showCompleted = persistedViewState.showCompleted;
+            return persistedViewState;
+        },
+        getRevealedTodoId: () => revealedTodoId,
+        clearRevealedTodoId: () => { revealedTodoId = undefined; },
+    });
+    const todoStorageMigration = { ready: Promise.resolve<unknown>(undefined) };
+
+    async function postTodoPanelContent(requestId?: number) {
+        let html: string;
+        let snapshot: ReturnType<typeof buildTodoPanelSnapshot> | undefined;
+        try {
+            await todoStorageMigration.ready;
+            const unsupportedVersionError = todoService.getUnsupportedVersionError();
+            if (unsupportedVersionError) {
+                throw unsupportedVersionError;
+            }
+            const todoData = todoService.getData();
+            const config = getConfiguration();
+            const todoRenderOptions = {
+                maxVisibleTodosPerGroup: getMaxVisibleTodosPerGroup(config),
+            };
+            snapshot = buildTodoPanelSnapshot(todoData, todoViewState, revealedTodoId);
+            html = getTodoPanelContent(
+                buildTodoViewModel(todoData, todoViewState, revealedTodoId),
+                todoRenderOptions,
+            );
+        } catch (error) {
+            if (!(error instanceof UnsupportedTodoDataVersionError)) {
+                throw error;
+            }
+            html = getUnsupportedTodoVersionPanelContent(error.version);
+        }
+        await provider.postMessage(requestId
+            ? {
+                type: 'todo-panel-content',
+                version: 1,
+                requestId,
+                html,
+                ...(snapshot ? { snapshot } : {}),
+                searchCatalog: getSearchCatalog(),
+            }
+            : {
+                type: 'todo-panel-updated',
+                version: 1,
+                html,
+                ...(snapshot ? { snapshot } : {}),
+                searchCatalog: getSearchCatalog(),
+            });
+    }
+
+    function getMaxVisibleTodosPerGroup(config: vscode.WorkspaceConfiguration): number {
+        const configuredItems = config.get('maxVisibleTodosPerGroup', 5);
+        const visibleItems = Math.floor(Number(configuredItems));
+        return Number.isFinite(visibleItems) && visibleItems > 0 ? visibleItems : 5;
+    }
+
+    async function runTodoPanelMutation(mutate: () => Promise<unknown>): Promise<boolean> {
+        return runTodoMutation({
+            mutate,
+            onSuccess: () => postTodoPanelContent(),
+            showErrorMessage: message => showErrorMessage(message),
+            logError,
+        });
+    }
+
+    const handlers: Record<string, DashboardMessageHandler> = {
+        'request-todo-panel': async e => {
+            if (e.version !== 1 || !Number.isSafeInteger(e.requestId) || e.requestId < 1) {
+                return;
+            }
+            await postTodoPanelContent(e.requestId as number);
+        },
+        'todo-command': async e => {
+            await todoStorageMigration.ready;
+            const result = await todoCommandController.handle(e);
+            if (result) {
+                await provider.postMessage({
+                    ...result,
+                    searchCatalog: getSearchCatalog(),
+                });
+            }
+        },
+        'todo-add': async e => {
+            const valid = typeof e.title === 'string' && Boolean(e.title.trim());
+            await runTodoRequestMutation({
+                requestId: e.requestId,
+                valid,
+                mutate: () => todoService.addTodo({
+                    title: e.title as string,
+                    notes: typeof e.notes === 'string' ? e.notes : '',
+                    priority: e.priority === 'high' || e.priority === 'medium' || e.priority === 'low' ? e.priority : 'medium',
+                    groupId: typeof e.groupId === 'string' ? e.groupId : undefined,
+                }),
+                onSuccess: () => postTodoPanelContent(),
+                postResult: message => provider.postMessage(message),
+                showErrorMessage: message => showErrorMessage(message),
+                logError,
+            });
+        },
+        'todo-add-group': async () => {
+            await runTodoPromptMutation({
+                prompt: value => showInputBox({
+                    prompt: 'Todo group title',
+                    placeHolder: 'Group name',
+                    value,
+                    ignoreFocusOut: true,
+                }),
+                mutate: title => todoService.addGroup(title),
+                refreshPanel: () => postTodoPanelContent(),
+                showErrorMessage: message => showErrorMessage(message),
+                logError,
+            });
+        },
+        'todo-toggle': async e => {
+            if (typeof e.todoId !== 'string') {
+                return;
+            }
+            await runTodoPanelMutation(() => todoService.completeTodo(e.todoId as string, e.completed === true));
+        },
+        'todo-delete': async e => {
+            if (typeof e.todoId !== 'string') {
+                return;
+            }
+            await deleteTodoWithConfirmation({
+                todoId: e.todoId,
+                getData: () => todoService.getData(),
+                confirm: title => showWarningMessage(
+                    `Delete TODO "${title}"?`,
+                    { modal: true },
+                    'Delete'
+                ),
+                deleteTodo: todoId => todoService.deleteTodo(todoId),
+                refreshPanel: () => postTodoPanelContent(),
+                showErrorMessage: message => showErrorMessage(message),
+                logError,
+            });
+        },
+        'todo-delete-group': async e => {
+            if (typeof e.groupId !== 'string') {
+                return;
+            }
+            const todoGroup = todoService.getData().groups.find(group => group.id === e.groupId);
+            if (!todoGroup) {
+                return;
+            }
+            const confirmed = await showWarningMessage(
+                `Delete TODO group "${todoGroup.title}" and all of its todos?`,
+                { modal: true },
+                'Delete'
+            );
+            if (confirmed !== 'Delete') {
+                return;
+            }
+            await runTodoPanelMutation(() => todoService.deleteGroup(e.groupId as string));
+        },
+        'todo-rename-group': async e => {
+            if (typeof e.groupId !== 'string') {
+                return;
+            }
+            await renameTodoGroupWithPrompt({
+                groupId: e.groupId,
+                getData: () => todoService.getData(),
+                prompt: value => showInputBox({
+                    prompt: 'Todo group title',
+                    value,
+                    ignoreFocusOut: true,
+                }),
+                renameGroup: (groupId, title) => todoService.renameGroup(groupId, title),
+                refreshPanel: () => postTodoPanelContent(),
+                showErrorMessage: message => showErrorMessage(message),
+                logError,
+            });
+        },
+        'todo-reorder-groups': async e => {
+            if (!Array.isArray(e.groupIds)) {
+                return;
+            }
+            await runTodoPanelMutation(() => todoService.reorderGroups(e.groupIds as string[]));
+        },
+        'todo-reorder-items': async e => {
+            if (typeof e.groupId !== 'string' || !Array.isArray(e.todoIds)) {
+                return;
+            }
+            await runTodoPanelMutation(() => todoService.reorderTodos(e.groupId as string, e.todoIds as string[]));
+        },
+        'todo-collapse-group': async e => {
+            if (typeof e.groupId !== 'string') {
+                return;
+            }
+            await runTodoPanelMutation(() => todoService.setGroupCollapsed(e.groupId as string, e.collapsed === true));
+        },
+        'todo-collapse-groups': async e => {
+            await runTodoPanelMutation(() => todoService.setGroupsCollapsed(e.collapsed === true));
+        },
+        'todo-sort-priority': async e => {
+            if (typeof e.groupId !== 'string') {
+                return;
+            }
+            await runTodoPanelMutation(() => todoService.sortGroupByPriority(e.groupId as string));
+        },
+        'todo-toggle-show-completed': async e => {
+            await runTodoPanelMutation(async () => {
+                const persistedViewState = await todoService.setShowCompleted(e.showCompleted === true);
+                todoViewState.showCompleted = persistedViewState.showCompleted;
+                revealedTodoId = undefined;
+            });
+        },
+        'todo-reveal': async e => {
+            if (typeof e.todoId !== 'string' || typeof e.groupId !== 'string') {
+                return;
+            }
+            await runTodoPanelMutation(async () => {
+                const result = await todoService.revealTodo(e.todoId as string, e.groupId as string);
+                if (result.revealed) {
+                    revealedTodoId = e.todoId as string;
+                }
+            });
+        },
+        'todo-update': async e => {
+            if (typeof e.todoId !== 'string' || typeof e.title !== 'string') {
+                return;
+            }
+            await runTodoPanelMutation(() => todoService.updateTodo(e.todoId as string, {
+                title: e.title as string,
+                notes: typeof e.notes === 'string' ? e.notes : '',
+                priority: e.priority === 'high' || e.priority === 'medium' || e.priority === 'low' ? e.priority : 'medium',
+            }));
+        },
+    };
+
+    return {
+        handlers,
+        setStorageMigrationReady: ready => { todoStorageMigration.ready = ready; },
+        // The slice owns no timers or event subscriptions; the hook keeps the
+        // capability shape uniform with the other dashboard capabilities.
+        dispose: () => undefined,
+    };
+}

--- a/tests/contract/aiSessions/runtimeSettlement.test.js
+++ b/tests/contract/aiSessions/runtimeSettlement.test.js
@@ -1,0 +1,315 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+    createAiSessionRuntimeSettlementCapability,
+} = require('../../../out/aiSessions/runtimeSettlementCapability');
+
+function flushAsync() {
+    return new Promise(resolve => setImmediate(resolve));
+}
+
+async function flushAll() {
+    for (let index = 0; index < 10; index++) {
+        await flushAsync();
+    }
+}
+
+function makeRuntime(overrides = {}) {
+    const identity = {
+        provider: 'codex',
+        sessionId: 'session-a',
+        workspaceScopeIdentity: 'scope-1',
+        workspaceNavigationIdentity: 'nav-1',
+        workspaceRootHostPaths: ['/work/api'],
+        cwd: '/work/api',
+        ...(overrides.identity || {}),
+    };
+    const runtime = {
+        identity,
+        backend: 'vscode',
+        state: 'completed',
+        markerPath: '/markers/a',
+        runStartedAtMs: 700,
+        attached: true,
+        terminal: { name: 'terminal-a' },
+        ...overrides,
+    };
+    runtime.identity = identity;
+    return runtime;
+}
+
+function settledEvaluation() {
+    return {
+        enabled: true,
+        published: true,
+        inScopeSessionKeys: [],
+        overflowedSessionKeys: [],
+        eventIdsBySession: {},
+    };
+}
+
+function createFixture(overrides = {}) {
+    const diagnostics = [];
+    const attentionEvaluations = [];
+    const viewRefreshes = [];
+    const highlighterSyncs = [];
+    const releasedSessions = [];
+    const tmuxAcknowledgements = [];
+    const timers = [];
+    const terminalService = {
+        getCompletedSessions: () => overrides.completedSessions || [],
+        releaseCompletedSession: (provider, sessionId, workspaceScopeIdentity) => {
+            releasedSessions.push([provider, sessionId, workspaceScopeIdentity]);
+        },
+    };
+    const tmuxDiscovery = {
+        getInactive: () => overrides.inactiveTmux || [],
+        acknowledgeInactive: async runtime => {
+            tmuxAcknowledgements.push(runtime.identity.sessionId);
+            if (overrides.acknowledgeError) {
+                throw overrides.acknowledgeError;
+            }
+            return overrides.acknowledgeOutcome || 'acknowledged';
+        },
+    };
+    const capability = createAiSessionRuntimeSettlementCapability({
+        runtimeBelongsToCurrentWorkspace: overrides.runtimeBelongsToCurrentWorkspace
+            || (runtime => runtime.identity.workspaceScopeIdentity === 'scope-1'),
+        evaluateAttention: overrides.evaluateAttention || (async runtimeOverrides => {
+            attentionEvaluations.push(runtimeOverrides);
+            return settledEvaluation();
+        }),
+        tmuxRuntimeDiscovery: tmuxDiscovery,
+        aiSessionTerminalService: terminalService,
+        refreshAiSessionViewsIncrementally: () => viewRefreshes.push(true),
+        syncActiveTerminalHighlighter: () => highlighterSyncs.push(true),
+        logDiagnostic: event => diagnostics.push(event),
+        setInterval: (callback, intervalMs) => {
+            const handle = { callback, intervalMs, cleared: false };
+            timers.push(handle);
+            return handle;
+        },
+        clearInterval: handle => { handle.cleared = true; },
+    });
+    return {
+        capability,
+        diagnostics,
+        attentionEvaluations,
+        viewRefreshes,
+        highlighterSyncs,
+        releasedSessions,
+        tmuxAcknowledgements,
+        timers,
+    };
+}
+
+test('ATTENTION-EXECUTION-STATE-SYNC-001 drains queued runtimes in key order with one attention evaluation per batch', async () => {
+    const f = createFixture();
+    const tmuxRuntime = makeRuntime({
+        identity: { sessionId: 'session-b' },
+        backend: 'tmux',
+        tmux: { sessionName: 'agent-pivot' },
+    });
+    const vscodeRuntime = makeRuntime({ identity: { sessionId: 'session-c' } });
+
+    f.capability.queueSettlements([tmuxRuntime, vscodeRuntime]);
+    await flushAll();
+
+    const expectedKey = runtime =>
+        `scope-1:codex:${runtime.identity.sessionId}:700:${runtime.backend}`;
+    assert.equal(f.attentionEvaluations.length, 1, 'one merged evaluation per drained batch');
+    const overrides = f.attentionEvaluations[0];
+    assert.deepEqual(overrides.map(override => override.attentionKey),
+        [expectedKey(tmuxRuntime), expectedKey(vscodeRuntime)].sort(),
+        'candidates drain in localeCompare key order');
+    assert.deepEqual(overrides.map(override => [override.providerId, override.sessionId]), [
+        ['codex', 'session-b'],
+        ['codex', 'session-c'],
+    ]);
+    assert.equal(overrides[0].runtime.identity.sessionId, 'session-b');
+    assert.deepEqual(f.tmuxAcknowledgements, ['session-b'],
+        'tmux runtimes release through the discovery acknowledgement');
+    assert.deepEqual(f.releasedSessions, [['codex', 'session-c', 'scope-1']],
+        'vscode runtimes release through the terminal service');
+    assert.equal(f.viewRefreshes.length, 1, 'a settled batch refreshes the session views');
+    assert.equal(f.highlighterSyncs.length, 1, 'a settled batch resyncs the active terminal highlight');
+    assert.deepEqual(f.diagnostics, []);
+});
+
+test('ATTENTION-EXECUTION-STATE-SYNC-001 retains the batch and reports when attention evaluation fails', async () => {
+    const f = createFixture({
+        evaluateAttention: async () => { throw new Error('evaluation blew up'); },
+    });
+
+    f.capability.queueSettlements([makeRuntime()]);
+    await flushAll();
+
+    assert.deepEqual(f.diagnostics, [{
+        event: 'runtime-lifecycle-settlement-failed',
+        operation: 'evaluate',
+        category: 'unexpected',
+        hasRuntimeKey: false,
+    }]);
+    assert.deepEqual(f.releasedSessions, []);
+    assert.deepEqual(f.viewRefreshes, [], 'a failed evaluation must not publish a refresh');
+});
+
+test('ATTENTION-EXECUTION-STATE-SYNC-001 reports stale tmux acknowledgements as release failures', async () => {
+    const f = createFixture({ acknowledgeOutcome: 'stale' });
+    const tmuxRuntime = makeRuntime({
+        backend: 'tmux',
+        tmux: { sessionName: 'agent-pivot' },
+    });
+
+    f.capability.queueSettlements([tmuxRuntime]);
+    await flushAll();
+
+    assert.deepEqual(f.tmuxAcknowledgements, ['session-a']);
+    assert.deepEqual(f.diagnostics, [{
+        event: 'runtime-lifecycle-settlement-failed',
+        operation: 'release',
+        category: 'unexpected',
+        hasRuntimeKey: true,
+    }]);
+    assert.deepEqual(f.viewRefreshes, [], 'an unreleased runtime must not trigger a refresh');
+});
+
+test('ATTENTION-EXECUTION-STATE-SYNC-001 runs lifecycle tasks behind the named-reason failure boundary', async () => {
+    const f = createFixture();
+
+    await f.capability.runSafeLifecycleTask('evaluate-attention-startup', async () => undefined);
+    assert.deepEqual(f.diagnostics, [], 'a healthy task stays silent');
+
+    await f.capability.runSafeLifecycleTask('evaluate-attention-startup', async () => {
+        throw new Error('task failed');
+    });
+    await f.capability.runSafeLifecycleTask('acknowledge-user-terminal-close', () => {
+        throw new Error('sync throw');
+    });
+    assert.deepEqual(f.diagnostics, [
+        {
+            event: 'runtime-lifecycle-task-failed',
+            operation: 'evaluate-attention-startup',
+            category: 'unexpected',
+        },
+        {
+            event: 'runtime-lifecycle-task-failed',
+            operation: 'acknowledge-user-terminal-close',
+            category: 'unexpected',
+        },
+    ], 'every failure carries its explicit operation reason');
+
+    await f.capability.runSafeLifecycleTask('evaluate-attention-startup', async () => {
+        throw new Error('task failed');
+    });
+    assert.equal(f.diagnostics.length, 3, 'the safe boundary resolves instead of rejecting');
+});
+
+test('ATTENTION-SINGLE-RUN-COMPLETION-DEDUP-001 coalesces repeats of the same attention key', async () => {
+    const f = createFixture();
+    const runtime = makeRuntime();
+
+    f.capability.queueSettlements([runtime, makeRuntime(), makeRuntime()]);
+    await flushAll();
+
+    assert.equal(f.attentionEvaluations.length, 1);
+    assert.equal(f.attentionEvaluations[0].length, 1,
+        'one run settles once no matter how many signals queued it');
+    assert.deepEqual(f.releasedSessions, [['codex', 'session-a', 'scope-1']]);
+});
+
+test('ATTENTION-SINGLE-RUN-COMPLETION-DEDUP-001 skips keys already settling and releases queued follow-ups in one drain', async () => {
+    let releaseEvaluation;
+    const f = createFixture({
+        evaluateAttention: async runtimeOverrides => {
+            f.attentionEvaluations.push(runtimeOverrides);
+            if (f.attentionEvaluations.length === 1) {
+                await new Promise(resolve => { releaseEvaluation = resolve; });
+            }
+            return settledEvaluation();
+        },
+    });
+    const runtimeA = makeRuntime();
+    const runtimeB = makeRuntime({ identity: { sessionId: 'session-b' } });
+
+    f.capability.queueSettlements([runtimeA]);
+    await flushAll();
+    assert.equal(f.attentionEvaluations.length, 1, 'the first drain holds the batch open');
+
+    f.capability.queueSettlements([makeRuntime(), runtimeB]);
+    await flushAll();
+    assert.equal(f.attentionEvaluations.length, 1,
+        'a key already settling is not queued again; new keys wait for the in-flight drain');
+
+    releaseEvaluation();
+    await flushAll();
+    assert.equal(f.attentionEvaluations.length, 2,
+        'the queued follow-up batch drains inside the same in-flight task');
+    assert.deepEqual(f.attentionEvaluations[1].map(override => override.sessionId), ['session-b']);
+    assert.deepEqual(f.releasedSessions, [
+        ['codex', 'session-a', 'scope-1'],
+        ['codex', 'session-b', 'scope-1'],
+    ]);
+});
+
+test('ATTENTION-SINGLE-RUN-COMPLETION-DEDUP-001 skips foreign workspaces and non-terminal states', async () => {
+    const f = createFixture();
+
+    f.capability.queueSettlements([
+        makeRuntime({ identity: { workspaceScopeIdentity: 'scope-2' } }),
+        makeRuntime({ state: 'running' }),
+        makeRuntime({ identity: { sessionId: null } }),
+    ]);
+    await flushAll();
+
+    assert.deepEqual(f.attentionEvaluations, []);
+    assert.deepEqual(f.releasedSessions, []);
+    assert.deepEqual(f.diagnostics, []);
+});
+
+test('ATTENTION-EXECUTION-STATE-SYNC-001 scans completed terminals and inactive tmux runtimes once per round', async () => {
+    const completedIdentity = {
+        provider: 'codex',
+        sessionId: 'session-scan',
+        workspaceScopeIdentity: 'scope-1',
+        workspaceNavigationIdentity: 'nav-1',
+        workspaceRootHostPaths: ['/work/api'],
+        cwd: '/work/api',
+    };
+    const f = createFixture({
+        completedSessions: [
+            {
+                entry: {
+                    runtimeIdentity: completedIdentity,
+                    markerPath: '/markers/scan',
+                    runStartedAtMs: 900,
+                },
+                terminal: { name: 'terminal-scan' },
+            },
+            { entry: { runtimeIdentity: null }, terminal: { name: 'terminal-orphan' } },
+        ],
+        inactiveTmux: [makeRuntime({
+            identity: { sessionId: 'session-tmux' },
+            backend: 'tmux',
+            tmux: { sessionName: 'agent-pivot' },
+        })],
+    });
+
+    f.capability.startSettlementScan();
+    f.capability.startSettlementScan();
+    assert.equal(f.timers.length, 1, 'the scan starts one interval');
+    assert.equal(f.timers[0].intervalMs, 1_000, 'the scan keeps the 1s cadence');
+
+    f.timers[0].callback();
+    await flushAll();
+    assert.deepEqual(f.releasedSessions, [['codex', 'session-scan', 'scope-1']],
+        'one round queues the completed terminal runtime');
+    assert.deepEqual(f.tmuxAcknowledgements, ['session-tmux'],
+        'one round queues the inactive tmux runtime');
+
+    f.capability.dispose();
+    assert.equal(f.timers[0].cleared, true, 'dispose clears the scan interval');
+});

--- a/tests/contract/projects/projectMessageHandlers.test.js
+++ b/tests/contract/projects/projectMessageHandlers.test.js
@@ -1,0 +1,271 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+    createProjectMessageHandlers,
+    createProjectSurfaceRefresh,
+} = require('../../../out/projects/projectMessageHandlers');
+const { getAttentionProjectKey } = require('../../../out/aiSessions/attentionProject');
+
+function createFixture(overrides = {}) {
+    const calls = [];
+    const record = name => (...args) => {
+        calls.push([name, ...args]);
+        return Promise.resolve();
+    };
+    const project = { id: 'project-a', name: 'API', path: '/work/api', isGitRepo: true };
+    const options = {
+        projectService: {
+            getProject: projectId => {
+                calls.push(['getProject', projectId]);
+                return Object.prototype.hasOwnProperty.call(overrides, 'project')
+                    ? overrides.project
+                    : project;
+            },
+            copyProjectsFromFilledStorageOptionToEmptyStorageOption: async () => {
+                calls.push(['copyFromOtherStorage']);
+            },
+        },
+        projectOpenController: { openProject: record('openProject') },
+        projectMutationController: {
+            addProject: record('addProject'),
+            editProject: record('editProject'),
+            editProjectColor: record('editProjectColor'),
+        },
+        projectOrderController: { reorderGroups: record('reorderGroups') },
+        favoriteProjectController: {
+            reorderFavoriteProjects: record('reorderFavoriteProjects'),
+            toggleProjectFavorite: record('toggleProjectFavorite'),
+        },
+        projectRemovalController: { removeProject: record('removeProject') },
+        groupCommandController: {
+            editGroup: record('editGroup'),
+            removeGroup: record('removeGroup'),
+            addGroup: record('addGroup'),
+        },
+        groupCollapseController: { collapseGroup: record('collapseGroup') },
+        getWorkspaceNavigationController: () => ({ open: record('openWorkspaceNavigation') }),
+        getOpenWorkspacePinController: () => ({ handle: record('handleOpenWorkspacePin') }),
+        getAttentionAggregate: () => overrides.attentionAggregate || null,
+        acknowledgeAiSessionAttentionEventIds: record('acknowledgeAttention'),
+        refreshAfterMutation: mode => { calls.push(['refreshAfterMutation', mode]); },
+        showWarningMessage: message => { calls.push(['showWarningMessage', message]); },
+    };
+    const handlers = createProjectMessageHandlers(options);
+    return { handlers, calls, project };
+}
+
+function createSurfaceFixture(options = {}) {
+    const events = [];
+    const panel = { postUpdated: mode => events.push(['projects-panel', mode]) };
+    const surface = createProjectSurfaceRefresh({
+        getProjectsPanelController: () => (options.omitPanel ? undefined : panel),
+        getOpenWorkspaceDashboardController: () => ({
+            postUpdated: () => events.push(['open-workspaces-panel']),
+        }),
+        publishOpenWorkspace: () => events.push(['publish-workspace']),
+        syncProjectColorToCurrentWindow: project => events.push(['window-color', project]),
+    });
+    return { surface, events };
+}
+
+test('WEBVIEW-DASHBOARD-MESSAGE-ROUTER-001 exposes every production project/group handler key', () => {
+    const { handlers } = createFixture();
+
+    assert.deepEqual(Object.keys(handlers), [
+        'selected-project',
+        'set-open-workspace-pin',
+        'add-project',
+        'import-from-other-storage',
+        'reordered-projects',
+        'reordered-favorites',
+        'remove-project',
+        'edit-project',
+        'color-project',
+        'favorite-project',
+        'edit-group',
+        'remove-group',
+        'add-group',
+        'collapse-group',
+        'toggle-all-groups',
+    ]);
+});
+
+test('OPEN-PROJECT-UI-HOST-NAVIGATION-001 routes workspace navigation cards before any project lookup', async () => {
+    const { handlers, calls } = createFixture();
+
+    await handlers['selected-project']({
+        type: 'selected-project',
+        projectId: '__openWorkspaceNavigation-card-7',
+    });
+
+    assert.deepEqual(calls, [['openWorkspaceNavigation', '__openWorkspaceNavigation-card-7']],
+        'navigation cards must go straight to the workspace navigation controller');
+});
+
+test('OPEN-PROJECT-UI-HOST-NAVIGATION-001 warns and stops when the selected project is gone', async () => {
+    const { handlers, calls } = createFixture({ project: null });
+
+    await handlers['selected-project']({
+        type: 'selected-project',
+        projectId: 'missing',
+        projectOpenType: 3,
+    });
+
+    assert.deepEqual(calls, [
+        ['getProject', 'missing'],
+        ['showWarningMessage', 'Selected Project not found.'],
+    ], 'a missing project must warn without acknowledging attention or opening anything');
+});
+
+test('OPEN-PROJECT-UI-HOST-NAVIGATION-001 acknowledges the card attention before opening the project', async () => {
+    const attentionAggregate = {
+        protocolVersion: 1,
+        aggregateRevision: '0'.repeat(64),
+        generatedAtMs: 10,
+        sessions: [{
+            projectId: getAttentionProjectKey('/work/api'),
+            sessionKey: 'codex:session-1',
+            reasons: ['completed'],
+            eventIds: ['evt-1', 'evt-2'],
+            observedAtMs: 9,
+        }],
+    };
+    const { handlers, calls, project } = createFixture({ attentionAggregate });
+
+    await handlers['selected-project']({
+        type: 'selected-project',
+        projectId: 'project-a',
+        projectOpenType: 3,
+    });
+
+    assert.deepEqual(calls, [
+        ['getProject', 'project-a'],
+        ['acknowledgeAttention', ['evt-1', 'evt-2']],
+        ['openProject', project, 3],
+    ], 'the open flow must acknowledge every event the card represents before opening');
+});
+
+test('WEBVIEW-DASHBOARD-MESSAGE-ROUTER-001 delegates project mutations to their controllers', async () => {
+    const { handlers, calls } = createFixture();
+
+    await handlers['add-project']({ groupId: 'group-a' });
+    await handlers['edit-project']({ projectId: 'project-a' });
+    await handlers['color-project']({ projectId: 'project-b' });
+
+    assert.deepEqual(calls, [
+        ['addProject', 'group-a'],
+        ['editProject', 'project-a'],
+        ['editProjectColor', 'project-b'],
+    ]);
+});
+
+test('PROJECT-PROJECT-ORDER-CONTROLLER-001 passes group orders through unchanged', async () => {
+    const { handlers, calls } = createFixture();
+
+    const groupOrders = [{ groupId: 'group-a', projectIds: ['project-a'] }];
+    await handlers['reordered-projects']({ groupOrders });
+
+    assert.deepEqual(calls, [['reorderGroups', groupOrders]]);
+    assert.equal(calls[0][1], groupOrders, 'group orders must pass through unchanged');
+});
+
+test('PROJECT-FAVORITE-PROJECT-CONTROLLER-001 delegates favorite mutations with the array guard', async () => {
+    const { handlers, calls } = createFixture();
+
+    await handlers['favorite-project']({ projectId: 'project-a' });
+    await handlers['reordered-favorites']({ projectIds: ['project-b', 'project-a'] });
+    await handlers['reordered-favorites']({ projectIds: 'project-a' });
+
+    assert.deepEqual(calls, [
+        ['toggleProjectFavorite', 'project-a'],
+        ['reorderFavoriteProjects', ['project-b', 'project-a']],
+        ['reorderFavoriteProjects', []],
+    ], 'a non-array favorite order must degrade to an empty order');
+});
+
+test('PROJECT-PROJECT-REMOVAL-CONTROLLER-001 delegates removals by project id', async () => {
+    const { handlers, calls } = createFixture();
+
+    await handlers['remove-project']({ projectId: 'project-a' });
+
+    assert.deepEqual(calls, [['removeProject', 'project-a']]);
+});
+
+test('PROJECT-INCREMENTAL-REFRESH-001 imports the other storage before refreshing the surfaces', async () => {
+    const { handlers, calls } = createFixture();
+
+    await handlers['import-from-other-storage']({ type: 'import-from-other-storage' });
+
+    assert.deepEqual(calls, [
+        ['copyFromOtherStorage'],
+        ['refreshAfterMutation', undefined],
+    ], 'the catalog copy must settle before the partial surface refresh');
+});
+
+test('WEBVIEW-DASHBOARD-MESSAGE-ROUTER-001 delegates group commands and workspace pins', async () => {
+    const { handlers, calls } = createFixture();
+
+    await handlers['edit-group']({ groupId: 'group-a' });
+    await handlers['remove-group']({ groupId: 'group-b' });
+    await handlers['add-group']({});
+    await handlers['collapse-group']({ groupId: 'group-a', collapsed: true });
+    const pinMessage = { type: 'set-open-workspace-pin', requestId: 'req-1', cardId: 'card-1', pinned: true };
+    await handlers['set-open-workspace-pin'](pinMessage);
+
+    assert.deepEqual(calls, [
+        ['editGroup', 'group-a'],
+        ['removeGroup', 'group-b'],
+        ['addGroup'],
+        ['collapseGroup', 'group-a', true],
+        ['handleOpenWorkspacePin', pinMessage],
+    ]);
+    assert.equal(calls[4][1], pinMessage, 'the pin message must pass through untouched');
+
+    assert.strictEqual(handlers['toggle-all-groups']({ collapsed: true }), undefined,
+        'collapse-all stays a per-webview convenience action with no host work');
+    assert.equal(calls.length, 5, 'toggle-all-groups must not reach any controller');
+});
+
+test('PROJECT-INCREMENTAL-REFRESH-001 posts both project surfaces without a full rebuild', () => {
+    const { surface, events } = createSurfaceFixture();
+
+    surface.postProjectSurfacesUpdated('merge');
+
+    assert.deepEqual(events, [
+        ['projects-panel', 'merge'],
+        ['open-workspaces-panel'],
+    ]);
+});
+
+test('PROJECT-INCREMENTAL-REFRESH-001 tolerates a missing projects panel', () => {
+    const { surface, events } = createSurfaceFixture({ omitPanel: true });
+
+    surface.postProjectSurfacesUpdated('replace');
+
+    assert.deepEqual(events, [['open-workspaces-panel']]);
+});
+
+test('PROJECT-INCREMENTAL-REFRESH-001 orders the mutation refresh: surfaces, colour, republish', () => {
+    const { surface, events } = createSurfaceFixture();
+    const project = { id: 'project-a' };
+
+    surface.refreshAfterMutation();
+    assert.deepEqual(events, [
+        ['projects-panel', 'replace'],
+        ['open-workspaces-panel'],
+        ['window-color', null],
+        ['publish-workspace'],
+    ], 'the default replace refresh must update surfaces, sync the window colour, then republish');
+
+    events.length = 0;
+    surface.refreshAfterMutation('merge');
+    assert.deepEqual(events[0], ['projects-panel', 'merge'], 'the update mode must reach the panels');
+
+    events.length = 0;
+    surface.applyProjectColorToCurrentWindow(project);
+    assert.deepEqual(events, [['window-color', project]],
+        'an explicit project colour sync must pass the project through');
+});

--- a/tests/contract/skills/skillPanelCapability.test.js
+++ b/tests/contract/skills/skillPanelCapability.test.js
@@ -1,0 +1,376 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const Module = require('node:module');
+const test = require('node:test');
+
+function loadSkillPanelCapability() {
+    const fakeVscode = {
+        ConfigurationTarget: { Global: 1, Workspace: 2 },
+        Uri: {
+            file: value => ({ scheme: 'file', fsPath: value, path: value, toString: () => value }),
+            parse: value => ({ scheme: 'file', fsPath: value, path: value, toString: () => value }),
+        },
+    };
+    const previousLoad = Module._load;
+    try {
+        Module._load = function (request, parent, isMain) {
+            if (request === 'vscode') return fakeVscode;
+            return previousLoad.call(this, request, parent, isMain);
+        };
+        return require('../../../out/skills/skillPanelCapability');
+    } finally {
+        Module._load = previousLoad;
+    }
+}
+
+const { createSkillPanelCapability } = loadSkillPanelCapability();
+
+function makeRecord(overrides = {}) {
+    return {
+        name: 'demo-skill',
+        dirPath: '/skills/user/demo-skill',
+        skillFilePath: '/skills/user/demo-skill/SKILL.md',
+        scope: 'user',
+        source: 'kimi',
+        central: { links: { user: { kimi: true }, project: {} } },
+        contentHash: 'hash-a',
+        ...overrides,
+    };
+}
+
+function createFixture(overrides = {}) {
+    const calls = [];
+    const posted = [];
+    const warnings = [];
+    const infos = [];
+    const prompts = [];
+    const quickPicks = [];
+    const records = overrides.records || [];
+    const dashboardController = {
+        getRecords: () => records,
+        getPanelView: () => ({ panelView: true }),
+        getStoreRoots: () => ({ user: '/skills/user', project: '/repo/.skills' }),
+        start: () => calls.push(['start']),
+        refresh: async (reason, settlement) => {
+            calls.push(['refresh', reason, settlement]);
+            return overrides.refreshDelivered !== false;
+        },
+        dispose: () => calls.push(['dispose']),
+        handleDeleteSkill: dirPath => { calls.push(['handleDeleteSkill', dirPath]); return { ok: true }; },
+        handleApplyCollectionSuggestion: name => { calls.push(['handleApplyCollectionSuggestion', name]); return { ok: true }; },
+        handleDismissCollectionSuggestion: async name => { calls.push(['handleDismissCollectionSuggestion', name]); },
+        handleSyncSkill: (source, target) => { calls.push(['handleSyncSkill', source, target]); return { ok: true }; },
+        handleCopySkill: (source, target) => { calls.push(['handleCopySkill', source, target]); return { ok: true }; },
+        handleSetGlobalSkillProjectAgents: (dirPath, agents) => {
+            calls.push(['handleSetGlobalSkillProjectAgents', dirPath, agents]);
+            return { ok: true, dirPath: `${dirPath}-applied` };
+        },
+        handleMoveProjectSkillToGlobal: dirPath => {
+            calls.push(['handleMoveProjectSkillToGlobal', dirPath]);
+            return { ok: true, dirPath: `${dirPath}-moved` };
+        },
+        handleCentralToggle: (...args) => { calls.push(['handleCentralToggle', ...args]); return { ok: true }; },
+        handleFolderToggle: (...args) => { calls.push(['handleFolderToggle', ...args]); return { ok: true }; },
+        handleMoveToFolder: (...args) => { calls.push(['handleMoveToFolder', ...args]); return { ok: true }; },
+        handleCreateFolder: (...args) => { calls.push(['handleCreateFolder', ...args]); return { ok: true }; },
+        handleRemoveFolder: (...args) => { calls.push(['handleRemoveFolder', ...args]); return { ok: true }; },
+        handleCentralize: dirPath => { calls.push(['handleCentralize', dirPath]); return { ok: true }; },
+        handleMigrateToCentral: scope => {
+            calls.push(['handleMigrateToCentral', scope]);
+            return overrides.migrationReport || {
+                migrated: ['a', 'b'], drifted: [], deleted: ['dup'], skipped: [], errors: [],
+            };
+        },
+        handleFixSkillDiagnostic: (...args) => { calls.push(['handleFixSkillDiagnostic', ...args]); return { ok: true }; },
+    };
+    const locationController = {
+        getActiveRoot: () => '/skills/user',
+        changeInteractively: async () => { calls.push(['changeInteractively']); return true; },
+        handleConfigurationChange: async () => { calls.push(['handleConfigurationChange']); return true; },
+    };
+    const factories = {
+        createLocationController: () => locationController,
+        createDashboardController: () => dashboardController,
+    };
+    const capability = createSkillPanelCapability({
+        getHomeDir: () => '/home/test',
+        getWorkspaceRoot: () => '/repo',
+        getWorkspaceRoots: () => ['/repo'],
+        hasWorkspace: () => overrides.hasWorkspace !== false,
+        groupStore: {},
+        readGlobalStorePath: () => '~/.skills',
+        writeGlobalStorePath: async () => undefined,
+        postMessage: async message => { posted.push(message); return true; },
+        refreshDashboard: () => calls.push(['refreshDashboard']),
+        isVisible: () => true,
+        showInputBox: async options => {
+            prompts.push(options);
+            return overrides.inputBoxResponses ? overrides.inputBoxResponses.shift() : undefined;
+        },
+        showQuickPickMany: async (items, options) => {
+            quickPicks.push({ items, options });
+            return overrides.quickPickResponses ? overrides.quickPickResponses.shift() : undefined;
+        },
+        showWarningMessage: async (message, options, ...items) => {
+            warnings.push({ message, options, items });
+            return overrides.warningResponses ? overrides.warningResponses.shift() : undefined;
+        },
+        showInformationMessage: async message => { infos.push(message); return undefined; },
+        showErrorMessage: async () => undefined,
+        openTextFile: async fsPath => { calls.push(['openTextFile', fsPath]); },
+        logError: (message, error) => { calls.push(['logError', message, String(error)]); },
+    }, factories);
+    return { capability, calls, posted, warnings, infos, prompts, quickPicks, records, dashboardController, locationController };
+}
+
+function scopeActionMessage(overrides = {}) {
+    return {
+        type: 'skill-scope-action',
+        version: 1,
+        requestId: 'req-1',
+        dirPath: '/skills/user/demo-skill',
+        operation: 'apply-to-project',
+        ...overrides,
+    };
+}
+
+test('PERSIST-AI-SKILL-SCOPE-ACTION-001 exposes every production skill handler key', () => {
+    const { capability } = createFixture();
+
+    assert.deepEqual(Object.keys(capability.handlers), [
+        'delete-skill',
+        'apply-skill-collection',
+        'dismiss-skill-collection',
+        'sync-skill',
+        'copy-skill',
+        'skill-scope-action',
+        'central-toggle-skill',
+        'folder-toggle-skill-links',
+        'move-skill-to-folder',
+        'create-skill-folder',
+        'remove-skill-folder',
+        'centralize-skill',
+        'migrate-skills-to-central',
+        'change-global-skills-location',
+        'fix-skill-diagnostic',
+        'open-skill-file',
+    ]);
+});
+
+test('PERSIST-AI-SKILL-SCOPE-ACTION-001 rejects malformed and duplicate scope-action envelopes', async () => {
+    const { capability, calls } = createFixture();
+
+    await capability.handlers['skill-scope-action']({ type: 'skill-scope-action', version: 2 });
+    await capability.handlers['skill-scope-action'](scopeActionMessage({ operation: 'clone' }));
+    await capability.handlers['skill-scope-action'](scopeActionMessage({ extra: true }));
+    assert.equal(calls.filter(call => call[0] === 'refresh').length, 0,
+        'invalid envelopes must not reach the settlement pipeline');
+
+    const applied = createFixture({
+        records: [makeRecord()],
+        quickPickResponses: [['kimi'].map(agent => ({ label: 'Kimi', agent }))],
+    });
+    await applied.capability.handlers['skill-scope-action'](scopeActionMessage());
+    await applied.capability.handlers['skill-scope-action'](scopeActionMessage());
+    assert.equal(
+        applied.calls.filter(call => call[0] === 'handleSetGlobalSkillProjectAgents').length,
+        1,
+        'a completed requestId settles exactly once',
+    );
+});
+
+test('PERSIST-AI-SKILL-SCOPE-ACTION-001 settles apply-to-project through the agent quickpick', async () => {
+    const f = createFixture({
+        records: [makeRecord()],
+        quickPickResponses: [[{ label: 'Kimi', agent: 'kimi' }, { label: 'Codex', agent: 'codex' }]],
+    });
+
+    await f.capability.handlers['skill-scope-action'](scopeActionMessage());
+
+    assert.deepEqual(
+        f.calls.find(call => call[0] === 'handleSetGlobalSkillProjectAgents'),
+        ['handleSetGlobalSkillProjectAgents', '/skills/user/demo-skill', ['kimi', 'codex']],
+    );
+    const refresh = f.calls.find(call => call[0] === 'refresh');
+    assert.deepEqual(refresh[1], 'skill-scope-action');
+    assert.deepEqual(refresh[2], {
+        version: 1,
+        requestId: 'req-1',
+        dirPath: '/skills/user/demo-skill',
+        operation: 'apply-to-project',
+        ok: true,
+        code: 'applied',
+        resultDirPath: '/skills/user/demo-skill-applied',
+    });
+    assert.equal(f.quickPicks.length, 1, 'the agent choice is prompted');
+    assert.equal(f.posted.length, 0, 'a delivered settlement never falls back to a raw post');
+});
+
+test('PERSIST-AI-SKILL-SCOPE-ACTION-001 falls back to a refresh-failed result when delivery fails', async () => {
+    const f = createFixture({
+        records: [makeRecord()],
+        quickPickResponses: [undefined],
+        refreshDelivered: false,
+    });
+
+    await f.capability.handlers['skill-scope-action'](scopeActionMessage());
+
+    assert.deepEqual(f.posted, [{
+        type: 'skill-scope-action-result',
+        version: 1,
+        requestId: 'req-1',
+        dirPath: '/skills/user/demo-skill',
+        operation: 'apply-to-project',
+        ok: false,
+        code: 'refresh-failed',
+        resultDirPath: undefined,
+    }]);
+    assert.ok(f.calls.some(call => call[0] === 'refreshDashboard'),
+        'a lost authoritative refresh rebuilds the dashboard before the raw result');
+});
+
+test('PERSIST-AI-SKILL-SCOPE-ACTION-001 settles move-to-global only after the modal choice', async () => {
+    const projectRecord = makeRecord({ scope: 'project', dirPath: '/repo/.skills/demo-skill' });
+    const declined = createFixture({
+        records: [projectRecord],
+        warningResponses: ['Cancel'],
+    });
+    await declined.capability.handlers['skill-scope-action'](scopeActionMessage({
+        dirPath: projectRecord.dirPath,
+        operation: 'move-to-global',
+    }));
+    assert.equal(
+        declined.calls.filter(call => call[0] === 'handleMoveProjectSkillToGlobal').length,
+        0,
+        'a declined modal must not move the skill',
+    );
+    const declinedRefresh = declined.calls.find(call => call[0] === 'refresh');
+    assert.equal(declinedRefresh[2].code, 'cancelled');
+
+    const accepted = createFixture({
+        records: [makeRecord({ scope: 'project', dirPath: '/repo/.skills/demo-skill' })],
+        warningResponses: ['Move to Global'],
+    });
+    await accepted.capability.handlers['skill-scope-action'](scopeActionMessage({
+        dirPath: '/repo/.skills/demo-skill',
+        operation: 'move-to-global',
+    }));
+    assert.deepEqual(
+        accepted.calls.find(call => call[0] === 'handleMoveProjectSkillToGlobal'),
+        ['handleMoveProjectSkillToGlobal', '/repo/.skills/demo-skill'],
+    );
+    const acceptedRefresh = accepted.calls.find(call => call[0] === 'refresh');
+    assert.equal(acceptedRefresh[2].code, 'moved');
+});
+
+test('PERSIST-AI-SKILL-CENTRAL-STORE-001 confirms destructive actions before mutating', async () => {
+    const f = createFixture({
+        records: [
+            makeRecord({ central: undefined }),
+            makeRecord({
+                central: undefined,
+                dirPath: '/skills/user/demo-copy',
+                skillFilePath: '/skills/user/demo-copy/SKILL.md',
+                contentHash: 'hash-b',
+            }),
+        ],
+        warningResponses: [undefined, undefined],
+    });
+
+    await f.capability.handlers['delete-skill']({ dirPath: '/skills/user/demo-skill' });
+    assert.match(f.warnings[0].message, /Delete skill "demo-skill" permanently\? This cannot be undone\./);
+    await f.capability.handlers['centralize-skill']({ dirPath: '/skills/user/demo-skill' });
+    assert.equal(f.calls.filter(call => call[0] === 'handleDeleteSkill').length, 0);
+    assert.equal(f.calls.filter(call => call[0] === 'handleCentralize').length, 0);
+    assert.match(f.warnings[1].message, /deleted permanently/);
+    assert.match(f.warnings[1].message, /different content/, 'drifted duplicates must be flagged');
+
+    const accepted = createFixture({
+        records: [makeRecord()],
+        warningResponses: ['Delete', 'Centralize'],
+    });
+    await accepted.capability.handlers['delete-skill']({ dirPath: '/skills/user/demo-skill' });
+    await accepted.capability.handlers['centralize-skill']({ dirPath: '/skills/user/demo-skill' });
+    assert.deepEqual(
+        accepted.calls.filter(call => call[0] === 'handleDeleteSkill'),
+        [['handleDeleteSkill', '/skills/user/demo-skill']],
+    );
+    assert.deepEqual(
+        accepted.calls.filter(call => call[0] === 'handleCentralize'),
+        [['handleCentralize', '/skills/user/demo-skill']],
+    );
+});
+
+test('PERSIST-AI-SKILL-CENTRAL-STORE-001 delegates panel mutations to the controller', async () => {
+    const f = createFixture({ inputBoxResponses: ['new-folder'], warningResponses: ['Delete'] });
+
+    await f.capability.handlers['apply-skill-collection']({ name: 'bundle' });
+    await f.capability.handlers['dismiss-skill-collection']({ name: 'bundle' });
+    await f.capability.handlers['sync-skill']({ sourceDir: '/a', targetDir: '/b' });
+    await f.capability.handlers['copy-skill']({ sourceDir: '/a', targetRoot: '/c' });
+    await f.capability.handlers['central-toggle-skill']({ dirPath: '/a', scope: 'project', source: 'kimi', enabled: true });
+    await f.capability.handlers['folder-toggle-skill-links']({ storeRoot: '/r', folder: 'f', scope: 'user', agent: 'codex', enabled: false });
+    await f.capability.handlers['move-skill-to-folder']({ dirPath: '/a', folder: 'f' });
+    await f.capability.handlers['create-skill-folder']({ scope: 'project' });
+    await f.capability.handlers['remove-skill-folder']({ storeRoot: '/r', folder: 'f' });
+    await f.capability.handlers['fix-skill-diagnostic']({ dirPath: '/a', code: 'broken' });
+
+    assert.deepEqual(f.calls, [
+        ['handleApplyCollectionSuggestion', 'bundle'],
+        ['handleDismissCollectionSuggestion', 'bundle'],
+        ['handleSyncSkill', '/a', '/b'],
+        ['handleCopySkill', '/a', '/c'],
+        ['handleCentralToggle', '/a', 'project', 'kimi', true],
+        ['handleFolderToggle', '/r', 'f', 'user', 'codex', false],
+        ['handleMoveToFolder', '/a', 'f'],
+        ['handleCreateFolder', 'project', 'new-folder'],
+        ['handleRemoveFolder', '/r', 'f'],
+        ['handleFixSkillDiagnostic', '/a', 'broken'],
+    ]);
+    assert.equal(f.warnings.length, 1, 'only the folder deletion prompts a confirmation');
+    assert.match(f.warnings[0].message, /Only empty folders can be deleted/);
+    assert.equal(f.prompts.length, 1, 'the folder name is prompted host-side');
+});
+
+test('PERSIST-AI-SKILL-CENTRAL-STORE-001 migrate summarizes the report and skips an empty selection', async () => {
+    const empty = createFixture({ records: [makeRecord()] });
+    await empty.capability.migrateToCentral();
+    assert.deepEqual(empty.infos, ['Every skill is already centralized.']);
+    assert.equal(empty.calls.filter(call => call[0] === 'handleMigrateToCentral').length, 0);
+
+    const migratable = makeRecord({ central: undefined, dirPath: '/repo/.agents/skills/demo' });
+    const f = createFixture({
+        records: [migratable],
+        warningResponses: ['Migrate'],
+    });
+    await f.capability.migrateToCentral('user');
+    assert.match(f.warnings[0].message, /Migrate 1 user skill\(s\) into \/skills\/user\?/);
+    assert.deepEqual(f.calls.find(call => call[0] === 'handleMigrateToCentral'), ['handleMigrateToCentral', 'user']);
+    assert.deepEqual(f.infos, ['Migrated 2 skill(s) into the central stores; 1 duplicate(s) deleted.']);
+});
+
+test('PERSIST-AI-SKILL-GLOBAL-STORE-LOCATION-001 exposes the location controller through the facade', async () => {
+    const f = createFixture();
+
+    await f.capability.changeGlobalStoreLocation();
+    await f.capability.handleGlobalStoreConfigurationChange();
+    await f.capability.handlers['change-global-skills-location']({ type: 'change-global-skills-location' });
+
+    assert.deepEqual(f.calls, [
+        ['changeInteractively'],
+        ['handleConfigurationChange'],
+        ['changeInteractively'],
+    ]);
+});
+
+test('PERSIST-AI-SKILL-GLOBAL-STORE-LOCATION-001 facade delegates reads, start, and dispose', () => {
+    const record = makeRecord();
+    const f = createFixture({ records: [record] });
+
+    assert.deepEqual(f.capability.getRecords(), [record]);
+    assert.deepEqual(f.capability.getPanelView(), { panelView: true });
+    f.capability.start();
+    f.capability.dispose();
+    assert.deepEqual(f.calls, [['start'], ['dispose']]);
+});

--- a/tests/contract/todos/commandController.test.js
+++ b/tests/contract/todos/commandController.test.js
@@ -248,9 +248,15 @@ test('TODO-TODO-COMMAND-CONTROLLER-001 routes versioned commands through the pro
         path.join(__dirname, '../../../src/dashboard.ts'),
         'utf8'
     );
+    const capabilitySource = fs.readFileSync(
+        path.join(__dirname, '../../../src/todos/todoPanelCapability.ts'),
+        'utf8'
+    );
 
-    assert.match(dashboardSource, /new TodoCommandController\s*\(/);
-    assert.match(dashboardSource, /'todo-command': async e =>/);
-    assert.match(dashboardSource, /todoCommandController\.handle\(e\)/);
-    assert.match(dashboardSource, /provider\.postMessage\(\{\s*\.\.\.result,\s*searchCatalog:/);
+    assert.match(capabilitySource, /new TodoCommandController\s*\(/);
+    assert.match(capabilitySource, /'todo-command': async e =>/);
+    assert.match(capabilitySource, /todoCommandController\.handle\(e\)/);
+    assert.match(capabilitySource, /provider\.postMessage\(\{\s*\.\.\.result,\s*searchCatalog:/);
+    assert.match(dashboardSource, /createTodoPanelCapability\(\{/);
+    assert.match(dashboardSource, /\.\.\.todoPanel\.handlers,/);
 });

--- a/tests/contract/todos/todoPanelCapability.test.js
+++ b/tests/contract/todos/todoPanelCapability.test.js
@@ -1,0 +1,343 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { createTodoPanelCapability } = require('../../../out/todos/todoPanelCapability');
+const { UnsupportedTodoDataVersionError } = require('../../../out/todos/types');
+
+const NOW = '2026-07-24T00:00:00.000Z';
+
+function makeTodoData() {
+    return {
+        version: 1,
+        groups: [{ id: 'group-a', title: 'Work', collapsed: false, order: 0 }],
+        todos: [
+            {
+                id: 'todo-a',
+                groupId: 'group-a',
+                title: 'Write the slice',
+                notes: '',
+                priority: 'high',
+                completed: false,
+                createdAt: NOW,
+                updatedAt: NOW,
+                order: 0,
+            },
+            {
+                id: 'todo-b',
+                groupId: 'group-a',
+                title: 'Audit the slice',
+                notes: 'notes',
+                priority: 'medium',
+                completed: true,
+                createdAt: NOW,
+                updatedAt: NOW,
+                order: 1,
+            },
+        ],
+    };
+}
+
+function createFixture(overrides = {}) {
+    const posted = [];
+    const errors = [];
+    const warnings = [];
+    const prompts = [];
+    const service = {
+        data: makeTodoData(),
+        viewState: { showCompleted: false },
+        unsupportedVersionError: undefined,
+        calls: [],
+        getViewState() { return { ...this.viewState }; },
+        async setShowCompleted(value) {
+            this.calls.push(['setShowCompleted', value]);
+            this.viewState = { ...this.viewState, showCompleted: value };
+            return { ...this.viewState };
+        },
+        getData() { return this.data; },
+        getSearchItems: () => [],
+        getUnsupportedVersionError() { return this.unsupportedVersionError; },
+        async addTodo(input) { this.calls.push(['addTodo', input]); return this.data; },
+        async addGroup(title) { this.calls.push(['addGroup', title]); return this.data; },
+        async completeTodo(todoId, completed) { this.calls.push(['completeTodo', todoId, completed]); return this.data; },
+        async deleteTodo(todoId) { this.calls.push(['deleteTodo', todoId]); return this.data; },
+        async deleteGroup(groupId) { this.calls.push(['deleteGroup', groupId]); return this.data; },
+        async renameGroup(groupId, title) { this.calls.push(['renameGroup', groupId, title]); return this.data; },
+        async reorderGroups(groupIds) { this.calls.push(['reorderGroups', groupIds]); return this.data; },
+        async reorderTodos(groupId, todoIds) { this.calls.push(['reorderTodos', groupId, todoIds]); return this.data; },
+        async setGroupCollapsed(groupId, collapsed) {
+            this.calls.push(['setGroupCollapsed', groupId, collapsed]);
+            return this.data;
+        },
+        async setGroupsCollapsed(collapsed) { this.calls.push(['setGroupsCollapsed', collapsed]); return this.data; },
+        async sortGroupByPriority(groupId) { this.calls.push(['sortGroupByPriority', groupId]); return this.data; },
+        async revealTodo(todoId, groupId) {
+            this.calls.push(['revealTodo', todoId, groupId]);
+            return { revealed: true };
+        },
+        async updateTodo(todoId, patch) { this.calls.push(['updateTodo', todoId, patch]); return this.data; },
+    };
+    const capability = createTodoPanelCapability({
+        provider: { postMessage: async message => { posted.push(message); return true; } },
+        todoService: service,
+        getSearchCatalog: () => ({ version: 2, todos: [] }),
+        getConfiguration: () => overrides.configuration || { get: (_key, fallback) => fallback },
+        showInputBox: async options => {
+            prompts.push(options);
+            return overrides.inputBoxResponses ? overrides.inputBoxResponses.shift() : undefined;
+        },
+        showWarningMessage: async message => {
+            warnings.push(message);
+            return overrides.warningResponse;
+        },
+        showErrorMessage: async message => { errors.push(message); return undefined; },
+        logError: (message, error) => { errors.push(`${message} ${String(error)}`); },
+    });
+    return { capability, posted, service, errors, warnings, prompts };
+}
+
+test('TODO-TODO-COMMAND-CONTROLLER-001 exposes every production todo handler key', () => {
+    const { capability } = createFixture();
+
+    assert.deepEqual(Object.keys(capability.handlers), [
+        'request-todo-panel',
+        'todo-command',
+        'todo-add',
+        'todo-add-group',
+        'todo-toggle',
+        'todo-delete',
+        'todo-delete-group',
+        'todo-rename-group',
+        'todo-reorder-groups',
+        'todo-reorder-items',
+        'todo-collapse-group',
+        'todo-collapse-groups',
+        'todo-sort-priority',
+        'todo-toggle-show-completed',
+        'todo-reveal',
+        'todo-update',
+    ]);
+});
+
+test('TODO-TODO-COMMAND-CONTROLLER-001 routes versioned commands and attaches the search catalog', async () => {
+    const { capability, posted, service } = createFixture();
+
+    await capability.handlers['todo-command']({
+        type: 'todo-command',
+        version: 2,
+        requestId: 7,
+        action: 'show-completed',
+        payload: { showCompleted: true },
+    });
+
+    assert.equal(posted.length, 1);
+    assert.equal(posted[0].type, 'todo-command-result');
+    assert.equal(posted[0].requestId, 7);
+    assert.equal(posted[0].success, true);
+    assert.deepEqual(posted[0].searchCatalog, { version: 2, todos: [] });
+    assert.equal(posted[0].snapshot.showCompleted, true);
+    assert.deepEqual(service.calls, [['setShowCompleted', true]]);
+
+    await capability.handlers['todo-command']({ type: 'todo-command', version: 1 });
+    assert.equal(posted.length, 1, 'invalid command envelopes must not produce results');
+});
+
+test('TODO-DASHBOARD-TODO-MIGRATION-SEQUENCING-001 gates rendering and commands on the storage migration', async () => {
+    const { capability, posted } = createFixture();
+
+    let releaseMigration;
+    capability.setStorageMigrationReady(new Promise(resolve => { releaseMigration = resolve; }));
+
+    const pendingPanel = capability.handlers['request-todo-panel']({
+        type: 'request-todo-panel', version: 1, requestId: 1,
+    });
+    const pendingCommand = capability.handlers['todo-command']({
+        type: 'todo-command', version: 2, requestId: 1,
+        action: 'collapse-groups', payload: { collapsed: true },
+    });
+    await new Promise(resolve => setImmediate(resolve));
+    assert.equal(posted.length, 0, 'the render gate must hold panel posts while migration runs');
+
+    releaseMigration();
+    await Promise.all([pendingPanel, pendingCommand]);
+    assert.equal(posted.length, 2);
+    assert.equal(posted[0].type, 'todo-panel-content');
+    assert.equal(posted[0].requestId, 1);
+    assert.equal(posted[1].type, 'todo-command-result');
+
+    await capability.handlers['request-todo-panel']({ type: 'request-todo-panel', version: 2, requestId: 2 });
+    await capability.handlers['request-todo-panel']({ type: 'request-todo-panel', version: 1, requestId: 0 });
+    assert.equal(posted.length, 2, 'invalid panel requests must stay ignored');
+});
+
+test('TODO-FUTURE-VERSION-DASHBOARD-001 live-probes and recovers inside the capability panel post', async () => {
+    const { capability, posted, service } = createFixture();
+
+    service.unsupportedVersionError = new UnsupportedTodoDataVersionError(9);
+    await capability.handlers['request-todo-panel']({ type: 'request-todo-panel', version: 1, requestId: 1 });
+    assert.equal(posted.length, 1);
+    assert.match(posted[0].html, /data-todo-error="unsupported-version"/);
+    assert.match(posted[0].html, /unsupported version 9/);
+    assert.equal(posted[0].snapshot, undefined, 'unsupported panels must not carry a stale snapshot');
+
+    service.unsupportedVersionError = undefined;
+    await capability.handlers['request-todo-panel']({ type: 'request-todo-panel', version: 1, requestId: 2 });
+    assert.equal(posted.length, 2);
+    assert.doesNotMatch(posted[1].html, /data-todo-error="unsupported-version"/);
+    assert.match(posted[1].html, /class="todo-panel\b/);
+    assert.ok(posted[1].snapshot, 'a recovered panel projects a fresh snapshot');
+});
+
+test('TODO-MAX-VISIBLE-PER-GROUP-001 applies the configured per-group viewport and safe fallback', async () => {
+    const configured = createFixture({
+        configuration: { get: (key, fallback) => key === 'maxVisibleTodosPerGroup' ? 2.9 : fallback },
+    });
+    await configured.capability.handlers['request-todo-panel']({
+        type: 'request-todo-panel', version: 1, requestId: 1,
+    });
+    assert.match(configured.posted[0].html, /--todo-visible-items: 2;/);
+
+    const fallback = createFixture({
+        configuration: { get: (key, value) => key === 'maxVisibleTodosPerGroup' ? 0 : value },
+    });
+    await fallback.capability.handlers['request-todo-panel']({
+        type: 'request-todo-panel', version: 1, requestId: 1,
+    });
+    assert.match(fallback.posted[0].html, /--todo-visible-items: 5;/);
+});
+
+test('TODO-TODO-HOST-MUTATION-001 legacy handlers validate, mutate, and refresh through the error boundary', async () => {
+    const { capability, posted, service } = createFixture();
+
+    await capability.handlers['todo-toggle']({ todoId: 'todo-a', completed: true });
+    assert.deepEqual(service.calls, [['completeTodo', 'todo-a', true]]);
+    assert.equal(posted[0].type, 'todo-panel-updated');
+    assert.deepEqual(posted[0].searchCatalog, { version: 2, todos: [] });
+
+    await capability.handlers['todo-toggle']({ todoId: 42 });
+    assert.equal(service.calls.length, 1, 'non-string todo ids must be rejected');
+
+    await capability.handlers['todo-update']({ todoId: 'todo-a', title: 'Renamed', notes: 7, priority: 'low' });
+    assert.deepEqual(service.calls[1], ['updateTodo', 'todo-a', {
+        title: 'Renamed', notes: '', priority: 'low',
+    }]);
+
+    await capability.handlers['todo-reorder-groups']({ groupIds: ['group-a'] });
+    await capability.handlers['todo-reorder-items']({ groupId: 'group-a', todoIds: ['todo-b', 'todo-a'] });
+    await capability.handlers['todo-collapse-group']({ groupId: 'group-a', collapsed: true });
+    await capability.handlers['todo-collapse-groups']({ collapsed: false });
+    await capability.handlers['todo-sort-priority']({ groupId: 'group-a' });
+    assert.deepEqual(service.calls.slice(2), [
+        ['reorderGroups', ['group-a']],
+        ['reorderTodos', 'group-a', ['todo-b', 'todo-a']],
+        ['setGroupCollapsed', 'group-a', true],
+        ['setGroupsCollapsed', false],
+        ['sortGroupByPriority', 'group-a'],
+    ]);
+
+    await capability.handlers['todo-reorder-groups']({ groupIds: 'group-a' });
+    await capability.handlers['todo-reorder-items']({ groupId: 'group-a', todoIds: 'todo-a' });
+    await capability.handlers['todo-collapse-group']({ groupId: 7 });
+    await capability.handlers['todo-sort-priority']({});
+    await capability.handlers['todo-update']({ todoId: 'todo-a' });
+    assert.equal(service.calls.length, 7, 'malformed mutation envelopes must not reach the service');
+});
+
+test('TODO-TODO-HOST-MUTATION-001 compose add posts the request-correlated result and refresh', async () => {
+    const { capability, posted, service } = createFixture();
+
+    await capability.handlers['todo-add']({
+        type: 'todo-add', requestId: 3, title: '  ', notes: 'n', priority: 'urgent',
+    });
+    assert.equal(posted.length, 1);
+    assert.equal(posted[0].type, 'todo-mutation-result');
+    assert.equal(posted[0].success, false, 'blank titles must fail validation');
+    assert.equal(service.calls.length, 0);
+
+    await capability.handlers['todo-add']({
+        type: 'todo-add', requestId: 4, title: 'Ship it', notes: 'n', priority: 'high', groupId: 'group-a',
+    });
+    assert.deepEqual(service.calls, [['addTodo', {
+        title: 'Ship it', notes: 'n', priority: 'high', groupId: 'group-a',
+    }]]);
+    assert.equal(posted[1].type, 'todo-panel-updated', 'the panel refresh precedes the result post');
+    assert.equal(posted[2].type, 'todo-mutation-result');
+    assert.equal(posted[2].success, true);
+});
+
+test('TODO-TODO-HOST-MUTATION-001 prompt and confirmation flows mutate only after acceptance', async () => {
+    const { capability, posted, service, warnings } = createFixture({
+        inputBoxResponses: ['New group', 'Renamed group'],
+        warningResponse: 'Delete',
+    });
+
+    await capability.handlers['todo-add-group']({});
+    assert.deepEqual(service.calls, [['addGroup', 'New group']]);
+
+    await capability.handlers['todo-rename-group']({ groupId: 'group-a' });
+    assert.deepEqual(service.calls[1], ['renameGroup', 'group-a', 'Renamed group']);
+
+    await capability.handlers['todo-delete']({ todoId: 'todo-a' });
+    assert.deepEqual(service.calls[2], ['deleteTodo', 'todo-a']);
+    assert.match(warnings[0], /Delete TODO "Write the slice"\?/);
+
+    await capability.handlers['todo-delete-group']({ groupId: 'group-a' });
+    assert.deepEqual(service.calls[3], ['deleteGroup', 'group-a']);
+    assert.match(warnings[1], /Delete TODO group "Work" and all of its todos\?/);
+
+    assert.equal(
+        posted.filter(message => message.type === 'todo-panel-updated').length,
+        4,
+        'every accepted prompt/confirmation mutation refreshes the panel',
+    );
+});
+
+test('TODO-TODO-HOST-MUTATION-001 declined confirmations and cancelled prompts leave state untouched', async () => {
+    const { capability, service } = createFixture({
+        inputBoxResponses: [undefined, undefined],
+        warningResponse: undefined,
+    });
+
+    await capability.handlers['todo-add-group']({});
+    await capability.handlers['todo-rename-group']({ groupId: 'group-a' });
+    await capability.handlers['todo-delete']({ todoId: 'todo-a' });
+    await capability.handlers['todo-delete-group']({ groupId: 'group-a' });
+    await capability.handlers['todo-delete-group']({ groupId: 'missing' });
+    assert.equal(service.calls.length, 0);
+});
+
+test('TODO-TODO-HOST-MUTATION-001 reveal and completed toggles manage the temporary reveal target', async () => {
+    const { capability, posted, service } = createFixture();
+
+    await capability.handlers['todo-reveal']({ todoId: 'todo-b', groupId: 'group-a' });
+    assert.deepEqual(service.calls, [['revealTodo', 'todo-b', 'group-a']]);
+    assert.equal(posted[0].type, 'todo-panel-updated');
+    assert.equal(posted[0].snapshot.revealedTodoId, 'todo-b');
+
+    await capability.handlers['todo-toggle-show-completed']({ showCompleted: false });
+    assert.deepEqual(service.calls[1], ['setShowCompleted', false]);
+    assert.equal(posted[1].snapshot.revealedTodoId, undefined,
+        'an explicit completed toggle clears the temporary target after persistence');
+
+    await capability.handlers['todo-reveal']({ todoId: 'todo-a', groupId: 'group-a' });
+    assert.equal(posted[2].snapshot.revealedTodoId, 'todo-a');
+    await capability.handlers['todo-reveal']({ todoId: 'todo-a' });
+    assert.equal(posted.length, 3, 'missing group ids must reject before mutating');
+    assert.equal(service.calls.length, 3);
+});
+
+test('TODO-TODO-COMMAND-CONTROLLER-001 versioned commands see the cleared reveal target', async () => {
+    const { capability, posted } = createFixture();
+
+    await capability.handlers['todo-reveal']({ todoId: 'todo-b', groupId: 'group-a' });
+    await capability.handlers['todo-command']({
+        type: 'todo-command', version: 2, requestId: 9,
+        action: 'show-completed', payload: { showCompleted: false },
+    });
+    const result = posted.find(message => message.type === 'todo-command-result');
+    assert.equal(result.snapshot.revealedTodoId, undefined,
+        'the versioned show-completed path clears the temporary target');
+
+    capability.dispose();
+});

--- a/tests/integration/dashboard/helpers/todoPanelHarness.js
+++ b/tests/integration/dashboard/helpers/todoPanelHarness.js
@@ -8,6 +8,7 @@ const path = require('node:path');
 
 const root = path.resolve(__dirname, '../../../..');
 const dashboardPath = path.join(root, 'out/dashboard.js');
+const todoPanelCapabilityPath = path.join(root, 'out/todos/todoPanelCapability.js');
 
 function disposable(dispose = () => undefined) {
     return { dispose };
@@ -62,13 +63,17 @@ function createVscode(listeners, commands) {
     };
 }
 
-function loadDashboard(transform) {
-    const source = transform(fs.readFileSync(dashboardPath, 'utf8'));
-    const loaded = new Module(dashboardPath, module);
-    loaded.filename = dashboardPath;
-    loaded.paths = Module._nodeModulePaths(path.dirname(dashboardPath));
-    loaded._compile(source, dashboardPath);
+function loadTransformedModule(modulePath, transform) {
+    const source = transform(fs.readFileSync(modulePath, 'utf8'));
+    const loaded = new Module(modulePath, module);
+    loaded.filename = modulePath;
+    loaded.paths = Module._nodeModulePaths(path.dirname(modulePath));
+    loaded._compile(source, modulePath);
     return loaded.exports;
+}
+
+function loadDashboard(transform) {
+    return loadTransformedModule(dashboardPath, transform);
 }
 
 async function runTodoPanelContract(transform) {
@@ -85,6 +90,9 @@ async function runTodoPanelContract(transform) {
     };
     Module._load = function (request, parent, isMain) {
         if (request === 'vscode') return vscode;
+        if (request === './todos/todoPanelCapability') {
+            return loadTransformedModule(todoPanelCapabilityPath, transform);
+        }
         return previousLoad.call(this, request, parent, isMain);
     };
     const state = (synchronized = false) => ({

--- a/tests/integration/dashboard/todoContent.test.js
+++ b/tests/integration/dashboard/todoContent.test.js
@@ -23,6 +23,10 @@ const dashboardSource = fs.readFileSync(
     path.join(__dirname, '../../../src/dashboard.ts'),
     'utf8'
 );
+const todoPanelCapabilitySource = fs.readFileSync(
+    path.join(__dirname, '../../../src/todos/todoPanelCapability.ts'),
+    'utf8'
+);
 const packageJson = fs.readFileSync(
     path.join(__dirname, '../../../package.json'),
     'utf8'
@@ -103,11 +107,12 @@ test('TODO-MAX-VISIBLE-PER-GROUP-001 applies the configured per-group viewport a
         styles,
         /\.todo-item\.expanded\s*\{[\s\S]*height:\s*var\(--todo-expanded-item-height,\s*auto\) !important/
     );
-    assert.match(dashboardSource, /function getMaxVisibleTodosPerGroup\(/);
+    assert.match(todoPanelCapabilitySource, /function getMaxVisibleTodosPerGroup\(/);
     assert.match(
-        dashboardSource,
+        todoPanelCapabilitySource,
         /maxVisibleTodosPerGroup:\s*getMaxVisibleTodosPerGroup\(config\)/
     );
+    assert.match(dashboardSource, /createTodoPanelCapability\(\{/);
     assert.match(
         packageJson,
         /Maximum number of TODO cards visible in each group before the group list scrolls\./


### PR DESCRIPTION
## 内容

`initializeDashboard` 拆解的第一个 PR，三个切片，沿用 `conversationHandlers` / PR #65 status capability 的既定模式。**行为零变化**，每片都带独立行为契约测试。

### 切片 A：todo 面板（`src/todos/todoPanelCapability.ts`，309 行）

- 17 个消息处理器（`request-todo-panel`、`todo-command`、`todo-add` … `todo-update`）+ 渲染门控（`postTodoPanelContent`、迁移 ready 门、`revealedTodoId`）收进 `createTodoPanelCapability`
- 新行为契约测试 11 个（343 行）；相关源码文本断言按 PR #65 惯例改为「模块行为断言 + dashboard 接线断言」

### 切片 B：projects/groups 处理器组（`src/projects/projectMessageHandlers.ts`）

- `selected-project`…`favorite-project` + group 处理器 + `refreshAfterMutation` 等收进 `createProjectMessageHandlers(deps)`；处理器本就是薄委托，纯机械迁移
- 新契约测试 `tests/contract/projects/projectMessageHandlers.test.js`

### 切片 F：skill 面板（`src/skills/skillPanelCapability.ts`，480 行）

- 16 个消息处理器 + GlobalStoreLocation/SkillDashboard 两个控制器 + scope-action 结算管线 + 迁移流程收进 `createSkillPanelCapability`；对 dashboard 其他区域暴露只读门面（`getRecords`/`getPanelView`），6 处跨域消费原样保留
- `run-skill-management-checks.js` 的 16 处源码字面量断言全部改为「模块断言 + 接线断言」
- 新契约测试 10 个（结算去重、迁移流、破坏操作确认门、门面）

### 切片 C：runtime 结算队列（`src/aiSessions/runtimeSettlementCapability.ts`，229 行）

- `queueSettlements`（attention-key 合并、作用域/终态过滤）+ `runSafeLifecycleTask`（命名原因失败边界）+ 1s 完成态扫描（注入定时器，`startSettlementScan()` 保持原启动时点，避免构造顺序 TDZ）
- `runSafeAiSessionRuntimeLifecycleTask` 的 6 个外部调用点经一行别名原样保留；架构守卫（`ARCH-AI-SESSION-FALLBACK-REASON-001`）零改动通过
- 新契约测试 8 个：合并 drain、失败上报、去重、作用域/终态跳过、扫描节奏/幂等启动/dispose

### 结果

- **`src/dashboard.ts`：3331 → 2517 行**（−814，四个切片合计；main 基线 3331）
- 本地全量 `test:ci:linux` 绿（最新一轮 changed-line coverage 97.93%）
- 审计：A → `MAIN-TODO-CONTINUOUS-EXPERIENCE`，B → `MAIN-PROJECT-CATALOG-CONSISTENCY`，C → `MAIN-ATTENTION-LIFECYCLE-HARDENING`，F → `MAIN-AI-SKILL-MANAGEMENT`

### 明确没做

D/E（attention bridge、终端事件，耦合最深）——后续单独评估。
