### PR TITLE
feat: view Claude session subagents and their transcripts in the conversation viewer

### DIFF
--- a/.skills/developing-provider-conversation-adapters/SKILL.md
+++ b/.skills/developing-provider-conversation-adapters/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: developing-provider-conversation-adapters
+description: Use when adding or changing AI provider (Kimi/Claude/Codex) session or conversation parsing in this repository, including subagent or transcript support, status inference, or onboarding a new provider.
+---
+
+# Developing Provider Conversation Adapters
+
+## Overview
+
+Provider session formats are undocumented and version-drifting. Self-authored
+fixtures embed the same layout guess as the code under test, so both can be
+wrong together while every contract test passes.
+
+**Core rule:** before committing adapter changes, run the compiled adapter
+against real on-disk provider data and compare the output with ground truth.
+Green self-authored fixtures alone are not evidence.
+
+## Workflow
+
+1. **Probe real data first** — never derive the format from assumptions,
+   docs, or a sibling provider's layout:
+   - census record shapes: `type` distribution, field presence per record
+     kind, single-record size bounds
+   - find lifecycle markers (start / finish / interrupt) and cross-file
+     links (toolUseId, promptId, sidechain flags)
+   - detect continuation records (distinct promptIds, injected user turns)
+2. **Mirror the real layout in fixtures** — fixtures derive paths the same
+   way production code does and match the observed directory tree exactly.
+   A fixture that invents a simpler layout is a self-consistent trap.
+3. **Verify against real data before commit** — point a throwaway script at
+   the compiled `out/` adapter with `resolveSource` returning a real session,
+   run the new read path, and eyeball the results against the files on disk.
+4. Then the standard gates: focused owner tests,
+   `npm run test:behavior-contracts`, `npm run test:ci:linux`.
+
+## Current On-Disk Layouts (re-probe before relying)
+
+| Provider | Session source | Subagents |
+|---|---|---|
+| Kimi | `<kimiHome>/sessions/<workdirHash>/<sessionUuid>/wire.jsonl` | `<sessionDir>/subagents/<id>/{meta.json,wire.jsonl}`; meta carries explicit `status` + `created_at` |
+| Claude | `<claudeHome>/projects/<slug>/<sessionId>.jsonl` | `<slug>/<sessionId>/subagents/agent-<id>.{jsonl,meta.json}`, flat across spawnDepths; meta has `agentType`/`description`/`spawnDepth`/`toolUseId` but **no status** — infer from the transcript tail plus mtime; SendMessage resumes arrive as `origin.kind === 'coordinator'` user records |
+| Codex | rollout JSONL | `session_meta.source.subagent.thread_spawn`; app-server read access unverified — spike first |
+
+Subagent transcripts reuse the provider's main record envelope; Claude
+subagent files consist entirely of `isSidechain: true` records, so any
+main-conversation sidechain filter must be relaxed for subagent sources.
+
+## Status Inference Without An On-Disk Status
+
+When the format records no status (Claude today), derive it from the
+transcript tail:
+
+- last complete record is an assistant message without tool_use → finished
+- anything else → running only while the file mtime is fresh (5 minutes);
+  a crashed CLI leaves a stale mid-turn transcript behind → failed
+
+Read bounded head/tail windows (a single record can exceed 200KB); never
+scan whole transcripts in the listing path.

--- a/.skills/developing-provider-conversation-adapters/agents/openai.yaml
+++ b/.skills/developing-provider-conversation-adapters/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Develop Provider Conversation Adapters"
+  short_description: "Verify provider parsing against real on-disk data"
+  default_prompt: "Use $developing-provider-conversation-adapters to probe the real provider session format, mirror it faithfully in fixtures, and verify the compiled adapter against real on-disk data before committing."

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -3661,7 +3661,8 @@
       ".skills/harvesting-workflow-lessons/SKILL.md",
       ".skills/installing-vscode-extensions-locally/SKILL.md",
       ".skills/publishing-and-merging-github-prs/SKILL.md",
