### PR TITLE
test: close the webview asset and legacy services coverage gaps

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -687,6 +687,19 @@
     ]
   },
   {
+    "id": "WEBVIEW-ASSET-IDENTITY-001",
+    "domain": "webview",
+    "title": "src/webview scripts mirror into media byte-for-byte",
+    "priority": "P1",
+    "status": "automated",
+    "owners": [
+      "tests/integration/dashboard/webviewAssetIdentity.test.js"
+    ],
+    "evidence": [
+      "src/webview/webviewDashboardScripts.js"
+    ]
+  },
+  {
     "id": "RUNTIME-TMUX-SMOKE-HARNESS-SAFETY-001",
     "domain": "runtime",
     "title": "Tmux Smoke Harness Safety behavior",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "49abbcc65dd88358f19fc70ee63f5cdbab9d4115",
+        "head": "8a21bfdda38027a0970fd4b01dfd9bb029928274",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -128,7 +128,8 @@
             "792f977c8e31dbcf11959a856d542e63bd62afb2",
             "1b90455b3055ff675a17a93a016ddc162ab5eba3",
             "a07588151b5209f33971c0f6a5b2c7401ab38546",
-            "22af2cec2ef399860fa92bc10a97fab0df4dc9a9"
+            "22af2cec2ef399860fa92bc10a97fab0df4dc9a9",
+            "8b0df252fdea186bf8d8f4291f91fb3aef9ca81d"
         ]
     },
     "capabilities": [
@@ -366,7 +367,8 @@
                 "e40efc402ddce538a3ac154290bac23a89a90ff7",
                 "64ebb955bcae54ad580b2310be10937c75337b0d",
                 "6ac51dfaaa47830413615bc260b6c39840c8dd96",
-                "edf561e5d8404b0620e9b744c6d5b0bbb48ba936"
+                "edf561e5d8404b0620e9b744c6d5b0bbb48ba936",
+                "6b1d7d6b074fef459a085181c4cc5f16b955831b"
             ],
             "behaviors": [
                 "WEBVIEW-CURRENT-WORKSPACE-RENDERING-001",
@@ -983,7 +985,8 @@
                 "9dd6c07a94418fb1e71997ab3e49cefad2ffe8e9",
                 "14c1213f64d62dad5cf200d642c83cdadd608b5f",
                 "d474d872dc937c72c39d92cde988b46c5844dbbb",
-                "699ad0032eeb22c9ebf065356e68ef889eb05f45"
+                "699ad0032eeb22c9ebf065356e68ef889eb05f45",
+                "8a21bfdda38027a0970fd4b01dfd9bb029928274"
             ],
             "behaviors": [
                 "ARCH-CI-QUALITY-GATE-001",

--- a/scripts/check-changed-coverage.js
+++ b/scripts/check-changed-coverage.js
@@ -36,6 +36,10 @@ const UNINSTRUMENTED_BY_DESIGN = [
     // compiles to an empty, statement-less file, so there is nothing to
     // instrument.
     'src/aiSessions/conversation/viewerTarget.ts',
+    // Vendored third-party library (Name that Color, Creative Commons). It is
+    // only reachable through colorService, whose own unit tests exercise the
+    // ntc call sites; vendored code carries no per-change coverage obligation.
+    'src/services/ntc.ts',
 ];
 
 function isUninstrumentedByDesign(file) {

--- a/tests/integration/dashboard/webviewAssetIdentity.test.js
+++ b/tests/integration/dashboard/webviewAssetIdentity.test.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const root = path.join(__dirname, '..', '..', '..');
+const SRC_WEBVIEW_DIR = path.join(root, 'src', 'webview');
+const MEDIA_DIR = path.join(root, 'media');
+
+// The webview behavior scripts are maintained in src/webview and mirrored
+// byte-for-byte into media/ (the runtime asset root). Historically each pair
+// had its own hand-written assertion, so newly added scripts could drift
+// silently. This loop keeps the guarantee automatic for every present and
+// future script.
+test('WEBVIEW-ASSET-IDENTITY-001 mirrors every src/webview script into media byte-for-byte', () => {
+    const scriptNames = fs.readdirSync(SRC_WEBVIEW_DIR)
+        .filter(name => name.endsWith('.js'))
+        .sort();
+    assert.ok(scriptNames.length > 0, 'expected webview scripts under src/webview');
+
+    const missing = [];
+    const drifted = [];
+    for (const name of scriptNames) {
+        const mediaPath = path.join(MEDIA_DIR, name);
+        if (!fs.existsSync(mediaPath)) {
+            missing.push(name);
+            continue;
+        }
+        const sourceBytes = fs.readFileSync(path.join(SRC_WEBVIEW_DIR, name));
+        if (!sourceBytes.equals(fs.readFileSync(mediaPath))) {
+            drifted.push(name);
+        }
+    }
+    assert.deepStrictEqual(missing, [], 'webview scripts missing from media/');
+    assert.deepStrictEqual(drifted, [], 'webview scripts drifted from their media/ copies');
+});

--- a/tests/unit/services/colorService.test.js
+++ b/tests/unit/services/colorService.test.js
@@ -1,0 +1,147 @@
+'use strict';
+
+// Covers the legacy ColorService surface so the changed-coverage gate can
+// instrument src/services/colorService.ts (previously absent from the report).
+
+const assert = require('node:assert/strict');
+const Module = require('node:module');
+const test = require('node:test');
+
+const { createFakeVscode } = require('../../helpers/fakeVscode');
+
+function createHarness(options = {}) {
+    const storeProjectsInSettings = options.storeProjectsInSettings ?? false;
+    const storedColors = options.storedColors || [];
+    const recentColorsToRemember = options.recentColorsToRemember ?? 10;
+    const updates = [];
+    const globalStateStore = new Map(Object.entries(options.globalState || {}));
+
+    const configuration = {
+        get: (key, defaultValue) => {
+            if (key === 'storeProjectsInSettings') { return storeProjectsInSettings; }
+            if (key === 'recentColorsToRemember') { return recentColorsToRemember; }
+            if (key === 'recentColors') { return storedColors; }
+            return defaultValue;
+        },
+        update: (key, value, target) => {
+            updates.push({ key, value, target });
+            return Promise.resolve();
+        },
+    };
+    const fakeVscode = createFakeVscode({
+        ConfigurationTarget: { Global: 1, Workspace: 2 },
+        workspace: {
+            workspaceFolders: undefined,
+            getConfiguration: () => configuration,
+        },
+    });
+    const context = {
+        globalState: {
+            get: key => globalStateStore.get(key),
+            update: (key, value) => {
+                if (value === undefined) {
+                    globalStateStore.delete(key);
+                } else {
+                    globalStateStore.set(key, value);
+                }
+                return Promise.resolve();
+            },
+        },
+    };
+
+    const previousLoad = Module._load;
+    let ColorService;
+    try {
+        // Each harness brings its own vscode fake, so the modules that capture
+        // the `vscode` binding at load time must be re-required per harness.
+        for (const modulePath of ['../../../out/services/colorService', '../../../out/services/baseService']) {
+            delete require.cache[require.resolve(modulePath)];
+        }
+        Module._load = function (request, parent, isMain) {
+            if (request === 'vscode') { return fakeVscode; }
+            return previousLoad.call(this, request, parent, isMain);
+        };
+        ColorService = require('../../../out/services/colorService').default;
+    } finally {
+        Module._load = previousLoad;
+    }
+    return {
+        service: new ColorService(context),
+        updates,
+        globalStateStore,
+    };
+}
+
+test('ColorService names predefined, hex, rgb, and unknown colors', () => {
+    const { service } = createHarness();
+
+    assert.strictEqual(
+        service.getColorName('var(--vscode-gitDecoration-deletedResourceForeground)'),
+        'Red',
+        'predefined colors keep their label',
+    );
+    assert.strictEqual(service.getColorName('#000000'), 'Black', 'hex colors resolve through ntc');
+    assert.strictEqual(service.getColorName('ffffff'), null,
+        'bare hex is rejected before ntc: colorStringToHex requires a # prefix');
+    assert.strictEqual(service.getColorName('rgb(255, 255, 255)'), null,
+        'ntc only parses hex inputs, so rgb strings stay unnamed');
+    assert.strictEqual(service.getColorName('not-a-color'), null);
+    assert.strictEqual(service.getColorName(''), null);
+});
+
+test('ColorService generates random colors from the palette or ntc', () => {
+    const { service } = createHarness();
+
+    const predefined = service.getRandomColor(true);
+    assert.ok(predefined.startsWith('var(--vscode-') || /^#[0-9a-f]{6}$/i.test(predefined),
+        'predefined-only random picks a predefined value');
+
+    for (let i = 0; i < 8; i += 1) {
+        assert.match(service.getRandomColor(), /^#[0-9a-f]{6}$/i, 'ntc random picks a hex color');
+    }
+});
+
+test('ColorService stores recent colors in global state by default', async () => {
+    const harness = createHarness();
+    const { service, globalStateStore, updates } = harness;
+
+    await service.addRecentColor('#000000');
+    await service.addRecentColor('#ffffff');
+    await service.addRecentColor('#000000');
+
+    const stored = globalStateStore.get('recentColors');
+    assert.deepStrictEqual(stored.map(entry => entry[0]), ['#000000', '#ffffff'],
+        'latest first, duplicate names deduped');
+    assert.deepStrictEqual(stored.map(entry => entry[1]), ['Black', 'White']);
+    assert.strictEqual(updates.length, 0, 'settings storage stays untouched');
+
+    await service.addRecentColor('');
+    assert.strictEqual(globalStateStore.get('recentColors').length, 2, 'empty colors are ignored');
+});
+
+test('ColorService caps recent colors at the configured count', async () => {
+    const { service, globalStateStore } = createHarness({ recentColorsToRemember: 2 });
+
+    await service.addRecentColor('#000000');
+    await service.addRecentColor('#ffffff');
+    await service.addRecentColor('#ff0000');
+
+    const stored = globalStateStore.get('recentColors');
+    assert.strictEqual(stored.length, 2);
+    assert.deepStrictEqual(stored.map(entry => entry[0]), ['#ff0000', '#ffffff']);
+});
+
+test('ColorService uses the settings storage when configured', async () => {
+    const { service, updates, globalStateStore } = createHarness({
+        storeProjectsInSettings: true,
+        storedColors: [['#000000', 'Black']],
+    });
+
+    assert.deepStrictEqual(service.getRecentColors(), [['#000000', 'Black']],
+        'recent colors read from settings');
+
+    await service.saveColors([['#ffffff', 'White']]);
+    assert.deepStrictEqual(updates, [{ key: 'recentColors', value: [['#ffffff', 'White']], target: 1 }],
+        'settings storage writes target the Global scope');
+    assert.strictEqual(globalStateStore.size, 0, 'global state stays untouched');
+});

--- a/tests/unit/services/fileService.test.js
+++ b/tests/unit/services/fileService.test.js
@@ -1,0 +1,114 @@
+'use strict';
+
+// Covers the legacy FileService surface so the changed-coverage gate can
+// instrument src/services/fileService.ts (previously absent from the report).
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const Module = require('node:module');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const { createFakeVscode } = require('../../helpers/fakeVscode');
+
+function loadWithFakeVscode(modulePath) {
+    const fakeVscode = createFakeVscode({
+        workspace: { workspaceFolders: undefined },
+    });
+    const previousLoad = Module._load;
+    try {
+        Module._load = function (request, parent, isMain) {
+            if (request === 'vscode') { return fakeVscode; }
+            return previousLoad.call(this, request, parent, isMain);
+        };
+        return require(modulePath);
+    } finally {
+        Module._load = previousLoad;
+    }
+}
+
+const FileService = loadWithFakeVscode('../../../out/services/fileService').default;
+const { ProjectPathType } = loadWithFakeVscode('../../../out/models');
+
+function createService() {
+    return new FileService({ globalState: undefined, workspaceState: undefined });
+}
+
+function makeTempDir() {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'file-service-'));
+}
+
+test('FileService writes text files, creating a missing parent directory', async () => {
+    const root = makeTempDir();
+    try {
+        const target = path.join(root, 'nested', 'note.txt');
+        await createService().writeTextFile(target, 'hello');
+        assert.strictEqual(fs.readFileSync(target, 'utf8'), 'hello');
+
+        await assert.rejects(
+            createService().writeTextFile(path.join(root, 'a', 'b', 'note.txt'), 'x'),
+            /ENOENT/,
+            'legacy behavior: mkdir is not recursive, so deeper chains reject',
+        );
+    } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+    }
+});
+
+test('FileService removes files and reports path types', async () => {
+    const root = makeTempDir();
+    try {
+        const service = createService();
+        const folder = path.join(root, 'project');
+        const file = path.join(root, 'notes.md');
+        const workspaceFile = path.join(root, 'TEAM.code-workspace');
+        fs.mkdirSync(folder);
+        fs.writeFileSync(file, 'x');
+        fs.writeFileSync(workspaceFile, '{}');
+
+        assert.strictEqual(await service.getProjectPathType(folder), ProjectPathType.Folder);
+        assert.strictEqual(await service.getProjectPathType(file), ProjectPathType.File);
+        assert.strictEqual(await service.getProjectPathType(workspaceFile), ProjectPathType.WorkspaceFile,
+            'workspace detection is case-insensitive');
+
+        await service.removeFile(file);
+        assert.strictEqual(fs.existsSync(file), false);
+    } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+    }
+});
+
+test('FileService resolves workspace folders relative to the workspace file', async () => {
+    const root = makeTempDir();
+    try {
+        const workspaceFile = path.join(root, 'team.code-workspace');
+        fs.writeFileSync(workspaceFile, JSON.stringify({
+            folders: [{ path: 'app' }, { path: 'libs/shared' }],
+        }));
+        assert.deepStrictEqual(
+            await createService().getFoldersFromWorkspaceFile(workspaceFile),
+            [path.join(root, 'app'), path.join(root, 'libs', 'shared')],
+        );
+    } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+    }
+});
+
+test('FileService lists only directories and detects files by extension', async () => {
+    const root = makeTempDir();
+    try {
+        fs.mkdirSync(path.join(root, 'alpha'));
+        fs.mkdirSync(path.join(root, 'beta'));
+        fs.writeFileSync(path.join(root, 'readme.md'), 'x');
+
+        const folders = await createService().getFolders(root);
+        assert.deepStrictEqual(folders.sort(), [path.join(root, 'alpha'), path.join(root, 'beta')].sort());
+
+        const service = createService();
+        assert.strictEqual(service.isFile('readme.md'), true);
+        assert.strictEqual(service.isFile('alpha'), false);
+    } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+    }
+});

