### PR TITLE
feat: show the session's current worktree in the conversation usage bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ All notable changes to the "Agent Pivot" extension will be documented in this fi
   reports context-window usage from its wire-protocol status updates, and
   Claude reports the current model and context-window usage from assistant
   usage records.
+- The AI Conversation usage bar now shows a worktree chip for the Session's
+  current operating worktree (resolved from Claude event directories, Codex
+  exec workdirs, and Kimi shell paths, falling back to the launch directory).
+  Clicking the chip mounts the worktree in Source Control and focuses the
+  view; deleted worktrees degrade to a struck-through label.
 
 ### Changed
 

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -3952,7 +3952,7 @@
   {
     "id": "CONVERSATION-TELEMETRY-001",
     "domain": "webview",
-    "title": "AI Conversation shows correlated provider model, context-window usage, and quota windows without replacing conversation content or accepting stale Session data",
+    "title": "AI Conversation shows correlated provider model, current worktree, context-window usage, and quota windows without replacing conversation content or accepting stale Session data",
     "priority": "P1",
     "status": "automated",
     "owners": [
@@ -3960,13 +3960,19 @@
       "tests/contract/aiSessions/codexConversationAdapter.test.js",
       "tests/contract/aiSessions/kimiConversationAdapter.test.js",
       "tests/contract/aiSessions/claudeConversationAdapter.test.js",
+      "tests/unit/aiSessions/codexRolloutWorkdir.test.js",
       "tests/browser/conversationViewer.test.js"
     ],
     "evidence": [
       "src/aiSessions/conversation/codexAdapter.ts",
       "src/aiSessions/conversation/kimiAdapter.ts",
       "src/aiSessions/conversation/claudeAdapter.ts",
+      "src/aiSessions/conversation/composition.ts",
       "src/aiSessions/conversation/viewer.ts",
+      "src/aiSessions/conversation/viewerProtocol.ts",
+      "src/aiSessions/conversation/worktreeResolver.ts",
+      "src/aiSessions/codexRolloutWorkdir.ts",
+      "src/services/sourceControl.ts",
       "src/webview/conversationViewerScripts.js",
       "media/conversationTelemetry.css"
     ]
@@ -4472,6 +4478,19 @@
     "evidence": [
       "src/aiSessions/notifyIntegration/commands.ts",
       "src/aiSessions/notifyIntegration/output.ts"
+    ]
+  },
+  {
+    "id": "ARCH-SESSION-WORKTREE-001",
+    "domain": "session",
+    "title": "Session worktree resolution maps operating paths to git worktrees across main checkouts, linked worktrees, and detached HEAD",
+    "priority": "P1",
+    "status": "automated",
+    "owners": [
+      "tests/unit/aiSessions/conversationWorktreeResolver.test.js"
+    ],
+    "evidence": [
+      "src/aiSessions/conversation/worktreeResolver.ts"
     ]
   }
 ]

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "06cb9f4375a9e10e3629a113f6e9cf239cce2156",
+        "head": "95248ccfca2df7faa03edf29b976d9f2a5117bae",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -70,7 +70,8 @@
             "84fec3d7d526cdad870da72a344138014c81ed59",
             "6ede7190457603c7d15ac89aa4bec4f3e18ef26a",
             "25d3f08a274f3ac0fe59015202f3b0d34b5b39d1",
-            "2442db899536f40b04d19d8679fc0d427d6367eb"
+            "2442db899536f40b04d19d8679fc0d427d6367eb",
+            "b6d312cf7537442c982aa84b4d0fef4e2c715e14"
         ]
     },
     "capabilities": [
@@ -1060,7 +1061,8 @@
                 "1eb53a01f70d35e71c42962a4f7f9291599eba7f",
                 "5f62d257ae68aec8fa8e76a7066802aaf9a1b5f3",
                 "e5796c73622355abd81a4e854a4a3b1d1e2bad70",
-                "06cb9f4375a9e10e3629a113f6e9cf239cce2156"
+                "06cb9f4375a9e10e3629a113f6e9cf239cce2156",
+                "95248ccfca2df7faa03edf29b976d9f2a5117bae"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "0ef3ebbe9d1fd66b8b88f43f1047614f8e2b52df",
+        "head": "06cb9f4375a9e10e3629a113f6e9cf239cce2156",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -69,7 +69,8 @@
             "256480b81ec57eef6f12f470715a26fc9a564065",
             "84fec3d7d526cdad870da72a344138014c81ed59",
             "6ede7190457603c7d15ac89aa4bec4f3e18ef26a",
-            "25d3f08a274f3ac0fe59015202f3b0d34b5b39d1"
+            "25d3f08a274f3ac0fe59015202f3b0d34b5b39d1",
+            "2442db899536f40b04d19d8679fc0d427d6367eb"
         ]
     },
     "capabilities": [
@@ -1058,7 +1059,8 @@
                 "fa20cec02b26c0b779e823e26fba87a99c03edb3",
                 "1eb53a01f70d35e71c42962a4f7f9291599eba7f",
                 "5f62d257ae68aec8fa8e76a7066802aaf9a1b5f3",
-                "e5796c73622355abd81a4e854a4a3b1d1e2bad70"
+                "e5796c73622355abd81a4e854a4a3b1d1e2bad70",
+                "06cb9f4375a9e10e3629a113f6e9cf239cce2156"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",

--- a/media/conversationTelemetry.css
+++ b/media/conversationTelemetry.css
@@ -47,3 +47,42 @@
 .conversation-telemetry-limits {
     display: contents;
 }
+
+.conversation-telemetry-worktree {
+    display: flex;
+    gap: .3rem;
+    align-items: center;
+    max-width: 16rem;
+    padding: .05rem .45rem;
+    border: 1px solid var(--vscode-panel-border);
+    border-radius: .55rem;
+    color: var(--vscode-editor-foreground);
+    background: transparent;
+    font: inherit;
+    cursor: pointer;
+}
+
+.conversation-telemetry-worktree:hover {
+    border-color: var(--vscode-focusBorder);
+    background: var(--vscode-toolbar-hoverBackground);
+}
+
+.conversation-telemetry-worktree svg {
+    flex: 0 0 auto;
+    color: var(--vscode-descriptionForeground);
+}
+
+.conversation-telemetry-worktree [data-telemetry-worktree-branch] {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.conversation-telemetry-worktree-missing {
+    opacity: .6;
+}
+
+.conversation-telemetry-worktree-missing
+    [data-telemetry-worktree-branch] {
+    text-decoration: line-through;
+}

--- a/media/conversationTelemetryScripts.js
+++ b/media/conversationTelemetryScripts.js
@@ -12,6 +12,8 @@
         var telemetryContextProgress = options.telemetryContextProgress;
         var telemetryContextValue = options.telemetryContextValue;
         var telemetryLimits = options.telemetryLimits;
+        var telemetryWorktree = options.telemetryWorktree;
+        var telemetryWorktreeBranch = options.telemetryWorktreeBranch;
         var scroll = options.scroll;
         var captureAnchor = options.captureAnchor;
         var restoreViewport = options.restoreViewport;
@@ -36,7 +38,7 @@
             if (!exactKeys(
                 value,
                 ['provider', 'sessionId', 'rateLimits'],
-                ['model', 'context']
+                ['model', 'context', 'worktree']
             )) return false;
             if (!['codex', 'kimi', 'claude'].includes(value.provider)
                 || typeof value.sessionId !== 'string'
@@ -56,6 +58,25 @@
                     || value.context.usedTokens < 0
                     || !Number.isSafeInteger(value.context.maxTokens)
                     || value.context.maxTokens <= 0)) {
+                return false;
+            }
+            if (value.worktree !== undefined
+                && (!exactKeys(
+                    value.worktree,
+                    ['branch', 'worktreeRoot', 'repoRoot'],
+                    ['missing']
+                )
+                    || typeof value.worktree.branch !== 'string'
+                    || !value.worktree.branch
+                    || value.worktree.branch.length > 128
+                    || typeof value.worktree.worktreeRoot !== 'string'
+                    || !value.worktree.worktreeRoot
+                    || value.worktree.worktreeRoot.length > 1024
+                    || typeof value.worktree.repoRoot !== 'string'
+                    || !value.worktree.repoRoot
+                    || value.worktree.repoRoot.length > 1024
+                    || (value.worktree.missing !== undefined
+                        && typeof value.worktree.missing !== 'boolean'))) {
                 return false;
             }
             return value.rateLimits.every(function (limit) {
@@ -122,7 +143,8 @@
                         || message.telemetry.sessionId !== commentTarget.sessionId))
                 || !telemetryRoot || !telemetryModel || !telemetryModelValue
                 || !telemetryContext || !telemetryContextProgress
-                || !telemetryContextValue || !telemetryLimits) {
+                || !telemetryContextValue || !telemetryLimits
+                || !telemetryWorktree || !telemetryWorktreeBranch) {
                 return false;
             }
             state.latestTelemetryRequestId = message.requestId;
@@ -139,6 +161,24 @@
             }
             telemetryModel.hidden = !telemetry.model;
             telemetryModelValue.textContent = telemetry.model || '';
