### PR TITLE
feat: report stale running subagents as quiet with relative last-activity times

### DIFF
--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "074d446d9082a5204b093d1fc2d08cbc36d27eef",
+        "head": "b13e4467eb8a0139325c0b2bc101a40d65ef5a29",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -91,7 +91,8 @@
             "8c6ea3c8b7396267a1c0e97273fed51cb5fdfdbc",
             "b504adc63638c07528b835dcac9a45b6fe6a7127",
             "7b4aa955d8211996d3ca8ce6f2e414cffc051c4f",
-            "074d446d9082a5204b093d1fc2d08cbc36d27eef"
+            "074d446d9082a5204b093d1fc2d08cbc36d27eef",
+            "199162a3a85a3455739664599bbf54786fb4ae72"
         ]
     },
     "capabilities": [
@@ -1114,7 +1115,8 @@
                 "34ba57c428cd9432737e4d77c15ec7694bfe4ebe",
                 "3ace01b5114ce4b2f91c1f7de6cda2c072d4a9a1",
                 "09b92ba14f12972fd719035b2d08c517a492c18f",
-                "913d3a8d6318e51df74e5e2e1529bb5ba9959aef"
+                "913d3a8d6318e51df74e5e2e1529bb5ba9959aef",
+                "b13e4467eb8a0139325c0b2bc101a40d65ef5a29"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",

--- a/media/conversationSubagentsScripts.js
+++ b/media/conversationSubagentsScripts.js
@@ -4,6 +4,7 @@
     var STATUS_LABELS = {
         running: 'Running',
         idle: 'Finished',
+        quiet: 'Quiet',
         failed: 'Failed',
         killed: 'Stopped',
     };
@@ -16,6 +17,17 @@
         if (!Number.isFinite(timestamp)) return '';
         try {
             var date = new Date(timestamp);
+            var now = Date.now();
+            var elapsedMs = now - timestamp;
+            if (elapsedMs >= 0 && elapsedMs < 60 * 1000) {
+                return 'just now';
+            }
+            if (elapsedMs >= 0 && elapsedMs < 60 * 60 * 1000) {
+                return Math.floor(elapsedMs / 60000) + 'm ago';
+            }
+            if (elapsedMs >= 0 && elapsedMs < 24 * 60 * 60 * 1000) {
+                return Math.floor(elapsedMs / 3600000) + 'h ago';
+            }
             var today = new Date();
             var sameDay = date.toDateString() === today.toDateString();
             return sameDay
@@ -48,13 +60,19 @@
         function visibleEntries() {
             var entries = runningOnly.checked
                 ? lastSubagents.filter(function (entry) {
-                    return entry.status === 'running';
+                    return entry.status === 'running'
+                        || entry.status === 'quiet';
                 })
                 : lastSubagents.slice();
-            // Running entries pin to the top; the rest keep dispatch order.
+            // Live-ish entries pin to the top: running first, then quiet;
+            // the rest keep dispatch order.
+            var rank = function (entry) {
+                return entry.status === 'running'
+                    ? 0
+                    : entry.status === 'quiet' ? 1 : 2;
+            };
             return entries.slice().sort(function (left, right) {
-                return (left.status === 'running' ? 0 : 1)
-                    - (right.status === 'running' ? 0 : 1);
+                return rank(left) - rank(right);
             });
         }
 

--- a/media/conversationViewerScripts.js
+++ b/media/conversationViewerScripts.js
@@ -503,7 +503,8 @@
             && (value.agentType === undefined
                 || typeof value.agentType === 'string')
             && (value.status === 'running' || value.status === 'idle'
-                || value.status === 'failed' || value.status === 'killed')
+                || value.status === 'quiet' || value.status === 'failed'
+                || value.status === 'killed')
             && (value.createdAt === undefined
                 || (Number.isSafeInteger(value.createdAt)
                     && value.createdAt >= 0))

--- a/src/aiSessions/conversation/claudeAdapter.ts
+++ b/src/aiSessions/conversation/claudeAdapter.ts
@@ -833,11 +833,12 @@ function subagentStatus(
         return 'idle';
     }
     // Claude records no status on disk: a mid-turn tail record only proves
-    // liveness while the transcript is freshly written; a crashed CLI
-    // leaves a stale mid-turn transcript behind.
+    // liveness while the transcript is freshly written. A stale mid-turn
+    // transcript means a crash OR a long quiet command — report quiet, not
+    // failed, without positive death evidence.
     return now - transcriptMtimeMs <= SUBAGENT_RUNNING_FRESHNESS_MS
         ? 'running'
-        : 'failed';
+        : 'quiet';
 }
 
 async function readSubagentCreatedAt(

--- a/src/aiSessions/conversation/codexAdapter.ts
+++ b/src/aiSessions/conversation/codexAdapter.ts
@@ -839,8 +839,10 @@ function subagentStatus(
         return 'idle';
     }
     // A crashed CLI leaves a stale transcript without task_complete
-    // behind; only a freshly written rollout proves the subagent is alive.
+    // behind, but so does a long quiet command: only a freshly written
+    // rollout proves the subagent is alive; staleness alone is not death
+    // evidence, so report quiet rather than failed.
     return now - transcriptMtimeMs <= SUBAGENT_RUNNING_FRESHNESS_MS
         ? 'running'
-        : 'failed';
+        : 'quiet';
 }