-      ".skills/review-fix-commit-loop/SKILL.md"
+      ".skills/review-fix-commit-loop/SKILL.md",
+      ".skills/developing-provider-conversation-adapters/SKILL.md"
     ]
   },
   {

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -3844,12 +3844,14 @@
     "status": "automated",
     "owners": [
       "tests/contract/aiSessions/kimiConversationAdapter.test.js",
+      "tests/contract/aiSessions/claudeConversationAdapter.test.js",
       "tests/integration/dashboard/conversationViewer.test.js",
       "tests/browser/conversationViewer.test.js"
     ],
     "evidence": [
       "src/aiSessions/conversation/subagentSessions.ts",
       "src/aiSessions/conversation/kimiAdapter.ts",
+      "src/aiSessions/conversation/claudeAdapter.ts",
       "src/aiSessions/conversation/viewer.ts",
       "src/aiSessions/conversation/viewerProtocol.ts",
       "src/aiSessions/conversation/viewerDocument.ts",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "83c960f4e79611a2c1616b25a9bd7df8b1e028b0",
+        "head": "822c2648c29207d7b17d8a03e52940a053324081",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -83,7 +83,8 @@
             "f596e75c38c30f2d86feb0957b94e7937292a40f",
             "674cb34c5c5b6dd1c3513dff1ef37ba3f41e1705",
             "81f78f0214e71c4dae081407445434a92049f865",
-            "6bf71031de396dcec5cf080c6ed6800540ab2dca"
+            "6bf71031de396dcec5cf080c6ed6800540ab2dca",
+            "dd927ae9bd22489676ba9d4e2cbafed579ed068c"
         ]
     },
     "capabilities": [
@@ -915,7 +916,8 @@
                 "c982f07c1ab89e22ef859e30399766bcd6ee5029",
                 "e11079d10e1dc321532205b445705799875dc5a6",
                 "37de455ba64a9e1c29d27892b2a2ad5a4b2ad0a0",
-                "4b09fd45d1e3461493b9a4f279d31401da44f853"
+                "4b09fd45d1e3461493b9a4f279d31401da44f853",
+                "822c2648c29207d7b17d8a03e52940a053324081"
             ],
             "behaviors": [
                 "ARCH-CI-QUALITY-GATE-001",
@@ -1097,7 +1099,8 @@
                 "65311abfd2623d28189e29d25bd662ab728d3912",
                 "312bd9b7d13b4f7c3aa414a4830acb0e8cdb72d8",
                 "5a0de3623b5d407c688a5b7fd6bbffee7cdac1b0",
-                "83c960f4e79611a2c1616b25a9bd7df8b1e028b0"
+                "83c960f4e79611a2c1616b25a9bd7df8b1e028b0",
+                "027f2666c0f07d2d42bc18cdcec30316a06c0153"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",

--- a/src/aiSessions/conversation/claudeAdapter.ts
+++ b/src/aiSessions/conversation/claudeAdapter.ts
@@ -1,5 +1,7 @@
 'use strict';
 
+import * as fs from 'fs';
+import * as path from 'path';
 import type {
     AiSessionConversationSourceCandidate,
     AiSessionDisposable,
@@ -31,12 +33,17 @@ import {
     ConversationPage,
     ConversationPageRequest,
     ConversationProviderAdapter,
+    ConversationSubagentEntry,
     ConversationTelemetry,
 } from './types';
 import {
     openValidatedConversationSource,
     OpenConversationSource,
 } from './source';
+import {
+    isSubagentId,
+    splitSubagentSessionId,
+} from './subagentSessions';
 import type {
     ConversationWorktreeInfo,
     ResolveWorktree,
@@ -60,6 +67,13 @@ type ConversationContextUsage = NonNullable<ConversationTelemetry['context']>;
 // Claude Code JSONL does not record the context-window size; all current
 // Claude models default to a 200k window.
 const CLAUDE_DEFAULT_MAX_CONTEXT_TOKENS = 200_000;
+
+const MAX_LISTED_SUBAGENTS = 64;
+const SUBAGENT_TRANSCRIPT_PATTERN = /^agent-([0-9a-z][0-9a-z-]{0,63})\.jsonl$/i;
+const SUBAGENT_RUNNING_FRESHNESS_MS = 5 * 60 * 1000;
+// A single record can exceed 200KB (large tool results); the read window
+// must hold one full record plus the partial line cut by the window edge.
+const SUBAGENT_RECORD_WINDOW_BYTES = 512 * 1024;
 
 interface ClaudeConversationIndex extends AiSessionDisposable {
     source: OpenConversationSource;
@@ -106,6 +120,13 @@ function isVisibleUserEvent(event: Record<string, any>): boolean {
         && typeof event.sourceToolUseID !== 'string'
         && event.promptSource !== 'system'
         && (!origin || origin.kind === undefined || origin.kind === 'human');
+}
+
+// A subagent resumed via SendMessage receives its follow-up instruction as
+// a coordinator-authored user record; inside a subagent transcript that
+// record is the dispatch turn of the next round and must stay visible.
+function isCoordinatorDispatch(event: Record<string, any>): boolean {
+    return asRecord(event.origin)?.kind === 'coordinator';
 }
 
 function visibleInputParts(value: unknown): VisibleUserInputPart[] {
@@ -263,6 +284,57 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
         };
     }
 
+    async readSubagents(
+        sessionId: string,
+        _signal?: ConversationAbortSignal
+    ): Promise<ConversationSubagentEntry[]> {
+        if (this.disposed) {
+            return [];
+        }
+        const split = splitSubagentSessionId(sessionId);
+        if (split.subagentId) {
+            return [];
+        }
+        const candidate = this.options.resolveSource(split.sessionId);
+        if (!candidate) {
+            return [];
+        }
+        const subagentsRoot = subagentsRootFor(candidate.sourcePath);
+        let dirents: fs.Dirent[];
+        try {
+            dirents = await fs.promises.readdir(subagentsRoot, {
+                withFileTypes: true,
+            });
+        } catch (_error) {
+            return [];
+        }
+        const now = Date.now();
+        const entries: ConversationSubagentEntry[] = [];
+        for (const dirent of dirents) {
+            if (entries.length >= MAX_LISTED_SUBAGENTS) {
+                break;
+            }
+            const match = dirent.isFile()
+                ? SUBAGENT_TRANSCRIPT_PATTERN.exec(dirent.name)
+                : null;
+            if (!match || !isSubagentId(match[1])) {
+                continue;
+            }
+            const entry = await readSubagentEntry(
+                subagentsRoot,
+                match[1],
+                now
+            );
+            if (entry) {
+                entries.push(entry);
+            }
+        }
+        entries.sort((left, right) =>
+            (left.createdAt ?? left.updatedAt ?? 0)
+            - (right.createdAt ?? right.updatedAt ?? 0));
+        return entries;
+    }
+
     private async readWorktree(
         loaded: LoadedConversation
     ): Promise<ConversationWorktreeInfo | undefined> {
@@ -350,14 +422,30 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
         if (this.disposed) {
             throw new ConversationError('unavailable', 'missingSource');
         }
-        const candidate = this.options.resolveSource(sessionId);
+        const split = splitSubagentSessionId(sessionId);
+        if (split.subagentId && !isSubagentId(split.subagentId)) {
+            throw new ConversationError('unavailable', 'missingSource');
+        }
+        const candidate = this.options.resolveSource(split.sessionId);
         if (!candidate) {
             throw new ConversationError('unavailable', 'missingSource');
         }
-        const source = await openValidatedConversationSource(candidate);
+        const effectiveCandidate = split.subagentId
+            ? {
+                providerHome: candidate.providerHome,
+                sourcePath: path.join(
+                    subagentsRootFor(candidate.sourcePath),
+                    `agent-${split.subagentId}.jsonl`
+                ),
+            }
+            : candidate;
+        const source = await openValidatedConversationSource(
+            effectiveCandidate
+        );
         if (!source) {
             throw new ConversationError('unavailable', 'missingSource');
         }
+        const isSubagentTranscript = Boolean(split.subagentId);
         const previous = this.cache.get(sessionId);
         let interactions: ConversationInteraction[] = [];
         let openInteractionIndex: number | undefined;
@@ -395,7 +483,9 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
             };
             const normalizeRecord = (record: ConversationJsonlRecord): void => {
                 const event = asRecord(record.value);
-                if (!event || event.isSidechain) {
+                // Subagent transcripts consist entirely of sidechain records;
+                // the sidechain filter only applies to the main conversation.
+                if (!event || (event.isSidechain && !split.subagentId)) {
                     return;
                 }
                 const message = asRecord(event.message);
@@ -426,7 +516,9 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
                     timeoutOpenInteractionIndex = undefined;
                 } else if (event.type === 'user'
                     && message?.role === 'user'
-                    && isVisibleUserEvent(event)
+                    && (isVisibleUserEvent(event)
+                        || (isSubagentTranscript
+                            && isCoordinatorDispatch(event)))
                     && !event.sourceToolAssistantUUID
                     && !event.toolUseResult
                     && !containsBlock(message.content, 'tool_result')) {
@@ -599,5 +691,189 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
             this.options.clearTimeout(this.invalidationTimer);
             this.invalidationTimer = undefined;
         }
+    }
+}
+
+interface SubagentMeta {
+    description?: string;
+    agentType?: string;
+    toolUseId?: string;
+    spawnDepth?: number;
+    model?: string;
+}
+
+// Claude stores subagent transcripts beside the session file:
+// <project>/<sessionId>.jsonl -> <project>/<sessionId>/subagents/.
+function subagentsRootFor(sourcePath: string): string {
+    const base = path.basename(sourcePath, path.extname(sourcePath));
+    return path.join(path.dirname(sourcePath), base, 'subagents');
+}
+
+async function readSubagentEntry(
+    subagentsRoot: string,
+    id: string,
+    now: number
+): Promise<ConversationSubagentEntry | undefined> {
+    const transcriptPath = path.join(subagentsRoot, `agent-${id}.jsonl`);
+    let transcriptStat: fs.Stats;
+    try {
+        transcriptStat = await fs.promises.stat(transcriptPath);
+    } catch (_error) {
+        return undefined;
+    }
+    const meta = await readSubagentMeta(
+        path.join(subagentsRoot, `agent-${id}.meta.json`)
+    );
+    // Only depth-1 agents (dispatched by the main session) are listed;
+    // deeper nested agents stay visible inside their parent's transcript
+    // as Task tool calls.
+    if (typeof meta?.spawnDepth === 'number' && meta.spawnDepth > 1) {
+        return undefined;
+    }
+    const [createdAt, completed] = await Promise.all([
+        readSubagentCreatedAt(transcriptPath),
+        readSubagentCompleted(transcriptPath, transcriptStat.size),
+    ]);
+    return {
+        id,
+        label: subagentLabel(meta, id),
+        ...(meta?.agentType ? { agentType: meta.agentType } : {}),
+        status: subagentStatus(completed, transcriptStat.mtimeMs, now),
+        ...(createdAt !== undefined ? { createdAt } : {}),
+        updatedAt: Math.floor(transcriptStat.mtimeMs),
+    };
+}
+
+async function readSubagentMeta(
+    metaPath: string
+): Promise<SubagentMeta | undefined> {
+    try {
+        const parsed: unknown = JSON.parse(
+            await fs.promises.readFile(metaPath, 'utf8')
+        );
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+            return undefined;
+        }
+        return parsed as SubagentMeta;
+    } catch (_error) {
+        return undefined;
+    }
+}
+
+function subagentLabel(meta: SubagentMeta | undefined, id: string): string {
+    const description = typeof meta?.description === 'string'
+        ? normalizeVisibleText(meta?.description ?? '')
+        : '';
+    if (description) {
+        return countGraphemes(description) <= 120
+            ? description
+            : truncateGraphemes(description, 119);
+    }
+    const agentType = typeof meta?.agentType === 'string'
+        ? meta.agentType
+        : '';
+    return agentType ? `${agentType} · ${id}` : id;
+}
+
+function subagentStatus(
+    completed: boolean,
+    transcriptMtimeMs: number,
+    now: number
+): ConversationSubagentEntry['status'] {
+    if (completed) {
+        return 'idle';
+    }
+    // Claude records no status on disk: a mid-turn tail record only proves
+    // liveness while the transcript is freshly written; a crashed CLI
+    // leaves a stale mid-turn transcript behind.
+    return now - transcriptMtimeMs <= SUBAGENT_RUNNING_FRESHNESS_MS
+        ? 'running'
+        : 'failed';
+}
+
+async function readSubagentCreatedAt(
+    transcriptPath: string
+): Promise<number | undefined> {
+    const head = await readFileWindow(
+        transcriptPath,
+        0,
+        SUBAGENT_RECORD_WINDOW_BYTES
+    );
+    if (!head) {
+        return undefined;
+    }
+    const newline = head.indexOf('\n');
+    if (newline <= 0) {
+        return undefined;
+    }
+    return recordTimestamp(head.slice(0, newline));
+}
+
+async function readSubagentCompleted(
+    transcriptPath: string,
+    fileSize: number
+): Promise<boolean> {
+    const length = Math.min(fileSize, SUBAGENT_RECORD_WINDOW_BYTES);
+    if (!length) {
+        return false;
+    }
+    const tail = await readFileWindow(
+        transcriptPath,
+        fileSize - length,
+        length
+    );
+    if (!tail) {
+        return false;
+    }
+    const lines = tail.split('\n');
+    if (fileSize > length) {
+        // The first line may be cut by the window edge; drop it.
+        lines.shift();
+    }
+    for (let index = lines.length - 1; index >= 0; index--) {
+        const line = lines[index].trim();
+        if (!line) {
+            continue;
+        }
+        try {
+            const record = asRecord(JSON.parse(line));
+            const message = asRecord(record?.message);
+            // An agent finishes with a final assistant message that calls
+            // no tools; anything else as the tail means the turn was still
+            // in flight when the transcript was last written.
+            return record?.type === 'assistant'
+                && message?.role === 'assistant'
+                && !containsBlock(message.content, 'tool_use');
+        } catch (_error) {
+            return false;
+        }
+    }
+    return false;
+}
+
+function recordTimestamp(line: string): number | undefined {
+    try {
+        const record = asRecord(JSON.parse(line));
+        return timestampValue(record?.timestamp);
+    } catch (_error) {
+        return undefined;
+    }
+}
+
+async function readFileWindow(
+    filePath: string,
+    position: number,
+    length: number
+): Promise<string | undefined> {
+    let handle: fs.promises.FileHandle | undefined;
+    try {
+        handle = await fs.promises.open(filePath, 'r');
+        const buffer = Buffer.alloc(length);
+        const { bytesRead } = await handle.read(buffer, 0, length, position);
+        return buffer.toString('utf8', 0, bytesRead);
+    } catch (_error) {
+        return undefined;
+    } finally {
+        await handle?.close().catch(() => undefined);
     }
 }

--- a/tests/contract/aiSessions/claudeConversationAdapter.test.js
+++ b/tests/contract/aiSessions/claudeConversationAdapter.test.js
@@ -760,3 +760,257 @@ test('CONVERSATION-TELEMETRY-001 Claude resolves the current worktree from the l
         missing: true,
     });
 });