--- a/tests/unit/services/projectWindowColorService.test.js
+++ b/tests/unit/services/projectWindowColorService.test.js
@@ -1,0 +1,169 @@
+'use strict';
+
+// Covers the legacy ProjectWindowColorService surface so the changed-coverage
+// gate can instrument src/services/projectWindowColorService.ts (previously
+// absent from the report).
+
+const assert = require('node:assert/strict');
+const Module = require('node:module');
+const test = require('node:test');
+
+const { createFakeVscode } = require('../../helpers/fakeVscode');
+
+function createHarness(options = {}) {
+    const applyToWindow = options.applyToWindow ?? true;
+    const workbenchColors = { ...(options.workbenchColors || {}) };
+    const workspaceStateStore = new Map(Object.entries(options.workspaceState || {}));
+    const updates = [];
+
+    const configurationBySection = section => ({
+        get: (key, defaultValue) => {
+            if (section === 'workbench' && key === 'colorCustomizations') {
+                return { ...workbenchColors };
+            }
+            if (key === 'applyProjectColorToWindow') {
+                return applyToWindow;
+            }
+            return defaultValue;
+        },
+        update: (key, value, target) => {
+            updates.push({ section, key, value, target });
+            return Promise.resolve();
+        },
+    });
+    const fakeVscode = createFakeVscode({
+        ConfigurationTarget: { Global: 1, Workspace: 2 },
+        workspace: {
+            workspaceFolders: undefined,
+            getConfiguration: section => configurationBySection(section),
+        },
+    });
+    const context = {
+        workspaceState: {
+            get: key => workspaceStateStore.get(key),
+            update: (key, value) => {
+                if (value === undefined) {
+                    workspaceStateStore.delete(key);
+                } else {
+                    workspaceStateStore.set(key, value);
+                }
+                return Promise.resolve();
+            },
+        },
+    };
+
+    const previousLoad = Module._load;
+    let ProjectWindowColorService;
+    try {
+        // Each harness brings its own vscode fake, so the modules that capture
+        // the `vscode` binding at load time must be re-required per harness.
+        for (const modulePath of [
+            '../../../out/services/projectWindowColorService',
+            '../../../out/services/baseService',
+        ]) {
+            delete require.cache[require.resolve(modulePath)];
+        }
+        Module._load = function (request, parent, isMain) {
+            if (request === 'vscode') { return fakeVscode; }
+            return previousLoad.call(this, request, parent, isMain);
+        };
+        ProjectWindowColorService = require('../../../out/services/projectWindowColorService').default;
+    } finally {
+        Module._load = previousLoad;
+    }
+    return {
+        service: new ProjectWindowColorService(context),
+        updates,
+        workspaceStateStore,
+    };
+}
+
+test('ProjectWindowColorService normalizes hex, rgb, and variable colors', () => {
+    const { service } = createHarness();
+
+    assert.strictEqual(service.resolveWindowColor('#ABCDEF'), '#abcdef');
+    assert.strictEqual(service.resolveWindowColor('#abc'), '#aabbcc');
+    assert.strictEqual(service.resolveWindowColor('rgb(255, 0, 128)'), '#ff0080');
+    assert.strictEqual(service.resolveWindowColor('rgb(300, 5, 16)'), '#ff0510',
+        'rgb channels clamp into 0-255');
+    assert.strictEqual(service.resolveWindowColor('rgba(255, 0, 128, 0.5)'), '#ff0080',
+        'rgba ignores the alpha channel');
+    assert.strictEqual(
+        service.resolveWindowColor('var(--vscode-gitDecoration-untrackedResourceForeground)'),
+        '#73c991',
+        'inbuilt variables resolve to their defaults',
+    );
+    assert.strictEqual(service.resolveWindowColor('var(--unknown-variable)'), null);
+    assert.strictEqual(service.resolveWindowColor('red'), null);
+    assert.strictEqual(service.resolveWindowColor(''), null);
+});
+
+test('ProjectWindowColorService builds the aura palette customization set', () => {
+    const { service } = createHarness();
+
+    const customizations = service.getWindowColorCustomizations('#ff0080');
+    const expectedKeys = [
+        'activityBar.activeBackground', 'activityBar.activeBorder', 'activityBar.foreground',
+        'activityBarBadge.background', 'activityBarBadge.foreground', 'commandCenter.activeBorder',
+        'statusBar.background', 'statusBar.foreground', 'statusBar.noFolderBackground',
+        'statusBar.debuggingBackground', 'statusBarItem.remoteBackground', 'statusBarItem.remoteForeground',
+        'titleBar.activeBackground', 'titleBar.activeForeground', 'titleBar.inactiveBackground',
+        'titleBar.inactiveForeground',
+    ];
+    assert.deepStrictEqual(Object.keys(customizations).sort(), expectedKeys.sort());
+    assert.strictEqual(customizations['activityBar.activeBorder'], '#ff0080', 'the accent passes through');
+    for (const [key, value] of Object.entries(customizations)) {
+        assert.match(value, /^#[0-9a-f]{6}(?:[0-9a-f]{2})?$/, `${key} is a hex color`);
+    }
+});
+
+test('ProjectWindowColorService syncs the window colors and keeps a backup', async () => {
+    const { service, updates, workspaceStateStore } = createHarness({
+        workbenchColors: { 'statusBar.background': '#123456', 'my.custom': 'keep' },
+    });
+
+    await service.syncProjectColorToCurrentWindow({ color: '#ff0080' });
+
+    assert.strictEqual(updates.length, 1, 'one workspace configuration write');
+    const write = updates[0];
+    assert.strictEqual(write.section, 'workbench');
+    assert.strictEqual(write.key, 'colorCustomizations');
+    assert.strictEqual(write.target, 2, 'workspace target');
+    assert.strictEqual(write.value['my.custom'], 'keep', 'unrelated customizations survive');
+    assert.strictEqual(write.value['statusBar.background'].startsWith('#'), true);
+    assert.notStrictEqual(write.value['statusBar.background'], '#123456', 'generated color replaced');
+
+    const backup = workspaceStateStore.get('projectWindowColorBackup');
+    assert.strictEqual(backup.values['statusBar.background'], '#123456', 'original value backed up');
+    assert.strictEqual(backup.values['titleBar.activeBackground'], null, 'unset values backed up as null');
+});
+
+test('ProjectWindowColorService restores backed-up colors when disabled', async () => {
+    const { service, updates, workspaceStateStore } = createHarness({
+        applyToWindow: false,
+        workbenchColors: { 'statusBar.background': '#999999', 'my.custom': 'keep' },
+        workspaceState: {
+            projectWindowColorBackup: { values: { 'statusBar.background': '#123456' } },
+        },
+    });
+
+    await service.syncProjectColorToCurrentWindow({ color: '#ff0080' });
+
+    assert.strictEqual(updates.length, 1, 'restore writes once');
+    assert.deepStrictEqual(updates[0].value, {
+        'statusBar.background': '#123456',
+        'my.custom': 'keep',
+    }, 'backed-up values restored');
+    assert.strictEqual(workspaceStateStore.has('projectWindowColorBackup'), false, 'backup consumed');
+});
+
+test('ProjectWindowColorService skips the write when nothing would change', async () => {
+    const { service, updates } = createHarness({
+        applyToWindow: false,
+        workbenchColors: { 'my.custom': 'keep' },
+    });
+
+    await service.restoreProjectWindowColors({ color: undefined });
+
+    assert.strictEqual(updates.length, 0, 'no generated colors and no backup means no write');
+});

--- a/tests/unit/tooling/changedCoverage.test.js
+++ b/tests/unit/tooling/changedCoverage.test.js
@@ -86,6 +86,8 @@ test('COVERAGE-CHANGED-CODE-001 exempts only the paths the suite structurally ca
     assert.equal(isUninstrumentedByDesign('src/dashboard.ts'), true);
     assert.equal(isUninstrumentedByDesign('scripts/run-ai-session-safety-checks.js'), true);
     assert.equal(isUninstrumentedByDesign('src/webview/conversationViewerScripts.js'), true);
+    assert.equal(isUninstrumentedByDesign('src/services/ntc.ts'), true);
+    assert.equal(isUninstrumentedByDesign('src/services/colorService.ts'), false);
     assert.equal(isUninstrumentedByDesign('src/webview/webviewContent.ts'), false);
     assert.equal(isUninstrumentedByDesign('src/aiSessions/dashboardController.ts'), false);
     assert.equal(isUninstrumentedByDesign('scripts/lib/behaviorCatalog.js'), false);


### PR DESCRIPTION
## Summary

Two test-safety nets from the main-branch review, both pure increments:

1. **Webview asset identity loop** (`tests/integration/dashboard/webviewAssetIdentity.test.js`): every `src/webview/*.js` must mirror byte-for-byte into `media/`. The 33 pairs were guarded by scattered per-file assertions (~11 covered); one loop now covers all present and future scripts, failing on missing or drifted counterparts. Registered as `WEBVIEW-ASSET-IDENTITY-001`.

2. **Legacy services instrumentation** (`fileService`, `colorService`, `projectWindowColorService`): these never reached `coverage-final.json` (only `dashboard.ts` loads them, in a coverage-disabled child process), so the first edit to any of them would hard-fail the changed-coverage gate as *uninstrumented* — an unannounced CI landmine. New unit tests run them through the fakeVscode harness:
   - fileService: path types, folder listing, workspace-file resolution, single-level mkdir quirk (documented)
   - colorService: predefined/hex naming, rgb-stays-unnamed quirk (documented), recent-color dedup/cap, globalState vs settings storage modes
   - projectWindowColorService: color normalization (hex/short-hex/rgb clamps/var defaults), aura palette payload shape, backup/restore flows, no-op write skipping
   - `ntc.ts` (vendored Name-that-Color, CC-BY) is explicitly exempted from the changed-coverage gate with a gate-test assertion; its call sites are exercised through colorService.

   Statement coverage after loading: fileService 100%, colorService 95%, projectWindowColorService 95%.

## Gate results

- Full local gate suite green; changed-line coverage 100% (4/4).
- New contract `WEBVIEW-ASSET-IDENTITY-001` registered; catalog checks pass.
- Per-harness require-cache resets were needed because compiled services capture the `vscode` binding at load time (same pattern as the existing sourceControl test).

## Skill harvest

No skill change justified: the require-cache reset pattern already exists in tests/helpers usage; the JSON text-precise edit lesson from the previous round was applied proactively here.

Skill-Harvest: none