### PR TITLE
docs: archive the optimization plan and publish the current architecture state

### DIFF
--- a/docs/architecture-current-state.md
+++ b/docs/architecture-current-state.md
@@ -1,0 +1,77 @@
+# Agent Pivot: Current Architecture State
+
+> Living reference, last reconciled against `main` at 1.0.3 (2026-08, PR #129).
+> Update this file when module ownership moves, when a work line completes, or
+> when the backlog changes. The historical plan it supersedes is
+> `docs/optimization-plan.md` (archived, with an epilogue mapping plan items to
+> landed PRs).
+
+## Module Map
+
+`src/` totals ~69k lines of TypeScript/JavaScript. Ownership by directory:
+
+| Area | Size | Owns |
+| --- | --- | --- |
+| `aiSessions/` | 122 files, ~31.4k lines | AI session runtime: tmux backend/discovery/binding store (`tmuxRuntimeBackend.ts`, `tmuxRuntimeDiscovery.ts`, `tmuxRuntimeBindingStore.ts` + `tmuxBindingRecords.ts`), runtime capabilities (`*Capability.ts`, factory + injected options, the #92 pattern), conversation viewer (`conversation/`), attention pipeline (`attention*.ts`), notifications (`notify/`), lifecycle readers |
+| `webview/` | 39 files, ~15k lines | Sidebar webview content (`webviewContent.ts` + `webviewAiSessionContent.ts`) and behavior scripts (`webview*Scripts.js`, mirrored byte-for-byte into `media/`, guarded by WEBVIEW-ASSET-IDENTITY-001) |
+| `services/` | 11 files, ~4.9k lines | Provider session services (codex/kimi/claude), legacy project services; `ntc.ts` is vendored and coverage-exempt |
+| `skills/` | 16 files, ~4.4k lines | Skills management: central store, scope actions, discovery (hash-cached), panel controller (hidden-scan gated) |
+| `projects/` | 21 files, ~2.7k lines | Project CRUD, favorites, path utilities, remote resolution |
+| `dashboard/` | 19 files, ~2.3k lines | View provider, message routing, startup/diagnostics |
+| `todos/` | 7 files, ~2.2k lines | TODO store, service, panel capability |
+| `openWorkspaces/` | 9 files, ~2k lines | Open-workspace bridge client/protocol |
+| `workspaces/` | 14 files, ~1.5k lines | Workspace hydration and session scoping |
+| `prompts/` | 5 files, ~1.4k lines | Prompt library service and webview content |
+| `dashboard.ts` (root) | 1.9k lines | Activation entry + composition root (coverage-exempt; integration-tested via the dashboard harness) |
+
+## Quality And Delivery System
+
+- **Deterministic suites**: unit / contract / integration (`node --test`) + browser (pinned Chromium) + platform (windows/macOS/remote) + extension-host smoke (weekly macOS; advisory PR job on Linux/xvfb when the command surface changes).
+- **Behavior contracts**: `docs/testing/behavior-contracts.json` (~325 entries) pin user-visible behavior to owner test files; `main-capability-coverage.json` audits every implementation commit to a capability; both are CI-enforced.
+- **Coverage gates**: ratchet baseline (`.ci/coverage-baseline.json`) + changed-line ≥80% with a hard failure for changed files missing from the report; `UNINSTRUMENTED_BY_DESIGN` lists the structurally exempt paths.
+- **CI**: `verify.yml` (quality-linux / platform-windows / tmux-smoke-linux, all required), weekly `scheduled-verification.yml`, `release-vsix.yml`.
+- **Merge approval gate**: merges mechanically require an owner approval comment newer than the latest commit (`merge-approval` required status, gate workflow + post-merge audit). See `ARCH-PR-MERGE-APPROVAL-GATE-001`.
+- **Agent workflow skills**: `.skills/` (symlinked into `.kimi/`, `.codex/`, `.claude/`) documents worktrees, PR publishing, local installs, webview mutation protocols, review loops; skill content is pinned by `tests/unit/tooling/repositorySkills.test.js`.
+
+## Completed Work Lines
+
+### Refactor line (#92–#106): split oversized modules, zero behavior change
+
+- #92 established the capability-extraction pattern in the tmux runtime (factory + explicit options, owner keeps composition root).
+- Webview scripts: dashboard 1234→494 lines across #101/#104 (validation, search, three panel factories), todo renderer extracted (#102), prompt protocol extracted (#103); every pair byte-identical to `media/`.
+- TypeScript: AI session rendering out of `webviewContent.ts` 1556→1013 (#105); tmux binding record schema out of the binding store 1731→889 (#106, validators covered by direct contract tests).
+
+### Performance line (#110, #125)
+
+- #110: skills scan chain — content-hash cache behind mtime+size manifests (steady-state rescan ~45ms → ~5ms on a 30-skill/30MB fixture) and hidden-sidebar scan deferral with lazy rescan on read.
+- #125: focused tmux runtime monitor backs off 1s→4s while quiet (the 1s beat, notification latency, and the idle-zero-I/O property are pinned by contract tests).
+
+### Test/CI line (#124, #129)
+
+- #124: one byte-identity loop guards all `src/webview`↔`media/` script pairs; legacy services (`fileService`/`colorService`/`projectWindowColorService`) instrumented, vendored `ntc.ts` exempted.
+- #129: Windows gate widened 5→9 suites; advisory extension-host smoke on PRs (Linux/xvfb, path-filtered); skills central/scope/migrate/fix services lifted from 8–33% to 61–75% statement coverage.
+
+### Process line (#126, #128)
+
+- Merge approval moved from convention to mechanism: skill rule + pinned harness test (#126), then the required `merge-approval` status check and the post-merge audit on main pushes (#128).
+
+## Remaining Backlog (prioritized)
+
+| Item | Risk | Notes |
+| --- | --- | --- |
+| `tmuxRuntimeBackend.ts` (1.6k) capability extraction | Medium | AttachTerminalManager (~500 lines) and CreationOrchestrator are the mapped candidates; two-step split, keep orchestration glue in the backend |
+| `tmuxRuntimeDiscovery.enumerate()` (224-line function) split | Medium | Stage functions share 8 accumulators — pass one accumulators object; no source-text assertions pin the file |
+| Provider session polling → event-driven with low-frequency fallback | Medium | Cross-platform `fs.watch` semantics differ; keep polling fallback |
+| `dashboard.ts` coverage measurement (measure-only first) | Medium | Coordinate with the ongoing dashboard.ts slicing work |
+| behavior-contracts P0 strengthening (ID in a test title + ≥1 assert in the block) | Low-Med | Owner check is currently string-contains |
+| Extension-host PR job → required check | Low | After it proves stable as advisory |
+| `conversation/viewer.ts` (1.5k and growing) | High — deferred | Active feature area; do not restructure while it is being built |
+| Full-HTML rebuild on sidebar becoming visible; `activationEvents` narrowing | Deferred | Both touch the dashboard.ts hot zone |
+
+## Conventions For Contributors (human or agent)
+
+1. Work in `.worktree/<topic>` off `origin/main`; `npm ci` inside the worktree; never push to `main` directly.
+2. Every PR: English title/body, `## Skill harvest` section, capability audit commit (`scripts/regenerate-capability-audit.js`), full local gate suite green.
+3. Merges require the owner approval comment (the `merge-approval` status must be green); agents never self-approve.
+4. Webview scripts keep `src/webview` and `media/` byte-identical; TS-side webview code has no mirror.
+5. New behavior ships with a behavior-contract owner test; changed-line coverage must stay ≥80%.

--- a/docs/optimization-plan.md
+++ b/docs/optimization-plan.md
@@ -1,5 +1,11 @@
 # Agent Pivot Optimization Plan
 
+> **Archived (2026-08, 1.0.3).** This plan is complete: Phases 0-7 landed, and
+> the follow-up refactor/performance/test/process lines landed afterwards (see
+> the epilogue). The living reference is `docs/architecture-current-state.md`.
+> The body below is kept unchanged as the historical record of the plan and its
+> rationale.
+
 This document describes the optimization plan for Agent Pivot after the 1.1.4 release. It focuses on performance, maintainability, AI session extensibility, and future product velocity.
 
 ## Background
@@ -895,3 +901,22 @@ Mitigation:
 Start with Phase 0: safety net and message protocol.
 
 This is the safest foundation because the next changes touch terminal behavior, provider routing, and webview update semantics. The first code PR should extract provider-neutral types and pure helpers without behavior changes. After that, the provider registry can be introduced on top of a smaller, testable surface, and incremental webview updates can depend on a clear message contract instead of ad hoc DOM patching.
+
+## Epilogue: Plan Outcome (2026-08)
+
+Phases 0-7 completed as recorded above. How the stated problems resolved, and what landed after the plan window:
+
+| Plan item | Outcome |
+| --- | --- |
+| 1. Full webview rebuilds | Incremental update channels landed (Phase 4); dashboard panel controllers later factory-extracted (#104) |
+| 2. Provider registry | Landed (Phase 2); codex/kimi/claude share the registry contract |
+| 3. Split `dashboard.ts` | Partially: 3,500+ → 1,936 lines via service/capability extractions; slicing continues |
+| 4. Synchronous I/O | `execSync` git detection removed (Phase 6); skills scan chain optimized with hash caching + hidden-scan deferral (#110); focused tmux monitor backs off when quiet (#125) |
+| 5. Discovery performance | Landed (Phase 6): candidate-path scoping, segmented reads for large Claude JSONL, incremental lifecycle readers |
+| 6. Webview maintainability | Shared render helpers + script splits: dashboard 1234→494 lines (#101/#104), todo renderer (#102), prompt protocol (#103), AI session content (#105); `src/webview`↔`media/` byte identity now loop-guarded (#124) |
+| 7. State ownership | Partially: local stores and attention persistence landed; some `globalState` usage remains transitional |
+| 8-10. Testing / lint / release | Deterministic suites + behavior-contract catalog + capability audit now gate every PR; changed-line coverage ≥80%; extension-host smoke runs weekly (macOS) and as an advisory PR job (Linux/xvfb, #129) |
+
+Post-plan execution lines: capability extractions in the tmux runtime (#92 onward), webview/TS splits (#101-#106), performance (#110, #125), test/CI (#124, #129), and the merge-approval gate (#126, #128).
+
+Success metrics check: `dashboard.ts` below 2,000 lines ✓ (1,936); incremental session updates ✓; no release workflow regression ✓. The remaining backlog lives in `docs/architecture-current-state.md`.

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "a9ab1f23959547152581dd031c131a9ff21acc82",
+        "head": "1f76af30e55e5801ff0908f9673625b98e1d13fe",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -133,7 +133,9 @@
             "afc02d771d7cacd7d590a44e384d24ab6108be14",
             "62af4782282fe782affbc4eab6531e3fa6676777",
             "4d1bbc3a1e04d7c17a173fec51f36aaa311d7a71",
-            "cc0386c57b9b30ae01b4be64aefa9e8d8b4c0042"
+            "cc0386c57b9b30ae01b4be64aefa9e8d8b4c0042",
+            "3b531708f9edfc5ddbd5f7484f822c8099ecaab3",
+            "1f76af30e55e5801ff0908f9673625b98e1d13fe"
         ]
     },
     "capabilities": [


### PR DESCRIPTION
## Summary

The 1.1.4-era `docs/optimization-plan.md` had fallen behind reality (Phases 0-7 long complete; nothing about the refactor/performance/test/process lines that followed). This repays the doc debt in two moves:

- **Archive the plan**: a banner marks it complete and an epilogue reconciles every stated problem (1-7), the testing/lint/release items (8-10), and the success metrics (`dashboard.ts` < 2,000 lines ✓ at 1,936, incremental updates ✓) against the PRs that landed them. The body is otherwise untouched as the historical record.
- **New living reference** `docs/architecture-current-state.md`: the current module map (ownership + sizes), the quality and delivery system (behavior contracts, capability audit, coverage gates, CI workflows, the merge-approval gate), the four completed work lines (refactor #92-#106, performance #110/#125, test/CI #124/#129, process #126/#128), the prioritized remaining backlog, and the contributor conventions (worktrees, PR requirements, approval flow, byte-identity rule, contract tests).

## Gates

Full local gate suite green (docs-only; coverage gate vacuous at 0 eligible files). The audit commit auto-registers the docs commit via the ignored-documentation path.

## Skill harvest

No skill change justified: routine docs work under the existing workflow.

Skill-Harvest: none