### PR TITLE
fix: restore tmux attach terminals concurrently after window reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,15 @@ All notable changes to the "Agent Pivot" extension will be documented in this fi
   telemetry pill now reports open/total (e.g. `Comments 2/5`). Existing stored
   comments migrate automatically (sent and resolved become done).
 
+### Fixed
+
+- Window reloads no longer stall tmux session restoration on windows with many
+  terminals: attach restore now resolves terminal process IDs concurrently
+  (previously serial with a per-terminal timeout, which multiplied the delay
+  by the terminal count while the pty host was still reconnecting) and shares
+  a single live-client list across all terminals instead of one tmux
+  invocation per terminal.
+
 ## [1.0.3] - 2026-08-04
 
 ### Added

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -1646,6 +1646,19 @@
     ]
   },
   {
+    "id": "RUNTIME-TMUX-ATTACH-RESTORE-CONCURRENCY-001",
+    "domain": "runtime",
+    "title": "Reload attach restore resolves terminal process IDs concurrently and shares one live-client list per pass",
+    "priority": "P1",
+    "status": "automated",
+    "owners": [
+      "tests/contract/aiSessions/runtimeBackends.test.js"
+    ],
+    "evidence": [
+      "src/aiSessions/tmuxRuntimeBackend.ts"
+    ]
+  },
+  {
     "id": "RUNTIME-TMUX-WEBVIEW-EXPERIENCE-001",
     "domain": "runtime",
     "title": "Tmux Webview Experience behavior",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "1f76af30e55e5801ff0908f9673625b98e1d13fe",
+        "head": "fb76fbaed8adbae010148a9d0322e7c9f3a40a9f",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -135,7 +135,8 @@
             "4d1bbc3a1e04d7c17a173fec51f36aaa311d7a71",
             "cc0386c57b9b30ae01b4be64aefa9e8d8b4c0042",
             "3b531708f9edfc5ddbd5f7484f822c8099ecaab3",
-            "1f76af30e55e5801ff0908f9673625b98e1d13fe"
+            "1f76af30e55e5801ff0908f9673625b98e1d13fe",
+            "57a90bc92f06d1143b418fa3737f11d1f74083c9"
         ]
     },
     "capabilities": [
@@ -837,7 +838,10 @@
                 "cf9022357308f9a5a45f8cf5523ce6a9cb94bd6d",
                 "202a407eee5c56c91e9a1a6e2e1ea78990fcf98d",
                 "7014d420067a4e2d95fbfcd21b40201ab6b5485b",
-                "f0a0a93cd0b01d606d4f3479f6d60a3c7c8f63a6"
+                "f0a0a93cd0b01d606d4f3479f6d60a3c7c8f63a6",
+                "4ea1cdb42f68bd853797824a5b976f3049dbba3d",
+                "b5833dc9dbabe561820ff330db4354e836859767",
+                "fb76fbaed8adbae010148a9d0322e7c9f3a40a9f"
             ],
             "behaviors": [
                 "RUNTIME-TMUX-BACKEND-001",
@@ -856,7 +860,8 @@
                 "WEBVIEW-MULTI-PROVIDER-SESSION-HISTORY-001",
                 "PERSIST-MULTI-PROVIDER-BATCH-ARCHIVE-001",
                 "AI-SESSION-PROVIDER-ICON-001",
-                "RUNTIME-TMUX-TERMINATE-SESSION-001"
+                "RUNTIME-TMUX-TERMINATE-SESSION-001",
+                "RUNTIME-TMUX-ATTACH-RESTORE-CONCURRENCY-001"
             ],
             "prGates": [
                 "test:ci:linux",

--- a/scripts/run-ai-session-tmux-checks.js
+++ b/scripts/run-ai-session-tmux-checks.js
@@ -355,6 +355,7 @@ function createTmuxBackendHarness(options = {}) {
         },
         getExecutablePath: () => '/opt/tmux',
         getClientSessionForProcess: async () => null,
+        getClientSessionsByProcess: async () => new Map(),
         setExecutablePath: () => undefined,
         listWindows: async () => {
             operations.push({ type: 'list-windows' });

--- a/src/aiSessions/tmuxClient.ts
+++ b/src/aiSessions/tmuxClient.ts
@@ -311,17 +311,21 @@ export class TmuxClient {
         if (!Number.isSafeInteger(processId) || processId < 1 || processId > MAX_PID) {
             throw new TypeError('The terminal process ID is invalid.');
         }
+        return (await this.getClientSessionsByProcess()).get(processId) || null;
+    }
+
+    async getClientSessionsByProcess(): Promise<Map<number, string>> {
         await this.requireAvailable();
         const result = await this.invoke('list-clients', [
             'list-clients', '-F', LIST_CLIENTS_FORMAT,
         ]);
         if (result.exitCode !== 0) {
             if (isNoServerResult(result)) {
-                return null;
+                return new Map();
             }
             throw resultError('list-clients', result);
         }
-        return parseClientSessions(result.stdout).get(processId) || null;
+        return parseClientSessions(result.stdout);
     }
 
     async getTargetWindow(locator: AiSessionTmuxLocator): Promise<TmuxTargetWindowRecord | null> {

--- a/src/aiSessions/tmuxRuntimeBackend.ts
+++ b/src/aiSessions/tmuxRuntimeBackend.ts
@@ -549,12 +549,25 @@ implements AiSessionExecutableRuntimeBackend<TTerminal> {
 
     private async restoreAttachTerminalsOnce(terminals: readonly TTerminal[]): Promise<void> {
         await this.dependencies.discovery.refresh(true);
-        for (const terminal of terminals || []) {
+        const untracked = (terminals || []).filter(terminal =>
+            ![...this.attaches.values()].some(entry => entry.terminal === terminal));
+        // Terminal process IDs can stay pending until the pty host reconnects them after
+        // a window reload (up to the per-terminal timeout each), so resolve them
+        // concurrently instead of multiplying the restore latency by the terminal count.
+        const resolved = await Promise.all(untracked.map(async terminal => {
             const attach = attachTerminal(terminal);
-            if ([...this.attaches.values()].some(entry => entry.terminal === terminal)) {
-                continue;
+            return { terminal, attach, processId: await resolveProcessId(attach.processId) };
+        }));
+        // Live tmux client lookups share one list-clients snapshot per restore pass so a
+        // window with many plain terminals does not spawn one tmux invocation each.
+        let clientSessionsByProcess: Map<number, string> | null = null;
+        const liveSessionForProcess = async (processId: number): Promise<string | null> => {
+            if (!clientSessionsByProcess) {
+                clientSessionsByProcess = await this.dependencies.client.getClientSessionsByProcess();
             }
-            const processId = await resolveProcessId(attach.processId);
+            return clientSessionsByProcess.get(processId) || null;
+        };
+        for (const { terminal, attach, processId } of resolved) {
             if (processId === null) {
                 continue;
             }
@@ -570,7 +583,7 @@ implements AiSessionExecutableRuntimeBackend<TTerminal> {
                 ? Boolean(recovery) || terminalMatchesBinding(attach, binding, launchSessionName)
                 : false;
             const liveSessionName = !bindingMatchesTerminal && launchSessionName === null
-                ? await this.dependencies.client.getClientSessionForProcess(processId)
+                ? await liveSessionForProcess(processId)
                 : launchSessionName;
             let runtime = bindingMatchesTerminal ? this.runtimeForBinding(binding as TmuxAttachBinding)
                 : await this.runtimeForAttachSession(liveSessionName);

--- a/tests/contract/aiSessions/runtimeBackends.test.js
+++ b/tests/contract/aiSessions/runtimeBackends.test.js
@@ -36,6 +36,17 @@ function createLaunchProbe(request) {
     };
 }
 
+function plainRestoredTerminal(name, processId) {
+    return {
+        name,
+        processId: Promise.resolve(processId),
+        shown: false,
+        disposed: false,
+        show() { this.shown = true; },
+        dispose() { this.disposed = true; },
+    };
+}
+
 // SESSION-DIRECT-BACKEND-001
 defineRuntimeContract({
     backendId: 'vscode',
@@ -86,10 +97,110 @@ for (const layout of ['project', 'session']) {
         );
         assert.equal(originalTerminal.shown, true);
         assert.equal(
-            harness.operations.some(operation => operation.type === 'get-client-session'),
+            harness.operations.some(operation => operation.type === 'get-client-sessions'),
             true,
             'reload recovery must use the live terminal process when VS Code metadata is unavailable'
         );
+    });
+
+    test(`RUNTIME-TMUX-ATTACH-RESTORE-CONCURRENCY-001 [tmux ${layout}] reload restore subscribes to every terminal process ID before any of them resolves`, async () => {
+        const harness = createTmuxRuntimeHarness(layout);
+        const runtime = await harness.backend.ensureResume(fakeResumeRequest(`concurrent-${layout}`), layout);
+        await harness.dependencies.attachStore.flush();
+        assert.equal(harness.terminals.length, 1);
+        harness.terminals.push(plainRestoredTerminal('bash', 9421));
+
+        const reloadedBackend = harness.createReloadedBackend();
+        const subscriptions = [];
+        const releases = [];
+        harness.terminals.forEach((terminal, index) => {
+            const originalProcessId = terminal.processId;
+            let unblocked = false;
+            terminal.processId = {
+                then: (onFulfilled, onRejected) => {
+                    if (unblocked) {
+                        return Promise.resolve(originalProcessId).then(onFulfilled, onRejected);
+                    }
+                    subscriptions.push(index);
+                    const released = new Promise(resolve => releases.push(() => {
+                        unblocked = true;
+                        resolve(originalProcessId);
+                    }));
+                    return released.then(onFulfilled, onRejected);
+                },
+            };
+        });
+
+        const restore = reloadedBackend.restoreAttachTerminals(harness.terminals);
+        await new Promise(resolve => setImmediate(resolve));
+        assert.deepEqual([...subscriptions].sort(), [0, 1],
+            'restore must start resolving every terminal process ID before any of them settles');
+
+        for (const release of releases) {
+            release();
+        }
+        await restore;
+
+        const viewerCount = harness.viewerCount();
+        await reloadedBackend.focus(reloadedBackend.find(runtime.identity)[0]);
+        assert.equal(harness.viewerCount(), viewerCount,
+            'attach terminals restored after reload must be reused instead of recreated');
+        assert.equal(harness.terminals[0].shown, true);
+        assert.equal(harness.terminals[1].shown, false,
+            'plain terminals must not be attached');
+    });
+
+    test(`RUNTIME-TMUX-ATTACH-RESTORE-CONCURRENCY-001 [tmux ${layout}] reload restore shares one live-client list across terminals`, async () => {
+        const harness = createTmuxRuntimeHarness(layout);
+        const runtime = await harness.backend.ensureResume(fakeResumeRequest(`batch-${layout}`), layout);
+        await harness.dependencies.attachStore.flush();
+        harness.loseReloadAttachMetadata(harness.terminals[0]);
+        harness.terminals.push(
+            plainRestoredTerminal('bash', 9501),
+            plainRestoredTerminal('zsh', 9502),
+        );
+
+        const reloadedBackend = harness.createReloadedBackend();
+        await reloadedBackend.restoreAttachTerminals(harness.terminals);
+
+        assert.equal(
+            harness.operations.filter(operation => operation.type === 'get-client-sessions').length,
+            1,
+            'live client recovery must reuse one list-clients snapshot per restore pass'
+        );
+        assert.equal(
+            harness.operations.some(operation => operation.type === 'get-client-session'),
+            false,
+            'restore must not spawn one tmux list-clients invocation per terminal'
+        );
+
+        const viewerCount = harness.viewerCount();
+        await reloadedBackend.focus(reloadedBackend.find(runtime.identity)[0]);
+        assert.equal(harness.viewerCount(), viewerCount,
+            'the attach terminal recovered through the live client list must be reused');
+        assert.equal(harness.terminals[0].shown, true);
+        assert.equal(harness.terminals[1].shown, false);
+        assert.equal(harness.terminals[2].shown, false);
+    });
+
+    test(`RUNTIME-TMUX-ATTACH-RESTORE-CONCURRENCY-001 [tmux ${layout}] terminals without process IDs are skipped without blocking the rest`, async () => {
+        const harness = createTmuxRuntimeHarness(layout);
+        const runtime = await harness.backend.ensureResume(fakeResumeRequest(`unresolved-pid-${layout}`), layout);
+        await harness.dependencies.attachStore.flush();
+
+        const reloadedBackend = harness.createReloadedBackend();
+        const plainTerminal = plainRestoredTerminal('bash', 9377);
+        plainTerminal.processId = Promise.resolve(undefined);
+
+        await reloadedBackend.restoreAttachTerminals([plainTerminal, ...harness.terminals]);
+
+        assert.equal(plainTerminal.shown, false,
+            'a terminal whose process ID never resolves must not be attached');
+        const viewerCount = harness.viewerCount();
+        await reloadedBackend.focus(reloadedBackend.find(runtime.identity)[0]);
+        assert.equal(harness.viewerCount(), viewerCount,
+            'the attach terminal with a live process must still be restored and reused');
+        assert.equal(harness.terminals[0].shown, true);
     });
 
     test(`RUNTIME-TMUX-BACKEND-001 [tmux ${layout}] creates a recoverable tmux attach terminal`, async () => {

--- a/tests/contract/aiSessions/tmuxClientBehavior.test.js
+++ b/tests/contract/aiSessions/tmuxClientBehavior.test.js
@@ -261,6 +261,54 @@ test('RUNTIME-TMUX-CLIENT-001 resolves a live terminal process to exactly one tm
     await assert.rejects(client.getClientSessionForProcess(0), TypeError);
 });
 
+test('RUNTIME-TMUX-CLIENT-001 lists live tmux client sessions by process in one snapshot', async () => {
+    const calls = [];
+    let result = {
+        exitCode: 0,
+        stdout: [
+            '4311|:ap-field:|other-session',
+            '4312|:ap-field:|managed-session',
+        ].join('\n') + '\n',
+        stderr: '',
+    };
+    const client = new TmuxClient('/private/tmux', {
+        run: async (_file, args) => {
+            calls.push(args);
+            return availabilityResult(args) || result;
+        },
+    });
+
+    const sessions = await client.getClientSessionsByProcess();
+    assert.deepEqual([...sessions.entries()], [[4311, 'other-session'], [4312, 'managed-session']]);
+    assert.deepEqual(calls.at(-1), [
+        'list-clients', '-F', '#{client_pid}|:ap-field:|#{session_name}',
+    ]);
+
+    result = {
+        exitCode: 1,
+        stdout: '',
+        stderr: 'no server running on /private/tmux-1000/default',
+    };
+    assert.deepEqual([...(await client.getClientSessionsByProcess()).entries()], []);
+
+    result = { exitCode: 0, stdout: '4312|:ap-field:|a\n4312|:ap-field:|b\n', stderr: '' };
+    await assert.rejects(
+        client.getClientSessionsByProcess(),
+        error => error instanceof TmuxClientError
+            && error.operation === 'list-clients'
+            && error.category === 'invalid-output'
+    );
+
+    result = { exitCode: 2, stdout: 'secret stdout', stderr: 'secret stderr' };
+    await assert.rejects(
+        client.getClientSessionsByProcess(),
+        error => error instanceof TmuxClientError
+            && error.operation === 'list-clients'
+            && error.category === 'nonzero-exit'
+            && !error.message.includes('secret')
+    );
+});
+
 test('RUNTIME-TMUX-CLIENT-001 reads and writes metadata options and maps runner failures safely', async () => {
     const calls = [];
     const values = {

--- a/tests/helpers/runtimeContract.js
+++ b/tests/helpers/runtimeContract.js
@@ -403,6 +403,10 @@ function createTmuxRuntimeHarness(layout, options = {}) {
             operations.push({ type: 'get-client-session', processId });
             return clientSessionsByProcessId.get(processId) || null;
         },
+        getClientSessionsByProcess: async () => {
+            operations.push({ type: 'get-client-sessions' });
+            return new Map(clientSessionsByProcessId);
+        },
         listWindows: async () => {
             operations.push({ type: 'list-windows' });
             if (listError) throw listError;


### PR DESCRIPTION
## Summary

Window reload on a workspace with many persistent terminals stalled tmux session restoration for ~22s (observed in production telemetry on a window with ~24 terminals; earlier single-window reloads took 5-7s). The dashboard itself stayed fast (first paint 1.2s, bootstrap ready 2.2s — the 800ms deferral budget worked as designed), but AI session cards kept their pre-restore state until the background attach restore settled.

Root cause: `restoreAttachTerminalsOnce` awaited `terminal.processId` **serially** for every terminal — including plain non-tmux terminals — with a per-terminal 2s timeout, right while the pty host was still reconnecting the persisted processes. It also issued one `tmux list-clients` invocation per terminal for live-client lookups.

## Changes

- `tmuxRuntimeBackend.restoreAttachTerminalsOnce`: resolve all untracked terminal process IDs **concurrently** (`Promise.all`, per-terminal timeout preserved), then process them serially as before. Live tmux client lookups now share one lazily-fetched `list-clients` snapshot per restore pass.
- `TmuxClient`: new `getClientSessionsByProcess()` returning the full `pid → session` map; `getClientSessionForProcess()` keeps its validation and delegates (no behavior change).
- No behavior change: manual `tmux attach` terminals created outside the extension remain restorable (that is exactly why the process-ID wait is kept for non-candidate terminals, just parallelized).

Expected effect on the observed scenario: ~22s → ~2-4s (bounded by pty host reconnection, not by our own serialization). Steady-state impact: none (this path runs once per window boot/reload).

## Tests and contracts

- New contract `RUNTIME-TMUX-ATTACH-RESTORE-CONCURRENCY-001` (P1, automated), owned by `tests/contract/aiSessions/runtimeBackends.test.js`:
  - restore subscribes to every terminal process ID before any of them settles (deterministic blocking-thenable pin, no timers);
  - one shared live-client list per restore pass, zero per-terminal `list-clients` calls;
  - terminals whose process ID never resolves are skipped without blocking the rest.
- `tmuxClientBehavior.test.js`: batched list-clients snapshot (map contents, no-server → empty map, invalid output, privacy-safe nonzero-exit error).
- Mutation-checked: all three new tests fail against the previous serial implementation.
- Hand-rolled tmux client fakes updated for the new interface (`tests/helpers/runtimeContract.js`, `scripts/run-ai-session-tmux-checks.js`).

## Gates

- Full local gates green (compile, unit, integration, dashboard, safety, guards, baseline, browser, contracts, lint, packaging).
- Changed-line coverage: **100.00% (24/24)** against `origin/main`.
- Capability audit: commits assigned to `MAIN-RUNTIME-SESSION-RECOVERY`, behavior registered, audit commit `8c58898`.

## Skill harvest

none — the only process friction was a hand-rolled tmux client fake missing the new interface method; the safety gate caught it deterministically in 31s with a self-explanatory `TypeError`, so no reusable instruction gap exists.