### PR TITLE
fix: restore Codex live conversation telemetry

### DIFF
--- a/.skills/developing-provider-conversation-adapters/SKILL.md
+++ b/.skills/developing-provider-conversation-adapters/SKILL.md
@@ -30,7 +30,12 @@ Green self-authored fixtures alone are not evidence.
 3. **Verify against real data before commit** — point a throwaway script at
    the compiled `out/` adapter with `resolveSource` returning a real session,
    run the new read path, and eyeball the results against the files on disk.
-4. Then the standard gates: focused owner tests,
+4. **Preserve the Codex adapter boundary** — its full relative-import graph,
+   including type-only imports, is architecture-guarded. Inject filesystem or
+   rollout telemetry readers through `composition.ts`; keep the adapter option
+   as a local structural type. After changing this import graph, run
+   `npm run test:architecture-guards` before the full gate.
+5. Then the standard gates: focused owner tests,
    `npm run test:behavior-contracts`, `npm run test:ci:linux`.
 
 ## Current On-Disk Layouts (re-probe before relying)

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "9c6a7223c606f3cdaaa2e3a3ef6f9a38f239a7c2",
+        "head": "1cd090c4fcd84dd94b28f5a26117c6525958572c",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -240,7 +240,8 @@
             "2724a1e575fc6a2da0355aeb2054e678475443c6",
             "b8a863f10a32baef04c4b916d3e08c6b70799657",
             "23e1655906f8fabb83019d5772ae8e714e67a952",
