### PR TITLE
Add keyboard switching for open windows

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -32,8 +32,17 @@ jobs:
           cache: npm
       - name: Install dependencies
         run: npm ci
-      - name: Install pinned Chromium
-        run: npx playwright install --with-deps chromium
+      - name: Install pinned Chromium headless shell
+        shell: bash
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            if timeout --kill-after=10s 120s npx playwright install --only-shell chromium; then
+              exit 0
+            fi
+            echo "::warning::Chromium install attempt ${attempt} failed"
+          done
+          exit 1
       - name: Run Linux quality gate
         run: npm run test:ci:linux
         env:

--- a/.skills/fixing-regressions-with-ci/SKILL.md
+++ b/.skills/fixing-regressions-with-ci/SKILL.md
@@ -22,6 +22,7 @@ Turn every confirmed regression into a CI-owned behavior before changing product
    - Read `docs/testing/README.md`.
    - Select an existing behavior ID or add one to `docs/testing/behavior-contracts.json`.
    - Add the ID to a focused test at the lowest stable layer.
+   - For every user-visible UI/Webview regression, ensure at least one automated owner asserts the final rendered or interaction surface. A ViewModel, controller, protocol, or intermediate message assertion alone is insufficient; if the focused owner stops at an intermediate layer, add a rendered-surface owner.
    - When one change has regressed multiple neighboring features, add a
      cross-feature journey in the real rendered surface in addition to the
      focused owners. Exercise the relevant transition, provider, and viewport

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@ All notable changes to the "Agent Pivot" extension will be documented in this fi
 ### Added
 
 - New `Agent Pivot: Switch to Open Window` command lists the other open VS
-  Code windows in a Quick Pick — by window name, with the project group as
-  the description when the window matches a saved project — and switches to
-  the selected window, so window switching is available from the keyboard
-  without opening the dashboard.
+  Code windows in a Quick Pick and switches to the selected window, so window
+  switching is available from the keyboard without opening the dashboard.
+- OPEN WINDOWS cards and the Switch to Open Window Quick Pick now display the
+  saved project name when the window matches a saved project (falling back to
+  the workspace name otherwise), with the project group shown as the Quick
+  Pick description.
 
 ## [1.0.3] - 2026-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ All notable changes to the "Agent Pivot" extension will be documented in this fi
 ### Added
 
 - New `Agent Pivot: Switch to Open Window` command lists the other open VS
-  Code windows in a Quick Pick — by project name and project group when the
-  window matches a saved project — and switches to the selected window, so
-  window switching is available from the keyboard without opening the
-  dashboard.
+  Code windows in a Quick Pick — by window name, with the project group as
+  the description when the window matches a saved project — and switches to
+  the selected window, so window switching is available from the keyboard
+  without opening the dashboard.
 
 ## [1.0.3] - 2026-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@ All notable changes to the "Agent Pivot" extension will be documented in this fi
 ### Added
 
 - New `Agent Pivot: Switch to Open Window` command lists the other open VS
-  Code windows in a Quick Pick — with environment, running AI session, and
-  attention summaries — and switches to the selected window, so window
-  switching is available from the keyboard without opening the dashboard.
+  Code windows in a Quick Pick — by project name and project group when the
+  window matches a saved project — and switches to the selected window, so
+  window switching is available from the keyboard without opening the
+  dashboard.
 
 ## [1.0.3] - 2026-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the "Agent Pivot" extension will be documented in this fi
 
 ## [Unreleased]
 
+### Added
+
+- New `Agent Pivot: Switch to Open Window` command lists the other open VS
+  Code windows in a Quick Pick — with environment, running AI session, and
+  attention summaries — and switches to the selected window, so window
+  switching is available from the keyboard without opening the dashboard.
+
 ## [1.0.3] - 2026-08-04
 
 ### Added

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "c9eb810b43b10caf940b0884ea0b2e62d0f3b127",
+        "head": "a6edd4e1b5c4cd77bdbee69a9a2ef2403536719f",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -115,7 +115,8 @@
             "c0b7922b8e40062fb1070c3771a52ac318a0c735",
             "d35a08bc990c63ff4f69bf94c2a3eee67729ca13",
             "9ea58d209a87cfdad86acb3011a9f7de38ea4d80",
