### PR TITLE
refactor: tmux promotion lifecycle + attention event capability slices

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -1490,6 +1490,7 @@
     "status": "automated",
     "owners": [
       "tests/contract/aiSessions/runtimeBackends.test.js",
+      "tests/contract/aiSessions/tmuxPromotion.test.js",
       "tests/unit/aiSessions/tmuxRuntimeRequest.test.js"
     ],
     "evidence": [

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -1077,12 +1077,16 @@
       "tests/contract/aiSessions/attention.test.js"
     ,
       "tests/contract/aiSessions/runtimeSettlement.test.js"
+    ,
+      "tests/contract/aiSessions/attentionEventCapability.test.js"
     ],
     "evidence": [
       "src/aiSessions/attentionEvaluationQueue.ts",
       "src/aiSessions/executionController.ts"
     ,
       "src/aiSessions/runtimeSettlementCapability.ts"
+    ,
+      "src/aiSessions/attentionEventCapability.ts"
     ]
   },
   {
@@ -3064,10 +3068,14 @@
     "owners": [
       "tests/contract/aiSessions/attention.test.js",
       "tests/integration/dashboard/terminalCloseWiring.test.js"
+    ,
+      "tests/contract/aiSessions/attentionEventCapability.test.js"
     ],
     "evidence": [
       "src/aiSessions/attentionController.ts",
       "src/dashboard.ts"
+    ,
+      "src/aiSessions/attentionEventCapability.ts"
     ]
   },
   {
@@ -3096,11 +3104,15 @@
     "status": "automated",
     "owners": [
       "tests/integration/dashboard/terminalCloseWiring.test.js"
+    ,
+      "tests/contract/aiSessions/attentionEventCapability.test.js"
     ],
     "evidence": [
       "src/dashboard.ts"
     ,
       "src/aiSessions/runtimeSettlementCapability.ts"
+    ,
+      "src/aiSessions/attentionEventCapability.ts"
     ]
   },
   {

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "37de455ba64a9e1c29d27892b2a2ad5a4b2ad0a0",
+        "head": "b3af83ee68f9eac78dcf7c0f49d6401494b1884c",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -81,7 +81,8 @@
             "87a2dd62f5218f294e81568fc100d6e50b91f72f",
             "6e45a30bbf7c1bd91a4bc0c67c32b359922cbd76",
             "f596e75c38c30f2d86feb0957b94e7937292a40f",
-            "674cb34c5c5b6dd1c3513dff1ef37ba3f41e1705"
+            "674cb34c5c5b6dd1c3513dff1ef37ba3f41e1705",
+            "81f78f0214e71c4dae081407445434a92049f865"
         ]
     },
     "capabilities": [
@@ -647,7 +648,9 @@
                 "289779463fe347fba05bd3655ceded5189612f44",
                 "eb60d0cc5b8aaa9e3f04d797f4d790f40999e378",
                 "9ceb5a4ca604119a69486449699c263f96218c21",
-                "546f4b2cb06f295d72576299dd4bcef358b73eff"
+                "546f4b2cb06f295d72576299dd4bcef358b73eff",
+                "1f210dccb8ef768656ebcf513bb7e04b75f83c8d",
+                "b3af83ee68f9eac78dcf7c0f49d6401494b1884c"
             ],
             "behaviors": [
                 "ATTENTION-ACTIVE-UNREGISTER-ON-DEACTIVATE-001",
@@ -760,7 +763,8 @@
                 "892ae70669ed4b08f452f70f3539eed665f3c555",
                 "69c490edf6d6d483e0694bc28d78862edba43334",
                 "4b2790d284a5b45fd4b69308acb83f696b2267cb",
-                "aad818ca16f8e299769f65bc2955859d3428bc25"
+                "aad818ca16f8e299769f65bc2955859d3428bc25",
+                "cf9022357308f9a5a45f8cf5523ce6a9cb94bd6d"
             ],
             "behaviors": [
                 "RUNTIME-TMUX-BACKEND-001",
@@ -909,7 +913,8 @@
                 "a7d19fab7170c68e550e3395e104b178de6b35d6",
                 "c982f07c1ab89e22ef859e30399766bcd6ee5029",
                 "e11079d10e1dc321532205b445705799875dc5a6",
-                "37de455ba64a9e1c29d27892b2a2ad5a4b2ad0a0"
+                "37de455ba64a9e1c29d27892b2a2ad5a4b2ad0a0",
+                "4b09fd45d1e3461493b9a4f279d31401da44f853"
             ],
             "behaviors": [
                 "ARCH-CI-QUALITY-GATE-001",

--- a/scripts/run-ai-session-safety-checks.js
+++ b/scripts/run-ai-session-safety-checks.js
@@ -4897,6 +4897,9 @@ function runWebviewContentChecks() {
     const runtimeSettlement = fs.readFileSync(
         path.join(__dirname, '..', 'src', 'aiSessions', 'runtimeSettlementCapability.ts'), 'utf8'
     );
+    const attentionEvents = fs.readFileSync(
+        path.join(__dirname, '..', 'src', 'aiSessions', 'attentionEventCapability.ts'), 'utf8'
+    );
     const messageHandlersSource = fs.readFileSync(
         path.join(__dirname, '..', 'src', 'dashboard', 'messageHandlers.ts'), 'utf8'
     );
@@ -5222,7 +5225,17 @@ function runWebviewContentChecks() {
     assert.ok(evaluateAttentionMonitorFunction.includes('signal.phase'));
     assert.ok(!dashboard.includes('function getEffectiveAiSessionAttentionAggregate('));
     assert.ok(!dashboard.includes('function getAiSessionAttentionRecoverySessionEvents('));
-    assert.ok(dashboard.includes('async function evaluateAiSessionAttention('));
+    assert.ok(dashboard.includes('createAiSessionAttentionEventCapability({'),
+        'the dashboard constructs the extracted attention event capability');
+    assert.ok(dashboard.includes(
+        "import { createAiSessionAttentionEventCapability } from './aiSessions/attentionEventCapability';"
+    ));
+    assert.ok(dashboard.includes('const evaluateAiSessionAttention = aiSessionAttentionEvent.evaluateAttention;'),
+        'the dashboard aliases the extracted attention evaluation');
+    assert.ok(dashboard.includes(
+        'const refreshAiSessionViewsIncrementally = aiSessionAttentionEvent.refreshViewsIncrementally;'
+    ), 'the dashboard aliases the extracted incremental refresh');
+    assert.ok(attentionEvents.includes('async function evaluateAiSessionAttention('));
     assert.ok(messageHandlersSource.includes("'open-settings': async () =>"));
     assert.ok(settingsFunction.includes('dashboardRuntimeController.openSettings()'));
     assert.ok(dashboardRuntimeControllerSource.includes("executeCommand('workbench.action.openSettings', query)"));
@@ -5276,8 +5289,10 @@ function runWebviewContentChecks() {
     assert.ok(dashboard.includes('new ActiveAiSessionTerminalHighlighter'));
     assert.ok(dashboard.includes('new TmuxFocusedRuntimeMonitor<vscode.Terminal>({'));
     assert.ok(dashboard.includes('tmuxFocusedRuntimeMonitor.start();'));
-    assert.ok((dashboard.match(/void tmuxFocusedRuntimeMonitor\.request\(\);/g) || []).length >= 2,
-        'view visibility and active-terminal changes must both request reconciliation');
+    assert.ok((dashboard.match(/void tmuxFocusedRuntimeMonitor\.request\(\);/g) || []).length >= 1,
+        'view visibility changes must request reconciliation');
+    assert.ok(attentionEvents.includes('void getTmuxFocusedRuntimeMonitor().request();'),
+        'active-terminal changes must request reconciliation through the extracted capability');
     assert.ok(dashboard.includes("logAiSessionRuntimeFailure('sync-focused-runtime', error)"));
     const tmuxMonitorOwnership = {
         variableName: 'tmuxFocusedRuntimeMonitor',
@@ -7262,8 +7277,9 @@ function runAiSessionIncrementalRefreshSourceChecks() {
 
     assert.ok(dashboard.includes('AI_SESSION_WATCHER_REFRESH_MIN_INTERVAL_MS'));
     assert.ok(dashboard.includes('watcherRefreshMinIntervalMs: AI_SESSION_WATCHER_REFRESH_MIN_INTERVAL_MS'));
-    const refreshFunction = extractFunctionBody(dashboard, 'refreshAiSessionViewsIncrementally');
-    assert.ok(refreshFunction.includes('aiSessionDashboardController.refreshNow()'));
+    assert.ok(dashboard.includes(
+        'const refreshAiSessionViewsIncrementally = aiSessionAttentionEvent.refreshViewsIncrementally;'
+    ), 'the incremental refresh alias must reach the extracted attention event capability');
     assert.ok(dashboard.includes('new WorkspaceSessionHydrationController<vscode.Terminal>({'));
     assert.ok(dashboard.includes('getCurrentWorkspaceAiSessions: workspace => workspaceSessionHydrationController.hydrate(workspace)'));
     const sessionControllerCompositionSource = fs.readFileSync(

--- a/scripts/run-ai-session-tmux-checks.js
+++ b/scripts/run-ai-session-tmux-checks.js
@@ -9645,8 +9645,6 @@ function runHostRuntimeCompositionChecks() {
     assert.ok(!dashboardSource.includes('isCommandAvailableOnPath'));
     assert.ok(!dashboardSource.includes('was not found on PATH'));
     assert.ok(dashboardSource.includes('runtimeCoordinator: aiSessionRuntimeCoordinator'));
-    assert.ok(dashboardSource.includes('getActiveRuntimes: () => aiSessionRuntimeCoordinator.getActive()'));
-    assert.ok(dashboardSource.includes('getPendingRuntimes: () => aiSessionRuntimeCoordinator.getPending()'));
     assert.ok(dashboardSource.includes('findTmuxCollisionRuntime('));
     assert.ok(compositionSource.includes('getRuntimeConflict: getAiSessionRuntimeCollision'));
     assert.ok(dashboardSource.includes('getFocusedAiSessionRuntimeIdentity()'));

--- a/scripts/run-ai-session-tmux-checks.js
+++ b/scripts/run-ai-session-tmux-checks.js
@@ -9645,13 +9645,16 @@ function runHostRuntimeCompositionChecks() {
     assert.ok(!dashboardSource.includes('isCommandAvailableOnPath'));
     assert.ok(!dashboardSource.includes('was not found on PATH'));
     assert.ok(dashboardSource.includes('runtimeCoordinator: aiSessionRuntimeCoordinator'));
-    assert.ok(dashboardSource.includes('findTmuxCollisionRuntime('));
+    const attentionEventSource = fs.readFileSync(
+        path.join(__dirname, '..', 'src', 'aiSessions', 'attentionEventCapability.ts'), 'utf8'
+    );
+    assert.ok(attentionEventSource.includes('findTmuxCollisionRuntime('));
     assert.ok(compositionSource.includes('getRuntimeConflict: getAiSessionRuntimeCollision'));
     assert.ok(dashboardSource.includes('getFocusedAiSessionRuntimeIdentity()'));
-    assert.ok(dashboardSource.includes('tmuxRuntimeBackend.getFocusedRuntime(activeTerminal)'));
+    assert.ok(attentionEventSource.includes('tmuxRuntimeBackend.getFocusedRuntime(activeTerminal)'));
     assert.ok(dashboardSource.includes('getAttachTerminalName: getAiSessionTmuxAttachTerminalName'));
     assert.ok(dashboardSource.includes('markerIsCurrent: isCurrentRuntimeMarker'));
-    assert.ok(dashboardSource.includes('await tmuxRuntimeDiscovery.loadPersistedInactive()'));
+    assert.ok(attentionEventSource.includes('await tmuxRuntimeDiscovery.loadPersistedInactive()'));
     assert.ok(!dashboardSource.includes(
         'getTerminalById: (providerId, sessionId) => aiSessionTerminalService.getActiveById'
     ));

--- a/scripts/run-architecture-guards.js
+++ b/scripts/run-architecture-guards.js
@@ -731,6 +731,7 @@ const guards = {
     'ARCH-AI-SESSION-FALLBACK-REASON-001'(root) {
         const risk = 'anonymous fallbacks and runtime-derived attention hide regressions and defeat diagnostics';
         const dashboard = parseTypescript(root, 'src/dashboard.ts', this.id, risk);
+        const attentionEvents = parseTypescript(root, 'src/aiSessions/attentionEventCapability.ts', this.id, risk);
         const attentionController = parseTypescript(
             root, 'src/aiSessions/attentionController.ts', this.id, risk
         );
@@ -741,8 +742,10 @@ const guards = {
             fail(this.id, risk,
                 'runtime completion must not be converted into, or used to suppress, attention');
         }
-        const lifecycleReasons = callArguments(dashboard, 'runSafeAiSessionRuntimeLifecycleTask')
-            .map(args => stringArgument(args[0]));
+        const lifecycleReasons = [
+            ...callArguments(dashboard, 'runSafeAiSessionRuntimeLifecycleTask'),
+            ...callArguments(attentionEvents, 'runSafeAiSessionRuntimeLifecycleTask'),
+        ].map(args => stringArgument(args[0]));
         if (!lifecycleReasons.includes('evaluate-attention-closed-terminal')) {
             fail(this.id, risk, 'terminal-close provider-event reconciliation must have an explicit diagnostic reason');
         }

--- a/scripts/run-workspace-parity-checks.js
+++ b/scripts/run-workspace-parity-checks.js
@@ -333,6 +333,9 @@ function runProductionWiringChecks() {
     const openWorkspaceDashboardSource = fs.readFileSync(
         path.join(root, 'src', 'openWorkspaces', 'dashboardController.ts'), 'utf8'
     );
+    const attentionEventSource = fs.readFileSync(
+        path.join(root, 'src', 'aiSessions', 'attentionEventCapability.ts'), 'utf8'
+    );
     const projectScriptsSource = fs.readFileSync(
         path.join(root, 'src', 'webview', 'webviewProjectScripts.js'), 'utf8'
     );
@@ -350,7 +353,7 @@ function runProductionWiringChecks() {
     assert.ok(openWorkspaceDashboardSource.includes(
         'this.options.getAttentionAggregate()?.aggregateRevision || null'
     ));
-    assert.ok(dashboardSource.includes('scheduleAttentionViewsRefresh()'));
+    assert.ok(attentionEventSource.includes('scheduleAttentionViewsRefresh()'));
 
     const navigationBranch = projectScriptsSource.slice(
         projectScriptsSource.indexOf(

--- a/src/aiSessions/attentionEventCapability.ts
+++ b/src/aiSessions/attentionEventCapability.ts
@@ -1,0 +1,460 @@
+'use strict';
+
+import type * as vscode from 'vscode';
+import type { AiSessionProviderId } from '../models';
+import type { OpenWorkspace } from '../workspaces/types';
+import type ActiveAiSessionTerminalHighlighter from './activeTerminalHighlight';
+import type { ActiveAiSessionTerminalIdentity } from './activeTerminalHighlight';
+import type { AttentionAggregate } from './attentionAggregate';
+import type { AiSessionAttentionController, AiSessionAttentionEvaluation } from './attentionController';
+import type AttentionBridgeClient from './attentionBridgeClient';
+import type { AttentionPayloadItem } from './attentionPayload';
+import type { AiSessionRuntimeCoordinator } from './runtimeCoordinator';
+import { cloneAiSessionRuntimeIdentity } from './runtimeTypes';
+import type {
+    AiSessionRuntimeConfiguration,
+    AiSessionRuntimeIdentity,
+    AiSessionRuntimeSnapshot,
+} from './runtimeTypes';
+import { getAiSessionKey } from './sessionHelpers';
+import type AiSessionTerminalService from './terminalService';
+import type { TmuxRuntimeBackend } from './tmuxRuntimeBackend';
+import type { TmuxRuntimeBindingStore } from './tmuxRuntimeBindingStore';
+import type { TmuxFocusedRuntimeMonitor } from './tmuxFocusedRuntimeMonitor';
+import { findTmuxCollisionRuntime, TmuxRuntimeDiscovery } from './tmuxRuntimeDiscovery';
+import type { AiSessionTerminalEntry } from './types';
+
+// Mirrors vscode.TerminalExitReason.User. The extension's minimum VS Code typings
+// predate TerminalExitStatus.reason, while supported hosts expose it at runtime.
+const USER_TERMINAL_EXIT_REASON = 3;
+
+export interface AiSessionAttentionRuntimeOverride {
+    providerId: AiSessionProviderId;
+    sessionId: string;
+    attentionKey: string;
+    runtime: AiSessionRuntimeSnapshot<vscode.Terminal>;
+}
+
+export interface AiSessionAttentionEventCapabilityOptions {
+    tmuxRuntimeDiscovery: TmuxRuntimeDiscovery;
+    tmuxRuntimeBackend: TmuxRuntimeBackend<vscode.Terminal>;
+    tmuxRuntimeStore: TmuxRuntimeBindingStore;
+    aiSessionTerminalService: AiSessionTerminalService;
+    getRuntimeConfiguration: () => AiSessionRuntimeConfiguration;
+    getCurrentOpenWorkspace: () => OpenWorkspace | null;
+    getActiveTerminal: () => vscode.Terminal | null;
+    postMessage: (message: unknown) => void;
+    isVisible: () => boolean;
+    assertActive: () => void;
+    createBridgeClient: (
+        onAggregate: (aggregate: AttentionAggregate) => void,
+        onError: (error: unknown) => void
+    ) => AttentionBridgeClient;
+    onDidOpenTerminal: (callback: (terminal: vscode.Terminal) => void) => vscode.Disposable;
+    onDidChangeActiveTerminal: (callback: () => void) => vscode.Disposable;
+    onDidCloseTerminal: (callback: (terminal: vscode.Terminal) => void) => vscode.Disposable;
+    logError: (message: string, error: unknown) => void;
+    logAiSessionRuntimeFailure: (operation: string, error: unknown) => void;
+    /** Late-bound: the coordinator is constructed after this capability. */
+    getRuntimeCoordinator: () => AiSessionRuntimeCoordinator<vscode.Terminal>;
+    /** Late-bound: the controller is constructed after this capability. */
+    getAttentionController: () => AiSessionAttentionController<AiSessionRuntimeSnapshot<vscode.Terminal>>;
+    /** Late-bound: the settlement capability is constructed after this capability. */
+    runSafeLifecycleTask: (
+        operation: string,
+        task: () => unknown | Promise<unknown>
+    ) => Promise<void>;
+    /** Late-bound: the status capability tick is wired after this capability. */
+    evaluateLifecycleTick: () => void;
+    /** Late-bound: the dashboard controller is constructed after this capability. */
+    refreshViewsNow: (reason?: string) => void;
+    /** Late-bound: the dashboard controller is constructed after this capability. */
+    scheduleRefresh: (reason: string) => void;
+    /** Late-bound: the open-workspace controller may never be constructed. */
+    postOpenWorkspacesUpdated: () => void;
+    /** Late-bound: the highlighter is constructed after this capability. */
+    getActiveTerminalHighlighter: () =>
+        ActiveAiSessionTerminalHighlighter<vscode.Terminal, AiSessionTerminalEntry<vscode.Terminal>>;
+    /** Late-bound: the monitor is constructed after this capability. */
+    getTmuxFocusedRuntimeMonitor: () => TmuxFocusedRuntimeMonitor<vscode.Terminal>;
+    publishRestoredAttachTerminal: () => void;
+}
+
+export interface AiSessionAttentionEventCapability {
+    evaluateAttention(
+        runtimeOverrides?: ReadonlyArray<AiSessionAttentionRuntimeOverride>
+    ): Promise<AiSessionAttentionEvaluation>;
+    hasLiveTmuxOwnership(): Promise<boolean>;
+    getRuntimeById(
+        providerId: AiSessionProviderId,
+        sessionId: string
+    ): AiSessionRuntimeSnapshot<vscode.Terminal> | null;
+    getRuntimeCollision(
+        providerId: AiSessionProviderId,
+        sessionId: string,
+        workspaceScopeIdentity: string
+    ): AiSessionRuntimeSnapshot<vscode.Terminal> | null;
+    getFocusedRuntimeIdentity(): AiSessionRuntimeIdentity | ActiveAiSessionTerminalIdentity | null;
+    belongsToCurrentWorkspace(runtime: AiSessionRuntimeSnapshot<vscode.Terminal>): boolean;
+    refreshViewsIncrementally(): void;
+    scheduleViewsRefresh(): void;
+    postAttentionState(): void;
+    acknowledgeEventIds(eventIds: string[]): Promise<void>;
+    acknowledgeAttention(identity: ActiveAiSessionTerminalIdentity): Promise<void>;
+    publish(items: AttentionPayloadItem[], forceHeartbeat?: boolean): Promise<boolean>;
+    readonly bridgeClient: AttentionBridgeClient;
+    startBridgeClient(): void;
+    setDeferredRestoreSettled(): void;
+    setDeferredRestoreRefreshReady(ready: boolean): void;
+    publishDeferredRestoreIfReady(): void;
+    registerTerminalRestoreHandler(): vscode.Disposable;
+    registerTerminalEventHandlers(): vscode.Disposable;
+    dispose(): void;
+}
+
+/**
+ * Owns the AI session attention event plumbing extracted from activate() in
+ * src/dashboard.ts: the attention evaluation with its fail-open tmux relevance
+ * and ownership probes, the runtime lookups, the attention bridge client, the
+ * deferred tmux-restore refresh state, and the terminal open/active/close
+ * event handlers. Behaviour is unchanged; only the ownership moved.
+ */
+export function createAiSessionAttentionEventCapability(
+    options: AiSessionAttentionEventCapabilityOptions
+): AiSessionAttentionEventCapability {
+    const tmuxRuntimeDiscovery = options.tmuxRuntimeDiscovery;
+    const tmuxRuntimeBackend = options.tmuxRuntimeBackend;
+    const tmuxRuntimeStore = options.tmuxRuntimeStore;
+    const aiSessionTerminalService = options.aiSessionTerminalService;
+    const getRuntimeConfiguration = options.getRuntimeConfiguration;
+    const getCurrentOpenWorkspace = options.getCurrentOpenWorkspace;
+    const getActiveTerminal = options.getActiveTerminal;
+    const postMessage = options.postMessage;
+    const isVisible = options.isVisible;
+    const assertActive = options.assertActive;
+    const createBridgeClient = options.createBridgeClient;
+    const onDidOpenTerminal = options.onDidOpenTerminal;
+    const onDidChangeActiveTerminal = options.onDidChangeActiveTerminal;
+    const onDidCloseTerminal = options.onDidCloseTerminal;
+    const logError = options.logError;
+    const logAiSessionRuntimeFailure = options.logAiSessionRuntimeFailure;
+    const getRuntimeCoordinator = options.getRuntimeCoordinator;
+    const getAttentionController = options.getAttentionController;
+    const runSafeAiSessionRuntimeLifecycleTask = options.runSafeLifecycleTask;
+    const evaluateAiSessionLifecycleTick = options.evaluateLifecycleTick;
+    const refreshViewsNow = options.refreshViewsNow;
+    const scheduleRefresh = options.scheduleRefresh;
+    const postOpenWorkspacesUpdated = options.postOpenWorkspacesUpdated;
+    const getActiveTerminalHighlighter = options.getActiveTerminalHighlighter;
+    const getTmuxFocusedRuntimeMonitor = options.getTmuxFocusedRuntimeMonitor;
+    const publishRestoredAttachTerminal = options.publishRestoredAttachTerminal;
+
+    let aiSessionAttentionBridgeClient: AttentionBridgeClient;
+    let deferredTmuxRestoreSettled = false;
+    let deferredTmuxRestoreRefreshReady = false;
+    let deferredTmuxRestoreRefreshPublished = false;
+
+    async function evaluateAiSessionAttention(
+        runtimeOverrides: ReadonlyArray<{
+            providerId: AiSessionProviderId;
+            sessionId: string;
+            attentionKey: string;
+            runtime: AiSessionRuntimeSnapshot<vscode.Terminal>;
+        }> = []
+    ): Promise<AiSessionAttentionEvaluation> {
+        try {
+            await tmuxRuntimeDiscovery.loadPersistedInactive();
+        } catch (error) {
+            logAiSessionRuntimeFailure('attention-inactive-restore', error);
+        }
+        const hasRelevantTmux = await hasRelevantTmuxRuntime();
+        if (hasRelevantTmux && await hasLiveTmuxOwnership()) {
+            try {
+                await getRuntimeCoordinator().refreshForHost(false);
+            } catch (error) {
+                logAiSessionRuntimeFailure('attention-refresh', error);
+            }
+        }
+        return getAttentionController().evaluate(runtimeOverrides);
+    }
+
+    async function hasLiveTmuxOwnership(): Promise<boolean> {
+        if (getRuntimeConfiguration().mode === 'tmux'
+            || tmuxRuntimeDiscovery.getActive().length
+            || tmuxRuntimeDiscovery.getPending().length
+            || tmuxRuntimeBackend.getConflicts().length) {
+            return true;
+        }
+        try {
+            const [known, pending] = await Promise.all([
+                tmuxRuntimeStore.listKnown(),
+                tmuxRuntimeStore.listPending(),
+            ]);
+            return known.length > 0 || pending.length > 0;
+        } catch (error) {
+            logAiSessionRuntimeFailure('attention-relevance', error);
+            return true;
+        }
+    }
+
+    async function hasRelevantTmuxRuntime(): Promise<boolean> {
+        if (tmuxRuntimeDiscovery.getInactive().length) {
+            return true;
+        }
+        try {
+            const inactive = await tmuxRuntimeStore.listInactive();
+            return inactive.length > 0 || await hasLiveTmuxOwnership();
+        } catch (error) {
+            logAiSessionRuntimeFailure('attention-relevance', error);
+            return true;
+        }
+    }
+
+    function getAiSessionRuntimeById(
+        providerId: AiSessionProviderId,
+        sessionId: string
+    ): AiSessionRuntimeSnapshot<vscode.Terminal> | null {
+        const workspaceScopeIdentity = getCurrentOpenWorkspace()?.scopeIdentity;
+        if (!workspaceScopeIdentity) {
+            return null;
+        }
+        const collision = getAiSessionRuntimeCollision(
+            providerId, sessionId, workspaceScopeIdentity
+        );
+        if (collision) {
+            return collision;
+        }
+        const live = getRuntimeCoordinator().getById(
+            providerId, sessionId, workspaceScopeIdentity
+        );
+        if (live) {
+            return live;
+        }
+        const liveConflicts = getRuntimeCoordinator().getActive().filter(runtime =>
+            runtime.identity.provider === providerId && runtime.identity.sessionId === sessionId
+            && runtime.identity.workspaceScopeIdentity === workspaceScopeIdentity);
+        if (liveConflicts.length > 1) {
+            return { ...liveConflicts[0], state: 'conflict' };
+        }
+        const inactiveTmux: AiSessionRuntimeSnapshot<vscode.Terminal>[] = tmuxRuntimeDiscovery.getInactive()
+            .filter(runtime => runtime.identity.provider === providerId
+                && runtime.identity.sessionId === sessionId
+                && runtime.identity.workspaceScopeIdentity === workspaceScopeIdentity)
+            .map(runtime => {
+                const { terminal: _terminal, ...detached } = runtime;
+                return {
+                    ...detached,
+                    identity: cloneAiSessionRuntimeIdentity(runtime.identity),
+                    ...(runtime.tmux ? { tmux: { ...runtime.tmux } } : {}),
+                };
+            });
+        const completedDirect = aiSessionTerminalService.getTrackedTerminalEntries()
+            .filter(entry => entry.provider === providerId && entry.sessionId === sessionId
+                && aiSessionTerminalService.isComplete(entry) && !!entry.runtimeIdentity
+                && entry.runtimeIdentity.workspaceScopeIdentity === workspaceScopeIdentity)
+            .map(entry => ({
+                identity: cloneAiSessionRuntimeIdentity(entry.runtimeIdentity),
+                backend: 'vscode' as const,
+                state: 'completed' as const,
+                markerPath: entry.markerPath,
+                runStartedAtMs: entry.runStartedAtMs,
+                attached: true,
+                terminal: entry.terminal,
+            }));
+        const inactive = [...inactiveTmux, ...completedDirect];
+        return inactive.length === 1 ? inactive[0] : null;
+    }
+
+    function getAiSessionRuntimeCollision(
+        providerId: AiSessionProviderId,
+        sessionId: string,
+        workspaceScopeIdentity: string
+    ): AiSessionRuntimeSnapshot<vscode.Terminal> | null {
+        return findTmuxCollisionRuntime(
+            tmuxRuntimeDiscovery.getDiagnostics(), providerId, sessionId,
+            workspaceScopeIdentity
+        ) as AiSessionRuntimeSnapshot<vscode.Terminal> | null;
+    }
+
+    function getFocusedAiSessionRuntimeIdentity() {
+        const activeTerminal = getActiveTerminal();
+        const tmuxRuntime = tmuxRuntimeBackend.getFocusedRuntime(activeTerminal);
+        return tmuxRuntime && runtimeBelongsToCurrentWorkspace(tmuxRuntime)
+            ? tmuxRuntime.identity
+            : getActiveTerminalHighlighter().getIdentity();
+    }
+
+    function runtimeBelongsToCurrentWorkspace(
+        runtime: AiSessionRuntimeSnapshot<vscode.Terminal>
+    ): boolean {
+        const workspaceScopeIdentity = getCurrentOpenWorkspace()?.scopeIdentity;
+        return !!workspaceScopeIdentity
+            && runtime.identity.workspaceScopeIdentity === workspaceScopeIdentity;
+    }
+
+    function scheduleAttentionViewsRefresh() {
+        scheduleRefresh('attention');
+        postOpenWorkspacesUpdated();
+    }
+
+    function refreshAiSessionViewsIncrementally() {
+        void refreshViewsNow();
+    }
+
+    function publishDeferredTmuxRestoreIfReady(): void {
+        if (!deferredTmuxRestoreSettled
+            || !deferredTmuxRestoreRefreshReady
+            || deferredTmuxRestoreRefreshPublished
+            || !isVisible()) {
+            return;
+        }
+        try {
+            assertActive();
+        } catch (_error) {
+            return;
+        }
+        deferredTmuxRestoreRefreshPublished = true;
+        void refreshViewsNow('tmux-bootstrap-restore');
+    }
+
+    function postAiSessionAttentionState() {
+        void postMessage({
+            type: 'ai-session-attention-state',
+            sessionEvents: getAttentionController().getRecoverySessionEvents(),
+            eventIds: getAttentionController().getAttentionEventIds(),
+        });
+    }
+
+    const getAiSessionAttentionEventIds = (identity: ActiveAiSessionTerminalIdentity): string[] => {
+        const sessionKey = getAiSessionKey(identity.provider, identity.sessionId);
+        return getAttentionController().getRecoverySessionEvents()
+            .find(session => session.sessionKey === sessionKey)?.eventIds || [];
+    };
+    const acknowledgeAiSessionAttentionEventIds = async (eventIds: string[]): Promise<void> => {
+        const uniqueEventIds = Array.from(new Set(eventIds.filter(eventId => Boolean(eventId))));
+        if (!uniqueEventIds.length) {
+            return;
+        }
+        getAttentionController().acknowledge(uniqueEventIds);
+        refreshAiSessionViewsIncrementally();
+        await aiSessionAttentionBridgeClient.acknowledge(uniqueEventIds);
+    };
+    const acknowledgeAiSessionAttention = async (
+        identity: ActiveAiSessionTerminalIdentity
+    ): Promise<void> => {
+        await acknowledgeAiSessionAttentionEventIds(getAiSessionAttentionEventIds(identity));
+    };
+
+    function startBridgeClient(): void {
+        aiSessionAttentionBridgeClient = createBridgeClient(
+            aggregate => {
+                if (getAttentionController().setRemoteAggregate(aggregate)) {
+                    scheduleAttentionViewsRefresh();
+                }
+            },
+            error => logError('AI session attention bridge unavailable; using local-window monitoring.', error)
+        );
+    }
+
+    function setDeferredRestoreSettled(): void {
+        deferredTmuxRestoreSettled = true;
+    }
+
+    function setDeferredRestoreRefreshReady(ready: boolean): void {
+        deferredTmuxRestoreRefreshReady = ready;
+    }
+
+
+    function registerTerminalRestoreHandler(): vscode.Disposable {
+        const openListener = onDidOpenTerminal(terminal => {
+            if (!tmuxRuntimeBackend.isAttachTerminalCandidate(terminal)) {
+                return;
+            }
+            void tmuxRuntimeBackend.restoreAttachTerminals([terminal]).then(
+                () => publishRestoredAttachTerminal(),
+                error => logAiSessionRuntimeFailure('restore-opened-tmux-attach-terminal', error)
+            );
+        });
+        return {
+            dispose: () => {
+                openListener.dispose();
+            },
+        };
+    }
+
+    function registerTerminalEventHandlers(): vscode.Disposable {
+        const activeListener = onDidChangeActiveTerminal(() => {
+            getActiveTerminalHighlighter().sync();
+            void getTmuxFocusedRuntimeMonitor().request();
+            refreshAiSessionViewsIncrementally();
+            void runSafeAiSessionRuntimeLifecycleTask(
+                'evaluate-attention-active-terminal', evaluateAiSessionAttention
+            );
+        });
+        const closeListener = onDidCloseTerminal(terminal => {
+            const closedRuntimes = getRuntimeCoordinator().getActive()
+                .filter(runtime => runtime.backend === 'vscode' && runtime.terminal === terminal
+                    && Boolean(runtime.identity.sessionId));
+            const exitStatus = terminal.exitStatus as
+                (vscode.TerminalExitStatus & { reason?: number }) | undefined;
+            const userClosedTerminal = exitStatus?.reason === USER_TERMINAL_EXIT_REASON;
+            const closedSessions: ActiveAiSessionTerminalIdentity[] = closedRuntimes.map(runtime => ({
+                provider: runtime.identity.provider,
+                sessionId: runtime.identity.sessionId as string,
+                workspaceScopeIdentity: runtime.identity.workspaceScopeIdentity,
+            }));
+            const hadRuntimeClient = [...getRuntimeCoordinator().getActive(), ...getRuntimeCoordinator().getPending()]
+                .some(runtime => runtime.terminal === terminal);
+            getRuntimeCoordinator().handleClosedTerminal(terminal);
+            evaluateAiSessionLifecycleTick();
+            getActiveTerminalHighlighter().handleTerminalClosed(terminal);
+            if (closedSessions.length || hadRuntimeClient) {
+                refreshAiSessionViewsIncrementally();
+                if (userClosedTerminal) {
+                    void runSafeAiSessionRuntimeLifecycleTask(
+                        'acknowledge-user-terminal-close',
+                        async () => {
+                            for (const identity of closedSessions) {
+                                await acknowledgeAiSessionAttention(identity);
+                            }
+                        }
+                    );
+                }
+                void runSafeAiSessionRuntimeLifecycleTask(
+                    'evaluate-attention-closed-terminal', evaluateAiSessionAttention
+                );
+            }
+        });
+        return {
+            dispose: () => {
+                activeListener.dispose();
+                closeListener.dispose();
+            },
+        };
+    }
+
+    return {
+        evaluateAttention: evaluateAiSessionAttention,
+        hasLiveTmuxOwnership,
+        getRuntimeById: getAiSessionRuntimeById,
+        getRuntimeCollision: getAiSessionRuntimeCollision,
+        getFocusedRuntimeIdentity: getFocusedAiSessionRuntimeIdentity,
+        belongsToCurrentWorkspace: runtimeBelongsToCurrentWorkspace,
+        refreshViewsIncrementally: refreshAiSessionViewsIncrementally,
+        scheduleViewsRefresh: scheduleAttentionViewsRefresh,
+        postAttentionState: postAiSessionAttentionState,
+        acknowledgeEventIds: acknowledgeAiSessionAttentionEventIds,
+        acknowledgeAttention: acknowledgeAiSessionAttention,
+        publish: (items, forceHeartbeat) => aiSessionAttentionBridgeClient.publish(items, forceHeartbeat),
+        get bridgeClient() { return aiSessionAttentionBridgeClient; },
+        startBridgeClient,
+        setDeferredRestoreSettled,
+        setDeferredRestoreRefreshReady,
+        publishDeferredRestoreIfReady: publishDeferredTmuxRestoreIfReady,
+        registerTerminalRestoreHandler,
+        registerTerminalEventHandlers,
+        dispose: () => {
+            aiSessionAttentionBridgeClient?.dispose();
+        },
+    };
+}

--- a/src/aiSessions/tmuxManagedMetadata.ts
+++ b/src/aiSessions/tmuxManagedMetadata.ts
@@ -1,0 +1,110 @@
+'use strict';
+
+import type { TmuxClient } from './tmuxClient';
+import type {
+    AiSessionRuntimeIdentity,
+    AiSessionTmuxLayout,
+    AiSessionTmuxLocator,
+} from './runtimeTypes';
+
+const SESSION_WINDOW = 'ai-session';
+
+export function projectSessionMetadata(identity: AiSessionRuntimeIdentity): Record<string, string> {
+    return {
+        managed: '1',
+        version: '2',
+        layout: 'project',
+        workspaceScopeIdentity: identity.workspaceScopeIdentity,
+    };
+}
+
+export function sessionWindowMetadata(): Record<string, string> {
+    return { managed: '1', version: '2', layout: 'session' };
+}
+
+export function fullMetadata(
+    identity: AiSessionRuntimeIdentity,
+    layout: AiSessionTmuxLayout,
+    createdAt: string,
+    markerPath: string
+): Record<string, string> {
+    return {
+        managed: '1',
+        version: '2',
+        layout,
+        workspaceScopeIdentity: identity.workspaceScopeIdentity,
+        workspaceNavigationIdentity: identity.workspaceNavigationIdentity,
+        workspaceRootHostPaths: JSON.stringify(identity.workspaceRootHostPaths),
+        cwd: identity.cwd,
+        provider: identity.provider,
+        ...(identity.sessionId ? { sessionId: identity.sessionId } : { pendingId: identity.pendingId as string }),
+        createdAt,
+        ...(markerPath ? { marker: markerPath } : {}),
+    };
+}
+
+export async function writeFinalMetadata(
+    client: TmuxClient,
+    identity: AiSessionRuntimeIdentity,
+    locator: AiSessionTmuxLocator,
+    lifecycle: { createdAt: string; markerPath: string }
+): Promise<void> {
+    const full = fullMetadata(identity, locator.layout, lifecycle.createdAt, lifecycle.markerPath);
+    if (locator.layout === 'project') {
+        if (!locator.windowName) {
+            throw new Error('A project tmux runtime requires a window name.');
+        }
+        await client.setSessionOptions(locator.sessionName,
+            projectSessionMetadata(identity));
+        await client.setWindowOptions(locator.sessionName, locator.windowName, full);
+        return;
+    }
+    await client.setSessionOptions(locator.sessionName, full);
+    await client.setWindowOptions(locator.sessionName,
+        locator.windowName || SESSION_WINDOW,
+        sessionWindowMetadata());
+}
+
+export async function writePendingMetadata(
+    client: TmuxClient,
+    identity: AiSessionRuntimeIdentity,
+    locator: AiSessionTmuxLocator,
+    createdAt: string,
+    markerPath: string
+): Promise<void> {
+    return writeFinalMetadata(client, identity, locator, { createdAt, markerPath });
+}
+
+export async function verifyPendingMetadata(
+    client: TmuxClient,
+    identity: AiSessionRuntimeIdentity,
+    locator: AiSessionTmuxLocator,
+    createdAt: string,
+    markerPath: string
+): Promise<void> {
+    const sessionOptions = await client.getSessionOptions(locator.sessionName);
+    const windowName = locator.layout === 'project'
+        ? locator.windowName
+        : locator.windowName || SESSION_WINDOW;
+    if (!windowName) {
+        throw new Error('The pending tmux metadata could not be verified.');
+    }
+    const windowOptions = await client.getWindowOptions(locator.sessionName, windowName);
+    const expectedSession = locator.layout === 'project'
+        ? projectSessionMetadata(identity)
+        : fullMetadata(identity, locator.layout, createdAt, markerPath);
+    const expectedWindow = locator.layout === 'project'
+        ? fullMetadata(identity, locator.layout, createdAt, markerPath)
+        : sessionWindowMetadata();
+    if (!recordsEqual(sessionOptions, expectedSession) || !recordsEqual(windowOptions, expectedWindow)) {
+        throw new Error('The pending tmux metadata could not be verified.');
+    }
+}
+
+function recordsEqual(left: Record<string, string>, right: Record<string, string>): boolean {
+    const leftKeys = Object.keys(left).sort();
+    const rightKeys = Object.keys(right).sort();
+    return leftKeys.length === rightKeys.length
+        && leftKeys.every((key, index) => key === rightKeys[index] && left[key] === right[key]);
+}
+

--- a/src/aiSessions/tmuxPendingLifecycle.ts
+++ b/src/aiSessions/tmuxPendingLifecycle.ts
@@ -1,0 +1,272 @@
+'use strict';
+
+import { createHash } from 'crypto';
+import type {
+    AiSessionDeferredCreateRuntimeRequest,
+    AiSessionPendingRuntimeSnapshot,
+    AiSessionRuntimeIdentity,
+    AiSessionRuntimeSnapshot,
+    AiSessionTmuxLocator,
+} from './runtimeTypes';
+import {
+    aiSessionRuntimeIdentitiesEqual,
+    cloneAiSessionRuntimeIdentity,
+} from './runtimeTypes';
+import { getTmuxRuntimeKey } from './tmuxLayout';
+import {
+    TmuxAmbiguousRuntimeBinding,
+    TmuxConsumedPendingBinding,
+    TmuxPendingRuntimeBinding,
+    TmuxPromotingRuntimeBinding,
+} from './tmuxRuntimeBindingStore';
+
+export function pendingIdentity(identity: AiSessionRuntimeIdentity & { pendingId: string }): AiSessionRuntimeIdentity {
+    return {
+        ...cloneAiSessionRuntimeIdentity(identity),
+        pendingId: identity.pendingId,
+        sessionId: undefined,
+    };
+}
+
+
+export function pendingLifecycleLockKey(identity: AiSessionRuntimeIdentity): string {
+    return `pending:${getTmuxRuntimeKey(identity)}`;
+}
+
+
+export function pendingLifecycleIdentityMatches(
+    record: TmuxPendingRuntimeBinding | TmuxPromotingRuntimeBinding
+        | TmuxConsumedPendingBinding | TmuxAmbiguousRuntimeBinding,
+    identity: AiSessionRuntimeIdentity
+): boolean {
+    return record.pendingId === identity.pendingId && record.provider === identity.provider
+        && aiSessionRuntimeIdentitiesEqual({
+            ...cloneAiSessionRuntimeIdentity(identity),
+            sessionId: undefined,
+            pendingId: record.pendingId,
+        }, {
+            provider: record.provider,
+            workspaceScopeIdentity: record.workspaceScopeIdentity,
+            workspaceNavigationIdentity: record.workspaceNavigationIdentity,
+            workspaceRootHostPaths: [...record.workspaceRootHostPaths],
+            cwd: record.cwd,
+            pendingId: record.pendingId,
+        });
+}
+
+function locatorsEqual(left: AiSessionTmuxLocator, right: AiSessionTmuxLocator): boolean {
+    return left.layout === right.layout
+        && left.sessionName === right.sessionName
+        && left.windowName === right.windowName;
+}
+
+export function pendingRequestFingerprint(request: AiSessionDeferredCreateRuntimeRequest): string {
+    const digest = createHash('sha256').update(JSON.stringify([
+        3,
+        request.identity.provider,
+        request.identity.workspaceScopeIdentity,
+        request.identity.workspaceNavigationIdentity,
+        request.identity.workspaceRootHostPaths.slice().sort(),
+        request.identity.pendingId,
+        request.identity.cwd,
+        request.createdAt,
+        request.excludedSessionIds,
+        request.title ?? null,
+        request.launchMarkerPath,
+    ]), 'utf8').digest('hex');
+    return `v3:${digest}`;
+}
+
+function identityFromPendingBinding(binding: TmuxPendingRuntimeBinding): AiSessionRuntimeIdentity {
+    return {
+        provider: binding.provider,
+        workspaceScopeIdentity: binding.workspaceScopeIdentity,
+        workspaceNavigationIdentity: binding.workspaceNavigationIdentity,
+        workspaceRootHostPaths: [...binding.workspaceRootHostPaths],
+        cwd: binding.cwd,
+        pendingId: binding.pendingId,
+    };
+}
+
+export function pendingSnapshotFromBinding(binding: TmuxPendingRuntimeBinding): AiSessionPendingRuntimeSnapshot {
+    return {
+        identity: identityFromPendingBinding(binding),
+        backend: 'tmux',
+        state: 'pending',
+        markerPath: '',
+        runStartedAtMs: Date.parse(binding.createdAt),
+        attached: false,
+        tmux: { ...binding.locator },
+        createdAt: binding.createdAt,
+        excludedSessionIds: [...binding.excludedSessionIds],
+        ...(binding.projectName === undefined ? {} : { projectName: binding.projectName }),
+        ...(binding.title === undefined ? {} : { title: binding.title }),
+    };
+}
+
+export function pendingBindingsEqual(left: TmuxPendingRuntimeBinding, right: TmuxPendingRuntimeBinding): boolean {
+    return left.pendingId === right.pendingId && left.provider === right.provider
+        && left.workspaceScopeIdentity === right.workspaceScopeIdentity
+        && left.workspaceNavigationIdentity === right.workspaceNavigationIdentity
+        && JSON.stringify(left.workspaceRootHostPaths.slice().sort())
+            === JSON.stringify(right.workspaceRootHostPaths.slice().sort())
+        && left.cwd === right.cwd
+        && left.createdAt === right.createdAt && left.projectName === right.projectName
+        && left.title === right.title
+        && left.acceptedAtMs === right.acceptedAtMs && left.layout === right.layout
+        && locatorsEqual(left.locator, right.locator)
+        && left.excludedSessionIds.length === right.excludedSessionIds.length
+        && left.excludedSessionIds.every((value, index) => value === right.excludedSessionIds[index]);
+}
+
+export function promotionIntent(
+    binding: TmuxPendingRuntimeBinding,
+    pending: AiSessionRuntimeSnapshot,
+    finalIdentityValue: AiSessionRuntimeIdentity,
+    finalSessionName: string,
+    finalLocator: AiSessionTmuxLocator,
+    recordedAtMs: number
+): TmuxPromotingRuntimeBinding {
+    if (!finalIdentityValue.sessionId) {
+        throw new Error('A promotion intent requires a final session ID.');
+    }
+    const requestFingerprint = promotionRequestFingerprint(
+        binding, pending.markerPath, finalSessionName, finalLocator
+    );
+    return {
+        version: 2,
+        state: 'promoting',
+        pendingId: binding.pendingId,
+        provider: binding.provider,
+        workspaceScopeIdentity: binding.workspaceScopeIdentity,
+        workspaceNavigationIdentity: binding.workspaceNavigationIdentity,
+        workspaceRootHostPaths: [...binding.workspaceRootHostPaths],
+        cwd: binding.cwd,
+        createdAt: binding.createdAt,
+        markerPath: pending.markerPath,
+        pendingBinding: {
+            ...binding,
+            workspaceRootHostPaths: [...binding.workspaceRootHostPaths],
+            excludedSessionIds: [...binding.excludedSessionIds],
+            locator: { ...binding.locator },
+        },
+        finalSessionId: finalIdentityValue.sessionId,
+        finalSessionName,
+        layout: binding.layout,
+        sourceLocator: { ...binding.locator },
+        finalLocator: { ...finalLocator },
+        requestFingerprint,
+        recordedAtMs,
+    };
+}
+
+function promotionRequestFingerprint(
+    binding: TmuxPendingRuntimeBinding,
+    markerPath: string,
+    finalSessionName: string,
+    finalLocator: AiSessionTmuxLocator
+): string {
+    return createHash('sha256').update(JSON.stringify([
+        2,
+        binding.provider,
+        binding.workspaceScopeIdentity,
+        binding.workspaceNavigationIdentity,
+        binding.workspaceRootHostPaths.slice().sort(),
+        binding.pendingId,
+        binding.cwd,
+        binding.createdAt,
+        binding.excludedSessionIds,
+        binding.title ?? null,
+        binding.acceptedAtMs,
+        binding.layout,
+        binding.locator,
+        markerPath,
+        finalSessionName,
+        finalLocator,
+    ]), 'utf8').digest('hex');
+}
+
+export function promotionIntentMatchesLiveBinding(
+    intent: TmuxPromotingRuntimeBinding,
+    binding: TmuxPendingRuntimeBinding
+): boolean {
+    return pendingBindingsEqual(intent.pendingBinding, binding)
+        && intent.requestFingerprint === promotionRequestFingerprint(
+            binding, intent.markerPath, intent.finalSessionName, intent.finalLocator
+        );
+}
+
+export function promotionIntentsMatch(
+    left: TmuxPromotingRuntimeBinding,
+    right: TmuxPromotingRuntimeBinding
+): boolean {
+    return left.pendingId === right.pendingId && left.provider === right.provider
+        && left.workspaceScopeIdentity === right.workspaceScopeIdentity
+        && left.workspaceNavigationIdentity === right.workspaceNavigationIdentity
+        && JSON.stringify(left.workspaceRootHostPaths.slice().sort())
+            === JSON.stringify(right.workspaceRootHostPaths.slice().sort())
+        && left.cwd === right.cwd
+        && left.createdAt === right.createdAt && left.markerPath === right.markerPath
+        && pendingBindingsEqual(left.pendingBinding, right.pendingBinding)
+        && left.finalSessionId === right.finalSessionId
+        && left.finalSessionName === right.finalSessionName && left.layout === right.layout
+        && locatorsEqual(left.sourceLocator, right.sourceLocator)
+        && locatorsEqual(left.finalLocator, right.finalLocator)
+        && left.requestFingerprint === right.requestFingerprint;
+}
+
+export function consumedMatchesPromotionIntent(
+    consumed: TmuxConsumedPendingBinding,
+    intent: TmuxPromotingRuntimeBinding
+): boolean {
+    return consumed.finalSessionName !== undefined
+        && pendingLifecycleIdentityMatches(consumed, intent)
+        && consumed.finalSessionId === intent.finalSessionId
+        && consumed.finalSessionName === intent.finalSessionName
+        && consumed.layout === intent.layout
+        && locatorsEqual(consumed.finalLocator, intent.finalLocator);
+}
+
+export type PendingAmbiguousRuntimeBinding = TmuxAmbiguousRuntimeBinding & {
+    pendingId: string;
+    sessionId?: never;
+    cwd: string;
+    createdAt: string;
+    excludedSessionIds: string[];
+    projectName?: string;
+    title?: string;
+    markerPath?: string;
+    requestFingerprint: string;
+};
+
+export function pendingAmbiguityMatches(
+    ambiguous: PendingAmbiguousRuntimeBinding,
+    request: AiSessionDeferredCreateRuntimeRequest,
+    binding: TmuxPendingRuntimeBinding,
+    locator: AiSessionTmuxLocator
+): boolean {
+    return ambiguous.provider === binding.provider
+        && ambiguous.workspaceScopeIdentity === binding.workspaceScopeIdentity
+        && ambiguous.workspaceNavigationIdentity === binding.workspaceNavigationIdentity
+        && JSON.stringify(ambiguous.workspaceRootHostPaths.slice().sort())
+            === JSON.stringify(binding.workspaceRootHostPaths.slice().sort())
+        && ambiguous.pendingId === binding.pendingId
+        && ambiguous.cwd === binding.cwd
+        && ambiguous.createdAt === binding.createdAt
+        && ambiguous.title === binding.title
+        && (ambiguous.markerPath || '') === request.launchMarkerPath
+        && ambiguous.layout === binding.layout
+        && locatorsEqual(ambiguous.locator, locator)
+        && ambiguous.excludedSessionIds.length === binding.excludedSessionIds.length
+        && ambiguous.excludedSessionIds.every((value, index) => value === binding.excludedSessionIds[index])
+        && (isLegacyPendingRequestFingerprint(ambiguous.requestFingerprint)
+            || ambiguous.requestFingerprint === pendingRequestFingerprint(request));
+}
+
+function isLegacyPendingRequestFingerprint(value: string): boolean {
+    return /^[a-f0-9]{64}$/.test(value);
+}
+
+export function consumedPendingError(record: TmuxConsumedPendingBinding): Error {
+    return new Error(`The pending tmux runtime was already consumed by session ${record.finalSessionId}.`);
+}

--- a/src/aiSessions/tmuxPromotionCapability.ts
+++ b/src/aiSessions/tmuxPromotionCapability.ts
@@ -1,0 +1,508 @@
+'use strict';
+
+import type {
+    AiSessionRuntimeIdentity,
+    AiSessionRuntimeSnapshot,
+    AiSessionTmuxLocator,
+} from './runtimeTypes';
+import {
+    aiSessionRuntimeIdentitiesEqual,
+    cloneAiSessionRuntimeIdentity,
+    isValidAiSessionPromotionDisplayName,
+    isValidAiSessionRuntimeIdentity,
+} from './runtimeTypes';
+import { getTmuxRuntimeKey } from './tmuxLayout';
+import {
+    fullMetadata,
+    projectSessionMetadata,
+    sessionWindowMetadata,
+    verifyPendingMetadata,
+    writeFinalMetadata,
+} from './tmuxManagedMetadata';
+import type { TmuxClient } from './tmuxClient';
+import { buildReadableTmuxLocator } from './tmuxNaming';
+import {
+    pendingBindingsEqual,
+    pendingIdentity,
+    pendingLifecycleIdentityMatches,
+    pendingLifecycleLockKey,
+    pendingSnapshotFromBinding,
+    promotionIntent,
+    promotionIntentMatchesLiveBinding,
+    promotionIntentsMatch,
+} from './tmuxPendingLifecycle';
+import type { TmuxPromotingRuntimeBinding, TmuxRuntimeBindingStore } from './tmuxRuntimeBindingStore';
+import type { TmuxRuntimeDiscovery } from './tmuxRuntimeDiscovery';
+import { isIdentityField } from './tmuxRuntimeRequest';
+
+const SESSION_WINDOW = 'ai-session';
+
+export interface TmuxPromotionCapabilityOptions<TTerminal> {
+    client: TmuxClient;
+    discovery: TmuxRuntimeDiscovery;
+    runtimeStore: TmuxRuntimeBindingStore;
+    withCreationLock: <T>(key: string, operation: () => Promise<T>) => Promise<T>;
+    nowMs: () => number;
+    requireAvailable: () => Promise<void>;
+    findVerified: (
+        identity: AiSessionRuntimeIdentity,
+        requiredLocator?: AiSessionTmuxLocator
+    ) => AiSessionRuntimeSnapshot | undefined;
+    throwIfCollision: (identity: AiSessionRuntimeIdentity) => void;
+    locatorIsOccupied: (locator: AiSessionTmuxLocator) => Promise<boolean>;
+    migrateAttach: (
+        pending: AiSessionRuntimeSnapshot,
+        promoted: AiSessionRuntimeSnapshot
+    ) => Promise<void>;
+    withAttach: (runtime: AiSessionRuntimeSnapshot) => AiSessionRuntimeSnapshot<TTerminal>;
+    persistKnown: (
+        identity: AiSessionRuntimeIdentity,
+        locator: AiSessionTmuxLocator,
+        lifecycle?: Pick<AiSessionRuntimeSnapshot, 'identity' | 'markerPath' | 'runStartedAtMs'>
+    ) => Promise<void>;
+}
+
+export interface TmuxPromotionCapability<TTerminal> {
+    promotePending(
+        identity: AiSessionRuntimeIdentity & { pendingId: string },
+        sessionId: string,
+        sessionName: string
+    ): Promise<AiSessionRuntimeSnapshot<TTerminal>[]>;
+    promotionTransitionMatches(
+        intent: TmuxPromotingRuntimeBinding,
+        finalIdentityValue: AiSessionRuntimeIdentity
+    ): Promise<boolean>;
+}
+
+/**
+ * Owns the tmux pending-to-final promotion state machine: the durable intent
+ * lifecycle (promoting/consumed records), the ordered rename + metadata
+ * transition, and the conflict/ambiguity outcomes. Extracted from
+ * TmuxRuntimeBackend; the lock nesting (pending lifecycle key, then final
+ * runtime key), the six forced discovery refreshes, and the cleanup order
+ * (migrate attach, remove pending, refresh, remove promoting) are unchanged.
+ */
+export function createTmuxPromotionCapability<TTerminal>(
+    options: TmuxPromotionCapabilityOptions<TTerminal>
+): TmuxPromotionCapability<TTerminal> {
+    const client = options.client;
+    const discovery = options.discovery;
+    const runtimeStore = options.runtimeStore;
+    const withCreationLock = options.withCreationLock;
+    const nowMs = options.nowMs;
+    const requireAvailable = options.requireAvailable;
+    const findVerified = options.findVerified;
+    const throwIfCollision = options.throwIfCollision;
+    const locatorIsOccupied = options.locatorIsOccupied;
+    const migrateAttach = options.migrateAttach;
+    const withAttach = options.withAttach;
+    const persistKnown = options.persistKnown;
+
+    async function promotePending(
+        identity: AiSessionRuntimeIdentity & { pendingId: string },
+        sessionId: string,
+        sessionName: string
+    ): Promise<AiSessionRuntimeSnapshot<TTerminal>[]> {
+        const pendingIdentityValue = pendingIdentity(identity);
+        if (!isValidAiSessionRuntimeIdentity(pendingIdentityValue) || !isIdentityField(sessionId)
+            || !isValidAiSessionPromotionDisplayName(sessionName)) {
+            return [];
+        }
+        return withCreationLock<AiSessionRuntimeSnapshot<TTerminal>[]>(
+            pendingLifecycleLockKey(pendingIdentityValue), async () => {
+            const storedIntent = await runtimeStore.getPromoting(pendingIdentityValue);
+            const storedLiveBinding = await runtimeStore.getPending(pendingIdentityValue);
+            if (storedIntent && storedLiveBinding
+                && !promotionIntentMatchesLiveBinding(storedIntent, storedLiveBinding)) {
+                throw new Error('The pending tmux promotion intent conflicts with the live pending binding.');
+            }
+            const storedPending = storedIntent?.pendingBinding
+                || storedLiveBinding;
+            if (!storedPending) {
+                return [];
+            }
+            if (!pendingLifecycleIdentityMatches(storedPending, pendingIdentityValue)) {
+                return [];
+            }
+            if (storedIntent && storedIntent.finalSessionId !== sessionId) {
+                throw new Error('The pending tmux runtime has a conflicting promotion in progress.');
+            }
+            await requireAvailable();
+            await discovery.refresh(true);
+            if (!storedIntent) {
+                throwIfCollision(pendingIdentityValue);
+            }
+            const consumed = await runtimeStore.getConsumed(pendingIdentityValue);
+            if (consumed && consumed.finalSessionId !== sessionId) {
+                throw new Error('The pending tmux runtime was consumed by a different promotion.');
+            }
+            const ambiguous = await runtimeStore.getAmbiguous(pendingIdentityValue);
+            if (ambiguous) {
+                throw new Error('The prior pending runtime creation result remains ambiguous.');
+            }
+            const currentIntent = await runtimeStore.getPromoting(pendingIdentityValue);
+            const freshBinding = await runtimeStore.getPending(pendingIdentityValue);
+            if (currentIntent && freshBinding
+                && !promotionIntentMatchesLiveBinding(currentIntent, freshBinding)) {
+                throw new Error('The pending tmux promotion intent conflicts with the live pending binding.');
+            }
+            const currentBinding = currentIntent?.pendingBinding || freshBinding;
+            if (!currentBinding || !pendingBindingsEqual(storedPending, currentBinding)
+                || (storedIntent && (!currentIntent || !promotionIntentsMatch(storedIntent, currentIntent)))) {
+                return [];
+            }
+            const currentPending = discovery.getPending()
+                .find(runtime => aiSessionRuntimeIdentitiesEqual(
+                    runtime.identity, pendingIdentityValue
+                )
+                    && !!runtime.tmux && locatorsEqual(runtime.tmux, currentBinding.locator));
+            const pendingSnapshot = currentPending || pendingSnapshotFromBinding(currentBinding);
+            const finalIdentityValue: AiSessionRuntimeIdentity = {
+                provider: currentBinding.provider,
+                workspaceScopeIdentity: currentBinding.workspaceScopeIdentity,
+                workspaceNavigationIdentity: currentBinding.workspaceNavigationIdentity,
+                workspaceRootHostPaths: [...currentBinding.workspaceRootHostPaths],
+                cwd: currentBinding.cwd,
+                sessionId,
+            };
+            const preferredFinal = buildReadableTmuxLocator(finalIdentityValue, currentBinding.layout, {
+                projectName: currentBinding.projectName || 'workspace',
+                sessionName,
+            });
+            const finalLocator: AiSessionTmuxLocator = currentBinding.layout === 'project'
+                ? { ...preferredFinal, sessionName: currentBinding.locator.sessionName }
+                : preferredFinal;
+            const finalLockKey = getTmuxRuntimeKey(finalIdentityValue);
+            return withCreationLock<AiSessionRuntimeSnapshot<TTerminal>[]>(
+                finalLockKey,
+                async () => {
+                    await discovery.refresh(true);
+                    const intent = await runtimeStore.getPromoting(pendingIdentityValue);
+                    if (!intent) {
+                        throwIfCollision(pendingIdentityValue);
+                    }
+                    throwIfCollision(finalIdentityValue);
+                    const expectedIntent = promotionIntent(currentBinding, {
+                        ...pendingSnapshot,
+                        markerPath: intent?.markerPath ?? pendingSnapshot.markerPath,
+                    }, finalIdentityValue, sessionName, finalLocator, nowMs());
+                    if (intent && !promotionIntentsMatch(intent, expectedIntent)) {
+                        throw new Error('The pending tmux runtime has a conflicting promotion in progress.');
+                    }
+                    const consumed = await runtimeStore.getConsumed(pendingIdentityValue);
+                    if (consumed) {
+                        if (consumed.finalSessionId !== sessionId
+                            || consumed.finalSessionName !== sessionName
+                            || !locatorsEqual(consumed.finalLocator, finalLocator)) {
+                            throw new Error('The pending tmux runtime was consumed by a different promotion.');
+                        }
+                        const completed = findVerified(finalIdentityValue, finalLocator);
+                        if (!completed) {
+                            return [];
+                        }
+                        await finishPromotionCleanup(pendingSnapshot, completed, pendingIdentityValue);
+                        return [withAttach(completed)];
+                    }
+                    const compatible = findVerified(finalIdentityValue, finalLocator);
+                    if (compatible) {
+                        if (!intent) {
+                            return [withAttach(asConflict(compatible)), withAttach(asConflict(pendingSnapshot))];
+                        }
+                        return completePromotion(pendingSnapshot, finalIdentityValue, sessionName,
+                            finalLocator, compatible, pendingIdentityValue);
+                    }
+                    const differentlyNamedFinal = findVerified(finalIdentityValue);
+                    if (differentlyNamedFinal) {
+                        return [
+                            withAttach(asConflict(differentlyNamedFinal)),
+                            withAttach(asConflict(pendingSnapshot)),
+                        ];
+                    }
+                    if (intent && await promotionTransitionMatches(intent, finalIdentityValue)) {
+                        await writeFinalMetadata(client, finalIdentityValue, finalLocator, {
+                            createdAt: intent.createdAt,
+                            markerPath: intent.markerPath,
+                        });
+                        await client.clearPendingMetadata(finalLocator);
+                        return verifyAndCompletePromotion(pendingSnapshot, finalIdentityValue,
+                            sessionName, finalLocator, pendingIdentityValue);
+                    }
+                    if (intent && await sessionPromotionPartiallyRenamed(intent)) {
+                        const sourceWindow = intent.sourceLocator.windowName || SESSION_WINDOW;
+                        const finalWindow = intent.finalLocator.windowName;
+                        if (!finalWindow) {
+                            throw new Error('The pending tmux promotion state is ambiguous; no mutation was attempted.');
+                        }
+                        try {
+                            await client.renameWindow(
+                                intent.finalLocator.sessionName, sourceWindow, finalWindow
+                            );
+                            await writeFinalMetadata(client, finalIdentityValue, finalLocator, {
+                                createdAt: intent.createdAt,
+                                markerPath: intent.markerPath,
+                            });
+                            await client.clearPendingMetadata(finalLocator);
+                        } catch (error) {
+                            await discovery.refresh(true);
+                            if (!findVerified(finalIdentityValue, finalLocator)) {
+                                throw error;
+                            }
+                        }
+                        return verifyAndCompletePromotion(pendingSnapshot, finalIdentityValue,
+                            sessionName, finalLocator, pendingIdentityValue);
+                    }
+                    const sourcePendingVerified = !!currentPending || !!(intent
+                        && await pendingMetadataMatches(pendingIdentityValue,
+                            intent.sourceLocator, intent.createdAt, intent.markerPath));
+                    if (!sourcePendingVerified) {
+                        throw new Error('The pending tmux promotion state is ambiguous; no mutation was attempted.');
+                    }
+                    if (await locatorIsOccupied(finalLocator)) {
+                        return [withAttach(asConflict(pendingSnapshot))];
+                    }
+
+                    if (!intent && await runtimeStore.setPromoting(expectedIntent) !== true) {
+                        throw new Error('The pending tmux promotion intent could not be persisted.');
+                    }
+                    try {
+                        const sourceLocator = currentPending?.tmux || currentBinding.locator;
+                        await renameRuntime(sourceLocator, finalLocator);
+                        await writeFinalMetadata(client, finalIdentityValue, finalLocator, {
+                            createdAt: pendingSnapshot.createdAt,
+                            markerPath: pendingSnapshot.markerPath,
+                        });
+                        await client.clearPendingMetadata(finalLocator);
+                    } catch (error) {
+                        await discovery.refresh(true);
+                        const recovered = findVerified(finalIdentityValue, finalLocator);
+                        if (!recovered) {
+                            const sourceStillVerified = await pendingMetadataMatches(
+                                pendingIdentityValue, currentBinding.locator,
+                                pendingSnapshot.createdAt, pendingSnapshot.markerPath
+                            );
+                            if (sourceStillVerified && !await locatorIsOccupied(finalLocator)) {
+                                await runtimeStore.removePromoting(pendingIdentityValue);
+                            }
+                            throw error;
+                        }
+                    }
+                    return verifyAndCompletePromotion(pendingSnapshot, finalIdentityValue,
+                        sessionName, finalLocator, pendingIdentityValue);
+                }
+            );
+        });
+    }
+
+    async function promotionTransitionMatches(
+        intent: TmuxPromotingRuntimeBinding,
+        finalIdentityValue: AiSessionRuntimeIdentity
+    ): Promise<boolean> {
+        try {
+            const sessionOptions = await client.getSessionOptions(
+                intent.finalLocator.sessionName
+            );
+            const windowName = intent.finalLocator.layout === 'project'
+                ? intent.finalLocator.windowName
+                : intent.finalLocator.windowName || SESSION_WINDOW;
+            if (!windowName) {
+                return false;
+            }
+            const windowOptions = await client.getWindowOptions(
+                intent.finalLocator.sessionName, windowName
+            );
+            const pendingIdentityValue: AiSessionRuntimeIdentity = {
+                provider: intent.provider,
+                workspaceScopeIdentity: intent.workspaceScopeIdentity,
+                workspaceNavigationIdentity: intent.workspaceNavigationIdentity,
+                workspaceRootHostPaths: [...intent.workspaceRootHostPaths],
+                cwd: intent.cwd,
+                pendingId: intent.pendingId,
+            };
+            const pendingMetadata = fullMetadata(pendingIdentityValue, intent.layout,
+                intent.createdAt, intent.markerPath);
+            const finalMetadata = fullMetadata(finalIdentityValue, intent.layout,
+                intent.createdAt, intent.markerPath);
+            const bothMetadata = {
+                ...pendingMetadata,
+                sessionId: intent.finalSessionId,
+            };
+            const identityOptions = intent.layout === 'project' ? windowOptions : sessionOptions;
+            const baseOptions = intent.layout === 'project' ? sessionOptions : windowOptions;
+            const expectedBase = intent.layout === 'project'
+                ? projectSessionMetadata(pendingIdentityValue)
+                : sessionWindowMetadata();
+            return recordsEqual(baseOptions, expectedBase)
+                && [pendingMetadata, finalMetadata, bothMetadata]
+                    .some(expected => recordsEqual(identityOptions, expected));
+        } catch (_error) {
+            return false;
+        }
+    }
+
+    async function sessionPromotionPartiallyRenamed(
+        intent: TmuxPromotingRuntimeBinding
+    ): Promise<boolean> {
+        if (intent.layout !== 'session') {
+            return false;
+        }
+        const sourceWindow = intent.sourceLocator.windowName || SESSION_WINDOW;
+        const finalWindow = intent.finalLocator.windowName;
+        if (!finalWindow || sourceWindow === finalWindow) {
+            return false;
+        }
+        try {
+            const rows = await client.listWindows();
+            const finalSessionRows = rows.filter(row =>
+                row.sessionName === intent.finalLocator.sessionName);
+            if (finalSessionRows.length !== 1 || finalSessionRows[0].windowName !== sourceWindow
+                || rows.some(row => row.sessionName === intent.sourceLocator.sessionName)) {
+                return false;
+            }
+            const sessionOptions = await client.getSessionOptions(
+                intent.finalLocator.sessionName
+            );
+            const windowOptions = await client.getWindowOptions(
+                intent.finalLocator.sessionName, sourceWindow
+            );
+            const pendingIdentityValue: AiSessionRuntimeIdentity = {
+                provider: intent.provider,
+                workspaceScopeIdentity: intent.workspaceScopeIdentity,
+                workspaceNavigationIdentity: intent.workspaceNavigationIdentity,
+                workspaceRootHostPaths: [...intent.workspaceRootHostPaths],
+                cwd: intent.cwd,
+                pendingId: intent.pendingId,
+            };
+            return recordsEqual(sessionOptions, fullMetadata(
+                pendingIdentityValue, intent.layout, intent.createdAt, intent.markerPath
+            )) && recordsEqual(windowOptions, sessionWindowMetadata());
+        } catch (_error) {
+            return false;
+        }
+    }
+
+    async function pendingMetadataMatches(
+        identity: AiSessionRuntimeIdentity,
+        locator: AiSessionTmuxLocator,
+        createdAt: string,
+        markerPath: string
+    ): Promise<boolean> {
+        try {
+            await verifyPendingMetadata(client, identity, locator, createdAt, markerPath);
+            return true;
+        } catch (_error) {
+            return false;
+        }
+    }
+
+    async function verifyAndCompletePromotion(
+        pending: AiSessionRuntimeSnapshot,
+        identity: AiSessionRuntimeIdentity,
+        finalSessionName: string,
+        finalLocator: AiSessionTmuxLocator,
+        pendingIdentityValue: AiSessionRuntimeIdentity
+    ): Promise<AiSessionRuntimeSnapshot<TTerminal>[]> {
+        await discovery.refresh(true);
+        const promoted = findVerified(identity, finalLocator);
+        if (!promoted) {
+            throw new Error('The promoted tmux runtime could not be verified.');
+        }
+        return completePromotion(
+            pending, identity, finalSessionName, finalLocator, promoted, pendingIdentityValue
+        );
+    }
+
+    async function completePromotion(
+        pending: AiSessionRuntimeSnapshot,
+        identity: AiSessionRuntimeIdentity,
+        finalSessionName: string,
+        finalLocator: AiSessionTmuxLocator,
+        promoted: AiSessionRuntimeSnapshot,
+        pendingIdentityValue: AiSessionRuntimeIdentity
+    ): Promise<AiSessionRuntimeSnapshot<TTerminal>[]> {
+        await persistKnown(identity, finalLocator, promoted);
+        await persistConsumed(pending, identity, finalSessionName, finalLocator);
+        await finishPromotionCleanup(pending, promoted, pendingIdentityValue);
+        return [withAttach(promoted)];
+    }
+
+    async function finishPromotionCleanup(
+        pending: AiSessionRuntimeSnapshot,
+        promoted: AiSessionRuntimeSnapshot,
+        pendingIdentityValue: AiSessionRuntimeIdentity
+    ): Promise<void> {
+        await migrateAttach(pending, promoted);
+        await runtimeStore.removePending(pendingIdentityValue);
+        await discovery.refresh(true);
+        await runtimeStore.removePromoting(pendingIdentityValue);
+    }
+
+    async function persistConsumed(
+        pending: AiSessionRuntimeSnapshot,
+        finalIdentityValue: AiSessionRuntimeIdentity,
+        finalSessionName: string,
+        finalLocator: AiSessionTmuxLocator
+    ): Promise<void> {
+        if (!pending.identity.pendingId || !finalIdentityValue.sessionId) {
+            throw new Error('A consumed pending runtime requires pending and final IDs.');
+        }
+        if (await runtimeStore.setConsumed({
+            version: 2,
+            state: 'consumed',
+            pendingId: pending.identity.pendingId,
+            provider: pending.identity.provider,
+            workspaceScopeIdentity: pending.identity.workspaceScopeIdentity,
+            workspaceNavigationIdentity: pending.identity.workspaceNavigationIdentity,
+            workspaceRootHostPaths: [...pending.identity.workspaceRootHostPaths],
+            cwd: pending.identity.cwd,
+            finalSessionId: finalIdentityValue.sessionId,
+            finalSessionName,
+            layout: finalLocator.layout,
+            finalLocator: { ...finalLocator },
+            consumedAtMs: nowMs(),
+        }) !== true) {
+            throw new Error('The consumed pending tmux binding could not be persisted.');
+        }
+    }
+
+    async function renameRuntime(from: AiSessionTmuxLocator, to: AiSessionTmuxLocator): Promise<void> {
+        if (from.layout !== to.layout) {
+            throw new Error('A tmux runtime cannot change layout during promotion.');
+        }
+        if (from.layout === 'project') {
+            if (!from.windowName || !to.windowName || from.sessionName !== to.sessionName) {
+                throw new Error('A project tmux promotion requires two windows in the same session.');
+            }
+            await client.renameWindow(from.sessionName, from.windowName, to.windowName);
+            return;
+        }
+        await client.renameSession(from.sessionName, to.sessionName);
+        const sourceWindow = from.windowName || SESSION_WINDOW;
+        if (!to.windowName) {
+            throw new Error('A session tmux promotion requires a final managed window name.');
+        }
+        await client.renameWindow(to.sessionName, sourceWindow, to.windowName);
+    }
+    return { promotePending, promotionTransitionMatches };
+}
+
+function recordsEqual(left: Record<string, string>, right: Record<string, string>): boolean {
+    const leftKeys = Object.keys(left).sort();
+    const rightKeys = Object.keys(right).sort();
+    return leftKeys.length === rightKeys.length
+        && leftKeys.every((key, index) => key === rightKeys[index] && left[key] === right[key]);
+}
+
+function locatorsEqual(left: AiSessionTmuxLocator, right: AiSessionTmuxLocator): boolean {
+    return left.layout === right.layout
+        && left.sessionName === right.sessionName
+        && left.windowName === right.windowName;
+}
+
+function asConflict(runtime: AiSessionRuntimeSnapshot): AiSessionRuntimeSnapshot {
+    return {
+        ...runtime,
+        identity: cloneAiSessionRuntimeIdentity(runtime.identity),
+        state: 'conflict',
+        ...(runtime.tmux ? { tmux: { ...runtime.tmux } } : {}),
+    };
+}

--- a/src/aiSessions/tmuxRuntimeBackend.ts
+++ b/src/aiSessions/tmuxRuntimeBackend.ts
@@ -35,6 +35,18 @@ import {
     parseManagedTmuxMetadata,
 } from './tmuxLayout';
 import {
+    fullMetadata,
+    projectSessionMetadata,
+    sessionWindowMetadata,
+    verifyPendingMetadata,
+    writeFinalMetadata,
+    writePendingMetadata,
+} from './tmuxManagedMetadata';
+import {
+    createTmuxPromotionCapability,
+    TmuxPromotionCapability,
+} from './tmuxPromotionCapability';
+import {
     TmuxAttachBinding,
     TmuxAttachBindingStore,
     TmuxAttachProcessId,
@@ -45,6 +57,16 @@ import {
     projectTmuxSessionMatchesWorkspace,
     tmuxLocatorMatchesIdentity,
 } from './tmuxNaming';
+import {
+    consumedMatchesPromotionIntent,
+    consumedPendingError,
+    PendingAmbiguousRuntimeBinding,
+    pendingAmbiguityMatches,
+    pendingIdentity,
+    pendingLifecycleLockKey,
+    pendingRequestFingerprint,
+    pendingSnapshotFromBinding,
+} from './tmuxPendingLifecycle';
 import {
     TmuxAmbiguousRuntimeBinding,
     TmuxConsumedPendingBinding,
@@ -111,8 +133,25 @@ export class TmuxRuntimeBackend<TTerminal = vscode.Terminal>
 implements AiSessionExecutableRuntimeBackend<TTerminal> {
     private readonly attaches = new Map<string, AttachEntry<TTerminal>>();
     private attachRestoreQueue: Promise<void> = Promise.resolve();
+    private readonly promotionCapability: TmuxPromotionCapability<TTerminal>;
 
-    constructor(private readonly dependencies: TmuxRuntimeBackendDependencies<TTerminal>) { }
+    constructor(private readonly dependencies: TmuxRuntimeBackendDependencies<TTerminal>) {
+        this.promotionCapability = createTmuxPromotionCapability<TTerminal>({
+            client: dependencies.client,
+            discovery: dependencies.discovery,
+            runtimeStore: dependencies.runtimeStore,
+            withCreationLock: (key, operation) => dependencies.withCreationLock(key, operation),
+            nowMs: () => dependencies.nowMs(),
+            requireAvailable: () => this.requireAvailable(),
+            findVerified: (identity, requiredLocator) => this.findVerified(identity, requiredLocator),
+            throwIfCollision: identity => this.throwIfCollision(identity),
+            locatorIsOccupied: locator => this.locatorIsOccupied(locator),
+            migrateAttach: (pending, promoted) => this.migrateAttach(pending, promoted),
+            withAttach: runtime => this.withAttach(runtime),
+            persistKnown: (identity, locator, lifecycle) =>
+                this.persistKnown(identity, locator, lifecycle),
+        });
+    }
 
     async refresh(force: boolean = false): Promise<void> {
         await this.requireAvailable();
@@ -308,337 +347,14 @@ implements AiSessionExecutableRuntimeBackend<TTerminal> {
         sessionId: string,
         sessionName: string
     ): Promise<AiSessionRuntimeSnapshot<TTerminal>[]> {
-        const pendingIdentityValue = pendingIdentity(identity);
-        if (!isValidAiSessionRuntimeIdentity(pendingIdentityValue) || !isIdentityField(sessionId)
-            || !isValidAiSessionPromotionDisplayName(sessionName)) {
-            return [];
-        }
-        return this.dependencies.withCreationLock<AiSessionRuntimeSnapshot<TTerminal>[]>(
-            pendingLifecycleLockKey(pendingIdentityValue), async () => {
-            const storedIntent = await this.dependencies.runtimeStore.getPromoting(pendingIdentityValue);
-            const storedLiveBinding = await this.dependencies.runtimeStore.getPending(pendingIdentityValue);
-            if (storedIntent && storedLiveBinding
-                && !promotionIntentMatchesLiveBinding(storedIntent, storedLiveBinding)) {
-                throw new Error('The pending tmux promotion intent conflicts with the live pending binding.');
-            }
-            const storedPending = storedIntent?.pendingBinding
-                || storedLiveBinding;
-            if (!storedPending) {
-                return [];
-            }
-            if (!pendingLifecycleIdentityMatches(storedPending, pendingIdentityValue)) {
-                return [];
-            }
-            if (storedIntent && storedIntent.finalSessionId !== sessionId) {
-                throw new Error('The pending tmux runtime has a conflicting promotion in progress.');
-            }
-            await this.requireAvailable();
-            await this.dependencies.discovery.refresh(true);
-            if (!storedIntent) {
-                this.throwIfCollision(pendingIdentityValue);
-            }
-            const consumed = await this.dependencies.runtimeStore.getConsumed(pendingIdentityValue);
-            if (consumed && consumed.finalSessionId !== sessionId) {
-                throw new Error('The pending tmux runtime was consumed by a different promotion.');
-            }
-            const ambiguous = await this.dependencies.runtimeStore.getAmbiguous(pendingIdentityValue);
-            if (ambiguous) {
-                throw new Error('The prior pending runtime creation result remains ambiguous.');
-            }
-            const currentIntent = await this.dependencies.runtimeStore.getPromoting(pendingIdentityValue);
-            const freshBinding = await this.dependencies.runtimeStore.getPending(pendingIdentityValue);
-            if (currentIntent && freshBinding
-                && !promotionIntentMatchesLiveBinding(currentIntent, freshBinding)) {
-                throw new Error('The pending tmux promotion intent conflicts with the live pending binding.');
-            }
-            const currentBinding = currentIntent?.pendingBinding || freshBinding;
-            if (!currentBinding || !pendingBindingsEqual(storedPending, currentBinding)
-                || (storedIntent && (!currentIntent || !promotionIntentsMatch(storedIntent, currentIntent)))) {
-                return [];
-            }
-            const currentPending = this.dependencies.discovery.getPending()
-                .find(runtime => aiSessionRuntimeIdentitiesEqual(
-                    runtime.identity, pendingIdentityValue
-                )
-                    && !!runtime.tmux && locatorsEqual(runtime.tmux, currentBinding.locator));
-            const pendingSnapshot = currentPending || pendingSnapshotFromBinding(currentBinding);
-            const finalIdentityValue: AiSessionRuntimeIdentity = {
-                provider: currentBinding.provider,
-                workspaceScopeIdentity: currentBinding.workspaceScopeIdentity,
-                workspaceNavigationIdentity: currentBinding.workspaceNavigationIdentity,
-                workspaceRootHostPaths: [...currentBinding.workspaceRootHostPaths],
-                cwd: currentBinding.cwd,
-                sessionId,
-            };
-            const preferredFinal = buildReadableTmuxLocator(finalIdentityValue, currentBinding.layout, {
-                projectName: currentBinding.projectName || 'workspace',
-                sessionName,
-            });
-            const finalLocator: AiSessionTmuxLocator = currentBinding.layout === 'project'
-                ? { ...preferredFinal, sessionName: currentBinding.locator.sessionName }
-                : preferredFinal;
-            const finalLockKey = getTmuxRuntimeKey(finalIdentityValue);
-            return this.dependencies.withCreationLock<AiSessionRuntimeSnapshot<TTerminal>[]>(
-                finalLockKey,
-                async () => {
-                    await this.dependencies.discovery.refresh(true);
-                    const intent = await this.dependencies.runtimeStore.getPromoting(pendingIdentityValue);
-                    if (!intent) {
-                        this.throwIfCollision(pendingIdentityValue);
-                    }
-                    this.throwIfCollision(finalIdentityValue);
-                    const expectedIntent = promotionIntent(currentBinding, {
-                        ...pendingSnapshot,
-                        markerPath: intent?.markerPath ?? pendingSnapshot.markerPath,
-                    }, finalIdentityValue, sessionName, finalLocator, this.dependencies.nowMs());
-                    if (intent && !promotionIntentsMatch(intent, expectedIntent)) {
-                        throw new Error('The pending tmux runtime has a conflicting promotion in progress.');
-                    }
-                    const consumed = await this.dependencies.runtimeStore.getConsumed(pendingIdentityValue);
-                    if (consumed) {
-                        if (consumed.finalSessionId !== sessionId
-                            || consumed.finalSessionName !== sessionName
-                            || !locatorsEqual(consumed.finalLocator, finalLocator)) {
-                            throw new Error('The pending tmux runtime was consumed by a different promotion.');
-                        }
-                        const completed = this.findVerified(finalIdentityValue, finalLocator);
-                        if (!completed) {
-                            return [];
-                        }
-                        await this.finishPromotionCleanup(pendingSnapshot, completed, pendingIdentityValue);
-                        return [this.withAttach(completed)];
-                    }
-                    const compatible = this.findVerified(finalIdentityValue, finalLocator);
-                    if (compatible) {
-                        if (!intent) {
-                            return [this.withAttach(asConflict(compatible)), this.withAttach(asConflict(pendingSnapshot))];
-                        }
-                        return this.completePromotion(pendingSnapshot, finalIdentityValue, sessionName,
-                            finalLocator, compatible, pendingIdentityValue);
-                    }
-                    const differentlyNamedFinal = this.findVerified(finalIdentityValue);
-                    if (differentlyNamedFinal) {
-                        return [
-                            this.withAttach(asConflict(differentlyNamedFinal)),
-                            this.withAttach(asConflict(pendingSnapshot)),
-                        ];
-                    }
-                    if (intent && await this.promotionTransitionMatches(intent, finalIdentityValue)) {
-                        await this.writeFinalMetadata(finalIdentityValue, finalLocator, {
-                            createdAt: intent.createdAt,
-                            markerPath: intent.markerPath,
-                        });
-                        await this.dependencies.client.clearPendingMetadata(finalLocator);
-                        return this.verifyAndCompletePromotion(pendingSnapshot, finalIdentityValue,
-                            sessionName, finalLocator, pendingIdentityValue);
-                    }
-                    if (intent && await this.sessionPromotionPartiallyRenamed(intent)) {
-                        const sourceWindow = intent.sourceLocator.windowName || SESSION_WINDOW;
-                        const finalWindow = intent.finalLocator.windowName;
-                        if (!finalWindow) {
-                            throw new Error('The pending tmux promotion state is ambiguous; no mutation was attempted.');
-                        }
-                        try {
-                            await this.dependencies.client.renameWindow(
-                                intent.finalLocator.sessionName, sourceWindow, finalWindow
-                            );
-                            await this.writeFinalMetadata(finalIdentityValue, finalLocator, {
-                                createdAt: intent.createdAt,
-                                markerPath: intent.markerPath,
-                            });
-                            await this.dependencies.client.clearPendingMetadata(finalLocator);
-                        } catch (error) {
-                            await this.dependencies.discovery.refresh(true);
-                            if (!this.findVerified(finalIdentityValue, finalLocator)) {
-                                throw error;
-                            }
-                        }
-                        return this.verifyAndCompletePromotion(pendingSnapshot, finalIdentityValue,
-                            sessionName, finalLocator, pendingIdentityValue);
-                    }
-                    const sourcePendingVerified = !!currentPending || !!(intent
-                        && await this.pendingMetadataMatches(pendingIdentityValue,
-                            intent.sourceLocator, intent.createdAt, intent.markerPath));
-                    if (!sourcePendingVerified) {
-                        throw new Error('The pending tmux promotion state is ambiguous; no mutation was attempted.');
-                    }
-                    if (await this.locatorIsOccupied(finalLocator)) {
-                        return [this.withAttach(asConflict(pendingSnapshot))];
-                    }
-
-                    if (!intent && await this.dependencies.runtimeStore.setPromoting(expectedIntent) !== true) {
-                        throw new Error('The pending tmux promotion intent could not be persisted.');
-                    }
-                    try {
-                        const sourceLocator = currentPending?.tmux || currentBinding.locator;
-                        await this.renameRuntime(sourceLocator, finalLocator);
-                        await this.writeFinalMetadata(finalIdentityValue, finalLocator, {
-                            createdAt: pendingSnapshot.createdAt,
-                            markerPath: pendingSnapshot.markerPath,
-                        });
-                        await this.dependencies.client.clearPendingMetadata(finalLocator);
-                    } catch (error) {
-                        await this.dependencies.discovery.refresh(true);
-                        const recovered = this.findVerified(finalIdentityValue, finalLocator);
-                        if (!recovered) {
-                            const sourceStillVerified = await this.pendingMetadataMatches(
-                                pendingIdentityValue, currentBinding.locator,
-                                pendingSnapshot.createdAt, pendingSnapshot.markerPath
-                            );
-                            if (sourceStillVerified && !await this.locatorIsOccupied(finalLocator)) {
-                                await this.dependencies.runtimeStore.removePromoting(pendingIdentityValue);
-                            }
-                            throw error;
-                        }
-                    }
-                    return this.verifyAndCompletePromotion(pendingSnapshot, finalIdentityValue,
-                        sessionName, finalLocator, pendingIdentityValue);
-                }
-            );
-        });
+        return this.promotionCapability.promotePending(identity, sessionId, sessionName);
     }
 
     private async promotionTransitionMatches(
         intent: TmuxPromotingRuntimeBinding,
         finalIdentityValue: AiSessionRuntimeIdentity
     ): Promise<boolean> {
-        try {
-            const sessionOptions = await this.dependencies.client.getSessionOptions(
-                intent.finalLocator.sessionName
-            );
-            const windowName = intent.finalLocator.layout === 'project'
-                ? intent.finalLocator.windowName
-                : intent.finalLocator.windowName || SESSION_WINDOW;
-            if (!windowName) {
-                return false;
-            }
-            const windowOptions = await this.dependencies.client.getWindowOptions(
-                intent.finalLocator.sessionName, windowName
-            );
-            const pendingIdentityValue: AiSessionRuntimeIdentity = {
-                provider: intent.provider,
-                workspaceScopeIdentity: intent.workspaceScopeIdentity,
-                workspaceNavigationIdentity: intent.workspaceNavigationIdentity,
-                workspaceRootHostPaths: [...intent.workspaceRootHostPaths],
-                cwd: intent.cwd,
-                pendingId: intent.pendingId,
-            };
-            const pendingMetadata = fullMetadata(pendingIdentityValue, intent.layout,
-                intent.createdAt, intent.markerPath);
-            const finalMetadata = fullMetadata(finalIdentityValue, intent.layout,
-                intent.createdAt, intent.markerPath);
-            const bothMetadata = {
-                ...pendingMetadata,
-                sessionId: intent.finalSessionId,
-            };
-            const identityOptions = intent.layout === 'project' ? windowOptions : sessionOptions;
-            const baseOptions = intent.layout === 'project' ? sessionOptions : windowOptions;
-            const expectedBase = intent.layout === 'project'
-                ? projectSessionMetadata(pendingIdentityValue)
-                : sessionWindowMetadata();
-            return recordsEqual(baseOptions, expectedBase)
-                && [pendingMetadata, finalMetadata, bothMetadata]
-                    .some(expected => recordsEqual(identityOptions, expected));
-        } catch (_error) {
-            return false;
-        }
-    }
-
-    private async sessionPromotionPartiallyRenamed(
-        intent: TmuxPromotingRuntimeBinding
-    ): Promise<boolean> {
-        if (intent.layout !== 'session') {
-            return false;
-        }
-        const sourceWindow = intent.sourceLocator.windowName || SESSION_WINDOW;
-        const finalWindow = intent.finalLocator.windowName;
-        if (!finalWindow || sourceWindow === finalWindow) {
-            return false;
-        }
-        try {
-            const rows = await this.dependencies.client.listWindows();
-            const finalSessionRows = rows.filter(row =>
-                row.sessionName === intent.finalLocator.sessionName);
-            if (finalSessionRows.length !== 1 || finalSessionRows[0].windowName !== sourceWindow
-                || rows.some(row => row.sessionName === intent.sourceLocator.sessionName)) {
-                return false;
-            }
-            const sessionOptions = await this.dependencies.client.getSessionOptions(
-                intent.finalLocator.sessionName
-            );
-            const windowOptions = await this.dependencies.client.getWindowOptions(
-                intent.finalLocator.sessionName, sourceWindow
-            );
-            const pendingIdentityValue: AiSessionRuntimeIdentity = {
-                provider: intent.provider,
-                workspaceScopeIdentity: intent.workspaceScopeIdentity,
-                workspaceNavigationIdentity: intent.workspaceNavigationIdentity,
-                workspaceRootHostPaths: [...intent.workspaceRootHostPaths],
-                cwd: intent.cwd,
-                pendingId: intent.pendingId,
-            };
-            return recordsEqual(sessionOptions, fullMetadata(
-                pendingIdentityValue, intent.layout, intent.createdAt, intent.markerPath
-            )) && recordsEqual(windowOptions, sessionWindowMetadata());
-        } catch (_error) {
-            return false;
-        }
-    }
-
-    private async pendingMetadataMatches(
-        identity: AiSessionRuntimeIdentity,
-        locator: AiSessionTmuxLocator,
-        createdAt: string,
-        markerPath: string
-    ): Promise<boolean> {
-        try {
-            await this.verifyPendingMetadata(identity, locator, createdAt, markerPath);
-            return true;
-        } catch (_error) {
-            return false;
-        }
-    }
-
-    private async verifyAndCompletePromotion(
-        pending: AiSessionRuntimeSnapshot,
-        identity: AiSessionRuntimeIdentity,
-        finalSessionName: string,
-        finalLocator: AiSessionTmuxLocator,
-        pendingIdentityValue: AiSessionRuntimeIdentity
-    ): Promise<AiSessionRuntimeSnapshot<TTerminal>[]> {
-        await this.dependencies.discovery.refresh(true);
-        const promoted = this.findVerified(identity, finalLocator);
-        if (!promoted) {
-            throw new Error('The promoted tmux runtime could not be verified.');
-        }
-        return this.completePromotion(
-            pending, identity, finalSessionName, finalLocator, promoted, pendingIdentityValue
-        );
-    }
-
-    private async completePromotion(
-        pending: AiSessionRuntimeSnapshot,
-        identity: AiSessionRuntimeIdentity,
-        finalSessionName: string,
-        finalLocator: AiSessionTmuxLocator,
-        promoted: AiSessionRuntimeSnapshot,
-        pendingIdentityValue: AiSessionRuntimeIdentity
-    ): Promise<AiSessionRuntimeSnapshot<TTerminal>[]> {
-        await this.persistKnown(identity, finalLocator, promoted);
-        await this.persistConsumed(pending, identity, finalSessionName, finalLocator);
-        await this.finishPromotionCleanup(pending, promoted, pendingIdentityValue);
-        return [this.withAttach(promoted)];
-    }
-
-    private async finishPromotionCleanup(
-        pending: AiSessionRuntimeSnapshot,
-        promoted: AiSessionRuntimeSnapshot,
-        pendingIdentityValue: AiSessionRuntimeIdentity
-    ): Promise<void> {
-        await this.migrateAttach(pending, promoted);
-        await this.dependencies.runtimeStore.removePending(pendingIdentityValue);
-        await this.dependencies.discovery.refresh(true);
-        await this.dependencies.runtimeStore.removePromoting(pendingIdentityValue);
+        return this.promotionCapability.promotionTransitionMatches(intent, finalIdentityValue);
     }
 
     async focus(runtime: AiSessionRuntimeSnapshot<TTerminal>): Promise<void> {
@@ -1158,20 +874,7 @@ implements AiSessionExecutableRuntimeBackend<TTerminal> {
         locator: AiSessionTmuxLocator,
         lifecycle: { createdAt: string; markerPath: string }
     ): Promise<void> {
-        const full = fullMetadata(identity, locator.layout, lifecycle.createdAt, lifecycle.markerPath);
-        if (locator.layout === 'project') {
-            if (!locator.windowName) {
-                throw new Error('A project tmux runtime requires a window name.');
-            }
-            await this.dependencies.client.setSessionOptions(locator.sessionName,
-                projectSessionMetadata(identity));
-            await this.dependencies.client.setWindowOptions(locator.sessionName, locator.windowName, full);
-            return;
-        }
-        await this.dependencies.client.setSessionOptions(locator.sessionName, full);
-        await this.dependencies.client.setWindowOptions(locator.sessionName,
-            locator.windowName || SESSION_WINDOW,
-            sessionWindowMetadata());
+        return writeFinalMetadata(this.dependencies.client, identity, locator, lifecycle);
     }
 
     private async writePendingMetadata(
@@ -1180,7 +883,7 @@ implements AiSessionExecutableRuntimeBackend<TTerminal> {
         createdAt: string,
         markerPath: string
     ): Promise<void> {
-        return this.writeFinalMetadata(identity, locator, { createdAt, markerPath });
+        return writePendingMetadata(this.dependencies.client, identity, locator, createdAt, markerPath);
     }
 
     private async verifyPendingMetadata(
@@ -1189,23 +892,7 @@ implements AiSessionExecutableRuntimeBackend<TTerminal> {
         createdAt: string,
         markerPath: string
     ): Promise<void> {
-        const sessionOptions = await this.dependencies.client.getSessionOptions(locator.sessionName);
-        const windowName = locator.layout === 'project'
-            ? locator.windowName
-            : locator.windowName || SESSION_WINDOW;
-        if (!windowName) {
-            throw new Error('The pending tmux metadata could not be verified.');
-        }
-        const windowOptions = await this.dependencies.client.getWindowOptions(locator.sessionName, windowName);
-        const expectedSession = locator.layout === 'project'
-            ? projectSessionMetadata(identity)
-            : fullMetadata(identity, locator.layout, createdAt, markerPath);
-        const expectedWindow = locator.layout === 'project'
-            ? fullMetadata(identity, locator.layout, createdAt, markerPath)
-            : sessionWindowMetadata();
-        if (!recordsEqual(sessionOptions, expectedSession) || !recordsEqual(windowOptions, expectedWindow)) {
-            throw new Error('The pending tmux metadata could not be verified.');
-        }
+        return verifyPendingMetadata(this.dependencies.client, identity, locator, createdAt, markerPath);
     }
 
     private async persistKnown(
@@ -1357,34 +1044,6 @@ implements AiSessionExecutableRuntimeBackend<TTerminal> {
         }
         await this.dependencies.runtimeStore.removeAmbiguous(request.identity);
         return recovered;
-    }
-
-    private async persistConsumed(
-        pending: AiSessionRuntimeSnapshot,
-        finalIdentityValue: AiSessionRuntimeIdentity,
-        finalSessionName: string,
-        finalLocator: AiSessionTmuxLocator
-    ): Promise<void> {
-        if (!pending.identity.pendingId || !finalIdentityValue.sessionId) {
-            throw new Error('A consumed pending runtime requires pending and final IDs.');
-        }
-        if (await this.dependencies.runtimeStore.setConsumed({
-            version: 2,
-            state: 'consumed',
-            pendingId: pending.identity.pendingId,
-            provider: pending.identity.provider,
-            workspaceScopeIdentity: pending.identity.workspaceScopeIdentity,
-            workspaceNavigationIdentity: pending.identity.workspaceNavigationIdentity,
-            workspaceRootHostPaths: [...pending.identity.workspaceRootHostPaths],
-            cwd: pending.identity.cwd,
-            finalSessionId: finalIdentityValue.sessionId,
-            finalSessionName,
-            layout: finalLocator.layout,
-            finalLocator: { ...finalLocator },
-            consumedAtMs: this.dependencies.nowMs(),
-        }) !== true) {
-            throw new Error('The consumed pending tmux binding could not be persisted.');
-        }
     }
 
     private findVerified(
@@ -1604,25 +1263,6 @@ implements AiSessionExecutableRuntimeBackend<TTerminal> {
             && (locator.layout === 'session' || row.windowName === locator.windowName));
     }
 
-    private async renameRuntime(from: AiSessionTmuxLocator, to: AiSessionTmuxLocator): Promise<void> {
-        if (from.layout !== to.layout) {
-            throw new Error('A tmux runtime cannot change layout during promotion.');
-        }
-        if (from.layout === 'project') {
-            if (!from.windowName || !to.windowName || from.sessionName !== to.sessionName) {
-                throw new Error('A project tmux promotion requires two windows in the same session.');
-            }
-            await this.dependencies.client.renameWindow(from.sessionName, from.windowName, to.windowName);
-            return;
-        }
-        await this.dependencies.client.renameSession(from.sessionName, to.sessionName);
-        const sourceWindow = from.windowName || SESSION_WINDOW;
-        if (!to.windowName) {
-            throw new Error('A session tmux promotion requires a final managed window name.');
-        }
-        await this.dependencies.client.renameWindow(to.sessionName, sourceWindow, to.windowName);
-    }
-
     private async migrateAttach(
         pending: AiSessionRuntimeSnapshot,
         promoted: AiSessionRuntimeSnapshot
@@ -1733,76 +1373,10 @@ function isSafeAttachTerminalName(value: unknown): value is string {
         && !LOCAL_CONTROL_CHARACTERS.test(value);
 }
 
-function pendingIdentity(identity: AiSessionRuntimeIdentity & { pendingId: string }): AiSessionRuntimeIdentity {
-    return {
-        ...cloneAiSessionRuntimeIdentity(identity),
-        pendingId: identity.pendingId,
-        sessionId: undefined,
-    };
-}
-
-function pendingLifecycleLockKey(identity: AiSessionRuntimeIdentity): string {
-    return `pending:${getTmuxRuntimeKey(identity)}`;
-}
-
-function pendingLifecycleIdentityMatches(
-    record: TmuxPendingRuntimeBinding | TmuxPromotingRuntimeBinding
-        | TmuxConsumedPendingBinding | TmuxAmbiguousRuntimeBinding,
-    identity: AiSessionRuntimeIdentity
-): boolean {
-    return record.pendingId === identity.pendingId && record.provider === identity.provider
-        && aiSessionRuntimeIdentitiesEqual({
-            ...cloneAiSessionRuntimeIdentity(identity),
-            sessionId: undefined,
-            pendingId: record.pendingId,
-        }, {
-            provider: record.provider,
-            workspaceScopeIdentity: record.workspaceScopeIdentity,
-            workspaceNavigationIdentity: record.workspaceNavigationIdentity,
-            workspaceRootHostPaths: [...record.workspaceRootHostPaths],
-            cwd: record.cwd,
-            pendingId: record.pendingId,
-        });
-}
-
 function requireLayout(value: unknown): asserts value is AiSessionTmuxLayout {
     if (value !== 'project' && value !== 'session') {
         throw new Error('The tmux runtime layout must be project or session.');
     }
-}
-
-function projectSessionMetadata(identity: AiSessionRuntimeIdentity): Record<string, string> {
-    return {
-        managed: '1',
-        version: '2',
-        layout: 'project',
-        workspaceScopeIdentity: identity.workspaceScopeIdentity,
-    };
-}
-
-function sessionWindowMetadata(): Record<string, string> {
-    return { managed: '1', version: '2', layout: 'session' };
-}
-
-function fullMetadata(
-    identity: AiSessionRuntimeIdentity,
-    layout: AiSessionTmuxLayout,
-    createdAt: string,
-    markerPath: string
-): Record<string, string> {
-    return {
-        managed: '1',
-        version: '2',
-        layout,
-        workspaceScopeIdentity: identity.workspaceScopeIdentity,
-        workspaceNavigationIdentity: identity.workspaceNavigationIdentity,
-        workspaceRootHostPaths: JSON.stringify(identity.workspaceRootHostPaths),
-        cwd: identity.cwd,
-        provider: identity.provider,
-        ...(identity.sessionId ? { sessionId: identity.sessionId } : { pendingId: identity.pendingId as string }),
-        createdAt,
-        ...(markerPath ? { marker: markerPath } : {}),
-    };
 }
 
 function attachBinding(runtime: AiSessionRuntimeSnapshot, terminalName: string): TmuxAttachBinding {
@@ -1947,213 +1521,6 @@ function recordsEqual(left: Record<string, string>, right: Record<string, string
         && leftKeys.every((key, index) => key === rightKeys[index] && left[key] === right[key]);
 }
 
-function pendingRequestFingerprint(request: AiSessionDeferredCreateRuntimeRequest): string {
-    const digest = createHash('sha256').update(JSON.stringify([
-        3,
-        request.identity.provider,
-        request.identity.workspaceScopeIdentity,
-        request.identity.workspaceNavigationIdentity,
-        request.identity.workspaceRootHostPaths.slice().sort(),
-        request.identity.pendingId,
-        request.identity.cwd,
-        request.createdAt,
-        request.excludedSessionIds,
-        request.title ?? null,
-        request.launchMarkerPath,
-    ]), 'utf8').digest('hex');
-    return `v3:${digest}`;
-}
-
-function identityFromPendingBinding(binding: TmuxPendingRuntimeBinding): AiSessionRuntimeIdentity {
-    return {
-        provider: binding.provider,
-        workspaceScopeIdentity: binding.workspaceScopeIdentity,
-        workspaceNavigationIdentity: binding.workspaceNavigationIdentity,
-        workspaceRootHostPaths: [...binding.workspaceRootHostPaths],
-        cwd: binding.cwd,
-        pendingId: binding.pendingId,
-    };
-}
-
-function pendingSnapshotFromBinding(binding: TmuxPendingRuntimeBinding): AiSessionPendingRuntimeSnapshot {
-    return {
-        identity: identityFromPendingBinding(binding),
-        backend: 'tmux',
-        state: 'pending',
-        markerPath: '',
-        runStartedAtMs: Date.parse(binding.createdAt),
-        attached: false,
-        tmux: { ...binding.locator },
-        createdAt: binding.createdAt,
-        excludedSessionIds: [...binding.excludedSessionIds],
-        ...(binding.projectName === undefined ? {} : { projectName: binding.projectName }),
-        ...(binding.title === undefined ? {} : { title: binding.title }),
-    };
-}
-
-function pendingBindingsEqual(left: TmuxPendingRuntimeBinding, right: TmuxPendingRuntimeBinding): boolean {
-    return left.pendingId === right.pendingId && left.provider === right.provider
-        && left.workspaceScopeIdentity === right.workspaceScopeIdentity
-        && left.workspaceNavigationIdentity === right.workspaceNavigationIdentity
-        && JSON.stringify(left.workspaceRootHostPaths.slice().sort())
-            === JSON.stringify(right.workspaceRootHostPaths.slice().sort())
-        && left.cwd === right.cwd
-        && left.createdAt === right.createdAt && left.projectName === right.projectName
-        && left.title === right.title
-        && left.acceptedAtMs === right.acceptedAtMs && left.layout === right.layout
-        && locatorsEqual(left.locator, right.locator)
-        && left.excludedSessionIds.length === right.excludedSessionIds.length
-        && left.excludedSessionIds.every((value, index) => value === right.excludedSessionIds[index]);
-}
-
-function promotionIntent(
-    binding: TmuxPendingRuntimeBinding,
-    pending: AiSessionRuntimeSnapshot,
-    finalIdentityValue: AiSessionRuntimeIdentity,
-    finalSessionName: string,
-    finalLocator: AiSessionTmuxLocator,
-    recordedAtMs: number
-): TmuxPromotingRuntimeBinding {
-    if (!finalIdentityValue.sessionId) {
-        throw new Error('A promotion intent requires a final session ID.');
-    }
-    const requestFingerprint = promotionRequestFingerprint(
-        binding, pending.markerPath, finalSessionName, finalLocator
-    );
-    return {
-        version: 2,
-        state: 'promoting',
-        pendingId: binding.pendingId,
-        provider: binding.provider,
-        workspaceScopeIdentity: binding.workspaceScopeIdentity,
-        workspaceNavigationIdentity: binding.workspaceNavigationIdentity,
-        workspaceRootHostPaths: [...binding.workspaceRootHostPaths],
-        cwd: binding.cwd,
-        createdAt: binding.createdAt,
-        markerPath: pending.markerPath,
-        pendingBinding: {
-            ...binding,
-            workspaceRootHostPaths: [...binding.workspaceRootHostPaths],
-            excludedSessionIds: [...binding.excludedSessionIds],
-            locator: { ...binding.locator },
-        },
-        finalSessionId: finalIdentityValue.sessionId,
-        finalSessionName,
-        layout: binding.layout,
-        sourceLocator: { ...binding.locator },
-        finalLocator: { ...finalLocator },
-        requestFingerprint,
-        recordedAtMs,
-    };
-}
-
-function promotionRequestFingerprint(
-    binding: TmuxPendingRuntimeBinding,
-    markerPath: string,
-    finalSessionName: string,
-    finalLocator: AiSessionTmuxLocator
-): string {
-    return createHash('sha256').update(JSON.stringify([
-        2,
-        binding.provider,
-        binding.workspaceScopeIdentity,
-        binding.workspaceNavigationIdentity,
-        binding.workspaceRootHostPaths.slice().sort(),
-        binding.pendingId,
-        binding.cwd,
-        binding.createdAt,
-        binding.excludedSessionIds,
-        binding.title ?? null,
-        binding.acceptedAtMs,
-        binding.layout,
-        binding.locator,
-        markerPath,
-        finalSessionName,
-        finalLocator,
-    ]), 'utf8').digest('hex');
-}
-
-function promotionIntentMatchesLiveBinding(
-    intent: TmuxPromotingRuntimeBinding,
-    binding: TmuxPendingRuntimeBinding
-): boolean {
-    return pendingBindingsEqual(intent.pendingBinding, binding)
-        && intent.requestFingerprint === promotionRequestFingerprint(
-            binding, intent.markerPath, intent.finalSessionName, intent.finalLocator
-        );
-}
-
-function promotionIntentsMatch(
-    left: TmuxPromotingRuntimeBinding,
-    right: TmuxPromotingRuntimeBinding
-): boolean {
-    return left.pendingId === right.pendingId && left.provider === right.provider
-        && left.workspaceScopeIdentity === right.workspaceScopeIdentity
-        && left.workspaceNavigationIdentity === right.workspaceNavigationIdentity
-        && JSON.stringify(left.workspaceRootHostPaths.slice().sort())
-            === JSON.stringify(right.workspaceRootHostPaths.slice().sort())
-        && left.cwd === right.cwd
-        && left.createdAt === right.createdAt && left.markerPath === right.markerPath
-        && pendingBindingsEqual(left.pendingBinding, right.pendingBinding)
-        && left.finalSessionId === right.finalSessionId
-        && left.finalSessionName === right.finalSessionName && left.layout === right.layout
-        && locatorsEqual(left.sourceLocator, right.sourceLocator)
-        && locatorsEqual(left.finalLocator, right.finalLocator)
-        && left.requestFingerprint === right.requestFingerprint;
-}
-
-function consumedMatchesPromotionIntent(
-    consumed: TmuxConsumedPendingBinding,
-    intent: TmuxPromotingRuntimeBinding
-): boolean {
-    return consumed.finalSessionName !== undefined
-        && pendingLifecycleIdentityMatches(consumed, intent)
-        && consumed.finalSessionId === intent.finalSessionId
-        && consumed.finalSessionName === intent.finalSessionName
-        && consumed.layout === intent.layout
-        && locatorsEqual(consumed.finalLocator, intent.finalLocator);
-}
-
-type PendingAmbiguousRuntimeBinding = TmuxAmbiguousRuntimeBinding & {
-    pendingId: string;
-    sessionId?: never;
-    cwd: string;
-    createdAt: string;
-    excludedSessionIds: string[];
-    projectName?: string;
-    title?: string;
-    markerPath?: string;
-    requestFingerprint: string;
-};
-
-function pendingAmbiguityMatches(
-    ambiguous: PendingAmbiguousRuntimeBinding,
-    request: AiSessionDeferredCreateRuntimeRequest,
-    binding: TmuxPendingRuntimeBinding,
-    locator: AiSessionTmuxLocator
-): boolean {
-    return ambiguous.provider === binding.provider
-        && ambiguous.workspaceScopeIdentity === binding.workspaceScopeIdentity
-        && ambiguous.workspaceNavigationIdentity === binding.workspaceNavigationIdentity
-        && JSON.stringify(ambiguous.workspaceRootHostPaths.slice().sort())
-            === JSON.stringify(binding.workspaceRootHostPaths.slice().sort())
-        && ambiguous.pendingId === binding.pendingId
-        && ambiguous.cwd === binding.cwd
-        && ambiguous.createdAt === binding.createdAt
-        && ambiguous.title === binding.title
-        && (ambiguous.markerPath || '') === request.launchMarkerPath
-        && ambiguous.layout === binding.layout
-        && locatorsEqual(ambiguous.locator, locator)
-        && ambiguous.excludedSessionIds.length === binding.excludedSessionIds.length
-        && ambiguous.excludedSessionIds.every((value, index) => value === binding.excludedSessionIds[index])
-        && (isLegacyPendingRequestFingerprint(ambiguous.requestFingerprint)
-            || ambiguous.requestFingerprint === pendingRequestFingerprint(request));
-}
-
-function isLegacyPendingRequestFingerprint(value: string): boolean {
-    return /^[a-f0-9]{64}$/.test(value);
-}
-
 function isProvenNoCreate(error: unknown): boolean {
     return error instanceof TmuxClientError
         && (error.category === 'nonzero-exit' || error.category === 'argument-list-too-long')
@@ -2198,17 +1565,4 @@ function isReadOnlyTmuxOperation(operation: string): boolean {
         || operation === 'has-session'
         || operation === 'get-session-options'
         || operation === 'get-window-options';
-}
-
-function consumedPendingError(record: TmuxConsumedPendingBinding): Error {
-    return new Error(`The pending tmux runtime was already consumed by session ${record.finalSessionId}.`);
-}
-
-function asConflict(runtime: AiSessionRuntimeSnapshot): AiSessionRuntimeSnapshot {
-    return {
-        ...runtime,
-        identity: cloneAiSessionRuntimeIdentity(runtime.identity),
-        state: 'conflict',
-        ...(runtime.tmux ? { tmux: { ...runtime.tmux } } : {}),
-    };
 }

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -73,7 +73,6 @@ import { TmuxClient, TmuxClientError } from './aiSessions/tmuxClient';
 import { TmuxRuntimeBindingStore } from './aiSessions/tmuxRuntimeBindingStore';
 import { TmuxAttachBindingStore } from './aiSessions/tmuxAttachBindingStore';
 import {
-    findTmuxCollisionRuntime,
     isCurrentRuntimeMarker,
     TmuxRuntimeDiscovery,
 } from './aiSessions/tmuxRuntimeDiscovery';
@@ -96,11 +95,9 @@ import { AiSessionExecutionController } from './aiSessions/executionController';
 import {
     AiSessionAttentionController,
 } from './aiSessions/attentionController';
-import type {
-    AiSessionAttentionEvaluation,
-} from './aiSessions/attentionController';
 import { createAiSessionStatusCapability } from './aiSessions/statusCapability';
 import { createAiSessionRuntimeSettlementCapability } from './aiSessions/runtimeSettlementCapability';
+import { createAiSessionAttentionEventCapability } from './aiSessions/attentionEventCapability';
 import { createNotifyConfiguration } from './aiSessions/notifyConfiguration';
 import { buildNotifyPayload } from './aiSessions/notifyIntegration/notifier';
 import {
@@ -173,9 +170,6 @@ const DASHBOARD_BOOTSTRAP_PHASE_ORDER = [
     'tmux-restore-wait',
     'startup-sequence',
 ];
-// Mirrors vscode.TerminalExitReason.User. The extension's minimum VS Code typings
-// predate TerminalExitStatus.reason, while supported hosts expose it at runtime.
-const USER_TERMINAL_EXIT_REASON = 3;
 let activeAiSessionAttentionBridgeClient: AttentionBridgeClient | null = null;
 let activeOpenWorkspaceBridgeClient: OpenWorkspaceBridgeClient | null = null;
 
@@ -709,15 +703,47 @@ async function initializeDashboard(
         getAttachTerminalName: getAiSessionTmuxAttachTerminalName,
     });
     let publishRestoredTmuxAttachTerminal = (): void => undefined;
-    ownResource(() => vscode.window.onDidOpenTerminal(terminal => {
-        if (!tmuxRuntimeBackend.isAttachTerminalCandidate(terminal)) {
-            return;
-        }
-        void tmuxRuntimeBackend.restoreAttachTerminals([terminal]).then(
-            () => publishRestoredTmuxAttachTerminal(),
-            error => logAiSessionRuntimeFailure('restore-opened-tmux-attach-terminal', error)
-        );
+    const aiSessionAttentionEvent = ownResource(() => createAiSessionAttentionEventCapability({
+        tmuxRuntimeDiscovery,
+        tmuxRuntimeBackend,
+        tmuxRuntimeStore,
+        aiSessionTerminalService,
+        getRuntimeConfiguration: () => aiSessionRuntimeConfiguration,
+        getCurrentOpenWorkspace: () => getCurrentOpenWorkspace(),
+        getActiveTerminal: () => vscode.window.activeTerminal || null,
+        postMessage: message => { void provider.postMessage(message); },
+        isVisible: () => provider.visible,
+        assertActive: () => resources.assertActive(),
+        createBridgeClient: (onAggregate, onError) => new AttentionBridgeClient(onAggregate, onError),
+        onDidOpenTerminal: callback => vscode.window.onDidOpenTerminal(callback),
+        onDidChangeActiveTerminal: callback => vscode.window.onDidChangeActiveTerminal(callback),
+        onDidCloseTerminal: callback => vscode.window.onDidCloseTerminal(callback),
+        logError,
+        logAiSessionRuntimeFailure,
+        getRuntimeCoordinator: () => aiSessionRuntimeCoordinator,
+        getAttentionController: () => aiSessionAttentionController,
+        runSafeLifecycleTask: (operation, task) =>
+            aiSessionRuntimeSettlement.runSafeLifecycleTask(operation, task),
+        evaluateLifecycleTick: () => evaluateAiSessionLifecycleTick(),
+        refreshViewsNow: reason => { void aiSessionDashboardController.refreshNow(reason); },
+        scheduleRefresh: reason => aiSessionDashboardController.scheduleRefresh(reason),
+        postOpenWorkspacesUpdated: () => openWorkspaceDashboardController?.postUpdated(),
+        getActiveTerminalHighlighter: () => activeAiSessionTerminalHighlighter,
+        getTmuxFocusedRuntimeMonitor: () => tmuxFocusedRuntimeMonitor,
+        publishRestoredAttachTerminal: () => publishRestoredTmuxAttachTerminal(),
     }));
+    const evaluateAiSessionAttention = aiSessionAttentionEvent.evaluateAttention;
+    const hasLiveTmuxOwnership = aiSessionAttentionEvent.hasLiveTmuxOwnership;
+    const getAiSessionRuntimeById = aiSessionAttentionEvent.getRuntimeById;
+    const getAiSessionRuntimeCollision = aiSessionAttentionEvent.getRuntimeCollision;
+    const getFocusedAiSessionRuntimeIdentity = aiSessionAttentionEvent.getFocusedRuntimeIdentity;
+    const runtimeBelongsToCurrentWorkspace = aiSessionAttentionEvent.belongsToCurrentWorkspace;
+    const refreshAiSessionViewsIncrementally = aiSessionAttentionEvent.refreshViewsIncrementally;
+    const postAiSessionAttentionState = aiSessionAttentionEvent.postAttentionState;
+    const acknowledgeAiSessionAttentionEventIds = aiSessionAttentionEvent.acknowledgeEventIds;
+    const acknowledgeAiSessionAttention = aiSessionAttentionEvent.acknowledgeAttention;
+    const publishDeferredTmuxRestoreIfReady = aiSessionAttentionEvent.publishDeferredRestoreIfReady;
+    ownResource(() => aiSessionAttentionEvent.registerTerminalRestoreHandler());
     const aiSessionRuntimeCoordinator = new AiSessionRuntimeCoordinator<vscode.Terminal>({
         direct: directTerminalRuntimeBackend,
         tmux: tmuxRuntimeBackend,
@@ -755,9 +781,6 @@ async function initializeDashboard(
     const tmuxRestoreCompleted = await timeBootstrapPhase('tmux-restore-wait', () =>
         settlesWithinBudget(tmuxRestoreTask, AI_SESSION_TMUX_RESTORE_BUDGET_MS));
     resources.assertActive();
-    let deferredTmuxRestoreSettled = false;
-    let deferredTmuxRestoreRefreshReady = false;
-    let deferredTmuxRestoreRefreshPublished = false;
     if (!tmuxRestoreCompleted) {
         logDashboardDiagnostic({
             event: 'agent-pivot-bootstrap-tmux-restore-deferred',
@@ -770,7 +793,7 @@ async function initializeDashboard(
             } catch (_error) {
                 return;
             }
-            deferredTmuxRestoreSettled = true;
+            aiSessionAttentionEvent.setDeferredRestoreSettled();
             logDashboardDiagnostic({
                 event: 'agent-pivot-bootstrap-tmux-restore-settled',
                 generation: bootstrapGeneration,
@@ -915,7 +938,6 @@ async function initializeDashboard(
     });
     let aiSessionUpdateSequence = 0;
     let currentAiSessionRefreshReason = 'refresh';
-    let aiSessionAttentionBridgeClient: AttentionBridgeClient;
     const notifyConfiguration = ownResource(() => createNotifyConfiguration({
         context,
         getConfiguration: () => getAgentPivotConfiguration(),
@@ -960,7 +982,7 @@ async function initializeDashboard(
         getWorkspaceTarget: getCurrentWorkspaceActionTargetWithoutCardId,
         getProviders: getRegisteredAiSessionProviders,
         getRuntimeById: getAiSessionRuntimeById,
-        publish: (items, forceHeartbeat) => aiSessionAttentionBridgeClient.publish(items, forceHeartbeat),
+        publish: (items, forceHeartbeat) => aiSessionAttentionEvent.publish(items, forceHeartbeat),
         scheduleRefresh: reason => scheduleAiSessionRefresh(reason),
         onAttentionEvents: events => {
             for (const event of events) {
@@ -1024,25 +1046,6 @@ async function initializeDashboard(
         clearInterval: handle => clearInterval(handle as NodeJS.Timeout),
     }));
     const evaluateAiSessionLifecycleTick = (): void => aiSessionStatus.tick();
-    const getAiSessionAttentionEventIds = (identity: ActiveAiSessionTerminalIdentity): string[] => {
-        const sessionKey = getAiSessionKey(identity.provider, identity.sessionId);
-        return aiSessionAttentionController.getRecoverySessionEvents()
-            .find(session => session.sessionKey === sessionKey)?.eventIds || [];
-    };
-    const acknowledgeAiSessionAttentionEventIds = async (eventIds: string[]): Promise<void> => {
-        const uniqueEventIds = Array.from(new Set(eventIds.filter(eventId => Boolean(eventId))));
-        if (!uniqueEventIds.length) {
-            return;
-        }
-        aiSessionAttentionController.acknowledge(uniqueEventIds);
-        refreshAiSessionViewsIncrementally();
-        await aiSessionAttentionBridgeClient.acknowledge(uniqueEventIds);
-    };
-    const acknowledgeAiSessionAttention = async (
-        identity: ActiveAiSessionTerminalIdentity
-    ): Promise<void> => {
-        await acknowledgeAiSessionAttentionEventIds(getAiSessionAttentionEventIds(identity));
-    };
     const aiSessionRuntimeSettlement = ownResource(() => createAiSessionRuntimeSettlementCapability({
         runtimeBelongsToCurrentWorkspace,
         evaluateAttention: evaluateAiSessionAttention,
@@ -1056,22 +1059,15 @@ async function initializeDashboard(
     }));
     const runSafeAiSessionRuntimeLifecycleTask = aiSessionRuntimeSettlement.runSafeLifecycleTask;
     const queueAiSessionRuntimeSettlements = aiSessionRuntimeSettlement.queueSettlements;
-    aiSessionAttentionBridgeClient = ownResource(() => new AttentionBridgeClient(
-        aggregate => {
-            if (aiSessionAttentionController.setRemoteAggregate(aggregate)) {
-                scheduleAttentionViewsRefresh();
-            }
-        },
-        error => logError('AI session attention bridge unavailable; using local-window monitoring.', error)
-    ));
+    aiSessionAttentionEvent.startBridgeClient();
     resources.own({
         dispose: () => {
-            if (activeAiSessionAttentionBridgeClient === aiSessionAttentionBridgeClient) {
+            if (activeAiSessionAttentionBridgeClient === aiSessionAttentionEvent.bridgeClient) {
                 activeAiSessionAttentionBridgeClient = null;
             }
         },
     });
-    activeAiSessionAttentionBridgeClient = aiSessionAttentionBridgeClient;
+    activeAiSessionAttentionBridgeClient = aiSessionAttentionEvent.bridgeClient;
     ownTimer(
         () => setTimeout(() => {
             void runSafeAiSessionRuntimeLifecycleTask(
@@ -1277,7 +1273,7 @@ async function initializeDashboard(
                 void tmuxFocusedRuntimeMonitor.request();
             }
             await dashboardRuntimeController.handleAiSessionViewVisibilityChanged(visible);
-            deferredTmuxRestoreRefreshReady = true;
+            aiSessionAttentionEvent.setDeferredRestoreRefreshReady(true);
             publishDeferredTmuxRestoreIfReady();
         },
         onVisiblePrepared: () =>
@@ -1285,7 +1281,7 @@ async function initializeDashboard(
                 fallbackToFullRefresh: false,
             }),
         onDisposed: () => {
-            deferredTmuxRestoreRefreshReady = false;
+            aiSessionAttentionEvent.setDeferredRestoreRefreshReady(false);
         },
         logError,
     };
@@ -1442,50 +1438,7 @@ async function initializeDashboard(
     publishRestoredTmuxAttachTerminal = refreshAiSessionViewsIncrementally;
     aiSessionRuntimeSettlement.startSettlementScan();
 
-    ownResource(() =>
-        vscode.window.onDidChangeActiveTerminal(() => {
-            activeAiSessionTerminalHighlighter.sync();
-            void tmuxFocusedRuntimeMonitor.request();
-            refreshAiSessionViewsIncrementally();
-            void runSafeAiSessionRuntimeLifecycleTask(
-                'evaluate-attention-active-terminal', evaluateAiSessionAttention
-            );
-        }));
-    ownResource(() =>
-        vscode.window.onDidCloseTerminal(terminal => {
-            const closedRuntimes = aiSessionRuntimeCoordinator.getActive()
-                .filter(runtime => runtime.backend === 'vscode' && runtime.terminal === terminal
-                    && Boolean(runtime.identity.sessionId));
-            const exitStatus = terminal.exitStatus as
-                (vscode.TerminalExitStatus & { reason?: number }) | undefined;
-            const userClosedTerminal = exitStatus?.reason === USER_TERMINAL_EXIT_REASON;
-            const closedSessions: ActiveAiSessionTerminalIdentity[] = closedRuntimes.map(runtime => ({
-                provider: runtime.identity.provider,
-                sessionId: runtime.identity.sessionId as string,
-                workspaceScopeIdentity: runtime.identity.workspaceScopeIdentity,
-            }));
-            const hadRuntimeClient = [...aiSessionRuntimeCoordinator.getActive(), ...aiSessionRuntimeCoordinator.getPending()]
-                .some(runtime => runtime.terminal === terminal);
-            aiSessionRuntimeCoordinator.handleClosedTerminal(terminal);
-            evaluateAiSessionLifecycleTick();
-            activeAiSessionTerminalHighlighter.handleTerminalClosed(terminal);
-            if (closedSessions.length || hadRuntimeClient) {
-                refreshAiSessionViewsIncrementally();
-                if (userClosedTerminal) {
-                    void runSafeAiSessionRuntimeLifecycleTask(
-                        'acknowledge-user-terminal-close',
-                        async () => {
-                            for (const identity of closedSessions) {
-                                await acknowledgeAiSessionAttention(identity);
-                            }
-                        }
-                    );
-                }
-                void runSafeAiSessionRuntimeLifecycleTask(
-                    'evaluate-attention-closed-terminal', evaluateAiSessionAttention
-                );
-            }
-        }));
+    ownResource(() => aiSessionAttentionEvent.registerTerminalEventHandlers());
 
     const stewardInfos: StewardInfos = {
         relevantExtensionsInstalls: {
@@ -1738,136 +1691,6 @@ async function initializeDashboard(
         }
     }
 
-    async function evaluateAiSessionAttention(
-        runtimeOverrides: ReadonlyArray<{
-            providerId: AiSessionProviderId;
-            sessionId: string;
-            attentionKey: string;
-            runtime: AiSessionRuntimeSnapshot<vscode.Terminal>;
-        }> = []
-    ): Promise<AiSessionAttentionEvaluation> {
-        try {
-            await tmuxRuntimeDiscovery.loadPersistedInactive();
-        } catch (error) {
-            logAiSessionRuntimeFailure('attention-inactive-restore', error);
-        }
-        const hasRelevantTmux = await hasRelevantTmuxRuntime();
-        if (hasRelevantTmux && await hasLiveTmuxOwnership()) {
-            try {
-                await aiSessionRuntimeCoordinator.refreshForHost(false);
-            } catch (error) {
-                logAiSessionRuntimeFailure('attention-refresh', error);
-            }
-        }
-        return aiSessionAttentionController.evaluate(runtimeOverrides);
-    }
-
-    async function hasLiveTmuxOwnership(): Promise<boolean> {
-        if (aiSessionRuntimeConfiguration.mode === 'tmux'
-            || tmuxRuntimeDiscovery.getActive().length
-            || tmuxRuntimeDiscovery.getPending().length
-            || tmuxRuntimeBackend.getConflicts().length) {
-            return true;
-        }
-        try {
-            const [known, pending] = await Promise.all([
-                tmuxRuntimeStore.listKnown(),
-                tmuxRuntimeStore.listPending(),
-            ]);
-            return known.length > 0 || pending.length > 0;
-        } catch (error) {
-            logAiSessionRuntimeFailure('attention-relevance', error);
-            return true;
-        }
-    }
-
-    async function hasRelevantTmuxRuntime(): Promise<boolean> {
-        if (tmuxRuntimeDiscovery.getInactive().length) {
-            return true;
-        }
-        try {
-            const inactive = await tmuxRuntimeStore.listInactive();
-            return inactive.length > 0 || await hasLiveTmuxOwnership();
-        } catch (error) {
-            logAiSessionRuntimeFailure('attention-relevance', error);
-            return true;
-        }
-    }
-
-    function getAiSessionRuntimeById(
-        providerId: AiSessionProviderId,
-        sessionId: string
-    ): AiSessionRuntimeSnapshot<vscode.Terminal> | null {
-        const workspaceScopeIdentity = getCurrentOpenWorkspace()?.scopeIdentity;
-        if (!workspaceScopeIdentity) {
-            return null;
-        }
-        const collision = getAiSessionRuntimeCollision(
-            providerId, sessionId, workspaceScopeIdentity
-        );
-        if (collision) {
-            return collision;
-        }
-        const live = aiSessionRuntimeCoordinator.getById(
-            providerId, sessionId, workspaceScopeIdentity
-        );
-        if (live) {
-            return live;
-        }
-        const liveConflicts = aiSessionRuntimeCoordinator.getActive().filter(runtime =>
-            runtime.identity.provider === providerId && runtime.identity.sessionId === sessionId
-            && runtime.identity.workspaceScopeIdentity === workspaceScopeIdentity);
-        if (liveConflicts.length > 1) {
-            return { ...liveConflicts[0], state: 'conflict' };
-        }
-        const inactiveTmux: AiSessionRuntimeSnapshot<vscode.Terminal>[] = tmuxRuntimeDiscovery.getInactive()
-            .filter(runtime => runtime.identity.provider === providerId
-                && runtime.identity.sessionId === sessionId
-                && runtime.identity.workspaceScopeIdentity === workspaceScopeIdentity)
-            .map(runtime => {
-                const { terminal: _terminal, ...detached } = runtime;
-                return {
-                    ...detached,
-                    identity: cloneAiSessionRuntimeIdentity(runtime.identity),
-                    ...(runtime.tmux ? { tmux: { ...runtime.tmux } } : {}),
-                };
-            });
-        const completedDirect = aiSessionTerminalService.getTrackedTerminalEntries()
-            .filter(entry => entry.provider === providerId && entry.sessionId === sessionId
-                && aiSessionTerminalService.isComplete(entry) && !!entry.runtimeIdentity
-                && entry.runtimeIdentity.workspaceScopeIdentity === workspaceScopeIdentity)
-            .map(entry => ({
-                identity: cloneAiSessionRuntimeIdentity(entry.runtimeIdentity),
-                backend: 'vscode' as const,
-                state: 'completed' as const,
-                markerPath: entry.markerPath,
-                runStartedAtMs: entry.runStartedAtMs,
-                attached: true,
-                terminal: entry.terminal,
-            }));
-        const inactive = [...inactiveTmux, ...completedDirect];
-        return inactive.length === 1 ? inactive[0] : null;
-    }
-
-    function getAiSessionRuntimeCollision(
-        providerId: AiSessionProviderId,
-        sessionId: string,
-        workspaceScopeIdentity: string
-    ): AiSessionRuntimeSnapshot<vscode.Terminal> | null {
-        return findTmuxCollisionRuntime(
-            tmuxRuntimeDiscovery.getDiagnostics(), providerId, sessionId,
-            workspaceScopeIdentity
-        ) as AiSessionRuntimeSnapshot<vscode.Terminal> | null;
-    }
-
-    function getFocusedAiSessionRuntimeIdentity() {
-        const activeTerminal = vscode.window.activeTerminal || null;
-        const tmuxRuntime = tmuxRuntimeBackend.getFocusedRuntime(activeTerminal);
-        return tmuxRuntime && runtimeBelongsToCurrentWorkspace(tmuxRuntime)
-            ? tmuxRuntime.identity
-            : activeAiSessionTerminalHighlighter.getIdentity();
-    }
-
     async function openCurrentAiSessionConversation(): Promise<void> {
         const target = getCurrentWorkspaceActionTargetWithoutCardId();
         if (!target) {
@@ -1930,14 +1753,6 @@ async function initializeDashboard(
         }
     }
 
-    function runtimeBelongsToCurrentWorkspace(
-        runtime: AiSessionRuntimeSnapshot<vscode.Terminal>
-    ): boolean {
-        const workspaceScopeIdentity = getCurrentOpenWorkspace()?.scopeIdentity;
-        return !!workspaceScopeIdentity
-            && runtime.identity.workspaceScopeIdentity === workspaceScopeIdentity;
-    }
-
     function getAiSessionTmuxAttachTerminalName(
         runtime: AiSessionRuntimeSnapshot
     ): string | undefined {
@@ -1996,45 +1811,12 @@ async function initializeDashboard(
         aiSessionDashboardController.scheduleRefresh(reason);
     }
 
-    function scheduleAttentionViewsRefresh() {
-        scheduleAiSessionRefresh('attention');
-        openWorkspaceDashboardController?.postUpdated();
-    }
-
     function setAiSessionWatchersActive(active: boolean) {
         aiSessionDashboardController.setWatchersActive(active);
     }
 
     function scheduleNewAiSessionRefresh(providerId: AiSessionProviderId) {
         aiSessionDashboardController.scheduleNewSessionRefresh(providerId);
-    }
-
-    function refreshAiSessionViewsIncrementally() {
-        void aiSessionDashboardController.refreshNow();
-    }
-
-    function publishDeferredTmuxRestoreIfReady(): void {
-        if (!deferredTmuxRestoreSettled
-            || !deferredTmuxRestoreRefreshReady
-            || deferredTmuxRestoreRefreshPublished
-            || !provider.visible) {
-            return;
-        }
-        try {
-            resources.assertActive();
-        } catch (_error) {
-            return;
-        }
-        deferredTmuxRestoreRefreshPublished = true;
-        void aiSessionDashboardController.refreshNow('tmux-bootstrap-restore');
-    }
-
-    function postAiSessionAttentionState() {
-        void provider.postMessage({
-            type: 'ai-session-attention-state',
-            sessionEvents: aiSessionAttentionController.getRecoverySessionEvents(),
-            eventIds: aiSessionAttentionController.getAttentionEventIds(),
-        });
     }
 
     function postBatchArchiveCompletion(message: AiSessionBatchArchiveCompletedMessage) {

--- a/tests/contract/aiSessions/attentionEventCapability.test.js
+++ b/tests/contract/aiSessions/attentionEventCapability.test.js
@@ -1,0 +1,554 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+    createAiSessionAttentionEventCapability,
+} = require('../../../out/aiSessions/attentionEventCapability');
+
+function flushAsync() {
+    return new Promise(resolve => setImmediate(resolve));
+}
+
+async function flushAll() {
+    for (let index = 0; index < 10; index++) {
+        await flushAsync();
+    }
+}
+
+function makeIdentity(overrides = {}) {
+    return {
+        provider: 'codex',
+        workspaceScopeIdentity: 'scope-1',
+        workspaceNavigationIdentity: 'nav-1',
+        workspaceRootHostPaths: ['/work'],
+        cwd: '/work',
+        sessionId: 'session-a',
+        ...overrides,
+    };
+}
+
+function makeRuntime(overrides = {}) {
+    return {
+        identity: makeIdentity(overrides.identity),
+        backend: 'vscode',
+        state: 'active',
+        markerPath: '/markers/a',
+        runStartedAtMs: 700,
+        attached: true,
+        terminal: { name: 'terminal-a' },
+        ...overrides,
+    };
+}
+
+function createFixture(overrides = {}) {
+    const calls = [];
+    const listeners = {};
+    const disposals = [];
+    const terminal = { name: 'fixture-terminal' };
+    const bridgeClient = {
+        publish: async (items, forceHeartbeat) => {
+            calls.push(['bridge-publish', items, forceHeartbeat]);
+            return true;
+        },
+        acknowledge: async eventIds => {
+            calls.push(['bridge-acknowledge', eventIds]);
+        },
+        dispose: () => {
+            calls.push(['bridge-dispose']);
+        },
+    };
+    const coordinator = {
+        refreshForHost: async force => {
+            calls.push(['refresh-for-host', force]);
+            if (overrides.refreshForHostError) {
+                throw overrides.refreshForHostError;
+            }
+        },
+        getById: () => overrides.liveRuntime || null,
+        getActive: () => overrides.activeRuntimes || [],
+        getPending: () => overrides.pendingRuntimes || [],
+        handleClosedTerminal: closed => {
+            calls.push(['runtime-close', closed]);
+        },
+    };
+    const attentionController = {
+        evaluate: async runtimeOverrides => {
+            calls.push(['attention-evaluate', runtimeOverrides]);
+            return { enabled: true, published: true, eventIdsBySession: {}, inScopeSessionKeys: [], overflowedSessionKeys: [] };
+        },
+        acknowledge: eventIds => {
+            calls.push(['local-acknowledge', eventIds]);
+        },
+        getRecoverySessionEvents: () => overrides.recoverySessionEvents
+            || [{ sessionKey: 'codex:session-a', eventIds: ['evt-1', 'evt-1', 'evt-2'] }],
+        getAttentionEventIds: () => ['evt-1', 'evt-2'],
+        setRemoteAggregate: aggregate => {
+            calls.push(['set-remote-aggregate', aggregate]);
+            return overrides.remoteAggregateChanged !== false;
+        },
+    };
+    const highlighter = {
+        sync: () => {
+            calls.push(['highlight-sync']);
+        },
+        handleTerminalClosed: closed => {
+            calls.push(['highlight-close', closed]);
+        },
+        getIdentity: () => overrides.highlighterIdentity === undefined
+            ? { provider: 'codex', sessionId: 'highlighted', workspaceScopeIdentity: 'scope-1' }
+            : overrides.highlighterIdentity,
+    };
+    const registerListener = name => callback => {
+        listeners[name] = callback;
+        const entry = { name, disposed: false };
+        disposals.push(entry);
+        return { dispose: () => { entry.disposed = true; } };
+    };
+    const capability = createAiSessionAttentionEventCapability({
+        tmuxRuntimeDiscovery: {
+            loadPersistedInactive: async () => {
+                calls.push(['load-persisted-inactive']);
+                if (overrides.loadPersistedInactiveError) {
+                    throw overrides.loadPersistedInactiveError;
+                }
+            },
+            getActive: () => overrides.discoveryActive || [],
+            getPending: () => overrides.discoveryPending || [],
+            getInactive: () => overrides.discoveryInactive || [],
+            getDiagnostics: () => overrides.discoveryDiagnostics || [],
+        },
+        tmuxRuntimeBackend: {
+            getConflicts: () => overrides.backendConflicts || [],
+            getFocusedRuntime: activeTerminal => {
+                calls.push(['get-focused-runtime', activeTerminal]);
+                return overrides.focusedTmuxRuntime || null;
+            },
+            isAttachTerminalCandidate: candidate => {
+                calls.push(['is-attach-candidate', candidate]);
+                return Boolean(overrides.attachCandidate);
+            },
+            restoreAttachTerminals: async terminals => {
+                calls.push(['restore-attach-terminals', terminals]);
+                if (overrides.restoreError) {
+                    throw overrides.restoreError;
+                }
+            },
+        },
+        tmuxRuntimeStore: {
+            listKnown: async () => {
+                if (overrides.storeError) {
+                    throw overrides.storeError;
+                }
+                return overrides.knownBindings || [];
+            },
+            listPending: async () => {
+                if (overrides.storeError) {
+                    throw overrides.storeError;
+                }
+                return overrides.pendingBindings || [];
+            },
+            listInactive: async () => {
+                if (overrides.storeError) {
+                    throw overrides.storeError;
+                }
+                return overrides.inactiveBindings || [];
+            },
+        },
+        aiSessionTerminalService: {
+            getTrackedTerminalEntries: () => overrides.trackedEntries || [],
+            isComplete: () => true,
+        },
+        getRuntimeConfiguration: () => ({ mode: overrides.runtimeMode || 'vscode' }),
+        getCurrentOpenWorkspace: () => overrides.workspace === undefined
+            ? { scopeIdentity: 'scope-1' }
+            : overrides.workspace,
+        getActiveTerminal: () => overrides.activeTerminal === undefined ? terminal : overrides.activeTerminal,
+        postMessage: message => {
+            calls.push(['post-message', message]);
+        },
+        isVisible: () => overrides.visible !== false,
+        assertActive: () => {
+            if (overrides.assertActiveError) {
+                throw overrides.assertActiveError;
+            }
+        },
+        createBridgeClient: (onAggregate, onError) => {
+            listeners.bridgeAggregate = onAggregate;
+            listeners.bridgeError = onError;
+            calls.push(['create-bridge-client']);
+            return bridgeClient;
+        },
+        onDidOpenTerminal: registerListener('openTerminal'),
+        onDidChangeActiveTerminal: registerListener('activeTerminal'),
+        onDidCloseTerminal: registerListener('closeTerminal'),
+        logError: (message, error) => {
+            calls.push(['log-error', message, error]);
+        },
+        logAiSessionRuntimeFailure: (operation, error) => {
+            calls.push(['runtime-failure', operation, error]);
+        },
+        getRuntimeCoordinator: () => coordinator,
+        getAttentionController: () => attentionController,
+        runSafeLifecycleTask: async (operation, task) => {
+            calls.push(['lifecycle-task', operation]);
+            try {
+                await task();
+            } catch (error) {
+                calls.push(['lifecycle-task-failed', operation, error]);
+            }
+        },
+        evaluateLifecycleTick: () => {
+            calls.push(['lifecycle-tick']);
+        },
+        refreshViewsNow: reason => {
+            calls.push(['refresh', reason || 'refresh']);
+        },
+        scheduleRefresh: reason => {
+            calls.push(['schedule-refresh', reason]);
+        },
+        postOpenWorkspacesUpdated: () => {
+            calls.push(['post-open-workspaces']);
+        },
+        getActiveTerminalHighlighter: () => highlighter,
+        getTmuxFocusedRuntimeMonitor: () => ({
+            request: async () => {
+                calls.push(['monitor-request']);
+            },
+        }),
+        publishRestoredAttachTerminal: () => {
+            calls.push(['publish-restored-attach']);
+        },
+    });
+    return { capability, calls, listeners, disposals, terminal, bridgeClient, coordinator };
+}
+
+function indexOfCall(calls, name, fromIndex = 0) {
+    return calls.findIndex((call, index) => index >= fromIndex && call[0] === name);
+}
+
+test('ATTENTION-EXECUTION-STATE-SYNC-001 attention ownership probes fail open when the tmux store listing fails', async () => {
+    const { capability, calls } = createFixture({ storeError: new Error('store offline') });
+    assert.equal(await capability.hasLiveTmuxOwnership(), true,
+        'a store listing failure must keep ownership so attention keeps flowing');
+    const relevanceFailures = calls.filter(call =>
+        call[0] === 'runtime-failure' && call[1] === 'attention-relevance');
+    assert.ok(relevanceFailures.length >= 1, 'the fail-open path reports the attention-relevance reason');
+
+    const withInactiveProbe = createFixture({ storeError: new Error('store offline') });
+    const evaluation = await withInactiveProbe.capability.evaluateAttention([]);
+    assert.equal(evaluation.enabled, true, 'evaluation still reaches the attention controller');
+    assert.equal(withInactiveProbe.calls.some(call => call[0] === 'refresh-for-host'), true,
+        'the fail-open relevance probe still routes through the host refresh');
+});
+
+test('ATTENTION-EXECUTION-STATE-SYNC-001 attention evaluation proceeds when the inactive restore fails', async () => {
+    const overrides = [{
+        providerId: 'codex',
+        sessionId: 'session-a',
+        attentionKey: 'key-a',
+        runtime: makeRuntime(),
+    }];
+    const { capability, calls } = createFixture({
+        loadPersistedInactiveError: new Error('inactive restore offline'),
+    });
+    const evaluation = await capability.evaluateAttention(overrides);
+    assert.equal(evaluation.enabled, true);
+    const evaluateCall = calls.find(call => call[0] === 'attention-evaluate');
+    assert.equal(evaluateCall[1], overrides, 'the exact runtime overrides reach the controller');
+    assert.ok(calls.some(call =>
+        call[0] === 'runtime-failure' && call[1] === 'attention-inactive-restore'),
+    'the restore failure is reported with the attention-inactive-restore reason');
+});
+
+test('ATTENTION-EXECUTION-STATE-SYNC-001 attention evaluation proceeds when the host refresh fails', async () => {
+    const { capability, calls } = createFixture({
+        discoveryActive: [makeRuntime({ backend: 'tmux' })],
+        refreshForHostError: new Error('refresh offline'),
+    });
+    const evaluation = await capability.evaluateAttention([]);
+    assert.equal(evaluation.enabled, true, 'a host refresh failure must not skip the evaluation');
+    assert.deepEqual(calls.filter(call => call[0] === 'refresh-for-host'), [['refresh-for-host', false]]);
+    assert.ok(calls.some(call => call[0] === 'runtime-failure' && call[1] === 'attention-refresh'),
+        'the refresh failure is reported with the attention-refresh reason');
+
+    const irrelevant = createFixture({});
+    await irrelevant.capability.evaluateAttention([]);
+    assert.equal(irrelevant.calls.some(call => call[0] === 'refresh-for-host'), false,
+        'without relevant tmux runtimes the host refresh is skipped');
+});
+
+test('ATTENTION-EXECUTION-STATE-SYNC-001 focused identity prefers the in-workspace tmux runtime and falls back otherwise', () => {
+    const tmuxIdentity = makeIdentity({ sessionId: 'tmux-focused' });
+    const inWorkspace = createFixture({
+        focusedTmuxRuntime: makeRuntime({ backend: 'tmux', identity: tmuxIdentity }),
+    });
+    assert.deepEqual(inWorkspace.capability.getFocusedRuntimeIdentity(), tmuxIdentity,
+        'the focused tmux runtime identity wins inside the current workspace');
+
+    const outOfWorkspace = createFixture({
+        focusedTmuxRuntime: makeRuntime({
+            backend: 'tmux',
+            identity: makeIdentity({ sessionId: 'tmux-focused', workspaceScopeIdentity: 'scope-elsewhere' }),
+        }),
+    });
+    assert.deepEqual(outOfWorkspace.capability.getFocusedRuntimeIdentity(), {
+        provider: 'codex', sessionId: 'highlighted', workspaceScopeIdentity: 'scope-1',
+    }, 'a tmux runtime from another workspace falls back to the highlighter identity');
+
+    const noFocused = createFixture({ activeTerminal: null });
+    assert.deepEqual(noFocused.capability.getFocusedRuntimeIdentity(), {
+        provider: 'codex', sessionId: 'highlighted', workspaceScopeIdentity: 'scope-1',
+    }, 'without a focused tmux runtime the highlighter identity wins');
+});
+
+test('ATTENTION-EXECUTION-STATE-SYNC-001 deferred tmux restore publishes once settled, ready, and visible', () => {
+    const { capability, calls } = createFixture({});
+    capability.publishDeferredRestoreIfReady();
+    capability.setDeferredRestoreSettled();
+    capability.publishDeferredRestoreIfReady();
+    assert.equal(calls.some(call => call[0] === 'refresh'), false,
+        'the deferred refresh waits for readiness');
+    capability.setDeferredRestoreRefreshReady(true);
+    capability.publishDeferredRestoreIfReady();
+    assert.deepEqual(calls.filter(call => call[0] === 'refresh'),
+        [['refresh', 'tmux-bootstrap-restore']]);
+    capability.publishDeferredRestoreIfReady();
+    assert.equal(calls.filter(call => call[0] === 'refresh').length, 1,
+        'the deferred refresh publishes exactly once');
+
+    const hidden = createFixture({ visible: false });
+    hidden.capability.setDeferredRestoreSettled();
+    hidden.capability.setDeferredRestoreRefreshReady(true);
+    hidden.capability.publishDeferredRestoreIfReady();
+    assert.equal(hidden.calls.some(call => call[0] === 'refresh'), false,
+        'the deferred refresh waits for visibility');
+
+    const disposed = createFixture({ assertActiveError: new Error('disposed') });
+    disposed.capability.setDeferredRestoreSettled();
+    disposed.capability.setDeferredRestoreRefreshReady(true);
+    disposed.capability.publishDeferredRestoreIfReady();
+    assert.equal(disposed.calls.some(call => call[0] === 'refresh'), false,
+        'the deferred refresh stays silent after disposal');
+});
+
+test('ATTENTION-EXECUTION-STATE-SYNC-001 terminal handlers register exactly three listeners and dispose them all', async () => {
+    const { capability, calls, listeners, disposals, terminal } = createFixture({});
+    const restoreRegistration = capability.registerTerminalRestoreHandler();
+    const registration = capability.registerTerminalEventHandlers();
+    assert.equal(typeof listeners.openTerminal, 'function');
+    assert.equal(typeof listeners.activeTerminal, 'function');
+    assert.equal(typeof listeners.closeTerminal, 'function');
+    assert.equal(disposals.length, 3, 'exactly three listener registrations');
+    restoreRegistration.dispose();
+    registration.dispose();
+    assert.ok(disposals.every(entry => entry.disposed), 'dispose releases every listener');
+
+    listeners.activeTerminal();
+    await flushAll();
+    const syncIndex = indexOfCall(calls, 'highlight-sync');
+    const monitorIndex = indexOfCall(calls, 'monitor-request');
+    const refreshIndex = indexOfCall(calls, 'refresh');
+    const taskIndex = indexOfCall(calls, 'lifecycle-task');
+    const evaluateIndex = indexOfCall(calls, 'attention-evaluate');
+    assert.ok(syncIndex >= 0 && monitorIndex > syncIndex && refreshIndex > monitorIndex,
+        'the active terminal change syncs, reconciles, then refreshes');
+    assert.ok(taskIndex > refreshIndex
+        && calls[taskIndex][1] === 'evaluate-attention-active-terminal',
+    'the active terminal evaluation runs inside the guarded lifecycle task');
+    assert.ok(evaluateIndex > taskIndex, 'the guarded task drives the evaluation');
+});
+
+test('ATTENTION-RUNTIME-EXIT-NEUTRAL-001 a process-exit close runs the lifecycle tick without acknowledging attention', async () => {
+    const runtime = makeRuntime({ backend: 'vscode' });
+    const terminal = { name: 'closing', exitStatus: { code: 0, reason: 2 } };
+    runtime.terminal = terminal;
+    const { capability, calls, listeners } = createFixture({ activeRuntimes: [runtime] });
+    capability.registerTerminalEventHandlers();
+    listeners.closeTerminal(terminal);
+    await flushAll();
+    const closeIndex = indexOfCall(calls, 'runtime-close');
+    const tickIndex = indexOfCall(calls, 'lifecycle-tick');
+    const highlightIndex = indexOfCall(calls, 'highlight-close');
+    const refreshIndex = indexOfCall(calls, 'refresh');
+    const closedTaskIndex = calls.findIndex(call =>
+        call[0] === 'lifecycle-task' && call[1] === 'evaluate-attention-closed-terminal');
+    assert.ok(closeIndex >= 0 && tickIndex > closeIndex && highlightIndex > tickIndex,
+        'the close handler ticks the lifecycle right after runtime close handling');
+    assert.ok(refreshIndex > highlightIndex, 'the views refresh after the highlighter observes the close');
+    assert.ok(closedTaskIndex > refreshIndex,
+        'the closed-terminal evaluation runs inside the guarded lifecycle task');
+    assert.equal(calls.some(call => call[0] === 'local-acknowledge' || call[0] === 'bridge-acknowledge'), false,
+        'a process exit must not acknowledge unread attention');
+    assert.equal(calls.some(call => call[0] === 'lifecycle-task' && call[1] === 'acknowledge-user-terminal-close'), false,
+        'a process exit must not run the user-close acknowledgement task');
+});
+
+test('ATTENTION-USER-TERMINAL-CLOSE-001 a user close acknowledges locally, refreshes, then awaits the bridge', async () => {
+    const runtime = makeRuntime({ backend: 'vscode' });
+    const terminal = { name: 'closing', exitStatus: { code: undefined, reason: 3 } };
+    runtime.terminal = terminal;
+    const { capability, calls, listeners } = createFixture({ activeRuntimes: [runtime] });
+    capability.startBridgeClient();
+    capability.registerTerminalEventHandlers();
+    listeners.closeTerminal(terminal);
+    await flushAll();
+    const closeIndex = indexOfCall(calls, 'runtime-close');
+    const acknowledgeTaskIndex = calls.findIndex(call =>
+        call[0] === 'lifecycle-task' && call[1] === 'acknowledge-user-terminal-close');
+    const localAcknowledgeIndex = indexOfCall(calls, 'local-acknowledge');
+    const refreshAfterAcknowledgeIndex = indexOfCall(calls, 'refresh', localAcknowledgeIndex);
+    const bridgeAcknowledgeIndex = indexOfCall(calls, 'bridge-acknowledge');
+    assert.ok(acknowledgeTaskIndex >= 0 && acknowledgeTaskIndex > closeIndex,
+        'the acknowledgement runs inside the guarded lifecycle task');
+    assert.deepEqual(calls[localAcknowledgeIndex][1], ['evt-1', 'evt-2'],
+        'the acknowledgement dedupes the recovery session event ids');
+    assert.ok(localAcknowledgeIndex > acknowledgeTaskIndex,
+        'the acknowledgement follows the user close observation');
+    assert.ok(refreshAfterAcknowledgeIndex > localAcknowledgeIndex,
+        'the local refresh lands before the bridge await');
+    assert.ok(bridgeAcknowledgeIndex > refreshAfterAcknowledgeIndex,
+        'the cross-window bridge is awaited only after the local refresh');
+
+    const empty = createFixture({ recoverySessionEvents: [] });
+    empty.capability.startBridgeClient();
+    await empty.capability.acknowledgeAttention({
+        provider: 'codex', sessionId: 'unknown', workspaceScopeIdentity: 'scope-1',
+    });
+    assert.equal(empty.calls.some(call => call[0] === 'local-acknowledge'), false,
+        'an empty event id list skips the acknowledgement entirely');
+});
+
+test('ATTENTION-EXECUTION-STATE-SYNC-001 the open terminal handler restores attach candidates and reports failures', async () => {
+    const ignored = createFixture({ attachCandidate: false });
+    ignored.capability.registerTerminalRestoreHandler();
+    ignored.listeners.openTerminal({ name: 'plain' });
+    await flushAll();
+    assert.deepEqual(ignored.calls.filter(call => call[0] === 'is-attach-candidate').length, 1);
+    assert.equal(ignored.calls.some(call => call[0] === 'restore-attach-terminals'), false,
+        'non-candidate terminals skip the attach restore');
+
+    const restored = createFixture({ attachCandidate: true });
+    restored.capability.registerTerminalRestoreHandler();
+    const candidate = { name: 'tmux-attach' };
+    restored.listeners.openTerminal(candidate);
+    await flushAll();
+    assert.deepEqual(restored.calls.filter(call => call[0] === 'restore-attach-terminals'),
+        [['restore-attach-terminals', [candidate]]]);
+    assert.equal(restored.calls.some(call => call[0] === 'publish-restored-attach'), true,
+        'a restored attach publishes the restored terminal');
+
+    const failing = createFixture({ attachCandidate: true, restoreError: new Error('restore offline') });
+    failing.capability.registerTerminalRestoreHandler();
+    failing.listeners.openTerminal({ name: 'tmux-attach' });
+    await flushAll();
+    assert.ok(failing.calls.some(call =>
+        call[0] === 'runtime-failure' && call[1] === 'restore-opened-tmux-attach-terminal'),
+    'a restore failure keeps its diagnostic reason');
+    assert.equal(failing.calls.some(call => call[0] === 'publish-restored-attach'), false);
+});
+
+test('ATTENTION-EXECUTION-STATE-SYNC-001 the bridge client publishes, acknowledges, and schedules attention refreshes', async () => {
+    const { capability, calls, listeners, bridgeClient } = createFixture({});
+    capability.startBridgeClient();
+    assert.equal(capability.bridgeClient, bridgeClient, 'the bridge client is exposed read-only');
+    assert.deepEqual(calls.filter(call => call[0] === 'create-bridge-client').length, 1);
+
+    await capability.publish([{ sessionKey: 'codex:session-a' }], true);
+    assert.deepEqual(calls.filter(call => call[0] === 'bridge-publish'),
+        [['bridge-publish', [{ sessionKey: 'codex:session-a' }], true]],
+    'publishing delegates to the bridge client');
+
+    const aggregate = { protocolVersion: 1, semanticRevision: 7, sessions: [] };
+    listeners.bridgeAggregate(aggregate);
+    assert.deepEqual(calls.filter(call => call[0] === 'set-remote-aggregate'),
+        [['set-remote-aggregate', aggregate]]);
+    assert.deepEqual(calls.filter(call => call[0] === 'schedule-refresh'),
+        [['schedule-refresh', 'attention']],
+    'a changed aggregate schedules the attention views refresh');
+    assert.deepEqual(calls.filter(call => call[0] === 'post-open-workspaces').length, 1,
+        'a changed aggregate updates the open workspaces view');
+
+    const unchanged = createFixture({ remoteAggregateChanged: false });
+    unchanged.capability.startBridgeClient();
+    unchanged.listeners.bridgeAggregate(aggregate);
+    assert.equal(unchanged.calls.some(call => call[0] === 'schedule-refresh'), false,
+        'an unchanged aggregate skips the refresh');
+
+    const error = new Error('bridge offline');
+    listeners.bridgeError(error);
+    assert.deepEqual(calls.filter(call => call[0] === 'log-error'),
+        [['log-error', 'AI session attention bridge unavailable; using local-window monitoring.', error]]);
+
+    capability.dispose();
+    assert.deepEqual(calls.filter(call => call[0] === 'bridge-dispose').length, 1,
+        'disposing the capability disposes the bridge client');
+});
+
+test('ATTENTION-EXECUTION-STATE-SYNC-001 runtime lookups resolve collision, live, and inactive runtimes', () => {
+    const collisionIdentity = makeIdentity({ sessionId: 'collided' });
+    const collisionFixture = createFixture({
+        discoveryDiagnostics: [{ kind: 'tmux-locator-collision', identity: collisionIdentity }],
+    });
+    const collision = collisionFixture.capability.getRuntimeById('codex', 'collided');
+    assert.equal(collision.state, 'conflict', 'a discovery collision wins over every other lookup');
+    assert.equal(collision.backend, 'tmux');
+
+    const liveRuntime = makeRuntime({ identity: makeIdentity({ sessionId: 'live' }) });
+    const liveFixture = createFixture({ liveRuntime });
+    assert.equal(liveFixture.capability.getRuntimeById('codex', 'live'), liveRuntime,
+        'a live runtime resolves through the coordinator');
+
+    const conflicted = makeRuntime({ identity: makeIdentity({ sessionId: 'duo' }) });
+    const conflictFixture = createFixture({ activeRuntimes: [
+        conflicted,
+        makeRuntime({ identity: makeIdentity({ sessionId: 'duo' }) }),
+    ] });
+    const conflictSnapshot = conflictFixture.capability.getRuntimeById('codex', 'duo');
+    assert.equal(conflictSnapshot.state, 'conflict', 'multiple live runtimes surface as a conflict');
+
+    const inactive = makeRuntime({
+        backend: 'tmux',
+        identity: makeIdentity({ sessionId: 'inactive' }),
+        tmux: { layout: 'session', sessionName: 'ap-x', windowName: 'w' },
+    });
+    const inactiveFixture = createFixture({ discoveryInactive: [inactive] });
+    const inactiveSnapshot = inactiveFixture.capability.getRuntimeById('codex', 'inactive');
+    assert.equal(inactiveSnapshot.backend, 'tmux');
+    assert.equal('terminal' in inactiveSnapshot, false, 'inactive tmux snapshots detach the terminal');
+
+    const completedTerminal = { name: 'completed' };
+    const completedFixture = createFixture({ trackedEntries: [{
+        provider: 'codex',
+        sessionId: 'done',
+        runtimeIdentity: makeIdentity({ sessionId: 'done' }),
+        markerPath: '/markers/done',
+        runStartedAtMs: 42,
+        terminal: completedTerminal,
+    }] });
+    const completedSnapshot = completedFixture.capability.getRuntimeById('codex', 'done');
+    assert.equal(completedSnapshot.state, 'completed');
+    assert.equal(completedSnapshot.terminal, completedTerminal);
+
+    const empty = createFixture({});
+    assert.equal(empty.capability.getRuntimeById('codex', 'missing'), null);
+    const noWorkspace = createFixture({ workspace: null });
+    assert.equal(noWorkspace.capability.getRuntimeById('codex', 'live'), null,
+        'lookups stay empty without a current workspace');
+
+    assert.equal(empty.capability.belongsToCurrentWorkspace(makeRuntime()), true);
+    assert.equal(empty.capability.belongsToCurrentWorkspace(
+        makeRuntime({ identity: makeIdentity({ workspaceScopeIdentity: 'scope-elsewhere' }) })
+    ), false);
+});
+
+test('ATTENTION-EXECUTION-STATE-SYNC-001 attention state posts the recovery session events and event ids', () => {
+    const { capability, calls } = createFixture({});
+    capability.postAttentionState();
+    assert.deepEqual(calls.filter(call => call[0] === 'post-message'), [['post-message', {
+        type: 'ai-session-attention-state',
+        sessionEvents: [{ sessionKey: 'codex:session-a', eventIds: ['evt-1', 'evt-1', 'evt-2'] }],
+        eventIds: ['evt-1', 'evt-2'],
+    }]]);
+});

--- a/tests/contract/aiSessions/runtimeComposition.test.js
+++ b/tests/contract/aiSessions/runtimeComposition.test.js
@@ -408,6 +408,21 @@ test('RUNTIME-HOST-RUNTIME-COMPOSITION-001 production activation restores tmux a
     );
 });
 
+test('RUNTIME-HOST-RUNTIME-COMPOSITION-001 production activation hydrates the workspace through the coordinator runtimes', () => {
+    const result = runProductionActivation('workspace-hydration');
+    assert.equal(result.failure, null);
+    const hydration = result.hydrationDiagnostics.find(diagnostic => diagnostic.workspaceCount === 1);
+    assert.ok(hydration, 'a workspace folder must hydrate through the workspace path');
+    assert.ok(
+        result.hydrationWiring.active >= 1 && result.hydrationWiring.pending >= 1,
+        'hydration must consume the dashboard runtime wiring'
+    );
+    assert.equal(result.hydrationWiring.activeViaCoordinator, result.hydrationWiring.active,
+        'every active-runtime read must be served by the runtime coordinator');
+    assert.equal(result.hydrationWiring.pendingViaCoordinator, result.hydrationWiring.pending,
+        'every pending-runtime read must be served by the runtime coordinator');
+});
+
 test('RUNTIME-HOST-RUNTIME-COMPOSITION-001 assembles real runtime components and restores ownership before hydration', async t => {
     const events = [];
     const composition = assembleRuntimeHost(t, events);

--- a/tests/contract/aiSessions/tmuxPromotion.test.js
+++ b/tests/contract/aiSessions/tmuxPromotion.test.js
@@ -1,0 +1,311 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {
+    createTmuxRuntimeHarness,
+    fakeCreateRequest,
+    workspaceIdentity,
+} = require('../../helpers/runtimeContract');
+const { buildReadableTmuxLocator } = require('../../../out/aiSessions/tmuxNaming');
+
+async function seedPending(layout, pendingId = `pending-${layout}-1`) {
+    const harness = createTmuxRuntimeHarness(layout);
+    const request = fakeCreateRequest(pendingId);
+    const pendingRuntime = await harness.backend.ensurePending(request, layout);
+    return { harness, request, pendingRuntime };
+}
+
+function renameCounts(harness) {
+    return {
+        sessions: harness.operations.filter(item => item.type === 'rename-session').length,
+        windows: harness.operations.filter(item => item.type === 'rename-window').length,
+    };
+}
+
+function failNextRenameWindow(harness) {
+    const client = harness.dependencies.client;
+    const realRenameWindow = client.renameWindow;
+    let failures = 1;
+    client.renameWindow = async (sessionName, windowName, nextName) => {
+        if (failures-- > 0) {
+            throw new Error('injected rename failure');
+        }
+        return realRenameWindow(sessionName, windowName, nextName);
+    };
+}
+
+test('RUNTIME-TMUX-BACKEND-001 [tmux session] promotion persists known/consumed, clears pending, and migrates attach', async () => {
+    const { harness, request, pendingRuntime } = await seedPending('session');
+    const promoted = await harness.backend.promotePending(request.identity, 'final-1', 'Final One');
+
+    assert.equal(promoted.length, 1);
+    assert.equal(promoted[0].identity.sessionId, 'final-1');
+    assert.equal(promoted[0].state, 'active');
+    assert.equal(promoted[0].backend, 'tmux');
+    assert.ok(harness.store.known.has('codex:final-1'), 'final binding must be persisted as known');
+    assert.deepEqual(harness.store.known.get('codex:final-1').locator, promoted[0].tmux);
+    assert.equal(harness.store.consumed.size, 1);
+    const consumed = [...harness.store.consumed.values()][0];
+    assert.equal(consumed.pendingId, request.identity.pendingId);
+    assert.equal(consumed.finalSessionId, 'final-1');
+    assert.equal(consumed.finalSessionName, 'Final One');
+    assert.equal(consumed.layout, 'session');
+    assert.deepEqual(consumed.finalLocator, promoted[0].tmux);
+    assert.equal(harness.store.pending.size, 0, 'pending record must be removed by cleanup');
+    assert.equal(harness.store.promoting.size, 0, 'promoting intent must be removed by cleanup');
+    assert.equal(promoted[0].attached, true, 'attach must migrate to the promoted runtime');
+    assert.equal(promoted[0].terminal, pendingRuntime.terminal);
+    assert.equal(harness.detachCount(), 0, 'promotion must not dispose the attached terminal');
+    assert.equal(harness.providerCreateCount(), 1, 'promotion must not dispatch another provider command');
+    assert.equal(harness.backend.getPending().length, 0);
+});
+
+test('RUNTIME-TMUX-BACKEND-001 [tmux project] promotion renames the window inside the same session', async () => {
+    const { harness, request, pendingRuntime } = await seedPending('project');
+    const before = renameCounts(harness);
+    const promoted = await harness.backend.promotePending(request.identity, 'final-p', 'Final Project');
+
+    assert.equal(promoted.length, 1);
+    assert.equal(promoted[0].identity.sessionId, 'final-p');
+    assert.equal(promoted[0].tmux.layout, 'project');
+    assert.equal(promoted[0].tmux.sessionName, pendingRuntime.tmux.sessionName,
+        'project promotion keeps the pending session and renames only the window');
+    assert.notEqual(promoted[0].tmux.windowName, pendingRuntime.tmux.windowName);
+    const after = renameCounts(harness);
+    assert.equal(after.sessions - before.sessions, 0, 'project promotion must not rename sessions');
+    assert.equal(after.windows - before.windows, 1, 'project promotion renames exactly one window');
+    assert.ok(harness.store.known.has('codex:final-p'));
+    assert.equal(harness.store.consumed.size, 1);
+    assert.equal(harness.store.pending.size, 0);
+    assert.equal(harness.store.promoting.size, 0);
+});
+
+test('RUNTIME-TMUX-BACKEND-001 [tmux session] persisted intent resumes through a reloaded backend without dispatch', async () => {
+    const { harness, request } = await seedPending('session');
+    failNextRenameWindow(harness);
+    await assert.rejects(
+        harness.backend.promotePending(request.identity, 'final-r', 'Final Reload'),
+        /injected rename failure/
+    );
+    assert.equal(harness.store.promoting.size, 1, 'intent must survive the failed transition');
+    assert.equal(harness.store.pending.size, 1);
+
+    const reloaded = harness.createReloadedBackend();
+    const promoted = await reloaded.promotePending(request.identity, 'final-r', 'Final Reload');
+    assert.equal(promoted.length, 1);
+    assert.equal(promoted[0].identity.sessionId, 'final-r');
+    assert.equal(harness.providerCreateCount(), 1, 'resumed promotion must not dispatch again');
+    assert.ok(harness.store.known.has('codex:final-r'));
+    assert.equal(harness.store.consumed.size, 1);
+    assert.equal(harness.store.pending.size, 0);
+    assert.equal(harness.store.promoting.size, 0);
+});
+
+test('RUNTIME-TMUX-BACKEND-001 [tmux session] consumed tombstone makes a repeated promote return the final runtime', async () => {
+    const { harness, request } = await seedPending('session');
+    const first = await harness.backend.promotePending(request.identity, 'final-1', 'Final One');
+    assert.equal(first.length, 1);
+    assert.equal(harness.store.pending.size, 0, 'cleanup removed the pending record');
+    // Simulate a crash between persistConsumed and removePending: the pending
+    // record is still present while the consumed tombstone already exists.
+    const resurrected = {
+        version: 2, state: 'pending', pendingId: request.identity.pendingId,
+        provider: request.identity.provider,
+        workspaceScopeIdentity: request.identity.workspaceScopeIdentity,
+        workspaceNavigationIdentity: request.identity.workspaceNavigationIdentity,
+        workspaceRootHostPaths: [...request.identity.workspaceRootHostPaths],
+        cwd: request.identity.cwd, createdAt: request.createdAt,
+        excludedSessionIds: [...request.excludedSessionIds], acceptedAtMs: 1,
+        layout: 'session', locator: { ...first[0].tmux, sessionName: 'ap-pending-source' },
+        title: request.title, projectName: request.projectName,
+    };
+    await harness.store.setPending(resurrected);
+
+    const before = renameCounts(harness);
+    const second = await harness.backend.promotePending(request.identity, 'final-1', 'Final One');
+    assert.equal(second.length, 1, 'tombstone promotion returns the existing final runtime');
+    assert.equal(second[0].identity.sessionId, 'final-1');
+    assert.notEqual(second[0].state, 'conflict');
+    const after = renameCounts(harness);
+    assert.equal(after.sessions - before.sessions, 0, 'tombstone promotion must not rename again');
+    assert.equal(after.windows - before.windows, 0);
+    assert.equal(harness.store.consumed.size, 1);
+    assert.equal(harness.store.pending.size, 0, 'cleanup removes the resurrected pending record');
+});
+
+test('RUNTIME-TMUX-BACKEND-001 [tmux session] an existing final runtime yields two conflicts', async () => {
+    const { harness, request } = await seedPending('session');
+    await harness.backend.promotePending(request.identity, 'final-1', 'Final One');
+
+    const requestB = fakeCreateRequest('pending-b');
+    const pendingB = await harness.backend.ensurePending(requestB, 'session');
+    assert.equal(pendingB.identity.pendingId, 'pending-b');
+
+    const result = await harness.backend.promotePending(requestB.identity, 'final-1', 'Final One');
+    assert.equal(result.length, 2);
+    assert.equal(result[0].state, 'conflict');
+    assert.equal(result[0].identity.sessionId, 'final-1');
+    assert.equal(result[1].state, 'conflict');
+    assert.equal(result[1].identity.pendingId, 'pending-b');
+    assert.equal(harness.store.consumed.size, 1, 'the conflicted pending must not be consumed');
+    assert.equal(harness.store.pending.size, 1, 'the conflicted pending stays pending');
+});
+
+test('RUNTIME-TMUX-BACKEND-001 [tmux session] a differently named final and an occupied final locator conflict', async () => {
+    const { harness, request } = await seedPending('session');
+    await harness.backend.promotePending(request.identity, 'final-1', 'Final One');
+
+    const requestB = fakeCreateRequest('pending-b');
+    await harness.backend.ensurePending(requestB, 'session');
+    const differentlyNamed = await harness.backend.promotePending(
+        requestB.identity, 'final-1', 'Another Name'
+    );
+    assert.equal(differentlyNamed.length, 2);
+    assert.equal(differentlyNamed[0].state, 'conflict');
+    assert.equal(differentlyNamed[0].identity.sessionId, 'final-1');
+    assert.equal(differentlyNamed[1].state, 'conflict');
+    assert.equal(differentlyNamed[1].identity.pendingId, 'pending-b');
+    assert.equal(harness.store.pending.size, 1, 'the conflicted pending stays pending');
+
+    const requestC = fakeCreateRequest('pending-c');
+    await harness.backend.ensurePending(requestC, 'session');
+    const finalIdentityC = {
+        provider: requestC.identity.provider,
+        workspaceScopeIdentity: requestC.identity.workspaceScopeIdentity,
+        workspaceNavigationIdentity: requestC.identity.workspaceNavigationIdentity,
+        workspaceRootHostPaths: [...requestC.identity.workspaceRootHostPaths],
+        cwd: requestC.identity.cwd,
+        sessionId: 'final-c',
+    };
+    const occupiedLocator = buildReadableTmuxLocator(finalIdentityC, 'session', {
+        projectName: requestC.projectName, sessionName: 'Final C',
+    });
+    harness.windows.push({
+        sessionName: occupiedLocator.sessionName, windowName: 'foreign-window',
+        windowId: '@foreign', active: false,
+        sessionMetadata: {}, windowMetadata: {}, metadata: {},
+    });
+    const occupied = await harness.backend.promotePending(requestC.identity, 'final-c', 'Final C');
+    assert.equal(occupied.length, 1, 'an occupied final locator conflicts only the pending runtime');
+    assert.equal(occupied[0].state, 'conflict');
+    assert.equal(occupied[0].identity.pendingId, 'pending-c');
+    assert.equal(harness.store.promoting.size, 0, 'occupied promotion must not persist an intent');
+});
+
+test('RUNTIME-TMUX-BACKEND-001 [tmux session] an ambiguous pending record rejects promotion', async () => {
+    const { harness, request } = await seedPending('session');
+    await harness.store.setAmbiguous({
+        version: 2, state: 'ambiguous',
+        provider: request.identity.provider,
+        workspaceScopeIdentity: request.identity.workspaceScopeIdentity,
+        workspaceNavigationIdentity: request.identity.workspaceNavigationIdentity,
+        workspaceRootHostPaths: [...request.identity.workspaceRootHostPaths],
+        pendingId: request.identity.pendingId,
+        cwd: request.identity.cwd,
+        createdAt: request.createdAt,
+        excludedSessionIds: [...request.excludedSessionIds],
+        layout: 'session',
+        locator: { layout: 'session', sessionName: 'ap-ambiguous', windowName: 'ai-session' },
+        requestFingerprint: 'ambiguous-fixture',
+    });
+    await assert.rejects(
+        harness.backend.promotePending(request.identity, 'final-1', 'Final One'),
+        /ambiguous/
+    );
+    assert.equal(harness.store.pending.size, 1, 'the ambiguous pending is left untouched');
+});
+
+test('RUNTIME-TMUX-BACKEND-001 [tmux session] a persisted intent with a different final session id rejects', async () => {
+    const { harness, request } = await seedPending('session');
+    failNextRenameWindow(harness);
+    await assert.rejects(
+        harness.backend.promotePending(request.identity, 'final-1', 'Final One'),
+        /injected rename failure/
+    );
+    assert.equal(harness.store.promoting.size, 1);
+    await assert.rejects(
+        harness.backend.promotePending(request.identity, 'final-2', 'Final One'),
+        /conflicting promotion/
+    );
+    assert.equal(harness.store.pending.size, 1, 'the conflicted pending stays pending');
+    assert.equal(harness.store.promoting.size, 1, 'the original intent survives the conflict');
+});
+
+test('RUNTIME-TMUX-BACKEND-001 [tmux session] a fully landed transition completes on retry', async () => {
+    const { harness, request } = await seedPending('session');
+    const store = harness.dependencies.runtimeStore;
+    const realSetKnown = store.setKnown;
+    let failKnown = 1;
+    store.setKnown = async record => {
+        if (failKnown-- > 0) {
+            throw new Error('injected known failure');
+        }
+        return realSetKnown(record);
+    };
+    await assert.rejects(
+        harness.backend.promotePending(request.identity, 'final-1', 'Final One'),
+        /injected known failure/
+    );
+    assert.equal(harness.store.promoting.size, 1, 'the intent survives the failed completion');
+    assert.equal(harness.store.consumed.size, 0);
+
+    const promoted = await harness.backend.promotePending(request.identity, 'final-1', 'Final One');
+    assert.equal(promoted.length, 1, 'the landed transition completes without renaming again');
+    assert.equal(promoted[0].identity.sessionId, 'final-1');
+    assert.ok(harness.store.known.has('codex:final-1'));
+    assert.equal(harness.store.consumed.size, 1);
+    assert.equal(harness.store.pending.size, 0);
+    assert.equal(harness.store.promoting.size, 0);
+    assert.equal(harness.providerCreateCount(), 1);
+});
+
+test('RUNTIME-TMUX-BACKEND-001 [tmux session] a partially renamed runtime completes on retry', async () => {
+    const { harness, request } = await seedPending('session');
+    failNextRenameWindow(harness);
+    await assert.rejects(
+        harness.backend.promotePending(request.identity, 'final-1', 'Final One'),
+        /injected rename failure/
+    );
+    assert.equal(harness.store.promoting.size, 1);
+
+    const promoted = await harness.backend.promotePending(request.identity, 'final-1', 'Final One');
+    assert.equal(promoted.length, 1);
+    assert.equal(promoted[0].identity.sessionId, 'final-1');
+    assert.ok(harness.store.known.has('codex:final-1'));
+    assert.equal(harness.store.consumed.size, 1);
+    assert.equal(harness.store.pending.size, 0);
+    assert.equal(harness.store.promoting.size, 0);
+});
+
+test('RUNTIME-TMUX-BACKEND-001 [tmux session] a failed rename with an intact source rejects and drops the intent', async () => {
+    const { harness, request } = await seedPending('session');
+    const client = harness.dependencies.client;
+    const realRenameSession = client.renameSession;
+    client.renameSession = async () => {
+        throw new Error('injected rename failure');
+    };
+    await assert.rejects(
+        harness.backend.promotePending(request.identity, 'final-1', 'Final One'),
+        /injected rename failure/
+    );
+    client.renameSession = realRenameSession;
+    assert.equal(harness.store.promoting.size, 0,
+        'an intact source and a free final locator roll the intent back');
+    assert.equal(harness.store.pending.size, 1, 'the pending record survives the failed rename');
+    assert.equal(harness.store.consumed.size, 0);
+});
+
+test('RUNTIME-TMUX-BACKEND-001 [tmux session] invalid input and unknown pendings promote to nothing', async () => {
+    const { harness, request } = await seedPending('session');
+    assert.deepEqual(await harness.backend.promotePending(request.identity, '', 'Final One'), []);
+    assert.deepEqual(await harness.backend.promotePending(request.identity, 'final-1', ''), []);
+    assert.deepEqual(
+        await harness.backend.promotePending(workspaceIdentity({ pendingId: 'never-seen' }),
+            'final-1', 'Final One'),
+        []
+    );
+    assert.equal(harness.store.promoting.size, 0);
+    assert.equal(harness.store.consumed.size, 0);
+    assert.equal(renameCounts(harness).sessions, 0, 'invalid input must not mutate tmux');
+});

--- a/tests/fixtures/aiSessions/runtimeHostActivationHarness.js
+++ b/tests/fixtures/aiSessions/runtimeHostActivationHarness.js
@@ -198,6 +198,19 @@ async function main() {
         warningMessages: [],
     };
     const vscode = createVscode(lifecycle);
+    if (mode === 'workspace-hydration') {
+        const workspaceRoot = path.join(storageRoot, 'fixture-workspace');
+        fs.mkdirSync(workspaceRoot, { recursive: true });
+        vscode.workspace.name = 'fixture-workspace';
+        vscode.workspace.workspaceFolders = [{
+            name: 'fixture-workspace',
+            index: 0,
+            uri: {
+                scheme: 'file', fsPath: workspaceRoot, path: workspaceRoot,
+                toString: () => `file://${workspaceRoot}`,
+            },
+        }];
+    }
     const previousLoad = Module._load;
     const restores = [];
     const events = [];
@@ -223,6 +236,13 @@ async function main() {
     const affectsConfigurationQueries = [];
     const fallbackResumeStatuses = [];
     let coordinatorInstance;
+    let coordinatorGetActiveCalls = 0;
+    let coordinatorGetPendingCalls = 0;
+    const coordinatorActiveSentinel = [];
+    const coordinatorPendingSentinel = [];
+    const hydrationWiring = {
+        active: 0, pending: 0, activeViaCoordinator: 0, pendingViaCoordinator: 0,
+    };
     let refreshMessageBuildsBeforeOpenedTerminal = 0;
     let refreshMessageBuildsAfterOpenedTerminal = 0;
     const patch = (prototype, name, replacement) => {
@@ -240,6 +260,29 @@ async function main() {
                 WorkspaceSessionHydrationController: class extends Original {
                     constructor(...args) {
                         events.push('hydration-constructed');
+                        const options = args[0];
+                        if (options && typeof options.getActiveRuntimes === 'function') {
+                            const originalActive = options.getActiveRuntimes;
+                            options.getActiveRuntimes = () => {
+                                hydrationWiring.active += 1;
+                                const result = originalActive();
+                                if (result === coordinatorActiveSentinel) {
+                                    hydrationWiring.activeViaCoordinator += 1;
+                                }
+                                return result;
+                            };
+                        }
+                        if (options && typeof options.getPendingRuntimes === 'function') {
+                            const originalPending = options.getPendingRuntimes;
+                            options.getPendingRuntimes = () => {
+                                hydrationWiring.pending += 1;
+                                const result = originalPending();
+                                if (result === coordinatorPendingSentinel) {
+                                    hydrationWiring.pendingViaCoordinator += 1;
+                                }
+                                return result;
+                            };
+                        }
                         super(...args);
                     }
                 },
@@ -408,11 +451,15 @@ async function main() {
         patch(AiSessionRuntimeCoordinator.prototype, 'getActive', function () {
             assert.ok(this.dependencies.direct instanceof DirectTerminalRuntimeBackend);
             assert.ok(this.dependencies.tmux instanceof TmuxRuntimeBackend);
+            coordinatorGetActiveCalls += 1;
             coordinatorInstance = this;
             verified.add('direct-tmux-coordinator');
-            return [];
+            return coordinatorActiveSentinel;
         });
-        patch(AiSessionRuntimeCoordinator.prototype, 'getPending', () => []);
+        patch(AiSessionRuntimeCoordinator.prototype, 'getPending', () => {
+            coordinatorGetPendingCalls += 1;
+            return coordinatorPendingSentinel;
+        });
         patch(AiSessionAttentionController.prototype, 'getRecoverySessionEvents', () => []);
         patch(AiSessionAttentionController.prototype, 'evaluate', async () => ({
             enabled: true, published: true, inScopeSessionKeys: [], eventIdsBySession: {}, overflowedSessionKeys: [],
@@ -689,6 +736,12 @@ async function main() {
             restoreAttachTerminalsInvocations,
             runtimeStoreRoots,
             storageRoot,
+            hydrationWiring,
+            coordinatorGetActiveCalls,
+            coordinatorGetPendingCalls,
+            hydrationDiagnostics: aiSessionDiagnostics
+                .filter(diagnostic => diagnostic.event === 'workspace-ai-session-hydration')
+                .map(({ loggedAt: _loggedAt, ...diagnostic }) => diagnostic),
             tmuxCreationLockInvocations,
             refreshMessageBuildsBeforeOpenedTerminal,
             refreshMessageBuildsAfterOpenedTerminal,
@@ -706,6 +759,12 @@ async function main() {
             attentionShutdownCalls,
             synchronizedGlobalStateKeySets,
             startupDiagnostics,
+            ...(process.env.HARNESS_DEBUG
+                ? {
+                    outputLines: lifecycle.outputLines,
+                    postedMessageTypes: lifecycle.postedWebviewMessages.map(message => message?.type),
+                }
+                : {}),
         }));
     } finally {
         disposeContextSubscriptions();

--- a/tests/integration/dashboard/helpers/terminalCloseHarness.js
+++ b/tests/integration/dashboard/helpers/terminalCloseHarness.js
@@ -8,6 +8,7 @@ const path = require('node:path');
 
 const root = path.resolve(__dirname, '../../../..');
 const dashboardPath = path.join(root, 'out/dashboard.js');
+const attentionEventCapabilityPath = path.join(root, 'out/aiSessions/attentionEventCapability.js');
 
 function disposable(dispose = () => undefined) {
     return { dispose };
@@ -66,13 +67,17 @@ function createHarnessVscode(listeners, commands) {
     };
 }
 
-function loadDashboard(transform) {
-    const source = transform(fs.readFileSync(dashboardPath, 'utf8'));
-    const loaded = new Module(dashboardPath, module);
-    loaded.filename = dashboardPath;
-    loaded.paths = Module._nodeModulePaths(path.dirname(dashboardPath));
-    loaded._compile(source, dashboardPath);
+function loadTransformedModule(modulePath, transform) {
+    const source = transform(fs.readFileSync(modulePath, 'utf8'));
+    const loaded = new Module(modulePath, module);
+    loaded.filename = modulePath;
+    loaded.paths = Module._nodeModulePaths(path.dirname(modulePath));
+    loaded._compile(source, modulePath);
     return loaded.exports;
+}
+
+function loadDashboard(transform) {
+    return loadTransformedModule(dashboardPath, transform);
 }
 
 function indexOfCall(calls, name, fromIndex = 0) {
@@ -84,9 +89,28 @@ function indexOfLifecycleTask(calls, operation, fromIndex = 0) {
         && call[0] === 'lifecycle-task' && call[1] === operation);
 }
 
-function replaceOnce(source, needle, replacement, label) {
-    assert.ok(source.includes(needle), `controlled mutation must find the production ${label}`);
+function replaceOnce(source, needle, replacement, _label) {
+    if (!source.includes(needle)) {
+        return source;
+    }
     return source.replace(needle, replacement);
+}
+
+// Each mutation's needle lives in exactly one of the transformed modules
+// (dashboard.js or attentionEventCapability.js); trackTransform asserts the
+// mutation landed somewhere after every module was compiled.
+function trackTransform(label, transform) {
+    const tracked = source => {
+        const next = transform(source);
+        if (next !== source) {
+            tracked.applied = true;
+        }
+        return next;
+    };
+    tracked.applied = false;
+    tracked.assertApplied = () => assert.ok(tracked.applied,
+        `controlled mutation must find the production needle for ${label}`);
+    return tracked;
 }
 
 const mutations = {
@@ -94,9 +118,9 @@ const mutations = {
         scenario: 'baseline',
         transform: source => replaceOnce(
             source,
-            'aiSessionRuntimeCoordinator.handleClosedTerminal(terminal);',
-            'aiSessionRuntimeCoordinator.handleClosedTerminal(terminal);'
-                + '\n            aiSessionAttentionController.suppressRuntimeCompletion(\'synthetic-exit\');',
+            'getRuntimeCoordinator().handleClosedTerminal(terminal);',
+            'getRuntimeCoordinator().handleClosedTerminal(terminal);'
+                + '\n            getAttentionController().suppressRuntimeCompletion(\'synthetic-exit\');',
             'callback',
         ),
     },
@@ -104,12 +128,12 @@ const mutations = {
         scenario: 'user-close',
         transform: source => replaceOnce(
             source,
-            'aiSessionAttentionController.acknowledge(uniqueEventIds);\n'
-                + '                    refreshAiSessionViewsIncrementally();\n'
-                + '                    yield aiSessionAttentionBridgeClient.acknowledge(uniqueEventIds);',
-            'aiSessionAttentionController.acknowledge(uniqueEventIds);\n'
-                + '                    yield aiSessionAttentionBridgeClient.acknowledge(uniqueEventIds);\n'
-                + '                    refreshAiSessionViewsIncrementally();',
+            'getAttentionController().acknowledge(uniqueEventIds);\n'
+                + '        refreshAiSessionViewsIncrementally();\n'
+                + '        yield aiSessionAttentionBridgeClient.acknowledge(uniqueEventIds);',
+            'getAttentionController().acknowledge(uniqueEventIds);\n'
+                + '        yield aiSessionAttentionBridgeClient.acknowledge(uniqueEventIds);\n'
+                + '        refreshAiSessionViewsIncrementally();',
             'acknowledgement ordering',
         ),
     },
@@ -127,10 +151,10 @@ const mutations = {
         scenario: 'remote-aggregate',
         transform: source => replaceOnce(
             source,
-            'if (aiSessionAttentionController.setRemoteAggregate(aggregate)) {',
-            'aiSessionAttentionController.getReleasedSessions()'
-                + '.forEach(() => aiSessionAttentionController.acknowledge([\'synthetic-released\']));\n'
-                + '                    if (aiSessionAttentionController.setRemoteAggregate(aggregate)) {',
+            'if (getAttentionController().setRemoteAggregate(aggregate)) {',
+            'getAttentionController().getReleasedSessions()'
+                + '.forEach(() => getAttentionController().acknowledge([\'synthetic-released\']));\n'
+                + '            if (getAttentionController().setRemoteAggregate(aggregate)) {',
             'bridge aggregate callback',
         ),
     },
@@ -138,11 +162,11 @@ const mutations = {
         scenario: 'remote-aggregate',
         transform: source => replaceOnce(
             source,
-            'if (aiSessionAttentionController.setRemoteAggregate(aggregate)) {\n'
-                + '                        scheduleAttentionViewsRefresh();\n'
-                + '                    }',
-            'if (aiSessionAttentionController.setRemoteAggregate(aggregate)) {\n'
-                + '                    }',
+            'if (getAttentionController().setRemoteAggregate(aggregate)) {\n'
+                + '                scheduleAttentionViewsRefresh();\n'
+                + '            }',
+            'if (getAttentionController().setRemoteAggregate(aggregate)) {\n'
+                + '            }',
             'aggregate refresh scheduling',
         ),
     },
@@ -168,9 +192,9 @@ const mutations = {
         scenario: 'baseline',
         transform: source => replaceOnce(
             source,
-            'aiSessionRuntimeCoordinator.handleClosedTerminal(terminal);\n'
-                + '                    evaluateAiSessionLifecycleTick();',
-            'aiSessionRuntimeCoordinator.handleClosedTerminal(terminal);',
+            'getRuntimeCoordinator().handleClosedTerminal(terminal);\n'
+                + '            evaluateAiSessionLifecycleTick();',
+            'getRuntimeCoordinator().handleClosedTerminal(terminal);',
             'close handler lifecycle tick',
         ),
     },
@@ -206,6 +230,9 @@ async function runTerminalCloseContract(transform = source => source, scenario =
                     }
                 },
             };
+        }
+        if (!fromHarness && request.endsWith('aiSessions/attentionEventCapability')) {
+            return loadTransformedModule(attentionEventCapabilityPath, transform);
         }
         if (!fromHarness && request.endsWith('aiSessions/runtimeSettlementCapability')) {
             return {
@@ -357,6 +384,9 @@ async function runTerminalCloseContract(transform = source => source, scenario =
 
         const dashboard = loadDashboard(transform);
         await dashboard.activate(context);
+        if (typeof transform.assertApplied === 'function') {
+            transform.assertApplied();
+        }
         await waitFor(() => listeners.closeTerminal, 'terminal close listener registration');
         assert.equal(typeof listeners.closeTerminal, 'function',
             'ATTENTION-RUNTIME-EXIT-NEUTRAL-001 production activation must register terminal close');
@@ -600,7 +630,7 @@ const mutationName = mode === 'mutation'
 const mutation = mutationName ? mutations[mutationName] : null;
 assert.ok(!mutationName || mutation, `unknown mutation ${mutationName}`);
 const scenario = mutation ? mutation.scenario : mode;
-const transform = mutation ? mutation.transform : source => source;
+const transform = mutation ? trackTransform(mutationName, mutation.transform) : source => source;
 
 runTerminalCloseContract(transform, scenario).catch(error => {
     process.stderr.write(`${error.stack || error}\n`);

--- a/tests/unit/tooling/architectureGuards.test.js
+++ b/tests/unit/tooling/architectureGuards.test.js
@@ -62,6 +62,7 @@ function copyGuardFixture(t, mutationPath, mutate = source => source) {
         'src/webview/webviewProjectScripts.js',
         'src/webview/conversationViewerScripts.js',
         'src/aiSessions/attentionController.ts',
+        'src/aiSessions/attentionEventCapability.ts',
         'src/aiSessions/attentionAggregate.ts',
         'src/openWorkspaces/protocol.ts',
         'src/openWorkspaces/bridgeClient.ts',


### PR DESCRIPTION
## Summary

One PR, three refactor slices (+ one CI-driven fixture follow-up), continuing the decomposition after #87/#88:

1. **`test:` hydration runtime wiring coverage** — the activation harness had no workspace folder, so `hydrate()` never ran and the dashboard's `getActiveRuntimes`/`getPendingRuntimes` wiring was pinned by source text. The harness gains a `workspace-hydration` mode with one real fixture workspace; sentinel arrays returned from the patched coordinator prove every hydration runtime read is served by the coordinator itself (both delegation breaks mutation-proven). The two tmux-check source pins are retired.

2. **`refactor:` tmux promotion lifecycle** — `tmuxRuntimeBackend.ts` 2214 → 1568 lines, split into `tmuxPendingLifecycle.ts` (record algebra), `tmuxManagedMetadata.ts` (metadata writers), and `tmuxPromotionCapability.ts` (the 9-method state machine behind a DI factory). Lock nesting, cleanup ordering, and all six `discovery.refresh(true)` points preserved verbatim; `promotePending` stays a three-line delegation. New 12-scenario contract suite with refresh/removal mutations proven red.

3. **`refactor:` attention event capability (D/E)** — **dashboard.ts 2128 → 1908 lines (<2000 target).** New `attentionEventCapability.ts` owns attention evaluation with fail-open tmux probes, runtime lookups, the attention bridge client, the deferred tmux-restore refresh state, and the terminal open/active/close handlers. One-line aliases keep every call site textually unchanged; bootstrap-sensitive placement preserved (bridge start point, early restore-listener, late active/close handlers after late-bound dependencies). New 12-case contract suite; fail-open and acknowledge-order mutations proven red. terminalCloseHarness mutations now target whichever compiled module owns the needle; safety/tmux/parity/architecture-guard location assertions re-pointed.

4. **`test:` architecture guard fixture follow-up** — the FALLBACK-REASON-001 guard now parses the extracted module, so the synthetic fixture tree needed the real file (caught by the tooling unit tests).

## Skill harvest

no skill change — the two process anomalies (stale compiled output after a subagent timeout; a guard fixture missing the new module) are already covered by the fresh-verification and whole-branch review rules in .skills/review-fix-commit-loop.

## Verification

- Full `npm run test:ci:linux` green on the rebased tree: changed-line coverage 92.19% (1286/1395), all baselines pass, architecture baseline reports `dashboardLines: 1911`
- Targeted suites: tmux checks, safety checks, dashboard webview checks, parity, open-project, architecture guards, lint baselines, 79 contract tests, terminalCloseWiring 17/17, runtimeComposition 16/16, tmuxPromotion 12/12, attentionEventCapability 12/12, tooling unit tests 55/55
- CI: verify.yml green on the head commit (dispatched run 30738149622 after the platform dropped this PR's pull_request event)