### PR TITLE
Add optional Thinking to AI Conversation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@ All notable changes to the "Agent Pivot" extension will be documented in this fi
 
 ### Added
 
-- AI Conversation renders provider thinking blocks, including visible Codex
+- AI Conversation can show provider thinking blocks, including visible Codex
   commentary and safe reasoning summaries, as collapsed entries interleaved
-  with assistant text and tool calls for Kimi, Claude, and Codex sessions, in
-  main sessions and subagent transcripts alike.
+  with assistant text and tool calls for Kimi, Claude, and Codex sessions.
+  Thinking is hidden by default and can be enabled for main sessions and
+  subagent transcripts with `agentPivot.aiConversation.showThinking`.
 - AI Conversation Markdown code fences now render with syntax highlighting,
   while mermaid fences keep their diagram rendering.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,10 @@ All notable changes to the "Agent Pivot" extension will be documented in this fi
 
 ### Added
 
-- AI Conversation renders provider thinking blocks and safe Codex reasoning
-  summaries as collapsed entries interleaved with assistant text and tool calls
-  for Kimi, Claude, and Codex sessions, in main sessions and subagent
-  transcripts alike.
+- AI Conversation renders provider thinking blocks, including visible Codex
+  commentary and safe reasoning summaries, as collapsed entries interleaved
+  with assistant text and tool calls for Kimi, Claude, and Codex sessions, in
+  main sessions and subagent transcripts alike.
 - AI Conversation Markdown code fences now render with syntax highlighting,
   while mermaid fences keep their diagram rendering.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ All notable changes to the "Agent Pivot" extension will be documented in this fi
 
 ### Added
 
