### PR TITLE
refactor: split initProjects into composed dashboard project controllers

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -28,6 +28,7 @@ media/brand/**
 !media/webviewWorkspaceUpdateScripts.js
 !media/webviewTodoGroupScripts.js
 !media/webviewProjectCollapseScripts.js
+!media/webviewTodoControlScripts.js
 !media/webviewProjectScripts.js
 !media/webviewPromptScripts.js
 !media/webviewTodoScripts.js

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -27,6 +27,7 @@ media/brand/**
 !media/webviewAiSessionViewStateScripts.js
 !media/webviewWorkspaceUpdateScripts.js
 !media/webviewTodoGroupScripts.js
+!media/webviewProjectCollapseScripts.js
 !media/webviewProjectScripts.js
 !media/webviewPromptScripts.js
 !media/webviewTodoScripts.js

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -30,6 +30,7 @@ media/brand/**
 !media/webviewProjectCollapseScripts.js
 !media/webviewTodoControlScripts.js
 !media/webviewProjectContextMenuScripts.js
+!media/webviewProjectAiUpdateScripts.js
 !media/webviewProjectScripts.js
 !media/webviewPromptScripts.js
 !media/webviewTodoScripts.js

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -31,6 +31,7 @@ media/brand/**
 !media/webviewTodoControlScripts.js
 !media/webviewProjectContextMenuScripts.js
 !media/webviewProjectAiUpdateScripts.js
+!media/webviewProjectAiSessionControlsScripts.js
 !media/webviewProjectScripts.js
 !media/webviewPromptScripts.js
 !media/webviewTodoScripts.js

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -29,6 +29,7 @@ media/brand/**
 !media/webviewTodoGroupScripts.js
 !media/webviewProjectCollapseScripts.js
 !media/webviewTodoControlScripts.js
+!media/webviewProjectContextMenuScripts.js
 !media/webviewProjectScripts.js
 !media/webviewPromptScripts.js
 !media/webviewTodoScripts.js

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "a368f0ae82b18db920de3530809f720a2fc32664",
+        "head": "059af49ce010a4097ac1e4a847b7c7be430b7171",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -286,7 +286,10 @@
                 "d58a88f8ba490cc3c31651fc27fe0c587b8965c9",
                 "ed456da6b0979899eb2228da7d72fd6f64ed4382",
                 "e73abf28b07191d306b4846a416734053fea9c91",
-                "90ea1181c2d196959003c01aa17961f1243e69b3"
+                "90ea1181c2d196959003c01aa17961f1243e69b3",
+                "82bb63d5feb544cd0e2a5e8395453508d3c0564a",
+                "100fcee6ed4aba58f48003f4e12d3dbaafc1b256",
+                "e40efc402ddce538a3ac154290bac23a89a90ff7"
             ],
             "behaviors": [
                 "WEBVIEW-CURRENT-WORKSPACE-RENDERING-001",
@@ -528,7 +531,8 @@
                 "9e643c840db5ab634c1ef4815428617118b96ee7",
                 "6ef7ba4a0d078b6558ff16d99ed4ce13fd8a0cf4",
                 "905cdcd5c94a781e63764fb8d2eb766578601ddc",
-                "a368f0ae82b18db920de3530809f720a2fc32664"
+                "a368f0ae82b18db920de3530809f720a2fc32664",
+                "4c542b0ef8a20178800078181b129987f5aefb7b"
             ],
             "behaviors": [
                 "TODO-COMPLETION-INCREMENTAL-001",
@@ -726,7 +730,8 @@
                 "2bc4a8a330bc498ffafe5df92ed807b27e0b8e79",
                 "c97615cee3b2629102643cf3f4560f98201e49d4",
                 "f2a66bf31f9e478e1c66f7db4643d09bc3406aea",
-                "2b82dcf05ce93ddd73217a5309e4ed12464841f6"
+                "2b82dcf05ce93ddd73217a5309e4ed12464841f6",
+                "059af49ce010a4097ac1e4a847b7c7be430b7171"
             ],
             "behaviors": [
                 "RUNTIME-TMUX-BACKEND-001",

--- a/media/webviewProjectAiSessionControlsScripts.js
+++ b/media/webviewProjectAiSessionControlsScripts.js
@@ -1,0 +1,701 @@
+function initProjectAiSessionControls(options) {
+    'use strict';
+
+    options = options || {};
+    var getAiSessionsUpdate = options.getAiSessionsUpdate;
+    var updateStickyGroupHeaderOffset = options.updateStickyGroupHeaderOffset;
+
+    var batchAiSessionState = {
+        projectId: null,
+        selectedItems: new Map(),
+        pending: false,
+        requestId: null,
+    };
+    var activeAiSessionTerminalState = { provider: null, sessionId: null };
+    var nextAiSessionBatchArchiveRequestId = 0;
+    var nextAiSessionProviderSelectionRequestId = 0;
+    var pendingAiSessionProviderSelectionProjectId = null;
+    var pendingAiSessionProviderSelectionRequestId = null;
+    var pendingAiSessionProviderSelectionProviders = [];
+
+    function getAiSessionBatchItemKey(provider, sessionId) {
+        return JSON.stringify([provider, sessionId]);
+    }
+
+    function enter(projectId) {
+        if (batchAiSessionState.pending)
+            return;
+        batchAiSessionState.projectId = projectId;
+        batchAiSessionState.selectedItems = new Map();
+        batchAiSessionState.pending = false;
+        batchAiSessionState.requestId = null;
+    }
+
+    function toggle(provider, sessionId, active) {
+        if (!isAiSessionProvider(provider) || !sessionId || active || batchAiSessionState.pending)
+            return;
+        var key = getAiSessionBatchItemKey(provider, sessionId);
+        if (batchAiSessionState.selectedItems.has(key))
+            batchAiSessionState.selectedItems.delete(key);
+        else
+            batchAiSessionState.selectedItems.set(key, { provider, sessionId });
+    }
+
+    function selectUnpinned(sessions) {
+        if (batchAiSessionState.pending)
+            return;
+        sessions
+            .filter(session => isAiSessionProvider(session.provider)
+                && session.id && !session.pinned && !session.active)
+            .forEach(session => {
+                var item = { provider: session.provider, sessionId: session.id };
+                batchAiSessionState.selectedItems.set(
+                    getAiSessionBatchItemKey(item.provider, item.sessionId),
+                    item
+                );
+            });
+    }
+
+    function clear() {
+        if (!batchAiSessionState.pending)
+            batchAiSessionState.selectedItems.clear();
+    }
+
+    function reconcile(projectId, remainingItems) {
+        if (projectId !== batchAiSessionState.projectId) {
+            exit();
+            return;
+        }
+        let selectedItems = batchAiSessionState.selectedItems;
+        batchAiSessionState.selectedItems = new Map(
+            remainingItems
+                .filter(item => item && isAiSessionProvider(item.provider) && item.sessionId)
+                .map(item => {
+                    var key = getAiSessionBatchItemKey(item.provider, item.sessionId);
+                    return [key, selectedItems.get(key)];
+                })
+                .filter(entry => entry[1])
+        );
+    }
+
+    function reconcileVisible(projectDiv) {
+        if (!projectDiv)
+            return;
+        var projectId = projectDiv.getAttribute('data-id');
+        var remainingItems = Array.from(
+            projectDiv.querySelectorAll('.ai-session-history-panel .codex-session-row[data-session-id]')
+        )
+            .filter(row => isAiSessionProvider(row.getAttribute('data-session-provider') || 'codex')
+                && row.getAttribute('data-session-id')
+                && !row.hasAttribute('data-session-active'))
+            .map(row => ({
+                provider: row.getAttribute('data-session-provider') || 'codex',
+                sessionId: row.getAttribute('data-session-id'),
+            }));
+        reconcile(projectId, remainingItems);
+    }
+
+    function submit() {
+        if (batchAiSessionState.pending || !batchAiSessionState.selectedItems.size)
+            return;
+        nextAiSessionBatchArchiveRequestId = nextAiSessionBatchArchiveRequestId >= Number.MAX_SAFE_INTEGER
+            ? 1
+            : nextAiSessionBatchArchiveRequestId + 1;
+        var requestId = nextAiSessionBatchArchiveRequestId;
+        batchAiSessionState.pending = true;
+        batchAiSessionState.requestId = requestId;
+        window.vscode.postMessage({
+            type: 'archive-ai-sessions',
+            version: 1,
+            requestId: requestId,
+            projectId: batchAiSessionState.projectId,
+            items: Array.from(batchAiSessionState.selectedItems.values()),
+        });
+    }
+
+    function complete(message) {
+        if (!message
+            || message.type !== 'ai-session-batch-archive-completed'
+            || message.version !== 1
+            || !Number.isSafeInteger(message.requestId)
+            || message.requestId < 1
+            || typeof message.projectId !== 'string'
+            || !['cancelled', 'rejected', 'finished'].includes(message.status)
+            || !batchAiSessionState.pending
+            || message.projectId !== batchAiSessionState.projectId
+            || message.requestId !== batchAiSessionState.requestId) {
+            return false;
+        }
+        if (message.status === 'finished') {
+            exit();
+            return true;
+        }
+        batchAiSessionState.pending = false;
+        batchAiSessionState.requestId = null;
+        return true;
+    }
+
+    function exit() {
+        batchAiSessionState.projectId = null;
+        batchAiSessionState.selectedItems = new Map();
+        batchAiSessionState.pending = false;
+        batchAiSessionState.requestId = null;
+    }
+
+    function snapshot() {
+        return {
+            projectId: batchAiSessionState.projectId,
+            selectedItems: Array.from(batchAiSessionState.selectedItems.values()),
+            pending: batchAiSessionState.pending,
+        };
+    }
+
+    var batchAiSessionManager = {
+        enter, toggle, selectUnpinned, clear, reconcile, reconcileVisible,
+        submit, complete, exit, snapshot,
+    };
+    window.__agentPivotBatchAiSessions = batchAiSessionManager;
+
+    function onTriggerAiSessionAction(target, projectId) {
+        var projectDiv = target.closest('.project[data-id]');
+        var tabAction = target.closest('[data-action="select-ai-session-tab"][data-tab]');
+        if (tabAction) {
+            var selectedTab = normalizeAiSessionTab(tabAction.getAttribute('data-tab'));
+            selectAiSessionTabDom(projectDiv, selectedTab);
+            writeAiSessionTabState(window.vscode, projectId, selectedTab);
+            return true;
+        }
+
+        var providerMenuTrigger = target.closest('[data-ai-provider-menu-trigger]');
+        if (providerMenuTrigger) {
+            toggleAiSessionProviderMenu(projectDiv);
+            return true;
+        }
+
+        var providerOption = target.closest('[data-ai-provider-option][data-provider]');
+        if (providerOption) {
+            activateAiSessionProviderOption(projectDiv, providerOption);
+            return true;
+        }
+
+        var createAction = target.closest('[data-action="create-ai-session"]');
+        if (createAction) {
+            window.vscode.postMessage({
+                type: 'create-ai-session',
+                projectId,
+            });
+
+            return true;
+        }
+
+        var manageAction = target.closest('[data-action="manage-ai-sessions"][data-provider]');
+        if (manageAction) {
+            if (batchAiSessionState.pending
+                || pendingAiSessionProviderSelectionProjectId)
+                return true;
+
+            var manageProvider = manageAction.getAttribute("data-provider");
+            if (projectDiv && isAiSessionProvider(manageProvider)) {
+                if (isActiveAiSessionBatchScope(projectId, manageProvider)) {
+                    exitAiSessionBatchManagement();
+                } else {
+                    batchAiSessionManager.enter(projectId);
+                    syncAiSessionBatchManagementDom(projectDiv);
+                }
+            }
+
+            return true;
+        }
+
+        var selectUnpinnedAction = target.closest('[data-action="select-unpinned-ai-sessions"]');
+        if (selectUnpinnedAction) {
+            if (isActiveAiSessionBatchScope(projectId, getProjectActiveAiSessionProvider(projectDiv))) {
+                var sessions = Array.from(projectDiv.querySelectorAll('.ai-session-history-panel .codex-session-row[data-session-id]'))
+                    .map(row => ({
+                        provider: row.getAttribute("data-session-provider") || "codex",
+                        id: row.getAttribute("data-session-id"),
+                        pinned: row.hasAttribute("data-session-pinned"),
+                        active: row.hasAttribute("data-session-active"),
+                    }));
+                batchAiSessionManager.selectUnpinned(sessions);
+                syncAiSessionBatchManagementDom(projectDiv);
+            }
+
+            return true;
+        }
+
+        var clearSelectionAction = target.closest('[data-action="clear-ai-session-selection"]');
+        if (clearSelectionAction) {
+            if (isActiveAiSessionBatchScope(projectId, getProjectActiveAiSessionProvider(projectDiv))) {
+                batchAiSessionManager.clear();
+                syncAiSessionBatchManagementDom(projectDiv);
+            }
+
+            return true;
+        }
+
+        var archiveSelectedAction = target.closest('[data-action="archive-selected-ai-sessions"]');
+        if (archiveSelectedAction) {
+            if (isActiveAiSessionBatchScope(projectId, getProjectActiveAiSessionProvider(projectDiv))) {
+                batchAiSessionManager.submit();
+                syncAiSessionBatchManagementDom(projectDiv);
+            }
+
+            return true;
+        }
+
+        var terminalAction = target.closest('[data-action="close-ai-session-terminal"], [data-action="detach-ai-session-terminal"]');
+        if (terminalAction) {
+            var terminalRow = terminalAction.closest('.codex-session-row[data-session-provider][data-session-backend]');
+            var terminalProvider = terminalRow && terminalRow.getAttribute('data-session-provider');
+            var terminalBackend = terminalRow && terminalRow.getAttribute('data-session-backend');
+            var requestedDetach = terminalAction.getAttribute('data-action') === 'detach-ai-session-terminal';
+            if (terminalRow && isAiSessionProvider(terminalProvider)
+                && ((requestedDetach && terminalBackend === 'tmux')
+                    || (!requestedDetach && terminalBackend === 'vscode'))) {
+                var terminalMessage = {
+                    type: requestedDetach ? 'detach-ai-session-terminal' : 'close-ai-session-terminal',
+                    projectId,
+                    provider: terminalProvider,
+                };
+                if (terminalRow.hasAttribute('data-session-pending')) {
+                    terminalMessage.pendingCreatedAt = terminalRow.getAttribute('data-pending-created-at');
+                } else {
+                    terminalMessage.sessionId = terminalRow.getAttribute('data-session-id');
+                }
+                window.vscode.postMessage(terminalMessage);
+            }
+            return true;
+        }
+
+        var managedSessionRow = target.closest('.codex-session-row[data-session-id]');
+        if (managedSessionRow) {
+            var managedSessionProvider = managedSessionRow.getAttribute("data-session-provider") || "codex";
+            if (isActiveAiSessionBatchScope(projectId, managedSessionProvider)
+                && !managedSessionRow.hasAttribute('data-session-active')) {
+                batchAiSessionManager.toggle(
+                    managedSessionProvider,
+                    managedSessionRow.getAttribute("data-session-id"),
+                    managedSessionRow.hasAttribute('data-session-active')
+                );
+                syncAiSessionBatchManagementDom(projectDiv);
+                return true;
+            }
+        }
+
+        var pinAction = target.closest('[data-action="toggle-ai-session-pin"]');
+        if (pinAction) {
+            var pinRow = pinAction.closest('.codex-session-row[data-session-id]');
+            var pinSessionId = pinRow && pinRow.getAttribute("data-session-id");
+            var pinProvider = pinRow && pinRow.getAttribute("data-session-provider") || "codex";
+            if (pinSessionId) {
+                window.vscode.postMessage({
+                    type: 'toggle-ai-session-pin',
+                    projectId,
+                    provider: pinProvider,
+                    sessionId: pinSessionId,
+                });
+            }
+
+            return true;
+        }
+
+        var archiveAction = target.closest('[data-action="archive-codex-session"], [data-action="archive-kimi-session"], [data-action="archive-claude-session"]');
+        if (archiveAction) {
+            var archiveRow = archiveAction.closest('.codex-session-row[data-session-id]');
+            var archiveSessionId = archiveRow && archiveRow.getAttribute("data-session-id");
+            var archiveProvider = archiveRow && archiveRow.getAttribute("data-session-provider") || "codex";
+            if (archiveSessionId && isAiSessionProvider(archiveProvider)) {
+                acknowledgeAiSessionRow(archiveRow);
+                window.vscode.postMessage({
+                    type: getArchiveAiSessionMessageType(archiveProvider),
+                    projectId,
+                    sessionId: archiveSessionId,
+                });
+            }
+
+            return true;
+        }
+
+        var activation = getAiSessionCardActivation(target, projectId);
+        if (!activation.handled)
+            return false;
+        if (activation.sessionRow
+            && !activation.sessionRow.hasAttribute('data-session-pending')
+            && activation.sessionRow.getAttribute('data-session-id')) {
+            acknowledgeAiSessionRow(activation.sessionRow);
+        }
+        if (activation.message) {
+            window.vscode.postMessage(activation.message);
+        }
+        return true;
+    }
+
+    function acknowledgeAiSessionRow(sessionRow) {
+        if (!sessionRow || !sessionRow.hasAttribute('data-ai-session-attention')) return;
+        var provider = sessionRow.getAttribute('data-session-provider') || 'codex';
+        var sessionId = sessionRow.getAttribute('data-session-id') || '';
+        var fallback = sessionRow.getAttribute('data-session-event-id') || sessionRow.getAttribute('data-ai-session-event-id');
+        acknowledgeAiSession(provider, sessionId, fallback);
+    }
+
+    function acknowledgeAiSession(provider, sessionId, fallbackEventId) {
+        var sessionKey = provider + ':' + sessionId;
+        window.__agentPivotAttentionSessionEvents = window.__agentPivotAttentionSessionEvents || {};
+        var eventIds = window.__agentPivotAttentionSessionEvents[sessionKey] || [];
+        if (!eventIds.length && fallbackEventId) {
+            eventIds = [fallbackEventId];
+        }
+        eventIds = Array.from(new Set(eventIds.filter(eventId => typeof eventId === 'string' && !!eventId)));
+        if (eventIds.length) {
+            window.vscode.postMessage({ type: 'acknowledge-ai-session-attention', eventIds: eventIds });
+        }
+    }
+
+    window.__agentPivotAcknowledgeSession = (provider, sessionId) => {
+        if (isAiSessionProvider(provider) && sessionId) {
+            acknowledgeAiSession(provider, sessionId);
+        }
+    };
+
+    function getSelectedAiSessionProviders(projectDiv) {
+        var region = projectDiv && projectDiv.querySelector('[data-ai-session-region]');
+        return (region && region.getAttribute('data-selected-ai-session-providers') || '')
+            .split(',')
+            .filter(isAiSessionProvider);
+    }
+
+    function submitAiSessionProviderSelection(projectDiv, providers) {
+        var projectId = projectDiv && projectDiv.getAttribute('data-id');
+        if (!projectId || !providers.length || batchAiSessionState.pending
+            || pendingAiSessionProviderSelectionProjectId)
+            return;
+
+        exitAiSessionBatchManagement();
+        nextAiSessionProviderSelectionRequestId += 1;
+        var requestId = nextAiSessionProviderSelectionRequestId;
+        pendingAiSessionProviderSelectionProjectId = projectId;
+        pendingAiSessionProviderSelectionRequestId = requestId;
+        pendingAiSessionProviderSelectionProviders = providers.slice();
+        syncAiSessionProviderMenuDisabledDom(projectDiv, true);
+        window.vscode.postMessage({
+            type: 'select-ai-session-providers',
+            version: 1,
+            requestId: requestId,
+            projectId,
+            selectedProviders: providers,
+        });
+    }
+
+    function setAiSessionProviderMenuOpen(projectDiv, open) {
+        var trigger = projectDiv && projectDiv.querySelector('[data-ai-provider-menu-trigger]');
+        var menu = projectDiv && projectDiv.querySelector('[data-ai-provider-menu]');
+        if (!trigger || !menu)
+            return;
+        if (open && (batchAiSessionState.pending
+            || pendingAiSessionProviderSelectionProjectId))
+            return;
+
+        trigger.setAttribute('aria-expanded', open ? 'true' : 'false');
+        menu.hidden = !open;
+    }
+
+    function closeAiSessionProviderMenus(exceptProjectDiv) {
+        document.querySelectorAll('.project[data-id]').forEach(projectDiv => {
+            if (projectDiv !== exceptProjectDiv) {
+                setAiSessionProviderMenuOpen(projectDiv, false);
+            }
+        });
+    }
+
+    function closeAiSessionProviderMenu(projectDiv, restoreFocus) {
+        setAiSessionProviderMenuOpen(projectDiv, false);
+        if (restoreFocus) {
+            projectDiv?.querySelector('[data-ai-provider-menu-trigger]')?.focus();
+        }
+    }
+
+    function toggleAiSessionProviderMenu(projectDiv) {
+        if (!projectDiv || batchAiSessionState.pending
+            || pendingAiSessionProviderSelectionProjectId)
+            return;
+        var trigger = projectDiv.querySelector('[data-ai-provider-menu-trigger]');
+        var open = trigger?.getAttribute('aria-expanded') !== 'true';
+        closeAiSessionProviderMenus(projectDiv);
+        setAiSessionProviderMenuOpen(projectDiv, open);
+    }
+
+    function activateAiSessionProviderOption(projectDiv, option) {
+        if (!projectDiv || !option || batchAiSessionState.pending
+            || pendingAiSessionProviderSelectionProjectId)
+            return;
+        var provider = option.getAttribute('data-provider');
+        if (!isAiSessionProvider(provider))
+            return;
+        var selectedProviders = getSelectedAiSessionProviders(projectDiv);
+        var selected = selectedProviders.includes(provider);
+        if (selected && selectedProviders.length === 1)
+            return;
+        submitAiSessionProviderSelection(
+            projectDiv,
+            selected
+                ? selectedProviders.filter(candidate => candidate !== provider)
+                : selectedProviders.concat(provider)
+        );
+    }
+
+    function getAiSessionProviderOptions(projectDiv) {
+        return projectDiv
+            ? Array.from(projectDiv.querySelectorAll('[data-ai-provider-option][data-provider]'))
+            : [];
+    }
+
+    function isAiSessionProvider(provider) {
+        return provider === "codex" || provider === "kimi" || provider === "claude";
+    }
+
+    function getResumeAiSessionMessageType(provider) {
+        if (provider === "kimi")
+            return 'resume-kimi-session';
+        if (provider === "claude")
+            return 'resume-claude-session';
+
+        return 'resume-codex-session';
+    }
+
+    function getArchiveAiSessionMessageType(provider) {
+        if (provider === "kimi")
+            return 'archive-kimi-session';
+        if (provider === "claude")
+            return 'archive-claude-session';
+
+        return 'archive-codex-session';
+    }
+
+    function toggleCodexSessions(projectDiv, projectId) {
+        var expanded = !projectDiv.hasAttribute("data-codex-expanded");
+        if (!expanded && batchAiSessionState.projectId === projectId) {
+            exitAiSessionBatchManagement();
+        }
+        projectDiv.toggleAttribute("data-codex-expanded", expanded);
+        updateStickyGroupHeaderOffset();
+
+        window.vscode.postMessage({
+            type: 'toggle-codex-sessions',
+            projectId,
+            expanded,
+        });
+    }
+
+    function isActiveAiSessionBatchScope(projectId) {
+        return projectId === batchAiSessionState.projectId;
+    }
+
+    function getProjectActiveAiSessionProvider(projectDiv) {
+        if (!projectDiv)
+            return null;
+
+        var region = projectDiv.querySelector('[data-ai-session-region]');
+        var activeProvider = region && region.getAttribute('data-active-ai-session-provider');
+        if (isAiSessionProvider(activeProvider))
+            return activeProvider;
+
+        var selectedProviders = region && region.getAttribute('data-selected-ai-session-providers') || '';
+        return selectedProviders.split(',').find(isAiSessionProvider) || null;
+    }
+
+    function syncActiveAiSessionTerminalDom() {
+        document.querySelectorAll('.codex-session-row[data-session-id]').forEach(row => {
+            var provider = row.getAttribute('data-session-provider') || 'codex';
+            var sessionId = row.getAttribute('data-session-id');
+            row.toggleAttribute(
+                'data-ai-session-active-terminal',
+                provider === activeAiSessionTerminalState.provider
+                    && sessionId === activeAiSessionTerminalState.sessionId
+            );
+        });
+    }
+
+    function syncAiSessionBatchManagementDom(projectDiv) {
+        var snapshot = batchAiSessionManager.snapshot();
+        document.querySelectorAll('.project[data-ai-session-managing], .project[data-ai-session-pending]').forEach(project => {
+            if (project !== projectDiv || project.getAttribute("data-id") !== snapshot.projectId) {
+                project.removeAttribute("data-ai-session-managing");
+                project.removeAttribute("data-ai-session-pending");
+                syncAiSessionProviderMenuDisabledDom(project, false);
+                var inactiveManageButton = project.querySelector('[data-action="manage-ai-sessions"]');
+                if (inactiveManageButton) {
+                    inactiveManageButton.setAttribute('aria-pressed', 'false');
+                    inactiveManageButton.disabled = false;
+                }
+            }
+        });
+
+        if (!projectDiv)
+            return;
+
+        var projectId = projectDiv.getAttribute("data-id");
+        var isScoped = projectId === snapshot.projectId;
+        projectDiv.toggleAttribute("data-ai-session-managing", isScoped);
+        projectDiv.toggleAttribute("data-ai-session-pending", isScoped && snapshot.pending);
+        syncAiSessionProviderMenuDisabledDom(projectDiv, isScoped && snapshot.pending);
+        var manageButton = projectDiv.querySelector('[data-action="manage-ai-sessions"]');
+        if (manageButton) {
+            manageButton.setAttribute('aria-pressed', isScoped ? 'true' : 'false');
+            manageButton.disabled = isScoped && snapshot.pending;
+        }
+
+        var selectedItems = new Set(snapshot.selectedItems.map(item =>
+            getAiSessionBatchItemKey(item.provider, item.sessionId)
+        ));
+        projectDiv.querySelectorAll('.ai-session-history-panel .codex-session-row[data-session-id]').forEach(row => {
+            var rowProvider = row.getAttribute("data-session-provider") || "codex";
+            var isActive = row.hasAttribute('data-session-active');
+            var isSelected = isScoped
+                && !isActive
+                && selectedItems.has(getAiSessionBatchItemKey(
+                    rowProvider,
+                    row.getAttribute("data-session-id")
+                ));
+            row.toggleAttribute("data-ai-session-selected", isSelected);
+            var checkbox = row.querySelector('.ai-session-batch-checkbox');
+            if (checkbox) {
+                checkbox.checked = isSelected;
+                checkbox.disabled = isActive || (isScoped && snapshot.pending);
+            }
+        });
+
+        var count = isScoped ? snapshot.selectedItems.length : 0;
+        var countElement = projectDiv.querySelector('.ai-session-batch-count');
+        if (countElement) {
+            countElement.textContent = count + ' selected';
+        }
+        projectDiv.querySelectorAll('.ai-session-batch-actions button').forEach(button => {
+            button.disabled = isScoped && snapshot.pending;
+        });
+        var archiveButton = projectDiv.querySelector('[data-action="archive-selected-ai-sessions"]');
+        if (archiveButton) {
+            archiveButton.disabled = !isScoped || snapshot.pending || count === 0;
+        }
+    }
+
+    function syncAiSessionProviderMenuDisabledDom(projectDiv, batchPending) {
+        var projectId = projectDiv?.getAttribute('data-id');
+        var providerSelectionPending = projectId
+            === pendingAiSessionProviderSelectionProjectId;
+        var pending = Boolean(
+            batchPending || batchAiSessionState.pending || providerSelectionPending
+        );
+        var trigger = projectDiv && projectDiv.querySelector('[data-ai-provider-menu-trigger]');
+        if (trigger) {
+            trigger.disabled = pending;
+            trigger.setAttribute('aria-disabled', pending ? 'true' : 'false');
+        }
+        var selectedProviders = getSelectedAiSessionProviders(projectDiv);
+        getAiSessionProviderOptions(projectDiv).forEach(option => {
+            var provider = option.getAttribute('data-provider');
+            var lastSelectedProvider = selectedProviders.length === 1
+                && selectedProviders[0] === provider;
+            option.disabled = pending;
+            option.setAttribute(
+                'aria-disabled',
+                pending || lastSelectedProvider ? 'true' : 'false'
+            );
+        });
+        if (pending) {
+            closeAiSessionProviderMenu(projectDiv, false);
+        }
+    }
+
+    function clearPendingAiSessionProviderSelection() {
+        pendingAiSessionProviderSelectionProjectId = null;
+        pendingAiSessionProviderSelectionRequestId = null;
+        pendingAiSessionProviderSelectionProviders = [];
+    }
+
+    function selectedAiSessionProvidersMatch(projectDiv, expectedProviders) {
+        var selectedProviders = getSelectedAiSessionProviders(projectDiv);
+        return selectedProviders.length === expectedProviders.length
+            && selectedProviders.every(provider =>
+                expectedProviders.includes(provider)
+            );
+    }
+
+    function reconcilePendingAiSessionProviderSelectionDom() {
+        if (!pendingAiSessionProviderSelectionProjectId)
+            return;
+        var projectDiv = getAiSessionsUpdate().findCurrentWorkspaceDiv(
+            pendingAiSessionProviderSelectionProjectId
+        );
+        if (!projectDiv)
+            return;
+        if (selectedAiSessionProvidersMatch(
+            projectDiv,
+            pendingAiSessionProviderSelectionProviders
+        )) {
+            clearPendingAiSessionProviderSelection();
+        }
+        syncAiSessionProviderMenuDisabledDom(projectDiv, false);
+    }
+
+    function applyAiSessionProviderSelectionResult(message) {
+        if (!message
+            || message.type !== 'ai-session-provider-selection-result'
+            || message.version !== 1
+            || !Number.isSafeInteger(message.requestId)
+            || message.requestId < 1
+            || typeof message.projectId !== 'string'
+            || typeof message.success !== 'boolean'
+            || message.projectId !== pendingAiSessionProviderSelectionProjectId
+            || message.requestId !== pendingAiSessionProviderSelectionRequestId) {
+            return false;
+        }
+        if (message.success) {
+            return true;
+        }
+
+        var projectDiv = getAiSessionsUpdate().findCurrentWorkspaceDiv(message.projectId);
+        clearPendingAiSessionProviderSelection();
+        syncAiSessionProviderMenuDisabledDom(projectDiv, false);
+        var liveRegion = projectDiv?.querySelector('[data-ai-session-live-region]');
+        if (liveRegion) {
+            liveRegion.textContent = 'Could not update AI session providers. Try again.';
+        }
+        return true;
+    }
+
+    function exitAiSessionBatchManagement() {
+        var projectId = batchAiSessionState.projectId;
+        batchAiSessionManager.exit();
+        syncAiSessionBatchManagementDom(getAiSessionsUpdate().findCurrentWorkspaceDiv(projectId));
+    }
+
+    function getPendingAiSessionProviderSelectionProjectId() {
+        return pendingAiSessionProviderSelectionProjectId;
+    }
+
+    return {
+        batchAiSessionManager: batchAiSessionManager,
+        batchAiSessionState: batchAiSessionState,
+        activeAiSessionTerminalState: activeAiSessionTerminalState,
+        getPendingAiSessionProviderSelectionProjectId: getPendingAiSessionProviderSelectionProjectId,
+        activateAiSessionProviderOption: activateAiSessionProviderOption,
+        applyAiSessionProviderSelectionResult: applyAiSessionProviderSelectionResult,
+        closeAiSessionProviderMenu: closeAiSessionProviderMenu,
+        closeAiSessionProviderMenus: closeAiSessionProviderMenus,
+        exitAiSessionBatchManagement: exitAiSessionBatchManagement,
+        getAiSessionProviderOptions: getAiSessionProviderOptions,
+        getArchiveAiSessionMessageType: getArchiveAiSessionMessageType,
+        getResumeAiSessionMessageType: getResumeAiSessionMessageType,
+        getSelectedAiSessionProviders: getSelectedAiSessionProviders,
+        isAiSessionProvider: isAiSessionProvider,
+        onTriggerAiSessionAction: onTriggerAiSessionAction,
+        reconcilePendingAiSessionProviderSelectionDom: reconcilePendingAiSessionProviderSelectionDom,
+        setAiSessionProviderMenuOpen: setAiSessionProviderMenuOpen,
+        submitAiSessionProviderSelection: submitAiSessionProviderSelection,
+        syncActiveAiSessionTerminalDom: syncActiveAiSessionTerminalDom,
+        syncAiSessionBatchManagementDom: syncAiSessionBatchManagementDom,
+        toggleAiSessionProviderMenu: toggleAiSessionProviderMenu,
+        toggleCodexSessions: toggleCodexSessions,
+    };
+}

--- a/media/webviewProjectAiUpdateScripts.js
+++ b/media/webviewProjectAiUpdateScripts.js
@@ -1,0 +1,176 @@
+function initProjectAiSessionsUpdate(options) {
+    'use strict';
+
+    options = options || {};
+    var batchAiSessionState = options.batchAiSessionState;
+    var batchAiSessionManager = options.batchAiSessionManager;
+    var getPendingAiSessionProviderSelectionProjectId = options.getPendingAiSessionProviderSelectionProjectId;
+    var getSelectedAiSessionProviders = options.getSelectedAiSessionProviders;
+    var syncAiSessionBatchManagementDom = options.syncAiSessionBatchManagementDom;
+    var syncActiveAiSessionTerminalDom = options.syncActiveAiSessionTerminalDom;
+    var reconcilePendingAiSessionProviderSelectionDom = options.reconcilePendingAiSessionProviderSelectionDom;
+    var submitAiSessionProviderSelection = options.submitAiSessionProviderSelection;
+    var toggleCodexSessions = options.toggleCodexSessions;
+    var exitAiSessionBatchManagement = options.exitAiSessionBatchManagement;
+    var isAiSessionProvider = options.isAiSessionProvider;
+    var updateStickyGroupHeaderOffset = options.updateStickyGroupHeaderOffset;
+
+    var pendingWorkspaceSessionReveal = null;
+    var latestAiSessionUpdateSequence = 0;
+
+    function applyAiSessionsUpdate(message) {
+        if (message.version !== 2
+            || typeof message.sequence !== 'number'
+            || (message.currentWorkspaceCount !== 0 && message.currentWorkspaceCount !== 1)
+            || typeof message.html !== 'string'
+            || typeof normalizeDashboardSearchCatalog !== 'function'
+            || normalizeDashboardSearchCatalog(message.searchCatalog) !== message.searchCatalog
+            || message.searchCatalog.version !== 2) {
+            requestFullRefresh('unsupported-ai-session-message');
+            return;
+        }
+
+        if (message.sequence <= latestAiSessionUpdateSequence) {
+            return;
+        }
+
+        if (!applyWorkspaceUpdate({
+            type: 'workspace-updated',
+            version: 2,
+            currentWorkspaceCount: message.currentWorkspaceCount,
+            html: message.html,
+        }, {
+            canRestoreAiSessionProviderMenu: () =>
+                !getPendingAiSessionProviderSelectionProjectId()
+                && !batchAiSessionState.pending,
+        })) {
+            requestFullRefresh('invalid-ai-session-workspace-update');
+            return;
+        }
+
+        latestAiSessionUpdateSequence = message.sequence;
+        if (batchAiSessionState.projectId) {
+            var projectDiv = findCurrentWorkspaceDiv(batchAiSessionState.projectId);
+            if (projectDiv) {
+                batchAiSessionManager.reconcileVisible(projectDiv);
+                syncAiSessionBatchManagementDom(projectDiv);
+            } else {
+                exitAiSessionBatchManagement();
+            }
+        }
+        reconcilePendingAiSessionProviderSelectionDom();
+        syncActiveAiSessionTerminalDom();
+        updateStickyGroupHeaderOffset();
+        if (window.__agentPivotDashboard) {
+            window.__agentPivotDashboard.replaceSearchCatalog(message.searchCatalog);
+        }
+    }
+
+    function findCurrentWorkspaceDiv(projectId) {
+        if (!projectId) {
+            return null;
+        }
+
+        var projects = document.querySelectorAll('.workspace-card[data-current-workspace][data-id]');
+        for (var projectDiv of projects) {
+            if (projectDiv.getAttribute("data-id") === projectId) {
+                return projectDiv;
+            }
+        }
+
+        return null;
+    }
+
+    function findWorkspaceDiv(navigationIdentity) {
+        if (!navigationIdentity) {
+            return null;
+        }
+        var workspaces = document.querySelectorAll('.workspace-card[data-workspace-navigation-identity]');
+        for (var workspaceDiv of workspaces) {
+            if (workspaceDiv.getAttribute('data-workspace-navigation-identity') === navigationIdentity) {
+                return workspaceDiv;
+            }
+        }
+        return null;
+    }
+
+    function focusSearchRevealTarget(target) {
+        target.setAttribute('tabindex', '-1');
+        target.focus();
+        target.scrollIntoView({ block: 'nearest' });
+        target.addEventListener('blur', () => target.removeAttribute('tabindex'), { once: true });
+    }
+
+    window.__agentPivotRevealWorkspace = navigationIdentity => {
+        var workspaceDiv = findWorkspaceDiv(navigationIdentity);
+        if (!workspaceDiv) {
+            return false;
+        }
+        focusSearchRevealTarget(workspaceDiv);
+        return true;
+    };
+
+    function revealWorkspaceSession(navigationIdentity, provider, sessionId) {
+        if (!isAiSessionProvider(provider) || !sessionId) {
+            return false;
+        }
+        var workspaceDiv = findWorkspaceDiv(navigationIdentity);
+        if (!workspaceDiv) {
+            return false;
+        }
+        var workspaceId = workspaceDiv.getAttribute('data-id');
+        if (!workspaceDiv.hasAttribute('data-codex-expanded')) {
+            toggleCodexSessions(workspaceDiv, workspaceId);
+        }
+        selectAiSessionTabDom(workspaceDiv, 'sessions');
+        writeAiSessionTabState(window.vscode, workspaceId, 'sessions');
+        var sessionRow = Array.from(workspaceDiv.querySelectorAll('.codex-session-row[data-session-id][data-session-provider]'))
+            .find(row => row.getAttribute('data-session-provider') === provider
+                && row.getAttribute('data-session-id') === sessionId);
+        if (sessionRow) {
+            pendingWorkspaceSessionReveal = null;
+            focusSearchRevealTarget(sessionRow);
+            return true;
+        }
+        var selectedProviders = getSelectedAiSessionProviders(workspaceDiv);
+        if (!selectedProviders.includes(provider)) {
+            pendingWorkspaceSessionReveal = { navigationIdentity, provider, sessionId };
+            submitAiSessionProviderSelection(
+                workspaceDiv,
+                selectedProviders.concat(provider)
+            );
+            return true;
+        }
+        pendingWorkspaceSessionReveal = null;
+        focusSearchRevealTarget(workspaceDiv);
+        return false;
+    }
+
+    window.__agentPivotRevealWorkspaceSession = revealWorkspaceSession;
+    window.__agentPivotRevealPendingWorkspaceSession = () => {
+        if (!pendingWorkspaceSessionReveal) {
+            return false;
+        }
+        var pending = pendingWorkspaceSessionReveal;
+        return revealWorkspaceSession(
+            pending.navigationIdentity,
+            pending.provider,
+            pending.sessionId
+        );
+    };
+
+    function requestFullRefresh(reason) {
+        window.vscode.postMessage({
+            type: 'request-full-refresh',
+            reason,
+        });
+    }
+
+    return {
+        applyAiSessionsUpdate: applyAiSessionsUpdate,
+        findCurrentWorkspaceDiv: findCurrentWorkspaceDiv,
+        findWorkspaceDiv: findWorkspaceDiv,
+        focusSearchRevealTarget: focusSearchRevealTarget,
+        requestFullRefresh: requestFullRefresh,
+    };
+}

--- a/media/webviewProjectCollapseScripts.js
+++ b/media/webviewProjectCollapseScripts.js
@@ -1,0 +1,95 @@
+function initProjectGroupCollapse() {
+    'use strict';
+
+    function updateToggleAllGroupsButton(state) {
+        document.body.classList.toggle("steward-all-collapsed", state.collapsed);
+        var button = document.querySelector('[data-action="toggle-all-groups"]');
+        if (!button)
+            return;
+
+        button.disabled = state.disabled;
+        button.setAttribute('aria-disabled', state.disabled ? 'true' : 'false');
+        button.setAttribute("title", state.title);
+        button.setAttribute("aria-label", state.title);
+    }
+
+    function getActiveDashboardTab() {
+        var dashboard = window.__agentPivotDashboard;
+        var selectedTab = !dashboard && document.querySelector
+            ? document.querySelector('[data-dashboard-tab][aria-selected="true"]')
+            : null;
+        var activeTab = dashboard && typeof dashboard.getActiveTab === 'function'
+            ? dashboard.getActiveTab()
+            : selectedTab && selectedTab.getAttribute('data-dashboard-tab');
+        return activeTab === 'projects' || activeTab === 'todo' || activeTab === 'ai'
+            ? activeTab
+            : 'open';
+    }
+
+    function getActiveCollapsibleGroups() {
+        var activeTab = getActiveDashboardTab();
+        var selector = activeTab === 'projects'
+            ? '#dashboard-tab-projects .group[data-group-id]'
+            : activeTab === 'todo'
+                ? '#dashboard-tab-todo .todo-group[data-todo-group-id]'
+                : activeTab === 'open'
+                    ? '#dashboard-tab-open .open-other-windows-group[data-group-id]'
+                    : null;
+        if (!selector) {
+            return [];
+        }
+        return [...document.querySelectorAll(selector)];
+    }
+
+    function setGroupCollapsed(group, collapsed, persist) {
+        group.classList.toggle('collapsed', collapsed);
+        if (persist) {
+            var isTodoGroup = group.classList.contains('todo-group');
+            window.vscode.postMessage({
+                type: isTodoGroup ? 'todo-collapse-group' : 'collapse-group',
+                groupId: isTodoGroup
+                    ? group.getAttribute('data-todo-group-id')
+                    : group.getAttribute('data-group-id'),
+                collapsed,
+            });
+        }
+    }
+
+    function syncCollapseButton() {
+        var activeTab = getActiveDashboardTab();
+        var groups = getActiveCollapsibleGroups();
+        updateToggleAllGroupsButton(getCollapseButtonState(
+            activeTab,
+            groups.map(group => group.classList.contains('collapsed'))
+        ));
+    }
+
+    function toggleAllGroups() {
+        var activeTab = getActiveDashboardTab();
+        var groups = getActiveCollapsibleGroups();
+        var shouldCollapse = groups.some(group => !group.classList.contains("collapsed"));
+
+        if (activeTab === 'todo') {
+            if (window.__agentPivotTodo
+                && typeof window.__agentPivotTodo.dispatch === 'function') {
+                window.__agentPivotTodo.dispatch('collapse-groups', { collapsed: shouldCollapse });
+            } else {
+                collapseTodoGroups(groups, shouldCollapse, message => window.vscode.postMessage(message));
+            }
+            syncCollapseButton();
+            return;
+        }
+
+        groups.forEach(group => setGroupCollapsed(group, shouldCollapse, true));
+        syncCollapseButton();
+    }
+
+
+    window.__agentPivotSyncCollapseButton = syncCollapseButton;
+
+    return {
+        setGroupCollapsed: setGroupCollapsed,
+        syncCollapseButton: syncCollapseButton,
+        toggleAllGroups: toggleAllGroups,
+    };
+}

--- a/media/webviewProjectContextMenuScripts.js
+++ b/media/webviewProjectContextMenuScripts.js
@@ -1,0 +1,306 @@
+function initProjectContextMenus(options) {
+    'use strict';
+
+    options = options || {};
+    var openProject = options.openProject;
+    var ProjectOpenType = options.ProjectOpenType;
+    var getResumeAiSessionMessageType = options.getResumeAiSessionMessageType;
+    var getArchiveAiSessionMessageType = options.getArchiveAiSessionMessageType;
+    var isAiSessionProvider = options.isAiSessionProvider;
+
+    function onTriggerProjectAction(target, projectId) {
+        var actionDiv = target.closest('[data-action]')
+        if (actionDiv == null)
+            return false;
+
+        var action = actionDiv.getAttribute("data-action");
+        if (!action)
+            return false;
+
+        if (action === 'save-current-workspace') {
+            window.vscode.postMessage({
+                type: 'save-current-workspace',
+                projectId,
+            });
+            return true;
+        }
+
+        if (action === 'toggle-open-workspace-pin') {
+            requestOpenWorkspacePin(actionDiv, projectId);
+            return true;
+        }
+
+        window.vscode.postMessage({
+            type: action + '-project',
+            projectId,
+        });
+
+        return true;
+    }
+
+    var contextMenuProjectId = null;
+    var contextMenuGroupId = null;
+    var contextMenuAiSessionId = null;
+    var contextMenuAiSessionProvider = null;
+    var contextMenuAiSessionProjectId = null;
+    var contextMenuAiSessionActive = false;
+    var contextMenuAiSessionBackend = null;
+    var contextMenuAiSessionConflict = false;
+    var contextMenuAiSessionOrigin = null;
+
+    function showContextMenu(contextMenuElement, e) {
+        contextMenuElement.style.visibility = "hidden";
+        contextMenuElement.style.left = "0px";
+        contextMenuElement.style.top = "0px";
+        contextMenuElement.classList.add("visible");
+
+        var rect = contextMenuElement.getBoundingClientRect();
+        var viewportPadding = 4;
+        var left = e.clientX;
+        var top = e.clientY;
+
+        if (left + rect.width + viewportPadding > window.innerWidth) {
+            left = Math.max(viewportPadding, window.innerWidth - rect.width - viewportPadding);
+        }
+
+        if (top + rect.height + viewportPadding > window.innerHeight) {
+            top = Math.max(viewportPadding, window.innerHeight - rect.height - viewportPadding);
+        }
+
+        contextMenuElement.style.left = left + "px";
+        contextMenuElement.style.top = top + "px";
+        contextMenuElement.style.visibility = "";
+    }
+
+    function onContextMenu(e) {
+        closeContextMenus(); // Close previews
+
+        var sessionRow = e.target.closest('.codex-session-row[data-session-id][data-session-provider]');
+        if (sessionRow) {
+            contextMenuAiSessionOrigin = sessionRow.querySelector('.ai-session-primary-action') || sessionRow;
+            contextMenuAiSessionId = sessionRow.getAttribute("data-session-id");
+            contextMenuAiSessionProvider = sessionRow.getAttribute("data-session-provider");
+            var sessionProjectDiv = sessionRow.closest('.project[data-id]');
+            contextMenuAiSessionProjectId = sessionProjectDiv ? sessionProjectDiv.getAttribute("data-id") : null;
+            contextMenuAiSessionActive = sessionRow.hasAttribute('data-session-active');
+            contextMenuAiSessionBackend = sessionRow.getAttribute('data-session-backend') || 'vscode';
+            contextMenuAiSessionConflict = sessionRow.hasAttribute('data-session-conflict');
+            if (!contextMenuAiSessionId || !isAiSessionProvider(contextMenuAiSessionProvider))
+                return;
+
+            e.preventDefault();
+            var sessionContextMenuElement = document.getElementById("aiSessionContextMenu");
+            if (!sessionContextMenuElement)
+                return;
+            sessionContextMenuElement.querySelectorAll(':scope > *').forEach(element => element.classList.remove('disabled'));
+            var archiveMenuItem = sessionContextMenuElement.querySelector('[data-action="archive"]');
+            var closeMenuItem = sessionContextMenuElement.querySelector('[data-action="close-terminal"]');
+            if (archiveMenuItem) archiveMenuItem.classList.toggle('disabled', contextMenuAiSessionActive);
+            if (closeMenuItem) {
+                var terminalActionLabel = contextMenuAiSessionBackend === 'tmux'
+                    ? 'Detach Terminal…' : 'Close Terminal…';
+                closeMenuItem.textContent = terminalActionLabel;
+                closeMenuItem.setAttribute('aria-label', terminalActionLabel);
+                closeMenuItem.toggleAttribute('hidden', contextMenuAiSessionConflict);
+                closeMenuItem.classList.toggle(
+                    'disabled', !contextMenuAiSessionActive || contextMenuAiSessionConflict
+                );
+            }
+
+            showContextMenu(sessionContextMenuElement, e);
+            if (e.keyboardTrigger) {
+                var firstMenuItem = sessionContextMenuElement.querySelector('.custom-context-menu-item[data-action]:not(.disabled)');
+                firstMenuItem?.focus();
+            }
+            return;
+        }
+
+        var projectDiv = e.target.closest('.project[data-id]');
+        var groupDiv = e.target.closest('.group-title')
+        if (!projectDiv && !groupDiv)
+            return;
+
+        if (projectDiv && projectDiv.hasAttribute("data-readonly-project"))
+            return;
+
+        e.preventDefault();
+
+        let contextMenuForProject = projectDiv != null;
+        var contextMenuElement;
+        if (contextMenuForProject) {
+            contextMenuProjectId = projectDiv.getAttribute("data-id");
+            if (contextMenuProjectId == null)
+                return;
+
+            contextMenuElement = document.getElementById("projectContextMenu");
+        } else {
+            let groupIdDiv = groupDiv.closest(".group[data-group-id]");
+            if (groupIdDiv && groupIdDiv.hasAttribute("data-virtual-group"))
+                return;
+
+            contextMenuGroupId = groupIdDiv ? groupIdDiv.getAttribute("data-group-id") : null;
+            if (contextMenuGroupId == null)
+                return;
+
+            contextMenuElement = document.getElementById("groupContextMenu");
+        }
+
+        // disable elements if needed
+        contextMenuElement.querySelectorAll(":scope > *").forEach(e => e.classList.remove("disabled"));
+
+        if (projectDiv && projectDiv.hasAttribute("data-is-remote")) {
+            contextMenuElement.querySelectorAll(".not-remote").forEach(e => e.classList.add("disabled"));
+        }
+
+        // place and show contextmenu
+
+        showContextMenu(contextMenuElement, e);
+    }
+
+    function onProjectContextMenuActionClicked(el) {
+        var action = el.getAttribute("data-action");
+
+        if (action == null || contextMenuProjectId == null)
+            return;
+
+        switch (action) {
+            case 'open':
+                openProject(contextMenuProjectId, ProjectOpenType.CurrentWindow);
+                break;
+            case 'open-add-to-workspace':
+                openProject(contextMenuProjectId, ProjectOpenType.AddToWorkspace);
+                break;
+            default:
+                window.vscode.postMessage({
+                    type: action + '-project',
+                    projectId: contextMenuProjectId,
+                });
+                break;
+        }
+
+        closeContextMenus();
+    }
+
+    function onGroupContextMenuActionClicked(el) {
+        var action = el.getAttribute("data-action");
+
+        if (action == null || contextMenuGroupId == null)
+            return;
+
+        switch (action) {
+            case 'add':
+                window.vscode.postMessage({
+                    type: 'add-project',
+                    groupId: contextMenuGroupId,
+                });
+                break;
+            default:
+                window.vscode.postMessage({
+                    type: action + '-group',
+                    groupId: contextMenuGroupId,
+                });
+                break;
+        }
+
+        closeContextMenus();
+    }
+
+    function onAiSessionContextMenuActionClicked(el) {
+        var action = el.getAttribute("data-action");
+        var origin = contextMenuAiSessionOrigin;
+
+        if (action == null || contextMenuAiSessionId == null || contextMenuAiSessionProvider == null)
+            return;
+
+        switch (action) {
+            case 'resume':
+                window.vscode.postMessage(contextMenuAiSessionActive ? {
+                    type: 'focus-ai-session-terminal',
+                    provider: contextMenuAiSessionProvider,
+                    projectId: contextMenuAiSessionProjectId,
+                    sessionId: contextMenuAiSessionId,
+                } : {
+                    type: getResumeAiSessionMessageType(contextMenuAiSessionProvider),
+                    provider: contextMenuAiSessionProvider,
+                    projectId: contextMenuAiSessionProjectId,
+                    sessionId: contextMenuAiSessionId,
+                });
+                break;
+            case 'rename':
+                window.vscode.postMessage({
+                    type: 'rename-ai-session',
+                    provider: contextMenuAiSessionProvider,
+                    sessionId: contextMenuAiSessionId,
+                });
+                break;
+            case 'copy-id':
+                window.vscode.postMessage({
+                    type: 'copy-ai-session-id',
+                    provider: contextMenuAiSessionProvider,
+                    sessionId: contextMenuAiSessionId,
+                });
+                break;
+            case 'pin':
+                window.vscode.postMessage({
+                    type: 'toggle-ai-session-pin',
+                    provider: contextMenuAiSessionProvider,
+                    sessionId: contextMenuAiSessionId,
+                });
+                break;
+            case 'archive':
+                if (contextMenuAiSessionActive) break;
+                window.vscode.postMessage({
+                    type: getArchiveAiSessionMessageType(contextMenuAiSessionProvider),
+                    projectId: contextMenuAiSessionProjectId,
+                    provider: contextMenuAiSessionProvider,
+                    sessionId: contextMenuAiSessionId,
+                });
+                break;
+            case 'close-terminal':
+                if (!contextMenuAiSessionActive || contextMenuAiSessionConflict) break;
+                window.vscode.postMessage({
+                    type: contextMenuAiSessionBackend === 'tmux'
+                        ? 'detach-ai-session-terminal' : 'close-ai-session-terminal',
+                    projectId: contextMenuAiSessionProjectId,
+                    provider: contextMenuAiSessionProvider,
+                    sessionId: contextMenuAiSessionId,
+                });
+                break;
+        }
+
+        closeContextMenus();
+        origin?.focus();
+    }
+
+    function closeContextMenus() {
+        contextMenuProjectId = null;
+        contextMenuGroupId = null;
+        contextMenuAiSessionId = null;
+        contextMenuAiSessionProvider = null;
+        contextMenuAiSessionProjectId = null;
+        contextMenuAiSessionActive = false;
+        contextMenuAiSessionBackend = null;
+        contextMenuAiSessionConflict = false;
+        contextMenuAiSessionOrigin = null;
+        // Only close menus this script owns; the dashboard script owns the
+        // skill folder menu and keeps it open across per-agent toggles.
+        document.querySelectorAll(".custom-context-menu:not(.skill-folder-menu)").forEach(element =>
+            element.classList.remove("visible")
+        );
+    }
+
+    function getAiSessionContextMenuOrigin() {
+        return contextMenuAiSessionOrigin;
+    }
+
+    return {
+        closeContextMenus: closeContextMenus,
+        getAiSessionContextMenuOrigin: getAiSessionContextMenuOrigin,
+        onAiSessionContextMenuActionClicked: onAiSessionContextMenuActionClicked,
+        onContextMenu: onContextMenu,
+        onGroupContextMenuActionClicked: onGroupContextMenuActionClicked,
+        onProjectContextMenuActionClicked: onProjectContextMenuActionClicked,
+        onTriggerProjectAction: onTriggerProjectAction,
+        showContextMenu: showContextMenu,
+    };
+}

--- a/media/webviewProjectScripts.js
+++ b/media/webviewProjectScripts.js
@@ -368,7 +368,7 @@ function initProjects() {
         if (onTriggerAiSessionAction(e.target, dataId))
             return;
 
-        if (onTriggerProjectAction(e.target, dataId))
+        if (contextMenus.onTriggerProjectAction(e.target, dataId))
             return;
 
         if (projectDiv.hasAttribute("data-current-workspace")) {
@@ -908,291 +908,18 @@ function initProjects() {
         syncAiSessionBatchManagementDom(findCurrentWorkspaceDiv(projectId));
     }
 
-    function onTriggerProjectAction(target, projectId) {
-        var actionDiv = target.closest('[data-action]')
-        if (actionDiv == null)
-            return false;
-
-        var action = actionDiv.getAttribute("data-action");
-        if (!action)
-            return false;
-
-        if (action === 'save-current-workspace') {
-            window.vscode.postMessage({
-                type: 'save-current-workspace',
-                projectId,
-            });
-            return true;
-        }
-
-        if (action === 'toggle-open-workspace-pin') {
-            requestOpenWorkspacePin(actionDiv, projectId);
-            return true;
-        }
-
-        window.vscode.postMessage({
-            type: action + '-project',
-            projectId,
-        });
-
-        return true;
-    }
-
-    var contextMenuProjectId = null;
-    var contextMenuGroupId = null;
-    var contextMenuAiSessionId = null;
-    var contextMenuAiSessionProvider = null;
-    var contextMenuAiSessionProjectId = null;
-    var contextMenuAiSessionActive = false;
-    var contextMenuAiSessionBackend = null;
-    var contextMenuAiSessionConflict = false;
-    var contextMenuAiSessionOrigin = null;
     var latestAiSessionUpdateSequence = 0;
-
-    function showContextMenu(contextMenuElement, e) {
-        contextMenuElement.style.visibility = "hidden";
-        contextMenuElement.style.left = "0px";
-        contextMenuElement.style.top = "0px";
-        contextMenuElement.classList.add("visible");
-
-        var rect = contextMenuElement.getBoundingClientRect();
-        var viewportPadding = 4;
-        var left = e.clientX;
-        var top = e.clientY;
-
-        if (left + rect.width + viewportPadding > window.innerWidth) {
-            left = Math.max(viewportPadding, window.innerWidth - rect.width - viewportPadding);
-        }
-
-        if (top + rect.height + viewportPadding > window.innerHeight) {
-            top = Math.max(viewportPadding, window.innerHeight - rect.height - viewportPadding);
-        }
-
-        contextMenuElement.style.left = left + "px";
-        contextMenuElement.style.top = top + "px";
-        contextMenuElement.style.visibility = "";
-    }
-
-    function onContextMenu(e) {
-        closeContextMenus(); // Close previews
-
-        var sessionRow = e.target.closest('.codex-session-row[data-session-id][data-session-provider]');
-        if (sessionRow) {
-            contextMenuAiSessionOrigin = sessionRow.querySelector('.ai-session-primary-action') || sessionRow;
-            contextMenuAiSessionId = sessionRow.getAttribute("data-session-id");
-            contextMenuAiSessionProvider = sessionRow.getAttribute("data-session-provider");
-            var sessionProjectDiv = sessionRow.closest('.project[data-id]');
-            contextMenuAiSessionProjectId = sessionProjectDiv ? sessionProjectDiv.getAttribute("data-id") : null;
-            contextMenuAiSessionActive = sessionRow.hasAttribute('data-session-active');
-            contextMenuAiSessionBackend = sessionRow.getAttribute('data-session-backend') || 'vscode';
-            contextMenuAiSessionConflict = sessionRow.hasAttribute('data-session-conflict');
-            if (!contextMenuAiSessionId || !isAiSessionProvider(contextMenuAiSessionProvider))
-                return;
-
-            e.preventDefault();
-            var sessionContextMenuElement = document.getElementById("aiSessionContextMenu");
-            if (!sessionContextMenuElement)
-                return;
-            sessionContextMenuElement.querySelectorAll(':scope > *').forEach(element => element.classList.remove('disabled'));
-            var archiveMenuItem = sessionContextMenuElement.querySelector('[data-action="archive"]');
-            var closeMenuItem = sessionContextMenuElement.querySelector('[data-action="close-terminal"]');
-            if (archiveMenuItem) archiveMenuItem.classList.toggle('disabled', contextMenuAiSessionActive);
-            if (closeMenuItem) {
-                var terminalActionLabel = contextMenuAiSessionBackend === 'tmux'
-                    ? 'Detach Terminal…' : 'Close Terminal…';
-                closeMenuItem.textContent = terminalActionLabel;
-                closeMenuItem.setAttribute('aria-label', terminalActionLabel);
-                closeMenuItem.toggleAttribute('hidden', contextMenuAiSessionConflict);
-                closeMenuItem.classList.toggle(
-                    'disabled', !contextMenuAiSessionActive || contextMenuAiSessionConflict
-                );
-            }
-
-            showContextMenu(sessionContextMenuElement, e);
-            if (e.keyboardTrigger) {
-                var firstMenuItem = sessionContextMenuElement.querySelector('.custom-context-menu-item[data-action]:not(.disabled)');
-                firstMenuItem?.focus();
-            }
-            return;
-        }
-
-        var projectDiv = e.target.closest('.project[data-id]');
-        var groupDiv = e.target.closest('.group-title')
-        if (!projectDiv && !groupDiv)
-            return;
-
-        if (projectDiv && projectDiv.hasAttribute("data-readonly-project"))
-            return;
-
-        e.preventDefault();
-
-        let contextMenuForProject = projectDiv != null;
-        var contextMenuElement;
-        if (contextMenuForProject) {
-            contextMenuProjectId = projectDiv.getAttribute("data-id");
-            if (contextMenuProjectId == null)
-                return;
-
-            contextMenuElement = document.getElementById("projectContextMenu");
-        } else {
-            let groupIdDiv = groupDiv.closest(".group[data-group-id]");
-            if (groupIdDiv && groupIdDiv.hasAttribute("data-virtual-group"))
-                return;
-
-            contextMenuGroupId = groupIdDiv ? groupIdDiv.getAttribute("data-group-id") : null;
-            if (contextMenuGroupId == null)
-                return;
-
-            contextMenuElement = document.getElementById("groupContextMenu");
-        }
-
-        // disable elements if needed
-        contextMenuElement.querySelectorAll(":scope > *").forEach(e => e.classList.remove("disabled"));
-
-        if (projectDiv && projectDiv.hasAttribute("data-is-remote")) {
-            contextMenuElement.querySelectorAll(".not-remote").forEach(e => e.classList.add("disabled"));
-        }
-
-        // place and show contextmenu
-
-        showContextMenu(contextMenuElement, e);
-    }
-
-    function onProjectContextMenuActionClicked(el) {
-        var action = el.getAttribute("data-action");
-
-        if (action == null || contextMenuProjectId == null)
-            return;
-
-        switch (action) {
-            case 'open':
-                openProject(contextMenuProjectId, ProjectOpenType.CurrentWindow);
-                break;
-            case 'open-add-to-workspace':
-                openProject(contextMenuProjectId, ProjectOpenType.AddToWorkspace);
-                break;
-            default:
-                window.vscode.postMessage({
-                    type: action + '-project',
-                    projectId: contextMenuProjectId,
-                });
-                break;
-        }
-
-        closeContextMenus();
-    }
-
-    function onGroupContextMenuActionClicked(el) {
-        var action = el.getAttribute("data-action");
-
-        if (action == null || contextMenuGroupId == null)
-            return;
-
-        switch (action) {
-            case 'add':
-                window.vscode.postMessage({
-                    type: 'add-project',
-                    groupId: contextMenuGroupId,
-                });
-                break;
-            default:
-                window.vscode.postMessage({
-                    type: action + '-group',
-                    groupId: contextMenuGroupId,
-                });
-                break;
-        }
-
-        closeContextMenus();
-    }
-
-    function onAiSessionContextMenuActionClicked(el) {
-        var action = el.getAttribute("data-action");
-        var origin = contextMenuAiSessionOrigin;
-
-        if (action == null || contextMenuAiSessionId == null || contextMenuAiSessionProvider == null)
-            return;
-
-        switch (action) {
-            case 'resume':
-                window.vscode.postMessage(contextMenuAiSessionActive ? {
-                    type: 'focus-ai-session-terminal',
-                    provider: contextMenuAiSessionProvider,
-                    projectId: contextMenuAiSessionProjectId,
-                    sessionId: contextMenuAiSessionId,
-                } : {
-                    type: getResumeAiSessionMessageType(contextMenuAiSessionProvider),
-                    provider: contextMenuAiSessionProvider,
-                    projectId: contextMenuAiSessionProjectId,
-                    sessionId: contextMenuAiSessionId,
-                });
-                break;
-            case 'rename':
-                window.vscode.postMessage({
-                    type: 'rename-ai-session',
-                    provider: contextMenuAiSessionProvider,
-                    sessionId: contextMenuAiSessionId,
-                });
-                break;
-            case 'copy-id':
-                window.vscode.postMessage({
-                    type: 'copy-ai-session-id',
-                    provider: contextMenuAiSessionProvider,
-                    sessionId: contextMenuAiSessionId,
-                });
-                break;
-            case 'pin':
-                window.vscode.postMessage({
-                    type: 'toggle-ai-session-pin',
-                    provider: contextMenuAiSessionProvider,
-                    sessionId: contextMenuAiSessionId,
-                });
-                break;
-            case 'archive':
-                if (contextMenuAiSessionActive) break;
-                window.vscode.postMessage({
-                    type: getArchiveAiSessionMessageType(contextMenuAiSessionProvider),
-                    projectId: contextMenuAiSessionProjectId,
-                    provider: contextMenuAiSessionProvider,
-                    sessionId: contextMenuAiSessionId,
-                });
-                break;
-            case 'close-terminal':
-                if (!contextMenuAiSessionActive || contextMenuAiSessionConflict) break;
-                window.vscode.postMessage({
-                    type: contextMenuAiSessionBackend === 'tmux'
-                        ? 'detach-ai-session-terminal' : 'close-ai-session-terminal',
-                    projectId: contextMenuAiSessionProjectId,
-                    provider: contextMenuAiSessionProvider,
-                    sessionId: contextMenuAiSessionId,
-                });
-                break;
-        }
-
-        closeContextMenus();
-        origin?.focus();
-    }
-
-    function closeContextMenus() {
-        contextMenuProjectId = null;
-        contextMenuGroupId = null;
-        contextMenuAiSessionId = null;
-        contextMenuAiSessionProvider = null;
-        contextMenuAiSessionProjectId = null;
-        contextMenuAiSessionActive = false;
-        contextMenuAiSessionBackend = null;
-        contextMenuAiSessionConflict = false;
-        contextMenuAiSessionOrigin = null;
-        // Only close menus this script owns; the dashboard script owns the
-        // skill folder menu and keeps it open across per-agent toggles.
-        document.querySelectorAll(".custom-context-menu:not(.skill-folder-menu)").forEach(element =>
-            element.classList.remove("visible")
-        );
-    }
 
     var groupCollapse = initProjectGroupCollapse();
     var todoControls = initProjectTodoControls({
         syncCollapseButton: () => groupCollapse.syncCollapseButton(),
+    });
+    var contextMenus = initProjectContextMenus({
+        openProject: openProject,
+        ProjectOpenType: ProjectOpenType,
+        getResumeAiSessionMessageType: getResumeAiSessionMessageType,
+        getArchiveAiSessionMessageType: getArchiveAiSessionMessageType,
+        isAiSessionProvider: isAiSessionProvider,
     });
 
     function onMouseEvent(e) {
@@ -1203,23 +930,23 @@ function initProjects() {
 
         var contextMenuElement = e.target.closest("#projectContextMenu [data-action]");
         if (contextMenuElement) {
-            onProjectContextMenuActionClicked(contextMenuElement);
+            contextMenus.onProjectContextMenuActionClicked(contextMenuElement);
             return;
         }
 
         contextMenuElement = e.target.closest("#aiSessionContextMenu [data-action]");
         if (contextMenuElement) {
-            onAiSessionContextMenuActionClicked(contextMenuElement);
+            contextMenus.onAiSessionContextMenuActionClicked(contextMenuElement);
             return;
         }
 
         contextMenuElement = e.target.closest("#groupContextMenu [data-action]");
         if (contextMenuElement) {
-            onGroupContextMenuActionClicked(contextMenuElement);
+            contextMenus.onGroupContextMenuActionClicked(contextMenuElement);
             return;
         }
 
-        closeContextMenus();
+        contextMenus.closeContextMenus();
         if (!e.target.closest('.ai-session-provider-menu-wrapper')) {
             closeAiSessionProviderMenus();
         }
@@ -1629,7 +1356,7 @@ function initProjects() {
         if (!e.target)
             return;
 
-        onContextMenu(e);
+        contextMenus.onContextMenu(e);
     });
 
     document.addEventListener("keydown", e => {
@@ -1710,18 +1437,18 @@ function initProjects() {
             }
             if (e.key === 'Enter' || e.key === ' ') {
                 e.preventDefault();
-                onAiSessionContextMenuActionClicked(aiSessionMenuItem);
+                contextMenus.onAiSessionContextMenuActionClicked(aiSessionMenuItem);
                 return;
             }
             if (e.key === 'Escape') {
                 e.preventDefault();
-                var menuOrigin = contextMenuAiSessionOrigin;
-                closeContextMenus();
+                var menuOrigin = contextMenus.getAiSessionContextMenuOrigin();
+                contextMenus.closeContextMenus();
                 menuOrigin?.focus();
                 return;
             }
             if (e.key === 'Tab') {
-                closeContextMenus();
+                contextMenus.closeContextMenus();
             }
         }
 
@@ -1753,7 +1480,7 @@ function initProjects() {
             && (e.key === 'ContextMenu' || (e.key === 'F10' && e.shiftKey))) {
             e.preventDefault();
             var sessionRowRect = sessionRow.getBoundingClientRect();
-            onContextMenu({
+            contextMenus.onContextMenu({
                 target: primarySessionAction || sessionRow,
                 preventDefault: () => {},
                 clientX: sessionRowRect.left + 8,
@@ -1769,7 +1496,7 @@ function initProjects() {
                 todoControls.setTodoEditing(editForm.getAttribute('data-todo-id'), false);
                 return;
             }
-            closeContextMenus();
+            contextMenus.closeContextMenus();
             if (batchAiSessionState.projectId && !batchAiSessionState.pending) {
                 exitAiSessionBatchManagement();
             }

--- a/media/webviewProjectScripts.js
+++ b/media/webviewProjectScripts.js
@@ -188,13 +188,6 @@ function initProjects() {
     var pendingAiSessionProviderSelectionRequestId = null;
     var pendingAiSessionProviderSelectionProviders = [];
 
-    function isDedicatedTodoTarget(target) {
-        return Boolean(window.__agentPivotTodo
-            && target
-            && target.closest
-            && target.closest('#dashboard-tab-todo'));
-    }
-
     function getAiSessionBatchItemKey(provider, sessionId) {
         return JSON.stringify([provider, sessionId]);
     }
@@ -915,301 +908,6 @@ function initProjects() {
         syncAiSessionBatchManagementDom(findCurrentWorkspaceDiv(projectId));
     }
 
-    function onInsideGroupClick(e, groupDiv) {
-        var groupId = groupDiv.getAttribute("data-group-id");
-        if (groupId == null)
-            return;
-
-        var actionDiv = e.target.closest('[data-action]')
-        var action = actionDiv != null ? actionDiv.getAttribute("data-action") : null;
-        if (!action)
-            return;
-
-        if (action === "add") {
-            window.vscode.postMessage({
-                type: 'add-project',
-                groupId: groupId,
-            });
-
-            return;
-        }
-
-        var collapsed = groupDiv.classList.contains("collapsed");
-        if (action === "collapse") {
-            groupDiv.classList.toggle("collapsed");
-            collapsed = groupDiv.classList.contains("collapsed");
-        }
-
-        window.vscode.postMessage({
-            type: action + '-group',
-            groupId: groupId,
-            collapsed,
-        });
-        groupCollapse.syncCollapseButton();
-    }
-
-    function onTodoAction(e) {
-        var addTodoAction = e.target.closest('[data-action="todo-add"]');
-        if (addTodoAction && !addTodoAction.closest('.todo-add-form')) {
-            setTodoAddFormVisible(true, addTodoAction.getAttribute('data-group-id'));
-            return true;
-        }
-
-        var addGroupAction = e.target.closest('[data-action="todo-add-group"]');
-        if (addGroupAction) {
-            window.vscode.postMessage({
-                type: 'todo-add-group',
-            });
-            return true;
-        }
-
-        var toggleAction = e.target.closest('[data-action="todo-toggle"]');
-        if (toggleAction) {
-            window.vscode.postMessage({
-                type: 'todo-toggle',
-                todoId: toggleAction.getAttribute('data-todo-id'),
-                completed: toggleAction.checked === true,
-            });
-            return true;
-        }
-
-        var deleteAction = e.target.closest('[data-action="todo-delete"]');
-        if (deleteAction) {
-            window.vscode.postMessage({
-                type: 'todo-delete',
-                todoId: deleteAction.getAttribute('data-todo-id'),
-            });
-            return true;
-        }
-
-        var deleteGroupAction = e.target.closest('[data-action="todo-delete-group"]');
-        if (deleteGroupAction) {
-            window.vscode.postMessage({
-                type: 'todo-delete-group',
-                groupId: deleteGroupAction.getAttribute('data-group-id'),
-            });
-            return true;
-        }
-
-        var renameGroupAction = e.target.closest('[data-action="todo-rename-group"]');
-        if (renameGroupAction) {
-            window.vscode.postMessage({
-                type: 'todo-rename-group',
-                groupId: renameGroupAction.getAttribute('data-group-id'),
-            });
-            return true;
-        }
-
-        var collapseGroupAction = e.target.closest('[data-action="todo-collapse-group"]');
-        if (collapseGroupAction) {
-            var todoGroup = collapseGroupAction.closest('.todo-group');
-            if (!todoGroup)
-                return true;
-            todoGroup.classList.toggle('collapsed');
-            syncTodoGroupCollapseControl(todoGroup);
-            window.vscode.postMessage({
-                type: 'todo-collapse-group',
-                groupId: todoGroup.getAttribute('data-todo-group-id'),
-                collapsed: todoGroup.classList.contains('collapsed'),
-            });
-            groupCollapse.syncCollapseButton();
-            return true;
-        }
-
-        var sortAction = e.target.closest('[data-action="todo-sort-priority"]');
-        if (sortAction) {
-            window.vscode.postMessage({
-                type: 'todo-sort-priority',
-                groupId: sortAction.getAttribute('data-group-id'),
-            });
-            return true;
-        }
-
-        var showCompletedAction = e.target.closest('[data-action="todo-toggle-show-completed"]');
-        if (showCompletedAction) {
-            window.vscode.postMessage({
-                type: 'todo-toggle-show-completed',
-                showCompleted: showCompletedAction.checked === true,
-            });
-            return true;
-        }
-
-        var focusAddAction = e.target.closest('[data-action="todo-focus-add"]');
-        if (focusAddAction) {
-            setTodoAddFormVisible(true, focusAddAction.getAttribute('data-group-id'));
-            return true;
-        }
-
-        var cancelAddAction = e.target.closest('[data-action="todo-cancel-add"]');
-        if (cancelAddAction) {
-            setTodoAddFormVisible(false);
-            return true;
-        }
-
-        var editAction = e.target.closest('[data-action="todo-edit"]');
-        if (editAction) {
-            setTodoEditing(editAction.getAttribute('data-todo-id'), true);
-            return true;
-        }
-
-        var expandAction = e.target.closest('[data-action="todo-toggle-expanded"]');
-        if (expandAction) {
-            toggleTodoItemExpanded(expandAction.closest('.todo-item'));
-            return true;
-        }
-
-        var cancelEditAction = e.target.closest('[data-action="todo-cancel-edit"]');
-        if (cancelEditAction) {
-            setTodoEditing(cancelEditAction.getAttribute('data-todo-id'), false);
-            return true;
-        }
-
-        return false;
-    }
-
-    function syncTodoPrioritySegment(segment) {
-        if (!segment)
-            return;
-
-        Array.from(segment.querySelectorAll('.todo-priority-choice')).forEach(choice => {
-            var input = choice.querySelector('input[name="priority"]');
-            choice.classList.toggle('active', !!input && input.checked === true);
-        });
-    }
-
-    function resetTodoEditForm(form) {
-        form.reset();
-        syncTodoPrioritySegment(form.querySelector('.todo-priority-segment'));
-    }
-
-    function syncTodoListExpandedHeight(list) {
-        if (!list)
-            return;
-
-        var panel = list.closest('.todo-panel');
-        var collapsedHeightValue = panel
-            ? getComputedStyle(panel).getPropertyValue('--todo-collapsed-item-height')
-            : '';
-        var collapsedHeight = parseFloat(collapsedHeightValue) || 58;
-        var expandedExtraHeight = Array.from(list.querySelectorAll('.todo-item.expanded'))
-            .reduce((total, expandedItem) => total + Math.max(0, expandedItem.offsetHeight - collapsedHeight), 0);
-        list.style.setProperty('--todo-list-expanded-extra-height', expandedExtraHeight + 'px');
-    }
-
-    function toggleTodoItemExpanded(item, expanded) {
-        if (!item)
-            return;
-
-        var nextExpanded = typeof expanded === 'boolean'
-            ? expanded
-            : !item.classList.contains('expanded');
-        item.classList.toggle('expanded', nextExpanded);
-        syncTodoExpandControl(item, nextExpanded);
-        syncTodoListExpandedHeight(item.closest('.todo-list'));
-    }
-
-    function isTodoInteractiveTarget(target) {
-        return !!(target && target.closest && target.closest('button, input, textarea, select, label, a, [data-action], .todo-edit-form'));
-    }
-
-    function setTodoAddFormVisible(visible, groupId) {
-        var form = document.querySelector('.todo-add-form');
-        if (!form)
-            return;
-
-        var groupSelect = form.querySelector('[name="groupId"]');
-        if (visible && groupSelect) {
-            groupSelect.value = groupId || '';
-        }
-        form.hidden = !visible;
-        if (!visible)
-            return;
-
-        var titleInput = form.querySelector('[name="title"]');
-        if (titleInput) {
-            titleInput.focus();
-        }
-        form.scrollIntoView({ block: 'nearest' });
-    }
-
-    function setTodoEditing(todoId, editing) {
-        if (!todoId)
-            return;
-
-        var item = Array.from(document.querySelectorAll('.todo-item[data-todo-id]'))
-            .find(candidate => candidate.getAttribute('data-todo-id') === todoId);
-        if (!item)
-            return;
-
-        var wasEditing = item.classList.contains('editing');
-        var expandedBeforeEdit = item.getAttribute('data-expanded-before-edit');
-        if (editing && !wasEditing) {
-            item.setAttribute(
-                'data-expanded-before-edit',
-                item.classList.contains('expanded') ? 'true' : 'false'
-            );
-            expandedBeforeEdit = item.getAttribute('data-expanded-before-edit');
-        }
-        var view = item.querySelector('.todo-item-view');
-        var form = item.querySelector('.todo-edit-form');
-        var list = item.closest('.todo-list');
-        if (form && !editing) {
-            resetTodoEditForm(form);
-        }
-        item.classList.toggle('editing', editing);
-        if (view) {
-            view.hidden = false;
-        }
-        if (form) {
-            form.hidden = !editing;
-        }
-        toggleTodoItemExpanded(item, editing ? true : expandedBeforeEdit === 'true');
-        if (!editing) {
-            item.removeAttribute('data-expanded-before-edit');
-        }
-        if (list) {
-            list.classList.toggle('has-editing-item', !!list.querySelector('.todo-item.editing'));
-        }
-        if (form && editing) {
-            var titleInput = form.querySelector('[name="title"]');
-            if (titleInput) {
-                titleInput.focus();
-            }
-            item.scrollIntoView({ block: 'nearest' });
-        }
-    }
-
-    function onTodoFormSubmit(e) {
-        if (window.__agentPivotTodo
-            && e.target
-            && e.target.closest
-            && e.target.closest('#dashboard-tab-todo')) {
-            return;
-        }
-        var addForm = e.target && e.target.closest ? e.target.closest('.todo-add-form') : null;
-        if (addForm) {
-            e.preventDefault();
-            submitTodoComposeForm(addForm, message => window.vscode.postMessage(message));
-            return;
-        }
-
-        var editForm = e.target && e.target.closest ? e.target.closest('.todo-edit-form') : null;
-        if (editForm) {
-            e.preventDefault();
-            var todoId = editForm.getAttribute('data-todo-id');
-            var editTitle = getTodoFormValue(editForm, 'title');
-            if (!todoId || !editTitle)
-                return;
-            window.vscode.postMessage({
-                type: 'todo-update',
-                todoId,
-                title: editTitle,
-                notes: getTodoFormValue(editForm, 'notes'),
-                priority: getTodoFormValue(editForm, 'priority'),
-            });
-        }
-    }
-
     function onTriggerProjectAction(target, projectId) {
         var actionDiv = target.closest('[data-action]')
         if (actionDiv == null)
@@ -1493,11 +1191,14 @@ function initProjects() {
     }
 
     var groupCollapse = initProjectGroupCollapse();
+    var todoControls = initProjectTodoControls({
+        syncCollapseButton: () => groupCollapse.syncCollapseButton(),
+    });
 
     function onMouseEvent(e) {
         if (!e.target || e.target.closest(".disabled"))
             return;
-        if (isDedicatedTodoTarget(e.target))
+        if (todoControls.isDedicatedTodoTarget(e.target))
             return;
 
         var contextMenuElement = e.target.closest("#projectContextMenu [data-action]");
@@ -1559,13 +1260,13 @@ function initProjects() {
             return;
         }
 
-        if (onTodoAction(e)) {
+        if (todoControls.onTodoAction(e)) {
             return;
         }
 
         var todoItem = e.target.closest('.todo-item[data-todo-id]');
-        if (todoItem && !todoItem.classList.contains('editing') && !isTodoInteractiveTarget(e.target)) {
-            toggleTodoItemExpanded(todoItem);
+        if (todoItem && !todoItem.classList.contains('editing') && !todoControls.isTodoInteractiveTarget(e.target)) {
+            todoControls.toggleTodoItemExpanded(todoItem);
             return;
         }
 
@@ -1577,7 +1278,7 @@ function initProjects() {
 
         var groupDiv = e.target.closest('.group');
         if (groupDiv) {
-            onInsideGroupClick(e, groupDiv);
+            todoControls.onInsideGroupClick(e, groupDiv);
             return;
         }
     }
@@ -1585,12 +1286,12 @@ function initProjects() {
     function onChangeEvent(e) {
         if (!e.target)
             return;
-        if (isDedicatedTodoTarget(e.target))
+        if (todoControls.isDedicatedTodoTarget(e.target))
             return;
 
         var todoPriorityInput = e.target.closest('.todo-priority-choice input[name="priority"]');
         if (todoPriorityInput) {
-            syncTodoPrioritySegment(todoPriorityInput.closest('.todo-priority-segment'));
+            todoControls.syncTodoPrioritySegment(todoPriorityInput.closest('.todo-priority-segment'));
             return;
         }
 
@@ -1912,7 +1613,7 @@ function initProjects() {
     });
 
     document.addEventListener('change', onChangeEvent);
-    document.addEventListener('submit', onTodoFormSubmit);
+    document.addEventListener('submit', e => todoControls.onTodoFormSubmit(e));
 
     document.addEventListener('mousedown', (e) => {
         if (e.target.closest('.codex-session-row')) {
@@ -2065,7 +1766,7 @@ function initProjects() {
             var editForm = e.target && e.target.closest ? e.target.closest('.todo-edit-form') : null;
             if (editForm) {
                 e.preventDefault();
-                setTodoEditing(editForm.getAttribute('data-todo-id'), false);
+                todoControls.setTodoEditing(editForm.getAttribute('data-todo-id'), false);
                 return;
             }
             closeContextMenus();

--- a/media/webviewProjectScripts.js
+++ b/media/webviewProjectScripts.js
@@ -945,7 +945,7 @@ function initProjects() {
             groupId: groupId,
             collapsed,
         });
-        syncCollapseButton();
+        groupCollapse.syncCollapseButton();
     }
 
     function onTodoAction(e) {
@@ -1012,7 +1012,7 @@ function initProjects() {
                 groupId: todoGroup.getAttribute('data-todo-group-id'),
                 collapsed: todoGroup.classList.contains('collapsed'),
             });
-            syncCollapseButton();
+            groupCollapse.syncCollapseButton();
             return true;
         }
 
@@ -1492,90 +1492,7 @@ function initProjects() {
         );
     }
 
-    function updateToggleAllGroupsButton(state) {
-        document.body.classList.toggle("steward-all-collapsed", state.collapsed);
-        var button = document.querySelector('[data-action="toggle-all-groups"]');
-        if (!button)
-            return;
-
-        button.disabled = state.disabled;
-        button.setAttribute('aria-disabled', state.disabled ? 'true' : 'false');
-        button.setAttribute("title", state.title);
-        button.setAttribute("aria-label", state.title);
-    }
-
-    function getActiveDashboardTab() {
-        var dashboard = window.__agentPivotDashboard;
-        var selectedTab = !dashboard && document.querySelector
-            ? document.querySelector('[data-dashboard-tab][aria-selected="true"]')
-            : null;
-        var activeTab = dashboard && typeof dashboard.getActiveTab === 'function'
-            ? dashboard.getActiveTab()
-            : selectedTab && selectedTab.getAttribute('data-dashboard-tab');
-        return activeTab === 'projects' || activeTab === 'todo' || activeTab === 'ai'
-            ? activeTab
-            : 'open';
-    }
-
-    function getActiveCollapsibleGroups() {
-        var activeTab = getActiveDashboardTab();
-        var selector = activeTab === 'projects'
-            ? '#dashboard-tab-projects .group[data-group-id]'
-            : activeTab === 'todo'
-                ? '#dashboard-tab-todo .todo-group[data-todo-group-id]'
-                : activeTab === 'open'
-                    ? '#dashboard-tab-open .open-other-windows-group[data-group-id]'
-                    : null;
-        if (!selector) {
-            return [];
-        }
-        return [...document.querySelectorAll(selector)];
-    }
-
-    function setGroupCollapsed(group, collapsed, persist) {
-        group.classList.toggle('collapsed', collapsed);
-        if (persist) {
-            var isTodoGroup = group.classList.contains('todo-group');
-            window.vscode.postMessage({
-                type: isTodoGroup ? 'todo-collapse-group' : 'collapse-group',
-                groupId: isTodoGroup
-                    ? group.getAttribute('data-todo-group-id')
-                    : group.getAttribute('data-group-id'),
-                collapsed,
-            });
-        }
-    }
-
-    function syncCollapseButton() {
-        var activeTab = getActiveDashboardTab();
-        var groups = getActiveCollapsibleGroups();
-        updateToggleAllGroupsButton(getCollapseButtonState(
-            activeTab,
-            groups.map(group => group.classList.contains('collapsed'))
-        ));
-    }
-
-    function toggleAllGroups() {
-        var activeTab = getActiveDashboardTab();
-        var groups = getActiveCollapsibleGroups();
-        var shouldCollapse = groups.some(group => !group.classList.contains("collapsed"));
-
-        if (activeTab === 'todo') {
-            if (window.__agentPivotTodo
-                && typeof window.__agentPivotTodo.dispatch === 'function') {
-                window.__agentPivotTodo.dispatch('collapse-groups', { collapsed: shouldCollapse });
-            } else {
-                collapseTodoGroups(groups, shouldCollapse, message => window.vscode.postMessage(message));
-            }
-            syncCollapseButton();
-            return;
-        }
-
-        groups.forEach(group => setGroupCollapsed(group, shouldCollapse, true));
-        syncCollapseButton();
-    }
-
-    window.__agentPivotSyncCollapseButton = syncCollapseButton;
+    var groupCollapse = initProjectGroupCollapse();
 
     function onMouseEvent(e) {
         if (!e.target || e.target.closest(".disabled"))
@@ -1607,7 +1524,7 @@ function initProjects() {
         }
 
         if (e.target.closest('[data-action="toggle-all-groups"]')) {
-            toggleAllGroups();
+            groupCollapse.toggleAllGroups();
             return;
         }
 
@@ -1708,7 +1625,7 @@ function initProjects() {
                 if (todoRoot && typeof initDnD === 'function' && typeof disposeDnD === 'function') {
                     disposeDnD(todoRoot);
                     initDnD(todoRoot);
-                    syncCollapseButton();
+                    groupCollapse.syncCollapseButton();
                 }
             }, 0);
         }

--- a/media/webviewProjectScripts.js
+++ b/media/webviewProjectScripts.js
@@ -174,157 +174,6 @@ function initProjects() {
         CurrentWindow: 3,
     };
 
-    var batchAiSessionState = {
-        projectId: null,
-        selectedItems: new Map(),
-        pending: false,
-        requestId: null,
-    };
-    var activeAiSessionTerminalState = { provider: null, sessionId: null };
-    var nextAiSessionBatchArchiveRequestId = 0;
-    var nextAiSessionProviderSelectionRequestId = 0;
-    var pendingAiSessionProviderSelectionProjectId = null;
-    var pendingAiSessionProviderSelectionRequestId = null;
-    var pendingAiSessionProviderSelectionProviders = [];
-
-    function getAiSessionBatchItemKey(provider, sessionId) {
-        return JSON.stringify([provider, sessionId]);
-    }
-
-    function enter(projectId) {
-        if (batchAiSessionState.pending)
-            return;
-        batchAiSessionState.projectId = projectId;
-        batchAiSessionState.selectedItems = new Map();
-        batchAiSessionState.pending = false;
-        batchAiSessionState.requestId = null;
-    }
-
-    function toggle(provider, sessionId, active) {
-        if (!isAiSessionProvider(provider) || !sessionId || active || batchAiSessionState.pending)
-            return;
-        var key = getAiSessionBatchItemKey(provider, sessionId);
-        if (batchAiSessionState.selectedItems.has(key))
-            batchAiSessionState.selectedItems.delete(key);
-        else
-            batchAiSessionState.selectedItems.set(key, { provider, sessionId });
-    }
-
-    function selectUnpinned(sessions) {
-        if (batchAiSessionState.pending)
-            return;
-        sessions
-            .filter(session => isAiSessionProvider(session.provider)
-                && session.id && !session.pinned && !session.active)
-            .forEach(session => {
-                var item = { provider: session.provider, sessionId: session.id };
-                batchAiSessionState.selectedItems.set(
-                    getAiSessionBatchItemKey(item.provider, item.sessionId),
-                    item
-                );
-            });
-    }
-
-    function clear() {
-        if (!batchAiSessionState.pending)
-            batchAiSessionState.selectedItems.clear();
-    }
-
-    function reconcile(projectId, remainingItems) {
-        if (projectId !== batchAiSessionState.projectId) {
-            exit();
-            return;
-        }
-        let selectedItems = batchAiSessionState.selectedItems;
-        batchAiSessionState.selectedItems = new Map(
-            remainingItems
-                .filter(item => item && isAiSessionProvider(item.provider) && item.sessionId)
-                .map(item => {
-                    var key = getAiSessionBatchItemKey(item.provider, item.sessionId);
-                    return [key, selectedItems.get(key)];
-                })
-                .filter(entry => entry[1])
-        );
-    }
-
-    function reconcileVisible(projectDiv) {
-        if (!projectDiv)
-            return;
-        var projectId = projectDiv.getAttribute('data-id');
-        var remainingItems = Array.from(
-            projectDiv.querySelectorAll('.ai-session-history-panel .codex-session-row[data-session-id]')
-        )
-            .filter(row => isAiSessionProvider(row.getAttribute('data-session-provider') || 'codex')
-                && row.getAttribute('data-session-id')
-                && !row.hasAttribute('data-session-active'))
-            .map(row => ({
-                provider: row.getAttribute('data-session-provider') || 'codex',
-                sessionId: row.getAttribute('data-session-id'),
-            }));
-        reconcile(projectId, remainingItems);
-    }
-
-    function submit() {
-        if (batchAiSessionState.pending || !batchAiSessionState.selectedItems.size)
-            return;
-        nextAiSessionBatchArchiveRequestId = nextAiSessionBatchArchiveRequestId >= Number.MAX_SAFE_INTEGER
-            ? 1
-            : nextAiSessionBatchArchiveRequestId + 1;
-        var requestId = nextAiSessionBatchArchiveRequestId;
-        batchAiSessionState.pending = true;
-        batchAiSessionState.requestId = requestId;
-        window.vscode.postMessage({
-            type: 'archive-ai-sessions',
-            version: 1,
-            requestId: requestId,
-            projectId: batchAiSessionState.projectId,
-            items: Array.from(batchAiSessionState.selectedItems.values()),
-        });
-    }
-
-    function complete(message) {
-        if (!message
-            || message.type !== 'ai-session-batch-archive-completed'
-            || message.version !== 1
-            || !Number.isSafeInteger(message.requestId)
-            || message.requestId < 1
-            || typeof message.projectId !== 'string'
-            || !['cancelled', 'rejected', 'finished'].includes(message.status)
-            || !batchAiSessionState.pending
-            || message.projectId !== batchAiSessionState.projectId
-            || message.requestId !== batchAiSessionState.requestId) {
-            return false;
-        }
-        if (message.status === 'finished') {
-            exit();
-            return true;
-        }
-        batchAiSessionState.pending = false;
-        batchAiSessionState.requestId = null;
-        return true;
-    }
-
-    function exit() {
-        batchAiSessionState.projectId = null;
-        batchAiSessionState.selectedItems = new Map();
-        batchAiSessionState.pending = false;
-        batchAiSessionState.requestId = null;
-    }
-
-    function snapshot() {
-        return {
-            projectId: batchAiSessionState.projectId,
-            selectedItems: Array.from(batchAiSessionState.selectedItems.values()),
-            pending: batchAiSessionState.pending,
-        };
-    }
-
-    var batchAiSessionManager = {
-        enter, toggle, selectUnpinned, clear, reconcile, reconcileVisible,
-        submit, complete, exit, snapshot,
-    };
-    window.__agentPivotBatchAiSessions = batchAiSessionManager;
-
     function openProject(projectId, projectOpenType) {
         window.vscode.postMessage({
             type: 'selected-project',
@@ -364,7 +213,7 @@ function initProjects() {
         if (dataId == null)
             return;
 
-        if (onTriggerAiSessionAction(e.target, dataId))
+        if (aiSessionControls.onTriggerAiSessionAction(e.target, dataId))
             return;
 
         if (contextMenus.onTriggerProjectAction(e.target, dataId))
@@ -374,7 +223,7 @@ function initProjects() {
             if (e.target.closest('[data-ai-session-region]'))
                 return;
 
-            toggleCodexSessions(projectDiv, dataId);
+            aiSessionControls.toggleCodexSessions(projectDiv, dataId);
             return;
         }
 
@@ -393,544 +242,34 @@ function initProjects() {
 
     }
 
-    function onTriggerAiSessionAction(target, projectId) {
-        var projectDiv = target.closest('.project[data-id]');
-        var tabAction = target.closest('[data-action="select-ai-session-tab"][data-tab]');
-        if (tabAction) {
-            var selectedTab = normalizeAiSessionTab(tabAction.getAttribute('data-tab'));
-            selectAiSessionTabDom(projectDiv, selectedTab);
-            writeAiSessionTabState(window.vscode, projectId, selectedTab);
-            return true;
-        }
-
-        var providerMenuTrigger = target.closest('[data-ai-provider-menu-trigger]');
-        if (providerMenuTrigger) {
-            toggleAiSessionProviderMenu(projectDiv);
-            return true;
-        }
-
-        var providerOption = target.closest('[data-ai-provider-option][data-provider]');
-        if (providerOption) {
-            activateAiSessionProviderOption(projectDiv, providerOption);
-            return true;
-        }
-
-        var createAction = target.closest('[data-action="create-ai-session"]');
-        if (createAction) {
-            window.vscode.postMessage({
-                type: 'create-ai-session',
-                projectId,
-            });
-
-            return true;
-        }
-
-        var manageAction = target.closest('[data-action="manage-ai-sessions"][data-provider]');
-        if (manageAction) {
-            if (batchAiSessionState.pending
-                || pendingAiSessionProviderSelectionProjectId)
-                return true;
-
-            var manageProvider = manageAction.getAttribute("data-provider");
-            if (projectDiv && isAiSessionProvider(manageProvider)) {
-                if (isActiveAiSessionBatchScope(projectId, manageProvider)) {
-                    exitAiSessionBatchManagement();
-                } else {
-                    batchAiSessionManager.enter(projectId);
-                    syncAiSessionBatchManagementDom(projectDiv);
-                }
-            }
-
-            return true;
-        }
-
-        var selectUnpinnedAction = target.closest('[data-action="select-unpinned-ai-sessions"]');
-        if (selectUnpinnedAction) {
-            if (isActiveAiSessionBatchScope(projectId, getProjectActiveAiSessionProvider(projectDiv))) {
-                var sessions = Array.from(projectDiv.querySelectorAll('.ai-session-history-panel .codex-session-row[data-session-id]'))
-                    .map(row => ({
-                        provider: row.getAttribute("data-session-provider") || "codex",
-                        id: row.getAttribute("data-session-id"),
-                        pinned: row.hasAttribute("data-session-pinned"),
-                        active: row.hasAttribute("data-session-active"),
-                    }));
-                batchAiSessionManager.selectUnpinned(sessions);
-                syncAiSessionBatchManagementDom(projectDiv);
-            }
-
-            return true;
-        }
-
-        var clearSelectionAction = target.closest('[data-action="clear-ai-session-selection"]');
-        if (clearSelectionAction) {
-            if (isActiveAiSessionBatchScope(projectId, getProjectActiveAiSessionProvider(projectDiv))) {
-                batchAiSessionManager.clear();
-                syncAiSessionBatchManagementDom(projectDiv);
-            }
-
-            return true;
-        }
-
-        var archiveSelectedAction = target.closest('[data-action="archive-selected-ai-sessions"]');
-        if (archiveSelectedAction) {
-            if (isActiveAiSessionBatchScope(projectId, getProjectActiveAiSessionProvider(projectDiv))) {
-                batchAiSessionManager.submit();
-                syncAiSessionBatchManagementDom(projectDiv);
-            }
-
-            return true;
-        }
-
-        var terminalAction = target.closest('[data-action="close-ai-session-terminal"], [data-action="detach-ai-session-terminal"]');
-        if (terminalAction) {
-            var terminalRow = terminalAction.closest('.codex-session-row[data-session-provider][data-session-backend]');
-            var terminalProvider = terminalRow && terminalRow.getAttribute('data-session-provider');
-            var terminalBackend = terminalRow && terminalRow.getAttribute('data-session-backend');
-            var requestedDetach = terminalAction.getAttribute('data-action') === 'detach-ai-session-terminal';
-            if (terminalRow && isAiSessionProvider(terminalProvider)
-                && ((requestedDetach && terminalBackend === 'tmux')
-                    || (!requestedDetach && terminalBackend === 'vscode'))) {
-                var terminalMessage = {
-                    type: requestedDetach ? 'detach-ai-session-terminal' : 'close-ai-session-terminal',
-                    projectId,
-                    provider: terminalProvider,
-                };
-                if (terminalRow.hasAttribute('data-session-pending')) {
-                    terminalMessage.pendingCreatedAt = terminalRow.getAttribute('data-pending-created-at');
-                } else {
-                    terminalMessage.sessionId = terminalRow.getAttribute('data-session-id');
-                }
-                window.vscode.postMessage(terminalMessage);
-            }
-            return true;
-        }
-
-        var managedSessionRow = target.closest('.codex-session-row[data-session-id]');
-        if (managedSessionRow) {
-            var managedSessionProvider = managedSessionRow.getAttribute("data-session-provider") || "codex";
-            if (isActiveAiSessionBatchScope(projectId, managedSessionProvider)
-                && !managedSessionRow.hasAttribute('data-session-active')) {
-                batchAiSessionManager.toggle(
-                    managedSessionProvider,
-                    managedSessionRow.getAttribute("data-session-id"),
-                    managedSessionRow.hasAttribute('data-session-active')
-                );
-                syncAiSessionBatchManagementDom(projectDiv);
-                return true;
-            }
-        }
-
-        var pinAction = target.closest('[data-action="toggle-ai-session-pin"]');
-        if (pinAction) {
-            var pinRow = pinAction.closest('.codex-session-row[data-session-id]');
-            var pinSessionId = pinRow && pinRow.getAttribute("data-session-id");
-            var pinProvider = pinRow && pinRow.getAttribute("data-session-provider") || "codex";
-            if (pinSessionId) {
-                window.vscode.postMessage({
-                    type: 'toggle-ai-session-pin',
-                    projectId,
-                    provider: pinProvider,
-                    sessionId: pinSessionId,
-                });
-            }
-
-            return true;
-        }
-
-        var archiveAction = target.closest('[data-action="archive-codex-session"], [data-action="archive-kimi-session"], [data-action="archive-claude-session"]');
-        if (archiveAction) {
-            var archiveRow = archiveAction.closest('.codex-session-row[data-session-id]');
-            var archiveSessionId = archiveRow && archiveRow.getAttribute("data-session-id");
-            var archiveProvider = archiveRow && archiveRow.getAttribute("data-session-provider") || "codex";
-            if (archiveSessionId && isAiSessionProvider(archiveProvider)) {
-                acknowledgeAiSessionRow(archiveRow);
-                window.vscode.postMessage({
-                    type: getArchiveAiSessionMessageType(archiveProvider),
-                    projectId,
-                    sessionId: archiveSessionId,
-                });
-            }
-
-            return true;
-        }
-
-        var activation = getAiSessionCardActivation(target, projectId);
-        if (!activation.handled)
-            return false;
-        if (activation.sessionRow
-            && !activation.sessionRow.hasAttribute('data-session-pending')
-            && activation.sessionRow.getAttribute('data-session-id')) {
-            acknowledgeAiSessionRow(activation.sessionRow);
-        }
-        if (activation.message) {
-            window.vscode.postMessage(activation.message);
-        }
-        return true;
-    }
-
-    function acknowledgeAiSessionRow(sessionRow) {
-        if (!sessionRow || !sessionRow.hasAttribute('data-ai-session-attention')) return;
-        var provider = sessionRow.getAttribute('data-session-provider') || 'codex';
-        var sessionId = sessionRow.getAttribute('data-session-id') || '';
-        var fallback = sessionRow.getAttribute('data-session-event-id') || sessionRow.getAttribute('data-ai-session-event-id');
-        acknowledgeAiSession(provider, sessionId, fallback);
-    }
-
-    function acknowledgeAiSession(provider, sessionId, fallbackEventId) {
-        var sessionKey = provider + ':' + sessionId;
-        window.__agentPivotAttentionSessionEvents = window.__agentPivotAttentionSessionEvents || {};
-        var eventIds = window.__agentPivotAttentionSessionEvents[sessionKey] || [];
-        if (!eventIds.length && fallbackEventId) {
-            eventIds = [fallbackEventId];
-        }
-        eventIds = Array.from(new Set(eventIds.filter(eventId => typeof eventId === 'string' && !!eventId)));
-        if (eventIds.length) {
-            window.vscode.postMessage({ type: 'acknowledge-ai-session-attention', eventIds: eventIds });
-        }
-    }
-
-    window.__agentPivotAcknowledgeSession = (provider, sessionId) => {
-        if (isAiSessionProvider(provider) && sessionId) {
-            acknowledgeAiSession(provider, sessionId);
-        }
-    };
-
-    function getSelectedAiSessionProviders(projectDiv) {
-        var region = projectDiv && projectDiv.querySelector('[data-ai-session-region]');
-        return (region && region.getAttribute('data-selected-ai-session-providers') || '')
-            .split(',')
-            .filter(isAiSessionProvider);
-    }
-
-    function submitAiSessionProviderSelection(projectDiv, providers) {
-        var projectId = projectDiv && projectDiv.getAttribute('data-id');
-        if (!projectId || !providers.length || batchAiSessionState.pending
-            || pendingAiSessionProviderSelectionProjectId)
-            return;
-
-        exitAiSessionBatchManagement();
-        nextAiSessionProviderSelectionRequestId += 1;
-        var requestId = nextAiSessionProviderSelectionRequestId;
-        pendingAiSessionProviderSelectionProjectId = projectId;
-        pendingAiSessionProviderSelectionRequestId = requestId;
-        pendingAiSessionProviderSelectionProviders = providers.slice();
-        syncAiSessionProviderMenuDisabledDom(projectDiv, true);
-        window.vscode.postMessage({
-            type: 'select-ai-session-providers',
-            version: 1,
-            requestId: requestId,
-            projectId,
-            selectedProviders: providers,
-        });
-    }
-
-    function setAiSessionProviderMenuOpen(projectDiv, open) {
-        var trigger = projectDiv && projectDiv.querySelector('[data-ai-provider-menu-trigger]');
-        var menu = projectDiv && projectDiv.querySelector('[data-ai-provider-menu]');
-        if (!trigger || !menu)
-            return;
-        if (open && (batchAiSessionState.pending
-            || pendingAiSessionProviderSelectionProjectId))
-            return;
-
-        trigger.setAttribute('aria-expanded', open ? 'true' : 'false');
-        menu.hidden = !open;
-    }
-
-    function closeAiSessionProviderMenus(exceptProjectDiv) {
-        document.querySelectorAll('.project[data-id]').forEach(projectDiv => {
-            if (projectDiv !== exceptProjectDiv) {
-                setAiSessionProviderMenuOpen(projectDiv, false);
-            }
-        });
-    }
-
-    function closeAiSessionProviderMenu(projectDiv, restoreFocus) {
-        setAiSessionProviderMenuOpen(projectDiv, false);
-        if (restoreFocus) {
-            projectDiv?.querySelector('[data-ai-provider-menu-trigger]')?.focus();
-        }
-    }
-
-    function toggleAiSessionProviderMenu(projectDiv) {
-        if (!projectDiv || batchAiSessionState.pending
-            || pendingAiSessionProviderSelectionProjectId)
-            return;
-        var trigger = projectDiv.querySelector('[data-ai-provider-menu-trigger]');
-        var open = trigger?.getAttribute('aria-expanded') !== 'true';
-        closeAiSessionProviderMenus(projectDiv);
-        setAiSessionProviderMenuOpen(projectDiv, open);
-    }
-
-    function activateAiSessionProviderOption(projectDiv, option) {
-        if (!projectDiv || !option || batchAiSessionState.pending
-            || pendingAiSessionProviderSelectionProjectId)
-            return;
-        var provider = option.getAttribute('data-provider');
-        if (!isAiSessionProvider(provider))
-            return;
-        var selectedProviders = getSelectedAiSessionProviders(projectDiv);
-        var selected = selectedProviders.includes(provider);
-        if (selected && selectedProviders.length === 1)
-            return;
-        submitAiSessionProviderSelection(
-            projectDiv,
-            selected
-                ? selectedProviders.filter(candidate => candidate !== provider)
-                : selectedProviders.concat(provider)
-        );
-    }
-
-    function getAiSessionProviderOptions(projectDiv) {
-        return projectDiv
-            ? Array.from(projectDiv.querySelectorAll('[data-ai-provider-option][data-provider]'))
-            : [];
-    }
-
-    function isAiSessionProvider(provider) {
-        return provider === "codex" || provider === "kimi" || provider === "claude";
-    }
-
-    function getResumeAiSessionMessageType(provider) {
-        if (provider === "kimi")
-            return 'resume-kimi-session';
-        if (provider === "claude")
-            return 'resume-claude-session';
-
-        return 'resume-codex-session';
-    }
-
-    function getArchiveAiSessionMessageType(provider) {
-        if (provider === "kimi")
-            return 'archive-kimi-session';
-        if (provider === "claude")
-            return 'archive-claude-session';
-
-        return 'archive-codex-session';
-    }
-
-    function toggleCodexSessions(projectDiv, projectId) {
-        var expanded = !projectDiv.hasAttribute("data-codex-expanded");
-        if (!expanded && batchAiSessionState.projectId === projectId) {
-            exitAiSessionBatchManagement();
-        }
-        projectDiv.toggleAttribute("data-codex-expanded", expanded);
-        updateStickyGroupHeaderOffset();
-
-        window.vscode.postMessage({
-            type: 'toggle-codex-sessions',
-            projectId,
-            expanded,
-        });
-    }
-
-    function isActiveAiSessionBatchScope(projectId) {
-        return projectId === batchAiSessionState.projectId;
-    }
-
-    function getProjectActiveAiSessionProvider(projectDiv) {
-        if (!projectDiv)
-            return null;
-
-        var region = projectDiv.querySelector('[data-ai-session-region]');
-        var activeProvider = region && region.getAttribute('data-active-ai-session-provider');
-        if (isAiSessionProvider(activeProvider))
-            return activeProvider;
-
-        var selectedProviders = region && region.getAttribute('data-selected-ai-session-providers') || '';
-        return selectedProviders.split(',').find(isAiSessionProvider) || null;
-    }
-
-    function syncActiveAiSessionTerminalDom() {
-        document.querySelectorAll('.codex-session-row[data-session-id]').forEach(row => {
-            var provider = row.getAttribute('data-session-provider') || 'codex';
-            var sessionId = row.getAttribute('data-session-id');
-            row.toggleAttribute(
-                'data-ai-session-active-terminal',
-                provider === activeAiSessionTerminalState.provider
-                    && sessionId === activeAiSessionTerminalState.sessionId
-            );
-        });
-    }
-
-    function syncAiSessionBatchManagementDom(projectDiv) {
-        var snapshot = batchAiSessionManager.snapshot();
-        document.querySelectorAll('.project[data-ai-session-managing], .project[data-ai-session-pending]').forEach(project => {
-            if (project !== projectDiv || project.getAttribute("data-id") !== snapshot.projectId) {
-                project.removeAttribute("data-ai-session-managing");
-                project.removeAttribute("data-ai-session-pending");
-                syncAiSessionProviderMenuDisabledDom(project, false);
-                var inactiveManageButton = project.querySelector('[data-action="manage-ai-sessions"]');
-                if (inactiveManageButton) {
-                    inactiveManageButton.setAttribute('aria-pressed', 'false');
-                    inactiveManageButton.disabled = false;
-                }
-            }
-        });
-
-        if (!projectDiv)
-            return;
-
-        var projectId = projectDiv.getAttribute("data-id");
-        var isScoped = projectId === snapshot.projectId;
-        projectDiv.toggleAttribute("data-ai-session-managing", isScoped);
-        projectDiv.toggleAttribute("data-ai-session-pending", isScoped && snapshot.pending);
-        syncAiSessionProviderMenuDisabledDom(projectDiv, isScoped && snapshot.pending);
-        var manageButton = projectDiv.querySelector('[data-action="manage-ai-sessions"]');
-        if (manageButton) {
-            manageButton.setAttribute('aria-pressed', isScoped ? 'true' : 'false');
-            manageButton.disabled = isScoped && snapshot.pending;
-        }
-
-        var selectedItems = new Set(snapshot.selectedItems.map(item =>
-            getAiSessionBatchItemKey(item.provider, item.sessionId)
-        ));
-        projectDiv.querySelectorAll('.ai-session-history-panel .codex-session-row[data-session-id]').forEach(row => {
-            var rowProvider = row.getAttribute("data-session-provider") || "codex";
-            var isActive = row.hasAttribute('data-session-active');
-            var isSelected = isScoped
-                && !isActive
-                && selectedItems.has(getAiSessionBatchItemKey(
-                    rowProvider,
-                    row.getAttribute("data-session-id")
-                ));
-            row.toggleAttribute("data-ai-session-selected", isSelected);
-            var checkbox = row.querySelector('.ai-session-batch-checkbox');
-            if (checkbox) {
-                checkbox.checked = isSelected;
-                checkbox.disabled = isActive || (isScoped && snapshot.pending);
-            }
-        });
-
-        var count = isScoped ? snapshot.selectedItems.length : 0;
-        var countElement = projectDiv.querySelector('.ai-session-batch-count');
-        if (countElement) {
-            countElement.textContent = count + ' selected';
-        }
-        projectDiv.querySelectorAll('.ai-session-batch-actions button').forEach(button => {
-            button.disabled = isScoped && snapshot.pending;
-        });
-        var archiveButton = projectDiv.querySelector('[data-action="archive-selected-ai-sessions"]');
-        if (archiveButton) {
-            archiveButton.disabled = !isScoped || snapshot.pending || count === 0;
-        }
-    }
-
-    function syncAiSessionProviderMenuDisabledDom(projectDiv, batchPending) {
-        var projectId = projectDiv?.getAttribute('data-id');
-        var providerSelectionPending = projectId
-            === pendingAiSessionProviderSelectionProjectId;
-        var pending = Boolean(
-            batchPending || batchAiSessionState.pending || providerSelectionPending
-        );
-        var trigger = projectDiv && projectDiv.querySelector('[data-ai-provider-menu-trigger]');
-        if (trigger) {
-            trigger.disabled = pending;
-            trigger.setAttribute('aria-disabled', pending ? 'true' : 'false');
-        }
-        var selectedProviders = getSelectedAiSessionProviders(projectDiv);
-        getAiSessionProviderOptions(projectDiv).forEach(option => {
-            var provider = option.getAttribute('data-provider');
-            var lastSelectedProvider = selectedProviders.length === 1
-                && selectedProviders[0] === provider;
-            option.disabled = pending;
-            option.setAttribute(
-                'aria-disabled',
-                pending || lastSelectedProvider ? 'true' : 'false'
-            );
-        });
-        if (pending) {
-            closeAiSessionProviderMenu(projectDiv, false);
-        }
-    }
-
-    function clearPendingAiSessionProviderSelection() {
-        pendingAiSessionProviderSelectionProjectId = null;
-        pendingAiSessionProviderSelectionRequestId = null;
-        pendingAiSessionProviderSelectionProviders = [];
-    }
-
-    function selectedAiSessionProvidersMatch(projectDiv, expectedProviders) {
-        var selectedProviders = getSelectedAiSessionProviders(projectDiv);
-        return selectedProviders.length === expectedProviders.length
-            && selectedProviders.every(provider =>
-                expectedProviders.includes(provider)
-            );
-    }
-
-    function reconcilePendingAiSessionProviderSelectionDom() {
-        if (!pendingAiSessionProviderSelectionProjectId)
-            return;
-        var projectDiv = aiSessionsUpdate.findCurrentWorkspaceDiv(
-            pendingAiSessionProviderSelectionProjectId
-        );
-        if (!projectDiv)
-            return;
-        if (selectedAiSessionProvidersMatch(
-            projectDiv,
-            pendingAiSessionProviderSelectionProviders
-        )) {
-            clearPendingAiSessionProviderSelection();
-        }
-        syncAiSessionProviderMenuDisabledDom(projectDiv, false);
-    }
-
-    function applyAiSessionProviderSelectionResult(message) {
-        if (!message
-            || message.type !== 'ai-session-provider-selection-result'
-            || message.version !== 1
-            || !Number.isSafeInteger(message.requestId)
-            || message.requestId < 1
-            || typeof message.projectId !== 'string'
-            || typeof message.success !== 'boolean'
-            || message.projectId !== pendingAiSessionProviderSelectionProjectId
-            || message.requestId !== pendingAiSessionProviderSelectionRequestId) {
-            return false;
-        }
-        if (message.success) {
-            return true;
-        }
-
-        var projectDiv = aiSessionsUpdate.findCurrentWorkspaceDiv(message.projectId);
-        clearPendingAiSessionProviderSelection();
-        syncAiSessionProviderMenuDisabledDom(projectDiv, false);
-        var liveRegion = projectDiv?.querySelector('[data-ai-session-live-region]');
-        if (liveRegion) {
-            liveRegion.textContent = 'Could not update AI session providers. Try again.';
-        }
-        return true;
-    }
-
-    function exitAiSessionBatchManagement() {
-        var projectId = batchAiSessionState.projectId;
-        batchAiSessionManager.exit();
-        syncAiSessionBatchManagementDom(aiSessionsUpdate.findCurrentWorkspaceDiv(projectId));
-    }
-
 
     var groupCollapse = initProjectGroupCollapse();
     var todoControls = initProjectTodoControls({
         syncCollapseButton: () => groupCollapse.syncCollapseButton(),
     });
+    var aiSessionControls = initProjectAiSessionControls({
+        getAiSessionsUpdate: () => aiSessionsUpdate,
+        updateStickyGroupHeaderOffset: updateStickyGroupHeaderOffset,
+    });
     var contextMenus = initProjectContextMenus({
         openProject: openProject,
         ProjectOpenType: ProjectOpenType,
-        getResumeAiSessionMessageType: getResumeAiSessionMessageType,
-        getArchiveAiSessionMessageType: getArchiveAiSessionMessageType,
-        isAiSessionProvider: isAiSessionProvider,
+        getResumeAiSessionMessageType: aiSessionControls.getResumeAiSessionMessageType,
+        getArchiveAiSessionMessageType: aiSessionControls.getArchiveAiSessionMessageType,
+        isAiSessionProvider: aiSessionControls.isAiSessionProvider,
     });
     var aiSessionsUpdate = initProjectAiSessionsUpdate({
-        batchAiSessionState: batchAiSessionState,
-        batchAiSessionManager: batchAiSessionManager,
-        getPendingAiSessionProviderSelectionProjectId: () => pendingAiSessionProviderSelectionProjectId,
-        getSelectedAiSessionProviders: getSelectedAiSessionProviders,
-        syncAiSessionBatchManagementDom: syncAiSessionBatchManagementDom,
-        syncActiveAiSessionTerminalDom: syncActiveAiSessionTerminalDom,
-        reconcilePendingAiSessionProviderSelectionDom: reconcilePendingAiSessionProviderSelectionDom,
-        submitAiSessionProviderSelection: submitAiSessionProviderSelection,
-        toggleCodexSessions: toggleCodexSessions,
-        exitAiSessionBatchManagement: exitAiSessionBatchManagement,
-        isAiSessionProvider: isAiSessionProvider,
+        batchAiSessionState: aiSessionControls.batchAiSessionState,
+        batchAiSessionManager: aiSessionControls.batchAiSessionManager,
+        getPendingAiSessionProviderSelectionProjectId: () => aiSessionControls.getPendingAiSessionProviderSelectionProjectId(),
+        getSelectedAiSessionProviders: aiSessionControls.getSelectedAiSessionProviders,
+        syncAiSessionBatchManagementDom: aiSessionControls.syncAiSessionBatchManagementDom,
+        syncActiveAiSessionTerminalDom: aiSessionControls.syncActiveAiSessionTerminalDom,
+        reconcilePendingAiSessionProviderSelectionDom: aiSessionControls.reconcilePendingAiSessionProviderSelectionDom,
+        submitAiSessionProviderSelection: aiSessionControls.submitAiSessionProviderSelection,
+        toggleCodexSessions: aiSessionControls.toggleCodexSessions,
+        exitAiSessionBatchManagement: aiSessionControls.exitAiSessionBatchManagement,
+        isAiSessionProvider: aiSessionControls.isAiSessionProvider,
         updateStickyGroupHeaderOffset: updateStickyGroupHeaderOffset,
     });
 
@@ -960,7 +299,7 @@ function initProjects() {
 
         contextMenus.closeContextMenus();
         if (!e.target.closest('.ai-session-provider-menu-wrapper')) {
-            closeAiSessionProviderMenus();
+            aiSessionControls.closeAiSessionProviderMenus();
         }
 
         if (e.target.closest('[data-action="toggle-all-groups"]')) {
@@ -1056,7 +395,7 @@ function initProjects() {
             return;
         }
         if (message && message.type === 'ai-session-provider-selection-result') {
-            applyAiSessionProviderSelectionResult(message);
+            aiSessionControls.applyAiSessionProviderSelectionResult(message);
             return;
         }
         if (message && (message.type === 'todo-panel-content' || message.type === 'todo-panel-updated')) {
@@ -1072,23 +411,23 @@ function initProjects() {
         if (message && message.type === 'workspace-updated') {
             if (!applyWorkspaceUpdate(message, {
                 canRestoreAiSessionProviderMenu: () =>
-                    !pendingAiSessionProviderSelectionProjectId
-                    && !batchAiSessionState.pending,
+                    !aiSessionControls.getPendingAiSessionProviderSelectionProjectId()
+                    && !aiSessionControls.batchAiSessionState.pending,
             })) {
                 aiSessionsUpdate.requestFullRefresh('invalid-workspace-update');
                 return;
             }
-            if (batchAiSessionState.projectId) {
-                var managedProjectDiv = aiSessionsUpdate.findCurrentWorkspaceDiv(batchAiSessionState.projectId);
+            if (aiSessionControls.batchAiSessionState.projectId) {
+                var managedProjectDiv = aiSessionsUpdate.findCurrentWorkspaceDiv(aiSessionControls.batchAiSessionState.projectId);
                 if (managedProjectDiv) {
-                    batchAiSessionManager.reconcileVisible(managedProjectDiv);
-                    syncAiSessionBatchManagementDom(managedProjectDiv);
+                    aiSessionControls.batchAiSessionManager.reconcileVisible(managedProjectDiv);
+                    aiSessionControls.syncAiSessionBatchManagementDom(managedProjectDiv);
                 } else {
-                    exitAiSessionBatchManagement();
+                    aiSessionControls.exitAiSessionBatchManagement();
                 }
             }
-            reconcilePendingAiSessionProviderSelectionDom();
-            syncActiveAiSessionTerminalDom();
+            aiSessionControls.reconcilePendingAiSessionProviderSelectionDom();
+            aiSessionControls.syncActiveAiSessionTerminalDom();
             updateStickyGroupHeaderOffset();
             var renderedWorkspaceState = getWorkspaceUpdateDomState(document);
             window.vscode.postMessage({
@@ -1103,7 +442,7 @@ function initProjects() {
                 aiSessionsUpdate.requestFullRefresh('invalid-open-workspaces-update');
                 return;
             }
-            syncActiveAiSessionTerminalDom();
+            aiSessionControls.syncActiveAiSessionTerminalDom();
             updateStickyGroupHeaderOffset();
             var renderedOpenWorkspaceState = getOpenWorkspacesUpdateDomState();
             window.vscode.postMessage({
@@ -1139,9 +478,9 @@ function initProjects() {
         }
 
         if (message && message.type === 'active-ai-session-terminal-changed') {
-            activeAiSessionTerminalState.provider = isAiSessionProvider(message.provider) ? message.provider : null;
-            activeAiSessionTerminalState.sessionId = typeof message.sessionId === 'string' ? message.sessionId : null;
-            syncActiveAiSessionTerminalDom();
+            aiSessionControls.activeAiSessionTerminalState.provider = aiSessionControls.isAiSessionProvider(message.provider) ? message.provider : null;
+            aiSessionControls.activeAiSessionTerminalState.sessionId = typeof message.sessionId === 'string' ? message.sessionId : null;
+            aiSessionControls.syncActiveAiSessionTerminalDom();
             return;
         }
 
@@ -1151,7 +490,7 @@ function initProjects() {
             (Array.isArray(message.sessionEvents) ? message.sessionEvents.slice(0, 1000) : []).forEach(session => {
                 if (!session || typeof session.sessionKey !== 'string' || !Array.isArray(session.eventIds)) return;
                 var separator = session.sessionKey.indexOf(':');
-                if (separator <= 0 || !isAiSessionProvider(session.sessionKey.slice(0, separator))) return;
+                if (separator <= 0 || !aiSessionControls.isAiSessionProvider(session.sessionKey.slice(0, separator))) return;
                 var eventIds = Array.from(new Set(session.eventIds
                     .slice(0, 1000)
                     .filter(eventId => typeof eventId === 'string' && !!eventId)));
@@ -1164,9 +503,9 @@ function initProjects() {
         }
 
         if (message && message.type === 'ai-session-batch-archive-completed') {
-            if (batchAiSessionManager.complete(message)) {
+            if (aiSessionControls.batchAiSessionManager.complete(message)) {
                 var completedProject = aiSessionsUpdate.findCurrentWorkspaceDiv(message.projectId);
-                syncAiSessionBatchManagementDom(completedProject);
+                aiSessionControls.syncAiSessionBatchManagementDom(completedProject);
                 var archiveLiveRegion = completedProject
                     && completedProject.querySelector('[data-ai-session-live-region]');
                 if (archiveLiveRegion) {
@@ -1232,9 +571,9 @@ function initProjects() {
                 || e.key === 'Home' || e.key === 'End')) {
             e.preventDefault();
             var triggerProject = aiSessionProviderTrigger.closest('.project[data-id]');
-            closeAiSessionProviderMenus(triggerProject);
-            setAiSessionProviderMenuOpen(triggerProject, true);
-            var triggerOptions = getAiSessionProviderOptions(triggerProject);
+            aiSessionControls.closeAiSessionProviderMenus(triggerProject);
+            aiSessionControls.setAiSessionProviderMenuOpen(triggerProject, true);
+            var triggerOptions = aiSessionControls.getAiSessionProviderOptions(triggerProject);
             var triggerOptionIndex = e.key === 'ArrowUp' || e.key === 'End'
                 ? triggerOptions.length - 1
                 : 0;
@@ -1243,7 +582,7 @@ function initProjects() {
         }
         if (aiSessionProviderTrigger && e.key === 'Escape') {
             e.preventDefault();
-            closeAiSessionProviderMenu(
+            aiSessionControls.closeAiSessionProviderMenu(
                 aiSessionProviderTrigger.closest('.project[data-id]'),
                 true
             );
@@ -1255,7 +594,7 @@ function initProjects() {
             : null;
         if (aiSessionProviderOption) {
             var providerProject = aiSessionProviderOption.closest('.project[data-id]');
-            var providerOptions = getAiSessionProviderOptions(providerProject);
+            var providerOptions = aiSessionControls.getAiSessionProviderOptions(providerProject);
             var providerOptionIndex = providerOptions.indexOf(aiSessionProviderOption);
             if (e.key === 'ArrowDown' || e.key === 'ArrowUp'
                 || e.key === 'Home' || e.key === 'End') {
@@ -1269,16 +608,16 @@ function initProjects() {
             }
             if (e.key === 'Enter' || e.key === ' ') {
                 e.preventDefault();
-                activateAiSessionProviderOption(providerProject, aiSessionProviderOption);
+                aiSessionControls.activateAiSessionProviderOption(providerProject, aiSessionProviderOption);
                 return;
             }
             if (e.key === 'Escape') {
                 e.preventDefault();
-                closeAiSessionProviderMenu(providerProject, true);
+                aiSessionControls.closeAiSessionProviderMenu(providerProject, true);
                 return;
             }
             if (e.key === 'Tab') {
-                closeAiSessionProviderMenu(providerProject, false);
+                aiSessionControls.closeAiSessionProviderMenu(providerProject, false);
             }
         }
 
@@ -1330,7 +669,7 @@ function initProjects() {
             e.preventDefault();
             var tabProject = tab.closest('.project[data-id]');
             var tabProjectId = tabProject && tabProject.getAttribute('data-id');
-            if (tabProjectId) onTriggerAiSessionAction(tab, tabProjectId);
+            if (tabProjectId) aiSessionControls.onTriggerAiSessionAction(tab, tabProjectId);
             return;
         }
 
@@ -1361,8 +700,8 @@ function initProjects() {
                 return;
             }
             contextMenus.closeContextMenus();
-            if (batchAiSessionState.projectId && !batchAiSessionState.pending) {
-                exitAiSessionBatchManagement();
+            if (aiSessionControls.batchAiSessionState.projectId && !aiSessionControls.batchAiSessionState.pending) {
+                aiSessionControls.exitAiSessionBatchManagement();
             }
         }
     });

--- a/media/webviewProjectScripts.js
+++ b/media/webviewProjectScripts.js
@@ -181,7 +181,6 @@ function initProjects() {
         requestId: null,
     };
     var activeAiSessionTerminalState = { provider: null, sessionId: null };
-    var pendingWorkspaceSessionReveal = null;
     var nextAiSessionBatchArchiveRequestId = 0;
     var nextAiSessionProviderSelectionRequestId = 0;
     var pendingAiSessionProviderSelectionProjectId = null;
@@ -862,7 +861,7 @@ function initProjects() {
     function reconcilePendingAiSessionProviderSelectionDom() {
         if (!pendingAiSessionProviderSelectionProjectId)
             return;
-        var projectDiv = findCurrentWorkspaceDiv(
+        var projectDiv = aiSessionsUpdate.findCurrentWorkspaceDiv(
             pendingAiSessionProviderSelectionProjectId
         );
         if (!projectDiv)
@@ -892,7 +891,7 @@ function initProjects() {
             return true;
         }
 
-        var projectDiv = findCurrentWorkspaceDiv(message.projectId);
+        var projectDiv = aiSessionsUpdate.findCurrentWorkspaceDiv(message.projectId);
         clearPendingAiSessionProviderSelection();
         syncAiSessionProviderMenuDisabledDom(projectDiv, false);
         var liveRegion = projectDiv?.querySelector('[data-ai-session-live-region]');
@@ -905,10 +904,9 @@ function initProjects() {
     function exitAiSessionBatchManagement() {
         var projectId = batchAiSessionState.projectId;
         batchAiSessionManager.exit();
-        syncAiSessionBatchManagementDom(findCurrentWorkspaceDiv(projectId));
+        syncAiSessionBatchManagementDom(aiSessionsUpdate.findCurrentWorkspaceDiv(projectId));
     }
 
-    var latestAiSessionUpdateSequence = 0;
 
     var groupCollapse = initProjectGroupCollapse();
     var todoControls = initProjectTodoControls({
@@ -920,6 +918,20 @@ function initProjects() {
         getResumeAiSessionMessageType: getResumeAiSessionMessageType,
         getArchiveAiSessionMessageType: getArchiveAiSessionMessageType,
         isAiSessionProvider: isAiSessionProvider,
+    });
+    var aiSessionsUpdate = initProjectAiSessionsUpdate({
+        batchAiSessionState: batchAiSessionState,
+        batchAiSessionManager: batchAiSessionManager,
+        getPendingAiSessionProviderSelectionProjectId: () => pendingAiSessionProviderSelectionProjectId,
+        getSelectedAiSessionProviders: getSelectedAiSessionProviders,
+        syncAiSessionBatchManagementDom: syncAiSessionBatchManagementDom,
+        syncActiveAiSessionTerminalDom: syncActiveAiSessionTerminalDom,
+        reconcilePendingAiSessionProviderSelectionDom: reconcilePendingAiSessionProviderSelectionDom,
+        submitAiSessionProviderSelection: submitAiSessionProviderSelection,
+        toggleCodexSessions: toggleCodexSessions,
+        exitAiSessionBatchManagement: exitAiSessionBatchManagement,
+        isAiSessionProvider: isAiSessionProvider,
+        updateStickyGroupHeaderOffset: updateStickyGroupHeaderOffset,
     });
 
     function onMouseEvent(e) {
@@ -1063,11 +1075,11 @@ function initProjects() {
                     !pendingAiSessionProviderSelectionProjectId
                     && !batchAiSessionState.pending,
             })) {
-                requestFullRefresh('invalid-workspace-update');
+                aiSessionsUpdate.requestFullRefresh('invalid-workspace-update');
                 return;
             }
             if (batchAiSessionState.projectId) {
-                var managedProjectDiv = findCurrentWorkspaceDiv(batchAiSessionState.projectId);
+                var managedProjectDiv = aiSessionsUpdate.findCurrentWorkspaceDiv(batchAiSessionState.projectId);
                 if (managedProjectDiv) {
                     batchAiSessionManager.reconcileVisible(managedProjectDiv);
                     syncAiSessionBatchManagementDom(managedProjectDiv);
@@ -1088,7 +1100,7 @@ function initProjects() {
         }
         if (message && message.type === 'open-workspaces-updated') {
             if (!applyOpenWorkspacesUpdate(message)) {
-                requestFullRefresh('invalid-open-workspaces-update');
+                aiSessionsUpdate.requestFullRefresh('invalid-open-workspaces-update');
                 return;
             }
             syncActiveAiSessionTerminalDom();
@@ -1110,7 +1122,7 @@ function initProjects() {
             return;
         }
         if (message && message.type === 'ai-session-tab-selection-requested') {
-            var requestedProject = findCurrentWorkspaceDiv(message.projectId);
+            var requestedProject = aiSessionsUpdate.findCurrentWorkspaceDiv(message.projectId);
             if (requestedProject && (message.tab === 'active' || message.tab === 'sessions')) {
                 selectAiSessionTabDom(requestedProject, message.tab);
                 writeAiSessionTabState(window.vscode, message.projectId, message.tab);
@@ -1119,7 +1131,7 @@ function initProjects() {
         }
 
         if (message && message.type === 'ai-session-status-announcement') {
-            var announcementProject = findCurrentWorkspaceDiv(message.projectId);
+            var announcementProject = aiSessionsUpdate.findCurrentWorkspaceDiv(message.projectId);
             var announcement = typeof message.message === 'string' ? message.message.trim().slice(0, 256) : '';
             var announcementRegion = announcementProject && announcementProject.querySelector('[data-ai-session-live-region]');
             if (announcementRegion && announcement) announcementRegion.textContent = announcement;
@@ -1153,7 +1165,7 @@ function initProjects() {
 
         if (message && message.type === 'ai-session-batch-archive-completed') {
             if (batchAiSessionManager.complete(message)) {
-                var completedProject = findCurrentWorkspaceDiv(message.projectId);
+                var completedProject = aiSessionsUpdate.findCurrentWorkspaceDiv(message.projectId);
                 syncAiSessionBatchManagementDom(completedProject);
                 var archiveLiveRegion = completedProject
                     && completedProject.querySelector('[data-ai-session-live-region]');
@@ -1169,155 +1181,7 @@ function initProjects() {
             return;
         }
 
-        applyAiSessionsUpdate(message);
-    }
-
-    function applyAiSessionsUpdate(message) {
-        if (message.version !== 2
-            || typeof message.sequence !== 'number'
-            || (message.currentWorkspaceCount !== 0 && message.currentWorkspaceCount !== 1)
-            || typeof message.html !== 'string'
-            || typeof normalizeDashboardSearchCatalog !== 'function'
-            || normalizeDashboardSearchCatalog(message.searchCatalog) !== message.searchCatalog
-            || message.searchCatalog.version !== 2) {
-            requestFullRefresh('unsupported-ai-session-message');
-            return;
-        }
-
-        if (message.sequence <= latestAiSessionUpdateSequence) {
-            return;
-        }
-
-        if (!applyWorkspaceUpdate({
-            type: 'workspace-updated',
-            version: 2,
-            currentWorkspaceCount: message.currentWorkspaceCount,
-            html: message.html,
-        }, {
-            canRestoreAiSessionProviderMenu: () =>
-                !pendingAiSessionProviderSelectionProjectId
-                && !batchAiSessionState.pending,
-        })) {
-            requestFullRefresh('invalid-ai-session-workspace-update');
-            return;
-        }
-
-        latestAiSessionUpdateSequence = message.sequence;
-        if (batchAiSessionState.projectId) {
-            var projectDiv = findCurrentWorkspaceDiv(batchAiSessionState.projectId);
-            if (projectDiv) {
-                batchAiSessionManager.reconcileVisible(projectDiv);
-                syncAiSessionBatchManagementDom(projectDiv);
-            } else {
-                exitAiSessionBatchManagement();
-            }
-        }
-        reconcilePendingAiSessionProviderSelectionDom();
-        syncActiveAiSessionTerminalDom();
-        updateStickyGroupHeaderOffset();
-        if (window.__agentPivotDashboard) {
-            window.__agentPivotDashboard.replaceSearchCatalog(message.searchCatalog);
-        }
-    }
-
-    function findCurrentWorkspaceDiv(projectId) {
-        if (!projectId) {
-            return null;
-        }
-
-        var projects = document.querySelectorAll('.workspace-card[data-current-workspace][data-id]');
-        for (var projectDiv of projects) {
-            if (projectDiv.getAttribute("data-id") === projectId) {
-                return projectDiv;
-            }
-        }
-
-        return null;
-    }
-
-    function findWorkspaceDiv(navigationIdentity) {
-        if (!navigationIdentity) {
-            return null;
-        }
-        var workspaces = document.querySelectorAll('.workspace-card[data-workspace-navigation-identity]');
-        for (var workspaceDiv of workspaces) {
-            if (workspaceDiv.getAttribute('data-workspace-navigation-identity') === navigationIdentity) {
-                return workspaceDiv;
-            }
-        }
-        return null;
-    }
-
-    function focusSearchRevealTarget(target) {
-        target.setAttribute('tabindex', '-1');
-        target.focus();
-        target.scrollIntoView({ block: 'nearest' });
-        target.addEventListener('blur', () => target.removeAttribute('tabindex'), { once: true });
-    }
-
-    window.__agentPivotRevealWorkspace = navigationIdentity => {
-        var workspaceDiv = findWorkspaceDiv(navigationIdentity);
-        if (!workspaceDiv) {
-            return false;
-        }
-        focusSearchRevealTarget(workspaceDiv);
-        return true;
-    };
-
-    function revealWorkspaceSession(navigationIdentity, provider, sessionId) {
-        if (!isAiSessionProvider(provider) || !sessionId) {
-            return false;
-        }
-        var workspaceDiv = findWorkspaceDiv(navigationIdentity);
-        if (!workspaceDiv) {
-            return false;
-        }
-        var workspaceId = workspaceDiv.getAttribute('data-id');
-        if (!workspaceDiv.hasAttribute('data-codex-expanded')) {
-            toggleCodexSessions(workspaceDiv, workspaceId);
-        }
-        selectAiSessionTabDom(workspaceDiv, 'sessions');
-        writeAiSessionTabState(window.vscode, workspaceId, 'sessions');
-        var sessionRow = Array.from(workspaceDiv.querySelectorAll('.codex-session-row[data-session-id][data-session-provider]'))
-            .find(row => row.getAttribute('data-session-provider') === provider
-                && row.getAttribute('data-session-id') === sessionId);
-        if (sessionRow) {
-            pendingWorkspaceSessionReveal = null;
-            focusSearchRevealTarget(sessionRow);
-            return true;
-        }
-        var selectedProviders = getSelectedAiSessionProviders(workspaceDiv);
-        if (!selectedProviders.includes(provider)) {
-            pendingWorkspaceSessionReveal = { navigationIdentity, provider, sessionId };
-            submitAiSessionProviderSelection(
-                workspaceDiv,
-                selectedProviders.concat(provider)
-            );
-            return true;
-        }
-        pendingWorkspaceSessionReveal = null;
-        focusSearchRevealTarget(workspaceDiv);
-        return false;
-    }
-
-    window.__agentPivotRevealWorkspaceSession = revealWorkspaceSession;
-    window.__agentPivotRevealPendingWorkspaceSession = () => {
-        if (!pendingWorkspaceSessionReveal) {
-            return false;
-        }
-        var pending = pendingWorkspaceSessionReveal;
-        return revealWorkspaceSession(
-            pending.navigationIdentity,
-            pending.provider,
-            pending.sessionId
-        );
-    };
-
-    function requestFullRefresh(reason) {
-        window.vscode.postMessage({
-            type: 'request-full-refresh',
-            reason,
-        });
+        aiSessionsUpdate.applyAiSessionsUpdate(message);
     }
 
     function observeStickyGroupHeaderOffset() {

--- a/media/webviewTodoControlScripts.js
+++ b/media/webviewTodoControlScripts.js
@@ -1,0 +1,324 @@
+function initProjectTodoControls(options) {
+    'use strict';
+
+    options = options || {};
+    var syncCollapseButton = typeof options.syncCollapseButton === 'function'
+        ? options.syncCollapseButton
+        : function () {};
+
+    function isDedicatedTodoTarget(target) {
+        return Boolean(window.__agentPivotTodo
+            && target
+            && target.closest
+            && target.closest('#dashboard-tab-todo'));
+    }
+
+    function onInsideGroupClick(e, groupDiv) {
+        var groupId = groupDiv.getAttribute("data-group-id");
+        if (groupId == null)
+            return;
+
+        var actionDiv = e.target.closest('[data-action]')
+        var action = actionDiv != null ? actionDiv.getAttribute("data-action") : null;
+        if (!action)
+            return;
+
+        if (action === "add") {
+            window.vscode.postMessage({
+                type: 'add-project',
+                groupId: groupId,
+            });
+
+            return;
+        }
+
+        var collapsed = groupDiv.classList.contains("collapsed");
+        if (action === "collapse") {
+            groupDiv.classList.toggle("collapsed");
+            collapsed = groupDiv.classList.contains("collapsed");
+        }
+
+        window.vscode.postMessage({
+            type: action + '-group',
+            groupId: groupId,
+            collapsed,
+        });
+        syncCollapseButton();
+    }
+
+    function onTodoAction(e) {
+        var addTodoAction = e.target.closest('[data-action="todo-add"]');
+        if (addTodoAction && !addTodoAction.closest('.todo-add-form')) {
+            setTodoAddFormVisible(true, addTodoAction.getAttribute('data-group-id'));
+            return true;
+        }
+
+        var addGroupAction = e.target.closest('[data-action="todo-add-group"]');
+        if (addGroupAction) {
+            window.vscode.postMessage({
+                type: 'todo-add-group',
+            });
+            return true;
+        }
+
+        var toggleAction = e.target.closest('[data-action="todo-toggle"]');
+        if (toggleAction) {
+            window.vscode.postMessage({
+                type: 'todo-toggle',
+                todoId: toggleAction.getAttribute('data-todo-id'),
+                completed: toggleAction.checked === true,
+            });
+            return true;
+        }
+
+        var deleteAction = e.target.closest('[data-action="todo-delete"]');
+        if (deleteAction) {
+            window.vscode.postMessage({
+                type: 'todo-delete',
+                todoId: deleteAction.getAttribute('data-todo-id'),
+            });
+            return true;
+        }
+
+        var deleteGroupAction = e.target.closest('[data-action="todo-delete-group"]');
+        if (deleteGroupAction) {
+            window.vscode.postMessage({
+                type: 'todo-delete-group',
+                groupId: deleteGroupAction.getAttribute('data-group-id'),
+            });
+            return true;
+        }
+
+        var renameGroupAction = e.target.closest('[data-action="todo-rename-group"]');
+        if (renameGroupAction) {
+            window.vscode.postMessage({
+                type: 'todo-rename-group',
+                groupId: renameGroupAction.getAttribute('data-group-id'),
+            });
+            return true;
+        }
+
+        var collapseGroupAction = e.target.closest('[data-action="todo-collapse-group"]');
+        if (collapseGroupAction) {
+            var todoGroup = collapseGroupAction.closest('.todo-group');
+            if (!todoGroup)
+                return true;
+            todoGroup.classList.toggle('collapsed');
+            syncTodoGroupCollapseControl(todoGroup);
+            window.vscode.postMessage({
+                type: 'todo-collapse-group',
+                groupId: todoGroup.getAttribute('data-todo-group-id'),
+                collapsed: todoGroup.classList.contains('collapsed'),
+            });
+            syncCollapseButton();
+            return true;
+        }
+
+        var sortAction = e.target.closest('[data-action="todo-sort-priority"]');
+        if (sortAction) {
+            window.vscode.postMessage({
+                type: 'todo-sort-priority',
+                groupId: sortAction.getAttribute('data-group-id'),
+            });
+            return true;
+        }
+
+        var showCompletedAction = e.target.closest('[data-action="todo-toggle-show-completed"]');
+        if (showCompletedAction) {
+            window.vscode.postMessage({
+                type: 'todo-toggle-show-completed',
+                showCompleted: showCompletedAction.checked === true,
+            });
+            return true;
+        }
+
+        var focusAddAction = e.target.closest('[data-action="todo-focus-add"]');
+        if (focusAddAction) {
+            setTodoAddFormVisible(true, focusAddAction.getAttribute('data-group-id'));
+            return true;
+        }
+
+        var cancelAddAction = e.target.closest('[data-action="todo-cancel-add"]');
+        if (cancelAddAction) {
+            setTodoAddFormVisible(false);
+            return true;
+        }
+
+        var editAction = e.target.closest('[data-action="todo-edit"]');
+        if (editAction) {
+            setTodoEditing(editAction.getAttribute('data-todo-id'), true);
+            return true;
+        }
+
+        var expandAction = e.target.closest('[data-action="todo-toggle-expanded"]');
+        if (expandAction) {
+            toggleTodoItemExpanded(expandAction.closest('.todo-item'));
+            return true;
+        }
+
+        var cancelEditAction = e.target.closest('[data-action="todo-cancel-edit"]');
+        if (cancelEditAction) {
+            setTodoEditing(cancelEditAction.getAttribute('data-todo-id'), false);
+            return true;
+        }
+
+        return false;
+    }
+
+    function syncTodoPrioritySegment(segment) {
+        if (!segment)
+            return;
+
+        Array.from(segment.querySelectorAll('.todo-priority-choice')).forEach(choice => {
+            var input = choice.querySelector('input[name="priority"]');
+            choice.classList.toggle('active', !!input && input.checked === true);
+        });
+    }
+
+    function resetTodoEditForm(form) {
+        form.reset();
+        syncTodoPrioritySegment(form.querySelector('.todo-priority-segment'));
+    }
+
+    function syncTodoListExpandedHeight(list) {
+        if (!list)
+            return;
+
+        var panel = list.closest('.todo-panel');
+        var collapsedHeightValue = panel
+            ? getComputedStyle(panel).getPropertyValue('--todo-collapsed-item-height')
+            : '';
+        var collapsedHeight = parseFloat(collapsedHeightValue) || 58;
+        var expandedExtraHeight = Array.from(list.querySelectorAll('.todo-item.expanded'))
+            .reduce((total, expandedItem) => total + Math.max(0, expandedItem.offsetHeight - collapsedHeight), 0);
+        list.style.setProperty('--todo-list-expanded-extra-height', expandedExtraHeight + 'px');
+    }
+
+    function toggleTodoItemExpanded(item, expanded) {
+        if (!item)
+            return;
+
+        var nextExpanded = typeof expanded === 'boolean'
+            ? expanded
+            : !item.classList.contains('expanded');
+        item.classList.toggle('expanded', nextExpanded);
+        syncTodoExpandControl(item, nextExpanded);
+        syncTodoListExpandedHeight(item.closest('.todo-list'));
+    }
+
+    function isTodoInteractiveTarget(target) {
+        return !!(target && target.closest && target.closest('button, input, textarea, select, label, a, [data-action], .todo-edit-form'));
+    }
+
+    function setTodoAddFormVisible(visible, groupId) {
+        var form = document.querySelector('.todo-add-form');
+        if (!form)
+            return;
+
+        var groupSelect = form.querySelector('[name="groupId"]');
+        if (visible && groupSelect) {
+            groupSelect.value = groupId || '';
+        }
+        form.hidden = !visible;
+        if (!visible)
+            return;
+
+        var titleInput = form.querySelector('[name="title"]');
+        if (titleInput) {
+            titleInput.focus();
+        }
+        form.scrollIntoView({ block: 'nearest' });
+    }
+
+    function setTodoEditing(todoId, editing) {
+        if (!todoId)
+            return;
+
+        var item = Array.from(document.querySelectorAll('.todo-item[data-todo-id]'))
+            .find(candidate => candidate.getAttribute('data-todo-id') === todoId);
+        if (!item)
+            return;
+
+        var wasEditing = item.classList.contains('editing');
+        var expandedBeforeEdit = item.getAttribute('data-expanded-before-edit');
+        if (editing && !wasEditing) {
+            item.setAttribute(
+                'data-expanded-before-edit',
+                item.classList.contains('expanded') ? 'true' : 'false'
+            );
+            expandedBeforeEdit = item.getAttribute('data-expanded-before-edit');
+        }
+        var view = item.querySelector('.todo-item-view');
+        var form = item.querySelector('.todo-edit-form');
+        var list = item.closest('.todo-list');
+        if (form && !editing) {
+            resetTodoEditForm(form);
+        }
+        item.classList.toggle('editing', editing);
+        if (view) {
+            view.hidden = false;
+        }
+        if (form) {
+            form.hidden = !editing;
+        }
+        toggleTodoItemExpanded(item, editing ? true : expandedBeforeEdit === 'true');
+        if (!editing) {
+            item.removeAttribute('data-expanded-before-edit');
+        }
+        if (list) {
+            list.classList.toggle('has-editing-item', !!list.querySelector('.todo-item.editing'));
+        }
+        if (form && editing) {
+            var titleInput = form.querySelector('[name="title"]');
+            if (titleInput) {
+                titleInput.focus();
+            }
+            item.scrollIntoView({ block: 'nearest' });
+        }
+    }
+
+    function onTodoFormSubmit(e) {
+        if (window.__agentPivotTodo
+            && e.target
+            && e.target.closest
+            && e.target.closest('#dashboard-tab-todo')) {
+            return;
+        }
+        var addForm = e.target && e.target.closest ? e.target.closest('.todo-add-form') : null;
+        if (addForm) {
+            e.preventDefault();
+            submitTodoComposeForm(addForm, message => window.vscode.postMessage(message));
+            return;
+        }
+
+        var editForm = e.target && e.target.closest ? e.target.closest('.todo-edit-form') : null;
+        if (editForm) {
+            e.preventDefault();
+            var todoId = editForm.getAttribute('data-todo-id');
+            var editTitle = getTodoFormValue(editForm, 'title');
+            if (!todoId || !editTitle)
+                return;
+            window.vscode.postMessage({
+                type: 'todo-update',
+                todoId,
+                title: editTitle,
+                notes: getTodoFormValue(editForm, 'notes'),
+                priority: getTodoFormValue(editForm, 'priority'),
+            });
+        }
+    }
+
+    return {
+        isDedicatedTodoTarget: isDedicatedTodoTarget,
+        isTodoInteractiveTarget: isTodoInteractiveTarget,
+        onInsideGroupClick: onInsideGroupClick,
+        onTodoAction: onTodoAction,
+        onTodoFormSubmit: onTodoFormSubmit,
+        resetTodoEditForm: resetTodoEditForm,
+        setTodoAddFormVisible: setTodoAddFormVisible,
+        setTodoEditing: setTodoEditing,
+        syncTodoListExpandedHeight: syncTodoListExpandedHeight,
+        syncTodoPrioritySegment: syncTodoPrioritySegment,
+        toggleTodoItemExpanded: toggleTodoItemExpanded,
+    };
+}

--- a/scripts/run-ai-session-safety-checks.js
+++ b/scripts/run-ai-session-safety-checks.js
@@ -4902,6 +4902,7 @@ function runWebviewContentChecks() {
         'webviewWorkspaceUpdateScripts.js',
         'webviewTodoGroupScripts.js',
         'webviewProjectCollapseScripts.js',
+        'webviewTodoControlScripts.js',
         'webviewProjectScripts.js',
     ].map(fileName => fs.readFileSync(
         path.join(__dirname, '..', 'src', 'webview', fileName), 'utf8'
@@ -6243,9 +6244,17 @@ function runBatchAiSessionWebviewChecks() {
     );
     const projectCollapseSource = fs.readFileSync(projectCollapseSourcePath, 'utf8');
     assert.strictEqual(fs.readFileSync(generatedProjectCollapsePath, 'utf8'), projectCollapseSource);
+    const todoControlSourcePath = path.join(
+        __dirname, '..', 'src', 'webview', 'webviewTodoControlScripts.js'
+    );
+    const generatedTodoControlPath = path.join(
+        __dirname, '..', 'media', 'webviewTodoControlScripts.js'
+    );
+    const todoControlSource = fs.readFileSync(todoControlSourcePath, 'utf8');
+    assert.strictEqual(fs.readFileSync(generatedTodoControlPath, 'utf8'), todoControlSource);
     const projectSource = fs.readFileSync(sourcePath, 'utf8');
     assert.strictEqual(fs.readFileSync(generatedPath, 'utf8'), projectSource);
-    const source = `${viewStateSource}\n${workspaceUpdateSource}\n${todoGroupSource}\n${projectCollapseSource}\n${projectSource}`;
+    const source = `${viewStateSource}\n${workspaceUpdateSource}\n${todoGroupSource}\n${projectCollapseSource}\n${todoControlSource}\n${projectSource}`;
     const messages = [];
     const eventListeners = {};
     const windowEventListeners = {};

--- a/scripts/run-ai-session-safety-checks.js
+++ b/scripts/run-ai-session-safety-checks.js
@@ -4904,6 +4904,7 @@ function runWebviewContentChecks() {
         'webviewProjectCollapseScripts.js',
         'webviewTodoControlScripts.js',
         'webviewProjectContextMenuScripts.js',
+        'webviewProjectAiUpdateScripts.js',
         'webviewProjectScripts.js',
     ].map(fileName => fs.readFileSync(
         path.join(__dirname, '..', 'src', 'webview', fileName), 'utf8'
@@ -6261,9 +6262,17 @@ function runBatchAiSessionWebviewChecks() {
     );
     const projectContextMenuSource = fs.readFileSync(projectContextMenuSourcePath, 'utf8');
     assert.strictEqual(fs.readFileSync(generatedProjectContextMenuPath, 'utf8'), projectContextMenuSource);
+    const projectAiUpdateSourcePath = path.join(
+        __dirname, '..', 'src', 'webview', 'webviewProjectAiUpdateScripts.js'
+    );
+    const generatedProjectAiUpdatePath = path.join(
+        __dirname, '..', 'media', 'webviewProjectAiUpdateScripts.js'
+    );
+    const projectAiUpdateSource = fs.readFileSync(projectAiUpdateSourcePath, 'utf8');
+    assert.strictEqual(fs.readFileSync(generatedProjectAiUpdatePath, 'utf8'), projectAiUpdateSource);
     const projectSource = fs.readFileSync(sourcePath, 'utf8');
     assert.strictEqual(fs.readFileSync(generatedPath, 'utf8'), projectSource);
-    const source = `${viewStateSource}\n${workspaceUpdateSource}\n${todoGroupSource}\n${projectCollapseSource}\n${todoControlSource}\n${projectContextMenuSource}\n${projectSource}`;
+    const source = `${viewStateSource}\n${workspaceUpdateSource}\n${todoGroupSource}\n${projectCollapseSource}\n${todoControlSource}\n${projectContextMenuSource}\n${projectAiUpdateSource}\n${projectSource}`;
     const messages = [];
     const eventListeners = {};
     const windowEventListeners = {};
@@ -7205,9 +7214,18 @@ function runAiSessionIncrementalRefreshSourceChecks() {
     const sessionPathsSource = fs.readFileSync(
         path.join(root, 'src', 'aiSessions', 'sessionPaths.ts'), 'utf8'
     );
-    const projectWebviewSource = fs.readFileSync(
-        path.join(root, 'src', 'webview', 'webviewProjectScripts.js'), 'utf8'
-    );
+    const projectWebviewSource = [
+        'webviewAiSessionViewStateScripts.js',
+        'webviewWorkspaceUpdateScripts.js',
+        'webviewTodoGroupScripts.js',
+        'webviewProjectCollapseScripts.js',
+        'webviewTodoControlScripts.js',
+        'webviewProjectContextMenuScripts.js',
+        'webviewProjectAiUpdateScripts.js',
+        'webviewProjectScripts.js',
+    ].map(fileName => fs.readFileSync(
+        path.join(root, 'src', 'webview', fileName), 'utf8'
+    )).join('\n');
 
     for (const removed of [
         'src/aiSessions/viewModels.ts',

--- a/scripts/run-ai-session-safety-checks.js
+++ b/scripts/run-ai-session-safety-checks.js
@@ -4905,6 +4905,7 @@ function runWebviewContentChecks() {
         'webviewTodoControlScripts.js',
         'webviewProjectContextMenuScripts.js',
         'webviewProjectAiUpdateScripts.js',
+        'webviewProjectAiSessionControlsScripts.js',
         'webviewProjectScripts.js',
     ].map(fileName => fs.readFileSync(
         path.join(__dirname, '..', 'src', 'webview', fileName), 'utf8'
@@ -6270,9 +6271,17 @@ function runBatchAiSessionWebviewChecks() {
     );
     const projectAiUpdateSource = fs.readFileSync(projectAiUpdateSourcePath, 'utf8');
     assert.strictEqual(fs.readFileSync(generatedProjectAiUpdatePath, 'utf8'), projectAiUpdateSource);
+    const aiSessionControlsSourcePath = path.join(
+        __dirname, '..', 'src', 'webview', 'webviewProjectAiSessionControlsScripts.js'
+    );
+    const generatedAiSessionControlsPath = path.join(
+        __dirname, '..', 'media', 'webviewProjectAiSessionControlsScripts.js'
+    );
+    const aiSessionControlsSource = fs.readFileSync(aiSessionControlsSourcePath, 'utf8');
+    assert.strictEqual(fs.readFileSync(generatedAiSessionControlsPath, 'utf8'), aiSessionControlsSource);
     const projectSource = fs.readFileSync(sourcePath, 'utf8');
     assert.strictEqual(fs.readFileSync(generatedPath, 'utf8'), projectSource);
-    const source = `${viewStateSource}\n${workspaceUpdateSource}\n${todoGroupSource}\n${projectCollapseSource}\n${todoControlSource}\n${projectContextMenuSource}\n${projectAiUpdateSource}\n${projectSource}`;
+    const source = `${viewStateSource}\n${workspaceUpdateSource}\n${todoGroupSource}\n${projectCollapseSource}\n${todoControlSource}\n${projectContextMenuSource}\n${projectAiUpdateSource}\n${aiSessionControlsSource}\n${projectSource}`;
     const messages = [];
     const eventListeners = {};
     const windowEventListeners = {};
@@ -7222,6 +7231,7 @@ function runAiSessionIncrementalRefreshSourceChecks() {
         'webviewTodoControlScripts.js',
         'webviewProjectContextMenuScripts.js',
         'webviewProjectAiUpdateScripts.js',
+        'webviewProjectAiSessionControlsScripts.js',
         'webviewProjectScripts.js',
     ].map(fileName => fs.readFileSync(
         path.join(root, 'src', 'webview', fileName), 'utf8'

--- a/scripts/run-ai-session-safety-checks.js
+++ b/scripts/run-ai-session-safety-checks.js
@@ -4903,6 +4903,7 @@ function runWebviewContentChecks() {
         'webviewTodoGroupScripts.js',
         'webviewProjectCollapseScripts.js',
         'webviewTodoControlScripts.js',
+        'webviewProjectContextMenuScripts.js',
         'webviewProjectScripts.js',
     ].map(fileName => fs.readFileSync(
         path.join(__dirname, '..', 'src', 'webview', fileName), 'utf8'
@@ -6252,9 +6253,17 @@ function runBatchAiSessionWebviewChecks() {
     );
     const todoControlSource = fs.readFileSync(todoControlSourcePath, 'utf8');
     assert.strictEqual(fs.readFileSync(generatedTodoControlPath, 'utf8'), todoControlSource);
+    const projectContextMenuSourcePath = path.join(
+        __dirname, '..', 'src', 'webview', 'webviewProjectContextMenuScripts.js'
+    );
+    const generatedProjectContextMenuPath = path.join(
+        __dirname, '..', 'media', 'webviewProjectContextMenuScripts.js'
+    );
+    const projectContextMenuSource = fs.readFileSync(projectContextMenuSourcePath, 'utf8');
+    assert.strictEqual(fs.readFileSync(generatedProjectContextMenuPath, 'utf8'), projectContextMenuSource);
     const projectSource = fs.readFileSync(sourcePath, 'utf8');
     assert.strictEqual(fs.readFileSync(generatedPath, 'utf8'), projectSource);
-    const source = `${viewStateSource}\n${workspaceUpdateSource}\n${todoGroupSource}\n${projectCollapseSource}\n${todoControlSource}\n${projectSource}`;
+    const source = `${viewStateSource}\n${workspaceUpdateSource}\n${todoGroupSource}\n${projectCollapseSource}\n${todoControlSource}\n${projectContextMenuSource}\n${projectSource}`;
     const messages = [];
     const eventListeners = {};
     const windowEventListeners = {};

--- a/scripts/run-ai-session-safety-checks.js
+++ b/scripts/run-ai-session-safety-checks.js
@@ -4901,6 +4901,7 @@ function runWebviewContentChecks() {
         'webviewAiSessionViewStateScripts.js',
         'webviewWorkspaceUpdateScripts.js',
         'webviewTodoGroupScripts.js',
+        'webviewProjectCollapseScripts.js',
         'webviewProjectScripts.js',
     ].map(fileName => fs.readFileSync(
         path.join(__dirname, '..', 'src', 'webview', fileName), 'utf8'
@@ -6234,9 +6235,17 @@ function runBatchAiSessionWebviewChecks() {
     );
     const todoGroupSource = fs.readFileSync(todoGroupSourcePath, 'utf8');
     assert.strictEqual(fs.readFileSync(generatedTodoGroupPath, 'utf8'), todoGroupSource);
+    const projectCollapseSourcePath = path.join(
+        __dirname, '..', 'src', 'webview', 'webviewProjectCollapseScripts.js'
+    );
+    const generatedProjectCollapsePath = path.join(
+        __dirname, '..', 'media', 'webviewProjectCollapseScripts.js'
+    );
+    const projectCollapseSource = fs.readFileSync(projectCollapseSourcePath, 'utf8');
+    assert.strictEqual(fs.readFileSync(generatedProjectCollapsePath, 'utf8'), projectCollapseSource);
     const projectSource = fs.readFileSync(sourcePath, 'utf8');
     assert.strictEqual(fs.readFileSync(generatedPath, 'utf8'), projectSource);
-    const source = `${viewStateSource}\n${workspaceUpdateSource}\n${todoGroupSource}\n${projectSource}`;
+    const source = `${viewStateSource}\n${workspaceUpdateSource}\n${todoGroupSource}\n${projectCollapseSource}\n${projectSource}`;
     const messages = [];
     const eventListeners = {};
     const windowEventListeners = {};

--- a/scripts/run-ai-session-tmux-checks.js
+++ b/scripts/run-ai-session-tmux-checks.js
@@ -9761,6 +9761,7 @@ function runTmuxWebviewExperienceChecks() {
         'webviewProjectCollapseScripts.js',
         'webviewTodoControlScripts.js',
         'webviewProjectContextMenuScripts.js',
+        'webviewProjectAiUpdateScripts.js',
         'webviewProjectScripts.js',
     ].map(fileName => fs.readFileSync(
         path.join(__dirname, '..', 'src', 'webview', fileName), 'utf8'

--- a/scripts/run-ai-session-tmux-checks.js
+++ b/scripts/run-ai-session-tmux-checks.js
@@ -9754,9 +9754,17 @@ function runTmuxWebviewExperienceChecks() {
     assert.ok(!conflictRow.includes('data-action="close-ai-session-terminal"'));
     assert.ok(!conflictRow.includes('data-action="detach-ai-session-terminal"'));
 
-    const projectScript = fs.readFileSync(
-        path.join(__dirname, '..', 'src', 'webview', 'webviewProjectScripts.js'), 'utf8'
-    );
+    const projectScript = [
+        'webviewAiSessionViewStateScripts.js',
+        'webviewWorkspaceUpdateScripts.js',
+        'webviewTodoGroupScripts.js',
+        'webviewProjectCollapseScripts.js',
+        'webviewTodoControlScripts.js',
+        'webviewProjectContextMenuScripts.js',
+        'webviewProjectScripts.js',
+    ].map(fileName => fs.readFileSync(
+        path.join(__dirname, '..', 'src', 'webview', fileName), 'utf8'
+    )).join('\n');
     assert.ok(projectScript.includes("'detach-ai-session-terminal'"));
     assert.ok(projectScript.includes("data-session-backend"));
     assert.ok(projectScript.includes("contextMenuAiSessionBackend"));

--- a/scripts/run-ai-session-tmux-checks.js
+++ b/scripts/run-ai-session-tmux-checks.js
@@ -9762,6 +9762,7 @@ function runTmuxWebviewExperienceChecks() {
         'webviewTodoControlScripts.js',
         'webviewProjectContextMenuScripts.js',
         'webviewProjectAiUpdateScripts.js',
+        'webviewProjectAiSessionControlsScripts.js',
         'webviewProjectScripts.js',
     ].map(fileName => fs.readFileSync(
         path.join(__dirname, '..', 'src', 'webview', fileName), 'utf8'

--- a/scripts/run-dashboard-webview-checks.js
+++ b/scripts/run-dashboard-webview-checks.js
@@ -71,6 +71,9 @@ const projectContextMenuScriptPath = path.join(
 const projectAiUpdateScriptPath = path.join(
     root, 'src', 'webview', 'webviewProjectAiUpdateScripts.js'
 );
+const aiSessionControlsScriptPath = path.join(
+    root, 'src', 'webview', 'webviewProjectAiSessionControlsScripts.js'
+);
 
 function readProjectWebviewSource() {
     return [
@@ -81,6 +84,7 @@ function readProjectWebviewSource() {
         todoControlScriptPath,
         projectContextMenuScriptPath,
         projectAiUpdateScriptPath,
+        aiSessionControlsScriptPath,
         projectScriptPath,
     ].map(scriptPath => fs.readFileSync(scriptPath, 'utf8')).join('\n');
 }

--- a/scripts/run-dashboard-webview-checks.js
+++ b/scripts/run-dashboard-webview-checks.js
@@ -62,6 +62,9 @@ const todoGroupScriptPath = path.join(
 const projectCollapseScriptPath = path.join(
     root, 'src', 'webview', 'webviewProjectCollapseScripts.js'
 );
+const todoControlScriptPath = path.join(
+    root, 'src', 'webview', 'webviewTodoControlScripts.js'
+);
 
 function readProjectWebviewSource() {
     return [
@@ -69,6 +72,7 @@ function readProjectWebviewSource() {
         workspaceUpdateScriptPath,
         todoGroupScriptPath,
         projectCollapseScriptPath,
+        todoControlScriptPath,
         projectScriptPath,
     ].map(scriptPath => fs.readFileSync(scriptPath, 'utf8')).join('\n');
 }

--- a/scripts/run-dashboard-webview-checks.js
+++ b/scripts/run-dashboard-webview-checks.js
@@ -65,6 +65,9 @@ const projectCollapseScriptPath = path.join(
 const todoControlScriptPath = path.join(
     root, 'src', 'webview', 'webviewTodoControlScripts.js'
 );
+const projectContextMenuScriptPath = path.join(
+    root, 'src', 'webview', 'webviewProjectContextMenuScripts.js'
+);
 
 function readProjectWebviewSource() {
     return [
@@ -73,6 +76,7 @@ function readProjectWebviewSource() {
         todoGroupScriptPath,
         projectCollapseScriptPath,
         todoControlScriptPath,
+        projectContextMenuScriptPath,
         projectScriptPath,
     ].map(scriptPath => fs.readFileSync(scriptPath, 'utf8')).join('\n');
 }

--- a/scripts/run-dashboard-webview-checks.js
+++ b/scripts/run-dashboard-webview-checks.js
@@ -68,6 +68,9 @@ const todoControlScriptPath = path.join(
 const projectContextMenuScriptPath = path.join(
     root, 'src', 'webview', 'webviewProjectContextMenuScripts.js'
 );
+const projectAiUpdateScriptPath = path.join(
+    root, 'src', 'webview', 'webviewProjectAiUpdateScripts.js'
+);
 
 function readProjectWebviewSource() {
     return [
@@ -77,6 +80,7 @@ function readProjectWebviewSource() {
         projectCollapseScriptPath,
         todoControlScriptPath,
         projectContextMenuScriptPath,
+        projectAiUpdateScriptPath,
         projectScriptPath,
     ].map(scriptPath => fs.readFileSync(scriptPath, 'utf8')).join('\n');
 }

--- a/scripts/run-dashboard-webview-checks.js
+++ b/scripts/run-dashboard-webview-checks.js
@@ -59,12 +59,16 @@ const workspaceUpdateScriptPath = path.join(
 const todoGroupScriptPath = path.join(
     root, 'src', 'webview', 'webviewTodoGroupScripts.js'
 );
+const projectCollapseScriptPath = path.join(
+    root, 'src', 'webview', 'webviewProjectCollapseScripts.js'
+);
 
 function readProjectWebviewSource() {
     return [
         aiSessionViewStateScriptPath,
         workspaceUpdateScriptPath,
         todoGroupScriptPath,
+        projectCollapseScriptPath,
         projectScriptPath,
     ].map(scriptPath => fs.readFileSync(scriptPath, 'utf8')).join('\n');
 }

--- a/scripts/run-performance-architecture-baseline-checks.js
+++ b/scripts/run-performance-architecture-baseline-checks.js
@@ -32,6 +32,7 @@ const productionSources = [
     'media/webviewProjectCollapseScripts.js',
     'media/webviewTodoControlScripts.js',
     'media/webviewProjectContextMenuScripts.js',
+    'media/webviewProjectAiUpdateScripts.js',
     'media/webviewProjectScripts.js',
     'media/webviewPromptScripts.js',
     'media/styles.scss',

--- a/scripts/run-performance-architecture-baseline-checks.js
+++ b/scripts/run-performance-architecture-baseline-checks.js
@@ -30,6 +30,7 @@ const productionSources = [
     'media/webviewWorkspaceUpdateScripts.js',
     'media/webviewTodoGroupScripts.js',
     'media/webviewProjectCollapseScripts.js',
+    'media/webviewTodoControlScripts.js',
     'media/webviewProjectScripts.js',
     'media/webviewPromptScripts.js',
     'media/styles.scss',

--- a/scripts/run-performance-architecture-baseline-checks.js
+++ b/scripts/run-performance-architecture-baseline-checks.js
@@ -29,6 +29,7 @@ const productionSources = [
     'media/webviewAiSessionViewStateScripts.js',
     'media/webviewWorkspaceUpdateScripts.js',
     'media/webviewTodoGroupScripts.js',
+    'media/webviewProjectCollapseScripts.js',
     'media/webviewProjectScripts.js',
     'media/webviewPromptScripts.js',
     'media/styles.scss',

--- a/scripts/run-performance-architecture-baseline-checks.js
+++ b/scripts/run-performance-architecture-baseline-checks.js
@@ -33,6 +33,7 @@ const productionSources = [
     'media/webviewTodoControlScripts.js',
     'media/webviewProjectContextMenuScripts.js',
     'media/webviewProjectAiUpdateScripts.js',
+    'media/webviewProjectAiSessionControlsScripts.js',
     'media/webviewProjectScripts.js',
     'media/webviewPromptScripts.js',
     'media/styles.scss',

--- a/scripts/run-performance-architecture-baseline-checks.js
+++ b/scripts/run-performance-architecture-baseline-checks.js
@@ -31,6 +31,7 @@ const productionSources = [
     'media/webviewTodoGroupScripts.js',
     'media/webviewProjectCollapseScripts.js',
     'media/webviewTodoControlScripts.js',
+    'media/webviewProjectContextMenuScripts.js',
     'media/webviewProjectScripts.js',
     'media/webviewPromptScripts.js',
     'media/styles.scss',

--- a/scripts/run-release-packaging-checks.js
+++ b/scripts/run-release-packaging-checks.js
@@ -81,6 +81,7 @@ const EXPECTED_MAIN_ENTRIES = Object.freeze([
     'extension/media/webviewTodoControlScripts.js',
     'extension/media/webviewProjectContextMenuScripts.js',
     'extension/media/webviewProjectAiUpdateScripts.js',
+    'extension/media/webviewProjectAiSessionControlsScripts.js',
     'extension/media/webviewProjectScripts.js',
     'extension/media/webviewPromptScripts.js',
     'extension/media/webviewScrollStateScripts.js',
@@ -599,6 +600,7 @@ function runRealVsixArchiveChecks(mainPackage, bridgePackage) {
         ['extension/media/webviewTodoControlScripts.js', 'media/webviewTodoControlScripts.js'],
         ['extension/media/webviewProjectContextMenuScripts.js', 'media/webviewProjectContextMenuScripts.js'],
         ['extension/media/webviewProjectAiUpdateScripts.js', 'media/webviewProjectAiUpdateScripts.js'],
+        ['extension/media/webviewProjectAiSessionControlsScripts.js', 'media/webviewProjectAiSessionControlsScripts.js'],
         ['extension/media/webviewProjectScripts.js', 'media/webviewProjectScripts.js'],
         ['extension/media/webviewPromptScripts.js', 'media/webviewPromptScripts.js'],
         ['extension/media/webviewScrollStateScripts.js', 'media/webviewScrollStateScripts.js'],
@@ -928,6 +930,7 @@ function run() {
     assertIncludes(mainIgnore, '!media/webviewTodoControlScripts.js', 'main VSIX ignore rules');
     assertIncludes(mainIgnore, '!media/webviewProjectContextMenuScripts.js', 'main VSIX ignore rules');
     assertIncludes(mainIgnore, '!media/webviewProjectAiUpdateScripts.js', 'main VSIX ignore rules');
+    assertIncludes(mainIgnore, '!media/webviewProjectAiSessionControlsScripts.js', 'main VSIX ignore rules');
     assertIncludes(mainIgnore, '!media/webviewProjectScripts.js', 'main VSIX ignore rules');
     assertIncludes(mainIgnore, '!media/webviewPromptScripts.js', 'main VSIX ignore rules');
     assertIncludes(mainIgnore, '!media/webviewScrollStateScripts.js', 'main VSIX ignore rules');
@@ -955,6 +958,7 @@ function run() {
         'media/webviewTodoControlScripts.js',
         'media/webviewProjectContextMenuScripts.js',
         'media/webviewProjectAiUpdateScripts.js',
+        'media/webviewProjectAiSessionControlsScripts.js',
         'media/webviewProjectScripts.js',
         'media/webviewPromptScripts.js',
         'media/webviewScrollStateScripts.js',

--- a/scripts/run-release-packaging-checks.js
+++ b/scripts/run-release-packaging-checks.js
@@ -77,6 +77,7 @@ const EXPECTED_MAIN_ENTRIES = Object.freeze([
     'extension/media/webviewAiSessionViewStateScripts.js',
     'extension/media/webviewWorkspaceUpdateScripts.js',
     'extension/media/webviewTodoGroupScripts.js',
+    'extension/media/webviewProjectCollapseScripts.js',
     'extension/media/webviewProjectScripts.js',
     'extension/media/webviewPromptScripts.js',
     'extension/media/webviewScrollStateScripts.js',
@@ -591,6 +592,7 @@ function runRealVsixArchiveChecks(mainPackage, bridgePackage) {
         ['extension/media/webviewAiSessionViewStateScripts.js', 'media/webviewAiSessionViewStateScripts.js'],
         ['extension/media/webviewWorkspaceUpdateScripts.js', 'media/webviewWorkspaceUpdateScripts.js'],
         ['extension/media/webviewTodoGroupScripts.js', 'media/webviewTodoGroupScripts.js'],
+        ['extension/media/webviewProjectCollapseScripts.js', 'media/webviewProjectCollapseScripts.js'],
         ['extension/media/webviewProjectScripts.js', 'media/webviewProjectScripts.js'],
         ['extension/media/webviewPromptScripts.js', 'media/webviewPromptScripts.js'],
         ['extension/media/webviewScrollStateScripts.js', 'media/webviewScrollStateScripts.js'],
@@ -916,6 +918,7 @@ function run() {
     assertIncludes(mainIgnore, '!media/webviewAiSessionViewStateScripts.js', 'main VSIX ignore rules');
     assertIncludes(mainIgnore, '!media/webviewWorkspaceUpdateScripts.js', 'main VSIX ignore rules');
     assertIncludes(mainIgnore, '!media/webviewTodoGroupScripts.js', 'main VSIX ignore rules');
+    assertIncludes(mainIgnore, '!media/webviewProjectCollapseScripts.js', 'main VSIX ignore rules');
     assertIncludes(mainIgnore, '!media/webviewProjectScripts.js', 'main VSIX ignore rules');
     assertIncludes(mainIgnore, '!media/webviewPromptScripts.js', 'main VSIX ignore rules');
     assertIncludes(mainIgnore, '!media/webviewScrollStateScripts.js', 'main VSIX ignore rules');
@@ -939,6 +942,7 @@ function run() {
         'media/webviewAiSessionViewStateScripts.js',
         'media/webviewWorkspaceUpdateScripts.js',
         'media/webviewTodoGroupScripts.js',
+        'media/webviewProjectCollapseScripts.js',
         'media/webviewProjectScripts.js',
         'media/webviewPromptScripts.js',
         'media/webviewScrollStateScripts.js',

--- a/scripts/run-release-packaging-checks.js
+++ b/scripts/run-release-packaging-checks.js
@@ -79,6 +79,7 @@ const EXPECTED_MAIN_ENTRIES = Object.freeze([
     'extension/media/webviewTodoGroupScripts.js',
     'extension/media/webviewProjectCollapseScripts.js',
     'extension/media/webviewTodoControlScripts.js',
+    'extension/media/webviewProjectContextMenuScripts.js',
     'extension/media/webviewProjectScripts.js',
     'extension/media/webviewPromptScripts.js',
     'extension/media/webviewScrollStateScripts.js',
@@ -595,6 +596,7 @@ function runRealVsixArchiveChecks(mainPackage, bridgePackage) {
         ['extension/media/webviewTodoGroupScripts.js', 'media/webviewTodoGroupScripts.js'],
         ['extension/media/webviewProjectCollapseScripts.js', 'media/webviewProjectCollapseScripts.js'],
         ['extension/media/webviewTodoControlScripts.js', 'media/webviewTodoControlScripts.js'],
+        ['extension/media/webviewProjectContextMenuScripts.js', 'media/webviewProjectContextMenuScripts.js'],
         ['extension/media/webviewProjectScripts.js', 'media/webviewProjectScripts.js'],
         ['extension/media/webviewPromptScripts.js', 'media/webviewPromptScripts.js'],
         ['extension/media/webviewScrollStateScripts.js', 'media/webviewScrollStateScripts.js'],
@@ -922,6 +924,7 @@ function run() {
     assertIncludes(mainIgnore, '!media/webviewTodoGroupScripts.js', 'main VSIX ignore rules');
     assertIncludes(mainIgnore, '!media/webviewProjectCollapseScripts.js', 'main VSIX ignore rules');
     assertIncludes(mainIgnore, '!media/webviewTodoControlScripts.js', 'main VSIX ignore rules');
+    assertIncludes(mainIgnore, '!media/webviewProjectContextMenuScripts.js', 'main VSIX ignore rules');
     assertIncludes(mainIgnore, '!media/webviewProjectScripts.js', 'main VSIX ignore rules');
     assertIncludes(mainIgnore, '!media/webviewPromptScripts.js', 'main VSIX ignore rules');
     assertIncludes(mainIgnore, '!media/webviewScrollStateScripts.js', 'main VSIX ignore rules');
@@ -947,6 +950,7 @@ function run() {
         'media/webviewTodoGroupScripts.js',
         'media/webviewProjectCollapseScripts.js',
         'media/webviewTodoControlScripts.js',
+        'media/webviewProjectContextMenuScripts.js',
         'media/webviewProjectScripts.js',
         'media/webviewPromptScripts.js',
         'media/webviewScrollStateScripts.js',

--- a/scripts/run-release-packaging-checks.js
+++ b/scripts/run-release-packaging-checks.js
@@ -80,6 +80,7 @@ const EXPECTED_MAIN_ENTRIES = Object.freeze([
     'extension/media/webviewProjectCollapseScripts.js',
     'extension/media/webviewTodoControlScripts.js',
     'extension/media/webviewProjectContextMenuScripts.js',
+    'extension/media/webviewProjectAiUpdateScripts.js',
     'extension/media/webviewProjectScripts.js',
     'extension/media/webviewPromptScripts.js',
     'extension/media/webviewScrollStateScripts.js',
@@ -597,6 +598,7 @@ function runRealVsixArchiveChecks(mainPackage, bridgePackage) {
         ['extension/media/webviewProjectCollapseScripts.js', 'media/webviewProjectCollapseScripts.js'],
         ['extension/media/webviewTodoControlScripts.js', 'media/webviewTodoControlScripts.js'],
         ['extension/media/webviewProjectContextMenuScripts.js', 'media/webviewProjectContextMenuScripts.js'],
+        ['extension/media/webviewProjectAiUpdateScripts.js', 'media/webviewProjectAiUpdateScripts.js'],
         ['extension/media/webviewProjectScripts.js', 'media/webviewProjectScripts.js'],
         ['extension/media/webviewPromptScripts.js', 'media/webviewPromptScripts.js'],
         ['extension/media/webviewScrollStateScripts.js', 'media/webviewScrollStateScripts.js'],
@@ -925,6 +927,7 @@ function run() {
     assertIncludes(mainIgnore, '!media/webviewProjectCollapseScripts.js', 'main VSIX ignore rules');
     assertIncludes(mainIgnore, '!media/webviewTodoControlScripts.js', 'main VSIX ignore rules');
     assertIncludes(mainIgnore, '!media/webviewProjectContextMenuScripts.js', 'main VSIX ignore rules');
+    assertIncludes(mainIgnore, '!media/webviewProjectAiUpdateScripts.js', 'main VSIX ignore rules');
     assertIncludes(mainIgnore, '!media/webviewProjectScripts.js', 'main VSIX ignore rules');
     assertIncludes(mainIgnore, '!media/webviewPromptScripts.js', 'main VSIX ignore rules');
     assertIncludes(mainIgnore, '!media/webviewScrollStateScripts.js', 'main VSIX ignore rules');
@@ -951,6 +954,7 @@ function run() {
         'media/webviewProjectCollapseScripts.js',
         'media/webviewTodoControlScripts.js',
         'media/webviewProjectContextMenuScripts.js',
+        'media/webviewProjectAiUpdateScripts.js',
         'media/webviewProjectScripts.js',
         'media/webviewPromptScripts.js',
         'media/webviewScrollStateScripts.js',

--- a/scripts/run-release-packaging-checks.js
+++ b/scripts/run-release-packaging-checks.js
@@ -78,6 +78,7 @@ const EXPECTED_MAIN_ENTRIES = Object.freeze([
     'extension/media/webviewWorkspaceUpdateScripts.js',
     'extension/media/webviewTodoGroupScripts.js',
     'extension/media/webviewProjectCollapseScripts.js',
+    'extension/media/webviewTodoControlScripts.js',
     'extension/media/webviewProjectScripts.js',
     'extension/media/webviewPromptScripts.js',
     'extension/media/webviewScrollStateScripts.js',
@@ -593,6 +594,7 @@ function runRealVsixArchiveChecks(mainPackage, bridgePackage) {
         ['extension/media/webviewWorkspaceUpdateScripts.js', 'media/webviewWorkspaceUpdateScripts.js'],
         ['extension/media/webviewTodoGroupScripts.js', 'media/webviewTodoGroupScripts.js'],
         ['extension/media/webviewProjectCollapseScripts.js', 'media/webviewProjectCollapseScripts.js'],
+        ['extension/media/webviewTodoControlScripts.js', 'media/webviewTodoControlScripts.js'],
         ['extension/media/webviewProjectScripts.js', 'media/webviewProjectScripts.js'],
         ['extension/media/webviewPromptScripts.js', 'media/webviewPromptScripts.js'],
         ['extension/media/webviewScrollStateScripts.js', 'media/webviewScrollStateScripts.js'],
@@ -919,6 +921,7 @@ function run() {
     assertIncludes(mainIgnore, '!media/webviewWorkspaceUpdateScripts.js', 'main VSIX ignore rules');
     assertIncludes(mainIgnore, '!media/webviewTodoGroupScripts.js', 'main VSIX ignore rules');
     assertIncludes(mainIgnore, '!media/webviewProjectCollapseScripts.js', 'main VSIX ignore rules');
+    assertIncludes(mainIgnore, '!media/webviewTodoControlScripts.js', 'main VSIX ignore rules');
     assertIncludes(mainIgnore, '!media/webviewProjectScripts.js', 'main VSIX ignore rules');
     assertIncludes(mainIgnore, '!media/webviewPromptScripts.js', 'main VSIX ignore rules');
     assertIncludes(mainIgnore, '!media/webviewScrollStateScripts.js', 'main VSIX ignore rules');
@@ -943,6 +946,7 @@ function run() {
         'media/webviewWorkspaceUpdateScripts.js',
         'media/webviewTodoGroupScripts.js',
         'media/webviewProjectCollapseScripts.js',
+        'media/webviewTodoControlScripts.js',
         'media/webviewProjectScripts.js',
         'media/webviewPromptScripts.js',
         'media/webviewScrollStateScripts.js',

--- a/scripts/run-skill-management-checks.js
+++ b/scripts/run-skill-management-checks.js
@@ -446,6 +446,7 @@ function runSkillWebviewScriptChecks() {
         'webviewProjectCollapseScripts.js',
         'webviewTodoControlScripts.js',
         'webviewProjectContextMenuScripts.js',
+        'webviewProjectAiUpdateScripts.js',
         'webviewProjectScripts.js',
     ].map(fileName => fs.readFileSync(
         path.join(__dirname, '..', 'media', fileName), 'utf8'

--- a/scripts/run-skill-management-checks.js
+++ b/scripts/run-skill-management-checks.js
@@ -439,7 +439,17 @@ function runSkillWebviewScriptChecks() {
     assert.ok(script.includes('captureSkillFolderMenuState'), '⋯ menu state captured across skills-updated');
     assert.ok(script.includes('restoreSkillFolderMenuState'), '⋯ menu re-synced after authoritative refresh');
     assert.ok(script.includes('skill-toggle-pending'), 'toggle pending state wired');
-    const projectScript = fs.readFileSync(path.join(__dirname, '..', 'media', 'webviewProjectScripts.js'), 'utf8');
+    const projectScript = [
+        'webviewAiSessionViewStateScripts.js',
+        'webviewWorkspaceUpdateScripts.js',
+        'webviewTodoGroupScripts.js',
+        'webviewProjectCollapseScripts.js',
+        'webviewTodoControlScripts.js',
+        'webviewProjectContextMenuScripts.js',
+        'webviewProjectScripts.js',
+    ].map(fileName => fs.readFileSync(
+        path.join(__dirname, '..', 'media', fileName), 'utf8'
+    )).join('\n');
     assert.ok(projectScript.includes('.custom-context-menu:not(.skill-folder-menu)'),
         'project script never closes the dashboard-owned skill folder menu');
     assert.ok(!script.includes('data-skill-scope-select'), 'scope selector wiring removed');

--- a/scripts/run-skill-management-checks.js
+++ b/scripts/run-skill-management-checks.js
@@ -447,6 +447,7 @@ function runSkillWebviewScriptChecks() {
         'webviewTodoControlScripts.js',
         'webviewProjectContextMenuScripts.js',
         'webviewProjectAiUpdateScripts.js',
+        'webviewProjectAiSessionControlsScripts.js',
         'webviewProjectScripts.js',
     ].map(fileName => fs.readFileSync(
         path.join(__dirname, '..', 'media', fileName), 'utf8'

--- a/src/webview/webviewContent.ts
+++ b/src/webview/webviewContent.ts
@@ -170,6 +170,12 @@ export function getStewardContent(
         'webviewProjectContextMenuScripts.js',
         assetRevision,
     );
+    var projectAiUpdateScriptsPath = getMediaResource(
+        context,
+        webview,
+        'webviewProjectAiUpdateScripts.js',
+        assetRevision,
+    );
     var projectScriptsPath = getMediaResource(
         context,
         webview,
@@ -310,6 +316,7 @@ export function getStewardContent(
     <script src="${projectCollapseScriptsPath}"></script>
     <script src="${todoControlScriptsPath}"></script>
     <script src="${projectContextMenuScriptsPath}"></script>
+    <script src="${projectAiUpdateScriptsPath}"></script>
     <script src="${projectScriptsPath}"></script>
     <script src="${dashboardScriptsPath}"></script>
     <script src="${promptScriptsPath}"></script>

--- a/src/webview/webviewContent.ts
+++ b/src/webview/webviewContent.ts
@@ -158,6 +158,12 @@ export function getStewardContent(
         'webviewProjectCollapseScripts.js',
         assetRevision,
     );
+    var todoControlScriptsPath = getMediaResource(
+        context,
+        webview,
+        'webviewTodoControlScripts.js',
+        assetRevision,
+    );
     var projectScriptsPath = getMediaResource(
         context,
         webview,
@@ -296,6 +302,7 @@ export function getStewardContent(
     <script src="${workspaceUpdateScriptsPath}"></script>
     <script src="${todoGroupScriptsPath}"></script>
     <script src="${projectCollapseScriptsPath}"></script>
+    <script src="${todoControlScriptsPath}"></script>
     <script src="${projectScriptsPath}"></script>
     <script src="${dashboardScriptsPath}"></script>
     <script src="${promptScriptsPath}"></script>

--- a/src/webview/webviewContent.ts
+++ b/src/webview/webviewContent.ts
@@ -152,6 +152,12 @@ export function getStewardContent(
         'webviewTodoGroupScripts.js',
         assetRevision,
     );
+    var projectCollapseScriptsPath = getMediaResource(
+        context,
+        webview,
+        'webviewProjectCollapseScripts.js',
+        assetRevision,
+    );
     var projectScriptsPath = getMediaResource(
         context,
         webview,
@@ -289,6 +295,7 @@ export function getStewardContent(
     <script src="${aiSessionViewStateScriptsPath}"></script>
     <script src="${workspaceUpdateScriptsPath}"></script>
     <script src="${todoGroupScriptsPath}"></script>
+    <script src="${projectCollapseScriptsPath}"></script>
     <script src="${projectScriptsPath}"></script>
     <script src="${dashboardScriptsPath}"></script>
     <script src="${promptScriptsPath}"></script>

--- a/src/webview/webviewContent.ts
+++ b/src/webview/webviewContent.ts
@@ -176,6 +176,12 @@ export function getStewardContent(
         'webviewProjectAiUpdateScripts.js',
         assetRevision,
     );
+    var aiSessionControlsScriptsPath = getMediaResource(
+        context,
+        webview,
+        'webviewProjectAiSessionControlsScripts.js',
+        assetRevision,
+    );
     var projectScriptsPath = getMediaResource(
         context,
         webview,
@@ -317,6 +323,7 @@ export function getStewardContent(
     <script src="${todoControlScriptsPath}"></script>
     <script src="${projectContextMenuScriptsPath}"></script>
     <script src="${projectAiUpdateScriptsPath}"></script>
+    <script src="${aiSessionControlsScriptsPath}"></script>
     <script src="${projectScriptsPath}"></script>
     <script src="${dashboardScriptsPath}"></script>
     <script src="${promptScriptsPath}"></script>

--- a/src/webview/webviewContent.ts
+++ b/src/webview/webviewContent.ts
@@ -164,6 +164,12 @@ export function getStewardContent(
         'webviewTodoControlScripts.js',
         assetRevision,
     );
+    var projectContextMenuScriptsPath = getMediaResource(
+        context,
+        webview,
+        'webviewProjectContextMenuScripts.js',
+        assetRevision,
+    );
     var projectScriptsPath = getMediaResource(
         context,
         webview,
@@ -303,6 +309,7 @@ export function getStewardContent(
     <script src="${todoGroupScriptsPath}"></script>
     <script src="${projectCollapseScriptsPath}"></script>
     <script src="${todoControlScriptsPath}"></script>
+    <script src="${projectContextMenuScriptsPath}"></script>
     <script src="${projectScriptsPath}"></script>
     <script src="${dashboardScriptsPath}"></script>
     <script src="${promptScriptsPath}"></script>

--- a/src/webview/webviewProjectAiSessionControlsScripts.js
+++ b/src/webview/webviewProjectAiSessionControlsScripts.js
@@ -1,0 +1,701 @@
+function initProjectAiSessionControls(options) {
+    'use strict';
+
+    options = options || {};
+    var getAiSessionsUpdate = options.getAiSessionsUpdate;
+    var updateStickyGroupHeaderOffset = options.updateStickyGroupHeaderOffset;
+
+    var batchAiSessionState = {
+        projectId: null,
+        selectedItems: new Map(),
+        pending: false,
+        requestId: null,
+    };
+    var activeAiSessionTerminalState = { provider: null, sessionId: null };
+    var nextAiSessionBatchArchiveRequestId = 0;
+    var nextAiSessionProviderSelectionRequestId = 0;
+    var pendingAiSessionProviderSelectionProjectId = null;
+    var pendingAiSessionProviderSelectionRequestId = null;
+    var pendingAiSessionProviderSelectionProviders = [];
+
+    function getAiSessionBatchItemKey(provider, sessionId) {
+        return JSON.stringify([provider, sessionId]);
+    }
+
+    function enter(projectId) {
+        if (batchAiSessionState.pending)
+            return;
+        batchAiSessionState.projectId = projectId;
+        batchAiSessionState.selectedItems = new Map();
+        batchAiSessionState.pending = false;
+        batchAiSessionState.requestId = null;
+    }
+
+    function toggle(provider, sessionId, active) {
+        if (!isAiSessionProvider(provider) || !sessionId || active || batchAiSessionState.pending)
+            return;
+        var key = getAiSessionBatchItemKey(provider, sessionId);
+        if (batchAiSessionState.selectedItems.has(key))
+            batchAiSessionState.selectedItems.delete(key);
+        else
+            batchAiSessionState.selectedItems.set(key, { provider, sessionId });
+    }
+
+    function selectUnpinned(sessions) {
+        if (batchAiSessionState.pending)
+            return;
+        sessions
+            .filter(session => isAiSessionProvider(session.provider)
+                && session.id && !session.pinned && !session.active)
+            .forEach(session => {
+                var item = { provider: session.provider, sessionId: session.id };
+                batchAiSessionState.selectedItems.set(
+                    getAiSessionBatchItemKey(item.provider, item.sessionId),
+                    item
+                );
+            });
+    }
+
+    function clear() {
+        if (!batchAiSessionState.pending)
+            batchAiSessionState.selectedItems.clear();
+    }
+
+    function reconcile(projectId, remainingItems) {
+        if (projectId !== batchAiSessionState.projectId) {
+            exit();
+            return;
+        }
+        let selectedItems = batchAiSessionState.selectedItems;
+        batchAiSessionState.selectedItems = new Map(
+            remainingItems
+                .filter(item => item && isAiSessionProvider(item.provider) && item.sessionId)
+                .map(item => {
+                    var key = getAiSessionBatchItemKey(item.provider, item.sessionId);
+                    return [key, selectedItems.get(key)];
+                })
+                .filter(entry => entry[1])
+        );
+    }
+
+    function reconcileVisible(projectDiv) {
+        if (!projectDiv)
+            return;
+        var projectId = projectDiv.getAttribute('data-id');
+        var remainingItems = Array.from(
+            projectDiv.querySelectorAll('.ai-session-history-panel .codex-session-row[data-session-id]')
+        )
+            .filter(row => isAiSessionProvider(row.getAttribute('data-session-provider') || 'codex')
+                && row.getAttribute('data-session-id')
+                && !row.hasAttribute('data-session-active'))
+            .map(row => ({
+                provider: row.getAttribute('data-session-provider') || 'codex',
+                sessionId: row.getAttribute('data-session-id'),
+            }));
+        reconcile(projectId, remainingItems);
+    }
+
+    function submit() {
+        if (batchAiSessionState.pending || !batchAiSessionState.selectedItems.size)
+            return;
+        nextAiSessionBatchArchiveRequestId = nextAiSessionBatchArchiveRequestId >= Number.MAX_SAFE_INTEGER
+            ? 1
+            : nextAiSessionBatchArchiveRequestId + 1;
+        var requestId = nextAiSessionBatchArchiveRequestId;
+        batchAiSessionState.pending = true;
+        batchAiSessionState.requestId = requestId;
+        window.vscode.postMessage({
+            type: 'archive-ai-sessions',
+            version: 1,
+            requestId: requestId,
+            projectId: batchAiSessionState.projectId,
+            items: Array.from(batchAiSessionState.selectedItems.values()),
+        });
+    }
+
+    function complete(message) {
+        if (!message
+            || message.type !== 'ai-session-batch-archive-completed'
+            || message.version !== 1
+            || !Number.isSafeInteger(message.requestId)
+            || message.requestId < 1
+            || typeof message.projectId !== 'string'
+            || !['cancelled', 'rejected', 'finished'].includes(message.status)
+            || !batchAiSessionState.pending
+            || message.projectId !== batchAiSessionState.projectId
+            || message.requestId !== batchAiSessionState.requestId) {
+            return false;
+        }
+        if (message.status === 'finished') {
+            exit();
+            return true;
+        }
+        batchAiSessionState.pending = false;
+        batchAiSessionState.requestId = null;
+        return true;
+    }
+
+    function exit() {
+        batchAiSessionState.projectId = null;
+        batchAiSessionState.selectedItems = new Map();
+        batchAiSessionState.pending = false;
+        batchAiSessionState.requestId = null;
+    }
+
+    function snapshot() {
+        return {
+            projectId: batchAiSessionState.projectId,
+            selectedItems: Array.from(batchAiSessionState.selectedItems.values()),
+            pending: batchAiSessionState.pending,
+        };
+    }
+
+    var batchAiSessionManager = {
+        enter, toggle, selectUnpinned, clear, reconcile, reconcileVisible,
+        submit, complete, exit, snapshot,
+    };
+    window.__agentPivotBatchAiSessions = batchAiSessionManager;
+
+    function onTriggerAiSessionAction(target, projectId) {
+        var projectDiv = target.closest('.project[data-id]');
+        var tabAction = target.closest('[data-action="select-ai-session-tab"][data-tab]');
+        if (tabAction) {
+            var selectedTab = normalizeAiSessionTab(tabAction.getAttribute('data-tab'));
+            selectAiSessionTabDom(projectDiv, selectedTab);
+            writeAiSessionTabState(window.vscode, projectId, selectedTab);
+            return true;
+        }
+
+        var providerMenuTrigger = target.closest('[data-ai-provider-menu-trigger]');
+        if (providerMenuTrigger) {
+            toggleAiSessionProviderMenu(projectDiv);
+            return true;
+        }
+
+        var providerOption = target.closest('[data-ai-provider-option][data-provider]');
+        if (providerOption) {
+            activateAiSessionProviderOption(projectDiv, providerOption);
+            return true;
+        }
+
+        var createAction = target.closest('[data-action="create-ai-session"]');
+        if (createAction) {
+            window.vscode.postMessage({
+                type: 'create-ai-session',
+                projectId,
+            });
+
+            return true;
+        }
+
+        var manageAction = target.closest('[data-action="manage-ai-sessions"][data-provider]');
+        if (manageAction) {
+            if (batchAiSessionState.pending
+                || pendingAiSessionProviderSelectionProjectId)
+                return true;
+
+            var manageProvider = manageAction.getAttribute("data-provider");
+            if (projectDiv && isAiSessionProvider(manageProvider)) {
+                if (isActiveAiSessionBatchScope(projectId, manageProvider)) {
+                    exitAiSessionBatchManagement();
+                } else {
+                    batchAiSessionManager.enter(projectId);
+                    syncAiSessionBatchManagementDom(projectDiv);
+                }
+            }
+
+            return true;
+        }
+
+        var selectUnpinnedAction = target.closest('[data-action="select-unpinned-ai-sessions"]');
+        if (selectUnpinnedAction) {
+            if (isActiveAiSessionBatchScope(projectId, getProjectActiveAiSessionProvider(projectDiv))) {
+                var sessions = Array.from(projectDiv.querySelectorAll('.ai-session-history-panel .codex-session-row[data-session-id]'))
+                    .map(row => ({
+                        provider: row.getAttribute("data-session-provider") || "codex",
+                        id: row.getAttribute("data-session-id"),
+                        pinned: row.hasAttribute("data-session-pinned"),
+                        active: row.hasAttribute("data-session-active"),
+                    }));
+                batchAiSessionManager.selectUnpinned(sessions);
+                syncAiSessionBatchManagementDom(projectDiv);
+            }
+
+            return true;
+        }
+
+        var clearSelectionAction = target.closest('[data-action="clear-ai-session-selection"]');
+        if (clearSelectionAction) {
+            if (isActiveAiSessionBatchScope(projectId, getProjectActiveAiSessionProvider(projectDiv))) {
+                batchAiSessionManager.clear();
+                syncAiSessionBatchManagementDom(projectDiv);
+            }
+
+            return true;
+        }
+
+        var archiveSelectedAction = target.closest('[data-action="archive-selected-ai-sessions"]');
+        if (archiveSelectedAction) {
+            if (isActiveAiSessionBatchScope(projectId, getProjectActiveAiSessionProvider(projectDiv))) {
+                batchAiSessionManager.submit();
+                syncAiSessionBatchManagementDom(projectDiv);
+            }
+
+            return true;
+        }
+
+        var terminalAction = target.closest('[data-action="close-ai-session-terminal"], [data-action="detach-ai-session-terminal"]');
+        if (terminalAction) {
+            var terminalRow = terminalAction.closest('.codex-session-row[data-session-provider][data-session-backend]');
+            var terminalProvider = terminalRow && terminalRow.getAttribute('data-session-provider');
+            var terminalBackend = terminalRow && terminalRow.getAttribute('data-session-backend');
+            var requestedDetach = terminalAction.getAttribute('data-action') === 'detach-ai-session-terminal';
+            if (terminalRow && isAiSessionProvider(terminalProvider)
+                && ((requestedDetach && terminalBackend === 'tmux')
+                    || (!requestedDetach && terminalBackend === 'vscode'))) {
+                var terminalMessage = {
+                    type: requestedDetach ? 'detach-ai-session-terminal' : 'close-ai-session-terminal',
+                    projectId,
+                    provider: terminalProvider,
+                };
+                if (terminalRow.hasAttribute('data-session-pending')) {
+                    terminalMessage.pendingCreatedAt = terminalRow.getAttribute('data-pending-created-at');
+                } else {
+                    terminalMessage.sessionId = terminalRow.getAttribute('data-session-id');
+                }
+                window.vscode.postMessage(terminalMessage);
+            }
+            return true;
+        }
+
+        var managedSessionRow = target.closest('.codex-session-row[data-session-id]');
+        if (managedSessionRow) {
+            var managedSessionProvider = managedSessionRow.getAttribute("data-session-provider") || "codex";
+            if (isActiveAiSessionBatchScope(projectId, managedSessionProvider)
+                && !managedSessionRow.hasAttribute('data-session-active')) {
+                batchAiSessionManager.toggle(
+                    managedSessionProvider,
+                    managedSessionRow.getAttribute("data-session-id"),
+                    managedSessionRow.hasAttribute('data-session-active')
+                );
+                syncAiSessionBatchManagementDom(projectDiv);
+                return true;
+            }
+        }
+
+        var pinAction = target.closest('[data-action="toggle-ai-session-pin"]');
+        if (pinAction) {
+            var pinRow = pinAction.closest('.codex-session-row[data-session-id]');
+            var pinSessionId = pinRow && pinRow.getAttribute("data-session-id");
+            var pinProvider = pinRow && pinRow.getAttribute("data-session-provider") || "codex";
+            if (pinSessionId) {
+                window.vscode.postMessage({
+                    type: 'toggle-ai-session-pin',
+                    projectId,
+                    provider: pinProvider,
+                    sessionId: pinSessionId,
+                });
+            }
+
+            return true;
+        }
+
+        var archiveAction = target.closest('[data-action="archive-codex-session"], [data-action="archive-kimi-session"], [data-action="archive-claude-session"]');
+        if (archiveAction) {
+            var archiveRow = archiveAction.closest('.codex-session-row[data-session-id]');
+            var archiveSessionId = archiveRow && archiveRow.getAttribute("data-session-id");
+            var archiveProvider = archiveRow && archiveRow.getAttribute("data-session-provider") || "codex";
+            if (archiveSessionId && isAiSessionProvider(archiveProvider)) {
+                acknowledgeAiSessionRow(archiveRow);
+                window.vscode.postMessage({
+                    type: getArchiveAiSessionMessageType(archiveProvider),
+                    projectId,
+                    sessionId: archiveSessionId,
+                });
+            }
+
+            return true;
+        }
+
+        var activation = getAiSessionCardActivation(target, projectId);
+        if (!activation.handled)
+            return false;
+        if (activation.sessionRow
+            && !activation.sessionRow.hasAttribute('data-session-pending')
+            && activation.sessionRow.getAttribute('data-session-id')) {
+            acknowledgeAiSessionRow(activation.sessionRow);
+        }
+        if (activation.message) {
+            window.vscode.postMessage(activation.message);
+        }
+        return true;
+    }
+
+    function acknowledgeAiSessionRow(sessionRow) {
+        if (!sessionRow || !sessionRow.hasAttribute('data-ai-session-attention')) return;
+        var provider = sessionRow.getAttribute('data-session-provider') || 'codex';
+        var sessionId = sessionRow.getAttribute('data-session-id') || '';
+        var fallback = sessionRow.getAttribute('data-session-event-id') || sessionRow.getAttribute('data-ai-session-event-id');
+        acknowledgeAiSession(provider, sessionId, fallback);
+    }
+
+    function acknowledgeAiSession(provider, sessionId, fallbackEventId) {
+        var sessionKey = provider + ':' + sessionId;
+        window.__agentPivotAttentionSessionEvents = window.__agentPivotAttentionSessionEvents || {};
+        var eventIds = window.__agentPivotAttentionSessionEvents[sessionKey] || [];
+        if (!eventIds.length && fallbackEventId) {
+            eventIds = [fallbackEventId];
+        }
+        eventIds = Array.from(new Set(eventIds.filter(eventId => typeof eventId === 'string' && !!eventId)));
+        if (eventIds.length) {
+            window.vscode.postMessage({ type: 'acknowledge-ai-session-attention', eventIds: eventIds });
+        }
+    }
+
+    window.__agentPivotAcknowledgeSession = (provider, sessionId) => {
+        if (isAiSessionProvider(provider) && sessionId) {
+            acknowledgeAiSession(provider, sessionId);
+        }
+    };
+
+    function getSelectedAiSessionProviders(projectDiv) {
+        var region = projectDiv && projectDiv.querySelector('[data-ai-session-region]');
+        return (region && region.getAttribute('data-selected-ai-session-providers') || '')
+            .split(',')
+            .filter(isAiSessionProvider);
+    }
+
+    function submitAiSessionProviderSelection(projectDiv, providers) {
+        var projectId = projectDiv && projectDiv.getAttribute('data-id');
+        if (!projectId || !providers.length || batchAiSessionState.pending
+            || pendingAiSessionProviderSelectionProjectId)
+            return;
+
+        exitAiSessionBatchManagement();
+        nextAiSessionProviderSelectionRequestId += 1;
+        var requestId = nextAiSessionProviderSelectionRequestId;
+        pendingAiSessionProviderSelectionProjectId = projectId;
+        pendingAiSessionProviderSelectionRequestId = requestId;
+        pendingAiSessionProviderSelectionProviders = providers.slice();
+        syncAiSessionProviderMenuDisabledDom(projectDiv, true);
+        window.vscode.postMessage({
+            type: 'select-ai-session-providers',
+            version: 1,
+            requestId: requestId,
+            projectId,
+            selectedProviders: providers,
+        });
+    }
+
+    function setAiSessionProviderMenuOpen(projectDiv, open) {
+        var trigger = projectDiv && projectDiv.querySelector('[data-ai-provider-menu-trigger]');
+        var menu = projectDiv && projectDiv.querySelector('[data-ai-provider-menu]');
+        if (!trigger || !menu)
+            return;
+        if (open && (batchAiSessionState.pending
+            || pendingAiSessionProviderSelectionProjectId))
+            return;
+
+        trigger.setAttribute('aria-expanded', open ? 'true' : 'false');
+        menu.hidden = !open;
+    }
+
+    function closeAiSessionProviderMenus(exceptProjectDiv) {
+        document.querySelectorAll('.project[data-id]').forEach(projectDiv => {
+            if (projectDiv !== exceptProjectDiv) {
+                setAiSessionProviderMenuOpen(projectDiv, false);
+            }
+        });
+    }
+
+    function closeAiSessionProviderMenu(projectDiv, restoreFocus) {
+        setAiSessionProviderMenuOpen(projectDiv, false);
+        if (restoreFocus) {
+            projectDiv?.querySelector('[data-ai-provider-menu-trigger]')?.focus();
+        }
+    }
+
+    function toggleAiSessionProviderMenu(projectDiv) {
+        if (!projectDiv || batchAiSessionState.pending
+            || pendingAiSessionProviderSelectionProjectId)
+            return;
+        var trigger = projectDiv.querySelector('[data-ai-provider-menu-trigger]');
+        var open = trigger?.getAttribute('aria-expanded') !== 'true';
+        closeAiSessionProviderMenus(projectDiv);
+        setAiSessionProviderMenuOpen(projectDiv, open);
+    }
+
+    function activateAiSessionProviderOption(projectDiv, option) {
+        if (!projectDiv || !option || batchAiSessionState.pending
+            || pendingAiSessionProviderSelectionProjectId)
+            return;
+        var provider = option.getAttribute('data-provider');
+        if (!isAiSessionProvider(provider))
+            return;
+        var selectedProviders = getSelectedAiSessionProviders(projectDiv);
+        var selected = selectedProviders.includes(provider);
+        if (selected && selectedProviders.length === 1)
+            return;
+        submitAiSessionProviderSelection(
+            projectDiv,
+            selected
+                ? selectedProviders.filter(candidate => candidate !== provider)
+                : selectedProviders.concat(provider)
+        );
+    }
+
+    function getAiSessionProviderOptions(projectDiv) {
+        return projectDiv
+            ? Array.from(projectDiv.querySelectorAll('[data-ai-provider-option][data-provider]'))
+            : [];
+    }
+
+    function isAiSessionProvider(provider) {
+        return provider === "codex" || provider === "kimi" || provider === "claude";
+    }
+
+    function getResumeAiSessionMessageType(provider) {
+        if (provider === "kimi")
+            return 'resume-kimi-session';
+        if (provider === "claude")
+            return 'resume-claude-session';
+
+        return 'resume-codex-session';
+    }
+
+    function getArchiveAiSessionMessageType(provider) {
+        if (provider === "kimi")
+            return 'archive-kimi-session';
+        if (provider === "claude")
+            return 'archive-claude-session';
+
+        return 'archive-codex-session';
+    }
+
+    function toggleCodexSessions(projectDiv, projectId) {
+        var expanded = !projectDiv.hasAttribute("data-codex-expanded");
+        if (!expanded && batchAiSessionState.projectId === projectId) {
+            exitAiSessionBatchManagement();
+        }
+        projectDiv.toggleAttribute("data-codex-expanded", expanded);
+        updateStickyGroupHeaderOffset();
+
+        window.vscode.postMessage({
+            type: 'toggle-codex-sessions',
+            projectId,
+            expanded,
+        });
+    }
+
+    function isActiveAiSessionBatchScope(projectId) {
+        return projectId === batchAiSessionState.projectId;
+    }
+
+    function getProjectActiveAiSessionProvider(projectDiv) {
+        if (!projectDiv)
+            return null;
+
+        var region = projectDiv.querySelector('[data-ai-session-region]');
+        var activeProvider = region && region.getAttribute('data-active-ai-session-provider');
+        if (isAiSessionProvider(activeProvider))
+            return activeProvider;
+
+        var selectedProviders = region && region.getAttribute('data-selected-ai-session-providers') || '';
+        return selectedProviders.split(',').find(isAiSessionProvider) || null;
+    }
+
+    function syncActiveAiSessionTerminalDom() {
+        document.querySelectorAll('.codex-session-row[data-session-id]').forEach(row => {
+            var provider = row.getAttribute('data-session-provider') || 'codex';
+            var sessionId = row.getAttribute('data-session-id');
+            row.toggleAttribute(
+                'data-ai-session-active-terminal',
+                provider === activeAiSessionTerminalState.provider
+                    && sessionId === activeAiSessionTerminalState.sessionId
+            );
+        });
+    }
+
+    function syncAiSessionBatchManagementDom(projectDiv) {
+        var snapshot = batchAiSessionManager.snapshot();
+        document.querySelectorAll('.project[data-ai-session-managing], .project[data-ai-session-pending]').forEach(project => {
+            if (project !== projectDiv || project.getAttribute("data-id") !== snapshot.projectId) {
+                project.removeAttribute("data-ai-session-managing");
+                project.removeAttribute("data-ai-session-pending");
+                syncAiSessionProviderMenuDisabledDom(project, false);
+                var inactiveManageButton = project.querySelector('[data-action="manage-ai-sessions"]');
+                if (inactiveManageButton) {
+                    inactiveManageButton.setAttribute('aria-pressed', 'false');
+                    inactiveManageButton.disabled = false;
+                }
+            }
+        });
+
+        if (!projectDiv)
+            return;
+
+        var projectId = projectDiv.getAttribute("data-id");
+        var isScoped = projectId === snapshot.projectId;
+        projectDiv.toggleAttribute("data-ai-session-managing", isScoped);
+        projectDiv.toggleAttribute("data-ai-session-pending", isScoped && snapshot.pending);
+        syncAiSessionProviderMenuDisabledDom(projectDiv, isScoped && snapshot.pending);
+        var manageButton = projectDiv.querySelector('[data-action="manage-ai-sessions"]');
+        if (manageButton) {
+            manageButton.setAttribute('aria-pressed', isScoped ? 'true' : 'false');
+            manageButton.disabled = isScoped && snapshot.pending;
+        }
+
+        var selectedItems = new Set(snapshot.selectedItems.map(item =>
+            getAiSessionBatchItemKey(item.provider, item.sessionId)
+        ));
+        projectDiv.querySelectorAll('.ai-session-history-panel .codex-session-row[data-session-id]').forEach(row => {
+            var rowProvider = row.getAttribute("data-session-provider") || "codex";
+            var isActive = row.hasAttribute('data-session-active');
+            var isSelected = isScoped
+                && !isActive
+                && selectedItems.has(getAiSessionBatchItemKey(
+                    rowProvider,
+                    row.getAttribute("data-session-id")
+                ));
+            row.toggleAttribute("data-ai-session-selected", isSelected);
+            var checkbox = row.querySelector('.ai-session-batch-checkbox');
+            if (checkbox) {
+                checkbox.checked = isSelected;
+                checkbox.disabled = isActive || (isScoped && snapshot.pending);
+            }
+        });
+
+        var count = isScoped ? snapshot.selectedItems.length : 0;
+        var countElement = projectDiv.querySelector('.ai-session-batch-count');
+        if (countElement) {
+            countElement.textContent = count + ' selected';
+        }
+        projectDiv.querySelectorAll('.ai-session-batch-actions button').forEach(button => {
+            button.disabled = isScoped && snapshot.pending;
+        });
+        var archiveButton = projectDiv.querySelector('[data-action="archive-selected-ai-sessions"]');
+        if (archiveButton) {
+            archiveButton.disabled = !isScoped || snapshot.pending || count === 0;
+        }
+    }
+
+    function syncAiSessionProviderMenuDisabledDom(projectDiv, batchPending) {
+        var projectId = projectDiv?.getAttribute('data-id');
+        var providerSelectionPending = projectId
+            === pendingAiSessionProviderSelectionProjectId;
+        var pending = Boolean(
+            batchPending || batchAiSessionState.pending || providerSelectionPending
+        );
+        var trigger = projectDiv && projectDiv.querySelector('[data-ai-provider-menu-trigger]');
+        if (trigger) {
+            trigger.disabled = pending;
+            trigger.setAttribute('aria-disabled', pending ? 'true' : 'false');
+        }
+        var selectedProviders = getSelectedAiSessionProviders(projectDiv);
+        getAiSessionProviderOptions(projectDiv).forEach(option => {
+            var provider = option.getAttribute('data-provider');
+            var lastSelectedProvider = selectedProviders.length === 1
+                && selectedProviders[0] === provider;
+            option.disabled = pending;
+            option.setAttribute(
+                'aria-disabled',
+                pending || lastSelectedProvider ? 'true' : 'false'
+            );
+        });
+        if (pending) {
+            closeAiSessionProviderMenu(projectDiv, false);
+        }
+    }
+
+    function clearPendingAiSessionProviderSelection() {
+        pendingAiSessionProviderSelectionProjectId = null;
+        pendingAiSessionProviderSelectionRequestId = null;
+        pendingAiSessionProviderSelectionProviders = [];
+    }
+
+    function selectedAiSessionProvidersMatch(projectDiv, expectedProviders) {
+        var selectedProviders = getSelectedAiSessionProviders(projectDiv);
+        return selectedProviders.length === expectedProviders.length
+            && selectedProviders.every(provider =>
+                expectedProviders.includes(provider)
+            );
+    }
+
+    function reconcilePendingAiSessionProviderSelectionDom() {
+        if (!pendingAiSessionProviderSelectionProjectId)
+            return;
+        var projectDiv = getAiSessionsUpdate().findCurrentWorkspaceDiv(
+            pendingAiSessionProviderSelectionProjectId
+        );
+        if (!projectDiv)
+            return;
+        if (selectedAiSessionProvidersMatch(
+            projectDiv,
+            pendingAiSessionProviderSelectionProviders
+        )) {
+            clearPendingAiSessionProviderSelection();
+        }
+        syncAiSessionProviderMenuDisabledDom(projectDiv, false);
+    }
+
+    function applyAiSessionProviderSelectionResult(message) {
+        if (!message
+            || message.type !== 'ai-session-provider-selection-result'
+            || message.version !== 1
+            || !Number.isSafeInteger(message.requestId)
+            || message.requestId < 1
+            || typeof message.projectId !== 'string'
+            || typeof message.success !== 'boolean'
+            || message.projectId !== pendingAiSessionProviderSelectionProjectId
+            || message.requestId !== pendingAiSessionProviderSelectionRequestId) {
+            return false;
+        }
+        if (message.success) {
+            return true;
+        }
+
+        var projectDiv = getAiSessionsUpdate().findCurrentWorkspaceDiv(message.projectId);
+        clearPendingAiSessionProviderSelection();
+        syncAiSessionProviderMenuDisabledDom(projectDiv, false);
+        var liveRegion = projectDiv?.querySelector('[data-ai-session-live-region]');
+        if (liveRegion) {
+            liveRegion.textContent = 'Could not update AI session providers. Try again.';
+        }
+        return true;
+    }
+
+    function exitAiSessionBatchManagement() {
+        var projectId = batchAiSessionState.projectId;
+        batchAiSessionManager.exit();
+        syncAiSessionBatchManagementDom(getAiSessionsUpdate().findCurrentWorkspaceDiv(projectId));
+    }
+
+    function getPendingAiSessionProviderSelectionProjectId() {
+        return pendingAiSessionProviderSelectionProjectId;
+    }
+
+    return {
+        batchAiSessionManager: batchAiSessionManager,
+        batchAiSessionState: batchAiSessionState,
+        activeAiSessionTerminalState: activeAiSessionTerminalState,
+        getPendingAiSessionProviderSelectionProjectId: getPendingAiSessionProviderSelectionProjectId,
+        activateAiSessionProviderOption: activateAiSessionProviderOption,
+        applyAiSessionProviderSelectionResult: applyAiSessionProviderSelectionResult,
+        closeAiSessionProviderMenu: closeAiSessionProviderMenu,
+        closeAiSessionProviderMenus: closeAiSessionProviderMenus,
+        exitAiSessionBatchManagement: exitAiSessionBatchManagement,
+        getAiSessionProviderOptions: getAiSessionProviderOptions,
+        getArchiveAiSessionMessageType: getArchiveAiSessionMessageType,
+        getResumeAiSessionMessageType: getResumeAiSessionMessageType,
+        getSelectedAiSessionProviders: getSelectedAiSessionProviders,
+        isAiSessionProvider: isAiSessionProvider,
+        onTriggerAiSessionAction: onTriggerAiSessionAction,
+        reconcilePendingAiSessionProviderSelectionDom: reconcilePendingAiSessionProviderSelectionDom,
+        setAiSessionProviderMenuOpen: setAiSessionProviderMenuOpen,
+        submitAiSessionProviderSelection: submitAiSessionProviderSelection,
+        syncActiveAiSessionTerminalDom: syncActiveAiSessionTerminalDom,
+        syncAiSessionBatchManagementDom: syncAiSessionBatchManagementDom,
+        toggleAiSessionProviderMenu: toggleAiSessionProviderMenu,
+        toggleCodexSessions: toggleCodexSessions,
+    };
+}

--- a/src/webview/webviewProjectAiUpdateScripts.js
+++ b/src/webview/webviewProjectAiUpdateScripts.js
@@ -1,0 +1,176 @@
+function initProjectAiSessionsUpdate(options) {
+    'use strict';
+
+    options = options || {};
+    var batchAiSessionState = options.batchAiSessionState;
+    var batchAiSessionManager = options.batchAiSessionManager;
+    var getPendingAiSessionProviderSelectionProjectId = options.getPendingAiSessionProviderSelectionProjectId;
+    var getSelectedAiSessionProviders = options.getSelectedAiSessionProviders;
+    var syncAiSessionBatchManagementDom = options.syncAiSessionBatchManagementDom;
+    var syncActiveAiSessionTerminalDom = options.syncActiveAiSessionTerminalDom;
+    var reconcilePendingAiSessionProviderSelectionDom = options.reconcilePendingAiSessionProviderSelectionDom;
+    var submitAiSessionProviderSelection = options.submitAiSessionProviderSelection;
+    var toggleCodexSessions = options.toggleCodexSessions;
+    var exitAiSessionBatchManagement = options.exitAiSessionBatchManagement;
+    var isAiSessionProvider = options.isAiSessionProvider;
+    var updateStickyGroupHeaderOffset = options.updateStickyGroupHeaderOffset;
+
+    var pendingWorkspaceSessionReveal = null;
+    var latestAiSessionUpdateSequence = 0;
+
+    function applyAiSessionsUpdate(message) {
+        if (message.version !== 2
+            || typeof message.sequence !== 'number'
+            || (message.currentWorkspaceCount !== 0 && message.currentWorkspaceCount !== 1)
+            || typeof message.html !== 'string'
+            || typeof normalizeDashboardSearchCatalog !== 'function'
+            || normalizeDashboardSearchCatalog(message.searchCatalog) !== message.searchCatalog
+            || message.searchCatalog.version !== 2) {
+            requestFullRefresh('unsupported-ai-session-message');
+            return;
+        }
+
+        if (message.sequence <= latestAiSessionUpdateSequence) {
+            return;
+        }
+
+        if (!applyWorkspaceUpdate({
+            type: 'workspace-updated',
+            version: 2,
+            currentWorkspaceCount: message.currentWorkspaceCount,
+            html: message.html,
+        }, {
+            canRestoreAiSessionProviderMenu: () =>
+                !getPendingAiSessionProviderSelectionProjectId()
+                && !batchAiSessionState.pending,
+        })) {
+            requestFullRefresh('invalid-ai-session-workspace-update');
+            return;
+        }
+
+        latestAiSessionUpdateSequence = message.sequence;
+        if (batchAiSessionState.projectId) {
+            var projectDiv = findCurrentWorkspaceDiv(batchAiSessionState.projectId);
+            if (projectDiv) {
+                batchAiSessionManager.reconcileVisible(projectDiv);
+                syncAiSessionBatchManagementDom(projectDiv);
+            } else {
+                exitAiSessionBatchManagement();
+            }
+        }
+        reconcilePendingAiSessionProviderSelectionDom();
+        syncActiveAiSessionTerminalDom();
+        updateStickyGroupHeaderOffset();
+        if (window.__agentPivotDashboard) {
+            window.__agentPivotDashboard.replaceSearchCatalog(message.searchCatalog);
+        }
+    }
+
+    function findCurrentWorkspaceDiv(projectId) {
+        if (!projectId) {
+            return null;
+        }
+
+        var projects = document.querySelectorAll('.workspace-card[data-current-workspace][data-id]');
+        for (var projectDiv of projects) {
+            if (projectDiv.getAttribute("data-id") === projectId) {
+                return projectDiv;
+            }
+        }
+
+        return null;
+    }
+
+    function findWorkspaceDiv(navigationIdentity) {
+        if (!navigationIdentity) {
+            return null;
+        }
+        var workspaces = document.querySelectorAll('.workspace-card[data-workspace-navigation-identity]');
+        for (var workspaceDiv of workspaces) {
+            if (workspaceDiv.getAttribute('data-workspace-navigation-identity') === navigationIdentity) {
+                return workspaceDiv;
+            }
+        }
+        return null;
+    }
+
+    function focusSearchRevealTarget(target) {
+        target.setAttribute('tabindex', '-1');
+        target.focus();
+        target.scrollIntoView({ block: 'nearest' });
+        target.addEventListener('blur', () => target.removeAttribute('tabindex'), { once: true });
+    }
+
+    window.__agentPivotRevealWorkspace = navigationIdentity => {
+        var workspaceDiv = findWorkspaceDiv(navigationIdentity);
+        if (!workspaceDiv) {
+            return false;
+        }
+        focusSearchRevealTarget(workspaceDiv);
+        return true;
+    };
+
+    function revealWorkspaceSession(navigationIdentity, provider, sessionId) {
+        if (!isAiSessionProvider(provider) || !sessionId) {
+            return false;
+        }
+        var workspaceDiv = findWorkspaceDiv(navigationIdentity);
+        if (!workspaceDiv) {
+            return false;
+        }
+        var workspaceId = workspaceDiv.getAttribute('data-id');
+        if (!workspaceDiv.hasAttribute('data-codex-expanded')) {
+            toggleCodexSessions(workspaceDiv, workspaceId);
+        }
+        selectAiSessionTabDom(workspaceDiv, 'sessions');
+        writeAiSessionTabState(window.vscode, workspaceId, 'sessions');
+        var sessionRow = Array.from(workspaceDiv.querySelectorAll('.codex-session-row[data-session-id][data-session-provider]'))
+            .find(row => row.getAttribute('data-session-provider') === provider
+                && row.getAttribute('data-session-id') === sessionId);
+        if (sessionRow) {
+            pendingWorkspaceSessionReveal = null;
+            focusSearchRevealTarget(sessionRow);
+            return true;
+        }
+        var selectedProviders = getSelectedAiSessionProviders(workspaceDiv);
+        if (!selectedProviders.includes(provider)) {
+            pendingWorkspaceSessionReveal = { navigationIdentity, provider, sessionId };
+            submitAiSessionProviderSelection(
+                workspaceDiv,
+                selectedProviders.concat(provider)
+            );
+            return true;
+        }
+        pendingWorkspaceSessionReveal = null;
+        focusSearchRevealTarget(workspaceDiv);
+        return false;
+    }
+
+    window.__agentPivotRevealWorkspaceSession = revealWorkspaceSession;
+    window.__agentPivotRevealPendingWorkspaceSession = () => {
+        if (!pendingWorkspaceSessionReveal) {
+            return false;
+        }
+        var pending = pendingWorkspaceSessionReveal;
+        return revealWorkspaceSession(
+            pending.navigationIdentity,
+            pending.provider,
+            pending.sessionId
+        );
+    };
+
+    function requestFullRefresh(reason) {
+        window.vscode.postMessage({
+            type: 'request-full-refresh',
+            reason,
+        });
+    }
+
+    return {
+        applyAiSessionsUpdate: applyAiSessionsUpdate,
+        findCurrentWorkspaceDiv: findCurrentWorkspaceDiv,
+        findWorkspaceDiv: findWorkspaceDiv,
+        focusSearchRevealTarget: focusSearchRevealTarget,
+        requestFullRefresh: requestFullRefresh,
+    };
+}

--- a/src/webview/webviewProjectCollapseScripts.js
+++ b/src/webview/webviewProjectCollapseScripts.js
@@ -1,0 +1,95 @@
+function initProjectGroupCollapse() {
+    'use strict';
+
+    function updateToggleAllGroupsButton(state) {
+        document.body.classList.toggle("steward-all-collapsed", state.collapsed);
+        var button = document.querySelector('[data-action="toggle-all-groups"]');
+        if (!button)
+            return;
+
+        button.disabled = state.disabled;
+        button.setAttribute('aria-disabled', state.disabled ? 'true' : 'false');
+        button.setAttribute("title", state.title);
+        button.setAttribute("aria-label", state.title);
+    }
+
+    function getActiveDashboardTab() {
+        var dashboard = window.__agentPivotDashboard;
+        var selectedTab = !dashboard && document.querySelector
+            ? document.querySelector('[data-dashboard-tab][aria-selected="true"]')
+            : null;
+        var activeTab = dashboard && typeof dashboard.getActiveTab === 'function'
+            ? dashboard.getActiveTab()
+            : selectedTab && selectedTab.getAttribute('data-dashboard-tab');
+        return activeTab === 'projects' || activeTab === 'todo' || activeTab === 'ai'
+            ? activeTab
+            : 'open';
+    }
+
+    function getActiveCollapsibleGroups() {
+        var activeTab = getActiveDashboardTab();
+        var selector = activeTab === 'projects'
+            ? '#dashboard-tab-projects .group[data-group-id]'
+            : activeTab === 'todo'
+                ? '#dashboard-tab-todo .todo-group[data-todo-group-id]'
+                : activeTab === 'open'
+                    ? '#dashboard-tab-open .open-other-windows-group[data-group-id]'
+                    : null;
+        if (!selector) {
+            return [];
+        }
+        return [...document.querySelectorAll(selector)];
+    }
+
+    function setGroupCollapsed(group, collapsed, persist) {
+        group.classList.toggle('collapsed', collapsed);
+        if (persist) {
+            var isTodoGroup = group.classList.contains('todo-group');
+            window.vscode.postMessage({
+                type: isTodoGroup ? 'todo-collapse-group' : 'collapse-group',
+                groupId: isTodoGroup
+                    ? group.getAttribute('data-todo-group-id')
+                    : group.getAttribute('data-group-id'),
+                collapsed,
+            });
+        }
+    }
+
+    function syncCollapseButton() {
+        var activeTab = getActiveDashboardTab();
+        var groups = getActiveCollapsibleGroups();
+        updateToggleAllGroupsButton(getCollapseButtonState(
+            activeTab,
+            groups.map(group => group.classList.contains('collapsed'))
+        ));
+    }
+
+    function toggleAllGroups() {
+        var activeTab = getActiveDashboardTab();
+        var groups = getActiveCollapsibleGroups();
+        var shouldCollapse = groups.some(group => !group.classList.contains("collapsed"));
+
+        if (activeTab === 'todo') {
+            if (window.__agentPivotTodo
+                && typeof window.__agentPivotTodo.dispatch === 'function') {
+                window.__agentPivotTodo.dispatch('collapse-groups', { collapsed: shouldCollapse });
+            } else {
+                collapseTodoGroups(groups, shouldCollapse, message => window.vscode.postMessage(message));
+            }
+            syncCollapseButton();
+            return;
+        }
+
+        groups.forEach(group => setGroupCollapsed(group, shouldCollapse, true));
+        syncCollapseButton();
+    }
+
+
+    window.__agentPivotSyncCollapseButton = syncCollapseButton;
+
+    return {
+        setGroupCollapsed: setGroupCollapsed,
+        syncCollapseButton: syncCollapseButton,
+        toggleAllGroups: toggleAllGroups,
+    };
+}

--- a/src/webview/webviewProjectContextMenuScripts.js
+++ b/src/webview/webviewProjectContextMenuScripts.js
@@ -1,0 +1,306 @@
+function initProjectContextMenus(options) {
+    'use strict';
+
+    options = options || {};
+    var openProject = options.openProject;
+    var ProjectOpenType = options.ProjectOpenType;
+    var getResumeAiSessionMessageType = options.getResumeAiSessionMessageType;
+    var getArchiveAiSessionMessageType = options.getArchiveAiSessionMessageType;
+    var isAiSessionProvider = options.isAiSessionProvider;
+
+    function onTriggerProjectAction(target, projectId) {
+        var actionDiv = target.closest('[data-action]')
+        if (actionDiv == null)
+            return false;
+
+        var action = actionDiv.getAttribute("data-action");
+        if (!action)
+            return false;
+
+        if (action === 'save-current-workspace') {
+            window.vscode.postMessage({
+                type: 'save-current-workspace',
+                projectId,
+            });
+            return true;
+        }
+
+        if (action === 'toggle-open-workspace-pin') {
+            requestOpenWorkspacePin(actionDiv, projectId);
+            return true;
+        }
+
+        window.vscode.postMessage({
+            type: action + '-project',
+            projectId,
+        });
+
+        return true;
+    }
+
+    var contextMenuProjectId = null;
+    var contextMenuGroupId = null;
+    var contextMenuAiSessionId = null;
+    var contextMenuAiSessionProvider = null;
+    var contextMenuAiSessionProjectId = null;
+    var contextMenuAiSessionActive = false;
+    var contextMenuAiSessionBackend = null;
+    var contextMenuAiSessionConflict = false;
+    var contextMenuAiSessionOrigin = null;
+
+    function showContextMenu(contextMenuElement, e) {
+        contextMenuElement.style.visibility = "hidden";
+        contextMenuElement.style.left = "0px";
+        contextMenuElement.style.top = "0px";
+        contextMenuElement.classList.add("visible");
+
+        var rect = contextMenuElement.getBoundingClientRect();
+        var viewportPadding = 4;
+        var left = e.clientX;
+        var top = e.clientY;
+
+        if (left + rect.width + viewportPadding > window.innerWidth) {
+            left = Math.max(viewportPadding, window.innerWidth - rect.width - viewportPadding);
+        }
+
+        if (top + rect.height + viewportPadding > window.innerHeight) {
+            top = Math.max(viewportPadding, window.innerHeight - rect.height - viewportPadding);
+        }
+
+        contextMenuElement.style.left = left + "px";
+        contextMenuElement.style.top = top + "px";
+        contextMenuElement.style.visibility = "";
+    }
+
+    function onContextMenu(e) {
+        closeContextMenus(); // Close previews
+
+        var sessionRow = e.target.closest('.codex-session-row[data-session-id][data-session-provider]');
+        if (sessionRow) {
+            contextMenuAiSessionOrigin = sessionRow.querySelector('.ai-session-primary-action') || sessionRow;
+            contextMenuAiSessionId = sessionRow.getAttribute("data-session-id");
+            contextMenuAiSessionProvider = sessionRow.getAttribute("data-session-provider");
+            var sessionProjectDiv = sessionRow.closest('.project[data-id]');
+            contextMenuAiSessionProjectId = sessionProjectDiv ? sessionProjectDiv.getAttribute("data-id") : null;
+            contextMenuAiSessionActive = sessionRow.hasAttribute('data-session-active');
+            contextMenuAiSessionBackend = sessionRow.getAttribute('data-session-backend') || 'vscode';
+            contextMenuAiSessionConflict = sessionRow.hasAttribute('data-session-conflict');
+            if (!contextMenuAiSessionId || !isAiSessionProvider(contextMenuAiSessionProvider))
+                return;
+
+            e.preventDefault();
+            var sessionContextMenuElement = document.getElementById("aiSessionContextMenu");
+            if (!sessionContextMenuElement)
+                return;
+            sessionContextMenuElement.querySelectorAll(':scope > *').forEach(element => element.classList.remove('disabled'));
+            var archiveMenuItem = sessionContextMenuElement.querySelector('[data-action="archive"]');
+            var closeMenuItem = sessionContextMenuElement.querySelector('[data-action="close-terminal"]');
+            if (archiveMenuItem) archiveMenuItem.classList.toggle('disabled', contextMenuAiSessionActive);
+            if (closeMenuItem) {
+                var terminalActionLabel = contextMenuAiSessionBackend === 'tmux'
+                    ? 'Detach Terminal…' : 'Close Terminal…';
+                closeMenuItem.textContent = terminalActionLabel;
+                closeMenuItem.setAttribute('aria-label', terminalActionLabel);
+                closeMenuItem.toggleAttribute('hidden', contextMenuAiSessionConflict);
+                closeMenuItem.classList.toggle(
+                    'disabled', !contextMenuAiSessionActive || contextMenuAiSessionConflict
+                );
+            }
+
+            showContextMenu(sessionContextMenuElement, e);
+            if (e.keyboardTrigger) {
+                var firstMenuItem = sessionContextMenuElement.querySelector('.custom-context-menu-item[data-action]:not(.disabled)');
+                firstMenuItem?.focus();
+            }
+            return;
+        }
+
+        var projectDiv = e.target.closest('.project[data-id]');
+        var groupDiv = e.target.closest('.group-title')
+        if (!projectDiv && !groupDiv)
+            return;
+
+        if (projectDiv && projectDiv.hasAttribute("data-readonly-project"))
+            return;
+
+        e.preventDefault();
+
+        let contextMenuForProject = projectDiv != null;
+        var contextMenuElement;
+        if (contextMenuForProject) {
+            contextMenuProjectId = projectDiv.getAttribute("data-id");
+            if (contextMenuProjectId == null)
+                return;
+
+            contextMenuElement = document.getElementById("projectContextMenu");
+        } else {
+            let groupIdDiv = groupDiv.closest(".group[data-group-id]");
+            if (groupIdDiv && groupIdDiv.hasAttribute("data-virtual-group"))
+                return;
+
+            contextMenuGroupId = groupIdDiv ? groupIdDiv.getAttribute("data-group-id") : null;
+            if (contextMenuGroupId == null)
+                return;
+
+            contextMenuElement = document.getElementById("groupContextMenu");
+        }
+
+        // disable elements if needed
+        contextMenuElement.querySelectorAll(":scope > *").forEach(e => e.classList.remove("disabled"));
+
+        if (projectDiv && projectDiv.hasAttribute("data-is-remote")) {
+            contextMenuElement.querySelectorAll(".not-remote").forEach(e => e.classList.add("disabled"));
+        }
+
+        // place and show contextmenu
+
+        showContextMenu(contextMenuElement, e);
+    }
+
+    function onProjectContextMenuActionClicked(el) {
+        var action = el.getAttribute("data-action");
+
+        if (action == null || contextMenuProjectId == null)
+            return;
+
+        switch (action) {
+            case 'open':
+                openProject(contextMenuProjectId, ProjectOpenType.CurrentWindow);
+                break;
+            case 'open-add-to-workspace':
+                openProject(contextMenuProjectId, ProjectOpenType.AddToWorkspace);
+                break;
+            default:
+                window.vscode.postMessage({
+                    type: action + '-project',
+                    projectId: contextMenuProjectId,
+                });
+                break;
+        }
+
+        closeContextMenus();
+    }
+
+    function onGroupContextMenuActionClicked(el) {
+        var action = el.getAttribute("data-action");
+
+        if (action == null || contextMenuGroupId == null)
+            return;
+
+        switch (action) {
+            case 'add':
+                window.vscode.postMessage({
+                    type: 'add-project',
+                    groupId: contextMenuGroupId,
+                });
+                break;
+            default:
+                window.vscode.postMessage({
+                    type: action + '-group',
+                    groupId: contextMenuGroupId,
+                });
+                break;
+        }
+
+        closeContextMenus();
+    }
+
+    function onAiSessionContextMenuActionClicked(el) {
+        var action = el.getAttribute("data-action");
+        var origin = contextMenuAiSessionOrigin;
+
+        if (action == null || contextMenuAiSessionId == null || contextMenuAiSessionProvider == null)
+            return;
+
+        switch (action) {
+            case 'resume':
+                window.vscode.postMessage(contextMenuAiSessionActive ? {
+                    type: 'focus-ai-session-terminal',
+                    provider: contextMenuAiSessionProvider,
+                    projectId: contextMenuAiSessionProjectId,
+                    sessionId: contextMenuAiSessionId,
+                } : {
+                    type: getResumeAiSessionMessageType(contextMenuAiSessionProvider),
+                    provider: contextMenuAiSessionProvider,
+                    projectId: contextMenuAiSessionProjectId,
+                    sessionId: contextMenuAiSessionId,
+                });
+                break;
+            case 'rename':
+                window.vscode.postMessage({
+                    type: 'rename-ai-session',
+                    provider: contextMenuAiSessionProvider,
+                    sessionId: contextMenuAiSessionId,
+                });
+                break;
+            case 'copy-id':
+                window.vscode.postMessage({
+                    type: 'copy-ai-session-id',
+                    provider: contextMenuAiSessionProvider,
+                    sessionId: contextMenuAiSessionId,
+                });
+                break;
+            case 'pin':
+                window.vscode.postMessage({
+                    type: 'toggle-ai-session-pin',
+                    provider: contextMenuAiSessionProvider,
+                    sessionId: contextMenuAiSessionId,
+                });
+                break;
+            case 'archive':
+                if (contextMenuAiSessionActive) break;
+                window.vscode.postMessage({
+                    type: getArchiveAiSessionMessageType(contextMenuAiSessionProvider),
+                    projectId: contextMenuAiSessionProjectId,
+                    provider: contextMenuAiSessionProvider,
+                    sessionId: contextMenuAiSessionId,
+                });
+                break;
+            case 'close-terminal':
+                if (!contextMenuAiSessionActive || contextMenuAiSessionConflict) break;
+                window.vscode.postMessage({
+                    type: contextMenuAiSessionBackend === 'tmux'
+                        ? 'detach-ai-session-terminal' : 'close-ai-session-terminal',
+                    projectId: contextMenuAiSessionProjectId,
+                    provider: contextMenuAiSessionProvider,
+                    sessionId: contextMenuAiSessionId,
+                });
+                break;
+        }
+
+        closeContextMenus();
+        origin?.focus();
+    }
+
+    function closeContextMenus() {
+        contextMenuProjectId = null;
+        contextMenuGroupId = null;
+        contextMenuAiSessionId = null;
+        contextMenuAiSessionProvider = null;
+        contextMenuAiSessionProjectId = null;
+        contextMenuAiSessionActive = false;
+        contextMenuAiSessionBackend = null;
+        contextMenuAiSessionConflict = false;
+        contextMenuAiSessionOrigin = null;
+        // Only close menus this script owns; the dashboard script owns the
+        // skill folder menu and keeps it open across per-agent toggles.
+        document.querySelectorAll(".custom-context-menu:not(.skill-folder-menu)").forEach(element =>
+            element.classList.remove("visible")
+        );
+    }
+
+    function getAiSessionContextMenuOrigin() {
+        return contextMenuAiSessionOrigin;
+    }
+
+    return {
+        closeContextMenus: closeContextMenus,
+        getAiSessionContextMenuOrigin: getAiSessionContextMenuOrigin,
+        onAiSessionContextMenuActionClicked: onAiSessionContextMenuActionClicked,
+        onContextMenu: onContextMenu,
+        onGroupContextMenuActionClicked: onGroupContextMenuActionClicked,
+        onProjectContextMenuActionClicked: onProjectContextMenuActionClicked,
+        onTriggerProjectAction: onTriggerProjectAction,
+        showContextMenu: showContextMenu,
+    };
+}

--- a/src/webview/webviewProjectScripts.js
+++ b/src/webview/webviewProjectScripts.js
@@ -368,7 +368,7 @@ function initProjects() {
         if (onTriggerAiSessionAction(e.target, dataId))
             return;
 
-        if (onTriggerProjectAction(e.target, dataId))
+        if (contextMenus.onTriggerProjectAction(e.target, dataId))
             return;
 
         if (projectDiv.hasAttribute("data-current-workspace")) {
@@ -908,291 +908,18 @@ function initProjects() {
         syncAiSessionBatchManagementDom(findCurrentWorkspaceDiv(projectId));
     }
 
-    function onTriggerProjectAction(target, projectId) {
-        var actionDiv = target.closest('[data-action]')
-        if (actionDiv == null)
-            return false;
-
-        var action = actionDiv.getAttribute("data-action");
-        if (!action)
-            return false;
-
-        if (action === 'save-current-workspace') {
-            window.vscode.postMessage({
-                type: 'save-current-workspace',
-                projectId,
-            });
-            return true;
-        }
-
-        if (action === 'toggle-open-workspace-pin') {
-            requestOpenWorkspacePin(actionDiv, projectId);
-            return true;
-        }
-
-        window.vscode.postMessage({
-            type: action + '-project',
-            projectId,
-        });
-
-        return true;
-    }
-
-    var contextMenuProjectId = null;
-    var contextMenuGroupId = null;
-    var contextMenuAiSessionId = null;
-    var contextMenuAiSessionProvider = null;
-    var contextMenuAiSessionProjectId = null;
-    var contextMenuAiSessionActive = false;
-    var contextMenuAiSessionBackend = null;
-    var contextMenuAiSessionConflict = false;
-    var contextMenuAiSessionOrigin = null;
     var latestAiSessionUpdateSequence = 0;
-
-    function showContextMenu(contextMenuElement, e) {
-        contextMenuElement.style.visibility = "hidden";
-        contextMenuElement.style.left = "0px";
-        contextMenuElement.style.top = "0px";
-        contextMenuElement.classList.add("visible");
-
-        var rect = contextMenuElement.getBoundingClientRect();
-        var viewportPadding = 4;
-        var left = e.clientX;
-        var top = e.clientY;
-
-        if (left + rect.width + viewportPadding > window.innerWidth) {
-            left = Math.max(viewportPadding, window.innerWidth - rect.width - viewportPadding);
-        }
-
-        if (top + rect.height + viewportPadding > window.innerHeight) {
-            top = Math.max(viewportPadding, window.innerHeight - rect.height - viewportPadding);
-        }
-
-        contextMenuElement.style.left = left + "px";
-        contextMenuElement.style.top = top + "px";
-        contextMenuElement.style.visibility = "";
-    }
-
-    function onContextMenu(e) {
-        closeContextMenus(); // Close previews
-
-        var sessionRow = e.target.closest('.codex-session-row[data-session-id][data-session-provider]');
-        if (sessionRow) {
-            contextMenuAiSessionOrigin = sessionRow.querySelector('.ai-session-primary-action') || sessionRow;
-            contextMenuAiSessionId = sessionRow.getAttribute("data-session-id");
-            contextMenuAiSessionProvider = sessionRow.getAttribute("data-session-provider");
-            var sessionProjectDiv = sessionRow.closest('.project[data-id]');
-            contextMenuAiSessionProjectId = sessionProjectDiv ? sessionProjectDiv.getAttribute("data-id") : null;
-            contextMenuAiSessionActive = sessionRow.hasAttribute('data-session-active');
-            contextMenuAiSessionBackend = sessionRow.getAttribute('data-session-backend') || 'vscode';
-            contextMenuAiSessionConflict = sessionRow.hasAttribute('data-session-conflict');
-            if (!contextMenuAiSessionId || !isAiSessionProvider(contextMenuAiSessionProvider))
-                return;
-
-            e.preventDefault();
-            var sessionContextMenuElement = document.getElementById("aiSessionContextMenu");
-            if (!sessionContextMenuElement)
-                return;
-            sessionContextMenuElement.querySelectorAll(':scope > *').forEach(element => element.classList.remove('disabled'));
-            var archiveMenuItem = sessionContextMenuElement.querySelector('[data-action="archive"]');
-            var closeMenuItem = sessionContextMenuElement.querySelector('[data-action="close-terminal"]');
-            if (archiveMenuItem) archiveMenuItem.classList.toggle('disabled', contextMenuAiSessionActive);
-            if (closeMenuItem) {
-                var terminalActionLabel = contextMenuAiSessionBackend === 'tmux'
-                    ? 'Detach Terminal…' : 'Close Terminal…';
-                closeMenuItem.textContent = terminalActionLabel;
-                closeMenuItem.setAttribute('aria-label', terminalActionLabel);
-                closeMenuItem.toggleAttribute('hidden', contextMenuAiSessionConflict);
-                closeMenuItem.classList.toggle(
-                    'disabled', !contextMenuAiSessionActive || contextMenuAiSessionConflict
-                );
-            }
-
-            showContextMenu(sessionContextMenuElement, e);
-            if (e.keyboardTrigger) {
-                var firstMenuItem = sessionContextMenuElement.querySelector('.custom-context-menu-item[data-action]:not(.disabled)');
-                firstMenuItem?.focus();
-            }
-            return;
-        }
-
-        var projectDiv = e.target.closest('.project[data-id]');
-        var groupDiv = e.target.closest('.group-title')
-        if (!projectDiv && !groupDiv)
-            return;
-
-        if (projectDiv && projectDiv.hasAttribute("data-readonly-project"))
-            return;
-
-        e.preventDefault();
-
-        let contextMenuForProject = projectDiv != null;
-        var contextMenuElement;
-        if (contextMenuForProject) {
-            contextMenuProjectId = projectDiv.getAttribute("data-id");
-            if (contextMenuProjectId == null)
-                return;
-
-            contextMenuElement = document.getElementById("projectContextMenu");
-        } else {
-            let groupIdDiv = groupDiv.closest(".group[data-group-id]");
-            if (groupIdDiv && groupIdDiv.hasAttribute("data-virtual-group"))
-                return;
-
-            contextMenuGroupId = groupIdDiv ? groupIdDiv.getAttribute("data-group-id") : null;
-            if (contextMenuGroupId == null)
-                return;
-
-            contextMenuElement = document.getElementById("groupContextMenu");
-        }
-
-        // disable elements if needed
-        contextMenuElement.querySelectorAll(":scope > *").forEach(e => e.classList.remove("disabled"));
-
-        if (projectDiv && projectDiv.hasAttribute("data-is-remote")) {
-            contextMenuElement.querySelectorAll(".not-remote").forEach(e => e.classList.add("disabled"));
-        }
-
-        // place and show contextmenu
-
-        showContextMenu(contextMenuElement, e);
-    }
-
-    function onProjectContextMenuActionClicked(el) {
-        var action = el.getAttribute("data-action");
-
-        if (action == null || contextMenuProjectId == null)
-            return;
-
-        switch (action) {
-            case 'open':
-                openProject(contextMenuProjectId, ProjectOpenType.CurrentWindow);
-                break;
-            case 'open-add-to-workspace':
-                openProject(contextMenuProjectId, ProjectOpenType.AddToWorkspace);
-                break;
-            default:
-                window.vscode.postMessage({
-                    type: action + '-project',
-                    projectId: contextMenuProjectId,
-                });
-                break;
-        }
-
-        closeContextMenus();
-    }
-
-    function onGroupContextMenuActionClicked(el) {
-        var action = el.getAttribute("data-action");
-
-        if (action == null || contextMenuGroupId == null)
-            return;
-
-        switch (action) {
-            case 'add':
-                window.vscode.postMessage({
-                    type: 'add-project',
-                    groupId: contextMenuGroupId,
-                });
-                break;
-            default:
-                window.vscode.postMessage({
-                    type: action + '-group',
-                    groupId: contextMenuGroupId,
-                });
-                break;
-        }
-
-        closeContextMenus();
-    }
-
-    function onAiSessionContextMenuActionClicked(el) {
-        var action = el.getAttribute("data-action");
-        var origin = contextMenuAiSessionOrigin;
-
-        if (action == null || contextMenuAiSessionId == null || contextMenuAiSessionProvider == null)
-            return;
-
-        switch (action) {
-            case 'resume':
-                window.vscode.postMessage(contextMenuAiSessionActive ? {
-                    type: 'focus-ai-session-terminal',
-                    provider: contextMenuAiSessionProvider,
-                    projectId: contextMenuAiSessionProjectId,
-                    sessionId: contextMenuAiSessionId,
-                } : {
-                    type: getResumeAiSessionMessageType(contextMenuAiSessionProvider),
-                    provider: contextMenuAiSessionProvider,
-                    projectId: contextMenuAiSessionProjectId,
-                    sessionId: contextMenuAiSessionId,
-                });
-                break;
-            case 'rename':
-                window.vscode.postMessage({
-                    type: 'rename-ai-session',
-                    provider: contextMenuAiSessionProvider,
-                    sessionId: contextMenuAiSessionId,
-                });
-                break;
-            case 'copy-id':
-                window.vscode.postMessage({
-                    type: 'copy-ai-session-id',
-                    provider: contextMenuAiSessionProvider,
-                    sessionId: contextMenuAiSessionId,
-                });
-                break;
-            case 'pin':
-                window.vscode.postMessage({
-                    type: 'toggle-ai-session-pin',
-                    provider: contextMenuAiSessionProvider,
-                    sessionId: contextMenuAiSessionId,
-                });
-                break;
-            case 'archive':
-                if (contextMenuAiSessionActive) break;
-                window.vscode.postMessage({
-                    type: getArchiveAiSessionMessageType(contextMenuAiSessionProvider),
-                    projectId: contextMenuAiSessionProjectId,
-                    provider: contextMenuAiSessionProvider,
-                    sessionId: contextMenuAiSessionId,
-                });
-                break;
-            case 'close-terminal':
-                if (!contextMenuAiSessionActive || contextMenuAiSessionConflict) break;
-                window.vscode.postMessage({
-                    type: contextMenuAiSessionBackend === 'tmux'
-                        ? 'detach-ai-session-terminal' : 'close-ai-session-terminal',
-                    projectId: contextMenuAiSessionProjectId,
-                    provider: contextMenuAiSessionProvider,
-                    sessionId: contextMenuAiSessionId,
-                });
-                break;
-        }
-
-        closeContextMenus();
-        origin?.focus();
-    }
-
-    function closeContextMenus() {
-        contextMenuProjectId = null;
-        contextMenuGroupId = null;
-        contextMenuAiSessionId = null;
-        contextMenuAiSessionProvider = null;
-        contextMenuAiSessionProjectId = null;
-        contextMenuAiSessionActive = false;
-        contextMenuAiSessionBackend = null;
-        contextMenuAiSessionConflict = false;
-        contextMenuAiSessionOrigin = null;
-        // Only close menus this script owns; the dashboard script owns the
-        // skill folder menu and keeps it open across per-agent toggles.
-        document.querySelectorAll(".custom-context-menu:not(.skill-folder-menu)").forEach(element =>
-            element.classList.remove("visible")
-        );
-    }
 
     var groupCollapse = initProjectGroupCollapse();
     var todoControls = initProjectTodoControls({
         syncCollapseButton: () => groupCollapse.syncCollapseButton(),
+    });
+    var contextMenus = initProjectContextMenus({
+        openProject: openProject,
+        ProjectOpenType: ProjectOpenType,
+        getResumeAiSessionMessageType: getResumeAiSessionMessageType,
+        getArchiveAiSessionMessageType: getArchiveAiSessionMessageType,
+        isAiSessionProvider: isAiSessionProvider,
     });
 
     function onMouseEvent(e) {
@@ -1203,23 +930,23 @@ function initProjects() {
 
         var contextMenuElement = e.target.closest("#projectContextMenu [data-action]");
         if (contextMenuElement) {
-            onProjectContextMenuActionClicked(contextMenuElement);
+            contextMenus.onProjectContextMenuActionClicked(contextMenuElement);
             return;
         }
 
         contextMenuElement = e.target.closest("#aiSessionContextMenu [data-action]");
         if (contextMenuElement) {
-            onAiSessionContextMenuActionClicked(contextMenuElement);
+            contextMenus.onAiSessionContextMenuActionClicked(contextMenuElement);
             return;
         }
 
         contextMenuElement = e.target.closest("#groupContextMenu [data-action]");
         if (contextMenuElement) {
-            onGroupContextMenuActionClicked(contextMenuElement);
+            contextMenus.onGroupContextMenuActionClicked(contextMenuElement);
             return;
         }
 
-        closeContextMenus();
+        contextMenus.closeContextMenus();
         if (!e.target.closest('.ai-session-provider-menu-wrapper')) {
             closeAiSessionProviderMenus();
         }
@@ -1629,7 +1356,7 @@ function initProjects() {
         if (!e.target)
             return;
 
-        onContextMenu(e);
+        contextMenus.onContextMenu(e);
     });
 
     document.addEventListener("keydown", e => {
@@ -1710,18 +1437,18 @@ function initProjects() {
             }
             if (e.key === 'Enter' || e.key === ' ') {
                 e.preventDefault();
-                onAiSessionContextMenuActionClicked(aiSessionMenuItem);
+                contextMenus.onAiSessionContextMenuActionClicked(aiSessionMenuItem);
                 return;
             }
             if (e.key === 'Escape') {
                 e.preventDefault();
-                var menuOrigin = contextMenuAiSessionOrigin;
-                closeContextMenus();
+                var menuOrigin = contextMenus.getAiSessionContextMenuOrigin();
+                contextMenus.closeContextMenus();
                 menuOrigin?.focus();
                 return;
             }
             if (e.key === 'Tab') {
-                closeContextMenus();
+                contextMenus.closeContextMenus();
             }
         }
 
@@ -1753,7 +1480,7 @@ function initProjects() {
             && (e.key === 'ContextMenu' || (e.key === 'F10' && e.shiftKey))) {
             e.preventDefault();
             var sessionRowRect = sessionRow.getBoundingClientRect();
-            onContextMenu({
+            contextMenus.onContextMenu({
                 target: primarySessionAction || sessionRow,
                 preventDefault: () => {},
                 clientX: sessionRowRect.left + 8,
@@ -1769,7 +1496,7 @@ function initProjects() {
                 todoControls.setTodoEditing(editForm.getAttribute('data-todo-id'), false);
                 return;
             }
-            closeContextMenus();
+            contextMenus.closeContextMenus();
             if (batchAiSessionState.projectId && !batchAiSessionState.pending) {
                 exitAiSessionBatchManagement();
             }

--- a/src/webview/webviewProjectScripts.js
+++ b/src/webview/webviewProjectScripts.js
@@ -188,13 +188,6 @@ function initProjects() {
     var pendingAiSessionProviderSelectionRequestId = null;
     var pendingAiSessionProviderSelectionProviders = [];
 
-    function isDedicatedTodoTarget(target) {
-        return Boolean(window.__agentPivotTodo
-            && target
-            && target.closest
-            && target.closest('#dashboard-tab-todo'));
-    }
-
     function getAiSessionBatchItemKey(provider, sessionId) {
         return JSON.stringify([provider, sessionId]);
     }
@@ -915,301 +908,6 @@ function initProjects() {
         syncAiSessionBatchManagementDom(findCurrentWorkspaceDiv(projectId));
     }
 
-    function onInsideGroupClick(e, groupDiv) {
-        var groupId = groupDiv.getAttribute("data-group-id");
-        if (groupId == null)
-            return;
-
-        var actionDiv = e.target.closest('[data-action]')
-        var action = actionDiv != null ? actionDiv.getAttribute("data-action") : null;
-        if (!action)
-            return;
-
-        if (action === "add") {
-            window.vscode.postMessage({
-                type: 'add-project',
-                groupId: groupId,
-            });
-
-            return;
-        }
-
-        var collapsed = groupDiv.classList.contains("collapsed");
-        if (action === "collapse") {
-            groupDiv.classList.toggle("collapsed");
-            collapsed = groupDiv.classList.contains("collapsed");
-        }
-
-        window.vscode.postMessage({
-            type: action + '-group',
-            groupId: groupId,
-            collapsed,
-        });
-        groupCollapse.syncCollapseButton();
-    }
-
-    function onTodoAction(e) {
-        var addTodoAction = e.target.closest('[data-action="todo-add"]');
-        if (addTodoAction && !addTodoAction.closest('.todo-add-form')) {
-            setTodoAddFormVisible(true, addTodoAction.getAttribute('data-group-id'));
-            return true;
-        }
-
-        var addGroupAction = e.target.closest('[data-action="todo-add-group"]');
-        if (addGroupAction) {
-            window.vscode.postMessage({
-                type: 'todo-add-group',
-            });
-            return true;
-        }
-
-        var toggleAction = e.target.closest('[data-action="todo-toggle"]');
-        if (toggleAction) {
-            window.vscode.postMessage({
-                type: 'todo-toggle',
-                todoId: toggleAction.getAttribute('data-todo-id'),
-                completed: toggleAction.checked === true,
-            });
-            return true;
-        }
-
-        var deleteAction = e.target.closest('[data-action="todo-delete"]');
-        if (deleteAction) {
-            window.vscode.postMessage({
-                type: 'todo-delete',
-                todoId: deleteAction.getAttribute('data-todo-id'),
-            });
-            return true;
-        }
-
-        var deleteGroupAction = e.target.closest('[data-action="todo-delete-group"]');
-        if (deleteGroupAction) {
-            window.vscode.postMessage({
-                type: 'todo-delete-group',
-                groupId: deleteGroupAction.getAttribute('data-group-id'),
-            });
-            return true;
-        }
-
-        var renameGroupAction = e.target.closest('[data-action="todo-rename-group"]');
-        if (renameGroupAction) {
-            window.vscode.postMessage({
-                type: 'todo-rename-group',
-                groupId: renameGroupAction.getAttribute('data-group-id'),
-            });
-            return true;
-        }
-
-        var collapseGroupAction = e.target.closest('[data-action="todo-collapse-group"]');
-        if (collapseGroupAction) {
-            var todoGroup = collapseGroupAction.closest('.todo-group');
-            if (!todoGroup)
-                return true;
-            todoGroup.classList.toggle('collapsed');
-            syncTodoGroupCollapseControl(todoGroup);
-            window.vscode.postMessage({
-                type: 'todo-collapse-group',
-                groupId: todoGroup.getAttribute('data-todo-group-id'),
-                collapsed: todoGroup.classList.contains('collapsed'),
-            });
-            groupCollapse.syncCollapseButton();
-            return true;
-        }
-
-        var sortAction = e.target.closest('[data-action="todo-sort-priority"]');
-        if (sortAction) {
-            window.vscode.postMessage({
-                type: 'todo-sort-priority',
-                groupId: sortAction.getAttribute('data-group-id'),
-            });
-            return true;
-        }
-
-        var showCompletedAction = e.target.closest('[data-action="todo-toggle-show-completed"]');
-        if (showCompletedAction) {
-            window.vscode.postMessage({
-                type: 'todo-toggle-show-completed',
-                showCompleted: showCompletedAction.checked === true,
-            });
-            return true;
-        }
-
-        var focusAddAction = e.target.closest('[data-action="todo-focus-add"]');
-        if (focusAddAction) {
-            setTodoAddFormVisible(true, focusAddAction.getAttribute('data-group-id'));
-            return true;
-        }
-
-        var cancelAddAction = e.target.closest('[data-action="todo-cancel-add"]');
-        if (cancelAddAction) {
-            setTodoAddFormVisible(false);
-            return true;
-        }
-
-        var editAction = e.target.closest('[data-action="todo-edit"]');
-        if (editAction) {
-            setTodoEditing(editAction.getAttribute('data-todo-id'), true);
-            return true;
-        }
-
-        var expandAction = e.target.closest('[data-action="todo-toggle-expanded"]');
-        if (expandAction) {
-            toggleTodoItemExpanded(expandAction.closest('.todo-item'));
-            return true;
-        }
-
-        var cancelEditAction = e.target.closest('[data-action="todo-cancel-edit"]');
-        if (cancelEditAction) {
-            setTodoEditing(cancelEditAction.getAttribute('data-todo-id'), false);
-            return true;
-        }
-
-        return false;
-    }
-
-    function syncTodoPrioritySegment(segment) {
-        if (!segment)
-            return;
-
-        Array.from(segment.querySelectorAll('.todo-priority-choice')).forEach(choice => {
-            var input = choice.querySelector('input[name="priority"]');
-            choice.classList.toggle('active', !!input && input.checked === true);
-        });
-    }
-
-    function resetTodoEditForm(form) {
-        form.reset();
-        syncTodoPrioritySegment(form.querySelector('.todo-priority-segment'));
-    }
-
-    function syncTodoListExpandedHeight(list) {
-        if (!list)
-            return;
-
-        var panel = list.closest('.todo-panel');
-        var collapsedHeightValue = panel
-            ? getComputedStyle(panel).getPropertyValue('--todo-collapsed-item-height')
-            : '';
-        var collapsedHeight = parseFloat(collapsedHeightValue) || 58;
-        var expandedExtraHeight = Array.from(list.querySelectorAll('.todo-item.expanded'))
-            .reduce((total, expandedItem) => total + Math.max(0, expandedItem.offsetHeight - collapsedHeight), 0);
-        list.style.setProperty('--todo-list-expanded-extra-height', expandedExtraHeight + 'px');
-    }
-
-    function toggleTodoItemExpanded(item, expanded) {
-        if (!item)
-            return;
-
-        var nextExpanded = typeof expanded === 'boolean'
-            ? expanded
-            : !item.classList.contains('expanded');
-        item.classList.toggle('expanded', nextExpanded);
-        syncTodoExpandControl(item, nextExpanded);
-        syncTodoListExpandedHeight(item.closest('.todo-list'));
-    }
-
-    function isTodoInteractiveTarget(target) {
-        return !!(target && target.closest && target.closest('button, input, textarea, select, label, a, [data-action], .todo-edit-form'));
-    }
-
-    function setTodoAddFormVisible(visible, groupId) {
-        var form = document.querySelector('.todo-add-form');
-        if (!form)
-            return;
-
-        var groupSelect = form.querySelector('[name="groupId"]');
-        if (visible && groupSelect) {
-            groupSelect.value = groupId || '';
-        }
-        form.hidden = !visible;
-        if (!visible)
-            return;
-
-        var titleInput = form.querySelector('[name="title"]');
-        if (titleInput) {
-            titleInput.focus();
-        }
-        form.scrollIntoView({ block: 'nearest' });
-    }
-
-    function setTodoEditing(todoId, editing) {
-        if (!todoId)
-            return;
-
-        var item = Array.from(document.querySelectorAll('.todo-item[data-todo-id]'))
-            .find(candidate => candidate.getAttribute('data-todo-id') === todoId);
-        if (!item)
-            return;
-
-        var wasEditing = item.classList.contains('editing');
-        var expandedBeforeEdit = item.getAttribute('data-expanded-before-edit');
-        if (editing && !wasEditing) {
-            item.setAttribute(
-                'data-expanded-before-edit',
-                item.classList.contains('expanded') ? 'true' : 'false'
-            );
-            expandedBeforeEdit = item.getAttribute('data-expanded-before-edit');
-        }
-        var view = item.querySelector('.todo-item-view');
-        var form = item.querySelector('.todo-edit-form');
-        var list = item.closest('.todo-list');
-        if (form && !editing) {
-            resetTodoEditForm(form);
-        }
-        item.classList.toggle('editing', editing);
-        if (view) {
-            view.hidden = false;
-        }
-        if (form) {
-            form.hidden = !editing;
-        }
-        toggleTodoItemExpanded(item, editing ? true : expandedBeforeEdit === 'true');
-        if (!editing) {
-            item.removeAttribute('data-expanded-before-edit');
-        }
-        if (list) {
-            list.classList.toggle('has-editing-item', !!list.querySelector('.todo-item.editing'));
-        }
-        if (form && editing) {
-            var titleInput = form.querySelector('[name="title"]');
-            if (titleInput) {
-                titleInput.focus();
-            }
-            item.scrollIntoView({ block: 'nearest' });
-        }
-    }
-
-    function onTodoFormSubmit(e) {
-        if (window.__agentPivotTodo
-            && e.target
-            && e.target.closest
-            && e.target.closest('#dashboard-tab-todo')) {
-            return;
-        }
-        var addForm = e.target && e.target.closest ? e.target.closest('.todo-add-form') : null;
-        if (addForm) {
-            e.preventDefault();
-            submitTodoComposeForm(addForm, message => window.vscode.postMessage(message));
-            return;
-        }
-
-        var editForm = e.target && e.target.closest ? e.target.closest('.todo-edit-form') : null;
-        if (editForm) {
-            e.preventDefault();
-            var todoId = editForm.getAttribute('data-todo-id');
-            var editTitle = getTodoFormValue(editForm, 'title');
-            if (!todoId || !editTitle)
-                return;
-            window.vscode.postMessage({
-                type: 'todo-update',
-                todoId,
-                title: editTitle,
-                notes: getTodoFormValue(editForm, 'notes'),
-                priority: getTodoFormValue(editForm, 'priority'),
-            });
-        }
-    }
-
     function onTriggerProjectAction(target, projectId) {
         var actionDiv = target.closest('[data-action]')
         if (actionDiv == null)
@@ -1493,11 +1191,14 @@ function initProjects() {
     }
 
     var groupCollapse = initProjectGroupCollapse();
+    var todoControls = initProjectTodoControls({
+        syncCollapseButton: () => groupCollapse.syncCollapseButton(),
+    });
 
     function onMouseEvent(e) {
         if (!e.target || e.target.closest(".disabled"))
             return;
-        if (isDedicatedTodoTarget(e.target))
+        if (todoControls.isDedicatedTodoTarget(e.target))
             return;
 
         var contextMenuElement = e.target.closest("#projectContextMenu [data-action]");
@@ -1559,13 +1260,13 @@ function initProjects() {
             return;
         }
 
-        if (onTodoAction(e)) {
+        if (todoControls.onTodoAction(e)) {
             return;
         }
 
         var todoItem = e.target.closest('.todo-item[data-todo-id]');
-        if (todoItem && !todoItem.classList.contains('editing') && !isTodoInteractiveTarget(e.target)) {
-            toggleTodoItemExpanded(todoItem);
+        if (todoItem && !todoItem.classList.contains('editing') && !todoControls.isTodoInteractiveTarget(e.target)) {
+            todoControls.toggleTodoItemExpanded(todoItem);
             return;
         }
 
@@ -1577,7 +1278,7 @@ function initProjects() {
 
         var groupDiv = e.target.closest('.group');
         if (groupDiv) {
-            onInsideGroupClick(e, groupDiv);
+            todoControls.onInsideGroupClick(e, groupDiv);
             return;
         }
     }
@@ -1585,12 +1286,12 @@ function initProjects() {
     function onChangeEvent(e) {
         if (!e.target)
             return;
-        if (isDedicatedTodoTarget(e.target))
+        if (todoControls.isDedicatedTodoTarget(e.target))
             return;
 
         var todoPriorityInput = e.target.closest('.todo-priority-choice input[name="priority"]');
         if (todoPriorityInput) {
-            syncTodoPrioritySegment(todoPriorityInput.closest('.todo-priority-segment'));
+            todoControls.syncTodoPrioritySegment(todoPriorityInput.closest('.todo-priority-segment'));
             return;
         }
 
@@ -1912,7 +1613,7 @@ function initProjects() {
     });
 
     document.addEventListener('change', onChangeEvent);
-    document.addEventListener('submit', onTodoFormSubmit);
+    document.addEventListener('submit', e => todoControls.onTodoFormSubmit(e));
 
     document.addEventListener('mousedown', (e) => {
         if (e.target.closest('.codex-session-row')) {
@@ -2065,7 +1766,7 @@ function initProjects() {
             var editForm = e.target && e.target.closest ? e.target.closest('.todo-edit-form') : null;
             if (editForm) {
                 e.preventDefault();
-                setTodoEditing(editForm.getAttribute('data-todo-id'), false);
+                todoControls.setTodoEditing(editForm.getAttribute('data-todo-id'), false);
                 return;
             }
             closeContextMenus();

--- a/src/webview/webviewProjectScripts.js
+++ b/src/webview/webviewProjectScripts.js
@@ -945,7 +945,7 @@ function initProjects() {
             groupId: groupId,
             collapsed,
         });
-        syncCollapseButton();
+        groupCollapse.syncCollapseButton();
     }
 
     function onTodoAction(e) {
@@ -1012,7 +1012,7 @@ function initProjects() {
                 groupId: todoGroup.getAttribute('data-todo-group-id'),
                 collapsed: todoGroup.classList.contains('collapsed'),
             });
-            syncCollapseButton();
+            groupCollapse.syncCollapseButton();
             return true;
         }
 
@@ -1492,90 +1492,7 @@ function initProjects() {
         );
     }
 
-    function updateToggleAllGroupsButton(state) {
-        document.body.classList.toggle("steward-all-collapsed", state.collapsed);
-        var button = document.querySelector('[data-action="toggle-all-groups"]');
-        if (!button)
-            return;
-
-        button.disabled = state.disabled;
-        button.setAttribute('aria-disabled', state.disabled ? 'true' : 'false');
-        button.setAttribute("title", state.title);
-        button.setAttribute("aria-label", state.title);
-    }
-
-    function getActiveDashboardTab() {
-        var dashboard = window.__agentPivotDashboard;
-        var selectedTab = !dashboard && document.querySelector
-            ? document.querySelector('[data-dashboard-tab][aria-selected="true"]')
-            : null;
-        var activeTab = dashboard && typeof dashboard.getActiveTab === 'function'
-            ? dashboard.getActiveTab()
-            : selectedTab && selectedTab.getAttribute('data-dashboard-tab');
-        return activeTab === 'projects' || activeTab === 'todo' || activeTab === 'ai'
-            ? activeTab
-            : 'open';
-    }
-
-    function getActiveCollapsibleGroups() {
-        var activeTab = getActiveDashboardTab();
-        var selector = activeTab === 'projects'
-            ? '#dashboard-tab-projects .group[data-group-id]'
-            : activeTab === 'todo'
-                ? '#dashboard-tab-todo .todo-group[data-todo-group-id]'
-                : activeTab === 'open'
-                    ? '#dashboard-tab-open .open-other-windows-group[data-group-id]'
-                    : null;
-        if (!selector) {
-            return [];
-        }
-        return [...document.querySelectorAll(selector)];
-    }
-
-    function setGroupCollapsed(group, collapsed, persist) {
-        group.classList.toggle('collapsed', collapsed);
-        if (persist) {
-            var isTodoGroup = group.classList.contains('todo-group');
-            window.vscode.postMessage({
-                type: isTodoGroup ? 'todo-collapse-group' : 'collapse-group',
-                groupId: isTodoGroup
-                    ? group.getAttribute('data-todo-group-id')
-                    : group.getAttribute('data-group-id'),
-                collapsed,
-            });
-        }
-    }
-
-    function syncCollapseButton() {
-        var activeTab = getActiveDashboardTab();
-        var groups = getActiveCollapsibleGroups();
-        updateToggleAllGroupsButton(getCollapseButtonState(
-            activeTab,
-            groups.map(group => group.classList.contains('collapsed'))
-        ));
-    }
-
-    function toggleAllGroups() {
-        var activeTab = getActiveDashboardTab();
-        var groups = getActiveCollapsibleGroups();
-        var shouldCollapse = groups.some(group => !group.classList.contains("collapsed"));
-
-        if (activeTab === 'todo') {
-            if (window.__agentPivotTodo
-                && typeof window.__agentPivotTodo.dispatch === 'function') {
-                window.__agentPivotTodo.dispatch('collapse-groups', { collapsed: shouldCollapse });
-            } else {
-                collapseTodoGroups(groups, shouldCollapse, message => window.vscode.postMessage(message));
-            }
-            syncCollapseButton();
-            return;
-        }
-
-        groups.forEach(group => setGroupCollapsed(group, shouldCollapse, true));
-        syncCollapseButton();
-    }
-
-    window.__agentPivotSyncCollapseButton = syncCollapseButton;
+    var groupCollapse = initProjectGroupCollapse();
 
     function onMouseEvent(e) {
         if (!e.target || e.target.closest(".disabled"))
@@ -1607,7 +1524,7 @@ function initProjects() {
         }
 
         if (e.target.closest('[data-action="toggle-all-groups"]')) {
-            toggleAllGroups();
+            groupCollapse.toggleAllGroups();
             return;
         }
 
@@ -1708,7 +1625,7 @@ function initProjects() {
                 if (todoRoot && typeof initDnD === 'function' && typeof disposeDnD === 'function') {
                     disposeDnD(todoRoot);
                     initDnD(todoRoot);
-                    syncCollapseButton();
+                    groupCollapse.syncCollapseButton();
                 }
             }, 0);
         }

--- a/src/webview/webviewProjectScripts.js
+++ b/src/webview/webviewProjectScripts.js
@@ -174,157 +174,6 @@ function initProjects() {
         CurrentWindow: 3,
     };
 
-    var batchAiSessionState = {
-        projectId: null,
-        selectedItems: new Map(),
-        pending: false,
-        requestId: null,
-    };
-    var activeAiSessionTerminalState = { provider: null, sessionId: null };
-    var nextAiSessionBatchArchiveRequestId = 0;
-    var nextAiSessionProviderSelectionRequestId = 0;
-    var pendingAiSessionProviderSelectionProjectId = null;
-    var pendingAiSessionProviderSelectionRequestId = null;
-    var pendingAiSessionProviderSelectionProviders = [];
-
-    function getAiSessionBatchItemKey(provider, sessionId) {
-        return JSON.stringify([provider, sessionId]);
-    }
-
-    function enter(projectId) {
-        if (batchAiSessionState.pending)
-            return;
-        batchAiSessionState.projectId = projectId;
-        batchAiSessionState.selectedItems = new Map();
-        batchAiSessionState.pending = false;
-        batchAiSessionState.requestId = null;
-    }
-
-    function toggle(provider, sessionId, active) {
-        if (!isAiSessionProvider(provider) || !sessionId || active || batchAiSessionState.pending)
-            return;
-        var key = getAiSessionBatchItemKey(provider, sessionId);
-        if (batchAiSessionState.selectedItems.has(key))
-            batchAiSessionState.selectedItems.delete(key);
-        else
-            batchAiSessionState.selectedItems.set(key, { provider, sessionId });
-    }
-
-    function selectUnpinned(sessions) {
-        if (batchAiSessionState.pending)
-            return;
-        sessions
-            .filter(session => isAiSessionProvider(session.provider)
-                && session.id && !session.pinned && !session.active)
-            .forEach(session => {
-                var item = { provider: session.provider, sessionId: session.id };
-                batchAiSessionState.selectedItems.set(
-                    getAiSessionBatchItemKey(item.provider, item.sessionId),
-                    item
-                );
-            });
-    }
-
-    function clear() {
-        if (!batchAiSessionState.pending)
-            batchAiSessionState.selectedItems.clear();
-    }
-
-    function reconcile(projectId, remainingItems) {
-        if (projectId !== batchAiSessionState.projectId) {
-            exit();
-            return;
-        }
-        let selectedItems = batchAiSessionState.selectedItems;
-        batchAiSessionState.selectedItems = new Map(
-            remainingItems
-                .filter(item => item && isAiSessionProvider(item.provider) && item.sessionId)
-                .map(item => {
-                    var key = getAiSessionBatchItemKey(item.provider, item.sessionId);
-                    return [key, selectedItems.get(key)];
-                })
-                .filter(entry => entry[1])
-        );
-    }
-
-    function reconcileVisible(projectDiv) {
-        if (!projectDiv)
-            return;
-        var projectId = projectDiv.getAttribute('data-id');
-        var remainingItems = Array.from(
-            projectDiv.querySelectorAll('.ai-session-history-panel .codex-session-row[data-session-id]')
-        )
-            .filter(row => isAiSessionProvider(row.getAttribute('data-session-provider') || 'codex')
-                && row.getAttribute('data-session-id')
-                && !row.hasAttribute('data-session-active'))
-            .map(row => ({
-                provider: row.getAttribute('data-session-provider') || 'codex',
-                sessionId: row.getAttribute('data-session-id'),
-            }));
-        reconcile(projectId, remainingItems);
-    }
-
-    function submit() {
-        if (batchAiSessionState.pending || !batchAiSessionState.selectedItems.size)
-            return;
-        nextAiSessionBatchArchiveRequestId = nextAiSessionBatchArchiveRequestId >= Number.MAX_SAFE_INTEGER
-            ? 1
-            : nextAiSessionBatchArchiveRequestId + 1;
-        var requestId = nextAiSessionBatchArchiveRequestId;
-        batchAiSessionState.pending = true;
-        batchAiSessionState.requestId = requestId;
-        window.vscode.postMessage({
-            type: 'archive-ai-sessions',
-            version: 1,
-            requestId: requestId,
-            projectId: batchAiSessionState.projectId,
-            items: Array.from(batchAiSessionState.selectedItems.values()),
-        });
-    }
-
-    function complete(message) {
-        if (!message
-            || message.type !== 'ai-session-batch-archive-completed'
-            || message.version !== 1
-            || !Number.isSafeInteger(message.requestId)
-            || message.requestId < 1
-            || typeof message.projectId !== 'string'
-            || !['cancelled', 'rejected', 'finished'].includes(message.status)
-            || !batchAiSessionState.pending
-            || message.projectId !== batchAiSessionState.projectId
-            || message.requestId !== batchAiSessionState.requestId) {
-            return false;
-        }
-        if (message.status === 'finished') {
-            exit();
-            return true;
-        }
-        batchAiSessionState.pending = false;
-        batchAiSessionState.requestId = null;
-        return true;
-    }
-
-    function exit() {
-        batchAiSessionState.projectId = null;
-        batchAiSessionState.selectedItems = new Map();
-        batchAiSessionState.pending = false;
-        batchAiSessionState.requestId = null;
-    }
-
-    function snapshot() {
-        return {
-            projectId: batchAiSessionState.projectId,
-            selectedItems: Array.from(batchAiSessionState.selectedItems.values()),
-            pending: batchAiSessionState.pending,
-        };
-    }
-
-    var batchAiSessionManager = {
-        enter, toggle, selectUnpinned, clear, reconcile, reconcileVisible,
-        submit, complete, exit, snapshot,
-    };
-    window.__agentPivotBatchAiSessions = batchAiSessionManager;
-
     function openProject(projectId, projectOpenType) {
         window.vscode.postMessage({
             type: 'selected-project',
@@ -364,7 +213,7 @@ function initProjects() {
         if (dataId == null)
             return;
 
-        if (onTriggerAiSessionAction(e.target, dataId))
+        if (aiSessionControls.onTriggerAiSessionAction(e.target, dataId))
             return;
 
         if (contextMenus.onTriggerProjectAction(e.target, dataId))
@@ -374,7 +223,7 @@ function initProjects() {
             if (e.target.closest('[data-ai-session-region]'))
                 return;
 
-            toggleCodexSessions(projectDiv, dataId);
+            aiSessionControls.toggleCodexSessions(projectDiv, dataId);
             return;
         }
 
@@ -393,544 +242,34 @@ function initProjects() {
 
     }
 
-    function onTriggerAiSessionAction(target, projectId) {
-        var projectDiv = target.closest('.project[data-id]');
-        var tabAction = target.closest('[data-action="select-ai-session-tab"][data-tab]');
-        if (tabAction) {
-            var selectedTab = normalizeAiSessionTab(tabAction.getAttribute('data-tab'));
-            selectAiSessionTabDom(projectDiv, selectedTab);
-            writeAiSessionTabState(window.vscode, projectId, selectedTab);
-            return true;
-        }
-
-        var providerMenuTrigger = target.closest('[data-ai-provider-menu-trigger]');
-        if (providerMenuTrigger) {
-            toggleAiSessionProviderMenu(projectDiv);
-            return true;
-        }
-
-        var providerOption = target.closest('[data-ai-provider-option][data-provider]');
-        if (providerOption) {
-            activateAiSessionProviderOption(projectDiv, providerOption);
-            return true;
-        }
-
-        var createAction = target.closest('[data-action="create-ai-session"]');
-        if (createAction) {
-            window.vscode.postMessage({
-                type: 'create-ai-session',
-                projectId,
-            });
-
-            return true;
-        }
-
-        var manageAction = target.closest('[data-action="manage-ai-sessions"][data-provider]');
-        if (manageAction) {
-            if (batchAiSessionState.pending
-                || pendingAiSessionProviderSelectionProjectId)
-                return true;
-
-            var manageProvider = manageAction.getAttribute("data-provider");
-            if (projectDiv && isAiSessionProvider(manageProvider)) {
-                if (isActiveAiSessionBatchScope(projectId, manageProvider)) {
-                    exitAiSessionBatchManagement();
-                } else {
-                    batchAiSessionManager.enter(projectId);
-                    syncAiSessionBatchManagementDom(projectDiv);
-                }
-            }
-
-            return true;
-        }
-
-        var selectUnpinnedAction = target.closest('[data-action="select-unpinned-ai-sessions"]');
-        if (selectUnpinnedAction) {
-            if (isActiveAiSessionBatchScope(projectId, getProjectActiveAiSessionProvider(projectDiv))) {
-                var sessions = Array.from(projectDiv.querySelectorAll('.ai-session-history-panel .codex-session-row[data-session-id]'))
-                    .map(row => ({
-                        provider: row.getAttribute("data-session-provider") || "codex",
-                        id: row.getAttribute("data-session-id"),
-                        pinned: row.hasAttribute("data-session-pinned"),
-                        active: row.hasAttribute("data-session-active"),
-                    }));
-                batchAiSessionManager.selectUnpinned(sessions);
-                syncAiSessionBatchManagementDom(projectDiv);
-            }
-
-            return true;
-        }
-
-        var clearSelectionAction = target.closest('[data-action="clear-ai-session-selection"]');
-        if (clearSelectionAction) {
-            if (isActiveAiSessionBatchScope(projectId, getProjectActiveAiSessionProvider(projectDiv))) {
-                batchAiSessionManager.clear();
-                syncAiSessionBatchManagementDom(projectDiv);
-            }
-
-            return true;
-        }
-
-        var archiveSelectedAction = target.closest('[data-action="archive-selected-ai-sessions"]');
-        if (archiveSelectedAction) {
-            if (isActiveAiSessionBatchScope(projectId, getProjectActiveAiSessionProvider(projectDiv))) {
-                batchAiSessionManager.submit();
-                syncAiSessionBatchManagementDom(projectDiv);
-            }
-
-            return true;
-        }
-
-        var terminalAction = target.closest('[data-action="close-ai-session-terminal"], [data-action="detach-ai-session-terminal"]');
-        if (terminalAction) {
-            var terminalRow = terminalAction.closest('.codex-session-row[data-session-provider][data-session-backend]');
-            var terminalProvider = terminalRow && terminalRow.getAttribute('data-session-provider');
-            var terminalBackend = terminalRow && terminalRow.getAttribute('data-session-backend');
-            var requestedDetach = terminalAction.getAttribute('data-action') === 'detach-ai-session-terminal';
-            if (terminalRow && isAiSessionProvider(terminalProvider)
-                && ((requestedDetach && terminalBackend === 'tmux')
-                    || (!requestedDetach && terminalBackend === 'vscode'))) {
-                var terminalMessage = {
-                    type: requestedDetach ? 'detach-ai-session-terminal' : 'close-ai-session-terminal',
-                    projectId,
-                    provider: terminalProvider,
-                };
-                if (terminalRow.hasAttribute('data-session-pending')) {
-                    terminalMessage.pendingCreatedAt = terminalRow.getAttribute('data-pending-created-at');
-                } else {
-                    terminalMessage.sessionId = terminalRow.getAttribute('data-session-id');
-                }
-                window.vscode.postMessage(terminalMessage);
-            }
-            return true;
-        }
-
-        var managedSessionRow = target.closest('.codex-session-row[data-session-id]');
-        if (managedSessionRow) {
-            var managedSessionProvider = managedSessionRow.getAttribute("data-session-provider") || "codex";
-            if (isActiveAiSessionBatchScope(projectId, managedSessionProvider)
-                && !managedSessionRow.hasAttribute('data-session-active')) {
-                batchAiSessionManager.toggle(
-                    managedSessionProvider,
-                    managedSessionRow.getAttribute("data-session-id"),
-                    managedSessionRow.hasAttribute('data-session-active')
-                );
-                syncAiSessionBatchManagementDom(projectDiv);
-                return true;
-            }
-        }
-
-        var pinAction = target.closest('[data-action="toggle-ai-session-pin"]');
-        if (pinAction) {
-            var pinRow = pinAction.closest('.codex-session-row[data-session-id]');
-            var pinSessionId = pinRow && pinRow.getAttribute("data-session-id");
-            var pinProvider = pinRow && pinRow.getAttribute("data-session-provider") || "codex";
-            if (pinSessionId) {
-                window.vscode.postMessage({
-                    type: 'toggle-ai-session-pin',
-                    projectId,
-                    provider: pinProvider,
-                    sessionId: pinSessionId,
-                });
-            }
-
-            return true;
-        }
-
-        var archiveAction = target.closest('[data-action="archive-codex-session"], [data-action="archive-kimi-session"], [data-action="archive-claude-session"]');
-        if (archiveAction) {
-            var archiveRow = archiveAction.closest('.codex-session-row[data-session-id]');
-            var archiveSessionId = archiveRow && archiveRow.getAttribute("data-session-id");
-            var archiveProvider = archiveRow && archiveRow.getAttribute("data-session-provider") || "codex";
-            if (archiveSessionId && isAiSessionProvider(archiveProvider)) {
-                acknowledgeAiSessionRow(archiveRow);
-                window.vscode.postMessage({
-                    type: getArchiveAiSessionMessageType(archiveProvider),
-                    projectId,
-                    sessionId: archiveSessionId,
-                });
-            }
-
-            return true;
-        }
-
-        var activation = getAiSessionCardActivation(target, projectId);
-        if (!activation.handled)
-            return false;
-        if (activation.sessionRow
-            && !activation.sessionRow.hasAttribute('data-session-pending')
-            && activation.sessionRow.getAttribute('data-session-id')) {
-            acknowledgeAiSessionRow(activation.sessionRow);
-        }
-        if (activation.message) {
-            window.vscode.postMessage(activation.message);
-        }
-        return true;
-    }
-
-    function acknowledgeAiSessionRow(sessionRow) {
-        if (!sessionRow || !sessionRow.hasAttribute('data-ai-session-attention')) return;
-        var provider = sessionRow.getAttribute('data-session-provider') || 'codex';
-        var sessionId = sessionRow.getAttribute('data-session-id') || '';
-        var fallback = sessionRow.getAttribute('data-session-event-id') || sessionRow.getAttribute('data-ai-session-event-id');
-        acknowledgeAiSession(provider, sessionId, fallback);
-    }
-
-    function acknowledgeAiSession(provider, sessionId, fallbackEventId) {
-        var sessionKey = provider + ':' + sessionId;
-        window.__agentPivotAttentionSessionEvents = window.__agentPivotAttentionSessionEvents || {};
-        var eventIds = window.__agentPivotAttentionSessionEvents[sessionKey] || [];
-        if (!eventIds.length && fallbackEventId) {
-            eventIds = [fallbackEventId];
-        }
-        eventIds = Array.from(new Set(eventIds.filter(eventId => typeof eventId === 'string' && !!eventId)));
-        if (eventIds.length) {
-            window.vscode.postMessage({ type: 'acknowledge-ai-session-attention', eventIds: eventIds });
-        }
-    }
-
-    window.__agentPivotAcknowledgeSession = (provider, sessionId) => {
-        if (isAiSessionProvider(provider) && sessionId) {
-            acknowledgeAiSession(provider, sessionId);
-        }
-    };
-
-    function getSelectedAiSessionProviders(projectDiv) {
-        var region = projectDiv && projectDiv.querySelector('[data-ai-session-region]');
-        return (region && region.getAttribute('data-selected-ai-session-providers') || '')
-            .split(',')
-            .filter(isAiSessionProvider);
-    }
-
-    function submitAiSessionProviderSelection(projectDiv, providers) {
-        var projectId = projectDiv && projectDiv.getAttribute('data-id');
-        if (!projectId || !providers.length || batchAiSessionState.pending
-            || pendingAiSessionProviderSelectionProjectId)
-            return;
-
-        exitAiSessionBatchManagement();
-        nextAiSessionProviderSelectionRequestId += 1;
-        var requestId = nextAiSessionProviderSelectionRequestId;
-        pendingAiSessionProviderSelectionProjectId = projectId;
-        pendingAiSessionProviderSelectionRequestId = requestId;
-        pendingAiSessionProviderSelectionProviders = providers.slice();
-        syncAiSessionProviderMenuDisabledDom(projectDiv, true);
-        window.vscode.postMessage({
-            type: 'select-ai-session-providers',
-            version: 1,
-            requestId: requestId,
-            projectId,
-            selectedProviders: providers,
-        });
-    }
-
-    function setAiSessionProviderMenuOpen(projectDiv, open) {
-        var trigger = projectDiv && projectDiv.querySelector('[data-ai-provider-menu-trigger]');
-        var menu = projectDiv && projectDiv.querySelector('[data-ai-provider-menu]');
-        if (!trigger || !menu)
-            return;
-        if (open && (batchAiSessionState.pending
-            || pendingAiSessionProviderSelectionProjectId))
-            return;
-
-        trigger.setAttribute('aria-expanded', open ? 'true' : 'false');
-        menu.hidden = !open;
-    }
-
-    function closeAiSessionProviderMenus(exceptProjectDiv) {
-        document.querySelectorAll('.project[data-id]').forEach(projectDiv => {
-            if (projectDiv !== exceptProjectDiv) {
-                setAiSessionProviderMenuOpen(projectDiv, false);
-            }
-        });
-    }
-
-    function closeAiSessionProviderMenu(projectDiv, restoreFocus) {
-        setAiSessionProviderMenuOpen(projectDiv, false);
-        if (restoreFocus) {
-            projectDiv?.querySelector('[data-ai-provider-menu-trigger]')?.focus();
-        }
-    }
-
-    function toggleAiSessionProviderMenu(projectDiv) {
-        if (!projectDiv || batchAiSessionState.pending
-            || pendingAiSessionProviderSelectionProjectId)
-            return;
-        var trigger = projectDiv.querySelector('[data-ai-provider-menu-trigger]');
-        var open = trigger?.getAttribute('aria-expanded') !== 'true';
-        closeAiSessionProviderMenus(projectDiv);
-        setAiSessionProviderMenuOpen(projectDiv, open);
-    }
-
-    function activateAiSessionProviderOption(projectDiv, option) {
-        if (!projectDiv || !option || batchAiSessionState.pending
-            || pendingAiSessionProviderSelectionProjectId)
-            return;
-        var provider = option.getAttribute('data-provider');
-        if (!isAiSessionProvider(provider))
-            return;
-        var selectedProviders = getSelectedAiSessionProviders(projectDiv);
-        var selected = selectedProviders.includes(provider);
-        if (selected && selectedProviders.length === 1)
-            return;
-        submitAiSessionProviderSelection(
-            projectDiv,
-            selected
-                ? selectedProviders.filter(candidate => candidate !== provider)
-                : selectedProviders.concat(provider)
-        );
-    }
-
-    function getAiSessionProviderOptions(projectDiv) {
-        return projectDiv
-            ? Array.from(projectDiv.querySelectorAll('[data-ai-provider-option][data-provider]'))
-            : [];
-    }
-
-    function isAiSessionProvider(provider) {
-        return provider === "codex" || provider === "kimi" || provider === "claude";
-    }
-
-    function getResumeAiSessionMessageType(provider) {
-        if (provider === "kimi")
-            return 'resume-kimi-session';
-        if (provider === "claude")
-            return 'resume-claude-session';
-
-        return 'resume-codex-session';
-    }
-
-    function getArchiveAiSessionMessageType(provider) {
-        if (provider === "kimi")
-            return 'archive-kimi-session';
-        if (provider === "claude")
-            return 'archive-claude-session';
-
-        return 'archive-codex-session';
-    }
-
-    function toggleCodexSessions(projectDiv, projectId) {
-        var expanded = !projectDiv.hasAttribute("data-codex-expanded");
-        if (!expanded && batchAiSessionState.projectId === projectId) {
-            exitAiSessionBatchManagement();
-        }
-        projectDiv.toggleAttribute("data-codex-expanded", expanded);
-        updateStickyGroupHeaderOffset();
-
-        window.vscode.postMessage({
-            type: 'toggle-codex-sessions',
-            projectId,
-            expanded,
-        });
-    }
-
-    function isActiveAiSessionBatchScope(projectId) {
-        return projectId === batchAiSessionState.projectId;
-    }
-
-    function getProjectActiveAiSessionProvider(projectDiv) {
-        if (!projectDiv)
-            return null;
-
-        var region = projectDiv.querySelector('[data-ai-session-region]');
-        var activeProvider = region && region.getAttribute('data-active-ai-session-provider');
-        if (isAiSessionProvider(activeProvider))
-            return activeProvider;
-
-        var selectedProviders = region && region.getAttribute('data-selected-ai-session-providers') || '';
-        return selectedProviders.split(',').find(isAiSessionProvider) || null;
-    }
-
-    function syncActiveAiSessionTerminalDom() {
-        document.querySelectorAll('.codex-session-row[data-session-id]').forEach(row => {
-            var provider = row.getAttribute('data-session-provider') || 'codex';
-            var sessionId = row.getAttribute('data-session-id');
-            row.toggleAttribute(
-                'data-ai-session-active-terminal',
-                provider === activeAiSessionTerminalState.provider
-                    && sessionId === activeAiSessionTerminalState.sessionId
-            );
-        });
-    }
-
-    function syncAiSessionBatchManagementDom(projectDiv) {
-        var snapshot = batchAiSessionManager.snapshot();
-        document.querySelectorAll('.project[data-ai-session-managing], .project[data-ai-session-pending]').forEach(project => {
-            if (project !== projectDiv || project.getAttribute("data-id") !== snapshot.projectId) {
-                project.removeAttribute("data-ai-session-managing");
-                project.removeAttribute("data-ai-session-pending");
-                syncAiSessionProviderMenuDisabledDom(project, false);
-                var inactiveManageButton = project.querySelector('[data-action="manage-ai-sessions"]');
-                if (inactiveManageButton) {
-                    inactiveManageButton.setAttribute('aria-pressed', 'false');
-                    inactiveManageButton.disabled = false;
-                }
-            }
-        });
-
-        if (!projectDiv)
-            return;
-
-        var projectId = projectDiv.getAttribute("data-id");
-        var isScoped = projectId === snapshot.projectId;
-        projectDiv.toggleAttribute("data-ai-session-managing", isScoped);
-        projectDiv.toggleAttribute("data-ai-session-pending", isScoped && snapshot.pending);
-        syncAiSessionProviderMenuDisabledDom(projectDiv, isScoped && snapshot.pending);
-        var manageButton = projectDiv.querySelector('[data-action="manage-ai-sessions"]');
-        if (manageButton) {
-            manageButton.setAttribute('aria-pressed', isScoped ? 'true' : 'false');
-            manageButton.disabled = isScoped && snapshot.pending;
-        }
-
-        var selectedItems = new Set(snapshot.selectedItems.map(item =>
-            getAiSessionBatchItemKey(item.provider, item.sessionId)
-        ));
-        projectDiv.querySelectorAll('.ai-session-history-panel .codex-session-row[data-session-id]').forEach(row => {
-            var rowProvider = row.getAttribute("data-session-provider") || "codex";
-            var isActive = row.hasAttribute('data-session-active');
-            var isSelected = isScoped
-                && !isActive
-                && selectedItems.has(getAiSessionBatchItemKey(
-                    rowProvider,
-                    row.getAttribute("data-session-id")
-                ));
-            row.toggleAttribute("data-ai-session-selected", isSelected);
-            var checkbox = row.querySelector('.ai-session-batch-checkbox');
-            if (checkbox) {
-                checkbox.checked = isSelected;
-                checkbox.disabled = isActive || (isScoped && snapshot.pending);
-            }
-        });
-
-        var count = isScoped ? snapshot.selectedItems.length : 0;
-        var countElement = projectDiv.querySelector('.ai-session-batch-count');
-        if (countElement) {
-            countElement.textContent = count + ' selected';
-        }
-        projectDiv.querySelectorAll('.ai-session-batch-actions button').forEach(button => {
-            button.disabled = isScoped && snapshot.pending;
-        });
-        var archiveButton = projectDiv.querySelector('[data-action="archive-selected-ai-sessions"]');
-        if (archiveButton) {
-            archiveButton.disabled = !isScoped || snapshot.pending || count === 0;
-        }
-    }
-
-    function syncAiSessionProviderMenuDisabledDom(projectDiv, batchPending) {
-        var projectId = projectDiv?.getAttribute('data-id');
-        var providerSelectionPending = projectId
-            === pendingAiSessionProviderSelectionProjectId;
-        var pending = Boolean(
-            batchPending || batchAiSessionState.pending || providerSelectionPending
-        );
-        var trigger = projectDiv && projectDiv.querySelector('[data-ai-provider-menu-trigger]');
-        if (trigger) {
-            trigger.disabled = pending;
-            trigger.setAttribute('aria-disabled', pending ? 'true' : 'false');
-        }
-        var selectedProviders = getSelectedAiSessionProviders(projectDiv);
-        getAiSessionProviderOptions(projectDiv).forEach(option => {
-            var provider = option.getAttribute('data-provider');
-            var lastSelectedProvider = selectedProviders.length === 1
-                && selectedProviders[0] === provider;
-            option.disabled = pending;
-            option.setAttribute(
-                'aria-disabled',
-                pending || lastSelectedProvider ? 'true' : 'false'
-            );
-        });
-        if (pending) {
-            closeAiSessionProviderMenu(projectDiv, false);
-        }
-    }
-
-    function clearPendingAiSessionProviderSelection() {
-        pendingAiSessionProviderSelectionProjectId = null;
-        pendingAiSessionProviderSelectionRequestId = null;
-        pendingAiSessionProviderSelectionProviders = [];
-    }
-
-    function selectedAiSessionProvidersMatch(projectDiv, expectedProviders) {
-        var selectedProviders = getSelectedAiSessionProviders(projectDiv);
-        return selectedProviders.length === expectedProviders.length
-            && selectedProviders.every(provider =>
-                expectedProviders.includes(provider)
-            );
-    }
-
-    function reconcilePendingAiSessionProviderSelectionDom() {
-        if (!pendingAiSessionProviderSelectionProjectId)
-            return;
-        var projectDiv = aiSessionsUpdate.findCurrentWorkspaceDiv(
-            pendingAiSessionProviderSelectionProjectId
-        );
-        if (!projectDiv)
-            return;
-        if (selectedAiSessionProvidersMatch(
-            projectDiv,
-            pendingAiSessionProviderSelectionProviders
-        )) {
-            clearPendingAiSessionProviderSelection();
-        }
-        syncAiSessionProviderMenuDisabledDom(projectDiv, false);
-    }
-
-    function applyAiSessionProviderSelectionResult(message) {
-        if (!message
-            || message.type !== 'ai-session-provider-selection-result'
-            || message.version !== 1
-            || !Number.isSafeInteger(message.requestId)
-            || message.requestId < 1
-            || typeof message.projectId !== 'string'
-            || typeof message.success !== 'boolean'
-            || message.projectId !== pendingAiSessionProviderSelectionProjectId
-            || message.requestId !== pendingAiSessionProviderSelectionRequestId) {
-            return false;
-        }
-        if (message.success) {
-            return true;
-        }
-
-        var projectDiv = aiSessionsUpdate.findCurrentWorkspaceDiv(message.projectId);
-        clearPendingAiSessionProviderSelection();
-        syncAiSessionProviderMenuDisabledDom(projectDiv, false);
-        var liveRegion = projectDiv?.querySelector('[data-ai-session-live-region]');
-        if (liveRegion) {
-            liveRegion.textContent = 'Could not update AI session providers. Try again.';
-        }
-        return true;
-    }
-
-    function exitAiSessionBatchManagement() {
-        var projectId = batchAiSessionState.projectId;
-        batchAiSessionManager.exit();
-        syncAiSessionBatchManagementDom(aiSessionsUpdate.findCurrentWorkspaceDiv(projectId));
-    }
-
 
     var groupCollapse = initProjectGroupCollapse();
     var todoControls = initProjectTodoControls({
         syncCollapseButton: () => groupCollapse.syncCollapseButton(),
     });
+    var aiSessionControls = initProjectAiSessionControls({
+        getAiSessionsUpdate: () => aiSessionsUpdate,
+        updateStickyGroupHeaderOffset: updateStickyGroupHeaderOffset,
+    });
     var contextMenus = initProjectContextMenus({
         openProject: openProject,
         ProjectOpenType: ProjectOpenType,
-        getResumeAiSessionMessageType: getResumeAiSessionMessageType,
-        getArchiveAiSessionMessageType: getArchiveAiSessionMessageType,
-        isAiSessionProvider: isAiSessionProvider,
+        getResumeAiSessionMessageType: aiSessionControls.getResumeAiSessionMessageType,
+        getArchiveAiSessionMessageType: aiSessionControls.getArchiveAiSessionMessageType,
+        isAiSessionProvider: aiSessionControls.isAiSessionProvider,
     });
     var aiSessionsUpdate = initProjectAiSessionsUpdate({
-        batchAiSessionState: batchAiSessionState,
-        batchAiSessionManager: batchAiSessionManager,
-        getPendingAiSessionProviderSelectionProjectId: () => pendingAiSessionProviderSelectionProjectId,
-        getSelectedAiSessionProviders: getSelectedAiSessionProviders,
-        syncAiSessionBatchManagementDom: syncAiSessionBatchManagementDom,
-        syncActiveAiSessionTerminalDom: syncActiveAiSessionTerminalDom,
-        reconcilePendingAiSessionProviderSelectionDom: reconcilePendingAiSessionProviderSelectionDom,
-        submitAiSessionProviderSelection: submitAiSessionProviderSelection,
-        toggleCodexSessions: toggleCodexSessions,
-        exitAiSessionBatchManagement: exitAiSessionBatchManagement,
-        isAiSessionProvider: isAiSessionProvider,
+        batchAiSessionState: aiSessionControls.batchAiSessionState,
+        batchAiSessionManager: aiSessionControls.batchAiSessionManager,
+        getPendingAiSessionProviderSelectionProjectId: () => aiSessionControls.getPendingAiSessionProviderSelectionProjectId(),
+        getSelectedAiSessionProviders: aiSessionControls.getSelectedAiSessionProviders,
+        syncAiSessionBatchManagementDom: aiSessionControls.syncAiSessionBatchManagementDom,
+        syncActiveAiSessionTerminalDom: aiSessionControls.syncActiveAiSessionTerminalDom,
+        reconcilePendingAiSessionProviderSelectionDom: aiSessionControls.reconcilePendingAiSessionProviderSelectionDom,
+        submitAiSessionProviderSelection: aiSessionControls.submitAiSessionProviderSelection,
+        toggleCodexSessions: aiSessionControls.toggleCodexSessions,
+        exitAiSessionBatchManagement: aiSessionControls.exitAiSessionBatchManagement,
+        isAiSessionProvider: aiSessionControls.isAiSessionProvider,
         updateStickyGroupHeaderOffset: updateStickyGroupHeaderOffset,
     });
 
@@ -960,7 +299,7 @@ function initProjects() {
 
         contextMenus.closeContextMenus();
         if (!e.target.closest('.ai-session-provider-menu-wrapper')) {
-            closeAiSessionProviderMenus();
+            aiSessionControls.closeAiSessionProviderMenus();
         }
 
         if (e.target.closest('[data-action="toggle-all-groups"]')) {
@@ -1056,7 +395,7 @@ function initProjects() {
             return;
         }
         if (message && message.type === 'ai-session-provider-selection-result') {
-            applyAiSessionProviderSelectionResult(message);
+            aiSessionControls.applyAiSessionProviderSelectionResult(message);
             return;
         }
         if (message && (message.type === 'todo-panel-content' || message.type === 'todo-panel-updated')) {
@@ -1072,23 +411,23 @@ function initProjects() {
         if (message && message.type === 'workspace-updated') {
             if (!applyWorkspaceUpdate(message, {
                 canRestoreAiSessionProviderMenu: () =>
-                    !pendingAiSessionProviderSelectionProjectId
-                    && !batchAiSessionState.pending,
+                    !aiSessionControls.getPendingAiSessionProviderSelectionProjectId()
+                    && !aiSessionControls.batchAiSessionState.pending,
             })) {
                 aiSessionsUpdate.requestFullRefresh('invalid-workspace-update');
                 return;
             }
-            if (batchAiSessionState.projectId) {
-                var managedProjectDiv = aiSessionsUpdate.findCurrentWorkspaceDiv(batchAiSessionState.projectId);
+            if (aiSessionControls.batchAiSessionState.projectId) {
+                var managedProjectDiv = aiSessionsUpdate.findCurrentWorkspaceDiv(aiSessionControls.batchAiSessionState.projectId);
                 if (managedProjectDiv) {
-                    batchAiSessionManager.reconcileVisible(managedProjectDiv);
-                    syncAiSessionBatchManagementDom(managedProjectDiv);
+                    aiSessionControls.batchAiSessionManager.reconcileVisible(managedProjectDiv);
+                    aiSessionControls.syncAiSessionBatchManagementDom(managedProjectDiv);
                 } else {
-                    exitAiSessionBatchManagement();
+                    aiSessionControls.exitAiSessionBatchManagement();
                 }
             }
-            reconcilePendingAiSessionProviderSelectionDom();
-            syncActiveAiSessionTerminalDom();
+            aiSessionControls.reconcilePendingAiSessionProviderSelectionDom();
+            aiSessionControls.syncActiveAiSessionTerminalDom();
             updateStickyGroupHeaderOffset();
             var renderedWorkspaceState = getWorkspaceUpdateDomState(document);
             window.vscode.postMessage({
@@ -1103,7 +442,7 @@ function initProjects() {
                 aiSessionsUpdate.requestFullRefresh('invalid-open-workspaces-update');
                 return;
             }
-            syncActiveAiSessionTerminalDom();
+            aiSessionControls.syncActiveAiSessionTerminalDom();
             updateStickyGroupHeaderOffset();
             var renderedOpenWorkspaceState = getOpenWorkspacesUpdateDomState();
             window.vscode.postMessage({
@@ -1139,9 +478,9 @@ function initProjects() {
         }
 
         if (message && message.type === 'active-ai-session-terminal-changed') {
-            activeAiSessionTerminalState.provider = isAiSessionProvider(message.provider) ? message.provider : null;
-            activeAiSessionTerminalState.sessionId = typeof message.sessionId === 'string' ? message.sessionId : null;
-            syncActiveAiSessionTerminalDom();
+            aiSessionControls.activeAiSessionTerminalState.provider = aiSessionControls.isAiSessionProvider(message.provider) ? message.provider : null;
+            aiSessionControls.activeAiSessionTerminalState.sessionId = typeof message.sessionId === 'string' ? message.sessionId : null;
+            aiSessionControls.syncActiveAiSessionTerminalDom();
             return;
         }
 
@@ -1151,7 +490,7 @@ function initProjects() {
             (Array.isArray(message.sessionEvents) ? message.sessionEvents.slice(0, 1000) : []).forEach(session => {
                 if (!session || typeof session.sessionKey !== 'string' || !Array.isArray(session.eventIds)) return;
                 var separator = session.sessionKey.indexOf(':');
-                if (separator <= 0 || !isAiSessionProvider(session.sessionKey.slice(0, separator))) return;
+                if (separator <= 0 || !aiSessionControls.isAiSessionProvider(session.sessionKey.slice(0, separator))) return;
                 var eventIds = Array.from(new Set(session.eventIds
                     .slice(0, 1000)
                     .filter(eventId => typeof eventId === 'string' && !!eventId)));
@@ -1164,9 +503,9 @@ function initProjects() {
         }
 
         if (message && message.type === 'ai-session-batch-archive-completed') {
-            if (batchAiSessionManager.complete(message)) {
+            if (aiSessionControls.batchAiSessionManager.complete(message)) {
                 var completedProject = aiSessionsUpdate.findCurrentWorkspaceDiv(message.projectId);
-                syncAiSessionBatchManagementDom(completedProject);
+                aiSessionControls.syncAiSessionBatchManagementDom(completedProject);
                 var archiveLiveRegion = completedProject
                     && completedProject.querySelector('[data-ai-session-live-region]');
                 if (archiveLiveRegion) {
@@ -1232,9 +571,9 @@ function initProjects() {
                 || e.key === 'Home' || e.key === 'End')) {
             e.preventDefault();
             var triggerProject = aiSessionProviderTrigger.closest('.project[data-id]');
-            closeAiSessionProviderMenus(triggerProject);
-            setAiSessionProviderMenuOpen(triggerProject, true);
-            var triggerOptions = getAiSessionProviderOptions(triggerProject);
+            aiSessionControls.closeAiSessionProviderMenus(triggerProject);
+            aiSessionControls.setAiSessionProviderMenuOpen(triggerProject, true);
+            var triggerOptions = aiSessionControls.getAiSessionProviderOptions(triggerProject);
             var triggerOptionIndex = e.key === 'ArrowUp' || e.key === 'End'
                 ? triggerOptions.length - 1
                 : 0;
@@ -1243,7 +582,7 @@ function initProjects() {
         }
         if (aiSessionProviderTrigger && e.key === 'Escape') {
             e.preventDefault();
-            closeAiSessionProviderMenu(
+            aiSessionControls.closeAiSessionProviderMenu(
                 aiSessionProviderTrigger.closest('.project[data-id]'),
                 true
             );
@@ -1255,7 +594,7 @@ function initProjects() {
             : null;
         if (aiSessionProviderOption) {
             var providerProject = aiSessionProviderOption.closest('.project[data-id]');
-            var providerOptions = getAiSessionProviderOptions(providerProject);
+            var providerOptions = aiSessionControls.getAiSessionProviderOptions(providerProject);
             var providerOptionIndex = providerOptions.indexOf(aiSessionProviderOption);
             if (e.key === 'ArrowDown' || e.key === 'ArrowUp'
                 || e.key === 'Home' || e.key === 'End') {
@@ -1269,16 +608,16 @@ function initProjects() {
             }
             if (e.key === 'Enter' || e.key === ' ') {
                 e.preventDefault();
-                activateAiSessionProviderOption(providerProject, aiSessionProviderOption);
+                aiSessionControls.activateAiSessionProviderOption(providerProject, aiSessionProviderOption);
                 return;
             }
             if (e.key === 'Escape') {
                 e.preventDefault();
-                closeAiSessionProviderMenu(providerProject, true);
+                aiSessionControls.closeAiSessionProviderMenu(providerProject, true);
                 return;
             }
             if (e.key === 'Tab') {
-                closeAiSessionProviderMenu(providerProject, false);
+                aiSessionControls.closeAiSessionProviderMenu(providerProject, false);
             }
         }
 
@@ -1330,7 +669,7 @@ function initProjects() {
             e.preventDefault();
             var tabProject = tab.closest('.project[data-id]');
             var tabProjectId = tabProject && tabProject.getAttribute('data-id');
-            if (tabProjectId) onTriggerAiSessionAction(tab, tabProjectId);
+            if (tabProjectId) aiSessionControls.onTriggerAiSessionAction(tab, tabProjectId);
             return;
         }
 
@@ -1361,8 +700,8 @@ function initProjects() {
                 return;
             }
             contextMenus.closeContextMenus();
-            if (batchAiSessionState.projectId && !batchAiSessionState.pending) {
-                exitAiSessionBatchManagement();
+            if (aiSessionControls.batchAiSessionState.projectId && !aiSessionControls.batchAiSessionState.pending) {
+                aiSessionControls.exitAiSessionBatchManagement();
             }
         }
     });

--- a/src/webview/webviewProjectScripts.js
+++ b/src/webview/webviewProjectScripts.js
@@ -181,7 +181,6 @@ function initProjects() {
         requestId: null,
     };
     var activeAiSessionTerminalState = { provider: null, sessionId: null };
-    var pendingWorkspaceSessionReveal = null;
     var nextAiSessionBatchArchiveRequestId = 0;
     var nextAiSessionProviderSelectionRequestId = 0;
     var pendingAiSessionProviderSelectionProjectId = null;
@@ -862,7 +861,7 @@ function initProjects() {
     function reconcilePendingAiSessionProviderSelectionDom() {
         if (!pendingAiSessionProviderSelectionProjectId)
             return;
-        var projectDiv = findCurrentWorkspaceDiv(
+        var projectDiv = aiSessionsUpdate.findCurrentWorkspaceDiv(
             pendingAiSessionProviderSelectionProjectId
         );
         if (!projectDiv)
@@ -892,7 +891,7 @@ function initProjects() {
             return true;
         }
 
-        var projectDiv = findCurrentWorkspaceDiv(message.projectId);
+        var projectDiv = aiSessionsUpdate.findCurrentWorkspaceDiv(message.projectId);
         clearPendingAiSessionProviderSelection();
         syncAiSessionProviderMenuDisabledDom(projectDiv, false);
         var liveRegion = projectDiv?.querySelector('[data-ai-session-live-region]');
@@ -905,10 +904,9 @@ function initProjects() {
     function exitAiSessionBatchManagement() {
         var projectId = batchAiSessionState.projectId;
         batchAiSessionManager.exit();
-        syncAiSessionBatchManagementDom(findCurrentWorkspaceDiv(projectId));
+        syncAiSessionBatchManagementDom(aiSessionsUpdate.findCurrentWorkspaceDiv(projectId));
     }
 
-    var latestAiSessionUpdateSequence = 0;
 
     var groupCollapse = initProjectGroupCollapse();
     var todoControls = initProjectTodoControls({
@@ -920,6 +918,20 @@ function initProjects() {
         getResumeAiSessionMessageType: getResumeAiSessionMessageType,
         getArchiveAiSessionMessageType: getArchiveAiSessionMessageType,
         isAiSessionProvider: isAiSessionProvider,
+    });
+    var aiSessionsUpdate = initProjectAiSessionsUpdate({
+        batchAiSessionState: batchAiSessionState,
+        batchAiSessionManager: batchAiSessionManager,
+        getPendingAiSessionProviderSelectionProjectId: () => pendingAiSessionProviderSelectionProjectId,
+        getSelectedAiSessionProviders: getSelectedAiSessionProviders,
+        syncAiSessionBatchManagementDom: syncAiSessionBatchManagementDom,
+        syncActiveAiSessionTerminalDom: syncActiveAiSessionTerminalDom,
+        reconcilePendingAiSessionProviderSelectionDom: reconcilePendingAiSessionProviderSelectionDom,
+        submitAiSessionProviderSelection: submitAiSessionProviderSelection,
+        toggleCodexSessions: toggleCodexSessions,
+        exitAiSessionBatchManagement: exitAiSessionBatchManagement,
+        isAiSessionProvider: isAiSessionProvider,
+        updateStickyGroupHeaderOffset: updateStickyGroupHeaderOffset,
     });
 
     function onMouseEvent(e) {
@@ -1063,11 +1075,11 @@ function initProjects() {
                     !pendingAiSessionProviderSelectionProjectId
                     && !batchAiSessionState.pending,
             })) {
-                requestFullRefresh('invalid-workspace-update');
+                aiSessionsUpdate.requestFullRefresh('invalid-workspace-update');
                 return;
             }
             if (batchAiSessionState.projectId) {
-                var managedProjectDiv = findCurrentWorkspaceDiv(batchAiSessionState.projectId);
+                var managedProjectDiv = aiSessionsUpdate.findCurrentWorkspaceDiv(batchAiSessionState.projectId);
                 if (managedProjectDiv) {
                     batchAiSessionManager.reconcileVisible(managedProjectDiv);
                     syncAiSessionBatchManagementDom(managedProjectDiv);
@@ -1088,7 +1100,7 @@ function initProjects() {
         }
         if (message && message.type === 'open-workspaces-updated') {
             if (!applyOpenWorkspacesUpdate(message)) {
-                requestFullRefresh('invalid-open-workspaces-update');
+                aiSessionsUpdate.requestFullRefresh('invalid-open-workspaces-update');
                 return;
             }
             syncActiveAiSessionTerminalDom();
@@ -1110,7 +1122,7 @@ function initProjects() {
             return;
         }
         if (message && message.type === 'ai-session-tab-selection-requested') {
-            var requestedProject = findCurrentWorkspaceDiv(message.projectId);
+            var requestedProject = aiSessionsUpdate.findCurrentWorkspaceDiv(message.projectId);
             if (requestedProject && (message.tab === 'active' || message.tab === 'sessions')) {
                 selectAiSessionTabDom(requestedProject, message.tab);
                 writeAiSessionTabState(window.vscode, message.projectId, message.tab);
@@ -1119,7 +1131,7 @@ function initProjects() {
         }
 
         if (message && message.type === 'ai-session-status-announcement') {
-            var announcementProject = findCurrentWorkspaceDiv(message.projectId);
+            var announcementProject = aiSessionsUpdate.findCurrentWorkspaceDiv(message.projectId);
             var announcement = typeof message.message === 'string' ? message.message.trim().slice(0, 256) : '';
             var announcementRegion = announcementProject && announcementProject.querySelector('[data-ai-session-live-region]');
             if (announcementRegion && announcement) announcementRegion.textContent = announcement;
@@ -1153,7 +1165,7 @@ function initProjects() {
 
         if (message && message.type === 'ai-session-batch-archive-completed') {
             if (batchAiSessionManager.complete(message)) {
-                var completedProject = findCurrentWorkspaceDiv(message.projectId);
+                var completedProject = aiSessionsUpdate.findCurrentWorkspaceDiv(message.projectId);
                 syncAiSessionBatchManagementDom(completedProject);
                 var archiveLiveRegion = completedProject
                     && completedProject.querySelector('[data-ai-session-live-region]');
@@ -1169,155 +1181,7 @@ function initProjects() {
             return;
         }
 
-        applyAiSessionsUpdate(message);
-    }
-
-    function applyAiSessionsUpdate(message) {
-        if (message.version !== 2
-            || typeof message.sequence !== 'number'
-            || (message.currentWorkspaceCount !== 0 && message.currentWorkspaceCount !== 1)
-            || typeof message.html !== 'string'
-            || typeof normalizeDashboardSearchCatalog !== 'function'
-            || normalizeDashboardSearchCatalog(message.searchCatalog) !== message.searchCatalog
-            || message.searchCatalog.version !== 2) {
-            requestFullRefresh('unsupported-ai-session-message');
-            return;
-        }
-
-        if (message.sequence <= latestAiSessionUpdateSequence) {
-            return;
-        }
-
-        if (!applyWorkspaceUpdate({
-            type: 'workspace-updated',
-            version: 2,
-            currentWorkspaceCount: message.currentWorkspaceCount,
-            html: message.html,
-        }, {
-            canRestoreAiSessionProviderMenu: () =>
-                !pendingAiSessionProviderSelectionProjectId
-                && !batchAiSessionState.pending,
-        })) {
-            requestFullRefresh('invalid-ai-session-workspace-update');
-            return;
-        }
-
-        latestAiSessionUpdateSequence = message.sequence;
-        if (batchAiSessionState.projectId) {
-            var projectDiv = findCurrentWorkspaceDiv(batchAiSessionState.projectId);
-            if (projectDiv) {
-                batchAiSessionManager.reconcileVisible(projectDiv);
-                syncAiSessionBatchManagementDom(projectDiv);
-            } else {
-                exitAiSessionBatchManagement();
-            }
-        }
-        reconcilePendingAiSessionProviderSelectionDom();
-        syncActiveAiSessionTerminalDom();
-        updateStickyGroupHeaderOffset();
-        if (window.__agentPivotDashboard) {
-            window.__agentPivotDashboard.replaceSearchCatalog(message.searchCatalog);
-        }
-    }
-
-    function findCurrentWorkspaceDiv(projectId) {
-        if (!projectId) {
-            return null;
-        }
-
-        var projects = document.querySelectorAll('.workspace-card[data-current-workspace][data-id]');
-        for (var projectDiv of projects) {
-            if (projectDiv.getAttribute("data-id") === projectId) {
-                return projectDiv;
-            }
-        }
-
-        return null;
-    }
-
-    function findWorkspaceDiv(navigationIdentity) {
-        if (!navigationIdentity) {
-            return null;
-        }
-        var workspaces = document.querySelectorAll('.workspace-card[data-workspace-navigation-identity]');
-        for (var workspaceDiv of workspaces) {
-            if (workspaceDiv.getAttribute('data-workspace-navigation-identity') === navigationIdentity) {
-                return workspaceDiv;
-            }
-        }
-        return null;
-    }
-
-    function focusSearchRevealTarget(target) {
-        target.setAttribute('tabindex', '-1');
-        target.focus();
-        target.scrollIntoView({ block: 'nearest' });
-        target.addEventListener('blur', () => target.removeAttribute('tabindex'), { once: true });
-    }
-
-    window.__agentPivotRevealWorkspace = navigationIdentity => {
-        var workspaceDiv = findWorkspaceDiv(navigationIdentity);
-        if (!workspaceDiv) {
-            return false;
-        }
-        focusSearchRevealTarget(workspaceDiv);
-        return true;
-    };
-
-    function revealWorkspaceSession(navigationIdentity, provider, sessionId) {
-        if (!isAiSessionProvider(provider) || !sessionId) {
-            return false;
-        }
-        var workspaceDiv = findWorkspaceDiv(navigationIdentity);
-        if (!workspaceDiv) {
-            return false;
-        }
-        var workspaceId = workspaceDiv.getAttribute('data-id');
-        if (!workspaceDiv.hasAttribute('data-codex-expanded')) {
-            toggleCodexSessions(workspaceDiv, workspaceId);
-        }
-        selectAiSessionTabDom(workspaceDiv, 'sessions');
-        writeAiSessionTabState(window.vscode, workspaceId, 'sessions');
-        var sessionRow = Array.from(workspaceDiv.querySelectorAll('.codex-session-row[data-session-id][data-session-provider]'))
-            .find(row => row.getAttribute('data-session-provider') === provider
-                && row.getAttribute('data-session-id') === sessionId);
-        if (sessionRow) {
-            pendingWorkspaceSessionReveal = null;
-            focusSearchRevealTarget(sessionRow);
-            return true;
-        }
-        var selectedProviders = getSelectedAiSessionProviders(workspaceDiv);
-        if (!selectedProviders.includes(provider)) {
-            pendingWorkspaceSessionReveal = { navigationIdentity, provider, sessionId };
-            submitAiSessionProviderSelection(
-                workspaceDiv,
-                selectedProviders.concat(provider)
-            );
-            return true;
-        }
-        pendingWorkspaceSessionReveal = null;
-        focusSearchRevealTarget(workspaceDiv);
-        return false;
-    }
-
-    window.__agentPivotRevealWorkspaceSession = revealWorkspaceSession;
-    window.__agentPivotRevealPendingWorkspaceSession = () => {
-        if (!pendingWorkspaceSessionReveal) {
-            return false;
-        }
-        var pending = pendingWorkspaceSessionReveal;
-        return revealWorkspaceSession(
-            pending.navigationIdentity,
-            pending.provider,
-            pending.sessionId
-        );
-    };
-
-    function requestFullRefresh(reason) {
-        window.vscode.postMessage({
-            type: 'request-full-refresh',
-            reason,
-        });
+        aiSessionsUpdate.applyAiSessionsUpdate(message);
     }
 
     function observeStickyGroupHeaderOffset() {

--- a/src/webview/webviewTodoControlScripts.js
+++ b/src/webview/webviewTodoControlScripts.js
@@ -1,0 +1,324 @@
+function initProjectTodoControls(options) {
+    'use strict';
+
+    options = options || {};
+    var syncCollapseButton = typeof options.syncCollapseButton === 'function'
+        ? options.syncCollapseButton
+        : function () {};
+
+    function isDedicatedTodoTarget(target) {
+        return Boolean(window.__agentPivotTodo
+            && target
+            && target.closest
+            && target.closest('#dashboard-tab-todo'));
+    }
+
+    function onInsideGroupClick(e, groupDiv) {
+        var groupId = groupDiv.getAttribute("data-group-id");
+        if (groupId == null)
+            return;
+
+        var actionDiv = e.target.closest('[data-action]')
+        var action = actionDiv != null ? actionDiv.getAttribute("data-action") : null;
+        if (!action)
+            return;
+
+        if (action === "add") {
+            window.vscode.postMessage({
+                type: 'add-project',
+                groupId: groupId,
+            });
+
+            return;
+        }
+
+        var collapsed = groupDiv.classList.contains("collapsed");
+        if (action === "collapse") {
+            groupDiv.classList.toggle("collapsed");
+            collapsed = groupDiv.classList.contains("collapsed");
+        }
+
+        window.vscode.postMessage({
+            type: action + '-group',
+            groupId: groupId,
+            collapsed,
+        });
+        syncCollapseButton();
+    }
+
+    function onTodoAction(e) {
+        var addTodoAction = e.target.closest('[data-action="todo-add"]');
+        if (addTodoAction && !addTodoAction.closest('.todo-add-form')) {
+            setTodoAddFormVisible(true, addTodoAction.getAttribute('data-group-id'));
+            return true;
+        }
+
+        var addGroupAction = e.target.closest('[data-action="todo-add-group"]');
+        if (addGroupAction) {
+            window.vscode.postMessage({
+                type: 'todo-add-group',
+            });
+            return true;
+        }
+
+        var toggleAction = e.target.closest('[data-action="todo-toggle"]');
+        if (toggleAction) {
+            window.vscode.postMessage({
+                type: 'todo-toggle',
+                todoId: toggleAction.getAttribute('data-todo-id'),
+                completed: toggleAction.checked === true,
+            });
+            return true;
+        }
+
+        var deleteAction = e.target.closest('[data-action="todo-delete"]');
+        if (deleteAction) {
+            window.vscode.postMessage({
+                type: 'todo-delete',
+                todoId: deleteAction.getAttribute('data-todo-id'),
+            });
+            return true;
+        }
+
+        var deleteGroupAction = e.target.closest('[data-action="todo-delete-group"]');
+        if (deleteGroupAction) {
+            window.vscode.postMessage({
+                type: 'todo-delete-group',
+                groupId: deleteGroupAction.getAttribute('data-group-id'),
+            });
+            return true;
+        }
+
+        var renameGroupAction = e.target.closest('[data-action="todo-rename-group"]');
+        if (renameGroupAction) {
+            window.vscode.postMessage({
+                type: 'todo-rename-group',
+                groupId: renameGroupAction.getAttribute('data-group-id'),
+            });
+            return true;
+        }
+
+        var collapseGroupAction = e.target.closest('[data-action="todo-collapse-group"]');
+        if (collapseGroupAction) {
+            var todoGroup = collapseGroupAction.closest('.todo-group');
+            if (!todoGroup)
+                return true;
+            todoGroup.classList.toggle('collapsed');
+            syncTodoGroupCollapseControl(todoGroup);
+            window.vscode.postMessage({
+                type: 'todo-collapse-group',
+                groupId: todoGroup.getAttribute('data-todo-group-id'),
+                collapsed: todoGroup.classList.contains('collapsed'),
+            });
+            syncCollapseButton();
+            return true;
+        }
+
+        var sortAction = e.target.closest('[data-action="todo-sort-priority"]');
+        if (sortAction) {
+            window.vscode.postMessage({
+                type: 'todo-sort-priority',
+                groupId: sortAction.getAttribute('data-group-id'),
+            });
+            return true;
+        }
+
+        var showCompletedAction = e.target.closest('[data-action="todo-toggle-show-completed"]');
+        if (showCompletedAction) {
+            window.vscode.postMessage({
+                type: 'todo-toggle-show-completed',
+                showCompleted: showCompletedAction.checked === true,
+            });
+            return true;
+        }
+
+        var focusAddAction = e.target.closest('[data-action="todo-focus-add"]');
+        if (focusAddAction) {
+            setTodoAddFormVisible(true, focusAddAction.getAttribute('data-group-id'));
+            return true;
+        }
+
+        var cancelAddAction = e.target.closest('[data-action="todo-cancel-add"]');
+        if (cancelAddAction) {
+            setTodoAddFormVisible(false);
+            return true;
+        }
+
+        var editAction = e.target.closest('[data-action="todo-edit"]');
+        if (editAction) {
+            setTodoEditing(editAction.getAttribute('data-todo-id'), true);
+            return true;
+        }
+
+        var expandAction = e.target.closest('[data-action="todo-toggle-expanded"]');
+        if (expandAction) {
+            toggleTodoItemExpanded(expandAction.closest('.todo-item'));
+            return true;
+        }
+
+        var cancelEditAction = e.target.closest('[data-action="todo-cancel-edit"]');
+        if (cancelEditAction) {
+            setTodoEditing(cancelEditAction.getAttribute('data-todo-id'), false);
+            return true;
+        }
+
+        return false;
+    }
+
+    function syncTodoPrioritySegment(segment) {
+        if (!segment)
+            return;
+
+        Array.from(segment.querySelectorAll('.todo-priority-choice')).forEach(choice => {
+            var input = choice.querySelector('input[name="priority"]');
+            choice.classList.toggle('active', !!input && input.checked === true);
+        });
+    }
+
+    function resetTodoEditForm(form) {
+        form.reset();
+        syncTodoPrioritySegment(form.querySelector('.todo-priority-segment'));
+    }
+
+    function syncTodoListExpandedHeight(list) {
+        if (!list)
+            return;
+
+        var panel = list.closest('.todo-panel');
+        var collapsedHeightValue = panel
+            ? getComputedStyle(panel).getPropertyValue('--todo-collapsed-item-height')
+            : '';
+        var collapsedHeight = parseFloat(collapsedHeightValue) || 58;
+        var expandedExtraHeight = Array.from(list.querySelectorAll('.todo-item.expanded'))
+            .reduce((total, expandedItem) => total + Math.max(0, expandedItem.offsetHeight - collapsedHeight), 0);
+        list.style.setProperty('--todo-list-expanded-extra-height', expandedExtraHeight + 'px');
+    }
+
+    function toggleTodoItemExpanded(item, expanded) {
+        if (!item)
+            return;
+
+        var nextExpanded = typeof expanded === 'boolean'
+            ? expanded
+            : !item.classList.contains('expanded');
+        item.classList.toggle('expanded', nextExpanded);
+        syncTodoExpandControl(item, nextExpanded);
+        syncTodoListExpandedHeight(item.closest('.todo-list'));
+    }
+
+    function isTodoInteractiveTarget(target) {
+        return !!(target && target.closest && target.closest('button, input, textarea, select, label, a, [data-action], .todo-edit-form'));
+    }
+
+    function setTodoAddFormVisible(visible, groupId) {
+        var form = document.querySelector('.todo-add-form');
+        if (!form)
+            return;
+
+        var groupSelect = form.querySelector('[name="groupId"]');
+        if (visible && groupSelect) {
+            groupSelect.value = groupId || '';
+        }
+        form.hidden = !visible;
+        if (!visible)
+            return;
+
+        var titleInput = form.querySelector('[name="title"]');
+        if (titleInput) {
+            titleInput.focus();
+        }
+        form.scrollIntoView({ block: 'nearest' });
+    }
+
+    function setTodoEditing(todoId, editing) {
+        if (!todoId)
+            return;
+
+        var item = Array.from(document.querySelectorAll('.todo-item[data-todo-id]'))
+            .find(candidate => candidate.getAttribute('data-todo-id') === todoId);
+        if (!item)
+            return;
+
+        var wasEditing = item.classList.contains('editing');
+        var expandedBeforeEdit = item.getAttribute('data-expanded-before-edit');
+        if (editing && !wasEditing) {
+            item.setAttribute(
+                'data-expanded-before-edit',
+                item.classList.contains('expanded') ? 'true' : 'false'
+            );
+            expandedBeforeEdit = item.getAttribute('data-expanded-before-edit');
+        }
+        var view = item.querySelector('.todo-item-view');
+        var form = item.querySelector('.todo-edit-form');
+        var list = item.closest('.todo-list');
+        if (form && !editing) {
+            resetTodoEditForm(form);
+        }
+        item.classList.toggle('editing', editing);
+        if (view) {
+            view.hidden = false;
+        }
+        if (form) {
+            form.hidden = !editing;
+        }
+        toggleTodoItemExpanded(item, editing ? true : expandedBeforeEdit === 'true');
+        if (!editing) {
+            item.removeAttribute('data-expanded-before-edit');
+        }
+        if (list) {
+            list.classList.toggle('has-editing-item', !!list.querySelector('.todo-item.editing'));
+        }
+        if (form && editing) {
+            var titleInput = form.querySelector('[name="title"]');
+            if (titleInput) {
+                titleInput.focus();
+            }
+            item.scrollIntoView({ block: 'nearest' });
+        }
+    }
+
+    function onTodoFormSubmit(e) {
+        if (window.__agentPivotTodo
+            && e.target
+            && e.target.closest
+            && e.target.closest('#dashboard-tab-todo')) {
+            return;
+        }
+        var addForm = e.target && e.target.closest ? e.target.closest('.todo-add-form') : null;
+        if (addForm) {
+            e.preventDefault();
+            submitTodoComposeForm(addForm, message => window.vscode.postMessage(message));
+            return;
+        }
+
+        var editForm = e.target && e.target.closest ? e.target.closest('.todo-edit-form') : null;
+        if (editForm) {
+            e.preventDefault();
+            var todoId = editForm.getAttribute('data-todo-id');
+            var editTitle = getTodoFormValue(editForm, 'title');
+            if (!todoId || !editTitle)
+                return;
+            window.vscode.postMessage({
+                type: 'todo-update',
+                todoId,
+                title: editTitle,
+                notes: getTodoFormValue(editForm, 'notes'),
+                priority: getTodoFormValue(editForm, 'priority'),
+            });
+        }
+    }
+
+    return {
+        isDedicatedTodoTarget: isDedicatedTodoTarget,
+        isTodoInteractiveTarget: isTodoInteractiveTarget,
+        onInsideGroupClick: onInsideGroupClick,
+        onTodoAction: onTodoAction,
+        onTodoFormSubmit: onTodoFormSubmit,
+        resetTodoEditForm: resetTodoEditForm,
+        setTodoAddFormVisible: setTodoAddFormVisible,
+        setTodoEditing: setTodoEditing,
+        syncTodoListExpandedHeight: syncTodoListExpandedHeight,
+        syncTodoPrioritySegment: syncTodoPrioritySegment,
+        toggleTodoItemExpanded: toggleTodoItemExpanded,
+    };
+}

--- a/tests/browser/activeSessionCardInteraction.test.js
+++ b/tests/browser/activeSessionCardInteraction.test.js
@@ -46,6 +46,10 @@ const todoControlScript = fs.readFileSync(
     path.join(__dirname, '../../src/webview/webviewTodoControlScripts.js'),
     'utf8'
 );
+const projectContextMenuScript = fs.readFileSync(
+    path.join(__dirname, '../../src/webview/webviewProjectContextMenuScripts.js'),
+    'utf8'
+);
 const projectScript = fs.readFileSync(
     path.join(__dirname, '../../src/webview/webviewProjectScripts.js'),
     'utf8'
@@ -232,6 +236,7 @@ async function openCardPage(t, activeAiSessions, viewport = { width: 360, height
     await page.addScriptTag({ content: todoGroupScript });
     await page.addScriptTag({ content: projectCollapseScript });
     await page.addScriptTag({ content: todoControlScript });
+    await page.addScriptTag({ content: projectContextMenuScript });
     await page.addScriptTag({ content: projectScript });
     await page.evaluate(() => {
         initProjects();
@@ -258,6 +263,7 @@ async function openListPage(t, activeAiSessions, historySessions) {
     await page.addScriptTag({ content: todoGroupScript });
     await page.addScriptTag({ content: projectCollapseScript });
     await page.addScriptTag({ content: todoControlScript });
+    await page.addScriptTag({ content: projectContextMenuScript });
     await page.addScriptTag({ content: projectScript });
     await page.evaluate(() => initProjects());
     return page;

--- a/tests/browser/activeSessionCardInteraction.test.js
+++ b/tests/browser/activeSessionCardInteraction.test.js
@@ -38,6 +38,10 @@ const todoGroupScript = fs.readFileSync(
     path.join(__dirname, '../../src/webview/webviewTodoGroupScripts.js'),
     'utf8'
 );
+const projectCollapseScript = fs.readFileSync(
+    path.join(__dirname, '../../src/webview/webviewProjectCollapseScripts.js'),
+    'utf8'
+);
 const projectScript = fs.readFileSync(
     path.join(__dirname, '../../src/webview/webviewProjectScripts.js'),
     'utf8'
@@ -222,6 +226,7 @@ async function openCardPage(t, activeAiSessions, viewport = { width: 360, height
     await page.addScriptTag({ content: viewStateScript });
     await page.addScriptTag({ content: workspaceUpdateScript });
     await page.addScriptTag({ content: todoGroupScript });
+    await page.addScriptTag({ content: projectCollapseScript });
     await page.addScriptTag({ content: projectScript });
     await page.evaluate(() => {
         initProjects();
@@ -246,6 +251,7 @@ async function openListPage(t, activeAiSessions, historySessions) {
     await page.addScriptTag({ content: viewStateScript });
     await page.addScriptTag({ content: workspaceUpdateScript });
     await page.addScriptTag({ content: todoGroupScript });
+    await page.addScriptTag({ content: projectCollapseScript });
     await page.addScriptTag({ content: projectScript });
     await page.evaluate(() => initProjects());
     return page;

--- a/tests/browser/activeSessionCardInteraction.test.js
+++ b/tests/browser/activeSessionCardInteraction.test.js
@@ -42,6 +42,10 @@ const projectCollapseScript = fs.readFileSync(
     path.join(__dirname, '../../src/webview/webviewProjectCollapseScripts.js'),
     'utf8'
 );
+const todoControlScript = fs.readFileSync(
+    path.join(__dirname, '../../src/webview/webviewTodoControlScripts.js'),
+    'utf8'
+);
 const projectScript = fs.readFileSync(
     path.join(__dirname, '../../src/webview/webviewProjectScripts.js'),
     'utf8'
@@ -227,6 +231,7 @@ async function openCardPage(t, activeAiSessions, viewport = { width: 360, height
     await page.addScriptTag({ content: workspaceUpdateScript });
     await page.addScriptTag({ content: todoGroupScript });
     await page.addScriptTag({ content: projectCollapseScript });
+    await page.addScriptTag({ content: todoControlScript });
     await page.addScriptTag({ content: projectScript });
     await page.evaluate(() => {
         initProjects();
@@ -252,6 +257,7 @@ async function openListPage(t, activeAiSessions, historySessions) {
     await page.addScriptTag({ content: workspaceUpdateScript });
     await page.addScriptTag({ content: todoGroupScript });
     await page.addScriptTag({ content: projectCollapseScript });
+    await page.addScriptTag({ content: todoControlScript });
     await page.addScriptTag({ content: projectScript });
     await page.evaluate(() => initProjects());
     return page;

--- a/tests/browser/activeSessionCardInteraction.test.js
+++ b/tests/browser/activeSessionCardInteraction.test.js
@@ -54,6 +54,10 @@ const projectAiUpdateScript = fs.readFileSync(
     path.join(__dirname, '../../src/webview/webviewProjectAiUpdateScripts.js'),
     'utf8'
 );
+const aiSessionControlsScript = fs.readFileSync(
+    path.join(__dirname, '../../src/webview/webviewProjectAiSessionControlsScripts.js'),
+    'utf8'
+);
 const projectScript = fs.readFileSync(
     path.join(__dirname, '../../src/webview/webviewProjectScripts.js'),
     'utf8'
@@ -242,6 +246,7 @@ async function openCardPage(t, activeAiSessions, viewport = { width: 360, height
     await page.addScriptTag({ content: todoControlScript });
     await page.addScriptTag({ content: projectContextMenuScript });
     await page.addScriptTag({ content: projectAiUpdateScript });
+    await page.addScriptTag({ content: aiSessionControlsScript });
     await page.addScriptTag({ content: projectScript });
     await page.evaluate(() => {
         initProjects();
@@ -270,6 +275,7 @@ async function openListPage(t, activeAiSessions, historySessions) {
     await page.addScriptTag({ content: todoControlScript });
     await page.addScriptTag({ content: projectContextMenuScript });
     await page.addScriptTag({ content: projectAiUpdateScript });
+    await page.addScriptTag({ content: aiSessionControlsScript });
     await page.addScriptTag({ content: projectScript });
     await page.evaluate(() => initProjects());
     return page;

--- a/tests/browser/activeSessionCardInteraction.test.js
+++ b/tests/browser/activeSessionCardInteraction.test.js
@@ -50,6 +50,10 @@ const projectContextMenuScript = fs.readFileSync(
     path.join(__dirname, '../../src/webview/webviewProjectContextMenuScripts.js'),
     'utf8'
 );
+const projectAiUpdateScript = fs.readFileSync(
+    path.join(__dirname, '../../src/webview/webviewProjectAiUpdateScripts.js'),
+    'utf8'
+);
 const projectScript = fs.readFileSync(
     path.join(__dirname, '../../src/webview/webviewProjectScripts.js'),
     'utf8'
@@ -237,6 +241,7 @@ async function openCardPage(t, activeAiSessions, viewport = { width: 360, height
     await page.addScriptTag({ content: projectCollapseScript });
     await page.addScriptTag({ content: todoControlScript });
     await page.addScriptTag({ content: projectContextMenuScript });
+    await page.addScriptTag({ content: projectAiUpdateScript });
     await page.addScriptTag({ content: projectScript });
     await page.evaluate(() => {
         initProjects();
@@ -264,6 +269,7 @@ async function openListPage(t, activeAiSessions, historySessions) {
     await page.addScriptTag({ content: projectCollapseScript });
     await page.addScriptTag({ content: todoControlScript });
     await page.addScriptTag({ content: projectContextMenuScript });
+    await page.addScriptTag({ content: projectAiUpdateScript });
     await page.addScriptTag({ content: projectScript });
     await page.evaluate(() => initProjects());
     return page;

--- a/tests/browser/sessionProviderMenu.test.js
+++ b/tests/browser/sessionProviderMenu.test.js
@@ -47,6 +47,10 @@ const todoControlScript = fs.readFileSync(
     path.join(__dirname, '../../src/webview/webviewTodoControlScripts.js'),
     'utf8'
 );
+const projectContextMenuScript = fs.readFileSync(
+    path.join(__dirname, '../../src/webview/webviewProjectContextMenuScripts.js'),
+    'utf8'
+);
 const projectScript = fs.readFileSync(
     path.join(__dirname, '../../src/webview/webviewProjectScripts.js'),
     'utf8'
@@ -116,6 +120,7 @@ async function openMenuPage(t, selectedProviders = ['codex']) {
     await page.addScriptTag({ content: todoGroupScript });
     await page.addScriptTag({ content: projectCollapseScript });
     await page.addScriptTag({ content: todoControlScript });
+    await page.addScriptTag({ content: projectContextMenuScript });
     await page.addScriptTag({ content: projectScript });
     await page.evaluate(() => {
         initProjects();

--- a/tests/browser/sessionProviderMenu.test.js
+++ b/tests/browser/sessionProviderMenu.test.js
@@ -55,6 +55,10 @@ const projectAiUpdateScript = fs.readFileSync(
     path.join(__dirname, '../../src/webview/webviewProjectAiUpdateScripts.js'),
     'utf8'
 );
+const aiSessionControlsScript = fs.readFileSync(
+    path.join(__dirname, '../../src/webview/webviewProjectAiSessionControlsScripts.js'),
+    'utf8'
+);
 const projectScript = fs.readFileSync(
     path.join(__dirname, '../../src/webview/webviewProjectScripts.js'),
     'utf8'
@@ -126,6 +130,7 @@ async function openMenuPage(t, selectedProviders = ['codex']) {
     await page.addScriptTag({ content: todoControlScript });
     await page.addScriptTag({ content: projectContextMenuScript });
     await page.addScriptTag({ content: projectAiUpdateScript });
+    await page.addScriptTag({ content: aiSessionControlsScript });
     await page.addScriptTag({ content: projectScript });
     await page.evaluate(() => {
         initProjects();

--- a/tests/browser/sessionProviderMenu.test.js
+++ b/tests/browser/sessionProviderMenu.test.js
@@ -51,6 +51,10 @@ const projectContextMenuScript = fs.readFileSync(
     path.join(__dirname, '../../src/webview/webviewProjectContextMenuScripts.js'),
     'utf8'
 );
+const projectAiUpdateScript = fs.readFileSync(
+    path.join(__dirname, '../../src/webview/webviewProjectAiUpdateScripts.js'),
+    'utf8'
+);
 const projectScript = fs.readFileSync(
     path.join(__dirname, '../../src/webview/webviewProjectScripts.js'),
     'utf8'
@@ -121,6 +125,7 @@ async function openMenuPage(t, selectedProviders = ['codex']) {
     await page.addScriptTag({ content: projectCollapseScript });
     await page.addScriptTag({ content: todoControlScript });
     await page.addScriptTag({ content: projectContextMenuScript });
+    await page.addScriptTag({ content: projectAiUpdateScript });
     await page.addScriptTag({ content: projectScript });
     await page.evaluate(() => {
         initProjects();

--- a/tests/browser/sessionProviderMenu.test.js
+++ b/tests/browser/sessionProviderMenu.test.js
@@ -43,6 +43,10 @@ const projectCollapseScript = fs.readFileSync(
     path.join(__dirname, '../../src/webview/webviewProjectCollapseScripts.js'),
     'utf8'
 );
+const todoControlScript = fs.readFileSync(
+    path.join(__dirname, '../../src/webview/webviewTodoControlScripts.js'),
+    'utf8'
+);
 const projectScript = fs.readFileSync(
     path.join(__dirname, '../../src/webview/webviewProjectScripts.js'),
     'utf8'
@@ -111,6 +115,7 @@ async function openMenuPage(t, selectedProviders = ['codex']) {
     await page.addScriptTag({ content: workspaceUpdateScript });
     await page.addScriptTag({ content: todoGroupScript });
     await page.addScriptTag({ content: projectCollapseScript });
+    await page.addScriptTag({ content: todoControlScript });
     await page.addScriptTag({ content: projectScript });
     await page.evaluate(() => {
         initProjects();

--- a/tests/browser/sessionProviderMenu.test.js
+++ b/tests/browser/sessionProviderMenu.test.js
@@ -39,6 +39,10 @@ const todoGroupScript = fs.readFileSync(
     path.join(__dirname, '../../src/webview/webviewTodoGroupScripts.js'),
     'utf8'
 );
+const projectCollapseScript = fs.readFileSync(
+    path.join(__dirname, '../../src/webview/webviewProjectCollapseScripts.js'),
+    'utf8'
+);
 const projectScript = fs.readFileSync(
     path.join(__dirname, '../../src/webview/webviewProjectScripts.js'),
     'utf8'
@@ -106,6 +110,7 @@ async function openMenuPage(t, selectedProviders = ['codex']) {
     await page.addScriptTag({ content: viewStateScript });
     await page.addScriptTag({ content: workspaceUpdateScript });
     await page.addScriptTag({ content: todoGroupScript });
+    await page.addScriptTag({ content: projectCollapseScript });
     await page.addScriptTag({ content: projectScript });
     await page.evaluate(() => {
         initProjects();

--- a/tests/browser/todoCreation.test.js
+++ b/tests/browser/todoCreation.test.js
@@ -32,6 +32,10 @@ const projectContextMenuScript = fs.readFileSync(
     path.join(__dirname, '../../src/webview/webviewProjectContextMenuScripts.js'),
     'utf8'
 );
+const projectAiUpdateScript = fs.readFileSync(
+    path.join(__dirname, '../../src/webview/webviewProjectAiUpdateScripts.js'),
+    'utf8'
+);
 const projectScript = fs.readFileSync(
     path.join(__dirname, '../../src/webview/webviewProjectScripts.js'),
     'utf8'
@@ -83,6 +87,7 @@ test('TODO-SINGLE-CREATE-DISPATCH-001 submits one group composer through only th
     await page.addScriptTag({ content: projectCollapseScript });
     await page.addScriptTag({ content: todoControlScript });
     await page.addScriptTag({ content: projectContextMenuScript });
+    await page.addScriptTag({ content: projectAiUpdateScript });
     await page.addScriptTag({ content: projectScript });
     await page.addScriptTag({ content: todoScript });
     await page.evaluate(value => {

--- a/tests/browser/todoCreation.test.js
+++ b/tests/browser/todoCreation.test.js
@@ -24,6 +24,10 @@ const projectCollapseScript = fs.readFileSync(
     path.join(__dirname, '../../src/webview/webviewProjectCollapseScripts.js'),
     'utf8'
 );
+const todoControlScript = fs.readFileSync(
+    path.join(__dirname, '../../src/webview/webviewTodoControlScripts.js'),
+    'utf8'
+);
 const projectScript = fs.readFileSync(
     path.join(__dirname, '../../src/webview/webviewProjectScripts.js'),
     'utf8'
@@ -73,6 +77,7 @@ test('TODO-SINGLE-CREATE-DISPATCH-001 submits one group composer through only th
     await page.addScriptTag({ content: workspaceUpdateScript });
     await page.addScriptTag({ content: todoGroupScript });
     await page.addScriptTag({ content: projectCollapseScript });
+    await page.addScriptTag({ content: todoControlScript });
     await page.addScriptTag({ content: projectScript });
     await page.addScriptTag({ content: todoScript });
     await page.evaluate(value => {

--- a/tests/browser/todoCreation.test.js
+++ b/tests/browser/todoCreation.test.js
@@ -36,6 +36,10 @@ const projectAiUpdateScript = fs.readFileSync(
     path.join(__dirname, '../../src/webview/webviewProjectAiUpdateScripts.js'),
     'utf8'
 );
+const aiSessionControlsScript = fs.readFileSync(
+    path.join(__dirname, '../../src/webview/webviewProjectAiSessionControlsScripts.js'),
+    'utf8'
+);
 const projectScript = fs.readFileSync(
     path.join(__dirname, '../../src/webview/webviewProjectScripts.js'),
     'utf8'
@@ -88,6 +92,7 @@ test('TODO-SINGLE-CREATE-DISPATCH-001 submits one group composer through only th
     await page.addScriptTag({ content: todoControlScript });
     await page.addScriptTag({ content: projectContextMenuScript });
     await page.addScriptTag({ content: projectAiUpdateScript });
+    await page.addScriptTag({ content: aiSessionControlsScript });
     await page.addScriptTag({ content: projectScript });
     await page.addScriptTag({ content: todoScript });
     await page.evaluate(value => {

--- a/tests/browser/todoCreation.test.js
+++ b/tests/browser/todoCreation.test.js
@@ -28,6 +28,10 @@ const todoControlScript = fs.readFileSync(
     path.join(__dirname, '../../src/webview/webviewTodoControlScripts.js'),
     'utf8'
 );
+const projectContextMenuScript = fs.readFileSync(
+    path.join(__dirname, '../../src/webview/webviewProjectContextMenuScripts.js'),
+    'utf8'
+);
 const projectScript = fs.readFileSync(
     path.join(__dirname, '../../src/webview/webviewProjectScripts.js'),
     'utf8'
@@ -78,6 +82,7 @@ test('TODO-SINGLE-CREATE-DISPATCH-001 submits one group composer through only th
     await page.addScriptTag({ content: todoGroupScript });
     await page.addScriptTag({ content: projectCollapseScript });
     await page.addScriptTag({ content: todoControlScript });
+    await page.addScriptTag({ content: projectContextMenuScript });
     await page.addScriptTag({ content: projectScript });
     await page.addScriptTag({ content: todoScript });
     await page.evaluate(value => {

--- a/tests/browser/todoCreation.test.js
+++ b/tests/browser/todoCreation.test.js
@@ -20,6 +20,10 @@ const todoGroupScript = fs.readFileSync(
     path.join(__dirname, '../../src/webview/webviewTodoGroupScripts.js'),
     'utf8'
 );
+const projectCollapseScript = fs.readFileSync(
+    path.join(__dirname, '../../src/webview/webviewProjectCollapseScripts.js'),
+    'utf8'
+);
 const projectScript = fs.readFileSync(
     path.join(__dirname, '../../src/webview/webviewProjectScripts.js'),
     'utf8'
@@ -68,6 +72,7 @@ test('TODO-SINGLE-CREATE-DISPATCH-001 submits one group composer through only th
     await page.addScriptTag({ content: viewStateScript });
     await page.addScriptTag({ content: workspaceUpdateScript });
     await page.addScriptTag({ content: todoGroupScript });
+    await page.addScriptTag({ content: projectCollapseScript });
     await page.addScriptTag({ content: projectScript });
     await page.addScriptTag({ content: todoScript });
     await page.evaluate(value => {

--- a/tests/integration/dashboard/openProjectFlow.test.js
+++ b/tests/integration/dashboard/openProjectFlow.test.js
@@ -46,6 +46,10 @@ const projectCollapseWebviewSource = fs.readFileSync(path.join(
     repositoryRoot,
     'src', 'webview', 'webviewProjectCollapseScripts.js'
 ), 'utf8');
+const todoControlWebviewSource = fs.readFileSync(path.join(
+    repositoryRoot,
+    'src', 'webview', 'webviewTodoControlScripts.js'
+), 'utf8');
 const filterWebviewSource = fs.readFileSync(path.join(
     repositoryRoot,
     'src', 'webview', 'webviewFilterScripts.js'
@@ -137,6 +141,9 @@ function createOpenWorkspaceUpdateVm(wrapper, catalogs) {
     });
     vm.runInNewContext(projectCollapseWebviewSource, context, {
         filename: 'webviewProjectCollapseScripts.js',
+    });
+    vm.runInNewContext(todoControlWebviewSource, context, {
+        filename: 'webviewTodoControlScripts.js',
     });
     vm.runInNewContext(projectWebviewSource, context, {
         filename: 'webviewProjectScripts.js',

--- a/tests/integration/dashboard/openProjectFlow.test.js
+++ b/tests/integration/dashboard/openProjectFlow.test.js
@@ -54,6 +54,10 @@ const projectContextMenuWebviewSource = fs.readFileSync(path.join(
     repositoryRoot,
     'src', 'webview', 'webviewProjectContextMenuScripts.js'
 ), 'utf8');
+const projectAiUpdateWebviewSource = fs.readFileSync(path.join(
+    repositoryRoot,
+    'src', 'webview', 'webviewProjectAiUpdateScripts.js'
+), 'utf8');
 const filterWebviewSource = fs.readFileSync(path.join(
     repositoryRoot,
     'src', 'webview', 'webviewFilterScripts.js'
@@ -151,6 +155,9 @@ function createOpenWorkspaceUpdateVm(wrapper, catalogs) {
     });
     vm.runInNewContext(projectContextMenuWebviewSource, context, {
         filename: 'webviewProjectContextMenuScripts.js',
+    });
+    vm.runInNewContext(projectAiUpdateWebviewSource, context, {
+        filename: 'webviewProjectAiUpdateScripts.js',
     });
     vm.runInNewContext(projectWebviewSource, context, {
         filename: 'webviewProjectScripts.js',

--- a/tests/integration/dashboard/openProjectFlow.test.js
+++ b/tests/integration/dashboard/openProjectFlow.test.js
@@ -58,6 +58,10 @@ const projectAiUpdateWebviewSource = fs.readFileSync(path.join(
     repositoryRoot,
     'src', 'webview', 'webviewProjectAiUpdateScripts.js'
 ), 'utf8');
+const aiSessionControlsWebviewSource = fs.readFileSync(path.join(
+    repositoryRoot,
+    'src', 'webview', 'webviewProjectAiSessionControlsScripts.js'
+), 'utf8');
 const filterWebviewSource = fs.readFileSync(path.join(
     repositoryRoot,
     'src', 'webview', 'webviewFilterScripts.js'
@@ -158,6 +162,9 @@ function createOpenWorkspaceUpdateVm(wrapper, catalogs) {
     });
     vm.runInNewContext(projectAiUpdateWebviewSource, context, {
         filename: 'webviewProjectAiUpdateScripts.js',
+    });
+    vm.runInNewContext(aiSessionControlsWebviewSource, context, {
+        filename: 'webviewProjectAiSessionControlsScripts.js',
     });
     vm.runInNewContext(projectWebviewSource, context, {
         filename: 'webviewProjectScripts.js',

--- a/tests/integration/dashboard/openProjectFlow.test.js
+++ b/tests/integration/dashboard/openProjectFlow.test.js
@@ -42,6 +42,10 @@ const todoGroupWebviewSource = fs.readFileSync(path.join(
     repositoryRoot,
     'src', 'webview', 'webviewTodoGroupScripts.js'
 ), 'utf8');
+const projectCollapseWebviewSource = fs.readFileSync(path.join(
+    repositoryRoot,
+    'src', 'webview', 'webviewProjectCollapseScripts.js'
+), 'utf8');
 const filterWebviewSource = fs.readFileSync(path.join(
     repositoryRoot,
     'src', 'webview', 'webviewFilterScripts.js'
@@ -130,6 +134,9 @@ function createOpenWorkspaceUpdateVm(wrapper, catalogs) {
     });
     vm.runInNewContext(todoGroupWebviewSource, context, {
         filename: 'webviewTodoGroupScripts.js',
+    });
+    vm.runInNewContext(projectCollapseWebviewSource, context, {
+        filename: 'webviewProjectCollapseScripts.js',
     });
     vm.runInNewContext(projectWebviewSource, context, {
         filename: 'webviewProjectScripts.js',

--- a/tests/integration/dashboard/openProjectFlow.test.js
+++ b/tests/integration/dashboard/openProjectFlow.test.js
@@ -50,6 +50,10 @@ const todoControlWebviewSource = fs.readFileSync(path.join(
     repositoryRoot,
     'src', 'webview', 'webviewTodoControlScripts.js'
 ), 'utf8');
+const projectContextMenuWebviewSource = fs.readFileSync(path.join(
+    repositoryRoot,
+    'src', 'webview', 'webviewProjectContextMenuScripts.js'
+), 'utf8');
 const filterWebviewSource = fs.readFileSync(path.join(
     repositoryRoot,
     'src', 'webview', 'webviewFilterScripts.js'
@@ -144,6 +148,9 @@ function createOpenWorkspaceUpdateVm(wrapper, catalogs) {
     });
     vm.runInNewContext(todoControlWebviewSource, context, {
         filename: 'webviewTodoControlScripts.js',
+    });
+    vm.runInNewContext(projectContextMenuWebviewSource, context, {
+        filename: 'webviewProjectContextMenuScripts.js',
     });
     vm.runInNewContext(projectWebviewSource, context, {
         filename: 'webviewProjectScripts.js',

--- a/tests/integration/dashboard/todoInteraction.test.js
+++ b/tests/integration/dashboard/todoInteraction.test.js
@@ -14,6 +14,10 @@ const projectSource = fs.readFileSync(
     path.join(__dirname, '../../../src/webview/webviewProjectScripts.js'),
     'utf8'
 );
+const todoControlSource = fs.readFileSync(
+    path.join(__dirname, '../../../src/webview/webviewTodoControlScripts.js'),
+    'utf8'
+);
 const dashboardSource = fs.readFileSync(
     path.join(__dirname, '../../../src/webview/webviewDashboardScripts.js'),
     'utf8'
@@ -1085,7 +1089,8 @@ test('TODO-FOCUSED-DETAIL-001 keeps inline editing open when form whitespace is 
 });
 
 test('TODO-INCREMENTAL-ROOT-001 isolates mounted TODO events from the legacy project controller', () => {
-    assert.match(projectSource, /isDedicatedTodoTarget/);
-    assert.match(projectSource, /window\.__agentPivotTodo/);
+    assert.match(projectSource, /todoControls\.isDedicatedTodoTarget/);
+    assert.match(todoControlSource, /isDedicatedTodoTarget/);
+    assert.match(todoControlSource, /window\.__agentPivotTodo/);
     assert.match(dashboardSource, /options\.onTodoMounted\(panels\.todo,\s*message\)/);
 });

--- a/tests/integration/dashboard/webviewState.test.js
+++ b/tests/integration/dashboard/webviewState.test.js
@@ -23,7 +23,9 @@ const workspaceUpdateSource = fs.readFileSync(path.join(root, 'src', 'webview', 
 const generatedWorkspaceUpdateSource = fs.readFileSync(path.join(root, 'media', 'webviewWorkspaceUpdateScripts.js'), 'utf8');
 const todoGroupSource = fs.readFileSync(path.join(root, 'src', 'webview', 'webviewTodoGroupScripts.js'), 'utf8');
 const generatedTodoGroupSource = fs.readFileSync(path.join(root, 'media', 'webviewTodoGroupScripts.js'), 'utf8');
-const projectVmSource = `${viewStateSource}\n${workspaceUpdateSource}\n${todoGroupSource}\n${projectSource}`;
+const projectCollapseSource = fs.readFileSync(path.join(root, 'src', 'webview', 'webviewProjectCollapseScripts.js'), 'utf8');
+const generatedProjectCollapseSource = fs.readFileSync(path.join(root, 'media', 'webviewProjectCollapseScripts.js'), 'utf8');
+const projectVmSource = `${viewStateSource}\n${workspaceUpdateSource}\n${todoGroupSource}\n${projectCollapseSource}\n${projectSource}`;
 const scrollStateSource = fs.readFileSync(path.join(root, 'src', 'webview', 'webviewScrollStateScripts.js'), 'utf8');
 const promptSource = fs.readFileSync(path.join(root, 'src', 'webview', 'webviewPromptScripts.js'), 'utf8');
 const generatedPromptPath = path.join(root, 'media', 'webviewPromptScripts.js');
@@ -891,6 +893,7 @@ test('WEBVIEW-RESOURCE-RECOVERY-001 gives every rendered document fresh versione
         'webviewAiSessionViewStateScripts.js',
         'webviewWorkspaceUpdateScripts.js',
         'webviewTodoGroupScripts.js',
+        'webviewProjectCollapseScripts.js',
         'webviewProjectScripts.js',
         'webviewDashboardScripts.js',
         'webviewPromptScripts.js',

--- a/tests/integration/dashboard/webviewState.test.js
+++ b/tests/integration/dashboard/webviewState.test.js
@@ -29,7 +29,9 @@ const todoControlSource = fs.readFileSync(path.join(root, 'src', 'webview', 'web
 const generatedTodoControlSource = fs.readFileSync(path.join(root, 'media', 'webviewTodoControlScripts.js'), 'utf8');
 const projectContextMenuSource = fs.readFileSync(path.join(root, 'src', 'webview', 'webviewProjectContextMenuScripts.js'), 'utf8');
 const generatedProjectContextMenuSource = fs.readFileSync(path.join(root, 'media', 'webviewProjectContextMenuScripts.js'), 'utf8');
-const projectVmSource = `${viewStateSource}\n${workspaceUpdateSource}\n${todoGroupSource}\n${projectCollapseSource}\n${todoControlSource}\n${projectContextMenuSource}\n${projectSource}`;
+const projectAiUpdateSource = fs.readFileSync(path.join(root, 'src', 'webview', 'webviewProjectAiUpdateScripts.js'), 'utf8');
+const generatedProjectAiUpdateSource = fs.readFileSync(path.join(root, 'media', 'webviewProjectAiUpdateScripts.js'), 'utf8');
+const projectVmSource = `${viewStateSource}\n${workspaceUpdateSource}\n${todoGroupSource}\n${projectCollapseSource}\n${todoControlSource}\n${projectContextMenuSource}\n${projectAiUpdateSource}\n${projectSource}`;
 const scrollStateSource = fs.readFileSync(path.join(root, 'src', 'webview', 'webviewScrollStateScripts.js'), 'utf8');
 const promptSource = fs.readFileSync(path.join(root, 'src', 'webview', 'webviewPromptScripts.js'), 'utf8');
 const generatedPromptPath = path.join(root, 'media', 'webviewPromptScripts.js');
@@ -900,6 +902,7 @@ test('WEBVIEW-RESOURCE-RECOVERY-001 gives every rendered document fresh versione
         'webviewProjectCollapseScripts.js',
         'webviewTodoControlScripts.js',
         'webviewProjectContextMenuScripts.js',
+        'webviewProjectAiUpdateScripts.js',
         'webviewProjectScripts.js',
         'webviewDashboardScripts.js',
         'webviewPromptScripts.js',

--- a/tests/integration/dashboard/webviewState.test.js
+++ b/tests/integration/dashboard/webviewState.test.js
@@ -25,7 +25,9 @@ const todoGroupSource = fs.readFileSync(path.join(root, 'src', 'webview', 'webvi
 const generatedTodoGroupSource = fs.readFileSync(path.join(root, 'media', 'webviewTodoGroupScripts.js'), 'utf8');
 const projectCollapseSource = fs.readFileSync(path.join(root, 'src', 'webview', 'webviewProjectCollapseScripts.js'), 'utf8');
 const generatedProjectCollapseSource = fs.readFileSync(path.join(root, 'media', 'webviewProjectCollapseScripts.js'), 'utf8');
-const projectVmSource = `${viewStateSource}\n${workspaceUpdateSource}\n${todoGroupSource}\n${projectCollapseSource}\n${projectSource}`;
+const todoControlSource = fs.readFileSync(path.join(root, 'src', 'webview', 'webviewTodoControlScripts.js'), 'utf8');
+const generatedTodoControlSource = fs.readFileSync(path.join(root, 'media', 'webviewTodoControlScripts.js'), 'utf8');
+const projectVmSource = `${viewStateSource}\n${workspaceUpdateSource}\n${todoGroupSource}\n${projectCollapseSource}\n${todoControlSource}\n${projectSource}`;
 const scrollStateSource = fs.readFileSync(path.join(root, 'src', 'webview', 'webviewScrollStateScripts.js'), 'utf8');
 const promptSource = fs.readFileSync(path.join(root, 'src', 'webview', 'webviewPromptScripts.js'), 'utf8');
 const generatedPromptPath = path.join(root, 'media', 'webviewPromptScripts.js');
@@ -894,6 +896,7 @@ test('WEBVIEW-RESOURCE-RECOVERY-001 gives every rendered document fresh versione
         'webviewWorkspaceUpdateScripts.js',
         'webviewTodoGroupScripts.js',
         'webviewProjectCollapseScripts.js',
+        'webviewTodoControlScripts.js',
         'webviewProjectScripts.js',
         'webviewDashboardScripts.js',
         'webviewPromptScripts.js',

--- a/tests/integration/dashboard/webviewState.test.js
+++ b/tests/integration/dashboard/webviewState.test.js
@@ -27,7 +27,9 @@ const projectCollapseSource = fs.readFileSync(path.join(root, 'src', 'webview', 
 const generatedProjectCollapseSource = fs.readFileSync(path.join(root, 'media', 'webviewProjectCollapseScripts.js'), 'utf8');
 const todoControlSource = fs.readFileSync(path.join(root, 'src', 'webview', 'webviewTodoControlScripts.js'), 'utf8');
 const generatedTodoControlSource = fs.readFileSync(path.join(root, 'media', 'webviewTodoControlScripts.js'), 'utf8');
-const projectVmSource = `${viewStateSource}\n${workspaceUpdateSource}\n${todoGroupSource}\n${projectCollapseSource}\n${todoControlSource}\n${projectSource}`;
+const projectContextMenuSource = fs.readFileSync(path.join(root, 'src', 'webview', 'webviewProjectContextMenuScripts.js'), 'utf8');
+const generatedProjectContextMenuSource = fs.readFileSync(path.join(root, 'media', 'webviewProjectContextMenuScripts.js'), 'utf8');
+const projectVmSource = `${viewStateSource}\n${workspaceUpdateSource}\n${todoGroupSource}\n${projectCollapseSource}\n${todoControlSource}\n${projectContextMenuSource}\n${projectSource}`;
 const scrollStateSource = fs.readFileSync(path.join(root, 'src', 'webview', 'webviewScrollStateScripts.js'), 'utf8');
 const promptSource = fs.readFileSync(path.join(root, 'src', 'webview', 'webviewPromptScripts.js'), 'utf8');
 const generatedPromptPath = path.join(root, 'media', 'webviewPromptScripts.js');
@@ -897,6 +899,7 @@ test('WEBVIEW-RESOURCE-RECOVERY-001 gives every rendered document fresh versione
         'webviewTodoGroupScripts.js',
         'webviewProjectCollapseScripts.js',
         'webviewTodoControlScripts.js',
+        'webviewProjectContextMenuScripts.js',
         'webviewProjectScripts.js',
         'webviewDashboardScripts.js',
         'webviewPromptScripts.js',

--- a/tests/integration/dashboard/webviewState.test.js
+++ b/tests/integration/dashboard/webviewState.test.js
@@ -31,7 +31,9 @@ const projectContextMenuSource = fs.readFileSync(path.join(root, 'src', 'webview
 const generatedProjectContextMenuSource = fs.readFileSync(path.join(root, 'media', 'webviewProjectContextMenuScripts.js'), 'utf8');
 const projectAiUpdateSource = fs.readFileSync(path.join(root, 'src', 'webview', 'webviewProjectAiUpdateScripts.js'), 'utf8');
 const generatedProjectAiUpdateSource = fs.readFileSync(path.join(root, 'media', 'webviewProjectAiUpdateScripts.js'), 'utf8');
-const projectVmSource = `${viewStateSource}\n${workspaceUpdateSource}\n${todoGroupSource}\n${projectCollapseSource}\n${todoControlSource}\n${projectContextMenuSource}\n${projectAiUpdateSource}\n${projectSource}`;
+const aiSessionControlsSource = fs.readFileSync(path.join(root, 'src', 'webview', 'webviewProjectAiSessionControlsScripts.js'), 'utf8');
+const generatedAiSessionControlsSource = fs.readFileSync(path.join(root, 'media', 'webviewProjectAiSessionControlsScripts.js'), 'utf8');
+const projectVmSource = `${viewStateSource}\n${workspaceUpdateSource}\n${todoGroupSource}\n${projectCollapseSource}\n${todoControlSource}\n${projectContextMenuSource}\n${projectAiUpdateSource}\n${aiSessionControlsSource}\n${projectSource}`;
 const scrollStateSource = fs.readFileSync(path.join(root, 'src', 'webview', 'webviewScrollStateScripts.js'), 'utf8');
 const promptSource = fs.readFileSync(path.join(root, 'src', 'webview', 'webviewPromptScripts.js'), 'utf8');
 const generatedPromptPath = path.join(root, 'media', 'webviewPromptScripts.js');
@@ -640,21 +642,22 @@ test('WEBVIEW-MULTI-PROVIDER-SESSION-HISTORY-001 renders one availability summar
 });
 
 test('WEBVIEW-MULTI-PROVIDER-SESSION-MENU-001 keeps the generated provider-menu controller boundary exact', () => {
-    assert.equal(generatedProjectSource, projectSource);
-    assert.match(projectSource, /function getSelectedAiSessionProviders\(projectDiv\)/);
-    assert.match(projectSource, /function submitAiSessionProviderSelection\(projectDiv, providers\)/);
-    assert.match(projectSource, /type: 'select-ai-session-providers'/);
-    assert.match(projectSource, /function applyAiSessionProviderSelectionResult\(message\)/);
-    assert.match(projectSource, /message\.type !== 'ai-session-provider-selection-result'/);
-    assert.match(projectSource, /requestId: requestId/);
-    assert.match(projectSource, /selectedProviders: providers/);
-    assert.match(projectSource, /pendingAiSessionProviderSelectionProjectId/);
-    assert.match(projectSource, /pendingAiSessionProviderSelectionRequestId/);
+    assert.equal(generatedAiSessionControlsSource, aiSessionControlsSource);
+    assert.match(aiSessionControlsSource, /function getSelectedAiSessionProviders\(projectDiv\)/);
+    assert.match(aiSessionControlsSource, /function submitAiSessionProviderSelection\(projectDiv, providers\)/);
+    assert.match(aiSessionControlsSource, /type: 'select-ai-session-providers'/);
+    assert.match(aiSessionControlsSource, /function applyAiSessionProviderSelectionResult\(message\)/);
+    assert.match(aiSessionControlsSource, /message\.type !== 'ai-session-provider-selection-result'/);
+    assert.match(aiSessionControlsSource, /requestId: requestId/);
+    assert.match(aiSessionControlsSource, /selectedProviders: providers/);
+    assert.match(aiSessionControlsSource, /pendingAiSessionProviderSelectionProjectId/);
+    assert.match(aiSessionControlsSource, /pendingAiSessionProviderSelectionRequestId/);
     assert.match(
         fs.readFileSync(path.join(root, 'src', 'dashboard.ts'), 'utf8'),
         /e\.selectedProviders,\s*e\.requestId,\s*e\.version/
     );
     assert.doesNotMatch(projectSource, /type: 'select-ai-session-provider'/);
+    assert.doesNotMatch(aiSessionControlsSource, /type: 'select-ai-session-provider'/);
 });
 
 test('ACTIVE-SESSION-CONVERSATION-OPEN-001 posts an open request for a focused active session in the generated controller', () => {
@@ -903,6 +906,7 @@ test('WEBVIEW-RESOURCE-RECOVERY-001 gives every rendered document fresh versione
         'webviewTodoControlScripts.js',
         'webviewProjectContextMenuScripts.js',
         'webviewProjectAiUpdateScripts.js',
+        'webviewProjectAiSessionControlsScripts.js',
         'webviewProjectScripts.js',
         'webviewDashboardScripts.js',
         'webviewPromptScripts.js',

--- a/tests/unit/tooling/architectureGuards.test.js
+++ b/tests/unit/tooling/architectureGuards.test.js
@@ -56,6 +56,7 @@ function copyGuardFixture(t, mutationPath, mutate = source => source) {
         'src/webview/webviewTodoControlScripts.js',
         'src/webview/webviewProjectContextMenuScripts.js',
         'src/webview/webviewProjectAiUpdateScripts.js',
+        'src/webview/webviewProjectAiSessionControlsScripts.js',
         'src/webview/webviewProjectScripts.js',
         'src/webview/conversationViewerScripts.js',
         'src/aiSessions/attentionController.ts',

--- a/tests/unit/tooling/architectureGuards.test.js
+++ b/tests/unit/tooling/architectureGuards.test.js
@@ -53,6 +53,7 @@ function copyGuardFixture(t, mutationPath, mutate = source => source) {
         'src/webview/webviewWorkspaceUpdateScripts.js',
         'src/webview/webviewTodoGroupScripts.js',
         'src/webview/webviewProjectCollapseScripts.js',
+        'src/webview/webviewTodoControlScripts.js',
         'src/webview/webviewProjectScripts.js',
         'src/webview/conversationViewerScripts.js',
         'src/aiSessions/attentionController.ts',

--- a/tests/unit/tooling/architectureGuards.test.js
+++ b/tests/unit/tooling/architectureGuards.test.js
@@ -55,6 +55,7 @@ function copyGuardFixture(t, mutationPath, mutate = source => source) {
         'src/webview/webviewProjectCollapseScripts.js',
         'src/webview/webviewTodoControlScripts.js',
         'src/webview/webviewProjectContextMenuScripts.js',
+        'src/webview/webviewProjectAiUpdateScripts.js',
         'src/webview/webviewProjectScripts.js',
         'src/webview/conversationViewerScripts.js',
         'src/aiSessions/attentionController.ts',

--- a/tests/unit/tooling/architectureGuards.test.js
+++ b/tests/unit/tooling/architectureGuards.test.js
@@ -54,6 +54,7 @@ function copyGuardFixture(t, mutationPath, mutate = source => source) {
         'src/webview/webviewTodoGroupScripts.js',
         'src/webview/webviewProjectCollapseScripts.js',
         'src/webview/webviewTodoControlScripts.js',
+        'src/webview/webviewProjectContextMenuScripts.js',
         'src/webview/webviewProjectScripts.js',
         'src/webview/conversationViewerScripts.js',
         'src/aiSessions/attentionController.ts',

--- a/tests/unit/tooling/architectureGuards.test.js
+++ b/tests/unit/tooling/architectureGuards.test.js
@@ -52,6 +52,7 @@ function copyGuardFixture(t, mutationPath, mutate = source => source) {
         'src/webview/webviewAiSessionViewStateScripts.js',
         'src/webview/webviewWorkspaceUpdateScripts.js',
         'src/webview/webviewTodoGroupScripts.js',
+        'src/webview/webviewProjectCollapseScripts.js',
         'src/webview/webviewProjectScripts.js',
         'src/webview/conversationViewerScripts.js',
         'src/aiSessions/attentionController.ts',


### PR DESCRIPTION
## 概述

`initProjects()`（~2000 行、75 个闭包共享 19 个状态变量）按子系统拆为 5 个 `initProjectXxx(options)` 工厂（对齐既有 `initTodos` 模式），`initProjects` 瘦身为组合根。这是 webviewProjectScripts.js 模块化的第二阶段（第一阶段 #77 已将其余顶层子系统拆出）。

| 提交 | 工厂 / 新文件 | 内容 | 规模 |
|---|---|---|---|
| 82bb63d | `initProjectGroupCollapse` / `webviewProjectCollapseScripts.js` | 组折叠控件 6 闭包 | 108 行 |
| 4c542b0 | `initProjectTodoControls` / `webviewTodoControlScripts.js` | TODO 交互 11 闭包 | 322 行 |
| 100fcee | `initProjectContextMenus` / `webviewProjectContextMenuScripts.js` | 上下文菜单 7 闭包 + 9 个私有状态 | 297 行 |
| e40efc4 | `initProjectAiSessionsUpdate` / `webviewProjectAiUpdateScripts.js` | ai-sessions 更新/工作区 reveal 6 闭包 | 183 行 |
| 059af49 | `initProjectAiSessionControls` / `webviewProjectAiSessionControlsScripts.js` | batch 管理 + provider 菜单 + 会话操作 36 闭包 + 7 个共享状态 | 701 行 |

**`webviewProjectScripts.js`：2167 → 715 行**（累计 4117 → 715，-83%）。组合根保留 ProjectOpenType、open-click、events 中枢与事件接线。

## 零行为变化的证据

- 函数体去缩进后逐字比对全部一致（python difflib）；仅两类白名单差异：跨组调用点 `foo(...)` → `handle.foo(...)`（逐一列出核对）、三角组循环依赖用 `getAiSessionsUpdate()` 惰性解析（3 处）
- 共享状态仅 3 个且均为字段级修改：对象身份经组合根传递（`batchAiSessionState` / `activeAiSessionTerminalState`），标量 `pendingAiSessionProviderSelectionProjectId` 由工厂持有 + getter 暴露
- window 全局暴露全部保留原位（`__agentPivotBatchAiSessions`、`__agentPivotSyncCollapseButton`、`__agentPivotAcknowledgeSession`、`__agentPivotRevealWorkspace*`）
- 每轮独立全门禁：test-compile、unit(525)、integration、browser(Playwright)、dashboard/safety/architecture/tmux/skill/workspace-parity 检查、changed-coverage 100%、lint:ci、release-packaging（VSIX）
- c33f017 收口 audit：5 个实现提交登记到 MAIN-WORKSPACE-WEBVIEW / MAIN-TODO-CONTINUOUS-EXPERIENCE / MAIN-RUNTIME-SESSION-RECOVERY

## 修复的断言迁移

内容断言随代码迁移同步更新到对应新文件（webviewState 的 provider-menu 边界、todoInteraction 的 TODO 隔离、tmux/skill/safety 的拼接读取），断言语义零变化。

Co-Authored-By: Kimi <noreply@moonshot.cn>