+            var worktree = telemetry.worktree;
+            telemetryWorktree.hidden = !worktree;
+            if (worktree) {
+                telemetryWorktreeBranch.textContent = worktree.branch;
+                telemetryWorktree.setAttribute(
+                    'data-worktree-root',
+                    worktree.worktreeRoot
+                );
+                telemetryWorktree.classList.toggle(
+                    'conversation-telemetry-worktree-missing',
+                    !!worktree.missing
+                );
+                telemetryWorktree.title = worktree.missing
+                    ? 'Worktree path no longer exists: '
+                        + worktree.worktreeRoot
+                    : 'Working in worktree: ' + worktree.worktreeRoot
+                        + ' · Click to show changes in Source Control';
+            }
             telemetryContext.hidden = !telemetry.context;
             if (telemetry.context) {
                 var percent = Math.max(0, Math.min(
@@ -176,6 +216,7 @@
             });
             telemetryRoot.hidden = !telemetry.model
                 && !telemetry.context
+                && !worktree
                 && telemetry.rateLimits.length === 0;
             restoreViewport(readingAnchor, previousScrollTop);
             return true;

--- a/media/conversationViewerScripts.js
+++ b/media/conversationViewerScripts.js
@@ -45,6 +45,10 @@
         '[data-telemetry-context-value]'
     );
     var telemetryLimits = document.querySelector('[data-telemetry-limits]');
+    var telemetryWorktree = document.querySelector('[data-telemetry-worktree]');
+    var telemetryWorktreeBranch = document.querySelector(
+        '[data-telemetry-worktree-branch]'
+    );
     var newResponse = document.querySelector('[data-new-response]');
     var previous = document.querySelector('[data-action="previous"]');
     var next = document.querySelector('[data-action="next"]');
@@ -198,6 +202,8 @@
         telemetryContextProgress: telemetryContextProgress,
         telemetryContextValue: telemetryContextValue,
         telemetryLimits: telemetryLimits,
+        telemetryWorktree: telemetryWorktree,
+        telemetryWorktreeBranch: telemetryWorktreeBranch,
         scroll: scroll,
         captureAnchor: captureReadingAnchor,
         restoreViewport: restoreViewportReadingPosition,
@@ -602,6 +608,20 @@
     latest.addEventListener('click', function () {
         postNavigation('conversation-viewer-latest');
     });
+    if (telemetryWorktree) {
+        telemetryWorktree.addEventListener('click', function () {
+            var worktreeRoot = telemetryWorktree.getAttribute(
+                'data-worktree-root'
+            );
+            if (worktreeRoot) {
+                post({
+                    type: 'conversation-viewer-open-worktree',
+                    version: 1,
+                    worktreeRoot: worktreeRoot,
+                });
+            }
+        });
+    }
     close.addEventListener('click', function () {
         postNavigation('conversation-viewer-closed');
     });

--- a/src/aiSessions/codexRolloutWorkdir.ts
+++ b/src/aiSessions/codexRolloutWorkdir.ts
@@ -1,0 +1,44 @@
+'use strict';
+
+import { readJsonlTailLines } from './jsonlTail';
+
+const ROLLOUT_TAIL_BYTES = 256 * 1024;
+const WORKDIR_PATTERN = /\bworkdir\s*:\s*"([^"]+)"/;
+
+/**
+ * Telemetry-only probe: app-server does not expose exec items, so the latest
+ * exec workdir is read from the rollout transcript tail. Conversation content
+ * remains app-server-only; this probe never feeds messages or outline data.
+ */
+export function readCodexRolloutWorkdir(
+    rolloutPath: string
+): string | undefined {
+    if (!rolloutPath) {
+        return undefined;
+    }
+    const lines = readJsonlTailLines(rolloutPath, ROLLOUT_TAIL_BYTES);
+    for (let index = lines.length - 1; index >= 0; index--) {
+        const line = lines[index];
+        if (!line.includes('workdir')) {
+            continue;
+        }
+        let record: unknown;
+        try {
+            record = JSON.parse(line);
+        } catch (_error) {
+            continue;
+        }
+        const payload = (record as { payload?: unknown })?.payload;
+        const input = payload
+            && typeof payload === 'object'
+            && !Array.isArray(payload)
+            && typeof (payload as { input?: unknown }).input === 'string'
+            ? (payload as { input: string }).input
+            : '';
+        const match = WORKDIR_PATTERN.exec(input);
+        if (match?.[1]) {
+            return match[1];
+        }
+    }
+    return undefined;
+}

--- a/src/aiSessions/conversation/claudeAdapter.ts
+++ b/src/aiSessions/conversation/claudeAdapter.ts
@@ -37,6 +37,10 @@ import {
     openValidatedConversationSource,
     OpenConversationSource,
 } from './source';
+import type {
+    ConversationWorktreeInfo,
+    ResolveWorktree,
+} from './worktreeResolver';
 
 type TimerHandle = unknown;
 
@@ -48,6 +52,7 @@ export interface ClaudeConversationAdapterOptions {
     now(): number;
     setTimeout(callback: () => void, delayMs: number): TimerHandle;
     clearTimeout(handle: TimerHandle): void;
+    resolveWorktree?: ResolveWorktree;
 }
 
 type ConversationContextUsage = NonNullable<ConversationTelemetry['context']>;
@@ -63,6 +68,8 @@ interface ClaudeConversationIndex extends AiSessionDisposable {
     appendInteractionIndex?: number;
     telemetryModel?: string;
     telemetryContext?: ConversationContextUsage;
+    telemetryCwd?: string;
+    telemetryGitBranch?: string;
     revision: number;
     partial: boolean;
 }
