### PR TITLE
Accelerate cross-provider conversation switching

### DIFF
--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "a7ba853f0e63c5fcad3378556b550aefe1c06a6d",
+        "head": "70cecf0bba10c3443fa0a0b182131e169726121e",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -169,7 +169,8 @@
             "988f8a1edfaeb211f39a2567d5faa698642ebe7f",
             "1ba1462088a1c347854f49d6abb8406816a7b6c7",
             "8fabc649a7093eba6a51e2509ca598aba8ee1746",
-            "7a0ebe7f08deb8081174cf0a59188218ae0e5dd3"
+            "7a0ebe7f08deb8081174cf0a59188218ae0e5dd3",
+            "06f98e5d4f2cdd022f4f964ba1e5e1888eab5e49"
         ]
     },
     "capabilities": [
@@ -1295,7 +1296,8 @@
                 "131b4c3b22bfaf2e7807a4a1379366db9d4ebc54",
                 "cc80a21cd6af2a684b60369cc3195bd3d9bf5f49",
                 "f0f1b0cf7267cb8fa77e7b14a396953325293fa9",
-                "a7ba853f0e63c5fcad3378556b550aefe1c06a6d"
+                "a7ba853f0e63c5fcad3378556b550aefe1c06a6d",
+                "70cecf0bba10c3443fa0a0b182131e169726121e"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",

--- a/src/aiSessions/conversation/composition.ts
+++ b/src/aiSessions/conversation/composition.ts
@@ -34,6 +34,7 @@ import {
     KimiConversationAdapterOptions,
 } from './kimiAdapter';
 import {
+    ConversationAbortController,
     ConversationError,
     ConversationProviderAdapter,
     ConversationSnapshot,
@@ -269,6 +270,17 @@ function createAvailableConversationCapability(
     ownership.transfer(codexAdapter);
     ownership.transfer(kimiAdapter);
     ownership.transfer(claudeAdapter);
+    const snapshotWarmup = typeof coordinator.readSnapshot === 'function'
+        && typeof coordinator.setSessionStopped === 'function'
+        ? ownership.own(new ConversationSnapshotWarmup({
+            readSnapshot: coordinator.readSnapshot.bind(coordinator),
+            setSessionStopped: coordinator.setSessionStopped.bind(coordinator),
+            resolveActiveTargets: options.resolveActiveTargets,
+            now: options.now,
+            setTimer: options.setTimer,
+            clearTimer: options.clearTimer,
+        }))
+        : undefined;
     let focusTail: Promise<void> = Promise.resolve();
     const queueFocus = (
         operation: () => void | PromiseLike<void>,
@@ -331,7 +343,8 @@ function createAvailableConversationCapability(
                 currentTarget,
                 () => intentGeneration === viewerIntentGeneration,
                 queueTerminalFocus,
-                terminalAuthority
+                terminalAuthority,
+                snapshotWarmup
             );
         },
         setKeyboardFocus: options.setConversationFocusContext,
@@ -357,7 +370,8 @@ function createAvailableConversationCapability(
                 coordinator,
                 viewer,
                 target,
-                () => intentGeneration === viewerIntentGeneration
+                () => intentGeneration === viewerIntentGeneration,
+                snapshotWarmup
             );
         },
         async openLatestActiveConversation(
@@ -369,7 +383,8 @@ function createAvailableConversationCapability(
                 coordinator,
                 viewer,
                 target,
-                () => intentGeneration === viewerIntentGeneration
+                () => intentGeneration === viewerIntentGeneration,
+                snapshotWarmup
             );
             if (result === 'opened') {
                 const currentTarget = viewer.getCurrentTarget();
@@ -391,7 +406,10 @@ function createAvailableConversationCapability(
             const resolution = await resolveLatestConversationTarget(
                 options,
                 coordinator,
-                target
+                target,
+                undefined,
+                undefined,
+                snapshotWarmup
             );
             if (intentGeneration !== viewerIntentGeneration) {
                 return 'superseded';
@@ -407,6 +425,11 @@ function createAvailableConversationCapability(
                 resolution.snapshot
             );
             if (followed) {
+                snapshotWarmup?.afterLoad(
+                    resolution.viewerTarget,
+                    resolution.prefetchedSnapshot === true,
+                    viewer
+                );
                 const currentTarget = viewer.getCurrentTarget();
                 terminalAuthority.confirmedTarget =
                     cloneConversationViewerTarget(
@@ -440,7 +463,8 @@ function createAvailableConversationCapability(
                     currentTarget,
                     isCurrent,
                     queueTerminalFocus,
-                    terminalAuthority
+                    terminalAuthority,
+                    snapshotWarmup
                 );
             } finally {
                 // A terminal focus from an older Webview switch may already
@@ -474,7 +498,8 @@ function createAvailableConversationCapability(
                 coordinator,
                 reboundTarget,
                 savedTarget.interactionId,
-                reboundRootChanged ? undefined : savedTarget.subagentId
+                reboundRootChanged ? undefined : savedTarget.subagentId,
+                snapshotWarmup
             );
             if (disposed || intentGeneration !== viewerIntentGeneration
                 || !resolution.viewerTarget) {
@@ -486,6 +511,11 @@ function createAvailableConversationCapability(
                     panel,
                     resolution.viewerTarget,
                     resolution.snapshot
+                );
+                snapshotWarmup?.afterLoad(
+                    resolution.viewerTarget,
+                    resolution.prefetchedSnapshot === true,
+                    viewer
                 );
             } catch (_error) {
                 panel.dispose();
@@ -619,12 +649,16 @@ async function openLatestConversation(
     coordinator: ConversationCoordinator,
     viewer: ConversationViewerApi,
     target: ConversationSessionOpenTarget,
-    isCurrent: () => boolean
+    isCurrent: () => boolean,
+    snapshotWarmup?: ConversationSnapshotWarmup
 ): Promise<OpenLatestConversationResult> {
     const resolution = await resolveLatestConversationTarget(
         options,
         coordinator,
-        target
+        target,
+        undefined,
+        undefined,
+        snapshotWarmup
     );
     if (!isCurrent()) {
         return 'superseded';
@@ -633,6 +667,11 @@ async function openLatestConversation(
         return resolution.result;
     }
     await viewer.open(resolution.viewerTarget, resolution.snapshot);
+    snapshotWarmup?.afterLoad(
+        resolution.viewerTarget,
+        resolution.prefetchedSnapshot === true,
+        viewer
+    );
     return 'opened';
 }
 
@@ -640,6 +679,7 @@ interface LatestConversationTargetResolution {
     result: OpenLatestConversationResult;
     viewerTarget?: ConversationViewerTarget;
     snapshot?: ConversationSnapshot;
+    prefetchedSnapshot?: boolean;
 }
 
 async function followAdjacentConversation(
@@ -655,7 +695,8 @@ async function followAdjacentConversation(
     ) => Promise<boolean>,
     terminalAuthority?: {
         confirmedTarget?: ConversationViewerTarget;
-    }
+    },
+    snapshotWarmup?: ConversationSnapshotWarmup
 ): Promise<FollowAdjacentConversationResult> {
     if (!viewer.isOpen()) {
         return 'closed';
@@ -704,7 +745,10 @@ async function followAdjacentConversation(
             projectId: currentTarget.projectId,
             provider: adjacent.provider,
             sessionId: adjacent.sessionId,
-        }
+        },
+        undefined,
+        undefined,
+        snapshotWarmup
     );
     if (!isCurrent()) {
         return 'superseded';
@@ -725,6 +769,11 @@ async function followAdjacentConversation(
     if (!followed) {
         return 'closed';
     }
+    snapshotWarmup?.afterLoad(
+        resolution.viewerTarget,
+        resolution.prefetchedSnapshot === true,
+        viewer
+    );
     if (queueTerminalFocus) {
         // Webview navigation syncs the terminal/tmux window. Command
         // navigation queues a Conversation reveal behind any terminal focus
@@ -792,12 +841,264 @@ function hasSameConversationSession(
         && left.sessionId === right.sessionId;
 }
 
+const CONVERSATION_SNAPSHOT_WARM_TTL_MS = 5_000;
+const CONVERSATION_SNAPSHOT_WARM_LIMIT = 4;
+
+interface WarmConversationSnapshot {
+    completedAt?: number;
+    abortController: ConversationAbortController;
+    promise: Promise<ConversationSnapshot | undefined>;
+    timeout?: ReturnType<typeof setTimeout>;
+    cancel(): void;
+}
+
+class ConversationSnapshotWarmup implements AiSessionDisposable {
+    private readonly snapshots = new Map<string, WarmConversationSnapshot>();
+    private readonly timers = new Set<ReturnType<typeof setTimeout>>();
+    private disposed = false;
+
+    constructor(private readonly options: {
+        readSnapshot(
+            provider: AiSessionProviderId,
+            sessionId: string,
+            preferredInteractionId?: string,
+            signal?: ConversationAbortController['signal']
+        ): Promise<ConversationSnapshot>;
+        setSessionStopped(
+            provider: AiSessionProviderId,
+            sessionId: string,
+            stopped: boolean
+        ): void;
+        resolveActiveTargets?: (
+            projectId: string
+        ) => readonly ActiveAiSessionViewModel[];
+        now(): number;
+        setTimer: typeof setTimeout;
+        clearTimer: typeof clearTimeout;
+    }) {}
+
+    take(
+        provider: AiSessionProviderId,
+        sessionId: string
+    ): Promise<ConversationSnapshot | undefined> | undefined {
+        const key = getWarmSnapshotKey(provider, sessionId);
+        const entry = this.snapshots.get(key);
+        if (!entry) {
+            return undefined;
+        }
+        if (entry.completedAt !== undefined
+            && this.options.now() - entry.completedAt
+                > CONVERSATION_SNAPSHOT_WARM_TTL_MS) {
+            this.snapshots.delete(key);
+            entry.cancel();
+            return undefined;
+        }
+        return entry.promise;
+    }
+
+    isDisposed(): boolean {
+        return this.disposed;
+    }
+
+    afterLoad(
+        target: ConversationViewerTarget,
+        prefetchedSnapshot: boolean,
+        viewer: ConversationViewerApi
+    ): void {
+        if (prefetchedSnapshot) {
+            this.schedule(async () => {
+                const current = viewer.getCurrentTarget();
+                if (current && hasSameConversationSession(current, target)) {
+                    await viewer.revalidateLatest?.(target.interactionId);
+                }
+            });
+        }
+        this.schedule(() => this.prefetchAdjacent(target, viewer));
+    }
+
+    dispose(): void {
+        if (this.disposed) {
+            return;
+        }
+        this.disposed = true;
+        this.timers.forEach(timer => this.options.clearTimer(timer));
+        this.timers.clear();
+        Array.from(this.snapshots.values()).forEach(entry => entry.cancel());
+        this.snapshots.clear();
+    }
+
+    private prefetchAdjacent(
+        target: ConversationViewerTarget,
+        viewer: ConversationViewerApi
+    ): void {
+        const current = viewer.getCurrentTarget();
+        if (!current || !hasSameConversationSession(current, target)
+            || typeof this.options.resolveActiveTargets !== 'function') {
+            return;
+        }
+        let sessions: readonly ActiveAiSessionViewModel[];
+        try {
+            sessions = this.options.resolveActiveTargets(target.projectId);
+        } catch (_error) {
+            return;
+        }
+        const switchable = sessions.filter(available =>
+            Boolean(available)
+                && typeof available.sessionId === 'string'
+                && available.sessionId.length > 0
+        ) as Array<ActiveAiSessionViewModel & { sessionId: string }>;
+        const currentIndex = switchable.findIndex(available =>
+            available.provider === target.provider
+                && available.sessionId === target.sessionId
+        );
+        if (currentIndex === -1 || switchable.length < 2) {
+            return;
+        }
+        const adjacent = new Map<string, ActiveAiSessionViewModel & {
+            sessionId: string;
+        }>();
+        for (const step of [-1, 1]) {
+            const candidate = switchable[
+                (currentIndex + step + switchable.length) % switchable.length
+            ];
+            adjacent.set(
+                getWarmSnapshotKey(candidate.provider, candidate.sessionId),
+                candidate
+            );
+        }
+        adjacent.forEach(candidate => this.prefetch(candidate));
+    }
+
+    private prefetch(
+        target: ActiveAiSessionViewModel & { sessionId: string }
+    ): void {
+        const key = getWarmSnapshotKey(target.provider, target.sessionId);
+        const existing = this.snapshots.get(key);
+        if (existing) {
+            if (existing.completedAt === undefined
+                || this.options.now() - existing.completedAt
+                    <= CONVERSATION_SNAPSHOT_WARM_TTL_MS) {
+                return;
+            }
+            this.snapshots.delete(key);
+            existing.cancel();
+        }
+        while (this.snapshots.size >= CONVERSATION_SNAPSHOT_WARM_LIMIT) {
+            const oldestKey = this.snapshots.keys().next().value;
+            if (typeof oldestKey !== 'string') {
+                break;
+            }
+            this.snapshots.get(oldestKey)?.cancel();
+            this.snapshots.delete(oldestKey);
+        }
+        this.options.setSessionStopped(
+            target.provider,
+            target.sessionId,
+            target.executionState === 'stopped'
+        );
+        const abortController = new ConversationAbortController();
+        let readSnapshot: Promise<ConversationSnapshot>;
+        try {
+            readSnapshot = this.options.readSnapshot(
+                target.provider,
+                target.sessionId,
+                undefined,
+                abortController.signal
+            );
+        } catch (_error) {
+            return;
+        }
+        let resolvePromise: (
+            snapshot: ConversationSnapshot | undefined
+        ) => void = () => undefined;
+        const promise = new Promise<ConversationSnapshot | undefined>(
+            resolve => { resolvePromise = resolve; }
+        );
+        let settled = false;
+        let entry: WarmConversationSnapshot;
+        const settle = (
+            snapshot: ConversationSnapshot | undefined,
+            abort: boolean
+        ): void => {
+            if (settled) {
+                return;
+            }
+            settled = true;
+            if (entry.timeout !== undefined) {
+                this.options.clearTimer(entry.timeout);
+                entry.timeout = undefined;
+            }
+            if (abort) {
+                abortController.abort();
+            }
+            if (snapshot) {
+                entry.completedAt = this.options.now();
+            } else if (this.snapshots.get(key) === entry) {
+                this.snapshots.delete(key);
+            }
+            resolvePromise(snapshot);
+        };
+        entry = {
+            abortController,
+            promise,
+            cancel: () => settle(undefined, true),
+        };
+        this.snapshots.set(key, entry);
+        let timeoutFiredSynchronously = false;
+        const timeout = this.options.setTimer(() => {
+            timeoutFiredSynchronously = true;
+            settle(undefined, true);
+        }, CONVERSATION_SNAPSHOT_WARM_TTL_MS);
+        if (!timeoutFiredSynchronously) {
+            entry.timeout = timeout;
+        }
+        void Promise.resolve(readSnapshot).then(
+            snapshot => settle(snapshot, false),
+            () => settle(undefined, false)
+        );
+    }
+
+    private schedule(operation: () => void | PromiseLike<void>): void {
+        if (this.disposed) {
+            return;
+        }
+        let handle: ReturnType<typeof setTimeout> | undefined;
+        let firedSynchronously = false;
+        const callback = (): void => {
+            firedSynchronously = true;
+            if (handle) {
+                this.timers.delete(handle);
+            }
+            if (this.disposed) {
+                return;
+            }
+            try {
+                void Promise.resolve(operation()).catch(() => undefined);
+            } catch (_error) {
+                // Warmup is optional and cannot break authoritative switching.
+            }
+        };
+        handle = this.options.setTimer(callback, 0);
+        if (!firedSynchronously) {
+            this.timers.add(handle);
+        }
+    }
+}
+
+function getWarmSnapshotKey(
+    provider: AiSessionProviderId,
+    sessionId: string
+): string {
+    return `${provider}:${sessionId}`;
+}
+
 async function resolveLatestConversationTarget(
     options: ConversationCapabilityOptions,
     coordinator: ConversationCoordinator,
     target: ConversationSessionOpenTarget,
     preferredInteractionId?: string,
-    subagentId?: string
+    subagentId?: string,
+    snapshotWarmup?: ConversationSnapshotWarmup
 ): Promise<LatestConversationTargetResolution> {
     const authoritativeTarget = resolveExactTarget(options, target);
     if (!authoritativeTarget) {
@@ -836,8 +1137,22 @@ async function resolveLatestConversationTarget(
         );
     }
     let snapshot: ConversationSnapshot;
+    let prefetchedSnapshot = false;
     try {
-        snapshot = typeof coordinator.readSnapshot === 'function'
+        const warmSnapshot = preferredInteractionId === undefined
+            && subagentId === undefined
+            ? snapshotWarmup?.take(target.provider, effectiveSessionId)
+            : undefined;
+        const resolvedWarmSnapshot = warmSnapshot
+            ? await warmSnapshot
+            : undefined;
+        if (warmSnapshot && !resolvedWarmSnapshot
+            && snapshotWarmup?.isDisposed()) {
+            return { result: 'unavailable' };
+        }
+        prefetchedSnapshot = Boolean(resolvedWarmSnapshot);
+        snapshot = resolvedWarmSnapshot || (
+            typeof coordinator.readSnapshot === 'function'
             ? await coordinator.readSnapshot(
                 target.provider,
                 effectiveSessionId,
@@ -848,7 +1163,7 @@ async function resolveLatestConversationTarget(
                     target.provider,
                     effectiveSessionId
                 ),
-            };
+            });
     } catch (_error) {
         return { result: 'unavailable' };
     }
@@ -880,6 +1195,7 @@ async function resolveLatestConversationTarget(
             ...(subagent ? { subagent } : {}),
         },
         snapshot,
+        prefetchedSnapshot,
     };
 }
 

--- a/src/aiSessions/conversation/viewer.ts
+++ b/src/aiSessions/conversation/viewer.ts
@@ -152,6 +152,7 @@ export interface ConversationViewerApi extends AiSessionDisposable {
         ) => Pick<ConversationViewerTarget, 'projectId' | 'provider' | 'sessionId'>
     ): Promise<boolean>;
     refresh(): Promise<void>;
+    revalidateLatest?(expectedInteractionId: string): Promise<void>;
     refreshPresentation(): Promise<void>;
     reconcileAuthority(
         resolveAuthority: (
@@ -217,6 +218,8 @@ export class ConversationViewer implements ConversationViewerApi {
     private rebindGeneration = 0;
     private authoritativeLoadInFlight?: Promise<boolean>;
     private authoritativeRefreshPending = false;
+    private authoritativeLatestRefreshPending?: string;
+    private subagentDiscoveryGeneration = 0;
     private keyboardFocused = false;
     private readonly commentController: ConversationCommentController;
     private readonly bookmarkController: ConversationBookmarkController;
@@ -489,6 +492,19 @@ export class ConversationViewer implements ConversationViewerApi {
         await this.loadAuthoritative('refresh', false);
     }
 
+    async revalidateLatest(expectedInteractionId: string): Promise<void> {
+        if (!this.target || !this.panel || this.suspended
+            || this.outlineController.selection !== expectedInteractionId) {
+            return;
+        }
+        await this.loadAuthoritative(
+            'refresh',
+            false,
+            undefined,
+            expectedInteractionId
+        );
+    }
+
     async refreshPresentation(): Promise<void> {
         const pendingLoad = this.authoritativeLoadInFlight;
         if (pendingLoad) {
@@ -593,6 +609,8 @@ export class ConversationViewer implements ConversationViewerApi {
     private replaceTarget(target: ConversationViewerTarget): number {
         this.authoritativeLoadInFlight = undefined;
         this.authoritativeRefreshPending = false;
+        this.authoritativeLatestRefreshPending = undefined;
+        this.subagentDiscoveryGeneration += 1;
         this.abortController?.abort();
         this.abortController = undefined;
         this.watch?.dispose();
@@ -676,6 +694,8 @@ export class ConversationViewer implements ConversationViewerApi {
     private clear(_restoreTarget: ConversationViewerTarget | undefined): void {
         this.authoritativeLoadInFlight = undefined;
         this.authoritativeRefreshPending = false;
+        this.authoritativeLatestRefreshPending = undefined;
+        this.subagentDiscoveryGeneration += 1;
         this.abortController?.abort();
         this.abortController = undefined;
         this.watch?.dispose();
@@ -817,6 +837,8 @@ export class ConversationViewer implements ConversationViewerApi {
         }
         this.authoritativeLoadInFlight = undefined;
         this.authoritativeRefreshPending = false;
+        this.authoritativeLatestRefreshPending = undefined;
+        this.subagentDiscoveryGeneration += 1;
         this.abortController?.abort();
         this.abortController = undefined;
         this.watch?.dispose();
@@ -1030,17 +1052,22 @@ export class ConversationViewer implements ConversationViewerApi {
     private loadAuthoritative(
         updateKind: 'initial' | 'refresh',
         replaceDocument: boolean,
-        snapshot?: ConversationSnapshot
+        snapshot?: ConversationSnapshot,
+        latestIfSelection?: string
     ): Promise<boolean> {
         if (this.authoritativeLoadInFlight) {
             this.authoritativeRefreshPending = true;
+            if (latestIfSelection !== undefined) {
+                this.authoritativeLatestRefreshPending = latestIfSelection;
+            }
             return this.authoritativeLoadInFlight;
         }
         let loadInFlight: Promise<boolean>;
         loadInFlight = this.performAuthoritativeLoad(
             updateKind,
             replaceDocument,
-            snapshot
+            snapshot,
+            latestIfSelection
         ).finally(() => {
             if (this.authoritativeLoadInFlight !== loadInFlight) {
                 return;
@@ -1053,7 +1080,14 @@ export class ConversationViewer implements ConversationViewerApi {
                 return;
             }
             this.authoritativeRefreshPending = false;
-            void this.loadAuthoritative('refresh', false);
+            const pendingLatest = this.authoritativeLatestRefreshPending;
+            this.authoritativeLatestRefreshPending = undefined;
+            void this.loadAuthoritative(
+                'refresh',
+                false,
+                undefined,
+                pendingLatest
+            );
         });
         this.authoritativeLoadInFlight = loadInFlight;
         return loadInFlight;
@@ -1062,7 +1096,8 @@ export class ConversationViewer implements ConversationViewerApi {
     private async performAuthoritativeLoad(
         updateKind: 'initial' | 'refresh',
         replaceDocument: boolean,
-        prefetchedSnapshot?: ConversationSnapshot
+        prefetchedSnapshot?: ConversationSnapshot,
+        latestIfSelection?: string
     ): Promise<boolean> {
         const target = this.target;
         const panel = this.panel;
@@ -1073,13 +1108,20 @@ export class ConversationViewer implements ConversationViewerApi {
         const abortController = new ConversationAbortController();
         this.abortController = abortController;
         const generation = this.subscriptionGeneration;
+        const subagentDiscoveryGeneration =
+            ++this.subagentDiscoveryGeneration;
         const requestId = this.allocateRequestId();
         this.currentRequestId = requestId;
         const previousSelectedInteractionId = this.outlineController.selection;
+        const advanceToLatest = updateKind === 'refresh'
+            && latestIfSelection !== undefined
+            && previousSelectedInteractionId === latestIfSelection;
         try {
             const preferredInteractionId = updateKind === 'initial'
                 ? target.interactionId
-                : previousSelectedInteractionId;
+                : advanceToLatest
+                    ? undefined
+                    : previousSelectedInteractionId;
             let snapshot = prefetchedSnapshot;
             if (!snapshot && this.options.readSnapshot) {
                 snapshot = await this.options.readSnapshot(
@@ -1112,14 +1154,17 @@ export class ConversationViewer implements ConversationViewerApi {
                 return false;
             }
             if (updateKind === 'refresh'
+                && !advanceToLatest
                 && (!previousSelectedInteractionId
                     || !interactionIds.includes(previousSelectedInteractionId))) {
                 await this.publishFailure(replaceDocument, updateKind);
                 return false;
             }
-            const selectedInteractionId = updateKind === 'initial'
+            let selectedInteractionId = updateKind === 'initial'
                 ? target.interactionId
-                : previousSelectedInteractionId as string;
+                : advanceToLatest
+                    ? interactionIds[interactionIds.length - 1]
+                    : previousSelectedInteractionId as string;
             const retainedOutline = this.outlineController.snapshot;
             if (updateKind === 'refresh'
                 && !this.stale
@@ -1189,6 +1234,11 @@ export class ConversationViewer implements ConversationViewerApi {
                         await this.publishFailure(replaceDocument, updateKind);
                         return false;
                     }
+                    if (advanceToLatest) {
+                        selectedInteractionId = outline.interactions[
+                            outline.interactions.length - 1
+                        ].id;
+                    }
                     if (!outline.interactions.some(
                         interaction => interaction.id === selectedInteractionId
                     )) {
@@ -1227,7 +1277,6 @@ export class ConversationViewer implements ConversationViewerApi {
             } else {
                 this.retain(page, 'replace');
             }
-            this.subagents = await this.readSubagentsSafely(target);
             if (!this.canPublish(panel, target, generation, requestId)) {
                 return false;
             }
@@ -1237,6 +1286,12 @@ export class ConversationViewer implements ConversationViewerApi {
                 updateKind
             );
             await this.deliverPublication(publication, replaceDocument);
+            this.refreshSubagentsAfterPublication(
+                panel,
+                target,
+                generation,
+                subagentDiscoveryGeneration
+            );
             void this.telemetryController.refresh(
                 target,
                 generation,
@@ -1257,6 +1312,39 @@ export class ConversationViewer implements ConversationViewerApi {
         }
     }
 
+    private refreshSubagentsAfterPublication(
+        panel: vscode.WebviewPanel,
+        target: ConversationViewerTarget,
+        generation: number,
+        discoveryGeneration: number
+    ): void {
+        if (this.panel !== panel
+            || this.target !== target
+            || this.suspended
+            || this.subscriptionGeneration !== generation
+            || this.subagentDiscoveryGeneration !== discoveryGeneration) {
+            return;
+        }
+        void this.readSubagentsSafely(target).then(async subagents => {
+            if (this.panel !== panel
+                || this.target !== target
+                || this.suspended
+                || this.subscriptionGeneration !== generation
+                || this.subagentDiscoveryGeneration !== discoveryGeneration
+                || sameSubagents(this.subagents, subagents)) {
+                return;
+            }
+            this.subagents = subagents.map(entry => ({ ...entry }));
+            const requestId = this.allocateRequestId();
+            this.currentRequestId = requestId;
+            await this.deliverPublication(this.createPublication(
+                requestId,
+                generation,
+                'refresh'
+            ), false);
+        }).catch(() => undefined);
+    }
+
     private async read(
         request: ConversationPageRequest,
         placement: 'replace' | 'before' | 'after',
@@ -1273,6 +1361,8 @@ export class ConversationViewer implements ConversationViewerApi {
         const abortController = new ConversationAbortController();
         this.abortController = abortController;
         const generation = this.subscriptionGeneration;
+        const subagentDiscoveryGeneration =
+            ++this.subagentDiscoveryGeneration;
         const requestId = this.allocateRequestId();
         this.currentRequestId = requestId;
         const previousOutline = this.outlineController.snapshot;
@@ -1351,6 +1441,12 @@ export class ConversationViewer implements ConversationViewerApi {
                 updateKind
             );
             await this.deliverPublication(publication, replaceDocument);
+            this.refreshSubagentsAfterPublication(
+                panel,
+                target,
+                generation,
+                subagentDiscoveryGeneration
+            );
             return true;
         } catch (_error) {
             if (!this.canPublish(panel, target, generation, requestId)
@@ -1738,6 +1834,22 @@ export class ConversationViewer implements ConversationViewerApi {
             return false;
         }
     }
+}
+
+function sameSubagents(
+    left: readonly ConversationSubagentEntry[],
+    right: readonly ConversationSubagentEntry[]
+): boolean {
+    return left.length === right.length && left.every((entry, index) => {
+        const candidate = right[index];
+        return Boolean(candidate)
+            && entry.id === candidate.id
+            && entry.label === candidate.label
+            && entry.agentType === candidate.agentType
+            && entry.status === candidate.status
+            && entry.createdAt === candidate.createdAt
+            && entry.updatedAt === candidate.updatedAt;
+    });
 }
 
 function cloneViewerTarget(

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -371,6 +371,46 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 applies an authoritative cross-
     });
 });
 
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 adds late subagents without replacing readable Conversation messages', async t => {
+    const { page } = await openHostViewerDocument(t);
+    const html = messageHtml('readable-before-subagents', 2);
+    await sendPage(page, {
+        ...hostileConversationPage,
+        requestId: 50,
+        updateKind: 'initial',
+        html,
+        subagents: [],
+    });
+    await page.locator('[data-message-id="readable-before-subagents-0"]')
+        .evaluate(element => { element.__retainedAfterSubagents = true; });
+
+    await sendPage(page, {
+        ...hostileConversationPage,
+        requestId: 51,
+        updateKind: 'refresh',
+        html,
+        subagents: [{
+            id: 'a11111111',
+            label: 'Late provider worker',
+            status: 'running',
+            updatedAt: 1_780_000_000_000,
+        }],
+    });
+
+    assert.equal(await page.locator(
+        '[data-message-id="readable-before-subagents-0"]'
+    ).evaluate(element => element.__retainedAfterSubagents), true,
+    'a late optional update must retain the readable message DOM');
+    assert.equal(
+        await page.locator('[data-subagent-id="a11111111"]').count(),
+        1
+    );
+    assert.equal(
+        await page.locator('[data-telemetry-subagents]').innerText(),
+        '1/1'
+    );
+});
+
 test('CONVERSATION-TELEMETRY-001 CONVERSATION-TELEMETRY-CONTROLLER-001 renders correlated model, context, and weekly quota updates in place', async t => {
     const page = await openViewerPage(t);
     await sendPage(page, {

--- a/tests/integration/dashboard/conversationOpenLatest.test.js
+++ b/tests/integration/dashboard/conversationOpenLatest.test.js
@@ -133,6 +133,9 @@ function createHarness(options = {}) {
     let capturedViewerOptions;
     let outlineReads = 0;
     let snapshotReads = 0;
+    const snapshotReadTargets = [];
+    let viewerRefreshes = 0;
+    let currentViewerTarget;
     const session = 'session' in options ? options.session : makeSession({
         conversationDisplayName: options.conversationDisplayName,
         duplicateConversationDisplayName:
@@ -140,8 +143,17 @@ function createHarness(options = {}) {
     });
     const fakeAdapter = provider => () => ({
         ...(options.enableSnapshots ? {
-            async readSnapshot(sessionId, preferredInteractionId) {
+            async readSnapshot(sessionId, preferredInteractionId, signal) {
                 snapshotReads += 1;
+                snapshotReadTargets.push(`${provider}:${sessionId}`);
+                if (options.readSnapshot) {
+                    return options.readSnapshot(
+                        provider,
+                        sessionId,
+                        preferredInteractionId,
+                        signal
+                    );
+                }
                 const interactionIds = options.interactionIds
                     || ['input-a', 'input-b'];
                 const selected = interactionIds.includes(preferredInteractionId)
@@ -197,9 +209,10 @@ function createHarness(options = {}) {
         spawnCodex: () => {
             throw new Error('spawnCodex is not used by openLatestConversation');
         },
-        now: () => Date.now(),
-        setTimer: (callback, delayMs) => setTimeout(callback, delayMs),
-        clearTimer: handle => clearTimeout(handle),
+        now: options.now || (() => Date.now()),
+        setTimer: options.setTimer
+            || ((callback, delayMs) => setTimeout(callback, delayMs)),
+        clearTimer: options.clearTimer || (handle => clearTimeout(handle)),
         onDiagnostic: () => {},
         resolveReboundTarget: options.resolveReboundTarget,
     }, {
@@ -215,6 +228,7 @@ function createHarness(options = {}) {
                     options.getCurrentViewerTarget?.()
                     || options.getFocusedViewerTarget?.()
                     || options.focusedViewerTarget
+                    || currentViewerTarget
                 ),
                 getFocusedTarget: () => (
                     options.getFocusedViewerTarget?.()
@@ -233,6 +247,7 @@ function createHarness(options = {}) {
                 open: async (target, snapshot) => {
                     viewerTargets.push(target);
                     viewerSnapshots.push(snapshot);
+                    currentViewerTarget = target;
                     await options.openViewer?.(target);
                 },
                 restore: async (panel, target) => {
@@ -241,9 +256,14 @@ function createHarness(options = {}) {
                 follow: async (target, snapshot) => {
                     followedViewerTargets.push(target);
                     viewerSnapshots.push(snapshot);
-                    return options.followViewer
+                    const followed = options.followViewer
                         ? options.followViewer(target)
                         : true;
+                    if (await followed) {
+                        currentViewerTarget = target;
+                        return true;
+                    }
+                    return false;
                 },
                 focus: () => {
                     viewerFocuses += 1;
@@ -252,7 +272,8 @@ function createHarness(options = {}) {
                 },
                 rebindSession: async () => false,
                 freezeSessionMetadata: async () => false,
-                refresh: async () => undefined,
+                refresh: async () => { viewerRefreshes += 1; },
+                revalidateLatest: async () => { viewerRefreshes += 1; },
                 reconcileAuthority: async () => undefined,
                 dispose() {},
             };
@@ -272,6 +293,12 @@ function createHarness(options = {}) {
         },
         get snapshotReads() {
             return snapshotReads;
+        },
+        get snapshotReadTargets() {
+            return [...snapshotReadTargets];
+        },
+        get viewerRefreshes() {
+            return viewerRefreshes;
         },
         get viewerFocuses() {
             return viewerFocuses;
@@ -324,6 +351,189 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 opens Codex, Kimi, and Claude w
         assert.equal(harness.viewerSnapshots[0].page.provider, provider);
         harness.capability.dispose();
     }
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 warms adjacent Codex, Kimi, and Claude snapshots and revalidates after instant switching', async () => {
+    const sessions = ['codex', 'kimi', 'claude'].map((provider, index) =>
+        makeSession({
+            key: `${provider}:session-${index}`,
+            provider,
+            sessionId: `session-${index}`,
+            name: `${provider} Session`,
+        })
+    );
+    const harness = createHarness({
+        enableSnapshots: true,
+        requireSnapshot: true,
+        viewerOpen: true,
+        session: sessions[0],
+        resolveTarget: (_projectId, provider, sessionId) =>
+            sessions.find(session => session.provider === provider
+                && session.sessionId === sessionId) || null,
+        resolveActiveTargets: () => sessions,
+    });
+
+    assert.equal(await harness.capability.openLatestConversation({
+        projectId: 'project-a',
+        provider: 'codex',
+        sessionId: 'session-0',
+    }), 'opened');
+    await new Promise(resolve => setTimeout(resolve, 10));
+    assert.deepEqual(harness.snapshotReadTargets.sort(), [
+        'claude:session-2',
+        'codex:session-0',
+        'kimi:session-1',
+    ]);
+
+    assert.equal(await harness.capability.followActiveConversation({
+        projectId: 'project-a',
+        provider: 'kimi',
+        sessionId: 'session-1',
+    }), 'opened');
+    assert.equal(harness.snapshotReadTargets.filter(target =>
+        target === 'kimi:session-1'
+    ).length, 1, 'Kimi switch must consume the warm snapshot');
+
+    assert.equal(await harness.capability.followActiveConversation({
+        projectId: 'project-a',
+        provider: 'claude',
+        sessionId: 'session-2',
+    }), 'opened');
+    assert.equal(harness.snapshotReadTargets.filter(target =>
+        target === 'claude:session-2'
+    ).length, 1, 'Claude switch must consume the warm snapshot');
+    await new Promise(resolve => setTimeout(resolve, 10));
+    assert.equal(harness.viewerRefreshes, 1,
+        'only the latest warm switch may run its authoritative refresh');
+    harness.capability.dispose();
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 shares a slow in-flight warmup instead of starting a duplicate provider read', async () => {
+    const sessions = ['codex', 'kimi'].map((provider, index) => makeSession({
+        key: `${provider}:slow-${index}`,
+        provider,
+        sessionId: `slow-${index}`,
+        name: `${provider} Session`,
+    }));
+    const slowKimiSnapshot = deferred();
+    let now = 1_000;
+    const harness = createHarness({
+        enableSnapshots: true,
+        requireSnapshot: true,
+        viewerOpen: true,
+        session: sessions[0],
+        now: () => now,
+        resolveTarget: (_projectId, provider, sessionId) =>
+            sessions.find(session => session.provider === provider
+                && session.sessionId === sessionId) || null,
+        resolveActiveTargets: () => sessions,
+        readSnapshot: async (provider, sessionId) => {
+            if (provider === 'kimi') {
+                return slowKimiSnapshot.promise;
+            }
+            return {
+                outline: makeOutline(provider, sessionId, ['input-a']),
+                page: makePage(provider, sessionId, 'input-a'),
+            };
+        },
+    });
+
+    assert.equal(await harness.capability.openLatestConversation({
+        projectId: 'project-a',
+        provider: 'codex',
+        sessionId: 'slow-0',
+    }), 'opened');
+    while (!harness.snapshotReadTargets.includes('kimi:slow-1')) {
+        await new Promise(resolve => setImmediate(resolve));
+    }
+
+    now += 10_000;
+    const supersededSwitch = harness.capability.followActiveConversation({
+        projectId: 'project-a',
+        provider: 'kimi',
+        sessionId: 'slow-1',
+    });
+    await new Promise(resolve => setImmediate(resolve));
+    const switching = harness.capability.followActiveConversation({
+        projectId: 'project-a',
+        provider: 'kimi',
+        sessionId: 'slow-1',
+    });
+    await new Promise(resolve => setImmediate(resolve));
+    assert.equal(harness.snapshotReadTargets.filter(target =>
+        target === 'kimi:slow-1'
+    ).length, 1, 'rapid intents must share the existing warmup');
+
+    slowKimiSnapshot.resolve({
+        outline: makeOutline('kimi', 'slow-1', ['input-a']),
+        page: makePage('kimi', 'slow-1', 'input-a'),
+    });
+    assert.equal(await supersededSwitch, 'superseded');
+    assert.equal(await switching, 'opened');
+    harness.capability.dispose();
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 times out a hung speculative read before the user switches', async () => {
+    const sessions = ['codex', 'kimi'].map((provider, index) => makeSession({
+        key: `${provider}:hung-${index}`,
+        provider,
+        sessionId: `hung-${index}`,
+        name: `${provider} Session`,
+    }));
+    const timers = [];
+    let kimiReads = 0;
+    const harness = createHarness({
+        enableSnapshots: true,
+        requireSnapshot: true,
+        viewerOpen: true,
+        session: sessions[0],
+        resolveTarget: (_projectId, provider, sessionId) =>
+            sessions.find(session => session.provider === provider
+                && session.sessionId === sessionId) || null,
+        resolveActiveTargets: () => sessions,
+        setTimer: (callback, delayMs) => {
+            const timer = { callback, delayMs, cleared: false };
+            timers.push(timer);
+            if (delayMs === 0) {
+                setImmediate(() => {
+                    if (!timer.cleared) callback();
+                });
+            }
+            return timer;
+        },
+        clearTimer: timer => { timer.cleared = true; },
+        readSnapshot: async (provider, sessionId) => {
+            if (provider === 'kimi' && ++kimiReads === 1) {
+                return new Promise(() => {});
+            }
+            return {
+                outline: makeOutline(provider, sessionId, ['input-a']),
+                page: makePage(provider, sessionId, 'input-a'),
+            };
+        },
+    });
+
+    assert.equal(await harness.capability.openLatestConversation({
+        projectId: 'project-a',
+        provider: 'codex',
+        sessionId: 'hung-0',
+    }), 'opened');
+    while (!harness.snapshotReadTargets.includes('kimi:hung-1')) {
+        await new Promise(resolve => setImmediate(resolve));
+    }
+    const warmTimeout = timers.find(timer => timer.delayMs === 5_000);
+    assert.ok(warmTimeout, 'the speculative read must have a hard timeout');
+    warmTimeout.callback();
+    await new Promise(resolve => setImmediate(resolve));
+
+    assert.equal(await harness.capability.followActiveConversation({
+        projectId: 'project-a',
+        provider: 'kimi',
+        sessionId: 'hung-1',
+    }), 'opened');
+    assert.equal(kimiReads, 2,
+        'the user switch must retry after the hung warmup is abandoned');
+    harness.capability.dispose();
 });
 
 test('WEBVIEW-AI-SESSION-CONVERSATION-VIEWER-001 dashboard registers a serializer that restores AI Conversation panels', () => {

--- a/tests/integration/dashboard/conversationViewer.test.js
+++ b/tests/integration/dashboard/conversationViewer.test.js
@@ -239,6 +239,7 @@ function createViewer(options = {}) {
         },
         readOutline: options.readOutline || (async (_provider, sessionId) =>
             outline(sessionId, ['input-1'])),
+        readSnapshot: options.readSnapshot,
         readPage: options.readPage || (async request =>
             page(request.sessionId, request.anchorInteractionId)),
         readSubagents: options.readSubagents,
@@ -611,7 +612,9 @@ test('WEBVIEW-AI-SESSION-SUBAGENT-VIEWER-001 opens a subagent transcript in plac
     });
 
     await viewer.open(target('session-a', 'input-a'));
-    const initial = decodeInitialPublication(panel.webview.html);
+    await new Promise(resolve => setImmediate(resolve));
+    const initial = panel.postedMessages.at(-1)
+        || decodeInitialPublication(panel.webview.html);
     assert.deepEqual(
         initial.subagents.map(entry => [entry.id, entry.status]),
         [['a11111111', 'running']]
@@ -683,6 +686,257 @@ test('WEBVIEW-AI-SESSION-SUBAGENT-VIEWER-001 opens a subagent transcript in plac
         publication.outline.map(entry => entry.interactionId),
         ['input-a', 'input-b']
     );
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 publishes readable content before optional subagent discovery settles for every provider', async () => {
+    for (const provider of ['codex', 'kimi', 'claude']) {
+        const subagents = deferred();
+        let openSettled = false;
+        const sessionId = `${provider}-nonblocking-subagents`;
+        const { viewer, panel } = createViewer({
+            readOutline: async () => ({
+                ...outline(sessionId, ['input-1']),
+                provider,
+            }),
+            readPage: async request => ({
+                ...page(sessionId, request.anchorInteractionId, `${provider}-visible`),
+                provider,
+            }),
+            readSubagents: async () => subagents.promise,
+        });
+
+        const opening = viewer.open(target(sessionId, 'input-1', { provider }))
+            .then(() => { openSettled = true; });
+        await new Promise(resolve => setImmediate(resolve));
+        const settledBeforeSubagents = openSettled;
+        const readableBeforeSubagents = panel.webview.html.includes(
+            `${provider}-visible`
+        ) || panel.postedMessages.some(message =>
+            message.html?.includes(`${provider}-visible`)
+        );
+
+        subagents.resolve([{
+            id: 'a11111111',
+            label: `${provider} worker`,
+            status: 'running',
+        }]);
+        await opening;
+
+        assert.equal(settledBeforeSubagents, true,
+            `${provider} content publication must not await subagents`);
+        assert.equal(readableBeforeSubagents, true,
+            `${provider} readable content must precede subagents`);
+        viewer.dispose();
+    }
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 keeps late subagents after same-session navigation supersedes the page request', async () => {
+    const subagents = deferred();
+    const sessionId = 'navigated-while-discovering';
+    const { viewer, panel } = createViewer({
+        readOutline: async () => outline(
+            sessionId,
+            ['input-1', 'input-2']
+        ),
+        readPage: async request => page(
+            sessionId,
+            request.anchorInteractionId,
+            'readable',
+            {
+                interactionIds: ['input-1', 'input-2'],
+                anchorInteractionId: request.anchorInteractionId,
+            }
+        ),
+        readSubagents: async () => subagents.promise,
+    });
+
+    await viewer.open(target(sessionId, 'input-2'));
+    await panel.receive({
+        type: 'conversation-viewer-previous',
+        version: 1,
+    });
+    assert.equal(panel.postedMessages.at(-1).selectedInteractionId, 'input-1');
+
+    subagents.resolve([{
+        id: 'a11111111',
+        label: 'Late worker',
+        status: 'running',
+    }]);
+    await new Promise(resolve => setImmediate(resolve));
+    assert.deepEqual(
+        panel.postedMessages.at(-1).subagents.map(entry => entry.id),
+        ['a11111111']
+    );
+    assert.equal(panel.postedMessages.at(-1).selectedInteractionId, 'input-1');
+    viewer.dispose();
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 prevents an older subagent result from superseding a newer authoritative refresh', async () => {
+    const sessionId = 'refresh-while-discovering';
+    const refreshedOutline = deferred();
+    const firstSubagents = deferred();
+    const secondSubagents = deferred();
+    let outlineReads = 0;
+    let subagentReads = 0;
+    const { viewer, panel } = createViewer({
+        readOutline: async () => {
+            outlineReads += 1;
+            if (outlineReads === 2) {
+                return refreshedOutline.promise;
+            }
+            return outline(sessionId, ['input-1']);
+        },
+        readPage: async request => page(
+            sessionId,
+            request.anchorInteractionId,
+            request.expectedRevision,
+            { sourceRevision: request.expectedRevision }
+        ),
+        readSubagents: async () => (
+            ++subagentReads === 1
+                ? firstSubagents.promise
+                : secondSubagents.promise
+        ),
+    });
+
+    await viewer.open(target(sessionId, 'input-1'));
+    const refreshing = viewer.refresh();
+    await new Promise(resolve => setImmediate(resolve));
+    firstSubagents.resolve([{
+        id: 'stale-worker',
+        label: 'Stale worker',
+        status: 'running',
+    }]);
+    await new Promise(resolve => setImmediate(resolve));
+    refreshedOutline.resolve(outline(
+        sessionId,
+        ['input-1'],
+        { sourceRevision: 'r2' }
+    ));
+    await refreshing;
+    secondSubagents.resolve([{
+        id: 'current-worker',
+        label: 'Current worker',
+        status: 'running',
+    }]);
+    await new Promise(resolve => setImmediate(resolve));
+
+    assert.deepEqual(
+        panel.postedMessages.at(-1).subagents.map(entry => entry.id),
+        ['current-worker']
+    );
+    assert.match(panel.postedMessages.at(-1).html, /r2/);
+    viewer.dispose();
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 prevents an older subagent result from cancelling cross-page navigation', async () => {
+    const sessionId = 'cross-page-while-discovering';
+    const navigationPage = deferred();
+    const firstSubagents = deferred();
+    const secondSubagents = deferred();
+    let pageReads = 0;
+    let subagentReads = 0;
+    const { viewer, panel } = createViewer({
+        readOutline: async () => outline(
+            sessionId,
+            ['input-1', 'input-2']
+        ),
+        readPage: async request => {
+            pageReads += 1;
+            if (pageReads === 2) {
+                return navigationPage.promise;
+            }
+            return page(sessionId, 'input-2', 'initial', {
+                interactionIds: ['input-2'],
+                anchorInteractionId: 'input-2',
+                previousCursor: 'before-input-2',
+            });
+        },
+        readSubagents: async () => (
+            ++subagentReads === 1
+                ? firstSubagents.promise
+                : secondSubagents.promise
+        ),
+    });
+
+    await viewer.open(target(sessionId, 'input-2'));
+    const navigating = panel.receive({
+        type: 'conversation-viewer-previous',
+        version: 1,
+    });
+    await new Promise(resolve => setImmediate(resolve));
+    firstSubagents.resolve([{
+        id: 'stale-worker',
+        label: 'Stale worker',
+        status: 'running',
+    }]);
+    await new Promise(resolve => setImmediate(resolve));
+    navigationPage.resolve(page(sessionId, 'input-1', 'navigated', {
+        interactionIds: ['input-1'],
+        anchorInteractionId: 'input-1',
+        nextCursor: 'after-input-1',
+    }));
+    await navigating;
+    secondSubagents.resolve([{
+        id: 'current-worker',
+        label: 'Current worker',
+        status: 'running',
+    }]);
+    await new Promise(resolve => setImmediate(resolve));
+
+    assert.equal(panel.postedMessages.at(-1).selectedInteractionId, 'input-1');
+    assert.match(panel.postedMessages.at(-1).html, /navigated/);
+    assert.deepEqual(
+        panel.postedMessages.at(-1).subagents.map(entry => entry.id),
+        ['current-worker']
+    );
+    viewer.dispose();
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 revalidates a warm latest snapshot without overriding later user navigation', async () => {
+    const sessionId = 'warm-latest';
+    let authoritativeReads = 0;
+    const snapshot = {
+        outline: outline(sessionId, ['input-1', 'input-2']),
+        page: page(sessionId, 'input-2', 'warm', {
+            interactionIds: ['input-1', 'input-2'],
+            anchorInteractionId: 'input-2',
+        }),
+    };
+    const { viewer, panel } = createViewer({
+        readSnapshot: async () => {
+            authoritativeReads += 1;
+            return {
+                outline: outline(
+                    sessionId,
+                    ['input-1', 'input-2', 'input-3'],
+                    { sourceRevision: 'r2' }
+                ),
+                page: page(sessionId, 'input-3', 'authoritative', {
+                    interactionIds: ['input-1', 'input-2', 'input-3'],
+                    anchorInteractionId: 'input-3',
+                    sourceRevision: 'r2',
+                }),
+            };
+        },
+    });
+
+    await viewer.open(target(sessionId, 'input-2'), snapshot);
+    await viewer.revalidateLatest('input-2');
+    assert.equal(panel.postedMessages.at(-1).selectedInteractionId, 'input-3');
+    assert.equal(authoritativeReads, 1);
+
+    await viewer.open(target(sessionId, 'input-2'), snapshot);
+    await panel.receive({
+        type: 'conversation-viewer-previous',
+        version: 1,
+    });
+    assert.equal(panel.postedMessages.at(-1).selectedInteractionId, 'input-1');
+    await viewer.revalidateLatest('input-2');
+    assert.equal(panel.postedMessages.at(-1).selectedInteractionId, 'input-1');
+    assert.equal(authoritativeReads, 1,
+        'manual navigation must cancel the automatic latest revalidation');
+    viewer.dispose();
 });
 
 test('CONVERSATION-VIEWER-OWNERSHIP-001 reuses one panel, rejects an old session generation, and clears sensitive state on disposal', async () => {


### PR DESCRIPTION
## Summary

- prefetch adjacent Codex, Kimi, and Claude conversation snapshots with bounded ownership, sharing, expiry, and timeout behavior
- publish readable conversation content before optional subagent discovery, then reconcile late metadata without replacing stable message DOM
- revalidate cached switches against the authoritative latest interaction while preserving explicit user navigation and closing refresh/navigation races
- add integration and browser regression coverage for rapid intents, hung warmups, late subagents, and cross-page navigation

No version or release metadata is changed.

## Skill harvest

no skill change — the existing regression and review skills already required RED-first coverage and final read-only review, which exposed and closed the task-specific races.

## Verification

- `npm run test:ci:linux`
- `npm run test:behavior-contracts` after the capability-audit commit
- final read-only integration review: no Critical or Important findings
- packaged and locally installed `hzcheng.agent-pivot@1.0.4` and `hzcheng.agent-pivot-attention-ui-bridge@1.0.1`; packaged and installed runtime hashes matched
- changed-line coverage: 91.09% (409/449)