--- a/src/aiSessions/conversation/kimiAdapter.ts
+++ b/src/aiSessions/conversation/kimiAdapter.ts
@@ -762,11 +762,12 @@ function subagentStatus(
     }
     if (rawStatus === 'running_foreground'
         || rawStatus === 'running_background') {
-        // A crashed CLI never resets meta.json: only a freshly written wire
-        // proves the subagent is actually alive.
+        // A crashed CLI never resets meta.json, and a long quiet command
+        // looks identical to a crash: only a freshly written wire proves
+        // the subagent is alive; staleness alone is not death evidence.
         return now - wireMtimeMs <= SUBAGENT_RUNNING_FRESHNESS_MS
             ? 'running'
-            : 'failed';
+            : 'quiet';
     }
     return 'idle';
 }

--- a/src/aiSessions/conversation/types.ts
+++ b/src/aiSessions/conversation/types.ts
@@ -233,7 +233,7 @@ export interface ConversationSubagentEntry {
     id: string;
     label: string;
     agentType?: string;
-    status: 'running' | 'idle' | 'failed' | 'killed';
+    status: 'running' | 'idle' | 'quiet' | 'failed' | 'killed';
     createdAt?: number;
     updatedAt?: number;
 }

--- a/src/webview/conversationSubagentsScripts.js
+++ b/src/webview/conversationSubagentsScripts.js
@@ -4,6 +4,7 @@
     var STATUS_LABELS = {
         running: 'Running',
         idle: 'Finished',
+        quiet: 'Quiet',
         failed: 'Failed',
         killed: 'Stopped',
     };
@@ -16,6 +17,17 @@
         if (!Number.isFinite(timestamp)) return '';
         try {
             var date = new Date(timestamp);
+            var now = Date.now();
+            var elapsedMs = now - timestamp;
+            if (elapsedMs >= 0 && elapsedMs < 60 * 1000) {
+                return 'just now';
+            }
+            if (elapsedMs >= 0 && elapsedMs < 60 * 60 * 1000) {
+                return Math.floor(elapsedMs / 60000) + 'm ago';
+            }
+            if (elapsedMs >= 0 && elapsedMs < 24 * 60 * 60 * 1000) {
+                return Math.floor(elapsedMs / 3600000) + 'h ago';
+            }
             var today = new Date();
             var sameDay = date.toDateString() === today.toDateString();
             return sameDay
@@ -48,13 +60,19 @@
         function visibleEntries() {
             var entries = runningOnly.checked
                 ? lastSubagents.filter(function (entry) {
-                    return entry.status === 'running';
+                    return entry.status === 'running'
+                        || entry.status === 'quiet';
                 })
                 : lastSubagents.slice();
-            // Running entries pin to the top; the rest keep dispatch order.
+            // Live-ish entries pin to the top: running first, then quiet;
+            // the rest keep dispatch order.
+            var rank = function (entry) {
+                return entry.status === 'running'
+                    ? 0
+                    : entry.status === 'quiet' ? 1 : 2;
+            };
             return entries.slice().sort(function (left, right) {
-                return (left.status === 'running' ? 0 : 1)
-                    - (right.status === 'running' ? 0 : 1);
+                return rank(left) - rank(right);
             });
         }
 

--- a/src/webview/conversationViewerScripts.js
+++ b/src/webview/conversationViewerScripts.js
@@ -503,7 +503,8 @@
             && (value.agentType === undefined
                 || typeof value.agentType === 'string')
             && (value.status === 'running' || value.status === 'idle'
-                || value.status === 'failed' || value.status === 'killed')
+                || value.status === 'quiet' || value.status === 'failed'
+                || value.status === 'killed')
             && (value.createdAt === undefined
                 || (Number.isSafeInteger(value.createdAt)
                     && value.createdAt >= 0))

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -4092,19 +4092,19 @@ test('WEBVIEW-AI-SESSION-SUBAGENT-VIEWER-001 pins running subagents above finish
                 id: 'a11111111',
                 label: 'Finished first',
                 status: 'idle',
-                updatedAt: 1,
+                updatedAt: Date.now() - 3 * 24 * 60 * 60 * 1000,
             },
             {
                 id: 'a22222222',
-                label: 'Finished second',
-                status: 'idle',
-                updatedAt: 2,
+                label: 'Quiet worker',
+                status: 'quiet',
+                updatedAt: Date.now() - 12 * 60 * 1000,
             },
             {
                 id: 'a33333333',
                 label: 'Still running',
                 status: 'running',
-                updatedAt: 3,
+                updatedAt: Date.now() - 3 * 60 * 1000,
             },
         ],
         activeSubagent: null,
