### PR TITLE
Fix sidebar watcher churn during rapid toggles

### DIFF
--- a/.skills/publishing-and-merging-github-prs/SKILL.md
+++ b/.skills/publishing-and-merging-github-prs/SKILL.md
@@ -20,6 +20,12 @@ after every GitHub write.
   when more than one repository remote exists; do not rely on automatic remote
   selection.
 - Resolve base branch from the user request first; otherwise use the target repo default.
+- Immediately before final verification, packaging, installation, and push,
+  fetch the target base and inspect whether the feature branch is behind it.
+  If it is behind, rebase before those final steps, reinstall worktree
+  dependencies, and rerun every affected build, local installation, byte
+  verification, and test. Never publish or report artifacts built before the
+  rebase as current.
 - Check for an existing PR with `gh pr list --head <branch> --repo <owner/repo>`.
 
 ## Create PR

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -2211,9 +2211,11 @@
     "owners": [
       "tests/browser/dashboardBootShell.test.js",
       "tests/contract/dashboardBoundaries.test.js",
-      "tests/integration/dashboard/errorRecovery.test.js"
+      "tests/integration/dashboard/errorRecovery.test.js",
+      "tests/integration/dashboard/sessionRuntimeFlow.test.js"
     ],
     "evidence": [
+      "src/aiSessions/dashboardController.ts",
       "src/dashboard.ts",
       "src/dashboard/viewProvider.ts"
     ]

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "6477a5c1eddc60cda384d02cdb5b5a8f59ad5ffe",
+        "head": "09932f96ba19f74b57eb2ddffa482b182d32fee5",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -145,7 +145,8 @@
             "dbd8578d82d5629db962805fce9d1d4f0e9ae678",
             "b686c08e36abd26c9c0c9eb93bc662ff4c1940da",
             "50e1301b07594c5f4de9ee1251dce196378838f2",
