### PR TITLE
Fix Codex conversation telemetry accuracy

### DIFF
--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "2ddbacf5903347ed17dd51c1cc6134a86d9b57c5",
+        "head": "60d65d94d3421e5f5f76486d32739322a4377276",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -191,7 +191,8 @@
             "9c4f1e6e643f1a123b13b1f61a7ba3769e123dc3",
             "e501d130c03bb3ddb3250626236accfe14593319",
             "5f49acdf8bbca37dcb2acc5f223ce3cd1d8485b6",
-            "ab3234b0a38f7bd5ad6baa9af74acd316465449e"
+            "ab3234b0a38f7bd5ad6baa9af74acd316465449e",
+            "6552649d2adfe96f30ffce43510ef56c50e47f52"
         ]
     },
     "capabilities": [
@@ -1349,7 +1350,8 @@
                 "561c0c27530b767ff4de86f2a2bae451d0ca28b7",
                 "fd136e910739c8880322f219091c34946c2778fc",
                 "f57b50cc3c0bbc2ae34feb59f3bbd8960a7245e8",
-                "2ddbacf5903347ed17dd51c1cc6134a86d9b57c5"
+                "2ddbacf5903347ed17dd51c1cc6134a86d9b57c5",
+                "60d65d94d3421e5f5f76486d32739322a4377276"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "60d65d94d3421e5f5f76486d32739322a4377276",
+        "head": "76a4676e2dbd4bb001489dd8c1ac9918f961ae99",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -192,7 +192,8 @@
             "e501d130c03bb3ddb3250626236accfe14593319",
             "5f49acdf8bbca37dcb2acc5f223ce3cd1d8485b6",
             "ab3234b0a38f7bd5ad6baa9af74acd316465449e",
-            "6552649d2adfe96f30ffce43510ef56c50e47f52"
+            "6552649d2adfe96f30ffce43510ef56c50e47f52",
+            "36b4b47320ebcf735f851fcfc7cc49e9ee92db4c"
         ]
     },
     "capabilities": [
@@ -1351,7 +1352,8 @@
                 "fd136e910739c8880322f219091c34946c2778fc",
                 "f57b50cc3c0bbc2ae34feb59f3bbd8960a7245e8",
                 "2ddbacf5903347ed17dd51c1cc6134a86d9b57c5",
-                "60d65d94d3421e5f5f76486d32739322a4377276"
+                "60d65d94d3421e5f5f76486d32739322a4377276",
+                "76a4676e2dbd4bb001489dd8c1ac9918f961ae99"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",

--- a/src/aiSessions/conversation/codexAdapter.ts
+++ b/src/aiSessions/conversation/codexAdapter.ts
@@ -82,6 +82,7 @@ const SUBAGENT_RUNNING_FRESHNESS_MS = 5 * 60 * 1000;
 const LARGE_CONVERSATION_CACHE_CHARS = 512 * 1024;
 const LARGE_CONVERSATION_CACHE_TTL_MS = 15_000;
 const LARGE_CONVERSATION_CACHE_ENTRIES = 2;
+const TOKEN_USAGE_NOTIFICATION_WAIT_MS = 250;
 
 interface LoadedConversation {
     interactions: ConversationInteraction[];
@@ -452,10 +453,18 @@ function rateLimitLabel(durationMins: number | undefined): string {
 
 function normalizeRateLimits(value: unknown): ConversationTelemetry['rateLimits'] {
     const result = asRecord(value);
+    const canonical = asRecord(result?.rateLimits);
     const byId = asRecord(result?.rateLimitsByLimitId);
-    const snapshots = byId
+    const byIdEntries = byId
         ? Object.entries(byId).slice(0, 16)
-        : [['codex', result?.rateLimits]];
+        : [];
+    const canonicalById = byIdEntries.find(([fallbackId, rawSnapshot]) => {
+        const snapshot = asRecord(rawSnapshot);
+        return fallbackId === 'codex' || snapshot?.limitId === 'codex';
+    });
+    const snapshots = canonical
+        ? [['codex', canonical] as [string, unknown]]
+        : canonicalById ? [canonicalById] : byIdEntries;
     const limits: ConversationTelemetry['rateLimits'] = [];
     const seen = new Set<string>();
     for (const [fallbackId, rawSnapshot] of snapshots) {
@@ -524,6 +533,7 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
         string,
         Promise<ConversationTelemetry | undefined>
     >();
+    private readonly tokenUsageWaiters = new Map<string, Set<() => void>>();
     private readonly loadedConversationCache = new Map<
         string,
         CachedLoadedConversation
@@ -676,24 +686,39 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
         sessionId: string,
         signal?: ConversationAbortSignal
     ): Promise<ConversationTelemetry | undefined> {
-        const [resumeResult, limitsResult] = await Promise.all([
-            this.options.client.request(
-                'thread/resume',
-                { threadId: sessionId },
-                signal
-            ).then(
-                value => ({ fulfilled: true as const, value }),
-                () => ({ fulfilled: false as const })
-            ),
-            this.options.client.request(
-                'account/rateLimits/read',
-                undefined,
-                signal
-            ).then(
-                value => ({ fulfilled: true as const, value }),
-                () => ({ fulfilled: false as const })
-            ),
-        ]);
+        const contextBeforeRead = this.tokenUsageBySession.get(sessionId);
+        const tokenUsageWaiter = this.createTokenUsageWaiter(sessionId);
+        let resumeResult: { fulfilled: true; value: unknown }
+            | { fulfilled: false };
+        let limitsResult: { fulfilled: true; value: unknown }
+            | { fulfilled: false };
+        try {
+            [resumeResult, limitsResult] = await Promise.all([
+                this.options.client.request(
+                    'thread/resume',
+                    { threadId: sessionId },
+                    signal
+                ).then(
+                    value => ({ fulfilled: true as const, value }),
+                    () => ({ fulfilled: false as const })
+                ),
+                this.options.client.request(
+                    'account/rateLimits/read',
+                    undefined,
+                    signal
+                ).then(
+                    value => ({ fulfilled: true as const, value }),
+                    () => ({ fulfilled: false as const })
+                ),
+            ]);
+            if (resumeResult.fulfilled
+                && this.tokenUsageBySession.get(sessionId)
+                === contextBeforeRead) {
+                await this.waitForTokenUsageOrTimeout(tokenUsageWaiter.promise);
+            }
+        } finally {
+            tokenUsageWaiter.dispose();
+        }
         const telemetry: ConversationTelemetry = {
             provider: 'codex',
             sessionId,
@@ -796,6 +821,10 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
         this.providerWatch?.dispose();
         this.providerWatch = undefined;
         this.notificationWatch?.dispose();
+        this.tokenUsageWaiters.forEach(waiters => {
+            waiters.forEach(resolve => resolve());
+        });
+        this.tokenUsageWaiters.clear();
         this.tokenUsageBySession.clear();
         this.telemetryCache.clear();
         this.telemetryReads.clear();
@@ -826,10 +855,70 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
         };
         this.makeRoomForTelemetrySession(params.threadId);
         this.tokenUsageBySession.set(params.threadId, context);
+        const waiters = this.tokenUsageWaiters.get(params.threadId);
+        if (waiters) {
+            this.tokenUsageWaiters.delete(params.threadId);
+            waiters.forEach(resolve => resolve());
+        }
         const cached = this.telemetryCache.get(params.threadId);
         if (cached?.value) {
             cached.value.context = { ...context };
         }
+    }
+
+    private createTokenUsageWaiter(sessionId: string): {
+        promise: Promise<void>;
+        dispose(): void;
+    } {
+        let resolvePromise = (): void => undefined;
+        const promise = new Promise<void>(resolve => {
+            resolvePromise = resolve;
+        });
+        let waiters = this.tokenUsageWaiters.get(sessionId);
+        if (!waiters) {
+            waiters = new Set();
+            this.tokenUsageWaiters.set(sessionId, waiters);
+        }
+        waiters.add(resolvePromise);
+        return {
+            promise,
+            dispose: () => {
+                const current = this.tokenUsageWaiters.get(sessionId);
+                current?.delete(resolvePromise);
+                if (!current?.size) {
+                    this.tokenUsageWaiters.delete(sessionId);
+                }
+            },
+        };
+    }
+
+    private waitForTokenUsageOrTimeout(notification: Promise<void>): Promise<void> {
+        return new Promise(resolve => {
+            let settled = false;
+            let timeoutHandle: TimerHandle | undefined;
+            const finish = (): void => {
+                if (settled) {
+                    return;
+                }
+                settled = true;
+                if (timeoutHandle !== undefined) {
+                    this.options.clearTimeout(timeoutHandle);
+                    timeoutHandle = undefined;
+                }
+                resolve();
+            };
+            notification.then(finish);
+            let timeoutFiredSynchronously = false;
+            const handle = this.options.setTimeout(() => {
+                timeoutFiredSynchronously = true;
+                finish();
+            }, TOKEN_USAGE_NOTIFICATION_WAIT_MS);
+            if (!timeoutFiredSynchronously && !settled) {
+                timeoutHandle = handle;
+            } else {
+                this.options.clearTimeout(handle);
+            }
+        });
     }
 
     private makeRoomForTelemetrySession(sessionId: string): void {

--- a/src/aiSessions/conversation/codexAdapter.ts
+++ b/src/aiSessions/conversation/codexAdapter.ts
@@ -669,11 +669,13 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
         this.telemetryReads.set(sessionId, read);
         try {
             const value = await read;
-            this.makeRoomForTelemetrySession(sessionId);
-            this.telemetryCache.set(sessionId, {
-                readAt: Date.now(),
-                value,
-            });
+            if (!this.disposed) {
+                this.makeRoomForTelemetrySession(sessionId);
+                this.telemetryCache.set(sessionId, {
+                    readAt: Date.now(),
+                    value,
+                });
+            }
             return value;
         } finally {
             if (this.telemetryReads.get(sessionId) === read) {

--- a/tests/contract/aiSessions/codexConversationAdapter.test.js
+++ b/tests/contract/aiSessions/codexConversationAdapter.test.js
@@ -560,6 +560,97 @@ test('CONVERSATION-TELEMETRY-001 reads model, context, and quota windows from st
     });
 });
 
+test('CONVERSATION-TELEMETRY-001 prefers the canonical Codex quota over same-window named limits', async t => {
+    const canonical = {
+        limitId: 'codex',
+        primary: {
+            usedPercent: 73,
+            windowDurationMins: 10_080,
+            resetsAt: 2_000_000_000,
+        },
+        secondary: null,
+    };
+    const harness = createAdapter(fixture, {
+        client: {
+            async request(method) {
+                if (method === 'thread/resume') {
+                    return { model: 'gpt-5.6-sol' };
+                }
+                assert.equal(method, 'account/rateLimits/read');
+                return {
+                    rateLimits: canonical,
+                    rateLimitsByLimitId: {
+                        codex_bengalfox: {
+                            limitId: 'codex_bengalfox',
+                            limitName: 'GPT-5.3-Codex-Spark',
+                            primary: {
+                                usedPercent: 0,
+                                windowDurationMins: 10_080,
+                                resetsAt: 2_100_000_000,
+                            },
+                            secondary: null,
+                        },
+                        codex: canonical,
+                    },
+                };
+            },
+            dispose() {},
+        },
+    });
+    t.after(() => harness.adapter.dispose());
+
+    const telemetry = await harness.adapter.readTelemetry(sessionId);
+
+    assert.deepEqual(telemetry.rateLimits, [{
+        id: 'codex:primary',
+        label: 'Week',
+        usedPercent: 73,
+        windowDurationMins: 10_080,
+        resetsAt: 2_000_000_000,
+    }]);
+});
+
+test('CONVERSATION-TELEMETRY-001 waits for token usage emitted after the resume response', async t => {
+    let notificationListener;
+    const harness = createAdapter(fixture, {
+        client: {
+            watchNotifications(listener) {
+                notificationListener = listener;
+                return { dispose() {} };
+            },
+            async request(method) {
+                if (method === 'thread/resume') {
+                    setImmediate(() => {
+                        notificationListener('thread/tokenUsage/updated', {
+                            threadId: sessionId,
+                            turnId: 'turn-delayed-telemetry',
+                            tokenUsage: {
+                                total: { totalTokens: 96_000 },
+                                last: { totalTokens: 48_000 },
+                                modelContextWindow: 128_000,
+                            },
+                        });
+                    });
+                    return { model: 'gpt-5.6-sol' };
+                }
+                assert.equal(method, 'account/rateLimits/read');
+                return { rateLimits: null, rateLimitsByLimitId: null };
+            },
+            dispose() {},
+        },
+        setTimeout: (callback, delayMs) => setTimeout(callback, delayMs),
+        clearTimeout: handle => clearTimeout(handle),
+    });
+    t.after(() => harness.adapter.dispose());
+
+    const telemetry = await harness.adapter.readTelemetry(sessionId);
+
+    assert.deepEqual(telemetry.context, {
+        usedTokens: 48_000,
+        maxTokens: 128_000,
+    });
+});
+
 test('SESSION-AI-SESSION-CODEX-CONVERSATION-002 starts one interaction per userMessage and attaches agents only to the latest qualifying input', async t => {
     const native = {
         thread: {

--- a/tests/contract/aiSessions/codexConversationAdapter.test.js
+++ b/tests/contract/aiSessions/codexConversationAdapter.test.js
@@ -651,6 +651,156 @@ test('CONVERSATION-TELEMETRY-001 waits for token usage emitted after the resume 
     });
 });
 
+test('CONVERSATION-TELEMETRY-001 isolates delayed token usage by session', async t => {
+    const secondSessionId = '44444444-4444-4444-8444-444444444444';
+    let notificationListener;
+    let nextTimer = 1;
+    const timers = new Map();
+    const harness = createAdapter(fixture, {
+        client: {
+            watchNotifications(listener) {
+                notificationListener = listener;
+                return { dispose() {} };
+            },
+            async request(method, params) {
+                if (method === 'thread/resume') {
+                    return { model: `model-${params.threadId}` };
+                }
+                assert.equal(method, 'account/rateLimits/read');
+                return { rateLimits: null, rateLimitsByLimitId: null };
+            },
+            dispose() {},
+        },
+        setTimeout(callback) {
+            const handle = nextTimer++;
+            timers.set(handle, callback);
+            return handle;
+        },
+        clearTimeout(handle) {
+            timers.delete(handle);
+        },
+    });
+    t.after(() => harness.adapter.dispose());
+
+    let firstSettled = false;
+    const firstRead = harness.adapter.readTelemetry(sessionId)
+        .then(value => {
+            firstSettled = true;
+            return value;
+        });
+    const secondRead = harness.adapter.readTelemetry(secondSessionId);
+    await new Promise(resolve => setImmediate(resolve));
+
+    notificationListener('thread/tokenUsage/updated', {
+        threadId: secondSessionId,
+        tokenUsage: {
+            last: { totalTokens: 22_000 },
+            modelContextWindow: 64_000,
+        },
+    });
+
+    const secondTelemetry = await secondRead;
+    await new Promise(resolve => setImmediate(resolve));
+    assert.equal(firstSettled, false);
+    assert.deepEqual(secondTelemetry.context, {
+        usedTokens: 22_000,
+        maxTokens: 64_000,
+    });
+
+    notificationListener('thread/tokenUsage/updated', {
+        threadId: sessionId,
+        tokenUsage: {
+            last: { totalTokens: 33_000 },
+            modelContextWindow: 128_000,
+        },
+    });
+
+    const firstTelemetry = await firstRead;
+    assert.deepEqual(firstTelemetry.context, {
+        usedTokens: 33_000,
+        maxTokens: 128_000,
+    });
+    assert.equal(timers.size, 0);
+});
+
+test('CONVERSATION-TELEMETRY-001 clears a delayed token usage waiter after timeout', async t => {
+    let nextTimer = 1;
+    const timers = new Map();
+    const cleared = [];
+    const harness = createAdapter(fixture, {
+        client: {
+            async request(method) {
+                if (method === 'thread/resume') {
+                    return { model: 'gpt-5.6-sol' };
+                }
+                assert.equal(method, 'account/rateLimits/read');
+                return { rateLimits: null, rateLimitsByLimitId: null };
+            },
+            dispose() {},
+        },
+        setTimeout(callback, delayMs) {
+            assert.equal(delayMs, 250);
+            const handle = nextTimer++;
+            timers.set(handle, callback);
+            return handle;
+        },
+        clearTimeout(handle) {
+            cleared.push(handle);
+            timers.delete(handle);
+        },
+    });
+    t.after(() => harness.adapter.dispose());
+
+    const read = harness.adapter.readTelemetry(sessionId);
+    await new Promise(resolve => setImmediate(resolve));
+    assert.equal(timers.size, 1);
+    const [handle, fireTimeout] = timers.entries().next().value;
+    fireTimeout();
+
+    const telemetry = await read;
+    assert.equal(telemetry.context, undefined);
+    assert.deepEqual(cleared, [handle]);
+    assert.equal(timers.size, 0);
+    assert.equal(harness.adapter.tokenUsageWaiters.size, 0);
+});
+
+test('CONVERSATION-TELEMETRY-001 dispose releases pending token usage reads without repopulating caches', async () => {
+    let nextTimer = 1;
+    const timers = new Map();
+    const harness = createAdapter(fixture, {
+        client: {
+            async request(method) {
+                if (method === 'thread/resume') {
+                    return { model: 'gpt-5.6-sol' };
+                }
+                assert.equal(method, 'account/rateLimits/read');
+                return { rateLimits: null, rateLimitsByLimitId: null };
+            },
+            dispose() {},
+        },
+        setTimeout(callback) {
+            const handle = nextTimer++;
+            timers.set(handle, callback);
+            return handle;
+        },
+        clearTimeout(handle) {
+            timers.delete(handle);
+        },
+    });
+
+    const read = harness.adapter.readTelemetry(sessionId);
+    await new Promise(resolve => setImmediate(resolve));
+    assert.equal(timers.size, 1);
+
+    harness.adapter.dispose();
+    const telemetry = await read;
+
+    assert.equal(telemetry.model, 'gpt-5.6-sol');
+    assert.equal(timers.size, 0);
+    assert.equal(harness.adapter.tokenUsageWaiters.size, 0);
+    assert.equal(harness.adapter.telemetryCache.size, 0);
+});
+
 test('SESSION-AI-SESSION-CODEX-CONVERSATION-002 starts one interaction per userMessage and attaches agents only to the latest qualifying input', async t => {
     const native = {
         thread: {


### PR DESCRIPTION
## Summary

- prefer the canonical Codex account quota over same-window named model limits
- wait briefly for the matching post-resume token-usage notification so context telemetry is current on the first read
- isolate telemetry waiters by session and close timeout/disposal lifecycle races
- add regression coverage for canonical quota selection, delayed notifications, concurrent sessions, timeout cleanup, and disposal

## Verification

- npm run test:ci:linux
- npm run test:behavior-contracts
- git diff --check
- SKIP_NPM_CI=1 npm run install-local
- verified the installed Agent Pivot runtime bundle matches the packaged VSIX and remains stable for 45 seconds

## Capability audit

- assigned implementation commits to MAIN-AI-SESSION-CONVERSATION-OUTLINE
- advanced audit.head to the final implementation commit

## Skill harvest

None. The existing provider-adapter, regression-testing, worktree, review, and local-install skills already covered the reusable workflow; this task exposed a product race and quota-selection bug rather than a missing workflow rule.