@@ -73,6 +80,8 @@ interface LoadedConversation {
     partial: boolean;
     telemetryModel?: string;
     telemetryContext?: ConversationContextUsage;
+    telemetryCwd?: string;
+    telemetryGitBranch?: string;
 }
 
 function asRecord(value: unknown): Record<string, any> | undefined {
@@ -238,18 +247,45 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
         signal?: ConversationAbortSignal
     ): Promise<ConversationTelemetry | undefined> {
         const loaded = await this.load(sessionId, signal);
-        if (!loaded.telemetryModel && !loaded.telemetryContext) {
+        const worktree = await this.readWorktree(loaded);
+        if (!loaded.telemetryModel && !loaded.telemetryContext && !worktree) {
             return undefined;
         }
         return {
             provider: 'claude',
             sessionId,
             model: loaded.telemetryModel,
+            ...(worktree ? { worktree } : {}),
             context: loaded.telemetryContext
                 ? { ...loaded.telemetryContext }
                 : undefined,
             rateLimits: [],
         };
+    }
+
+    private async readWorktree(
+        loaded: LoadedConversation
+    ): Promise<ConversationWorktreeInfo | undefined> {
+        const cwd = loaded.telemetryCwd;
+        if (!cwd) {
+            return undefined;
+        }
+        if (this.options.resolveWorktree) {
+            const resolved = await this.options.resolveWorktree(cwd);
+            if (resolved) {
+                return resolved;
+            }
+        }
+        // The path is gone (worktree deleted) but Claude logs the branch.
+        if (loaded.telemetryGitBranch) {
+            return {
+                branch: loaded.telemetryGitBranch,
+                worktreeRoot: cwd,
+                repoRoot: cwd,
+                missing: true,
+            };
+        }
+        return undefined;
     }
 
     watch(sessionId: string, onChange: () => void): AiSessionDisposable {
@@ -328,6 +364,8 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
         let timeoutOpenInteractionIndex: number | undefined;
         let telemetryModel: string | undefined;
         let telemetryContext: ConversationContextUsage | undefined;
+        let telemetryCwd: string | undefined;
+        let telemetryGitBranch: string | undefined;
         try {
             const startOffset = await getConversationReadStart(
                 source,
@@ -343,6 +381,8 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
                 openInteractionIndex = previous.appendInteractionIndex;
                 telemetryModel = previous.telemetryModel;
                 telemetryContext = previous.telemetryContext;
+                telemetryCwd = previous.telemetryCwd;
+                telemetryGitBranch = previous.telemetryGitBranch;
             }
             const finishInteraction = (
                 state: 'complete' | 'interrupted' = 'complete'
@@ -359,6 +399,12 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
                     return;
                 }
                 const message = asRecord(event.message);
+                if (typeof event.cwd === 'string' && event.cwd) {
+                    telemetryCwd = event.cwd;
+                }
+                if (typeof event.gitBranch === 'string' && event.gitBranch) {
+                    telemetryGitBranch = event.gitBranch;
+                }
                 if (event.type === 'assistant'
                     && message?.role === 'assistant') {
                     if (typeof message.model === 'string'
@@ -453,6 +499,8 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
                     partial: true,
                     telemetryModel,
                     telemetryContext,
+                    telemetryCwd,
+                    telemetryGitBranch,
                 };
             }
             const appendInteractionIndex = openInteractionIndex;
@@ -477,6 +525,8 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
                 previous.appendInteractionIndex = appendInteractionIndex;
                 previous.telemetryModel = telemetryModel;
                 previous.telemetryContext = telemetryContext;
+                previous.telemetryCwd = telemetryCwd;
+                previous.telemetryGitBranch = telemetryGitBranch;
                 previous.revision = revision;
                 previous.partial = partial;
             } else {
@@ -487,6 +537,8 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
                     appendInteractionIndex,
                     telemetryModel,
                     telemetryContext,
+                    telemetryCwd,
+                    telemetryGitBranch,
                     revision,
                     partial,
                     dispose() {},
@@ -503,6 +555,8 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
                 partial,
                 telemetryModel,
                 telemetryContext,
+                telemetryCwd,
+                telemetryGitBranch,
             };
         } finally {
             await source.handle.close().catch(() => undefined);

--- a/src/aiSessions/conversation/codexAdapter.ts
+++ b/src/aiSessions/conversation/codexAdapter.ts
@@ -26,6 +26,10 @@ import {
     ConversationResponseState,
     ConversationTelemetry,
 } from './types';
+import type {
+    ConversationWorktreeInfo,
+    ResolveWorktree,
+} from './worktreeResolver';
 
 type TimerHandle = unknown;
 
@@ -45,6 +49,8 @@ export interface CodexConversationAdapterOptions {
     watchSessionChanges(onDidChange: () => void): AiSessionDisposable;
     setTimeout(callback: () => void, delayMs: number): TimerHandle;
     clearTimeout(handle: TimerHandle): void;
+    resolveWorktree?: ResolveWorktree;
+    readCurrentWorkdir?(sessionId: string): string | undefined;
 }
 
 interface LoadedConversation {
@@ -387,14 +393,44 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
                 telemetry.model = response.model.trim().slice(0, 128);
             }
         }
+        const worktree = await this.readWorktree(sessionId, resumeResult);
+        if (worktree) {
+            telemetry.worktree = worktree;
+        }
         const context = this.tokenUsageBySession.get(sessionId);
         if (context) {
             telemetry.context = { ...context };
         }
-        return telemetry.model || telemetry.context
+        return telemetry.model || telemetry.context || telemetry.worktree
             || telemetry.rateLimits.length
             ? telemetry
             : undefined;
+    }
+
+    private async readWorktree(
+        sessionId: string,
+        resumeResult: { fulfilled: true; value: unknown } | { fulfilled: false }
+    ): Promise<ConversationWorktreeInfo | undefined> {
+        if (!this.options.resolveWorktree) {
+            return undefined;
+        }
+        // The current operating directory wins over the launch directory:
+        // app-server exposes no exec items, so composition injects a
+        // telemetry-only probe for the latest exec workdir.
+        const currentWorkdir = this.options.readCurrentWorkdir?.(sessionId);
+        if (currentWorkdir) {
+            const resolved = await this.options.resolveWorktree(currentWorkdir);
+            if (resolved) {
+                return resolved;
+            }
+        }
+        const response = resumeResult.fulfilled
+            ? asRecord(resumeResult.value)
+            : undefined;
+        const cwd = typeof response?.cwd === 'string' && response.cwd
+            ? response.cwd
+            : undefined;
+        return cwd ? this.options.resolveWorktree(cwd) : undefined;
     }
 
     watch(sessionId: string, onChange: () => void): AiSessionDisposable {

--- a/src/aiSessions/conversation/composition.ts
+++ b/src/aiSessions/conversation/composition.ts
@@ -44,6 +44,8 @@ import {
     ConversationViewerOptions,
     ConversationViewerTarget,
 } from './viewer';
+import { ConversationWorktreeResolver } from './worktreeResolver';
+import { readCodexRolloutWorkdir } from '../codexRolloutWorkdir';
 
 export interface ConversationSessionOpenTarget {
     projectId: string;
@@ -85,6 +87,9 @@ export interface ConversationCapabilityOptions {
     clearTimer: typeof clearTimeout;
     onDiagnostic: (event: SanitizedConversationDiagnostic) => void;
     getWorkspaceRootHostPaths?: () => readonly string[];
+    showWorktreeInSourceControl?: (
+        worktreeRoot: string
+    ) => PromiseLike<void> | Promise<void> | void;
     submitPrompt: (
         target: ConversationViewerTarget,
         prompt: string
@@ -158,12 +163,24 @@ function createAvailableConversationCapability(
         clearTimeout: options.clearTimer,
         onDiagnostic: options.onDiagnostic,
     }));
+    const worktreeResolver = new ConversationWorktreeResolver({
+        now: options.now,
+    });
     const codexAdapter = ownership.own(factories.createCodexAdapter({
         client: codexClient,
         watchSessionChanges: onDidChange =>
             options.services.codex.watchSessionChanges(onDidChange),
         setTimeout: options.setTimer,
         clearTimeout: options.clearTimer,
+        resolveWorktree: candidatePath =>
+            worktreeResolver.resolve(candidatePath),
+        readCurrentWorkdir: sessionId => {
+            const rolloutPath = options.services.codex
+                .resolveSessionFilePath?.(sessionId);
+            return rolloutPath
+                ? readCodexRolloutWorkdir(rolloutPath)
+                : undefined;
+        },
     }));
     ownership.transfer(codexClient);
     const kimiAdapter = ownership.own(factories.createKimiAdapter({
@@ -175,6 +192,8 @@ function createAvailableConversationCapability(
         now: options.now,
         setTimeout: options.setTimer,
         clearTimeout: options.clearTimer,
+        resolveWorktree: candidatePath =>
+            worktreeResolver.resolve(candidatePath),
     }));
     const claudeAdapter = ownership.own(factories.createClaudeAdapter({
         resolveSource: sessionId =>
@@ -187,6 +206,8 @@ function createAvailableConversationCapability(
         now: options.now,
         setTimeout: options.setTimer,
         clearTimeout: options.clearTimer,
+        resolveWorktree: candidatePath =>
+            worktreeResolver.resolve(candidatePath),
     }));
     const adapters: Record<AiSessionProviderId, ConversationProviderAdapter> = {
         codex: codexAdapter,
@@ -216,6 +237,7 @@ function createAvailableConversationCapability(
         focusSession: options.focusSession,
         commentStore: options.commentStore,
         bookmarkStore: options.bookmarkStore,
+        showWorktreeInSourceControl: options.showWorktreeInSourceControl,
     }));
     let viewerIntentGeneration = 0;
     let disposed = false;

--- a/src/aiSessions/conversation/conversationTelemetryController.ts
+++ b/src/aiSessions/conversation/conversationTelemetryController.ts
@@ -127,11 +127,19 @@ function formatResetTime(resetsAt: number): string {
     return `${Math.ceil(remainingHours / 24)}d`;
 }
 
+const WORKTREE_ICON_SVG = '<svg viewBox="0 0 16 16" width="11" height="11"'
+    + ' aria-hidden="true" fill="none" stroke="currentColor"'
+    + ' stroke-width="1.4"><circle cx="4.5" cy="3.5" r="1.8"/>'
+    + '<circle cx="4.5" cy="12.5" r="1.8"/><circle cx="11.5" cy="5.5" r="1.8"/>'
+    + '<path d="M4.5 5.3v5.4M11.5 7.3c0 2.4-2.6 2.8-4.7 3"/></svg>';
+
 export function renderConversationTelemetry(
     telemetry: ConversationTelemetry | undefined
 ): string {
     const hasContext = Boolean(telemetry?.context);
     const hasModel = Boolean(telemetry?.model);
+    const worktree = telemetry?.worktree;
+    const hasWorktree = Boolean(worktree);
     const limits = telemetry?.rateLimits || [];
     const context = telemetry?.context;
     const contextPercent = context
@@ -159,9 +167,29 @@ export function renderConversationTelemetry(
             )}</span>
         </div>`;
     }).join('');
+    const worktreeTitle = worktree
+        ? worktree.missing
+            ? `Worktree path no longer exists: ${worktree.worktreeRoot} (branch ${worktree.branch})`
+            : `Working in worktree: ${worktree.worktreeRoot} (branch ${worktree.branch}) · Click to show changes in Source Control`
+        : '';
     return `<section class="conversation-telemetry"
         data-conversation-telemetry aria-label="Session usage"${hasModel
-            || hasContext || limits.length ? '' : ' hidden'}>
+            || hasContext || hasWorktree || limits.length ? '' : ' hidden'}>
+        <button type="button"
+            class="conversation-telemetry-worktree${worktree?.missing
+                ? ' conversation-telemetry-worktree-missing'
+                : ''}"
+            data-telemetry-worktree
+            data-worktree-root="${escapeAttribute(
+                worktree?.worktreeRoot || ''
+            )}"
+            title="${escapeAttribute(worktreeTitle)}"${hasWorktree
+                ? ''
+                : ' hidden'}>
+            ${WORKTREE_ICON_SVG}<span data-telemetry-worktree-branch>${escapeHtml(
+                worktree?.branch || ''
+            )}</span>
+        </button>
         <div class="conversation-telemetry-model"
             data-telemetry-model${hasModel ? '' : ' hidden'}>
             <span>Model</span>

--- a/src/aiSessions/conversation/kimiAdapter.ts
+++ b/src/aiSessions/conversation/kimiAdapter.ts
@@ -39,6 +39,27 @@ import {
     openValidatedConversationSource,
     OpenConversationSource,
 } from './source';
+import type {
+    ConversationWorktreeInfo,
+    ResolveWorktree,
+} from './worktreeResolver';
+
+const MAX_TELEMETRY_PATHS = 16;
+const ABSOLUTE_PATH_PATTERN = /(?<![\w.~=-])\/(?:[\w.@+~-]+\/)*[\w.@+~-]+/g;
+
+function extractAbsolutePaths(value: string): string[] {
+    const paths = new Set<string>();
+    const pattern = new RegExp(ABSOLUTE_PATH_PATTERN.source, 'g');
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(value)) !== null) {
+        const candidate = match[0];
+        if (candidate.length > 1 && candidate.length <= 1024
+            && !candidate.startsWith('/dev/')) {
+            paths.add(candidate);
+        }
+    }
+    return Array.from(paths);
+}
 
 type TimerHandle = unknown;
 
@@ -50,6 +71,7 @@ export interface KimiConversationAdapterOptions {
     now(): number;
     setTimeout(callback: () => void, delayMs: number): TimerHandle;
     clearTimeout(handle: TimerHandle): void;
+    resolveWorktree?: ResolveWorktree;
 }
 
 type ConversationContextUsage = NonNullable<ConversationTelemetry['context']>;
@@ -60,6 +82,7 @@ interface KimiConversationIndex extends AiSessionDisposable {
     interactions: ConversationInteraction[];
     openInteractionIndex?: number;
     telemetryContext?: ConversationContextUsage;
+    telemetryPaths: string[];
     revision: number;
     partial: boolean;
 }
