### PR TITLE
Centralize session navigation transactions

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -755,7 +755,7 @@
   {
     "id": "ATTENTION-STATUS-BAR-QUEUE-001",
     "domain": "attention",
-    "title": "A right-aligned status bar entry surfaces the cross-window attention count with a per-session tooltip and serially cycles a resilient cursor through the oldest-first queue on click: manual focus changes re-anchor the cursor, local sessions focus their terminal and open their conversation while staying unread by default, an opt-in setting acknowledges only after the conversation really opens, unfocusable sessions warn and stay unread without trapping the cursor, and remote sessions use an exact-target delivered mailbox hand-off before switching to the owning window",
+    "title": "A right-aligned status bar entry surfaces the cross-window attention count with a per-session tooltip and serially cycles a resilient cursor through the oldest-first queue on click: manual focus changes re-anchor the cursor, local sessions use the shared navigation transaction to focus their terminal and open their conversation while staying unread by default, interleaved Running and Attention commands settle in invocation order, an opt-in setting acknowledges only after the conversation really opens, unfocusable sessions warn and stay unread without trapping the cursor, and remote sessions use an exact-target delivered mailbox hand-off before switching to the owning window",
     "priority": "P1",
     "status": "automated",
     "owners": [
@@ -768,6 +768,8 @@
       "src/aiSessions/attentionQueue.ts",
       "src/aiSessions/attentionStatusBarController.ts",
       "src/dashboard/attentionQueueJump.ts",
+      "src/dashboard/sessionNavigationCoordinator.ts",
+      "src/dashboard/sessionNavigationFocusExecutor.ts",
       "src/openWorkspaces/attentionFocusProtocol.ts",
       "src/openWorkspaces/bridgeClient.ts",
       "src/openWorkspaces/earlyBridge.ts",
@@ -782,7 +784,7 @@
   {
     "id": "AI-SESSION-NEXT-RUNNING-COMMAND-001",
     "domain": "session",
-    "title": "The Next Running Session command serially cycles running AI sessions one jump per invocation with a stable local-first queue and a resilient cursor: manual focus changes re-anchor the cursor, local jumps focus the session terminal and open its conversation, sessions that ended mid-cycle are skipped with a warning, and remote jumps switch windows only after a v2 delivered mailbox hand-off is accepted so stale Running requests cannot steal focus from newer Attention navigation",
+    "title": "The Next Running Session command cycles running AI sessions one jump per invocation with a stable local-first queue and a resilient cursor: manual focus changes re-anchor the cursor, local jumps use the shared navigation transaction to focus the session terminal and open its conversation, interleaved Running and Attention commands settle in invocation order, sessions that ended mid-cycle are skipped with a warning, and remote jumps switch windows only after a v2 delivered mailbox hand-off is accepted so stale requests cannot steal focus from newer navigation",
     "priority": "P1",
     "status": "automated",
     "owners": [
@@ -793,6 +795,8 @@
     "evidence": [
       "src/aiSessions/runningQueue.ts",
       "src/dashboard/runningSessionJump.ts",
+      "src/dashboard/sessionNavigationCoordinator.ts",
+      "src/dashboard/sessionNavigationFocusExecutor.ts",
       "src/openWorkspaces/runningFocusProtocol.ts",
       "src/openWorkspaces/bridgeClient.ts",
       "src/openWorkspaces/earlyBridge.ts",
@@ -915,6 +919,21 @@
     ],
     "evidence": [
       "src/webview/webviewProjectScripts.js"
+    ]
+  },
+  {
+    "id": "ARCH-AI-SESSION-NAVIGATION-OWNERSHIP-001",
+    "domain": "architecture",
+    "title": "Running and Attention session commands share one navigation coordinator and one local focus executor",
+    "priority": "P1",
+    "status": "automated",
+    "owners": [
+      "scripts/run-architecture-guards.js"
+    ],
+    "evidence": [
+      "src/dashboard.ts",
+      "src/dashboard/sessionNavigationCoordinator.ts",
+      "src/dashboard/sessionNavigationFocusExecutor.ts"
     ]
   },
   {

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "01c32587c0857840cada682a13a15cdf870f6a17",
+        "head": "e8b5a718c96adda592bfbd2d268d6b178a19136d",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -236,7 +236,8 @@
             "e7678f673873894d9f6c221109dee650a8117739",
             "a0baa428798e59ac65ac58f7c4cd0a14a71666f3",
             "21028b68aaa73e4cbc512fde3409964acf25132c",
-            "85ec6150c194c09726a8e82c86c537889b765026"
+            "85ec6150c194c09726a8e82c86c537889b765026",
+            "2724a1e575fc6a2da0355aeb2054e678475443c6"
         ]
     },
     "capabilities": [
@@ -1700,7 +1701,8 @@
                 "b271c828bd442e737177e721e9e488e68a8a19b6",
                 "ff988964303fee38715e761eba7dfcb4b213b346",
                 "37ff2474d279549bd084f9b11ff880de139cdc26",
-                "01c32587c0857840cada682a13a15cdf870f6a17"
+                "01c32587c0857840cada682a13a15cdf870f6a17",
+                "e8b5a718c96adda592bfbd2d268d6b178a19136d"
             ],
             "behaviors": [
                 "AI-SESSION-NEXT-RUNNING-COMMAND-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "4da8c5f062d86ea3812752b8c5827f63585274d0",
+        "head": "01c32587c0857840cada682a13a15cdf870f6a17",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -235,7 +235,8 @@
             "126c1a5da37599264d8e5ca2a1262e7a6552f219",
             "e7678f673873894d9f6c221109dee650a8117739",
             "a0baa428798e59ac65ac58f7c4cd0a14a71666f3",
-            "21028b68aaa73e4cbc512fde3409964acf25132c"
+            "21028b68aaa73e4cbc512fde3409964acf25132c",
+            "85ec6150c194c09726a8e82c86c537889b765026"
         ]
     },
     "capabilities": [
@@ -1697,7 +1698,9 @@
                 "8470896ecde82f785aca2a3d7a162469d877bc59",
                 "8f129507ca012aa6a30b9bda870bdd65744b838a",
                 "b271c828bd442e737177e721e9e488e68a8a19b6",
-                "ff988964303fee38715e761eba7dfcb4b213b346"
+                "ff988964303fee38715e761eba7dfcb4b213b346",
+                "37ff2474d279549bd084f9b11ff880de139cdc26",
+                "01c32587c0857840cada682a13a15cdf870f6a17"
             ],
             "behaviors": [
                 "AI-SESSION-NEXT-RUNNING-COMMAND-001",

--- a/scripts/run-architecture-guards.js
+++ b/scripts/run-architecture-guards.js
@@ -563,6 +563,53 @@ function objectFreezeProperties(sourceFile, variableName, id, risk) {
 }
 
 const guards = {
+    // ARCH-AI-SESSION-NAVIGATION-OWNERSHIP-001
+    'ARCH-AI-SESSION-NAVIGATION-OWNERSHIP-001'(root) {
+        const risk = 'independent session navigation pipelines can race and project different targets';
+        const dashboard = parseTypescript(root, 'src/dashboard.ts', this.id, risk);
+        const coordinator = findVariable(
+            dashboard,
+            'sessionNavigationCoordinator',
+            this.id,
+            risk,
+        );
+        if (!coordinator.initializer
+            || !ts.isCallExpression(coordinator.initializer)
+            || coordinator.initializer.expression.getText(dashboard)
+                !== 'createSessionNavigationCoordinator') {
+            fail(this.id, risk,
+                'the Dashboard must create exactly one session navigation coordinator');
+        }
+        for (const factoryName of [
+            'createAttentionQueueJumpHandler',
+            'createRunningSessionJumpHandler',
+        ]) {
+            const calls = callArguments(dashboard, factoryName);
+            const options = calls.length === 1 ? calls[0][0] : null;
+            if (!options || !ts.isObjectLiteralExpression(options)) {
+                fail(this.id, risk, `${factoryName} must have one options object`);
+            }
+            const navigationOwner = options.properties.find(property =>
+                property.name?.getText(dashboard) === 'navigationCoordinator');
+            if (!navigationOwner || !ts.isPropertyAssignment(navigationOwner)
+                || navigationOwner.initializer.getText(dashboard)
+                    !== 'sessionNavigationCoordinator') {
+                fail(this.id, risk,
+                    'both session commands must use the shared navigation coordinator');
+            }
+            const localNavigator = options.properties.find(property =>
+                property.name?.getText(dashboard) === 'navigateSession');
+            if (!localNavigator || !ts.isPropertyAssignment(localNavigator)
+                || callArguments(
+                    localNavigator.initializer,
+                    'sessionNavigationFocusExecutor.execute',
+                ).length !== 1) {
+                fail(this.id, risk,
+                    'both session commands must use the shared local focus executor');
+            }
+        }
+    },
+
     // ARCH-AI-SESSION-CONVERSATION-BOUNDARY-001
     'ARCH-AI-SESSION-CONVERSATION-BOUNDARY-001'(root) {
         const risk = 'conversation history can expose private content or exhaust the extension host';

--- a/scripts/run-architecture-guards.js
+++ b/scripts/run-architecture-guards.js
@@ -578,7 +578,7 @@ const guards = {
             || coordinator.initializer.expression.getText(dashboard)
                 !== 'createSessionNavigationCoordinator') {
             fail(this.id, risk,
-                'the Dashboard must create exactly one session navigation coordinator');
+                'dashboard composition must create exactly one session navigation coordinator');
         }
         for (const factoryName of [
             'createAttentionQueueJumpHandler',

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -83,6 +83,8 @@ import {
 import {
     createRunningSessionJumpHandler,
 } from './dashboard/runningSessionJump';
+import { createSessionNavigationCoordinator } from './dashboard/sessionNavigationCoordinator';
+import { createSessionNavigationFocusExecutor } from './dashboard/sessionNavigationFocusExecutor';
 import {
     createAiSessionQuickSwitchHandlers,
 } from './dashboard/sessionQuickSwitch';
@@ -1788,28 +1790,21 @@ async function initializeDashboard(
         }
         return null;
     };
+    const sessionNavigationCoordinator = createSessionNavigationCoordinator();
+    const sessionNavigationFocusExecutor = createSessionNavigationFocusExecutor({
+        getProjectId: () => getCurrentWorkspaceActionTargetWithoutCardId()?.cardId || null,
+        focusActive: (projectId, provider, sessionId) =>
+            aiSessionTerminalCommandController.focusActive(
+                projectId,
+                provider,
+                sessionId,
+            ),
+        openConversation: request => openAiSessionConversationWithFeedback(request),
+    });
     const jumpToNextAttentionSession = createAttentionQueueJumpHandler({
+        navigationCoordinator: sessionNavigationCoordinator,
         buildQueue: buildCurrentAttentionQueue,
-        focusSession: item => {
-            const cardId = getCurrentWorkspaceActionTargetWithoutCardId()?.cardId;
-            return cardId
-                ? aiSessionTerminalCommandController.focusActive(
-                    cardId,
-                    item.provider,
-                    item.sessionId
-                )
-                : Promise.resolve(false);
-        },
-        openConversation: item => {
-            const cardId = getCurrentWorkspaceActionTargetWithoutCardId()?.cardId;
-            return cardId
-                ? openAiSessionConversationWithFeedback({
-                    projectId: cardId,
-                    provider: item.provider,
-                    sessionId: item.sessionId,
-                })
-                : Promise.resolve(false);
-        },
+        navigateSession: item => sessionNavigationFocusExecutor.execute(item),
         acknowledge: eventIds =>
             acknowledgeAiSessionAttentionEventIds(eventIds),
         shouldAcknowledge: () => getAgentPivotConfiguration()
@@ -1863,7 +1858,7 @@ async function initializeDashboard(
                 && Boolean(candidate.identity.sessionId));
         return direct?.identity || null;
     };
-    const focusAiSessionForJump = (target: {
+    const focusAiSessionForQuickSwitch = (target: {
         provider: AiSessionProviderId;
         sessionId: string;
     }): Promise<boolean> => {
@@ -1876,15 +1871,13 @@ async function initializeDashboard(
             target.provider,
             target.sessionId
         ).then(focused => {
-            // Re-showing an already-active terminal fires no focus event, so
-            // successful command jumps record into the MRU directly.
             if (focused) {
                 aiSessionMru.record(target.provider, target.sessionId);
             }
             return focused;
         });
     };
-    const openAiSessionConversationForJump = (target: {
+    const openAiSessionConversationForQuickSwitch = (target: {
         provider: AiSessionProviderId;
         sessionId: string;
     }): Promise<void> => {
@@ -1900,6 +1893,7 @@ async function initializeDashboard(
     const requestRemoteAiSessionFocus = (navigationIdentity: string): Promise<boolean> =>
         openWorkspaceBridgeClient.requestRunningFocus(navigationIdentity);
     const runningSessionJumpHandler = createRunningSessionJumpHandler({
+        navigationCoordinator: sessionNavigationCoordinator,
         buildQueue: () => buildRunningSessionQueue({
             localSessions: (getCurrentWorkspaceActionTargetWithoutCardId()
                 ?.sessions.activeSessions || [])
@@ -1921,8 +1915,13 @@ async function initializeDashboard(
                 })),
             selfNavigationIdentity: getCurrentOpenWorkspace()?.navigationIdentity,
         }),
-        focusSession: focusAiSessionForJump,
-        openConversation: openAiSessionConversationForJump,
+        navigateSession: item => sessionNavigationFocusExecutor.execute(item, {
+            onFocused: () => {
+                // Re-showing an already-active terminal fires no focus event,
+                // so successful Running jumps record into the MRU directly.
+                aiSessionMru.record(item.provider, item.sessionId);
+            },
+        }),
         requestRemoteFocus: item =>
             requestRemoteAiSessionFocus(item.navigationIdentity),
         openNavigationCard: cardId =>
@@ -1982,8 +1981,8 @@ async function initializeDashboard(
             placeHolder,
             matchOnDescription: true,
         }),
-        focusSession: focusAiSessionForJump,
-        openConversation: openAiSessionConversationForJump,
+        focusSession: focusAiSessionForQuickSwitch,
+        openConversation: openAiSessionConversationForQuickSwitch,
         requestRemoteFocus: target =>
             requestRemoteAiSessionFocus(target.navigationIdentity),
         openNavigationCard: cardId =>

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1804,7 +1804,8 @@ async function initializeDashboard(
     const jumpToNextAttentionSession = createAttentionQueueJumpHandler({
         navigationCoordinator: sessionNavigationCoordinator,
         buildQueue: buildCurrentAttentionQueue,
-        navigateSession: item => sessionNavigationFocusExecutor.execute(item),
+        navigateSession: (item, executionOptions) =>
+            sessionNavigationFocusExecutor.execute(item, executionOptions),
         acknowledge: eventIds =>
             acknowledgeAiSessionAttentionEventIds(eventIds),
         shouldAcknowledge: () => getAgentPivotConfiguration()
@@ -1915,13 +1916,15 @@ async function initializeDashboard(
                 })),
             selfNavigationIdentity: getCurrentOpenWorkspace()?.navigationIdentity,
         }),
-        navigateSession: item => sessionNavigationFocusExecutor.execute(item, {
+        navigateSession: (item, executionOptions) =>
+            sessionNavigationFocusExecutor.execute(item, {
             onFocused: () => {
+                executionOptions.onFocused?.();
                 // Re-showing an already-active terminal fires no focus event,
                 // so successful Running jumps record into the MRU directly.
                 aiSessionMru.record(item.provider, item.sessionId);
             },
-        }),
+            }),
         requestRemoteFocus: item =>
             requestRemoteAiSessionFocus(item.navigationIdentity),
         openNavigationCard: cardId =>

--- a/src/dashboard/attentionQueueJump.ts
+++ b/src/dashboard/attentionQueueJump.ts
@@ -5,11 +5,15 @@ import type {
     AttentionQueueItem,
 } from '../aiSessions/attentionQueue';
 import type { AiSessionProviderId } from '../models';
+import {
+    createSessionNavigationCoordinator,
+    SessionNavigationCoordinator,
+} from './sessionNavigationCoordinator';
+import type { SessionNavigationFocusResult } from './sessionNavigationFocusExecutor';
 
-export interface AttentionQueueJumpOptions {
+interface AttentionQueueJumpBaseOptions {
+    navigationCoordinator?: SessionNavigationCoordinator;
     buildQueue: () => AttentionQueue;
-    focusSession: (item: AttentionQueueItem) => Promise<boolean>;
-    openConversation: (item: AttentionQueueItem) => Promise<boolean>;
     acknowledge: (eventIds: string[]) => Promise<void>;
     shouldAcknowledge: () => boolean;
     requestRemoteFocus?: (item: AttentionQueueItem) => Promise<boolean>;
@@ -20,6 +24,19 @@ export interface AttentionQueueJumpOptions {
     /** The session the user is currently watching, when it is a known AI session. */
     getCurrentIdentity?: () => { provider: AiSessionProviderId; sessionId: string } | null;
 }
+
+export type AttentionQueueJumpOptions = AttentionQueueJumpBaseOptions & (
+    {
+        navigateSession: (item: AttentionQueueItem) => Promise<SessionNavigationFocusResult>;
+        focusSession?: never;
+        openConversation?: never;
+    }
+    | {
+        navigateSession?: never;
+        focusSession: (item: AttentionQueueItem) => Promise<boolean>;
+        openConversation: (item: AttentionQueueItem) => Promise<boolean>;
+    }
+);
 
 export interface AttentionQueueJumpHandler {
     (): Promise<void>;
@@ -45,29 +62,41 @@ export function createAttentionQueueJumpHandler(
 ): AttentionQueueJumpHandler {
     let lastKey: string | null = null;
     let lastObservedCurrentKey: string | null = null;
-    let tail: Promise<void> = Promise.resolve();
-
-    function enqueue(task: () => Promise<void>): Promise<void> {
-        const result = tail.then(task, task);
-        tail = result.then(() => undefined, () => undefined);
-        return result;
-    }
+    const navigationCoordinator = options.navigationCoordinator
+        || createSessionNavigationCoordinator();
 
     async function jumpToLocal(item: AttentionQueueItem): Promise<void> {
         const key = attentionQueueItemKey(item);
         lastKey = key;
-        const focused = await options.focusSession(item);
-        if (!focused) {
+        const result = options.navigateSession
+            ? await options.navigateSession(item)
+            : await navigateWithLegacyCallbacks(item);
+        if (!result.focused) {
             options.showWarningMessage(
                 'Agent Pivot: the selected AI session is no longer active.'
             );
             return;
         }
         lastObservedCurrentKey = key;
-        const opened = await options.openConversation(item);
-        if (opened && options.shouldAcknowledge()) {
+        if (result.conversationOpened && options.shouldAcknowledge()) {
             await options.acknowledge(item.eventIds);
         }
+    }
+
+    async function navigateWithLegacyCallbacks(
+        item: AttentionQueueItem,
+    ): Promise<SessionNavigationFocusResult> {
+        if (!options.focusSession || !options.openConversation) {
+            throw new Error('Attention navigation requires one local execution strategy');
+        }
+        const focused = await options.focusSession(item);
+        if (!focused) {
+            return { focused: false, conversationOpened: false };
+        }
+        return {
+            focused: true,
+            conversationOpened: await options.openConversation(item),
+        };
     }
 
     async function jumpToNextAttentionSession(): Promise<void> {
@@ -167,8 +196,12 @@ export function createAttentionQueueJumpHandler(
         await jumpToLocal(local);
     }
 
-    const handler = (() => enqueue(jumpToNextAttentionSession)) as AttentionQueueJumpHandler;
-    handler.jumpToAttentionSession = item => enqueue(() => jumpToAttentionSession(item));
+    const handler = (() => navigationCoordinator.enqueue(
+        jumpToNextAttentionSession
+    )) as AttentionQueueJumpHandler;
+    handler.jumpToAttentionSession = item => navigationCoordinator.enqueue(
+        () => jumpToAttentionSession(item)
+    );
     return handler;
 }
 

--- a/src/dashboard/attentionQueueJump.ts
+++ b/src/dashboard/attentionQueueJump.ts
@@ -9,7 +9,10 @@ import {
     createSessionNavigationCoordinator,
     SessionNavigationCoordinator,
 } from './sessionNavigationCoordinator';
-import type { SessionNavigationFocusResult } from './sessionNavigationFocusExecutor';
+import type {
+    SessionNavigationFocusExecutionOptions,
+    SessionNavigationFocusResult,
+} from './sessionNavigationFocusExecutor';
 
 interface AttentionQueueJumpBaseOptions {
     navigationCoordinator?: SessionNavigationCoordinator;
@@ -27,7 +30,10 @@ interface AttentionQueueJumpBaseOptions {
 
 export type AttentionQueueJumpOptions = AttentionQueueJumpBaseOptions & (
     {
-        navigateSession: (item: AttentionQueueItem) => Promise<SessionNavigationFocusResult>;
+        navigateSession: (
+            item: AttentionQueueItem,
+            executionOptions: SessionNavigationFocusExecutionOptions,
+        ) => Promise<SessionNavigationFocusResult>;
         focusSession?: never;
         openConversation?: never;
     }
@@ -69,15 +75,18 @@ export function createAttentionQueueJumpHandler(
         const key = attentionQueueItemKey(item);
         lastKey = key;
         const result = options.navigateSession
-            ? await options.navigateSession(item)
-            : await navigateWithLegacyCallbacks(item);
+            ? await options.navigateSession(item, {
+                onFocused: () => { lastObservedCurrentKey = key; },
+            })
+            : await navigateWithLegacyCallbacks(item, {
+                onFocused: () => { lastObservedCurrentKey = key; },
+            });
         if (!result.focused) {
             options.showWarningMessage(
                 'Agent Pivot: the selected AI session is no longer active.'
             );
             return;
         }
-        lastObservedCurrentKey = key;
         if (result.conversationOpened && options.shouldAcknowledge()) {
             await options.acknowledge(item.eventIds);
         }
@@ -85,6 +94,7 @@ export function createAttentionQueueJumpHandler(
 
     async function navigateWithLegacyCallbacks(
         item: AttentionQueueItem,
+        executionOptions: SessionNavigationFocusExecutionOptions,
     ): Promise<SessionNavigationFocusResult> {
         if (!options.focusSession || !options.openConversation) {
             throw new Error('Attention navigation requires one local execution strategy');
@@ -93,6 +103,7 @@ export function createAttentionQueueJumpHandler(
         if (!focused) {
             return { focused: false, conversationOpened: false };
         }
+        executionOptions.onFocused?.();
         return {
             focused: true,
             conversationOpened: await options.openConversation(item),

--- a/src/dashboard/runningSessionJump.ts
+++ b/src/dashboard/runningSessionJump.ts
@@ -7,11 +7,15 @@ import {
     RunningSessionQueueLocalItem,
     RunningSessionQueueRemoteItem,
 } from '../aiSessions/runningQueue';
+import {
+    createSessionNavigationCoordinator,
+    SessionNavigationCoordinator,
+} from './sessionNavigationCoordinator';
+import type { SessionNavigationFocusResult } from './sessionNavigationFocusExecutor';
 
-export interface RunningSessionJumpOptions {
+interface RunningSessionJumpBaseOptions {
+    navigationCoordinator?: SessionNavigationCoordinator;
     buildQueue: () => RunningSessionQueue;
-    focusSession: (item: RunningSessionQueueLocalItem) => Promise<boolean>;
-    openConversation: (item: RunningSessionQueueLocalItem) => Promise<void>;
     requestRemoteFocus: (item: RunningSessionQueueRemoteItem) => Promise<boolean>;
     openNavigationCard: (cardId: string) => Promise<void>;
     showInformationMessage: (message: string) => void;
@@ -19,6 +23,21 @@ export interface RunningSessionJumpOptions {
     /** Key of the session the user is currently looking at, when known. */
     getCurrentKey?: () => string | null;
 }
+
+export type RunningSessionJumpOptions = RunningSessionJumpBaseOptions & (
+    {
+        navigateSession: (
+            item: RunningSessionQueueLocalItem
+        ) => Promise<SessionNavigationFocusResult>;
+        focusSession?: never;
+        openConversation?: never;
+    }
+    | {
+        navigateSession?: never;
+        focusSession: (item: RunningSessionQueueLocalItem) => Promise<boolean>;
+        openConversation: (item: RunningSessionQueueLocalItem) => Promise<void>;
+    }
+);
 
 export interface RunningSessionJumpHandler {
     jumpToNextRunningSession(): Promise<void>;
@@ -43,25 +62,35 @@ export function createRunningSessionJumpHandler(
 ): RunningSessionJumpHandler {
     let lastKey: string | null = null;
     let lastObservedCurrentKey: string | null = null;
-    let tail: Promise<void> = Promise.resolve();
-
-    function enqueue(task: () => Promise<void>): Promise<void> {
-        const result = tail.then(task, task);
-        tail = result.then(() => undefined, () => undefined);
-        return result;
-    }
+    const navigationCoordinator = options.navigationCoordinator
+        || createSessionNavigationCoordinator();
 
     async function jumpToLocal(item: RunningSessionQueueLocalItem): Promise<void> {
-        const focused = await options.focusSession(item);
+        const result = options.navigateSession
+            ? await options.navigateSession(item)
+            : await navigateWithLegacyCallbacks(item);
         lastKey = item.key;
-        if (!focused) {
+        if (!result.focused) {
             options.showWarningMessage(
                 'Agent Pivot: the selected AI session is no longer active.'
             );
             return;
         }
         lastObservedCurrentKey = item.key;
+    }
+
+    async function navigateWithLegacyCallbacks(
+        item: RunningSessionQueueLocalItem,
+    ): Promise<SessionNavigationFocusResult> {
+        if (!options.focusSession || !options.openConversation) {
+            throw new Error('Running navigation requires one local execution strategy');
+        }
+        const focused = await options.focusSession(item);
+        if (!focused) {
+            return { focused: false, conversationOpened: false };
+        }
         await options.openConversation(item);
+        return { focused: true, conversationOpened: true };
     }
 
     async function jumpToRemote(item: RunningSessionQueueRemoteItem): Promise<void> {
@@ -121,7 +150,7 @@ export function createRunningSessionJumpHandler(
     }
 
     return {
-        jumpToNextRunningSession: () => enqueue(() => jump('all')),
-        jumpToNextLocalRunningSession: () => enqueue(() => jump('local')),
+        jumpToNextRunningSession: () => navigationCoordinator.enqueue(() => jump('all')),
+        jumpToNextLocalRunningSession: () => navigationCoordinator.enqueue(() => jump('local')),
     };
 }

--- a/src/dashboard/runningSessionJump.ts
+++ b/src/dashboard/runningSessionJump.ts
@@ -11,7 +11,10 @@ import {
     createSessionNavigationCoordinator,
     SessionNavigationCoordinator,
 } from './sessionNavigationCoordinator';
-import type { SessionNavigationFocusResult } from './sessionNavigationFocusExecutor';
+import type {
+    SessionNavigationFocusExecutionOptions,
+    SessionNavigationFocusResult,
+} from './sessionNavigationFocusExecutor';
 
 interface RunningSessionJumpBaseOptions {
     navigationCoordinator?: SessionNavigationCoordinator;
@@ -27,7 +30,8 @@ interface RunningSessionJumpBaseOptions {
 export type RunningSessionJumpOptions = RunningSessionJumpBaseOptions & (
     {
         navigateSession: (
-            item: RunningSessionQueueLocalItem
+            item: RunningSessionQueueLocalItem,
+            executionOptions: SessionNavigationFocusExecutionOptions,
         ) => Promise<SessionNavigationFocusResult>;
         focusSession?: never;
         openConversation?: never;
@@ -67,20 +71,30 @@ export function createRunningSessionJumpHandler(
 
     async function jumpToLocal(item: RunningSessionQueueLocalItem): Promise<void> {
         const result = options.navigateSession
-            ? await options.navigateSession(item)
-            : await navigateWithLegacyCallbacks(item);
-        lastKey = item.key;
+            ? await options.navigateSession(item, {
+                onFocused: () => {
+                    lastKey = item.key;
+                    lastObservedCurrentKey = item.key;
+                },
+            })
+            : await navigateWithLegacyCallbacks(item, {
+                onFocused: () => {
+                    lastKey = item.key;
+                    lastObservedCurrentKey = item.key;
+                },
+            });
         if (!result.focused) {
+            lastKey = item.key;
             options.showWarningMessage(
                 'Agent Pivot: the selected AI session is no longer active.'
             );
             return;
         }
-        lastObservedCurrentKey = item.key;
     }
 
     async function navigateWithLegacyCallbacks(
         item: RunningSessionQueueLocalItem,
+        executionOptions: SessionNavigationFocusExecutionOptions,
     ): Promise<SessionNavigationFocusResult> {
         if (!options.focusSession || !options.openConversation) {
             throw new Error('Running navigation requires one local execution strategy');
@@ -89,6 +103,7 @@ export function createRunningSessionJumpHandler(
         if (!focused) {
             return { focused: false, conversationOpened: false };
         }
+        executionOptions.onFocused?.();
         await options.openConversation(item);
         return { focused: true, conversationOpened: true };
     }

--- a/src/dashboard/sessionNavigationCoordinator.ts
+++ b/src/dashboard/sessionNavigationCoordinator.ts
@@ -1,0 +1,23 @@
+'use strict';
+
+export type SessionNavigationTask = () => Promise<void>;
+
+export interface SessionNavigationCoordinator {
+    enqueue(task: SessionNavigationTask): Promise<void>;
+}
+
+/**
+ * Owns the ordering of every user-visible AI session navigation transaction
+ * in one extension host. A failed transaction does not poison later commands,
+ * while a later command never starts before the earlier transaction settles.
+ */
+export function createSessionNavigationCoordinator(): SessionNavigationCoordinator {
+    let tail: Promise<void> = Promise.resolve();
+    return {
+        enqueue(task: SessionNavigationTask): Promise<void> {
+            const result = tail.then(task, task);
+            tail = result.then(() => undefined, () => undefined);
+            return result;
+        },
+    };
+}

--- a/src/dashboard/sessionNavigationFocusExecutor.ts
+++ b/src/dashboard/sessionNavigationFocusExecutor.ts
@@ -1,0 +1,74 @@
+'use strict';
+
+import type { AiSessionProviderId } from '../models';
+
+export interface SessionNavigationFocusTarget {
+    provider: AiSessionProviderId;
+    sessionId: string;
+}
+
+export interface SessionNavigationFocusResult {
+    focused: boolean;
+    conversationOpened: boolean;
+}
+
+export interface SessionNavigationFocusExecutionOptions {
+    onFocused?(): void;
+}
+
+export interface SessionNavigationFocusExecutor {
+    execute(
+        target: SessionNavigationFocusTarget,
+        executionOptions?: SessionNavigationFocusExecutionOptions,
+    ): Promise<SessionNavigationFocusResult>;
+}
+
+export interface SessionNavigationFocusExecutorOptions {
+    getProjectId(): string | null;
+    focusActive(
+        projectId: string,
+        provider: AiSessionProviderId,
+        sessionId: string,
+    ): Promise<boolean>;
+    openConversation(request: {
+        projectId: string;
+        provider: AiSessionProviderId;
+        sessionId: string;
+    }): Promise<boolean>;
+}
+
+/**
+ * Executes the local, user-visible portion of an AI session navigation as one
+ * transaction. The project is resolved once so a refresh or window handoff
+ * cannot make terminal focus and conversation open target different cards.
+ */
+export function createSessionNavigationFocusExecutor(
+    options: SessionNavigationFocusExecutorOptions,
+): SessionNavigationFocusExecutor {
+    return {
+        async execute(
+            target: SessionNavigationFocusTarget,
+            executionOptions: SessionNavigationFocusExecutionOptions = {},
+        ): Promise<SessionNavigationFocusResult> {
+            const projectId = options.getProjectId();
+            if (!projectId) {
+                return { focused: false, conversationOpened: false };
+            }
+            const focused = await options.focusActive(
+                projectId,
+                target.provider,
+                target.sessionId,
+            );
+            if (!focused) {
+                return { focused: false, conversationOpened: false };
+            }
+            executionOptions.onFocused?.();
+            const conversationOpened = await options.openConversation({
+                projectId,
+                provider: target.provider,
+                sessionId: target.sessionId,
+            });
+            return { focused: true, conversationOpened };
+        },
+    };
+}

--- a/tests/contract/aiSessions/attentionStatusBar.test.js
+++ b/tests/contract/aiSessions/attentionStatusBar.test.js
@@ -29,6 +29,12 @@ const {
 const {
     createAttentionQueueJumpHandler,
 } = require('../../../out/dashboard/attentionQueueJump');
+const {
+    createRunningSessionJumpHandler,
+} = require('../../../out/dashboard/runningSessionJump');
+const {
+    createSessionNavigationCoordinator,
+} = require('../../../out/dashboard/sessionNavigationCoordinator');
 
 function projectKeyOf(uri) {
     return getAttentionProjectKey(getAttentionProjectPath(uri));
@@ -608,4 +614,84 @@ test('ATTENTION-STATUS-BAR-QUEUE-001 serializes rapid invocations so the last pr
     releases.shift()();
     await Promise.all([first, second]);
     assert.equal(focused, 'c');
+});
+
+test('ATTENTION-STATUS-BAR-QUEUE-001 AI-SESSION-NEXT-RUNNING-COMMAND-001 serializes interleaved navigation commands so the last invocation wins', async () => {
+    const navigationCoordinator = createSessionNavigationCoordinator();
+    let releaseRunningFocus;
+    let focused = 'running-a';
+    const calls = [];
+    const running = createRunningSessionJumpHandler({
+        navigationCoordinator,
+        buildQueue: () => ({
+            items: [
+                { kind: 'local', key: 'session:codex:running-a', provider: 'codex', sessionId: 'running-a' },
+                { kind: 'local', key: 'session:codex:running-b', provider: 'codex', sessionId: 'running-b' },
+            ],
+            localCount: 2,
+            remoteCount: 0,
+            total: 2,
+        }),
+        focusSession: item => new Promise(resolve => {
+            calls.push(['running-focus-start', item.sessionId]);
+            releaseRunningFocus = () => {
+                focused = item.sessionId;
+                calls.push(['running-focus-end', item.sessionId]);
+                resolve(true);
+            };
+        }),
+        openConversation: async item => calls.push(['running-open', item.sessionId]),
+        requestRemoteFocus: async () => true,
+        openNavigationCard: async () => {},
+        showInformationMessage: () => {},
+        showWarningMessage: () => {},
+        getCurrentKey: () => `session:codex:${focused}`,
+    });
+    const attention = createAttentionQueueJumpHandler({
+        navigationCoordinator,
+        buildQueue: () => ({
+            items: [{
+                provider: 'codex', sessionId: 'attention', projectId: 'A',
+                eventIds: ['event'], reasons: ['completed'], observedAtMs: 1, local: true,
+            }],
+            localCount: 1,
+            remoteCount: 0,
+            total: 1,
+        }),
+        focusSession: async item => {
+            focused = item.sessionId;
+            calls.push(['attention-focus', item.sessionId]);
+            return true;
+        },
+        openConversation: async item => {
+            calls.push(['attention-open', item.sessionId]);
+            return true;
+        },
+        acknowledge: async () => {},
+        shouldAcknowledge: () => false,
+        findNavigationCardId: () => null,
+        openNavigationCard: async () => {},
+        showInformationMessage: () => {},
+        showWarningMessage: () => {},
+        getCurrentIdentity: () => null,
+    });
+
+    const runningJump = running.jumpToNextRunningSession();
+    await Promise.resolve();
+    const attentionJump = attention();
+    await Promise.resolve();
+
+    assert.deepEqual(calls, [['running-focus-start', 'running-b']],
+        'Attention must wait for the earlier Running focus transaction');
+    releaseRunningFocus();
+    await Promise.all([runningJump, attentionJump]);
+
+    assert.deepEqual(calls, [
+        ['running-focus-start', 'running-b'],
+        ['running-focus-end', 'running-b'],
+        ['running-open', 'running-b'],
+        ['attention-focus', 'attention'],
+        ['attention-open', 'attention'],
+    ]);
+    assert.equal(focused, 'attention', 'the latest navigation invocation must own final focus');
 });

--- a/tests/contract/aiSessions/runningSessionJump.test.js
+++ b/tests/contract/aiSessions/runningSessionJump.test.js
@@ -10,6 +10,12 @@ const {
 const {
     createRunningSessionJumpHandler,
 } = require('../../../out/dashboard/runningSessionJump');
+const {
+    createSessionNavigationCoordinator,
+} = require('../../../out/dashboard/sessionNavigationCoordinator');
+const {
+    createSessionNavigationFocusExecutor,
+} = require('../../../out/dashboard/sessionNavigationFocusExecutor');
 
 const WINDOW_A = 'a'.repeat(64);
 const WINDOW_B = 'b'.repeat(64);
@@ -452,4 +458,86 @@ test('AI-SESSION-NEXT-RUNNING-COMMAND-001 makes a late handoff idempotent with a
     assert.deepEqual(picked, ['b2', 'b2'],
         'a handoff delivered after a user jump may reaffirm, but never reverse, that jump');
     assert.equal(focused, 'b2');
+});
+
+test('AI-SESSION-NEXT-RUNNING-COMMAND-001 keeps the shared navigation queue usable after a failed transaction', async () => {
+    const coordinator = createSessionNavigationCoordinator();
+    const calls = [];
+
+    const failed = coordinator.enqueue(async () => {
+        calls.push('failed');
+        throw new Error('focus failed');
+    });
+    const recovered = coordinator.enqueue(async () => {
+        calls.push('recovered');
+    });
+
+    await assert.rejects(failed, /focus failed/);
+    await recovered;
+    assert.deepEqual(calls, ['failed', 'recovered']);
+});
+
+test('AI-SESSION-NEXT-RUNNING-COMMAND-001 executes terminal focus and conversation open against one project snapshot', async () => {
+    let projectId = 'project-before-focus';
+    const calls = [];
+    const executor = createSessionNavigationFocusExecutor({
+        getProjectId: () => projectId,
+        focusActive: async (capturedProjectId, provider, sessionId) => {
+            calls.push(['focus', capturedProjectId, provider, sessionId]);
+            projectId = 'project-after-focus';
+            return true;
+        },
+        openConversation: async request => {
+            calls.push(['open', request.projectId, request.provider, request.sessionId]);
+            return true;
+        },
+    });
+
+    assert.deepEqual(await executor.execute({ provider: 'codex', sessionId: 'target' }), {
+        focused: true,
+        conversationOpened: true,
+    });
+    assert.deepEqual(calls, [
+        ['focus', 'project-before-focus', 'codex', 'target'],
+        ['open', 'project-before-focus', 'codex', 'target'],
+    ], 'one transaction cannot focus and open against different workspace cards');
+});
+
+test('AI-SESSION-NEXT-RUNNING-COMMAND-001 does not open a conversation when local focus cannot be established', async () => {
+    let opens = 0;
+    const executor = createSessionNavigationFocusExecutor({
+        getProjectId: () => 'project',
+        focusActive: async () => false,
+        openConversation: async () => {
+            opens += 1;
+            return true;
+        },
+    });
+
+    assert.deepEqual(await executor.execute({ provider: 'codex', sessionId: 'gone' }), {
+        focused: false,
+        conversationOpened: false,
+    });
+    assert.equal(opens, 0);
+});
+
+test('AI-SESSION-NEXT-RUNNING-COMMAND-001 records focus before opening the conversation', async () => {
+    const calls = [];
+    const executor = createSessionNavigationFocusExecutor({
+        getProjectId: () => 'project',
+        focusActive: async () => {
+            calls.push('focus');
+            return true;
+        },
+        openConversation: async () => {
+            calls.push('open');
+            return true;
+        },
+    });
+
+    await executor.execute(
+        { provider: 'codex', sessionId: 'target' },
+        { onFocused: () => calls.push('record-mru') },
+    );
+    assert.deepEqual(calls, ['focus', 'record-mru', 'open']);
 });

--- a/tests/contract/aiSessions/runningSessionJump.test.js
+++ b/tests/contract/aiSessions/runningSessionJump.test.js
@@ -541,3 +541,33 @@ test('AI-SESSION-NEXT-RUNNING-COMMAND-001 records focus before opening the conve
     );
     assert.deepEqual(calls, ['focus', 'record-mru', 'open']);
 });
+
+test('AI-SESSION-NEXT-RUNNING-COMMAND-001 advances after conversation open fails post-focus', async () => {
+    const queue = buildRunningSessionQueue({
+        localSessions: ['a', 'b', 'c'].map(sessionId => local('codex', sessionId)),
+        remoteWindows: [],
+    });
+    let focused = 'a';
+    const picked = [];
+    const { options } = makeJumpOptions({ queue });
+    options.focusSession = async item => {
+        focused = item.sessionId;
+        picked.push(item.sessionId);
+        return true;
+    };
+    let opens = 0;
+    options.openConversation = async () => {
+        opens += 1;
+        if (opens === 1) {
+            throw new Error('conversation unavailable');
+        }
+    };
+    options.getCurrentKey = () => `session:codex:${focused}`;
+    const handler = createRunningSessionJumpHandler(options);
+
+    await assert.rejects(handler.jumpToNextRunningSession(), /conversation unavailable/);
+    await handler.jumpToNextRunningSession();
+
+    assert.deepEqual(picked, ['b', 'c'],
+        'a post-focus open failure must not make the next command repeat the focused session');
+});

--- a/tests/unit/tooling/architectureGuards.test.js
+++ b/tests/unit/tooling/architectureGuards.test.js
@@ -290,6 +290,24 @@ for (const [label, reExport] of [
 
 for (const mutation of [
     {
+        id: 'ARCH-AI-SESSION-NAVIGATION-OWNERSHIP-001',
+        file: 'src/dashboard.ts',
+        expectedDetail: 'both session commands must use the shared navigation coordinator',
+        mutate: source => source.replace(
+            'navigationCoordinator: sessionNavigationCoordinator,',
+            'navigationCoordinator: createSessionNavigationCoordinator(),',
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-NAVIGATION-OWNERSHIP-001',
+        file: 'src/dashboard.ts',
+        expectedDetail: 'both session commands must use the shared local focus executor',
+        mutate: source => source.replace(
+            'navigateSession: item => sessionNavigationFocusExecutor.execute(item),',
+            'navigateSession: async () => ({ focused: false, conversationOpened: false }),',
+        ),
+    },
+    {
         id: 'ARCH-AI-SESSION-CONVERSATION-BOUNDARY-001',
         file: 'src/aiSessions/conversation/codexAdapter.ts',
         expectedDetail: 'Codex conversation adapter must not import filesystem or transcript JSONL readers',

--- a/tests/unit/tooling/architectureGuards.test.js
+++ b/tests/unit/tooling/architectureGuards.test.js
@@ -303,7 +303,8 @@ for (const mutation of [
         file: 'src/dashboard.ts',
         expectedDetail: 'both session commands must use the shared local focus executor',
         mutate: source => source.replace(
-            'navigateSession: item => sessionNavigationFocusExecutor.execute(item),',
+            'navigateSession: (item, executionOptions) =>\n'
+                + '            sessionNavigationFocusExecutor.execute(item, executionOptions),',
             'navigateSession: async () => ({ focused: false, conversationOpened: false }),',
         ),
     },


### PR DESCRIPTION
## Summary

- Serialize Next Running Session and Next Attention Session through one shared navigation coordinator.
- Route both commands through one local focus executor that keeps terminal focus and conversation open on the same workspace snapshot.
- Preserve focus-phase cursor and MRU ordering when conversation opening fails.
- Add an interleaved Running/Attention regression journey and an architecture guard that prevents the commands from regaining private navigation ownership.

## Scope

This is the first architecture-refactor stage. Queue selection policies, cross-window protocols, persisted formats, provider adapters, and tmux backend behavior remain unchanged. Follow-up stages can consolidate the versioned remote transport after this boundary is proven stable.

## Testing

- `npm run test:ci:linux`
- 861 deterministic tests passed
- 394 integration tests passed
- 176 browser tests passed
- Release packaging passed
- Changed-line coverage: 94.04% (205/218)

## Skill harvest

No skill change. Existing architecture-refactor and review-loop guidance already requires safety-net-first execution, call-site review, partial-failure checks, executable boundaries, and fresh full-suite verification.