### PR TITLE
chore: release Agent Pivot 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the "Agent Pivot" extension will be documented in this fi
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-08-09
+
 ### Added
 
 - New `Agent Pivot: Sponsor` command and a heart button in the dashboard

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "91094fccf74d20e553514ebfbb3705be7c5c1556",
+        "head": "b388dee9464be7e0ac6850cd12c3a943b5868f3b",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -224,7 +224,8 @@
             "2c1d16c63cab58bdfa75dc41f8d095e0a4e3bf84",
             "6eb07444bf9dd9346b257e68ca19280e06d851d5",
             "141522b97549e11c99cd3234e9b43f3ed91e55c3",
-            "17f35696c9f896aae55b18b67c390b3cc162e8ef"
+            "17f35696c9f896aae55b18b67c390b3cc162e8ef",
+            "0a632f3705805af9c1b2397da2f2304aa6b698cf"
         ]
     },
     "capabilities": [
@@ -665,7 +666,8 @@
                 "9217c9f1d43c84bde18849cf6bf12d8836c589c3",
                 "e3bbf75c4999c83b4c775cc317f9f6b1d180e9a1",
                 "fcc2af40ea5c3a4941dfe13be97e16c9a0c10b20",
-                "91094fccf74d20e553514ebfbb3705be7c5c1556"
+                "91094fccf74d20e553514ebfbb3705be7c5c1556",
+                "b388dee9464be7e0ac6850cd12c3a943b5868f3b"
             ],
             "behaviors": [
                 "RELEASE-VSIX-PACKAGING-001",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "agent-pivot",
-    "version": "1.0.4",
+    "version": "1.1.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "agent-pivot",
-            "version": "1.0.4",
+            "version": "1.1.0",
             "license": "MIT",
             "dependencies": {
                 "dom-autoscroller": "^2.3.4",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "agent-pivot",
     "displayName": "Agent Pivot",
     "description": "Switch, monitor, and resume Codex, Claude, and Kimi sessions across VS Code workspaces. Project manager, prompt library, and todos for AI coding agents.",
-    "version": "1.0.4",
+    "version": "1.1.0",
     "publisher": "hzcheng",
     "license": "MIT",
     "icon": "media/extension_icon.png",

--- a/scripts/lib/brandIdentity.js
+++ b/scripts/lib/brandIdentity.js
@@ -10,7 +10,7 @@ const BRAND_IDENTITY = Object.freeze({
     publisher: 'hzcheng',
     mainPackageName: 'agent-pivot',
     mainExtensionId: 'hzcheng.agent-pivot',
-    mainVersion: '1.0.4',
+    mainVersion: '1.1.0',
     bridgePackageName: 'agent-pivot-attention-ui-bridge',
     bridgeExtensionId: 'hzcheng.agent-pivot-attention-ui-bridge',
     commandPrefix: 'agentPivot.',

--- a/scripts/run-release-notes-checks.js
+++ b/scripts/run-release-notes-checks.js
@@ -14,18 +14,19 @@ const workflowPath = path.join(repositoryRoot, '.github', 'workflows', 'release-
 function validateReleaseContent({ readme, changelog, packageMetadata }) {
     assert.strictEqual(packageMetadata.displayName, 'Agent Pivot',
         'release metadata must use the Agent Pivot display name');
-    assert.strictEqual(packageMetadata.version, '1.0.4',
-        'the current Agent Pivot release must be version 1.0.4');
+    assert.strictEqual(packageMetadata.version, '1.1.0',
+        'the current Agent Pivot release must be version 1.1.0');
     const currentRelease = extractReleaseNotes(changelog, packageMetadata.version);
     const requiredReleaseFacts = [
-        ['window switching command', /Switch to Open Window/i],
-        ['comment card states', /comment cards were redesigned/i],
-        ['tmux restoration', /tmux session restoration/i],
-        ['durable attention acknowledgement', /stable event acknowledgements/i],
+        ['sponsor entry points', /Agent Pivot: Sponsor/i],
+        ['marketplace discoverability', /discoverability/i],
+        ['workspace conversation comments', /Workspace section/i],
+        ['custom running animation', /aiSessionRunningCardCustomImage/i],
     ];
 
     for (const [label, pattern] of requiredReleaseFacts) {
-        assert.match(currentRelease, pattern, `1.0.4 CHANGELOG release must document ${label}`);
+        assert.match(currentRelease, pattern,
+            `${packageMetadata.version} CHANGELOG release must document ${label}`);
     }
     assert.match(readme, /Agent Pivot/i, 'README must document the current product name');
     assert.match(packageMetadata.description, /workspace/i,

--- a/scripts/run-release-packaging-checks.js
+++ b/scripts/run-release-packaging-checks.js
@@ -401,7 +401,7 @@ function runRealVsixArchiveChecks(mainPackage, bridgePackage) {
     );
     assert.strictEqual(
         path.basename(mainArtifact),
-        'agent-pivot-1.0.4.vsix',
+        'agent-pivot-1.1.0.vsix',
         'main release artifact name must remain exact',
     );
     assert.strictEqual(

--- a/tests/unit/tooling/brandIdentity.test.js
+++ b/tests/unit/tooling/brandIdentity.test.js
@@ -50,7 +50,7 @@ function manifests() {
             name: 'agent-pivot',
             displayName: 'Agent Pivot',
             publisher: 'hzcheng',
-            version: '1.0.4',
+            version: '1.1.0',
             icon: 'media/extension_icon.png',
             repository: {
                 type: 'git',
@@ -282,7 +282,7 @@ test('brand identity exposes the exact approved public contract', () => {
         publisher: 'hzcheng',
         mainPackageName: 'agent-pivot',
         mainExtensionId: 'hzcheng.agent-pivot',
-        mainVersion: '1.0.4',
+        mainVersion: '1.1.0',
         bridgePackageName: 'agent-pivot-attention-ui-bridge',
         bridgeExtensionId: 'hzcheng.agent-pivot-attention-ui-bridge',
         commandPrefix: 'agentPivot.',

--- a/tests/unit/tooling/extensionHostLauncher.test.js
+++ b/tests/unit/tooling/extensionHostLauncher.test.js
@@ -149,7 +149,7 @@ test('RELEASE-SCHEDULED-EXTENSION-HOST-001 launches both extensions with pinned 
         ]);
         assert.deepEqual(packagePlan.map(item => path.basename(item.artifactPath)), [
             'agent-pivot-attention-ui-bridge-1.0.1.vsix',
-            'agent-pivot-1.0.4.vsix',
+            'agent-pivot-1.1.0.vsix',
         ]);
         assert.equal(options.extensionTestsPath,
             path.join(environment.testHarness, 'index.js'));

--- a/tests/unit/tooling/releaseNotes.test.js
+++ b/tests/unit/tooling/releaseNotes.test.js
@@ -14,7 +14,7 @@ test('release content validation cannot satisfy current facts from historical no
     const changelog = [
         '# Changelog',
         '',
-        '## [1.0.4] - 2026-08-06',
+        '## [1.1.0] - 2026-08-09',
         '',
         '- AI Conversation renders provider tool calls as collapsible entries.',
         '- Added context-window usage telemetry.',
@@ -33,10 +33,10 @@ test('release content validation cannot satisfy current facts from historical no
             changelog,
             packageMetadata: {
                 displayName: 'Agent Pivot',
-                version: '1.0.4',
+                version: '1.1.0',
                 description: 'Workspace command center.',
             },
         }),
-        /1\.0\.4 CHANGELOG release must document window switching command/,
+        /1\.1\.0 CHANGELOG release must document sponsor entry points/,
     );
 });


### PR DESCRIPTION
## Summary

- Releases the work merged since 1.0.4 as **Agent Pivot 1.1.0**: the sponsor entry points and marketplace discoverability metadata (#190), the Workspace section for AI Conversation Comments, provider brand icons in the conversation telemetry bar, custom running-animation images, comment panel fixes, the Mermaid/DOMPurify security bumps, and the anime-artwork animation removal.
- Moves the Unreleased CHANGELOG entries into `## [1.1.0] - 2026-08-09` and bumps the main extension to 1.1.0 (the Attention UI Bridge stays at 1.0.1 — unchanged this cycle).
- Re-anchors every versioned reader in the same commit: brand identity, release-notes facts, release-packaging artifact names, the extension-host launcher plan, and their test fixtures. The release-notes failure message now interpolates the manifest version instead of hardcoding it.

## Skill harvest

no skill change — the release used the existing version-anchor workflow (review-fix-commit-loop anchored-content rule) with every anchored reader updated in the same commit; the capability audit commit carries the same Skill-Harvest trailer.

## Verification

- `npm run test:release-notes` (version ↔ CHANGELOG ↔ required facts), `npm run brand:check`, and the tooling suites (brandIdentity / releaseNotes / extensionHostLauncher, 24/24) pass.
- `npm run test:ci:linux` green on the branch head, including the release-packaging gate that builds the 1.1.0 VSIX artifacts.
- After merge, tagging `v1.1.0` triggers `release-vsix.yml` (verify → extension-host → VSIX build → GitHub release with extracted notes).
