### PR TITLE
Unify cross-window focus transport

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -937,6 +937,21 @@
     ]
   },
   {
+    "id": "ARCH-OPEN-WORKSPACE-FOCUS-TRANSPORT-OWNERSHIP-001",
+    "domain": "architecture",
+    "title": "Running and Attention cross-window focus share one mailbox and delivery state machine",
+    "priority": "P1",
+    "status": "automated",
+    "owners": [
+      "scripts/run-architecture-guards.js",
+      "tests/contract/openProjects/attentionFocus.test.js"
+    ],
+    "evidence": [
+      "extensions/attention-ui-bridge/src/openWorkspaceFocusMailboxStore.ts",
+      "extensions/attention-ui-bridge/src/openWorkspaceFocusMailboxCoordinator.ts"
+    ]
+  },
+  {
     "id": "ARCH-AI-SESSION-INCREMENTAL-REFRESH-SOURCE-001",
     "domain": "architecture",
     "title": "AI Session Incremental Refresh Source behavior",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "e8b5a718c96adda592bfbd2d268d6b178a19136d",
+        "head": "0651bb2aa5339a882b3d7fffa705907df6b9c796",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -237,7 +237,8 @@
             "a0baa428798e59ac65ac58f7c4cd0a14a71666f3",
             "21028b68aaa73e4cbc512fde3409964acf25132c",
             "85ec6150c194c09726a8e82c86c537889b765026",
-            "2724a1e575fc6a2da0355aeb2054e678475443c6"
+            "2724a1e575fc6a2da0355aeb2054e678475443c6",
+            "b8a863f10a32baef04c4b916d3e08c6b70799657"
         ]
     },
     "capabilities": [
@@ -1702,17 +1703,20 @@
                 "ff988964303fee38715e761eba7dfcb4b213b346",
                 "37ff2474d279549bd084f9b11ff880de139cdc26",
                 "01c32587c0857840cada682a13a15cdf870f6a17",
-                "e8b5a718c96adda592bfbd2d268d6b178a19136d"
+                "e8b5a718c96adda592bfbd2d268d6b178a19136d",
+                "0651bb2aa5339a882b3d7fffa705907df6b9c796"
             ],
             "behaviors": [
                 "AI-SESSION-NEXT-RUNNING-COMMAND-001",
                 "OPEN-WORKSPACE-RUNNING-FOCUS-PROTOCOL-001",
                 "OPEN-WORKSPACE-RUNNING-FOCUS-STORE-001",
                 "OPEN-WORKSPACE-RUNNING-FOCUS-COORDINATOR-001",
-                "OPEN-WORKSPACE-RUNNING-FOCUS-CLIENT-001"
+                "OPEN-WORKSPACE-RUNNING-FOCUS-CLIENT-001",
+                "ARCH-OPEN-WORKSPACE-FOCUS-TRANSPORT-OWNERSHIP-001"
             ],
             "prGates": [
-                "test:deterministic:run"
+                "test:deterministic:run",
+                "test:architecture-guards"
             ],
             "scheduledJobs": [],
             "realEnvironmentRequired": false

--- a/extensions/attention-ui-bridge/src/openWorkspaceAttentionFocusCoordinator.ts
+++ b/extensions/attention-ui-bridge/src/openWorkspaceAttentionFocusCoordinator.ts
@@ -1,149 +1,59 @@
 'use strict';
 
-import * as fs from 'fs';
-
 import {
     OPEN_WORKSPACE_ATTENTION_FOCUS_PROTOCOL_VERSION,
     OpenWorkspaceAttentionFocusOutcome,
     OpenWorkspaceAttentionFocusRequest,
     validateOpenWorkspaceAttentionFocusRequest,
 } from '../../../src/openWorkspaces/attentionFocusProtocol';
+import {
+    OpenWorkspaceFocusMailboxCoordinator,
+    OpenWorkspaceFocusMailboxCoordinatorDependencies,
+} from './openWorkspaceFocusMailboxCoordinator';
 import { OpenWorkspaceAttentionFocusStore } from './openWorkspaceAttentionFocusStore';
 
