### PR TITLE
fix: surface Kimi plan mode content in the conversation viewer

### DIFF
--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "aad818ca16f8e299769f65bc2955859d3428bc25",
+        "head": "5a0de3623b5d407c688a5b7fd6bbffee7cdac1b0",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -78,7 +78,8 @@
             "05edca8119b9a471cbcd32f287144cebe7ebae08",
             "0e0016d9449d61753fe3f30711656cad881b12a6",
             "5efaa7ae0901f8da52b8211cccbf37386ee51498",
-            "87a2dd62f5218f294e81568fc100d6e50b91f72f"
+            "87a2dd62f5218f294e81568fc100d6e50b91f72f",
+            "6e45a30bbf7c1bd91a4bc0c67c32b359922cbd76"
         ]
     },
     "capabilities": [
@@ -1082,7 +1083,8 @@
                 "06cb9f4375a9e10e3629a113f6e9cf239cce2156",
                 "95248ccfca2df7faa03edf29b976d9f2a5117bae",
                 "65311abfd2623d28189e29d25bd662ab728d3912",
-                "312bd9b7d13b4f7c3aa414a4830acb0e8cdb72d8"
+                "312bd9b7d13b4f7c3aa414a4830acb0e8cdb72d8",
+                "5a0de3623b5d407c688a5b7fd6bbffee7cdac1b0"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",

--- a/src/aiSessions/conversation/kimiAdapter.ts
+++ b/src/aiSessions/conversation/kimiAdapter.ts
@@ -377,6 +377,16 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                                 .assistantMarkdown.push(text);
                         }
                     }
+                } else if (event.type === 'PlanDisplay') {
+                    const payload = asRecord(event.payload);
+                    if (openInteractionIndex !== undefined
+                        && typeof payload?.content === 'string') {
+                        const content = visibleMessage(payload.content);
+                        if (content) {
+                            interactions[openInteractionIndex]
+                                .assistantMarkdown.push(content);
+                        }
+                    }
                 } else if (event.type === 'StatusUpdate') {
                     const payload = asRecord(event.payload);
                     const usedTokens = Number(payload?.context_tokens);

--- a/tests/contract/aiSessions/kimiConversationAdapter.test.js
+++ b/tests/contract/aiSessions/kimiConversationAdapter.test.js
@@ -125,6 +125,94 @@ test('SESSION-AI-SESSION-CONVERSATION-ADAPTER-001 Kimi normalizes only visible t
     assert.equal(new Set(appended.interactions.map(item => item.id)).size, 4);
 });
 
+test('SESSION-AI-SESSION-CONVERSATION-ADAPTER-001 Kimi surfaces PlanDisplay markdown as assistant content', async t => {
+    const source = await createFixture(t);
+    await fs.promises.writeFile(source.sourcePath, [
+        {
+            timestamp: 1000,
+            message: {
+                type: 'TurnBegin',
+                payload: { user_input: 'Draft a rollout plan' },
+            },
+        },
+        {
+            timestamp: 1001,
+            message: {
+                type: 'PlanDisplay',
+                payload: { content: '# Rollout Plan\n\n## v1 steps' },
+            },
+        },
+        {
+            timestamp: 1002,
+            message: {
+                type: 'ContentPart',
+                payload: { type: 'text', text: 'I revised the plan.' },
+            },
+        },
+        {
+            timestamp: 1003,
+            message: {
+                type: 'PlanDisplay',
+                payload: { content: '# Rollout Plan\n\n## v2 steps' },
+            },
+        },
+        {
+            timestamp: 1004,
+            message: { type: 'TurnEnd', payload: {} },
+        },
+        {
+            timestamp: 1005,
+            message: {
+                type: 'PlanDisplay',
+                payload: { content: '# Orphan plan without an open turn' },
+            },
+        },
+        {
+            timestamp: 1006,
+            message: {
+                type: 'TurnBegin',
+                payload: { user_input: 'Ignore malformed plan payloads' },
+            },
+        },
+        {
+            timestamp: 1007,
+            message: {
+                type: 'PlanDisplay',
+                payload: { content: 42 },
+            },
+        },
+        {
+            timestamp: 1008,
+            message: { type: 'TurnEnd', payload: {} },
+        },
+    ].map(record => JSON.stringify(record)).join('\n') + '\n');
+    const adapter = createAdapter(source);
+    t.after(() => adapter.dispose());
+
+    const outline = await adapter.readOutline(sessionId);
+    assert.deepEqual(
+        outline.interactions.map(interaction => interaction.userPreview),
+        ['Draft a rollout plan', 'Ignore malformed plan payloads']
+    );
+    const page = await adapter.readPage({
+        provider: 'kimi',
+        sessionId,
+        anchorInteractionId: outline.interactions[0].id,
+        direction: 'around',
+        expectedRevision: outline.sourceRevision,
+    });
+    assert.deepEqual(
+        page.messages.map(message => [message.role, message.markdown]),
+        [
+            ['user', 'Draft a rollout plan'],
+            ['assistant', '# Rollout Plan\n\n## v1 steps'],
+            ['assistant', 'I revised the plan.'],
+            ['assistant', '# Rollout Plan\n\n## v2 steps'],
+            ['user', 'Ignore malformed plan payloads'],
+        ]
+    );
+});
+
 test('SESSION-AI-SESSION-KIMI-CONVERSATION-002 deduplicates a reread and changes offset identity after source reset', async t => {
     const source = await createFixture(t);
     const adapter = createAdapter(source);


### PR DESCRIPTION
## 问题

Kimi CLI 的 plan mode 输出以专用 `PlanDisplay` wire 事件记录（而非 `ContentPart:text`),Kimi 会话解析器不识别该事件类型，导致 plan 正文在 AI conversation 查看器中被整体丢弃——plan mode 回合几乎只剩一句过渡语。Claude 不受影响（Claude Code 把 plan 当普通 text block 记录）。

## 修复

`kimiAdapter.ts` 的 `normalizeRecord` 新增 `PlanDisplay` 分支：有 open turn 且 `payload.content` 为字符串时，经 `visibleMessage` 归一化后按到达顺序推入 `assistantMarkdown`,与 `ContentPart:text` 分支同构。同一回合的多个 plan 版本（初版/修订版）按序各成一条 assistant 消息；无 open turn 的孤儿事件与畸形 payload 继续忽略。`ContentPart:think` 等排除规则不变。

## 验证

- 新契约测试（归入既有 `SESSION-AI-SESSION-CONVERSATION-ADAPTER-001`)：两版 plan 按序呈现、夹在 text chunk 之间位置正确、孤儿/畸形 PlanDisplay 被忽略
- 真实 plan mode 会话（28KB plan)验证：修复前 assistant 侧仅 50 字符过渡句，修复后两版 plan(26.5KB/21.3KB)完整呈现
- `npm run test:ci:linux` 全绿，变更行覆盖率 100%(10/10)
- 能力审计：实现 commit 归入 `MAIN-AI-SESSION-CONVERSATION-OUTLINE`