### PR TITLE
Fix dashboard sidebar renderer stalls

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -2203,6 +2203,22 @@
     ]
   },
   {
+    "id": "WEBVIEW-SIDEBAR-VISIBILITY-RETENTION-001",
+    "domain": "webview",
+    "title": "Rapid dashboard sidebar visibility changes retain one authoritative Webview document",
+    "priority": "P0",
+    "status": "automated",
+    "owners": [
+      "tests/browser/dashboardBootShell.test.js",
+      "tests/contract/dashboardBoundaries.test.js",
+      "tests/integration/dashboard/errorRecovery.test.js"
+    ],
+    "evidence": [
+      "src/dashboard.ts",
+      "src/dashboard/viewProvider.ts"
+    ]
+  },
+  {
     "id": "WEBVIEW-TWO-STAGE-STARTUP-001",
     "domain": "webview",
     "title": "Agent Pivot paints a privacy-safe boot shell before ordered dashboard bootstrap completes",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "ca08c5218352a702fd36d0abbab7ac418663388b",
+        "head": "9111829c98e594f2cde4c24803449e045955fb92",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -141,7 +141,8 @@
             "a1f1c9b59dec5b531ff24e11406f6f540fe9ba74",
             "afa2f485202870540d17c33608512c2ec42a481a",
             "63cd5d2f5d69ee92d9d60cc96cb08e30eb546107",
-            "275a72370040a46240e980522b93a5bd6eaa8ab3"
+            "275a72370040a46240e980522b93a5bd6eaa8ab3",
+            "dbd8578d82d5629db962805fce9d1d4f0e9ae678"
         ]
     },
     "capabilities": [
@@ -917,7 +918,8 @@
                 "bf0174af2b1ad9d80cad458cabca60e7407f5c62",
                 "adf59d17328ff629dece01d2dcb32953512995aa",
                 "5a25b7235bc87ef798884d88f1fce06fcde091ac",
-                "ca08c5218352a702fd36d0abbab7ac418663388b"
+                "ca08c5218352a702fd36d0abbab7ac418663388b",
+                "9111829c98e594f2cde4c24803449e045955fb92"
             ],
             "behaviors": [
                 "RUNTIME-BOOTSTRAP-TMUX-RESTORE-DEFERRAL-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "499dc7a3f0d1384adddec85f586fd0c45a48dbd9",
+        "head": "5a25b7235bc87ef798884d88f1fce06fcde091ac",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -139,7 +139,8 @@
             "57a90bc92f06d1143b418fa3737f11d1f74083c9",
             "8c58898bc0201b64d1f63d11f4705bfc2294eb77",
             "a1f1c9b59dec5b531ff24e11406f6f540fe9ba74",
-            "afa2f485202870540d17c33608512c2ec42a481a"
+            "afa2f485202870540d17c33608512c2ec42a481a",
+            "63cd5d2f5d69ee92d9d60cc96cb08e30eb546107"
         ]
     },
     "capabilities": [
@@ -913,7 +914,8 @@
                 "2f76bf86b88cda8d37f96fa77d9fdb17cb57a63f",
                 "cb99568a4be2da413d9c94a910701c6d94bea367",
                 "bf0174af2b1ad9d80cad458cabca60e7407f5c62",
-                "adf59d17328ff629dece01d2dcb32953512995aa"
+                "adf59d17328ff629dece01d2dcb32953512995aa",
+                "5a25b7235bc87ef798884d88f1fce06fcde091ac"
             ],
             "behaviors": [
                 "RUNTIME-BOOTSTRAP-TMUX-RESTORE-DEFERRAL-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "5a25b7235bc87ef798884d88f1fce06fcde091ac",
+        "head": "ca08c5218352a702fd36d0abbab7ac418663388b",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -140,7 +140,8 @@
             "8c58898bc0201b64d1f63d11f4705bfc2294eb77",
             "a1f1c9b59dec5b531ff24e11406f6f540fe9ba74",
             "afa2f485202870540d17c33608512c2ec42a481a",
-            "63cd5d2f5d69ee92d9d60cc96cb08e30eb546107"
+            "63cd5d2f5d69ee92d9d60cc96cb08e30eb546107",
+            "275a72370040a46240e980522b93a5bd6eaa8ab3"
         ]
     },
     "capabilities": [
@@ -915,7 +916,8 @@
                 "cb99568a4be2da413d9c94a910701c6d94bea367",
                 "bf0174af2b1ad9d80cad458cabca60e7407f5c62",
                 "adf59d17328ff629dece01d2dcb32953512995aa",
-                "5a25b7235bc87ef798884d88f1fce06fcde091ac"
+                "5a25b7235bc87ef798884d88f1fce06fcde091ac",
+                "ca08c5218352a702fd36d0abbab7ac418663388b"
             ],
             "behaviors": [
                 "RUNTIME-BOOTSTRAP-TMUX-RESTORE-DEFERRAL-001",
@@ -925,7 +927,8 @@
                 "WEBVIEW-DASHBOARD-COMMAND-AVAILABILITY-001",
                 "WEBVIEW-RESOURCE-RECOVERY-001",
                 "WEBVIEW-LAZY-PANEL-RECOVERY-001",
-                "SESSION-SIDEBAR-STEWARD-VIEW-PROVIDER-ORDERING-001"
+                "SESSION-SIDEBAR-STEWARD-VIEW-PROVIDER-ORDERING-001",
+                "WEBVIEW-SIDEBAR-VISIBILITY-RETENTION-001"
             ],
             "prGates": [
                 "test:deterministic:run",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "20499e38594dafefa9c3fd5d9e39a8e2fe191273",
+        "head": "499dc7a3f0d1384adddec85f586fd0c45a48dbd9",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -138,7 +138,8 @@
             "1f76af30e55e5801ff0908f9673625b98e1d13fe",
             "57a90bc92f06d1143b418fa3737f11d1f74083c9",
             "8c58898bc0201b64d1f63d11f4705bfc2294eb77",
-            "a1f1c9b59dec5b531ff24e11406f6f540fe9ba74"
+            "a1f1c9b59dec5b531ff24e11406f6f540fe9ba74",
+            "afa2f485202870540d17c33608512c2ec42a481a"
         ]
     },
     "capabilities": [
@@ -270,7 +271,8 @@
                 "8bb4c12dde9e7f1ce4ea163ffb2e97edcdcb9b73",
                 "1cb17856b4e8db7fc94d2f6b4a5479d11f95f7d1",
                 "20f0258e412d2e448840658e67d181b06afb0fdf",
-                "f287d527971ec6a53b99ab20e75dbe73d8e28ec5"
+                "f287d527971ec6a53b99ab20e75dbe73d8e28ec5",
+                "499dc7a3f0d1384adddec85f586fd0c45a48dbd9"
             ],
             "behaviors": [
                 "OPEN-OPEN-PROJECT-AUTHORITATIVE-IDENTITY-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "9111829c98e594f2cde4c24803449e045955fb92",
+        "head": "ce77d458452d77fa64281a3e160c683afa46880e",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -142,7 +142,8 @@
             "afa2f485202870540d17c33608512c2ec42a481a",
             "63cd5d2f5d69ee92d9d60cc96cb08e30eb546107",
             "275a72370040a46240e980522b93a5bd6eaa8ab3",
-            "dbd8578d82d5629db962805fce9d1d4f0e9ae678"
+            "dbd8578d82d5629db962805fce9d1d4f0e9ae678",
+            "b686c08e36abd26c9c0c9eb93bc662ff4c1940da"
         ]
     },
     "capabilities": [
@@ -919,7 +920,8 @@
                 "adf59d17328ff629dece01d2dcb32953512995aa",
                 "5a25b7235bc87ef798884d88f1fce06fcde091ac",
                 "ca08c5218352a702fd36d0abbab7ac418663388b",
-                "9111829c98e594f2cde4c24803449e045955fb92"
+                "9111829c98e594f2cde4c24803449e045955fb92",
+                "ce77d458452d77fa64281a3e160c683afa46880e"
             ],
             "behaviors": [
                 "RUNTIME-BOOTSTRAP-TMUX-RESTORE-DEFERRAL-001",

--- a/media/webviewProjectScripts.js
+++ b/media/webviewProjectScripts.js
@@ -707,6 +707,10 @@ function initProjects() {
     });
 
     window.addEventListener('message', onWindowMessage);
