### PR TITLE
Fix exact conversation comment quote location

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -4182,6 +4182,19 @@
     ]
   },
   {
+    "id": "CONVERSATION-COMMENT-QUOTE-LOCATION-001",
+    "domain": "webview",
+    "title": "AI Conversation locates the exact quoted occurrence for a comment and centers that text within the conversation viewport",
+    "priority": "P1",
+    "status": "automated",
+    "owners": [
+      "tests/browser/conversationViewer.test.js"
+    ],
+    "evidence": [
+      "src/webview/conversationCommentsScripts.js"
+    ]
+  },
+  {
     "id": "CONVERSATION-COMMENTS-BULK-001",
     "domain": "webview",
     "title": "AI Conversation clears done or all comments through correlated Host-authoritative batch mutations with explicit clear-all confirmation",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "6f22284edc8b8e3b4e71dcf8abb5b46569164abc",
+        "head": "3bf7c016ed82999f21a3ed013167fd9df56a8bb0",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -162,7 +162,8 @@
             "e0b043799f4b9c5ff4ffa4099ec6c3690b103129",
             "3fe5e04ecb7a6022b4e1aa20125f207796e8a31a",
             "db085481b95fc9b3372c83023343a00640e678e7",
-            "d2341beee5e0d318fc847c3ec7c12234e27f19a8"
+            "d2341beee5e0d318fc847c3ec7c12234e27f19a8",
+            "cfa1d431d17fe5b334f34a7f220b8c905d2883de"
         ]
     },
     "capabilities": [
@@ -1279,7 +1280,8 @@
                 "f947662341d783a160b3642f6c50f2eb7922522a",
                 "1b008ace0a59a6539fc8e70c90d148a369c61fae",
                 "bf14ae5b6286d268264f4246604d99860a06aaf6",
-                "d6385f753ae6fde4801ccfc6a2b2a59b294a39b7"
+                "d6385f753ae6fde4801ccfc6a2b2a59b294a39b7",
+                "3bf7c016ed82999f21a3ed013167fd9df56a8bb0"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",
@@ -1320,7 +1322,8 @@
                 "CONVERSATION-CHROME-LAYOUT-001",
                 "CONVERSATION-LIVE-UPDATE-JOURNEY-001",
                 "CONVERSATION-NAVIGATION-STATE-001",
-                "CONVERSATION-LOCAL-FILE-LINKS-001"
+                "CONVERSATION-LOCAL-FILE-LINKS-001",
+                "CONVERSATION-COMMENT-QUOTE-LOCATION-001"
             ],
             "prGates": [
                 "test:ci:linux"

--- a/media/conversationCommentsScripts.js
+++ b/media/conversationCommentsScripts.js
@@ -86,6 +86,7 @@
                         && value.quote === ''
                         && value.prefix === ''
                         && value.suffix === ''))
+                && (hasSessionScope || value.quote.trim().length > 0)
                 && (value.status === 'open' || value.status === 'done')
                 && (value.createdAt === undefined
                     || (Number.isSafeInteger(value.createdAt)
@@ -355,7 +356,17 @@
             if (!message) {
                 return false;
             }
-            message.scrollIntoView({ block: 'center' });
+            var markdown = message.querySelector('.conversation-markdown');
+            var range = markdown && findQuoteRange(markdown, comment);
+            var scroll = messages.closest('[data-conversation-scroll]');
+            if (range && scroll) {
+                var quoteBounds = range.getBoundingClientRect();
+                var scrollBounds = scroll.getBoundingClientRect();
+                scroll.scrollTop += (quoteBounds.top + quoteBounds.bottom) / 2
+                    - (scrollBounds.top + scrollBounds.bottom) / 2;
+            } else {
+                message.scrollIntoView({ block: 'center' });
+            }
             message.tabIndex = -1;
             message.focus({ preventScroll: true });
             message.classList.add('conversation-comment-located');
@@ -861,19 +872,90 @@
                 );
             }
             var start = candidates.find(function (offset) {
-                var before = combined.slice(
-                    Math.max(0, offset - comment.prefix.length),
-                    offset
-                );
-                var after = combined.slice(
-                    offset + comment.quote.length,
-                    offset + comment.quote.length + comment.suffix.length
-                );
-                return before === comment.prefix && after === comment.suffix;
+                return offset >= comment.prefix.length
+                    && combined.startsWith(
+                        comment.prefix,
+                        offset - comment.prefix.length
+                    )
+                    && combined.startsWith(
+                        comment.suffix,
+                        offset + comment.quote.length
+                    );
             });
