### PR TITLE
chore: release Agent Pivot 1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,7 @@ All notable changes to the "Agent Pivot" extension will be documented in this fi
 
 ## [Unreleased]
 
-### Fixed
-
-- AI Conversation now contains scrolling within the message viewport, keeping
-  its header and session telemetry visible during Latest navigation, and
-  preventing blank overscroll beyond the content.
-- AI Conversation now follows live response content automatically while the
-  reader is at the end, without requiring a New response content button;
-  scrolling up still preserves the historical reading position.
-- AI Conversation shows an animated Working status below the latest response
-  while the provider is still processing, including active Codex turns read as
-  interrupted by a detached reader and lifecycle-only transitions without new
-  provider content, then removes it on completion.
+## [1.0.3] - 2026-08-04
 
 ### Added
 
@@ -29,6 +18,19 @@ All notable changes to the "Agent Pivot" extension will be documented in this fi
   subagent transcripts with `agentPivot.aiConversation.showThinking`.
 - AI Conversation Markdown code fences now render with syntax highlighting,
   while mermaid fences keep their diagram rendering.
+
+### Fixed
+
+- AI Conversation now contains scrolling within the message viewport, keeping
+  its header and session telemetry visible during Latest navigation, and
+  preventing blank overscroll beyond the content.
+- AI Conversation now follows live response content automatically while the
+  reader is at the end, without requiring a New response content button;
+  scrolling up still preserves the historical reading position.
+- AI Conversation shows an animated Working status below the latest response
+  while the provider is still processing, including active Codex turns read as
+  interrupted by a detached reader and lifecycle-only transitions without new
+  provider content, then removes it on completion.
 
 ## [1.0.2] - 2026-08-03
 

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "d6243e95f56ccc846112fe1817d3734a0e3e1d2c",
+        "head": "a2008ccbea072221e551fded2cc7ef02f8a96ff3",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -113,7 +113,8 @@
             "9af6fbc76b87f2022467305b211f1bd1f8937c9d",
             "299338b91f6f36559b78fec16e9dd24cbde49c37",
             "c0b7922b8e40062fb1070c3771a52ac318a0c735",
