### PR TITLE
refactor(conversation): consolidate the bookmark stack onto the shared mutation pipeline

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -4614,11 +4614,13 @@
     "priority": "P0",
     "status": "automated",
     "owners": [
+      "tests/unit/aiSessions/conversationBookmarkController.test.js",
       "tests/unit/aiSessions/conversationBookmarkStore.test.js",
       "tests/integration/dashboard/conversationViewer.test.js",
       "tests/browser/conversationViewer.test.js"
     ],
     "evidence": [
+      "src/aiSessions/conversation/bookmarkController.ts",
       "src/aiSessions/conversation/bookmarkStore.ts",
       "src/aiSessions/conversation/viewer.ts",
       "src/webview/conversationOutlineScripts.js",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "84daa1256b925387cc57a8d3af4c04c016ad3c5c",
+        "head": "fe9935f1097409d38cb6f6bad191528e83aa4279",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -196,7 +196,8 @@
             "36b4b47320ebcf735f851fcfc7cc49e9ee92db4c",
             "6583e3d30a357c053969e4d5f56a2c9b230cacd2",
             "760884b37442addbbe8d80594f6774de6a7319f2",
-            "42ef83d63ba1a6d647c7f2381cb4757f328181de"
+            "42ef83d63ba1a6d647c7f2381cb4757f328181de",
+            "161ca7e06780c77bf7118db6aebf6bd2d643afdc"
         ]
     },
     "capabilities": [
@@ -1385,7 +1386,12 @@
                 "5ed14daa6020e63af6fc1df2fed6aac3966ef8ba",
                 "89242f82aac8c208a1106bb5ba1202c857fcf123",
                 "1d78d7e8bc5873187fc2e7ad7141115fb4fd401f",
-                "84daa1256b925387cc57a8d3af4c04c016ad3c5c"
+                "84daa1256b925387cc57a8d3af4c04c016ad3c5c",
+                "73a0058ddc44b9f2aa2d0385eebd16b0448ee2f7",
+                "5f9a95076ed5eed5e8ee7d74efddd4cc74a156a2",
+                "5991139966a7f0b24d68e1de3459e4425f04bb03",
+                "fca1c7602d0569b532394ffa92ecf50abe8026f5",
+                "fe9935f1097409d38cb6f6bad191528e83aa4279"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",

--- a/src/aiSessions/conversation/bookmarkController.ts
+++ b/src/aiSessions/conversation/bookmarkController.ts
@@ -1,66 +1,52 @@
 'use strict';
 
-import * as vscode from 'vscode';
 import {
     ConversationBookmarkSnapshot,
     ConversationBookmarkStore,
+    ConversationBookmarkTarget,
     isConversationBookmarkSnapshot,
     MAX_CONVERSATION_BOOKMARKS,
 } from './bookmarkStore';
+import type { CommentErrorCode } from './commentPrimitives';
+import { CommentError } from './commentPrimitives';
+import {
+    QueuedMutationController,
+    QueuedMutationControllerOptions,
+    QueuedMutationResultBase,
+} from './queuedMutationController';
 import type { ConversationOutline } from './types';
 import type { ConversationViewerTarget } from './viewerTarget';
 import type {
     ConversationViewerBookmarkMutationMessage,
 } from './viewerProtocol';
 
-interface ConversationViewerBookmarksResultMessage {
+interface ConversationViewerBookmarksResultMessage
+    extends QueuedMutationResultBase {
     type: 'conversation-viewer-bookmarks-result';
-    version: 1;
-    requestId: string;
-    subscriptionGeneration: number;
-    projectId: string;
-    provider: ConversationViewerTarget['provider'];
-    sessionId: string;
     operation: 'set';
-    success: boolean;
-    revision: number;
     interactionIds: string[];
     error?: 'invalid' | 'stale' | 'failed' | 'limit';
 }
 
-export interface ConversationBookmarkControllerOptions {
+export interface ConversationBookmarkControllerOptions
+    extends QueuedMutationControllerOptions {
     bookmarkStore?: ConversationBookmarkStore;
-    getTarget: () => ConversationViewerTarget | undefined;
-    getSubscriptionGeneration: () => number;
-    getPanel: () => vscode.WebviewPanel | undefined;
     getOutline: () => ConversationOutline | undefined;
-    rebuildLatestDocument: () => void;
 }
 
-export class ConversationBookmarkController {
+export class ConversationBookmarkController extends QueuedMutationController<
+    ConversationBookmarkTarget,
+    ConversationBookmarkSnapshot,
+    ConversationViewerBookmarkMutationMessage,
+    ConversationViewerBookmarksResultMessage
+> {
+    protected readonly options: ConversationBookmarkControllerOptions;
     private interactionIds = new Set<string>();
-    private revision = 0;
-    private operationQueue: Promise<void> = Promise.resolve();
     private mutationsFrozen = false;
-    private readonly settlements =
-        new Map<string, ConversationViewerBookmarksResultMessage>();
 
-    constructor(
-        private readonly options: ConversationBookmarkControllerOptions
-    ) {}
-
-    get snapshot(): ConversationBookmarkSnapshot {
-        return {
-            revision: this.revision,
-            interactionIds: [...this.interactionIds],
-        };
-    }
-
-    reset(): void {
-        this.mutationsFrozen = false;
-        this.interactionIds.clear();
-        this.revision = 0;
-        this.settlements.clear();
+    constructor(options: ConversationBookmarkControllerOptions) {
+        super(options);
+        this.options = options;
     }
 
     async freezeMutations(): Promise<void> {
@@ -68,72 +54,61 @@ export class ConversationBookmarkController {
         await this.drainMutations();
     }
 
-    async drainMutations(): Promise<void> {
-        await this.operationQueue;
+    protected isMutationsFrozen(): boolean {
+        return this.mutationsFrozen;
     }
 
-    enqueue(
-        request: ConversationViewerBookmarkMutationMessage
-    ): Promise<void> {
-        const operation = () => this.handleOperation(request);
-        const queued = this.operationQueue.then(operation, operation);
-        this.operationQueue = queued.catch(() => undefined);
-        return queued;
+    protected readonly resultType: 'conversation-viewer-bookmarks-result'
+        = 'conversation-viewer-bookmarks-result';
+
+    protected getStore(): ConversationBookmarkStore | undefined {
+        return this.options.bookmarkStore;
     }
 
-    async restore(
-        target: ConversationViewerTarget,
-        generation: number
-    ): Promise<void> {
-        if (!this.options.bookmarkStore) {
-            return;
-        }
-        let snapshot: ConversationBookmarkSnapshot;
-        try {
-            snapshot = await this.options.bookmarkStore.load(
-                toBookmarkTarget(target)
-            );
-            if (!isConversationBookmarkSnapshot(snapshot)) {
-                return;
-            }
-        } catch (_error) {
-            return;
-        }
-        if (this.options.getTarget() !== target
-            || this.options.getSubscriptionGeneration() !== generation) {
-            return;
-        }
+    protected toStoreTarget(
+        target: ConversationViewerTarget
+    ): ConversationBookmarkTarget {
+        return {
+            projectId: target.projectId,
+            provider: target.provider,
+            sessionId: target.sessionId,
+        };
+    }
+
+    protected makeError(code: CommentErrorCode): CommentError {
+        return new CommentError(code);
+    }
+
+    protected statePayload(): object {
+        return { interactionIds: [...this.interactionIds] };
+    }
+
+    protected validateRestoredSnapshot(
+        snapshot: ConversationBookmarkSnapshot
+    ): boolean {
+        return isConversationBookmarkSnapshot(snapshot);
+    }
+
+    protected applyRestoredSnapshot(
+        snapshot: ConversationBookmarkSnapshot
+    ): void {
         this.interactionIds = new Set(snapshot.interactionIds);
-        this.revision = snapshot.revision;
     }
 
-    private async handleOperation(
-        request: ConversationViewerBookmarkMutationMessage
+    protected clearState(): void {
+        this.interactionIds.clear();
+        this.mutationsFrozen = false;
+    }
+
+    protected async performRequest(
+        request: ConversationViewerBookmarkMutationMessage,
+        target: ConversationViewerTarget
     ): Promise<void> {
-        const target = this.options.getTarget();
-        if (!target || !this.options.getPanel()) {
-            return;
-        }
-        const settlementKey = getSettlementKey(request);
-        const settled = this.settlements.get(settlementKey);
-        if (settled) {
-            await this.publishSettlement(settled);
-            return;
-        }
-        if (this.mutationsFrozen || !requestTargetsViewer(
-            request,
-            target,
-            this.options.getSubscriptionGeneration()
-        ) || request.expectedRevision !== this.revision) {
-            await this.settleRequest(request, false, 'stale');
-            return;
-        }
         const interactionExists = this.options.getOutline()?.interactions.some(
             interaction => interaction.id === request.payload.interactionId
         ) === true;
         if (!interactionExists) {
-            await this.settleRequest(request, false, 'stale');
-            return;
+            throw new CommentError('stale');
         }
         const next = new Set(this.interactionIds);
         if (request.payload.bookmarked) {
@@ -142,133 +117,32 @@ export class ConversationBookmarkController {
             next.delete(request.payload.interactionId);
         }
         if (next.size > MAX_CONVERSATION_BOOKMARKS) {
-            await this.settleRequest(request, false, 'limit');
-            return;
+            throw new CommentError('limit');
         }
         const changed = next.size !== this.interactionIds.size
             || [...next].some(id => !this.interactionIds.has(id));
+        if (!changed) {
+            // A redundant toggle settles successfully without touching the
+            // persisted snapshot.
+            return;
+        }
         const snapshot = {
-            revision: this.revision + (changed ? 1 : 0),
+            revision: this.revision + 1,
             interactionIds: [...next],
         };
         const previousSnapshot = this.snapshot;
+        await this.persist(target, snapshot);
         try {
-            await this.persist(target, snapshot);
-            if (this.options.getTarget() !== target
-                || this.options.getSubscriptionGeneration()
-                    !== request.subscriptionGeneration
-                || this.revision !== request.expectedRevision) {
-                await this.persist(target, previousSnapshot);
-                throw new Error('stale');
-            }
-            this.interactionIds = next;
-            this.revision = snapshot.revision;
-            await this.settleRequest(request, true);
-        } catch (error) {
-            await this.settleRequest(
-                request,
-                false,
-                error instanceof Error && error.message === 'stale'
-                    ? 'stale'
-                    : 'failed'
+            this.assertUnchanged(
+                target,
+                request.subscriptionGeneration,
+                request.expectedRevision
             );
+        } catch (error) {
+            await this.persist(target, previousSnapshot);
+            throw error;
         }
+        this.interactionIds = next;
+        this.revision = snapshot.revision;
     }
-
-    private async persist(
-        target: ConversationViewerTarget,
-        snapshot: ConversationBookmarkSnapshot
-    ): Promise<void> {
-        if (!this.options.bookmarkStore) {
-            return;
-        }
-        await this.options.bookmarkStore.save(
-            toBookmarkTarget(target),
-            snapshot
-        );
-    }
-
-    private async settleRequest(
-        request: ConversationViewerBookmarkMutationMessage,
-        success: boolean,
-        error?: ConversationViewerBookmarksResultMessage['error']
-    ): Promise<void> {
-        const settlement: ConversationViewerBookmarksResultMessage = {
-            type: 'conversation-viewer-bookmarks-result',
-            version: 1,
-            requestId: request.requestId,
-            subscriptionGeneration: request.subscriptionGeneration,
-            projectId: request.projectId,
-            provider: request.provider,
-            sessionId: request.sessionId,
-            operation: 'set',
-            success,
-            revision: this.revision,
-            interactionIds: [...this.interactionIds],
-            ...(error ? { error } : {}),
-        };
-        this.settlements.set(getSettlementKey(request), settlement);
-        while (this.settlements.size > 100) {
-            const oldest = this.settlements.keys().next().value;
-            if (typeof oldest !== 'string') {
-                break;
-            }
-            this.settlements.delete(oldest);
-        }
-        await this.publishSettlement(settlement);
-    }
-
-    private async publishSettlement(
-        settlement: ConversationViewerBookmarksResultMessage
-    ): Promise<void> {
-        const panel = this.options.getPanel();
-        if (!panel) {
-            return;
-        }
-        let delivered = false;
-        try {
-            delivered = await panel.webview.postMessage(settlement);
-        } catch (_error) {
-            delivered = false;
-        }
-        if (!delivered && this.options.getPanel() === panel) {
-            this.options.rebuildLatestDocument();
-        }
-    }
-}
-
-function toBookmarkTarget(
-    target: ConversationViewerTarget
-): Pick<
-    ConversationViewerTarget,
-    'projectId' | 'provider' | 'sessionId'
-> {
-    return {
-        projectId: target.projectId,
-        provider: target.provider,
-        sessionId: target.sessionId,
-    };
-}
-
-function requestTargetsViewer(
-    request: ConversationViewerBookmarkMutationMessage,
-    target: ConversationViewerTarget,
-    subscriptionGeneration: number
-): boolean {
-    return request.subscriptionGeneration === subscriptionGeneration
-        && request.projectId === target.projectId
-        && request.provider === target.provider
-        && request.sessionId === target.sessionId;
-}
-
-function getSettlementKey(
-    request: ConversationViewerBookmarkMutationMessage
-): string {
-    return [
-        request.subscriptionGeneration,
-        request.projectId,
-        request.provider,
-        request.sessionId,
-        request.requestId,
-    ].join('\u0000');
 }

--- a/src/aiSessions/conversation/bookmarkStore.ts
+++ b/src/aiSessions/conversation/bookmarkStore.ts
@@ -1,13 +1,14 @@
 'use strict';
 
-import { createHash, randomBytes } from 'crypto';
-import * as fs from 'fs';
-import * as path from 'path';
 import type { AiSessionProviderId } from '../../models';
+import {
+    isAiSessionProvider,
+    isBoundedId,
+    isRecord,
+} from './commentPrimitives';
+import { KeyedSnapshotFileStore } from './snapshotFileStore';
 
-const STORE_VERSION = 1;
-const STORE_DIRECTORY = path.join('conversation-bookmarks', 'v1');
-const MAX_SNAPSHOT_BYTES = 256 * 1024;
+const STORE_DIRECTORY = ['conversation-bookmarks', 'v1'].join('/');
 export const MAX_CONVERSATION_BOOKMARKS = 2000;
 
 export interface ConversationBookmarkTarget {
@@ -34,93 +35,43 @@ export interface ConversationBookmarkStore {
 export type ConversationBookmarkRebindCopyResult =
     'copied' | 'source-empty' | 'destination-exists';
 
-interface PersistedConversationBookmarkSnapshot
-    extends ConversationBookmarkSnapshot {
-    version: 1;
-    target: ConversationBookmarkTarget;
-    updatedAt: string;
-}
-
 export class ConversationBookmarkFileStore
-implements ConversationBookmarkStore {
-    private readonly directoryPath: string;
+    extends KeyedSnapshotFileStore<
+        ConversationBookmarkTarget,
+        string,
+        ConversationBookmarkSnapshot
+    >
+    implements ConversationBookmarkStore {
 
     constructor(
         globalStoragePath: string,
-        private readonly now: () => number = () => Date.now()
+        now: () => number = () => Date.now()
     ) {
-        this.directoryPath = path.join(globalStoragePath, STORE_DIRECTORY);
-    }
-
-    async load(
-        target: ConversationBookmarkTarget
-    ): Promise<ConversationBookmarkSnapshot> {
-        if (!isTarget(target)) {
-            return emptySnapshot();
-        }
-        const snapshotPath = this.getSnapshotPath(target);
-        try {
-            const stats = await fs.promises.stat(snapshotPath);
-            if (!stats.isFile() || stats.size > MAX_SNAPSHOT_BYTES) {
-                return emptySnapshot();
-            }
-            const value = JSON.parse(
-                await fs.promises.readFile(snapshotPath, 'utf8')
-            );
-            return isPersistedSnapshot(value, target)
-                ? cloneSnapshot(value)
-                : emptySnapshot();
-        } catch (_error) {
-            return emptySnapshot();
-        }
-    }
-
-    async save(
-        target: ConversationBookmarkTarget,
-        snapshot: ConversationBookmarkSnapshot
-    ): Promise<void> {
-        if (!isTarget(target) || !isSnapshot(snapshot)) {
-            throw new Error('Invalid conversation bookmark snapshot.');
-        }
-        const snapshotPath = this.getSnapshotPath(target);
-        if (snapshot.interactionIds.length === 0) {
-            try {
-                await fs.promises.unlink(snapshotPath);
-            } catch (error) {
-                if (!isFileNotFoundError(error)) {
-                    throw error;
-                }
-            }
-            return;
-        }
-        await fs.promises.mkdir(this.directoryPath, {
-            recursive: true,
-            mode: 0o700,
-        });
-        const persisted: PersistedConversationBookmarkSnapshot = {
-            version: STORE_VERSION,
-            target: { ...target },
-            revision: snapshot.revision,
-            updatedAt: new Date(this.now()).toISOString(),
-            interactionIds: [...snapshot.interactionIds],
-        };
-        const temporaryPath = `${snapshotPath}.${process.pid}.${
-            randomBytes(8).toString('hex')
-        }.tmp`;
-        try {
-            await fs.promises.writeFile(
-                temporaryPath,
-                JSON.stringify(persisted),
-                { encoding: 'utf8', flag: 'wx', mode: 0o600 }
-            );
-            await fs.promises.rename(temporaryPath, snapshotPath);
-        } finally {
-            try {
-                await fs.promises.unlink(temporaryPath);
-            } catch (_error) {
-                // Temporary cleanup must not mask the authoritative result.
-            }
-        }
+        super(globalStoragePath, STORE_DIRECTORY, {
+            isValidTarget: isTarget,
+            targetsMatch: (persisted, target) =>
+                persisted.projectId === target.projectId
+                && persisted.provider === target.provider
+                && persisted.sessionId === target.sessionId,
+            digestIdentity: target => [
+                target.projectId,
+                target.provider,
+                target.sessionId,
+            ],
+            payloadKey: 'interactionIds',
+            itemsOf: snapshot => snapshot.interactionIds,
+            buildSnapshot: (revision, interactionIds) => ({
+                revision,
+                interactionIds,
+            }),
+            validateItems: validateInteractionIds,
+            cloneItems: interactionIds => [...interactionIds],
+            invalidSnapshotMessage:
+                'Invalid conversation bookmark snapshot.',
+            invalidPersistedMessage:
+                'Invalid persisted conversation bookmark snapshot.',
+            maxSnapshotBytes: 256 * 1024,
+        }, now);
     }
 
     async copyForRebind(
@@ -130,143 +81,41 @@ implements ConversationBookmarkStore {
         if (!isValidRebind(previous, next)) {
             throw new Error('Invalid conversation bookmark rebind.');
         }
-        const source = await this.loadForRebind(previous);
+        const source = await this.loadStrict(previous);
         if (source.interactionIds.length === 0) {
             return 'source-empty';
         }
-        return this.saveForRebindIfAbsent(next, source);
-    }
-
-    private async loadForRebind(
-        target: ConversationBookmarkTarget
-    ): Promise<ConversationBookmarkSnapshot> {
-        const snapshotPath = this.getSnapshotPath(target);
-        try {
-            const stats = await fs.promises.stat(snapshotPath);
-            if (!stats.isFile() || stats.size > MAX_SNAPSHOT_BYTES) {
-                throw new Error('Invalid persisted conversation bookmark snapshot.');
-            }
-            const value = JSON.parse(
-                await fs.promises.readFile(snapshotPath, 'utf8')
-            );
-            if (!isPersistedSnapshot(value, target)) {
-                throw new Error('Invalid persisted conversation bookmark snapshot.');
-            }
-            return cloneSnapshot(value);
-        } catch (error) {
-            if (isFileNotFoundError(error)) {
-                return emptySnapshot();
-            }
-            throw new Error('Invalid persisted conversation bookmark snapshot.');
-        }
-    }
-
-    private async saveForRebindIfAbsent(
-        target: ConversationBookmarkTarget,
-        snapshot: ConversationBookmarkSnapshot
-    ): Promise<ConversationBookmarkRebindCopyResult> {
-        const snapshotPath = this.getSnapshotPath(target);
-        await fs.promises.mkdir(this.directoryPath, {
-            recursive: true,
-            mode: 0o700,
-        });
-        const persisted: PersistedConversationBookmarkSnapshot = {
-            version: STORE_VERSION,
-            target: { ...target },
-            revision: snapshot.revision,
-            updatedAt: new Date(this.now()).toISOString(),
-            interactionIds: [...snapshot.interactionIds],
-        };
-        const temporaryPath = `${snapshotPath}.${process.pid}.${
-            randomBytes(8).toString('hex')
-        }.tmp`;
-        try {
-            await fs.promises.writeFile(
-                temporaryPath,
-                JSON.stringify(persisted),
-                { encoding: 'utf8', flag: 'wx', mode: 0o600 }
-            );
-            try {
-                await fs.promises.link(temporaryPath, snapshotPath);
-                return 'copied';
-            } catch (error) {
-                if (isFileExistsError(error)) {
-                    return 'destination-exists';
-                }
-                throw error;
-            }
-        } finally {
-            try {
-                await fs.promises.unlink(temporaryPath);
-            } catch (_error) {
-                // Cleanup must not mask the authoritative link result.
-            }
-        }
-    }
-
-    private getSnapshotPath(target: ConversationBookmarkTarget): string {
-        const identity = JSON.stringify([
-            target.projectId,
-            target.provider,
-            target.sessionId,
-        ]);
-        const digest = createHash('sha256').update(identity).digest('hex');
-        return path.join(this.directoryPath, `${digest}.json`);
+        return this.saveIfAbsent(next, source);
     }
 }
 
 export function isConversationBookmarkSnapshot(
     value: unknown
 ): value is ConversationBookmarkSnapshot {
-    return isSnapshot(value);
+    return isRecord(value)
+        && Number.isSafeInteger(value.revision)
+        && (value.revision as number) >= 0
+        && Array.isArray(value.interactionIds)
+        && isValidInteractionIds(value.interactionIds);
 }
 
-function emptySnapshot(): ConversationBookmarkSnapshot {
-    return { revision: 0, interactionIds: [] };
-}
-
-function cloneSnapshot(
-    snapshot: ConversationBookmarkSnapshot
-): ConversationBookmarkSnapshot {
-    return {
-        revision: snapshot.revision,
-        interactionIds: [...snapshot.interactionIds],
-    };
-}
-
-function isSnapshot(value: unknown): value is ConversationBookmarkSnapshot {
-    if (!isRecord(value)
-        || !Number.isSafeInteger(value.revision)
-        || (value.revision as number) < 0
-        || !Array.isArray(value.interactionIds)
-        || value.interactionIds.length > MAX_CONVERSATION_BOOKMARKS
-        || !value.interactionIds.every(isIdentity)) {
-        return false;
+function validateInteractionIds(items: string[]): void {
+    if (!isValidInteractionIds(items)) {
+        throw new Error('Invalid conversation bookmark snapshot.');
     }
-    return new Set(value.interactionIds).size === value.interactionIds.length;
 }
 
-function isPersistedSnapshot(
-    value: unknown,
-    target: ConversationBookmarkTarget
-): value is PersistedConversationBookmarkSnapshot {
-    if (!isRecord(value)
-        || value.version !== STORE_VERSION
-        || typeof value.updatedAt !== 'string'
-        || !isTarget(value.target)
-        || !isSnapshot(value)) {
-        return false;
-    }
-    return value.target.projectId === target.projectId
-        && value.target.provider === target.provider
-        && value.target.sessionId === target.sessionId;
+function isValidInteractionIds(items: unknown[]): boolean {
+    return items.length <= MAX_CONVERSATION_BOOKMARKS
+        && items.every(item => isBoundedId(item))
+        && new Set(items).size === items.length;
 }
 
 function isTarget(value: unknown): value is ConversationBookmarkTarget {
     return isRecord(value)
-        && isIdentity(value.projectId)
-        && isProvider(value.provider)
-        && isIdentity(value.sessionId);
+        && isBoundedId(value.projectId)
+        && isAiSessionProvider(value.provider)
+        && isBoundedId(value.sessionId);
 }
 
 function isValidRebind(
@@ -278,29 +127,4 @@ function isValidRebind(
         && previous.projectId === next.projectId
         && previous.provider === next.provider
         && previous.sessionId !== next.sessionId;
-}
-
-function isIdentity(value: unknown): value is string {
-    return typeof value === 'string'
-        && value.length > 0
-        && value.length <= 512
-        && !/[\u0000-\u001f\u007f]/.test(value);
-}
-
-function isProvider(value: unknown): value is AiSessionProviderId {
-    return value === 'codex' || value === 'kimi' || value === 'claude';
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-    return Boolean(value)
-        && typeof value === 'object'
-        && !Array.isArray(value);
-}
-
-function isFileNotFoundError(error: unknown): boolean {
-    return Boolean(error && (error as NodeJS.ErrnoException).code === 'ENOENT');
-}
-
-function isFileExistsError(error: unknown): boolean {
-    return Boolean(error && (error as NodeJS.ErrnoException).code === 'EEXIST');
 }

--- a/src/aiSessions/conversation/commentStore.ts
+++ b/src/aiSessions/conversation/commentStore.ts
@@ -8,7 +8,7 @@ import {
 } from './comments';
 import {
     CommentSnapshot,
-    CommentSnapshotFileStore,
+    KeyedSnapshotFileStore,
 } from './snapshotFileStore';
 import {
     isAiSessionProvider,
@@ -35,9 +35,10 @@ export type ConversationCommentRebindCopyResult =
     'copied' | 'source-empty' | 'destination-exists';
 
 export class ConversationCommentFileStore
-    extends CommentSnapshotFileStore<
+    extends KeyedSnapshotFileStore<
         ConversationCommentTarget,
-        ConversationCommentDraft
+        ConversationCommentDraft,
+        ConversationCommentSnapshot
     >
     implements ConversationCommentStore {
 
@@ -56,13 +57,17 @@ export class ConversationCommentFileStore
                 target.provider,
                 target.sessionId,
             ],
-            validateComments: validateConversationComments,
-            cloneComments: cloneConversationComments,
-            normalizeLegacyComments: normalizeLegacyCommentStatuses,
+            payloadKey: 'comments',
+            itemsOf: snapshot => snapshot.comments,
+            buildSnapshot: (revision, comments) => ({ revision, comments }),
+            validateItems: validateConversationComments,
+            cloneItems: cloneConversationComments,
+            normalizeLegacyItems: normalizeLegacyCommentStatuses,
             invalidSnapshotMessage:
                 'Invalid conversation comment snapshot.',
             invalidPersistedMessage:
                 'Invalid persisted conversation comment snapshot.',
+            maxSnapshotBytes: 2 * 1024 * 1024,
         }, now);
     }
 

--- a/src/aiSessions/conversation/projectCommentStore.ts
+++ b/src/aiSessions/conversation/projectCommentStore.ts
@@ -8,7 +8,7 @@ import {
 } from './projectComments';
 import {
     CommentSnapshot,
-    CommentSnapshotFileStore,
+    KeyedSnapshotFileStore,
 } from './snapshotFileStore';
 import {
     isBoundedId,
@@ -28,7 +28,11 @@ export interface ProjectCommentStore {
 }
 
 export class ProjectCommentFileStore
-    extends CommentSnapshotFileStore<ProjectCommentTarget, ProjectComment>
+    extends KeyedSnapshotFileStore<
+        ProjectCommentTarget,
+        ProjectComment,
+        ProjectCommentSnapshot
+    >
     implements ProjectCommentStore {
 
     constructor(
@@ -40,11 +44,15 @@ export class ProjectCommentFileStore
             targetsMatch: (persisted, target) =>
                 persisted.projectId === target.projectId,
             digestIdentity: target => [target.projectId],
-            validateComments: validateProjectComments,
-            cloneComments: cloneProjectComments,
+            payloadKey: 'comments',
+            itemsOf: snapshot => snapshot.comments,
+            buildSnapshot: (revision, comments) => ({ revision, comments }),
+            validateItems: validateProjectComments,
+            cloneItems: cloneProjectComments,
             invalidSnapshotMessage: 'Invalid project comment snapshot.',
             invalidPersistedMessage:
                 'Invalid persisted project comment snapshot.',
+            maxSnapshotBytes: 2 * 1024 * 1024,
         }, now);
     }
 }

--- a/src/aiSessions/conversation/queuedCommentController.ts
+++ b/src/aiSessions/conversation/queuedCommentController.ts
@@ -1,50 +1,34 @@
 'use strict';
 
-import * as vscode from 'vscode';
-import type { AiSessionProviderId } from '../../models';
 import type { CommentErrorCode, CommentStatus } from './commentPrimitives';
 import { CommentError } from './commentPrimitives';
+import {
+    QueuedMutationController,
+    QueuedMutationControllerOptions,
+    QueuedMutationRequestBase,
+    QueuedMutationResultBase,
+} from './queuedMutationController';
 import type { CommentSnapshot } from './snapshotFileStore';
 import type { ConversationViewerTarget } from './viewerTarget';
 
 /**
- * Shared resilience protocol for the comment-stack controllers: serialized
- * operations, optimistic revisions, persist → commit → rollback, idempotent
- * settlements with replay, and a rebuild fallback when the webview goes
- * away. Each stack supplies its model operations through the abstract
+ * Comment-stack specialization of the queued mutation pipeline: adds the
+ * mutate/send choreography (prompt building, done-marking or dispatch
+ * recording, submit rollback, focus-after-send) on top of the shared
+ * serialized operations, optimistic revisions, and idempotent settlements.
+ * Each comment stack supplies its model operations through the abstract
  * hooks; everything else lives here exactly once.
  */
 
-export interface QueuedCommentRequestBase {
-    type: string;
-    version: 1;
-    requestId: string;
-    subscriptionGeneration: number;
-    projectId: string;
-    provider: AiSessionProviderId;
-    sessionId: string;
-    operation: string;
-    expectedRevision: number;
-    payload: unknown;
-}
+export interface QueuedCommentRequestBase extends QueuedMutationRequestBase {}
 
-export interface QueuedCommentResultBase<TComment> {
-    type: string;
-    version: 1;
-    requestId: string;
-    subscriptionGeneration: number;
-    projectId: string;
-    provider: AiSessionProviderId;
-    sessionId: string;
-    operation: string;
-    success: boolean;
-    revision: number;
+export interface QueuedCommentResultBase<TComment>
+    extends QueuedMutationResultBase {
     comments: TComment[];
-    error?: CommentErrorCode;
 }
 
-export interface QueuedCommentControllerOptions {
-    now?: () => number;
+export interface QueuedCommentControllerOptions
+    extends QueuedMutationControllerOptions {
     submitPrompt: (
         target: ConversationViewerTarget,
         prompt: string
@@ -55,18 +39,6 @@ export interface QueuedCommentControllerOptions {
             'projectId' | 'provider' | 'sessionId'
         >
     ) => PromiseLike<void> | Promise<void>;
-    getTarget: () => ConversationViewerTarget | undefined;
-    getSubscriptionGeneration: () => number;
-    getPanel: () => vscode.WebviewPanel | undefined;
-    rebuildLatestDocument: () => void;
-}
-
-interface CommentSnapshotStore<TStoreTarget, TComment> {
-    load(target: TStoreTarget): Promise<CommentSnapshot<TComment>>;
-    save(
-        target: TStoreTarget,
-        snapshot: CommentSnapshot<TComment>
-    ): Promise<void>;
 }
 
 export abstract class QueuedCommentController<
@@ -74,133 +46,73 @@ export abstract class QueuedCommentController<
     TStoreTarget,
     TRequest extends QueuedCommentRequestBase,
     TResult extends QueuedCommentResultBase<TComment>
+> extends QueuedMutationController<
+    TStoreTarget,
+    CommentSnapshot<TComment>,
+    TRequest,
+    TResult
 > {
     private comments: TComment[] = [];
-    private revision = 0;
-    private operationQueue: Promise<void> = Promise.resolve();
-    private readonly settlements = new Map<string, TResult>();
 
     constructor(
         protected readonly options: QueuedCommentControllerOptions
-    ) {}
-
-    protected now(): number {
-        return this.options.now?.() ?? Date.now();
+    ) {
+        super(options);
     }
 
-    get snapshot(): CommentSnapshot<TComment> {
-        return {
-            revision: this.revision,
-            comments: this.cloneComments(this.comments),
-        };
+    /** Read-only view for subclass mutation branches. */
+    protected get currentComments(): readonly TComment[] {
+        return this.comments;
     }
 
-    reset(): void {
+    protected clearState(): void {
         this.comments = [];
-        this.revision = 0;
-        this.settlements.clear();
-        this.onReset();
     }
 
-    async drainMutations(): Promise<void> {
-        await this.operationQueue;
+    protected statePayload(): object {
+        return { comments: this.cloneComments(this.comments) };
     }
 
-    enqueue(request: TRequest): Promise<void> {
-        return this.enqueueTask(() => this.handleOperation(request));
+    protected validateRestoredSnapshot(
+        snapshot: CommentSnapshot<TComment>
+    ): boolean {
+        try {
+            this.validateComments(snapshot.comments);
+            return Number.isSafeInteger(snapshot.revision)
+                && snapshot.revision >= 0;
+        } catch (_error) {
+            return false;
+        }
     }
 
-    /** Serializes an arbitrary task behind the queued mutations. */
-    protected enqueueTask(operation: () => Promise<void>): Promise<void> {
-        const queued = this.operationQueue.then(operation, operation);
-        this.operationQueue = queued.catch(() => undefined);
-        return queued;
+    protected applyRestoredSnapshot(
+        snapshot: CommentSnapshot<TComment>
+    ): void {
+        this.comments = this.cloneComments(snapshot.comments);
     }
 
-    async restore(
+    protected async performRequest(
+        request: TRequest,
         target: ConversationViewerTarget,
         generation: number
     ): Promise<void> {
-        const store = this.getStore();
-        if (!store) {
+        if (this.isSendRequest(request)) {
+            await this.sendComments(
+                target,
+                generation,
+                this.sendCommentId(request)
+            );
             return;
         }
-        let snapshot: CommentSnapshot<TComment>;
-        try {
-            snapshot = await store.load(this.toStoreTarget(target));
-            this.validateComments(snapshot.comments);
-            if (!Number.isSafeInteger(snapshot.revision)
-                || snapshot.revision < 0) {
-                throw this.makeError('invalid');
-            }
-        } catch (_error) {
-            return;
-        }
-        if (this.options.getTarget() !== target
-            || this.options.getSubscriptionGeneration() !== generation) {
-            return;
-        }
-        this.comments = this.cloneComments(snapshot.comments);
-        this.revision = snapshot.revision;
+        await this.mutateComments(request, target, generation);
     }
 
-    private async handleOperation(request: TRequest): Promise<void> {
-        const target = this.options.getTarget();
-        if (!target || !this.options.getPanel()) {
-            return;
-        }
-        const settlementKey = getSettlementKey(request);
-        const settled = this.settlements.get(settlementKey);
-        if (settled) {
-            await this.publishSettlement(
-                settled.operation === request.operation
-                    ? settled
-                    : {
-                        ...settled,
-                        operation: request.operation,
-                        success: false,
-                        revision: this.revision,
-                        comments: this.cloneComments(this.comments),
-                        error: 'invalid',
-                    } as TResult,
-                false
-            );
-            return;
-        }
-        if (this.isMutationsFrozen()
-            || !requestTargetsViewer(
-                request,
-                target,
-                this.options.getSubscriptionGeneration()
-            )
-            || request.expectedRevision !== this.revision) {
-            await this.settleRequest(request, false, 'stale');
-            return;
-        }
-        try {
-            if (this.isSendRequest(request)) {
-                await this.sendComments(
-                    target,
-                    this.options.getSubscriptionGeneration(),
-                    this.sendCommentId(request)
-                );
-            } else {
-                await this.mutateComments(
-                    request,
-                    target,
-                    this.options.getSubscriptionGeneration()
-                );
-            }
-            await this.settleRequest(request, true);
-            if (this.isSendRequest(request)) {
-                await this.focusSessionAfterSend(target);
-            }
-        } catch (error) {
-            await this.settleRequest(
-                request,
-                false,
-                this.toErrorCode(error)
-            );
+    protected async afterSuccessful(
+        request: TRequest,
+        target: ConversationViewerTarget
+    ): Promise<void> {
+        if (this.isSendRequest(request)) {
+            await this.focusSessionAfterSend(target);
         }
     }
 
@@ -224,26 +136,30 @@ export abstract class QueuedCommentController<
         target: ConversationViewerTarget,
         generation: number
     ): Promise<void> {
-        const { comments, changed } = this.applyMutation(request);
-        if (!changed) {
+        const mutation = this.applyMutation(request);
+        if (!mutation.changed) {
             // A no-op mutation (e.g. adding a duplicate tag) still settles
             // successfully, just without touching the persisted snapshot.
             return;
         }
-        const snapshot = { revision: this.revision + 1, comments };
+        const snapshot = {
+            revision: this.revision + 1,
+            comments: mutation.comments,
+        };
         const previousSnapshot = this.snapshot;
         await this.persist(target, snapshot);
         try {
-            this.commitPersisted(
+            this.assertUnchanged(
                 target,
                 generation,
-                request.expectedRevision,
-                snapshot
+                request.expectedRevision
             );
         } catch (error) {
             await this.persist(target, previousSnapshot);
             throw error;
         }
+        this.comments = snapshot.comments;
+        this.revision = snapshot.revision;
     }
 
     private async sendComments(
@@ -268,11 +184,15 @@ export abstract class QueuedCommentController<
             comments: this.buildSendComments(targetComments, target),
         };
         await this.persist(target, sentSnapshot);
-        if (this.options.getTarget() !== target
-            || this.options.getSubscriptionGeneration() !== generation
-            || this.revision !== previousSnapshot.revision) {
+        try {
+            this.assertUnchanged(
+                target,
+                generation,
+                previousSnapshot.revision
+            );
+        } catch (error) {
             await this.persist(target, previousSnapshot);
-            throw this.makeError('stale');
+            throw error;
         }
         try {
             await Promise.resolve(this.options.submitPrompt(
@@ -284,9 +204,7 @@ export abstract class QueuedCommentController<
             // submitPrompt surfaces submission.ts failures; both stacks'
             // error classes share the CommentError base, so user-actionable
             // codes survive the cross-stack hop.
-            throw error instanceof CommentError
-                ? this.makeError(error.code)
-                : this.makeError('failed');
+            throw this.makeError(this.toErrorCode(error));
         }
         if (this.options.getTarget() !== target) {
             throw this.makeError('stale');
@@ -295,119 +213,6 @@ export abstract class QueuedCommentController<
         this.revision = sentSnapshot.revision;
     }
 
-    private async persist(
-        target: ConversationViewerTarget,
-        snapshot: CommentSnapshot<TComment>
-    ): Promise<void> {
-        const store = this.getStore();
-        if (!store) {
-            return;
-        }
-        try {
-            await store.save(this.toStoreTarget(target), snapshot);
-        } catch (_error) {
-            throw this.makeError('failed');
-        }
-    }
-
-    private commitPersisted(
-        target: ConversationViewerTarget,
-        generation: number,
-        expectedRevision: number,
-        snapshot: CommentSnapshot<TComment>
-    ): void {
-        if (this.options.getTarget() !== target
-            || this.options.getSubscriptionGeneration() !== generation
-            || this.revision !== expectedRevision) {
-            throw this.makeError('stale');
-        }
-        this.comments = snapshot.comments;
-        this.revision = snapshot.revision;
-    }
-
-    private async settleRequest(
-        request: TRequest,
-        success: boolean,
-        error?: CommentErrorCode
-    ): Promise<void> {
-        const settlement = {
-            type: this.resultType,
-            version: 1,
-            requestId: request.requestId,
-            subscriptionGeneration: request.subscriptionGeneration,
-            projectId: request.projectId,
-            provider: request.provider,
-            sessionId: request.sessionId,
-            operation: request.operation,
-            success,
-            revision: this.revision,
-            comments: this.cloneComments(this.comments),
-            ...(error ? { error } : {}),
-        } as TResult;
-        this.rememberSettlement(getSettlementKey(request), settlement);
-        await this.publishSettlement(settlement, true);
-    }
-
-    private rememberSettlement(key: string, settlement: TResult): void {
-        this.settlements.set(key, settlement);
-        while (this.settlements.size > 100) {
-            const oldest = this.settlements.keys().next().value;
-            if (typeof oldest !== 'string') {
-                break;
-            }
-            this.settlements.delete(oldest);
-        }
-    }
-
-    protected async publishSettlement(
-        settlement: object,
-        rebuildOnFailure: boolean
-    ): Promise<void> {
-        const panel = this.options.getPanel();
-        if (!panel) {
-            return;
-        }
-        let delivered = false;
-        try {
-            delivered = await panel.webview.postMessage(settlement);
-        } catch (_error) {
-            delivered = false;
-        }
-        if (!delivered
-            && rebuildOnFailure
-            && this.options.getPanel() === panel) {
-            this.options.rebuildLatestDocument();
-        }
-    }
-
-    protected toErrorCode(error: unknown): CommentErrorCode {
-        return error instanceof CommentError
-            ? error.code
-            : 'failed';
-    }
-
-    /** Read-only view for subclass mutation branches. */
-    protected get currentComments(): readonly TComment[] {
-        return this.comments;
-    }
-
-    /** Hook for subclass state cleared alongside the base state. */
-    protected onReset(): void {}
-
-    /** Frozen stacks reject mutations as 'stale' (session rebind windows). */
-    protected isMutationsFrozen(): boolean {
-        return false;
-    }
-
-    protected abstract readonly resultType: TResult['type'];
-
-    protected abstract getStore():
-        CommentSnapshotStore<TStoreTarget, TComment> | undefined;
-
-    protected abstract toStoreTarget(
-        target: ConversationViewerTarget
-    ): TStoreTarget;
-
     protected abstract cloneComments(
         comments: readonly TComment[]
     ): TComment[];
@@ -415,8 +220,6 @@ export abstract class QueuedCommentController<
     protected abstract validateComments(
         comments: readonly TComment[]
     ): void;
-
-    protected abstract makeError(code: CommentErrorCode): CommentError;
 
     protected abstract isSendRequest(request: TRequest): boolean;
 
@@ -441,24 +244,4 @@ export abstract class QueuedCommentController<
         targetComments: readonly TComment[],
         target: ConversationViewerTarget
     ): TComment[];
-}
-
-function requestTargetsViewer(
-    request: QueuedCommentRequestBase,
-    target: ConversationViewerTarget,
-    subscriptionGeneration: number
-): boolean {
-    return request.subscriptionGeneration === subscriptionGeneration
-        && request.projectId === target.projectId
-        && request.provider === target.provider
-        && request.sessionId === target.sessionId;
-}
-
-function getSettlementKey(request: QueuedCommentRequestBase): string {
-    return JSON.stringify([
-        request.projectId,
-        request.provider,
-        request.sessionId,
-        request.requestId,
-    ]);
 }

--- a/src/aiSessions/conversation/queuedMutationController.ts
+++ b/src/aiSessions/conversation/queuedMutationController.ts
@@ -1,0 +1,335 @@
+'use strict';
+
+import * as vscode from 'vscode';
+import type { AiSessionProviderId } from '../../models';
+import type { CommentErrorCode } from './commentPrimitives';
+import { CommentError } from './commentPrimitives';
+import type { ConversationViewerTarget } from './viewerTarget';
+
+/**
+ * Shared mutation pipeline for the viewer state controllers (comments,
+ * workspace notes, bookmarks): serialized operations, optimistic revisions,
+ * idempotent settlements with replay, and a rebuild fallback when the
+ * webview goes away. Each stack owns its state shape and domain operation
+ * through the abstract hooks; everything else lives here exactly once.
+ */
+
+export interface QueuedMutationRequestBase {
+    type: string;
+    version: 1;
+    requestId: string;
+    subscriptionGeneration: number;
+    projectId: string;
+    provider: AiSessionProviderId;
+    sessionId: string;
+    operation: string;
+    expectedRevision: number;
+    payload: unknown;
+}
+
+export interface QueuedMutationResultBase {
+    type: string;
+    version: 1;
+    requestId: string;
+    subscriptionGeneration: number;
+    projectId: string;
+    provider: AiSessionProviderId;
+    sessionId: string;
+    operation: string;
+    success: boolean;
+    revision: number;
+    error?: CommentErrorCode;
+}
+
+export interface QueuedMutationControllerOptions {
+    now?: () => number;
+    getTarget: () => ConversationViewerTarget | undefined;
+    getSubscriptionGeneration: () => number;
+    getPanel: () => vscode.WebviewPanel | undefined;
+    rebuildLatestDocument: () => void;
+}
+
+interface MutationSnapshotStore<TStoreTarget, TSnap> {
+    load(target: TStoreTarget): Promise<TSnap>;
+    save(target: TStoreTarget, snapshot: TSnap): Promise<void>;
+}
+
+export abstract class QueuedMutationController<
+    TStoreTarget,
+    TSnap extends { revision: number },
+    TRequest extends QueuedMutationRequestBase,
+    TResult extends QueuedMutationResultBase
+> {
+    protected revision = 0;
+    private operationQueue: Promise<void> = Promise.resolve();
+    private readonly settlements = new Map<string, TResult>();
+
+    constructor(
+        protected readonly options: QueuedMutationControllerOptions
+    ) {}
+
+    protected now(): number {
+        return this.options.now?.() ?? Date.now();
+    }
+
+    get snapshot(): TSnap {
+        return {
+            revision: this.revision,
+            ...this.statePayload(),
+        } as TSnap;
+    }
+
+    reset(): void {
+        this.revision = 0;
+        this.settlements.clear();
+        this.clearState();
+        this.onReset();
+    }
+
+    async drainMutations(): Promise<void> {
+        await this.operationQueue;
+    }
+
+    enqueue(request: TRequest): Promise<void> {
+        return this.enqueueTask(() => this.handleOperation(request));
+    }
+
+    /** Serializes an arbitrary task behind the queued mutations. */
+    protected enqueueTask(operation: () => Promise<void>): Promise<void> {
+        const queued = this.operationQueue.then(operation, operation);
+        this.operationQueue = queued.catch(() => undefined);
+        return queued;
+    }
+
+    async restore(
+        target: ConversationViewerTarget,
+        generation: number
+    ): Promise<void> {
+        const store = this.getStore();
+        if (!store) {
+            return;
+        }
+        let snapshot: TSnap;
+        try {
+            snapshot = await store.load(this.toStoreTarget(target));
+            if (!this.validateRestoredSnapshot(snapshot)) {
+                return;
+            }
+        } catch (_error) {
+            return;
+        }
+        if (this.options.getTarget() !== target
+            || this.options.getSubscriptionGeneration() !== generation) {
+            return;
+        }
+        this.applyRestoredSnapshot(snapshot);
+        this.revision = snapshot.revision;
+    }
+
+    private async handleOperation(request: TRequest): Promise<void> {
+        const target = this.options.getTarget();
+        if (!target || !this.options.getPanel()) {
+            return;
+        }
+        const settlementKey = getSettlementKey(request);
+        const settled = this.settlements.get(settlementKey);
+        if (settled) {
+            await this.publishSettlement(
+                settled.operation === request.operation
+                    ? settled
+                    : {
+                        ...settled,
+                        operation: request.operation,
+                        success: false,
+                        revision: this.revision,
+                        ...this.statePayload(),
+                        error: 'invalid',
+                    } as TResult,
+                false
+            );
+            return;
+        }
+        if (this.isMutationsFrozen()
+            || !requestTargetsViewer(
+                request,
+                target,
+                this.options.getSubscriptionGeneration()
+            )
+            || request.expectedRevision !== this.revision) {
+            await this.settleRequest(request, false, 'stale');
+            return;
+        }
+        try {
+            await this.performRequest(
+                request,
+                target,
+                this.options.getSubscriptionGeneration()
+            );
+            await this.settleRequest(request, true);
+            await this.afterSuccessful(request, target);
+        } catch (error) {
+            await this.settleRequest(
+                request,
+                false,
+                this.toErrorCode(error)
+            );
+        }
+    }
+
+    /** Persists via the stack store, mapping IO failures to 'failed'. */
+    protected async persist(
+        target: ConversationViewerTarget,
+        snapshot: TSnap
+    ): Promise<void> {
+        const store = this.getStore();
+        if (!store) {
+            return;
+        }
+        try {
+            await store.save(this.toStoreTarget(target), snapshot);
+        } catch (_error) {
+            throw this.makeError('failed');
+        }
+    }
+
+    /**
+     * Post-await commit gate: the target, generation, and revision must not
+     * have moved while the persist was in flight.
+     */
+    protected assertUnchanged(
+        target: ConversationViewerTarget,
+        generation: number,
+        expectedRevision: number
+    ): void {
+        if (this.options.getTarget() !== target
+            || this.options.getSubscriptionGeneration() !== generation
+            || this.revision !== expectedRevision) {
+            throw this.makeError('stale');
+        }
+    }
+
+    private async settleRequest(
+        request: TRequest,
+        success: boolean,
+        error?: CommentErrorCode
+    ): Promise<void> {
+        const settlement = {
+            type: this.resultType,
+            version: 1,
+            requestId: request.requestId,
+            subscriptionGeneration: request.subscriptionGeneration,
+            projectId: request.projectId,
+            provider: request.provider,
+            sessionId: request.sessionId,
+            operation: request.operation,
+            success,
+            revision: this.revision,
+            ...this.statePayload(),
+            ...(error ? { error } : {}),
+        } as TResult;
+        this.rememberSettlement(getSettlementKey(request), settlement);
+        await this.publishSettlement(settlement, true);
+    }
+
+    private rememberSettlement(key: string, settlement: TResult): void {
+        this.settlements.set(key, settlement);
+        while (this.settlements.size > 100) {
+            const oldest = this.settlements.keys().next().value;
+            if (typeof oldest !== 'string') {
+                break;
+            }
+            this.settlements.delete(oldest);
+        }
+    }
+
+    protected async publishSettlement(
+        settlement: object,
+        rebuildOnFailure: boolean
+    ): Promise<void> {
+        const panel = this.options.getPanel();
+        if (!panel) {
+            return;
+        }
+        let delivered = false;
+        try {
+            delivered = await panel.webview.postMessage(settlement);
+        } catch (_error) {
+            delivered = false;
+        }
+        if (!delivered
+            && rebuildOnFailure
+            && this.options.getPanel() === panel) {
+            this.options.rebuildLatestDocument();
+        }
+    }
+
+    protected toErrorCode(error: unknown): CommentErrorCode {
+        return error instanceof CommentError
+            ? error.code
+            : 'failed';
+    }
+
+    /** Hook for subclass state cleared alongside the base state. */
+    protected onReset(): void {}
+
+    /** Frozen stacks reject mutations as 'stale' (session rebind windows). */
+    protected isMutationsFrozen(): boolean {
+        return false;
+    }
+
+    /** Runs after a successful settlement (e.g. focusing a send target). */
+    protected async afterSuccessful(
+        _request: TRequest,
+        _target: ConversationViewerTarget
+    ): Promise<void> {}
+
+    protected abstract readonly resultType: TResult['type'];
+
+    protected abstract getStore():
+        MutationSnapshotStore<TStoreTarget, TSnap> | undefined;
+
+    protected abstract toStoreTarget(
+        target: ConversationViewerTarget
+    ): TStoreTarget;
+
+    protected abstract makeError(code: CommentErrorCode): CommentError;
+
+    /** The state fields embedded in snapshots and result messages. */
+    protected abstract statePayload(): object;
+
+    /** Second-line validation for store-provided snapshots. */
+    protected abstract validateRestoredSnapshot(snapshot: TSnap): boolean;
+
+    /** Adopts the state carried by a snapshot (revision stays with the base). */
+    protected abstract applyRestoredSnapshot(snapshot: TSnap): void;
+
+    /** Clears the subclass-owned state (revision/settlements are the base's). */
+    protected abstract clearState(): void;
+
+    /** The domain operation; failures throw CommentError-coded errors. */
+    protected abstract performRequest(
+        request: TRequest,
+        target: ConversationViewerTarget,
+        generation: number
+    ): Promise<void>;
+}
+
+function requestTargetsViewer(
+    request: QueuedMutationRequestBase,
+    target: ConversationViewerTarget,
+    subscriptionGeneration: number
+): boolean {
+    return request.subscriptionGeneration === subscriptionGeneration
+        && request.projectId === target.projectId
+        && request.provider === target.provider
+        && request.sessionId === target.sessionId;
+}
+
+function getSettlementKey(request: QueuedMutationRequestBase): string {
+    return JSON.stringify([
+        request.projectId,
+        request.provider,
+        request.sessionId,
+        request.requestId,
+    ]);
+}

--- a/src/aiSessions/conversation/snapshotFileStore.ts
+++ b/src/aiSessions/conversation/snapshotFileStore.ts
@@ -5,83 +5,87 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 /**
- * Generic atomic file storage for the comment stacks. Each stack keys
- * snapshots by a target identity (session comments by
- * project+provider+session, workspace notes by project alone) and supplies
- * its own validation/cloning hooks; this class owns the shared persistence
- * protocol: digest-addressed JSON files, size caps, temp-write + rename
- * (or hard-link for create-if-absent), and fail-soft reads.
+ * Generic atomic file storage for keyed viewer state (comments, workspace
+ * notes, bookmarks). Each stack keys snapshots by a target identity and
+ * supplies its own validation/cloning hooks; this class owns the shared
+ * persistence protocol: digest-addressed JSON files, size caps, temp-write +
+ * rename (or hard-link for create-if-absent), and fail-soft reads.
  */
 
 const STORE_VERSION = 1;
-const MAX_SNAPSHOT_BYTES = 2 * 1024 * 1024;
 
+/** The comments-shaped snapshot shared by both comment stacks. */
 export interface CommentSnapshot<TComment> {
     revision: number;
     comments: TComment[];
 }
 
-interface PersistedCommentSnapshot<TTarget, TComment> {
-    version: 1;
-    target: TTarget;
-    revision: number;
-    updatedAt: string;
-    comments: TComment[];
-}
-
-export interface CommentSnapshotStoreHooks<TTarget, TComment> {
+export interface KeyedSnapshotStoreHooks<TTarget, TItem, TSnap> {
     /** Rejects caller-supplied targets before any IO happens. */
     isValidTarget: (value: unknown) => value is TTarget;
     /** The persisted target must match the requested one exactly. */
     targetsMatch: (persisted: TTarget, target: TTarget) => boolean;
     /** Stable identity fields feeding the per-target digest file name. */
     digestIdentity: (target: TTarget) => readonly unknown[];
-    /** Throws when persisted comments fail model validation. */
-    validateComments: (comments: TComment[]) => void;
-    cloneComments: (comments: TComment[]) => TComment[];
+    /** Envelope field carrying the item array ('comments', …). */
+    payloadKey: string;
+    itemsOf: (snapshot: TSnap) => TItem[];
+    buildSnapshot: (revision: number, items: TItem[]) => TSnap;
+    /** Throws when persisted items fail model validation. */
+    validateItems: (items: TItem[]) => void;
+    cloneItems: (items: TItem[]) => TItem[];
     /** In-place migration hook for legacy persisted shapes (optional). */
-    normalizeLegacyComments?: (comments: TComment[]) => void;
+    normalizeLegacyItems?: (items: TItem[]) => void;
     /** Error message used when save() receives an invalid snapshot. */
     invalidSnapshotMessage: string;
     /** Error message used when a strict rebind read hits corruption. */
     invalidPersistedMessage: string;
+    /** Persisted files larger than this are treated as corrupt. */
+    maxSnapshotBytes: number;
 }
 
-export class CommentSnapshotFileStore<TTarget, TComment> {
+export class KeyedSnapshotFileStore<
+    TTarget,
+    TItem,
+    TSnap extends { revision: number }
+> {
     protected readonly directoryPath: string;
 
     constructor(
         globalStoragePath: string,
         storageDirectory: string,
-        protected readonly hooks: CommentSnapshotStoreHooks<TTarget, TComment>,
+        protected readonly hooks: KeyedSnapshotStoreHooks<
+            TTarget,
+            TItem,
+            TSnap
+        >,
         protected readonly now: () => number = () => Date.now()
     ) {
         this.directoryPath = path.join(globalStoragePath, storageDirectory);
     }
 
-    async load(target: TTarget): Promise<CommentSnapshot<TComment>> {
+    async load(target: TTarget): Promise<TSnap> {
         if (!this.hooks.isValidTarget(target)) {
-            return emptySnapshot();
+            return this.hooks.buildSnapshot(0, []);
         }
         try {
             return await this.readPersisted(target);
         } catch {
             // Missing or corrupt snapshots degrade to an empty list; the
             // controller simply starts from a clean revision.
-            return emptySnapshot();
+            return this.hooks.buildSnapshot(0, []);
         }
     }
 
-    async save(
-        target: TTarget,
-        snapshot: CommentSnapshot<TComment>
-    ): Promise<void> {
-        if (!this.hooks.isValidTarget(target) || !isSnapshot(snapshot)) {
+    async save(target: TTarget, snapshot: TSnap): Promise<void> {
+        if (!this.hooks.isValidTarget(target)
+            || !this.isSnapshotShape(snapshot)) {
             throw new Error(this.hooks.invalidSnapshotMessage);
         }
-        this.hooks.validateComments(snapshot.comments);
+        const items = this.hooks.itemsOf(snapshot);
+        this.hooks.validateItems(items);
         const snapshotPath = this.getSnapshotPath(target);
-        if (snapshot.comments.length === 0) {
+        if (items.length === 0) {
             try {
                 await fs.promises.unlink(snapshotPath);
             } catch (error) {
@@ -111,14 +115,12 @@ export class CommentSnapshotFileStore<TTarget, TComment> {
      * Strict read for rebind flows: corruption raises instead of degrading,
      * only a missing file yields the empty snapshot.
      */
-    protected async loadStrict(
-        target: TTarget
-    ): Promise<CommentSnapshot<TComment>> {
+    protected async loadStrict(target: TTarget): Promise<TSnap> {
         try {
             return await this.readPersisted(target);
         } catch (error) {
             if (isFileNotFoundError(error)) {
-                return emptySnapshot();
+                return this.hooks.buildSnapshot(0, []);
             }
             throw new Error(this.hooks.invalidPersistedMessage);
         }
@@ -127,7 +129,7 @@ export class CommentSnapshotFileStore<TTarget, TComment> {
     /** Atomic create-if-absent via hard link; never overwrites. */
     protected async saveIfAbsent(
         target: TTarget,
-        snapshot: CommentSnapshot<TComment>
+        snapshot: TSnap
     ): Promise<'copied' | 'destination-exists'> {
         const snapshotPath = this.getSnapshotPath(target);
         await fs.promises.mkdir(this.directoryPath, {
@@ -160,54 +162,55 @@ export class CommentSnapshotFileStore<TTarget, TComment> {
         return path.join(this.directoryPath, `${digest}.json`);
     }
 
-    private async readPersisted(
-        target: TTarget
-    ): Promise<CommentSnapshot<TComment>> {
+    private async readPersisted(target: TTarget): Promise<TSnap> {
         const snapshotPath = this.getSnapshotPath(target);
         const stats = await fs.promises.stat(snapshotPath);
-        if (!stats.isFile() || stats.size > MAX_SNAPSHOT_BYTES) {
+        if (!stats.isFile() || stats.size > this.hooks.maxSnapshotBytes) {
             throw new Error(this.hooks.invalidPersistedMessage);
         }
         const value: unknown = JSON.parse(
             await fs.promises.readFile(snapshotPath, 'utf8')
         );
-        if (!this.isPersistedSnapshot(value, target)) {
-            throw new Error(this.hooks.invalidPersistedMessage);
-        }
-        this.hooks.normalizeLegacyComments?.(value.comments);
-        this.hooks.validateComments(value.comments);
-        return {
-            revision: value.revision,
-            comments: this.hooks.cloneComments(value.comments),
-        };
-    }
-
-    private isPersistedSnapshot(
-        value: unknown,
-        target: TTarget
-    ): value is PersistedCommentSnapshot<TTarget, TComment> {
         if (!isRecord(value)
             || value.version !== STORE_VERSION
-            || !isSnapshot(value)
             || typeof value.updatedAt !== 'string'
-            || !this.hooks.isValidTarget(value.target)) {
-            return false;
+            || !Number.isSafeInteger(value.revision)
+            || (value.revision as number) < 0
+            || !this.hooks.isValidTarget(value.target)
+            || !this.hooks.targetsMatch(value.target, target)
+            || !Array.isArray(value[this.hooks.payloadKey])) {
+            throw new Error(this.hooks.invalidPersistedMessage);
         }
-        return this.hooks.targetsMatch(value.target, target);
+        const items = value[this.hooks.payloadKey] as TItem[];
+        this.hooks.normalizeLegacyItems?.(items);
+        this.hooks.validateItems(items);
+        return this.hooks.buildSnapshot(
+            value.revision as number,
+            this.hooks.cloneItems(items)
+        );
+    }
+
+    private isSnapshotShape(snapshot: TSnap): boolean {
+        return Boolean(snapshot)
+            && Number.isSafeInteger(snapshot.revision)
+            && snapshot.revision >= 0
+            && Array.isArray(this.hooks.itemsOf(snapshot));
     }
 
     private async writeTemporary(
         target: TTarget,
-        snapshot: CommentSnapshot<TComment>,
+        snapshot: TSnap,
         snapshotPath: string
     ): Promise<string> {
-        const persisted: PersistedCommentSnapshot<TTarget, TComment> = {
+        const persisted: Record<string, unknown> = {
             version: STORE_VERSION,
             target: { ...target },
             revision: snapshot.revision,
             updatedAt: new Date(this.now()).toISOString(),
-            comments: this.hooks.cloneComments(snapshot.comments),
         };
+        persisted[this.hooks.payloadKey] = this.hooks.cloneItems(
+            this.hooks.itemsOf(snapshot)
+        );
         const temporaryPath = `${snapshotPath}.${process.pid}.${
             randomBytes(8).toString('hex')
         }.tmp`;
@@ -229,21 +232,6 @@ export class CommentSnapshotFileStore<TTarget, TComment> {
             }
         }
     }
-}
-
-function emptySnapshot<TComment>(): CommentSnapshot<TComment> {
-    return { revision: 0, comments: [] };
-}
-
-function isSnapshot<TComment>(
-    value: unknown
-): value is CommentSnapshot<TComment> {
-    if (!isRecord(value)) {
-        return false;
-    }
-    return Number.isSafeInteger(value.revision)
-        && (value.revision as number) >= 0
-        && Array.isArray(value.comments);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/tests/unit/aiSessions/conversationBookmarkController.test.js
+++ b/tests/unit/aiSessions/conversationBookmarkController.test.js
@@ -1,0 +1,238 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {
+    ConversationBookmarkController,
+} = require('../../../out/aiSessions/conversation/bookmarkController');
+const {
+    MAX_CONVERSATION_BOOKMARKS,
+} = require('../../../out/aiSessions/conversation/bookmarkStore');
+
+const TARGET = Object.freeze({
+    projectId: 'project-a',
+    provider: 'codex',
+    sessionId: 'session-a',
+});
+
+const OUTLINE = Object.freeze({
+    interactions: [
+        Object.freeze({ id: 'interaction-a' }),
+        Object.freeze({ id: 'interaction-b' }),
+        Object.freeze({ id: 'interaction-extra' }),
+    ],
+});
+
+function createHarness(overrides = {}) {
+    const posted = [];
+    const saved = [];
+    const store = {
+        load: async () => ({ revision: 0, interactionIds: [] }),
+        save: async (target, snapshot) => {
+            saved.push({ target, snapshot });
+        },
+    };
+    const controller = new ConversationBookmarkController({
+        bookmarkStore: store,
+        getTarget: () => TARGET,
+        getSubscriptionGeneration: () => 7,
+        getPanel: () => ({
+            webview: {
+                postMessage: async message => {
+                    posted.push(message);
+                    return true;
+                },
+            },
+        }),
+        getOutline: () => OUTLINE,
+        rebuildLatestDocument: () => undefined,
+        ...overrides,
+    });
+    return { controller, posted, saved };
+}
+
+function mutation(requestId, interactionId, bookmarked, expectedRevision, generation = 7) {
+    return {
+        type: 'conversation-viewer-bookmark-mutation',
+        version: 1,
+        requestId,
+        subscriptionGeneration: generation,
+        ...TARGET,
+        operation: 'set',
+        expectedRevision,
+        payload: { interactionId, bookmarked },
+    };
+}
+
+test('CONVERSATION-OUTLINE-BOOKMARKS-001 toggles bookmarks host-side with revision bumps', async () => {
+    const { controller, posted, saved } = createHarness();
+
+    await controller.enqueue(mutation('req-add', 'interaction-a', true, 0));
+    let settlement = posted.at(-1);
+    assert.equal(settlement.type, 'conversation-viewer-bookmarks-result');
+    assert.equal(settlement.operation, 'set');
+    assert.equal(settlement.requestId, 'req-add');
+    assert.equal(settlement.subscriptionGeneration, 7);
+    assert.equal(settlement.projectId, TARGET.projectId);
+    assert.equal(settlement.success, true);
+    assert.equal(settlement.revision, 1);
+    assert.deepEqual(settlement.interactionIds, ['interaction-a']);
+    assert.equal(saved.length, 1);
+    assert.deepEqual(saved[0].snapshot, {
+        revision: 1,
+        interactionIds: ['interaction-a'],
+    });
+
+    await controller.enqueue(mutation('req-add-2', 'interaction-b', true, 1));
+    assert.equal(posted.at(-1).revision, 2);
+    assert.deepEqual(controller.snapshot.interactionIds.sort(), [
+        'interaction-a',
+        'interaction-b',
+    ]);
+
+    await controller.enqueue(mutation('req-remove', 'interaction-a', false, 2));
+    settlement = posted.at(-1);
+    assert.equal(settlement.success, true);
+    assert.equal(settlement.revision, 3);
+    assert.deepEqual(settlement.interactionIds, ['interaction-b']);
+    assert.equal(saved.length, 3);
+});
+
+test('CONVERSATION-OUTLINE-BOOKMARKS-001 rejects stale revisions and unknown interactions without persisting', async () => {
+    const { controller, posted, saved } = createHarness();
+
+    await controller.enqueue(mutation('req-stale', 'interaction-a', true, 4));
+    assert.deepEqual(
+        {
+            success: posted.at(-1).success,
+            error: posted.at(-1).error,
+        },
+        { success: false, error: 'stale' }
+    );
+    assert.equal(saved.length, 0);
+    assert.equal(controller.snapshot.revision, 0);
+
+    await controller.enqueue(mutation('req-unknown', 'interaction-missing', true, 0));
+    assert.equal(posted.at(-1).success, false);
+    assert.equal(posted.at(-1).error, 'stale');
+    assert.equal(saved.length, 0);
+});
+
+test('CONVERSATION-OUTLINE-BOOKMARKS-001 replays the cached settlement for a repeated request', async () => {
+    const { controller, posted, saved } = createHarness();
+
+    await controller.enqueue(mutation('req-once', 'interaction-a', true, 0));
+    assert.equal(saved.length, 1);
+
+    await controller.enqueue(mutation('req-once', 'interaction-a', true, 0));
+    assert.equal(saved.length, 1);
+    assert.equal(posted.length, 2);
+    assert.deepEqual(posted[1], posted[0]);
+    assert.equal(controller.snapshot.revision, 1);
+});
+
+test('CONVERSATION-OUTLINE-BOOKMARKS-001 replays the true outcome for a cross-generation repeat', async () => {
+    // Settlement keys ignore the subscription generation: a retried request
+    // gets the result of the work that actually ran, and the webview drops
+    // stale-generation messages on its own.
+    const { controller, posted, saved } = createHarness();
+
+    await controller.enqueue(mutation('req-retry', 'interaction-a', true, 0));
+    await controller.enqueue(mutation('req-retry', 'interaction-a', true, 0, 8));
+    assert.equal(saved.length, 1);
+    assert.equal(posted.length, 2);
+    assert.equal(posted[1].success, true);
+    assert.equal(posted[1].subscriptionGeneration, 7);
+});
+
+test('CONVERSATION-OUTLINE-BOOKMARKS-001 enforces the bookmark budget', async () => {
+    const existing = Array.from(
+        { length: MAX_CONVERSATION_BOOKMARKS },
+        (_unused, index) => `interaction-${index}`
+    );
+    const { controller, posted, saved } = createHarness({
+        bookmarkStore: {
+            load: async () => ({
+                revision: 3,
+                interactionIds: existing,
+            }),
+            save: async () => undefined,
+        },
+    });
+
+    await controller.restore(TARGET, 7);
+    assert.equal(controller.snapshot.revision, 3);
+    assert.equal(
+        controller.snapshot.interactionIds.length,
+        MAX_CONVERSATION_BOOKMARKS
+    );
+
+    await controller.enqueue(
+        mutation('req-overflow', 'interaction-extra', true, 3)
+    );
+    assert.equal(posted.at(-1).success, false);
+    assert.equal(posted.at(-1).error, 'limit');
+    assert.equal(saved.length, 0);
+});
+
+test('CONVERSATION-OUTLINE-BOOKMARKS-001 settles frozen mutations as stale until reset', async () => {
+    const { controller, posted, saved } = createHarness();
+
+    await controller.freezeMutations();
+    await controller.enqueue(mutation('req-frozen', 'interaction-a', true, 0));
+    assert.equal(posted.at(-1).success, false);
+    assert.equal(posted.at(-1).error, 'stale');
+    assert.equal(saved.length, 0);
+
+    controller.reset();
+    await controller.enqueue(mutation('req-thawed', 'interaction-a', true, 0));
+    assert.equal(posted.at(-1).success, true);
+    assert.equal(controller.snapshot.revision, 1);
+});
+
+test('CONVERSATION-OUTLINE-BOOKMARKS-001 restores only for the live target and generation', async () => {
+    const stored = { revision: 5, interactionIds: ['interaction-a'] };
+    const { controller } = createHarness({
+        bookmarkStore: {
+            load: async () => stored,
+            save: async () => undefined,
+        },
+    });
+
+    await controller.restore(TARGET, 8);
+    assert.equal(controller.snapshot.revision, 0);
+
+    await controller.restore(TARGET, 7);
+    assert.equal(controller.snapshot.revision, 5);
+    assert.deepEqual(controller.snapshot.interactionIds, ['interaction-a']);
+});
+
+test('CONVERSATION-OUTLINE-BOOKMARKS-001 settles redundant toggles without persisting', async () => {
+    const { controller, posted, saved } = createHarness();
+
+    await controller.enqueue(mutation('req-add', 'interaction-a', true, 0));
+    assert.equal(saved.length, 1);
+
+    await controller.enqueue(mutation('req-again', 'interaction-a', true, 1));
+    const settlement = posted.at(-1);
+    assert.equal(settlement.success, true);
+    assert.equal(settlement.revision, 1);
+    assert.equal(saved.length, 1);
+});
+
+test('CONVERSATION-OUTLINE-BOOKMARKS-001 maps persistence failures to failed without touching state', async () => {
+    const { controller, posted } = createHarness({
+        bookmarkStore: {
+            load: async () => ({ revision: 0, interactionIds: [] }),
+            save: async () => {
+                throw new Error('disk full');
+            },
+        },
+    });
+
+    await controller.enqueue(mutation('req-io', 'interaction-a', true, 0));
+    assert.equal(posted.at(-1).success, false);
+    assert.equal(posted.at(-1).error, 'failed');
+    assert.equal(controller.snapshot.revision, 0);
+    assert.deepEqual(controller.snapshot.interactionIds, []);
+});


### PR DESCRIPTION
## Summary

Follow-up to #173: the bookmark stack was the third instance of the same queue/settlement/persist pattern and is now migrated onto the shared modules built there. Pure internal consolidation — no user-visible change.

- `snapshotFileStore.ts` is generalized on the payload shape (`payloadKey`/`itemsOf`/`buildSnapshot`/`maxSnapshotBytes` hooks), and `bookmarkStore.ts` becomes a thin wrapper (306 → ~110 lines). The on-disk format (`conversation-bookmarks/v1`, `interactionIds` field) is unchanged — zero migration.
- New `queuedMutationController.ts` extracts the mid-level pipeline shared by all three viewer-state controllers: serialized operation queue, optimistic revisions, idempotent settlements with replay, persist/commit gate helpers, and the rebuild-on-undeliverable fallback. `QueuedCommentController` was re-based onto it with behavior preserved point-for-point, and `bookmarkController.ts` was migrated (274 → ~160 lines).
- Three latent edge inconsistencies aligned to the comment stacks' semantics, each pinned by a unit test: settlement keys no longer include the subscription generation (a cross-generation retry now replays the true outcome instead of `stale`; the webview drops stale-generation messages on its own), redundant bookmark toggles settle successfully without rewriting identical bytes to disk, and replayed settlements no longer re-trigger a document rebuild on delivery failure (the original publish already attempted it).
- First dedicated unit suite for the bookmark controller (9 tests: toggle flow, stale defense, replay, budget limit, freeze/reset, restore gating, no-op persistence skip, IO failure mapping), registered as an owner of `CONVERSATION-OUTLINE-BOOKMARKS-001`.
- Public API surface unchanged: viewer.ts, composition.ts, dashboard.ts, and sessionRebindCoordinator.ts required no edits.

## Skill harvest

no skill change — this cycle's friction (an `Array.every(fn)` arity trap caught immediately by the store tests, and a JSON contract-file reformat that was reverted in favor of surgical edits) was reviewed against the decision standard: both are one-off items already guarded by existing checks. Recorded as `Skill-Harvest: none` in the capability audit commit (8b1ff5e).

## Verification

- `npm run test-compile`; unit **674/674** (665 + 9 new); integration **385/385**; browser **162/162**; `lint:ci`; `test:behavior-contracts`; `brand:check`; coverage baselines (`test:coverage:ci`, changed-line coverage 96.71%).
- Capability audit regenerated and green (`8b1ff5e`); all five implementation commits assigned to `MAIN-AI-SESSION-CONVERSATION-OUTLINE`.
- Packaged and installed locally (`SKIP_NPM_CI=1 npm run install-local`, byte-verified) and accepted through a manual regression pass (bookmarks, both comment stacks).
