### PR TITLE
Fix Codex worklog duration display

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -4050,6 +4050,7 @@
       "tests/unit/aiSessions/conversationText.test.js",
       "tests/unit/aiSessions/conversationModel.test.js",
       "tests/contract/aiSessions/claudeConversationAdapter.test.js",
+      "tests/contract/aiSessions/codexConversationAdapter.test.js",
       "tests/contract/aiSessions/kimiConversationAdapter.test.js",
       "tests/integration/dashboard/conversationViewer.test.js",
       "tests/browser/conversationViewer.test.js"
@@ -4059,6 +4060,7 @@
       "src/aiSessions/conversation/model.ts",
       "src/aiSessions/conversation/text.ts",
       "src/aiSessions/conversation/claudeAdapter.ts",
+      "src/aiSessions/conversation/codexAdapter.ts",
       "src/aiSessions/conversation/kimiAdapter.ts",
       "src/aiSessions/conversation/viewer.ts",
       "src/webview/conversationViewerScripts.js",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "a74f599b081ab3b1f3cf7831d41725956162548e",
+        "head": "03caaf49f2d6c05fa691afeabad00c831139304b",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -183,7 +183,8 @@
             "6d9121d2e321c7e56946db87e29e215fec1d9e48",
             "83b140ad79d365f53e724c673d7bda344bc47939",
             "76b172488e0410234c34777dd799ed1c95061700",