+
+async function writeSubagentFixture(source, id, meta, records) {
+    // Real layout: <dir>/<session>.jsonl -> <dir>/<session>/subagents/.
+    const base = path.basename(source.sourcePath, path.extname(source.sourcePath));
+    const directory = path.join(path.dirname(source.sourcePath), base, 'subagents');
+    await fs.promises.mkdir(directory, { recursive: true });
+    if (meta) {
+        await fs.promises.writeFile(
+            path.join(directory, `agent-${id}.meta.json`),
+            JSON.stringify(meta)
+        );
+    }
+    const transcriptPath = path.join(directory, `agent-${id}.jsonl`);
+    await fs.promises.writeFile(
+        transcriptPath,
+        records.map(record => JSON.stringify(record)).join('\n') + '\n'
+    );
+    return { directory, transcriptPath };
+}
+
+function subagentTranscriptRecords(id, options = {}) {
+    const startedAt = options.startedAt || '2025-01-02T03:04:05.000Z';
+    const finalContent = options.midTurn === 'toolUse'
+        ? [{
+            type: 'tool_use',
+            id: 'toolu_fixture_1',
+            name: 'Bash',
+            input: { command: 'npm test' },
+        }]
+        : [{ type: 'text', text: 'The parser normalizes visible text.' }];
+    return [
+        {
+            type: 'user',
+            uuid: `${id}-user-1`,
+            isSidechain: true,
+            agentId: id,
+            promptId: `${id}-prompt-1`,
+            timestamp: startedAt,
+            message: {
+                role: 'user',
+                content: 'Explore the parser and report back',
+            },
+        },
+        {
+            type: 'assistant',
+            uuid: `${id}-assistant-1`,
+            isSidechain: true,
+            agentId: id,
+            timestamp: '2025-01-02T03:04:06.000Z',
+            message: {
+                role: 'assistant',
+                model: 'claude-haiku-4-5-20251001',
+                content: [{ type: 'thinking', thinking: 'subagent-secret' }],
+            },
+        },
+        {
+            type: 'user',
+            uuid: `${id}-user-2`,
+            isSidechain: true,
+            agentId: id,
+            timestamp: '2025-01-02T03:04:07.000Z',
+            message: {
+                role: 'user',
+                content: [{ type: 'tool_result', content: 'local/path' }],
+            },
+        },
+        ...(options.midTurn === 'toolResult'
+            ? []
+            : [{
+                type: 'assistant',
+                uuid: `${id}-assistant-2`,
+                isSidechain: true,
+                agentId: id,
+                timestamp: '2025-01-02T03:04:08.000Z',
+                message: { role: 'assistant', content: finalContent },
+            }]),
+    ];
+}
+
+test('WEBVIEW-AI-SESSION-SUBAGENT-VIEWER-001 Claude lists depth-1 subagents with inferred statuses and labels', async t => {
+    const source = await createFixture(t);
+    const fresh = await writeSubagentFixture(
+        source,
+        'a11111111',
+        {
+            description: 'Explore the parser',
+            agentType: 'Explore',
+            spawnDepth: 1,
+            toolUseId: 'toolu_fixture_alpha',
+        },
+        subagentTranscriptRecords('a11111111')
+    );
+    await writeSubagentFixture(
+        source,
+        'a22222222',
+        { agentType: 'general-purpose', spawnDepth: 1 },
+        subagentTranscriptRecords('a22222222', {
+            startedAt: '2025-01-02T02:04:05.000Z',
+            midTurn: 'toolUse',
+        })
+    );
+    const stale = await writeSubagentFixture(
+        source,
+        'a33333333',
+        { description: 'Stale worker', spawnDepth: 1 },
+        subagentTranscriptRecords('a33333333', {
+            startedAt: '2025-01-02T01:04:05.000Z',
+            midTurn: 'toolResult',
+        })
+    );
+    const tenMinutesAgo = (Date.now() - 10 * 60 * 1000) / 1000;
+    await fs.promises.utimes(
+        stale.transcriptPath,
+        tenMinutesAgo,
+        tenMinutesAgo
+    );
+    await writeSubagentFixture(
+        source,
+        'a44444444',
+        { description: 'Nested grandchild', spawnDepth: 2 },
+        subagentTranscriptRecords('a44444444')
+    );
+    await writeSubagentFixture(
+        source,
+        'a55555555',
+        null,
+        subagentTranscriptRecords('a55555555', {
+            startedAt: '2025-01-02T04:04:05.000Z',
+        })
+    );
+    const adapter = createAdapter(source);
+    t.after(() => adapter.dispose());
+
+    const entries = await adapter.readSubagents(sessionId);
+    assert.deepEqual(
+        entries.map(entry => [entry.id, entry.status, entry.agentType]),
+        [
+            ['a33333333', 'failed', undefined],
+            ['a22222222', 'running', 'general-purpose'],
+            ['a11111111', 'idle', 'Explore'],
+            ['a55555555', 'idle', undefined],
+        ]
+    );
+    assert.equal(entries[2].label, 'Explore the parser');
+    assert.equal(entries[1].label, 'general-purpose · a22222222');
+    assert.equal(entries[3].label, 'a55555555');
+    assert.equal(entries[2].createdAt, Date.parse('2025-01-02T03:04:05.000Z'));
+    assert.ok(Number.isSafeInteger(entries[0].updatedAt));
+
+    const stat = await fs.promises.stat(fresh.transcriptPath);
+    assert.equal(entries[2].updatedAt, Math.floor(stat.mtimeMs));
+});
+
+test('WEBVIEW-AI-SESSION-SUBAGENT-VIEWER-001 Claude reads a subagent transcript as its own conversation', async t => {
+    const source = await createFixture(t);
+    await writeSubagentFixture(
+        source,
+        'a11111111',
+        { description: 'Explore the parser', spawnDepth: 1 },
+        subagentTranscriptRecords('a11111111')
+    );
+    const adapter = createAdapter(source);
+    t.after(() => adapter.dispose());
+
+    const encodedId = `${sessionId}#agent:a11111111`;
+    const outline = await adapter.readOutline(encodedId);
+    assert.equal(outline.sessionId, encodedId);
+    assert.equal(outline.totalInteractions, 1);
+    assert.equal(
+        outline.interactions[0].userPreview,
+        'Explore the parser and report back'
+    );
+    const page = await adapter.readPage({
+        provider: 'claude',
+        sessionId: encodedId,
+        anchorInteractionId: outline.interactions[0].id,
+        direction: 'around',
+        expectedRevision: outline.sourceRevision,
+    });
+    assert.deepEqual(
+        page.messages.map(message => [message.role, message.markdown]),
+        [
+            ['user', 'Explore the parser and report back'],
+            ['assistant', 'The parser normalizes visible text.'],
+        ]
+    );
+
+    // A resumed subagent (SendMessage) grows a second interaction round.
+    await writeSubagentFixture(
+        source,
+        'a66666666',
+        { description: 'Resumed worker', spawnDepth: 1 },
+        [
+            ...subagentTranscriptRecords('a66666666'),
+            {
+                type: 'user',
+                uuid: 'a66666666-user-3',
+                isSidechain: true,
+                isMeta: true,
+                origin: { kind: 'coordinator' },
+                agentId: 'a66666666',
+                promptId: 'a66666666-prompt-2',
+                timestamp: '2025-01-02T03:05:00.000Z',
+                message: { role: 'user', content: 'One more check please' },
+            },
+            {
+                type: 'assistant',
+                uuid: 'a66666666-assistant-3',
+                isSidechain: true,
+                agentId: 'a66666666',
+                timestamp: '2025-01-02T03:05:01.000Z',
+                message: {
+                    role: 'assistant',
+                    content: [{ type: 'text', text: 'Follow-up done.' }],
+                },
+            },
+        ]
+    );
+    const resumed = await adapter.readOutline(`${sessionId}#agent:a66666666`);
+    assert.equal(resumed.totalInteractions, 2);
+    assert.deepEqual(
+        resumed.interactions.map(item => item.userPreview),
+        ['Explore the parser and report back', 'One more check please']
+    );
+
+    // The parent session conversation is unaffected by the subagent files.
+    const parent = await adapter.readOutline(sessionId);
+    assert.equal(parent.totalInteractions, 3);
+});
+
+test('WEBVIEW-AI-SESSION-SUBAGENT-VIEWER-001 Claude rejects malformed and missing subagent targets', async t => {
+    const source = await createFixture(t);
+    await writeSubagentFixture(
+        source,
+        'a11111111',
+        { spawnDepth: 1 },
+        subagentTranscriptRecords('a11111111')
+    );
+    const adapter = createAdapter(source);
+    t.after(() => adapter.dispose());
+
+    await assert.rejects(
+        () => adapter.readOutline(`${sessionId}#agent:..`),
+        error => error?.code === 'unavailable'
+    );
+    await assert.rejects(
+        () => adapter.readOutline(`${sessionId}#agent:a99999999`),
+        error => error?.code === 'unavailable'
+    );
+    await assert.rejects(
+        () => adapter.readOutline(`${sessionId}#agent:a11111111#agent:a22222222`),
+        error => error?.code === 'unavailable'
+    );
+});

