### PR TITLE
feat: gate merges on a mechanical owner-approval status check

### DIFF
--- a/.github/workflows/merge-approval-gate.yml
+++ b/.github/workflows/merge-approval-gate.yml
@@ -1,0 +1,26 @@
+name: Merge approval gate
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+  statuses: write
+
+jobs:
+  gate:
+    name: gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Evaluate and post the merge-approval status
+        run: node scripts/run-merge-approval-gate.js
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -88,3 +88,21 @@ jobs:
         run: sudo apt-get install -y tmux
       - name: Run isolated real-tmux smoke gate
         run: npm run test:tmux:smoke
+
+  merge-approval-audit:
+    name: merge-approval-audit
+    # Post-merge backstop: only meaningful on the default branch.
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Audit recent merges for owner approval markers
+        run: node scripts/run-merge-approval-audit.js
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.skills/publishing-and-merging-github-prs/SKILL.md
+++ b/.skills/publishing-and-merging-github-prs/SKILL.md
@@ -60,15 +60,16 @@ If push reports HTTP 408, `unexpected EOF`, or an RPC disconnect:
    - Inspect failing Actions with `gh pr checks <n> --repo <owner/repo>` and
      `gh run view <run-id> --repo <owner/repo> --log-failed`.
 2. Treat every merge as gated by default: a green CI is never merge authorization. After all checks pass, stop, report the state, and wait for an explicit in-conversation approval ("merge", "合并", or equivalent) for this specific PR. This applies to every PR type — refactors, test-only changes, and behavior changes alike. Only a standing instruction from the user in the current conversation can relax this default, and any earlier "merge after CI" habit from pure-refactor rounds does not carry over.
-3. Honor approval gates exactly. If the user said "merge after I approve", stop until that approval is present in the conversation.
-4. If draft and user approved/asked to merge, run `gh pr ready <n>`.
-5. Merge with the repository's expected strategy, or default to merge commit:
+3. The merge-approval status check enforces the gate mechanically. Before merging, confirm the `merge-approval` status on the PR head is green; it turns green only after the repository owner posts an approval comment ("合并"/"merge"/"lgtm"/"approved") newer than the latest commit. If it is missing or stale, ask the user to comment on the PR page and wait. Never use `--admin` or any bypass, and never post, edit, or imitate the approval comment yourself — the main-branch audit (`scripts/run-merge-approval-audit.js`) fails red when a merged PR lacks the owner marker.
+4. Honor approval gates exactly. If the user said "merge after I approve", stop until that approval is present in the conversation.
+5. If draft and user approved/asked to merge, run `gh pr ready <n>`.
+6. Merge with the repository's expected strategy, or default to merge commit:
    - `gh pr merge <n> --merge --delete-branch`
-6. GitHub GraphQL can return `unexpected EOF` after a successful mutation. Always re-check:
+7. GitHub GraphQL can return `unexpected EOF` after a successful mutation. Always re-check:
    - `gh pr view <n> --json state,mergedAt,mergeCommit,isDraft`
    - `git fetch origin <base> --prune`
    - `git log --oneline -1 origin/<base>`
