### PR TITLE
Fix duplicate external link navigation

### DIFF
--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "6218c88baa1aacc6ad07f611fa38bf52ef999ab2",
+        "head": "1a00402f2c5263c909984e436db792a897aa7a5d",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -185,7 +185,8 @@
             "76b172488e0410234c34777dd799ed1c95061700",
             "bae1c9a0cac6e337d8e2898564b18b3cb871aa9b",
             "3f07358793308564ff9ef5bf1fb978990dbeb705",
-            "63b71d86916eb6e30cbf110ffc8988298776bec5"
+            "63b71d86916eb6e30cbf110ffc8988298776bec5",
+            "5ab475d61ba350a3fb0ee5570f62ccde9269488d"
         ]
     },
     "capabilities": [
@@ -1331,7 +1332,8 @@
                 "b99af6f7df742b8b23f613445987fd6285eb0cc0",
                 "a74f599b081ab3b1f3cf7831d41725956162548e",
                 "03caaf49f2d6c05fa691afeabad00c831139304b",
-                "6218c88baa1aacc6ad07f611fa38bf52ef999ab2"
+                "6218c88baa1aacc6ad07f611fa38bf52ef999ab2",
+                "1a00402f2c5263c909984e436db792a897aa7a5d"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",

--- a/media/conversationViewerScripts.js
+++ b/media/conversationViewerScripts.js
@@ -1134,9 +1134,10 @@
             ? event.target.closest('a[href]')
             : null;
         if (!link || !messages.contains(link)) return;
-        event.preventDefault();
         var href = link.getAttribute('href');
-        if (!isAllowedLinkHref(href)) return;
+        if (isHttps(href)) return;
+        event.preventDefault();
+        if (!isAbsoluteFileHref(href)) return;
         post({
             type: 'conversation-viewer-open-link',
             version: 1,

--- a/src/webview/conversationViewerScripts.js
+++ b/src/webview/conversationViewerScripts.js
@@ -1134,9 +1134,10 @@
             ? event.target.closest('a[href]')
             : null;
         if (!link || !messages.contains(link)) return;
-        event.preventDefault();
         var href = link.getAttribute('href');
-        if (!isAllowedLinkHref(href)) return;
+        if (isHttps(href)) return;
+        event.preventDefault();
+        if (!isAbsoluteFileHref(href)) return;
         post({
             type: 'conversation-viewer-open-link',
             version: 1,

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -1161,14 +1161,29 @@ function assertConversationEmphasisForcedColors(styles) {
     assert.equal(styles.assistantSeparatorWidth, 1);
 }
 
-test('WEBVIEW-AI-SESSION-CONVERSATION-VIEWER-001 acquires one real document API and posts every control action', async t => {
+test('WEBVIEW-AI-SESSION-CONVERSATION-VIEWER-001 acquires one real document API and delegates HTTPS links only to native Webview navigation', async t => {
     const { page } = await openHostViewerDocument(t);
 
     assert.equal(await page.evaluate(() => window.__acquireCount), 1);
     await page.getByRole('button', { name: 'Previous', exact: true }).click();
     await page.getByRole('button', { name: 'Next', exact: true }).click();
     await page.getByRole('button', { name: 'Latest', exact: true }).click();
-    await page.locator('a[href="https://example.test/safe"]').click();
+    const defaultPreventedBeforeTestGuard = await page.locator(
+        'a[href="https://example.test/safe"]'
+    ).evaluate(link => {
+        let defaultPrevented;
+        document.addEventListener('click', event => {
+            defaultPrevented = event.defaultPrevented;
+            event.preventDefault();
+        }, { once: true });
+        link.click();
+        return defaultPrevented;
+    });
+    assert.equal(
+        defaultPreventedBeforeTestGuard,
+        false,
+        'the Webview must retain the native HTTPS navigation path'
+    );
 
     assert.deepEqual(await postedMessages(page), [
         {
@@ -1179,11 +1194,6 @@ test('WEBVIEW-AI-SESSION-CONVERSATION-VIEWER-001 acquires one real document API 
         { type: 'conversation-viewer-previous', version: 1 },
         { type: 'conversation-viewer-next', version: 1 },
         { type: 'conversation-viewer-latest', version: 1 },
-        {
-            type: 'conversation-viewer-open-link',
-            version: 1,
-            href: 'https://example.test/safe',
-        },
     ]);
 });
 
@@ -4542,7 +4552,7 @@ test('CONVERSATION-VIEWER-USER-EMPHASIS-001 makes User a full-width Prompt block
     }
 });
 
-test('WEBVIEW-AI-SESSION-CONVERSATION-VIEWER-001 sanitizes hostile HTML, posts exact version-1 navigation, and keeps the viewer open on Escape', async t => {
+test('WEBVIEW-AI-SESSION-CONVERSATION-VIEWER-001 sanitizes hostile HTML, preserves one native HTTPS path, and keeps the viewer open on Escape', async t => {
     const page = await openViewerPage(t);
     await sendPage(page, hostileConversationPage);
 
@@ -4584,12 +4594,24 @@ test('WEBVIEW-AI-SESSION-CONVERSATION-VIEWER-001 sanitizes hostile HTML, posts e
         version: 1,
     });
 
-    await page.locator('a[href="https://example.test/safe"]').click();
-    assert.deepEqual((await postedMessages(page)).at(-1), {
-        type: 'conversation-viewer-open-link',
-        version: 1,
-        href: 'https://example.test/safe',
+    const postedBeforeLink = (await postedMessages(page)).length;
+    const defaultPreventedBeforeTestGuard = await page.locator(
+        'a[href="https://example.test/safe"]'
+    ).evaluate(link => {
+        let defaultPrevented;
+        document.addEventListener('click', event => {
+            defaultPrevented = event.defaultPrevented;
+            event.preventDefault();
+        }, { once: true });
+        link.click();
+        return defaultPrevented;
     });
+    assert.equal(defaultPreventedBeforeTestGuard, false);
+    assert.equal(
+        (await postedMessages(page)).length,
+        postedBeforeLink,
+        'sanitized HTTPS links must not also ask the Host to open them'
+    );
 
     const postedBeforeEscape = (await postedMessages(page)).length;
     await page.keyboard.press('Escape');


### PR DESCRIPTION
## Summary

- let VS Code Webview handle HTTPS links through its native navigation path
- keep absolute local file links routed through the Extension Host for exact file and line opening
- add rendered browser coverage that rejects simultaneous native and Host navigation for both initial and sanitized live content

## Skill harvest

no skill change — the only workflow retry was a missing compiled test artifact, and the existing testing guidance already requires compilation before browser tests

## Verification

- `npm run test:ci:linux` (149 Chromium tests; changed-line coverage passed)
- focused rendered HTTPS and local-file link browser tests (3 passed)
- `npm run test:behavior-contracts`
- `node scripts/run-dashboard-webview-checks.js`
- `git diff --check`
- `SKIP_NPM_CI=1 npm run install-local` (Agent Pivot 1.0.4 and Attention UI Bridge 1.0.1 installed; packaged and installed bytes verified)