### PR TITLE
Add authoritative active session navigation

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -4581,6 +4581,26 @@
     ]
   },
   {
+    "id": "CONVERSATION-ACTIVE-SESSION-NAVIGATION-COMMANDS-001",
+    "domain": "session",
+    "title": "Previous and Next Active Session commands synchronize the authoritative active terminal and card while restoring keyboard focus to AI Conversation",
+    "priority": "P1",
+    "status": "automated",
+    "owners": [
+      "tests/contract/aiSessions/sessionControllers.test.js",
+      "tests/contract/dashboardBoundaries.test.js",
+      "tests/integration/dashboard/conversationOpenLatest.test.js",
+      "tests/integration/dashboard/conversationViewer.test.js"
+    ],
+    "evidence": [
+      "package.json",
+      "src/dashboard/commandRegistration.ts",
+      "src/dashboard.ts",
+      "src/aiSessions/conversation/composition.ts",
+      "src/aiSessions/conversation/viewer.ts"
+    ]
+  },
+  {
     "id": "SECURITY-AI-SESSION-CONVERSATION-SOURCE-001",
     "domain": "session",
     "title": "Conversation history enforces canonical sources, opaque protocol tokens, and bounded private content",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "94c139ff153d9c39e809814de35605d62b44e363",
+        "head": "f0f1b0cf7267cb8fa77e7b14a396953325293fa9",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -167,7 +167,8 @@
             "67e5c350a0c48974fb444a821143971bcc99e8d5",
             "13ea7824781c9eeaff4b08ee59e26cd86e9ac835",
             "988f8a1edfaeb211f39a2567d5faa698642ebe7f",
-            "1ba1462088a1c347854f49d6abb8406816a7b6c7"
+            "1ba1462088a1c347854f49d6abb8406816a7b6c7",
+            "8fabc649a7093eba6a51e2509ca598aba8ee1746"
         ]
     },
     "capabilities": [
@@ -1291,7 +1292,8 @@
                 "d6385f753ae6fde4801ccfc6a2b2a59b294a39b7",
                 "3bf7c016ed82999f21a3ed013167fd9df56a8bb0",
                 "131b4c3b22bfaf2e7807a4a1379366db9d4ebc54",
-                "cc80a21cd6af2a684b60369cc3195bd3d9bf5f49"
+                "cc80a21cd6af2a684b60369cc3195bd3d9bf5f49",
+                "f0f1b0cf7267cb8fa77e7b14a396953325293fa9"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",

--- a/media/conversationViewerScripts.js
+++ b/media/conversationViewerScripts.js
@@ -904,6 +904,16 @@
         if (telemetryController.apply(event.data)) return;
         applyPage(event.data);
     });
+    function postFocusState() {
+        post({
+            type: 'conversation-viewer-focus',
+            version: 1,
+            focused: document.hasFocus(),
+        });
+    }
+    window.addEventListener('focus', postFocusState);
+    window.addEventListener('blur', postFocusState);
+    postFocusState();
     window.addEventListener('unload', releaseMermaidObjectUrls);
 
     saveRestoreTarget(restoreTarget);

--- a/package.json
+++ b/package.json
@@ -99,6 +99,16 @@
                 "title": "Agent Pivot: Open Current AI Session Conversation"
             },
             {
+                "command": "agentPivot.previousActiveSession",
+                "title": "Agent Pivot: Previous Active Session",
+                "enablement": "activeWebviewPanelId == agentPivot.aiConversation && agentPivot.aiConversationFocus && !terminalFocus"
+            },
+            {
+                "command": "agentPivot.nextActiveSession",
+                "title": "Agent Pivot: Next Active Session",
+                "enablement": "activeWebviewPanelId == agentPivot.aiConversation && agentPivot.aiConversationFocus && !terminalFocus"
+            },
+            {
                 "command": "agentPivot.notify.setWebhook",
                 "title": "Agent Pivot: Set Notification Webhook"
             },

--- a/scripts/run-dashboard-webview-checks.js
+++ b/scripts/run-dashboard-webview-checks.js
@@ -3721,6 +3721,8 @@ async function runDashboardCommandRegistrationChecks() {
         'migrateSkillsToCentral',
         'changeGlobalSkillsLocation',
         'openCurrentAiSessionConversation',
+        'previousActiveSession',
+        'nextActiveSession',
         'switchToOpenWindow',
     ];
     const registration = new DashboardCommandRegistration({
@@ -3749,6 +3751,8 @@ async function runDashboardCommandRegistrationChecks() {
         'agentPivot.migrateSkillsToCentral',
         'agentPivot.changeGlobalSkillsLocation',
         'agentPivot.openCurrentAiSessionConversation',
+        'agentPivot.previousActiveSession',
+        'agentPivot.nextActiveSession',
         'agentPivot.switchToOpenWindow',
     ]);
     assert.deepStrictEqual(subscriptions.map(disposable => disposable.command), registered.map(([command]) => command));
@@ -3780,6 +3784,8 @@ async function runDashboardCommandRegistrationChecks() {
         'migrateSkillsToCentral',
         'changeGlobalSkillsLocation',
         'openCurrentAiSessionConversation',
+        'previousActiveSession',
+        'nextActiveSession',
         'switchToOpenWindow',
     ]);
 

--- a/src/aiSessions/conversation/composition.ts
+++ b/src/aiSessions/conversation/composition.ts
@@ -63,7 +63,7 @@ export type OpenLatestConversationResult =
 export type FollowActiveConversationResult =
     OpenLatestConversationResult | 'closed';
 export type FollowAdjacentConversationResult =
