### PR TITLE
Cut sidebar startup latency for Open Windows

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -1935,10 +1935,14 @@
     "priority": "P1",
     "status": "automated",
     "owners": [
-      "tests/contract/openProjects/bridgeClient.test.js"
+      "tests/contract/openProjects/bridgeClient.test.js",
+      "tests/contract/openProjects/dashboardConnectingStatus.test.js",
+      "tests/integration/dashboard/openWorkspacesConnecting.test.js"
     ],
     "evidence": [
-      "scripts/run-open-project-safety-checks.js"
+      "scripts/run-open-project-safety-checks.js",
+      "src/openWorkspaces/dashboardController.ts",
+      "src/webview/webviewContent.ts"
     ]
   },
   {

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "131b4c3b22bfaf2e7807a4a1379366db9d4ebc54",
+        "head": "a7613039cd4196cb6f43c022d15eea1483204eaf",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -164,7 +164,8 @@
             "db085481b95fc9b3372c83023343a00640e678e7",
             "d2341beee5e0d318fc847c3ec7c12234e27f19a8",
             "cfa1d431d17fe5b334f34a7f220b8c905d2883de",
-            "67e5c350a0c48974fb444a821143971bcc99e8d5"
+            "67e5c350a0c48974fb444a821143971bcc99e8d5",
+            "13ea7824781c9eeaff4b08ee59e26cd86e9ac835"
         ]
     },
     "capabilities": [
@@ -297,7 +298,10 @@
                 "1cb17856b4e8db7fc94d2f6b4a5479d11f95f7d1",
                 "20f0258e412d2e448840658e67d181b06afb0fdf",
                 "f287d527971ec6a53b99ab20e75dbe73d8e28ec5",
-                "499dc7a3f0d1384adddec85f586fd0c45a48dbd9"
+                "499dc7a3f0d1384adddec85f586fd0c45a48dbd9",
+                "ee825a7244d9a7d5a2aa1acf795434520d6ecfd1",
+                "e393b67fb9f066c94ee38c2f0bfcbb618adc60f2",
+                "a7613039cd4196cb6f43c022d15eea1483204eaf"
             ],
             "behaviors": [
                 "OPEN-OPEN-PROJECT-AUTHORITATIVE-IDENTITY-001",

--- a/media/webviewDashboardBundle.js
+++ b/media/webviewDashboardBundle.js
@@ -609,6 +609,7 @@ function applyOpenWorkspacesUpdate(message) {
         || !Number.isSafeInteger(message.navigationWorkspaceCount)
         || message.navigationWorkspaceCount < 0
         || (message.otherWindowsStatus !== 'ready'
+            && message.otherWindowsStatus !== 'connecting'
             && message.otherWindowsStatus !== 'unavailable'
             && message.otherWindowsStatus !== 'update-required')
         || typeof message.html !== 'string'

--- a/media/webviewWorkspaceUpdateScripts.js
+++ b/media/webviewWorkspaceUpdateScripts.js
@@ -202,6 +202,7 @@ function applyOpenWorkspacesUpdate(message) {
         || !Number.isSafeInteger(message.navigationWorkspaceCount)
         || message.navigationWorkspaceCount < 0
         || (message.otherWindowsStatus !== 'ready'
+            && message.otherWindowsStatus !== 'connecting'
             && message.otherWindowsStatus !== 'unavailable'
             && message.otherWindowsStatus !== 'update-required')
         || typeof message.html !== 'string'

--- a/scripts/run-open-project-safety-checks.js
+++ b/scripts/run-open-project-safety-checks.js
@@ -3239,12 +3239,36 @@ function runDashboardBridgeLifecycleChecks() {
     assert.ok(dashboard.includes('openWorkspaceDashboardController = new OpenWorkspaceDashboardController({'));
     assert.ok(dashboard.includes('openWorkspaceController = new OpenWorkspaceController({'));
     assert.ok(dashboard.includes('new OpenWorkspaceBridgeClient('));
-    assert.ok(dashboard.includes("reportDiagnostic: event => logOpenWorkspaceDiagnostic('Workspace', event)"));
-    assert.ok(dashboard.includes("reportBridgeDiagnostic: event => logOpenWorkspaceDiagnostic('Bridge', event)"));
-    assert.ok(dashboard.includes('error => logOpenWorkspaceBridgeError(error)'),
+    assert.ok(dashboard.includes(
+        "reportDiagnostic: event =>\n                    dashboardDiagnostics.logOpenWorkspaceDiagnostic('Workspace', event)"
+    ), 'the bridge must report workspace diagnostics through the bounded entry');
+    assert.ok(dashboard.includes(
+        "reportBridgeDiagnostic: event =>\n                    dashboardDiagnostics.logOpenWorkspaceDiagnostic('Bridge', event)"
+    ), 'the bridge must report bridge diagnostics through the bounded entry');
+    assert.ok(dashboard.includes('onError: error => logOpenWorkspaceBridgeError(error)'),
         'the OpenWorkspaceBridgeClient error callback must use the privacy-bounded diagnostics entry');
+    // The client is deliberately created before bootstrap so its cross-host
+    // handshake overlaps the dashboard build, which means it is owned by the
+    // extension context rather than by a bootstrap generation.
+    assert.strictEqual(
+        dashboard.includes('new OpenWorkspaceBridgeClient(', dashboard.indexOf('async function initializeDashboard')),
+        false,
+        'the open-workspace bridge must be constructed before bootstrap, not inside it',
+    );
+    assert.strictEqual(
+        (dashboard.match(/new OpenWorkspaceBridgeClient\(/g) || []).length,
+        1,
+        'exactly one open-workspace bridge client may be constructed',
+    );
+    assert.ok(dashboard.includes('const earlyOpenWorkspaceBridge = new EarlyOpenWorkspaceBridge<OpenWorkspaceBridgeClient>({'));
+    assert.ok(dashboard.includes('openWorkspaceBridgeClient = earlyOpenWorkspaceBridge.adopt({'),
+        'bootstrap must adopt the pre-bootstrap bridge instead of building a second one');
+    assert.ok(dashboard.includes('resources.own({ dispose: () => earlyOpenWorkspaceBridge.release() });'),
+        'a disposed bootstrap generation must stop bridge delivery without shutting the bridge down');
+    assert.ok(dashboard.includes('void earlyOpenWorkspaceBridge.getClient().shutdown();'),
+        'the bridge must be shut down when the extension context is disposed');
     const openWorkspaceBridgeWiring = dashboard.slice(
-        dashboard.indexOf('openWorkspaceBridgeClient = ownResource(() => new OpenWorkspaceBridgeClient('),
+        dashboard.indexOf('openWorkspaceBridgeClient = earlyOpenWorkspaceBridge.adopt({'),
         dashboard.indexOf('const activeAiSessionTerminalHighlighter')
     );
     assert.strictEqual(openWorkspaceBridgeWiring.includes("logError('Open workspace bridge unavailable"), false,
@@ -3254,36 +3278,6 @@ function runDashboardBridgeLifecycleChecks() {
     assert.ok(dashboard.includes('new DashboardDiagnostics({'));
     assert.ok(!dashboard.includes('function logOpenWorkspaceDiagnostic('));
     assert.ok(dashboard.includes('openWorkspaceController.publish('));
-    const openWorkspaceBridgeOwnership = {
-        variableName: 'openWorkspaceBridgeClient',
-        factoryKind: 'new',
-        factoryName: 'OpenWorkspaceBridgeClient',
-    };
-    assert.doesNotThrow(() =>
-        assertBootstrapOwnedResource(dashboard, openWorkspaceBridgeOwnership));
-    assert.throws(
-        () => assertBootstrapOwnedResource(
-            withRenamedBootstrapFactory(
-                dashboard,
-                openWorkspaceBridgeOwnership,
-                'UnexpectedOpenWorkspaceBridgeClient',
-            ),
-            openWorkspaceBridgeOwnership,
-        ),
-        /exactly one bootstrap-owned OpenWorkspaceBridgeClient factory/,
-        'the open-workspace bridge must remain linked to its exact constructor',
-    );
-    assert.throws(
-        () => assertBootstrapOwnedResource(
-            withDuplicateBootstrapPush(
-                dashboard,
-                openWorkspaceBridgeOwnership.variableName,
-            ),
-            openWorkspaceBridgeOwnership,
-        ),
-        /openWorkspaceBridgeClient must not also be pushed directly/,
-        'the bootstrap-owned open-workspace bridge must reject duplicate context ownership',
-    );
     assert.ok(!dashboard.includes('get openProjects()'));
     assert.ok(projectedOpenWorkspaces.includes('openWorkspaceDashboardController.getCards()'));
     assert.ok(selectedProjectHandler.includes("projectId.startsWith('__openWorkspaceNavigation-')"));

--- a/scripts/run-release-packaging-checks.js
+++ b/scripts/run-release-packaging-checks.js
@@ -99,6 +99,7 @@ const EXPECTED_MAIN_ENTRIES = Object.freeze([
     'extension/media/webviewTodoScripts.js',
     'extension/out/openWorkspaces/bridgeClient.js',
     'extension/out/openWorkspaces/dashboardController.js',
+    'extension/out/openWorkspaces/earlyBridge.js',
     'extension/out/openWorkspaces/navigationController.js',
     'extension/out/openWorkspaces/navigationQuickPickController.js',
     'extension/out/openWorkspaces/pinController.js',

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -152,6 +152,8 @@ import {
 import { DashboardStartupController, settleMigration } from './dashboard/startupController';
 import { getDashboardWebviewOptions } from './dashboard/webviewOptions';
 import OpenWorkspaceBridgeClient from './openWorkspaces/bridgeClient';
+import { EarlyOpenWorkspaceBridge } from './openWorkspaces/earlyBridge';
+import { createOpenWorkspacePublication } from './openWorkspaces/projection';
 import { OpenWorkspaceDashboardController } from './openWorkspaces/dashboardController';
 import { WorkspaceNavigationController } from './openWorkspaces/navigationController';
 import {
@@ -180,6 +182,10 @@ const DASHBOARD_BOOTSTRAP_PHASE_ORDER = [
     'tmux-restore-wait',
     'startup-sequence',
 ];
+// Captured while this module is still being required, so the gap to
+// `activate()` separates our own module load from everything VS Code does
+// before calling us (notably activating the UI-host bridge dependency).
+const DASHBOARD_MODULE_LOADED_AT_MS = performance.now();
 let activeAiSessionAttentionBridgeClient: AttentionBridgeClient | null = null;
 let activeOpenWorkspaceBridgeClient: OpenWorkspaceBridgeClient | null = null;
 
@@ -246,6 +252,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     });
     dashboardDiagnostics.logDashboardDiagnostic({
         event: 'agent-pivot-activation-entered',
+        sinceModuleLoadMs: Math.max(
+            0,
+            Math.round(activationStartedAtMs - DASHBOARD_MODULE_LOADED_AT_MS),
+        ),
     });
 
     let bootstrapController: DashboardBootstrapController | undefined;
@@ -300,6 +310,44 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         }
     ));
 
+    // Created before bootstrap so its cross-host handshake round trip overlaps
+    // the local dashboard build instead of queueing behind it. The publication
+    // is derived straight from VS Code state; the accurate AI session count
+    // follows on the first real publish once hydration exists.
+    const earlyOpenWorkspaceBridge = new EarlyOpenWorkspaceBridge<OpenWorkspaceBridgeClient>({
+        createClient: handlers => new OpenWorkspaceBridgeClient(
+            createOpenWorkspacePublication(
+                new WorkspaceContextResolver().resolve({
+                    workspaceFile: vscode.workspace.workspaceFile,
+                    workspaceFolders: vscode.workspace.workspaceFolders,
+                    workspaceName: vscode.workspace.name,
+                    remoteName: vscode.env.remoteName,
+                }),
+                0,
+            ),
+            handlers.onAggregate,
+            handlers.onError,
+            {
+                reportDiagnostic: event =>
+                    dashboardDiagnostics.logOpenWorkspaceDiagnostic('Workspace', event),
+                reportBridgeDiagnostic: event =>
+                    dashboardDiagnostics.logOpenWorkspaceDiagnostic('Bridge', event),
+                onStatusChange: handlers.onStatusChange,
+                onPinSnapshot: handlers.onPinSnapshot,
+            },
+        ),
+        logError: (message, error) => dashboardDiagnostics.logError(message, error),
+    });
+    activeOpenWorkspaceBridgeClient = earlyOpenWorkspaceBridge.getClient();
+    context.subscriptions.push({
+        dispose: () => {
+            if (activeOpenWorkspaceBridgeClient === earlyOpenWorkspaceBridge.getClient()) {
+                activeOpenWorkspaceBridgeClient = null;
+            }
+            void earlyOpenWorkspaceBridge.getClient().shutdown();
+        },
+    });
+
     const dashboardCommandRegistration =
         new DashboardCommandRegistration<vscode.Disposable>({
             registerCommand: (command, callback) =>
@@ -325,6 +373,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
                     generation,
                     dashboardCommandRegistration,
                     conversationPanelRestore,
+                    earlyOpenWorkspaceBridge,
                 );
                 return options;
             } catch (error) {
@@ -365,6 +414,7 @@ async function initializeDashboard(
     bootstrapGeneration: number,
     dashboardCommandRegistration: DashboardCommandRegistration<vscode.Disposable>,
     conversationPanelRestore: ConversationPanelRestoreCoordinator,
+    earlyOpenWorkspaceBridge: EarlyOpenWorkspaceBridge<OpenWorkspaceBridgeClient>,
 ): Promise<AgentPivotViewProviderOptions> {
     const ownResource = <T extends { dispose(): unknown }>(factory: () => T): T => {
         let resource: T | undefined;
@@ -1640,38 +1690,30 @@ async function initializeDashboard(
         open: cardId => workspaceNavigationController.open(cardId),
         showInformationMessage: message => vscode.window.showInformationMessage(message),
     });
-    openWorkspaceBridgeClient = ownResource(() => new OpenWorkspaceBridgeClient(
-        openWorkspaceController.getPublication(),
-        aggregate => {
+    openWorkspaceBridgeClient = earlyOpenWorkspaceBridge.adopt({
+        onAggregate: aggregate => {
             const statusChanged = openWorkspaceDashboardController.setBridgeStatus('ready');
             if (openWorkspaceDashboardController.setAggregate(aggregate) || statusChanged) {
                 postOpenWorkspacesUpdated();
             }
         },
-        error => logOpenWorkspaceBridgeError(error),
-        {
-            reportDiagnostic: event => logOpenWorkspaceDiagnostic('Workspace', event),
-            reportBridgeDiagnostic: event => logOpenWorkspaceDiagnostic('Bridge', event),
-            onStatusChange: status => {
-                if (openWorkspaceDashboardController.setBridgeStatus(status)) {
-                    postOpenWorkspacesUpdated();
-                }
-            },
-            onPinSnapshot: snapshot => {
-                if (openWorkspaceDashboardController.setPinSnapshot(snapshot)) {
-                    postOpenWorkspacesUpdated();
-                }
-            },
-        }
-    ));
-    resources.own({
-        dispose: () => {
-            if (activeOpenWorkspaceBridgeClient === openWorkspaceBridgeClient) {
-                activeOpenWorkspaceBridgeClient = null;
+        onError: error => logOpenWorkspaceBridgeError(error),
+        onStatusChange: status => {
+            if (openWorkspaceDashboardController.setBridgeStatus(status)) {
+                postOpenWorkspacesUpdated();
+            }
+        },
+        onPinSnapshot: snapshot => {
+            if (openWorkspaceDashboardController.setPinSnapshot(snapshot)) {
+                postOpenWorkspacesUpdated();
             }
         },
     });
-    activeOpenWorkspaceBridgeClient = openWorkspaceBridgeClient;
+    // The client outlives this generation, so a disposed bootstrap only stops
+    // delivery to these handlers; it must not shut the bridge down.
+    resources.own({ dispose: () => earlyOpenWorkspaceBridge.release() });
+    // The publication built before bootstrap carried no AI session count.
+    openWorkspaceController.publish();
     openWorkspacePinController = new OpenWorkspacePinController({
         getNavigationIdentity: cardId =>
             openWorkspaceDashboardController.getPinNavigationIdentity(cardId),

--- a/src/dashboard/messageHandlers.ts
+++ b/src/dashboard/messageHandlers.ts
@@ -214,6 +214,7 @@ export function createDashboardMessageHandlers(
                     : -1,
                 hasOtherWindowsGroup: e.hasOtherWindowsGroup === true,
                 otherWindowsStatus: e.otherWindowsStatus === 'ready'
+                    || e.otherWindowsStatus === 'connecting'
                     || e.otherWindowsStatus === 'unavailable'
                     || e.otherWindowsStatus === 'update-required'
                     ? e.otherWindowsStatus as string

--- a/src/openWorkspaces/bridgeClient.ts
+++ b/src/openWorkspaces/bridgeClient.ts
@@ -29,7 +29,17 @@ export const OPEN_WORKSPACE_HANDSHAKE_COMMAND = '_agentPivotOpenWorkspaces.bridg
 export const OPEN_WORKSPACE_AGGREGATE_COMMAND = '_agentPivotOpenWorkspaces.workspace.aggregate';
 export const OPEN_WORKSPACE_DIAGNOSTIC_COMMAND = '_agentPivotOpenWorkspaces.workspace.diagnostic';
 
-export type OpenWorkspaceBridgeStatus = 'ready' | 'unavailable' | 'update-required';
+/**
+ * `connecting` is the pre-handshake state. It exists so the Open Windows
+ * section can say it is still looking instead of rendering an empty list that
+ * looks settled: the handshake alone takes 0.36-3.2s on a remote host, and the
+ * first aggregate another 0.3-2.6s after that.
+ */
+export type OpenWorkspaceBridgeStatus =
+    | 'connecting'
+    | 'ready'
+    | 'unavailable'
+    | 'update-required';
 
 const RETRY_DELAYS_MS = [100, 500, 2_000, 10_000, 30_000];
 const MAX_FORWARDED_DIAGNOSTIC_BYTES = 64 * 1024;

--- a/src/openWorkspaces/dashboardController.ts
+++ b/src/openWorkspaces/dashboardController.ts
@@ -53,7 +53,7 @@ export interface OpenWorkspaceDashboardControllerOptions {
 export class OpenWorkspaceDashboardController {
     private aggregate: OpenWorkspaceAggregate | null = null;
     private pinSnapshot: OpenWorkspacePinSnapshot = createOpenWorkspacePinSnapshot([]);
-    private bridgeStatus: OpenWorkspaceBridgeStatus = 'ready';
+    private bridgeStatus: OpenWorkspaceBridgeStatus = 'connecting';
     private navigationWorkspacesById = new Map<string, OpenWorkspaceRecord>();
     private pinNavigationIdentityById = new Map<string, string>();
     private lastPostedSemanticRevision: string | null = null;

--- a/src/openWorkspaces/earlyBridge.ts
+++ b/src/openWorkspaces/earlyBridge.ts
@@ -1,0 +1,129 @@
+'use strict';
+
+import type { OpenWorkspaceAggregate } from './protocol';
+import type { OpenWorkspaceBridgeStatus } from './bridgeClient';
+import type { OpenWorkspacePinSnapshot } from './pinProtocol';
+
+export interface OpenWorkspaceBridgeHandlers {
+    onAggregate: (aggregate: OpenWorkspaceAggregate) => unknown;
+    onStatusChange: (status: OpenWorkspaceBridgeStatus) => void;
+    onPinSnapshot: (snapshot: OpenWorkspacePinSnapshot) => unknown;
+    onError: (error: unknown) => void;
+}
+
+export interface EarlyOpenWorkspaceBridgeOptions<TClient> {
+    createClient: (handlers: OpenWorkspaceBridgeHandlers) => TClient;
+    logError: (message: string, error: unknown) => void;
+}
+
+/**
+ * Owns the Open Windows bridge client across bootstrap generations so its
+ * cross-host handshake can start immediately instead of after the dashboard is
+ * built.
+ *
+ * The handshake is a round trip to the UI host and measured 0.6-1.3s, but the
+ * client used to be constructed 590-1055ms into bootstrap, so that round trip
+ * ran strictly after all local work rather than alongside it. Creating the
+ * client first means aggregates can arrive before the dashboard controller
+ * exists, so state that lands early is buffered (latest wins, since every one
+ * of these values is a snapshot) and replayed on adoption.
+ *
+ * The client also outlives a bootstrap generation. Re-adopting after a retry
+ * reuses it rather than registering its commands a second time, which would
+ * throw.
+ */
+export class EarlyOpenWorkspaceBridge<TClient> {
+    private readonly client: TClient;
+    private handlers: OpenWorkspaceBridgeHandlers | null = null;
+    private pendingAggregate: OpenWorkspaceAggregate | null = null;
+    private pendingStatus: OpenWorkspaceBridgeStatus | null = null;
+    private pendingPinSnapshot: OpenWorkspacePinSnapshot | null = null;
+
+    constructor(private readonly options: EarlyOpenWorkspaceBridgeOptions<TClient>) {
+        this.client = options.createClient({
+            onAggregate: aggregate => this.deliver(
+                'aggregate',
+                handlers => handlers.onAggregate(aggregate),
+                () => { this.pendingAggregate = aggregate; },
+            ),
+            onStatusChange: status => this.deliver(
+                'status',
+                handlers => handlers.onStatusChange(status),
+                () => { this.pendingStatus = status; },
+            ),
+            onPinSnapshot: snapshot => this.deliver(
+                'pin snapshot',
+                handlers => handlers.onPinSnapshot(snapshot),
+                () => { this.pendingPinSnapshot = snapshot; },
+            ),
+            // Errors are diagnostics about a moment that has passed. Replaying
+            // them later would report a stale outage as a fresh one.
+            onError: error => this.deliver(
+                'error',
+                handlers => handlers.onError(error),
+                () => this.options.logError(
+                    'Agent Pivot open workspace bridge failed before adoption.',
+                    error,
+                ),
+            ),
+        });
+    }
+
+    getClient(): TClient {
+        return this.client;
+    }
+
+    adopt(handlers: OpenWorkspaceBridgeHandlers): TClient {
+        this.handlers = handlers;
+        const status = this.pendingStatus;
+        const pinSnapshot = this.pendingPinSnapshot;
+        const aggregate = this.pendingAggregate;
+        this.pendingStatus = null;
+        this.pendingPinSnapshot = null;
+        this.pendingAggregate = null;
+        // Status first so the section stops claiming it is still connecting,
+        // then the pin snapshot the aggregate's cards are rendered against.
+        if (status !== null) {
+            this.replay('status', () => handlers.onStatusChange(status));
+        }
+        if (pinSnapshot !== null) {
+            this.replay('pin snapshot', () => handlers.onPinSnapshot(pinSnapshot));
+        }
+        if (aggregate !== null) {
+            this.replay('aggregate', () => handlers.onAggregate(aggregate));
+        }
+        return this.client;
+    }
+
+    /** Returns to buffering when a bootstrap generation is disposed. */
+    release(): void {
+        this.handlers = null;
+    }
+
+    private deliver(
+        kind: string,
+        toHandlers: (handlers: OpenWorkspaceBridgeHandlers) => unknown,
+        buffer: () => void,
+    ): void {
+        const handlers = this.handlers;
+        if (!handlers) {
+            buffer();
+            return;
+        }
+        this.replay(kind, () => toHandlers(handlers));
+    }
+
+    private replay(kind: string, run: () => unknown): void {
+        try {
+            run();
+        } catch (error) {
+            // A failed hand-off must not propagate into the bridge client's
+            // delivery acknowledgement, and must not re-buffer: the handlers
+            // already own this value and would receive it twice on retry.
+            this.options.logError(
+                `Agent Pivot open workspace bridge ${kind} handling failed.`,
+                error,
+            );
+        }
+    }
+}

--- a/src/webview/webviewContent.ts
+++ b/src/webview/webviewContent.ts
@@ -302,8 +302,16 @@ export function getOpenWorkspacesGroupContent(
             ? `<div class="open-other-windows-state" role="status">
                 <p>Open-window discovery is temporarily unavailable. Agent Pivot will retry automatically.</p>
             </div>`
-            : '';
-    const otherWindowsCollapsed = otherWindowsStatus === 'ready' && collapsed;
+            : otherWindowsStatus === 'connecting'
+                ? `<div class="open-other-windows-state" role="status" data-other-windows-connecting>
+                    <p>Looking for your other open windows…</p>
+                </div>`
+                : '';
+    // A bridge that never connected must stay visible so its state can be read,
+    // but connecting is a normal startup step and must not fight the user's
+    // collapse preference only to snap shut a few seconds later.
+    const otherWindowsCollapsed = (otherWindowsStatus === 'ready'
+        || otherWindowsStatus === 'connecting') && collapsed;
     return `${currentSection}
 <div class="group steward-section open-other-windows-group ${otherWindowsCollapsed ? 'collapsed' : ''}" data-group-id="${OPEN_WORKSPACES_GROUP_ID}" data-virtual-group data-system-group="${OPEN_WORKSPACES_GROUP_ID}" data-other-windows-status="${otherWindowsStatus}">
     <div class="group-title steward-section-header steward-group-header">
@@ -311,7 +319,7 @@ export function getOpenWorkspacesGroupContent(
             <span class="collapse-icon" title="Open/Collapse Group">${Icons.collapse}</span>
             ${OPEN_WINDOWS_GROUP_NAME}
         </span>
-        <span class="group-title-badge">${otherWindowsStatus === 'update-required' ? 'Update required' : otherWindowsStatus === 'unavailable' ? 'Unavailable' : 'Live'}</span>
+        <span class="group-title-badge">${otherWindowsStatus === 'update-required' ? 'Update required' : otherWindowsStatus === 'unavailable' ? 'Unavailable' : otherWindowsStatus === 'connecting' ? 'Connecting…' : 'Live'}</span>
     </div>
     <div class="group-list">
         <div class="open-workspace-pin-live-region" data-open-workspace-pin-live-region role="status" aria-live="polite" aria-atomic="true"></div>

--- a/src/webview/webviewWorkspaceUpdateScripts.js
+++ b/src/webview/webviewWorkspaceUpdateScripts.js
@@ -202,6 +202,7 @@ function applyOpenWorkspacesUpdate(message) {
         || !Number.isSafeInteger(message.navigationWorkspaceCount)
         || message.navigationWorkspaceCount < 0
         || (message.otherWindowsStatus !== 'ready'
+            && message.otherWindowsStatus !== 'connecting'
             && message.otherWindowsStatus !== 'unavailable'
             && message.otherWindowsStatus !== 'update-required')
         || typeof message.html !== 'string'

--- a/tests/contract/aiSessions/runtimeComposition.test.js
+++ b/tests/contract/aiSessions/runtimeComposition.test.js
@@ -189,6 +189,11 @@ test('WEBVIEW-TWO-STAGE-STARTUP-001 production startup diagnostics preserve exac
             }
             normalized = { ...normalized, phases: '<phases>' };
         }
+        if (Object.hasOwn(normalized, 'sinceModuleLoadMs')) {
+            assert.equal(Number.isFinite(normalized.sinceModuleLoadMs), true);
+            assert.ok(normalized.sinceModuleLoadMs >= 0);
+            normalized = { ...normalized, sinceModuleLoadMs: '<sinceModuleLoadMs>' };
+        }
         if (!Object.hasOwn(normalized, 'durationMs')) {
             return normalized;
         }
@@ -199,6 +204,7 @@ test('WEBVIEW-TWO-STAGE-STARTUP-001 production startup diagnostics preserve exac
     assert.deepEqual(normalizedDiagnostics, [
         {
             event: 'agent-pivot-activation-entered',
+            sinceModuleLoadMs: '<sinceModuleLoadMs>',
         },
         {
             event: 'agent-pivot-boot-shell-assigned',

--- a/tests/contract/openProjects/dashboardConnectingStatus.test.js
+++ b/tests/contract/openProjects/dashboardConnectingStatus.test.js
@@ -1,0 +1,68 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {
+    createOpenWorkspacePinSnapshot,
+} = require('../../../out/openWorkspaces/pinProtocol');
+const { loadWithFakeVscode, makeAggregate, makeRecord, makeRegistration, OTHER } = require('./helpers');
+const {
+    OpenWorkspaceDashboardController,
+} = loadWithFakeVscode('../../../out/openWorkspaces/dashboardController');
+
+function createController(overrides = {}) {
+    const currentWorkspace = makeRecord({ name: 'Current', uri: '/work/current' });
+    return new OpenWorkspaceDashboardController({
+        getCurrentWorkspace: () => ({
+            ...currentWorkspace,
+            roots: currentWorkspace.roots.map(root => ({ ...root, hostPath: '/work/current' })),
+        }),
+        isWorkspaceSavedAsProject: () => true,
+        getWorkspaceProjectColor: () => '',
+        getCurrentWorkspaceAiSessions: () => null,
+        getGroups: () => [],
+        getTodoSearchItems: () => [],
+        getCollapsed: () => false,
+        getRunningCardAnimation: () => undefined,
+        getRunningIconAnimation: () => undefined,
+        getAttentionAggregate: () => null,
+        getBridgeInstanceId: () => 'instance',
+        nextSequence: () => 1,
+        postMessage: async () => true,
+        isVisible: () => true,
+        logDiagnostic: () => undefined,
+        logError: () => undefined,
+        ...overrides,
+    });
+}
+
+test('OPEN-DASHBOARD-BRIDGE-LIFECYCLE-001 starts connecting so the section is never a complete-looking empty list', () => {
+    const controller = createController();
+
+    assert.equal(controller.getState().otherWindows.status, 'connecting');
+});
+
+test('OPEN-DASHBOARD-BRIDGE-LIFECYCLE-001 leaves connecting for the first bridge status', () => {
+    const controller = createController();
+
+    assert.equal(controller.setBridgeStatus('ready'), true);
+    assert.equal(controller.getState().otherWindows.status, 'ready');
+});
+
+test('OPEN-DASHBOARD-BRIDGE-LIFECYCLE-001 reports an unavailable bridge instead of staying connecting', () => {
+    const controller = createController();
+
+    assert.equal(controller.setBridgeStatus('unavailable'), true);
+    assert.equal(controller.getState().otherWindows.status, 'unavailable');
+});
+
+test('OPEN-DASHBOARD-BRIDGE-LIFECYCLE-001 discards a connecting-era aggregate when the bridge turns unavailable', () => {
+    const controller = createController();
+    controller.setBridgeStatus('ready');
+    controller.setAggregate(makeAggregate([makeRegistration(OTHER, 4000, '/work/other')]));
+    controller.setPinSnapshot(createOpenWorkspacePinSnapshot([]));
+    assert.ok(controller.getCards().some(card => card.kind === 'navigation'));
+
+    assert.equal(controller.setBridgeStatus('unavailable'), true);
+    assert.equal(controller.getCards().filter(card => card.kind === 'navigation').length, 0);
+});

--- a/tests/contract/openProjects/earlyBridge.test.js
+++ b/tests/contract/openProjects/earlyBridge.test.js
@@ -1,0 +1,127 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {
+    EarlyOpenWorkspaceBridge,
+} = require('../../../out/openWorkspaces/earlyBridge');
+
+function makeBridge() {
+    const created = [];
+    const bridge = new EarlyOpenWorkspaceBridge({
+        createClient: handlers => {
+            const client = { handlers, id: created.length + 1 };
+            created.push(client);
+            return client;
+        },
+        logError: () => undefined,
+    });
+    return { bridge, created };
+}
+
+function makeHandlers(log) {
+    return {
+        onAggregate: aggregate => log.push(['aggregate', aggregate]),
+        onStatusChange: status => log.push(['status', status]),
+        onPinSnapshot: snapshot => log.push(['pin', snapshot]),
+        onError: error => log.push(['error', error]),
+    };
+}
+
+test('OPEN-DASHBOARD-BRIDGE-LIFECYCLE-001 creates the client once so the handshake starts before bootstrap', () => {
+    const { bridge, created } = makeBridge();
+
+    assert.equal(created.length, 1);
+    assert.equal(bridge.getClient(), created[0]);
+});
+
+test('OPEN-DASHBOARD-BRIDGE-LIFECYCLE-001 replays the latest pre-adoption state exactly once', () => {
+    const { bridge, created } = makeBridge();
+    const log = [];
+    created[0].handlers.onStatusChange('unavailable');
+    created[0].handlers.onPinSnapshot({ revision: 1 });
+    created[0].handlers.onAggregate({ semanticRevision: 'a' });
+    created[0].handlers.onStatusChange('ready');
+    created[0].handlers.onAggregate({ semanticRevision: 'b' });
+    assert.deepEqual(log, []);
+
+    bridge.adopt(makeHandlers(log));
+
+    assert.deepEqual(log, [
+        ['status', 'ready'],
+        ['pin', { revision: 1 }],
+        ['aggregate', { semanticRevision: 'b' }],
+    ]);
+});
+
+test('OPEN-DASHBOARD-BRIDGE-LIFECYCLE-001 forwards live callbacks straight to the adopted handlers', () => {
+    const { bridge, created } = makeBridge();
+    const log = [];
+    bridge.adopt(makeHandlers(log));
+
+    created[0].handlers.onAggregate({ semanticRevision: 'c' });
+    created[0].handlers.onStatusChange('ready');
+
+    assert.deepEqual(log, [
+        ['aggregate', { semanticRevision: 'c' }],
+        ['status', 'ready'],
+    ]);
+});
+
+test('OPEN-DASHBOARD-BRIDGE-LIFECYCLE-001 keeps the same client and re-buffers after a bootstrap generation is released', () => {
+    const { bridge, created } = makeBridge();
+    const first = [];
+    bridge.adopt(makeHandlers(first));
+    bridge.release();
+
+    created[0].handlers.onAggregate({ semanticRevision: 'd' });
+    assert.deepEqual(first, []);
+
+    const second = [];
+    bridge.adopt(makeHandlers(second));
+
+    assert.equal(created.length, 1, 'a retry must not register a second bridge client');
+    assert.deepEqual(second, [['aggregate', { semanticRevision: 'd' }]]);
+});
+
+test('OPEN-DASHBOARD-BRIDGE-LIFECYCLE-001 does not replay state the adopted handlers already saw', () => {
+    const { bridge, created } = makeBridge();
+    const log = [];
+    created[0].handlers.onAggregate({ semanticRevision: 'e' });
+    bridge.adopt(makeHandlers(log));
+    bridge.release();
+
+    const second = [];
+    bridge.adopt(makeHandlers(second));
+
+    assert.deepEqual(log, [['aggregate', { semanticRevision: 'e' }]]);
+    assert.deepEqual(second, [], 'nothing new arrived while released');
+});
+
+test('OPEN-DASHBOARD-BRIDGE-LIFECYCLE-001 keeps buffering when an adopted handler throws', () => {
+    const { bridge, created } = makeBridge();
+    bridge.adopt({
+        onAggregate: () => { throw new Error('handler exploded'); },
+        onStatusChange: () => undefined,
+        onPinSnapshot: () => undefined,
+        onError: () => undefined,
+    });
+
+    assert.doesNotThrow(() => created[0].handlers.onAggregate({ semanticRevision: 'f' }));
+
+    const log = [];
+    bridge.release();
+    bridge.adopt(makeHandlers(log));
+    assert.deepEqual(log, [], 'a delivered-then-failed aggregate is not silently replayed');
+});
+
+test('OPEN-DASHBOARD-BRIDGE-LIFECYCLE-001 reports pre-adoption errors without losing them', () => {
+    const { bridge, created } = makeBridge();
+    const failure = new Error('bridge unreachable');
+
+    assert.doesNotThrow(() => created[0].handlers.onError(failure));
+
+    const log = [];
+    bridge.adopt(makeHandlers(log));
+    assert.deepEqual(log, [], 'errors are logged as they happen, never replayed as new failures');
+});

--- a/tests/integration/dashboard/openWorkspacesConnecting.test.js
+++ b/tests/integration/dashboard/openWorkspacesConnecting.test.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const Module = require('node:module');
+const test = require('node:test');
+const { createFakeVscode } = require('../../helpers/fakeVscode');
+
+function loadWebviewContent() {
+    const vscode = createFakeVscode({});
+    vscode.Uri = {
+        file: value => ({ fsPath: value, path: value, toString: () => `file://${value}` }),
+    };
+    const previousLoad = Module._load;
+    try {
+        Module._load = function (request, parent, isMain) {
+            if (request === 'vscode') return vscode;
+            return previousLoad.call(this, request, parent, isMain);
+        };
+        delete require.cache[require.resolve('../../../out/webview/webviewContent')];
+        return require('../../../out/webview/webviewContent');
+    } finally {
+        Module._load = previousLoad;
+    }
+}
+
+const { getOpenWorkspacesGroupContent } = loadWebviewContent();
+
+function render(status, collapsed = false) {
+    const html = getOpenWorkspacesGroupContent([], collapsed, status);
+    const start = html.indexOf('<div class="group steward-section open-other-windows-group');
+    assert.ok(start >= 0, 'the other-windows group must be rendered');
+    // The CURRENT WINDOW section carries its own "Live" badge, so every badge
+    // assertion has to be scoped to the other-windows group.
+    return html.slice(start);
+}
+
+test('OPEN-DASHBOARD-BRIDGE-LIFECYCLE-001 marks the section as connecting instead of claiming a live empty list', () => {
+    const html = render('connecting');
+
+    assert.match(html, /data-other-windows-status="connecting"/);
+    assert.doesNotMatch(html, /<span class="group-title-badge">Live<\/span>/);
+});
+
+test('OPEN-DASHBOARD-BRIDGE-LIFECYCLE-001 shows a connecting surface while the bridge handshake is in flight', () => {
+    const html = render('connecting');
+
+    assert.match(html, /class="open-other-windows-state"/);
+    assert.match(html, /data-other-windows-connecting/);
+});
+
+test('OPEN-DASHBOARD-BRIDGE-LIFECYCLE-001 keeps the collapsed preference while connecting', () => {
+    assert.match(render('connecting', true), /open-other-windows-group collapsed/);
+    assert.match(render('ready', true), /open-other-windows-group collapsed/);
+});
+
+test('OPEN-DASHBOARD-BRIDGE-LIFECYCLE-001 still forces the section open for a broken bridge', () => {
+    assert.doesNotMatch(render('unavailable', true), /open-other-windows-group collapsed/);
+    assert.doesNotMatch(render('update-required', true), /open-other-windows-group collapsed/);
+});
+
+test('OPEN-DASHBOARD-BRIDGE-LIFECYCLE-001 leaves the settled statuses unchanged', () => {
+    assert.match(render('ready'), /<span class="group-title-badge">Live<\/span>/);
+    assert.match(render('unavailable'), /<span class="group-title-badge">Unavailable<\/span>/);
+    assert.match(render('update-required'), /<span class="group-title-badge">Update required<\/span>/);
+    assert.doesNotMatch(render('ready'), /class="open-other-windows-state"/);
+});


### PR DESCRIPTION
## Summary

Two measured startup latency fixes for the sidebar, plus the disproof of a third hypothesis so nobody retries it.

- **Start the Open Windows bridge handshake before bootstrap.** The bridge client was constructed 590-1055ms into bootstrap, and its constructor is what kicks off the handshake — a cross-host round trip to the UI extension host. That round trip therefore ran strictly *after* all local dashboard construction instead of alongside it. The client is now created at the top of `activate()` from a publication derived straight from VS Code state; aggregates, status and pin snapshots arriving before the dashboard controller exists are buffered latest-wins and replayed on adoption. The client outlives a bootstrap generation, so a retry re-adopts it instead of registering its commands twice.
- **Show Open Windows as `connecting` before the bridge answers.** `bridgeStatus` started at `ready`, so for seconds after every reload the section rendered a settled-looking "Live" empty list while the window data was still in flight. `unavailable` and `update-required` still force the section open; `connecting` respects an existing collapse preference rather than snapping shut a few seconds later.
- **Instrument `sinceModuleLoadMs`** on `activation-entered`, splitting the previously unattributed gap between activation dispatch and `activate()`.

## Measured effect

Production telemetry from the Agent Pivot output channel, 8 reloads on the new build vs 31 on the old, medians:

| | old (n=31) | new (n=8) | delta |
|---|---|---|---|
| bridge client created | 806ms | **4ms** | −802ms |
| handshake completed | 1789ms | 1204ms | −585ms |
| **first aggregate** | 2974ms | **2227ms** | **−747ms** |
| bootstrap ready (control) | 1039ms | 1069ms | +30ms (noise) |

The Open Windows section now fills in ~0.75s earlier, and `ready` is unchanged, so the gain is not paid for elsewhere.

Note the round trip itself got *slower* when started earlier (600-1300ms → 900-2027ms), which means a large part of the handshake is gated on UI-host readiness rather than transport. Starting earlier is now exhausted as a lever: the client is created at +4ms.

`sinceModuleLoadMs` measures 315-791ms — the gap between our module body finishing and VS Code calling `activate()`. That is extension-host contention, not our `require`, so shrinking the bundle or lazy-requiring cold paths is not a promising lever either.

## Disproved hypothesis (recorded so it is not retried)

An earlier revision of this branch added a bounded gate that held bootstrap until the two-stage boot skeleton was painted, on the hypothesis that `resolveWebviewView` was starved by our uninterrupted microtask drain (shell delay correlated with bootstrap duration at r=0.987 over 39 reloads). Production disproved it: the gate reported `painted=false` on 2/2 reloads, with the view resolve arriving up to 746ms *after* the 250ms budget expired, and `browser-first-paint` still absent. The view resolve is delivered on VS Code's own schedule; the correlation came from both timings sharing extension-host contention as a cause. The gate was reverted — it only added 250ms.

## Skill harvest

no skill change — all three lessons were compliance gaps against rules the existing skills already state, not missing guidance:

1. A `git rebase` ran against the primary checkout because the shell cwd had reset; `protecting-main-with-worktrees` already requires `git -C <worktree>`. No changes were made (the user's dirty files aborted it) and the primary checkout was verified unchanged.
2. A harness contract pass was reported as end-to-end proof that the paint gate worked in production; `fixing-regressions-with-ci` already stops on "a fake covers enough of a real environment". Production telemetry later disproved the claim.
3. The capability manifest was hand-edited, which is exactly why the rebase left stale commit hashes; `fixing-regressions-with-ci` already requires `regenerate-capability-audit.js`, which was used for the final audit commit.

## Verification

- `npm run test:ci:linux` — exit 0
  - deterministic: 612 unit / 719 contract / 336 integration
  - browser: 137
  - behavior contracts, safety, architecture, release packaging: passed
  - changed-line coverage: 100.00% (153/153) against `origin/main`
- rebased onto `origin/main` (`2344b9f`, includes #150) and re-run after the rebase
- built and installed locally via `npm run install-local` with VSIX-to-installed byte verification; the measurements above come from that installed build