@@ -69,6 +92,7 @@ interface LoadedConversation {
     sourceRevision: string;
     partial: boolean;
     telemetryContext?: ConversationContextUsage;
+    telemetryPaths: string[];
 }
 
 function asRecord(value: unknown): Record<string, any> | undefined {
@@ -161,15 +185,38 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
         signal?: ConversationAbortSignal
     ): Promise<ConversationTelemetry | undefined> {
         const loaded = await this.load(sessionId, signal);
-        if (!loaded.telemetryContext) {
+        const worktree = await this.readWorktree(loaded);
+        if (!loaded.telemetryContext && !worktree) {
             return undefined;
         }
         return {
             provider: 'kimi',
             sessionId,
-            context: { ...loaded.telemetryContext },
+            ...(worktree ? { worktree } : {}),
+            context: loaded.telemetryContext
+                ? { ...loaded.telemetryContext }
+                : undefined,
             rateLimits: [],
         };
+    }
+
+    private async readWorktree(
+        loaded: LoadedConversation
+    ): Promise<ConversationWorktreeInfo | undefined> {
+        if (!this.options.resolveWorktree) {
+            return undefined;
+        }
+        for (let index = loaded.telemetryPaths.length - 1;
+            index >= 0;
+            index--) {
+            const resolved = await this.options.resolveWorktree(
+                loaded.telemetryPaths[index]
+            );
+            if (resolved) {
+                return resolved;
+            }
+        }
+        return undefined;
     }
 
     watch(sessionId: string, onChange: () => void): AiSessionDisposable {
@@ -246,6 +293,7 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
         let interactions: ConversationInteraction[] = [];
         let openInteractionIndex: number | undefined;
         let telemetryContext: ConversationContextUsage | undefined;
+        let telemetryPaths: string[] = [];
         try {
             const startOffset = await getConversationReadStart(
                 source,
@@ -260,6 +308,7 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                 interactions = cloneInteractions(previous.interactions);
                 openInteractionIndex = previous.openInteractionIndex;
                 telemetryContext = previous.telemetryContext;
+                telemetryPaths = previous.telemetryPaths.slice();
             }
             const normalizeRecord = (record: ConversationJsonlRecord): void => {
                 const envelope = asRecord(record.value);
@@ -339,6 +388,33 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                             maxTokens: Math.floor(maxTokens),
                         };
                     }
+                } else if (event.type === 'ToolCall') {
+                    const payload = asRecord(event.payload);
+                    const toolFunction = asRecord(payload?.function);
+                    const toolName = typeof toolFunction?.name === 'string'
+                        ? toolFunction.name.toLowerCase()
+                        : '';
+                    if ((toolName === 'shell' || toolName === 'bash')
+                        && typeof toolFunction?.arguments === 'string') {
+                        try {
+                            const args = asRecord(
+                                JSON.parse(toolFunction.arguments)
+                            );
+                            if (typeof args?.command === 'string') {
+                                telemetryPaths.push(
+                                    ...extractAbsolutePaths(args.command)
+                                );
+                                if (telemetryPaths.length
+                                    > MAX_TELEMETRY_PATHS) {
+                                    telemetryPaths = telemetryPaths.slice(
+                                        -MAX_TELEMETRY_PATHS
+                                    );
+                                }
+                            }
+                        } catch (_error) {
+                            // Malformed tool arguments carry no path signal.
+                        }
+                    }
                 } else if (event.type === 'TurnEnd') {
                     finishInteraction('complete');
                 } else if (event.type === 'Interrupt'
@@ -384,6 +460,7 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                     sourceRevision: `r${revision}`,
                     partial: true,
                     telemetryContext,
+                    telemetryPaths,
                 };
             }
             const partial = continuing ? previous.partial : result.partial;
@@ -405,6 +482,7 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                 previous.interactions = interactions;
                 previous.openInteractionIndex = openInteractionIndex;
                 previous.telemetryContext = telemetryContext;
