### PR TITLE
Fix reusable verification permissions for releases

### DIFF
--- a/.github/workflows/release-vsix.yml
+++ b/.github/workflows/release-vsix.yml
@@ -23,6 +23,8 @@ on:
 
 permissions:
   contents: read
+  issues: read
+  pull-requests: read
 
 jobs:
   verify:

--- a/.github/workflows/scheduled-verification.yml
+++ b/.github/workflows/scheduled-verification.yml
@@ -13,6 +13,8 @@ on:
 
 permissions:
   contents: read
+  issues: read
+  pull-requests: read
 
 jobs:
   verify:

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -1349,6 +1349,9 @@
       "tests/unit/tooling/packageScripts.test.js"
     ],
     "evidence": [
+      ".github/workflows/release-vsix.yml",
+      ".github/workflows/scheduled-verification.yml",
+      "scripts/lib/ciContracts.js",
       "scripts/run-release-packaging-checks.js",
       "scripts/seed-release-packaging-stale-output.js",
       ".vscodeignore"

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "f3e53a32c81c87dc0df919c8f0d3355c37ca69fb",
+        "head": "a407a441bc95df0f24353d5acd80e70a49bfe3b3",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -152,7 +152,8 @@
             "d87bc399ac0e3effb7621f9c12d69591968869d7",
             "cc5526ab22e3066336feeb3c0353ce66b34ce357",
             "1402cc4972bf048edc537f86ab97f3aba7d99815",
-            "b7aad7dcb3018287f688400e995c0d6eca2ea69a"
+            "b7aad7dcb3018287f688400e995c0d6eca2ea69a",
+            "d0b25f1367445497e16c1051a1d63b6cb070bb96"
         ]
     },
     "capabilities": [
@@ -565,7 +566,8 @@
                 "af19b2c9fbab071d6e8004846bff1cdd810836bc",
                 "de9edffbf61d702fb616f2d21a44b39051338973",
                 "a2008ccbea072221e551fded2cc7ef02f8a96ff3",
-                "f7c9e8784b25e5487a482c0799a0bb4d25434f1b"
+                "f7c9e8784b25e5487a482c0799a0bb4d25434f1b",
+                "a407a441bc95df0f24353d5acd80e70a49bfe3b3"
             ],
             "behaviors": [
                 "RELEASE-VSIX-PACKAGING-001",

--- a/scripts/lib/ciContracts.js
+++ b/scripts/lib/ciContracts.js
@@ -188,8 +188,11 @@ function validateScheduledWorkflow(scheduledWorkflow) {
             },
         },
     }, 'scheduled workflow_dispatch must expose only the bounded Host diagnostic input');
-    assert.deepEqual(workflow.permissions, { contents: 'read' },
-        'GitHub scheduled verification workflow permissions must be exactly contents: read');
+    assert.deepEqual(workflow.permissions, {
+        contents: 'read',
+        issues: 'read',
+        'pull-requests': 'read',
+    }, 'GitHub scheduled verification workflow permissions must include every nested read permission');
     assert.ok(isMapping(workflow.jobs),
         'GitHub scheduled verification workflow jobs must be a mapping');
 
@@ -243,8 +246,11 @@ function validateReleaseWorkflow(releaseWorkflow) {
     const workflow = parseVerifyWorkflow(releaseWorkflow);
     assert.ok(isMapping(workflow.jobs),
         'GitHub release workflow jobs must be a mapping');
-    assert.deepEqual(workflow.permissions, { contents: 'read' },
-        'GitHub release workflow permissions must be exactly contents: read');
+    assert.deepEqual(workflow.permissions, {
+        contents: 'read',
+        issues: 'read',
+        'pull-requests': 'read',
+    }, 'GitHub release workflow permissions must include every nested read permission');
     assert.deepEqual(Object.keys(workflow.jobs).sort(), [
         'release',
         'release-extension-host',

--- a/scripts/run-release-packaging-checks.js
+++ b/scripts/run-release-packaging-checks.js
@@ -189,8 +189,11 @@ function validateScheduledWorkflow(workflow) {
             },
         },
     }, 'scheduled workflow_dispatch must expose only the bounded Host diagnostic input');
