### PR TITLE
Fix sidebar rendering focus theft

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -2001,14 +2001,15 @@
   {
     "id": "WEBVIEW-WEBVIEW-REFRESH-FOCUS-001",
     "domain": "webview",
-    "title": "Webview Refresh Focus behavior",
+    "title": "Dashboard rendering preserves external input focus and only auto-focuses search when the Webview is active",
     "priority": "P1",
     "status": "automated",
     "owners": [
-      "tests/integration/dashboard/openProjectFlow.test.js"
+      "tests/integration/dashboard/openProjectFlow.test.js",
+      "tests/browser/dashboardFocus.test.js"
     ],
     "evidence": [
-      "scripts/run-open-project-safety-checks.js"
+      "src/webview/webviewFilterScripts.js"
     ]
   },
   {

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "d686c611197886d76ef92f9595fd2a134930d01c",
+        "head": "fa980dcae7aaf4187dde798fffe7c19b2a4d31a1",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -157,7 +157,8 @@
             "d5145246c3280f22ea6cd90f91df8b67d8e4bbb3",
             "2fd9438ad2707351d11ce71c72c470cbd54412a1",
             "7720b6b13cd6655ba464da4cb2cdad4b9de5ba1c",
-            "7b00b3df273741dc168f477a51f9eb757dd9a586"
+            "7b00b3df273741dc168f477a51f9eb757dd9a586",
+            "f5997922baf5be996565953d1c1dd4841ecb7de5"
         ]
     },
     "capabilities": [
@@ -943,7 +944,8 @@
                 "bc9af0891c815988a1f74d5fd3c502b2ea8988cd",
                 "cfb3451f7a19d86d63213226b61329c088960ccf",
                 "b4f14c8ec40227225e5053314a71986b7aa31eb6",
-                "d686c611197886d76ef92f9595fd2a134930d01c"
+                "d686c611197886d76ef92f9595fd2a134930d01c",
+                "fa980dcae7aaf4187dde798fffe7c19b2a4d31a1"
             ],
             "behaviors": [
                 "RUNTIME-BOOTSTRAP-TMUX-RESTORE-DEFERRAL-001",
@@ -956,7 +958,8 @@
                 "SESSION-SIDEBAR-STEWARD-VIEW-PROVIDER-ORDERING-001",
                 "WEBVIEW-SIDEBAR-VISIBILITY-RETENTION-001",
                 "WEBVIEW-SINGLE-BOOT-ASSET-001",
-                "WEBVIEW-STYLESHEET-FIRST-PAINT-001"
+                "WEBVIEW-STYLESHEET-FIRST-PAINT-001",
+                "WEBVIEW-WEBVIEW-REFRESH-FOCUS-001"
             ],
             "prGates": [
                 "test:deterministic:run",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "fa980dcae7aaf4187dde798fffe7c19b2a4d31a1",
+        "head": "98b73a4dc087b0c0a71554036bb988b00226abe6",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -158,7 +158,8 @@
             "2fd9438ad2707351d11ce71c72c470cbd54412a1",
             "7720b6b13cd6655ba464da4cb2cdad4b9de5ba1c",
             "7b00b3df273741dc168f477a51f9eb757dd9a586",
-            "f5997922baf5be996565953d1c1dd4841ecb7de5"
+            "f5997922baf5be996565953d1c1dd4841ecb7de5",
+            "e0b043799f4b9c5ff4ffa4099ec6c3690b103129"
         ]
     },
     "capabilities": [
@@ -945,7 +946,8 @@
                 "cfb3451f7a19d86d63213226b61329c088960ccf",
                 "b4f14c8ec40227225e5053314a71986b7aa31eb6",
                 "d686c611197886d76ef92f9595fd2a134930d01c",
-                "fa980dcae7aaf4187dde798fffe7c19b2a4d31a1"
+                "fa980dcae7aaf4187dde798fffe7c19b2a4d31a1",
+                "98b73a4dc087b0c0a71554036bb988b00226abe6"
             ],
             "behaviors": [
                 "RUNTIME-BOOTSTRAP-TMUX-RESTORE-DEFERRAL-001",

--- a/media/webviewDashboardBundle.js
+++ b/media/webviewDashboardBundle.js
@@ -8792,7 +8792,11 @@ function initFiltering(activeByDefault, dashboard) {
     filterWrapper.classList.toggle(hasFilterValueClass, storedFilter.length > 0);
     document.body.classList.add('filtering-active');
     if (activeByDefault && !storedFilter) {
-        requestAnimationFrame(focus);
+        requestAnimationFrame(() => {
+            if (typeof document.hasFocus === 'function' && document.hasFocus()) {
+                focus();
+            }
+        });
     }
 
     return { clear, focus, apply };

--- a/media/webviewFilterScripts.js
+++ b/media/webviewFilterScripts.js
@@ -45,7 +45,11 @@ function initFiltering(activeByDefault, dashboard) {
     filterWrapper.classList.toggle(hasFilterValueClass, storedFilter.length > 0);
     document.body.classList.add('filtering-active');
     if (activeByDefault && !storedFilter) {
-        requestAnimationFrame(focus);
+        requestAnimationFrame(() => {
+            if (typeof document.hasFocus === 'function' && document.hasFocus()) {
+                focus();
+            }
+        });
     }
 
     return { clear, focus, apply };

--- a/scripts/run-open-project-safety-checks.js
+++ b/scripts/run-open-project-safety-checks.js
@@ -3599,8 +3599,10 @@ function runWebviewRefreshFocusChecks() {
         addEventListener: () => undefined,
     };
     const clearSearchElement = { addEventListener: () => undefined };
+    let documentFocused = false;
     const document = {
         body: { classList },
+        hasFocus: () => documentFocused,
         getElementById: id => id === 'filter' ? filterInput : clearSearchElement,
         querySelectorAll: () => [],
     };
@@ -3623,9 +3625,20 @@ function runWebviewRefreshFocusChecks() {
         callback => callback()
     )(true, dashboard);
 
-    assert.strictEqual(focusCalls, 1, 'active-by-default search must focus after initialization');
-    assert.strictEqual(selectCalls, 1, 'active-by-default search must select the current query');
-    assert.strictEqual(blurCalls, 0, 'reloading a visible Webview must not alter editor focus');
+    assert.strictEqual(focusCalls, 0, 'background Webview rendering must preserve editor focus');
+    assert.strictEqual(selectCalls, 0, 'background Webview rendering must not select its search query');
+
+    documentFocused = true;
+    initFiltering(
+        document,
+        window,
+        sessionStorage,
+        callback => callback()
+    )(true, dashboard);
+
+    assert.strictEqual(focusCalls, 1, 'an active Webview must focus default search after initialization');
+    assert.strictEqual(selectCalls, 1, 'an active Webview must select the current query');
+    assert.strictEqual(blurCalls, 0, 'Webview initialization must not blur another focus owner');
 }
 
 async function runDashboardMigrationPublicationChecks() {

--- a/src/webview/webviewFilterScripts.js
+++ b/src/webview/webviewFilterScripts.js
@@ -45,7 +45,11 @@ function initFiltering(activeByDefault, dashboard) {
     filterWrapper.classList.toggle(hasFilterValueClass, storedFilter.length > 0);
     document.body.classList.add('filtering-active');
     if (activeByDefault && !storedFilter) {
-        requestAnimationFrame(focus);
+        requestAnimationFrame(() => {
+            if (typeof document.hasFocus === 'function' && document.hasFocus()) {
+                focus();
+            }
+        });
     }
 
     return { clear, focus, apply };

--- a/tests/browser/dashboardFocus.test.js
+++ b/tests/browser/dashboardFocus.test.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const { chromium } = require('playwright-chromium');
+
+const filterScript = fs.readFileSync(path.join(
+    __dirname,
+    '..', '..',
+    'src', 'webview', 'webviewFilterScripts.js'
+), 'utf8');
+
+let browser;
+
+test.before(async () => {
+    browser = await chromium.launch({ headless: true, args: ['--no-sandbox'] });
+});
+
+test.after(async () => {
+    await browser.close();
+});
+
+async function settleAnimationFrames(frame) {
+    await frame.evaluate(() => new Promise(resolve => {
+        requestAnimationFrame(() => requestAnimationFrame(resolve));
+    }));
+}
+
+test('WEBVIEW-WEBVIEW-REFRESH-FOCUS-001 rendered dashboard preserves editor focus during background initialization', async t => {
+    const page = await browser.newPage({ viewport: { width: 640, height: 480 } });
+    t.after(() => page.close());
+    await page.route('http://agent-pivot.test/', route => route.fulfill({
+        contentType: 'text/html',
+        body: [
+            '<label>Editor <input id="editor-input"></label>',
+            '<iframe name="agent-pivot-dashboard"></iframe>',
+        ].join(''),
+    }));
+    await page.goto('http://agent-pivot.test/');
+    const frame = page.frames().find(candidate =>
+        candidate.name() === 'agent-pivot-dashboard'
+    );
+    assert.ok(frame);
+    await frame.setContent([
+        '<button id="webview-entry" type="button">Dashboard</button>',
+        '<div id="filter-wrapper"><input id="filter" type="search"></div>',
+        '<button id="clear" type="button">Clear</button>',
+    ].join(''));
+    await frame.addScriptTag({ content: filterScript });
+
+    await page.locator('#editor-input').focus();
+    assert.equal(await page.evaluate(() => document.activeElement?.id), 'editor-input');
+    await frame.evaluate(() => {
+        window.initFiltering(true, {
+            isSearchActive: () => false,
+            setSearchQuery: () => undefined,
+        });
+    });
+    await settleAnimationFrames(frame);
+
+    assert.equal(await page.evaluate(() => document.activeElement?.id), 'editor-input');
+    assert.notEqual(await frame.evaluate(() => document.activeElement?.id), 'filter');
+
+    await frame.locator('#webview-entry').focus();
+    assert.equal(await frame.evaluate(() => document.hasFocus()), true);
+    await frame.evaluate(() => {
+        window.initFiltering(true, {
+            isSearchActive: () => false,
+            setSearchQuery: () => undefined,
+        });
+    });
+    await settleAnimationFrames(frame);
+
+    assert.equal(await frame.evaluate(() => document.activeElement?.id), 'filter');
+});

--- a/tests/integration/dashboard/openProjectFlow.test.js
+++ b/tests/integration/dashboard/openProjectFlow.test.js
@@ -172,10 +172,11 @@ function createOpenWorkspaceUpdateVm(wrapper, catalogs) {
     return context;
 }
 
-function createFilterVm(input) {
+function createFilterVm(input, { documentFocused = false } = {}) {
     const context = {
         document: {
             body: { classList: createClassList() },
+            hasFocus: () => documentFocused,
             getElementById: id => id === 'filter' ? input : { addEventListener: () => undefined },
             querySelectorAll: () => [],
         },
@@ -441,7 +442,7 @@ test('OPEN-WORKSPACE-PIN-WEBVIEW-001 waits for authoritative markup before chang
     assert.equal(announcements.at(-1), 'Window pinned.');
 });
 
-test('WEBVIEW-WEBVIEW-REFRESH-FOCUS-001 focuses active search on initialization without blurring editor focus', () => {
+test('WEBVIEW-WEBVIEW-REFRESH-FOCUS-001 only focuses default search when the Webview already owns focus', () => {
     const calls = [];
     const input = {
         value: '',
@@ -451,13 +452,19 @@ test('WEBVIEW-WEBVIEW-REFRESH-FOCUS-001 focuses active search on initialization 
         select: () => calls.push('select'),
         addEventListener: () => undefined,
     };
-    const context = createFilterVm(input);
-    assert.equal(typeof context.initFiltering, 'function');
+    const backgroundContext = createFilterVm(input);
+    assert.equal(typeof backgroundContext.initFiltering, 'function');
 
-    context.initFiltering(true, {
+    backgroundContext.initFiltering(true, {
         isSearchActive: () => false,
         setSearchQuery: () => undefined,
     });
+    assert.deepEqual(calls, []);
 
+    const focusedContext = createFilterVm(input, { documentFocused: true });
+    focusedContext.initFiltering(true, {
+        isSearchActive: () => false,
+        setSearchQuery: () => undefined,
+    });
     assert.deepEqual(calls, ['focus', 'select']);
 });


### PR DESCRIPTION
## Summary

- preserve editor and terminal focus while the Agent Pivot sidebar initializes in the background
- keep default search autofocus when the Webview already owns focus
- add integration and real Chromium iframe coverage, and align the open-workspace safety gate with the corrected behavior

## Skill harvest

no skill change — existing regression and worktree skills already require rendered-surface coverage and worktree-local dependency installation; task friction was a compliance issue, not an instruction gap

## Verification

- `npm run test:ci:linux`
- `node --test --test-concurrency=1 tests/integration/dashboard/openProjectFlow.test.js`
- `node --test --test-concurrency=1 tests/browser/dashboardFocus.test.js`
- `node scripts/run-open-project-safety-checks.js`
- `SKIP_NPM_CI=1 npm run install-local` (Agent Pivot 1.0.4 bytes verified in the active VS Code Server)