@@ -4116,5 +4116,25 @@ test('WEBVIEW-AI-SESSION-SUBAGENT-VIEWER-001 pins running subagents above finish
         elements => elements.map(element =>
             element.getAttribute('data-subagent-id'))
     );
-    assert.deepEqual(ids, ['a33333333', 'a11111111', 'a22222222']);
+    assert.deepEqual(ids, ['a33333333', 'a22222222', 'a11111111']);
+    assert.equal(
+        await page.locator('[data-subagent-id="a22222222"] .conversation-subagent-status').innerText(),
+        'Quiet'
+    );
+    assert.equal(
+        await page.locator('[data-subagent-id="a33333333"] .conversation-subagent-time').innerText(),
+        '3m ago'
+    );
+    assert.equal(
+        await page.locator('[data-subagent-id="a22222222"] .conversation-subagent-time').innerText(),
+        '12m ago'
+    );
+
+    // The Running only filter keeps quiet (not-finished) entries visible.
+    await page.locator('[data-subagents-running-only]').check();
+    const filteredIds = await page.locator('[data-subagent-id]').evaluateAll(
+        elements => elements.map(element =>
+            element.getAttribute('data-subagent-id'))
+    );
+    assert.deepEqual(filteredIds, ['a33333333', 'a22222222']);
 });

--- a/tests/contract/aiSessions/claudeConversationAdapter.test.js
+++ b/tests/contract/aiSessions/claudeConversationAdapter.test.js
@@ -897,7 +897,7 @@ test('WEBVIEW-AI-SESSION-SUBAGENT-VIEWER-001 Claude lists depth-1 subagents with
     assert.deepEqual(
         entries.map(entry => [entry.id, entry.status, entry.agentType]),
         [
-            ['a33333333', 'failed', undefined],
+            ['a33333333', 'quiet', undefined],
             ['a22222222', 'running', 'general-purpose'],
             ['a11111111', 'idle', 'Explore'],
             ['a55555555', 'idle', undefined],

--- a/tests/contract/aiSessions/codexConversationAdapter.test.js
+++ b/tests/contract/aiSessions/codexConversationAdapter.test.js
@@ -685,7 +685,7 @@ test('WEBVIEW-AI-SESSION-SUBAGENT-VIEWER-001 Codex lists depth-1 subagent thread
     assert.deepEqual(
         entries.map(entry => [entry.id, entry.status, entry.agentType]),
         [
-            [thirdChildThreadId, 'failed', undefined],
+            [thirdChildThreadId, 'quiet', undefined],
             [otherChildThreadId, 'running', 'review_fix_loop'],
             [childThreadId, 'idle', 'implement_webview_mutation_skill'],
         ]

--- a/tests/contract/aiSessions/kimiConversationAdapter.test.js
+++ b/tests/contract/aiSessions/kimiConversationAdapter.test.js
@@ -400,7 +400,7 @@ test('WEBVIEW-AI-SESSION-SUBAGENT-VIEWER-001 Kimi lists subagents with mapped st
         entries.map(entry => [entry.id, entry.status, entry.agentType]),
         [
             ['a33333333', 'killed', undefined],
-            ['a22222222', 'failed', 'coder'],
+            ['a22222222', 'quiet', 'coder'],
             ['a11111111', 'running', 'explore'],
         ]
     );


### PR DESCRIPTION
## Summary

Stop reporting alive-but-silent subagents as failures. A subagent that has not finished and whose transcript has not been written for more than 5 minutes now shows a new **Quiet** status instead of **Failed** — a long quiet command (large build, big test run) is indistinguishable from a crash on disk, so staleness alone is no longer treated as death evidence. `Failed`/`Stopped` now appear only on explicit provider evidence (Kimi `meta.json` status).

- New `'quiet'` status across the shared entry type and all three adapters (Kimi `running_*` + stale, Claude mid-turn tail + stale, Codex missing `task_complete` + stale), with the webview badge label "Quiet".
- List ordering pins live-ish entries: Running → Quiet → everything else (dispatch order preserved within groups). The **Running only** filter keeps Quiet entries visible (both are not-finished); the `Agents r/t` pill counts only freshly-running entries so long-dead quiet rows never inflate it.
- Last-activity times are now relative: `just now`, `Xm ago`, `Xh ago` under 24h, absolute date beyond — staleness is readable at a glance.

## Skill harvest

no skill change — the implementation and verification ran clean with no workflow friction (recorded as the `Skill-Harvest: none` trailer of audit commit b6f3845).

## Verification

- Focused: three adapter contract suites 59/59 (stale fixtures now expect `quiet`), integration 32/32, browser 44/44 (quiet badge, running→quiet→other ordering, filter behavior, relative time rendering).
- `npm run test:behavior-contracts` — pass (10 blockers).
- `npm run test:ci:linux` — pass; changed-line coverage 100% (13/13) against origin/main.
- Real-data verification against `~/.codex`: the weeks-old unfinished subagent previously reported as Failed now reports Quiet.
