### PR TITLE
Redesign AI Conversation telemetry

### DIFF
--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "f947662341d783a160b3642f6c50f2eb7922522a",
+        "head": "1b008ace0a59a6539fc8e70c90d148a369c61fae",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -154,7 +154,8 @@
             "1402cc4972bf048edc537f86ab97f3aba7d99815",
             "b7aad7dcb3018287f688400e995c0d6eca2ea69a",
             "d0b25f1367445497e16c1051a1d63b6cb070bb96",
-            "d5145246c3280f22ea6cd90f91df8b67d8e4bbb3"
+            "d5145246c3280f22ea6cd90f91df8b67d8e4bbb3",
+            "2fd9438ad2707351d11ce71c72c470cbd54412a1"
         ]
     },
     "capabilities": [
@@ -1260,7 +1261,8 @@
                 "7c666c40b1f23e923ade5b152c804b7cc12c922f",
                 "4b933987acaf78c7c625b7a4c0ad9f50c3b690b0",
                 "521648bd80db1d0fc36abd9b9a5d155b98154f66",
-                "f947662341d783a160b3642f6c50f2eb7922522a"
+                "f947662341d783a160b3642f6c50f2eb7922522a",
+                "1b008ace0a59a6539fc8e70c90d148a369c61fae"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",

--- a/media/conversationCommentsScripts.js
+++ b/media/conversationCommentsScripts.js
@@ -224,14 +224,29 @@
                 // The pill doubles as the Comments quick entry; keep it
                 // visible even at zero.
                 telemetryComments.hidden = false;
-                telemetryComments.textContent = state.comments.length > 0
-                    ? 'Comments ' + counts.open + '/' + state.comments.length
-                    : 'Comments 0';
-                telemetryComments.title = counts.open
+                var telemetryCommentValue = telemetryComments.querySelector(
+                    '[data-telemetry-comments-value]'
+                );
+                var visibleCommentCount = state.comments.length > 0
+                    ? counts.open + '/' + state.comments.length
+                    : '0';
+                if (telemetryCommentValue) {
+                    telemetryCommentValue.textContent = visibleCommentCount;
+                } else {
+                    telemetryComments.textContent = visibleCommentCount;
+                }
+                var telemetryCommentLabel = counts.open
                     + ' open of '
                     + state.comments.length
                     + (state.comments.length === 1 ? ' comment' : ' comments')
                     + ' — click to review';
+                telemetryComments.title = telemetryCommentLabel;
+                telemetryComments.setAttribute(
+                    'aria-label', telemetryCommentLabel
+                );
+                telemetryComments.setAttribute(
+                    'data-tooltip', telemetryCommentLabel
+                );
                 if (telemetrySection) {
                     telemetrySection.hidden = false;
                 }

--- a/media/conversationSubagentsScripts.js
+++ b/media/conversationSubagentsScripts.js
@@ -140,12 +140,26 @@
             // visible even at zero.
             telemetrySubagents.hidden = false;
             telemetrySection.hidden = false;
-            telemetrySubagents.textContent = 'Agents ' + runningCount + '/'
-                + lastSubagents.length;
-            telemetrySubagents.title = runningCount + ' running of '
+            var telemetrySubagentsValue = telemetrySubagents.querySelector(
+                '[data-telemetry-subagents-value]'
+            );
+            var visibleSubagents = runningCount + '/' + lastSubagents.length;
+            if (telemetrySubagentsValue) {
+                telemetrySubagentsValue.textContent = visibleSubagents;
+            } else {
+                telemetrySubagents.textContent = visibleSubagents;
+            }
+            var telemetrySubagentsLabel = runningCount + ' running of '
                 + lastSubagents.length
                 + (lastSubagents.length === 1 ? ' subagent' : ' subagents')
                 + ' — click to view';
+            telemetrySubagents.title = telemetrySubagentsLabel;
+            telemetrySubagents.setAttribute(
+                'aria-label', telemetrySubagentsLabel
+            );
+            telemetrySubagents.setAttribute(
+                'data-tooltip', telemetrySubagentsLabel
+            );
         }
 
         function apply(subagents, activeSubagent) {

--- a/media/conversationTelemetry.css
+++ b/media/conversationTelemetry.css
@@ -1,15 +1,20 @@
 .conversation-telemetry {
+    position: relative;
+    z-index: 4;
     display: flex;
     min-width: 0;
+    min-height: 2.75rem;
+    box-sizing: border-box;
     flex: 0 0 auto;
-    flex-wrap: wrap;
-    gap: .25rem .75rem;
+    flex-wrap: nowrap;
+    gap: .45rem;
     align-items: center;
-    padding: .25rem .75rem;
+    padding: .38rem .7rem;
     border-bottom: 1px solid var(--vscode-panel-border);
     color: var(--vscode-descriptionForeground);
     background: var(--vscode-sideBar-background, var(--vscode-editor-background));
-    font-size: .8rem;
+    font-size: .78rem;
+    white-space: nowrap;
 }
 
 .conversation-telemetry[hidden],
@@ -18,68 +23,84 @@
 }
 
 .conversation-telemetry-model,