+            if (start === undefined) {
+                var relaxedPrefix = comment.prefix.trimEnd();
+                var relaxedSuffix = comment.suffix.trimStart();
+                start = candidates.find(function (offset) {
+                    var beforeEnd = offset;
+                    while (beforeEnd > 0
+                        && /\s/.test(combined.charAt(beforeEnd - 1))) {
+                        beforeEnd -= 1;
+                    }
+                    var afterStart = offset + comment.quote.length;
+                    while (afterStart < combined.length
+                        && /\s/.test(combined.charAt(afterStart))) {
+                        afterStart += 1;
+                    }
+                    return beforeEnd >= relaxedPrefix.length
+                        && combined.startsWith(
+                            relaxedPrefix,
+                            beforeEnd - relaxedPrefix.length
+                        )
+                        && combined.startsWith(relaxedSuffix, afterStart);
+                });
+            }
+            var end;
+            if (start !== undefined) {
+                end = start + comment.quote.length;
+            } else {
+                var compactChars = [];
+                var compactOffsets = [];
+                for (var index = 0; index < combined.length; index += 1) {
+                    if (/\s/.test(combined.charAt(index))) continue;
+                    compactOffsets.push(index);
+                    compactChars.push(combined.charAt(index));
+                }
+                var compacted = compactChars.join('');
+                var compactQuote = comment.quote.replace(/\s/g, '');
+                if (!compactQuote) return null;
+                var compactPrefix = comment.prefix.replace(/\s/g, '');
+                var compactSuffix = comment.suffix.replace(/\s/g, '');
+                var compactCandidate = compacted.indexOf(compactQuote);
+                var firstCompactCandidate = compactCandidate >= 0
+                    ? compactCandidate
+                    : undefined;
+                var compactStart;
+                while (compactCandidate >= 0) {
+                    if (compactCandidate >= compactPrefix.length
+                        && compacted.startsWith(
+                            compactPrefix,
+                            compactCandidate - compactPrefix.length
+                        )
+                        && compacted.startsWith(
+                            compactSuffix,
+                            compactCandidate + compactQuote.length
+                        )) {
+                        compactStart = compactCandidate;
+                        break;
+                    }
+                    compactCandidate = compacted.indexOf(
+                        compactQuote,
+                        compactCandidate + 1
+                    );
+                }
+                if (compactStart === undefined) {
+                    compactStart = firstCompactCandidate;
+                }
+                if (compactStart !== undefined) {
+                    start = compactOffsets[compactStart];
+                    end = compactOffsets[
+                        compactStart + compactQuote.length - 1
+                    ] + 1;
+                }
+            }
             if (start === undefined) start = candidates[0];
             if (start === undefined) return null;
