### PR TITLE
fix: render the comment composer actions as icon buttons

### DIFF
--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "47312e9a48be6aacebd147e4cb717727e49c0b2e",
+        "head": "20499e38594dafefa9c3fd5d9e39a8e2fe191273",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -137,7 +137,8 @@
             "3b531708f9edfc5ddbd5f7484f822c8099ecaab3",
             "1f76af30e55e5801ff0908f9673625b98e1d13fe",
             "57a90bc92f06d1143b418fa3737f11d1f74083c9",
-            "8c58898bc0201b64d1f63d11f4705bfc2294eb77"
+            "8c58898bc0201b64d1f63d11f4705bfc2294eb77",
+            "a1f1c9b59dec5b531ff24e11406f6f540fe9ba74"
         ]
     },
     "capabilities": [
@@ -1223,7 +1224,8 @@
                 "c6f192dcf6fdb2c66415430a93854c5ee1f8357c",
                 "afd8939014f40ba86df7c679963774c5ef84d64a",
                 "c9f8e09a61c5450f82e056b6a63331062d283461",
-                "49abbcc65dd88358f19fc70ee63f5cdbab9d4115"
+                "49abbcc65dd88358f19fc70ee63f5cdbab9d4115",
+                "20499e38594dafefa9c3fd5d9e39a8e2fe191273"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",

--- a/src/aiSessions/conversation/viewerDocument.ts
+++ b/src/aiSessions/conversation/viewerDocument.ts
@@ -17,6 +17,7 @@ import type { ConversationViewerTarget } from './viewerTarget';
 const CONVERSATION_COMMENT_ICON_LIST = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 6h16"/><path d="M4 12h16"/><path d="M4 18h16"/></svg>';
 const CONVERSATION_COMMENT_ICON_DOT = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="6"/></svg>';
 const CONVERSATION_COMMENT_ICON_CHECK = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 6 9 17l-5-5"/></svg>';
+const CONVERSATION_COMMENT_ICON_X = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 6 6 18"/><path d="M6 6l12 12"/></svg>';
 const CONVERSATION_COMMENT_ICON_SEND = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 2 11 13"/><path d="M22 2 15 22l-4-9-9-4Z"/></svg>';
 const CONVERSATION_COMMENT_ICON_ERASER = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m7 21-4.3-4.3c-1-1-1-2.5 0-3.4l9.6-9.6c1-1 2.5-1 3.4 0l5.6 5.6c1 1 1 2.5 0 3.4L13 21"/><path d="M22 21H7"/><path d="m5 11 9 9"/></svg>';
 const CONVERSATION_COMMENT_ICON_TRASH = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 6h18"/><path d="M8 6V4h8v2"/><path d="m19 6-1 14H6L5 6"/><path d="M10 11v6"/><path d="M14 11v6"/></svg>';
@@ -240,11 +241,14 @@ export function renderConversationViewerDocument(
                             aria-keyshortcuts="Control+Enter Meta+Enter"
                             placeholder="What should the AI address?"></textarea>
                         <div class="conversation-comment-actions">
-                            <button type="button"
-                                data-comment-action="cancel-add">Cancel</button>
-                            <button type="button"
-                                data-comment-action="confirm-add"
-                                title="Add comment (Ctrl+Enter or Cmd+Enter)">Add comment</button>
+                            <button class="conversation-comment-icon-button"
+                                type="button" data-comment-action="cancel-add"
+                                title="Cancel (Esc)"
+                                aria-label="Cancel (Esc)">${CONVERSATION_COMMENT_ICON_X}</button>
+                            <button class="conversation-comment-icon-button"
+                                type="button" data-comment-action="confirm-add"
+                                title="Add comment (Ctrl+Enter or Cmd+Enter)"
+                                aria-label="Add comment (Ctrl+Enter or Cmd+Enter)">${CONVERSATION_COMMENT_ICON_CHECK}</button>
                         </div>
                     </div>
                     <div class="conversation-comment-list"

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -2778,6 +2778,44 @@ test('CONVERSATION-COMMENTS-UI-001 CONVERSATION-COMMENTS-BULK-001 CONVERSATION-C
             clearOfFirstCard: true,
         }
     );
+
+    // The composer actions are icon buttons, same family as card actions.
+    assert.deepEqual(
+        await page.evaluate(() => {
+            const actions = document.querySelector(
+                '[data-comment-composer] .conversation-comment-actions'
+            );
+            return Array.from(actions.querySelectorAll('button'))
+                .map(button => {
+                    const box = button.getBoundingClientRect();
+                    return {
+                        action: button.getAttribute('data-comment-action'),
+                        iconOnly: button.innerText === ''
+                            && button.querySelectorAll('svg').length === 1,
+                        iconButtonClass: button.classList.contains(
+                            'conversation-comment-icon-button'
+                        ),
+                        size: Math.round(box.width) + 'x'
+                            + Math.round(box.height),
+                    };
+                });
+        }),
+        [
+            {
+                action: 'cancel-add',
+                iconOnly: true,
+                iconButtonClass: true,
+                size: '22x22',
+            },
+            {
+                action: 'confirm-add',
+                iconOnly: true,
+                iconButtonClass: true,
+                size: '22x22',
+            },
+        ],
+        'composer actions must be 22px icon buttons like the card actions'
+    );
     await page.locator('[data-comment-action="cancel-add"]').click();
 
     await page.setViewportSize({ width: 180, height: 600 });


### PR DESCRIPTION
## Summary

- The comment composer kept two word buttons — **Cancel** and **Add comment** — that rendered as 64×25 text buttons next to the 22×22 ghost icon family used by the comment cards, toolbar, and header.
- Replace them with the same icon-button family: an **✕** to cancel (Esc still closes the composer, noted in the tooltip) and a **✓** to confirm (tooltip keeps "Add comment (Ctrl+Enter or Cmd+Enter)"), reusing the exact save/cancel icon language of the card edit mode.
- No script or stylesheet changes were needed: the composer already used the shared `.conversation-comment-actions` container and the `.conversation-comment-icon-button` family.

## Behavior ownership

- `CONVERSATION-COMMENTS-LAYOUT-001` (`tests/browser/conversationViewer.test.js`) asserts the final rendered surface: both composer actions are icon-only (one SVG, no text), carry the shared `conversation-comment-icon-button` class, and render at exactly 22×22 like the card actions. RED observed before the fix (`64x25` text buttons, `iconOnly: false`); GREEN after.
- The existing cancel flow (click ✕ closes the composer) and Ctrl+Enter submission are unchanged and stay green.

## Verification

- `npm run test-compile`
- Focused browser test RED → GREEN (`node --test --test-name-pattern 'reviews contained cards' tests/browser/conversationViewer.test.js`)
- `npm run test:deterministic:run` (unit + contract + integration)
- `npm run test:browser:run`
- `npm run lint`
- `npm run test:ci:linux`
- `git diff --check`
- Rendered screenshot of the open composer checked for icon-button consistency

## Skill harvest

no skill change — the fix followed the existing fixing-regressions-with-ci and protecting-main-with-worktrees flows without friction, corrections, or retries.
