### PR TITLE
feat: make attention clearing on session jumps optional

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -755,7 +755,7 @@
   {
     "id": "ATTENTION-STATUS-BAR-QUEUE-001",
     "domain": "attention",
-    "title": "A right-aligned status bar entry surfaces the cross-window attention count with a per-session tooltip and drains the queue oldest-first on click: local sessions focus their terminal, open their conversation, and acknowledge only after both succeed, unfocusable sessions warn and stay unread, remote sessions switch to the owning window without acknowledging, and the entry hides while the queue is empty or attention is disabled",
+    "title": "A right-aligned status bar entry surfaces the cross-window attention count with a per-session tooltip and cycles an independent cursor through the oldest-first queue on click: local sessions focus their terminal and open their conversation while staying unread by default, an opt-in setting acknowledges only after both actions succeed, session-card clicks still acknowledge, unfocusable sessions warn and stay unread without trapping the cursor, remote sessions switch to the owning window without acknowledging, and the entry hides while the queue is empty or attention is disabled",
     "priority": "P1",
     "status": "automated",
     "owners": [

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "17cf2c716dbf8b28e2f95c5f6a5de1dc14452c68",
+        "head": "776aca0520d27860898ed4bee34edd7007c3f1db",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -220,7 +220,8 @@
             "fc2b8cc3ee49ac2d7f16c61155cdb40310a6e0a0",
             "88cfcc74c32df5df8f48ee7b1a6e9f5bdd53d72f",
             "3f4a0156aac342b9602427fa40113d067012f54c",
-            "fa9df64a1fce021e5c49516c40213c63c7fa01f7"
+            "fa9df64a1fce021e5c49516c40213c63c7fa01f7",
+            "2c1d16c63cab58bdfa75dc41f8d095e0a4e3bf84"
         ]
     },
     "capabilities": [
@@ -516,7 +517,8 @@
                 "d48593ecb3f6b5f1bbb1c9cbeb81c793d2c0e19c",
                 "77ea054df480d4ac53c5240f96883b95dedd622b",
                 "7c0c01b089003aa101897fc27da835a60a35d03d",
-                "e39d410b1108687c831625d421ee91b0571aeed4"
+                "e39d410b1108687c831625d421ee91b0571aeed4",
+                "776aca0520d27860898ed4bee34edd7007c3f1db"
             ],
             "behaviors": [
                 "ATTENTION-ATTENTION-PROJECTION-001",

--- a/package.json
+++ b/package.json
@@ -382,6 +382,11 @@
                     "default": true,
                     "description": "Show attention indicators when Agent Pivot AI sessions finish or may need input."
                 },
