### PR TITLE
Keep src/dashboard.ts inside the coverage report

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -3591,6 +3591,20 @@
     ]
   },
   {
+    "id": "COVERAGE-BASELINE-INSTRUMENTATION-001",
+    "domain": "architecture",
+    "title": "Files reachable only through a subprocess harness stay inside the coverage report",
+    "priority": "P1",
+    "status": "automated",
+    "owners": [
+      "tests/unit/tooling/coverageBaseline.test.js"
+    ],
+    "evidence": [
+      "scripts/check-coverage-baseline.js",
+      "tests/contract/aiSessions/runtimeComposition.test.js"
+    ]
+  },
+  {
     "id": "COVERAGE-CHANGED-CODE-001",
     "domain": "architecture",
     "title": "Pull requests keep instrumented changed executable lines at or above the reviewed coverage threshold",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "cc80a21cd6af2a684b60369cc3195bd3d9bf5f49",
+        "head": "94c139ff153d9c39e809814de35605d62b44e363",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -166,7 +166,8 @@
             "cfa1d431d17fe5b334f34a7f220b8c905d2883de",
             "67e5c350a0c48974fb444a821143971bcc99e8d5",
             "13ea7824781c9eeaff4b08ee59e26cd86e9ac835",
-            "988f8a1edfaeb211f39a2567d5faa698642ebe7f"
+            "988f8a1edfaeb211f39a2567d5faa698642ebe7f",
+            "1ba1462088a1c347854f49d6abb8406816a7b6c7"
         ]
     },
     "capabilities": [
@@ -958,7 +959,8 @@
                 "d686c611197886d76ef92f9595fd2a134930d01c",
                 "fa980dcae7aaf4187dde798fffe7c19b2a4d31a1",
                 "98b73a4dc087b0c0a71554036bb988b00226abe6",
-                "6f22284edc8b8e3b4e71dcf8abb5b46569164abc"
+                "6f22284edc8b8e3b4e71dcf8abb5b46569164abc",
+                "94c139ff153d9c39e809814de35605d62b44e363"
             ],
             "behaviors": [
                 "RUNTIME-BOOTSTRAP-TMUX-RESTORE-DEFERRAL-001",

--- a/scripts/check-coverage-baseline.js
+++ b/scripts/check-coverage-baseline.js
@@ -6,6 +6,18 @@ const { writeJsonFileAtomically } = require('./lib/jsonFile');
 
 const COVERAGE_METRICS = ['lines', 'branches', 'functions', 'statements'];
 
+// Files that are only reachable through a subprocess harness, and therefore
+// drop out of the report silently the moment that subprocess stops inheriting
+// NODE_V8_COVERAGE. A percentage baseline cannot catch that: removing a file
+// from the denominator usually makes the totals look better.
+const REQUIRED_INSTRUMENTED_FILES = ['src/dashboard.ts'];
+
+function findUninstrumentedFiles(summary, requiredFiles = REQUIRED_INSTRUMENTED_FILES) {
+    const measured = Object.keys(summary || {}).filter(key => key !== 'total');
+    return requiredFiles.filter(required =>
+        !measured.some(key => key === required || key.endsWith(`/${required}`)));
+}
+
 function roundPercentage(value) {
     return Math.round((value + Number.EPSILON) * 100) / 100;
 }
@@ -57,6 +69,21 @@ function writeCoverageBaseline(baselinePath, current, fileSystem = fs) {
     writeJsonFileAtomically(baselinePath, current, fileSystem);
 }
 
+/**
+ * Returns the failure lines for a coverage run, empty when it passes.
+ *
+ * Kept separate from `main` so every branch is reachable from unit tests
+ * without a real repository layout on disk.
+ */
+function collectCoverageFailures(summary, baseline) {
+    const uninstrumented = findUninstrumentedFiles(summary);
+    if (uninstrumented.length > 0) {
+        return uninstrumented.map(file =>
+            `${file} is missing from the coverage report; its executing process must inherit NODE_V8_COVERAGE`);
+    }
+    return compareCoverageBaseline(baseline, readCoverageTotals(summary));
+}
+
 function main() {
     const root = path.resolve(__dirname, '..');
     const baselinePath = path.join(root, '.ci', 'coverage-baseline.json');
@@ -67,18 +94,18 @@ function main() {
     }
 
     const summaryPath = path.join(root, 'coverage', 'coverage-summary.json');
-    const current = readCoverageTotals(JSON.parse(fs.readFileSync(summaryPath, 'utf8')));
+    const summary = JSON.parse(fs.readFileSync(summaryPath, 'utf8'));
 
     if (isWriteBaseline) {
-        writeCoverageBaseline(baselinePath, current);
+        writeCoverageBaseline(baselinePath, readCoverageTotals(summary));
         return;
     }
 
     const baseline = validateCoverageBaseline(JSON.parse(fs.readFileSync(baselinePath, 'utf8')));
-    const decreases = compareCoverageBaseline(baseline, current);
-    if (decreases.length > 0) {
-        for (const decrease of decreases) {
-            console.error(decrease);
+    const failures = collectCoverageFailures(summary, baseline);
+    if (failures.length > 0) {
+        for (const failure of failures) {
+            console.error(failure);
         }
         process.exitCode = 1;
         return;
@@ -96,8 +123,11 @@ if (require.main === module) {
 }
 
 module.exports = {
+    collectCoverageFailures,
     compareCoverageBaseline,
+    findUninstrumentedFiles,
     readCoverageTotals,
+    REQUIRED_INSTRUMENTED_FILES,
     validateCoverageBaseline,
     writeCoverageBaseline,
 };

--- a/tests/contract/aiSessions/runtimeComposition.test.js
+++ b/tests/contract/aiSessions/runtimeComposition.test.js
@@ -100,11 +100,14 @@ async function restoreRuntimeHost(composition, terminals, createHydration) {
 }
 
 function runProductionActivation(mode) {
-    const environment = { ...process.env, NODE_V8_COVERAGE: '' };
+    // NODE_V8_COVERAGE is inherited on purpose. This harness is the only thing
+    // that executes src/dashboard.ts, so clearing it (as the tmux smoke harness
+    // deliberately does, to keep instrumentation out of a real-tmux run) made
+    // the largest file in the extension invisible to c8 entirely.
     const result = spawnSync(process.execPath, [
         path.resolve(__dirname, '../../fixtures/aiSessions/runtimeHostActivationHarness.js'),
         mode,
-    ], { encoding: 'utf8', env: environment });
+    ], { encoding: 'utf8', env: process.env });
     assert.equal(result.status, 0, result.stderr || result.stdout);
     return JSON.parse(result.stdout);
 }

--- a/tests/unit/tooling/coverageBaseline.test.js
+++ b/tests/unit/tooling/coverageBaseline.test.js
@@ -11,6 +11,9 @@ const {
     readCoverageTotals,
     validateCoverageBaseline,
     writeCoverageBaseline,
+    collectCoverageFailures,
+    findUninstrumentedFiles,
+    REQUIRED_INSTRUMENTED_FILES,
 } = require(checkerPath);
 
 function coverageSummary(metrics) {
@@ -123,4 +126,67 @@ test('COVERAGE-BASELINE-009 prevents CI from writing a coverage baseline', () =>
 
     assert.notEqual(result.status, 0);
     assert.match(result.stderr, /cannot write the coverage baseline in CI/);
+});
+
+test('COVERAGE-BASELINE-INSTRUMENTATION-001 rejects a summary missing a file that must stay instrumented', () => {
+    const summary = {
+        total: {},
+        '/repo/src/aiSessions/dashboardController.ts': {},
+    };
+
+    assert.deepEqual(
+        findUninstrumentedFiles(summary, ['src/dashboard.ts', 'src/aiSessions/dashboardController.ts']),
+        ['src/dashboard.ts']
+    );
+});
+
+test('COVERAGE-BASELINE-INSTRUMENTATION-001 accepts a summary that instruments every required file', () => {
+    const summary = {
+        total: {},
+        '/repo/src/dashboard.ts': {},
+        '/repo/other/src/dashboard.ts.map': {},
+    };
+
+    assert.deepEqual(findUninstrumentedFiles(summary, ['src/dashboard.ts']), []);
+});
+
+test('COVERAGE-BASELINE-INSTRUMENTATION-001 keeps src/dashboard.ts on the required instrumentation list', () => {
+    // Only the production activation harness executes this file, and it runs in
+    // a subprocess. When that subprocess stopped inheriting NODE_V8_COVERAGE the
+    // largest file in the extension silently left the report for weeks.
+    assert.ok(REQUIRED_INSTRUMENTED_FILES.includes('src/dashboard.ts'));
+});
+
+test('COVERAGE-BASELINE-INSTRUMENTATION-001 reports the missing file and skips the percentage comparison', () => {
+    const summary = { total: { lines: { pct: 1 }, branches: { pct: 1 }, functions: { pct: 1 }, statements: { pct: 1 } } };
+    const baseline = { lines: 90, branches: 90, functions: 90, statements: 90 };
+
+    // A file dropping out usually *raises* the totals, so the instrumentation
+    // failure has to be reported on its own rather than as a percentage drop.
+    assert.deepEqual(collectCoverageFailures(summary, baseline), [
+        'src/dashboard.ts is missing from the coverage report; '
+        + 'its executing process must inherit NODE_V8_COVERAGE',
+    ]);
+});
+
+test('COVERAGE-BASELINE-INSTRUMENTATION-001 falls through to baseline comparison once every file is instrumented', () => {
+    const summary = {
+        total: { lines: { pct: 50 }, branches: { pct: 95 }, functions: { pct: 95 }, statements: { pct: 95 } },
+        '/repo/src/dashboard.ts': {},
+    };
+    const baseline = { lines: 90, branches: 90, functions: 90, statements: 90 };
+
+    assert.deepEqual(collectCoverageFailures(summary, baseline), [
+        'lines coverage decreased from 90.00% to 50.00%',
+    ]);
+});
+
+test('COVERAGE-BASELINE-INSTRUMENTATION-001 returns no failures for an instrumented run at baseline', () => {
+    const summary = {
+        total: { lines: { pct: 90 }, branches: { pct: 90 }, functions: { pct: 90 }, statements: { pct: 90 } },
+        '/repo/src/dashboard.ts': {},
+    };
+    const baseline = { lines: 90, branches: 90, functions: 90, statements: 90 };
+
+    assert.deepEqual(collectCoverageFailures(summary, baseline), []);
 });


### PR DESCRIPTION
## Summary

`src/dashboard.ts` — 2296 lines, the largest file in the extension — was absent from the coverage report entirely. Every one of the other 74 `src/` modules over 250 lines appears in it; that one did not.

The cause is `tests/contract/aiSessions/runtimeComposition.test.js`. It is the only test that executes `src/dashboard.ts`, it does so by spawning the production activation harness in a subprocess, and it cleared `NODE_V8_COVERAGE` for that child. c8 collects subprocess profiles through exactly that variable, so the file was invisible.

The clearing was copied from `tmuxSmokeHarness.test.js`, which genuinely needs an uninstrumented child — it drives real tmux and asserts `v8Coverage: null` explicitly. Nothing required the same of the activation harness, and no test asserted it. That harness now inherits the variable; the tmux smoke harness is untouched.

## What the file's coverage actually is

| metric | src/dashboard.ts |
|---|---|
| lines | 76.91% (1766/2296) |
| branches | 83.71% (257/307) |
| **functions** | **36.00% (166/461)** |

The shape is informative. Line coverage is respectable because `activate()` and `initializeDashboard` run top to bottom under the harness. Function coverage is not, because 295 functions are never invoked — and 271 of those sit inside the `initializeDashboard` construction section. They are the callback properties of the options objects being wired up (`onDiagnostic`, `onConflict`, `confirmDelete`, `createId`, `renderAiPanel`, …). The wiring executes; the things it wires almost never fire.

Repository totals move because 2296 previously invisible lines re-enter the denominator: functions 86.79% → 80.81%, statements 85.07% → 84.40%, branches 76.93% → 78.10%. All stay above `.ci/coverage-baseline.json`, which is unchanged.

## Guard

A percentage baseline cannot catch this class of regression by itself: dropping a file out of the denominator usually makes the totals look *better*, which is why this went unnoticed since 2026-07-23. `check-coverage-baseline.js` now fails when a file reachable only through a subprocess harness is missing from the report, with a message naming the cause.

Mutation-verified: reverting the harness change makes the guard fail with `src/dashboard.ts is missing from the coverage report; its executing process must inherit NODE_V8_COVERAGE`, and restoring it makes it pass.

`main()` was split so the decision path is reachable from unit tests rather than only from a real repository layout on disk.

## Skill harvest

no skill change — the miss was a gap in repository tooling, not in Agent workflow guidance. The existing skills already require CI-reachable coverage and mutation-sensitive guards; this PR supplies the missing mechanical check rather than a new instruction.

## Verification

- `npm run test:ci:linux` — exit 0
  - deterministic: 615 unit / 719 contract / 336 integration; browser 140
  - changed-line coverage 83.33% (30/36) against `origin/main`
  - coverage baseline passed with the new instrumentation assertion active
- activation harness run 5× uninstrumented and 3× instrumented: 20/20 each time, no timing flakiness from the added instrumentation
- behavior `COVERAGE-BASELINE-INSTRUMENTATION-001` registered in `docs/testing/behavior-contracts.json`
