### PR TITLE
perf: back off the quiet focused tmux monitor and pin idle-tick contracts

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -601,7 +601,8 @@
     "priority": "P1",
     "status": "automated",
     "owners": [
-      "tests/contract/aiSessions/tmuxDiscovery.test.js"
+      "tests/contract/aiSessions/tmuxDiscovery.test.js",
+      "tests/contract/aiSessions/runtimeTickOverhead.test.js"
     ],
     "evidence": [
       "scripts/run-ai-session-safety-checks.js"
@@ -1047,7 +1048,8 @@
     "priority": "P1",
     "status": "automated",
     "owners": [
-      "tests/contract/aiSessions/incrementalJsonlLifecycleReader.test.js"
+      "tests/contract/aiSessions/incrementalJsonlLifecycleReader.test.js",
+      "tests/contract/aiSessions/runtimeTickOverhead.test.js"
     ],
     "evidence": [
       "scripts/run-ai-session-safety-checks.js"

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "8a21bfdda38027a0970fd4b01dfd9bb029928274",
+        "head": "4475d2c1b5a1f16ee1950ddeaeb783e188ede071",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -129,7 +129,8 @@
             "1b90455b3055ff675a17a93a016ddc162ab5eba3",
             "a07588151b5209f33971c0f6a5b2c7401ab38546",
             "22af2cec2ef399860fa92bc10a97fab0df4dc9a9",
-            "8b0df252fdea186bf8d8f4291f91fb3aef9ca81d"
+            "8b0df252fdea186bf8d8f4291f91fb3aef9ca81d",
+            "afc02d771d7cacd7d590a44e384d24ab6108be14"
         ]
     },
     "capabilities": [
@@ -435,7 +436,8 @@
                 "47fd52eda4c1c3b1469d5b3cd9b3eb45d098f516",
                 "e2e32b9e3706fc3100667f1236ee56fd90ca27d6",
                 "08f7837ea30b562e6e3a1a705dfac474b6f88a2d",
-                "0aa444ce65cfcd15d442289db8e69d668f0afa95"
+                "0aa444ce65cfcd15d442289db8e69d668f0afa95",
+                "2340f5e7588b35972ac7a611a7fbdadb500bf645"
             ],
             "behaviors": [
                 "RUNTIME-RUNTIME-COORDINATOR-001",
@@ -986,7 +988,8 @@
                 "14c1213f64d62dad5cf200d642c83cdadd608b5f",
                 "d474d872dc937c72c39d92cde988b46c5844dbbb",
                 "699ad0032eeb22c9ebf065356e68ef889eb05f45",
-                "8a21bfdda38027a0970fd4b01dfd9bb029928274"
+                "8a21bfdda38027a0970fd4b01dfd9bb029928274",
+                "4475d2c1b5a1f16ee1950ddeaeb783e188ede071"
             ],
             "behaviors": [
                 "ARCH-CI-QUALITY-GATE-001",

--- a/src/aiSessions/tmuxFocusedRuntimeMonitor.ts
+++ b/src/aiSessions/tmuxFocusedRuntimeMonitor.ts
@@ -3,6 +3,7 @@
 import type { TmuxFocusedRuntimeSyncResult } from './tmuxRuntimeBackend';
 
 export const TMUX_FOCUSED_RUNTIME_CHECK_INTERVAL_MS = 1000;
+const MAX_FOCUSED_RUNTIME_CHECK_DELAY_MS = 4000;
 
 export interface TmuxFocusedRuntimeMonitorOptions<TTerminal> {
     isVisible(): boolean;
@@ -12,11 +13,15 @@ export interface TmuxFocusedRuntimeMonitorOptions<TTerminal> {
     onError(error: unknown): void;
     setInterval(callback: () => void, intervalMs: number): unknown;
     clearInterval(handle: unknown): void;
+    /** Test hook for the backoff cadence; defaults to Date.now. */
+    nowMs?(): number;
 }
 
 export class TmuxFocusedRuntimeMonitor<TTerminal> {
     private interval: unknown = null;
     private inFlight: Promise<void> | null = null;
+    private currentDelayMs = TMUX_FOCUSED_RUNTIME_CHECK_INTERVAL_MS;
+    private nextTimerSyncAtMs = 0;
     private disposed = false;
 
     constructor(private readonly options: TmuxFocusedRuntimeMonitorOptions<TTerminal>) { }
@@ -26,12 +31,37 @@ export class TmuxFocusedRuntimeMonitor<TTerminal> {
             return;
         }
         this.interval = this.options.setInterval(
-            () => { void this.request(); },
+            () => this.requestFromTimer(),
             TMUX_FOCUSED_RUNTIME_CHECK_INTERVAL_MS
         );
     }
 
+    // The timer keeps its 1s beat (and its pinned contract), but quiet periods
+    // skip beats: unchanged results double the gap up to 4s, any change snaps
+    // back to 1s. Each timer-driven sync still spawns a private tmux query, so
+    // this is where the steady-state subprocess churn is saved.
+    private requestFromTimer(): void {
+        if (this.disposed) {
+            return;
+        }
+        if (this.now() < this.nextTimerSyncAtMs) {
+            return;
+        }
+        void this.runRequest(true);
+    }
+
+    private now(): number {
+        return this.options.nowMs ? this.options.nowMs() : Date.now();
+    }
+
+    /** Explicit requests (focus/visibility events) run immediately at the fast cadence. */
     request(): Promise<void> {
+        this.currentDelayMs = TMUX_FOCUSED_RUNTIME_CHECK_INTERVAL_MS;
+        this.nextTimerSyncAtMs = 0;
+        return this.runRequest(false);
+    }
+
+    private runRequest(fromTimer: boolean): Promise<void> {
         if (this.disposed || !this.options.isVisible()) {
             return Promise.resolve();
         }
@@ -52,6 +82,12 @@ export class TmuxFocusedRuntimeMonitor<TTerminal> {
             if (!this.disposed && result.changed && this.options.isVisible()
                 && this.options.getActiveTerminal() === terminal) {
                 this.options.refresh();
+            }
+            if (fromTimer && !this.disposed) {
+                this.currentDelayMs = result.changed
+                    ? TMUX_FOCUSED_RUNTIME_CHECK_INTERVAL_MS
+                    : Math.min(this.currentDelayMs * 2, MAX_FOCUSED_RUNTIME_CHECK_DELAY_MS);
+                this.nextTimerSyncAtMs = this.now() + this.currentDelayMs;
             }
         }, error => {
             try {

--- a/tests/contract/aiSessions/runtimeTickOverhead.test.js
+++ b/tests/contract/aiSessions/runtimeTickOverhead.test.js
@@ -1,0 +1,243 @@
+'use strict';
+
+// Covers PERSIST-INCREMENTAL-JSONL-LIFECYCLE-READER-001 and
+// RUNTIME-TMUX-FOCUSED-RUNTIME-MONITOR-001: the resident runtime timers are
+// demand-driven — an idle tick performs no filesystem work at all — and the
+// focused tmux monitor backs off while nothing changes.
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { createAiSessionStatusCapability } = require('../../../out/aiSessions/statusCapability');
+const { createAiSessionRuntimeSettlementCapability } = require('../../../out/aiSessions/runtimeSettlementCapability');
+const { TmuxFocusedRuntimeMonitor } = require('../../../out/aiSessions/tmuxFocusedRuntimeMonitor');
+
+const FS_METHODS = [
+    'statSync', 'lstatSync', 'existsSync', 'readdirSync',
+    'readFileSync', 'openSync', 'readSync', 'realpathSync',
+];
+
+function countFsCalls(fn) {
+    const fs = require('node:fs');
+    const originals = new Map();
+    const counts = new Map();
+    for (const method of FS_METHODS) {
+        originals.set(method, fs[method]);
+        counts.set(method, 0);
+        fs[method] = (...args) => {
+            counts.set(method, counts.get(method) + 1);
+            return originals.get(method).apply(fs, args);
+        };
+    }
+    try {
+        fn();
+    } finally {
+        for (const method of FS_METHODS) {
+            fs[method] = originals.get(method);
+        }
+    }
+    return [...counts.values()].reduce((total, count) => total + count, 0);
+}
+
+test('PERSIST-INCREMENTAL-JSONL-LIFECYCLE-READER-001 idle status tick performs no filesystem work', async () => {
+    const providerReads = [];
+    let executionEvaluations = 0;
+    let attentionSignalEvaluations = 0;
+    let runtimeReconciliations = 0;
+    const timers = [];
+    const capability = createAiSessionStatusCapability({
+        getProviders: () => [{
+            id: 'codex',
+            service: {
+                getLifecycleSignals: () => {
+                    providerReads.push('read');
+                    return {};
+                },
+            },
+        }],
+        getLifecycleRequests: () => [],
+        evaluateExecution: () => { executionEvaluations += 1; },
+        evaluateAttentionSignals: () => {
+            attentionSignalEvaluations += 1;
+            return Promise.resolve({});
+        },
+        evaluateAttentionRuntimes: () => {
+            runtimeReconciliations += 1;
+            return Promise.resolve({});
+        },
+        onFailure: () => undefined,
+        setInterval: (callback, intervalMs) => {
+            const handle = { callback, intervalMs };
+            timers.push(handle);
+            return handle;
+        },
+        clearInterval: () => undefined,
+    });
+
+    assert.deepStrictEqual(timers.map(timer => timer.intervalMs), [1000, 10000],
+        'the cadence contract is unchanged');
+
+    const tickFsCalls = countFsCalls(() => capability.tick());
+    assert.strictEqual(tickFsCalls, 0, 'an idle lifecycle tick touches no files');
+    assert.deepStrictEqual(providerReads, [], 'providers are not even queried without requests');
+    assert.strictEqual(executionEvaluations, 1, 'execution evaluation still runs on the empty signal set');
+
+    const reconcileFsCalls = countFsCalls(() => timers[1].callback());
+    assert.strictEqual(reconcileFsCalls, 0, 'the idle runtime reconciliation touches no files');
+    // The attention evaluation queue evaluates asynchronously.
+    await new Promise(resolve => setImmediate(resolve));
+    assert.strictEqual(runtimeReconciliations, 1);
+
+    capability.dispose();
+});
+
+test('PERSIST-INCREMENTAL-JSONL-LIFECYCLE-READER-001 idle settlement scan performs no filesystem work', () => {
+    let attentionEvaluations = 0;
+    let refreshes = 0;
+    let highlighterSyncs = 0;
+    const timers = [];
+    const capability = createAiSessionRuntimeSettlementCapability({
+        runtimeBelongsToCurrentWorkspace: () => true,
+        evaluateAttention: () => {
+            attentionEvaluations += 1;
+            return Promise.resolve({});
+        },
+        tmuxRuntimeDiscovery: { getInactive: () => [] },
+        aiSessionTerminalService: { getCompletedSessions: () => [] },
+        refreshAiSessionViewsIncrementally: () => { refreshes += 1; },
+        syncActiveTerminalHighlighter: () => { highlighterSyncs += 1; },
+        logDiagnostic: () => undefined,
+        setInterval: (callback, intervalMs) => {
+            const handle = { callback, intervalMs };
+            timers.push(handle);
+            return handle;
+        },
+        clearInterval: () => undefined,
+    });
+
+    capability.startSettlementScan();
+    capability.startSettlementScan();
+    assert.strictEqual(timers.length, 1, 'the scan start is idempotent');
+    assert.strictEqual(timers[0].intervalMs, 1000, 'the scan cadence is unchanged');
+
+    const fsCalls = countFsCalls(() => timers[0].callback());
+    assert.strictEqual(fsCalls, 0, 'an idle settlement scan touches no files');
+    assert.strictEqual(attentionEvaluations, 0, 'an empty queue never drains');
+    assert.strictEqual(refreshes, 0);
+    assert.strictEqual(highlighterSyncs, 0);
+
+    capability.dispose();
+});
+
+function createMonitorHarness(options = {}) {
+    const state = {
+        now: options.startNow ?? 0,
+        visible: options.visible ?? true,
+        terminal: { name: 'Project tmux attach' },
+        syncCalls: 0,
+        refreshes: 0,
+        errors: [],
+        result: { monitored: true, changed: false, identity: null },
+        timer: null,
+    };
+    const monitor = new TmuxFocusedRuntimeMonitor({
+        isVisible: () => state.visible,
+        getActiveTerminal: () => state.terminal,
+        syncFocusedRuntime: () => {
+            state.syncCalls += 1;
+            return Promise.resolve(state.result);
+        },
+        refresh: () => { state.refreshes += 1; },
+        onError: error => state.errors.push(error),
+        setInterval: (callback, intervalMs) => {
+            state.timer = { callback, intervalMs };
+            return state.timer;
+        },
+        clearInterval: () => undefined,
+        nowMs: () => state.now,
+    });
+    const beat = async () => {
+        state.now += 1000;
+        state.timer.callback();
+        // Flush the resolved-promise chain (result handler + in-flight clear).
+        await new Promise(resolve => setImmediate(resolve));
+        await new Promise(resolve => setImmediate(resolve));
+    };
+    return { monitor, state, beat };
+}
+
+test('RUNTIME-TMUX-FOCUSED-RUNTIME-MONITOR-001 quiet focused runtimes back off to a 4s cadence', async () => {
+    const { monitor, state, beat } = createMonitorHarness();
+    monitor.start();
+    assert.strictEqual(state.timer.intervalMs, 1000, 'the timer keeps its 1s beat');
+
+    await beat(); // t=1000: first sync
+    assert.strictEqual(state.syncCalls, 1);
+    await beat(); // t=2000: backed off (1s -> 2s window)
+    assert.strictEqual(state.syncCalls, 1, 'unchanged result skips the next beat');
+    await beat(); // t=3000
+    assert.strictEqual(state.syncCalls, 2);
+    await beat(); // t=4000..6000: backed off (2s -> 4s window)
+    await beat();
+    await beat();
+    assert.strictEqual(state.syncCalls, 2);
+    await beat(); // t=7000
+    assert.strictEqual(state.syncCalls, 3, 'the gap caps at 4s');
+    await beat(); // t=8000
+    assert.strictEqual(state.syncCalls, 3, 'the cap holds at 4s');
+    await beat(); // t=9000
+    assert.strictEqual(state.syncCalls, 3);
+    await beat(); // t=10000
+    assert.strictEqual(state.syncCalls, 3);
+    await beat(); // t=11000
+    assert.strictEqual(state.syncCalls, 4);
+
+    monitor.dispose();
+});
+
+test('RUNTIME-TMUX-FOCUSED-RUNTIME-MONITOR-001 changes and explicit requests restore the fast cadence', async () => {
+    const { monitor, state, beat } = createMonitorHarness();
+    monitor.start();
+
+    await beat(); // t=1000: sync, then back off
+    await beat(); // t=2000: skipped
+    assert.strictEqual(state.syncCalls, 1);
+
+    state.result = { monitored: true, changed: true, identity: null };
+    await beat(); // t=3000: sync sees a change
+    assert.strictEqual(state.syncCalls, 2);
+    assert.strictEqual(state.refreshes, 1, 'a change still refreshes immediately');
+    await beat(); // t=4000: fast cadence restored after the change
+    assert.strictEqual(state.syncCalls, 3);
+
+    state.result = { monitored: true, changed: false, identity: null };
+    await beat(); // t=5000: sync, back off again (1s -> 2s)
+    assert.strictEqual(state.syncCalls, 4);
+    state.now += 500;
+    await monitor.request(); // explicit request bypasses the backoff window
+    assert.strictEqual(state.syncCalls, 5, 'explicit requests run immediately');
+    await beat(); // t=6500: backoff was reset by the explicit request
+    assert.strictEqual(state.syncCalls, 6);
+
+    monitor.dispose();
+});
+
+test('RUNTIME-TMUX-FOCUSED-RUNTIME-MONITOR-001 hidden periods skip timer syncs without advancing the backoff', async () => {
+    const { monitor, state, beat } = createMonitorHarness();
+    monitor.start();
+
+    await beat(); // t=1000: sync, backoff window now 2s
+    assert.strictEqual(state.syncCalls, 1);
+
+    state.visible = false;
+    await beat(); // t=2000
+    await beat(); // t=3000
+    await beat(); // t=4000
+    assert.strictEqual(state.syncCalls, 1, 'hidden beats never spawn a sync');
+
+    state.visible = true;
+    await beat(); // t=5000: the pre-hidden 2s window (due at t=3000) fires on the first visible beat
+    assert.strictEqual(state.syncCalls, 2, 'hidden time does not stretch the backoff further');
+
+    monitor.dispose();
+});


### PR DESCRIPTION
## Summary

A review of the resident 1s timers (status capability, runtime settlement scan, focused tmux monitor) found the idle baseline is already demand-driven and ~free, and that the two heavier paths must NOT be gated on sidebar visibility: the lifecycle tick and settlement scan feed `notifyDispatcher` (dashboard.ts stop/attention notifications), whose core value is precisely while the sidebar is hidden. So instead of blanket gating/throttling:

- **`tmuxFocusedRuntimeMonitor` adaptive backoff** (the one real steady-state cost: a private tmux query every second while the sidebar is visible and a tmux terminal is focused). The 1s timer and its pinned contract stay; quiet timer beats are skipped (1s → 2s → 4s cap), any change snaps back to 1s, explicit `request()` calls (focus/visibility events) still run immediately and reset the cadence, and hidden periods neither sync nor stretch the backoff. External exits are still caught by the settlement/discovery reconcile, the monitor is only the fast lane.
- **Idle-overhead contract tests** (`tests/contract/aiSessions/runtimeTickOverhead.test.js`): with zero tracked sessions/terminals, a lifecycle tick and a settlement scan perform **zero filesystem calls** (providers are not even queried); the monitor's 1s/10s cadence registration, backoff rhythm, change reset, explicit-request bypass, and hidden-skip semantics are all pinned. Registered as owner of `PERSIST-INCREMENTAL-JSONL-LIFECYCLE-READER-001` and `RUNTIME-TMUX-FOCUSED-RUNTIME-MONITOR-001`.

Deliberately NOT done (documented for future reviewers): visibility-gating or slowing the status tick / settlement scan — the notification latency risk outweighs a near-zero idle win.

## Gates

- Full local gate suite green; changed-line coverage 94.59% (35/37).
- Existing pinned behavior untouched: safety-check monitor cases (intervalMs=1000, request immediacy, hidden short-circuit, in-flight coalescing) all pass unchanged.

## Manual checklist

- Focus a tmux session terminal: activity state still reflects changes within ~1s.
- Leave it focused and quiet: sync spacing stretches to <=4s (no visible change).
- Stop/attention notifications arrive with unchanged latency, sidebar open or hidden.

## Skill harvest

No skill change justified: the evidence-first re-scoping followed the existing regression-fixing and review workflows; the async-queue flush pattern in tests matches existing harness conventions.

Skill-Harvest: none