### PR TITLE
Fix conversation reload and session rollover recovery

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -1030,7 +1030,7 @@
   {
     "id": "PERSIST-LIFECYCLE-PARSER-001",
     "domain": "persistence",
-    "title": "Lifecycle Parser behavior",
+    "title": "Provider lifecycle signals preserve running progress and terminal outcomes",
     "priority": "P1",
     "status": "automated",
     "owners": [
@@ -1038,6 +1038,7 @@
       "tests/unit/aiSessions/lifecycle.test.js"
     ],
     "evidence": [
+      "src/aiSessions/lifecycle.ts",
       "scripts/run-ai-session-safety-checks.js"
     ]
   },
@@ -3922,15 +3923,21 @@
   {
     "id": "WEBVIEW-AI-SESSION-CONVERSATION-VIEWER-001",
     "domain": "webview",
-    "title": "Conversation markers open one bounded sanitized rich Markdown viewer with HTTPS images and Mermaid diagrams",
+    "title": "Conversation markers open and reload restores one bounded sanitized rich Markdown viewer with live updates",
     "priority": "P0",
     "status": "automated",
     "owners": [
+      "tests/integration/dashboard/conversationOpenLatest.test.js",
       "tests/integration/dashboard/conversationViewer.test.js",
       "tests/browser/conversationViewer.test.js"
     ],
     "evidence": [
+      "src/dashboard.ts",
+      "src/aiSessions/conversation/composition.ts",
+      "src/aiSessions/conversation/panelRestoreCoordinator.ts",
       "src/aiSessions/conversation/viewer.ts",
+      "src/aiSessions/conversation/viewerDocument.ts",
+      "src/aiSessions/conversation/viewerRestoreState.ts",
       "src/aiSessions/conversation/markdown.ts",
       "src/webview/conversationViewerScripts.js",
       "media/conversationViewer.scss"
@@ -4221,6 +4228,28 @@
     "evidence": [
       "src/aiSessions/conversation/commentStore.ts",
       "src/aiSessions/conversation/viewer.ts",
+      "src/dashboard.ts"
+    ]
+  },
+  {
+    "id": "CONVERSATION-SESSION-REBIND-001",
+    "domain": "persistence",
+    "title": "AI Conversation copies comments and bookmarks across an explicit provider Session rebind before publishing the new runtime without mixing same-name Sessions or overwriting destination state",
+    "priority": "P0",
+    "status": "automated",
+    "owners": [
+      "tests/unit/aiSessions/conversationCommentStore.test.js",
+      "tests/unit/aiSessions/conversationBookmarkStore.test.js",
+      "tests/unit/aiSessions/conversationSessionRebindCoordinator.test.js",
+      "tests/contract/aiSessions/tmuxDiscovery.test.js",
+      "tests/contract/aiSessions/runtimeComposition.test.js",
+      "tests/browser/conversationViewer.test.js"
+    ],
+    "evidence": [
+      "src/aiSessions/conversation/commentStore.ts",
+      "src/aiSessions/conversation/bookmarkStore.ts",
+      "src/aiSessions/conversation/sessionRebindCoordinator.ts",
+      "src/aiSessions/tmuxRuntimeDiscovery.ts",
       "src/dashboard.ts"
     ]
   },

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "bf14ae5b6286d268264f4246604d99860a06aaf6",
+        "head": "d6385f753ae6fde4801ccfc6a2b2a59b294a39b7",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -160,7 +160,8 @@
             "7b00b3df273741dc168f477a51f9eb757dd9a586",
             "f5997922baf5be996565953d1c1dd4841ecb7de5",
             "e0b043799f4b9c5ff4ffa4099ec6c3690b103129",
-            "3fe5e04ecb7a6022b4e1aa20125f207796e8a31a"
+            "3fe5e04ecb7a6022b4e1aa20125f207796e8a31a",
+            "db085481b95fc9b3372c83023343a00640e678e7"
         ]
     },
     "capabilities": [
@@ -1275,7 +1276,8 @@
                 "521648bd80db1d0fc36abd9b9a5d155b98154f66",
                 "f947662341d783a160b3642f6c50f2eb7922522a",
                 "1b008ace0a59a6539fc8e70c90d148a369c61fae",
-                "bf14ae5b6286d268264f4246604d99860a06aaf6"
+                "bf14ae5b6286d268264f4246604d99860a06aaf6",
+                "d6385f753ae6fde4801ccfc6a2b2a59b294a39b7"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",

--- a/media/conversationViewerScripts.js
+++ b/media/conversationViewerScripts.js
@@ -33,6 +33,9 @@
     var working = document.querySelector('[data-conversation-working]');
     var position = document.querySelector('[data-conversation-position]');
     var status = document.querySelector('[data-conversation-status]');
+    var conversationDisplayName = document.querySelector(
+        '[data-conversation-display-name]'
+    );
     var telemetryRoot = document.querySelector('[data-conversation-telemetry]');
     var telemetryModel = document.querySelector('[data-telemetry-model]');
     var telemetryModelValue = document.querySelector(
@@ -119,6 +122,9 @@
         '[data-telemetry-comments]'
     );
     var commentTarget = readJsonAttribute('data-conversation-target');
+    var restoreTarget = readJsonAttribute(
+        'data-conversation-restore-target'
+    );
     var sidebarUiAvailable = !!sidebarToggle
         && !!commentsWorkspace && !!commentsResizer && !!sidebarRoot
         && sidebarTabs.length === 3 && !!outlineRoot
@@ -477,6 +483,55 @@
             && value.sessionId.length > 0;
     }
 
+    function validRestoreTarget(value) {
+        if (!value || typeof value !== 'object' || Array.isArray(value)) {
+            return false;
+        }
+        var keys = Object.keys(value);
+        var hasSubagent = Object.prototype.hasOwnProperty.call(
+            value,
+            'subagentId'
+        );
+        return keys.length === (hasSubagent ? 5 : 4)
+            && typeof value.projectId === 'string'
+            && value.projectId.length > 0
+            && (value.provider === 'codex'
+                || value.provider === 'kimi'
+                || value.provider === 'claude')
+            && typeof value.sessionId === 'string'
+            && value.sessionId.length > 0
+            && typeof value.interactionId === 'string'
+            && value.interactionId.length > 0
+            && (!hasSubagent
+                || (typeof value.subagentId === 'string'
+                    && value.subagentId.length > 0));
+    }
+
+    function saveRestoreTarget(nextTarget) {
+        if (!validRestoreTarget(nextTarget)
+            || !vscodeApi
+            || typeof vscodeApi.setState !== 'function') {
+            return;
+        }
+        restoreTarget = Object.assign({}, nextTarget);
+        try {
+            var saved = typeof vscodeApi.getState === 'function'
+                ? vscodeApi.getState()
+                : null;
+            var next = saved && typeof saved === 'object'
+                && !Array.isArray(saved)
+                ? Object.assign({}, saved)
+                : {};
+            next.conversationViewer = {
+                version: 1,
+                target: Object.assign({}, restoreTarget),
+            };
+            vscodeApi.setState(next);
+        } catch (_error) {
+            // Panel restoration is best-effort local Webview state.
+        }
+    }
+
     function validOutlineEntry(entry) {
         if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
             return false;
@@ -568,6 +623,7 @@
         ];
         var allowedKeys = new Set(requiredKeys.concat([
             'previousCursor', 'nextCursor', 'subagents', 'activeSubagent',
+            'displayName',
         ]));
         if (Object.keys(message).some(function (key) {
             return !allowedKeys.has(key);
@@ -600,6 +656,9 @@
                 || typeof message.nextCursor === 'string')
             && validSubagents(message.subagents)
             && validActiveSubagent(message.activeSubagent)
+            && (message.displayName === undefined
+                || (typeof message.displayName === 'string'
+                    && message.displayName.length <= 640))
             && typeof message.stale === 'boolean';
     }
 
@@ -675,6 +734,15 @@
         state.messageSignatures = nextSignatures;
         state.atLatest = message.atLatest;
         state.initialized = true;
+        var nextRestoreTarget = Object.assign({}, restoreTarget || {}, {
+            interactionId: message.selectedInteractionId,
+        });
+        if (message.activeSubagent) {
+            nextRestoreTarget.subagentId = message.activeSubagent.id;
+        } else {
+            delete nextRestoreTarget.subagentId;
+        }
+        saveRestoreTarget(nextRestoreTarget);
         outlineController.applyOutline(message);
         if (subagentsController) {
             subagentsController.apply(
@@ -683,6 +751,10 @@
             );
         }
         commentsController.updateHighlights();
+        if (conversationDisplayName
+            && typeof message.displayName === 'string') {
+            conversationDisplayName.textContent = message.displayName;
+        }
         updatePosition(message);
         var latestInteraction = message.outline[message.outline.length - 1];
         working.hidden = !message.atLatest
@@ -830,6 +902,7 @@
     });
     window.addEventListener('unload', releaseMermaidObjectUrls);
 
