### PR TITLE
fix: reveal the focused sidebar session card when session focus changes

### DIFF
--- a/.skills/installing-vscode-extensions-locally/SKILL.md
+++ b/.skills/installing-vscode-extensions-locally/SKILL.md
@@ -125,5 +125,6 @@ Always tell the user:
 - Do not claim that the current VSIX was installed without ID/version and
   representative hash comparison against the active Server installation.
 - Do not claim install success from packaging success alone.
+- Parallel agent sessions installing the same extension version race on the live extensions directory: an `install-local` from another worktree can overwrite every installed byte seconds after a verified install, and each installer's own byte verification still passes. Immediately before reporting an install as ready for user verification, re-hash the task-critical installed files (the changed runtime or webview bundle) against the VSIX; on mismatch, reinstall and re-verify instead of trusting the earlier success.
 - Do not skip the repo's packaging script in favor of a generic VSIX command unless the repo lacks one.
 - Do not run bare `npx gulp` to rebuild webview assets (SCSS or `src/webview` copies): the default development mode starts watchers and never exits. Use `npx gulp --production` for one-shot builds, matching `vscode:prepublish`.

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -3952,6 +3952,20 @@
     ]
   },
   {
+    "id": "ACTIVE-SESSION-FOCUS-REVEAL-001",
+    "domain": "webview",
+    "title": "Sidebar reveals the focused Active Session card whenever session focus changes",
+    "priority": "P0",
+    "status": "automated",
+    "owners": [
+      "tests/browser/activeSessionCardInteraction.test.js"
+    ],
+    "evidence": [
+      "src/webview/webviewAiSessionViewStateScripts.js",
+      "src/webview/webviewWorkspaceUpdateScripts.js"
+    ]
+  },
+  {
     "id": "WEBVIEW-PROJECTS-PANEL-SCROLL-001",
     "domain": "webview",
     "title": "Required Projects panel replacement preserves semantic group-list and Dashboard positions",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "9217c9f1d43c84bde18849cf6bf12d8836c589c3",
+        "head": "680cda193f6fb74064502fe463da5fb9b5154251",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -215,7 +215,8 @@
             "bf0633a753faa53f9e4fef4367f79c3d6298ae4b",
             "faad172f4700a6bc0620533b7b4f45a51f95bfd9",
             "3d7f71f3683aa7608f8180e8cf68766a16a7b23d",
-            "160b46b2f8686f4a36817b97a15291ee23c0e226"
+            "160b46b2f8686f4a36817b97a15291ee23c0e226",
+            "58c5275d06effcf3088c87eb0934fed80c7d0af1"
         ]
     },
     "capabilities": [
@@ -460,14 +461,16 @@
                 "6ac51dfaaa47830413615bc260b6c39840c8dd96",
                 "edf561e5d8404b0620e9b744c6d5b0bbb48ba936",
                 "6b1d7d6b074fef459a085181c4cc5f16b955831b",
-                "d2b9b3ad677d546a781265603fad088101616133"
+                "d2b9b3ad677d546a781265603fad088101616133",
+                "680cda193f6fb74064502fe463da5fb9b5154251"
             ],
             "behaviors": [
                 "WEBVIEW-CURRENT-WORKSPACE-RENDERING-001",
                 "WEBVIEW-SHARED-CARD-STATE-001",
                 "CUSTOM-RUNNING-IMAGE-001",
                 "CUSTOM-RUNNING-IMAGE-RESOLVER-001",
-                "WEBVIEW-AI-SESSION-LIST-SCROLL-001"
+                "WEBVIEW-AI-SESSION-LIST-SCROLL-001",
+                "ACTIVE-SESSION-FOCUS-REVEAL-001"
             ],
             "prGates": [
                 "test:deterministic:run",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "680cda193f6fb74064502fe463da5fb9b5154251",
+        "head": "e3bbf75c4999c83b4c775cc317f9f6b1d180e9a1",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -216,7 +216,8 @@
             "faad172f4700a6bc0620533b7b4f45a51f95bfd9",
             "3d7f71f3683aa7608f8180e8cf68766a16a7b23d",
             "160b46b2f8686f4a36817b97a15291ee23c0e226",
-            "58c5275d06effcf3088c87eb0934fed80c7d0af1"
+            "58c5275d06effcf3088c87eb0934fed80c7d0af1",
+            "fc2b8cc3ee49ac2d7f16c61155cdb40310a6e0a0"
         ]
     },
     "capabilities": [
@@ -653,7 +654,8 @@
                 "99721ef4650fc87fa1612a869f21aa8c30ec9988",
                 "6a8a277c9a61a30d1200b67bed75c66ade8819ad",
                 "572a9293a28af431fe3b0183bb1cabf388545463",
-                "9217c9f1d43c84bde18849cf6bf12d8836c589c3"
+                "9217c9f1d43c84bde18849cf6bf12d8836c589c3",
+                "e3bbf75c4999c83b4c775cc317f9f6b1d180e9a1"
             ],
             "behaviors": [
                 "RELEASE-VSIX-PACKAGING-001",

--- a/media/webviewAiSessionViewStateScripts.js
+++ b/media/webviewAiSessionViewStateScripts.js
@@ -55,6 +55,7 @@ function focusAiSessionConversationOrigin(message) {
         if (header && typeof header.focus === 'function') {
             header.focus({ preventScroll: true });
         }
+        row.scrollIntoView({ block: 'nearest' });
         if (header && document.activeElement === header) {
             return true;
         }
@@ -156,10 +157,22 @@ function restoreAiSessionListAnchor(list, anchor) {
     });
 }
 
