### PR TITLE
feat: view Codex session subagents and their transcripts in the conversation viewer

### DIFF
--- a/.skills/developing-provider-conversation-adapters/SKILL.md
+++ b/.skills/developing-provider-conversation-adapters/SKILL.md
@@ -39,7 +39,7 @@ Green self-authored fixtures alone are not evidence.
 |---|---|---|
 | Kimi | `<kimiHome>/sessions/<workdirHash>/<sessionUuid>/wire.jsonl` | `<sessionDir>/subagents/<id>/{meta.json,wire.jsonl}`; meta carries explicit `status` + `created_at` |
 | Claude | `<claudeHome>/projects/<slug>/<sessionId>.jsonl` | `<slug>/<sessionId>/subagents/agent-<id>.{jsonl,meta.json}`, flat across spawnDepths; meta has `agentType`/`description`/`spawnDepth`/`toolUseId` but **no status** — infer from the transcript tail plus mtime; SendMessage resumes arrive as `origin.kind === 'coordinator'` user records |
-| Codex | rollout JSONL | `session_meta.source.subagent.thread_spawn`; app-server read access unverified — spike first |
+| Codex | rollout JSONL under `<codexHome>/sessions/YYYY/MM/DD/`; conversation content is app-server-only (`thread/read`) | Independent rollout files per thread; `session_meta.payload.source.subagent.thread_spawn` carries `parent_thread_id`/`depth`/`agent_nickname`/`agent_path`; discovery scans first lines by parent id; `thread/read` accepts subagent thread ids (verified 0.146); no userMessage in subagent threads — seed the dispatch interaction from metadata; status = last `event_msg` is `task_complete` → finished, else mtime freshness |
 
 Subagent transcripts reuse the provider's main record envelope; Claude
 subagent files consist entirely of `isSidechain: true` records, so any
@@ -47,10 +47,12 @@ main-conversation sidechain filter must be relaxed for subagent sources.
 
 ## Status Inference Without An On-Disk Status
 
-When the format records no status (Claude today), derive it from the
-transcript tail:
+When the format records no status (Claude and Codex today), derive it from
+the transcript tail:
 
-- last complete record is an assistant message without tool_use → finished
+- last lifecycle signal means finished — Claude: last record is an
+  assistant message without tool_use; Codex: last `event_msg` is
+  `task_complete`
 - anything else → running only while the file mtime is fresh (5 minutes);
   a crashed CLI leaves a stale mid-turn transcript behind → failed
 

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -3846,6 +3846,8 @@
     "owners": [
       "tests/contract/aiSessions/kimiConversationAdapter.test.js",
       "tests/contract/aiSessions/claudeConversationAdapter.test.js",
+      "tests/contract/aiSessions/codexConversationAdapter.test.js",
+      "tests/unit/aiSessions/codexSessionFilePath.test.js",
       "tests/integration/dashboard/conversationViewer.test.js",
       "tests/browser/conversationViewer.test.js"
     ],
@@ -3853,6 +3855,8 @@
       "src/aiSessions/conversation/subagentSessions.ts",
       "src/aiSessions/conversation/kimiAdapter.ts",
       "src/aiSessions/conversation/claudeAdapter.ts",
+      "src/aiSessions/conversation/codexAdapter.ts",
+      "src/services/codexSessionService.ts",
       "src/aiSessions/conversation/viewer.ts",
       "src/aiSessions/conversation/viewerProtocol.ts",
       "src/aiSessions/conversation/viewerDocument.ts",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "822c2648c29207d7b17d8a03e52940a053324081",
+        "head": "c4fc3765929b05fc0e3b41710d6ca2527d0b15d0",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -84,7 +84,8 @@
             "674cb34c5c5b6dd1c3513dff1ef37ba3f41e1705",
             "81f78f0214e71c4dae081407445434a92049f865",
             "6bf71031de396dcec5cf080c6ed6800540ab2dca",