--- a/tests/unit/tooling/repositorySkills.test.js
+++ b/tests/unit/tooling/repositorySkills.test.js
@@ -115,3 +115,16 @@ test('ARCH-REPOSITORY-SKILL-GUIDANCE-001 installs dependencies inside fresh work
         ['path-constructed lookup failure', /constructs[\s\S]*node_modules\/\.\.\.[\s\S]*paths directly/i],
     ]);
 });
+
+
+test('ARCH-REPOSITORY-SKILL-GUIDANCE-001 verifies provider adapters against real on-disk data', () => {
+    const skill = readSkill('.skills/developing-provider-conversation-adapters/SKILL.md');
+
+    assertSkillMentions(skill, [
+        ['real data verification rule', /real on-disk provider data/i],
+        ['self-consistent fixture trap', /self-consistent trap/i],
+        ['probe before assuming', /probe real data first/i],
+        ['layout mirroring', /mirror the real layout/i],
+        ['status inference guidance', /no status[\s\S]*transcript tail/i],
+    ]);
+});


### PR DESCRIPTION
## Summary

Extend the subagent viewer (shipped for Kimi in #94) to Claude sessions. The webview and protocol layers were already provider-neutral; this change teaches the Claude adapter to list subagents and load their transcripts.

- `readSubagents` lists depth-1 agents from the real on-disk layout `<projectSlug>/<sessionId>/subagents/agent-<id>.{jsonl,meta.json}` (a flat directory across all spawn depths; nested agents with `spawnDepth > 1` are intentionally not listed and remain visible inside their parent's transcript).
- Claude records no status on disk, so status is inferred: a transcript whose last complete record is an assistant message without tool_use is finished; anything else is running only while the file mtime is fresh (5 minutes), then failed — the same zombie guard as the Kimi adapter. Head/tail reads use bounded 512KB windows because a single record can exceed 200KB.
- `load()` resolves encoded `<sessionId>#agent:<id>` targets to the subagent transcript and relaxes the main-conversation `isSidechain` filter for subagent sources (subagent transcripts consist entirely of sidechain records).
- Subagents resumed via SendMessage arrive as `origin.kind === 'coordinator'` user records; these are surfaced as new interaction rounds so multi-round transcripts segment correctly.
- New repository skill `developing-provider-conversation-adapters` capturing the verified workflow (probe real data, mirror real layout in fixtures, verify the compiled adapter against real on-disk data) plus the current layout reference and the status-inference rule.

## Skill harvest

updated .skills/developing-provider-conversation-adapters — the implementation's self-authored fixtures initially mirrored a wrong subagents-root assumption and passed green; only running the compiled adapter against real `~/.claude` data exposed it. That lesson (plus the probed layout reference) generalizes to the upcoming Codex adapter work. Recorded as the `Skill-Harvest: updated:.skills/developing-provider-conversation-adapters` trailer of audit commit c215404; skill owner test added in `tests/unit/tooling/repositorySkills.test.js`.

## Verification

- `node --test tests/contract/aiSessions/claudeConversationAdapter.test.js` — 18/18, including the three new `WEBVIEW-AI-SESSION-SUBAGENT-VIEWER-001` tests (list/status inference/depth filter, transcript reading incl. coordinator resume rounds, malformed-target rejection).
- `npm run test:behavior-contracts` — pass (10 blockers).
- `npm run test:ci:linux` — pass; changed-line coverage 88.21% (247/280) against origin/main.
- Real-data verification against `~/.claude` production sessions: 19 depth-1 subagents listed with correct statuses/labels/order; transcripts load; a SendMessage-resumed agent segments into its 3 rounds.
- Manual acceptance on a locally installed build: list rendering, in-place transcript switching, banner return, nested-depth filtering.