+function getFocusedAiSessionCardIdentity(projectDiv) {
+    if (!projectDiv || typeof projectDiv.querySelector !== 'function') return null;
+    var row = projectDiv.querySelector(
+        '.codex-session-row[data-session-focused][data-session-provider][data-session-id]'
+    );
+    return row ? {
+        provider: row.getAttribute('data-session-provider') || '',
+        sessionId: row.getAttribute('data-session-id') || '',
+    } : null;
+}
+
 function captureAiSessionViewState(projectDiv) {
     var activeList = projectDiv.querySelector('.ai-session-active-panel .codex-sessions-list');
     var historyList = projectDiv.querySelector('.ai-session-history-panel .codex-sessions-list');
     var focused = typeof document !== 'undefined' ? document.activeElement : null;
+    var focusedSession = getFocusedAiSessionCardIdentity(projectDiv);
     var focusedInside = focused && typeof focused.closest === 'function' && focused.closest('.project[data-id]') === projectDiv;
     var focusedRow = focusedInside ? focused.closest('.codex-session-row') : null;
     var focusedTab = focusedInside ? focused.closest('[data-ai-session-tab]') : null;
@@ -176,6 +189,7 @@ function captureAiSessionViewState(projectDiv) {
         pendingCount: projectDiv.querySelectorAll('.active-ai-session-row[data-session-pending]').length,
         activeCount: projectDiv.querySelectorAll('.active-ai-session-row[data-session-active]').length,
         restoreFocus: !!focusedInside,
+        focusedSession: focusedSession,
         focusedTab: focusedTab && focusedTab.getAttribute('data-ai-session-tab'),
         focusedRow: focusedRow ? {
             provider: focusedRow.getAttribute('data-session-provider') || '',
@@ -219,6 +233,33 @@ function restoreAiSessionViewState(projectDiv, viewState, requestedTab, options)
         restoreAiSessionViewFocus(projectDiv, viewState, selectedTab);
     }
     return selectedTab;
+}
+
+function revealChangedFocusedAiSessionCard(root, states) {
+    if (!root || typeof root.querySelectorAll !== 'function'
+        || !states || typeof states.get !== 'function') return;
+    root.querySelectorAll('.workspace-card[data-current-workspace][data-id]').forEach(projectDiv => {
+        var state = states.get(projectDiv.getAttribute('data-id'));
+        var previous = state && state.view ? state.view.focusedSession : null;
+        var row = projectDiv.querySelector(
+            '.ai-session-active-panel .codex-session-row[data-session-focused]'
+            + '[data-session-provider][data-session-id]'
+        );
+        if (!row) return;
+        var provider = row.getAttribute('data-session-provider') || '';
+        var sessionId = row.getAttribute('data-session-id') || '';
+        if (previous && previous.provider === provider && previous.sessionId === sessionId) {
+            return;
+        }
+        // Session focus moved to this card during the authoritative refresh:
+        // surface it instead of preserving the stale scroll position.
+        var panel = row.closest('[data-ai-session-panel]');
+        if (panel && panel.hidden) {
+            selectAiSessionTabDom(projectDiv, 'active');
+            writeAiSessionTabState(window.vscode, projectDiv.getAttribute('data-id'), 'active');
+        }
+        row.scrollIntoView({ block: 'nearest' });
+    });
 }
 
 function captureAiSessionProviderMenuState(projectDiv) {

--- a/media/webviewDashboardBundle.js
+++ b/media/webviewDashboardBundle.js
@@ -137,6 +137,7 @@ function focusAiSessionConversationOrigin(message) {
         if (header && typeof header.focus === 'function') {
             header.focus({ preventScroll: true });
         }
+        row.scrollIntoView({ block: 'nearest' });
         if (header && document.activeElement === header) {
             return true;
         }
@@ -238,10 +239,22 @@ function restoreAiSessionListAnchor(list, anchor) {
     });
 }
 
+function getFocusedAiSessionCardIdentity(projectDiv) {
+    if (!projectDiv || typeof projectDiv.querySelector !== 'function') return null;
+    var row = projectDiv.querySelector(
+        '.codex-session-row[data-session-focused][data-session-provider][data-session-id]'
+    );
+    return row ? {
+        provider: row.getAttribute('data-session-provider') || '',
+        sessionId: row.getAttribute('data-session-id') || '',
+    } : null;
+}
+
 function captureAiSessionViewState(projectDiv) {
     var activeList = projectDiv.querySelector('.ai-session-active-panel .codex-sessions-list');
     var historyList = projectDiv.querySelector('.ai-session-history-panel .codex-sessions-list');
     var focused = typeof document !== 'undefined' ? document.activeElement : null;
+    var focusedSession = getFocusedAiSessionCardIdentity(projectDiv);
     var focusedInside = focused && typeof focused.closest === 'function' && focused.closest('.project[data-id]') === projectDiv;
     var focusedRow = focusedInside ? focused.closest('.codex-session-row') : null;
     var focusedTab = focusedInside ? focused.closest('[data-ai-session-tab]') : null;
@@ -258,6 +271,7 @@ function captureAiSessionViewState(projectDiv) {
         pendingCount: projectDiv.querySelectorAll('.active-ai-session-row[data-session-pending]').length,
         activeCount: projectDiv.querySelectorAll('.active-ai-session-row[data-session-active]').length,
         restoreFocus: !!focusedInside,
+        focusedSession: focusedSession,
         focusedTab: focusedTab && focusedTab.getAttribute('data-ai-session-tab'),
         focusedRow: focusedRow ? {
             provider: focusedRow.getAttribute('data-session-provider') || '',
@@ -301,6 +315,33 @@ function restoreAiSessionViewState(projectDiv, viewState, requestedTab, options)
         restoreAiSessionViewFocus(projectDiv, viewState, selectedTab);
     }
     return selectedTab;
+}
+
+function revealChangedFocusedAiSessionCard(root, states) {
+    if (!root || typeof root.querySelectorAll !== 'function'
+        || !states || typeof states.get !== 'function') return;
+    root.querySelectorAll('.workspace-card[data-current-workspace][data-id]').forEach(projectDiv => {
+        var state = states.get(projectDiv.getAttribute('data-id'));
+        var previous = state && state.view ? state.view.focusedSession : null;
+        var row = projectDiv.querySelector(
+            '.ai-session-active-panel .codex-session-row[data-session-focused]'
+            + '[data-session-provider][data-session-id]'
+        );
+        if (!row) return;
+        var provider = row.getAttribute('data-session-provider') || '';
+        var sessionId = row.getAttribute('data-session-id') || '';
+        if (previous && previous.provider === provider && previous.sessionId === sessionId) {
+            return;
+        }
+        // Session focus moved to this card during the authoritative refresh:
+        // surface it instead of preserving the stale scroll position.
+        var panel = row.closest('[data-ai-session-panel]');
+        if (panel && panel.hidden) {
+            selectAiSessionTabDom(projectDiv, 'active');
+            writeAiSessionTabState(window.vscode, projectDiv.getAttribute('data-id'), 'active');
+        }
+        row.scrollIntoView({ block: 'nearest' });
+    });
 }
 
 function captureAiSessionProviderMenuState(projectDiv) {
@@ -464,6 +505,7 @@ function applyWorkspaceUpdate(message, options) {
             && options.canRestoreAiSessionProviderMenu(projectId)
     );
     restoreCurrentWorkspaceAiSessionAnchorsAndFocus(replacement, aiSessionStates);
+    revealChangedFocusedAiSessionCard(replacement, aiSessionStates);
     if (typeof window.__agentPivotSyncCollapseButton === 'function') {
         window.__agentPivotSyncCollapseButton();
     }
@@ -650,6 +692,7 @@ function applyOpenWorkspacesUpdate(message) {
     }
     restoreCurrentWorkspaceAiSessionViewStates(wrapper, aiSessionStates);
     restoreCurrentWorkspaceAiSessionAnchorsAndFocus(wrapper, aiSessionStates);
+    revealChangedFocusedAiSessionCard(wrapper, aiSessionStates);
     reconcilePendingOpenWorkspacePins(wrapper);
     var restoredPinButton = focusedPinButton
         ? findOpenWorkspacePinButton(focusedPinButton, wrapper)

--- a/media/webviewWorkspaceUpdateScripts.js
+++ b/media/webviewWorkspaceUpdateScripts.js
@@ -57,6 +57,7 @@ function applyWorkspaceUpdate(message, options) {
             && options.canRestoreAiSessionProviderMenu(projectId)
     );
     restoreCurrentWorkspaceAiSessionAnchorsAndFocus(replacement, aiSessionStates);
+    revealChangedFocusedAiSessionCard(replacement, aiSessionStates);
     if (typeof window.__agentPivotSyncCollapseButton === 'function') {
         window.__agentPivotSyncCollapseButton();
     }
@@ -243,6 +244,7 @@ function applyOpenWorkspacesUpdate(message) {
     }
     restoreCurrentWorkspaceAiSessionViewStates(wrapper, aiSessionStates);
     restoreCurrentWorkspaceAiSessionAnchorsAndFocus(wrapper, aiSessionStates);
+    revealChangedFocusedAiSessionCard(wrapper, aiSessionStates);
     reconcilePendingOpenWorkspacePins(wrapper);
     var restoredPinButton = focusedPinButton
         ? findOpenWorkspacePinButton(focusedPinButton, wrapper)

--- a/src/webview/webviewAiSessionViewStateScripts.js
+++ b/src/webview/webviewAiSessionViewStateScripts.js
@@ -55,6 +55,7 @@ function focusAiSessionConversationOrigin(message) {
         if (header && typeof header.focus === 'function') {
             header.focus({ preventScroll: true });
         }
+        row.scrollIntoView({ block: 'nearest' });
         if (header && document.activeElement === header) {
             return true;
         }
@@ -156,10 +157,22 @@ function restoreAiSessionListAnchor(list, anchor) {
     });
 }
 
+function getFocusedAiSessionCardIdentity(projectDiv) {
+    if (!projectDiv || typeof projectDiv.querySelector !== 'function') return null;
+    var row = projectDiv.querySelector(
+        '.codex-session-row[data-session-focused][data-session-provider][data-session-id]'
+    );
+    return row ? {
+        provider: row.getAttribute('data-session-provider') || '',
+        sessionId: row.getAttribute('data-session-id') || '',
+    } : null;
+}
+
 function captureAiSessionViewState(projectDiv) {
     var activeList = projectDiv.querySelector('.ai-session-active-panel .codex-sessions-list');
     var historyList = projectDiv.querySelector('.ai-session-history-panel .codex-sessions-list');
     var focused = typeof document !== 'undefined' ? document.activeElement : null;
+    var focusedSession = getFocusedAiSessionCardIdentity(projectDiv);
     var focusedInside = focused && typeof focused.closest === 'function' && focused.closest('.project[data-id]') === projectDiv;
     var focusedRow = focusedInside ? focused.closest('.codex-session-row') : null;
     var focusedTab = focusedInside ? focused.closest('[data-ai-session-tab]') : null;
@@ -176,6 +189,7 @@ function captureAiSessionViewState(projectDiv) {
         pendingCount: projectDiv.querySelectorAll('.active-ai-session-row[data-session-pending]').length,
         activeCount: projectDiv.querySelectorAll('.active-ai-session-row[data-session-active]').length,
         restoreFocus: !!focusedInside,
+        focusedSession: focusedSession,
         focusedTab: focusedTab && focusedTab.getAttribute('data-ai-session-tab'),
         focusedRow: focusedRow ? {
             provider: focusedRow.getAttribute('data-session-provider') || '',
@@ -219,6 +233,33 @@ function restoreAiSessionViewState(projectDiv, viewState, requestedTab, options)
         restoreAiSessionViewFocus(projectDiv, viewState, selectedTab);
     }
     return selectedTab;
+}
+
+function revealChangedFocusedAiSessionCard(root, states) {
+    if (!root || typeof root.querySelectorAll !== 'function'
+        || !states || typeof states.get !== 'function') return;
+    root.querySelectorAll('.workspace-card[data-current-workspace][data-id]').forEach(projectDiv => {
+        var state = states.get(projectDiv.getAttribute('data-id'));
+        var previous = state && state.view ? state.view.focusedSession : null;
+        var row = projectDiv.querySelector(
+            '.ai-session-active-panel .codex-session-row[data-session-focused]'
+            + '[data-session-provider][data-session-id]'
+        );
+        if (!row) return;
+        var provider = row.getAttribute('data-session-provider') || '';
+        var sessionId = row.getAttribute('data-session-id') || '';
+        if (previous && previous.provider === provider && previous.sessionId === sessionId) {
+            return;
+        }
+        // Session focus moved to this card during the authoritative refresh:
+        // surface it instead of preserving the stale scroll position.
+        var panel = row.closest('[data-ai-session-panel]');
+        if (panel && panel.hidden) {
+            selectAiSessionTabDom(projectDiv, 'active');
+            writeAiSessionTabState(window.vscode, projectDiv.getAttribute('data-id'), 'active');
+        }
+        row.scrollIntoView({ block: 'nearest' });
+    });
 }
 
 function captureAiSessionProviderMenuState(projectDiv) {

--- a/src/webview/webviewWorkspaceUpdateScripts.js
+++ b/src/webview/webviewWorkspaceUpdateScripts.js
@@ -57,6 +57,7 @@ function applyWorkspaceUpdate(message, options) {
             && options.canRestoreAiSessionProviderMenu(projectId)
     );
     restoreCurrentWorkspaceAiSessionAnchorsAndFocus(replacement, aiSessionStates);
+    revealChangedFocusedAiSessionCard(replacement, aiSessionStates);
     if (typeof window.__agentPivotSyncCollapseButton === 'function') {
         window.__agentPivotSyncCollapseButton();
     }
@@ -243,6 +244,7 @@ function applyOpenWorkspacesUpdate(message) {
     }
     restoreCurrentWorkspaceAiSessionViewStates(wrapper, aiSessionStates);
     restoreCurrentWorkspaceAiSessionAnchorsAndFocus(wrapper, aiSessionStates);
+    revealChangedFocusedAiSessionCard(wrapper, aiSessionStates);
     reconcilePendingOpenWorkspacePins(wrapper);
     var restoredPinButton = focusedPinButton
         ? findOpenWorkspacePinButton(focusedPinButton, wrapper)

--- a/tests/browser/activeSessionCardInteraction.test.js
+++ b/tests/browser/activeSessionCardInteraction.test.js
@@ -209,6 +209,18 @@ async function relativeTop(locator) {
     }, '.codex-sessions-list');
 }
 
+async function isRowFullyVisibleInList(rowLocator) {
+    return rowLocator.evaluate(node => {
+        const list = node.closest('.codex-sessions-list');
+        if (!list || node.offsetParent === null) return false;
+        const listRect = list.getBoundingClientRect();
+        const rowRect = node.getBoundingClientRect();
+        return rowRect.height > 0
+            && rowRect.top >= listRect.top - 1
+            && rowRect.bottom <= listRect.bottom + 1;
+    });
+}
+
 function documentMarkup(activeAiSessions) {
     return `<!doctype html>
         <html>
@@ -360,6 +372,66 @@ test('WEBVIEW-AI-SESSION-LIST-SCROLL-001 preserves semantic Active and History a
     assert.ok(Math.abs((await relativeTop(historyRestored)) - historyBefore) <= 1);
     assert.equal(await page.locator('[data-ai-session-tab="sessions"]').getAttribute('aria-selected'), 'true');
     assert.equal(await historyRestored.locator('.ai-session-primary-action').evaluate(node => document.activeElement === node), true);
+});
+
+test('ACTIVE-SESSION-FOCUS-REVEAL-001 reveals the newly focused card when a workspace or open-workspaces refresh moves focus', async t => {
+    const active = Array.from({ length: 8 }, (_, index) => session(
+        'codex', `active-${index + 1}`, index === 0
+    ));
+    const history = Array.from({ length: 8 }, (_, index) =>
+        historySession('codex', `history-${index + 1}`)
+    );
+    const page = await openListPage(t, active, history);
+    await waitForPageCondition(page, () => {
+        const list = document.querySelector('[data-ai-session-panel="active"] .codex-sessions-list');
+        return list && list.scrollHeight > list.clientHeight;
+    });
+    assert.equal(await isRowFullyVisibleInList(row(page, 'codex', 'active-7')), false);
+
+    await postListWorkspaceUpdate(page, active.map((entry, index) => ({
+        ...entry,
+        focused: index === 6,
+    })), history);
+    assert.equal(await isRowFullyVisibleInList(row(page, 'codex', 'active-7')), true);
+
+    await page.locator('[data-ai-session-tab="sessions"]').click();
+    assert.equal(
+        await page.locator('[data-ai-session-tab="sessions"]').getAttribute('aria-selected'),
+        'true'
+    );
+    await postListOpenWorkspacesUpdate(page, active.map((entry, index) => ({
+        ...entry,
+        focused: index === 1,
+    })), history);
+    assert.equal(
+        await page.locator('[data-ai-session-tab="active"]').getAttribute('aria-selected'),
+        'true'
+    );
+    assert.equal(await isRowFullyVisibleInList(row(page, 'codex', 'active-2')), true);
+});
+
+test('ACTIVE-SESSION-FOCUS-REVEAL-001 scrolls the origin card into view when conversation focus returns to the sidebar', async t => {
+    const active = Array.from({ length: 8 }, (_, index) => session(
+        'codex', `active-${index + 1}`, index === 6
+    ));
+    const history = Array.from({ length: 8 }, (_, index) =>
+        historySession('codex', `history-${index + 1}`)
+    );
+    const page = await openListPage(t, active, history);
+    await waitForPageCondition(page, () => {
+        const list = document.querySelector('[data-ai-session-panel="active"] .codex-sessions-list');
+        return list && list.scrollHeight > list.clientHeight;
+    });
+    assert.equal(await isRowFullyVisibleInList(row(page, 'codex', 'active-7')), false);
+
+    await postHostMessage(page, focusOrigin({ sessionId: 'active-7' }));
+    assert.equal(
+        await row(page, 'codex', 'active-7')
+            .locator('.ai-session-primary-action')
+            .evaluate(header => document.activeElement === header),
+        true
+    );
+    assert.equal(await isRowFullyVisibleInList(row(page, 'codex', 'active-7')), true);
 });
 
 test('ACTIVE-SESSION-CONVERSATION-OPEN-001 click focuses an unfocused card and opens the conversation for a focused card', async t => {


### PR DESCRIPTION
## Summary

Reported behavior: switching the focused AI Conversation by any method left the dashboard sidebar's Active Sessions list at its previous scroll position, so the newly focused card could stay clipped inside the bounded list (only ~3 cards visible).

Root cause: every focus-switch entry point ends in an authoritative re-render whose anchor preservation deliberately keeps list scroll positions, and the conversation-origin handler focused the card header with `preventScroll: true` — no path ever scrolled the focused card into view.

Fix (webview-only, minimal):

- `captureAiSessionViewState` now also captures the focused card identity per project.
- New `revealChangedFocusedAiSessionCard` runs after anchor restoration in both workspace replacement paths (`applyWorkspaceUpdate`, also covering `ai-sessions-updated`, and `applyOpenWorkspacesUpdate`): only when the focused identity **changed**, it reselects the Active tab when that panel is hidden (persisting the tab choice) and `scrollIntoView({ block: 'nearest' })` the focused card.
- `focusAiSessionConversationOrigin` (conversation viewer close → sidebar refocus) now scrolls the origin card into view after its `preventScroll` header focus.

Focus switches covered uniformly: sidebar card click, attention queue jump (Ctrl+Alt+A), running session jump, viewer previous/next navigation, direct terminal focus, and conversation viewer close. Routine refreshes with unchanged focus keep the preserved anchors exactly as before (WEBVIEW-AI-SESSION-LIST-SCROLL-001 stays green).

## Verification

- RED: two new `ACTIVE-SESSION-FOCUS-REVEAL-001` browser tests failed on the unfixed code for exactly the reported symptom (focused card stays clipped after a workspace/open-workspaces refresh moves focus; origin card stays clipped after the origin message). Mutation check: disabling the open-workspaces hook re-breaks the second half of the first test.
- GREEN: focused file 7/7; full browser suite 174/174; dashboard integration 393/393; `test:behavior-contracts`, `lint:ci`, dashboard webview checks all pass.
- `npm run test:ci:linux` green end to end (including release packaging).
- Packaged and installed locally (`agent-pivot-1.0.4.vsix`); installed bundle byte-verified against the VSIX; user confirmed the fix in a real window.

## Skill harvest

updated:.skills/installing-vscode-extensions-locally — during installation a parallel session's `install-local` overwrote the freshly installed same-version extension seconds later; recorded the concurrent same-version install race pitfall with a re-verify-before-reporting guard (repositorySkills.test.js green).