### PR TITLE
Fix repeated AI Conversation selection highlights

### DIFF
--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "09932f96ba19f74b57eb2ddffa482b182d32fee5",
+        "head": "7c666c40b1f23e923ade5b152c804b7cc12c922f",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -146,7 +146,8 @@
             "b686c08e36abd26c9c0c9eb93bc662ff4c1940da",
             "50e1301b07594c5f4de9ee1251dce196378838f2",
             "8b76c02463e8dad6bd9817ce22cc298781572be3",
-            "19b2c5759393105a7be519320435c8aa1dc4a2a2"
+            "19b2c5759393105a7be519320435c8aa1dc4a2a2",
+            "37078676633b19bf0a6366e97e59ef0ef041b7fd"
         ]
     },
     "capabilities": [
@@ -1243,7 +1244,8 @@
                 "49abbcc65dd88358f19fc70ee63f5cdbab9d4115",
                 "20499e38594dafefa9c3fd5d9e39a8e2fe191273",
                 "2e3609074cb55dbb41b9fbcf7ff494300b0fca7e",
-                "6477a5c1eddc60cda384d02cdb5b5a8f59ad5ffe"
+                "6477a5c1eddc60cda384d02cdb5b5a8f59ad5ffe",
+                "7c666c40b1f23e923ade5b152c804b7cc12c922f"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",

--- a/media/conversationViewerScripts.js
+++ b/media/conversationViewerScripts.js
@@ -677,12 +677,13 @@
                     === message.selectedInteractionId;
             }
         );
-        selectedMessages.forEach(function (candidate) {
-            candidate.classList.add('conversation-selected-interaction');
+        var selected = selectedMessages[0];
+        if (!isLiveRefresh && selected) {
+            selected.classList.add('conversation-selected-interaction');
             window.setTimeout(function () {
-                candidate.classList.remove('conversation-selected-interaction');
+                selected.classList.remove('conversation-selected-interaction');
             }, 1600);
-        });
+        }
         if (isLiveRefresh
             && focusedMessageId
             && (!focusedMessage.isConnected
@@ -702,7 +703,6 @@
         renderMermaidDiagrams(renderGeneration);
 
         if (!isLiveRefresh) {
-            var selected = selectedMessages[0];
             var openingAtLatest = message.atLatest
                 && message.updateKind === 'initial';
             if (openingAtLatest) {

--- a/src/webview/conversationViewerScripts.js
+++ b/src/webview/conversationViewerScripts.js
@@ -677,12 +677,13 @@
                     === message.selectedInteractionId;
             }
         );
-        selectedMessages.forEach(function (candidate) {
-            candidate.classList.add('conversation-selected-interaction');
+        var selected = selectedMessages[0];
+        if (!isLiveRefresh && selected) {
+            selected.classList.add('conversation-selected-interaction');
             window.setTimeout(function () {
-                candidate.classList.remove('conversation-selected-interaction');
+                selected.classList.remove('conversation-selected-interaction');
             }, 1600);
-        });
+        }
         if (isLiveRefresh
             && focusedMessageId
             && (!focusedMessage.isConnected
@@ -702,7 +703,6 @@
         renderMermaidDiagrams(renderGeneration);
 
         if (!isLiveRefresh) {
-            var selected = selectedMessages[0];
             var openingAtLatest = message.atLatest
                 && message.updateKind === 'initial';
             if (openingAtLatest) {

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -4393,6 +4393,66 @@ test('CONVERSATION-VIEWER-BROWSER-NAVIGATION-002 anchors and focuses the Host-se
     ), 'selected-2');
 });
 
+test('CONVERSATION-NAVIGATION-STATE-001 CONVERSATION-READING-FOCUS-001 highlights only the selected input and does not replay the locator on live refresh', async t => {
+    const page = await openViewerPage(t);
+    const outline = [{
+        interactionId: 'highlight-0',
+        userPreview: 'Highlighted input',
+        responseState: 'inProgress',
+    }];
+    await sendPage(page, {
+        ...hostileConversationPage,
+        html: interactionHtml('highlight', 1, 3),
+        outline,
+        selectedInteractionId: 'highlight-0',
+        selectedInput: 1,
+        totalInputs: 1,
+        atLatest: true,
+        previousCursor: undefined,
+        nextCursor: undefined,
+    });
+    const initialHighlights = await page.locator(
+        '.conversation-selected-interaction'
+    ).evaluateAll(elements => elements.map(element =>
+        element.getAttribute('data-message-id')
+    ));
+
+    await page.locator('.conversation-selected-interaction').evaluateAll(
+        elements => elements.forEach(element =>
+            element.classList.remove('conversation-selected-interaction')
+        )
+    );
+    const refreshHighlights = [];
+    for (const requestId of [2, 3]) {
+        await sendPage(page, {
+            ...hostileConversationPage,
+            requestId,
+            updateKind: 'refresh',
+            html: interactionHtml('highlight', 1, requestId + 2),
+            outline,
+            selectedInteractionId: 'highlight-0',
+            selectedInput: 1,
+            totalInputs: 1,
+            atLatest: true,
+            previousCursor: undefined,
+            nextCursor: undefined,
+        });
+        refreshHighlights.push(await page.locator(
+            '.conversation-selected-interaction'
+        ).evaluateAll(elements => elements.map(element =>
+            element.getAttribute('data-message-id')
+        )));
+        await page.locator('.conversation-selected-interaction').evaluateAll(
+            elements => elements.forEach(element =>
+                element.classList.remove('conversation-selected-interaction')
+            )
+        );
+    }
+
+    assert.deepEqual(refreshHighlights, [[], []]);
+    assert.deepEqual(initialHighlights, ['highlight-0-user']);
+});
+
 test('CONVERSATION-OPEN-LATEST-001 reveals the newest line when the viewer opens at the latest interaction inside a short viewport', async t => {
     const page = await openViewerPage(t);
     const outline = Array.from({ length: 5 }, (_item, index) => ({


### PR DESCRIPTION
## Summary

- Highlight only the selected user input when navigating to a conversation interaction.
- Do not replay the temporary selection highlight during live refreshes.
- Cover initial navigation and repeated refresh behavior in Chromium.

## Verification

- `npm run test-compile`
- `node --test --test-concurrency=1 tests/browser/conversationViewer.test.js`
- `npm run lint`
- `npm run test:behavior-contracts`
- `git diff --check`

## Skill harvest

- `none`: the task exposed no reusable workflow gap beyond existing repository skills and process rules.

No version release is included.