-7. If `--delete-branch` did not run because of a transient API failure, delete the remote feature branch explicitly after confirming the PR is merged:
+8. If `--delete-branch` did not run because of a transient API failure, delete the remote feature branch explicitly after confirming the PR is merged:
    - `git push origin --delete <branch>`
    - `git ls-remote --heads origin <branch>`
 

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -3483,6 +3483,22 @@
     ]
   },
   {
+    "id": "ARCH-PR-MERGE-APPROVAL-GATE-001",
+    "domain": "architecture",
+    "title": "Merges mechanically require an owner approval comment and are audited afterwards",
+    "priority": "P1",
+    "status": "automated",
+    "owners": [
+      "tests/unit/tooling/mergeApprovals.test.js",
+      "tests/unit/tooling/mergeApprovalGate.test.js"
+    ],
+    "evidence": [
+      "scripts/lib/mergeApprovals.js",
+      ".github/workflows/merge-approval-gate.yml",
+      ".github/workflows/verify.yml"
+    ]
+  },
+  {
     "id": "ARCH-MAIN-CAPABILITY-CURRENCY-001",
     "domain": "architecture",
     "title": "Implementation commits cannot remain beyond the recorded capability audit head",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "24df1dbeadcd4b8f8ba28f7b35ee40469bee0a86",
+        "head": "ee64dfaeb58eb3578a780d787af5cd77403b51c2",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -131,7 +131,8 @@
             "22af2cec2ef399860fa92bc10a97fab0df4dc9a9",
             "8b0df252fdea186bf8d8f4291f91fb3aef9ca81d",
             "afc02d771d7cacd7d590a44e384d24ab6108be14",
-            "62af4782282fe782affbc4eab6531e3fa6676777"
+            "62af4782282fe782affbc4eab6531e3fa6676777",
+            "4d1bbc3a1e04d7c17a173fec51f36aaa311d7a71"
         ]
     },
     "capabilities": [
@@ -565,7 +566,9 @@
                 "587b4178a4ec63a2734ed2b916494638583e3390",
                 "e9145123b3ad1cdcbc625e52291ae053e8acbce5",
                 "77b6b35c72b8505d4817e8a59a0bdfbb8af44149",
-                "e4174cab66e88f3a65cf95863dce7b899c8c508b"
+                "e4174cab66e88f3a65cf95863dce7b899c8c508b",
+                "04b08eea061cc8f848bbadbe98e374603e99a3f0",
+                "ee64dfaeb58eb3578a780d787af5cd77403b51c2"
             ],
             "behaviors": [
                 "ARCH-CI-QUALITY-GATE-001",

--- a/scripts/lib/mergeApprovals.js
+++ b/scripts/lib/mergeApprovals.js
@@ -1,0 +1,85 @@
+'use strict';
+
+// Merge approval gate logic. The gate is a mechanical merge-time block: a PR
+// may only merge once the repository owner has left an approval comment newer
+// than the latest head commit. The audit is the post-merge backstop that the
+// marker exists at all.
+
+// First-word approval markers. "mergeable" or a mid-sentence "merge" must not
+// qualify; CJK markers need no word boundary.
+const MERGE_APPROVAL_PATTERN = /^\s*(?:合并|批准|lgtm|approve[ds]?|merge)(?![A-Za-z])/i;
+
+// Merges before this date predate the gate and are exempt from the audit
+// (they were approved in conversation under the previous rules).
+const MERGE_APPROVAL_REQUIRED_SINCE = '2026-08-05T00:00:00Z';
+
+function isApprovalComment(body) {
+    return MERGE_APPROVAL_PATTERN.test(String(body || ''));
+}
+
+/**
+ * Latest qualifying approval comment, or null. Only comments authored by
+ * authorLogin (case-insensitive) and created at or after sinceMs qualify.
+ */
+function findApprovalComment(comments, options) {
+    const authorLogin = String(options.authorLogin || '').toLowerCase();
+    const sinceMs = options.sinceMs ?? 0;
+    let latest = null;
+    for (const comment of comments || []) {
+        if (!comment || String(comment?.user?.login || '').toLowerCase() !== authorLogin) {
+            continue;
+        }
+        if (!isApprovalComment(comment.body)) {
+            continue;
+        }
+        const createdAtMs = Date.parse(comment.created_at || '');
+        if (!Number.isFinite(createdAtMs) || createdAtMs < sinceMs) {
+            continue;
+        }
+        if (!latest || createdAtMs > Date.parse(latest.created_at)) {
+            latest = comment;
+        }
+    }
+    return latest;
+}
+
+/**
+ * Gate verdict for a PR head: an owner approval comment must be newer than
+ * the head commit, so pushing new commits invalidates earlier approvals.
+ */
+function evaluateMergeApproval(options) {
+    const comment = findApprovalComment(options.comments, {
+        authorLogin: options.authorLogin,
+        sinceMs: options.headCommittedAtMs,
+    });
+    if (comment) {
+        return { approved: true, reason: 'approved by owner comment', commentUrl: comment.html_url || '' };
+    }
+    const anyApproval = findApprovalComment(options.comments, { authorLogin: options.authorLogin });
+    if (anyApproval) {
+        return {
+            approved: false,
+            reason: 'the approval predates the latest commit; re-approve the current head',
+            commentUrl: '',
+        };
+    }
+    return { approved: false, reason: 'no owner approval comment', commentUrl: '' };
+}
+
+/** Audit predicate: merges at or after the activation date must be approved. */
+function mergeRequiresApproval(mergedAt) {
+    const mergedAtMs = Date.parse(mergedAt || '');
+    if (!Number.isFinite(mergedAtMs)) {
+        return true;
+    }
+    return mergedAtMs >= Date.parse(MERGE_APPROVAL_REQUIRED_SINCE);
+}
+
+module.exports = {
+    MERGE_APPROVAL_PATTERN,
+    MERGE_APPROVAL_REQUIRED_SINCE,
+    isApprovalComment,
+    findApprovalComment,
+    evaluateMergeApproval,
+    mergeRequiresApproval,
+};

--- a/scripts/run-merge-approval-audit.js
+++ b/scripts/run-merge-approval-audit.js
@@ -1,0 +1,71 @@
+'use strict';
+
+// Post-merge audit (L3): every PR merged into main since the gate activated
+// must carry an owner approval comment. The gate (L2) enforces the timing at
+// merge time; this audit is the backstop that the marker exists at all, so
+// protection changes or bypasses surface as a red main branch.
+
+const { isApprovalComment, mergeRequiresApproval } = require('./lib/mergeApprovals');
+
+const RECENT_MERGES_TO_AUDIT = 5;
+
+async function api(token, resource) {
+    const response = await fetch(`https://api.github.com${resource}`, {
+        headers: {
+            Accept: 'application/vnd.github+json',
+            Authorization: `Bearer ${token}`,
+            'X-GitHub-Api-Version': '2022-11-28',
+        },
+    });
+    if (!response.ok) {
+        throw new Error(`GET ${resource} failed: ${response.status} ${await response.text()}`);
+    }
+    return response.json();
+}
+
+async function main() {
+    const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+    const repo = process.env.GITHUB_REPOSITORY;
+    if (!token || !repo) {
+        throw new Error('GITHUB_TOKEN and GITHUB_REPOSITORY are required');
+    }
+    const ownerLogin = repo.split('/')[0].toLowerCase();
+
+    const closed = await api(
+        token,
+        `/repos/${repo}/pulls?state=closed&sort=updated&direction=desc&per_page=30`,
+    );
+    const merged = closed
+        .filter(pr => pr.merged_at && pr.base?.ref === 'main' && mergeRequiresApproval(pr.merged_at))
+        .slice(0, RECENT_MERGES_TO_AUDIT);
+    if (!merged.length) {
+        console.log('No gated merges to audit yet.');
+        return;
+    }
+
+    const violations = [];
+    for (const pr of merged) {
+        const comments = await api(token, `/repos/${repo}/issues/${pr.number}/comments?per_page=100`);
+        const approved = comments.some(comment =>
+            String(comment?.user?.login || '').toLowerCase() === ownerLogin
+            && isApprovalComment(comment.body));
+        if (!approved) {
+            violations.push(`#${pr.number} (${pr.title}) merged at ${pr.merged_at} without an owner approval comment`);
+        } else {
+            console.log(`#${pr.number}: approval marker present`);
+        }
+    }
+    if (violations.length) {
+        for (const violation of violations) {
+            console.error(`MISSING APPROVAL: ${violation}`);
+        }
+        process.exitCode = 1;
+        return;
+    }
+    console.log(`Merge approval audit passed for ${merged.length} merged PR(s).`);
+}
+
+main().catch(error => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+});

