### PR TITLE
test: widen the Windows gate, smoke the extension host on PRs, cover skill services

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -89,6 +89,49 @@ jobs:
       - name: Run isolated real-tmux smoke gate
         run: npm run test:tmux:smoke
 
+  extension-host-linux:
+    name: extension-host-linux
+    # Advisory PR gate: real VS Code activation smoke, only when the command
+    # surface or the harness itself changed. Not a required check yet.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Detect extension-host-relevant changes
+        id: changes
+        run: |
+          if git diff --name-only "origin/${{ github.base_ref }}...HEAD" -- \
+              package.json \
+              src/dashboard.ts \
+              extensions \
+              tests/extension-host \
+              scripts/run-extension-host-tests.js \
+              scripts/run-extension-host-worker.js \
+              scripts/lib/extensionHostLauncher.js | grep -q .; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Setup Node
+        if: steps.changes.outputs.relevant == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.12.0
+          cache: npm
+      - name: Install dependencies
+        if: steps.changes.outputs.relevant == 'true'
+        run: npm ci
+      - name: Install Xvfb
+        if: steps.changes.outputs.relevant == 'true'
+        run: sudo apt-get install -y xvfb
+      - name: Run Extension Host smoke
+        if: steps.changes.outputs.relevant == 'true'
+        run: xvfb-run -a npm run test:extension-host
+
   merge-approval-audit:
     name: merge-approval-audit
     # Post-merge backstop: only meaningful on the default branch.

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -4455,7 +4455,8 @@
     "owners": [
       "scripts/run-skill-management-checks.js"
     ,
-      "tests/contract/skills/skillPanelCapability.test.js"
+      "tests/contract/skills/skillPanelCapability.test.js",
+      "tests/contract/skills/skillCentralAndScope.test.js"
     ],
     "evidence": [
       "src/skills/centralService.ts",
@@ -4506,7 +4507,8 @@
       "scripts/run-skill-management-checks.js",
       "tests/browser/skillsFolderTree.test.js"
     ,
-      "tests/contract/skills/skillPanelCapability.test.js"
+      "tests/contract/skills/skillPanelCapability.test.js",
+      "tests/contract/skills/skillCentralAndScope.test.js"
     ],
     "evidence": [
       "src/skills/scopeService.ts",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "ee64dfaeb58eb3578a780d787af5cd77403b51c2",
+        "head": "a9ab1f23959547152581dd031c131a9ff21acc82",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -132,7 +132,8 @@
             "8b0df252fdea186bf8d8f4291f91fb3aef9ca81d",
             "afc02d771d7cacd7d590a44e384d24ab6108be14",
             "62af4782282fe782affbc4eab6531e3fa6676777",
-            "4d1bbc3a1e04d7c17a173fec51f36aaa311d7a71"
+            "4d1bbc3a1e04d7c17a173fec51f36aaa311d7a71",
+            "cc0386c57b9b30ae01b4be64aefa9e8d8b4c0042"
         ]
     },
     "capabilities": [
@@ -568,7 +569,8 @@
                 "77b6b35c72b8505d4817e8a59a0bdfbb8af44149",
                 "e4174cab66e88f3a65cf95863dce7b899c8c508b",
                 "04b08eea061cc8f848bbadbe98e374603e99a3f0",
-                "ee64dfaeb58eb3578a780d787af5cd77403b51c2"
+                "ee64dfaeb58eb3578a780d787af5cd77403b51c2",
+                "e0dbdfc03bc83c2bbebb278dde6efdb350c71c06"
             ],
             "behaviors": [
                 "ARCH-CI-QUALITY-GATE-001",
@@ -994,7 +996,8 @@
                 "699ad0032eeb22c9ebf065356e68ef889eb05f45",
                 "8a21bfdda38027a0970fd4b01dfd9bb029928274",
                 "4475d2c1b5a1f16ee1950ddeaeb783e188ede071",
-                "24df1dbeadcd4b8f8ba28f7b35ee40469bee0a86"
+                "24df1dbeadcd4b8f8ba28f7b35ee40469bee0a86",
+                "a9ab1f23959547152581dd031c131a9ff21acc82"
             ],
             "behaviors": [
                 "ARCH-CI-QUALITY-GATE-001",

--- a/package.json
+++ b/package.json
@@ -541,7 +541,7 @@
         "brand:check": "node scripts/check-brand-identity.js",
         "brand:generate": "node scripts/generate-brand-assets.js",
         "brand:verify": "node scripts/generate-brand-assets.js --check",
-        "test:ci:windows": "npm run test-compile && node --test tests/unit/projects/projectPathUtils.test.js tests/unit/aiSessions/commandBuilders.test.js tests/platform/windows/commandBuilders.test.js tests/platform/windows/projectPaths.test.js tests/platform/windows/conversationSources.test.js",
+        "test:ci:windows": "npm run test-compile && node --test tests/unit/projects/projectPathUtils.test.js tests/unit/projects/orderAndFavorites.test.js tests/unit/projects/workspaceAndOpenMatching.test.js tests/unit/aiSessions/commandBuilders.test.js tests/unit/todos/types.test.js tests/unit/prompts/service.test.js tests/platform/windows/commandBuilders.test.js tests/platform/windows/projectPaths.test.js tests/platform/windows/conversationSources.test.js",
         "spike:attention:compile": "tsc -p spikes/attention-local-bridge/tsconfig.json",
         "spike:attention:test": "npm run spike:attention:compile && npm run attention:bridge:compile && node scripts/run-attention-local-bridge-spike-checks.js",
         "spike:attention:bundle": "webpack --config spikes/attention-local-bridge/webpack.config.js --mode production",

--- a/scripts/lib/ciContracts.js
+++ b/scripts/lib/ciContracts.js
@@ -150,6 +150,20 @@ function validateVerifyWorkflow(verifyWorkflow) {
     validateJob(workflow.jobs, 'platform-windows', 'windows-latest', 'npm run test:ci:windows');
     validateJob(workflow.jobs, 'tmux-smoke-linux', 'ubuntu-latest',
         'npm run test:tmux:smoke', ['sudo apt-get install -y tmux']);
+    validateJob(
+        workflow.jobs,
+        'extension-host-linux',
+        'ubuntu-latest',
+        'xvfb-run -a npm run test:extension-host',
+        ['sudo apt-get install -y xvfb'],
+        true,
+        15
+    );
+    assert.equal(
+        workflow.jobs['extension-host-linux'].if,
+        "github.event_name == 'pull_request'",
+        'extension-host-linux must stay a pull_request-only advisory gate'
+    );
     assert.equal(containsKey(workflow, 'continue-on-error'), false,
         'GitHub verification workflow must not define continue-on-error');
 }

--- a/tests/contract/skills/skillCentralAndScope.test.js
+++ b/tests/contract/skills/skillCentralAndScope.test.js
@@ -1,0 +1,279 @@
+'use strict';
+
+// Covers PERSIST-AI-SKILL-CENTRAL-STORE-001 and PERSIST-AI-SKILL-SCOPE-ACTION-001:
+// the central store and scope services ran mostly outside the deterministic
+// coverage run (only the standalone skill-management script exercised them),
+// so these tests drive the real services against temporary fixtures.
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const centralService = require('../../../out/skills/centralService');
+const discovery = require('../../../out/skills/discovery');
+const fixService = require('../../../out/skills/fixService');
+const globalStore = require('../../../out/skills/globalStoreService');
+const migrateService = require('../../../out/skills/migrateService');
+const scopeService = require('../../../out/skills/scopeService');
+
+const real = dirPath => fs.realpathSync(dirPath);
+
+function makeTempDir(prefix) {
+    return real(fs.mkdtempSync(path.join(os.tmpdir(), prefix)));
+}
+
+function writeSkill(filePath, frontmatter) {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, frontmatter);
+}
+
+/** Home with a centralized global skill (linked into kimi+codex) and a solo claude skill. */
+function makeHomeFixture() {
+    const home = makeTempDir('skills-contract-home-');
+    writeSkill(path.join(home, '.skills/shared/SKILL.md'), '---\nname: shared\ndescription: Shared\n---\n# S\n');
+    fs.mkdirSync(path.join(home, '.kimi/skills'), { recursive: true });
+    fs.mkdirSync(path.join(home, '.codex/skills'), { recursive: true });
+    fs.symlinkSync(path.join(home, '.skills/shared'), path.join(home, '.kimi/skills/shared'), 'dir');
+    fs.symlinkSync(path.join(home, '.skills/shared'), path.join(home, '.codex/skills/shared'), 'dir');
+    writeSkill(path.join(home, '.claude/skills/solo/SKILL.md'), '---\nname: solo\ndescription: Solo\n---\n');
+    return home;
+}
+
+/** Workspace with a centralized project skill linked into the project claude root. */
+function makeWorkspaceFixture() {
+    const ws = makeTempDir('skills-contract-ws-');
+    writeSkill(path.join(ws, '.skills/proj/SKILL.md'), '---\nname: proj\ndescription: Project\n---\n');
+    fs.mkdirSync(path.join(ws, '.claude/skills'), { recursive: true });
+    fs.symlinkSync(path.join(ws, '.skills/proj'), path.join(ws, '.claude/skills/proj'), 'dir');
+    return ws;
+}
+
+test('PERSIST-AI-SKILL-CENTRAL-STORE-001 setCentralLink creates, removes, and refuses real directories', () => {
+    const home = makeTempDir('skills-link-');
+    const centralDir = path.join(home, '.skills', 'tool');
+    writeSkill(path.join(centralDir, 'SKILL.md'), '---\nname: tool\ndescription: T\n---\n');
+    const kimiRoot = path.join(home, '.kimi', 'skills');
+    const linkPath = path.join(kimiRoot, 'tool');
+
+    assert.strictEqual(centralService.setCentralLink(centralDir, kimiRoot, true).ok, true);
+    assert.strictEqual(fs.realpathSync(linkPath), centralDir);
+    assert.strictEqual(centralService.setCentralLink(centralDir, kimiRoot, true).ok, true, 're-link is idempotent');
+    assert.strictEqual(centralService.setCentralLink(centralDir, kimiRoot, false).ok, true, 'removes the link');
+    assert.ok(!fs.existsSync(linkPath));
+
+    fs.mkdirSync(linkPath, { recursive: true });
+    assert.strictEqual(centralService.setCentralLink(centralDir, kimiRoot, true).ok, false,
+        'never replaces a real directory');
+    assert.strictEqual(centralService.setCentralLink(centralDir, kimiRoot, false).ok, false,
+        'never deletes a real directory');
+});
+
+test('PERSIST-AI-SKILL-CENTRAL-STORE-001 centralizeSkill moves the winner into the store and links back', () => {
+    const home = makeHomeFixture();
+    const ws = makeWorkspaceFixture();
+    const scanned = discovery.scanSkills({ homeDir: home, workspaceRoot: ws });
+    const solo = scanned.find(record => record.name === 'solo' && record.source === 'claude');
+    const duplicates = scanned.filter(record =>
+        record.scope === solo.scope && record.name === solo.name && record.dirPath !== solo.dirPath);
+
+    const lock = globalStore.acquireSkillsMutationLocks([path.join(home, '.skills')]);
+    assert.strictEqual(
+        centralService.centralizeSkill(solo, duplicates, home, ws).ok,
+        false,
+        'a held Global store lock blocks centralization',
+    );
+    lock.lock.release();
+
+    const result = centralService.centralizeSkill(solo, duplicates, home, ws);
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(result.dirPath, path.join(home, '.skills', 'solo'));
+    assert.ok(fs.existsSync(path.join(home, '.skills', 'solo', 'SKILL.md')), 'content moved into the store');
+    assert.strictEqual(
+        fs.realpathSync(path.join(home, '.claude', 'skills', 'solo')),
+        path.join(home, '.skills', 'solo'),
+        'original root links back to the store',
+    );
+
+    const rescanned = discovery.scanSkills({ homeDir: home, workspaceRoot: ws });
+    const solos = rescanned.filter(record => record.name === 'solo');
+    assert.strictEqual(solos.length, 1, 'centralized skill merges into one record');
+    assert.strictEqual(solos[0].source, 'central');
+});
+
+test('PERSIST-AI-SKILL-CENTRAL-STORE-001 store folders create and delete only when empty', () => {
+    const home = makeHomeFixture();
+    const storeRoot = path.join(home, '.skills');
+
+    assert.strictEqual(centralService.createSkillFolder(storeRoot, 'team/backend').ok, true, 'nested create');
+    assert.strictEqual(centralService.createSkillFolder(storeRoot, 'team/backend').ok, false, 'no recreate');
+    assert.strictEqual(centralService.createSkillFolder(storeRoot, '../escape').ok, false, 'traversal rejected');
+    assert.strictEqual(centralService.createSkillFolder(storeRoot, '').ok, false, 'empty rejected');
+
+    writeSkill(path.join(storeRoot, 'team/backend/notes/SKILL.md'), '---\nname: notes\n---\n');
+    assert.strictEqual(centralService.removeSkillFolder(storeRoot, 'team/backend').ok, false,
+        'non-empty folders stay');
+    fs.rmSync(path.join(storeRoot, 'team/backend/notes'), { recursive: true });
+    assert.strictEqual(centralService.removeSkillFolder(storeRoot, 'team/backend').ok, true, 'empty deletes');
+    assert.strictEqual(centralService.removeSkillFolder(storeRoot, 'team/backend').ok, false,
+        'unknown folder fails');
+    assert.ok(fs.existsSync(path.join(storeRoot, 'team')), 'parent folders survive');
+});
+
+test('PERSIST-AI-SKILL-CENTRAL-STORE-001 moveSkillToFolder renames and re-points links', () => {
+    const home = makeHomeFixture();
+    const record = discovery.scanSkills({ homeDir: home })
+        .find(candidate => candidate.name === 'shared');
+
+    const result = centralService.moveSkillToFolder(record, 'packed', home);
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(result.dirPath, path.join(home, '.skills', 'packed', 'shared'));
+    assert.strictEqual(
+        fs.realpathSync(path.join(home, '.kimi', 'skills', 'shared')),
+        path.join(home, '.skills', 'packed', 'shared'),
+        'existing links follow the move',
+    );
+
+    const again = discovery.scanSkills({ homeDir: home })
+        .find(candidate => candidate.name === 'shared');
+    assert.strictEqual(centralService.moveSkillToFolder(again, 'packed', home).ok, true,
+        'moving to the current folder is a no-op success');
+
+    const plain = { ...record, central: undefined };
+    assert.strictEqual(centralService.moveSkillToFolder(plain, 'x', home).ok, false,
+        'non-central skills cannot move between folders');
+});
+
+test('PERSIST-AI-SKILL-CENTRAL-STORE-001 setFolderLinks toggles every skill under a folder', () => {
+    const home = makeTempDir('skills-folder-links-');
+    writeSkill(path.join(home, '.skills/pack/one/SKILL.md'), '---\nname: one\n---\n');
+    writeSkill(path.join(home, '.skills/pack/two/SKILL.md'), '---\nname: two\n---\n');
+    const kimiRoot = path.join(home, '.kimi', 'skills');
+
+    const enabled = centralService.setFolderLinks(
+        path.join(home, '.skills'), 'pack', 'user', home, undefined, true, ['kimi']);
+    assert.strictEqual(enabled.ok, true);
+    assert.strictEqual(enabled.changed, 2);
+    assert.strictEqual(fs.realpathSync(path.join(kimiRoot, 'one')), path.join(home, '.skills', 'pack', 'one'));
+
+    const disabled = centralService.setFolderLinks(
+        path.join(home, '.skills'), 'pack', 'user', home, undefined, false, ['kimi']);
+    assert.strictEqual(disabled.changed, 2);
+    assert.ok(!fs.existsSync(path.join(kimiRoot, 'one')));
+
+    const invalid = centralService.setFolderLinks(
+        path.join(home, '.skills'), '../pack', 'user', home, undefined, true, ['kimi']);
+    assert.strictEqual(invalid.ok, false, 'traversal folders rejected');
+});
+
+test('PERSIST-AI-SKILL-SCOPE-ACTION-001 skillDirectoriesEqual compares content, structure, and links', () => {
+    const root = makeTempDir('skills-equal-');
+    const left = path.join(root, 'left');
+    const right = path.join(root, 'right');
+    writeSkill(path.join(left, 'SKILL.md'), '---\nname: a\n---\n');
+    writeSkill(path.join(left, 'refs/x.txt'), 'x');
+    writeSkill(path.join(right, 'SKILL.md'), '---\nname: a\n---\n');
+    writeSkill(path.join(right, 'refs/x.txt'), 'x');
+    assert.strictEqual(scopeService.skillDirectoriesEqual(left, right), true);
+
+    fs.writeFileSync(path.join(right, 'refs/x.txt'), 'changed');
+    assert.strictEqual(scopeService.skillDirectoriesEqual(left, right), false, 'content drift detected');
+    fs.writeFileSync(path.join(right, 'refs/x.txt'), 'x');
+    fs.rmSync(path.join(right, 'refs'), { recursive: true });
+    assert.strictEqual(scopeService.skillDirectoriesEqual(left, right), false, 'structure drift detected');
+});
+
+test('PERSIST-AI-SKILL-SCOPE-ACTION-001 apply-global-to-project links only the selected agents', () => {
+    const home = makeHomeFixture();
+    const ws = makeTempDir('skills-apply-ws-');
+    const record = discovery.scanSkills({ homeDir: home })
+        .find(candidate => candidate.name === 'shared' && candidate.central);
+
+    const result = scopeService.setGlobalSkillProjectAgents(record, ['kimi', 'claude'], home, ws);
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(
+        fs.realpathSync(path.join(ws, '.kimi', 'skills', 'shared')),
+        path.join(home, '.skills', 'shared'),
+    );
+    assert.strictEqual(
+        fs.realpathSync(path.join(ws, '.claude', 'skills', 'shared')),
+        path.join(home, '.skills', 'shared'),
+    );
+    assert.ok(!fs.existsSync(path.join(ws, '.codex', 'skills', 'shared')),
+        'unselected agents stay unlinked');
+
+    assert.strictEqual(
+        scopeService.setGlobalSkillProjectAgents(record, ['kimi', 'kimi'], home, ws).ok,
+        false,
+        'duplicate agents rejected',
+    );
+    const plain = { ...record, central: undefined };
+    assert.strictEqual(
+        scopeService.setGlobalSkillProjectAgents(plain, ['kimi'], home, ws).ok,
+        false,
+        'non-central skills rejected',
+    );
+});
+
+test('PERSIST-AI-SKILL-SCOPE-ACTION-001 moveProjectSkillToGlobal relocates the project skill', () => {
+    const home = makeHomeFixture();
+    const ws = makeWorkspaceFixture();
+    const record = discovery.scanSkills({ homeDir: home, workspaceRoot: ws })
+        .find(candidate => candidate.name === 'proj' && candidate.central);
+
+    const result = scopeService.moveProjectSkillToGlobal(record, undefined, home, ws);
+    assert.strictEqual(result.ok, true);
+    assert.ok(fs.existsSync(path.join(home, '.skills', 'proj', 'SKILL.md')),
+        'skill content landed in the Global store');
+    assert.ok(!fs.existsSync(path.join(ws, '.skills', 'proj')), 'project store copy removed');
+
+    const rescanned = discovery.scanSkills({ homeDir: home, workspaceRoot: ws });
+    const proj = rescanned.find(candidate => candidate.name === 'proj');
+    assert.strictEqual(proj.scope, 'user', 'moved skill is now global');
+});
+
+test('PERSIST-AI-SKILL-CENTRAL-STORE-001 migrateSkillsToCentral centralizes plain brand skills', () => {
+    const home = makeTempDir('skills-migrate-');
+    writeSkill(path.join(home, '.kimi/skills/plain/SKILL.md'), '---\nname: plain\ndescription: P\n---\n');
+    const records = discovery.scanSkills({ homeDir: home });
+
+    const report = migrateService.migrateSkillsToCentral(records, home, 'user');
+    assert.strictEqual(report.ok, true);
+    assert.ok(report.migrated.includes('plain'));
+    assert.ok(fs.existsSync(path.join(home, '.skills', 'plain', 'SKILL.md')));
+    assert.ok(!fs.existsSync(path.join(home, '.kimi', 'skills', 'plain')),
+        'migration creates no agent links (linkBack: false); the winner moved out');
+});
+
+test('PERSIST-AI-SKILL-DISCOVERY-001 fixSkillDiagnostic repairs fixable diagnostics only', () => {
+    const home = makeTempDir('skills-fix-');
+    const record = overrides => ({
+        name: 'demo', description: '', dirPath: path.join(home, '.kimi', 'skills', 'demo'),
+        skillFilePath: path.join(home, '.kimi', 'skills', 'demo', 'SKILL.md'),
+        scope: 'user', source: 'kimi', folder: '',
+        visibility: { kimi: 'active', claude: 'absent', codex: 'absent' },
+        shadowedBy: {}, diagnostics: [], ...overrides,
+    });
+
+    const lower = path.join(home, '.kimi', 'skills', 'demo', 'skill.md');
+    writeSkill(lower, '---\nname: demo\n---\nbody\n');
+    assert.strictEqual(fixService.fixSkillDiagnostic(
+        record({ skillFilePath: lower }), 'lowercase-filename').ok, true);
+    assert.ok(fs.existsSync(path.join(home, '.kimi', 'skills', 'demo', 'SKILL.md')));
+    assert.strictEqual(fixService.fixSkillDiagnostic(
+        record({ skillFilePath: lower }), 'lowercase-filename').ok, false,
+        'never overwrites an existing SKILL.md');
+
+    const noName = path.join(home, '.kimi', 'skills', 'demo4', 'SKILL.md');
+    writeSkill(noName, '---\ndescription: x\n---\nbody\n');
+    assert.strictEqual(fixService.fixSkillDiagnostic(record({
+        name: 'demo4',
+        dirPath: path.join(home, '.kimi', 'skills', 'demo4'),
+        skillFilePath: noName,
+    }), 'missing-name').ok, true);
+    assert.ok(fs.readFileSync(noName, 'utf8').startsWith('---\nname: demo4\ndescription: x\n---\n'));
+
+    assert.strictEqual(fixService.fixSkillDiagnostic(record(), 'body-too-long').ok, false,
+        'non-fixable diagnostics are refused');
+});