-const SCAN_INTERVAL_MS = 2_000;
-const DELIVERY_WAIT_MS = 5_000;
-
-interface WatcherLike {
-    close(): void;
-}
-
-export interface OpenWorkspaceAttentionFocusCoordinatorDependencies {
-    now(): number;
-    deliverRequest(request: OpenWorkspaceAttentionFocusRequest): PromiseLike<unknown> | unknown;
-    isNavigationWinner(navigationIdentity: string): Promise<boolean>;
-    reportError(error: unknown): void;
-    setInterval(callback: () => void, intervalMs: number): unknown;
-    clearInterval(handle: unknown): void;
-    createWatcher(directoryPath: string, onDidChange: () => void): WatcherLike;
+export interface OpenWorkspaceAttentionFocusCoordinatorDependencies
+    extends OpenWorkspaceFocusMailboxCoordinatorDependencies<OpenWorkspaceAttentionFocusRequest> {
     createStore?(rootDirectory: string): OpenWorkspaceAttentionFocusStore;
-    deliveryWaitMs?: number;
 }
 
 export class OpenWorkspaceAttentionFocusCoordinator {
-    private readonly store: OpenWorkspaceAttentionFocusStore;
-    private readonly watcher: WatcherLike;
-    private readonly intervalHandle: unknown;
-    private scanFlight: Promise<void> | null = null;
-    private scanRequested = false;
-    private disposed = false;
+    private readonly coordinator: OpenWorkspaceFocusMailboxCoordinator<
+        OpenWorkspaceAttentionFocusRequest,
+        OpenWorkspaceAttentionFocusOutcome
+    >;
 
     constructor(
         rootDirectory: string,
-        private readonly dependencies: OpenWorkspaceAttentionFocusCoordinatorDependencies,
+        dependencies: OpenWorkspaceAttentionFocusCoordinatorDependencies,
     ) {
-        this.store = dependencies.createStore
-            ? dependencies.createStore(rootDirectory)
-            : new OpenWorkspaceAttentionFocusStore(rootDirectory);
-        fs.mkdirSync(this.store.directoryPath, { recursive: true, mode: 0o700 });
-        this.watcher = dependencies.createWatcher(
-            this.store.directoryPath,
-            () => this.requestDelivery(),
-        );
-        this.intervalHandle = dependencies.setInterval(
-            () => this.requestDelivery(),
-            SCAN_INTERVAL_MS,
-        );
+        this.coordinator = new OpenWorkspaceFocusMailboxCoordinator({
+            store: dependencies.createStore
+                ? dependencies.createStore(rootDirectory)
+                : new OpenWorkspaceAttentionFocusStore(rootDirectory),
+            dependencies,
+            validateRequest: validateOpenWorkspaceAttentionFocusRequest,
+            createOutcome: request => ({
+                protocolVersion: OPEN_WORKSPACE_ATTENTION_FOCUS_PROTOCOL_VERSION,
+                requestId: request.requestId,
+                targetNavigationIdentity: request.targetNavigationIdentity,
+                delivered: true,
+            }),
+            deliveryTimeoutMessage:
+                'open workspace attention focus request was not delivered in time',
+            disposedMessage: 'open workspace attention focus coordinator is disposed',
+        });
     }
 
-    async submit(raw: unknown): Promise<OpenWorkspaceAttentionFocusOutcome> {
-        this.ensureActive();
-        const request = await this.store.submit(
-            validateOpenWorkspaceAttentionFocusRequest(raw),
-        );
-        this.requestDelivery();
-        const delivered = await this.store.waitForDelivery(
-            request.requestId,
-            this.dependencies.deliveryWaitMs ?? DELIVERY_WAIT_MS,
-        );
-        if (!delivered) {
-            await this.store.cancel(request.requestId);
-            throw new Error('open workspace attention focus request was not delivered in time');
-        }
-        return {
-            protocolVersion: OPEN_WORKSPACE_ATTENTION_FOCUS_PROTOCOL_VERSION,
-            requestId: request.requestId,
-            targetNavigationIdentity: request.targetNavigationIdentity,
-            delivered: true,
-        };
+    submit(raw: unknown): Promise<OpenWorkspaceAttentionFocusOutcome> {
+        return this.coordinator.submit(raw);
     }
 
     requestDelivery(): void {
-        if (this.disposed) {
-            return;
-        }
-        void this.scanAndDeliver().catch(error => this.dependencies.reportError(error));
+        this.coordinator.requestDelivery();
     }
 
     dispose(): void {
-        if (this.disposed) {
-            return;
-        }
-        this.disposed = true;
-        this.dependencies.clearInterval(this.intervalHandle);
-        this.watcher.close();
-    }
-
-    private scanAndDeliver(): Promise<void> {
-        if (this.scanFlight) {
-            this.scanRequested = true;
-            return this.scanFlight;
-        }
-        const flight = this.runQueuedScans();
-        this.scanFlight = flight;
-        void flight.then(
-            () => { if (this.scanFlight === flight) this.scanFlight = null; },
-            () => { if (this.scanFlight === flight) this.scanFlight = null; },
-        );
-        return flight;
-    }
-
-    private async runQueuedScans(): Promise<void> {
-        do {
-            this.scanRequested = false;
-            await this.scanOnce();
-        } while (this.scanRequested && !this.disposed);
-    }
-
-    private async scanOnce(): Promise<void> {
-        const requests = await this.store.scan(this.dependencies.now());
-        for (const request of requests) {
-            if (this.disposed) {
-                return;
-            }
-            let winner = false;
-            try {
-                winner = await this.dependencies
-                    .isNavigationWinner(request.targetNavigationIdentity);
-            } catch (error) {
-                this.dependencies.reportError(error);
-                continue;
-            }
-            if (!winner || !await this.store.claim(request.requestId)) {
-                continue;
-            }
-            try {
-                await this.dependencies.deliverRequest(request);
-                await this.store.complete(request.requestId);
-            } catch (error) {
-                this.dependencies.reportError(error);
-                await this.store.restore(request.requestId);
-            }
-        }
-    }
-
-    private ensureActive(): void {
-        if (this.disposed) {
-            throw new Error('open workspace attention focus coordinator is disposed');
-        }
+        this.coordinator.dispose();
     }
 }

--- a/extensions/attention-ui-bridge/src/openWorkspaceAttentionFocusStore.ts
+++ b/extensions/attention-ui-bridge/src/openWorkspaceAttentionFocusStore.ts
@@ -1,198 +1,20 @@
 'use strict';
 
-import * as crypto from 'crypto';
-import * as fs from 'fs';
-import * as path from 'path';
-
 import {
     MAX_OPEN_WORKSPACE_ATTENTION_FOCUS_REQUESTS,
     OpenWorkspaceAttentionFocusRequest,
     validateOpenWorkspaceAttentionFocusRequest,
 } from '../../../src/openWorkspaces/attentionFocusProtocol';
+import { OpenWorkspaceFocusMailboxStore } from './openWorkspaceFocusMailboxStore';
 
-const REQUEST_PATTERN = /^([a-f0-9]{32})\.request\.json$/;
-const MAX_FILE_BYTES = 4 * 1024;
-const MAX_SCAN_ENTRIES = 1_000;
-const POLL_MS = 10;
-
-function hasErrorCode(error: unknown, code: string): boolean {
-    return typeof error === 'object'
-        && error !== null
-        && 'code' in error
-        && (error as { code?: unknown }).code === code;
-}
-
-export class OpenWorkspaceAttentionFocusStore {
-    public readonly directoryPath: string;
-
-    constructor(private readonly rootDirectory: string) {
-        this.directoryPath = path.join(rootDirectory, 'open-workspaces', 'attention-focus', 'v1');
-    }
-
-    async submit(raw: unknown): Promise<OpenWorkspaceAttentionFocusRequest> {
-        const request = validateOpenWorkspaceAttentionFocusRequest(raw);
-        const pending = await this.scan(request.createdAtMs);
-        if (pending.length >= MAX_OPEN_WORKSPACE_ATTENTION_FOCUS_REQUESTS
-            && !pending.some(candidate => candidate.requestId === request.requestId)) {
-            throw new Error(
-                `No more than ${MAX_OPEN_WORKSPACE_ATTENTION_FOCUS_REQUESTS}`
-                    + ' attention focus requests can be pending',
-            );
-        }
-        await fs.promises.mkdir(this.directoryPath, { recursive: true, mode: 0o700 });
-        await this.writeAtomic(this.requestPath(request.requestId), request);
-        return request;
-    }
-
-    async scan(nowMs: number): Promise<OpenWorkspaceAttentionFocusRequest[]> {
-        let entries: fs.Dirent[];
-        try {
-            entries = await fs.promises.readdir(this.directoryPath, { withFileTypes: true });
-        } catch (error) {
-            if (hasErrorCode(error, 'ENOENT')) {
-                return [];
-            }
-            throw error;
-        }
-        const requests: OpenWorkspaceAttentionFocusRequest[] = [];
-        for (const entry of entries
-            .filter(candidate => REQUEST_PATTERN.test(candidate.name))
-            .sort((left, right) => left.name.localeCompare(right.name))
-            .slice(0, MAX_SCAN_ENTRIES)) {
-            const match = REQUEST_PATTERN.exec(entry.name);
-            if (!match) {
-                continue;
-            }
-            const filePath = path.join(this.directoryPath, entry.name);
-            try {
-                const stats = await fs.promises.lstat(filePath);
-                if (!stats.isFile() || stats.isSymbolicLink()
-                    || stats.size < 2 || stats.size > MAX_FILE_BYTES) {
-                    continue;
-                }
-                const request = validateOpenWorkspaceAttentionFocusRequest(
-                    JSON.parse(await fs.promises.readFile(filePath, 'utf8')),
-                );
-                if (request.requestId !== match[1]) {
-                    continue;
-                }
-                if (request.expiresAtMs <= nowMs) {
-                    await this.cancel(request.requestId);
-                    continue;
-                }
-                requests.push(request);
-            } catch (_error) {
-                // Malformed and transient records never become authoritative.
-            }
-        }
-        requests.sort((left, right) =>
-            left.createdAtMs - right.createdAtMs
-            || left.requestId.localeCompare(right.requestId));
-        return requests;
-    }
-
-    async claim(requestId: string): Promise<boolean> {
-        try {
-            await fs.promises.rename(this.requestPath(requestId), this.claimPath(requestId));
-            return true;
-        } catch (error) {
-            if (hasErrorCode(error, 'ENOENT')) {
-                return false;
-            }
-            throw error;
-        }
-    }
-
-    async restore(requestId: string): Promise<void> {
-        try {
-            await fs.promises.rename(this.claimPath(requestId), this.requestPath(requestId));
-        } catch (error) {
-            if (!hasErrorCode(error, 'ENOENT')) {
-                throw error;
-            }
-        }
-    }
-
-    async complete(requestId: string): Promise<void> {
-        try {
-            // Promote the claim itself into the receipt. The rename is the
-            // ownership check and completion in one atomic operation, so a
-            // timeout cancellation cannot race between a claim check and a
-            // later receipt write and leave an orphan receipt behind.
-            await fs.promises.rename(
-                this.claimPath(requestId),
-                this.receiptPath(requestId),
-            );
-        } catch (error) {
-            if (hasErrorCode(error, 'ENOENT')) {
-                return;
-            }
-            throw error;
-        }
-    }
-
-    async waitForDelivery(requestId: string, timeoutMs: number): Promise<boolean> {
-        const deadline = Date.now() + timeoutMs;
-        do {
-            try {
-                const raw = JSON.parse(await fs.promises.readFile(
-                    this.receiptPath(requestId),
-                    'utf8',
-                )) as { requestId?: unknown };
-                if (raw.requestId === requestId) {
-                    await this.unlinkIfPresent(this.receiptPath(requestId));
-                    return true;
-                }
-            } catch (error) {
-                if (!hasErrorCode(error, 'ENOENT') && !(error instanceof SyntaxError)) {
-                    throw error;
-                }
-            }
-            await new Promise(resolve => setTimeout(resolve, POLL_MS));
-        } while (Date.now() < deadline);
-        return false;
-    }
-
-    async cancel(requestId: string): Promise<void> {
-        await this.unlinkIfPresent(this.requestPath(requestId));
-        await this.unlinkIfPresent(this.claimPath(requestId));
-        await this.unlinkIfPresent(this.receiptPath(requestId));
-    }
-
-    private async writeAtomic(finalPath: string, value: unknown): Promise<void> {
-        const temporaryPath = path.join(
-            this.directoryPath,
-            `.${path.basename(finalPath)}.${process.pid}.${crypto.randomBytes(8).toString('hex')}.tmp`,
-        );
-        try {
-            await fs.promises.writeFile(temporaryPath, `${JSON.stringify(value)}\n`, {
-                encoding: 'utf8', mode: 0o600, flag: 'wx',
-            });
-            await fs.promises.rename(temporaryPath, finalPath);
-        } finally {
-            await this.unlinkIfPresent(temporaryPath);
-        }
-    }
-
-    private async unlinkIfPresent(filePath: string): Promise<void> {
-        try {
-            await fs.promises.unlink(filePath);
-        } catch (error) {
-            if (!hasErrorCode(error, 'ENOENT')) {
-                throw error;
-            }
-        }
-    }
-
-    private requestPath(requestId: string): string {
-        return path.join(this.directoryPath, `${requestId}.request.json`);
-    }
-
-    private claimPath(requestId: string): string {
-        return path.join(this.directoryPath, `${requestId}.claim.json`);
-    }
-
-    private receiptPath(requestId: string): string {
-        return path.join(this.directoryPath, `${requestId}.delivered.json`);
+export class OpenWorkspaceAttentionFocusStore
+    extends OpenWorkspaceFocusMailboxStore<OpenWorkspaceAttentionFocusRequest> {
+    constructor(rootDirectory: string) {
+        super(rootDirectory, {
+            directorySegments: ['open-workspaces', 'attention-focus', 'v1'],
+            maxPendingRequests: MAX_OPEN_WORKSPACE_ATTENTION_FOCUS_REQUESTS,
+            pendingRequestDescription: 'attention focus requests',
+            validateRequest: validateOpenWorkspaceAttentionFocusRequest,
+        });
     }
 }

--- a/extensions/attention-ui-bridge/src/openWorkspaceFocusMailboxCoordinator.ts
+++ b/extensions/attention-ui-bridge/src/openWorkspaceFocusMailboxCoordinator.ts
@@ -1,0 +1,158 @@
+'use strict';
+
+import * as fs from 'fs';
+
+import {
+    OpenWorkspaceFocusMailboxRequest,
+    OpenWorkspaceFocusMailboxStoreLike,
+} from './openWorkspaceFocusMailboxStore';
+
+const SCAN_INTERVAL_MS = 2_000;
+const DELIVERY_WAIT_MS = 5_000;
+
+export interface OpenWorkspaceFocusMailboxWatcher {
+    close(): void;
+}
+
+export interface OpenWorkspaceFocusMailboxCoordinatorDependencies<
+    Request extends OpenWorkspaceFocusMailboxRequest,
+> {
+    now(): number;
+    deliverRequest(request: Request): PromiseLike<unknown> | unknown;
+    isNavigationWinner(navigationIdentity: string): Promise<boolean>;
+    reportError(error: unknown): void;
+    setInterval(callback: () => void, intervalMs: number): unknown;
+    clearInterval(handle: unknown): void;
+    createWatcher(
+        directoryPath: string,
+        onDidChange: () => void,
+    ): OpenWorkspaceFocusMailboxWatcher;
+    deliveryWaitMs?: number;
+}
+
+export interface OpenWorkspaceFocusMailboxCoordinatorOptions<
+    Request extends OpenWorkspaceFocusMailboxRequest,
+    Outcome,
+> {
+    readonly store: OpenWorkspaceFocusMailboxStoreLike<Request>;
+    readonly dependencies: OpenWorkspaceFocusMailboxCoordinatorDependencies<Request>;
+    readonly validateRequest: (raw: unknown) => Request;
+    readonly createOutcome: (request: Request) => Outcome;
+    readonly deliveryTimeoutMessage: string;
+    readonly disposedMessage: string;
+}
+
+/**
+ * Owns the shared request-delivery state machine for cross-window focus.
+ * Protocol wrappers provide their request validation, outcome, and mailbox;
+ * claim, retry, receipt, and single-flight scan behavior live only here.
+ */
+export class OpenWorkspaceFocusMailboxCoordinator<
+    Request extends OpenWorkspaceFocusMailboxRequest,
+    Outcome,
+> {
+    private readonly watcher: OpenWorkspaceFocusMailboxWatcher;
+    private readonly intervalHandle: unknown;
+    private scanFlight: Promise<void> | null = null;
+    private scanRequested = false;
+    private disposed = false;
+
+    constructor(private readonly options: OpenWorkspaceFocusMailboxCoordinatorOptions<Request, Outcome>) {
+        fs.mkdirSync(options.store.directoryPath, { recursive: true, mode: 0o700 });
+        this.watcher = options.dependencies.createWatcher(
+            options.store.directoryPath,
+            () => this.requestDelivery(),
+        );
+        this.intervalHandle = options.dependencies.setInterval(
+            () => this.requestDelivery(),
+            SCAN_INTERVAL_MS,
+        );
+    }
+
+    async submit(raw: unknown): Promise<Outcome> {
+        this.ensureActive();
+        const request = await this.options.store.submit(
+            this.options.validateRequest(raw),
+        );
+        this.requestDelivery();
+        const delivered = await this.options.store.waitForDelivery(
+            request.requestId,
+            this.options.dependencies.deliveryWaitMs ?? DELIVERY_WAIT_MS,
+        );
+        if (!delivered) {
+            await this.options.store.cancel(request.requestId);
+            throw new Error(this.options.deliveryTimeoutMessage);
+        }
+        return this.options.createOutcome(request);
+    }
+
+    requestDelivery(): void {
+        if (this.disposed) {
+            return;
+        }
+        void this.scanAndDeliver().catch(error => this.options.dependencies.reportError(error));
+    }
+
+    dispose(): void {
+        if (this.disposed) {
+            return;
+        }
+        this.disposed = true;
+        this.options.dependencies.clearInterval(this.intervalHandle);
+        this.watcher.close();
+    }
+
+    private scanAndDeliver(): Promise<void> {
+        if (this.scanFlight) {
+            this.scanRequested = true;
+            return this.scanFlight;
+        }
+        const flight = this.runQueuedScans();
+        this.scanFlight = flight;
+        void flight.then(
+            () => { if (this.scanFlight === flight) this.scanFlight = null; },
+            () => { if (this.scanFlight === flight) this.scanFlight = null; },
+        );
+        return flight;
+    }
+
+    private async runQueuedScans(): Promise<void> {
+        do {
+            this.scanRequested = false;
+            await this.scanOnce();
+        } while (this.scanRequested && !this.disposed);
+    }
+
+    private async scanOnce(): Promise<void> {
+        const requests = await this.options.store.scan(this.options.dependencies.now());
+        for (const request of requests) {
+            if (this.disposed) {
+                return;
+            }
+            let winner = false;
+            try {
+                winner = await this.options.dependencies
+                    .isNavigationWinner(request.targetNavigationIdentity);
+            } catch (error) {
+                this.options.dependencies.reportError(error);
+                continue;
+            }
+            if (!winner || !await this.options.store.claim(request.requestId)) {
+                continue;
+            }
+            try {
+                await this.options.dependencies.deliverRequest(request);
+                await this.options.store.complete(request.requestId);
+            } catch (error) {
+                this.options.dependencies.reportError(error);
+                await this.options.store.restore(request.requestId);
+            }
+        }
+    }
+
+    private ensureActive(): void {
+        if (this.disposed) {
+            throw new Error(this.options.disposedMessage);
+        }
+    }
+}

--- a/extensions/attention-ui-bridge/src/openWorkspaceFocusMailboxStore.ts
+++ b/extensions/attention-ui-bridge/src/openWorkspaceFocusMailboxStore.ts
@@ -1,0 +1,237 @@
+'use strict';
+
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const REQUEST_FILE_SUFFIX = '.request.json';
+const REQUEST_FILE_PATTERN = /^([a-f0-9]{32})\.request\.json$/;
+const MAX_REQUEST_FILE_BYTES = 4 * 1024;
+const MAX_REQUEST_SCAN_ENTRIES = 1_000;
+const DELIVERY_POLL_MS = 10;
+
+export interface OpenWorkspaceFocusMailboxRequest {
+    requestId: string;
+    targetNavigationIdentity: string;
+    createdAtMs: number;
+    expiresAtMs: number;
+}
+
+export interface OpenWorkspaceFocusMailboxStoreLike<
+    Request extends OpenWorkspaceFocusMailboxRequest,
+> {
+    readonly directoryPath: string;
+    submit(raw: unknown): Promise<Request>;
+    scan(nowMs: number): Promise<Request[]>;
+    claim(requestId: string): Promise<boolean>;
+    restore(requestId: string): Promise<void>;
+    complete(requestId: string): Promise<void>;
+    waitForDelivery(requestId: string, timeoutMs: number): Promise<boolean>;
+    cancel(requestId: string): Promise<void>;
+}
+
+export interface OpenWorkspaceFocusMailboxStoreOptions<
+    Request extends OpenWorkspaceFocusMailboxRequest,
+> {
+    readonly directorySegments: readonly string[];
+    readonly maxPendingRequests: number;
+    readonly pendingRequestDescription: string;
+    readonly validateRequest: (raw: unknown) => Request;
+    readonly temporaryFileStem?: (requestId: string) => string;
+    readonly ignoreTemporaryCleanupErrors?: boolean;
+}
+
+function hasErrorCode(error: unknown, code: string): boolean {
+    return typeof error === 'object'
+        && error !== null
+        && 'code' in error
+        && (error as { code?: unknown }).code === code;
+}
+
+/**
+ * Durable one-shot mailbox shared by cross-window focus transports.
+ * Protocol-specific stores supply only validation, capacity, and the stable
+ * on-disk directory that belongs to their wire protocol.
+ */
+export class OpenWorkspaceFocusMailboxStore<
+    Request extends OpenWorkspaceFocusMailboxRequest,
+> implements OpenWorkspaceFocusMailboxStoreLike<Request> {
+    public readonly directoryPath: string;
+
+    constructor(
+        rootDirectory: string,
+        private readonly options: OpenWorkspaceFocusMailboxStoreOptions<Request>,
+    ) {
+        this.directoryPath = path.join(rootDirectory, ...options.directorySegments);
+    }
+
+    async submit(raw: unknown): Promise<Request> {
+        const request = this.options.validateRequest(raw);
+        const pending = await this.scan(request.createdAtMs);
+        if (pending.length >= this.options.maxPendingRequests
+            && !pending.some(candidate => candidate.requestId === request.requestId)) {
+            throw new Error(
+                `No more than ${this.options.maxPendingRequests}`
+                    + ` ${this.options.pendingRequestDescription} can be pending`,
+            );
+        }
+        await fs.promises.mkdir(this.directoryPath, { recursive: true, mode: 0o700 });
+        await this.writeAtomic(this.requestPath(request.requestId), request, request.requestId);
+        return request;
+    }
+
+    async scan(nowMs: number): Promise<Request[]> {
+        let entries: fs.Dirent[];
+        try {
+            entries = await fs.promises.readdir(this.directoryPath, { withFileTypes: true });
+        } catch (error) {
+            if (hasErrorCode(error, 'ENOENT')) {
+                return [];
+            }
+            throw error;
+        }
+        const requests: Request[] = [];
+        for (const entry of entries
+            .filter(candidate => REQUEST_FILE_PATTERN.test(candidate.name))
+            .sort((left, right) => left.name.localeCompare(right.name))
+            .slice(0, MAX_REQUEST_SCAN_ENTRIES)) {
+            const match = REQUEST_FILE_PATTERN.exec(entry.name);
+            if (!match) {
+                continue;
+            }
+            const filePath = path.join(this.directoryPath, entry.name);
+            try {
+                const stats = await fs.promises.lstat(filePath);
+                if (!stats.isFile() || stats.isSymbolicLink()
+                    || stats.size < 2 || stats.size > MAX_REQUEST_FILE_BYTES) {
+                    continue;
+                }
+                const request = this.options.validateRequest(
+                    JSON.parse(await fs.promises.readFile(filePath, 'utf8')),
+                );
+                if (request.requestId !== match[1]) {
+                    continue;
+                }
+                if (request.expiresAtMs <= nowMs) {
+                    await this.cancel(request.requestId);
+                    continue;
+                }
+                requests.push(request);
+            } catch (_error) {
+                // Malformed and transient records never become authoritative.
+            }
+        }
+        requests.sort((left, right) =>
+            left.createdAtMs - right.createdAtMs
+            || left.requestId.localeCompare(right.requestId));
+        return requests;
+    }
+
+    async claim(requestId: string): Promise<boolean> {
+        try {
+            await fs.promises.rename(this.requestPath(requestId), this.claimPath(requestId));
+            return true;
+        } catch (error) {
+            if (hasErrorCode(error, 'ENOENT')) {
+                return false;
+            }
+            throw error;
+        }
+    }
+
+    async restore(requestId: string): Promise<void> {
+        try {
+            await fs.promises.rename(this.claimPath(requestId), this.requestPath(requestId));
+        } catch (error) {
+            if (!hasErrorCode(error, 'ENOENT')) {
+                throw error;
+            }
+        }
+    }
+
+    async complete(requestId: string): Promise<void> {
+        try {
+            // The rename is both the ownership check and receipt creation, so
+            // timeout cancellation cannot race with a later receipt write.
+            await fs.promises.rename(this.claimPath(requestId), this.receiptPath(requestId));
+        } catch (error) {
+            if (!hasErrorCode(error, 'ENOENT')) {
+                throw error;
+            }
+        }
+    }
+
+    async waitForDelivery(requestId: string, timeoutMs: number): Promise<boolean> {
+        const deadline = Date.now() + timeoutMs;
+        do {
+            try {
+                const raw = JSON.parse(await fs.promises.readFile(
+                    this.receiptPath(requestId),
+                    'utf8',
+                )) as { requestId?: unknown };
+                if (raw.requestId === requestId) {
+                    await this.unlinkIfPresent(this.receiptPath(requestId));
+                    return true;
+                }
+            } catch (error) {
+                if (!hasErrorCode(error, 'ENOENT') && !(error instanceof SyntaxError)) {
+                    throw error;
+                }
+            }
+            await new Promise(resolve => setTimeout(resolve, DELIVERY_POLL_MS));
+        } while (Date.now() < deadline);
+        return false;
+    }
+
+    async cancel(requestId: string): Promise<void> {
+        await this.unlinkIfPresent(this.requestPath(requestId));
+        await this.unlinkIfPresent(this.claimPath(requestId));
+        await this.unlinkIfPresent(this.receiptPath(requestId));
+    }
+
+    private async writeAtomic(finalPath: string, value: unknown, requestId: string): Promise<void> {
+        const temporaryFileStem = this.options.temporaryFileStem
+            ? this.options.temporaryFileStem(requestId)
+            : path.basename(finalPath);
+        const temporaryPath = path.join(
+            this.directoryPath,
+            `.${temporaryFileStem}.${process.pid}.${crypto.randomBytes(8).toString('hex')}.tmp`,
+        );
+        try {
+            await fs.promises.writeFile(temporaryPath, `${JSON.stringify(value)}\n`, {
+                encoding: 'utf8', mode: 0o600, flag: 'wx',
+            });
+            await fs.promises.rename(temporaryPath, finalPath);
+        } finally {
+            try {
+                await this.unlinkIfPresent(temporaryPath);
+            } catch (error) {
+                if (!this.options.ignoreTemporaryCleanupErrors) {
+                    throw error;
+                }
+            }
+        }
+    }
+
+    private async unlinkIfPresent(filePath: string): Promise<void> {
+        try {
+            await fs.promises.unlink(filePath);
+        } catch (error) {
+            if (!hasErrorCode(error, 'ENOENT')) {
+                throw error;
+            }
+        }
+    }
+
+    private requestPath(requestId: string): string {
+        return path.join(this.directoryPath, `${requestId}${REQUEST_FILE_SUFFIX}`);
+    }
+
+    private claimPath(requestId: string): string {
+        return path.join(this.directoryPath, `${requestId}.claim.json`);
+    }
+
+    private receiptPath(requestId: string): string {
+        return path.join(this.directoryPath, `${requestId}.delivered.json`);
+    }
+}

--- a/extensions/attention-ui-bridge/src/openWorkspaceRunningFocusCoordinator.ts
+++ b/extensions/attention-ui-bridge/src/openWorkspaceRunningFocusCoordinator.ts
@@ -1,158 +1,60 @@
 'use strict';
 
-import * as fs from 'fs';
-
 import {
     OPEN_WORKSPACE_RUNNING_FOCUS_PROTOCOL_VERSION,
     OpenWorkspaceRunningFocusOutcome,
     OpenWorkspaceRunningFocusRequest,
     validateOpenWorkspaceRunningFocusRequest,
 } from '../../../src/openWorkspaces/runningFocusProtocol';
+import {
+    OpenWorkspaceFocusMailboxCoordinator,
+    OpenWorkspaceFocusMailboxCoordinatorDependencies,
+} from './openWorkspaceFocusMailboxCoordinator';
 import { OpenWorkspaceRunningFocusStore } from './openWorkspaceRunningFocusStore';
 
-const RUNNING_FOCUS_SCAN_INTERVAL_MS = 2_000;
-const RUNNING_FOCUS_DELIVERY_WAIT_MS = 5_000;
-
-interface OpenWorkspaceRunningFocusWatcher {
-    close(): void;
-}
-
-export interface OpenWorkspaceRunningFocusCoordinatorDependencies {
-    now(): number;
-    deliverRequest(request: OpenWorkspaceRunningFocusRequest): PromiseLike<unknown> | unknown;
-    isNavigationWinner(navigationIdentity: string): Promise<boolean>;
-    reportError(error: unknown): void;
-    setInterval(callback: () => void, intervalMs: number): unknown;
-    clearInterval(handle: unknown): void;
-    createWatcher(directoryPath: string, onDidChange: () => void): OpenWorkspaceRunningFocusWatcher;
+export interface OpenWorkspaceRunningFocusCoordinatorDependencies
+    extends OpenWorkspaceFocusMailboxCoordinatorDependencies<OpenWorkspaceRunningFocusRequest> {
     createStore?(rootDirectory: string): OpenWorkspaceRunningFocusStore;
-    deliveryWaitMs?: number;
 }
 
-/**
- * Watches the shared running-focus mailbox and delivers each request to this
- * window's main extension only when this window is the navigation winner for
- * the request's target workspace — the same priority order direct navigation
- * uses, so the focus handoff lands in the window the user was switched to.
- * The winning window claims each request before delivery and receipts it only
- * after the main extension has accepted the handoff. Failed deliveries are
- * restored for retry until the submitter times out and cancels them.
- */
+/** Cross-window coordinator for running-session focus requests. */
 export class OpenWorkspaceRunningFocusCoordinator {
-    private readonly store: OpenWorkspaceRunningFocusStore;
-    private readonly watcher: OpenWorkspaceRunningFocusWatcher;
-    private readonly intervalHandle: unknown;
-    private scanFlight: Promise<void> | null = null;
-    private scanRequested = false;
-    private disposed = false;
+    private readonly coordinator: OpenWorkspaceFocusMailboxCoordinator<
+        OpenWorkspaceRunningFocusRequest,
+        OpenWorkspaceRunningFocusOutcome
+    >;
 
     constructor(
         rootDirectory: string,
-        private readonly dependencies: OpenWorkspaceRunningFocusCoordinatorDependencies,
+        dependencies: OpenWorkspaceRunningFocusCoordinatorDependencies,
     ) {
-        this.store = dependencies.createStore
-            ? dependencies.createStore(rootDirectory)
-            : new OpenWorkspaceRunningFocusStore(rootDirectory);
-        fs.mkdirSync(this.store.directoryPath, { recursive: true, mode: 0o700 });
-        this.watcher = dependencies.createWatcher(
-            this.store.directoryPath,
-            () => this.requestDelivery(),
-        );
-        this.intervalHandle = dependencies.setInterval(
-            () => this.requestDelivery(),
-            RUNNING_FOCUS_SCAN_INTERVAL_MS,
-        );
+        this.coordinator = new OpenWorkspaceFocusMailboxCoordinator({
+            store: dependencies.createStore
+                ? dependencies.createStore(rootDirectory)
+                : new OpenWorkspaceRunningFocusStore(rootDirectory),
+            dependencies,
+            validateRequest: validateOpenWorkspaceRunningFocusRequest,
+            createOutcome: request => ({
+                protocolVersion: OPEN_WORKSPACE_RUNNING_FOCUS_PROTOCOL_VERSION,
+                requestId: request.requestId,
+                targetNavigationIdentity: request.targetNavigationIdentity,
+                delivered: true,
+            }),
+            deliveryTimeoutMessage:
+                'open workspace running focus request was not delivered in time',
+            disposedMessage: 'open workspace running focus coordinator is disposed',
+        });
     }
 
-    async submit(raw: unknown): Promise<OpenWorkspaceRunningFocusOutcome> {
-        this.ensureActive();
-        const request = await this.store.submit(
-            validateOpenWorkspaceRunningFocusRequest(raw),
-        );
-        this.requestDelivery();
-        const delivered = await this.store.waitForDelivery(
-            request.requestId,
-            this.dependencies.deliveryWaitMs ?? RUNNING_FOCUS_DELIVERY_WAIT_MS,
-        );
-        if (!delivered) {
-            await this.store.cancel(request.requestId);
-            throw new Error('open workspace running focus request was not delivered in time');
-        }
-        return {
-            protocolVersion: OPEN_WORKSPACE_RUNNING_FOCUS_PROTOCOL_VERSION,
-            requestId: request.requestId,
-            targetNavigationIdentity: request.targetNavigationIdentity,
-            delivered: true,
-        };
+    submit(raw: unknown): Promise<OpenWorkspaceRunningFocusOutcome> {
+        return this.coordinator.submit(raw);
     }
 
     requestDelivery(): void {
-        if (this.disposed) {
-            return;
-        }
-        void this.scanAndDeliver().catch(error => this.dependencies.reportError(error));
+        this.coordinator.requestDelivery();
     }
 
     dispose(): void {
-        if (this.disposed) {
-            return;
-        }
-        this.disposed = true;
-        this.dependencies.clearInterval(this.intervalHandle);
-        this.watcher.close();
-    }
-
-    private scanAndDeliver(): Promise<void> {
-        if (this.scanFlight) {
-            this.scanRequested = true;
-            return this.scanFlight;
-        }
-        const flight = this.runQueuedScans();
-        this.scanFlight = flight;
-        void flight.then(
-            () => { if (this.scanFlight === flight) this.scanFlight = null; },
-            () => { if (this.scanFlight === flight) this.scanFlight = null; },
-        );
-        return flight;
-    }
-
-    private async runQueuedScans(): Promise<void> {
-        do {
-            this.scanRequested = false;
-            await this.scanOnce();
-        } while (this.scanRequested && !this.disposed);
-    }
-
-    private async scanOnce(): Promise<void> {
-        const requests = await this.store.scan(this.dependencies.now());
-        for (const request of requests) {
-            if (this.disposed) {
-                return;
-            }
-            let winner = false;
-            try {
-                winner = await this.dependencies
-                    .isNavigationWinner(request.targetNavigationIdentity);
-            } catch (error) {
-                this.dependencies.reportError(error);
-                continue;
-            }
-            if (!winner || !await this.store.claim(request.requestId)) {
-                continue;
-            }
-            try {
-                await this.dependencies.deliverRequest(request);
-                await this.store.complete(request.requestId);
-            } catch (error) {
-                this.dependencies.reportError(error);
-                await this.store.restore(request.requestId);
-            }
-        }
-    }
-
-    private ensureActive(): void {
-        if (this.disposed) {
-            throw new Error('open workspace running focus coordinator is disposed');
-        }
+        this.coordinator.dispose();
     }
 }

--- a/extensions/attention-ui-bridge/src/openWorkspaceRunningFocusStore.ts
+++ b/extensions/attention-ui-bridge/src/openWorkspaceRunningFocusStore.ts
@@ -1,199 +1,24 @@
 'use strict';
 
-import * as crypto from 'crypto';
-import * as fs from 'fs';
-import * as path from 'path';
-
 import {
     MAX_OPEN_WORKSPACE_RUNNING_FOCUS_REQUESTS,
     OpenWorkspaceRunningFocusRequest,
     validateOpenWorkspaceRunningFocusRequest,
 } from '../../../src/openWorkspaces/runningFocusProtocol';
+import { OpenWorkspaceFocusMailboxStore } from './openWorkspaceFocusMailboxStore';
 
-const REQUEST_FILE_SUFFIX = '.request.json';
-const REQUEST_FILE_PATTERN = /^[a-f0-9]{32}\.request\.json$/;
-const MAX_REQUEST_FILE_BYTES = 4 * 1024;
-const MAX_REQUEST_SCAN_ENTRIES = 1_000;
-const DELIVERY_POLL_MS = 10;
-
-function hasErrorCode(error: unknown, code: string): boolean {
-    return typeof error === 'object'
-        && error !== null
-        && 'code' in error
-        && (error as { code?: unknown }).code === code;
-}
-
-/**
- * Durable one-shot mailbox for cross-window running-session focus requests.
- * Requests are individual atomic files (temp file + rename), so a submitter
- * never needs a lock. The winning window atomically claims a request and
- * promotes that claim into a delivery receipt; the submitter consumes the
- * receipt before reporting success.
- */
-export class OpenWorkspaceRunningFocusStore {
-    public readonly directoryPath: string;
-
-    constructor(private readonly rootDirectory: string) {
-        this.directoryPath = path.join(rootDirectory, 'open-workspaces', 'running-focus', 'v2');
-    }
-
-    async submit(raw: unknown): Promise<OpenWorkspaceRunningFocusRequest> {
-        const request = validateOpenWorkspaceRunningFocusRequest(raw);
-        const pending = await this.scan(request.createdAtMs);
-        if (pending.length >= MAX_OPEN_WORKSPACE_RUNNING_FOCUS_REQUESTS
-            && !pending.some(candidate => candidate.requestId === request.requestId)) {
-            throw new Error(
-                `No more than ${MAX_OPEN_WORKSPACE_RUNNING_FOCUS_REQUESTS} running focus requests can be pending`,
-            );
-        }
-        await fs.promises.mkdir(this.directoryPath, { recursive: true, mode: 0o700 });
-        const temporaryPath = path.join(
-            this.directoryPath,
-            `.${request.requestId}.${process.pid}.${crypto.randomBytes(8).toString('hex')}.tmp`,
-        );
-        try {
-            await fs.promises.writeFile(temporaryPath, `${JSON.stringify(request)}\n`, {
-                encoding: 'utf8',
-                mode: 0o600,
-                flag: 'wx',
-            });
-            await fs.promises.rename(temporaryPath, this.requestPath(request.requestId));
-        } finally {
-            try {
-                await fs.promises.unlink(temporaryPath);
-            } catch (error) {
-                if (!hasErrorCode(error, 'ENOENT')) {
-                    // The unique temporary file never participates in delivery.
-                }
-            }
-        }
-        return request;
-    }
-
-    async scan(nowMs: number): Promise<OpenWorkspaceRunningFocusRequest[]> {
-        let entries: fs.Dirent[];
-        try {
-            entries = await fs.promises.readdir(this.directoryPath, { withFileTypes: true });
-        } catch (error) {
-            if (hasErrorCode(error, 'ENOENT')) {
-                return [];
-            }
-            throw error;
-        }
-        const requests: OpenWorkspaceRunningFocusRequest[] = [];
-        for (const entry of entries
-            .filter(entry => REQUEST_FILE_PATTERN.test(entry.name))
-            .sort((left, right) => left.name.localeCompare(right.name))
-            .slice(0, MAX_REQUEST_SCAN_ENTRIES)) {
-            const filePath = path.join(this.directoryPath, entry.name);
-            try {
-                const stats = await fs.promises.lstat(filePath);
-                if (!stats.isFile() || stats.isSymbolicLink()
-                    || stats.size < 2 || stats.size > MAX_REQUEST_FILE_BYTES) {
-                    continue;
-                }
-                const request = validateOpenWorkspaceRunningFocusRequest(
-                    JSON.parse(await fs.promises.readFile(filePath, 'utf8')),
-                );
-                if (entry.name !== `${request.requestId}${REQUEST_FILE_SUFFIX}`) {
-                    continue;
-                }
-                if (request.expiresAtMs <= nowMs) {
-                    await this.cancel(request.requestId);
-                    continue;
-                }
-                requests.push(request);
-            } catch (_error) {
-                // Ignore malformed or transient records; valid requests remain authoritative.
-            }
-        }
-        requests.sort((left, right) =>
-            left.createdAtMs - right.createdAtMs
-            || left.requestId.localeCompare(right.requestId));
-        return requests;
-    }
-
-    async claim(requestId: string): Promise<boolean> {
-        try {
-            await fs.promises.rename(this.requestPath(requestId), this.claimPath(requestId));
-            return true;
-        } catch (error) {
-            if (hasErrorCode(error, 'ENOENT')) {
-                return false;
-            }
-            throw error;
-        }
-    }
-
-    async restore(requestId: string): Promise<void> {
-        try {
-            await fs.promises.rename(this.claimPath(requestId), this.requestPath(requestId));
-        } catch (error) {
-            if (!hasErrorCode(error, 'ENOENT')) {
-                throw error;
-            }
-        }
-    }
-
-    async complete(requestId: string): Promise<void> {
-        try {
-            // Atomic promotion prevents timeout cancellation from racing with
-            // receipt creation and leaving a stale success marker behind.
-            await fs.promises.rename(this.claimPath(requestId), this.receiptPath(requestId));
-        } catch (error) {
-            if (!hasErrorCode(error, 'ENOENT')) {
-                throw error;
-            }
-        }
-    }
-
-    async waitForDelivery(requestId: string, timeoutMs: number): Promise<boolean> {
-        const deadline = Date.now() + timeoutMs;
-        do {
-            try {
-                const raw = JSON.parse(await fs.promises.readFile(
-                    this.receiptPath(requestId),
-                    'utf8',
-                )) as { requestId?: unknown };
-                if (raw.requestId === requestId) {
-                    await this.unlinkIfPresent(this.receiptPath(requestId));
-                    return true;
-                }
-            } catch (error) {
-                if (!hasErrorCode(error, 'ENOENT') && !(error instanceof SyntaxError)) {
-                    throw error;
-                }
-            }
-            await new Promise(resolve => setTimeout(resolve, DELIVERY_POLL_MS));
-        } while (Date.now() < deadline);
-        return false;
-    }
-
-    async cancel(requestId: string): Promise<void> {
-        await this.unlinkIfPresent(this.requestPath(requestId));
-        await this.unlinkIfPresent(this.claimPath(requestId));
-        await this.unlinkIfPresent(this.receiptPath(requestId));
-    }
-
-    private async unlinkIfPresent(filePath: string): Promise<void> {
-        try {
-            await fs.promises.unlink(filePath);
-        } catch (error) {
-            if (!hasErrorCode(error, 'ENOENT')) {
-                throw error;
-            }
-        }
-    }
-
-    private requestPath(requestId: string): string {
-        return path.join(this.directoryPath, `${requestId}${REQUEST_FILE_SUFFIX}`);
-    }
-
-    private claimPath(requestId: string): string {
-        return path.join(this.directoryPath, `${requestId}.claim.json`);
-    }
-
-    private receiptPath(requestId: string): string {
-        return path.join(this.directoryPath, `${requestId}.delivered.json`);
+/** Durable cross-window mailbox for running-session focus requests. */
+export class OpenWorkspaceRunningFocusStore
+    extends OpenWorkspaceFocusMailboxStore<OpenWorkspaceRunningFocusRequest> {
+    constructor(rootDirectory: string) {
+        super(rootDirectory, {
+            directorySegments: ['open-workspaces', 'running-focus', 'v2'],
+            maxPendingRequests: MAX_OPEN_WORKSPACE_RUNNING_FOCUS_REQUESTS,
+            pendingRequestDescription: 'running focus requests',
+            validateRequest: validateOpenWorkspaceRunningFocusRequest,
+            temporaryFileStem: requestId => requestId,
+            // Preserve the v2 implementation's best-effort temp-file cleanup.
+            ignoreTemporaryCleanupErrors: true,
+        });
     }
 }

--- a/scripts/run-architecture-guards.js
+++ b/scripts/run-architecture-guards.js
@@ -610,6 +610,100 @@ const guards = {
         }
     },
 
+    // ARCH-OPEN-WORKSPACE-FOCUS-TRANSPORT-OWNERSHIP-001
+    'ARCH-OPEN-WORKSPACE-FOCUS-TRANSPORT-OWNERSHIP-001'(root) {
+        const risk = 'Running and Attention focus transports can drift into incompatible delivery state machines';
+        const sharedStore = parseTypescript(
+            root,
+            'extensions/attention-ui-bridge/src/openWorkspaceFocusMailboxStore.ts',
+            this.id,
+            risk,
+        );
+        const sharedCoordinator = parseTypescript(
+            root,
+            'extensions/attention-ui-bridge/src/openWorkspaceFocusMailboxCoordinator.ts',
+            this.id,
+            risk,
+        );
+
+        for (const methodName of [
+            'submit', 'scan', 'claim', 'restore', 'complete', 'waitForDelivery', 'cancel',
+        ]) {
+            classMethod(
+                sharedStore,
+                'OpenWorkspaceFocusMailboxStore',
+                methodName,
+                this.id,
+                risk,
+            );
+        }
+        for (const methodName of ['submit', 'requestDelivery', 'scanAndDeliver', 'scanOnce']) {
+            classMethod(
+                sharedCoordinator,
+                'OpenWorkspaceFocusMailboxCoordinator',
+                methodName,
+                this.id,
+                risk,
+            );
+        }
+
+        for (const protocol of ['Attention', 'Running']) {
+            const storePath = `extensions/attention-ui-bridge/src/openWorkspace${protocol}FocusStore.ts`;
+            const storeSource = parseTypescript(root, storePath, this.id, risk);
+            const storeClass = uniqueAstNode(
+                storeSource,
+                node => ts.isClassDeclaration(node)
+                    && node.name?.text === `OpenWorkspace${protocol}FocusStore`,
+                this.id,
+                risk,
+                `${protocol} focus store wrapper`,
+            );
+            const extendsSharedStore = storeClass.heritageClauses?.some(clause =>
+                clause.token === ts.SyntaxKind.ExtendsKeyword
+                && clause.types.length === 1
+                && clause.types[0].expression.getText(storeSource)
+                    === 'OpenWorkspaceFocusMailboxStore');
+            if (!extendsSharedStore) {
+                fail(this.id, risk,
+                    `${protocol} focus store must extend the shared mailbox store`);
+            }
+            if (protocol === 'Running') {
+                const superCalls = callArguments(storeClass, 'super');
+                const storeOptions = superCalls.length === 1 ? superCalls[0][1] : undefined;
+                const temporaryFileStem = storeOptions && ts.isObjectLiteralExpression(storeOptions)
+                    ? storeOptions.properties.find(property =>
+                        property.name?.getText(storeSource) === 'temporaryFileStem')
+                    : undefined;
+                if (!temporaryFileStem || !ts.isPropertyAssignment(temporaryFileStem)
+                    || !ts.isArrowFunction(temporaryFileStem.initializer)
+                    || temporaryFileStem.initializer.getText(storeSource) !== 'requestId => requestId') {
+                    fail(this.id, risk,
+                        'Running focus store must preserve its v2 temporary-file naming');
+                }
+            }
+
+            const coordinatorPath =
+                `extensions/attention-ui-bridge/src/openWorkspace${protocol}FocusCoordinator.ts`;
+            const coordinatorSource = parseTypescript(root, coordinatorPath, this.id, risk);
+            const sharedCoordinatorConstructions = nodesMatching(coordinatorSource, node =>
+                ts.isNewExpression(node)
+                && node.expression.getText(coordinatorSource)
+                    === 'OpenWorkspaceFocusMailboxCoordinator');
+            if (sharedCoordinatorConstructions.length !== 1) {
+                fail(this.id, risk,
+                    `${protocol} focus coordinator must delegate to one shared mailbox coordinator`);
+            }
+            for (const forbiddenMethod of ['scanAndDeliver', 'runQueuedScans', 'scanOnce']) {
+                if (nodesMatching(coordinatorSource, node =>
+                    ts.isMethodDeclaration(node)
+                    && node.name.getText(coordinatorSource) === forbiddenMethod).length) {
+                    fail(this.id, risk,
+                        `${protocol} focus coordinator must not duplicate ${forbiddenMethod}`);
+                }
+            }
+        }
+    },
+
     // ARCH-AI-SESSION-CONVERSATION-BOUNDARY-001
     'ARCH-AI-SESSION-CONVERSATION-BOUNDARY-001'(root) {
         const risk = 'conversation history can expose private content or exhaust the extension host';

--- a/tests/contract/openProjects/attentionFocus.test.js
+++ b/tests/contract/openProjects/attentionFocus.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assert = require('node:assert/strict');
+const path = require('node:path');
 const test = require('node:test');
 
 const { makeTempDirectory } = require('../../helpers/tempDirectory');
@@ -15,6 +16,9 @@ const {
 const {
     OpenWorkspaceAttentionFocusCoordinator,
 } = require('../../../extensions/attention-ui-bridge/out/extensions/attention-ui-bridge/src/openWorkspaceAttentionFocusCoordinator');
+const {
+    OpenWorkspaceRunningFocusStore,
+} = require('../../../extensions/attention-ui-bridge/out/extensions/attention-ui-bridge/src/openWorkspaceRunningFocusStore');
 
 const TARGET_IDENTITY = 'f'.repeat(64);
 const PROJECT_ID = 'e'.repeat(64);
@@ -107,6 +111,29 @@ test('ATTENTION-STATUS-BAR-QUEUE-001 claims and receipts attention focus mailbox
     await store.complete('b'.repeat(32));
     assert.equal(await store.waitForDelivery('b'.repeat(32), 20), false,
         'a completion that lost its claim after timeout must not leave an orphan receipt');
+});
+
+test('ARCH-OPEN-WORKSPACE-FOCUS-TRANSPORT-OWNERSHIP-001 keeps protocol mailboxes isolated', async t => {
+    const root = makeTempDirectory(t, 'focus-mailbox-isolation-');
+    const attentionStore = new OpenWorkspaceAttentionFocusStore(root);
+    const runningStore = new OpenWorkspaceRunningFocusStore(root);
+
+    assert.equal(attentionStore.directoryPath,
+        path.join(root, 'open-workspaces', 'attention-focus', 'v1'));
+    assert.equal(runningStore.directoryPath,
+        path.join(root, 'open-workspaces', 'running-focus', 'v2'));
+
+    await attentionStore.submit(makeRequest());
+    await runningStore.submit({
+        protocolVersion: 2,
+        requestId: 'a'.repeat(32),
+        targetNavigationIdentity: TARGET_IDENTITY,
+        createdAtMs: 1000,
+        expiresAtMs: 61_000,
+    });
+
+    assert.equal((await attentionStore.scan(1000))[0].sessionId, 'session-1');
+    assert.equal((await runningStore.scan(1000))[0].protocolVersion, 2);
 });
 
 test('ATTENTION-STATUS-BAR-QUEUE-001 reports delivery only after the target queues the exact focus', async t => {

--- a/tests/unit/tooling/architectureGuards.test.js
+++ b/tests/unit/tooling/architectureGuards.test.js
@@ -72,6 +72,12 @@ function copyGuardFixture(t, mutationPath, mutate = source => source) {
         'src/aiSessions/attentionBridgeClient.ts',
         'src/services/codexSessionService.ts',
         'extensions/attention-ui-bridge/src/openWorkspaceCoordinator.ts',
+        'extensions/attention-ui-bridge/src/openWorkspaceFocusMailboxStore.ts',
+        'extensions/attention-ui-bridge/src/openWorkspaceFocusMailboxCoordinator.ts',
+        'extensions/attention-ui-bridge/src/openWorkspaceAttentionFocusStore.ts',
+        'extensions/attention-ui-bridge/src/openWorkspaceAttentionFocusCoordinator.ts',
+        'extensions/attention-ui-bridge/src/openWorkspaceRunningFocusStore.ts',
+        'extensions/attention-ui-bridge/src/openWorkspaceRunningFocusCoordinator.ts',
         'extensions/attention-ui-bridge/src/extension.ts',
         'scripts/lib/brandIdentity.js',
         'package.json',
@@ -289,6 +295,33 @@ for (const [label, reExport] of [
 }
 
 for (const mutation of [
+    {
+        id: 'ARCH-OPEN-WORKSPACE-FOCUS-TRANSPORT-OWNERSHIP-001',
+        file: 'extensions/attention-ui-bridge/src/openWorkspaceAttentionFocusStore.ts',
+        expectedDetail: 'Attention focus store must extend the shared mailbox store',
+        mutate: source => source.replace(
+            'extends OpenWorkspaceFocusMailboxStore<OpenWorkspaceAttentionFocusRequest>',
+            'extends LegacyAttentionFocusStore<OpenWorkspaceAttentionFocusRequest>',
+        ),
+    },
+    {
+        id: 'ARCH-OPEN-WORKSPACE-FOCUS-TRANSPORT-OWNERSHIP-001',
+        file: 'extensions/attention-ui-bridge/src/openWorkspaceRunningFocusCoordinator.ts',
+        expectedDetail: 'Running focus coordinator must delegate to one shared mailbox coordinator',
+        mutate: source => source.replace(
+            'this.coordinator = new OpenWorkspaceFocusMailboxCoordinator({',
+            'this.coordinator = new LegacyRunningFocusCoordinator({',
+        ),
+    },
+    {
+        id: 'ARCH-OPEN-WORKSPACE-FOCUS-TRANSPORT-OWNERSHIP-001',
+        file: 'extensions/attention-ui-bridge/src/openWorkspaceRunningFocusStore.ts',
+        expectedDetail: 'Running focus store must preserve its v2 temporary-file naming',
+        mutate: source => source.replace(
+            'temporaryFileStem: requestId => requestId,',
+            'temporaryFileStem: requestId => `${requestId}.request.json`,',
+        ),
+    },
     {
         id: 'ARCH-AI-SESSION-NAVIGATION-OWNERSHIP-001',
         file: 'src/dashboard.ts',


### PR DESCRIPTION
## Summary

- Extract one durable mailbox store for Running and Attention cross-window focus requests.
- Extract one delivery coordinator for winner selection, atomic claim, retry, receipt, timeout cancellation, and single-flight scanning.
- Keep the existing protocol-specific stores and coordinators as stable wrappers.
- Add mailbox-isolation coverage and an architecture guard with controlled mutations to prevent the two transports from diverging again.

## Scope

This is the second session-navigation architecture stage. Running v2 and Attention v1 protocol versions, mailbox directories, request and outcome shapes, command names, capacity limits, temporary-file behavior, and exported wrapper APIs remain unchanged. This PR does not introduce a new wire protocol or migration.

## Testing

- `npm run test-compile`
- `node --test tests/contract/openProjects/attentionFocus.test.js tests/contract/openProjects/runningFocus.test.js tests/unit/tooling/architectureGuards.test.js`
- `npm run test:architecture-guards`
- `npm run lint`
- `npm run test:behavior-contracts`
- `npm run test:ci:linux`
- Release packaging passed
- Changed-line coverage: 92.21% (450/488)

## Skill harvest

No skill change. The only task-local correction was preserving Running v2 temporary-file naming during extraction; the existing architecture-refactor and review-loop skills already require observable behavior preservation, explicit safety nets, and fresh post-fix verification.