--- a/scripts/run-merge-approval-gate.js
+++ b/scripts/run-merge-approval-gate.js
@@ -1,0 +1,111 @@
+'use strict';
+
+// Posts the `merge-approval` commit status on a PR head after evaluating the
+// owner approval comment. Runs from the merge-approval-gate workflow on
+// pull_request and issue_comment events. Fail-closed: unexpected errors post
+// a failure status and exit non-zero, so a broken gate blocks merges loudly
+// instead of silently opening them.
+
+const fs = require('node:fs');
+const { evaluateMergeApproval } = require('./lib/mergeApprovals');
+
+const STATUS_CONTEXT = 'merge-approval';
+
+function readEventPayload() {
+    const eventPath = process.env.GITHUB_EVENT_PATH;
+    if (!eventPath) {
+        throw new Error('GITHUB_EVENT_PATH is not set');
+    }
+    return JSON.parse(fs.readFileSync(eventPath, 'utf8'));
+}
+
+function resolvePullRequestNumber(payload) {
+    if (payload.pull_request?.number) {
+        return payload.pull_request.number;
+    }
+    // issue_comment events fire for plain issues too; only PRs carry this key.
+    if (payload.issue?.pull_request && payload.issue.number) {
+        return payload.issue.number;
+    }
+    return null;
+}
+
+async function api(token, method, resource, body) {
+    const response = await fetch(`https://api.github.com${resource}`, {
+        method,
+        headers: {
+            Accept: 'application/vnd.github+json',
+            Authorization: `Bearer ${token}`,
+            'X-GitHub-Api-Version': '2022-11-28',
+        },
+        body: body ? JSON.stringify(body) : undefined,
+    });
+    if (!response.ok) {
+        throw new Error(`${method} ${resource} failed: ${response.status} ${await response.text()}`);
+    }
+    return response.json();
+}
+
+async function listAllComments(token, repo, prNumber) {
+    const comments = [];
+    for (let page = 1; page <= 10; page += 1) {
+        const batch = await api(
+            token,
+            'GET',
+            `/repos/${repo}/issues/${prNumber}/comments?per_page=100&page=${page}`,
+        );
+        comments.push(...batch);
+        if (batch.length < 100) {
+            break;
+        }
+    }
+    return comments;
+}
+
+async function main() {
+    const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+    const repo = process.env.GITHUB_REPOSITORY;
+    if (!token || !repo) {
+        throw new Error('GITHUB_TOKEN and GITHUB_REPOSITORY are required');
+    }
+    const payload = readEventPayload();
+    const prNumber = resolvePullRequestNumber(payload);
+    if (!prNumber) {
+        console.log('Not a pull request event; nothing to evaluate.');
+        return;
+    }
+    const ownerLogin = repo.split('/')[0];
+
+    const pullRequest = await api(token, 'GET', `/repos/${repo}/pulls/${prNumber}`);
+    const headSha = pullRequest.head?.sha;
+    if (!headSha) {
+        throw new Error(`PR #${prNumber} has no head sha`);
+    }
+    const headCommit = await api(token, 'GET', `/repos/${repo}/commits/${headSha}`);
+    const headCommittedAtMs = Date.parse(headCommit.commit?.committer?.date || '');
+
+    const comments = await listAllComments(token, repo, prNumber);
+    const verdict = evaluateMergeApproval({
+        comments,
+        authorLogin: ownerLogin,
+        headCommittedAtMs,
+    });
+
+    const status = {
+        context: STATUS_CONTEXT,
+        state: verdict.approved ? 'success' : 'failure',
+        description: verdict.reason.slice(0, 140),
+        target_url: verdict.commentUrl || payload.comment?.html_url || undefined,
+    };
+    await api(token, 'POST', `/repos/${repo}/statuses/${headSha}`, status);
+    console.log(`${STATUS_CONTEXT}: ${status.state} — ${status.description}`);
+    // The verdict lives in the commit status, not this job's exit code: the
+    // required check stays red until approval, while the workflow run itself
+    // stays green (it computed and posted successfully). If we crash before
+    // posting, the missing status still blocks the merge (fail-closed).
+}
+
+main().catch(error => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+});

