### PR TITLE
fix: strip inline emphasis tags from Mermaid diagram labels

### DIFF
--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "8bef5e6e4ecffde948dd4fbb94e273fff78426fa",
+        "head": "eec04834cd255f0775672fd7f0fa708d70bc041c",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -171,7 +171,8 @@
             "8fabc649a7093eba6a51e2509ca598aba8ee1746",
             "7a0ebe7f08deb8081174cf0a59188218ae0e5dd3",
             "06f98e5d4f2cdd022f4f964ba1e5e1888eab5e49",
-            "8a4457cce77ac21f1955d50438d223ce4c6cdc7f"
+            "8a4457cce77ac21f1955d50438d223ce4c6cdc7f",
+            "5667da2d9f220374e20f77869e29097790f0332d"
         ]
     },
     "capabilities": [
@@ -1299,7 +1300,8 @@
                 "f0f1b0cf7267cb8fa77e7b14a396953325293fa9",
                 "a7ba853f0e63c5fcad3378556b550aefe1c06a6d",
                 "70cecf0bba10c3443fa0a0b182131e169726121e",
-                "8bef5e6e4ecffde948dd4fbb94e273fff78426fa"
+                "8bef5e6e4ecffde948dd4fbb94e273fff78426fa",
+                "eec04834cd255f0775672fd7f0fa708d70bc041c"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",

--- a/media/conversationMermaidScripts.js
+++ b/media/conversationMermaidScripts.js
@@ -123,6 +123,14 @@
             return loadPromise;
         }
 
+        var INLINE_EMPHASIS_TAG = /<\/?(b|strong|i|em)(?=[\s/>])[^>]*>/gi;
+
+        function sanitizeSource(source) {
+            // Mermaid renders SVG text with htmlLabels disabled, so inline
+            // emphasis tags AI providers emit would show up literally.
+            return source.replace(INLINE_EMPHASIS_TAG, '');
+        }
+
         function alt(source) {
             var summary = source.split(/\r?\n/).map(function (line) {
                 return line.trim();
@@ -179,8 +187,9 @@
         }
 
         function renderDiagram(pre, source, id) {
+            var sanitized = sanitizeSource(source);
             pre.setAttribute('aria-busy', 'true');
-            return Promise.resolve(window.mermaid.render(id, source))
+            return Promise.resolve(window.mermaid.render(id, sanitized))
                 .then(function (result) {
                     if (!pre.isConnected) return;
                     var normalized = normalizeSvg(result.svg);
@@ -201,7 +210,7 @@
                         image.height = normalized.height;
                     }
                     image.src = objectUrl;
-                    image.alt = alt(source);
+                    image.alt = alt(sanitized);
                     image.decoding = 'async';
                     figure.appendChild(image);
                     var decoded = typeof image.decode === 'function'

--- a/src/webview/conversationMermaidScripts.js
+++ b/src/webview/conversationMermaidScripts.js
@@ -123,6 +123,14 @@
             return loadPromise;
         }
 
+        var INLINE_EMPHASIS_TAG = /<\/?(b|strong|i|em)(?=[\s/>])[^>]*>/gi;
+
+        function sanitizeSource(source) {
+            // Mermaid renders SVG text with htmlLabels disabled, so inline
+            // emphasis tags AI providers emit would show up literally.
+            return source.replace(INLINE_EMPHASIS_TAG, '');
+        }
+
         function alt(source) {
             var summary = source.split(/\r?\n/).map(function (line) {
                 return line.trim();
@@ -179,8 +187,9 @@
         }
 
         function renderDiagram(pre, source, id) {
+            var sanitized = sanitizeSource(source);
             pre.setAttribute('aria-busy', 'true');
-            return Promise.resolve(window.mermaid.render(id, source))
+            return Promise.resolve(window.mermaid.render(id, sanitized))
                 .then(function (result) {
                     if (!pre.isConnected) return;
                     var normalized = normalizeSvg(result.svg);
@@ -201,7 +210,7 @@
                         image.height = normalized.height;
                     }
                     image.src = objectUrl;
-                    image.alt = alt(source);
+                    image.alt = alt(sanitized);
                     image.decoding = 'async';
                     figure.appendChild(image);
                     var decoded = typeof image.decode === 'function'

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -4495,6 +4495,33 @@ test('WEBVIEW-AI-SESSION-CONVERSATION-VIEWER-001 CONVERSATION-VIEWER-RICH-MARKDO
     );
 });
 
+test('WEBVIEW-AI-SESSION-CONVERSATION-VIEWER-001 strips inline emphasis tags from Mermaid labels instead of rendering them literally', async t => {
+    const page = await openViewerPage(t, { includeMermaid: true });
+    await sendPage(page, {
+        ...hostileConversationPage,
+        html: `<article data-message-id="emphasis" data-interaction-id="input-4">
+            <section class="conversation-markdown">
+                <pre><code class="language-mermaid">flowchart LR
+                    A[&quot;&lt;b&gt;Deploy&lt;/b&gt; &lt;i&gt;service&lt;/i&gt;&quot;] --&gt; B[Done]</code></pre>
+            </section>
+        </article>`,
+    });
+
+    const diagram = page.locator('.conversation-mermaid-image');
+    await diagram.waitFor();
+    await page.waitForFunction(() => {
+        const image = document.querySelector('.conversation-mermaid-image');
+        return image && image.complete && image.naturalWidth > 0;
+    });
+    const normalizedSvg = await diagram.evaluate(async image =>
+        (await fetch(image.src)).text()
+    );
+    assert.match(normalizedSvg, />Deploy</);
+    assert.match(normalizedSvg, /> service</);
+    assert.doesNotMatch(normalizedSvg, /&lt;\/?(b|i|em|strong)&gt;/i);
+    assert.match(normalizedSvg, />Done</);
+});
+
 test('WEBVIEW-AI-SESSION-CONVERSATION-VIEWER-001 preserves structured text indentation and horizontal scrolling', async t => {
     const page = await openViewerPage(t);
     await page.setViewportSize({ width: 360, height: 500 });


### PR DESCRIPTION
## Summary

AI providers frequently emit inline emphasis tags such as `<b>` or `<i>` inside Mermaid diagram labels. The conversation viewer initializes Mermaid with `htmlLabels: false` and `securityLevel: 'strict'`, so those tags were escaped and painted literally into the SVG text.

The viewer now strips inline `b`, `strong`, `i`, and `em` tags from the diagram source before rendering (line-break tags like `<br/>` remain untouched because Mermaid handles them natively). The raw source is still used as the `preserve()` matching key, and the sanitized source feeds the generated alt text.

## Skill harvest

no skill change — fix is a localized source sanitization plus one browser regression test; existing RED/GREEN and audit workflow skills covered the work.

## Verification

- New browser regression test `WEBVIEW-AI-SESSION-CONVERSATION-VIEWER-001 strips inline emphasis tags from Mermaid labels instead of rendering them literally` fails before the fix (mutation-verified by stashing the implementation) and passes after it.
- Full `tests/browser/conversationViewer.test.js` suite: 71/71 pass.
- `npm run test:behavior-contracts`, `npm run lint:ci`, and `git diff --check` pass.
- `npm run test:ci:linux` passes on the final commits.
