### PR TITLE
fix: keep the conversation viewer open on Escape

### DIFF
--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "699ad0032eeb22c9ebf065356e68ef889eb05f45",
+        "head": "c6f192dcf6fdb2c66415430a93854c5ee1f8357c",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -124,7 +124,8 @@
             "26780e9b673c21035ec297fb86cedde520a7e786",
             "3e1742cfab4bff723886c6133be4a612b6897b33",
             "b3107928e042ca50ec3883381e32cbde869945f4",
-            "ff8a679b2491c8408b218954c30c028b7388c32b"
+            "ff8a679b2491c8408b218954c30c028b7388c32b",
+            "792f977c8e31dbcf11959a856d542e63bd62afb2"
         ]
     },
     "capabilities": [
@@ -1192,7 +1193,8 @@
                 "66771a061609afa5cf02ee62b4920e49d3d1ae28",
                 "e768127b71b2517b658ba116b31527612a29fa61",
                 "1b41bfd14aafb639f6686f2fb921ccd5575d3b46",
-                "70a4e9d3236772426b5855a516cf572c92fdf905"
+                "70a4e9d3236772426b5855a516cf572c92fdf905",
+                "c6f192dcf6fdb2c66415430a93854c5ee1f8357c"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",

--- a/media/conversationViewerScripts.js
+++ b/media/conversationViewerScripts.js
@@ -793,9 +793,7 @@
         if (commentsController.handleEnterShortcut(event)) return;
         if (event.key !== 'Escape') return;
         if (commentsController.handleEscape(event)) return;
-        if (sidebarController.handleEscape(event)) return;
-        event.preventDefault();
-        postNavigation('conversation-viewer-closed');
+        sidebarController.handleEscape(event);
     });
     window.addEventListener('message', function (event) {
         if (outlineController.applyBookmarksResult(event.data)) return;

--- a/src/aiSessions/conversation/viewer.ts
+++ b/src/aiSessions/conversation/viewer.ts
@@ -427,10 +427,6 @@ export class ConversationViewer implements ConversationViewerApi {
         if (!parsed || !this.target || !this.panel) {
             return;
         }
-        if (parsed.type === 'conversation-viewer-closed') {
-            this.panel.dispose();
-            return;
-        }
         if (parsed.type === 'conversation-viewer-open-link') {
             await this.openLink(parsed.href);
             return;

--- a/src/aiSessions/conversation/viewerProtocol.ts
+++ b/src/aiSessions/conversation/viewerProtocol.ts
@@ -7,8 +7,7 @@ import { isSubagentId } from './subagentSessions';
 export interface ConversationViewerNavigationMessage {
     type: 'conversation-viewer-previous'
         | 'conversation-viewer-next'
-        | 'conversation-viewer-latest'
-        | 'conversation-viewer-closed';
+        | 'conversation-viewer-latest';
     version: 1;
 }
 
@@ -110,7 +109,6 @@ const NAVIGATION_MESSAGE_TYPES = new Set([
     'conversation-viewer-previous',
     'conversation-viewer-next',
     'conversation-viewer-latest',
-    'conversation-viewer-closed',
 ]);
 
 export function parseConversationViewerMessage(

--- a/src/webview/conversationViewerScripts.js
+++ b/src/webview/conversationViewerScripts.js
@@ -793,9 +793,7 @@
         if (commentsController.handleEnterShortcut(event)) return;
         if (event.key !== 'Escape') return;
         if (commentsController.handleEscape(event)) return;
-        if (sidebarController.handleEscape(event)) return;
-        event.preventDefault();
-        postNavigation('conversation-viewer-closed');
+        sidebarController.handleEscape(event);
     });
     window.addEventListener('message', function (event) {
         if (outlineController.applyBookmarksResult(event.data)) return;

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -3124,7 +3124,7 @@ test('CONVERSATION-VIEWER-USER-EMPHASIS-001 makes User a full-width Prompt block
     }
 });
 
-test('WEBVIEW-AI-SESSION-CONVERSATION-VIEWER-001 sanitizes hostile HTML and posts exact version-1 navigation', async t => {
+test('WEBVIEW-AI-SESSION-CONVERSATION-VIEWER-001 sanitizes hostile HTML, posts exact version-1 navigation, and keeps the viewer open on Escape', async t => {
     const page = await openViewerPage(t);
     await sendPage(page, hostileConversationPage);
 
@@ -3173,11 +3173,13 @@ test('WEBVIEW-AI-SESSION-CONVERSATION-VIEWER-001 sanitizes hostile HTML and post
         href: 'https://example.test/safe',
     });
 
+    const postedBeforeEscape = (await postedMessages(page)).length;
     await page.keyboard.press('Escape');
-    assert.deepEqual((await postedMessages(page)).at(-1), {
-        type: 'conversation-viewer-closed',
-        version: 1,
-    });
+    assert.equal(
+        (await postedMessages(page)).length,
+        postedBeforeEscape,
+        'Escape must not close the conversation viewer'
+    );
 });
 
 test('WEBVIEW-AI-SESSION-CONVERSATION-VIEWER-001 preserves ordered numbering across loose multi-paragraph list items', async t => {


### PR DESCRIPTION
## Summary

- Fix: pressing Escape inside the AI Conversation viewer no longer exits the conversation. Previously, any Escape not consumed by the comments or sidebar controllers posted `conversation-viewer-closed` and disposed the panel, so one stray keypress closed the whole viewer.
- Retire the now-unused `conversation-viewer-closed` navigation message from the webview→host protocol (`viewerProtocol.ts`) and the host dispatch (`viewer.ts`).
- Escape keeps its in-viewer behavior: it still cancels comment editing and collapses the sidebar. The viewer now closes only through explicit panel affordances (editor tab close).

## Behavior ownership

- `WEBVIEW-AI-SESSION-CONVERSATION-VIEWER-001` (`tests/browser/conversationViewer.test.js`) asserts the final interaction surface: after Escape, no message is posted (`Escape must not close the conversation viewer`). RED observed before the fix (`5 !== 4` — the stray `conversation-viewer-closed` message); GREEN after.
- Existing Escape owners remain green: sidebar collapse on Escape and comment-edit cancel/pending swallow are unchanged.

## Verification

- `npm run test-compile`
- Focused browser test RED → GREEN (`node --test --test-name-pattern 'keeps the viewer open on Escape' tests/browser/conversationViewer.test.js`)
- `npm run test:deterministic:run` (unit + contract + integration)
- `npm run test:browser:run`
- `npm run test:ci:linux`
- `git diff --check`

## Skill harvest

no skill change — the fix followed the existing fixing-regressions-with-ci and protecting-main-with-worktrees flows without friction, corrections, or retries.