--- a/tests/unit/tooling/mergeApprovalGate.test.js
+++ b/tests/unit/tooling/mergeApprovalGate.test.js
@@ -1,0 +1,57 @@
+'use strict';
+
+// Meta-harness for the merge approval gate itself: the workflow wiring that
+// makes merges mechanically block on owner approval must not silently regress.
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const yaml = require('js-yaml');
+
+const repositoryRoot = path.resolve(__dirname, '../../..');
+
+function loadWorkflow(name) {
+    return yaml.load(
+        fs.readFileSync(path.join(repositoryRoot, '.github', 'workflows', name), 'utf8'),
+        { schema: yaml.JSON_SCHEMA },
+    );
+}
+
+test('ARCH-PR-MERGE-APPROVAL-GATE-001 wires the gate workflow to PRs and comments', () => {
+    const workflow = loadWorkflow('merge-approval-gate.yml');
+    const triggers = workflow.on;
+    assert.ok(triggers.pull_request, 'gate must evaluate on pull_request events');
+    assert.ok(triggers.pull_request.types.includes('synchronize'),
+        'new pushes must re-evaluate (stale approvals)');
+    assert.ok(triggers.issue_comment, 'gate must re-evaluate when approval comments arrive');
+
+    assert.strictEqual(workflow.permissions.statuses, 'write', 'the job posts a commit status');
+    const gate = workflow.jobs.gate;
+    assert.ok(gate, 'gate job exists');
+    const runSteps = gate.steps.map(step => step.run || '').join('\n');
+    assert.match(runSteps, /run-merge-approval-gate\.js/, 'the job runs the gate script');
+
+    const script = fs.readFileSync(path.join(repositoryRoot, 'scripts', 'run-merge-approval-gate.js'), 'utf8');
+    assert.match(script, /STATUS_CONTEXT = 'merge-approval'/,
+        'the posted status context is the required-check name');
+});
+
+test('ARCH-PR-MERGE-APPROVAL-GATE-001 audits recent merges on main pushes', () => {
+    const verify = loadWorkflow('verify.yml');
+    const audit = verify.jobs['merge-approval-audit'];
+    assert.ok(audit, 'verify.yml must carry the merge-approval-audit job');
+    assert.strictEqual(audit.if, "github.event_name == 'push'",
+        'the audit only runs on default-branch pushes, never on PRs');
+    assert.match(
+        audit.steps.map(step => step.run || '').join('\n'),
+        /run-merge-approval-audit\.js/,
+    );
+
+    // The scheduled workflow must stay secret-free (packaging gate), so the
+    // audit lives only on the push path; every merge is a push, so nothing
+    // slips through.
+    const scheduled = loadWorkflow('scheduled-verification.yml');
+    assert.ok(!scheduled.jobs['merge-approval-audit'],
+        'the secret-free scheduled workflow must not carry the token-using audit');
+});