-            "d35a08bc990c63ff4f69bf94c2a3eee67729ca13"
+            "d35a08bc990c63ff4f69bf94c2a3eee67729ca13",
+            "9ea58d209a87cfdad86acb3011a9f7de38ea4d80"
         ]
     },
     "capabilities": [
@@ -515,7 +516,8 @@
                 "6a514e5499745fed0383e103cd302616d54ed67e",
                 "aa4652ce76238eefdbf73381da93f410e2db096d",
                 "af19b2c9fbab071d6e8004846bff1cdd810836bc",
-                "de9edffbf61d702fb616f2d21a44b39051338973"
+                "de9edffbf61d702fb616f2d21a44b39051338973",
+                "a2008ccbea072221e551fded2cc7ef02f8a96ff3"
             ],
             "behaviors": [
                 "RELEASE-VSIX-PACKAGING-001",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "agent-pivot",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "agent-pivot",
-            "version": "1.0.2",
+            "version": "1.0.3",
             "license": "MIT",
             "dependencies": {
                 "dom-autoscroller": "^2.3.4",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "agent-pivot",
     "displayName": "Agent Pivot",
     "description": "Switch, monitor, and resume Codex, Claude, and Kimi sessions across VS Code workspaces.",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "publisher": "hzcheng",
     "license": "MIT",
     "icon": "media/extension_icon.png",

--- a/scripts/lib/brandIdentity.js
+++ b/scripts/lib/brandIdentity.js
@@ -10,7 +10,7 @@ const BRAND_IDENTITY = Object.freeze({
     publisher: 'hzcheng',
     mainPackageName: 'agent-pivot',
     mainExtensionId: 'hzcheng.agent-pivot',
-    mainVersion: '1.0.2',
+    mainVersion: '1.0.3',
     bridgePackageName: 'agent-pivot-attention-ui-bridge',
     bridgeExtensionId: 'hzcheng.agent-pivot-attention-ui-bridge',
     commandPrefix: 'agentPivot.',

--- a/scripts/run-release-notes-checks.js
+++ b/scripts/run-release-notes-checks.js
@@ -14,19 +14,19 @@ const workflowPath = path.join(repositoryRoot, '.github', 'workflows', 'release-
 function validateReleaseContent({ readme, changelog, packageMetadata }) {
     assert.strictEqual(packageMetadata.displayName, 'Agent Pivot',
         'release metadata must use the Agent Pivot display name');
-    assert.strictEqual(packageMetadata.version, '1.0.2',
-        'the current Agent Pivot release must be version 1.0.2');
+    assert.strictEqual(packageMetadata.version, '1.0.3',
+        'the current Agent Pivot release must be version 1.0.3');
     const currentRelease = extractReleaseNotes(changelog, packageMetadata.version);
     const requiredReleaseFacts = [
-        ['subagent viewing', /list a session's subagents/i],
-        ['collapsible tool calls', /tool calls as collapsible entries/i],
-        ['always-on quick entries', /stay visible at zero/i],
-        ['conversation telemetry', /context-window usage/i],
-        ['worktree chip', /worktree chip/i],
+        ['progress updates', /progress updates/i],
+        ['thinking blocks', /thinking blocks/i],
+        ['syntax highlighting', /syntax highlighting/i],
+        ['working status', /Working status/i],
+        ['live response following', /follows live response content/i],
     ];
 
     for (const [label, pattern] of requiredReleaseFacts) {
-        assert.match(currentRelease, pattern, `1.0.2 CHANGELOG release must document ${label}`);
+        assert.match(currentRelease, pattern, `1.0.3 CHANGELOG release must document ${label}`);
     }
     assert.match(readme, /Agent Pivot/i, 'README must document the current product name');
     assert.match(packageMetadata.description, /workspace/i,

--- a/scripts/run-release-packaging-checks.js
+++ b/scripts/run-release-packaging-checks.js
@@ -397,7 +397,7 @@ function runRealVsixArchiveChecks(mainPackage, bridgePackage) {
     );
     assert.strictEqual(
         path.basename(mainArtifact),
-        'agent-pivot-1.0.2.vsix',
+        'agent-pivot-1.0.3.vsix',
         'main release artifact name must remain exact',
     );
     assert.strictEqual(

--- a/tests/unit/tooling/brandIdentity.test.js
+++ b/tests/unit/tooling/brandIdentity.test.js
@@ -50,7 +50,7 @@ function manifests() {
             name: 'agent-pivot',
             displayName: 'Agent Pivot',
             publisher: 'hzcheng',
-            version: '1.0.2',
+            version: '1.0.3',
             icon: 'media/extension_icon.png',
             repository: {
                 type: 'git',
@@ -294,7 +294,7 @@ test('brand identity exposes the exact approved public contract', () => {
         publisher: 'hzcheng',
         mainPackageName: 'agent-pivot',
         mainExtensionId: 'hzcheng.agent-pivot',
-        mainVersion: '1.0.2',
+        mainVersion: '1.0.3',
         bridgePackageName: 'agent-pivot-attention-ui-bridge',
         bridgeExtensionId: 'hzcheng.agent-pivot-attention-ui-bridge',
         commandPrefix: 'agentPivot.',

--- a/tests/unit/tooling/extensionHostLauncher.test.js
+++ b/tests/unit/tooling/extensionHostLauncher.test.js
@@ -149,7 +149,7 @@ test('RELEASE-SCHEDULED-EXTENSION-HOST-001 launches both extensions with pinned 
         ]);
         assert.deepEqual(packagePlan.map(item => path.basename(item.artifactPath)), [
             'agent-pivot-attention-ui-bridge-1.0.0.vsix',
-            'agent-pivot-1.0.2.vsix',
+            'agent-pivot-1.0.3.vsix',
         ]);
         assert.equal(options.extensionTestsPath,
             path.join(environment.testHarness, 'index.js'));

--- a/tests/unit/tooling/releaseNotes.test.js
+++ b/tests/unit/tooling/releaseNotes.test.js
@@ -14,16 +14,16 @@ test('release content validation cannot satisfy current facts from historical no
     const changelog = [
         '# Changelog',
         '',
-        '## [1.0.2] - 2026-08-03',
+        '## [1.0.3] - 2026-08-04',
         '',
         '- AI Conversation renders provider tool calls as collapsible entries.',
         '- Added context-window usage telemetry.',
         '- The usage bar shows a worktree chip.',
         '- The quick-entry pills stay visible at zero count.',
         '',
-        '## [1.0.1] - 2026-07-31',
+        '## [1.0.2] - 2026-08-03',
         '',
-        '- Added an AI Skills workspace.',
+        '- Added subagent viewing.',
         '',
     ].join('\n');
 
@@ -33,10 +33,10 @@ test('release content validation cannot satisfy current facts from historical no
             changelog,
             packageMetadata: {
                 displayName: 'Agent Pivot',
-                version: '1.0.2',
+                version: '1.0.3',
                 description: 'Workspace command center.',
             },
         }),
-        /1\.0\.2 CHANGELOG release must document subagent viewing/,
+        /1\.0\.3 CHANGELOG release must document progress updates/,
     );
 });


### PR DESCRIPTION
## Summary

- Bump Agent Pivot to 1.0.3 and move the Unreleased CHANGELOG entries into the 1.0.3 release section (2026-08-04): cross-provider conversation progress updates, collapsible thinking blocks with safe Codex reasoning summaries, Markdown syntax highlighting, conversation scroll containment, live response following, and the Working status indicator.
- Update release notes and packaging guards plus tooling tests to the 1.0.3 version and release facts.

## Verification

- npm run test-compile
- npm run test:behavior-contracts (behavior catalog, main capability coverage, release journeys)
- npm run test:release-notes
- npm run test:release-packaging (agent-pivot-1.0.3.vsix)
- npm run brand:check
- npm run lint:ci

## Skill harvest

Reviewed this release task for workflow friction, corrections, retries, and tool ambiguity. One lesson surfaced: a recalled capability-coverage gate script name (`check-main-capability-coverage.js`) did not exist, and piping the failing command through `tail` masked its exit code inside an `&&` chain, so a missing gate appeared to pass. No skill change in this PR: the correct gate is already documented in package.json (`test:main-capabilities` / `test:behavior-contracts`); recorded here for the next skill iteration review.