+                previous.telemetryPaths = telemetryPaths;
                 previous.revision = revision;
                 previous.partial = partial;
             } else {
@@ -414,6 +492,7 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                     interactions,
                     openInteractionIndex,
                     telemetryContext,
+                    telemetryPaths,
                     revision,
                     partial,
                     dispose() {},
@@ -429,6 +508,7 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                 sourceRevision: `r${revision}`,
                 partial,
                 telemetryContext,
+                telemetryPaths,
             };
         } finally {
             await source.handle.close().catch(() => undefined);

--- a/src/aiSessions/conversation/types.ts
+++ b/src/aiSessions/conversation/types.ts
@@ -85,10 +85,19 @@ export interface ConversationPage {
     isEnd: boolean;
 }
 
+export interface ConversationTelemetryWorktree {
+    branch: string;
+    worktreeRoot: string;
+    repoRoot: string;
+    /** The worktree path no longer exists; branch comes from session logs. */
+    missing?: boolean;
+}
+
 export interface ConversationTelemetry {
     provider: AiSessionProviderId;
     sessionId: string;
     model?: string;
+    worktree?: ConversationTelemetryWorktree;
     context?: {
         usedTokens: number;
         maxTokens: number;

--- a/src/aiSessions/conversation/viewer.ts
+++ b/src/aiSessions/conversation/viewer.ts
@@ -72,6 +72,9 @@ export interface ConversationViewerOptions {
     ) => PromiseLike<void> | Promise<void>;
     commentStore?: ConversationCommentStore;
     bookmarkStore?: ConversationBookmarkStore;
+    showWorktreeInSourceControl?: (
+        worktreeRoot: string
+    ) => PromiseLike<void> | Promise<void> | void;
 }
 
 export interface ConversationViewerApi extends AiSessionDisposable {
@@ -386,6 +389,12 @@ export class ConversationViewer implements ConversationViewerApi {
         }
         if (parsed.type === 'conversation-viewer-open-link') {
             await this.openLink(parsed.href);
+            return;
+        }
+        if (parsed.type === 'conversation-viewer-open-worktree') {
+            await this.options.showWorktreeInSourceControl?.(
+                parsed.worktreeRoot
+            );
             return;
         }
         if (parsed.type === 'conversation-viewer-comment-mutation'

--- a/src/aiSessions/conversation/viewerProtocol.ts
+++ b/src/aiSessions/conversation/viewerProtocol.ts
@@ -77,10 +77,17 @@ export interface ConversationViewerBookmarkMutationMessage {
     };
 }
 
+export interface ConversationViewerOpenWorktreeMessage {
+    type: 'conversation-viewer-open-worktree';
+    version: 1;
+    worktreeRoot: string;
+}
+
 export type ConversationViewerMessage =
     ConversationViewerNavigationMessage
     | ConversationViewerSelectInteractionMessage
     | ConversationViewerOpenLinkMessage
+    | ConversationViewerOpenWorktreeMessage
     | ConversationViewerCommentMutationMessage
     | ConversationViewerSendCommentsMessage
     | ConversationViewerLocateCommentMessage
@@ -129,6 +136,19 @@ export function parseConversationViewerMessage(
             return undefined;
         }
         return value as unknown as ConversationViewerOpenLinkMessage;
+    }
+    if (value.type === 'conversation-viewer-open-worktree') {
+        if (keys.length !== 3
+            || !hasOwn(value, 'type')
+            || !hasOwn(value, 'version')
+            || !hasOwn(value, 'worktreeRoot')
+            || typeof value.worktreeRoot !== 'string'
+            || !value.worktreeRoot
+            || value.worktreeRoot.length > 1024
+            || /[\u0000-\u001f\u007f]/.test(value.worktreeRoot)) {
+            return undefined;
+        }
+        return value as unknown as ConversationViewerOpenWorktreeMessage;
     }
     if (value.type === 'conversation-viewer-locate-comment') {
         if (!hasExactKeys(value, [

--- a/src/aiSessions/conversation/worktreeResolver.ts
+++ b/src/aiSessions/conversation/worktreeResolver.ts
@@ -1,0 +1,139 @@
+'use strict';
+
+import { execFile } from 'child_process';
+import * as path from 'path';
+
+export interface ConversationWorktreeInfo {
+    branch: string;
+    worktreeRoot: string;
+    repoRoot: string;
+    /** The signaled path no longer exists; branch comes from session logs. */
+    missing?: boolean;
+}
+
+export interface WorktreeResolverOptions {
+    now(): number;
+    execGit?: (
+        args: string[],
+        cwd: string
+    ) => Promise<{ stdout: string; stderr: string }>;
+    cacheTtlMs?: number;
+    maxCacheEntries?: number;
+}
+
+const DEFAULT_CACHE_TTL_MS = 5_000;
+const DEFAULT_MAX_CACHE_ENTRIES = 64;
+const GIT_TIMEOUT_MS = 5_000;
+const MAX_PATH_LENGTH = 1024;
+
+function defaultExecGit(
+    args: string[],
+    cwd: string
+): Promise<{ stdout: string; stderr: string }> {
+    return new Promise((resolve, reject) => {
+        execFile(
+            'git',
+            args,
+            { cwd, timeout: GIT_TIMEOUT_MS, maxBuffer: 64 * 1024 },
+            (error, stdout, stderr) => {
+                if (error) {
+                    reject(error);
+                    return;
+                }
+                resolve({ stdout, stderr });
+            }
+        );
+    });
+}
+
+export type ResolveWorktree = (
+    candidatePath: string
+) => Promise<ConversationWorktreeInfo | undefined>;
+
+/**
+ * Resolves the git worktree that contains a candidate path (a session's
+ * current working directory or a path extracted from tool activity).
+ * Results are cached briefly so telemetry refreshes stay cheap.
+ */
+export class ConversationWorktreeResolver {
+    private readonly cache = new Map<string, {
+        readAt: number;
+        value?: ConversationWorktreeInfo;
+    }>();
+
+    constructor(private readonly options: WorktreeResolverOptions) {}
+
+    async resolve(
+        candidatePath: string
+    ): Promise<ConversationWorktreeInfo | undefined> {
+        if (typeof candidatePath !== 'string'
+            || !candidatePath.startsWith('/')
+            || candidatePath.length > MAX_PATH_LENGTH) {
+            return undefined;
+        }
+        const cached = this.cache.get(candidatePath);
+        const now = this.options.now();
+        if (cached
+            && now - cached.readAt
+                < (this.options.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS)) {
+            return cached.value ? { ...cached.value } : undefined;
+        }
+        const value = await this.query(candidatePath);
+        if (this.cache.size
+            >= (this.options.maxCacheEntries ?? DEFAULT_MAX_CACHE_ENTRIES)) {
+            const oldest = this.cache.keys().next().value;
+            if (typeof oldest === 'string') {
+                this.cache.delete(oldest);
+            }
+        }
+        this.cache.set(candidatePath, { readAt: now, value });
+        return value ? { ...value } : undefined;
+    }
+
+    private async query(
+        candidatePath: string
+    ): Promise<ConversationWorktreeInfo | undefined> {
+        const execGit = this.options.execGit || defaultExecGit;
+        let stdout: string;
+        try {
+            const result = await execGit([
+                '-C', candidatePath,
+                'rev-parse',
+                '--show-toplevel',
+                '--git-common-dir',
+                '--abbrev-ref', 'HEAD',
+            ], candidatePath);
+            stdout = result.stdout;
+        } catch (_error) {
+            return undefined;
+        }
+        const lines = stdout.split('\n').map(line => line.trim());
+        const [worktreeRoot, commonDir, abbrevRef] = lines;
+        if (!worktreeRoot || !commonDir) {
+            return undefined;
+        }
+        const toplevel = path.resolve(worktreeRoot);
+        const absoluteCommonDir = path.isAbsolute(commonDir)
+            ? commonDir
+            : path.resolve(toplevel, commonDir);
+        let branch = abbrevRef && abbrevRef !== 'HEAD' ? abbrevRef : '';
+        if (!branch) {
+            try {
+                const result = await execGit([
+                    '-C', candidatePath, 'rev-parse', '--short', 'HEAD',
+                ], candidatePath);
+                branch = result.stdout.trim();
+            } catch (_error) {
+                branch = '';
+            }
+        }
+        if (!branch) {
+            return undefined;
+        }
+        return {
+            branch: branch.slice(0, 128),
+            worktreeRoot: toplevel,
+            repoRoot: path.dirname(absoluteCommonDir),
+        };
+    }
+}

--- a/src/aiSessions/types.ts
+++ b/src/aiSessions/types.ts
@@ -97,8 +97,10 @@ export interface AiSessionService {
     watchSessionChanges(onDidChange: () => void): AiSessionDisposable;
     archiveSession(sessionId: string): boolean;
     invalidateCache(): void;
+    resolveSessionFilePath?(sessionId: string): string | null;
     resolveConversationSource?(
         sessionId: string,
+
         candidatePaths?: readonly string[]
     ): AiSessionConversationSourceCandidate | null;
 }

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -33,6 +33,7 @@ import CodexSessionService from './services/codexSessionService';
 import { ProcCodexRootThreadObserver } from './aiSessions/codexRootThreadObserver';
 import KimiSessionService from './services/kimiSessionService';
 import ClaudeSessionService from './services/claudeSessionService';
+import { showWorktreeInSourceControl } from './services/sourceControl';
 import ProjectWindowColorService from './services/projectWindowColorService';
 import AiSessionAliasStore from './aiSessions/aliasStore';
 import AiSessionAliasController from './aiSessions/aliasController';
@@ -1423,6 +1424,8 @@ async function initializeDashboard(
         publish: message => provider.postMessage(message),
         createPanel: vscode.window.createWebviewPanel,
         openExternal: vscode.env.openExternal,
+        showWorktreeInSourceControl: (worktreeRoot: string) =>
+            showWorktreeInSourceControl(worktreeRoot),
         spawnCodex: childProcess.spawn,
         now: () => Date.now(),
         setTimer: setTimeout,

--- a/src/services/codexSessionService.ts
+++ b/src/services/codexSessionService.ts
@@ -166,6 +166,17 @@ export default class CodexSessionService {
         return signals;
     }
 
+    resolveSessionFilePath(sessionId: string): string | null {
+        if (!sessionId) {
+            return null;
+        }
+        const codexHome = this.getCodexHome();
+        if (!codexHome) {
+            return null;
+        }
+        return this.getSessionFiles(codexHome).get(sessionId) || null;
+    }
+
     archiveSession(sessionId: string): boolean {
         if (!sessionId) {
             return false;

--- a/src/services/sourceControl.ts
+++ b/src/services/sourceControl.ts
@@ -1,0 +1,42 @@
+'use strict';
+
+import * as vscode from 'vscode';
+
+interface GitExtensionApiV1 {
+    openRepository(root: vscode.Uri): Promise<unknown>;
+}
+
+function getGitApi(): GitExtensionApiV1 | undefined {
+    const exports = vscode.extensions.getExtension('vscode.git')?.exports as
+        { getAPI?: (version: number) => GitExtensionApiV1 | undefined }
+        | undefined;
+    const api = exports?.getAPI?.(1);
+    return api && typeof api.openRepository === 'function' ? api : undefined;
+}
+
+export async function showWorktreeInSourceControl(
+    worktreeRoot: string
+): Promise<void> {
+    let exists = true;
+    try {
+        await vscode.workspace.fs.stat(vscode.Uri.file(worktreeRoot));
+    } catch (_error) {
+        exists = false;
+    }
+    if (!exists) {
+        void vscode.window.showWarningMessage(
+            `Worktree path no longer exists: ${worktreeRoot}`
+        );
+        return;
+    }
+    const gitApi = getGitApi();
+    if (!gitApi) {
+        void vscode.window.showWarningMessage(
+            'The built-in Git extension is unavailable; '
+                + 'cannot show the worktree in Source Control.'
+        );
+        return;
+    }
+    await gitApi.openRepository(vscode.Uri.file(worktreeRoot));
+    await vscode.commands.executeCommand('workbench.view.scm');
+}

--- a/src/webview/conversationTelemetryScripts.js
+++ b/src/webview/conversationTelemetryScripts.js
@@ -12,6 +12,8 @@
         var telemetryContextProgress = options.telemetryContextProgress;
         var telemetryContextValue = options.telemetryContextValue;
         var telemetryLimits = options.telemetryLimits;
+        var telemetryWorktree = options.telemetryWorktree;
+        var telemetryWorktreeBranch = options.telemetryWorktreeBranch;
         var scroll = options.scroll;
         var captureAnchor = options.captureAnchor;
         var restoreViewport = options.restoreViewport;
@@ -36,7 +38,7 @@
             if (!exactKeys(
                 value,
                 ['provider', 'sessionId', 'rateLimits'],
-                ['model', 'context']
+                ['model', 'context', 'worktree']
             )) return false;
             if (!['codex', 'kimi', 'claude'].includes(value.provider)
                 || typeof value.sessionId !== 'string'
@@ -56,6 +58,25 @@
                     || value.context.usedTokens < 0
                     || !Number.isSafeInteger(value.context.maxTokens)
                     || value.context.maxTokens <= 0)) {
+                return false;
+            }
+            if (value.worktree !== undefined
+                && (!exactKeys(
+                    value.worktree,
+                    ['branch', 'worktreeRoot', 'repoRoot'],
+                    ['missing']
+                )
+                    || typeof value.worktree.branch !== 'string'
+                    || !value.worktree.branch
+                    || value.worktree.branch.length > 128
+                    || typeof value.worktree.worktreeRoot !== 'string'
+                    || !value.worktree.worktreeRoot
+                    || value.worktree.worktreeRoot.length > 1024
+                    || typeof value.worktree.repoRoot !== 'string'
+                    || !value.worktree.repoRoot
+                    || value.worktree.repoRoot.length > 1024
+                    || (value.worktree.missing !== undefined
+                        && typeof value.worktree.missing !== 'boolean'))) {
                 return false;
             }
             return value.rateLimits.every(function (limit) {
@@ -122,7 +143,8 @@
                         || message.telemetry.sessionId !== commentTarget.sessionId))
                 || !telemetryRoot || !telemetryModel || !telemetryModelValue
                 || !telemetryContext || !telemetryContextProgress
-                || !telemetryContextValue || !telemetryLimits) {
+                || !telemetryContextValue || !telemetryLimits
+                || !telemetryWorktree || !telemetryWorktreeBranch) {
                 return false;
             }
             state.latestTelemetryRequestId = message.requestId;
@@ -139,6 +161,24 @@
             }
             telemetryModel.hidden = !telemetry.model;
             telemetryModelValue.textContent = telemetry.model || '';
+            var worktree = telemetry.worktree;
+            telemetryWorktree.hidden = !worktree;
+            if (worktree) {
+                telemetryWorktreeBranch.textContent = worktree.branch;
+                telemetryWorktree.setAttribute(
+                    'data-worktree-root',
+                    worktree.worktreeRoot
+                );
+                telemetryWorktree.classList.toggle(
+                    'conversation-telemetry-worktree-missing',
+                    !!worktree.missing
+                );
+                telemetryWorktree.title = worktree.missing
+                    ? 'Worktree path no longer exists: '
+                        + worktree.worktreeRoot
+                    : 'Working in worktree: ' + worktree.worktreeRoot
+                        + ' · Click to show changes in Source Control';
+            }
             telemetryContext.hidden = !telemetry.context;
             if (telemetry.context) {
                 var percent = Math.max(0, Math.min(
@@ -176,6 +216,7 @@
             });
             telemetryRoot.hidden = !telemetry.model
                 && !telemetry.context
+                && !worktree
                 && telemetry.rateLimits.length === 0;
             restoreViewport(readingAnchor, previousScrollTop);
             return true;

--- a/src/webview/conversationViewerScripts.js
+++ b/src/webview/conversationViewerScripts.js
@@ -45,6 +45,10 @@
         '[data-telemetry-context-value]'
     );
     var telemetryLimits = document.querySelector('[data-telemetry-limits]');
+    var telemetryWorktree = document.querySelector('[data-telemetry-worktree]');
+    var telemetryWorktreeBranch = document.querySelector(
+        '[data-telemetry-worktree-branch]'
+    );
     var newResponse = document.querySelector('[data-new-response]');
     var previous = document.querySelector('[data-action="previous"]');
     var next = document.querySelector('[data-action="next"]');
@@ -198,6 +202,8 @@
         telemetryContextProgress: telemetryContextProgress,
         telemetryContextValue: telemetryContextValue,
         telemetryLimits: telemetryLimits,
+        telemetryWorktree: telemetryWorktree,
+        telemetryWorktreeBranch: telemetryWorktreeBranch,
         scroll: scroll,
         captureAnchor: captureReadingAnchor,
         restoreViewport: restoreViewportReadingPosition,
@@ -602,6 +608,20 @@
     latest.addEventListener('click', function () {
         postNavigation('conversation-viewer-latest');
     });
+    if (telemetryWorktree) {
+        telemetryWorktree.addEventListener('click', function () {
+            var worktreeRoot = telemetryWorktree.getAttribute(
+                'data-worktree-root'
+            );
+            if (worktreeRoot) {
+                post({
+                    type: 'conversation-viewer-open-worktree',
+                    version: 1,
+                    worktreeRoot: worktreeRoot,
+                });
+            }
+        });
+    }
     close.addEventListener('click', function () {
         postNavigation('conversation-viewer-closed');
     });

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -182,6 +182,11 @@ async function openViewerPage(t, options = {}) {
                     <button type="button" data-action="close">Close</button>
                 </header>
                 <section data-conversation-telemetry hidden>
+                    <button type="button" class="conversation-telemetry-worktree"
+                        data-telemetry-worktree data-worktree-root="" title=""
+                        hidden>
+                        <span data-telemetry-worktree-branch></span>
+                    </button>
                     <div data-telemetry-model hidden>
                         <span>Model</span>
                         <strong data-telemetry-model-value></strong>
@@ -3655,4 +3660,101 @@ test('CONVERSATION-VIEWER-BROWSER-REFRESH-001 CONVERSATION-READING-FOCUS-001 pre
             name: 'New response content',
         }).isVisible(), true);
     }
+});
+
+test('CONVERSATION-TELEMETRY-001 renders the worktree chip, degrades missing paths, and posts open-worktree on click', async t => {
+    const page = await openViewerPage(t);
+    await sendPage(page, {
+        type: 'conversation-viewer-telemetry',
+        version: 1,
+        requestId: 1,
+        subscriptionGeneration: 1,
+        telemetry: {
+            provider: 'codex',
+            sessionId: 'session-telemetry',
+            worktree: {
+                branch: 'feat/worktree',
+                worktreeRoot: '/repo/.worktree/feat-worktree',
+                repoRoot: '/repo',
+            },
+            rateLimits: [],
+        },
+    });
+
+    const chip = page.locator('[data-telemetry-worktree]');
+    assert.equal(await chip.isVisible(), true);
+    assert.equal(
+        await page.locator('[data-telemetry-worktree-branch]').textContent(),
+        'feat/worktree'
+    );
+    assert.match(
+        await chip.getAttribute('title'),
+        /Click to show changes in Source Control/
+    );
+    assert.equal(
+        await page.locator('[data-conversation-telemetry]').isVisible(),
+        true
+    );
+
+    await chip.click();
+    assert.deepEqual(await postedMessages(page), [{
+        type: 'conversation-viewer-open-worktree',
+        version: 1,
+        worktreeRoot: '/repo/.worktree/feat-worktree',
+    }]);
+
+    await sendPage(page, {
+        type: 'conversation-viewer-telemetry',
+        version: 1,
+        requestId: 2,
+        subscriptionGeneration: 1,
+        telemetry: {
+            provider: 'codex',
+            sessionId: 'session-telemetry',
+            worktree: {
+                branch: 'feat/gone',
+                worktreeRoot: '/repo/.worktree/feat-gone',
+                repoRoot: '/repo',
+                missing: true,
+            },
+            rateLimits: [],
+        },
+    });
+    assert.equal(
+        await chip.getAttribute('class'),
+        'conversation-telemetry-worktree conversation-telemetry-worktree-missing'
+    );
+    assert.match(await chip.getAttribute('title'), /no longer exists/);
+
+    await sendPage(page, {
+        type: 'conversation-viewer-telemetry',
+        version: 1,
+        requestId: 3,
+        subscriptionGeneration: 1,
+        telemetry: {
+            provider: 'codex',
+            sessionId: 'session-telemetry',
+            model: 'gpt-5.6-sol',
+            rateLimits: [],
+        },
+    });
+    assert.equal(await chip.isHidden(), true);
+
+    await sendPage(page, {
+        type: 'conversation-viewer-telemetry',
+        version: 1,
+        requestId: 4,
+        subscriptionGeneration: 1,
+        telemetry: {
+            provider: 'codex',
+            sessionId: 'session-telemetry',
+            worktree: { branch: 42 },
+            rateLimits: [],
+        },
+    });
+    assert.equal(
+        await page.locator('[data-telemetry-model-value]').textContent(),
+        'gpt-5.6-sol',
+        'malformed worktree telemetry must be rejected as a whole'
+    );
 });

--- a/tests/contract/aiSessions/claudeConversationAdapter.test.js
+++ b/tests/contract/aiSessions/claudeConversationAdapter.test.js
@@ -698,3 +698,65 @@ test('CONVERSATION-TELEMETRY-001 Claude surfaces the latest assistant model and 
         rateLimits: [],
     });
 });