--- a/tests/unit/tooling/mergeApprovals.test.js
+++ b/tests/unit/tooling/mergeApprovals.test.js
@@ -1,0 +1,75 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+    evaluateMergeApproval,
+    findApprovalComment,
+    isApprovalComment,
+    mergeRequiresApproval,
+    MERGE_APPROVAL_REQUIRED_SINCE,
+} = require('../../../scripts/lib/mergeApprovals');
+
+test('ARCH-PR-MERGE-APPROVAL-GATE-001 recognizes first-word approval markers', () => {
+    for (const body of ['合并', '合并吧', ' merge', 'merge it', 'LGTM', 'approved', 'Approve!', 'approved.']) {
+        assert.ok(isApprovalComment(body), `accepts: ${body}`);
+    }
+    for (const body of ['mergeable', 'merged', 'please merge this', 'looks good', '合并x 不行', '', null, undefined]) {
+        assert.ok(!isApprovalComment(body), `rejects: ${body}`);
+    }
+});
+
+test('ARCH-PR-MERGE-APPROVAL-GATE-001 only the owner can approve', () => {
+    const comments = [
+        { user: { login: 'someone-else' }, body: 'merge', created_at: '2026-08-05T10:00:00Z', html_url: 'x' },
+        { user: { login: 'HZCHENG' }, body: '合并', created_at: '2026-08-05T11:00:00Z', html_url: 'y' },
+    ];
+    const found = findApprovalComment(comments, { authorLogin: 'hzcheng' });
+    assert.strictEqual(found.html_url, 'y', 'login comparison is case-insensitive');
+    assert.strictEqual(
+        findApprovalComment(comments, { authorLogin: 'hzcheng', sinceMs: Date.parse('2026-08-05T12:00:00Z') }),
+        null,
+        'approvals older than sinceMs do not qualify',
+    );
+});
+
+test('ARCH-PR-MERGE-APPROVAL-GATE-001 approvals predate the head commit are stale', () => {
+    const headCommittedAtMs = Date.parse('2026-08-05T12:00:00Z');
+    const stale = evaluateMergeApproval({
+        comments: [{ user: { login: 'hzcheng' }, body: 'merge', created_at: '2026-08-05T11:00:00Z' }],
+        authorLogin: 'hzcheng',
+        headCommittedAtMs,
+    });
+    assert.strictEqual(stale.approved, false);
+    assert.match(stale.reason, /predates the latest commit/);
+
+    const fresh = evaluateMergeApproval({
+        comments: [{ user: { login: 'hzcheng' }, body: 'merge', created_at: '2026-08-05T13:00:00Z', html_url: 'u' }],
+        authorLogin: 'hzcheng',
+        headCommittedAtMs,
+    });
+    assert.strictEqual(fresh.approved, true);
+    assert.strictEqual(fresh.commentUrl, 'u');
+
+    const none = evaluateMergeApproval({ comments: [], authorLogin: 'hzcheng', headCommittedAtMs });
+    assert.strictEqual(none.approved, false);
+    assert.match(none.reason, /no owner approval comment/);
+});
+
+test('ARCH-PR-MERGE-APPROVAL-GATE-001 multiple approvals use the latest comment', () => {
+    const comments = [
+        { user: { login: 'hzcheng' }, body: 'merge', created_at: '2026-08-05T13:00:00Z', html_url: 'old' },
+        { user: { login: 'hzcheng' }, body: '合并', created_at: '2026-08-05T14:00:00Z', html_url: 'new' },
+    ];
+    const found = findApprovalComment(comments, { authorLogin: 'hzcheng' });
+    assert.strictEqual(found.html_url, 'new');
+});
+
+test('ARCH-PR-MERGE-APPROVAL-GATE-001 merges before the activation date are exempt', () => {
+    assert.strictEqual(mergeRequiresApproval('2026-08-01T00:00:00Z'), false);
+    assert.strictEqual(mergeRequiresApproval('2026-08-06T00:00:00Z'), true);
+    assert.strictEqual(mergeRequiresApproval(MERGE_APPROVAL_REQUIRED_SINCE), true);
+    assert.strictEqual(mergeRequiresApproval('not-a-date'), true, 'unparseable dates fail closed');
+    assert.strictEqual(mergeRequiresApproval(undefined), true);
+});