-.conversation-telemetry-meter {
-    display: flex;
-    min-width: 0;
-    gap: .4rem;
-    align-items: center;
+.conversation-telemetry-worktree,
+.conversation-telemetry-position,
+.conversation-telemetry-subagents,
+.conversation-telemetry-comments {
+    height: 1.75rem;
+    box-sizing: border-box;
+    border: 1px solid color-mix(
+        in srgb,
+        var(--vscode-panel-border) 76%,
+        transparent
+    );
+    border-radius: .55rem;
+    color: var(--vscode-editor-foreground);
+    background: color-mix(
+        in srgb,
+        var(--vscode-editor-foreground) 4%,
+        transparent
+    );
 }
 
-.conversation-telemetry-model strong {
-    max-width: 18rem;
+.conversation-telemetry-model,
+.conversation-telemetry-worktree {
+    display: inline-flex;
+    min-width: 0;
+    flex: 0 1 auto;
+    gap: .35rem;
+    align-items: center;
+    padding: .15rem .48rem;
+}
+
+.conversation-telemetry-model {
+    max-width: 15rem;
+}
+
+.conversation-telemetry-model > svg,
+.conversation-telemetry-worktree > svg {
+    width: .9rem;
+    height: .9rem;
+    flex: 0 0 auto;
+    color: var(
+        --vscode-symbolIcon-methodForeground,
+        var(--vscode-descriptionForeground)
+    );
+}
+
+.conversation-telemetry-model strong,
+.conversation-telemetry-worktree [data-telemetry-worktree-branch] {
+    min-width: 0;
     overflow: hidden;
-    color: var(--vscode-editor-foreground);
     text-overflow: ellipsis;
     white-space: nowrap;
 }
 
-.conversation-telemetry-meter progress {
-    width: 5.5rem;
-    height: .45rem;
-    accent-color: var(--vscode-progressBar-background);
-}
-
-.conversation-telemetry-meter > span:last-child {
-    color: var(--vscode-editor-foreground);
-    white-space: nowrap;
-}
-
-.conversation-telemetry-limits {
-    display: contents;
+.conversation-telemetry-model strong {
+    max-width: 11rem;
+    font-weight: 600;
+    letter-spacing: .01em;
 }
 
 .conversation-telemetry-worktree {
-    display: flex;
-    gap: .3rem;
-    align-items: center;
-    max-width: 16rem;
-    padding: .05rem .45rem;
-    border: 1px solid var(--vscode-panel-border);
-    border-radius: .55rem;
-    color: var(--vscode-editor-foreground);
-    background: transparent;
+    max-width: 13rem;
     font: inherit;
     cursor: pointer;
 }
 
-.conversation-telemetry-worktree:hover {
+.conversation-telemetry-worktree:hover,
+.conversation-telemetry-position:hover,
+.conversation-telemetry-subagents:hover,
+.conversation-telemetry-comments:hover {
     border-color: var(--vscode-focusBorder);
-    background: var(--vscode-toolbar-hoverBackground);
-}
-
-.conversation-telemetry-worktree svg {
-    flex: 0 0 auto;
-    color: var(--vscode-descriptionForeground);
-}
-
-.conversation-telemetry-worktree [data-telemetry-worktree-branch] {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    background: var(
+        --vscode-toolbar-hoverBackground,
+        var(--vscode-list-hoverBackground)
+    );
 }
 
 .conversation-telemetry-worktree-missing {
-    opacity: .6;
+    opacity: .62;
 }
 
 .conversation-telemetry-worktree-missing
@@ -87,23 +108,333 @@
     text-decoration: line-through;
 }
 
+.conversation-telemetry-divider {
+    width: 1px;
+    height: 1.35rem;
+    flex: 0 0 auto;
+    margin: 0 .08rem;
+    background: var(--vscode-panel-border);
+    opacity: .8;
+}
+
+.conversation-telemetry-usage {
+    display: inline-flex;
+    min-width: 0;
+    flex: 0 0 auto;
+    gap: .32rem;
+    align-items: center;
+    color: var(--vscode-editor-foreground);
+}
+
+.conversation-telemetry-usage strong {
+    min-width: 2.25rem;
+    font-size: .76rem;
+    font-variant-numeric: tabular-nums;
+    font-weight: 650;
+    letter-spacing: .01em;
+}
+
+.conversation-telemetry-ring {
+    position: relative;
+    display: inline-grid;
+    width: 1.9rem;
+    height: 1.9rem;
+    flex: 0 0 auto;
+    place-items: center;
+}
+
+.conversation-telemetry-ring-progress {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    overflow: visible;
+    transform: rotate(-90deg);
+}
+
+.conversation-telemetry-ring-track,
+.conversation-telemetry-ring-value {
+    fill: none;
+    stroke-width: 2.7;
+}
+
+.conversation-telemetry-ring-track {
+    stroke: var(--vscode-panel-border);
+    opacity: .6;
+}
+
+.conversation-telemetry-ring-value {
+    stroke: var(
+        --vscode-progressBar-background,
+        var(--vscode-focusBorder)
+    );
+    stroke-linecap: round;
+    transition: stroke-dashoffset 180ms ease-out;
+}
+
+.conversation-telemetry-limit .conversation-telemetry-ring-value {
+    stroke: var(
+        --vscode-charts-yellow,
+        var(--vscode-editorWarning-foreground, #c89a40)
+    );
+}
+
+.conversation-telemetry-ring-icon {
+    position: relative;
+    z-index: 1;
+    width: .82rem;
+    height: .82rem;
+    color: var(--vscode-descriptionForeground);
+}
+
+.conversation-telemetry-context .conversation-telemetry-ring-icon {
+    color: var(
+        --vscode-progressBar-background,
+        var(--vscode-focusBorder)
+    );
+}
+
+.conversation-telemetry-limit .conversation-telemetry-ring-icon {
+    color: var(
+        --vscode-charts-yellow,
+        var(--vscode-editorWarning-foreground, #c89a40)
+    );
+}
+
+.conversation-telemetry-limits {
+    display: contents;
+}
+
+.conversation-telemetry-spacer {
+    min-width: 0;
+    flex: 1 1 auto;
+}
+
 .conversation-telemetry-position,
 .conversation-telemetry-subagents,
 .conversation-telemetry-comments {
     display: inline-flex;
+    min-width: 1.75rem;
+    flex: 0 0 auto;
+    gap: .28rem;
     align-items: center;
-    padding: 0 .5rem;
-    border: 1px solid var(--vscode-panel-border);
-    border-radius: 999px;
-    color: var(--vscode-editor-foreground);
-    background: transparent;
+    justify-content: center;
+    padding: .15rem .42rem;
     font: inherit;
+    font-variant-numeric: tabular-nums;
+    font-weight: 600;
     cursor: pointer;
 }
 
-.conversation-telemetry-position:hover,
-.conversation-telemetry-subagents:hover,
-.conversation-telemetry-comments:hover {
-    border-color: var(--vscode-focusBorder);
-    background: var(--vscode-list-hoverBackground);
+.conversation-telemetry-position > svg,
+.conversation-telemetry-subagents > svg,
+.conversation-telemetry-comments > svg {
+    width: .92rem;
+    height: .92rem;
+    flex: 0 0 auto;
+    color: var(--vscode-descriptionForeground);
+}
+
+.conversation-telemetry-tooltip {
+    position: relative;
+}
+
+.conversation-telemetry-tooltip::before,
+.conversation-telemetry-tooltip::after {
+    position: absolute;
+    z-index: 20;
+    top: calc(100% + .45rem);
+    visibility: hidden;
+    pointer-events: none;
+    opacity: 0;
+    transform: translateY(-.15rem);
+    transition: opacity 100ms ease-out, transform 100ms ease-out;
+}
+
+.conversation-telemetry-tooltip::before {
+    left: .65rem;
+    width: .5rem;
+    height: .5rem;
+    border-top: 1px solid var(--vscode-panel-border);
+    border-left: 1px solid var(--vscode-panel-border);
+    background: var(
+        --vscode-editorHoverWidget-background,
+        var(--vscode-editor-background)
+    );
+    content: '';
+    transform: translateY(-.25rem) rotate(45deg);
+}
+
+.conversation-telemetry-tooltip::after {
+    left: 0;
+    width: max-content;
+    max-width: min(18rem, calc(100vw - 1rem));
+    box-sizing: border-box;
+    padding: .42rem .58rem;
+    border: 1px solid var(--vscode-panel-border);
+    border-radius: .38rem;
+    color: var(
+        --vscode-editorHoverWidget-foreground,
+        var(--vscode-editor-foreground)
+    );
+    background: var(
+        --vscode-editorHoverWidget-background,
+        var(--vscode-editor-background)
+    );
+    box-shadow: 0 .3rem .9rem color-mix(in srgb, #000 20%, transparent);
+    content: attr(data-tooltip);
+    font-size: .76rem;
+    font-weight: 400;
+    line-height: 1.35;
+    text-align: left;
+    white-space: pre-line;
+}
+
+.conversation-telemetry-position::before,
+.conversation-telemetry-position::after,
+.conversation-telemetry-comments::before,
+.conversation-telemetry-comments::after,
+.conversation-telemetry-subagents::before,
+.conversation-telemetry-subagents::after {
+    right: 0;
+    left: auto;
+}
+
+.conversation-telemetry-position::before,
+.conversation-telemetry-comments::before,
+.conversation-telemetry-subagents::before {
+    right: .65rem;
+}
+
+.conversation-telemetry-tooltip:hover::before,
+.conversation-telemetry-tooltip:hover::after,
+.conversation-telemetry-tooltip:focus-visible::before,
+.conversation-telemetry-tooltip:focus-visible::after {
+    visibility: visible;
+    opacity: 1;
+    transform: translateY(0);
+}
+
+.conversation-telemetry-tooltip:hover::before,
+.conversation-telemetry-tooltip:focus-visible::before {
+    transform: translateY(-.25rem) rotate(45deg);
+}
+
+.conversation-telemetry .conversation-telemetry-tooltip:focus-visible {
+    outline: 1px solid var(--vscode-focusBorder);
+    outline-offset: 1px;
+}
+
+@media (max-width: 520px) {
+    .conversation-telemetry {
+        gap: .3rem;
+        padding-right: .4rem;
+        padding-left: .4rem;
+    }
+
+    .conversation-telemetry-model strong {
+        max-width: 6rem;
+    }
+
+    .conversation-telemetry-worktree
+        [data-telemetry-worktree-branch] {
+        max-width: 5rem;
+    }
+}
+
+@media (max-width: 360px) {
+    .conversation-telemetry {
+        min-height: 2.35rem;
+        gap: .18rem;
+        padding: .25rem;
+    }
+
+    .conversation-telemetry-model,
+    .conversation-telemetry-worktree,
+    .conversation-telemetry-position,
+    .conversation-telemetry-subagents,
+    .conversation-telemetry-comments {
+        height: 1.65rem;
+    }
+
+    .conversation-telemetry-model,
+    .conversation-telemetry-worktree {
+        width: 1.65rem;
+        flex-basis: 1.65rem;
+        justify-content: center;
+        padding: 0;
+    }
+
+    .conversation-telemetry-model strong,
+    .conversation-telemetry-worktree
+        [data-telemetry-worktree-branch],
+    .conversation-telemetry-usage strong {
+        display: none;
+    }
+
+    .conversation-telemetry-divider {
+        margin: 0;
+    }
+
+    .conversation-telemetry-ring {
+        width: 1.65rem;
+        height: 1.65rem;
+    }
+
+    .conversation-telemetry-position,
+    .conversation-telemetry-subagents,
+    .conversation-telemetry-comments {
+        min-width: 1.65rem;
+        gap: .18rem;
+        padding: .1rem .25rem;
+    }
+}
+
+@media (max-width: 320px) {
+    .conversation-telemetry-model {
+        display: none;
+    }
+}
+
+@media (max-width: 220px) {
+    .conversation-telemetry-worktree,
+    .conversation-telemetry-divider {
+        display: none;
+    }
+}
+
+@media (forced-colors: active) {
+    .conversation-telemetry-model,
+    .conversation-telemetry-worktree,
+    .conversation-telemetry-position,
+    .conversation-telemetry-subagents,
+    .conversation-telemetry-comments {
+        border-color: ButtonText;
+        color: ButtonText;
+        background: Canvas;
+    }
+
+    .conversation-telemetry-ring-track {
+        stroke: GrayText;
+        opacity: 1;
+    }
+
+    .conversation-telemetry-ring-value,
+    .conversation-telemetry-limit .conversation-telemetry-ring-value {
+        stroke: Highlight;
+    }
+
+    .conversation-telemetry-ring-icon,
+    .conversation-telemetry-context .conversation-telemetry-ring-icon,
+    .conversation-telemetry-limit .conversation-telemetry-ring-icon {
+        color: ButtonText;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .conversation-telemetry-ring-value,
+    .conversation-telemetry-tooltip::before,
+    .conversation-telemetry-tooltip::after {
+        transition: none;
+    }
 }

--- a/media/conversationTelemetryScripts.js
+++ b/media/conversationTelemetryScripts.js
@@ -124,6 +124,68 @@
             return Math.ceil(remainingHours / 24) + 'd';
         }
 
+        function setTooltip(element, label) {
+            element.title = label;
+            element.setAttribute('aria-label', label);
+            element.setAttribute('data-tooltip', label);
+        }
+
+        function setRingProgress(circle, percent) {
+            var usedPercent = Math.max(0, Math.min(100, percent));
+            circle.setAttribute('stroke-dasharray', '100');
+            circle.setAttribute(
+                'stroke-dashoffset',
+                String(Math.round((100 - usedPercent) * 10) / 10)
+            );
+        }
+
+        function createLimitRing(limit) {
+            var usedPercent = Math.max(0, Math.min(100, limit.usedPercent));
+            var visibleValue = Math.round(usedPercent) + '%';
+            var details = limit.label + ' · ' + visibleValue + ' used';
+            if (limit.resetsAt) {
+                details += ' · resets in ' + compactResetTime(limit.resetsAt);
+            }
+            var meter = document.createElement('div');
+            meter.className = 'conversation-telemetry-usage '
+                + 'conversation-telemetry-limit conversation-telemetry-tooltip';
+            meter.setAttribute('data-telemetry-limit', '');
+            meter.setAttribute('data-telemetry-limit-id', limit.id);
+            meter.setAttribute('role', 'meter');
+            meter.tabIndex = 0;
+            meter.setAttribute('aria-valuemin', '0');
+            meter.setAttribute('aria-valuemax', '100');
+            meter.setAttribute('aria-valuenow', String(usedPercent));
+            setTooltip(meter, details);
+
+            var ring = document.createElement('span');
+            ring.className = 'conversation-telemetry-ring';
+            ring.setAttribute('aria-hidden', 'true');
+            ring.innerHTML = '<svg class="conversation-telemetry-ring-progress"'
+                + ' viewBox="0 0 36 36"><circle'
+                + ' class="conversation-telemetry-ring-track" cx="18" cy="18"'
+                + ' r="15.5" pathLength="100"></circle><circle'
+                + ' class="conversation-telemetry-ring-value"'
+                + ' data-telemetry-limit-progress cx="18" cy="18" r="15.5"'
+                + ' pathLength="100"></circle></svg><svg'
+                + ' class="conversation-telemetry-ring-icon" viewBox="0 0 16 16"'
+                + ' aria-hidden="true" fill="none" stroke="currentColor"'
+                + ' stroke-width="1.35" stroke-linecap="round"'
+                + ' stroke-linejoin="round"><rect x="2.5" y="3.5"'
+                + ' width="11" height="10" rx="2"></rect><path'
+                + ' d="M5 2v3M11 2v3M2.5 6.5h11"></path><path'
+                + ' d="M6.3 9h3.4l-2 3"></path></svg>';
+            setRingProgress(
+                ring.querySelector('[data-telemetry-limit-progress]'),
+                usedPercent
+            );
+            var value = document.createElement('strong');
+            value.setAttribute('data-telemetry-limit-value', '');
+            value.textContent = visibleValue;
+            meter.append(ring, value);
+            return meter;
+        }
+
         function applyTelemetry(message) {
             if (!exactKeys(
                 message,
@@ -154,6 +216,10 @@
             if (!telemetry) {
                 // The quick-entry pills keep the bar visible even without
                 // usage data; only the usage widgets stay hidden.
+                telemetryModel.hidden = true;
+                telemetryWorktree.hidden = true;
+                telemetryContext.hidden = true;
+                telemetryLimits.replaceChildren();
                 telemetryRoot.hidden = false;
                 restoreViewport(
                     readingAnchor,
@@ -163,6 +229,10 @@
             }
             telemetryModel.hidden = !telemetry.model;
             telemetryModelValue.textContent = telemetry.model || '';
+            setTooltip(
+                telemetryModel,
+                telemetry.model ? 'Model · ' + telemetry.model : 'Model'
+            );
             var worktree = telemetry.worktree;
             telemetryWorktree.hidden = !worktree;
             if (worktree) {
@@ -175,11 +245,13 @@
                     'conversation-telemetry-worktree-missing',
                     !!worktree.missing
                 );
-                telemetryWorktree.title = worktree.missing
+                var worktreeTitle = worktree.missing
                     ? 'Worktree path no longer exists: '
-                        + worktree.worktreeRoot
+                        + worktree.worktreeRoot + ' (branch ' + worktree.branch + ')'
                     : 'Working in worktree: ' + worktree.worktreeRoot
+                        + ' (branch ' + worktree.branch + ')'
                         + ' · Click to show changes in Source Control';
+                setTooltip(telemetryWorktree, worktreeTitle);
             }
             telemetryContext.hidden = !telemetry.context;
             if (telemetry.context) {
@@ -188,33 +260,19 @@
                     telemetry.context.usedTokens
                         / telemetry.context.maxTokens * 100
                 ));
-                telemetryContextProgress.max = telemetry.context.maxTokens;
-                telemetryContextProgress.value = telemetry.context.usedTokens;
-                telemetryContextValue.textContent = Math.round(percent) + '% · '
-                    + compactTokens(telemetry.context.usedTokens) + ' / '
-                    + compactTokens(telemetry.context.maxTokens);
+                var visibleContext = Math.round(percent) + '%';
+                var contextDetails = 'Context window · ' + visibleContext
+                    + ' used\n' + compactTokens(telemetry.context.usedTokens)
+                    + ' / ' + compactTokens(telemetry.context.maxTokens)
+                    + ' tokens';
+                setRingProgress(telemetryContextProgress, percent);
+                telemetryContext.setAttribute('aria-valuenow', String(percent));
+                setTooltip(telemetryContext, contextDetails);
+                telemetryContextValue.textContent = visibleContext;
             }
             telemetryLimits.replaceChildren();
             telemetry.rateLimits.forEach(function (limit) {
-                var meter = document.createElement('div');
-                meter.className = 'conversation-telemetry-meter';
-                var label = document.createElement('span');
-                label.textContent = limit.label;
-                var progress = document.createElement('progress');
-                progress.max = 100;
-                progress.value = limit.usedPercent;
-                progress.setAttribute('aria-label', limit.label + ' usage');
-                var value = document.createElement('span');
-                var text = Math.round(100 - limit.usedPercent) + '% left';
-                if (limit.resetsAt) {
-                    text += ' · resets in ' + compactResetTime(limit.resetsAt);
-                    value.title = new Date(
-                        limit.resetsAt * 1000
-                    ).toLocaleString();
-                }
-                value.textContent = text;
-                meter.append(label, progress, value);
-                telemetryLimits.appendChild(meter);
+                telemetryLimits.appendChild(createLimitRing(limit));
             });
             telemetryRoot.hidden = false;
             restoreViewport(readingAnchor, previousScrollTop);

--- a/media/conversationViewerScripts.js
+++ b/media/conversationViewerScripts.js
@@ -607,7 +607,16 @@
     function updatePosition(message) {
         var total = message.totalInputs.toLocaleString();
         if (message.partial) total += '+';
-        position.textContent = 'Input ' + message.selectedInput + ' of ' + total;
+        var label = 'Input ' + message.selectedInput + ' of ' + total;
+        var value = position.querySelector('[data-conversation-position-value]');
+        if (value) {
+            value.textContent = message.selectedInput + '/' + total;
+            position.title = label + ' — click to open the outline';
+            position.setAttribute('aria-label', position.title);
+            position.setAttribute('data-tooltip', position.title);
+        } else {
+            position.textContent = label;
+        }
     }
 
     function centerInMessageViewport(element) {

--- a/src/aiSessions/conversation/conversationTelemetryController.ts
+++ b/src/aiSessions/conversation/conversationTelemetryController.ts
@@ -134,6 +134,64 @@ const WORKTREE_ICON_SVG = '<svg viewBox="0 0 16 16" width="11" height="11"'
     + '<circle cx="4.5" cy="12.5" r="1.8"/><circle cx="11.5" cy="5.5" r="1.8"/>'
     + '<path d="M4.5 5.3v5.4M11.5 7.3c0 2.4-2.6 2.8-4.7 3"/></svg>';
 
+const MODEL_ICON_SVG = '<svg viewBox="0 0 16 16" aria-hidden="true"'
+    + ' fill="none" stroke="currentColor" stroke-width="1.35"'
+    + ' stroke-linecap="round" stroke-linejoin="round">'
+    + '<rect x="4" y="4" width="8" height="8" rx="2"/>'
+    + '<path d="M6.5 1.8v2.1M9.5 1.8v2.1M6.5 12.1v2.1M9.5 12.1v2.1M1.8 6.5h2.1M12.1 6.5h2.1M1.8 9.5h2.1M12.1 9.5h2.1"/>'
+    + '<path d="m6.5 8 1 1 2-2"/></svg>';
+
+const CONTEXT_ICON_SVG = '<svg class="conversation-telemetry-ring-icon"'
+    + ' viewBox="0 0 16 16" aria-hidden="true" fill="none"'
+    + ' stroke="currentColor" stroke-width="1.45" stroke-linecap="round">'
+    + '<path d="M5.5 3H4a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h1.5M10.5 3H12a1 1 0 0 1 1 1v8a1 1 0 0 1-1 1h-1.5"/>'
+    + '<path d="M6.5 6.2 8.3 8l-1.8 1.8"/></svg>';
+
+const LIMIT_ICON_SVG = '<svg class="conversation-telemetry-ring-icon"'
+    + ' viewBox="0 0 16 16" aria-hidden="true" fill="none"'
+    + ' stroke="currentColor" stroke-width="1.35" stroke-linecap="round"'
+    + ' stroke-linejoin="round"><rect x="2.5" y="3.5" width="11"'
+    + ' height="10" rx="2"/><path d="M5 2v3M11 2v3M2.5 6.5h11"/>'
+    + '<path d="M6.3 9h3.4l-2 3"/></svg>';
+
+const POSITION_ICON_SVG = '<svg viewBox="0 0 16 16" aria-hidden="true"'
+    + ' fill="none" stroke="currentColor" stroke-width="1.35"'
+    + ' stroke-linecap="round"><path d="M3 3.5h10M3 8h7M3 12.5h5"/>'
+    + '<circle cx="12.2" cy="11.8" r="1.8"/></svg>';
+
+const COMMENTS_ICON_SVG = '<svg viewBox="0 0 16 16" aria-hidden="true"'
+    + ' fill="none" stroke="currentColor" stroke-width="1.35"'
+    + ' stroke-linejoin="round"><path d="M3.2 3h9.6A1.2 1.2 0 0 1 14 4.2v6.1a1.2 1.2 0 0 1-1.2 1.2H7l-3.4 2v-2H3.2A1.2 1.2 0 0 1 2 10.3V4.2A1.2 1.2 0 0 1 3.2 3Z"/>'
+    + '<path d="M5 6.2h6M5 8.7h4"/></svg>';
+
+const SUBAGENTS_ICON_SVG = '<svg viewBox="0 0 16 16" aria-hidden="true"'
+    + ' fill="none" stroke="currentColor" stroke-width="1.35">'
+    + '<circle cx="8" cy="3" r="1.7"/><circle cx="3.5" cy="12.5" r="1.7"/>'
+    + '<circle cx="12.5" cy="12.5" r="1.7"/><path d="M8 4.7v3M8 7.7 4.5 11M8 7.7l3.5 3.3"/></svg>';
+
+function clampPercent(value: number): number {
+    return Math.max(0, Math.min(100, value));
+}
+
+function renderProgressRing(
+    progressAttribute: string,
+    percent: number,
+    icon: string
+): string {
+    const rounded = Math.round(clampPercent(percent) * 10) / 10;
+    const offset = Math.round((100 - rounded) * 10) / 10;
+    return `<span class="conversation-telemetry-ring" aria-hidden="true">
+        <svg class="conversation-telemetry-ring-progress" viewBox="0 0 36 36">
+            <circle class="conversation-telemetry-ring-track"
+                cx="18" cy="18" r="15.5" pathLength="100"></circle>
+            <circle class="conversation-telemetry-ring-value"
+                ${progressAttribute} cx="18" cy="18" r="15.5"
+                pathLength="100" stroke-dasharray="100"
+                stroke-dashoffset="${offset}"></circle>
+        </svg>${icon}
+    </span>`;
+}
+
 export function renderConversationTelemetry(
     telemetry: ConversationTelemetry | undefined
 ): string {
@@ -144,28 +202,33 @@ export function renderConversationTelemetry(
     const limits = telemetry?.rateLimits || [];
     const context = telemetry?.context;
     const contextPercent = context
-        ? Math.max(0, Math.min(
-            100,
-            context.usedTokens / context.maxTokens * 100
-        ))
+        ? clampPercent(context.usedTokens / context.maxTokens * 100)
         : 0;
+    const contextValue = `${Math.round(contextPercent)}%`;
+    const contextDetails = context
+        ? `Context window · ${contextValue} used\n${formatTokenCount(
+            context.usedTokens
+        )} / ${formatTokenCount(context.maxTokens)} tokens`
+        : 'Context window';
     const limitMarkup = limits.map(limit => {
-        const remaining = Math.max(0, 100 - limit.usedPercent);
+        const usedPercent = clampPercent(limit.usedPercent);
+        const visibleValue = `${Math.round(usedPercent)}%`;
         const reset = limit.resetsAt
             ? ` · resets in ${formatResetTime(limit.resetsAt)}`
             : '';
-        const resetTitle = limit.resetsAt
-            ? ` title="${escapeAttribute(
-                new Date(limit.resetsAt * 1000).toLocaleString()
-            )}"`
-            : '';
-        return `<div class="conversation-telemetry-meter">
-            <span>${escapeHtml(limit.label)}</span>
-            <progress max="100" value="${limit.usedPercent}"
-                aria-label="${escapeAttribute(`${limit.label} usage`)}"></progress>
-            <span${resetTitle}>${escapeHtml(
-                `${Math.round(remaining)}% left${reset}`
-            )}</span>
+        const details = `${limit.label} · ${visibleValue} used${reset}`;
+        return `<div class="conversation-telemetry-usage conversation-telemetry-limit conversation-telemetry-tooltip"
+            data-telemetry-limit data-telemetry-limit-id="${escapeAttribute(limit.id)}"
+            role="meter" tabindex="0" aria-valuemin="0" aria-valuemax="100"
+            aria-valuenow="${usedPercent}" aria-label="${escapeAttribute(details)}"
+            title="${escapeAttribute(details)}"
+            data-tooltip="${escapeAttribute(details)}">
+            ${renderProgressRing(
+                'data-telemetry-limit-progress',
+                usedPercent,
+                LIMIT_ICON_SVG
+            )}
+            <strong data-telemetry-limit-value>${escapeHtml(visibleValue)}</strong>
         </div>`;
     }).join('');
     const worktreeTitle = worktree
@@ -173,58 +236,80 @@ export function renderConversationTelemetry(
             ? `Worktree path no longer exists: ${worktree.worktreeRoot} (branch ${worktree.branch})`
             : `Working in worktree: ${worktree.worktreeRoot} (branch ${worktree.branch}) · Click to show changes in Source Control`
         : '';
+    const modelTitle = telemetry?.model
+        ? `Model · ${telemetry.model}`
+        : 'Model';
     return `<section class="conversation-telemetry"
         data-conversation-telemetry aria-label="Session usage">
+        <div class="conversation-telemetry-model conversation-telemetry-tooltip"
+            data-telemetry-model tabindex="0"
+            aria-label="${escapeAttribute(modelTitle)}"
+            title="${escapeAttribute(modelTitle)}"
+            data-tooltip="${escapeAttribute(modelTitle)}"${hasModel ? '' : ' hidden'}>
+            ${MODEL_ICON_SVG}
+            <strong data-telemetry-model-value>${escapeHtml(
+                telemetry?.model || ''
+            )}</strong>
+        </div>
         <button type="button"
-            class="conversation-telemetry-worktree${worktree?.missing
+            class="conversation-telemetry-worktree conversation-telemetry-tooltip${worktree?.missing
                 ? ' conversation-telemetry-worktree-missing'
                 : ''}"
             data-telemetry-worktree
             data-worktree-root="${escapeAttribute(
                 worktree?.worktreeRoot || ''
             )}"
-            title="${escapeAttribute(worktreeTitle)}"${hasWorktree
+            aria-label="${escapeAttribute(worktreeTitle)}"
+            title="${escapeAttribute(worktreeTitle)}"
+            data-tooltip="${escapeAttribute(worktreeTitle)}"${hasWorktree
                 ? ''
                 : ' hidden'}>
             ${WORKTREE_ICON_SVG}<span data-telemetry-worktree-branch>${escapeHtml(
                 worktree?.branch || ''
             )}</span>
         </button>
-        <div class="conversation-telemetry-model"
-            data-telemetry-model${hasModel ? '' : ' hidden'}>
-            <span>Model</span>
-            <strong data-telemetry-model-value>${escapeHtml(
-                telemetry?.model || ''
-            )}</strong>
-        </div>
-        <div class="conversation-telemetry-meter"
-            data-telemetry-context${hasContext ? '' : ' hidden'}>
-            <span>Context</span>
-            <progress data-telemetry-context-progress
-                max="${context?.maxTokens || 1}"
-                value="${context?.usedTokens || 0}"
-                aria-label="Context window usage"></progress>
-            <span data-telemetry-context-value>${context
-                ? escapeHtml(
-                    `${Math.round(contextPercent)}% · ${formatTokenCount(
-                        context.usedTokens
-                    )} / ${formatTokenCount(context.maxTokens)}`
-                )
-                : ''}</span>
+        <span class="conversation-telemetry-divider" aria-hidden="true"></span>
+        <div class="conversation-telemetry-usage conversation-telemetry-context conversation-telemetry-tooltip"
+            data-telemetry-context role="meter" aria-valuemin="0"
+            tabindex="0" aria-valuemax="100" aria-valuenow="${contextPercent}"
+            aria-label="${escapeAttribute(contextDetails)}"
+            title="${escapeAttribute(contextDetails)}"
+            data-tooltip="${escapeAttribute(contextDetails)}"${hasContext ? '' : ' hidden'}>
+            ${renderProgressRing(
+                'data-telemetry-context-progress',
+                contextPercent,
+                CONTEXT_ICON_SVG
+            )}
+            <strong data-telemetry-context-value>${hasContext
+                ? escapeHtml(contextValue)
+                : ''}</strong>
         </div>
         <div class="conversation-telemetry-limits"
             data-telemetry-limits>${limitMarkup}</div>
+        <span class="conversation-telemetry-spacer" aria-hidden="true"></span>
         <button type="button"
-            class="conversation-telemetry-position"
+            class="conversation-telemetry-position conversation-telemetry-tooltip"
             data-conversation-position
-            title="Jump to the current input in the outline">Input 0 of 0</button>
+            aria-label="Input 0 of 0 — click to open the outline"
+            title="Input 0 of 0 — click to open the outline"
+            data-tooltip="Input 0 of 0 — click to open the outline">
+            ${POSITION_ICON_SVG}<span data-conversation-position-value>0/0</span>
+        </button>
         <button type="button"
-            class="conversation-telemetry-comments"
+            class="conversation-telemetry-comments conversation-telemetry-tooltip"
             data-telemetry-comments
-            title="0 comments — click to review">Comments 0</button>
+            aria-label="0 comments — click to review"
+            title="0 comments — click to review"
+            data-tooltip="0 comments — click to review">
+            ${COMMENTS_ICON_SVG}<span data-telemetry-comments-value>0</span>
+        </button>
         <button type="button"
-            class="conversation-telemetry-subagents"
+            class="conversation-telemetry-subagents conversation-telemetry-tooltip"
             data-telemetry-subagents
-            title="0 running of 0 subagents — click to view">Agents 0/0</button>
+            aria-label="0 running of 0 subagents — click to view"
+            title="0 running of 0 subagents — click to view"
+            data-tooltip="0 running of 0 subagents — click to view">
+            ${SUBAGENTS_ICON_SVG}<span data-telemetry-subagents-value>0/0</span>
+        </button>
     </section>`;
 }

--- a/src/webview/conversationCommentsScripts.js
+++ b/src/webview/conversationCommentsScripts.js
@@ -224,14 +224,29 @@
                 // The pill doubles as the Comments quick entry; keep it
                 // visible even at zero.
                 telemetryComments.hidden = false;
-                telemetryComments.textContent = state.comments.length > 0
-                    ? 'Comments ' + counts.open + '/' + state.comments.length
-                    : 'Comments 0';
-                telemetryComments.title = counts.open
+                var telemetryCommentValue = telemetryComments.querySelector(
+                    '[data-telemetry-comments-value]'
+                );
+                var visibleCommentCount = state.comments.length > 0
+                    ? counts.open + '/' + state.comments.length
+                    : '0';
+                if (telemetryCommentValue) {
+                    telemetryCommentValue.textContent = visibleCommentCount;
+                } else {
+                    telemetryComments.textContent = visibleCommentCount;
+                }
+                var telemetryCommentLabel = counts.open
                     + ' open of '
                     + state.comments.length
                     + (state.comments.length === 1 ? ' comment' : ' comments')
                     + ' — click to review';
+                telemetryComments.title = telemetryCommentLabel;
+                telemetryComments.setAttribute(
+                    'aria-label', telemetryCommentLabel
+                );
+                telemetryComments.setAttribute(
+                    'data-tooltip', telemetryCommentLabel
+                );
                 if (telemetrySection) {
                     telemetrySection.hidden = false;
                 }

--- a/src/webview/conversationSubagentsScripts.js
+++ b/src/webview/conversationSubagentsScripts.js
@@ -140,12 +140,26 @@
             // visible even at zero.
             telemetrySubagents.hidden = false;
             telemetrySection.hidden = false;
-            telemetrySubagents.textContent = 'Agents ' + runningCount + '/'
-                + lastSubagents.length;
-            telemetrySubagents.title = runningCount + ' running of '
+            var telemetrySubagentsValue = telemetrySubagents.querySelector(
+                '[data-telemetry-subagents-value]'
+            );
+            var visibleSubagents = runningCount + '/' + lastSubagents.length;
+            if (telemetrySubagentsValue) {
+                telemetrySubagentsValue.textContent = visibleSubagents;
+            } else {
+                telemetrySubagents.textContent = visibleSubagents;
+            }
+            var telemetrySubagentsLabel = runningCount + ' running of '
                 + lastSubagents.length
                 + (lastSubagents.length === 1 ? ' subagent' : ' subagents')
                 + ' — click to view';
+            telemetrySubagents.title = telemetrySubagentsLabel;
+            telemetrySubagents.setAttribute(
+                'aria-label', telemetrySubagentsLabel
+            );
+            telemetrySubagents.setAttribute(
+                'data-tooltip', telemetrySubagentsLabel
+            );
         }
 
         function apply(subagents, activeSubagent) {

--- a/src/webview/conversationTelemetryScripts.js
+++ b/src/webview/conversationTelemetryScripts.js
@@ -124,6 +124,68 @@
             return Math.ceil(remainingHours / 24) + 'd';
         }
 
+        function setTooltip(element, label) {
+            element.title = label;
+            element.setAttribute('aria-label', label);
+            element.setAttribute('data-tooltip', label);
+        }
+
+        function setRingProgress(circle, percent) {
+            var usedPercent = Math.max(0, Math.min(100, percent));
+            circle.setAttribute('stroke-dasharray', '100');
+            circle.setAttribute(
+                'stroke-dashoffset',
+                String(Math.round((100 - usedPercent) * 10) / 10)
+            );
+        }
+
+        function createLimitRing(limit) {
+            var usedPercent = Math.max(0, Math.min(100, limit.usedPercent));
+            var visibleValue = Math.round(usedPercent) + '%';
+            var details = limit.label + ' · ' + visibleValue + ' used';
+            if (limit.resetsAt) {
+                details += ' · resets in ' + compactResetTime(limit.resetsAt);
+            }
+            var meter = document.createElement('div');
+            meter.className = 'conversation-telemetry-usage '
+                + 'conversation-telemetry-limit conversation-telemetry-tooltip';
+            meter.setAttribute('data-telemetry-limit', '');
+            meter.setAttribute('data-telemetry-limit-id', limit.id);
+            meter.setAttribute('role', 'meter');
+            meter.tabIndex = 0;
+            meter.setAttribute('aria-valuemin', '0');
+            meter.setAttribute('aria-valuemax', '100');
+            meter.setAttribute('aria-valuenow', String(usedPercent));
+            setTooltip(meter, details);
+
+            var ring = document.createElement('span');
+            ring.className = 'conversation-telemetry-ring';
+            ring.setAttribute('aria-hidden', 'true');
+            ring.innerHTML = '<svg class="conversation-telemetry-ring-progress"'
+                + ' viewBox="0 0 36 36"><circle'
+                + ' class="conversation-telemetry-ring-track" cx="18" cy="18"'
+                + ' r="15.5" pathLength="100"></circle><circle'
+                + ' class="conversation-telemetry-ring-value"'
+                + ' data-telemetry-limit-progress cx="18" cy="18" r="15.5"'
+                + ' pathLength="100"></circle></svg><svg'
+                + ' class="conversation-telemetry-ring-icon" viewBox="0 0 16 16"'
+                + ' aria-hidden="true" fill="none" stroke="currentColor"'
+                + ' stroke-width="1.35" stroke-linecap="round"'
+                + ' stroke-linejoin="round"><rect x="2.5" y="3.5"'
+                + ' width="11" height="10" rx="2"></rect><path'
+                + ' d="M5 2v3M11 2v3M2.5 6.5h11"></path><path'
+                + ' d="M6.3 9h3.4l-2 3"></path></svg>';
+            setRingProgress(
+                ring.querySelector('[data-telemetry-limit-progress]'),
+                usedPercent
+            );
+            var value = document.createElement('strong');
+            value.setAttribute('data-telemetry-limit-value', '');
+            value.textContent = visibleValue;
+            meter.append(ring, value);
+            return meter;
+        }
+
         function applyTelemetry(message) {
             if (!exactKeys(
                 message,
@@ -154,6 +216,10 @@
             if (!telemetry) {
                 // The quick-entry pills keep the bar visible even without
                 // usage data; only the usage widgets stay hidden.
+                telemetryModel.hidden = true;
+                telemetryWorktree.hidden = true;
+                telemetryContext.hidden = true;
+                telemetryLimits.replaceChildren();
                 telemetryRoot.hidden = false;
                 restoreViewport(
                     readingAnchor,
@@ -163,6 +229,10 @@
             }
             telemetryModel.hidden = !telemetry.model;
             telemetryModelValue.textContent = telemetry.model || '';
+            setTooltip(
+                telemetryModel,
+                telemetry.model ? 'Model · ' + telemetry.model : 'Model'
+            );
             var worktree = telemetry.worktree;
             telemetryWorktree.hidden = !worktree;
             if (worktree) {
@@ -175,11 +245,13 @@
                     'conversation-telemetry-worktree-missing',
                     !!worktree.missing
                 );
-                telemetryWorktree.title = worktree.missing
+                var worktreeTitle = worktree.missing
                     ? 'Worktree path no longer exists: '
-                        + worktree.worktreeRoot
+                        + worktree.worktreeRoot + ' (branch ' + worktree.branch + ')'
                     : 'Working in worktree: ' + worktree.worktreeRoot
+                        + ' (branch ' + worktree.branch + ')'
                         + ' · Click to show changes in Source Control';
+                setTooltip(telemetryWorktree, worktreeTitle);
             }
             telemetryContext.hidden = !telemetry.context;
             if (telemetry.context) {
@@ -188,33 +260,19 @@
                     telemetry.context.usedTokens
                         / telemetry.context.maxTokens * 100
                 ));
-                telemetryContextProgress.max = telemetry.context.maxTokens;
-                telemetryContextProgress.value = telemetry.context.usedTokens;
-                telemetryContextValue.textContent = Math.round(percent) + '% · '
-                    + compactTokens(telemetry.context.usedTokens) + ' / '
-                    + compactTokens(telemetry.context.maxTokens);
+                var visibleContext = Math.round(percent) + '%';
+                var contextDetails = 'Context window · ' + visibleContext
+                    + ' used\n' + compactTokens(telemetry.context.usedTokens)
+                    + ' / ' + compactTokens(telemetry.context.maxTokens)
+                    + ' tokens';
+                setRingProgress(telemetryContextProgress, percent);
+                telemetryContext.setAttribute('aria-valuenow', String(percent));
+                setTooltip(telemetryContext, contextDetails);
+                telemetryContextValue.textContent = visibleContext;
             }
             telemetryLimits.replaceChildren();
             telemetry.rateLimits.forEach(function (limit) {
-                var meter = document.createElement('div');
-                meter.className = 'conversation-telemetry-meter';
-                var label = document.createElement('span');
-                label.textContent = limit.label;
-                var progress = document.createElement('progress');
-                progress.max = 100;
-                progress.value = limit.usedPercent;
-                progress.setAttribute('aria-label', limit.label + ' usage');
-                var value = document.createElement('span');
-                var text = Math.round(100 - limit.usedPercent) + '% left';
-                if (limit.resetsAt) {
-                    text += ' · resets in ' + compactResetTime(limit.resetsAt);
-                    value.title = new Date(
-                        limit.resetsAt * 1000
-                    ).toLocaleString();
-                }
-                value.textContent = text;
-                meter.append(label, progress, value);
-                telemetryLimits.appendChild(meter);
+                telemetryLimits.appendChild(createLimitRing(limit));
             });
             telemetryRoot.hidden = false;
             restoreViewport(readingAnchor, previousScrollTop);

--- a/src/webview/conversationViewerScripts.js
+++ b/src/webview/conversationViewerScripts.js
@@ -607,7 +607,16 @@
     function updatePosition(message) {
         var total = message.totalInputs.toLocaleString();
         if (message.partial) total += '+';
-        position.textContent = 'Input ' + message.selectedInput + ' of ' + total;
+        var label = 'Input ' + message.selectedInput + ' of ' + total;
+        var value = position.querySelector('[data-conversation-position-value]');
+        if (value) {
+            value.textContent = message.selectedInput + '/' + total;
+            position.title = label + ' — click to open the outline';
+            position.setAttribute('aria-label', position.title);
+            position.setAttribute('data-tooltip', position.title);
+        } else {
+            position.textContent = label;
+        }
     }
 
     function centerInMessageViewport(element) {

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -186,23 +186,32 @@ async function openViewerPage(t, options = {}) {
                     <button type="button" data-action="next">Next</button>
                     <button type="button" data-action="latest">Latest</button>
                 </header>
-                <section data-conversation-telemetry hidden>
+                <section class="conversation-telemetry"
+                    data-conversation-telemetry hidden>
                     <button type="button" class="conversation-telemetry-worktree"
                         data-telemetry-worktree data-worktree-root="" title=""
                         hidden>
                         <span data-telemetry-worktree-branch></span>
                     </button>
-                    <div data-telemetry-model hidden>
-                        <span>Model</span>
+                    <div class="conversation-telemetry-model"
+                        data-telemetry-model hidden>
                         <strong data-telemetry-model-value></strong>
                     </div>
-                    <div data-telemetry-context hidden>
-                        <span>Context</span>
-                        <progress data-telemetry-context-progress
-                            max="1" value="0"></progress>
+                    <div class="conversation-telemetry-usage conversation-telemetry-context"
+                        data-telemetry-context hidden>
+                        <span class="conversation-telemetry-ring"
+                            aria-hidden="true">
+                            <svg class="conversation-telemetry-ring-progress"
+                                viewBox="0 0 36 36">
+                                <circle data-telemetry-context-progress
+                                    cx="18" cy="18" r="15.5"
+                                    pathLength="100"></circle>
+                            </svg>
+                        </span>
                         <span data-telemetry-context-value></span>
                     </div>
-                    <div data-telemetry-limits></div>
+                    <div class="conversation-telemetry-limits"
+                        data-telemetry-limits></div>
                 </section>
                 <div data-conversation-status aria-live="polite"></div>
                 <div data-conversation-scroll tabindex="0"
@@ -335,16 +344,24 @@ test('CONVERSATION-TELEMETRY-001 CONVERSATION-TELEMETRY-CONTROLLER-001 renders c
     );
     assert.equal(
         await page.locator('[data-telemetry-context-value]').textContent(),
-        '25% · 32.0k / 128k'
+        '25%'
     );
-    assert.match(
-        await page.locator('[data-telemetry-limits]').textContent(),
-        /Week.*60% left/
+    assert.equal(
+        await page.locator('[data-telemetry-limit-value]').textContent(),
+        '40%'
     );
     assert.equal(
         await page.locator('[data-telemetry-context-progress]')
-            .getAttribute('max'),
-        '128000'
+            .getAttribute('stroke-dashoffset'),
+        '75'
+    );
+    assert.match(
+        await page.locator('[data-telemetry-context]').getAttribute('title'),
+        /Context window · 25% used.*32\.0k \/ 128k tokens/s
+    );
+    assert.match(
+        await page.locator('[data-telemetry-limit]').getAttribute('title'),
+        /Week · 40% used · resets in/
     );
 
     await sendPage(page, {
@@ -1075,7 +1092,7 @@ test('WEBVIEW-AI-SESSION-SUBAGENT-VIEWER-001 lists subagents, opens a transcript
     // The telemetry counter shows running/total and opens the Subagents tab.
     const counter = rebuilt.page.locator('[data-telemetry-subagents]');
     assert.equal(await counter.isVisible(), true);
-    assert.equal(await counter.innerText(), 'Agents 1/2');
+    assert.equal(await counter.innerText(), '1/2');
     assert.match(await counter.getAttribute('title'), /1 running of 2/);
     assert.equal(
         await rebuilt.page.locator('[data-conversation-telemetry]').isVisible(),
@@ -1162,7 +1179,7 @@ test('WEBVIEW-AI-SESSION-SUBAGENT-VIEWER-001 lists subagents, opens a transcript
     // The pill doubles as the Subagents quick entry and stays visible at
     // zero instead of disappearing.
     assert.equal(await counter.isVisible(), true);
-    assert.equal(await counter.innerText(), 'Agents 0/0');
+    assert.equal(await counter.innerText(), '0/0');
 });
 
 test('WEBVIEW-AI-SESSION-CONVERSATION-VIEWER-001 keeps boundary navigation inert while Latest stays available', async t => {
@@ -1738,7 +1755,7 @@ test('CONVERSATION-COMMENTS-UI-001 send action and telemetry comments pill drive
     const pill = page.locator('[data-telemetry-comments]');
     assert.equal(await toolbarSend.isDisabled(), true);
     assert.equal(await pill.isVisible(), true);
-    assert.equal(await pill.innerText(), 'Comments 0');
+    assert.equal(await pill.innerText(), '0');
 
     await page.locator('[data-sidebar-tab="comments"]').click();
     await page.locator('[data-comment-action="new"]').click();
@@ -1783,7 +1800,7 @@ test('CONVERSATION-COMMENTS-UI-001 send action and telemetry comments pill drive
         'Send 1 open comment to the session input'
     );
     assert.equal(await pill.isVisible(), true);
-    assert.equal(await pill.innerText(), 'Comments 1/1');
+    assert.equal(await pill.innerText(), '1/1');
 
     await page.locator('[data-sidebar-tab="outline"]').click();
     await pill.click();
@@ -2549,7 +2566,7 @@ test('CONVERSATION-COMMENTS-UI-001 filters cards, jumps from message markers, an
     // Telemetry pill reports open/total.
     assert.equal(
         await page.locator('[data-telemetry-comments]').innerText(),
-        'Comments 2/3'
+        '2/3'
     );
 
     // A done card settled outside a send starts collapsed and dimmed.
@@ -2615,7 +2632,7 @@ test('CONVERSATION-COMMENTS-UI-001 filters cards, jumps from message markers, an
     await settle(sendAll, 2, allDone);
     assert.equal(
         await page.locator('[data-telemetry-comments]').innerText(),
-        'Comments 0/3'
+        '0/3'
     );
     await page.locator('[data-comment-filter="open"]').click();
     assert.equal(await page.locator('[data-comment-id]').count(), 0);
@@ -2685,7 +2702,7 @@ test('CONVERSATION-COMMENTS-UI-001 filters cards, jumps from message markers, an
     assert.equal(await page.locator('[data-comment-marker]').count(), 0);
     assert.equal(
         await page.locator('[data-telemetry-comments]').innerText(),
-        'Comments 0'
+        '0'
     );
 });
 
@@ -5543,11 +5560,20 @@ test('CONVERSATION-CHROME-LAYOUT-001 keeps header, telemetry, and the message vi
             sessionId: 'session-host-document',
             model: 'gpt-5.6-sol',
             context: { usedTokens: 32_000, maxTokens: 128_000 },
-            rateLimits: [],
+            worktree: {
+                branch: 'feature/telemetry-rings',
+                worktreeRoot: '/repo/.worktree/telemetry-rings',
+                repoRoot: '/repo',
+            },
+            rateLimits: [{
+                id: 'codex:secondary',
+                label: 'Week',
+                usedPercent: 40,
+            }],
         },
     });
 
-    for (const width of [700, 240]) {
+    for (const width of [700, 400, 360, 320, 281, 240]) {
         await page.setViewportSize({ width, height: 500 });
         const layout = await page.evaluate(() => {
             const header = document.querySelector('.conversation-header');
@@ -5578,6 +5604,9 @@ test('CONVERSATION-CHROME-LAYOUT-001 keeps header, telemetry, and the message vi
                 readerTop: readerBounds.top,
                 readerBottom: readerBounds.bottom,
                 readerScrollable: reader.scrollHeight > reader.clientHeight,
+                telemetryHeight: telemetryBounds.height,
+                telemetryClientWidth: telemetry.clientWidth,
+                telemetryScrollWidth: telemetry.scrollWidth,
                 rootOverflow: getComputedStyle(
                     document.documentElement
                 ).overflowY,
@@ -5598,6 +5627,14 @@ test('CONVERSATION-CHROME-LAYOUT-001 keeps header, telemetry, and the message vi
         assert.ok(layout.readerBottom <= layout.workspaceBottom + 1);
         assert.ok(layout.workspaceBottom <= layout.viewportHeight + 1);
         assert.equal(layout.readerScrollable, true);
+        assert.ok(
+            layout.telemetryHeight <= (width > 360 ? 48 : 42),
+            `telemetry grew vertically at ${width}px`
+        );
+        assert.ok(
+            layout.telemetryScrollWidth <= layout.telemetryClientWidth + 1,
+            `telemetry overflowed horizontally at ${width}px`
+        );
 
         const reader = page.locator('[data-conversation-scroll]');
         await reader.evaluate(element => {
@@ -5610,6 +5647,59 @@ test('CONVERSATION-CHROME-LAYOUT-001 keeps header, telemetry, and the message vi
             document.body.scrollTop,
         ]), [0, 0], `overscroll escaped at ${width}px`);
     }
+
+    await page.setViewportSize({ width: 700, height: 500 });
+    await page.locator('[data-telemetry-context]').hover();
+    const tooltipState = await page.locator(
+        '[data-telemetry-context]'
+    ).evaluate(element => {
+        const style = getComputedStyle(element, '::after');
+        return { content: style.content, visibility: style.visibility };
+    });
+    assert.equal(tooltipState.visibility, 'visible');
+    assert.match(tooltipState.content, /Context window/);
+    assert.deepEqual(
+        await page.locator(
+            '[data-telemetry-context], [data-telemetry-limit]'
+        ).evaluateAll(elements => elements.map(element =>
+            element.getAttribute('tabindex')
+        )),
+        ['0', '0'],
+        'usage details must remain keyboard-focusable after labels become icons'
+    );
+    const orderedLeftEdges = await page.locator([
+        '[data-telemetry-model]',
+        '[data-telemetry-worktree]',
+        '[data-telemetry-context]',
+        '[data-telemetry-limit]',
+        '[data-conversation-position]',
+        '[data-telemetry-comments]',
+        '[data-telemetry-subagents]',
+    ].join(',')).evaluateAll(elements => elements.map(element =>
+        Math.round(element.getBoundingClientRect().left)
+    ));
+    assert.deepEqual(
+        orderedLeftEdges,
+        [...orderedLeftEdges].sort((a, b) => a - b),
+        'telemetry must follow model, branch, usage, then quick-entry order'
+    );
+
+    await page.emulateMedia({ forcedColors: 'active' });
+    const forcedColorStroke = await page.locator(
+        '[data-telemetry-context-progress]'
+    ).evaluate(element => getComputedStyle(element).stroke);
+    assert.notEqual(forcedColorStroke, 'none');
+    assert.notEqual(
+        forcedColorStroke,
+        'rgba(0, 0, 0, 0)',
+        'forced colors must preserve a visible progress-ring stroke'
+    );
+    assert.equal(
+        await page.locator('[data-conversation-position]').evaluate(
+            element => getComputedStyle(element).borderTopStyle
+        ),
+        'solid'
+    );
 });
 
 test('CONVERSATION-LIVE-UPDATE-JOURNEY-001 preserves telemetry, auto-follow, history, and Working through a response lifecycle', async t => {
@@ -5758,7 +5848,7 @@ test('CONVERSATION-NAVIGATION-STATE-001 keeps controls, status, focus, and scrol
     const previous = page.locator('[data-action="previous"]');
     const next = page.locator('[data-action="next"]');
     const latest = page.locator('[data-action="latest"]');
-    assert.equal(await page.locator('[data-conversation-position]').innerText(), 'Input 2 of 3');
+    assert.equal(await page.locator('[data-conversation-position]').innerText(), '2/3');
     assert.equal(await previous.isEnabled(), true);
     assert.equal(await next.isEnabled(), true);
     assert.equal(await latest.isEnabled(), true);
@@ -5782,7 +5872,7 @@ test('CONVERSATION-NAVIGATION-STATE-001 keeps controls, status, focus, and scrol
         nextCursor: 'next-page',
         stale: true,
     });
-    assert.equal(await page.locator('[data-conversation-position]').innerText(), 'Input 1 of 3+');
+    assert.equal(await page.locator('[data-conversation-position]').innerText(), '1/3+');
     assert.equal(await previous.isDisabled(), true);
     assert.equal(await next.isEnabled(), true);
     assert.match(
@@ -5814,7 +5904,7 @@ test('CONVERSATION-NAVIGATION-STATE-001 keeps controls, status, focus, and scrol
         nextCursor: undefined,
         stale: false,
     });
-    assert.equal(await page.locator('[data-conversation-position]').innerText(), 'Input 3 of 3');
+    assert.equal(await page.locator('[data-conversation-position]').innerText(), '3/3');
     assert.equal(await previous.isEnabled(), true);
     assert.equal(await next.isDisabled(), true);
     assert.equal(await page.locator('[data-conversation-status]').innerText(), '');

--- a/tests/unit/aiSessions/conversationTelemetryController.test.js
+++ b/tests/unit/aiSessions/conversationTelemetryController.test.js
@@ -127,7 +127,11 @@ test('CONVERSATION-TELEMETRY-CONTROLLER-001 renders escaped model and quota mark
         }],
     });
     assert.match(html, /&lt;unsafe&gt;/);
-    assert.match(html, /25% · 1\.5k \/ 6\.0k/);
-    assert.match(html, /75% left/);
+    assert.match(html, /data-telemetry-context-value>25%/);
+    assert.match(html, /Context window · 25% used\s+1\.5k \/ 6\.0k tokens/);
+    assert.match(html, /Weekly &lt;quota&gt; · 25% used/);
+    assert.match(html, /data-telemetry-limit-value>25%/);
+    assert.doesNotMatch(html, />Model</);
+    assert.doesNotMatch(html, />Context</);
     assert.doesNotMatch(html, /Weekly <quota>/);
 });


### PR DESCRIPTION
## Summary

- reorder AI Conversation telemetry into model, worktree, usage, and quick-entry groups
- replace context and quota bars with compact SVG progress rings, icon-first counters, and detailed hover or keyboard tooltips
- keep the strip bounded across 700, 400, 360, 320, 281, and 240 pixel widths while preserving forced-colors and reduced-motion support
- update initial Host markup and incremental Webview mutations together, including comments, subagents, and input-position counters

## Skill harvest

no skill change — the temporary bare-SVG fixture failure reinforced the existing rendered-output and minimum-width review guidance; the fixture and coverage were corrected directly.

## Verification

- `npm run test-compile`
- `npm run lint`
- `node --test tests/unit/aiSessions/conversationTelemetryController.test.js`
- focused AI Conversation Chromium tests
- `node --test tests/browser/conversationViewer.test.js` (59 passed)
- focused dashboard integration tests (54 passed)
- `npm run test:behavior-contracts`
- `npm run package:release`
- `node scripts/run-release-packaging-checks.js`
- `git diff --check`
- rendered dark-theme review at default and minimum widths, including tooltip and forced-colors states
