### PR TITLE
perf: cache skill content hashes and skip hidden skill scans

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -4290,7 +4290,8 @@
     "priority": "P1",
     "status": "automated",
     "owners": [
-      "scripts/run-skill-management-checks.js"
+      "scripts/run-skill-management-checks.js",
+      "tests/contract/skills/skillScanCache.test.js"
     ],
     "evidence": [
       "src/skills/discovery.ts",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "3080a7a2eac78518e4766d2528b369121efef5a7",
+        "head": "c1fe20edb9f771393c9d21918c926b94ea251e95",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -95,7 +95,8 @@
             "199162a3a85a3455739664599bbf54786fb4ae72",
             "ca6733b7be50783dc248ddfb3d853afced6e691f",
             "90bf3db102d4353ad487e40dc16b63b2c169d006",
-            "f81209ee67f598dc424d859e2651fcd085ca3be2"
+            "f81209ee67f598dc424d859e2651fcd085ca3be2",
+            "d000b253224f83f3b7d01e3a92f201eea5ff793f"
         ]
     },
     "capabilities": [
@@ -1229,7 +1230,9 @@
                 "7ebe4973e9fed30042171f08f8048e142f2a2f49",
                 "8335f4b0cd7dedd0b4ef2ee6f131cbe590a39ad5",
                 "42139dc54d09861d33d19c91e5734c8d7d14fef0",
-                "70a4e0178b2b916655ff4d855f24bbf3d38ff3c0"
+                "70a4e0178b2b916655ff4d855f24bbf3d38ff3c0",
+                "28a37dd88ae68674e25dedebaa51d7912e2bbd1a",
+                "c1fe20edb9f771393c9d21918c926b94ea251e95"
             ],
             "behaviors": [
                 "PERSIST-AI-SKILL-CENTRAL-STORE-001",

--- a/src/skills/dashboardController.ts
+++ b/src/skills/dashboardController.ts
@@ -68,16 +68,19 @@ export class SkillDashboardController {
     private storeFolders: Partial<Record<SkillScope, string[]>> = {};
     private watchers: fs.FSWatcher[] = [];
     private refreshTimer: NodeJS.Timeout | null = null;
+    private scanStale = false;
     private disposed = false;
 
     constructor(private readonly options: SkillDashboardControllerOptions) {
     }
 
     getRecords(): SkillRecord[] {
+        this.ensureFreshRecords();
         return this.records;
     }
 
     getCollectionSuggestions(): SkillCollectionSuggestion[] {
+        this.ensureFreshRecords();
         const store = this.options.groupStore;
         if (!store) {
             return [];
@@ -86,6 +89,7 @@ export class SkillDashboardController {
     }
 
     getCopyTargets(): Map<string, SkillCopyTarget[]> {
+        this.ensureFreshRecords();
         return computeSkillCopyTargets(
             this.records,
             this.options.getHomeDir(),
@@ -102,6 +106,7 @@ export class SkillDashboardController {
     }
 
     getPanelView(): SkillPanelView {
+        this.ensureFreshRecords();
         return {
             hasWorkspace: Boolean(this.options.getWorkspaceRoot()),
             copyTargets: this.getCopyTargets(),
@@ -438,23 +443,18 @@ export class SkillDashboardController {
         this.refresh('start');
     }
 
-    refresh(_reason = 'refresh', settlement?: unknown): Promise<boolean> {
+    refresh(reason = 'refresh', settlement?: unknown): Promise<boolean> {
         if (this.disposed) {
             return Promise.resolve(false);
         }
-        try {
-            const scan = scanSkillsDetailed({
-                homeDir: this.options.getHomeDir(),
-                workspaceRoot: this.options.getWorkspaceRoot(),
-                globalSkillsRoot: this.getGlobalSkillsRoot(),
-            });
-            this.records = scan.records;
-            this.storeFolders = scan.storeFolders;
-        } catch (error) {
-            this.options.logError('Skill scan failed.', error);
-            this.records = [];
+        if (reason === 'watch' && !this.options.isVisible()) {
+            // Hidden sidebar: skip the rescan entirely. The next read
+            // (getRecords et al.) rescans lazily, and the visible refresh
+            // always reads before rendering the panel.
+            this.scanStale = true;
+            return Promise.resolve(false);
         }
-        this.resetWatchers();
+        this.performScan();
         if (this.options.isVisible()) {
             return Promise.resolve(this.options.postMessage({
                 type: 'skills-updated',
@@ -463,6 +463,29 @@ export class SkillDashboardController {
             }));
         }
         return Promise.resolve(false);
+    }
+
+    private performScan(): void {
+        try {
+            const scan = scanSkillsDetailed({
+                homeDir: this.options.getHomeDir(),
+                workspaceRoot: this.options.getWorkspaceRoot(),
+                globalSkillsRoot: this.getGlobalSkillsRoot(),
+            });
+            this.records = scan.records;
+            this.storeFolders = scan.storeFolders;
+            this.scanStale = false;
+        } catch (error) {
+            this.options.logError('Skill scan failed.', error);
+            this.records = [];
+        }
+        this.resetWatchers();
+    }
+
+    private ensureFreshRecords(): void {
+        if (this.scanStale) {
+            this.performScan();
+        }
     }
 
     handleDeleteSkill(dirPath: string): { ok: boolean; error?: string } {

--- a/src/skills/syncService.ts
+++ b/src/skills/syncService.ts
@@ -8,12 +8,67 @@ import { getProjectSkillsRoots, getUserSkillsRoots } from './roots';
 import { getSkillStableKey } from './skillGroupStore';
 import type { SkillRecord, SkillScope, SkillSourceDir } from './types';
 
+interface SkillHashCacheEntry {
+    manifest: string;
+    hash: string;
+}
+
+// Content fingerprints cached per absolute directory path. The manifest
+// (relative path + mtime + size of every hashed file) is rebuilt with readdir
+// and stat only, so unchanged directories skip every content read. mtime+size
+// signatures follow standard cache semantics (the same tradeoff as git's
+// index): a write preserving both mtime and size would serve a stale hash,
+// which real editor saves never produce.
+const skillHashCache = new Map<string, SkillHashCacheEntry>();
+const SKILL_HASH_CACHE_LIMIT = 256;
+
+// Mirrors the traversal of hashSkillDirectory exactly (same skips, same
+// ordering) so the manifest changes precisely when the hashed content can.
+function buildSkillDirectoryManifest(dirPath: string): string {
+    const parts: string[] = [];
+    const walk = (current: string): void => {
+        let entries: fs.Dirent[];
+        try {
+            entries = fs.readdirSync(current, { withFileTypes: true });
+        } catch (_error) {
+            return;
+        }
+        entries.sort((a, b) => a.name.localeCompare(b.name));
+        for (const entry of entries) {
+            const entryPath = path.join(current, entry.name);
+            if (entry.isDirectory()) {
+                if (entry.name === 'node_modules' || entry.name === '.git') {
+                    continue;
+                }
+                walk(entryPath);
+                continue;
+            }
+            if (!entry.isFile()) {
+                continue;
+            }
+            try {
+                const stat = fs.statSync(entryPath);
+                parts.push(`${path.relative(dirPath, entryPath)}:${stat.mtimeMs}:${stat.size}`);
+            } catch (_error) {
+                // Unreadable files simply do not contribute to the manifest.
+            }
+        }
+    };
+    walk(dirPath);
+    return parts.join('\0');
+}
+
 /**
  * Content fingerprint of a skill directory: a hash over every file's
  * relative path and content, so two copies of "the same" skill can be
  * compared for drift.
  */
 export function hashSkillDirectory(dirPath: string): string {
+    const manifest = buildSkillDirectoryManifest(dirPath);
+    const cached = skillHashCache.get(dirPath);
+    if (cached && cached.manifest === manifest) {
+        return cached.hash;
+    }
     const hash = crypto.createHash('sha256');
     const walk = (current: string): void => {
         let entries: fs.Dirent[];
@@ -46,7 +101,12 @@ export function hashSkillDirectory(dirPath: string): string {
         }
     };
     walk(dirPath);
-    return hash.digest('hex');
+    const digest = hash.digest('hex');
+    if (skillHashCache.size >= SKILL_HASH_CACHE_LIMIT) {
+        skillHashCache.clear();
+    }
+    skillHashCache.set(dirPath, { manifest, hash: digest });
+    return digest;
 }
 
 export interface SkillDuplicateGroup {

--- a/tests/contract/skills/skillScanCache.test.js
+++ b/tests/contract/skills/skillScanCache.test.js
@@ -1,0 +1,180 @@
+'use strict';
+
+// Covers PERSIST-AI-SKILL-DISCOVERY-001 (scan freshness after the skill hash
+// cache and the hidden-sidebar scan gate landed).
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const Module = require('node:module');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+function loadSkillsModules() {
+    // dashboardController transitively requires webviewSkillContent → webviewContent
+    // → vscode, and getSkillsPanelContent calls vscode.Uri.file at render time
+    // (mirrors run-skill-management-checks.js).
+    const fakeVscode = {
+        Uri: {
+            file: filePath => ({
+                scheme: 'file',
+                path: filePath,
+                toString: () => `file://${filePath}`,
+            }),
+        },
+    };
+    const previousLoad = Module._load;
+    try {
+        Module._load = function (request, parent, isMain) {
+            if (request === 'vscode') { return fakeVscode; }
+            return previousLoad.call(this, request, parent, isMain);
+        };
+        return {
+            syncService: require('../../../out/skills/syncService'),
+            dashboardController: require('../../../out/skills/dashboardController'),
+        };
+    } finally {
+        Module._load = previousLoad;
+    }
+}
+
+const { syncService, dashboardController } = loadSkillsModules();
+const { hashSkillDirectory } = syncService;
+const { SkillDashboardController } = dashboardController;
+
+function makeTempDir(prefix) {
+    return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function writeSkill(dirPath, description, extras = {}, name) {
+    fs.mkdirSync(dirPath, { recursive: true });
+    fs.writeFileSync(
+        path.join(dirPath, 'SKILL.md'),
+        `---\nname: ${name || path.basename(dirPath)}\ndescription: ${description}\n---\n\nbody\n`,
+    );
+    for (const [relative, content] of Object.entries(extras)) {
+        const filePath = path.join(dirPath, relative);
+        fs.mkdirSync(path.dirname(filePath), { recursive: true });
+        fs.writeFileSync(filePath, content);
+    }
+}
+
+test('PERSIST-AI-SKILL-DISCOVERY-001 hash cache serves identical copies and unchanged directories', () => {
+    const home = makeTempDir('skill-hash-cache-');
+    try {
+        const dirA = path.join(home, 'copy-a');
+        const dirB = path.join(home, 'copy-b');
+        writeSkill(dirA, 'first', { 'refs/guide.txt': 'guide-body' }, 'demo');
+        writeSkill(dirB, 'first', { 'refs/guide.txt': 'guide-body' }, 'demo');
+
+        const hashA = hashSkillDirectory(dirA);
+        assert.strictEqual(hashSkillDirectory(dirB), hashA, 'identical copies share a fingerprint');
+        assert.strictEqual(hashSkillDirectory(dirA), hashA, 'an unchanged directory reuses its cached hash');
+    } finally {
+        fs.rmSync(home, { recursive: true, force: true });
+    }
+});
+
+test('PERSIST-AI-SKILL-DISCOVERY-001 hash cache tracks top-level and nested file changes', () => {
+    const home = makeTempDir('skill-hash-invalidation-');
+    try {
+        const dir = path.join(home, 'skill');
+        writeSkill(dir, 'first', { 'scripts/run.sh': 'echo one' });
+        const initial = hashSkillDirectory(dir);
+
+        writeSkill(dir, 'second-description-is-longer', { 'scripts/run.sh': 'echo one' });
+        const afterTopLevel = hashSkillDirectory(dir);
+        assert.notStrictEqual(afterTopLevel, initial, 'top-level file change invalidates the cache');
+
+        fs.writeFileSync(path.join(dir, 'scripts', 'run.sh'), 'echo one && echo two');
+        const afterNested = hashSkillDirectory(dir);
+        assert.notStrictEqual(afterNested, afterTopLevel, 'nested file change invalidates the cache');
+    } finally {
+        fs.rmSync(home, { recursive: true, force: true });
+    }
+});
+
+test('PERSIST-AI-SKILL-DISCOVERY-001 hash cache ignores node_modules and .git content', () => {
+    const home = makeTempDir('skill-hash-exclusions-');
+    try {
+        const dir = path.join(home, 'skill');
+        writeSkill(dir, 'first', { 'node_modules/pkg/index.js': 'v1', '.git/refs/heads/main': 'ref-a' });
+        const initial = hashSkillDirectory(dir);
+
+        fs.writeFileSync(path.join(dir, 'node_modules', 'pkg', 'index.js'), 'v2-with-more-bytes');
+        fs.writeFileSync(path.join(dir, '.git', 'refs', 'heads', 'main'), 'ref-b-longer');
+        assert.strictEqual(hashSkillDirectory(dir), initial, 'excluded directories never affect the fingerprint');
+    } finally {
+        fs.rmSync(home, { recursive: true, force: true });
+    }
+});
+
+function createControllerFixture(home, options = {}) {
+    const posted = [];
+    let visible = options.visible ?? false;
+    const controller = new SkillDashboardController({
+        getHomeDir: () => home,
+        getWorkspaceRoot: () => undefined,
+        postMessage: message => { posted.push(message); return Promise.resolve(true); },
+        isVisible: () => visible,
+        logError: () => undefined,
+    });
+    return {
+        controller,
+        posted,
+        setVisible: value => { visible = value; },
+    };
+}
+
+test('PERSIST-AI-SKILL-DISCOVERY-001 hidden watch refreshes defer the scan until records are read', async () => {
+    const home = makeTempDir('skill-hidden-scan-');
+    try {
+        const skillDir = path.join(home, '.kimi', 'skills', 'demo');
+        writeSkill(skillDir, 'first');
+        const { controller, posted } = createControllerFixture(home, { visible: false });
+
+        controller.start();
+        assert.strictEqual(controller.getRecords().length, 1, 'start() still performs the bootstrap scan while hidden');
+        assert.strictEqual(posted.length, 0, 'hidden start posts nothing');
+
+        writeSkill(skillDir, 'second-description-is-longer');
+        const delivered = await controller.refresh('watch');
+        assert.strictEqual(delivered, false, 'hidden watch refresh skips delivery');
+        assert.strictEqual(posted.length, 0, 'hidden watch refresh posts nothing');
+
+        const records = controller.getRecords();
+        assert.strictEqual(records.length, 1);
+        assert.strictEqual(
+            records[0].description,
+            'second-description-is-longer',
+            'reading records after a hidden watch refresh rescans lazily',
+        );
+        controller.dispose();
+    } finally {
+        fs.rmSync(home, { recursive: true, force: true });
+    }
+});
+
+test('PERSIST-AI-SKILL-DISCOVERY-001 visible watch refreshes scan and post immediately', async () => {
+    const home = makeTempDir('skill-visible-scan-');
+    try {
+        const skillDir = path.join(home, '.kimi', 'skills', 'demo');
+        writeSkill(skillDir, 'first');
+        const { controller, posted } = createControllerFixture(home, { visible: true });
+
+        controller.start();
+        assert.strictEqual(posted.length, 1, 'visible start posts the panel');
+        assert.strictEqual(posted[0].type, 'skills-updated');
+
+        writeSkill(skillDir, 'second-description-is-longer');
+        const delivered = await controller.refresh('watch');
+        assert.strictEqual(delivered, true, 'visible watch refresh delivers');
+        assert.strictEqual(posted.length, 2, 'visible watch refresh posts the rebuilt panel');
+        assert.strictEqual(posted[1].type, 'skills-updated');
+        assert.match(posted[1].html, /second-description-is-longer/);
+        assert.strictEqual(controller.getRecords()[0].description, 'second-description-is-longer');
+        controller.dispose();
+    } finally {
+        fs.rmSync(home, { recursive: true, force: true });
+    }
+});


### PR DESCRIPTION
## Summary

Every skills refresh (fs.watch debounce, activation, every mutation) reran `scanSkillsDetailed`, which reread **every file of every skill** to rebuild drift fingerprints (`hashSkillDirectory`), synchronously on the extension host. The scan also ran while the sidebar was hidden.

- `src/skills/syncService.ts`: cache content hashes per directory behind an mtime+size manifest built with readdir+stat only. Unchanged skill directories reuse their cached hash and skip all content reads. Same cache semantics as the git index; traversal mirrors the hash walk exactly (same `node_modules`/'.git' skips, same ordering).
- `src/skills/dashboardController.ts`: watch-triggered refreshes while hidden now just mark records stale and return; the next read (`getRecords`/`getPanelView`/...) rescans lazily. `start()` and every mutation handler still scan eagerly, so bootstrap and action semantics are unchanged. No changes to the watch mechanism itself.

## Benchmark

One-off local benchmark (30 skills x 20 files x 50 KB, `scanSkillsDetailed` x20 after warmup, mean):

| | steady-state rescan |
| --- | --- |
| before | ~45.0 ms |
| after | ~4.6 ms |

## Tests

- New `tests/contract/skills/skillScanCache.test.js` exercises the real controller and hash service through the deterministic suite (previously only stub-loaded): identical-copy fingerprints, cache reuse, top-level/nested invalidation, exclusion rules, deferred hidden watch scans with lazy rescan on read, immediate visible delivery.
- Registered as an owner of `PERSIST-AI-SKILL-DISCOVERY-001`.
- Full gate suite green; changed-line coverage 91.30% (84/92).

## Manual checklist

- Edit a skill file -> panel updates within ~300 ms.
- Hide the sidebar, edit a skill externally, show the sidebar -> panel and search show the new content.
- Centralize/copy/sync actions refresh immediately; drift chips still render correctly.

## Skill harvest

No skill change justified: the established worktree/gates/audit workflow covered this change; the only friction (a fixture bug in my own new test, and a JSON reformat churn I reverted) is already captured by existing skills and the coverage gate.

Skill-Harvest: none