### PR TITLE
fix: resolve relative Kimi Shell cd targets for telemetry worktree branches

### DIFF
--- a/.skills/developing-provider-conversation-adapters/SKILL.md
+++ b/.skills/developing-provider-conversation-adapters/SKILL.md
@@ -37,7 +37,7 @@ Green self-authored fixtures alone are not evidence.
 
 | Provider | Session source | Subagents |
 |---|---|---|
-| Kimi | `<kimiHome>/sessions/<workdirHash>/<sessionUuid>/wire.jsonl` | `<sessionDir>/subagents/<id>/{meta.json,wire.jsonl}`; meta carries explicit `status` + `created_at` |
+| Kimi | `<kimiHome>/sessions/<workdirHash>/<sessionUuid>/wire.jsonl` | `<sessionDir>/subagents/<id>/{meta.json,wire.jsonl}`; meta carries explicit `status` + `created_at`. The Shell tool is **stateless per command** — every invocation runs with `cwd = session.work_dir` (kimi_cli/tools/shell source), so relative `cd` targets resolve against the session workdir, not the previous command |
 | Claude | `<claudeHome>/projects/<slug>/<sessionId>.jsonl` | `<slug>/<sessionId>/subagents/agent-<id>.{jsonl,meta.json}`, flat across spawnDepths; meta has `agentType`/`description`/`spawnDepth`/`toolUseId` but **no status** — infer from the transcript tail plus mtime; SendMessage resumes arrive as `origin.kind === 'coordinator'` user records |
 | Codex | rollout JSONL under `<codexHome>/sessions/YYYY/MM/DD/`; conversation content is app-server-only (`thread/read`) | Independent rollout files per thread; `session_meta.payload.source.subagent.thread_spawn` carries `parent_thread_id`/`depth`/`agent_nickname`/`agent_path`; discovery scans first lines by parent id; `thread/read` accepts subagent thread ids (verified 0.146); no userMessage in subagent threads — seed the dispatch interaction from metadata; status = last `event_msg` is `task_complete` → finished, else mtime freshness |
 

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "e39d410b1108687c831625d421ee91b0571aeed4",
+        "head": "710fc3d55d5221efd9b54119d578acbee5bce268",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -208,7 +208,8 @@
             "e6ba1a9d2f63ed31e1661c5149d616794917763e",
             "2ce7a7af019d282760c493c8fad6132dd384749e",
             "4485a481c37e1ffb4e0bdb1c90a5d2f3345d35b9",
