### PR TITLE
feat: add AI session quick switching and harden conversation navigation

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -797,6 +797,24 @@
     ]
   },
   {
+    "id": "AI-SESSION-QUICK-SWITCH-COMMANDS-001",
+    "domain": "session",
+    "title": "The Switch to AI Session picker lists every live local session most-recently-focused first plus one entry per other window with running sessions, jumping locally with terminal focus and conversation open or handing off through the focus mailbox with plain-navigation degradation, while Toggle Last AI Session alternates the two most recently focused local sessions from a terminal-focus-fed MRU that prunes dead sessions, and both commands are contributed without default keybindings",
+    "priority": "P1",
+    "status": "automated",
+    "owners": [
+      "tests/contract/aiSessions/sessionQuickSwitch.test.js",
+      "tests/contract/dashboardBoundaries.test.js"
+    ],
+    "evidence": [
+      "src/aiSessions/sessionMru.ts",
+      "src/dashboard/sessionQuickSwitch.ts",
+      "src/dashboard.ts",
+      "src/dashboard/commandRegistration.ts",
+      "package.json"
+    ]
+  },
+  {
     "id": "OPEN-WORKSPACE-RUNNING-FOCUS-PROTOCOL-001",
     "domain": "open-project",
     "title": "Running focus hand-off requests are strictly validated one-shot mailbox records with bounded leases and correlated outcomes",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "2390fc13ca86aeadd6c470a92bbff673855f4310",
+        "head": "17cf2c716dbf8b28e2f95c5f6a5de1dc14452c68",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -219,7 +219,8 @@
             "58c5275d06effcf3088c87eb0934fed80c7d0af1",
             "fc2b8cc3ee49ac2d7f16c61155cdb40310a6e0a0",
             "88cfcc74c32df5df8f48ee7b1a6e9f5bdd53d72f",
-            "3f4a0156aac342b9602427fa40113d067012f54c"
+            "3f4a0156aac342b9602427fa40113d067012f54c",
+            "fa9df64a1fce021e5c49516c40213c63c7fa01f7"
         ]
     },
     "capabilities": [
@@ -1457,7 +1458,8 @@
                 "58d8ce053961e9897b25bb389e66e04ff46b4a9a",
                 "710fc3d55d5221efd9b54119d578acbee5bce268",
                 "b012cd88e557d70cc0d459727c71cccbc4acc3f8",
-                "2390fc13ca86aeadd6c470a92bbff673855f4310"
+                "2390fc13ca86aeadd6c470a92bbff673855f4310",
+                "17cf2c716dbf8b28e2f95c5f6a5de1dc14452c68"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "e3bbf75c4999c83b4c775cc317f9f6b1d180e9a1",
+        "head": "0eec5f1fdac5105b1a6139eb2125d565860ec16f",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -217,7 +217,8 @@
             "3d7f71f3683aa7608f8180e8cf68766a16a7b23d",
             "160b46b2f8686f4a36817b97a15291ee23c0e226",
             "58c5275d06effcf3088c87eb0934fed80c7d0af1",
-            "fc2b8cc3ee49ac2d7f16c61155cdb40310a6e0a0"
+            "fc2b8cc3ee49ac2d7f16c61155cdb40310a6e0a0",
+            "88cfcc74c32df5df8f48ee7b1a6e9f5bdd53d72f"
         ]
     },
     "capabilities": [
@@ -1678,8 +1679,13 @@
             "id": "MAIN-AI-SESSION-QUICK-SWITCH",
             "title": "AI session quick switch and MRU toggle",
             "requirement": "The Switch to AI Session picker lists every live local session most-recently-focused first plus one entry per other window with running sessions, jumping locally with terminal focus and conversation open or handing off through the focus mailbox with plain-navigation degradation, and Toggle Last AI Session alternates the two most recently focused local sessions from a terminal-focus-fed MRU that prunes dead sessions.",
-            "commits": [],
-            "behaviors": [],
+            "commits": [
+                "4b7095d337d022973fa0d90926ae1ba6f795eca1",
+                "0eec5f1fdac5105b1a6139eb2125d565860ec16f"
+            ],
+            "behaviors": [
+                "AI-SESSION-QUICK-SWITCH-COMMANDS-001"
+            ],
             "prGates": [
                 "test:deterministic:run"
             ],

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -1673,6 +1673,18 @@
             ],
             "scheduledJobs": [],
             "realEnvironmentRequired": false
+        },
+        {
+            "id": "MAIN-AI-SESSION-QUICK-SWITCH",
+            "title": "AI session quick switch and MRU toggle",
+            "requirement": "The Switch to AI Session picker lists every live local session most-recently-focused first plus one entry per other window with running sessions, jumping locally with terminal focus and conversation open or handing off through the focus mailbox with plain-navigation degradation, and Toggle Last AI Session alternates the two most recently focused local sessions from a terminal-focus-fed MRU that prunes dead sessions.",
+            "commits": [],
+            "behaviors": [],
+            "prGates": [
+                "test:deterministic:run"
+            ],
+            "scheduledJobs": [],
+            "realEnvironmentRequired": false
         }
     ]
 }

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "0eec5f1fdac5105b1a6139eb2125d565860ec16f",
+        "head": "2390fc13ca86aeadd6c470a92bbff673855f4310",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -218,7 +218,8 @@
             "160b46b2f8686f4a36817b97a15291ee23c0e226",
             "58c5275d06effcf3088c87eb0934fed80c7d0af1",
             "fc2b8cc3ee49ac2d7f16c61155cdb40310a6e0a0",
-            "88cfcc74c32df5df8f48ee7b1a6e9f5bdd53d72f"
+            "88cfcc74c32df5df8f48ee7b1a6e9f5bdd53d72f",
+            "3f4a0156aac342b9602427fa40113d067012f54c"
         ]
     },
     "capabilities": [
@@ -1455,7 +1456,8 @@
                 "c7bf0efc7972f6b7ebf55888c2353f9cef162e76",
                 "58d8ce053961e9897b25bb389e66e04ff46b4a9a",
                 "710fc3d55d5221efd9b54119d578acbee5bce268",
-                "b012cd88e557d70cc0d459727c71cccbc4acc3f8"
+                "b012cd88e557d70cc0d459727c71cccbc4acc3f8",
+                "2390fc13ca86aeadd6c470a92bbff673855f4310"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",

--- a/package.json
+++ b/package.json
@@ -115,6 +115,14 @@
                 "title": "Agent Pivot: Next Running Session"
             },
             {
+                "command": "agentPivot.switchToAiSession",
+                "title": "Agent Pivot: Switch to AI Session"
+            },
+            {
+                "command": "agentPivot.toggleLastAiSession",
+                "title": "Agent Pivot: Toggle Last AI Session"
+            },
+            {
                 "command": "agentPivot.notify.setWebhook",
                 "title": "Agent Pivot: Set Notification Webhook"
             },

