### PR TITLE
Fix local file links in AI Conversation

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -3909,6 +3909,24 @@
     ]
   },
   {
+    "id": "CONVERSATION-LOCAL-FILE-LINKS-001",
+    "domain": "webview",
+    "title": "AI Conversation renders absolute local file references as clickable links and opens their exact line in the workspace host",
+    "priority": "P1",
+    "status": "automated",
+    "owners": [
+      "tests/integration/dashboard/conversationViewer.test.js",
+      "tests/browser/conversationViewer.test.js"
+    ],
+    "evidence": [
+      "src/dashboard.ts",
+      "src/aiSessions/conversation/composition.ts",
+      "src/aiSessions/conversation/markdown.ts",
+      "src/aiSessions/conversation/viewer.ts",
+      "src/webview/conversationViewerScripts.js"
+    ]
+  },
+  {
     "id": "CONVERSATION-THINKING-VISIBILITY-001",
     "domain": "webview",
     "title": "Conversation viewers hide provider thinking by default and render it as collapsed entries when enabled",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "a407a441bc95df0f24353d5acd80e70a49bfe3b3",
+        "head": "f947662341d783a160b3642f6c50f2eb7922522a",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -153,7 +153,8 @@
             "cc5526ab22e3066336feeb3c0353ce66b34ce357",
             "1402cc4972bf048edc537f86ab97f3aba7d99815",
             "b7aad7dcb3018287f688400e995c0d6eca2ea69a",
-            "d0b25f1367445497e16c1051a1d63b6cb070bb96"
+            "d0b25f1367445497e16c1051a1d63b6cb070bb96",
+            "d5145246c3280f22ea6cd90f91df8b67d8e4bbb3"
         ]
     },
     "capabilities": [
@@ -1258,7 +1259,8 @@
                 "6477a5c1eddc60cda384d02cdb5b5a8f59ad5ffe",
                 "7c666c40b1f23e923ade5b152c804b7cc12c922f",
                 "4b933987acaf78c7c625b7a4c0ad9f50c3b690b0",
-                "521648bd80db1d0fc36abd9b9a5d155b98154f66"
+                "521648bd80db1d0fc36abd9b9a5d155b98154f66",
+                "f947662341d783a160b3642f6c50f2eb7922522a"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",
@@ -1297,7 +1299,8 @@
                 "CONVERSATION-PROVIDER-PARITY-001",
                 "CONVERSATION-CHROME-LAYOUT-001",
                 "CONVERSATION-LIVE-UPDATE-JOURNEY-001",
-                "CONVERSATION-NAVIGATION-STATE-001"
+                "CONVERSATION-NAVIGATION-STATE-001",
+                "CONVERSATION-LOCAL-FILE-LINKS-001"
             ],
             "prGates": [
                 "test:ci:linux"

--- a/media/conversationViewerScripts.js
+++ b/media/conversationViewerScripts.js
@@ -323,15 +323,33 @@
 
     function isHttps(value) {
         try {
-            return new URL(value, document.baseURI).protocol === 'https:';
+            return new URL(value).protocol === 'https:';
         } catch (_error) {
             return false;
         }
     }
 
+    function isAbsoluteFileHref(value) {
+        if (!value || value.length > 4096) return false;
+        var decoded;
+        try {
+            decoded = decodeURIComponent(value);
+        } catch (_error) {
+            return false;
+        }
+        return !/[\u0000-\u001f\u007f]/.test(decoded)
+            && decoded.indexOf('?') === -1
+            && decoded.indexOf('#') === -1
+            && (/^\/(?!\/)/.test(decoded) || /^[A-Za-z]:[\\/]/.test(decoded));
+    }
+
+    function isAllowedLinkHref(value) {
+        return isHttps(value) || isAbsoluteFileHref(value);
+    }
+
     window.DOMPurify.addHook('afterSanitizeAttributes', function (node) {
         if (!node.hasAttribute) return;
-        if (node.hasAttribute('href') && !isHttps(
+        if (node.hasAttribute('href') && !isAllowedLinkHref(
             node.getAttribute('href')
         )) {
             node.removeAttribute('href');
@@ -778,11 +796,7 @@
         if (!link || !messages.contains(link)) return;
         event.preventDefault();
         var href = link.getAttribute('href');
-        try {
-            if (new URL(href, document.baseURI).protocol !== 'https:') return;
-        } catch (_error) {
-            return;
-        }
+        if (!isAllowedLinkHref(href)) return;
         post({
             type: 'conversation-viewer-open-link',
             version: 1,

--- a/src/aiSessions/conversation/composition.ts
+++ b/src/aiSessions/conversation/composition.ts
@@ -87,6 +87,7 @@ export interface ConversationCapabilityOptions {
     publish: (message: unknown) => Thenable<boolean>;
     createPanel: typeof vscode.window.createWebviewPanel;
     openExternal: typeof vscode.env.openExternal;
+    openLocalFile?: ConversationViewerOptions['openLocalFile'];
     spawnCodex: typeof childProcess.spawn;
     now: () => number;
     setTimer: typeof setTimeout;
@@ -251,6 +252,7 @@ function createAvailableConversationCapability(
         watch: coordinator.watch.bind(coordinator),
         restoreFocus: target => restoreConversationFocus(options, target),
         openExternal: options.openExternal,
+        openLocalFile: options.openLocalFile,
         mediaUri: getConversationMediaUri,
         showThinking: options.getShowThinking,
         submitPrompt: options.submitPrompt,

--- a/src/aiSessions/conversation/markdown.ts
+++ b/src/aiSessions/conversation/markdown.ts
@@ -46,12 +46,56 @@ const markdown = new MarkdownIt({
     highlight: highlightCode,
 });
 
+const MAX_LOCAL_FILE_LINK_LENGTH = 4096;
+const MAX_LOCAL_FILE_POSITION = 10_000_000;
+
+export interface ConversationLocalFileTarget {
+    fsPath: string;
+    line: number;
+    column: number;
+}
+
+export function parseConversationLocalFileLink(
+    value: string
+): ConversationLocalFileTarget | undefined {
+    if (!value || value.length > MAX_LOCAL_FILE_LINK_LENGTH) {
+        return undefined;
+    }
+    let decoded: string;
+    try {
+        decoded = decodeURIComponent(value);
+    } catch (_error) {
+        return undefined;
+    }
+    if (/[\u0000-\u001f\u007f]/.test(decoded)
+        || decoded.includes('?')
+        || decoded.includes('#')) {
+        return undefined;
+    }
+    const position = decoded.match(/:([1-9]\d{0,7})(?::([1-9]\d{0,7}))?$/);
+    const fsPath = position
+        ? decoded.slice(0, position.index)
+        : decoded;
+    if (!(/^\/(?!\/)/.test(fsPath) || /^[A-Za-z]:[\\/]/.test(fsPath))) {
+        return undefined;
+    }
+    const line = position ? Number(position[1]) : 1;
+    const column = position?.[2] ? Number(position[2]) : 1;
+    if (line > MAX_LOCAL_FILE_POSITION || column > MAX_LOCAL_FILE_POSITION) {
+        return undefined;
+    }
+    return { fsPath, line, column };
+}
+
 markdown.validateLink = (url: string): boolean => {
     try {
-        return new URL(url).protocol === 'https:';
+        if (new URL(url).protocol === 'https:') {
+            return true;
+        }
     } catch (_error) {
-        return false;
+        // Absolute filesystem paths are not URL values.
     }
+    return Boolean(parseConversationLocalFileLink(url));
 };
 
 export function renderConversationMarkdown(value: string): string {

--- a/src/aiSessions/conversation/viewer.ts
+++ b/src/aiSessions/conversation/viewer.ts
@@ -18,7 +18,11 @@ import {
     ConversationOutlineController,
     ConversationViewerOutlineEntry,
 } from './outlineController';
-import { renderConversationMarkdown } from './markdown';
+import {
+    ConversationLocalFileTarget,
+    parseConversationLocalFileLink,
+    renderConversationMarkdown,
+} from './markdown';
 import { parseConversationViewerMessage } from './viewerProtocol';
 import type { ConversationSessionSwitchDirection } from './viewerProtocol';
 import type { ConversationViewerTarget } from './viewerTarget';
@@ -67,6 +71,9 @@ export interface ConversationViewerOptions {
         target: ConversationViewerTarget
     ) => void | PromiseLike<void>;
     openExternal: (uri: vscode.Uri) => Thenable<boolean>;
+    openLocalFile?: (
+        target: ConversationLocalFileTarget
+    ) => PromiseLike<void> | Promise<void> | void;
     mediaUri: (fileName: string) => vscode.Uri;
     showThinking?: () => boolean;
     submitPrompt: (
@@ -634,6 +641,11 @@ export class ConversationViewer implements ConversationViewerApi {
     }
 
     private async openLink(href: string): Promise<void> {
+        const localFile = parseConversationLocalFileLink(href);
+        if (localFile) {
+            await this.options.openLocalFile?.(localFile);
+            return;
+        }
         let parsed: URL;
         try {
             parsed = new URL(href);

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1148,6 +1148,16 @@ async function initializeDashboard(
         publish: message => provider.postMessage(message),
         createPanel: vscode.window.createWebviewPanel,
         openExternal: vscode.env.openExternal,
+        openLocalFile: async targetFile => {
+            const position = new vscode.Position(
+                targetFile.line - 1,
+                targetFile.column - 1
+            );
+            await vscode.window.showTextDocument(
+                vscode.Uri.file(targetFile.fsPath),
+                { selection: new vscode.Range(position, position) }
+            );
+        },
         showWorktreeInSourceControl: (worktreeRoot: string) =>
             showWorktreeInSourceControl(worktreeRoot),
         insertIntoActiveTerminal: async text => {

--- a/src/webview/conversationViewerScripts.js
+++ b/src/webview/conversationViewerScripts.js
@@ -323,15 +323,33 @@
 
     function isHttps(value) {
         try {
-            return new URL(value, document.baseURI).protocol === 'https:';
+            return new URL(value).protocol === 'https:';
         } catch (_error) {
             return false;
         }
     }
 
+    function isAbsoluteFileHref(value) {
+        if (!value || value.length > 4096) return false;
+        var decoded;
+        try {
+            decoded = decodeURIComponent(value);
+        } catch (_error) {
+            return false;
+        }
+        return !/[\u0000-\u001f\u007f]/.test(decoded)
+            && decoded.indexOf('?') === -1
+            && decoded.indexOf('#') === -1
+            && (/^\/(?!\/)/.test(decoded) || /^[A-Za-z]:[\\/]/.test(decoded));
+    }
+
+    function isAllowedLinkHref(value) {
+        return isHttps(value) || isAbsoluteFileHref(value);
+    }
+
     window.DOMPurify.addHook('afterSanitizeAttributes', function (node) {
         if (!node.hasAttribute) return;
-        if (node.hasAttribute('href') && !isHttps(
+        if (node.hasAttribute('href') && !isAllowedLinkHref(
             node.getAttribute('href')
         )) {
             node.removeAttribute('href');
@@ -778,11 +796,7 @@
         if (!link || !messages.contains(link)) return;
         event.preventDefault();
         var href = link.getAttribute('href');
-        try {
-            if (new URL(href, document.baseURI).protocol !== 'https:') return;
-        } catch (_error) {
-            return;
-        }
+        if (!isAllowedLinkHref(href)) return;
         post({
             type: 'conversation-viewer-open-link',
             version: 1,

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -3470,6 +3470,26 @@ test('WEBVIEW-AI-SESSION-CONVERSATION-VIEWER-001 sanitizes hostile HTML, posts e
     );
 });
 
+test('CONVERSATION-LOCAL-FILE-LINKS-001 keeps rendered absolute file links clickable through the Webview', async t => {
+    const firstHref = '/home/example/project/src/localStore.ts:17';
+    const secondHref = '/home/example/project/src/localStore.ts:216';
+    const { page } = await openHostViewerDocument(t, {
+        markdown: `[localStore.ts](${firstHref}) expires records and `
+            + `[localStore.ts](${secondHref}) deletes them.`,
+    });
+
+    const links = page.getByRole('link', { name: 'localStore.ts' });
+    assert.equal(await links.count(), 2);
+    assert.equal(await links.nth(0).getAttribute('href'), firstHref);
+    assert.equal(await links.nth(1).getAttribute('href'), secondHref);
+    await links.nth(1).click();
+    assert.deepEqual((await postedMessages(page)).at(-1), {
+        type: 'conversation-viewer-open-link',
+        version: 1,
+        href: secondHref,
+    });
+});
+
 test('WEBVIEW-AI-SESSION-CONVERSATION-VIEWER-001 preserves ordered numbering across loose multi-paragraph list items', async t => {
     const { page } = await openHostViewerDocument(t, {
         markdown: [

--- a/tests/integration/dashboard/conversationViewer.test.js
+++ b/tests/integration/dashboard/conversationViewer.test.js
@@ -245,6 +245,7 @@ function createViewer(options = {}) {
             openedUris.push(uri.toString());
             return true;
         },
+        openLocalFile: options.openLocalFile,
         insertIntoActiveTerminal: options.insertIntoActiveTerminal,
         followAdjacentConversation: options.followAdjacentConversation,
         mediaUri: fileName => fakeUri(`file:///extension/media/${fileName}`),
@@ -936,6 +937,38 @@ test('CONVERSATION-VIEWER-SECURITY-001 emits a nonce-only CSP and opens only HTT
     }
 
     assert.deepEqual(openedUris, ['https://example.test/safe']);
+});
+
+test('CONVERSATION-LOCAL-FILE-LINKS-001 renders absolute file links and opens their exact line', async () => {
+    const openedFiles = [];
+    const filePath = '/home/example/project/src/localStore.ts';
+    const { viewer, panel } = createViewer({
+        openLocalFile: async targetFile => {
+            openedFiles.push(targetFile);
+        },
+        readPage: async request => ({
+            ...page(request.sessionId, request.anchorInteractionId),
+            messages: [{
+                id: `${request.anchorInteractionId}:assistant`,
+                interactionId: request.anchorInteractionId,
+                role: 'assistant',
+                markdown: `[localStore.ts](${filePath}:17)`,
+            }],
+        }),
+    });
+
+    await viewer.open(target('session-a'));
+
+    assert.match(
+        decodeInitialPublication(panel.webview.html).html,
+        /<a href="\/home\/example\/project\/src\/localStore\.ts:17">localStore\.ts<\/a>/
+    );
+    await panel.receive({
+        type: 'conversation-viewer-open-link',
+        version: 1,
+        href: `${filePath}:17`,
+    });
+    assert.deepEqual(openedFiles, [{ fsPath: filePath, line: 17, column: 1 }]);
 });
 
 test('WEBVIEW-AI-SESSION-CONVERSATION-VIEWER-001 routes one exact selection send to the active terminal inserter', async () => {


### PR DESCRIPTION
## Summary

- render absolute local file references in AI Conversation as clickable links
- open file links in the workspace Extension Host at the requested line and column
- preserve the existing sanitizer boundary for unsafe schemes and relative URLs

## Skill harvest

no skill change — the task corrections were compliance gaps already covered by the regression and worktree skills

## Verification

- `npm run test:ci:linux`
- `npm run test:behavior-contracts` after the capability audit commit
- packaged and installed `hzcheng.agent-pivot@1.0.4` in the active remote VS Code Server with manifest and runtime hash verification
- user manually verified the installed build