--- a/tests/unit/tooling/ciContracts.test.js
+++ b/tests/unit/tooling/ciContracts.test.js
@@ -52,6 +52,34 @@ test('RUNTIME-REAL-TMUX-CI-GATE-001 requires tmux installation in the smoke job'
     );
 });
 
+test('ARCH-CI-QUALITY-GATE-001 requires the extension host smoke to run headless on PRs', () => {
+    const directRunWorkflow = verifyWorkflow.replace(
+        '        run: xvfb-run -a npm run test:extension-host',
+        '        run: npm run test:extension-host'
+    );
+    assert.throws(
+        () => validateVerifyWorkflow(directRunWorkflow),
+        /extension-host-linux must run xvfb-run -a npm run test:extension-host/
+    );
+});
+
+test('ARCH-CI-QUALITY-GATE-001 keeps the Windows gate on meaningful platform coverage', () => {
+    const windows = packageScripts['test:ci:windows'];
+    for (const required of [
+        'tests/platform/windows/commandBuilders.test.js',
+        'tests/platform/windows/projectPaths.test.js',
+        'tests/platform/windows/conversationSources.test.js',
+        'tests/unit/projects/projectPathUtils.test.js',
+        'tests/unit/projects/orderAndFavorites.test.js',
+        'tests/unit/projects/workspaceAndOpenMatching.test.js',
+        'tests/unit/aiSessions/commandBuilders.test.js',
+        'tests/unit/todos/types.test.js',
+        'tests/unit/prompts/service.test.js',
+    ]) {
+        assert.ok(windows.includes(required), `test:ci:windows must run ${required}`);
+    }
+});
+
 test('RELEASE-VSIX-PACKAGING-001 rejects workflow requirements that appear only in comments', () => {
     const commentOnlyWorkflow = verifyWorkflow
         .split('\n')


### PR DESCRIPTION
## Summary

Three test/CI items from the main-branch review, all pure increments:

1. **Windows gate widening** (`test:ci:windows`): the job paid `npm ci` for only five files; it now also runs the platform-safe unit suites — `unit/projects/orderAndFavorites`, `unit/projects/workspaceAndOpenMatching`, `unit/todos/types`, `unit/prompts/service` — on top of the existing path/command suites.
2. **Extension-host smoke on PRs**: a new advisory, PR-only `extension-host-linux` job in verify.yml runs the real VS Code activation smoke under `xvfb-run` when the command surface or harness changes (`package.json`, `src/dashboard.ts`, `extensions/`, the E2E harness/tests). Previously only the weekly macOS run and releases caught activation regressions. Not a required check yet — prove it stable first.
3. **Skills services in the deterministic coverage suite** (`tests/contract/skills/skillCentralAndScope.test.js`): `centralService`/`scopeService`/`migrateService`/`fixService` were only loaded transitively (8–33% statements), so any edit risked failing the 80% changed-line gate. New contract tests drive the real services against temporary fixtures (link create/remove/refusals, centralize with lock arbitration, folder rules, folder moves re-pointing links, directory equality, cross-scope apply/move, user-scope migration, fixable diagnostics). Statement coverage: centralService 16.8→72.8%, scopeService 8.1→61.3%, migrateService 32.4→70.5%, fixService 33.0→75.5%.

## Harness pinning

- `ciContracts.js` now validates the `extension-host-linux` job (runner, `xvfb-run` wrapper, xvfb install, full-history checkout, 15min timeout, PR-only `if`); mutation tests prove the validator bites.
- `ciContracts.test.js` also pins the widened `test:ci:windows` file list.
- Registered as owner of `PERSIST-AI-SKILL-CENTRAL-STORE-001` and `PERSIST-AI-SKILL-SCOPE-ACTION-001`.

## Gates

Full local gate suite green; changed-line coverage 100% (14/14). The Windows and extension-host jobs validate themselves on this PR's CI run.

## Skill harvest

No skill change justified: established worktree/gates/audit workflow applied; the JSON reformat lesson was applied proactively (text-level edits for package.json and behavior-contracts.json).

Skill-Harvest: none