--- a/scripts/run-dashboard-webview-checks.js
+++ b/scripts/run-dashboard-webview-checks.js
@@ -3720,6 +3720,8 @@ async function runDashboardCommandRegistrationChecks() {
         'nextActiveSession',
         'nextAttentionSession',
         'nextRunningSession',
+        'switchToAiSession',
+        'toggleLastAiSession',
         'switchToOpenWindow',
     ];
     const registration = new DashboardCommandRegistration({
@@ -3752,6 +3754,8 @@ async function runDashboardCommandRegistrationChecks() {
         'agentPivot.nextActiveSession',
         'agentPivot.nextAttentionSession',
         'agentPivot.nextRunningSession',
+        'agentPivot.switchToAiSession',
+        'agentPivot.toggleLastAiSession',
         'agentPivot.switchToOpenWindow',
     ]);
     assert.deepStrictEqual(subscriptions.map(disposable => disposable.command), registered.map(([command]) => command));
@@ -3787,6 +3791,8 @@ async function runDashboardCommandRegistrationChecks() {
         'nextActiveSession',
         'nextAttentionSession',
         'nextRunningSession',
+        'switchToAiSession',
+        'toggleLastAiSession',
         'switchToOpenWindow',
     ]);
 

--- a/src/aiSessions/conversation/codexAdapter.ts
+++ b/src/aiSessions/conversation/codexAdapter.ts
@@ -733,6 +733,10 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
         if (cached
             && Date.now() - cached.readAt
             < CONVERSATION_LIMITS.telemetryRefreshMs) {
+            cached.value = await this.refreshCachedWorktree(
+                sessionId,
+                cached.value
+            );
             return cached.value;
         }
         const existing = this.telemetryReads.get(sessionId);
@@ -847,6 +851,35 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
             ? response.cwd
             : undefined;
         return cwd ? this.options.resolveWorktree(cwd) : undefined;
