### PR TITLE
Coalesce rapid sidebar workspace updates

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -2211,13 +2211,15 @@
     "owners": [
       "tests/browser/dashboardBootShell.test.js",
       "tests/contract/dashboardBoundaries.test.js",
+      "tests/contract/openProjects/dashboardController.test.js",
       "tests/integration/dashboard/errorRecovery.test.js",
       "tests/integration/dashboard/sessionRuntimeFlow.test.js"
     ],
     "evidence": [
       "src/aiSessions/dashboardController.ts",
       "src/dashboard.ts",
-      "src/dashboard/viewProvider.ts"
+      "src/dashboard/viewProvider.ts",
+      "src/openWorkspaces/dashboardController.ts"
     ]
   },
   {

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "7c666c40b1f23e923ade5b152c804b7cc12c922f",
+        "head": "cfb3451f7a19d86d63213226b61329c088960ccf",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -147,7 +147,8 @@
             "50e1301b07594c5f4de9ee1251dce196378838f2",
             "8b76c02463e8dad6bd9817ce22cc298781572be3",
             "19b2c5759393105a7be519320435c8aa1dc4a2a2",
-            "37078676633b19bf0a6366e97e59ef0ef041b7fd"
+            "37078676633b19bf0a6366e97e59ef0ef041b7fd",
+            "bebadff0d65566b8aba1a84c2c794e90af995e31"
         ]
     },
     "capabilities": [
@@ -926,7 +927,8 @@
                 "ca08c5218352a702fd36d0abbab7ac418663388b",
                 "9111829c98e594f2cde4c24803449e045955fb92",
                 "ce77d458452d77fa64281a3e160c683afa46880e",
-                "bc9af0891c815988a1f74d5fd3c502b2ea8988cd"
+                "bc9af0891c815988a1f74d5fd3c502b2ea8988cd",
+                "cfb3451f7a19d86d63213226b61329c088960ccf"
             ],
             "behaviors": [
                 "RUNTIME-BOOTSTRAP-TMUX-RESTORE-DEFERRAL-001",

--- a/src/openWorkspaces/dashboardController.ts
+++ b/src/openWorkspaces/dashboardController.ts
@@ -58,6 +58,9 @@ export class OpenWorkspaceDashboardController {
     private pinNavigationIdentityById = new Map<string, string>();
     private lastPostedSemanticRevision: string | null = null;
     private deliveryGeneration = 0;
+    private updateFlight: Promise<void> | null = null;
+    private updateRequested = false;
+    private requestedFallbackToFullRefresh = true;
     private readonly fallbackOpenedAtMs: number;
 
     constructor(private readonly options: OpenWorkspaceDashboardControllerOptions) {
@@ -177,6 +180,42 @@ export class OpenWorkspaceDashboardController {
 
     postUpdated(options: { fallbackToFullRefresh?: boolean } = {}): Promise<void> {
         if (!this.options.isVisible()) { return Promise.resolve(); }
+        this.updateRequested = true;
+        this.requestedFallbackToFullRefresh = options.fallbackToFullRefresh !== false;
+        if (this.updateFlight) { return this.updateFlight; }
+
+        let resolveFlight: () => void;
+        let rejectFlight: (error: unknown) => void;
+        const flight = new Promise<void>((resolve, reject) => {
+            resolveFlight = resolve;
+            rejectFlight = reject;
+        });
+        this.updateFlight = flight;
+        void this.drainUpdates(flight, resolveFlight, rejectFlight);
+        return flight;
+    }
+
+    private async drainUpdates(
+        flight: Promise<void>,
+        resolveFlight: () => void,
+        rejectFlight: (error: unknown) => void,
+    ): Promise<void> {
+        try {
+            while (this.updateRequested) {
+                this.updateRequested = false;
+                const fallbackToFullRefresh = this.requestedFallbackToFullRefresh;
+                await this.postLatestUpdate(fallbackToFullRefresh);
+            }
+            if (this.updateFlight === flight) { this.updateFlight = null; }
+            resolveFlight();
+        } catch (error) {
+            if (this.updateFlight === flight) { this.updateFlight = null; }
+            rejectFlight(error);
+        }
+    }
+
+    private postLatestUpdate(fallbackToFullRefresh: boolean): Promise<void> {
+        if (!this.options.isVisible()) { return Promise.resolve(); }
         const semanticRevision = this.getViewSemanticRevision();
         if (semanticRevision === this.lastPostedSemanticRevision) { return Promise.resolve(); }
         const message = buildOpenWorkspacesUpdatedMessage({
@@ -198,7 +237,7 @@ export class OpenWorkspaceDashboardController {
                     message.semanticRevision,
                     deliveryGeneration
                 );
-                if (current && options.fallbackToFullRefresh !== false
+                if (current && !this.updateRequested && fallbackToFullRefresh
                     && this.options.isVisible()) {
                     this.options.refresh('open-workspace-update-not-delivered');
                 }
@@ -209,7 +248,7 @@ export class OpenWorkspaceDashboardController {
                 deliveryGeneration
             );
             this.options.logError('Failed to post OPEN WORKSPACE update message.', error);
-            if (current && options.fallbackToFullRefresh !== false
+            if (current && !this.updateRequested && fallbackToFullRefresh
                 && this.options.isVisible()) {
                 this.options.refresh('open-workspace-update-post-error');
             }

--- a/tests/contract/openProjects/dashboardController.test.js
+++ b/tests/contract/openProjects/dashboardController.test.js
@@ -106,6 +106,37 @@ test('OPEN-OPEN-PROJECT-DASHBOARD-CONTROLLER-001 posts each semantic revision on
     assert.notEqual(posted[0].semanticRevision, posted[1].semanticRevision);
 });
 
+test('WEBVIEW-SIDEBAR-VISIBILITY-RETENTION-001 coalesces rapid OPEN revisions behind one delivery', async () => {
+    const firstDelivery = createDeferred();
+    const posted = [];
+    let groups = [];
+    const controller = new OpenWorkspaceDashboardController(createOptions({
+        getGroups: () => groups,
+        postMessage: message => {
+            posted.push(message);
+            return posted.length === 1 ? firstDelivery.promise : Promise.resolve(true);
+        },
+    }));
+
+    controller.postUpdated();
+    for (let iteration = 1; iteration <= 15; iteration += 1) {
+        groups = [{
+            id: 'work',
+            groupName: `Work ${iteration}`,
+            collapsed: false,
+            projects: [{ id: 'saved', name: 'Saved', path: '/work/saved' }],
+        }];
+        controller.postUpdated();
+    }
+
+    assert.equal(posted.length, 1, 'an unresolved Webview delivery must bound the queue');
+    firstDelivery.resolve(true);
+    await flushAsync();
+
+    assert.equal(posted.length, 2, 'only the latest hidden-epoch state is replayed');
+    assert.deepEqual(posted[1].searchCatalog.savedProjects[0].groupLabels, ['Work 15']);
+});
+
 test('OPEN-ALL-WINDOWS-LIST-001 orders current and navigation cards together without focus-driven movement', () => {
     const current = makeRecord({ name: 'Current', uri: '/work/current' });
     const oldest = makeRecord({ name: 'Oldest', uri: '/work/oldest' });
@@ -321,8 +352,10 @@ test('PROJECT-INCREMENTAL-REFRESH-001 ignores stale and invalidated OPEN deliver
         projects: [{ id: 'saved', name: 'Saved', path: '/work/saved' }],
     }];
     controller.postUpdated();
-    deliveries[1].resolve(true);
     deliveries[0].resolve(false);
+    await flushAsync();
+    assert.equal(deliveries.length, 2);
+    deliveries[1].resolve(true);
     await flushAsync();
 
     groups = [{


### PR DESCRIPTION
## Summary

- serialize Open Workspaces Webview deliveries so only one update is in flight
- collapse rapid sidebar-triggered revisions into one replay of the latest authoritative state
- preserve delivery failure recovery and generation invalidation semantics
- add a regression contract for fifteen rapid revisions behind a pending delivery

## Root cause

Rapid sidebar visibility changes could enqueue every distinct Open Workspaces revision while the previous `postMessage` delivery was unresolved. Under Extension Host pressure, this unbounded concurrent burst amplified render latency and could leave the sidebar appearing stuck.

## Verification

- `npm run test-compile`
- `node --test --test-concurrency=1 tests/contract/openProjects/dashboardController.test.js`
- `node scripts/run-dashboard-webview-checks.js`
- `npm run test:unit`
- `npm run test:integration` (305 passed)
- `npm run lint` (passed with existing repository warnings)
- `npm run test:behavior-contracts`
- `git diff --check origin/main..HEAD`
- packaged and byte-verified `hzcheng.agent-pivot@1.0.3` in the active VS Code Server

## Skill harvest

No skill change was justified. The PR-body correction and build-order risks encountered in this task are already covered by the existing GitHub publication and review skills; they were compliance issues rather than instruction gaps.

## Release

No version release is included.