-            var end = start + comment.quote.length;
+            if (end === undefined) end = start + comment.quote.length;
             var startRecord = nodes.find(function (record) {
                 return start >= record.start
                     && start <= record.start + (record.node.nodeValue || '').length;
@@ -1083,7 +1165,8 @@
             var markdown = startElement && startElement.closest
                 ? startElement.closest('.conversation-markdown')
                 : null;
-            var quote = selection.toString().trim();
+            var selectedText = selection.toString();
+            var quote = selectedText.trim();
             if (!startMessage || startMessage !== endMessage || !markdown
                 || !messages.contains(startMessage) || !quote
                 || Array.from(quote).length > 4000) {
@@ -1092,6 +1175,12 @@
                 return;
             }
             var context = selectionContext(range, markdown);
+            var quoteStart = selectedText.indexOf(quote);
+            var quoteEnd = quoteStart + quote.length;
+            context.prefix = (context.prefix
+                + selectedText.slice(0, quoteStart)).slice(-240);
+            context.suffix = (selectedText.slice(quoteEnd)
+                + context.suffix).slice(0, 240);
             state.selectedCommentText = {
                 messageId: conversationMessageId(startMessage),
                 interactionId: startMessage.getAttribute('data-interaction-id'),

--- a/src/webview/conversationCommentsScripts.js
+++ b/src/webview/conversationCommentsScripts.js
@@ -86,6 +86,7 @@
                         && value.quote === ''
                         && value.prefix === ''
                         && value.suffix === ''))
+                && (hasSessionScope || value.quote.trim().length > 0)
                 && (value.status === 'open' || value.status === 'done')
                 && (value.createdAt === undefined
                     || (Number.isSafeInteger(value.createdAt)
@@ -355,7 +356,17 @@
             if (!message) {
                 return false;
             }
-            message.scrollIntoView({ block: 'center' });
+            var markdown = message.querySelector('.conversation-markdown');
+            var range = markdown && findQuoteRange(markdown, comment);
+            var scroll = messages.closest('[data-conversation-scroll]');
+            if (range && scroll) {
+                var quoteBounds = range.getBoundingClientRect();
+                var scrollBounds = scroll.getBoundingClientRect();
+                scroll.scrollTop += (quoteBounds.top + quoteBounds.bottom) / 2
+                    - (scrollBounds.top + scrollBounds.bottom) / 2;
+            } else {
+                message.scrollIntoView({ block: 'center' });
+            }
             message.tabIndex = -1;
             message.focus({ preventScroll: true });
             message.classList.add('conversation-comment-located');
@@ -861,19 +872,90 @@
                 );
             }
             var start = candidates.find(function (offset) {
-                var before = combined.slice(
-                    Math.max(0, offset - comment.prefix.length),
-                    offset
-                );
-                var after = combined.slice(
-                    offset + comment.quote.length,
-                    offset + comment.quote.length + comment.suffix.length
-                );
-                return before === comment.prefix && after === comment.suffix;
+                return offset >= comment.prefix.length
+                    && combined.startsWith(
+                        comment.prefix,
+                        offset - comment.prefix.length
+                    )
+                    && combined.startsWith(
+                        comment.suffix,
+                        offset + comment.quote.length
+                    );
             });
+            if (start === undefined) {
+                var relaxedPrefix = comment.prefix.trimEnd();
+                var relaxedSuffix = comment.suffix.trimStart();
+                start = candidates.find(function (offset) {
+                    var beforeEnd = offset;
+                    while (beforeEnd > 0
+                        && /\s/.test(combined.charAt(beforeEnd - 1))) {
+                        beforeEnd -= 1;
+                    }
+                    var afterStart = offset + comment.quote.length;
+                    while (afterStart < combined.length
+                        && /\s/.test(combined.charAt(afterStart))) {
+                        afterStart += 1;
+                    }
+                    return beforeEnd >= relaxedPrefix.length
+                        && combined.startsWith(
+                            relaxedPrefix,
+                            beforeEnd - relaxedPrefix.length
+                        )
+                        && combined.startsWith(relaxedSuffix, afterStart);
+                });
+            }
+            var end;
+            if (start !== undefined) {
+                end = start + comment.quote.length;
+            } else {
+                var compactChars = [];
+                var compactOffsets = [];
+                for (var index = 0; index < combined.length; index += 1) {
+                    if (/\s/.test(combined.charAt(index))) continue;
+                    compactOffsets.push(index);
+                    compactChars.push(combined.charAt(index));
+                }
+                var compacted = compactChars.join('');
+                var compactQuote = comment.quote.replace(/\s/g, '');
+                if (!compactQuote) return null;
+                var compactPrefix = comment.prefix.replace(/\s/g, '');
+                var compactSuffix = comment.suffix.replace(/\s/g, '');
+                var compactCandidate = compacted.indexOf(compactQuote);
+                var firstCompactCandidate = compactCandidate >= 0
+                    ? compactCandidate
+                    : undefined;
+                var compactStart;
+                while (compactCandidate >= 0) {
+                    if (compactCandidate >= compactPrefix.length
+                        && compacted.startsWith(
+                            compactPrefix,
+                            compactCandidate - compactPrefix.length
+                        )
+                        && compacted.startsWith(
+                            compactSuffix,
+                            compactCandidate + compactQuote.length
+                        )) {
+                        compactStart = compactCandidate;
+                        break;
+                    }
+                    compactCandidate = compacted.indexOf(
+                        compactQuote,
+                        compactCandidate + 1
+                    );
+                }
+                if (compactStart === undefined) {
+                    compactStart = firstCompactCandidate;
+                }
+                if (compactStart !== undefined) {
+                    start = compactOffsets[compactStart];
+                    end = compactOffsets[
+                        compactStart + compactQuote.length - 1
+                    ] + 1;
+                }
+            }
             if (start === undefined) start = candidates[0];
             if (start === undefined) return null;
-            var end = start + comment.quote.length;
+            if (end === undefined) end = start + comment.quote.length;
             var startRecord = nodes.find(function (record) {
                 return start >= record.start
                     && start <= record.start + (record.node.nodeValue || '').length;
@@ -1083,7 +1165,8 @@
             var markdown = startElement && startElement.closest
                 ? startElement.closest('.conversation-markdown')
                 : null;
-            var quote = selection.toString().trim();
+            var selectedText = selection.toString();
+            var quote = selectedText.trim();
             if (!startMessage || startMessage !== endMessage || !markdown
                 || !messages.contains(startMessage) || !quote
                 || Array.from(quote).length > 4000) {
@@ -1092,6 +1175,12 @@
                 return;
             }
             var context = selectionContext(range, markdown);
+            var quoteStart = selectedText.indexOf(quote);
+            var quoteEnd = quoteStart + quote.length;
+            context.prefix = (context.prefix
+                + selectedText.slice(0, quoteStart)).slice(-240);
+            context.suffix = (selectedText.slice(quoteEnd)
+                + context.suffix).slice(0, 240);
             state.selectedCommentText = {
                 messageId: conversationMessageId(startMessage),
                 interactionId: startMessage.getAttribute('data-interaction-id'),

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -2775,6 +2775,249 @@ test('CONVERSATION-COMMENTS-UI-001 CONVERSATION-COMMENTS-SUBMIT-002 renders read
     ]);
 });
 
+test('CONVERSATION-COMMENT-QUOTE-LOCATION-001 centers the exact quoted occurrence instead of the whole message', async t => {
+    const interactionId = 'input-quote-location';
+    const fillerBefore = Array.from(
+        { length: 60 },
+        (_item, index) => `Filler paragraph ${index}.`
+    ).join('\n\n');
+    const fillerAfter = Array.from(
+        { length: 20 },
+        (_item, index) => `Trailing paragraph ${index}.`
+    ).join('\n\n');
+    const comment = {
+        id: 'comment-quote-location',
+        messageId: `${interactionId}:user`,
+        interactionId,
+        role: 'user',
+        quote: 'repeated quote',
+        // Legacy comments could omit selected edge whitespace from their
+        // context, so this intentionally lacks the space before the quote.
+        prefix: 'Second occurrence:',
+        suffix: ' after second.',
+        comment: 'Review the second occurrence.',
+        status: 'open',
+    };
+    const { page } = await openHostViewerDocument(t, {
+        includeStyles: true,
+        themeFixture: viewerThemeFixtures[0],
+        viewport: { width: 850, height: 500 },
+        initialWebviewState: {
+            conversationCommentsPanel: { open: true, width: 240 },
+        },
+        interactionIds: [interactionId],
+        interactionId,
+        markdown: `First occurrence: repeated quote after first.\n\n${fillerBefore}`
+            + '\n\nSecond occurrence: repeated quote after second.\n\n'
+            + fillerAfter,
+        pageOverrides: {
+            previousCursor: undefined,
+            nextCursor: undefined,
+            isStart: true,
+            isEnd: true,
+        },
+        commentStore: {
+            async load() {
+                return { revision: 1, comments: [comment] };
+            },
+        },
+    });
+    const target = page.locator('.conversation-markdown p')
+        .filter({ hasText: /^Second occurrence:/ });
+    assert.match(await target.innerText(), /^Second occurrence:/);
+
+    await page.locator('[data-comment-id="comment-quote-location"]')
+        .locator('[data-comment-action="locate"]').click();
+
+    const location = await target.evaluate(element => {
+        const scroll = document.querySelector('[data-conversation-scroll]');
+        const targetBounds = element.getBoundingClientRect();
+        const scrollBounds = scroll.getBoundingClientRect();
+        return {
+            visible: targetBounds.top >= scrollBounds.top
+                && targetBounds.bottom <= scrollBounds.bottom,
+            centerOffset: Math.abs(
+                (targetBounds.top + targetBounds.bottom) / 2
+                - (scrollBounds.top + scrollBounds.bottom) / 2
+            ),
+        };
+    });
+    assert.equal(location.visible, true, JSON.stringify(location));
+    assert.ok(
+        location.centerOffset <= 40,
+        `quoted text was ${location.centerOffset}px away from viewport center`
+    );
+
+    await target.evaluate(element => {
+        const node = element.firstChild;
+        const selectedText = ' repeated quote ';
+        const start = node.nodeValue.indexOf(selectedText);
+        const range = document.createRange();
+        range.setStart(node, start);
+        range.setEnd(node, start + selectedText.length);
+        const selection = window.getSelection();
+        selection.removeAllRanges();
+        selection.addRange(range);
+        element.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+    });
+    await page.locator(
+        '[data-comment-selection-action="comment"]'
+    ).click();
+    await page.locator('[data-comment-input]').fill(
+        'Keep context aligned with the trimmed quote.'
+    );
+    await page.locator('[data-comment-input]').press('Control+Enter');
+    const addRequest = (await postedMessages(page)).at(-1);
+    assert.equal(addRequest.operation, 'add');
+    const { prefix, suffix, ...selection } = addRequest.payload;
+    assert.deepEqual(selection, {
+        messageId: `${interactionId}:user`,
+        interactionId,
+        quote: 'repeated quote',
+        comment: 'Keep context aligned with the trimmed quote.',
+    });
+    assert.equal(prefix.endsWith('Second occurrence: '), true);
+    assert.equal(suffix.startsWith(' after second.'), true);
+});
+
+test('CONVERSATION-COMMENT-QUOTE-LOCATION-001 preserves and locates a quote spanning Markdown blocks', async t => {
+    const interactionId = 'input-block-quote-location';
+    const fillerBefore = Array.from(
+        { length: 50 },
+        (_item, index) => `Earlier paragraph ${index}.`
+    ).join('\n\n');
+    const fillerAfter = Array.from(
+        { length: 20 },
+        (_item, index) => `Later paragraph ${index}.`
+    ).join('\n\n');
+    const { page } = await openHostViewerDocument(t, {
+        includeStyles: true,
+        themeFixture: viewerThemeFixtures[0],
+        viewport: { width: 850, height: 500 },
+        initialWebviewState: {
+            conversationCommentsPanel: { open: true, width: 240 },
+        },
+        interactionIds: [interactionId],
+        interactionId,
+        markdown: `${fillerBefore}\n\nOpening block phrase alpha.`
+            + '\n\nClosing block beta phrase.\n\n'
+            + fillerAfter,
+        pageOverrides: {
+            previousCursor: undefined,
+            nextCursor: undefined,
+            isStart: true,
+            isEnd: true,
+        },
+    });
+    const opening = page.locator('.conversation-markdown p')
+        .filter({ hasText: /^Opening block/ });
+    const closing = page.locator('.conversation-markdown p')
+        .filter({ hasText: /^Closing block/ });
+    await page.locator('.conversation-markdown').evaluate((element, labels) => {
+        const paragraphs = Array.from(element.querySelectorAll('p'));
+        const startNode = paragraphs.find(paragraph =>
+            paragraph.textContent.startsWith(labels.opening)
+        ).firstChild;
+        const endNode = paragraphs.find(paragraph =>
+            paragraph.textContent.startsWith(labels.closing)
+        ).firstChild;
+        const range = document.createRange();
+        range.setStart(startNode, startNode.nodeValue.indexOf('alpha'));
+        range.setEnd(
+            endNode,
+            endNode.nodeValue.indexOf('beta') + 'beta'.length
+        );
+        const selection = window.getSelection();
+        selection.removeAllRanges();
+        selection.addRange(range);
+        element.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+    }, { opening: 'Opening block', closing: 'Closing block' });
+    await page.locator('[data-comment-selection-action="comment"]')
+        .evaluate(button => button.click());
+    await page.locator('[data-comment-input]').fill('Review both blocks.');
+    await page.locator('[data-comment-input]').press('Control+Enter');
+    const addRequest = (await postedMessages(page)).at(-1);
+    assert.equal(addRequest.payload.quote, 'alpha.\n\nClosing block beta');
+    const comment = {
+        id: 'comment-block-quote-location',
+        ...addRequest.payload,
+        role: 'user',
+        status: 'open',
+    };
+    await page.evaluate(({ request, comment }) => {
+        window.dispatchEvent(new MessageEvent('message', {
+            data: {
+                type: 'conversation-viewer-comments-result',
+                version: 1,
+                requestId: request.requestId,
+                subscriptionGeneration: request.subscriptionGeneration,
+                projectId: request.projectId,
+                provider: request.provider,
+                sessionId: request.sessionId,
+                operation: request.operation,
+                success: true,
+                revision: 1,
+                comments: [{ ...comment, quote: '   ' }],
+            },
+        }));
+    }, { request: addRequest, comment });
+    assert.equal(
+        await page.locator('[data-conversation-comments]')
+            .getAttribute('aria-busy'),
+        'true',
+        'a whitespace-only quote settlement must be rejected'
+    );
+    await page.evaluate(({ request, comment }) => {
+        window.dispatchEvent(new MessageEvent('message', {
+            data: {
+                type: 'conversation-viewer-comments-result',
+                version: 1,
+                requestId: request.requestId,
+                subscriptionGeneration: request.subscriptionGeneration,
+                projectId: request.projectId,
+                provider: request.provider,
+                sessionId: request.sessionId,
+                operation: request.operation,
+                success: true,
+                revision: 1,
+                comments: [comment],
+            },
+        }));
+    }, { request: addRequest, comment });
+
+    await page.locator('[data-comment-id="comment-block-quote-location"]')
+        .locator('[data-comment-action="locate"]').click();
+    const location = await page.evaluate(() => {
+        const scroll = document.querySelector('[data-conversation-scroll]');
+        const paragraphs = Array.from(document.querySelectorAll(
+            '.conversation-markdown p'
+        ));
+        const opening = paragraphs.find(paragraph =>
+            paragraph.textContent.startsWith('Opening block')
+        ).getBoundingClientRect();
+        const closing = paragraphs.find(paragraph =>
+            paragraph.textContent.startsWith('Closing block')
+        ).getBoundingClientRect();
+        const scrollBounds = scroll.getBoundingClientRect();
+        return {
+            openingVisible: opening.top >= scrollBounds.top,
+            closingVisible: closing.bottom <= scrollBounds.bottom,
+            centerOffset: Math.abs(
+                (opening.top + closing.bottom) / 2
+                - (scrollBounds.top + scrollBounds.bottom) / 2
+            ),
+        };
+    });
+    assert.equal(await opening.count(), 1);
+    assert.equal(await closing.count(), 1);
+    assert.equal(location.openingVisible, true, JSON.stringify(location));
+    assert.equal(location.closingVisible, true, JSON.stringify(location));
+    assert.ok(
+        location.centerOffset <= 40,
+        `block quote was ${location.centerOffset}px away from viewport center`
+    );
+});
+
 test('CONVERSATION-COMMENTS-UI-001 filters cards, jumps from message markers, and keeps the toolbar to one icon row', async t => {
     const interactionId = 'input-filter-marker';
     const { page } = await openHostViewerDocument(t, {


### PR DESCRIPTION
## Summary

- locate the exact quoted occurrence for AI Conversation comments instead of centering the entire message
- preserve trimmed selection context, legacy whitespace compatibility, and quotes spanning Markdown blocks
- reject malformed whitespace-only quotes and keep fallback matching bounded on long messages
- add a Chromium behavior contract covering duplicate, legacy, cross-block, and malformed quote cases

## Skill harvest

None. The existing regression and final-review skills already required rendered-surface coverage and caught the cross-block and complexity edge cases; no reusable workflow instruction gap was found.

## Verification

- `npm run test:ci:linux`
- `npm run test:behavior-contracts` after the capability audit commit
- `git diff --check`
- `SKIP_NPM_CI=1 npm run install-local`
- verified `media/conversationCommentsScripts.js` SHA-256 `aa43a59de7a969d43e84cc8bb597152b383ab723e4bca3fe4e25e88f594f024e` across the source tree, VSIX, and installed VS Code Server extension