--- a/tests/unit/tooling/repositorySkills.test.js
+++ b/tests/unit/tooling/repositorySkills.test.js
@@ -144,5 +144,8 @@ test('ARCH-REPOSITORY-SKILL-GUIDANCE-001 gates every PR merge on explicit approv
         ['every PR type covered', /refactors, test-only changes, and behavior changes alike/i],
         ['pure-refactor merge habits do not carry over', /does not carry over/i],
         ['guardrail: checks are not approval', /Never merge a PR without an explicit in-conversation approval[\s\S]*green checks are not approval/i],
+        ['mechanical merge-approval status', /`merge-approval` status[\s\S]*turns green only after the repository owner posts an approval comment/i],
+        ['never bypass or forge approval', /Never use `--admin`[\s\S]*never post, edit, or imitate the approval comment/i],
+        ['post-merge audit catches violations', /run-merge-approval-audit\.js[\s\S]*fails red/i],
     ]);
 });


### PR DESCRIPTION
> Replaces #127 (auto-closed when its stacked base branch was deleted after #126 merged). Same commits, rebased onto main via merge.

## Summary

The conversation-level merge-approval rule relies on the agent remembering it. This PR adds the mechanical layer (L2) plus a post-merge audit (L3):

- **L2 gate**: new `merge-approval-gate` workflow (triggers: `pull_request` + `issue_comment`) evaluates whether the repository owner posted an approval comment (`合并`/`merge`/`lgtm`/`approved`, first word) **newer than the latest head commit**, and posts a legacy commit status `merge-approval` on the PR head. New pushes invalidate stale approvals automatically. (Self-demonstrated on #127: the status showed red "no owner approval comment" until approval.)
- **L3 audit**: push-only `merge-approval-audit` job in verify.yml re-checks the last five gated merges for the owner marker, so violations surface as a red main branch. Merges before the activation date constant are exempt. The audit stays off the scheduled workflow (must remain secret-free per the packaging gate); every merge is a push, so the push path covers it.
- **Logic** in `scripts/lib/mergeApprovals.js` (unit-tested); the two runners match the `scripts/run-*` instrumentation exemption.

## Rollout (after merge)

```bash
gh api -X PUT repos/hzcheng/agent-pivot/branches/main/protection/required_status_checks \
  -f strict=true -f contexts[]=quality-linux -f contexts[]=platform-windows \
  -f contexts[]=tmux-smoke-linux -f contexts[]=merge-approval
```

Rollback: same call without `merge-approval`, or repo Settings → Branches. With `enforce_admins=true` this is a hard gate for agents and humans alike until the approval comment exists.

## Honest limits (discussed and accepted)

The agent operates with the owner's gh credentials, so any GitHub-side marker is theoretically forgeable; L2+L3 makes habitual/accidental merges impossible and deliberate violations require overt forgery that leaves a permanent timeline trail.

## Tests

- `mergeApprovals.test.js`: marker pattern, owner case-insensitivity, stale approval rejection, latest-wins, activation-date exemption.
- `mergeApprovalGate.test.js` (meta-harness): gate workflow triggers/permissions/status context, push-only audit job, scheduled workflow stays audit-free.
- New contract `ARCH-PR-MERGE-APPROVAL-GATE-001`; skill updated (never `--admin`, never self-post approvals) with pinned phrases.
- Full local gate suite green; changed-line coverage 97.65% (83/85).

## Skill harvest

This PR includes the `publishing-and-merging-github-prs` iteration (mechanical gate workflow + prohibitions) and pins it via repositorySkills tests.

Skill-Harvest: updated .skills/publishing-and-merging-github-prs