+                "agentPivot.aiSessionAttention.clearOnNextSession": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Automatically clear a session's attention indicator after Next Attention Session successfully switches to it. When disabled, clicking the session card still clears the indicator."
+                },
                 "agentPivot.notify.enabled": {
                     "type": "boolean",
                     "default": false,

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1794,6 +1794,8 @@ async function initializeDashboard(
         },
         acknowledge: eventIds =>
             acknowledgeAiSessionAttentionEventIds(eventIds),
+        shouldAcknowledge: () => getAgentPivotConfiguration()
+            .get<boolean>('aiSessionAttention.clearOnNextSession', false) === true,
         findNavigationCardId: projectId => {
             for (const card of openWorkspaceDashboardController.getCards()) {
                 if (card.kind !== 'navigation') {

--- a/src/dashboard/attentionQueueJump.ts
+++ b/src/dashboard/attentionQueueJump.ts
@@ -10,6 +10,7 @@ export interface AttentionQueueJumpOptions {
     focusSession: (item: AttentionQueueItem) => Promise<boolean>;
     openConversation: (item: AttentionQueueItem) => Promise<void>;
     acknowledge: (eventIds: string[]) => Promise<void>;
+    shouldAcknowledge: () => boolean;
     findNavigationCardId: (projectId: string) => string | null;
     openNavigationCard: (cardId: string) => Promise<void>;
     showInformationMessage: (message: string) => void;
@@ -17,22 +18,32 @@ export interface AttentionQueueJumpOptions {
 }
 
 /**
- * Drains the attention queue one entry per invocation. A local jump only
- * acknowledges after the terminal focus and the conversation open both
- * succeeded; a remote jump switches windows and deliberately leaves the
- * entry unread so the destination window drains it from its own queue.
+ * Advances a cursor through the oldest-first attention queue independently
+ * from acknowledgement. A local jump acknowledges only when the user setting
+ * opts in and after terminal focus and conversation open both succeed.
+ * Otherwise it stays unread until the session card is clicked, while the next
+ * invocation can still advance. A remote jump switches windows and
+ * deliberately leaves the entry unread.
  */
 export function createAttentionQueueJumpHandler(
     options: AttentionQueueJumpOptions
 ): () => Promise<void> {
+    let lastKey: string | null = null;
     return async function jumpToNextAttentionSession(): Promise<void> {
-        const next = options.buildQueue().items[0];
-        if (!next) {
+        const items = options.buildQueue().items;
+        if (!items.length) {
             options.showInformationMessage(
                 'Agent Pivot: no AI sessions need attention.'
             );
             return;
         }
+        const previousIndex = lastKey === null
+            ? -1
+            : items.findIndex(item => attentionQueueItemKey(item) === lastKey);
+        const next = previousIndex < 0
+            ? items[0]
+            : items[(previousIndex + 1) % items.length];
+        lastKey = attentionQueueItemKey(next);
         if (next.local) {
             const focused = await options.focusSession(next);
             if (!focused) {
@@ -42,7 +53,9 @@ export function createAttentionQueueJumpHandler(
                 return;
             }
             await options.openConversation(next);
-            await options.acknowledge(next.eventIds);
+            if (options.shouldAcknowledge()) {
+                await options.acknowledge(next.eventIds);
+            }
             return;
         }
         const cardId = options.findNavigationCardId(next.projectId);
@@ -55,4 +68,8 @@ export function createAttentionQueueJumpHandler(
         }
         await options.openNavigationCard(cardId);
     };
+}
+
+function attentionQueueItemKey(item: AttentionQueueItem): string {
+    return JSON.stringify([item.projectId, item.provider, item.sessionId]);
 }

--- a/tests/contract/aiSessions/attentionStatusBar.test.js
+++ b/tests/contract/aiSessions/attentionStatusBar.test.js
@@ -230,7 +230,7 @@ test('ATTENTION-STATUS-BAR-QUEUE-001 drives the status bar item visibility and c
     assert.equal(item.disposed, true);
 });
 
-function makeJumpOptions(queue) {
+function makeJumpOptions(queue, clearOnNextSession = false) {
     const calls = [];
     return {
         calls,
@@ -246,6 +246,7 @@ function makeJumpOptions(queue) {
             acknowledge: async eventIds => {
                 calls.push(['acknowledge', eventIds]);
             },
+            shouldAcknowledge: () => clearOnNextSession,
             findNavigationCardId: projectId => {
                 calls.push(['findNavigationCardId', projectId]);
                 return queue.navigationCardId || null;
@@ -263,9 +264,24 @@ function makeJumpOptions(queue) {
     };
 }
 
-test('ATTENTION-STATUS-BAR-QUEUE-001 jump focuses, opens, and acknowledges the oldest local session', async () => {
+test('ATTENTION-STATUS-BAR-QUEUE-001 jump cycles local sessions while keeping them unread by default', async () => {
     const queue = buildAttentionQueue(makeQueueInput());
     const { calls, options } = makeJumpOptions(queue);
+
+    await options();
+    await options();
+
+    assert.deepEqual(calls, [
+        ['focusSession', 'kimi:sess-1'],
+        ['openConversation', 'kimi:sess-1'],
+        ['focusSession', 'codex:sess-2'],
+        ['openConversation', 'codex:sess-2'],
+    ], 'navigation advances without clearing attention unless the setting opts in');
+});
+
+test('ATTENTION-STATUS-BAR-QUEUE-001 jump acknowledges after focus and open when enabled', async () => {
+    const queue = buildAttentionQueue(makeQueueInput());
+    const { calls, options } = makeJumpOptions(queue, true);
 
     await options();
 
@@ -273,7 +289,7 @@ test('ATTENTION-STATUS-BAR-QUEUE-001 jump focuses, opens, and acknowledges the o
         ['focusSession', 'kimi:sess-1'],
         ['openConversation', 'kimi:sess-1'],
         ['acknowledge', ['e-1']],
-    ], 'a local jump drains the queue entry only after focus and open succeed');
+    ], 'the opt-in setting drains the queue only after focus and open succeed');
 });
 
 test('ATTENTION-STATUS-BAR-QUEUE-001 jump keeps an unfocusable session unread and warns', async () => {
@@ -282,9 +298,12 @@ test('ATTENTION-STATUS-BAR-QUEUE-001 jump keeps an unfocusable session unread an
     const { calls, options } = makeJumpOptions(queue);
 
     await options();
+    await options();
 
     assert.deepEqual(calls, [
         ['focusSession', 'kimi:sess-1'],
+        ['warning', 'Agent Pivot: the selected AI session is no longer active.'],
+        ['focusSession', 'codex:sess-2'],
         ['warning', 'Agent Pivot: the selected AI session is no longer active.'],
     ]);
 });

--- a/tests/contract/dashboardBoundaries.test.js
+++ b/tests/contract/dashboardBoundaries.test.js
@@ -492,6 +492,16 @@ test('CONVERSATION-ACTIVE-SESSION-NAVIGATION-COMMANDS-001 contributes globally a
 test('ATTENTION-STATUS-BAR-QUEUE-001 contributes the next-attention command with exactly one global keybinding', () => {
     const manifest = require('../../package.json');
     assert.deepEqual(
+        manifest.contributes.configuration.properties[
+            'agentPivot.aiSessionAttention.clearOnNextSession'
+        ],
+        {
+            type: 'boolean',
+            default: false,
+            description: 'Automatically clear a session\'s attention indicator after Next Attention Session successfully switches to it. When disabled, clicking the session card still clears the indicator.',
+        }
+    );
+    assert.deepEqual(
         manifest.contributes.commands.filter(
             command => command.command === 'agentPivot.nextAttentionSession'
         ),


### PR DESCRIPTION
## Summary

- add `agentPivot.aiSessionAttention.clearOnNextSession`, disabled by default
- keep attention indicators unread after Next Attention Session unless the setting explicitly opts in, while preserving card-click acknowledgement
- decouple the navigation cursor from acknowledgement so repeated jumps continue cycling through unread sessions
- advance past unavailable sessions instead of trapping the cursor on a stale target

## Testing

- `npm run test:ci:linux`
- focused attention status-bar and dashboard boundary contract tests
- local VSIX package and install verification in the active Dev Container
- changed-line coverage: 100% (24/24)

## Skill harvest

No skill changes were justified. The only additional finding was a product behavior requirement—navigation must keep advancing when acknowledgement is disabled—and it is now captured by the attention queue contract tests; the existing worktree, Webview mutation, review, installation, and publishing workflows were sufficient.
