### PR TITLE
Fix sidebar initial render starvation

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -2231,7 +2231,9 @@
     "priority": "P0",
     "status": "automated",
     "owners": [
-      "tests/integration/dashboard/errorRecovery.test.js"
+      "tests/browser/dashboardStylesheetStartup.test.js",
+      "tests/integration/dashboard/errorRecovery.test.js",
+      "tests/integration/dashboard/twoStageStartup.test.js"
     ],
     "evidence": [
       "src/dashboard/viewProvider.ts",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "d6385f753ae6fde4801ccfc6a2b2a59b294a39b7",
+        "head": "6f22284edc8b8e3b4e71dcf8abb5b46569164abc",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -161,7 +161,8 @@
             "f5997922baf5be996565953d1c1dd4841ecb7de5",
             "e0b043799f4b9c5ff4ffa4099ec6c3690b103129",
             "3fe5e04ecb7a6022b4e1aa20125f207796e8a31a",
-            "db085481b95fc9b3372c83023343a00640e678e7"
+            "db085481b95fc9b3372c83023343a00640e678e7",
+            "d2341beee5e0d318fc847c3ec7c12234e27f19a8"
         ]
     },
     "capabilities": [
@@ -949,7 +950,8 @@
                 "b4f14c8ec40227225e5053314a71986b7aa31eb6",
                 "d686c611197886d76ef92f9595fd2a134930d01c",
                 "fa980dcae7aaf4187dde798fffe7c19b2a4d31a1",
-                "98b73a4dc087b0c0a71554036bb988b00226abe6"
+                "98b73a4dc087b0c0a71554036bb988b00226abe6",
+                "6f22284edc8b8e3b4e71dcf8abb5b46569164abc"
             ],
             "behaviors": [
                 "RUNTIME-BOOTSTRAP-TMUX-RESTORE-DEFERRAL-001",

--- a/media/webviewDashboardBundle.js
+++ b/media/webviewDashboardBundle.js
@@ -3220,6 +3220,7 @@ function initProjects() {
     window.vscode.postMessage({
         type: 'open-workspaces-renderer-ready',
         version: 1,
+        documentGeneration: window.__agentPivotReadyDocumentGeneration,
     });
     restoreAiSessionTabsFromState(document, window.vscode);
     window.vscode.postMessage({ type: 'request-active-ai-session-terminal' });

--- a/media/webviewProjectScripts.js
+++ b/media/webviewProjectScripts.js
@@ -710,6 +710,7 @@ function initProjects() {
     window.vscode.postMessage({
         type: 'open-workspaces-renderer-ready',
         version: 1,
+        documentGeneration: window.__agentPivotReadyDocumentGeneration,
     });
     restoreAiSessionTabsFromState(document, window.vscode);
     window.vscode.postMessage({ type: 'request-active-ai-session-terminal' });

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1526,7 +1526,7 @@ async function initializeDashboard(
     });
     const providerOptions: AgentPivotViewProviderOptions = {
         getWebviewOptions: () => getDashboardWebviewOptions(context.extensionPath, vscode.Uri.file),
-        renderContent: webview => getStewardContent(
+        renderContent: (webview, documentGeneration) => getStewardContent(
             context,
             webview,
             projectService.getGroups(),
@@ -1534,6 +1534,7 @@ async function initializeDashboard(
             true,
             getOpenWorkspaceCards(),
             openWorkspaceDashboardController.getState().otherWindows.status,
+            documentGeneration,
         ),
         renderError: getErrorContent,
         onMessage: message => messageRequiresStorageMigration(message)

--- a/src/dashboard/viewProvider.ts
+++ b/src/dashboard/viewProvider.ts
@@ -6,11 +6,27 @@ import { AGENT_PIVOT_DASHBOARD_VIEW_ID } from '../constants';
 const VISIBLE_VIEW_FAILURE_MESSAGE = 'Unexpected Agent Pivot view failure.';
 const RETRY_BOOTSTRAP_MESSAGE_TYPE = 'retry-agent-pivot-bootstrap';
 const FIRST_PAINT_MESSAGE_TYPE = 'agent-pivot-browser-first-paint';
+const READY_DOCUMENT_MESSAGE_TYPE = 'open-workspaces-renderer-ready';
 const BOOT_MESSAGE_VERSION = 1;
+const READY_DOCUMENT_RECOVERY_MS = 30_000;
+
+interface ReadyDocumentScheduler {
+    setTimeout(callback: () => void, delayMs: number): unknown;
+    clearTimeout(handle: unknown): void;
+}
+
+const DEFAULT_READY_DOCUMENT_SCHEDULER: ReadyDocumentScheduler = {
+    setTimeout: (callback, delayMs) => {
+        const handle = setTimeout(callback, delayMs);
+        handle.unref();
+        return handle;
+    },
+    clearTimeout: handle => clearTimeout(handle as NodeJS.Timeout),
+};
 
 export interface AgentPivotViewProviderOptions {
     getWebviewOptions: () => vscode.WebviewOptions;
-    renderContent: (webview: vscode.Webview) => string;
+    renderContent: (webview: vscode.Webview, documentGeneration: number) => string;
     renderError: (error: unknown) => string;
     onMessage: (message: unknown) => Promise<void>;
     onVisibleChanged: (visible: boolean) => void | Thenable<void> | Promise<void>;
@@ -55,8 +71,17 @@ export class AgentPivotViewProvider implements vscode.WebviewViewProvider {
     private lifecycle: ProviderLifecycle;
     private bootShellAssignedGeneration?: number;
     private completingBootstrapGeneration?: number;
+    private readyDocumentGeneration = 0;
+    private readyDocumentHandshakePending?: number;
+    private readyDocumentRefreshQueued = false;
+    private readyDocumentRecoveryAttempted = false;
+    private readyDocumentRecoveryTimer?: unknown;
 
-    constructor(private readonly configuration: AgentPivotViewProviderConfiguration) {
+    constructor(
+        private readonly configuration: AgentPivotViewProviderConfiguration,
+        private readonly readyDocumentScheduler: ReadyDocumentScheduler =
+            DEFAULT_READY_DOCUMENT_SCHEDULER,
+    ) {
         this.lifecycle = configuration.mode === 'ready'
             ? { kind: 'ready', options: configuration.options }
             : { kind: 'idle' };
@@ -143,6 +168,7 @@ export class AgentPivotViewProvider implements vscode.WebviewViewProvider {
 
     async resolveWebviewView(webviewView: vscode.WebviewView, webviewContext: vscode.WebviewViewResolveContext<unknown>, token: vscode.CancellationToken): Promise<void> {
         const viewGeneration = ++this.viewGeneration;
+        this.resetReadyDocumentDelivery();
         const previousRelease = this.releaseCurrent;
         this.releaseCurrent = undefined;
         this._view = undefined;
@@ -164,6 +190,7 @@ export class AgentPivotViewProvider implements vscode.WebviewViewProvider {
             disposed = true;
             if (this._view === webviewView) {
                 this._view = undefined;
+                this.resetReadyDocumentDelivery();
             }
             if (this.releaseCurrent === release) {
                 this.releaseCurrent = undefined;
@@ -217,6 +244,13 @@ export class AgentPivotViewProvider implements vscode.WebviewViewProvider {
             return;
         }
         if (this.lifecycle.kind === 'ready') {
+            if (this.readyDocumentHandshakePending !== undefined) {
+                this.readyDocumentRefreshQueued = true;
+                // Repeated short retries can keep destroying a slow remote
+                // document, so recovery is delayed and limited to one attempt.
+                this.scheduleReadyDocumentRecovery();
+                return;
+            }
             this.renderReadyContent(this._view, this.lifecycle.options);
             return;
         }
@@ -256,8 +290,29 @@ export class AgentPivotViewProvider implements vscode.WebviewViewProvider {
 
     private async handleMessage(message: unknown, isCurrent: () => boolean): Promise<void> {
         if (this.lifecycle.kind === 'ready') {
+            const readyDocumentMessage = parseReadyDocumentMessage(message);
+            if (isReadyDocumentMessageCandidate(message)
+                && (!readyDocumentMessage
+                    || readyDocumentMessage.documentGeneration
+                        !== this.readyDocumentHandshakePending)) {
+                return;
+            }
+            const readyDocumentHandshake = readyDocumentMessage !== undefined;
+            const refreshQueuedBeforeHandshake = readyDocumentHandshake
+                && this.readyDocumentRefreshQueued;
+            if (readyDocumentHandshake) {
+                this.readyDocumentHandshakePending = undefined;
+                this.readyDocumentRefreshQueued = false;
+                this.readyDocumentRecoveryAttempted = false;
+                this.clearReadyDocumentRecovery();
+            }
             try {
-                await this.lifecycle.options.onMessage(message);
+                await this.lifecycle.options.onMessage(readyDocumentHandshake
+                    ? {
+                        type: READY_DOCUMENT_MESSAGE_TYPE,
+                        version: BOOT_MESSAGE_VERSION,
+                    }
+                    : message);
             } catch (_error) {
                 if (!isCurrent()) {
                     return;
@@ -265,6 +320,13 @@ export class AgentPivotViewProvider implements vscode.WebviewViewProvider {
                 this.lifecycle.options.logError(
                     'Failed to handle an Agent Pivot message.', sanitizedViewFailure()
                 );
+            }
+            if (readyDocumentHandshake
+                && refreshQueuedBeforeHandshake
+                && isCurrent()
+                && this.lifecycle.kind === 'ready'
+                && this.readyDocumentHandshakePending === undefined) {
+                this.refresh();
             }
             return;
         }
@@ -296,13 +358,60 @@ export class AgentPivotViewProvider implements vscode.WebviewViewProvider {
         webviewView: vscode.WebviewView,
         options: AgentPivotViewProviderOptions,
     ): void {
+        this.clearReadyDocumentRecovery();
+        const documentGeneration = ++this.readyDocumentGeneration;
+        this.readyDocumentHandshakePending = documentGeneration;
         try {
-            webviewView.webview.html = options.renderContent(webviewView.webview);
+            webviewView.webview.html = options.renderContent(
+                webviewView.webview,
+                documentGeneration,
+            );
         } catch (_error) {
+            this.readyDocumentHandshakePending = undefined;
             const failure = sanitizedViewFailure();
             options.logError('Failed to render Agent Pivot view.', failure);
             webviewView.webview.html = options.renderError(failure);
         }
+    }
+
+    private scheduleReadyDocumentRecovery(): void {
+        if (this.readyDocumentRecoveryAttempted
+            || this.readyDocumentRecoveryTimer !== undefined
+            || this.readyDocumentHandshakePending === undefined) {
+            return;
+        }
+        const viewGeneration = this.viewGeneration;
+        const documentGeneration = this.readyDocumentHandshakePending;
+        this.readyDocumentRecoveryTimer = this.readyDocumentScheduler.setTimeout(() => {
+            this.readyDocumentRecoveryTimer = undefined;
+            if (viewGeneration !== this.viewGeneration
+                || !this._view
+                || this.lifecycle.kind !== 'ready'
+                || this.readyDocumentHandshakePending !== documentGeneration
+                || !this.readyDocumentRefreshQueued
+                || this.readyDocumentRecoveryAttempted) {
+                return;
+            }
+            this.readyDocumentRecoveryAttempted = true;
+            this.readyDocumentHandshakePending = undefined;
+            this.readyDocumentRefreshQueued = false;
+            this.refresh();
+        }, READY_DOCUMENT_RECOVERY_MS);
+    }
+
+    private clearReadyDocumentRecovery(): void {
+        if (this.readyDocumentRecoveryTimer === undefined) {
+            return;
+        }
+        this.readyDocumentScheduler.clearTimeout(this.readyDocumentRecoveryTimer);
+        this.readyDocumentRecoveryTimer = undefined;
+    }
+
+    private resetReadyDocumentDelivery(): void {
+        this.clearReadyDocumentRecovery();
+        this.readyDocumentHandshakePending = undefined;
+        this.readyDocumentRefreshQueued = false;
+        this.readyDocumentRecoveryAttempted = false;
     }
 
     private renderBootContent(webviewView: vscode.WebviewView, generation: number): void {
@@ -405,6 +514,25 @@ function isFirstPaintMessage(message: unknown, generation: number): boolean {
         && message.type === FIRST_PAINT_MESSAGE_TYPE
         && message.version === BOOT_MESSAGE_VERSION
         && message.generation === generation;
+}
+
+function isReadyDocumentMessageCandidate(message: unknown): boolean {
+    return Boolean(message)
+        && typeof message === 'object'
+        && !Array.isArray(message)
+        && (message as Record<string, unknown>).type === READY_DOCUMENT_MESSAGE_TYPE;
+}
+
+function parseReadyDocumentMessage(message: unknown): {
+    documentGeneration: number;
+} | undefined {
+    if (!isExactMessage(message, ['type', 'version', 'documentGeneration'])
+        || message.type !== READY_DOCUMENT_MESSAGE_TYPE
+        || message.version !== BOOT_MESSAGE_VERSION
+        || !isPositiveSafeInteger(message.documentGeneration)) {
+        return undefined;
+    }
+    return { documentGeneration: message.documentGeneration };
 }
 
 function sanitizedViewFailure(): Error {

--- a/src/webview/webviewContent.ts
+++ b/src/webview/webviewContent.ts
@@ -62,7 +62,12 @@ export function getStewardContent(
     isSidebar: boolean = false,
     workspaceCards: WorkspaceCardViewModel[] = [],
     otherWindowsStatus: OpenWorkspaceBridgeStatus = 'ready',
+    readyDocumentGeneration: number = 1,
 ): string {
+    var safeReadyDocumentGeneration = Number.isSafeInteger(readyDocumentGeneration)
+        && readyDocumentGeneration > 0
+        ? readyDocumentGeneration
+        : 1;
     var assetRevision = `${WEBVIEW_ASSET_ACTIVATION}-${++webviewAssetRevision}`;
     var stylesPath = getMediaResource(context, webview, 'styles.css', assetRevision);
     var dashboardBundlePath = getMediaResource(
@@ -181,6 +186,9 @@ export function getStewardContent(
         </div>
     </body>
 
+    <script>
+        window.__agentPivotReadyDocumentGeneration = ${safeReadyDocumentGeneration};
+    </script>
     <script src="${dashboardBundlePath}"></script>
 
     <script>

--- a/src/webview/webviewProjectScripts.js
+++ b/src/webview/webviewProjectScripts.js
@@ -710,6 +710,7 @@ function initProjects() {
     window.vscode.postMessage({
         type: 'open-workspaces-renderer-ready',
         version: 1,
+        documentGeneration: window.__agentPivotReadyDocumentGeneration,
     });
     restoreAiSessionTabsFromState(document, window.vscode);
     window.vscode.postMessage({ type: 'request-active-ai-session-terminal' });

--- a/tests/browser/dashboardStylesheetStartup.test.js
+++ b/tests/browser/dashboardStylesheetStartup.test.js
@@ -31,6 +31,10 @@ const dashboardStyles = fs.readFileSync(
     path.join(__dirname, '../../media/styles.css'),
     'utf8'
 );
+const dashboardBundle = fs.readFileSync(
+    path.join(__dirname, '../../media/webviewDashboardBundle.js'),
+    'utf8'
+);
 
 let browser;
 
@@ -85,4 +89,75 @@ test('WEBVIEW-STYLESHEET-FIRST-PAINT-001 keeps the real Dashboard out of layout 
     const settingsBox = await page.locator('.settings-button').boundingBox();
     assert.ok(settingsBox && settingsBox.width <= 32 && settingsBox.height <= 32,
         `the styled settings icon must stay bounded: ${JSON.stringify(settingsBox)}`);
+});
+
+test('WEBVIEW-NONBLOCKING-FIRST-PAINT-001 production Dashboard announces its document generation', async t => {
+    const page = await browser.newPage({ viewport: { width: 360, height: 640 } });
+    t.after(() => page.close());
+    const pageErrors = [];
+    page.on('pageerror', error => pageErrors.push(error.message));
+    await page.addInitScript(() => {
+        window.__agentPivotMessages = [];
+        window.acquireVsCodeApi = () => ({
+            postMessage(message) { window.__agentPivotMessages.push(message); },
+            getState() { return {}; },
+            setState() {},
+        });
+    });
+    await page.route('https://assets.test/**', route => {
+        const url = route.request().url();
+        if (url.includes('webviewDashboardBundle.js')) {
+            return route.fulfill({
+                status: 200,
+                contentType: 'application/javascript',
+                body: dashboardBundle,
+            });
+        }
+        if (url.includes('styles.css')) {
+            return route.fulfill({
+                status: 200,
+                contentType: 'text/css',
+                body: dashboardStyles,
+            });
+        }
+        return route.abort();
+    });
+    const html = getStewardContent(
+        { extensionPath: '/extension' },
+        {
+            cspSource: 'https://assets.test',
+            asWebviewUri: resource => ({
+                toString: () => `https://assets.test/${path.basename(resource.fsPath)}`,
+            }),
+        },
+        [],
+        {
+            config: { get: (_key, fallback) => fallback },
+            relevantExtensionsInstalls: { remoteSSH: true, remoteContainers: false },
+            otherStorageHasData: false,
+        },
+        true,
+        [],
+        'ready',
+        41,
+    );
+
+    await page.route('https://dashboard.test/', route => route.fulfill({
+        status: 200,
+        contentType: 'text/html',
+        body: html,
+    }));
+    await page.goto('https://dashboard.test/', { waitUntil: 'load' });
+    await page.waitForTimeout(100);
+    const readyMessage = await page.evaluate(() =>
+        window.__agentPivotMessages.find(message =>
+            message.type === 'open-workspaces-renderer-ready'
+        )
+    );
+    assert.deepEqual(readyMessage, {
+        type: 'open-workspaces-renderer-ready',
+        version: 1,
+        documentGeneration: 41,
+    }, pageErrors.join('\n'));
+    assert.deepEqual(pageErrors, []);
 });

--- a/tests/integration/dashboard/twoStageStartup.test.js
+++ b/tests/integration/dashboard/twoStageStartup.test.js
@@ -88,6 +88,23 @@ function bootProvider(events, getWebviewOptions = () => ({ enableScripts: true }
     });
 }
 
+function manualScheduler() {
+    const timers = [];
+    return {
+        scheduler: {
+            setTimeout(callback, delayMs) {
+                const timer = { callback, delayMs, cleared: false };
+                timers.push(timer);
+                return timer;
+            },
+            clearTimeout(timer) {
+                timer.cleared = true;
+            },
+        },
+        timers,
+    };
+}
+
 function nextTurn() {
     return new Promise(resolve => setImmediate(resolve));
 }
@@ -176,6 +193,150 @@ test('WEBVIEW-TWO-STAGE-STARTUP-001 adopts ready callbacks once and prepares the
         ['prepared'],
     ]);
     assert.equal(provider.completeBootstrap(1, readyOptions(events)), false);
+});
+
+test('WEBVIEW-NONBLOCKING-FIRST-PAINT-001 coalesces refreshes until the ready document handshake', async () => {
+    const events = [];
+    const provider = new AgentPivotViewProvider({
+        mode: 'boot',
+        options: {
+            getWebviewOptions: () => ({ enableScripts: true }),
+            renderBootContent: (_webview, generation) => `<main>boot ${generation}</main>`,
+            renderBootError: (_webview, generation) => `<main>failed ${generation}</main>`,
+            onBootShellAssigned: generation => events.push(['shell', generation]),
+            onRetry: () => undefined,
+            onFirstPaint: () => undefined,
+            logError: () => undefined,
+        },
+    });
+    const fake = makeVisibleView();
+    let renderCount = 0;
+    provider.beginBootstrap(1);
+    await provider.resolveWebviewView(fake.view, {}, {});
+    assert.equal(provider.completeBootstrap(1, {
+        ...readyOptions(events),
+        renderContent: (_webview, documentGeneration) =>
+            `<main data-document-generation="${documentGeneration}">ready ${++renderCount}</main>`,
+    }), true);
+
+    for (let refresh = 0; refresh < 100; refresh += 1) {
+        provider.refresh();
+    }
+
+    assert.deepEqual(fake.assignedHtml, [
+        '<main>boot 1</main>',
+        '<main data-document-generation="1">ready 1</main>',
+    ]);
+    await fake.receiveMessage({
+        type: 'open-workspaces-renderer-ready',
+        version: 1,
+        documentGeneration: 1,
+        extra: true,
+    });
+    assert.equal(fake.assignedHtml.length, 2);
+
+    await fake.receiveMessage({
+        type: 'open-workspaces-renderer-ready',
+        version: 1,
+        documentGeneration: 1,
+    });
+
+    assert.deepEqual(fake.assignedHtml, [
+        '<main>boot 1</main>',
+        '<main data-document-generation="1">ready 1</main>',
+        '<main data-document-generation="2">ready 2</main>',
+    ]);
+    assert.deepEqual(events.filter(event => event[0] === 'dashboard-message'), [
+        [
+            'dashboard-message',
+            { type: 'open-workspaces-renderer-ready', version: 1 },
+        ],
+    ]);
+});
+
+test('WEBVIEW-NONBLOCKING-FIRST-PAINT-001 retries at most once when the ready handshake stays missing', async () => {
+    const events = [];
+    const scheduled = manualScheduler();
+    const provider = new AgentPivotViewProvider({ mode: 'ready', options: {
+        ...readyOptions(events),
+        renderContent: (_webview, documentGeneration) =>
+            `<main>ready ${documentGeneration}</main>`,
+    } }, scheduled.scheduler);
+    const fake = makeVisibleView();
+    await provider.resolveWebviewView(fake.view, {}, {});
+
+    for (let refresh = 0; refresh < 100; refresh += 1) {
+        provider.refresh();
+    }
+
+    assert.deepEqual(fake.assignedHtml, ['<main>ready 1</main>']);
+    assert.equal(scheduled.timers.length, 1);
+    assert.equal(scheduled.timers[0].delayMs, 30_000);
+
+    scheduled.timers[0].callback();
+    for (let refresh = 0; refresh < 100; refresh += 1) {
+        provider.refresh();
+    }
+
+    assert.deepEqual(fake.assignedHtml, [
+        '<main>ready 1</main>',
+        '<main>ready 2</main>',
+    ]);
+    assert.equal(scheduled.timers.length, 1);
+
+    await fake.receiveMessage({
+        type: 'open-workspaces-renderer-ready',
+        version: 1,
+        documentGeneration: 2,
+    });
+    provider.refresh();
+    assert.deepEqual(fake.assignedHtml, [
+        '<main>ready 1</main>',
+        '<main>ready 2</main>',
+        '<main>ready 3</main>',
+    ]);
+    assert.equal(scheduled.timers.length, 2);
+});
+
+test('WEBVIEW-NONBLOCKING-FIRST-PAINT-001 ignores a stale ready handshake from the replaced document', async () => {
+    const events = [];
+    const provider = new AgentPivotViewProvider({ mode: 'ready', options: {
+        ...readyOptions(events),
+        renderContent: (_webview, documentGeneration) =>
+            `<main>ready ${documentGeneration}</main>`,
+    } });
+    const fake = makeVisibleView();
+    await provider.resolveWebviewView(fake.view, {}, {});
+    provider.refresh();
+
+    await fake.receiveMessage({
+        type: 'open-workspaces-renderer-ready',
+        version: 1,
+        documentGeneration: 1,
+    });
+    assert.deepEqual(fake.assignedHtml, [
+        '<main>ready 1</main>',
+        '<main>ready 2</main>',
+    ]);
+
+    provider.refresh();
+    await fake.receiveMessage({
+        type: 'open-workspaces-renderer-ready',
+        version: 1,
+        documentGeneration: 1,
+    });
+    assert.equal(fake.assignedHtml.length, 2);
+
+    await fake.receiveMessage({
+        type: 'open-workspaces-renderer-ready',
+        version: 1,
+        documentGeneration: 2,
+    });
+    assert.deepEqual(fake.assignedHtml, [
+        '<main>ready 1</main>',
+        '<main>ready 2</main>',
+        '<main>ready 3</main>',
+    ]);
 });
 
 test('WEBVIEW-TWO-STAGE-STARTUP-001 applies ready webview options before ready rendering and preparation', async () => {

--- a/tests/integration/dashboard/webviewState.test.js
+++ b/tests/integration/dashboard/webviewState.test.js
@@ -1830,6 +1830,7 @@ function createProjectVm({
         window: {
             innerWidth: 1024,
             innerHeight: 768,
+            __agentPivotReadyDocumentGeneration: 7,
             addEventListener: (type, listener) => {
                 windowListeners[type] = listener;
                 initializationEvents.push(`listener:${type}`);
@@ -2275,6 +2276,7 @@ test('OPEN-OPEN-PROJECT-INCREMENTAL-RENDERING-001 announces renderer readiness a
     assert.deepEqual(toPlain(harness.initialMessages[0]), {
         type: 'open-workspaces-renderer-ready',
         version: 1,
+        documentGeneration: 7,
     });
     assert.ok(
         harness.initializationEvents.indexOf('listener:message')


### PR DESCRIPTION
## Summary

- keep the current Dashboard Webview document alive while it is still loading and coalesce startup refreshes into one latest render
- correlate renderer-ready acknowledgements with a document generation so stale acknowledgements cannot release a newer document
- recover a genuinely missing acknowledgement with one delayed retry, without creating a periodic reload storm
- cover the Host lifecycle and the production Dashboard HTML/CSS/bundle handshake in CI

## Skill harvest

no skill change — the false start was a product-specific recovery-policy defect; the existing regression workflow already requires RED evidence and production rendered-surface ownership, which this branch now supplies.

## Verification

- `npm run test:ci:linux`
  - deterministic: 331/331
  - browser: 135/135
  - changed-line coverage: 98.58% (139/141)
  - behavior contracts, safety, architecture, release packaging: passed
- final read-only integration review: no Critical or Important findings
- `SKIP_NPM_CI=1 npm run install-local`
  - installed `hzcheng.agent-pivot@1.0.4`
  - installed bytes match the final worktree build
- manual reload validation in two remote VS Code windows
