### PR TITLE
Serialize every AI session switch command

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -812,7 +812,7 @@
   {
     "id": "AI-SESSION-QUICK-SWITCH-COMMANDS-001",
     "domain": "session",
-    "title": "The Switch to AI Session picker lists every live local session most-recently-focused first plus one entry per other window with running sessions, jumping locally with terminal focus and conversation open or handing off through the focus mailbox with plain-navigation degradation, while Toggle Last AI Session alternates the two most recently focused local sessions from a terminal-focus-fed MRU that prunes dead sessions, and both commands are contributed without default keybindings",
+    "title": "The Switch to AI Session picker lists every live local session most-recently-focused first plus one entry per other window with running sessions, jumping locally with terminal focus and conversation open or handing off through the focus mailbox with plain-navigation degradation, while Toggle Last AI Session alternates the two most recently focused local sessions from a terminal-focus-fed MRU that prunes dead sessions, and both commands share the global navigation transaction, use one workspace snapshot, and are contributed without default keybindings",
     "priority": "P1",
     "status": "automated",
     "owners": [
@@ -822,6 +822,8 @@
     "evidence": [
       "src/aiSessions/sessionMru.ts",
       "src/dashboard/sessionQuickSwitch.ts",
+      "src/dashboard/sessionNavigationCoordinator.ts",
+      "src/dashboard/sessionNavigationFocusExecutor.ts",
       "src/dashboard.ts",
       "src/dashboard/commandRegistration.ts",
       "package.json"
@@ -924,7 +926,7 @@
   {
     "id": "ARCH-AI-SESSION-NAVIGATION-OWNERSHIP-001",
     "domain": "architecture",
-    "title": "Running and Attention session commands share one navigation coordinator and one local focus executor",
+    "title": "Every AI Session command that moves terminal authority shares one navigation coordinator, while direct local jumps share one focus executor",
     "priority": "P1",
     "status": "automated",
     "owners": [
@@ -4997,7 +4999,7 @@
   {
     "id": "CONVERSATION-ACTIVE-SESSION-NAVIGATION-COMMANDS-001",
     "domain": "session",
-    "title": "Previous and Next Active Session commands remain globally available, synchronize the authoritative active terminal and card, and restore keyboard focus to AI Conversation",
+    "title": "Previous and Next Active Session commands remain globally available, join the global navigation transaction, synchronize the authoritative active terminal and card, and restore keyboard focus to AI Conversation",
     "priority": "P1",
     "status": "automated",
     "owners": [
@@ -5010,6 +5012,7 @@
       "package.json",
       "src/dashboard/commandRegistration.ts",
       "src/dashboard.ts",
+      "src/dashboard/sessionNavigationCoordinator.ts",
       "src/aiSessions/conversation/composition.ts",
       "src/aiSessions/conversation/viewer.ts"
     ]

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "1cd090c4fcd84dd94b28f5a26117c6525958572c",
+        "head": "26fb48d07086ecf8ebfe4a70d854cb7166204665",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -241,7 +241,8 @@
             "b8a863f10a32baef04c4b916d3e08c6b70799657",
             "23e1655906f8fabb83019d5772ae8e714e67a952",
             "4aede6f792e9348697acfea174e308368f7157f7",
-            "2c5f31a95dbd671b637cf5013789826ed1bedb10"
+            "2c5f31a95dbd671b637cf5013789826ed1bedb10",
+            "a760309127206890f64a3fa5e1439e75261f067e"
         ]
     },
     "capabilities": [
@@ -1736,7 +1737,10 @@
             "requirement": "The Switch to AI Session picker lists every live local session most-recently-focused first plus one entry per other window with running sessions, jumping locally with terminal focus and conversation open or handing off through the focus mailbox with plain-navigation degradation, and Toggle Last AI Session alternates the two most recently focused local sessions from a terminal-focus-fed MRU that prunes dead sessions.",
             "commits": [
                 "4b7095d337d022973fa0d90926ae1ba6f795eca1",
-                "0eec5f1fdac5105b1a6139eb2125d565860ec16f"
+                "0eec5f1fdac5105b1a6139eb2125d565860ec16f",
+                "cc2e6152fa07e584611251ec3a984a13c3e0e95c",
+                "91984761d09cb71eabd73a5d33455f2f3bba6e73",
+                "26fb48d07086ecf8ebfe4a70d854cb7166204665"
             ],
             "behaviors": [
                 "AI-SESSION-QUICK-SWITCH-COMMANDS-001"

--- a/scripts/run-architecture-guards.js
+++ b/scripts/run-architecture-guards.js
@@ -565,8 +565,14 @@ function objectFreezeProperties(sourceFile, variableName, id, risk) {
 const guards = {
     // ARCH-AI-SESSION-NAVIGATION-OWNERSHIP-001
     'ARCH-AI-SESSION-NAVIGATION-OWNERSHIP-001'(root) {
-        const risk = 'independent session navigation pipelines can race and project different targets';
+        const risk = 'terminal-moving session commands can race and project different targets';
         const dashboard = parseTypescript(root, 'src/dashboard.ts', this.id, risk);
+        const quickSwitch = parseTypescript(
+            root,
+            'src/dashboard/sessionQuickSwitch.ts',
+            this.id,
+            risk,
+        );
         const coordinator = findVariable(
             dashboard,
             'sessionNavigationCoordinator',
@@ -583,6 +589,7 @@ const guards = {
         for (const factoryName of [
             'createAttentionQueueJumpHandler',
             'createRunningSessionJumpHandler',
+            'createAiSessionQuickSwitchHandlers',
         ]) {
             const calls = callArguments(dashboard, factoryName);
             const options = calls.length === 1 ? calls[0][0] : null;
@@ -595,7 +602,7 @@ const guards = {
                 || navigationOwner.initializer.getText(dashboard)
                     !== 'sessionNavigationCoordinator') {
                 fail(this.id, risk,
-                    'both session commands must use the shared navigation coordinator');
+                    'every direct session command must use the shared navigation coordinator');
             }
             const localNavigator = options.properties.find(property =>
                 property.name?.getText(dashboard) === 'navigateSession');
@@ -605,7 +612,48 @@ const guards = {
                     'sessionNavigationFocusExecutor.execute',
                 ).length !== 1) {
                 fail(this.id, risk,
-                    'both session commands must use the shared local focus executor');
+                    'every direct session command must use the shared local focus executor');
+            }
+        }
+        if (callArguments(quickSwitch, 'navigationCoordinator.enqueue').length !== 3
+            || callArguments(quickSwitch, 'options.navigateSession').length !== 1
+            || callArguments(quickSwitch, 'options.focusSession').length !== 0
+            || callArguments(quickSwitch, 'options.openConversation').length !== 0) {
+            fail(this.id, risk,
+                'Quick Switch and Toggle must own no navigation path outside the shared transaction');
+        }
+        const commandHandlers = findVariable(
+            dashboard,
+            'commandHandlers',
+            this.id,
+            risk,
+        );
+        if (!commandHandlers.initializer
+            || !ts.isObjectLiteralExpression(commandHandlers.initializer)) {
+            fail(this.id, risk, 'dashboard command handlers must remain one object literal');
+        }
+        for (const [name, direction] of [
+            ['previousActiveSession', 'previous'],
+            ['nextActiveSession', 'next'],
+        ]) {
+            const handler = commandHandlers.initializer.properties.find(property =>
+                property.name?.getText(dashboard) === name);
+            if (!handler || !ts.isPropertyAssignment(handler)
+                || callArguments(
+                    handler.initializer,
+                    'sessionNavigationCoordinator.enqueue',
+                ).length !== 1) {
+                fail(this.id, risk,
+                    'Previous and Next Active Session commands must use the shared navigation coordinator');
+            }
+            const followCalls = callArguments(
+                handler.initializer,
+                'followAdjacentActiveConversationWithFeedback',
+            );
+            if (followCalls.length !== 1
+                || stringArgument(followCalls[0][0]) !== direction) {
+                fail(this.id, risk,
+                    'Previous and Next Active Session commands must preserve their direction');
             }
         }
     },

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1859,38 +1859,6 @@ async function initializeDashboard(
                 && Boolean(candidate.identity.sessionId));
         return direct?.identity || null;
     };
-    const focusAiSessionForQuickSwitch = (target: {
-        provider: AiSessionProviderId;
-        sessionId: string;
-    }): Promise<boolean> => {
-        const cardId = getCurrentWorkspaceActionTargetWithoutCardId()?.cardId;
-        if (!cardId) {
-            return Promise.resolve(false);
-        }
-        return aiSessionTerminalCommandController.focusActive(
-            cardId,
-            target.provider,
-            target.sessionId
-        ).then(focused => {
-            if (focused) {
-                aiSessionMru.record(target.provider, target.sessionId);
-            }
-            return focused;
-        });
-    };
-    const openAiSessionConversationForQuickSwitch = (target: {
-        provider: AiSessionProviderId;
-        sessionId: string;
-    }): Promise<void> => {
-        const cardId = getCurrentWorkspaceActionTargetWithoutCardId()?.cardId;
-        return cardId
-            ? openAiSessionConversationWithFeedback({
-                projectId: cardId,
-                provider: target.provider,
-                sessionId: target.sessionId,
-            }).then(() => undefined)
-            : Promise.resolve();
-    };
     const requestRemoteAiSessionFocus = (navigationIdentity: string): Promise<boolean> =>
         openWorkspaceBridgeClient.requestRunningFocus(navigationIdentity);
     const runningSessionJumpHandler = createRunningSessionJumpHandler({
@@ -1962,6 +1930,7 @@ async function initializeDashboard(
         return { dispose: () => clearInterval(handle) };
     });
     const aiSessionQuickSwitchHandlers = createAiSessionQuickSwitchHandlers({
+        navigationCoordinator: sessionNavigationCoordinator,
         getLocalSessions: () => getCurrentWorkspaceActionTargetWithoutCardId()
             ?.sessions.activeSessions || [],
         getRemoteWindows: () => openWorkspaceDashboardController.getCards()
@@ -1984,8 +1953,8 @@ async function initializeDashboard(
             placeHolder,
             matchOnDescription: true,
         }),
-        focusSession: focusAiSessionForQuickSwitch,
-        openConversation: openAiSessionConversationForQuickSwitch,
+        navigateSession: (target, executionOptions) =>
+            sessionNavigationFocusExecutor.execute(target, executionOptions),
         requestRemoteFocus: target =>
             requestRemoteAiSessionFocus(target.navigationIdentity),
         openNavigationCard: cardId =>
@@ -2249,10 +2218,12 @@ async function initializeDashboard(
         changeGlobalSkillsLocation: () =>
             skillPanel.changeGlobalStoreLocation(),
         openCurrentAiSessionConversation: () => openCurrentAiSessionConversation(),
-        previousActiveSession: () =>
-            followAdjacentActiveConversationWithFeedback('previous'),
-        nextActiveSession: () =>
-            followAdjacentActiveConversationWithFeedback('next'),
+        previousActiveSession: () => sessionNavigationCoordinator.enqueue(
+            () => followAdjacentActiveConversationWithFeedback('previous')
+        ),
+        nextActiveSession: () => sessionNavigationCoordinator.enqueue(
+            () => followAdjacentActiveConversationWithFeedback('next')
+        ),
         nextAttentionSession: () => jumpToNextAttentionSession(),
         nextRunningSession: () =>
             runningSessionJumpHandler.jumpToNextRunningSession(),

--- a/src/dashboard/sessionQuickSwitch.ts
+++ b/src/dashboard/sessionQuickSwitch.ts
@@ -7,6 +7,14 @@ import type {
 } from '../aiSessions/types';
 import { getAiSessionKey } from '../aiSessions/sessionHelpers';
 import type { AiSessionMruTracker } from '../aiSessions/sessionMru';
+import {
+    createSessionNavigationCoordinator,
+    SessionNavigationCoordinator,
+} from './sessionNavigationCoordinator';
+import type {
+    SessionNavigationFocusExecutionOptions,
+    SessionNavigationFocusResult,
+} from './sessionNavigationFocusExecutor';
 
 export interface AiSessionSwitchRemoteWindow {
     cardId: string;
@@ -135,6 +143,7 @@ export function buildAiSessionSwitchItems(input: {
 }
 
 export interface AiSessionQuickSwitchOptions {
+    navigationCoordinator?: SessionNavigationCoordinator;
     getLocalSessions: () => readonly ActiveAiSessionViewModel[];
     getRemoteWindows: () => readonly AiSessionSwitchRemoteWindow[];
     getFocusedSessionKey: () => string | null;
@@ -143,14 +152,13 @@ export interface AiSessionQuickSwitchOptions {
         items: readonly AiSessionSwitchPickItem[],
         placeHolder: string
     ) => Promise<AiSessionSwitchPickItem | undefined>;
-    focusSession: (target: {
-        provider: AiSessionProviderId;
-        sessionId: string;
-    }) => Promise<boolean>;
-    openConversation: (target: {
-        provider: AiSessionProviderId;
-        sessionId: string;
-    }) => Promise<void>;
+    navigateSession: (
+        target: {
+            provider: AiSessionProviderId;
+            sessionId: string;
+        },
+        executionOptions: SessionNavigationFocusExecutionOptions,
+    ) => Promise<SessionNavigationFocusResult>;
     requestRemoteFocus: (target: AiSessionSwitchRemoteWindow) => Promise<boolean>;
     openNavigationCard: (cardId: string) => Promise<void>;
     showInformationMessage: (message: string) => void;
@@ -172,18 +180,39 @@ export interface AiSessionQuickSwitchHandlers {
 export function createAiSessionQuickSwitchHandlers(
     options: AiSessionQuickSwitchOptions
 ): AiSessionQuickSwitchHandlers {
+    const navigationCoordinator = options.navigationCoordinator
+        || createSessionNavigationCoordinator();
+
     async function jumpToLocal(target: {
         provider: AiSessionProviderId;
         sessionId: string;
     }): Promise<void> {
-        const focused = await options.focusSession(target);
-        if (!focused) {
+        const result = await options.navigateSession(target, {
+            onFocused: () => options.mru.record(target.provider, target.sessionId),
+        });
+        if (!result.focused) {
             options.showWarningMessage(
                 'Agent Pivot: the selected AI session is no longer active.'
             );
-            return;
         }
-        await options.openConversation(target);
+    }
+
+    async function jumpToRemote(target: AiSessionSwitchRemoteWindow): Promise<void> {
+        let handedOff = false;
+        try {
+            handedOff = await options.requestRemoteFocus(target);
+        } catch (_error) {
+            // A missing or failing handoff channel degrades to a plain window
+            // switch; navigation below still moves the user closer.
+            handedOff = false;
+        }
+        await options.openNavigationCard(target.cardId);
+        if (!handedOff) {
+            options.showInformationMessage(
+                `Agent Pivot: switched to ${target.displayName || 'the other window'};`
+                    + ' run Next Running Session there to focus a session.'
+            );
+        }
     }
 
     async function switchToAiSession(): Promise<void> {
@@ -204,27 +233,15 @@ export function createAiSessionQuickSwitchHandlers(
             return;
         }
         if (picked.target.kind === 'local') {
-            await jumpToLocal(picked.target);
+            const target = picked.target;
+            await navigationCoordinator.enqueue(() => jumpToLocal(target));
             return;
         }
-        let handedOff = false;
-        try {
-            handedOff = await options.requestRemoteFocus(picked.target);
-        } catch (_error) {
-            // A missing or failing handoff channel degrades to a plain window
-            // switch; navigation below still moves the user closer.
-            handedOff = false;
-        }
-        await options.openNavigationCard(picked.target.cardId);
-        if (!handedOff) {
-            options.showInformationMessage(
-                `Agent Pivot: switched to ${picked.target.displayName || 'the other window'};`
-                    + ' run Next Running Session there to focus a session.'
-            );
-        }
+        const target = picked.target;
+        await navigationCoordinator.enqueue(() => jumpToRemote(target));
     }
 
-    async function toggleLastAiSession(): Promise<void> {
+    async function toggleLastAiSessionTransaction(): Promise<void> {
         const liveByKey = new Map<string, ActiveAiSessionViewModel & { sessionId: string }>();
         for (const session of options.getLocalSessions()) {
             if (session && typeof session.sessionId === 'string' && session.sessionId) {
@@ -247,6 +264,10 @@ export function createAiSessionQuickSwitchHandlers(
             provider: target.provider,
             sessionId: target.sessionId,
         });
+    }
+
+    async function toggleLastAiSession(): Promise<void> {
+        await navigationCoordinator.enqueue(toggleLastAiSessionTransaction);
     }
 
     return {

--- a/tests/contract/aiSessions/sessionQuickSwitch.test.js
+++ b/tests/contract/aiSessions/sessionQuickSwitch.test.js
@@ -12,6 +12,12 @@ const {
     buildAiSessionSwitchItems,
     createAiSessionQuickSwitchHandlers,
 } = require('../../../out/dashboard/sessionQuickSwitch');
+const {
+    createRunningSessionJumpHandler,
+} = require('../../../out/dashboard/runningSessionJump');
+const {
+    createSessionNavigationCoordinator,
+} = require('../../../out/dashboard/sessionNavigationCoordinator');
 
 const WINDOW_A = 'a'.repeat(64);
 const WINDOW_B = 'b'.repeat(64);
@@ -50,6 +56,12 @@ function makeMru(keys) {
     return tracker;
 }
 
+function deferred() {
+    let resolve;
+    const promise = new Promise(done => { resolve = done; });
+    return { promise, resolve };
+}
+
 function makeOptions(overrides = {}) {
     const calls = [];
     const options = {
@@ -65,13 +77,17 @@ function makeOptions(overrides = {}) {
                     : items[overrides.pick]
             );
         },
-        focusSession: target => {
+        navigateSession: async (target, executionOptions) => {
             calls.push(['focus', target.provider, target.sessionId]);
-            return Promise.resolve(overrides.focusResult !== false);
-        },
-        openConversation: target => {
+            if (overrides.focusResult === false) {
+                return { focused: false, conversationOpened: false };
+            }
+            executionOptions.onFocused?.();
             calls.push(['open', target.provider, target.sessionId]);
-            return Promise.resolve();
+            return {
+                focused: true,
+                conversationOpened: overrides.conversationOpened !== false,
+            };
         },
         requestRemoteFocus: target => {
             calls.push(['request', target.navigationIdentity]);
@@ -110,7 +126,18 @@ test('AI-SESSION-QUICK-SWITCH-COMMANDS-001 wires the MRU to a completion-indepen
 
     const sampler = /setInterval\(\(\) => \{\s*const identity = getFocusedAiSessionIdentity\(\);[\s\S]*?aiSessionMru\.record\(/;
     assert.match(source, sampler);
-    assert.match(source, /aiSessionMru\.record\(target\.provider, target\.sessionId\)/);
+    const quickSwitchSource = fs.readFileSync(
+        path.resolve(__dirname, '../../../src/dashboard/sessionQuickSwitch.ts'),
+        'utf8'
+    );
+    assert.match(
+        quickSwitchSource,
+        /onFocused: \(\) => options\.mru\.record\(target\.provider, target\.sessionId\)/
+    );
+    assert.match(
+        source,
+        /navigateSession: \(target, executionOptions\) =>\s*sessionNavigationFocusExecutor\.execute\(target, executionOptions\)/
+    );
     assert.match(source, /getFocusedSessionKey: \(\) => \{\s*const identity = getFocusedAiSessionIdentity\(\);/);
 });
 
@@ -232,6 +259,84 @@ test('AI-SESSION-QUICK-SWITCH-COMMANDS-001 switch hands off remote windows and d
     }
 });
 
+test('AI-SESSION-QUICK-SWITCH-COMMANDS-001 AI-SESSION-NEXT-RUNNING-COMMAND-001 serializes Quick Switch behind an older navigation so the latest command wins', async () => {
+    const coordinator = createSessionNavigationCoordinator();
+    const olderStarted = deferred();
+    const releaseOlder = deferred();
+    const settled = [];
+    let terminal = 'initial';
+    let conversation = 'initial';
+    const running = createRunningSessionJumpHandler({
+        navigationCoordinator: coordinator,
+        buildQueue: () => ({
+            items: [{
+                kind: 'local',
+                key: 'session:codex:older',
+                provider: 'codex',
+                sessionId: 'older',
+                name: 'Older',
+            }],
+            localCount: 1,
+            remoteCount: 0,
+            total: 1,
+        }),
+        navigateSession: async item => {
+            olderStarted.resolve();
+            await releaseOlder.promise;
+            terminal = item.sessionId;
+            conversation = item.sessionId;
+            settled.push(item.sessionId);
+            return { focused: true, conversationOpened: true };
+        },
+        requestRemoteFocus: async () => false,
+        openNavigationCard: async () => {},
+        showInformationMessage: () => {},
+        showWarningMessage: () => {},
+    });
+    const quick = createAiSessionQuickSwitchHandlers({
+        navigationCoordinator: coordinator,
+        getLocalSessions: () => [session('codex', 'newer')],
+        getRemoteWindows: () => [],
+        getFocusedSessionKey: () => null,
+        mru: makeMru([]),
+        showPick: async items => items[0],
+        navigateSession: async (target, executionOptions) => {
+            terminal = target.sessionId;
+            executionOptions.onFocused?.();
+            conversation = target.sessionId;
+            settled.push(target.sessionId);
+            return { focused: true, conversationOpened: true };
+        },
+        // The unfixed implementation ignores the shared transaction options
+        // and calls these independent legacy callbacks immediately.
+        focusSession: async target => {
+            terminal = target.sessionId;
+            return true;
+        },
+        openConversation: async target => {
+            conversation = target.sessionId;
+            settled.push(target.sessionId);
+        },
+        requestRemoteFocus: async () => false,
+        openNavigationCard: async () => {},
+        showInformationMessage: () => {},
+        showWarningMessage: () => {},
+    });
+
+    const older = running.jumpToNextRunningSession();
+    await olderStarted.promise;
+    const newer = quick.switchToAiSession();
+    await new Promise(resolve => setImmediate(resolve));
+    releaseOlder.resolve();
+    await Promise.all([older, newer]);
+
+    assert.deepEqual(settled, ['older', 'newer']);
+    assert.deepEqual({ terminal, conversation }, {
+        terminal: 'newer',
+        conversation: 'newer',
+    });
+});
+
 test('AI-SESSION-QUICK-SWITCH-COMMANDS-001 toggle alternates the two most recent local sessions', async () => {
     const mru = makeMru(['codex:c1', 'kimi:k1']);
     const toggling = makeOptions({
@@ -249,6 +354,71 @@ test('AI-SESSION-QUICK-SWITCH-COMMANDS-001 toggle alternates the two most recent
     toggling.options.getFocusedSessionKey = () => 'codex:c1';
     await handler.toggleLastAiSession();
     assert.deepEqual(toggling.calls.slice(2), [['focus', 'kimi', 'k1'], ['open', 'kimi', 'k1']]);
+});
+
+test('AI-SESSION-QUICK-SWITCH-COMMANDS-001 AI-SESSION-NEXT-RUNNING-COMMAND-001 resolves Toggle Last after older navigation settles', async () => {
+    const coordinator = createSessionNavigationCoordinator();
+    const olderStarted = deferred();
+    const releaseOlder = deferred();
+    const settled = [];
+    let focusedKey = 'codex:newer';
+    const mru = makeMru(['codex:newer', 'codex:older']);
+    const running = createRunningSessionJumpHandler({
+        navigationCoordinator: coordinator,
+        buildQueue: () => ({
+            items: [{
+                kind: 'local',
+                key: 'session:codex:older',
+                provider: 'codex',
+                sessionId: 'older',
+                name: 'Older',
+            }],
+            localCount: 1,
+            remoteCount: 0,
+            total: 1,
+        }),
+        navigateSession: async item => {
+            olderStarted.resolve();
+            await releaseOlder.promise;
+            focusedKey = `${item.provider}:${item.sessionId}`;
+            settled.push(item.sessionId);
+            return { focused: true, conversationOpened: true };
+        },
+        requestRemoteFocus: async () => false,
+        openNavigationCard: async () => {},
+        showInformationMessage: () => {},
+        showWarningMessage: () => {},
+    });
+    const toggle = createAiSessionQuickSwitchHandlers({
+        navigationCoordinator: coordinator,
+        getLocalSessions: () => [
+            session('codex', 'older'),
+            session('codex', 'newer'),
+        ],
+        getRemoteWindows: () => [],
+        getFocusedSessionKey: () => focusedKey,
+        mru,
+        showPick: async () => undefined,
+        navigateSession: async (target, executionOptions) => {
+            focusedKey = `${target.provider}:${target.sessionId}`;
+            executionOptions.onFocused?.();
+            settled.push(target.sessionId);
+            return { focused: true, conversationOpened: true };
+        },
+        requestRemoteFocus: async () => false,
+        openNavigationCard: async () => {},
+        showInformationMessage: () => {},
+        showWarningMessage: () => {},
+    });
+
+    const older = running.jumpToNextRunningSession();
+    await olderStarted.promise;
+    const newer = toggle.toggleLastAiSession();
+    releaseOlder.resolve();
+    await Promise.all([older, newer]);
+
+    assert.deepEqual(settled, ['older', 'newer']);
+    assert.equal(focusedKey, 'codex:newer');
 });
 
 test('AI-SESSION-QUICK-SWITCH-COMMANDS-001 toggle prunes dead sessions and reports an empty history', async () => {

--- a/tests/contract/dashboardBoundaries.test.js
+++ b/tests/contract/dashboardBoundaries.test.js
@@ -594,6 +594,26 @@ test('AI-SESSION-QUICK-SWITCH-COMMANDS-001 contributes the session switch and to
     );
 });
 
+test('AI-SESSION-QUICK-SWITCH-COMMANDS-001 CONVERSATION-ACTIVE-SESSION-NAVIGATION-COMMANDS-001 routes every terminal-moving command through the shared navigation transaction', () => {
+    const source = fs.readFileSync(
+        path.resolve(__dirname, '../../src/dashboard.ts'),
+        'utf8'
+    );
+    assert.match(
+        source,
+        /createAiSessionQuickSwitchHandlers\(\{[\s\S]*?navigationCoordinator: sessionNavigationCoordinator,[\s\S]*?navigateSession: \(target, executionOptions\) =>\s*sessionNavigationFocusExecutor\.execute\(target, executionOptions\)/
+    );
+    for (const direction of ['previous', 'next']) {
+        assert.match(
+            source,
+            new RegExp(
+                `${direction}ActiveSession: \\(\\) => sessionNavigationCoordinator\\.enqueue\\(`
+                    + `[\\s\\S]*?\\(\\) => followAdjacentActiveConversationWithFeedback\\('${direction}'\\)`
+            )
+        );
+    }
+});
+
 test('CONVERSATION-ACTIVE-SESSION-NAVIGATION-COMMANDS-001 marks only an actually focused Open Current selection as terminal-authoritative', () => {
     const source = fs.readFileSync(
         path.resolve(__dirname, '../../src/dashboard.ts'),

--- a/tests/unit/tooling/architectureGuards.test.js
+++ b/tests/unit/tooling/architectureGuards.test.js
@@ -40,6 +40,7 @@ function copyGuardFixture(t, mutationPath, mutate = source => source) {
         'src/aiSessions/launchSpec.ts',
         'src/aiSessions/lifecycle.ts',
         'src/aiSessions/runtimeTypes.ts',
+        'src/dashboard/sessionQuickSwitch.ts',
         'src/constants.ts',
         'src/models.ts',
         'src/todos/types.ts',
@@ -344,7 +345,7 @@ for (const mutation of [
     {
         id: 'ARCH-AI-SESSION-NAVIGATION-OWNERSHIP-001',
         file: 'src/dashboard.ts',
-        expectedDetail: 'both session commands must use the shared navigation coordinator',
+        expectedDetail: 'every direct session command must use the shared navigation coordinator',
         mutate: source => source.replace(
             'navigationCoordinator: sessionNavigationCoordinator,',
             'navigationCoordinator: createSessionNavigationCoordinator(),',
@@ -353,11 +354,31 @@ for (const mutation of [
     {
         id: 'ARCH-AI-SESSION-NAVIGATION-OWNERSHIP-001',
         file: 'src/dashboard.ts',
-        expectedDetail: 'both session commands must use the shared local focus executor',
+        expectedDetail: 'every direct session command must use the shared local focus executor',
         mutate: source => source.replace(
             'navigateSession: (item, executionOptions) =>\n'
                 + '            sessionNavigationFocusExecutor.execute(item, executionOptions),',
             'navigateSession: async () => ({ focused: false, conversationOpened: false }),',
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-NAVIGATION-OWNERSHIP-001',
+        file: 'src/dashboard/sessionQuickSwitch.ts',
+        expectedDetail: 'Quick Switch and Toggle must own no navigation path outside the shared transaction',
+        mutate: source => source.replace(
+            'await navigationCoordinator.enqueue(() => jumpToLocal(target));',
+            'await jumpToLocal(target);',
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-NAVIGATION-OWNERSHIP-001',
+        file: 'src/dashboard.ts',
+        expectedDetail: 'Previous and Next Active Session commands must use the shared navigation coordinator',
+        mutate: source => source.replace(
+            "previousActiveSession: () => sessionNavigationCoordinator.enqueue(\n"
+                + "            () => followAdjacentActiveConversationWithFeedback('previous')\n"
+                + '        ),',
+            "previousActiveSession: () => followAdjacentActiveConversationWithFeedback('previous'),",
         ),
     },
     {

--- a/tests/unit/tooling/architectureGuards.test.js
+++ b/tests/unit/tooling/architectureGuards.test.js
@@ -373,6 +373,27 @@ for (const mutation of [
     {
         id: 'ARCH-AI-SESSION-NAVIGATION-OWNERSHIP-001',
         file: 'src/dashboard.ts',
+        expectedDetail: 'every direct session command must use the shared navigation coordinator',
+        mutate: source => source.replace(
+            'const aiSessionQuickSwitchHandlers = createAiSessionQuickSwitchHandlers({\n'
+                + '        navigationCoordinator: sessionNavigationCoordinator,',
+            'const aiSessionQuickSwitchHandlers = createAiSessionQuickSwitchHandlers({\n'
+                + '        navigationCoordinator: createSessionNavigationCoordinator(),',
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-NAVIGATION-OWNERSHIP-001',
+        file: 'src/dashboard.ts',
+        expectedDetail: 'every direct session command must use the shared local focus executor',
+        mutate: source => source.replace(
+            'navigateSession: (target, executionOptions) =>\n'
+                + '            sessionNavigationFocusExecutor.execute(target, executionOptions),',
+            'navigateSession: async () => ({ focused: false, conversationOpened: false }),',
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-NAVIGATION-OWNERSHIP-001',
+        file: 'src/dashboard.ts',
         expectedDetail: 'Previous and Next Active Session commands must use the shared navigation coordinator',
         mutate: source => source.replace(
             "previousActiveSession: () => sessionNavigationCoordinator.enqueue(\n"


### PR DESCRIPTION
## Summary

- route Switch to AI Session and Toggle Last AI Session through the shared session navigation coordinator and single-snapshot focus executor
- queue local and remote Quick Switch actions so an older slow navigation cannot overwrite a newer command
- resolve Toggle Last's MRU target only when its queued transaction starts
- join Previous and Next Active Session command invocations to the same global ordering boundary while preserving the Conversation module's newest-intent, rollback, and keyboard-focus behavior
- expand the architecture guard and controlled mutations to cover every terminal-moving AI Session command

## Regression evidence

Before the fix, a controlled journey started a slow Next Running Session navigation and then completed Switch to AI Session. When the older navigation resumed, it replaced both the terminal and Conversation selected by the newer command. The new contract test failed with settlement order `newer, older`; after the fix it passes with `older, newer`, and the final terminal and Conversation both belong to the newer command.

## Scope

Open Current AI Session Conversation remains conversation-only, and Switch to Open Window remains window-only. Running/Attention queue selection, MRU policy, focus protocols, mailbox formats, attention acknowledgement, tmux behavior, and serialized data are unchanged.

## Verification

- `npm run test-compile`
- 113 focused navigation and Conversation tests passed
- 66 architecture mutation tests passed
- `npm run test:architecture-guards`
- `npm run lint`
- `npm run test:behavior-contracts`
- `npm run test:ci:linux`
- changed-line coverage: 100.00% (50/50)
- release VSIX packaging checks passed
- `git diff --check`

## Skill harvest

No skill change was justified. The earlier work intentionally scoped itself to Running and Attention; this follow-up expanded the product scope. Existing architecture-refactor guidance already requires entry-point inventories, and regression guidance already requires cross-feature journeys for neighboring commands.