-    assert.deepStrictEqual(workflow.permissions, { contents: 'read' },
-        'scheduled verification permissions must be exactly contents: read');
+    assert.deepStrictEqual(workflow.permissions, {
+        contents: 'read',
+        issues: 'read',
+        'pull-requests': 'read',
+    }, 'scheduled verification permissions must include every nested read permission');
     assert.ok(isMapping(workflow.jobs), 'scheduled verification jobs must be a mapping');
     assert.deepStrictEqual(Object.keys(workflow.jobs), ['verify', 'scheduled-macos'],
         'scheduled verification must contain only verify and scheduled-macos jobs');
@@ -248,8 +251,11 @@ function validateReleaseWorkflow(workflow) {
     validateReleaseWorkflowSource(yaml.safeDump(workflow));
     assert.ok(isMapping(workflow.on), 'release workflow on must be a mapping');
     assert.ok(isMapping(workflow.jobs), 'release workflow jobs must be a mapping');
-    assert.deepStrictEqual(workflow.permissions, { contents: 'read' },
-        'release workflow top-level permissions must be exactly contents: read');
+    assert.deepStrictEqual(workflow.permissions, {
+        contents: 'read',
+        issues: 'read',
+        'pull-requests': 'read',
+    }, 'release workflow top-level permissions must include every nested read permission');
     assert.strictEqual(containsKey(workflow, 'continue-on-error'), false,
         'release workflow must not define continue-on-error');
     assert.deepStrictEqual(

--- a/tests/unit/tooling/ciContracts.test.js
+++ b/tests/unit/tooling/ciContracts.test.js
@@ -4,6 +4,7 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
 const test = require('node:test');
+const yaml = require('js-yaml');
 const {
     validateQualityGateScripts,
     validateReleaseWorkflow,
@@ -28,6 +29,39 @@ const packageScripts = JSON.parse(fs.readFileSync(
     path.resolve(__dirname, '../../../package.json'),
     'utf8'
 )).scripts;
+
+test('RELEASE-VSIX-PACKAGING-001 reusable verification callers grant every read permission required by nested jobs', () => {
+    const requiredPermissions = {
+        contents: 'read',
+        issues: 'read',
+        'pull-requests': 'read',
+    };
+    for (const [label, source] of [
+        ['release', releaseWorkflow],
+        ['scheduled', scheduledWorkflow],
+    ]) {
+        const workflow = yaml.safeLoad(source, { schema: yaml.JSON_SCHEMA });
+        assert.deepEqual(
+            workflow.permissions,
+            requiredPermissions,
+            `${label} workflow must pass the reusable verification workflow its nested read permissions`
+        );
+    }
+});
+
+test('RELEASE-VSIX-PACKAGING-001 rejects either reusable verification caller losing a nested read permission', () => {
+    const releaseWithoutIssues = releaseWorkflow.replace('  issues: read\n', '');
+    assert.throws(
+        () => validateReleaseWorkflow(releaseWithoutIssues),
+        /release workflow permissions must include every nested read permission/
+    );
+
+    const scheduledWithoutPullRequests = scheduledWorkflow.replace('  pull-requests: read\n', '');
+    assert.throws(
+        () => validateScheduledWorkflow(scheduledWithoutPullRequests),
+        /scheduled verification workflow permissions must include every nested read permission/
+    );
+});
 
 test('RELEASE-VSIX-PACKAGING-001 accepts the unquoted GitHub Actions on key', () => {
     assert.doesNotThrow(() => validateVerifyWorkflow(verifyWorkflow));


### PR DESCRIPTION
## Summary

- pass issues and pull-request read permissions from release and scheduled workflows into the reusable verification workflow
- extend CI contracts so either caller losing a nested permission fails the required Linux quality gate
- restore the Agent Pivot 1.0.4 release path after the zero-job startup failure

## Failure evidence

- Release run 31060403690 ended with startup_failure before creating any jobs
- the reusable verification workflow now contains a merge approval audit job requiring issues: read and pull-requests: read
- both callers previously granted only contents: read

## Testing

- npm run test:ci:linux
- npm run test:release-packaging
- node --test tests/unit/tooling/ciContracts.test.js
- npm run test:behavior-contracts
- git diff --check

Full Linux CI passed locally with 100% changed-line coverage.

## Skill harvest

No skill change was justified. Existing regression, CI failure, review, worktree, capability-audit, and PR publishing skills already require the RED evidence, failure classification, reusable verification, and publication checks used here.