### PR TITLE
Fix AI Conversation working indicator lifecycle

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -4348,11 +4348,13 @@
   {
     "id": "CONVERSATION-WORKING-INDICATOR-001",
     "domain": "webview",
-    "title": "AI Conversation shows a reduced-motion-safe Working indicator only while the latest response remains in progress",
+    "title": "AI Conversation keeps a reduced-motion-safe Working indicator visible through quiet provider work and newly appended running inputs",
     "priority": "P0",
     "status": "automated",
     "owners": [
       "tests/unit/aiSessions/codexSessionFilePath.test.js",
+      "tests/contract/aiSessions/controllerBoundaries.test.js",
+      "tests/contract/aiSessions/incrementalJsonlLifecycleReader.test.js",
       "tests/contract/aiSessions/codexConversationAdapter.test.js",
       "tests/contract/aiSessions/conversationCoordinator.test.js",
       "tests/integration/dashboard/conversationViewer.test.js",
@@ -4360,6 +4362,8 @@
     ],
     "evidence": [
       "src/services/codexSessionService.ts",
+      "src/aiSessions/executionMonitor.ts",
+      "src/aiSessions/incrementalJsonlLifecycleReader.ts",
       "src/aiSessions/conversation/codexAdapter.ts",
       "src/aiSessions/conversation/composition.ts",
       "src/aiSessions/conversation/viewer.ts",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "b99af6f7df742b8b23f613445987fd6285eb0cc0",
+        "head": "a74f599b081ab3b1f3cf7831d41725956162548e",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -182,7 +182,8 @@
             "3d28e38ad2fd8aaa2ca61eae8dfa6c981c9bf749",
             "6d9121d2e321c7e56946db87e29e215fec1d9e48",
             "83b140ad79d365f53e724c673d7bda344bc47939",
-            "76b172488e0410234c34777dd799ed1c95061700"
+            "76b172488e0410234c34777dd799ed1c95061700",
+            "bae1c9a0cac6e337d8e2898564b18b3cb871aa9b"
         ]
     },
     "capabilities": [
@@ -1325,7 +1326,8 @@
                 "b1b417e9af95101f0930d3caf9f9e91ed65f8ef9",
                 "6c1958c97bf1de8b7bead4f698c2c14fcc848ee5",
                 "6d16abc51cf0da5266cff6131f574fdb50a8b658",
-                "b99af6f7df742b8b23f613445987fd6285eb0cc0"
+                "b99af6f7df742b8b23f613445987fd6285eb0cc0",
+                "a74f599b081ab3b1f3cf7831d41725956162548e"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "6d16abc51cf0da5266cff6131f574fdb50a8b658",
+        "head": "b99af6f7df742b8b23f613445987fd6285eb0cc0",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -181,7 +181,8 @@
             "75f6d6c75d7e1ecf70e44269d7b8e348079c985d",
             "3d28e38ad2fd8aaa2ca61eae8dfa6c981c9bf749",
             "6d9121d2e321c7e56946db87e29e215fec1d9e48",
-            "83b140ad79d365f53e724c673d7bda344bc47939"
+            "83b140ad79d365f53e724c673d7bda344bc47939",
+            "76b172488e0410234c34777dd799ed1c95061700"
         ]
     },
     "capabilities": [
@@ -1323,7 +1324,8 @@
                 "c7539a1cff1868ccf4f0ece0c490ae53a3ad6e53",
                 "b1b417e9af95101f0930d3caf9f9e91ed65f8ef9",
                 "6c1958c97bf1de8b7bead4f698c2c14fcc848ee5",
-                "6d16abc51cf0da5266cff6131f574fdb50a8b658"
+                "6d16abc51cf0da5266cff6131f574fdb50a8b658",
+                "b99af6f7df742b8b23f613445987fd6285eb0cc0"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",

--- a/media/conversationViewerScripts.js
+++ b/media/conversationViewerScripts.js
@@ -966,8 +966,15 @@
         }
         updatePosition(message);
         var latestInteraction = message.outline[message.outline.length - 1];
-        working.hidden = !message.atLatest
-            || !latestInteraction
+        var latestInteractionRendered = latestInteraction
+            && Array.prototype.some.call(
+                messages.querySelectorAll('[data-interaction-id]'),
+                function (candidate) {
+                    return candidate.getAttribute('data-interaction-id')
+                        === latestInteraction.interactionId;
+                }
+            );
+        working.hidden = !latestInteractionRendered
             || latestInteraction.responseState !== 'inProgress';
         previous.disabled = message.previousCursor === undefined;
         next.disabled = message.nextCursor === undefined;

--- a/scripts/run-ai-session-safety-checks.js
+++ b/scripts/run-ai-session-safety-checks.js
@@ -9229,13 +9229,19 @@ function runIncrementalJsonlLifecycleReaderChecks() {
 
             signal = reader.read('codex:stat-failure', statFailurePath, runStartedAtMs, createAccumulator);
             assert.strictEqual(
-                signal.executionState,
-                'stopped',
-                'a stat failure preserves the cached signal for the matching path and run'
+                signal,
+                null,
+                'a stat failure must expose unavailable authority even with an exact cursor'
             );
         } finally {
             fs.statSync = originalStatSync;
         }