-    FollowActiveConversationResult | 'noAdjacentSession';
+    FollowActiveConversationResult | 'inactive' | 'noAdjacentSession';
 
 export interface ConversationCapability {
     viewer: ConversationViewerApi;
@@ -71,9 +71,15 @@ export interface ConversationCapability {
     openLatestConversation(
         target: ConversationSessionOpenTarget
     ): Promise<OpenLatestConversationResult>;
+    openLatestActiveConversation(
+        target: ConversationSessionOpenTarget
+    ): Promise<OpenLatestConversationResult>;
     followActiveConversation(
         target: ConversationSessionOpenTarget
     ): Promise<FollowActiveConversationResult>;
+    followAdjacentActiveConversation(
+        direction: ConversationSessionSwitchDirection
+    ): Promise<FollowAdjacentConversationResult>;
     restorePanel(panel: vscode.WebviewPanel, state: unknown): Promise<void>;
     rebindSession(
         previous: ConversationSessionOpenTarget,
@@ -118,10 +124,13 @@ export interface ConversationCapabilityOptions {
     ) => PromiseLike<void> | Promise<void>;
     focusSession?: (
         target: ConversationSessionOpenTarget
-    ) => PromiseLike<void> | Promise<void>;
+    ) => boolean | void | PromiseLike<boolean | void>;
     commentStore?: ConversationCommentStore;
     bookmarkStore?: ConversationBookmarkStore;
     getShowThinking?: () => boolean;
+    setConversationFocusContext?: (
+        focused: boolean
+    ) => PromiseLike<void> | Promise<void> | void;
     resolveReboundTarget?: (
         target: ConversationSessionOpenTarget
     ) => ConversationSessionOpenTarget;
@@ -256,6 +265,33 @@ function createAvailableConversationCapability(
     ownership.transfer(codexAdapter);
     ownership.transfer(kimiAdapter);
     ownership.transfer(claudeAdapter);
+    let focusTail: Promise<void> = Promise.resolve();
+    const queueFocus = (
+        operation: () => void | PromiseLike<void>,
+        isCurrent: () => boolean
+    ): Promise<boolean> => {
+        const pending = focusTail.then(async () => {
+            if (!isCurrent()) {
+                return false;
+            }
+            await operation();
+            return true;
+        });
+        focusTail = pending.then(() => undefined, () => undefined);
+        return pending;
+    };
+    const queueTerminalFocus = (
+        target: ConversationSessionOpenTarget,
+        isCurrent: () => boolean
+    ): Promise<boolean> => queueFocus(
+        async () => {
+            const focused = await options.focusSession?.(target);
+            if (focused === false) {
+                throw new Error('AI session terminal focus was rejected');
+            }
+        },
+        isCurrent
+    );
     const viewer = ownership.own(factories.createViewer({
         createPanel: options.createPanel,
         readOutline: coordinator.readOutline.bind(coordinator),
@@ -284,10 +320,22 @@ function createAvailableConversationCapability(
                 viewer,
                 direction,
                 currentTarget,
-                () => intentGeneration === viewerIntentGeneration
+                () => intentGeneration === viewerIntentGeneration,
+                queueTerminalFocus,
+                terminalAuthority
             );
         },
+        setKeyboardFocus: options.setConversationFocusContext,
     }));
+    const queueConversationFocus = (
+        _target: ConversationSessionOpenTarget,
+        isCurrent: () => boolean
+    ): Promise<boolean> => queueFocus(() => {
+        viewer.focus();
+    }, isCurrent);
+    const terminalAuthority: {
+        confirmedTarget?: ConversationViewerTarget;
+    } = {};
     let viewerIntentGeneration = 0;
     let disposed = false;
     return {
@@ -302,6 +350,27 @@ function createAvailableConversationCapability(
                 target,
                 () => intentGeneration === viewerIntentGeneration
             );
+        },
+        async openLatestActiveConversation(
+            target: ConversationSessionOpenTarget
+        ): Promise<OpenLatestConversationResult> {
+            const intentGeneration = ++viewerIntentGeneration;
+            const result = await openLatestConversation(
+                options,
+                coordinator,
+                viewer,
+                target,
+                () => intentGeneration === viewerIntentGeneration
+            );
+            if (result === 'opened') {
+                const currentTarget = viewer.getCurrentTarget();
+                if (currentTarget
+                    && hasSameConversationSession(currentTarget, target)) {
+                    terminalAuthority.confirmedTarget =
+                        cloneConversationViewerTarget(currentTarget);
+                }
+            }
+            return result;
         },
         async followActiveConversation(
             target: ConversationSessionOpenTarget
@@ -324,9 +393,53 @@ function createAvailableConversationCapability(
             if (!viewer.isOpen()) {
                 return 'closed';
             }
-            return await viewer.follow(resolution.viewerTarget)
-                ? 'opened'
-                : 'closed';
+            const followed = await viewer.follow(resolution.viewerTarget);
+            if (followed) {
+                const currentTarget = viewer.getCurrentTarget();
+                terminalAuthority.confirmedTarget =
+                    cloneConversationViewerTarget(
+                        currentTarget
+                            && hasSameConversationSession(
+                                currentTarget,
+                                resolution.viewerTarget
+                            )
+                            ? currentTarget
+                            : resolution.viewerTarget
+                    );
+            }
+            return followed ? 'opened' : 'closed';
+        },
+        async followAdjacentActiveConversation(
+            direction: ConversationSessionSwitchDirection
+        ): Promise<FollowAdjacentConversationResult> {
+            const currentTarget = viewer.getFocusedTarget();
+            if (!currentTarget) {
+                return viewer.isOpen() ? 'inactive' : 'closed';
+            }
+            const intentGeneration = ++viewerIntentGeneration;
+            const isCurrent = () =>
+                intentGeneration === viewerIntentGeneration;
+            try {
+                return await followAdjacentConversation(
+                    options,
+                    coordinator,
+                    viewer,
+                    direction,
+                    currentTarget,
+                    isCurrent,
+                    queueTerminalFocus,
+                    terminalAuthority
+                );
+            } finally {
+                // A terminal focus from an older Webview switch may already
+                // be running. Queue the command's Conversation refocus for
+                // every result, including no-adjacent and failed loads.
+                try {
+                    await queueConversationFocus(currentTarget, isCurrent);
+                } catch (_error) {
+                    // Preserve the authoritative switch result if reveal fails.
+                }
+            }
         },
         async restorePanel(
             panel: vscode.WebviewPanel,
@@ -424,6 +537,10 @@ function createAvailableConversationCapability(
 function createUnavailableConversationCapability(): ConversationCapability {
     const viewer: ConversationViewerApi = {
         isOpen: () => false,
+        focus: () => false,
+        getCurrentTarget: () => undefined,
+        getFocusedTarget: () => undefined,
+        getFocusedSessionTarget: () => undefined,
         async open() {},
         async restore(panel) {
             panel.dispose();
@@ -452,7 +569,13 @@ function createUnavailableConversationCapability(): ConversationCapability {
         async openLatestConversation(): Promise<OpenLatestConversationResult> {
             return 'unavailable';
         },
+        async openLatestActiveConversation(): Promise<OpenLatestConversationResult> {
+            return 'unavailable';
+        },
         async followActiveConversation(): Promise<FollowActiveConversationResult> {
+            return 'unavailable';
+        },
+        async followAdjacentActiveConversation(): Promise<FollowAdjacentConversationResult> {
             return 'unavailable';
         },
         async restorePanel(panel: vscode.WebviewPanel): Promise<void> {
@@ -507,11 +630,29 @@ async function followAdjacentConversation(
     coordinator: ConversationCoordinator,
     viewer: ConversationViewerApi,
     direction: ConversationSessionSwitchDirection,
-    currentTarget: ConversationSessionOpenTarget,
-    isCurrent: () => boolean
+    currentTarget: ConversationViewerTarget,
+    isCurrent: () => boolean,
+    queueTerminalFocus?: (
+        target: ConversationSessionOpenTarget,
+        isCurrent: () => boolean
+    ) => Promise<boolean>,
+    terminalAuthority?: {
+        confirmedTarget?: ConversationViewerTarget;
+    }
 ): Promise<FollowAdjacentConversationResult> {
     if (!viewer.isOpen()) {
         return 'closed';
+    }
+    if (terminalAuthority
+        && (!terminalAuthority.confirmedTarget
+            || hasSameConversationSession(
+                terminalAuthority.confirmedTarget,
+                currentTarget
+            ))) {
+        // Moving between interactions or subagents does not change terminal
+        // authority. Keep the exact visible target fresh for a later rollback.
+        terminalAuthority.confirmedTarget =
+            cloneConversationViewerTarget(currentTarget);
     }
     let sessions: readonly ActiveAiSessionViewModel[];
     try {
@@ -558,22 +699,77 @@ async function followAdjacentConversation(
         return 'closed';
     }
     const followed = await viewer.follow(resolution.viewerTarget);
+    if (!isCurrent()) {
+        return 'superseded';
+    }
     if (!followed) {
         return 'closed';
     }
-    // Keep the visible session terminal/tmux window in sync with the
-    // conversation. Terminal sync is best-effort: a focus failure must not
-    // undo or retry the settled conversation switch.
-    try {
-        await options.focusSession?.({
-            projectId: currentTarget.projectId,
-            provider: adjacent.provider,
-            sessionId: adjacent.sessionId,
-        });
-    } catch (_error) {
-        // The conversation switch has already settled.
+    if (queueTerminalFocus) {
+        // Webview navigation syncs the terminal/tmux window. Command
+        // navigation queues a Conversation reveal behind any terminal focus
+        // already in flight, so AI Conversation remains the final focus owner.
+        try {
+            const terminalFocused = await queueTerminalFocus({
+                projectId: currentTarget.projectId,
+                provider: adjacent.provider,
+                sessionId: adjacent.sessionId,
+            }, isCurrent);
+            if (!terminalFocused) {
+                return 'superseded';
+            }
+            if (terminalAuthority) {
+                terminalAuthority.confirmedTarget =
+                    cloneConversationViewerTarget(resolution.viewerTarget);
+            }
+        } catch (_error) {
+            if (!isCurrent()) {
+                return 'superseded';
+            }
+            // Terminal authority did not move to the requested Session. Best
+            // effort restores the previous terminal and exact Conversation
+            // target so the card and viewer cannot settle on different roots.
+            const rollbackTarget = terminalAuthority?.confirmedTarget
+                || currentTarget;
+            try {
+                await queueTerminalFocus(rollbackTarget, isCurrent);
+            } catch (_rollbackError) {
+                // The authoritative refresh still reflects the observed runtime.
+            }
+            if (!isCurrent()) {
+                return 'superseded';
+            }
+            if (!viewer.isOpen()) {
+                return 'closed';
+            }
+            const restored = await viewer.follow(rollbackTarget);
+            if (!isCurrent()) {
+                return 'superseded';
+            }
+            return restored ? 'unavailable' : 'closed';
+        }
     }
-    return 'opened';
+    return isCurrent() ? 'opened' : 'superseded';
+}
+
+function cloneConversationViewerTarget(
+    target: ConversationViewerTarget
+): ConversationViewerTarget {
+    return {
+        ...target,
+        ...(target.subagent
+            ? { subagent: { ...target.subagent } }
+            : {}),
+    };
+}
+
+function hasSameConversationSession(
+    left: ConversationSessionOpenTarget,
+    right: ConversationSessionOpenTarget
+): boolean {
+    return left.projectId === right.projectId
+        && left.provider === right.provider
+        && left.sessionId === right.sessionId;
 }
 
 async function resolveLatestConversationTarget(

--- a/src/aiSessions/conversation/viewer.ts
+++ b/src/aiSessions/conversation/viewer.ts
@@ -86,7 +86,7 @@ export interface ConversationViewerOptions {
             ConversationViewerTarget,
             'projectId' | 'provider' | 'sessionId'
         >
-    ) => PromiseLike<void> | Promise<void>;
+    ) => boolean | void | PromiseLike<boolean | void>;
     commentStore?: ConversationCommentStore;
     bookmarkStore?: ConversationBookmarkStore;
     showWorktreeInSourceControl?: (
@@ -97,15 +97,22 @@ export interface ConversationViewerOptions {
     ) => PromiseLike<void> | Promise<void> | void;
     followAdjacentConversation?: (
         direction: ConversationSessionSwitchDirection,
-        currentTarget: Pick<
-            ConversationViewerTarget,
-            'projectId' | 'provider' | 'sessionId'
-        >
+        currentTarget: ConversationViewerTarget
     ) => PromiseLike<unknown> | Promise<unknown> | void;
+    setKeyboardFocus?: (
+        focused: boolean
+    ) => PromiseLike<void> | Promise<void> | void;
 }
 
 export interface ConversationViewerApi extends AiSessionDisposable {
     isOpen(): boolean;
+    focus(): boolean;
+    getCurrentTarget(): ConversationViewerTarget | undefined;
+    getFocusedTarget(): ConversationViewerTarget | undefined;
+    getFocusedSessionTarget(): Pick<
+        ConversationViewerTarget,
+        'projectId' | 'provider' | 'sessionId'
+    > | undefined;
     open(target: ConversationViewerTarget): Promise<void>;
     restore(
         panel: vscode.WebviewPanel,
@@ -184,6 +191,7 @@ export class ConversationViewer implements ConversationViewerApi {
     private rebindGeneration = 0;
     private authoritativeLoadInFlight?: Promise<boolean>;
     private authoritativeRefreshPending = false;
+    private keyboardFocused = false;
     private readonly commentController: ConversationCommentController;
     private readonly bookmarkController: ConversationBookmarkController;
     private readonly outlineController = new ConversationOutlineController();
@@ -202,7 +210,9 @@ export class ConversationViewer implements ConversationViewerApi {
         this.commentController = new ConversationCommentController({
             commentStore: options.commentStore,
             submitPrompt: options.submitPrompt,
-            focusSession: options.focusSession,
+            focusSession: async target => {
+                await options.focusSession?.(target);
+            },
             getTarget: () => this.target,
             getSubscriptionGeneration: () => this.subscriptionGeneration,
             getPanel: () => this.panel,
@@ -227,6 +237,43 @@ export class ConversationViewer implements ConversationViewerApi {
 
     isOpen(): boolean {
         return Boolean(this.panel);
+    }
+
+    focus(): boolean {
+        const panel = this.panel;
+        if (!panel) {
+            return false;
+        }
+        panel.reveal(panel.viewColumn || vscode.ViewColumn.Active, false);
+        return true;
+    }
+
+    getCurrentTarget(): ConversationViewerTarget | undefined {
+        if (!this.panel || !this.target) {
+            return undefined;
+        }
+        return cloneViewerTarget(this.target);
+    }
+
+    getFocusedTarget(): ConversationViewerTarget | undefined {
+        if (!this.panel?.active || !this.keyboardFocused || !this.target) {
+            return undefined;
+        }
+        return cloneViewerTarget(this.target);
+    }
+
+    getFocusedSessionTarget(): Pick<
+        ConversationViewerTarget,
+        'projectId' | 'provider' | 'sessionId'
+    > | undefined {
+        if (!this.panel?.active || !this.keyboardFocused || !this.target) {
+            return undefined;
+        }
+        return {
+            projectId: this.target.projectId,
+            provider: this.target.provider,
+            sessionId: this.target.sessionId,
+        };
     }
 
     async open(target: ConversationViewerTarget): Promise<void> {
@@ -378,8 +425,7 @@ export class ConversationViewer implements ConversationViewerApi {
         }
         panel.webview.html = this.renderDocument(undefined, 'Loading conversation…');
         this.ensureWatch(generation);
-        await this.loadAuthoritative('initial', true);
-        return true;
+        return this.loadAuthoritative('initial', true);
     }
 
     async refresh(): Promise<void> {
@@ -542,6 +588,7 @@ export class ConversationViewer implements ConversationViewerApi {
             return;
         }
         this.panel = panel;
+        this.publishKeyboardFocus(false, true);
         this.panelWasVisible = panel.visible;
         this.messageListener = panel.webview.onDidReceiveMessage(
             message => this.handleMessage(message)
@@ -552,6 +599,9 @@ export class ConversationViewer implements ConversationViewerApi {
             }
             const becameVisible = !this.panelWasVisible && panel.visible;
             this.panelWasVisible = panel.visible;
+            if (!panel.active) {
+                this.publishKeyboardFocus(false);
+            }
             if (becameVisible) {
                 this.rebuildLatestDocument();
             }
@@ -597,6 +647,7 @@ export class ConversationViewer implements ConversationViewerApi {
         this.commentController.reset();
         this.bookmarkController.reset();
         this.panelWasVisible = false;
+        this.publishKeyboardFocus(false);
         this.suspended = false;
         this.subscriptionGeneration += 1;
         this.currentRequestId = 0;
@@ -604,7 +655,14 @@ export class ConversationViewer implements ConversationViewerApi {
 
     private async handleMessage(message: unknown): Promise<void> {
         const parsed = parseConversationViewerMessage(message);
-        if (!parsed || !this.target || !this.panel) {
+        if (!parsed || !this.panel) {
+            return;
+        }
+        if (parsed.type === 'conversation-viewer-focus') {
+            this.publishKeyboardFocus(parsed.focused && this.panel.active);
+            return;
+        }
+        if (!this.target) {
             return;
         }
         if (parsed.type === 'conversation-viewer-open-link') {
@@ -623,11 +681,10 @@ export class ConversationViewer implements ConversationViewerApi {
         }
         if (parsed.type === 'conversation-viewer-switch-session') {
             const currentTarget = this.target;
-            await this.options.followAdjacentConversation?.(parsed.direction, {
-                projectId: currentTarget.projectId,
-                provider: currentTarget.provider,
-                sessionId: currentTarget.sessionId,
-            });
+            await this.options.followAdjacentConversation?.(
+                parsed.direction,
+                currentTarget
+            );
             return;
         }
         if (parsed.type === 'conversation-viewer-comment-mutation'
@@ -664,6 +721,19 @@ export class ConversationViewer implements ConversationViewerApi {
             return;
         }
         await this.navigateLatest();
+    }
+
+    private publishKeyboardFocus(focused: boolean, force = false): void {
+        if (!force && this.keyboardFocused === focused) {
+            return;
+        }
+        this.keyboardFocused = focused;
+        try {
+            void Promise.resolve(this.options.setKeyboardFocus?.(focused))
+                .catch(() => undefined);
+        } catch (_error) {
+            // Focus context is advisory and must not break the viewer.
+        }
     }
 
     private effectiveSessionId(target: ConversationViewerTarget): string {
@@ -1592,6 +1662,17 @@ export class ConversationViewer implements ConversationViewerApi {
             return false;
         }
     }
+}
+
+function cloneViewerTarget(
+    target: ConversationViewerTarget
+): ConversationViewerTarget {
+    return {
+        ...target,
+        ...(target.subagent
+            ? { subagent: { ...target.subagent } }
+            : {}),
+    };
 }
 
 function boundedConversationDisplayName(value: string): string {

--- a/src/aiSessions/conversation/viewerProtocol.ts
+++ b/src/aiSessions/conversation/viewerProtocol.ts
@@ -97,6 +97,12 @@ export interface ConversationViewerSwitchSessionMessage {
     direction: ConversationSessionSwitchDirection;
 }
 
+export interface ConversationViewerFocusMessage {
+    type: 'conversation-viewer-focus';
+    version: 1;
+    focused: boolean;
+}
+
 export interface ConversationViewerOpenSubagentMessage {
     type: 'conversation-viewer-open-subagent';
     version: 1;
@@ -115,6 +121,7 @@ export type ConversationViewerMessage =
     | ConversationViewerOpenWorktreeMessage
     | ConversationViewerSendSelectionMessage
     | ConversationViewerSwitchSessionMessage
+    | ConversationViewerFocusMessage
     | ConversationViewerOpenSubagentMessage
     | ConversationViewerCloseSubagentMessage
     | ConversationViewerCommentMutationMessage
@@ -197,6 +204,13 @@ export function parseConversationViewerMessage(
             return undefined;
         }
         return value as unknown as ConversationViewerSwitchSessionMessage;
+    }
+    if (value.type === 'conversation-viewer-focus') {
+        if (!hasExactKeys(value, ['type', 'version', 'focused'])
+            || typeof value.focused !== 'boolean') {
+            return undefined;
+        }
+        return value as unknown as ConversationViewerFocusMessage;
     }
     if (value.type === 'conversation-viewer-open-subagent') {
         if (!hasExactKeys(value, ['type', 'version', 'subagentId'])

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1465,13 +1465,18 @@ async function initializeDashboard(
                     resumePrompt
                 ),
         }, viewerTarget, prompt),
-        focusSession: async viewerTarget => {
-            await aiSessionTerminalCommandController.focusActive(
+        focusSession: viewerTarget =>
+            aiSessionTerminalCommandController.focusActive(
                 viewerTarget.projectId,
                 viewerTarget.provider,
                 viewerTarget.sessionId
-            );
-        },
+            ),
+        setConversationFocusContext: focused =>
+            vscode.commands.executeCommand(
+                'setContext',
+                'agentPivot.aiConversationFocus',
+                focused
+            ),
     }));
     followConversationSessionRebind = (previous, next) =>
         conversationCapability.rebindSession(previous, next);
@@ -1920,6 +1925,10 @@ async function initializeDashboard(
         changeGlobalSkillsLocation: () =>
             skillPanel.changeGlobalStoreLocation(),
         openCurrentAiSessionConversation: () => openCurrentAiSessionConversation(),
+        previousActiveSession: () =>
+            followAdjacentActiveConversationWithFeedback('previous'),
+        nextActiveSession: () =>
+            followAdjacentActiveConversationWithFeedback('next'),
         switchToOpenWindow: () => workspaceNavigationQuickPickController.pickAndOpen(),
     };
 
@@ -2095,19 +2104,22 @@ async function initializeDashboard(
         if (!selected?.sessionId) {
             return;
         }
+        const terminalAuthoritative = selected.focused === true;
         await openAiSessionConversationWithFeedback({
             projectId: target.cardId,
             provider: selected.provider,
             sessionId: selected.sessionId,
-        });
+        }, terminalAuthoritative);
     }
 
     async function openAiSessionConversationWithFeedback(target: {
         projectId: string;
         provider: AiSessionProviderId;
         sessionId: string;
-    }): Promise<void> {
-        const result = await conversationCapability.openLatestConversation(target);
+    }, terminalAuthoritative = false): Promise<void> {
+        const result = terminalAuthoritative
+            ? await conversationCapability.openLatestActiveConversation(target)
+            : await conversationCapability.openLatestConversation(target);
         if (result === 'empty') {
             void vscode.window.showInformationMessage(
                 'Agent Pivot: this AI session has no conversation yet.'
@@ -2119,6 +2131,34 @@ async function initializeDashboard(
         } else if (result === 'unavailable') {
             void vscode.window.showWarningMessage(
                 'Agent Pivot: unable to read the AI session conversation.'
+            );
+        }
+    }
+
+    async function followAdjacentActiveConversationWithFeedback(
+        direction: 'previous' | 'next'
+    ): Promise<void> {
+        const result = await conversationCapability
+            .followAdjacentActiveConversation(direction);
+        if (result === 'inactive' || result === 'closed') {
+            void vscode.window.showInformationMessage(
+                'Agent Pivot: focus an AI Conversation editor to switch active sessions.'
+            );
+        } else if (result === 'noAdjacentSession') {
+            void vscode.window.showInformationMessage(
+                'Agent Pivot: no other active AI session is available.'
+            );
+        } else if (result === 'empty') {
+            void vscode.window.showInformationMessage(
+                'Agent Pivot: the adjacent AI session has no conversation yet.'
+            );
+        } else if (result === 'unknownSession') {
+            void vscode.window.showWarningMessage(
+                'Agent Pivot: the adjacent AI session is no longer active.'
+            );
+        } else if (result === 'unavailable') {
+            void vscode.window.showWarningMessage(
+                'Agent Pivot: unable to switch AI Conversation sessions.'
             );
         }
     }

--- a/src/dashboard/commandRegistration.ts
+++ b/src/dashboard/commandRegistration.ts
@@ -20,6 +20,8 @@ export interface DashboardCommandHandlers {
     migrateSkillsToCentral: DashboardCommandHandler;
     changeGlobalSkillsLocation: DashboardCommandHandler;
     openCurrentAiSessionConversation: DashboardCommandHandler;
+    previousActiveSession: DashboardCommandHandler;
+    nextActiveSession: DashboardCommandHandler;
     switchToOpenWindow: DashboardCommandHandler;
 }
 
@@ -48,6 +50,8 @@ const DASHBOARD_COMMANDS: ReadonlyArray<readonly [string, DashboardCommandName]>
     ['agentPivot.migrateSkillsToCentral', 'migrateSkillsToCentral'],
     ['agentPivot.changeGlobalSkillsLocation', 'changeGlobalSkillsLocation'],
     ['agentPivot.openCurrentAiSessionConversation', 'openCurrentAiSessionConversation'],
+    ['agentPivot.previousActiveSession', 'previousActiveSession'],
+    ['agentPivot.nextActiveSession', 'nextActiveSession'],
     ['agentPivot.switchToOpenWindow', 'switchToOpenWindow'],
 ];
 

--- a/src/webview/conversationViewerScripts.js
+++ b/src/webview/conversationViewerScripts.js
@@ -904,6 +904,16 @@
         if (telemetryController.apply(event.data)) return;
         applyPage(event.data);
     });
+    function postFocusState() {
+        post({
+            type: 'conversation-viewer-focus',
+            version: 1,
+            focused: document.hasFocus(),
+        });
+    }
+    window.addEventListener('focus', postFocusState);
+    window.addEventListener('blur', postFocusState);
+    postFocusState();
     window.addEventListener('unload', releaseMermaidObjectUrls);
 
     saveRestoreTarget(restoreTarget);

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -1058,6 +1058,11 @@ test('WEBVIEW-AI-SESSION-CONVERSATION-VIEWER-001 acquires one real document API 
     await page.locator('a[href="https://example.test/safe"]').click();
 
     assert.deepEqual(await postedMessages(page), [
+        {
+            type: 'conversation-viewer-focus',
+            version: 1,
+            focused: true,
+        },
         { type: 'conversation-viewer-previous', version: 1 },
         { type: 'conversation-viewer-next', version: 1 },
         { type: 'conversation-viewer-latest', version: 1 },
@@ -1273,14 +1278,20 @@ test('WEBVIEW-AI-SESSION-CONVERSATION-VIEWER-001 keeps boundary navigation inert
     assert.equal(await previous.isDisabled(), true);
     assert.equal(await next.isDisabled(), true);
     assert.equal(await latest.isDisabled(), false);
-    assert.deepEqual(await postedMessages(page), []);
+    const initialFocus = [{
+        type: 'conversation-viewer-focus',
+        version: 1,
+        focused: true,
+    }];
+    assert.deepEqual(await postedMessages(page), initialFocus);
 
     await previous.evaluate(element => element.click());
     await next.evaluate(element => element.click());
-    assert.deepEqual(await postedMessages(page), []);
+    assert.deepEqual(await postedMessages(page), initialFocus);
 
     await latest.click();
     assert.deepEqual(await postedMessages(page), [
+        ...initialFocus,
         { type: 'conversation-viewer-latest', version: 1 },
     ]);
 });
@@ -5926,11 +5937,18 @@ test('CONVERSATION-TELEMETRY-001 renders the worktree chip, degrades missing pat
     );
 
     await chip.click();
-    assert.deepEqual(await postedMessages(page), [{
-        type: 'conversation-viewer-open-worktree',
-        version: 1,
-        worktreeRoot: '/repo/.worktree/feat-worktree',
-    }]);
+    assert.deepEqual(await postedMessages(page), [
+        {
+            type: 'conversation-viewer-focus',
+            version: 1,
+            focused: true,
+        },
+        {
+            type: 'conversation-viewer-open-worktree',
+            version: 1,
+            worktreeRoot: '/repo/.worktree/feat-worktree',
+        },
+    ]);
 
     await sendPage(page, {
         type: 'conversation-viewer-telemetry',

--- a/tests/contract/aiSessions/runtimeComposition.test.js
+++ b/tests/contract/aiSessions/runtimeComposition.test.js
@@ -162,6 +162,8 @@ test('WEBVIEW-DASHBOARD-COMMAND-AVAILABILITY-001 production activation exposes c
         'agentPivot.migrateSkillsToCentral',
         'agentPivot.changeGlobalSkillsLocation',
         'agentPivot.openCurrentAiSessionConversation',
+        'agentPivot.previousActiveSession',
+        'agentPivot.nextActiveSession',
         'agentPivot.switchToOpenWindow',
         'agentPivot.notify.setWebhook',
         'agentPivot.notify.showOutput',

--- a/tests/contract/aiSessions/sessionControllers.test.js
+++ b/tests/contract/aiSessions/sessionControllers.test.js
@@ -258,7 +258,7 @@ test('SESSION-AI-SESSION-YOLO-LAZY-001 does not read options or build specs for 
     }
 });
 
-test('SESSION-AI-SESSION-TERMINAL-COMMAND-CONTROLLER-001 ATTENTION-EXPLICIT-SESSION-CLOSE-001 CONVERSATION-FOLLOW-ACTIVE-SESSION-001 reports whether a project-owned terminal was focused', async () => {
+test('SESSION-AI-SESSION-TERMINAL-COMMAND-CONTROLLER-001 ATTENTION-EXPLICIT-SESSION-CLOSE-001 CONVERSATION-FOLLOW-ACTIVE-SESSION-001 CONVERSATION-ACTIVE-SESSION-NAVIGATION-COMMANDS-001 reports whether a project-owned terminal was focused', async () => {
     const effects = [];
     const terminal = { show: () => effects.push('show'), dispose: () => effects.push('dispose') };
     const identity = {

--- a/tests/contract/dashboardBoundaries.test.js
+++ b/tests/contract/dashboardBoundaries.test.js
@@ -371,7 +371,9 @@ const DASHBOARD_COMMANDS = [
     'agentPivot.removeGroup', 'agentPivot.addProjectsFromFolder',
     'agentPivot.addFileToActiveTerminal', 'agentPivot.insertPromptToActiveTerminal',
     'agentPivot.migrateSkillsToCentral', 'agentPivot.changeGlobalSkillsLocation',
-    'agentPivot.openCurrentAiSessionConversation', 'agentPivot.switchToOpenWindow',
+    'agentPivot.openCurrentAiSessionConversation',
+    'agentPivot.previousActiveSession', 'agentPivot.nextActiveSession',
+    'agentPivot.switchToOpenWindow',
 ];
 
 // Registered directly from initializeDashboard, outside the dashboard command facade.
@@ -388,7 +390,9 @@ test('WEBVIEW-DASHBOARD-COMMAND-REGISTRATION-001 WEBVIEW-DASHBOARD-COMMAND-AVAIL
         'open', 'addProject', 'saveProject', 'removeProject', 'editProjects', 'addGroup', 'removeGroup',
         'addProjectsFromFolder', 'addFileToActiveTerminal', 'insertPromptToActiveTerminal',
         'migrateSkillsToCentral', 'changeGlobalSkillsLocation',
-        'openCurrentAiSessionConversation', 'switchToOpenWindow',
+        'openCurrentAiSessionConversation',
+        'previousActiveSession', 'nextActiveSession',
+        'switchToOpenWindow',
     ];
     const facade = new DashboardCommandRegistration({
         registerCommand: (command, callback) => {
@@ -451,6 +455,51 @@ test('WEBVIEW-DASHBOARD-COMMAND-REGISTRATION-001 contributes the Prompt terminal
     assert.equal(manifest.contributes.keybindings.some(
         keybinding => keybinding.command === 'agentPivot.insertPromptToActiveTerminal'
     ), false);
+});
+
+test('CONVERSATION-ACTIVE-SESSION-NAVIGATION-COMMANDS-001 contributes focused Conversation navigation commands without taking global shortcuts', () => {
+    const manifest = require('../../package.json');
+    const commands = manifest.contributes.commands.filter(command =>
+        command.command === 'agentPivot.previousActiveSession'
+            || command.command === 'agentPivot.nextActiveSession'
+    );
+    assert.deepEqual(commands, [
+        {
+            command: 'agentPivot.previousActiveSession',
+            title: 'Agent Pivot: Previous Active Session',
+            enablement: 'activeWebviewPanelId == agentPivot.aiConversation && agentPivot.aiConversationFocus && !terminalFocus',
+        },
+        {
+            command: 'agentPivot.nextActiveSession',
+            title: 'Agent Pivot: Next Active Session',
+            enablement: 'activeWebviewPanelId == agentPivot.aiConversation && agentPivot.aiConversationFocus && !terminalFocus',
+        },
+    ]);
+    assert.deepEqual(
+        manifest.contributes.keybindings.filter(binding =>
+            commands.some(command => command.command === binding.command)
+        ),
+        []
+    );
+});
+
+test('CONVERSATION-ACTIVE-SESSION-NAVIGATION-COMMANDS-001 marks only an actually focused Open Current selection as terminal-authoritative', () => {
+    const source = fs.readFileSync(
+        path.resolve(__dirname, '../../src/dashboard.ts'),
+        'utf8'
+    );
+    assert.match(
+        source,
+        /const terminalAuthoritative = selected\.focused === true;/
+    );
+    assert.match(
+        source,
+        /sessionId: selected\.sessionId,\s*}, terminalAuthoritative\);/
+    );
+    assert.doesNotMatch(
+        source,
+        /sessionId: selected\.sessionId,\s*}, true\);/
+    );
 });
 
 test('WEBVIEW-DASHBOARD-COMMAND-REGISTRATION-001 production activation installs the exact Dashboard public command surface', () => {

--- a/tests/extension-host/suite/index.js
+++ b/tests/extension-host/suite/index.js
@@ -20,6 +20,8 @@ const PUBLIC_COMMANDS = [
     'agentPivot.migrateSkillsToCentral',
     'agentPivot.changeGlobalSkillsLocation',
     'agentPivot.openCurrentAiSessionConversation',
+    'agentPivot.previousActiveSession',
+    'agentPivot.nextActiveSession',
     'agentPivot.switchToOpenWindow',
 ];
 

--- a/tests/integration/dashboard/conversationOpenLatest.test.js
+++ b/tests/integration/dashboard/conversationOpenLatest.test.js
@@ -107,6 +107,7 @@ function createHarness(options = {}) {
     const viewerTargets = [];
     const followedViewerTargets = [];
     const restoredViewerTargets = [];
+    let viewerFocuses = 0;
     let capturedViewerOptions;
     let outlineReads = 0;
     const session = 'session' in options ? options.session : makeSession({
@@ -169,14 +170,41 @@ function createHarness(options = {}) {
             capturedViewerOptions = viewerOptions;
             return {
                 isOpen: () => options.viewerOpen === true,
+                getCurrentTarget: () => (
+                    options.getCurrentViewerTarget?.()
+                    || options.getFocusedViewerTarget?.()
+                    || options.focusedViewerTarget
+                ),
+                getFocusedTarget: () => (
+                    options.getFocusedViewerTarget?.()
+                    || options.focusedViewerTarget
+                )
+                    ? {
+                        interactionId: 'input-a',
+                        expectedRevision: 'native-1',
+                        displayName: 'Focused session',
+                        duplicateDisplayName: false,
+                        ...(options.getFocusedViewerTarget?.()
+                            || options.focusedViewerTarget),
+                    }
+                    : undefined,
+                getFocusedSessionTarget: () => options.focusedViewerTarget,
                 open: async target => {
                     viewerTargets.push(target);
+                    await options.openViewer?.(target);
                 },
                 restore: async (panel, target) => {
                     restoredViewerTargets.push({ panel, target });
                 },
                 follow: async target => {
                     followedViewerTargets.push(target);
+                    return options.followViewer
+                        ? options.followViewer(target)
+                        : true;
+                },
+                focus: () => {
+                    viewerFocuses += 1;
+                    options.focusViewer?.();
                     return true;
                 },
                 rebindSession: async () => false,
@@ -197,6 +225,9 @@ function createHarness(options = {}) {
         },
         get outlineReads() {
             return outlineReads;
+        },
+        get viewerFocuses() {
+            return viewerFocuses;
         },
     };
 }
@@ -609,6 +640,473 @@ test('CONVERSATION-FOLLOW-ACTIVE-SESSION-001 follows the adjacent active session
     harness.capability.dispose();
 });
 
+test('CONVERSATION-ACTIVE-SESSION-NAVIGATION-COMMANDS-001 switches from the focused Conversation target and ignores an unfocused viewer', async () => {
+    const sessions = [
+        makeSession({ key: 'codex:session-a', sessionId: 'session-a' }),
+        makeSession({ key: 'codex:session-b', sessionId: 'session-b' }),
+    ];
+    const currentTarget = {
+        projectId: 'project-a',
+        provider: 'codex',
+        sessionId: 'session-a',
+    };
+    const focusedSessions = [];
+    const harness = createHarness({
+        viewerOpen: true,
+        focusedViewerTarget: currentTarget,
+        resolveTarget: (_projectId, provider, sessionId) =>
+            sessions.find(session =>
+                session.provider === provider && session.sessionId === sessionId
+            ) || null,
+        resolveActiveTargets: () => sessions,
+        focusSession: async target => {
+            focusedSessions.push(target);
+        },
+    });
+
+    assert.equal(
+        await harness.capability.followAdjacentActiveConversation('next'),
+        'opened'
+    );
+    assert.deepEqual(
+        harness.followedViewerTargets.map(target => target.sessionId),
+        ['session-b']
+    );
+    assert.deepEqual(
+        focusedSessions.map(target => target.sessionId),
+        ['session-b'],
+        'command navigation must activate the target terminal/session'
+    );
+    assert.equal(harness.viewerFocuses, 1);
+    harness.capability.dispose();
+
+    const unfocused = createHarness({ viewerOpen: true });
+    assert.equal(
+        await unfocused.capability.followAdjacentActiveConversation('previous'),
+        'inactive'
+    );
+    assert.equal(unfocused.outlineReads, 0);
+    unfocused.capability.dispose();
+});
+
+test('CONVERSATION-ACTIVE-SESSION-NAVIGATION-COMMANDS-001 rolls a rejected command switch back before restoring Conversation focus', async () => {
+    const sessions = [
+        makeSession({ key: 'codex:session-a', sessionId: 'session-a' }),
+        makeSession({ key: 'codex:session-b', sessionId: 'session-b' }),
+    ];
+    const focusOrder = [];
+    const harness = createHarness({
+        viewerOpen: true,
+        focusedViewerTarget: {
+            projectId: 'project-a',
+            provider: 'codex',
+            sessionId: 'session-a',
+        },
+        resolveTarget: (_projectId, provider, sessionId) =>
+            sessions.find(session =>
+                session.provider === provider && session.sessionId === sessionId
+            ) || null,
+        resolveActiveTargets: () => sessions,
+        focusSession: async target => {
+            focusOrder.push(`terminal:${target.sessionId}`);
+            return target.sessionId === 'session-a';
+        },
+        focusViewer: () => focusOrder.push('conversation'),
+    });
+
+    assert.equal(
+        await harness.capability.followAdjacentActiveConversation('next'),
+        'unavailable'
+    );
+    assert.deepEqual(
+        harness.followedViewerTargets.map(target => target.sessionId),
+        ['session-b', 'session-a']
+    );
+    assert.deepEqual(focusOrder, [
+        'terminal:session-b',
+        'terminal:session-a',
+        'conversation',
+    ]);
+    assert.equal(harness.viewerFocuses, 1);
+    harness.capability.dispose();
+});
+
+test('CONVERSATION-ACTIVE-SESSION-NAVIGATION-COMMANDS-001 rolls consecutive rejected commands back to the last confirmed terminal authority', async () => {
+    const sessions = [
+        makeSession({ key: 'codex:session-a', sessionId: 'session-a' }),
+        makeSession({ key: 'codex:session-b', sessionId: 'session-b' }),
+        makeSession({ key: 'codex:session-c', sessionId: 'session-c' }),
+    ];
+    let currentViewerTarget = {
+        projectId: 'project-a',
+        provider: 'codex',
+        sessionId: 'session-a',
+    };
+    const slowBFocusStarted = deferred();
+    const releaseSlowBFocus = deferred();
+    const focusOrder = [];
+    const harness = createHarness({
+        viewerOpen: true,
+        getFocusedViewerTarget: () => currentViewerTarget,
+        resolveTarget: (_projectId, provider, sessionId) =>
+            sessions.find(session =>
+                session.provider === provider && session.sessionId === sessionId
+            ) || null,
+        resolveActiveTargets: () => sessions,
+        followViewer: async target => {
+            currentViewerTarget = target;
+            return true;
+        },
+        focusSession: async target => {
+            focusOrder.push(`terminal:${target.sessionId}`);
+            if (target.sessionId === 'session-b') {
+                slowBFocusStarted.resolve();
+                await releaseSlowBFocus.promise;
+                return false;
+            }
+            return target.sessionId === 'session-a';
+        },
+        focusViewer: () => focusOrder.push('conversation'),
+    });
+
+    const first = harness.capability.followAdjacentActiveConversation('next');
+    await slowBFocusStarted.promise;
+    const second = harness.capability.followAdjacentActiveConversation('next');
+    releaseSlowBFocus.resolve();
+
+    assert.equal(await first, 'superseded');
+    assert.equal(await second, 'unavailable');
+    assert.deepEqual(focusOrder, [
+        'terminal:session-b',
+        'terminal:session-c',
+        'terminal:session-a',
+        'conversation',
+    ]);
+    assert.equal(currentViewerTarget.sessionId, 'session-a');
+    assert.equal(harness.viewerFocuses, 1);
+    harness.capability.dispose();
+});
+
+test('CONVERSATION-ACTIVE-SESSION-NAVIGATION-COMMANDS-001 refreshes authority after opening the current terminal Conversation', async () => {
+    const sessions = [
+        makeSession({ key: 'codex:session-a', sessionId: 'session-a' }),
+        makeSession({ key: 'codex:session-b', sessionId: 'session-b' }),
+    ];
+    let currentViewerTarget = {
+        projectId: 'project-a',
+        provider: 'codex',
+        sessionId: 'session-a',
+    };
+    let rejectB = false;
+    const focusOrder = [];
+    const harness = createHarness({
+        viewerOpen: true,
+        getFocusedViewerTarget: () => currentViewerTarget,
+        getCurrentViewerTarget: () => currentViewerTarget,
+        resolveTarget: (_projectId, provider, sessionId) =>
+            sessions.find(session =>
+                session.provider === provider && session.sessionId === sessionId
+            ) || null,
+        resolveActiveTargets: () => sessions,
+        openViewer: async target => {
+            currentViewerTarget = target;
+        },
+        followViewer: async target => {
+            currentViewerTarget = target;
+            return true;
+        },
+        focusSession: async target => {
+            focusOrder.push(`terminal:${target.sessionId}`);
+            return target.sessionId !== 'session-b' || !rejectB;
+        },
+    });
+
+    assert.equal(
+        await harness.capability.followAdjacentActiveConversation('next'),
+        'opened'
+    );
+    assert.equal(currentViewerTarget.sessionId, 'session-b');
+
+    assert.equal(await harness.capability.openLatestActiveConversation({
+        projectId: 'project-a',
+        provider: 'codex',
+        sessionId: 'session-a',
+    }), 'opened');
+    rejectB = true;
+
+    assert.equal(
+        await harness.capability.followAdjacentActiveConversation('next'),
+        'unavailable'
+    );
+    assert.equal(currentViewerTarget.sessionId, 'session-a');
+    assert.deepEqual(focusOrder, [
+        'terminal:session-b',
+        'terminal:session-b',
+        'terminal:session-a',
+    ]);
+    harness.capability.dispose();
+});
+
+test('CONVERSATION-ACTIVE-SESSION-NAVIGATION-COMMANDS-001 does not confirm a queued terminal focus skipped after supersession', async () => {
+    const sessions = [
+        makeSession({ key: 'codex:session-a', sessionId: 'session-a' }),
+        makeSession({ key: 'codex:session-b', sessionId: 'session-b' }),
+        makeSession({ key: 'codex:session-c', sessionId: 'session-c' }),
+        makeSession({ key: 'codex:session-d', sessionId: 'session-d' }),
+    ];
+    let currentViewerTarget = {
+        projectId: 'project-a',
+        provider: 'codex',
+        sessionId: 'session-a',
+    };
+    const slowBFocusStarted = deferred();
+    const releaseSlowBFocus = deferred();
+    const focusOrder = [];
+    const harness = createHarness({
+        viewerOpen: true,
+        getFocusedViewerTarget: () => currentViewerTarget,
+        resolveTarget: (_projectId, provider, sessionId) =>
+            sessions.find(session =>
+                session.provider === provider && session.sessionId === sessionId
+            ) || null,
+        resolveActiveTargets: () => sessions,
+        followViewer: async target => {
+            currentViewerTarget = target;
+            return true;
+        },
+        focusSession: async target => {
+            focusOrder.push(`terminal:${target.sessionId}`);
+            if (target.sessionId === 'session-b') {
+                slowBFocusStarted.resolve();
+                await releaseSlowBFocus.promise;
+                return true;
+            }
+            return target.sessionId !== 'session-d';
+        },
+    });
+
+    const first = harness.capability.followAdjacentActiveConversation('next');
+    await slowBFocusStarted.promise;
+    const second = harness.capability.followAdjacentActiveConversation('next');
+    await new Promise(resolve => setImmediate(resolve));
+    const third = harness.capability.followAdjacentActiveConversation('next');
+    releaseSlowBFocus.resolve();
+
+    assert.equal(await first, 'superseded');
+    assert.equal(await second, 'superseded');
+    assert.equal(await third, 'unavailable');
+    assert.deepEqual(focusOrder, [
+        'terminal:session-b',
+        'terminal:session-d',
+        'terminal:session-b',
+    ]);
+    assert.equal(currentViewerTarget.sessionId, 'session-b');
+    assert.equal(harness.viewerFocuses, 1);
+    harness.capability.dispose();
+});
+
+test('CONVERSATION-ACTIVE-SESSION-NAVIGATION-COMMANDS-001 refreshes the rollback snapshot after in-session interaction navigation', async () => {
+    const sessions = [
+        makeSession({ key: 'codex:session-a', sessionId: 'session-a' }),
+        makeSession({ key: 'codex:session-b', sessionId: 'session-b' }),
+        makeSession({ key: 'codex:session-c', sessionId: 'session-c' }),
+    ];
+    let currentViewerTarget = {
+        projectId: 'project-a',
+        provider: 'codex',
+        sessionId: 'session-a',
+    };
+    const harness = createHarness({
+        viewerOpen: true,
+        getFocusedViewerTarget: () => currentViewerTarget,
+        resolveTarget: (_projectId, provider, sessionId) =>
+            sessions.find(session =>
+                session.provider === provider && session.sessionId === sessionId
+            ) || null,
+        resolveActiveTargets: () => sessions,
+        followViewer: async target => {
+            currentViewerTarget = target;
+            return true;
+        },
+        focusSession: async target => target.sessionId !== 'session-c',
+    });
+
+    assert.equal(
+        await harness.capability.followAdjacentActiveConversation('next'),
+        'opened'
+    );
+    const inSessionTarget = {
+        ...currentViewerTarget,
+        interactionId: 'input-new',
+        expectedRevision: 'native-new',
+        subagent: { id: 'subagent-new', label: 'Research' },
+    };
+    currentViewerTarget = inSessionTarget;
+
+    assert.equal(
+        await harness.capability.followAdjacentActiveConversation('next'),
+        'unavailable'
+    );
+    assert.deepEqual(currentViewerTarget, inSessionTarget);
+    assert.deepEqual(
+        harness.followedViewerTargets.at(-1),
+        inSessionTarget
+    );
+    harness.capability.dispose();
+});
+
+test('CONVERSATION-ACTIVE-SESSION-NAVIGATION-COMMANDS-001 restores Conversation focus after an older terminal focus has already started', async () => {
+    const sessions = [
+        makeSession({ key: 'codex:session-a', sessionId: 'session-a' }),
+        makeSession({ key: 'codex:session-b', sessionId: 'session-b' }),
+        makeSession({ key: 'codex:session-c', sessionId: 'session-c' }),
+    ];
+    const currentTarget = {
+        projectId: 'project-a',
+        provider: 'codex',
+        sessionId: 'session-a',
+    };
+    const slowTerminalFocusStarted = deferred();
+    const releaseSlowTerminalFocus = deferred();
+    const focusOrder = [];
+    const harness = createHarness({
+        viewerOpen: true,
+        focusedViewerTarget: currentTarget,
+        resolveTarget: (_projectId, provider, sessionId) =>
+            sessions.find(session =>
+                session.provider === provider && session.sessionId === sessionId
+            ) || null,
+        resolveActiveTargets: () => sessions,
+        focusSession: async target => {
+            focusOrder.push(`terminal:${target.sessionId}:started`);
+            slowTerminalFocusStarted.resolve();
+            await releaseSlowTerminalFocus.promise;
+            focusOrder.push(`terminal:${target.sessionId}:finished`);
+        },
+        focusViewer: () => {
+            focusOrder.push('conversation');
+        },
+    });
+
+    const oldSwitch = harness.viewerOptions.followAdjacentConversation(
+        'next',
+        currentTarget
+    );
+    await slowTerminalFocusStarted.promise;
+    const commandSwitch = harness.capability.followAdjacentActiveConversation(
+        'previous'
+    );
+    await new Promise(resolve => setImmediate(resolve));
+    assert.deepEqual(focusOrder, ['terminal:session-b:started']);
+
+    releaseSlowTerminalFocus.resolve();
+    assert.equal(await oldSwitch, 'superseded');
+    assert.equal(await commandSwitch, 'opened');
+    assert.deepEqual(focusOrder, [
+        'terminal:session-b:started',
+        'terminal:session-b:finished',
+        'terminal:session-c:started',
+        'terminal:session-c:finished',
+        'conversation',
+    ]);
+    assert.equal(harness.viewerFocuses, 1);
+    harness.capability.dispose();
+});
+
+test('CONVERSATION-ACTIVE-SESSION-NAVIGATION-COMMANDS-001 restores Conversation focus when the commanded viewer follow fails', async () => {
+    const sessions = [
+        makeSession({ key: 'codex:session-a', sessionId: 'session-a' }),
+        makeSession({ key: 'codex:session-b', sessionId: 'session-b' }),
+        makeSession({ key: 'codex:session-c', sessionId: 'session-c' }),
+    ];
+    const currentTarget = {
+        projectId: 'project-a',
+        provider: 'codex',
+        sessionId: 'session-a',
+    };
+    const slowTerminalFocusStarted = deferred();
+    const releaseSlowTerminalFocus = deferred();
+    const focusOrder = [];
+    const harness = createHarness({
+        viewerOpen: true,
+        focusedViewerTarget: currentTarget,
+        resolveTarget: (_projectId, provider, sessionId) =>
+            sessions.find(session =>
+                session.provider === provider && session.sessionId === sessionId
+            ) || null,
+        resolveActiveTargets: () => sessions,
+        followViewer: async target => target.sessionId !== 'session-c',
+        focusSession: async target => {
+            focusOrder.push(`terminal:${target.sessionId}`);
+            slowTerminalFocusStarted.resolve();
+            await releaseSlowTerminalFocus.promise;
+        },
+        focusViewer: () => focusOrder.push('conversation'),
+    });
+
+    const oldSwitch = harness.viewerOptions.followAdjacentConversation(
+        'next',
+        currentTarget
+    );
+    await slowTerminalFocusStarted.promise;
+    const commandSwitch = harness.capability.followAdjacentActiveConversation(
+        'previous'
+    );
+    releaseSlowTerminalFocus.resolve();
+
+    assert.equal(await oldSwitch, 'superseded');
+    assert.equal(await commandSwitch, 'closed');
+    assert.deepEqual(focusOrder, ['terminal:session-b', 'conversation']);
+    harness.capability.dispose();
+});
+
+test('CONVERSATION-ACTIVE-SESSION-NAVIGATION-COMMANDS-001 restores Conversation focus when no adjacent session remains', async () => {
+    const sessions = [
+        makeSession({ key: 'codex:session-a', sessionId: 'session-a' }),
+        makeSession({ key: 'codex:session-b', sessionId: 'session-b' }),
+    ];
+    let activeSessions = sessions;
+    const currentTarget = {
+        projectId: 'project-a',
+        provider: 'codex',
+        sessionId: 'session-a',
+    };
+    const slowTerminalFocusStarted = deferred();
+    const releaseSlowTerminalFocus = deferred();
+    const focusOrder = [];
+    const harness = createHarness({
+        viewerOpen: true,
+        focusedViewerTarget: currentTarget,
+        resolveTarget: (_projectId, provider, sessionId) =>
+            sessions.find(session =>
+                session.provider === provider && session.sessionId === sessionId
+            ) || null,
+        resolveActiveTargets: () => activeSessions,
+        focusSession: async target => {
+            focusOrder.push(`terminal:${target.sessionId}`);
+            slowTerminalFocusStarted.resolve();
+            await releaseSlowTerminalFocus.promise;
+        },
+        focusViewer: () => focusOrder.push('conversation'),
+    });
+
+    const oldSwitch = harness.viewerOptions.followAdjacentConversation(
+        'next',
+        currentTarget
+    );
+    await slowTerminalFocusStarted.promise;
+    activeSessions = [sessions[0]];
+    const commandSwitch = harness.capability.followAdjacentActiveConversation(
+        'next'
+    );
+    releaseSlowTerminalFocus.resolve();
+
+    assert.equal(await oldSwitch, 'superseded');
+    assert.equal(await commandSwitch, 'noAdjacentSession');
+    assert.deepEqual(focusOrder, ['terminal:session-b', 'conversation']);
+    harness.capability.dispose();
+});
+
 test('CONVERSATION-FOLLOW-ACTIVE-SESSION-001 skips pending sessions and reports when no adjacent session exists', async () => {
     const sessions = [
         makeSession({ key: 'codex:session-a', sessionId: 'session-a' }),
@@ -715,6 +1213,95 @@ test('CONVERSATION-FOLLOW-ACTIVE-SESSION-001 lets the newest adjacent switch win
     harness.capability.dispose();
 });
 
+test('CONVERSATION-ACTIVE-SESSION-NAVIGATION-COMMANDS-001 prevents a superseded in-viewer switch from restoring the old terminal focus', async () => {
+    const sessions = [
+        makeSession({ key: 'codex:session-a', sessionId: 'session-a' }),
+        makeSession({ key: 'codex:session-b', sessionId: 'session-b' }),
+        makeSession({ key: 'codex:session-c', sessionId: 'session-c' }),
+    ];
+    const slowFollowStarted = deferred();
+    const releaseSlowFollow = deferred();
+    const focusedSessions = [];
+    const harness = createHarness({
+        viewerOpen: true,
+        resolveTarget: (_projectId, provider, sessionId) =>
+            sessions.find(session =>
+                session.provider === provider && session.sessionId === sessionId
+            ) || null,
+        resolveActiveTargets: () => sessions,
+        followViewer: async target => {
+            if (target.sessionId === 'session-b') {
+                slowFollowStarted.resolve();
+                await releaseSlowFollow.promise;
+            }
+            return true;
+        },
+        focusSession: async target => {
+            focusedSessions.push(target);
+        },
+    });
+    const switchSession = harness.viewerOptions.followAdjacentConversation;
+    const currentTarget = {
+        projectId: 'project-a',
+        provider: 'codex',
+        sessionId: 'session-a',
+    };
+
+    const first = switchSession('next', currentTarget);
+    await slowFollowStarted.promise;
+    assert.equal(await switchSession('previous', currentTarget), 'opened');
+    releaseSlowFollow.resolve();
+    assert.equal(await first, 'superseded');
+    assert.deepEqual(
+        focusedSessions.map(target => target.sessionId),
+        ['session-c']
+    );
+    harness.capability.dispose();
+});
+
+test('CONVERSATION-ACTIVE-SESSION-NAVIGATION-COMMANDS-001 serializes terminal focus so the latest Conversation remains authoritative', async () => {
+    const sessions = [
+        makeSession({ key: 'codex:session-a', sessionId: 'session-a' }),
+        makeSession({ key: 'codex:session-b', sessionId: 'session-b' }),
+        makeSession({ key: 'codex:session-c', sessionId: 'session-c' }),
+    ];
+    const slowFocusStarted = deferred();
+    const releaseSlowFocus = deferred();
+    const completedFocuses = [];
+    const harness = createHarness({
+        viewerOpen: true,
+        resolveTarget: (_projectId, provider, sessionId) =>
+            sessions.find(session =>
+                session.provider === provider && session.sessionId === sessionId
+            ) || null,
+        resolveActiveTargets: () => sessions,
+        focusSession: async target => {
+            if (target.sessionId === 'session-b') {
+                slowFocusStarted.resolve();
+                await releaseSlowFocus.promise;
+            }
+            completedFocuses.push(target.sessionId);
+        },
+    });
+    const switchSession = harness.viewerOptions.followAdjacentConversation;
+    const currentTarget = {
+        projectId: 'project-a',
+        provider: 'codex',
+        sessionId: 'session-a',
+    };
+
+    const first = switchSession('next', currentTarget);
+    await slowFocusStarted.promise;
+    const second = switchSession('previous', currentTarget);
+    await new Promise(resolve => setImmediate(resolve));
+    releaseSlowFocus.resolve();
+
+    assert.equal(await first, 'superseded');
+    assert.equal(await second, 'opened');
+    assert.deepEqual(completedFocuses, ['session-b', 'session-c']);
+    harness.capability.dispose();
+});
+
 test('CONVERSATION-FOLLOW-ACTIVE-SESSION-001 fails closed when the active list cannot be resolved', async () => {
     const harness = createHarness({
         viewerOpen: true,
@@ -731,11 +1318,12 @@ test('CONVERSATION-FOLLOW-ACTIVE-SESSION-001 fails closed when the active list c
     harness.capability.dispose();
 });
 
-test('CONVERSATION-FOLLOW-ACTIVE-SESSION-001 keeps the switch settled when terminal sync fails', async () => {
+test('CONVERSATION-ACTIVE-SESSION-NAVIGATION-COMMANDS-001 rolls Conversation and terminal authority back when terminal sync fails', async () => {
     const sessions = [
         makeSession({ key: 'codex:session-a', sessionId: 'session-a' }),
         makeSession({ key: 'codex:session-b', sessionId: 'session-b' }),
     ];
+    const focusedSessions = [];
     const harness = createHarness({
         viewerOpen: true,
         resolveTarget: (_projectId, provider, sessionId) =>
@@ -743,17 +1331,24 @@ test('CONVERSATION-FOLLOW-ACTIVE-SESSION-001 keeps the switch settled when termi
                 session.provider === provider && session.sessionId === sessionId
             ) || null,
         resolveActiveTargets: () => sessions,
-        focusSession: async () => {
-            throw new Error('terminal focus failed');
+        focusSession: async target => {
+            focusedSessions.push(target.sessionId);
+            return target.sessionId === 'session-a';
         },
     });
     assert.equal(await harness.viewerOptions.followAdjacentConversation('next', {
         projectId: 'project-a',
         provider: 'codex',
         sessionId: 'session-a',
-    }), 'opened');
+        interactionId: 'input-a',
+        expectedRevision: 'native-1',
+        displayName: 'Session A',
+        duplicateDisplayName: false,
+    }), 'unavailable');
     assert.deepEqual(harness.followedViewerTargets.map(target => target.sessionId), [
         'session-b',
+        'session-a',
     ]);
+    assert.deepEqual(focusedSessions, ['session-b', 'session-a']);
     harness.capability.dispose();
 });

--- a/tests/integration/dashboard/conversationViewer.test.js
+++ b/tests/integration/dashboard/conversationViewer.test.js
@@ -159,9 +159,11 @@ function fakePanel(options = {}) {
         createCount: 0,
         revealCount: 0,
         revealColumns: [],
+        revealPreserveFocus: [],
         postedMessages: [],
         createArguments: undefined,
         visible: true,
+        active: options.active !== false,
         get viewStateListenerCount() {
             return viewStateListeners.size;
         },
@@ -187,9 +189,10 @@ function fakePanel(options = {}) {
                 ));
             },
         },
-        reveal(column) {
+        reveal(column, preserveFocus) {
             panel.revealCount += 1;
             panel.revealColumns.push(column);
+            panel.revealPreserveFocus.push(preserveFocus);
         },
         onDidDispose(listener) {
             disposeListeners.add(listener);
@@ -206,6 +209,12 @@ function fakePanel(options = {}) {
         },
         async setVisible(visible) {
             panel.visible = visible;
+            await Promise.all(Array.from(viewStateListeners).map(listener =>
+                listener({ webviewPanel: panel })
+            ));
+        },
+        async setActive(active) {
+            panel.active = active;
             await Promise.all(Array.from(viewStateListeners).map(listener =>
                 listener({ webviewPanel: panel })
             ));
@@ -248,6 +257,7 @@ function createViewer(options = {}) {
         openLocalFile: options.openLocalFile,
         insertIntoActiveTerminal: options.insertIntoActiveTerminal,
         followAdjacentConversation: options.followAdjacentConversation,
+        setKeyboardFocus: options.setKeyboardFocus,
         mediaUri: fileName => fakeUri(`file:///extension/media/${fileName}`),
         showThinking: options.showThinking,
         commentStore: options.commentStore,
@@ -446,6 +456,79 @@ test('CONVERSATION-FOLLOW-ACTIVE-SESSION-001 follows another Session only when t
     assert.equal(panel.webview.html.includes('visible-session-b'), true);
     assert.equal(panel.webview.html.includes('visible-session-a'), false);
     assert.deepEqual(panel.revealColumns, [fakeVscode.ViewColumn.Active]);
+});
+
+test('CONVERSATION-ACTIVE-SESSION-NAVIGATION-COMMANDS-001 distinguishes the current target from the focused Conversation target', async () => {
+    const focusStates = [];
+    const { viewer, panel } = createViewer({
+        setKeyboardFocus: focused => focusStates.push(focused),
+    });
+    assert.equal(viewer.getCurrentTarget(), undefined);
+    assert.equal(viewer.getFocusedSessionTarget(), undefined);
+
+    await viewer.open(target('session-a', 'input-a'));
+    assert.deepEqual(viewer.getCurrentTarget(), target('session-a', 'input-a'));
+    assert.equal(viewer.getFocusedTarget(), undefined);
+    await panel.receive({
+        type: 'conversation-viewer-focus',
+        version: 1,
+        focused: true,
+    });
+    assert.deepEqual(viewer.getFocusedTarget(), target('session-a', 'input-a'));
+    assert.deepEqual(viewer.getFocusedSessionTarget(), {
+        projectId: 'project-a',
+        provider: 'codex',
+        sessionId: 'session-a',
+    });
+
+    await panel.receive({
+        type: 'conversation-viewer-focus',
+        version: 1,
+        focused: false,
+    });
+    assert.deepEqual(viewer.getCurrentTarget(), target('session-a', 'input-a'));
+    assert.equal(viewer.getFocusedTarget(), undefined);
+    assert.equal(viewer.getFocusedSessionTarget(), undefined);
+    assert.deepEqual(focusStates, [false, true, false]);
+});
+
+test('CONVERSATION-ACTIVE-SESSION-NAVIGATION-COMMANDS-001 explicitly restores focus to an open Conversation panel', async () => {
+    const { viewer, panel } = createViewer();
+    assert.equal(viewer.focus(), false);
+
+    await viewer.open(target('session-a', 'input-a'));
+    await panel.setActive(false);
+    assert.equal(viewer.focus(), true);
+    assert.deepEqual(panel.revealColumns, [
+        fakeVscode.ViewColumn.Active,
+        fakeVscode.ViewColumn.Active,
+    ]);
+    assert.deepEqual(panel.revealPreserveFocus, [undefined, false]);
+});
+
+test('CONVERSATION-ACTIVE-SESSION-NAVIGATION-COMMANDS-001 reports a superseded in-viewer Session load as not followed', async () => {
+    const slowOutlineStarted = deferred();
+    const releaseSlowOutline = deferred();
+    const { viewer, panel } = createViewer({
+        readOutline: async (_provider, sessionId) => {
+            if (sessionId === 'session-b') {
+                slowOutlineStarted.resolve();
+                await releaseSlowOutline.promise;
+            }
+            return outline(sessionId, [`${sessionId}-input`]);
+        },
+    });
+    await viewer.open(target('session-a', 'session-a-input'));
+
+    const first = viewer.follow(target('session-b', 'session-b-input'));
+    await slowOutlineStarted.promise;
+    assert.equal(
+        await viewer.follow(target('session-c', 'session-c-input')),
+        true
+    );
+    releaseSlowOutline.resolve();
+    assert.equal(await first, false);
+    assert.match(panel.webview.html, /session-c-input/);
 });
 
 test('WEBVIEW-AI-SESSION-SUBAGENT-VIEWER-001 opens a subagent transcript in place and returns to the conversation', async () => {
@@ -1391,11 +1474,7 @@ test('WEBVIEW-AI-SESSION-CONVERSATION-VIEWER-001 routes adjacent session switche
     });
     assert.deepEqual(switches, [{
         direction: 'next',
-        currentTarget: {
-            projectId: 'project-a',
-            provider: 'codex',
-            sessionId: 'session-a',
-        },
+        currentTarget: target('session-a', 'input-1'),
     }]);
 
     for (const message of [

--- a/tests/unit/aiSessions/conversationViewerProtocol.test.js
+++ b/tests/unit/aiSessions/conversationViewerProtocol.test.js
@@ -43,6 +43,14 @@ test('CONVERSATION-PROTOCOL-VALIDATOR-001 accepts every exact version-1 viewer i
         version: 1,
         direction: 'next',
     }, {
+        type: 'conversation-viewer-focus',
+        version: 1,
+        focused: true,
+    }, {
+        type: 'conversation-viewer-focus',
+        version: 1,
+        focused: false,
+    }, {
         type: 'conversation-viewer-locate-comment',
         version: 1,
         ...target,
@@ -162,6 +170,17 @@ test('CONVERSATION-PROTOCOL-VALIDATOR-001 rejects malformed, inherited, and over
             type: 'conversation-viewer-switch-session',
             version: 1,
             direction: 'next',
+            extra: true,
+        },
+        {
+            type: 'conversation-viewer-focus',
+            version: 1,
+            focused: 'yes',
+        },
+        {
+            type: 'conversation-viewer-focus',
+            version: 1,
+            focused: true,
             extra: true,
         },
         {

--- a/tests/unit/tooling/extensionHostSuite.test.js
+++ b/tests/unit/tooling/extensionHostSuite.test.js
@@ -23,6 +23,8 @@ const publicCommands = [
     'agentPivot.migrateSkillsToCentral',
     'agentPivot.changeGlobalSkillsLocation',
     'agentPivot.openCurrentAiSessionConversation',
+    'agentPivot.previousActiveSession',
+    'agentPivot.nextActiveSession',
     'agentPivot.switchToOpenWindow',
 ];
 


### PR DESCRIPTION
## Summary

- add Previous and Next Active Session commands for a focused AI Conversation editor
- synchronize Conversation, terminal/tmux authority, and Active Session card refresh while restoring final keyboard focus to Conversation
- serialize rapid switches and roll back terminal and exact Conversation targets on rejected focus operations
- track real Webview keyboard focus so shortcuts remain disabled in Terminal and other workbench surfaces
- preserve authority across Open Current, interaction, and subagent navigation without treating ordinary card or Quick Pick opens as terminal-authoritative

## Skill harvest

no skill change — the only workflow issue encountered, overlapping build producers clearing `out/`, is already covered by the existing review-fix-commit-loop guidance; focus handling is product behavior.

## Verification

- `npm ci` after rebasing onto the latest `origin/main`
- focused Host, protocol, controller, and command contract tests
- 68 Chromium AI Conversation tests
- final read-only integration review: no Critical or Important findings
- `npm run test:ci:linux`
- changed-line coverage: 94.53% (311/329)
- packaged and installed Agent Pivot 1.0.4 and UI Bridge 1.0.1; installed bytes verified
- `git diff --check`