-- AI Conversation renders provider thinking blocks as collapsed entries
-  interleaved with assistant text and tool calls for Kimi and Claude
-  sessions, in main sessions and subagent transcripts alike.
+- AI Conversation renders provider thinking blocks and safe Codex reasoning
+  summaries as collapsed entries interleaved with assistant text and tool calls
+  for Kimi, Claude, and Codex sessions, in main sessions and subagent
+  transcripts alike.
 - AI Conversation Markdown code fences now render with syntax highlighting,
   while mermaid fences keep their diagram rendering.
 

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -3840,7 +3840,7 @@
   {
     "id": "CONVERSATION-THINKING-VISIBILITY-001",
     "domain": "webview",
-    "title": "Conversation viewers render provider thinking blocks as collapsed entries interleaved with assistant text and tool calls",
+    "title": "Conversation viewers render provider thinking and Codex commentary as collapsed entries interleaved with assistant text and tool calls",
     "priority": "P1",
     "status": "automated",
     "owners": [

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -3848,6 +3848,7 @@
       "tests/contract/aiSessions/conversationCoordinator.test.js",
       "tests/contract/aiSessions/kimiConversationAdapter.test.js",
       "tests/contract/aiSessions/claudeConversationAdapter.test.js",
+      "tests/contract/aiSessions/codexConversationAdapter.test.js",
       "tests/integration/dashboard/conversationViewer.test.js",
       "tests/integration/dashboard/conversationRouting.test.js",
       "tests/browser/conversationViewer.test.js"
@@ -3857,6 +3858,7 @@
       "src/aiSessions/conversation/model.ts",
       "src/aiSessions/conversation/kimiAdapter.ts",
       "src/aiSessions/conversation/claudeAdapter.ts",
+      "src/aiSessions/conversation/codexAdapter.ts",
       "src/aiSessions/conversation/viewer.ts",
       "media/conversationViewer.scss"
     ]

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -3840,11 +3840,13 @@
   {
     "id": "CONVERSATION-THINKING-VISIBILITY-001",
     "domain": "webview",
-    "title": "Conversation viewers render provider thinking and Codex commentary as collapsed entries interleaved with assistant text and tool calls",
+    "title": "Conversation viewers hide provider thinking by default and render it as collapsed entries when enabled",
     "priority": "P1",
     "status": "automated",
     "owners": [
       "tests/unit/aiSessions/conversationModel.test.js",
+      "tests/contract/aiSessions/runtimePrimitives.test.js",
+      "tests/contract/aiSessions/runtimeComposition.test.js",
       "tests/contract/aiSessions/conversationCoordinator.test.js",
       "tests/contract/aiSessions/kimiConversationAdapter.test.js",
       "tests/contract/aiSessions/claudeConversationAdapter.test.js",
@@ -3860,6 +3862,8 @@
       "src/aiSessions/conversation/claudeAdapter.ts",
       "src/aiSessions/conversation/codexAdapter.ts",
       "src/aiSessions/conversation/viewer.ts",
+      "src/dashboard.ts",
+      "package.json",
       "media/conversationViewer.scss"
     ]
   },

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "e4174cab66e88f3a65cf95863dce7b899c8c508b",
+        "head": "26a11951cd33a37c6dc1ea2c39d7310745fa1e9e",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -101,7 +101,8 @@
             "15d7345968381b6f3e30dca8160ebf0826a34278",
             "cdc07bea25ff69aaf9521903b6e7c919d14f6789",
             "c5a50a2bab670c73790eaab897ff5d2b9962a67f",
-            "9dafc0f7348c719172e5754bd39f2c7d41d0e1f6"
+            "9dafc0f7348c719172e5754bd39f2c7d41d0e1f6",
+            "d8e2ea91f842c332417a3b039004940321ab1c43"
         ]
     },
     "capabilities": [
@@ -1141,7 +1142,8 @@
                 "722c49da1767c054df6f9f7aef3091b797f7a555",
                 "c383bfb593b2d2b55b98f0ecae4ff709a17a0291",
                 "41958bd51b5dadf6b4d4eabbec73d791d1b37a4a",
-                "84992bf52892579a68ba65eb8aeb80a51ff79d4d"
+                "84992bf52892579a68ba65eb8aeb80a51ff79d4d",
+                "26a11951cd33a37c6dc1ea2c39d7310745fa1e9e"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "1d30bca79ecb76040dbef3fbae5698a45426c2a0",
+        "head": "7a517a9cdf8c41f304b95e1e5b9ad9a85494800c",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -103,7 +103,8 @@
             "c5a50a2bab670c73790eaab897ff5d2b9962a67f",
             "9dafc0f7348c719172e5754bd39f2c7d41d0e1f6",
             "d8e2ea91f842c332417a3b039004940321ab1c43",
-            "3dc9a819bda19c6a897ebbfa92e15af4f577b800"
+            "3dc9a819bda19c6a897ebbfa92e15af4f577b800",
+            "a54ae75ec363f2cac0cbc180829958dafed8e845"
         ]
     },
     "capabilities": [
@@ -1145,7 +1146,8 @@
                 "41958bd51b5dadf6b4d4eabbec73d791d1b37a4a",
                 "84992bf52892579a68ba65eb8aeb80a51ff79d4d",
                 "26a11951cd33a37c6dc1ea2c39d7310745fa1e9e",
-                "1d30bca79ecb76040dbef3fbae5698a45426c2a0"
+                "1d30bca79ecb76040dbef3fbae5698a45426c2a0",
+                "7a517a9cdf8c41f304b95e1e5b9ad9a85494800c"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "26a11951cd33a37c6dc1ea2c39d7310745fa1e9e",
+        "head": "1d30bca79ecb76040dbef3fbae5698a45426c2a0",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -102,7 +102,8 @@
             "cdc07bea25ff69aaf9521903b6e7c919d14f6789",
             "c5a50a2bab670c73790eaab897ff5d2b9962a67f",
             "9dafc0f7348c719172e5754bd39f2c7d41d0e1f6",
-            "d8e2ea91f842c332417a3b039004940321ab1c43"
+            "d8e2ea91f842c332417a3b039004940321ab1c43",
+            "3dc9a819bda19c6a897ebbfa92e15af4f577b800"
         ]
     },
     "capabilities": [
@@ -1143,7 +1144,8 @@
                 "c383bfb593b2d2b55b98f0ecae4ff709a17a0291",
                 "41958bd51b5dadf6b4d4eabbec73d791d1b37a4a",
                 "84992bf52892579a68ba65eb8aeb80a51ff79d4d",
-                "26a11951cd33a37c6dc1ea2c39d7310745fa1e9e"
+                "26a11951cd33a37c6dc1ea2c39d7310745fa1e9e",
+                "1d30bca79ecb76040dbef3fbae5698a45426c2a0"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",

--- a/package.json
+++ b/package.json
@@ -234,6 +234,12 @@
                     "minimum": 1,
                     "markdownDescription": "Maximum number of AI session rows visible in an expanded project card before the session list scrolls."
                 },