+
+test('CONVERSATION-TELEMETRY-001 Claude resolves the current worktree from the latest event cwd and degrades to the logged branch', async t => {
+    const source = await createFixture(t);
+    const adapter = createAdapter(source, {
+        resolveWorktree: async candidate =>
+            candidate === '/repo/.worktree/feat'
+                ? {
+                    branch: 'feat',
+                    worktreeRoot: candidate,
+                    repoRoot: '/repo',
+                }
+                : undefined,
+    });
+    t.after(() => adapter.dispose());
+
+    assert.equal(await adapter.readTelemetry(sessionId), undefined);
+
+    await fs.promises.appendFile(source.sourcePath, [
+        JSON.stringify({
+            type: 'user',
+            uuid: 'worktree-user-1',
+            cwd: '/repo',
+            gitBranch: 'main',
+            message: {
+                role: 'user',
+                content: [{ type: 'text', text: 'Start in the main checkout' }],
+            },
+        }),
+        JSON.stringify({
+            type: 'assistant',
+            uuid: 'worktree-assistant-1',
+            cwd: '/repo/.worktree/feat',
+            gitBranch: 'feat',
+            message: {
+                role: 'assistant',
+                model: 'claude-sonnet-4-6',
+                content: [{ type: 'text', text: 'Now working in the worktree.' }],
+                usage: { input_tokens: 5, output_tokens: 7 },
+            },
+        }),
+        '',
+    ].join('\n'));
+
+    const telemetry = await adapter.readTelemetry(sessionId);
+    assert.deepEqual(telemetry.worktree, {
+        branch: 'feat',
+        worktreeRoot: '/repo/.worktree/feat',
+        repoRoot: '/repo',
+    });
+
+    const missingAdapter = createAdapter(source, {
+        resolveWorktree: async () => undefined,
+    });
+    t.after(() => missingAdapter.dispose());
+    const missing = await missingAdapter.readTelemetry(sessionId);
+    assert.deepEqual(missing.worktree, {
+        branch: 'feat',
+        worktreeRoot: '/repo/.worktree/feat',
+        repoRoot: '/repo/.worktree/feat',
+        missing: true,
+    });
+});

--- a/tests/contract/aiSessions/codexConversationAdapter.test.js
+++ b/tests/contract/aiSessions/codexConversationAdapter.test.js
@@ -44,6 +44,8 @@ function createAdapter(result = fixture, overrides = {}) {
             return 1;
         }),
         clearTimeout: overrides.clearTimeout || (() => undefined),
