### PR TITLE
Fix conversation telemetry and worktree freshness

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -4557,6 +4557,7 @@
     "evidence": [
       "src/aiSessions/conversation/codexAdapter.ts",
       "src/aiSessions/conversation/kimiAdapter.ts",
+      "src/services/kimiSessionService.ts",
       "src/aiSessions/conversation/claudeAdapter.ts",
       "src/aiSessions/conversation/composition.ts",
       "src/aiSessions/conversation/viewer.ts",
@@ -4578,6 +4579,7 @@
     "status": "automated",
     "owners": [
       "tests/unit/aiSessions/conversationTelemetryController.test.js",
+      "tests/integration/dashboard/conversationViewer.test.js",
       "tests/browser/conversationViewer.test.js"
     ],
     "evidence": [

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "03caaf49f2d6c05fa691afeabad00c831139304b",
+        "head": "6218c88baa1aacc6ad07f611fa38bf52ef999ab2",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -184,7 +184,8 @@
             "83b140ad79d365f53e724c673d7bda344bc47939",
             "76b172488e0410234c34777dd799ed1c95061700",
             "bae1c9a0cac6e337d8e2898564b18b3cb871aa9b",
-            "3f07358793308564ff9ef5bf1fb978990dbeb705"
+            "3f07358793308564ff9ef5bf1fb978990dbeb705",
+            "63b71d86916eb6e30cbf110ffc8988298776bec5"
         ]
     },
     "capabilities": [
@@ -1329,7 +1330,8 @@
                 "6d16abc51cf0da5266cff6131f574fdb50a8b658",
                 "b99af6f7df742b8b23f613445987fd6285eb0cc0",
                 "a74f599b081ab3b1f3cf7831d41725956162548e",
-                "03caaf49f2d6c05fa691afeabad00c831139304b"
+                "03caaf49f2d6c05fa691afeabad00c831139304b",
+                "6218c88baa1aacc6ad07f611fa38bf52ef999ab2"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",

--- a/src/aiSessions/codexRolloutWorkdir.ts
+++ b/src/aiSessions/codexRolloutWorkdir.ts
@@ -2,7 +2,10 @@
 
 import { readJsonlTailLines } from './jsonlTail';
 
-const ROLLOUT_TAIL_BYTES = 256 * 1024;
+// A single assistant/tool result record may itself exceed the former 256 KiB
+// window. Keep enough trailing data to reach the preceding exec record while
+// remaining bounded for very long rollouts.
+const ROLLOUT_TAIL_BYTES = 2 * 1024 * 1024;
 const WORKDIR_PATTERN = /\bworkdir\s*:\s*"([^"]+)"/;
 
 /**

--- a/src/aiSessions/conversation/composition.ts
+++ b/src/aiSessions/conversation/composition.ts
@@ -348,6 +348,8 @@ function createAvailableConversationCapability(
             );
         },
         setKeyboardFocus: options.setConversationFocusContext,
+        setTimer: options.setTimer,
+        clearTimer: options.clearTimer,
     }));
     const queueConversationFocus = (
         _target: ConversationSessionOpenTarget,

--- a/src/aiSessions/conversation/conversationTelemetryController.ts
+++ b/src/aiSessions/conversation/conversationTelemetryController.ts
@@ -9,9 +9,12 @@ import {
 } from '../../webview/webviewIcons';
 import type { ConversationViewerTarget } from './viewerTarget';
 import {
+    CONVERSATION_LIMITS,
     ConversationAbortSignal,
     ConversationTelemetry,
 } from './types';
+
+type TimerHandle = unknown;
 
 interface ConversationViewerTelemetryMessage {
     type: 'conversation-viewer-telemetry';
@@ -33,10 +36,24 @@ export interface ConversationTelemetryControllerOptions {
     getCurrentRequestId: () => number;
     isSuspended: () => boolean;
     rebuildLatestDocument: () => void;
+    setTimer?: (callback: () => void, delayMs: number) => TimerHandle;
+    clearTimer?: (handle: TimerHandle) => void;
 }
 
 export class ConversationTelemetryController {
     private telemetry?: ConversationTelemetry;
+    private refreshTimer?: TimerHandle;
+    private active?: {
+        target: ConversationViewerTarget;
+        generation: number;
+        sessionId: string;
+    };
+    private refreshInFlight?: {
+        target: ConversationViewerTarget;
+        generation: number;
+        sessionId: string;
+        promise: Promise<void>;
+    };
 
     constructor(
         private readonly options: ConversationTelemetryControllerOptions
@@ -47,13 +64,85 @@ export class ConversationTelemetryController {
     }
 
     reset(): void {
+        this.pause();
         this.telemetry = undefined;
     }
 
-    async refresh(
+    activate(
         target: ConversationViewerTarget,
         generation: number,
         sessionId = target.sessionId
+    ): void {
+        this.pause();
+        this.active = { target, generation, sessionId };
+        if (!this.matchesRefresh(
+            this.refreshInFlight,
+            target,
+            generation,
+            sessionId
+        )) {
+            this.scheduleRefresh();
+        }
+    }
+
+    pause(): void {
+        this.clearRefreshTimer();
+        this.active = undefined;
+    }
+
+    private clearRefreshTimer(): void {
+        if (this.refreshTimer !== undefined) {
+            const clearTimer = this.options.clearTimer || (handle =>
+                clearTimeout(handle as ReturnType<typeof setTimeout>)
+            );
+            clearTimer(this.refreshTimer);
+            this.refreshTimer = undefined;
+        }
+    }
+
+    refresh(
+        target: ConversationViewerTarget,
+        generation: number,
+        sessionId = target.sessionId
+    ): Promise<void> {
+        if (this.matchesRefresh(
+            this.refreshInFlight,
+            target,
+            generation,
+            sessionId
+        )) {
+            return this.refreshInFlight.promise;
+        }
+        if (this.matchesRefresh(
+            this.active,
+            target,
+            generation,
+            sessionId
+        )) {
+            this.clearRefreshTimer();
+        }
+        const promise = this.readAndPublish(target, generation, sessionId);
+        const refresh = { target, generation, sessionId, promise };
+        this.refreshInFlight = refresh;
+        return promise.finally(() => {
+            if (this.refreshInFlight === refresh) {
+                this.refreshInFlight = undefined;
+            }
+            if (this.matchesRefresh(
+                this.active,
+                target,
+                generation,
+                sessionId
+            )) {
+                this.scheduleRefresh();
+            }
+        });
+    }
+
+    private async readAndPublish(
+        target: ConversationViewerTarget,
+        generation: number,
+        sessionId: string
     ): Promise<void> {
         if (!this.options.readTelemetry) {
             return;
@@ -93,6 +182,39 @@ export class ConversationTelemetryController {
             && this.options.getSubscriptionGeneration() === generation) {
             this.options.rebuildLatestDocument();
         }
+    }
+
+    private scheduleRefresh(): void {
+        const active = this.active;
+        const panel = this.options.getPanel();
+        if (!active || !this.options.readTelemetry || !panel?.visible
+            || this.options.isSuspended()) {
+            return;
+        }
+        const setTimer = this.options.setTimer || setTimeout;
+        this.refreshTimer = setTimer(() => {
+            this.refreshTimer = undefined;
+            void this.refresh(
+                active.target,
+                active.generation,
+                active.sessionId
+            );
+        }, CONVERSATION_LIMITS.telemetryRefreshMs);
+    }
+
+    private matchesRefresh(
+        candidate: {
+            target: ConversationViewerTarget;
+            generation: number;
+            sessionId: string;
+        } | undefined,
+        target: ConversationViewerTarget,
+        generation: number,
+        sessionId: string
+    ): boolean {
+        return candidate?.target === target
+            && candidate.generation === generation
+            && candidate.sessionId === sessionId;
     }
 }
 

--- a/src/aiSessions/conversation/kimiAdapter.ts
+++ b/src/aiSessions/conversation/kimiAdapter.ts
@@ -58,19 +58,18 @@ import type {
 } from './worktreeResolver';
 
 const MAX_TELEMETRY_PATHS = 16;
-const ABSOLUTE_PATH_PATTERN = /(?<![\w.~=-])\/(?:[\w.@+~-]+\/)*[\w.@+~-]+/g;
+const SHELL_CD_PATTERN = /(?:^|&&|\|\||;|\n)\s*cd(?:\s+--)?\s+(?:"([^"]+)"|'([^']+)'|([^\s;&|]+))/g;
 const MAX_LISTED_SUBAGENTS = 64;
 const SUBAGENT_DIRECTORY_PATTERN = /^[0-9a-z][0-9a-z-]{0,63}$/i;
 const SUBAGENT_RUNNING_FRESHNESS_MS = 5 * 60 * 1000;
 
-function extractAbsolutePaths(value: string): string[] {
+function extractShellWorkingDirectories(value: string): string[] {
     const paths = new Set<string>();
-    const pattern = new RegExp(ABSOLUTE_PATH_PATTERN.source, 'g');
+    const pattern = new RegExp(SHELL_CD_PATTERN.source, 'g');
     let match: RegExpExecArray | null;
     while ((match = pattern.exec(value)) !== null) {
-        const candidate = match[0];
-        if (candidate.length > 1 && candidate.length <= 1024
-            && !candidate.startsWith('/dev/')) {
+        const candidate = match[1] || match[2] || match[3] || '';
+        if (candidate.startsWith('/') && candidate.length <= 1024) {
             paths.add(candidate);
         }
     }
@@ -411,6 +410,7 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                     split.subagentId,
                     'wire.jsonl'
                 ),
+                cwd: candidate.cwd,
             }
             : candidate;
         const source = await openValidatedConversationSource(
@@ -423,7 +423,9 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
         let interactions: ConversationInteraction[] = [];
         let openInteractionIndex: number | undefined;
         let telemetryContext: ConversationContextUsage | undefined;
-        let telemetryPaths: string[] = [];
+        let telemetryPaths: string[] = effectiveCandidate.cwd
+            ? [effectiveCandidate.cwd]
+            : [];
         try {
             const startOffset = await getConversationReadStart(
                 source,
@@ -595,7 +597,9 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                             );
                             if (typeof args?.command === 'string') {
                                 telemetryPaths.push(
-                                    ...extractAbsolutePaths(args.command)
+                                    ...extractShellWorkingDirectories(
+                                        args.command
+                                    )
                                 );
                                 if (telemetryPaths.length
                                     > MAX_TELEMETRY_PATHS) {

--- a/src/aiSessions/conversation/viewer.ts
+++ b/src/aiSessions/conversation/viewer.ts
@@ -119,6 +119,8 @@ export interface ConversationViewerOptions {
     setKeyboardFocus?: (
         focused: boolean
     ) => PromiseLike<void> | Promise<void> | void;
+    setTimer?: (callback: () => void, delayMs: number) => unknown;
+    clearTimer?: (handle: unknown) => void;
 }
 
 export interface ConversationViewerApi extends AiSessionDisposable {
@@ -239,6 +241,8 @@ export class ConversationViewer implements ConversationViewerApi {
             getCurrentRequestId: () => this.currentRequestId,
             isSuspended: () => this.suspended,
             rebuildLatestDocument: () => this.rebuildLatestDocument(),
+            setTimer: options.setTimer,
+            clearTimer: options.clearTimer,
         });
         this.commentController = new ConversationCommentController({
             commentStore: options.commentStore,
@@ -485,7 +489,20 @@ export class ConversationViewer implements ConversationViewerApi {
             );
         }
         this.ensureWatch(generation);
-        return this.loadAuthoritative('initial', replaceDocument, snapshot);
+        const loaded = await this.loadAuthoritative(
+            'initial',
+            replaceDocument,
+            snapshot
+        );
+        if (loaded && this.target === activeTarget
+            && this.subscriptionGeneration === generation) {
+            this.telemetryController.activate(
+                activeTarget,
+                generation,
+                this.effectiveSessionId(activeTarget)
+            );
+        }
+        return loaded;
     }
 
     async refresh(): Promise<void> {
@@ -559,6 +576,7 @@ export class ConversationViewer implements ConversationViewerApi {
                 return;
             }
             this.suspended = true;
+            this.telemetryController.pause();
             this.authoritativeLoadInFlight = undefined;
             this.authoritativeRefreshPending = false;
             this.abortController?.abort();
@@ -600,6 +618,13 @@ export class ConversationViewer implements ConversationViewerApi {
         }
         this.suspended = false;
         await this.refresh();
+        if (this.target === target && !this.suspended) {
+            this.telemetryController.activate(
+                target,
+                this.subscriptionGeneration,
+                this.effectiveSessionId(target)
+            );
+        }
         const expectedDisplayName = visibleConversationDisplayName(target);
         if (metadataChanged
             && this.latestPublication?.displayName !== expectedDisplayName) {
@@ -679,6 +704,15 @@ export class ConversationViewer implements ConversationViewerApi {
             }
             if (!panel.active) {
                 this.publishKeyboardFocus(false);
+            }
+            if (!panel.visible) {
+                this.telemetryController.pause();
+            } else if (this.target && !this.suspended) {
+                this.telemetryController.activate(
+                    this.target,
+                    this.subscriptionGeneration,
+                    this.effectiveSessionId(this.target)
+                );
             }
         });
         this.panelDisposeListener = panel.onDidDispose(() => {

--- a/src/aiSessions/types.ts
+++ b/src/aiSessions/types.ts
@@ -89,6 +89,8 @@ export interface AiSessionDisposable {
 export interface AiSessionConversationSourceCandidate {
     providerHome: string;
     sourcePath: string;
+    /** Provider-authoritative working directory for this Session. */
+    cwd?: string;
 }
 
 /**

--- a/src/services/kimiSessionService.ts
+++ b/src/services/kimiSessionService.ts
@@ -59,8 +59,15 @@ export default class KimiSessionService {
         const kimiHome = this.getKimiHome();
         const sessionDir = kimiHome && this.findSessionDir(kimiHome, sessionId);
         const sourcePath = sessionDir && path.join(sessionDir, 'wire.jsonl');
+        const workDir = sessionDir
+            ? this.findWorkDirForSessionDir(kimiHome, sessionDir)
+            : null;
         return sourcePath && fs.existsSync(sourcePath)
-            ? { providerHome: kimiHome, sourcePath }
+            ? {
+                providerHome: kimiHome,
+                sourcePath,
+                ...(workDir ? { cwd: workDir } : {}),
+            }
             : null;
     }
 
@@ -340,6 +347,16 @@ export default class KimiSessionService {
         }
 
         return null;
+    }
+
+    private findWorkDirForSessionDir(
+        kimiHome: string,
+        sessionDir: string
+    ): string {
+        const workDirHash = path.basename(path.dirname(sessionDir));
+        return this.getWorkDirs(kimiHome).find(workDir =>
+            this.getWorkDirHash(workDir) === workDirHash
+        ) || null;
     }
 
     private readSession(workDir: string, sessionId: string, sessionDir: string): CodexSession {

--- a/tests/contract/aiSessions/kimiConversationAdapter.test.js
+++ b/tests/contract/aiSessions/kimiConversationAdapter.test.js
@@ -656,6 +656,11 @@ test('SESSION-AI-SESSION-CONVERSATION-ADAPTER-001 real Kimi polling invalidates 
         'wire.jsonl'
     );
     const service = new KimiSessionService();
+    assert.equal(
+        service.resolveConversationSource(liveSessionId).cwd,
+        '/fixtures/other',
+        'the real Kimi work-dir hash must resolve back to its Session cwd'
+    );
     service.changePollIntervalMs = 10;
     const adapter = new KimiConversationAdapter({
         resolveSource: id => service.resolveConversationSource(id),
@@ -874,18 +879,24 @@ test('CONVERSATION-TELEMETRY-001 Kimi surfaces the latest StatusUpdate context w
     });
 });
 
-test('CONVERSATION-TELEMETRY-001 Kimi resolves the worktree from the newest Shell tool paths', async t => {
+test('CONVERSATION-TELEMETRY-001 Kimi resolves the worktree from Shell cwd signals without mistaking referenced files for cwd', async t => {
     const source = await createFixture(t);
     const calls = [];
     const adapter = createAdapter(source, {
         resolveWorktree: async candidate => {
             calls.push(candidate);
-            return candidate === '/repo/.worktree/feat'
+            return candidate.startsWith('/repo/.worktree/feat')
                 ? {
                     branch: 'feat',
-                    worktreeRoot: candidate,
+                    worktreeRoot: '/repo/.worktree/feat',
                     repoRoot: '/repo',
                 }
+                : candidate.startsWith('/repo')
+                    ? {
+                        branch: 'main',
+                        worktreeRoot: '/repo',
+                        repoRoot: '/repo',
+                    }
                 : undefined;
         },
     });
@@ -920,7 +931,7 @@ test('CONVERSATION-TELEMETRY-001 Kimi resolves the worktree from the newest Shel
                     function: {
                         name: 'Shell',
                         arguments: JSON.stringify({
-                            command: 'cd /repo/.worktree/feat && ls /tmp',
+                            command: 'cd /repo/.worktree/feat && cat /repo/README.md && ls /tmp',
                         }),
                     },
                 },
@@ -949,7 +960,49 @@ test('CONVERSATION-TELEMETRY-001 Kimi resolves the worktree from the newest Shel
         worktreeRoot: '/repo/.worktree/feat',
         repoRoot: '/repo',
     });
-    assert.deepEqual(calls.slice(0, 2), ['/tmp', '/repo/.worktree/feat']);
+    assert.deepEqual(calls, ['/repo/.worktree/feat']);
+});
+
+test('CONVERSATION-TELEMETRY-001 Kimi falls back to the Session working directory when no Shell command changes cwd', async t => {
+    const source = await createFixture(t);
+    source.cwd = '/repo/.worktree/session-cwd';
+    const calls = [];
+    const adapter = createAdapter(source, {
+        resolveWorktree: async candidate => {
+            calls.push(candidate);
+            return {
+                branch: 'session-cwd',
+                worktreeRoot: candidate,
+                repoRoot: '/repo',
+            };
+        },
+    });
+    t.after(() => adapter.dispose());
+
+    await fs.promises.appendFile(source.sourcePath, `${JSON.stringify({
+        timestamp: 5000,
+        message: {
+            type: 'ToolCall',
+            payload: {
+                type: 'function',
+                id: 'Shell_cwd_fallback',
+                function: {
+                    name: 'Shell',
+                    arguments: JSON.stringify({
+                        command: 'cat /repo/README.md',
+                    }),
+                },
+            },
+        },
+    })}\n`);
+
+    const telemetry = await adapter.readTelemetry(sessionId);
+    assert.deepEqual(telemetry.worktree, {
+        branch: 'session-cwd',
+        worktreeRoot: '/repo/.worktree/session-cwd',
+        repoRoot: '/repo',
+    });
+    assert.deepEqual(calls, ['/repo/.worktree/session-cwd']);
 });
 
 test('CONVERSATION-TOOL-CALL-VISIBILITY-001 CONVERSATION-PROGRESS-VISIBILITY-001 Kimi treats a tool preamble as progress and preserves the final answer', async t => {

--- a/tests/integration/dashboard/conversationViewer.test.js
+++ b/tests/integration/dashboard/conversationViewer.test.js
@@ -251,6 +251,7 @@ function createViewer(options = {}) {
         readPage: options.readPage || (async request =>
             page(request.sessionId, request.anchorInteractionId)),
         readSubagents: options.readSubagents,
+        readTelemetry: options.readTelemetry,
         watch: options.watch || ((_provider, sessionId) => ({
             dispose() {
                 watchDisposals.push(sessionId);
@@ -271,9 +272,68 @@ function createViewer(options = {}) {
         showThinking: options.showThinking,
         commentStore: options.commentStore,
         bookmarkStore: options.bookmarkStore,
+        setTimer: options.setTimer,
+        clearTimer: options.clearTimer,
     });
     return { viewer, panel, watchDisposals, restoredTargets, openedUris };
 }
+
+test('CONVERSATION-TELEMETRY-CONTROLLER-001 refreshes telemetry while the visible conversation is otherwise idle', async () => {
+    const timers = new Map();
+    let nextTimer = 1;
+    let telemetryReads = 0;
+    const { viewer, panel } = createViewer({
+        readTelemetry: async (_provider, sessionId) => ({
+            provider: 'codex',
+            sessionId,
+            context: {
+                usedTokens: ++telemetryReads * 100,
+                maxTokens: 1_000,
+            },
+            rateLimits: [],
+        }),
+        setTimer(callback, delayMs) {
+            const handle = nextTimer++;
+            timers.set(handle, {
+                callback: () => {
+                    timers.delete(handle);
+                    return callback();
+                },
+                delayMs,
+            });
+            return handle;
+        },
+        clearTimer(handle) {
+            timers.delete(handle);
+        },
+    });
+
+    await viewer.open(target('session-idle'));
+    await new Promise(resolve => setImmediate(resolve));
+    assert.equal(telemetryReads, 1, 'initial publication reads telemetry');
+    const scheduled = Array.from(timers.values()).at(-1);
+    assert.ok(scheduled, 'visible conversation must schedule a telemetry refresh');
+    assert.equal(scheduled.delayMs, 5_000);
+
+    await scheduled.callback();
+    await new Promise(resolve => setImmediate(resolve));
+    assert.equal(telemetryReads, 2);
+    assert.equal(
+        panel.postedMessages.filter(message =>
+            message.type === 'conversation-viewer-telemetry'
+        ).at(-1).telemetry.context.usedTokens,
+        200
+    );
+    assert.equal(timers.size, 1, 'the next visible refresh is scheduled');
+
+    await panel.setVisible(false);
+    assert.equal(timers.size, 0, 'hidden conversations stop telemetry work');
+    await panel.setVisible(true);
+    assert.equal(timers.size, 1, 'showing the conversation resumes telemetry');
+
+    panel.dispose();
+    assert.equal(timers.size, 0, 'disposing the viewer cancels telemetry work');
+});
 
 test('WEBVIEW-AI-SESSION-CONVERSATION-VIEWER-001 opens and reuses one viewer in the active editor group', async () => {
     const { viewer, panel } = createViewer();

--- a/tests/unit/aiSessions/codexRolloutWorkdir.test.js
+++ b/tests/unit/aiSessions/codexRolloutWorkdir.test.js
@@ -51,3 +51,29 @@ test('CONVERSATION-TELEMETRY-001 rollout probe reads the newest exec workdir fro
     );
     assert.equal(readCodexRolloutWorkdir(rolloutPath), undefined);
 });
+
+test('CONVERSATION-TELEMETRY-001 rollout probe keeps the latest workdir across a large trailing record', async t => {
+    const dir = await fs.promises.mkdtemp(
+        path.join(os.tmpdir(), 'steward-codex-rollout-large-tail-')
+    );
+    t.after(() => fs.promises.rm(dir, { recursive: true, force: true }));
+    const rolloutPath = path.join(dir, 'rollout.jsonl');
+    const largeAssistantRecord = JSON.stringify({
+        type: 'response_item',
+        payload: {
+            type: 'message',
+            content: 'x'.repeat(300 * 1024),
+        },
+    });
+
+    await fs.promises.writeFile(rolloutPath, [
+        execLine('/repo/.worktree/telemetry-fix'),
+        largeAssistantRecord,
+        '',
+    ].join('\n'));
+
+    assert.equal(
+        readCodexRolloutWorkdir(rolloutPath),
+        '/repo/.worktree/telemetry-fix'
+    );
+});

--- a/tests/unit/aiSessions/conversationTelemetryController.test.js
+++ b/tests/unit/aiSessions/conversationTelemetryController.test.js
@@ -114,6 +114,53 @@ test('CONVERSATION-TELEMETRY-CONTROLLER-001 ignores stale reads and rebuilds onl
     assert.equal(rebuilds, 1);
 });
 
+test('CONVERSATION-TELEMETRY-CONTROLLER-001 schedules the next sample after the current read completes', async () => {
+    const activeTarget = target();
+    const timers = new Map();
+    let nextTimer = 1;
+    let resolveRead;
+    const controller = new ConversationTelemetryController({
+        readTelemetry: () => new Promise(resolve => {
+            resolveRead = resolve;
+        }),
+        getPanel: () => ({
+            visible: true,
+            webview: { postMessage: async () => true },
+        }),
+        getTarget: () => activeTarget,
+        getSubscriptionGeneration: () => 2,
+        getCurrentRequestId: () => 7,
+        isSuspended: () => false,
+        rebuildLatestDocument() {},
+        setTimer(callback, delayMs) {
+            const handle = nextTimer++;
+            timers.set(handle, { callback, delayMs });
+            return handle;
+        },
+        clearTimer(handle) {
+            timers.delete(handle);
+        },
+    });
+
+    const refresh = controller.refresh(activeTarget, 2);
+    controller.activate(activeTarget, 2);
+    assert.equal(
+        timers.size,
+        0,
+        'an in-flight provider read must finish before its cache interval starts'
+    );
+
+    resolveRead({
+        provider: 'codex',
+        sessionId: activeTarget.sessionId,
+        rateLimits: [],
+    });
+    await refresh;
+    assert.equal(timers.size, 1);
+    assert.equal(Array.from(timers.values())[0].delayMs, 5_000);
+    controller.pause();
+});
+
 test('CONVERSATION-TELEMETRY-CONTROLLER-001 renders escaped model and quota markup for initial documents', () => {
     const html = renderConversationTelemetry({
         provider: 'codex',


### PR DESCRIPTION
## Summary

- refresh telemetry for every visible AI Conversation every five seconds without overlapping provider reads
- pause telemetry work while the viewer is hidden, suspended, or disposed
- improve Codex rollout worktree recovery for large trailing records and use authoritative Kimi Session cwd data without treating referenced files as cwd changes

## Skill harvest

no skill change — the only workflow retry was a compliance miss already explicitly covered by protecting-main-with-worktrees

## Verification

- `npm run test:ci:linux` (149 Chromium tests; changed-line coverage 98.47%)
- `npm run test-compile`
- `node --test tests/unit/aiSessions/codexRolloutWorkdir.test.js tests/unit/aiSessions/conversationTelemetryController.test.js tests/contract/aiSessions/kimiConversationAdapter.test.js tests/contract/aiSessions/codexConversationAdapter.test.js tests/contract/aiSessions/claudeConversationAdapter.test.js tests/integration/dashboard/conversationViewer.test.js` (167 passed)
- `npm run test:behavior-contracts`
- `node scripts/run-dashboard-webview-checks.js`
- `npm run lint` (baseline warnings only)
- `git diff --check`
- verified real Codex and Kimi telemetry sources resolve their current worktrees
- built and installed the VSIX locally; verified installed extension files match the package