-            "8b76c02463e8dad6bd9817ce22cc298781572be3"
+            "8b76c02463e8dad6bd9817ce22cc298781572be3",
+            "19b2c5759393105a7be519320435c8aa1dc4a2a2"
         ]
     },
     "capabilities": [
@@ -923,7 +924,8 @@
                 "5a25b7235bc87ef798884d88f1fce06fcde091ac",
                 "ca08c5218352a702fd36d0abbab7ac418663388b",
                 "9111829c98e594f2cde4c24803449e045955fb92",
-                "ce77d458452d77fa64281a3e160c683afa46880e"
+                "ce77d458452d77fa64281a3e160c683afa46880e",
+                "bc9af0891c815988a1f74d5fd3c502b2ea8988cd"
             ],
             "behaviors": [
                 "RUNTIME-BOOTSTRAP-TMUX-RESTORE-DEFERRAL-001",
@@ -1020,7 +1022,8 @@
                 "8a21bfdda38027a0970fd4b01dfd9bb029928274",
                 "4475d2c1b5a1f16ee1950ddeaeb783e188ede071",
                 "24df1dbeadcd4b8f8ba28f7b35ee40469bee0a86",
-                "a9ab1f23959547152581dd031c131a9ff21acc82"
+                "a9ab1f23959547152581dd031c131a9ff21acc82",
+                "09932f96ba19f74b57eb2ddffa482b182d32fee5"
             ],
             "behaviors": [
                 "ARCH-CI-QUALITY-GATE-001",

--- a/src/aiSessions/dashboardController.ts
+++ b/src/aiSessions/dashboardController.ts
@@ -30,6 +30,7 @@ export interface AiSessionDashboardControllerOptions {
     afterRefresh?: () => void;
     debounceMs: number;
     watcherRefreshMinIntervalMs?: number;
+    watcherStopGraceMs?: number;
     newSessionRefreshDelaysMs: number[];
     setTimeout: (callback: () => void, delayMs: number) => NodeJS.Timeout;
     clearTimeout: (handle: NodeJS.Timeout) => void;
@@ -41,6 +42,7 @@ export interface AiSessionDashboardRefreshOptions {
 
 export class AiSessionDashboardController {
     private refreshTimeout: NodeJS.Timeout = null;
+    private watcherStopTimeout: NodeJS.Timeout = null;
     private newSessionRefreshTimeouts: NodeJS.Timeout[] = [];
     private watcherDisposables: DisposableLike[] = [];
     private pendingRefreshReason = 'refresh';
@@ -79,9 +81,10 @@ export class AiSessionDashboardController {
 
     setWatchersActive(active: boolean): void {
         if (active) {
+            this.cancelWatcherStop();
             this.startWatchers();
         } else {
-            this.stopWatchers();
+            this.scheduleWatcherStop();
         }
     }
 
@@ -183,6 +186,7 @@ export class AiSessionDashboardController {
     }
 
     dispose(): void {
+        this.cancelWatcherStop();
         this.stopWatchers();
         for (let timeout of this.newSessionRefreshTimeouts) {
             this.options.clearTimeout(timeout);
@@ -197,6 +201,31 @@ export class AiSessionDashboardController {
 
         this.watcherDisposables = this.options.providerIds
             .map(providerId => this.options.watchSessionChanges(providerId, () => this.scheduleRefresh('watcher')));
+    }
+
+    private scheduleWatcherStop(): void {
+        if (!this.watcherDisposables.length || this.watcherStopTimeout !== null) {
+            return;
+        }
+        const delayMs = Math.max(0, this.options.watcherStopGraceMs ?? 5000);
+        if (delayMs === 0) {
+            this.stopWatchers();
+            return;
+        }
+        this.watcherStopTimeout = this.options.setTimeout(() => {
+            this.watcherStopTimeout = null;
+            if (!this.options.isVisible()) {
+                this.stopWatchers();
+            }
+        }, delayMs);
+    }
+
+    private cancelWatcherStop(): void {
+        if (this.watcherStopTimeout === null) {
+            return;
+        }
+        this.options.clearTimeout(this.watcherStopTimeout);
+        this.watcherStopTimeout = null;
     }
 
     private stopWatchers(): void {

--- a/tests/integration/dashboard/sessionRuntimeFlow.test.js
+++ b/tests/integration/dashboard/sessionRuntimeFlow.test.js
@@ -245,6 +245,57 @@ test('WEBVIEW-AI-SESSION-DASHBOARD-WATCHER-COALESCING-001 coalesces watcher refr
     assert.deepEqual(reasons, ['watcher', 'watcher', 'attention']);
 });
 
+test('WEBVIEW-SIDEBAR-VISIBILITY-RETENTION-001 reuses provider watchers across rapid sidebar visibility changes', () => {
+    const clock = createFakeClock(1000);
+    let visible = true;
+    let watcherStarts = 0;
+    let watcherDisposals = 0;
+    const { AiSessionDashboardController } = loadFreshWithFakeVscode(
+        '../../../out/aiSessions/dashboardController', {}, __dirname
+    );
+    const controller = new AiSessionDashboardController({
+        providerIds: ['codex', 'kimi', 'claude'],
+        isVisible: () => visible,
+        invalidateCache: () => undefined,
+        watchSessionChanges: () => {
+            watcherStarts += 1;
+            return { dispose: () => { watcherDisposals += 1; } };
+        },
+        getGroups: () => [], getTodoSearchItems: () => [], getCards: () => [],
+        getRunningCardAnimation: () => undefined,
+        getRunningIconAnimation: () => undefined,
+        nextSequence: () => 1,
+        postMessage: () => Promise.resolve(true),
+        refresh: () => undefined,
+        logError: (_message, error) => { throw error; },
+        debounceMs: 100,
+        watcherStopGraceMs: 5000,
+        newSessionRefreshDelaysMs: [],
+        setTimeout: (callback, delay) => clock.setTimeout(callback, delay),
+        clearTimeout: handle => clock.clearTimeout(handle),
+    });
+
+    controller.setWatchersActive(true);
+    for (let iteration = 0; iteration < 15; iteration += 1) {
+        visible = false;
+        controller.setWatchersActive(false);
+        clock.advanceBy(100);
+        visible = true;
+        controller.setWatchersActive(true);
+    }
+
+    assert.equal(watcherStarts, 3, 'each provider watcher must be created only once');
+    assert.equal(watcherDisposals, 0, 'brief hidden epochs must keep the watchers reusable');
+
+    visible = false;
+    controller.setWatchersActive(false);
+    clock.advanceBy(4999);
+    assert.equal(watcherDisposals, 0, 'watchers stay alive throughout the visibility grace period');
+    clock.advanceBy(1);
+    assert.equal(watcherDisposals, 3, 'a genuinely hidden dashboard eventually releases every watcher');
+    controller.dispose();
+});
+
 test('WEBVIEW-AI-SESSION-DASHBOARD-WATCHER-COALESCING-001 never postpones a pending status refresh behind later watcher events', async () => {
     const clock = createFakeClock(1000);
     const reasons = [];

--- a/tests/unit/tooling/repositorySkills.test.js
+++ b/tests/unit/tooling/repositorySkills.test.js
@@ -88,6 +88,7 @@ test('ARCH-REPOSITORY-SKILL-GUIDANCE-001 verifies ambiguous GitHub writes and tr
     assertSkillMentions(skill, [
         ['workflow lesson harvest before audit', /harvesting-workflow-lessons[\s\S]*before[\s\S]*final capability audit/i],
         ['explicit repository selection', /--repo <owner\/name>[\s\S]*automatic remote[\s\S]*selection/i],
+        ['base freshness before final artifacts', /before final verification[\s\S]*feature branch is behind[\s\S]*rebase[\s\S]*Never publish or report artifacts built before the[\s\S]*rebase/i],
         ['transport result verification', /HTTP 408[\s\S]*unexpected EOF[\s\S]*remote branch SHA/i],
         ['HTTP/1.1 retry', /http\.version=HTTP\/1\.1 push/i],
         ['non-force retry', /same non-force refspec/i],


### PR DESCRIPTION
## Summary

- keep AI session provider watchers alive through a five-second hidden grace period so rapid sidebar toggles reuse them
- release watchers after the dashboard remains hidden and cover the 15-toggle regression in CI
- require feature branches to refresh their base before final verification, packaging, installation, and publication

## Verification

- `npm run test-compile`
- `node --test tests/integration/dashboard/sessionRuntimeFlow.test.js tests/integration/dashboard/errorRecovery.test.js`
- `node --test tests/browser/dashboardBootShell.test.js`
- `node --test tests/unit/tooling/repositorySkills.test.js`
- `npm run test:behavior-contracts`
- `SKIP_NPM_CI=1 npm run install-local`
- manual two-window repeated sidebar toggle verification

## Skill harvest

Updated `.skills/publishing-and-merging-github-prs`: the user correction exposed that a long-running branch can become stale after its initial build, so the skill now requires fetching/rebasing before final artifacts and rerunning affected build, install, byte verification, and tests. Validated with `quick_validate.py` and `tests/unit/tooling/repositorySkills.test.js`.

No release is included.