+        resolveWorktree: overrides.resolveWorktree,
+        readCurrentWorkdir: overrides.readCurrentWorkdir,
     });
     return {
         adapter,
@@ -523,4 +525,67 @@ test('SESSION-AI-SESSION-CODEX-CONVERSATION-007 keeps revisions stable until nor
     current.thread.turns[0].items[2].text = 'Changed visible response';
     const changed = await harness.adapter.readOutline(sessionId);
     assert.notEqual(changed.sourceRevision, first.sourceRevision);
+});
+
+test('CONVERSATION-TELEMETRY-001 Codex prefers the latest exec workdir and falls back to the launch cwd', async t => {
+    const telemetryClient = {
+        async request(method) {
+            if (method === 'thread/resume') {
+                return { model: 'gpt-5.6-sol', cwd: '/launch/repo' };
+            }
+            return {};
+        },
+        dispose() {},
+    };
+    const rolloutAdapter = createAdapter(fixture, {
+        client: telemetryClient,
+        readCurrentWorkdir: id =>
+            id === sessionId ? '/launch/repo/.worktree/feature-x' : undefined,
+        resolveWorktree: async candidate => {
+            if (candidate === '/launch/repo/.worktree/feature-x') {
+                return {
+                    branch: 'feature-x',
+                    worktreeRoot: candidate,
+                    repoRoot: '/launch/repo',
+                };
+            }
+            if (candidate === '/launch/repo') {
+                return {
+                    branch: 'main',
+                    worktreeRoot: candidate,
+                    repoRoot: candidate,
+                };
+            }
+            return undefined;
+        },
+    });
+    t.after(() => rolloutAdapter.adapter.dispose());
+
+    const telemetry = await rolloutAdapter.adapter.readTelemetry(sessionId);
+    assert.deepEqual(telemetry.worktree, {
+        branch: 'feature-x',
+        worktreeRoot: '/launch/repo/.worktree/feature-x',
+        repoRoot: '/launch/repo',
+    });
+
+    const fallbackAdapter = createAdapter(fixture, {
+        client: telemetryClient,
+        readCurrentWorkdir: () => undefined,
+        resolveWorktree: async candidate =>
+            candidate === '/launch/repo'
+                ? {
+                    branch: 'main',
+                    worktreeRoot: candidate,
+                    repoRoot: candidate,
+                }
+                : undefined,
+    });
+    t.after(() => fallbackAdapter.adapter.dispose());
+
+    const fallback = await fallbackAdapter.adapter.readTelemetry(sessionId);
+    assert.deepEqual(fallback.worktree, {
+        branch: 'main',
+        worktreeRoot: '/launch/repo',
+        repoRoot: '/launch/repo',
+    });
 });

--- a/tests/contract/aiSessions/kimiConversationAdapter.test.js
+++ b/tests/contract/aiSessions/kimiConversationAdapter.test.js
@@ -553,3 +553,81 @@ test('CONVERSATION-TELEMETRY-001 Kimi surfaces the latest StatusUpdate context w
         rateLimits: [],
     });
 });
+
+test('CONVERSATION-TELEMETRY-001 Kimi resolves the worktree from the newest Shell tool paths', async t => {
+    const source = await createFixture(t);
+    const calls = [];
+    const adapter = createAdapter(source, {
+        resolveWorktree: async candidate => {
+            calls.push(candidate);
+            return candidate === '/repo/.worktree/feat'
+                ? {
+                    branch: 'feat',
+                    worktreeRoot: candidate,
+                    repoRoot: '/repo',
+                }
+                : undefined;
+        },
+    });
+    t.after(() => adapter.dispose());
+
+    assert.equal(await adapter.readTelemetry(sessionId), undefined);
+
+    await fs.promises.appendFile(source.sourcePath, [
+        JSON.stringify({
+            timestamp: 5000,
+            message: {
+                type: 'ToolCall',
+                payload: {
+                    type: 'function',
+                    id: 'Shell_1',
+                    function: {
+                        name: 'Shell',
+                        arguments: JSON.stringify({
+                            command: 'cd /repo && git status',
+                        }),
+                    },
+                },
+            },
+        }),
+        JSON.stringify({
+            timestamp: 6000,
+            message: {
+                type: 'ToolCall',
+                payload: {
+                    type: 'function',
+                    id: 'Shell_2',
+                    function: {
+                        name: 'Shell',
+                        arguments: JSON.stringify({
+                            command: 'cd /repo/.worktree/feat && ls /tmp',
+                        }),
+                    },
+                },
+            },
+        }),
+        JSON.stringify({
+            timestamp: 7000,
+            message: {
+                type: 'ToolCall',
+                payload: {
+                    type: 'function',
+                    id: 'Shell_3',
+                    function: {
+                        name: 'Shell',
+                        arguments: '{malformed',
+                    },
+                },
+            },
+        }),
+        '',
+    ].join('\n'));
+
+    const telemetry = await adapter.readTelemetry(sessionId);
+    assert.deepEqual(telemetry.worktree, {
+        branch: 'feat',
+        worktreeRoot: '/repo/.worktree/feat',
+        repoRoot: '/repo',
+    });
+    assert.deepEqual(calls.slice(0, 2), ['/tmp', '/repo/.worktree/feat']);
+});

--- a/tests/unit/aiSessions/codexRolloutWorkdir.test.js
+++ b/tests/unit/aiSessions/codexRolloutWorkdir.test.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const {
+    readCodexRolloutWorkdir,
+} = require('../../../out/aiSessions/codexRolloutWorkdir');
+
+function execLine(workdir) {
+    return JSON.stringify({
+        type: 'response_item',
+        payload: {
+            type: 'custom_tool_call',
+            name: 'exec',
+            input: `const r = await tools.exec_command({cmd:"git status",workdir:"${workdir}"})`,
+        },
+    });
+}
+
+test('CONVERSATION-TELEMETRY-001 rollout probe reads the newest exec workdir from the transcript tail', async t => {
+    const dir = await fs.promises.mkdtemp(
+        path.join(os.tmpdir(), 'steward-codex-rollout-probe-')
+    );
+    t.after(() => fs.promises.rm(dir, { recursive: true, force: true }));
+    const rolloutPath = path.join(dir, 'rollout.jsonl');
+
+    assert.equal(readCodexRolloutWorkdir(rolloutPath), undefined);
+
+    await fs.promises.writeFile(rolloutPath, [
+        execLine('/launch/repo'),
+        JSON.stringify({ type: 'response_item', payload: { type: 'message' } }),
+        '{"malformed workdir',
+        execLine('/launch/repo/.worktree/feature-x'),
+        '',
+    ].join('\n'));
+    assert.equal(
+        readCodexRolloutWorkdir(rolloutPath),
+        '/launch/repo/.worktree/feature-x'
+    );
+
+    await fs.promises.writeFile(rolloutPath, `${execLine('/launch/repo')}\n`);
+    assert.equal(readCodexRolloutWorkdir(rolloutPath), '/launch/repo');
+
+    await fs.promises.writeFile(
+        rolloutPath,
+        `${JSON.stringify({ type: 'response_item', payload: { type: 'message' } })}\n`
+    );
+    assert.equal(readCodexRolloutWorkdir(rolloutPath), undefined);
+});

--- a/tests/unit/aiSessions/codexSessionFilePath.test.js
+++ b/tests/unit/aiSessions/codexSessionFilePath.test.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const CodexSessionService = require('../../../out/services/codexSessionService').default;
+
+test('CONVERSATION-TELEMETRY-001 resolveSessionFilePath locates rollout files by session id', async t => {
+    // The AiSessionService contract module is type-only; load it once so
+    // changed-line coverage sees the instrumented module.
+    assert.doesNotThrow(() => require('../../../out/aiSessions/types'));
+
+    const home = await fs.promises.mkdtemp(
+        path.join(os.tmpdir(), 'steward-codex-home-')
+    );
+    t.after(() => fs.promises.rm(home, { recursive: true, force: true }));
+    const sessionsDir = path.join(home, 'sessions', '2026', '08', '02');
+    await fs.promises.mkdir(sessionsDir, { recursive: true });
+    const sessionId = '11111111-1111-4111-8111-111111111111';
+    const rolloutPath = path.join(
+        sessionsDir,
+        `rollout-2026-08-02T00-00-00-${sessionId}.jsonl`
+    );
+    await fs.promises.writeFile(rolloutPath, '{}\n');
+
+    process.env.CODEX_HOME = home;
+    t.after(() => {
+        delete process.env.CODEX_HOME;
+    });
+    const service = new CodexSessionService();
+    assert.equal(service.resolveSessionFilePath(sessionId), rolloutPath);
+    assert.equal(service.resolveSessionFilePath('missing-session'), null);
+    assert.equal(service.resolveSessionFilePath(''), null);
+});

