### PR TITLE
test: convert D/E-adjacent source pins to behavioral coverage

### DIFF
--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "e5b492de8e4bf551e3ef8015cfab9d6612b89d97",
+        "head": "c982f07c1ab89e22ef859e30399766bcd6ee5029",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -75,7 +75,8 @@
             "b842d24f0a64555709e1b6a07f9894ee7a018845",
             "af9cc7328dc642243b8c9e00cf86869353ced1ac",
             "95a9a7bc69b494fcd4f0d902d76370687baf4472",
-            "05edca8119b9a471cbcd32f287144cebe7ebae08"
+            "05edca8119b9a471cbcd32f287144cebe7ebae08",
+            "0e0016d9449d61753fe3f30711656cad881b12a6"
         ]
     },
     "capabilities": [
@@ -894,7 +895,9 @@
                 "11961748a8a85bcf96b1ff8d888fff17cd08e88f",
                 "98a5ec277ff6805aa6e7f3bd858c6349dc7f7fe4",
                 "ec78b66e2e85c2d3f213579c4c42edb8bc7637b7",
-                "0ef3ebbe9d1fd66b8b88f43f1047614f8e2b52df"
+                "0ef3ebbe9d1fd66b8b88f43f1047614f8e2b52df",
+                "a7d19fab7170c68e550e3395e104b178de6b35d6",
+                "c982f07c1ab89e22ef859e30399766bcd6ee5029"
             ],
             "behaviors": [
                 "ARCH-CI-QUALITY-GATE-001",

--- a/scripts/run-ai-session-safety-checks.js
+++ b/scripts/run-ai-session-safety-checks.js
@@ -5197,24 +5197,11 @@ function runWebviewContentChecks() {
     assert.ok(!pendingTerminalResolverSource.includes('.terminal'));
     assert.ok(resumeControllerSource.includes('runtimeCoordinator.resume(request)'));
     assert.ok(!dashboardRuntimeControllerSource.includes("type: 'ai-session-attention-projects-updated'"));
-    assert.ok(dashboard.includes('sessionEvents: aiSessionAttentionController.getRecoverySessionEvents()'));
     assert.ok(webviewProjectScripts.includes('message.sessionEvents'));
     assert.ok(runtimeSettlement.includes('settleAiSessionRuntimeLifecycles'));
-    assert.ok(dashboard.includes('createAiSessionRuntimeSettlementCapability({'),
-        'the dashboard constructs the extracted runtime settlement capability');
-    assert.ok(dashboard.includes('const runSafeAiSessionRuntimeLifecycleTask = aiSessionRuntimeSettlement.runSafeLifecycleTask;'),
-        'the dashboard keeps one lifecycle task runner from the capability');
-    assert.ok(dashboard.includes('const queueAiSessionRuntimeSettlements = aiSessionRuntimeSettlement.queueSettlements;'),
-        'the dashboard keeps one settlement queue from the capability');
     assert.match(runtimeSettlement,
         /for \(const runtime of runtimes\) \{\s*if \(!runtimeBelongsToCurrentWorkspace\(runtime\)\) \{\s*continue;\s*\}/,
         'runtime settlement collection must reject other scopes before session-key processing');
-    assert.ok(dashboard.includes('const aiSessionAttentionController = new AiSessionAttentionController<AiSessionRuntimeSnapshot<vscode.Terminal>>({'));
-    assert.ok(dashboard.includes("import { AiSessionExecutionController } from './aiSessions/executionController';"));
-    assert.ok(dashboard.includes('const aiSessionExecutionController = new AiSessionExecutionController({'));
-    assert.ok(dashboard.includes('new WorkspaceSessionHydrationController<vscode.Terminal>({'));
-    assert.ok(dashboard.includes('getExecutionSnapshot: () => aiSessionExecutionController.getSnapshot()'));
-    assert.ok(dashboard.includes('getActiveSessions: () => aiSessionRuntimeCoordinator.getActive()'));
     // The cadence itself lives in createAiSessionStatusCapability and is covered
     // behaviourally by ATTENTION-EXECUTION-STATE-SYNC-001; assert only that the
     // dashboard hands it both consumers and routes the tick through it.
@@ -5229,7 +5216,6 @@ function runWebviewContentChecks() {
         /evaluateAttentionSignals: signals => aiSessionAttentionController\.evaluate\(\[\], signals\)/);
     assert.match(dashboard,
         /const evaluateAiSessionLifecycleTick = \(\): void => aiSessionStatus\.tick\(\);/);
-    assert.match(dashboard, /onDidCloseTerminal\(terminal => \{[\s\S]*?handleClosedTerminal\(terminal\);[\s\S]*?evaluateAiSessionLifecycleTick\(\);/);
     assert.ok(!evaluateExecutionFunction.includes('isEnabled'));
     assert.ok(!evaluateExecutionFunction.includes('attention'));
     assert.ok(evaluateAttentionFunction.includes('if (!this.options.isEnabled())'));
@@ -5287,10 +5273,6 @@ function runWebviewContentChecks() {
     const terminalServiceSource = fs.readFileSync(path.join(__dirname, '..', 'src', 'aiSessions', 'terminalService.ts'), 'utf8');
     assert.ok(!terminalServiceSource.includes('AI_SESSION_PROVIDER_IDS'));
     assert.ok(dashboard.includes('const aiSessionProviders = aiSessionProviderRegistry.providers();'));
-    assert.ok(dashboard.includes('aiSessionTerminalService.restorePersistedTerminals(vscode.window.terminals)'));
-    assert.ok(dashboard.includes('tmuxRuntimeBackend.restoreAttachTerminals(vscode.window.terminals)'));
-    assert.match(dashboard, /onDidOpenTerminal\(terminal => \{[\s\S]*?tmuxRuntimeBackend\.restoreAttachTerminals\(\[terminal\]\)/,
-        'a terminal restored after extension activation must still recover its tmux attachment');
     assert.ok(dashboard.includes('new ActiveAiSessionTerminalHighlighter'));
     assert.ok(dashboard.includes('new TmuxFocusedRuntimeMonitor<vscode.Terminal>({'));
     assert.ok(dashboard.includes('tmuxFocusedRuntimeMonitor.start();'));
@@ -5327,15 +5309,6 @@ function runWebviewContentChecks() {
         /tmuxFocusedRuntimeMonitor must not also be pushed directly/,
         'a bootstrap-owned focused-runtime monitor must reject duplicate context ownership',
     );
-    assert.match(dashboard,
-        /beforeRefresh: reason => \{\s*currentAiSessionRefreshReason = reason;\s*postAiSessionAttentionState\(\);\s*\}/,
-        'every incremental AI-session render must publish its current attention event map before the HTML update');
-    assert.match(dashboard,
-        /function postAiSessionAttentionState\(\) \{[\s\S]*?sessionEvents: aiSessionAttentionController\.getRecoverySessionEvents\(\)[\s\S]*?eventIds: aiSessionAttentionController\.getAttentionEventIds\(\)/,
-        'the shared attention-state publisher must carry every event for each logical session');
-    assert.match(dashboard, /const acknowledgeAiSessionAttentionEventIds = async[\s\S]*?aiSessionAttentionController\.acknowledge\(uniqueEventIds\);\s*refreshAiSessionViewsIncrementally\(\);\s*await aiSessionAttentionBridgeClient\.acknowledge\(uniqueEventIds\)/,
-        'attention acknowledgement must refresh the local view before waiting for the cross-window bridge');
-    assert.match(dashboard, /const acknowledgeAiSessionAttention = async[\s\S]*?await acknowledgeAiSessionAttentionEventIds\(getAiSessionAttentionEventIds\(identity\)\)/);
     const selectedProjectHandler = projectMessageHandlers.slice(
         projectMessageHandlers.indexOf("'selected-project': async e =>"),
         projectMessageHandlers.indexOf("'add-project': async e =>")
@@ -5352,12 +5325,6 @@ function runWebviewContentChecks() {
     assert.ok(settlementCall.includes('release: async candidate =>'));
     assert.ok(!settlementCall.includes('acknowledgePublished'));
     assert.ok(!settlementCall.includes('acknowledgeLocal'));
-    assert.doesNotMatch(
-        dashboard,
-        /setRemoteAggregate\(aggregate\)[\s\S]*?getReleasedSessions\(\)\.forEach/,
-        'a later aggregate must not auto-acknowledge a delivered completion'
-    );
-    assert.match(dashboard, /onComplete: resolution => \{[\s\S]*?queueAiSessionRuntimeSettlements\(\[\{/);
     const runtimeSettlementQueue = runtimeSettlement.slice(
         runtimeSettlement.indexOf('const queueAiSessionRuntimeSettlements = ('),
         runtimeSettlement.indexOf('const drainAiSessionRuntimeSettlements = async')
@@ -5377,26 +5344,6 @@ function runWebviewContentChecks() {
         'the dashboard starts the capability settlement scan in place of its old timer');
     assert.match(runtimeSettlement, /queueAiSessionRuntimeSettlements\(\[\.\.\.completedRuntimes, \.\.\.inactiveTmuxRuntimes\]\)/,
         'one completion polling round must queue one structured batch');
-    const closeTerminalHandlerStart = dashboard.indexOf('vscode.window.onDidCloseTerminal(terminal => {');
-    const closeTerminalHandlerEnd = dashboard.indexOf(
-        'const stewardInfos:',
-        closeTerminalHandlerStart
-    );
-    assert.ok(closeTerminalHandlerStart >= 0 && closeTerminalHandlerEnd > closeTerminalHandlerStart);
-    const closeTerminalHandler = dashboard.slice(closeTerminalHandlerStart, closeTerminalHandlerEnd);
-    assert.match(closeTerminalHandler, /hadRuntimeClient[\s\S]*?aiSessionRuntimeCoordinator\.handleClosedTerminal\(terminal\)[\s\S]*?closedSessions\.length \|\| hadRuntimeClient[\s\S]*?refreshAiSessionViewsIncrementally\(\)/);
-    assert.ok(!dashboard.includes('acknowledge-closed-attention'));
-    assert.doesNotMatch(closeTerminalHandler, /suppressRuntimeCompletion|restoreRuntimeCompletion/,
-        'terminal exit and close handlers must not manufacture or suppress runtime-completion attention');
-    assert.match(
-        closeTerminalHandler,
-        /const userClosedTerminal = exitStatus\?\.reason === USER_TERMINAL_EXIT_REASON;[\s\S]*?handleClosedTerminal\(terminal\)[\s\S]*?if \(userClosedTerminal\) \{[\s\S]*?'acknowledge-user-terminal-close'[\s\S]*?acknowledgeAiSessionAttention\(identity\)/,
-        'user terminal closure must acknowledge only inside its reason guard'
-    );
-    assert.ok(dashboard.includes('vscode.window.onDidChangeActiveTerminal'));
-    assert.match(dashboard, /onDidChangeActiveTerminal\(\(\) => \{[\s\S]*?activeAiSessionTerminalHighlighter\.sync\(\);[\s\S]*?runSafeAiSessionRuntimeLifecycleTask\([\s\S]*?'evaluate-attention-active-terminal'[\s\S]*?\}\)/);
-    assert.ok(!dashboard.includes('void evaluateAiSessionAttention()'));
-    assert.ok(!dashboard.includes('void acknowledgeAiSessionAttention('));
     assert.ok(runtimeSettlement.includes('runAiSessionRuntimeLifecycleTask('));
     assert.match(dashboard, /onDidChangeWindowState\(windowState => \{[\s\S]*?dashboardLifecycleController\.handleWindowStateChanged\(windowState\);[\s\S]*?\}\)/);
     assert.ok(dashboardLifecycleControllerSource.includes('this.options.evaluateAiSessionAttention();'));
@@ -5408,8 +5355,6 @@ function runWebviewContentChecks() {
     assert.ok(webviewProjectScripts.includes("type: 'request-active-ai-session-terminal'"));
     assert.ok(webviewProjectScripts.includes("message.type === 'active-ai-session-terminal-changed'"));
     assert.ok(webviewProjectScripts.includes('data-ai-session-active-terminal'));
-    assert.ok(dashboard.includes('activeAiSessionTerminalHighlighter.handleTerminalClosed(terminal)'));
-    assert.ok(dashboard.includes('activeAiSessionTerminalHighlighter.sync()'));
     assert.ok(dashboard.includes('onVisibleChanged: async visible =>'));
     assert.ok(dashboard.includes('activeAiSessionTerminalHighlighter.setVisible(visible)'));
     assert.ok(dashboard.includes('await dashboardRuntimeController.handleAiSessionViewVisibilityChanged(visible)'));

--- a/scripts/run-ai-session-tmux-checks.js
+++ b/scripts/run-ai-session-tmux-checks.js
@@ -9613,20 +9613,6 @@ function runHostRuntimeCompositionChecks() {
     ));
     assert.ok(!dashboardSource.includes('isCommandAvailableOnPath'));
     assert.ok(!dashboardSource.includes('was not found on PATH'));
-    assert.ok(dashboardSource.includes('new TmuxRuntimeBindingStore'));
-    assert.ok(dashboardSource.includes('new TmuxAttachBindingStore(context.workspaceState'));
-    assert.ok(dashboardSource.includes('new TmuxClient'));
-    assert.ok(dashboardSource.includes('new TmuxRuntimeDiscovery'));
-    assert.ok(dashboardSource.includes('new DirectTerminalRuntimeBackend'));
-    assert.ok(dashboardSource.includes('new TmuxRuntimeBackend'));
-    assert.ok(dashboardSource.includes('new AiSessionRuntimeCoordinator'));
-    assert.ok(dashboardSource.includes('onDidChangeConfiguration'));
-    assert.ok(dashboardSource.includes(
-        'affectsConfiguration(`${AGENT_PIVOT_CONFIG_SECTION}.aiSessionTerminalMode`)'
-    ));
-    assert.ok(dashboardSource.includes('runtimeCoordinator: aiSessionRuntimeCoordinator'));
-    assert.ok(dashboardSource.includes("path.join(context.globalStoragePath, 'ai-session-tmux-runtimes')"));
-    assert.ok(dashboardSource.includes("'runtime-binding-final-records'"));
     assert.ok(dashboardSource.includes('runtimeCoordinator: aiSessionRuntimeCoordinator'));
     assert.ok(dashboardSource.includes('getActiveRuntimes: () => aiSessionRuntimeCoordinator.getActive()'));
     assert.ok(dashboardSource.includes('getPendingRuntimes: () => aiSessionRuntimeCoordinator.getPending()'));
@@ -9636,22 +9622,7 @@ function runHostRuntimeCompositionChecks() {
     assert.ok(dashboardSource.includes('tmuxRuntimeBackend.getFocusedRuntime(activeTerminal)'));
     assert.ok(dashboardSource.includes('getAttachTerminalName: getAiSessionTmuxAttachTerminalName'));
     assert.ok(dashboardSource.includes('markerIsCurrent: isCurrentRuntimeMarker'));
-    assert.ok(dashboardSource.includes("'Use VS Code Terminal This Time'"));
-    assert.ok(dashboardSource.includes("'Resume in VS Code Anyway'"));
-    assert.ok(dashboardSource.includes("'Open Settings'"));
-    assert.match(dashboardSource, /fallback\.knownHint[\s\S]*?showWarningMessage\([\s\S]*?\{ modal: true \}/);
-    assert.ok(dashboardSource.includes('tmuxClient.setExecutablePath(nextConfiguration.tmuxPath)'));
-    assert.ok(dashboardSource.includes('tmuxRuntimeDiscovery.invalidate()'));
-    assert.ok(dashboardSource.includes('await aiSessionRuntimeCoordinator.refreshForHost(true)'));
     assert.ok(dashboardSource.includes('await tmuxRuntimeDiscovery.loadPersistedInactive()'));
-    assert.ok(dashboardSource.includes("category: 'unexpected'"));
-    const runtimeFailureBody = dashboardSource.slice(
-        dashboardSource.indexOf('function logAiSessionRuntimeFailure('),
-        dashboardSource.indexOf('async function chooseAiSessionTmuxFallback(')
-    );
-    assert.ok(!runtimeFailureBody.includes('error.message'));
-    assert.ok(!runtimeFailureBody.includes('String(error)'));
-    assert.ok(!runtimeFailureBody.includes('logError('));
     assert.ok(!dashboardSource.includes(
         'getTerminalById: (providerId, sessionId) => aiSessionTerminalService.getActiveById'
     ));
@@ -9668,30 +9639,6 @@ function runHostRuntimeCompositionChecks() {
     assert.ok(dashboardSource.includes('vscode.window.showQuickPick'));
     assert.ok(compositionSource.includes("runtime.backend === 'tmux'"));
     assert.ok(compositionSource.includes("runtime.attached ? 'attached' : 'detached'"));
-    const directRestore = dashboardSource.indexOf(
-        'aiSessionTerminalService.restorePersistedTerminals(vscode.window.terminals)'
-    );
-    const tmuxRestoreTask = dashboardSource.indexOf(
-        'const tmuxRestoreTask = persistedInactiveRestoreTask.then'
-    );
-    const tmuxRestore = dashboardSource.indexOf(
-        'tmuxRuntimeBackend.restoreAttachTerminals(vscode.window.terminals)'
-    );
-    const tmuxRestoreBudgetWait = dashboardSource.indexOf(
-        'settlesWithinBudget(tmuxRestoreTask, AI_SESSION_TMUX_RESTORE_BUDGET_MS)'
-    );
-    const hydrationConstruction = dashboardSource.indexOf(
-        'const workspaceSessionHydrationController = new WorkspaceSessionHydrationController'
-    );
-    assert.ok(directRestore >= 0
-        && tmuxRestoreTask > directRestore
-        && tmuxRestore > tmuxRestoreTask
-        && tmuxRestoreBudgetWait > tmuxRestore
-        && hydrationConstruction > tmuxRestoreBudgetWait,
-    'Direct restoration and the bounded tmux wait must precede first hydration');
-    assert.ok(dashboardSource.includes(
-        "aiSessionDashboardController.refreshNow('tmux-bootstrap-restore')"
-    ), 'deferred tmux restoration must publish one incremental refresh path');
 }
 
 function runTmuxWebviewExperienceChecks() {

--- a/scripts/run-dashboard-webview-checks.js
+++ b/scripts/run-dashboard-webview-checks.js
@@ -4799,12 +4799,6 @@ function runSourceContractChecks(source) {
     assert.ok(!extensionHostSource.includes('async function removeProject('));
     assert.ok(projectRemovalControllerSource.includes('export class ProjectRemovalController'));
     assert.ok(openWorkspacesMessageBody.includes('openWorkspaceDashboardController.postUpdated()'));
-    assert.ok(extensionHostSource.includes('function scheduleAttentionViewsRefresh()'));
-    const attentionBridgeWiring = extensionHostSource.slice(
-        extensionHostSource.indexOf('new AttentionBridgeClient('),
-        extensionHostSource.indexOf('const aiSessionAttentionInterval')
-    );
-    assert.ok(attentionBridgeWiring.includes('scheduleAttentionViewsRefresh()'));
     assert.ok(openWorkspaceControllerSource.includes('buildOpenWorkspacesUpdatedMessage({'));
     assert.ok(openWorkspaceControllerSource.includes('groups: this.options.getGroups()'));
     assert.ok(openWorkspaceControllerSource.includes('cards: this.getCards()'));

--- a/tests/contract/aiSessions/runtimeComposition.test.js
+++ b/tests/contract/aiSessions/runtimeComposition.test.js
@@ -114,6 +114,7 @@ const RESTORE_EVENTS = new Set([
     'direct-restored',
     'direct-failed',
     'tmux-restored',
+    'tmux-restore-failed',
     'hydration-constructed',
 ]);
 
@@ -305,6 +306,106 @@ test('RUNTIME-BOOTSTRAP-TMUX-RESTORE-DEFERRAL-001 disposed bootstrap ignores lat
             budgetMs: 800,
         },
     ]);
+});
+
+test('RUNTIME-HOST-RUNTIME-COMPOSITION-001 RUNTIME-TMUX-STORE-001 production activation stores tmux runtime bindings under the locked extension storage', () => {
+    const result = runProductionActivation('success');
+    assert.equal(result.failure, null);
+    assert.deepEqual(result.runtimeStoreRoots, [
+        path.join(result.storageRoot, 'ai-session-tmux-runtimes'),
+    ]);
+    assert.equal(
+        result.tmuxCreationLockInvocations.every(
+            invocation => invocation.root === result.storageRoot
+        ),
+        true,
+        'tmux filesystem mutation locks must stay inside the extension global storage'
+    );
+    assert.equal(
+        result.tmuxCreationLockInvocations.some(
+            invocation => invocation.key === 'runtime-binding-final-records'
+        ),
+        true,
+        'final runtime binding records must be serialized under the creation lock'
+    );
+});
+
+test('RUNTIME-HOST-RUNTIME-COMPOSITION-001 production tmux fallback prompt is modal for known hints and plain otherwise', () => {
+    const result = runProductionActivation('fallback-choice');
+    assert.equal(result.failure, null);
+    assert.deepEqual(result.warningMessages, [
+        {
+            message: 'Agent Pivot cannot verify the previous tmux runtime.'
+                + ' Resuming in VS Code may start a duplicate AI process.',
+            modal: true,
+            items: ['Resume in VS Code Anyway', 'Open Settings'],
+        },
+        {
+            message: 'Agent Pivot cannot use tmux in this extension host.',
+            modal: false,
+            items: ['Use VS Code Terminal This Time', 'Open Settings'],
+        },
+    ]);
+    assert.deepEqual(result.fallbackResumeStatuses, ['cancelled', 'cancelled']);
+    assert.deepEqual(
+        result.tmuxRuntimeFailureDiagnostics.filter(
+            diagnostic => diagnostic.operation === 'resume-fallback'
+        ),
+        [
+            { event: 'tmux-runtime-failure', operation: 'resume-fallback', backend: 'tmux', category: 'not-found' },
+            { event: 'tmux-runtime-failure', operation: 'resume-fallback', backend: 'tmux', category: 'not-found' },
+        ]
+    );
+});
+
+test('RUNTIME-HOST-RUNTIME-COMPOSITION-001 RUNTIME-RUNTIME-CONFIGURATION-001 production runtime configuration change rebinds tmux before refreshing runtimes', () => {
+    const result = runProductionActivation('configuration-change');
+    assert.equal(result.failure, null);
+    assert.deepEqual(result.runtimeConfigurationSequence, [
+        'set-executable-path:tmux',
+        'discovery-invalidated',
+        'refresh-for-host:true',
+    ]);
+    assert.equal(
+        result.affectsConfigurationQueries.includes('agentPivot.aiSessionTerminalMode'),
+        true,
+        'the configuration listener must match the AI session terminal mode key'
+    );
+});
+
+test('RUNTIME-HOST-RUNTIME-COMPOSITION-001 production tmux restore failure stays privacy-safe and does not block hydration', () => {
+    const result = runProductionActivation('tmux-restore-failure');
+    assert.equal(result.failure, null);
+    assert.equal(result.bootstrapState, 'ready');
+    assert.deepEqual(result.events.filter(isRestoreEvent), [
+        'inactive-restored',
+        'direct-restored',
+        'tmux-restore-failed',
+        'hydration-constructed',
+    ]);
+    assert.deepEqual(result.tmuxRuntimeFailureDiagnostics, [
+        {
+            event: 'tmux-runtime-failure',
+            operation: 'restore-attach-terminals',
+            backend: 'tmux',
+            category: 'unexpected',
+        },
+    ]);
+    assert.deepEqual(result.leakedPrivacyCanaries, []);
+});
+
+test('RUNTIME-HOST-RUNTIME-COMPOSITION-001 production activation restores tmux attachments for terminals opened after activation', () => {
+    const result = runProductionActivation('opened-terminal-restore');
+    assert.equal(result.failure, null);
+    assert.deepEqual(result.restoreAttachTerminalsInvocations, [
+        [],
+        ['tmux-attach-terminal'],
+    ], 'a terminal opened after activation must recover its tmux attachment exactly once');
+    assert.equal(
+        result.refreshMessageBuildsAfterOpenedTerminal > result.refreshMessageBuildsBeforeOpenedTerminal,
+        true,
+        'restoring an opened attach terminal must publish an incremental refresh'
+    );
 });
 
 test('RUNTIME-HOST-RUNTIME-COMPOSITION-001 assembles real runtime components and restores ownership before hydration', async t => {

--- a/tests/fixtures/aiSessions/runtimeHostActivationHarness.js
+++ b/tests/fixtures/aiSessions/runtimeHostActivationHarness.js
@@ -30,7 +30,13 @@ function createVscode(lifecycle) {
     let providerRegistrations = 0;
     let registeredProvider;
     let providerResolution = Promise.resolve();
-    const configuration = { get: (_key, fallback) => fallback, inspect: () => undefined, update: async () => undefined };
+    const configuration = {
+        get: (key, fallback) => key === 'aiSessionTerminalMode' && lifecycle.forceTmuxMode
+            ? 'tmux'
+            : fallback,
+        inspect: () => undefined,
+        update: async () => undefined,
+    };
     const uri = value => ({ scheme: 'file', fsPath: value, path: value, toString: () => value });
     const webview = {
         cspSource: 'fixture-webview',
@@ -60,6 +66,8 @@ function createVscode(lifecycle) {
         onDidChangeVisibility: () => disposable(),
         onDidDispose: () => disposable(),
     };
+    const openTerminalCallbacks = [];
+    const configurationChangeCallbacks = [];
     const trackedResource = (kind, onDispose = () => undefined) => {
         if (lifecycle.activationDisposed) {
             lifecycle.lateResourceAcquisitions.push(kind);
@@ -77,6 +85,8 @@ function createVscode(lifecycle) {
     return {
         registeredCommands,
         webviewHtmlHistory,
+        openTerminalCallbacks,
+        configurationChangeCallbacks,
         get bootWebviewMessageCallback() { return bootWebviewMessageCallback; },
         get providerRegistrations() { return providerRegistrations; },
         get providerResolution() { return providerResolution; },
@@ -101,7 +111,8 @@ function createVscode(lifecycle) {
                 return trackedResource('provider-registration');
             },
             onDidChangeActiveTerminal: () => trackedListener('active-terminal-listener'),
-            onDidOpenTerminal: () => {
+            onDidOpenTerminal: callback => {
+                openTerminalCallbacks.push(callback);
                 lifecycle.activeOpenTerminalListeners += 1;
                 return trackedResource('open-terminal-listener', () => {
                     lifecycle.activeOpenTerminalListeners -= 1;
@@ -112,14 +123,27 @@ function createVscode(lifecycle) {
             onDidChangeWindowState: () => trackedListener('window-state-listener'),
             onDidChangeVisibleTextEditors: () => trackedListener('visible-editors-listener'),
             onDidChangeActiveTextEditor: () => trackedListener('active-editor-listener'),
-            showErrorMessage: async () => undefined, showWarningMessage: async () => undefined,
+            showErrorMessage: async () => undefined,
+            showWarningMessage: async (message, ...rest) => {
+                const [first, ...items] = rest;
+                const options = first && typeof first === 'object' ? first : undefined;
+                lifecycle.warningMessages.push({
+                    message,
+                    modal: options?.modal === true,
+                    items: (options ? items : rest).map(item => String(item)),
+                });
+                return undefined;
+            },
             showInformationMessage: async () => undefined, showInputBox: async () => undefined,
             showQuickPick: async () => undefined, showOpenDialog: async () => undefined,
         },
         workspace: {
             workspaceFile: undefined, workspaceFolders: undefined,
             getConfiguration: () => configuration, updateWorkspaceFolders: () => true,
-            onDidChangeConfiguration: () => trackedListener('configuration-listener'),
+            onDidChangeConfiguration: callback => {
+                configurationChangeCallbacks.push(callback);
+                return trackedListener('configuration-listener');
+            },
             onDidChangeWorkspaceFolders: () => trackedListener('workspace-folders-listener'),
             onWillSaveTextDocument: () => trackedListener('save-document-listener'),
             openTextDocument: async () => ({}),
@@ -164,12 +188,14 @@ async function main() {
     const lifecycle = {
         activationDisposed: false,
         activeOpenTerminalListeners: 0,
+        forceTmuxMode: mode === 'fallback-choice',
         lateResourceAcquisitions: [],
         openTerminalListenerDisposals: 0,
         outputLines: [],
         postDisposePublications: [],
         postDisposeWebviewMessages: [],
         postedWebviewMessages: [],
+        warningMessages: [],
     };
     const vscode = createVscode(lifecycle);
     const previousLoad = Module._load;
@@ -189,6 +215,16 @@ async function main() {
     let tmuxRestoreSettled = false;
     let releasePendingTmuxRestore;
     const synchronizedGlobalStateKeySets = [];
+    const runtimeStoreRoots = [];
+    const capturedRuntimeStores = [];
+    const tmuxCreationLockInvocations = [];
+    const runtimeConfigurationSequence = [];
+    const restoreAttachTerminalsInvocations = [];
+    const affectsConfigurationQueries = [];
+    const fallbackResumeStatuses = [];
+    let coordinatorInstance;
+    let refreshMessageBuildsBeforeOpenedTerminal = 0;
+    let refreshMessageBuildsAfterOpenedTerminal = 0;
     const patch = (prototype, name, replacement) => {
         const original = prototype[name];
         prototype[name] = replacement;
@@ -206,6 +242,28 @@ async function main() {
                         events.push('hydration-constructed');
                         super(...args);
                     }
+                },
+            };
+        }
+        if (parent?.filename === dashboardPath && request === './aiSessions/tmuxRuntimeBindingStore') {
+            const Original = loaded.TmuxRuntimeBindingStore;
+            return {
+                ...loaded,
+                TmuxRuntimeBindingStore: class extends Original {
+                    constructor(...args) {
+                        runtimeStoreRoots.push(args[0]);
+                        super(...args);
+                        capturedRuntimeStores.push(this);
+                    }
+                },
+            };
+        }
+        if (parent?.filename === dashboardPath && request === './aiSessions/tmuxCreationLock') {
+            return {
+                ...loaded,
+                withTmuxCreationLock: (root, key, operation) => {
+                    tmuxCreationLockInvocations.push({ root, key });
+                    return loaded.withTmuxCreationLock(root, key, operation);
                 },
             };
         }
@@ -243,6 +301,8 @@ async function main() {
         const { TmuxRuntimeBackend } = require('../../../out/aiSessions/tmuxRuntimeBackend');
         const { TmuxRuntimeBindingStore } = require('../../../out/aiSessions/tmuxRuntimeBindingStore');
         const { TmuxRuntimeDiscovery } = require('../../../out/aiSessions/tmuxRuntimeDiscovery');
+        const { TmuxRuntimeUnavailableError } = require('../../../out/aiSessions/runtimeTypes');
+        const { fakeResumeRequest } = require('../../helpers/runtimeContract');
         const { AiSessionAttentionController } = require('../../../out/aiSessions/attentionController');
         const AttentionBridgeClient = require('../../../out/aiSessions/attentionBridgeClient').default;
         const AiSessionAliasController = require('../../../out/aiSessions/aliasController').default;
@@ -292,12 +352,50 @@ async function main() {
             events.push('direct-restored');
             directRestoreSettled = true;
         });
-        patch(TmuxRuntimeBackend.prototype, 'restoreAttachTerminals', async function () {
+        const originalTmuxRefresh = TmuxRuntimeBackend.prototype.refresh;
+        patch(TmuxRuntimeBackend.prototype, 'refresh', async function (...args) {
+            if (mode === 'fallback-choice') {
+                throw new TmuxRuntimeUnavailableError('not-found', 'tmux is unavailable (fixture)');
+            }
+            return originalTmuxRefresh.apply(this, args);
+        });
+        const originalGetKnown = TmuxRuntimeBindingStore.prototype.getKnown;
+        patch(TmuxRuntimeBindingStore.prototype, 'getKnown', async function (...args) {
+            if (mode === 'fallback-choice' && args[1] === 'fallback-known') {
+                return { state: 'known', provider: args[0], sessionId: args[1] };
+            }
+            return originalGetKnown.apply(this, args);
+        });
+        const originalSetExecutablePath = TmuxClient.prototype.setExecutablePath;
+        patch(TmuxClient.prototype, 'setExecutablePath', function (...args) {
+            runtimeConfigurationSequence.push(`set-executable-path:${args[0]}`);
+            return originalSetExecutablePath.apply(this, args);
+        });
+        const originalInvalidate = TmuxRuntimeDiscovery.prototype.invalidate;
+        patch(TmuxRuntimeDiscovery.prototype, 'invalidate', function (...args) {
+            runtimeConfigurationSequence.push('discovery-invalidated');
+            return originalInvalidate.apply(this, args);
+        });
+        const originalRefreshForHost = AiSessionRuntimeCoordinator.prototype.refreshForHost;
+        patch(AiSessionRuntimeCoordinator.prototype, 'refreshForHost', async function (...args) {
+            if (mode === 'configuration-change') {
+                runtimeConfigurationSequence.push(`refresh-for-host:${args[0]}`);
+                return;
+            }
+            return originalRefreshForHost.apply(this, args);
+        });
+        patch(TmuxRuntimeBackend.prototype, 'restoreAttachTerminals', async function (terminals) {
             assert.ok(this instanceof TmuxRuntimeBackend);
             assert.ok(this.dependencies.discovery instanceof TmuxRuntimeDiscovery);
             assert.ok(this.dependencies.runtimeStore instanceof TmuxRuntimeBindingStore);
             assert.ok(this.dependencies.attachStore instanceof TmuxAttachBindingStore);
             verified.add('tmux-backend');
+            restoreAttachTerminalsInvocations.push((terminals || []).map(terminal => terminal?.name));
+            if (mode === 'tmux-restore-failure') {
+                events.push('tmux-restore-failed');
+                tmuxRestoreSettled = true;
+                throw new Error(privacyCanaries.join(' '));
+            }
             if (mode === 'slow-tmux-restore' || mode === 'slow-tmux-restore-dispose') {
                 pendingTmuxRestoreEntered = true;
                 await new Promise(resolve => {
@@ -310,6 +408,7 @@ async function main() {
         patch(AiSessionRuntimeCoordinator.prototype, 'getActive', function () {
             assert.ok(this.dependencies.direct instanceof DirectTerminalRuntimeBackend);
             assert.ok(this.dependencies.tmux instanceof TmuxRuntimeBackend);
+            coordinatorInstance = this;
             verified.add('direct-tmux-coordinator');
             return [];
         });
@@ -438,6 +537,70 @@ async function main() {
                     'ready dashboard visibility preparation'
                 );
             }
+            if (mode === 'success' && capturedRuntimeStores.length > 0) {
+                await capturedRuntimeStores[0].listFinalSnapshot();
+            }
+            if (mode === 'configuration-change') {
+                const event = {
+                    affectsConfiguration: key => {
+                        affectsConfigurationQueries.push(key);
+                        return key === 'agentPivot.aiSessionTerminalMode';
+                    },
+                };
+                runtimeConfigurationSequence.length = 0;
+                for (const callback of vscode.configurationChangeCallbacks) {
+                    callback(event);
+                }
+                await waitFor(
+                    () => runtimeConfigurationSequence.length >= 3,
+                    'runtime configuration change handling'
+                );
+            }
+            if (mode === 'fallback-choice') {
+                await waitFor(() => Boolean(coordinatorInstance), 'runtime coordinator capture');
+                const hinted = await coordinatorInstance.resume(fakeResumeRequest('fallback-known'));
+                fallbackResumeStatuses.push(hinted.status);
+                const unhinted = await coordinatorInstance.resume(fakeResumeRequest('fallback-unknown'));
+                fallbackResumeStatuses.push(unhinted.status);
+            }
+            if (mode === 'opened-terminal-restore') {
+                refreshMessageBuildsBeforeOpenedTerminal = lifecycle.outputLines.filter(line =>
+                    line.startsWith('[AiSessions] ')
+                        && line.includes('"event":"ai-session-message-build"')
+                        && line.includes('"reason":"refresh"')).length;
+                const plainTerminal = {
+                    name: 'plain-terminal',
+                    creationOptions: { shellPath: '/bin/bash', shellArgs: [] },
+                };
+                for (const callback of vscode.openTerminalCallbacks) {
+                    callback(plainTerminal);
+                }
+                await new Promise(resolve => setImmediate(resolve));
+                const attachTerminal = {
+                    name: 'tmux-attach-terminal',
+                    creationOptions: { shellPath: 'tmux', shellArgs: ['attach-session', '-t', 'restored-session'] },
+                };
+                for (const callback of vscode.openTerminalCallbacks) {
+                    callback(attachTerminal);
+                }
+                await waitFor(
+                    () => restoreAttachTerminalsInvocations.some(invocation =>
+                        invocation.includes('tmux-attach-terminal')),
+                    'opened terminal tmux attach restoration'
+                );
+                await waitFor(
+                    () => lifecycle.outputLines.filter(line =>
+                        line.startsWith('[AiSessions] ')
+                            && line.includes('"event":"ai-session-message-build"')
+                            && line.includes('"reason":"refresh"')).length
+                        > refreshMessageBuildsBeforeOpenedTerminal,
+                    'opened terminal restoration refresh publication'
+                );
+                refreshMessageBuildsAfterOpenedTerminal = lifecycle.outputLines.filter(line =>
+                    line.startsWith('[AiSessions] ')
+                        && line.includes('"event":"ai-session-message-build"')
+                        && line.includes('"reason":"refresh"')).length;
+            }
         }
         let inFlightListenerDisposedBeforeGateRelease = false;
         let lateAttentionClientObserved = false;
@@ -489,6 +652,12 @@ async function main() {
         const aiSessionDiagnostics = lifecycle.outputLines
             .filter(line => line.startsWith('[AiSessions] '))
             .map(line => JSON.parse(line.slice('[AiSessions] '.length)));
+        const tmuxRuntimeFailureDiagnostics = aiSessionDiagnostics
+            .filter(diagnostic => diagnostic.event === 'tmux-runtime-failure')
+            .map(({ loggedAt: _loggedAt, ...diagnostic }) => diagnostic);
+        const observableText = `${lifecycle.outputLines.join('\n')}\n${vscode.webviewHtmlHistory.join('\n')}`
+            + `\n${JSON.stringify(lifecycle.postedWebviewMessages)}`;
+        const leakedPrivacyCanaries = privacyCanaries.filter(canary => observableText.includes(canary));
         process.stdout.write(JSON.stringify({
             activationReturnedBeforeDirectRestoreSettled,
             providerRegistrations: vscode.providerRegistrations,
@@ -512,6 +681,18 @@ async function main() {
                 diagnostic => diagnostic.event === 'ai-session-message-build'
                     && diagnostic.reason === 'tmux-bootstrap-restore'
             ).length,
+            tmuxRuntimeFailureDiagnostics,
+            warningMessages: lifecycle.warningMessages,
+            fallbackResumeStatuses,
+            runtimeConfigurationSequence,
+            affectsConfigurationQueries,
+            restoreAttachTerminalsInvocations,
+            runtimeStoreRoots,
+            storageRoot,
+            tmuxCreationLockInvocations,
+            refreshMessageBuildsBeforeOpenedTerminal,
+            refreshMessageBuildsAfterOpenedTerminal,
+            leakedPrivacyCanaries,
             tmuxRestoreDiagnostics: startupDiagnostics.filter(diagnostic =>
                 diagnostic.event === 'agent-pivot-bootstrap-tmux-restore-deferred'
                     || diagnostic.event === 'agent-pivot-bootstrap-tmux-restore-settled'),

--- a/tests/integration/dashboard/helpers/terminalCloseHarness.js
+++ b/tests/integration/dashboard/helpers/terminalCloseHarness.js
@@ -75,7 +75,108 @@ function loadDashboard(transform) {
     return loaded.exports;
 }
 
-async function runTerminalCloseContract(transform = source => source) {
+function indexOfCall(calls, name, fromIndex = 0) {
+    return calls.findIndex((call, index) => index >= fromIndex && call[0] === name);
+}
+
+function indexOfLifecycleTask(calls, operation, fromIndex = 0) {
+    return calls.findIndex((call, index) => index >= fromIndex
+        && call[0] === 'lifecycle-task' && call[1] === operation);
+}
+
+function replaceOnce(source, needle, replacement, label) {
+    assert.ok(source.includes(needle), `controlled mutation must find the production ${label}`);
+    return source.replace(needle, replacement);
+}
+
+const mutations = {
+    'completion-suppression': {
+        scenario: 'baseline',
+        transform: source => replaceOnce(
+            source,
+            'aiSessionRuntimeCoordinator.handleClosedTerminal(terminal);',
+            'aiSessionRuntimeCoordinator.handleClosedTerminal(terminal);'
+                + '\n            aiSessionAttentionController.suppressRuntimeCompletion(\'synthetic-exit\');',
+            'callback',
+        ),
+    },
+    'acknowledge-order': {
+        scenario: 'user-close',
+        transform: source => replaceOnce(
+            source,
+            'aiSessionAttentionController.acknowledge(uniqueEventIds);\n'
+                + '                    refreshAiSessionViewsIncrementally();\n'
+                + '                    yield aiSessionAttentionBridgeClient.acknowledge(uniqueEventIds);',
+            'aiSessionAttentionController.acknowledge(uniqueEventIds);\n'
+                + '                    yield aiSessionAttentionBridgeClient.acknowledge(uniqueEventIds);\n'
+                + '                    refreshAiSessionViewsIncrementally();',
+            'acknowledgement ordering',
+        ),
+    },
+    'attention-state-before-render': {
+        scenario: 'attention-state-order',
+        transform: source => replaceOnce(
+            source,
+            'currentAiSessionRefreshReason = reason;\n'
+                + '                        postAiSessionAttentionState();',
+            'currentAiSessionRefreshReason = reason;',
+            'attention state publication',
+        ),
+    },
+    'aggregate-auto-acknowledge': {
+        scenario: 'remote-aggregate',
+        transform: source => replaceOnce(
+            source,
+            'if (aiSessionAttentionController.setRemoteAggregate(aggregate)) {',
+            'aiSessionAttentionController.getReleasedSessions()'
+                + '.forEach(() => aiSessionAttentionController.acknowledge([\'synthetic-released\']));\n'
+                + '                    if (aiSessionAttentionController.setRemoteAggregate(aggregate)) {',
+            'bridge aggregate callback',
+        ),
+    },
+    'aggregate-refresh-skipped': {
+        scenario: 'remote-aggregate',
+        transform: source => replaceOnce(
+            source,
+            'if (aiSessionAttentionController.setRemoteAggregate(aggregate)) {\n'
+                + '                        scheduleAttentionViewsRefresh();\n'
+                + '                    }',
+            'if (aiSessionAttentionController.setRemoteAggregate(aggregate)) {\n'
+                + '                    }',
+            'aggregate refresh scheduling',
+        ),
+    },
+    'completion-queue-skipped': {
+        scenario: 'highlighter-completion',
+        transform: source => replaceOnce(
+            source,
+            'if (!resolution.entry.runtimeIdentity) {',
+            'if (true) {',
+            'completion identity guard',
+        ),
+    },
+    'active-terminal-bare-evaluate': {
+        scenario: 'active-terminal',
+        transform: source => replaceOnce(
+            source,
+            'void runSafeAiSessionRuntimeLifecycleTask(\'evaluate-attention-active-terminal\', evaluateAiSessionAttention);',
+            'void evaluateAiSessionAttention();',
+            'active terminal lifecycle task',
+        ),
+    },
+    'close-tick-skipped': {
+        scenario: 'baseline',
+        transform: source => replaceOnce(
+            source,
+            'aiSessionRuntimeCoordinator.handleClosedTerminal(terminal);\n'
+                + '                    evaluateAiSessionLifecycleTick();',
+            'aiSessionRuntimeCoordinator.handleClosedTerminal(terminal);',
+            'close handler lifecycle tick',
+        ),
+    },
+};
+
+async function runTerminalCloseContract(transform = source => source, scenario = 'baseline') {
     const storageRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-pivot-close-wiring-'));
     const listeners = {};
     const commands = new Map();
@@ -83,6 +184,8 @@ async function runTerminalCloseContract(transform = source => source) {
     const previousLoad = Module._load;
     const calls = [];
     let activeFixtures = [];
+    let bridgeAggregateHandler = null;
+    let highlighterOptions = null;
     const restores = [];
     const patchMethod = (prototype, name, replacement) => {
         const original = prototype[name];
@@ -91,8 +194,71 @@ async function runTerminalCloseContract(transform = source => source) {
     };
     Module._load = function (request, parent, isMain) {
         if (request === 'vscode') return vscode;
+        const fromHarness = Boolean(parent && parent.filename === __filename);
+        if (!fromHarness && request.endsWith('aiSessions/attentionBridgeClient')) {
+            const AttentionBridgeClient = attentionBridgeClientModule.default;
+            return {
+                ...attentionBridgeClientModule,
+                default: class extends AttentionBridgeClient {
+                    constructor(onAggregate, onError, options) {
+                        super(onAggregate, onError, options);
+                        bridgeAggregateHandler = onAggregate;
+                    }
+                },
+            };
+        }
+        if (!fromHarness && request.endsWith('aiSessions/runtimeSettlementCapability')) {
+            return {
+                ...runtimeSettlementModule,
+                createAiSessionRuntimeSettlementCapability: options => {
+                    const capability = runtimeSettlementModule
+                        .createAiSessionRuntimeSettlementCapability(options);
+                    const queueSettlements = capability.queueSettlements;
+                    const runSafeLifecycleTask = capability.runSafeLifecycleTask;
+                    capability.queueSettlements = settlements => {
+                        calls.push(['queue-settlements', settlements]);
+                        return queueSettlements(settlements);
+                    };
+                    capability.runSafeLifecycleTask = (operation, task) => {
+                        calls.push(['lifecycle-task', operation]);
+                        return runSafeLifecycleTask(operation, task);
+                    };
+                    return capability;
+                },
+            };
+        }
+        if (!fromHarness && request.endsWith('aiSessions/statusCapability')) {
+            return {
+                ...statusCapabilityModule,
+                createAiSessionStatusCapability: options => {
+                    const capability = statusCapabilityModule.createAiSessionStatusCapability(options);
+                    const tick = capability.tick;
+                    capability.tick = () => {
+                        calls.push(['lifecycle-tick']);
+                        return tick();
+                    };
+                    return capability;
+                },
+            };
+        }
+        if (!fromHarness && request.endsWith('aiSessions/activeTerminalHighlight')) {
+            const ActiveAiSessionTerminalHighlighter = activeTerminalHighlightModule.default;
+            return {
+                ...activeTerminalHighlightModule,
+                default: class extends ActiveAiSessionTerminalHighlighter {
+                    constructor(options) {
+                        super(options);
+                        highlighterOptions = options;
+                    }
+                },
+            };
+        }
         return previousLoad.call(this, request, parent, isMain);
     };
+    const attentionBridgeClientModule = require('../../../../out/aiSessions/attentionBridgeClient');
+    const runtimeSettlementModule = require('../../../../out/aiSessions/runtimeSettlementCapability');
+    const statusCapabilityModule = require('../../../../out/aiSessions/statusCapability');
+    const activeTerminalHighlightModule = require('../../../../out/aiSessions/activeTerminalHighlight');
     const state = (synchronized = false) => ({
         get: (_key, fallback) => fallback,
         update: async () => undefined,
@@ -110,6 +276,7 @@ async function runTerminalCloseContract(transform = source => source) {
         const { AiSessionRuntimeCoordinator } = require('../../../../out/aiSessions/runtimeCoordinator');
         const ActiveAiSessionTerminalHighlighter = require('../../../../out/aiSessions/activeTerminalHighlight').default;
         const { AiSessionAttentionController } = require('../../../../out/aiSessions/attentionController');
+        const { AiSessionDashboardController } = require('../../../../out/aiSessions/dashboardController');
         const { AiSessionTerminalCommandController } = require(
             '../../../../out/aiSessions/terminalCommandController'
         );
@@ -128,11 +295,25 @@ async function runTerminalCloseContract(transform = source => source) {
         patchMethod(ActiveAiSessionTerminalHighlighter.prototype, 'handleTerminalClosed', terminal => {
             calls.push(['highlight-close', terminal]);
         });
+        const originalHighlightSync = ActiveAiSessionTerminalHighlighter.prototype.sync;
+        patchMethod(ActiveAiSessionTerminalHighlighter.prototype, 'sync', function (...args) {
+            calls.push(['highlight-sync']);
+            return originalHighlightSync.apply(this, args);
+        });
         patchMethod(AiSessionAttentionController.prototype, 'getRecoverySessionEvents', () => [{
             sessionKey: 'codex:session', eventIds: ['attention-event'],
         }]);
+        patchMethod(AiSessionAttentionController.prototype, 'getAttentionEventIds', () => ['attention-event']);
         patchMethod(AiSessionAttentionController.prototype, 'acknowledge', eventIds => {
             calls.push(['local-acknowledge', eventIds]);
+        });
+        patchMethod(AiSessionAttentionController.prototype, 'setRemoteAggregate', aggregate => {
+            calls.push(['set-remote-aggregate', aggregate]);
+            return true;
+        });
+        patchMethod(AiSessionAttentionController.prototype, 'getReleasedSessions', () => {
+            calls.push(['released-sessions']);
+            return [{ sessionKey: 'codex:session', eventIds: ['released-event'] }];
         });
         patchMethod(AiSessionAttentionController.prototype, 'suppressRuntimeCompletion', attentionKey => {
             calls.push(['suppress-runtime-completion', attentionKey]);
@@ -147,7 +328,17 @@ async function runTerminalCloseContract(transform = source => source) {
         patchMethod(AttentionBridgeClient.prototype, 'acknowledge', async eventIds => {
             calls.push(['bridge-acknowledge', eventIds]);
         });
-        if (mode === 'explicit-close' || mode === 'explicit-detach') {
+        const originalRefreshNow = AiSessionDashboardController.prototype.refreshNow;
+        patchMethod(AiSessionDashboardController.prototype, 'refreshNow', function (...args) {
+            calls.push(['refresh', args[0] || 'refresh']);
+            return originalRefreshNow.apply(this, args);
+        });
+        const originalScheduleRefresh = AiSessionDashboardController.prototype.scheduleRefresh;
+        patchMethod(AiSessionDashboardController.prototype, 'scheduleRefresh', function (...args) {
+            calls.push(['schedule-refresh', args[0] || 'refresh']);
+            return originalScheduleRefresh.apply(this, args);
+        });
+        if (scenario === 'explicit-close' || scenario === 'explicit-detach') {
             patchMethod(AiSessionTerminalCommandController.prototype, 'closeTerminal', async function () {
                 const runtime = activeFixtures[0];
                 this.options.onRuntimeCloseStart?.(runtime);
@@ -163,10 +354,130 @@ async function runTerminalCloseContract(transform = source => source) {
             'ATTENTION-RUNTIME-EXIT-NEUTRAL-001 production activation must register terminal close');
         const terminal = {
             name: 'tracked fixture terminal',
-            exitStatus: mode === 'user-close'
+            exitStatus: scenario === 'user-close'
                 ? { code: undefined, reason: 3 }
                 : { code: 0, reason: 2 },
         };
+
+        if (scenario === 'attention-state-order') {
+            const postedMessages = [];
+            const webview = {
+                options: {}, html: '', cspSource: 'fixture', asWebviewUri: value => value,
+                onDidReceiveMessage: () => disposable(),
+                postMessage: async message => {
+                    postedMessages.push(message);
+                    return true;
+                },
+            };
+            const view = { visible: true, webview, onDidChangeVisibility: () => disposable() };
+            await listeners.viewProvider.resolveWebviewView(view, {}, {});
+            const messageMark = postedMessages.length;
+            listeners.activeTerminal(terminal);
+            await waitFor(
+                () => postedMessages.slice(messageMark)
+                    .some(message => message && message.type === 'ai-sessions-updated'),
+                'incremental AI-session render after the active terminal change',
+            );
+            const renderedMessages = postedMessages.slice(messageMark);
+            const attentionStateIndex = renderedMessages
+                .findIndex(message => message && message.type === 'ai-session-attention-state');
+            const updateIndex = renderedMessages
+                .findIndex(message => message && message.type === 'ai-sessions-updated');
+            assert.ok(attentionStateIndex >= 0,
+                'WEBVIEW-AI-SESSION-DASHBOARD-CONTROLLER-001 every incremental render must publish the current attention event map');
+            assert.ok(updateIndex > attentionStateIndex,
+                'WEBVIEW-AI-SESSION-DASHBOARD-CONTROLLER-001 the attention event map must reach the webview before the HTML update');
+            assert.deepEqual(renderedMessages[attentionStateIndex].sessionEvents,
+                [{ sessionKey: 'codex:session', eventIds: ['attention-event'] }],
+                'WEBVIEW-AI-SESSION-DASHBOARD-CONTROLLER-001 the attention state must carry every recovery session event');
+            assert.deepEqual(renderedMessages[attentionStateIndex].eventIds, ['attention-event'],
+                'WEBVIEW-AI-SESSION-DASHBOARD-CONTROLLER-001 the attention state must carry the current attention event ids');
+            return calls;
+        }
+
+        if (scenario === 'remote-aggregate') {
+            assert.equal(typeof bridgeAggregateHandler, 'function',
+                'ATTENTION-PRODUCTION-ATTENTION-BRIDGE-INTEGRATION-001 the dashboard must hand the bridge client an aggregate callback');
+            const aggregate = { protocolVersion: 1, semanticRevision: 7, sessions: [] };
+            const aggregateMark = calls.length;
+            bridgeAggregateHandler(aggregate);
+            assert.ok(calls.slice(aggregateMark)
+                .some(call => call[0] === 'set-remote-aggregate' && call[1] === aggregate),
+                'ATTENTION-PRODUCTION-ATTENTION-BRIDGE-INTEGRATION-001 a bridge aggregate must reach the attention controller');
+            assert.ok(calls.slice(aggregateMark)
+                .some(call => call[0] === 'schedule-refresh' && call[1] === 'attention'),
+                'ATTENTION-PRODUCTION-ATTENTION-BRIDGE-INTEGRATION-001 a bridge aggregate must schedule an attention views refresh');
+            assert.equal(calls.slice(aggregateMark).some(call => call[0] === 'released-sessions'), false,
+                'ATTENTION-PRODUCTION-ATTENTION-BRIDGE-INTEGRATION-001 a later aggregate must not scan released sessions');
+            assert.equal(calls.slice(aggregateMark)
+                .some(call => call[0] === 'local-acknowledge' || call[0] === 'bridge-acknowledge'), false,
+                'ATTENTION-PRODUCTION-ATTENTION-BRIDGE-INTEGRATION-001 a later aggregate must not auto-acknowledge a delivered completion');
+            return calls;
+        }
+
+        if (scenario === 'highlighter-completion') {
+            assert.ok(highlighterOptions && typeof highlighterOptions.onComplete === 'function',
+                'ATTENTION-EXECUTION-STATE-SYNC-001 the dashboard must wire the highlighter completion callback');
+            const completionTerminal = { name: 'completed fixture terminal' };
+            const runtimeIdentity = {
+                provider: 'codex',
+                sessionId: 'session',
+                workspaceScopeIdentity: 'a'.repeat(64),
+                workspaceNavigationIdentity: 'navigation:fixture',
+                workspaceRootHostPaths: ['/fixture'],
+                cwd: '/fixture',
+            };
+            const completionMark = calls.length;
+            highlighterOptions.onComplete({
+                terminal: completionTerminal,
+                entry: { runtimeIdentity, markerPath: '/fixture/marker', runStartedAtMs: 42 },
+            });
+            const queueCall = calls.slice(completionMark).find(call => call[0] === 'queue-settlements');
+            assert.ok(queueCall,
+                'ATTENTION-EXECUTION-STATE-SYNC-001 a terminal completion must queue a runtime settlement');
+            assert.equal(queueCall[1].length, 1,
+                'ATTENTION-EXECUTION-STATE-SYNC-001 one completion must queue exactly one settlement');
+            assert.deepEqual(queueCall[1][0], {
+                identity: runtimeIdentity,
+                backend: 'vscode',
+                state: 'completed',
+                markerPath: '/fixture/marker',
+                runStartedAtMs: 42,
+                attached: true,
+                terminal: completionTerminal,
+            }, 'ATTENTION-EXECUTION-STATE-SYNC-001 the settlement must carry the completed runtime snapshot');
+            const guardMark = calls.length;
+            highlighterOptions.onComplete({
+                terminal: completionTerminal,
+                entry: { runtimeIdentity: null, markerPath: '/fixture/marker', runStartedAtMs: 42 },
+            });
+            assert.equal(calls.slice(guardMark).some(call => call[0] === 'queue-settlements'), false,
+                'ATTENTION-EXECUTION-STATE-SYNC-001 a completion without a runtime identity must not queue a settlement');
+            return calls;
+        }
+
+        if (scenario === 'active-terminal') {
+            const activeMark = calls.length;
+            listeners.activeTerminal(terminal);
+            await waitFor(
+                () => indexOfCall(calls, 'attention-evaluate', activeMark) >= 0,
+                'active terminal attention evaluation',
+            );
+            const highlightSyncIndex = indexOfCall(calls, 'highlight-sync', activeMark);
+            const refreshIndex = indexOfCall(calls, 'refresh', activeMark);
+            const lifecycleTaskIndex = indexOfLifecycleTask(calls, 'evaluate-attention-active-terminal', activeMark);
+            const evaluateIndex = indexOfCall(calls, 'attention-evaluate', activeMark);
+            assert.ok(highlightSyncIndex >= activeMark,
+                'WEBVIEW-ACTIVE-AI-SESSION-TERMINAL-HIGHLIGHT-001 an active terminal change must sync the highlighter');
+            assert.ok(refreshIndex > highlightSyncIndex,
+                'WEBVIEW-ACTIVE-AI-SESSION-TERMINAL-HIGHLIGHT-001 the highlighter sync must precede the incremental refresh');
+            assert.ok(lifecycleTaskIndex > refreshIndex,
+                'WEBVIEW-ACTIVE-AI-SESSION-TERMINAL-HIGHLIGHT-001 the attention evaluation must be routed through the safe lifecycle task');
+            assert.ok(evaluateIndex > lifecycleTaskIndex,
+                'WEBVIEW-ACTIVE-AI-SESSION-TERMINAL-HIGHLIGHT-001 a bare fire-and-forget evaluation must not replace the lifecycle task');
+            return calls;
+        }
+
         activeFixtures = [{
             backend: 'vscode', terminal, state: 'active', runStartedAtMs: 1,
             identity: {
@@ -187,9 +498,10 @@ async function runTerminalCloseContract(transform = source => source) {
         );
         assert.ok(calls.some(call => call[0] === 'runtime-close'));
         assert.ok(calls.some(call => call[0] === 'highlight-close'));
-        if (mode === 'user-close') {
+        if (scenario === 'user-close') {
             await waitFor(
-                () => calls.some(call => call[0] === 'local-acknowledge'),
+                () => calls.some(call => call[0] === 'local-acknowledge')
+                    && calls.some(call => call[0] === 'bridge-acknowledge'),
                 'user terminal close attention acknowledgement',
             );
             const suppressionIndex = calls.findIndex(call => call[0] === 'suppress-runtime-completion');
@@ -199,14 +511,30 @@ async function runTerminalCloseContract(transform = source => source) {
                 'ATTENTION-RUNTIME-EXIT-NEUTRAL-001 runtime exit must never suppress completion attention');
             assert.ok(localAcknowledgeIndex > runtimeCloseIndex,
                 'ATTENTION-USER-TERMINAL-CLOSE-001 must acknowledge after the user close is observed');
+            const refreshAfterAcknowledgeIndex = indexOfCall(calls, 'refresh', localAcknowledgeIndex);
+            const bridgeAcknowledgeIndex = indexOfCall(calls, 'bridge-acknowledge');
+            assert.ok(refreshAfterAcknowledgeIndex > localAcknowledgeIndex,
+                'ATTENTION-USER-TERMINAL-CLOSE-001 acknowledgement must refresh the local view before waiting for the cross-window bridge');
+            assert.ok(bridgeAcknowledgeIndex > refreshAfterAcknowledgeIndex,
+                'ATTENTION-USER-TERMINAL-CLOSE-001 the cross-window bridge must be awaited only after the local refresh');
+            const acknowledgeTaskIndex = indexOfLifecycleTask(calls, 'acknowledge-user-terminal-close');
+            assert.ok(acknowledgeTaskIndex >= 0 && acknowledgeTaskIndex < localAcknowledgeIndex,
+                'ATTENTION-USER-TERMINAL-CLOSE-001 acknowledgement must run inside the guarded lifecycle task');
         } else {
             assert.equal(calls.some(call => call[0] === 'suppress-runtime-completion'), false,
                 'ATTENTION-RUNTIME-EXIT-NEUTRAL-001 runtime exit must never suppress completion attention');
             assert.equal(calls.some(call => call[0] === 'local-acknowledge' || call[0] === 'bridge-acknowledge'), false,
                 'ATTENTION-RUNTIME-EXIT-NEUTRAL-001 process exit must not acknowledge unread attention');
+            const runtimeCloseIndex = indexOfCall(calls, 'runtime-close');
+            const highlightCloseIndex = indexOfCall(calls, 'highlight-close', runtimeCloseIndex);
+            const lifecycleTickIndex = indexOfCall(calls, 'lifecycle-tick', runtimeCloseIndex);
+            assert.ok(lifecycleTickIndex > runtimeCloseIndex && lifecycleTickIndex < highlightCloseIndex,
+                'ATTENTION-RUNTIME-EXIT-NEUTRAL-001 terminal close must re-run the lifecycle tick right after runtime close handling');
+            assert.equal(calls[highlightCloseIndex][1], terminal,
+                'WEBVIEW-ACTIVE-AI-SESSION-TERMINAL-HIGHLIGHT-001 the highlighter must observe the exact closed terminal');
         }
-        if (mode === 'explicit-close' || mode === 'explicit-detach') {
-            if (mode === 'explicit-detach') {
+        if (scenario === 'explicit-close' || scenario === 'explicit-detach') {
+            if (scenario === 'explicit-detach') {
                 activeFixtures[0] = {
                     ...activeFixtures[0],
                     backend: 'tmux',
@@ -223,7 +551,7 @@ async function runTerminalCloseContract(transform = source => source) {
             await listeners.viewProvider.resolveWebviewView(view, {}, {});
             assert.equal(typeof onMessage, 'function');
             await onMessage({
-                type: mode === 'explicit-detach'
+                type: scenario === 'explicit-detach'
                     ? 'detach-ai-session-terminal'
                     : 'close-ai-session-terminal',
                 projectId: '__currentWorkspace',
@@ -254,17 +582,16 @@ async function runTerminalCloseContract(transform = source => source) {
     }
 }
 
-const mode = process.argv[2];
-const run = mode === 'mutation'
-    ? () => runTerminalCloseContract(source => {
-        const needle = 'aiSessionRuntimeCoordinator.handleClosedTerminal(terminal);';
-        assert.ok(source.includes(needle), 'controlled mutation must find the production callback');
-        return source.replace(needle,
-            `${needle}\n            aiSessionAttentionController.suppressRuntimeCompletion('synthetic-exit');`);
-    })
-    : () => runTerminalCloseContract();
+const mode = process.argv[2] || 'baseline';
+const mutationName = mode === 'mutation'
+    ? 'completion-suppression'
+    : (mode.startsWith('mutation:') ? mode.slice('mutation:'.length) : null);
+const mutation = mutationName ? mutations[mutationName] : null;
+assert.ok(!mutationName || mutation, `unknown mutation ${mutationName}`);
+const scenario = mutation ? mutation.scenario : mode;
+const transform = mutation ? mutation.transform : source => source;
 
-run().catch(error => {
+runTerminalCloseContract(transform, scenario).catch(error => {
     process.stderr.write(`${error.stack || error}\n`);
     process.exitCode = 1;
 });

--- a/tests/integration/dashboard/productionAttentionBridge.test.js
+++ b/tests/integration/dashboard/productionAttentionBridge.test.js
@@ -223,11 +223,11 @@ test('ATTENTION-PRODUCTION-ATTENTION-BRIDGE-INTEGRATION-001 OPEN-WORKSPACE-UI-HO
             && entry.args[0]?.instanceId === validSnapshot.instanceId).length;
         assert.equal(fs.existsSync(path.join(productionRoot, `${validSnapshot.instanceId}.json`)), true);
         client.dispose();
-        for (let attempt = 0; attempt < 50
-            && (unregisterCount() === 0
-                || fs.existsSync(path.join(productionRoot, `${validSnapshot.instanceId}.json`))); attempt += 1) {
-            await new Promise(resolve => setImmediate(resolve));
-        }
+        // Awaiting shutdown is deterministic: shutdownFlight chains the unregister
+        // executeCommand onto publicationQueue, so its resolution guarantees the bridge
+        // handler (and the production store remove) completed. Event-loop-turn polling
+        // here flaked under c8-instrumented full-suite load.
+        await client.shutdown();
         assert.equal(unregisterCount(), 1, 'disposing the real client unregisters its production snapshot');
         assert.equal(fs.existsSync(path.join(productionRoot, `${validSnapshot.instanceId}.json`)), false);
     } finally {

--- a/tests/integration/dashboard/terminalCloseWiring.test.js
+++ b/tests/integration/dashboard/terminalCloseWiring.test.js
@@ -29,6 +29,64 @@ test('ATTENTION-EXPLICIT-SESSION-CLOSE-001 tmux detach acknowledges current atte
     await execFile(process.execPath, [harnessPath, 'explicit-detach'], { env: harnessEnvironment() });
 });
 
+test('ATTENTION-USER-TERMINAL-CLOSE-001 controlled bridge-first acknowledgement mutation is rejected', async () => {
+    await assert.rejects(
+        execFile(process.execPath, [harnessPath, 'mutation:acknowledge-order'], { env: harnessEnvironment() }),
+        /must be awaited only after the local refresh/);
+});
+
+test('WEBVIEW-AI-SESSION-DASHBOARD-CONTROLLER-001 attention state publication precedes the incremental render', async () => {
+    await execFile(process.execPath, [harnessPath, 'attention-state-order'], { env: harnessEnvironment() });
+});
+
+test('WEBVIEW-AI-SESSION-DASHBOARD-CONTROLLER-001 controlled render-before-attention-state mutation is rejected', async () => {
+    await assert.rejects(
+        execFile(process.execPath, [harnessPath, 'mutation:attention-state-before-render'], { env: harnessEnvironment() }),
+        /must publish the current attention event map/);
+});
+
+test('ATTENTION-PRODUCTION-ATTENTION-BRIDGE-INTEGRATION-001 remote aggregate schedules a refresh without auto-acknowledging', async () => {
+    await execFile(process.execPath, [harnessPath, 'remote-aggregate'], { env: harnessEnvironment() });
+});
+
+test('ATTENTION-PRODUCTION-ATTENTION-BRIDGE-INTEGRATION-001 controlled aggregate auto-acknowledge mutation is rejected', async () => {
+    await assert.rejects(
+        execFile(process.execPath, [harnessPath, 'mutation:aggregate-auto-acknowledge'], { env: harnessEnvironment() }),
+        /must not (scan released sessions|auto-acknowledge a delivered completion)/);
+});
+
+test('ATTENTION-PRODUCTION-ATTENTION-BRIDGE-INTEGRATION-001 controlled missing aggregate refresh mutation is rejected', async () => {
+    await assert.rejects(
+        execFile(process.execPath, [harnessPath, 'mutation:aggregate-refresh-skipped'], { env: harnessEnvironment() }),
+        /must schedule an attention views refresh/);
+});
+
+test('ATTENTION-EXECUTION-STATE-SYNC-001 terminal completion queues a structured runtime settlement', async () => {
+    await execFile(process.execPath, [harnessPath, 'highlighter-completion'], { env: harnessEnvironment() });
+});
+
+test('ATTENTION-EXECUTION-STATE-SYNC-001 controlled completion-without-settlement mutation is rejected', async () => {
+    await assert.rejects(
+        execFile(process.execPath, [harnessPath, 'mutation:completion-queue-skipped'], { env: harnessEnvironment() }),
+        /must queue a runtime settlement/);
+});
+
+test('WEBVIEW-ACTIVE-AI-SESSION-TERMINAL-HIGHLIGHT-001 active terminal change syncs highlight and evaluates through the lifecycle task', async () => {
+    await execFile(process.execPath, [harnessPath, 'active-terminal'], { env: harnessEnvironment() });
+});
+
+test('WEBVIEW-ACTIVE-AI-SESSION-TERMINAL-HIGHLIGHT-001 controlled bare active-terminal evaluation mutation is rejected', async () => {
+    await assert.rejects(
+        execFile(process.execPath, [harnessPath, 'mutation:active-terminal-bare-evaluate'], { env: harnessEnvironment() }),
+        /must be routed through the safe lifecycle task/);
+});
+
+test('ATTENTION-RUNTIME-EXIT-NEUTRAL-001 controlled close-without-lifecycle-tick mutation is rejected', async () => {
+    await assert.rejects(
+        execFile(process.execPath, [harnessPath, 'mutation:close-tick-skipped'], { env: harnessEnvironment() }),
+        /must re-run the lifecycle tick/);
+});
+
 test('ATTENTION-RUNTIME-EXIT-NEUTRAL-001 controlled completion-suppression mutation is rejected', async () => {
     await assert.rejects(
         execFile(process.execPath, [harnessPath, 'mutation'], { env: harnessEnvironment() }),


### PR DESCRIPTION
## What

Test-debt conversion ahead of the dashboard.ts D/E extraction, plus one flake fix:

1. **Flake fix** (`productionAttentionBridge.test.js`): the post-dispose unregister assertion polled 50 event-loop turns, which measures scheduler luck rather than wall-clock progress. Under c8-instrumented full-suite load the loop exhausts its budget in milliseconds while the unregister chain still waits on thread-pool fs work. Now awaits the idempotent `client.shutdown()` flight — deterministic by construction. Verified 15× normal + 8× under c8 with 8-way CPU spin load, all green.

2. **tmux composition pins → behavioral** (`run-ai-session-tmux-checks.js` −53 lines): the indexOf bootstrap-order chain and construction includes are retired; `runtimeComposition.test.js` gains production-activation cases for the locked tmux binding store root, modal vs plain fallback prompts, runtime configuration rebinding order, privacy-safe tmux restore failure, and post-activation terminal attachment restore. Each new assertion mutation-proven.

3. **attention/terminal pins → behavioral** (`run-ai-session-safety-checks.js` −55, `run-dashboard-webview-checks.js` −6): retired dashboard.ts source slices covering acknowledge ordering, attention-state-before-render, aggregate no-auto-ack, settlement-on-completion, and active-terminal evaluation. `terminalCloseWiring.test.js` gains 4 scenarios + strengthened baselines, each paired with a permanent controlled-mutation test.

## Kept as source assertions (deliberately)

- `assertBootstrapOwnedResource` mutation proofs (assertion-validity self-proof requires source mutation)
- PATH regression anti-assertions
- coordinator `getActive`/`getPending` wiring (no behavioral coverage yet — harness hydration early-returns without workspace folders)
- architecture/location guards (updated during the D/E extraction itself)

## Verification

- `node --test tests/contract/aiSessions/runtimeComposition.test.js`: 15/15
- `node --test tests/integration/dashboard/**/*.test.js`: 288/288
- `run-ai-session-tmux-checks.js` / `run-ai-session-safety-checks.js` / `run-dashboard-webview-checks.js`: all pass
- `check-behavior-contracts.js`: pass (no behavior-ID evidence impacted)
- Full `test:ci:linux`: running locally and in CI