+    saveRestoreTarget(restoreTarget);
     var initialPage = document.body.getAttribute('data-initial-page');
     if (initialPage) {
         document.body.removeAttribute('data-initial-page');

--- a/src/aiSessions/conversation/bookmarkController.ts
+++ b/src/aiSessions/conversation/bookmarkController.ts
@@ -41,6 +41,7 @@ export class ConversationBookmarkController {
     private interactionIds = new Set<string>();
     private revision = 0;
     private operationQueue: Promise<void> = Promise.resolve();
+    private mutationsFrozen = false;
     private readonly settlements =
         new Map<string, ConversationViewerBookmarksResultMessage>();
 
@@ -56,9 +57,19 @@ export class ConversationBookmarkController {
     }
 
     reset(): void {
+        this.mutationsFrozen = false;
         this.interactionIds.clear();
         this.revision = 0;
         this.settlements.clear();
+    }
+
+    async freezeMutations(): Promise<void> {
+        this.mutationsFrozen = true;
+        await this.drainMutations();
+    }
+
+    async drainMutations(): Promise<void> {
+        await this.operationQueue;
     }
 
     enqueue(
@@ -109,7 +120,7 @@ export class ConversationBookmarkController {
             await this.publishSettlement(settled);
             return;
         }
-        if (!requestTargetsViewer(
+        if (this.mutationsFrozen || !requestTargetsViewer(
             request,
             target,
             this.options.getSubscriptionGeneration()

--- a/src/aiSessions/conversation/bookmarkStore.ts
+++ b/src/aiSessions/conversation/bookmarkStore.ts
@@ -31,6 +31,9 @@ export interface ConversationBookmarkStore {
     ): Promise<void>;
 }
 
+export type ConversationBookmarkRebindCopyResult =
+    'copied' | 'source-empty' | 'destination-exists';
+
 interface PersistedConversationBookmarkSnapshot
     extends ConversationBookmarkSnapshot {
     version: 1;
@@ -120,6 +123,87 @@ implements ConversationBookmarkStore {
         }
     }
 
+    async copyForRebind(
+        previous: ConversationBookmarkTarget,
+        next: ConversationBookmarkTarget
+    ): Promise<ConversationBookmarkRebindCopyResult> {
+        if (!isValidRebind(previous, next)) {
+            throw new Error('Invalid conversation bookmark rebind.');
+        }
+        const source = await this.loadForRebind(previous);
+        if (source.interactionIds.length === 0) {
+            return 'source-empty';
+        }
+        return this.saveForRebindIfAbsent(next, source);
+    }
+
+    private async loadForRebind(
+        target: ConversationBookmarkTarget
+    ): Promise<ConversationBookmarkSnapshot> {
+        const snapshotPath = this.getSnapshotPath(target);
+        try {
+            const stats = await fs.promises.stat(snapshotPath);
+            if (!stats.isFile() || stats.size > MAX_SNAPSHOT_BYTES) {
+                throw new Error('Invalid persisted conversation bookmark snapshot.');
+            }
+            const value = JSON.parse(
+                await fs.promises.readFile(snapshotPath, 'utf8')
+            );
+            if (!isPersistedSnapshot(value, target)) {
+                throw new Error('Invalid persisted conversation bookmark snapshot.');
+            }
+            return cloneSnapshot(value);
+        } catch (error) {
+            if (isFileNotFoundError(error)) {
+                return emptySnapshot();
+            }
+            throw new Error('Invalid persisted conversation bookmark snapshot.');
+        }
+    }
+
+    private async saveForRebindIfAbsent(
+        target: ConversationBookmarkTarget,
+        snapshot: ConversationBookmarkSnapshot
+    ): Promise<ConversationBookmarkRebindCopyResult> {
+        const snapshotPath = this.getSnapshotPath(target);
+        await fs.promises.mkdir(this.directoryPath, {
+            recursive: true,
+            mode: 0o700,
+        });
+        const persisted: PersistedConversationBookmarkSnapshot = {
+            version: STORE_VERSION,
+            target: { ...target },
+            revision: snapshot.revision,
+            updatedAt: new Date(this.now()).toISOString(),
+            interactionIds: [...snapshot.interactionIds],
+        };
+        const temporaryPath = `${snapshotPath}.${process.pid}.${
+            randomBytes(8).toString('hex')
+        }.tmp`;
+        try {
+            await fs.promises.writeFile(
+                temporaryPath,
+                JSON.stringify(persisted),
+                { encoding: 'utf8', flag: 'wx', mode: 0o600 }
+            );
+            try {
+                await fs.promises.link(temporaryPath, snapshotPath);
+                return 'copied';
+            } catch (error) {
+                if (isFileExistsError(error)) {
+                    return 'destination-exists';
+                }
+                throw error;
+            }
+        } finally {
+            try {
+                await fs.promises.unlink(temporaryPath);
+            } catch (_error) {
+                // Cleanup must not mask the authoritative link result.
+            }
+        }
+    }
+
     private getSnapshotPath(target: ConversationBookmarkTarget): string {
         const identity = JSON.stringify([
             target.projectId,
@@ -185,6 +269,17 @@ function isTarget(value: unknown): value is ConversationBookmarkTarget {
         && isIdentity(value.sessionId);
 }
 
+function isValidRebind(
+    previous: ConversationBookmarkTarget,
+    next: ConversationBookmarkTarget
+): boolean {
+    return isTarget(previous)
+        && isTarget(next)
+        && previous.projectId === next.projectId
+        && previous.provider === next.provider
+        && previous.sessionId !== next.sessionId;
+}
+
 function isIdentity(value: unknown): value is string {
     return typeof value === 'string'
         && value.length > 0
@@ -204,4 +299,8 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function isFileNotFoundError(error: unknown): boolean {
     return Boolean(error && (error as NodeJS.ErrnoException).code === 'ENOENT');
+}
+
+function isFileExistsError(error: unknown): boolean {
+    return Boolean(error && (error as NodeJS.ErrnoException).code === 'EEXIST');
 }

--- a/src/aiSessions/conversation/commentController.ts
+++ b/src/aiSessions/conversation/commentController.ts
@@ -87,6 +87,7 @@ export class ConversationCommentController {
     private comments: ConversationCommentDraft[] = [];
     private revision = 0;
     private operationQueue: Promise<void> = Promise.resolve();
+    private mutationsFrozen = false;
     private readonly settlements =
         new Map<string, ConversationViewerCommentsResultMessage>();
 
@@ -106,9 +107,19 @@ export class ConversationCommentController {
     }
 
     reset(): void {
+        this.mutationsFrozen = false;
         this.comments = [];
         this.revision = 0;
         this.settlements.clear();
+    }
+
+    async freezeMutations(): Promise<void> {
+        this.mutationsFrozen = true;
+        await this.drainMutations();
+    }
+
+    async drainMutations(): Promise<void> {
+        await this.operationQueue;
     }
 
     enqueue(
@@ -205,7 +216,7 @@ export class ConversationCommentController {
             );
             return;
         }
-        if (!requestTargetsViewer(
+        if (this.mutationsFrozen || !requestTargetsViewer(
             request,
             target,
             this.options.getSubscriptionGeneration()
@@ -342,13 +353,19 @@ export class ConversationCommentController {
             revision += 1;
         }
         const snapshot = { revision, comments };
+        const previousSnapshot = this.snapshot;
         await this.persist(target, snapshot);
-        this.commitPersisted(
-            target,
-            generation,
-            request.expectedRevision,
-            snapshot
-        );
+        try {
+            this.commitPersisted(
+                target,
+                generation,
+                request.expectedRevision,
+                snapshot
+            );
+        } catch (error) {
+            await this.persist(target, previousSnapshot);
+            throw error;
+        }
     }
 
     private async sendComments(

--- a/src/aiSessions/conversation/commentStore.ts
+++ b/src/aiSessions/conversation/commentStore.ts
@@ -30,6 +30,9 @@ export interface ConversationCommentStore {
     ): Promise<void>;
 }
 
+export type ConversationCommentRebindCopyResult =
+    'copied' | 'source-empty' | 'destination-exists';
+
 interface PersistedConversationCommentSnapshot {
     version: 1;
     target: ConversationCommentTarget;
@@ -133,6 +136,94 @@ export class ConversationCommentFileStore implements ConversationCommentStore {
         }
     }
 
+    async copyForRebind(
+        previous: ConversationCommentTarget,
+        next: ConversationCommentTarget
+    ): Promise<ConversationCommentRebindCopyResult> {
+        if (!isValidRebind(previous, next)) {
+            throw new Error('Invalid conversation comment rebind.');
+        }
+        const source = await this.loadForRebind(previous);
+        if (source.comments.length === 0) {
+            return 'source-empty';
+        }
+        return this.saveForRebindIfAbsent(next, source);
+    }
+
+    private async loadForRebind(
+        target: ConversationCommentTarget
+    ): Promise<ConversationCommentSnapshot> {
+        const snapshotPath = this.getSnapshotPath(target);
+        try {
+            const stats = await fs.promises.stat(snapshotPath);
+            if (!stats.isFile() || stats.size > MAX_SNAPSHOT_BYTES) {
+                throw new Error('Invalid persisted conversation comment snapshot.');
+            }
+            const value = JSON.parse(
+                await fs.promises.readFile(snapshotPath, 'utf8')
+            );
+            if (!isPersistedSnapshot(value, target)) {
+                throw new Error('Invalid persisted conversation comment snapshot.');
+            }
+            normalizeLegacyCommentStatuses(value.comments);
+            validateConversationComments(value.comments);
+            return {
+                revision: value.revision,
+                comments: cloneConversationComments(value.comments),
+            };
+        } catch (error) {
+            if (isFileNotFoundError(error)) {
+                return emptySnapshot();
+            }
+            throw new Error('Invalid persisted conversation comment snapshot.');
+        }
+    }
+
+    private async saveForRebindIfAbsent(
+        target: ConversationCommentTarget,
+        snapshot: ConversationCommentSnapshot
+    ): Promise<ConversationCommentRebindCopyResult> {
+        const snapshotPath = this.getSnapshotPath(target);
+        await fs.promises.mkdir(this.directoryPath, {
+            recursive: true,
+            mode: 0o700,
+        });
+        const persisted: PersistedConversationCommentSnapshot = {
+            version: STORE_VERSION,
+            target: { ...target },
+            revision: snapshot.revision,
+            updatedAt: new Date(this.now()).toISOString(),
+            comments: cloneConversationComments(snapshot.comments),
+        };
+        const temporaryPath = `${snapshotPath}.${process.pid}.${
+            randomBytes(8).toString('hex')
+        }.tmp`;
+        try {
+            await fs.promises.writeFile(
+                temporaryPath,
+                JSON.stringify(persisted),
+                { encoding: 'utf8', flag: 'wx', mode: 0o600 }
+            );
+            try {
+                await fs.promises.link(temporaryPath, snapshotPath);
+                return 'copied';
+            } catch (error) {
+                if (isFileExistsError(error)) {
+                    return 'destination-exists';
+                }
+                throw error;
+            }
+        } finally {
+            try {
+                await fs.promises.unlink(temporaryPath);
+            } catch (error) {
+                if (!isFileNotFoundError(error)) {
+                    // Cleanup must not mask the authoritative link result.
+                }
+            }
+        }
+    }
+
     private getSnapshotPath(target: ConversationCommentTarget): string {
         const identity = JSON.stringify([
             target.projectId,
@@ -197,6 +288,17 @@ function isConversationCommentTarget(
         && isBoundedIdentity(value.sessionId);
 }
 
+function isValidRebind(
+    previous: ConversationCommentTarget,
+    next: ConversationCommentTarget
+): boolean {
+    return isConversationCommentTarget(previous)
+        && isConversationCommentTarget(next)
+        && previous.projectId === next.projectId
+        && previous.provider === next.provider
+        && previous.sessionId !== next.sessionId;
+}
+
 function isAiSessionProvider(value: unknown): value is AiSessionProviderId {
     return value === 'codex' || value === 'kimi' || value === 'claude';
 }
@@ -216,4 +318,8 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function isFileNotFoundError(error: unknown): boolean {
     return Boolean(error && (error as NodeJS.ErrnoException).code === 'ENOENT');
+}
+
+function isFileExistsError(error: unknown): boolean {
+    return Boolean(error && (error as NodeJS.ErrnoException).code === 'EEXIST');
 }

--- a/src/aiSessions/conversation/composition.ts
+++ b/src/aiSessions/conversation/composition.ts
@@ -45,8 +45,12 @@ import {
     ConversationViewerTarget,
 } from './viewer';
 import type { ConversationSessionSwitchDirection } from './viewerProtocol';
+import {
+    parseConversationViewerRestoreTarget,
+} from './viewerRestoreState';
 import { ConversationWorktreeResolver } from './worktreeResolver';
 import { readCodexRolloutWorkdir } from '../codexRolloutWorkdir';
+import { encodeSubagentSessionId } from './subagentSessions';
 
 export interface ConversationSessionOpenTarget {
     projectId: string;
@@ -70,6 +74,14 @@ export interface ConversationCapability {
     followActiveConversation(
         target: ConversationSessionOpenTarget
     ): Promise<FollowActiveConversationResult>;
+    restorePanel(panel: vscode.WebviewPanel, state: unknown): Promise<void>;
+    rebindSession(
+        previous: ConversationSessionOpenTarget,
+        next: ConversationSessionOpenTarget
+    ): Promise<boolean>;
+    freezeSessionMetadata(
+        target: ConversationSessionOpenTarget
+    ): Promise<boolean>;
     reconcile(): Promise<void>;
     dispose(): void;
 }
@@ -110,6 +122,9 @@ export interface ConversationCapabilityOptions {
     commentStore?: ConversationCommentStore;
     bookmarkStore?: ConversationBookmarkStore;
     getShowThinking?: () => boolean;
+    resolveReboundTarget?: (
+        target: ConversationSessionOpenTarget
+    ) => ConversationSessionOpenTarget;
 }
 
 interface ConversationCapabilityInternalFactories {
@@ -313,11 +328,54 @@ function createAvailableConversationCapability(
                 ? 'opened'
                 : 'closed';
         },
+        async restorePanel(
+            panel: vscode.WebviewPanel,
+            state: unknown
+        ): Promise<void> {
+            const savedTarget = parseConversationViewerRestoreTarget(state);
+            if (!savedTarget || disposed) {
+                panel.dispose();
+                return;
+            }
+            const intentGeneration = ++viewerIntentGeneration;
+            const reboundTarget = options.resolveReboundTarget?.(savedTarget)
+                || savedTarget;
+            const reboundRootChanged = reboundTarget.projectId
+                !== savedTarget.projectId
+                || reboundTarget.provider !== savedTarget.provider
+                || reboundTarget.sessionId !== savedTarget.sessionId;
+            const resolution = await resolveLatestConversationTarget(
+                options,
+                coordinator,
+                reboundTarget,
+                savedTarget.interactionId,
+                reboundRootChanged ? undefined : savedTarget.subagentId
+            );
+            if (disposed || intentGeneration !== viewerIntentGeneration
+                || !resolution.viewerTarget) {
+                panel.dispose();
+                return;
+            }
+            try {
+                await viewer.restore(panel, resolution.viewerTarget);
+            } catch (_error) {
+                panel.dispose();
+            }
+        },
+        rebindSession: (previous, next) =>
+            viewer.rebindSession(previous, next),
+        freezeSessionMetadata: target =>
+            viewer.freezeSessionMetadata(target),
         async reconcile(): Promise<void> {
             if (disposed) {
                 return;
             }
             try {
+                if (options.resolveReboundTarget) {
+                    await viewer.reconcileReboundSession(
+                        options.resolveReboundTarget
+                    );
+                }
                 await viewer.reconcileAuthority(target => {
                     const authoritativeTarget = resolveExactTarget(
                         options,
@@ -331,7 +389,22 @@ function createAvailableConversationCapability(
                         target.sessionId,
                         authoritativeTarget.executionState === 'stopped'
                     );
-                    return true;
+                    const displayMetadata = authoritativeTarget as
+                        ActiveAiSessionViewModel & {
+                            conversationDisplayName?: string;
+                            duplicateConversationDisplayName?: boolean;
+                        };
+                    const trimmedName = String(
+                        authoritativeTarget.name || ''
+                    ).trim();
+                    return {
+                        displayName: displayMetadata.conversationDisplayName
+                            || (trimmedName
+                                || `${target.provider} conversation`),
+                        duplicateDisplayName:
+                            displayMetadata.duplicateConversationDisplayName
+                                === true,
+                    };
                 });
             } catch (_error) {
                 reportUnavailable(options.onDiagnostic);
@@ -352,7 +425,19 @@ function createUnavailableConversationCapability(): ConversationCapability {
     const viewer: ConversationViewerApi = {
         isOpen: () => false,
         async open() {},
+        async restore(panel) {
+            panel.dispose();
+        },
         async follow() {
+            return false;
+        },
+        async rebindSession() {
+            return false;
+        },
+        async freezeSessionMetadata() {
+            return false;
+        },
+        async reconcileReboundSession() {
             return false;
         },
         async refresh() {},
@@ -369,6 +454,15 @@ function createUnavailableConversationCapability(): ConversationCapability {
         },
         async followActiveConversation(): Promise<FollowActiveConversationResult> {
             return 'unavailable';
+        },
+        async restorePanel(panel: vscode.WebviewPanel): Promise<void> {
+            panel.dispose();
+        },
+        async rebindSession(): Promise<boolean> {
+            return false;
+        },
+        async freezeSessionMetadata(): Promise<boolean> {
+            return false;
         },
         async reconcile(): Promise<void> {},
         dispose(): void {
@@ -485,7 +579,9 @@ async function followAdjacentConversation(
 async function resolveLatestConversationTarget(
     options: ConversationCapabilityOptions,
     coordinator: ConversationCoordinator,
-    target: ConversationSessionOpenTarget
+    target: ConversationSessionOpenTarget,
+    preferredInteractionId?: string,
+    subagentId?: string
 ): Promise<LatestConversationTargetResolution> {
     const authoritativeTarget = resolveExactTarget(options, target);
     if (!authoritativeTarget) {
@@ -496,17 +592,46 @@ async function resolveLatestConversationTarget(
         target.sessionId,
         authoritativeTarget.executionState === 'stopped'
     );
+    let subagent: ConversationViewerTarget['subagent'];
+    let effectiveSessionId = target.sessionId;
+    if (subagentId) {
+        let subagents;
+        try {
+            subagents = await coordinator.readSubagents(
+                target.provider,
+                target.sessionId
+            );
+        } catch (_error) {
+            return { result: 'unavailable' };
+        }
+        const authoritativeSubagent = subagents.find(entry =>
+            entry.id === subagentId
+        );
+        if (!authoritativeSubagent) {
+            return { result: 'unavailable' };
+        }
+        subagent = {
+            id: authoritativeSubagent.id,
+            label: authoritativeSubagent.label,
+        };
+        effectiveSessionId = encodeSubagentSessionId(
+            target.sessionId,
+            authoritativeSubagent.id
+        );
+    }
     let outline;
     try {
         outline = await coordinator.readOutline(
             target.provider,
-            target.sessionId
+            effectiveSessionId
         );
     } catch (_error) {
         return { result: 'unavailable' };
     }
-    const latest = outline.interactions[outline.interactions.length - 1];
-    if (!latest) {
+    const selected = outline.interactions.find(interaction =>
+        interaction.id === preferredInteractionId
+    ) || outline.interactions[outline.interactions.length - 1];
+    if (!selected) {
         return { result: 'empty' };
     }
     const displayMetadata = authoritativeTarget as ActiveAiSessionViewModel & {
@@ -520,12 +645,13 @@ async function resolveLatestConversationTarget(
             projectId: target.projectId,
             provider: target.provider,
             sessionId: target.sessionId,
-            interactionId: latest.id,
+            interactionId: selected.id,
             expectedRevision: outline.sourceRevision,
             displayName: displayMetadata.conversationDisplayName
                 || (trimmedName || `${target.provider} conversation`),
             duplicateDisplayName:
                 displayMetadata.duplicateConversationDisplayName === true,
+            ...(subagent ? { subagent } : {}),
         },
     };
 }

--- a/src/aiSessions/conversation/panelRestoreCoordinator.ts
+++ b/src/aiSessions/conversation/panelRestoreCoordinator.ts
@@ -1,0 +1,121 @@
+'use strict';
+
+import type * as vscode from 'vscode';
+import type { AiSessionDisposable } from '../types';
+import type { ConversationCapability } from './composition';
+
+interface PendingPanelRestore {
+    panel: vscode.WebviewPanel;
+    state: unknown;
+    resolve: () => void;
+}
+
+export class ConversationPanelRestoreCoordinator implements AiSessionDisposable {
+    private capability?: ConversationCapability;
+    private pending: PendingPanelRestore[] = [];
+    private disposed = false;
+
+    restorePanel(
+        panel: vscode.WebviewPanel,
+        state: unknown
+    ): Promise<void> {
+        if (this.disposed) {
+            panel.dispose();
+            return Promise.resolve();
+        }
+        const capability = this.capability;
+        if (capability) {
+            return this.runRestore(capability, panel, state);
+        }
+        panel.webview.html = restoringDocument();
+        return new Promise(resolve => {
+            this.pending.push({ panel, state, resolve });
+        });
+    }
+
+    connect(capability: ConversationCapability): AiSessionDisposable {
+        if (this.disposed) {
+            return { dispose() {} };
+        }
+        this.capability = capability;
+        const pending = this.pending.splice(0);
+        for (const restore of pending) {
+            void this.runRestore(
+                capability,
+                restore.panel,
+                restore.state
+            ).finally(restore.resolve);
+        }
+        return {
+            dispose: () => {
+                if (this.capability === capability) {
+                    this.capability = undefined;
+                }
+            },
+        };
+    }
+
+    connectWhenReady(
+        capability: ConversationCapability,
+        authorityReady: PromiseLike<unknown>
+    ): AiSessionDisposable {
+        let active = true;
+        let connection: AiSessionDisposable | undefined;
+        void Promise.resolve(authorityReady).then(
+            () => {
+                if (active) {
+                    connection = this.connect(capability);
+                }
+            },
+            () => {
+                if (active) {
+                    this.failPending();
+                }
+            }
+        );
+        return {
+            dispose: () => {
+                active = false;
+                connection?.dispose();
+                connection = undefined;
+            },
+        };
+    }
+
+    failPending(): void {
+        const pending = this.pending.splice(0);
+        for (const restore of pending) {
+            restore.panel.dispose();
+            restore.resolve();
+        }
+    }
+
+    dispose(): void {
+        if (this.disposed) {
+            return;
+        }
+        this.disposed = true;
+        this.capability = undefined;
+        this.failPending();
+    }
+
+    private async runRestore(
+        capability: ConversationCapability,
+        panel: vscode.WebviewPanel,
+        state: unknown
+    ): Promise<void> {
+        try {
+            await capability.restorePanel(panel, state);
+        } catch (_error) {
+            panel.dispose();
+        }
+    }
+}
+
+function restoringDocument(): string {
+    return '<!doctype html><html><head>'
+        + '<meta http-equiv="Content-Security-Policy" content="default-src \'none\';">'
+        + '<meta name="viewport" content="width=device-width, initial-scale=1.0">'
+        + '<title>AI Conversation</title></head>'
+        + '<body><p>Restoring conversation…</p></body></html>';
+}

--- a/src/aiSessions/conversation/sessionRebindCoordinator.ts
+++ b/src/aiSessions/conversation/sessionRebindCoordinator.ts
@@ -1,0 +1,456 @@
+'use strict';
+
+import { createHash, randomBytes } from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+import type { AiSessionProviderId } from '../../models';
+import type {
+    ConversationBookmarkRebindCopyResult,
+    ConversationBookmarkTarget,
+} from './bookmarkStore';
+import type {
+    ConversationCommentRebindCopyResult,
+} from './commentStore';
+import type { ConversationCommentTarget } from './comments';
+
+const STORE_VERSION = 1;
+const STORE_DIRECTORY = path.join('conversation-session-rebinds', 'v1');
+const MAX_RECORD_BYTES = 64 * 1024;
+const MAX_RECORDS = 512;
+const MAX_CHAIN_LENGTH = 64;
+
+export type ConversationSessionRebindTarget = ConversationCommentTarget;
+export type ConversationSessionMetadataKind = 'comments' | 'bookmarks';
+type RebindCopyResult = ConversationCommentRebindCopyResult
+    | ConversationBookmarkRebindCopyResult;
+
+interface RebindCopyStore<TTarget> {
+    copyForRebind(
+        previous: TTarget,
+        next: TTarget
+    ): Promise<RebindCopyResult>;
+}
+
+interface PersistedConversationSessionRebind {
+    version: 1;
+    previous: ConversationSessionRebindTarget;
+    next: ConversationSessionRebindTarget;
+    commentsComplete: boolean;
+    bookmarksComplete: boolean;
+    runtimeCommitted: boolean;
+    updatedAt: string;
+}
+
+export interface ConversationSessionRebindCoordinatorOptions {
+    globalStoragePath: string;
+    commentStore: RebindCopyStore<ConversationCommentTarget>;
+    bookmarkStore: RebindCopyStore<ConversationBookmarkTarget>;
+    now?: () => number;
+    onResult?: (
+        kind: ConversationSessionMetadataKind,
+        result: RebindCopyResult
+    ) => void;
+    onFailure?: (
+        kind: ConversationSessionMetadataKind,
+        error: unknown
+    ) => void;
+    isRuntimeRebindCommitted?: (
+        previous: ConversationSessionRebindTarget,
+        next: ConversationSessionRebindTarget
+    ) => Promise<boolean>;
+}
+
+export function hasCommittedConversationSessionRuntimeRebind(
+    bindings: readonly ConversationSessionRebindTarget[],
+    previous: ConversationSessionRebindTarget,
+    next: ConversationSessionRebindTarget
+): boolean {
+    return isValidRebind(previous, next)
+        && !bindings.some(binding => targetsEqual(binding, previous))
+        && bindings.some(binding => targetsEqual(binding, next));
+}
+
+export class ConversationSessionRebindCoordinator {
+    private readonly directoryPath: string;
+    private readonly now: () => number;
+    private readonly mappings = new Map<
+        string,
+        ConversationSessionRebindTarget
+    >();
+    private readonly records = new Map<
+        string,
+        PersistedConversationSessionRebind
+    >();
+    private operationQueue: Promise<void> = Promise.resolve();
+
+    constructor(
+        private readonly options: ConversationSessionRebindCoordinatorOptions
+    ) {
+        this.directoryPath = path.join(
+            options.globalStoragePath,
+            STORE_DIRECTORY
+        );
+        this.now = options.now || (() => Date.now());
+    }
+
+    restore(): Promise<void> {
+        return this.serialize(async () => {
+            const records = await this.readRecords();
+            for (let index = 0; index < records.length; index += 1) {
+                let record = records[index];
+                this.records.set(targetKey(record.previous), record);
+                if (!record.runtimeCommitted
+                    && this.options.isRuntimeRebindCommitted
+                    && await this.options.isRuntimeRebindCommitted(
+                        record.previous,
+                        record.next
+                    )) {
+                    record = await this.persistUpdate(record, {
+                        runtimeCommitted: true,
+                    });
+                    records[index] = record;
+                }
+                if (record.runtimeCommitted) {
+                    this.addMapping(record.previous, record.next);
+                }
+            }
+            const failures: string[] = [];
+            for (const record of records) {
+                if (record.runtimeCommitted) {
+                    failures.push(...await this.finish(record));
+                }
+            }
+            if (failures.length) {
+                throw new Error(
+                    `Conversation Session rebind migration failed: ${
+                        failures.join(', ')
+                    }.`
+                );
+            }
+        });
+    }
+
+    rebind(
+        previous: ConversationSessionRebindTarget,
+        next: ConversationSessionRebindTarget
+    ): Promise<void> {
+        return this.serialize(async () => {
+            const record = await this.prepareUnlocked(previous, next);
+            const failures = await this.commitUnlocked(record);
+            if (failures.length) {
+                throw new Error(
+                    `Conversation Session rebind migration failed: ${
+                        failures.join(', ')
+                    }.`
+                );
+            }
+        });
+    }
+
+    prepare(
+        previous: ConversationSessionRebindTarget,
+        next: ConversationSessionRebindTarget
+    ): Promise<void> {
+        return this.serialize(async () => {
+            await this.prepareUnlocked(previous, next);
+        });
+    }
+
+    commit(
+        previous: ConversationSessionRebindTarget,
+        next: ConversationSessionRebindTarget
+    ): Promise<void> {
+        return this.serialize(async () => {
+            let record = this.records.get(targetKey(previous));
+            if (!record || !targetsEqual(record.next, next)) {
+                record = await this.prepareUnlocked(previous, next);
+            }
+            const failures = await this.commitUnlocked(record);
+            if (failures.length) {
+                throw new Error(
+                    `Conversation Session rebind migration failed: ${
+                        failures.join(', ')
+                    }.`
+                );
+            }
+        });
+    }
+
+    resolve<T extends ConversationSessionRebindTarget>(target: T): T {
+        if (!isTarget(target)) {
+            return target;
+        }
+        let current: ConversationSessionRebindTarget = { ...target };
+        const visited = new Set<string>();
+        for (let depth = 0; depth < MAX_CHAIN_LENGTH; depth += 1) {
+            const key = targetKey(current);
+            if (visited.has(key)) {
+                break;
+            }
+            visited.add(key);
+            const next = this.mappings.get(key);
+            if (!next) {
+                break;
+            }
+            current = { ...next };
+        }
+        return { ...target, sessionId: current.sessionId };
+    }
+
+    private async finish(
+        record: PersistedConversationSessionRebind
+    ): Promise<string[]> {
+        const failures: string[] = [];
+        if (!record.commentsComplete) {
+            try {
+                const result = await this.options.commentStore.copyForRebind(
+                    record.previous,
+                    record.next
+                );
+                this.options.onResult?.('comments', result);
+                record = await this.persistUpdate(record, {
+                    commentsComplete: true,
+                });
+            } catch (error) {
+                this.options.onFailure?.('comments', error);
+                failures.push('comments');
+            }
+        }
+        if (!record.bookmarksComplete) {
+            try {
+                const result = await this.options.bookmarkStore.copyForRebind(
+                    record.previous,
+                    record.next
+                );
+                this.options.onResult?.('bookmarks', result);
+                record = await this.persistUpdate(record, {
+                    bookmarksComplete: true,
+                });
+            } catch (error) {
+                this.options.onFailure?.('bookmarks', error);
+                failures.push('bookmarks');
+            }
+        }
+        return failures;
+    }
+
+    private async prepareUnlocked(
+        previous: ConversationSessionRebindTarget,
+        next: ConversationSessionRebindTarget
+    ): Promise<PersistedConversationSessionRebind> {
+        if (!isValidRebind(previous, next)
+            || this.resolve(next).sessionId === previous.sessionId) {
+            throw new Error('Invalid conversation Session rebind.');
+        }
+        const existing = this.records.get(targetKey(previous));
+        if (existing && targetsEqual(existing.next, next)) {
+            return existing;
+        }
+        const record: PersistedConversationSessionRebind = {
+            version: STORE_VERSION,
+            previous: { ...previous },
+            next: { ...next },
+            commentsComplete: false,
+            bookmarksComplete: false,
+            runtimeCommitted: false,
+            updatedAt: new Date(this.now()).toISOString(),
+        };
+        await this.writeRecord(record);
+        this.records.set(targetKey(previous), record);
+        return record;
+    }
+
+    private async commitUnlocked(
+        record: PersistedConversationSessionRebind
+    ): Promise<string[]> {
+        if (!record.runtimeCommitted) {
+            record = await this.persistUpdate(record, {
+                runtimeCommitted: true,
+            });
+        }
+        this.addMapping(record.previous, record.next);
+        return this.finish(record);
+    }
+
+    private async persistUpdate(
+        record: PersistedConversationSessionRebind,
+        changes: Partial<Pick<
+            PersistedConversationSessionRebind,
+            'runtimeCommitted' | 'commentsComplete' | 'bookmarksComplete'
+        >>
+    ): Promise<PersistedConversationSessionRebind> {
+        const updated = {
+            ...record,
+            ...changes,
+            updatedAt: new Date(this.now()).toISOString(),
+        };
+        await this.writeRecord(updated);
+        this.records.set(targetKey(updated.previous), updated);
+        return updated;
+    }
+
+    private addMapping(
+        previous: ConversationSessionRebindTarget,
+        next: ConversationSessionRebindTarget
+    ): void {
+        this.mappings.set(targetKey(previous), { ...next });
+    }
+
+    private async readRecords(): Promise<PersistedConversationSessionRebind[]> {
+        let names: string[];
+        try {
+            names = await fs.promises.readdir(this.directoryPath);
+        } catch (error) {
+            if (isNodeError(error, 'ENOENT')) {
+                return [];
+            }
+            throw error;
+        }
+        const entries: PersistedConversationSessionRebind[] = [];
+        for (const name of names.filter(candidate => candidate.endsWith('.json'))) {
+            const filePath = path.join(this.directoryPath, name);
+            try {
+                const stats = await fs.promises.stat(filePath);
+                if (!stats.isFile() || stats.size > MAX_RECORD_BYTES) {
+                    continue;
+                }
+                const value = JSON.parse(
+                    await fs.promises.readFile(filePath, 'utf8')
+                );
+                if (isPersistedRecord(value)
+                    && filePath === this.recordPath(value.previous)) {
+                    entries.push(value);
+                }
+            } catch (_error) {
+                // One malformed private record must not block other retries.
+            }
+        }
+        entries.sort((left, right) =>
+            Date.parse(right.updatedAt) - Date.parse(left.updatedAt)
+        );
+        for (const stale of entries.slice(MAX_RECORDS)) {
+            await removeFile(this.recordPath(stale.previous));
+        }
+        return entries.slice(0, MAX_RECORDS);
+    }
+
+    private async writeRecord(
+        record: PersistedConversationSessionRebind
+    ): Promise<void> {
+        await fs.promises.mkdir(this.directoryPath, {
+            recursive: true,
+            mode: 0o700,
+        });
+        const recordPath = this.recordPath(record.previous);
+        const temporaryPath = `${recordPath}.${process.pid}.${
+            randomBytes(8).toString('hex')
+        }.tmp`;
+        try {
+            await fs.promises.writeFile(
+                temporaryPath,
+                JSON.stringify(record),
+                { encoding: 'utf8', flag: 'wx', mode: 0o600 }
+            );
+            await fs.promises.rename(temporaryPath, recordPath);
+        } finally {
+            await removeFile(temporaryPath);
+        }
+    }
+
+    private recordPath(target: ConversationSessionRebindTarget): string {
+        const digest = createHash('sha256')
+            .update(targetKey(target))
+            .digest('hex');
+        return path.join(this.directoryPath, `${digest}.json`);
+    }
+
+    private serialize<T>(operation: () => Promise<T>): Promise<T> {
+        const result = this.operationQueue.then(operation);
+        this.operationQueue = result.then(() => undefined, () => undefined);
+        return result;
+    }
+}
+
+function isPersistedRecord(
+    value: unknown
+): value is PersistedConversationSessionRebind {
+    if (!isRecord(value)
+        || value.version !== STORE_VERSION
+        || !isTarget(value.previous)
+        || !isTarget(value.next)
+        || !isValidRebind(value.previous, value.next)
+        || typeof value.commentsComplete !== 'boolean'
+        || typeof value.bookmarksComplete !== 'boolean'
+        || typeof value.runtimeCommitted !== 'boolean'
+        || typeof value.updatedAt !== 'string'
+        || !Number.isFinite(Date.parse(value.updatedAt))) {
+        return false;
+    }
+    return true;
+}
+
+function targetsEqual(
+    left: ConversationSessionRebindTarget,
+    right: ConversationSessionRebindTarget
+): boolean {
+    return left.projectId === right.projectId
+        && left.provider === right.provider
+        && left.sessionId === right.sessionId;
+}
+
+function isValidRebind(
+    previous: ConversationSessionRebindTarget,
+    next: ConversationSessionRebindTarget
+): boolean {
+    return isTarget(previous)
+        && isTarget(next)
+        && previous.projectId === next.projectId
+        && previous.provider === next.provider
+        && previous.sessionId !== next.sessionId;
+}
+
+function isTarget(value: unknown): value is ConversationSessionRebindTarget {
+    return isRecord(value)
+        && isIdentity(value.projectId)
+        && isProvider(value.provider)
+        && isIdentity(value.sessionId);
+}
+
+function targetKey(target: ConversationSessionRebindTarget): string {
+    return JSON.stringify([
+        target.projectId,
+        target.provider,
+        target.sessionId,
+    ]);
+}
+
+function isIdentity(value: unknown): value is string {
+    return typeof value === 'string'
+        && value.length > 0
+        && value.length <= 512
+        && !/[\u0000-\u001f\u007f]/.test(value);
+}
+
+function isProvider(value: unknown): value is AiSessionProviderId {
+    return value === 'codex' || value === 'kimi' || value === 'claude';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return Boolean(value)
+        && typeof value === 'object'
+        && !Array.isArray(value);
+}
+
+function isNodeError(error: unknown, code: string): boolean {
+    return Boolean(error && (error as NodeJS.ErrnoException).code === code);
+}
+
+async function removeFile(filePath: string): Promise<void> {
+    try {
+        await fs.promises.unlink(filePath);
+    } catch (error) {
+        if (!isNodeError(error, 'ENOENT')) {
+            throw error;
+        }
+    }
+}

--- a/src/aiSessions/conversation/viewer.ts
+++ b/src/aiSessions/conversation/viewer.ts
@@ -27,6 +27,7 @@ import { parseConversationViewerMessage } from './viewerProtocol';
 import type { ConversationSessionSwitchDirection } from './viewerProtocol';
 import type { ConversationViewerTarget } from './viewerTarget';
 export type { ConversationViewerTarget } from './viewerTarget';
+import { truncateGraphemes } from './text';
 import {
     CONVERSATION_LIMITS,
     ConversationAbortController,
@@ -106,12 +107,35 @@ export interface ConversationViewerOptions {
 export interface ConversationViewerApi extends AiSessionDisposable {
     isOpen(): boolean;
     open(target: ConversationViewerTarget): Promise<void>;
+    restore(
+        panel: vscode.WebviewPanel,
+        target: ConversationViewerTarget
+    ): Promise<void>;
     follow(target: ConversationViewerTarget): Promise<boolean>;
+    rebindSession(
+        previous: Pick<ConversationViewerTarget, 'projectId' | 'provider' | 'sessionId'>,
+        next: Pick<ConversationViewerTarget, 'projectId' | 'provider' | 'sessionId'>
+    ): Promise<boolean>;
+    freezeSessionMetadata(
+        target: Pick<ConversationViewerTarget, 'projectId' | 'provider' | 'sessionId'>
+    ): Promise<boolean>;
+    reconcileReboundSession(
+        resolve: (
+            target: Pick<ConversationViewerTarget, 'projectId' | 'provider' | 'sessionId'>
+        ) => Pick<ConversationViewerTarget, 'projectId' | 'provider' | 'sessionId'>
+    ): Promise<boolean>;
     refresh(): Promise<void>;
     refreshPresentation(): Promise<void>;
     reconcileAuthority(
-        resolveAuthority: (target: ConversationViewerTarget) => boolean
+        resolveAuthority: (
+            target: ConversationViewerTarget
+        ) => boolean | ConversationViewerAuthorityMetadata
     ): Promise<void>;
+}
+
+export interface ConversationViewerAuthorityMetadata {
+    displayName: string;
+    duplicateDisplayName: boolean;
 }
 
 interface RetainedConversationPage {
@@ -134,6 +158,7 @@ export interface ConversationViewerPageMessage {
     previousCursor?: string;
     nextCursor?: string;
     stale: boolean;
+    displayName: string;
     subagents: ConversationSubagentEntry[];
     activeSubagent: { id: string; label: string } | null;
 }
@@ -156,6 +181,7 @@ export class ConversationViewer implements ConversationViewerApi {
     private latestPublication?: ConversationViewerPageMessage;
     private panelWasVisible = false;
     private suspended = false;
+    private rebindGeneration = 0;
     private authoritativeLoadInFlight?: Promise<boolean>;
     private authoritativeRefreshPending = false;
     private readonly commentController: ConversationCommentController;
@@ -207,6 +233,19 @@ export class ConversationViewer implements ConversationViewerApi {
         await this.loadTarget(target, true);
     }
 
+    async restore(
+        panel: vscode.WebviewPanel,
+        target: ConversationViewerTarget
+    ): Promise<void> {
+        if (this.panel && this.panel !== panel) {
+            panel.dispose();
+            return;
+        }
+        panel.webview.options = this.webviewOptions();
+        this.attachPanel(panel);
+        await this.loadTarget(target, false);
+    }
+
     async follow(target: ConversationViewerTarget): Promise<boolean> {
         if (!this.panel) {
             return false;
@@ -220,6 +259,95 @@ export class ConversationViewer implements ConversationViewerApi {
             return true;
         }
         return this.loadTarget(target, false);
+    }
+
+    async rebindSession(
+        previous: Pick<ConversationViewerTarget, 'projectId' | 'provider' | 'sessionId'>,
+        next: Pick<ConversationViewerTarget, 'projectId' | 'provider' | 'sessionId'>
+    ): Promise<boolean> {
+        const current = this.target;
+        if (!this.panel || !current
+            || current.projectId !== previous.projectId
+            || current.provider !== previous.provider
+            || current.sessionId !== previous.sessionId
+            || next.projectId !== previous.projectId
+            || next.provider !== previous.provider
+            || next.sessionId === previous.sessionId) {
+            return false;
+        }
+        const rebindGeneration = ++this.rebindGeneration;
+        let outline: ConversationOutline;
+        try {
+            const rebindRead = new ConversationAbortController();
+            outline = await this.options.readOutline(
+                next.provider,
+                next.sessionId,
+                rebindRead.signal
+            );
+        } catch (_error) {
+            return false;
+        }
+        if (rebindGeneration !== this.rebindGeneration
+            || this.target !== current || !this.panel
+            || outline.provider !== next.provider
+            || outline.sessionId !== next.sessionId
+            || !outline.interactions.length) {
+            return false;
+        }
+        const selected = outline.interactions.find(interaction =>
+            interaction.id === current.interactionId
+        ) || outline.interactions[outline.interactions.length - 1];
+        const { subagent: _oldSubagent, ...rootTarget } = current;
+        return this.loadTarget({
+            ...rootTarget,
+            sessionId: next.sessionId,
+            interactionId: selected.id,
+            expectedRevision: outline.sourceRevision,
+        }, false);
+    }
+
+    async freezeSessionMetadata(
+        target: Pick<ConversationViewerTarget, 'projectId' | 'provider' | 'sessionId'>
+    ): Promise<boolean> {
+        const current = this.target;
+        if (!this.panel || !current
+            || current.projectId !== target.projectId
+            || current.provider !== target.provider
+            || current.sessionId !== target.sessionId) {
+            await Promise.all([
+                this.commentController.drainMutations(),
+                this.bookmarkController.drainMutations(),
+            ]);
+            return false;
+        }
+        await Promise.all([
+            this.commentController.freezeMutations(),
+            this.bookmarkController.freezeMutations(),
+        ]);
+        return this.target === current && Boolean(this.panel);
+    }
+
+    async reconcileReboundSession(
+        resolve: (
+            target: Pick<ConversationViewerTarget, 'projectId' | 'provider' | 'sessionId'>
+        ) => Pick<ConversationViewerTarget, 'projectId' | 'provider' | 'sessionId'>
+    ): Promise<boolean> {
+        const current = this.target;
+        if (!this.panel || !current) {
+            return false;
+        }
+        const previous = {
+            projectId: current.projectId,
+            provider: current.provider,
+            sessionId: current.sessionId,
+        };
+        const next = resolve(previous);
+        if (next.projectId === previous.projectId
+            && next.provider === previous.provider
+            && next.sessionId === previous.sessionId) {
+            return false;
+        }
+        return this.rebindSession(previous, next);
     }
 
     private async loadTarget(
@@ -285,19 +413,23 @@ export class ConversationViewer implements ConversationViewerApi {
     }
 
     async reconcileAuthority(
-        resolveAuthority: (target: ConversationViewerTarget) => boolean
+        resolveAuthority: (
+            target: ConversationViewerTarget
+        ) => boolean | ConversationViewerAuthorityMetadata
     ): Promise<void> {
         const target = this.target;
         const panel = this.panel;
         if (!target || !panel) {
             return;
         }
-        let available = false;
+        let authority: boolean | ConversationViewerAuthorityMetadata = false;
         try {
-            available = resolveAuthority({ ...target }) === true;
+            authority = resolveAuthority({ ...target });
         } catch (_error) {
-            available = false;
+            authority = false;
         }
+        const available = authority === true
+            || (Boolean(authority) && typeof authority === 'object');
         if (!available) {
             if (this.suspended) {
                 return;
@@ -326,6 +458,17 @@ export class ConversationViewer implements ConversationViewerApi {
             }
             return;
         }
+        let metadataChanged = false;
+        if (typeof authority === 'object') {
+            const displayName = boundedConversationDisplayName(
+                authority.displayName
+            );
+            metadataChanged = target.displayName !== displayName
+                || target.duplicateDisplayName
+                    !== authority.duplicateDisplayName;
+            target.displayName = displayName;
+            target.duplicateDisplayName = authority.duplicateDisplayName;
+        }
         const wasSuspended = this.suspended;
         if (wasSuspended
             && !this.ensureWatch(this.subscriptionGeneration, true)) {
@@ -333,6 +476,11 @@ export class ConversationViewer implements ConversationViewerApi {
         }
         this.suspended = false;
         await this.refresh();
+        const expectedDisplayName = visibleConversationDisplayName(target);
+        if (metadataChanged
+            && this.latestPublication?.displayName !== expectedDisplayName) {
+            await this.refreshPresentation();
+        }
     }
 
     dispose(): void {
@@ -358,7 +506,10 @@ export class ConversationViewer implements ConversationViewerApi {
         this.latestPublication = undefined;
         this.commentController.reset();
         this.bookmarkController.reset();
-        this.target = { ...target };
+        this.target = {
+            ...target,
+            displayName: boundedConversationDisplayName(target.displayName),
+        };
         this.suspended = false;
         this.subscriptionGeneration += 1;
         this.currentRequestId = 0;
@@ -373,11 +524,23 @@ export class ConversationViewer implements ConversationViewerApi {
             AGENT_PIVOT_CONVERSATION_VIEW_TYPE,
             'AI Conversation',
             vscode.ViewColumn.Active,
-            {
-                enableScripts: true,
-                localResourceRoots: [this.options.mediaUri('')],
-            }
+            this.webviewOptions()
         );
+        this.attachPanel(panel);
+        return panel;
+    }
+
+    private webviewOptions(): vscode.WebviewOptions {
+        return {
+            enableScripts: true,
+            localResourceRoots: [this.options.mediaUri('')],
+        };
+    }
+
+    private attachPanel(panel: vscode.WebviewPanel): void {
+        if (this.panel === panel) {
+            return;
+        }
         this.panel = panel;
         this.panelWasVisible = panel.visible;
         this.messageListener = panel.webview.onDidReceiveMessage(
@@ -410,7 +573,6 @@ export class ConversationViewer implements ConversationViewerApi {
                 }
             }
         });
-        return panel;
     }
 
     private clear(_restoreTarget: ConversationViewerTarget | undefined): void {
@@ -1395,6 +1557,7 @@ export class ConversationViewer implements ConversationViewerApi {
                 ? last?.nextCursor || ''
                 : undefined,
             stale: this.stale,
+            displayName: visibleConversationDisplayName(target),
             subagents: this.subagents.map(entry => ({ ...entry })),
             activeSubagent: target.subagent ? { ...target.subagent } : null,
         };
@@ -1429,6 +1592,30 @@ export class ConversationViewer implements ConversationViewerApi {
             return false;
         }
     }
+}
+
+function boundedConversationDisplayName(value: string): string {
+    const graphemeBounded = truncateGraphemes(String(value || '').trim(), 200)
+        || 'Conversation';
+    if (graphemeBounded.length <= 600) {
+        return graphemeBounded;
+    }
+    let bounded = '';
+    for (const codePoint of Array.from(graphemeBounded)) {
+        if (bounded.length + codePoint.length > 599) {
+            break;
+        }
+        bounded += codePoint;
+    }
+    return `${bounded}…`;
+}
+
+function visibleConversationDisplayName(
+    target: ConversationViewerTarget
+): string {
+    return target.displayName + (target.duplicateDisplayName
+        ? ` · ${target.sessionId.slice(0, 8)}`
+        : '');
 }
 
 function isStaleRevision(error: unknown): error is ConversationError {

--- a/src/aiSessions/conversation/viewerDocument.ts
+++ b/src/aiSessions/conversation/viewerDocument.ts
@@ -107,6 +107,15 @@ export function renderConversationViewerDocument(
             sessionId: target.sessionId,
         })
     )}"`;
+    const restoreTargetAttribute = ` data-conversation-restore-target="${escapeAttribute(
+        JSON.stringify({
+            projectId: target.projectId,
+            provider: target.provider,
+            sessionId: target.sessionId,
+            interactionId: target.interactionId,
+            ...(target.subagent ? { subagentId: target.subagent.id } : {}),
+        })
+    )}"`;
     return `<!doctype html>
 <html lang="en">
 <head>
@@ -123,11 +132,13 @@ export function renderConversationViewerDocument(
 </head>
 <body data-auto-scroll-threshold="${CONVERSATION_LIMITS.autoScrollThresholdPx}"
     data-mermaid-src="${escapeAttribute(mermaid.toString())}"
-    data-subscription-generation="${options.subscriptionGeneration}"${initialPageAttribute}${commentStateAttribute}${bookmarkStateAttribute}${targetAttribute}>
+    data-subscription-generation="${options.subscriptionGeneration}"${initialPageAttribute}${commentStateAttribute}${bookmarkStateAttribute}${targetAttribute}${restoreTargetAttribute}>
     <header class="conversation-header">
         <div class="conversation-identity">
             <strong>${escapeHtml(providerLabel(target.provider))}</strong>
-            <span>${escapeHtml(target.displayName + duplicateId)}</span>
+            <span data-conversation-display-name>${escapeHtml(
+                target.displayName + duplicateId
+            )}</span>
         </div>
         <nav class="conversation-navigation" aria-label="Conversation navigation">
             <button class="conversation-icon-button" type="button"

--- a/src/aiSessions/conversation/viewerRestoreState.ts
+++ b/src/aiSessions/conversation/viewerRestoreState.ts
@@ -1,0 +1,63 @@
+'use strict';
+
+import { isAiSessionProviderId } from '../../models';
+import type { AiSessionProviderId } from '../../models';
+import { isSubagentId } from './subagentSessions';
+import {
+    hasExactKeys,
+    isConversationViewerTargetId,
+} from './viewerProtocol';
+
+export interface ConversationViewerRestoreTarget {
+    projectId: string;
+    provider: AiSessionProviderId;
+    sessionId: string;
+    interactionId: string;
+    subagentId?: string;
+}
+
+export function parseConversationViewerRestoreTarget(
+    state: unknown
+): ConversationViewerRestoreTarget | undefined {
+    if (!isRecord(state)) {
+        return undefined;
+    }
+    const envelope = state.conversationViewer;
+    if (!isRecord(envelope)
+        || !hasExactKeys(envelope, ['version', 'target'])
+        || envelope.version !== 1
+        || !isRecord(envelope.target)) {
+        return undefined;
+    }
+    const target = envelope.target;
+    const keys = Object.keys(target);
+    const hasSubagent = Object.prototype.hasOwnProperty.call(
+        target,
+        'subagentId'
+    );
+    if (!hasExactKeys(target, hasSubagent
+        ? ['projectId', 'provider', 'sessionId', 'interactionId', 'subagentId']
+        : ['projectId', 'provider', 'sessionId', 'interactionId'])
+        || !isConversationViewerTargetId(target.projectId)
+        || typeof target.provider !== 'string'
+        || !isAiSessionProviderId(target.provider)
+        || !isConversationViewerTargetId(target.sessionId)
+        || !isConversationViewerTargetId(target.interactionId)
+        || (hasSubagent && (typeof target.subagentId !== 'string'
+            || !isSubagentId(target.subagentId)))) {
+        return undefined;
+    }
+    return {
+        projectId: target.projectId,
+        provider: target.provider,
+        sessionId: target.sessionId,
+        interactionId: target.interactionId,
+        ...(hasSubagent ? { subagentId: target.subagentId as string } : {}),
+    };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return Boolean(value)
+        && typeof value === 'object'
+        && !Array.isArray(value);
+}

--- a/src/aiSessions/lifecycle.ts
+++ b/src/aiSessions/lifecycle.ts
@@ -90,18 +90,39 @@ function attention(
 
 export function createCodexLifecycleAccumulator(runStartedAtMs: number): AiSessionLifecycleAccumulator {
     let pendingInputCallIds = new Set<string>();
+    let turnRunning = false;
     return createAccumulator(runStartedAtMs, (event, occurredAtMs) => {
         let payload = event?.payload || {};
         if (event?.type === 'event_msg') {
             switch (payload.type) {
                 case 'task_started':
                     pendingInputCallIds.clear();
+                    turnRunning = true;
                     return running('codex', payload.type, occurredAtMs, payload.turn_id);
+                case 'agent_message':
+                    if (!turnRunning || pendingInputCallIds.size) {
+                        return null;
+                    }
+                    return running('codex', payload.type, occurredAtMs, payload.item_id);
+                case 'patch_apply_end':
+                case 'sub_agent_activity':
+                case 'image_generation_end':
+                    if (!turnRunning || pendingInputCallIds.size) {
+                        return null;
+                    }
+                    return running(
+                        'codex',
+                        payload.type,
+                        occurredAtMs,
+                        payload.event_id || payload.call_id
+                    );
                 case 'task_complete':
                     pendingInputCallIds.clear();
+                    turnRunning = false;
                     return attention('codex', payload.type, occurredAtMs, 'completed', payload.turn_id);
                 case 'turn_aborted':
                     pendingInputCallIds.clear();
+                    turnRunning = false;
                     return idle('codex', payload.type, occurredAtMs, payload.turn_id);
                 default:
                     return null;
@@ -111,12 +132,31 @@ export function createCodexLifecycleAccumulator(runStartedAtMs: number): AiSessi
             if (typeof payload.call_id === 'string' && payload.call_id) {
                 pendingInputCallIds.add(payload.call_id);
             }
+            turnRunning = false;
             return attention('codex', 'request_user_input', occurredAtMs, 'input-required', payload.call_id || payload.id);
         }
         if (event?.type === 'response_item' && payload.type === 'custom_tool_call_output'
             && typeof payload.call_id === 'string' && pendingInputCallIds.has(payload.call_id)) {
             pendingInputCallIds.delete(payload.call_id);
+            turnRunning = true;
             return running('codex', payload.type, occurredAtMs, payload.call_id);
+        }
+        if (event?.type === 'response_item'
+            && turnRunning
+            && pendingInputCallIds.size === 0
+            && (payload.type === 'reasoning'
+                || payload.type === 'agent_message'
+                || payload.type === 'custom_tool_call'
+                || payload.type === 'custom_tool_call_output'
+                || payload.type === 'function_call'
+                || payload.type === 'function_call_output'
+                || (payload.type === 'message' && payload.role === 'assistant'))) {
+            return running(
+                'codex',
+                payload.type,
+                occurredAtMs,
+                payload.call_id || payload.id
+            );
         }
         return null;
     });

--- a/src/aiSessions/tmuxRuntimeDiscovery.ts
+++ b/src/aiSessions/tmuxRuntimeDiscovery.ts
@@ -77,10 +77,14 @@ export interface TmuxRuntimeDiscoveryOptions {
     client: TmuxDiscoveryClient;
     bindingStore: TmuxDiscoveryBindingStore;
     codexRootThreadObserver?: CodexRootThreadObserver;
+    onSessionRebinding?: (
+        previous: AiSessionRuntimeIdentity,
+        next: AiSessionRuntimeIdentity
+    ) => PromiseLike<void> | void;
     onSessionRebound?: (
         previous: AiSessionRuntimeIdentity,
         next: AiSessionRuntimeIdentity
-    ) => void;
+    ) => PromiseLike<void> | void;
     markerIsCurrent: (markerPath: string, runStartedAtMs: number) => boolean | Promise<boolean>;
     nowMs?: () => number;
     cacheTtlMs?: number;
@@ -340,12 +344,12 @@ export class TmuxRuntimeDiscovery {
         }));
     }
 
-    private notifySessionRebound(
+    private async notifySessionRebound(
         previous: AiSessionRuntimeIdentity,
         next: AiSessionRuntimeIdentity
-    ): void {
+    ): Promise<void> {
         try {
-            this.options.onSessionRebound?.(
+            await this.options.onSessionRebound?.(
                 cloneAiSessionRuntimeIdentity(previous),
                 cloneAiSessionRuntimeIdentity(next)
             );
@@ -481,16 +485,26 @@ export class TmuxRuntimeDiscovery {
                     observedSessionId = null;
                 }
                 if (observedSessionId && observedSessionId !== locatorKnown.sessionId) {
-                    const rebound = await this.options.bindingStore.rebindKnown(
-                        locatorKnown, observedSessionId
-                    );
-                    if (rebound === 'rebound') {
-                        const nextIdentity = {
-                            ...projectedIdentity,
-                            sessionId: observedSessionId,
-                        };
-                        this.notifySessionRebound(projectedIdentity, nextIdentity);
-                        projectedIdentity = nextIdentity;
+                    const nextIdentity = {
+                        ...projectedIdentity,
+                        sessionId: observedSessionId,
+                    };
+                    try {
+                        await this.options.onSessionRebinding?.(
+                            cloneAiSessionRuntimeIdentity(projectedIdentity),
+                            cloneAiSessionRuntimeIdentity(nextIdentity)
+                        );
+                    } catch (_error) {
+                        observedSessionId = null;
+                    }
+                    if (observedSessionId) {
+                        const rebound = await this.options.bindingStore.rebindKnown(
+                            locatorKnown, observedSessionId
+                        );
+                        if (rebound === 'rebound') {
+                            await this.notifySessionRebound(projectedIdentity, nextIdentity);
+                            projectedIdentity = nextIdentity;
+                        }
                     }
                 }
             }

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1,7 +1,7 @@
 'use strict';
 import * as vscode from 'vscode';
 import * as childProcess from 'child_process';
-import { randomBytes } from 'crypto';
+import { createHash, randomBytes } from 'crypto';
 import { existsSync } from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -11,6 +11,7 @@ import { getProjectsPanelContent, getStewardContent } from './webview/webviewCon
 import { getSkillsPanelContent } from './webview/webviewSkillContent';
 import {
     AGENT_PIVOT_CONFIG_SECTION,
+    AGENT_PIVOT_CONVERSATION_VIEW_TYPE,
     AGENT_PIVOT_DASHBOARD_VIEW_ID,
     USER_CANCELED,
     RelevantExtensions,
@@ -45,6 +46,10 @@ import {
 import {
     ConversationBookmarkFileStore,
 } from './aiSessions/conversation/bookmarkStore';
+import {
+    ConversationSessionRebindCoordinator,
+    hasCommittedConversationSessionRuntimeRebind,
+} from './aiSessions/conversation/sessionRebindCoordinator';
 import AiSessionWorkspaceStateStore from './aiSessions/workspaceStateStore';
 import ActiveAiSessionTerminalHighlighter from './aiSessions/activeTerminalHighlight';
 import AttentionBridgeClient from './aiSessions/attentionBridgeClient';
@@ -84,6 +89,9 @@ import {
     ConversationCapability,
     createConversationCapability,
 } from './aiSessions/conversation/composition';
+import {
+    ConversationPanelRestoreCoordinator,
+} from './aiSessions/conversation/panelRestoreCoordinator';
 import {
     withConversationDisplayMetadata,
 } from './aiSessions/conversation/displayMetadata';
@@ -282,6 +290,15 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
             },
         ),
     );
+    const conversationPanelRestore = new ConversationPanelRestoreCoordinator();
+    context.subscriptions.push(conversationPanelRestore);
+    context.subscriptions.push(vscode.window.registerWebviewPanelSerializer(
+        AGENT_PIVOT_CONVERSATION_VIEW_TYPE,
+        {
+            deserializeWebviewPanel: (panel, state) =>
+                conversationPanelRestore.restorePanel(panel, state),
+        }
+    ));
 
     const dashboardCommandRegistration =
         new DashboardCommandRegistration<vscode.Disposable>({
@@ -307,6 +324,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
                     dashboardDiagnostics,
                     generation,
                     dashboardCommandRegistration,
+                    conversationPanelRestore,
                 );
                 return options;
             } catch (error) {
@@ -328,6 +346,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         },
         fail: generation => {
             dashboardCommandRegistration.discard(generation);
+            conversationPanelRestore.failPending();
             return provider.failBootstrap(generation);
         },
         transfer: resources => resources.transferTo(context.subscriptions),
@@ -345,6 +364,7 @@ async function initializeDashboard(
     dashboardDiagnostics: DashboardDiagnostics,
     bootstrapGeneration: number,
     dashboardCommandRegistration: DashboardCommandRegistration<vscode.Disposable>,
+    conversationPanelRestore: ConversationPanelRestoreCoordinator,
 ): Promise<AgentPivotViewProviderOptions> {
     const ownResource = <T extends { dispose(): unknown }>(factory: () => T): T => {
         let resource: T | undefined;
@@ -680,6 +700,19 @@ async function initializeDashboard(
         logError,
         showSaveError: () => vscode.window.showErrorMessage("Could not save the chat name."),
     });
+    const conversationCommentStore = new ConversationCommentFileStore(
+        context.globalStoragePath
+    );
+    const conversationBookmarkStore = new ConversationBookmarkFileStore(
+        context.globalStoragePath
+    );
+    let followConversationSessionRebind = (
+        _previous: { projectId: string; provider: AiSessionProviderId; sessionId: string },
+        _next: { projectId: string; provider: AiSessionProviderId; sessionId: string }
+    ): Promise<boolean> => Promise.resolve(false);
+    let freezeConversationSessionMetadata = (
+        _target: { projectId: string; provider: AiSessionProviderId; sessionId: string }
+    ): Promise<boolean> => Promise.resolve(false);
     const aiSessionTerminalBindingStore = new AiSessionTerminalBindingStore(context.workspaceState, error =>
         logError('Failed to persist AI session terminal ownership.', error)
     );
@@ -700,6 +733,66 @@ async function initializeDashboard(
             operation
         )
     );
+    const conversationSessionRebindCoordinator =
+        new ConversationSessionRebindCoordinator({
+            globalStoragePath: context.globalStoragePath,
+            commentStore: conversationCommentStore,
+            bookmarkStore: conversationBookmarkStore,
+            isRuntimeRebindCommitted: async (previous, next) =>
+                hasCommittedConversationSessionRuntimeRebind(
+                    (await tmuxRuntimeStore.listKnown()).map(binding => ({
+                        provider: binding.provider,
+                        sessionId: binding.sessionId,
+                        projectId: getCurrentWorkspaceConversationProjectId(
+                            binding.workspaceScopeIdentity
+                        ),
+                    })),
+                    previous,
+                    next
+                ),
+            onResult: (kind, result) => logAiSessionDiagnostic({
+                event: 'conversation-session-rebind-metadata',
+                kind,
+                result,
+            }),
+            onFailure: (kind, error) => logAiSessionRuntimeFailure(
+                `copy-conversation-${kind}-for-rebind`,
+                error
+            ),
+        });
+    const conversationViewerCommentStore = {
+        load: (target: { projectId: string; provider: AiSessionProviderId; sessionId: string }) =>
+            conversationCommentStore.load(
+                conversationSessionRebindCoordinator.resolve(target)
+            ),
+        save: (
+            target: { projectId: string; provider: AiSessionProviderId; sessionId: string },
+            snapshot: Parameters<typeof conversationCommentStore.save>[1]
+        ) => conversationCommentStore.save(
+            conversationSessionRebindCoordinator.resolve(target),
+            snapshot
+        ),
+    };
+    const conversationViewerBookmarkStore = {
+        load: (target: { projectId: string; provider: AiSessionProviderId; sessionId: string }) =>
+            conversationBookmarkStore.load(
+                conversationSessionRebindCoordinator.resolve(target)
+            ),
+        save: (
+            target: { projectId: string; provider: AiSessionProviderId; sessionId: string },
+            snapshot: Parameters<typeof conversationBookmarkStore.save>[1]
+        ) => conversationBookmarkStore.save(
+            conversationSessionRebindCoordinator.resolve(target),
+            snapshot
+        ),
+    };
+    const conversationSessionRebindRestoreTask =
+        conversationSessionRebindCoordinator.restore().catch(error => {
+            logAiSessionRuntimeFailure(
+                'restore-conversation-session-rebinds',
+                error
+            );
+        });
     const tmuxAttachBindingStore = new TmuxAttachBindingStore(context.workspaceState, error => {
         logAiSessionRuntimeFailure('persist-attach-binding', error);
     });
@@ -708,11 +801,77 @@ async function initializeDashboard(
         client: tmuxClient,
         bindingStore: tmuxRuntimeStore,
         codexRootThreadObserver: new ProcCodexRootThreadObserver(),
-        onSessionRebound: (previous, next) => aiSessionAliasController.copyForRebind(
-            previous.provider,
-            previous.sessionId || '',
-            next.sessionId || ''
-        ),
+        onSessionRebinding: async (previous, next) => {
+            const projectId = getCurrentWorkspaceConversationProjectId(
+                previous.workspaceScopeIdentity
+            );
+            if (!projectId || !previous.sessionId || !next.sessionId
+                || previous.provider !== next.provider
+                || previous.workspaceScopeIdentity !== next.workspaceScopeIdentity) {
+                throw new Error('Invalid conversation Session rebind identity.');
+            }
+            await conversationSessionRebindCoordinator.prepare({
+                projectId,
+                provider: previous.provider,
+                sessionId: previous.sessionId,
+            }, {
+                projectId,
+                provider: next.provider,
+                sessionId: next.sessionId,
+            });
+        },
+        onSessionRebound: async (previous, next) => {
+            aiSessionAliasController.copyForRebind(
+                previous.provider,
+                previous.sessionId || '',
+                next.sessionId || ''
+            );
+            const projectId = getCurrentWorkspaceConversationProjectId(
+                previous.workspaceScopeIdentity
+            );
+            if (!projectId || !previous.sessionId || !next.sessionId
+                || previous.provider !== next.provider
+                || previous.workspaceScopeIdentity !== next.workspaceScopeIdentity) {
+                return;
+            }
+            const previousTarget = {
+                projectId,
+                provider: previous.provider,
+                sessionId: previous.sessionId,
+            };
+            const nextTarget = {
+                projectId,
+                provider: next.provider,
+                sessionId: next.sessionId,
+            };
+            await freezeConversationSessionMetadata(previousTarget);
+            try {
+                await conversationSessionRebindCoordinator.commit(
+                    previousTarget,
+                    nextTarget
+                );
+            } catch (error) {
+                logAiSessionRuntimeFailure(
+                    'migrate-conversation-session-rebind',
+                    error
+                );
+            }
+            if (conversationSessionRebindCoordinator.resolve(previousTarget)
+                .sessionId !== nextTarget.sessionId) {
+                return;
+            }
+            try {
+                await followConversationSessionRebind(
+                    previousTarget,
+                    nextTarget
+                );
+            } catch (error) {
+                logAiSessionRuntimeFailure(
+                    'follow-conversation-session-rebind',
+                    error
+                );
+            }
+        },
         markerIsCurrent: isCurrentRuntimeMarker,
     });
     const persistedInactiveRestoreTask = (async (): Promise<void> => {
@@ -1238,12 +1397,10 @@ async function initializeDashboard(
         setTimer: setTimeout,
         clearTimer: clearTimeout,
         onDiagnostic: event => logAiSessionDiagnostic({ ...event }),
-        commentStore: new ConversationCommentFileStore(
-            context.globalStoragePath
-        ),
-        bookmarkStore: new ConversationBookmarkFileStore(
-            context.globalStoragePath
-        ),
+        commentStore: conversationViewerCommentStore,
+        bookmarkStore: conversationViewerBookmarkStore,
+        resolveReboundTarget: target =>
+            conversationSessionRebindCoordinator.resolve(target),
         getShowThinking: () => getAgentPivotConfiguration()
             .get<unknown>('aiConversation.showThinking', false) === true,
         submitPrompt: (viewerTarget, prompt) => submitConversationPrompt({
@@ -1266,6 +1423,18 @@ async function initializeDashboard(
             );
         },
     }));
+    followConversationSessionRebind = (previous, next) =>
+        conversationCapability.rebindSession(previous, next);
+    freezeConversationSessionMetadata = target =>
+        conversationCapability.freezeSessionMetadata(target);
+    resources.own(conversationPanelRestore.connectWhenReady(
+        conversationCapability,
+        Promise.all([
+            directTerminalRestoreOutcomeTask,
+            tmuxRestoreTask,
+            conversationSessionRebindRestoreTask,
+        ])
+    ));
     const conversationHandlers = {
         'open-active-ai-session-conversation': async (e: Record<string, unknown>) => {
             if (e.version !== 1
@@ -2065,4 +2234,20 @@ export async function deactivate(): Promise<void> {
     const openWorkspaceClient = activeOpenWorkspaceBridgeClient;
     activeOpenWorkspaceBridgeClient = null;
     await openWorkspaceClient?.shutdown();
+}
+
+function getCurrentWorkspaceConversationProjectId(
+    workspaceScopeIdentity: unknown
+): string | null {
+    if (typeof workspaceScopeIdentity !== 'string'
+        || workspaceScopeIdentity.length === 0
+        || workspaceScopeIdentity.length > 512
+        || /[\u0000-\u001f\u007f]/.test(workspaceScopeIdentity)) {
+        return null;
+    }
+    const digest = createHash('sha256')
+        .update(workspaceScopeIdentity)
+        .digest('hex')
+        .slice(0, 24);
+    return `__currentWorkspace-${digest}`;
 }

--- a/src/webview/conversationViewerScripts.js
+++ b/src/webview/conversationViewerScripts.js
@@ -33,6 +33,9 @@
     var working = document.querySelector('[data-conversation-working]');
     var position = document.querySelector('[data-conversation-position]');
     var status = document.querySelector('[data-conversation-status]');
+    var conversationDisplayName = document.querySelector(
+        '[data-conversation-display-name]'
+    );
     var telemetryRoot = document.querySelector('[data-conversation-telemetry]');
     var telemetryModel = document.querySelector('[data-telemetry-model]');
     var telemetryModelValue = document.querySelector(
@@ -119,6 +122,9 @@
         '[data-telemetry-comments]'
     );
     var commentTarget = readJsonAttribute('data-conversation-target');
+    var restoreTarget = readJsonAttribute(
+        'data-conversation-restore-target'
+    );
     var sidebarUiAvailable = !!sidebarToggle
         && !!commentsWorkspace && !!commentsResizer && !!sidebarRoot
         && sidebarTabs.length === 3 && !!outlineRoot
@@ -477,6 +483,55 @@
             && value.sessionId.length > 0;
     }
 
+    function validRestoreTarget(value) {
+        if (!value || typeof value !== 'object' || Array.isArray(value)) {
+            return false;
+        }
+        var keys = Object.keys(value);
+        var hasSubagent = Object.prototype.hasOwnProperty.call(
+            value,
+            'subagentId'
+        );
+        return keys.length === (hasSubagent ? 5 : 4)
+            && typeof value.projectId === 'string'
+            && value.projectId.length > 0
+            && (value.provider === 'codex'
+                || value.provider === 'kimi'
+                || value.provider === 'claude')
+            && typeof value.sessionId === 'string'
+            && value.sessionId.length > 0
+            && typeof value.interactionId === 'string'
+            && value.interactionId.length > 0
+            && (!hasSubagent
+                || (typeof value.subagentId === 'string'
+                    && value.subagentId.length > 0));
+    }
+
+    function saveRestoreTarget(nextTarget) {
+        if (!validRestoreTarget(nextTarget)
+            || !vscodeApi
+            || typeof vscodeApi.setState !== 'function') {
+            return;
+        }
+        restoreTarget = Object.assign({}, nextTarget);
+        try {
+            var saved = typeof vscodeApi.getState === 'function'
+                ? vscodeApi.getState()
+                : null;
+            var next = saved && typeof saved === 'object'
+                && !Array.isArray(saved)
+                ? Object.assign({}, saved)
+                : {};
+            next.conversationViewer = {
+                version: 1,
+                target: Object.assign({}, restoreTarget),
+            };
+            vscodeApi.setState(next);
+        } catch (_error) {
+            // Panel restoration is best-effort local Webview state.
+        }
+    }
+
     function validOutlineEntry(entry) {
         if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
             return false;
@@ -568,6 +623,7 @@
         ];
         var allowedKeys = new Set(requiredKeys.concat([
             'previousCursor', 'nextCursor', 'subagents', 'activeSubagent',
+            'displayName',
         ]));
         if (Object.keys(message).some(function (key) {
             return !allowedKeys.has(key);
@@ -600,6 +656,9 @@
                 || typeof message.nextCursor === 'string')
             && validSubagents(message.subagents)
             && validActiveSubagent(message.activeSubagent)
+            && (message.displayName === undefined
+                || (typeof message.displayName === 'string'
+                    && message.displayName.length <= 640))
             && typeof message.stale === 'boolean';
     }
 
@@ -675,6 +734,15 @@
         state.messageSignatures = nextSignatures;
         state.atLatest = message.atLatest;
         state.initialized = true;
+        var nextRestoreTarget = Object.assign({}, restoreTarget || {}, {
+            interactionId: message.selectedInteractionId,
+        });
+        if (message.activeSubagent) {
+            nextRestoreTarget.subagentId = message.activeSubagent.id;
+        } else {
+            delete nextRestoreTarget.subagentId;
+        }
+        saveRestoreTarget(nextRestoreTarget);
         outlineController.applyOutline(message);
         if (subagentsController) {
             subagentsController.apply(
@@ -683,6 +751,10 @@
             );
         }
         commentsController.updateHighlights();
+        if (conversationDisplayName
+            && typeof message.displayName === 'string') {
+            conversationDisplayName.textContent = message.displayName;
+        }
         updatePosition(message);
         var latestInteraction = message.outline[message.outline.length - 1];
         working.hidden = !message.atLatest
@@ -830,6 +902,7 @@
     });
     window.addEventListener('unload', releaseMermaidObjectUrls);
 
+    saveRestoreTarget(restoreTarget);
     var initialPage = document.body.getAttribute('data-initial-page');
     if (initialPage) {
         document.body.removeAttribute('data-initial-page');

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -3,9 +3,16 @@
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const Module = require('node:module');
+const os = require('node:os');
 const path = require('node:path');
 const test = require('node:test');
 const { chromium } = require('playwright-chromium');
+const {
+    ConversationCommentFileStore,
+} = require('../../out/aiSessions/conversation/commentStore');
+const {
+    ConversationBookmarkFileStore,
+} = require('../../out/aiSessions/conversation/bookmarkStore');
 
 const purifyScript = fs.readFileSync(
     path.join(__dirname, '../../node_modules/dompurify/dist/purify.min.js'),
@@ -181,6 +188,7 @@ async function openViewerPage(t, options = {}) {
                 data-subscription-generation="1"
                 data-conversation-target='{"projectId":"project-1","provider":"codex","sessionId":"session-telemetry"}'>
                 <header>
+                    <span data-conversation-display-name>Original session</span>
                     <span data-conversation-position>Input 0 of 0</span>
                     <button type="button" data-action="previous">Previous</button>
                     <button type="button" data-action="next">Next</button>
@@ -886,6 +894,62 @@ async function realHostAppendPublications() {
     return { initial, refresh };
 }
 
+test('WEBVIEW-AI-SESSION-CONVERSATION-VIEWER-001 persists the authoritative target for extension-host reload restoration', async t => {
+    const { page } = await openHostViewerDocument(t, {
+        initialWebviewState: {
+            conversationSidebar: { open: true, width: 260, view: 'outline' },
+        },
+    });
+
+    const savedState = await page.evaluate(() => window.__webviewState);
+    assert.deepEqual(savedState.conversationSidebar, {
+        open: true,
+        width: 260,
+        view: 'outline',
+    });
+    assert.deepEqual(savedState.conversationViewer, {
+        version: 1,
+        target: {
+            projectId: 'project-a',
+            provider: 'codex',
+            sessionId: 'session-host-document',
+            interactionId: 'input-2',
+        },
+    });
+});
+
+test('CONVERSATION-SESSION-REBIND-001 updates the identity without replacing focused DOM state', async t => {
+    const page = await openViewerPage(t);
+    await page.evaluate(() => {
+        const draft = document.createElement('input');
+        draft.setAttribute('data-test-local-draft', '');
+        draft.value = 'unfinished local draft';
+        document.body.appendChild(draft);
+        draft.focus();
+    });
+
+    await sendPage(page, {
+        ...hostileConversationPage,
+        requestId: 2,
+        displayName: 'Rebound session',
+    });
+
+    assert.equal(
+        await page.locator('[data-conversation-display-name]').innerText(),
+        'Rebound session'
+    );
+    assert.equal(
+        await page.locator('[data-test-local-draft]').inputValue(),
+        'unfinished local draft'
+    );
+    assert.equal(
+        await page.locator('[data-test-local-draft]').evaluate(
+            element => element === document.activeElement
+        ),
+        true
+    );
+});
+
 function assertMessageFillsReadingArea(message, name, messagesBounds) {
     const tolerance = 1;
     assert.ok(
@@ -1261,15 +1325,13 @@ test('CONVERSATION-OUTLINE-NAVIGATION-001 filters the current Session outline an
         1
     );
     assert.deepEqual(
-        await page.evaluate(() => window.__webviewState),
+        await page.evaluate(() => window.__webviewState.conversationSidebar),
         {
-            conversationSidebar: {
-                open: true,
-                width: 240,
-                view: 'outline',
-                query: 'deploy',
-                subagentsRunningOnly: false,
-            },
+            open: true,
+            width: 240,
+            view: 'outline',
+            query: 'deploy',
+            subagentsRunningOnly: false,
         }
     );
     await page.locator('[data-outline-search]').fill('');
@@ -1457,6 +1519,65 @@ test('CONVERSATION-OUTLINE-BOOKMARKS-001 settles stars authoritatively, filters 
     );
 });
 
+test('CONVERSATION-SESSION-REBIND-001 renders comments and bookmarks copied to the rebound Session', async t => {
+    const root = await fs.promises.mkdtemp(
+        path.join(os.tmpdir(), 'agent-pivot-conversation-rebind-browser-')
+    );
+    t.after(() => fs.promises.rm(root, { recursive: true, force: true }));
+    const commentStore = new ConversationCommentFileStore(root);
+    const bookmarkStore = new ConversationBookmarkFileStore(root);
+    const previous = {
+        projectId: 'project-a',
+        provider: 'codex',
+        sessionId: 'old-root',
+    };
+    const next = { ...previous, sessionId: 'session-host-document' };
+    await commentStore.save(previous, {
+        revision: 5,
+        comments: [{
+            id: 'rebound-comment',
+            messageId: 'input-2:user',
+            interactionId: 'input-2',
+            role: 'user',
+            quote: 'input-2',
+            prefix: '',
+            suffix: '',
+            comment: 'Survives the root rollover.',
+            status: 'open',
+        }],
+    });
+    await bookmarkStore.save(previous, {
+        revision: 4,
+        interactionIds: ['input-2'],
+    });
+    await Promise.all([
+        commentStore.copyForRebind(previous, next),
+        bookmarkStore.copyForRebind(previous, next),
+    ]);
+
+    const { page } = await openHostViewerDocument(t, {
+        initialWebviewState: {
+            conversationCommentsPanel: {
+                open: true,
+                width: 240,
+                view: 'comments',
+            },
+        },
+        commentStore,
+        bookmarkStore,
+    });
+
+    assert.equal(
+        await page.locator('[data-comment-id="rebound-comment"]').count(),
+        1
+    );
+    assert.equal(
+        await page.locator('[data-outline-bookmark-id="input-2"]')
+            .getAttribute('aria-pressed'),
+        'true'
+    );
+});
+
 test('CONVERSATION-OUTLINE-NAVIGATION-001 CONVERSATION-COMMENTS-LAYOUT-001 shares one resizable and responsive Outline or Comments panel', async t => {
     const options = {
         includeStyles: true,
@@ -1489,15 +1610,13 @@ test('CONVERSATION-OUTLINE-NAVIGATION-001 CONVERSATION-COMMENTS-LAYOUT-001 share
     await resizer.press('ArrowLeft');
     assert.equal(await resizer.getAttribute('aria-valuenow'), '272');
     assert.deepEqual(
-        await page.evaluate(() => window.__webviewState),
+        await page.evaluate(() => window.__webviewState.conversationSidebar),
         {
-            conversationSidebar: {
-                open: true,
-                width: 272,
-                view: 'outline',
-                query: '',
-                subagentsRunningOnly: false,
-            },
+            open: true,
+            width: 272,
+            view: 'outline',
+            query: '',
+            subagentsRunningOnly: false,
         }
     );
 
@@ -1506,15 +1625,13 @@ test('CONVERSATION-OUTLINE-NAVIGATION-001 CONVERSATION-COMMENTS-LAYOUT-001 share
     assert.equal(await panel.isHidden(), true);
     assert.equal(await resizer.isHidden(), true);
     assert.deepEqual(
-        await page.evaluate(() => window.__webviewState),
+        await page.evaluate(() => window.__webviewState.conversationSidebar),
         {
-            conversationSidebar: {
-                open: false,
-                width: 272,
-                view: 'outline',
-                query: '',
-                subagentsRunningOnly: false,
-            },
+            open: false,
+            width: 272,
+            view: 'outline',
+            query: '',
+            subagentsRunningOnly: false,
         }
     );
 

--- a/tests/contract/aiSessions/runtimeComposition.test.js
+++ b/tests/contract/aiSessions/runtimeComposition.test.js
@@ -249,7 +249,7 @@ test('WEBVIEW-TWO-STAGE-STARTUP-001 deferred Direct recovery failure keeps ready
     }
 });
 
-test('RUNTIME-HOST-RUNTIME-COMPOSITION-001 SESSION-ALIAS-THREAD-SWITCH-001 ATTENTION-ACTIVE-UNREGISTER-ON-DEACTIVATE-001 production activation wires lifecycle ownership around deferred recovery', () => {
+test('RUNTIME-HOST-RUNTIME-COMPOSITION-001 SESSION-ALIAS-THREAD-SWITCH-001 CONVERSATION-SESSION-REBIND-001 ATTENTION-ACTIVE-UNREGISTER-ON-DEACTIVATE-001 production activation wires lifecycle ownership around deferred recovery', () => {
     const result = runProductionActivation('success');
     assert.equal(result.failure, null);
     assert.deepEqual(result.events.filter(isRestoreEvent), [
@@ -264,6 +264,26 @@ test('RUNTIME-HOST-RUNTIME-COMPOSITION-001 SESSION-ALIAS-THREAD-SWITCH-001 ATTEN
         'tmux-backend',
     ]);
     assert.deepEqual(result.aliasRebinds, [['codex', 'old-root', 'new-root']]);
+    assert.deepEqual(result.conversationMetadataRebinds, [
+        ['comments', {
+            projectId: result.expectedConversationProjectId,
+            provider: 'codex',
+            sessionId: 'old-root',
+        }, {
+            projectId: result.expectedConversationProjectId,
+            provider: 'codex',
+            sessionId: 'new-root',
+        }],
+        ['bookmarks', {
+            projectId: result.expectedConversationProjectId,
+            provider: 'codex',
+            sessionId: 'old-root',
+        }, {
+            projectId: result.expectedConversationProjectId,
+            provider: 'codex',
+            sessionId: 'new-root',
+        }],
+    ]);
 });
 
 test('RUNTIME-HOST-RUNTIME-COMPOSITION-001 Direct recovery failure preserves independent tmux restore without blocking hydration', () => {

--- a/tests/contract/aiSessions/tmuxDiscovery.test.js
+++ b/tests/contract/aiSessions/tmuxDiscovery.test.js
@@ -303,6 +303,12 @@ test('RUNTIME-TMUX-THREAD-SWITCH-001 SESSION-ALIAS-THREAD-SWITCH-001 rebinds one
             return 'new-root';
         },
     };
+    const rebindOrder = [];
+    const rebindKnown = store.rebindKnown;
+    store.rebindKnown = async (...args) => {
+        rebindOrder.push('runtime-commit');
+        return rebindKnown(...args);
+    };
     const discovery = new TmuxRuntimeDiscovery({
         client: { listWindows: async () => [row] },
         bindingStore: store,
@@ -310,6 +316,7 @@ test('RUNTIME-TMUX-THREAD-SWITCH-001 SESSION-ALIAS-THREAD-SWITCH-001 rebinds one
         markerIsCurrent: () => false,
         nowMs: () => 2000,
         cacheTtlMs: 0,
+        onSessionRebinding: async () => { rebindOrder.push('intent'); },
         onSessionRebound: (previous, next) => reboundEvents.push({ previous, next }),
     });
 
@@ -328,6 +335,7 @@ test('RUNTIME-TMUX-THREAD-SWITCH-001 SESSION-ALIAS-THREAD-SWITCH-001 rebinds one
         event.next.provider,
         event.next.sessionId,
     ]), [['codex', 'old-root', 'codex', 'new-root']]);
+    assert.deepEqual(rebindOrder, ['intent', 'runtime-commit']);
 
     const restarted = new TmuxRuntimeDiscovery({
         client: { listWindows: async () => [row] },
@@ -349,7 +357,7 @@ test('RUNTIME-TMUX-THREAD-SWITCH-001 preserves the durable projection when obser
         windowName: row.windowName,
     };
     let reboundEvents = 0;
-    for (const failure of ['observer', 'stale', 'missing']) {
+    for (const failure of ['observer', 'prepare', 'stale', 'missing']) {
         const store = createSyntheticTmuxStore({
             known: [makeTmuxKnownBinding('old-root', { locator })],
         });
@@ -368,6 +376,11 @@ test('RUNTIME-TMUX-THREAD-SWITCH-001 preserves the durable projection when obser
             markerIsCurrent: () => false,
             nowMs: () => 2000,
             cacheTtlMs: 0,
+            onSessionRebinding: async () => {
+                if (failure === 'prepare') {
+                    throw new Error('controlled durable intent failure');
+                }
+            },
             onSessionRebound: () => { reboundEvents += 1; },
         });
         await discovery.refresh(true);
@@ -380,7 +393,43 @@ test('RUNTIME-TMUX-THREAD-SWITCH-001 preserves the durable projection when obser
     assert.equal(reboundEvents, 0);
 });
 
-test('SESSION-ALIAS-THREAD-SWITCH-001 keeps a committed rebind when the alias hook fails', async () => {
+test('CONVERSATION-SESSION-REBIND-001 waits for Session metadata migration before publishing the rebound runtime', async () => {
+    const row = makeTmuxDiscoveryRow({ sessionId: 'old-root', panePid: 4321 });
+    const locator = {
+        layout: 'project',
+        sessionName: row.sessionName,
+        windowName: row.windowName,
+    };
+    const store = createSyntheticTmuxStore({
+        known: [makeTmuxKnownBinding('old-root', { locator })],
+    });
+    let releaseMigration;
+    const migrationGate = new Promise(resolve => { releaseMigration = resolve; });
+    let migrationEntered = false;
+    let refreshSettled = false;
+    const discovery = new TmuxRuntimeDiscovery({
+        client: { listWindows: async () => [row] },
+        bindingStore: store,
+        codexRootThreadObserver: { observe: async () => 'new-root' },
+        onSessionRebound: async () => {
+            migrationEntered = true;
+            await migrationGate;
+        },
+        markerIsCurrent: () => false,
+        cacheTtlMs: 0,
+    });
+
+    const refresh = discovery.refresh(true).then(() => { refreshSettled = true; });
+    await new Promise(resolve => setImmediate(resolve));
+    assert.equal(migrationEntered, true);
+    assert.equal(refreshSettled, false);
+
+    releaseMigration();
+    await refresh;
+    assert.deepEqual(discovery.getActive().map(runtime => runtime.identity.sessionId), ['new-root']);
+});
+
+test('SESSION-ALIAS-THREAD-SWITCH-001 CONVERSATION-SESSION-REBIND-001 keeps a committed rebind when an asynchronous metadata hook fails', async () => {
     const row = makeTmuxDiscoveryRow({ sessionId: 'old-root', panePid: 4321 });
     const locator = {
         layout: 'project',
@@ -394,7 +443,9 @@ test('SESSION-ALIAS-THREAD-SWITCH-001 keeps a committed rebind when the alias ho
         client: { listWindows: async () => [row] },
         bindingStore: store,
         codexRootThreadObserver: { observe: async () => 'new-root' },
-        onSessionRebound: () => { throw new Error('controlled alias hook failure'); },
+        onSessionRebound: async () => {
+            throw new Error('controlled metadata hook failure');
+        },
         markerIsCurrent: () => false,
         cacheTtlMs: 0,
     });

--- a/tests/fixtures/aiSessions/runtimeHostActivationHarness.js
+++ b/tests/fixtures/aiSessions/runtimeHostActivationHarness.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assert = require('node:assert/strict');
+const crypto = require('node:crypto');
 const Module = require('node:module');
 const fs = require('node:fs');
 const os = require('node:os');
@@ -110,6 +111,8 @@ function createVscode(lifecycle) {
                 ));
                 return trackedResource('provider-registration');
             },
+            registerWebviewPanelSerializer: () =>
+                trackedResource('panel-serializer-registration'),
             onDidChangeActiveTerminal: () => trackedListener('active-terminal-listener'),
             onDidOpenTerminal: callback => {
                 openTerminalCallbacks.push(callback);
@@ -257,6 +260,7 @@ async function main() {
     const restoreAttachTerminalsInvocations = [];
     const affectsConfigurationQueries = [];
     const fallbackResumeStatuses = [];
+    const conversationMetadataRebinds = [];
     let coordinatorInstance;
     let coordinatorGetActiveCalls = 0;
     let coordinatorGetPendingCalls = 0;
@@ -371,6 +375,9 @@ async function main() {
         const { AiSessionAttentionController } = require('../../../out/aiSessions/attentionController');
         const AttentionBridgeClient = require('../../../out/aiSessions/attentionBridgeClient').default;
         const AiSessionAliasController = require('../../../out/aiSessions/aliasController').default;
+        const { ConversationCommentFileStore } = require('../../../out/aiSessions/conversation/commentStore');
+        const { ConversationBookmarkFileStore } = require('../../../out/aiSessions/conversation/bookmarkStore');
+        const { ConversationSessionRebindCoordinator } = require('../../../out/aiSessions/conversation/sessionRebindCoordinator');
         const { DashboardCommandRegistration } = require('../../../out/dashboard/commandRegistration');
         const { DashboardStartupController } = require('../../../out/dashboard/startupController');
         const { ProjectMutationController } = require('../../../out/projects/projectMutationController');
@@ -397,19 +404,27 @@ async function main() {
         patch(AiSessionAliasController.prototype, 'copyForRebind', function (...args) {
             aliasRebinds.push(args);
         });
+        patch(ConversationCommentFileStore.prototype, 'copyForRebind', async function (...args) {
+            conversationMetadataRebinds.push(['comments', ...args]);
+            return 'copied';
+        });
+        patch(ConversationBookmarkFileStore.prototype, 'copyForRebind', async function (...args) {
+            conversationMetadataRebinds.push(['bookmarks', ...args]);
+            return 'copied';
+        });
+        patch(ConversationSessionRebindCoordinator.prototype, 'restore', async function () {});
+        patch(ConversationSessionRebindCoordinator.prototype, 'prepare', async function () {});
+        patch(ConversationSessionRebindCoordinator.prototype, 'commit', async function (previous, next) {
+            await this.options.commentStore.copyForRebind(previous, next);
+            await this.options.bookmarkStore.copyForRebind(previous, next);
+        });
 
         patch(TmuxRuntimeDiscovery.prototype, 'loadPersistedInactive', async function () {
             assert.ok(this instanceof TmuxRuntimeDiscovery);
             assert.ok(this.options.client instanceof TmuxClient);
             assert.ok(this.options.bindingStore instanceof TmuxRuntimeBindingStore);
+            assert.equal(typeof this.options.onSessionRebinding, 'function');
             assert.equal(typeof this.options.onSessionRebound, 'function');
-            if (!simulatedAliasRebind) {
-                simulatedAliasRebind = true;
-                this.options.onSessionRebound(
-                    { provider: 'codex', sessionId: 'old-root' },
-                    { provider: 'codex', sessionId: 'new-root' }
-                );
-            }
             verified.add('client-store-discovery');
             verified.add('thread-switch-alias-wiring');
             if ((mode === 'slow-runtime-restore' || mode === 'blocked-restore-budget')
@@ -426,6 +441,21 @@ async function main() {
                 initialInactiveRestoreRecorded = true;
                 events.push('inactive-restored');
                 inactiveRestoreSettled = true;
+            }
+            if (!simulatedAliasRebind) {
+                simulatedAliasRebind = true;
+                const previous = {
+                    provider: 'codex',
+                    sessionId: 'old-root',
+                    workspaceScopeIdentity: 'workspace-scope-a',
+                };
+                const next = {
+                    provider: 'codex',
+                    sessionId: 'new-root',
+                    workspaceScopeIdentity: 'workspace-scope-a',
+                };
+                await this.options.onSessionRebinding(previous, next);
+                await this.options.onSessionRebound(previous, next);
             }
         });
         patch(TerminalService.prototype, 'restorePersistedTerminals', async function () {
@@ -927,6 +957,12 @@ async function main() {
             registeredCommands: vscode.registeredCommands,
             dashboardCommandRegistrationInvocations,
             aliasRebinds,
+            conversationMetadataRebinds,
+            expectedConversationProjectId: `__currentWorkspace-${crypto
+                .createHash('sha256')
+                .update('workspace-scope-a')
+                .digest('hex')
+                .slice(0, 24)}`,
             attentionShutdownCalls,
             synchronizedGlobalStateKeySets,
             startupDiagnostics,

--- a/tests/integration/dashboard/conversationOpenLatest.test.js
+++ b/tests/integration/dashboard/conversationOpenLatest.test.js
@@ -49,6 +49,9 @@ function loadConversationComposition() {
 const {
     createConversationCapability,
 } = loadConversationComposition();
+const {
+    ConversationPanelRestoreCoordinator,
+} = require('../../../out/aiSessions/conversation/panelRestoreCoordinator');
 
 function makeService(provider) {
     return {
@@ -103,6 +106,7 @@ function makeSession(overrides = {}) {
 function createHarness(options = {}) {
     const viewerTargets = [];
     const followedViewerTargets = [];
+    const restoredViewerTargets = [];
     let capturedViewerOptions;
     let outlineReads = 0;
     const session = 'session' in options ? options.session : makeSession({
@@ -155,6 +159,7 @@ function createHarness(options = {}) {
         setTimer: (callback, delayMs) => setTimeout(callback, delayMs),
         clearTimer: handle => clearTimeout(handle),
         onDiagnostic: () => {},
+        resolveReboundTarget: options.resolveReboundTarget,
     }, {
         createCodexClient: options.createCodexClient || (() => ({ dispose() {} })),
         createCodexAdapter: fakeAdapter('codex'),
@@ -167,10 +172,15 @@ function createHarness(options = {}) {
                 open: async target => {
                     viewerTargets.push(target);
                 },
+                restore: async (panel, target) => {
+                    restoredViewerTargets.push({ panel, target });
+                },
                 follow: async target => {
                     followedViewerTargets.push(target);
                     return true;
                 },
+                rebindSession: async () => false,
+                freezeSessionMetadata: async () => false,
                 refresh: async () => undefined,
                 reconcileAuthority: async () => undefined,
                 dispose() {},
@@ -181,6 +191,7 @@ function createHarness(options = {}) {
         capability,
         viewerTargets,
         followedViewerTargets,
+        restoredViewerTargets,
         get viewerOptions() {
             return capturedViewerOptions;
         },
@@ -208,6 +219,171 @@ test('CONVERSATION-OPEN-LATEST-001 opens the latest interaction of the resolved 
         duplicateDisplayName: false,
     }]);
     capability.dispose();
+});
+
+test('WEBVIEW-AI-SESSION-CONVERSATION-VIEWER-001 dashboard registers a serializer that restores AI Conversation panels', () => {
+    const dashboardSource = fs.readFileSync(
+        path.join(__dirname, '../../../src/dashboard.ts'),
+        'utf8'
+    );
+    assert.match(
+        dashboardSource,
+        /registerWebviewPanelSerializer\([\s\S]*AGENT_PIVOT_CONVERSATION_VIEW_TYPE[\s\S]*deserializeWebviewPanel[\s\S]*conversationPanelRestore\.restorePanel\(/
+    );
+    assert.ok(
+        dashboardSource.indexOf('registerWebviewPanelSerializer(')
+            < dashboardSource.indexOf('bootstrapController.start()'),
+        'the serializer must be registered before activation returns'
+    );
+});
+
+test('WEBVIEW-AI-SESSION-CONVERSATION-VIEWER-001 queues retained panels until the asynchronous dashboard capability is ready', async () => {
+    const coordinator = new ConversationPanelRestoreCoordinator();
+    const runtimeAuthority = deferred();
+    const restored = [];
+    let disposed = false;
+    const panel = {
+        webview: { html: 'stale transcript' },
+        dispose() { disposed = true; },
+    };
+    let settled = false;
+    const restoration = coordinator.restorePanel(panel, { saved: true })
+        .then(() => { settled = true; });
+
+    await new Promise(resolve => setImmediate(resolve));
+    assert.equal(settled, false);
+    assert.match(panel.webview.html, /Restoring conversation/);
+
+    const connection = coordinator.connectWhenReady({
+        async restorePanel(restoredPanel, state) {
+            restored.push({ restoredPanel, state });
+        },
+    }, runtimeAuthority.promise);
+    await new Promise(resolve => setImmediate(resolve));
+    assert.equal(restored.length, 0, 'runtime authority must settle first');
+
+    runtimeAuthority.resolve();
+    await restoration;
+    assert.equal(disposed, false);
+    assert.deepEqual(restored, [{ restoredPanel: panel, state: { saved: true } }]);
+
+    connection.dispose();
+    coordinator.dispose();
+});
+
+test('WEBVIEW-AI-SESSION-CONVERSATION-VIEWER-001 waits for direct and tmux runtime restoration before resolving panel authority', () => {
+    const dashboardSource = fs.readFileSync(
+        path.join(__dirname, '../../../src/dashboard.ts'),
+        'utf8'
+    );
+    assert.match(
+        dashboardSource,
+        /conversationPanelRestore\.connectWhenReady\([\s\S]*Promise\.all\(\[[\s\S]*directTerminalRestoreOutcomeTask[\s\S]*tmuxRestoreTask/
+    );
+});
+
+test('WEBVIEW-AI-SESSION-CONVERSATION-VIEWER-001 restores only an authoritative serialized target at its saved interaction', async () => {
+    const harness = createHarness();
+    const panel = { dispose() { throw new Error('must not dispose'); } };
+
+    await harness.capability.restorePanel(panel, {
+        conversationSidebar: { open: true },
+        conversationViewer: {
+            version: 1,
+            target: {
+                projectId: 'project-a',
+                provider: 'codex',
+                sessionId: 'session-a',
+                interactionId: 'input-a',
+            },
+        },
+    });
+
+    assert.equal(harness.restoredViewerTargets.length, 1);
+    assert.equal(harness.restoredViewerTargets[0].panel, panel);
+    assert.deepEqual(harness.restoredViewerTargets[0].target, {
+        projectId: 'project-a',
+        provider: 'codex',
+        sessionId: 'session-a',
+        interactionId: 'input-a',
+        expectedRevision: 'r1',
+        displayName: 'Focused session',
+        duplicateDisplayName: false,
+    });
+    harness.capability.dispose();
+});
+
+test('CONVERSATION-SESSION-REBIND-001 restores an old serialized target through the explicit rebound Session', async () => {
+    const harness = createHarness({
+        resolveTarget: (_projectId, _provider, sessionId) =>
+            sessionId === 'new-root'
+                ? makeSession({ id: 'new-root', sessionId: 'new-root' })
+                : null,
+        resolveReboundTarget: target => target.sessionId === 'old-root'
+            ? { ...target, sessionId: 'new-root' }
+            : target,
+    });
+    const panel = { dispose() { throw new Error('must not dispose'); } };
+
+    await harness.capability.restorePanel(panel, {
+        conversationViewer: {
+            version: 1,
+            target: {
+                projectId: 'project-a',
+                provider: 'codex',
+                sessionId: 'old-root',
+                interactionId: 'input-a',
+                subagentId: 'old-root-subagent',
+            },
+        },
+    });
+
+    assert.equal(harness.restoredViewerTargets.length, 1);
+    assert.equal(harness.restoredViewerTargets[0].target.sessionId, 'new-root');
+    assert.equal(
+        harness.restoredViewerTargets[0].target.subagent,
+        undefined,
+        'a subagent from the old root must not be resolved in the new root'
+    );
+    assert.equal(await harness.capability.openLatestConversation({
+        projectId: 'project-a',
+        provider: 'codex',
+        sessionId: 'old-root',
+    }), 'unknownSession', 'an explicit historical open must not be redirected');
+    harness.capability.dispose();
+});
+
+test('WEBVIEW-AI-SESSION-CONVERSATION-VIEWER-001 closes a retained panel with invalid or stale restore authority', async () => {
+    let disposeCount = 0;
+    const panel = { dispose() { disposeCount += 1; } };
+    const invalidHarness = createHarness();
+    await invalidHarness.capability.restorePanel(panel, {
+        conversationViewer: {
+            version: 1,
+            target: {
+                projectId: 'project-a',
+                provider: 'codex',
+                sessionId: 'session-a',
+            },
+        },
+    });
+    invalidHarness.capability.dispose();
+
+    const staleHarness = createHarness({ session: null });
+    await staleHarness.capability.restorePanel(panel, {
+        conversationViewer: {
+            version: 1,
+            target: {
+                projectId: 'project-a',
+                provider: 'codex',
+                sessionId: 'session-a',
+                interactionId: 'input-a',
+            },
+        },
+    });
+    staleHarness.capability.dispose();
+
+    assert.equal(disposeCount, 2);
 });
 
 test('CONVERSATION-OPEN-LATEST-001 prefers conversation display metadata for the viewer target', async () => {

--- a/tests/integration/dashboard/conversationViewer.test.js
+++ b/tests/integration/dashboard/conversationViewer.test.js
@@ -250,6 +250,7 @@ function createViewer(options = {}) {
         followAdjacentConversation: options.followAdjacentConversation,
         mediaUri: fileName => fakeUri(`file:///extension/media/${fileName}`),
         showThinking: options.showThinking,
+        commentStore: options.commentStore,
         bookmarkStore: options.bookmarkStore,
     });
     return { viewer, panel, watchDisposals, restoredTargets, openedUris };
@@ -267,6 +268,159 @@ test('WEBVIEW-AI-SESSION-CONVERSATION-VIEWER-001 opens and reuses one viewer in 
         fakeVscode.ViewColumn.Active,
         fakeVscode.ViewColumn.Active,
     ]);
+});
+
+test('CONVERSATION-SESSION-REBIND-001 retargets an open viewer from the exact old Session to the new Session', async () => {
+    const outlineReads = [];
+    const { viewer, panel, watchDisposals } = createViewer({
+        readOutline: async (_provider, sessionId) => {
+            outlineReads.push(sessionId);
+            return outline(
+                sessionId,
+                sessionId === 'old-root'
+                    ? ['old-input']
+                    : ['new-input-a', 'new-input-b']
+            );
+        },
+    });
+    await viewer.open(target('old-root', 'old-input'));
+
+    assert.equal(await viewer.rebindSession(
+        { projectId: 'project-a', provider: 'codex', sessionId: 'old-root' },
+        { projectId: 'project-a', provider: 'codex', sessionId: 'new-root' }
+    ), true);
+
+    assert.deepEqual(outlineReads, ['old-root', 'new-root', 'new-root']);
+    assert.deepEqual(watchDisposals, ['old-root']);
+    assert.equal(panel.createCount, 1);
+    assert.match(panel.webview.html, /new-input-b/);
+    await viewer.reconcileAuthority(() => ({
+        displayName: 'New root display',
+        duplicateDisplayName: false,
+    }));
+    assert.equal(panel.postedMessages.at(-1).displayName, 'New root display');
+});
+
+test('CONVERSATION-SESSION-REBIND-001 keeps an initial rebound load current while display metadata reconciles', async () => {
+    const reboundInitialStarted = deferred();
+    const releaseReboundInitial = deferred();
+    let newRootReads = 0;
+    const { viewer, panel } = createViewer({
+        readOutline: async (_provider, sessionId) => {
+            if (sessionId === 'new-root') {
+                newRootReads += 1;
+                if (newRootReads === 2) {
+                    reboundInitialStarted.resolve();
+                    await releaseReboundInitial.promise;
+                }
+            }
+            return outline(sessionId, [`${sessionId}-input`]);
+        },
+    });
+    await viewer.open(target('old-root', 'old-root-input'));
+
+    const rebind = viewer.rebindSession(
+        { projectId: 'project-a', provider: 'codex', sessionId: 'old-root' },
+        { projectId: 'project-a', provider: 'codex', sessionId: 'new-root' }
+    );
+    await reboundInitialStarted.promise;
+    const reconcile = viewer.reconcileAuthority(() => ({
+        displayName: 'Current root',
+        duplicateDisplayName: false,
+    }));
+    releaseReboundInitial.resolve();
+
+    assert.equal(await rebind, true);
+    await reconcile;
+    assert.match(panel.webview.html, /new-root-input/);
+    assert.match(panel.webview.html, /Current root/);
+    assert.equal(panel.webview.html.includes('history unavailable'), false);
+});
+
+test('CONVERSATION-SESSION-REBIND-001 bounds reconciled display metadata before publishing it', async () => {
+    const { viewer, panel } = createViewer();
+    await viewer.open(target('session-a'));
+
+    await viewer.reconcileAuthority(() => ({
+        displayName: '🧭'.repeat(1_000),
+        duplicateDisplayName: true,
+    }));
+
+    const publication = panel.postedMessages.at(-1);
+    assert.equal(publication.type, 'conversation-viewer-page');
+    assert.ok(publication.displayName.length <= 640);
+    assert.match(publication.displayName, / · session-/);
+});
+
+test('CONVERSATION-SESSION-REBIND-001 lets the newest live rebind win while an older outline read is pending', async () => {
+    const oldRebind = deferred();
+    const { viewer, panel } = createViewer({
+        readOutline: async (_provider, sessionId) => {
+            if (sessionId === 'new-root-a') {
+                await oldRebind.promise;
+            }
+            return outline(sessionId, [`${sessionId}-input`]);
+        },
+    });
+    await viewer.open(target('old-root', 'old-root-input'));
+    const previous = {
+        projectId: 'project-a',
+        provider: 'codex',
+        sessionId: 'old-root',
+    };
+    const first = viewer.rebindSession(previous, {
+        ...previous,
+        sessionId: 'new-root-a',
+    });
+    await new Promise(resolve => setImmediate(resolve));
+    assert.equal(await viewer.rebindSession(previous, {
+        ...previous,
+        sessionId: 'new-root-b',
+    }), true);
+    oldRebind.resolve();
+    assert.equal(await first, false);
+    assert.match(panel.webview.html, /new-root-b-input/);
+});
+
+test('WEBVIEW-AI-SESSION-CONVERSATION-VIEWER-001 restores a retained panel without revealing it and resumes live updates', async () => {
+    const panel = fakePanel();
+    let onChange;
+    let revision = 1;
+    const { viewer } = createViewer({
+        panel,
+        readOutline: async (_provider, sessionId) => outline(
+            sessionId,
+            ['input-1'],
+            { sourceRevision: `r${revision}` }
+        ),
+        readPage: async request => page(
+            request.sessionId,
+            request.anchorInteractionId,
+            `revision-${revision}`,
+            { sourceRevision: `r${revision}` }
+        ),
+        watch: (_provider, _sessionId, callback) => {
+            onChange = callback;
+            return { dispose() {} };
+        },
+    });
+
+    await viewer.restore(panel, target('session-a', 'input-1'));
+
+    assert.equal(panel.createCount, 0, 'VS Code already owns the retained panel');
+    assert.equal(panel.revealCount, 0, 'restoration must not steal editor focus');
+    assert.equal(panel.webview.options.enableScripts, true);
+    assert.match(panel.webview.html, /revision-1/);
+
+    revision = 2;
+    onChange();
+    await new Promise(resolve => setImmediate(resolve));
+    const refresh = panel.postedMessages.filter(message =>
+        message.type === 'conversation-viewer-page'
+    ).at(-1);
+    assert.ok(refresh, 'the restored watcher must publish new transcript data');
+    assert.match(refresh.html, /revision-2/);
+    viewer.dispose();
 });
 
 test('CONVERSATION-FOLLOW-ACTIVE-SESSION-001 follows another Session only when the viewer is open and does not reveal it again', async () => {
@@ -707,6 +861,220 @@ test('CONVERSATION-OUTLINE-BOOKMARKS-001 restores and Host-settles bookmarks wit
             .outline.map(entry => entry.interactionId),
         before
     );
+});
+
+test('CONVERSATION-SESSION-REBIND-001 freezes and drains old-root metadata mutations before copying', async () => {
+    const saveStarted = deferred();
+    const releaseSave = deferred();
+    const saved = [];
+    const { viewer, panel } = createViewer({
+        bookmarkStore: {
+            async load() {
+                return { revision: 0, interactionIds: [] };
+            },
+            async save(storeTarget, snapshot) {
+                saved.push({ storeTarget, snapshot });
+                saveStarted.resolve();
+                await releaseSave.promise;
+            },
+        },
+    });
+    await viewer.open(target('old-root'));
+    const firstMutation = panel.receive({
+        type: 'conversation-viewer-bookmark-mutation',
+        version: 1,
+        requestId: 'before-freeze',
+        subscriptionGeneration: 1,
+        projectId: 'project-a',
+        provider: 'codex',
+        sessionId: 'old-root',
+        operation: 'set',
+        expectedRevision: 0,
+        payload: { interactionId: 'input-1', bookmarked: true },
+    });
+    await saveStarted.promise;
+
+    let drainSettled = false;
+    const drain = viewer.freezeSessionMetadata({
+        projectId: 'project-a',
+        provider: 'codex',
+        sessionId: 'old-root',
+    }).then(result => {
+        drainSettled = true;
+        return result;
+    });
+    await Promise.resolve();
+    assert.equal(drainSettled, false, 'copy barrier must await active saves');
+    const frozenMutation = panel.receive({
+        type: 'conversation-viewer-bookmark-mutation',
+        version: 1,
+        requestId: 'after-freeze',
+        subscriptionGeneration: 1,
+        projectId: 'project-a',
+        provider: 'codex',
+        sessionId: 'old-root',
+        operation: 'set',
+        expectedRevision: 0,
+        payload: { interactionId: 'input-1', bookmarked: false },
+    });
+    releaseSave.resolve();
+
+    await firstMutation;
+    assert.equal(await drain, true);
+    await frozenMutation;
+    assert.equal(saved.length, 1, 'a frozen mutation must not write old storage');
+    assert.deepEqual(panel.postedMessages.at(-1), {
+        type: 'conversation-viewer-bookmarks-result',
+        version: 1,
+        requestId: 'after-freeze',
+        subscriptionGeneration: 1,
+        projectId: 'project-a',
+        provider: 'codex',
+        sessionId: 'old-root',
+        operation: 'set',
+        success: false,
+        revision: 1,
+        interactionIds: ['input-1'],
+        error: 'stale',
+    });
+});
+
+test('CONVERSATION-SESSION-REBIND-001 drains an old-root mutation after the viewer has already switched', async () => {
+    const saveStarted = deferred();
+    const releaseSave = deferred();
+    const saved = [];
+    const { viewer, panel } = createViewer({
+        bookmarkStore: {
+            async load() {
+                return { revision: 0, interactionIds: [] };
+            },
+            async save(storeTarget, snapshot) {
+                saved.push({
+                    target: { ...storeTarget },
+                    snapshot: {
+                        revision: snapshot.revision,
+                        interactionIds: [...snapshot.interactionIds],
+                    },
+                });
+                if (saved.length === 1) {
+                    saveStarted.resolve();
+                    await releaseSave.promise;
+                }
+            },
+        },
+    });
+    await viewer.open(target('old-root'));
+    const oldMutation = panel.receive({
+        type: 'conversation-viewer-bookmark-mutation',
+        version: 1,
+        requestId: 'old-pending',
+        subscriptionGeneration: 1,
+        projectId: 'project-a',
+        provider: 'codex',
+        sessionId: 'old-root',
+        operation: 'set',
+        expectedRevision: 0,
+        payload: { interactionId: 'input-1', bookmarked: true },
+    });
+    await saveStarted.promise;
+    assert.equal(await viewer.follow(target('other-root')), true);
+
+    let drainSettled = false;
+    const drain = viewer.freezeSessionMetadata({
+        projectId: 'project-a',
+        provider: 'codex',
+        sessionId: 'old-root',
+    }).then(result => {
+        drainSettled = true;
+        return result;
+    });
+    await Promise.resolve();
+    assert.equal(drainSettled, false);
+    releaseSave.resolve();
+
+    await oldMutation;
+    assert.equal(await drain, false, 'the current target must stay unfrozen');
+    assert.deepEqual(saved, [{
+        target: {
+            projectId: 'project-a',
+            provider: 'codex',
+            sessionId: 'old-root',
+        },
+        snapshot: { revision: 1, interactionIds: ['input-1'] },
+    }, {
+        target: {
+            projectId: 'project-a',
+            provider: 'codex',
+            sessionId: 'old-root',
+        },
+        snapshot: { revision: 0, interactionIds: [] },
+    }], 'the stale old write must finish its rollback before copying');
+});
+
+test('CONVERSATION-SESSION-REBIND-001 rolls back a stale old-root comment before the copy barrier settles', async () => {
+    const saveStarted = deferred();
+    const releaseSave = deferred();
+    const saved = [];
+    const { viewer, panel } = createViewer({
+        commentStore: {
+            async load() {
+                return { revision: 0, comments: [] };
+            },
+            async save(storeTarget, snapshot) {
+                saved.push({
+                    target: { ...storeTarget },
+                    snapshot: {
+                        revision: snapshot.revision,
+                        comments: snapshot.comments.map(comment => ({
+                            ...comment,
+                        })),
+                    },
+                });
+                if (saved.length === 1) {
+                    saveStarted.resolve();
+                    await releaseSave.promise;
+                }
+            },
+        },
+    });
+    await viewer.open(target('old-root'));
+    const oldMutation = panel.receive({
+        type: 'conversation-viewer-comment-mutation',
+        version: 1,
+        requestId: 'old-comment-pending',
+        subscriptionGeneration: 1,
+        projectId: 'project-a',
+        provider: 'codex',
+        sessionId: 'old-root',
+        operation: 'add',
+        expectedRevision: 0,
+        payload: {
+            scope: 'session',
+            comment: 'Do not migrate a failed comment.',
+        },
+    });
+    await saveStarted.promise;
+    assert.equal(await viewer.follow(target('other-root')), true);
+    const drain = viewer.freezeSessionMetadata({
+        projectId: 'project-a',
+        provider: 'codex',
+        sessionId: 'old-root',
+    });
+    releaseSave.resolve();
+
+    await oldMutation;
+    assert.equal(await drain, false);
+    assert.equal(saved.length, 2);
+    assert.equal(saved[0].snapshot.revision, 1);
+    assert.equal(saved[0].snapshot.comments.length, 1);
+    assert.deepEqual(saved[1], {
+        target: {
+            projectId: 'project-a',
+            provider: 'codex',
+            sessionId: 'old-root',
+        },
+        snapshot: { revision: 0, comments: [] },
+    });
 });
 
 test('CONVERSATION-OUTLINE-BOOKMARKS-001 rejects stale or unknown input bookmark intents without persisting', async () => {

--- a/tests/integration/dashboard/helpers/terminalCloseHarness.js
+++ b/tests/integration/dashboard/helpers/terminalCloseHarness.js
@@ -39,6 +39,7 @@ function createHarnessVscode(listeners, commands) {
                 listeners.viewProvider = provider;
                 return disposable();
             },
+            registerWebviewPanelSerializer: () => disposable(),
             onDidChangeActiveTerminal: callback => { listeners.activeTerminal = callback; return disposable(); },
             onDidOpenTerminal: () => disposable(),
             onDidCloseTerminal: callback => { listeners.closeTerminal = callback; return disposable(); },

--- a/tests/integration/dashboard/helpers/todoPanelHarness.js
+++ b/tests/integration/dashboard/helpers/todoPanelHarness.js
@@ -39,6 +39,7 @@ function createVscode(listeners, commands) {
                 listeners.viewProvider = provider;
                 return disposable();
             },
+            registerWebviewPanelSerializer: () => disposable(),
             onDidChangeActiveTerminal: () => disposable(), onDidOpenTerminal: () => disposable(),
             onDidCloseTerminal: () => disposable(),
             onDidChangeWindowState: () => disposable(), onDidChangeVisibleTextEditors: () => disposable(),

--- a/tests/unit/aiSessions/conversationBookmarkStore.test.js
+++ b/tests/unit/aiSessions/conversationBookmarkStore.test.js
@@ -80,3 +80,68 @@ test('CONVERSATION-OUTLINE-BOOKMARKS-001 rejects duplicate bookmark identities a
         { revision: 0, interactionIds: [] }
     );
 });
+
+test('CONVERSATION-SESSION-REBIND-001 copies bookmarks only along an explicit Session rebind', async t => {
+    const root = await fs.promises.mkdtemp(
+        path.join(os.tmpdir(), 'agent-pivot-conversation-bookmarks-rebind-')
+    );
+    t.after(() => fs.promises.rm(root, { recursive: true, force: true }));
+    const store = new ConversationBookmarkFileStore(root);
+    const previous = target('old-root');
+    const next = target('new-root');
+    const source = { revision: 3, interactionIds: ['input-1', 'input-3'] };
+
+    await store.save(previous, source);
+    assert.equal(await store.copyForRebind(previous, next), 'copied');
+    assert.deepEqual(await store.load(next), source);
+    assert.deepEqual(await store.load(previous), source);
+
+    const destination = { revision: 7, interactionIds: ['input-2'] };
+    await store.save(target('occupied-root'), destination);
+    assert.equal(
+        await store.copyForRebind(previous, target('occupied-root')),
+        'destination-exists'
+    );
+    assert.deepEqual(await store.load(target('occupied-root')), destination);
+
+    await assert.rejects(
+        store.copyForRebind(previous, { ...next, provider: 'claude' }),
+        /Invalid conversation bookmark rebind/
+    );
+
+    await store.save(target('race-source-a'), {
+        revision: 10,
+        interactionIds: ['input-a'],
+    });
+    await store.save(target('race-source-b'), {
+        revision: 11,
+        interactionIds: ['input-b'],
+    });
+    const raceTarget = target('race-destination');
+    const raceResults = await Promise.all([
+        store.copyForRebind(target('race-source-a'), raceTarget),
+        store.copyForRebind(target('race-source-b'), raceTarget),
+    ]);
+    assert.deepEqual(raceResults.sort(), ['copied', 'destination-exists']);
+    assert.ok([10, 11].includes((await store.load(raceTarget)).revision));
+
+    await store.save(target('corrupt-source'), {
+        revision: 12,
+        interactionIds: ['input-corrupt'],
+    });
+    const directory = path.join(root, 'conversation-bookmarks', 'v1');
+    for (const fileName of await fs.promises.readdir(directory)) {
+        const filePath = path.join(directory, fileName);
+        const persisted = JSON.parse(await fs.promises.readFile(filePath, 'utf8'));
+        if (persisted.target?.sessionId === 'corrupt-source') {
+            await fs.promises.writeFile(filePath, '{"invalid":true}', 'utf8');
+        }
+    }
+    await assert.rejects(
+        store.copyForRebind(
+            target('corrupt-source'),
+            target('corrupt-destination')
+        ),
+        /Invalid persisted conversation bookmark snapshot/
+    );
+});

--- a/tests/unit/aiSessions/conversationCommentStore.test.js
+++ b/tests/unit/aiSessions/conversationCommentStore.test.js
@@ -125,3 +125,75 @@ test('CONVERSATION-COMMENTS-PERSISTENCE-001 ignores malformed private snapshots 
         { revision: 0, comments: [] }
     );
 });
+
+test('CONVERSATION-SESSION-REBIND-001 copies comments only along an explicit Session rebind', async t => {
+    const root = await fs.promises.mkdtemp(
+        path.join(os.tmpdir(), 'agent-pivot-conversation-comments-rebind-')
+    );
+    t.after(() => fs.promises.rm(root, { recursive: true, force: true }));
+    const store = new ConversationCommentFileStore(root);
+    const previous = target('old-root');
+    const next = target('new-root');
+
+    await store.save(previous, snapshot());
+    assert.equal(await store.copyForRebind(previous, next), 'copied');
+    assert.deepEqual(await store.load(next), snapshot());
+    assert.deepEqual(await store.load(previous), snapshot());
+
+    const destination = {
+        revision: 9,
+        comments: [{
+            ...snapshot().comments[0],
+            id: 'destination-comment',
+            comment: 'Keep destination authority.',
+        }],
+    };
+    await store.save(target('occupied-root'), destination);
+    assert.equal(
+        await store.copyForRebind(previous, target('occupied-root')),
+        'destination-exists'
+    );
+    assert.deepEqual(await store.load(target('occupied-root')), destination);
+
+    await assert.rejects(
+        store.copyForRebind(previous, {
+            ...next,
+            projectId: 'different-project',
+        }),
+        /Invalid conversation comment rebind/
+    );
+
+    await store.save(target('race-source-a'), snapshot());
+    await store.save(target('race-source-b'), {
+        revision: 8,
+        comments: [{
+            ...snapshot().comments[0],
+            id: 'race-winner-b',
+        }],
+    });
+    const raceTarget = target('race-destination');
+    const raceResults = await Promise.all([
+        store.copyForRebind(target('race-source-a'), raceTarget),
+        store.copyForRebind(target('race-source-b'), raceTarget),
+    ]);
+    assert.deepEqual(raceResults.sort(), ['copied', 'destination-exists']);
+    assert.ok([4, 8].includes((await store.load(raceTarget)).revision));
+
+    await store.save(target('corrupt-source'), snapshot());
+    const directory = path.join(root, 'conversation-comments', 'v1');
+    const persistedFiles = await fs.promises.readdir(directory);
+    for (const fileName of persistedFiles) {
+        const filePath = path.join(directory, fileName);
+        const persisted = JSON.parse(await fs.promises.readFile(filePath, 'utf8'));
+        if (persisted.target?.sessionId === 'corrupt-source') {
+            await fs.promises.writeFile(filePath, '{"invalid":true}', 'utf8');
+        }
+    }
+    await assert.rejects(
+        store.copyForRebind(
+            target('corrupt-source'),
+            target('corrupt-destination')
+        ),
+        /Invalid persisted conversation comment snapshot/
+    );
+});

--- a/tests/unit/aiSessions/conversationSessionRebindCoordinator.test.js
+++ b/tests/unit/aiSessions/conversationSessionRebindCoordinator.test.js
@@ -1,0 +1,200 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+const {
+    ConversationSessionRebindCoordinator,
+    hasCommittedConversationSessionRuntimeRebind,
+} = require('../../../out/aiSessions/conversation/sessionRebindCoordinator');
+
+function target(sessionId, overrides = {}) {
+    return {
+        projectId: 'project-a',
+        provider: 'codex',
+        sessionId,
+        ...overrides,
+    };
+}
+
+test('CONVERSATION-SESSION-REBIND-001 durably retries partial metadata migration and resolves only the explicit target chain', async t => {
+    const root = await fs.promises.mkdtemp(
+        path.join(os.tmpdir(), 'agent-pivot-session-rebind-')
+    );
+    t.after(() => fs.promises.rm(root, { recursive: true, force: true }));
+    const firstCalls = [];
+    const first = new ConversationSessionRebindCoordinator({
+        globalStoragePath: root,
+        commentStore: {
+            async copyForRebind(previous, next) {
+                firstCalls.push(['comments', previous, next]);
+                throw new Error('transient comment failure');
+            },
+        },
+        bookmarkStore: {
+            async copyForRebind(previous, next) {
+                firstCalls.push(['bookmarks', previous, next]);
+                return 'copied';
+            },
+        },
+        now: () => Date.parse('2026-08-06T10:00:00.000Z'),
+    });
+
+    await assert.rejects(
+        first.rebind(target('old-root'), target('new-root')),
+        /comments/
+    );
+    assert.equal(first.resolve(target('old-root')).sessionId, 'new-root');
+    assert.equal(
+        first.resolve(target('old-root', { provider: 'claude' })).sessionId,
+        'old-root'
+    );
+    assert.deepEqual(firstCalls.map(call => call[0]), ['comments', 'bookmarks']);
+
+    const retryCalls = [];
+    const restarted = new ConversationSessionRebindCoordinator({
+        globalStoragePath: root,
+        commentStore: {
+            async copyForRebind(previous, next) {
+                retryCalls.push(['comments', previous, next]);
+                return 'copied';
+            },
+        },
+        bookmarkStore: {
+            async copyForRebind(previous, next) {
+                retryCalls.push(['bookmarks', previous, next]);
+                return 'copied';
+            },
+        },
+        now: () => Date.parse('2026-08-06T10:01:00.000Z'),
+    });
+    await restarted.restore();
+
+    assert.deepEqual(retryCalls.map(call => call[0]), ['comments']);
+    assert.equal(restarted.resolve(target('old-root')).sessionId, 'new-root');
+    await restarted.rebind(target('new-root'), target('newer-root'));
+    assert.equal(restarted.resolve(target('old-root')).sessionId, 'newer-root');
+    assert.equal(restarted.resolve(target('unrelated')).sessionId, 'unrelated');
+
+    await restarted.prepare(target('pending-old'), target('pending-new'));
+    const uncommittedCalls = [];
+    const uncommitted = new ConversationSessionRebindCoordinator({
+        globalStoragePath: root,
+        commentStore: {
+            async copyForRebind() {
+                uncommittedCalls.push('comments');
+                return 'copied';
+            },
+        },
+        bookmarkStore: {
+            async copyForRebind() {
+                uncommittedCalls.push('bookmarks');
+                return 'copied';
+            },
+        },
+        isRuntimeRebindCommitted: async () => false,
+    });
+    await uncommitted.restore();
+    assert.equal(
+        uncommitted.resolve(target('pending-old')).sessionId,
+        'pending-old'
+    );
+    assert.deepEqual(uncommittedCalls, []);
+
+    assert.equal(hasCommittedConversationSessionRuntimeRebind(
+        [target('pending-old'), target('pending-new')],
+        target('pending-old'),
+        target('pending-new')
+    ), false, 'an existing destination does not prove a runtime rebind');
+    assert.equal(hasCommittedConversationSessionRuntimeRebind(
+        [target('pending-new')],
+        target('pending-old'),
+        target('pending-new')
+    ), true, 'a committed runtime rebind removes old before exposing new');
+
+    const destinationCollision = new ConversationSessionRebindCoordinator({
+        globalStoragePath: root,
+        commentStore: { async copyForRebind() { return 'copied'; } },
+        bookmarkStore: { async copyForRebind() { return 'copied'; } },
+        isRuntimeRebindCommitted: async (previous, next) =>
+            hasCommittedConversationSessionRuntimeRebind(
+                [target('pending-old'), target('pending-new')],
+                previous,
+                next
+            ),
+    });
+    await destinationCollision.restore();
+    assert.equal(
+        destinationCollision.resolve(target('pending-old')).sessionId,
+        'pending-old',
+        'restart must not promote a stale destination collision'
+    );
+
+    const crashRecoveryCalls = [];
+    const crashRecovery = new ConversationSessionRebindCoordinator({
+        globalStoragePath: root,
+        commentStore: {
+            async copyForRebind() {
+                crashRecoveryCalls.push('comments');
+                return 'copied';
+            },
+        },
+        bookmarkStore: {
+            async copyForRebind() {
+                crashRecoveryCalls.push('bookmarks');
+                return 'copied';
+            },
+        },
+        isRuntimeRebindCommitted: async (previous, next) =>
+            previous.sessionId === 'pending-old'
+                && next.sessionId === 'pending-new',
+    });
+    await crashRecovery.restore();
+    assert.equal(
+        crashRecovery.resolve(target('pending-old')).sessionId,
+        'pending-new'
+    );
+    assert.deepEqual(crashRecoveryCalls, ['comments', 'bookmarks']);
+});
+
+test('CONVERSATION-SESSION-REBIND-001 retries a failed intent write in the same process', async t => {
+    const root = await fs.promises.mkdtemp(
+        path.join(os.tmpdir(), 'agent-pivot-session-rebind-write-')
+    );
+    t.after(() => fs.promises.rm(root, { recursive: true, force: true }));
+    const coordinator = new ConversationSessionRebindCoordinator({
+        globalStoragePath: root,
+        commentStore: { async copyForRebind() { return 'source-empty'; } },
+        bookmarkStore: { async copyForRebind() { return 'source-empty'; } },
+    });
+    const writeRecord = coordinator.writeRecord.bind(coordinator);
+    let writes = 0;
+    coordinator.writeRecord = async record => {
+        writes += 1;
+        if (writes === 1) {
+            throw new Error('transient intent write failure');
+        }
+        await writeRecord(record);
+    };
+
+    await assert.rejects(
+        coordinator.prepare(target('write-old'), target('write-new')),
+        /transient intent write failure/
+    );
+    await coordinator.prepare(target('write-old'), target('write-new'));
+    assert.equal(writes, 2, 'retry must durably write the pre-commit intent');
+
+    const restarted = new ConversationSessionRebindCoordinator({
+        globalStoragePath: root,
+        commentStore: { async copyForRebind() { return 'source-empty'; } },
+        bookmarkStore: { async copyForRebind() { return 'source-empty'; } },
+        isRuntimeRebindCommitted: async () => false,
+    });
+    await restarted.restore();
+    assert.equal(
+        restarted.resolve(target('write-old')).sessionId,
+        'write-old'
+    );
+});

--- a/tests/unit/aiSessions/lifecycle.test.js
+++ b/tests/unit/aiSessions/lifecycle.test.js
@@ -98,6 +98,86 @@ test('PERSIST-LIFECYCLE-PARSER-001 [kimi] treats subagent progress events as run
     assert.match(signal.token, /^kimi:SubagentEvent:/);
 });
 
+test('PERSIST-LIFECYCLE-PARSER-001 [codex] treats ordinary turn progress as a running lease renewal', () => {
+    const signal = lifecycle.parseCodexLifecycleLines([
+        JSON.stringify({
+            timestamp: '2026-07-24T08:00:00.000Z',
+            type: 'event_msg',
+            payload: { type: 'task_started', turn_id: 'turn-long' },
+        }),
+        JSON.stringify({
+            timestamp: '2026-07-24T08:31:00.000Z',
+            type: 'response_item',
+            payload: {
+                type: 'function_call',
+                name: 'wait',
+                call_id: 'call-still-running',
+            },
+        }),
+    ], runStartedAtMs);
+
+    assert.ok(signal);
+    assert.equal(signal.phase, 'running');
+    assert.equal(signal.executionState, 'running');
+    assert.equal(signal.occurredAtMs, Date.parse('2026-07-24T08:31:00.000Z'));
+    assert.match(signal.token, /^codex:function_call:/);
+});
+
+test('PERSIST-LIFECYCLE-PARSER-001 [codex] does not let unrelated progress answer a pending question', () => {
+    const signal = lifecycle.parseCodexLifecycleLines([
+        JSON.stringify({
+            timestamp: '2026-07-24T08:00:00.000Z',
+            type: 'response_item',
+            payload: {
+                type: 'custom_tool_call',
+                name: 'request_user_input',
+                call_id: 'question-call',
+            },
+        }),
+        JSON.stringify({
+            timestamp: '2026-07-24T08:01:00.000Z',
+            type: 'response_item',
+            payload: {
+                type: 'function_call_output',
+                call_id: 'unrelated-call',
+            },
+        }),
+    ], runStartedAtMs);
+
+    assert.ok(signal);
+    assert.equal(signal.phase, 'needsAttention');
+    assert.equal(signal.reason, 'input-required');
+    assert.equal(signal.executionState, 'stopped');
+});
+
+test('PERSIST-LIFECYCLE-PARSER-001 [codex] ignores delayed progress after a terminal event until a new task starts', () => {
+    const signal = lifecycle.parseCodexLifecycleLines([
+        JSON.stringify({
+            timestamp: '2026-07-24T08:00:00.000Z',
+            type: 'event_msg',
+            payload: { type: 'task_started', turn_id: 'turn-complete' },
+        }),
+        JSON.stringify({
+            timestamp: '2026-07-24T08:01:00.000Z',
+            type: 'event_msg',
+            payload: { type: 'task_complete', turn_id: 'turn-complete' },
+        }),
+        JSON.stringify({
+            timestamp: '2026-07-24T08:02:00.000Z',
+            type: 'response_item',
+            payload: {
+                type: 'custom_tool_call_output',
+                call_id: 'delayed-output',
+            },
+        }),
+    ], runStartedAtMs);
+
+    assert.ok(signal);
+    assert.equal(signal.phase, 'needsAttention');
+    assert.equal(signal.reason, 'completed');
+    assert.equal(signal.executionState, 'stopped');
+});
+
 test('PERSIST-LIFECYCLE-PARSER-001 [kimi] treats a TurnEnd trailing a StepInterrupted as interruption, not completion', () => {
     const signal = lifecycle.parseKimiLifecycleLines([
         JSON.stringify({


### PR DESCRIPTION
## Summary

- restore retained AI Conversation panels after an extension-host reload without revealing or duplicating them
- follow exact provider Session rollover identities and migrate comments and bookmarks through a durable, atomic rebind
- preserve live viewer state and reject stale metadata mutations while a rebind is committed
- correct provider lifecycle edge cases that could report active work as stopped

## Skill harvest

no skill change — the existing worktree, review, audit, and PR skills already state the applicable workflow; this task exposed no reusable instruction gap.

## Verification

- `npm run test:deterministic` (passed; final integration suite 328/328)
- `npm run test:browser` (134/134)
- `npm run test:dashboard:run`
- `npm run test:behavior-contracts`
- `npm run lint` (passed with pre-existing warnings)
- `git diff origin/main --check`
- `SKIP_NPM_CI=1 npm run install-local` (both VSIX files installed and byte-verified)

The separately observed sidebar startup-render starvation predates this branch and is intentionally excluded from this PR.