-            "0d735cf7a616237a194f1838d93bc124dec7429d"
+            "0d735cf7a616237a194f1838d93bc124dec7429d",
+            "6d7f0acc2e19b0f8ae3a10b6c8d05deb4c63ed85"
         ]
     },
     "capabilities": [
@@ -279,7 +280,8 @@
                 "35a8eba46ff1e7b17dcbfeb020b80caaa3b62d64",
                 "a2b20e451f77413965004d7958af784af08f3449",
                 "d0615b4e0484feb208772e8ccb77cb1054c92308",
-                "c9eb810b43b10caf940b0884ea0b2e62d0f3b127"
+                "c9eb810b43b10caf940b0884ea0b2e62d0f3b127",
+                "a6edd4e1b5c4cd77bdbee69a9a2ef2403536719f"
             ],
             "behaviors": [
                 "OPEN-OPEN-PROJECT-WORKSPACE-CONTROLLER-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "20f0258e412d2e448840658e67d181b06afb0fdf",
+        "head": "f287d527971ec6a53b99ab20e75dbe73d8e28ec5",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -118,7 +118,8 @@
             "0d735cf7a616237a194f1838d93bc124dec7429d",
             "6d7f0acc2e19b0f8ae3a10b6c8d05deb4c63ed85",
             "683ca1eeba16f817b07e65ed9e5d0a9d2c276c94",
-            "65d60138ffd2d2c28bebb38abb86d73295fa0e52"
+            "65d60138ffd2d2c28bebb38abb86d73295fa0e52",
+            "e1b690ecfb1e03bc0119615882c1981e4f6c12d3"
         ]
     },
     "capabilities": [
@@ -249,7 +250,8 @@
                 "12559648732d3bcd2e830f70c3406de9ba5b3751",
                 "8bb4c12dde9e7f1ce4ea163ffb2e97edcdcb9b73",
                 "1cb17856b4e8db7fc94d2f6b4a5479d11f95f7d1",
-                "20f0258e412d2e448840658e67d181b06afb0fdf"
+                "20f0258e412d2e448840658e67d181b06afb0fdf",
+                "f287d527971ec6a53b99ab20e75dbe73d8e28ec5"
             ],
             "behaviors": [
                 "OPEN-OPEN-PROJECT-AUTHORITATIVE-IDENTITY-001",
@@ -263,7 +265,8 @@
                 "OPEN-WORKSPACE-PIN-CLIENT-001",
                 "OPEN-WORKSPACE-PIN-HOST-001",
                 "OPEN-WORKSPACE-PIN-SORT-001",
-                "OPEN-WORKSPACE-PIN-WEBVIEW-001"
+                "OPEN-WORKSPACE-PIN-WEBVIEW-001",
+                "OPEN-ALL-WINDOWS-LIST-001"
             ],
             "prGates": [
                 "test:deterministic:run"

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "a2008ccbea072221e551fded2cc7ef02f8a96ff3",
+        "head": "c9eb810b43b10caf940b0884ea0b2e62d0f3b127",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -114,7 +114,8 @@
             "299338b91f6f36559b78fec16e9dd24cbde49c37",
             "c0b7922b8e40062fb1070c3771a52ac318a0c735",
             "d35a08bc990c63ff4f69bf94c2a3eee67729ca13",
-            "9ea58d209a87cfdad86acb3011a9f7de38ea4d80"
+            "9ea58d209a87cfdad86acb3011a9f7de38ea4d80",
+            "0d735cf7a616237a194f1838d93bc124dec7429d"
         ]
     },
     "capabilities": [
@@ -277,7 +278,8 @@
                 "3d1588d05d4b7f30b971702e24e55f561786c527",
                 "35a8eba46ff1e7b17dcbfeb020b80caaa3b62d64",
                 "a2b20e451f77413965004d7958af784af08f3449",
-                "d0615b4e0484feb208772e8ccb77cb1054c92308"
+                "d0615b4e0484feb208772e8ccb77cb1054c92308",
+                "c9eb810b43b10caf940b0884ea0b2e62d0f3b127"
             ],
             "behaviors": [
                 "OPEN-OPEN-PROJECT-WORKSPACE-CONTROLLER-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "f287d527971ec6a53b99ab20e75dbe73d8e28ec5",
+        "head": "9dd6c07a94418fb1e71997ab3e49cefad2ffe8e9",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -119,7 +119,8 @@
             "6d7f0acc2e19b0f8ae3a10b6c8d05deb4c63ed85",
             "683ca1eeba16f817b07e65ed9e5d0a9d2c276c94",
             "65d60138ffd2d2c28bebb38abb86d73295fa0e52",
-            "e1b690ecfb1e03bc0119615882c1981e4f6c12d3"
+            "e1b690ecfb1e03bc0119615882c1981e4f6c12d3",
+            "443ead14d8013fa321c7b7431babceea43acf550"
         ]
     },
     "capabilities": [
@@ -970,7 +971,8 @@
                 "822c2648c29207d7b17d8a03e52940a053324081",
                 "c4fc3765929b05fc0e3b41710d6ca2527d0b15d0",
                 "3b72a3f40da2d816105c7fbd37f76e16e4fd239c",
-                "1123385bc527059ed7325350e92923f770d070b3"
+                "1123385bc527059ed7325350e92923f770d070b3",
+                "9dd6c07a94418fb1e71997ab3e49cefad2ffe8e9"
             ],
             "behaviors": [
                 "ARCH-CI-QUALITY-GATE-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "9dd6c07a94418fb1e71997ab3e49cefad2ffe8e9",
+        "head": "14c1213f64d62dad5cf200d642c83cdadd608b5f",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -120,7 +120,8 @@
             "683ca1eeba16f817b07e65ed9e5d0a9d2c276c94",
             "65d60138ffd2d2c28bebb38abb86d73295fa0e52",
             "e1b690ecfb1e03bc0119615882c1981e4f6c12d3",
-            "443ead14d8013fa321c7b7431babceea43acf550"
+            "443ead14d8013fa321c7b7431babceea43acf550",
+            "26780e9b673c21035ec297fb86cedde520a7e786"
         ]
     },
     "capabilities": [
@@ -972,7 +973,8 @@
                 "c4fc3765929b05fc0e3b41710d6ca2527d0b15d0",
                 "3b72a3f40da2d816105c7fbd37f76e16e4fd239c",
                 "1123385bc527059ed7325350e92923f770d070b3",
-                "9dd6c07a94418fb1e71997ab3e49cefad2ffe8e9"
+                "9dd6c07a94418fb1e71997ab3e49cefad2ffe8e9",
+                "14c1213f64d62dad5cf200d642c83cdadd608b5f"
             ],
             "behaviors": [
                 "ARCH-CI-QUALITY-GATE-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "73221dde44294e71adb8190f0e3116aa1e3283d6",
+        "head": "20f0258e412d2e448840658e67d181b06afb0fdf",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -117,7 +117,8 @@
             "9ea58d209a87cfdad86acb3011a9f7de38ea4d80",
             "0d735cf7a616237a194f1838d93bc124dec7429d",
             "6d7f0acc2e19b0f8ae3a10b6c8d05deb4c63ed85",
-            "683ca1eeba16f817b07e65ed9e5d0a9d2c276c94"
+            "683ca1eeba16f817b07e65ed9e5d0a9d2c276c94",
+            "65d60138ffd2d2c28bebb38abb86d73295fa0e52"
         ]
     },
     "capabilities": [
@@ -247,7 +248,8 @@
                 "837c9d66584a0ed8265d23e314faaa34df5f5f1f",
                 "12559648732d3bcd2e830f70c3406de9ba5b3751",
                 "8bb4c12dde9e7f1ce4ea163ffb2e97edcdcb9b73",
-                "1cb17856b4e8db7fc94d2f6b4a5479d11f95f7d1"
+                "1cb17856b4e8db7fc94d2f6b4a5479d11f95f7d1",
+                "20f0258e412d2e448840658e67d181b06afb0fdf"
             ],
             "behaviors": [
                 "OPEN-OPEN-PROJECT-AUTHORITATIVE-IDENTITY-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "a6edd4e1b5c4cd77bdbee69a9a2ef2403536719f",
+        "head": "73221dde44294e71adb8190f0e3116aa1e3283d6",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -116,7 +116,8 @@
             "d35a08bc990c63ff4f69bf94c2a3eee67729ca13",
             "9ea58d209a87cfdad86acb3011a9f7de38ea4d80",
             "0d735cf7a616237a194f1838d93bc124dec7429d",
-            "6d7f0acc2e19b0f8ae3a10b6c8d05deb4c63ed85"
+            "6d7f0acc2e19b0f8ae3a10b6c8d05deb4c63ed85",
+            "683ca1eeba16f817b07e65ed9e5d0a9d2c276c94"
         ]
     },
     "capabilities": [
@@ -281,7 +282,8 @@
                 "a2b20e451f77413965004d7958af784af08f3449",
                 "d0615b4e0484feb208772e8ccb77cb1054c92308",
                 "c9eb810b43b10caf940b0884ea0b2e62d0f3b127",
-                "a6edd4e1b5c4cd77bdbee69a9a2ef2403536719f"
+                "a6edd4e1b5c4cd77bdbee69a9a2ef2403536719f",
+                "73221dde44294e71adb8190f0e3116aa1e3283d6"
             ],
             "behaviors": [
                 "OPEN-OPEN-PROJECT-WORKSPACE-CONTROLLER-001",

--- a/package.json
+++ b/package.json
@@ -109,6 +109,10 @@
             {
                 "command": "agentPivot.notify.showOutput",
                 "title": "Agent Pivot: Show Notification Log"
+            },
+            {
+                "command": "agentPivot.switchToOpenWindow",
+                "title": "Agent Pivot: Switch to Open Window"
             }
         ],
         "keybindings": [

--- a/scripts/lib/ciContracts.js
+++ b/scripts/lib/ciContracts.js
@@ -99,6 +99,32 @@ function validateJob(
         `${jobId} must run ${expectedGate}`);
 }
 
