### PR TITLE
Improve AI Conversation switching across providers

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -4116,6 +4116,11 @@
     "owners": [
       "scripts/run-conversation-performance-checks.js",
       "tests/browser/conversationViewer.test.js",
+      "tests/contract/aiSessions/claudeConversationAdapter.test.js",
+      "tests/contract/aiSessions/codexConversationAdapter.test.js",
+      "tests/contract/aiSessions/kimiConversationAdapter.test.js",
+      "tests/integration/dashboard/conversationOpenLatest.test.js",
+      "tests/integration/dashboard/conversationViewer.test.js",
       "tests/unit/tooling/conversationPerformance.test.js"
     ],
     "evidence": [

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "f0f1b0cf7267cb8fa77e7b14a396953325293fa9",
+        "head": "a7ba853f0e63c5fcad3378556b550aefe1c06a6d",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -168,7 +168,8 @@
             "13ea7824781c9eeaff4b08ee59e26cd86e9ac835",
             "988f8a1edfaeb211f39a2567d5faa698642ebe7f",
             "1ba1462088a1c347854f49d6abb8406816a7b6c7",
-            "8fabc649a7093eba6a51e2509ca598aba8ee1746"
+            "8fabc649a7093eba6a51e2509ca598aba8ee1746",
+            "7a0ebe7f08deb8081174cf0a59188218ae0e5dd3"
         ]
     },
     "capabilities": [
@@ -1293,7 +1294,8 @@
                 "3bf7c016ed82999f21a3ed013167fd9df56a8bb0",
                 "131b4c3b22bfaf2e7807a4a1379366db9d4ebc54",
                 "cc80a21cd6af2a684b60369cc3195bd3d9bf5f49",
-                "f0f1b0cf7267cb8fa77e7b14a396953325293fa9"
+                "f0f1b0cf7267cb8fa77e7b14a396953325293fa9",
+                "a7ba853f0e63c5fcad3378556b550aefe1c06a6d"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",

--- a/media/conversationCommentsScripts.js
+++ b/media/conversationCommentsScripts.js
@@ -1608,14 +1608,39 @@
             }
         }
 
+        function resetSession(target, generation, snapshot) {
+            if (!validInitialComments(snapshot)) {
+                return false;
+            }
+            commentTarget = target;
+            subscriptionGeneration = generation;
+            state.comments = snapshot.comments.map(function (comment) {
+                return Object.assign({}, comment);
+            });
+            state.commentRevision = snapshot.revision;
+            state.pendingCommentRequest = null;
+            state.pendingLocateRequest = null;
+            state.editingComment = null;
+            state.expandedDoneComments.clear();
+            if (!commentUiAvailable) {
+                return true;
+            }
+            closeCommentComposer();
+            renderComments();
+            updateCommentHighlights();
+            return true;
+        }
+
         return Object.freeze({
             applyCommentsResult: applyCommentsResult,
             applyLocateResult: applyLocateResult,
             attach: attach,
+            canResetSession: validInitialComments,
             handleEnterShortcut: handleEnterShortcut,
             handleEscape: handleEscape,
             initializeComments: initializeComments,
             openCount: openCommentCount,
+            resetSession: resetSession,
             sendOpenComments: function () {
                 postCommentOperation('sendComments', {});
             },

--- a/media/conversationOutlineScripts.js
+++ b/media/conversationOutlineScripts.js
@@ -469,6 +469,29 @@
             }
         }
 
+        function resetSession(target, generation, bookmarks) {
+            if (!validBookmarkSnapshot(bookmarks)) {
+                return false;
+            }
+            commentTarget = target;
+            subscriptionGeneration = generation;
+            state.outline = [];
+            state.outlineSelectedInteractionId = '';
+            state.outlineSelectedInput = 0;
+            state.outlineTotalInputs = 0;
+            state.outlinePartial = false;
+            state.bookmarkIds = new Set(bookmarks.interactionIds);
+            state.bookmarkRevision = bookmarks.revision;
+            state.pendingBookmarkRequest = null;
+            if (!sidebarUiAvailable) {
+                return true;
+            }
+            buildOutlineList();
+            renderBookmarkState();
+            filterOutline();
+            return true;
+        }
+
         function restoreQuery(value) {
             if (typeof value !== 'string') return;
             state.outlineQuery = value.slice(0, 4096);
@@ -487,9 +510,11 @@
             applyBookmarksResult: applyBookmarksResult,
             applyOutline: applyOutline,
             attach: attach,
+            canResetSession: validBookmarkSnapshot,
             filter: filterOutline,
             initializeBookmarks: initializeBookmarks,
             query: query,
+            resetSession: resetSession,
             restoreQuery: restoreQuery,
             size: size,
         });

--- a/media/conversationTelemetryScripts.js
+++ b/media/conversationTelemetryScripts.js
@@ -279,8 +279,20 @@
             return true;
         }
 
+        function resetSession(target, generation) {
+            commentTarget = target;
+            subscriptionGeneration = generation;
+            state.latestTelemetryRequestId = 0;
+            telemetryModel.hidden = true;
+            telemetryWorktree.hidden = true;
+            telemetryContext.hidden = true;
+            telemetryLimits.replaceChildren();
+            return true;
+        }
+
         return Object.freeze({
             apply: applyTelemetry,
+            resetSession: resetSession,
         });
     }
 

--- a/media/conversationViewerScripts.js
+++ b/media/conversationViewerScripts.js
@@ -36,6 +36,9 @@
     var conversationDisplayName = document.querySelector(
         '[data-conversation-display-name]'
     );
+    var conversationProvider = document.querySelector(
+        '[data-conversation-provider]'
+    );
     var telemetryRoot = document.querySelector('[data-conversation-telemetry]');
     var telemetryModel = document.querySelector('[data-telemetry-model]');
     var telemetryModelValue = document.querySelector(
@@ -616,6 +619,50 @@
             && typeof value.label === 'string';
     }
 
+    function validPageTarget(value) {
+        if (!value || typeof value !== 'object' || Array.isArray(value)) {
+            return false;
+        }
+        var required = [
+            'projectId', 'provider', 'sessionId', 'interactionId', 'displayName',
+        ];
+        var allowed = new Set(required.concat(['duplicateDisplayName']));
+        return Object.keys(value).every(function (key) {
+            return allowed.has(key);
+        }) && required.every(function (key) {
+            return Object.prototype.hasOwnProperty.call(value, key);
+        })
+            && validCommentTarget({
+                projectId: value.projectId,
+                provider: value.provider,
+                sessionId: value.sessionId,
+            })
+            && typeof value.interactionId === 'string'
+            && value.interactionId.length > 0
+            && typeof value.displayName === 'string'
+            && value.displayName.length <= 640
+            && (value.duplicateDisplayName === undefined
+                || typeof value.duplicateDisplayName === 'boolean');
+    }
+
+    function validCommentSnapshot(value) {
+        return value && typeof value === 'object' && !Array.isArray(value)
+            && Object.keys(value).length === 2
+            && Number.isSafeInteger(value.revision) && value.revision >= 0
+            && Array.isArray(value.comments) && value.comments.length <= 20;
+    }
+
+    function validBookmarkSnapshot(value) {
+        return value && typeof value === 'object' && !Array.isArray(value)
+            && Object.keys(value).length === 2
+            && Number.isSafeInteger(value.revision) && value.revision >= 0
+            && Array.isArray(value.interactionIds)
+            && value.interactionIds.length <= 2000
+            && value.interactionIds.every(function (id) {
+                return typeof id === 'string' && id.length > 0;
+            });
+    }
+
     function validPage(message) {
         if (!message || typeof message !== 'object' || Array.isArray(message)) {
             return false;
@@ -627,7 +674,7 @@
         ];
         var allowedKeys = new Set(requiredKeys.concat([
             'previousCursor', 'nextCursor', 'subagents', 'activeSubagent',
-            'displayName',
+            'displayName', 'target', 'comments', 'bookmarks',
         ]));
         if (Object.keys(message).some(function (key) {
             return !allowedKeys.has(key);
@@ -663,7 +710,75 @@
             && (message.displayName === undefined
                 || (typeof message.displayName === 'string'
                     && message.displayName.length <= 640))
+            && (message.target === undefined
+                || validPageTarget(message.target))
+            && (message.comments === undefined
+                || validCommentSnapshot(message.comments))
+            && (message.bookmarks === undefined
+                || validBookmarkSnapshot(message.bookmarks))
             && typeof message.stale === 'boolean';
+    }
+
+    function providerLabel(provider) {
+        if (provider === 'kimi') return 'Kimi';
+        if (provider === 'claude') return 'Claude';
+        return 'Codex';
+    }
+
+    function applySessionGeneration(message) {
+        if (message.subscriptionGeneration === state.subscriptionGeneration) {
+            return true;
+        }
+        if (message.subscriptionGeneration < state.subscriptionGeneration
+            || !validPageTarget(message.target)
+            || !validCommentSnapshot(message.comments)
+            || !validBookmarkSnapshot(message.bookmarks)
+            || !outlineController.canResetSession(message.bookmarks)
+            || !commentsController.canResetSession(message.comments)) {
+            return false;
+        }
+        var nextCommentTarget = {
+            projectId: message.target.projectId,
+            provider: message.target.provider,
+            sessionId: message.target.sessionId,
+        };
+        if (!outlineController.resetSession(
+            nextCommentTarget,
+            message.subscriptionGeneration,
+            message.bookmarks
+        ) || !commentsController.resetSession(
+            nextCommentTarget,
+            message.subscriptionGeneration,
+            message.comments
+        )) {
+            return false;
+        }
+        telemetryController.resetSession(
+            nextCommentTarget,
+            message.subscriptionGeneration
+        );
+        commentTarget = nextCommentTarget;
+        restoreTarget = {
+            projectId: message.target.projectId,
+            provider: message.target.provider,
+            sessionId: message.target.sessionId,
+            interactionId: message.target.interactionId,
+        };
+        state.subscriptionGeneration = message.subscriptionGeneration;
+        state.latestRequestId = 0;
+        state.initialized = false;
+        state.messageIds = [];
+        state.messageSignatures = new Map();
+        document.body.setAttribute(
+            'data-subscription-generation',
+            String(message.subscriptionGeneration)
+        );
+        if (conversationProvider) {
+            conversationProvider.textContent = providerLabel(
+                message.target.provider
+            );
+        }
+        return true;
     }
 
 
@@ -691,7 +806,7 @@
 
     function applyPage(message) {
         if (!validPage(message)
-            || message.subscriptionGeneration !== state.subscriptionGeneration
+            || !applySessionGeneration(message)
             || message.requestId <= state.latestRequestId) {
             return;
         }
@@ -756,8 +871,12 @@
         }
         commentsController.updateHighlights();
         if (conversationDisplayName
-            && typeof message.displayName === 'string') {
-            conversationDisplayName.textContent = message.displayName;
+            && (typeof message.displayName === 'string'
+                || validPageTarget(message.target))) {
+            conversationDisplayName.textContent = typeof message.displayName
+                === 'string'
+                ? message.displayName
+                : message.target.displayName;
         }
         updatePosition(message);
         var latestInteraction = message.outline[message.outline.length - 1];

--- a/scripts/run-ai-session-tmux-checks.js
+++ b/scripts/run-ai-session-tmux-checks.js
@@ -7943,9 +7943,17 @@ async function runRuntimeCoordinatorChecks() {
             getConfiguration: () => ({ mode: 'tmux', tmuxLayout: 'session', tmuxPath: 'tmux' }),
             chooseTmuxFallback: async () => 'cancel',
         });
-        await guardedActionCoordinator[operation]({
+        const guardedAction = guardedActionCoordinator[operation]({
             provider: 'codex', workspaceScopeIdentity: 'pk', workspaceNavigationIdentity: 'nav-1', workspaceRootHostPaths: ['/work'], cwd: '/work', sessionId: `guarded-${operation}`,
         });
+        if (operation === 'focus') {
+            await assert.rejects(
+                guardedAction,
+                error => error instanceof runtimeTypesModule.AiSessionRuntimeTargetChangedError
+            );
+        } else {
+            await guardedAction;
+        }
         assert.deepStrictEqual(guardedTmux[`${operation}Calls`], [],
             `${operation} must not act on a runtime replaced by a fresh collision`);
         assert.deepStrictEqual(guardedTmux.refreshCalls, [true]);
@@ -8494,7 +8502,10 @@ async function runRuntimeCoordinatorChecks() {
         getConfiguration: () => ({ mode: 'tmux', tmuxLayout: 'project', tmuxPath: 'tmux' }),
         chooseTmuxFallback: async () => 'cancel',
     });
-    await fastPathMissingCoordinator.focus(fakeResumeRequest('missing-after-refresh').identity);
+    await assert.rejects(
+        fastPathMissingCoordinator.focus(fakeResumeRequest('missing-after-refresh').identity),
+        error => error instanceof runtimeTypesModule.AiSessionRuntimeTargetChangedError
+    );
     assert.strictEqual(fastPathMissingTmux.focusAttempts.length, 1,
         'a target removed by reconciliation must not be retried');
     assert.strictEqual(fastPathMissingTmux.focusCalls.length, 0);
@@ -8512,7 +8523,10 @@ async function runRuntimeCoordinatorChecks() {
         getConfiguration: () => ({ mode: 'tmux', tmuxLayout: 'project', tmuxPath: 'tmux' }),
         chooseTmuxFallback: async () => 'cancel',
     });
-    await fastPathDuplicateCoordinator.focus(fakeResumeRequest('duplicate-after-refresh').identity);
+    await assert.rejects(
+        fastPathDuplicateCoordinator.focus(fakeResumeRequest('duplicate-after-refresh').identity),
+        error => error instanceof runtimeTypesModule.AiSessionRuntimeTargetChangedError
+    );
     assert.strictEqual(fastPathDuplicateTmux.focusAttempts.length, 1,
         'a cross-backend duplicate discovered during reconciliation must not be focused');
     assert.strictEqual(fastPathDuplicateTmux.focusCalls.length, 0);
@@ -8529,7 +8543,10 @@ async function runRuntimeCoordinatorChecks() {
         getConfiguration: () => ({ mode: 'tmux', tmuxLayout: 'project', tmuxPath: 'tmux' }),
         chooseTmuxFallback: async () => 'cancel',
     });
-    await fastPathRepeatedCoordinator.focus(fakeResumeRequest('repeated-change').identity);
+    await assert.rejects(
+        fastPathRepeatedCoordinator.focus(fakeResumeRequest('repeated-change').identity),
+        error => error instanceof runtimeTypesModule.AiSessionRuntimeTargetChangedError
+    );
     assert.strictEqual(fastPathRepeatedTmux.focusAttempts.length, 2,
         'a second target change must stop without an unbounded retry loop');
     assert.strictEqual(fastPathRepeatedTmux.focusCalls.length, 0);
@@ -8581,7 +8598,10 @@ async function runRuntimeCoordinatorChecks() {
         identity: { provider: 'codex', workspaceScopeIdentity: 'pk', workspaceNavigationIdentity: 'nav-1', workspaceRootHostPaths: ['/work'], cwd: '/work', pendingId: 'pending-conflict' },
         state: 'pending', createdAt: '2026-07-18T10:00:00.000Z', excludedSessionIds: [],
     });