+    window.vscode.postMessage({
+        type: 'open-workspaces-renderer-ready',
+        version: 1,
+    });
     restoreAiSessionTabsFromState(document, window.vscode);
     window.vscode.postMessage({ type: 'request-active-ai-session-terminal' });
     window.vscode.postMessage({ type: 'request-ai-session-attention-state' });

--- a/scripts/run-ai-session-safety-checks.js
+++ b/scripts/run-ai-session-safety-checks.js
@@ -3352,8 +3352,15 @@ async function runAgentPivotViewProviderOrderingChecks() {
         'hidden views must not render or force a runtime refresh');
     view.visible = true;
     await visibilityListeners[0]();
-    assert.deepStrictEqual(order.slice(-3), ['render', 'visible:true:start', 'visible:true:end'],
-        'later visible renders must also paint before refresh and render exactly once');
+    assert.deepStrictEqual(order, [
+        'render',
+        'visible:true:start',
+        'visible:true:end',
+        'visible:false:start',
+        'visible:false:end',
+        'visible:true:start',
+        'visible:true:end',
+    ], 'later visibility changes must refresh without replacing the retained document');
 
     let staleRenderCount = 0;
     const failedLogs = [];
@@ -5377,7 +5384,7 @@ function runWebviewContentChecks() {
     assert.ok(dashboard.includes('activeAiSessionTerminalHighlighter.setVisible(visible)'));
     assert.ok(dashboard.includes('await dashboardRuntimeController.handleAiSessionViewVisibilityChanged(visible)'));
     const viewProvider = fs.readFileSync(path.join(__dirname, '..', 'src', 'dashboard', 'viewProvider.ts'), 'utf8');
-    assert.ok(viewProvider.includes('await options.onVisibleChanged(webviewView.visible)'));
+    assert.ok(viewProvider.includes('await options.onVisibleChanged(visible)'));
     const terminalCandidatesSource = fs.readFileSync(path.join(__dirname, '..', 'src', 'aiSessions', 'terminalCandidates.ts'), 'utf8');
     assert.ok(terminalCandidatesSource.includes("reason: 'terminal-candidates'"));
     assert.ok(!terminalCandidatesSource.includes('AI_SESSION_PROVIDER_IDS'));

--- a/scripts/run-ai-session-safety-checks.js
+++ b/scripts/run-ai-session-safety-checks.js
@@ -6706,11 +6706,18 @@ function runBatchAiSessionWebviewChecks() {
     context.initProjects();
 
     const messageListenerIndex = source.indexOf("window.addEventListener('message', onWindowMessage)");
+    const rendererReadyIndex = source.indexOf("type: 'open-workspaces-renderer-ready'");
     const activeTerminalRequestIndex = source.indexOf("type: 'request-active-ai-session-terminal'");
     assert.notStrictEqual(messageListenerIndex, -1);
+    assert.notStrictEqual(rendererReadyIndex, -1);
     assert.notStrictEqual(activeTerminalRequestIndex, -1);
-    assert.ok(messageListenerIndex < activeTerminalRequestIndex);
+    assert.ok(messageListenerIndex < rendererReadyIndex);
+    assert.ok(rendererReadyIndex < activeTerminalRequestIndex);
     assert.ok(windowEventListeners.message);
+    assert.deepStrictEqual(JSON.parse(JSON.stringify(messages.shift())), {
+        type: 'open-workspaces-renderer-ready',
+        version: 1,
+    });
     assert.deepStrictEqual(JSON.parse(JSON.stringify(messages.shift())), {
         type: 'request-active-ai-session-terminal',
     });

--- a/src/aiSessions/attentionController.ts
+++ b/src/aiSessions/attentionController.ts
@@ -36,6 +36,8 @@ export interface AiSessionAttentionProvider {
 
 export interface AiSessionAttentionControllerOptions<TRuntime extends AiSessionAttentionRuntimeEntry = AiSessionAttentionRuntimeEntry> {
     isEnabled: () => boolean;
+    /** A cheap stable identity opts the resident lifecycle tick into snapshot reuse. */
+    getWorkspaceIdentity?: () => string | null;
     getWorkspaceTarget: () => WorkspaceAiSessionActionTarget | null;
     getProviders: () => AiSessionAttentionProvider[];
     getSessionKey?: (providerId: AiSessionProviderId, sessionId: string) => string;
@@ -67,6 +69,11 @@ export interface AiSessionAttentionRuntimeOverride<TRuntime> {
 
 export class AiSessionAttentionController<TRuntime extends AiSessionAttentionRuntimeEntry = AiSessionAttentionRuntimeEntry> {
     private readonly monitor: AiSessionAttentionMonitor;
+    // The one-second lifecycle pass needs stable session ids and workspace roots,
+    // while runtime and signal state are read independently on every pass.
+    private workspaceTargetCached = false;
+    private workspaceTargetIdentity: string | null = null;
+    private workspaceTarget: WorkspaceAiSessionActionTarget | null = null;
     private remoteAggregate: AttentionAggregate | null = null;
     private localItems: AttentionPayloadItem[] = [];
     private attentionKeysBySession = new Map<string, string[]>();
@@ -82,6 +89,7 @@ export class AiSessionAttentionController<TRuntime extends AiSessionAttentionRun
         signals?: AiSessionLifecycleSignals
     ): Promise<AiSessionAttentionEvaluation> {
         if (!this.options.isEnabled()) {
+            this.invalidateWorkspaceTarget();
             this.monitor.clear();
             this.remoteAggregate = null;
             this.localItems = [];
@@ -99,7 +107,7 @@ export class AiSessionAttentionController<TRuntime extends AiSessionAttentionRun
             };
         }
 
-        const workspaceTarget = this.options.getWorkspaceTarget();
+        const workspaceTarget = this.getWorkspaceTargetSnapshot();
         const providers = this.options.getProviders();
         const ownedSessions = this.getOwnedSessions(workspaceTarget?.sessions || null, providers, runtimeOverrides);
         for (const [attentionKey, owned] of ownedSessions) {
@@ -190,8 +198,14 @@ export class AiSessionAttentionController<TRuntime extends AiSessionAttentionRun
         } catch (_error) {
             // 同上。
         }
-        const result = this.buildLocalItems(this.options.getWorkspaceTarget(), this.options.getProviders());
+        const result = this.buildLocalItems(this.getWorkspaceTargetSnapshot(), this.options.getProviders());
         this.localItems = result.items;
+    }
+
+    invalidateWorkspaceTarget(): void {
+        this.workspaceTargetCached = false;
+        this.workspaceTargetIdentity = null;
+        this.workspaceTarget = null;
     }
 
     setRemoteAggregate(aggregate: AttentionAggregate): boolean {
@@ -374,11 +388,12 @@ export class AiSessionAttentionController<TRuntime extends AiSessionAttentionRun
         runtimeOverrides: readonly AiSessionAttentionRuntimeOverride<TRuntime>[] = []
     ): AiSessionLifecycleRequestsByProvider {
         if (!this.options.isEnabled()) {
+            this.invalidateWorkspaceTarget();
             return {};
         }
         const requests: Partial<Record<AiSessionProviderId, AiSessionLifecycleRequest[]>> = {};
         const ownedSessions = this.getOwnedSessions(
-            this.options.getWorkspaceTarget()?.sessions || null,
+            this.getWorkspaceTargetSnapshot()?.sessions || null,
             this.options.getProviders(),
             runtimeOverrides
         );
@@ -391,6 +406,21 @@ export class AiSessionAttentionController<TRuntime extends AiSessionAttentionRun
             requests[owned.providerId] = owning;
         }
         return requests;
+    }
+
+    private getWorkspaceTargetSnapshot(): WorkspaceAiSessionActionTarget | null {
+        if (!this.options.getWorkspaceIdentity) {
+            return this.options.getWorkspaceTarget();
+        }
+        const currentIdentity = this.options.getWorkspaceIdentity();
+        if (this.workspaceTargetCached
+            && currentIdentity === this.workspaceTargetIdentity) {
+            return this.workspaceTarget;
+        }
+        this.workspaceTarget = this.options.getWorkspaceTarget();
+        this.workspaceTargetIdentity = currentIdentity;
+        this.workspaceTargetCached = true;
+        return this.workspaceTarget;
     }
 
     private readSignals(

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -982,6 +982,7 @@ async function initializeDashboard(
     };
     const aiSessionAttentionController = new AiSessionAttentionController<AiSessionRuntimeSnapshot<vscode.Terminal>>({
         isEnabled: () => getAgentPivotConfiguration().get<boolean>('aiSessionAttention.enabled', true) !== false,
+        getWorkspaceIdentity: () => getCurrentOpenWorkspace()?.scopeIdentity || null,
         getWorkspaceTarget: getCurrentWorkspaceActionTargetWithoutCardId,
         getProviders: getRegisteredAiSessionProviders,
         getRuntimeById: getAiSessionRuntimeById,
@@ -1103,6 +1104,7 @@ async function initializeDashboard(
         logError,
         logDiagnostic: logAiSessionDiagnostic,
         beforeRefresh: reason => {
+            aiSessionAttentionController.invalidateWorkspaceTarget();
             currentAiSessionRefreshReason = reason;
             postAiSessionAttentionState();
         },
@@ -1218,6 +1220,12 @@ async function initializeDashboard(
         acknowledgeAiSessionAttentionEventIds,
         logOpenWorkspaceDiagnostic,
         refreshStewardViews,
+        onOpenWorkspacesRendererReady: () => {
+            openWorkspaceDashboardController.invalidatePendingUpdates();
+            void openWorkspaceDashboardController.postUpdated({
+                fallbackToFullRefresh: false,
+            });
+        },
         requestActiveAiSessionTerminalHighlight: () => activeAiSessionTerminalHighlighter.request(),
         postAiSessionAttentionState,
         showAgentPivotSettings,

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -295,6 +295,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         vscode.window.registerWebviewViewProvider(
             AGENT_PIVOT_DASHBOARD_VIEW_ID,
             provider,
+            {
+                webviewOptions: {
+                    retainContextWhenHidden: true,
+                },
+            },
         ),
     );
 

--- a/src/dashboard/messageHandlers.ts
+++ b/src/dashboard/messageHandlers.ts
@@ -28,6 +28,7 @@ export interface DashboardMessageHandlersOptions {
     acknowledgeAiSessionAttentionEventIds: (eventIds: string[]) => Promise<void>;
     logOpenWorkspaceDiagnostic: (component: string, event: unknown) => void;
     refreshStewardViews: (reason?: string) => void;
+    onOpenWorkspacesRendererReady: () => void;
     /** Late-bound: the highlighter is constructed after the message router. */
     requestActiveAiSessionTerminalHighlight: () => void;
     postAiSessionAttentionState: () => void;
@@ -61,6 +62,7 @@ export function createDashboardMessageHandlers(
     const acknowledgeAiSessionAttentionEventIds = options.acknowledgeAiSessionAttentionEventIds;
     const logOpenWorkspaceDiagnostic = options.logOpenWorkspaceDiagnostic;
     const refreshStewardViews = options.refreshStewardViews;
+    const onOpenWorkspacesRendererReady = options.onOpenWorkspacesRendererReady;
     const requestActiveAiSessionTerminalHighlight = options.requestActiveAiSessionTerminalHighlight;
     const postAiSessionAttentionState = options.postAiSessionAttentionState;
     const showAgentPivotSettings = options.showAgentPivotSettings;
@@ -185,6 +187,17 @@ export function createDashboardMessageHandlers(
                 reason: typeof e.reason === 'string' ? e.reason.slice(0, 256) : 'unknown',
             });
             refreshStewardViews(typeof e.reason === 'string' ? e.reason.slice(0, 256) : 'webview-requested');
+        },
+        'open-workspaces-renderer-ready': e => {
+            if (Object.keys(e).length !== 2
+                || e.type !== 'open-workspaces-renderer-ready'
+                || e.version !== 1) {
+                return;
+            }
+            logOpenWorkspaceDiagnostic('Renderer', {
+                event: 'open-workspaces-renderer-ready',
+            });
+            onOpenWorkspacesRendererReady();
         },
         'open-workspaces-rendered': e => {
             logOpenWorkspaceDiagnostic('Renderer', {

--- a/src/dashboard/viewProvider.ts
+++ b/src/dashboard/viewProvider.ts
@@ -124,7 +124,6 @@ export class AgentPivotViewProvider implements vscode.WebviewViewProvider {
             void this.prepareVisibility(
                 webviewView,
                 () => this._view === webviewView,
-                false,
             ).catch(_error => undefined);
         }
         return true;
@@ -202,6 +201,7 @@ export class AgentPivotViewProvider implements vscode.WebviewViewProvider {
             });
         }
         if (this.lifecycle.kind === 'ready') {
+            this.refresh();
             void this.prepareVisibility(webviewView, isCurrent);
             return;
         }
@@ -353,24 +353,21 @@ export class AgentPivotViewProvider implements vscode.WebviewViewProvider {
     private async prepareVisibility(
         webviewView: vscode.WebviewView,
         isCurrent: () => boolean,
-        refresh = true,
     ): Promise<void> {
         const options = this.readyOptions();
         if (!options) {
             return;
         }
+        const visible = webviewView.visible;
         const preparationGeneration = ++this.preparationGeneration;
         const isLatest = () =>
             isCurrent() && preparationGeneration === this.preparationGeneration;
         if (!isLatest()) {
             return;
         }
-        if (refresh && webviewView.visible) {
-            this.refresh();
-        }
         try {
-            await options.onVisibleChanged(webviewView.visible);
-            if (!isLatest() || !webviewView.visible) {
+            await options.onVisibleChanged(visible);
+            if (!isLatest() || !visible || !webviewView.visible) {
                 return;
             }
             await options.onVisiblePrepared?.();

--- a/src/openWorkspaces/dashboardController.ts
+++ b/src/openWorkspaces/dashboardController.ts
@@ -175,7 +175,7 @@ export class OpenWorkspaceDashboardController {
         return cards;
     }
 
-    postUpdated(): Promise<void> {
+    postUpdated(options: { fallbackToFullRefresh?: boolean } = {}): Promise<void> {
         if (!this.options.isVisible()) { return Promise.resolve(); }
         const semanticRevision = this.getViewSemanticRevision();
         if (semanticRevision === this.lastPostedSemanticRevision) { return Promise.resolve(); }
@@ -198,7 +198,8 @@ export class OpenWorkspaceDashboardController {
                     message.semanticRevision,
                     deliveryGeneration
                 );
-                if (current && this.options.isVisible()) {
+                if (current && options.fallbackToFullRefresh !== false
+                    && this.options.isVisible()) {
                     this.options.refresh('open-workspace-update-not-delivered');
                 }
             }
@@ -208,7 +209,8 @@ export class OpenWorkspaceDashboardController {
                 deliveryGeneration
             );
             this.options.logError('Failed to post OPEN WORKSPACE update message.', error);
-            if (current && this.options.isVisible()) {
+            if (current && options.fallbackToFullRefresh !== false
+                && this.options.isVisible()) {
                 this.options.refresh('open-workspace-update-post-error');
             }
         });

--- a/src/webview/webviewProjectScripts.js
+++ b/src/webview/webviewProjectScripts.js
@@ -707,6 +707,10 @@ function initProjects() {
     });
 
     window.addEventListener('message', onWindowMessage);
+    window.vscode.postMessage({
+        type: 'open-workspaces-renderer-ready',
+        version: 1,
+    });
     restoreAiSessionTabsFromState(document, window.vscode);
     window.vscode.postMessage({ type: 'request-active-ai-session-terminal' });
     window.vscode.postMessage({ type: 'request-ai-session-attention-state' });

--- a/tests/browser/dashboardBootShell.test.js
+++ b/tests/browser/dashboardBootShell.test.js
@@ -101,7 +101,7 @@ test('WEBVIEW-TWO-STAGE-STARTUP-001 failed shell provides one focusable Retry th
     ]);
 });
 
-test('WEBVIEW-TWO-STAGE-STARTUP-001 boot shell becomes authoritative content in the same Webview document', async t => {
+test('WEBVIEW-TWO-STAGE-STARTUP-001 WEBVIEW-SIDEBAR-VISIBILITY-RETENTION-001 boot shell becomes authoritative content that survives repeated visibility changes', async t => {
     const page = await openBootDocument(t, { kind: 'booting', generation: 9 });
     const context = page.context();
     const initialPageCount = context.pages().length;
@@ -126,11 +126,40 @@ test('WEBVIEW-TWO-STAGE-STARTUP-001 boot shell becomes authoritative content in 
 
     await assignWebviewDocument(page, [
         '<head><title>Agent Pivot</title></head>',
-        '<body><main data-agent-pivot-authoritative="ready">ready dashboard</main></body>',
+        '<body><main data-agent-pivot-authoritative="ready">',
+        '<button data-agent-pivot-retained-action>ready dashboard</button>',
+        '</main></body>',
     ].join(''));
+    await page.evaluate(() => {
+        const root = document.querySelector('[data-agent-pivot-authoritative="ready"]');
+        const action = document.querySelector('[data-agent-pivot-retained-action]');
+        window.__agentPivotRetainedRoot = root;
+        root.dataset.activationCount = '0';
+        action.addEventListener('click', () => {
+            root.dataset.activationCount = String(Number(root.dataset.activationCount) + 1);
+        });
+        action.focus();
+    });
+
+    for (let iteration = 0; iteration < 15; iteration += 1) {
+        await page.evaluate(() => {
+            document.body.hidden = true;
+            document.body.hidden = false;
+        });
+    }
+    await page.locator('[data-agent-pivot-retained-action]').click();
 
     assert.equal(await page.locator('[data-agent-pivot-authoritative="ready"]').count(), 1);
     assert.equal(await page.locator('[data-agent-pivot-authoritative="ready"]').isVisible(), true);
+    assert.equal(await page.evaluate(() => (
+        window.__agentPivotRetainedRoot
+        === document.querySelector('[data-agent-pivot-authoritative="ready"]')
+    )), true);
+    assert.equal(await page.locator('[data-agent-pivot-authoritative="ready"]')
+        .getAttribute('data-activation-count'), '1');
+    assert.equal(await page.locator('[data-agent-pivot-retained-action]').evaluate(
+        element => document.activeElement === element
+    ), true);
     assert.equal(await page.evaluate(() => window.__agentPivotWindowOpenCalls.length), 0);
     assert.equal(context.pages().length, initialPageCount);
     assert.deepEqual(popupUrls, []);

--- a/tests/contract/aiSessions/runtimeTickOverhead.test.js
+++ b/tests/contract/aiSessions/runtimeTickOverhead.test.js
@@ -9,6 +9,7 @@ const assert = require('node:assert/strict');
 const test = require('node:test');
 
 const { createAiSessionStatusCapability } = require('../../../out/aiSessions/statusCapability');
+const { AiSessionAttentionController } = require('../../../out/aiSessions/attentionController');
 const { createAiSessionRuntimeSettlementCapability } = require('../../../out/aiSessions/runtimeSettlementCapability');
 const { TmuxFocusedRuntimeMonitor } = require('../../../out/aiSessions/tmuxFocusedRuntimeMonitor');
 
@@ -87,6 +88,59 @@ test('PERSIST-INCREMENTAL-JSONL-LIFECYCLE-READER-001 idle status tick performs n
     // The attention evaluation queue evaluates asynchronously.
     await new Promise(resolve => setImmediate(resolve));
     assert.strictEqual(runtimeReconciliations, 1);
+
+    capability.dispose();
+});
+
+test('PERSIST-INCREMENTAL-JSONL-LIFECYCLE-READER-001 status ticks reuse the stable attention workspace snapshot', async () => {
+    let workspaceTargetReads = 0;
+    let workspaceIdentity = 'scope:fixture';
+    const attentionController = new AiSessionAttentionController({
+        isEnabled: () => true,
+        getWorkspaceIdentity: () => workspaceIdentity,
+        getWorkspaceTarget: () => {
+            workspaceTargetReads += 1;
+            return {
+                cardId: 'current',
+                workspace: { scopeIdentity: workspaceIdentity, roots: [] },
+                sessions: { sessionsByProvider: {} },
+            };
+        },
+        getProviders: () => [],
+        getRuntimeById: () => null,
+        publish: () => Promise.resolve(true),
+        scheduleRefresh: () => undefined,
+        nowMs: () => 0,
+    });
+    const capability = createAiSessionStatusCapability({
+        getProviders: () => [],
+        getLifecycleRequests: () => [attentionController.getLifecycleRequests()],
+        evaluateExecution: () => undefined,
+        evaluateAttentionSignals: signals => attentionController.evaluate([], signals),
+        evaluateAttentionRuntimes: () => Promise.resolve({}),
+        onFailure: () => undefined,
+        setInterval: () => ({}),
+        clearInterval: () => undefined,
+    });
+    const tick = async () => {
+        capability.tick();
+        await new Promise(resolve => setImmediate(resolve));
+    };
+
+    await tick();
+    await tick();
+    assert.strictEqual(workspaceTargetReads, 1,
+        'resident ticks must not rebuild the workspace cards and session hydration');
+
+    attentionController.invalidateWorkspaceTarget();
+    await tick();
+    assert.strictEqual(workspaceTargetReads, 2,
+        'an explicit catalog invalidation must refresh the cached workspace target');
+
+    workspaceIdentity = 'scope:other';
+    await tick();
+    assert.strictEqual(workspaceTargetReads, 3,
+        'changing workspaces must refresh the cached workspace target');
 
     capability.dispose();
 });

--- a/tests/contract/dashboard/messageHandlers.test.js
+++ b/tests/contract/dashboard/messageHandlers.test.js
@@ -65,6 +65,7 @@ function createFixture(overrides = {}) {
         refreshStewardViews: reason => calls.push(['refreshStewardViews', reason]),
         requestActiveAiSessionTerminalHighlight: () => calls.push(['requestHighlight']),
         postAiSessionAttentionState: () => calls.push(['postAttentionState']),
+        onOpenWorkspacesRendererReady: () => calls.push(['openWorkspacesRendererReady']),
         showAgentPivotSettings: async () => { calls.push(['showSettings']); },
         showBridgeExtension: async () => { calls.push(['showBridgeExtension']); },
     });
@@ -91,6 +92,7 @@ test('WEBVIEW-DASHBOARD-MESSAGE-ROUTER-001 exposes every extracted handler key',
         'rename-ai-session',
         'copy-ai-session-id',
         'request-full-refresh',
+        'open-workspaces-renderer-ready',
         'open-workspaces-rendered',
         'request-active-ai-session-terminal',
         'request-ai-session-attention-state',
@@ -192,6 +194,9 @@ test('WEBVIEW-DASHBOARD-MESSAGE-ROUTER-001 delegates the simple openers and stat
 
     await handlers['request-active-ai-session-terminal']({});
     await handlers['request-ai-session-attention-state']({});
+    await handlers['open-workspaces-renderer-ready']({
+        type: 'open-workspaces-renderer-ready', version: 1,
+    });
     await handlers['open-settings']({});
     await handlers['open-bridge-extension']({});
     await handlers['acknowledge-ai-session-attention']({ eventIds: ['a', 1, 'b'] });
@@ -199,10 +204,28 @@ test('WEBVIEW-DASHBOARD-MESSAGE-ROUTER-001 delegates the simple openers and stat
     assert.deepEqual(calls, [
         ['requestHighlight'],
         ['postAttentionState'],
+        ['rendererDiagnostic', 'Renderer', {
+            event: 'open-workspaces-renderer-ready',
+        }],
+        ['openWorkspacesRendererReady'],
         ['showSettings'],
         ['showBridgeExtension'],
         ['acknowledgeAttention', ['a', 'b']],
     ], 'non-string attention event ids are filtered before acknowledgement');
+});
+
+test('WEBVIEW-DASHBOARD-MESSAGE-ROUTER-001 rejects malformed open-workspaces renderer readiness', async () => {
+    const { handlers, calls } = createFixture();
+
+    await handlers['open-workspaces-renderer-ready']({});
+    await handlers['open-workspaces-renderer-ready']({
+        type: 'open-workspaces-renderer-ready', version: 2,
+    });
+    await handlers['open-workspaces-renderer-ready']({
+        type: 'open-workspaces-renderer-ready', version: 1, extra: true,
+    });
+
+    assert.deepEqual(calls, []);
 });
 
 test('SESSION-AI-SESSION-TERMINAL-COMMAND-CONTROLLER-001 delegates focus and close flows', async () => {

--- a/tests/contract/dashboardBoundaries.test.js
+++ b/tests/contract/dashboardBoundaries.test.js
@@ -265,6 +265,26 @@ test('WEBVIEW-TWO-STAGE-STARTUP-001 production activation registers one provider
     );
 });
 
+test('WEBVIEW-SIDEBAR-VISIBILITY-RETENTION-001 production retains the rendered dashboard while its sidebar is hidden', () => {
+    const dashboardSource = fs.readFileSync(
+        path.resolve(__dirname, '../../src/dashboard.ts'),
+        'utf8'
+    );
+    const activateStart = dashboardSource.indexOf(
+        'export async function activate(context: vscode.ExtensionContext): Promise<void> {'
+    );
+    const initializeStart = dashboardSource.indexOf(
+        'async function initializeDashboard(',
+        activateStart
+    );
+    const activationSource = dashboardSource.slice(activateStart, initializeStart);
+
+    assert.match(
+        activationSource,
+        /registerWebviewViewProvider\(\s*AGENT_PIVOT_DASHBOARD_VIEW_ID,\s*provider,\s*\{\s*webviewOptions:\s*\{\s*retainContextWhenHidden:\s*true,?\s*\},?\s*\},?\s*\)/
+    );
+});
+
 test('WEBVIEW-DASHBOARD-STARTUP-CONTROLLER-001 production startup uses the bootstrap generation liveness guard', () => {
     const dashboardSource = fs.readFileSync(
         path.resolve(__dirname, '../../src/dashboard.ts'),

--- a/tests/contract/openProjects/dashboardController.test.js
+++ b/tests/contract/openProjects/dashboardController.test.js
@@ -372,6 +372,26 @@ test('OPEN-OPEN-PROJECT-DASHBOARD-CONTROLLER-001 retries undelivered and rejecte
     assert.deepEqual(errors, [['Failed to post OPEN WORKSPACE update message.', 'webview closed']]);
 });
 
+test('OPEN-OPEN-PROJECT-INCREMENTAL-RENDERING-001 renderer-ready replay never falls back to a self-refresh loop', async () => {
+    const refreshes = [];
+    const errors = [];
+    let delivery = () => Promise.resolve(false);
+    const controller = new OpenWorkspaceDashboardController(createOptions({
+        postMessage: () => delivery(),
+        refresh: reason => refreshes.push(reason),
+        logError: (message, error) => errors.push([message, error.message]),
+    }));
+
+    controller.postUpdated({ fallbackToFullRefresh: false });
+    await flushAsync();
+    delivery = () => Promise.reject(new Error('webview closed'));
+    controller.postUpdated({ fallbackToFullRefresh: false });
+    await flushAsync();
+
+    assert.deepEqual(refreshes, []);
+    assert.deepEqual(errors, [['Failed to post OPEN WORKSPACE update message.', 'webview closed']]);
+});
+
 test('PERSIST-DASHBOARD-MIGRATION-PUBLICATION-001 republishes only after migrated project metadata is visible', async () => {
     const events = [];
     let metadata = 'before-migration';

--- a/tests/integration/dashboard/errorRecovery.test.js
+++ b/tests/integration/dashboard/errorRecovery.test.js
@@ -289,7 +289,7 @@ test('WEBVIEW-NONBLOCKING-FIRST-PAINT-001 renders cached HTML before visible pre
     assert.deepEqual(order, ['render', 'visible:true:start', 'visible:true:end']);
 });
 
-test('WEBVIEW-NONBLOCKING-FIRST-PAINT-001 keeps the rendered document across rapid sidebar visibility changes', async () => {
+test('WEBVIEW-NONBLOCKING-FIRST-PAINT-001 WEBVIEW-SIDEBAR-VISIBILITY-RETENTION-001 keeps the rendered document across rapid sidebar visibility changes', async () => {
     let visibilityChanged;
     let renderCalls = 0;
     const prepared = [];

--- a/tests/integration/dashboard/errorRecovery.test.js
+++ b/tests/integration/dashboard/errorRecovery.test.js
@@ -289,6 +289,55 @@ test('WEBVIEW-NONBLOCKING-FIRST-PAINT-001 renders cached HTML before visible pre
     assert.deepEqual(order, ['render', 'visible:true:start', 'visible:true:end']);
 });
 
+test('WEBVIEW-NONBLOCKING-FIRST-PAINT-001 keeps the rendered document across rapid sidebar visibility changes', async () => {
+    let visibilityChanged;
+    let renderCalls = 0;
+    const prepared = [];
+    const view = {
+        visible: true,
+        webview: {
+            html: '',
+            options: {},
+            onDidReceiveMessage: () => ({ dispose() {} }),
+            postMessage: async () => true,
+        },
+        onDidChangeVisibility(callback) {
+            visibilityChanged = callback;
+            return { dispose() {} };
+        },
+        onDidDispose: () => ({ dispose() {} }),
+    };
+    const provider = new AgentPivotViewProvider({ mode: 'ready', options: {
+        getWebviewOptions: () => ({}),
+        renderContent: () => {
+            renderCalls += 1;
+            return `<main>dashboard document ${renderCalls}</main>`;
+        },
+        renderError: () => '<main>safe error</main>',
+        onMessage: async () => undefined,
+        onVisibleChanged: async () => undefined,
+        onVisiblePrepared: async () => {
+            prepared.push('prepared');
+        },
+        onDisposed: () => undefined,
+        logError: () => undefined,
+    }});
+
+    await provider.resolveWebviewView(view, {}, {});
+    await new Promise(resolve => setImmediate(resolve));
+
+    for (let iteration = 0; iteration < 15; iteration += 1) {
+        view.visible = false;
+        await visibilityChanged();
+        view.visible = true;
+        await visibilityChanged();
+    }
+
+    assert.equal(renderCalls, 1, 'visibility changes must not recreate the Webview document');
+    assert.equal(view.webview.html, '<main>dashboard document 1</main>');
+    assert.equal(prepared.length, 16, 'each visible epoch still receives incremental preparation');
+});
+
 test('SESSION-SIDEBAR-STEWARD-VIEW-PROVIDER-ORDERING-001 preserves healthy HTML when visible preparation fails', async () => {
     const visibilityGate = deferred();
     const logs = [];
@@ -495,7 +544,7 @@ test('SESSION-SIDEBAR-STEWARD-VIEW-PROVIDER-OWNERSHIP-001 ignores stale visibili
     const staleInFlight = viewA.fireVisibility();
     await new Promise(resolve => setImmediate(resolve));
     await provider.resolveWebviewView(viewB.view, {}, {});
-    assert.deepEqual(renders, ['a', 'a', 'b']);
+    assert.deepEqual(renders, ['a', 'b']);
     assert.equal(disposed, 1);
     assert.deepEqual(disposalVisibility, [false]);
 
@@ -503,7 +552,7 @@ test('SESSION-SIDEBAR-STEWARD-VIEW-PROVIDER-OWNERSHIP-001 ignores stale visibili
     await staleInFlight;
     assert.deepEqual(
         renders,
-        ['a', 'a', 'b'],
+        ['a', 'b'],
         'an old post-await continuation must not refresh the current view'
     );
 
@@ -523,7 +572,7 @@ test('SESSION-SIDEBAR-STEWARD-VIEW-PROVIDER-OWNERSHIP-001 ignores stale visibili
     viewB.view.visible = true;
     await viewB.fireVisibility();
     assert.equal(provider.visible, true);
-    assert.deepEqual(renders, ['a', 'a', 'b', 'b']);
+    assert.deepEqual(renders, ['a', 'b']);
     await viewB.fireDispose();
     assert.equal(disposed, 2);
     assert.deepEqual(disposalVisibility, [false, false]);

--- a/tests/integration/dashboard/helpers/todoPanelHarness.js
+++ b/tests/integration/dashboard/helpers/todoPanelHarness.js
@@ -189,8 +189,8 @@ if (mode === 'missing-live-probe') {
         'if (error instanceof types_1.UnsupportedTodoDataVersionError)');
 } else if (mode === 'missing-view-registration') {
     transform = source => source.replace(
-        'context.subscriptions.push(vscode.window.registerWebviewViewProvider(constants_1.AGENT_PIVOT_DASHBOARD_VIEW_ID, provider));',
-        'context.subscriptions.push({ dispose: () => undefined });');
+        'vscode.window.registerWebviewViewProvider',
+        '((_viewId, _provider, _options) => ({ dispose: () => undefined }))');
 }
 
 runTodoPanelContract(transform).catch(error => {

--- a/tests/integration/dashboard/webviewState.test.js
+++ b/tests/integration/dashboard/webviewState.test.js
@@ -1834,6 +1834,7 @@ function createProjectVm({
     const documentListeners = {};
     const windowListeners = {};
     const messages = [];
+    const initializationEvents = [];
     const replacedCatalogs = [];
     let webviewState = { unrelated: 'preserved' };
     const context = {
@@ -1864,11 +1865,17 @@ function createProjectVm({
         window: {
             innerWidth: 1024,
             innerHeight: 768,
-            addEventListener: (type, listener) => { windowListeners[type] = listener; },
+            addEventListener: (type, listener) => {
+                windowListeners[type] = listener;
+                initializationEvents.push(`listener:${type}`);
+            },
             requestAnimationFrame: callback => callback(),
             setTimeout: callback => callback(),
             vscode: {
-                postMessage: message => messages.push(message),
+                postMessage: message => {
+                    messages.push(message);
+                    initializationEvents.push(`message:${message.type}`);
+                },
                 getState: () => webviewState,
                 setState: state => { webviewState = state; },
             },
@@ -1881,8 +1888,18 @@ function createProjectVm({
     vm.runInNewContext(scrollStateSource, context);
     vm.runInNewContext(source, context);
     context.initProjects();
+    const initialMessages = messages.map(message => ({ ...message }));
     messages.length = 0;
-    return { context, documentListeners, windowListeners, messages, replacedCatalogs, getWebviewState: () => webviewState };
+    return {
+        context,
+        documentListeners,
+        windowListeners,
+        messages,
+        initialMessages,
+        initializationEvents,
+        replacedCatalogs,
+        getWebviewState: () => webviewState,
+    };
 }
 
 function createCrossProviderBatchProject() {
@@ -2286,6 +2303,19 @@ test('SESSION-CONTROLLER-001 preserves AI tab helpers, persisted state, and sema
     assert.equal(historyList.scrollTop, 29);
     assert.equal(tabs[0].getAttribute('aria-selected'), 'true');
     assert.equal(tabs[1].getAttribute('aria-selected'), 'false');
+});
+
+test('OPEN-OPEN-PROJECT-INCREMENTAL-RENDERING-001 announces renderer readiness after installing the message listener', () => {
+    const harness = createProjectVm();
+    assert.deepEqual(toPlain(harness.initialMessages[0]), {
+        type: 'open-workspaces-renderer-ready',
+        version: 1,
+    });
+    assert.ok(
+        harness.initializationEvents.indexOf('listener:message')
+            < harness.initializationEvents.indexOf('message:open-workspaces-renderer-ready'),
+        'the host handshake must not race ahead of the installed message listener',
+    );
 });
 
 function assertCollapseButtonBehavior(context) {


### PR DESCRIPTION
## Summary
- stabilize open-workspace target refreshes and replay renderer readiness without a full-document fallback
- keep the dashboard Webview document across visibility changes and retain its renderer while hidden
- add contract, integration, and Chromium regression coverage for rapid sidebar toggling

## Verification
- `npm run test:ci:linux`
- local VSIX installation with byte verification
- reddb-dev: 20 rapid sidebar toggles, one renderer-ready event, zero full refreshes

## Skill harvest
No skill change was justified. Existing regression guidance already required RED, CI reachability, and rendered-surface ownership; the VS Code renderer-lifecycle gap is now protected by `WEBVIEW-SIDEBAR-VISIBILITY-RETENTION-001`.

## Release
No version, tag, GitHub Release, or marketplace publication is included.