### PR TITLE
Fix delayed conversation worklog collapse

### DIFF
--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "6c1958c97bf1de8b7bead4f698c2c14fcc848ee5",
+        "head": "6d16abc51cf0da5266cff6131f574fdb50a8b658",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -180,7 +180,8 @@
             "455777b4a9d308dc3984fa294aca384284bc7f2f",
             "75f6d6c75d7e1ecf70e44269d7b8e348079c985d",
             "3d28e38ad2fd8aaa2ca61eae8dfa6c981c9bf749",
-            "6d9121d2e321c7e56946db87e29e215fec1d9e48"
+            "6d9121d2e321c7e56946db87e29e215fec1d9e48",
+            "83b140ad79d365f53e724c673d7bda344bc47939"
         ]
     },
     "capabilities": [
@@ -1321,7 +1322,8 @@
                 "79f7443527f7f20912771feeb6d2f62dfd943021",
                 "c7539a1cff1868ccf4f0ece0c490ae53a3ad6e53",
                 "b1b417e9af95101f0930d3caf9f9e91ed65f8ef9",
-                "6c1958c97bf1de8b7bead4f698c2c14fcc848ee5"
+                "6c1958c97bf1de8b7bead4f698c2c14fcc848ee5",
+                "6d16abc51cf0da5266cff6131f574fdb50a8b658"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",

--- a/media/conversationViewerScripts.js
+++ b/media/conversationViewerScripts.js
@@ -809,6 +809,43 @@
             - (scroll.clientHeight - elementBounds.height) / 2;
     }
 
+    function worklogRowForInteraction(interactionId) {
+        if (!interactionId) return null;
+        return Array.prototype.find.call(
+            messages.querySelectorAll('.conversation-message-worklog'),
+            function (row) {
+                return row.getAttribute('data-interaction-id')
+                    === interactionId;
+            }
+        ) || null;
+    }
+
+    function retargetCollapsedWorklogAnchor(anchor) {
+        if (!anchor || !anchor.element || !anchor.element.closest) {
+            return anchor;
+        }
+        var message = anchor.element.closest(conversationMessageSelector());
+        if (message && !message.isConnected && anchor.messageId) {
+            message = Array.prototype.find.call(
+                messages.querySelectorAll(conversationMessageSelector()),
+                function (candidate) {
+                    return conversationMessageId(candidate)
+                        === anchor.messageId;
+                }
+            ) || null;
+        }
+        if (!message || !message.hidden) return anchor;
+        var row = worklogRowForInteraction(
+            message.getAttribute('data-interaction-id')
+        );
+        if (!row) return anchor;
+        return Object.assign({}, anchor, {
+            element: row,
+            messageId: conversationMessageId(row),
+            blockIndex: -1,
+        });
+    }
+
     function applyWorklogStates() {
         Array.prototype.forEach.call(
             messages.querySelectorAll('.conversation-message-worklog'),
@@ -867,6 +904,9 @@
             : null;
         var focusedMessageId = focusedMessage
             ? conversationMessageId(focusedMessage)
+            : null;
+        var focusedInteractionId = focusedMessage
+            ? focusedMessage.getAttribute('data-interaction-id')
             : null;
         var oldSignatures = state.messageSignatures;
         state.renderGeneration += 1;
@@ -958,6 +998,7 @@
         if (isLiveRefresh
             && focusedMessageId
             && (!focusedMessage.isConnected
+                || focusedMessage.hidden
                 || !focusedMessage.contains(document.activeElement))) {
             var restoredFocus = Array.prototype.find.call(
                 messages.querySelectorAll(conversationMessageSelector()),
@@ -966,9 +1007,19 @@
                         === focusedMessageId;
                 }
             );
-            if (restoredFocus) {
+            if (restoredFocus && !restoredFocus.hidden) {
                 restoredFocus.tabIndex = -1;
                 restoredFocus.focus({ preventScroll: true });
+            } else {
+                var worklogRow = worklogRowForInteraction(
+                    focusedInteractionId
+                );
+                var worklogToggle = worklogRow
+                    ? worklogRow.querySelector('.conversation-worklog-toggle')
+                    : null;
+                if (worklogToggle) {
+                    worklogToggle.focus({ preventScroll: true });
+                }
             }
         }
         renderMermaidDiagrams(renderGeneration);
@@ -992,7 +1043,10 @@
         if (wasFollowingEnd) {
             reconcileController.scrollToEnd();
         } else {
-            restoreReadingPosition(readingAnchor, previousScrollTop);
+            restoreReadingPosition(
+                retargetCollapsedWorklogAnchor(readingAnchor),
+                previousScrollTop
+            );
             reconcileController.trackEnd();
         }
     }

--- a/src/aiSessions/conversation/coordinator.ts
+++ b/src/aiSessions/conversation/coordinator.ts
@@ -460,6 +460,12 @@ export class ConversationCoordinator implements AiSessionDisposable {
                     active,
                     page.isEnd && index === page.interactionStates.length - 1
                 ),
+                ...(state.timestamp !== undefined
+                    ? { timestamp: state.timestamp }
+                    : {}),
+                ...(state.completedAt !== undefined
+                    ? { completedAt: state.completedAt }
+                    : {}),
             })),
             previousCursor: page.previousCursor === undefined
                 ? undefined
@@ -748,6 +754,12 @@ export class ConversationCoordinator implements AiSessionDisposable {
                 && typeof state.interactionId === 'string'
                 && Boolean(state.interactionId)
                 && isResponseState(state.responseState)
+                && (state.timestamp === undefined
+                    || (typeof state.timestamp === 'number'
+                        && Number.isFinite(state.timestamp)))
+                && (state.completedAt === undefined
+                    || (typeof state.completedAt === 'number'
+                        && Number.isFinite(state.completedAt)))
             ))
             || (page.previousCursor !== undefined
                 && typeof page.previousCursor !== 'string')

