### PR TITLE
chore: drop untracked-reference demo GIF and dead ignore rule

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -23,7 +23,6 @@ scripts/**
 gulpfile.js
 .gitignore
 tsconfig.json
-vsc-extension-quickstart.md
 tslint.json
 media/*.scss
 media/brand/**

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "8470896ecde82f785aca2a3d7a162469d877bc59",
+        "head": "572a9293a28af431fe3b0183bb1cabf388545463",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -213,7 +213,8 @@
             "5348ef6c217420e10150822131825f8abcdf5aa0",
             "cacb7f7ae16ff0f11d795ffc48bf15723719a718",
             "bf0633a753faa53f9e4fef4367f79c3d6298ae4b",
-            "faad172f4700a6bc0620533b7b4f45a51f95bfd9"
+            "faad172f4700a6bc0620533b7b4f45a51f95bfd9",
+            "3d7f71f3683aa7608f8180e8cf68766a16a7b23d"
         ]
     },
     "capabilities": [
@@ -646,7 +647,8 @@
                 "b543c8a0cd382a7c27f75884d0c052f7ec66017c",
                 "494b642991deff266711535360d90b206be0bc65",
                 "99721ef4650fc87fa1612a869f21aa8c30ec9988",
-                "6a8a277c9a61a30d1200b67bed75c66ade8819ad"
+                "6a8a277c9a61a30d1200b67bed75c66ade8819ad",
+                "572a9293a28af431fe3b0183bb1cabf388545463"
             ],
             "behaviors": [
                 "RELEASE-VSIX-PACKAGING-001",


### PR DESCRIPTION
## Summary

Repository hygiene cleanup, no behavior changes:

- Remove `agent-pivot-demo.gif` (34.6 MB) — tracked in git but referenced nowhere (README, docs, package.json, workflows all clean), so every clone paid for an unused asset. The VSIX already excluded it via the `*.gif` rule.
- Remove the dead `vsc-extension-quickstart.md` rule from `.vscodeignore` — the file no longer exists.

## Skill harvest

no skill change — the failure this round was an Agent-side shell mistake (a pipe masked a failing check's exit code before a push), which .skills/review-fix-commit-loop already calls out explicitly; no instruction gap.

## Verification

- `node scripts/check-brand-identity.js` — passed.
- `npm run test:release-packaging` — passed against the real VSIX archives (entry list unchanged apart from nothing shipping the GIF before either).
- `npm run test:behavior-contracts` — passed after the capability audit commit.