-            "4aede6f792e9348697acfea174e308368f7157f7"
+            "4aede6f792e9348697acfea174e308368f7157f7",
+            "2c5f31a95dbd671b637cf5013789826ed1bedb10"
         ]
     },
     "capabilities": [
@@ -1492,7 +1493,8 @@
                 "710fc3d55d5221efd9b54119d578acbee5bce268",
                 "b012cd88e557d70cc0d459727c71cccbc4acc3f8",
                 "2390fc13ca86aeadd6c470a92bbff673855f4310",
-                "17cf2c716dbf8b28e2f95c5f6a5de1dc14452c68"
+                "17cf2c716dbf8b28e2f95c5f6a5de1dc14452c68",
+                "1cd090c4fcd84dd94b28f5a26117c6525958572c"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",

--- a/src/aiSessions/codexRolloutWorkdir.ts
+++ b/src/aiSessions/codexRolloutWorkdir.ts
@@ -6,7 +6,78 @@ import { readJsonlTailLines } from './jsonlTail';
 // window. Keep enough trailing data to reach the preceding exec record while
 // remaining bounded for very long rollouts.
 const ROLLOUT_TAIL_BYTES = 2 * 1024 * 1024;
-const WORKDIR_PATTERN = /\bworkdir\s*:\s*"([^"]+)"/;
+const WORKDIR_PATTERN = /\bworkdir\b"?\s*:\s*"([^"]+)"/;
+
+export interface CodexRolloutTelemetry {
+    model?: string;
+    context?: {
+        usedTokens: number;
+        maxTokens: number;
+    };
+    currentWorkdir?: string;
+}
+
+function asRecord(value: unknown): Record<string, any> | undefined {
+    return value && typeof value === 'object' && !Array.isArray(value)
+        ? value as Record<string, any>
+        : undefined;
+}
+
+export function readCodexRolloutTelemetry(
+    rolloutPath: string
+): CodexRolloutTelemetry | undefined {
+    if (!rolloutPath) {
+        return undefined;
+    }
+    const lines = readJsonlTailLines(rolloutPath, ROLLOUT_TAIL_BYTES);
+    let model: string | undefined;
+    let context: CodexRolloutTelemetry['context'];
+    let currentWorkdir: string | undefined;
+    for (let index = lines.length - 1; index >= 0; index--) {
+        let record: Record<string, any> | undefined;
+        try {
+            record = asRecord(JSON.parse(lines[index]));
+        } catch (_error) {
+            continue;
+        }
+        const payload = asRecord(record?.payload);
+        if (!model && record?.type === 'turn_context'
+            && typeof payload?.model === 'string'
+            && payload.model.trim()) {
+            model = payload.model.trim().slice(0, 128);
+        }
+        if (!context && record?.type === 'event_msg'
+            && payload?.type === 'token_count') {
+            const info = asRecord(payload.info);
+            const last = asRecord(info?.last_token_usage);
+            if (Number.isSafeInteger(last?.total_tokens)
+                && last.total_tokens >= 0
+                && Number.isSafeInteger(info?.model_context_window)
+                && info.model_context_window > 0) {
+                context = {
+                    usedTokens: last.total_tokens,
+                    maxTokens: info.model_context_window,
+                };
+            }
+        }
+        if (!currentWorkdir && typeof payload?.input === 'string') {
+            const match = WORKDIR_PATTERN.exec(payload.input);
+            if (match?.[1]) {
+                currentWorkdir = match[1];
+            }
+        }
+        if (model && context && currentWorkdir) {
+            break;
+        }
+    }
+    return model || context || currentWorkdir
+        ? {
+            ...(model ? { model } : {}),
+            ...(context ? { context } : {}),
+            ...(currentWorkdir ? { currentWorkdir } : {}),
+        }
+        : undefined;
+}
 
 /**
  * Telemetry-only probe: app-server does not expose exec items, so the latest
@@ -16,32 +87,5 @@ const WORKDIR_PATTERN = /\bworkdir\s*:\s*"([^"]+)"/;
 export function readCodexRolloutWorkdir(
     rolloutPath: string
 ): string | undefined {
-    if (!rolloutPath) {
-        return undefined;
-    }
-    const lines = readJsonlTailLines(rolloutPath, ROLLOUT_TAIL_BYTES);
-    for (let index = lines.length - 1; index >= 0; index--) {
-        const line = lines[index];
-        if (!line.includes('workdir')) {
-            continue;
-        }
-        let record: unknown;
-        try {
-            record = JSON.parse(line);
-        } catch (_error) {
-            continue;
-        }
-        const payload = (record as { payload?: unknown })?.payload;
-        const input = payload
-            && typeof payload === 'object'
-            && !Array.isArray(payload)
-            && typeof (payload as { input?: unknown }).input === 'string'
-            ? (payload as { input: string }).input
-            : '';
-        const match = WORKDIR_PATTERN.exec(input);
-        if (match?.[1]) {
-            return match[1];
-        }
-    }
-    return undefined;
+    return readCodexRolloutTelemetry(rolloutPath)?.currentWorkdir;
 }

--- a/src/aiSessions/conversation/codexAdapter.ts
+++ b/src/aiSessions/conversation/codexAdapter.ts
@@ -61,6 +61,15 @@ export interface CodexConversationClient extends AiSessionDisposable {
     ): AiSessionDisposable;
 }
 
+interface CodexRolloutTelemetrySnapshot {
+    model?: string;
+    context?: {
+        usedTokens: number;
+        maxTokens: number;
+    };
+    currentWorkdir?: string;
+}
+
 export interface CodexConversationAdapterOptions {
     client: CodexConversationClient;
     watchSessionChanges(onDidChange: () => void): AiSessionDisposable;
@@ -69,7 +78,9 @@ export interface CodexConversationAdapterOptions {
     setCacheTimeout?(callback: () => void, delayMs: number): TimerHandle;
     clearCacheTimeout?(handle: TimerHandle): void;
     resolveWorktree?: ResolveWorktree;
-    readCurrentWorkdir?(sessionId: string): string | undefined;
+    readRolloutTelemetry?(
+        sessionId: string
+    ): CodexRolloutTelemetrySnapshot | undefined;
     readLifecycleSignal?(
         sessionId: string
     ): AiSessionLifecycleSignal | undefined;
@@ -84,7 +95,6 @@ const SUBAGENT_RUNNING_FRESHNESS_MS = 5 * 60 * 1000;
 const LARGE_CONVERSATION_CACHE_CHARS = 512 * 1024;
 const LARGE_CONVERSATION_CACHE_TTL_MS = 15_000;
 const LARGE_CONVERSATION_CACHE_ENTRIES = 2;
-const TOKEN_USAGE_NOTIFICATION_WAIT_MS = 250;
 
 interface LoadedConversation {
     interactions: ConversationInteraction[];
@@ -607,7 +617,6 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
         string,
         Promise<ConversationTelemetry | undefined>
     >();
-    private readonly tokenUsageWaiters = new Map<string, Set<() => void>>();
     private readonly loadedConversationCache = new Map<
         string,
         CachedLoadedConversation
@@ -733,7 +742,7 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
         if (cached
             && Date.now() - cached.readAt
             < CONVERSATION_LIMITS.telemetryRefreshMs) {
-            cached.value = await this.refreshCachedWorktree(
+            cached.value = await this.refreshCachedTelemetry(
                 sessionId,
                 cached.value
             );
@@ -766,39 +775,25 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
         sessionId: string,
         signal?: ConversationAbortSignal
     ): Promise<ConversationTelemetry | undefined> {
-        const contextBeforeRead = this.tokenUsageBySession.get(sessionId);
-        const tokenUsageWaiter = this.createTokenUsageWaiter(sessionId);
-        let resumeResult: { fulfilled: true; value: unknown }
-            | { fulfilled: false };
-        let limitsResult: { fulfilled: true; value: unknown }
-            | { fulfilled: false };
-        try {
-            [resumeResult, limitsResult] = await Promise.all([
-                this.options.client.request(
-                    'thread/resume',
-                    { threadId: sessionId },
-                    signal
-                ).then(
-                    value => ({ fulfilled: true as const, value }),
-                    () => ({ fulfilled: false as const })
-                ),
-                this.options.client.request(
-                    'account/rateLimits/read',
-                    undefined,
-                    signal
-                ).then(
-                    value => ({ fulfilled: true as const, value }),
-                    () => ({ fulfilled: false as const })
-                ),
-            ]);
-            if (resumeResult.fulfilled
-                && this.tokenUsageBySession.get(sessionId)
-                === contextBeforeRead) {
-                await this.waitForTokenUsageOrTimeout(tokenUsageWaiter.promise);
-            }
-        } finally {
-            tokenUsageWaiter.dispose();
-        }
+        const rollout = this.readRolloutTelemetrySnapshot(sessionId);
+        const [threadReadResult, limitsResult] = await Promise.all([
+            this.options.client.request(
+                'thread/read',
+                { threadId: sessionId, includeTurns: false },
+                signal
+            ).then(
+                value => ({ fulfilled: true as const, value }),
+                () => ({ fulfilled: false as const })
+            ),
+            this.options.client.request(
+                'account/rateLimits/read',
+                undefined,
+                signal
+            ).then(
+                value => ({ fulfilled: true as const, value }),
+                () => ({ fulfilled: false as const })
+            ),
+        ]);
         const telemetry: ConversationTelemetry = {
             provider: 'codex',
             sessionId,
@@ -806,18 +801,18 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
                 ? normalizeRateLimits(limitsResult.value)
                 : [],
         };
-        if (resumeResult.fulfilled) {
-            const response = asRecord(resumeResult.value);
-            if (typeof response?.model === 'string'
-                && response.model.trim()) {
-                telemetry.model = response.model.trim().slice(0, 128);
-            }
+        if (rollout?.model) {
+            telemetry.model = rollout.model;
         }
-        const worktree = await this.readWorktree(sessionId, resumeResult);
+        const worktree = await this.readWorktree(
+            threadReadResult,
+            rollout?.currentWorkdir
+        );
         if (worktree) {
             telemetry.worktree = worktree;
         }
-        const context = this.tokenUsageBySession.get(sessionId);
+        const context = rollout?.context
+            || this.tokenUsageBySession.get(sessionId);
         if (context) {
             telemetry.context = { ...context };
         }
@@ -828,8 +823,9 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
     }
 
     private async readWorktree(
-        sessionId: string,
-        resumeResult: { fulfilled: true; value: unknown } | { fulfilled: false }
+        threadReadResult: { fulfilled: true; value: unknown }
+            | { fulfilled: false },
+        currentWorkdir: string | undefined
     ): Promise<ConversationWorktreeInfo | undefined> {
         if (!this.options.resolveWorktree) {
             return undefined;
@@ -837,33 +833,58 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
         // The current operating directory wins over the launch directory:
         // app-server exposes no exec items, so composition injects a
         // telemetry-only probe for the latest exec workdir.
-        const currentWorkdir = this.options.readCurrentWorkdir?.(sessionId);
         if (currentWorkdir) {
             const resolved = await this.options.resolveWorktree(currentWorkdir);
             if (resolved) {
                 return resolved;
             }
         }
-        const response = resumeResult.fulfilled
-            ? asRecord(resumeResult.value)
+        const response = threadReadResult.fulfilled
+            ? asRecord(threadReadResult.value)
             : undefined;
-        const cwd = typeof response?.cwd === 'string' && response.cwd
-            ? response.cwd
+        const thread = asRecord(response?.thread);
+        const cwd = typeof thread?.cwd === 'string' && thread.cwd
+            ? thread.cwd
             : undefined;
         return cwd ? this.options.resolveWorktree(cwd) : undefined;
     }
 
-    private async refreshCachedWorktree(
+    private readRolloutTelemetrySnapshot(
+        sessionId: string
+    ): CodexRolloutTelemetrySnapshot | undefined {
+        try {
+            return this.options.readRolloutTelemetry?.(sessionId);
+        } catch (_error) {
+            return undefined;
+        }
+    }
+
+    private async refreshCachedTelemetry(
         sessionId: string,
         telemetry: ConversationTelemetry | undefined
     ): Promise<ConversationTelemetry | undefined> {
-        const currentWorkdir = this.options.readCurrentWorkdir?.(sessionId);
-        if (!currentWorkdir || !this.options.resolveWorktree) {
+        const rollout = this.readRolloutTelemetrySnapshot(sessionId);
+        if (rollout?.model || rollout?.context) {
+            telemetry = telemetry || {
+                provider: 'codex',
+                sessionId,
+                rateLimits: [],
+            };
+            if (rollout.model) {
+                telemetry.model = rollout.model;
+            }
+            if (rollout.context) {
+                telemetry.context = { ...rollout.context };
+            }
+        }
+        if (!rollout?.currentWorkdir || !this.options.resolveWorktree) {
             return telemetry;
         }
         let worktree: ConversationWorktreeInfo | undefined;
         try {
-            worktree = await this.options.resolveWorktree(currentWorkdir);
+            worktree = await this.options.resolveWorktree(
+                rollout.currentWorkdir
+            );
         } catch (_error) {
             return telemetry;
         }
@@ -930,10 +951,6 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
         this.providerWatch?.dispose();
         this.providerWatch = undefined;
         this.notificationWatch?.dispose();
-        this.tokenUsageWaiters.forEach(waiters => {
-            waiters.forEach(resolve => resolve());
-        });
-        this.tokenUsageWaiters.clear();
         this.tokenUsageBySession.clear();
         this.telemetryCache.clear();
         this.telemetryReads.clear();
@@ -964,70 +981,10 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
         };
         this.makeRoomForTelemetrySession(params.threadId);
         this.tokenUsageBySession.set(params.threadId, context);
-        const waiters = this.tokenUsageWaiters.get(params.threadId);
-        if (waiters) {
-            this.tokenUsageWaiters.delete(params.threadId);
-            waiters.forEach(resolve => resolve());
-        }
         const cached = this.telemetryCache.get(params.threadId);
         if (cached?.value) {
             cached.value.context = { ...context };
         }
-    }
-
-    private createTokenUsageWaiter(sessionId: string): {
-        promise: Promise<void>;
-        dispose(): void;
-    } {
-        let resolvePromise = (): void => undefined;
-        const promise = new Promise<void>(resolve => {
-            resolvePromise = resolve;
-        });
-        let waiters = this.tokenUsageWaiters.get(sessionId);
-        if (!waiters) {
-            waiters = new Set();
-            this.tokenUsageWaiters.set(sessionId, waiters);
-        }
-        waiters.add(resolvePromise);
-        return {
-            promise,
-            dispose: () => {
-                const current = this.tokenUsageWaiters.get(sessionId);
-                current?.delete(resolvePromise);
-                if (!current?.size) {
-                    this.tokenUsageWaiters.delete(sessionId);
-                }
-            },
-        };
-    }
-
-    private waitForTokenUsageOrTimeout(notification: Promise<void>): Promise<void> {
-        return new Promise(resolve => {
-            let settled = false;
-            let timeoutHandle: TimerHandle | undefined;
-            const finish = (): void => {
-                if (settled) {
-                    return;
-                }
-                settled = true;
-                if (timeoutHandle !== undefined) {
-                    this.options.clearTimeout(timeoutHandle);
-                    timeoutHandle = undefined;
-                }
-                resolve();
-            };
-            notification.then(finish);
-            let timeoutFiredSynchronously = false;
-            const handle = this.options.setTimeout(() => {
-                timeoutFiredSynchronously = true;
-                finish();
-            }, TOKEN_USAGE_NOTIFICATION_WAIT_MS);
-            if (!timeoutFiredSynchronously && !settled) {
-                timeoutHandle = handle;
-            } else {
-                this.options.clearTimeout(handle);
-            }
-        });
     }
 
     private makeRoomForTelemetrySession(sessionId: string): void {

--- a/src/aiSessions/conversation/composition.ts
+++ b/src/aiSessions/conversation/composition.ts
@@ -54,7 +54,7 @@ import {
     parseConversationViewerRestoreTarget,
 } from './viewerRestoreState';
 import { ConversationWorktreeResolver } from './worktreeResolver';
-import { readCodexRolloutWorkdir } from '../codexRolloutWorkdir';
+import { readCodexRolloutTelemetry } from '../codexRolloutWorkdir';
 import { encodeSubagentSessionId } from './subagentSessions';
 
 export interface ConversationSessionOpenTarget {
@@ -218,11 +218,11 @@ function createAvailableConversationCapability(
         clearTimeout: options.clearTimer,
         resolveWorktree: candidatePath =>
             worktreeResolver.resolve(candidatePath),
-        readCurrentWorkdir: sessionId => {
+        readRolloutTelemetry: sessionId => {
             const rolloutPath = options.services.codex
                 .resolveSessionFilePath?.(sessionId);
             return rolloutPath
-                ? readCodexRolloutWorkdir(rolloutPath)
+                ? readCodexRolloutTelemetry(rolloutPath)
                 : undefined;
         },
         readLifecycleSignal: sessionId =>

--- a/tests/contract/aiSessions/codexConversationAdapter.test.js
+++ b/tests/contract/aiSessions/codexConversationAdapter.test.js
@@ -51,7 +51,7 @@ function createAdapter(result = fixture, overrides = {}) {
         setCacheTimeout: overrides.setCacheTimeout || (() => 2),
         clearCacheTimeout: overrides.clearCacheTimeout || (() => undefined),
         resolveWorktree: overrides.resolveWorktree,
-        readCurrentWorkdir: overrides.readCurrentWorkdir,
+        readRolloutTelemetry: overrides.readRolloutTelemetry,
         readLifecycleSignal: overrides.readLifecycleSignal,
         listSubagentThreads: overrides.listSubagentThreads,
         now: overrides.now,
@@ -568,29 +568,12 @@ test('CONVERSATION-DIFF-VISIBILITY-001 Codex renders every changed file with par
     assert.equal(tool.tool.detail, 'not a diff at all');
 });
 
-test('CONVERSATION-TELEMETRY-001 reads model, context, and quota windows from structured Codex protocol data', async t => {
-    let notificationListener;
+test('CONVERSATION-TELEMETRY-001 reads model, context, and quota windows from Codex rollout and protocol data', async t => {
     const harness = createAdapter(fixture, {
         client: {
-            watchNotifications(listener) {
-                notificationListener = listener;
-                return { dispose() {} };
-            },
             async request(method) {
-                if (method === 'thread/resume') {
-                    notificationListener('thread/tokenUsage/updated', {
-                        threadId: sessionId,
-                        turnId: 'turn-telemetry',
-                        tokenUsage: {
-                            total: { totalTokens: 88_000 },
-                            last: { totalTokens: 32_000 },
-                            modelContextWindow: 128_000,
-                        },
-                    });
-                    return {
-                        model: 'gpt-5.6-sol',
-                        modelProvider: 'openai',
-                    };
+                if (method === 'thread/read') {
+                    return { thread: { cwd: '/repo' } };
                 }
                 assert.equal(method, 'account/rateLimits/read');
                 return {
@@ -612,6 +595,13 @@ test('CONVERSATION-TELEMETRY-001 reads model, context, and quota windows from st
             },
             dispose() {},
         },
+        readRolloutTelemetry: () => ({
+            model: 'gpt-5.6-sol',
+            context: {
+                usedTokens: 32_000,
+                maxTokens: 128_000,
+            },
+        }),
     });
     t.after(() => harness.adapter.dispose());
 
@@ -639,6 +629,66 @@ test('CONVERSATION-TELEMETRY-001 reads model, context, and quota windows from st
     });
 });
 
+test('CONVERSATION-TELEMETRY-001 keeps live branch and context telemetry without resuming an active-writer thread', async t => {
+    const requests = [];
+    const harness = createAdapter(fixture, {
+        client: {
+            async request(method, params) {
+                requests.push([method, params]);
+                if (method === 'thread/read') {
+                    return { thread: { cwd: '/launch/repo' } };
+                }
+                if (method === 'account/rateLimits/read') {
+                    return { rateLimits: null, rateLimitsByLimitId: null };
+                }
+                if (method === 'thread/resume') {
+                    throw new Error(`thread ${sessionId} already has an active writer`);
+                }
+                throw new Error(`unexpected method ${method}`);
+            },
+            dispose() {},
+        },
+        readRolloutTelemetry: () => ({
+            model: 'gpt-5.6-sol',
+            context: {
+                usedTokens: 54_297,
+                maxTokens: 258_400,
+            },
+        }),
+        resolveWorktree: async candidate => candidate === '/launch/repo'
+            ? {
+                branch: 'main',
+                worktreeRoot: candidate,
+                repoRoot: candidate,
+            }
+            : undefined,
+    });
+    t.after(() => harness.adapter.dispose());
+
+    assert.deepEqual(await harness.adapter.readTelemetry(sessionId), {
+        provider: 'codex',
+        sessionId,
+        model: 'gpt-5.6-sol',
+        context: {
+            usedTokens: 54_297,
+            maxTokens: 258_400,
+        },
+        worktree: {
+            branch: 'main',
+            worktreeRoot: '/launch/repo',
+            repoRoot: '/launch/repo',
+        },
+        rateLimits: [],
+    });
+    assert.deepEqual(requests, [[
+        'thread/read',
+        { threadId: sessionId, includeTurns: false },
+    ], [
+        'account/rateLimits/read',
+        undefined,
+    ]]);
+});
+
 test('CONVERSATION-TELEMETRY-001 prefers the canonical Codex quota over same-window named limits', async t => {
     const canonical = {
         limitId: 'codex',
@@ -652,8 +702,8 @@ test('CONVERSATION-TELEMETRY-001 prefers the canonical Codex quota over same-win
     const harness = createAdapter(fixture, {
         client: {
             async request(method) {
-                if (method === 'thread/resume') {
-                    return { model: 'gpt-5.6-sol' };
+                if (method === 'thread/read') {
+                    return { thread: { cwd: '/repo' } };
                 }
                 assert.equal(method, 'account/rateLimits/read');
                 return {
@@ -689,7 +739,51 @@ test('CONVERSATION-TELEMETRY-001 prefers the canonical Codex quota over same-win
     }]);
 });
 
-test('CONVERSATION-TELEMETRY-001 waits for token usage emitted after the resume response', async t => {
+test('CONVERSATION-TELEMETRY-001 refreshes cached model and context from the newest rollout tail', async t => {
+    let rollout = {
+        model: 'gpt-5.5',
+        context: { usedTokens: 12_000, maxTokens: 128_000 },
+    };
+    let requestCount = 0;
+    const harness = createAdapter(fixture, {
+        client: {
+            async request(method) {
+                requestCount += 1;
+                if (method === 'thread/read') {
+                    return { thread: { cwd: '/repo' } };
+                }
+                assert.equal(method, 'account/rateLimits/read');
+                return { rateLimits: null, rateLimitsByLimitId: null };
+            },
+            dispose() {},
+        },
+        readRolloutTelemetry: () => rollout,
+    });
+    t.after(() => harness.adapter.dispose());
+
+    const initial = await harness.adapter.readTelemetry(sessionId);
+    assert.equal(initial.model, 'gpt-5.5');
+    assert.deepEqual(initial.context, {
+        usedTokens: 12_000,
+        maxTokens: 128_000,
+    });
+
+    rollout = {
+        model: 'gpt-5.6-sol',
+        context: { usedTokens: 48_000, maxTokens: 258_400 },
+    };
+    const refreshed = await harness.adapter.readTelemetry(sessionId);
+
+    assert.equal(refreshed.model, 'gpt-5.6-sol');
+    assert.deepEqual(refreshed.context, {
+        usedTokens: 48_000,
+        maxTokens: 258_400,
+    });
+    assert.equal(requestCount, 2,
+        'rollout-only refreshes must reuse cached app-server telemetry');
+});
+
+test('CONVERSATION-TELEMETRY-001 keeps an observed token notification when the rollout tail is unavailable', async t => {
     let notificationListener;
     const harness = createAdapter(fixture, {
         client: {
@@ -698,93 +792,16 @@ test('CONVERSATION-TELEMETRY-001 waits for token usage emitted after the resume 
                 return { dispose() {} };
             },
             async request(method) {
-                if (method === 'thread/resume') {
-                    setImmediate(() => {
-                        notificationListener('thread/tokenUsage/updated', {
-                            threadId: sessionId,
-                            turnId: 'turn-delayed-telemetry',
-                            tokenUsage: {
-                                total: { totalTokens: 96_000 },
-                                last: { totalTokens: 48_000 },
-                                modelContextWindow: 128_000,
-                            },
-                        });
-                    });
-                    return { model: 'gpt-5.6-sol' };
+                if (method === 'thread/read') {
+                    return { thread: { cwd: '/repo' } };
                 }
                 assert.equal(method, 'account/rateLimits/read');
                 return { rateLimits: null, rateLimitsByLimitId: null };
             },
             dispose() {},
         },
-        setTimeout: (callback, delayMs) => setTimeout(callback, delayMs),
-        clearTimeout: handle => clearTimeout(handle),
     });
     t.after(() => harness.adapter.dispose());
-
-    const telemetry = await harness.adapter.readTelemetry(sessionId);
-
-    assert.deepEqual(telemetry.context, {
-        usedTokens: 48_000,
-        maxTokens: 128_000,
-    });
-});
-
-test('CONVERSATION-TELEMETRY-001 isolates delayed token usage by session', async t => {
-    const secondSessionId = '44444444-4444-4444-8444-444444444444';
-    let notificationListener;
-    let nextTimer = 1;
-    const timers = new Map();
-    const harness = createAdapter(fixture, {
-        client: {
-            watchNotifications(listener) {
-                notificationListener = listener;
-                return { dispose() {} };
-            },
-            async request(method, params) {
-                if (method === 'thread/resume') {
-                    return { model: `model-${params.threadId}` };
-                }
-                assert.equal(method, 'account/rateLimits/read');
-                return { rateLimits: null, rateLimitsByLimitId: null };
-            },
-            dispose() {},
-        },
-        setTimeout(callback) {
-            const handle = nextTimer++;
-            timers.set(handle, callback);
-            return handle;
-        },
-        clearTimeout(handle) {
-            timers.delete(handle);
-        },
-    });
-    t.after(() => harness.adapter.dispose());
-
-    let firstSettled = false;
-    const firstRead = harness.adapter.readTelemetry(sessionId)
-        .then(value => {
-            firstSettled = true;
-            return value;
-        });
-    const secondRead = harness.adapter.readTelemetry(secondSessionId);
-    await new Promise(resolve => setImmediate(resolve));
-
-    notificationListener('thread/tokenUsage/updated', {
-        threadId: secondSessionId,
-        tokenUsage: {
-            last: { totalTokens: 22_000 },
-            modelContextWindow: 64_000,
-        },
-    });
-
-    const secondTelemetry = await secondRead;
-    await new Promise(resolve => setImmediate(resolve));
-    assert.equal(firstSettled, false);
-    assert.deepEqual(secondTelemetry.context, {
-        usedTokens: 22_000,
-        maxTokens: 64_000,
-    });
 
     notificationListener('thread/tokenUsage/updated', {
         threadId: sessionId,
@@ -794,89 +811,71 @@ test('CONVERSATION-TELEMETRY-001 isolates delayed token usage by session', async
         },
     });
 
-    const firstTelemetry = await firstRead;
-    assert.deepEqual(firstTelemetry.context, {
+    const telemetry = await harness.adapter.readTelemetry(sessionId);
+    assert.deepEqual(telemetry.context, {
         usedTokens: 33_000,
         maxTokens: 128_000,
     });
-    assert.equal(timers.size, 0);
 });
 
-test('CONVERSATION-TELEMETRY-001 clears a delayed token usage waiter after timeout', async t => {
-    let nextTimer = 1;
-    const timers = new Map();
-    const cleared = [];
+test('CONVERSATION-TELEMETRY-001 isolates rollout telemetry reads by session', async t => {
+    const secondSessionId = '44444444-4444-4444-8444-444444444444';
     const harness = createAdapter(fixture, {
         client: {
             async request(method) {
-                if (method === 'thread/resume') {
-                    return { model: 'gpt-5.6-sol' };
+                if (method === 'thread/read') {
+                    return { thread: { cwd: '/repo' } };
                 }
                 assert.equal(method, 'account/rateLimits/read');
                 return { rateLimits: null, rateLimitsByLimitId: null };
             },
             dispose() {},
         },
-        setTimeout(callback, delayMs) {
-            assert.equal(delayMs, 250);
-            const handle = nextTimer++;
-            timers.set(handle, callback);
-            return handle;
-        },
-        clearTimeout(handle) {
-            cleared.push(handle);
-            timers.delete(handle);
-        },
+        readRolloutTelemetry: id => ({
+            model: `model-${id}`,
+            context: {
+                usedTokens: id === sessionId ? 11_000 : 22_000,
+                maxTokens: 64_000,
+            },
+        }),
     });
     t.after(() => harness.adapter.dispose());
 
-    const read = harness.adapter.readTelemetry(sessionId);
-    await new Promise(resolve => setImmediate(resolve));
-    assert.equal(timers.size, 1);
-    const [handle, fireTimeout] = timers.entries().next().value;
-    fireTimeout();
-
-    const telemetry = await read;
-    assert.equal(telemetry.context, undefined);
-    assert.deepEqual(cleared, [handle]);
-    assert.equal(timers.size, 0);
-    assert.equal(harness.adapter.tokenUsageWaiters.size, 0);
+    const [first, second] = await Promise.all([
+        harness.adapter.readTelemetry(sessionId),
+        harness.adapter.readTelemetry(secondSessionId),
+    ]);
+    assert.equal(first.model, `model-${sessionId}`);
+    assert.equal(second.model, `model-${secondSessionId}`);
+    assert.equal(first.context.usedTokens, 11_000);
+    assert.equal(second.context.usedTokens, 22_000);
 });
 
-test('CONVERSATION-TELEMETRY-001 dispose releases pending token usage reads without repopulating caches', async () => {
-    let nextTimer = 1;
-    const timers = new Map();
+test('CONVERSATION-TELEMETRY-001 dispose prevents a pending read-only telemetry request from repopulating caches', async () => {
+    let resolveThreadRead;
     const harness = createAdapter(fixture, {
         client: {
             async request(method) {
-                if (method === 'thread/resume') {
-                    return { model: 'gpt-5.6-sol' };
+                if (method === 'thread/read') {
+                    return new Promise(resolve => {
+                        resolveThreadRead = resolve;
+                    });
                 }
                 assert.equal(method, 'account/rateLimits/read');
                 return { rateLimits: null, rateLimitsByLimitId: null };
             },
             dispose() {},
         },
-        setTimeout(callback) {
-            const handle = nextTimer++;
-            timers.set(handle, callback);
-            return handle;
-        },
-        clearTimeout(handle) {
-            timers.delete(handle);
-        },
+        readRolloutTelemetry: () => ({ model: 'gpt-5.6-sol' }),
     });
 
     const read = harness.adapter.readTelemetry(sessionId);
     await new Promise(resolve => setImmediate(resolve));
-    assert.equal(timers.size, 1);
-
     harness.adapter.dispose();
+    resolveThreadRead({ thread: { cwd: '/repo' } });
     const telemetry = await read;
 
     assert.equal(telemetry.model, 'gpt-5.6-sol');
-    assert.equal(timers.size, 0);
-    assert.equal(harness.adapter.tokenUsageWaiters.size, 0);
     assert.equal(harness.adapter.telemetryCache.size, 0);
 });
 
@@ -1327,8 +1326,8 @@ test('SESSION-AI-SESSION-CODEX-CONVERSATION-007 keeps revisions stable until nor
 test('CONVERSATION-TELEMETRY-001 Codex prefers the latest exec workdir and falls back to the launch cwd', async t => {
     const telemetryClient = {
         async request(method) {
-            if (method === 'thread/resume') {
-                return { model: 'gpt-5.6-sol', cwd: '/launch/repo' };
+            if (method === 'thread/read') {
+                return { thread: { cwd: '/launch/repo' } };
             }
             return {};
         },
@@ -1336,8 +1335,12 @@ test('CONVERSATION-TELEMETRY-001 Codex prefers the latest exec workdir and falls
     };
     const rolloutAdapter = createAdapter(fixture, {
         client: telemetryClient,
-        readCurrentWorkdir: id =>
-            id === sessionId ? '/launch/repo/.worktree/feature-x' : undefined,
+        readRolloutTelemetry: id => id === sessionId
+            ? {
+                model: 'gpt-5.6-sol',
+                currentWorkdir: '/launch/repo/.worktree/feature-x',
+            }
+            : undefined,
         resolveWorktree: async candidate => {
             if (candidate === '/launch/repo/.worktree/feature-x') {
                 return {
@@ -1367,7 +1370,7 @@ test('CONVERSATION-TELEMETRY-001 Codex prefers the latest exec workdir and falls
 
     const fallbackAdapter = createAdapter(fixture, {
         client: telemetryClient,
-        readCurrentWorkdir: () => undefined,
+        readRolloutTelemetry: () => ({ model: 'gpt-5.6-sol' }),
         resolveWorktree: async candidate =>
             candidate === '/launch/repo'
                 ? {
@@ -1393,8 +1396,8 @@ test('CONVERSATION-TELEMETRY-001 Codex refreshes the latest exec workdir inside 
     const telemetryClient = {
         async request(method) {
             requestCount += 1;
-            if (method === 'thread/resume') {
-                return { model: 'gpt-5.6-sol', cwd: '/launch/repo' };
+            if (method === 'thread/read') {
+                return { thread: { cwd: '/launch/repo' } };
             }
             return {};
         },
@@ -1402,7 +1405,10 @@ test('CONVERSATION-TELEMETRY-001 Codex refreshes the latest exec workdir inside 
     };
     const harness = createAdapter(fixture, {
         client: telemetryClient,
-        readCurrentWorkdir: () => currentWorkdir,
+        readRolloutTelemetry: () => ({
+            model: 'gpt-5.6-sol',
+            currentWorkdir,
+        }),
         resolveWorktree: async candidate => ({
             branch: candidate.endsWith('/feature-x') ? 'feature-x' : 'main',
             worktreeRoot: candidate,
@@ -1436,7 +1442,9 @@ test('CONVERSATION-TELEMETRY-001 Codex discovers a worktree after an empty telem
             },
             dispose() {},
         },
-        readCurrentWorkdir: () => currentWorkdir,
+        readRolloutTelemetry: () => currentWorkdir
+            ? { currentWorkdir }
+            : undefined,
         resolveWorktree: async candidate => ({
             branch: 'feature-x',
             worktreeRoot: candidate,

--- a/tests/unit/aiSessions/codexRolloutWorkdir.test.js
+++ b/tests/unit/aiSessions/codexRolloutWorkdir.test.js
@@ -7,6 +7,7 @@ const path = require('node:path');
 const test = require('node:test');
 
 const {
+    readCodexRolloutTelemetry,
     readCodexRolloutWorkdir,
 } = require('../../../out/aiSessions/codexRolloutWorkdir');
 
@@ -16,7 +17,10 @@ function execLine(workdir) {
         payload: {
             type: 'custom_tool_call',
             name: 'exec',
-            input: `const r = await tools.exec_command({cmd:"git status",workdir:"${workdir}"})`,
+            input: `const r = await tools.exec_command(${JSON.stringify({
+                cmd: 'git status',
+                workdir,
+            })})`,
         },
     });
 }
@@ -76,4 +80,54 @@ test('CONVERSATION-TELEMETRY-001 rollout probe keeps the latest workdir across a
         readCodexRolloutWorkdir(rolloutPath),
         '/repo/.worktree/telemetry-fix'
     );
+});
+
+test('CONVERSATION-TELEMETRY-001 rollout probe reads current model and context usage from real Codex record shapes', async t => {
+    const dir = await fs.promises.mkdtemp(
+        path.join(os.tmpdir(), 'steward-codex-rollout-telemetry-')
+    );
+    t.after(() => fs.promises.rm(dir, { recursive: true, force: true }));
+    const rolloutPath = path.join(dir, 'rollout.jsonl');
+
+    await fs.promises.writeFile(rolloutPath, [
+        JSON.stringify({
+            type: 'turn_context',
+            payload: { model: 'gpt-5.5' },
+        }),
+        JSON.stringify({
+            type: 'event_msg',
+            payload: {
+                type: 'token_count',
+                info: {
+                    last_token_usage: { total_tokens: 12_000 },
+                    model_context_window: 128_000,
+                },
+            },
+        }),
+        '{"type":"event_msg","payload":',
+        JSON.stringify({
+            type: 'turn_context',
+            payload: { model: 'gpt-5.6-sol' },
+        }),
+        JSON.stringify({
+            type: 'event_msg',
+            payload: {
+                type: 'token_count',
+                info: {
+                    total_token_usage: { total_tokens: 226_194 },
+                    last_token_usage: { total_tokens: 54_297 },
+                    model_context_window: 258_400,
+                },
+            },
+        }),
+        '',
+    ].join('\n'));
+
+    assert.deepEqual(readCodexRolloutTelemetry(rolloutPath), {
+        model: 'gpt-5.6-sol',
+        context: {
+            usedTokens: 54_297,
+            maxTokens: 258_400,
+        },
+    });
 });

--- a/tests/unit/tooling/repositorySkills.test.js
+++ b/tests/unit/tooling/repositorySkills.test.js
@@ -144,6 +144,9 @@ test('ARCH-REPOSITORY-SKILL-GUIDANCE-001 verifies provider adapters against real
         ['probe before assuming', /probe real data first/i],
         ['layout mirroring', /mirror the real layout/i],
         ['status inference guidance', /no status[\s\S]*transcript tail/i],
+        ['type imports remain inside the Codex boundary', /full relative-import graph[\s\S]*type-only imports[\s\S]*architecture-guarded/i],
+        ['rollout readers are injected at composition', /rollout telemetry readers[\s\S]*composition\.ts[\s\S]*local structural type/i],
+        ['focused architecture verification', /npm run test:architecture-guards[\s\S]*before the full gate/i],
     ]);
 });
 


### PR DESCRIPTION
## Summary

- replace `thread/resume` telemetry reads with read-only `thread/read` so active Codex writers no longer suppress branch and context data
- read the current model, context-window usage, and latest quoted workdir from the bounded Codex rollout tail
- add regression coverage for active-writer sessions and document the guarded Codex adapter import boundary

## Skill harvest

updated .skills/developing-provider-conversation-adapters — the architecture guard caught that type-only relative imports also enter the Codex adapter graph, so rollout readers must be injected through composition and checked with the focused architecture gate.

## Verification

- `npm run test:ci:linux`
- real active-writer compiled adapter probe against the current Codex rollout
- `SKIP_NPM_CI=1 npm run install-local` with VSIX-to-installed byte verification
- manual telemetry verification pending after local installation
