### PR TITLE
fix: allow global active session navigation

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -4588,7 +4588,7 @@
   {
     "id": "CONVERSATION-ACTIVE-SESSION-NAVIGATION-COMMANDS-001",
     "domain": "session",
-    "title": "Previous and Next Active Session commands synchronize the authoritative active terminal and card while restoring keyboard focus to AI Conversation",
+    "title": "Previous and Next Active Session commands remain globally available, synchronize the authoritative active terminal and card, and restore keyboard focus to AI Conversation",
     "priority": "P1",
     "status": "automated",
     "owners": [

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "70cecf0bba10c3443fa0a0b182131e169726121e",
+        "head": "8bef5e6e4ecffde948dd4fbb94e273fff78426fa",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -170,7 +170,8 @@
             "1ba1462088a1c347854f49d6abb8406816a7b6c7",
             "8fabc649a7093eba6a51e2509ca598aba8ee1746",
             "7a0ebe7f08deb8081174cf0a59188218ae0e5dd3",
-            "06f98e5d4f2cdd022f4f964ba1e5e1888eab5e49"
+            "06f98e5d4f2cdd022f4f964ba1e5e1888eab5e49",
+            "8a4457cce77ac21f1955d50438d223ce4c6cdc7f"
         ]
     },
     "capabilities": [
@@ -1297,7 +1298,8 @@
                 "cc80a21cd6af2a684b60369cc3195bd3d9bf5f49",
                 "f0f1b0cf7267cb8fa77e7b14a396953325293fa9",
                 "a7ba853f0e63c5fcad3378556b550aefe1c06a6d",
-                "70cecf0bba10c3443fa0a0b182131e169726121e"
+                "70cecf0bba10c3443fa0a0b182131e169726121e",
+                "8bef5e6e4ecffde948dd4fbb94e273fff78426fa"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",
@@ -1339,7 +1341,8 @@
                 "CONVERSATION-LIVE-UPDATE-JOURNEY-001",
                 "CONVERSATION-NAVIGATION-STATE-001",
                 "CONVERSATION-LOCAL-FILE-LINKS-001",
-                "CONVERSATION-COMMENT-QUOTE-LOCATION-001"
+                "CONVERSATION-COMMENT-QUOTE-LOCATION-001",
+                "CONVERSATION-ACTIVE-SESSION-NAVIGATION-COMMANDS-001"
             ],
             "prGates": [
                 "test:ci:linux"

--- a/package.json
+++ b/package.json
@@ -100,13 +100,11 @@
             },
             {
                 "command": "agentPivot.previousActiveSession",
-                "title": "Agent Pivot: Previous Active Session",
-                "enablement": "activeWebviewPanelId == agentPivot.aiConversation && agentPivot.aiConversationFocus && !terminalFocus"
+                "title": "Agent Pivot: Previous Active Session"
             },
             {
                 "command": "agentPivot.nextActiveSession",
-                "title": "Agent Pivot: Next Active Session",
-                "enablement": "activeWebviewPanelId == agentPivot.aiConversation && agentPivot.aiConversationFocus && !terminalFocus"
+                "title": "Agent Pivot: Next Active Session"
             },
             {
                 "command": "agentPivot.notify.setWebhook",

--- a/src/aiSessions/conversation/composition.ts
+++ b/src/aiSessions/conversation/composition.ts
@@ -447,7 +447,7 @@ function createAvailableConversationCapability(
         async followAdjacentActiveConversation(
             direction: ConversationSessionSwitchDirection
         ): Promise<FollowAdjacentConversationResult> {
-            const currentTarget = viewer.getFocusedTarget();
+            const currentTarget = viewer.getCurrentTarget();
             if (!currentTarget) {
                 return viewer.isOpen() ? 'inactive' : 'closed';
             }

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -2149,7 +2149,7 @@ async function initializeDashboard(
             .followAdjacentActiveConversation(direction);
         if (result === 'inactive' || result === 'closed') {
             void vscode.window.showInformationMessage(
-                'Agent Pivot: focus an AI Conversation editor to switch active sessions.'
+                'Agent Pivot: open an AI Conversation editor to switch active sessions.'
             );
         } else if (result === 'noAdjacentSession') {
             void vscode.window.showInformationMessage(

--- a/tests/contract/dashboardBoundaries.test.js
+++ b/tests/contract/dashboardBoundaries.test.js
@@ -457,7 +457,7 @@ test('WEBVIEW-DASHBOARD-COMMAND-REGISTRATION-001 contributes the Prompt terminal
     ), false);
 });
 
-test('CONVERSATION-ACTIVE-SESSION-NAVIGATION-COMMANDS-001 contributes focused Conversation navigation commands without taking global shortcuts', () => {
+test('CONVERSATION-ACTIVE-SESSION-NAVIGATION-COMMANDS-001 contributes globally available Conversation navigation commands without taking global shortcuts', () => {
     const manifest = require('../../package.json');
     const commands = manifest.contributes.commands.filter(command =>
         command.command === 'agentPivot.previousActiveSession'
@@ -467,12 +467,10 @@ test('CONVERSATION-ACTIVE-SESSION-NAVIGATION-COMMANDS-001 contributes focused Co
         {
             command: 'agentPivot.previousActiveSession',
             title: 'Agent Pivot: Previous Active Session',
-            enablement: 'activeWebviewPanelId == agentPivot.aiConversation && agentPivot.aiConversationFocus && !terminalFocus',
         },
         {
             command: 'agentPivot.nextActiveSession',
             title: 'Agent Pivot: Next Active Session',
-            enablement: 'activeWebviewPanelId == agentPivot.aiConversation && agentPivot.aiConversationFocus && !terminalFocus',
         },
     ]);
     assert.deepEqual(

--- a/tests/integration/dashboard/conversationOpenLatest.test.js
+++ b/tests/integration/dashboard/conversationOpenLatest.test.js
@@ -924,7 +924,7 @@ test('CONVERSATION-FOLLOW-ACTIVE-SESSION-001 follows the adjacent active session
     harness.capability.dispose();
 });
 
-test('CONVERSATION-ACTIVE-SESSION-NAVIGATION-COMMANDS-001 switches from the focused Conversation target and ignores an unfocused viewer', async () => {
+test('CONVERSATION-ACTIVE-SESSION-NAVIGATION-COMMANDS-001 switches from the current Conversation target even when the viewer is unfocused', async () => {
     const sessions = [
         makeSession({ key: 'codex:session-a', sessionId: 'session-a' }),
         makeSession({ key: 'codex:session-b', sessionId: 'session-b' }),
@@ -964,12 +964,24 @@ test('CONVERSATION-ACTIVE-SESSION-NAVIGATION-COMMANDS-001 switches from the focu
     assert.equal(harness.viewerFocuses, 1);
     harness.capability.dispose();
 
-    const unfocused = createHarness({ viewerOpen: true });
+    const unfocused = createHarness({
+        viewerOpen: true,
+        getCurrentViewerTarget: () => currentTarget,
+        resolveTarget: (_projectId, provider, sessionId) =>
+            sessions.find(session =>
+                session.provider === provider && session.sessionId === sessionId
+            ) || null,
+        resolveActiveTargets: () => sessions,
+    });
     assert.equal(
         await unfocused.capability.followAdjacentActiveConversation('previous'),
-        'inactive'
+        'opened'
     );
-    assert.equal(unfocused.outlineReads, 0);
+    assert.deepEqual(
+        unfocused.followedViewerTargets.map(target => target.sessionId),
+        ['session-b']
+    );
+    assert.equal(unfocused.viewerFocuses, 1);
     unfocused.capability.dispose();
 });
 


### PR DESCRIPTION
## Summary

- make Previous Active Session and Next Active Session globally discoverable by removing the AI Conversation focus enablement constraint
- switch from the currently open Conversation target even when keyboard focus is in the terminal, Command Palette, or another surface
- keep terminal/card authority synchronized and restore keyboard focus to AI Conversation after switching
- update user feedback, regression ownership, and the main-capability audit

## Skill harvest

no skill change — the user correction changed product behavior, while the existing worktree, RED-first regression, verified installation, and PR workflow skills already covered the execution process.

## Verification

- npm run test-compile
- node --test tests/contract/dashboardBoundaries.test.js
- node --test tests/integration/dashboard/conversationOpenLatest.test.js
- npm run test:behavior-contracts
- git diff --check origin/main...HEAD
- SKIP_NPM_CI=1 npm run install-local (Agent Pivot 1.0.4 and Attention UI Bridge 1.0.1 installed; packaged-to-installed bytes verified)
