### PR TITLE
refactor: move the tmux runtime request validation out of tmuxRuntimeBackend.ts

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -1489,7 +1489,8 @@
     "priority": "P1",
     "status": "automated",
     "owners": [
-      "tests/contract/aiSessions/runtimeBackends.test.js"
+      "tests/contract/aiSessions/runtimeBackends.test.js",
+      "tests/unit/aiSessions/tmuxRuntimeRequest.test.js"
     ],
     "evidence": [
       "scripts/run-ai-session-tmux-checks.js"

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "c982f07c1ab89e22ef859e30399766bcd6ee5029",
+        "head": "4b2790d284a5b45fd4b69308acb83f696b2267cb",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -76,7 +76,8 @@
             "af9cc7328dc642243b8c9e00cf86869353ced1ac",
             "95a9a7bc69b494fcd4f0d902d76370687baf4472",
             "05edca8119b9a471cbcd32f287144cebe7ebae08",
-            "0e0016d9449d61753fe3f30711656cad881b12a6"
+            "0e0016d9449d61753fe3f30711656cad881b12a6",
+            "5efaa7ae0901f8da52b8211cccbf37386ee51498"
         ]
     },
     "capabilities": [
@@ -751,7 +752,8 @@
                 "2b82dcf05ce93ddd73217a5309e4ed12464841f6",
                 "059af49ce010a4097ac1e4a847b7c7be430b7171",
                 "892ae70669ed4b08f452f70f3539eed665f3c555",
-                "69c490edf6d6d483e0694bc28d78862edba43334"
+                "69c490edf6d6d483e0694bc28d78862edba43334",
+                "4b2790d284a5b45fd4b69308acb83f696b2267cb"
             ],
             "behaviors": [
                 "RUNTIME-TMUX-BACKEND-001",

--- a/src/aiSessions/tmuxRuntimeBackend.ts
+++ b/src/aiSessions/tmuxRuntimeBackend.ts
@@ -3,14 +3,12 @@
 import { createHash, randomBytes } from 'crypto';
 import type * as vscode from 'vscode';
 import { serializeTmuxLaunchCommand } from './launchSpec';
-import type { AiSessionLaunchSpec } from './launchSpec';
 import type {
     AiSessionCreateRuntimeRequest,
     AiSessionDeferredCreateRuntimeRequest,
     AiSessionDeferredResumeRuntimeRequest,
     AiSessionDurablePendingPromotionCandidate,
     AiSessionExecutableRuntimeBackend,
-    AiSessionLazyRuntimeLaunch,
     AiSessionManagedTmuxMetadata,
     AiSessionMaterializedCreateRuntimeRequest,
     AiSessionMaterializedResumeRuntimeRequest,
@@ -22,10 +20,6 @@ import type {
     AiSessionTmuxLocator,
     TmuxRuntimeUnavailableReason,
 } from './runtimeTypes';
-import {
-    materializeAiSessionLaunchSpec,
-    snapshotAiSessionRuntimeLaunch,
-} from './runtimeLaunch';
 import {
     aiSessionRuntimeIdentitiesEqual,
     AiSessionRuntimeConflictError,
@@ -39,8 +33,6 @@ import {
 import {
     getTmuxRuntimeKey,
     parseManagedTmuxMetadata,
-    ProjectTmuxLayout,
-    SessionTmuxLayout,
 } from './tmuxLayout';
 import {
     TmuxAttachBinding,
@@ -62,17 +54,19 @@ import {
     validateTmuxPendingRuntimeBinding,
 } from './tmuxRuntimeBindingStore';
 import { getTmuxCollisionRuntimes, TmuxRuntimeDiscovery } from './tmuxRuntimeDiscovery';
+import {
+    isBoundedOptionalLocalPath,
+    isIdentityField,
+    isLocalPath,
+    materializePendingRequest,
+    materializeResumeRequest,
+    snapshotPendingRequest,
+    snapshotResumeRequest,
+    validateDispatchIdentity,
+} from './tmuxRuntimeRequest';
 
 const SESSION_WINDOW = 'ai-session';
 const TERMINAL_PROCESS_ID_TIMEOUT_MS = 2000;
-const MAX_LOCAL_PATH_LENGTH = 4096;
-const MAX_IDENTITY_FIELD_LENGTH = 512;
-const MAX_EXECUTABLE_LENGTH = 4096;
-const MAX_LAUNCH_ARGUMENT_BYTES = 16 * 1024;
-const MAX_LAUNCH_ARGUMENTS = 256;
-const MAX_EXCLUDED_SESSION_IDS = 1000;
-const MAX_AGGREGATE_LAUNCH_BYTES = 32 * 1024;
-const MAX_SERIALIZED_TMUX_COMMAND_BYTES = 128 * 1024;
 const LOCAL_CONTROL_CHARACTERS = /[\u0000-\u001f\u007f]/;
 const TMUX_ATTACH_RECOVERY_ENV = 'AGENT_PIVOT_TMUX_ATTACH_ID';
 const TMUX_ATTACH_RECOVERY_TOKEN = /^[0-9a-f]{32}$/;
@@ -1695,233 +1689,6 @@ function isSafeAttachTerminalName(value: unknown): value is string {
         && !LOCAL_CONTROL_CHARACTERS.test(value);
 }
 
-function snapshotResumeRequest(
-    request: AiSessionResumeRuntimeRequest
-): AiSessionDeferredResumeRuntimeRequest {
-    if (!isRecordShape(request)) {
-        throw new Error('The tmux runtime request shape is invalid.');
-    }
-    const identity = snapshotResumeIdentity(request.identity);
-    const projectName = snapshotRequiredString(request.projectName, 'The tmux runtime request');
-    const sessionName = snapshotDisplayName(
-        request.sessionName, identity.sessionId, 'The tmux runtime request'
-    );
-    const terminalName = snapshotRequiredString(request.terminalName, 'The tmux runtime request');
-    const launch = snapshotTmuxRuntimeLaunch(request, identity);
-    return {
-        identity,
-        projectName,
-        sessionName,
-        terminalName,
-        launchMarkerPath: launch.launchMarkerPath,
-        createLaunchSpec: launch.createLaunchSpec,
-        directoryScope: request.directoryScope,
-    };
-}
-
-function snapshotPendingRequest(
-    request: AiSessionCreateRuntimeRequest
-): AiSessionDeferredCreateRuntimeRequest {
-    if (!isRecordShape(request)) {
-        throw new Error('The pending runtime request shape is invalid.');
-    }
-    const identity = snapshotPendingIdentity(request.identity);
-    const projectName = snapshotRequiredString(request.projectName, 'The pending runtime request');
-    const terminalName = snapshotRequiredString(request.terminalName, 'The pending runtime request');
-    const createdAt = snapshotRequiredString(request.createdAt, 'The pending runtime request');
-    const excludedSessionIds = snapshotDenseStringArray(request.excludedSessionIds,
-        MAX_EXCLUDED_SESSION_IDS, 'excluded session IDs', 'The pending runtime request');
-    const title = snapshotOptionalString(request.title, 'The pending runtime request');
-    const launch = snapshotTmuxRuntimeLaunch(request, identity);
-    return {
-        identity,
-        projectName,
-        terminalName,
-        createdAt,
-        excludedSessionIds,
-        ...(title === undefined ? {} : { title }),
-        launchMarkerPath: launch.launchMarkerPath,
-        createLaunchSpec: launch.createLaunchSpec,
-        directoryScope: request.directoryScope,
-    };
-}
-
-function snapshotLaunch(
-    launch: unknown
-): AiSessionLaunchSpec {
-    if (!isRecordShape(launch)) {
-        throw new Error('The tmux runtime request shape is invalid.');
-    }
-    const executable = snapshotRequiredString(launch.executable, 'The tmux runtime request');
-    const args = snapshotDenseStringArray(launch.args, MAX_LAUNCH_ARGUMENTS,
-        'provider launch arguments', 'The tmux runtime request');
-    const cwd = snapshotOptionalString(launch.cwd, 'The tmux runtime request');
-    const markerPath = snapshotOptionalString(launch.markerPath, 'The tmux runtime request');
-    const windowsDirectShell = launch.windowsDirectShell;
-    if (windowsDirectShell !== undefined && windowsDirectShell !== 'current'
-        && windowsDirectShell !== 'powershell') {
-        throw new Error('The tmux runtime request shape is invalid.');
-    }
-    return {
-        executable,
-        args,
-        ...(cwd === undefined ? {} : { cwd }),
-        ...(markerPath === undefined ? {} : { markerPath }),
-        ...(windowsDirectShell === undefined
-            ? {}
-            : { windowsDirectShell: windowsDirectShell as 'current' | 'powershell' }),
-    };
-}
-
-function snapshotTmuxRuntimeLaunch(
-    request: AiSessionCreateRuntimeRequest | AiSessionResumeRuntimeRequest,
-    identity: AiSessionRuntimeIdentity
-): AiSessionLazyRuntimeLaunch {
-    const candidate = request as unknown as Record<string, unknown>;
-    if (typeof candidate.createLaunchSpec === 'function') {
-        return snapshotAiSessionRuntimeLaunch(request);
-    }
-    const launch = snapshotLaunch(candidate.launch);
-    validateDispatchInputs(identity, launch);
-    const launchMarkerPath = candidate.launchMarkerPath === undefined
-        ? launch.markerPath || ''
-        : snapshotRequiredString(candidate.launchMarkerPath, 'The tmux runtime request');
-    return {
-        launchMarkerPath,
-        createLaunchSpec: () => launch,
-    };
-}
-
-function materializeResumeRequest(
-    request: AiSessionDeferredResumeRuntimeRequest
-): AiSessionMaterializedResumeRuntimeRequest {
-    const launch = snapshotLaunch(materializeAiSessionLaunchSpec(request));
-    validateDispatchInputs(request.identity, launch);
-    return {
-        identity: cloneAiSessionRuntimeIdentity(request.identity),
-        projectName: request.projectName,
-        sessionName: request.sessionName,
-        terminalName: request.terminalName,
-        launchMarkerPath: request.launchMarkerPath,
-        launch,
-        directoryScope: request.directoryScope,
-    };
-}
-
-function materializePendingRequest(
-    request: AiSessionDeferredCreateRuntimeRequest
-): AiSessionMaterializedCreateRuntimeRequest {
-    const launch = snapshotLaunch(materializeAiSessionLaunchSpec(request));
-    validateDispatchInputs(request.identity, launch);
-    return {
-        identity: cloneAiSessionRuntimeIdentity(request.identity),
-        projectName: request.projectName,
-        terminalName: request.terminalName,
-        createdAt: request.createdAt,
-        excludedSessionIds: [...request.excludedSessionIds],
-        ...(request.title === undefined ? {} : { title: request.title }),
-        launchMarkerPath: request.launchMarkerPath,
-        launch,
-        directoryScope: request.directoryScope,
-    };
-}
-
-function snapshotResumeIdentity(value: unknown): AiSessionResumeRuntimeRequest['identity'] {
-    if (!isRecordShape(value)) {
-        throw new Error('The tmux runtime request shape is invalid.');
-    }
-    const provider = snapshotRequiredString(value.provider, 'The tmux runtime request');
-    const workspaceScopeIdentity = snapshotRequiredString(value.workspaceScopeIdentity, 'The tmux runtime request');
-    const workspaceNavigationIdentity = snapshotRequiredString(
-        value.workspaceNavigationIdentity, 'The tmux runtime request'
-    );
-    const workspaceRootHostPaths = snapshotDenseStringArray(value.workspaceRootHostPaths,
-        MAX_EXCLUDED_SESSION_IDS, 'workspace root paths', 'The tmux runtime request');
-    const cwd = snapshotRequiredString(value.cwd, 'The tmux runtime request');
-    const sessionId = snapshotRequiredString(value.sessionId, 'The tmux runtime request');
-    return {
-        provider: provider as AiSessionResumeRuntimeRequest['identity']['provider'],
-        workspaceScopeIdentity,
-        workspaceNavigationIdentity,
-        workspaceRootHostPaths,
-        cwd,
-        sessionId,
-    };
-}
-
-function snapshotPendingIdentity(value: unknown): AiSessionCreateRuntimeRequest['identity'] {
-    if (!isRecordShape(value)) {
-        throw new Error('The pending runtime request shape is invalid.');
-    }
-    const provider = snapshotRequiredString(value.provider, 'The pending runtime request');
-    const workspaceScopeIdentity = snapshotRequiredString(value.workspaceScopeIdentity, 'The pending runtime request');
-    const workspaceNavigationIdentity = snapshotRequiredString(
-        value.workspaceNavigationIdentity, 'The pending runtime request'
-    );
-    const workspaceRootHostPaths = snapshotDenseStringArray(value.workspaceRootHostPaths,
-        MAX_EXCLUDED_SESSION_IDS, 'workspace root paths', 'The pending runtime request');
-    const cwd = snapshotRequiredString(value.cwd, 'The pending runtime request');
-    const pendingId = snapshotRequiredString(value.pendingId, 'The pending runtime request');
-    return {
-        provider: provider as AiSessionCreateRuntimeRequest['identity']['provider'],
-        workspaceScopeIdentity,
-        workspaceNavigationIdentity,
-        workspaceRootHostPaths,
-        cwd,
-        pendingId,
-    };
-}
-
-function snapshotRequiredString(value: unknown, owner: string): string {
-    if (typeof value !== 'string') {
-        throw new Error(`${owner} shape is invalid.`);
-    }
-    return value;
-}
-
-function snapshotOptionalString(value: unknown, owner: string): string | undefined {
-    return value === undefined ? undefined : snapshotRequiredString(value, owner);
-}
-
-function snapshotDisplayName(value: unknown, fallback: string, owner: string): string {
-    const candidate = value === undefined ? fallback : snapshotRequiredString(value, owner);
-    if (candidate.length > 200 || LOCAL_CONTROL_CHARACTERS.test(candidate)) {
-        throw new Error(`${owner} display name is invalid.`);
-    }
-    return candidate;
-}
-
-function snapshotDenseStringArray(
-    value: unknown,
-    maximum: number,
-    label: string,
-    owner: string
-): string[] {
-    if (!Array.isArray(value)) {
-        throw new Error(`${owner} ${label} must be an array.`);
-    }
-    const length = value.length;
-    if (!Number.isSafeInteger(length) || length > maximum) {
-        throw new Error(`${owner} has too many ${label}; the ${label} count is too large.`);
-    }
-    const snapshot: string[] = [];
-    for (let index = 0; index < length; index++) {
-        if (!Object.prototype.hasOwnProperty.call(value, index)) {
-            throw new Error(`${owner} requires dense ${label}.`);
-        }
-        const item = value[index];
-        if (typeof item !== 'string') {
-            throw new Error(`${owner} requires dense ${label}.`);
-        }
-        snapshot.push(item);
-    }
-    return snapshot;
-}
-
-function isRecordShape(value: unknown): value is Record<string, unknown> {
-    return !!value && typeof value === 'object' && !Array.isArray(value);
-}
-
 function pendingIdentity(identity: AiSessionRuntimeIdentity & { pendingId: string }): AiSessionRuntimeIdentity {
     return {
         ...cloneAiSessionRuntimeIdentity(identity),
@@ -1954,97 +1721,10 @@ function pendingLifecycleIdentityMatches(
         });
 }
 
-function pendingIdentityConflictError(): Error {
-    return new Error('The pending ID belongs to a different tmux runtime identity.');
-}
-
-function getFinalLocator(identity: AiSessionRuntimeIdentity, layout: AiSessionTmuxLayout): AiSessionTmuxLocator {
-    return layout === 'project'
-        ? new ProjectTmuxLayout().getLocator(identity)
-        : new SessionTmuxLayout().getLocator(identity);
-}
-
 function requireLayout(value: unknown): asserts value is AiSessionTmuxLayout {
     if (value !== 'project' && value !== 'session') {
         throw new Error('The tmux runtime layout must be project or session.');
     }
-}
-
-function validateDispatchInputs(
-    identity: AiSessionRuntimeIdentity,
-    launch: AiSessionLaunchSpec
-): void {
-    validateDispatchIdentity(identity);
-    validateLaunchInputs(identity, launch);
-}
-
-function validateDispatchIdentity(identity: AiSessionRuntimeIdentity): void {
-    if (!identity || !isValidAiSessionRuntimeIdentity(identity)) {
-        throw new Error('The tmux runtime cwd is invalid.');
-    }
-    const hasSessionId = identity.sessionId !== undefined;
-    const hasPendingId = identity.pendingId !== undefined;
-    if ((identity.provider !== 'codex' && identity.provider !== 'kimi' && identity.provider !== 'claude')
-        || hasSessionId === hasPendingId
-        || !isIdentityField(hasSessionId ? identity.sessionId : identity.pendingId)) {
-        throw new Error('The tmux runtime identity is invalid.');
-    }
-}
-
-function validateLaunchInputs(
-    identity: AiSessionRuntimeIdentity,
-    launch: AiSessionLaunchSpec
-): void {
-    if (!launch || typeof launch.executable !== 'string' || !launch.executable
-        || launch.executable.length > MAX_EXECUTABLE_LENGTH
-        || LOCAL_CONTROL_CHARACTERS.test(launch.executable)) {
-        throw new Error('The provider executable is invalid.');
-    }
-    if (!Array.isArray(launch.args) || launch.args.length > MAX_LAUNCH_ARGUMENTS
-        || launch.args.some(argument => typeof argument !== 'string'
-            || Buffer.byteLength(argument, 'utf8') > MAX_LAUNCH_ARGUMENT_BYTES
-            || argument.indexOf('\0') !== -1)) {
-        throw new Error('A provider launch argument is invalid or too large.');
-    }
-    if (launch.cwd !== undefined && !isLocalPath(launch.cwd)) {
-        throw new Error('The provider launch cwd is invalid.');
-    }
-    if (launch.markerPath !== undefined && !isLocalPath(launch.markerPath)) {
-        throw new Error('The provider marker path is invalid.');
-    }
-    if (launch.windowsDirectShell !== undefined
-        && launch.windowsDirectShell !== 'current' && launch.windowsDirectShell !== 'powershell') {
-        throw new Error('The provider launch shell is invalid.');
-    }
-    const aggregateBytes = [
-        identity.cwd,
-        launch.executable,
-        ...launch.args,
-        launch.cwd || '',
-        launch.markerPath || '',
-    ].reduce((total, value) => total + Buffer.byteLength(value, 'utf8'), 0);
-    if (aggregateBytes > MAX_AGGREGATE_LAUNCH_BYTES) {
-        throw new Error('The provider launch exceeds the aggregate launch budget.');
-    }
-    if (Buffer.byteLength(serializeTmuxLaunchCommand(launch), 'utf8')
-        > MAX_SERIALIZED_TMUX_COMMAND_BYTES) {
-        throw new Error('The serialized provider launch exceeds the tmux command budget.');
-    }
-}
-
-function isIdentityField(value: unknown): value is string {
-    return typeof value === 'string' && value.length > 0 && value.length <= MAX_IDENTITY_FIELD_LENGTH
-        && !LOCAL_CONTROL_CHARACTERS.test(value);
-}
-
-function isLocalPath(value: unknown): value is string {
-    return typeof value === 'string' && value.length > 0 && value.length <= MAX_LOCAL_PATH_LENGTH
-        && !LOCAL_CONTROL_CHARACTERS.test(value);
-}
-
-function isBoundedOptionalLocalPath(value: unknown): value is string {
-    return typeof value === 'string' && value.length <= MAX_LOCAL_PATH_LENGTH
-        && !LOCAL_CONTROL_CHARACTERS.test(value);
 }
 
 function projectSessionMetadata(identity: AiSessionRuntimeIdentity): Record<string, string> {

--- a/src/aiSessions/tmuxRuntimeRequest.ts
+++ b/src/aiSessions/tmuxRuntimeRequest.ts
@@ -1,0 +1,336 @@
+'use strict';
+
+import type { AiSessionLaunchSpec } from './launchSpec';
+import { serializeTmuxLaunchCommand } from './launchSpec';
+import {
+    materializeAiSessionLaunchSpec,
+    snapshotAiSessionRuntimeLaunch,
+} from './runtimeLaunch';
+import type {
+    AiSessionCreateRuntimeRequest,
+    AiSessionDeferredCreateRuntimeRequest,
+    AiSessionDeferredResumeRuntimeRequest,
+    AiSessionLazyRuntimeLaunch,
+    AiSessionMaterializedCreateRuntimeRequest,
+    AiSessionMaterializedResumeRuntimeRequest,
+    AiSessionResumeRuntimeRequest,
+    AiSessionRuntimeIdentity,
+} from './runtimeTypes';
+import {
+    cloneAiSessionRuntimeIdentity,
+    isValidAiSessionRuntimeIdentity,
+} from './runtimeTypes';
+
+const MAX_LOCAL_PATH_LENGTH = 4096;
+const MAX_IDENTITY_FIELD_LENGTH = 512;
+const MAX_EXECUTABLE_LENGTH = 4096;
+const MAX_LAUNCH_ARGUMENT_BYTES = 16 * 1024;
+const MAX_LAUNCH_ARGUMENTS = 256;
+const MAX_EXCLUDED_SESSION_IDS = 1000;
+const MAX_AGGREGATE_LAUNCH_BYTES = 32 * 1024;
+const MAX_SERIALIZED_TMUX_COMMAND_BYTES = 128 * 1024;
+const LOCAL_CONTROL_CHARACTERS = /[\u0000-\u001f\u007f]/;
+
+export function snapshotResumeRequest(
+    request: AiSessionResumeRuntimeRequest
+): AiSessionDeferredResumeRuntimeRequest {
+    if (!isRecordShape(request)) {
+        throw new Error('The tmux runtime request shape is invalid.');
+    }
+    const identity = snapshotResumeIdentity(request.identity);
+    const projectName = snapshotRequiredString(request.projectName, 'The tmux runtime request');
+    const sessionName = snapshotDisplayName(
+        request.sessionName, identity.sessionId, 'The tmux runtime request'
+    );
+    const terminalName = snapshotRequiredString(request.terminalName, 'The tmux runtime request');
+    const launch = snapshotTmuxRuntimeLaunch(request, identity);
+    return {
+        identity,
+        projectName,
+        sessionName,
+        terminalName,
+        launchMarkerPath: launch.launchMarkerPath,
+        createLaunchSpec: launch.createLaunchSpec,
+        directoryScope: request.directoryScope,
+    };
+}
+
+export function snapshotPendingRequest(
+    request: AiSessionCreateRuntimeRequest
+): AiSessionDeferredCreateRuntimeRequest {
+    if (!isRecordShape(request)) {
+        throw new Error('The pending runtime request shape is invalid.');
+    }
+    const identity = snapshotPendingIdentity(request.identity);
+    const projectName = snapshotRequiredString(request.projectName, 'The pending runtime request');
+    const terminalName = snapshotRequiredString(request.terminalName, 'The pending runtime request');
+    const createdAt = snapshotRequiredString(request.createdAt, 'The pending runtime request');
+    const excludedSessionIds = snapshotDenseStringArray(request.excludedSessionIds,
+        MAX_EXCLUDED_SESSION_IDS, 'excluded session IDs', 'The pending runtime request');
+    const title = snapshotOptionalString(request.title, 'The pending runtime request');
+    const launch = snapshotTmuxRuntimeLaunch(request, identity);
+    return {
+        identity,
+        projectName,
+        terminalName,
+        createdAt,
+        excludedSessionIds,
+        ...(title === undefined ? {} : { title }),
+        launchMarkerPath: launch.launchMarkerPath,
+        createLaunchSpec: launch.createLaunchSpec,
+        directoryScope: request.directoryScope,
+    };
+}
+
+function snapshotLaunch(
+    launch: unknown
+): AiSessionLaunchSpec {
+    if (!isRecordShape(launch)) {
+        throw new Error('The tmux runtime request shape is invalid.');
+    }
+    const executable = snapshotRequiredString(launch.executable, 'The tmux runtime request');
+    const args = snapshotDenseStringArray(launch.args, MAX_LAUNCH_ARGUMENTS,
+        'provider launch arguments', 'The tmux runtime request');
+    const cwd = snapshotOptionalString(launch.cwd, 'The tmux runtime request');
+    const markerPath = snapshotOptionalString(launch.markerPath, 'The tmux runtime request');
+    const windowsDirectShell = launch.windowsDirectShell;
+    if (windowsDirectShell !== undefined && windowsDirectShell !== 'current'
+        && windowsDirectShell !== 'powershell') {
+        throw new Error('The tmux runtime request shape is invalid.');
+    }
+    return {
+        executable,
+        args,
+        ...(cwd === undefined ? {} : { cwd }),
+        ...(markerPath === undefined ? {} : { markerPath }),
+        ...(windowsDirectShell === undefined
+            ? {}
+            : { windowsDirectShell: windowsDirectShell as 'current' | 'powershell' }),
+    };
+}
+
+function snapshotTmuxRuntimeLaunch(
+    request: AiSessionCreateRuntimeRequest | AiSessionResumeRuntimeRequest,
+    identity: AiSessionRuntimeIdentity
+): AiSessionLazyRuntimeLaunch {
+    const candidate = request as unknown as Record<string, unknown>;
+    if (typeof candidate.createLaunchSpec === 'function') {
+        return snapshotAiSessionRuntimeLaunch(request);
+    }
+    const launch = snapshotLaunch(candidate.launch);
+    validateDispatchInputs(identity, launch);
+    const launchMarkerPath = candidate.launchMarkerPath === undefined
+        ? launch.markerPath || ''
+        : snapshotRequiredString(candidate.launchMarkerPath, 'The tmux runtime request');
+    return {
+        launchMarkerPath,
+        createLaunchSpec: () => launch,
+    };
+}
+
+export function materializeResumeRequest(
+    request: AiSessionDeferredResumeRuntimeRequest
+): AiSessionMaterializedResumeRuntimeRequest {
+    const launch = snapshotLaunch(materializeAiSessionLaunchSpec(request));
+    validateDispatchInputs(request.identity, launch);
+    return {
+        identity: cloneAiSessionRuntimeIdentity(request.identity),
+        projectName: request.projectName,
+        sessionName: request.sessionName,
+        terminalName: request.terminalName,
+        launchMarkerPath: request.launchMarkerPath,
+        launch,
+        directoryScope: request.directoryScope,
+    };
+}
+
+export function materializePendingRequest(
+    request: AiSessionDeferredCreateRuntimeRequest
+): AiSessionMaterializedCreateRuntimeRequest {
+    const launch = snapshotLaunch(materializeAiSessionLaunchSpec(request));
+    validateDispatchInputs(request.identity, launch);
+    return {
+        identity: cloneAiSessionRuntimeIdentity(request.identity),
+        projectName: request.projectName,
+        terminalName: request.terminalName,
+        createdAt: request.createdAt,
+        excludedSessionIds: [...request.excludedSessionIds],
+        ...(request.title === undefined ? {} : { title: request.title }),
+        launchMarkerPath: request.launchMarkerPath,
+        launch,
+        directoryScope: request.directoryScope,
+    };
+}
+
+function snapshotResumeIdentity(value: unknown): AiSessionResumeRuntimeRequest['identity'] {
+    if (!isRecordShape(value)) {
+        throw new Error('The tmux runtime request shape is invalid.');
+    }
+    const provider = snapshotRequiredString(value.provider, 'The tmux runtime request');
+    const workspaceScopeIdentity = snapshotRequiredString(value.workspaceScopeIdentity, 'The tmux runtime request');
+    const workspaceNavigationIdentity = snapshotRequiredString(
+        value.workspaceNavigationIdentity, 'The tmux runtime request'
+    );
+    const workspaceRootHostPaths = snapshotDenseStringArray(value.workspaceRootHostPaths,
+        MAX_EXCLUDED_SESSION_IDS, 'workspace root paths', 'The tmux runtime request');
+    const cwd = snapshotRequiredString(value.cwd, 'The tmux runtime request');
+    const sessionId = snapshotRequiredString(value.sessionId, 'The tmux runtime request');
+    return {
+        provider: provider as AiSessionResumeRuntimeRequest['identity']['provider'],
+        workspaceScopeIdentity,
+        workspaceNavigationIdentity,
+        workspaceRootHostPaths,
+        cwd,
+        sessionId,
+    };
+}
+
+function snapshotPendingIdentity(value: unknown): AiSessionCreateRuntimeRequest['identity'] {
+    if (!isRecordShape(value)) {
+        throw new Error('The pending runtime request shape is invalid.');
+    }
+    const provider = snapshotRequiredString(value.provider, 'The pending runtime request');
+    const workspaceScopeIdentity = snapshotRequiredString(value.workspaceScopeIdentity, 'The pending runtime request');
+    const workspaceNavigationIdentity = snapshotRequiredString(
+        value.workspaceNavigationIdentity, 'The pending runtime request'
+    );
+    const workspaceRootHostPaths = snapshotDenseStringArray(value.workspaceRootHostPaths,
+        MAX_EXCLUDED_SESSION_IDS, 'workspace root paths', 'The pending runtime request');
+    const cwd = snapshotRequiredString(value.cwd, 'The pending runtime request');
+    const pendingId = snapshotRequiredString(value.pendingId, 'The pending runtime request');
+    return {
+        provider: provider as AiSessionCreateRuntimeRequest['identity']['provider'],
+        workspaceScopeIdentity,
+        workspaceNavigationIdentity,
+        workspaceRootHostPaths,
+        cwd,
+        pendingId,
+    };
+}
+
+function snapshotRequiredString(value: unknown, owner: string): string {
+    if (typeof value !== 'string') {
+        throw new Error(`${owner} shape is invalid.`);
+    }
+    return value;
+}
+
+function snapshotOptionalString(value: unknown, owner: string): string | undefined {
+    return value === undefined ? undefined : snapshotRequiredString(value, owner);
+}
+
+function snapshotDisplayName(value: unknown, fallback: string, owner: string): string {
+    const candidate = value === undefined ? fallback : snapshotRequiredString(value, owner);
+    if (candidate.length > 200 || LOCAL_CONTROL_CHARACTERS.test(candidate)) {
+        throw new Error(`${owner} display name is invalid.`);
+    }
+    return candidate;
+}
+
+function snapshotDenseStringArray(
+    value: unknown,
+    maximum: number,
+    label: string,
+    owner: string
+): string[] {
+    if (!Array.isArray(value)) {
+        throw new Error(`${owner} ${label} must be an array.`);
+    }
+    const length = value.length;
+    if (!Number.isSafeInteger(length) || length > maximum) {
+        throw new Error(`${owner} has too many ${label}; the ${label} count is too large.`);
+    }
+    const snapshot: string[] = [];
+    for (let index = 0; index < length; index++) {
+        if (!Object.prototype.hasOwnProperty.call(value, index)) {
+            throw new Error(`${owner} requires dense ${label}.`);
+        }
+        const item = value[index];
+        if (typeof item !== 'string') {
+            throw new Error(`${owner} requires dense ${label}.`);
+        }
+        snapshot.push(item);
+    }
+    return snapshot;
+}
+
+function isRecordShape(value: unknown): value is Record<string, unknown> {
+    return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function validateDispatchInputs(
+    identity: AiSessionRuntimeIdentity,
+    launch: AiSessionLaunchSpec
+): void {
+    validateDispatchIdentity(identity);
+    validateLaunchInputs(identity, launch);
+}
+
+export function validateDispatchIdentity(identity: AiSessionRuntimeIdentity): void {
+    if (!identity || !isValidAiSessionRuntimeIdentity(identity)) {
+        throw new Error('The tmux runtime cwd is invalid.');
+    }
+    const hasSessionId = identity.sessionId !== undefined;
+    const hasPendingId = identity.pendingId !== undefined;
+    if ((identity.provider !== 'codex' && identity.provider !== 'kimi' && identity.provider !== 'claude')
+        || hasSessionId === hasPendingId
+        || !isIdentityField(hasSessionId ? identity.sessionId : identity.pendingId)) {
+        throw new Error('The tmux runtime identity is invalid.');
+    }
+}
+
+function validateLaunchInputs(
+    identity: AiSessionRuntimeIdentity,
+    launch: AiSessionLaunchSpec
+): void {
+    if (!launch || typeof launch.executable !== 'string' || !launch.executable
+        || launch.executable.length > MAX_EXECUTABLE_LENGTH
+        || LOCAL_CONTROL_CHARACTERS.test(launch.executable)) {
+        throw new Error('The provider executable is invalid.');
+    }
+    if (!Array.isArray(launch.args) || launch.args.length > MAX_LAUNCH_ARGUMENTS
+        || launch.args.some(argument => typeof argument !== 'string'
+            || Buffer.byteLength(argument, 'utf8') > MAX_LAUNCH_ARGUMENT_BYTES
+            || argument.indexOf('\0') !== -1)) {
+        throw new Error('A provider launch argument is invalid or too large.');
+    }
+    if (launch.cwd !== undefined && !isLocalPath(launch.cwd)) {
+        throw new Error('The provider launch cwd is invalid.');
+    }
+    if (launch.markerPath !== undefined && !isLocalPath(launch.markerPath)) {
+        throw new Error('The provider marker path is invalid.');
+    }
+    if (launch.windowsDirectShell !== undefined
+        && launch.windowsDirectShell !== 'current' && launch.windowsDirectShell !== 'powershell') {
+        throw new Error('The provider launch shell is invalid.');
+    }
+    const aggregateBytes = [
+        identity.cwd,
+        launch.executable,
+        ...launch.args,
+        launch.cwd || '',
+        launch.markerPath || '',
+    ].reduce((total, value) => total + Buffer.byteLength(value, 'utf8'), 0);
+    if (aggregateBytes > MAX_AGGREGATE_LAUNCH_BYTES) {
+        throw new Error('The provider launch exceeds the aggregate launch budget.');
+    }
+    if (Buffer.byteLength(serializeTmuxLaunchCommand(launch), 'utf8')
+        > MAX_SERIALIZED_TMUX_COMMAND_BYTES) {
+        throw new Error('The serialized provider launch exceeds the tmux command budget.');
+    }
+}
+
+export function isIdentityField(value: unknown): value is string {
+    return typeof value === 'string' && value.length > 0 && value.length <= MAX_IDENTITY_FIELD_LENGTH
+        && !LOCAL_CONTROL_CHARACTERS.test(value);
+}
+
+export function isLocalPath(value: unknown): value is string {
+    return typeof value === 'string' && value.length > 0 && value.length <= MAX_LOCAL_PATH_LENGTH
+        && !LOCAL_CONTROL_CHARACTERS.test(value);
+}
+
+export function isBoundedOptionalLocalPath(value: unknown): value is string {
+    return typeof value === 'string' && value.length <= MAX_LOCAL_PATH_LENGTH
+        && !LOCAL_CONTROL_CHARACTERS.test(value);
+}

--- a/tests/unit/aiSessions/tmuxRuntimeRequest.test.js
+++ b/tests/unit/aiSessions/tmuxRuntimeRequest.test.js
@@ -1,0 +1,327 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {
+    isBoundedOptionalLocalPath,
+    isIdentityField,
+    isLocalPath,
+    materializePendingRequest,
+    materializeResumeRequest,
+    snapshotPendingRequest,
+    snapshotResumeRequest,
+    validateDispatchIdentity,
+} = require('../../../out/aiSessions/tmuxRuntimeRequest');
+
+function directoryScope() {
+    return {
+        workspaceNavigationIdentity: 'navigation:fixture', workspaceScopeIdentity: 'scope:fixture',
+        workspaceRootHostPaths: ['/work/a'], primaryRootId: 'root:fixture', primaryCwd: '/work/a',
+        additionalDirectories: [],
+    };
+}
+
+function resumeIdentity(overrides = {}) {
+    return {
+        provider: 'codex',
+        workspaceScopeIdentity: 'scope-a',
+        workspaceNavigationIdentity: 'navigation-a',
+        workspaceRootHostPaths: ['/work/a'],
+        cwd: '/work/a',
+        sessionId: 'session-123456789',
+        ...overrides,
+    };
+}
+
+function pendingIdentity(overrides = {}) {
+    return {
+        provider: 'kimi',
+        workspaceScopeIdentity: 'scope-a',
+        workspaceNavigationIdentity: 'navigation-a',
+        workspaceRootHostPaths: ['/work/a'],
+        cwd: '/work/a',
+        pendingId: 'pending-123456789',
+        ...overrides,
+    };
+}
+
+function launch(overrides = {}) {
+    return {
+        executable: 'provider-tool',
+        args: ['--flag', 'value'],
+        ...overrides,
+    };
+}
+
+function resumeRequest(overrides = {}) {
+    return {
+        identity: resumeIdentity(),
+        projectName: 'Project Alpha',
+        sessionName: 'Fix replication',
+        terminalName: 'Agent Pivot: codex',
+        directoryScope: directoryScope(),
+        launch: launch(),
+        ...overrides,
+    };
+}
+
+function pendingRequest(overrides = {}) {
+    return {
+        identity: pendingIdentity(),
+        projectName: 'Project Alpha',
+        terminalName: 'Agent Pivot: kimi',
+        createdAt: '2026-01-02T03:04:05.000Z',
+        excludedSessionIds: ['session-old-1', 'session-old-2'],
+        directoryScope: directoryScope(),
+        launch: launch(),
+        ...overrides,
+    };
+}
+
+test('RUNTIME-TMUX-BACKEND-001 snapshots resume and pending requests through happy paths', () => {
+    const request = resumeRequest();
+    const deferred = snapshotResumeRequest(request);
+    assert.deepEqual(deferred.identity, resumeIdentity());
+    assert.notEqual(deferred.identity, request.identity);
+    assert.notEqual(deferred.identity.workspaceRootHostPaths, request.identity.workspaceRootHostPaths);
+    assert.equal(deferred.projectName, 'Project Alpha');
+    assert.equal(deferred.sessionName, 'Fix replication');
+    assert.equal(deferred.terminalName, 'Agent Pivot: codex');
+    assert.equal(deferred.launchMarkerPath, '');
+    assert.equal(deferred.directoryScope, request.directoryScope);
+    assert.deepEqual(deferred.createLaunchSpec(), launch());
+
+    const pending = pendingRequest({ title: 'Triage alerts' });
+    const deferredPending = snapshotPendingRequest(pending);
+    assert.deepEqual(deferredPending.identity, pendingIdentity());
+    assert.equal(deferredPending.createdAt, '2026-01-02T03:04:05.000Z');
+    assert.deepEqual(deferredPending.excludedSessionIds, ['session-old-1', 'session-old-2']);
+    assert.notEqual(deferredPending.excludedSessionIds, pending.excludedSessionIds);
+    assert.equal(deferredPending.title, 'Triage alerts');
+    assert.equal(deferredPending.directoryScope, pending.directoryScope);
+    assert.deepEqual(deferredPending.createLaunchSpec(), launch());
+
+    const untitled = snapshotPendingRequest(pendingRequest());
+    assert.equal(Object.prototype.hasOwnProperty.call(untitled, 'title'), false);
+});
+
+test('RUNTIME-TMUX-BACKEND-001 falls back to the session id for display names and bounds them', () => {
+    const deferred = snapshotResumeRequest(resumeRequest({ sessionName: undefined }));
+    assert.equal(deferred.sessionName, 'session-123456789');
+    assert.throws(
+        () => snapshotResumeRequest(resumeRequest({ sessionName: 'x'.repeat(201) })),
+        /display name is invalid/
+    );
+    assert.throws(
+        () => snapshotResumeRequest(resumeRequest({ sessionName: 'bad\u0007name' })),
+        /display name is invalid/
+    );
+    assert.throws(
+        () => snapshotResumeRequest(resumeRequest({ sessionName: 42 })),
+        /shape is invalid/
+    );
+});
+
+test('RUNTIME-TMUX-BACKEND-001 rejects non-record requests, identities, and launches', () => {
+    assert.throws(() => snapshotResumeRequest(null), /shape is invalid/);
+    assert.throws(() => snapshotResumeRequest(['not', 'a', 'record']), /shape is invalid/);
+    assert.throws(() => snapshotPendingRequest('nope'), /shape is invalid/);
+    assert.throws(() => snapshotResumeRequest(resumeRequest({ identity: null })), /shape is invalid/);
+    assert.throws(() => snapshotPendingRequest(pendingRequest({ identity: ['bad'] })), /shape is invalid/);
+    assert.throws(() => snapshotResumeRequest(resumeRequest({ launch: 42 })), /shape is invalid/);
+    assert.throws(() => snapshotResumeRequest(resumeRequest({ projectName: 7 })), /shape is invalid/);
+    assert.throws(() => snapshotPendingRequest(pendingRequest({ createdAt: undefined })), /shape is invalid/);
+    assert.throws(() => snapshotPendingRequest(pendingRequest({ title: 9 })), /shape is invalid/);
+});
+
+test('RUNTIME-TMUX-BACKEND-001 requires dense bounded string arrays', () => {
+    const sparse = ['a', , 'b'];
+    assert.throws(() => snapshotResumeRequest(resumeRequest({ launch: launch({ args: sparse }) })), /dense/);
+    assert.throws(
+        () => snapshotResumeRequest(resumeRequest({ launch: launch({ args: ['a', 1] }) })),
+        /dense/
+    );
+    assert.throws(
+        () => snapshotResumeRequest(resumeRequest({ launch: launch({ args: 'nope' }) })),
+        /must be an array/
+    );
+    assert.throws(
+        () => snapshotResumeRequest(resumeRequest({ launch: launch({ args: new Array(257).fill('a') }) })),
+        /too many/
+    );
+    assert.throws(
+        () => snapshotPendingRequest(pendingRequest({ excludedSessionIds: new Array(1001).fill('s') })),
+        /too many/
+    );
+    const sparseExclusions = ['a', , 'b'];
+    assert.throws(
+        () => snapshotPendingRequest(pendingRequest({ excludedSessionIds: sparseExclusions })),
+        /dense/
+    );
+});
+
+test('RUNTIME-TMUX-BACKEND-001 honors the createLaunchSpec function path', () => {
+    const request = resumeRequest();
+    delete request.launch;
+    request.launchMarkerPath = '/tmp/marker';
+    const factory = () => ({ executable: 'fn-tool', args: ['run'] });
+    request.createLaunchSpec = factory;
+    const deferred = snapshotResumeRequest(request);
+    assert.equal(deferred.launchMarkerPath, '/tmp/marker');
+    assert.equal(deferred.createLaunchSpec, factory);
+    assert.throws(() => {
+        const invalid = resumeRequest();
+        delete invalid.launch;
+        invalid.createLaunchSpec = factory;
+        snapshotResumeRequest(invalid);
+    }, /launch marker is invalid/);
+});
+
+test('RUNTIME-TMUX-BACKEND-001 resolves launchMarkerPath fallback and explicit override', () => {
+    const fromMarker = snapshotResumeRequest(resumeRequest({ launch: launch({ markerPath: '/tmp/m' }) }));
+    assert.equal(fromMarker.launchMarkerPath, '/tmp/m');
+    const override = snapshotResumeRequest(resumeRequest({
+        launch: launch({ markerPath: '/tmp/m' }),
+        launchMarkerPath: '/tmp/override',
+    }));
+    assert.equal(override.launchMarkerPath, '/tmp/override');
+    assert.throws(
+        () => snapshotResumeRequest(resumeRequest({ launch: launch(), launchMarkerPath: 42 })),
+        /shape is invalid/
+    );
+});
+
+test('RUNTIME-TMUX-BACKEND-001 materializes deferred requests with cloned identities', () => {
+    const deferred = snapshotResumeRequest(resumeRequest({ launch: launch({ markerPath: '/tmp/m' }) }));
+    const materialized = materializeResumeRequest(deferred);
+    assert.equal(materialized.launchMarkerPath, '/tmp/m');
+    assert.deepEqual(materialized.launch, launch({ markerPath: '/tmp/m' }));
+    assert.deepEqual(materialized.identity, deferred.identity);
+    assert.notEqual(materialized.identity, deferred.identity);
+    assert.equal(materialized.sessionName, 'Fix replication');
+
+    const deferredPending = snapshotPendingRequest(pendingRequest({ title: 'Triage' }));
+    const materializedPending = materializePendingRequest(deferredPending);
+    assert.deepEqual(materializedPending.launch, launch());
+    assert.deepEqual(materializedPending.excludedSessionIds, ['session-old-1', 'session-old-2']);
+    assert.notEqual(materializedPending.excludedSessionIds, deferredPending.excludedSessionIds);
+    assert.equal(materializedPending.title, 'Triage');
+    assert.notEqual(materializedPending.identity, deferredPending.identity);
+});
+
+test('RUNTIME-TMUX-BACKEND-001 rejects launch specs whose marker changes before dispatch', () => {
+    const deferred = snapshotResumeRequest(resumeRequest({ launch: launch({ markerPath: '/tmp/m' }) }));
+    const tampered = {
+        ...deferred,
+        createLaunchSpec: () => launch({ markerPath: '/tmp/other' }),
+    };
+    assert.throws(() => materializeResumeRequest(tampered), /marker changed before dispatch/);
+    const tamperedPending = {
+        ...snapshotPendingRequest(pendingRequest()),
+        createLaunchSpec: () => launch({ markerPath: '/tmp/other' }),
+    };
+    assert.throws(() => materializePendingRequest(tamperedPending), /marker changed before dispatch/);
+});
+
+test('RUNTIME-TMUX-BACKEND-001 validates executable, arguments, cwd, and marker paths', () => {
+    assert.throws(
+        () => snapshotResumeRequest(resumeRequest({ launch: launch({ executable: '' }) })),
+        /provider executable is invalid/
+    );
+    assert.throws(
+        () => snapshotResumeRequest(resumeRequest({ launch: launch({ executable: 'bad\u000aexec' }) })),
+        /provider executable is invalid/
+    );
+    assert.throws(
+        () => snapshotResumeRequest(resumeRequest({ launch: launch({ executable: 'x'.repeat(4097) }) })),
+        /provider executable is invalid/
+    );
+    assert.throws(
+        () => snapshotResumeRequest(resumeRequest({ launch: launch({ args: ['a'.repeat(16 * 1024 + 1)] }) })),
+        /launch argument is invalid or too large/
+    );
+    assert.throws(
+        () => snapshotResumeRequest(resumeRequest({ launch: launch({ args: ['nul\u0000byte'] }) })),
+        /launch argument is invalid or too large/
+    );
+    assert.throws(
+        () => snapshotResumeRequest(resumeRequest({ launch: launch({ cwd: 'bad\u0007cwd' }) })),
+        /provider launch cwd is invalid/
+    );
+    assert.throws(
+        () => snapshotResumeRequest(resumeRequest({ launch: launch({ markerPath: 'bad\u0007marker' }) })),
+        /provider marker path is invalid/
+    );
+    assert.throws(
+        () => snapshotResumeRequest(resumeRequest({ launch: launch({ windowsDirectShell: 'zsh' }) })),
+        /shape is invalid/
+    );
+    const shell = snapshotResumeRequest(resumeRequest({ launch: launch({ windowsDirectShell: 'powershell' }) }));
+    assert.equal(shell.createLaunchSpec().windowsDirectShell, 'powershell');
+});
+
+test('RUNTIME-TMUX-BACKEND-001 enforces aggregate and serialized launch budgets', () => {
+    const wide = launch({ args: new Array(250).fill('a'.repeat(200)) });
+    assert.throws(
+        () => snapshotResumeRequest(resumeRequest({ launch: wide })),
+        /aggregate launch budget/
+    );
+    const quoted = launch({ args: new Array(230).fill("'".repeat(130)) });
+    assert.throws(
+        () => snapshotResumeRequest(resumeRequest({ launch: quoted })),
+        /serialized provider launch exceeds the tmux command budget/
+    );
+});
+
+test('RUNTIME-TMUX-BACKEND-001 validates dispatch identity shape and whitelist', () => {
+    assert.doesNotThrow(() => validateDispatchIdentity(resumeIdentity()));
+    assert.doesNotThrow(() => validateDispatchIdentity(pendingIdentity()));
+    assert.throws(() => validateDispatchIdentity(null), /cwd is invalid/);
+    assert.throws(
+        () => validateDispatchIdentity(resumeIdentity({ provider: 'other' })),
+        /cwd is invalid/
+    );
+    assert.throws(
+        () => validateDispatchIdentity(resumeIdentity({ pendingId: 'pending-1' })),
+        /cwd is invalid/
+    );
+    assert.throws(
+        () => validateDispatchIdentity(resumeIdentity({ sessionId: undefined })),
+        /cwd is invalid/
+    );
+    assert.throws(
+        () => validateDispatchIdentity(resumeIdentity({ sessionId: 'has space' })),
+        /cwd is invalid/
+    );
+    assert.throws(
+        () => validateDispatchIdentity(resumeIdentity({ cwd: 'bad\u0007cwd' })),
+        /cwd is invalid/
+    );
+    assert.throws(
+        () => snapshotResumeRequest(resumeRequest({ identity: resumeIdentity({ sessionId: 'bad id' }) })),
+        /cwd is invalid/
+    );
+});
+
+test('RUNTIME-TMUX-BACKEND-001 bounds identity fields and local paths', () => {
+    assert.equal(isIdentityField('session-1'), true);
+    assert.equal(isIdentityField(''), false);
+    assert.equal(isIdentityField('x'.repeat(512)), true);
+    assert.equal(isIdentityField('x'.repeat(513)), false);
+    assert.equal(isIdentityField('bad\u000afield'), false);
+    assert.equal(isIdentityField(42), false);
+
+    assert.equal(isLocalPath('/tmp/marker'), true);
+    assert.equal(isLocalPath(''), false);
+    assert.equal(isLocalPath('x'.repeat(4096)), true);
+    assert.equal(isLocalPath('x'.repeat(4097)), false);
+    assert.equal(isLocalPath('bad\u0007path'), false);
+    assert.equal(isLocalPath(undefined), false);
+
+    assert.equal(isBoundedOptionalLocalPath(''), true);
+    assert.equal(isBoundedOptionalLocalPath('/tmp/marker'), true);
+    assert.equal(isBoundedOptionalLocalPath('x'.repeat(4096)), true);
+    assert.equal(isBoundedOptionalLocalPath('x'.repeat(4097)), false);
+    assert.equal(isBoundedOptionalLocalPath('bad\u0007path'), false);
+    assert.equal(isBoundedOptionalLocalPath(undefined), false);
+});


### PR DESCRIPTION
## What

Pure-move slice from the tmux backend decomposition plan: the deferred runtime request snapshotting and validation lived as **19 module-level pure functions + 9 bound constants** inside `tmuxRuntimeBackend.ts`, none touching instance state. They move verbatim into the new `src/aiSessions/tmuxRuntimeRequest.ts`; the backend keeps only runtime lifecycle and dispatch machinery and resolves call sites through one import.

- `tmuxRuntimeBackend.ts`: 2490 → 2170 lines (−320; the only added lines are the import block)
- `tmuxRuntimeRequest.ts`: +336 (9 constants + 19 functions, 8 exported, original relative order preserved)
- Dead code removed after zero-reference grep proof: `getFinalLocator`, `pendingIdentityConflictError` (and their sole `tmuxLayout` type imports)
- `LOCAL_CONTROL_CHARACTERS` deliberately re-declared in both files (repo convention: per-file declaration, also in tmuxClient/tmuxRuntimeBindingStore/tmuxLayout)

## Why this is the safest slice class

- Zero source-text assertions pin the moved functions (verified repo-wide after #87); nothing to re-point
- All existing behavioral suites protect the logic unchanged: tmux checks' 429-assert adversarial `runTmuxBackendChecks` (Proxy/sparse/budget/identity rejection matrices driving the public `ensureResume`/`ensurePending` entries), runtimeComposition production-activation cases
- No error message text touched (checks pin them by regex)

## Coverage gate

New `tests/unit/aiSessions/tmuxRuntimeRequest.test.js` (12 tests, RUNTIME-TMUX-BACKEND-001 co-owner) pins the validation matrix so the moved lines keep coverage: new module at **98.8% lines / 96.5% branch / 100% funcs**. Changed-line gate: **98.84% (342/346)** — the 4 uncovered lines are provably unreachable defensive throws (preconditions fully implied by upstream shape validation), preserved verbatim per pure-move discipline.

## Verification

- Full `test:ci:linux`: 1438 tests green, all baselines pass
- `test:tmux` (1390+ asserts), runtimeComposition + runtimeBackends 43/43, behavior-contracts, lint baselines: all pass

## Harvest

No skill change justified this cycle: the slice plan executed without friction, corrections, or retries.