### PR TITLE
Fix Claude context window telemetry

### DIFF
--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "3bf7c016ed82999f21a3ed013167fd9df56a8bb0",
+        "head": "131b4c3b22bfaf2e7807a4a1379366db9d4ebc54",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -163,7 +163,8 @@
             "3fe5e04ecb7a6022b4e1aa20125f207796e8a31a",
             "db085481b95fc9b3372c83023343a00640e678e7",
             "d2341beee5e0d318fc847c3ec7c12234e27f19a8",
-            "cfa1d431d17fe5b334f34a7f220b8c905d2883de"
+            "cfa1d431d17fe5b334f34a7f220b8c905d2883de",
+            "67e5c350a0c48974fb444a821143971bcc99e8d5"
         ]
     },
     "capabilities": [
@@ -1281,7 +1282,8 @@
                 "1b008ace0a59a6539fc8e70c90d148a369c61fae",
                 "bf14ae5b6286d268264f4246604d99860a06aaf6",
                 "d6385f753ae6fde4801ccfc6a2b2a59b294a39b7",
-                "3bf7c016ed82999f21a3ed013167fd9df56a8bb0"
+                "3bf7c016ed82999f21a3ed013167fd9df56a8bb0",
+                "131b4c3b22bfaf2e7807a4a1379366db9d4ebc54"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",

--- a/src/aiSessions/conversation/claudeAdapter.ts
+++ b/src/aiSessions/conversation/claudeAdapter.ts
@@ -67,9 +67,11 @@ export interface ClaudeConversationAdapterOptions {
 
 type ConversationContextUsage = NonNullable<ConversationTelemetry['context']>;
 
-// Claude Code JSONL does not record the context-window size; all current
-// Claude models default to a 200k window.
-const CLAUDE_DEFAULT_MAX_CONTEXT_TOKENS = 200_000;
+// Claude Code JSONL records the resolved model but not its context-window
+// size. Opus and Sonnet moved to a 1M default in 4.6; generation 5 frontier
+// models also use 1M. Older models, including Haiku 4.5, retain 200k.
+const CLAUDE_LEGACY_MAX_CONTEXT_TOKENS = 200_000;
+const CLAUDE_LONG_MAX_CONTEXT_TOKENS = 1_000_000;
 
 const MAX_LISTED_SUBAGENTS = 64;
 const SUBAGENT_TRANSCRIPT_PATTERN = /^agent-([0-9a-z][0-9a-z-]{0,63})\.jsonl$/i;
@@ -169,6 +171,15 @@ function contextUsageTokens(value: unknown): number | undefined {
         0
     );
     return total > 0 ? total : undefined;
+}
+
+function maxContextTokens(model: string | undefined): number {
+    const normalized = model?.trim().toLowerCase() ?? '';
+    if (/(?:^|[.:/])claude-(?:(?:opus-4-(?:6|7|8))|sonnet-4-6|(?:fable|mythos|opus|sonnet)-5|mythos-preview)(?:-|$)/
+        .test(normalized)) {
+        return CLAUDE_LONG_MAX_CONTEXT_TOKENS;
+    }
+    return CLAUDE_LEGACY_MAX_CONTEXT_TOKENS;
 }
 
 function isUserInterrupt(value: unknown): boolean {
@@ -511,7 +522,7 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
                     if (usedTokens) {
                         telemetryContext = {
                             usedTokens,
-                            maxTokens: CLAUDE_DEFAULT_MAX_CONTEXT_TOKENS,
+                            maxTokens: maxContextTokens(telemetryModel),
                         };
                     }
                 }

--- a/tests/contract/aiSessions/claudeConversationAdapter.test.js
+++ b/tests/contract/aiSessions/claudeConversationAdapter.test.js
@@ -671,7 +671,7 @@ test('CONVERSATION-TELEMETRY-001 Claude surfaces the latest assistant model and 
         provider: 'claude',
         sessionId,
         model: 'claude-sonnet-4-6',
-        context: { usedTokens: 120047, maxTokens: 200000 },
+        context: { usedTokens: 120047, maxTokens: 1_000_000 },
         rateLimits: [],
     });
 
@@ -696,7 +696,81 @@ test('CONVERSATION-TELEMETRY-001 Claude surfaces the latest assistant model and 
         provider: 'claude',
         sessionId,
         model: 'claude-opus-4-6',
-        context: { usedTokens: 131072, maxTokens: 200000 },
+        context: { usedTokens: 131072, maxTokens: 1_000_000 },
+        rateLimits: [],
+    });
+});
+
+test('CONVERSATION-TELEMETRY-001 Claude uses model-specific context windows', async t => {
+    const source = await createFixture(t);
+    const adapter = createAdapter(source);
+    t.after(() => adapter.dispose());
+
+    const millionTokenModels = [
+        'claude-opus-4-6',
+        'claude-opus-4-7',
+        'claude-opus-4-8',
+        'claude-sonnet-4-6',
+        'claude-opus-5',
+        'claude-sonnet-5',
+        'claude-fable-5',
+        'claude-mythos-5',
+        'claude-mythos-preview',
+        'us.anthropic.claude-opus-5-v1:0',
+    ];
+    for (const [index, model] of millionTokenModels.entries()) {
+        await fs.promises.appendFile(
+            source.sourcePath,
+            `${JSON.stringify({
+                type: 'assistant',
+                uuid: `telemetry-million-${index}`,
+                message: {
+                    role: 'assistant',
+                    model,
+                    content: [{ type: 'text', text: 'Continuing a long session.' }],
+                    usage: {
+                        input_tokens: 2,
+                        cache_creation_input_tokens: 3873,
+                        cache_read_input_tokens: 352883,
+                        output_tokens: 2026,
+                    },
+                },
+            })}\n`
+        );
+
+        assert.deepEqual(await adapter.readTelemetry(sessionId), {
+            provider: 'claude',
+            sessionId,
+            model,
+            context: { usedTokens: 358784, maxTokens: 1_000_000 },
+            rateLimits: [],
+        });
+    }
+
+    await fs.promises.appendFile(
+        source.sourcePath,
+        `${JSON.stringify({
+            type: 'assistant',
+            uuid: 'telemetry-haiku-4-5',
+            message: {
+                role: 'assistant',
+                model: 'claude-haiku-4-5-20251001',
+                content: [{ type: 'text', text: 'Using a smaller window.' }],
+                usage: {
+                    input_tokens: 3,
+                    cache_creation_input_tokens: 1200,
+                    cache_read_input_tokens: 48000,
+                    output_tokens: 300,
+                },
+            },
+        })}\n`
+    );
+
+    assert.deepEqual(await adapter.readTelemetry(sessionId), {
+        provider: 'claude',
+        sessionId,
+        model: 'claude-haiku-4-5-20251001',
+        context: { usedTokens: 49503, maxTokens: 200_000 },
         rateLimits: [],
     });
 });


### PR DESCRIPTION
## Summary

- derive Claude context-window capacity from the resolved model instead of a global 200k fallback
- cover the current 1M model matrix, provider-prefixed IDs, Mythos Preview, and legacy 200k behavior
- verify the adapter against a real local Claude Opus 5 transcript without exposing conversation content

## Skill harvest

No skill change was justified. The worktree dependency-install retry was already covered by the existing worktree skill, and the installation workflow already required artifact and installed-byte verification.

## Verification

- npm run test-compile
- node --test tests/contract/aiSessions/claudeConversationAdapter.test.js
- npm run test:behavior-contracts
- npm run test:ci:linux
- git diff --check
- local VSIX installation with packaged-to-installed byte verification