### PR TITLE
Fix Claude compact lifecycle status

### DIFF
--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "18a6618d6dbd214d0383938fac41f1cb3730f430",
+        "head": "687e3f6959ffce62db59daed3fc785a78a284ed1",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -174,7 +174,8 @@
             "8a4457cce77ac21f1955d50438d223ce4c6cdc7f",
             "5667da2d9f220374e20f77869e29097790f0332d",
             "473e14e3a78c9abd379da9c09cca67fa62ef7753",
-            "4cb24754461b81356412c1d3396493fa9712949e"
+            "4cb24754461b81356412c1d3396493fa9712949e",
+            "84ecb123c7c94fb471278fde3056d9c627bcabbc"
         ]
     },
     "capabilities": [
@@ -770,7 +771,8 @@
                 "1f210dccb8ef768656ebcf513bb7e04b75f83c8d",
                 "b3af83ee68f9eac78dcf7c0f49d6401494b1884c",
                 "16dc36ed5da9f6ba589fb8b748f723056657bcef",
-                "f3e53a32c81c87dc0df919c8f0d3355c37ca69fb"
+                "f3e53a32c81c87dc0df919c8f0d3355c37ca69fb",
+                "687e3f6959ffce62db59daed3fc785a78a284ed1"
             ],
             "behaviors": [
                 "ATTENTION-ACTIVE-UNREGISTER-ON-DEACTIVATE-001",
@@ -784,7 +786,8 @@
                 "ATTENTION-BRIDGE-STALENESS-001",
                 "SESSION-CLAUDE-SESSION-SERVICE-001",
                 "SESSION-CODEX-SESSION-SERVICE-001",
-                "SESSION-FINGERPRINT-HASH-001"
+                "SESSION-FINGERPRINT-HASH-001",
+                "PERSIST-LIFECYCLE-PARSER-001"
             ],
             "prGates": [
                 "test:deterministic:run"

--- a/src/aiSessions/lifecycle.ts
+++ b/src/aiSessions/lifecycle.ts
@@ -247,7 +247,16 @@ export function createClaudeLifecycleAccumulator(runStartedAtMs: number): AiSess
         if (event?.type === 'system' && event?.subtype === 'api_error') {
             return attention('claude', 'api_error', occurredAtMs, 'failed');
         }
+        if (event?.type === 'system' && event?.subtype === 'compact_boundary') {
+            if (event?.compactMetadata?.trigger === 'manual') {
+                return idle('claude', event.subtype, occurredAtMs, event.uuid);
+            }
+            return running('claude', event.subtype, occurredAtMs, event.uuid);
+        }
         if (event?.type === 'user') {
+            if (event?.isCompactSummary === true) {
+                return null;
+            }
             if (isClaudeUserInterrupt(event)) {
                 return idle('claude', 'user_interrupt', occurredAtMs, event.uuid);
             }

--- a/tests/unit/aiSessions/lifecycle.test.js
+++ b/tests/unit/aiSessions/lifecycle.test.js
@@ -321,3 +321,95 @@ test('PERSIST-LIFECYCLE-PARSER-001 [claude] treats the tool-use interrupt marker
     assert.equal(signal.executionState, 'stopped');
     assert.match(signal.token, /^claude:user_interrupt:/);
 });
+
+test('PERSIST-LIFECYCLE-PARSER-001 [claude] treats a manual compact boundary as stopped', () => {
+    const compacted = lifecycle.parseClaudeLifecycleLines([
+        JSON.stringify({
+            type: 'system',
+            subtype: 'compact_boundary',
+            timestamp: '2026-08-06T06:10:14.521Z',
+            uuid: 'compact-boundary',
+            content: 'Conversation compacted',
+            compactMetadata: { trigger: 'manual' },
+        }),
+        JSON.stringify({
+            type: 'user',
+            timestamp: '2026-08-06T06:10:14.522Z',
+            uuid: 'compact-summary',
+            isCompactSummary: true,
+            message: {
+                role: 'user',
+                content: 'Sanitized compact summary',
+            },
+        }),
+    ], runStartedAtMs);
+
+    assert.ok(compacted);
+    assert.equal(compacted.phase, 'idle');
+    assert.equal(compacted.reason, undefined);
+    assert.equal(compacted.executionState, 'stopped');
+    assert.match(compacted.token, /^claude:compact_boundary:/);
+});
+
+test('PERSIST-LIFECYCLE-PARSER-001 [claude] keeps an automatic compact boundary running', () => {
+    const compactLines = [
+        JSON.stringify({
+            type: 'system',
+            subtype: 'compact_boundary',
+            timestamp: '2026-08-06T06:10:14.521Z',
+            uuid: 'compact-boundary',
+            content: 'Conversation compacted',
+            compactMetadata: { trigger: 'auto' },
+        }),
+        JSON.stringify({
+            type: 'user',
+            timestamp: '2026-08-06T06:10:14.520Z',
+            uuid: 'compact-summary',
+            isCompactSummary: true,
+            message: { role: 'user', content: 'Sanitized compact summary' },
+        }),
+    ];
+    const compacted = lifecycle.parseClaudeLifecycleLines(compactLines, runStartedAtMs);
+
+    assert.ok(compacted);
+    assert.equal(compacted.phase, 'running');
+    assert.equal(compacted.executionState, 'running');
+    assert.match(compacted.token, /^claude:compact_boundary:/);
+
+    const resumed = lifecycle.parseClaudeLifecycleLines([
+        ...compactLines,
+        JSON.stringify({
+            type: 'assistant',
+            timestamp: '2026-08-06T06:10:19.000Z',
+            uuid: 'assistant-after-compact',
+            message: { role: 'assistant', stop_reason: null, content: [] },
+        }),
+    ], runStartedAtMs);
+
+    assert.ok(resumed);
+    assert.equal(resumed.phase, 'running');
+    assert.equal(resumed.executionState, 'running');
+});
+
+test('PERSIST-LIFECYCLE-PARSER-001 [claude] keeps an unknown compact trigger backward-compatible', () => {
+    const signal = lifecycle.parseClaudeLifecycleLines([
+        JSON.stringify({
+            type: 'system',
+            subtype: 'compact_boundary',
+            timestamp: '2026-08-06T06:10:14.521Z',
+            uuid: 'compact-boundary-without-trigger',
+        }),
+        JSON.stringify({
+            type: 'user',
+            timestamp: '2026-08-06T06:10:14.522Z',
+            uuid: 'compact-summary',
+            isCompactSummary: true,
+            message: { role: 'user', content: 'Sanitized compact summary' },
+        }),
+    ], runStartedAtMs);
+
+    assert.ok(signal);
+    assert.equal(signal.phase, 'running');
+    assert.equal(signal.executionState, 'running');
+    assert.match(signal.token, /^claude:compact_boundary:/);
+});


### PR DESCRIPTION
## Summary

- Treat Claude manual `compact_boundary` records as idle/stopped so compacted sessions do not remain stuck in the running state.
- Keep automatic and unknown compact triggers running, and ignore synthetic `isCompactSummary` user records so record order or timestamp ties cannot overwrite the boundary decision.
- Add regression coverage for manual, automatic, unknown-trigger, resumed-assistant, and out-of-order compact records.

## Validation

- `npm run test:ci:linux`
- Focused lifecycle, provider, and attention suites: 93 passed
- Real Claude transcript validation: manual boundaries stopped; automatic boundaries remained running
- `npm run test:behavior-contracts`
- `git diff --check`
- Local VSIX installation and installed-byte verification for Agent Pivot 1.0.4 and Attention UI Bridge 1.0.1
- Final read-only integration review: no Critical, Important, or Minor findings

## Skill harvest

No skill change was justified. The existing provider-adapter skill already requires a real-data shape census, real-layout fixtures, and compiled-adapter validation; the initial sampling gap was a compliance issue rather than a missing reusable rule.
