### PR TITLE
chore: release Agent Pivot 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,22 @@ All notable changes to the "Agent Pivot" extension will be documented in this fi
 
 ## [Unreleased]
 
+## [1.0.2] - 2026-08-03
+
 ### Added
 
+- AI Conversation viewers now list a session's subagents in a dedicated
+  Subagents tab for Kimi, Claude, and Codex sessions, with status badges,
+  running entries pinned to the top, a persisted Running only filter, and an
+  Agents quick-entry pill in the usage bar. Selecting a subagent reads its
+  transcript in place and a banner returns to the main conversation; nested
+  subagents stay visible inside their parent's transcript.
+- AI Conversation renders provider tool calls as collapsible entries
+  interleaved with the assistant output, in main sessions and subagent
+  transcripts alike: shell commands, file reads and edits, and searches pair
+  input with output under a one-line summary, so agent work stays auditable.
+- Kimi plan-mode updates now render inline in the AI Conversation assistant
+  stream.
 - The AI Conversation usage bar now covers Kimi and Claude sessions: Kimi
   reports context-window usage from its wire-protocol status updates, and
   Claude reports the current model and context-window usage from assistant
@@ -18,6 +32,11 @@ All notable changes to the "Agent Pivot" extension will be documented in this fi
 
 ### Changed
 
+- The focused window's workspace card and the focused session row now pick
+  up a subtle accent veil with a solid Current pill, so the active context
+  reads at a glance; attention state still wins with a red veil.
+- The Comments and Agents usage-bar pills now stay visible at zero count, so
+  the quick entries into the side panel are always available.
 - Clicking an already-focused Active Session now opens its AI Conversation at
   the latest input instead of expanding an inline outline; the inline
   conversation outline rail was removed in favor of the richer outline built

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "913d3a8d6318e51df74e5e2e1529bb5ba9959aef",
+        "head": "de9edffbf61d702fb616f2d21a44b39051338973",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -88,7 +88,8 @@
             "c215404072fd9c60af5aeb46fc964a8f83cc353d",
             "d443a6bbeed8aa85275efdcfe4c0ff5a6c600983",
             "4fb8eb73a88ee9ae76310018d61bdb9e58839e8e",
