### PR TITLE
docs(skill): require explicit approval before every PR merge

### DIFF
--- a/.skills/publishing-and-merging-github-prs/SKILL.md
+++ b/.skills/publishing-and-merging-github-prs/SKILL.md
@@ -59,22 +59,23 @@ If push reports HTTP 408, `unexpected EOF`, or an RPC disconnect:
    - `gh pr view <n> --repo <owner/repo> --json state,isDraft,mergeable,mergeStateStatus,statusCheckRollup,baseRefName,headRefName`
    - Inspect failing Actions with `gh pr checks <n> --repo <owner/repo>` and
      `gh run view <run-id> --repo <owner/repo> --log-failed`.
-2. Honor approval gates exactly. If the user said "merge after I approve", stop until that approval is present in the conversation.
-3. If draft and user approved/asked to merge, run `gh pr ready <n>`.
-4. Merge with the repository's expected strategy, or default to merge commit:
+2. Treat every merge as gated by default: a green CI is never merge authorization. After all checks pass, stop, report the state, and wait for an explicit in-conversation approval ("merge", "合并", or equivalent) for this specific PR. This applies to every PR type — refactors, test-only changes, and behavior changes alike. Only a standing instruction from the user in the current conversation can relax this default, and any earlier "merge after CI" habit from pure-refactor rounds does not carry over.
+3. Honor approval gates exactly. If the user said "merge after I approve", stop until that approval is present in the conversation.
+4. If draft and user approved/asked to merge, run `gh pr ready <n>`.
+5. Merge with the repository's expected strategy, or default to merge commit:
    - `gh pr merge <n> --merge --delete-branch`
-5. GitHub GraphQL can return `unexpected EOF` after a successful mutation. Always re-check:
+6. GitHub GraphQL can return `unexpected EOF` after a successful mutation. Always re-check:
    - `gh pr view <n> --json state,mergedAt,mergeCommit,isDraft`
    - `git fetch origin <base> --prune`
    - `git log --oneline -1 origin/<base>`
-6. If `--delete-branch` did not run because of a transient API failure, delete the remote feature branch explicitly after confirming the PR is merged:
+7. If `--delete-branch` did not run because of a transient API failure, delete the remote feature branch explicitly after confirming the PR is merged:
    - `git push origin --delete <branch>`
    - `git ls-remote --heads origin <branch>`
 
 ## Guardrails
 
 - Never merge a PR whose target repository or base branch is ambiguous.
-- Never merge before an explicit requested approval gate has been satisfied.
+- Never merge a PR without an explicit in-conversation approval for that PR; green checks are not approval.
 - Never treat an API transport error as failure or success without checking PR state.
 - Never delete the local worktree or branch until the merge commit is confirmed.
 - Do not force push or force update refs unless the user explicitly asks.

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "4475d2c1b5a1f16ee1950ddeaeb783e188ede071",
+        "head": "24df1dbeadcd4b8f8ba28f7b35ee40469bee0a86",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -130,7 +130,8 @@
             "a07588151b5209f33971c0f6a5b2c7401ab38546",
             "22af2cec2ef399860fa92bc10a97fab0df4dc9a9",
             "8b0df252fdea186bf8d8f4291f91fb3aef9ca81d",
-            "afc02d771d7cacd7d590a44e384d24ab6108be14"
+            "afc02d771d7cacd7d590a44e384d24ab6108be14",
+            "62af4782282fe782affbc4eab6531e3fa6676777"
         ]
     },
     "capabilities": [
@@ -989,7 +990,8 @@
                 "d474d872dc937c72c39d92cde988b46c5844dbbb",
                 "699ad0032eeb22c9ebf065356e68ef889eb05f45",
                 "8a21bfdda38027a0970fd4b01dfd9bb029928274",
-                "4475d2c1b5a1f16ee1950ddeaeb783e188ede071"
+                "4475d2c1b5a1f16ee1950ddeaeb783e188ede071",
+                "24df1dbeadcd4b8f8ba28f7b35ee40469bee0a86"
             ],
             "behaviors": [
                 "ARCH-CI-QUALITY-GATE-001",

--- a/tests/unit/tooling/repositorySkills.test.js
+++ b/tests/unit/tooling/repositorySkills.test.js
@@ -132,3 +132,17 @@ test('ARCH-REPOSITORY-SKILL-GUIDANCE-001 verifies provider adapters against real
         ['status inference guidance', /no status[\s\S]*transcript tail/i],
     ]);
 });
+
+
+test('ARCH-REPOSITORY-SKILL-GUIDANCE-001 gates every PR merge on explicit approval', () => {
+    const skill = readSkill('.skills/publishing-and-merging-github-prs/SKILL.md');
+
+    assertSkillMentions(skill, [
+        ['merge gated by default', /every merge as gated by default/i],
+        ['green CI is not merge authorization', /green CI is never merge authorization/i],
+        ['stop and wait for explicit approval', /stop, report the state, and wait for an explicit in-conversation approval/i],
+        ['every PR type covered', /refactors, test-only changes, and behavior changes alike/i],
+        ['pure-refactor merge habits do not carry over', /does not carry over/i],
+        ['guardrail: checks are not approval', /Never merge a PR without an explicit in-conversation approval[\s\S]*green checks are not approval/i],
+    ]);
+});


### PR DESCRIPTION
## Summary

Merging right after green CI was a habit formed during the zero-behavior-change refactor rounds; carried into perf/fix PRs it means behavior changes land before any human review. This change writes the correction into the publishing skill and pins it with a harness test.

- `.skills/publishing-and-merging-github-prs/SKILL.md`: every merge is gated by default — a green CI is never merge authorization; after checks pass, stop, report, and wait for an explicit in-conversation approval for that specific PR; applies to refactors, test-only changes, and behavior changes alike; the guardrail is restated ("green checks are not approval").
- `tests/unit/tooling/repositorySkills.test.js`: new `ARCH-REPOSITORY-SKILL-GUIDANCE-001` case pins the rule phrases so the gate cannot silently regress.

## Gates

- Full local gate suite green; changed-line coverage 100% (0/0 eligible).
- repositorySkills tooling tests: 9/9 pass.

## Skill harvest

This PR **is** the harvest: the user correction (" merges need my approval ") was reviewed under harvesting-workflow-lessons and landed as an iteration of `.skills/publishing-and-merging-github-prs` plus its owner test.

Skill-Harvest: updated .skills/publishing-and-merging-github-prs