### PR TITLE
refactor: move the tmux binding record schema out of the binding store

### DIFF
--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "202a407eee5c56c91e9a1a6e2e1ea78990fcf98d",
+        "head": "f0a0a93cd0b01d606d4f3479f6d60a3c7c8f63a6",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -779,7 +779,9 @@
                 "4b2790d284a5b45fd4b69308acb83f696b2267cb",
                 "aad818ca16f8e299769f65bc2955859d3428bc25",
                 "cf9022357308f9a5a45f8cf5523ce6a9cb94bd6d",
-                "202a407eee5c56c91e9a1a6e2e1ea78990fcf98d"
+                "202a407eee5c56c91e9a1a6e2e1ea78990fcf98d",
+                "7014d420067a4e2d95fbfcd21b40201ab6b5485b",
+                "f0a0a93cd0b01d606d4f3479f6d60a3c7c8f63a6"
             ],
             "behaviors": [
                 "RUNTIME-TMUX-BACKEND-001",

--- a/src/aiSessions/tmuxBindingRecords.ts
+++ b/src/aiSessions/tmuxBindingRecords.ts
@@ -1,0 +1,931 @@
+'use strict';
+
+import { createHash } from 'crypto';
+import * as path from 'path';
+import type { AiSessionProviderId } from '../models';
+import type {
+    AiSessionRuntimeIdentity,
+    AiSessionTmuxLayout,
+    AiSessionTmuxLocator,
+} from './runtimeTypes';
+import {
+    cloneAiSessionRuntimeIdentity,
+    getAiSessionRuntimeRootSnapshotKey,
+    isValidAiSessionPromotionDisplayName,
+    isValidAiSessionRuntimeIdentity,
+} from './runtimeTypes';
+
+export interface TmuxPendingRuntimeBinding {
+    version: 2;
+    state: 'pending';
+    pendingId: string;
+    provider: AiSessionProviderId;
+    workspaceScopeIdentity: string;
+    workspaceNavigationIdentity: string;
+    workspaceRootHostPaths: string[];
+    cwd: string;
+    createdAt: string;
+    excludedSessionIds: string[];
+    projectName?: string;
+    title?: string;
+    acceptedAtMs: number;
+    layout: AiSessionTmuxLayout;
+    locator: AiSessionTmuxLocator;
+}
+
+export interface TmuxKnownRuntimeBinding {
+    version: 2;
+    state: 'known';
+    provider: AiSessionProviderId;
+    sessionId: string;
+    workspaceScopeIdentity: string;
+    workspaceNavigationIdentity: string;
+    workspaceRootHostPaths: string[];
+    cwd: string;
+    layout: AiSessionTmuxLayout;
+    locator: AiSessionTmuxLocator;
+    lastSeenAtMs: number;
+    markerPath?: string;
+    runStartedAtMs?: number;
+}
+
+export interface TmuxInactiveRuntimeBinding {
+    version: 2;
+    state: 'completed' | 'stopped';
+    provider: AiSessionProviderId;
+    sessionId: string;
+    workspaceScopeIdentity: string;
+    workspaceNavigationIdentity: string;
+    workspaceRootHostPaths: string[];
+    cwd: string;
+    layout: AiSessionTmuxLayout;
+    locator: AiSessionTmuxLocator;
+    markerPath: string;
+    runStartedAtMs: number;
+    detectedAtMs: number;
+}
+
+export type TmuxInactiveAcknowledgementResult = 'acknowledged' | 'stale' | 'missing';
+export type TmuxKnownRebindResult = 'rebound' | 'stale' | 'missing';
+
+export interface TmuxFinalBindingSnapshot {
+    pending: TmuxPendingRuntimeBinding[];
+    known: TmuxKnownRuntimeBinding[];
+    inactive: TmuxInactiveRuntimeBinding[];
+}
+
+export interface TmuxKnownRebindIntent {
+    version: 1;
+    state: 'rebind-known';
+    expected: TmuxKnownRuntimeBinding;
+    replacement: TmuxKnownRuntimeBinding;
+    recordedAtMs: number;
+}
+
+export interface TmuxConsumedPendingBinding {
+    version: 2;
+    state: 'consumed';
+    pendingId: string;
+    provider: AiSessionProviderId;
+    workspaceScopeIdentity: string;
+    workspaceNavigationIdentity: string;
+    workspaceRootHostPaths: string[];
+    cwd: string;
+    finalSessionId: string;
+    finalSessionName?: string;
+    layout: AiSessionTmuxLayout;
+    finalLocator: AiSessionTmuxLocator;
+    consumedAtMs: number;
+}
+
+export interface TmuxPromotingRuntimeBinding {
+    version: 2;
+    state: 'promoting';
+    pendingId: string;
+    provider: AiSessionProviderId;
+    workspaceScopeIdentity: string;
+    workspaceNavigationIdentity: string;
+    workspaceRootHostPaths: string[];
+    cwd: string;
+    createdAt: string;
+    markerPath: string;
+    pendingBinding: TmuxPendingRuntimeBinding;
+    finalSessionId: string;
+    finalSessionName: string;
+    layout: AiSessionTmuxLayout;
+    sourceLocator: AiSessionTmuxLocator;
+    finalLocator: AiSessionTmuxLocator;
+    requestFingerprint: string;
+    recordedAtMs: number;
+}
+
+export interface TmuxRecoverablePendingBinding {
+    pendingBinding: TmuxPendingRuntimeBinding;
+    promotionRecoveryDisplayName: string;
+    recoverySessionId: string;
+}
+
+export interface TmuxAmbiguousRuntimeBindingBase {
+    version: 2;
+    state: 'ambiguous';
+    provider: AiSessionProviderId;
+    workspaceScopeIdentity: string;
+    workspaceNavigationIdentity: string;
+    workspaceRootHostPaths: string[];
+    cwd: string;
+    layout: AiSessionTmuxLayout;
+    locator: AiSessionTmuxLocator;
+    acceptedAtMs: number;
+}
+
+export type TmuxAmbiguousRuntimeBinding = TmuxAmbiguousRuntimeBindingBase & (
+    { sessionId: string; pendingId?: never }
+    | {
+        pendingId: string;
+        sessionId?: never;
+        cwd: string;
+        createdAt: string;
+        excludedSessionIds: string[];
+        projectName?: string;
+        title?: string;
+        markerPath?: string;
+        requestFingerprint: string;
+    }
+);
+
+export type TmuxFinalRuntimeBinding = TmuxKnownRuntimeBinding | TmuxInactiveRuntimeBinding;
+
+export type TmuxRuntimeBinding = TmuxPendingRuntimeBinding | TmuxFinalRuntimeBinding
+    | TmuxAmbiguousRuntimeBinding | TmuxConsumedPendingBinding | TmuxPromotingRuntimeBinding
+    | TmuxKnownRebindIntent;
+
+export type TmuxFinalRecordLock = <T>(operation: () => Promise<T>) => Promise<T>;
+
+const RECORD_VERSION = 2;
+export const MAX_ID_LENGTH = 512;
+const MAX_PATH_LENGTH = 4096;
+const MAX_TITLE_LENGTH = 200;
+const MAX_EXCLUDED_SESSION_IDS = 1000;
+const PENDING_TTL_MS = 24 * 60 * 60 * 1000;
+const MAX_FUTURE_SKEW_MS = 5 * 60 * 1000;
+const KNOWN_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+const CONTROL_CHARACTERS = /[\u0000-\u001f\u007f]/;
+
+export function isCanonicalRecordPath(filePath: string, record: TmuxRuntimeBinding): boolean {
+    if (record.state === 'rebind-known') {
+        return false;
+    }
+    let identity: string[];
+    if (record.state === 'pending') {
+        identity = pendingRecordIdentityParts(record);
+    } else if (record.state === 'known' || record.state === 'completed' || record.state === 'stopped') {
+        identity = [record.provider, record.workspaceScopeIdentity, record.sessionId];
+    } else if (record.state === 'consumed' || record.state === 'promoting') {
+        identity = pendingRecordIdentityParts(record);
+    } else {
+        identity = ambiguousRecordIdentityParts(record as TmuxAmbiguousRuntimeBinding);
+    }
+    const canonicalState = record.state === 'completed' || record.state === 'stopped'
+        ? 'known' : record.state;
+    return path.basename(filePath) === getRecordFilename(canonicalState, ...identity);
+}
+
+export function getRecordFilename(
+    kind: 'pending' | 'known' | 'ambiguous' | 'consumed' | 'promoting' | 'rebind',
+    ...identity: string[]
+): string {
+    const digest = createHash('sha256')
+        .update(JSON.stringify([RECORD_VERSION, kind, ...identity]), 'utf8')
+        .digest('hex');
+    return `${kind}-${digest}.json`;
+}
+
+function validatePendingRecord(value: unknown): TmuxPendingRuntimeBinding | null {
+    if (!isObject(value)) {
+        return null;
+    }
+    const record = value as Record<string, unknown>;
+    const locator = validateLocator(record.locator);
+    const identity = validateBindingIdentity(record, { pendingId: record.pendingId });
+    if (!hasExactKeys(record, [
+        'version', 'state', 'pendingId', 'provider', 'workspaceScopeIdentity',
+        'workspaceNavigationIdentity', 'workspaceRootHostPaths', 'cwd', 'createdAt',
+        'excludedSessionIds', 'acceptedAtMs', 'layout', 'locator',
+    ], ['projectName', 'title'])
+        || record.version !== RECORD_VERSION || record.state !== 'pending'
+        || !identity
+        || !isDateString(record.createdAt) || !isLayout(record.layout) || !locator
+        || locator.layout !== record.layout || !Array.isArray(record.excludedSessionIds)
+        || record.excludedSessionIds.length > MAX_EXCLUDED_SESSION_IDS
+        || record.excludedSessionIds.some(id => !isBoundedString(id, MAX_ID_LENGTH))
+        || !isFiniteNonNegative(record.acceptedAtMs)
+        || (record.projectName !== undefined && !isOptionalTitle(record.projectName))
+        || (record.title !== undefined && !isOptionalTitle(record.title))) {
+        return null;
+    }
+    return {
+        version: 2,
+        state: 'pending',
+        pendingId: identity.pendingId as string,
+        ...bindingIdentityFields(identity),
+        createdAt: record.createdAt,
+        excludedSessionIds: [...record.excludedSessionIds] as string[],
+        ...(record.projectName === undefined ? {} : { projectName: record.projectName as string }),
+        ...(record.title === undefined ? {} : { title: record.title as string }),
+        acceptedAtMs: record.acceptedAtMs,
+        layout: record.layout,
+        locator,
+    };
+}
+
+export function validateTmuxPendingRuntimeBinding(
+    value: unknown,
+    nowMs: number = Date.now()
+): TmuxPendingRuntimeBinding | null {
+    const record = validatePersistedPendingRecord(value, nowMs);
+    const createdAtMs = record ? Date.parse(record.createdAt) : NaN;
+    return record && nowMs - createdAtMs < PENDING_TTL_MS
+        ? record
+        : null;
+}
+
+export function validatePersistedPendingRecord(
+    value: unknown,
+    nowMs: number
+): TmuxPendingRuntimeBinding | null {
+    const record = validatePendingRecord(value);
+    const createdAtMs = record ? Date.parse(record.createdAt) : NaN;
+    return record && Number.isFinite(nowMs) && createdAtMs <= nowMs + MAX_FUTURE_SKEW_MS
+        && record.acceptedAtMs <= nowMs + MAX_FUTURE_SKEW_MS
+        && !isPendingExpired(record, nowMs)
+        ? record
+        : null;
+}
+
+export function validateConsumedRecord(
+    value: unknown,
+    requireFinalSessionName: boolean = false
+): TmuxConsumedPendingBinding | null {
+    if (!isObject(value)) {
+        return null;
+    }
+    const record = value as Record<string, unknown>;
+    const locator = validateLocator(record.finalLocator);
+    const identity = validateBindingIdentity(record, { pendingId: record.pendingId });
+    const legacyKeys = [
+        'version', 'state', 'pendingId', 'provider', 'workspaceScopeIdentity',
+        'workspaceNavigationIdentity', 'workspaceRootHostPaths', 'cwd', 'finalSessionId',
+        'layout', 'finalLocator', 'consumedAtMs',
+    ];
+    const hasFinalSessionName = Object.prototype.hasOwnProperty.call(record, 'finalSessionName');
+    if (!(hasExactKeys(record, [...legacyKeys, 'finalSessionName'])
+            || (!requireFinalSessionName && hasExactKeys(record, legacyKeys)))
+        || record.version !== RECORD_VERSION || record.state !== 'consumed'
+        || !identity
+        || !isBoundedString(record.finalSessionId, MAX_ID_LENGTH)
+        || (hasFinalSessionName && !isRequiredDisplayName(record.finalSessionName))
+        || !isLayout(record.layout) || !locator || locator.layout !== record.layout
+        || !isFiniteNonNegative(record.consumedAtMs)) {
+        return null;
+    }
+    return {
+        version: 2,
+        state: 'consumed',
+        pendingId: identity.pendingId as string,
+        ...bindingIdentityFields(identity),
+        finalSessionId: record.finalSessionId,
+        ...(hasFinalSessionName ? { finalSessionName: record.finalSessionName as string } : {}),
+        layout: record.layout,
+        finalLocator: locator,
+        consumedAtMs: record.consumedAtMs,
+    };
+}
+
+export function isLegacyProjectKeyConsumedRecord(value: unknown): boolean {
+    if (!isObject(value)) {
+        return false;
+    }
+    const record = value as Record<string, unknown>;
+    const locator = validateLocator(record.finalLocator);
+    return hasExactKeys(record, [
+        'version', 'state', 'pendingId', 'provider', 'projectKey', 'cwd',
+        'finalSessionId', 'layout', 'finalLocator', 'consumedAtMs',
+    ])
+        && record.version === 1
+        && record.state === 'consumed'
+        && isBoundedString(record.pendingId, MAX_ID_LENGTH)
+        && isProviderId(record.provider)
+        && isBoundedString(record.projectKey, MAX_ID_LENGTH)
+        && isBoundedString(record.cwd, MAX_PATH_LENGTH)
+        && isBoundedString(record.finalSessionId, MAX_ID_LENGTH)
+        && isLayout(record.layout)
+        && !!locator && locator.layout === record.layout
+        && isFiniteNonNegative(record.consumedAtMs);
+}
+
+export function validatePromotingRecord(value: unknown): TmuxPromotingRuntimeBinding | null {
+    if (!isObject(value)) {
+        return null;
+    }
+    const record = value as Record<string, unknown>;
+    const sourceLocator = validateLocator(record.sourceLocator);
+    const finalLocator = validateLocator(record.finalLocator);
+    const pendingBinding = validatePendingRecord(record.pendingBinding);
+    const identity = validateBindingIdentity(record, { pendingId: record.pendingId });
+    if (!hasExactKeys(record, [
+        'version', 'state', 'pendingId', 'provider', 'workspaceScopeIdentity',
+        'workspaceNavigationIdentity', 'workspaceRootHostPaths', 'cwd', 'createdAt',
+        'markerPath', 'pendingBinding', 'finalSessionId', 'layout', 'sourceLocator',
+        'finalSessionName', 'finalLocator', 'requestFingerprint', 'recordedAtMs',
+    ]) || record.version !== RECORD_VERSION || record.state !== 'promoting'
+        || !identity
+        || !isDateString(record.createdAt)
+        || (record.markerPath !== '' && !isBoundedString(record.markerPath, MAX_PATH_LENGTH))
+        || !isBoundedString(record.finalSessionId, MAX_ID_LENGTH)
+        || !isRequiredDisplayName(record.finalSessionName) || !isLayout(record.layout)
+        || !sourceLocator || sourceLocator.layout !== record.layout
+        || !finalLocator || finalLocator.layout !== record.layout
+        || (record.layout === 'project' && sourceLocator.sessionName !== finalLocator.sessionName)
+        || locatorsEqual(sourceLocator, finalLocator)
+        || !pendingBinding || pendingBinding.pendingId !== record.pendingId
+        || !bindingIdentitiesEqual(pendingBinding, identity)
+        || pendingBinding.createdAt !== record.createdAt
+        || pendingBinding.layout !== record.layout || !locatorsEqual(pendingBinding.locator, sourceLocator)
+        || typeof record.requestFingerprint !== 'string' || !/^[a-f0-9]{64}$/.test(record.requestFingerprint)
+        || !isFiniteNonNegative(record.recordedAtMs)) {
+        return null;
+    }
+    return {
+        version: 2,
+        state: 'promoting',
+        pendingId: identity.pendingId as string,
+        ...bindingIdentityFields(identity),
+        createdAt: record.createdAt,
+        markerPath: record.markerPath,
+        pendingBinding,
+        finalSessionId: record.finalSessionId,
+        finalSessionName: record.finalSessionName,
+        layout: record.layout,
+        sourceLocator,
+        finalLocator,
+        requestFingerprint: record.requestFingerprint,
+        recordedAtMs: record.recordedAtMs,
+    };
+}
+
+export function validateAmbiguousRecord(value: unknown): TmuxAmbiguousRuntimeBinding | null {
+    if (!isObject(value)) {
+        return null;
+    }
+    const record = value as Record<string, unknown>;
+    const locator = validateLocator(record.locator);
+    const hasSessionId = record.sessionId !== undefined;
+    const hasPendingId = record.pendingId !== undefined;
+    const exactKeys = hasSessionId
+        ? hasExactKeys(record, [
+            'version', 'state', 'provider', 'workspaceScopeIdentity',
+            'workspaceNavigationIdentity', 'workspaceRootHostPaths', 'cwd', 'layout',
+            'locator', 'acceptedAtMs', 'sessionId',
+        ])
+        : hasExactKeys(record, [
+            'version', 'state', 'provider', 'workspaceScopeIdentity',
+            'workspaceNavigationIdentity', 'workspaceRootHostPaths', 'cwd', 'layout',
+            'locator', 'acceptedAtMs', 'pendingId', 'createdAt', 'excludedSessionIds',
+            'requestFingerprint',
+        ], ['projectName', 'title', 'markerPath']);
+    const identity = hasSessionId === hasPendingId ? null : validateBindingIdentity(record,
+        hasSessionId ? { sessionId: record.sessionId } : { pendingId: record.pendingId });
+    if (!exactKeys || record.version !== RECORD_VERSION || record.state !== 'ambiguous'
+        || !identity
+        || !isLayout(record.layout) || !locator || locator.layout !== record.layout
+        || !isFiniteNonNegative(record.acceptedAtMs)
+        || (hasPendingId && (!isDateString(record.createdAt) || !Array.isArray(record.excludedSessionIds)
+            || record.excludedSessionIds.length > MAX_EXCLUDED_SESSION_IDS
+            || record.excludedSessionIds.some(id => !isBoundedString(id, MAX_ID_LENGTH))
+            || (record.projectName !== undefined && !isOptionalTitle(record.projectName))
+            || (record.title !== undefined && !isOptionalTitle(record.title))
+            || (record.markerPath !== undefined
+                && !isBoundedString(record.markerPath, MAX_PATH_LENGTH))
+            || typeof record.requestFingerprint !== 'string'
+            || !/^(?:v3:)?[a-f0-9]{64}$/.test(record.requestFingerprint)))) {
+        return null;
+    }
+    return {
+        version: 2,
+        state: 'ambiguous',
+        ...bindingIdentityFields(identity),
+        ...(hasSessionId
+            ? { sessionId: record.sessionId as string }
+            : {
+                pendingId: record.pendingId as string,
+                cwd: record.cwd as string,
+                createdAt: record.createdAt as string,
+                excludedSessionIds: [...record.excludedSessionIds as string[]],
+                ...(record.projectName === undefined ? {} : { projectName: record.projectName as string }),
+                ...(record.title === undefined ? {} : { title: record.title as string }),
+                ...(record.markerPath === undefined ? {} : { markerPath: record.markerPath as string }),
+                requestFingerprint: record.requestFingerprint as string,
+            }),
+        layout: record.layout,
+        locator,
+        acceptedAtMs: record.acceptedAtMs,
+    } as TmuxAmbiguousRuntimeBinding;
+}
+
+export function validateKnownRecord(value: unknown): TmuxKnownRuntimeBinding | null {
+    if (!isObject(value)) {
+        return null;
+    }
+    const record = value as Record<string, unknown>;
+    const locator = validateLocator(record.locator);
+    const identity = validateBindingIdentity(record, { sessionId: record.sessionId });
+    const lifecycleFieldCount = [record.markerPath, record.runStartedAtMs]
+        .filter(field => field !== undefined).length;
+    if (!hasExactKeys(record, [
+        'version', 'state', 'provider', 'sessionId', 'workspaceScopeIdentity',
+        'workspaceNavigationIdentity', 'workspaceRootHostPaths', 'cwd', 'layout',
+        'locator', 'lastSeenAtMs',
+    ], ['markerPath', 'runStartedAtMs'])
+        || record.version !== RECORD_VERSION || record.state !== 'known'
+        || !identity
+        || !isLayout(record.layout) || !locator || locator.layout !== record.layout
+        || !isFiniteNonNegative(record.lastSeenAtMs)
+        || (lifecycleFieldCount !== 0 && lifecycleFieldCount !== 2)
+        || (lifecycleFieldCount === 2 && (!isBoundedPath(record.markerPath)
+            || !isFinitePositive(record.runStartedAtMs)))) {
+        return null;
+    }
+    return {
+        version: 2,
+        state: 'known',
+        sessionId: identity.sessionId as string,
+        ...bindingIdentityFields(identity),
+        layout: record.layout,
+        locator,
+        lastSeenAtMs: record.lastSeenAtMs,
+        ...(lifecycleFieldCount === 2 ? {
+            markerPath: record.markerPath as string,
+            runStartedAtMs: record.runStartedAtMs as number,
+        } : {}),
+    };
+}
+
+export function validateKnownRebindIntent(value: unknown): TmuxKnownRebindIntent | null {
+    if (!isObject(value)) {
+        return null;
+    }
+    const record = value as Record<string, unknown>;
+    const expected = validateKnownRecord(record.expected);
+    const replacement = validateKnownRecord(record.replacement);
+    if (!hasExactKeys(record, [
+        'version', 'state', 'expected', 'replacement', 'recordedAtMs',
+    ]) || record.version !== 1 || record.state !== 'rebind-known'
+        || !expected || !replacement
+        || expected.sessionId === replacement.sessionId
+        || !knownBindingsEqualExceptSessionId(expected, replacement)
+        || !isFiniteNonNegative(record.recordedAtMs)) {
+        return null;
+    }
+    return {
+        version: 1,
+        state: 'rebind-known',
+        expected: cloneKnown(expected),
+        replacement: cloneKnown(replacement),
+        recordedAtMs: record.recordedAtMs as number,
+    };
+}
+
+export function validateInactiveRecord(
+    value: unknown,
+    nowMs: number = Date.now()
+): TmuxInactiveRuntimeBinding | null {
+    if (!isObject(value)) {
+        return null;
+    }
+    const record = value as Record<string, unknown>;
+    const locator = validateLocator(record.locator);
+    const identity = validateBindingIdentity(record, { sessionId: record.sessionId });
+    if (!hasExactKeys(record, [
+        'version', 'state', 'provider', 'sessionId', 'workspaceScopeIdentity',
+        'workspaceNavigationIdentity', 'workspaceRootHostPaths', 'cwd', 'layout',
+        'locator', 'markerPath', 'runStartedAtMs', 'detectedAtMs',
+    ]) || record.version !== RECORD_VERSION
+        || (record.state !== 'completed' && record.state !== 'stopped')
+        || !identity || !isLayout(record.layout)
+        || !locator || locator.layout !== record.layout
+        || !isBoundedPath(record.markerPath)
+        || !isFinitePositive(record.runStartedAtMs)
+        || !isFinitePositive(record.detectedAtMs)
+        || !Number.isFinite(nowMs) || record.detectedAtMs > nowMs + MAX_FUTURE_SKEW_MS) {
+        return null;
+    }
+    return {
+        version: 2,
+        state: record.state,
+        sessionId: identity.sessionId as string,
+        ...bindingIdentityFields(identity),
+        layout: record.layout,
+        locator,
+        markerPath: record.markerPath,
+        runStartedAtMs: record.runStartedAtMs,
+        detectedAtMs: record.detectedAtMs,
+    };
+}
+
+export function validateFinalRuntimeRecord(
+    value: unknown,
+    nowMs: number = Date.now()
+): TmuxFinalRuntimeBinding | null {
+    return validateKnownRecord(value) || validateInactiveRecord(value, nowMs);
+}
+
+function validateLocator(value: unknown): AiSessionTmuxLocator | null {
+    if (!isObject(value)) {
+        return null;
+    }
+    const record = value as Record<string, unknown>;
+    const hasValidKeys = record.layout === 'project'
+        ? hasExactKeys(record, ['layout', 'sessionName', 'windowName'])
+        : hasExactKeys(record, ['layout', 'sessionName'])
+            || hasExactKeys(record, ['layout', 'sessionName', 'windowName']);
+    if (!isLayout(record.layout) || !isBoundedString(record.sessionName, MAX_ID_LENGTH)
+        || !hasValidKeys) {
+        return null;
+    }
+    if (record.layout === 'project') {
+        return isBoundedString(record.windowName, MAX_ID_LENGTH)
+            ? { layout: 'project', sessionName: record.sessionName, windowName: record.windowName }
+            : null;
+    }
+    return hasExactKeys(record, ['layout', 'sessionName'])
+        ? { layout: 'session', sessionName: record.sessionName }
+        : isBoundedString(record.windowName, MAX_ID_LENGTH)
+            ? { layout: 'session', sessionName: record.sessionName, windowName: record.windowName }
+            : null;
+}
+
+function hasExactKeys(
+    record: Record<string, unknown>,
+    required: readonly string[],
+    optional: readonly string[] = []
+): boolean {
+    const allowed = new Set([...required, ...optional]);
+    return required.every(key => Object.prototype.hasOwnProperty.call(record, key))
+        && Object.keys(record).every(key => allowed.has(key));
+}
+
+export function locatorsEqual(left: AiSessionTmuxLocator, right: AiSessionTmuxLocator): boolean {
+    return left.layout === right.layout && left.sessionName === right.sessionName
+        && left.windowName === right.windowName;
+}
+
+export function pendingLifecycleRecordKey(record: {
+    provider: AiSessionProviderId;
+    workspaceScopeIdentity: string;
+    workspaceNavigationIdentity: string;
+    workspaceRootHostPaths: string[];
+    cwd: string;
+    pendingId: string;
+}): string {
+    return JSON.stringify(pendingRecordIdentityParts(record));
+}
+
+export function pendingBindingsEqual(
+    left: TmuxPendingRuntimeBinding,
+    right: TmuxPendingRuntimeBinding
+): boolean {
+    return pendingLifecycleRecordKey(left) === pendingLifecycleRecordKey(right)
+        && left.createdAt === right.createdAt
+        && left.acceptedAtMs === right.acceptedAtMs
+        && left.projectName === right.projectName
+        && left.title === right.title
+        && left.layout === right.layout
+        && locatorsEqual(left.locator, right.locator)
+        && left.excludedSessionIds.length === right.excludedSessionIds.length
+        && left.excludedSessionIds.every((value, index) => value === right.excludedSessionIds[index]);
+}
+
+export function consumedMatchesPromoting(
+    consumed: TmuxConsumedPendingBinding,
+    promoting: TmuxPromotingRuntimeBinding
+): boolean {
+    return consumed.finalSessionName !== undefined
+        && consumed.finalSessionId === promoting.finalSessionId
+        && consumed.finalSessionName === promoting.finalSessionName
+        && consumed.layout === promoting.layout
+        && locatorsEqual(consumed.finalLocator, promoting.finalLocator);
+}
+
+export function inactiveBindingsMatchRun(
+    left: TmuxInactiveRuntimeBinding,
+    right: TmuxInactiveRuntimeBinding
+): boolean {
+    return bindingIdentitiesEqual(left, right)
+        && left.layout === right.layout && locatorsEqual(left.locator, right.locator)
+        && left.markerPath === right.markerPath
+        && left.runStartedAtMs === right.runStartedAtMs;
+}
+
+export function inactiveBindingsEqual(
+    left: TmuxInactiveRuntimeBinding,
+    right: TmuxInactiveRuntimeBinding
+): boolean {
+    return inactiveBindingsMatchRun(left, right)
+        && left.state === right.state
+        && left.detectedAtMs === right.detectedAtMs;
+}
+
+export function knownBindingsEqual(
+    left: TmuxKnownRuntimeBinding,
+    right: TmuxKnownRuntimeBinding
+): boolean {
+    return left.sessionId === right.sessionId
+        && knownBindingsEqualExceptSessionId(left, right);
+}
+
+function knownBindingsEqualExceptSessionId(
+    left: TmuxKnownRuntimeBinding,
+    right: TmuxKnownRuntimeBinding
+): boolean {
+    return bindingIdentitiesEqual(left, right)
+        && left.layout === right.layout
+        && locatorsEqual(left.locator, right.locator)
+        && left.lastSeenAtMs === right.lastSeenAtMs
+        && left.markerPath === right.markerPath
+        && left.runStartedAtMs === right.runStartedAtMs;
+}
+
+export function clonePending(record: TmuxPendingRuntimeBinding): TmuxPendingRuntimeBinding {
+    return { ...record, workspaceRootHostPaths: [...record.workspaceRootHostPaths], excludedSessionIds: [...record.excludedSessionIds], locator: { ...record.locator } };
+}
+
+export function cloneKnown(record: TmuxKnownRuntimeBinding): TmuxKnownRuntimeBinding {
+    return { ...record, workspaceRootHostPaths: [...record.workspaceRootHostPaths], locator: { ...record.locator } };
+}
+
+export function cloneInactive(record: TmuxInactiveRuntimeBinding): TmuxInactiveRuntimeBinding {
+    return { ...record, workspaceRootHostPaths: [...record.workspaceRootHostPaths], locator: { ...record.locator } };
+}
+
+export function cloneAmbiguous(record: TmuxAmbiguousRuntimeBinding): TmuxAmbiguousRuntimeBinding {
+    if (record.sessionId !== undefined) {
+        return { ...record, workspaceRootHostPaths: [...record.workspaceRootHostPaths], locator: { ...record.locator } };
+    }
+    const pendingRecord = record as TmuxAmbiguousRuntimeBindingBase & {
+        pendingId: string;
+        cwd: string;
+        createdAt: string;
+        excludedSessionIds: string[];
+        projectName?: string;
+        title?: string;
+        markerPath?: string;
+        requestFingerprint: string;
+    };
+    return {
+        ...pendingRecord,
+        workspaceRootHostPaths: [...pendingRecord.workspaceRootHostPaths],
+        locator: { ...pendingRecord.locator },
+        excludedSessionIds: [...pendingRecord.excludedSessionIds],
+    };
+}
+
+export function cloneConsumed(record: TmuxConsumedPendingBinding): TmuxConsumedPendingBinding {
+    return { ...record, workspaceRootHostPaths: [...record.workspaceRootHostPaths], finalLocator: { ...record.finalLocator } };
+}
+
+export function clonePromoting(record: TmuxPromotingRuntimeBinding): TmuxPromotingRuntimeBinding {
+    return {
+        ...record,
+        workspaceRootHostPaths: [...record.workspaceRootHostPaths],
+        sourceLocator: { ...record.sourceLocator },
+        finalLocator: { ...record.finalLocator },
+        pendingBinding: clonePending(record.pendingBinding),
+    };
+}
+
+export function consumedRecordMatchesIdentity(
+    record: TmuxConsumedPendingBinding,
+    identity: AiSessionRuntimeIdentity
+): boolean {
+    return record.pendingId === identity.pendingId && bindingIdentitiesEqual(record, identity);
+}
+
+export function pendingRecordMatchesIdentity(
+    record: TmuxPendingRuntimeBinding,
+    identity: AiSessionRuntimeIdentity
+): boolean {
+    return record.pendingId === identity.pendingId && bindingIdentitiesEqual(record, identity);
+}
+
+export function pendingIdentityParts(identity: AiSessionRuntimeIdentity): string[] | null {
+    return identity && identity.sessionId === undefined && isValidAiSessionRuntimeIdentity(identity)
+        ? [
+            identity.provider,
+            identity.workspaceScopeIdentity,
+            identity.workspaceNavigationIdentity,
+            getAiSessionRuntimeRootSnapshotKey(identity),
+            identity.cwd,
+            identity.pendingId as string,
+        ]
+        : null;
+}
+
+export function pendingRecordIdentityParts(record: {
+    provider: AiSessionProviderId;
+    workspaceScopeIdentity: string;
+    workspaceNavigationIdentity: string;
+    workspaceRootHostPaths: string[];
+    cwd: string;
+    pendingId: string;
+}): string[] {
+    return [
+        record.provider,
+        record.workspaceScopeIdentity,
+        record.workspaceNavigationIdentity,
+        getAiSessionRuntimeRootSnapshotKey(record as AiSessionRuntimeIdentity),
+        record.cwd,
+        record.pendingId,
+    ];
+}
+
+export function promotingRecordMatchesIdentity(
+    record: TmuxPromotingRuntimeBinding,
+    identity: AiSessionRuntimeIdentity
+): boolean {
+    return record.pendingId === identity.pendingId && bindingIdentitiesEqual(record, identity);
+}
+
+export function ambiguousIdentityParts(identity: AiSessionRuntimeIdentity): string[] | null {
+    if (!isValidAiSessionRuntimeIdentity(identity)) {
+        return null;
+    }
+    const hasSessionId = identity.sessionId !== undefined;
+    const hasPendingId = identity.pendingId !== undefined;
+    if (hasSessionId === hasPendingId) {
+        return null;
+    }
+    const id = hasSessionId ? identity.sessionId : identity.pendingId;
+    if (!isBoundedString(id, MAX_ID_LENGTH)) {
+        return null;
+    }
+    return hasSessionId
+        ? [identity.provider, identity.workspaceScopeIdentity, 'session', id]
+        : [
+            identity.provider,
+            identity.workspaceScopeIdentity,
+            'pending',
+            identity.workspaceNavigationIdentity,
+            getAiSessionRuntimeRootSnapshotKey(identity),
+            identity.cwd,
+            id,
+        ];
+}
+
+export function ambiguousRecordIdentityParts(record: TmuxAmbiguousRuntimeBinding): string[] {
+    return record.sessionId !== undefined ? [
+        record.provider,
+        record.workspaceScopeIdentity,
+        'session',
+        record.sessionId,
+    ] : [
+        record.provider,
+        record.workspaceScopeIdentity,
+        'pending',
+        record.workspaceNavigationIdentity,
+        getAiSessionRuntimeRootSnapshotKey(record as AiSessionRuntimeIdentity),
+        record.cwd,
+        record.pendingId,
+    ];
+}
+
+export function ambiguousRecordMatchesIdentity(
+    record: TmuxAmbiguousRuntimeBinding,
+    identity: AiSessionRuntimeIdentity
+): boolean {
+    return record.provider === identity.provider
+        && bindingIdentitiesEqual(record, identity)
+        && record.sessionId === identity.sessionId
+        && record.pendingId === identity.pendingId;
+}
+
+function validateBindingIdentity(
+    record: Record<string, unknown>,
+    id: { sessionId: unknown } | { pendingId: unknown }
+): AiSessionRuntimeIdentity | null {
+    const identity = {
+        provider: record.provider,
+        workspaceScopeIdentity: record.workspaceScopeIdentity,
+        workspaceNavigationIdentity: record.workspaceNavigationIdentity,
+        workspaceRootHostPaths: record.workspaceRootHostPaths,
+        cwd: record.cwd,
+        ...id,
+    };
+    return isValidAiSessionRuntimeIdentity(identity)
+        ? cloneAiSessionRuntimeIdentity(identity)
+        : null;
+}
+
+function bindingIdentityFields(identity: AiSessionRuntimeIdentity) {
+    return {
+        provider: identity.provider,
+        workspaceScopeIdentity: identity.workspaceScopeIdentity,
+        workspaceNavigationIdentity: identity.workspaceNavigationIdentity,
+        workspaceRootHostPaths: [...identity.workspaceRootHostPaths],
+        cwd: identity.cwd,
+    };
+}
+
+export function bindingIdentitiesEqual(
+    left: {
+        provider: AiSessionProviderId;
+        workspaceScopeIdentity: string;
+        workspaceNavigationIdentity: string;
+        workspaceRootHostPaths: string[];
+        cwd: string;
+    },
+    right: {
+        provider: AiSessionProviderId;
+        workspaceScopeIdentity: string;
+        workspaceNavigationIdentity: string;
+        workspaceRootHostPaths: string[];
+        cwd: string;
+    }
+): boolean {
+    return left.provider === right.provider
+        && left.workspaceScopeIdentity === right.workspaceScopeIdentity
+        && left.workspaceNavigationIdentity === right.workspaceNavigationIdentity
+        && getAiSessionRuntimeRootSnapshotKey(left as AiSessionRuntimeIdentity)
+            === getAiSessionRuntimeRootSnapshotKey(right as AiSessionRuntimeIdentity)
+        && left.cwd === right.cwd;
+}
+
+function isPendingExpired(record: TmuxPendingRuntimeBinding, now: number): boolean {
+    return now - record.acceptedAtMs >= PENDING_TTL_MS;
+}
+
+export function isKnownExpired(record: TmuxKnownRuntimeBinding, now: number): boolean {
+    return now - record.lastSeenAtMs >= KNOWN_TTL_MS;
+}
+
+export function isInactiveExpired(record: TmuxInactiveRuntimeBinding, now: number): boolean {
+    return now - record.detectedAtMs >= KNOWN_TTL_MS;
+}
+
+export function isFinalRuntimeExpired(record: TmuxFinalRuntimeBinding, now: number): boolean {
+    return record.state === 'known' ? isKnownExpired(record, now) : isInactiveExpired(record, now);
+}
+
+export function finalRuntimePriority(record: TmuxFinalRuntimeBinding): number {
+    return record.state === 'completed' ? 0 : record.state === 'known' ? 1 : 2;
+}
+
+export function finalRuntimeTimestamp(record: TmuxFinalRuntimeBinding): number {
+    return record.state === 'known' ? record.lastSeenAtMs : record.detectedAtMs;
+}
+
+function isObject(value: unknown): value is object {
+    return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+export function isProviderId(value: unknown): value is AiSessionProviderId {
+    return value === 'codex' || value === 'kimi' || value === 'claude';
+}
+
+function isLayout(value: unknown): value is AiSessionTmuxLayout {
+    return value === 'project' || value === 'session';
+}
+
+export function isBoundedString(value: unknown, maxLength: number): value is string {
+    return typeof value === 'string' && value.length > 0 && value.length <= maxLength
+        && !CONTROL_CHARACTERS.test(value);
+}
+
+function isOptionalTitle(value: unknown): value is string {
+    return typeof value === 'string' && value.length <= MAX_TITLE_LENGTH && !CONTROL_CHARACTERS.test(value);
+}
+
+function isRequiredDisplayName(value: unknown): value is string {
+    return isValidAiSessionPromotionDisplayName(value);
+}
+
+function isDateString(value: unknown): value is string {
+    return typeof value === 'string' && value.length > 0 && value.length <= MAX_TITLE_LENGTH
+        && Number.isFinite(Date.parse(value));
+}
+
+export function isFiniteNonNegative(value: unknown): value is number {
+    return typeof value === 'number' && Number.isFinite(value) && value >= 0;
+}
+
+export function isFinitePositive(value: unknown): value is number {
+    return typeof value === 'number' && Number.isFinite(value) && value > 0;
+}
+
+export function isBoundedPath(value: unknown): value is string {
+    return typeof value === 'string' && value.length <= MAX_PATH_LENGTH
+        && !CONTROL_CHARACTERS.test(value);
+}
+
+export function isNodeError(error: unknown, code: string): boolean {
+    return !!error && typeof error === 'object' && (error as NodeJS.ErrnoException).code === code;
+}

--- a/src/aiSessions/tmuxRuntimeBindingStore.ts
+++ b/src/aiSessions/tmuxRuntimeBindingStore.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import { createHash, randomBytes } from 'crypto';
+import { randomBytes } from 'crypto';
 import { constants as fsConstants, promises as fs } from 'fs';
 import type { Stats } from 'fs';
 import * as path from 'path';
@@ -8,178 +8,93 @@ import type { AiSessionProviderId } from '../models';
 import type {
     AiSessionRuntimeIdentity,
     AiSessionRuntimeSnapshot,
-    AiSessionTmuxLayout,
-    AiSessionTmuxLocator,
 } from './runtimeTypes';
 import {
-    cloneAiSessionRuntimeIdentity,
-    getAiSessionRuntimeRootSnapshotKey,
-    isValidAiSessionPromotionDisplayName,
-    isValidAiSessionRuntimeIdentity,
-} from './runtimeTypes';
+    ambiguousIdentityParts,
+    ambiguousRecordIdentityParts,
+    ambiguousRecordMatchesIdentity,
+    bindingIdentitiesEqual,
+    cloneAmbiguous,
+    cloneConsumed,
+    cloneInactive,
+    cloneKnown,
+    clonePending,
+    clonePromoting,
+    consumedMatchesPromoting,
+    consumedRecordMatchesIdentity,
+    finalRuntimePriority,
+    finalRuntimeTimestamp,
+    getRecordFilename,
+    inactiveBindingsEqual,
+    inactiveBindingsMatchRun,
+    isBoundedPath,
+    isBoundedString,
+    isCanonicalRecordPath,
+    isFinalRuntimeExpired,
+    isFiniteNonNegative,
+    isFinitePositive,
+    isInactiveExpired,
+    isKnownExpired,
+    isLegacyProjectKeyConsumedRecord,
+    isNodeError,
+    isProviderId,
+    knownBindingsEqual,
+    locatorsEqual,
+    pendingBindingsEqual,
+    pendingIdentityParts,
+    pendingLifecycleRecordKey,
+    pendingRecordIdentityParts,
+    pendingRecordMatchesIdentity,
+    promotingRecordMatchesIdentity,
+    validateAmbiguousRecord,
+    validateConsumedRecord,
+    validateFinalRuntimeRecord,
+    validateInactiveRecord,
+    validateKnownRebindIntent,
+    validateKnownRecord,
+    validatePersistedPendingRecord,
+    validatePromotingRecord,
+    MAX_ID_LENGTH,
+} from './tmuxBindingRecords';
+import type {
+    TmuxAmbiguousRuntimeBinding,
+    TmuxConsumedPendingBinding,
+    TmuxFinalBindingSnapshot,
+    TmuxFinalRecordLock,
+    TmuxFinalRuntimeBinding,
+    TmuxInactiveAcknowledgementResult,
+    TmuxInactiveRuntimeBinding,
+    TmuxKnownRebindIntent,
+    TmuxKnownRebindResult,
+    TmuxKnownRuntimeBinding,
+    TmuxPendingRuntimeBinding,
+    TmuxPromotingRuntimeBinding,
+    TmuxRecoverablePendingBinding,
+    TmuxRuntimeBinding,
+} from './tmuxBindingRecords';
+export type {
+    TmuxPendingRuntimeBinding,
+    TmuxKnownRuntimeBinding,
+    TmuxInactiveRuntimeBinding,
+    TmuxInactiveAcknowledgementResult,
+    TmuxKnownRebindResult,
+    TmuxFinalBindingSnapshot,
+    TmuxConsumedPendingBinding,
+    TmuxPromotingRuntimeBinding,
+    TmuxRecoverablePendingBinding,
+    TmuxAmbiguousRuntimeBinding,
+    TmuxFinalRecordLock,
+} from './tmuxBindingRecords';
+export { validateTmuxPendingRuntimeBinding } from './tmuxBindingRecords';
 
-const RECORD_VERSION = 2;
-const MAX_ID_LENGTH = 512;
-const MAX_PATH_LENGTH = 4096;
-const MAX_TITLE_LENGTH = 200;
-const MAX_EXCLUDED_SESSION_IDS = 1000;
 const MAX_RECORD_BYTES = 1024 * 1024;
 const MAX_KNOWN_RECORDS = 512;
 const MAX_INACTIVE_RECORDS = 512;
-const PENDING_TTL_MS = 24 * 60 * 60 * 1000;
-const MAX_FUTURE_SKEW_MS = 5 * 60 * 1000;
-const KNOWN_TTL_MS = 30 * 24 * 60 * 60 * 1000;
-const CONTROL_CHARACTERS = /[\u0000-\u001f\u007f]/;
 const NO_FOLLOW_FLAG = (fsConstants as Record<string, number>).O_NOFOLLOW || 0;
 const NON_BLOCKING_FLAG = (fsConstants as Record<string, number>).O_NONBLOCK || 0;
 const READ_ONLY_FALLBACK = fsConstants.O_RDONLY | NON_BLOCKING_FLAG;
 const READ_ONLY_NO_FOLLOW = READ_ONLY_FALLBACK | NO_FOLLOW_FLAG;
 
-export interface TmuxPendingRuntimeBinding {
-    version: 2;
-    state: 'pending';
-    pendingId: string;
-    provider: AiSessionProviderId;
-    workspaceScopeIdentity: string;
-    workspaceNavigationIdentity: string;
-    workspaceRootHostPaths: string[];
-    cwd: string;
-    createdAt: string;
-    excludedSessionIds: string[];
-    projectName?: string;
-    title?: string;
-    acceptedAtMs: number;
-    layout: AiSessionTmuxLayout;
-    locator: AiSessionTmuxLocator;
-}
-
-export interface TmuxKnownRuntimeBinding {
-    version: 2;
-    state: 'known';
-    provider: AiSessionProviderId;
-    sessionId: string;
-    workspaceScopeIdentity: string;
-    workspaceNavigationIdentity: string;
-    workspaceRootHostPaths: string[];
-    cwd: string;
-    layout: AiSessionTmuxLayout;
-    locator: AiSessionTmuxLocator;
-    lastSeenAtMs: number;
-    markerPath?: string;
-    runStartedAtMs?: number;
-}
-
-export interface TmuxInactiveRuntimeBinding {
-    version: 2;
-    state: 'completed' | 'stopped';
-    provider: AiSessionProviderId;
-    sessionId: string;
-    workspaceScopeIdentity: string;
-    workspaceNavigationIdentity: string;
-    workspaceRootHostPaths: string[];
-    cwd: string;
-    layout: AiSessionTmuxLayout;
-    locator: AiSessionTmuxLocator;
-    markerPath: string;
-    runStartedAtMs: number;
-    detectedAtMs: number;
-}
-
-export type TmuxInactiveAcknowledgementResult = 'acknowledged' | 'stale' | 'missing';
-export type TmuxKnownRebindResult = 'rebound' | 'stale' | 'missing';
-
-export interface TmuxFinalBindingSnapshot {
-    pending: TmuxPendingRuntimeBinding[];
-    known: TmuxKnownRuntimeBinding[];
-    inactive: TmuxInactiveRuntimeBinding[];
-}
-
-interface TmuxKnownRebindIntent {
-    version: 1;
-    state: 'rebind-known';
-    expected: TmuxKnownRuntimeBinding;
-    replacement: TmuxKnownRuntimeBinding;
-    recordedAtMs: number;
-}
-
-export interface TmuxConsumedPendingBinding {
-    version: 2;
-    state: 'consumed';
-    pendingId: string;
-    provider: AiSessionProviderId;
-    workspaceScopeIdentity: string;
-    workspaceNavigationIdentity: string;
-    workspaceRootHostPaths: string[];
-    cwd: string;
-    finalSessionId: string;
-    finalSessionName?: string;
-    layout: AiSessionTmuxLayout;
-    finalLocator: AiSessionTmuxLocator;
-    consumedAtMs: number;
-}
-
-export interface TmuxPromotingRuntimeBinding {
-    version: 2;
-    state: 'promoting';
-    pendingId: string;
-    provider: AiSessionProviderId;
-    workspaceScopeIdentity: string;
-    workspaceNavigationIdentity: string;
-    workspaceRootHostPaths: string[];
-    cwd: string;
-    createdAt: string;
-    markerPath: string;
-    pendingBinding: TmuxPendingRuntimeBinding;
-    finalSessionId: string;
-    finalSessionName: string;
-    layout: AiSessionTmuxLayout;
-    sourceLocator: AiSessionTmuxLocator;
-    finalLocator: AiSessionTmuxLocator;
-    requestFingerprint: string;
-    recordedAtMs: number;
-}
-
-export interface TmuxRecoverablePendingBinding {
-    pendingBinding: TmuxPendingRuntimeBinding;
-    promotionRecoveryDisplayName: string;
-    recoverySessionId: string;
-}
-
-interface TmuxAmbiguousRuntimeBindingBase {
-    version: 2;
-    state: 'ambiguous';
-    provider: AiSessionProviderId;
-    workspaceScopeIdentity: string;
-    workspaceNavigationIdentity: string;
-    workspaceRootHostPaths: string[];
-    cwd: string;
-    layout: AiSessionTmuxLayout;
-    locator: AiSessionTmuxLocator;
-    acceptedAtMs: number;
-}
-
-export type TmuxAmbiguousRuntimeBinding = TmuxAmbiguousRuntimeBindingBase & (
-    { sessionId: string; pendingId?: never }
-    | {
-        pendingId: string;
-        sessionId?: never;
-        cwd: string;
-        createdAt: string;
-        excludedSessionIds: string[];
-        projectName?: string;
-        title?: string;
-        markerPath?: string;
-        requestFingerprint: string;
-    }
-);
-
-type TmuxFinalRuntimeBinding = TmuxKnownRuntimeBinding | TmuxInactiveRuntimeBinding;
-
-type TmuxRuntimeBinding = TmuxPendingRuntimeBinding | TmuxFinalRuntimeBinding
-    | TmuxAmbiguousRuntimeBinding | TmuxConsumedPendingBinding | TmuxPromotingRuntimeBinding
-    | TmuxKnownRebindIntent;
-
-export type TmuxFinalRecordLock = <T>(operation: () => Promise<T>) => Promise<T>;
 
 const runWithoutFinalRecordLock: TmuxFinalRecordLock = operation => operation();
 
@@ -938,34 +853,6 @@ function isUnsupportedNoFollowError(error: unknown): boolean {
     return isNodeError(error, 'EINVAL') || isNodeError(error, 'ENOTSUP') || isNodeError(error, 'EOPNOTSUPP');
 }
 
-function isCanonicalRecordPath(filePath: string, record: TmuxRuntimeBinding): boolean {
-    if (record.state === 'rebind-known') {
-        return false;
-    }
-    let identity: string[];
-    if (record.state === 'pending') {
-        identity = pendingRecordIdentityParts(record);
-    } else if (record.state === 'known' || record.state === 'completed' || record.state === 'stopped') {
-        identity = [record.provider, record.workspaceScopeIdentity, record.sessionId];
-    } else if (record.state === 'consumed' || record.state === 'promoting') {
-        identity = pendingRecordIdentityParts(record);
-    } else {
-        identity = ambiguousRecordIdentityParts(record as TmuxAmbiguousRuntimeBinding);
-    }
-    const canonicalState = record.state === 'completed' || record.state === 'stopped'
-        ? 'known' : record.state;
-    return path.basename(filePath) === getRecordFilename(canonicalState, ...identity);
-}
-
-function getRecordFilename(
-    kind: 'pending' | 'known' | 'ambiguous' | 'consumed' | 'promoting' | 'rebind',
-    ...identity: string[]
-): string {
-    const digest = createHash('sha256')
-        .update(JSON.stringify([RECORD_VERSION, kind, ...identity]), 'utf8')
-        .digest('hex');
-    return `${kind}-${digest}.json`;
-}
 
 async function removeFile(filePath: string): Promise<void> {
     try {
@@ -1000,732 +887,3 @@ async function removeFileDurably(filePath: string): Promise<void> {
     }
 }
 
-function validatePendingRecord(value: unknown): TmuxPendingRuntimeBinding | null {
-    if (!isObject(value)) {
-        return null;
-    }
-    const record = value as Record<string, unknown>;
-    const locator = validateLocator(record.locator);
-    const identity = validateBindingIdentity(record, { pendingId: record.pendingId });
-    if (!hasExactKeys(record, [
-        'version', 'state', 'pendingId', 'provider', 'workspaceScopeIdentity',
-        'workspaceNavigationIdentity', 'workspaceRootHostPaths', 'cwd', 'createdAt',
-        'excludedSessionIds', 'acceptedAtMs', 'layout', 'locator',
-    ], ['projectName', 'title'])
-        || record.version !== RECORD_VERSION || record.state !== 'pending'
-        || !identity
-        || !isDateString(record.createdAt) || !isLayout(record.layout) || !locator
-        || locator.layout !== record.layout || !Array.isArray(record.excludedSessionIds)
-        || record.excludedSessionIds.length > MAX_EXCLUDED_SESSION_IDS
-        || record.excludedSessionIds.some(id => !isBoundedString(id, MAX_ID_LENGTH))
-        || !isFiniteNonNegative(record.acceptedAtMs)
-        || (record.projectName !== undefined && !isOptionalTitle(record.projectName))
-        || (record.title !== undefined && !isOptionalTitle(record.title))) {
-        return null;
-    }
-    return {
-        version: 2,
-        state: 'pending',
-        pendingId: identity.pendingId as string,
-        ...bindingIdentityFields(identity),
-        createdAt: record.createdAt,
-        excludedSessionIds: [...record.excludedSessionIds] as string[],
-        ...(record.projectName === undefined ? {} : { projectName: record.projectName as string }),
-        ...(record.title === undefined ? {} : { title: record.title as string }),
-        acceptedAtMs: record.acceptedAtMs,
-        layout: record.layout,
-        locator,
-    };
-}
-
-export function validateTmuxPendingRuntimeBinding(
-    value: unknown,
-    nowMs: number = Date.now()
-): TmuxPendingRuntimeBinding | null {
-    const record = validatePersistedPendingRecord(value, nowMs);
-    const createdAtMs = record ? Date.parse(record.createdAt) : NaN;
-    return record && nowMs - createdAtMs < PENDING_TTL_MS
-        ? record
-        : null;
-}
-
-function validatePersistedPendingRecord(
-    value: unknown,
-    nowMs: number
-): TmuxPendingRuntimeBinding | null {
-    const record = validatePendingRecord(value);
-    const createdAtMs = record ? Date.parse(record.createdAt) : NaN;
-    return record && Number.isFinite(nowMs) && createdAtMs <= nowMs + MAX_FUTURE_SKEW_MS
-        && record.acceptedAtMs <= nowMs + MAX_FUTURE_SKEW_MS
-        && !isPendingExpired(record, nowMs)
-        ? record
-        : null;
-}
-
-function validateConsumedRecord(
-    value: unknown,
-    requireFinalSessionName: boolean = false
-): TmuxConsumedPendingBinding | null {
-    if (!isObject(value)) {
-        return null;
-    }
-    const record = value as Record<string, unknown>;
-    const locator = validateLocator(record.finalLocator);
-    const identity = validateBindingIdentity(record, { pendingId: record.pendingId });
-    const legacyKeys = [
-        'version', 'state', 'pendingId', 'provider', 'workspaceScopeIdentity',
-        'workspaceNavigationIdentity', 'workspaceRootHostPaths', 'cwd', 'finalSessionId',
-        'layout', 'finalLocator', 'consumedAtMs',
-    ];
-    const hasFinalSessionName = Object.prototype.hasOwnProperty.call(record, 'finalSessionName');
-    if (!(hasExactKeys(record, [...legacyKeys, 'finalSessionName'])
-            || (!requireFinalSessionName && hasExactKeys(record, legacyKeys)))
-        || record.version !== RECORD_VERSION || record.state !== 'consumed'
-        || !identity
-        || !isBoundedString(record.finalSessionId, MAX_ID_LENGTH)
-        || (hasFinalSessionName && !isRequiredDisplayName(record.finalSessionName))
-        || !isLayout(record.layout) || !locator || locator.layout !== record.layout
-        || !isFiniteNonNegative(record.consumedAtMs)) {
-        return null;
-    }
-    return {
-        version: 2,
-        state: 'consumed',
-        pendingId: identity.pendingId as string,
-        ...bindingIdentityFields(identity),
-        finalSessionId: record.finalSessionId,
-        ...(hasFinalSessionName ? { finalSessionName: record.finalSessionName as string } : {}),
-        layout: record.layout,
-        finalLocator: locator,
-        consumedAtMs: record.consumedAtMs,
-    };
-}
-
-function isLegacyProjectKeyConsumedRecord(value: unknown): boolean {
-    if (!isObject(value)) {
-        return false;
-    }
-    const record = value as Record<string, unknown>;
-    const locator = validateLocator(record.finalLocator);
-    return hasExactKeys(record, [
-        'version', 'state', 'pendingId', 'provider', 'projectKey', 'cwd',
-        'finalSessionId', 'layout', 'finalLocator', 'consumedAtMs',
-    ])
-        && record.version === 1
-        && record.state === 'consumed'
-        && isBoundedString(record.pendingId, MAX_ID_LENGTH)
-        && isProviderId(record.provider)
-        && isBoundedString(record.projectKey, MAX_ID_LENGTH)
-        && isBoundedString(record.cwd, MAX_PATH_LENGTH)
-        && isBoundedString(record.finalSessionId, MAX_ID_LENGTH)
-        && isLayout(record.layout)
-        && !!locator && locator.layout === record.layout
-        && isFiniteNonNegative(record.consumedAtMs);
-}
-
-function validatePromotingRecord(value: unknown): TmuxPromotingRuntimeBinding | null {
-    if (!isObject(value)) {
-        return null;
-    }
-    const record = value as Record<string, unknown>;
-    const sourceLocator = validateLocator(record.sourceLocator);
-    const finalLocator = validateLocator(record.finalLocator);
-    const pendingBinding = validatePendingRecord(record.pendingBinding);
-    const identity = validateBindingIdentity(record, { pendingId: record.pendingId });
-    if (!hasExactKeys(record, [
-        'version', 'state', 'pendingId', 'provider', 'workspaceScopeIdentity',
-        'workspaceNavigationIdentity', 'workspaceRootHostPaths', 'cwd', 'createdAt',
-        'markerPath', 'pendingBinding', 'finalSessionId', 'layout', 'sourceLocator',
-        'finalSessionName', 'finalLocator', 'requestFingerprint', 'recordedAtMs',
-    ]) || record.version !== RECORD_VERSION || record.state !== 'promoting'
-        || !identity
-        || !isDateString(record.createdAt)
-        || (record.markerPath !== '' && !isBoundedString(record.markerPath, MAX_PATH_LENGTH))
-        || !isBoundedString(record.finalSessionId, MAX_ID_LENGTH)
-        || !isRequiredDisplayName(record.finalSessionName) || !isLayout(record.layout)
-        || !sourceLocator || sourceLocator.layout !== record.layout
-        || !finalLocator || finalLocator.layout !== record.layout
-        || (record.layout === 'project' && sourceLocator.sessionName !== finalLocator.sessionName)
-        || locatorsEqual(sourceLocator, finalLocator)
-        || !pendingBinding || pendingBinding.pendingId !== record.pendingId
-        || !bindingIdentitiesEqual(pendingBinding, identity)
-        || pendingBinding.createdAt !== record.createdAt
-        || pendingBinding.layout !== record.layout || !locatorsEqual(pendingBinding.locator, sourceLocator)
-        || typeof record.requestFingerprint !== 'string' || !/^[a-f0-9]{64}$/.test(record.requestFingerprint)
-        || !isFiniteNonNegative(record.recordedAtMs)) {
-        return null;
-    }
-    return {
-        version: 2,
-        state: 'promoting',
-        pendingId: identity.pendingId as string,
-        ...bindingIdentityFields(identity),
-        createdAt: record.createdAt,
-        markerPath: record.markerPath,
-        pendingBinding,
-        finalSessionId: record.finalSessionId,
-        finalSessionName: record.finalSessionName,
-        layout: record.layout,
-        sourceLocator,
-        finalLocator,
-        requestFingerprint: record.requestFingerprint,
-        recordedAtMs: record.recordedAtMs,
-    };
-}
-
-function validateAmbiguousRecord(value: unknown): TmuxAmbiguousRuntimeBinding | null {
-    if (!isObject(value)) {
-        return null;
-    }
-    const record = value as Record<string, unknown>;
-    const locator = validateLocator(record.locator);
-    const hasSessionId = record.sessionId !== undefined;
-    const hasPendingId = record.pendingId !== undefined;
-    const exactKeys = hasSessionId
-        ? hasExactKeys(record, [
-            'version', 'state', 'provider', 'workspaceScopeIdentity',
-            'workspaceNavigationIdentity', 'workspaceRootHostPaths', 'cwd', 'layout',
-            'locator', 'acceptedAtMs', 'sessionId',
-        ])
-        : hasExactKeys(record, [
-            'version', 'state', 'provider', 'workspaceScopeIdentity',
-            'workspaceNavigationIdentity', 'workspaceRootHostPaths', 'cwd', 'layout',
-            'locator', 'acceptedAtMs', 'pendingId', 'createdAt', 'excludedSessionIds',
-            'requestFingerprint',
-        ], ['projectName', 'title', 'markerPath']);
-    const identity = hasSessionId === hasPendingId ? null : validateBindingIdentity(record,
-        hasSessionId ? { sessionId: record.sessionId } : { pendingId: record.pendingId });
-    if (!exactKeys || record.version !== RECORD_VERSION || record.state !== 'ambiguous'
-        || !identity
-        || !isLayout(record.layout) || !locator || locator.layout !== record.layout
-        || !isFiniteNonNegative(record.acceptedAtMs)
-        || (hasPendingId && (!isDateString(record.createdAt) || !Array.isArray(record.excludedSessionIds)
-            || record.excludedSessionIds.length > MAX_EXCLUDED_SESSION_IDS
-            || record.excludedSessionIds.some(id => !isBoundedString(id, MAX_ID_LENGTH))
-            || (record.projectName !== undefined && !isOptionalTitle(record.projectName))
-            || (record.title !== undefined && !isOptionalTitle(record.title))
-            || (record.markerPath !== undefined
-                && !isBoundedString(record.markerPath, MAX_PATH_LENGTH))
-            || typeof record.requestFingerprint !== 'string'
-            || !/^(?:v3:)?[a-f0-9]{64}$/.test(record.requestFingerprint)))) {
-        return null;
-    }
-    return {
-        version: 2,
-        state: 'ambiguous',
-        ...bindingIdentityFields(identity),
-        ...(hasSessionId
-            ? { sessionId: record.sessionId as string }
-            : {
-                pendingId: record.pendingId as string,
-                cwd: record.cwd as string,
-                createdAt: record.createdAt as string,
-                excludedSessionIds: [...record.excludedSessionIds as string[]],
-                ...(record.projectName === undefined ? {} : { projectName: record.projectName as string }),
-                ...(record.title === undefined ? {} : { title: record.title as string }),
-                ...(record.markerPath === undefined ? {} : { markerPath: record.markerPath as string }),
-                requestFingerprint: record.requestFingerprint as string,
-            }),
-        layout: record.layout,
-        locator,
-        acceptedAtMs: record.acceptedAtMs,
-    } as TmuxAmbiguousRuntimeBinding;
-}
-
-function validateKnownRecord(value: unknown): TmuxKnownRuntimeBinding | null {
-    if (!isObject(value)) {
-        return null;
-    }
-    const record = value as Record<string, unknown>;
-    const locator = validateLocator(record.locator);
-    const identity = validateBindingIdentity(record, { sessionId: record.sessionId });
-    const lifecycleFieldCount = [record.markerPath, record.runStartedAtMs]
-        .filter(field => field !== undefined).length;
-    if (!hasExactKeys(record, [
-        'version', 'state', 'provider', 'sessionId', 'workspaceScopeIdentity',
-        'workspaceNavigationIdentity', 'workspaceRootHostPaths', 'cwd', 'layout',
-        'locator', 'lastSeenAtMs',
-    ], ['markerPath', 'runStartedAtMs'])
-        || record.version !== RECORD_VERSION || record.state !== 'known'
-        || !identity
-        || !isLayout(record.layout) || !locator || locator.layout !== record.layout
-        || !isFiniteNonNegative(record.lastSeenAtMs)
-        || (lifecycleFieldCount !== 0 && lifecycleFieldCount !== 2)
-        || (lifecycleFieldCount === 2 && (!isBoundedPath(record.markerPath)
-            || !isFinitePositive(record.runStartedAtMs)))) {
-        return null;
-    }
-    return {
-        version: 2,
-        state: 'known',
-        sessionId: identity.sessionId as string,
-        ...bindingIdentityFields(identity),
-        layout: record.layout,
-        locator,
-        lastSeenAtMs: record.lastSeenAtMs,
-        ...(lifecycleFieldCount === 2 ? {
-            markerPath: record.markerPath as string,
-            runStartedAtMs: record.runStartedAtMs as number,
-        } : {}),
-    };
-}
-
-function validateKnownRebindIntent(value: unknown): TmuxKnownRebindIntent | null {
-    if (!isObject(value)) {
-        return null;
-    }
-    const record = value as Record<string, unknown>;
-    const expected = validateKnownRecord(record.expected);
-    const replacement = validateKnownRecord(record.replacement);
-    if (!hasExactKeys(record, [
-        'version', 'state', 'expected', 'replacement', 'recordedAtMs',
-    ]) || record.version !== 1 || record.state !== 'rebind-known'
-        || !expected || !replacement
-        || expected.sessionId === replacement.sessionId
-        || !knownBindingsEqualExceptSessionId(expected, replacement)
-        || !isFiniteNonNegative(record.recordedAtMs)) {
-        return null;
-    }
-    return {
-        version: 1,
-        state: 'rebind-known',
-        expected: cloneKnown(expected),
-        replacement: cloneKnown(replacement),
-        recordedAtMs: record.recordedAtMs as number,
-    };
-}
-
-function validateInactiveRecord(
-    value: unknown,
-    nowMs: number = Date.now()
-): TmuxInactiveRuntimeBinding | null {
-    if (!isObject(value)) {
-        return null;
-    }
-    const record = value as Record<string, unknown>;
-    const locator = validateLocator(record.locator);
-    const identity = validateBindingIdentity(record, { sessionId: record.sessionId });
-    if (!hasExactKeys(record, [
-        'version', 'state', 'provider', 'sessionId', 'workspaceScopeIdentity',
-        'workspaceNavigationIdentity', 'workspaceRootHostPaths', 'cwd', 'layout',
-        'locator', 'markerPath', 'runStartedAtMs', 'detectedAtMs',
-    ]) || record.version !== RECORD_VERSION
-        || (record.state !== 'completed' && record.state !== 'stopped')
-        || !identity || !isLayout(record.layout)
-        || !locator || locator.layout !== record.layout
-        || !isBoundedPath(record.markerPath)
-        || !isFinitePositive(record.runStartedAtMs)
-        || !isFinitePositive(record.detectedAtMs)
-        || !Number.isFinite(nowMs) || record.detectedAtMs > nowMs + MAX_FUTURE_SKEW_MS) {
-        return null;
-    }
-    return {
-        version: 2,
-        state: record.state,
-        sessionId: identity.sessionId as string,
-        ...bindingIdentityFields(identity),
-        layout: record.layout,
-        locator,
-        markerPath: record.markerPath,
-        runStartedAtMs: record.runStartedAtMs,
-        detectedAtMs: record.detectedAtMs,
-    };
-}
-
-function validateFinalRuntimeRecord(
-    value: unknown,
-    nowMs: number = Date.now()
-): TmuxFinalRuntimeBinding | null {
-    return validateKnownRecord(value) || validateInactiveRecord(value, nowMs);
-}
-
-function validateLocator(value: unknown): AiSessionTmuxLocator | null {
-    if (!isObject(value)) {
-        return null;
-    }
-    const record = value as Record<string, unknown>;
-    const hasValidKeys = record.layout === 'project'
-        ? hasExactKeys(record, ['layout', 'sessionName', 'windowName'])
-        : hasExactKeys(record, ['layout', 'sessionName'])
-            || hasExactKeys(record, ['layout', 'sessionName', 'windowName']);
-    if (!isLayout(record.layout) || !isBoundedString(record.sessionName, MAX_ID_LENGTH)
-        || !hasValidKeys) {
-        return null;
-    }
-    if (record.layout === 'project') {
-        return isBoundedString(record.windowName, MAX_ID_LENGTH)
-            ? { layout: 'project', sessionName: record.sessionName, windowName: record.windowName }
-            : null;
-    }
-    return hasExactKeys(record, ['layout', 'sessionName'])
-        ? { layout: 'session', sessionName: record.sessionName }
-        : isBoundedString(record.windowName, MAX_ID_LENGTH)
-            ? { layout: 'session', sessionName: record.sessionName, windowName: record.windowName }
-            : null;
-}
-
-function hasExactKeys(
-    record: Record<string, unknown>,
-    required: readonly string[],
-    optional: readonly string[] = []
-): boolean {
-    const allowed = new Set([...required, ...optional]);
-    return required.every(key => Object.prototype.hasOwnProperty.call(record, key))
-        && Object.keys(record).every(key => allowed.has(key));
-}
-
-function locatorsEqual(left: AiSessionTmuxLocator, right: AiSessionTmuxLocator): boolean {
-    return left.layout === right.layout && left.sessionName === right.sessionName
-        && left.windowName === right.windowName;
-}
-
-function pendingLifecycleRecordKey(record: {
-    provider: AiSessionProviderId;
-    workspaceScopeIdentity: string;
-    workspaceNavigationIdentity: string;
-    workspaceRootHostPaths: string[];
-    cwd: string;
-    pendingId: string;
-}): string {
-    return JSON.stringify(pendingRecordIdentityParts(record));
-}
-
-function pendingBindingsEqual(
-    left: TmuxPendingRuntimeBinding,
-    right: TmuxPendingRuntimeBinding
-): boolean {
-    return pendingLifecycleRecordKey(left) === pendingLifecycleRecordKey(right)
-        && left.createdAt === right.createdAt
-        && left.acceptedAtMs === right.acceptedAtMs
-        && left.projectName === right.projectName
-        && left.title === right.title
-        && left.layout === right.layout
-        && locatorsEqual(left.locator, right.locator)
-        && left.excludedSessionIds.length === right.excludedSessionIds.length
-        && left.excludedSessionIds.every((value, index) => value === right.excludedSessionIds[index]);
-}
-
-function consumedMatchesPromoting(
-    consumed: TmuxConsumedPendingBinding,
-    promoting: TmuxPromotingRuntimeBinding
-): boolean {
-    return consumed.finalSessionName !== undefined
-        && consumed.finalSessionId === promoting.finalSessionId
-        && consumed.finalSessionName === promoting.finalSessionName
-        && consumed.layout === promoting.layout
-        && locatorsEqual(consumed.finalLocator, promoting.finalLocator);
-}
-
-function inactiveBindingsMatchRun(
-    left: TmuxInactiveRuntimeBinding,
-    right: TmuxInactiveRuntimeBinding
-): boolean {
-    return bindingIdentitiesEqual(left, right)
-        && left.layout === right.layout && locatorsEqual(left.locator, right.locator)
-        && left.markerPath === right.markerPath
-        && left.runStartedAtMs === right.runStartedAtMs;
-}
-
-function inactiveBindingsEqual(
-    left: TmuxInactiveRuntimeBinding,
-    right: TmuxInactiveRuntimeBinding
-): boolean {
-    return inactiveBindingsMatchRun(left, right)
-        && left.state === right.state
-        && left.detectedAtMs === right.detectedAtMs;
-}
-
-function knownBindingsEqual(
-    left: TmuxKnownRuntimeBinding,
-    right: TmuxKnownRuntimeBinding
-): boolean {
-    return left.sessionId === right.sessionId
-        && knownBindingsEqualExceptSessionId(left, right);
-}
-
-function knownBindingsEqualExceptSessionId(
-    left: TmuxKnownRuntimeBinding,
-    right: TmuxKnownRuntimeBinding
-): boolean {
-    return bindingIdentitiesEqual(left, right)
-        && left.layout === right.layout
-        && locatorsEqual(left.locator, right.locator)
-        && left.lastSeenAtMs === right.lastSeenAtMs
-        && left.markerPath === right.markerPath
-        && left.runStartedAtMs === right.runStartedAtMs;
-}
-
-function clonePending(record: TmuxPendingRuntimeBinding): TmuxPendingRuntimeBinding {
-    return { ...record, workspaceRootHostPaths: [...record.workspaceRootHostPaths], excludedSessionIds: [...record.excludedSessionIds], locator: { ...record.locator } };
-}
-
-function cloneKnown(record: TmuxKnownRuntimeBinding): TmuxKnownRuntimeBinding {
-    return { ...record, workspaceRootHostPaths: [...record.workspaceRootHostPaths], locator: { ...record.locator } };
-}
-
-function cloneInactive(record: TmuxInactiveRuntimeBinding): TmuxInactiveRuntimeBinding {
-    return { ...record, workspaceRootHostPaths: [...record.workspaceRootHostPaths], locator: { ...record.locator } };
-}
-
-function cloneAmbiguous(record: TmuxAmbiguousRuntimeBinding): TmuxAmbiguousRuntimeBinding {
-    if (record.sessionId !== undefined) {
-        return { ...record, workspaceRootHostPaths: [...record.workspaceRootHostPaths], locator: { ...record.locator } };
-    }
-    const pendingRecord = record as TmuxAmbiguousRuntimeBindingBase & {
-        pendingId: string;
-        cwd: string;
-        createdAt: string;
-        excludedSessionIds: string[];
-        projectName?: string;
-        title?: string;
-        markerPath?: string;
-        requestFingerprint: string;
-    };
-    return {
-        ...pendingRecord,
-        workspaceRootHostPaths: [...pendingRecord.workspaceRootHostPaths],
-        locator: { ...pendingRecord.locator },
-        excludedSessionIds: [...pendingRecord.excludedSessionIds],
-    };
-}
-
-function cloneConsumed(record: TmuxConsumedPendingBinding): TmuxConsumedPendingBinding {
-    return { ...record, workspaceRootHostPaths: [...record.workspaceRootHostPaths], finalLocator: { ...record.finalLocator } };
-}
-
-function clonePromoting(record: TmuxPromotingRuntimeBinding): TmuxPromotingRuntimeBinding {
-    return {
-        ...record,
-        workspaceRootHostPaths: [...record.workspaceRootHostPaths],
-        sourceLocator: { ...record.sourceLocator },
-        finalLocator: { ...record.finalLocator },
-        pendingBinding: clonePending(record.pendingBinding),
-    };
-}
-
-function consumedRecordMatchesIdentity(
-    record: TmuxConsumedPendingBinding,
-    identity: AiSessionRuntimeIdentity
-): boolean {
-    return record.pendingId === identity.pendingId && bindingIdentitiesEqual(record, identity);
-}
-
-function pendingRecordMatchesIdentity(
-    record: TmuxPendingRuntimeBinding,
-    identity: AiSessionRuntimeIdentity
-): boolean {
-    return record.pendingId === identity.pendingId && bindingIdentitiesEqual(record, identity);
-}
-
-function pendingIdentityParts(identity: AiSessionRuntimeIdentity): string[] | null {
-    return identity && identity.sessionId === undefined && isValidAiSessionRuntimeIdentity(identity)
-        ? [
-            identity.provider,
-            identity.workspaceScopeIdentity,
-            identity.workspaceNavigationIdentity,
-            getAiSessionRuntimeRootSnapshotKey(identity),
-            identity.cwd,
-            identity.pendingId as string,
-        ]
-        : null;
-}
-
-function pendingRecordIdentityParts(record: {
-    provider: AiSessionProviderId;
-    workspaceScopeIdentity: string;
-    workspaceNavigationIdentity: string;
-    workspaceRootHostPaths: string[];
-    cwd: string;
-    pendingId: string;
-}): string[] {
-    return [
-        record.provider,
-        record.workspaceScopeIdentity,
-        record.workspaceNavigationIdentity,
-        getAiSessionRuntimeRootSnapshotKey(record as AiSessionRuntimeIdentity),
-        record.cwd,
-        record.pendingId,
-    ];
-}
-
-function promotingRecordMatchesIdentity(
-    record: TmuxPromotingRuntimeBinding,
-    identity: AiSessionRuntimeIdentity
-): boolean {
-    return record.pendingId === identity.pendingId && bindingIdentitiesEqual(record, identity);
-}
-
-function ambiguousIdentityParts(identity: AiSessionRuntimeIdentity): string[] | null {
-    if (!isValidAiSessionRuntimeIdentity(identity)) {
-        return null;
-    }
-    const hasSessionId = identity.sessionId !== undefined;
-    const hasPendingId = identity.pendingId !== undefined;
-    if (hasSessionId === hasPendingId) {
-        return null;
-    }
-    const id = hasSessionId ? identity.sessionId : identity.pendingId;
-    if (!isBoundedString(id, MAX_ID_LENGTH)) {
-        return null;
-    }
-    return hasSessionId
-        ? [identity.provider, identity.workspaceScopeIdentity, 'session', id]
-        : [
-            identity.provider,
-            identity.workspaceScopeIdentity,
-            'pending',
-            identity.workspaceNavigationIdentity,
-            getAiSessionRuntimeRootSnapshotKey(identity),
-            identity.cwd,
-            id,
-        ];
-}
-
-function ambiguousRecordIdentityParts(record: TmuxAmbiguousRuntimeBinding): string[] {
-    return record.sessionId !== undefined ? [
-        record.provider,
-        record.workspaceScopeIdentity,
-        'session',
-        record.sessionId,
-    ] : [
-        record.provider,
-        record.workspaceScopeIdentity,
-        'pending',
-        record.workspaceNavigationIdentity,
-        getAiSessionRuntimeRootSnapshotKey(record as AiSessionRuntimeIdentity),
-        record.cwd,
-        record.pendingId,
-    ];
-}
-
-function ambiguousRecordMatchesIdentity(
-    record: TmuxAmbiguousRuntimeBinding,
-    identity: AiSessionRuntimeIdentity
-): boolean {
-    return record.provider === identity.provider
-        && bindingIdentitiesEqual(record, identity)
-        && record.sessionId === identity.sessionId
-        && record.pendingId === identity.pendingId;
-}
-
-function validateBindingIdentity(
-    record: Record<string, unknown>,
-    id: { sessionId: unknown } | { pendingId: unknown }
-): AiSessionRuntimeIdentity | null {
-    const identity = {
-        provider: record.provider,
-        workspaceScopeIdentity: record.workspaceScopeIdentity,
-        workspaceNavigationIdentity: record.workspaceNavigationIdentity,
-        workspaceRootHostPaths: record.workspaceRootHostPaths,
-        cwd: record.cwd,
-        ...id,
-    };
-    return isValidAiSessionRuntimeIdentity(identity)
-        ? cloneAiSessionRuntimeIdentity(identity)
-        : null;
-}
-
-function bindingIdentityFields(identity: AiSessionRuntimeIdentity) {
-    return {
-        provider: identity.provider,
-        workspaceScopeIdentity: identity.workspaceScopeIdentity,
-        workspaceNavigationIdentity: identity.workspaceNavigationIdentity,
-        workspaceRootHostPaths: [...identity.workspaceRootHostPaths],
-        cwd: identity.cwd,
-    };
-}
-
-function bindingIdentitiesEqual(
-    left: {
-        provider: AiSessionProviderId;
-        workspaceScopeIdentity: string;
-        workspaceNavigationIdentity: string;
-        workspaceRootHostPaths: string[];
-        cwd: string;
-    },
-    right: {
-        provider: AiSessionProviderId;
-        workspaceScopeIdentity: string;
-        workspaceNavigationIdentity: string;
-        workspaceRootHostPaths: string[];
-        cwd: string;
-    }
-): boolean {
-    return left.provider === right.provider
-        && left.workspaceScopeIdentity === right.workspaceScopeIdentity
-        && left.workspaceNavigationIdentity === right.workspaceNavigationIdentity
-        && getAiSessionRuntimeRootSnapshotKey(left as AiSessionRuntimeIdentity)
-            === getAiSessionRuntimeRootSnapshotKey(right as AiSessionRuntimeIdentity)
-        && left.cwd === right.cwd;
-}
-
-function isPendingExpired(record: TmuxPendingRuntimeBinding, now: number): boolean {
-    return now - record.acceptedAtMs >= PENDING_TTL_MS;
-}
-
-function isKnownExpired(record: TmuxKnownRuntimeBinding, now: number): boolean {
-    return now - record.lastSeenAtMs >= KNOWN_TTL_MS;
-}
-
-function isInactiveExpired(record: TmuxInactiveRuntimeBinding, now: number): boolean {
-    return now - record.detectedAtMs >= KNOWN_TTL_MS;
-}
-
-function isFinalRuntimeExpired(record: TmuxFinalRuntimeBinding, now: number): boolean {
-    return record.state === 'known' ? isKnownExpired(record, now) : isInactiveExpired(record, now);
-}
-
-function finalRuntimePriority(record: TmuxFinalRuntimeBinding): number {
-    return record.state === 'completed' ? 0 : record.state === 'known' ? 1 : 2;
-}
-
-function finalRuntimeTimestamp(record: TmuxFinalRuntimeBinding): number {
-    return record.state === 'known' ? record.lastSeenAtMs : record.detectedAtMs;
-}
-
-function isObject(value: unknown): value is object {
-    return !!value && typeof value === 'object' && !Array.isArray(value);
-}
-
-function isProviderId(value: unknown): value is AiSessionProviderId {
-    return value === 'codex' || value === 'kimi' || value === 'claude';
-}
-
-function isLayout(value: unknown): value is AiSessionTmuxLayout {
-    return value === 'project' || value === 'session';
-}
-
-function isBoundedString(value: unknown, maxLength: number): value is string {
-    return typeof value === 'string' && value.length > 0 && value.length <= maxLength
-        && !CONTROL_CHARACTERS.test(value);
-}
-
-function isOptionalTitle(value: unknown): value is string {
-    return typeof value === 'string' && value.length <= MAX_TITLE_LENGTH && !CONTROL_CHARACTERS.test(value);
-}
-
-function isRequiredDisplayName(value: unknown): value is string {
-    return isValidAiSessionPromotionDisplayName(value);
-}
-
-function isDateString(value: unknown): value is string {
-    return typeof value === 'string' && value.length > 0 && value.length <= MAX_TITLE_LENGTH
-        && Number.isFinite(Date.parse(value));
-}
-
-function isFiniteNonNegative(value: unknown): value is number {
-    return typeof value === 'number' && Number.isFinite(value) && value >= 0;
-}
-
-function isFinitePositive(value: unknown): value is number {
-    return typeof value === 'number' && Number.isFinite(value) && value > 0;
-}
-
-function isBoundedPath(value: unknown): value is string {
-    return typeof value === 'string' && value.length <= MAX_PATH_LENGTH
-        && !CONTROL_CHARACTERS.test(value);
-}
-
-function isNodeError(error: unknown, code: string): boolean {
-    return !!error && typeof error === 'object' && (error as NodeJS.ErrnoException).code === code;
-}

--- a/tests/contract/aiSessions/tmuxBindingRecords.test.js
+++ b/tests/contract/aiSessions/tmuxBindingRecords.test.js
@@ -1,0 +1,373 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {
+    makeTmuxInactiveBinding,
+    makeTmuxKnownBinding,
+    makeTmuxPendingBinding,
+} = require('../../helpers/runtimeContract');
+const {
+    ambiguousIdentityParts,
+    ambiguousRecordIdentityParts,
+    ambiguousRecordMatchesIdentity,
+    cloneAmbiguous,
+    cloneConsumed,
+    clonePromoting,
+    consumedMatchesPromoting,
+    consumedRecordMatchesIdentity,
+    isCanonicalRecordPath,
+    isLegacyProjectKeyConsumedRecord,
+    pendingBindingsEqual,
+    pendingLifecycleRecordKey,
+    promotingRecordMatchesIdentity,
+    validateAmbiguousRecord,
+    validateConsumedRecord,
+    validateKnownRebindIntent,
+    validatePromotingRecord,
+} = require('../../../out/aiSessions/tmuxBindingRecords');
+
+const NOW = Date.parse('2026-07-18T10:00:00.000Z');
+const FINGERPRINT = 'a'.repeat(64);
+
+function identityOf(record) {
+    return {
+        provider: record.provider,
+        workspaceScopeIdentity: record.workspaceScopeIdentity,
+        workspaceNavigationIdentity: record.workspaceNavigationIdentity,
+        workspaceRootHostPaths: [...record.workspaceRootHostPaths],
+        cwd: record.cwd,
+        pendingId: record.pendingId,
+    };
+}
+
+function makeConsumedBinding(pendingId, overrides = {}) {
+    const pending = makeTmuxPendingBinding(pendingId);
+    const finalLocator = overrides.finalLocator
+        || { layout: pending.layout, sessionName: 'final-' + pendingId, windowName: 'final-window' };
+    return {
+        version: 2,
+        state: 'consumed',
+        ...identityOf(pending),
+        finalSessionId: 'final-session-' + pendingId,
+        ...(overrides.omitFinalSessionName ? {} : { finalSessionName: 'Final ' + pendingId }),
+        layout: pending.layout,
+        finalLocator,
+        consumedAtMs: overrides.consumedAtMs ?? NOW,
+        ...(overrides.extra || {}),
+    };
+}
+
+function makePromotingBinding(pendingId, overrides = {}) {
+    const pendingBinding = overrides.pendingBinding || makeTmuxPendingBinding(pendingId);
+    const sourceLocator = overrides.sourceLocator || { ...pendingBinding.locator };
+    const finalLocator = overrides.finalLocator
+        || { layout: pendingBinding.layout, sessionName: sourceLocator.sessionName, windowName: 'promoted-window' };
+    return {
+        version: 2,
+        state: 'promoting',
+        ...identityOf(pendingBinding),
+        createdAt: pendingBinding.createdAt,
+        markerPath: '',
+        pendingBinding,
+        finalSessionId: 'final-session-' + pendingId,
+        finalSessionName: 'Final ' + pendingId,
+        layout: pendingBinding.layout,
+        sourceLocator,
+        finalLocator,
+        requestFingerprint: FINGERPRINT,
+        recordedAtMs: overrides.recordedAtMs ?? NOW,
+        ...(overrides.extra || {}),
+    };
+}
+
+function makeAmbiguousSessionBinding(sessionId) {
+    const known = makeTmuxKnownBinding(sessionId);
+    return {
+        version: 2,
+        state: 'ambiguous',
+        provider: known.provider,
+        workspaceScopeIdentity: known.workspaceScopeIdentity,
+        workspaceNavigationIdentity: known.workspaceNavigationIdentity,
+        workspaceRootHostPaths: [...known.workspaceRootHostPaths],
+        cwd: known.cwd,
+        layout: known.layout,
+        locator: { ...known.locator },
+        acceptedAtMs: NOW,
+        sessionId,
+    };
+}
+
+function makeAmbiguousPendingBinding(pendingId, overrides = {}) {
+    const pending = makeTmuxPendingBinding(pendingId);
+    return {
+        version: 2,
+        state: 'ambiguous',
+        provider: pending.provider,
+        workspaceScopeIdentity: pending.workspaceScopeIdentity,
+        workspaceNavigationIdentity: pending.workspaceNavigationIdentity,
+        workspaceRootHostPaths: [...pending.workspaceRootHostPaths],
+        cwd: pending.cwd,
+        layout: pending.layout,
+        locator: { ...pending.locator },
+        acceptedAtMs: NOW,
+        pendingId,
+        createdAt: pending.createdAt,
+        excludedSessionIds: ['excluded-one'],
+        requestFingerprint: FINGERPRINT,
+        ...(overrides.extra || {}),
+    };
+}
+
+function mutations(record, cases) {
+    return cases.map(([label, mutate]) => {
+        const copy = JSON.parse(JSON.stringify(record));
+        const replacement = mutate(copy);
+        return [label, replacement === undefined ? copy : replacement];
+    });
+}
+
+test('RUNTIME-TMUX-RECORDS-001 validates consumed records with and without a final session name', () => {
+    const withName = makeConsumedBinding('consumed-one');
+    assert.equal(validateConsumedRecord(withName)?.finalSessionName, 'Final consumed-one');
+    assert.equal(validateConsumedRecord(withName, true)?.pendingId, 'consumed-one');
+
+    const withoutName = makeConsumedBinding('consumed-two', { omitFinalSessionName: true });
+    assert.equal(validateConsumedRecord(withoutName)?.pendingId, 'consumed-two');
+    assert.equal(validateConsumedRecord(withoutName, true), null);
+
+    for (const [label, copy] of mutations(withName, [
+        ['non-object', record => record = null],
+        ['bad version', record => { record.version = 1; }],
+        ['bad state', record => { record.state = 'pending'; }],
+        ['extra key', record => { record.extra = true; }],
+        ['missing key', record => { delete record.finalSessionId; }],
+        ['empty finalSessionId', record => { record.finalSessionId = ''; }],
+        ['empty finalSessionName', record => { record.finalSessionName = '  '; }],
+        ['bad layout', record => { record.layout = 'unknown'; }],
+        ['locator layout mismatch', record => { record.finalLocator = { layout: 'session', sessionName: 'x' }; }],
+        ['negative consumedAtMs', record => { record.consumedAtMs = -1; }],
+    ])) {
+        assert.equal(validateConsumedRecord(copy), null, label);
+    }
+});
+
+test('RUNTIME-TMUX-RECORDS-001 detects legacy project-key consumed records', () => {
+    const pending = makeTmuxPendingBinding('legacy-one');
+    const legacy = {
+        version: 1,
+        state: 'consumed',
+        pendingId: pending.pendingId,
+        provider: pending.provider,
+        projectKey: 'project-key-one',
+        cwd: pending.cwd,
+        finalSessionId: 'final-session-legacy',
+        layout: pending.layout,
+        finalLocator: { layout: pending.layout, sessionName: 'final-legacy', windowName: 'w' },
+        consumedAtMs: NOW,
+    };
+    assert.equal(isLegacyProjectKeyConsumedRecord(legacy), true);
+    assert.equal(isLegacyProjectKeyConsumedRecord(null), false);
+    assert.equal(isLegacyProjectKeyConsumedRecord({ ...legacy, version: 2 }), false);
+    assert.equal(isLegacyProjectKeyConsumedRecord({ ...legacy, projectKey: '' }), false);
+    assert.equal(isLegacyProjectKeyConsumedRecord({ ...legacy, extra: true }), false);
+    assert.equal(isLegacyProjectKeyConsumedRecord({
+        ...legacy,
+        finalLocator: { layout: 'session', sessionName: 'mismatch' },
+    }), false);
+});
+
+test('RUNTIME-TMUX-RECORDS-001 validates promoting records and their pending consistency', () => {
+    const promoting = makePromotingBinding('promoting-one');
+    assert.equal(validatePromotingRecord(promoting)?.pendingId, 'promoting-one');
+
+    for (const [label, copy] of mutations(promoting, [
+        ['non-object', () => null],
+        ['bad state', record => { record.state = 'consumed'; }],
+        ['missing finalSessionName', record => { delete record.finalSessionName; }],
+        ['bad markerPath', record => { record.markerPath = 42; }],
+        ['locators identical', record => { record.finalLocator = { ...record.sourceLocator }; }],
+        ['final locator layout mismatch', record => { record.finalLocator = { layout: 'session', sessionName: 'x' }; }],
+        ['source session differs from final', record => {
+            record.sourceLocator = { layout: 'project', sessionName: 'other', windowName: 'w' };
+        }],
+        ['pending id mismatch', record => { record.pendingBinding = makeTmuxPendingBinding('other-pending'); }],
+        ['createdAt mismatch', record => {
+            record.pendingBinding = { ...record.pendingBinding, createdAt: '2026-01-01T00:00:00.000Z' };
+        }],
+        ['pending locator mismatch', record => {
+            record.pendingBinding = { ...record.pendingBinding, locator: { layout: 'session', sessionName: 'elsewhere' } };
+        }],
+        ['bad fingerprint', record => { record.requestFingerprint = 'not-a-fingerprint'; }],
+        ['negative recordedAtMs', record => { record.recordedAtMs = -5; }],
+    ])) {
+        assert.equal(validatePromotingRecord(copy), null, label);
+    }
+
+    const promoted = makePromotingBinding('promoting-two');
+    assert.equal(consumedMatchesPromoting(
+        { ...makeConsumedBinding('promoting-two'), finalSessionId: promoted.finalSessionId,
+            finalSessionName: promoted.finalSessionName, finalLocator: promoted.finalLocator },
+        promoted
+    ), true);
+    assert.equal(consumedMatchesPromoting(makeConsumedBinding('other'), promoted), false);
+    assert.equal(consumedMatchesPromoting(
+        { ...makeConsumedBinding('promoting-two', { omitFinalSessionName: true }),
+            finalSessionId: promoted.finalSessionId, finalLocator: promoted.finalLocator },
+        promoted
+    ), false);
+});
+
+test('RUNTIME-TMUX-RECORDS-001 validates ambiguous session and pending variants', () => {
+    const sessionVariant = makeAmbiguousSessionBinding('ambiguous-session');
+    assert.equal(validateAmbiguousRecord(sessionVariant)?.sessionId, 'ambiguous-session');
+
+    const pendingVariant = makeAmbiguousPendingBinding('ambiguous-pending', {
+        extra: { projectName: 'RedDB', title: 'Repair', markerPath: '/tmp/m.done' },
+    });
+    const validatedPending = validateAmbiguousRecord(pendingVariant);
+    assert.equal(validatedPending?.pendingId, 'ambiguous-pending');
+    assert.equal(validatedPending?.projectName, 'RedDB');
+    assert.deepEqual(validateAmbiguousRecord({
+        ...pendingVariant,
+        requestFingerprint: 'v3:' + FINGERPRINT,
+    })?.pendingId, 'ambiguous-pending');
+
+    for (const [label, copy] of [
+        ['both ids', { ...sessionVariant, pendingId: 'p2', createdAt: 'x', excludedSessionIds: [], requestFingerprint: FINGERPRINT }],
+        ['neither id', (() => { const r = makeAmbiguousPendingBinding('x'); delete r.pendingId; delete r.sessionId; return r; })()],
+        ['bad excluded ids', { ...makeAmbiguousPendingBinding('x'), excludedSessionIds: [''] }],
+        ['too many excluded ids', { ...makeAmbiguousPendingBinding('x'), excludedSessionIds: Array(1001).fill('a') }],
+        ['bad projectName', { ...makeAmbiguousPendingBinding('x'), projectName: 1 }],
+        ['bad fingerprint', { ...makeAmbiguousPendingBinding('x'), requestFingerprint: 'zz' }],
+        ['locator layout mismatch', { ...sessionVariant, locator: { layout: 'session', sessionName: 'y' } }],
+        ['negative acceptedAtMs', { ...sessionVariant, acceptedAtMs: -1 }],
+    ]) {
+        assert.equal(validateAmbiguousRecord(copy), null, label);
+    }
+});
+
+test('RUNTIME-TMUX-RECORDS-001 derives ambiguous identity parts for both variants', () => {
+    const sessionIdentity = {
+        ...identityOf(makeTmuxPendingBinding('unused')),
+        pendingId: undefined,
+        sessionId: 'session-x',
+    };
+    delete sessionIdentity.pendingId;
+    assert.deepEqual(ambiguousIdentityParts(sessionIdentity), [
+        sessionIdentity.provider, sessionIdentity.workspaceScopeIdentity, 'session', 'session-x',
+    ]);
+
+    const pendingIdentity = identityOf(makeTmuxPendingBinding('pending-y'));
+    const parts = ambiguousIdentityParts(pendingIdentity);
+    assert.deepEqual(parts.slice(0, 3), [pendingIdentity.provider, pendingIdentity.workspaceScopeIdentity, 'pending']);
+    assert.equal(parts.at(-1), 'pending-y');
+
+    assert.equal(ambiguousIdentityParts({ ...sessionIdentity, pendingId: 'also-pending' }), null);
+    assert.equal(ambiguousIdentityParts({ provider: 'unknown' }), null);
+    assert.equal(ambiguousIdentityParts({ ...sessionIdentity, sessionId: '' }), null);
+
+    assert.deepEqual(
+        ambiguousRecordIdentityParts(makeAmbiguousSessionBinding('record-session')),
+        ['codex', makeTmuxKnownBinding('record-session').workspaceScopeIdentity, 'session', 'record-session']
+    );
+    const pendingParts = ambiguousRecordIdentityParts(makeAmbiguousPendingBinding('record-pending'));
+    assert.equal(pendingParts[2], 'pending');
+    assert.equal(pendingParts.at(-1), 'record-pending');
+});
+
+test('RUNTIME-TMUX-RECORDS-001 clones ambiguous, promoting, and consumed records defensively', () => {
+    const ambiguous = makeAmbiguousPendingBinding('clone-ambiguous', { extra: { title: 'T' } });
+    const ambiguousCopy = cloneAmbiguous(ambiguous);
+    assert.deepEqual(ambiguousCopy, ambiguous);
+    ambiguousCopy.excludedSessionIds.push('mutated');
+    ambiguousCopy.locator.sessionName = 'mutated';
+    assert.equal(ambiguous.excludedSessionIds.length, 1);
+    assert.notEqual(ambiguous.locator.sessionName, 'mutated');
+
+    const promoting = makePromotingBinding('clone-promoting');
+    const promotingCopy = clonePromoting(promoting);
+    assert.deepEqual(promotingCopy, promoting);
+    promotingCopy.pendingBinding.excludedSessionIds.push('mutated');
+    promotingCopy.sourceLocator.sessionName = 'mutated';
+    assert.equal(promoting.pendingBinding.excludedSessionIds.length, 0);
+    assert.notEqual(promoting.sourceLocator.sessionName, 'mutated');
+
+    const consumed = makeConsumedBinding('clone-consumed');
+    const consumedCopy = cloneConsumed(consumed);
+    assert.deepEqual(consumedCopy, consumed);
+    consumedCopy.finalLocator.sessionName = 'mutated';
+    assert.notEqual(consumed.finalLocator.sessionName, 'mutated');
+});
+
+test('RUNTIME-TMUX-RECORDS-001 matches records against runtime identities', () => {
+    const promoting = makePromotingBinding('match-promoting');
+    const identity = identityOf(makeTmuxPendingBinding('match-promoting'));
+    assert.equal(promotingRecordMatchesIdentity(promoting, identity), true);
+    assert.equal(promotingRecordMatchesIdentity(promoting, { ...identity, pendingId: 'other' }), false);
+
+    const ambiguous = makeAmbiguousPendingBinding('match-ambiguous');
+    assert.equal(ambiguousRecordMatchesIdentity(ambiguous, identityOf(makeTmuxPendingBinding('match-ambiguous'))), true);
+    assert.equal(ambiguousRecordMatchesIdentity(ambiguous, { ...identity, pendingId: 'other' }), false);
+
+    const consumed = makeConsumedBinding('match-promoting');
+    assert.equal(consumedRecordMatchesIdentity(consumed, identity), true);
+    assert.equal(consumedRecordMatchesIdentity(consumed, { ...identity, cwd: '/elsewhere' }), false);
+});
+
+test('RUNTIME-TMUX-RECORDS-001 compares pending bindings and lifecycle keys', () => {
+    const left = makeTmuxPendingBinding('equal-one', { title: 'A' });
+    const right = makeTmuxPendingBinding('equal-one', { title: 'A' });
+    assert.equal(pendingBindingsEqual(left, right), true);
+    assert.equal(pendingLifecycleRecordKey(left), pendingLifecycleRecordKey(right));
+    assert.equal(pendingBindingsEqual(left, { ...right, title: 'B' }), false);
+    assert.equal(pendingBindingsEqual(left, { ...right, excludedSessionIds: ['x'] }), false);
+    assert.equal(pendingBindingsEqual(left, {
+        ...right,
+        locator: { ...right.locator, sessionName: 'different' },
+    }), false);
+});
+
+test('RUNTIME-TMUX-RECORDS-001 classifies canonical record paths', () => {
+    const { createHash } = require('node:crypto');
+    const pending = makeTmuxPendingBinding('canonical-one');
+    const identityParts = [pending.provider, pending.workspaceScopeIdentity,
+        pending.workspaceNavigationIdentity,
+        require('../../../out/aiSessions/runtimeTypes').getAiSessionRuntimeRootSnapshotKey(pending),
+        pending.cwd, pending.pendingId];
+    const canonicalName = `pending-${createHash('sha256')
+        .update(JSON.stringify([2, 'pending', ...identityParts]), 'utf8').digest('hex')}.json`;
+    assert.equal(isCanonicalRecordPath(`/records/${canonicalName}`, pending), true);
+    assert.equal(isCanonicalRecordPath('/records/pending-deadbeef.json', pending), false);
+    assert.equal(isCanonicalRecordPath('/records/rebind-known-deadbeef.json',
+        { ...makeTmuxKnownBinding('rebind-one'), state: 'rebind-known' }), false);
+
+    const known = makeTmuxKnownBinding('canonical-known');
+    const completed = makeTmuxInactiveBinding('canonical-known', 'completed');
+    const knownParts = [known.provider, known.workspaceScopeIdentity, known.sessionId];
+    const knownName = `known-${createHash('sha256')
+        .update(JSON.stringify([2, 'known', ...knownParts]), 'utf8').digest('hex')}.json`;
+    assert.equal(isCanonicalRecordPath(`/records/${knownName}`, known), true);
+    assert.equal(isCanonicalRecordPath(`/records/${knownName}`, completed), true);
+});
+
+test('RUNTIME-TMUX-RECORDS-001 validates known rebind intents', () => {
+    const expected = makeTmuxKnownBinding('rebind-expected');
+    const replacement = { ...expected, sessionId: 'rebind-replacement' };
+    const intent = {
+        version: 1,
+        state: 'rebind-known',
+        expected,
+        replacement,
+        recordedAtMs: NOW,
+    };
+    const validated = validateKnownRebindIntent(intent);
+    assert.equal(validated?.expected.sessionId, 'rebind-expected');
+    assert.equal(validated?.replacement.sessionId, 'rebind-replacement');
+
+    assert.equal(validateKnownRebindIntent({ ...intent, version: 2 }), null);
+    assert.equal(validateKnownRebindIntent({ ...intent, state: 'known' }), null);
+    assert.equal(validateKnownRebindIntent({ ...intent, expected: { ...expected, markerPath: '/different' } }), null);
+    assert.equal(validateKnownRebindIntent({ ...intent, replacement: { ...replacement, sessionId: expected.sessionId } }), null);
+    assert.equal(validateKnownRebindIntent({ ...intent, recordedAtMs: -1 }), null);
+});


### PR DESCRIPTION
## Summary

Second tier-2 slice, splitting `tmuxRuntimeBindingStore.ts` (1731 lines) along its natural internal seam:

- New `tmuxBindingRecords.ts` (931 lines): all binding record types, the six record validators, defensive cloning, identity derivation/matching, expiry helpers, and the small field guards — the pure record schema layer.
- `tmuxRuntimeBindingStore.ts` is now 889 lines: the serialized store class plus the filesystem IO helpers (regular-file reads, no-follow opens, durable removes). It imports the record layer back and re-exports the original public surface, so all six external consumers (backend, discovery, pending lifecycle, promotion, attention, dashboard) are untouched.
- Verbatim move (inverse-diff verified); store non-blank content identical to the original minus moved blocks; public export list unchanged.
- New `tests/contract/aiSessions/tmuxBindingRecords.test.js` (10 tests) exercises the validators and identity helpers directly through the exported record surface — this takes the new module from 68.9% to 98.0% changed-line coverage (gate: 80%).

No behavior change.

## Verification

- Full local gate suite green (compile, unit, integration, dashboard webview checks, safety suites, architecture guards, performance baseline, browser, behavior contracts, lint, changed coverage 98.02% 988/1008, release packaging).

## Skill harvest

none — the extraction playbook already covers verbatim moves and inverse-diff checks; the changed-coverage gate behaved as designed and is satisfied with real tests, no skill change justified.