-            "7d090329a20a7f4be0c39b136d97ed6db791e29d"
+            "7d090329a20a7f4be0c39b136d97ed6db791e29d",
+            "64d6790871e820ef61fa93712cbde016a0a49f78"
         ]
     },
     "capabilities": [
@@ -1427,7 +1428,8 @@
                 "1291f7f81814caf7ad14935c53b49e144fdd8e1d",
                 "96d19ea4aaf1d2ff39610559a885394354c92ac8",
                 "c7bf0efc7972f6b7ebf55888c2353f9cef162e76",
-                "58d8ce053961e9897b25bb389e66e04ff46b4a9a"
+                "58d8ce053961e9897b25bb389e66e04ff46b4a9a",
+                "710fc3d55d5221efd9b54119d578acbee5bce268"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",

--- a/src/aiSessions/conversation/kimiAdapter.ts
+++ b/src/aiSessions/conversation/kimiAdapter.ts
@@ -74,15 +74,37 @@ const MAX_LISTED_SUBAGENTS = 64;
 const SUBAGENT_DIRECTORY_PATTERN = /^[0-9a-z][0-9a-z-]{0,63}$/i;
 const SUBAGENT_RUNNING_FRESHNESS_MS = 5 * 60 * 1000;
 
-function extractShellWorkingDirectories(value: string): string[] {
+function extractShellWorkingDirectories(
+    value: string,
+    baseCwd?: string
+): string[] {
     const paths = new Set<string>();
     const pattern = new RegExp(SHELL_CD_PATTERN.source, 'g');
     let match: RegExpExecArray | null;
+    // The Shell tool runs every command with cwd = session work_dir, so a
+    // relative cd resolves against the session directory; within one
+    // command, each resolved cd becomes the base for the next.
+    let base = baseCwd;
     while ((match = pattern.exec(value)) !== null) {
         const candidate = match[1] || match[2] || match[3] || '';
-        if (candidate.startsWith('/') && candidate.length <= 1024) {
-            paths.add(candidate);
+        if (!candidate
+            || candidate.startsWith('~')
+            || candidate.includes('$')) {
+            continue;
         }
+        let resolved: string;
+        if (candidate.startsWith('/')) {
+            resolved = candidate;
+        } else if (base) {
+            resolved = path.resolve(base, candidate);
+        } else {
+            continue;
+        }
+        if (resolved.length > 1024) {
+            continue;
+        }
+        paths.add(resolved);
+        base = resolved;
     }
     return Array.from(paths);
 }
@@ -935,7 +957,8 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                             if (typeof args?.command === 'string') {
                                 telemetryPaths.push(
                                     ...extractShellWorkingDirectories(
-                                        args.command
+                                        args.command,
+                                        effectiveCandidate.cwd
                                     )
                                 );
                                 if (telemetryPaths.length

--- a/tests/contract/aiSessions/kimiConversationAdapter.test.js
+++ b/tests/contract/aiSessions/kimiConversationAdapter.test.js
@@ -1754,6 +1754,79 @@ test('CONVERSATION-TELEMETRY-001 Kimi resolves the worktree from Shell cwd signa
     assert.deepEqual(calls, ['/repo/.worktree/feat']);
 });
 
+test('CONVERSATION-TELEMETRY-001 Kimi resolves relative Shell cd targets against the session working directory', async t => {
+    const source = await createFixture(t);
+    source.cwd = '/repo';
+    const calls = [];
+    const adapter = createAdapter(source, {
+        resolveWorktree: async candidate => {
+            calls.push(candidate);
+            return candidate === '/repo/.worktree/feat-x'
+                ? {
+                    branch: 'feat-x',
+                    worktreeRoot: candidate,
+                    repoRoot: '/repo',
+                }
+                : candidate === '/repo'
+                    ? {
+                        branch: 'main',
+                        worktreeRoot: '/repo',
+                        repoRoot: '/repo',
+                    }
+                    : undefined;
+        },
+    });
+    t.after(() => adapter.dispose());
+
+    await fs.promises.appendFile(source.sourcePath, [
+        JSON.stringify({
+            timestamp: 5000,
+            message: {
+                type: 'ToolCall',
+                payload: {
+                    type: 'function',
+                    id: 'Shell_rel_1',
+                    function: {
+                        name: 'Shell',
+                        arguments: JSON.stringify({
+                            command: 'cd .worktree/feat-x && npm test',
+                        }),
+                    },
+                },
+            },
+        }),
+        JSON.stringify({
+            timestamp: 6000,
+            message: {
+                type: 'ToolCall',
+                payload: {
+                    type: 'function',
+                    id: 'Shell_rel_2',
+                    function: {
+                        name: 'Shell',
+                        arguments: JSON.stringify({
+                            // Unresolvable forms must not corrupt the base.
+                            command: 'cd ~ && cd "$SOME_DIR" && cd .worktree/feat-y',
+                        }),
+                    },
+                },
+            },
+        }),
+        '',
+    ].join('\n'));
+
+    const telemetry = await adapter.readTelemetry(sessionId);
+    assert.equal(
+        telemetry.worktree?.branch,
+        'feat-x',
+        'the newest resolvable relative-cd worktree wins'
+    );
+    assert.deepEqual(calls.filter(candidate => candidate.includes('feat')), [
+        '/repo/.worktree/feat-y',
+        '/repo/.worktree/feat-x',
+    ]);
+});
+
 test('CONVERSATION-TELEMETRY-001 Kimi falls back to the Session working directory when no Shell command changes cwd', async t => {
     const source = await createFixture(t);
     source.cwd = '/repo/.worktree/session-cwd';


### PR DESCRIPTION
## Summary

A Kimi session operating in a worktree via `cd .worktree/...` showed the launch repo's branch (`main`) in the conversation telemetry forever. Root cause: the Shell `cd` mining only kept **absolute** targets, silently dropping every relative one. Verified against the installed kimi-cli source that the Shell tool is stateless per command (`cwd = session.work_dir`), so relative targets now resolve against the session working directory, chaining within a single command; `~` and `$VAR` forms stay unresolvable by design.

Also verified the other providers do **not** share the bug: Claude's per-record `cwd` follows the persistent shell (verified end-to-end on a real worktree session, resolves the worktree branch), and Codex reads explicit absolute `workdir` fields from exec records.

## Test plan

- [x] RED-first contract test (relative cd dropped → `main`), then GREEN
- [x] Newest-resolvable-wins fallthrough pinned (deleted newest worktree → next mined path)
- [x] Compiled adapter + real git resolver against the reported session: now resolves `fix/marketplace-compliance`
- [x] unit 686 / contract 783 / integration 387 / browser 170
- [x] `lint:ci`, `brand:check`, behavior contracts + capability audit
- [x] local install byte-verified

Contract: `CONVERSATION-TELEMETRY-001`.

## Skill harvest

Updated `.skills/developing-provider-conversation-adapters`: the Kimi Shell tool is stateless per command (cwd = session work_dir, source-verified) — durable provider knowledge for any future cwd-dependent parsing.