-            "bae1c9a0cac6e337d8e2898564b18b3cb871aa9b"
+            "bae1c9a0cac6e337d8e2898564b18b3cb871aa9b",
+            "3f07358793308564ff9ef5bf1fb978990dbeb705"
         ]
     },
     "capabilities": [
@@ -1327,7 +1328,8 @@
                 "6c1958c97bf1de8b7bead4f698c2c14fcc848ee5",
                 "6d16abc51cf0da5266cff6131f574fdb50a8b658",
                 "b99af6f7df742b8b23f613445987fd6285eb0cc0",
-                "a74f599b081ab3b1f3cf7831d41725956162548e"
+                "a74f599b081ab3b1f3cf7831d41725956162548e",
+                "03caaf49f2d6c05fa691afeabad00c831139304b"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",

--- a/src/aiSessions/conversation/codexAdapter.ts
+++ b/src/aiSessions/conversation/codexAdapter.ts
@@ -144,6 +144,68 @@ function turnResponseState(value: string): ConversationResponseState {
     return 'unknown';
 }
 
+function epochSecondsToMs(value: unknown): number | undefined {
+    if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+        return undefined;
+    }
+    const milliseconds = Math.floor(value * 1000);
+    return Number.isSafeInteger(milliseconds) ? milliseconds : undefined;
+}
+
+function turnTiming(
+    turn: Record<string, any>
+): Pick<ConversationInteraction, 'timestamp' | 'completedAt'> {
+    const timestamp = epochSecondsToMs(turn.startedAt);
+    if (timestamp === undefined) {
+        return {};
+    }
+    let completedAt: number | undefined;
+    if (typeof turn.durationMs === 'number'
+        && Number.isFinite(turn.durationMs)
+        && turn.durationMs >= 0) {
+        const preciseCompletion = timestamp + Math.floor(turn.durationMs);
+        if (Number.isSafeInteger(preciseCompletion)) {
+            completedAt = preciseCompletion;
+        }
+    }
+    if (completedAt === undefined) {
+        const providerCompletion = epochSecondsToMs(turn.completedAt);
+        if (providerCompletion !== undefined
+            && providerCompletion >= timestamp) {
+            completedAt = providerCompletion;
+        }
+    }
+    return {
+        timestamp,
+        ...(completedAt !== undefined ? { completedAt } : {}),
+    };
+}
+
+function appendTurnTiming(
+    interaction: ConversationInteraction,
+    timing: Pick<ConversationInteraction, 'timestamp' | 'completedAt'>
+): boolean {
+    if (timing.timestamp === undefined || timing.completedAt === undefined) {
+        return false;
+    }
+    const timestamp = interaction.timestamp !== undefined
+        && Number.isSafeInteger(interaction.timestamp)
+        ? interaction.timestamp
+        : timing.timestamp;
+    interaction.timestamp = timestamp;
+    const turnDuration = timing.completedAt - timing.timestamp;
+    const accumulatedDuration = interaction.completedAt !== undefined
+        && interaction.completedAt >= timestamp
+        ? interaction.completedAt - timestamp
+        : 0;
+    const completedAt = timestamp + accumulatedDuration + turnDuration;
+    if (!Number.isSafeInteger(completedAt)) {
+        return false;
+    }
+    interaction.completedAt = completedAt;
+    return true;
+}
+
 function normalizeThreadRead(
     value: unknown,
     sessionId: string,
@@ -164,6 +226,7 @@ function normalizeThreadRead(
     // (the app-server strips it), so seed one from the thread metadata to
     // give the subagent's agentMessages an interaction to attach to.
     let seededDispatchIndex: number | undefined;
+    let seededDispatchTimingComplete = true;
     if (dispatch) {
         interactions.push({
             id: `${sessionId}-dispatch`,
@@ -193,6 +256,8 @@ function normalizeThreadRead(
         if (seededDispatchIndex !== undefined) {
             interactions[seededDispatchIndex].responseState = responseState;
         }
+        const timing = turnTiming(turn);
+        let timingAssigned = false;
         let currentInteractionIndex: number | undefined = seededDispatchIndex;
         for (const rawItem of turn.items) {
             const item = asRecord(rawItem);
@@ -247,6 +312,7 @@ function normalizeThreadRead(
                 interactions.push({
                     id: item.id,
                     providerTurnId: turn.id,
+                    ...(!timingAssigned ? timing : {}),
                     userMarkdown,
                     userPreview: buildUserPreview(userMarkdown),
                     userGraphemeCount: countGraphemes(userMarkdown),
@@ -254,6 +320,7 @@ function normalizeThreadRead(
                     responseState,
                 });
                 currentInteractionIndex = interactions.length - 1;
+                timingAssigned = true;
             } else if (item.type === 'reasoning') {
                 if (currentInteractionIndex === undefined) {
                     continue;
@@ -304,6 +371,20 @@ function normalizeThreadRead(
                 } else {
                     appendConversationAssistantText(interaction, text);
                 }
+            }
+        }
+        if (seededDispatchIndex !== undefined && !timingAssigned) {
+            // A Codex subagent transcript can span several provider turns
+            // while still representing one synthetic dispatch interaction.
+            // Sum active turn durations so the UI reports actual work time,
+            // excluding idle gaps between those turns.
+            if (seededDispatchTimingComplete
+                && !appendTurnTiming(
+                    interactions[seededDispatchIndex],
+                    timing
+                )) {
+                seededDispatchTimingComplete = false;
+                delete interactions[seededDispatchIndex].completedAt;
             }
         }
     }

--- a/tests/contract/aiSessions/codexConversationAdapter.test.js
+++ b/tests/contract/aiSessions/codexConversationAdapter.test.js
@@ -17,6 +17,10 @@ const fixturePath = path.resolve(
     '../../fixtures/conversations/codex/thread-read.json'
 );
 const fixture = JSON.parse(fs.readFileSync(fixturePath, 'utf8'));
+const timedFixture = JSON.parse(fs.readFileSync(path.resolve(
+    __dirname,
+    '../../fixtures/conversations/codex/thread-read-timed.json'
+), 'utf8'));
 const sessionId = '33333333-3333-4333-8333-333333333333';
 
 function clone(value) {
@@ -118,6 +122,154 @@ async function readWholeConversation(adapter) {
     });
     return { outline, page };
 }
+
+test('CONVERSATION-WORKLOG-COLLAPSE-001 Codex preserves app-server turn timing for the Worked-for row', async t => {
+    const harness = createAdapter(timedFixture);
+    t.after(() => harness.adapter.dispose());
+
+    const { outline, page } = await readWholeConversation(harness.adapter);
+
+    assert.equal(outline.interactions[0].timestamp, 1_786_113_121_000);
+    assert.deepEqual(page.interactionStates[0], {
+        interactionId: 'user-timed',
+        responseState: 'complete',
+        timestamp: 1_786_113_121_000,
+        completedAt: 1_786_113_197_803,
+    });
+});
+
+test('CONVERSATION-WORKLOG-COLLAPSE-001 Codex falls back to completedAt and times only the first visible input in a turn', async t => {
+    const result = clone(timedFixture);
+    const turn = result.thread.turns[0];
+    turn.startedAt = 1_000.125;
+    turn.completedAt = 1_002.75;
+    turn.durationMs = -1;
+    turn.items.splice(1, 0, {
+        id: 'user-timed-second',
+        type: 'userMessage',
+        content: [{ type: 'text', text: 'A second visible input' }],
+    });
+    const harness = createAdapter(result);
+    t.after(() => harness.adapter.dispose());
+
+    const { page } = await readWholeConversation(harness.adapter);
+
+    assert.deepEqual(page.interactionStates, [
+        {
+            interactionId: 'user-timed',
+            responseState: 'complete',
+            timestamp: 1_000_125,
+            completedAt: 1_002_750,
+        },
+        {
+            interactionId: 'user-timed-second',
+            responseState: 'complete',
+        },
+    ]);
+});
+
+test('CONVERSATION-WORKLOG-COLLAPSE-001 Codex sums timed subagent turns into one dispatch duration', async t => {
+    const result = createThreadReadResult(childThreadId, sessionId, {
+        turns: [
+            {
+                id: 'turn-timed-1',
+                status: 'completed',
+                startedAt: 1_700_000_010,
+                completedAt: 1_700_000_020,
+                durationMs: 10_000,
+                items: [{
+                    id: 'agent-timed-1',
+                    type: 'agentMessage',
+                    text: 'First timed result',
+                }],
+            },
+            {
+                id: 'turn-timed-2',
+                status: 'completed',
+                startedAt: 1_700_000_100,
+                completedAt: 1_700_000_120,
+                durationMs: 20_000,
+                items: [{
+                    id: 'agent-timed-2',
+                    type: 'agentMessage',
+                    text: 'Second timed result',
+                }],
+            },
+        ],
+    });
+    const harness = createAdapter(result);
+    t.after(() => harness.adapter.dispose());
+    const encodedId = `${sessionId}#agent:${childThreadId}`;
+
+    const outline = await harness.adapter.readOutline(encodedId);
+    const page = await harness.adapter.readPage({
+        provider: 'codex',
+        sessionId: encodedId,
+        anchorInteractionId: `${childThreadId}-dispatch`,
+        direction: 'around',
+        expectedRevision: outline.sourceRevision,
+    });
+
+    assert.deepEqual(page.interactionStates, [{
+        interactionId: `${childThreadId}-dispatch`,
+        responseState: 'complete',
+        timestamp: 1_700_000_000_000,
+        completedAt: 1_700_000_030_000,
+    }]);
+});
+
+test('CONVERSATION-WORKLOG-COLLAPSE-001 Codex never reports a partial subagent duration as the total', async t => {
+    const timedTurn = {
+        id: 'turn-valid',
+        status: 'completed',
+        startedAt: 1_700_000_100,
+        durationMs: 20_000,
+        items: [{
+            id: 'agent-valid',
+            type: 'agentMessage',
+            text: 'Timed result',
+        }],
+    };
+    const untimedTurn = {
+        id: 'turn-untimed',
+        status: 'completed',
+        items: [{
+            id: 'agent-untimed',
+            type: 'agentMessage',
+            text: 'Untimed result',
+        }],
+    };
+    const cases = [
+        ['untimed then timed', [untimedTurn, timedTurn]],
+        ['timed then untimed', [timedTurn, untimedTurn]],
+        ['overflow', [{
+            ...timedTurn,
+            id: 'turn-overflow',
+            durationMs: Number.MAX_SAFE_INTEGER,
+        }]],
+    ];
+
+    for (const [name, turns] of cases) {
+        await t.test(name, async subtest => {
+            const result = createThreadReadResult(childThreadId, sessionId, {
+                turns: clone(turns),
+            });
+            const harness = createAdapter(result);
+            subtest.after(() => harness.adapter.dispose());
+            const encodedId = `${sessionId}#agent:${childThreadId}`;
+            const outline = await harness.adapter.readOutline(encodedId);
+            const page = await harness.adapter.readPage({
+                provider: 'codex',
+                sessionId: encodedId,
+                anchorInteractionId: `${childThreadId}-dispatch`,
+                direction: 'around',
+                expectedRevision: outline.sourceRevision,
+            });
+
+            assert.equal(page.interactionStates[0].completedAt, undefined);
+        });
+    }
+});
 
 test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 Codex returns one correlated outline and page from one provider read', async t => {
     const harness = createAdapter();

--- a/tests/fixtures/conversations/codex/thread-read-timed.json
+++ b/tests/fixtures/conversations/codex/thread-read-timed.json
@@ -1,0 +1,42 @@
+{
+  "thread": {
+    "id": "33333333-3333-4333-8333-333333333333",
+    "turns": [
+      {
+        "id": "turn-timed",
+        "status": "completed",
+        "startedAt": 1786113121,
+        "completedAt": 1786113198,
+        "durationMs": 76803,
+        "error": null,
+        "itemsView": "full",
+        "items": [
+          {
+            "id": "user-timed",
+            "type": "userMessage",
+            "clientId": "fixture-client",
+            "content": [
+              {
+                "type": "text",
+                "text": "Run the timed task"
+              }
+            ]
+          },
+          {
+            "id": "command-timed",
+            "type": "commandExecution",
+            "command": "npm test",
+            "aggregatedOutput": "9 passing",
+            "status": "completed"
+          },
+          {
+            "id": "agent-timed",
+            "type": "agentMessage",
+            "text": "All tests pass.",
+            "phase": "final_answer"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/integration/dashboard/conversationViewer.test.js
+++ b/tests/integration/dashboard/conversationViewer.test.js
@@ -41,6 +41,14 @@ const {
 const {
     KimiConversationAdapter,
 } = require('../../../out/aiSessions/conversation/kimiAdapter');
+const {
+    CodexConversationAdapter,
+} = require('../../../out/aiSessions/conversation/codexAdapter');
+
+const timedCodexFixture = JSON.parse(fs.readFileSync(path.resolve(
+    __dirname,
+    '../../fixtures/conversations/codex/thread-read-timed.json'
+), 'utf8'));
 
 function deferred() {
     let resolve;
@@ -3245,6 +3253,124 @@ test('CONVERSATION-WORKLOG-COLLAPSE-001 publishes a Worked-for row between work 
         && toolIndex > worklogIndex && answerIndex > toolIndex,
         'worklog row heads the work group so expanding never moves the toggle:'
             + ` ${userIndex}/${worklogIndex}/${toolIndex}/${answerIndex}`);
+});
+
+test('CONVERSATION-WORKLOG-COLLAPSE-001 renders Codex app-server duration in the Worked-for row', async t => {
+    const adapter = new CodexConversationAdapter({
+        client: {
+            async request() {
+                return timedCodexFixture;
+            },
+            dispose() {},
+        },
+        watchSessionChanges: () => ({ dispose() {} }),
+        setTimeout: callback => {
+            callback();
+            return 1;
+        },
+        clearTimeout() {},
+        setCacheTimeout: () => 2,
+        clearCacheTimeout() {},
+    });
+    t.after(() => adapter.dispose());
+    const { viewer, panel } = createViewer({
+        readOutline: (_provider, sessionId) => adapter.readOutline(sessionId),
+        readSnapshot: (_provider, sessionId, preferredInteractionId) =>
+            adapter.readSnapshot(sessionId, preferredInteractionId),
+        readPage: request => adapter.readPage(request),
+    });
+
+    await viewer.open(target(
+        timedCodexFixture.thread.id,
+        'user-timed',
+        { expectedRevision: undefined }
+    ));
+
+    assert.equal(panel.webview.html.includes('Worked for 1m 16s'), true);
+});
+
+test('CONVERSATION-WORKLOG-COLLAPSE-001 renders the sum of Codex subagent turn durations', async t => {
+    const rootId = '33333333-3333-4333-8333-333333333333';
+    const childId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+    const timedTurns = [
+        {
+            id: 'turn-subagent-1',
+            status: 'completed',
+            startedAt: 1_700_000_010,
+            durationMs: 10_000,
+            items: [
+                { id: 'progress-subagent-1', type: 'agentMessage', text: 'First progress', phase: 'commentary' },
+            ],
+        },
+        {
+            id: 'turn-subagent-2',
+            status: 'completed',
+            startedAt: 1_700_000_100,
+            durationMs: 20_000,
+            items: [
+                { id: 'answer-subagent-2', type: 'agentMessage', text: 'Finished' },
+            ],
+        },
+    ];
+    const childFixture = turns => ({
+        thread: {
+            id: childId,
+            parentThreadId: rootId,
+            agentNickname: 'Zeno',
+            createdAt: 1_700_000_000,
+            turns,
+        },
+    });
+    const render = async result => {
+        const adapter = new CodexConversationAdapter({
+            client: {
+                async request() {
+                    return result;
+                },
+                dispose() {},
+            },
+            watchSessionChanges: () => ({ dispose() {} }),
+            setTimeout: callback => {
+                callback();
+                return 1;
+            },
+            clearTimeout() {},
+            setCacheTimeout: () => 2,
+            clearCacheTimeout() {},
+        });
+        t.after(() => adapter.dispose());
+        const { viewer, panel } = createViewer({
+            readOutline: (_provider, sessionId) =>
+                adapter.readOutline(sessionId),
+            readSnapshot: (_provider, sessionId, preferredInteractionId) =>
+                adapter.readSnapshot(sessionId, preferredInteractionId),
+            readPage: request => adapter.readPage(request),
+        });
+        await viewer.open(target(rootId, `${childId}-dispatch`, {
+            expectedRevision: undefined,
+            subagent: { id: childId, label: 'Zeno' },
+        }));
+        return decodeInitialPublication(panel.webview.html).html;
+    };
+
+    const timedHtml = await render(childFixture(timedTurns));
+    assert.equal(timedHtml.includes('Worked for 30s'), true);
+
+    const untimedHtml = await render(childFixture([{
+        id: 'turn-subagent-untimed',
+        status: 'completed',
+        items: [{
+            id: 'progress-subagent-untimed',
+            type: 'agentMessage',
+            text: 'Untimed progress',
+            phase: 'commentary',
+        }],
+    }, timedTurns[1]]));
+    assert.equal(untimedHtml.includes('Worked for 20s'), false);
+    assert.equal(
+        untimedHtml.includes('conversation-worklog-label">Worked</span>'),
+        true
+    );
 });
 
 test('CONVERSATION-WORKLOG-COLLAPSE-001 omits the row while in progress and falls back without timing', async () => {


### PR DESCRIPTION
## Summary

- preserve Codex app-server turn timing through the conversation adapter so completed worklogs show their duration
- sum fully timed subagent turns while excluding idle gaps and fail closed to plain Worked when any contributing turn is incomplete
- add real adapter-to-viewer coverage for precise durations, fallbacks, multi-turn dispatches, and malformed timing

## Testing

- npm run test:ci:linux
- npm run test:behavior-contracts
- npm run test-compile
- node --test tests/contract/aiSessions/codexConversationAdapter.test.js tests/integration/dashboard/conversationViewer.test.js
- git diff --check origin/main..HEAD
- SKIP_NPM_CI=1 npm run install-local

## Skill harvest

No skill change was justified. The task friction around build ordering, review fixes, capability auditing, and installed-byte verification is already covered by the existing repository skills.