### PR TITLE
Fix extension host pressure during conversation refreshes

### DIFF
--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "eec04834cd255f0775672fd7f0fa708d70bc041c",
+        "head": "396d66c5b6c32aa7e4c4ff4c8d13f609995fe732",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -172,7 +172,8 @@
             "7a0ebe7f08deb8081174cf0a59188218ae0e5dd3",
             "06f98e5d4f2cdd022f4f964ba1e5e1888eab5e49",
             "8a4457cce77ac21f1955d50438d223ce4c6cdc7f",
-            "5667da2d9f220374e20f77869e29097790f0332d"
+            "5667da2d9f220374e20f77869e29097790f0332d",
+            "473e14e3a78c9abd379da9c09cca67fa62ef7753"
         ]
     },
     "capabilities": [
@@ -308,7 +309,8 @@
                 "499dc7a3f0d1384adddec85f586fd0c45a48dbd9",
                 "ee825a7244d9a7d5a2aa1acf795434520d6ecfd1",
                 "e393b67fb9f066c94ee38c2f0bfcbb618adc60f2",
-                "a7613039cd4196cb6f43c022d15eea1483204eaf"
+                "a7613039cd4196cb6f43c022d15eea1483204eaf",
+                "6da59174093c712c3a1623d5f9a649c9c803e9cd"
             ],
             "behaviors": [
                 "OPEN-OPEN-PROJECT-AUTHORITATIVE-IDENTITY-001",
@@ -712,7 +714,8 @@
                 "4ad7604bb9a4d4ff10f790486512c3313c351200",
                 "1f2baaa6b2a5c18bd80954be773c00968619d245",
                 "dd561101bb195c5da5a3bed0acfcb3696dfbfcf4",
-                "0a26be7106e6ff264bc4a200820b302b52e88b0e"
+                "0a26be7106e6ff264bc4a200820b302b52e88b0e",
+                "396d66c5b6c32aa7e4c4ff4c8d13f609995fe732"
             ],
             "behaviors": [
                 "PROJECT-CATALOG-SYNC-CONFLICT-001",
@@ -1301,7 +1304,8 @@
                 "a7ba853f0e63c5fcad3378556b550aefe1c06a6d",
                 "70cecf0bba10c3443fa0a0b182131e169726121e",
                 "8bef5e6e4ecffde948dd4fbb94e273fff78426fa",
-                "eec04834cd255f0775672fd7f0fa708d70bc041c"
+                "eec04834cd255f0775672fd7f0fa708d70bc041c",
+                "47368dc6dd350fb1b4113cb0fb417b7752b4e003"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",

--- a/src/aiSessions/conversation/claudeAdapter.ts
+++ b/src/aiSessions/conversation/claudeAdapter.ts
@@ -22,6 +22,7 @@ import {
     buildVisibleUserInput,
     capToolCallDetail,
     countGraphemes,
+    hasAtMostGraphemes,
     normalizeVisibleText,
     truncateGraphemes,
     VisibleUserInputPart,
@@ -231,7 +232,10 @@ function cloneInteractions(
 
 function visibleMessage(value: string): string {
     const normalized = normalizeVisibleText(value);
-    return countGraphemes(normalized) <= CONVERSATION_LIMITS.maxMessageGraphemes
+    return hasAtMostGraphemes(
+        normalized,
+        CONVERSATION_LIMITS.maxMessageGraphemes
+    )
         ? normalized
         : truncateGraphemes(
             normalized,
@@ -877,7 +881,7 @@ function subagentLabel(meta: SubagentMeta | undefined, id: string): string {
         ? normalizeVisibleText(meta?.description ?? '')
         : '';
     if (description) {
-        return countGraphemes(description) <= 120
+        return hasAtMostGraphemes(description, 120)
             ? description
             : truncateGraphemes(description, 119);
     }

--- a/src/aiSessions/conversation/codexAdapter.ts
+++ b/src/aiSessions/conversation/codexAdapter.ts
@@ -17,12 +17,14 @@ import {
     buildVisibleUserInput,
     capToolCallDetail,
     countGraphemes,
+    hasAtMostGraphemes,
     normalizeVisibleText,
     truncateGraphemes,
     VisibleUserInputPart,
 } from './text';
 import {
     CONVERSATION_LIMITS,
+    ConversationAbortError,
     ConversationAbortSignal,
     ConversationError,
     ConversationInteraction,
@@ -62,6 +64,8 @@ export interface CodexConversationAdapterOptions {
     watchSessionChanges(onDidChange: () => void): AiSessionDisposable;
     setTimeout(callback: () => void, delayMs: number): TimerHandle;
     clearTimeout(handle: TimerHandle): void;
+    setCacheTimeout?(callback: () => void, delayMs: number): TimerHandle;
+    clearCacheTimeout?(handle: TimerHandle): void;
     resolveWorktree?: ResolveWorktree;
     readCurrentWorkdir?(sessionId: string): string | undefined;
     readLifecycleSignal?(
@@ -70,14 +74,24 @@ export interface CodexConversationAdapterOptions {
     listSubagentThreads?(
         sessionId: string
     ): AiSessionCodexSubagentThread[] | Promise<AiSessionCodexSubagentThread[]>;
+    now?(): number;
 }
 
 const MAX_LISTED_SUBAGENTS = 64;
 const SUBAGENT_RUNNING_FRESHNESS_MS = 5 * 60 * 1000;
+const LARGE_CONVERSATION_CACHE_CHARS = 512 * 1024;
+const LARGE_CONVERSATION_CACHE_TTL_MS = 15_000;
+const LARGE_CONVERSATION_CACHE_ENTRIES = 2;
 
 interface LoadedConversation {
     interactions: ConversationInteraction[];
     sourceRevision: string;
+}
+
+interface CachedLoadedConversation {
+    value: LoadedConversation;
+    expiresAt: number;
+    expiryTimer?: TimerHandle;
 }
 
 function asRecord(value: unknown): Record<string, any> | undefined {
@@ -95,7 +109,10 @@ function protocolError(): ConversationError {
 
 function visibleMessage(value: string): string {
     const normalized = normalizeVisibleText(value);
-    return countGraphemes(normalized) <= CONVERSATION_LIMITS.maxMessageGraphemes
+    return hasAtMostGraphemes(
+        normalized,
+        CONVERSATION_LIMITS.maxMessageGraphemes
+    )
         ? normalized
         : truncateGraphemes(
             normalized,
@@ -426,6 +443,11 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
         string,
         Promise<ConversationTelemetry | undefined>
     >();
+    private readonly loadedConversationCache = new Map<
+        string,
+        CachedLoadedConversation
+    >();
+    private conversationCacheGeneration = 0;
     private disposed = false;
 
     constructor(private readonly options: CodexConversationAdapterOptions) {
@@ -696,6 +718,7 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
         this.tokenUsageBySession.clear();
         this.telemetryCache.clear();
         this.telemetryReads.clear();
+        this.invalidateLoadedConversationCache();
         this.subscriptions.clear();
         this.options.client.dispose();
     }
@@ -748,7 +771,97 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
         }
     }
 
-    private async load(
+    private load(
+        sessionId: string,
+        signal?: ConversationAbortSignal
+    ): Promise<LoadedConversation> {
+        if (signal?.aborted) {
+            return Promise.reject(new ConversationAbortError());
+        }
+        const cached = this.loadedConversationCache.get(sessionId);
+        if (cached && cached.expiresAt > this.now()) {
+            return Promise.resolve(cached.value);
+        }
+        if (cached) {
+            this.deleteLoadedConversationCacheEntry(sessionId, cached);
+        }
+        const generation = this.conversationCacheGeneration;
+        return this.loadFresh(sessionId, signal).then(value => {
+            if (!this.disposed
+                && generation === this.conversationCacheGeneration
+                && this.isLargeConversation(value)) {
+                const previous = this.loadedConversationCache.get(sessionId);
+                if (previous) {
+                    this.deleteLoadedConversationCacheEntry(sessionId, previous);
+                }
+                const entry: CachedLoadedConversation = {
+                    value,
+                    expiresAt: this.now() + LARGE_CONVERSATION_CACHE_TTL_MS,
+                };
+                this.loadedConversationCache.set(sessionId, entry);
+                this.scheduleLoadedConversationCacheExpiry(sessionId, entry);
+                while (this.loadedConversationCache.size
+                    > LARGE_CONVERSATION_CACHE_ENTRIES) {
+                    const oldest = this.loadedConversationCache.keys().next().value;
+                    if (typeof oldest !== 'string') {
+                        break;
+                    }
+                    const evicted = this.loadedConversationCache.get(oldest);
+                    if (evicted) {
+                        this.deleteLoadedConversationCacheEntry(oldest, evicted);
+                    }
+                }
+            }
+            return value;
+        });
+    }
+
+    private scheduleLoadedConversationCacheExpiry(
+        sessionId: string,
+        entry: CachedLoadedConversation
+    ): void {
+        let firedSynchronously = false;
+        const setTimer = this.options.setCacheTimeout
+            && this.options.clearCacheTimeout
+            ? this.options.setCacheTimeout
+            : this.options.setTimeout;
+        const handle = setTimer(() => {
+            firedSynchronously = true;
+            entry.expiryTimer = undefined;
+            if (this.loadedConversationCache.get(sessionId) === entry) {
+                this.loadedConversationCache.delete(sessionId);
+            }
+        }, LARGE_CONVERSATION_CACHE_TTL_MS);
+        if (!firedSynchronously) {
+            entry.expiryTimer = handle;
+        }
+    }
+
+    private deleteLoadedConversationCacheEntry(
+        sessionId: string,
+        entry: CachedLoadedConversation
+    ): void {
+        if (entry.expiryTimer !== undefined) {
+            const clearTimer = this.options.setCacheTimeout
+                && this.options.clearCacheTimeout
+                ? this.options.clearCacheTimeout
+                : this.options.clearTimeout;
+            clearTimer(entry.expiryTimer);
+            entry.expiryTimer = undefined;
+        }
+        if (this.loadedConversationCache.get(sessionId) === entry) {
+            this.loadedConversationCache.delete(sessionId);
+        }
+    }
+
+    private invalidateLoadedConversationCache(): void {
+        this.conversationCacheGeneration += 1;
+        for (const [sessionId, entry] of this.loadedConversationCache) {
+            this.deleteLoadedConversationCacheEntry(sessionId, entry);
+        }
+    }
+
+    private async loadFresh(
         sessionId: string,
         signal?: ConversationAbortSignal
     ): Promise<LoadedConversation> {
@@ -828,6 +941,39 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
         return { interactions, sourceRevision };
     }
 
+    private isLargeConversation(value: LoadedConversation): boolean {
+        let characters = 0;
+        const add = (text: string | undefined): boolean => {
+            characters += text?.length || 0;
+            return characters >= LARGE_CONVERSATION_CACHE_CHARS;
+        };
+        for (const interaction of value.interactions) {
+            if (add(interaction.userMarkdown)) {
+                return true;
+            }
+            for (const markdown of interaction.assistantMarkdown) {
+                if (add(markdown)) {
+                    return true;
+                }
+            }
+            for (const tool of interaction.toolCalls || []) {
+                if (add(tool.summary) || add(tool.detail)) {
+                    return true;
+                }
+            }
+            for (const thinking of interaction.thinking || []) {
+                if (add(thinking.text)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private now(): number {
+        return this.options.now ? this.options.now() : Date.now();
+    }
+
     private ensureProviderWatch(): void {
         if (this.providerWatch) {
             return;
@@ -838,6 +984,7 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
     }
 
     private scheduleInvalidation(): void {
+        this.invalidateLoadedConversationCache();
         if (this.invalidationTimer !== undefined || this.disposed) {
             return;
         }
@@ -894,7 +1041,7 @@ function subagentLabel(
         : base;
     const normalized = normalizeVisibleText(label);
     if (normalized) {
-        return countGraphemes(normalized) <= 120
+        return hasAtMostGraphemes(normalized, 120)
             ? normalized
             : truncateGraphemes(normalized, 119);
     }

--- a/src/aiSessions/conversation/codexAppServerClient.ts
+++ b/src/aiSessions/conversation/codexAppServerClient.ts
@@ -112,7 +112,8 @@ export class CodexAppServerClient implements AiSessionDisposable {
     private initialized = false;
     private disposed = false;
     private nextRequestId = CONVERSATION_LIMITS.minRequestId;
-    private stdoutRemainder = Buffer.alloc(0);
+    private stdoutChunks: Buffer[] = [];
+    private stdoutBytes = 0;
     private readonly pending = new Map<number, PendingRequest>();
     private writeTail: Promise<void> = Promise.resolve();
     private cancelActiveWrite?: (error: Error) => void;
@@ -239,7 +240,7 @@ export class CodexAppServerClient implements AiSessionDisposable {
         }
         this.connecting = undefined;
         this.restartAttempts = [];
-        this.stdoutRemainder = Buffer.alloc(0);
+        this.resetStdoutBuffer();
         this.notificationListeners.clear();
     }
 
@@ -341,7 +342,7 @@ export class CodexAppServerClient implements AiSessionDisposable {
         this.child = child;
         this.childSpawned = false;
         this.initialized = false;
-        this.stdoutRemainder = Buffer.alloc(0);
+        this.resetStdoutBuffer();
         child.stdin.on('error', this.onStdinError);
         child.stdout.on('data', this.onStdoutData);
         child.stderr.on('data', this.onStderrData);
@@ -567,19 +568,38 @@ export class CodexAppServerClient implements AiSessionDisposable {
             }
             return;
         }
-        this.stdoutRemainder = Buffer.concat([this.stdoutRemainder, chunk]);
-        let newline = this.stdoutRemainder.indexOf(0x0a);
-        while (newline >= 0) {
-            if (newline > CONVERSATION_LIMITS.maxCodexResponseBytes) {
-                const error = new ConversationError('tooLarge');
-                this.report('oversized');
-                if (this.child) {
-                    this.releaseChild(this.child, error, true);
+        let offset = 0;
+        while (offset < chunk.length) {
+            const newline = chunk.indexOf(0x0a, offset);
+            if (newline < 0) {
+                const remainder = chunk.subarray(offset);
+                if (this.stdoutBytes + remainder.length
+                    > CONVERSATION_LIMITS.maxCodexResponseBytes) {
+                    this.failOversizedResponse();
+                    return;
+                }
+                if (remainder.length > 0) {
+                    this.stdoutChunks.push(remainder);
+                    this.stdoutBytes += remainder.length;
                 }
                 return;
             }
-            let line = this.stdoutRemainder.subarray(0, newline);
-            this.stdoutRemainder = this.stdoutRemainder.subarray(newline + 1);
+            const segment = chunk.subarray(offset, newline);
+            const lineBytes = this.stdoutBytes + segment.length;
+            if (lineBytes > CONVERSATION_LIMITS.maxCodexResponseBytes) {
+                this.failOversizedResponse();
+                return;
+            }
+            let line: Buffer;
+            if (this.stdoutChunks.length === 0) {
+                line = segment;
+            } else {
+                if (segment.length > 0) {
+                    this.stdoutChunks.push(segment);
+                }
+                line = Buffer.concat(this.stdoutChunks, lineBytes);
+            }
+            this.resetStdoutBuffer();
             if (line.length > 0 && line[line.length - 1] === 0x0d) {
                 line = line.subarray(0, line.length - 1);
             }
@@ -597,15 +617,22 @@ export class CodexAppServerClient implements AiSessionDisposable {
             if (!this.acceptResponse(response)) {
                 return;
             }
-            newline = this.stdoutRemainder.indexOf(0x0a);
+            offset = newline + 1;
         }
-        if (this.stdoutRemainder.length
-            > CONVERSATION_LIMITS.maxCodexResponseBytes) {
-            const error = new ConversationError('tooLarge');
-            this.report('oversized');
-            if (this.child) {
-                this.releaseChild(this.child, error, true);
-            }
+    }
+
+    private resetStdoutBuffer(): void {
+        this.stdoutChunks = [];
+        this.stdoutBytes = 0;
+    }
+
+    private failOversizedResponse(): void {
+        const error = new ConversationError('tooLarge');
+        this.report('oversized');
+        if (this.child) {
+            this.releaseChild(this.child, error, true);
+        } else {
+            this.resetStdoutBuffer();
         }
     }
 
@@ -719,7 +746,7 @@ export class CodexAppServerClient implements AiSessionDisposable {
         this.child = undefined;
         this.childSpawned = false;
         this.initialized = false;
-        this.stdoutRemainder = Buffer.alloc(0);
+        this.resetStdoutBuffer();
         this.serverVersion = undefined;
         if (allowRestart) {
             this.restartRequired = true;

--- a/src/aiSessions/conversation/composition.ts
+++ b/src/aiSessions/conversation/composition.ts
@@ -846,6 +846,7 @@ const CONVERSATION_SNAPSHOT_WARM_LIMIT = 4;
 
 interface WarmConversationSnapshot {
     completedAt?: number;
+    claimed: boolean;
     abortController: ConversationAbortController;
     promise: Promise<ConversationSnapshot | undefined>;
     timeout?: ReturnType<typeof setTimeout>;
@@ -892,6 +893,11 @@ class ConversationSnapshotWarmup implements AiSessionDisposable {
             this.snapshots.delete(key);
             entry.cancel();
             return undefined;
+        }
+        entry.claimed = true;
+        if (entry.completedAt !== undefined) {
+            this.snapshots.delete(key);
+            entry.cancel();
         }
         return entry.promise;
     }
@@ -1016,6 +1022,26 @@ class ConversationSnapshotWarmup implements AiSessionDisposable {
         );
         let settled = false;
         let entry: WarmConversationSnapshot;
+        const clearEntryTimeout = (): void => {
+            if (entry.timeout === undefined) {
+                return;
+            }
+            this.options.clearTimer(entry.timeout);
+            entry.timeout = undefined;
+        };
+        const scheduleCompletedExpiry = (): void => {
+            let timeoutFiredSynchronously = false;
+            const timeout = this.options.setTimer(() => {
+                timeoutFiredSynchronously = true;
+                entry.timeout = undefined;
+                if (this.snapshots.get(key) === entry) {
+                    this.snapshots.delete(key);
+                }
+            }, CONVERSATION_SNAPSHOT_WARM_TTL_MS);
+            if (!timeoutFiredSynchronously) {
+                entry.timeout = timeout;
+            }
+        };
         const settle = (
             snapshot: ConversationSnapshot | undefined,
             abort: boolean
@@ -1024,15 +1050,19 @@ class ConversationSnapshotWarmup implements AiSessionDisposable {
                 return;
             }
             settled = true;
-            if (entry.timeout !== undefined) {
-                this.options.clearTimer(entry.timeout);
-                entry.timeout = undefined;
-            }
+            clearEntryTimeout();
             if (abort) {
                 abortController.abort();
             }
             if (snapshot) {
                 entry.completedAt = this.options.now();
+                if (entry.claimed) {
+                    if (this.snapshots.get(key) === entry) {
+                        this.snapshots.delete(key);
+                    }
+                } else {
+                    scheduleCompletedExpiry();
+                }
             } else if (this.snapshots.get(key) === entry) {
                 this.snapshots.delete(key);
             }
@@ -1040,8 +1070,14 @@ class ConversationSnapshotWarmup implements AiSessionDisposable {
         };
         entry = {
             abortController,
+            claimed: false,
             promise,
-            cancel: () => settle(undefined, true),
+            cancel: () => {
+                clearEntryTimeout();
+                if (!settled) {
+                    settle(undefined, true);
+                }
+            },
         };
         this.snapshots.set(key, entry);
         let timeoutFiredSynchronously = false;

--- a/src/aiSessions/conversation/coordinator.ts
+++ b/src/aiSessions/conversation/coordinator.ts
@@ -8,7 +8,7 @@ import {
     applyActiveLifecycleToResponseState,
     applyStoppedLifecycleToResponseState,
 } from './model';
-import { countGraphemes } from './text';
+import { hasAtMostGraphemes } from './text';
 import {
     CONVERSATION_LIMITS,
     ConversationAbortError,
@@ -661,8 +661,10 @@ export class ConversationCoordinator implements AiSessionDisposable {
                     || (typeof interaction.timestamp === 'number'
                         && Number.isFinite(interaction.timestamp)))
                 && typeof interaction.userPreview === 'string'
-                && countGraphemes(interaction.userPreview)
-                    <= CONVERSATION_LIMITS.previewGraphemes
+                && hasAtMostGraphemes(
+                    interaction.userPreview,
+                    CONVERSATION_LIMITS.previewGraphemes
+                )
                 && Number.isSafeInteger(interaction.userGraphemeCount)
                 && interaction.userGraphemeCount >= 0
                 && interaction.userGraphemeCount
@@ -707,26 +709,36 @@ export class ConversationCoordinator implements AiSessionDisposable {
                         && Boolean(message.tool)
                         && typeof message.tool.name === 'string'
                         && Boolean(message.tool.name)
-                        && countGraphemes(message.tool.name)
-                            <= CONVERSATION_LIMITS.toolCallSummaryGraphemes
+                        && hasAtMostGraphemes(
+                            message.tool.name,
+                            CONVERSATION_LIMITS.toolCallSummaryGraphemes
+                        )
                         && typeof message.tool.summary === 'string'
-                        && countGraphemes(message.tool.summary)
-                            <= CONVERSATION_LIMITS.toolCallSummaryGraphemes
+                        && hasAtMostGraphemes(
+                            message.tool.summary,
+                            CONVERSATION_LIMITS.toolCallSummaryGraphemes
+                        )
                         && (message.tool.detail === undefined
                             || (typeof message.tool.detail === 'string'
-                                && countGraphemes(message.tool.detail)
-                                    <= CONVERSATION_LIMITS.toolCallDetailGraphemes)))
+                                && hasAtMostGraphemes(
+                                    message.tool.detail,
+                                    CONVERSATION_LIMITS.toolCallDetailGraphemes
+                                )))
                     || (message.role === 'thinking'
                         && Boolean(message.thinking)
                         && typeof message.thinking.text === 'string'
-                        && countGraphemes(message.thinking.text)
-                            <= CONVERSATION_LIMITS.maxMessageGraphemes))
+                        && hasAtMostGraphemes(
+                            message.thinking.text,
+                            CONVERSATION_LIMITS.maxMessageGraphemes
+                        ))))
                 && (message.timestamp === undefined
                     || (typeof message.timestamp === 'number'
                         && Number.isFinite(message.timestamp)))
                 && typeof message.markdown === 'string'
-                && countGraphemes(message.markdown)
-                    <= CONVERSATION_LIMITS.maxMessageGraphemes
+                && hasAtMostGraphemes(
+                    message.markdown,
+                    CONVERSATION_LIMITS.maxMessageGraphemes
+                )
             ))
             || !isDenseOwnArray(page.interactionStates)
             || !page.interactionStates.length

--- a/src/aiSessions/conversation/kimiAdapter.ts
+++ b/src/aiSessions/conversation/kimiAdapter.ts
@@ -24,6 +24,7 @@ import {
     buildVisibleUserInput,
     capToolCallDetail,
     countGraphemes,
+    hasAtMostGraphemes,
     normalizeVisibleText,
     truncateGraphemes,
     VisibleUserInputPart,
@@ -149,7 +150,10 @@ function cloneInteractions(
 
 function visibleMessage(value: string): string {
     const normalized = normalizeVisibleText(value);
-    return countGraphemes(normalized) <= CONVERSATION_LIMITS.maxMessageGraphemes
+    return hasAtMostGraphemes(
+        normalized,
+        CONVERSATION_LIMITS.maxMessageGraphemes
+    )
         ? normalized
         : truncateGraphemes(
             normalized,
@@ -831,7 +835,7 @@ function subagentLabel(meta: SubagentMeta | undefined, id: string): string {
         ? normalizeVisibleText(meta?.description ?? '')
         : '';
     if (description) {
-        return countGraphemes(description) <= 120
+        return hasAtMostGraphemes(description, 120)
             ? description
             : truncateGraphemes(description, 119);
     }

--- a/src/aiSessions/conversation/model.ts
+++ b/src/aiSessions/conversation/model.ts
@@ -125,103 +125,155 @@ export function buildConversationPage(
     const pageAnchorInteractionId = request.direction === 'before'
         ? interactions[end - 1].id
         : interactions[start].id;
-    const messagesForRange = (): ConversationMessage[] => interactions.slice(start, end).reduce(
-        (messages: ConversationMessage[], interaction) => {
-            messages.push({
-                id: `${interaction.id}:user`,
-                interactionId: interaction.id,
-                role: 'user',
-                timestamp: interaction.timestamp,
-                markdown: interaction.userMarkdown,
-            });
-            const toolCalls = interaction.toolCalls || [];
-            const thinkingBlocks = interaction.thinking || [];
-            const pushAnchoredAt = (position: number): void => {
-                toolCalls.forEach((toolCall, toolIndex) => {
-                    if (toolCall.position !== position) {
-                        return;
-                    }
-                    messages.push({
-                        id: `${interaction.id}:tool:${toolIndex}`,
-                        interactionId: interaction.id,
-                        role: 'tool',
-                        timestamp: interaction.timestamp,
-                        markdown: '',
-                        tool: {
-                            name: toolCall.name,
-                            summary: toolCall.summary,
-                            ...(toolCall.detail !== undefined
-                                ? { detail: toolCall.detail }
-                                : {}),
-                        },
-                    });
-                });
-                thinkingBlocks.forEach((block, blockIndex) => {
-                    if (block.position !== position) {
-                        return;
-                    }
-                    messages.push({
-                        id: `${interaction.id}:thinking:${blockIndex}`,
-                        interactionId: interaction.id,
-                        role: 'thinking',
-                        timestamp: interaction.timestamp,
-                        markdown: '',
-                        thinking: { text: block.text },
-                    });
-                });
-            };
-            interaction.assistantMarkdown.forEach((markdown, index) => {
-                pushAnchoredAt(index);
-                const phase = assistantPhase(interaction, index);
-                messages.push({
-                    id: `${interaction.id}:${phase === 'progress'
-                        ? 'progress'
-                        : 'assistant'}:${index}`,
-                    interactionId: interaction.id,
-                    role: phase === 'progress' ? 'progress' : 'assistant',
-                    timestamp: interaction.timestamp,
-                    markdown,
-                });
-            });
-            pushAnchoredAt(interaction.assistantMarkdown.length);
-            return messages;
-        },
-        []
-    );
-    const makePage = (): ConversationPage => ({
-        provider: request.provider,
-        sessionId: request.sessionId,
-        sourceRevision,
-        anchorInteractionId: request.direction === 'around'
-            ? request.anchorInteractionId
-            : pageAnchorInteractionId,
-        messages: messagesForRange(),
-        interactionStates: interactions.slice(start, end).map(interaction => ({
+    const messagesForInteraction = (
+        interaction: ConversationInteraction
+    ): ConversationMessage[] => {
+        const messages: ConversationMessage[] = [{
+            id: `${interaction.id}:user`,
             interactionId: interaction.id,
-            responseState: interaction.responseState,
-        })),
-        previousCursor: start > 0 ? encodeCursor(interactions[start].id, 'before') : undefined,
-        nextCursor: end < interactions.length
-            ? encodeCursor(interactions[end - 1].id, 'after')
-            : undefined,
-        isStart: start === 0,
-        isEnd: end === interactions.length,
-    });
-    let page = makePage();
-    while (Buffer.byteLength(JSON.stringify(page), 'utf8') > CONVERSATION_LIMITS.maxPageBytes
-        && end - start > 1) {
+            role: 'user',
+            timestamp: interaction.timestamp,
+            markdown: interaction.userMarkdown,
+        }];
+        const toolCalls = interaction.toolCalls || [];
+        const thinkingBlocks = interaction.thinking || [];
+        const pushAnchoredAt = (position: number): void => {
+            toolCalls.forEach((toolCall, toolIndex) => {
+                if (toolCall.position !== position) {
+                    return;
+                }
+                messages.push({
+                    id: `${interaction.id}:tool:${toolIndex}`,
+                    interactionId: interaction.id,
+                    role: 'tool',
+                    timestamp: interaction.timestamp,
+                    markdown: '',
+                    tool: {
+                        name: toolCall.name,
+                        summary: toolCall.summary,
+                        ...(toolCall.detail !== undefined
+                            ? { detail: toolCall.detail }
+                            : {}),
+                    },
+                });
+            });
+            thinkingBlocks.forEach((block, blockIndex) => {
+                if (block.position !== position) {
+                    return;
+                }
+                messages.push({
+                    id: `${interaction.id}:thinking:${blockIndex}`,
+                    interactionId: interaction.id,
+                    role: 'thinking',
+                    timestamp: interaction.timestamp,
+                    markdown: '',
+                    thinking: { text: block.text },
+                });
+            });
+        };
+        interaction.assistantMarkdown.forEach((markdown, index) => {
+            pushAnchoredAt(index);
+            const phase = assistantPhase(interaction, index);
+            messages.push({
+                id: `${interaction.id}:${phase === 'progress'
+                    ? 'progress'
+                    : 'assistant'}:${index}`,
+                interactionId: interaction.id,
+                role: phase === 'progress' ? 'progress' : 'assistant',
+                timestamp: interaction.timestamp,
+                markdown,
+            });
+        });
+        pushAnchoredAt(interaction.assistantMarkdown.length);
+        return messages;
+    };
+    const blocks = new Map<number, {
+        messages: ConversationMessage[];
+        state: { interactionId: string; responseState: ConversationResponseState };
+        serializedBytes: number;
+    }>();
+    let estimatedBytes = 0;
+    for (let index = start; index < end; index += 1) {
+        const interaction = interactions[index];
+        const block = {
+            messages: messagesForInteraction(interaction),
+            state: {
+                interactionId: interaction.id,
+                responseState: interaction.responseState,
+            },
+            serializedBytes: 0,
+        };
+        block.serializedBytes = Buffer.byteLength(JSON.stringify({
+            messages: block.messages,
+            state: block.state,
+        }), 'utf8');
+        blocks.set(index, block);
+        estimatedBytes += block.serializedBytes;
+    }
+    const shrinkRange = (): void => {
+        let removedIndex: number;
         if (request.direction === 'before') {
+            removedIndex = start;
             start += 1;
         } else if (request.direction === 'after') {
             end -= 1;
+            removedIndex = end;
         } else if (anchorIndex - start > end - 1 - anchorIndex) {
+            removedIndex = start;
             start += 1;
         } else {
             end -= 1;
+            removedIndex = end;
         }
-        page = makePage();
+        estimatedBytes -= blocks.get(removedIndex)?.serializedBytes || 0;
+    };
+    const PAGE_ENVELOPE_RESERVE_BYTES = 2 * 1024;
+    while (estimatedBytes
+        > CONVERSATION_LIMITS.maxPageBytes - PAGE_ENVELOPE_RESERVE_BYTES
+        && end - start > 1) {
+        shrinkRange();
     }
-    if (Buffer.byteLength(JSON.stringify(page), 'utf8') > CONVERSATION_LIMITS.maxPageBytes) {
+    const makePage = (): ConversationPage => {
+        const messages: ConversationMessage[] = [];
+        const interactionStates: Array<{
+            interactionId: string;
+            responseState: ConversationResponseState;
+        }> = [];
+        for (let index = start; index < end; index += 1) {
+            const block = blocks.get(index)!;
+            for (const message of block.messages) {
+                messages.push(message);
+            }
+            interactionStates.push(block.state);
+        }
+        return {
+            provider: request.provider,
+            sessionId: request.sessionId,
+            sourceRevision,
+            anchorInteractionId: request.direction === 'around'
+                ? request.anchorInteractionId
+                : pageAnchorInteractionId,
+            messages,
+            interactionStates,
+            previousCursor: start > 0
+                ? encodeCursor(interactions[start].id, 'before')
+                : undefined,
+            nextCursor: end < interactions.length
+                ? encodeCursor(interactions[end - 1].id, 'after')
+                : undefined,
+            isStart: start === 0,
+            isEnd: end === interactions.length,
+        };
+    };
+    let page = makePage();
+    let pageBytes = Buffer.byteLength(JSON.stringify(page), 'utf8');
+    while (pageBytes > CONVERSATION_LIMITS.maxPageBytes
+        && end - start > 1) {
+        shrinkRange();
+        page = makePage();
+        pageBytes = Buffer.byteLength(JSON.stringify(page), 'utf8');
+    }
+    if (pageBytes > CONVERSATION_LIMITS.maxPageBytes) {
         throw new ConversationError('tooLarge');
     }
     return page;

--- a/src/aiSessions/conversation/text.ts
+++ b/src/aiSessions/conversation/text.ts
@@ -4,30 +4,112 @@ import { CONVERSATION_LIMITS } from './types';
 
 type Segmenter = { segment(value: string): Iterable<{ segment: string }> };
 
-function graphemes(value: string): string[] {
+let sharedSegmenter: Segmenter | null | undefined;
+const COMPLEX_GRAPHEME_PATTERN = /[\p{M}\p{Cf}\r\u1100-\u11ff\ua960-\ua97f\ud7b0-\ud7ff\u{1f1e6}-\u{1f1ff}\u{1f3fb}-\u{1f3ff}]/u;
+
+function segmenter(): Segmenter | undefined {
+    if (sharedSegmenter !== undefined) {
+        return sharedSegmenter || undefined;
+    }
     const SegmenterCtor = (Intl as unknown as {
         Segmenter?: new (
             locale?: string,
             options?: { granularity: string }
         ) => Segmenter;
     }).Segmenter;
-    if (SegmenterCtor) {
-        return Array.from(
-            new SegmenterCtor(undefined, { granularity: 'grapheme' }).segment(value),
-            item => item.segment
-        );
+    sharedSegmenter = SegmenterCtor
+        ? new SegmenterCtor(undefined, { granularity: 'grapheme' })
+        : null;
+    return sharedSegmenter || undefined;
+}
+
+function* graphemes(value: string): Iterable<string> {
+    const resolved = segmenter();
+    if (resolved) {
+        for (const item of resolved.segment(value)) {
+            yield item.segment;
+        }
+        return;
     }
-    return Array.from(value);
+    yield* value;
+}
+
+function hasComplexGraphemes(value: string): boolean {
+    return COMPLEX_GRAPHEME_PATTERN.test(value);
+}
+
+function countSimpleCodePoints(value: string, stopAfter?: number): number {
+    let count = 0;
+    for (let index = 0; index < value.length;) {
+        const codePoint = value.codePointAt(index)!;
+        index += codePoint > 0xffff ? 2 : 1;
+        count += 1;
+        if (stopAfter !== undefined && count > stopAfter) {
+            return count;
+        }
+    }
+    return count;
+}
+
+function truncateSimpleCodePoints(value: string, limit: number): string {
+    let count = 0;
+    let index = 0;
+    while (index < value.length && count < limit) {
+        const codePoint = value.codePointAt(index)!;
+        index += codePoint > 0xffff ? 2 : 1;
+        count += 1;
+    }
+    return index < value.length ? `${value.slice(0, index)}…` : value;
 }
 
 export function countGraphemes(value: string): number {
-    return graphemes(String(value || '')).length;
+    const source = String(value || '');
+    if (!hasComplexGraphemes(source)) {
+        return countSimpleCodePoints(source);
+    }
+    let count = 0;
+    for (const _part of graphemes(source)) {
+        count += 1;
+    }
+    return count;
+}
+
+export function hasAtMostGraphemes(value: string, limit: number): boolean {
+    const source = String(value || '');
+    const safeLimit = Math.max(0, Math.floor(limit));
+    if (source.length <= safeLimit) {
+        return true;
+    }
+    if (!hasComplexGraphemes(source)) {
+        return countSimpleCodePoints(source, safeLimit) <= safeLimit;
+    }
+    let count = 0;
+    for (const _part of graphemes(source)) {
+        count += 1;
+        if (count > safeLimit) {
+            return false;
+        }
+    }
+    return true;
 }
 
 export function truncateGraphemes(value: string, limit: number): string {
-    const parts = graphemes(String(value || ''));
+    const source = String(value || '');
     const safeLimit = Math.max(0, Math.floor(limit));
-    return parts.length <= safeLimit ? parts.join('') : `${parts.slice(0, safeLimit).join('')}…`;
+    if (source.length <= safeLimit) {
+        return source;
+    }
+    if (!hasComplexGraphemes(source)) {
+        return truncateSimpleCodePoints(source, safeLimit);
+    }
+    const parts: string[] = [];
+    for (const part of graphemes(source)) {
+        if (parts.length >= safeLimit) {
+            return `${parts.join('')}…`;
+        }
+        parts.push(part);
+    }
+    return source;
 }
 
 export function normalizeVisibleText(value: string): string {
@@ -43,7 +125,10 @@ export function normalizeVisibleText(value: string): string {
 
 export function buildUserPreview(value: string): string {
     const normalized = normalizeVisibleText(value);
-    return countGraphemes(normalized) <= CONVERSATION_LIMITS.previewGraphemes
+    return hasAtMostGraphemes(
+        normalized,
+        CONVERSATION_LIMITS.previewGraphemes
+    )
         ? normalized
         : truncateGraphemes(
             normalized,
@@ -69,7 +154,10 @@ export function buildToolCallSummary(
     ).replace(/\n+/g, ' ');
     const base = normalizeVisibleText(name);
     const combined = argument ? `${base} ${argument}` : base;
-    return countGraphemes(combined) <= CONVERSATION_LIMITS.toolCallSummaryGraphemes
+    return hasAtMostGraphemes(
+        combined,
+        CONVERSATION_LIMITS.toolCallSummaryGraphemes
+    )
         ? combined
         : truncateGraphemes(
             combined,
@@ -82,7 +170,10 @@ export function capToolCallDetail(value: string): string | undefined {
     if (!normalized) {
         return undefined;
     }
-    return countGraphemes(normalized) <= CONVERSATION_LIMITS.toolCallDetailGraphemes
+    return hasAtMostGraphemes(
+        normalized,
+        CONVERSATION_LIMITS.toolCallDetailGraphemes
+    )
         ? normalized
         : truncateGraphemes(
             normalized,

--- a/src/openWorkspaces/dashboardController.ts
+++ b/src/openWorkspaces/dashboardController.ts
@@ -24,6 +24,8 @@ import {
     validateOpenWorkspacePinSnapshot,
 } from './pinProtocol';
 
+const CARD_PROJECTION_BURST_TTL_MS = 100;
+
 export interface OpenWorkspaceDashboardState {
     otherWindows: { status: OpenWorkspaceBridgeStatus };
 }
@@ -62,6 +64,9 @@ export class OpenWorkspaceDashboardController {
     private updateRequested = false;
     private requestedFallbackToFullRefresh = true;
     private readonly fallbackOpenedAtMs: number;
+    private cachedCards: WorkspaceCardViewModel[] | null = null;
+    private cachedCardsKey: string | null = null;
+    private cachedCardsExpiresAtMs = 0;
 
     constructor(private readonly options: OpenWorkspaceDashboardControllerOptions) {
         this.fallbackOpenedAtMs = this.nowMs();
@@ -70,6 +75,7 @@ export class OpenWorkspaceDashboardController {
     setAggregate(aggregate: OpenWorkspaceAggregate | null): boolean {
         if (aggregate?.semanticRevision === this.aggregate?.semanticRevision) { return false; }
         this.aggregate = aggregate;
+        this.invalidateCardProjection();
         this.navigationWorkspacesById.clear();
         this.pinNavigationIdentityById.clear();
         return true;
@@ -79,12 +85,14 @@ export class OpenWorkspaceDashboardController {
         const normalized = validateOpenWorkspacePinSnapshot(snapshot);
         if (normalized.revision === this.pinSnapshot.revision) { return false; }
         this.pinSnapshot = normalized;
+        this.invalidateCardProjection();
         return true;
     }
 
     setBridgeStatus(status: OpenWorkspaceBridgeStatus): boolean {
         if (status === this.bridgeStatus) { return false; }
         this.bridgeStatus = status;
+        this.invalidateCardProjection();
         if (status !== 'ready') {
             this.aggregate = null;
             this.navigationWorkspacesById.clear();
@@ -109,6 +117,15 @@ export class OpenWorkspaceDashboardController {
         const startedAt = this.nowMs();
         const currentWorkspace = this.options.getCurrentWorkspace();
         const attentionAggregate = this.options.getAttentionAggregate();
+        const cacheKey = this.getCardProjectionCacheKey(
+            currentWorkspace,
+            attentionAggregate,
+        );
+        if (this.cachedCards
+            && cacheKey === this.cachedCardsKey
+            && startedAt < this.cachedCardsExpiresAtMs) {
+            return this.cachedCards;
+        }
         const pinTimes = getOpenWorkspacePinTimes(this.pinSnapshot);
         const ownRegistration = this.aggregate?.registrations.find(
             registration => registration.instanceId === this.options.getBridgeInstanceId()
@@ -175,6 +192,9 @@ export class OpenWorkspaceDashboardController {
             navigationWorkspaceCount: navigationCards.length,
             semanticRevision: this.aggregate?.semanticRevision || null,
         });
+        this.cachedCards = cards;
+        this.cachedCardsKey = cacheKey;
+        this.cachedCardsExpiresAtMs = startedAt + CARD_PROJECTION_BURST_TTL_MS;
         return cards;
     }
 
@@ -258,6 +278,7 @@ export class OpenWorkspaceDashboardController {
     invalidatePendingUpdates(): void {
         this.deliveryGeneration += 1;
         this.lastPostedSemanticRevision = null;
+        this.invalidateCardProjection();
     }
 
     private createCurrentCard(
@@ -347,6 +368,40 @@ export class OpenWorkspaceDashboardController {
             this.options.getGroups(),
             this.options.getTodoSearchItems(),
         ])).digest('hex');
+    }
+
+    private invalidateCardProjection(): void {
+        this.cachedCards = null;
+        this.cachedCardsKey = null;
+        this.cachedCardsExpiresAtMs = 0;
+    }
+
+    private getCardProjectionCacheKey(
+        workspace: OpenWorkspace | null,
+        attentionAggregate: AttentionAggregate | null,
+    ): string {
+        return JSON.stringify([
+            this.bridgeStatus,
+            this.aggregate?.semanticRevision || null,
+            this.pinSnapshot.revision,
+            attentionAggregate?.aggregateRevision || null,
+            workspace ? {
+                navigationIdentity: workspace.navigationIdentity,
+                scopeIdentity: workspace.scopeIdentity,
+                kind: workspace.kind,
+                displayName: workspace.displayName,
+                navigationUri: workspace.navigationUri,
+                environment: workspace.environment,
+                roots: workspace.roots.map(root => [
+                    root.id,
+                    root.name,
+                    root.uri,
+                    root.hostPath,
+                    root.ordinal,
+                ]),
+                saved: this.options.isWorkspaceSavedAsProject(workspace),
+            } : null,
+        ]);
     }
 
     private nowMs(): number {

--- a/src/services/kimiSessionService.ts
+++ b/src/services/kimiSessionService.ts
@@ -51,6 +51,9 @@ export default class KimiSessionService {
     private readonly lifecycleReader = new IncrementalJsonlLifecycleReader();
     private readonly cacheTtlMs = 5000;
     private readonly changePollIntervalMs = 3000;
+    private readonly changeListeners = new Set<{ onDidChange: () => void }>();
+    private changePoll: ReturnType<typeof setInterval> = null;
+    private changeFingerprint: string = null;
 
     resolveConversationSource(sessionId: string): AiSessionConversationSourceCandidate | null {
         const kimiHome = this.getKimiHome();
@@ -183,21 +186,56 @@ export default class KimiSessionService {
     }
 
     watchSessionChanges(onDidChange: () => void): Disposable {
-        let previousFingerprint = this.getSessionFingerprint();
-        let interval = setInterval(() => {
+        let listener = { onDidChange };
+        this.changeListeners.add(listener);
+        this.startChangePoll();
+        let disposed = false;
+
+        return {
+            dispose: () => {
+                if (disposed) {
+                    return;
+                }
+                disposed = true;
+                this.changeListeners.delete(listener);
+                if (this.changeListeners.size === 0) {
+                    this.stopChangePoll();
+                }
+            },
+        };
+    }
+
+    private startChangePoll(): void {
+        if (this.changePoll) {
+            return;
+        }
+
+        this.changeFingerprint = this.getSessionFingerprint();
+        this.changePoll = setInterval(() => {
             let nextFingerprint = this.getSessionFingerprint();
-            if (nextFingerprint === previousFingerprint) {
+            if (nextFingerprint === this.changeFingerprint) {
                 return;
             }
 
-            previousFingerprint = nextFingerprint;
+            this.changeFingerprint = nextFingerprint;
             this.invalidateCache();
-            onDidChange();
+            for (let listener of Array.from(this.changeListeners)) {
+                try {
+                    listener.onDidChange();
+                } catch (_error) {
+                    // One consumer must not prevent the shared poll from
+                    // invalidating every other Kimi conversation subscriber.
+                }
+            }
         }, this.changePollIntervalMs);
+    }
 
-        return {
-            dispose: () => clearInterval(interval),
-        };
+    private stopChangePoll(): void {
+        if (this.changePoll) {
+            clearInterval(this.changePoll);
+        }
+        this.changePoll = null;
+        this.changeFingerprint = null;
     }
 
     private cacheResult(result: KimiSessionReadResult): KimiSessionReadResult {

--- a/src/services/projectCatalogSyncService.ts
+++ b/src/services/projectCatalogSyncService.ts
@@ -257,12 +257,16 @@ export class ProjectCatalogSyncService {
     private nextConfigurationWriteId = 1;
     private pendingSyncDataWrites: PendingConfigurationWrite[] = [];
     private pendingLegacyGroupWrites: PendingConfigurationWrite[] = [];
+    private cachedGroups: Group[] = null;
 
     constructor(private readonly options: ProjectCatalogSyncServiceOptions) {
     }
 
     getGroups(): Group[] {
-        return materializeProjectCatalog(this.readCurrent().document);
+        if (!this.cachedGroups) {
+            this.cachedGroups = materializeProjectCatalog(this.readCurrent().document);
+        }
+        return clone(this.cachedGroups);
     }
 
     reconcile(): Promise<ProjectCatalogMergeResult> {
@@ -307,6 +311,9 @@ export class ProjectCatalogSyncService {
                 this.options.getLegacyGroups(),
                 value => Array.isArray(value)
             ) && local;
+        }
+        if (!local) {
+            this.cachedGroups = null;
         }
         return local;
     }
@@ -478,6 +485,8 @@ export class ProjectCatalogSyncService {
                 conflictProjectIds: current.conflictProjectIds,
             });
         }
+
+        this.cachedGroups = clone(groups);
 
         return {
             document: clone(document),

--- a/tests/contract/aiSessions/codexAppServerClient.test.js
+++ b/tests/contract/aiSessions/codexAppServerClient.test.js
@@ -308,6 +308,44 @@ test('SESSION-AI-SESSION-CODEX-APP-SERVER-002 frames Buffer chunks across arbitr
     ]);
 });
 
+test('SESSION-AI-SESSION-CODEX-APP-SERVER-002A keeps fragmented response copying linear', async t => {
+    const harness = createHarness();
+    t.after(() => harness.client.dispose());
+    const request = harness.client.request('thread/read', {
+        threadId: SESSION_ID,
+    });
+    await finishHandshake(harness.child);
+
+    const response = Buffer.from(`${JSON.stringify({
+        id: 2,
+        result: { text: 'x'.repeat(512 * 1024) },
+    })}\n`, 'utf8');
+    const originalConcat = Buffer.concat;
+    let copiedBytes = 0;
+    Buffer.concat = function measuredConcat(list, totalLength) {
+        copiedBytes += totalLength === undefined
+            ? list.reduce((total, bytes) => total + bytes.length, 0)
+            : totalLength;
+        return originalConcat(list, totalLength);
+    };
+    try {
+        for (let offset = 0; offset < response.length; offset += 4 * 1024) {
+            harness.child.stdout.emit(
+                'data',
+                response.subarray(offset, offset + 4 * 1024)
+            );
+        }
+        assert.equal((await request).text.length, 512 * 1024);
+    } finally {
+        Buffer.concat = originalConcat;
+    }
+
+    assert.ok(
+        copiedBytes <= response.length * 3,
+        `expected linear copying, copied ${copiedBytes} bytes for ${response.length}`
+    );
+});
+
 test('SESSION-AI-SESSION-CODEX-APP-SERVER-003 enforces the 16 MiB limit before parsing framed or unterminated lines', async t => {
     for (const terminated of [false, true]) {
         await t.test(terminated ? 'terminated line' : 'unterminated line', async t => {

--- a/tests/contract/aiSessions/codexConversationAdapter.test.js
+++ b/tests/contract/aiSessions/codexConversationAdapter.test.js
@@ -44,15 +44,39 @@ function createAdapter(result = fixture, overrides = {}) {
             return 1;
         }),
         clearTimeout: overrides.clearTimeout || (() => undefined),
+        setCacheTimeout: overrides.setCacheTimeout || (() => 2),
+        clearCacheTimeout: overrides.clearCacheTimeout || (() => undefined),
         resolveWorktree: overrides.resolveWorktree,
         readCurrentWorkdir: overrides.readCurrentWorkdir,
         readLifecycleSignal: overrides.readLifecycleSignal,
         listSubagentThreads: overrides.listSubagentThreads,
+        now: overrides.now,
     });
     return {
         adapter,
         requests,
         getClientDisposeCount: () => clientDisposeCount,
+    };
+}
+
+function createLargeThread() {
+    return {
+        thread: {
+            id: sessionId,
+            turns: Array.from({ length: 12 }, (_, index) => ({
+                id: `turn-${index}`,
+                status: 'completed',
+                items: [{
+                    id: `user-${index}`,
+                    type: 'userMessage',
+                    content: [{ type: 'text', text: `request ${index}` }],
+                }, {
+                    id: `agent-${index}`,
+                    type: 'agentMessage',
+                    text: 'x'.repeat(60 * 1024),
+                }],
+            })),
+        },
     };
 }
 
@@ -107,6 +131,114 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 Codex returns one correlated ou
         snapshot.page.anchorInteractionId,
         snapshot.outline.interactions.at(-1).id
     );
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 throttles repeated full reads of a large Codex thread', async t => {
+    const large = createLargeThread();
+    let now = 1_000;
+    const harness = createAdapter(large, { now: () => now });
+    t.after(() => harness.adapter.dispose());
+
+    const first = await harness.adapter.readOutline(sessionId);
+    const cached = await harness.adapter.readOutline(sessionId);
+    assert.equal(cached.sourceRevision, first.sourceRevision);
+    assert.equal(harness.requests.length, 1);
+
+    now += 15_001;
+    await harness.adapter.readOutline(sessionId);
+    assert.equal(harness.requests.length, 2);
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 invalidates a large Codex thread before publishing a provider change', async t => {
+    const large = createLargeThread();
+    let current = large;
+    let providerCallback;
+    const harness = createAdapter(() => current, {
+        watchSessionChanges(callback) {
+            providerCallback = callback;
+            return { dispose() {} };
+        },
+    });
+    t.after(() => harness.adapter.dispose());
+    const subscription = harness.adapter.watch(sessionId, () => undefined);
+    t.after(() => subscription.dispose());
+
+    const first = await harness.adapter.readOutline(sessionId);
+    current = clone(large);
+    current.thread.turns.at(-1).items.at(-1).text =
+        `${'x'.repeat(60 * 1024)} changed`;
+    providerCallback();
+    const updated = await harness.adapter.readOutline(sessionId);
+
+    assert.notEqual(updated.sourceRevision, first.sourceRevision);
+    assert.equal(harness.requests.length, 2);
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 actively releases an unread expired Codex thread', async t => {
+    const large = createLargeThread();
+    let expiryCallback;
+    const harness = createAdapter(large, {
+        setCacheTimeout(callback, delayMs) {
+            assert.equal(delayMs, 15_000);
+            expiryCallback = callback;
+            return 42;
+        },
+    });
+    t.after(() => harness.adapter.dispose());
+
+    await harness.adapter.readOutline(sessionId);
+    assert.equal(harness.adapter.loadedConversationCache.size, 1);
+    expiryCallback();
+    assert.equal(harness.adapter.loadedConversationCache.size, 0);
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 does not cache a large Codex read invalidated while pending', async t => {
+    const large = createLargeThread();
+    let resolveRead;
+    let providerCallback;
+    const harness = createAdapter(large, {
+        client: {
+            request() {
+                return new Promise(resolve => {
+                    resolveRead = resolve;
+                });
+            },
+            dispose() {},
+        },
+        watchSessionChanges(callback) {
+            providerCallback = callback;
+            return { dispose() {} };
+        },
+    });
+    t.after(() => harness.adapter.dispose());
+    const subscription = harness.adapter.watch(sessionId, () => undefined);
+    t.after(() => subscription.dispose());
+
+    const pending = harness.adapter.readOutline(sessionId);
+    providerCallback();
+    resolveRead(large);
+    await pending;
+
+    assert.equal(harness.adapter.loadedConversationCache.size, 0);
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 handles a synchronous Codex cache expiry timer without retaining its handle', async t => {
+    let clearCalls = 0;
+    const harness = createAdapter(createLargeThread(), {
+        setCacheTimeout(callback) {
+            callback();
+            return 42;
+        },
+        clearCacheTimeout() {
+            clearCalls += 1;
+        },
+    });
+    t.after(() => harness.adapter.dispose());
+
+    await harness.adapter.readOutline(sessionId);
+
+    assert.equal(harness.adapter.loadedConversationCache.size, 0);
+    assert.equal(clearCalls, 0);
 });
 
 test('SESSION-AI-SESSION-CONVERSATION-ADAPTER-001 Codex normalizes only stable visible user and agent items', async t => {

--- a/tests/contract/aiSessions/kimiConversationAdapter.test.js
+++ b/tests/contract/aiSessions/kimiConversationAdapter.test.js
@@ -709,6 +709,41 @@ test('SESSION-AI-SESSION-CONVERSATION-ADAPTER-001 real Kimi polling invalidates 
     );
 });
 
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 shares one Kimi filesystem poll across subscribers', () => {
+    const service = new KimiSessionService();
+    let fingerprintReads = 0;
+    service.getSessionFingerprint = () => `revision-${++fingerprintReads}`;
+
+    const first = service.watchSessionChanges(() => undefined);
+    const second = service.watchSessionChanges(() => undefined);
+    try {
+        assert.equal(fingerprintReads, 1);
+    } finally {
+        first.dispose();
+        second.dispose();
+    }
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 isolates Kimi subscriber failures during a shared poll', () => {
+    const service = new KimiSessionService();
+    let fingerprintReads = 0;
+    service.getSessionFingerprint = () => `revision-${++fingerprintReads}`;
+    let delivered = 0;
+    const failing = service.watchSessionChanges(() => {
+        throw new Error('subscriber failed');
+    });
+    const healthy = service.watchSessionChanges(() => {
+        delivered += 1;
+    });
+    try {
+        assert.doesNotThrow(() => service.changePoll._onTimeout());
+        assert.equal(delivered, 1);
+    } finally {
+        failing.dispose();
+        healthy.dispose();
+    }
+});
+
 test('SESSION-AI-SESSION-CONVERSATION-ADAPTER-001 real Kimi cap keeps newest 2,000 inputs and marks the outline partial', async t => {
     const source = await createFixture(t);
     const records = [];

--- a/tests/contract/openProjects/dashboardController.test.js
+++ b/tests/contract/openProjects/dashboardController.test.js
@@ -137,6 +137,39 @@ test('WEBVIEW-SIDEBAR-VISIBILITY-RETENTION-001 coalesces rapid OPEN revisions be
     assert.deepEqual(posted[1].searchCatalog.savedProjects[0].groupLabels, ['Work 15']);
 });
 
+test('WEBVIEW-SIDEBAR-VISIBILITY-RETENTION-001 reuses one card projection across a burst of sidebar consumers', () => {
+    let nowMs = 5_000;
+    let hydrationCalls = 0;
+    let savedAsProject = false;
+    const controller = new OpenWorkspaceDashboardController(createOptions({
+        isWorkspaceSavedAsProject: () => savedAsProject,
+        getCurrentWorkspaceAiSessions: () => {
+            hydrationCalls += 1;
+            return null;
+        },
+        nowMs: () => nowMs,
+    }));
+
+    const first = controller.getCards();
+    for (let iteration = 0; iteration < 20; iteration += 1) {
+        assert.strictEqual(controller.getCards(), first);
+    }
+    assert.equal(hydrationCalls, 1,
+        'parallel dashboard consumers must share one expensive session projection');
+
+    savedAsProject = true;
+    const savedProjection = controller.getCards();
+    assert.notStrictEqual(savedProjection, first,
+        'a semantic workspace change must invalidate the burst immediately');
+    assert.equal(savedProjection[0].showSaveAction, false);
+    assert.equal(hydrationCalls, 2);
+
+    nowMs += 1_000;
+    assert.notStrictEqual(controller.getCards(), savedProjection,
+        'the burst cache must not become an authoritative long-lived snapshot');
+    assert.equal(hydrationCalls, 3);
+});
+
 test('OPEN-ALL-WINDOWS-LIST-001 orders current and navigation cards together without focus-driven movement', () => {
     const current = makeRecord({ name: 'Current', uri: '/work/current' });
     const oldest = makeRecord({ name: 'Oldest', uri: '/work/oldest' });

--- a/tests/contract/persistence/projectCatalogSync.test.js
+++ b/tests/contract/persistence/projectCatalogSync.test.js
@@ -451,6 +451,44 @@ test('PROJECT-CATALOG-SYNC-CONFLICT-001 persistence reads merged shadow state be
     assert.deepEqual(harness.writes, []);
 });
 
+test('PROJECT-INCREMENTAL-REFRESH-001 reuses the materialized catalog until configuration changes', () => {
+    const groups = makeCatalogGroups();
+    let syncReads = 0;
+    let localReads = 0;
+    let legacyReads = 0;
+    const ProjectCatalogSyncService = loadProjectCatalogSyncService();
+    const service = new ProjectCatalogSyncService({
+        getSyncData: () => {
+            syncReads++;
+            return null;
+        },
+        updateSyncData: async () => undefined,
+        getLegacyGroups: () => {
+            legacyReads++;
+            return clone(groups);
+        },
+        updateLegacyGroups: async () => undefined,
+        getLocalState: () => {
+            localReads++;
+            return null;
+        },
+        updateLocalState: async () => undefined,
+        createActorId: () => 'actor-cache',
+    });
+
+    const first = service.getGroups();
+    first[0].projects[0].name = 'Caller mutation';
+    assert.equal(service.getGroups()[0].projects[0].name, 'Existing');
+    assert.deepEqual([syncReads, localReads, legacyReads], [1, 1, 1]);
+
+    assert.equal(service.consumeConfigurationWriteEcho({
+        syncData: false,
+        legacyGroups: true,
+    }), false);
+    service.getGroups();
+    assert.deepEqual([syncReads, localReads, legacyReads], [2, 2, 3]);
+});
+
 test('PROJECT-CATALOG-SYNC-CONFLICT-001 hardening repairs malformed sync data without logging catalog content', async () => {
     const {
         applyProjectCatalogSnapshot,

--- a/tests/integration/dashboard/conversationOpenLatest.test.js
+++ b/tests/integration/dashboard/conversationOpenLatest.test.js
@@ -536,6 +536,68 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 times out a hung speculative re
     harness.capability.dispose();
 });
 
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 evicts completed speculative snapshots without requiring another navigation', async () => {
+    const sessions = ['codex', 'kimi'].map((provider, index) => makeSession({
+        key: `${provider}:retained-${index}`,
+        provider,
+        sessionId: `retained-${index}`,
+        name: `${provider} Session`,
+    }));
+    const timers = [];
+    let nowMs = 1_000;
+    const harness = createHarness({
+        enableSnapshots: true,
+        requireSnapshot: true,
+        viewerOpen: true,
+        session: sessions[0],
+        now: () => nowMs,
+        resolveTarget: (_projectId, provider, sessionId) =>
+            sessions.find(session => session.provider === provider
+                && session.sessionId === sessionId) || null,
+        resolveActiveTargets: () => sessions,
+        setTimer: (callback, delayMs) => {
+            const timer = { callback, delayMs, cleared: false };
+            timers.push(timer);
+            if (delayMs === 0) {
+                setImmediate(() => {
+                    if (!timer.cleared) callback();
+                });
+            }
+            return timer;
+        },
+        clearTimer: timer => { timer.cleared = true; },
+    });
+
+    assert.equal(await harness.capability.openLatestConversation({
+        projectId: 'project-a',
+        provider: 'codex',
+        sessionId: 'retained-0',
+    }), 'opened');
+    while (!harness.snapshotReadTargets.includes('kimi:retained-1')) {
+        await new Promise(resolve => setImmediate(resolve));
+    }
+    await new Promise(resolve => setImmediate(resolve));
+
+    const completedExpiry = timers.find(timer =>
+        timer.delayMs === 5_000 && !timer.cleared
+    );
+    assert.ok(completedExpiry,
+        'a completed warm snapshot must retain an active expiry timer');
+    nowMs += 5_001;
+    completedExpiry.callback();
+    await new Promise(resolve => setImmediate(resolve));
+
+    assert.equal(await harness.capability.followActiveConversation({
+        projectId: 'project-a',
+        provider: 'kimi',
+        sessionId: 'retained-1',
+    }), 'opened');
+    assert.equal(harness.snapshotReadTargets.filter(target =>
+        target === 'kimi:retained-1'
+    ).length, 2, 'an expired speculative snapshot must be read authoritatively');
+    harness.capability.dispose();
+});
+
 test('WEBVIEW-AI-SESSION-CONVERSATION-VIEWER-001 dashboard registers a serializer that restores AI Conversation panels', () => {
     const dashboardSource = fs.readFileSync(
         path.join(__dirname, '../../../src/dashboard.ts'),

--- a/tests/unit/aiSessions/conversationModel.test.js
+++ b/tests/unit/aiSessions/conversationModel.test.js
@@ -81,6 +81,42 @@ test('SESSION-AI-SESSION-CONVERSATION-MODEL-003 removes complete interactions un
     assert.ok(Buffer.byteLength(JSON.stringify(page), 'utf8') <= CONVERSATION_LIMITS.maxPageBytes);
 });
 
+test('SESSION-AI-SESSION-CONVERSATION-MODEL-004 bounds serialization work while shrinking a large page', () => {
+    const interactions = makeInteractions(20).map(interaction => ({
+        ...interaction,
+        userMarkdown: 'u'.repeat(60 * 1024),
+        assistantMarkdown: ['a'.repeat(60 * 1024)],
+    }));
+    const sourceCharacters = interactions.length * 120 * 1024;
+    const originalStringify = JSON.stringify;
+    let serializedCharacters = 0;
+    JSON.stringify = function measuredStringify(...args) {
+        const result = originalStringify(...args);
+        serializedCharacters += result?.length || 0;
+        return result;
+    };
+    let page;
+    try {
+        page = model.buildConversationPage(interactions, {
+            provider: 'codex',
+            sessionId: 'session',
+            anchorInteractionId: 'i-20',
+            direction: 'around',
+            limit: 20,
+        }, 'r1');
+    } finally {
+        JSON.stringify = originalStringify;
+    }
+    assert.ok(
+        serializedCharacters <= sourceCharacters * 3,
+        `serialized ${serializedCharacters} characters for ${sourceCharacters} source characters`
+    );
+    assert.ok(
+        Buffer.byteLength(JSON.stringify(page), 'utf8')
+            <= CONVERSATION_LIMITS.maxPageBytes
+    );
+});
+
 test('CONVERSATION-TOOL-CALL-VISIBILITY-001 CONVERSATION-PROGRESS-VISIBILITY-001 interleaves tool calls with progress and final assistant text by position', () => {
     const interactions = [{
         id: 'i-1',

--- a/tests/unit/aiSessions/conversationText.test.js
+++ b/tests/unit/aiSessions/conversationText.test.js
@@ -31,3 +31,39 @@ test('SESSION-AI-SESSION-CONVERSATION-TEXT-001 counts and truncates visible inpu
     controller.abort();
     assert.equal(cancelled, 1);
 });
+
+test('SESSION-AI-SESSION-CONVERSATION-TEXT-002 does not materialize every grapheme while enforcing limits', () => {
+    const value = '😀'.repeat(128 * 1024);
+    const originalFrom = Array.from;
+    const segmenterPrototype = Intl.Segmenter?.prototype;
+    const originalSegment = segmenterPrototype?.segment;
+    let arrayFromCalls = 0;
+    let segmentCalls = 0;
+    Array.from = function measuredFrom(...args) {
+        arrayFromCalls += 1;
+        return originalFrom(...args);
+    };
+    if (segmenterPrototype && originalSegment) {
+        segmenterPrototype.segment = function measuredSegment(...args) {
+            segmentCalls += 1;
+            return originalSegment.apply(this, args);
+        };
+    }
+    try {
+        assert.equal(text.countGraphemes(value), 128 * 1024);
+        assert.equal(
+            text.truncateGraphemes(value, 160),
+            `${'😀'.repeat(160)}…`
+        );
+        const ordinary = `${'普通文本'.repeat(64 * 1024)}${'x'.repeat(64 * 1024)}`;
+        assert.equal(text.hasAtMostGraphemes(ordinary, 160), false);
+        assert.equal(text.truncateGraphemes(ordinary, 3), '普通文…');
+    } finally {
+        Array.from = originalFrom;
+        if (segmenterPrototype && originalSegment) {
+            segmenterPrototype.segment = originalSegment;
+        }
+    }
+    assert.equal(arrayFromCalls, 0);
+    assert.equal(segmentCalls, 0);
+});


### PR DESCRIPTION
## Summary

- bound large AI Conversation parsing, validation, page serialization, and Codex app-server buffering work
- actively expire and invalidate large Codex conversation snapshots without stale refill races
- share Kimi filesystem polling across subscribers and isolate listener failures
- reuse burst-stable open-workspace projections and materialized project catalogs

## Runtime evidence

- before: both Extension Hosts grew to roughly 4.5 GB within about four minutes
- after: two reloaded Extension Hosts remained around 0.8 GB and 0.7 GB after five minutes with normal garbage collection
- an eight-second CPU profile was 86.3% idle, with each Agent Pivot background path below 1% self time

## Validation

- npm run test:ci:linux
- npm run test:conversation-performance
- node scripts/run-dashboard-webview-checks.js
- npm run test:behavior-contracts
- SKIP_NPM_CI=1 npm run install-local
- git diff --check
- final read-only review: no Critical or Important findings

## Skill harvest

- none: existing repository skills already cover worktree isolation, rebase and verification ordering, review, capability audit, and PR publication; the process-level Extension Host profiling details were incident-specific and did not justify a reusable skill change.