### PR TITLE
refactor: extract the prompt protocol helpers out of webviewPromptScripts.js

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -41,6 +41,7 @@ media/brand/**
 !media/webviewProjectsPanelScripts.js
 !media/webviewDashboardValidationScripts.js
 !media/webviewDashboardSearchScripts.js
+!media/webviewPromptProtocolScripts.js
 !media/webviewPromptScripts.js
 !media/webviewTodoRenderScripts.js
 !media/webviewTodoScripts.js

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "50149e75f12f8b886e074ec3edea164697ecc5e8",
+        "head": "601d080c79f196d331dd468ea409b7d215c6056c",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -999,7 +999,8 @@
                 "cf89c6b1ffaf8f2b1383f58cd80dd6eb151a9875",
                 "c504d556cda783a5ef2e686d5474d323d5871898",
                 "42f36435479b6e2fd1083508f01afb7e2263b5c1",
-                "4ee4569c7cfd599eed7589e46945b76634de7775"
+                "4ee4569c7cfd599eed7589e46945b76634de7775",
+                "601d080c79f196d331dd468ea409b7d215c6056c"
             ],
             "behaviors": [
                 "PERSIST-AI-PROMPT-STORE-001",

--- a/media/webviewPromptProtocolScripts.js
+++ b/media/webviewPromptProtocolScripts.js
@@ -1,0 +1,340 @@
+var PROMPT_VERSION = 1;
+
+var PROMPT_TARGET = 'global-prompt-library';
+
+var MAX_REQUEST_ID_LENGTH = 128;
+
+var OPERATIONS = new Set([
+    'create',
+    'update',
+    'delete',
+    'reorder',
+    'select-default',
+]);
+
+var ERROR_CODES = new Set([
+    'invalid',
+    'not-found',
+    'conflict',
+    'storage',
+    'settings-write-conflict',
+    'unsupported-version',
+    'cancelled',
+]);
+
+var INSERT_ERROR_CODES = new Set([
+    'no-active-terminal',
+    'prompt-unavailable',
+    'prompt-not-found',
+    'terminal-unavailable',
+]);
+
+function clonePromptValue(value) {
+    if (value === null || value === undefined) {
+        return value;
+    }
+    return JSON.parse(JSON.stringify(value));
+}
+
+function correlationKey(message) {
+    return [
+        message.version,
+        message.requestId,
+        message.target,
+        message.operation,
+    ].join(':');
+}
+
+function insertCorrelationKey(message) {
+    return [
+        message.version,
+        message.requestId,
+        message.target,
+        'insert-terminal',
+    ].join(':');
+}
+
+function hasExactKeys(value, requiredKeys, optionalKeys) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return false;
+    }
+    var allowedKeys = requiredKeys.concat(optionalKeys || []);
+    var keys = Object.keys(value);
+    return requiredKeys.every(function (key) {
+        return Object.prototype.hasOwnProperty.call(value, key);
+    }) && keys.every(function (key) {
+        return allowedKeys.indexOf(key) >= 0;
+    });
+}
+
+function isRequestId(value) {
+    return typeof value === 'string'
+        && value.length > 0
+        && value.length <= MAX_REQUEST_ID_LENGTH;
+}
+
+function isAuthoritySequence(value) {
+    return Number.isSafeInteger(value) && value > 0;
+}
+
+function isPromptSnapshot(snapshot) {
+    if (!hasExactKeys(
+        snapshot,
+        ['version', 'revision', 'selectedPromptId', 'prompts'],
+        ['readOnlyReason']
+    )
+        || snapshot.version !== PROMPT_VERSION
+        || !Number.isSafeInteger(snapshot.revision)
+        || snapshot.revision < 0
+        || (snapshot.selectedPromptId !== null
+            && (typeof snapshot.selectedPromptId !== 'string'
+                || snapshot.selectedPromptId.length === 0))
+        || !Array.isArray(snapshot.prompts)
+        || (snapshot.readOnlyReason !== undefined
+            && snapshot.readOnlyReason !== 'invalid-data'
+            && snapshot.readOnlyReason !== 'unsupported-version')) {
+        return false;
+    }
+
+    var ids = new Set();
+    var names = new Set();
+    for (var prompt of snapshot.prompts) {
+        if (!hasExactKeys(prompt, ['id', 'name', 'text'])
+            || typeof prompt.id !== 'string'
+            || prompt.id.length === 0
+            || typeof prompt.name !== 'string'
+            || prompt.name.trim().length === 0
+            || typeof prompt.text !== 'string'
+            || prompt.text.trim().length === 0
+            || ids.has(prompt.id)
+            || names.has(prompt.name.toLowerCase())) {
+            return false;
+        }
+        ids.add(prompt.id);
+        names.add(prompt.name.toLowerCase());
+    }
+    return snapshot.selectedPromptId === null || ids.has(snapshot.selectedPromptId);
+}
+
+function isCommandResult(message) {
+    return hasExactKeys(message, [
+        'type',
+        'version',
+        'authoritySequence',
+        'requestId',
+        'target',
+        'operation',
+        'success',
+        'snapshot',
+        'html',
+    ], ['errorCode'])
+        && message.type === 'prompt-command-result'
+        && message.version === PROMPT_VERSION
+        && isAuthoritySequence(message.authoritySequence)
+        && isRequestId(message.requestId)
+        && message.target === PROMPT_TARGET
+        && OPERATIONS.has(message.operation)
+        && typeof message.success === 'boolean'
+        && isPromptSnapshot(message.snapshot)
+        && typeof message.html === 'string'
+        && (message.success
+            ? message.errorCode === undefined
+            : ERROR_CODES.has(message.errorCode));
+}
+
+function isInsertResult(message) {
+    return hasExactKeys(message, [
+        'type',
+        'version',
+        'requestId',
+        'target',
+        'success',
+        'errorCode',
+    ])
+        && message.type === 'prompt-insert-terminal-result'
+        && message.version === PROMPT_VERSION
+        && isRequestId(message.requestId)
+        && message.target === PROMPT_TARGET
+        && typeof message.success === 'boolean'
+        && (message.success
+            ? message.errorCode === null
+            : INSERT_ERROR_CODES.has(message.errorCode));
+}
+
+function isRefresh(message) {
+    return hasExactKeys(message, [
+        'type',
+        'version',
+        'authoritySequence',
+        'target',
+        'snapshot',
+        'html',
+    ])
+        && message.type === 'prompt-panel-updated'
+        && message.version === PROMPT_VERSION
+        && isAuthoritySequence(message.authoritySequence)
+        && message.target === PROMPT_TARGET
+        && isPromptSnapshot(message.snapshot)
+        && typeof message.html === 'string';
+}
+
+function readSurfaceRevision(surface) {
+    if (!surface || typeof surface.getAttribute !== 'function') {
+        return null;
+    }
+    var value = surface.getAttribute('data-prompt-revision');
+    if (typeof value !== 'string' || !/^(0|[1-9]\d*)$/.test(value)) {
+        return null;
+    }
+    var revision = Number(value);
+    return Number.isSafeInteger(revision) ? revision : null;
+}
+
+function mutationAnnouncement(operation) {
+    if (operation === 'create') return 'Saving new Prompt…';
+    if (operation === 'update') return 'Saving Prompt changes…';
+    if (operation === 'delete') return 'Waiting for Prompt deletion confirmation…';
+    if (operation === 'reorder') return 'Saving Prompt order…';
+    return 'Saving default Prompt…';
+}
+
+function successAnnouncement(operation) {
+    if (operation === 'create') return 'Prompt created.';
+    if (operation === 'update') return 'Prompt updated.';
+    if (operation === 'delete') return 'Prompt deleted.';
+    if (operation === 'reorder') return 'Prompt order saved.';
+    return 'Default Prompt updated.';
+}
+
+function errorAnnouncement(code) {
+    if (code === 'cancelled') return 'Prompt deletion was cancelled.';
+    if (code === 'conflict') {
+        return 'Prompts changed elsewhere. Reopen the form to review your draft.';
+    }
+    if (code === 'not-found') return 'That Prompt no longer exists.';
+    if (code === 'invalid') return 'Check the Prompt fields and try again.';
+    if (code === 'unsupported-version') {
+        return 'This Prompt library needs a newer version of Agent Pivot.';
+    }
+    if (code === 'settings-write-conflict') {
+        return 'Save or revert User Settings, then try again. Your Prompt draft is still here.';
+    }
+    return 'Could not save the Prompt change. The latest saved library is shown.';
+}
+
+function insertErrorAnnouncement(code) {
+    if (code === 'no-active-terminal') {
+        return 'No active terminal is available to receive the Prompt.';
+    }
+    if (code === 'prompt-unavailable') {
+        return 'AI Prompts are currently unavailable.';
+    }
+    if (code === 'prompt-not-found') {
+        return 'That Prompt is no longer available.';
+    }
+    return 'The selected terminal is no longer available.';
+}
+
+function closest(target, selector) {
+    return target && typeof target.closest === 'function'
+        ? target.closest(selector)
+        : null;
+}
+
+function setInsertPending(control, pending) {
+    if (!control || typeof control.setAttribute !== 'function') {
+        return;
+    }
+    if (pending) {
+        control.setAttribute('aria-disabled', 'true');
+        control.setAttribute('data-prompt-insert-pending', 'true');
+    } else {
+        control.removeAttribute('aria-disabled');
+        control.removeAttribute('data-prompt-insert-pending');
+    }
+}
+
+function surfaceHtmlHasRevision(html, revision) {
+    var trimmed = String(html || '').trim();
+    if (!trimmed) {
+        return false;
+    }
+    if (typeof document.createElement === 'function') {
+        try {
+            var template = document.createElement('template');
+            template.innerHTML = trimmed;
+            if (!template.content
+                || template.content.childElementCount !== 1
+                || !template.content.firstElementChild
+                || !template.content.firstElementChild.hasAttribute('data-prompt-surface')) {
+                return false;
+            }
+            return readSurfaceRevision(template.content.firstElementChild) === revision;
+        } catch (_error) {
+            return false;
+        }
+    }
+    var opening = trimmed.match(/^<[a-zA-Z][\w:-]*\b([^>]*)>/);
+    if (!opening || !/\bdata-prompt-surface(?:\s|=|>)/.test(opening[0])) {
+        return false;
+    }
+    var revisionMatch = opening[0].match(
+        /\bdata-prompt-revision\s*=\s*["'](0|[1-9]\d*)["']/
+    );
+    return Boolean(revisionMatch) && Number(revisionMatch[1]) === revision;
+}
+
+function readField(form, name) {
+    var field = form && typeof form.querySelector === 'function'
+        ? form.querySelector('[name="' + name + '"]')
+        : null;
+    return field ? String(field.value || '') : '';
+}
+
+function resetPromptForm(form) {
+    if (!form) {
+        return;
+    }
+    if (typeof form.reset === 'function') {
+        form.reset();
+    }
+    clearFieldError(form, 'name');
+    clearFieldError(form, 'text');
+    form.hidden = true;
+}
+
+function formMatchesDraft(form, draft) {
+    if (!form || !draft) {
+        return false;
+    }
+    var kind = form.getAttribute('data-prompt-form');
+    if (kind !== draft.kind) {
+        return false;
+    }
+    return kind === 'create'
+        || form.getAttribute('data-prompt-id') === draft.promptId;
+}
+
+function clearFieldError(form, name) {
+    var error = form.querySelector('[data-prompt-field-error="' + name + '"]');
+    var field = form.querySelector('[name="' + name + '"]');
+    if (error) error.textContent = '';
+    if (field && typeof field.removeAttribute === 'function') {
+        field.removeAttribute('aria-invalid');
+    }
+}
+
+function setFieldError(form, name, message) {
+    var error = form.querySelector('[data-prompt-field-error="' + name + '"]');
+    var field = form.querySelector('[name="' + name + '"]');
+    if (error) error.textContent = message;
+    if (field && typeof field.setAttribute === 'function') {
+        field.setAttribute('aria-invalid', 'true');
+    }
+}
+
+function tabName(tab) {
+    var id = tab && (tab.id || tab.getAttribute('id'));
+    var match = typeof id === 'string' ? id.match(/^ai-tab-(prompts|skills|mcp|hooks)$/) : null;
+    return match ? match[1] : null;
+}

--- a/media/webviewPromptScripts.js
+++ b/media/webviewPromptScripts.js
@@ -1,32 +1,13 @@
 (function () {
     'use strict';
 
-    var PROMPT_VERSION = 1;
-    var PROMPT_TARGET = 'global-prompt-library';
-    var MAX_REQUEST_ID_LENGTH = 128;
+
+
+
     var MAX_SETTLED_KEYS = 100;
-    var OPERATIONS = new Set([
-        'create',
-        'update',
-        'delete',
-        'reorder',
-        'select-default',
-    ]);
-    var ERROR_CODES = new Set([
-        'invalid',
-        'not-found',
-        'conflict',
-        'storage',
-        'settings-write-conflict',
-        'unsupported-version',
-        'cancelled',
-    ]);
-    var INSERT_ERROR_CODES = new Set([
-        'no-active-terminal',
-        'prompt-unavailable',
-        'prompt-not-found',
-        'terminal-unavailable',
-    ]);
+
+
+
     var state = {
         snapshot: null,
         pending: new Map(),
@@ -47,154 +28,15 @@
     var dragOriginList = null;
     var dragOriginNodes = [];
 
-    function clone(value) {
-        if (value === null || value === undefined) {
-            return value;
-        }
-        return JSON.parse(JSON.stringify(value));
-    }
 
-    function correlationKey(message) {
-        return [
-            message.version,
-            message.requestId,
-            message.target,
-            message.operation,
-        ].join(':');
-    }
 
-    function insertCorrelationKey(message) {
-        return [
-            message.version,
-            message.requestId,
-            message.target,
-            'insert-terminal',
-        ].join(':');
-    }
 
-    function hasExactKeys(value, requiredKeys, optionalKeys) {
-        if (!value || typeof value !== 'object' || Array.isArray(value)) {
-            return false;
-        }
-        var allowedKeys = requiredKeys.concat(optionalKeys || []);
-        var keys = Object.keys(value);
-        return requiredKeys.every(function (key) {
-            return Object.prototype.hasOwnProperty.call(value, key);
-        }) && keys.every(function (key) {
-            return allowedKeys.indexOf(key) >= 0;
-        });
-    }
 
-    function isRequestId(value) {
-        return typeof value === 'string'
-            && value.length > 0
-            && value.length <= MAX_REQUEST_ID_LENGTH;
-    }
 
-    function isAuthoritySequence(value) {
-        return Number.isSafeInteger(value) && value > 0;
-    }
 
-    function isSnapshot(snapshot) {
-        if (!hasExactKeys(
-            snapshot,
-            ['version', 'revision', 'selectedPromptId', 'prompts'],
-            ['readOnlyReason']
-        )
-            || snapshot.version !== PROMPT_VERSION
-            || !Number.isSafeInteger(snapshot.revision)
-            || snapshot.revision < 0
-            || (snapshot.selectedPromptId !== null
-                && (typeof snapshot.selectedPromptId !== 'string'
-                    || snapshot.selectedPromptId.length === 0))
-            || !Array.isArray(snapshot.prompts)
-            || (snapshot.readOnlyReason !== undefined
-                && snapshot.readOnlyReason !== 'invalid-data'
-                && snapshot.readOnlyReason !== 'unsupported-version')) {
-            return false;
-        }
 
-        var ids = new Set();
-        var names = new Set();
-        for (var prompt of snapshot.prompts) {
-            if (!hasExactKeys(prompt, ['id', 'name', 'text'])
-                || typeof prompt.id !== 'string'
-                || prompt.id.length === 0
-                || typeof prompt.name !== 'string'
-                || prompt.name.trim().length === 0
-                || typeof prompt.text !== 'string'
-                || prompt.text.trim().length === 0
-                || ids.has(prompt.id)
-                || names.has(prompt.name.toLowerCase())) {
-                return false;
-            }
-            ids.add(prompt.id);
-            names.add(prompt.name.toLowerCase());
-        }
-        return snapshot.selectedPromptId === null || ids.has(snapshot.selectedPromptId);
-    }
 
-    function isCommandResult(message) {
-        return hasExactKeys(message, [
-            'type',
-            'version',
-            'authoritySequence',
-            'requestId',
-            'target',
-            'operation',
-            'success',
-            'snapshot',
-            'html',
-        ], ['errorCode'])
-            && message.type === 'prompt-command-result'
-            && message.version === PROMPT_VERSION
-            && isAuthoritySequence(message.authoritySequence)
-            && isRequestId(message.requestId)
-            && message.target === PROMPT_TARGET
-            && OPERATIONS.has(message.operation)
-            && typeof message.success === 'boolean'
-            && isSnapshot(message.snapshot)
-            && typeof message.html === 'string'
-            && (message.success
-                ? message.errorCode === undefined
-                : ERROR_CODES.has(message.errorCode));
-    }
 
-    function isInsertResult(message) {
-        return hasExactKeys(message, [
-            'type',
-            'version',
-            'requestId',
-            'target',
-            'success',
-            'errorCode',
-        ])
-            && message.type === 'prompt-insert-terminal-result'
-            && message.version === PROMPT_VERSION
-            && isRequestId(message.requestId)
-            && message.target === PROMPT_TARGET
-            && typeof message.success === 'boolean'
-            && (message.success
-                ? message.errorCode === null
-                : INSERT_ERROR_CODES.has(message.errorCode));
-    }
-
-    function isRefresh(message) {
-        return hasExactKeys(message, [
-            'type',
-            'version',
-            'authoritySequence',
-            'target',
-            'snapshot',
-            'html',
-        ])
-            && message.type === 'prompt-panel-updated'
-            && message.version === PROMPT_VERSION
-            && isAuthoritySequence(message.authoritySequence)
-            && message.target === PROMPT_TARGET
-            && isSnapshot(message.snapshot)
-            && typeof message.html === 'string';
-    }
 
     function getSurface() {
         return root && typeof root.querySelector === 'function'
@@ -202,17 +44,6 @@
             : null;
     }
 
-    function readSurfaceRevision(surface) {
-        if (!surface || typeof surface.getAttribute !== 'function') {
-            return null;
-        }
-        var value = surface.getAttribute('data-prompt-revision');
-        if (typeof value !== 'string' || !/^(0|[1-9]\d*)$/.test(value)) {
-            return null;
-        }
-        var revision = Number(value);
-        return Number.isSafeInteger(revision) ? revision : null;
-    }
 
     function getStatusRegion() {
         var surface = getSurface();
@@ -253,50 +84,9 @@
         announce('A Prompt change is already in progress. Wait for it to finish.');
     }
 
-    function mutationAnnouncement(operation) {
-        if (operation === 'create') return 'Saving new Prompt…';
-        if (operation === 'update') return 'Saving Prompt changes…';
-        if (operation === 'delete') return 'Waiting for Prompt deletion confirmation…';
-        if (operation === 'reorder') return 'Saving Prompt order…';
-        return 'Saving default Prompt…';
-    }
 
-    function successAnnouncement(operation) {
-        if (operation === 'create') return 'Prompt created.';
-        if (operation === 'update') return 'Prompt updated.';
-        if (operation === 'delete') return 'Prompt deleted.';
-        if (operation === 'reorder') return 'Prompt order saved.';
-        return 'Default Prompt updated.';
-    }
 
-    function errorAnnouncement(code) {
-        if (code === 'cancelled') return 'Prompt deletion was cancelled.';
-        if (code === 'conflict') {
-            return 'Prompts changed elsewhere. Reopen the form to review your draft.';
-        }
-        if (code === 'not-found') return 'That Prompt no longer exists.';
-        if (code === 'invalid') return 'Check the Prompt fields and try again.';
-        if (code === 'unsupported-version') {
-            return 'This Prompt library needs a newer version of Agent Pivot.';
-        }
-        if (code === 'settings-write-conflict') {
-            return 'Save or revert User Settings, then try again. Your Prompt draft is still here.';
-        }
-        return 'Could not save the Prompt change. The latest saved library is shown.';
-    }
 
-    function insertErrorAnnouncement(code) {
-        if (code === 'no-active-terminal') {
-            return 'No active terminal is available to receive the Prompt.';
-        }
-        if (code === 'prompt-unavailable') {
-            return 'AI Prompts are currently unavailable.';
-        }
-        if (code === 'prompt-not-found') {
-            return 'That Prompt is no longer available.';
-        }
-        return 'The selected terminal is no longer available.';
-    }
 
     function setMutationLock(enabled) {
         var surface = getSurface();
@@ -348,11 +138,6 @@
         return (randomId + '-' + requestSequence.toString(36)).slice(0, MAX_REQUEST_ID_LENGTH);
     }
 
-    function closest(target, selector) {
-        return target && typeof target.closest === 'function'
-            ? target.closest(selector)
-            : null;
-    }
 
     function captureSemanticFocus() {
         var active = document.activeElement;
@@ -423,18 +208,6 @@
             }) || null;
     }
 
-    function setInsertPending(control, pending) {
-        if (!control || typeof control.setAttribute !== 'function') {
-            return;
-        }
-        if (pending) {
-            control.setAttribute('aria-disabled', 'true');
-            control.setAttribute('data-prompt-insert-pending', 'true');
-        } else {
-            control.removeAttribute('aria-disabled');
-            control.removeAttribute('data-prompt-insert-pending');
-        }
-    }
 
     function restoreSemanticFocus(target) {
         if (!target) {
@@ -500,7 +273,7 @@
             focus: captureSemanticFocus(),
             scrollTop: list && typeof list.scrollTop === 'number' ? list.scrollTop : 0,
             scrollY: typeof window.scrollY === 'number' ? window.scrollY : 0,
-            draft: clone(state.draft),
+            draft: clonePromptValue(state.draft),
             activeSubtab: state.activeSubtab,
         };
     }
@@ -520,35 +293,6 @@
         }
     }
 
-    function surfaceHtmlHasRevision(html, revision) {
-        var trimmed = String(html || '').trim();
-        if (!trimmed) {
-            return false;
-        }
-        if (typeof document.createElement === 'function') {
-            try {
-                var template = document.createElement('template');
-                template.innerHTML = trimmed;
-                if (!template.content
-                    || template.content.childElementCount !== 1
-                    || !template.content.firstElementChild
-                    || !template.content.firstElementChild.hasAttribute('data-prompt-surface')) {
-                    return false;
-                }
-                return readSurfaceRevision(template.content.firstElementChild) === revision;
-            } catch (_error) {
-                return false;
-            }
-        }
-        var opening = trimmed.match(/^<[a-zA-Z][\w:-]*\b([^>]*)>/);
-        if (!opening || !/\bdata-prompt-surface(?:\s|=|>)/.test(opening[0])) {
-            return false;
-        }
-        var revisionMatch = opening[0].match(
-            /\bdata-prompt-revision\s*=\s*["'](0|[1-9]\d*)["']/
-        );
-        return Boolean(revisionMatch) && Number(revisionMatch[1]) === revision;
-    }
 
     function installAuthoritative(message) {
         if (!surfaceHtmlHasRevision(message.html, message.snapshot.revision)) {
@@ -570,7 +314,7 @@
         }
         currentRevision = message.snapshot.revision;
         currentAuthoritySequence = message.authoritySequence;
-        state.snapshot = clone(message.snapshot);
+        state.snapshot = clonePromptValue(message.snapshot);
         lockedControls = [];
         configurePromptForms();
         state.pendingInserts.forEach(function (pending) {
@@ -609,12 +353,6 @@
             }) || null;
     }
 
-    function readField(form, name) {
-        var field = form && typeof form.querySelector === 'function'
-            ? form.querySelector('[name="' + name + '"]')
-            : null;
-        return field ? String(field.value || '') : '';
-    }
 
     function applyDraft(draft) {
         if (!draft) {
@@ -639,17 +377,6 @@
         return true;
     }
 
-    function resetPromptForm(form) {
-        if (!form) {
-            return;
-        }
-        if (typeof form.reset === 'function') {
-            form.reset();
-        }
-        clearFieldError(form, 'name');
-        clearFieldError(form, 'text');
-        form.hidden = true;
-    }
 
     function resetOpenDraft() {
         getPromptForms().forEach(resetPromptForm);
@@ -657,17 +384,6 @@
         state.blockedDraft = false;
     }
 
-    function formMatchesDraft(form, draft) {
-        if (!form || !draft) {
-            return false;
-        }
-        var kind = form.getAttribute('data-prompt-form');
-        if (kind !== draft.kind) {
-            return false;
-        }
-        return kind === 'create'
-            || form.getAttribute('data-prompt-id') === draft.promptId;
-    }
 
     function applyQueuedRefresh() {
         var refresh = pendingRefresh;
@@ -707,7 +423,7 @@
             target: PROMPT_TARGET,
             expectedRevision: currentRevision,
             operation: operation,
-            payload: clone(payload),
+            payload: clonePromptValue(payload),
         };
         var key = correlationKey(message);
         var local = captureLocalState();
@@ -717,7 +433,7 @@
             target: message.target,
             expectedRevision: message.expectedRevision,
             operation: message.operation,
-            payload: clone(message.payload),
+            payload: clonePromptValue(message.payload),
             draft: local.draft,
             focus: local.focus,
             scrollTop: local.scrollTop,
@@ -819,7 +535,7 @@
             && pending.focus
             && (!document.activeElement || document.activeElement === document.body)
             && local.activeSubtab === pending.activeSubtab) {
-            local.focus = clone(pending.focus);
+            local.focus = clonePromptValue(pending.focus);
         }
         if (message.success && local.focus && local.focus.formKind) {
             if (message.operation === 'create') {
@@ -846,7 +562,7 @@
                 ? null
                 : local.draft;
         } else {
-            state.draft = clone(pending.draft || local.draft);
+            state.draft = clonePromptValue(pending.draft || local.draft);
             state.blockedDraft = message.errorCode === 'conflict' && Boolean(state.draft);
         }
         setMutationLock(false);
@@ -880,7 +596,7 @@
                 version: message.version,
                 authoritySequence: message.authoritySequence,
                 target: message.target,
-                snapshot: clone(message.snapshot),
+                snapshot: clonePromptValue(message.snapshot),
                 html: message.html,
             };
             return true;
@@ -896,23 +612,7 @@
         return applied;
     }
 
-    function clearFieldError(form, name) {
-        var error = form.querySelector('[data-prompt-field-error="' + name + '"]');
-        var field = form.querySelector('[name="' + name + '"]');
-        if (error) error.textContent = '';
-        if (field && typeof field.removeAttribute === 'function') {
-            field.removeAttribute('aria-invalid');
-        }
-    }
 
-    function setFieldError(form, name, message) {
-        var error = form.querySelector('[data-prompt-field-error="' + name + '"]');
-        var field = form.querySelector('[name="' + name + '"]');
-        if (error) error.textContent = message;
-        if (field && typeof field.setAttribute === 'function') {
-            field.setAttribute('aria-invalid', 'true');
-        }
-    }
 
     function submitForm(form) {
         var kind = form.getAttribute('data-prompt-form');
@@ -962,7 +662,7 @@
             return false;
         }
         var retained = state.blockedDraft && state.draft && state.draft.kind === 'create'
-            ? clone(state.draft)
+            ? clonePromptValue(state.draft)
             : { kind: 'create', promptId: null, name: '', text: '' };
         resetOpenDraft();
         state.draft = retained;
@@ -1021,7 +721,7 @@
             && state.draft
             && state.draft.kind === 'edit'
             && state.draft.promptId === promptId
-            ? clone(state.draft)
+            ? clonePromptValue(state.draft)
             : null;
         resetOpenDraft();
         retained = retained || {
@@ -1112,11 +812,6 @@
         clearFieldError(form, name);
     }
 
-    function tabName(tab) {
-        var id = tab && (tab.id || tab.getAttribute('id'));
-        var match = typeof id === 'string' ? id.match(/^ai-tab-(prompts|skills|mcp|hooks)$/) : null;
-        return match ? match[1] : null;
-    }
 
     function activateSubtab(name, focus) {
         if (!root || ['prompts', 'skills', 'mcp', 'hooks'].indexOf(name) < 0) {
@@ -1266,7 +961,7 @@
             || !initialAuthority
             || !isAuthoritySequence(initialAuthority.authoritySequence)
             || initialAuthority.authoritySequence <= currentAuthoritySequence
-            || !isSnapshot(initialAuthority.snapshot)) {
+            || !isPromptSnapshot(initialAuthority.snapshot)) {
             return false;
         }
         var surface = nextRoot.querySelector('[data-prompt-surface]');
@@ -1277,7 +972,7 @@
         root = nextRoot;
         currentAuthoritySequence = initialAuthority.authoritySequence;
         currentRevision = revision;
-        state.snapshot = clone(initialAuthority.snapshot);
+        state.snapshot = clonePromptValue(initialAuthority.snapshot);
         configurePromptForms();
         var selectedTab = typeof root.querySelectorAll === 'function'
             ? Array.from(root.querySelectorAll('[role="tab"]')).find(function (tab) {

--- a/scripts/run-dashboard-webview-checks.js
+++ b/scripts/run-dashboard-webview-checks.js
@@ -4430,6 +4430,11 @@ function runSourceContractChecks(source) {
         'generated media/webviewScrollStateScripts.js must match its source byte-for-byte'
     );
     assert.deepStrictEqual(
+        fs.readFileSync(path.join(root, 'media', 'webviewPromptProtocolScripts.js')),
+        fs.readFileSync(path.join(root, 'src', 'webview', 'webviewPromptProtocolScripts.js')),
+        'generated media/webviewPromptProtocolScripts.js must match its source byte-for-byte'
+    );
+    assert.deepStrictEqual(
         fs.readFileSync(path.join(root, 'media', 'webviewPromptScripts.js')),
         fs.readFileSync(promptScriptPath),
         'generated media/webviewPromptScripts.js must match its source byte-for-byte'

--- a/scripts/run-performance-architecture-baseline-checks.js
+++ b/scripts/run-performance-architecture-baseline-checks.js
@@ -39,6 +39,7 @@ const productionSources = [
     'media/webviewProjectAiUpdateScripts.js',
     'media/webviewProjectAiSessionControlsScripts.js',
     'media/webviewProjectScripts.js',
+    'media/webviewPromptProtocolScripts.js',
     'media/webviewPromptScripts.js',
     'media/styles.scss',
     'media/styles.css',

--- a/scripts/run-release-packaging-checks.js
+++ b/scripts/run-release-packaging-checks.js
@@ -88,6 +88,7 @@ const EXPECTED_MAIN_ENTRIES = Object.freeze([
     'extension/media/webviewProjectAiUpdateScripts.js',
     'extension/media/webviewProjectAiSessionControlsScripts.js',
     'extension/media/webviewProjectScripts.js',
+    'extension/media/webviewPromptProtocolScripts.js',
     'extension/media/webviewPromptScripts.js',
     'extension/media/webviewScrollStateScripts.js',
     'extension/media/webviewTodoRenderScripts.js',
@@ -612,6 +613,7 @@ function runRealVsixArchiveChecks(mainPackage, bridgePackage) {
         ['extension/media/webviewProjectsPanelScripts.js', 'media/webviewProjectsPanelScripts.js'],
         ['extension/media/webviewDashboardValidationScripts.js', 'media/webviewDashboardValidationScripts.js'],
         ['extension/media/webviewDashboardSearchScripts.js', 'media/webviewDashboardSearchScripts.js'],
+        ['extension/media/webviewPromptProtocolScripts.js', 'media/webviewPromptProtocolScripts.js'],
         ['extension/media/webviewPromptScripts.js', 'media/webviewPromptScripts.js'],
         ['extension/media/webviewScrollStateScripts.js', 'media/webviewScrollStateScripts.js'],
         ['extension/media/webviewTodoRenderScripts.js', 'media/webviewTodoRenderScripts.js'],
@@ -947,6 +949,7 @@ function run() {
     assertIncludes(mainIgnore, '!media/webviewProjectsPanelScripts.js', 'main VSIX ignore rules');
     assertIncludes(mainIgnore, '!media/webviewDashboardValidationScripts.js', 'main VSIX ignore rules');
     assertIncludes(mainIgnore, '!media/webviewDashboardSearchScripts.js', 'main VSIX ignore rules');
+    assertIncludes(mainIgnore, '!media/webviewPromptProtocolScripts.js', 'main VSIX ignore rules');
     assertIncludes(mainIgnore, '!media/webviewPromptScripts.js', 'main VSIX ignore rules');
     assertIncludes(mainIgnore, '!media/webviewScrollStateScripts.js', 'main VSIX ignore rules');
     assertIncludes(mainIgnore, '!media/webviewTodoRenderScripts.js', 'main VSIX ignore rules');
@@ -980,6 +983,7 @@ function run() {
         'media/webviewProjectsPanelScripts.js',
         'media/webviewDashboardValidationScripts.js',
         'media/webviewDashboardSearchScripts.js',
+        'media/webviewPromptProtocolScripts.js',
         'media/webviewPromptScripts.js',
         'media/webviewScrollStateScripts.js',
         'media/webviewTodoRenderScripts.js',

--- a/src/webview/webviewContent.ts
+++ b/src/webview/webviewContent.ts
@@ -224,6 +224,12 @@ export function getStewardContent(
         'webviewDashboardScripts.js',
         assetRevision,
     );
+    var promptProtocolScriptsPath = getMediaResource(
+        context,
+        webview,
+        'webviewPromptProtocolScripts.js',
+        assetRevision,
+    );
     var promptScriptsPath = getMediaResource(
         context,
         webview,
@@ -360,6 +366,7 @@ export function getStewardContent(
     <script src="${dashboardValidationScriptsPath}"></script>
     <script src="${dashboardSearchScriptsPath}"></script>
     <script src="${dashboardScriptsPath}"></script>
+    <script src="${promptProtocolScriptsPath}"></script>
     <script src="${promptScriptsPath}"></script>
     <script src="${todoRenderScriptsPath}"></script>
     <script src="${todoScriptsPath}"></script>

--- a/src/webview/webviewPromptProtocolScripts.js
+++ b/src/webview/webviewPromptProtocolScripts.js
@@ -1,0 +1,340 @@
+var PROMPT_VERSION = 1;
+
+var PROMPT_TARGET = 'global-prompt-library';
+
+var MAX_REQUEST_ID_LENGTH = 128;
+
+var OPERATIONS = new Set([
+    'create',
+    'update',
+    'delete',
+    'reorder',
+    'select-default',
+]);
+
+var ERROR_CODES = new Set([
+    'invalid',
+    'not-found',
+    'conflict',
+    'storage',
+    'settings-write-conflict',
+    'unsupported-version',
+    'cancelled',
+]);
+
+var INSERT_ERROR_CODES = new Set([
+    'no-active-terminal',
+    'prompt-unavailable',
+    'prompt-not-found',
+    'terminal-unavailable',
+]);
+
+function clonePromptValue(value) {
+    if (value === null || value === undefined) {
+        return value;
+    }
+    return JSON.parse(JSON.stringify(value));
+}
+
+function correlationKey(message) {
+    return [
+        message.version,
+        message.requestId,
+        message.target,
+        message.operation,
+    ].join(':');
+}
+
+function insertCorrelationKey(message) {
+    return [
+        message.version,
+        message.requestId,
+        message.target,
+        'insert-terminal',
+    ].join(':');
+}
+
+function hasExactKeys(value, requiredKeys, optionalKeys) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return false;
+    }
+    var allowedKeys = requiredKeys.concat(optionalKeys || []);
+    var keys = Object.keys(value);
+    return requiredKeys.every(function (key) {
+        return Object.prototype.hasOwnProperty.call(value, key);
+    }) && keys.every(function (key) {
+        return allowedKeys.indexOf(key) >= 0;
+    });
+}
+
+function isRequestId(value) {
+    return typeof value === 'string'
+        && value.length > 0
+        && value.length <= MAX_REQUEST_ID_LENGTH;
+}
+
+function isAuthoritySequence(value) {
+    return Number.isSafeInteger(value) && value > 0;
+}
+
+function isPromptSnapshot(snapshot) {
+    if (!hasExactKeys(
+        snapshot,
+        ['version', 'revision', 'selectedPromptId', 'prompts'],
+        ['readOnlyReason']
+    )
+        || snapshot.version !== PROMPT_VERSION
+        || !Number.isSafeInteger(snapshot.revision)
+        || snapshot.revision < 0
+        || (snapshot.selectedPromptId !== null
+            && (typeof snapshot.selectedPromptId !== 'string'
+                || snapshot.selectedPromptId.length === 0))
+        || !Array.isArray(snapshot.prompts)
+        || (snapshot.readOnlyReason !== undefined
+            && snapshot.readOnlyReason !== 'invalid-data'
+            && snapshot.readOnlyReason !== 'unsupported-version')) {
+        return false;
+    }
+
+    var ids = new Set();
+    var names = new Set();
+    for (var prompt of snapshot.prompts) {
+        if (!hasExactKeys(prompt, ['id', 'name', 'text'])
+            || typeof prompt.id !== 'string'
+            || prompt.id.length === 0
+            || typeof prompt.name !== 'string'
+            || prompt.name.trim().length === 0
+            || typeof prompt.text !== 'string'
+            || prompt.text.trim().length === 0
+            || ids.has(prompt.id)
+            || names.has(prompt.name.toLowerCase())) {
+            return false;
+        }
+        ids.add(prompt.id);
+        names.add(prompt.name.toLowerCase());
+    }
+    return snapshot.selectedPromptId === null || ids.has(snapshot.selectedPromptId);
+}
+
+function isCommandResult(message) {
+    return hasExactKeys(message, [
+        'type',
+        'version',
+        'authoritySequence',
+        'requestId',
+        'target',
+        'operation',
+        'success',
+        'snapshot',
+        'html',
+    ], ['errorCode'])
+        && message.type === 'prompt-command-result'
+        && message.version === PROMPT_VERSION
+        && isAuthoritySequence(message.authoritySequence)
+        && isRequestId(message.requestId)
+        && message.target === PROMPT_TARGET
+        && OPERATIONS.has(message.operation)
+        && typeof message.success === 'boolean'
+        && isPromptSnapshot(message.snapshot)
+        && typeof message.html === 'string'
+        && (message.success
+            ? message.errorCode === undefined
+            : ERROR_CODES.has(message.errorCode));
+}
+
+function isInsertResult(message) {
+    return hasExactKeys(message, [
+        'type',
+        'version',
+        'requestId',
+        'target',
+        'success',
+        'errorCode',
+    ])
+        && message.type === 'prompt-insert-terminal-result'
+        && message.version === PROMPT_VERSION
+        && isRequestId(message.requestId)
+        && message.target === PROMPT_TARGET
+        && typeof message.success === 'boolean'
+        && (message.success
+            ? message.errorCode === null
+            : INSERT_ERROR_CODES.has(message.errorCode));
+}
+
+function isRefresh(message) {
+    return hasExactKeys(message, [
+        'type',
+        'version',
+        'authoritySequence',
+        'target',
+        'snapshot',
+        'html',
+    ])
+        && message.type === 'prompt-panel-updated'
+        && message.version === PROMPT_VERSION
+        && isAuthoritySequence(message.authoritySequence)
+        && message.target === PROMPT_TARGET
+        && isPromptSnapshot(message.snapshot)
+        && typeof message.html === 'string';
+}
+
+function readSurfaceRevision(surface) {
+    if (!surface || typeof surface.getAttribute !== 'function') {
+        return null;
+    }
+    var value = surface.getAttribute('data-prompt-revision');
+    if (typeof value !== 'string' || !/^(0|[1-9]\d*)$/.test(value)) {
+        return null;
+    }
+    var revision = Number(value);
+    return Number.isSafeInteger(revision) ? revision : null;
+}
+
+function mutationAnnouncement(operation) {
+    if (operation === 'create') return 'Saving new Prompt…';
+    if (operation === 'update') return 'Saving Prompt changes…';
+    if (operation === 'delete') return 'Waiting for Prompt deletion confirmation…';
+    if (operation === 'reorder') return 'Saving Prompt order…';
+    return 'Saving default Prompt…';
+}
+
+function successAnnouncement(operation) {
+    if (operation === 'create') return 'Prompt created.';
+    if (operation === 'update') return 'Prompt updated.';
+    if (operation === 'delete') return 'Prompt deleted.';
+    if (operation === 'reorder') return 'Prompt order saved.';
+    return 'Default Prompt updated.';
+}
+
+function errorAnnouncement(code) {
+    if (code === 'cancelled') return 'Prompt deletion was cancelled.';
+    if (code === 'conflict') {
+        return 'Prompts changed elsewhere. Reopen the form to review your draft.';
+    }
+    if (code === 'not-found') return 'That Prompt no longer exists.';
+    if (code === 'invalid') return 'Check the Prompt fields and try again.';
+    if (code === 'unsupported-version') {
+        return 'This Prompt library needs a newer version of Agent Pivot.';
+    }
+    if (code === 'settings-write-conflict') {
+        return 'Save or revert User Settings, then try again. Your Prompt draft is still here.';
+    }
+    return 'Could not save the Prompt change. The latest saved library is shown.';
+}
+
+function insertErrorAnnouncement(code) {
+    if (code === 'no-active-terminal') {
+        return 'No active terminal is available to receive the Prompt.';
+    }
+    if (code === 'prompt-unavailable') {
+        return 'AI Prompts are currently unavailable.';
+    }
+    if (code === 'prompt-not-found') {
+        return 'That Prompt is no longer available.';
+    }
+    return 'The selected terminal is no longer available.';
+}
+
+function closest(target, selector) {
+    return target && typeof target.closest === 'function'
+        ? target.closest(selector)
+        : null;
+}
+
+function setInsertPending(control, pending) {
+    if (!control || typeof control.setAttribute !== 'function') {
+        return;
+    }
+    if (pending) {
+        control.setAttribute('aria-disabled', 'true');
+        control.setAttribute('data-prompt-insert-pending', 'true');
+    } else {
+        control.removeAttribute('aria-disabled');
+        control.removeAttribute('data-prompt-insert-pending');
+    }
+}
+
+function surfaceHtmlHasRevision(html, revision) {
+    var trimmed = String(html || '').trim();
+    if (!trimmed) {
+        return false;
+    }
+    if (typeof document.createElement === 'function') {
+        try {
+            var template = document.createElement('template');
+            template.innerHTML = trimmed;
+            if (!template.content
+                || template.content.childElementCount !== 1
+                || !template.content.firstElementChild
+                || !template.content.firstElementChild.hasAttribute('data-prompt-surface')) {
+                return false;
+            }
+            return readSurfaceRevision(template.content.firstElementChild) === revision;
+        } catch (_error) {
+            return false;
+        }
+    }
+    var opening = trimmed.match(/^<[a-zA-Z][\w:-]*\b([^>]*)>/);
+    if (!opening || !/\bdata-prompt-surface(?:\s|=|>)/.test(opening[0])) {
+        return false;
+    }
+    var revisionMatch = opening[0].match(
+        /\bdata-prompt-revision\s*=\s*["'](0|[1-9]\d*)["']/
+    );
+    return Boolean(revisionMatch) && Number(revisionMatch[1]) === revision;
+}
+
+function readField(form, name) {
+    var field = form && typeof form.querySelector === 'function'
+        ? form.querySelector('[name="' + name + '"]')
+        : null;
+    return field ? String(field.value || '') : '';
+}
+
+function resetPromptForm(form) {
+    if (!form) {
+        return;
+    }
+    if (typeof form.reset === 'function') {
+        form.reset();
+    }
+    clearFieldError(form, 'name');
+    clearFieldError(form, 'text');
+    form.hidden = true;
+}
+
+function formMatchesDraft(form, draft) {
+    if (!form || !draft) {
+        return false;
+    }
+    var kind = form.getAttribute('data-prompt-form');
+    if (kind !== draft.kind) {
+        return false;
+    }
+    return kind === 'create'
+        || form.getAttribute('data-prompt-id') === draft.promptId;
+}
+
+function clearFieldError(form, name) {
+    var error = form.querySelector('[data-prompt-field-error="' + name + '"]');
+    var field = form.querySelector('[name="' + name + '"]');
+    if (error) error.textContent = '';
+    if (field && typeof field.removeAttribute === 'function') {
+        field.removeAttribute('aria-invalid');
+    }
+}
+
+function setFieldError(form, name, message) {
+    var error = form.querySelector('[data-prompt-field-error="' + name + '"]');
+    var field = form.querySelector('[name="' + name + '"]');
+    if (error) error.textContent = message;
+    if (field && typeof field.setAttribute === 'function') {
+        field.setAttribute('aria-invalid', 'true');
+    }
+}
+
+function tabName(tab) {
+    var id = tab && (tab.id || tab.getAttribute('id'));
+    var match = typeof id === 'string' ? id.match(/^ai-tab-(prompts|skills|mcp|hooks)$/) : null;
+    return match ? match[1] : null;
+}

--- a/src/webview/webviewPromptScripts.js
+++ b/src/webview/webviewPromptScripts.js
@@ -1,32 +1,13 @@
 (function () {
     'use strict';
 
-    var PROMPT_VERSION = 1;
-    var PROMPT_TARGET = 'global-prompt-library';
-    var MAX_REQUEST_ID_LENGTH = 128;
+
+
+
     var MAX_SETTLED_KEYS = 100;
-    var OPERATIONS = new Set([
-        'create',
-        'update',
-        'delete',
-        'reorder',
-        'select-default',
-    ]);
-    var ERROR_CODES = new Set([
-        'invalid',
-        'not-found',
-        'conflict',
-        'storage',
-        'settings-write-conflict',
-        'unsupported-version',
-        'cancelled',
-    ]);
-    var INSERT_ERROR_CODES = new Set([
-        'no-active-terminal',
-        'prompt-unavailable',
-        'prompt-not-found',
-        'terminal-unavailable',
-    ]);
+
+
+
     var state = {
         snapshot: null,
         pending: new Map(),
@@ -47,154 +28,15 @@
     var dragOriginList = null;
     var dragOriginNodes = [];
 
-    function clone(value) {
-        if (value === null || value === undefined) {
-            return value;
-        }
-        return JSON.parse(JSON.stringify(value));
-    }
 
-    function correlationKey(message) {
-        return [
-            message.version,
-            message.requestId,
-            message.target,
-            message.operation,
-        ].join(':');
-    }
 
-    function insertCorrelationKey(message) {
-        return [
-            message.version,
-            message.requestId,
-            message.target,
-            'insert-terminal',
-        ].join(':');
-    }
 
-    function hasExactKeys(value, requiredKeys, optionalKeys) {
-        if (!value || typeof value !== 'object' || Array.isArray(value)) {
-            return false;
-        }
-        var allowedKeys = requiredKeys.concat(optionalKeys || []);
-        var keys = Object.keys(value);
-        return requiredKeys.every(function (key) {
-            return Object.prototype.hasOwnProperty.call(value, key);
-        }) && keys.every(function (key) {
-            return allowedKeys.indexOf(key) >= 0;
-        });
-    }
 
-    function isRequestId(value) {
-        return typeof value === 'string'
-            && value.length > 0
-            && value.length <= MAX_REQUEST_ID_LENGTH;
-    }
 
-    function isAuthoritySequence(value) {
-        return Number.isSafeInteger(value) && value > 0;
-    }
 
-    function isSnapshot(snapshot) {
-        if (!hasExactKeys(
-            snapshot,
-            ['version', 'revision', 'selectedPromptId', 'prompts'],
-            ['readOnlyReason']
-        )
-            || snapshot.version !== PROMPT_VERSION
-            || !Number.isSafeInteger(snapshot.revision)
-            || snapshot.revision < 0
-            || (snapshot.selectedPromptId !== null
-                && (typeof snapshot.selectedPromptId !== 'string'
-                    || snapshot.selectedPromptId.length === 0))
-            || !Array.isArray(snapshot.prompts)
-            || (snapshot.readOnlyReason !== undefined
-                && snapshot.readOnlyReason !== 'invalid-data'
-                && snapshot.readOnlyReason !== 'unsupported-version')) {
-            return false;
-        }
 
-        var ids = new Set();
-        var names = new Set();
-        for (var prompt of snapshot.prompts) {
-            if (!hasExactKeys(prompt, ['id', 'name', 'text'])
-                || typeof prompt.id !== 'string'
-                || prompt.id.length === 0
-                || typeof prompt.name !== 'string'
-                || prompt.name.trim().length === 0
-                || typeof prompt.text !== 'string'
-                || prompt.text.trim().length === 0
-                || ids.has(prompt.id)
-                || names.has(prompt.name.toLowerCase())) {
-                return false;
-            }
-            ids.add(prompt.id);
-            names.add(prompt.name.toLowerCase());
-        }
-        return snapshot.selectedPromptId === null || ids.has(snapshot.selectedPromptId);
-    }
 
-    function isCommandResult(message) {
-        return hasExactKeys(message, [
-            'type',
-            'version',
-            'authoritySequence',
-            'requestId',
-            'target',
-            'operation',
-            'success',
-            'snapshot',
-            'html',
-        ], ['errorCode'])
-            && message.type === 'prompt-command-result'
-            && message.version === PROMPT_VERSION
-            && isAuthoritySequence(message.authoritySequence)
-            && isRequestId(message.requestId)
-            && message.target === PROMPT_TARGET
-            && OPERATIONS.has(message.operation)
-            && typeof message.success === 'boolean'
-            && isSnapshot(message.snapshot)
-            && typeof message.html === 'string'
-            && (message.success
-                ? message.errorCode === undefined
-                : ERROR_CODES.has(message.errorCode));
-    }
 
-    function isInsertResult(message) {
-        return hasExactKeys(message, [
-            'type',
-            'version',
-            'requestId',
-            'target',
-            'success',
-            'errorCode',
-        ])
-            && message.type === 'prompt-insert-terminal-result'
-            && message.version === PROMPT_VERSION
-            && isRequestId(message.requestId)
-            && message.target === PROMPT_TARGET
-            && typeof message.success === 'boolean'
-            && (message.success
-                ? message.errorCode === null
-                : INSERT_ERROR_CODES.has(message.errorCode));
-    }
-
-    function isRefresh(message) {
-        return hasExactKeys(message, [
-            'type',
-            'version',
-            'authoritySequence',
-            'target',
-            'snapshot',
-            'html',
-        ])
-            && message.type === 'prompt-panel-updated'
-            && message.version === PROMPT_VERSION
-            && isAuthoritySequence(message.authoritySequence)
-            && message.target === PROMPT_TARGET
-            && isSnapshot(message.snapshot)
-            && typeof message.html === 'string';
-    }
 
     function getSurface() {
         return root && typeof root.querySelector === 'function'
@@ -202,17 +44,6 @@
             : null;
     }
 
-    function readSurfaceRevision(surface) {
-        if (!surface || typeof surface.getAttribute !== 'function') {
-            return null;
-        }
-        var value = surface.getAttribute('data-prompt-revision');
-        if (typeof value !== 'string' || !/^(0|[1-9]\d*)$/.test(value)) {
-            return null;
-        }
-        var revision = Number(value);
-        return Number.isSafeInteger(revision) ? revision : null;
-    }
 
     function getStatusRegion() {
         var surface = getSurface();
@@ -253,50 +84,9 @@
         announce('A Prompt change is already in progress. Wait for it to finish.');
     }
 
-    function mutationAnnouncement(operation) {
-        if (operation === 'create') return 'Saving new Prompt…';
-        if (operation === 'update') return 'Saving Prompt changes…';
-        if (operation === 'delete') return 'Waiting for Prompt deletion confirmation…';
-        if (operation === 'reorder') return 'Saving Prompt order…';
-        return 'Saving default Prompt…';
-    }
 
-    function successAnnouncement(operation) {
-        if (operation === 'create') return 'Prompt created.';
-        if (operation === 'update') return 'Prompt updated.';
-        if (operation === 'delete') return 'Prompt deleted.';
-        if (operation === 'reorder') return 'Prompt order saved.';
-        return 'Default Prompt updated.';
-    }
 
-    function errorAnnouncement(code) {
-        if (code === 'cancelled') return 'Prompt deletion was cancelled.';
-        if (code === 'conflict') {
-            return 'Prompts changed elsewhere. Reopen the form to review your draft.';
-        }
-        if (code === 'not-found') return 'That Prompt no longer exists.';
-        if (code === 'invalid') return 'Check the Prompt fields and try again.';
-        if (code === 'unsupported-version') {
-            return 'This Prompt library needs a newer version of Agent Pivot.';
-        }
-        if (code === 'settings-write-conflict') {
-            return 'Save or revert User Settings, then try again. Your Prompt draft is still here.';
-        }
-        return 'Could not save the Prompt change. The latest saved library is shown.';
-    }
 
-    function insertErrorAnnouncement(code) {
-        if (code === 'no-active-terminal') {
-            return 'No active terminal is available to receive the Prompt.';
-        }
-        if (code === 'prompt-unavailable') {
-            return 'AI Prompts are currently unavailable.';
-        }
-        if (code === 'prompt-not-found') {
-            return 'That Prompt is no longer available.';
-        }
-        return 'The selected terminal is no longer available.';
-    }
 
     function setMutationLock(enabled) {
         var surface = getSurface();
@@ -348,11 +138,6 @@
         return (randomId + '-' + requestSequence.toString(36)).slice(0, MAX_REQUEST_ID_LENGTH);
     }
 
-    function closest(target, selector) {
-        return target && typeof target.closest === 'function'
-            ? target.closest(selector)
-            : null;
-    }
 
     function captureSemanticFocus() {
         var active = document.activeElement;
@@ -423,18 +208,6 @@
             }) || null;
     }
 
-    function setInsertPending(control, pending) {
-        if (!control || typeof control.setAttribute !== 'function') {
-            return;
-        }
-        if (pending) {
-            control.setAttribute('aria-disabled', 'true');
-            control.setAttribute('data-prompt-insert-pending', 'true');
-        } else {
-            control.removeAttribute('aria-disabled');
-            control.removeAttribute('data-prompt-insert-pending');
-        }
-    }
 
     function restoreSemanticFocus(target) {
         if (!target) {
@@ -500,7 +273,7 @@
             focus: captureSemanticFocus(),
             scrollTop: list && typeof list.scrollTop === 'number' ? list.scrollTop : 0,
             scrollY: typeof window.scrollY === 'number' ? window.scrollY : 0,
-            draft: clone(state.draft),
+            draft: clonePromptValue(state.draft),
             activeSubtab: state.activeSubtab,
         };
     }
@@ -520,35 +293,6 @@
         }
     }
 
-    function surfaceHtmlHasRevision(html, revision) {
-        var trimmed = String(html || '').trim();
-        if (!trimmed) {
-            return false;
-        }
-        if (typeof document.createElement === 'function') {
-            try {
-                var template = document.createElement('template');
-                template.innerHTML = trimmed;
-                if (!template.content
-                    || template.content.childElementCount !== 1
-                    || !template.content.firstElementChild
-                    || !template.content.firstElementChild.hasAttribute('data-prompt-surface')) {
-                    return false;
-                }
-                return readSurfaceRevision(template.content.firstElementChild) === revision;
-            } catch (_error) {
-                return false;
-            }
-        }
-        var opening = trimmed.match(/^<[a-zA-Z][\w:-]*\b([^>]*)>/);
-        if (!opening || !/\bdata-prompt-surface(?:\s|=|>)/.test(opening[0])) {
-            return false;
-        }
-        var revisionMatch = opening[0].match(
-            /\bdata-prompt-revision\s*=\s*["'](0|[1-9]\d*)["']/
-        );
-        return Boolean(revisionMatch) && Number(revisionMatch[1]) === revision;
-    }
 
     function installAuthoritative(message) {
         if (!surfaceHtmlHasRevision(message.html, message.snapshot.revision)) {
@@ -570,7 +314,7 @@
         }
         currentRevision = message.snapshot.revision;
         currentAuthoritySequence = message.authoritySequence;
-        state.snapshot = clone(message.snapshot);
+        state.snapshot = clonePromptValue(message.snapshot);
         lockedControls = [];
         configurePromptForms();
         state.pendingInserts.forEach(function (pending) {
@@ -609,12 +353,6 @@
             }) || null;
     }
 
-    function readField(form, name) {
-        var field = form && typeof form.querySelector === 'function'
-            ? form.querySelector('[name="' + name + '"]')
-            : null;
-        return field ? String(field.value || '') : '';
-    }
 
     function applyDraft(draft) {
         if (!draft) {
@@ -639,17 +377,6 @@
         return true;
     }
 
-    function resetPromptForm(form) {
-        if (!form) {
-            return;
-        }
-        if (typeof form.reset === 'function') {
-            form.reset();
-        }
-        clearFieldError(form, 'name');
-        clearFieldError(form, 'text');
-        form.hidden = true;
-    }
 
     function resetOpenDraft() {
         getPromptForms().forEach(resetPromptForm);
@@ -657,17 +384,6 @@
         state.blockedDraft = false;
     }
 
-    function formMatchesDraft(form, draft) {
-        if (!form || !draft) {
-            return false;
-        }
-        var kind = form.getAttribute('data-prompt-form');
-        if (kind !== draft.kind) {
-            return false;
-        }
-        return kind === 'create'
-            || form.getAttribute('data-prompt-id') === draft.promptId;
-    }
 
     function applyQueuedRefresh() {
         var refresh = pendingRefresh;
@@ -707,7 +423,7 @@
             target: PROMPT_TARGET,
             expectedRevision: currentRevision,
             operation: operation,
-            payload: clone(payload),
+            payload: clonePromptValue(payload),
         };
         var key = correlationKey(message);
         var local = captureLocalState();
@@ -717,7 +433,7 @@
             target: message.target,
             expectedRevision: message.expectedRevision,
             operation: message.operation,
-            payload: clone(message.payload),
+            payload: clonePromptValue(message.payload),
             draft: local.draft,
             focus: local.focus,
             scrollTop: local.scrollTop,
@@ -819,7 +535,7 @@
             && pending.focus
             && (!document.activeElement || document.activeElement === document.body)
             && local.activeSubtab === pending.activeSubtab) {
-            local.focus = clone(pending.focus);
+            local.focus = clonePromptValue(pending.focus);
         }
         if (message.success && local.focus && local.focus.formKind) {
             if (message.operation === 'create') {
@@ -846,7 +562,7 @@
                 ? null
                 : local.draft;
         } else {
-            state.draft = clone(pending.draft || local.draft);
+            state.draft = clonePromptValue(pending.draft || local.draft);
             state.blockedDraft = message.errorCode === 'conflict' && Boolean(state.draft);
         }
         setMutationLock(false);
@@ -880,7 +596,7 @@
                 version: message.version,
                 authoritySequence: message.authoritySequence,
                 target: message.target,
-                snapshot: clone(message.snapshot),
+                snapshot: clonePromptValue(message.snapshot),
                 html: message.html,
             };
             return true;
@@ -896,23 +612,7 @@
         return applied;
     }
 
-    function clearFieldError(form, name) {
-        var error = form.querySelector('[data-prompt-field-error="' + name + '"]');
-        var field = form.querySelector('[name="' + name + '"]');
-        if (error) error.textContent = '';
-        if (field && typeof field.removeAttribute === 'function') {
-            field.removeAttribute('aria-invalid');
-        }
-    }
 
-    function setFieldError(form, name, message) {
-        var error = form.querySelector('[data-prompt-field-error="' + name + '"]');
-        var field = form.querySelector('[name="' + name + '"]');
-        if (error) error.textContent = message;
-        if (field && typeof field.setAttribute === 'function') {
-            field.setAttribute('aria-invalid', 'true');
-        }
-    }
 
     function submitForm(form) {
         var kind = form.getAttribute('data-prompt-form');
@@ -962,7 +662,7 @@
             return false;
         }
         var retained = state.blockedDraft && state.draft && state.draft.kind === 'create'
-            ? clone(state.draft)
+            ? clonePromptValue(state.draft)
             : { kind: 'create', promptId: null, name: '', text: '' };
         resetOpenDraft();
         state.draft = retained;
@@ -1021,7 +721,7 @@
             && state.draft
             && state.draft.kind === 'edit'
             && state.draft.promptId === promptId
-            ? clone(state.draft)
+            ? clonePromptValue(state.draft)
             : null;
         resetOpenDraft();
         retained = retained || {
@@ -1112,11 +812,6 @@
         clearFieldError(form, name);
     }
 
-    function tabName(tab) {
-        var id = tab && (tab.id || tab.getAttribute('id'));
-        var match = typeof id === 'string' ? id.match(/^ai-tab-(prompts|skills|mcp|hooks)$/) : null;
-        return match ? match[1] : null;
-    }
 
     function activateSubtab(name, focus) {
         if (!root || ['prompts', 'skills', 'mcp', 'hooks'].indexOf(name) < 0) {
@@ -1266,7 +961,7 @@
             || !initialAuthority
             || !isAuthoritySequence(initialAuthority.authoritySequence)
             || initialAuthority.authoritySequence <= currentAuthoritySequence
-            || !isSnapshot(initialAuthority.snapshot)) {
+            || !isPromptSnapshot(initialAuthority.snapshot)) {
             return false;
         }
         var surface = nextRoot.querySelector('[data-prompt-surface]');
@@ -1277,7 +972,7 @@
         root = nextRoot;
         currentAuthoritySequence = initialAuthority.authoritySequence;
         currentRevision = revision;
-        state.snapshot = clone(initialAuthority.snapshot);
+        state.snapshot = clonePromptValue(initialAuthority.snapshot);
         configurePromptForms();
         var selectedTab = typeof root.querySelectorAll === 'function'
             ? Array.from(root.querySelectorAll('[role="tab"]')).find(function (tab) {

--- a/tests/browser/promptLayout.test.js
+++ b/tests/browser/promptLayout.test.js
@@ -12,6 +12,10 @@ const {
 } = require('../../out/prompts/webviewContent');
 
 const styles = fs.readFileSync(path.join(__dirname, '../../media/styles.css'), 'utf8');
+const promptProtocolScript = fs.readFileSync(
+    path.join(__dirname, '../../src/webview/webviewPromptProtocolScripts.js'),
+    'utf8'
+);
 const promptScript = fs.readFileSync(
     path.join(__dirname, '../../src/webview/webviewPromptScripts.js'),
     'utf8'
@@ -107,6 +111,7 @@ async function openPromptPage(browser, snapshot) {
             },
         };
     });
+    await page.addScriptTag({ content: promptProtocolScript });
     await page.addScriptTag({ content: promptScript });
     assert.equal(await page.evaluate(initialSnapshot =>
         window.__agentPivotPrompts.mount(document.getElementById('ai-host'), {
@@ -262,6 +267,7 @@ test('WEBVIEW-AI-PROMPT-INTERACTION-001 keeps Prompt controls and text usable in
             await page.evaluate(() => {
                 window.vscode = { postMessage() {} };
             });
+            await page.addScriptTag({ content: promptProtocolScript });
             await page.addScriptTag({ content: promptScript });
             assert.equal(await page.evaluate(snapshot =>
                 window.__agentPivotPrompts.mount(document.getElementById('ai-host'), {
@@ -428,6 +434,7 @@ test('WEBVIEW-AI-PROMPT-INTERACTION-001 keeps all Prompt actions visible without
     await page.evaluate(() => {
         window.vscode = { postMessage() {} };
     });
+    await page.addScriptTag({ content: promptProtocolScript });
     await page.addScriptTag({ content: promptScript });
     assert.equal(await page.evaluate(snapshot =>
         window.__agentPivotPrompts.mount(document.getElementById('ai-host'), {

--- a/tests/integration/dashboard/promptInteraction.test.js
+++ b/tests/integration/dashboard/promptInteraction.test.js
@@ -6,6 +6,10 @@ const path = require('node:path');
 const test = require('node:test');
 const vm = require('node:vm');
 
+const protocolSource = fs.readFileSync(
+    path.join(__dirname, '../../../src/webview/webviewPromptProtocolScripts.js'),
+    'utf8'
+);
 const source = fs.readFileSync(
     path.join(__dirname, '../../../src/webview/webviewPromptScripts.js'),
     'utf8'
@@ -421,7 +425,7 @@ function createPromptHarness(options = {}) {
             },
         },
     };
-    vm.runInNewContext(source, context, { filename: 'webviewPromptScripts.js' });
+    vm.runInNewContext(`${protocolSource}\n${source}`, context, { filename: 'webviewPromptScripts.js' });
     const controller = context.window.__agentPivotPrompts;
     const initialRevision = Number(initialHtml.match(/data-prompt-revision="(\d+)"/)?.[1] || 0);
     controller.mount(root, {

--- a/tests/integration/dashboard/webviewState.test.js
+++ b/tests/integration/dashboard/webviewState.test.js
@@ -44,6 +44,8 @@ const aiSessionControlsSource = fs.readFileSync(path.join(root, 'src', 'webview'
 const generatedAiSessionControlsSource = fs.readFileSync(path.join(root, 'media', 'webviewProjectAiSessionControlsScripts.js'), 'utf8');
 const projectVmSource = `${viewStateSource}\n${workspaceUpdateSource}\n${todoGroupSource}\n${projectCollapseSource}\n${todoControlSource}\n${projectContextMenuSource}\n${projectAiUpdateSource}\n${aiSessionControlsSource}\n${projectSource}`;
 const scrollStateSource = fs.readFileSync(path.join(root, 'src', 'webview', 'webviewScrollStateScripts.js'), 'utf8');
+const promptProtocolSource = fs.readFileSync(path.join(root, 'src', 'webview', 'webviewPromptProtocolScripts.js'), 'utf8');
+const generatedPromptProtocolSource = fs.readFileSync(path.join(root, 'media', 'webviewPromptProtocolScripts.js'), 'utf8');
 const promptSource = fs.readFileSync(path.join(root, 'src', 'webview', 'webviewPromptScripts.js'), 'utf8');
 const generatedPromptPath = path.join(root, 'media', 'webviewPromptScripts.js');
 const todoRenderSource = fs.readFileSync(path.join(root, 'src', 'webview', 'webviewTodoRenderScripts.js'), 'utf8');
@@ -696,6 +698,7 @@ test('ACTIVE-SESSION-CONVERSATION-OPEN-001 posts an open request for a focused a
 test('WEBVIEW-AI-PROMPT-ASSET-001 keeps the generated Prompt controller byte-identical to source', () => {
     assert.ok(fs.existsSync(generatedPromptPath), 'missing media/webviewPromptScripts.js');
     assert.equal(fs.readFileSync(generatedPromptPath, 'utf8'), promptSource);
+    assert.equal(generatedPromptProtocolSource, promptProtocolSource);
 });
 
 test('WEBVIEW-WEBVIEW-CONTENT-001 keeps the generated Dashboard controller byte-identical to source', () => {
@@ -875,6 +878,11 @@ test('WEBVIEW-WEBVIEW-CONTENT-001 renders OPEN PROJECTS TODO and lazy AI tab she
         'Dashboard pure helpers must load before the Dashboard controller that calls them'
     );
     assert.ok(
+        html.indexOf('webviewPromptProtocolScripts.js') > html.indexOf('webviewDashboardScripts.js')
+            && html.indexOf('webviewPromptProtocolScripts.js') < html.indexOf('webviewPromptScripts.js'),
+        'Prompt protocol helpers must load after the Dashboard lazy loader and before the Prompt controller'
+    );
+    assert.ok(
         html.indexOf('webviewPromptScripts.js') > html.indexOf('webviewDashboardScripts.js'),
         'Prompt interactions must install after the Dashboard lazy loader'
     );
@@ -949,6 +957,7 @@ test('WEBVIEW-RESOURCE-RECOVERY-001 gives every rendered document fresh versione
         'webviewDashboardValidationScripts.js',
         'webviewDashboardSearchScripts.js',
         'webviewDashboardScripts.js',
+        'webviewPromptProtocolScripts.js',
         'webviewPromptScripts.js',
         'webviewTodoRenderScripts.js',
         'webviewTodoScripts.js',


### PR DESCRIPTION
## Summary

Third slice of the webview tier-1 cleanup, covering `webviewPromptScripts.js` (1311 lines):

- New `webviewPromptProtocolScripts.js` (340 lines): the six prompt protocol constants (`PROMPT_VERSION`, `PROMPT_TARGET`, `OPERATIONS`, `ERROR_CODES`, `INSERT_ERROR_CODES`, `MAX_REQUEST_ID_LENGTH`) plus 24 pure top-level functions — message validators (`isSnapshot`/`isCommandResult`/`isInsertResult`/`isRefresh`), correlation keys, announcement templates, and pure DOM/form helpers.
- **Collision handling**: `clone` and `isSnapshot` already exist as globals in `webviewTodoRenderScripts.js`; the prompt copies move as `clonePromptValue` and `isPromptSnapshot` (rename whitelist-verified on both sides).
- `webviewPromptScripts.js` is now 1006 lines: the stateful IIFE controller, resolving moved helpers through the shared script scope. Zero call-site changes beyond the two renames.
- Loads ahead of `webviewPromptScripts.js` (and after the Dashboard lazy loader) in the webview HTML and every vm/browser harness; packaging, ignore rules, byte-identity, load-order guards, and the performance baseline list updated to match.

No behavior change.

## Verification

- Full local gate suite green (compile, unit, integration, dashboard webview checks, safety suites, architecture guards, performance baseline, browser, behavior contracts, lint, changed coverage 100% 7/7, release packaging).
- media/ copies byte-identical to src/webview/.

## Skill harvest

none — the established extraction playbook and registration checklist covered this round; the global-name collision scan is now a standard step of it.