-            "dd927ae9bd22489676ba9d4e2cbafed579ed068c"
+            "dd927ae9bd22489676ba9d4e2cbafed579ed068c",
+            "c215404072fd9c60af5aeb46fc964a8f83cc353d"
         ]
     },
     "capabilities": [
@@ -917,7 +918,8 @@
                 "e11079d10e1dc321532205b445705799875dc5a6",
                 "37de455ba64a9e1c29d27892b2a2ad5a4b2ad0a0",
                 "4b09fd45d1e3461493b9a4f279d31401da44f853",
-                "822c2648c29207d7b17d8a03e52940a053324081"
+                "822c2648c29207d7b17d8a03e52940a053324081",
+                "c4fc3765929b05fc0e3b41710d6ca2527d0b15d0"
             ],
             "behaviors": [
                 "ARCH-CI-QUALITY-GATE-001",
@@ -1100,7 +1102,8 @@
                 "312bd9b7d13b4f7c3aa414a4830acb0e8cdb72d8",
                 "5a0de3623b5d407c688a5b7fd6bbffee7cdac1b0",
                 "83c960f4e79611a2c1616b25a9bd7df8b1e028b0",
-                "027f2666c0f07d2d42bc18cdcec30316a06c0153"
+                "027f2666c0f07d2d42bc18cdcec30316a06c0153",
+                "34ba57c428cd9432737e4d77c15ec7694bfe4ebe"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",

--- a/src/aiSessions/conversation/codexAdapter.ts
+++ b/src/aiSessions/conversation/codexAdapter.ts
@@ -1,7 +1,10 @@
 'use strict';
 
 import { createHash } from 'crypto';
-import type { AiSessionDisposable } from '../types';
+import type {
+    AiSessionCodexSubagentThread,
+    AiSessionDisposable,
+} from '../types';
 import {
     buildConversationOutline,
     buildConversationPage,
@@ -24,8 +27,13 @@ import {
     ConversationPageRequest,
     ConversationProviderAdapter,
     ConversationResponseState,
+    ConversationSubagentEntry,
     ConversationTelemetry,
 } from './types';
+import {
+    isSubagentId,
+    splitSubagentSessionId,
+} from './subagentSessions';
 import type {
     ConversationWorktreeInfo,
     ResolveWorktree,
@@ -51,7 +59,13 @@ export interface CodexConversationAdapterOptions {
     clearTimeout(handle: TimerHandle): void;
     resolveWorktree?: ResolveWorktree;
     readCurrentWorkdir?(sessionId: string): string | undefined;
+    listSubagentThreads?(
+        sessionId: string
+    ): AiSessionCodexSubagentThread[] | Promise<AiSessionCodexSubagentThread[]>;
 }
+
+const MAX_LISTED_SUBAGENTS = 64;
+const SUBAGENT_RUNNING_FRESHNESS_MS = 5 * 60 * 1000;
 
 interface LoadedConversation {
     interactions: ConversationInteraction[];
@@ -96,7 +110,8 @@ function turnResponseState(value: string): ConversationResponseState {
 
 function normalizeThreadRead(
     value: unknown,
-    sessionId: string
+    sessionId: string,
+    dispatch?: { label: string; timestamp?: number }
 ): ConversationInteraction[] {
     const result = asRecord(value);
     const thread = asRecord(result?.thread);
@@ -109,6 +124,24 @@ function normalizeThreadRead(
     const turnIds = new Set<string>();
     const itemIds = new Set<string>();
     const interactions: ConversationInteraction[] = [];
+    // A subagent thread exposes no userMessage for its dispatch prompt
+    // (the app-server strips it), so seed one from the thread metadata to
+    // give the subagent's agentMessages an interaction to attach to.
+    let seededDispatchIndex: number | undefined;
+    if (dispatch) {
+        interactions.push({
+            id: `${sessionId}-dispatch`,
+            ...(dispatch.timestamp !== undefined
+                ? { timestamp: dispatch.timestamp }
+                : {}),
+            userMarkdown: dispatch.label,
+            userPreview: buildUserPreview(dispatch.label),
+            userGraphemeCount: countGraphemes(dispatch.label),
+            assistantMarkdown: [],
+            responseState: 'unknown',
+        });
+        seededDispatchIndex = 0;
+    }
     for (const rawTurn of thread.turns) {
         const turn = asRecord(rawTurn);
         if (!turn
@@ -121,7 +154,10 @@ function normalizeThreadRead(
         }
         turnIds.add(turn.id);
         const responseState = turnResponseState(turn.status);
-        let currentInteractionIndex: number | undefined;
+        if (seededDispatchIndex !== undefined) {
+            interactions[seededDispatchIndex].responseState = responseState;
+        }
+        let currentInteractionIndex: number | undefined = seededDispatchIndex;
         for (const rawItem of turn.items) {
             const item = asRecord(rawItem);
             if (!item
@@ -324,6 +360,53 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
             { ...request, provider: 'codex' },
             loaded.sourceRevision
         );
+    }
+
+    async readSubagents(
+        sessionId: string,
+        _signal?: ConversationAbortSignal
+    ): Promise<ConversationSubagentEntry[]> {
+        if (this.disposed) {
+            return [];
+        }
+        const split = splitSubagentSessionId(sessionId);
+        if (split.subagentId
+            || typeof this.options.listSubagentThreads !== 'function') {
+            return [];
+        }
+        let threads: AiSessionCodexSubagentThread[];
+        try {
+            threads = await this.options.listSubagentThreads(split.sessionId);
+        } catch (_error) {
+            return [];
+        }
+        const now = Date.now();
+        const entries: ConversationSubagentEntry[] = [];
+        for (const thread of threads) {
+            if (entries.length >= MAX_LISTED_SUBAGENTS
+                || !isSubagentId(thread.id)) {
+                continue;
+            }
+            const base = subagentPathBase(thread.agentPath);
+            entries.push({
+                id: thread.id,
+                label: subagentLabel(thread),
+                ...(base ? { agentType: base } : {}),
+                status: subagentStatus(
+                    thread.completed,
+                    thread.fileMtimeMs,
+                    now
+                ),
+                ...(thread.createdAt !== undefined
+                    ? { createdAt: Math.floor(thread.createdAt) }
+                    : {}),
+                updatedAt: Math.floor(thread.fileMtimeMs),
+            });
+        }
+        entries.sort((left, right) =>
+            (left.createdAt ?? left.updatedAt ?? 0)
+            - (right.createdAt ?? right.updatedAt ?? 0));
+        return entries;
     }
 
     async readTelemetry(
@@ -546,10 +629,15 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
                 'reconnectingCodex'
             );
         }
+        const split = splitSubagentSessionId(sessionId);
+        if (split.subagentId && !isSubagentId(split.subagentId)) {
+            throw new ConversationError('unavailable', 'missingSource');
+        }
+        const threadId = split.subagentId || split.sessionId;
         let result: unknown;
         try {
             result = await this.options.client.request('thread/read', {
-                threadId: sessionId,
+                threadId,
                 includeTurns: true,
             }, signal);
         } catch (error) {
@@ -557,12 +645,31 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
                 || error?.name === 'AbortError') {
                 throw error;
             }
-            throw protocolError();
+            // A missing or unreadable subagent thread is a missing source,
+            // not a protocol failure of the parent conversation.
+            throw split.subagentId
+                ? new ConversationError('unavailable', 'missingSource')
+                : protocolError();
         }
         let interactions: ConversationInteraction[];
         try {
-            interactions = normalizeThreadRead(result, sessionId);
-        } catch (_error) {
+            if (split.subagentId) {
+                const thread = asRecord(asRecord(result)?.thread);
+                if (thread?.parentThreadId !== split.sessionId) {
+                    throw new ConversationError('unavailable', 'missingSource');
+                }
+            }
+            const dispatch = split.subagentId
+                ? subagentDispatch(
+                    asRecord(asRecord(result)?.thread),
+                    threadId
+                )
+                : undefined;
+            interactions = normalizeThreadRead(result, threadId, dispatch);
+        } catch (error) {
+            if (error instanceof ConversationError) {
+                throw error;
+            }
             throw protocolError();
         }
         return {
@@ -608,4 +715,75 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
             this.invalidationTimer = undefined;
         }
     }
+}
+
+function subagentAgentPath(
+    thread: Record<string, any> | undefined
+): string | undefined {
+    const spawn = asRecord(asRecord(asRecord(thread?.source)?.subAgent)
+        ?.thread_spawn);
+    return typeof spawn?.agent_path === 'string' && spawn.agent_path
+        ? spawn.agent_path
+        : undefined;
+}
+
+function subagentPathBase(agentPath: string | undefined): string {
+    if (!agentPath) {
+        return '';
+    }
+    const segments = agentPath.split('/').filter(Boolean);
+    return segments[segments.length - 1] || '';
+}
+
+function subagentLabel(
+    thread: Pick<AiSessionCodexSubagentThread, 'id' | 'agentNickname' | 'agentPath'>
+): string {
+    const base = subagentPathBase(thread.agentPath);
+    const label = thread.agentNickname
+        ? `${thread.agentNickname} · ${base}`
+        : base;
+    const normalized = normalizeVisibleText(label);
+    if (normalized) {
+        return countGraphemes(normalized) <= 120
+            ? normalized
+            : truncateGraphemes(normalized, 119);
+    }
+    return thread.id;
+}
+
+function subagentDispatch(
+    thread: Record<string, any> | undefined,
+    threadId: string
+): { label: string; timestamp?: number } {
+    const createdAtSeconds = typeof thread?.createdAt === 'number'
+        && Number.isFinite(thread.createdAt)
+        ? thread.createdAt
+        : undefined;
+    return {
+        label: subagentLabel({
+            id: threadId,
+            agentNickname: typeof thread?.agentNickname === 'string'
+                ? thread.agentNickname
+                : undefined,
+            agentPath: subagentAgentPath(thread),
+        }),
+        ...(createdAtSeconds !== undefined
+            ? { timestamp: Math.floor(createdAtSeconds * 1000) }
+            : {}),
+    };
+}
+
+function subagentStatus(
+    completed: boolean,
+    transcriptMtimeMs: number,
+    now: number
+): ConversationSubagentEntry['status'] {
+    if (completed) {
+        return 'idle';
+    }
+    // A crashed CLI leaves a stale transcript without task_complete
+    // behind; only a freshly written rollout proves the subagent is alive.
+    return now - transcriptMtimeMs <= SUBAGENT_RUNNING_FRESHNESS_MS
+        ? 'running'
+        : 'failed';
 }

--- a/src/aiSessions/conversation/composition.ts
+++ b/src/aiSessions/conversation/composition.ts
@@ -181,6 +181,8 @@ function createAvailableConversationCapability(
                 ? readCodexRolloutWorkdir(rolloutPath)
                 : undefined;
         },
+        listSubagentThreads: sessionId =>
+            options.services.codex.listSubagentThreads?.(sessionId) || [],
     }));
     ownership.transfer(codexClient);
     const kimiAdapter = ownership.own(factories.createKimiAdapter({

--- a/src/aiSessions/types.ts
+++ b/src/aiSessions/types.ts
@@ -91,6 +91,22 @@ export interface AiSessionConversationSourceCandidate {
     sourcePath: string;
 }
 
+/**
+ * A Codex subagent thread discovered on disk: an independent rollout file
+ * whose session_meta marks it as spawned by a parent thread.
+ */
+export interface AiSessionCodexSubagentThread {
+    id: string;
+    filePath: string;
+    agentNickname?: string;
+    agentPath?: string;
+    agentRole?: string | null;
+    createdAt?: number;
+    fileMtimeMs: number;
+    /** True when the rollout's last lifecycle event is task_complete. */
+    completed: boolean;
+}
+
 export interface AiSessionService {
     getSessions(options?: boolean | AiSessionQueryOptions): AiSessionReadResult;
     getLifecycleSignals(requests: readonly AiSessionLifecycleRequest[]): Record<string, AiSessionLifecycleSignal>;
@@ -103,6 +119,7 @@ export interface AiSessionService {
 
         candidatePaths?: readonly string[]
     ): AiSessionConversationSourceCandidate | null;
+    listSubagentThreads?(sessionId: string): AiSessionCodexSubagentThread[];
 }
 
 export interface AiSessionProviderDefinition {

--- a/src/services/codexSessionService.ts
+++ b/src/services/codexSessionService.ts
@@ -7,7 +7,7 @@ import * as path from 'path';
 import { CodexSession } from '../models';
 import IncrementalJsonlLifecycleReader from '../aiSessions/incrementalJsonlLifecycleReader';
 import { compareAiSessionUpdatedAt, filterAiSessionsByCandidatePaths, getAiSessionFileSignature, getAvailableAiSessionArchivePath, normalizeAiSessionCandidatePaths, resolveAiSessionQueryOptions } from '../aiSessions/sessionHelpers';
-import type { AiSessionQueryOptions } from '../aiSessions/types';
+import type { AiSessionCodexSubagentThread, AiSessionQueryOptions } from '../aiSessions/types';
 import { createCodexLifecycleAccumulator, AiSessionLifecycleRequest, AiSessionLifecycleSignal } from '../aiSessions/lifecycle';
 import SessionFingerprint from '../aiSessions/sessionFingerprint';
 
@@ -17,12 +17,21 @@ interface CodexSessionIndexEntry {
     updated_at?: string;
 }
 
+interface CodexSessionSubagentSpawn {
+    parentThreadId?: string;
+    depth?: number;
+    agentNickname?: string;
+    agentPath?: string;
+    agentRole?: string | null;
+}
+
 interface CodexSessionMeta {
     id?: string;
     session_id?: string;
     cwd?: string;
     timestamp?: string;
     isExcluded?: boolean;
+    subagent?: CodexSessionSubagentSpawn;
 }
 
 interface CodexDiscoveredSessionFile {
@@ -428,6 +437,80 @@ export default class CodexSessionService {
         );
     }
 
+    private readSubagentSpawn(source: unknown): CodexSessionSubagentSpawn | undefined {
+        if (!source || typeof source !== 'object') {
+            return undefined;
+        }
+        let spawn = (source as { subagent?: { thread_spawn?: Record<string, unknown> } })
+            .subagent?.thread_spawn;
+        if (!spawn || typeof spawn !== 'object') {
+            return undefined;
+        }
+        return {
+            parentThreadId: typeof spawn.parent_thread_id === 'string'
+                ? spawn.parent_thread_id
+                : undefined,
+            depth: typeof spawn.depth === 'number' ? spawn.depth : undefined,
+            agentNickname: typeof spawn.agent_nickname === 'string'
+                ? spawn.agent_nickname
+                : undefined,
+            agentPath: typeof spawn.agent_path === 'string'
+                ? spawn.agent_path
+                : undefined,
+            agentRole: typeof spawn.agent_role === 'string'
+                ? spawn.agent_role
+                : null,
+        };
+    }
+
+    /**
+     * Lists depth-1 subagent threads spawned by the given session, oldest
+     * first. Deeper nested agents stay visible inside their parent's
+     * transcript as spawn tool calls.
+     */
+    listSubagentThreads(sessionId: string): AiSessionCodexSubagentThread[] {
+        if (!sessionId) {
+            return [];
+        }
+        let codexHome = this.getCodexHome();
+        if (!codexHome) {
+            return [];
+        }
+        let sessionFiles = this.getSessionFiles(codexHome);
+        let threads: AiSessionCodexSubagentThread[] = [];
+        for (let [id, filePath] of sessionFiles) {
+            if (id === sessionId) {
+                continue;
+            }
+            let meta = this.readSessionMeta(id, sessionFiles);
+            let spawn = meta?.subagent;
+            if (!spawn
+                || spawn.parentThreadId !== sessionId
+                || spawn.depth !== 1) {
+                continue;
+            }
+            let createdAt = Date.parse(meta?.timestamp || '');
+            let fileStat = this.getFileStat(filePath);
+            threads.push({
+                id,
+                filePath,
+                agentNickname: spawn.agentNickname,
+                agentPath: spawn.agentPath,
+                agentRole: spawn.agentRole,
+                createdAt: Number.isNaN(createdAt) ? undefined : createdAt,
+                fileMtimeMs: fileStat.mtimeMs,
+                completed: this.readRolloutCompleted(
+                    filePath,
+                    fileStat.sizeBytes
+                ),
+            });
+        }
+        threads.sort((left, right) =>
+            (left.createdAt ?? left.fileMtimeMs)
+            - (right.createdAt ?? right.fileMtimeMs));
+        return threads;
+    }
+
     private readSessionMeta(sessionId: string, sessionFiles: Map<string, string>): CodexSessionMeta {
         let sessionFile = sessionFiles.get(sessionId);
         if (!sessionFile) {
@@ -460,6 +543,7 @@ export default class CodexSessionService {
                 cwd: payload.cwd,
                 timestamp: payload.timestamp || event.timestamp,
                 isExcluded: this.isExcludedSessionSource(payload.source),
+                subagent: this.readSubagentSpawn(payload.source),
             };
             this.sessionMetaCache.set(sessionFile, { signature, meta });
             return meta;
@@ -476,7 +560,6 @@ export default class CodexSessionService {
             let chunks: Buffer[] = [];
             let buffer = Buffer.alloc(4096);
             let bytesRead = 0;
-
             do {
                 bytesRead = fs.readSync(fd, buffer, 0, buffer.length, null);
                 if (bytesRead <= 0) {
@@ -496,6 +579,60 @@ export default class CodexSessionService {
             return Buffer.concat(chunks).toString('utf8').trim();
         } catch (e) {
             return null;
+        } finally {
+            if (fd !== null) {
+                try {
+                    fs.closeSync(fd);
+                } catch (e) {
+                    // Ignore close failures for best-effort metadata reads.
+                }
+            }
+        }
+    }
+
+    /**
+     * A subagent thread completed its turn when the rollout's last
+     * lifecycle event is task_complete; anything else means the turn was
+     * still in flight when the rollout was last written. Reads a bounded
+     * tail window because a single record can exceed 200KB.
+     */
+    private readRolloutCompleted(filePath: string, sizeBytes: number): boolean {
+        const windowBytes = 512 * 1024;
+        const length = Math.min(sizeBytes, windowBytes);
+        if (!length) {
+            return false;
+        }
+        let fd: number = null;
+        try {
+            fd = fs.openSync(filePath, 'r');
+            const buffer = Buffer.alloc(length);
+            const bytesRead = fs.readSync(
+                fd,
+                buffer,
+                0,
+                length,
+                sizeBytes - length
+            );
+            const tail = buffer.toString('utf8', 0, bytesRead);
+            const lines = tail.split('\n');
+            if (sizeBytes > length) {
+                // The first line may be cut by the window edge; drop it.
+                lines.shift();
+            }
+            for (let index = lines.length - 1; index >= 0; index--) {
+                const line = lines[index].trim();
+                if (!line) {
+                    continue;
+                }
+                const record = JSON.parse(line);
+                if (record?.type !== 'event_msg') {
+                    continue;
+                }
+                return record?.payload?.type === 'task_complete';
+            }
+            return false;
+        } catch (e) {
+            return false;
         } finally {
             if (fd !== null) {
                 try {

--- a/tests/contract/aiSessions/codexConversationAdapter.test.js
+++ b/tests/contract/aiSessions/codexConversationAdapter.test.js
@@ -46,6 +46,7 @@ function createAdapter(result = fixture, overrides = {}) {
         clearTimeout: overrides.clearTimeout || (() => undefined),
         resolveWorktree: overrides.resolveWorktree,
         readCurrentWorkdir: overrides.readCurrentWorkdir,
+        listSubagentThreads: overrides.listSubagentThreads,
     });
     return {
         adapter,
@@ -588,4 +589,195 @@ test('CONVERSATION-TELEMETRY-001 Codex prefers the latest exec workdir and falls
         worktreeRoot: '/launch/repo',
         repoRoot: '/launch/repo',
     });
+});
+
+const childThreadId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const otherChildThreadId = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+const thirdChildThreadId = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+
+function createThreadReadResult(threadId, parentThreadId, overrides = {}) {
+    return {
+        thread: {
+            id: threadId,
+            parentThreadId,
+            agentNickname: 'Zeno',
+            createdAt: 1_700_000_000,
+            source: {
+                subAgent: {
+                    thread_spawn: {
+                        parent_thread_id: parentThreadId,
+                        depth: 1,
+                        agent_path: '/root/implement_webview_mutation_skill',
+                        agent_nickname: 'Zeno',
+                        agent_role: null,
+                    },
+                },
+            },
+            turns: [
+                {
+                    id: 'turn-1',
+                    status: 'completed',
+                    items: [
+                        { id: 'agent-item-1', type: 'agentMessage', text: 'First progress note' },
+                        { id: 'file-item-1', type: 'fileChange', path: '/repo/x.ts' },
+                        { id: 'agent-item-2', type: 'agentMessage', text: 'status: complete' },
+                    ],
+                },
+            ],
+            ...overrides,
+        },
+    };
+}
+
+test('WEBVIEW-AI-SESSION-SUBAGENT-VIEWER-001 Codex lists depth-1 subagent threads with inferred statuses and labels', async t => {
+    const now = Date.now();
+    const { adapter } = createAdapter(fixture, {
+        listSubagentThreads: () => [
+            {
+                id: childThreadId,
+                filePath: '/codex/sessions/2026/08/02/rollout-child.jsonl',
+                agentNickname: 'Zeno',
+                agentPath: '/root/implement_webview_mutation_skill',
+                createdAt: 1_700_000_000_000,
+                fileMtimeMs: now,
+                completed: true,
+            },
+            {
+                id: otherChildThreadId,
+                filePath: '/codex/sessions/2026/08/02/rollout-running.jsonl',
+                agentPath: '/root/review_fix_loop',
+                createdAt: 1_699_000_000_000,
+                fileMtimeMs: now,
+                completed: false,
+            },
+            {
+                id: thirdChildThreadId,
+                filePath: '/codex/sessions/2026/08/02/rollout-stale.jsonl',
+                createdAt: 1_698_000_000_000,
+                fileMtimeMs: now - 10 * 60 * 1000,
+                completed: false,
+            },
+        ],
+    });
+    t.after(() => adapter.dispose());
+
+    const entries = await adapter.readSubagents(sessionId);
+    assert.deepEqual(
+        entries.map(entry => [entry.id, entry.status, entry.agentType]),
+        [
+            [thirdChildThreadId, 'failed', undefined],
+            [otherChildThreadId, 'running', 'review_fix_loop'],
+            [childThreadId, 'idle', 'implement_webview_mutation_skill'],
+        ]
+    );
+    assert.equal(entries[2].label, 'Zeno · implement_webview_mutation_skill');
+    assert.equal(entries[1].label, 'review_fix_loop');
+    assert.equal(entries[0].label, thirdChildThreadId);
+    assert.equal(entries[2].createdAt, 1_700_000_000_000);
+
+    // Encoded subagent ids never list nested subagents.
+    assert.deepEqual(
+        await adapter.readSubagents(`${sessionId}#agent:${childThreadId}`),
+        []
+    );
+});
+
+test('WEBVIEW-AI-SESSION-SUBAGENT-VIEWER-001 Codex reads a subagent thread as its own conversation', async t => {
+    const childResult = createThreadReadResult(childThreadId, sessionId);
+    const requests = [];
+    const client = {
+        async request(method, params) {
+            requests.push({ method, params });
+            if (params && params.threadId === childThreadId) {
+                return childResult;
+            }
+            return fixture;
+        },
+        dispose() {},
+    };
+    const { adapter } = createAdapter(fixture, {
+        client,
+        listSubagentThreads: () => [],
+    });
+    t.after(() => adapter.dispose());
+
+    const encodedId = `${sessionId}#agent:${childThreadId}`;
+    const outline = await adapter.readOutline(encodedId);
+    assert.equal(outline.sessionId, encodedId);
+    assert.equal(outline.totalInteractions, 1);
+    assert.equal(
+        outline.interactions[0].userPreview,
+        'Zeno · implement_webview_mutation_skill'
+    );
+    assert.deepEqual(
+        requests.map(entry => [entry.method, entry.params.threadId]),
+        [['thread/read', childThreadId]]
+    );
+    const page = await adapter.readPage({
+        provider: 'codex',
+        sessionId: encodedId,
+        anchorInteractionId: outline.interactions[0].id,
+        direction: 'around',
+        expectedRevision: outline.sourceRevision,
+    });
+    assert.deepEqual(
+        page.messages.map(message => [message.role, message.markdown]),
+        [
+            ['user', 'Zeno · implement_webview_mutation_skill'],
+            ['assistant', 'First progress note'],
+            ['assistant', 'status: complete'],
+        ]
+    );
+
+    // The parent session conversation is unaffected.
+    const parent = await adapter.readOutline(sessionId);
+    assert.equal(parent.totalInteractions, 3);
+    assert.equal(parent.interactions[0].userPreview, 'Visible request [Attachment]');
+});
+
+test('WEBVIEW-AI-SESSION-SUBAGENT-VIEWER-001 Codex rejects malformed and mismatched subagent targets', async t => {
+    const requests = [];
+    const client = {
+        async request(method, params) {
+            requests.push({ method, params });
+            if (params && params.threadId === childThreadId) {
+                // Thread exists but belongs to a different parent.
+                return createThreadReadResult(
+                    childThreadId,
+                    otherChildThreadId
+                );
+            }
+            throw new Error('thread not found');
+        },
+        dispose() {},
+    };
+    const { adapter } = createAdapter(fixture, {
+        client,
+        listSubagentThreads: () => [],
+    });
+    t.after(() => adapter.dispose());
+
+    await assert.rejects(
+        () => adapter.readOutline(`${sessionId}#agent:..`),
+        error => error?.code === 'unavailable'
+    );
+    await assert.rejects(
+        () => adapter.readOutline(`${sessionId}#agent:${childThreadId}`),
+        error => error?.code === 'unavailable'
+    );
+    await assert.rejects(
+        () => adapter.readOutline(`${sessionId}#agent:${otherChildThreadId}`),
+        error => error?.code === 'unavailable'
+    );
+    await assert.rejects(
+        () => adapter.readOutline(
+            `${sessionId}#agent:${childThreadId}#agent:${otherChildThreadId}`
+        ),
+        error => error?.code === 'unavailable'
+    );
+    // A main-session protocol failure still reports the protocol reason.
+    await assert.rejects(
+        () => adapter.readOutline(sessionId),
+        error => error?.code === 'unsupportedVersion'
+    );
 });

--- a/tests/unit/aiSessions/codexSessionFilePath.test.js
+++ b/tests/unit/aiSessions/codexSessionFilePath.test.js
@@ -35,3 +35,115 @@ test('CONVERSATION-TELEMETRY-001 resolveSessionFilePath locates rollout files by
     assert.equal(service.resolveSessionFilePath('missing-session'), null);
     assert.equal(service.resolveSessionFilePath(''), null);
 });
+
+
+test('WEBVIEW-AI-SESSION-SUBAGENT-VIEWER-001 listSubagentThreads discovers depth-1 spawn threads by parent id', async t => {
+    const home = await fs.promises.mkdtemp(
+        path.join(os.tmpdir(), 'steward-codex-subagent-home-')
+    );
+    t.after(() => fs.promises.rm(home, { recursive: true, force: true }));
+    const sessionsDir = path.join(home, 'sessions', '2026', '08', '02');
+    await fs.promises.mkdir(sessionsDir, { recursive: true });
+
+    const parentId = '11111111-1111-4111-8111-111111111111';
+    const childId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+    const nestedId = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+    const otherParentChildId = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+
+    async function writeRollout(id, payload, eventTypes = []) {
+        const filePath = path.join(
+            sessionsDir,
+            `rollout-2026-08-02T00-00-00-${id}.jsonl`
+        );
+        await fs.promises.writeFile(
+            filePath,
+            [
+                JSON.stringify({
+                    timestamp: '2026-08-02T00:00:00.000Z',
+                    type: 'session_meta',
+                    payload,
+                }),
+                ...eventTypes.map(eventType => JSON.stringify({
+                    timestamp: '2026-08-02T00:00:01.000Z',
+                    type: 'event_msg',
+                    payload: { type: eventType },
+                })),
+                '',
+            ].join('\n')
+        );
+        return filePath;
+    }
+
+    await writeRollout(parentId, {
+        id: parentId,
+        session_id: parentId,
+        timestamp: '2026-08-02T00:00:00.000Z',
+    });
+    const childPath = await writeRollout(childId, {
+        id: childId,
+        session_id: parentId,
+        timestamp: '2026-08-02T00:01:00.000Z',
+        source: {
+            subagent: {
+                thread_spawn: {
+                    parent_thread_id: parentId,
+                    depth: 1,
+                    agent_path: '/root/implement_webview_mutation_skill',
+                    agent_nickname: 'Zeno',
+                    agent_role: null,
+                },
+            },
+        },
+    }, ['task_started', 'task_complete']);
+    await writeRollout(nestedId, {
+        id: nestedId,
+        session_id: parentId,
+        timestamp: '2026-08-02T00:02:00.000Z',
+        source: {
+            subagent: {
+                thread_spawn: {
+                    parent_thread_id: parentId,
+                    depth: 2,
+                    agent_path: '/root/nested',
+                },
+            },
+        },
+    });
+    await writeRollout(otherParentChildId, {
+        id: otherParentChildId,
+        session_id: otherParentChildId,
+        timestamp: '2026-08-02T00:03:00.000Z',
+        source: {
+            subagent: {
+                thread_spawn: {
+                    parent_thread_id: 'dddddddd-dddd-4ddd-8ddd-dddddddddddd',
+                    depth: 1,
+                },
+            },
+        },
+    }, ['task_started', 'token_count']);
+
+    process.env.CODEX_HOME = home;
+    t.after(() => {
+        delete process.env.CODEX_HOME;
+    });
+    const service = new CodexSessionService();
+
+    const threads = service.listSubagentThreads(parentId);
+    assert.equal(threads.length, 1);
+    assert.equal(threads[0].id, childId);
+    assert.equal(threads[0].filePath, childPath);
+    assert.equal(threads[0].agentNickname, 'Zeno');
+    assert.equal(threads[0].agentPath, '/root/implement_webview_mutation_skill');
+    assert.equal(threads[0].agentRole, null);
+    assert.equal(threads[0].createdAt, Date.parse('2026-08-02T00:01:00.000Z'));
+    assert.ok(threads[0].fileMtimeMs > 0);
+    assert.equal(threads[0].completed, true);
+
+    assert.deepEqual(service.listSubagentThreads(''), []);
+    const otherThreads = service.listSubagentThreads(
+        'dddddddd-dddd-4ddd-8ddd-dddddddddddd'
+    );
+    assert.deepEqual(otherThreads.map(thread => thread.id), [otherParentChildId]);
+    assert.equal(otherThreads[0].completed, false);
+});

--- a/tests/unit/tooling/architectureGuards.test.js
+++ b/tests/unit/tooling/architectureGuards.test.js
@@ -27,6 +27,7 @@ function copyGuardFixture(t, mutationPath, mutate = source => source) {
         'src/aiSessions/dashboardController.ts',
         'src/aiSessions/providers.ts',
         'src/aiSessions/conversation/types.ts',
+        'src/aiSessions/conversation/subagentSessions.ts',
         'src/aiSessions/conversation/codexAdapter.ts',
         'src/aiSessions/conversation/codexAppServerClient.ts',
         'src/aiSessions/conversation/model.ts',


### PR DESCRIPTION
## Summary

Complete the subagent viewer trilogy: after Kimi (#94) and Claude (#95), Codex sessions now list their subagents and render subagent transcripts in place. The webview and protocol layers were already provider-neutral.

- **Discovery** (file layer, `codexSessionService.listSubagentThreads`): subagent threads are independent rollout files under `~/.codex/sessions/YYYY/MM/DD/` whose first-line `session_meta.payload.source.subagent.thread_spawn` carries `parent_thread_id`, `depth`, `agent_nickname`, and `agent_path`. Discovery matches depth-1 children of the viewed session; deeper nesting stays inside the parent's transcript as spawn tool calls.
- **Content** (app-server only): the architecture guard `ARCH-AI-SESSION-CONVERSATION-BOUNDARY-001` requires Codex conversation content to stay app-server-only, so the adapter reads subagent transcripts via `thread/read` with the child thread id (verified against codex-cli 0.146) — no filesystem access anywhere in the adapter's reachable module graph. The encoded target validates `thread.parentThreadId` before rendering; mismatches and missing threads report `unavailable` rather than a protocol failure.
- **Dispatch seed**: app-server turns of a subagent thread contain no `userMessage` (the dispatch prompt is stripped), so the adapter seeds the opening interaction from thread metadata (`nickname · agent_path`); subsequent `agentMessage` items attach to it.
- **Status inference**: the service tail-scans each rollout with a bounded 512KB window — a last `event_msg` of `task_complete` means finished; otherwise the entry is running only while the file mtime is fresh (5 minutes), then failed (same zombie guard as the other providers).
- Labels are `nickname · agent_path basename` (falling back to path basename, then id); entries sort by dispatch time.
- Provider-adapter skill updated with the verified Codex layout, the app-server capability finding, and the `task_complete` status rule.

## Skill harvest

updated .skills/developing-provider-conversation-adapters — the Codex spike resolved the skill's own "app-server read access unverified" note, and the architecture-guard boundary (app-server-only content, fs in the service layer) is now recorded for the next provider change. Recorded as the `Skill-Harvest: updated:.skills/developing-provider-conversation-adapters` trailer of audit commit d443a6b.

## Verification

- `node --test tests/contract/aiSessions/codexConversationAdapter.test.js tests/unit/aiSessions/codexSessionFilePath.test.js` — 25/25, including list/status inference, transcript reading with dispatch seed, parent-mismatch and malformed-target rejection, and depth-1 discovery against a fixture `CODEX_HOME`.
- `node --test tests/unit/tooling/architectureGuards.test.js` — 55/55 (fixture module list extended for `subagentSessions.ts`).
- `npm run test:behavior-contracts` — pass (10 blockers).
- `npm run test:ci:linux` — pass; changed-line coverage 92.71% (318/343) against origin/main.
- Real-data verification against `~/.codex` and a live app-server: 51 depth-1 subagent threads discovered for a real orchestration session (50 finished, 1 correctly failed), transcripts load through `thread/read` with the seeded dispatch interaction.
- Manual acceptance on a locally installed build.