-            "8c6ea3c8b7396267a1c0e97273fed51cb5fdfdbc"
+            "8c6ea3c8b7396267a1c0e97273fed51cb5fdfdbc",
+            "b504adc63638c07528b835dcac9a45b6fe6a7127"
         ]
     },
     "capabilities": [
@@ -487,7 +488,8 @@
                 "0b1a72a4df82c1bfc595d63b52e85d2aacd753de",
                 "6a514e5499745fed0383e103cd302616d54ed67e",
                 "aa4652ce76238eefdbf73381da93f410e2db096d",
-                "af19b2c9fbab071d6e8004846bff1cdd810836bc"
+                "af19b2c9fbab071d6e8004846bff1cdd810836bc",
+                "de9edffbf61d702fb616f2d21a44b39051338973"
             ],
             "behaviors": [
                 "RELEASE-VSIX-PACKAGING-001",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "agent-pivot",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "agent-pivot",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "license": "MIT",
             "dependencies": {
                 "dom-autoscroller": "^2.3.4",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "agent-pivot",
     "displayName": "Agent Pivot",
     "description": "Switch, monitor, and resume Codex, Claude, and Kimi sessions across VS Code workspaces.",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "publisher": "hzcheng",
     "license": "MIT",
     "icon": "media/extension_icon.png",

--- a/scripts/lib/brandIdentity.js
+++ b/scripts/lib/brandIdentity.js
@@ -10,7 +10,7 @@ const BRAND_IDENTITY = Object.freeze({
     publisher: 'hzcheng',
     mainPackageName: 'agent-pivot',
     mainExtensionId: 'hzcheng.agent-pivot',
-    mainVersion: '1.0.1',
+    mainVersion: '1.0.2',
     bridgePackageName: 'agent-pivot-attention-ui-bridge',
     bridgeExtensionId: 'hzcheng.agent-pivot-attention-ui-bridge',
     commandPrefix: 'agentPivot.',

--- a/scripts/run-release-notes-checks.js
+++ b/scripts/run-release-notes-checks.js
@@ -14,19 +14,19 @@ const workflowPath = path.join(repositoryRoot, '.github', 'workflows', 'release-
 function validateReleaseContent({ readme, changelog, packageMetadata }) {
     assert.strictEqual(packageMetadata.displayName, 'Agent Pivot',
         'release metadata must use the Agent Pivot display name');
-    assert.strictEqual(packageMetadata.version, '1.0.1',
-        'the current Agent Pivot release must be version 1.0.1');
+    assert.strictEqual(packageMetadata.version, '1.0.2',
+        'the current Agent Pivot release must be version 1.0.2');
     const currentRelease = extractReleaseNotes(changelog, packageMetadata.version);
     const requiredReleaseFacts = [
-        ['AI Skills management', /AI Skills workspace/i],
-        ['rich AI Conversation review', /rich AI Conversation review workflow/i],
+        ['subagent viewing', /list a session's subagents/i],
+        ['collapsible tool calls', /tool calls as collapsible entries/i],
+        ['always-on quick entries', /stay visible at zero/i],
         ['conversation telemetry', /context-window usage/i],
-        ['other workspace pinning', /pinning.*other open workspace cards/i],
-        ['conversation reading stability', /reading position stable/i],
+        ['worktree chip', /worktree chip/i],
     ];
 
     for (const [label, pattern] of requiredReleaseFacts) {
-        assert.match(currentRelease, pattern, `1.0.1 CHANGELOG release must document ${label}`);
+        assert.match(currentRelease, pattern, `1.0.2 CHANGELOG release must document ${label}`);
     }
     assert.match(readme, /Agent Pivot/i, 'README must document the current product name');
     assert.match(packageMetadata.description, /workspace/i,

--- a/scripts/run-release-packaging-checks.js
+++ b/scripts/run-release-packaging-checks.js
@@ -390,7 +390,7 @@ function runRealVsixArchiveChecks(mainPackage, bridgePackage) {
     );
     assert.strictEqual(
         path.basename(mainArtifact),
-        'agent-pivot-1.0.1.vsix',
+        'agent-pivot-1.0.2.vsix',
         'main release artifact name must remain exact',
     );
     assert.strictEqual(

--- a/tests/unit/tooling/brandIdentity.test.js
+++ b/tests/unit/tooling/brandIdentity.test.js
@@ -50,7 +50,7 @@ function manifests() {
             name: 'agent-pivot',
             displayName: 'Agent Pivot',
             publisher: 'hzcheng',
-            version: '1.0.1',
+            version: '1.0.2',
             icon: 'media/extension_icon.png',
             repository: {
                 type: 'git',
@@ -294,7 +294,7 @@ test('brand identity exposes the exact approved public contract', () => {
         publisher: 'hzcheng',
         mainPackageName: 'agent-pivot',
         mainExtensionId: 'hzcheng.agent-pivot',
-        mainVersion: '1.0.1',
+        mainVersion: '1.0.2',
         bridgePackageName: 'agent-pivot-attention-ui-bridge',
         bridgeExtensionId: 'hzcheng.agent-pivot-attention-ui-bridge',
         commandPrefix: 'agentPivot.',

--- a/tests/unit/tooling/extensionHostLauncher.test.js
+++ b/tests/unit/tooling/extensionHostLauncher.test.js
@@ -149,7 +149,7 @@ test('RELEASE-SCHEDULED-EXTENSION-HOST-001 launches both extensions with pinned 
         ]);
         assert.deepEqual(packagePlan.map(item => path.basename(item.artifactPath)), [
             'agent-pivot-attention-ui-bridge-1.0.0.vsix',
-            'agent-pivot-1.0.1.vsix',
+            'agent-pivot-1.0.2.vsix',
         ]);
         assert.equal(options.extensionTestsPath,
             path.join(environment.testHarness, 'index.js'));

--- a/tests/unit/tooling/releaseNotes.test.js
+++ b/tests/unit/tooling/releaseNotes.test.js
@@ -14,14 +14,14 @@ test('release content validation cannot satisfy current facts from historical no
     const changelog = [
         '# Changelog',
         '',
-        '## [1.0.1] - 2026-07-31',
+        '## [1.0.2] - 2026-08-03',
         '',
-        '- Added a rich AI Conversation review workflow.',
+        '- AI Conversation renders provider tool calls as collapsible entries.',
         '- Added context-window usage telemetry.',
-        '- Added pinning for other open workspace cards.',
-        '- Kept the AI Conversation reading position stable.',
+        '- The usage bar shows a worktree chip.',
+        '- The quick-entry pills stay visible at zero count.',
         '',
-        '## [1.0.0] - 2026-07-26',
+        '## [1.0.1] - 2026-07-31',
         '',
         '- Added an AI Skills workspace.',
         '',
@@ -33,10 +33,10 @@ test('release content validation cannot satisfy current facts from historical no
             changelog,
             packageMetadata: {
                 displayName: 'Agent Pivot',
-                version: '1.0.1',
+                version: '1.0.2',
                 description: 'Workspace command center.',
             },
         }),
-        /1\.0\.1 CHANGELOG release must document AI Skills management/,
+        /1\.0\.2 CHANGELOG release must document subagent viewing/,
     );
 });


### PR DESCRIPTION
## Summary

Release Agent Pivot 1.0.2.

- Moves the accumulated Unreleased notes into `## [1.0.2] - 2026-08-03`, adding this batch's entries: subagent viewing for Kimi/Claude/Codex (#94, #95, #96) and collapsible conversation tool calls with always-on quick-entry pills (#97), plus the Kimi plan-mode rendering and accent-veil emphasis entries that were not yet logged.
- Bumps the version to 1.0.2 in `package.json`, `package-lock.json`, and `scripts/lib/brandIdentity.js`.
- Rewrites the release-notes contract to the 1.0.2 facts (subagent viewing, collapsible tool calls, always-on quick entries, telemetry, worktree chip) and points the packaging check at `agent-pivot-1.0.2.vsix`.

After merge, tag `v1.0.2` on the merge commit triggers the `release-vsix.yml` workflow, which packages the VSIX files and publishes the GitHub release with the extracted notes.

## Skill harvest

no skill change — the release mechanics followed the documented publish workflow without friction (recorded as the `Skill-Harvest: none` trailer of audit commit 576f44e).

## Verification

- `npm run test:release-notes` — pass.
- `node --test tests/unit/tooling/releaseNotes.test.js tests/unit/tooling/brandIdentity.test.js` — 16/16.
- `npm run test:release-packaging` — pass; produced `artifacts/agent-pivot-1.0.2.vsix` and the bridge VSIX.
- `npm run test:ci:linux` — pass.