+        signal = reader.read('codex:stat-failure', statFailurePath, runStartedAtMs, createAccumulator);
+        assert.strictEqual(
+            signal.executionState,
+            'stopped',
+            'a recovered source may reuse its exact cursor'
+        );
 
         const nonFileSourcePath = path.join(tempRoot, 'non-file-source.jsonl');
         const nonFilePath = path.join(tempRoot, 'non-file-target');

--- a/src/aiSessions/conversation/viewer.ts
+++ b/src/aiSessions/conversation/viewer.ts
@@ -493,7 +493,12 @@ export class ConversationViewer implements ConversationViewerApi {
         if (!target || !this.panel || this.suspended) {
             return;
         }
-        await this.loadAuthoritative('refresh', false);
+        await this.loadAuthoritative(
+            'refresh',
+            false,
+            undefined,
+            this.outlineController.latestInteractionId()
+        );
     }
 
     async revalidateLatest(expectedInteractionId: string): Promise<void> {
@@ -1084,8 +1089,19 @@ export class ConversationViewer implements ConversationViewerApi {
                 return;
             }
             this.authoritativeRefreshPending = false;
-            const pendingLatest = this.authoritativeLatestRefreshPending;
+            let pendingLatest = this.authoritativeLatestRefreshPending;
             this.authoritativeLatestRefreshPending = undefined;
+            const currentLatest = this.outlineController.latestInteractionId();
+            if (pendingLatest !== undefined
+                && this.outlineController.selection !== pendingLatest
+                && this.outlineController.selection === currentLatest) {
+                // The in-flight refresh followed the former latest input.
+                // Continue from the newly published latest input when another
+                // watcher invalidation was coalesced behind it. A historical
+                // user selection does not satisfy this condition, so it stays
+                // pinned instead of being pulled back to the tail.
+                pendingLatest = currentLatest;
+            }
             void this.loadAuthoritative(
                 'refresh',
                 false,
@@ -1117,13 +1133,13 @@ export class ConversationViewer implements ConversationViewerApi {
         const requestId = this.allocateRequestId();
         this.currentRequestId = requestId;
         const previousSelectedInteractionId = this.outlineController.selection;
-        const advanceToLatest = updateKind === 'refresh'
+        const followLatest = updateKind === 'refresh'
             && latestIfSelection !== undefined
             && previousSelectedInteractionId === latestIfSelection;
         try {
             const preferredInteractionId = updateKind === 'initial'
                 ? target.interactionId
-                : advanceToLatest
+                : followLatest
                     ? undefined
                     : previousSelectedInteractionId;
             let snapshot = prefetchedSnapshot;
@@ -1152,6 +1168,8 @@ export class ConversationViewer implements ConversationViewerApi {
             const interactionIds = outline.interactions.map(
                 interaction => interaction.id
             );
+            let advanceToLatest = followLatest
+                && interactionIds.includes(latestIfSelection as string);
             if (updateKind === 'initial'
                 && !interactionIds.includes(target.interactionId)) {
                 await this.publishFailure(replaceDocument, updateKind);
@@ -1272,10 +1290,28 @@ export class ConversationViewer implements ConversationViewerApi {
                         await this.publishFailure(replaceDocument, updateKind);
                         return false;
                     }
+                    const retryInteractionIds = outline.interactions.map(
+                        interaction => interaction.id
+                    );
+                    advanceToLatest = followLatest
+                        && retryInteractionIds.includes(
+                            latestIfSelection as string
+                        );
+                    if (updateKind === 'refresh'
+                        && !advanceToLatest
+                        && (!previousSelectedInteractionId
+                            || !retryInteractionIds.includes(
+                                previousSelectedInteractionId
+                            ))) {
+                        await this.publishFailure(replaceDocument, updateKind);
+                        return false;
+                    }
                     if (advanceToLatest) {
                         selectedInteractionId = outline.interactions[
                             outline.interactions.length - 1
                         ].id;
+                    } else if (updateKind === 'refresh') {
+                        selectedInteractionId = previousSelectedInteractionId as string;
                     }
                     if (!outline.interactions.some(
                         interaction => interaction.id === selectedInteractionId

--- a/src/aiSessions/executionMonitor.ts
+++ b/src/aiSessions/executionMonitor.ts
@@ -57,12 +57,27 @@ export default class AiSessionExecutionMonitor {
                     entry.stateChangedAt = signal.occurredAtMs;
                     changed.add(input.key);
                 }
+            } else {
+                const repeatedSignal = input.signal;
+                if (repeatedSignal?.token === entry.lastSignalToken
+                    && repeatedSignal.occurredAtMs === entry.lastOccurredAtMs) {
+                    // Incremental provider readers intentionally return their
+                    // cached latest signal when no new transcript bytes exist.
+                    // Seeing that same signal still proves the lifecycle source
+                    // is readable; renew the observation instead of letting a
+                    // long quiet tool call expire a genuinely running session.
+                    entry.lastSignalAtMs = this.now();
+                    if (entry.state !== repeatedSignal.executionState) {
+                        entry.state = repeatedSignal.executionState;
+                        entry.stateChangedAt = this.now();
+                        changed.add(input.key);
+                    }
+                }
             }
 
-            // Backstop: without a fresh transcript signal for the whole stale
-            // window there is no evidence the session is still running. A
-            // missed terminal event (for example an unrecognised interrupt
-            // marker) would otherwise wedge the running state forever.
+            // Backstop only a genuinely unavailable lifecycle source. A
+            // readable cached running signal above remains authoritative even
+            // when the provider has emitted no new transcript bytes.
             if (entry.state === 'running'
                 && this.now() - entry.lastSignalAtMs >= this.staleRunningTimeoutMs) {
                 entry.state = 'stopped';

--- a/src/aiSessions/executionMonitor.ts
+++ b/src/aiSessions/executionMonitor.ts
@@ -59,7 +59,8 @@ export default class AiSessionExecutionMonitor {
                 }
             } else {
                 const repeatedSignal = input.signal;
-                if (repeatedSignal?.token === entry.lastSignalToken
+                if (repeatedSignal?.token
+                    && repeatedSignal.token === entry.lastSignalToken
                     && repeatedSignal.occurredAtMs === entry.lastOccurredAtMs) {
                     // Incremental provider readers intentionally return their
                     // cached latest signal when no new transcript bytes exist.

--- a/src/aiSessions/incrementalJsonlLifecycleReader.ts
+++ b/src/aiSessions/incrementalJsonlLifecycleReader.ts
@@ -35,17 +35,12 @@ export default class IncrementalJsonlLifecycleReader {
         createAccumulator: () => AiSessionLifecycleAccumulator
     ): AiSessionLifecycleSignal | null {
         let previousCursor = this.cursors.get(key);
-        let previousCursorMatchesRequest = previousCursor
-            && previousCursor.filePath === filePath
-            && previousCursor.runStartedAtMs === runStartedAtMs;
-        let previousSignal = previousCursorMatchesRequest ? previousCursor.accumulator.getSignal() : null;
-        let errorCursor = previousCursorMatchesRequest ? previousCursor : null;
         let fd: number = null;
 
         try {
             let stat = fs.statSync(filePath);
             if (!stat.isFile()) {
-                return previousSignal;
+                return null;
             }
 
             let cursor = previousCursor;
@@ -56,7 +51,6 @@ export default class IncrementalJsonlLifecycleReader {
                 || cursor.ino !== stat.ino
                 || cursor.birthtimeMs !== stat.birthtimeMs
                 || stat.size < cursor.offset) {
-                errorCursor = null;
                 cursor = {
                     filePath,
                     runStartedAtMs,
@@ -69,7 +63,6 @@ export default class IncrementalJsonlLifecycleReader {
                     accumulator: createAccumulator(),
                 };
                 this.cursors.set(key, cursor);
-                errorCursor = cursor;
             }
 
             if (cursor.offset >= stat.size) {
@@ -96,7 +89,10 @@ export default class IncrementalJsonlLifecycleReader {
 
             return cursor.accumulator.getSignal();
         } catch (e) {
-            return errorCursor ? errorCursor.accumulator.getSignal() : null;
+            // Keep the cursor for a later recovery, but do not expose its
+            // cached signal as a successful lifecycle observation. Callers
+            // can retain their current state while availability times out.
+            return null;
         } finally {
             if (fd !== null) {
                 try {

--- a/src/webview/conversationViewerScripts.js
+++ b/src/webview/conversationViewerScripts.js
@@ -966,8 +966,15 @@
         }
         updatePosition(message);
         var latestInteraction = message.outline[message.outline.length - 1];
-        working.hidden = !message.atLatest
-            || !latestInteraction
+        var latestInteractionRendered = latestInteraction
+            && Array.prototype.some.call(
+                messages.querySelectorAll('[data-interaction-id]'),
+                function (candidate) {
+                    return candidate.getAttribute('data-interaction-id')
+                        === latestInteraction.interactionId;
+                }
+            );
+        working.hidden = !latestInteractionRendered
             || latestInteraction.responseState !== 'inProgress';
         previous.disabled = message.previousCursor === undefined;
         next.disabled = message.nextCursor === undefined;

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -6501,19 +6501,83 @@ test('CONVERSATION-WORKING-INDICATOR-001 shows an animated status only for the l
         ...hostileConversationPage,
         requestId: 2,
         updateKind: 'refresh',
-        outline: [{ ...inProgressOutline[0], responseState: 'complete' }],
+        html: hostileConversationPage.html + `
+            <article data-message-id="message-new-request"
+                data-interaction-id="input-5">
+                <section>New request</section>
+            </article>`,
+        outline: [
+            { ...inProgressOutline[0], responseState: 'complete' },
+            {
+                interactionId: 'input-5',
+                userPreview: 'New request',
+                responseState: 'inProgress',
+            },
+        ],
+        selectedInteractionId: 'input-5',
         atLatest: true,
-        totalInputs: 4,
+        totalInputs: 5,
+    });
+    assert.equal(await working.isVisible(), true,
+        'a newly appended running input must not hide Working');
+
+    await sendPage(page, {
+        ...hostileConversationPage,
+        requestId: 3,
+        updateKind: 'refresh',
+        html: hostileConversationPage.html + `
+            <article data-message-id="message-new-request"
+                data-interaction-id="input-5">
+                <section>New request</section>
+            </article>`,
+        outline: [
+            { ...inProgressOutline[0], responseState: 'complete' },
+            {
+                interactionId: 'input-5',
+                userPreview: 'New request',
+                responseState: 'inProgress',
+            },
+        ],
+        selectedInteractionId: 'input-4',
+        atLatest: false,
+        totalInputs: 5,
+    });
+    assert.equal(await page.locator(
+        '[data-conversation-messages] [data-interaction-id="input-5"]'
+    ).count(), 1, 'the latest running input is rendered in the current page');
+    assert.equal(await working.isVisible(), true,
+        'a rendered latest running input must show Working even before selection follows it');
+
+    await sendPage(page, {
+        ...hostileConversationPage,
+        requestId: 4,
+        updateKind: 'navigation',
+        outline: [
+            { ...inProgressOutline[0], responseState: 'complete' },
+            {
+                interactionId: 'input-5',
+                userPreview: 'New request',
+                responseState: 'inProgress',
+            },
+        ],
+        selectedInteractionId: 'input-4',
+        atLatest: false,
+        totalInputs: 5,
     });
     assert.equal(await working.isHidden(), true);
 
     await sendPage(page, {
         ...hostileConversationPage,
-        requestId: 3,
-        updateKind: 'navigation',
-        outline: inProgressOutline,
-        atLatest: false,
-        totalInputs: 4,
+        requestId: 5,
+        updateKind: 'refresh',
+        outline: [{
+            interactionId: 'input-5',
+            userPreview: 'New request',
+            responseState: 'complete',
+        }],
+        selectedInteractionId: 'input-5',
+        atLatest: true,
+        totalInputs: 5,
     });
     assert.equal(await working.isHidden(), true);
 });

--- a/tests/contract/aiSessions/controllerBoundaries.test.js
+++ b/tests/contract/aiSessions/controllerBoundaries.test.js
@@ -325,40 +325,45 @@ test('SESSION-AI-SESSION-EXECUTION-MONITOR-001 ignores duplicate and older event
     assert.deepEqual(monitor.getSnapshot(), {});
 });
 
-test('SESSION-AI-SESSION-EXECUTION-MONITOR-001 degrades running sessions whose transcript stays silent past the stale timeout', () => {
-    let now = 0;
-    const monitor = new AiSessionExecutionMonitor({ now: () => now, staleRunningTimeoutMs: 1000 });
-    const running = { token: 'run-1', occurredAtMs: 0, executionState: 'running' };
-    assert.deepEqual(monitor.evaluate([{ key: 'claude:a', signal: running }]), ['claude:a']);
-    assert.equal(monitor.getSnapshot()['claude:a'].state, 'running');
+for (const provider of ['codex', 'kimi', 'claude']) {
+    test(`SESSION-AI-SESSION-EXECUTION-MONITOR-001 CONVERSATION-WORKING-INDICATOR-001 [${provider}] keeps a readable running signal alive and degrades only while lifecycle authority is unavailable`, () => {
+        let now = 0;
+        const monitor = new AiSessionExecutionMonitor({ now: () => now, staleRunningTimeoutMs: 1000 });
+        const key = `${provider}:a`;
+        const completedKey = `${provider}:b`;
+        const running = { token: 'run-1', occurredAtMs: 0, executionState: 'running' };
+        assert.deepEqual(monitor.evaluate([{ key, signal: running }]), [key]);
+        assert.equal(monitor.getSnapshot()[key].state, 'running');
 
-    now = 500;
-    assert.deepEqual(monitor.evaluate([{ key: 'claude:a', signal: running }]), []);
-    assert.equal(monitor.getSnapshot()['claude:a'].state, 'running');
+        now = 500;
+        assert.deepEqual(monitor.evaluate([{ key, signal: running }]), []);
+        assert.equal(monitor.getSnapshot()[key].state, 'running');
 
-    now = 1001;
-    assert.deepEqual(monitor.evaluate([{ key: 'claude:a', signal: running }]), ['claude:a']);
-    assert.deepEqual(monitor.getSnapshot()['claude:a'], { state: 'stopped', stateChangedAt: 1001 });
-    assert.deepEqual(monitor.evaluate([{ key: 'claude:a', signal: running }]), []);
+        now = 1001;
+        assert.deepEqual(monitor.evaluate([{ key, signal: running }]), []);
+        assert.deepEqual(monitor.getSnapshot()[key], { state: 'running', stateChangedAt: 0 });
 
-    now = 1500;
-    const resumed = { token: 'run-2', occurredAtMs: 1500, executionState: 'running' };
-    assert.deepEqual(monitor.evaluate([{ key: 'claude:a', signal: resumed }]), ['claude:a']);
-    now = 2000;
-    assert.deepEqual(monitor.evaluate([{ key: 'claude:a', signal: resumed }]), []);
-    assert.equal(monitor.getSnapshot()['claude:a'].state, 'running');
+        now = 1500;
+        assert.deepEqual(monitor.evaluate([{ key }]), []);
+        assert.equal(monitor.getSnapshot()[key].state, 'running');
 
-    now = 2600;
-    assert.deepEqual(monitor.evaluate([{ key: 'claude:a' }]), ['claude:a']);
-    assert.equal(monitor.getSnapshot()['claude:a'].state, 'stopped');
+        now = 2002;
+        assert.deepEqual(monitor.evaluate([{ key }]), [key]);
+        assert.equal(monitor.getSnapshot()[key].state, 'stopped');
 
-    now = 3000;
-    const settled = { token: 'done-1', occurredAtMs: 3000, executionState: 'stopped' };
-    assert.deepEqual(monitor.evaluate([{ key: 'claude:a' }, { key: 'codex:b', signal: settled }]), []);
-    now = 6000;
-    assert.deepEqual(monitor.evaluate([{ key: 'claude:a' }, { key: 'codex:b' }]), []);
-    assert.equal(monitor.getSnapshot()['codex:b'].state, 'stopped');
-});
+        now = 2100;
+        assert.deepEqual(monitor.evaluate([{ key, signal: running }]), [key]);
+        assert.deepEqual(monitor.getSnapshot()[key], { state: 'running', stateChangedAt: 2100 });
+
+        now = 3000;
+        const settled = { token: 'done-1', occurredAtMs: 3000, executionState: 'stopped' };
+        assert.deepEqual(monitor.evaluate([{ key }, { key: completedKey, signal: settled }]), []);
+        now = 6000;
+        assert.deepEqual(monitor.evaluate([{ key }, { key: completedKey }]), [key]);
+        assert.equal(monitor.getSnapshot()[key].state, 'stopped');
+        assert.equal(monitor.getSnapshot()[completedKey].state, 'stopped');
+    });
+}
 
 test('ARCH-AI-SESSION-READ-COORDINATOR-001 reads registered providers with bounded diagnostics and deepest assignments', () => {
     let now = 100;

--- a/tests/contract/aiSessions/controllerBoundaries.test.js
+++ b/tests/contract/aiSessions/controllerBoundaries.test.js
@@ -313,6 +313,10 @@ test('SESSION-AI-SESSION-COMMAND-CONTROLLER-003 rejects unsupported protocols an
 
 test('SESSION-AI-SESSION-EXECUTION-MONITOR-001 ignores duplicate and older events while exposing immutable snapshots', () => {
     let now = 10;
+    const emptyMonitor = new AiSessionExecutionMonitor({ now: () => now });
+    assert.deepEqual(emptyMonitor.evaluate([{ key: 'codex:empty' }]), []);
+    assert.deepEqual(emptyMonitor.getSnapshot()['codex:empty'], { state: 'stopped', stateChangedAt: 10 });
+
     const monitor = new AiSessionExecutionMonitor({ now: () => now });
     const signal = { token: 'one', occurredAtMs: 20, executionState: 'running' };
     assert.deepEqual(monitor.evaluate([{ key: 'codex:a', signal }]), ['codex:a']);

--- a/tests/contract/aiSessions/incrementalJsonlLifecycleReader.test.js
+++ b/tests/contract/aiSessions/incrementalJsonlLifecycleReader.test.js
@@ -7,6 +7,7 @@ const test = require('node:test');
 const { makeTempDirectory } = require('../../helpers/tempDirectory');
 const lifecycle = require('../../../out/aiSessions/lifecycle');
 const IncrementalJsonlLifecycleReader = require('../../../out/aiSessions/incrementalJsonlLifecycleReader').default;
+const AiSessionExecutionMonitor = require('../../../out/aiSessions/executionMonitor').default;
 
 const RUN_STARTED_AT_MS = Date.parse('2026-07-15T00:00:00.000Z');
 
@@ -49,6 +50,46 @@ test('PERSIST-INCREMENTAL-JSONL-LIFECYCLE-READER-001 cold-scans all chunks, appe
         'codex:long', filePath, RUN_STARTED_AT_MS, createAccumulator
     ).executionState, 'stopped');
     assert.equal(readCalls, readsAfterAppend, 'unchanged size must perform no additional reads');
+});
+
+test('PERSIST-INCREMENTAL-JSONL-LIFECYCLE-READER-001 SESSION-AI-SESSION-EXECUTION-MONITOR-001 CONVERSATION-WORKING-INDICATOR-001 distinguishes a quiet readable source from unavailable cached authority', t => {
+    const root = makeTempDirectory(t, 'incremental-reader-authority-');
+    const reader = new IncrementalJsonlLifecycleReader(64);
+    const filePath = path.join(root, 'codex.jsonl');
+    fs.writeFileSync(filePath, `${codexEvent(
+        '2026-07-15T00:00:01.000Z', 'task_started', 'quiet-turn'
+    )}\n`, 'utf8');
+    let now = 0;
+    const monitor = new AiSessionExecutionMonitor({
+        now: () => now,
+        staleRunningTimeoutMs: 1000,
+    });
+    const key = 'codex:quiet-turn';
+    const readSignal = () => reader.read(
+        key,
+        filePath,
+        RUN_STARTED_AT_MS,
+        createAccumulator
+    );
+
+    assert.deepEqual(monitor.evaluate([{ key, signal: readSignal() }]), [key]);
+    now = 1001;
+    assert.deepEqual(monitor.evaluate([{ key, signal: readSignal() }]), []);
+    assert.equal(monitor.getSnapshot()[key].state, 'running');
+
+    const originalStatSync = fs.statSync;
+    fs.statSync = () => { throw new Error('forced stat failure'); };
+    t.after(() => { fs.statSync = originalStatSync; });
+    now = 1500;
+    assert.deepEqual(monitor.evaluate([{ key, signal: readSignal() }]), []);
+    now = 2002;
+    assert.deepEqual(monitor.evaluate([{ key, signal: readSignal() }]), [key]);
+    assert.equal(monitor.getSnapshot()[key].state, 'stopped');
+
+    fs.statSync = originalStatSync;
+    now = 2100;
+    assert.deepEqual(monitor.evaluate([{ key, signal: readSignal() }]), [key]);
+    assert.equal(monitor.getSnapshot()[key].state, 'running');
 });
 
 test('PERSIST-INCREMENTAL-JSONL-LIFECYCLE-READER-001 joins split lines, resumes later input, and survives malformed JSON', t => {
@@ -138,8 +179,11 @@ test('PERSIST-INCREMENTAL-JSONL-LIFECYCLE-READER-001 resets on truncation and is
     ), null, 'a stat failure must not leak a different run');
     assert.equal(reader.read(
         'codex:stat-failure', statFailurePath, RUN_STARTED_AT_MS, createAccumulator
-    ).executionState, 'stopped', 'a stat failure may preserve the exact matching cursor');
+    ), null, 'a stat failure must expose unavailable authority even with an exact cursor');
     fs.statSync = originalStatSync;
+    assert.equal(reader.read(
+        'codex:stat-failure', statFailurePath, RUN_STARTED_AT_MS, createAccumulator
+    ).executionState, 'stopped', 'a recovered source may reuse its exact cursor');
     t.after(() => {
         fs.openSync = originalOpenSync;
         fs.statSync = originalStatSync;

--- a/tests/integration/dashboard/conversationViewer.test.js
+++ b/tests/integration/dashboard/conversationViewer.test.js
@@ -93,7 +93,7 @@ function page(
         })),
         interactionStates: interactionIds.map(id => ({
             interactionId: id,
-            responseState: 'complete',
+            responseState: options.responseStates?.[id] || 'complete',
         })),
         previousCursor: options.previousCursor,
         nextCursor: options.nextCursor,
@@ -111,7 +111,7 @@ function outline(sessionId, interactionIds, options = {}) {
             id,
             userPreview: id,
             userGraphemeCount: id.length,
-            responseState: 'complete',
+            responseState: options.responseStates?.[id] || 'complete',
         })),
         totalInteractions: options.totalInteractions || interactionIds.length,
         partial: options.partial || false,
@@ -2117,6 +2117,128 @@ test('CONVERSATION-VIEWER-LOADING-001 coalesces watched invalidations without st
     assert.equal(panel.webview.html.includes('Loading conversation…'), false);
 });
 
+test('CONVERSATION-VIEWER-LOADING-001 CONVERSATION-READING-FOCUS-001 CONVERSATION-WORKING-INDICATOR-001 keeps following newly appended running inputs across coalesced watcher refreshes', async t => {
+    let onChange;
+    let outlineReads = 0;
+    const secondOutline = deferred();
+    const { viewer, panel } = createViewer({
+        watch: (_provider, _sessionId, callback) => {
+            onChange = callback;
+            return { dispose() {} };
+        },
+        readOutline: async (_provider, sessionId) => {
+            outlineReads += 1;
+            if (outlineReads === 1) {
+                return outline(sessionId, ['input-1'], {
+                    sourceRevision: 'r1',
+                    responseStates: { 'input-1': 'inProgress' },
+                });
+            }
+            if (outlineReads === 2) {
+                return secondOutline.promise;
+            }
+            return outline(sessionId, ['input-1', 'input-2', 'input-3'], {
+                sourceRevision: 'r3',
+                responseStates: { 'input-3': 'inProgress' },
+            });
+        },
+        readPage: async request => page(
+            request.sessionId,
+            request.anchorInteractionId,
+            `visible-${request.anchorInteractionId}`,
+            {
+                sourceRevision: request.expectedRevision,
+                responseStates: {
+                    [request.anchorInteractionId]: 'inProgress',
+                },
+            }
+        ),
+    });
+    t.after(() => viewer.dispose());
+
+    await viewer.open(target('session-a', 'input-1'));
+    onChange();
+    await new Promise(resolve => setImmediate(resolve));
+    assert.equal(outlineReads, 2);
+    onChange();
+    secondOutline.resolve(outline('session-a', ['input-1', 'input-2'], {
+        sourceRevision: 'r2',
+        responseStates: { 'input-2': 'inProgress' },
+    }));
+    for (let turn = 0; turn < 4; turn += 1) {
+        await new Promise(resolve => setImmediate(resolve));
+    }
+
+    assert.equal(outlineReads, 3);
+    const publication = panel.postedMessages.filter(message =>
+        message.type === 'conversation-viewer-page').at(-1);
+    assert.equal(publication.selectedInteractionId, 'input-3');
+    assert.equal(publication.atLatest, true);
+    assert.equal(publication.outline.at(-1).responseState, 'inProgress');
+});
+
+test('CONVERSATION-VIEWER-LOADING-001 CONVERSATION-READING-FOCUS-001 keeps a historical selection made during coalesced watcher refreshes', async t => {
+    let onChange;
+    let outlineReads = 0;
+    const secondOutline = deferred();
+    const { viewer, panel } = createViewer({
+        watch: (_provider, _sessionId, callback) => {
+            onChange = callback;
+            return { dispose() {} };
+        },
+        readOutline: async (_provider, sessionId) => {
+            outlineReads += 1;
+            if (outlineReads === 1) {
+                return outline(sessionId, ['input-1', 'input-2'], {
+                    sourceRevision: 'r1',
+                });
+            }
+            if (outlineReads === 2) {
+                return secondOutline.promise;
+            }
+            return outline(
+                sessionId,
+                ['input-1', 'input-2', 'input-3', 'input-4'],
+                { sourceRevision: 'r3' }
+            );
+        },
+        readPage: async request => page(
+            request.sessionId,
+            request.anchorInteractionId,
+            `visible-${request.anchorInteractionId}`,
+            {
+                sourceRevision: request.expectedRevision,
+                interactionIds: request.anchorInteractionId === 'input-2'
+                    ? ['input-1', 'input-2']
+                    : [request.anchorInteractionId],
+                anchorInteractionId: request.anchorInteractionId,
+            }
+        ),
+    });
+    t.after(() => viewer.dispose());
+
+    await viewer.open(target('session-a', 'input-2'));
+    onChange();
+    await new Promise(resolve => setImmediate(resolve));
+    assert.equal(outlineReads, 2);
+    onChange();
+    await panel.receive({ type: 'conversation-viewer-previous', version: 1 });
+    secondOutline.resolve(outline(
+        'session-a',
+        ['input-1', 'input-2', 'input-3'],
+        { sourceRevision: 'r2' }
+    ));
+    for (let turn = 0; turn < 4; turn += 1) {
+        await new Promise(resolve => setImmediate(resolve));
+    }
+
+    assert.equal(outlineReads, 3);
+    const publication = panel.postedMessages.filter(message =>
+        message.type === 'conversation-viewer-page').at(-1);
+    assert.equal(publication.selectedInteractionId, 'input-1');
+    assert.equal(publication.atLatest, false);
+});
+
 test('CONVERSATION-VIEWER-AUTHORITY-003 suspends exact authority without clearing the snapshot and resumes with a fresh watch/read', async () => {
     let outlineReads = 0;
     let pageReads = 0;
@@ -2324,7 +2446,7 @@ test('CONVERSATION-VIEWER-AUTHORITY-001 fails closed when an initial marker no l
     assert.equal(panel.webview.html.includes('wrong-interaction'), false);
 });
 
-test('CONVERSATION-VIEWER-REFRESH-002 CONVERSATION-READING-FOCUS-001 preserves the selected interaction when a refresh adds a new last input', async () => {
+test('CONVERSATION-VIEWER-REFRESH-002 CONVERSATION-READING-FOCUS-001 CONVERSATION-WORKING-INDICATOR-001 follows a newly appended running input when the previous selection was latest', async () => {
     let onChange;
     let outlineRead = 0;
     const { viewer, panel } = createViewer({
@@ -2337,6 +2459,55 @@ test('CONVERSATION-VIEWER-REFRESH-002 CONVERSATION-READING-FOCUS-001 preserves t
             return outline(
                 sessionId,
                 outlineRead === 1 ? ['input-1'] : ['input-1', 'input-2'],
+                {
+                    sourceRevision: outlineRead === 1 ? 'r1' : 'r2',
+                    responseStates: outlineRead === 1
+                        ? { 'input-1': 'inProgress' }
+                        : { 'input-1': 'complete', 'input-2': 'inProgress' },
+                }
+            );
+        },
+        readPage: async request => page(
+            request.sessionId,
+            request.anchorInteractionId,
+            `visible-${request.anchorInteractionId}`,
+            {
+                sourceRevision: request.expectedRevision,
+                responseStates: {
+                    [request.anchorInteractionId]: 'inProgress',
+                },
+            }
+        ),
+    });
+
+    await viewer.open(target('session-a', 'input-1'));
+    onChange();
+    await new Promise(resolve => setImmediate(resolve));
+
+    const publication = panel.postedMessages.filter(message =>
+        message.type === 'conversation-viewer-page').at(-1);
+    assert.equal(publication.selectedInteractionId, 'input-2');
+    assert.equal(publication.selectedInput, 2);
+    assert.equal(publication.totalInputs, 2);
+    assert.equal(publication.atLatest, true);
+    assert.equal(publication.outline.at(-1).responseState, 'inProgress');
+});
+
+test('CONVERSATION-VIEWER-REFRESH-002 CONVERSATION-READING-FOCUS-001 preserves a historical selection when a refresh adds a new last input', async () => {
+    let onChange;
+    let outlineRead = 0;
+    const { viewer, panel } = createViewer({
+        watch: (_provider, _sessionId, callback) => {
+            onChange = callback;
+            return { dispose() {} };
+        },
+        readOutline: async (_provider, sessionId) => {
+            outlineRead += 1;
+            return outline(
+                sessionId,
+                outlineRead === 1
+                    ? ['input-1', 'input-2']
+                    : ['input-1', 'input-2', 'input-3'],
                 { sourceRevision: outlineRead === 1 ? 'r1' : 'r2' }
             );
         },
@@ -2356,8 +2527,45 @@ test('CONVERSATION-VIEWER-REFRESH-002 CONVERSATION-READING-FOCUS-001 preserves t
         message.type === 'conversation-viewer-page').at(-1);
     assert.equal(publication.selectedInteractionId, 'input-1');
     assert.equal(publication.selectedInput, 1);
-    assert.equal(publication.totalInputs, 2);
+    assert.equal(publication.totalInputs, 3);
     assert.equal(publication.atLatest, false);
+});
+
+test('CONVERSATION-VIEWER-REFRESH-002 CONVERSATION-READING-FOCUS-001 CONVERSATION-WORKING-INDICATOR-001 follows a new running input when authority reconciliation arrives before the provider watch', async () => {
+    let revision = 1;
+    const { viewer, panel } = createViewer({
+        readOutline: async (_provider, sessionId) => outline(
+            sessionId,
+            revision === 1 ? ['input-1'] : ['input-1', 'input-2'],
+            {
+                sourceRevision: `r${revision}`,
+                responseStates: revision === 1
+                    ? { 'input-1': 'inProgress' }
+                    : { 'input-1': 'complete', 'input-2': 'inProgress' },
+            }
+        ),
+        readPage: async request => page(
+            request.sessionId,
+            request.anchorInteractionId,
+            `visible-${request.anchorInteractionId}`,
+            {
+                sourceRevision: request.expectedRevision,
+                responseStates: {
+                    [request.anchorInteractionId]: 'inProgress',
+                },
+            }
+        ),
+    });
+
+    await viewer.open(target('session-a', 'input-1'));
+    revision = 2;
+    await viewer.reconcileAuthority(() => true);
+
+    const publication = panel.postedMessages.filter(message =>
+        message.type === 'conversation-viewer-page').at(-1);
+    assert.equal(publication.selectedInteractionId, 'input-2');
+    assert.equal(publication.atLatest, true);
+    assert.equal(publication.outline.at(-1).responseState, 'inProgress');
 });
 
 test('CONVERSATION-VIEWER-DELIVERY-001 retains hidden Webview context without rebuilding it on visibility changes', async () => {
@@ -2492,6 +2700,54 @@ test('CONVERSATION-VIEWER-STALE-004 fails an initial stale retry closed when the
     assert.equal(panel.webview.html.includes('must-not-publish-input-2'), false);
 });
 
+test('CONVERSATION-VIEWER-STALE-004 fails a follow-latest refresh retry closed when the prior latest interaction disappears', async () => {
+    let outlineReads = 0;
+    let pageReads = 0;
+    const requests = [];
+    const { viewer, panel } = createViewer({
+        readOutline: async (_provider, sessionId) => {
+            outlineReads += 1;
+            const interactionIds = outlineReads === 1
+                ? ['input-1']
+                : outlineReads === 2
+                    ? ['input-1', 'input-2']
+                    : ['input-2', 'input-3'];
+            return outline(sessionId, interactionIds, {
+                sourceRevision: `r${outlineReads}`,
+            });
+        },
+        readPage: async request => {
+            pageReads += 1;
+            requests.push(request);
+            if (pageReads === 2) {
+                throw new ConversationError('staleRevision');
+            }
+            return page(
+                request.sessionId,
+                request.anchorInteractionId,
+                pageReads === 1 ? 'visible-established' : 'must-not-follow',
+                { sourceRevision: request.expectedRevision }
+            );
+        },
+    });
+
+    await viewer.open(target('session-a', 'input-1'));
+    await viewer.refresh();
+
+    assert.equal(outlineReads, 3);
+    assert.equal(pageReads, 2);
+    assert.deepEqual(
+        requests.map(request => request.anchorInteractionId),
+        ['input-1', 'input-2']
+    );
+    const publication = panel.postedMessages.filter(message =>
+        message.type === 'conversation-viewer-page').at(-1);
+    assert.equal(publication.selectedInteractionId, 'input-1');
+    assert.equal(publication.stale, true);
+    assert.equal(publication.html.includes('visible-established'), true);
+    assert.equal(publication.html.includes('must-not-follow'), false);
+});
+
 test('CONVERSATION-VIEWER-STALE-002 recovers expired navigation cursors through one fresh authoritative around read', async () => {
     let outlineReads = 0;
     let pageReads = 0;
@@ -2622,7 +2878,7 @@ test('CONVERSATION-VIEWER-AUTHORITY-002 retains stale content when the establish
     );
 });
 
-test('CONVERSATION-VIEWER-REFRESH-003 CONVERSATION-READING-FOCUS-001 merges a new tail page without advancing the selected interaction', async () => {
+test('CONVERSATION-VIEWER-REFRESH-003 CONVERSATION-READING-FOCUS-001 CONVERSATION-WORKING-INDICATOR-001 merges a new tail page and advances from the prior latest interaction', async () => {
     let onChange;
     let revision = 1;
     const firstIds = Array.from(
@@ -2663,7 +2919,8 @@ test('CONVERSATION-VIEWER-REFRESH-003 CONVERSATION-READING-FOCUS-001 merges a ne
 
     const publication = panel.postedMessages.filter(message =>
         message.type === 'conversation-viewer-page').at(-1);
-    assert.equal(publication.selectedInteractionId, 'input-20');
+    assert.equal(publication.selectedInteractionId, 'input-21');
+    assert.equal(publication.atLatest, true);
     assert.equal(publication.html.includes('data-interaction-id="input-1"'), true);
     assert.equal(publication.html.includes('data-interaction-id="input-21"'), true);
     assert.equal(


### PR DESCRIPTION
## Summary

- Keep readable provider lifecycle signals authoritative during quiet work so running sessions do not age into a false stopped state.
- Follow newly appended running turns without overriding explicit historical navigation, including coalesced refreshes and stale-revision recovery.
- Show Working when the latest in-progress interaction is already rendered even if the selected-input metadata is transiently stale.
- Handle a temporarily unavailable lifecycle signal without throwing, and keep safety fixtures aligned with failure and recovery semantics.

## Skill harvest

no skill change — Existing regression and provider-adapter skills already require rendered-surface coverage, real provider data, and the full branch-level CI equivalent before push; the initial CI failure came from not running that existing gate, not from an instruction gap.

## Verification

- `npm run test:ci:linux`
- `npm run test:safety:run`
- Focused execution-monitor contract RED before the null guard, then GREEN
- `npm run test:behavior-contracts` (41 catalog/audit plus 4 release-journey tests passed)
- Changed-line coverage: 100% (65/65) against `origin/main`
- `git diff --check`
- Final independent read-only review: no Critical, Important, or Minor findings
- `SKIP_NPM_CI=1 npm run install-local`