+function validateChromiumInstall(job) {
+    assert.equal(findStep(job, step => isMapping(step) && typeof step.run === 'string'
+        && (step.run.includes('playwright install-deps') || step.run.includes('--with-deps'))),
+    undefined,
+    'quality-linux must not run redundant apt-backed Playwright dependency installs');
+
+    const browserInstall = findStep(job,
+        step => isMapping(step) && step.name === 'Install pinned Chromium headless shell');
+    assert.ok(browserInstall,
+        'quality-linux must define the pinned Chromium headless shell install step');
+    assert.equal(browserInstall.shell, 'bash',
+        'quality-linux Chromium install step must use bash');
+    assert.equal(browserInstall.run, [
+        'set -euo pipefail',
+        'for attempt in 1 2 3; do',
+        '  if timeout --kill-after=10s 120s npx playwright install --only-shell chromium; then',
+        '    exit 0',
+        '  fi',
+        '  echo "::warning::Chromium install attempt ${attempt} failed"',
+        'done',
+        'exit 1',
+        '',
+    ].join('\n'),
+    'quality-linux must install only the Chromium headless shell with three bounded retries');
+}
+
 function validateVerifyWorkflow(verifyWorkflow) {
     const workflow = parseVerifyWorkflow(verifyWorkflow);
     validateTriggers(workflow);
@@ -116,10 +142,11 @@ function validateVerifyWorkflow(verifyWorkflow) {
         'quality-linux',
         'ubuntu-latest',
         'npm run test:ci:linux',
-        ['npx playwright install --with-deps chromium'],
+        [],
         true,
         15
     );
+    validateChromiumInstall(workflow.jobs['quality-linux']);
     validateJob(workflow.jobs, 'platform-windows', 'windows-latest', 'npm run test:ci:windows');
     validateJob(workflow.jobs, 'tmux-smoke-linux', 'ubuntu-latest',
         'npm run test:tmux:smoke', ['sudo apt-get install -y tmux']);

--- a/scripts/run-dashboard-webview-checks.js
+++ b/scripts/run-dashboard-webview-checks.js
@@ -539,7 +539,7 @@ function runWorkspaceCardRenderingChecks() {
     assert.strictEqual((singleHtml.match(/class="codex-sessions"/g) || []).length, 1);
     assert.ok(singleHtml.includes(icons.folder));
     assert.ok(singleHtml.includes('title="Local Project"'));
-    assert.ok(singleHtml.includes('<h2 class="project-header">App</h2>'));
+    assert.ok(singleHtml.includes('<h2 class="project-header">Dashboard</h2>'));
     assert.ok(singleHtml.includes('<p class="project-description workspace-metadata">1 folder</p>'));
     assert.strictEqual(singleHtml.includes('Local ·'), false,
         'the environment icon already identifies local workspaces');
@@ -3704,6 +3704,7 @@ async function runDashboardCommandRegistrationChecks() {
         'migrateSkillsToCentral',
         'changeGlobalSkillsLocation',
         'openCurrentAiSessionConversation',
+        'switchToOpenWindow',
     ];
     const registration = new DashboardCommandRegistration({
         registerCommand: (command, callback) => {
@@ -3731,6 +3732,7 @@ async function runDashboardCommandRegistrationChecks() {
         'agentPivot.migrateSkillsToCentral',
         'agentPivot.changeGlobalSkillsLocation',
         'agentPivot.openCurrentAiSessionConversation',
+        'agentPivot.switchToOpenWindow',
     ]);
     assert.deepStrictEqual(subscriptions.map(disposable => disposable.command), registered.map(([command]) => command));
 
@@ -3761,6 +3763,7 @@ async function runDashboardCommandRegistrationChecks() {
         'migrateSkillsToCentral',
         'changeGlobalSkillsLocation',
         'openCurrentAiSessionConversation',
+        'switchToOpenWindow',
     ]);
 
     registration.dispose();

--- a/scripts/run-release-packaging-checks.js
+++ b/scripts/run-release-packaging-checks.js
@@ -99,6 +99,7 @@ const EXPECTED_MAIN_ENTRIES = Object.freeze([
     'extension/out/openWorkspaces/bridgeClient.js',
     'extension/out/openWorkspaces/dashboardController.js',
     'extension/out/openWorkspaces/navigationController.js',
+    'extension/out/openWorkspaces/navigationQuickPickController.js',
     'extension/out/openWorkspaces/pinController.js',
     'extension/out/openWorkspaces/pinProtocol.js',
     'extension/out/openWorkspaces/projection.js',

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1358,12 +1358,12 @@ async function initializeDashboard(
         getCards: () => openWorkspaceDashboardController.getCards(),
         getRecord: cardId => openWorkspaceDashboardController.getNavigationWorkspace(cardId),
         showQuickPick: (items, options) => vscode.window.showQuickPick(items, options),
-        getProjectDisplay: workspace => {
+        getProjectGroupName: workspace => {
             const project = getSavedProjectForWorkspace(workspace);
             if (!project) { return null; }
             const group = projectService.getGroups()
                 .find(candidate => candidate.projects.some(entry => entry.id === project.id));
-            return { name: project.name, groupName: group ? group.groupName : null };
+            return group ? group.groupName : null;
         },
         open: cardId => workspaceNavigationController.open(cardId),
         showInformationMessage: message => vscode.window.showInformationMessage(message),

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -146,6 +146,9 @@ import { getDashboardWebviewOptions } from './dashboard/webviewOptions';
 import OpenWorkspaceBridgeClient from './openWorkspaces/bridgeClient';
 import { OpenWorkspaceDashboardController } from './openWorkspaces/dashboardController';
 import { WorkspaceNavigationController } from './openWorkspaces/navigationController';
+import {
+    WorkspaceNavigationQuickPickController,
+} from './openWorkspaces/navigationQuickPickController';
 import { OpenWorkspacePinController } from './openWorkspaces/pinController';
 import { OpenWorkspaceController } from './openWorkspaces/workspaceController';
 import { WorkspaceContextResolver } from './workspaces/contextResolver';
@@ -1351,6 +1354,13 @@ async function initializeDashboard(
         showWarningMessage: message => vscode.window.showWarningMessage(message),
         refresh: refreshStewardViews,
     });
+    const workspaceNavigationQuickPickController = new WorkspaceNavigationQuickPickController({
+        getCards: () => openWorkspaceDashboardController.getCards(),
+        getRecord: cardId => openWorkspaceDashboardController.getNavigationWorkspace(cardId),
+        showQuickPick: (items, options) => vscode.window.showQuickPick(items, options),
+        open: cardId => workspaceNavigationController.open(cardId),
+        showInformationMessage: message => vscode.window.showInformationMessage(message),
+    });
     openWorkspaceBridgeClient = ownResource(() => new OpenWorkspaceBridgeClient(
         openWorkspaceController.getPublication(),
         aggregate => {
@@ -1584,6 +1594,7 @@ async function initializeDashboard(
         changeGlobalSkillsLocation: () =>
             skillPanel.changeGlobalStoreLocation(),
         openCurrentAiSessionConversation: () => openCurrentAiSessionConversation(),
+        switchToOpenWindow: () => workspaceNavigationQuickPickController.pickAndOpen(),
     };
 
     ownResource(() => vscode.workspace.onDidChangeConfiguration(

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1330,6 +1330,7 @@ async function initializeDashboard(
         getCurrentWorkspace: getCurrentOpenWorkspace,
         isWorkspaceSavedAsProject: workspace => Boolean(getSavedProjectForWorkspace(workspace)),
         getWorkspaceProjectColor: workspace => getSavedProjectForWorkspace(workspace)?.color || '',
+        getWorkspaceProjectName: workspace => getSavedProjectForWorkspace(workspace)?.name || '',
         getCurrentWorkspaceAiSessions: workspace => workspaceSessionHydrationController.hydrate(workspace),
         getGroups: () => projectService.getGroups(),
         getTodoSearchItems: () => todoService.getSearchItems(),

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1358,6 +1358,13 @@ async function initializeDashboard(
         getCards: () => openWorkspaceDashboardController.getCards(),
         getRecord: cardId => openWorkspaceDashboardController.getNavigationWorkspace(cardId),
         showQuickPick: (items, options) => vscode.window.showQuickPick(items, options),
+        getProjectDisplay: workspace => {
+            const project = getSavedProjectForWorkspace(workspace);
+            if (!project) { return null; }
+            const group = projectService.getGroups()
+                .find(candidate => candidate.projects.some(entry => entry.id === project.id));
+            return { name: project.name, groupName: group ? group.groupName : null };
+        },
         open: cardId => workspaceNavigationController.open(cardId),
         showInformationMessage: message => vscode.window.showInformationMessage(message),
     });

--- a/src/dashboard/commandRegistration.ts
+++ b/src/dashboard/commandRegistration.ts
@@ -20,6 +20,7 @@ export interface DashboardCommandHandlers {
     migrateSkillsToCentral: DashboardCommandHandler;
     changeGlobalSkillsLocation: DashboardCommandHandler;
     openCurrentAiSessionConversation: DashboardCommandHandler;
+    switchToOpenWindow: DashboardCommandHandler;
 }
 
 export interface DashboardCommandRegistrationOptions<TDisposable extends DisposableLike = DisposableLike> {
@@ -47,6 +48,7 @@ const DASHBOARD_COMMANDS: ReadonlyArray<readonly [string, DashboardCommandName]>
     ['agentPivot.migrateSkillsToCentral', 'migrateSkillsToCentral'],
     ['agentPivot.changeGlobalSkillsLocation', 'changeGlobalSkillsLocation'],
     ['agentPivot.openCurrentAiSessionConversation', 'openCurrentAiSessionConversation'],
+    ['agentPivot.switchToOpenWindow', 'switchToOpenWindow'],
 ];
 
 interface DashboardCommandGeneration {

--- a/src/openWorkspaces/dashboardController.ts
+++ b/src/openWorkspaces/dashboardController.ts
@@ -32,6 +32,7 @@ export interface OpenWorkspaceDashboardControllerOptions {
     getCurrentWorkspace: () => OpenWorkspace | null;
     isWorkspaceSavedAsProject: (workspace: OpenWorkspace) => boolean;
     getWorkspaceProjectColor: (workspace: Pick<OpenWorkspace, 'kind' | 'navigationUri'>) => string;
+    getWorkspaceProjectName?: (workspace: Pick<OpenWorkspace, 'kind' | 'navigationUri'>) => string;
     getCurrentWorkspaceAiSessions: (workspace: OpenWorkspace) => WorkspaceAiSessionViewModel | null;
     getGroups: () => Group[];
     getTodoSearchItems: () => TodoSearchCatalogItem[];
@@ -134,6 +135,7 @@ export class OpenWorkspaceDashboardController {
         const navigationCards = navigationProjections.map(projection => ({
             card: {
                 ...projection.card,
+                name: this.getWorkspaceProjectName(projection.workspace) || projection.card.name,
                 color: this.getWorkspaceCardColor(projection.workspace),
             },
             openedAtMs: projection.openedAtMs,
@@ -236,7 +238,7 @@ export class OpenWorkspaceDashboardController {
                 .filter(session => session.executionState === 'running').length,
             navigationIdentity,
             scopeIdentity: workspace.scopeIdentity,
-            name: workspace.displayName,
+            name: this.getWorkspaceProjectName(workspace) || workspace.displayName,
             environment: workspace.environment,
             environmentLabel: this.getEnvironmentLabel(workspace.environment),
             color: this.getWorkspaceCardColor(workspace),
@@ -258,6 +260,14 @@ export class OpenWorkspaceDashboardController {
             case 'local':
             default: return 'Local';
         }
+    }
+
+    private getWorkspaceProjectName(
+        workspace: Pick<OpenWorkspace, 'kind' | 'navigationUri'>,
+    ): string {
+        if (!this.options.getWorkspaceProjectName) { return ''; }
+        const name = this.options.getWorkspaceProjectName(workspace);
+        return name && name.trim() ? name : '';
     }
 
     private getWorkspaceCardColor(

--- a/src/openWorkspaces/navigationQuickPickController.ts
+++ b/src/openWorkspaces/navigationQuickPickController.ts
@@ -1,0 +1,68 @@
+'use strict';
+
+import type { WorkspaceCardViewModel } from '../models';
+import type { OpenWorkspaceRecord } from './protocol';
+
+export interface OpenWindowQuickPickItem {
+    label: string;
+    description?: string;
+    detail?: string;
+    cardId: string;
+}
+
+export interface WorkspaceNavigationQuickPickControllerOptions {
+    getCards: () => WorkspaceCardViewModel[];
+    getRecord: (cardId: string) => OpenWorkspaceRecord | null;
+    showQuickPick: (
+        items: OpenWindowQuickPickItem[],
+        options: { placeHolder: string; title: string },
+    ) => Thenable<OpenWindowQuickPickItem | undefined> | Promise<OpenWindowQuickPickItem | undefined>;
+    open: (cardId: string) => Promise<void>;
+    showInformationMessage: (message: string) => unknown;
+}
+
+export class WorkspaceNavigationQuickPickController {
+    constructor(private readonly options: WorkspaceNavigationQuickPickControllerOptions) {
+    }
+
+    async pickAndOpen(): Promise<void> {
+        const cards = this.options.getCards().filter(card => card.kind === 'navigation');
+        if (cards.length === 0) {
+            this.options.showInformationMessage('No other open windows to switch to.');
+            return;
+        }
+
+        const picked = await this.options.showQuickPick(cards.map(card => this.createItem(card)), {
+            placeHolder: 'Select an open window to switch to',
+            title: 'Switch to Open Window',
+        });
+        if (!picked) {
+            return;
+        }
+        await this.options.open(picked.cardId);
+    }
+
+    private createItem(card: WorkspaceCardViewModel): OpenWindowQuickPickItem {
+        const record = this.options.getRecord(card.id);
+        const segments = [card.environmentLabel];
+        if (card.runningSessionCount > 0) {
+            segments.push(card.runningSessionCount === 1
+                ? '1 running session'
+                : `${card.runningSessionCount} running sessions`);
+        }
+        if (card.attentionCount > 0) {
+            segments.push(card.attentionCount === 1
+                ? '1 needs attention'
+                : `${card.attentionCount} need attention`);
+        }
+        if (card.workspaceKind === 'untitledMultiRoot') {
+            segments.push('unsaved workspace');
+        }
+        return {
+            label: card.name,
+            description: segments.filter(segment => !!segment).join(' · '),
+            detail: record ? record.navigationUri : undefined,
+            cardId: card.id,
+        };
+    }
+}

--- a/src/openWorkspaces/navigationQuickPickController.ts
+++ b/src/openWorkspaces/navigationQuickPickController.ts
@@ -6,13 +6,20 @@ import type { OpenWorkspaceRecord } from './protocol';
 export interface OpenWindowQuickPickItem {
     label: string;
     description?: string;
-    detail?: string;
     cardId: string;
+}
+
+export interface OpenWindowProjectDisplay {
+    name: string;
+    groupName: string | null;
 }
 
 export interface WorkspaceNavigationQuickPickControllerOptions {
     getCards: () => WorkspaceCardViewModel[];
     getRecord: (cardId: string) => OpenWorkspaceRecord | null;
+    getProjectDisplay: (
+        workspace: Pick<OpenWorkspaceRecord, 'kind' | 'navigationUri'>,
+    ) => OpenWindowProjectDisplay | null;
     showQuickPick: (
         items: OpenWindowQuickPickItem[],
         options: { placeHolder: string; title: string },
@@ -44,24 +51,10 @@ export class WorkspaceNavigationQuickPickController {
 
     private createItem(card: WorkspaceCardViewModel): OpenWindowQuickPickItem {
         const record = this.options.getRecord(card.id);
-        const segments = [card.environmentLabel];
-        if (card.runningSessionCount > 0) {
-            segments.push(card.runningSessionCount === 1
-                ? '1 running session'
-                : `${card.runningSessionCount} running sessions`);
-        }
-        if (card.attentionCount > 0) {
-            segments.push(card.attentionCount === 1
-                ? '1 needs attention'
-                : `${card.attentionCount} need attention`);
-        }
-        if (card.workspaceKind === 'untitledMultiRoot') {
-            segments.push('unsaved workspace');
-        }
+        const projectDisplay = record ? this.options.getProjectDisplay(record) : null;
         return {
-            label: card.name,
-            description: segments.filter(segment => !!segment).join(' · '),
-            detail: record ? record.navigationUri : undefined,
+            label: projectDisplay ? projectDisplay.name : card.name,
+            description: projectDisplay?.groupName || undefined,
             cardId: card.id,
         };
     }

--- a/src/openWorkspaces/navigationQuickPickController.ts
+++ b/src/openWorkspaces/navigationQuickPickController.ts
@@ -9,17 +9,12 @@ export interface OpenWindowQuickPickItem {
     cardId: string;
 }
 
-export interface OpenWindowProjectDisplay {
-    name: string;
-    groupName: string | null;
-}
-
 export interface WorkspaceNavigationQuickPickControllerOptions {
     getCards: () => WorkspaceCardViewModel[];
     getRecord: (cardId: string) => OpenWorkspaceRecord | null;
-    getProjectDisplay: (
+    getProjectGroupName: (
         workspace: Pick<OpenWorkspaceRecord, 'kind' | 'navigationUri'>,
-    ) => OpenWindowProjectDisplay | null;
+    ) => string | null;
     showQuickPick: (
         items: OpenWindowQuickPickItem[],
         options: { placeHolder: string; title: string },
@@ -51,10 +46,10 @@ export class WorkspaceNavigationQuickPickController {
 
     private createItem(card: WorkspaceCardViewModel): OpenWindowQuickPickItem {
         const record = this.options.getRecord(card.id);
-        const projectDisplay = record ? this.options.getProjectDisplay(record) : null;
+        const groupName = record ? this.options.getProjectGroupName(record) : null;
         return {
-            label: projectDisplay ? projectDisplay.name : card.name,
-            description: projectDisplay?.groupName || undefined,
+            label: card.name,
+            description: groupName || undefined,
             cardId: card.id,
         };
     }

--- a/src/webview/webviewContent.ts
+++ b/src/webview/webviewContent.ts
@@ -476,9 +476,8 @@ function getWorkspaceCardDiv(
 ): string {
     const roots = card.roots.slice().sort((left, right) => left.ordinal - right.ordinal);
     const rootCount = roots.length;
-    const compactWorkspaceName = rootCount === 1
-        ? roots[0].name
-        : removeWorkspaceWindowDecorations(card.name);
+    const compactWorkspaceName = removeWorkspaceWindowDecorations(card.name)
+        || (rootCount === 1 ? roots[0].name : '');
     const workspaceName = escapeAttribute(sanitizeProjectName(compactWorkspaceName) || 'Workspace');
     const environmentLabel = escapeAttribute(sanitizeProjectName(card.environmentLabel) || 'Local');
     const remoteType = getWorkspaceRemoteType(card.environment);

--- a/tests/contract/aiSessions/runtimeComposition.test.js
+++ b/tests/contract/aiSessions/runtimeComposition.test.js
@@ -153,6 +153,7 @@ test('WEBVIEW-DASHBOARD-COMMAND-AVAILABILITY-001 production activation exposes s
         'agentPivot.migrateSkillsToCentral',
         'agentPivot.changeGlobalSkillsLocation',
         'agentPivot.openCurrentAiSessionConversation',
+        'agentPivot.switchToOpenWindow',
     ]);
     assert.equal(result.dashboardCommandRegistrationInvocations, 1);
     assert.equal(result.pendingOpenRevealedBootShell, true);

--- a/tests/contract/dashboardBoundaries.test.js
+++ b/tests/contract/dashboardBoundaries.test.js
@@ -328,7 +328,7 @@ const DASHBOARD_COMMANDS = [
     'agentPivot.removeGroup', 'agentPivot.addProjectsFromFolder',
     'agentPivot.addFileToActiveTerminal', 'agentPivot.insertPromptToActiveTerminal',
     'agentPivot.migrateSkillsToCentral', 'agentPivot.changeGlobalSkillsLocation',
-    'agentPivot.openCurrentAiSessionConversation',
+    'agentPivot.openCurrentAiSessionConversation', 'agentPivot.switchToOpenWindow',
 ];
 
 // Registered directly from initializeDashboard, outside the dashboard command facade.
@@ -345,7 +345,7 @@ test('WEBVIEW-DASHBOARD-COMMAND-REGISTRATION-001 WEBVIEW-DASHBOARD-COMMAND-AVAIL
         'open', 'addProject', 'saveProject', 'removeProject', 'editProjects', 'addGroup', 'removeGroup',
         'addProjectsFromFolder', 'addFileToActiveTerminal', 'insertPromptToActiveTerminal',
         'migrateSkillsToCentral', 'changeGlobalSkillsLocation',
-        'openCurrentAiSessionConversation',
+        'openCurrentAiSessionConversation', 'switchToOpenWindow',
     ];
     const facade = new DashboardCommandRegistration({
         registerCommand: (command, callback) => {

--- a/tests/contract/openProjects/dashboardController.test.js
+++ b/tests/contract/openProjects/dashboardController.test.js
@@ -162,6 +162,32 @@ test('OPEN-ALL-WINDOWS-LIST-001 orders current and navigation cards together wit
     assert.equal(pinned[0].pinned, true);
 });
 
+test('OPEN-ALL-WINDOWS-LIST-001 prefers saved project names over window display names', () => {
+    const current = makeRecord({ name: 'Current', uri: '/work/current' });
+    const other = makeRecord({ name: 'Other', uri: '/work/other' });
+    const unnamed = makeRecord({ name: 'Unnamed', uri: '/work/unnamed' });
+    const controller = new OpenWorkspaceDashboardController(createOptions({
+        getCurrentWorkspace: () => ({
+            ...current,
+            roots: current.roots.map(root => ({ ...root, hostPath: '/work/current' })),
+        }),
+        getWorkspaceProjectName: workspace => {
+            if (workspace.navigationUri === current.navigationUri) { return 'Current Alias'; }
+            if (workspace.navigationUri === other.navigationUri) { return 'Other Alias'; }
+            return '   ';
+        },
+    }));
+    controller.setAggregate(makeAggregate([
+        makeRegistration(SELF, 9000, current.navigationUri, { openedAtMs: 3000, workspace: current }),
+        makeRegistration(OLDER, 8000, other.navigationUri, { openedAtMs: 1000, workspace: other }),
+        makeRegistration(NEWER, 7000, unnamed.navigationUri, { openedAtMs: 2000, workspace: unnamed }),
+    ]));
+
+    const cards = controller.getCards();
+    assert.deepEqual(cards.map(card => card.name), ['Other Alias', 'Unnamed', 'Current Alias']);
+    assert.equal(cards[2].kind, 'current');
+});
+
 test('OPEN-ALL-WINDOWS-LIST-001 gives every remote window the same authoritative project order', () => {
     const localProjectA = makeRecord({ name: 'Project A', uri: '/work/project-a' });
     const localProjectB = makeRecord({ name: 'Project B', uri: '/work/project-b' });

--- a/tests/extension-host/suite/index.js
+++ b/tests/extension-host/suite/index.js
@@ -20,6 +20,7 @@ const PUBLIC_COMMANDS = [
     'agentPivot.migrateSkillsToCentral',
     'agentPivot.changeGlobalSkillsLocation',
     'agentPivot.openCurrentAiSessionConversation',
+    'agentPivot.switchToOpenWindow',
 ];
 
 async function verifyExtensionHostLifecycle() {

--- a/tests/integration/dashboard/webviewState.test.js
+++ b/tests/integration/dashboard/webviewState.test.js
@@ -543,6 +543,27 @@ test('OPEN-ALL-WINDOWS-LIST-001 WEBVIEW-CURRENT-WORKSPACE-RENDERING-001 WEBVIEW-
     assert.equal(html.includes('Leaked'), false);
 });
 
+test('OPEN-ALL-WINDOWS-LIST-001 renders saved project names for single-root window cards', () => {
+    const html = webviewModules.content.getOpenWorkspacesGroupContent([
+        makeWorkspaceCard({
+            id: 'current',
+            name: 'agent-pivot',
+            rootName: 'vscode-dashboard',
+        }),
+        makeWorkspaceCard({
+            id: 'navigation',
+            kind: 'navigation',
+            name: 'reddb project',
+            rootName: 'reddb',
+        }),
+    ], false, 'ready');
+
+    const renderedNames = Array.from(html.matchAll(
+        /<h2 class="project-header">([^<]+)<\/h2>/g
+    )).map(match => match[1]);
+    assert.deepEqual(renderedNames, ['agent-pivot', 'agent-pivot', 'reddb project']);
+});
+
 test('WEBVIEW-MULTI-PROVIDER-SESSION-HISTORY-001 WEBVIEW-MULTI-PROVIDER-SESSION-HISTORY-002 renders a pinned-first selected-provider history list', () => {
     const html = webviewModules.content.getOpenWorkspacesGroupContent([
         makeWorkspaceCard({

--- a/tests/unit/openWorkspaces/navigationQuickPick.test.js
+++ b/tests/unit/openWorkspaces/navigationQuickPick.test.js
@@ -33,7 +33,7 @@ function createController(overrides) {
     const options = Object.assign({
         getCards: () => [],
         getRecord: () => null,
-        getProjectDisplay: workspace => { calls.projectDisplay.push(workspace); return null; },
+        getProjectGroupName: workspace => { calls.projectDisplay.push(workspace); return null; },
         showQuickPick: async () => { calls.quickPick += 1; return undefined; },
         open: async cardId => { calls.open.push(cardId); },
         showInformationMessage: message => { calls.info.push(message); },
@@ -56,7 +56,7 @@ test('pickAndOpen informs when no other windows are open', async () => {
     assert.deepEqual(calls.info, ['No other open windows to switch to.']);
 });
 
-test('pickAndOpen shows project name and group name for saved projects', async () => {
+test('pickAndOpen shows the window name with its project group', async () => {
     let shownItems;
     let shownOptions;
     const { controller, calls } = createController({
@@ -67,13 +67,10 @@ test('pickAndOpen shows project name and group name for saved projects', async (
             card({ id: '__openWorkspaceNavigation-ghi789', name: 'workspace-c' }),
         ],
         getRecord: cardId => (cardId === '__openWorkspaceNavigation-ghi789' ? null : record(`file:///work/${cardId}`)),
-        getProjectDisplay: workspace => {
+        getProjectGroupName: workspace => {
             calls.projectDisplay.push(workspace);
             if (workspace.navigationUri.endsWith('abc123')) {
-                return { name: 'Project Alpha', groupName: 'Backend' };
-            }
-            if (workspace.navigationUri.endsWith('def456')) {
-                return { name: 'Project Beta', groupName: null };
+                return 'Backend';
             }
             return null;
         },
@@ -83,8 +80,8 @@ test('pickAndOpen shows project name and group name for saved projects', async (
     await controller.pickAndOpen();
 
     assert.deepEqual(shownItems, [
-        { label: 'Project Alpha', description: 'Backend', cardId: '__openWorkspaceNavigation-abc123' },
-        { label: 'Project Beta', description: undefined, cardId: '__openWorkspaceNavigation-def456' },
+        { label: 'workspace-a', description: 'Backend', cardId: '__openWorkspaceNavigation-abc123' },
+        { label: 'workspace-b', description: undefined, cardId: '__openWorkspaceNavigation-def456' },
         { label: 'workspace-c', description: undefined, cardId: '__openWorkspaceNavigation-ghi789' },
     ]);
     assert.equal(shownOptions.title, 'Switch to Open Window');

--- a/tests/unit/openWorkspaces/navigationQuickPick.test.js
+++ b/tests/unit/openWorkspaces/navigationQuickPick.test.js
@@ -1,0 +1,132 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {
+    WorkspaceNavigationQuickPickController,
+} = require('../../../out/openWorkspaces/navigationQuickPickController');
+
+function card(overrides) {
+    return Object.assign({
+        id: '__openWorkspaceNavigation-abc123',
+        kind: 'navigation',
+        workspaceKind: 'singleFolder',
+        name: 'workspace-a',
+        environmentLabel: 'Local',
+        runningSessionCount: 0,
+        attentionCount: 0,
+    }, overrides);
+}
+
+function record(navigationUri) {
+    return {
+        navigationIdentity: 'a'.repeat(64),
+        scopeIdentity: 'b'.repeat(64),
+        kind: 'singleFolder',
+        displayName: 'workspace-a',
+        navigationUri,
+        environment: 'local',
+        runningAiSessionCount: 0,
+        roots: [],
+    };
+}
+
+function createController(overrides) {
+    const calls = { quickPick: 0, open: [], info: [] };
+    const options = Object.assign({
+        getCards: () => [],
+        getRecord: () => null,
+        showQuickPick: async () => { calls.quickPick += 1; return undefined; },
+        open: async cardId => { calls.open.push(cardId); },
+        showInformationMessage: message => { calls.info.push(message); },
+    }, overrides);
+    return {
+        controller: new WorkspaceNavigationQuickPickController(options),
+        calls,
+    };
+}
+
+test('pickAndOpen informs when no other windows are open', async () => {
+    const { controller, calls } = createController({
+        getCards: () => [card({ kind: 'current' })],
+    });
+
+    await controller.pickAndOpen();
+
+    assert.equal(calls.quickPick, 0);
+    assert.equal(calls.open.length, 0);
+    assert.deepEqual(calls.info, ['No other open windows to switch to.']);
+});
+
+test('pickAndOpen maps navigation cards to quick pick items', async () => {
+    const uri = 'vscode-remote://ssh-remote%2Bhost/work/workspace-a';
+    let shownItems;
+    let shownOptions;
+    const { controller } = createController({
+        getCards: () => [
+            card({ kind: 'current', id: '__currentWorkspace-fff' }),
+            card({ runningSessionCount: 2, attentionCount: 1 }),
+            card({
+                id: '__openWorkspaceNavigation-def456',
+                name: 'workspace-b',
+                environmentLabel: 'WSL',
+                workspaceKind: 'untitledMultiRoot',
+            }),
+        ],
+        getRecord: cardId => (cardId === '__openWorkspaceNavigation-abc123' ? record(uri) : null),
+        showQuickPick: async (items, options) => { shownItems = items; shownOptions = options; return undefined; },
+    });
+
+    await controller.pickAndOpen();
+
+    assert.equal(shownItems.length, 2);
+    assert.deepEqual(shownItems[0], {
+        label: 'workspace-a',
+        description: 'Local · 2 running sessions · 1 needs attention',
+        detail: uri,
+        cardId: '__openWorkspaceNavigation-abc123',
+    });
+    assert.deepEqual(shownItems[1], {
+        label: 'workspace-b',
+        description: 'WSL · unsaved workspace',
+        detail: undefined,
+        cardId: '__openWorkspaceNavigation-def456',
+    });
+    assert.equal(shownOptions.title, 'Switch to Open Window');
+    assert.ok(shownOptions.placeHolder.length > 0);
+});
+
+test('pickAndOpen opens the selected card', async () => {
+    const { controller, calls } = createController({
+        getCards: () => [card()],
+        showQuickPick: async items => items[0],
+    });
+
+    await controller.pickAndOpen();
+
+    assert.deepEqual(calls.open, ['__openWorkspaceNavigation-abc123']);
+    assert.equal(calls.info.length, 0);
+});
+
+test('pickAndOpen does nothing when the pick is cancelled', async () => {
+    const { controller, calls } = createController({
+        getCards: () => [card()],
+        showQuickPick: async () => undefined,
+    });
+
+    await controller.pickAndOpen();
+
+    assert.deepEqual(calls.open, []);
+});
+
+test('pickAndOpen uses singular running session wording', async () => {
+    let shownItems;
+    const { controller } = createController({
+        getCards: () => [card({ runningSessionCount: 1 })],
+        showQuickPick: async items => { shownItems = items; return undefined; },
+    });
+
+    await controller.pickAndOpen();
+
+    assert.equal(shownItems[0].description, 'Local · 1 running session');
+});

--- a/tests/unit/openWorkspaces/navigationQuickPick.test.js
+++ b/tests/unit/openWorkspaces/navigationQuickPick.test.js
@@ -12,9 +12,6 @@ function card(overrides) {
         kind: 'navigation',
         workspaceKind: 'singleFolder',
         name: 'workspace-a',
-        environmentLabel: 'Local',
-        runningSessionCount: 0,
-        attentionCount: 0,
     }, overrides);
 }
 
@@ -32,10 +29,11 @@ function record(navigationUri) {
 }
 
 function createController(overrides) {
-    const calls = { quickPick: 0, open: [], info: [] };
+    const calls = { quickPick: 0, open: [], info: [], projectDisplay: [] };
     const options = Object.assign({
         getCards: () => [],
         getRecord: () => null,
+        getProjectDisplay: workspace => { calls.projectDisplay.push(workspace); return null; },
         showQuickPick: async () => { calls.quickPick += 1; return undefined; },
         open: async cardId => { calls.open.push(cardId); },
         showInformationMessage: message => { calls.info.push(message); },
@@ -58,47 +56,46 @@ test('pickAndOpen informs when no other windows are open', async () => {
     assert.deepEqual(calls.info, ['No other open windows to switch to.']);
 });
 
-test('pickAndOpen maps navigation cards to quick pick items', async () => {
-    const uri = 'vscode-remote://ssh-remote%2Bhost/work/workspace-a';
+test('pickAndOpen shows project name and group name for saved projects', async () => {
     let shownItems;
     let shownOptions;
-    const { controller } = createController({
+    const { controller, calls } = createController({
         getCards: () => [
             card({ kind: 'current', id: '__currentWorkspace-fff' }),
-            card({ runningSessionCount: 2, attentionCount: 1 }),
-            card({
-                id: '__openWorkspaceNavigation-def456',
-                name: 'workspace-b',
-                environmentLabel: 'WSL',
-                workspaceKind: 'untitledMultiRoot',
-            }),
+            card(),
+            card({ id: '__openWorkspaceNavigation-def456', name: 'workspace-b' }),
+            card({ id: '__openWorkspaceNavigation-ghi789', name: 'workspace-c' }),
         ],
-        getRecord: cardId => (cardId === '__openWorkspaceNavigation-abc123' ? record(uri) : null),
+        getRecord: cardId => (cardId === '__openWorkspaceNavigation-ghi789' ? null : record(`file:///work/${cardId}`)),
+        getProjectDisplay: workspace => {
+            calls.projectDisplay.push(workspace);
+            if (workspace.navigationUri.endsWith('abc123')) {
+                return { name: 'Project Alpha', groupName: 'Backend' };
+            }
+            if (workspace.navigationUri.endsWith('def456')) {
+                return { name: 'Project Beta', groupName: null };
+            }
+            return null;
+        },
         showQuickPick: async (items, options) => { shownItems = items; shownOptions = options; return undefined; },
     });
 
     await controller.pickAndOpen();
 
-    assert.equal(shownItems.length, 2);
-    assert.deepEqual(shownItems[0], {
-        label: 'workspace-a',
-        description: 'Local · 2 running sessions · 1 needs attention',
-        detail: uri,
-        cardId: '__openWorkspaceNavigation-abc123',
-    });
-    assert.deepEqual(shownItems[1], {
-        label: 'workspace-b',
-        description: 'WSL · unsaved workspace',
-        detail: undefined,
-        cardId: '__openWorkspaceNavigation-def456',
-    });
+    assert.deepEqual(shownItems, [
+        { label: 'Project Alpha', description: 'Backend', cardId: '__openWorkspaceNavigation-abc123' },
+        { label: 'Project Beta', description: undefined, cardId: '__openWorkspaceNavigation-def456' },
+        { label: 'workspace-c', description: undefined, cardId: '__openWorkspaceNavigation-ghi789' },
+    ]);
     assert.equal(shownOptions.title, 'Switch to Open Window');
     assert.ok(shownOptions.placeHolder.length > 0);
+    assert.equal(calls.projectDisplay.length, 2);
 });
 
 test('pickAndOpen opens the selected card', async () => {
     const { controller, calls } = createController({
         getCards: () => [card()],
+        getRecord: () => record('file:///work/workspace-a'),
         showQuickPick: async items => items[0],
     });
 
@@ -117,16 +114,4 @@ test('pickAndOpen does nothing when the pick is cancelled', async () => {
     await controller.pickAndOpen();
 
     assert.deepEqual(calls.open, []);
-});
-
-test('pickAndOpen uses singular running session wording', async () => {
-    let shownItems;
-    const { controller } = createController({
-        getCards: () => [card({ runningSessionCount: 1 })],
-        showQuickPick: async items => { shownItems = items; return undefined; },
-    });
-
-    await controller.pickAndOpen();
-
-    assert.equal(shownItems[0].description, 'Local · 1 running session');
 });

--- a/tests/unit/tooling/ciContracts.test.js
+++ b/tests/unit/tooling/ciContracts.test.js
@@ -90,13 +90,55 @@ test('ARCH-MAIN-CAPABILITY-COVERAGE-001 requires full Git history in the Linux q
 
 test('TODO-BROWSER-EXPANDED-LAYOUT-001 requires pinned Chromium in the Linux quality job', () => {
     const missingChromiumWorkflow = verifyWorkflow.replace(
-        '        run: npx playwright install --with-deps chromium',
-        '        run: npx playwright --version'
+        '            if timeout --kill-after=10s 120s npx playwright install --only-shell chromium; then',
+        '            if npx playwright --version; then'
     );
 
     assert.throws(
         () => validateVerifyWorkflow(missingChromiumWorkflow),
-        /quality-linux must run npx playwright install --with-deps chromium/
+        /quality-linux must install only the Chromium headless shell with three bounded retries/
+    );
+});
+
+test('ARCH-CI-QUALITY-GATE-001 accepts bounded retries for the Chromium headless shell', () => {
+    assert.doesNotThrow(() => validateVerifyWorkflow(verifyWorkflow));
+});
+
+test('ARCH-CI-QUALITY-GATE-001 rejects Chromium installs without three attempts', () => {
+    const oneAttemptWorkflow = verifyWorkflow.replace(
+        '          for attempt in 1 2 3; do',
+        '          for attempt in 1; do'
+    );
+
+    assert.throws(
+        () => validateVerifyWorkflow(oneAttemptWorkflow),
+        /quality-linux must install only the Chromium headless shell with three bounded retries/
+    );
+});
+
+test('ARCH-CI-QUALITY-GATE-001 rejects Chromium installs without a hard timeout', () => {
+    const unboundedWorkflow = verifyWorkflow.replace(
+        'timeout --kill-after=10s 120s npx playwright install --only-shell chromium',
+        'npx playwright install --only-shell chromium'
+    );
+
+    assert.throws(
+        () => validateVerifyWorkflow(unboundedWorkflow),
+        /quality-linux must install only the Chromium headless shell with three bounded retries/
+    );
+});
+
+test('ARCH-CI-QUALITY-GATE-001 rejects redundant apt font downloads on the hosted runner', () => {
+    const aptBackedWorkflow = verifyWorkflow.replace(
+        '      - name: Install pinned Chromium headless shell',
+        '      - name: Install Chromium system dependencies\n'
+            + '        run: npx playwright install-deps chromium\n'
+            + '      - name: Install pinned Chromium headless shell'
+    );
+
+    assert.throws(
+        () => validateVerifyWorkflow(aptBackedWorkflow),
+        /quality-linux must not run redundant apt-backed Playwright dependency installs/
     );
 });
 

--- a/tests/unit/tooling/extensionHostSuite.test.js
+++ b/tests/unit/tooling/extensionHostSuite.test.js
@@ -23,6 +23,7 @@ const publicCommands = [
     'agentPivot.migrateSkillsToCentral',
     'agentPivot.changeGlobalSkillsLocation',
     'agentPivot.openCurrentAiSessionConversation',
+    'agentPivot.switchToOpenWindow',
 ];
 
 function loadSuite(vscode) {

--- a/tests/unit/tooling/repositorySkills.test.js
+++ b/tests/unit/tooling/repositorySkills.test.js
@@ -47,6 +47,7 @@ test('ARCH-REPOSITORY-SKILL-GUIDANCE-001 keeps regression audits path-based and 
         ['tracked or CI-produced test inputs', /git-tracked or produced by an earlier step of the CI job/i],
         ['build outputs absent rerun', /build outputs absent/i],
         ['machine state hermeticity', /git identity, environment variables, tools on PATH/i],
+        ['user-visible rendered owner', /every user-visible UI\/Webview regression[\s\S]*automated owner[\s\S]*final rendered or interaction surface[\s\S]*ViewModel[\s\S]*insufficient/i],
         ['cross-feature rendered journey', /cross-feature journey[\s\S]*real rendered surface[\s\S]*provider[\s\S]*viewport\s+matrix/i],
         ['post-repair mutation sensitivity', /implementation is already repaired[\s\S]*mutation sensitivity[\s\S]*reintroduce each causal defect/i],
     ]);


### PR DESCRIPTION
## Summary

- add the **Agent Pivot: Switch to Open Window** command with saved project names and group context in Quick Pick
- render saved project names consistently on dashboard cards, including single-root windows
- add final rendered-surface regression coverage and strengthen the regression-fix skill guidance
- keep the Linux quality gate complete while removing redundant apt font downloads and bounding Chromium headless-shell retries
- include the new navigation Quick Pick controller in the reviewed VSIX allowlist

## User-visible regression proof

- **RED:** the focused dashboard Webview regression rendered `vscode-dashboard` instead of the saved `agent-pivot` project name
- **GREEN:** the Webview now prefers `card.name` and the integration owner asserts the final rendered title
- the repository-skill guard also failed before the rendered-surface ownership rule was added, then passed after the skill update

## CI failure and optimization proof

- **RED:** `quality-linux` rejected the packaged VSIX because `navigationQuickPickController.js` was not in the exact reviewed entry allowlist
- **GREEN:** the real release packaging command builds both VSIX files and accepts the updated exact allowlist
- the slow run spent 10 minutes 11 seconds downloading nine optional font packages from the Ubuntu mirror; all Chromium shared-library dependencies were already present on `ubuntu-latest`
- CI now installs only the pinned Chromium headless shell, skips redundant `install-deps`, and limits each download attempt to 120 seconds with three attempts
- CI contract mutations reject removing the headless-only flag, timeout, retry count, or reintroducing apt-backed Playwright dependency installation

## Testing

- `COVERAGE_DIFF_BASE=origin/main npm run test:ci:linux`
  - 674 unit tests passed
  - 298 integration tests passed
  - 122 Chromium browser tests passed
  - release VSIX packaging passed
  - changed-line coverage: 100% (99/99)
- `npm run test:behavior-contracts`
- `node --test tests/unit/tooling/ciContracts.test.js`
- `npx playwright install --dry-run --only-shell chromium`
- `git diff --check`

## Skill harvest

This CI follow-up records `none`: the existing repository workflow already requires the branch-level `test:ci:linux` equivalent before push, so the missed packaging failure was a compliance gap rather than a missing instruction. Earlier in this PR, `.skills/fixing-regressions-with-ci` was updated to require a final rendered or interaction-surface owner for every user-visible UI/Webview regression; that update passed `quick_validate.py` and its repository ownership test.
