### PR TITLE
refactor: extract the TODO renderer out of webviewTodoScripts.js

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -42,6 +42,7 @@ media/brand/**
 !media/webviewDashboardValidationScripts.js
 !media/webviewDashboardSearchScripts.js
 !media/webviewPromptScripts.js
+!media/webviewTodoRenderScripts.js
 !media/webviewTodoScripts.js
 !media/conversationMermaidScripts.js
 !media/conversationReadingAnchorScripts.js

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "6ac51dfaaa47830413615bc260b6c39840c8dd96",
+        "head": "50149e75f12f8b886e074ec3edea164697ecc5e8",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -568,7 +568,8 @@
                 "6ef7ba4a0d078b6558ff16d99ed4ce13fd8a0cf4",
                 "905cdcd5c94a781e63764fb8d2eb766578601ddc",
                 "a368f0ae82b18db920de3530809f720a2fc32664",
-                "4c542b0ef8a20178800078181b129987f5aefb7b"
+                "4c542b0ef8a20178800078181b129987f5aefb7b",
+                "50149e75f12f8b886e074ec3edea164697ecc5e8"
             ],
             "behaviors": [
                 "TODO-COMPLETION-INCREMENTAL-001",

--- a/media/webviewTodoRenderScripts.js
+++ b/media/webviewTodoRenderScripts.js
@@ -1,0 +1,345 @@
+function escapeHtml(value) {
+    return String(value == null ? '' : value)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
+function clone(value) {
+    return value == null ? value : JSON.parse(JSON.stringify(value));
+}
+
+function isSnapshot(value) {
+    return !!value
+        && value.version === 1
+        && value.data
+        && value.data.version === 1
+        && Array.isArray(value.data.groups)
+        && Array.isArray(value.data.todos)
+        && typeof value.showCompleted === 'boolean';
+}
+
+function renderTodoCommandIcon(kind) {
+    if (kind === 'add') {
+        return '<svg viewBox="0 0 512 512"><path d="M416 208H272V64c0-17.67-14.33-32-32-32h-32'
+            + 'c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32'
+            + 'h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33'
+            + ' 32-32v-32c0-17.67-14.33-32-32-32z"></path></svg>';
+    }
+    if (kind === 'group') {
+        return '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" '
+            + 'stroke-linecap="round" stroke-linejoin="round"><path d="m3.5 6 1.5 1.5L7.5 5"></path>'
+            + '<path d="m3.5 12 1.5 1.5 2.5-2.5"></path><path d="m3.5 18 1.5 1.5L7.5 17"></path>'
+            + '<path d="M10.5 6.5h10M10.5 12.5h10M10.5 18.5h10"></path></svg>';
+    }
+    return '<svg viewBox="0 0 448 512"><path d="M64 32C28.7 32 0 60.7 0 96v320c0 35.3 28.7'
+        + ' 64 64 64h320c35.3 0 64-28.7 64-64V96c0-35.3-28.7-64-64-64H64zm88 200h144c13.3 0'
+        + ' 24 10.7 24 24s-10.7 24-24 24H152c-13.3 0-24-10.7-24-24s10.7-24 24-24z"></path></svg>';
+}
+
+function renderGroupChevron() {
+    return '<span class="todo-group-chevron collapse-icon" aria-hidden="true">'
+        + '<svg viewBox="0 0 320 512"><path d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 '
+        + '0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 '
+        + '24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 '
+        + '9.4-24.4 9.4-33.8 0z"></path></svg></span>';
+}
+
+function createTodoRenderer(options) {
+    'use strict';
+
+    options = options || {};
+    var state = options.state;
+
+    function orderedGroups() {
+        return state.snapshot.data.groups.slice().sort(function (left, right) {
+            return left.order - right.order;
+        });
+    }
+
+    function orderedTodos(groupId) {
+        var todos = state.snapshot.data.todos
+            .filter(function (todo) { return todo.groupId === groupId; })
+            .sort(function (left, right) { return left.order - right.order; });
+        var incomplete = todos.filter(function (todo) { return !todo.completed; });
+        var completed = todos.filter(function (todo) { return todo.completed; });
+        var visibleCompleted = state.snapshot.showCompleted
+            ? completed
+            : completed.filter(function (todo) {
+                return todo.id === state.snapshot.revealedTodoId;
+            });
+        return incomplete.concat(visibleCompleted);
+    }
+
+    function findTodo(todoId) {
+        return state.snapshot && state.snapshot.data.todos.find(function (todo) {
+            return todo.id === todoId;
+        });
+    }
+
+    function findGroup(groupId) {
+        return state.snapshot && state.snapshot.data.groups.find(function (group) {
+            return group.id === groupId;
+        });
+    }
+
+    function renderPriorityOptions(selected) {
+        return ['high', 'medium', 'low'].map(function (priority) {
+            return '<option value="' + priority + '"' + (priority === selected ? ' selected' : '') + '>'
+                + priority.toUpperCase() + '</option>';
+        }).join('');
+    }
+
+    function renderGroupOptions(selected) {
+        return '<option value=""' + (!selected ? ' selected' : '') + '>Inbox</option>'
+            + orderedGroups().map(function (group) {
+            return '<option value="' + escapeHtml(group.id) + '"'
+                + (group.id === selected ? ' selected' : '') + '>'
+                + escapeHtml(group.title) + '</option>';
+        }).join('');
+    }
+
+    function todoClassName(todo) {
+        return 'todo-item steward-item-card todo-priority-' + escapeHtml(todo.priority)
+            + (todo.completed ? ' completed' : '')
+            + (state.selectedTodoId === todo.id ? ' expanded' : '');
+    }
+
+    function renderTodoBody(todo) {
+        var checked = todo.completed ? ' checked' : '';
+        var expanded = state.selectedTodoId === todo.id;
+        var priorityBadge = todo.priority === 'medium'
+            ? ''
+            : '<span class="todo-priority-badge steward-badge">'
+                + escapeHtml(todo.priority.toUpperCase()) + '</span>';
+        return '<span class="todo-item-accent steward-item-accent" aria-hidden="true"></span>'
+            + '<div class="todo-item-view"><div class="todo-item-main">'
+            + '<label class="todo-check"><input type="checkbox" data-action="todo-toggle" data-todo-id="'
+            + escapeHtml(todo.id) + '" aria-label="Complete ' + escapeHtml(todo.title) + '"' + checked + '>'
+            + '<span class="todo-checkbox-visual"></span></label>'
+            + '<div class="todo-item-content"><div class="todo-title-line">'
+            + '<button class="todo-title-button" type="button" data-action="todo-open-detail" data-todo-id="'
+            + escapeHtml(todo.id) + '" aria-expanded="' + (expanded ? 'true' : 'false') + '" title="'
+            + (expanded ? 'Collapse details' : 'Expand details') + '"><span class="todo-title-text">'
+            + escapeHtml(todo.title) + '</span></button>' + priorityBadge + '</div></div>'
+            + '<div class="todo-item-actions">'
+            + '<button class="todo-icon-button steward-icon-button danger" type="button" data-action="todo-delete" '
+            + 'data-todo-id="' + escapeHtml(todo.id) + '" title="Delete todo" aria-label="Delete todo">×</button>'
+            + '<button class="todo-drag-handle todo-icon-button steward-icon-button" type="button" draggable="true" '
+            + 'data-drag-todo-item="' + escapeHtml(todo.id) + '" title="Drag to reorder" aria-label="Drag '
+            + escapeHtml(todo.title) + '">⋮⋮</button></div>'
+            + '</div>' + (expanded ? renderInlineDetail(todo) : '') + '</div>';
+    }
+
+    function renderTodo(todo) {
+        return '<li class="' + todoClassName(todo) + '" data-todo-id="' + escapeHtml(todo.id) + '">'
+            + renderTodoBody(todo) + '</li>';
+    }
+
+    function renderCompose(group) {
+        var groupId = group ? group.id : null;
+        var visible = state.composeGroupId === groupId;
+        var draft = visible && state.composeDraft
+            ? state.composeDraft
+            : { title: '', notes: '', priority: 'medium', groupId: groupId };
+        var groupControl = group
+            ? '<input type="hidden" name="groupId" value="' + escapeHtml(group.id) + '">'
+                + '<span class="todo-compose-group-fixed steward-meta" title="' + escapeHtml(group.title)
+                + '" aria-label="Todo group: ' + escapeHtml(group.title) + '">' + escapeHtml(group.title) + '</span>'
+            : '<select name="groupId" aria-label="Todo group">'
+                + renderGroupOptions(draft.groupId) + '</select>';
+        return '<form class="todo-add-form todo-compose-panel steward-card" data-todo-form="'
+            + (group ? 'quick-add' : 'add') + '"'
+            + (group ? ' data-group-id="' + escapeHtml(group.id) + '"' : '')
+            + (visible ? '' : ' hidden') + '>'
+            + '<div class="todo-compose-primary"><span class="todo-compose-icon">＋</span>'
+            + '<input class="todo-title-input" type="text" name="title" placeholder="'
+            + (group ? 'Add to ' + escapeHtml(group.title) : 'Add a todo') + '" aria-label="Todo title" value="'
+            + escapeHtml(draft.title) + '">'
+            + '</div><textarea class="todo-notes-input" name="notes" rows="2" placeholder="Notes" '
+            + 'aria-label="Todo notes">' + escapeHtml(draft.notes)
+            + '</textarea><div class="todo-form-row todo-compose-meta">'
+            + '<select name="priority" aria-label="Todo priority">'
+            + renderPriorityOptions(draft.priority) + '</select>'
+            + groupControl
+            + '<button class="todo-primary-button steward-button steward-button-primary" type="submit">Add</button>'
+            + '<button class="todo-secondary-button steward-button" type="button" data-action="'
+            + (group ? 'todo-cancel-quick-add' : 'todo-cancel-add') + '">Cancel</button></div></form>';
+    }
+
+    function getGroupStats(groupId) {
+        var todos = state.snapshot.data.todos.filter(function (todo) {
+            return todo.groupId === groupId;
+        });
+        var incompleteCount = todos.filter(function (todo) { return !todo.completed; }).length;
+        var completedCount = todos.length - incompleteCount;
+        var visibleCompletedCount = orderedTodos(groupId)
+            .filter(function (todo) { return todo.completed; }).length;
+        return {
+            incompleteCount: incompleteCount,
+            completedCount: completedCount,
+            hiddenCompletedCount: completedCount - visibleCompletedCount,
+        };
+    }
+
+    function todoGroupMeta(groupId) {
+        var stats = getGroupStats(groupId);
+        return stats.incompleteCount + ' open'
+            + (state.snapshot.showCompleted && stats.completedCount
+                ? ' · ' + stats.completedCount + ' done'
+                : '');
+    }
+
+    function todoSummaryMeta() {
+        var todos = state.snapshot.data.todos;
+        var incomplete = todos.filter(function (todo) { return !todo.completed; }).length;
+        var completed = todos.length - incomplete;
+        var groupCount = orderedGroups().length;
+        return incomplete + ' open · ' + groupCount + (groupCount === 1 ? ' group' : ' groups')
+            + ' · ' + (state.snapshot.showCompleted ? completed + ' completed shown' : 'completed hidden');
+    }
+
+    function renderGroup(group) {
+        var visibleTodos = orderedTodos(group.id);
+        var stats = getGroupStats(group.id);
+        return '<section class="todo-group group steward-section' + (group.collapsed ? ' collapsed' : '')
+            + '" data-todo-group-id="' + escapeHtml(group.id) + '">'
+            + '<header class="todo-group-header group-title steward-group-header">'
+            + '<div class="todo-group-title-block group-title-text">'
+            + '<button class="todo-group-collapse-button" type="button" data-action="todo-collapse-group" '
+            + 'data-todo-group-id="' + escapeHtml(group.id) + '" aria-expanded="'
+            + (group.collapsed ? 'false' : 'true') + '" aria-label="'
+            + (group.collapsed ? 'Expand ' : 'Collapse ') + escapeHtml(group.title) + '">'
+            + renderGroupChevron() + '</button>'
+            + '<h2 data-drag-todo-group title="' + escapeHtml(group.title) + '">' + escapeHtml(group.title) + '</h2>'
+            + '<span class="todo-group-count">' + todoGroupMeta(group.id) + '</span></div>'
+            + '<div class="todo-group-actions group-actions right">'
+            + '<button class="todo-group-action" type="button" data-action="todo-quick-add" data-group-id="'
+            + escapeHtml(group.id) + '" title="Add todo to group" aria-label="Add todo to '
+            + escapeHtml(group.title) + '">＋</button>'
+            + '<button class="todo-group-action" type="button" data-action="todo-sort-priority" data-group-id="'
+            + escapeHtml(group.id) + '" title="Sort by priority" aria-label="Sort by priority">⇅</button>'
+            + '<button class="todo-group-action" type="button" data-action="todo-rename-group" data-group-id="'
+            + escapeHtml(group.id) + '" title="Rename todo group" aria-label="Rename todo group">✎</button>'
+            + '<button class="todo-group-action danger" type="button" data-action="todo-delete-group" data-group-id="'
+            + escapeHtml(group.id) + '" title="Delete todo group" aria-label="Delete todo group">×</button>'
+            + '</div></header>' + renderCompose(group)
+            + (visibleTodos.length
+                ? '<ul class="todo-list">' + visibleTodos.map(renderTodo).join('') + '</ul>'
+                : '<p class="todo-group-empty">No visible todos</p>')
+            + (stats.hiddenCompletedCount > 0
+                ? '<p class="todo-hidden-completed">' + stats.hiddenCompletedCount + ' completed hidden</p>'
+                : '')
+            + '</section>';
+    }
+
+    function renderGlobalCompose() {
+        return renderCompose(null);
+    }
+
+    function renderListSurface() {
+        var groups = orderedGroups();
+        return '<div class="todo-list-surface">'
+            + '<header class="todo-page-header todo-page-command-bar">'
+            + '<div class="todo-summary-copy"><strong>TODO</strong>'
+            + '<span class="todo-summary-meta steward-meta">' + todoSummaryMeta() + '</span></div>'
+            + '<div class="todo-summary-actions group-actions right">'
+            + '<button class="todo-square-button steward-icon-button" type="button" data-action="todo-add" '
+            + 'title="Add todo" aria-label="Add todo">' + renderTodoCommandIcon('add') + '</button>'
+            + '<button class="todo-square-button steward-icon-button" type="button" data-action="todo-add-group" '
+            + 'title="Add group" aria-label="Add group">' + renderTodoCommandIcon('group') + '</button>'
+            + '<label class="todo-square-toggle steward-icon-button'
+            + (state.snapshot.showCompleted ? ' active' : '') + '" title="Show completed" aria-label="Show completed">'
+            + '<input type="checkbox" data-action="todo-toggle-show-completed"'
+            + (state.snapshot.showCompleted ? ' checked' : '') + '><span>'
+            + renderTodoCommandIcon('completed') + '</span></label>'
+            + '</div></header>' + renderGlobalCompose()
+            + (groups.length
+                ? '<div class="todo-groups">' + groups.map(renderGroup).join('') + '</div>'
+                : '<p class="todo-empty-state steward-empty-state">No todos yet</p>')
+            + '</div>';
+    }
+
+    function detailDraft(todo) {
+        return state.draft || {
+            title: todo.title,
+            notes: todo.notes || '',
+            priority: todo.priority,
+            groupId: todo.groupId,
+        };
+    }
+
+    function renderInlineDetail(todo) {
+        var group = findGroup(todo.groupId);
+        var groupName = group ? group.title : 'Unknown group';
+        if (state.draft) {
+            var draft = detailDraft(todo);
+            return '<form class="todo-inline-detail todo-detail-edit-form" data-todo-form="detail-edit" '
+                + 'aria-label="Edit ' + escapeHtml(todo.title) + '" '
+                + 'data-todo-id="' + escapeHtml(todo.id) + '">'
+                + '<label class="todo-field-label">Title</label>'
+                + '<textarea class="todo-title-input" name="title" rows="3" aria-label="Todo title">'
+                + escapeHtml(draft.title) + '</textarea>'
+                + '<label class="todo-field-label">Notes</label>'
+                + '<textarea class="todo-notes-input" name="notes" rows="8" aria-label="Todo notes">'
+                + escapeHtml(draft.notes) + '</textarea>'
+                + '<label class="todo-field-label">Priority</label><select name="priority" aria-label="Todo priority">'
+                + renderPriorityOptions(draft.priority) + '</select>'
+                + '<label class="todo-field-label">Group</label><select name="groupId" aria-label="Todo group">'
+                + renderGroupOptions(draft.groupId) + '</select>'
+                + '<div class="todo-detail-actions"><button class="todo-primary-button steward-button '
+                + 'steward-button-primary" type="submit">Save</button>'
+                + '<button class="todo-secondary-button steward-button" type="button" '
+                + 'data-action="todo-cancel-detail-edit">Cancel</button></div></form>';
+        }
+        return '<section class="todo-inline-detail" role="region" aria-label="Details for '
+            + escapeHtml(todo.title) + '">'
+            + '<div class="todo-inline-row"><span class="todo-inline-label">Notes</span>'
+            + '<p class="todo-inline-value todo-detail-notes">' + escapeHtml(todo.notes || 'No notes') + '</p></div>'
+            + '<div class="todo-inline-row"><span class="todo-inline-label">Group</span>'
+            + '<span class="todo-inline-value">' + escapeHtml(groupName) + '</span></div>'
+            + '<div class="todo-inline-row"><span class="todo-inline-label">Priority</span>'
+            + '<span class="todo-inline-value">' + escapeHtml(todo.priority.toUpperCase()) + '</span></div>'
+            + '<div class="todo-inline-row"><span class="todo-inline-label">Created</span>'
+            + '<span class="todo-inline-value">' + escapeHtml(String(todo.createdAt || '').slice(0, 10)) + '</span></div>'
+            + '<div class="todo-inline-row"><span class="todo-inline-label">Updated</span>'
+            + '<span class="todo-inline-value">' + escapeHtml(String(todo.updatedAt || '').slice(0, 10)) + '</span></div>'
+            + (todo.completedAt
+                ? '<div class="todo-inline-row"><span class="todo-inline-label">Completed</span>'
+                    + '<span class="todo-inline-value">'
+                    + escapeHtml(String(todo.completedAt).slice(0, 10)) + '</span></div>'
+                : '')
+            + '<div class="todo-detail-actions">'
+            + '<button class="todo-primary-button steward-button" type="button" data-action="todo-toggle-detail" '
+            + 'data-todo-id="' + escapeHtml(todo.id) + '">' + (todo.completed ? 'Reopen' : 'Complete') + '</button>'
+            + '<button class="todo-secondary-button steward-button" type="button" data-action="todo-edit-detail">Edit</button>'
+            + '<button class="todo-secondary-button steward-button danger" type="button" data-action="todo-delete" '
+            + 'data-todo-id="' + escapeHtml(todo.id) + '">Delete</button>'
+            + '</div></section>';
+    }
+
+    function renderUndo() {
+        if (!state.undo) {
+            return '<div class="todo-undo-region" role="status" aria-live="polite" hidden></div>';
+        }
+        return '<div class="todo-undo-region" role="status" aria-live="polite" style="display:flex">'
+            + '<span>' + escapeHtml(state.undo.label) + '</span>'
+            + '<button class="todo-primary-button steward-button" type="button" data-action="todo-undo">Undo</button></div>';
+    }
+
+    return {
+        orderedTodos: orderedTodos,
+        findTodo: findTodo,
+        findGroup: findGroup,
+        renderTodoBody: renderTodoBody,
+        todoClassName: todoClassName,
+        getGroupStats: getGroupStats,
+        todoGroupMeta: todoGroupMeta,
+        todoSummaryMeta: todoSummaryMeta,
+        renderListSurface: renderListSurface,
+        renderUndo: renderUndo,
+        detailDraft: detailDraft,
+    };
+}

--- a/media/webviewTodoScripts.js
+++ b/media/webviewTodoScripts.js
@@ -21,23 +21,13 @@ function initTodos(options) {
         announcement: '',
         renderedSurfaceHtml: '',
     };
+    var renderer = createTodoRenderer({ state: state });
     var panelHost = null;
     var root = null;
     var layoutObserver = null;
     var skipNextTodoLayoutObserverSync = false;
 
-    function escapeHtml(value) {
-        return String(value == null ? '' : value)
-            .replace(/&/g, '&amp;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;')
-            .replace(/"/g, '&quot;')
-            .replace(/'/g, '&#39;');
-    }
 
-    function clone(value) {
-        return value == null ? value : JSON.parse(JSON.stringify(value));
-    }
 
     function clearCompose() {
         state.composeGroupId = undefined;
@@ -45,317 +35,27 @@ function initTodos(options) {
         state.composeRequestId = null;
     }
 
-    function isSnapshot(value) {
-        return !!value
-            && value.version === 1
-            && value.data
-            && value.data.version === 1
-            && Array.isArray(value.data.groups)
-            && Array.isArray(value.data.todos)
-            && typeof value.showCompleted === 'boolean';
-    }
 
-    function orderedGroups() {
-        return state.snapshot.data.groups.slice().sort(function (left, right) {
-            return left.order - right.order;
-        });
-    }
 
-    function orderedTodos(groupId) {
-        var todos = state.snapshot.data.todos
-            .filter(function (todo) { return todo.groupId === groupId; })
-            .sort(function (left, right) { return left.order - right.order; });
-        var incomplete = todos.filter(function (todo) { return !todo.completed; });
-        var completed = todos.filter(function (todo) { return todo.completed; });
-        var visibleCompleted = state.snapshot.showCompleted
-            ? completed
-            : completed.filter(function (todo) {
-                return todo.id === state.snapshot.revealedTodoId;
-            });
-        return incomplete.concat(visibleCompleted);
-    }
 
-    function findTodo(todoId) {
-        return state.snapshot && state.snapshot.data.todos.find(function (todo) {
-            return todo.id === todoId;
-        });
-    }
 
-    function findGroup(groupId) {
-        return state.snapshot && state.snapshot.data.groups.find(function (group) {
-            return group.id === groupId;
-        });
-    }
 
-    function renderPriorityOptions(selected) {
-        return ['high', 'medium', 'low'].map(function (priority) {
-            return '<option value="' + priority + '"' + (priority === selected ? ' selected' : '') + '>'
-                + priority.toUpperCase() + '</option>';
-        }).join('');
-    }
 
-    function renderGroupOptions(selected) {
-        return '<option value=""' + (!selected ? ' selected' : '') + '>Inbox</option>'
-            + orderedGroups().map(function (group) {
-            return '<option value="' + escapeHtml(group.id) + '"'
-                + (group.id === selected ? ' selected' : '') + '>'
-                + escapeHtml(group.title) + '</option>';
-        }).join('');
-    }
 
-    function todoClassName(todo) {
-        return 'todo-item steward-item-card todo-priority-' + escapeHtml(todo.priority)
-            + (todo.completed ? ' completed' : '')
-            + (state.selectedTodoId === todo.id ? ' expanded' : '');
-    }
 
-    function renderTodoBody(todo) {
-        var checked = todo.completed ? ' checked' : '';
-        var expanded = state.selectedTodoId === todo.id;
-        var priorityBadge = todo.priority === 'medium'
-            ? ''
-            : '<span class="todo-priority-badge steward-badge">'
-                + escapeHtml(todo.priority.toUpperCase()) + '</span>';
-        return '<span class="todo-item-accent steward-item-accent" aria-hidden="true"></span>'
-            + '<div class="todo-item-view"><div class="todo-item-main">'
-            + '<label class="todo-check"><input type="checkbox" data-action="todo-toggle" data-todo-id="'
-            + escapeHtml(todo.id) + '" aria-label="Complete ' + escapeHtml(todo.title) + '"' + checked + '>'
-            + '<span class="todo-checkbox-visual"></span></label>'
-            + '<div class="todo-item-content"><div class="todo-title-line">'
-            + '<button class="todo-title-button" type="button" data-action="todo-open-detail" data-todo-id="'
-            + escapeHtml(todo.id) + '" aria-expanded="' + (expanded ? 'true' : 'false') + '" title="'
-            + (expanded ? 'Collapse details' : 'Expand details') + '"><span class="todo-title-text">'
-            + escapeHtml(todo.title) + '</span></button>' + priorityBadge + '</div></div>'
-            + '<div class="todo-item-actions">'
-            + '<button class="todo-icon-button steward-icon-button danger" type="button" data-action="todo-delete" '
-            + 'data-todo-id="' + escapeHtml(todo.id) + '" title="Delete todo" aria-label="Delete todo">×</button>'
-            + '<button class="todo-drag-handle todo-icon-button steward-icon-button" type="button" draggable="true" '
-            + 'data-drag-todo-item="' + escapeHtml(todo.id) + '" title="Drag to reorder" aria-label="Drag '
-            + escapeHtml(todo.title) + '">⋮⋮</button></div>'
-            + '</div>' + (expanded ? renderInlineDetail(todo) : '') + '</div>';
-    }
 
-    function renderTodo(todo) {
-        return '<li class="' + todoClassName(todo) + '" data-todo-id="' + escapeHtml(todo.id) + '">'
-            + renderTodoBody(todo) + '</li>';
-    }
 
-    function renderCompose(group) {
-        var groupId = group ? group.id : null;
-        var visible = state.composeGroupId === groupId;
-        var draft = visible && state.composeDraft
-            ? state.composeDraft
-            : { title: '', notes: '', priority: 'medium', groupId: groupId };
-        var groupControl = group
-            ? '<input type="hidden" name="groupId" value="' + escapeHtml(group.id) + '">'
-                + '<span class="todo-compose-group-fixed steward-meta" title="' + escapeHtml(group.title)
-                + '" aria-label="Todo group: ' + escapeHtml(group.title) + '">' + escapeHtml(group.title) + '</span>'
-            : '<select name="groupId" aria-label="Todo group">'
-                + renderGroupOptions(draft.groupId) + '</select>';
-        return '<form class="todo-add-form todo-compose-panel steward-card" data-todo-form="'
-            + (group ? 'quick-add' : 'add') + '"'
-            + (group ? ' data-group-id="' + escapeHtml(group.id) + '"' : '')
-            + (visible ? '' : ' hidden') + '>'
-            + '<div class="todo-compose-primary"><span class="todo-compose-icon">＋</span>'
-            + '<input class="todo-title-input" type="text" name="title" placeholder="'
-            + (group ? 'Add to ' + escapeHtml(group.title) : 'Add a todo') + '" aria-label="Todo title" value="'
-            + escapeHtml(draft.title) + '">'
-            + '</div><textarea class="todo-notes-input" name="notes" rows="2" placeholder="Notes" '
-            + 'aria-label="Todo notes">' + escapeHtml(draft.notes)
-            + '</textarea><div class="todo-form-row todo-compose-meta">'
-            + '<select name="priority" aria-label="Todo priority">'
-            + renderPriorityOptions(draft.priority) + '</select>'
-            + groupControl
-            + '<button class="todo-primary-button steward-button steward-button-primary" type="submit">Add</button>'
-            + '<button class="todo-secondary-button steward-button" type="button" data-action="'
-            + (group ? 'todo-cancel-quick-add' : 'todo-cancel-add') + '">Cancel</button></div></form>';
-    }
 
-    function renderTodoCommandIcon(kind) {
-        if (kind === 'add') {
-            return '<svg viewBox="0 0 512 512"><path d="M416 208H272V64c0-17.67-14.33-32-32-32h-32'
-                + 'c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32'
-                + 'h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33'
-                + ' 32-32v-32c0-17.67-14.33-32-32-32z"></path></svg>';
-        }
-        if (kind === 'group') {
-            return '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" '
-                + 'stroke-linecap="round" stroke-linejoin="round"><path d="m3.5 6 1.5 1.5L7.5 5"></path>'
-                + '<path d="m3.5 12 1.5 1.5 2.5-2.5"></path><path d="m3.5 18 1.5 1.5L7.5 17"></path>'
-                + '<path d="M10.5 6.5h10M10.5 12.5h10M10.5 18.5h10"></path></svg>';
-        }
-        return '<svg viewBox="0 0 448 512"><path d="M64 32C28.7 32 0 60.7 0 96v320c0 35.3 28.7'
-            + ' 64 64 64h320c35.3 0 64-28.7 64-64V96c0-35.3-28.7-64-64-64H64zm88 200h144c13.3 0'
-            + ' 24 10.7 24 24s-10.7 24-24 24H152c-13.3 0-24-10.7-24-24s10.7-24 24-24z"></path></svg>';
-    }
 
-    function renderGroupChevron() {
-        return '<span class="todo-group-chevron collapse-icon" aria-hidden="true">'
-            + '<svg viewBox="0 0 320 512"><path d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 '
-            + '0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 '
-            + '24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 '
-            + '9.4-24.4 9.4-33.8 0z"></path></svg></span>';
-    }
 
-    function getGroupStats(groupId) {
-        var todos = state.snapshot.data.todos.filter(function (todo) {
-            return todo.groupId === groupId;
-        });
-        var incompleteCount = todos.filter(function (todo) { return !todo.completed; }).length;
-        var completedCount = todos.length - incompleteCount;
-        var visibleCompletedCount = orderedTodos(groupId)
-            .filter(function (todo) { return todo.completed; }).length;
-        return {
-            incompleteCount: incompleteCount,
-            completedCount: completedCount,
-            hiddenCompletedCount: completedCount - visibleCompletedCount,
-        };
-    }
 
-    function todoGroupMeta(groupId) {
-        var stats = getGroupStats(groupId);
-        return stats.incompleteCount + ' open'
-            + (state.snapshot.showCompleted && stats.completedCount
-                ? ' · ' + stats.completedCount + ' done'
-                : '');
-    }
 
-    function todoSummaryMeta() {
-        var todos = state.snapshot.data.todos;
-        var incomplete = todos.filter(function (todo) { return !todo.completed; }).length;
-        var completed = todos.length - incomplete;
-        var groupCount = orderedGroups().length;
-        return incomplete + ' open · ' + groupCount + (groupCount === 1 ? ' group' : ' groups')
-            + ' · ' + (state.snapshot.showCompleted ? completed + ' completed shown' : 'completed hidden');
-    }
 
-    function renderGroup(group) {
-        var visibleTodos = orderedTodos(group.id);
-        var stats = getGroupStats(group.id);
-        return '<section class="todo-group group steward-section' + (group.collapsed ? ' collapsed' : '')
-            + '" data-todo-group-id="' + escapeHtml(group.id) + '">'
-            + '<header class="todo-group-header group-title steward-group-header">'
-            + '<div class="todo-group-title-block group-title-text">'
-            + '<button class="todo-group-collapse-button" type="button" data-action="todo-collapse-group" '
-            + 'data-todo-group-id="' + escapeHtml(group.id) + '" aria-expanded="'
-            + (group.collapsed ? 'false' : 'true') + '" aria-label="'
-            + (group.collapsed ? 'Expand ' : 'Collapse ') + escapeHtml(group.title) + '">'
-            + renderGroupChevron() + '</button>'
-            + '<h2 data-drag-todo-group title="' + escapeHtml(group.title) + '">' + escapeHtml(group.title) + '</h2>'
-            + '<span class="todo-group-count">' + todoGroupMeta(group.id) + '</span></div>'
-            + '<div class="todo-group-actions group-actions right">'
-            + '<button class="todo-group-action" type="button" data-action="todo-quick-add" data-group-id="'
-            + escapeHtml(group.id) + '" title="Add todo to group" aria-label="Add todo to '
-            + escapeHtml(group.title) + '">＋</button>'
-            + '<button class="todo-group-action" type="button" data-action="todo-sort-priority" data-group-id="'
-            + escapeHtml(group.id) + '" title="Sort by priority" aria-label="Sort by priority">⇅</button>'
-            + '<button class="todo-group-action" type="button" data-action="todo-rename-group" data-group-id="'
-            + escapeHtml(group.id) + '" title="Rename todo group" aria-label="Rename todo group">✎</button>'
-            + '<button class="todo-group-action danger" type="button" data-action="todo-delete-group" data-group-id="'
-            + escapeHtml(group.id) + '" title="Delete todo group" aria-label="Delete todo group">×</button>'
-            + '</div></header>' + renderCompose(group)
-            + (visibleTodos.length
-                ? '<ul class="todo-list">' + visibleTodos.map(renderTodo).join('') + '</ul>'
-                : '<p class="todo-group-empty">No visible todos</p>')
-            + (stats.hiddenCompletedCount > 0
-                ? '<p class="todo-hidden-completed">' + stats.hiddenCompletedCount + ' completed hidden</p>'
-                : '')
-            + '</section>';
-    }
 
-    function renderGlobalCompose() {
-        return renderCompose(null);
-    }
 
-    function renderListSurface() {
-        var groups = orderedGroups();
-        return '<div class="todo-list-surface">'
-            + '<header class="todo-page-header todo-page-command-bar">'
-            + '<div class="todo-summary-copy"><strong>TODO</strong>'
-            + '<span class="todo-summary-meta steward-meta">' + todoSummaryMeta() + '</span></div>'
-            + '<div class="todo-summary-actions group-actions right">'
-            + '<button class="todo-square-button steward-icon-button" type="button" data-action="todo-add" '
-            + 'title="Add todo" aria-label="Add todo">' + renderTodoCommandIcon('add') + '</button>'
-            + '<button class="todo-square-button steward-icon-button" type="button" data-action="todo-add-group" '
-            + 'title="Add group" aria-label="Add group">' + renderTodoCommandIcon('group') + '</button>'
-            + '<label class="todo-square-toggle steward-icon-button'
-            + (state.snapshot.showCompleted ? ' active' : '') + '" title="Show completed" aria-label="Show completed">'
-            + '<input type="checkbox" data-action="todo-toggle-show-completed"'
-            + (state.snapshot.showCompleted ? ' checked' : '') + '><span>'
-            + renderTodoCommandIcon('completed') + '</span></label>'
-            + '</div></header>' + renderGlobalCompose()
-            + (groups.length
-                ? '<div class="todo-groups">' + groups.map(renderGroup).join('') + '</div>'
-                : '<p class="todo-empty-state steward-empty-state">No todos yet</p>')
-            + '</div>';
-    }
 
-    function detailDraft(todo) {
-        return state.draft || {
-            title: todo.title,
-            notes: todo.notes || '',
-            priority: todo.priority,
-            groupId: todo.groupId,
-        };
-    }
 
-    function renderInlineDetail(todo) {
-        var group = findGroup(todo.groupId);
-        var groupName = group ? group.title : 'Unknown group';
-        if (state.draft) {
-            var draft = detailDraft(todo);
-            return '<form class="todo-inline-detail todo-detail-edit-form" data-todo-form="detail-edit" '
-                + 'aria-label="Edit ' + escapeHtml(todo.title) + '" '
-                + 'data-todo-id="' + escapeHtml(todo.id) + '">'
-                + '<label class="todo-field-label">Title</label>'
-                + '<textarea class="todo-title-input" name="title" rows="3" aria-label="Todo title">'
-                + escapeHtml(draft.title) + '</textarea>'
-                + '<label class="todo-field-label">Notes</label>'
-                + '<textarea class="todo-notes-input" name="notes" rows="8" aria-label="Todo notes">'
-                + escapeHtml(draft.notes) + '</textarea>'
-                + '<label class="todo-field-label">Priority</label><select name="priority" aria-label="Todo priority">'
-                + renderPriorityOptions(draft.priority) + '</select>'
-                + '<label class="todo-field-label">Group</label><select name="groupId" aria-label="Todo group">'
-                + renderGroupOptions(draft.groupId) + '</select>'
-                + '<div class="todo-detail-actions"><button class="todo-primary-button steward-button '
-                + 'steward-button-primary" type="submit">Save</button>'
-                + '<button class="todo-secondary-button steward-button" type="button" '
-                + 'data-action="todo-cancel-detail-edit">Cancel</button></div></form>';
-        }
-        return '<section class="todo-inline-detail" role="region" aria-label="Details for '
-            + escapeHtml(todo.title) + '">'
-            + '<div class="todo-inline-row"><span class="todo-inline-label">Notes</span>'
-            + '<p class="todo-inline-value todo-detail-notes">' + escapeHtml(todo.notes || 'No notes') + '</p></div>'
-            + '<div class="todo-inline-row"><span class="todo-inline-label">Group</span>'
-            + '<span class="todo-inline-value">' + escapeHtml(groupName) + '</span></div>'
-            + '<div class="todo-inline-row"><span class="todo-inline-label">Priority</span>'
-            + '<span class="todo-inline-value">' + escapeHtml(todo.priority.toUpperCase()) + '</span></div>'
-            + '<div class="todo-inline-row"><span class="todo-inline-label">Created</span>'
-            + '<span class="todo-inline-value">' + escapeHtml(String(todo.createdAt || '').slice(0, 10)) + '</span></div>'
-            + '<div class="todo-inline-row"><span class="todo-inline-label">Updated</span>'
-            + '<span class="todo-inline-value">' + escapeHtml(String(todo.updatedAt || '').slice(0, 10)) + '</span></div>'
-            + (todo.completedAt
-                ? '<div class="todo-inline-row"><span class="todo-inline-label">Completed</span>'
-                    + '<span class="todo-inline-value">'
-                    + escapeHtml(String(todo.completedAt).slice(0, 10)) + '</span></div>'
-                : '')
-            + '<div class="todo-detail-actions">'
-            + '<button class="todo-primary-button steward-button" type="button" data-action="todo-toggle-detail" '
-            + 'data-todo-id="' + escapeHtml(todo.id) + '">' + (todo.completed ? 'Reopen' : 'Complete') + '</button>'
-            + '<button class="todo-secondary-button steward-button" type="button" data-action="todo-edit-detail">Edit</button>'
-            + '<button class="todo-secondary-button steward-button danger" type="button" data-action="todo-delete" '
-            + 'data-todo-id="' + escapeHtml(todo.id) + '">Delete</button>'
-            + '</div></section>';
-    }
 
-    function renderUndo() {
-        if (!state.undo) {
-            return '<div class="todo-undo-region" role="status" aria-live="polite" hidden></div>';
-        }
-        return '<div class="todo-undo-region" role="status" aria-live="polite" style="display:flex">'
-            + '<span>' + escapeHtml(state.undo.label) + '</span>'
-            + '<button class="todo-primary-button steward-button" type="button" data-action="todo-undo">Undo</button></div>';
-    }
 
     function syncTodoListExpandedHeights() {
         if (!root || !root.querySelectorAll) {
@@ -454,11 +154,11 @@ function initTodos(options) {
         if (!root || !isSnapshot(state.snapshot)) {
             return false;
         }
-        if (state.selectedTodoId && !findTodo(state.selectedTodoId)) {
+        if (state.selectedTodoId && !renderer.findTodo(state.selectedTodoId)) {
             state.selectedTodoId = null;
             state.draft = null;
         }
-        var surfaceHtml = renderListSurface();
+        var surfaceHtml = renderer.renderListSurface();
         if (!force && surfaceHtml === state.renderedSurfaceHtml) {
             updateFeedback();
             return false;
@@ -470,7 +170,7 @@ function initTodos(options) {
             surface.outerHTML = surfaceHtml;
         } else {
             root.innerHTML = surfaceHtml
-                + renderUndo()
+                + renderer.renderUndo()
                 + '<div class="todo-live-region" role="status" aria-live="polite" aria-atomic="true">'
                 + escapeHtml(state.announcement) + '</div>';
         }
@@ -495,7 +195,7 @@ function initTodos(options) {
         });
         for (var index = 0; index < uniqueTodoIds.length; index += 1) {
             var todoId = uniqueTodoIds[index];
-            var todo = findTodo(todoId);
+            var todo = renderer.findTodo(todoId);
             var selector = '.todo-item[data-todo-id="' + String(todoId).replace(/"/g, '\\"') + '"]';
             var item = root.querySelector(selector);
             if (!todo || !item || typeof item.innerHTML !== 'string') {
@@ -505,10 +205,10 @@ function initTodos(options) {
             patches.push({ item: item, todo: todo });
         }
         patches.forEach(function (patch) {
-            patch.item.className = todoClassName(patch.todo);
-            patch.item.innerHTML = renderTodoBody(patch.todo);
+            patch.item.className = renderer.todoClassName(patch.todo);
+            patch.item.innerHTML = renderer.renderTodoBody(patch.todo);
         });
-        state.renderedSurfaceHtml = renderListSurface();
+        state.renderedSurfaceHtml = renderer.renderListSurface();
         syncTodoListExpandedHeights();
         refreshTodoLayoutObserverTargets();
         updateFeedback();
@@ -519,8 +219,8 @@ function initTodos(options) {
         if (!root || !root.querySelector) {
             return false;
         }
-        var todo = findTodo(todoId);
-        var group = todo ? findGroup(todo.groupId) : null;
+        var todo = renderer.findTodo(todoId);
+        var group = todo ? renderer.findGroup(todo.groupId) : null;
         var itemSelector = '.todo-item[data-todo-id="' + String(todoId).replace(/"/g, '\\"') + '"]';
         var groupSelector = group
             ? '.todo-group[data-todo-group-id="' + String(group.id).replace(/"/g, '\\"') + '"]'
@@ -539,7 +239,7 @@ function initTodos(options) {
             return false;
         }
 
-        var visibleTodos = orderedTodos(group.id);
+        var visibleTodos = renderer.orderedTodos(group.id);
         var visibleIndex = visibleTodos.findIndex(function (candidate) {
             return candidate.id === todoId;
         });
@@ -550,8 +250,8 @@ function initTodos(options) {
         }
         item.hidden = !remainsVisible;
         if (remainsVisible) {
-            item.className = todoClassName(todo);
-            item.innerHTML = renderTodoBody(todo);
+            item.className = renderer.todoClassName(todo);
+            item.innerHTML = renderer.renderTodoBody(todo);
             var nextTodo = visibleTodos[visibleIndex + 1];
             var nextItem = nextTodo && list.querySelector
                 ? list.querySelector('.todo-item[data-todo-id="'
@@ -564,9 +264,9 @@ function initTodos(options) {
             }
         }
 
-        summaryMeta.textContent = todoSummaryMeta();
-        groupCount.textContent = todoGroupMeta(group.id);
-        var stats = getGroupStats(group.id);
+        summaryMeta.textContent = renderer.todoSummaryMeta();
+        groupCount.textContent = renderer.todoGroupMeta(group.id);
+        var stats = renderer.getGroupStats(group.id);
         var hiddenCompleted = groupElement.querySelector('.todo-hidden-completed');
         if (hiddenCompleted) {
             hiddenCompleted.hidden = stats.hiddenCompletedCount === 0;
@@ -586,7 +286,7 @@ function initTodos(options) {
         } else if (!visibleTodos.length && list.insertAdjacentHTML) {
             list.insertAdjacentHTML('afterend', '<p class="todo-group-empty">No visible todos</p>');
         }
-        state.renderedSurfaceHtml = renderListSurface();
+        state.renderedSurfaceHtml = renderer.renderListSurface();
         syncTodoListExpandedHeights();
         refreshTodoLayoutObserverTargets();
         updateFeedback();
@@ -601,7 +301,7 @@ function initTodos(options) {
         var patches = [];
         for (var index = 0; index < groupIds.length; index += 1) {
             var groupId = groupIds[index];
-            var group = findGroup(groupId);
+            var group = renderer.findGroup(groupId);
             var selector = '.todo-group[data-todo-group-id="' + String(groupId).replace(/"/g, '\\"') + '"]';
             var groupElement = root.querySelector(selector);
             var button = groupElement && groupElement.querySelector
@@ -619,7 +319,7 @@ function initTodos(options) {
             patch.button.setAttribute('aria-label',
                 (patch.group.collapsed ? 'Expand ' : 'Collapse ') + patch.group.title);
         });
-        state.renderedSurfaceHtml = renderListSurface();
+        state.renderedSurfaceHtml = renderer.renderListSurface();
         updateFeedback();
         return true;
     }
@@ -757,12 +457,12 @@ function initTodos(options) {
     }
 
     function isTodoRendered(todoId) {
-        var todo = findTodo(todoId);
-        var group = todo && findGroup(todo.groupId);
+        var todo = renderer.findTodo(todoId);
+        var group = todo && renderer.findGroup(todo.groupId);
         return !!todo
             && !!group
             && !group.collapsed
-            && orderedTodos(group.id).some(function (candidate) {
+            && renderer.orderedTodos(group.id).some(function (candidate) {
                 return candidate.id === todoId;
             });
     }
@@ -772,14 +472,14 @@ function initTodos(options) {
             return false;
         }
         if (typeof composeGroupId === 'string') {
-            return !!findGroup(composeGroupId);
+            return !!renderer.findGroup(composeGroupId);
         }
         if (composeGroupId !== null) {
             return false;
         }
         return typeof composeDraft.groupId !== 'string'
             || composeDraft.groupId.length === 0
-            || !!findGroup(composeDraft.groupId);
+            || !!renderer.findGroup(composeDraft.groupId);
     }
 
     function reconcileTodoRefreshState(local) {
@@ -925,12 +625,12 @@ function initTodos(options) {
     }
 
     function openDetail(todoId) {
-        var todo = findTodo(todoId);
+        var todo = renderer.findTodo(todoId);
         if (!todo) {
             return false;
         }
-        var group = findGroup(todo.groupId);
-        var rendered = orderedTodos(todo.groupId).some(function (item) {
+        var group = renderer.findGroup(todo.groupId);
+        var rendered = renderer.orderedTodos(todo.groupId).some(function (item) {
             return item.id === todoId;
         });
         if (!rendered || (group && group.collapsed)) {
@@ -975,7 +675,7 @@ function initTodos(options) {
 
     function optimisticMutation(action, payload) {
         if (action === 'complete') {
-            var completedTodo = findTodo(payload.todoId);
+            var completedTodo = renderer.findTodo(payload.todoId);
             if (completedTodo) {
                 completedTodo.completed = payload.completed === true;
                 completedTodo.completedAt = payload.completed ? new Date().toISOString() : undefined;
@@ -989,7 +689,7 @@ function initTodos(options) {
                 state.draft = null;
             }
         } else if (action === 'collapse-group') {
-            var group = findGroup(payload.groupId);
+            var group = renderer.findGroup(payload.groupId);
             if (group) {
                 group.collapsed = payload.collapsed === true;
             }
@@ -1000,7 +700,7 @@ function initTodos(options) {
         } else if (action === 'show-completed') {
             state.snapshot.showCompleted = payload.showCompleted === true;
         } else if (action === 'update') {
-            var updated = findTodo(payload.todoId);
+            var updated = renderer.findTodo(payload.todoId);
             if (updated) {
                 ['title', 'notes', 'priority', 'groupId'].forEach(function (key) {
                     if (payload[key] !== undefined) {
@@ -1010,14 +710,14 @@ function initTodos(options) {
             }
         } else if (action === 'reorder-items' && Array.isArray(payload.todoIds)) {
             payload.todoIds.forEach(function (todoId, index) {
-                var todo = findTodo(todoId);
+                var todo = renderer.findTodo(todoId);
                 if (todo && todo.groupId === payload.groupId) {
                     todo.order = index;
                 }
             });
         } else if (action === 'reorder-groups' && Array.isArray(payload.groupIds)) {
             payload.groupIds.forEach(function (groupId, index) {
-                var reorderedGroup = findGroup(groupId);
+                var reorderedGroup = renderer.findGroup(groupId);
                 if (reorderedGroup) {
                     reorderedGroup.order = index;
                 }
@@ -1055,7 +755,7 @@ function initTodos(options) {
         } else if (action === 'collapse-groups') {
             patchGroupElements(state.snapshot.data.groups.map(function (group) { return group.id; }));
         } else if (action === 'reorder-items' || action === 'reorder-groups') {
-            state.renderedSurfaceHtml = renderListSurface();
+            state.renderedSurfaceHtml = renderer.renderListSurface();
             updateFeedback();
         } else {
             render();
@@ -1319,14 +1019,14 @@ function initTodos(options) {
         } else if (action === 'todo-back') {
             backToList();
         } else if (action === 'todo-edit-detail') {
-            var todo = findTodo(state.selectedTodoId);
-            state.draft = todo ? detailDraft(todo) : null;
+            var todo = renderer.findTodo(state.selectedTodoId);
+            state.draft = todo ? renderer.detailDraft(todo) : null;
             patchTodoElements([state.selectedTodoId]);
         } else if (action === 'todo-cancel-detail-edit') {
             state.draft = null;
             patchTodoElements([state.selectedTodoId]);
         } else if (action === 'todo-toggle-detail') {
-            var detailTodo = findTodo(todoId);
+            var detailTodo = renderer.findTodo(todoId);
             if (detailTodo) dispatch('complete', { todoId: todoId, completed: !detailTodo.completed });
         } else if (action === 'todo-delete') {
             dispatch('delete', { todoId: todoId });
@@ -1358,7 +1058,7 @@ function initTodos(options) {
             render();
             focusCompose(groupId);
         } else if (action === 'todo-collapse-group') {
-            var group = findGroup(groupId);
+            var group = renderer.findGroup(groupId);
             if (group) dispatch('collapse-group', { groupId: groupId, collapsed: !group.collapsed });
         } else if (action === 'todo-sort-priority') {
             dispatch('sort-priority', { groupId: groupId });
@@ -1420,7 +1120,7 @@ function initTodos(options) {
             && field.closest('.todo-detail-edit-form')
             && (name === 'title' || name === 'notes' || name === 'priority' || name === 'groupId')) {
             state.draft[name] = String(field.value || '');
-            state.renderedSurfaceHtml = renderListSurface();
+            state.renderedSurfaceHtml = renderer.renderListSurface();
             return;
         }
         var composeForm = field.closest('.todo-add-form[data-todo-form]');
@@ -1429,7 +1129,7 @@ function initTodos(options) {
             && (name === 'title' || name === 'notes' || name === 'priority' || name === 'groupId')) {
             state.composeRequestId = null;
             state.composeDraft[name] = String(field.value || '');
-            state.renderedSurfaceHtml = renderListSurface();
+            state.renderedSurfaceHtml = renderer.renderListSurface();
         }
     }
 

--- a/scripts/run-dashboard-webview-checks.js
+++ b/scripts/run-dashboard-webview-checks.js
@@ -4543,6 +4543,12 @@ function runSourceContractChecks(source) {
             < webviewContentSource.indexOf('webviewProjectScripts.js'),
         'semantic scroll state must load before every domain Webview script'
     );
+    assert.ok(webviewContentSource.includes("'webviewTodoRenderScripts.js'"));
+    assert.ok(
+        webviewContentSource.indexOf('webviewTodoRenderScripts.js')
+            < webviewContentSource.indexOf('webviewTodoScripts.js'),
+        'the TODO renderer must load before the TODO controller that calls it'
+    );
     assert.ok(webviewContentSource.includes("'webviewTodoScripts.js'"));
     assert.match(
         webviewContentSource,

--- a/scripts/run-release-packaging-checks.js
+++ b/scripts/run-release-packaging-checks.js
@@ -90,6 +90,7 @@ const EXPECTED_MAIN_ENTRIES = Object.freeze([
     'extension/media/webviewProjectScripts.js',
     'extension/media/webviewPromptScripts.js',
     'extension/media/webviewScrollStateScripts.js',
+    'extension/media/webviewTodoRenderScripts.js',
     'extension/media/webviewTodoScripts.js',
     'extension/out/openWorkspaces/bridgeClient.js',
     'extension/out/openWorkspaces/dashboardController.js',
@@ -613,6 +614,7 @@ function runRealVsixArchiveChecks(mainPackage, bridgePackage) {
         ['extension/media/webviewDashboardSearchScripts.js', 'media/webviewDashboardSearchScripts.js'],
         ['extension/media/webviewPromptScripts.js', 'media/webviewPromptScripts.js'],
         ['extension/media/webviewScrollStateScripts.js', 'media/webviewScrollStateScripts.js'],
+        ['extension/media/webviewTodoRenderScripts.js', 'media/webviewTodoRenderScripts.js'],
         ['extension/media/webviewTodoScripts.js', 'media/webviewTodoScripts.js'],
     ]) {
         assert.deepStrictEqual(mainEntries.get(archiveEntry), fs.readFileSync(path.join(repositoryRoot, localPath)),
@@ -947,6 +949,7 @@ function run() {
     assertIncludes(mainIgnore, '!media/webviewDashboardSearchScripts.js', 'main VSIX ignore rules');
     assertIncludes(mainIgnore, '!media/webviewPromptScripts.js', 'main VSIX ignore rules');
     assertIncludes(mainIgnore, '!media/webviewScrollStateScripts.js', 'main VSIX ignore rules');
+    assertIncludes(mainIgnore, '!media/webviewTodoRenderScripts.js', 'main VSIX ignore rules');
     assertIncludes(mainIgnore, '!media/webviewTodoScripts.js', 'main VSIX ignore rules');
     assertIncludes(mainIgnore, '!media/mermaid.min.js', 'main VSIX ignore rules');
     assertIncludes(mainIgnore, '!media/styles.css', 'main VSIX ignore rules');
@@ -979,6 +982,7 @@ function run() {
         'media/webviewDashboardSearchScripts.js',
         'media/webviewPromptScripts.js',
         'media/webviewScrollStateScripts.js',
+        'media/webviewTodoRenderScripts.js',
         'media/webviewTodoScripts.js',
         'media/mermaid.min.js',
         'media/styles.css',

--- a/src/webview/webviewContent.ts
+++ b/src/webview/webviewContent.ts
@@ -230,6 +230,12 @@ export function getStewardContent(
         'webviewPromptScripts.js',
         assetRevision,
     );
+    var todoRenderScriptsPath = getMediaResource(
+        context,
+        webview,
+        'webviewTodoRenderScripts.js',
+        assetRevision,
+    );
     var todoScriptsPath = getMediaResource(
         context,
         webview,
@@ -355,6 +361,7 @@ export function getStewardContent(
     <script src="${dashboardSearchScriptsPath}"></script>
     <script src="${dashboardScriptsPath}"></script>
     <script src="${promptScriptsPath}"></script>
+    <script src="${todoRenderScriptsPath}"></script>
     <script src="${todoScriptsPath}"></script>
     <script src="${dndScriptsPath}"></script>
     <script src="${filterScriptsPath}"></script>

--- a/src/webview/webviewTodoRenderScripts.js
+++ b/src/webview/webviewTodoRenderScripts.js
@@ -1,0 +1,345 @@
+function escapeHtml(value) {
+    return String(value == null ? '' : value)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
+function clone(value) {
+    return value == null ? value : JSON.parse(JSON.stringify(value));
+}
+
+function isSnapshot(value) {
+    return !!value
+        && value.version === 1
+        && value.data
+        && value.data.version === 1
+        && Array.isArray(value.data.groups)
+        && Array.isArray(value.data.todos)
+        && typeof value.showCompleted === 'boolean';
+}
+
+function renderTodoCommandIcon(kind) {
+    if (kind === 'add') {
+        return '<svg viewBox="0 0 512 512"><path d="M416 208H272V64c0-17.67-14.33-32-32-32h-32'
+            + 'c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32'
+            + 'h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33'
+            + ' 32-32v-32c0-17.67-14.33-32-32-32z"></path></svg>';
+    }
+    if (kind === 'group') {
+        return '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" '
+            + 'stroke-linecap="round" stroke-linejoin="round"><path d="m3.5 6 1.5 1.5L7.5 5"></path>'
+            + '<path d="m3.5 12 1.5 1.5 2.5-2.5"></path><path d="m3.5 18 1.5 1.5L7.5 17"></path>'
+            + '<path d="M10.5 6.5h10M10.5 12.5h10M10.5 18.5h10"></path></svg>';
+    }
+    return '<svg viewBox="0 0 448 512"><path d="M64 32C28.7 32 0 60.7 0 96v320c0 35.3 28.7'
+        + ' 64 64 64h320c35.3 0 64-28.7 64-64V96c0-35.3-28.7-64-64-64H64zm88 200h144c13.3 0'
+        + ' 24 10.7 24 24s-10.7 24-24 24H152c-13.3 0-24-10.7-24-24s10.7-24 24-24z"></path></svg>';
+}
+
+function renderGroupChevron() {
+    return '<span class="todo-group-chevron collapse-icon" aria-hidden="true">'
+        + '<svg viewBox="0 0 320 512"><path d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 '
+        + '0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 '
+        + '24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 '
+        + '9.4-24.4 9.4-33.8 0z"></path></svg></span>';
+}
+
+function createTodoRenderer(options) {
+    'use strict';
+
+    options = options || {};
+    var state = options.state;
+
+    function orderedGroups() {
+        return state.snapshot.data.groups.slice().sort(function (left, right) {
+            return left.order - right.order;
+        });
+    }
+
+    function orderedTodos(groupId) {
+        var todos = state.snapshot.data.todos
+            .filter(function (todo) { return todo.groupId === groupId; })
+            .sort(function (left, right) { return left.order - right.order; });
+        var incomplete = todos.filter(function (todo) { return !todo.completed; });
+        var completed = todos.filter(function (todo) { return todo.completed; });
+        var visibleCompleted = state.snapshot.showCompleted
+            ? completed
+            : completed.filter(function (todo) {
+                return todo.id === state.snapshot.revealedTodoId;
+            });
+        return incomplete.concat(visibleCompleted);
+    }
+
+    function findTodo(todoId) {
+        return state.snapshot && state.snapshot.data.todos.find(function (todo) {
+            return todo.id === todoId;
+        });
+    }
+
+    function findGroup(groupId) {
+        return state.snapshot && state.snapshot.data.groups.find(function (group) {
+            return group.id === groupId;
+        });
+    }
+
+    function renderPriorityOptions(selected) {
+        return ['high', 'medium', 'low'].map(function (priority) {
+            return '<option value="' + priority + '"' + (priority === selected ? ' selected' : '') + '>'
+                + priority.toUpperCase() + '</option>';
+        }).join('');
+    }
+
+    function renderGroupOptions(selected) {
+        return '<option value=""' + (!selected ? ' selected' : '') + '>Inbox</option>'
+            + orderedGroups().map(function (group) {
+            return '<option value="' + escapeHtml(group.id) + '"'
+                + (group.id === selected ? ' selected' : '') + '>'
+                + escapeHtml(group.title) + '</option>';
+        }).join('');
+    }
+
+    function todoClassName(todo) {
+        return 'todo-item steward-item-card todo-priority-' + escapeHtml(todo.priority)
+            + (todo.completed ? ' completed' : '')
+            + (state.selectedTodoId === todo.id ? ' expanded' : '');
+    }
+
+    function renderTodoBody(todo) {
+        var checked = todo.completed ? ' checked' : '';
+        var expanded = state.selectedTodoId === todo.id;
+        var priorityBadge = todo.priority === 'medium'
+            ? ''
+            : '<span class="todo-priority-badge steward-badge">'
+                + escapeHtml(todo.priority.toUpperCase()) + '</span>';
+        return '<span class="todo-item-accent steward-item-accent" aria-hidden="true"></span>'
+            + '<div class="todo-item-view"><div class="todo-item-main">'
+            + '<label class="todo-check"><input type="checkbox" data-action="todo-toggle" data-todo-id="'
+            + escapeHtml(todo.id) + '" aria-label="Complete ' + escapeHtml(todo.title) + '"' + checked + '>'
+            + '<span class="todo-checkbox-visual"></span></label>'
+            + '<div class="todo-item-content"><div class="todo-title-line">'
+            + '<button class="todo-title-button" type="button" data-action="todo-open-detail" data-todo-id="'
+            + escapeHtml(todo.id) + '" aria-expanded="' + (expanded ? 'true' : 'false') + '" title="'
+            + (expanded ? 'Collapse details' : 'Expand details') + '"><span class="todo-title-text">'
+            + escapeHtml(todo.title) + '</span></button>' + priorityBadge + '</div></div>'
+            + '<div class="todo-item-actions">'
+            + '<button class="todo-icon-button steward-icon-button danger" type="button" data-action="todo-delete" '
+            + 'data-todo-id="' + escapeHtml(todo.id) + '" title="Delete todo" aria-label="Delete todo">×</button>'
+            + '<button class="todo-drag-handle todo-icon-button steward-icon-button" type="button" draggable="true" '
+            + 'data-drag-todo-item="' + escapeHtml(todo.id) + '" title="Drag to reorder" aria-label="Drag '
+            + escapeHtml(todo.title) + '">⋮⋮</button></div>'
+            + '</div>' + (expanded ? renderInlineDetail(todo) : '') + '</div>';
+    }
+
+    function renderTodo(todo) {
+        return '<li class="' + todoClassName(todo) + '" data-todo-id="' + escapeHtml(todo.id) + '">'
+            + renderTodoBody(todo) + '</li>';
+    }
+
+    function renderCompose(group) {
+        var groupId = group ? group.id : null;
+        var visible = state.composeGroupId === groupId;
+        var draft = visible && state.composeDraft
+            ? state.composeDraft
+            : { title: '', notes: '', priority: 'medium', groupId: groupId };
+        var groupControl = group
+            ? '<input type="hidden" name="groupId" value="' + escapeHtml(group.id) + '">'
+                + '<span class="todo-compose-group-fixed steward-meta" title="' + escapeHtml(group.title)
+                + '" aria-label="Todo group: ' + escapeHtml(group.title) + '">' + escapeHtml(group.title) + '</span>'
+            : '<select name="groupId" aria-label="Todo group">'
+                + renderGroupOptions(draft.groupId) + '</select>';
+        return '<form class="todo-add-form todo-compose-panel steward-card" data-todo-form="'
+            + (group ? 'quick-add' : 'add') + '"'
+            + (group ? ' data-group-id="' + escapeHtml(group.id) + '"' : '')
+            + (visible ? '' : ' hidden') + '>'
+            + '<div class="todo-compose-primary"><span class="todo-compose-icon">＋</span>'
+            + '<input class="todo-title-input" type="text" name="title" placeholder="'
+            + (group ? 'Add to ' + escapeHtml(group.title) : 'Add a todo') + '" aria-label="Todo title" value="'
+            + escapeHtml(draft.title) + '">'
+            + '</div><textarea class="todo-notes-input" name="notes" rows="2" placeholder="Notes" '
+            + 'aria-label="Todo notes">' + escapeHtml(draft.notes)
+            + '</textarea><div class="todo-form-row todo-compose-meta">'
+            + '<select name="priority" aria-label="Todo priority">'
+            + renderPriorityOptions(draft.priority) + '</select>'
+            + groupControl
+            + '<button class="todo-primary-button steward-button steward-button-primary" type="submit">Add</button>'
+            + '<button class="todo-secondary-button steward-button" type="button" data-action="'
+            + (group ? 'todo-cancel-quick-add' : 'todo-cancel-add') + '">Cancel</button></div></form>';
+    }
+
+    function getGroupStats(groupId) {
+        var todos = state.snapshot.data.todos.filter(function (todo) {
+            return todo.groupId === groupId;
+        });
+        var incompleteCount = todos.filter(function (todo) { return !todo.completed; }).length;
+        var completedCount = todos.length - incompleteCount;
+        var visibleCompletedCount = orderedTodos(groupId)
+            .filter(function (todo) { return todo.completed; }).length;
+        return {
+            incompleteCount: incompleteCount,
+            completedCount: completedCount,
+            hiddenCompletedCount: completedCount - visibleCompletedCount,
+        };
+    }
+
+    function todoGroupMeta(groupId) {
+        var stats = getGroupStats(groupId);
+        return stats.incompleteCount + ' open'
+            + (state.snapshot.showCompleted && stats.completedCount
+                ? ' · ' + stats.completedCount + ' done'
+                : '');
+    }
+
+    function todoSummaryMeta() {
+        var todos = state.snapshot.data.todos;
+        var incomplete = todos.filter(function (todo) { return !todo.completed; }).length;
+        var completed = todos.length - incomplete;
+        var groupCount = orderedGroups().length;
+        return incomplete + ' open · ' + groupCount + (groupCount === 1 ? ' group' : ' groups')
+            + ' · ' + (state.snapshot.showCompleted ? completed + ' completed shown' : 'completed hidden');
+    }
+
+    function renderGroup(group) {
+        var visibleTodos = orderedTodos(group.id);
+        var stats = getGroupStats(group.id);
+        return '<section class="todo-group group steward-section' + (group.collapsed ? ' collapsed' : '')
+            + '" data-todo-group-id="' + escapeHtml(group.id) + '">'
+            + '<header class="todo-group-header group-title steward-group-header">'
+            + '<div class="todo-group-title-block group-title-text">'
+            + '<button class="todo-group-collapse-button" type="button" data-action="todo-collapse-group" '
+            + 'data-todo-group-id="' + escapeHtml(group.id) + '" aria-expanded="'
+            + (group.collapsed ? 'false' : 'true') + '" aria-label="'
+            + (group.collapsed ? 'Expand ' : 'Collapse ') + escapeHtml(group.title) + '">'
+            + renderGroupChevron() + '</button>'
+            + '<h2 data-drag-todo-group title="' + escapeHtml(group.title) + '">' + escapeHtml(group.title) + '</h2>'
+            + '<span class="todo-group-count">' + todoGroupMeta(group.id) + '</span></div>'
+            + '<div class="todo-group-actions group-actions right">'
+            + '<button class="todo-group-action" type="button" data-action="todo-quick-add" data-group-id="'
+            + escapeHtml(group.id) + '" title="Add todo to group" aria-label="Add todo to '
+            + escapeHtml(group.title) + '">＋</button>'
+            + '<button class="todo-group-action" type="button" data-action="todo-sort-priority" data-group-id="'
+            + escapeHtml(group.id) + '" title="Sort by priority" aria-label="Sort by priority">⇅</button>'
+            + '<button class="todo-group-action" type="button" data-action="todo-rename-group" data-group-id="'
+            + escapeHtml(group.id) + '" title="Rename todo group" aria-label="Rename todo group">✎</button>'
+            + '<button class="todo-group-action danger" type="button" data-action="todo-delete-group" data-group-id="'
+            + escapeHtml(group.id) + '" title="Delete todo group" aria-label="Delete todo group">×</button>'
+            + '</div></header>' + renderCompose(group)
+            + (visibleTodos.length
+                ? '<ul class="todo-list">' + visibleTodos.map(renderTodo).join('') + '</ul>'
+                : '<p class="todo-group-empty">No visible todos</p>')
+            + (stats.hiddenCompletedCount > 0
+                ? '<p class="todo-hidden-completed">' + stats.hiddenCompletedCount + ' completed hidden</p>'
+                : '')
+            + '</section>';
+    }
+
+    function renderGlobalCompose() {
+        return renderCompose(null);
+    }
+
+    function renderListSurface() {
+        var groups = orderedGroups();
+        return '<div class="todo-list-surface">'
+            + '<header class="todo-page-header todo-page-command-bar">'
+            + '<div class="todo-summary-copy"><strong>TODO</strong>'
+            + '<span class="todo-summary-meta steward-meta">' + todoSummaryMeta() + '</span></div>'
+            + '<div class="todo-summary-actions group-actions right">'
+            + '<button class="todo-square-button steward-icon-button" type="button" data-action="todo-add" '
+            + 'title="Add todo" aria-label="Add todo">' + renderTodoCommandIcon('add') + '</button>'
+            + '<button class="todo-square-button steward-icon-button" type="button" data-action="todo-add-group" '
+            + 'title="Add group" aria-label="Add group">' + renderTodoCommandIcon('group') + '</button>'
+            + '<label class="todo-square-toggle steward-icon-button'
+            + (state.snapshot.showCompleted ? ' active' : '') + '" title="Show completed" aria-label="Show completed">'
+            + '<input type="checkbox" data-action="todo-toggle-show-completed"'
+            + (state.snapshot.showCompleted ? ' checked' : '') + '><span>'
+            + renderTodoCommandIcon('completed') + '</span></label>'
+            + '</div></header>' + renderGlobalCompose()
+            + (groups.length
+                ? '<div class="todo-groups">' + groups.map(renderGroup).join('') + '</div>'
+                : '<p class="todo-empty-state steward-empty-state">No todos yet</p>')
+            + '</div>';
+    }
+
+    function detailDraft(todo) {
+        return state.draft || {
+            title: todo.title,
+            notes: todo.notes || '',
+            priority: todo.priority,
+            groupId: todo.groupId,
+        };
+    }
+
+    function renderInlineDetail(todo) {
+        var group = findGroup(todo.groupId);
+        var groupName = group ? group.title : 'Unknown group';
+        if (state.draft) {
+            var draft = detailDraft(todo);
+            return '<form class="todo-inline-detail todo-detail-edit-form" data-todo-form="detail-edit" '
+                + 'aria-label="Edit ' + escapeHtml(todo.title) + '" '
+                + 'data-todo-id="' + escapeHtml(todo.id) + '">'
+                + '<label class="todo-field-label">Title</label>'
+                + '<textarea class="todo-title-input" name="title" rows="3" aria-label="Todo title">'
+                + escapeHtml(draft.title) + '</textarea>'
+                + '<label class="todo-field-label">Notes</label>'
+                + '<textarea class="todo-notes-input" name="notes" rows="8" aria-label="Todo notes">'
+                + escapeHtml(draft.notes) + '</textarea>'
+                + '<label class="todo-field-label">Priority</label><select name="priority" aria-label="Todo priority">'
+                + renderPriorityOptions(draft.priority) + '</select>'
+                + '<label class="todo-field-label">Group</label><select name="groupId" aria-label="Todo group">'
+                + renderGroupOptions(draft.groupId) + '</select>'
+                + '<div class="todo-detail-actions"><button class="todo-primary-button steward-button '
+                + 'steward-button-primary" type="submit">Save</button>'
+                + '<button class="todo-secondary-button steward-button" type="button" '
+                + 'data-action="todo-cancel-detail-edit">Cancel</button></div></form>';
+        }
+        return '<section class="todo-inline-detail" role="region" aria-label="Details for '
+            + escapeHtml(todo.title) + '">'
+            + '<div class="todo-inline-row"><span class="todo-inline-label">Notes</span>'
+            + '<p class="todo-inline-value todo-detail-notes">' + escapeHtml(todo.notes || 'No notes') + '</p></div>'
+            + '<div class="todo-inline-row"><span class="todo-inline-label">Group</span>'
+            + '<span class="todo-inline-value">' + escapeHtml(groupName) + '</span></div>'
+            + '<div class="todo-inline-row"><span class="todo-inline-label">Priority</span>'
+            + '<span class="todo-inline-value">' + escapeHtml(todo.priority.toUpperCase()) + '</span></div>'
+            + '<div class="todo-inline-row"><span class="todo-inline-label">Created</span>'
+            + '<span class="todo-inline-value">' + escapeHtml(String(todo.createdAt || '').slice(0, 10)) + '</span></div>'
+            + '<div class="todo-inline-row"><span class="todo-inline-label">Updated</span>'
+            + '<span class="todo-inline-value">' + escapeHtml(String(todo.updatedAt || '').slice(0, 10)) + '</span></div>'
+            + (todo.completedAt
+                ? '<div class="todo-inline-row"><span class="todo-inline-label">Completed</span>'
+                    + '<span class="todo-inline-value">'
+                    + escapeHtml(String(todo.completedAt).slice(0, 10)) + '</span></div>'
+                : '')
+            + '<div class="todo-detail-actions">'
+            + '<button class="todo-primary-button steward-button" type="button" data-action="todo-toggle-detail" '
+            + 'data-todo-id="' + escapeHtml(todo.id) + '">' + (todo.completed ? 'Reopen' : 'Complete') + '</button>'
+            + '<button class="todo-secondary-button steward-button" type="button" data-action="todo-edit-detail">Edit</button>'
+            + '<button class="todo-secondary-button steward-button danger" type="button" data-action="todo-delete" '
+            + 'data-todo-id="' + escapeHtml(todo.id) + '">Delete</button>'
+            + '</div></section>';
+    }
+
+    function renderUndo() {
+        if (!state.undo) {
+            return '<div class="todo-undo-region" role="status" aria-live="polite" hidden></div>';
+        }
+        return '<div class="todo-undo-region" role="status" aria-live="polite" style="display:flex">'
+            + '<span>' + escapeHtml(state.undo.label) + '</span>'
+            + '<button class="todo-primary-button steward-button" type="button" data-action="todo-undo">Undo</button></div>';
+    }
+
+    return {
+        orderedTodos: orderedTodos,
+        findTodo: findTodo,
+        findGroup: findGroup,
+        renderTodoBody: renderTodoBody,
+        todoClassName: todoClassName,
+        getGroupStats: getGroupStats,
+        todoGroupMeta: todoGroupMeta,
+        todoSummaryMeta: todoSummaryMeta,
+        renderListSurface: renderListSurface,
+        renderUndo: renderUndo,
+        detailDraft: detailDraft,
+    };
+}

--- a/src/webview/webviewTodoScripts.js
+++ b/src/webview/webviewTodoScripts.js
@@ -21,23 +21,13 @@ function initTodos(options) {
         announcement: '',
         renderedSurfaceHtml: '',
     };
+    var renderer = createTodoRenderer({ state: state });
     var panelHost = null;
     var root = null;
     var layoutObserver = null;
     var skipNextTodoLayoutObserverSync = false;
 
-    function escapeHtml(value) {
-        return String(value == null ? '' : value)
-            .replace(/&/g, '&amp;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;')
-            .replace(/"/g, '&quot;')
-            .replace(/'/g, '&#39;');
-    }
 
-    function clone(value) {
-        return value == null ? value : JSON.parse(JSON.stringify(value));
-    }
 
     function clearCompose() {
         state.composeGroupId = undefined;
@@ -45,317 +35,27 @@ function initTodos(options) {
         state.composeRequestId = null;
     }
 
-    function isSnapshot(value) {
-        return !!value
-            && value.version === 1
-            && value.data
-            && value.data.version === 1
-            && Array.isArray(value.data.groups)
-            && Array.isArray(value.data.todos)
-            && typeof value.showCompleted === 'boolean';
-    }
 
-    function orderedGroups() {
-        return state.snapshot.data.groups.slice().sort(function (left, right) {
-            return left.order - right.order;
-        });
-    }
 
-    function orderedTodos(groupId) {
-        var todos = state.snapshot.data.todos
-            .filter(function (todo) { return todo.groupId === groupId; })
-            .sort(function (left, right) { return left.order - right.order; });
-        var incomplete = todos.filter(function (todo) { return !todo.completed; });
-        var completed = todos.filter(function (todo) { return todo.completed; });
-        var visibleCompleted = state.snapshot.showCompleted
-            ? completed
-            : completed.filter(function (todo) {
-                return todo.id === state.snapshot.revealedTodoId;
-            });
-        return incomplete.concat(visibleCompleted);
-    }
 
-    function findTodo(todoId) {
-        return state.snapshot && state.snapshot.data.todos.find(function (todo) {
-            return todo.id === todoId;
-        });
-    }
 
-    function findGroup(groupId) {
-        return state.snapshot && state.snapshot.data.groups.find(function (group) {
-            return group.id === groupId;
-        });
-    }
 
-    function renderPriorityOptions(selected) {
-        return ['high', 'medium', 'low'].map(function (priority) {
-            return '<option value="' + priority + '"' + (priority === selected ? ' selected' : '') + '>'
-                + priority.toUpperCase() + '</option>';
-        }).join('');
-    }
 
-    function renderGroupOptions(selected) {
-        return '<option value=""' + (!selected ? ' selected' : '') + '>Inbox</option>'
-            + orderedGroups().map(function (group) {
-            return '<option value="' + escapeHtml(group.id) + '"'
-                + (group.id === selected ? ' selected' : '') + '>'
-                + escapeHtml(group.title) + '</option>';
-        }).join('');
-    }
 
-    function todoClassName(todo) {
-        return 'todo-item steward-item-card todo-priority-' + escapeHtml(todo.priority)
-            + (todo.completed ? ' completed' : '')
-            + (state.selectedTodoId === todo.id ? ' expanded' : '');
-    }
 
-    function renderTodoBody(todo) {
-        var checked = todo.completed ? ' checked' : '';
-        var expanded = state.selectedTodoId === todo.id;
-        var priorityBadge = todo.priority === 'medium'
-            ? ''
-            : '<span class="todo-priority-badge steward-badge">'
-                + escapeHtml(todo.priority.toUpperCase()) + '</span>';
-        return '<span class="todo-item-accent steward-item-accent" aria-hidden="true"></span>'
-            + '<div class="todo-item-view"><div class="todo-item-main">'
-            + '<label class="todo-check"><input type="checkbox" data-action="todo-toggle" data-todo-id="'
-            + escapeHtml(todo.id) + '" aria-label="Complete ' + escapeHtml(todo.title) + '"' + checked + '>'
-            + '<span class="todo-checkbox-visual"></span></label>'
-            + '<div class="todo-item-content"><div class="todo-title-line">'
-            + '<button class="todo-title-button" type="button" data-action="todo-open-detail" data-todo-id="'
-            + escapeHtml(todo.id) + '" aria-expanded="' + (expanded ? 'true' : 'false') + '" title="'
-            + (expanded ? 'Collapse details' : 'Expand details') + '"><span class="todo-title-text">'
-            + escapeHtml(todo.title) + '</span></button>' + priorityBadge + '</div></div>'
-            + '<div class="todo-item-actions">'
-            + '<button class="todo-icon-button steward-icon-button danger" type="button" data-action="todo-delete" '
-            + 'data-todo-id="' + escapeHtml(todo.id) + '" title="Delete todo" aria-label="Delete todo">×</button>'
-            + '<button class="todo-drag-handle todo-icon-button steward-icon-button" type="button" draggable="true" '
-            + 'data-drag-todo-item="' + escapeHtml(todo.id) + '" title="Drag to reorder" aria-label="Drag '
-            + escapeHtml(todo.title) + '">⋮⋮</button></div>'
-            + '</div>' + (expanded ? renderInlineDetail(todo) : '') + '</div>';
-    }
 
-    function renderTodo(todo) {
-        return '<li class="' + todoClassName(todo) + '" data-todo-id="' + escapeHtml(todo.id) + '">'
-            + renderTodoBody(todo) + '</li>';
-    }
 
-    function renderCompose(group) {
-        var groupId = group ? group.id : null;
-        var visible = state.composeGroupId === groupId;
-        var draft = visible && state.composeDraft
-            ? state.composeDraft
-            : { title: '', notes: '', priority: 'medium', groupId: groupId };
-        var groupControl = group
-            ? '<input type="hidden" name="groupId" value="' + escapeHtml(group.id) + '">'
-                + '<span class="todo-compose-group-fixed steward-meta" title="' + escapeHtml(group.title)
-                + '" aria-label="Todo group: ' + escapeHtml(group.title) + '">' + escapeHtml(group.title) + '</span>'
-            : '<select name="groupId" aria-label="Todo group">'
-                + renderGroupOptions(draft.groupId) + '</select>';
-        return '<form class="todo-add-form todo-compose-panel steward-card" data-todo-form="'
-            + (group ? 'quick-add' : 'add') + '"'
-            + (group ? ' data-group-id="' + escapeHtml(group.id) + '"' : '')
-            + (visible ? '' : ' hidden') + '>'
-            + '<div class="todo-compose-primary"><span class="todo-compose-icon">＋</span>'
-            + '<input class="todo-title-input" type="text" name="title" placeholder="'
-            + (group ? 'Add to ' + escapeHtml(group.title) : 'Add a todo') + '" aria-label="Todo title" value="'
-            + escapeHtml(draft.title) + '">'
-            + '</div><textarea class="todo-notes-input" name="notes" rows="2" placeholder="Notes" '
-            + 'aria-label="Todo notes">' + escapeHtml(draft.notes)
-            + '</textarea><div class="todo-form-row todo-compose-meta">'
-            + '<select name="priority" aria-label="Todo priority">'
-            + renderPriorityOptions(draft.priority) + '</select>'
-            + groupControl
-            + '<button class="todo-primary-button steward-button steward-button-primary" type="submit">Add</button>'
-            + '<button class="todo-secondary-button steward-button" type="button" data-action="'
-            + (group ? 'todo-cancel-quick-add' : 'todo-cancel-add') + '">Cancel</button></div></form>';
-    }
 
-    function renderTodoCommandIcon(kind) {
-        if (kind === 'add') {
-            return '<svg viewBox="0 0 512 512"><path d="M416 208H272V64c0-17.67-14.33-32-32-32h-32'
-                + 'c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32'
-                + 'h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33'
-                + ' 32-32v-32c0-17.67-14.33-32-32-32z"></path></svg>';
-        }
-        if (kind === 'group') {
-            return '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" '
-                + 'stroke-linecap="round" stroke-linejoin="round"><path d="m3.5 6 1.5 1.5L7.5 5"></path>'
-                + '<path d="m3.5 12 1.5 1.5 2.5-2.5"></path><path d="m3.5 18 1.5 1.5L7.5 17"></path>'
-                + '<path d="M10.5 6.5h10M10.5 12.5h10M10.5 18.5h10"></path></svg>';
-        }
-        return '<svg viewBox="0 0 448 512"><path d="M64 32C28.7 32 0 60.7 0 96v320c0 35.3 28.7'
-            + ' 64 64 64h320c35.3 0 64-28.7 64-64V96c0-35.3-28.7-64-64-64H64zm88 200h144c13.3 0'
-            + ' 24 10.7 24 24s-10.7 24-24 24H152c-13.3 0-24-10.7-24-24s10.7-24 24-24z"></path></svg>';
-    }
 
-    function renderGroupChevron() {
-        return '<span class="todo-group-chevron collapse-icon" aria-hidden="true">'
-            + '<svg viewBox="0 0 320 512"><path d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 '
-            + '0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 '
-            + '24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 '
-            + '9.4-24.4 9.4-33.8 0z"></path></svg></span>';
-    }
 
-    function getGroupStats(groupId) {
-        var todos = state.snapshot.data.todos.filter(function (todo) {
-            return todo.groupId === groupId;
-        });
-        var incompleteCount = todos.filter(function (todo) { return !todo.completed; }).length;
-        var completedCount = todos.length - incompleteCount;
-        var visibleCompletedCount = orderedTodos(groupId)
-            .filter(function (todo) { return todo.completed; }).length;
-        return {
-            incompleteCount: incompleteCount,
-            completedCount: completedCount,
-            hiddenCompletedCount: completedCount - visibleCompletedCount,
-        };
-    }
 
-    function todoGroupMeta(groupId) {
-        var stats = getGroupStats(groupId);
-        return stats.incompleteCount + ' open'
-            + (state.snapshot.showCompleted && stats.completedCount
-                ? ' · ' + stats.completedCount + ' done'
-                : '');
-    }
 
-    function todoSummaryMeta() {
-        var todos = state.snapshot.data.todos;
-        var incomplete = todos.filter(function (todo) { return !todo.completed; }).length;
-        var completed = todos.length - incomplete;
-        var groupCount = orderedGroups().length;
-        return incomplete + ' open · ' + groupCount + (groupCount === 1 ? ' group' : ' groups')
-            + ' · ' + (state.snapshot.showCompleted ? completed + ' completed shown' : 'completed hidden');
-    }
 
-    function renderGroup(group) {
-        var visibleTodos = orderedTodos(group.id);
-        var stats = getGroupStats(group.id);
-        return '<section class="todo-group group steward-section' + (group.collapsed ? ' collapsed' : '')
-            + '" data-todo-group-id="' + escapeHtml(group.id) + '">'
-            + '<header class="todo-group-header group-title steward-group-header">'
-            + '<div class="todo-group-title-block group-title-text">'
-            + '<button class="todo-group-collapse-button" type="button" data-action="todo-collapse-group" '
-            + 'data-todo-group-id="' + escapeHtml(group.id) + '" aria-expanded="'
-            + (group.collapsed ? 'false' : 'true') + '" aria-label="'
-            + (group.collapsed ? 'Expand ' : 'Collapse ') + escapeHtml(group.title) + '">'
-            + renderGroupChevron() + '</button>'
-            + '<h2 data-drag-todo-group title="' + escapeHtml(group.title) + '">' + escapeHtml(group.title) + '</h2>'
-            + '<span class="todo-group-count">' + todoGroupMeta(group.id) + '</span></div>'
-            + '<div class="todo-group-actions group-actions right">'
-            + '<button class="todo-group-action" type="button" data-action="todo-quick-add" data-group-id="'
-            + escapeHtml(group.id) + '" title="Add todo to group" aria-label="Add todo to '
-            + escapeHtml(group.title) + '">＋</button>'
-            + '<button class="todo-group-action" type="button" data-action="todo-sort-priority" data-group-id="'
-            + escapeHtml(group.id) + '" title="Sort by priority" aria-label="Sort by priority">⇅</button>'
-            + '<button class="todo-group-action" type="button" data-action="todo-rename-group" data-group-id="'
-            + escapeHtml(group.id) + '" title="Rename todo group" aria-label="Rename todo group">✎</button>'
-            + '<button class="todo-group-action danger" type="button" data-action="todo-delete-group" data-group-id="'
-            + escapeHtml(group.id) + '" title="Delete todo group" aria-label="Delete todo group">×</button>'
-            + '</div></header>' + renderCompose(group)
-            + (visibleTodos.length
-                ? '<ul class="todo-list">' + visibleTodos.map(renderTodo).join('') + '</ul>'
-                : '<p class="todo-group-empty">No visible todos</p>')
-            + (stats.hiddenCompletedCount > 0
-                ? '<p class="todo-hidden-completed">' + stats.hiddenCompletedCount + ' completed hidden</p>'
-                : '')
-            + '</section>';
-    }
 
-    function renderGlobalCompose() {
-        return renderCompose(null);
-    }
 
-    function renderListSurface() {
-        var groups = orderedGroups();
-        return '<div class="todo-list-surface">'
-            + '<header class="todo-page-header todo-page-command-bar">'
-            + '<div class="todo-summary-copy"><strong>TODO</strong>'
-            + '<span class="todo-summary-meta steward-meta">' + todoSummaryMeta() + '</span></div>'
-            + '<div class="todo-summary-actions group-actions right">'
-            + '<button class="todo-square-button steward-icon-button" type="button" data-action="todo-add" '
-            + 'title="Add todo" aria-label="Add todo">' + renderTodoCommandIcon('add') + '</button>'
-            + '<button class="todo-square-button steward-icon-button" type="button" data-action="todo-add-group" '
-            + 'title="Add group" aria-label="Add group">' + renderTodoCommandIcon('group') + '</button>'
-            + '<label class="todo-square-toggle steward-icon-button'
-            + (state.snapshot.showCompleted ? ' active' : '') + '" title="Show completed" aria-label="Show completed">'
-            + '<input type="checkbox" data-action="todo-toggle-show-completed"'
-            + (state.snapshot.showCompleted ? ' checked' : '') + '><span>'
-            + renderTodoCommandIcon('completed') + '</span></label>'
-            + '</div></header>' + renderGlobalCompose()
-            + (groups.length
-                ? '<div class="todo-groups">' + groups.map(renderGroup).join('') + '</div>'
-                : '<p class="todo-empty-state steward-empty-state">No todos yet</p>')
-            + '</div>';
-    }
 
-    function detailDraft(todo) {
-        return state.draft || {
-            title: todo.title,
-            notes: todo.notes || '',
-            priority: todo.priority,
-            groupId: todo.groupId,
-        };
-    }
 
-    function renderInlineDetail(todo) {
-        var group = findGroup(todo.groupId);
-        var groupName = group ? group.title : 'Unknown group';
-        if (state.draft) {
-            var draft = detailDraft(todo);
-            return '<form class="todo-inline-detail todo-detail-edit-form" data-todo-form="detail-edit" '
-                + 'aria-label="Edit ' + escapeHtml(todo.title) + '" '
-                + 'data-todo-id="' + escapeHtml(todo.id) + '">'
-                + '<label class="todo-field-label">Title</label>'
-                + '<textarea class="todo-title-input" name="title" rows="3" aria-label="Todo title">'
-                + escapeHtml(draft.title) + '</textarea>'
-                + '<label class="todo-field-label">Notes</label>'
-                + '<textarea class="todo-notes-input" name="notes" rows="8" aria-label="Todo notes">'
-                + escapeHtml(draft.notes) + '</textarea>'
-                + '<label class="todo-field-label">Priority</label><select name="priority" aria-label="Todo priority">'
-                + renderPriorityOptions(draft.priority) + '</select>'
-                + '<label class="todo-field-label">Group</label><select name="groupId" aria-label="Todo group">'
-                + renderGroupOptions(draft.groupId) + '</select>'
-                + '<div class="todo-detail-actions"><button class="todo-primary-button steward-button '
-                + 'steward-button-primary" type="submit">Save</button>'
-                + '<button class="todo-secondary-button steward-button" type="button" '
-                + 'data-action="todo-cancel-detail-edit">Cancel</button></div></form>';
-        }
-        return '<section class="todo-inline-detail" role="region" aria-label="Details for '
-            + escapeHtml(todo.title) + '">'
-            + '<div class="todo-inline-row"><span class="todo-inline-label">Notes</span>'
-            + '<p class="todo-inline-value todo-detail-notes">' + escapeHtml(todo.notes || 'No notes') + '</p></div>'
-            + '<div class="todo-inline-row"><span class="todo-inline-label">Group</span>'
-            + '<span class="todo-inline-value">' + escapeHtml(groupName) + '</span></div>'
-            + '<div class="todo-inline-row"><span class="todo-inline-label">Priority</span>'
-            + '<span class="todo-inline-value">' + escapeHtml(todo.priority.toUpperCase()) + '</span></div>'
-            + '<div class="todo-inline-row"><span class="todo-inline-label">Created</span>'
-            + '<span class="todo-inline-value">' + escapeHtml(String(todo.createdAt || '').slice(0, 10)) + '</span></div>'
-            + '<div class="todo-inline-row"><span class="todo-inline-label">Updated</span>'
-            + '<span class="todo-inline-value">' + escapeHtml(String(todo.updatedAt || '').slice(0, 10)) + '</span></div>'
-            + (todo.completedAt
-                ? '<div class="todo-inline-row"><span class="todo-inline-label">Completed</span>'
-                    + '<span class="todo-inline-value">'
-                    + escapeHtml(String(todo.completedAt).slice(0, 10)) + '</span></div>'
-                : '')
-            + '<div class="todo-detail-actions">'
-            + '<button class="todo-primary-button steward-button" type="button" data-action="todo-toggle-detail" '
-            + 'data-todo-id="' + escapeHtml(todo.id) + '">' + (todo.completed ? 'Reopen' : 'Complete') + '</button>'
-            + '<button class="todo-secondary-button steward-button" type="button" data-action="todo-edit-detail">Edit</button>'
-            + '<button class="todo-secondary-button steward-button danger" type="button" data-action="todo-delete" '
-            + 'data-todo-id="' + escapeHtml(todo.id) + '">Delete</button>'
-            + '</div></section>';
-    }
 
-    function renderUndo() {
-        if (!state.undo) {
-            return '<div class="todo-undo-region" role="status" aria-live="polite" hidden></div>';
-        }
-        return '<div class="todo-undo-region" role="status" aria-live="polite" style="display:flex">'
-            + '<span>' + escapeHtml(state.undo.label) + '</span>'
-            + '<button class="todo-primary-button steward-button" type="button" data-action="todo-undo">Undo</button></div>';
-    }
 
     function syncTodoListExpandedHeights() {
         if (!root || !root.querySelectorAll) {
@@ -454,11 +154,11 @@ function initTodos(options) {
         if (!root || !isSnapshot(state.snapshot)) {
             return false;
         }
-        if (state.selectedTodoId && !findTodo(state.selectedTodoId)) {
+        if (state.selectedTodoId && !renderer.findTodo(state.selectedTodoId)) {
             state.selectedTodoId = null;
             state.draft = null;
         }
-        var surfaceHtml = renderListSurface();
+        var surfaceHtml = renderer.renderListSurface();
         if (!force && surfaceHtml === state.renderedSurfaceHtml) {
             updateFeedback();
             return false;
@@ -470,7 +170,7 @@ function initTodos(options) {
             surface.outerHTML = surfaceHtml;
         } else {
             root.innerHTML = surfaceHtml
-                + renderUndo()
+                + renderer.renderUndo()
                 + '<div class="todo-live-region" role="status" aria-live="polite" aria-atomic="true">'
                 + escapeHtml(state.announcement) + '</div>';
         }
@@ -495,7 +195,7 @@ function initTodos(options) {
         });
         for (var index = 0; index < uniqueTodoIds.length; index += 1) {
             var todoId = uniqueTodoIds[index];
-            var todo = findTodo(todoId);
+            var todo = renderer.findTodo(todoId);
             var selector = '.todo-item[data-todo-id="' + String(todoId).replace(/"/g, '\\"') + '"]';
             var item = root.querySelector(selector);
             if (!todo || !item || typeof item.innerHTML !== 'string') {
@@ -505,10 +205,10 @@ function initTodos(options) {
             patches.push({ item: item, todo: todo });
         }
         patches.forEach(function (patch) {
-            patch.item.className = todoClassName(patch.todo);
-            patch.item.innerHTML = renderTodoBody(patch.todo);
+            patch.item.className = renderer.todoClassName(patch.todo);
+            patch.item.innerHTML = renderer.renderTodoBody(patch.todo);
         });
-        state.renderedSurfaceHtml = renderListSurface();
+        state.renderedSurfaceHtml = renderer.renderListSurface();
         syncTodoListExpandedHeights();
         refreshTodoLayoutObserverTargets();
         updateFeedback();
@@ -519,8 +219,8 @@ function initTodos(options) {
         if (!root || !root.querySelector) {
             return false;
         }
-        var todo = findTodo(todoId);
-        var group = todo ? findGroup(todo.groupId) : null;
+        var todo = renderer.findTodo(todoId);
+        var group = todo ? renderer.findGroup(todo.groupId) : null;
         var itemSelector = '.todo-item[data-todo-id="' + String(todoId).replace(/"/g, '\\"') + '"]';
         var groupSelector = group
             ? '.todo-group[data-todo-group-id="' + String(group.id).replace(/"/g, '\\"') + '"]'
@@ -539,7 +239,7 @@ function initTodos(options) {
             return false;
         }
 
-        var visibleTodos = orderedTodos(group.id);
+        var visibleTodos = renderer.orderedTodos(group.id);
         var visibleIndex = visibleTodos.findIndex(function (candidate) {
             return candidate.id === todoId;
         });
@@ -550,8 +250,8 @@ function initTodos(options) {
         }
         item.hidden = !remainsVisible;
         if (remainsVisible) {
-            item.className = todoClassName(todo);
-            item.innerHTML = renderTodoBody(todo);
+            item.className = renderer.todoClassName(todo);
+            item.innerHTML = renderer.renderTodoBody(todo);
             var nextTodo = visibleTodos[visibleIndex + 1];
             var nextItem = nextTodo && list.querySelector
                 ? list.querySelector('.todo-item[data-todo-id="'
@@ -564,9 +264,9 @@ function initTodos(options) {
             }
         }
 
-        summaryMeta.textContent = todoSummaryMeta();
-        groupCount.textContent = todoGroupMeta(group.id);
-        var stats = getGroupStats(group.id);
+        summaryMeta.textContent = renderer.todoSummaryMeta();
+        groupCount.textContent = renderer.todoGroupMeta(group.id);
+        var stats = renderer.getGroupStats(group.id);
         var hiddenCompleted = groupElement.querySelector('.todo-hidden-completed');
         if (hiddenCompleted) {
             hiddenCompleted.hidden = stats.hiddenCompletedCount === 0;
@@ -586,7 +286,7 @@ function initTodos(options) {
         } else if (!visibleTodos.length && list.insertAdjacentHTML) {
             list.insertAdjacentHTML('afterend', '<p class="todo-group-empty">No visible todos</p>');
         }
-        state.renderedSurfaceHtml = renderListSurface();
+        state.renderedSurfaceHtml = renderer.renderListSurface();
         syncTodoListExpandedHeights();
         refreshTodoLayoutObserverTargets();
         updateFeedback();
@@ -601,7 +301,7 @@ function initTodos(options) {
         var patches = [];
         for (var index = 0; index < groupIds.length; index += 1) {
             var groupId = groupIds[index];
-            var group = findGroup(groupId);
+            var group = renderer.findGroup(groupId);
             var selector = '.todo-group[data-todo-group-id="' + String(groupId).replace(/"/g, '\\"') + '"]';
             var groupElement = root.querySelector(selector);
             var button = groupElement && groupElement.querySelector
@@ -619,7 +319,7 @@ function initTodos(options) {
             patch.button.setAttribute('aria-label',
                 (patch.group.collapsed ? 'Expand ' : 'Collapse ') + patch.group.title);
         });
-        state.renderedSurfaceHtml = renderListSurface();
+        state.renderedSurfaceHtml = renderer.renderListSurface();
         updateFeedback();
         return true;
     }
@@ -757,12 +457,12 @@ function initTodos(options) {
     }
 
     function isTodoRendered(todoId) {
-        var todo = findTodo(todoId);
-        var group = todo && findGroup(todo.groupId);
+        var todo = renderer.findTodo(todoId);
+        var group = todo && renderer.findGroup(todo.groupId);
         return !!todo
             && !!group
             && !group.collapsed
-            && orderedTodos(group.id).some(function (candidate) {
+            && renderer.orderedTodos(group.id).some(function (candidate) {
                 return candidate.id === todoId;
             });
     }
@@ -772,14 +472,14 @@ function initTodos(options) {
             return false;
         }
         if (typeof composeGroupId === 'string') {
-            return !!findGroup(composeGroupId);
+            return !!renderer.findGroup(composeGroupId);
         }
         if (composeGroupId !== null) {
             return false;
         }
         return typeof composeDraft.groupId !== 'string'
             || composeDraft.groupId.length === 0
-            || !!findGroup(composeDraft.groupId);
+            || !!renderer.findGroup(composeDraft.groupId);
     }
 
     function reconcileTodoRefreshState(local) {
@@ -925,12 +625,12 @@ function initTodos(options) {
     }
 
     function openDetail(todoId) {
-        var todo = findTodo(todoId);
+        var todo = renderer.findTodo(todoId);
         if (!todo) {
             return false;
         }
-        var group = findGroup(todo.groupId);
-        var rendered = orderedTodos(todo.groupId).some(function (item) {
+        var group = renderer.findGroup(todo.groupId);
+        var rendered = renderer.orderedTodos(todo.groupId).some(function (item) {
             return item.id === todoId;
         });
         if (!rendered || (group && group.collapsed)) {
@@ -975,7 +675,7 @@ function initTodos(options) {
 
     function optimisticMutation(action, payload) {
         if (action === 'complete') {
-            var completedTodo = findTodo(payload.todoId);
+            var completedTodo = renderer.findTodo(payload.todoId);
             if (completedTodo) {
                 completedTodo.completed = payload.completed === true;
                 completedTodo.completedAt = payload.completed ? new Date().toISOString() : undefined;
@@ -989,7 +689,7 @@ function initTodos(options) {
                 state.draft = null;
             }
         } else if (action === 'collapse-group') {
-            var group = findGroup(payload.groupId);
+            var group = renderer.findGroup(payload.groupId);
             if (group) {
                 group.collapsed = payload.collapsed === true;
             }
@@ -1000,7 +700,7 @@ function initTodos(options) {
         } else if (action === 'show-completed') {
             state.snapshot.showCompleted = payload.showCompleted === true;
         } else if (action === 'update') {
-            var updated = findTodo(payload.todoId);
+            var updated = renderer.findTodo(payload.todoId);
             if (updated) {
                 ['title', 'notes', 'priority', 'groupId'].forEach(function (key) {
                     if (payload[key] !== undefined) {
@@ -1010,14 +710,14 @@ function initTodos(options) {
             }
         } else if (action === 'reorder-items' && Array.isArray(payload.todoIds)) {
             payload.todoIds.forEach(function (todoId, index) {
-                var todo = findTodo(todoId);
+                var todo = renderer.findTodo(todoId);
                 if (todo && todo.groupId === payload.groupId) {
                     todo.order = index;
                 }
             });
         } else if (action === 'reorder-groups' && Array.isArray(payload.groupIds)) {
             payload.groupIds.forEach(function (groupId, index) {
-                var reorderedGroup = findGroup(groupId);
+                var reorderedGroup = renderer.findGroup(groupId);
                 if (reorderedGroup) {
                     reorderedGroup.order = index;
                 }
@@ -1055,7 +755,7 @@ function initTodos(options) {
         } else if (action === 'collapse-groups') {
             patchGroupElements(state.snapshot.data.groups.map(function (group) { return group.id; }));
         } else if (action === 'reorder-items' || action === 'reorder-groups') {
-            state.renderedSurfaceHtml = renderListSurface();
+            state.renderedSurfaceHtml = renderer.renderListSurface();
             updateFeedback();
         } else {
             render();
@@ -1319,14 +1019,14 @@ function initTodos(options) {
         } else if (action === 'todo-back') {
             backToList();
         } else if (action === 'todo-edit-detail') {
-            var todo = findTodo(state.selectedTodoId);
-            state.draft = todo ? detailDraft(todo) : null;
+            var todo = renderer.findTodo(state.selectedTodoId);
+            state.draft = todo ? renderer.detailDraft(todo) : null;
             patchTodoElements([state.selectedTodoId]);
         } else if (action === 'todo-cancel-detail-edit') {
             state.draft = null;
             patchTodoElements([state.selectedTodoId]);
         } else if (action === 'todo-toggle-detail') {
-            var detailTodo = findTodo(todoId);
+            var detailTodo = renderer.findTodo(todoId);
             if (detailTodo) dispatch('complete', { todoId: todoId, completed: !detailTodo.completed });
         } else if (action === 'todo-delete') {
             dispatch('delete', { todoId: todoId });
@@ -1358,7 +1058,7 @@ function initTodos(options) {
             render();
             focusCompose(groupId);
         } else if (action === 'todo-collapse-group') {
-            var group = findGroup(groupId);
+            var group = renderer.findGroup(groupId);
             if (group) dispatch('collapse-group', { groupId: groupId, collapsed: !group.collapsed });
         } else if (action === 'todo-sort-priority') {
             dispatch('sort-priority', { groupId: groupId });
@@ -1420,7 +1120,7 @@ function initTodos(options) {
             && field.closest('.todo-detail-edit-form')
             && (name === 'title' || name === 'notes' || name === 'priority' || name === 'groupId')) {
             state.draft[name] = String(field.value || '');
-            state.renderedSurfaceHtml = renderListSurface();
+            state.renderedSurfaceHtml = renderer.renderListSurface();
             return;
         }
         var composeForm = field.closest('.todo-add-form[data-todo-form]');
@@ -1429,7 +1129,7 @@ function initTodos(options) {
             && (name === 'title' || name === 'notes' || name === 'priority' || name === 'groupId')) {
             state.composeRequestId = null;
             state.composeDraft[name] = String(field.value || '');
-            state.renderedSurfaceHtml = renderListSurface();
+            state.renderedSurfaceHtml = renderer.renderListSurface();
         }
     }
 

--- a/tests/browser/dashboardRefreshStability.test.js
+++ b/tests/browser/dashboardRefreshStability.test.js
@@ -40,6 +40,9 @@ const dashboardValidationScript = fs.readFileSync(
 const dashboardSearchScript = fs.readFileSync(
     path.join(__dirname, '../../src/webview/webviewDashboardSearchScripts.js'), 'utf8'
 );
+const todoRenderScript = fs.readFileSync(
+    path.join(__dirname, '../../src/webview/webviewTodoRenderScripts.js'), 'utf8'
+);
 const todoScript = fs.readFileSync(
     path.join(__dirname, '../../src/webview/webviewTodoScripts.js'), 'utf8'
 );
@@ -226,6 +229,7 @@ async function openDashboardPage(t) {
     await page.addScriptTag({ content: dashboardValidationScript });
     await page.addScriptTag({ content: dashboardSearchScript });
     await page.addScriptTag({ content: dashboardScript });
+    await page.addScriptTag({ content: todoRenderScript });
     await page.addScriptTag({ content: todoScript });
     await page.evaluate(() => {
         window.__todos = initTodos({

--- a/tests/browser/todoCreation.test.js
+++ b/tests/browser/todoCreation.test.js
@@ -44,6 +44,10 @@ const projectScript = fs.readFileSync(
     path.join(__dirname, '../../src/webview/webviewProjectScripts.js'),
     'utf8'
 );
+const todoRenderScript = fs.readFileSync(
+    path.join(__dirname, '../../src/webview/webviewTodoRenderScripts.js'),
+    'utf8'
+);
 const todoScript = fs.readFileSync(
     path.join(__dirname, '../../src/webview/webviewTodoScripts.js'),
     'utf8'
@@ -94,6 +98,7 @@ test('TODO-SINGLE-CREATE-DISPATCH-001 submits one group composer through only th
     await page.addScriptTag({ content: projectAiUpdateScript });
     await page.addScriptTag({ content: aiSessionControlsScript });
     await page.addScriptTag({ content: projectScript });
+    await page.addScriptTag({ content: todoRenderScript });
     await page.addScriptTag({ content: todoScript });
     await page.evaluate(value => {
         initProjects();

--- a/tests/browser/todoLayout.test.js
+++ b/tests/browser/todoLayout.test.js
@@ -10,6 +10,10 @@ const { buildTodoViewModel } = require('../../out/todos/viewModel');
 
 const NOW = '2026-07-24T00:00:00.000Z';
 const styles = fs.readFileSync(path.join(__dirname, '../../media/styles.css'), 'utf8');
+const todoRenderScript = fs.readFileSync(
+    path.join(__dirname, '../../src/webview/webviewTodoRenderScripts.js'),
+    'utf8'
+);
 const todoScript = fs.readFileSync(
     path.join(__dirname, '../../src/webview/webviewTodoScripts.js'),
     'utf8'
@@ -72,6 +76,7 @@ test('TODO-BROWSER-EXPANDED-LAYOUT-001 gives an expanded card its full Chromium 
                 <section id="todo-host">${panel}</section>
             </body>
         </html>`);
+    await page.addScriptTag({ content: todoRenderScript });
     await page.addScriptTag({ content: todoScript });
     await page.evaluate(value => {
         window.vscode = { postMessage() {} };

--- a/tests/integration/dashboard/todoContent.test.js
+++ b/tests/integration/dashboard/todoContent.test.js
@@ -11,6 +11,10 @@ const {
 const { buildTodoViewModel } = require('../../../out/todos/viewModel');
 
 const NOW = '2026-07-24T00:00:00.000Z';
+const todoRenderScript = fs.readFileSync(
+    path.join(__dirname, '../../../src/webview/webviewTodoRenderScripts.js'),
+    'utf8'
+);
 const todoScript = fs.readFileSync(
     path.join(__dirname, '../../../src/webview/webviewTodoScripts.js'),
     'utf8'
@@ -131,14 +135,14 @@ test('TODO-PAGE-HIERARCHY-001 separates the page command bar from real group hea
     assert.match(errorPageHeader, /todo-page-command-bar/);
     assert.doesNotMatch(errorPageHeader, /(?:group-title|steward-group-header)/);
     assert.match(html, /class="todo-group-header group-title steward-group-header"/);
-    assert.match(todoScript, /todo-page-header todo-page-command-bar/);
-    assert.doesNotMatch(todoScript, /todo-page-header group-title steward-group-header/);
+    assert.match(todoRenderScript, /todo-page-header todo-page-command-bar/);
+    assert.doesNotMatch(todoRenderScript, /todo-page-header group-title steward-group-header/);
     assert.equal((pageHeaderMarkup.match(/<svg /g) || []).length, 3);
-    assert.match(todoScript, /aria-label="Add todo">'\s*\+\s*renderTodoCommandIcon\('add'\)/);
-    assert.match(todoScript, /aria-label="Add group">'\s*\+\s*renderTodoCommandIcon\('group'\)/);
-    assert.match(todoScript, /<span>'\s*\+\s*renderTodoCommandIcon\('completed'\)/);
-    assert.doesNotMatch(todoScript, /aria-label="Add todo">＋<\/button>/);
-    assert.doesNotMatch(todoScript, /aria-label="Add group">☷<\/button>/);
+    assert.match(todoRenderScript, /aria-label="Add todo">'\s*\+\s*renderTodoCommandIcon\('add'\)/);
+    assert.match(todoRenderScript, /aria-label="Add group">'\s*\+\s*renderTodoCommandIcon\('group'\)/);
+    assert.match(todoRenderScript, /<span>'\s*\+\s*renderTodoCommandIcon\('completed'\)/);
+    assert.doesNotMatch(todoRenderScript, /aria-label="Add todo">＋<\/button>/);
+    assert.doesNotMatch(todoRenderScript, /aria-label="Add group">☷<\/button>/);
     assert.match(styles, /\.todo-page-command-bar\s*\{[^}]*border:\s*0[^}]*background:\s*transparent/);
     assert.match(styles, /\.todo-page-command-bar \.todo-summary-actions\s*\{[^}]*opacity:\s*1[^}]*pointer-events:\s*all/);
     assert.match(styles, /\.todo-page-command-bar \.todo-summary-actions svg\s*\{[^}]*width:\s*14px[^}]*height:\s*14px/);
@@ -166,8 +170,8 @@ test('TODO-GROUP-DISCLOSURE-001 uses one centered SVG chevron with distinct expa
     const html = renderPanel();
 
     assert.match(html, /class="todo-group-chevron collapse-icon"[\s\S]*<svg/);
-    assert.match(todoScript, /class="todo-group-chevron collapse-icon"[\s\S]*<svg/);
-    assert.doesNotMatch(todoScript, /<span class="collapse-icon"[^>]*>⌄<\/span>/);
+    assert.match(todoRenderScript, /class="todo-group-chevron collapse-icon"[\s\S]*<svg/);
+    assert.doesNotMatch(todoRenderScript, /<span class="collapse-icon"[^>]*>⌄<\/span>/);
     assert.match(styles, /\.todo-group-chevron\s*\{[\s\S]*display:\s*grid[\s\S]*place-items:\s*center/);
     assert.match(styles, /\.todo-group\.collapsed \.todo-group-chevron svg\s*\{[\s\S]*transform:\s*rotate\(-90deg\)/);
 });

--- a/tests/integration/dashboard/todoInteraction.test.js
+++ b/tests/integration/dashboard/todoInteraction.test.js
@@ -6,6 +6,10 @@ const path = require('node:path');
 const test = require('node:test');
 const vm = require('node:vm');
 
+const renderSource = fs.readFileSync(
+    path.join(__dirname, '../../../src/webview/webviewTodoRenderScripts.js'),
+    'utf8'
+);
 const source = fs.readFileSync(
     path.join(__dirname, '../../../src/webview/webviewTodoScripts.js'),
     'utf8'
@@ -239,7 +243,7 @@ function createHarness(options = {}) {
             },
         },
     };
-    vm.runInNewContext(source, context, { filename: 'webviewTodoScripts.js' });
+    vm.runInNewContext(`${renderSource}\n${source}`, context, { filename: 'webviewTodoScripts.js' });
     const controller = context.initTodos({
         postMessage: message => messages.push(JSON.parse(JSON.stringify(message))),
         replaceSearchCatalog: catalog => catalogs.push(JSON.parse(JSON.stringify(catalog))),

--- a/tests/integration/dashboard/webviewState.test.js
+++ b/tests/integration/dashboard/webviewState.test.js
@@ -46,6 +46,8 @@ const projectVmSource = `${viewStateSource}\n${workspaceUpdateSource}\n${todoGro
 const scrollStateSource = fs.readFileSync(path.join(root, 'src', 'webview', 'webviewScrollStateScripts.js'), 'utf8');
 const promptSource = fs.readFileSync(path.join(root, 'src', 'webview', 'webviewPromptScripts.js'), 'utf8');
 const generatedPromptPath = path.join(root, 'media', 'webviewPromptScripts.js');
+const todoRenderSource = fs.readFileSync(path.join(root, 'src', 'webview', 'webviewTodoRenderScripts.js'), 'utf8');
+const generatedTodoRenderSource = fs.readFileSync(path.join(root, 'media', 'webviewTodoRenderScripts.js'), 'utf8');
 const dndSource = fs.readFileSync(path.join(root, 'src', 'webview', 'webviewDnDScripts.js'), 'utf8');
 const NOW = '2026-07-23T00:00:00.000Z';
 
@@ -704,6 +706,13 @@ test('WEBVIEW-WEBVIEW-CONTENT-001 keeps the generated Dashboard controller byte-
     assert.equal(generatedDashboardSource, dashboardSource);
 });
 
+test('WEBVIEW-TODO-RENDER-001 keeps the generated TODO renderer byte-identical to source', () => {
+    assert.equal(generatedTodoRenderSource, todoRenderSource);
+    assert.match(todoRenderSource, /function createTodoRenderer\(options\)/);
+    assert.match(todoRenderSource, /function renderTodoBody\(todo\)/);
+    assert.match(todoRenderSource, /function renderListSurface\(\)/);
+});
+
 test('ACTIVE-SESSION-ICON-ANIMATION-001 renders effects only for running Active Session rows', () => {
     const surface = {
         id: 'active-session-icons',
@@ -941,6 +950,7 @@ test('WEBVIEW-RESOURCE-RECOVERY-001 gives every rendered document fresh versione
         'webviewDashboardSearchScripts.js',
         'webviewDashboardScripts.js',
         'webviewPromptScripts.js',
+        'webviewTodoRenderScripts.js',
         'webviewTodoScripts.js',
         'webviewDnDScripts.js',
         'webviewFilterScripts.js',


### PR DESCRIPTION
## Summary

Second slice of the webview tier-1 cleanup, applying the initProjects factory playbook to `webviewTodoScripts.js` (1473 lines):

- New `webviewTodoRenderScripts.js` (345 lines): `createTodoRenderer(options)` factory owning the 19 state-reading HTML render functions (`orderedTodos`, `findTodo`, `renderTodoBody`, `renderListSurface`, `renderUndo`, ...), with `state` passed by identity, plus five pure helpers (`escapeHtml`, `clone`, `isSnapshot`, `renderTodoCommandIcon`, `renderGroupChevron`) as top-level functions.
- `webviewTodoScripts.js` is now 1173 lines of DOM/event core (`initTodos`), calling the renderer through the `renderer` handle (11-function API).
- Function bodies moved verbatim (diff-verified); call-site renames limited to the 11 API entries. Loads ahead of `webviewTodoScripts.js` in the webview HTML and every vm/browser harness; packaging, ignore rules, byte-identity, and load-order guards updated to match.

No behavior change.

## Verification

- Full local gate suite green (compile, unit, integration, dashboard webview checks, safety suites, architecture guards, performance baseline, browser, behavior contracts, lint, changed coverage 100% 7/7, release packaging).
- media/ copies byte-identical to src/webview/.

## Skill harvest

none — the established factory extraction playbook and registration checklist covered this round; no skill change justified.