### PR TITLE
refactor: extract message handlers, controller composition, notify config, and shared helpers from dashboard.ts

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -4428,6 +4428,8 @@
     ],
     "evidence": [
       "src/aiSessions/notify/dispatcher.ts"
+    ,
+      "src/aiSessions/notifyConfiguration.ts"
     ]
   },
   {
@@ -4465,9 +4467,13 @@
     "status": "automated",
     "owners": [
       "tests/unit/aiSessions/notify/credentials.test.js"
+    ,
+      "tests/contract/aiSessions/notifyConfiguration.test.js"
     ],
     "evidence": [
       "src/aiSessions/notifyIntegration/credentials.ts"
+    ,
+      "src/aiSessions/notifyConfiguration.ts"
     ]
   },
   {
@@ -4506,10 +4512,14 @@
     "status": "automated",
     "owners": [
       "tests/unit/aiSessions/notify/guidedSetup.test.js"
+    ,
+      "tests/contract/aiSessions/notifyConfiguration.test.js"
     ],
     "evidence": [
       "src/aiSessions/notifyIntegration/commands.ts",
       "src/aiSessions/notifyIntegration/output.ts"
+    ,
+      "src/aiSessions/notifyConfiguration.ts"
     ]
   },
   {

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -432,9 +432,13 @@
     "status": "automated",
     "owners": [
       "tests/contract/aiSessions/sessionControllers.test.js"
+    ,
+      "tests/contract/dashboard/messageHandlers.test.js"
     ],
     "evidence": [
       "scripts/run-ai-session-safety-checks.js"
+    ,
+      "src/dashboard/messageHandlers.ts"
     ]
   },
   {
@@ -3021,11 +3025,15 @@
       "tests/integration/dashboard/messageRouter.test.js"
     ,
       "tests/contract/projects/projectMessageHandlers.test.js"
+    ,
+      "tests/contract/dashboard/messageHandlers.test.js"
     ],
     "evidence": [
       "src/dashboard/messageRouter.ts"
     ,
       "src/projects/projectMessageHandlers.ts"
+    ,
+      "src/dashboard/messageHandlers.ts"
     ]
   },
   {
@@ -3508,11 +3516,15 @@
     "owners": [
       "tests/contract/aiSessions/archiveAndHydration.test.js",
       "tests/integration/dashboard/webviewState.test.js"
+    ,
+      "tests/contract/dashboard/messageHandlers.test.js"
     ],
     "evidence": [
       "src/aiSessions/archiveBatchAcrossProviders.ts",
       "src/aiSessions/archiveController.ts",
       "scripts/run-ai-session-safety-checks.js"
+    ,
+      "src/dashboard/messageHandlers.ts"
     ]
   },
   {

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -246,6 +246,8 @@
     ],
     "evidence": [
       "scripts/run-ai-session-safety-checks.js"
+    ,
+      "src/aiSessions/sessionHelpers.ts"
     ]
   },
   {
@@ -1106,9 +1108,13 @@
     "status": "automated",
     "owners": [
       "tests/contract/aiSessions/providerSpecificBehavior.test.js"
+    ,
+      "tests/unit/aiSessions/sessionBoundaries.test.js"
     ],
     "evidence": [
       "src/services/codexSessionService.ts"
+    ,
+      "src/aiSessions/sessionHelpers.ts"
     ]
   },
   {
@@ -1119,9 +1125,13 @@
     "status": "automated",
     "owners": [
       "tests/contract/aiSessions/providerSpecificBehavior.test.js"
+    ,
+      "tests/unit/aiSessions/sessionBoundaries.test.js"
     ],
     "evidence": [
       "src/services/claudeSessionService.ts"
+    ,
+      "src/aiSessions/sessionHelpers.ts"
     ]
   },
   {
@@ -1132,12 +1142,16 @@
     "status": "automated",
     "owners": [
       "tests/contract/aiSessions/providerSpecificBehavior.test.js"
+    ,
+      "tests/unit/aiSessions/sessionBoundaries.test.js"
     ],
     "evidence": [
       "src/aiSessions/sessionFingerprint.ts",
       "src/services/claudeSessionService.ts",
       "src/services/codexSessionService.ts",
       "src/services/kimiSessionService.ts"
+    ,
+      "src/aiSessions/sessionHelpers.ts"
     ]
   },
   {

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -392,9 +392,13 @@
     "status": "automated",
     "owners": [
       "tests/contract/aiSessions/sessionControllers.test.js"
+    ,
+      "tests/contract/aiSessions/sessionControllerComposition.test.js"
     ],
     "evidence": [
       "scripts/run-ai-session-safety-checks.js"
+    ,
+      "src/aiSessions/sessionControllerComposition.ts"
     ]
   },
   {
@@ -405,10 +409,14 @@
     "status": "automated",
     "owners": [
       "tests/unit/aiSessions/sessionBoundaries.test.js"
+    ,
+      "tests/contract/aiSessions/sessionControllerComposition.test.js"
     ],
     "evidence": [
       "src/aiSessions/providers.ts",
       "src/dashboard.ts"
+    ,
+      "src/aiSessions/sessionControllerComposition.ts"
     ]
   },
   {
@@ -419,9 +427,13 @@
     "status": "automated",
     "owners": [
       "tests/contract/aiSessions/sessionControllers.test.js"
+    ,
+      "tests/contract/aiSessions/sessionControllerComposition.test.js"
     ],
     "evidence": [
       "scripts/run-ai-session-safety-checks.js"
+    ,
+      "src/aiSessions/sessionControllerComposition.ts"
     ]
   },
   {
@@ -434,11 +446,15 @@
       "tests/contract/aiSessions/sessionControllers.test.js"
     ,
       "tests/contract/dashboard/messageHandlers.test.js"
+    ,
+      "tests/contract/aiSessions/sessionControllerComposition.test.js"
     ],
     "evidence": [
       "scripts/run-ai-session-safety-checks.js"
     ,
       "src/dashboard/messageHandlers.ts"
+    ,
+      "src/aiSessions/sessionControllerComposition.ts"
     ]
   },
   {
@@ -3518,6 +3534,8 @@
       "tests/integration/dashboard/webviewState.test.js"
     ,
       "tests/contract/dashboard/messageHandlers.test.js"
+    ,
+      "tests/contract/aiSessions/sessionControllerComposition.test.js"
     ],
     "evidence": [
       "src/aiSessions/archiveBatchAcrossProviders.ts",
@@ -3525,6 +3543,8 @@
       "scripts/run-ai-session-safety-checks.js"
     ,
       "src/dashboard/messageHandlers.ts"
+    ,
+      "src/aiSessions/sessionControllerComposition.ts"
     ]
   },
   {

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "0a26be7106e6ff264bc4a200820b302b52e88b0e",
+        "head": "546f4b2cb06f295d72576299dd4bcef358b73eff",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -73,7 +73,8 @@
             "2442db899536f40b04d19d8679fc0d427d6367eb",
             "b6d312cf7537442c982aa84b4d0fef4e2c715e14",
             "b842d24f0a64555709e1b6a07f9894ee7a018845",
-            "af9cc7328dc642243b8c9e00cf86869353ced1ac"
+            "af9cc7328dc642243b8c9e00cf86869353ced1ac",
+            "95a9a7bc69b494fcd4f0d902d76370687baf4472"
         ]
     },
     "capabilities": [
@@ -634,7 +635,8 @@
                 "f51aa569d4adb1dd750947181008c3764dbe6163",
                 "289779463fe347fba05bd3655ceded5189612f44",
                 "eb60d0cc5b8aaa9e3f04d797f4d790f40999e378",
-                "9ceb5a4ca604119a69486449699c263f96218c21"
+                "9ceb5a4ca604119a69486449699c263f96218c21",
+                "546f4b2cb06f295d72576299dd4bcef358b73eff"
             ],
             "behaviors": [
                 "ATTENTION-ACTIVE-UNREGISTER-ON-DEACTIVATE-001",
@@ -743,7 +745,9 @@
                 "c97615cee3b2629102643cf3f4560f98201e49d4",
                 "f2a66bf31f9e478e1c66f7db4643d09bc3406aea",
                 "2b82dcf05ce93ddd73217a5309e4ed12464841f6",
-                "059af49ce010a4097ac1e4a847b7c7be430b7171"
+                "059af49ce010a4097ac1e4a847b7c7be430b7171",
+                "892ae70669ed4b08f452f70f3539eed665f3c555",
+                "69c490edf6d6d483e0694bc28d78862edba43334"
             ],
             "behaviors": [
                 "RUNTIME-TMUX-BACKEND-001",
@@ -1213,7 +1217,8 @@
                 "f60bd39d97326e34ca7a228ec491c34ecb5d8b5a",
                 "c172724a4c5d9d0a696382abf03f5ea25fd2841c",
                 "1953cbdb600b933f0e13db18b7c8f507c174a9e1",
-                "404ab50e89380a9e8475d3e919efc650d6c6be60"
+                "404ab50e89380a9e8475d3e919efc650d6c6be60",
+                "e1a18cdb03603bacd4209c6cb56cd69382328751"
             ],
             "behaviors": [
                 "ATTENTION-NOTIFY-EVENT-IDENTITY-001",

--- a/scripts/run-ai-session-safety-checks.js
+++ b/scripts/run-ai-session-safety-checks.js
@@ -4897,6 +4897,10 @@ function runWebviewContentChecks() {
     const runtimeSettlement = fs.readFileSync(
         path.join(__dirname, '..', 'src', 'aiSessions', 'runtimeSettlementCapability.ts'), 'utf8'
     );
+    const messageHandlersSource = fs.readFileSync(
+        path.join(__dirname, '..', 'src', 'dashboard', 'messageHandlers.ts'), 'utf8'
+    );
+
     const webviewProjectScripts = [
         'webviewAiSessionViewStateScripts.js',
         'webviewWorkspaceUpdateScripts.js',
@@ -5230,7 +5234,7 @@ function runWebviewContentChecks() {
     assert.ok(!dashboard.includes('function getEffectiveAiSessionAttentionAggregate('));
     assert.ok(!dashboard.includes('function getAiSessionAttentionRecoverySessionEvents('));
     assert.ok(dashboard.includes('async function evaluateAiSessionAttention('));
-    assert.ok(dashboard.includes("'open-settings': async () =>"));
+    assert.ok(messageHandlersSource.includes("'open-settings': async () =>"));
     assert.ok(settingsFunction.includes('dashboardRuntimeController.openSettings()'));
     assert.ok(dashboardRuntimeControllerSource.includes("executeCommand('workbench.action.openSettings', query)"));
     assert.ok(!settingsFunction.includes('showQuickPick'));
@@ -5388,7 +5392,9 @@ function runWebviewContentChecks() {
     assert.match(dashboard, /onDidChangeWindowState\(windowState => \{[\s\S]*?dashboardLifecycleController\.handleWindowStateChanged\(windowState\);[\s\S]*?\}\)/);
     assert.ok(dashboardLifecycleControllerSource.includes('this.options.evaluateAiSessionAttention();'));
     assert.ok(dashboardLifecycleControllerSource.includes('this.options.publishOpenWorkspace(true);'));
-    assert.ok(dashboard.includes("'request-active-ai-session-terminal': () =>"));
+    assert.ok(messageHandlersSource.includes("'request-active-ai-session-terminal': () =>"));
+    assert.ok(dashboard.includes('requestActiveAiSessionTerminalHighlight: () => activeAiSessionTerminalHighlighter.request()'),
+        'the dashboard wires the highlighter request into the extracted handlers');
     assert.ok(dashboardRuntimeControllerSource.includes("type: 'active-ai-session-terminal-changed'"));
     assert.ok(webviewProjectScripts.includes("type: 'request-active-ai-session-terminal'"));
     assert.ok(webviewProjectScripts.includes("message.type === 'active-ai-session-terminal-changed'"));
@@ -5406,7 +5412,7 @@ function runWebviewContentChecks() {
     assert.ok(!terminalCandidatesSource.includes('getOpenProjects('));
     assert.ok(!terminalCandidatesSource.includes('activeAiSessionProvider'));
     assert.ok(!dashboard.includes('prunePinnedAiSessionKeys'));
-    assert.ok(dashboard.includes("'archive-ai-sessions': async e =>"));
+    assert.ok(messageHandlersSource.includes("'archive-ai-sessions': async e =>"));
     assert.ok(dashboard.includes('AiSessionBatchArchiveCompletedMessage'));
     assert.ok(dashboard.includes("import { AiSessionArchiveController } from './aiSessions/archiveController';"));
     assert.ok(dashboard.includes('const aiSessionArchiveController = new AiSessionArchiveController<AiSessionRuntimeSnapshot<vscode.Terminal>>({'));
@@ -5414,9 +5420,9 @@ function runWebviewContentChecks() {
         dashboard.includes('refreshRuntimeGuard: () => aiSessionRuntimeCoordinator.refreshForHost(true),'),
         'archive confirmation must rescan every runtime backend so a newly external tmux runtime cannot be missed'
     );
-    assert.ok(dashboard.includes('await aiSessionArchiveController.archiveSessions('));
+    assert.ok(messageHandlersSource.includes('await aiSessionArchiveController.archiveSessions('));
     assert.match(
-        dashboard,
+        messageHandlersSource,
         /archiveSessions\(\s*e\.projectId,\s*e\.items,\s*e\.requestId,\s*e\.version\s*\)/
     );
     assert.ok(dashboard.includes('await aiSessionArchiveController.archiveSession('));
@@ -5631,11 +5637,11 @@ function runWebviewContentChecks() {
     assert.ok(!dashboard.includes('async function createAiSession('));
     assert.ok(!dashboard.includes('async function queryNewAiSessionFields('));
     assert.ok(!dashboard.includes('async function createProviderAiSession('));
-    assert.ok(dashboard.includes('await aiSessionCommandController.toggleSessionsExpanded('));
-    assert.ok(dashboard.includes('await aiSessionCommandController.selectProviders('));
-    assert.ok(dashboard.includes('await aiSessionCommandController.togglePin('));
-    assert.ok(dashboard.includes('await aiSessionCommandController.renameSession('));
-    assert.ok(dashboard.includes('await aiSessionCommandController.copySessionId('));
+    assert.ok(messageHandlersSource.includes('await aiSessionCommandController.toggleSessionsExpanded('));
+    assert.ok(messageHandlersSource.includes('await aiSessionCommandController.selectProviders('));
+    assert.ok(messageHandlersSource.includes('await aiSessionCommandController.togglePin('));
+    assert.ok(messageHandlersSource.includes('await aiSessionCommandController.renameSession('));
+    assert.ok(messageHandlersSource.includes('await aiSessionCommandController.copySessionId('));
     assert.ok(dashboard.includes('await aiSessionCreationController.createSession('));
     assert.ok(dashboard.includes('await aiSessionResumeController.resumeProjectSession('));
     assert.ok(!dashboard.includes('async function resumeProjectAiSession('));

--- a/scripts/run-ai-session-safety-checks.js
+++ b/scripts/run-ai-session-safety-checks.js
@@ -4900,6 +4900,9 @@ function runWebviewContentChecks() {
     const messageHandlersSource = fs.readFileSync(
         path.join(__dirname, '..', 'src', 'dashboard', 'messageHandlers.ts'), 'utf8'
     );
+    const compositionSource = fs.readFileSync(
+        path.join(__dirname, '..', 'src', 'aiSessions', 'sessionControllerComposition.ts'), 'utf8'
+    );
 
     const webviewProjectScripts = [
         'webviewAiSessionViewStateScripts.js',
@@ -5240,18 +5243,24 @@ function runWebviewContentChecks() {
     assert.ok(!settingsFunction.includes('showQuickPick'));
     assert.ok(!settingsFunction.includes('ai-session-terminal-mode-planned'));
     assert.ok(dashboard.includes('new AiSessionPinStore(context.globalStoragePath)'));
-    assert.ok(dashboard.includes("import { AiSessionCommandController } from './aiSessions/commandController';"));
-    assert.ok(dashboard.includes("import { AiSessionCreationController } from './aiSessions/creationController';"));
-    assert.ok(dashboard.includes("import { AiSessionResumeController } from './aiSessions/resumeController';"));
-    assert.ok(dashboard.includes('const aiSessionCommandController = new AiSessionCommandController({'));
-    assert.ok(dashboard.includes('const aiSessionCreationController = new AiSessionCreationController({'));
-    assert.ok(dashboard.includes('const aiSessionResumeController = new AiSessionResumeController<vscode.Terminal>({'));
+    assert.ok(compositionSource.includes("import { AiSessionCommandController } from './commandController';"));
+    assert.ok(compositionSource.includes("import { AiSessionCreationController } from './creationController';"));
+    assert.ok(compositionSource.includes("import { AiSessionResumeController } from './resumeController';"));
+    assert.ok(compositionSource.includes('factories.createCommandController({'));
+    assert.ok(compositionSource.includes('createCommandController: options => new AiSessionCommandController(options)'));
+    assert.ok(compositionSource.includes('factories.createCreationController({'));
+    assert.ok(compositionSource.includes('createCreationController: options => new AiSessionCreationController(options)'));
+    assert.ok(compositionSource.includes('factories.createResumeController({'));
+    assert.ok(compositionSource.includes('createResumeController: options => new AiSessionResumeController(options)'));
+    assert.ok(dashboard.includes('createSessionControllerComposition({'),
+        'the dashboard constructs the extracted session controller composition');
     assert.ok(dashboard.includes(
         "import { readAiSessionLaunchOptions } from './aiSessions/launchOptions';"
     ));
     assert.strictEqual(
-        (dashboard.match(/getLaunchOptions: \(\) =>/g) || []).length,
-        2
+        (compositionSource.match(/getLaunchOptions,/g) || []).length,
+        2,
+        'both creation and resume read launch options through the injected live read'
     );
     assert.ok(dashboard.includes(
         'readAiSessionLaunchOptions(vscode.workspace)'
@@ -5261,8 +5270,8 @@ function runWebviewContentChecks() {
     ), 'YOLO configuration must not pass through the legacy dashboard fallback');
     assert.ok(dashboard.includes('new AiSessionPinController({'));
     assert.ok(dashboard.includes('aiSessionPinController.getAll()'));
-    assert.ok(dashboard.includes('aiSessionPinController.toggle('));
-    assert.ok(dashboard.includes('aiSessionPinController.remove('));
+    assert.ok(compositionSource.includes('aiSessionPinController.toggle('));
+    assert.ok(compositionSource.includes('aiSessionPinController.remove('));
     assert.ok(!dashboard.includes('aiSessionPinController.migrateLegacy('));
     assert.ok(!dashboard.includes('function getPinnedAiSessionKeys('));
     assert.ok(!dashboard.includes('function migrateLegacyPinnedAiSessions('));
@@ -5414,10 +5423,10 @@ function runWebviewContentChecks() {
     assert.ok(!dashboard.includes('prunePinnedAiSessionKeys'));
     assert.ok(messageHandlersSource.includes("'archive-ai-sessions': async e =>"));
     assert.ok(dashboard.includes('AiSessionBatchArchiveCompletedMessage'));
-    assert.ok(dashboard.includes("import { AiSessionArchiveController } from './aiSessions/archiveController';"));
-    assert.ok(dashboard.includes('const aiSessionArchiveController = new AiSessionArchiveController<AiSessionRuntimeSnapshot<vscode.Terminal>>({'));
+    assert.ok(compositionSource.includes("import { AiSessionArchiveController } from './archiveController';"));
+    assert.ok(compositionSource.includes('factories.createArchiveController({'));
     assert.ok(
-        dashboard.includes('refreshRuntimeGuard: () => aiSessionRuntimeCoordinator.refreshForHost(true),'),
+        compositionSource.includes('refreshRuntimeGuard: () => aiSessionRuntimeCoordinator.refreshForHost(true),'),
         'archive confirmation must rescan every runtime backend so a newly external tmux runtime cannot be missed'
     );
     assert.ok(messageHandlersSource.includes('await aiSessionArchiveController.archiveSessions('));
@@ -5615,20 +5624,20 @@ function runWebviewContentChecks() {
     assert.ok(!dashboard.includes('function getAiSessionAliasesPath('));
     assert.ok(dashboard.includes('new AiSessionAliasController({'));
     assert.ok(dashboard.includes('aiSessionAliasController.getAll()'));
-    assert.ok(dashboard.includes('aiSessionAliasController.saveAll(aliases)'));
+    assert.ok(compositionSource.includes('aiSessionAliasController.saveAll(aliases)'));
     assert.strictEqual((dashboard.match(/aiSessionAliasController\.set\(/g) || []).length, 1,
         'workspace pending promotion must persist the resolved Session alias once');
-    assert.ok(dashboard.includes('aiSessionAliasController.remove('));
-    assert.ok(dashboard.includes('aiSessionAliasController.getOriginalName('));
+    assert.ok(compositionSource.includes('aiSessionAliasController.remove('));
+    assert.ok(compositionSource.includes('aiSessionAliasController.getOriginalName('));
     assert.ok(!dashboard.includes('function getAiSessionAliases('));
     assert.ok(!dashboard.includes('function saveAiSessionAliases('));
     assert.ok(!dashboard.includes('function deleteAiSessionAlias('));
     assert.ok(!dashboard.includes('function setAiSessionAlias('));
     assert.ok(!dashboard.includes('function getAiSessionOriginalName('));
     assert.ok(dashboard.includes('aiSessionWorkspaceStateStore.getExpandedWorkspaces()'));
-    assert.ok(dashboard.includes('aiSessionWorkspaceStateStore.setExpanded('));
+    assert.ok(compositionSource.includes('aiSessionWorkspaceStateStore.setExpanded('));
     assert.ok(dashboard.includes('aiSessionWorkspaceStateStore.getActiveProviders()'));
-    assert.ok(dashboard.includes('aiSessionWorkspaceStateStore.setProviderSelection('));
+    assert.ok(compositionSource.includes('aiSessionWorkspaceStateStore.setProviderSelection('));
     assert.ok(!dashboard.includes('async function toggleCodexSessions('));
     assert.ok(!dashboard.includes('async function selectAiSessionProvider('));
     assert.ok(!dashboard.includes('async function toggleAiSessionPin('));
@@ -7281,10 +7290,18 @@ function runAiSessionIncrementalRefreshSourceChecks() {
     assert.ok(refreshFunction.includes('aiSessionDashboardController.refreshNow()'));
     assert.ok(dashboard.includes('new WorkspaceSessionHydrationController<vscode.Terminal>({'));
     assert.ok(dashboard.includes('getCurrentWorkspaceAiSessions: workspace => workspaceSessionHydrationController.hydrate(workspace)'));
+    const sessionControllerCompositionSource = fs.readFileSync(
+        path.join(root, 'src', 'aiSessions', 'sessionControllerComposition.ts'), 'utf8'
+    );
+    assert.strictEqual(
+        (sessionControllerCompositionSource.match(/getWorkspaceTarget: getCurrentWorkspaceActionTarget/g) || []).length,
+        5,
+        'the extracted session action controllers must resolve the v2 current workspace',
+    );
     assert.strictEqual(
         (dashboard.match(/getWorkspaceTarget: getCurrentWorkspaceActionTarget/g) || []).length,
-        7,
-        'all live AI action and attention controllers must resolve the v2 current workspace',
+        2,
+        'the remaining attention and conversation consumers must resolve the v2 current workspace',
     );
     assert.ok(dashboard.includes(
         'submitPrompt: (viewerTarget, prompt) => submitConversationPrompt({'

--- a/scripts/run-ai-session-tmux-checks.js
+++ b/scripts/run-ai-session-tmux-checks.js
@@ -9605,7 +9605,10 @@ async function runRuntimeControllerChecks() {
 
 function runHostRuntimeCompositionChecks() {
     const dashboardSource = fs.readFileSync(path.join(__dirname, '..', 'src', 'dashboard.ts'), 'utf8');
-    assert.ok(dashboardSource.includes(
+    const compositionSource = fs.readFileSync(
+        path.join(__dirname, '..', 'src', 'aiSessions', 'sessionControllerComposition.ts'), 'utf8'
+    );
+    assert.ok(compositionSource.includes(
         'buildAiSessionProviderPicks(getRegisteredAiSessionProviders())'
     ));
     assert.ok(!dashboardSource.includes('isCommandAvailableOnPath'));
@@ -9628,7 +9631,7 @@ function runHostRuntimeCompositionChecks() {
     assert.ok(dashboardSource.includes('getActiveRuntimes: () => aiSessionRuntimeCoordinator.getActive()'));
     assert.ok(dashboardSource.includes('getPendingRuntimes: () => aiSessionRuntimeCoordinator.getPending()'));
     assert.ok(dashboardSource.includes('findTmuxCollisionRuntime('));
-    assert.ok(dashboardSource.includes('getRuntimeConflict: getAiSessionRuntimeCollision'));
+    assert.ok(compositionSource.includes('getRuntimeConflict: getAiSessionRuntimeCollision'));
     assert.ok(dashboardSource.includes('getFocusedAiSessionRuntimeIdentity()'));
     assert.ok(dashboardSource.includes('tmuxRuntimeBackend.getFocusedRuntime(activeTerminal)'));
     assert.ok(dashboardSource.includes('getAttachTerminalName: getAiSessionTmuxAttachTerminalName'));
@@ -9661,10 +9664,10 @@ function runHostRuntimeCompositionChecks() {
     assert.match(messageHandlersSource,
         /'close-ai-session-terminal':[\s\S]*?expectedBackend: 'vscode'[\s\S]*?'detach-ai-session-terminal':[\s\S]*?expectedBackend: 'tmux'/,
         'host routes must constrain close/detach to the requested runtime backend');
-    assert.ok(dashboardSource.includes('chooseRuntimeConflict:'));
+    assert.ok(compositionSource.includes('chooseRuntimeConflict:'));
     assert.ok(dashboardSource.includes('vscode.window.showQuickPick'));
-    assert.ok(dashboardSource.includes("runtime.backend === 'tmux'"));
-    assert.ok(dashboardSource.includes("runtime.attached ? 'attached' : 'detached'"));
+    assert.ok(compositionSource.includes("runtime.backend === 'tmux'"));
+    assert.ok(compositionSource.includes("runtime.attached ? 'attached' : 'detached'"));
     const directRestore = dashboardSource.indexOf(
         'aiSessionTerminalService.restorePersistedTerminals(vscode.window.terminals)'
     );

--- a/scripts/run-ai-session-tmux-checks.js
+++ b/scripts/run-ai-session-tmux-checks.js
@@ -9655,7 +9655,10 @@ function runHostRuntimeCompositionChecks() {
     assert.ok(!dashboardSource.includes(
         'getActiveTerminal: (providerId, sessionId) => aiSessionTerminalService.getActiveById'
     ));
-    assert.match(dashboardSource,
+    const messageHandlersSource = fs.readFileSync(
+        path.join(__dirname, '..', 'src', 'dashboard', 'messageHandlers.ts'), 'utf8'
+    );
+    assert.match(messageHandlersSource,
         /'close-ai-session-terminal':[\s\S]*?expectedBackend: 'vscode'[\s\S]*?'detach-ai-session-terminal':[\s\S]*?expectedBackend: 'tmux'/,
         'host routes must constrain close/detach to the requested runtime backend');
     assert.ok(dashboardSource.includes('chooseRuntimeConflict:'));

--- a/scripts/run-dashboard-webview-checks.js
+++ b/scripts/run-dashboard-webview-checks.js
@@ -4540,16 +4540,23 @@ function runSourceContractChecks(source) {
     assert.ok(source.includes('scrollPositions'));
     assert.ok(source.includes('acceptedProjectsRequestId'));
     assert.ok(source.includes('pendingScrollRestoreTab'));
-    assert.ok(extensionHostSource.includes("'request-projects-panel': async e =>"));
+    const messageHandlersSource = fs.readFileSync(
+        path.join(__dirname, '..', 'src', 'dashboard', 'messageHandlers.ts'), 'utf8'
+    );
+    assert.ok(messageHandlersSource.includes("'request-projects-panel': async e =>"));
+    assert.ok(extensionHostSource.includes('...dashboardMessageHandlers,'),
+        'the dashboard spreads the extracted message handlers into the router');
     assert.ok(todoPanelCapabilitySource.includes("'request-todo-panel': async e =>"));
     assert.ok(packageJson.includes('"agentPivot.maxVisibleTodosPerGroup"'));
     assert.ok(packageJson.includes('Maximum number of TODO cards visible in each group before the group list scrolls.'));
     assert.ok(packageJson.includes('"agentPivot.maxVisibleProjectsPerGroup"'));
     assert.strictEqual(extensionHostSource.includes('function handleStewardMessage('), false);
     assert.ok(extensionHostSource.includes('getAiSessionProviderIds: () => getRegisteredAiSessionProviders().map(provider => provider.id)'));
-    assert.ok(extensionHostSource.includes("type: 'projects-panel-content'"));
+    assert.ok(messageHandlersSource.includes("type: 'projects-panel-content'"));
     assert.ok(todoPanelCapabilitySource.includes("type: 'todo-panel-content'"));
-    assert.ok(extensionHostSource.includes('getProjectsPanelContent(projectService.getGroups(), stewardInfos)'));
+    assert.ok(messageHandlersSource.includes('getProjectsPanelContent(projectService.getGroups(), getStewardInfos())'));
+    assert.ok(extensionHostSource.includes('getStewardInfos: () => stewardInfos'),
+        'the dashboard wires steward infos into the extracted panel handler');
     assert.ok(todoPanelCapabilitySource.includes('getTodoPanelContent('));
     assert.ok(todoPanelCapabilitySource.includes('buildTodoViewModel(todoData, todoViewState, revealedTodoId)'));
     assert.ok(todoPanelCapabilitySource.includes('todoRenderOptions'));

--- a/src/aiSessions/notifyConfiguration.ts
+++ b/src/aiSessions/notifyConfiguration.ts
@@ -1,0 +1,160 @@
+'use strict';
+
+import * as path from 'path';
+import type * as vscode from 'vscode';
+import { NotifyDispatcher } from './notify/dispatcher';
+import { createHttpsTransport } from './notify/httpClient';
+import { NotifiedEventStore } from './notify/store';
+import type { NotifyConfig } from './notify/types';
+import { registerNotifyCommands, resolveNotifySecretStorage } from './notifyIntegration/commands';
+import { assembleNotifyConfig, NOTIFY_SECRET_KEY_PREFIX } from './notifyIntegration/credentials';
+import { createNotifyOutputChannel } from './notifyIntegration/output';
+import type { NotifyOutput } from './notifyIntegration/output';
+
+export interface NotifyConfigurationOptions {
+    context: vscode.ExtensionContext;
+    getConfiguration: () => vscode.WorkspaceConfiguration;
+    configurationTargetGlobal: vscode.ConfigurationTarget;
+    homedir: () => string;
+    env: NodeJS.ProcessEnv;
+    nowMs: () => number;
+    setTimeout: (handler: () => void, ms: number) => unknown;
+    clearTimeout: (handle: unknown) => void;
+    sleep: (ms: number) => Promise<void>;
+    showWarningMessage: (
+        message: string,
+        options: vscode.MessageOptions,
+        ...items: string[]
+    ) => Thenable<string | undefined>;
+}
+
+export interface NotifyConfiguration {
+    output: NotifyOutput;
+    dispatcher: NotifyDispatcher;
+    getConfig: () => NotifyConfig | null;
+    /** Refreshes the assembled config; never throws (keeps the previous one). */
+    refresh: () => Promise<void>;
+    dispose(): void;
+}
+
+/**
+ * Owns the notification configuration wiring: the output channel, the notified
+ * event store, the dispatcher, the consent-gated config assembly with secret
+ * storage, the secret-change listener, and the notify palette commands.
+ *
+ * Extracted from `initializeDashboard` in src/dashboard.ts. Behaviour is
+ * unchanged; notify delivery has manual acceptance coverage in
+ * docs/manual-tests/notification-delivery.md. The factory subscribes the
+ * secret listener before the dashboard runs the first `refresh()`, so a secret
+ * write during bootstrap now triggers one extra idempotent refresh instead of
+ * being missed.
+ */
+export function createNotifyConfiguration(
+    options: NotifyConfigurationOptions
+): NotifyConfiguration {
+    const context = options.context;
+    const getConfiguration = options.getConfiguration;
+    const showWarningMessage = options.showWarningMessage;
+    const notifyOutput = createNotifyOutputChannel();
+    const notifiedStore = new NotifiedEventStore(
+        path.join(options.homedir(), '.agent-pivot', 'notified.json'));
+    notifiedStore.load();
+    let currentNotifyConfig: NotifyConfig | null = null;
+    const notifyDispatcher = new NotifyDispatcher({
+        transport: createHttpsTransport(),
+        store: notifiedStore,
+        nowMs: () => options.nowMs(),
+        setTimeout: (handler, ms) => options.setTimeout(handler, ms),
+        clearTimeout: handle => options.clearTimeout(handle),
+        sleep: ms => options.sleep(ms),
+        globalProxy: () => getConfiguration().get<string>('notify.proxy', ''),
+        env: options.env,
+        onLog: line => notifyOutput.log(line),
+    });
+    const refreshNotifyConfig = async (): Promise<void> => {
+        try {
+            await refreshNotifyConfigUnsafe();
+        } catch (error) {
+            // 通知配置刷新绝不能让 Dashboard 激活/运行崩溃;保留上一份配置。
+            notifyOutput.log(`notify: config refresh failed: ${(error as Error).message}`);
+        }
+    };
+    const refreshNotifyConfigUnsafe = async (): Promise<void> => {
+        const configuration = getConfiguration();
+        const enabled = configuration.get<boolean>('notify.enabled', false);
+        if (enabled && !context.globalState.get<boolean>('agentPivot.notify.consented')) {
+            const choice = await showWarningMessage(
+                'Agent Pivot will send project names, session names and status to the '
+                + 'notification endpoints you configure. No code or file contents are sent. Continue?',
+                { modal: true },
+                'Enable notifications'
+            );
+            if (choice !== 'Enable notifications') {
+                await configuration.update(
+                    'notify.enabled', false, options.configurationTargetGlobal);
+                return;
+            }
+            await context.globalState.update('agentPivot.notify.consented', true);
+        }
+        const skeletons = configuration.get<Array<Record<string, unknown>>>('notify.sinks', []);
+        const secretStorage = resolveNotifySecretStorage(context);
+        const secrets: Record<string, string> = {};
+        for (const skeleton of skeletons) {
+            const id = typeof skeleton.id === 'string' ? skeleton.id : '';
+            if (!id) {
+                continue;
+            }
+            const stored = secretStorage
+                ? await secretStorage.get(`${NOTIFY_SECRET_KEY_PREFIX}${id}`)
+                : undefined;
+            if (stored) {
+                secrets[id] = stored;
+            }
+        }
+        const assembled = assembleNotifyConfig({
+            enabled,
+            sinks: skeletons,
+            reasons: configuration.get<string[]>('notify.reasons',
+                ['completed', 'input-required', 'failed']),
+            minRunDurationMs: configuration.get<number>('notify.minRunDurationMs', 60000),
+            debounceMs: configuration.get<number>('notify.debounceMs', 5000),
+            rateLimitPerMin: configuration.get<number>('notify.rateLimitPerMin', 6),
+            escalateAfterMs: configuration.get<number>('notify.escalateAfterMs', 0),
+            projectPathMode: configuration.get<string>('notify.projectPathMode', 'basename'),
+            includeSessionLabel: configuration.get<boolean>('notify.includeSessionLabel', true),
+        }, secrets, line => notifyOutput.log(line));
+        currentNotifyConfig = assembled;
+        notifyDispatcher.setConfig(assembled);
+    };
+    // 凭据写入不触发配置变化事件,必须单独监听,否则存完凭据后 dispatcher
+    // 仍拿着存凭据之前装配的空 sinks 配置,直到下次配置变更或重载。
+    const notifySecretChanges = resolveNotifySecretStorage(context);
+    const onNotifySecretChange = notifySecretChanges?.onDidChange;
+    const disposables: vscode.Disposable[] = [];
+    if (onNotifySecretChange) {
+        disposables.push(onNotifySecretChange(event => {
+            if (event.key.startsWith(NOTIFY_SECRET_KEY_PREFIX)) {
+                void refreshNotifyConfig();
+            }
+        }));
+    }
+    disposables.push(...registerNotifyCommands(context, {
+        output: notifyOutput,
+        getConfig: () => currentNotifyConfig || assembleNotifyConfig({
+            enabled: false, sinks: [], reasons: [], minRunDurationMs: 0,
+            debounceMs: 0, rateLimitPerMin: 1, escalateAfterMs: 0,
+            projectPathMode: 'basename', includeSessionLabel: true,
+        }, {}),
+        globalProxy: () => getConfiguration().get<string>('notify.proxy', ''),
+    }));
+    return {
+        output: notifyOutput,
+        dispatcher: notifyDispatcher,
+        getConfig: () => currentNotifyConfig,
+        refresh: refreshNotifyConfig,
+        dispose: () => {
+            disposables.forEach(disposable => disposable.dispose());
+            notifyOutput.dispose();
+        },
+    };
+}

--- a/src/aiSessions/sessionControllerComposition.ts
+++ b/src/aiSessions/sessionControllerComposition.ts
@@ -1,0 +1,419 @@
+'use strict';
+
+import { randomBytes } from 'crypto';
+import { statSync } from 'fs';
+import type * as vscode from 'vscode';
+import { isAiSessionProviderId } from '../models';
+import type { AiSessionProviderId } from '../models';
+import type { OpenWorkspace } from '../workspaces/types';
+import type { WorkspacePrimaryRootStore } from '../workspaces/primaryRootStore';
+import type { ActiveAiSessionTerminalIdentity } from './activeTerminalHighlight';
+import type AiSessionAliasController from './aliasController';
+import { AiSessionArchiveController } from './archiveController';
+import type { AiSessionArchiveControllerOptions } from './archiveController';
+import { AiSessionCommandController } from './commandController';
+import type { AiSessionCommandControllerOptions } from './commandController';
+import { AiSessionCreationController } from './creationController';
+import type { AiSessionCreationControllerOptions } from './creationController';
+import { readAiSessionLaunchOptions } from './launchOptions';
+import { getAiSessionIdsForCwd } from './pendingTerminals';
+import type AiSessionPinController from './pinController';
+import type { ProviderDirectoryCapabilityProbe } from './providerDirectoryCapability';
+import { buildAiSessionProviderPicks, getAiSessionProviderLabel } from './providers';
+import type { AiSessionReadCoordinator } from './readCoordinator';
+import { AiSessionResumeController } from './resumeController';
+import type { AiSessionResumeControllerOptions } from './resumeController';
+import type { AiSessionRuntimeCoordinator } from './runtimeCoordinator';
+import type { AiSessionRuntimeSnapshot } from './runtimeTypes';
+import { getAiSessionTerminalName as getProviderAiSessionTerminalName } from './sessionPaths';
+import { AiSessionTerminalCommandController } from './terminalCommandController';
+import type { AiSessionTerminalCommandControllerOptions } from './terminalCommandController';
+import type AiSessionTerminalService from './terminalService';
+import type {
+    AiSessionBatchArchiveCompletedMessage,
+    AiSessionProvider,
+    WorkspaceAiSessionActionTarget,
+} from './types';
+import type AiSessionWorkspaceStateStore from './workspaceStateStore';
+
+export interface SessionControllerCompositionOptions {
+    getCurrentWorkspaceActionTarget: (cardId: string) => WorkspaceAiSessionActionTarget | null;
+    getCurrentOpenWorkspace: () => OpenWorkspace | null;
+    getActiveEditorUri: () => vscode.Uri | undefined;
+    isWorkspaceTrusted: () => boolean;
+    getRegisteredAiSessionProvider: (providerId: AiSessionProviderId) => AiSessionProvider;
+    getRegisteredAiSessionProviders: () => AiSessionProvider[];
+    providerDirectoryCapability: ProviderDirectoryCapabilityProbe;
+    workspacePrimaryRootStore: WorkspacePrimaryRootStore;
+    aiSessionWorkspaceStateStore: AiSessionWorkspaceStateStore;
+    aiSessionPinController: AiSessionPinController;
+    aiSessionAliasController: AiSessionAliasController;
+    aiSessionReadCoordinator: AiSessionReadCoordinator;
+    aiSessionRuntimeCoordinator: AiSessionRuntimeCoordinator<vscode.Terminal>;
+    aiSessionTerminalService: AiSessionTerminalService;
+    aiSessionProviders: AiSessionProvider[];
+    getAiSessionRuntimeById: (
+        providerId: AiSessionProviderId,
+        sessionId: string
+    ) => AiSessionRuntimeSnapshot<vscode.Terminal> | null;
+    getAiSessionRuntimeCollision: (
+        providerId: AiSessionProviderId,
+        sessionId: string,
+        workspaceScopeIdentity: string
+    ) => AiSessionRuntimeSnapshot<vscode.Terminal> | null;
+    getAiSessionPinKey: (providerId: AiSessionProviderId, sessionId: string) => string;
+    /** Late-bound: the settlement capability is constructed after the controllers. */
+    runSafeLifecycleTask: (
+        operation: string,
+        task: () => unknown | Promise<unknown>
+    ) => Promise<void>;
+    /** Late-bound: the attention acknowledgement is constructed after the controllers. */
+    acknowledgeAttention: (identity: ActiveAiSessionTerminalIdentity) => Promise<void>;
+    /** Late-bound: the highlighter is constructed after the controllers. */
+    syncActiveRuntime: () => void;
+    getLaunchOptions: () => ReturnType<typeof readAiSessionLaunchOptions>;
+    postMessage: (message: unknown) => Thenable<unknown>;
+    appendOutput: (message: string) => void;
+    postBatchArchiveCompletion: (message: AiSessionBatchArchiveCompletedMessage) => void;
+    logError: (message: string, error: unknown) => void;
+    logAiSessionRuntimeFailure: (operation: string, error: unknown, backend?: 'vscode' | 'tmux') => void;
+    refreshAiSessionViewsIncrementally: () => void;
+    scheduleNewAiSessionRefresh: (providerId: AiSessionProviderId) => void;
+    nowMs: () => number;
+    showInputBox: (options: vscode.InputBoxOptions) => Thenable<string | undefined>;
+    showQuickPick: <T extends vscode.QuickPickItem>(
+        items: T[],
+        options: vscode.QuickPickOptions
+    ) => Thenable<T | undefined>;
+    showWarningMessage: (message: string) => Thenable<string | undefined>;
+    showWarningWithItems: (message: string, ...items: string[]) => Thenable<string | undefined>;
+    showModalWarning: (message: string, action: string) => Thenable<string | undefined>;
+    showInformationMessage: (message: string) => Thenable<string | undefined>;
+    showErrorMessage: (message: string) => Thenable<string | undefined>;
+    writeClipboard: (value: string) => Thenable<void>;
+    focusTerminalView: () => Thenable<unknown>;
+}
+
+export interface SessionControllerComposition {
+    aiSessionCommandController: AiSessionCommandController;
+    aiSessionCreationController: AiSessionCreationController;
+    aiSessionArchiveController: AiSessionArchiveController<AiSessionRuntimeSnapshot<vscode.Terminal>>;
+    aiSessionTerminalCommandController: AiSessionTerminalCommandController<vscode.Terminal>;
+    aiSessionResumeController: AiSessionResumeController<vscode.Terminal>;
+}
+
+/**
+ * Owns the construction wiring of the five session action controllers:
+ * command, creation, archive, terminal command, and resume, including the
+ * workspace-root and provider quick picks shared by their options.
+ *
+ * Extracted from `initializeDashboard` in src/dashboard.ts. Behaviour is
+ * unchanged: the option literals are the same; only their ownership moved.
+ */
+interface SessionControllerCompositionFactories {
+    createCommandController(options: AiSessionCommandControllerOptions): AiSessionCommandController;
+    createCreationController(options: AiSessionCreationControllerOptions): AiSessionCreationController;
+    createArchiveController(
+        options: AiSessionArchiveControllerOptions<AiSessionRuntimeSnapshot<vscode.Terminal>>
+    ): AiSessionArchiveController<AiSessionRuntimeSnapshot<vscode.Terminal>>;
+    createTerminalCommandController(
+        options: AiSessionTerminalCommandControllerOptions<vscode.Terminal>
+    ): AiSessionTerminalCommandController<vscode.Terminal>;
+    createResumeController(
+        options: AiSessionResumeControllerOptions<vscode.Terminal>
+    ): AiSessionResumeController<vscode.Terminal>;
+}
+
+const DEFAULT_FACTORIES: SessionControllerCompositionFactories = {
+    createCommandController: options => new AiSessionCommandController(options),
+    createCreationController: options => new AiSessionCreationController(options),
+    createArchiveController: options => new AiSessionArchiveController(options),
+    createTerminalCommandController: options => new AiSessionTerminalCommandController(options),
+    createResumeController: options => new AiSessionResumeController(options),
+};
+
+export function createSessionControllerComposition(
+    options: SessionControllerCompositionOptions,
+    internalFactories: Partial<SessionControllerCompositionFactories> = {}
+): SessionControllerComposition {
+    const factories = { ...DEFAULT_FACTORIES, ...internalFactories };
+    const getCurrentWorkspaceActionTarget = options.getCurrentWorkspaceActionTarget;
+    const getCurrentOpenWorkspace = options.getCurrentOpenWorkspace;
+    const getRegisteredAiSessionProvider = options.getRegisteredAiSessionProvider;
+    const getRegisteredAiSessionProviders = options.getRegisteredAiSessionProviders;
+    const providerDirectoryCapability = options.providerDirectoryCapability;
+    const workspacePrimaryRootStore = options.workspacePrimaryRootStore;
+    const aiSessionWorkspaceStateStore = options.aiSessionWorkspaceStateStore;
+    const aiSessionPinController = options.aiSessionPinController;
+    const aiSessionAliasController = options.aiSessionAliasController;
+    const aiSessionReadCoordinator = options.aiSessionReadCoordinator;
+    const aiSessionRuntimeCoordinator = options.aiSessionRuntimeCoordinator;
+    const aiSessionTerminalService = options.aiSessionTerminalService;
+    const aiSessionProviders = options.aiSessionProviders;
+    const getAiSessionRuntimeById = options.getAiSessionRuntimeById;
+    const getAiSessionRuntimeCollision = options.getAiSessionRuntimeCollision;
+    const getAiSessionPinKey = options.getAiSessionPinKey;
+    const runSafeAiSessionRuntimeLifecycleTask = options.runSafeLifecycleTask;
+    const acknowledgeAiSessionAttention = options.acknowledgeAttention;
+    const getLaunchOptions = options.getLaunchOptions;
+    const postMessage = options.postMessage;
+    const appendOutput = options.appendOutput;
+    const postBatchArchiveCompletion = options.postBatchArchiveCompletion;
+    const logError = options.logError;
+    const logAiSessionRuntimeFailure = options.logAiSessionRuntimeFailure;
+    const refreshAiSessionViewsIncrementally = options.refreshAiSessionViewsIncrementally;
+    const scheduleNewAiSessionRefresh = options.scheduleNewAiSessionRefresh;
+    const nowMs = options.nowMs;
+    const showInputBox = options.showInputBox;
+    const showQuickPick = options.showQuickPick;
+    const showWarningMessage = options.showWarningMessage;
+    const showWarningWithItems = options.showWarningWithItems;
+    const showModalWarning = options.showModalWarning;
+    const showInformationMessage = options.showInformationMessage;
+    const showErrorMessage = options.showErrorMessage;
+    const writeClipboard = options.writeClipboard;
+    const focusTerminalView = options.focusTerminalView;
+
+    const pickAiSessionWorkspaceRoot = async (
+        workspace: OpenWorkspace,
+        action: 'create' | 'resume'
+    ): Promise<string | undefined> => {
+        const selected = await showQuickPick(
+            workspace.roots.map(root => ({
+                label: root.name,
+                description: root.hostPath,
+                rootId: root.id,
+            })),
+            {
+                placeHolder: 'Select a workspace root',
+                ignoreFocusOut: true,
+                title: action === 'resume'
+                    ? 'Resume AI Session in Workspace Root'
+                    : 'New AI Session Working Directory',
+            } as vscode.QuickPickOptions & { title: string }
+        );
+        return selected?.rootId;
+    };
+    const pickAiSessionProvider = async (): Promise<AiSessionProviderId | undefined> => {
+        const quickPickOptions: vscode.QuickPickOptions = {
+            placeHolder: 'Select an AI provider',
+            ignoreFocusOut: true,
+        };
+        (quickPickOptions as vscode.QuickPickOptions & { title?: string }).title = 'Select an AI provider';
+        const selected = await showQuickPick(
+            buildAiSessionProviderPicks(getRegisteredAiSessionProviders()),
+            quickPickOptions
+        );
+        return selected?.providerId;
+    };
+    const aiSessionCommandController = factories.createCommandController({
+        getWorkspaceTarget: getCurrentWorkspaceActionTarget,
+        getOpenWorkspace: getCurrentOpenWorkspace,
+        getActiveEditorUri: options.getActiveEditorUri,
+        isWorkspaceTrusted: options.isWorkspaceTrusted,
+        getProvider: getRegisteredAiSessionProvider,
+        getProviderDirectoryCapability: providerDefinition =>
+            providerDirectoryCapability.probe(providerDefinition),
+        getPrimaryRootId: workspace => workspacePrimaryRootStore.getPrimaryRootId(
+            workspace.scopeIdentity,
+            workspace.roots
+        ),
+        setPrimaryRootId: (scopeIdentity, rootId) =>
+            workspacePrimaryRootStore.setPrimaryRootId(scopeIdentity, rootId),
+        pickWorkspaceRoot: pickAiSessionWorkspaceRoot,
+        isDirectory: hostPath => {
+            try {
+                return statSync(hostPath).isDirectory();
+            } catch (error) {
+                return false;
+            }
+        },
+        showWarningMessage: message => showWarningMessage(message),
+        isProviderId: isAiSessionProviderId,
+        setExpanded: (workspaceScopeIdentity, expanded) => aiSessionWorkspaceStateStore.setExpanded(workspaceScopeIdentity, expanded),
+        setProviderSelection: (workspaceScopeIdentity, selection) =>
+            aiSessionWorkspaceStateStore.setProviderSelection(workspaceScopeIdentity, selection),
+        postProviderSelectionResult: result => postMessage(result),
+        showErrorMessage: message => showErrorMessage(message),
+        logError,
+        togglePin: (providerId, sessionId) => aiSessionPinController.toggle(providerId, sessionId),
+        getAliases: () => aiSessionAliasController.getAll(),
+        saveAliases: aliases => aiSessionAliasController.saveAll(aliases),
+        getOriginalName: (providerId, sessionId) => aiSessionAliasController.getOriginalName(providerId, sessionId),
+        getSessionKey: getAiSessionPinKey,
+        showInputBox: options => showInputBox(options),
+        writeClipboard: value => writeClipboard(value),
+        showInformationMessage: message => showInformationMessage(message),
+        refresh: refreshAiSessionViewsIncrementally,
+    });
+    const aiSessionCreationController = factories.createCreationController({
+        isProviderId: isAiSessionProviderId,
+        getWorkspaceTarget: getCurrentWorkspaceActionTarget,
+        pickWorkspaceRoot: workspace => pickAiSessionWorkspaceRoot(workspace, 'create'),
+        pickProvider: pickAiSessionProvider,
+        getProviderLabel: getAiSessionProviderLabel,
+        getLaunchOptions,
+        getProvider: getRegisteredAiSessionProvider,
+        resolveWorkspaceDirectoryScope: (target, providerId, explicitRootId) =>
+            aiSessionCommandController.resolveWorkspaceDirectoryScope(
+                target.workspace, providerId, undefined, explicitRootId
+            ),
+        rememberDirectoryScope: async directoryScope => {
+            try {
+                await aiSessionCommandController.rememberDirectoryScope(directoryScope);
+            } catch (error) {
+                logError('Could not save the AI session workspace root.', error);
+            }
+        },
+        runtimeCoordinator: aiSessionRuntimeCoordinator,
+        createPendingId: () => randomBytes(16).toString('hex'),
+        showInputBox: options => showInputBox(options),
+        showActiveTab: projectId => postMessage({
+            type: 'ai-session-tab-selection-requested',
+            projectId,
+            tab: 'active',
+        }),
+        showWarningMessage: (message, ...items) => showWarningWithItems(message, ...items),
+        showErrorMessage: message => showErrorMessage(message),
+        logRuntimeFailure: logAiSessionRuntimeFailure,
+        refresh: refreshAiSessionViewsIncrementally,
+        getExistingSessionIdsForCwd: (providerId, cwd) => getAiSessionIdsForCwd(providerId, aiSessionReadCoordinator.getProviderResult(providerId, {
+            forceRefresh: true,
+            candidatePaths: [cwd],
+            reason: 'new-session',
+        }), cwd, aiSessionProviders),
+        getPendingMarkerPath: providerId => aiSessionTerminalService.getPendingMarkerPath(providerId),
+        scheduleNewSessionRefresh: scheduleNewAiSessionRefresh,
+        announceStatus: (projectId, message) => postMessage({
+            type: 'ai-session-status-announcement',
+            projectId,
+            message,
+        }),
+        nowMs,
+    });
+    const aiSessionArchiveController = factories.createArchiveController({
+        isProviderId: isAiSessionProviderId,
+        getProvider: getRegisteredAiSessionProvider,
+        getProviderLabel: getAiSessionProviderLabel,
+        getWorkspaceTarget: getCurrentWorkspaceActionTarget,
+        getRuntimeById: getAiSessionRuntimeById,
+        refreshRuntimeGuard: () => aiSessionRuntimeCoordinator.refreshForHost(true),
+        isRuntimeComplete: runtime => runtime.state === 'completed',
+        focusRuntime: runtime => aiSessionRuntimeCoordinator.focus({ ...runtime.identity }),
+        deleteRuntimeMarker: runtime => aiSessionTerminalService.deleteMarker(runtime.markerPath),
+        untrackRuntime: (providerId, sessionId, workspaceScopeIdentity) =>
+            aiSessionTerminalService.untrack(providerId, sessionId, workspaceScopeIdentity),
+        deletePin: (providerId, sessionId) => aiSessionPinController.remove(providerId, sessionId),
+        deleteAlias: (providerId, sessionId) => aiSessionAliasController.remove(providerId, sessionId),
+        confirmSingleArchive: providerLabel => showModalWarning(`Archive this ${providerLabel} session?`, "Archive"),
+        confirmBatchArchive: message => showModalWarning(message, 'Archive'),
+        showWarningMessage: message => showWarningMessage(message),
+        showErrorMessage: message => showErrorMessage(message),
+        showInformationMessage: message => showInformationMessage(message),
+        appendLine: message => appendOutput(message),
+        postCompletion: completion => postBatchArchiveCompletion(completion as AiSessionBatchArchiveCompletedMessage),
+        refresh: refreshAiSessionViewsIncrementally,
+        syncActiveRuntime: options.syncActiveRuntime,
+        logUnexpectedError: (operation, error, failedSessionId) => {
+            if (operation === 'focus-runtime') {
+                logAiSessionRuntimeFailure(operation, error, 'tmux');
+                return;
+            }
+            logError(`Batch AI session archive failed during ${operation}${failedSessionId ? ` (${failedSessionId})` : ''}.`, error);
+        },
+    });
+    const aiSessionTerminalCommandController = factories.createTerminalCommandController({
+        isProviderId: isAiSessionProviderId,
+        getWorkspaceTarget: getCurrentWorkspaceActionTarget,
+        runtimeCoordinator: aiSessionRuntimeCoordinator,
+        confirmRuntimeClose: (message, action) => showModalWarning(message, action),
+        chooseRuntimeConflict: async runtimes => {
+            const picks = runtimes.map(runtime => {
+                const backendLabel = runtime.backend === 'tmux'
+                    ? `tmux · ${runtime.tmux?.layout || 'unknown'} layout`
+                    : 'Direct · VS Code Terminal';
+                const attachment = runtime.attached ? 'attached' : 'detached';
+                const target = runtime.backend === 'tmux'
+                    ? `${runtime.tmux?.sessionName || 'unknown session'}${runtime.tmux?.windowName
+                        ? `:${runtime.tmux.windowName}` : ''}`
+                    : runtime.terminal?.name || 'unnamed VS Code terminal';
+                return {
+                    label: `$(terminal) ${backendLabel}`,
+                    description: attachment,
+                    detail: `Target: ${target}`,
+                    runtime,
+                };
+            });
+            const selected = await showQuickPick(picks, {
+                placeHolder: 'Select the exact AI session runtime to focus',
+                ignoreFocusOut: true,
+            });
+            return selected?.runtime;
+        },
+        announceStatus: (projectId, message) => postMessage({
+            type: 'ai-session-status-announcement',
+            projectId,
+            message,
+        }),
+        showErrorMessage: message => showErrorMessage(message),
+        logRuntimeFailure: logAiSessionRuntimeFailure,
+        getProviderLabel: getAiSessionProviderLabel,
+        refresh: refreshAiSessionViewsIncrementally,
+        onRuntimeCloseEnd: (runtime, succeeded) => {
+            const sessionId = runtime.identity.sessionId;
+            if (!sessionId || !succeeded) {
+                return;
+            }
+            void runSafeAiSessionRuntimeLifecycleTask(
+                'acknowledge-explicit-session-close',
+                () => acknowledgeAiSessionAttention({
+                    provider: runtime.identity.provider,
+                    sessionId,
+                    workspaceScopeIdentity: runtime.identity.workspaceScopeIdentity,
+                })
+            );
+        },
+        focusTerminalView: () => focusTerminalView(),
+    });
+    const aiSessionResumeController = factories.createResumeController({
+        getWorkspaceTarget: getCurrentWorkspaceActionTarget,
+        getLaunchOptions,
+        getProvider: getRegisteredAiSessionProvider,
+        resolveWorkspaceDirectoryScope: (target, session, providerId, explicitRootId) =>
+            aiSessionCommandController.resolveWorkspaceDirectoryScope(
+                target.workspace, providerId, session, explicitRootId
+            ),
+        rememberDirectoryScope: async directoryScope => {
+            try {
+                await aiSessionCommandController.rememberDirectoryScope(directoryScope);
+            } catch (error) {
+                logError('Could not save the AI session workspace root.', error);
+            }
+        },
+        getTerminalName: (providerId, session) => getProviderAiSessionTerminalName(providerId, session, aiSessionProviders),
+        runtimeCoordinator: aiSessionRuntimeCoordinator,
+        getRuntimeConflict: getAiSessionRuntimeCollision,
+        getMarkerPath: (providerId, sessionId) => aiSessionTerminalService.getMarkerPath(providerId, sessionId),
+        showWarningMessage: message => showWarningMessage(message),
+        showErrorMessage: message => showErrorMessage(message),
+        logRuntimeFailure: logAiSessionRuntimeFailure,
+        refresh: refreshAiSessionViewsIncrementally,
+        showActiveTab: projectId => postMessage({
+            type: 'ai-session-tab-selection-requested',
+            projectId,
+            tab: 'active',
+        }),
+        announceStatus: (projectId, message) => postMessage({
+            type: 'ai-session-status-announcement',
+            projectId,
+            message,
+        }),
+    });
+    return {
+        aiSessionCommandController,
+        aiSessionCreationController,
+        aiSessionArchiveController,
+        aiSessionTerminalCommandController,
+        aiSessionResumeController,
+    };
+}

--- a/src/aiSessions/sessionHelpers.ts
+++ b/src/aiSessions/sessionHelpers.ts
@@ -1,7 +1,9 @@
 'use strict';
 
+import * as fs from 'fs';
+import * as path from 'path';
 import type { AiSessionProviderId, CodexSession } from '../models';
-import type { AiSessionAssignmentCandidate, AiSessionReadResult } from './types';
+import type { AiSessionAssignmentCandidate, AiSessionQueryOptions, AiSessionReadResult } from './types';
 
 export function getAiSessionKey(providerId: AiSessionProviderId, sessionId: string): string {
     return `${providerId}:${sessionId}`;
@@ -158,4 +160,46 @@ export function compareAiSessionUpdatedAt(a: string, b: string): number {
     }
 
     return aTime - bTime;
+}
+
+/** Bounds a scan's file budget; non-positive or non-finite values mean unbounded. */
+export function normalizeAiSessionMaxFiles(maxFiles: number): number {
+    return Number.isFinite(maxFiles) && maxFiles > 0 ? Math.floor(maxFiles) : 0;
+}
+
+/** Normalizes the boolean-or-object session query form every provider shares. */
+export function resolveAiSessionQueryOptions(options: boolean | AiSessionQueryOptions): { forceRefresh: boolean; candidatePaths: string[]; maxFiles: number } {
+    if (typeof options === 'boolean') {
+        return { forceRefresh: options, candidatePaths: [], maxFiles: 0 };
+    }
+
+    return {
+        forceRefresh: Boolean(options?.forceRefresh),
+        candidatePaths: normalizeAiSessionCandidatePaths(options?.candidatePaths || []),
+        maxFiles: normalizeAiSessionMaxFiles(options?.maxFiles),
+    };
+}
+
+/** One-stat content signature used by the provider change fingerprints. */
+export function getAiSessionFileSignature(filePath: string): string {
+    try {
+        let stat = fs.statSync(filePath);
+        return `${filePath}:${stat.size}:${stat.mtimeMs}`;
+    } catch (e) {
+        return `${filePath}:missing`;
+    }
+}
+
+/** Picks a collision-free archive destination by suffixing `-1`, `-2`, ... */
+export function getAvailableAiSessionArchivePath(archivePath: string, fileName: string): string {
+    let parsed = path.parse(fileName);
+    let destination = path.join(archivePath, fileName);
+    let index = 1;
+
+    while (fs.existsSync(destination)) {
+        destination = path.join(archivePath, `${parsed.name}-${index}${parsed.ext}`);
+        index++;
+    }
+
+    return destination;
 }

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -154,6 +154,7 @@ import { getErrorContent } from './dashboard/errorContent';
 import { GroupCollapseController } from './dashboard/groupCollapseController';
 import { DashboardLifecycleController } from './dashboard/lifecycleController';
 import { createDashboardMessageRouter } from './dashboard/messageRouter';
+import { createDashboardMessageHandlers } from './dashboard/messageHandlers';
 import { ProjectsPanelController } from './dashboard/projectsPanelController';
 import {
     DashboardRuntimeController,
@@ -1489,6 +1490,28 @@ async function initializeDashboard(
         showWarningMessage: message => vscode.window.showWarningMessage(message),
     });
 
+    const dashboardMessageHandlers = createDashboardMessageHandlers({
+        postMessage: message => provider.postMessage(message),
+        getStewardInfos: () => stewardInfos,
+        projectService,
+        promptDashboardController,
+        getPromptTerminalCommandController: () => promptTerminalCommandController,
+        aiSessionCommandController,
+        aiSessionTerminalCommandController,
+        conversationCapability,
+        aiSessionArchiveController,
+        acknowledgeAiSessionAttentionEventIds,
+        logOpenWorkspaceDiagnostic,
+        refreshStewardViews,
+        requestActiveAiSessionTerminalHighlight: () => activeAiSessionTerminalHighlighter.request(),
+        postAiSessionAttentionState,
+        showAgentPivotSettings,
+        showBridgeExtension: () => vscode.commands.executeCommand(
+            'workbench.extensions.action.showExtensionsWithIds',
+            ['hzcheng.agent-pivot-attention-ui-bridge'],
+        ),
+    });
+
     const dashboardMessageRouter = createDashboardMessageRouter({
         getAiSessionProviderIds: () => getRegisteredAiSessionProviders().map(provider => provider.id),
         saveCurrentWorkspace: () => savedWorkspaceProjectAdapter.saveCurrentWorkspace(),
@@ -1497,160 +1520,7 @@ async function initializeDashboard(
             ...todoPanel.handlers,
             ...projectHandlers,
             ...skillPanel.handlers,
-            'request-projects-panel': async e => {
-                if (e.version !== 1 || !Number.isSafeInteger(e.requestId) || e.requestId < 1) {
-                    return;
-                }
-                await provider.postMessage({
-                    type: 'projects-panel-content',
-                    version: 1,
-                    requestId: e.requestId,
-                    html: getProjectsPanelContent(projectService.getGroups(), stewardInfos),
-                });
-            },
-            'request-ai-panel': async e => {
-                if (Object.keys(e).length !== 4
-                    || e.version !== 1
-                    || typeof e.requestId !== 'string'
-                    || e.requestId.length < 1
-                    || e.requestId.length > 128
-                    || e.target !== 'global-prompt-library') {
-                    return;
-                }
-                await provider.postMessage(
-                    promptDashboardController.getPanelContent(e.requestId)
-                );
-            },
-            'prompt-command': async e => {
-                const result = await promptDashboardController.handle(e);
-                if (result !== undefined) {
-                    await provider.postMessage(result);
-                }
-            },
-            'prompt-insert-terminal': async e => {
-                const result = await promptTerminalCommandController.handleInsertRequest(e);
-                if (result !== undefined) {
-                    await provider.postMessage(result);
-                }
-            },
-            'toggle-codex-sessions': async e => {
-                await aiSessionCommandController.toggleSessionsExpanded(e.projectId as string, Boolean(e.expanded));
-            },
-            'select-ai-session-providers': async e => {
-                await aiSessionCommandController.selectProviders(
-                    e.projectId as string,
-                    e.selectedProviders,
-                    e.requestId,
-                    e.version
-                );
-            },
-            'focus-ai-session-terminal': async e => {
-                const target = {
-                    projectId: e.projectId as string,
-                    provider: e.provider as AiSessionProviderId,
-                    sessionId: e.sessionId as string,
-                };
-                const focused =
-                    await aiSessionTerminalCommandController.focusActive(
-                        target.projectId,
-                        target.provider,
-                        target.sessionId
-                    );
-                if (focused) {
-                    await conversationCapability.followActiveConversation(
-                        target
-                    );
-                }
-            },
-            'focus-pending-ai-session': async e => {
-                await aiSessionTerminalCommandController.focusPending(
-                    e.projectId as string,
-                    e.provider as string,
-                    e.createdAt as string
-                );
-            },
-            'close-ai-session-terminal': async e => {
-                await aiSessionTerminalCommandController.closeTerminal({
-                    projectId: e.projectId as string,
-                    providerId: e.provider as string,
-                    sessionId: e.sessionId as string,
-                    pendingCreatedAt: e.pendingCreatedAt as string,
-                    expectedBackend: 'vscode',
-                });
-            },
-            'detach-ai-session-terminal': async e => {
-                await aiSessionTerminalCommandController.closeTerminal({
-                    projectId: e.projectId as string,
-                    providerId: e.provider as string,
-                    sessionId: e.sessionId as string,
-                    pendingCreatedAt: e.pendingCreatedAt as string,
-                    expectedBackend: 'tmux',
-                });
-            },
-            'toggle-ai-session-pin': async e => {
-                await aiSessionCommandController.togglePin(e.provider as string, e.sessionId as string);
-            },
-            'acknowledge-ai-session-attention': async e => {
-                const attentionEventIds = Array.isArray(e.eventIds) ? e.eventIds.filter((id: unknown): id is string => typeof id === 'string') : [];
-                await acknowledgeAiSessionAttentionEventIds(attentionEventIds);
-            },
-            'rename-ai-session': async e => {
-                await aiSessionCommandController.renameSession(e.provider as string, e.sessionId as string);
-            },
-            'copy-ai-session-id': async e => {
-                await aiSessionCommandController.copySessionId(e.sessionId as string);
-            },
-            'request-full-refresh': e => {
-                logOpenWorkspaceDiagnostic('Renderer', {
-                    event: 'full-refresh-requested',
-                    reason: typeof e.reason === 'string' ? e.reason.slice(0, 256) : 'unknown',
-                });
-                refreshStewardViews(typeof e.reason === 'string' ? e.reason.slice(0, 256) : 'webview-requested');
-            },
-            'open-workspaces-rendered': e => {
-                logOpenWorkspaceDiagnostic('Renderer', {
-                    event: 'open-workspaces-rendered',
-                    semanticRevision: typeof e.semanticRevision === 'string'
-                        ? e.semanticRevision.slice(0, 128)
-                        : 'invalid',
-                    currentWorkspaceCount: (e.currentWorkspaceCount === 0 || e.currentWorkspaceCount === 1)
-                        ? e.currentWorkspaceCount as number
-                        : -1,
-                    navigationWorkspaceCount: Number.isSafeInteger(e.navigationWorkspaceCount)
-                        && e.navigationWorkspaceCount >= 0
-                        ? e.navigationWorkspaceCount as number
-                        : -1,
-                    hasOtherWindowsGroup: e.hasOtherWindowsGroup === true,
-                    otherWindowsStatus: e.otherWindowsStatus === 'ready'
-                        || e.otherWindowsStatus === 'unavailable'
-                        || e.otherWindowsStatus === 'update-required'
-                        ? e.otherWindowsStatus as string
-                        : 'invalid',
-                });
-            },
-            'request-active-ai-session-terminal': () => {
-                activeAiSessionTerminalHighlighter.request();
-            },
-            'request-ai-session-attention-state': () => {
-                postAiSessionAttentionState();
-            },
-            'open-settings': async () => {
-                await showAgentPivotSettings();
-            },
-            'open-bridge-extension': async () => {
-                await vscode.commands.executeCommand(
-                    'workbench.extensions.action.showExtensionsWithIds',
-                    ['hzcheng.agent-pivot-attention-ui-bridge'],
-                );
-            },
-            'archive-ai-sessions': async e => {
-                await aiSessionArchiveController.archiveSessions(
-                    e.projectId,
-                    e.items,
-                    e.requestId,
-                    e.version
-                );
-            },
+            ...dashboardMessageHandlers,
         },
         createAiSession: async e => {
             await aiSessionCreationController.createSession(e.projectId as string);

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -2,7 +2,7 @@
 import * as vscode from 'vscode';
 import * as childProcess from 'child_process';
 import { randomBytes } from 'crypto';
-import { existsSync, statSync } from 'fs';
+import { existsSync } from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { performance } from 'perf_hooks';
@@ -51,19 +51,13 @@ import AttentionBridgeClient from './aiSessions/attentionBridgeClient';
 import { getLogicalAttentionSessionKey } from './aiSessions/attentionProject';
 import type { ActiveAiSessionTerminalIdentity } from './aiSessions/activeTerminalHighlight';
 import { getAiSessionKey } from './aiSessions/sessionHelpers';
-import {
-    AI_SESSION_PROVIDER_DEFINITIONS,
-    buildAiSessionProviderPicks,
-    createAiSessionProviderRegistry,
-    getAiSessionProviderLabel,
-} from './aiSessions/providers';
+import { createAiSessionProviderRegistry } from './aiSessions/providers';
 import { ProviderDirectoryCapabilityProbe } from './aiSessions/providerDirectoryCapability';
 import type {
     BoundedChildProcessOptions,
     BoundedChildProcessResult,
 } from './aiSessions/providerDirectoryCapability';
 import { getAiSessionComparableCwd as getProviderAiSessionComparableCwd, getAiSessionTerminalName as getProviderAiSessionTerminalName } from './aiSessions/sessionPaths';
-import { getAiSessionIdsForCwd } from './aiSessions/pendingTerminals';
 import { getAiSessionTerminalCandidates } from './aiSessions/terminalCandidates';
 import { AiSessionReadCoordinator } from './aiSessions/readCoordinator';
 import AiSessionTerminalService from './aiSessions/terminalService';
@@ -98,11 +92,6 @@ import {
     submitConversationPrompt,
 } from './aiSessions/conversation/submission';
 import { AiSessionDashboardController } from './aiSessions/dashboardController';
-import { AiSessionCommandController } from './aiSessions/commandController';
-import { AiSessionCreationController } from './aiSessions/creationController';
-import { AiSessionArchiveController } from './aiSessions/archiveController';
-import { AiSessionResumeController } from './aiSessions/resumeController';
-import { AiSessionTerminalCommandController } from './aiSessions/terminalCommandController';
 import { AiSessionExecutionController } from './aiSessions/executionController';
 import {
     AiSessionAttentionController,
@@ -155,6 +144,7 @@ import { GroupCollapseController } from './dashboard/groupCollapseController';
 import { DashboardLifecycleController } from './dashboard/lifecycleController';
 import { createDashboardMessageRouter } from './dashboard/messageRouter';
 import { createDashboardMessageHandlers } from './dashboard/messageHandlers';
+import { createSessionControllerComposition } from './aiSessions/sessionControllerComposition';
 import { ProjectsPanelController } from './dashboard/projectsPanelController';
 import {
     DashboardRuntimeController,
@@ -878,247 +868,55 @@ async function initializeDashboard(
         resolveExecutable: commandName => resolveAiProviderExecutable(commandName),
         run: (executable, args, options) => runBoundedAiProviderHelp(executable, args, options),
     }, message => outputChannel.appendLine(message));
-    const pickAiSessionWorkspaceRoot = async (
-        workspace: OpenWorkspace,
-        action: 'create' | 'resume'
-    ): Promise<string | undefined> => {
-        const selected = await vscode.window.showQuickPick(
-            workspace.roots.map(root => ({
-                label: root.name,
-                description: root.hostPath,
-                rootId: root.id,
-            })),
-            {
-                placeHolder: 'Select a workspace root',
-                ignoreFocusOut: true,
-                title: action === 'resume'
-                    ? 'Resume AI Session in Workspace Root'
-                    : 'New AI Session Working Directory',
-            } as vscode.QuickPickOptions & { title: string }
-        );
-        return selected?.rootId;
-    };
-    const aiSessionCommandController = new AiSessionCommandController({
-        getWorkspaceTarget: getCurrentWorkspaceActionTarget,
-        getOpenWorkspace: getCurrentOpenWorkspace,
+    const {
+        aiSessionCommandController,
+        aiSessionCreationController,
+        aiSessionArchiveController,
+        aiSessionTerminalCommandController,
+        aiSessionResumeController,
+    } = createSessionControllerComposition({
+        getCurrentWorkspaceActionTarget,
+        getCurrentOpenWorkspace,
+        getRegisteredAiSessionProvider,
+        getRegisteredAiSessionProviders,
+        getAiSessionRuntimeById,
+        getAiSessionRuntimeCollision,
+        getLaunchOptions: () => readAiSessionLaunchOptions(vscode.workspace),
+        refreshAiSessionViewsIncrementally,
+        scheduleNewAiSessionRefresh,
+        logAiSessionRuntimeFailure,
+        logError,
+        getAiSessionPinKey,
+        postBatchArchiveCompletion,
+        aiSessionWorkspaceStateStore,
+        workspacePrimaryRootStore,
+        aiSessionPinController,
+        aiSessionAliasController,
+        aiSessionRuntimeCoordinator,
+        aiSessionTerminalService,
+        aiSessionReadCoordinator,
+        aiSessionProviders,
+        providerDirectoryCapability,
+        syncActiveRuntime: () => activeAiSessionTerminalHighlighter.sync(),
+        runSafeLifecycleTask: (operation, task) =>
+            aiSessionRuntimeSettlement.runSafeLifecycleTask(operation, task),
+        acknowledgeAttention: identity => acknowledgeAiSessionAttention(identity),
+        postMessage: message => provider.postMessage(message),
+        appendOutput: message => outputChannel.appendLine(message),
         getActiveEditorUri: () => vscode.window.activeTextEditor?.document.uri,
         isWorkspaceTrusted: () => (
             vscode.workspace as typeof vscode.workspace & { isTrusted?: boolean }
         ).isTrusted !== false,
-        getProvider: getRegisteredAiSessionProvider,
-        getProviderDirectoryCapability: providerDefinition =>
-            providerDirectoryCapability.probe(providerDefinition),
-        getPrimaryRootId: workspace => workspacePrimaryRootStore.getPrimaryRootId(
-            workspace.scopeIdentity,
-            workspace.roots
-        ),
-        setPrimaryRootId: (scopeIdentity, rootId) =>
-            workspacePrimaryRootStore.setPrimaryRootId(scopeIdentity, rootId),
-        pickWorkspaceRoot: pickAiSessionWorkspaceRoot,
-        isDirectory: hostPath => {
-            try {
-                return statSync(hostPath).isDirectory();
-            } catch (error) {
-                return false;
-            }
-        },
-        showWarningMessage: message => vscode.window.showWarningMessage(message),
-        isProviderId: isAiSessionProviderId,
-        setExpanded: (workspaceScopeIdentity, expanded) => aiSessionWorkspaceStateStore.setExpanded(workspaceScopeIdentity, expanded),
-        setProviderSelection: (workspaceScopeIdentity, selection) =>
-            aiSessionWorkspaceStateStore.setProviderSelection(workspaceScopeIdentity, selection),
-        postProviderSelectionResult: result => provider.postMessage(result),
-        showErrorMessage: message => vscode.window.showErrorMessage(message),
-        logError,
-        togglePin: (providerId, sessionId) => aiSessionPinController.toggle(providerId, sessionId),
-        getAliases: () => aiSessionAliasController.getAll(),
-        saveAliases: aliases => aiSessionAliasController.saveAll(aliases),
-        getOriginalName: (providerId, sessionId) => aiSessionAliasController.getOriginalName(providerId, sessionId),
-        getSessionKey: getAiSessionPinKey,
         showInputBox: options => vscode.window.showInputBox(options),
+        showQuickPick: (items, quickPickOptions) => vscode.window.showQuickPick(items, quickPickOptions),
+        showWarningMessage: message => vscode.window.showWarningMessage(message),
+        showWarningWithItems: (message, ...items) => vscode.window.showWarningMessage(message, ...items),
+        showModalWarning: (message, action) => vscode.window.showWarningMessage(message, { modal: true }, action),
+        showErrorMessage: message => vscode.window.showErrorMessage(message),
+        showInformationMessage: message => vscode.window.showInformationMessage(message),
         writeClipboard: value => vscode.env.clipboard.writeText(value),
-        showInformationMessage: message => vscode.window.showInformationMessage(message),
-        refresh: refreshAiSessionViewsIncrementally,
-    });
-    const pickAiSessionProvider = async (): Promise<AiSessionProviderId | undefined> => {
-        const quickPickOptions: vscode.QuickPickOptions = {
-            placeHolder: 'Select an AI provider',
-            ignoreFocusOut: true,
-        };
-        (quickPickOptions as vscode.QuickPickOptions & { title?: string }).title = 'Select an AI provider';
-        const selected = await vscode.window.showQuickPick(
-            buildAiSessionProviderPicks(getRegisteredAiSessionProviders()),
-            quickPickOptions
-        );
-        return selected?.providerId;
-    };
-    const aiSessionCreationController = new AiSessionCreationController({
-        isProviderId: isAiSessionProviderId,
-        getWorkspaceTarget: getCurrentWorkspaceActionTarget,
-        pickWorkspaceRoot: workspace => pickAiSessionWorkspaceRoot(workspace, 'create'),
-        pickProvider: pickAiSessionProvider,
-        getProviderLabel: getAiSessionProviderLabel,
-        getLaunchOptions: () =>
-            readAiSessionLaunchOptions(vscode.workspace),
-        getProvider: getRegisteredAiSessionProvider,
-        resolveWorkspaceDirectoryScope: (target, providerId, explicitRootId) =>
-            aiSessionCommandController.resolveWorkspaceDirectoryScope(
-                target.workspace, providerId, undefined, explicitRootId
-            ),
-        rememberDirectoryScope: async directoryScope => {
-            try {
-                await aiSessionCommandController.rememberDirectoryScope(directoryScope);
-            } catch (error) {
-                logError('Could not save the AI session workspace root.', error);
-            }
-        },
-        runtimeCoordinator: aiSessionRuntimeCoordinator,
-        createPendingId: () => randomBytes(16).toString('hex'),
-        showInputBox: options => vscode.window.showInputBox(options),
-        showActiveTab: projectId => provider.postMessage({
-            type: 'ai-session-tab-selection-requested',
-            projectId,
-            tab: 'active',
-        }),
-        showWarningMessage: (message, ...items) => vscode.window.showWarningMessage(message, ...items),
-        showErrorMessage: message => vscode.window.showErrorMessage(message),
-        logRuntimeFailure: logAiSessionRuntimeFailure,
-        refresh: refreshAiSessionViewsIncrementally,
-        getExistingSessionIdsForCwd: (providerId, cwd) => getAiSessionIdsForCwd(providerId, aiSessionReadCoordinator.getProviderResult(providerId, {
-            forceRefresh: true,
-            candidatePaths: [cwd],
-            reason: 'new-session',
-        }), cwd, aiSessionProviders),
-        getPendingMarkerPath: providerId => aiSessionTerminalService.getPendingMarkerPath(providerId),
-        scheduleNewSessionRefresh: scheduleNewAiSessionRefresh,
-        announceStatus: (projectId, message) => provider.postMessage({
-            type: 'ai-session-status-announcement',
-            projectId,
-            message,
-        }),
+        focusTerminalView: () => vscode.commands.executeCommand('workbench.action.terminal.focus'),
         nowMs: () => Date.now(),
-    });
-    const aiSessionArchiveController = new AiSessionArchiveController<AiSessionRuntimeSnapshot<vscode.Terminal>>({
-        isProviderId: isAiSessionProviderId,
-        getProvider: getRegisteredAiSessionProvider,
-        getProviderLabel: getAiSessionProviderLabel,
-        getWorkspaceTarget: getCurrentWorkspaceActionTarget,
-        getRuntimeById: getAiSessionRuntimeById,
-        refreshRuntimeGuard: () => aiSessionRuntimeCoordinator.refreshForHost(true),
-        isRuntimeComplete: runtime => runtime.state === 'completed',
-        focusRuntime: runtime => aiSessionRuntimeCoordinator.focus({ ...runtime.identity }),
-        deleteRuntimeMarker: runtime => aiSessionTerminalService.deleteMarker(runtime.markerPath),
-        untrackRuntime: (providerId, sessionId, workspaceScopeIdentity) =>
-            aiSessionTerminalService.untrack(providerId, sessionId, workspaceScopeIdentity),
-        deletePin: (providerId, sessionId) => aiSessionPinController.remove(providerId, sessionId),
-        deleteAlias: (providerId, sessionId) => aiSessionAliasController.remove(providerId, sessionId),
-        confirmSingleArchive: providerLabel => vscode.window.showWarningMessage(`Archive this ${providerLabel} session?`, { modal: true }, "Archive"),
-        confirmBatchArchive: message => vscode.window.showWarningMessage(message, { modal: true }, 'Archive'),
-        showWarningMessage: message => vscode.window.showWarningMessage(message),
-        showErrorMessage: message => vscode.window.showErrorMessage(message),
-        showInformationMessage: message => vscode.window.showInformationMessage(message),
-        appendLine: message => outputChannel.appendLine(message),
-        postCompletion: completion => postBatchArchiveCompletion(completion as AiSessionBatchArchiveCompletedMessage),
-        refresh: refreshAiSessionViewsIncrementally,
-        syncActiveRuntime: () => activeAiSessionTerminalHighlighter.sync(),
-        logUnexpectedError: (operation, error, failedSessionId) => {
-            if (operation === 'focus-runtime') {
-                logAiSessionRuntimeFailure(operation, error, 'tmux');
-                return;
-            }
-            logError(`Batch AI session archive failed during ${operation}${failedSessionId ? ` (${failedSessionId})` : ''}.`, error);
-        },
-    });
-    const aiSessionTerminalCommandController = new AiSessionTerminalCommandController<vscode.Terminal>({
-        isProviderId: isAiSessionProviderId,
-        getWorkspaceTarget: getCurrentWorkspaceActionTarget,
-        runtimeCoordinator: aiSessionRuntimeCoordinator,
-        confirmRuntimeClose: (message, action) => vscode.window.showWarningMessage(
-            message, { modal: true }, action
-        ),
-        chooseRuntimeConflict: async runtimes => {
-            const picks = runtimes.map(runtime => {
-                const backendLabel = runtime.backend === 'tmux'
-                    ? `tmux · ${runtime.tmux?.layout || 'unknown'} layout`
-                    : 'Direct · VS Code Terminal';
-                const attachment = runtime.attached ? 'attached' : 'detached';
-                const target = runtime.backend === 'tmux'
-                    ? `${runtime.tmux?.sessionName || 'unknown session'}${runtime.tmux?.windowName
-                        ? `:${runtime.tmux.windowName}` : ''}`
-                    : runtime.terminal?.name || 'unnamed VS Code terminal';
-                return {
-                    label: `$(terminal) ${backendLabel}`,
-                    description: attachment,
-                    detail: `Target: ${target}`,
-                    runtime,
-                };
-            });
-            const selected = await vscode.window.showQuickPick(picks, {
-                placeHolder: 'Select the exact AI session runtime to focus',
-                ignoreFocusOut: true,
-            });
-            return selected?.runtime;
-        },
-        announceStatus: (projectId, message) => provider.postMessage({
-            type: 'ai-session-status-announcement',
-            projectId,
-            message,
-        }),
-        showErrorMessage: message => vscode.window.showErrorMessage(message),
-        logRuntimeFailure: logAiSessionRuntimeFailure,
-        getProviderLabel: getAiSessionProviderLabel,
-        refresh: refreshAiSessionViewsIncrementally,
-        onRuntimeCloseEnd: (runtime, succeeded) => {
-            const sessionId = runtime.identity.sessionId;
-            if (!sessionId || !succeeded) {
-                return;
-            }
-            void runSafeAiSessionRuntimeLifecycleTask(
-                'acknowledge-explicit-session-close',
-                () => acknowledgeAiSessionAttention({
-                    provider: runtime.identity.provider,
-                    sessionId,
-                    workspaceScopeIdentity: runtime.identity.workspaceScopeIdentity,
-                })
-            );
-        },
-        focusTerminalView: () =>
-            vscode.commands.executeCommand('workbench.action.terminal.focus'),
-    });
-    const aiSessionResumeController = new AiSessionResumeController<vscode.Terminal>({
-        getWorkspaceTarget: getCurrentWorkspaceActionTarget,
-        getLaunchOptions: () =>
-            readAiSessionLaunchOptions(vscode.workspace),
-        getProvider: getRegisteredAiSessionProvider,
-        resolveWorkspaceDirectoryScope: (target, session, providerId, explicitRootId) =>
-            aiSessionCommandController.resolveWorkspaceDirectoryScope(
-                target.workspace, providerId, session, explicitRootId
-            ),
-        rememberDirectoryScope: async directoryScope => {
-            try {
-                await aiSessionCommandController.rememberDirectoryScope(directoryScope);
-            } catch (error) {
-                logError('Could not save the AI session workspace root.', error);
-            }
-        },
-        getTerminalName: (providerId, session) => getProviderAiSessionTerminalName(providerId, session, aiSessionProviders),
-        runtimeCoordinator: aiSessionRuntimeCoordinator,
-        getRuntimeConflict: getAiSessionRuntimeCollision,
-        getMarkerPath: (providerId, sessionId) => aiSessionTerminalService.getMarkerPath(providerId, sessionId),
-        showWarningMessage: message => vscode.window.showWarningMessage(message),
-        showErrorMessage: message => vscode.window.showErrorMessage(message),
-        logRuntimeFailure: logAiSessionRuntimeFailure,
-        refresh: refreshAiSessionViewsIncrementally,
-        showActiveTab: projectId => provider.postMessage({
-            type: 'ai-session-tab-selection-requested',
-            projectId,
-            tab: 'active',
-        }),
-        announceStatus: (projectId, message) => provider.postMessage({
-            type: 'ai-session-status-announcement',
-            projectId,
-            message,
-        }),
     });
     let aiSessionUpdateSequence = 0;
     let currentAiSessionRefreshReason = 'refresh';

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -101,14 +101,8 @@ import type {
 } from './aiSessions/attentionController';
 import { createAiSessionStatusCapability } from './aiSessions/statusCapability';
 import { createAiSessionRuntimeSettlementCapability } from './aiSessions/runtimeSettlementCapability';
-import { NotifyDispatcher } from './aiSessions/notify/dispatcher';
-import { createHttpsTransport } from './aiSessions/notify/httpClient';
-import { NotifiedEventStore } from './aiSessions/notify/store';
-import type { NotifyConfig } from './aiSessions/notify/types';
-import { registerNotifyCommands, resolveNotifySecretStorage } from './aiSessions/notifyIntegration/commands';
-import { assembleNotifyConfig, NOTIFY_SECRET_KEY_PREFIX } from './aiSessions/notifyIntegration/credentials';
+import { createNotifyConfiguration } from './aiSessions/notifyConfiguration';
 import { buildNotifyPayload } from './aiSessions/notifyIntegration/notifier';
-import { createNotifyOutputChannel } from './aiSessions/notifyIntegration/output';
 import {
     getLastPartOfPath,
     isUriString,
@@ -921,101 +915,22 @@ async function initializeDashboard(
     let aiSessionUpdateSequence = 0;
     let currentAiSessionRefreshReason = 'refresh';
     let aiSessionAttentionBridgeClient: AttentionBridgeClient;
-    const notifyOutput = ownResource(() => createNotifyOutputChannel());
-    const notifiedStore = new NotifiedEventStore(
-        path.join(os.homedir(), '.agent-pivot', 'notified.json'));
-    notifiedStore.load();
-    let currentNotifyConfig: NotifyConfig | null = null;
-    const notifyDispatcher = new NotifyDispatcher({
-        transport: createHttpsTransport(),
-        store: notifiedStore,
+    const notifyConfiguration = ownResource(() => createNotifyConfiguration({
+        context,
+        getConfiguration: () => getAgentPivotConfiguration(),
+        configurationTargetGlobal: vscode.ConfigurationTarget.Global,
+        homedir: () => os.homedir(),
+        env: process.env,
         nowMs: () => Date.now(),
         setTimeout: (handler, ms) => setTimeout(handler, ms),
         clearTimeout: handle => clearTimeout(handle as NodeJS.Timeout),
         sleep: ms => new Promise(resolve => setTimeout(resolve, ms)),
-        globalProxy: () => getAgentPivotConfiguration().get<string>('notify.proxy', ''),
-        env: process.env,
-        onLog: line => notifyOutput.log(line),
-    });
-    const refreshNotifyConfig = async (): Promise<void> => {
-        try {
-            await refreshNotifyConfigUnsafe();
-        } catch (error) {
-            // 通知配置刷新绝不能让 Dashboard 激活/运行崩溃;保留上一份配置。
-            notifyOutput.log(`notify: config refresh failed: ${(error as Error).message}`);
-        }
-    };
-    const refreshNotifyConfigUnsafe = async (): Promise<void> => {
-        const configuration = getAgentPivotConfiguration();
-        const enabled = configuration.get<boolean>('notify.enabled', false);
-        if (enabled && !context.globalState.get<boolean>('agentPivot.notify.consented')) {
-            const choice = await vscode.window.showWarningMessage(
-                'Agent Pivot will send project names, session names and status to the '
-                + 'notification endpoints you configure. No code or file contents are sent. Continue?',
-                { modal: true },
-                'Enable notifications'
-            );
-            if (choice !== 'Enable notifications') {
-                await configuration.update(
-                    'notify.enabled', false, vscode.ConfigurationTarget.Global);
-                return;
-            }
-            await context.globalState.update('agentPivot.notify.consented', true);
-        }
-        const skeletons = configuration.get<Array<Record<string, unknown>>>('notify.sinks', []);
-        const secretStorage = resolveNotifySecretStorage(context);
-        const secrets: Record<string, string> = {};
-        for (const skeleton of skeletons) {
-            const id = typeof skeleton.id === 'string' ? skeleton.id : '';
-            if (!id) {
-                continue;
-            }
-            const stored = secretStorage
-                ? await secretStorage.get(`${NOTIFY_SECRET_KEY_PREFIX}${id}`)
-                : undefined;
-            if (stored) {
-                secrets[id] = stored;
-            }
-        }
-        const assembled = assembleNotifyConfig({
-            enabled,
-            sinks: skeletons,
-            reasons: configuration.get<string[]>('notify.reasons',
-                ['completed', 'input-required', 'failed']),
-            minRunDurationMs: configuration.get<number>('notify.minRunDurationMs', 60000),
-            debounceMs: configuration.get<number>('notify.debounceMs', 5000),
-            rateLimitPerMin: configuration.get<number>('notify.rateLimitPerMin', 6),
-            escalateAfterMs: configuration.get<number>('notify.escalateAfterMs', 0),
-            projectPathMode: configuration.get<string>('notify.projectPathMode', 'basename'),
-            includeSessionLabel: configuration.get<boolean>('notify.includeSessionLabel', true),
-        }, secrets, line => notifyOutput.log(line));
-        currentNotifyConfig = assembled;
-        notifyDispatcher.setConfig(assembled);
-    };
-    await refreshNotifyConfig();
-    // 凭据写入不触发配置变化事件,必须单独监听,否则存完凭据后 dispatcher
-    // 仍拿着存凭据之前装配的空 sinks 配置,直到下次配置变更或重载。
-    const notifySecretChanges = resolveNotifySecretStorage(context);
-    const onNotifySecretChange = notifySecretChanges?.onDidChange;
-    if (onNotifySecretChange) {
-        ownResource(() => onNotifySecretChange(event => {
-            if (event.key.startsWith(NOTIFY_SECRET_KEY_PREFIX)) {
-                void refreshNotifyConfig();
-            }
-        }));
-    }
-    ownResource(() => {
-        const disposables = registerNotifyCommands(context, {
-            output: notifyOutput,
-            getConfig: () => currentNotifyConfig || assembleNotifyConfig({
-                enabled: false, sinks: [], reasons: [], minRunDurationMs: 0,
-                debounceMs: 0, rateLimitPerMin: 1, escalateAfterMs: 0,
-                projectPathMode: 'basename', includeSessionLabel: true,
-            }, {}),
-            globalProxy: () => getAgentPivotConfiguration().get<string>('notify.proxy', ''),
-        });
-        return { dispose: () => disposables.forEach(disposable => disposable.dispose()) };
-    });
+        showWarningMessage: (message, messageOptions, ...items) =>
+            vscode.window.showWarningMessage(message, messageOptions, ...items),
+    }));
+    const notifyOutput = notifyConfiguration.output;
+    const notifyDispatcher = notifyConfiguration.dispatcher;
+    await notifyConfiguration.refresh();
     const locateAttentionSession = (key: string) => {
         const target = getCurrentWorkspaceActionTargetWithoutCardId();
         if (!target) {
@@ -1708,7 +1623,7 @@ async function initializeDashboard(
 
     ownResource(() => vscode.workspace.onDidChangeConfiguration(event => {
         if (event.affectsConfiguration(`${AGENT_PIVOT_CONFIG_SECTION}.notify`)) {
-            void refreshNotifyConfig();
+            void notifyConfiguration.refresh();
         }
     }));
 

--- a/src/dashboard/messageHandlers.ts
+++ b/src/dashboard/messageHandlers.ts
@@ -1,0 +1,222 @@
+'use strict';
+
+import type * as vscode from 'vscode';
+import type { AiSessionArchiveController } from '../aiSessions/archiveController';
+import type { AiSessionCommandController } from '../aiSessions/commandController';
+import type { ConversationCapability } from '../aiSessions/conversation/composition';
+import type { AiSessionRuntimeSnapshot } from '../aiSessions/runtimeTypes';
+import type { AiSessionTerminalCommandController } from '../aiSessions/terminalCommandController';
+import type { AiSessionProviderId, StewardInfos } from '../models';
+import type { PromptDashboardController } from '../prompts/dashboardController';
+import type { PromptTerminalCommandController } from '../prompts/terminalCommandController';
+import type ProjectService from '../services/projectService';
+import { getProjectsPanelContent } from '../webview/webviewContent';
+import type { DashboardMessageHandler } from './messageRouter';
+
+export interface DashboardMessageHandlersOptions {
+    postMessage: (message: unknown) => Thenable<unknown>;
+    /** Late-bound: stewardInfos is assembled after the message router. */
+    getStewardInfos: () => StewardInfos;
+    projectService: ProjectService;
+    promptDashboardController: PromptDashboardController;
+    /** Late-bound: the prompt terminal controller is constructed after the router. */
+    getPromptTerminalCommandController: () => PromptTerminalCommandController;
+    aiSessionCommandController: AiSessionCommandController;
+    aiSessionTerminalCommandController: AiSessionTerminalCommandController<vscode.Terminal>;
+    conversationCapability: ConversationCapability;
+    aiSessionArchiveController: AiSessionArchiveController<AiSessionRuntimeSnapshot<vscode.Terminal>>;
+    acknowledgeAiSessionAttentionEventIds: (eventIds: string[]) => Promise<void>;
+    logOpenWorkspaceDiagnostic: (component: string, event: unknown) => void;
+    refreshStewardViews: (reason?: string) => void;
+    /** Late-bound: the highlighter is constructed after the message router. */
+    requestActiveAiSessionTerminalHighlight: () => void;
+    postAiSessionAttentionState: () => void;
+    showAgentPivotSettings: () => Promise<void>;
+    showBridgeExtension: () => Thenable<unknown>;
+}
+
+/**
+ * Owns the remaining plain-delegate dashboard message handlers: panel content
+ * requests, prompt commands, AI session terminal/pin/rename/archive delegates,
+ * renderer diagnostics, and settings/bridge openers.
+ *
+ * Extracted from `initializeDashboard` in src/dashboard.ts (see the project
+ * message handlers for the same slice pattern). Behaviour is unchanged: the
+ * handler bodies delegate to the same controllers with the same arguments;
+ * only their ownership moved. The router-level special hooks (create/resume/
+ * archive session, save workspace) stay in dashboard.ts.
+ */
+export function createDashboardMessageHandlers(
+    options: DashboardMessageHandlersOptions
+): Record<string, DashboardMessageHandler> {
+    const postMessage = options.postMessage;
+    const getStewardInfos = options.getStewardInfos;
+    const projectService = options.projectService;
+    const promptDashboardController = options.promptDashboardController;
+    const getPromptTerminalCommandController = options.getPromptTerminalCommandController;
+    const aiSessionCommandController = options.aiSessionCommandController;
+    const aiSessionTerminalCommandController = options.aiSessionTerminalCommandController;
+    const conversationCapability = options.conversationCapability;
+    const aiSessionArchiveController = options.aiSessionArchiveController;
+    const acknowledgeAiSessionAttentionEventIds = options.acknowledgeAiSessionAttentionEventIds;
+    const logOpenWorkspaceDiagnostic = options.logOpenWorkspaceDiagnostic;
+    const refreshStewardViews = options.refreshStewardViews;
+    const requestActiveAiSessionTerminalHighlight = options.requestActiveAiSessionTerminalHighlight;
+    const postAiSessionAttentionState = options.postAiSessionAttentionState;
+    const showAgentPivotSettings = options.showAgentPivotSettings;
+    const showBridgeExtension = options.showBridgeExtension;
+
+    return {
+        'request-projects-panel': async e => {
+            if (e.version !== 1 || !Number.isSafeInteger(e.requestId) || e.requestId < 1) {
+                return;
+            }
+            await postMessage({
+                type: 'projects-panel-content',
+                version: 1,
+                requestId: e.requestId,
+                html: getProjectsPanelContent(projectService.getGroups(), getStewardInfos()),
+            });
+        },
+        'request-ai-panel': async e => {
+            if (Object.keys(e).length !== 4
+                || e.version !== 1
+                || typeof e.requestId !== 'string'
+                || e.requestId.length < 1
+                || e.requestId.length > 128
+                || e.target !== 'global-prompt-library') {
+                return;
+            }
+            await postMessage(
+                promptDashboardController.getPanelContent(e.requestId)
+            );
+        },
+        'prompt-command': async e => {
+            const result = await promptDashboardController.handle(e);
+            if (result !== undefined) {
+                await postMessage(result);
+            }
+        },
+        'prompt-insert-terminal': async e => {
+            const result = await getPromptTerminalCommandController().handleInsertRequest(e);
+            if (result !== undefined) {
+                await postMessage(result);
+            }
+        },
+        'toggle-codex-sessions': async e => {
+            await aiSessionCommandController.toggleSessionsExpanded(e.projectId as string, Boolean(e.expanded));
+        },
+        'select-ai-session-providers': async e => {
+            await aiSessionCommandController.selectProviders(
+                e.projectId as string,
+                e.selectedProviders,
+                e.requestId,
+                e.version
+            );
+        },
+        'focus-ai-session-terminal': async e => {
+            const target = {
+                projectId: e.projectId as string,
+                provider: e.provider as AiSessionProviderId,
+                sessionId: e.sessionId as string,
+            };
+            const focused =
+                await aiSessionTerminalCommandController.focusActive(
+                    target.projectId,
+                    target.provider,
+                    target.sessionId
+                );
+            if (focused) {
+                await conversationCapability.followActiveConversation(
+                    target
+                );
+            }
+        },
+        'focus-pending-ai-session': async e => {
+            await aiSessionTerminalCommandController.focusPending(
+                e.projectId as string,
+                e.provider as string,
+                e.createdAt as string
+            );
+        },
+        'close-ai-session-terminal': async e => {
+            await aiSessionTerminalCommandController.closeTerminal({
+                projectId: e.projectId as string,
+                providerId: e.provider as string,
+                sessionId: e.sessionId as string,
+                pendingCreatedAt: e.pendingCreatedAt as string,
+                expectedBackend: 'vscode',
+            });
+        },
+        'detach-ai-session-terminal': async e => {
+            await aiSessionTerminalCommandController.closeTerminal({
+                projectId: e.projectId as string,
+                providerId: e.provider as string,
+                sessionId: e.sessionId as string,
+                pendingCreatedAt: e.pendingCreatedAt as string,
+                expectedBackend: 'tmux',
+            });
+        },
+        'toggle-ai-session-pin': async e => {
+            await aiSessionCommandController.togglePin(e.provider as string, e.sessionId as string);
+        },
+        'acknowledge-ai-session-attention': async e => {
+            const attentionEventIds = Array.isArray(e.eventIds) ? e.eventIds.filter((id: unknown): id is string => typeof id === 'string') : [];
+            await acknowledgeAiSessionAttentionEventIds(attentionEventIds);
+        },
+        'rename-ai-session': async e => {
+            await aiSessionCommandController.renameSession(e.provider as string, e.sessionId as string);
+        },
+        'copy-ai-session-id': async e => {
+            await aiSessionCommandController.copySessionId(e.sessionId as string);
+        },
+        'request-full-refresh': e => {
+            logOpenWorkspaceDiagnostic('Renderer', {
+                event: 'full-refresh-requested',
+                reason: typeof e.reason === 'string' ? e.reason.slice(0, 256) : 'unknown',
+            });
+            refreshStewardViews(typeof e.reason === 'string' ? e.reason.slice(0, 256) : 'webview-requested');
+        },
+        'open-workspaces-rendered': e => {
+            logOpenWorkspaceDiagnostic('Renderer', {
+                event: 'open-workspaces-rendered',
+                semanticRevision: typeof e.semanticRevision === 'string'
+                    ? e.semanticRevision.slice(0, 128)
+                    : 'invalid',
+                currentWorkspaceCount: (e.currentWorkspaceCount === 0 || e.currentWorkspaceCount === 1)
+                    ? e.currentWorkspaceCount as number
+                    : -1,
+                navigationWorkspaceCount: Number.isSafeInteger(e.navigationWorkspaceCount)
+                    && e.navigationWorkspaceCount >= 0
+                    ? e.navigationWorkspaceCount as number
+                    : -1,
+                hasOtherWindowsGroup: e.hasOtherWindowsGroup === true,
+                otherWindowsStatus: e.otherWindowsStatus === 'ready'
+                    || e.otherWindowsStatus === 'unavailable'
+                    || e.otherWindowsStatus === 'update-required'
+                    ? e.otherWindowsStatus as string
+                    : 'invalid',
+            });
+        },
+        'request-active-ai-session-terminal': () => {
+            requestActiveAiSessionTerminalHighlight();
+        },
+        'request-ai-session-attention-state': () => {
+            postAiSessionAttentionState();
+        },
+        'open-settings': async () => {
+            await showAgentPivotSettings();
+        },
+        'open-bridge-extension': async () => {
+            await showBridgeExtension();
+        },
+        'archive-ai-sessions': async e => {
+            await aiSessionArchiveController.archiveSessions(
+                e.projectId,
+                e.items,
+                e.requestId,
+                e.version
+            );
+        },
+    };
+}

--- a/src/services/claudeSessionService.ts
+++ b/src/services/claudeSessionService.ts
@@ -5,7 +5,7 @@ import * as os from 'os';
 import * as path from 'path';
 
 import { CodexSession } from '../models';
-import { aiSessionPathContains, filterAiSessionsByCandidatePaths, normalizeAiSessionCandidatePaths } from '../aiSessions/sessionHelpers';
+import { aiSessionPathContains, compareAiSessionUpdatedAt, filterAiSessionsByCandidatePaths, getAvailableAiSessionArchivePath, normalizeAiSessionCandidatePaths, resolveAiSessionQueryOptions } from '../aiSessions/sessionHelpers';
 import IncrementalJsonlLifecycleReader from '../aiSessions/incrementalJsonlLifecycleReader';
 import type { AiSessionConversationSourceCandidate, AiSessionQueryOptions } from '../aiSessions/types';
 import { createClaudeLifecycleAccumulator, AiSessionLifecycleRequest, AiSessionLifecycleSignal } from '../aiSessions/lifecycle';
@@ -80,7 +80,7 @@ export default class ClaudeSessionService {
     }
 
     getSessions(options: boolean | AiSessionQueryOptions = false): ClaudeSessionReadResult {
-        let { forceRefresh, candidatePaths, maxFiles } = this.getQueryOptions(options);
+        let { forceRefresh, candidatePaths, maxFiles } = resolveAiSessionQueryOptions(options);
         let now = Date.now();
         if (!forceRefresh && this.cachedResult && now - this.cachedAt < this.cacheTtlMs) {
             return this.filterResult(this.cachedResult, candidatePaths);
@@ -106,7 +106,7 @@ export default class ClaudeSessionService {
         let sessions = sessionFiles
             .map(sessionFile => this.readSession(sessionFile))
             .filter(session => !!session)
-            .sort((a, b) => this.compareUpdatedAt(b.updatedAt, a.updatedAt));
+            .sort((a, b) => compareAiSessionUpdatedAt(b.updatedAt, a.updatedAt));
 
         return this.filterResult(this.cacheResult({
             available: true,
@@ -220,7 +220,7 @@ export default class ClaudeSessionService {
             let projectDirName = path.basename(path.dirname(sessionFile));
             let archivePath = path.join(claudeHome, 'archived_projects', projectDirName);
             fs.mkdirSync(archivePath, { recursive: true });
-            fs.renameSync(sessionFile, this.getAvailableArchivePath(archivePath, path.basename(sessionFile)));
+            fs.renameSync(sessionFile, getAvailableAiSessionArchivePath(archivePath, path.basename(sessionFile)));
             this.sessionFilesById.delete(sessionId);
             this.lifecycleReader.delete(sessionId);
             this.invalidateCache();
@@ -260,18 +260,6 @@ export default class ClaudeSessionService {
         return result;
     }
 
-    private getQueryOptions(options: boolean | AiSessionQueryOptions): { forceRefresh: boolean; candidatePaths: string[]; maxFiles: number } {
-        if (typeof options === 'boolean') {
-            return { forceRefresh: options, candidatePaths: [], maxFiles: 0 };
-        }
-
-        return {
-            forceRefresh: Boolean(options?.forceRefresh),
-            candidatePaths: normalizeAiSessionCandidatePaths(options?.candidatePaths || []),
-            maxFiles: this.normalizeMaxFiles(options?.maxFiles),
-        };
-    }
-
     private filterResult(result: ClaudeSessionReadResult, candidatePaths: string[]): ClaudeSessionReadResult {
         return filterAiSessionsByCandidatePaths(result, candidatePaths, session => session.workDir || session.cwd);
     }
@@ -284,10 +272,6 @@ export default class ClaudeSessionService {
 
         let defaultHome = path.join(os.homedir(), '.claude');
         return fs.existsSync(defaultHome) ? defaultHome : null;
-    }
-
-    private normalizeMaxFiles(maxFiles: number): number {
-        return Number.isFinite(maxFiles) && maxFiles > 0 ? Math.floor(maxFiles) : 0;
     }
 
     private getSessionFiles(projectRoot: string, maxFiles = 0, stats?: { discoveredFiles: number }): string[] {
@@ -626,19 +610,6 @@ export default class ClaudeSessionService {
         return `${stat.size}:${stat.mtimeMs}`;
     }
 
-    private getAvailableArchivePath(archivePath: string, fileName: string): string {
-        let parsed = path.parse(fileName);
-        let destination = path.join(archivePath, fileName);
-        let index = 1;
-
-        while (fs.existsSync(destination)) {
-            destination = path.join(archivePath, `${parsed.name}-${index}${parsed.ext}`);
-            index++;
-        }
-
-        return destination;
-    }
-
     private getSessionIdFromFileName(fileName: string): string {
         let match = fileName.match(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i);
         return match ? match[0] : null;
@@ -656,22 +627,4 @@ export default class ClaudeSessionService {
         return value.replace(/\\/g, '/').replace(/\/+$/g, '');
     }
 
-    private compareUpdatedAt(a: string, b: string): number {
-        let aTime = a ? Date.parse(a) : 0;
-        let bTime = b ? Date.parse(b) : 0;
-
-        if (isNaN(aTime) && isNaN(bTime)) {
-            return 0;
-        }
-
-        if (isNaN(aTime)) {
-            return -1;
-        }
-
-        if (isNaN(bTime)) {
-            return 1;
-        }
-
-        return aTime - bTime;
-    }
 }

--- a/src/services/codexSessionService.ts
+++ b/src/services/codexSessionService.ts
@@ -6,7 +6,7 @@ import * as path from 'path';
 
 import { CodexSession } from '../models';
 import IncrementalJsonlLifecycleReader from '../aiSessions/incrementalJsonlLifecycleReader';
-import { filterAiSessionsByCandidatePaths, normalizeAiSessionCandidatePaths } from '../aiSessions/sessionHelpers';
+import { compareAiSessionUpdatedAt, filterAiSessionsByCandidatePaths, getAiSessionFileSignature, getAvailableAiSessionArchivePath, normalizeAiSessionCandidatePaths, resolveAiSessionQueryOptions } from '../aiSessions/sessionHelpers';
 import type { AiSessionQueryOptions } from '../aiSessions/types';
 import { createCodexLifecycleAccumulator, AiSessionLifecycleRequest, AiSessionLifecycleSignal } from '../aiSessions/lifecycle';
 import SessionFingerprint from '../aiSessions/sessionFingerprint';
@@ -54,7 +54,7 @@ export default class CodexSessionService {
     private readonly changePollIntervalMs = 3000;
 
     getSessions(options: boolean | AiSessionQueryOptions = false): CodexSessionReadResult {
-        let { forceRefresh, candidatePaths, maxFiles } = this.getQueryOptions(options);
+        let { forceRefresh, candidatePaths, maxFiles } = resolveAiSessionQueryOptions(options);
         let now = Date.now();
         if (!forceRefresh && this.cachedResult && now - this.cachedAt < this.cacheTtlMs) {
             return this.filterResult(this.cachedResult, candidatePaths);
@@ -103,7 +103,7 @@ export default class CodexSessionService {
                 cwd: meta?.cwd,
             };
 
-            if (!previous || this.compareUpdatedAt(session.updatedAt, previous.updatedAt) > 0) {
+            if (!previous || compareAiSessionUpdatedAt(session.updatedAt, previous.updatedAt) > 0) {
                 sessionsById.set(session.id, session);
             }
         }
@@ -111,7 +111,7 @@ export default class CodexSessionService {
         this.addSessionsFromFiles(sessionsById, sessionFiles);
 
         let sessions = Array.from(sessionsById.values())
-            .sort((a, b) => this.compareUpdatedAt(b.updatedAt, a.updatedAt));
+            .sort((a, b) => compareAiSessionUpdatedAt(b.updatedAt, a.updatedAt));
 
         return this.filterResult(this.cacheResult({
             available: true,
@@ -195,7 +195,7 @@ export default class CodexSessionService {
         try {
             let archivePath = path.join(codexHome, 'archived_sessions');
             fs.mkdirSync(archivePath, { recursive: true });
-            fs.renameSync(sessionFile, this.getAvailableArchivePath(archivePath, path.basename(sessionFile)));
+            fs.renameSync(sessionFile, getAvailableAiSessionArchivePath(archivePath, path.basename(sessionFile)));
             this.lifecycleSessionFiles.delete(sessionId);
             this.lifecycleReader.delete(sessionId);
             this.invalidateCache();
@@ -235,33 +235,8 @@ export default class CodexSessionService {
         return result;
     }
 
-    private getQueryOptions(options: boolean | AiSessionQueryOptions): { forceRefresh: boolean; candidatePaths: string[]; maxFiles: number } {
-        if (typeof options === 'boolean') {
-            return { forceRefresh: options, candidatePaths: [], maxFiles: 0 };
-        }
-
-        return {
-            forceRefresh: Boolean(options?.forceRefresh),
-            candidatePaths: normalizeAiSessionCandidatePaths(options?.candidatePaths || []),
-            maxFiles: this.normalizeMaxFiles(options?.maxFiles),
-        };
-    }
-
     private filterResult(result: CodexSessionReadResult, candidatePaths: string[]): CodexSessionReadResult {
         return filterAiSessionsByCandidatePaths(result, candidatePaths, session => session.cwd);
-    }
-
-    private getAvailableArchivePath(archivePath: string, fileName: string): string {
-        let parsed = path.parse(fileName);
-        let destination = path.join(archivePath, fileName);
-        let index = 1;
-
-        while (fs.existsSync(destination)) {
-            destination = path.join(archivePath, `${parsed.name}-${index}${parsed.ext}`);
-            index++;
-        }
-
-        return destination;
     }
 
     private getCodexHome(): string {
@@ -282,7 +257,7 @@ export default class CodexSessionService {
 
         let fingerprint = new SessionFingerprint();
         fingerprint.addEntry(codexHome);
-        fingerprint.addEntry(this.getFileSignature(path.join(codexHome, 'session_index.jsonl')));
+        fingerprint.addEntry(getAiSessionFileSignature(path.join(codexHome, 'session_index.jsonl')));
         // Discovery already stats every file to order by recency, so the change
         // fingerprint reuses that instead of stat'ing every path a second time.
         for (let entry of this.discoverSessionFiles(codexHome)) {
@@ -291,17 +266,8 @@ export default class CodexSessionService {
         return fingerprint.digest();
     }
 
-    private getFileSignature(filePath: string): string {
-        try {
-            let stat = fs.statSync(filePath);
-            return `${filePath}:${stat.size}:${stat.mtimeMs}`;
-        } catch (e) {
-            return `${filePath}:missing`;
-        }
-    }
-
     private readSessionIndex(indexPath: string): CodexSessionIndexEntry[] {
-        let signature = this.getFileSignature(indexPath);
+        let signature = getAiSessionFileSignature(indexPath);
         let cached = this.sessionIndexCache.get(indexPath);
         if (cached?.signature === signature) {
             return cached.entries;
@@ -331,10 +297,6 @@ export default class CodexSessionService {
             this.sessionIndexCache.delete(indexPath);
             return [];
         }
-    }
-
-    private normalizeMaxFiles(maxFiles: number): number {
-        return Number.isFinite(maxFiles) && maxFiles > 0 ? Math.floor(maxFiles) : 0;
     }
 
     private discoverSessionFiles(
@@ -472,7 +434,7 @@ export default class CodexSessionService {
             return null;
         }
 
-        let signature = this.getFileSignature(sessionFile);
+        let signature = getAiSessionFileSignature(sessionFile);
         let cached = this.sessionMetaCache.get(sessionFile);
         if (cached?.signature === signature) {
             return cached.meta;
@@ -545,22 +507,4 @@ export default class CodexSessionService {
         }
     }
 
-    private compareUpdatedAt(a: string, b: string): number {
-        let aTime = a ? Date.parse(a) : 0;
-        let bTime = b ? Date.parse(b) : 0;
-
-        if (isNaN(aTime) && isNaN(bTime)) {
-            return 0;
-        }
-
-        if (isNaN(aTime)) {
-            return -1;
-        }
-
-        if (isNaN(bTime)) {
-            return 1;
-        }
-
-        return aTime - bTime;
-    }
 }

--- a/src/services/kimiSessionService.ts
+++ b/src/services/kimiSessionService.ts
@@ -6,7 +6,7 @@ import * as os from 'os';
 import * as path from 'path';
 
 import { CodexSession } from '../models';
-import { aiSessionPathContains, filterAiSessionsByCandidatePaths, normalizeAiSessionCandidatePaths } from '../aiSessions/sessionHelpers';
+import { aiSessionPathContains, compareAiSessionUpdatedAt, filterAiSessionsByCandidatePaths, getAiSessionFileSignature, normalizeAiSessionCandidatePaths, resolveAiSessionQueryOptions } from '../aiSessions/sessionHelpers';
 import IncrementalJsonlLifecycleReader from '../aiSessions/incrementalJsonlLifecycleReader';
 import type { AiSessionConversationSourceCandidate, AiSessionQueryOptions } from '../aiSessions/types';
 import { createKimiLifecycleAccumulator, AiSessionLifecycleRequest, AiSessionLifecycleSignal } from '../aiSessions/lifecycle';
@@ -62,7 +62,7 @@ export default class KimiSessionService {
     }
 
     getSessions(options: boolean | AiSessionQueryOptions = false): KimiSessionReadResult {
-        let { forceRefresh, candidatePaths, maxFiles } = this.getQueryOptions(options);
+        let { forceRefresh, candidatePaths, maxFiles } = resolveAiSessionQueryOptions(options);
         let now = Date.now();
         if (!forceRefresh && this.cachedResult && now - this.cachedAt < this.cacheTtlMs) {
             return this.filterResult(this.cachedResult, candidatePaths);
@@ -103,7 +103,7 @@ export default class KimiSessionService {
             }
         }
 
-        sessions.sort((a, b) => this.compareUpdatedAt(b.updatedAt, a.updatedAt));
+        sessions.sort((a, b) => compareAiSessionUpdatedAt(b.updatedAt, a.updatedAt));
         let result = { available: true, sessions, scannedFiles: candidates.length, parsedFiles };
         return candidatePaths.length ? this.filterResult(result, candidatePaths) : this.cacheResult(result);
     }
@@ -207,18 +207,6 @@ export default class KimiSessionService {
         return result;
     }
 
-    private getQueryOptions(options: boolean | AiSessionQueryOptions): { forceRefresh: boolean; candidatePaths: string[]; maxFiles: number } {
-        if (typeof options === 'boolean') {
-            return { forceRefresh: options, candidatePaths: [], maxFiles: 0 };
-        }
-
-        return {
-            forceRefresh: Boolean(options?.forceRefresh),
-            candidatePaths: normalizeAiSessionCandidatePaths(options?.candidatePaths || []),
-            maxFiles: this.normalizeMaxFiles(options?.maxFiles),
-        };
-    }
-
     private filterResult(result: KimiSessionReadResult, candidatePaths: string[]): KimiSessionReadResult {
         return filterAiSessionsByCandidatePaths(result, candidatePaths, session => session.workDir || session.cwd);
     }
@@ -253,10 +241,6 @@ export default class KimiSessionService {
         }
 
         return workDirs;
-    }
-
-    private normalizeMaxFiles(maxFiles: number): number {
-        return Number.isFinite(maxFiles) && maxFiles > 0 ? Math.floor(maxFiles) : 0;
     }
 
     private getSessionCandidatesForWorkDir(kimiHome: string, workDir: string): KimiSessionCandidate[] {
@@ -359,7 +343,7 @@ export default class KimiSessionService {
 
         let fingerprint = new SessionFingerprint();
         fingerprint.addEntry(kimiHome);
-        fingerprint.addEntry(this.getFileSignature(path.join(kimiHome, 'kimi.json')));
+        fingerprint.addEntry(getAiSessionFileSignature(path.join(kimiHome, 'kimi.json')));
         for (let workDir of this.getWorkDirs(kimiHome)) {
             this.addWorkDirFingerprint(fingerprint, kimiHome, workDir);
         }
@@ -382,20 +366,11 @@ export default class KimiSessionService {
             for (let sessionId of sessionIds) {
                 let sessionDir = path.join(sessionsDir, sessionId);
                 fingerprint.addEntry(sessionId);
-                fingerprint.addEntry(this.getFileSignature(path.join(sessionDir, 'state.json')));
-                fingerprint.addEntry(this.getFileSignature(path.join(sessionDir, 'wire.jsonl')));
+                fingerprint.addEntry(getAiSessionFileSignature(path.join(sessionDir, 'state.json')));
+                fingerprint.addEntry(getAiSessionFileSignature(path.join(sessionDir, 'wire.jsonl')));
             }
         } catch (e) {
             fingerprint.addEntry(`${workDir}:unreadable`);
-        }
-    }
-
-    private getFileSignature(filePath: string): string {
-        try {
-            let stat = fs.statSync(filePath);
-            return `${filePath}:${stat.size}:${stat.mtimeMs}`;
-        } catch (e) {
-            return `${filePath}:missing`;
         }
     }
 
@@ -431,22 +406,4 @@ export default class KimiSessionService {
         return value.replace(/\\/g, '/').replace(/\/+$/g, '');
     }
 
-    private compareUpdatedAt(a: string, b: string): number {
-        let aTime = a ? Date.parse(a) : 0;
-        let bTime = b ? Date.parse(b) : 0;
-
-        if (isNaN(aTime) && isNaN(bTime)) {
-            return 0;
-        }
-
-        if (isNaN(aTime)) {
-            return -1;
-        }
-
-        if (isNaN(bTime)) {
-            return 1;
-        }
-
-        return aTime - bTime;
-    }
 }

--- a/tests/contract/aiSessions/notifyConfiguration.test.js
+++ b/tests/contract/aiSessions/notifyConfiguration.test.js
@@ -1,0 +1,212 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const Module = require('node:module');
+const test = require('node:test');
+const { makeTempDirectory } = require('../../helpers/tempDirectory');
+
+// The compiled module graph is cached after the first require, so the vscode
+// stub delegates to a mutable target that each fixture installs before
+// constructing its capability.
+const vscodeStub = {
+    registerCommand: null,
+    createOutputChannel: null,
+};
+
+function loadNotifyConfiguration() {
+    const fakeVscode = {
+        ConfigurationTarget: { Global: 1, Workspace: 2 },
+        commands: {
+            registerCommand: (...args) => vscodeStub.registerCommand(...args),
+        },
+        window: {
+            createOutputChannel: () => vscodeStub.createOutputChannel(),
+        },
+    };
+    const previousLoad = Module._load;
+    try {
+        Module._load = function (request, parent, isMain) {
+            if (request === 'vscode') return fakeVscode;
+            return previousLoad.call(this, request, parent, isMain);
+        };
+        return require('../../../out/aiSessions/notifyConfiguration');
+    } finally {
+        Module._load = previousLoad;
+    }
+}
+
+function createFixture(t, overrides = {}) {
+    const registeredCommands = new Map();
+    const createdChannels = [];
+    const updates = [];
+    const warnings = [];
+    const outputLines = [];
+    vscodeStub.registerCommand = (id, callback) => {
+        registeredCommands.set(id, callback);
+        return { dispose: () => registeredCommands.delete(id) };
+    };
+    vscodeStub.createOutputChannel = () => {
+        const channel = {
+            shown: 0,
+            disposed: false,
+            appendLine(line) { outputLines.push(line); },
+            show() { this.shown += 1; },
+            dispose() { this.disposed = true; },
+        };
+        createdChannels.push(channel);
+        return channel;
+    };
+    const { createNotifyConfiguration } = loadNotifyConfiguration();
+    const secretListeners = new Set();
+    const secrets = overrides.secrets || {};
+    const state = new Map(Object.entries(overrides.globalState || {}));
+    const configurationValues = {
+        'notify.enabled': false,
+        'notify.sinks': [],
+        'notify.reasons': ['completed'],
+        ...overrides.configuration,
+    };
+    const context = {
+        globalState: {
+            get: key => state.get(key),
+            update: async (key, value) => { state.set(key, value); },
+        },
+        secrets: overrides.noSecrets === true
+            ? undefined
+            : {
+                get: async key => secrets[key],
+                store: async (key, value) => { secrets[key] = value; },
+                onDidChange: listener => {
+                    secretListeners.add(listener);
+                    return { dispose: () => secretListeners.delete(listener) };
+                },
+            },
+    };
+    const capability = createNotifyConfiguration({
+        context,
+        getConfiguration: () => ({
+            get: (key, fallback) => Object.prototype.hasOwnProperty.call(configurationValues, key)
+                ? configurationValues[key]
+                : fallback,
+            update: async (key, value, target) => { updates.push([key, value, target]); },
+        }),
+        configurationTargetGlobal: 1,
+        homedir: () => makeTempDirectory(t, 'notify-config-'),
+        env: {},
+        nowMs: () => 1000,
+        setTimeout: () => ({}),
+        clearTimeout: () => undefined,
+        sleep: async () => undefined,
+        showWarningMessage: async (message, options, ...items) => {
+            warnings.push({ message, options, items });
+            return overrides.consentChoice;
+        },
+    });
+    const notifyChannel = () => createdChannels[0];
+    const fireSecretChange = key => secretListeners.forEach(listener => listener({ key }));
+    return {
+        capability, registeredCommands, secretListeners, secrets, state,
+        configurationValues, updates, warnings, outputLines, fireSecretChange, notifyChannel,
+    };
+}
+
+test('ATTENTION-NOTIFY-CREDENTIALS-001 assembles config from settings and prefixed secrets', async t => {
+    const f = createFixture(t, {
+        configuration: { 'notify.enabled': true, 'notify.sinks': [{ id: 'hook' }] },
+        secrets: { 'agentPivot.notify.sink.hook': '{"url":"https://example.com/h"}' },
+        globalState: { 'agentPivot.notify.consented': true },
+    });
+
+    await f.capability.refresh();
+
+    const config = f.capability.getConfig();
+    assert.ok(config, 'a refresh publishes the assembled config');
+    assert.equal(config.enabled, true);
+    assert.deepEqual(config.policy.reasons, ['completed']);
+    assert.deepEqual(f.outputLines.filter(line => line.includes('not valid JSON')), [],
+        'a parseable secret must not be dropped');
+});
+
+test('ATTENTION-NOTIFY-CREDENTIALS-001 consent decline disables and never assembles', async t => {
+    const declined = createFixture(t, {
+        configuration: { 'notify.enabled': true, 'notify.sinks': [{ id: 'hook' }] },
+        consentChoice: undefined,
+    });
+
+    await declined.capability.refresh();
+
+    assert.equal(declined.warnings.length, 1, 'the consent modal is shown once');
+    assert.match(declined.warnings[0].message, /No code or file contents are sent/);
+    assert.deepEqual(declined.updates, [['notify.enabled', false, 1]],
+        'a declined consent disables notifications globally');
+    assert.equal(declined.capability.getConfig(), null, 'no config assembles without consent');
+
+    const accepted = createFixture(t, {
+        configuration: { 'notify.enabled': true },
+        consentChoice: 'Enable notifications',
+    });
+    await accepted.capability.refresh();
+    assert.equal(accepted.state.get('agentPivot.notify.consented'), true,
+        'an accepted consent persists');
+    assert.ok(accepted.capability.getConfig(), 'an accepted consent assembles the config');
+});
+
+test('ATTENTION-NOTIFY-CREDENTIALS-001 refresh failures keep the previous config and log', async t => {
+    const f = createFixture(t, { globalState: { 'agentPivot.notify.consented': true } });
+
+    await f.capability.refresh();
+    assert.ok(f.capability.getConfig(), 'initial refresh assembles');
+
+    f.configurationValues['notify.sinks'] = null;
+    await f.capability.refresh();
+    assert.ok(f.capability.getConfig(), 'the previous config survives a failed refresh');
+    assert.ok(f.outputLines.some(line => line.includes('notify: config refresh failed:')),
+        'the failure is logged to the notify output');
+});
+
+test('ATTENTION-NOTIFY-CREDENTIALS-001 secret changes re-read the config; other keys stay ignored', async t => {
+    const f = createFixture(t, {
+        configuration: { 'notify.enabled': true, 'notify.sinks': [{ id: 'hook' }] },
+        globalState: { 'agentPivot.notify.consented': true },
+    });
+
+    await f.capability.refresh();
+    assert.equal(f.secretListeners.size, 1, 'the secret listener is subscribed');
+
+    f.secrets['agentPivot.notify.sink.hook'] = '{"url":"https://example.com/new"}';
+    f.fireSecretChange('agentPivot.notify.sink.hook');
+    await new Promise(resolve => setImmediate(resolve));
+    await new Promise(resolve => setImmediate(resolve));
+
+    f.fireSecretChange('unrelated.key');
+    const before = f.outputLines.length;
+    f.fireSecretChange('unrelated.key');
+    assert.equal(f.outputLines.length, before, 'non-notify keys never refresh');
+});
+
+test('ATTENTION-NOTIFY-GUIDED-SETUP-001 registers the palette commands with the fallback config', async t => {
+    const f = createFixture(t);
+
+    assert.ok(f.registeredCommands.has('agentPivot.notify.setWebhook'));
+    assert.ok(f.registeredCommands.has('agentPivot.notify.showOutput'));
+
+    await f.registeredCommands.get('agentPivot.notify.showOutput')();
+    assert.equal(f.notifyChannel().shown, 1, 'show output surfaces the notify channel');
+});
+
+test('ATTENTION-NOTIFY-GUIDED-SETUP-001 dispose tears down the listener, commands, and output', async t => {
+    const f = createFixture(t, {
+        configuration: { 'notify.enabled': true },
+        globalState: { 'agentPivot.notify.consented': true },
+        consentChoice: 'Enable notifications',
+    });
+    await f.capability.refresh();
+
+    const commandCount = f.registeredCommands.size;
+    assert.ok(commandCount >= 2);
+    f.capability.dispose();
+
+    assert.equal(f.secretListeners.size, 0, 'the secret listener is disposed');
+    assert.equal(f.registeredCommands.size, 0, 'the commands are unregistered');
+    assert.equal(f.notifyChannel().disposed, true, 'the output channel is disposed');
+});

--- a/tests/contract/aiSessions/sessionControllerComposition.test.js
+++ b/tests/contract/aiSessions/sessionControllerComposition.test.js
@@ -1,0 +1,297 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const Module = require('node:module');
+const test = require('node:test');
+
+function loadComposition() {
+    const previousLoad = Module._load;
+    try {
+        Module._load = function (request, parent, isMain) {
+            if (request === 'vscode') return {};
+            return previousLoad.call(this, request, parent, isMain);
+        };
+        return require('../../../out/aiSessions/sessionControllerComposition');
+    } finally {
+        Module._load = previousLoad;
+    }
+}
+
+const { createSessionControllerComposition } = loadComposition();
+
+function createFixture(overrides = {}) {
+    const calls = [];
+    const record = name => (...args) => {
+        calls.push([name, ...args]);
+        return Promise.resolve();
+    };
+    const controllerOptions = {};
+    const factories = {
+        createCommandController: options => {
+            controllerOptions.command = options;
+            return { marker: 'command', ...overrides.commandController };
+        },
+        createCreationController: options => {
+            controllerOptions.creation = options;
+            return { marker: 'creation' };
+        },
+        createArchiveController: options => {
+            controllerOptions.archive = options;
+            return { marker: 'archive' };
+        },
+        createTerminalCommandController: options => {
+            controllerOptions.terminal = options;
+            return { marker: 'terminal' };
+        },
+        createResumeController: options => {
+            controllerOptions.resume = options;
+            return { marker: 'resume' };
+        },
+    };
+    const providers = [{ id: 'codex' }, { id: 'kimi' }, { id: 'claude' }];
+    const composition = createSessionControllerComposition({
+        getCurrentWorkspaceActionTarget: cardId => ({ cardId }),
+        getCurrentOpenWorkspace: () => ({ scopeIdentity: 'scope-1' }),
+        getActiveEditorUri: () => undefined,
+        isWorkspaceTrusted: () => true,
+        getRegisteredAiSessionProvider: providerId => providers.find(provider => provider.id === providerId) || null,
+        getRegisteredAiSessionProviders: () => providers,
+        providerDirectoryCapability: { probe: record('probeCapability') },
+        workspacePrimaryRootStore: {
+            getPrimaryRootId: record('getPrimaryRootId'),
+            setPrimaryRootId: record('setPrimaryRootId'),
+        },
+        aiSessionWorkspaceStateStore: {
+            setExpanded: record('setExpanded'),
+            setProviderSelection: record('setProviderSelection'),
+        },
+        aiSessionPinController: { toggle: record('pinToggle'), remove: record('pinRemove') },
+        aiSessionAliasController: {
+            getAll: () => ({}),
+            saveAll: record('saveAliases'),
+            getOriginalName: record('getOriginalName'),
+            remove: record('aliasRemove'),
+        },
+        aiSessionReadCoordinator: { getProviderResult: record('getProviderResult') },
+        aiSessionRuntimeCoordinator: {
+            refreshForHost: record('refreshForHost'),
+            focus: record('runtimeFocus'),
+        },
+        aiSessionTerminalService: {
+            getPendingMarkerPath: record('getPendingMarkerPath'),
+            getMarkerPath: record('getMarkerPath'),
+            deleteMarker: record('deleteMarker'),
+            untrack: record('untrack'),
+        },
+        aiSessionProviders: providers,
+        getAiSessionRuntimeById: record('getRuntimeById'),
+        getAiSessionRuntimeCollision: record('getRuntimeCollision'),
+        getAiSessionPinKey: (providerId, sessionId) => `${providerId}:${sessionId}`,
+        runSafeLifecycleTask: (operation, task) => {
+            calls.push(['runSafeLifecycleTask', operation]);
+            return Promise.resolve().then(task).then(() => undefined, () => undefined);
+        },
+        acknowledgeAttention: record('acknowledgeAttention'),
+        syncActiveRuntime: () => calls.push(['syncActiveRuntime']),
+        getLaunchOptions: () => ({ launch: true }),
+        postMessage: record('postMessage'),
+        appendOutput: record('appendOutput'),
+        postBatchArchiveCompletion: record('postBatchArchiveCompletion'),
+        logError: record('logError'),
+        logAiSessionRuntimeFailure: record('logRuntimeFailure'),
+        refreshAiSessionViewsIncrementally: () => calls.push(['refreshViews']),
+        scheduleNewAiSessionRefresh: record('scheduleNewSessionRefresh'),
+        nowMs: () => 1234,
+        showInputBox: record('showInputBox'),
+        showQuickPick: overrides.showQuickPick || record('showQuickPick'),
+        showWarningMessage: record('showWarningMessage'),
+        showWarningWithItems: record('showWarningWithItems'),
+        showModalWarning: record('showModalWarning'),
+        showInformationMessage: record('showInformationMessage'),
+        showErrorMessage: record('showErrorMessage'),
+        writeClipboard: record('writeClipboard'),
+        focusTerminalView: record('focusTerminalView'),
+    }, factories);
+    return { composition, controllerOptions, calls, providers };
+}
+
+test('SESSION-AI-SESSION-CREATION-CONTROLLER-001 returns all five composed controllers', () => {
+    const { composition } = createFixture();
+
+    assert.deepEqual(
+        Object.keys(composition),
+        [
+            'aiSessionCommandController',
+            'aiSessionCreationController',
+            'aiSessionArchiveController',
+            'aiSessionTerminalCommandController',
+            'aiSessionResumeController',
+        ]
+    );
+    assert.deepEqual(
+        Object.values(composition).map(controller => controller.marker),
+        ['command', 'creation', 'archive', 'terminal', 'resume']
+    );
+});
+
+test('SESSION-AI-SESSION-PROVIDER-AVAILABILITY-001 wires the workspace root and provider picks', async () => {
+    const picks = [];
+    const { controllerOptions } = createFixture({
+        showQuickPick: async (items, options) => {
+            picks.push({ items, options });
+            return items[0];
+        },
+    });
+
+    const workspace = {
+        scopeIdentity: 'scope-1',
+        roots: [{ id: 'root-1', name: 'api', hostPath: '/work/api' }],
+    };
+    const rootId = await controllerOptions.command.pickWorkspaceRoot(workspace, 'resume');
+    assert.equal(rootId, 'root-1');
+    assert.equal(picks[0].options.title, 'Resume AI Session in Workspace Root');
+    assert.deepEqual(picks[0].items, [{ label: 'api', description: '/work/api', rootId: 'root-1' }]);
+
+    const providerId = await controllerOptions.creation.pickProvider();
+    assert.equal(providerId, 'codex', 'provider picks come from the registry order');
+    assert.equal(picks[1].options.title, 'Select an AI provider');
+
+    await controllerOptions.command.getProviderDirectoryCapability({ id: 'codex' });
+    assert.equal(picks.length, 2);
+});
+
+test('SESSION-AI-SESSION-CREATION-CONTROLLER-001 delegates directory scopes to the command controller', async () => {
+    const resolved = [];
+    const { controllerOptions, calls } = createFixture({
+        commandController: {
+            resolveWorkspaceDirectoryScope: async (...args) => {
+                resolved.push(args);
+                return { rootId: 'root-1' };
+            },
+            rememberDirectoryScope: async () => { throw new Error('disk full'); },
+        },
+    });
+
+    await controllerOptions.creation.resolveWorkspaceDirectoryScope({ workspace: 'w' }, 'codex', 'root-9');
+    assert.deepEqual(resolved, [['w', 'codex', undefined, 'root-9']],
+        'creation resolves against the target workspace');
+
+    await controllerOptions.resume.resolveWorkspaceDirectoryScope({ workspace: 'w' }, 'session', 'kimi', 'root-8');
+    assert.deepEqual(resolved[1], ['w', 'kimi', 'session', 'root-8'],
+        'resume resolves against the target workspace with the session');
+
+    await controllerOptions.creation.rememberDirectoryScope({ rootId: 'root-1' });
+    const logErrorCall = calls.find(call => call[0] === 'logError');
+    assert.equal(logErrorCall[1], 'Could not save the AI session workspace root.');
+    assert.ok(logErrorCall[2] instanceof Error && logErrorCall[2].message === 'disk full',
+        'a failed scope memory logs instead of throwing');
+});
+
+test('SESSION-AI-SESSION-CREATION-CONTROLLER-001 wires refresh cadence, markers, and status posts', async () => {
+    const { controllerOptions, calls } = createFixture();
+    const creation = controllerOptions.creation;
+
+    await creation.getExistingSessionIdsForCwd('codex', '/work/api');
+    assert.deepEqual(calls.find(call => call[0] === 'getProviderResult'),
+        ['getProviderResult', 'codex', {
+            forceRefresh: true,
+            candidatePaths: ['/work/api'],
+            reason: 'new-session',
+        }]);
+
+    creation.showActiveTab('project-1');
+    creation.announceStatus('project-1', 'ready');
+    assert.deepEqual(calls.filter(call => call[0] === 'postMessage'), [
+        ['postMessage', { type: 'ai-session-tab-selection-requested', projectId: 'project-1', tab: 'active' }],
+        ['postMessage', { type: 'ai-session-status-announcement', projectId: 'project-1', message: 'ready' }],
+    ]);
+    assert.equal(creation.nowMs(), 1234);
+    assert.equal(typeof creation.createPendingId(), 'string');
+    assert.equal(creation.createPendingId().length, 32);
+});
+
+test('PERSIST-MULTI-PROVIDER-BATCH-ARCHIVE-001 wires archive guards, confirmations, and completion', async () => {
+    const { controllerOptions, calls } = createFixture();
+    const archive = controllerOptions.archive;
+
+    await archive.refreshRuntimeGuard();
+    assert.deepEqual(calls.find(call => call[0] === 'refreshForHost'), ['refreshForHost', true]);
+
+    archive.confirmSingleArchive('Codex');
+    assert.deepEqual(calls.find(call => call[0] === 'showModalWarning'),
+        ['showModalWarning', 'Archive this Codex session?', 'Archive']);
+
+    archive.postCompletion({ type: 'batch' });
+    assert.deepEqual(calls.find(call => call[0] === 'postBatchArchiveCompletion'),
+        ['postBatchArchiveCompletion', { type: 'batch' }]);
+
+    archive.syncActiveRuntime();
+    assert.deepEqual(calls.filter(call => call[0] === 'syncActiveRuntime').length, 1);
+});
+
+test('SESSION-AI-SESSION-TERMINAL-COMMAND-CONTROLLER-001 closes runtimes through the settlement boundary', async () => {
+    const { controllerOptions, calls } = createFixture();
+    const terminal = controllerOptions.terminal;
+
+    terminal.onRuntimeCloseEnd({ identity: { provider: 'codex', sessionId: 's1', workspaceScopeIdentity: 'scope-1' } }, true);
+    await new Promise(resolve => setImmediate(resolve));
+    await new Promise(resolve => setImmediate(resolve));
+    assert.deepEqual(calls.find(call => call[0] === 'runSafeLifecycleTask'),
+        ['runSafeLifecycleTask', 'acknowledge-explicit-session-close']);
+    assert.deepEqual(calls.find(call => call[0] === 'acknowledgeAttention'),
+        ['acknowledgeAttention', { provider: 'codex', sessionId: 's1', workspaceScopeIdentity: 'scope-1' }]);
+
+    calls.length = 0;
+    terminal.onRuntimeCloseEnd({ identity: { provider: 'codex', sessionId: 's1' } }, false);
+    terminal.onRuntimeCloseEnd({ identity: { provider: 'codex', workspaceScopeIdentity: 'scope-1' } }, true);
+    assert.deepEqual(calls, [], 'failed or session-less closes must not acknowledge');
+
+    terminal.confirmRuntimeClose('Close it?', 'Close');
+    assert.deepEqual(calls[0], ['showModalWarning', 'Close it?', 'Close']);
+});
+
+test('SESSION-AI-SESSION-TERMINAL-COMMAND-CONTROLLER-001 builds exact runtime conflict picks', async () => {
+    const runtimes = [
+        {
+            backend: 'tmux',
+            tmux: { layout: 'project', sessionName: 'agent-pivot', windowName: 'main' },
+            attached: true,
+            identity: { sessionId: 's-tmux' },
+        },
+        {
+            backend: 'vscode',
+            terminal: { name: 'term-1' },
+            attached: false,
+            identity: { sessionId: 's-direct' },
+        },
+    ];
+    let pickCall;
+    const { controllerOptions } = createFixture({
+        showQuickPick: async (items, options) => {
+            pickCall = { items, options };
+            return items[1];
+        },
+    });
+
+    const selected = await controllerOptions.terminal.chooseRuntimeConflict(runtimes);
+    assert.equal(selected.identity.sessionId, 's-direct');
+    assert.deepEqual(pickCall.items.map(item => [item.label, item.description, item.detail]), [
+        ['$(terminal) tmux · project layout', 'attached', 'Target: agent-pivot:main'],
+        ['$(terminal) Direct · VS Code Terminal', 'detached', 'Target: term-1'],
+    ]);
+});
+
+test('SESSION-AI-SESSION-RESUME-CONTROLLER-001 wires names, conflicts, and markers', async () => {
+    const { controllerOptions, calls, providers } = createFixture();
+    const resume = controllerOptions.resume;
+
+    resume.getRuntimeConflict('codex', 's1', 'scope-1');
+    assert.deepEqual(calls.find(call => call[0] === 'getRuntimeCollision'),
+        ['getRuntimeCollision', 'codex', 's1', 'scope-1']);
+
+    resume.getMarkerPath('codex', 's1');
+    assert.deepEqual(calls.find(call => call[0] === 'getMarkerPath'), ['getMarkerPath', 'codex', 's1']);
+
+    const name = resume.getTerminalName('codex', { id: 's1', name: 'Fix bug' }, providers);
+    assert.equal(typeof name, 'string');
+});

--- a/tests/contract/dashboard/messageHandlers.test.js
+++ b/tests/contract/dashboard/messageHandlers.test.js
@@ -1,0 +1,252 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const Module = require('node:module');
+const test = require('node:test');
+
+function loadMessageHandlers() {
+    const fakeVscode = {
+        ConfigurationTarget: { Global: 1, Workspace: 2 },
+        Uri: {
+            file: value => ({ scheme: 'file', fsPath: value, path: value, toString: () => value }),
+            parse: value => ({ scheme: 'file', fsPath: value, path: value, toString: () => value }),
+        },
+    };
+    const previousLoad = Module._load;
+    try {
+        Module._load = function (request, parent, isMain) {
+            if (request === 'vscode') return fakeVscode;
+            return previousLoad.call(this, request, parent, isMain);
+        };
+        return require('../../../out/dashboard/messageHandlers');
+    } finally {
+        Module._load = previousLoad;
+    }
+}
+
+const { createDashboardMessageHandlers } = loadMessageHandlers();
+
+function createFixture(overrides = {}) {
+    const calls = [];
+    const posted = [];
+    const record = name => (...args) => {
+        calls.push([name, ...args]);
+        return Promise.resolve();
+    };
+    const handlers = createDashboardMessageHandlers({
+        postMessage: async message => { posted.push(message); return true; },
+        getStewardInfos: () => ({ config: { get: (_key, fallback) => fallback } }),
+        projectService: { getGroups: () => [{ id: 'group-a', name: 'Work', projects: [] }] },
+        promptDashboardController: {
+            getPanelContent: requestId => ({ type: 'ai-panel-content', requestId }),
+            handle: record('promptHandle'),
+        },
+        getPromptTerminalCommandController: () => ({ handleInsertRequest: record('promptInsert') }),
+        aiSessionCommandController: {
+            toggleSessionsExpanded: record('toggleSessionsExpanded'),
+            selectProviders: record('selectProviders'),
+            togglePin: record('togglePin'),
+            renameSession: record('renameSession'),
+            copySessionId: record('copySessionId'),
+        },
+        aiSessionTerminalCommandController: {
+            focusActive: async (...args) => {
+                calls.push(['focusActive', ...args]);
+                return overrides.focused !== false;
+            },
+            focusPending: record('focusPending'),
+            closeTerminal: record('closeTerminal'),
+        },
+        conversationCapability: { followActiveConversation: record('followActiveConversation') },
+        aiSessionArchiveController: { archiveSessions: record('archiveSessions') },
+        acknowledgeAiSessionAttentionEventIds: record('acknowledgeAttention'),
+        logOpenWorkspaceDiagnostic: (component, event) => calls.push(['rendererDiagnostic', component, event]),
+        refreshStewardViews: reason => calls.push(['refreshStewardViews', reason]),
+        requestActiveAiSessionTerminalHighlight: () => calls.push(['requestHighlight']),
+        postAiSessionAttentionState: () => calls.push(['postAttentionState']),
+        showAgentPivotSettings: async () => { calls.push(['showSettings']); },
+        showBridgeExtension: async () => { calls.push(['showBridgeExtension']); },
+    });
+    return { handlers, calls, posted };
+}
+
+test('WEBVIEW-DASHBOARD-MESSAGE-ROUTER-001 exposes every extracted handler key', () => {
+    const { handlers } = createFixture();
+
+    assert.deepEqual(Object.keys(handlers), [
+        'request-projects-panel',
+        'request-ai-panel',
+        'prompt-command',
+        'prompt-insert-terminal',
+        'toggle-codex-sessions',
+        'select-ai-session-providers',
+        'focus-ai-session-terminal',
+        'focus-pending-ai-session',
+        'close-ai-session-terminal',
+        'detach-ai-session-terminal',
+        'toggle-ai-session-pin',
+        'acknowledge-ai-session-attention',
+        'rename-ai-session',
+        'copy-ai-session-id',
+        'request-full-refresh',
+        'open-workspaces-rendered',
+        'request-active-ai-session-terminal',
+        'request-ai-session-attention-state',
+        'open-settings',
+        'open-bridge-extension',
+        'archive-ai-sessions',
+    ]);
+});
+
+test('WEBVIEW-DASHBOARD-MESSAGE-ROUTER-001 validates panel request envelopes and posts content', async () => {
+    const { handlers, posted } = createFixture();
+
+    await handlers['request-projects-panel']({ version: 1, requestId: 7 });
+    assert.equal(posted.length, 1);
+    assert.equal(posted[0].type, 'projects-panel-content');
+    assert.equal(posted[0].requestId, 7);
+    assert.ok(posted[0].html.length > 0, 'the panel html renders from current groups');
+
+    await handlers['request-projects-panel']({ version: 2, requestId: 8 });
+    await handlers['request-projects-panel']({ version: 1, requestId: 0 });
+    assert.equal(posted.length, 1, 'invalid panel envelopes stay ignored');
+
+    await handlers['request-ai-panel']({
+        type: 'request-ai-panel', version: 1, requestId: 'req-9',
+        target: 'global-prompt-library', extra: 'kept-out',
+    });
+    assert.equal(posted.length, 1, 'a fifth envelope key must reject the ai panel request');
+
+    await handlers['request-ai-panel']({
+        type: 'request-ai-panel', version: 1, requestId: 'req-9', target: 'global-prompt-library',
+    });
+    assert.equal(posted.length, 2);
+    assert.deepEqual(posted[1], { type: 'ai-panel-content', requestId: 'req-9' });
+
+    await handlers['request-ai-panel']({ type: 'request-ai-panel', version: 1, requestId: 'req-9', target: 'other' });
+    assert.equal(posted.length, 2, 'unknown targets stay ignored');
+});
+
+test('WEBVIEW-DASHBOARD-MESSAGE-ROUTER-001 posts prompt results only when produced', async () => {
+    const { handlers, posted, calls } = createFixture();
+    calls.length = 0;
+
+    await handlers['prompt-command']({ type: 'prompt-command', requestId: 1 });
+    await handlers['prompt-insert-terminal']({ type: 'prompt-insert-terminal', requestId: 2 });
+
+    assert.deepEqual(calls, [
+        ['promptHandle', { type: 'prompt-command', requestId: 1 }],
+        ['promptInsert', { type: 'prompt-insert-terminal', requestId: 2 }],
+    ]);
+    assert.equal(posted.length, 0, 'undefined results post nothing');
+});
+
+test('WEBVIEW-DASHBOARD-MESSAGE-ROUTER-001 sanitizes renderer diagnostics and refreshes', async () => {
+    const { handlers, calls } = createFixture();
+
+    await handlers['request-full-refresh']({ reason: 'x'.repeat(300) });
+    assert.deepEqual(calls[0], ['rendererDiagnostic', 'Renderer', {
+        event: 'full-refresh-requested',
+        reason: 'x'.repeat(256),
+    }]);
+    assert.deepEqual(calls[1], ['refreshStewardViews', 'x'.repeat(256)],
+        'the refresh reason is truncated to the same bound');
+
+    calls.length = 0;
+    await handlers['request-full-refresh']({});
+    assert.deepEqual(calls[1], ['refreshStewardViews', 'webview-requested']);
+
+    calls.length = 0;
+    await handlers['open-workspaces-rendered']({
+        semanticRevision: 'rev', currentWorkspaceCount: 1, navigationWorkspaceCount: 2,
+        hasOtherWindowsGroup: true, otherWindowsStatus: 'ready',
+    });
+    assert.deepEqual(calls[0][2], {
+        event: 'open-workspaces-rendered',
+        semanticRevision: 'rev',
+        currentWorkspaceCount: 1,
+        navigationWorkspaceCount: 2,
+        hasOtherWindowsGroup: true,
+        otherWindowsStatus: 'ready',
+    });
+
+    calls.length = 0;
+    await handlers['open-workspaces-rendered']({
+        semanticRevision: 7, currentWorkspaceCount: 3, navigationWorkspaceCount: -1,
+        otherWindowsStatus: 'bogus',
+    });
+    assert.deepEqual(calls[0][2], {
+        event: 'open-workspaces-rendered',
+        semanticRevision: 'invalid',
+        currentWorkspaceCount: -1,
+        navigationWorkspaceCount: -1,
+        hasOtherWindowsGroup: false,
+        otherWindowsStatus: 'invalid',
+    }, 'malformed renderer reports sanitize to invalid markers');
+});
+
+test('WEBVIEW-DASHBOARD-MESSAGE-ROUTER-001 delegates the simple openers and state requests', async () => {
+    const { handlers, calls } = createFixture();
+
+    await handlers['request-active-ai-session-terminal']({});
+    await handlers['request-ai-session-attention-state']({});
+    await handlers['open-settings']({});
+    await handlers['open-bridge-extension']({});
+    await handlers['acknowledge-ai-session-attention']({ eventIds: ['a', 1, 'b'] });
+
+    assert.deepEqual(calls, [
+        ['requestHighlight'],
+        ['postAttentionState'],
+        ['showSettings'],
+        ['showBridgeExtension'],
+        ['acknowledgeAttention', ['a', 'b']],
+    ], 'non-string attention event ids are filtered before acknowledgement');
+});
+
+test('SESSION-AI-SESSION-TERMINAL-COMMAND-CONTROLLER-001 delegates focus and close flows', async () => {
+    const { handlers, calls } = createFixture();
+
+    await handlers['focus-ai-session-terminal']({ projectId: 'p1', provider: 'codex', sessionId: 's1' });
+    assert.deepEqual(calls[0], ['focusActive', 'p1', 'codex', 's1']);
+    assert.deepEqual(calls[1], ['followActiveConversation', { projectId: 'p1', provider: 'codex', sessionId: 's1' }],
+        'a successful focus follows the conversation');
+
+    const unfocused = createFixture({ focused: false });
+    await unfocused.handlers['focus-ai-session-terminal']({ projectId: 'p1', provider: 'codex', sessionId: 's1' });
+    assert.equal(unfocused.calls.filter(call => call[0] === 'followActiveConversation').length, 0,
+        'no conversation follows an unfocused terminal');
+
+    await handlers['focus-pending-ai-session']({ projectId: 'p1', provider: 'kimi', createdAt: 'c1' });
+    await handlers['close-ai-session-terminal']({ projectId: 'p1', provider: 'codex', sessionId: 's1', pendingCreatedAt: 'pc1' });
+    await handlers['detach-ai-session-terminal']({ projectId: 'p1', provider: 'codex', sessionId: 's2' });
+
+    assert.deepEqual(calls[2], ['focusPending', 'p1', 'kimi', 'c1']);
+    assert.deepEqual(calls[3], ['closeTerminal', {
+        projectId: 'p1', providerId: 'codex', sessionId: 's1',
+        pendingCreatedAt: 'pc1', expectedBackend: 'vscode',
+    }]);
+    assert.deepEqual(calls[4], ['closeTerminal', {
+        projectId: 'p1', providerId: 'codex', sessionId: 's2',
+        pendingCreatedAt: undefined, expectedBackend: 'tmux',
+    }], 'detach keeps the tmux backend marker');
+});
+
+test('PERSIST-MULTI-PROVIDER-BATCH-ARCHIVE-001 delegates archive, provider, and pin mutations', async () => {
+    const { handlers, calls } = createFixture();
+
+    await handlers['archive-ai-sessions']({ projectId: 'p1', items: ['i1'], requestId: 'r1', version: 1 });
+    await handlers['toggle-codex-sessions']({ projectId: 'p1', expanded: 1 });
+    await handlers['select-ai-session-providers']({ projectId: 'p1', selectedProviders: ['codex'], requestId: 'r2', version: 1 });
+    await handlers['toggle-ai-session-pin']({ provider: 'codex', sessionId: 's1' });
+    await handlers['rename-ai-session']({ provider: 'codex', sessionId: 's1' });
+    await handlers['copy-ai-session-id']({ sessionId: 's1' });
+
+    assert.deepEqual(calls, [
+        ['archiveSessions', 'p1', ['i1'], 'r1', 1],
+        ['toggleSessionsExpanded', 'p1', true],
+        ['selectProviders', 'p1', ['codex'], 'r2', 1],
+        ['togglePin', 'codex', 's1'],
+        ['renameSession', 'codex', 's1'],
+        ['copySessionId', 's1'],
+    ]);
+});

--- a/tests/integration/dashboard/conversationOpenLatest.test.js
+++ b/tests/integration/dashboard/conversationOpenLatest.test.js
@@ -306,11 +306,11 @@ test('CONVERSATION-FOLLOW-ACTIVE-SESSION-001 follows the latest interaction only
 });
 
 test('CONVERSATION-FOLLOW-ACTIVE-SESSION-001 routes a successful Active Session card focus into Conversation following', () => {
-    const dashboardSource = fs.readFileSync(
-        path.join(__dirname, '../../../src/dashboard.ts'),
+    const handlersSource = fs.readFileSync(
+        path.join(__dirname, '../../../src/dashboard/messageHandlers.ts'),
         'utf8'
     );
-    const handler = dashboardSource.match(
+    const handler = handlersSource.match(
         /'focus-ai-session-terminal': async e => \{[\s\S]*?\n\s*\},\n\s*'focus-pending-ai-session'/
     );
     assert.ok(handler, 'Active Session focus handler must remain inspectable');

--- a/tests/integration/dashboard/webviewState.test.js
+++ b/tests/integration/dashboard/webviewState.test.js
@@ -658,7 +658,7 @@ test('WEBVIEW-MULTI-PROVIDER-SESSION-MENU-001 keeps the generated provider-menu 
     assert.match(aiSessionControlsSource, /pendingAiSessionProviderSelectionProjectId/);
     assert.match(aiSessionControlsSource, /pendingAiSessionProviderSelectionRequestId/);
     assert.match(
-        fs.readFileSync(path.join(root, 'src', 'dashboard.ts'), 'utf8'),
+        fs.readFileSync(path.join(root, 'src', 'dashboard', 'messageHandlers.ts'), 'utf8'),
         /e\.selectedProviders,\s*e\.requestId,\s*e\.version/
     );
     assert.doesNotMatch(projectSource, /type: 'select-ai-session-provider'/);

--- a/tests/unit/aiSessions/sessionBoundaries.test.js
+++ b/tests/unit/aiSessions/sessionBoundaries.test.js
@@ -164,3 +164,58 @@ test('SESSION-KEY-001 round-trips supported provider keys and rejects malformed 
     assert.equal(helpers.getAiSessionProviderIdFromKey('unknown:session', isProviderId), null);
     assert.equal(helpers.getAiSessionProviderIdFromKey('missing-separator', isProviderId), null);
 });
+
+test('SESSION-SCAN-OPTION-001 normalizes shared query options for every provider', () => {
+    assert.deepEqual(helpers.resolveAiSessionQueryOptions(true), {
+        forceRefresh: true, candidatePaths: [], maxFiles: 0,
+    });
+    assert.deepEqual(helpers.resolveAiSessionQueryOptions(false), {
+        forceRefresh: false, candidatePaths: [], maxFiles: 0,
+    });
+    assert.deepEqual(helpers.resolveAiSessionQueryOptions({
+        forceRefresh: 1, candidatePaths: ['/work/api/'], maxFiles: 42.9,
+    }), {
+        forceRefresh: true, candidatePaths: ['/work/api'], maxFiles: 42,
+    });
+    assert.equal(helpers.normalizeAiSessionMaxFiles(0), 0);
+    assert.equal(helpers.normalizeAiSessionMaxFiles(Number.NaN), 0);
+    assert.equal(helpers.normalizeAiSessionMaxFiles(2000.7), 2000);
+});
+
+test('SESSION-SCAN-OPTION-001 shares one updatedAt ordering across providers', () => {
+    assert.equal(helpers.compareAiSessionUpdatedAt('2026-01-02T00:00:00Z', '2026-01-01T00:00:00Z') > 0, true);
+    assert.equal(helpers.compareAiSessionUpdatedAt('not-a-date', 'not-a-date'), 0);
+    assert.equal(helpers.compareAiSessionUpdatedAt('not-a-date', '2026-01-01T00:00:00Z'), -1);
+    assert.equal(helpers.compareAiSessionUpdatedAt('2026-01-01T00:00:00Z', 'not-a-date'), 1);
+});
+
+test('SESSION-FINGERPRINT-HASH-001 signs present files once and marks missing files', t => {
+    const { makeTempDirectory } = require('../../helpers/tempDirectory');
+    const fs = require('node:fs');
+    const path = require('node:path');
+    const root = makeTempDirectory(t, 'session-signature-');
+    const filePath = path.join(root, 'session.jsonl');
+    fs.writeFileSync(filePath, 'x');
+
+    const signature = helpers.getAiSessionFileSignature(filePath);
+    assert.ok(signature.startsWith(`${filePath}:`), 'the signature carries the path');
+    assert.notEqual(signature, `${filePath}:missing`);
+    assert.equal(helpers.getAiSessionFileSignature(path.join(root, 'gone.jsonl')),
+        `${path.join(root, 'gone.jsonl')}:missing`);
+});
+
+test('SESSION-CODEX-SESSION-SERVICE-001 SESSION-CLAUDE-SESSION-SERVICE-001 share the collision-free archive path helper', t => {
+    const { makeTempDirectory } = require('../../helpers/tempDirectory');
+    const fs = require('node:fs');
+    const path = require('node:path');
+    const root = makeTempDirectory(t, 'session-archive-');
+
+    assert.equal(helpers.getAvailableAiSessionArchivePath(root, 'session.jsonl'),
+        path.join(root, 'session.jsonl'), 'a free name passes through');
+    fs.writeFileSync(path.join(root, 'session.jsonl'), 'a');
+    assert.equal(helpers.getAvailableAiSessionArchivePath(root, 'session.jsonl'),
+        path.join(root, 'session-1.jsonl'), 'the first collision suffixes -1');
+    fs.writeFileSync(path.join(root, 'session-1.jsonl'), 'b');
+    assert.equal(helpers.getAvailableAiSessionArchivePath(root, 'session.jsonl'),
+        path.join(root, 'session-2.jsonl'), 'the next collision keeps counting');
+});


### PR DESCRIPTION
## 内容

`initializeDashboard` 拆解的又一批（承接 #75 四切片），四个行为零变化的切片，各自独立 commit、独立可回退：

| 切片 | 内容 | 归属能力 |
|---|---|---|
| 消息处理器 | 剩余 21 个内联处理器 → `src/dashboard/messageHandlers.ts`（全是 2-8 行薄委托，`createProjectMessageHandlers` 同款工厂） | `MAIN-RUNTIME-SESSION-RECOVERY` |
| 组合区 | AiSessionCommand/Creation/archive/terminal-command/resume 五个控制器接线 → composition 工厂 | `MAIN-RUNTIME-SESSION-RECOVERY` |
| notify 配置 | `refreshNotifyConfig` + secret 监听 + 命令注册 → 独立模块 | `MAIN-SESSION-STOP-NOTIFICATION` |
| 共享助手 | 三个 session service 里逐字节相同的 `getQueryOptions`/`normalizeMaxFiles`/`compareUpdatedAt` 等 → `sessionHelpers.ts` | `MAIN-ATTENTION-LIFECYCLE-HARDENING` |

## 验证

- 本地全量 `test:ci:linux` 绿（changed-line coverage 95.83%）
- 全量跑抓到过一处漏网的源码断言（`conversationOpenLatest.test.js` 按正则读 dashboard.ts 找已移走的 focus 处理器）——已重指向到 `messageHandlers.ts` 并折叠回切片 1；行为测试自始至终全绿，证实行为零变化
- 审计由 `regenerate-capability-audit.js` 生成

## 没做

webview 层（PR #84 在途）、D/E（attention bridge / 终端事件，等实测）。