-    await routed.focus({ provider: 'codex', workspaceScopeIdentity: 'pk', workspaceNavigationIdentity: 'nav-1', workspaceRootHostPaths: ['/work'], cwd: '/work', pendingId: 'pending-conflict' });
+    await assert.rejects(
+        routed.focus({ provider: 'codex', workspaceScopeIdentity: 'pk', workspaceNavigationIdentity: 'nav-1', workspaceRootHostPaths: ['/work'], cwd: '/work', pendingId: 'pending-conflict' }),
+        error => error instanceof runtimeTypesModule.AiSessionRuntimeTargetChangedError
+    );
     assert.strictEqual(routedDirect.focusCalls.length, 0);
     assert.strictEqual(routedTmux.focusCalls.length, 2);
     const promotedPending = await routed.promotePending(

--- a/src/aiSessions/conversation/claudeAdapter.ts
+++ b/src/aiSessions/conversation/claudeAdapter.ts
@@ -36,6 +36,7 @@ import {
     ConversationPage,
     ConversationPageRequest,
     ConversationProviderAdapter,
+    ConversationSnapshot,
     ConversationSubagentEntry,
     ConversationTelemetry,
 } from './types';
@@ -248,6 +249,37 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
 
     constructor(private readonly options: ClaudeConversationAdapterOptions) {
         this.cache = new ConversationIndexCache(options.now);
+    }
+
+    async readSnapshot(
+        sessionId: string,
+        preferredInteractionId?: string,
+        signal?: ConversationAbortSignal
+    ): Promise<ConversationSnapshot> {
+        const loaded = await this.load(sessionId, signal);
+        const outline = buildConversationOutline(
+            'claude',
+            sessionId,
+            loaded.sourceRevision,
+            loaded.interactions,
+            loaded.partial
+        );
+        const selected = outline.interactions.find(interaction =>
+            interaction.id === preferredInteractionId
+        ) || outline.interactions[outline.interactions.length - 1];
+        return {
+            outline,
+            ...(selected ? {
+                page: buildConversationPage(loaded.interactions, {
+                    provider: 'claude',
+                    sessionId,
+                    anchorInteractionId: selected.id,
+                    direction: 'around',
+                    expectedRevision: loaded.sourceRevision,
+                    limit: CONVERSATION_LIMITS.maxPageInteractions,
+                }, loaded.sourceRevision),
+            } : {}),
+        };
     }
 
     async readOutline(

--- a/src/aiSessions/conversation/codexAdapter.ts
+++ b/src/aiSessions/conversation/codexAdapter.ts
@@ -31,6 +31,7 @@ import {
     ConversationPageRequest,
     ConversationProviderAdapter,
     ConversationResponseState,
+    ConversationSnapshot,
     ConversationSubagentEntry,
     ConversationTelemetry,
 } from './types';
@@ -431,6 +432,37 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
         this.notificationWatch = options.client.watchNotifications?.(
             (method, params) => this.acceptNotification(method, params)
         );
+    }
+
+    async readSnapshot(
+        sessionId: string,
+        preferredInteractionId?: string,
+        signal?: ConversationAbortSignal
+    ): Promise<ConversationSnapshot> {
+        const loaded = await this.load(sessionId, signal);
+        const outline = buildConversationOutline(
+            'codex',
+            sessionId,
+            loaded.sourceRevision,
+            loaded.interactions,
+            false
+        );
+        const selected = outline.interactions.find(interaction =>
+            interaction.id === preferredInteractionId
+        ) || outline.interactions[outline.interactions.length - 1];
+        return {
+            outline,
+            ...(selected ? {
+                page: buildConversationPage(loaded.interactions, {
+                    provider: 'codex',
+                    sessionId,
+                    anchorInteractionId: selected.id,
+                    direction: 'around',
+                    expectedRevision: loaded.sourceRevision,
+                    limit: CONVERSATION_LIMITS.maxPageInteractions,
+                }, loaded.sourceRevision),
+            } : {}),
+        };
     }
 
     async readOutline(

--- a/src/aiSessions/conversation/composition.ts
+++ b/src/aiSessions/conversation/composition.ts
@@ -36,6 +36,7 @@ import {
 import {
     ConversationError,
     ConversationProviderAdapter,
+    ConversationSnapshot,
     SanitizedConversationDiagnostic,
 } from './types';
 import {
@@ -123,6 +124,9 @@ export interface ConversationCapabilityOptions {
         prompt: string
     ) => PromiseLike<void> | Promise<void>;
     focusSession?: (
+        target: ConversationSessionOpenTarget
+    ) => boolean | void | PromiseLike<boolean | void>;
+    syncSession?: (
         target: ConversationSessionOpenTarget
     ) => boolean | void | PromiseLike<boolean | void>;
     commentStore?: ConversationCommentStore;
@@ -285,7 +289,9 @@ function createAvailableConversationCapability(
         isCurrent: () => boolean
     ): Promise<boolean> => queueFocus(
         async () => {
-            const focused = await options.focusSession?.(target);
+            const focused = await (options.syncSession || options.focusSession)?.(
+                target
+            );
             if (focused === false) {
                 throw new Error('AI session terminal focus was rejected');
             }
@@ -294,6 +300,9 @@ function createAvailableConversationCapability(
     );
     const viewer = ownership.own(factories.createViewer({
         createPanel: options.createPanel,
+        readSnapshot: typeof coordinator.readSnapshot === 'function'
+            ? coordinator.readSnapshot.bind(coordinator)
+            : undefined,
         readOutline: coordinator.readOutline.bind(coordinator),
         readPage: coordinator.readPage.bind(coordinator),
         readSubagents: typeof coordinator.readSubagents === 'function'
@@ -393,7 +402,10 @@ function createAvailableConversationCapability(
             if (!viewer.isOpen()) {
                 return 'closed';
             }
-            const followed = await viewer.follow(resolution.viewerTarget);
+            const followed = await viewer.follow(
+                resolution.viewerTarget,
+                resolution.snapshot
+            );
             if (followed) {
                 const currentTarget = viewer.getCurrentTarget();
                 terminalAuthority.confirmedTarget =
@@ -470,7 +482,11 @@ function createAvailableConversationCapability(
                 return;
             }
             try {
-                await viewer.restore(panel, resolution.viewerTarget);
+                await viewer.restore(
+                    panel,
+                    resolution.viewerTarget,
+                    resolution.snapshot
+                );
             } catch (_error) {
                 panel.dispose();
             }
@@ -616,13 +632,14 @@ async function openLatestConversation(
     if (!resolution.viewerTarget) {
         return resolution.result;
     }
-    await viewer.open(resolution.viewerTarget);
+    await viewer.open(resolution.viewerTarget, resolution.snapshot);
     return 'opened';
 }
 
 interface LatestConversationTargetResolution {
     result: OpenLatestConversationResult;
     viewerTarget?: ConversationViewerTarget;
+    snapshot?: ConversationSnapshot;
 }
 
 async function followAdjacentConversation(
@@ -698,7 +715,10 @@ async function followAdjacentConversation(
     if (!viewer.isOpen()) {
         return 'closed';
     }
-    const followed = await viewer.follow(resolution.viewerTarget);
+    const followed = await viewer.follow(
+        resolution.viewerTarget,
+        resolution.snapshot
+    );
     if (!isCurrent()) {
         return 'superseded';
     }
@@ -815,18 +835,28 @@ async function resolveLatestConversationTarget(
             authoritativeSubagent.id
         );
     }
-    let outline;
+    let snapshot: ConversationSnapshot;
     try {
-        outline = await coordinator.readOutline(
-            target.provider,
-            effectiveSessionId
-        );
+        snapshot = typeof coordinator.readSnapshot === 'function'
+            ? await coordinator.readSnapshot(
+                target.provider,
+                effectiveSessionId,
+                preferredInteractionId
+            )
+            : {
+                outline: await coordinator.readOutline(
+                    target.provider,
+                    effectiveSessionId
+                ),
+            };
     } catch (_error) {
         return { result: 'unavailable' };
     }
-    const selected = outline.interactions.find(interaction =>
+    const selected = snapshot.outline.interactions.find(interaction =>
         interaction.id === preferredInteractionId
-    ) || outline.interactions[outline.interactions.length - 1];
+    ) || snapshot.outline.interactions[
+        snapshot.outline.interactions.length - 1
+    ];
     if (!selected) {
         return { result: 'empty' };
     }
@@ -842,13 +872,14 @@ async function resolveLatestConversationTarget(
             provider: target.provider,
             sessionId: target.sessionId,
             interactionId: selected.id,
-            expectedRevision: outline.sourceRevision,
+            expectedRevision: snapshot.outline.sourceRevision,
             displayName: displayMetadata.conversationDisplayName
                 || (trimmedName || `${target.provider} conversation`),
             duplicateDisplayName:
                 displayMetadata.duplicateConversationDisplayName === true,
             ...(subagent ? { subagent } : {}),
         },
+        snapshot,
     };
 }
 

--- a/src/aiSessions/conversation/coordinator.ts
+++ b/src/aiSessions/conversation/coordinator.ts
@@ -18,6 +18,7 @@ import {
     ConversationPage,
     ConversationPageRequest,
     ConversationProviderAdapter,
+    ConversationSnapshot,
     ConversationSubagentEntry,
     ConversationTelemetry,
     SanitizedConversationDiagnostic,
@@ -114,28 +115,66 @@ export class ConversationCoordinator implements AiSessionDisposable {
                 getAiSessionKey(provider, sessionId),
                 outline.sourceRevision
             );
-            const key = getAiSessionKey(provider, sessionId);
-            return {
+            return this.projectOutline(
+                outline,
                 provider,
                 sessionId,
-                sourceRevision: revision.token,
-                interactions: outline.interactions.map((interaction, index) => ({
-                    id: interaction.id,
-                    providerTurnId: interaction.providerTurnId,
-                    timestamp: interaction.timestamp,
-                    userPreview: interaction.userPreview,
-                    userGraphemeCount: interaction.userGraphemeCount,
-                    responseState: applyActiveLifecycleToResponseState(
-                        applyStoppedLifecycleToResponseState(
-                            interaction.responseState,
-                            this.stoppedSessions.has(key)
-                        ),
-                        this.activeSessions.has(key),
-                        index === outline.interactions.length - 1
+                revision.token
+            );
+        } catch (error) {
+            throw this.toSafeError(provider, error);
+        }
+    }
+
+    async readSnapshot(
+        provider: AiSessionProviderId,
+        sessionId: string,
+        preferredInteractionId?: string,
+        signal?: ConversationAbortSignal
+    ): Promise<ConversationSnapshot> {
+        const adapter = this.getAdapter(provider);
+        const key = getAiSessionKey(provider, sessionId);
+        try {
+            let snapshot: ConversationSnapshot;
+            if (adapter.readSnapshot) {
+                snapshot = await adapter.readSnapshot(
+                    sessionId,
+                    preferredInteractionId,
+                    signal
+                );
+            } else {
+                const outline = await adapter.readOutline(sessionId, signal);
+                snapshot = { outline };
+            }
+            throwIfAborted(signal);
+            this.validateOutline(snapshot.outline, provider, sessionId);
+            if (snapshot.page) {
+                this.validatePage(snapshot.page, provider, sessionId);
+                if (snapshot.page.sourceRevision
+                    !== snapshot.outline.sourceRevision) {
+                    throw new ConversationError('staleRevision');
+                }
+            }
+            const observed = this.observeRevision(
+                key,
+                snapshot.outline.sourceRevision
+            );
+            return {
+                outline: this.projectOutline(
+                    snapshot.outline,
+                    provider,
+                    sessionId,
+                    observed.token
+                ),
+                ...(snapshot.page ? {
+                    page: this.projectPage(
+                        snapshot.page,
+                        provider,
+                        sessionId,
+                        key,
+                        observed
                     ),
-                })),
-                totalInteractions: outline.totalInteractions,
-                partial: outline.partial,
+                } : {}),
             };
         } catch (error) {
             throw this.toSafeError(provider, error);
@@ -207,79 +246,13 @@ export class ConversationCoordinator implements AiSessionDisposable {
             if (revision && observed.nativeRevision !== revision.nativeRevision) {
                 throw new ConversationError('staleRevision');
             }
-            const stopped = this.stoppedSessions.has(key);
-            const active = this.activeSessions.has(key);
-            const activeInferredInteractionId = active
-                && request.provider !== 'codex'
-                && page.isEnd
-                ? page.interactionStates[page.interactionStates.length - 1]
-                    .interactionId
-                : undefined;
-            const result: ConversationPage = {
-                provider: request.provider,
-                sessionId: request.sessionId,
-                sourceRevision: observed.token,
-                anchorInteractionId: page.anchorInteractionId,
-                messages: page.messages.map(message => ({
-                    id: message.id,
-                    interactionId: message.interactionId,
-                    role: message.role === 'assistant'
-                        && message.interactionId === activeInferredInteractionId
-                        ? 'progress'
-                        : message.role,
-                    timestamp: message.timestamp,
-                    markdown: message.markdown,
-                    ...(message.tool
-                        ? {
-                            tool: {
-                                name: message.tool.name,
-                                summary: message.tool.summary,
-                                ...(message.tool.detail !== undefined
-                                    ? { detail: message.tool.detail }
-                                    : {}),
-                            },
-                        }
-                        : {}),
-                    ...(message.thinking
-                        ? { thinking: { text: message.thinking.text } }
-                        : {}),
-                })),
-                interactionStates: page.interactionStates.map((state, index) => ({
-                    interactionId: state.interactionId,
-                    responseState: applyActiveLifecycleToResponseState(
-                        applyStoppedLifecycleToResponseState(
-                            state.responseState,
-                            stopped
-                        ),
-                        active,
-                        page.isEnd && index === page.interactionStates.length - 1
-                    ),
-                })),
-                previousCursor: page.previousCursor === undefined
-                    ? undefined
-                    : this.storeCursor(
-                        key,
-                        observed.token,
-                        page.interactionStates[0].interactionId,
-                        'before'
-                    ),
-                nextCursor: page.nextCursor === undefined
-                    ? undefined
-                    : this.storeCursor(
-                        key,
-                        observed.token,
-                        page.interactionStates[page.interactionStates.length - 1]
-                            .interactionId,
-                        'after'
-                    ),
-                isStart: page.isStart,
-                isEnd: page.isEnd,
-            };
-            if (Buffer.byteLength(JSON.stringify(result), 'utf8')
-                > CONVERSATION_LIMITS.maxPageBytes) {
-                throw new ConversationError('tooLarge');
-            }
-            return result;
+            return this.projectPage(
+                page,
+                request.provider,
+                request.sessionId,
+                key,
+                observed
+            );
         } catch (error) {
             throw this.toSafeError(request.provider, error);
         }
@@ -400,6 +373,119 @@ export class ConversationCoordinator implements AiSessionDisposable {
             throw new ConversationError('unavailable');
         }
         return adapter;
+    }
+
+    private projectOutline(
+        outline: ConversationOutline,
+        provider: AiSessionProviderId,
+        sessionId: string,
+        publicRevision: string
+    ): ConversationOutline {
+        const key = getAiSessionKey(provider, sessionId);
+        return {
+            provider,
+            sessionId,
+            sourceRevision: publicRevision,
+            interactions: outline.interactions.map((interaction, index) => ({
+                id: interaction.id,
+                providerTurnId: interaction.providerTurnId,
+                timestamp: interaction.timestamp,
+                userPreview: interaction.userPreview,
+                userGraphemeCount: interaction.userGraphemeCount,
+                responseState: applyActiveLifecycleToResponseState(
+                    applyStoppedLifecycleToResponseState(
+                        interaction.responseState,
+                        this.stoppedSessions.has(key)
+                    ),
+                    this.activeSessions.has(key),
+                    index === outline.interactions.length - 1
+                ),
+            })),
+            totalInteractions: outline.totalInteractions,
+            partial: outline.partial,
+        };
+    }
+
+    private projectPage(
+        page: ConversationPage,
+        provider: AiSessionProviderId,
+        sessionId: string,
+        key: string,
+        observed: PublicRevision
+    ): ConversationPage {
+        const stopped = this.stoppedSessions.has(key);
+        const active = this.activeSessions.has(key);
+        const activeInferredInteractionId = active
+            && provider !== 'codex'
+            && page.isEnd
+            ? page.interactionStates[page.interactionStates.length - 1]
+                .interactionId
+            : undefined;
+        const result: ConversationPage = {
+            provider,
+            sessionId,
+            sourceRevision: observed.token,
+            anchorInteractionId: page.anchorInteractionId,
+            messages: page.messages.map(message => ({
+                id: message.id,
+                interactionId: message.interactionId,
+                role: message.role === 'assistant'
+                    && message.interactionId === activeInferredInteractionId
+                    ? 'progress'
+                    : message.role,
+                timestamp: message.timestamp,
+                markdown: message.markdown,
+                ...(message.tool
+                    ? {
+                        tool: {
+                            name: message.tool.name,
+                            summary: message.tool.summary,
+                            ...(message.tool.detail !== undefined
+                                ? { detail: message.tool.detail }
+                                : {}),
+                        },
+                    }
+                    : {}),
+                ...(message.thinking
+                    ? { thinking: { text: message.thinking.text } }
+                    : {}),
+            })),
+            interactionStates: page.interactionStates.map((state, index) => ({
+                interactionId: state.interactionId,
+                responseState: applyActiveLifecycleToResponseState(
+                    applyStoppedLifecycleToResponseState(
+                        state.responseState,
+                        stopped
+                    ),
+                    active,
+                    page.isEnd && index === page.interactionStates.length - 1
+                ),
+            })),
+            previousCursor: page.previousCursor === undefined
+                ? undefined
+                : this.storeCursor(
+                    key,
+                    observed.token,
+                    page.interactionStates[0].interactionId,
+                    'before'
+                ),
+            nextCursor: page.nextCursor === undefined
+                ? undefined
+                : this.storeCursor(
+                    key,
+                    observed.token,
+                    page.interactionStates[page.interactionStates.length - 1]
+                        .interactionId,
+                    'after'
+                ),
+            isStart: page.isStart,
+            isEnd: page.isEnd,
+        };
+        if (Buffer.byteLength(JSON.stringify(result), 'utf8')
+            > CONVERSATION_LIMITS.maxPageBytes) {
+            throw new ConversationError('tooLarge');
+        }
+        return result;
     }
 
     private observeRevision(key: string, nativeRevision: string): PublicRevision {

--- a/src/aiSessions/conversation/kimiAdapter.ts
+++ b/src/aiSessions/conversation/kimiAdapter.ts
@@ -39,6 +39,7 @@ import {
     ConversationPageRequest,
     ConversationProviderAdapter,
     ConversationResponseState,
+    ConversationSnapshot,
     ConversationSubagentEntry,
     ConversationTelemetry,
 } from './types';
@@ -177,6 +178,37 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
 
     constructor(private readonly options: KimiConversationAdapterOptions) {
         this.cache = new ConversationIndexCache(options.now);
+    }
+
+    async readSnapshot(
+        sessionId: string,
+        preferredInteractionId?: string,
+        signal?: ConversationAbortSignal
+    ): Promise<ConversationSnapshot> {
+        const loaded = await this.load(sessionId, signal);
+        const outline = buildConversationOutline(
+            'kimi',
+            sessionId,
+            loaded.sourceRevision,
+            loaded.interactions,
+            loaded.partial
+        );
+        const selected = outline.interactions.find(interaction =>
+            interaction.id === preferredInteractionId
+        ) || outline.interactions[outline.interactions.length - 1];
+        return {
+            outline,
+            ...(selected ? {
+                page: buildConversationPage(loaded.interactions, {
+                    provider: 'kimi',
+                    sessionId,
+                    anchorInteractionId: selected.id,
+                    direction: 'around',
+                    expectedRevision: loaded.sourceRevision,
+                    limit: CONVERSATION_LIMITS.maxPageInteractions,
+                }, loaded.sourceRevision),
+            } : {}),
+        };
     }
 
     async readOutline(

--- a/src/aiSessions/conversation/types.ts
+++ b/src/aiSessions/conversation/types.ts
@@ -108,6 +108,11 @@ export interface ConversationPage {
     isEnd: boolean;
 }
 
+export interface ConversationSnapshot {
+    outline: ConversationOutline;
+    page?: ConversationPage;
+}
+
 export interface ConversationTelemetryWorktree {
     branch: string;
     worktreeRoot: string;
@@ -250,6 +255,11 @@ export interface ConversationSubagentEntry {
 }
 
 export interface ConversationProviderAdapter extends AiSessionDisposable {
+    readSnapshot?(
+        sessionId: string,
+        preferredInteractionId?: string,
+        signal?: ConversationAbortSignal
+    ): Promise<ConversationSnapshot>;
     readOutline(
         sessionId: string,
         signal?: ConversationAbortSignal

--- a/src/aiSessions/conversation/viewer.ts
+++ b/src/aiSessions/conversation/viewer.ts
@@ -5,8 +5,14 @@ import * as vscode from 'vscode';
 import { AGENT_PIVOT_CONVERSATION_VIEW_TYPE } from '../../constants';
 import type { AiSessionProviderId } from '../../models';
 import type { AiSessionDisposable } from '../types';
-import type { ConversationCommentStore } from './commentStore';
-import type { ConversationBookmarkStore } from './bookmarkStore';
+import type {
+    ConversationCommentSnapshot,
+    ConversationCommentStore,
+} from './commentStore';
+import type {
+    ConversationBookmarkSnapshot,
+    ConversationBookmarkStore,
+} from './bookmarkStore';
 import { ConversationCommentController } from './commentController';
 import { ConversationBookmarkController } from './bookmarkController';
 import { ConversationTelemetryController } from './conversationTelemetryController';
@@ -37,6 +43,7 @@ import {
     ConversationOutline,
     ConversationPage,
     ConversationPageRequest,
+    ConversationSnapshot,
     ConversationSubagentEntry,
     ConversationTelemetry,
 } from './types';
@@ -44,6 +51,12 @@ import { encodeSubagentSessionId } from './subagentSessions';
 
 export interface ConversationViewerOptions {
     createPanel: typeof vscode.window.createWebviewPanel;
+    readSnapshot?: (
+        provider: AiSessionProviderId,
+        sessionId: string,
+        preferredInteractionId: string | undefined,
+        signal: ConversationAbortSignal
+    ) => Promise<ConversationSnapshot>;
     readOutline: (
         provider: AiSessionProviderId,
         sessionId: string,
@@ -113,12 +126,19 @@ export interface ConversationViewerApi extends AiSessionDisposable {
         ConversationViewerTarget,
         'projectId' | 'provider' | 'sessionId'
     > | undefined;
-    open(target: ConversationViewerTarget): Promise<void>;
+    open(
+        target: ConversationViewerTarget,
+        snapshot?: ConversationSnapshot
+    ): Promise<void>;
     restore(
         panel: vscode.WebviewPanel,
-        target: ConversationViewerTarget
+        target: ConversationViewerTarget,
+        snapshot?: ConversationSnapshot
     ): Promise<void>;
-    follow(target: ConversationViewerTarget): Promise<boolean>;
+    follow(
+        target: ConversationViewerTarget,
+        snapshot?: ConversationSnapshot
+    ): Promise<boolean>;
     rebindSession(
         previous: Pick<ConversationViewerTarget, 'projectId' | 'provider' | 'sessionId'>,
         next: Pick<ConversationViewerTarget, 'projectId' | 'provider' | 'sessionId'>
@@ -168,6 +188,13 @@ export interface ConversationViewerPageMessage {
     displayName: string;
     subagents: ConversationSubagentEntry[];
     activeSubagent: { id: string; label: string } | null;
+    target: Pick<
+        ConversationViewerTarget,
+        'projectId' | 'provider' | 'sessionId' | 'interactionId'
+            | 'displayName' | 'duplicateDisplayName'
+    >;
+    comments: ConversationCommentSnapshot;
+    bookmarks: ConversationBookmarkSnapshot;
 }
 
 export class ConversationViewer implements ConversationViewerApi {
@@ -186,7 +213,6 @@ export class ConversationViewer implements ConversationViewerApi {
     private currentRequestId = 0;
     private stale = false;
     private latestPublication?: ConversationViewerPageMessage;
-    private panelWasVisible = false;
     private suspended = false;
     private rebindGeneration = 0;
     private authoritativeLoadInFlight?: Promise<boolean>;
@@ -276,13 +302,17 @@ export class ConversationViewer implements ConversationViewerApi {
         };
     }
 
-    async open(target: ConversationViewerTarget): Promise<void> {
-        await this.loadTarget(target, true);
+    async open(
+        target: ConversationViewerTarget,
+        snapshot?: ConversationSnapshot
+    ): Promise<void> {
+        await this.loadTarget(target, true, snapshot);
     }
 
     async restore(
         panel: vscode.WebviewPanel,
-        target: ConversationViewerTarget
+        target: ConversationViewerTarget,
+        snapshot?: ConversationSnapshot
     ): Promise<void> {
         if (this.panel && this.panel !== panel) {
             panel.dispose();
@@ -290,10 +320,13 @@ export class ConversationViewer implements ConversationViewerApi {
         }
         panel.webview.options = this.webviewOptions();
         this.attachPanel(panel);
-        await this.loadTarget(target, false);
+        await this.loadTarget(target, false, snapshot, true);
     }
 
-    async follow(target: ConversationViewerTarget): Promise<boolean> {
+    async follow(
+        target: ConversationViewerTarget,
+        snapshot?: ConversationSnapshot
+    ): Promise<boolean> {
         if (!this.panel) {
             return false;
         }
@@ -305,7 +338,7 @@ export class ConversationViewer implements ConversationViewerApi {
             && this.target.sessionId === target.sessionId) {
             return true;
         }
-        return this.loadTarget(target, false);
+        return this.loadTarget(target, false, snapshot);
     }
 
     async rebindSession(
@@ -324,13 +357,24 @@ export class ConversationViewer implements ConversationViewerApi {
         }
         const rebindGeneration = ++this.rebindGeneration;
         let outline: ConversationOutline;
+        let snapshot: ConversationSnapshot | undefined;
         try {
             const rebindRead = new ConversationAbortController();
-            outline = await this.options.readOutline(
-                next.provider,
-                next.sessionId,
-                rebindRead.signal
-            );
+            if (this.options.readSnapshot) {
+                snapshot = await this.options.readSnapshot(
+                    next.provider,
+                    next.sessionId,
+                    current.interactionId,
+                    rebindRead.signal
+                );
+                outline = snapshot.outline;
+            } else {
+                outline = await this.options.readOutline(
+                    next.provider,
+                    next.sessionId,
+                    rebindRead.signal
+                );
+            }
         } catch (_error) {
             return false;
         }
@@ -350,7 +394,7 @@ export class ConversationViewer implements ConversationViewerApi {
             sessionId: next.sessionId,
             interactionId: selected.id,
             expectedRevision: outline.sourceRevision,
-        }, false);
+        }, false, snapshot);
     }
 
     async freezeSessionMetadata(
@@ -399,8 +443,11 @@ export class ConversationViewer implements ConversationViewerApi {
 
     private async loadTarget(
         target: ConversationViewerTarget,
-        reveal: boolean
+        reveal: boolean,
+        snapshot?: ConversationSnapshot,
+        forceDocumentReplacement = false
     ): Promise<boolean> {
+        const hadPanel = Boolean(this.panel);
         const followedPanel = reveal ? undefined : this.panel;
         const generation = this.replaceTarget(target);
         const activeTarget = this.target;
@@ -423,9 +470,15 @@ export class ConversationViewer implements ConversationViewerApi {
         if (reveal) {
             panel.reveal(vscode.ViewColumn.Active);
         }
-        panel.webview.html = this.renderDocument(undefined, 'Loading conversation…');
+        const replaceDocument = forceDocumentReplacement || !hadPanel;
+        if (replaceDocument) {
+            panel.webview.html = this.renderDocument(
+                undefined,
+                'Loading conversation…'
+            );
+        }
         this.ensureWatch(generation);
-        return this.loadAuthoritative('initial', true);
+        return this.loadAuthoritative('initial', replaceDocument, snapshot);
     }
 
     async refresh(): Promise<void> {
@@ -576,10 +629,11 @@ export class ConversationViewer implements ConversationViewerApi {
         return panel;
     }
 
-    private webviewOptions(): vscode.WebviewOptions {
+    private webviewOptions(): vscode.WebviewOptions & vscode.WebviewPanelOptions {
         return {
             enableScripts: true,
             localResourceRoots: [this.options.mediaUri('')],
+            retainContextWhenHidden: true,
         };
     }
 
@@ -589,7 +643,6 @@ export class ConversationViewer implements ConversationViewerApi {
         }
         this.panel = panel;
         this.publishKeyboardFocus(false, true);
-        this.panelWasVisible = panel.visible;
         this.messageListener = panel.webview.onDidReceiveMessage(
             message => this.handleMessage(message)
         );
@@ -597,13 +650,8 @@ export class ConversationViewer implements ConversationViewerApi {
             if (this.panel !== panel || event.webviewPanel !== panel) {
                 return;
             }
-            const becameVisible = !this.panelWasVisible && panel.visible;
-            this.panelWasVisible = panel.visible;
             if (!panel.active) {
                 this.publishKeyboardFocus(false);
-            }
-            if (becameVisible) {
-                this.rebuildLatestDocument();
             }
         });
         this.panelDisposeListener = panel.onDidDispose(() => {
@@ -646,7 +694,6 @@ export class ConversationViewer implements ConversationViewerApi {
         this.latestPublication = undefined;
         this.commentController.reset();
         this.bookmarkController.reset();
-        this.panelWasVisible = false;
         this.publishKeyboardFocus(false);
         this.suspended = false;
         this.subscriptionGeneration += 1;
@@ -982,7 +1029,8 @@ export class ConversationViewer implements ConversationViewerApi {
 
     private loadAuthoritative(
         updateKind: 'initial' | 'refresh',
-        replaceDocument: boolean
+        replaceDocument: boolean,
+        snapshot?: ConversationSnapshot
     ): Promise<boolean> {
         if (this.authoritativeLoadInFlight) {
             this.authoritativeRefreshPending = true;
@@ -991,7 +1039,8 @@ export class ConversationViewer implements ConversationViewerApi {
         let loadInFlight: Promise<boolean>;
         loadInFlight = this.performAuthoritativeLoad(
             updateKind,
-            replaceDocument
+            replaceDocument,
+            snapshot
         ).finally(() => {
             if (this.authoritativeLoadInFlight !== loadInFlight) {
                 return;
@@ -1012,7 +1061,8 @@ export class ConversationViewer implements ConversationViewerApi {
 
     private async performAuthoritativeLoad(
         updateKind: 'initial' | 'refresh',
-        replaceDocument: boolean
+        replaceDocument: boolean,
+        prefetchedSnapshot?: ConversationSnapshot
     ): Promise<boolean> {
         const target = this.target;
         const panel = this.panel;
@@ -1027,7 +1077,19 @@ export class ConversationViewer implements ConversationViewerApi {
         this.currentRequestId = requestId;
         const previousSelectedInteractionId = this.outlineController.selection;
         try {
-            let outline = await this.options.readOutline(
+            const preferredInteractionId = updateKind === 'initial'
+                ? target.interactionId
+                : previousSelectedInteractionId;
+            let snapshot = prefetchedSnapshot;
+            if (!snapshot && this.options.readSnapshot) {
+                snapshot = await this.options.readSnapshot(
+                    target.provider,
+                    this.effectiveSessionId(target),
+                    preferredInteractionId,
+                    abortController.signal
+                );
+            }
+            let outline = snapshot?.outline || await this.options.readOutline(
                 target.provider,
                 this.effectiveSessionId(target),
                 abortController.signal
@@ -1093,51 +1155,55 @@ export class ConversationViewer implements ConversationViewerApi {
                 return true;
             }
             let page: ConversationPage;
-            try {
-                page = await this.options.readPage({
-                    provider: target.provider,
-                    sessionId: this.effectiveSessionId(target),
-                    anchorInteractionId: selectedInteractionId,
-                    direction: 'around',
-                    expectedRevision: outline.sourceRevision,
-                    limit: CONVERSATION_LIMITS.maxPageInteractions,
-                }, abortController.signal);
-            } catch (error) {
-                if (!isStaleRevision(error)) {
-                    throw error;
+            if (snapshot?.page) {
+                page = snapshot.page;
+            } else {
+                try {
+                    page = await this.options.readPage({
+                        provider: target.provider,
+                        sessionId: this.effectiveSessionId(target),
+                        anchorInteractionId: selectedInteractionId,
+                        direction: 'around',
+                        expectedRevision: outline.sourceRevision,
+                        limit: CONVERSATION_LIMITS.maxPageInteractions,
+                    }, abortController.signal);
+                } catch (error) {
+                    if (!isStaleRevision(error)) {
+                        throw error;
+                    }
+                    if (!this.canPublish(panel, target, generation, requestId)
+                        || abortController.signal.aborted) {
+                        return false;
+                    }
+                    outline = await this.options.readOutline(
+                        target.provider,
+                        this.effectiveSessionId(target),
+                        abortController.signal
+                    );
+                    if (!this.canPublish(panel, target, generation, requestId)) {
+                        return false;
+                    }
+                    if (outline.provider !== target.provider
+                        || outline.sessionId !== this.effectiveSessionId(target)
+                        || !outline.interactions.length) {
+                        await this.publishFailure(replaceDocument, updateKind);
+                        return false;
+                    }
+                    if (!outline.interactions.some(
+                        interaction => interaction.id === selectedInteractionId
+                    )) {
+                        await this.publishFailure(replaceDocument, updateKind);
+                        return false;
+                    }
+                    page = await this.options.readPage({
+                        provider: target.provider,
+                        sessionId: this.effectiveSessionId(target),
+                        anchorInteractionId: selectedInteractionId,
+                        direction: 'around',
+                        expectedRevision: outline.sourceRevision,
+                        limit: CONVERSATION_LIMITS.maxPageInteractions,
+                    }, abortController.signal);
                 }
-                if (!this.canPublish(panel, target, generation, requestId)
-                    || abortController.signal.aborted) {
-                    return false;
-                }
-                outline = await this.options.readOutline(
-                    target.provider,
-                    this.effectiveSessionId(target),
-                    abortController.signal
-                );
-                if (!this.canPublish(panel, target, generation, requestId)) {
-                    return false;
-                }
-                if (outline.provider !== target.provider
-                    || outline.sessionId !== this.effectiveSessionId(target)
-                    || !outline.interactions.length) {
-                    await this.publishFailure(replaceDocument, updateKind);
-                    return false;
-                }
-                if (!outline.interactions.some(
-                    interaction => interaction.id === selectedInteractionId
-                )) {
-                    await this.publishFailure(replaceDocument, updateKind);
-                    return false;
-                }
-                page = await this.options.readPage({
-                    provider: target.provider,
-                    sessionId: this.effectiveSessionId(target),
-                    anchorInteractionId: selectedInteractionId,
-                    direction: 'around',
-                    expectedRevision: outline.sourceRevision,
-                    limit: CONVERSATION_LIMITS.maxPageInteractions,
-                }, abortController.signal);
             }
             if (!this.canPublish(panel, target, generation, requestId)) {
                 return false;
@@ -1630,6 +1696,16 @@ export class ConversationViewer implements ConversationViewerApi {
             displayName: visibleConversationDisplayName(target),
             subagents: this.subagents.map(entry => ({ ...entry })),
             activeSubagent: target.subagent ? { ...target.subagent } : null,
+            target: {
+                projectId: target.projectId,
+                provider: target.provider,
+                sessionId: target.sessionId,
+                interactionId: target.interactionId,
+                displayName: target.displayName,
+                duplicateDisplayName: target.duplicateDisplayName,
+            },
+            comments: this.commentController.snapshot,
+            bookmarks: this.bookmarkController.snapshot,
         };
     }
 

--- a/src/aiSessions/conversation/viewerDocument.ts
+++ b/src/aiSessions/conversation/viewerDocument.ts
@@ -135,7 +135,9 @@ export function renderConversationViewerDocument(
     data-subscription-generation="${options.subscriptionGeneration}"${initialPageAttribute}${commentStateAttribute}${bookmarkStateAttribute}${targetAttribute}${restoreTargetAttribute}>
     <header class="conversation-header">
         <div class="conversation-identity">
-            <strong>${escapeHtml(providerLabel(target.provider))}</strong>
+            <strong data-conversation-provider>${escapeHtml(
+                providerLabel(target.provider)
+            )}</strong>
             <span data-conversation-display-name>${escapeHtml(
                 target.displayName + duplicateId
             )}</span>

--- a/src/aiSessions/directTerminalRuntimeBackend.ts
+++ b/src/aiSessions/directTerminalRuntimeBackend.ts
@@ -12,6 +12,7 @@ import type {
     AiSessionMaterializedResumeRuntimeRequest,
     AiSessionPendingRuntimeSnapshot,
     AiSessionResumeRuntimeRequest,
+    AiSessionRuntimeFocusOptions,
     AiSessionRuntimeIdentity,
     AiSessionRuntimeSnapshot,
 } from './runtimeTypes';
@@ -81,7 +82,7 @@ interface DirectTerminalService<TTerminal> {
     }): void;
     trackPending(entry: DirectPendingTerminalEntry<TTerminal>): void;
     replacePendingTerminals(entries: DirectPendingTerminalEntry<TTerminal>[]): void;
-    focusTerminal(terminal: TTerminal): void;
+    focusTerminal(terminal: TTerminal, preserveFocus?: boolean): void;
     closeTerminal(terminal: TTerminal): void;
     handleClosedTerminal(terminal: TTerminal): unknown;
 }
@@ -296,9 +297,12 @@ implements AiSessionExecutableRuntimeBackend<TTerminal> {
         })];
     }
 
-    async focus(runtime: AiSessionRuntimeSnapshot<TTerminal>): Promise<void> {
+    async focus(
+        runtime: AiSessionRuntimeSnapshot<TTerminal>,
+        options: AiSessionRuntimeFocusOptions = {}
+    ): Promise<void> {
         if (runtime?.backend === 'vscode' && runtime.terminal) {
-            this.terminalService.focusTerminal(runtime.terminal);
+            this.terminalService.focusTerminal(runtime.terminal, options.preserveFocus === true);
         }
     }
 

--- a/src/aiSessions/runtimeCoordinator.ts
+++ b/src/aiSessions/runtimeCoordinator.ts
@@ -13,6 +13,7 @@ import type {
     AiSessionResumeRuntimeRequest,
     AiSessionRuntimeActionResult,
     AiSessionRuntimeConfiguration,
+    AiSessionRuntimeFocusOptions,
     AiSessionRuntimeIdentity,
     AiSessionRuntimeSnapshot,
 } from './runtimeTypes';
@@ -256,19 +257,23 @@ export class AiSessionRuntimeCoordinator<TTerminal = vscode.Terminal> {
             : [];
     }
 
-    async focus(identity: AiSessionRuntimeIdentity): Promise<void> {
+    async focus(
+        identity: AiSessionRuntimeIdentity,
+        options: AiSessionRuntimeFocusOptions = {}
+    ): Promise<void> {
         const cached = this.matchesForIdentity(identity);
         if (cached.length === 1 && cached[0].state !== 'conflict') {
             if (cached[0].backend === 'vscode') {
                 await this.dependencies.direct.refresh(true);
                 const directMatches = this.matchesInBackend(this.dependencies.direct, identity);
                 if (directMatches.length === 1 && directMatches[0].state !== 'conflict') {
-                    await this.dependencies.direct.focus(cloneRuntime(directMatches[0]));
+                    await this.dependencies.direct.focus(cloneRuntime(directMatches[0]), options);
+                    return;
                 }
-                return;
+                throw new AiSessionRuntimeTargetChangedError();
             }
             try {
-                await this.dependencies.tmux.focus(cloneRuntime(cached[0]));
+                await this.dependencies.tmux.focus(cloneRuntime(cached[0]), options);
                 return;
             } catch (error) {
                 if (!(error instanceof AiSessionRuntimeTargetChangedError)) {
@@ -278,32 +283,23 @@ export class AiSessionRuntimeCoordinator<TTerminal = vscode.Terminal> {
             await this.refreshForHost(true);
             const refreshed = this.matchesForIdentity(identity);
             if (refreshed.length !== 1 || refreshed[0].state === 'conflict') {
-                return;
+                throw new AiSessionRuntimeTargetChangedError();
             }
-            try {
-                await this.backendFor(refreshed[0]).focus(cloneRuntime(refreshed[0]));
-            } catch (error) {
-                if (!(error instanceof AiSessionRuntimeTargetChangedError)) {
-                    throw error;
-                }
-            }
+            await this.backendFor(refreshed[0]).focus(cloneRuntime(refreshed[0]), options);
             return;
         }
         await this.refreshForHost(true);
         const matches = this.matchesForIdentity(identity);
         if (matches.length !== 1 || matches[0].state === 'conflict') {
-            return;
+            throw new AiSessionRuntimeTargetChangedError();
         }
-        try {
-            await this.backendFor(matches[0]).focus(cloneRuntime(matches[0]));
-        } catch (error) {
-            if (!(error instanceof AiSessionRuntimeTargetChangedError)) {
-                throw error;
-            }
-        }
+        await this.backendFor(matches[0]).focus(cloneRuntime(matches[0]), options);
     }
 
-    async focusSelected(selected: AiSessionRuntimeSnapshot<TTerminal>): Promise<boolean> {
+    async focusSelected(
+        selected: AiSessionRuntimeSnapshot<TTerminal>,
+        options: AiSessionRuntimeFocusOptions = {}
+    ): Promise<boolean> {
         const selection = cloneRuntime(selected);
         const refresh = await this.refreshBackends(true);
         this.throwRefreshFailure(refresh);
@@ -314,7 +310,7 @@ export class AiSessionRuntimeCoordinator<TTerminal = vscode.Terminal> {
         if (matches.length !== 1) {
             return false;
         }
-        await backend.focus(cloneRuntime(matches[0]));
+        await backend.focus(cloneRuntime(matches[0]), options);
         return true;
     }
 

--- a/src/aiSessions/runtimeTypes.ts
+++ b/src/aiSessions/runtimeTypes.ts
@@ -280,6 +280,10 @@ export interface AiSessionRuntimeConfiguration {
     tmuxPath: string;
 }
 
+export interface AiSessionRuntimeFocusOptions {
+    preserveFocus?: boolean;
+}
+
 export interface AiSessionRuntimeBackend<TTerminal = unknown> {
     refresh(force?: boolean): Promise<void>;
     getActive(): AiSessionRuntimeSnapshot<TTerminal>[];
@@ -287,7 +291,10 @@ export interface AiSessionRuntimeBackend<TTerminal = unknown> {
     getConflicts?(): AiSessionRuntimeSnapshot<TTerminal>[];
     getLifecycleBlockers?(): AiSessionRuntimeSnapshot<TTerminal>[];
     find(identity: AiSessionRuntimeIdentity): AiSessionRuntimeSnapshot<TTerminal>[];
-    focus(runtime: AiSessionRuntimeSnapshot<TTerminal>): Promise<void>;
+    focus(
+        runtime: AiSessionRuntimeSnapshot<TTerminal>,
+        options?: AiSessionRuntimeFocusOptions
+    ): Promise<void>;
     detach(runtime: AiSessionRuntimeSnapshot<TTerminal>): Promise<void>;
     terminate(runtime: AiSessionRuntimeSnapshot<TTerminal>): Promise<void>;
 }

--- a/src/aiSessions/terminalCommandController.ts
+++ b/src/aiSessions/terminalCommandController.ts
@@ -3,6 +3,7 @@
 import type { AiSessionProviderId } from '../models';
 import type {
     AiSessionPendingRuntimeSnapshot,
+    AiSessionRuntimeFocusOptions,
     AiSessionRuntimeIdentity,
     AiSessionRuntimeSnapshot,
 } from './runtimeTypes';
@@ -26,8 +27,11 @@ export interface AiSessionTerminalCommandRuntimeCoordinator<TTerminal> {
         workspaceScopeIdentity: string
     ): AiSessionRuntimeSnapshot<TTerminal>[];
     getPending(): AiSessionPendingRuntimeSnapshot<TTerminal>[];
-    focus(identity: AiSessionRuntimeIdentity): Promise<void>;
-    focusSelected?(runtime: AiSessionRuntimeSnapshot<TTerminal>): Promise<boolean>;
+    focus(identity: AiSessionRuntimeIdentity, options?: AiSessionRuntimeFocusOptions): Promise<void>;
+    focusSelected?(
+        runtime: AiSessionRuntimeSnapshot<TTerminal>,
+        options?: AiSessionRuntimeFocusOptions
+    ): Promise<boolean>;
     detach(identity: AiSessionRuntimeIdentity): Promise<void>;
     terminate(identity: AiSessionRuntimeIdentity): Promise<void>;
 }
@@ -75,6 +79,10 @@ export interface CloseAiSessionTerminalRequest {
     expectedBackend?: 'vscode' | 'tmux';
 }
 
+export interface FocusActiveAiSessionOptions {
+    revealTerminal?: boolean;
+}
+
 export class AiSessionTerminalCommandController<
     TTerminal extends { show(): void; dispose(): void }
 > {
@@ -88,7 +96,8 @@ export class AiSessionTerminalCommandController<
     async focusActive(
         projectId: string,
         providerId: string,
-        sessionId: string
+        sessionId: string,
+        focusOptions: FocusActiveAiSessionOptions = {}
     ): Promise<boolean> {
         if (!sessionId || !this.options.isProviderId(providerId)) {
             return false;
@@ -110,22 +119,29 @@ export class AiSessionTerminalCommandController<
             return this.chooseAndFocusConflict(
                 projectId,
                 candidates,
-                this.options
+                this.options,
+                focusOptions
             );
         }
         if (candidates.length === 1 && hasUnverifiedConflict) {
             return this.focusVerifiedSelection(
                 projectId,
                 candidates[0],
-                this.options
+                this.options,
+                focusOptions
             );
         }
         const runtime = this.getScopedActiveRuntime(projectId, providerId, sessionId, this.options);
         if (runtime) {
             try {
-                await this.options.runtimeCoordinator.focus({ ...runtime.identity });
+                await this.options.runtimeCoordinator.focus(
+                    { ...runtime.identity },
+                    runtimeFocusOptions(focusOptions)
+                );
                 this.options.refresh();
-                await this.options.focusTerminalView?.();
+                if (focusOptions.revealTerminal !== false) {
+                    await this.options.focusTerminalView?.();
+                }
                 return true;
             } catch (error) {
                 await this.handleRuntimeActionFailure(
@@ -141,7 +157,8 @@ export class AiSessionTerminalCommandController<
     private async chooseAndFocusConflict(
         projectId: string,
         candidates: AiSessionRuntimeSnapshot<TTerminal>[],
-        options: AiSessionTerminalCommandRuntimeControllerOptions<TTerminal>
+        options: AiSessionTerminalCommandRuntimeControllerOptions<TTerminal>,
+        focusOptions: FocusActiveAiSessionOptions
     ): Promise<boolean> {
         if (!options.chooseRuntimeConflict || !options.runtimeCoordinator.focusSelected) {
             return false;
@@ -156,16 +173,25 @@ export class AiSessionTerminalCommandController<
         if (!selected) {
             return false;
         }
-        return this.focusVerifiedSelection(projectId, selected, options);
+        return this.focusVerifiedSelection(
+            projectId,
+            selected,
+            options,
+            focusOptions
+        );
     }
 
     private async focusVerifiedSelection(
         projectId: string,
         selected: AiSessionRuntimeSnapshot<TTerminal>,
-        options: AiSessionTerminalCommandRuntimeControllerOptions<TTerminal>
+        options: AiSessionTerminalCommandRuntimeControllerOptions<TTerminal>,
+        focusOptions: FocusActiveAiSessionOptions
     ): Promise<boolean> {
         try {
-            const focused = await options.runtimeCoordinator.focusSelected(cloneRuntime(selected));
+            const focused = await options.runtimeCoordinator.focusSelected(
+                cloneRuntime(selected),
+                runtimeFocusOptions(focusOptions)
+            );
             if (!focused) {
                 options.refresh();
                 await options.announceStatus(
@@ -175,7 +201,9 @@ export class AiSessionTerminalCommandController<
                 return false;
             }
             options.refresh();
-            await options.focusTerminalView?.();
+            if (focusOptions.revealTerminal !== false) {
+                await options.focusTerminalView?.();
+            }
             return true;
         } catch (error) {
             await this.handleRuntimeActionFailure(
@@ -490,6 +518,12 @@ function cloneRuntime<TTerminal>(
         identity: cloneAiSessionRuntimeIdentity(runtime.identity),
         ...(runtime.tmux ? { tmux: { ...runtime.tmux } } : {}),
     };
+}
+
+function runtimeFocusOptions(
+    options: FocusActiveAiSessionOptions
+): AiSessionRuntimeFocusOptions {
+    return { preserveFocus: options.revealTerminal === false };
 }
 
 function clonePendingRuntime<TTerminal>(

--- a/src/aiSessions/terminalService.ts
+++ b/src/aiSessions/terminalService.ts
@@ -162,8 +162,8 @@ export default class AiSessionTerminalService {
             : {};
     }
 
-    focusTerminal(terminal: vscode.Terminal): void {
-        terminal?.show();
+    focusTerminal(terminal: vscode.Terminal, preserveFocus: boolean = false): void {
+        terminal?.show(preserveFocus);
     }
 
     closeTerminal(terminal: vscode.Terminal): void {

--- a/src/aiSessions/tmuxRuntimeBackend.ts
+++ b/src/aiSessions/tmuxRuntimeBackend.ts
@@ -14,6 +14,7 @@ import type {
     AiSessionMaterializedResumeRuntimeRequest,
     AiSessionPendingRuntimeSnapshot,
     AiSessionResumeRuntimeRequest,
+    AiSessionRuntimeFocusOptions,
     AiSessionRuntimeIdentity,
     AiSessionRuntimeSnapshot,
     AiSessionTmuxLayout,
@@ -97,7 +98,7 @@ interface AttachTerminal {
     readonly name: string;
     readonly processId: number | PromiseLike<number | undefined>;
     readonly creationOptions?: Readonly<vscode.TerminalOptions | vscode.ExtensionTerminalOptions>;
-    show(): void;
+    show(preserveFocus?: boolean): void;
     dispose(): void;
 }
 
@@ -357,13 +358,20 @@ implements AiSessionExecutableRuntimeBackend<TTerminal> {
         return this.promotionCapability.promotionTransitionMatches(intent, finalIdentityValue);
     }
 
-    async focus(runtime: AiSessionRuntimeSnapshot<TTerminal>): Promise<void> {
+    async focus(
+        runtime: AiSessionRuntimeSnapshot<TTerminal>,
+        options: AiSessionRuntimeFocusOptions = {}
+    ): Promise<void> {
         if (!runtime || runtime.backend !== 'tmux' || !runtime.tmux) {
             return;
         }
         await this.attachRestoreQueue;
         await this.verifyFocusTarget(runtime);
-        await this.attachAndFocus(runtime, this.getAttachTerminalName(runtime));
+        await this.attachAndFocus(
+            runtime,
+            this.getAttachTerminalName(runtime),
+            options.preserveFocus === true
+        );
     }
 
     private async verifyFocusTarget(runtime: AiSessionRuntimeSnapshot<TTerminal>): Promise<void> {
@@ -1092,7 +1100,8 @@ implements AiSessionExecutableRuntimeBackend<TTerminal> {
 
     private async attachAndFocus<T extends AiSessionRuntimeSnapshot>(
         runtime: T,
-        terminalName: string
+        terminalName: string,
+        preserveFocus: boolean = false
     ): Promise<T & AiSessionRuntimeSnapshot<TTerminal>> {
         if (!runtime.tmux) {
             throw new Error('A tmux runtime must include a locator.');
@@ -1141,7 +1150,7 @@ implements AiSessionExecutableRuntimeBackend<TTerminal> {
                 );
             }
             try {
-                attachTerminal(entry.terminal).show();
+                attachTerminal(entry.terminal).show(preserveFocus);
             } catch (error) {
                 entry.focusEpoch++;
                 this.attaches.delete(key);

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1471,6 +1471,13 @@ async function initializeDashboard(
                 viewerTarget.provider,
                 viewerTarget.sessionId
             ),
+        syncSession: viewerTarget =>
+            aiSessionTerminalCommandController.focusActive(
+                viewerTarget.projectId,
+                viewerTarget.provider,
+                viewerTarget.sessionId,
+                { revealTerminal: false }
+            ),
         setConversationFocusContext: focused =>
             vscode.commands.executeCommand(
                 'setContext',

--- a/src/webview/conversationCommentsScripts.js
+++ b/src/webview/conversationCommentsScripts.js
@@ -1608,14 +1608,39 @@
             }
         }
 
+        function resetSession(target, generation, snapshot) {
+            if (!validInitialComments(snapshot)) {
+                return false;
+            }
+            commentTarget = target;
+            subscriptionGeneration = generation;
+            state.comments = snapshot.comments.map(function (comment) {
+                return Object.assign({}, comment);
+            });
+            state.commentRevision = snapshot.revision;
+            state.pendingCommentRequest = null;
+            state.pendingLocateRequest = null;
+            state.editingComment = null;
+            state.expandedDoneComments.clear();
+            if (!commentUiAvailable) {
+                return true;
+            }
+            closeCommentComposer();
+            renderComments();
+            updateCommentHighlights();
+            return true;
+        }
+
         return Object.freeze({
             applyCommentsResult: applyCommentsResult,
             applyLocateResult: applyLocateResult,
             attach: attach,
+            canResetSession: validInitialComments,
             handleEnterShortcut: handleEnterShortcut,
             handleEscape: handleEscape,
             initializeComments: initializeComments,
             openCount: openCommentCount,
+            resetSession: resetSession,
             sendOpenComments: function () {
                 postCommentOperation('sendComments', {});
             },

--- a/src/webview/conversationOutlineScripts.js
+++ b/src/webview/conversationOutlineScripts.js
@@ -469,6 +469,29 @@
             }
         }
 
+        function resetSession(target, generation, bookmarks) {
+            if (!validBookmarkSnapshot(bookmarks)) {
+                return false;
+            }
+            commentTarget = target;
+            subscriptionGeneration = generation;
+            state.outline = [];
+            state.outlineSelectedInteractionId = '';
+            state.outlineSelectedInput = 0;
+            state.outlineTotalInputs = 0;
+            state.outlinePartial = false;
+            state.bookmarkIds = new Set(bookmarks.interactionIds);
+            state.bookmarkRevision = bookmarks.revision;
+            state.pendingBookmarkRequest = null;
+            if (!sidebarUiAvailable) {
+                return true;
+            }
+            buildOutlineList();
+            renderBookmarkState();
+            filterOutline();
+            return true;
+        }
+
         function restoreQuery(value) {
             if (typeof value !== 'string') return;
             state.outlineQuery = value.slice(0, 4096);
@@ -487,9 +510,11 @@
             applyBookmarksResult: applyBookmarksResult,
             applyOutline: applyOutline,
             attach: attach,
+            canResetSession: validBookmarkSnapshot,
             filter: filterOutline,
             initializeBookmarks: initializeBookmarks,
             query: query,
+            resetSession: resetSession,
             restoreQuery: restoreQuery,
             size: size,
         });

--- a/src/webview/conversationTelemetryScripts.js
+++ b/src/webview/conversationTelemetryScripts.js
@@ -279,8 +279,20 @@
             return true;
         }
 
+        function resetSession(target, generation) {
+            commentTarget = target;
+            subscriptionGeneration = generation;
+            state.latestTelemetryRequestId = 0;
+            telemetryModel.hidden = true;
+            telemetryWorktree.hidden = true;
+            telemetryContext.hidden = true;
+            telemetryLimits.replaceChildren();
+            return true;
+        }
+
         return Object.freeze({
             apply: applyTelemetry,
+            resetSession: resetSession,
         });
     }
 

--- a/src/webview/conversationViewerScripts.js
+++ b/src/webview/conversationViewerScripts.js
@@ -36,6 +36,9 @@
     var conversationDisplayName = document.querySelector(
         '[data-conversation-display-name]'
     );
+    var conversationProvider = document.querySelector(
+        '[data-conversation-provider]'
+    );
     var telemetryRoot = document.querySelector('[data-conversation-telemetry]');
     var telemetryModel = document.querySelector('[data-telemetry-model]');
     var telemetryModelValue = document.querySelector(
@@ -616,6 +619,50 @@
             && typeof value.label === 'string';
     }
 
+    function validPageTarget(value) {
+        if (!value || typeof value !== 'object' || Array.isArray(value)) {
+            return false;
+        }
+        var required = [
+            'projectId', 'provider', 'sessionId', 'interactionId', 'displayName',
+        ];
+        var allowed = new Set(required.concat(['duplicateDisplayName']));
+        return Object.keys(value).every(function (key) {
+            return allowed.has(key);
+        }) && required.every(function (key) {
+            return Object.prototype.hasOwnProperty.call(value, key);
+        })
+            && validCommentTarget({
+                projectId: value.projectId,
+                provider: value.provider,
+                sessionId: value.sessionId,
+            })
+            && typeof value.interactionId === 'string'
+            && value.interactionId.length > 0
+            && typeof value.displayName === 'string'
+            && value.displayName.length <= 640
+            && (value.duplicateDisplayName === undefined
+                || typeof value.duplicateDisplayName === 'boolean');
+    }
+
+    function validCommentSnapshot(value) {
+        return value && typeof value === 'object' && !Array.isArray(value)
+            && Object.keys(value).length === 2
+            && Number.isSafeInteger(value.revision) && value.revision >= 0
+            && Array.isArray(value.comments) && value.comments.length <= 20;
+    }
+
+    function validBookmarkSnapshot(value) {
+        return value && typeof value === 'object' && !Array.isArray(value)
+            && Object.keys(value).length === 2
+            && Number.isSafeInteger(value.revision) && value.revision >= 0
+            && Array.isArray(value.interactionIds)
+            && value.interactionIds.length <= 2000
+            && value.interactionIds.every(function (id) {
+                return typeof id === 'string' && id.length > 0;
+            });
+    }
+
     function validPage(message) {
         if (!message || typeof message !== 'object' || Array.isArray(message)) {
             return false;
@@ -627,7 +674,7 @@
         ];
         var allowedKeys = new Set(requiredKeys.concat([
             'previousCursor', 'nextCursor', 'subagents', 'activeSubagent',
-            'displayName',
+            'displayName', 'target', 'comments', 'bookmarks',
         ]));
         if (Object.keys(message).some(function (key) {
             return !allowedKeys.has(key);
@@ -663,7 +710,75 @@
             && (message.displayName === undefined
                 || (typeof message.displayName === 'string'
                     && message.displayName.length <= 640))
+            && (message.target === undefined
+                || validPageTarget(message.target))
+            && (message.comments === undefined
+                || validCommentSnapshot(message.comments))
+            && (message.bookmarks === undefined
+                || validBookmarkSnapshot(message.bookmarks))
             && typeof message.stale === 'boolean';
+    }
+
+    function providerLabel(provider) {
+        if (provider === 'kimi') return 'Kimi';
+        if (provider === 'claude') return 'Claude';
+        return 'Codex';
+    }
+
+    function applySessionGeneration(message) {
+        if (message.subscriptionGeneration === state.subscriptionGeneration) {
+            return true;
+        }
+        if (message.subscriptionGeneration < state.subscriptionGeneration
+            || !validPageTarget(message.target)
+            || !validCommentSnapshot(message.comments)
+            || !validBookmarkSnapshot(message.bookmarks)
+            || !outlineController.canResetSession(message.bookmarks)
+            || !commentsController.canResetSession(message.comments)) {
+            return false;
+        }
+        var nextCommentTarget = {
+            projectId: message.target.projectId,
+            provider: message.target.provider,
+            sessionId: message.target.sessionId,
+        };
+        if (!outlineController.resetSession(
+            nextCommentTarget,
+            message.subscriptionGeneration,
+            message.bookmarks
+        ) || !commentsController.resetSession(
+            nextCommentTarget,
+            message.subscriptionGeneration,
+            message.comments
+        )) {
+            return false;
+        }
+        telemetryController.resetSession(
+            nextCommentTarget,
+            message.subscriptionGeneration
+        );
+        commentTarget = nextCommentTarget;
+        restoreTarget = {
+            projectId: message.target.projectId,
+            provider: message.target.provider,
+            sessionId: message.target.sessionId,
+            interactionId: message.target.interactionId,
+        };
+        state.subscriptionGeneration = message.subscriptionGeneration;
+        state.latestRequestId = 0;
+        state.initialized = false;
+        state.messageIds = [];
+        state.messageSignatures = new Map();
+        document.body.setAttribute(
+            'data-subscription-generation',
+            String(message.subscriptionGeneration)
+        );
+        if (conversationProvider) {
+            conversationProvider.textContent = providerLabel(
+                message.target.provider
+            );
+        }
+        return true;
     }
 
 
@@ -691,7 +806,7 @@
 
     function applyPage(message) {
         if (!validPage(message)
-            || message.subscriptionGeneration !== state.subscriptionGeneration
+            || !applySessionGeneration(message)
             || message.requestId <= state.latestRequestId) {
             return;
         }
@@ -756,8 +871,12 @@
         }
         commentsController.updateHighlights();
         if (conversationDisplayName
-            && typeof message.displayName === 'string') {
-            conversationDisplayName.textContent = message.displayName;
+            && (typeof message.displayName === 'string'
+                || validPageTarget(message.target))) {
+            conversationDisplayName.textContent = typeof message.displayName
+                === 'string'
+                ? message.displayName
+                : message.target.displayName;
         }
         updatePosition(message);
         var latestInteraction = message.outline[message.outline.length - 1];

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -188,6 +188,7 @@ async function openViewerPage(t, options = {}) {
                 data-subscription-generation="1"
                 data-conversation-target='{"projectId":"project-1","provider":"codex","sessionId":"session-telemetry"}'>
                 <header>
+                    <strong data-conversation-provider>Codex</strong>
                     <span data-conversation-display-name>Original session</span>
                     <span data-conversation-position>Input 0 of 0</span>
                     <button type="button" data-action="previous">Previous</button>
@@ -316,6 +317,59 @@ async function sendPage(page, payload) {
         new MessageEvent('message', { data: message })
     ), payload);
 }
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 applies an authoritative cross-provider Session switch without replacing the Webview shell', async t => {
+    const page = await openViewerPage(t);
+    await sendPage(page, hostileConversationPage);
+    await page.evaluate(() => {
+        window.__retainedConversationMessages = document.querySelector(
+            '[data-conversation-messages]'
+        );
+    });
+
+    await sendPage(page, {
+        ...hostileConversationPage,
+        requestId: 2,
+        subscriptionGeneration: 2,
+        html: '<article data-message-id="kimi-message" '
+            + 'data-interaction-id="kimi-input"><p>Kimi response</p></article>',
+        outline: [{
+            interactionId: 'kimi-input',
+            userPreview: 'Kimi input',
+            responseState: 'complete',
+        }],
+        selectedInteractionId: 'kimi-input',
+        selectedInput: 1,
+        totalInputs: 1,
+        previousCursor: undefined,
+        nextCursor: undefined,
+        target: {
+            projectId: 'project-1',
+            provider: 'kimi',
+            sessionId: 'kimi-session',
+            interactionId: 'kimi-input',
+            displayName: 'Kimi Session',
+        },
+        comments: { revision: 0, comments: [] },
+        bookmarks: { revision: 0, interactionIds: [] },
+    });
+
+    assert.deepEqual(await page.evaluate(() => ({
+        retainedRoot: document.querySelector('[data-conversation-messages]')
+            === window.__retainedConversationMessages,
+        provider: document.querySelector('[data-conversation-provider]')
+            .textContent,
+        displayName: document.querySelector('[data-conversation-display-name]')
+            .textContent,
+        response: document.querySelector('[data-conversation-messages]')
+            .textContent.trim(),
+    })), {
+        retainedRoot: true,
+        provider: 'Kimi',
+        displayName: 'Kimi Session',
+        response: 'Kimi response',
+    });
+});
 
 test('CONVERSATION-TELEMETRY-001 CONVERSATION-TELEMETRY-CONTROLLER-001 renders correlated model, context, and weekly quota updates in place', async t => {
     const page = await openViewerPage(t);
@@ -5847,10 +5901,35 @@ test('CONVERSATION-VIEWER-BROWSER-CORRELATION-001 rejects stale request and subs
         subscriptionGeneration: 2,
         html: messageHtml('generation-2', 1),
     });
+    await sendPage(page, {
+        ...hostileConversationPage,
+        requestId: 7,
+        subscriptionGeneration: 2,
+        html: messageHtml('invalid-generation-2', 1),
+        target: {
+            projectId: 'project-1',
+            provider: 'kimi',
+            sessionId: 'kimi-session',
+            interactionId: 'input-4',
+            displayName: 'Kimi Session',
+        },
+        comments: { revision: 0, comments: [{}] },
+        bookmarks: { revision: 0, interactionIds: [] },
+    });
+    await sendPage(page, {
+        ...hostileConversationPage,
+        requestId: 6,
+        html: messageHtml('request-6', 1),
+    });
 
-    assert.equal(await page.locator('[data-message-id="request-5-0"]').count(), 1);
+    assert.equal(await page.locator('[data-message-id="request-5-0"]').count(), 0);
+    assert.equal(await page.locator('[data-message-id="request-6-0"]').count(), 1);
     assert.equal(await page.locator('[data-message-id="request-4-0"]').count(), 0);
     assert.equal(await page.locator('[data-message-id="generation-2-0"]').count(), 0);
+    assert.equal(await page.locator(
+        '[data-message-id="invalid-generation-2-0"]'
+    ).count(), 0);
+    assert.equal(await page.locator('[data-conversation-provider]').innerText(), 'Codex');
 });
 
 test('CONVERSATION-VIEWER-BROWSER-RACE-001 treats a refresh that wins initial loading as the initial page', async t => {

--- a/tests/contract/aiSessions/claudeConversationAdapter.test.js
+++ b/tests/contract/aiSessions/claudeConversationAdapter.test.js
@@ -61,6 +61,20 @@ async function readWholeConversation(adapter) {
     return { outline, page };
 }
 
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 Claude returns one correlated outline and page snapshot', async t => {
+    const source = await createFixture(t);
+    const adapter = createAdapter(source);
+    t.after(() => adapter.dispose());
+
+    const snapshot = await adapter.readSnapshot(sessionId);
+
+    assert.equal(snapshot.page.sourceRevision, snapshot.outline.sourceRevision);
+    assert.equal(
+        snapshot.page.anchorInteractionId,
+        snapshot.outline.interactions.at(-1).id
+    );
+});
+
 test('SESSION-AI-SESSION-CONVERSATION-ADAPTER-001 Claude normalizes only top-level visible user and assistant text', async t => {
     const source = await createFixture(t);
     const adapter = createAdapter(source);

--- a/tests/contract/aiSessions/codexConversationAdapter.test.js
+++ b/tests/contract/aiSessions/codexConversationAdapter.test.js
@@ -95,6 +95,20 @@ async function readWholeConversation(adapter) {
     return { outline, page };
 }
 
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 Codex returns one correlated outline and page from one provider read', async t => {
+    const harness = createAdapter();
+    t.after(() => harness.adapter.dispose());
+
+    const snapshot = await harness.adapter.readSnapshot(sessionId);
+
+    assert.equal(harness.requests.length, 1);
+    assert.equal(snapshot.page.sourceRevision, snapshot.outline.sourceRevision);
+    assert.equal(
+        snapshot.page.anchorInteractionId,
+        snapshot.outline.interactions.at(-1).id
+    );
+});
+
 test('SESSION-AI-SESSION-CONVERSATION-ADAPTER-001 Codex normalizes only stable visible user and agent items', async t => {
     const harness = createAdapter();
     t.after(() => harness.adapter.dispose());

--- a/tests/contract/aiSessions/kimiConversationAdapter.test.js
+++ b/tests/contract/aiSessions/kimiConversationAdapter.test.js
@@ -59,6 +59,20 @@ async function readWholeConversation(adapter) {
     return { outline, page };
 }
 
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 Kimi returns one correlated outline and page snapshot', async t => {
+    const source = await createFixture(t);
+    const adapter = createAdapter(source);
+    t.after(() => adapter.dispose());
+
+    const snapshot = await adapter.readSnapshot(sessionId);
+
+    assert.equal(snapshot.page.sourceRevision, snapshot.outline.sourceRevision);
+    assert.equal(
+        snapshot.page.anchorInteractionId,
+        snapshot.outline.interactions.at(-1).id
+    );
+});
+
 test('SESSION-AI-SESSION-CONVERSATION-ADAPTER-001 Kimi normalizes only visible turns and preserves suffix identities', async t => {
     const source = await createFixture(t);
     await fs.promises.appendFile(source.sourcePath, [

--- a/tests/contract/aiSessions/runtimeBackends.test.js
+++ b/tests/contract/aiSessions/runtimeBackends.test.js
@@ -54,6 +54,16 @@ defineRuntimeContract({
     createHarness: createDirectRuntimeHarness,
 });
 
+test('CONVERSATION-ACTIVE-SESSION-NAVIGATION-COMMANDS-001 direct focus can reveal a terminal without stealing keyboard focus', async () => {
+    const harness = createDirectRuntimeHarness();
+    const runtime = await harness.backend.ensureResume(fakeResumeRequest('preserve-direct'));
+
+    await harness.backend.focus(runtime, { preserveFocus: true });
+
+    assert.equal(harness.operations.at(-1).type, 'focus');
+    assert.equal(harness.operations.at(-1).preserveFocus, true);
+});
+
 // RUNTIME-TMUX-BACKEND-001
 for (const layout of ['project', 'session']) {
     defineRuntimeContract({
@@ -75,6 +85,21 @@ for (const layout of ['project', 'session']) {
 
         assert.equal(harness.viewerCount(), viewerCount);
         assert.equal(harness.terminals[0].shown, true);
+    });
+
+    test(`CONVERSATION-ACTIVE-SESSION-NAVIGATION-COMMANDS-001 [tmux ${layout}] focus can select a runtime without stealing keyboard focus`, async () => {
+        const harness = createTmuxRuntimeHarness(layout);
+        const runtime = await harness.backend.ensureResume(
+            fakeResumeRequest(`preserve-focus-${layout}`),
+            layout
+        );
+
+        await harness.backend.focus(runtime, { preserveFocus: true });
+
+        const show = harness.operations.filter(operation =>
+            operation.type === 'show-terminal'
+        ).at(-1);
+        assert.equal(show.preserveFocus, true);
     });
 
     test(`RUNTIME-TMUX-BACKEND-001 [tmux ${layout}] focus after reload recovers the live tmux client when VS Code drops terminal metadata`, async () => {

--- a/tests/contract/aiSessions/runtimeCoordinator.test.js
+++ b/tests/contract/aiSessions/runtimeCoordinator.test.js
@@ -367,9 +367,10 @@ test('RUNTIME-TMUX-FOCUS-FAST-PATH-001 focuses a unique cached tmux target witho
     tmux.active.push(runtime);
     const coordinator = createCoordinator(direct, tmux);
 
-    await coordinator.focus(runtime.identity);
+    await coordinator.focus(runtime.identity, { preserveFocus: true });
 
     assert.equal(tmux.focusCalls.length, 1);
+    assert.deepEqual(tmux.focusOptions, [{ preserveFocus: true }]);
     assert.deepEqual(tmux.refreshCalls, []);
     assert.deepEqual(direct.refreshCalls, []);
 });
@@ -390,7 +391,9 @@ test('RUNTIME-TMUX-FOCUS-FAST-PATH-001 reconciles and retries one changed target
     tmux.focus = async value => {
         tmux.focusCalls.push(value);
         focusAttempts += 1;
-        throw new AiSessionRuntimeTargetChangedError();
+        if (focusAttempts === 1) {
+            throw new AiSessionRuntimeTargetChangedError();
+        }
     };
     const coordinator = createCoordinator(direct, tmux);
 
@@ -399,6 +402,75 @@ test('RUNTIME-TMUX-FOCUS-FAST-PATH-001 reconciles and retries one changed target
     assert.equal(focusAttempts, 2);
     assert.deepEqual(tmux.refreshCalls, [true]);
     assert.deepEqual(direct.refreshCalls, [true]);
+});
+
+test('CONVERSATION-ACTIVE-SESSION-NAVIGATION-COMMANDS-001 rejects direct focus when the runtime disappears during refresh', async () => {
+    const direct = createFakeRuntimeBackend('vscode', {
+        onRefresh: backend => backend.active.splice(0),
+    });
+    const tmux = createFakeRuntimeBackend('tmux');
+    const runtime = fakeRuntime('vscode', 'direct-disappeared');
+    direct.active.push(runtime);
+    const coordinator = createCoordinator(direct, tmux);
+
+    await assert.rejects(
+        coordinator.focus(runtime.identity, { preserveFocus: true }),
+        AiSessionRuntimeTargetChangedError
+    );
+
+    assert.equal(direct.focusCalls.length, 0);
+});
+
+test('CONVERSATION-ACTIVE-SESSION-NAVIGATION-COMMANDS-001 rejects tmux focus when the runtime disappears during reconciliation', async () => {
+    const direct = createFakeRuntimeBackend('vscode');
+    const tmux = createFakeRuntimeBackend('tmux', {
+        onRefresh: backend => backend.active.splice(0),
+    });
+    const runtime = fakeRuntime('tmux', 'tmux-disappeared', {
+        attached: false,
+        tmux: {
+            layout: 'project',
+            sessionName: 'managed',
+            windowName: 'codex-tmux-disappeared',
+        },
+    });
+    tmux.active.push(runtime);
+    tmux.focus = async () => {
+        throw new AiSessionRuntimeTargetChangedError();
+    };
+    const coordinator = createCoordinator(direct, tmux);
+
+    await assert.rejects(
+        coordinator.focus(runtime.identity),
+        AiSessionRuntimeTargetChangedError
+    );
+});
+
+test('CONVERSATION-ACTIVE-SESSION-NAVIGATION-COMMANDS-001 rejects tmux focus after a repeated target change', async () => {
+    const direct = createFakeRuntimeBackend('vscode');
+    const tmux = createFakeRuntimeBackend('tmux');
+    const runtime = fakeRuntime('tmux', 'tmux-changed-twice', {
+        attached: false,
+        tmux: {
+            layout: 'project',
+            sessionName: 'managed',
+            windowName: 'codex-tmux-changed-twice',
+        },
+    });
+    tmux.active.push(runtime);
+    let focusAttempts = 0;
+    tmux.focus = async () => {
+        focusAttempts += 1;
+        throw new AiSessionRuntimeTargetChangedError();
+    };
+    const coordinator = createCoordinator(direct, tmux);
+
+    await assert.rejects(
+        coordinator.focus(runtime.identity),
+        AiSessionRuntimeTargetChangedError
+    );
+
+    assert.equal(focusAttempts, 2);
 });
 
 test('RUNTIME-TMUX-TERMINATE-SESSION-001 routes terminate to the owning backend and skips conflicts', async () => {

--- a/tests/contract/aiSessions/sessionControllers.test.js
+++ b/tests/contract/aiSessions/sessionControllers.test.js
@@ -308,6 +308,56 @@ test('SESSION-AI-SESSION-TERMINAL-COMMAND-CONTROLLER-001 ATTENTION-EXPLICIT-SESS
     assert.equal(missing, false);
 });
 
+test('CONVERSATION-ACTIVE-SESSION-NAVIGATION-COMMANDS-001 can synchronize an active runtime without moving keyboard focus to the Terminal view', async () => {
+    const effects = [];
+    const identity = {
+        provider: 'codex',
+        sessionId: 'session-b',
+        workspaceScopeIdentity: 'scope:fixture',
+        workspaceNavigationIdentity: 'navigation:fixture',
+        workspaceRootHostPaths: ['/work'],
+        cwd: '/work',
+    };
+    const runtime = {
+        backend: 'tmux',
+        state: 'active',
+        identity,
+        terminal: { show() {}, dispose() {} },
+        attached: true,
+        stale: false,
+        runStartedAtMs: 1,
+    };
+    const controller = new AiSessionTerminalCommandController({
+        isProviderId: value => value === 'codex',
+        getWorkspaceTarget: () => makeWorkspaceTarget([{ id: 'session-b' }]),
+        showErrorMessage: async () => undefined,
+        getProviderLabel: () => 'Codex',
+        refresh: () => effects.push('refresh'),
+        runtimeCoordinator: {
+            getById: () => runtime,
+            getPending: () => [],
+            focus: async (_identity, options) => effects.push(
+                `focus-runtime:${options?.preserveFocus === true}`
+            ),
+            detach: async () => undefined,
+            terminate: async () => undefined,
+        },
+        confirmRuntimeClose: async () => 'Cancel',
+        announceStatus: async () => undefined,
+        focusTerminalView: async () => effects.push('focus-terminal-view'),
+        onRuntimeCloseStart() {},
+        onRuntimeCloseEnd() {},
+    });
+
+    assert.equal(await controller.focusActive(
+        'p',
+        'codex',
+        'session-b',
+        { revealTerminal: false }
+    ), true);
+    assert.deepEqual(effects, ['focus-runtime:true', 'refresh']);
+});
+
 test('ATTENTION-EXPLICIT-SESSION-CLOSE-001 reports failed detach without a success acknowledgement', async () => {
     const effects = [];
     const identity = {

--- a/tests/helpers/runtimeContract.js
+++ b/tests/helpers/runtimeContract.js
@@ -107,7 +107,7 @@ function fakeCreateRequest(pendingId, overrides = {}) {
 function createFakeRuntimeBackend(backend, options = {}) {
     const fake = {
         active: [], pending: [], conflicts: [], lifecycleBlockers: [],
-        refreshCalls: [], focusCalls: [], detachCalls: [], terminateCalls: [], promoted: [], closed: [],
+        refreshCalls: [], focusCalls: [], focusOptions: [], detachCalls: [], terminateCalls: [], promoted: [], closed: [],
         launches: [], ensureResumeCalls: 0, ensurePendingCalls: 0,
     };
     fake.refresh = async force => {
@@ -122,7 +122,10 @@ function createFakeRuntimeBackend(backend, options = {}) {
     fake.find = identity => fake.getActive().filter(runtime =>
         runtime.identity.provider === identity.provider
         && runtime.identity.sessionId === identity.sessionId);
-    fake.focus = async runtime => { fake.focusCalls.push(cloneRuntime(runtime)); };
+    fake.focus = async (runtime, focusOptions = {}) => {
+        fake.focusCalls.push(cloneRuntime(runtime));
+        fake.focusOptions.push({ ...focusOptions });
+    };
     fake.detach = async runtime => { fake.detachCalls.push(cloneRuntime(runtime)); };
     fake.terminate = async runtime => { fake.terminateCalls.push(cloneRuntime(runtime)); };
     fake.ensureResume = async (request, layout) => {
@@ -214,7 +217,9 @@ function createDirectRuntimeHarness() {
                 ...entry, excludedSessionIds: [...entry.excludedSessionIds],
             })));
         },
-        focusTerminal: terminal => { operations.push({ type: 'focus', terminal }); },
+        focusTerminal: (terminal, preserveFocus = false) => {
+            operations.push({ type: 'focus', terminal, preserveFocus });
+        },
         closeTerminal: terminal => { operations.push({ type: 'close', terminal }); },
         handleClosedTerminal: terminal => {
             for (let index = tracked.length - 1; index >= 0; index -= 1) {
@@ -573,7 +578,10 @@ function createTmuxRuntimeHarness(layout, options = {}) {
                 processId: Promise.resolve(processId),
                 shown: false,
                 disposed: false,
-                show() { this.shown = true; operations.push({ type: 'show-terminal', terminal: this }); },
+                show(preserveFocus = false) {
+                    this.shown = true;
+                    operations.push({ type: 'show-terminal', terminal: this, preserveFocus });
+                },
                 dispose() { this.disposed = true; operations.push({ type: 'dispose-terminal', terminal: this }); },
             };
             terminals.push(terminal);

--- a/tests/integration/dashboard/conversationOpenLatest.test.js
+++ b/tests/integration/dashboard/conversationOpenLatest.test.js
@@ -86,6 +86,27 @@ function makeOutline(provider, sessionId, interactionIds) {
     };
 }
 
+function makePage(provider, sessionId, interactionId) {
+    return {
+        provider,
+        sessionId,
+        sourceRevision: 'native-1',
+        anchorInteractionId: interactionId,
+        messages: [{
+            id: `${interactionId}:user`,
+            interactionId,
+            role: 'user',
+            markdown: interactionId,
+        }],
+        interactionStates: [{
+            interactionId,
+            responseState: 'complete',
+        }],
+        isStart: true,
+        isEnd: true,
+    };
+}
+
 function makeSession(overrides = {}) {
     return {
         key: 'codex:session-a',
@@ -105,19 +126,38 @@ function makeSession(overrides = {}) {
 
 function createHarness(options = {}) {
     const viewerTargets = [];
+    const viewerSnapshots = [];
     const followedViewerTargets = [];
     const restoredViewerTargets = [];
     let viewerFocuses = 0;
     let capturedViewerOptions;
     let outlineReads = 0;
+    let snapshotReads = 0;
     const session = 'session' in options ? options.session : makeSession({
         conversationDisplayName: options.conversationDisplayName,
         duplicateConversationDisplayName:
             options.duplicateConversationDisplayName,
     });
     const fakeAdapter = provider => () => ({
+        ...(options.enableSnapshots ? {
+            async readSnapshot(sessionId, preferredInteractionId) {
+                snapshotReads += 1;
+                const interactionIds = options.interactionIds
+                    || ['input-a', 'input-b'];
+                const selected = interactionIds.includes(preferredInteractionId)
+                    ? preferredInteractionId
+                    : interactionIds.at(-1);
+                return {
+                    outline: makeOutline(provider, sessionId, interactionIds),
+                    page: makePage(provider, sessionId, selected),
+                };
+            },
+        } : {}),
         async readOutline(sessionId) {
             outlineReads += 1;
+            if (options.requireSnapshot) {
+                throw new Error('initial Conversation load must use one snapshot');
+            }
             if (options.readOutline) {
                 return options.readOutline(provider, sessionId);
             }
@@ -148,6 +188,7 @@ function createHarness(options = {}) {
         resolveActiveTargets: options.resolveActiveTargets
             || (() => (session ? [session] : [])),
         focusSession: options.focusSession,
+        syncSession: options.syncSession,
         publish: async () => true,
         createPanel: () => {
             throw new Error('createPanel is not used by openLatestConversation');
@@ -189,15 +230,17 @@ function createHarness(options = {}) {
                     }
                     : undefined,
                 getFocusedSessionTarget: () => options.focusedViewerTarget,
-                open: async target => {
+                open: async (target, snapshot) => {
                     viewerTargets.push(target);
+                    viewerSnapshots.push(snapshot);
                     await options.openViewer?.(target);
                 },
                 restore: async (panel, target) => {
                     restoredViewerTargets.push({ panel, target });
                 },
-                follow: async target => {
+                follow: async (target, snapshot) => {
                     followedViewerTargets.push(target);
+                    viewerSnapshots.push(snapshot);
                     return options.followViewer
                         ? options.followViewer(target)
                         : true;
@@ -218,6 +261,7 @@ function createHarness(options = {}) {
     return {
         capability,
         viewerTargets,
+        viewerSnapshots,
         followedViewerTargets,
         restoredViewerTargets,
         get viewerOptions() {
@@ -225,6 +269,9 @@ function createHarness(options = {}) {
         },
         get outlineReads() {
             return outlineReads;
+        },
+        get snapshotReads() {
+            return snapshotReads;
         },
         get viewerFocuses() {
             return viewerFocuses;
@@ -250,6 +297,33 @@ test('CONVERSATION-OPEN-LATEST-001 opens the latest interaction of the resolved 
         duplicateDisplayName: false,
     }]);
     capability.dispose();
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 opens Codex, Kimi, and Claude with one shared provider snapshot each', async () => {
+    for (const provider of ['codex', 'kimi', 'claude']) {
+        const sessionId = `${provider}-session`;
+        const harness = createHarness({
+            enableSnapshots: true,
+            requireSnapshot: true,
+            session: makeSession({
+                key: `${provider}:${sessionId}`,
+                provider,
+                sessionId,
+                name: `${provider} Session`,
+            }),
+        });
+        assert.equal(await harness.capability.openLatestConversation({
+            projectId: 'project-a',
+            provider,
+            sessionId,
+        }), 'opened');
+        assert.equal(harness.snapshotReads, 1, `${provider} snapshot reads`);
+        assert.equal(harness.outlineReads, 0, `${provider} outline re-reads`);
+        assert.equal(harness.viewerSnapshots.length, 1);
+        assert.equal(harness.viewerSnapshots[0].outline.provider, provider);
+        assert.equal(harness.viewerSnapshots[0].page.provider, provider);
+        harness.capability.dispose();
+    }
 });
 
 test('WEBVIEW-AI-SESSION-CONVERSATION-VIEWER-001 dashboard registers a serializer that restores AI Conversation panels', () => {
@@ -687,6 +761,42 @@ test('CONVERSATION-ACTIVE-SESSION-NAVIGATION-COMMANDS-001 switches from the focu
     );
     assert.equal(unfocused.outlineReads, 0);
     unfocused.capability.dispose();
+});
+
+test('CONVERSATION-ACTIVE-SESSION-NAVIGATION-COMMANDS-001 synchronizes runtime authority without revealing the Terminal during Conversation navigation', async () => {
+    const sessions = [
+        makeSession({ key: 'codex:session-a', sessionId: 'session-a' }),
+        makeSession({ key: 'kimi:session-b', provider: 'kimi', sessionId: 'session-b' }),
+    ];
+    const revealed = [];
+    const synchronized = [];
+    const harness = createHarness({
+        viewerOpen: true,
+        focusedViewerTarget: {
+            projectId: 'project-a',
+            provider: 'codex',
+            sessionId: 'session-a',
+        },
+        resolveTarget: (_projectId, provider, sessionId) =>
+            sessions.find(session =>
+                session.provider === provider && session.sessionId === sessionId
+            ) || null,
+        resolveActiveTargets: () => sessions,
+        focusSession: async target => revealed.push(target),
+        syncSession: async target => synchronized.push(target),
+    });
+
+    assert.equal(
+        await harness.capability.followAdjacentActiveConversation('next'),
+        'opened'
+    );
+    assert.deepEqual(revealed, []);
+    assert.deepEqual(synchronized.map(target => [
+        target.provider,
+        target.sessionId,
+    ]), [['kimi', 'session-b']]);
+    assert.equal(harness.viewerFocuses, 1);
+    harness.capability.dispose();
 });
 
 test('CONVERSATION-ACTIVE-SESSION-NAVIGATION-COMMANDS-001 rolls a rejected command switch back before restoring Conversation focus', async () => {

--- a/tests/integration/dashboard/conversationViewer.test.js
+++ b/tests/integration/dashboard/conversationViewer.test.js
@@ -303,7 +303,7 @@ test('CONVERSATION-SESSION-REBIND-001 retargets an open viewer from the exact ol
     assert.deepEqual(outlineReads, ['old-root', 'new-root', 'new-root']);
     assert.deepEqual(watchDisposals, ['old-root']);
     assert.equal(panel.createCount, 1);
-    assert.match(panel.webview.html, /new-input-b/);
+    assert.match(panel.postedMessages.at(-1).html, /new-input-b/);
     await viewer.reconcileAuthority(() => ({
         displayName: 'New root display',
         duplicateDisplayName: false,
@@ -342,9 +342,8 @@ test('CONVERSATION-SESSION-REBIND-001 keeps an initial rebound load current whil
 
     assert.equal(await rebind, true);
     await reconcile;
-    assert.match(panel.webview.html, /new-root-input/);
-    assert.match(panel.webview.html, /Current root/);
-    assert.equal(panel.webview.html.includes('history unavailable'), false);
+    assert.match(panel.postedMessages.at(-1).html, /new-root-input/);
+    assert.match(panel.postedMessages.at(-1).displayName, /Current root/);
 });
 
 test('CONVERSATION-SESSION-REBIND-001 bounds reconciled display metadata before publishing it', async () => {
@@ -389,7 +388,7 @@ test('CONVERSATION-SESSION-REBIND-001 lets the newest live rebind win while an o
     }), true);
     oldRebind.resolve();
     assert.equal(await first, false);
-    assert.match(panel.webview.html, /new-root-b-input/);
+    assert.match(panel.postedMessages.at(-1).html, /new-root-b-input/);
 });
 
 test('WEBVIEW-AI-SESSION-CONVERSATION-VIEWER-001 restores a retained panel without revealing it and resumes live updates', async () => {
@@ -451,11 +450,66 @@ test('CONVERSATION-FOLLOW-ACTIVE-SESSION-001 follows another Session only when t
     assert.equal(panel.createCount, 0);
 
     await viewer.open(target('session-a', 'input-a'));
+    const retainedDocument = panel.webview.html;
     assert.equal(viewer.isOpen(), true);
     assert.equal(await viewer.follow(target('session-b', 'input-b')), true);
-    assert.equal(panel.webview.html.includes('visible-session-b'), true);
-    assert.equal(panel.webview.html.includes('visible-session-a'), false);
+    assert.equal(
+        panel.webview.html,
+        retainedDocument,
+        'following a Session must update the retained Webview in place'
+    );
+    assert.equal(
+        panel.postedMessages.at(-1).html.includes('visible-session-b'),
+        true
+    );
     assert.deepEqual(panel.revealColumns, [fakeVscode.ViewColumn.Active]);
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 retains one Webview document while switching Codex, Kimi, and Claude Sessions and while hidden', async () => {
+    const { viewer, panel } = createViewer({
+        readOutline: async (provider, sessionId) => ({
+            ...outline(sessionId, [`${sessionId}-input`]),
+            provider,
+        }),
+        readPage: async request => ({
+            ...page(
+                request.sessionId,
+                request.anchorInteractionId,
+                `visible-${request.provider}`
+            ),
+            provider: request.provider,
+        }),
+    });
+
+    await viewer.open(target('codex-session', 'codex-session-input'));
+    assert.equal(
+        panel.createArguments[3].retainContextWhenHidden,
+        true,
+        'the singleton Conversation panel must retain its Webview context'
+    );
+    const retainedDocument = panel.webview.html;
+
+    for (const provider of ['kimi', 'claude']) {
+        const sessionId = `${provider}-session`;
+        assert.equal(await viewer.follow(target(
+            sessionId,
+            `${sessionId}-input`,
+            { provider }
+        )), true);
+        assert.equal(panel.webview.html, retainedDocument);
+        const publication = panel.postedMessages.at(-1);
+        assert.equal(publication.target.provider, provider);
+        assert.equal(publication.target.sessionId, sessionId);
+        assert.match(publication.html, new RegExp(`visible-${provider}`));
+    }
+
+    await panel.setVisible(false);
+    await panel.setVisible(true);
+    assert.equal(
+        panel.webview.html,
+        retainedDocument,
+        'showing a retained panel must not rebuild its document'
+    );
 });
 
 test('CONVERSATION-ACTIVE-SESSION-NAVIGATION-COMMANDS-001 distinguishes the current target from the focused Conversation target', async () => {
@@ -528,7 +582,7 @@ test('CONVERSATION-ACTIVE-SESSION-NAVIGATION-COMMANDS-001 reports a superseded i
     );
     releaseSlowOutline.resolve();
     assert.equal(await first, false);
-    assert.match(panel.webview.html, /session-c-input/);
+    assert.match(panel.postedMessages.at(-1).html, /session-c-input/);
 });
 
 test('WEBVIEW-AI-SESSION-SUBAGENT-VIEWER-001 opens a subagent transcript in place and returns to the conversation', async () => {
@@ -654,8 +708,8 @@ test('CONVERSATION-VIEWER-OWNERSHIP-001 reuses one panel, rejects an old session
     pages.get('session-a').resolve(page('session-a', 'input-a', 'visible-a'));
     await openA;
 
-    assert.equal(panel.webview.html.includes('visible-b'), true);
-    assert.equal(panel.webview.html.includes('visible-a'), false);
+    assert.equal(panel.postedMessages.at(-1).html.includes('visible-b'), true);
+    assert.equal(panel.postedMessages.at(-1).html.includes('visible-a'), false);
     assert.equal(panel.createCount, 1);
     assert.deepEqual(watchDisposals, ['session-a']);
     assert.equal(viewer.snapshotSize, 1);
@@ -2051,7 +2105,7 @@ test('CONVERSATION-VIEWER-REFRESH-002 CONVERSATION-READING-FOCUS-001 preserves t
     assert.equal(publication.atLatest, false);
 });
 
-test('CONVERSATION-VIEWER-DELIVERY-001 rebuilds the latest hidden publication when the panel becomes visible and disposes its listener', async () => {
+test('CONVERSATION-VIEWER-DELIVERY-001 retains hidden Webview context without rebuilding it on visibility changes', async () => {
     let onChange;
     let revision = 1;
     const panel = fakePanel({
@@ -2078,17 +2132,16 @@ test('CONVERSATION-VIEWER-DELIVERY-001 rebuilds the latest hidden publication wh
 
     await viewer.open(target('session-a', 'input-1'));
     assert.equal(panel.viewStateListenerCount, 1);
+    assert.equal(panel.createArguments[3].retainContextWhenHidden, true);
     await panel.setVisible(false);
     revision = 2;
     onChange();
     await new Promise(resolve => setImmediate(resolve));
     assert.equal(panel.webview.html.includes('visible-r2'), true);
-    panel.webview.html = 'simulated destroyed hidden document';
+    const retainedDocument = panel.webview.html;
     await panel.setVisible(true);
 
-    assert.equal(panel.webview.html.includes('visible-r2'), true);
-    assert.equal(panel.webview.html.includes('&quot;selectedInput&quot;:1'), true);
-    assert.equal(panel.webview.html.includes('&quot;subscriptionGeneration&quot;:1'), true);
+    assert.equal(panel.webview.html, retainedDocument);
 
     panel.dispose();
     assert.equal(panel.viewStateListenerCount, 0);


### PR DESCRIPTION
## Summary

- reuse one correlated provider snapshot for initial Conversation rendering across Codex, Kimi, and Claude
- retain the existing Webview document while switching sessions and providers, with generation-safe atomic state replacement
- synchronize terminal authority without stealing Conversation focus and roll back when a runtime disappears or changes during switching
- add cross-provider performance, browser, runtime-focus, and race regression coverage

## Verification

- `npm run test:ci:linux`
- `npm run test:behavior-contracts`
- `SKIP_NPM_CI=1 npm run install-local` (both VSIX installations verified byte-for-byte)
- real-session snapshot probes: Kimi ~996 ms, Claude ~300 ms, Codex ~1694 ms, each using one shared revision
- final read-only review: no Critical or Important findings

## Skill harvest

- `none` — the review and CI friction was already covered by the repository's existing review/fix workflow guidance; no reusable skill change was justified