--- a/tests/unit/aiSessions/conversationViewerProtocol.test.js
+++ b/tests/unit/aiSessions/conversationViewerProtocol.test.js
@@ -27,6 +27,10 @@ test('CONVERSATION-PROTOCOL-VALIDATOR-001 accepts every exact version-1 viewer i
         version: 1,
         href: 'https://example.test',
     }, {
+        type: 'conversation-viewer-open-worktree',
+        version: 1,
+        worktreeRoot: '/repo/.worktree/feature-x',
+    }, {
         type: 'conversation-viewer-locate-comment',
         version: 1,
         ...target,
@@ -81,6 +85,21 @@ test('CONVERSATION-PROTOCOL-VALIDATOR-001 rejects malformed, inherited, and over
             type: 'conversation-viewer-select-interaction',
             version: 1,
             interactionId: 'input\u0000private',
+        },
+        {
+            type: 'conversation-viewer-open-worktree',
+            version: 1,
+        },
+        {
+            type: 'conversation-viewer-open-worktree',
+            version: 1,
+            worktreeRoot: '/repo\u0000private',
+        },
+        {
+            type: 'conversation-viewer-open-worktree',
+            version: 1,
+            worktreeRoot: '/repo',
+            extra: true,
         },
         {
             type: 'conversation-viewer-bookmark-mutation',

--- a/tests/unit/aiSessions/conversationWorktreeResolver.test.js
+++ b/tests/unit/aiSessions/conversationWorktreeResolver.test.js
@@ -1,0 +1,112 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const childProcess = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const {
+    ConversationWorktreeResolver,
+} = require('../../../out/aiSessions/conversation/worktreeResolver');
+
+// Hermetic git setup: identity comes from -c flags, and every command runs
+// with an empty HOME so global or system config can never leak in.
+function git(cwd, args, env = {}) {
+    return childProcess.execFileSync('git', args, {
+        cwd,
+        encoding: 'utf8',
+        env: {
+            ...process.env,
+            HOME: env.home || '/nonexistent-home',
+            GIT_CONFIG_NOSYSTEM: '1',
+            XDG_CONFIG_HOME: '/nonexistent-xdg',
+            ...env.extra,
+        },
+    }).trim();
+}
+
+function gitCommit(cwd, args) {
+    return git(cwd, [
+        '-c', 'user.name=Agent Pivot Tests',
+        '-c', 'user.email=tests@example.invalid',
+        ...args,
+    ]);
+}
+
+async function createRepo(t) {
+    const root = await fs.promises.mkdtemp(
+        path.join(os.tmpdir(), 'steward-worktree-resolver-')
+    );
+    t.after(() => fs.promises.rm(root, { recursive: true, force: true }));
+    const repo = path.join(root, 'repo');
+    await fs.promises.mkdir(repo);
+    git(repo, ['init', '-b', 'main']);
+    await fs.promises.writeFile(path.join(repo, 'README.md'), 'demo\n');
+    gitCommit(repo, ['add', 'README.md']);
+    gitCommit(repo, ['commit', '-m', 'initial']);
+    return { root, repo };
+}
+
+test('ARCH-SESSION-WORKTREE-001 resolves the main checkout, linked worktrees, and detached HEAD', async t => {
+    const { repo, root } = await createRepo(t);
+    const resolver = new ConversationWorktreeResolver({ now: Date.now });
+
+    const main = await resolver.resolve(path.join(repo));
+    assert.deepEqual(main, {
+        branch: 'main',
+        worktreeRoot: repo,
+        repoRoot: repo,
+    });
+
+    const linked = path.join(root, 'feature-x');
+    git(repo, ['worktree', 'add', '-b', 'feature/x', linked]);
+    const missingDir = path.join(linked, 'missing-dir');
+    const worktree = await resolver.resolve(missingDir);
+    assert.equal(worktree, undefined, 'missing directories do not resolve');
+    const nested = path.join(linked, 'sub', 'dir');
+    await fs.promises.mkdir(nested, { recursive: true });
+    const linkedInfo = await resolver.resolve(nested);
+    assert.deepEqual(linkedInfo, {
+        branch: 'feature/x',
+        worktreeRoot: linked,
+        repoRoot: repo,
+    });
+
+    git(linked, ['checkout', '--detach', 'HEAD']);
+    const detached = await resolver.resolve(linked);
+    assert.match(detached.branch, /^[0-9a-f]{7}$/);
+    assert.equal(detached.worktreeRoot, linked);
+    assert.equal(detached.repoRoot, repo);
+
+    const plain = path.join(root, 'plain');
+    await fs.promises.mkdir(plain);
+    assert.equal(await resolver.resolve(plain), undefined);
+});
+
+test('ARCH-SESSION-WORKTREE-001 caches resolutions briefly and rejects non-absolute paths', async t => {
+    const { repo } = await createRepo(t);
+    let gitCalls = 0;
+    const resolver = new ConversationWorktreeResolver({
+        now: Date.now,
+        execGit: (args, cwd) => new Promise((resolve, reject) => {
+            gitCalls += 1;
+            childProcess.execFile(
+                'git',
+                args,
+                { cwd, timeout: 5000 },
+                (error, stdout, stderr) =>
+                    error ? reject(error) : resolve({ stdout, stderr })
+            );
+        }),
+        cacheTtlMs: 60_000,
+    });
+
+    assert.equal(await resolver.resolve('relative/path'), undefined);
+    assert.equal(gitCalls, 0);
+    const first = await resolver.resolve(repo);
+    const second = await resolver.resolve(repo);
+    assert.deepEqual(second, first);
+    assert.equal(gitCalls, 1, 'the second resolve hits the cache');
+});

--- a/tests/unit/services/sourceControl.test.js
+++ b/tests/unit/services/sourceControl.test.js
@@ -1,0 +1,85 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const Module = require('node:module');
+const test = require('node:test');
+
+const { createFakeVscode } = require('../../helpers/fakeVscode');
+
+function loadSourceControl(fakeVscode) {
+    const modulePath = require.resolve('../../../out/services/sourceControl');
+    delete require.cache[modulePath];
+    const previousLoad = Module._load;
+    try {
+        Module._load = function (request, parent, isMain) {
+            if (request === 'vscode') return fakeVscode;
+            return previousLoad.call(this, request, parent, isMain);
+        };
+        return require(modulePath);
+    } finally {
+        Module._load = previousLoad;
+    }
+}
+
+function createVscodeHarness(overrides = {}) {
+    const api = {
+        openRepository: async () => ({}),
+    };
+    return createFakeVscode({
+        workspace: { fs: { stat: async () => ({ type: 2 }) } },
+        window: { showWarningMessage: async () => undefined },
+        commands: { executeCommand: async () => undefined },
+        extensions: {
+            getExtension: () => ({
+                exports: { getAPI: () => api },
+            }),
+        },
+        Uri: { file: value => ({ scheme: 'file', fsPath: value }) },
+        ...overrides,
+    });
+}
+
+test('ARCH-SESSION-WORKTREE-001 mounts the worktree in Source Control and focuses the view', async () => {
+    const fakeVscode = createVscodeHarness();
+    const { showWorktreeInSourceControl } = loadSourceControl(fakeVscode);
+
+    await showWorktreeInSourceControl('/repo/.worktree/feature-x');
+
+    const surfaces = fakeVscode.calls.map(call =>
+        `${call.surface}.${call.method || ''}`);
+    assert.ok(surfaces.includes('Uri.file'));
+    assert.ok(surfaces.includes('commands.executeCommand'));
+    const focus = fakeVscode.calls.find(call =>
+        call.surface === 'commands' && call.method === 'executeCommand');
+    assert.deepEqual(focus.args, ['workbench.view.scm']);
+    assert.equal(fakeVscode.calls.some(call =>
+        call.surface === 'window' && call.method === 'showWarningMessage'), false);
+});
+
+test('ARCH-SESSION-WORKTREE-001 warns instead of failing on missing paths or a missing Git extension', async () => {
+    const missingPath = createVscodeHarness({
+        workspace: {
+            fs: {
+                stat: async () => {
+                    throw new Error('ENOENT');
+                },
+            },
+        },
+    });
+    const missingModule = loadSourceControl(missingPath);
+    await missingModule.showWorktreeInSourceControl('/repo/.worktree/gone');
+    const missingWarning = missingPath.calls.find(call =>
+        call.surface === 'window' && call.method === 'showWarningMessage');
+    assert.match(missingWarning.args[0], /no longer exists/);
+    assert.equal(missingPath.calls.some(call =>
+        call.surface === 'commands'), false);
+
+    const noGit = createVscodeHarness({
+        extensions: { getExtension: () => undefined },
+    });
+    const noGitModule = loadSourceControl(noGit);
+    await noGitModule.showWorktreeInSourceControl('/repo/.worktree/feature-x');
+    const noGitWarning = noGit.calls.find(call =>
+        call.surface === 'window' && call.method === 'showWarningMessage');
+    assert.match(noGitWarning.args[0], /Git extension is unavailable/);
+});

--- a/tests/unit/tooling/architectureGuards.test.js
+++ b/tests/unit/tooling/architectureGuards.test.js
@@ -45,6 +45,8 @@ function copyGuardFixture(t, mutationPath, mutate = source => source) {
         'src/workspaces/sessionAssignment.ts',
         'src/workspaces/types.ts',
         'src/aiSessions/conversation/composition.ts',
+        'src/aiSessions/conversation/worktreeResolver.ts',
+        'src/aiSessions/codexRolloutWorkdir.ts',
         'src/aiSessions/conversation/kimiAdapter.ts',
         'src/aiSessions/conversation/claudeAdapter.ts',
         'src/aiSessions/conversation/coordinator.ts',


### PR DESCRIPTION
## Summary

The AI Conversation usage bar gains a worktree chip showing the Session's **current operating worktree** (not just its launch directory), resolved live per provider:

- **Claude**: latest event `cwd`/`gitBranch` (follows the bash tool's persistent directory); deleted worktrees degrade to the logged branch with a struck-through label.
- **Codex**: app-server exposes no exec items (verified: 92 turns, 0 exec items), so a telemetry-only rollout-tail probe reads the newest exec `workdir`; `thread/resume`'s `cwd` is the fallback. Conversation content stays app-server-only; the probe is injected from composition so the adapter's architecture boundary holds.
- **Kimi**: newest absolute paths from Shell tool calls, resolved newest-first.

Clicking the chip mounts the worktree repository in Source Control (`git.openRepository`) and focuses the SCM view. Missing Git extension or deleted paths surface a warning instead of failing.

## Verification

- 655 unit/contract tests + 40 conversation-viewer browser tests, behavior-contract catalog, brand identity, tslint baseline — all green after rebase onto latest main.
- New coverage: hermetic real-git resolver tests (empty HOME), three adapter contracts, rollout probe, protocol validator, browser chip render/click/missing-state.
- Packaged and byte-verified install into the active VS Code Server host; manually smoke-tested chip display, dynamic updates across worktree switches, and SCM mounting.

## Notes

- VS Code's public API cannot programmatically select a repository in the SCM list (`Repository.ui.selected` is read-only); mount + focus is the documented ceiling.
- No version bump; release not published.