+    }
+
+    private async refreshCachedWorktree(
+        sessionId: string,
+        telemetry: ConversationTelemetry | undefined
+    ): Promise<ConversationTelemetry | undefined> {
+        const currentWorkdir = this.options.readCurrentWorkdir?.(sessionId);
+        if (!currentWorkdir || !this.options.resolveWorktree) {
+            return telemetry;
+        }
+        let worktree: ConversationWorktreeInfo | undefined;
+        try {
+            worktree = await this.options.resolveWorktree(currentWorkdir);
+        } catch (_error) {
+            return telemetry;
+        }
+        if (!worktree) {
+            return telemetry;
+        }
+        if (telemetry) {
+            telemetry.worktree = worktree;
+            return telemetry;
+        }
+        return {
+            provider: 'codex',
+            sessionId,
+            worktree,
+            rateLimits: [],
+        };
     }
 
     watch(sessionId: string, onChange: () => void): AiSessionDisposable {

--- a/src/aiSessions/conversation/composition.ts
+++ b/src/aiSessions/conversation/composition.ts
@@ -1209,8 +1209,16 @@ async function resolveLatestConversationTarget(
             && snapshotWarmup?.isDisposed()) {
             return { result: 'unavailable' };
         }
-        prefetchedSnapshot = Boolean(resolvedWarmSnapshot);
-        snapshot = resolvedWarmSnapshot || (
+        // A speculative read can finish before a newly started provider has
+        // persisted its first user turn. Never let that empty warm snapshot
+        // authoritatively report a live Session as conversation-less: confirm
+        // it against the provider when the user actually navigates there.
+        const usableWarmSnapshot = resolvedWarmSnapshot
+            && resolvedWarmSnapshot.outline.interactions.length
+            ? resolvedWarmSnapshot
+            : undefined;
+        prefetchedSnapshot = Boolean(usableWarmSnapshot);
+        snapshot = usableWarmSnapshot || (
             typeof coordinator.readSnapshot === 'function'
             ? await coordinator.readSnapshot(
                 target.provider,

--- a/src/aiSessions/sessionMru.ts
+++ b/src/aiSessions/sessionMru.ts
@@ -1,0 +1,64 @@
+'use strict';
+
+import type { AiSessionProviderId } from '../models';
+import { getAiSessionKey } from './sessionHelpers';
+
+export interface AiSessionMruEntry {
+    key: string;
+    provider: AiSessionProviderId;
+    sessionId: string;
+    recordedAtMs: number;
+}
+
+export interface AiSessionMruTracker {
+    record(provider: AiSessionProviderId, sessionId: string): void;
+    entries(): readonly AiSessionMruEntry[];
+    mostRecentKey(excludeKey?: string | null): string | null;
+    prune(validKeys: ReadonlySet<string>): void;
+}
+
+export const AI_SESSION_MRU_MAX_ENTRIES = 20;
+
+/**
+ * Bounded most-recently-used list of focused AI sessions, newest first. The
+ * tracker is fed by terminal focus events, so every host-initiated jump and
+ * every manual terminal click contributes without instrumenting each call
+ * site. Keys use the canonical `provider:sessionId` shape.
+ */
+export function createAiSessionMruTracker(options: {
+    now: () => number;
+    maxEntries?: number;
+}): AiSessionMruTracker {
+    const maxEntries = options.maxEntries && options.maxEntries > 0
+        ? Math.floor(options.maxEntries)
+        : AI_SESSION_MRU_MAX_ENTRIES;
+    let entries: AiSessionMruEntry[] = [];
+    return {
+        record(provider, sessionId) {
+            if (typeof provider !== 'string' || !provider
+                || typeof sessionId !== 'string' || !sessionId) {
+                return;
+            }
+            const key = getAiSessionKey(provider, sessionId);
+            entries = [
+                {
+                    key,
+                    provider,
+                    sessionId,
+                    recordedAtMs: options.now(),
+                },
+                ...entries.filter(entry => entry.key !== key),
+            ].slice(0, maxEntries);
+        },
+        entries() {
+            return entries.slice();
+        },
+        mostRecentKey(excludeKey) {
+            const found = entries.find(entry => entry.key !== excludeKey);
+            return found ? found.key : null;
+        },
+        prune(validKeys) {
+            entries = entries.filter(entry => validKeys.has(entry.key));
+        },
+    };
+}

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -84,6 +84,12 @@ import {
     createRunningSessionJumpHandler,
 } from './dashboard/runningSessionJump';
 import {
+    createAiSessionQuickSwitchHandlers,
+} from './dashboard/sessionQuickSwitch';
+import {
+    createAiSessionMruTracker,
+} from './aiSessions/sessionMru';
+import {
     buildRunningSessionQueue,
 } from './aiSessions/runningQueue';
 import type { ActiveAiSessionTerminalIdentity } from './aiSessions/activeTerminalHighlight';
@@ -1809,6 +1815,34 @@ async function initializeDashboard(
         showWarningMessage: message =>
             vscode.window.showWarningMessage(message),
     });
+    const focusAiSessionForJump = (target: {
+        provider: AiSessionProviderId;
+        sessionId: string;
+    }): Promise<boolean> => {
+        const cardId = getCurrentWorkspaceActionTargetWithoutCardId()?.cardId;
+        return cardId
+            ? aiSessionTerminalCommandController.focusActive(
+                cardId,
+                target.provider,
+                target.sessionId
+            )
+            : Promise.resolve(false);
+    };
+    const openAiSessionConversationForJump = (target: {
+        provider: AiSessionProviderId;
+        sessionId: string;
+    }): Promise<void> => {
+        const cardId = getCurrentWorkspaceActionTargetWithoutCardId()?.cardId;
+        return cardId
+            ? openAiSessionConversationWithFeedback({
+                projectId: cardId,
+                provider: target.provider,
+                sessionId: target.sessionId,
+            })
+            : Promise.resolve();
+    };
+    const requestRemoteAiSessionFocus = (navigationIdentity: string): Promise<boolean> =>
+        openWorkspaceBridgeClient.requestRunningFocus(navigationIdentity);
     const runningSessionJumpHandler = createRunningSessionJumpHandler({
         buildQueue: () => buildRunningSessionQueue({
             localSessions: (getCurrentWorkspaceActionTargetWithoutCardId()
@@ -1830,28 +1864,53 @@ async function initializeDashboard(
                     runningSessionCount: card.runningSessionCount,
                 })),
         }),
-        focusSession: item => {
-            const cardId = getCurrentWorkspaceActionTargetWithoutCardId()?.cardId;
-            return cardId
-                ? aiSessionTerminalCommandController.focusActive(
-                    cardId,
-                    item.provider,
-                    item.sessionId
-                )
-                : Promise.resolve(false);
-        },
-        openConversation: item => {
-            const cardId = getCurrentWorkspaceActionTargetWithoutCardId()?.cardId;
-            return cardId
-                ? openAiSessionConversationWithFeedback({
-                    projectId: cardId,
-                    provider: item.provider,
-                    sessionId: item.sessionId,
-                })
-                : Promise.resolve();
-        },
+        focusSession: focusAiSessionForJump,
+        openConversation: openAiSessionConversationForJump,
         requestRemoteFocus: item =>
-            openWorkspaceBridgeClient.requestRunningFocus(item.navigationIdentity),
+            requestRemoteAiSessionFocus(item.navigationIdentity),
+        openNavigationCard: cardId =>
+            workspaceNavigationController.open(cardId),
+        showInformationMessage: message =>
+            vscode.window.showInformationMessage(message),
+        showWarningMessage: message =>
+            vscode.window.showWarningMessage(message),
+    });
+    // Every jump path focuses a terminal, so this single listener keeps the
+    // MRU truthful for command jumps and manual terminal clicks alike.
+    const aiSessionMru = createAiSessionMruTracker({ now: () => Date.now() });
+    ownResource(() => vscode.window.onDidChangeActiveTerminal(() => {
+        const identity = getFocusedAiSessionRuntimeIdentity();
+        if (identity?.sessionId) {
+            aiSessionMru.record(identity.provider, identity.sessionId);
+        }
+    }));
+    const aiSessionQuickSwitchHandlers = createAiSessionQuickSwitchHandlers({
+        getLocalSessions: () => getCurrentWorkspaceActionTargetWithoutCardId()
+            ?.sessions.activeSessions || [],
+        getRemoteWindows: () => openWorkspaceDashboardController.getCards()
+            .filter(card => card.kind === 'navigation'
+                && card.runningSessionCount > 0)
+            .map(card => ({
+                cardId: card.id,
+                navigationIdentity: card.navigationIdentity,
+                displayName: card.name,
+                runningSessionCount: card.runningSessionCount,
+            })),
+        getFocusedSessionKey: () => {
+            const identity = getFocusedAiSessionRuntimeIdentity();
+            return identity?.sessionId
+                ? getAiSessionKey(identity.provider, identity.sessionId)
+                : null;
+        },
+        mru: aiSessionMru,
+        showPick: async (items, placeHolder) => vscode.window.showQuickPick([...items], {
+            placeHolder,
+            matchOnDescription: true,
+        }),
+        focusSession: focusAiSessionForJump,
+        openConversation: openAiSessionConversationForJump,
+        requestRemoteFocus: target =>
+            requestRemoteAiSessionFocus(target.navigationIdentity),
         openNavigationCard: cardId =>
             workspaceNavigationController.open(cardId),
         showInformationMessage: message =>
@@ -2114,6 +2173,10 @@ async function initializeDashboard(
         nextAttentionSession: () => jumpToNextAttentionSession(),
         nextRunningSession: () =>
             runningSessionJumpHandler.jumpToNextRunningSession(),
+        switchToAiSession: () =>
+            aiSessionQuickSwitchHandlers.switchToAiSession(),
+        toggleLastAiSession: () =>
+            aiSessionQuickSwitchHandlers.toggleLastAiSession(),
         switchToOpenWindow: () => workspaceNavigationQuickPickController.pickAndOpen(),
     };
 

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -112,6 +112,7 @@ import { AiSessionRuntimeCoordinator } from './aiSessions/runtimeCoordinator';
 import type { AiSessionTmuxFallbackContext } from './aiSessions/runtimeCoordinator';
 import type { AiSessionRuntimeSnapshot } from './aiSessions/runtimeTypes';
 import { cloneAiSessionRuntimeIdentity, TmuxRuntimeUnavailableError } from './aiSessions/runtimeTypes';
+import type { AiSessionRuntimeIdentity } from './aiSessions/runtimeTypes';
 import { TmuxClient, TmuxClientError } from './aiSessions/tmuxClient';
 import { TmuxRuntimeBindingStore } from './aiSessions/tmuxRuntimeBindingStore';
 import { TmuxAttachBindingStore } from './aiSessions/tmuxAttachBindingStore';
@@ -1815,18 +1816,45 @@ async function initializeDashboard(
         showWarningMessage: message =>
             vscode.window.showWarningMessage(message),
     });
+    // MRU focus resolution must be completion- and visibility-independent:
+    // the attention highlighter clears its identity when a turn completes or
+    // the dashboard hides, which would starve the tracker. Resolve the active
+    // terminal straight from the tmux focus binding and the runtime registry.
+    const getFocusedAiSessionIdentity = (): AiSessionRuntimeIdentity | null => {
+        const activeTerminal = vscode.window.activeTerminal;
+        if (!activeTerminal) {
+            return null;
+        }
+        const tmuxRuntime = tmuxRuntimeBackend.getFocusedRuntime(activeTerminal);
+        if (tmuxRuntime?.identity.sessionId) {
+            return tmuxRuntime.identity;
+        }
+        const direct = aiSessionRuntimeCoordinator.getActive().find(candidate =>
+            candidate.backend === 'vscode'
+                && candidate.terminal === activeTerminal
+                && Boolean(candidate.identity.sessionId));
+        return direct?.identity || null;
+    };
     const focusAiSessionForJump = (target: {
         provider: AiSessionProviderId;
         sessionId: string;
     }): Promise<boolean> => {
         const cardId = getCurrentWorkspaceActionTargetWithoutCardId()?.cardId;
-        return cardId
-            ? aiSessionTerminalCommandController.focusActive(
-                cardId,
-                target.provider,
-                target.sessionId
-            )
-            : Promise.resolve(false);
+        if (!cardId) {
+            return Promise.resolve(false);
+        }
+        return aiSessionTerminalCommandController.focusActive(
+            cardId,
+            target.provider,
+            target.sessionId
+        ).then(focused => {
+            // Re-showing an already-active terminal fires no focus event, so
+            // successful command jumps record into the MRU directly.
+            if (focused) {
+                aiSessionMru.record(target.provider, target.sessionId);
+            }
+            return focused;
+        });
     };
     const openAiSessionConversationForJump = (target: {
         provider: AiSessionProviderId;
@@ -1875,15 +1903,27 @@ async function initializeDashboard(
         showWarningMessage: message =>
             vscode.window.showWarningMessage(message),
     });
-    // Every jump path focuses a terminal, so this single listener keeps the
-    // MRU truthful for command jumps and manual terminal clicks alike.
+    // Tmux window switches inside one attach terminal never fire VS Code
+    // terminal focus events, so event-driven recording starves the tracker.
+    // Sample the resolved focus instead: the tmux focused-runtime monitor
+    // already polls every second, keeping this resolution fresh.
     const aiSessionMru = createAiSessionMruTracker({ now: () => Date.now() });
-    ownResource(() => vscode.window.onDidChangeActiveTerminal(() => {
-        const identity = getFocusedAiSessionRuntimeIdentity();
-        if (identity?.sessionId) {
-            aiSessionMru.record(identity.provider, identity.sessionId);
-        }
-    }));
+    ownResource(() => {
+        let lastSampledKey: string | null = null;
+        const handle = setInterval(() => {
+            const identity = getFocusedAiSessionIdentity();
+            const key = identity?.sessionId
+                ? getAiSessionKey(identity.provider, identity.sessionId)
+                : null;
+            if (key !== lastSampledKey) {
+                lastSampledKey = key;
+                if (identity?.sessionId) {
+                    aiSessionMru.record(identity.provider, identity.sessionId);
+                }
+            }
+        }, 1000);
+        return { dispose: () => clearInterval(handle) };
+    });
     const aiSessionQuickSwitchHandlers = createAiSessionQuickSwitchHandlers({
         getLocalSessions: () => getCurrentWorkspaceActionTargetWithoutCardId()
             ?.sessions.activeSessions || [],
@@ -1897,7 +1937,7 @@ async function initializeDashboard(
                 runningSessionCount: card.runningSessionCount,
             })),
         getFocusedSessionKey: () => {
-            const identity = getFocusedAiSessionRuntimeIdentity();
+            const identity = getFocusedAiSessionIdentity();
             return identity?.sessionId
                 ? getAiSessionKey(identity.provider, identity.sessionId)
                 : null;

--- a/src/dashboard/commandRegistration.ts
+++ b/src/dashboard/commandRegistration.ts
@@ -24,6 +24,8 @@ export interface DashboardCommandHandlers {
     nextActiveSession: DashboardCommandHandler;
     nextAttentionSession: DashboardCommandHandler;
     nextRunningSession: DashboardCommandHandler;
+    switchToAiSession: DashboardCommandHandler;
+    toggleLastAiSession: DashboardCommandHandler;
     switchToOpenWindow: DashboardCommandHandler;
 }
 
@@ -56,6 +58,8 @@ const DASHBOARD_COMMANDS: ReadonlyArray<readonly [string, DashboardCommandName]>
     ['agentPivot.nextActiveSession', 'nextActiveSession'],
     ['agentPivot.nextAttentionSession', 'nextAttentionSession'],
     ['agentPivot.nextRunningSession', 'nextRunningSession'],
+    ['agentPivot.switchToAiSession', 'switchToAiSession'],
+    ['agentPivot.toggleLastAiSession', 'toggleLastAiSession'],
     ['agentPivot.switchToOpenWindow', 'switchToOpenWindow'],
 ];
 

--- a/src/dashboard/sessionQuickSwitch.ts
+++ b/src/dashboard/sessionQuickSwitch.ts
@@ -1,0 +1,256 @@
+'use strict';
+
+import type { AiSessionProviderId } from '../models';
+import type {
+    ActiveAiSessionExecutionState,
+    ActiveAiSessionViewModel,
+} from '../aiSessions/types';
+import { getAiSessionKey } from '../aiSessions/sessionHelpers';
+import type { AiSessionMruTracker } from '../aiSessions/sessionMru';
+
+export interface AiSessionSwitchRemoteWindow {
+    cardId: string;
+    navigationIdentity: string;
+    displayName: string;
+    runningSessionCount: number;
+}
+
+export type AiSessionSwitchTarget =
+    | {
+        kind: 'local';
+        key: string;
+        provider: AiSessionProviderId;
+        sessionId: string;
+    }
+    | {
+        kind: 'remote';
+        key: string;
+        cardId: string;
+        navigationIdentity: string;
+        displayName: string;
+        runningSessionCount: number;
+    };
+
+export interface AiSessionSwitchPickItem {
+    label: string;
+    description: string;
+    target: AiSessionSwitchTarget;
+}
+
+function providerLabel(provider: AiSessionProviderId): string {
+    if (provider === 'kimi') {
+        return 'Kimi';
+    }
+    if (provider === 'claude') {
+        return 'Claude';
+    }
+    return 'Codex';
+}
+
+function executionStateLabel(executionState: ActiveAiSessionExecutionState): string {
+    return executionState === 'running'
+        ? 'Running'
+        : executionState === 'starting' ? 'Starting' : 'Stopped';
+}
+
+/**
+ * Builds the QuickPick items for the global session switcher: every live
+ * local session (most-recently focused first, stable key order after that),
+ * then one entry per other window that reported running sessions. Remote
+ * entries stay window-granular because the Open Windows channel publishes
+ * running counts, not per-session identities.
+ */
+export function buildAiSessionSwitchItems(input: {
+    localSessions: readonly ActiveAiSessionViewModel[];
+    remoteWindows: readonly AiSessionSwitchRemoteWindow[];
+    mruOrder: readonly string[];
+}): AiSessionSwitchPickItem[] {
+    const mruIndex = new Map(input.mruOrder.map((key, index) => [key, index] as const));
+    const locals: AiSessionSwitchPickItem[] = [];
+    const seen = new Set<string>();
+    for (const session of input.localSessions || []) {
+        if (!session || typeof session.sessionId !== 'string' || !session.sessionId) {
+            continue;
+        }
+        const key = getAiSessionKey(session.provider, session.sessionId);
+        if (seen.has(key)) {
+            continue;
+        }
+        seen.add(key);
+        const badges = [providerLabel(session.provider), executionStateLabel(session.executionState)];
+        if (session.focused) {
+            badges.push('Focused');
+        }
+        if (session.needsAttention) {
+            badges.push('Needs attention');
+        }
+        locals.push({
+            label: `$(terminal) ${session.name || session.sessionId}`,
+            description: badges.join(' · '),
+            target: {
+                kind: 'local',
+                key,
+                provider: session.provider,
+                sessionId: session.sessionId,
+            },
+        });
+    }
+    locals.sort((left, right) =>
+        (mruIndex.get(left.target.key) ?? Number.MAX_SAFE_INTEGER)
+            - (mruIndex.get(right.target.key) ?? Number.MAX_SAFE_INTEGER)
+        || left.target.key.localeCompare(right.target.key));
+    const remotes: AiSessionSwitchPickItem[] = [];
+    const seenWindows = new Set<string>();
+    for (const window of input.remoteWindows || []) {
+        if (!window
+            || typeof window.navigationIdentity !== 'string'
+            || !window.navigationIdentity
+            || typeof window.cardId !== 'string'
+            || !window.cardId
+            || !Number.isSafeInteger(window.runningSessionCount)
+            || window.runningSessionCount < 1) {
+            continue;
+        }
+        if (seenWindows.has(window.navigationIdentity)) {
+            continue;
+        }
+        seenWindows.add(window.navigationIdentity);
+        remotes.push({
+            label: `$(arrow-right) ${window.displayName || 'another window'}`,
+            description: `${window.runningSessionCount} running session${
+                window.runningSessionCount === 1 ? '' : 's'
+            } in another window`,
+            target: {
+                kind: 'remote',
+                key: `window:${window.navigationIdentity}`,
+                cardId: window.cardId,
+                navigationIdentity: window.navigationIdentity,
+                displayName: window.displayName,
+                runningSessionCount: window.runningSessionCount,
+            },
+        });
+    }
+    remotes.sort((left, right) => left.target.key.localeCompare(right.target.key));
+    return [...locals, ...remotes];
+}
+
+export interface AiSessionQuickSwitchOptions {
+    getLocalSessions: () => readonly ActiveAiSessionViewModel[];
+    getRemoteWindows: () => readonly AiSessionSwitchRemoteWindow[];
+    getFocusedSessionKey: () => string | null;
+    mru: AiSessionMruTracker;
+    showPick: (
+        items: readonly AiSessionSwitchPickItem[],
+        placeHolder: string
+    ) => Promise<AiSessionSwitchPickItem | undefined>;
+    focusSession: (target: {
+        provider: AiSessionProviderId;
+        sessionId: string;
+    }) => Promise<boolean>;
+    openConversation: (target: {
+        provider: AiSessionProviderId;
+        sessionId: string;
+    }) => Promise<void>;
+    requestRemoteFocus: (target: AiSessionSwitchRemoteWindow) => Promise<boolean>;
+    openNavigationCard: (cardId: string) => Promise<void>;
+    showInformationMessage: (message: string) => void;
+    showWarningMessage: (message: string) => void;
+}
+
+export interface AiSessionQuickSwitchHandlers {
+    switchToAiSession(): Promise<void>;
+    toggleLastAiSession(): Promise<void>;
+}
+
+/**
+ * Direct session navigation: the switcher jumps to a picked session (or a
+ * window with running sessions, through the focus mailbox), and the toggle
+ * alternates between the two most recently focused local sessions like an
+ * AI-session alt-tab. Both share the jump wiring with the running-session
+ * cycle.
+ */
+export function createAiSessionQuickSwitchHandlers(
+    options: AiSessionQuickSwitchOptions
+): AiSessionQuickSwitchHandlers {
+    async function jumpToLocal(target: {
+        provider: AiSessionProviderId;
+        sessionId: string;
+    }): Promise<void> {
+        const focused = await options.focusSession(target);
+        if (!focused) {
+            options.showWarningMessage(
+                'Agent Pivot: the selected AI session is no longer active.'
+            );
+            return;
+        }
+        await options.openConversation(target);
+    }
+
+    async function switchToAiSession(): Promise<void> {
+        const items = buildAiSessionSwitchItems({
+            localSessions: options.getLocalSessions(),
+            remoteWindows: options.getRemoteWindows(),
+            mruOrder: options.mru.entries().map(entry => entry.key),
+        });
+        if (!items.length) {
+            options.showInformationMessage('Agent Pivot: no active AI sessions.');
+            return;
+        }
+        const picked = await options.showPick(
+            items,
+            'Select an AI session to focus'
+        );
+        if (!picked) {
+            return;
+        }
+        if (picked.target.kind === 'local') {
+            await jumpToLocal(picked.target);
+            return;
+        }
+        let handedOff = false;
+        try {
+            handedOff = await options.requestRemoteFocus(picked.target);
+        } catch (_error) {
+            // A missing or failing handoff channel degrades to a plain window
+            // switch; navigation below still moves the user closer.
+            handedOff = false;
+        }
+        await options.openNavigationCard(picked.target.cardId);
+        if (!handedOff) {
+            options.showInformationMessage(
+                `Agent Pivot: switched to ${picked.target.displayName || 'the other window'};`
+                    + ' run Next Running Session there to focus a session.'
+            );
+        }
+    }
+
+    async function toggleLastAiSession(): Promise<void> {
+        const liveByKey = new Map<string, ActiveAiSessionViewModel & { sessionId: string }>();
+        for (const session of options.getLocalSessions()) {
+            if (session && typeof session.sessionId === 'string' && session.sessionId) {
+                liveByKey.set(
+                    getAiSessionKey(session.provider, session.sessionId),
+                    session as ActiveAiSessionViewModel & { sessionId: string }
+                );
+            }
+        }
+        options.mru.prune(new Set(liveByKey.keys()));
+        const targetKey = options.mru.mostRecentKey(options.getFocusedSessionKey());
+        const target = targetKey ? liveByKey.get(targetKey) : undefined;
+        if (!target) {
+            options.showInformationMessage(
+                'Agent Pivot: no previous AI session in this window.'
+            );
+            return;
+        }
+        await jumpToLocal({
+            provider: target.provider,
+            sessionId: target.sessionId,
+        });
+    }
+
+    return {
+        switchToAiSession,
+        toggleLastAiSession,
+    };
+}

--- a/tests/contract/aiSessions/codexConversationAdapter.test.js
+++ b/tests/contract/aiSessions/codexConversationAdapter.test.js
@@ -1387,6 +1387,81 @@ test('CONVERSATION-TELEMETRY-001 Codex prefers the latest exec workdir and falls
     });
 });
 
+test('CONVERSATION-TELEMETRY-001 Codex refreshes the latest exec workdir inside the telemetry cache window', async t => {
+    let currentWorkdir;
+    let requestCount = 0;
+    const telemetryClient = {
+        async request(method) {
+            requestCount += 1;
+            if (method === 'thread/resume') {
+                return { model: 'gpt-5.6-sol', cwd: '/launch/repo' };
+            }
+            return {};
+        },
+        dispose() {},
+    };
+    const harness = createAdapter(fixture, {
+        client: telemetryClient,
+        readCurrentWorkdir: () => currentWorkdir,
+        resolveWorktree: async candidate => ({
+            branch: candidate.endsWith('/feature-x') ? 'feature-x' : 'main',
+            worktreeRoot: candidate,
+            repoRoot: '/launch/repo',
+        }),
+    });
+    t.after(() => harness.adapter.dispose());
+
+    const initial = await harness.adapter.readTelemetry(sessionId);
+    assert.equal(initial.worktree.branch, 'main');
+    currentWorkdir = '/launch/repo/.worktree/feature-x';
+
+    const refreshed = await harness.adapter.readTelemetry(sessionId);
+    assert.deepEqual(refreshed.worktree, {
+        branch: 'feature-x',
+        worktreeRoot: '/launch/repo/.worktree/feature-x',
+        repoRoot: '/launch/repo',
+    });
+    assert.equal(requestCount, 2,
+        'a worktree-only refresh must reuse cached app-server telemetry');
+});
+
+test('CONVERSATION-TELEMETRY-001 Codex discovers a worktree after an empty telemetry result was cached', async t => {
+    let currentWorkdir;
+    let requestCount = 0;
+    const harness = createAdapter(fixture, {
+        client: {
+            async request() {
+                requestCount += 1;
+                throw new Error('telemetry unavailable');
+            },
+            dispose() {},
+        },
+        readCurrentWorkdir: () => currentWorkdir,
+        resolveWorktree: async candidate => ({
+            branch: 'feature-x',
+            worktreeRoot: candidate,
+            repoRoot: '/launch/repo',
+        }),
+    });
+    t.after(() => harness.adapter.dispose());
+
+    assert.equal(await harness.adapter.readTelemetry(sessionId), undefined);
+    currentWorkdir = '/launch/repo/.worktree/feature-x';
+
+    assert.deepEqual(await harness.adapter.readTelemetry(sessionId), {
+        provider: 'codex',
+        sessionId,
+        worktree: {
+            branch: 'feature-x',
+            worktreeRoot: '/launch/repo/.worktree/feature-x',
+            repoRoot: '/launch/repo',
+        },
+        rateLimits: [],
+    });
+    assert.equal(requestCount, 2,
+        'discovering the worktree must not repeat failed app-server reads');
+});
+
 const childThreadId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
 const otherChildThreadId = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
 const thirdChildThreadId = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';

--- a/tests/contract/aiSessions/runtimeComposition.test.js
+++ b/tests/contract/aiSessions/runtimeComposition.test.js
@@ -166,6 +166,8 @@ test('WEBVIEW-DASHBOARD-COMMAND-AVAILABILITY-001 production activation exposes c
         'agentPivot.nextActiveSession',
         'agentPivot.nextAttentionSession',
         'agentPivot.nextRunningSession',
+        'agentPivot.switchToAiSession',
+        'agentPivot.toggleLastAiSession',
         'agentPivot.switchToOpenWindow',
         'agentPivot.notify.setWebhook',
         'agentPivot.notify.showOutput',

--- a/tests/contract/aiSessions/sessionQuickSwitch.test.js
+++ b/tests/contract/aiSessions/sessionQuickSwitch.test.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
 const test = require('node:test');
 
 const {
@@ -87,6 +89,30 @@ function makeOptions(overrides = {}) {
     };
     return { calls, options };
 }
+
+test('AI-SESSION-QUICK-SWITCH-COMMANDS-001 wires the MRU to a completion-independent focus resolver', () => {
+    // Regression: the first wiring read the attention highlighter's focused
+    // identity, which is cleared when a turn completes or the dashboard
+    // hides, and waited for onDidChangeActiveTerminal, which tmux window
+    // switches inside one attach terminal never fire — so the tracker
+    // starved and the toggle always reported no previous session. The MRU
+    // must sample a completion-independent terminal resolution instead.
+    const source = fs.readFileSync(
+        path.resolve(__dirname, '../../../src/dashboard.ts'),
+        'utf8'
+    );
+    const resolver = /const getFocusedAiSessionIdentity = [\s\S]*?\n    \};/;
+    assert.match(source, resolver);
+    const resolverBody = source.match(resolver)[0];
+    assert.match(resolverBody, /tmuxRuntimeBackend\.getFocusedRuntime\(activeTerminal\)/);
+    assert.match(resolverBody, /candidate\.terminal === activeTerminal/);
+    assert.doesNotMatch(resolverBody, /getFocusedAiSessionRuntimeIdentity/);
+
+    const sampler = /setInterval\(\(\) => \{\s*const identity = getFocusedAiSessionIdentity\(\);[\s\S]*?aiSessionMru\.record\(/;
+    assert.match(source, sampler);
+    assert.match(source, /aiSessionMru\.record\(target\.provider, target\.sessionId\)/);
+    assert.match(source, /getFocusedSessionKey: \(\) => \{\s*const identity = getFocusedAiSessionIdentity\(\);/);
+});
 
 test('AI-SESSION-QUICK-SWITCH-COMMANDS-001 tracker keeps a bounded deduplicated newest-first order', () => {
     const tracker = createAiSessionMruTracker({ now: () => 1000, maxEntries: 3 });

--- a/tests/contract/aiSessions/sessionQuickSwitch.test.js
+++ b/tests/contract/aiSessions/sessionQuickSwitch.test.js
@@ -1,0 +1,254 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+    createAiSessionMruTracker,
+} = require('../../../out/aiSessions/sessionMru');
+const {
+    buildAiSessionSwitchItems,
+    createAiSessionQuickSwitchHandlers,
+} = require('../../../out/dashboard/sessionQuickSwitch');
+
+const WINDOW_A = 'a'.repeat(64);
+const WINDOW_B = 'b'.repeat(64);
+
+function session(provider, sessionId, overrides = {}) {
+    return {
+        key: `${provider}:${sessionId}`,
+        provider,
+        sessionId,
+        name: overrides.name || sessionId,
+        executionState: overrides.executionState || 'running',
+        status: overrides.status || 'running',
+        focused: overrides.focused === true,
+        needsAttention: overrides.needsAttention === true,
+        pending: false,
+        backend: 'vscode',
+        attached: true,
+    };
+}
+
+function remoteWindow(navigationIdentity, runningSessionCount = 1) {
+    return {
+        cardId: `card-${navigationIdentity.slice(0, 8)}`,
+        navigationIdentity,
+        displayName: `Window ${navigationIdentity.slice(0, 4)}`,
+        runningSessionCount,
+    };
+}
+
+function makeMru(keys) {
+    const tracker = createAiSessionMruTracker({ now: () => 1000 });
+    for (const key of [...keys].reverse()) {
+        const separator = key.indexOf(':');
+        tracker.record(key.slice(0, separator), key.slice(separator + 1));
+    }
+    return tracker;
+}
+
+function makeOptions(overrides = {}) {
+    const calls = [];
+    const options = {
+        getLocalSessions: () => overrides.localSessions || [],
+        getRemoteWindows: () => overrides.remoteWindows || [],
+        getFocusedSessionKey: () => overrides.focusedKey ?? null,
+        mru: overrides.mru || makeMru([]),
+        showPick: (items, placeHolder) => {
+            calls.push(['pick', placeHolder, items.map(item => item.label)]);
+            return Promise.resolve(
+                overrides.pick === undefined
+                    ? undefined
+                    : items[overrides.pick]
+            );
+        },
+        focusSession: target => {
+            calls.push(['focus', target.provider, target.sessionId]);
+            return Promise.resolve(overrides.focusResult !== false);
+        },
+        openConversation: target => {
+            calls.push(['open', target.provider, target.sessionId]);
+            return Promise.resolve();
+        },
+        requestRemoteFocus: target => {
+            calls.push(['request', target.navigationIdentity]);
+            if (overrides.requestThrows) {
+                return Promise.reject(new Error('command is not registered'));
+            }
+            return Promise.resolve(overrides.requestResult !== false);
+        },
+        openNavigationCard: cardId => {
+            calls.push(['navigate', cardId]);
+            return Promise.resolve();
+        },
+        showInformationMessage: message => calls.push(['info', message]),
+        showWarningMessage: message => calls.push(['warn', message]),
+    };
+    return { calls, options };
+}
+
+test('AI-SESSION-QUICK-SWITCH-COMMANDS-001 tracker keeps a bounded deduplicated newest-first order', () => {
+    const tracker = createAiSessionMruTracker({ now: () => 1000, maxEntries: 3 });
+
+    tracker.record('codex', 'c1');
+    tracker.record('kimi', 'k1');
+    tracker.record('codex', 'c1');
+    tracker.record('claude', 'l1');
+    tracker.record('kimi', 'k2');
+
+    assert.deepEqual(tracker.entries().map(entry => entry.key), [
+        'kimi:k2',
+        'claude:l1',
+        'codex:c1',
+    ]);
+    assert.equal(tracker.mostRecentKey(), 'kimi:k2');
+    assert.equal(tracker.mostRecentKey('kimi:k2'), 'claude:l1');
+    assert.equal(tracker.mostRecentKey('kimi:k9'), 'kimi:k2');
+
+    tracker.record('', 'x1');
+    assert.equal(tracker.entries().length, 3);
+
+    tracker.prune(new Set(['codex:c1']));
+    assert.deepEqual(tracker.entries().map(entry => entry.key), ['codex:c1']);
+});
+
+test('AI-SESSION-QUICK-SWITCH-COMMANDS-001 switch items are MRU-first locals then window-granular remotes', () => {
+    const items = buildAiSessionSwitchItems({
+        localSessions: [
+            session('kimi', 'k2', { name: 'Beta' }),
+            session('codex', 'c1', { name: 'Alpha', focused: true, needsAttention: true }),
+            session('codex', 'c1'),
+            session('claude', ''),
+            null,
+        ],
+        remoteWindows: [
+            remoteWindow(WINDOW_B, 2),
+            remoteWindow(WINDOW_A),
+            remoteWindow(WINDOW_A),
+            remoteWindow('c'.repeat(64), 0),
+        ],
+        mruOrder: ['kimi:k2'],
+    });
+
+    assert.deepEqual(items.map(item => item.label), [
+        '$(terminal) Beta',
+        '$(terminal) Alpha',
+        `$(arrow-right) Window ${'aaaa'}`,
+        `$(arrow-right) Window ${'bbbb'}`,
+    ]);
+    assert.equal(items[0].description, 'Kimi · Running');
+    assert.equal(items[1].description, 'Codex · Running · Focused · Needs attention');
+    assert.equal(items[2].description, '1 running session in another window');
+    assert.equal(items[3].description, '2 running sessions in another window');
+    assert.deepEqual(items.map(item => item.target.kind), [
+        'local', 'local', 'remote', 'remote',
+    ]);
+});
+
+test('AI-SESSION-QUICK-SWITCH-COMMANDS-001 switch jumps locally, cancels quietly, and reports an empty list', async () => {
+    const empty = makeOptions({});
+    await createAiSessionQuickSwitchHandlers(empty.options).switchToAiSession();
+    assert.deepEqual(empty.calls, [['info', 'Agent Pivot: no active AI sessions.']]);
+
+    const cancelled = makeOptions({ localSessions: [session('codex', 'c1')] });
+    await createAiSessionQuickSwitchHandlers(cancelled.options).switchToAiSession();
+    assert.equal(cancelled.calls.length, 1);
+    assert.equal(cancelled.calls[0][0], 'pick');
+
+    const picked = makeOptions({
+        localSessions: [session('codex', 'c1', { name: 'Alpha' }), session('kimi', 'k1')],
+        pick: 1,
+    });
+    await createAiSessionQuickSwitchHandlers(picked.options).switchToAiSession();
+    assert.deepEqual(picked.calls.slice(1), [
+        ['focus', 'kimi', 'k1'],
+        ['open', 'kimi', 'k1'],
+    ]);
+
+    const stale = makeOptions({
+        localSessions: [session('codex', 'c1')],
+        pick: 0,
+        focusResult: false,
+    });
+    await createAiSessionQuickSwitchHandlers(stale.options).switchToAiSession();
+    assert.deepEqual(stale.calls.slice(1), [
+        ['focus', 'codex', 'c1'],
+        ['warn', 'Agent Pivot: the selected AI session is no longer active.'],
+    ]);
+});
+
+test('AI-SESSION-QUICK-SWITCH-COMMANDS-001 switch hands off remote windows and degrades to plain navigation', async () => {
+    const handedOff = makeOptions({
+        localSessions: [session('codex', 'c1')],
+        remoteWindows: [remoteWindow(WINDOW_A, 2)],
+        pick: 1,
+    });
+    await createAiSessionQuickSwitchHandlers(handedOff.options).switchToAiSession();
+    assert.deepEqual(handedOff.calls.slice(1), [
+        ['request', WINDOW_A],
+        ['navigate', `card-${'a'.repeat(8)}`],
+    ]);
+
+    for (const overrides of [{ requestResult: false }, { requestThrows: true }]) {
+        const degraded = makeOptions({
+            ...overrides,
+            remoteWindows: [remoteWindow(WINDOW_A)],
+            pick: 0,
+        });
+        await createAiSessionQuickSwitchHandlers(degraded.options).switchToAiSession();
+        assert.deepEqual(degraded.calls.slice(1), [
+            ['request', WINDOW_A],
+            ['navigate', `card-${'a'.repeat(8)}`],
+            ['info', 'Agent Pivot: switched to Window aaaa;'
+                + ' run Next Running Session there to focus a session.'],
+        ]);
+    }
+});
+
+test('AI-SESSION-QUICK-SWITCH-COMMANDS-001 toggle alternates the two most recent local sessions', async () => {
+    const mru = makeMru(['codex:c1', 'kimi:k1']);
+    const toggling = makeOptions({
+        localSessions: [session('codex', 'c1'), session('kimi', 'k1')],
+        focusedKey: 'kimi:k1',
+        mru,
+    });
+    const handler = createAiSessionQuickSwitchHandlers(toggling.options);
+
+    await handler.toggleLastAiSession();
+    assert.deepEqual(toggling.calls, [['focus', 'codex', 'c1'], ['open', 'codex', 'c1']]);
+
+    // The natural focus event after the jump records c1 as most recent.
+    mru.record('codex', 'c1');
+    toggling.options.getFocusedSessionKey = () => 'codex:c1';
+    await handler.toggleLastAiSession();
+    assert.deepEqual(toggling.calls.slice(2), [['focus', 'kimi', 'k1'], ['open', 'kimi', 'k1']]);
+});
+
+test('AI-SESSION-QUICK-SWITCH-COMMANDS-001 toggle prunes dead sessions and reports an empty history', async () => {
+    const mru = makeMru(['codex:dead', 'kimi:k1']);
+    const { calls, options } = makeOptions({
+        localSessions: [session('kimi', 'k1')],
+        focusedKey: null,
+        mru,
+    });
+    await createAiSessionQuickSwitchHandlers(options).toggleLastAiSession();
+    assert.deepEqual(calls, [['focus', 'kimi', 'k1'], ['open', 'kimi', 'k1']]);
+    assert.deepEqual(mru.entries().map(entry => entry.key), ['kimi:k1']);
+
+    const empty = makeOptions({ localSessions: [session('codex', 'c1')] });
+    await createAiSessionQuickSwitchHandlers(empty.options).toggleLastAiSession();
+    assert.deepEqual(empty.calls, [
+        ['info', 'Agent Pivot: no previous AI session in this window.'],
+    ]);
+
+    const onlyCurrent = makeOptions({
+        localSessions: [session('codex', 'c1')],
+        focusedKey: 'codex:c1',
+        mru: makeMru(['codex:c1']),
+    });
+    await createAiSessionQuickSwitchHandlers(onlyCurrent.options).toggleLastAiSession();
+    assert.deepEqual(onlyCurrent.calls, [
+        ['info', 'Agent Pivot: no previous AI session in this window.'],
+    ]);
+});

--- a/tests/contract/dashboardBoundaries.test.js
+++ b/tests/contract/dashboardBoundaries.test.js
@@ -375,6 +375,8 @@ const DASHBOARD_COMMANDS = [
     'agentPivot.previousActiveSession', 'agentPivot.nextActiveSession',
     'agentPivot.nextAttentionSession',
     'agentPivot.nextRunningSession',
+    'agentPivot.switchToAiSession',
+    'agentPivot.toggleLastAiSession',
     'agentPivot.switchToOpenWindow',
 ];
 
@@ -396,6 +398,8 @@ test('WEBVIEW-DASHBOARD-COMMAND-REGISTRATION-001 WEBVIEW-DASHBOARD-COMMAND-AVAIL
         'previousActiveSession', 'nextActiveSession',
         'nextAttentionSession',
         'nextRunningSession',
+        'switchToAiSession',
+        'toggleLastAiSession',
         'switchToOpenWindow',
     ];
     const facade = new DashboardCommandRegistration({
@@ -522,6 +526,30 @@ test('AI-SESSION-NEXT-RUNNING-COMMAND-001 contributes the next-running command w
     assert.deepEqual(
         manifest.contributes.keybindings.filter(
             keybinding => keybinding.command === 'agentPivot.nextRunningSession'
+        ),
+        []
+    );
+});
+
+test('AI-SESSION-QUICK-SWITCH-COMMANDS-001 contributes the session switch and toggle commands without default keybindings', () => {
+    const manifest = require('../../package.json');
+    const commands = manifest.contributes.commands.filter(command =>
+        command.command === 'agentPivot.switchToAiSession'
+            || command.command === 'agentPivot.toggleLastAiSession'
+    );
+    assert.deepEqual(commands, [
+        {
+            command: 'agentPivot.switchToAiSession',
+            title: 'Agent Pivot: Switch to AI Session',
+        },
+        {
+            command: 'agentPivot.toggleLastAiSession',
+            title: 'Agent Pivot: Toggle Last AI Session',
+        },
+    ]);
+    assert.deepEqual(
+        manifest.contributes.keybindings.filter(binding =>
+            commands.some(command => command.command === binding.command)
         ),
         []
     );

--- a/tests/extension-host/suite/index.js
+++ b/tests/extension-host/suite/index.js
@@ -23,7 +23,9 @@ const PUBLIC_COMMANDS = [
     'agentPivot.previousActiveSession',
     'agentPivot.nextActiveSession',
     'agentPivot.nextRunningSession',
-    'agentPivot.switchToOpenWindow',
+    'agentPivot.switchToAiSession',
+    'agentPivot.toggleLastAiSession',
+    'agentPivot.switchToOpenWindow'
 ];
 
 async function verifyExtensionHostLifecycle() {

--- a/tests/integration/dashboard/conversationOpenLatest.test.js
+++ b/tests/integration/dashboard/conversationOpenLatest.test.js
@@ -414,6 +414,55 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 warms adjacent Codex, Kimi, and
     harness.capability.dispose();
 });
 
+test('CONVERSATION-OPEN-LATEST-001 retries an empty speculative snapshot before reporting an active session empty', async () => {
+    const sessions = ['codex', 'kimi'].map((provider, index) => makeSession({
+        key: `${provider}:session-${index}`,
+        provider,
+        sessionId: `session-${index}`,
+        name: `${provider} Session`,
+    }));
+    let kimiReads = 0;
+    const harness = createHarness({
+        enableSnapshots: true,
+        requireSnapshot: true,
+        viewerOpen: true,
+        session: sessions[0],
+        resolveTarget: (_projectId, provider, sessionId) =>
+            sessions.find(session => session.provider === provider
+                && session.sessionId === sessionId) || null,
+        resolveActiveTargets: () => sessions,
+        readSnapshot: async (provider, sessionId) => {
+            if (provider === 'kimi' && ++kimiReads === 1) {
+                return {
+                    outline: makeOutline(provider, sessionId, []),
+                };
+            }
+            return {
+                outline: makeOutline(provider, sessionId, ['input-a']),
+                page: makePage(provider, sessionId, 'input-a'),
+            };
+        },
+    });
+
+    assert.equal(await harness.capability.openLatestConversation({
+        projectId: 'project-a',
+        provider: 'codex',
+        sessionId: 'session-0',
+    }), 'opened');
+    while (!harness.snapshotReadTargets.includes('kimi:session-1')) {
+        await new Promise(resolve => setImmediate(resolve));
+    }
+
+    assert.equal(await harness.capability.openLatestConversation({
+        projectId: 'project-a',
+        provider: 'kimi',
+        sessionId: 'session-1',
+    }), 'opened');
+    assert.equal(kimiReads, 2,
+        'an empty warm snapshot must be confirmed by an authoritative read');
+    harness.capability.dispose();
+});
+
 test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 shares a slow in-flight warmup instead of starting a duplicate provider read', async () => {
     const sessions = ['codex', 'kimi'].map((provider, index) => makeSession({
         key: `${provider}:slow-${index}`,

--- a/tests/unit/tooling/extensionHostSuite.test.js
+++ b/tests/unit/tooling/extensionHostSuite.test.js
@@ -27,7 +27,9 @@ const publicCommands = [
     'agentPivot.nextActiveSession',
     'agentPivot.nextAttentionSession',
     'agentPivot.nextRunningSession',
-    'agentPivot.switchToOpenWindow',
+    'agentPivot.switchToAiSession',
+    'agentPivot.toggleLastAiSession',
+    'agentPivot.switchToOpenWindow'
 ];
 
 function loadSuite(vscode) {


### PR DESCRIPTION
## Summary

- add a global AI session picker and an MRU toggle for local sessions, including cross-window handoff for running sessions
- sample Direct and tmux focus independently of attention state so active sessions feed the MRU reliably
- confirm empty speculative conversation snapshots before reporting an active Kimi session as conversation-less
- refresh Codex worktree telemetry from the latest rollout working directory while retaining cached model and quota telemetry

## Testing

- `npm run test:ci:linux`
- focused AI session quick-switch, conversation composition, and Codex telemetry tests
- real Codex rollout probe verified the feature worktree and branch independently from the launch checkout

## Skill harvest

No skill changes were justified. The existing regression, provider-adapter, worktree, review, and publishing skills covered the required RED-before-fix checks, real-provider verification, capability audit, and publication sequence.