--- a/src/aiSessions/conversation/viewer.ts
+++ b/src/aiSessions/conversation/viewer.ts
@@ -1169,49 +1169,83 @@ export class ConversationViewer implements ConversationViewerApi {
                 : advanceToLatest
                     ? interactionIds[interactionIds.length - 1]
                     : previousSelectedInteractionId as string;
+            let lifecycleProjectionInteractionId: string | undefined;
             const retainedOutline = this.outlineController.snapshot;
-            if (updateKind === 'refresh'
-                && !this.stale
-                && retainedOutline?.sourceRevision
-                    === outline.sourceRevision) {
+            const retainedRevisionMatches = retainedOutline?.sourceRevision
+                === outline.sourceRevision;
+            if (updateKind === 'refresh' && !this.stale && retainedOutline) {
                 const sameInteractionIds = retainedOutline.interactions.length
                     === outline.interactions.length
                     && outline.interactions.every((interaction, index) =>
                         retainedOutline.interactions[index].id
                             === interaction.id
                     );
-                const lifecycleChanged = sameInteractionIds
-                    && outline.interactions.some((interaction, index) =>
+                const lifecycleChangedInteractionIds = sameInteractionIds
+                    ? outline.interactions.filter((interaction, index) =>
                         retainedOutline.interactions[index].responseState
                             !== interaction.responseState
+                    ).map(interaction => interaction.id)
+                    : [];
+                if (retainedRevisionMatches
+                    && !lifecycleChangedInteractionIds.length) {
+                    void this.telemetryController.refresh(
+                        target,
+                        generation,
+                        this.effectiveSessionId(target)
                     );
-                if (lifecycleChanged
-                    && this.outlineController.replace(
+                    return true;
+                }
+                // Lifecycle projection can change both responseState and the
+                // latest assistant/progress roles. Re-read the bounded page
+                // even though provider content is unchanged so retained HTML
+                // cannot lag behind the authoritative turn state.
+                const loadedInteractionIds = new Set(this.interactionIds());
+                for (let index = lifecycleChangedInteractionIds.length - 1;
+                    index >= 0;
+                    index--) {
+                    const interactionId = lifecycleChangedInteractionIds[index];
+                    if (loadedInteractionIds.has(interactionId)) {
+                        lifecycleProjectionInteractionId = interactionId;
+                        break;
+                    }
+                }
+                if (retainedRevisionMatches
+                    && !lifecycleProjectionInteractionId) {
+                    if (this.outlineController.replace(
                         outline,
                         selectedInteractionId
                     )) {
-                    await this.deliverPublication(this.createPublication(
-                        requestId,
-                        generation,
-                        updateKind
-                    ), replaceDocument);
+                        await this.deliverPublication(this.createPublication(
+                            requestId,
+                            generation,
+                            updateKind
+                        ), replaceDocument);
+                    }
+                    return true;
                 }
-                void this.telemetryController.refresh(
-                    target,
-                    generation,
-                    this.effectiveSessionId(target)
-                );
-                return true;
             }
             let page: ConversationPage;
-            if (snapshot?.page) {
+            let selectedRefreshPage: ConversationPage | undefined;
+            const snapshotCoversLifecycleProjection =
+                !lifecycleProjectionInteractionId
+                || snapshot?.page?.interactionStates.some(state =>
+                    state.interactionId === lifecycleProjectionInteractionId
+                ) === true;
+            if (snapshot?.page && snapshotCoversLifecycleProjection) {
                 page = snapshot.page;
             } else {
+                // A content revision can advance in the same refresh that
+                // completes a retained turn. Keep the selected snapshot page
+                // as well as re-reading the changed turn: the former carries
+                // unrelated content changes, while the latter restores final
+                // assistant roles and worklog collapse state.
+                selectedRefreshPage = snapshot?.page;
                 try {
                     page = await this.options.readPage({
                         provider: target.provider,
                         sessionId: this.effectiveSessionId(target),
-                        anchorInteractionId: selectedInteractionId,
+                        anchorInteractionId: lifecycleProjectionInteractionId
+                            || selectedInteractionId,
                         direction: 'around',
                         expectedRevision: outline.sourceRevision,
                         limit: CONVERSATION_LIMITS.maxPageInteractions,
@@ -1249,10 +1283,18 @@ export class ConversationViewer implements ConversationViewerApi {
                         await this.publishFailure(replaceDocument, updateKind);
                         return false;
                     }
+                    if (lifecycleProjectionInteractionId
+                        && !outline.interactions.some(interaction =>
+                            interaction.id
+                                === lifecycleProjectionInteractionId)) {
+                        lifecycleProjectionInteractionId = undefined;
+                    }
+                    selectedRefreshPage = undefined;
                     page = await this.options.readPage({
                         provider: target.provider,
                         sessionId: this.effectiveSessionId(target),
-                        anchorInteractionId: selectedInteractionId,
+                        anchorInteractionId: lifecycleProjectionInteractionId
+                            || selectedInteractionId,
                         direction: 'around',
                         expectedRevision: outline.sourceRevision,
                         limit: CONVERSATION_LIMITS.maxPageInteractions,
@@ -1268,15 +1310,28 @@ export class ConversationViewer implements ConversationViewerApi {
                 await this.publishFailure(replaceDocument, updateKind);
                 return false;
             }
+            if (selectedRefreshPage
+                && (selectedRefreshPage.provider !== target.provider
+                    || selectedRefreshPage.sessionId
+                        !== this.effectiveSessionId(target)
+                    || selectedRefreshPage.sourceRevision
+                        !== outline.sourceRevision)) {
+                selectedRefreshPage = undefined;
+            }
             if (!this.outlineController.replace(
                 outline,
-                page.anchorInteractionId
+                lifecycleProjectionInteractionId
+                    ? selectedInteractionId
+                    : page.anchorInteractionId
             )) {
                 await this.publishFailure(replaceDocument, updateKind);
                 return false;
             }
             this.stale = false;
             if (updateKind === 'refresh') {
+                if (selectedRefreshPage) {
+                    this.mergeRefreshPage(selectedRefreshPage, outline);
+                }
                 this.mergeRefreshPage(page, outline);
             } else {
                 this.retain(page, 'replace');
@@ -1635,10 +1690,19 @@ export class ConversationViewer implements ConversationViewerApi {
         );
         const loadedIds = new Set<string>();
         const messagesByInteraction = new Map<string, ConversationMessage[]>();
+        const statesByInteraction = new Map<
+            string,
+            ConversationPage['interactionStates'][number]
+        >();
         this.pages.forEach(retained => {
             retained.page.interactionStates.forEach(state => {
                 if (outlineIds.has(state.interactionId)) {
                     loadedIds.add(state.interactionId);
+                    if (!statesByInteraction.has(state.interactionId)) {
+                        statesByInteraction.set(state.interactionId, {
+                            ...state,
+                        });
+                    }
                 }
             });
             retained.page.messages.forEach(message => {
@@ -1659,6 +1723,11 @@ export class ConversationViewer implements ConversationViewerApi {
             loadedIds.add(state.interactionId);
             refreshedIds.add(state.interactionId);
             messagesByInteraction.set(state.interactionId, []);
+            const previous = statesByInteraction.get(state.interactionId);
+            statesByInteraction.set(state.interactionId, {
+                ...previous,
+                ...state,
+            });
         });
         page.messages.forEach(message => {
             if (!refreshedIds.has(message.interactionId)) {
@@ -1674,6 +1743,7 @@ export class ConversationViewer implements ConversationViewerApi {
                 if (!loadedIds.has(interaction.id)) {
                     return retainedPages;
                 }
+                const retainedState = statesByInteraction.get(interaction.id);
                 retainedPages.push({
                     page: {
                         provider: outline.provider,
@@ -1684,6 +1754,12 @@ export class ConversationViewer implements ConversationViewerApi {
                         interactionStates: [{
                             interactionId: interaction.id,
                             responseState: interaction.responseState,
+                            ...(retainedState?.timestamp !== undefined
+                                ? { timestamp: retainedState.timestamp }
+                                : {}),
+                            ...(retainedState?.completedAt !== undefined
+                                ? { completedAt: retainedState.completedAt }
+                                : {}),
                         }],
                         isStart: index === 0,
                         isEnd: index === outline.interactions.length - 1,
@@ -1999,7 +2075,9 @@ function worklogDurationMs(
         return undefined;
     }
     const duration = info.completedAt - info.timestamp;
-    return duration >= 1000 ? duration : undefined;
+    return Number.isFinite(duration) && duration >= 1000
+        ? duration
+        : undefined;
 }
 
 function renderWorklogRow(

--- a/src/webview/conversationViewerScripts.js
+++ b/src/webview/conversationViewerScripts.js
@@ -809,6 +809,43 @@
             - (scroll.clientHeight - elementBounds.height) / 2;
     }
 
+    function worklogRowForInteraction(interactionId) {
+        if (!interactionId) return null;
+        return Array.prototype.find.call(
+            messages.querySelectorAll('.conversation-message-worklog'),
+            function (row) {
+                return row.getAttribute('data-interaction-id')
+                    === interactionId;
+            }
+        ) || null;
+    }
+
+    function retargetCollapsedWorklogAnchor(anchor) {
+        if (!anchor || !anchor.element || !anchor.element.closest) {
+            return anchor;
+        }
+        var message = anchor.element.closest(conversationMessageSelector());
+        if (message && !message.isConnected && anchor.messageId) {
+            message = Array.prototype.find.call(
+                messages.querySelectorAll(conversationMessageSelector()),
+                function (candidate) {
+                    return conversationMessageId(candidate)
+                        === anchor.messageId;
+                }
+            ) || null;
+        }
+        if (!message || !message.hidden) return anchor;
+        var row = worklogRowForInteraction(
+            message.getAttribute('data-interaction-id')
+        );
+        if (!row) return anchor;
+        return Object.assign({}, anchor, {
+            element: row,
+            messageId: conversationMessageId(row),
+            blockIndex: -1,
+        });
+    }
+
     function applyWorklogStates() {
         Array.prototype.forEach.call(
             messages.querySelectorAll('.conversation-message-worklog'),
@@ -867,6 +904,9 @@
             : null;
         var focusedMessageId = focusedMessage
             ? conversationMessageId(focusedMessage)
+            : null;
+        var focusedInteractionId = focusedMessage
+            ? focusedMessage.getAttribute('data-interaction-id')
             : null;
         var oldSignatures = state.messageSignatures;
         state.renderGeneration += 1;
@@ -958,6 +998,7 @@
         if (isLiveRefresh
             && focusedMessageId
             && (!focusedMessage.isConnected
+                || focusedMessage.hidden
                 || !focusedMessage.contains(document.activeElement))) {
             var restoredFocus = Array.prototype.find.call(
                 messages.querySelectorAll(conversationMessageSelector()),
@@ -966,9 +1007,19 @@
                         === focusedMessageId;
                 }
             );
-            if (restoredFocus) {
+            if (restoredFocus && !restoredFocus.hidden) {
                 restoredFocus.tabIndex = -1;
                 restoredFocus.focus({ preventScroll: true });
+            } else {
+                var worklogRow = worklogRowForInteraction(
+                    focusedInteractionId
+                );
+                var worklogToggle = worklogRow
+                    ? worklogRow.querySelector('.conversation-worklog-toggle')
+                    : null;
+                if (worklogToggle) {
+                    worklogToggle.focus({ preventScroll: true });
+                }
             }
         }
         renderMermaidDiagrams(renderGeneration);
@@ -992,7 +1043,10 @@
         if (wasFollowingEnd) {
             reconcileController.scrollToEnd();
         } else {
-            restoreReadingPosition(readingAnchor, previousScrollTop);
+            restoreReadingPosition(
+                retargetCollapsedWorklogAnchor(readingAnchor),
+                previousScrollTop
+            );
             reconcileController.trackEnd();
         }
     }

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -4929,6 +4929,154 @@ test('CONVERSATION-WORKLOG-COLLAPSE-001 keeps in-progress work expanded and coll
     assert.equal(await toggle.getAttribute('aria-expanded'), 'false');
 });
 
+test('CONVERSATION-WORKLOG-COLLAPSE-001 moves focus to the worklog toggle when focused work auto-collapses', async t => {
+    const page = await openViewerPage(t, {});
+    const liveHtml = `<article class="conversation-message conversation-message-user"
+            data-message-id="input-4:user"
+            data-conversation-message-id="input-4%3Auser"
+            data-interaction-id="input-4">
+        <span class="conversation-role">User</span>
+        <section class="conversation-markdown"><p>Run the tests</p></section>
+    </article>
+    <article class="conversation-message conversation-message-tool"
+            data-message-id="input-4:tool:0"
+            data-conversation-message-id="input-4%3Atool%3A0"
+            data-interaction-id="input-4">
+        <div class="conversation-tool-call-static">Running tests</div>
+    </article>`;
+    await sendPage(page, {
+        ...hostileConversationPage,
+        requestId: 75,
+        updateKind: 'initial',
+        html: liveHtml,
+        outline: [{
+            interactionId: 'input-4',
+            userPreview: 'Run the tests',
+            responseState: 'inProgress',
+        }],
+        atLatest: true,
+    });
+    const tool = page.locator('.conversation-message-tool');
+    await tool.evaluate(element => {
+        element.tabIndex = -1;
+        element.focus();
+    });
+    assert.equal(await tool.evaluate(element =>
+        document.activeElement === element), true);
+
+    const doneHtml = liveHtml.replace(
+        '<article class="conversation-message conversation-message-tool"',
+        `<article class="conversation-message conversation-message-worklog"
+            data-message-id="input-4:worklog"
+            data-conversation-message-id="input-4%3Aworklog"
+            data-interaction-id="input-4">
+        <button class="conversation-worklog-toggle">
+            <span class="conversation-worklog-label">Worked for 45s</span>
+        </button>
+    </article>
+    <article class="conversation-message conversation-message-tool"`
+    ) + `
+    <article class="conversation-message conversation-message-assistant"
+            data-message-id="input-4:assistant:0"
+            data-conversation-message-id="input-4%3Aassistant%3A0"
+            data-interaction-id="input-4">
+        <span class="conversation-role">Assistant</span>
+        <section class="conversation-markdown"><p>All pass.</p></section>
+    </article>`;
+    await sendPage(page, {
+        ...hostileConversationPage,
+        requestId: 76,
+        updateKind: 'refresh',
+        html: doneHtml,
+        atLatest: true,
+    });
+
+    assert.equal(await tool.isHidden(), true);
+    assert.equal(
+        await page.locator('.conversation-worklog-toggle').evaluate(element =>
+            document.activeElement === element),
+        true,
+        'focus must remain visible on the control that reveals the hidden work'
+    );
+});
+
+test('CONVERSATION-WORKLOG-COLLAPSE-001 keeps the worklog row at the reading anchor when work auto-collapses', async t => {
+    const page = await openViewerPage(t, {});
+    const filler = Array.from({ length: 40 }, (_item, index) => `
+    <article class="conversation-message conversation-message-tool"
+            data-message-id="input-5:tool:${index}"
+            data-conversation-message-id="input-5%3Atool%3A${index}"
+            data-interaction-id="input-5">
+        <div class="conversation-tool-call-static">Later work ${index}</div>
+    </article>`).join('');
+    const userHtml = `<article class="conversation-message conversation-message-user"
+            data-message-id="input-4:user"
+            data-conversation-message-id="input-4%3Auser"
+            data-interaction-id="input-4">
+        <span class="conversation-role">User</span>
+        <section class="conversation-markdown"><p>Run the tests</p></section>
+    </article>`;
+    const toolHtml = `<article class="conversation-message conversation-message-tool"
+            data-message-id="input-4:tool:0"
+            data-conversation-message-id="input-4%3Atool%3A0"
+            data-interaction-id="input-4">
+        <div class="conversation-tool-call-static">Running tests</div>
+    </article>`;
+    const liveHtml = userHtml + toolHtml + filler;
+    await sendPage(page, {
+        ...hostileConversationPage,
+        requestId: 77,
+        updateKind: 'initial',
+        html: liveHtml,
+        outline: [{
+            interactionId: 'input-4',
+            userPreview: 'Run the tests',
+            responseState: 'inProgress',
+        }],
+        atLatest: false,
+    });
+    const scroll = page.locator('[data-conversation-scroll]');
+    const tool = page.locator('[data-message-id="input-4:tool:0"]');
+    await scroll.evaluate((element, top) => {
+        element.scrollTop += top
+            - element.getBoundingClientRect().top;
+    }, (await tool.boundingBox()).y);
+    const anchoredTop = (await tool.boundingBox()).y;
+
+    const worklogHtml = `<article class="conversation-message conversation-message-worklog"
+            data-message-id="input-4:worklog"
+            data-conversation-message-id="input-4%3Aworklog"
+            data-interaction-id="input-4">
+        <button class="conversation-worklog-toggle">
+            <span class="conversation-worklog-label">Worked for 45s</span>
+        </button>
+    </article>`;
+    const answerHtml = `<article class="conversation-message conversation-message-assistant"
+            data-message-id="input-4:assistant:0"
+            data-conversation-message-id="input-4%3Aassistant%3A0"
+            data-interaction-id="input-4">
+        <span class="conversation-role">Assistant</span>
+        <section class="conversation-markdown"><p>All pass.</p></section>
+    </article>`;
+    await sendPage(page, {
+        ...hostileConversationPage,
+        requestId: 78,
+        updateKind: 'refresh',
+        html: userHtml + worklogHtml
+            + toolHtml.replace('Running tests', 'Tests passed')
+            + answerHtml + filler,
+        atLatest: false,
+    });
+
+    const worklogTop = (await page.locator(
+        '.conversation-message-worklog'
+    ).boundingBox()).y;
+    assert.ok(
+        Math.abs(worklogTop - anchoredTop) <= 2,
+        `collapsed row moved from reading anchor: ${anchoredTop} -> ${worklogTop}`
+    );
+});
+
 test('CONVERSATION-WORKLOG-COLLAPSE-001 aligns the Worked-for row with the message column', async t => {
     const { page } = await openHostViewerDocument(t, {
         includeStyles: true,

--- a/tests/contract/aiSessions/conversationCoordinator.test.js
+++ b/tests/contract/aiSessions/conversationCoordinator.test.js
@@ -379,6 +379,71 @@ test('CONVERSATION-WORKING-INDICATOR-001 projects only the latest interrupted pr
     assert.equal(page.interactionStates[1].responseState, 'inProgress');
 });
 
+test('CONVERSATION-WORKLOG-COLLAPSE-001 preserves turn timing through coordinator projection', async t => {
+    for (const provider of ['codex', 'kimi', 'claude']) {
+        await t.test(provider, async t => {
+            const calls = { codex: 0, kimi: 0, claude: 0 };
+            const adapter = adapterReturning(calls, provider, {
+                readOutline: async sessionId => makeOutline(
+                    provider,
+                    sessionId,
+                    'native-timing',
+                    {
+                        interactions: [{
+                            id: 'input-a',
+                            userPreview: 'Timed turn',
+                            userGraphemeCount: 10,
+                            responseState: 'complete',
+                        }],
+                        totalInteractions: 1,
+                    }
+                ),
+                readPage: async request => makePage(
+                    provider,
+                    request.sessionId,
+                    'native-timing',
+                    {
+                        interactionStates: [{
+                            interactionId: 'input-a',
+                            responseState: 'complete',
+                            timestamp: 1_000,
+                            completedAt: 81_000,
+                        }],
+                        previousCursor: undefined,
+                        nextCursor: undefined,
+                        isStart: true,
+                        isEnd: true,
+                    }
+                ),
+            });
+            const { coordinator } = createCoordinatorHarness({
+                [provider]: adapter,
+            });
+            t.after(() => coordinator.dispose());
+            coordinator.setSessionStopped(provider, 'session-a', true);
+
+            const outline = await coordinator.readOutline(
+                provider,
+                'session-a'
+            );
+            const page = await coordinator.readPage({
+                provider,
+                sessionId: 'session-a',
+                anchorInteractionId: 'input-a',
+                direction: 'around',
+                expectedRevision: outline.sourceRevision,
+            });
+
+            assert.deepEqual(page.interactionStates[0], {
+                interactionId: 'input-a',
+                responseState: 'complete',
+                timestamp: 1_000,
+                completedAt: 81_000,
+            });
+        });
+    }
+});
+
 test('SESSION-CONVERSATION-COORDINATOR-005 releases only the exact opaque watch ownership', async () => {
     const { adapters, clock, coordinator } = createCoordinatorHarness();
     const calls = [];
@@ -769,6 +834,16 @@ test('SESSION-CONVERSATION-COORDINATOR-001 rejects deep outline and page bound v
                 { interactionId: 'input-a', responseState: 'complete' },
                 { interactionId: 'input-a', responseState: 'complete' },
             ],
+        });
+    });
+    await t.test('non-finite interaction timing is rejected', async () => {
+        await rejectPage({
+            interactionStates: [{
+                interactionId: 'input-a',
+                responseState: 'complete',
+                timestamp: Number.NaN,
+                completedAt: Number.POSITIVE_INFINITY,
+            }],
         });
     });
     await t.test('cursor presence must agree with page boundaries', async () => {

--- a/tests/integration/dashboard/conversationRouting.test.js
+++ b/tests/integration/dashboard/conversationRouting.test.js
@@ -766,7 +766,8 @@ test('PRODUCTION-CONVERSATION-LIFECYCLE-001 keeps the exact viewer authority lif
     );
     assert.deepEqual(
         readsAfterStopped.slice(readsBeforeLifecycle),
-        ['read-outline:codex']
+        ['read-outline:codex', 'read-page:codex'],
+        'a lifecycle edge reprojects the loaded turn as well as its outline'
     );
     assert.equal(harness.panels.length, 1);
 

--- a/tests/integration/dashboard/conversationViewer.test.js
+++ b/tests/integration/dashboard/conversationViewer.test.js
@@ -2053,7 +2053,8 @@ test('CONVERSATION-WORKING-INDICATOR-001 republishes lifecycle state when conten
 
     const publications = panel.postedMessages.filter(message =>
         message.type === 'conversation-viewer-page');
-    assert.equal(pageReads, 1, 'lifecycle-only refresh reuses retained messages');
+    assert.equal(pageReads, 2,
+        'lifecycle-only refresh reprojects response state and message roles');
     assert.equal(publications.length, 1);
     assert.equal(publications[0].outline[0].responseState, 'inProgress');
 });
@@ -2895,6 +2896,74 @@ function worklogPage(sessionId, options = {}) {
     };
 }
 
+function lifecycleProjectionPage(
+    sessionId,
+    sourceRevision,
+    anchorInteractionId,
+    latestState,
+    options = {}
+) {
+    const messages = [];
+    const interactionStates = [];
+    if (options.includeEarlier !== false) {
+        messages.push({
+            id: 'input-1:user',
+            interactionId: 'input-1',
+            role: 'user',
+            markdown: 'Read the earlier turn',
+        });
+        interactionStates.push({
+            interactionId: 'input-1',
+            responseState: 'complete',
+        });
+    }
+    if (options.includeLatest !== false) {
+        messages.push(
+            {
+                id: 'input-2:user',
+                interactionId: 'input-2',
+                role: 'user',
+                markdown: 'Run the tests',
+            },
+            {
+                id: 'input-2:tool:0',
+                interactionId: 'input-2',
+                role: 'tool',
+                markdown: '',
+                tool: { name: 'Shell', summary: 'Shell npm test' },
+            },
+            {
+                id: `input-2:${latestState === 'inProgress'
+                    ? 'progress'
+                    : 'assistant'}:0`,
+                interactionId: 'input-2',
+                role: latestState === 'inProgress'
+                    ? 'progress'
+                    : 'assistant',
+                markdown: latestState === 'inProgress'
+                    ? 'Still running.'
+                    : 'All pass.',
+            }
+        );
+        interactionStates.push({
+            interactionId: 'input-2',
+            responseState: latestState,
+            timestamp: 1_000,
+            completedAt: 81_000,
+        });
+    }
+    return {
+        provider: 'codex',
+        sessionId,
+        sourceRevision,
+        anchorInteractionId,
+        messages,
+        interactionStates,
+        isStart: true,
+        isEnd: true,
+    };
+}
+
 test('CONVERSATION-WORKLOG-COLLAPSE-001 publishes a Worked-for row between work entries and the answer', async () => {
     const { viewer, panel } = createViewer({
         readOutline: async (_provider, sessionId) => outline(
@@ -2953,6 +3022,375 @@ test('CONVERSATION-WORKLOG-COLLAPSE-001 omits the row while in progress and fall
     assert.equal(html.includes('&gt;Worked&lt;/span'), true,
         'turns without timing fall back to a plain Worked label');
     assert.equal(html.includes('Worked for'), false);
+});
+
+test('CONVERSATION-WORKLOG-COLLAPSE-001 collapses on a lifecycle-only completion refresh', async () => {
+    let onChange;
+    let responseState = 'inProgress';
+    let pageReads = 0;
+    const { viewer, panel } = createViewer({
+        watch: (_provider, _sessionId, callback) => {
+            onChange = callback;
+            return { dispose() {} };
+        },
+        readOutline: async (_provider, sessionId) => {
+            const value = outline(sessionId, ['input-1'], {
+                sourceRevision: 'stable-r1',
+            });
+            value.interactions[0].responseState = responseState;
+            return value;
+        },
+        readPage: async request => {
+            pageReads += 1;
+            const value = worklogPage(request.sessionId, {
+                responseState,
+                timestamp: 1_000,
+                completedAt: 81_000,
+            });
+            if (responseState === 'inProgress') {
+                value.messages = value.messages.map(message => ({
+                    ...message,
+                    role: message.role === 'assistant'
+                        ? 'progress'
+                        : message.role,
+                }));
+            }
+            return {
+                ...value,
+                sourceRevision: request.expectedRevision,
+            };
+        },
+    });
+
+    await viewer.open(target('session-a', 'input-1', {
+        expectedRevision: 'stable-r1',
+    }));
+    responseState = 'complete';
+    onChange();
+    await new Promise(resolve => setImmediate(resolve));
+
+    const publication = panel.postedMessages.filter(message =>
+        message.type === 'conversation-viewer-page').at(-1);
+    assert.equal(publication.outline[0].responseState, 'complete');
+    assert.equal(pageReads, 2,
+        'completion must reproject progress back to the final answer');
+    assert.equal(
+        publication.html.includes('conversation-message-worklog'),
+        true,
+        'the same lifecycle refresh must collapse retained work'
+    );
+    assert.equal(publication.html.includes('Worked for 1m 20s'), true);
+});
+
+test('CONVERSATION-WORKLOG-COLLAPSE-001 reprojects the changed turn without moving a historical selection', async () => {
+    let onChange;
+    let latestState = 'inProgress';
+    const pageAnchors = [];
+    const { viewer, panel } = createViewer({
+        watch: (_provider, _sessionId, callback) => {
+            onChange = callback;
+            return { dispose() {} };
+        },
+        readOutline: async (_provider, sessionId) => {
+            const value = outline(sessionId, ['input-1', 'input-2'], {
+                sourceRevision: 'stable-r1',
+            });
+            value.interactions[1].responseState = latestState;
+            return value;
+        },
+        readPage: async request => {
+            pageAnchors.push(request.anchorInteractionId);
+            return {
+                provider: 'codex',
+                sessionId: request.sessionId,
+                sourceRevision: request.expectedRevision,
+                anchorInteractionId: request.anchorInteractionId,
+                messages: [
+                    {
+                        id: 'input-1:user',
+                        interactionId: 'input-1',
+                        role: 'user',
+                        markdown: 'Read the earlier turn',
+                    },
+                    {
+                        id: 'input-2:user',
+                        interactionId: 'input-2',
+                        role: 'user',
+                        markdown: 'Run the tests',
+                    },
+                    {
+                        id: 'input-2:tool:0',
+                        interactionId: 'input-2',
+                        role: 'tool',
+                        markdown: '',
+                        tool: { name: 'Shell', summary: 'Shell npm test' },
+                    },
+                    {
+                        id: `input-2:${latestState === 'inProgress'
+                            ? 'progress'
+                            : 'assistant'}:0`,
+                        interactionId: 'input-2',
+                        role: latestState === 'inProgress'
+                            ? 'progress'
+                            : 'assistant',
+                        markdown: latestState === 'inProgress'
+                            ? 'Still running.'
+                            : 'All pass.',
+                    },
+                ],
+                interactionStates: [
+                    {
+                        interactionId: 'input-1',
+                        responseState: 'complete',
+                    },
+                    {
+                        interactionId: 'input-2',
+                        responseState: latestState,
+                        timestamp: 1_000,
+                        completedAt: 81_000,
+                    },
+                ],
+                isStart: true,
+                isEnd: true,
+            };
+        },
+    });
+
+    await viewer.open(target('session-a', 'input-1', {
+        expectedRevision: 'stable-r1',
+    }));
+    latestState = 'complete';
+    onChange();
+    await new Promise(resolve => setImmediate(resolve));
+
+    const publication = panel.postedMessages.filter(message =>
+        message.type === 'conversation-viewer-page').at(-1);
+    assert.deepEqual(pageAnchors, ['input-1', 'input-2']);
+    assert.equal(publication.selectedInteractionId, 'input-1');
+    assert.equal(publication.html.includes('conversation-message-worklog'), true);
+});
+
+test('CONVERSATION-WORKLOG-COLLAPSE-001 bypasses a snapshot page that misses the changed turn', async () => {
+    let onChange;
+    let latestState = 'inProgress';
+    let snapshotReads = 0;
+    const pageAnchors = [];
+    const currentOutline = sessionId => {
+        const value = outline(sessionId, ['input-1', 'input-2'], {
+            sourceRevision: 'stable-r1',
+        });
+        value.interactions[1].responseState = latestState;
+        return value;
+    };
+    const { viewer, panel } = createViewer({
+        watch: (_provider, _sessionId, callback) => {
+            onChange = callback;
+            return { dispose() {} };
+        },
+        readSnapshot: async (_provider, sessionId, preferredInteractionId) => {
+            snapshotReads += 1;
+            return {
+                outline: currentOutline(sessionId),
+                page: lifecycleProjectionPage(
+                    sessionId,
+                    'stable-r1',
+                    preferredInteractionId || 'input-1',
+                    latestState,
+                    { includeLatest: snapshotReads === 1 }
+                ),
+            };
+        },
+        readOutline: async (_provider, sessionId) => currentOutline(sessionId),
+        readPage: async request => {
+            pageAnchors.push(request.anchorInteractionId);
+            return lifecycleProjectionPage(
+                request.sessionId,
+                request.expectedRevision,
+                request.anchorInteractionId,
+                latestState,
+                { includeEarlier: false }
+            );
+        },
+    });
+
+    await viewer.open(target('session-a', 'input-1', {
+        expectedRevision: 'stable-r1',
+    }));
+    latestState = 'complete';
+    onChange();
+    await new Promise(resolve => setImmediate(resolve));
+
+    const publication = panel.postedMessages.filter(message =>
+        message.type === 'conversation-viewer-page').at(-1);
+    assert.deepEqual(pageAnchors, ['input-2']);
+    assert.equal(publication.selectedInteractionId, 'input-1');
+    assert.equal(publication.html.includes('conversation-message-worklog'), true);
+});
+
+test('CONVERSATION-WORKLOG-COLLAPSE-001 merges a historical snapshot and the completed turn across revisions', async () => {
+    let onChange;
+    let latestState = 'inProgress';
+    let revision = 'r1';
+    let snapshotReads = 0;
+    const pageAnchors = [];
+    const currentOutline = sessionId => {
+        const value = outline(sessionId, ['input-1', 'input-2'], {
+            sourceRevision: revision,
+        });
+        value.interactions[1].responseState = latestState;
+        return value;
+    };
+    const { viewer, panel } = createViewer({
+        watch: (_provider, _sessionId, callback) => {
+            onChange = callback;
+            return { dispose() {} };
+        },
+        readSnapshot: async (_provider, sessionId, preferredInteractionId) => {
+            snapshotReads += 1;
+            const snapshotPage = lifecycleProjectionPage(
+                sessionId,
+                revision,
+                preferredInteractionId || 'input-1',
+                latestState,
+                { includeLatest: snapshotReads === 1 }
+            );
+            if (snapshotReads > 1) {
+                snapshotPage.messages[0].markdown = 'Updated earlier turn';
+            }
+            return {
+                outline: currentOutline(sessionId),
+                page: snapshotPage,
+            };
+        },
+        readOutline: async (_provider, sessionId) => currentOutline(sessionId),
+        readPage: async request => {
+            pageAnchors.push(request.anchorInteractionId);
+            return lifecycleProjectionPage(
+                request.sessionId,
+                request.expectedRevision,
+                request.anchorInteractionId,
+                latestState,
+                { includeEarlier: false }
+            );
+        },
+    });
+
+    await viewer.open(target('session-a', 'input-1', {
+        expectedRevision: 'r1',
+    }));
+    latestState = 'complete';
+    revision = 'r2';
+    onChange();
+    await new Promise(resolve => setImmediate(resolve));
+
+    const publication = panel.postedMessages.filter(message =>
+        message.type === 'conversation-viewer-page').at(-1);
+    assert.deepEqual(pageAnchors, ['input-2']);
+    assert.equal(publication.selectedInteractionId, 'input-1');
+    assert.equal(publication.html.includes('Updated earlier turn'), true,
+        'the selected historical page must retain its content refresh');
+    assert.equal(publication.html.includes('conversation-message-worklog'), true,
+        'the retained completed turn must receive its final projection');
+});
+
+test('CONVERSATION-WORKLOG-COLLAPSE-001 retries a stale changed-turn projection without falling back to history', async () => {
+    let onChange;
+    let latestState = 'inProgress';
+    let revision = 'r1';
+    const pageAnchors = [];
+    const currentOutline = sessionId => {
+        const value = outline(sessionId, ['input-1', 'input-2'], {
+            sourceRevision: revision,
+        });
+        value.interactions[1].responseState = latestState;
+        return value;
+    };
+    const { viewer, panel } = createViewer({
+        watch: (_provider, _sessionId, callback) => {
+            onChange = callback;
+            return { dispose() {} };
+        },
+        readOutline: async (_provider, sessionId) => currentOutline(sessionId),
+        readPage: async request => {
+            pageAnchors.push(request.anchorInteractionId);
+            if (request.anchorInteractionId === 'input-2'
+                && request.expectedRevision === 'r1') {
+                revision = 'r2';
+                throw new ConversationError('staleRevision');
+            }
+            return lifecycleProjectionPage(
+                request.sessionId,
+                request.expectedRevision,
+                request.anchorInteractionId,
+                latestState,
+                request.anchorInteractionId === 'input-2'
+                    ? { includeEarlier: false }
+                    : { includeLatest: pageAnchors.length === 1 }
+            );
+        },
+    });
+
+    await viewer.open(target('session-a', 'input-1'));
+    latestState = 'complete';
+    onChange();
+    await new Promise(resolve => setImmediate(resolve));
+
+    const publication = panel.postedMessages.filter(message =>
+        message.type === 'conversation-viewer-page').at(-1);
+    assert.deepEqual(pageAnchors, ['input-1', 'input-2', 'input-2']);
+    assert.equal(publication.selectedInteractionId, 'input-1');
+    assert.equal(publication.html.includes('conversation-message-worklog'), true);
+});
+
+test('CONVERSATION-WORKLOG-COLLAPSE-001 keeps timing after a content refresh merge', async () => {
+    let onChange;
+    let revision = 'r1';
+    const { viewer, panel } = createViewer({
+        watch: (_provider, _sessionId, callback) => {
+            onChange = callback;
+            return { dispose() {} };
+        },
+        readOutline: async (_provider, sessionId) => outline(
+            sessionId,
+            ['input-1'],
+            { sourceRevision: revision }
+        ),
+        readPage: async request => ({
+            ...worklogPage(request.sessionId, {
+                timestamp: 1_000,
+                completedAt: 81_000,
+            }),
+            sourceRevision: request.expectedRevision,
+        }),
+    });
+
+    await viewer.open(target('session-a', 'input-1'));
+    revision = 'r2';
+    onChange();
+    await new Promise(resolve => setImmediate(resolve));
+
+    const publication = panel.postedMessages.filter(message =>
+        message.type === 'conversation-viewer-page').at(-1);
+    assert.equal(publication.html.includes('Worked for 1m 20s'), true);
+});
+
+test('CONVERSATION-WORKLOG-COLLAPSE-001 falls back safely when finite timestamps overflow', async () => {
+    const { viewer, panel } = createViewer({
+        readOutline: async (_provider, sessionId) => outline(
+            sessionId,
+            ['input-1']
+        ),
+        readPage: async request => worklogPage(request.sessionId, {
+            timestamp: -1e308,
+            completedAt: 1e308,
+        }),
+    });
+
+    await viewer.open(target('session-a', 'input-1'));
+    const html = panel.webview.html;
+    assert.equal(html.includes('&gt;Worked&lt;/span'), true);
+    assert.equal(html.includes('Infinity'), false);
+    assert.equal(html.includes('NaN'), false);
 });
 
 test('CONVERSATION-MESSAGE-BOOKMARK-001 renders a bookmark toggle inside each user input card only', async () => {


### PR DESCRIPTION
## Summary

- reproject lifecycle-changed turns immediately, including completion refreshes that advance the provider revision
- preserve provider timing metadata so completed work rows render their duration consistently across Codex, Kimi, and Claude
- keep historical snapshot content, keyboard focus, and reading anchors stable when work entries auto-collapse
- reject invalid timing values and safely fall back when duration arithmetic overflows

## Skill harvest

no skill change — the rebase conflict, review-discovered edge cases, and verification retry are already covered by the existing worktree, regression, review, and publishing skills.

## Verification

- npm ci
- npm run test:ci:linux
- focused Host tests: 27 passed
- focused browser tests: 6 passed
- changed-line coverage: 89.47% (102/114)
- git diff --check
- local VSIX installation and installed-byte verification for Agent Pivot 1.0.4 and Attention UI Bridge 1.0.1
- final read-only integration review: no Critical or Important findings