+                "agentPivot.aiConversation.showThinking": {
+                    "type": "boolean",
+                    "default": false,
+                    "scope": "application",
+                    "description": "Show provider Thinking content in AI Conversation for Kimi, Claude, and Codex."
+                },
                 "agentPivot.aiSessionTerminalMode": {
                     "type": "string",
                     "enum": [

--- a/src/aiSessions/conversation/codexAdapter.ts
+++ b/src/aiSessions/conversation/codexAdapter.ts
@@ -97,6 +97,17 @@ function visibleMessage(value: string): string {
         );
 }
 
+function normalizeReasoningSummary(value: unknown): string | undefined {
+    if (!Array.isArray(value)) {
+        return undefined;
+    }
+    const summary = value
+        .filter((part): part is string => typeof part === 'string')
+        .join('\n\n');
+    const visible = visibleMessage(summary);
+    return visible || undefined;
+}
+
 function turnResponseState(value: string): ConversationResponseState {
     if (value === 'completed') {
         return 'complete';
@@ -220,6 +231,21 @@ function normalizeThreadRead(
                     responseState,
                 });
                 currentInteractionIndex = interactions.length - 1;
+            } else if (item.type === 'reasoning') {
+                if (currentInteractionIndex === undefined) {
+                    continue;
+                }
+                // App-server exposes readable summaries separately from raw
+                // reasoning content. Only the summary is safe viewer output;
+                // never fall back to `content` or legacy `text` fields.
+                const text = normalizeReasoningSummary(item.summary);
+                if (text) {
+                    const interaction = interactions[currentInteractionIndex];
+                    (interaction.thinking ||= []).push({
+                        position: interaction.assistantMarkdown.length,
+                        text,
+                    });
+                }
             } else if (item.type === 'commandExecution'
                 || item.type === 'fileChange') {
                 if (currentInteractionIndex === undefined) {

--- a/src/aiSessions/conversation/codexAdapter.ts
+++ b/src/aiSessions/conversation/codexAdapter.ts
@@ -267,10 +267,18 @@ function normalizeThreadRead(
                 if (currentInteractionIndex === undefined) {
                     continue;
                 }
-                const assistantMarkdown = visibleMessage(item.text);
-                if (assistantMarkdown) {
-                    interactions[currentInteractionIndex]
-                        .assistantMarkdown.push(assistantMarkdown);
+                const text = visibleMessage(item.text);
+                if (!text) {
+                    continue;
+                }
+                const interaction = interactions[currentInteractionIndex];
+                if (item.phase === 'commentary') {
+                    (interaction.thinking ||= []).push({
+                        position: interaction.assistantMarkdown.length,
+                        text,
+                    });
+                } else {
+                    interaction.assistantMarkdown.push(text);
                 }
             }
         }

--- a/src/aiSessions/conversation/composition.ts
+++ b/src/aiSessions/conversation/composition.ts
@@ -99,6 +99,7 @@ export interface ConversationCapabilityOptions {
     ) => PromiseLike<void> | Promise<void>;
     commentStore?: ConversationCommentStore;
     bookmarkStore?: ConversationBookmarkStore;
+    getShowThinking?: () => boolean;
 }
 
 interface ConversationCapabilityInternalFactories {
@@ -238,6 +239,7 @@ function createAvailableConversationCapability(
         restoreFocus: target => restoreConversationFocus(options, target),
         openExternal: options.openExternal,
         mediaUri: getConversationMediaUri,
+        showThinking: options.getShowThinking,
         submitPrompt: options.submitPrompt,
         focusSession: options.focusSession,
         commentStore: options.commentStore,
@@ -327,6 +329,7 @@ function createUnavailableConversationCapability(): ConversationCapability {
             return false;
         },
         async refresh() {},
+        async refreshPresentation() {},
         async reconcileAuthority() {},
         dispose() {},
     };

--- a/src/aiSessions/conversation/viewer.ts
+++ b/src/aiSessions/conversation/viewer.ts
@@ -67,6 +67,7 @@ export interface ConversationViewerOptions {
     ) => void | PromiseLike<void>;
     openExternal: (uri: vscode.Uri) => Thenable<boolean>;
     mediaUri: (fileName: string) => vscode.Uri;
+    showThinking?: () => boolean;
     submitPrompt: (
         target: ConversationViewerTarget,
         prompt: string
@@ -89,6 +90,7 @@ export interface ConversationViewerApi extends AiSessionDisposable {
     open(target: ConversationViewerTarget): Promise<void>;
     follow(target: ConversationViewerTarget): Promise<boolean>;
     refresh(): Promise<void>;
+    refreshPresentation(): Promise<void>;
     reconcileAuthority(
         resolveAuthority: (target: ConversationViewerTarget) => boolean
     ): Promise<void>;
@@ -240,6 +242,28 @@ export class ConversationViewer implements ConversationViewerApi {
             return;
         }
         await this.loadAuthoritative('refresh', false);
+    }
+
+    async refreshPresentation(): Promise<void> {
+        const pendingLoad = this.authoritativeLoadInFlight;
+        if (pendingLoad) {
+            try {
+                await pendingLoad;
+            } catch (_error) {
+                // The normal load path owns its failure presentation.
+            }
+        }
+        if (!this.panel || !this.target || !this.outlineController.snapshot
+            || !this.pages.length || this.suspended) {
+            return;
+        }
+        const requestId = this.allocateRequestId();
+        this.currentRequestId = requestId;
+        await this.deliverPublication(this.createPublication(
+            requestId,
+            this.subscriptionGeneration,
+            'refresh'
+        ), false);
     }
 
     async reconcileAuthority(
@@ -1306,7 +1330,7 @@ export class ConversationViewer implements ConversationViewerApi {
             requestId,
             subscriptionGeneration: generation,
             updateKind,
-            html: renderMessages(this.messages()),
+            html: renderMessages(this.messages(), this.showThinking()),
             ...projection,
             previousCursor: selectedIndex > 0
                 ? first?.previousCursor || ''
@@ -1341,6 +1365,14 @@ export class ConversationViewer implements ConversationViewerApi {
             initialPage,
             initialStatus,
         });
+    }
+
+    private showThinking(): boolean {
+        try {
+            return this.options.showThinking?.() === true;
+        } catch (_error) {
+            return false;
+        }
     }
 }
 
@@ -1399,13 +1431,16 @@ function renderThinkingMessage(message: ConversationMessage): string {
 </article>`;
 }
 
-function renderMessages(messages: ConversationMessage[]): string {
+function renderMessages(
+    messages: ConversationMessage[],
+    showThinking: boolean
+): string {
     return messages.map(message => {
         if (message.role === 'tool') {
             return renderToolMessage(message);
         }
         if (message.role === 'thinking') {
-            return renderThinkingMessage(message);
+            return showThinking ? renderThinkingMessage(message) : '';
         }
         return `<article class="conversation-message conversation-message-${message.role}"
     data-message-id="${escapeAttribute(message.id)}"

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1148,6 +1148,8 @@ async function initializeDashboard(
         bookmarkStore: new ConversationBookmarkFileStore(
             context.globalStoragePath
         ),
+        getShowThinking: () => getAgentPivotConfiguration()
+            .get<unknown>('aiConversation.showThinking', false) === true,
         submitPrompt: (viewerTarget, prompt) => submitConversationPrompt({
             getWorkspaceTarget: getCurrentWorkspaceActionTarget,
             getRuntime: getAiSessionRuntimeById,
@@ -1509,6 +1511,11 @@ async function initializeDashboard(
                 || event.affectsConfiguration(`${AGENT_PIVOT_CONFIG_SECTION}.aiSessionTmuxLayout`)
                 || event.affectsConfiguration(`${AGENT_PIVOT_CONFIG_SECTION}.aiSessionTmuxPath`)) {
                 await handleAiSessionRuntimeConfigurationChanged();
+            }
+            if (event.affectsConfiguration(
+                `${AGENT_PIVOT_CONFIG_SECTION}.aiConversation.showThinking`
+            )) {
+                await conversationCapability.viewer.refreshPresentation();
             }
         },
         checkDataMigration: async openStewardAfterMigrate => {

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -577,6 +577,7 @@ async function renderHostViewerDocument(options = {}) {
         openExternal: async () => true,
         mediaUri: fileName =>
             fakeHostUri(`file:///extension/media/${fileName}`),
+        showThinking: options.showThinking,
         submitPrompt: options.submitPrompt || (async () => {}),
         bookmarkStore: options.bookmarkStore,
     });
@@ -4176,5 +4177,36 @@ test('CONVERSATION-THINKING-VISIBILITY-001 renders collapsed thinking blocks and
     assert.match(
         await details.locator('.conversation-thinking-body').innerText(),
         /Compare the two runs\./
+    );
+});
+
+test('CONVERSATION-THINKING-VISIBILITY-001 omits Thinking from the default Host document and renders it when enabled', async t => {
+    const thinkingMessage = {
+        id: 'input-2:thinking:0',
+        interactionId: 'input-2',
+        role: 'thinking',
+        markdown: '',
+        thinking: { text: 'Compare the two runs.' },
+    };
+    const hidden = await openHostViewerDocument(t, {
+        showThinking: () => false,
+        pageOverrides: { messages: [thinkingMessage] },
+    });
+    assert.equal(
+        await hidden.page.locator('.conversation-message-thinking').count(),
+        0
+    );
+
+    const shown = await openHostViewerDocument(t, {
+        showThinking: () => true,
+        pageOverrides: { messages: [thinkingMessage] },
+    });
+    const details = shown.page.locator('.conversation-thinking');
+    assert.equal(await details.count(), 1);
+    assert.equal(await details.evaluate(element => element.open), false);
+    await details.locator('summary').click();
+    assert.equal(
+        await details.locator('.conversation-thinking-body').innerText(),
+        'Compare the two runs.'
     );
 });

--- a/tests/contract/aiSessions/codexConversationAdapter.test.js
+++ b/tests/contract/aiSessions/codexConversationAdapter.test.js
@@ -521,6 +521,54 @@ test('CONVERSATION-THINKING-VISIBILITY-001 Codex never falls back to raw reasoni
     assert.equal(serialized.includes('legacy-reasoning-secret'), false);
 });
 
+test('CONVERSATION-THINKING-VISIBILITY-001 Codex renders commentary as thinking and final answers as assistant output', async t => {
+    const native = {
+        thread: {
+            id: sessionId,
+            turns: [{
+                id: 'phased-agent-turn',
+                status: 'completed',
+                items: [
+                    {
+                        id: 'phased-agent-user',
+                        type: 'userMessage',
+                        content: [{ type: 'text', text: 'Inspect the failure' }],
+                    },
+                    {
+                        id: 'phased-agent-commentary',
+                        type: 'agentMessage',
+                        phase: 'commentary',
+                        text: 'Comparing the two runs.',
+                    },
+                    {
+                        id: 'phased-agent-answer',
+                        type: 'agentMessage',
+                        phase: 'final_answer',
+                        text: 'The parser dropped the event.',
+                    },
+                ],
+            }],
+        },
+    };
+    const harness = createAdapter(native);
+    t.after(() => harness.adapter.dispose());
+    const { page } = await readWholeConversation(harness.adapter);
+
+    assert.deepEqual(
+        page.messages.map(message => [
+            message.role,
+            message.role === 'thinking'
+                ? message.thinking.text
+                : message.markdown,
+        ]),
+        [
+            ['user', 'Inspect the failure'],
+            ['thinking', 'Comparing the two runs.'],
+            ['assistant', 'The parser dropped the event.'],
+        ]
+    );
+});
+
 test('SESSION-AI-SESSION-CODEX-CONVERSATION-006 shares the service watcher and disposes lifecycle ownership once', async () => {
     let subscribeCount = 0;
     let providerCallback;

--- a/tests/contract/aiSessions/codexConversationAdapter.test.js
+++ b/tests/contract/aiSessions/codexConversationAdapter.test.js
@@ -95,7 +95,25 @@ test('SESSION-AI-SESSION-CONVERSATION-ADAPTER-001 Codex normalizes only stable v
             ['user-item-3', 'Streaming visible response'],
         ]
     );
-    assert.equal(JSON.stringify(page).includes('reasoning-secret'), false);
+    assert.deepEqual(
+        page.messages.filter(message => message.role === 'thinking')
+            .map(message => [message.interactionId, message.thinking.text]),
+        [[
+            'user-item-1',
+            'Inspect the request.\n\nChoose a safe response.',
+        ]]
+    );
+    assert.deepEqual(
+        page.messages.filter(message =>
+            message.interactionId === 'user-item-1'
+        ).map(message => message.role),
+        ['user', 'thinking', 'assistant', 'tool', 'tool']
+    );
+    assert.equal(JSON.stringify(page).includes('raw-reasoning-secret'), false);
+    assert.equal(
+        JSON.stringify(page).includes('legacy-reasoning-secret'),
+        false
+    );
     assert.deepEqual(
         page.messages.filter(message => message.role === 'tool')
             .map(message => [
@@ -434,6 +452,73 @@ test('SESSION-AI-SESSION-CODEX-CONVERSATION-005 applies shared message and page 
             <= CONVERSATION_LIMITS.maxPageBytes,
         true
     );
+});
+
+test('CONVERSATION-THINKING-VISIBILITY-001 Codex bounds readable reasoning summaries without exposing raw content', async t => {
+    const longSummary = '🙂'.repeat(
+        CONVERSATION_LIMITS.maxMessageGraphemes + 50
+    );
+    const native = {
+        thread: {
+            id: sessionId,
+            turns: [{
+                id: 'reasoning-turn',
+                status: 'completed',
+                items: [
+                    {
+                        id: 'reasoning-user',
+                        type: 'userMessage',
+                        content: [{ type: 'text', text: 'Explain the change' }],
+                    },
+                    {
+                        id: 'reasoning-item',
+                        type: 'reasoning',
+                        summary: [longSummary],
+                        content: ['RAW-REASONING-CONTENT'],
+                        text: 'LEGACY-REASONING-CONTENT',
+                    },
+                    {
+                        id: 'reasoning-answer',
+                        type: 'agentMessage',
+                        text: 'Visible answer',
+                    },
+                ],
+            }],
+        },
+    };
+    const harness = createAdapter(native);
+    t.after(() => harness.adapter.dispose());
+    const { page } = await readWholeConversation(harness.adapter);
+    const thinking = page.messages.find(message =>
+        message.role === 'thinking'
+    );
+
+    assert.ok(thinking);
+    assert.equal(
+        Array.from(thinking.thinking.text).length,
+        CONVERSATION_LIMITS.maxMessageGraphemes
+    );
+    assert.equal(JSON.stringify(page).includes('RAW-REASONING-CONTENT'), false);
+    assert.equal(
+        JSON.stringify(page).includes('LEGACY-REASONING-CONTENT'),
+        false
+    );
+});
+
+test('CONVERSATION-THINKING-VISIBILITY-001 Codex never falls back to raw reasoning fields when a summary is unavailable', async t => {
+    const native = clone(fixture);
+    delete native.thread.turns[0].items[1].summary;
+    const harness = createAdapter(native);
+    t.after(() => harness.adapter.dispose());
+    const { page } = await readWholeConversation(harness.adapter);
+    const serialized = JSON.stringify(page);
+
+    assert.equal(
+        page.messages.some(message => message.role === 'thinking'),
+        false
+    );
+    assert.equal(serialized.includes('raw-reasoning-secret'), false);
+    assert.equal(serialized.includes('legacy-reasoning-secret'), false);
 });
 
 test('SESSION-AI-SESSION-CODEX-CONVERSATION-006 shares the service watcher and disposes lifecycle ownership once', async () => {

--- a/tests/contract/aiSessions/runtimeComposition.test.js
+++ b/tests/contract/aiSessions/runtimeComposition.test.js
@@ -358,7 +358,7 @@ test('RUNTIME-HOST-RUNTIME-COMPOSITION-001 production tmux fallback prompt is mo
     );
 });
 
-test('RUNTIME-HOST-RUNTIME-COMPOSITION-001 RUNTIME-RUNTIME-CONFIGURATION-001 production runtime configuration change rebinds tmux before refreshing runtimes', () => {
+test('RUNTIME-HOST-RUNTIME-COMPOSITION-001 RUNTIME-RUNTIME-CONFIGURATION-001 CONVERSATION-THINKING-VISIBILITY-001 production configuration change routes runtime and Conversation settings', () => {
     const result = runProductionActivation('configuration-change');
     assert.equal(result.failure, null);
     assert.deepEqual(result.runtimeConfigurationSequence, [
@@ -370,6 +370,13 @@ test('RUNTIME-HOST-RUNTIME-COMPOSITION-001 RUNTIME-RUNTIME-CONFIGURATION-001 pro
         result.affectsConfigurationQueries.includes('agentPivot.aiSessionTerminalMode'),
         true,
         'the configuration listener must match the AI session terminal mode key'
+    );
+    assert.equal(
+        result.affectsConfigurationQueries.includes(
+            'agentPivot.aiConversation.showThinking'
+        ),
+        true,
+        'the configuration listener must match the shared Thinking visibility key'
     );
 });
 

--- a/tests/contract/aiSessions/runtimePrimitives.test.js
+++ b/tests/contract/aiSessions/runtimePrimitives.test.js
@@ -116,6 +116,20 @@ test('SESSION-AI-SESSION-YOLO-CONFIGURATION-001 reads only literal true and decl
     assert.match(setting.description, /newly created and resumed/i);
 });
 
+test('CONVERSATION-THINKING-VISIBILITY-001 declares Thinking hidden by default for every AI Conversation', () => {
+    const manifest = JSON.parse(fs.readFileSync(
+        path.resolve(__dirname, '../../../package.json'),
+        'utf8'
+    ));
+    const setting = manifest.contributes.configuration.properties[
+        'agentPivot.aiConversation.showThinking'
+    ];
+    assert.equal(setting.type, 'boolean');
+    assert.equal(setting.default, false);
+    assert.equal(setting.scope, 'application');
+    assert.match(setting.description, /Kimi, Claude, and Codex/);
+});
+
 test('RUNTIME-LAUNCH-SPEC-001 preserves argv boundaries and renders hostile values as inert shell data', () => {
     const resume = commandBuilders.buildCodexResumeLaunchSpec(
         `session'; touch /tmp/nope; '`, directoryScope(`/work/it's app`), '/tmp/done marker'

--- a/tests/fixtures/conversations/codex/thread-read.json
+++ b/tests/fixtures/conversations/codex/thread-read.json
@@ -23,7 +23,14 @@
           {
             "id": "reasoning-item-1",
             "type": "reasoning",
-            "text": "reasoning-secret"
+            "summary": [
+              "Inspect the request.",
+              "Choose a safe response."
+            ],
+            "content": [
+              "raw-reasoning-secret"
+            ],
+            "text": "legacy-reasoning-secret"
           },
           {
             "id": "agent-item-1",

--- a/tests/integration/dashboard/conversationRouting.test.js
+++ b/tests/integration/dashboard/conversationRouting.test.js
@@ -1514,9 +1514,9 @@ test('CONVERSATION-THINKING-VISIBILITY-001 opens one comment-enabled AI Conversa
     assert.equal(panelHtml.includes('data-comment-input'), true);
     assert.equal(
         panelHtml.includes('conversation-message-thinking'),
-        true
+        false
     );
-    assert.equal(panelHtml.includes('secret-thought'), true);
+    assert.equal(panelHtml.includes('secret-thought'), false);
     assert.equal(panelHtml.includes('local/path'), false);
     assert.ok(harness.kimiSourceCalls.length >= 1);
     assert.equal(

--- a/tests/integration/dashboard/conversationViewer.test.js
+++ b/tests/integration/dashboard/conversationViewer.test.js
@@ -246,6 +246,7 @@ function createViewer(options = {}) {
             return true;
         },
         mediaUri: fileName => fakeUri(`file:///extension/media/${fileName}`),
+        showThinking: options.showThinking,
         bookmarkStore: options.bookmarkStore,
     });
     return { viewer, panel, watchDisposals, restoredTargets, openedUris };
@@ -1033,6 +1034,7 @@ test('CONVERSATION-THINKING-VISIBILITY-001 preserves thinking content across an 
                 thinking: { text: `thinking revision ${revision}` },
             }],
         }),
+        showThinking: () => true,
     });
 
     await viewer.open(target('session-a', 'input-1'));
@@ -1047,6 +1049,55 @@ test('CONVERSATION-THINKING-VISIBILITY-001 preserves thinking content across an 
     const publication = panel.postedMessages.filter(message =>
         message.type === 'conversation-viewer-page').at(-1);
     assert.equal(publication.html.includes('thinking revision 2'), true);
+});
+
+test('CONVERSATION-THINKING-VISIBILITY-001 hides Thinking by default and republishes it only when enabled', async () => {
+    let showThinking = false;
+    let pageReads = 0;
+    const { viewer, panel } = createViewer({
+        readPage: async request => {
+            pageReads += 1;
+            return {
+                ...page(request.sessionId, request.anchorInteractionId),
+                messages: [
+                    {
+                        id: 'input-1:thinking:0',
+                        interactionId: 'input-1',
+                        role: 'thinking',
+                        markdown: '',
+                        thinking: { text: 'private working notes' },
+                    },
+                    {
+                        id: 'input-1:assistant:0',
+                        interactionId: 'input-1',
+                        role: 'assistant',
+                        markdown: 'public answer',
+                    },
+                ],
+            };
+        },
+        showThinking: () => showThinking,
+    });
+
+    await viewer.open(target('session-a', 'input-1'));
+    let publication = decodeInitialPublication(panel.webview.html);
+    assert.equal(publication.html.includes('private working notes'), false);
+    assert.equal(publication.html.includes('public answer'), true);
+
+    showThinking = true;
+    await viewer.refreshPresentation();
+    publication = panel.postedMessages.filter(message =>
+        message.type === 'conversation-viewer-page').at(-1);
+    assert.equal(publication.html.includes('private working notes'), true);
+    assert.equal(publication.html.includes('public answer'), true);
+
+    showThinking = false;
+    await viewer.refreshPresentation();
+    publication = panel.postedMessages.filter(message =>
+        message.type === 'conversation-viewer-page').at(-1);
+    assert.equal(publication.html.includes('private working notes'), false);
+    assert.equal(publication.html.includes('public answer'), true);
+    assert.equal(pageReads, 1, 'presentation changes must reuse retained data');
 });
 
 test('CONVERSATION-READING-FOCUS-001 ignores watched refreshes when the authoritative source revision is unchanged', async () => {


### PR DESCRIPTION
## Summary

- preserve Kimi, Claude, and Codex Thinking in the shared Conversation model
- render visible Codex commentary and safe reasoning summaries as Thinking without exposing raw reasoning
- hide Thinking by default for every provider
- add the application-scoped `agentPivot.aiConversation.showThinking` setting to enable it
- republish retained Conversation data immediately when the setting changes, without rereading provider history

## Verification

- `npm run test:ci:linux`
- `npm run test:behavior-contracts` after the final capability audit
- full deterministic suites: 564 unit, 670 contract, 295 integration
- full Chromium suite: 115 tests, including default-hidden and enabled Thinking states
- current Codex app-server thread parsed through the adapter: 47 Thinking messages
- changed-line coverage: 82.28%
- `git diff --check`

## Skill harvest

No skill change. This update implements an explicit product default and shared-provider preference; it did not expose a missing or ambiguous reusable engineering workflow.