### PR TITLE
Refactor AI session state projection

### DIFF
--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "26fb48d07086ecf8ebfe4a70d854cb7166204665",
+        "head": "911e592f02fd9fbc71c8f566d61074a3e96d263b",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -242,7 +242,8 @@
             "23e1655906f8fabb83019d5772ae8e714e67a952",
             "4aede6f792e9348697acfea174e308368f7157f7",
             "2c5f31a95dbd671b637cf5013789826ed1bedb10",
-            "a760309127206890f64a3fa5e1439e75261f067e"
+            "a760309127206890f64a3fa5e1439e75261f067e",
+            "3363eb2837186021d1342c708533e1636ad080d5"
         ]
     },
     "capabilities": [
@@ -318,7 +319,8 @@
                 "9f30fe66a1d18df6aa5940361f9197ab108f2496",
                 "aa2b38cebefde3ca2f00dece901106a2cbaeec72",
                 "52e44f13ab7b933c7ef484b112e8b9c5a4ecd6a6",
-                "26681274ff250e21172beb905a99d5fce79a92af"
+                "26681274ff250e21172beb905a99d5fce79a92af",
+                "911e592f02fd9fbc71c8f566d61074a3e96d263b"
             ],
             "behaviors": [
                 "PERSIST-AI-SESSION-PROJECT-HYDRATION-CONTROLLER-001"

--- a/media/webviewDashboardBundle.js
+++ b/media/webviewDashboardBundle.js
@@ -1675,7 +1675,7 @@ function initProjectAiSessionsUpdate(options) {
     var getPendingAiSessionProviderSelectionProjectId = options.getPendingAiSessionProviderSelectionProjectId;
     var getSelectedAiSessionProviders = options.getSelectedAiSessionProviders;
     var syncAiSessionBatchManagementDom = options.syncAiSessionBatchManagementDom;
-    var syncActiveAiSessionTerminalDom = options.syncActiveAiSessionTerminalDom;
+    var syncActiveAiSessionProjectionDom = options.syncActiveAiSessionProjectionDom;
     var reconcilePendingAiSessionProviderSelectionDom = options.reconcilePendingAiSessionProviderSelectionDom;
     var submitAiSessionProviderSelection = options.submitAiSessionProviderSelection;
     var toggleCodexSessions = options.toggleCodexSessions;
@@ -1685,6 +1685,30 @@ function initProjectAiSessionsUpdate(options) {
 
     var pendingWorkspaceSessionReveal = null;
     var latestAiSessionUpdateSequence = 0;
+    var latestAiSessionProjectionRevision = 0;
+
+    function canApplyProjectionRevision(revision) {
+        if (typeof revision === 'undefined') {
+            return latestAiSessionProjectionRevision === 0;
+        }
+        return Number.isSafeInteger(revision)
+            && revision > 0
+            && revision > latestAiSessionProjectionRevision;
+    }
+
+    function commitProjectionRevision(revision) {
+        if (Number.isSafeInteger(revision) && revision > 0) {
+            latestAiSessionProjectionRevision = revision;
+        }
+    }
+
+    function acceptProjectionRevision(revision) {
+        if (!canApplyProjectionRevision(revision)) {
+            return false;
+        }
+        commitProjectionRevision(revision);
+        return true;
+    }
 
     function applyAiSessionsUpdate(message) {
         if (message.version !== 2
@@ -1699,6 +1723,9 @@ function initProjectAiSessionsUpdate(options) {
         }
 
         if (message.sequence <= latestAiSessionUpdateSequence) {
+            return;
+        }
+        if (!canApplyProjectionRevision(message.projectionRevision)) {
             return;
         }
 
@@ -1717,6 +1744,7 @@ function initProjectAiSessionsUpdate(options) {
         }
 
         latestAiSessionUpdateSequence = message.sequence;
+        commitProjectionRevision(message.projectionRevision);
         if (batchAiSessionState.projectId) {
             var projectDiv = findCurrentWorkspaceDiv(batchAiSessionState.projectId);
             if (projectDiv) {
@@ -1727,7 +1755,7 @@ function initProjectAiSessionsUpdate(options) {
             }
         }
         reconcilePendingAiSessionProviderSelectionDom();
-        syncActiveAiSessionTerminalDom();
+        syncActiveAiSessionProjectionDom();
         updateStickyGroupHeaderOffset();
         if (window.__agentPivotDashboard) {
             window.__agentPivotDashboard.replaceSearchCatalog(message.searchCatalog);
@@ -1836,6 +1864,9 @@ function initProjectAiSessionsUpdate(options) {
 
     return {
         applyAiSessionsUpdate: applyAiSessionsUpdate,
+        acceptProjectionRevision: acceptProjectionRevision,
+        canApplyProjectionRevision: canApplyProjectionRevision,
+        commitProjectionRevision: commitProjectionRevision,
         findCurrentWorkspaceDiv: findCurrentWorkspaceDiv,
         findWorkspaceDiv: findWorkspaceDiv,
         focusSearchRevealTarget: focusSearchRevealTarget,
@@ -2812,13 +2843,24 @@ function initProjects() {
         getArchiveAiSessionMessageType: aiSessionControls.getArchiveAiSessionMessageType,
         isAiSessionProvider: aiSessionControls.isAiSessionProvider,
     });
+    function syncActiveAiSessionProjectionDom() {
+        var focusedRow = document.querySelector(
+            '.codex-session-row[data-session-focused][data-session-provider][data-session-id]'
+        );
+        var provider = focusedRow && focusedRow.getAttribute('data-session-provider');
+        aiSessionControls.activeAiSessionTerminalState.provider =
+            aiSessionControls.isAiSessionProvider(provider) ? provider : null;
+        aiSessionControls.activeAiSessionTerminalState.sessionId = focusedRow
+            ? focusedRow.getAttribute('data-session-id') : null;
+        aiSessionControls.syncActiveAiSessionTerminalDom();
+    }
     var aiSessionsUpdate = initProjectAiSessionsUpdate({
         batchAiSessionState: aiSessionControls.batchAiSessionState,
         batchAiSessionManager: aiSessionControls.batchAiSessionManager,
         getPendingAiSessionProviderSelectionProjectId: () => aiSessionControls.getPendingAiSessionProviderSelectionProjectId(),
         getSelectedAiSessionProviders: aiSessionControls.getSelectedAiSessionProviders,
         syncAiSessionBatchManagementDom: aiSessionControls.syncAiSessionBatchManagementDom,
-        syncActiveAiSessionTerminalDom: aiSessionControls.syncActiveAiSessionTerminalDom,
+        syncActiveAiSessionProjectionDom: syncActiveAiSessionProjectionDom,
         reconcilePendingAiSessionProviderSelectionDom: aiSessionControls.reconcilePendingAiSessionProviderSelectionDom,
         submitAiSessionProviderSelection: aiSessionControls.submitAiSessionProviderSelection,
         toggleCodexSessions: aiSessionControls.toggleCodexSessions,
@@ -2988,7 +3030,7 @@ function initProjects() {
                 }
             }
             aiSessionControls.reconcilePendingAiSessionProviderSelectionDom();
-            aiSessionControls.syncActiveAiSessionTerminalDom();
+            syncActiveAiSessionProjectionDom();
             updateStickyGroupHeaderOffset();
             var renderedWorkspaceState = getWorkspaceUpdateDomState(document);
             window.vscode.postMessage({
@@ -2999,11 +3041,13 @@ function initProjects() {
             return;
         }
         if (message && message.type === 'open-workspaces-updated') {
+            if (!aiSessionsUpdate.canApplyProjectionRevision(message.projectionRevision)) return;
             if (!applyOpenWorkspacesUpdate(message)) {
                 aiSessionsUpdate.requestFullRefresh('invalid-open-workspaces-update');
                 return;
             }
-            aiSessionControls.syncActiveAiSessionTerminalDom();
+            aiSessionsUpdate.commitProjectionRevision(message.projectionRevision);
+            syncActiveAiSessionProjectionDom();
             updateStickyGroupHeaderOffset();
             var renderedOpenWorkspaceState = getOpenWorkspacesUpdateDomState();
             window.vscode.postMessage({
@@ -3039,6 +3083,7 @@ function initProjects() {
         }
 
         if (message && message.type === 'active-ai-session-terminal-changed') {
+            if (!aiSessionsUpdate.acceptProjectionRevision(message.projectionRevision)) return;
             aiSessionControls.activeAiSessionTerminalState.provider = aiSessionControls.isAiSessionProvider(message.provider) ? message.provider : null;
             aiSessionControls.activeAiSessionTerminalState.sessionId = typeof message.sessionId === 'string' ? message.sessionId : null;
             aiSessionControls.syncActiveAiSessionTerminalDom();
@@ -3046,6 +3091,7 @@ function initProjects() {
         }
 
         if (message && message.type === 'ai-session-attention-state') {
+            if (!aiSessionsUpdate.acceptProjectionRevision(message.projectionRevision)) return;
             window.__agentPivotAttentionEvents = window.__agentPivotAttentionEvents || {};
             window.__agentPivotAttentionSessionEvents = {};
             (Array.isArray(message.sessionEvents) ? message.sessionEvents.slice(0, 1000) : []).forEach(session => {

--- a/media/webviewProjectAiUpdateScripts.js
+++ b/media/webviewProjectAiUpdateScripts.js
@@ -7,7 +7,7 @@ function initProjectAiSessionsUpdate(options) {
     var getPendingAiSessionProviderSelectionProjectId = options.getPendingAiSessionProviderSelectionProjectId;
     var getSelectedAiSessionProviders = options.getSelectedAiSessionProviders;
     var syncAiSessionBatchManagementDom = options.syncAiSessionBatchManagementDom;
-    var syncActiveAiSessionTerminalDom = options.syncActiveAiSessionTerminalDom;
+    var syncActiveAiSessionProjectionDom = options.syncActiveAiSessionProjectionDom;
     var reconcilePendingAiSessionProviderSelectionDom = options.reconcilePendingAiSessionProviderSelectionDom;
     var submitAiSessionProviderSelection = options.submitAiSessionProviderSelection;
     var toggleCodexSessions = options.toggleCodexSessions;
@@ -17,6 +17,30 @@ function initProjectAiSessionsUpdate(options) {
 
     var pendingWorkspaceSessionReveal = null;
     var latestAiSessionUpdateSequence = 0;
+    var latestAiSessionProjectionRevision = 0;
+
+    function canApplyProjectionRevision(revision) {
+        if (typeof revision === 'undefined') {
+            return latestAiSessionProjectionRevision === 0;
+        }
+        return Number.isSafeInteger(revision)
+            && revision > 0
+            && revision > latestAiSessionProjectionRevision;
+    }
+
+    function commitProjectionRevision(revision) {
+        if (Number.isSafeInteger(revision) && revision > 0) {
+            latestAiSessionProjectionRevision = revision;
+        }
+    }
+
+    function acceptProjectionRevision(revision) {
+        if (!canApplyProjectionRevision(revision)) {
+            return false;
+        }
+        commitProjectionRevision(revision);
+        return true;
+    }
 
     function applyAiSessionsUpdate(message) {
         if (message.version !== 2
@@ -31,6 +55,9 @@ function initProjectAiSessionsUpdate(options) {
         }
 
         if (message.sequence <= latestAiSessionUpdateSequence) {
+            return;
+        }
+        if (!canApplyProjectionRevision(message.projectionRevision)) {
             return;
         }
 
@@ -49,6 +76,7 @@ function initProjectAiSessionsUpdate(options) {
         }
 
         latestAiSessionUpdateSequence = message.sequence;
+        commitProjectionRevision(message.projectionRevision);
         if (batchAiSessionState.projectId) {
             var projectDiv = findCurrentWorkspaceDiv(batchAiSessionState.projectId);
             if (projectDiv) {
@@ -59,7 +87,7 @@ function initProjectAiSessionsUpdate(options) {
             }
         }
         reconcilePendingAiSessionProviderSelectionDom();
-        syncActiveAiSessionTerminalDom();
+        syncActiveAiSessionProjectionDom();
         updateStickyGroupHeaderOffset();
         if (window.__agentPivotDashboard) {
             window.__agentPivotDashboard.replaceSearchCatalog(message.searchCatalog);
@@ -168,6 +196,9 @@ function initProjectAiSessionsUpdate(options) {
 
     return {
         applyAiSessionsUpdate: applyAiSessionsUpdate,
+        acceptProjectionRevision: acceptProjectionRevision,
+        canApplyProjectionRevision: canApplyProjectionRevision,
+        commitProjectionRevision: commitProjectionRevision,
         findCurrentWorkspaceDiv: findCurrentWorkspaceDiv,
         findWorkspaceDiv: findWorkspaceDiv,
         focusSearchRevealTarget: focusSearchRevealTarget,

--- a/media/webviewProjectScripts.js
+++ b/media/webviewProjectScripts.js
@@ -258,13 +258,24 @@ function initProjects() {
         getArchiveAiSessionMessageType: aiSessionControls.getArchiveAiSessionMessageType,
         isAiSessionProvider: aiSessionControls.isAiSessionProvider,
     });
+    function syncActiveAiSessionProjectionDom() {
+        var focusedRow = document.querySelector(
+            '.codex-session-row[data-session-focused][data-session-provider][data-session-id]'
+        );
+        var provider = focusedRow && focusedRow.getAttribute('data-session-provider');
+        aiSessionControls.activeAiSessionTerminalState.provider =
+            aiSessionControls.isAiSessionProvider(provider) ? provider : null;
+        aiSessionControls.activeAiSessionTerminalState.sessionId = focusedRow
+            ? focusedRow.getAttribute('data-session-id') : null;
+        aiSessionControls.syncActiveAiSessionTerminalDom();
+    }
     var aiSessionsUpdate = initProjectAiSessionsUpdate({
         batchAiSessionState: aiSessionControls.batchAiSessionState,
         batchAiSessionManager: aiSessionControls.batchAiSessionManager,
         getPendingAiSessionProviderSelectionProjectId: () => aiSessionControls.getPendingAiSessionProviderSelectionProjectId(),
         getSelectedAiSessionProviders: aiSessionControls.getSelectedAiSessionProviders,
         syncAiSessionBatchManagementDom: aiSessionControls.syncAiSessionBatchManagementDom,
-        syncActiveAiSessionTerminalDom: aiSessionControls.syncActiveAiSessionTerminalDom,
+        syncActiveAiSessionProjectionDom: syncActiveAiSessionProjectionDom,
         reconcilePendingAiSessionProviderSelectionDom: aiSessionControls.reconcilePendingAiSessionProviderSelectionDom,
         submitAiSessionProviderSelection: aiSessionControls.submitAiSessionProviderSelection,
         toggleCodexSessions: aiSessionControls.toggleCodexSessions,
@@ -434,7 +445,7 @@ function initProjects() {
                 }
             }
             aiSessionControls.reconcilePendingAiSessionProviderSelectionDom();
-            aiSessionControls.syncActiveAiSessionTerminalDom();
+            syncActiveAiSessionProjectionDom();
             updateStickyGroupHeaderOffset();
             var renderedWorkspaceState = getWorkspaceUpdateDomState(document);
             window.vscode.postMessage({
@@ -445,11 +456,13 @@ function initProjects() {
             return;
         }
         if (message && message.type === 'open-workspaces-updated') {
+            if (!aiSessionsUpdate.canApplyProjectionRevision(message.projectionRevision)) return;
             if (!applyOpenWorkspacesUpdate(message)) {
                 aiSessionsUpdate.requestFullRefresh('invalid-open-workspaces-update');
                 return;
             }
-            aiSessionControls.syncActiveAiSessionTerminalDom();
+            aiSessionsUpdate.commitProjectionRevision(message.projectionRevision);
+            syncActiveAiSessionProjectionDom();
             updateStickyGroupHeaderOffset();
             var renderedOpenWorkspaceState = getOpenWorkspacesUpdateDomState();
             window.vscode.postMessage({
@@ -485,6 +498,7 @@ function initProjects() {
         }
 
         if (message && message.type === 'active-ai-session-terminal-changed') {
+            if (!aiSessionsUpdate.acceptProjectionRevision(message.projectionRevision)) return;
             aiSessionControls.activeAiSessionTerminalState.provider = aiSessionControls.isAiSessionProvider(message.provider) ? message.provider : null;
             aiSessionControls.activeAiSessionTerminalState.sessionId = typeof message.sessionId === 'string' ? message.sessionId : null;
             aiSessionControls.syncActiveAiSessionTerminalDom();
@@ -492,6 +506,7 @@ function initProjects() {
         }
 
         if (message && message.type === 'ai-session-attention-state') {
+            if (!aiSessionsUpdate.acceptProjectionRevision(message.projectionRevision)) return;
             window.__agentPivotAttentionEvents = window.__agentPivotAttentionEvents || {};
             window.__agentPivotAttentionSessionEvents = {};
             (Array.isArray(message.sessionEvents) ? message.sessionEvents.slice(0, 1000) : []).forEach(session => {

--- a/scripts/run-ai-session-safety-checks.js
+++ b/scripts/run-ai-session-safety-checks.js
@@ -43,8 +43,10 @@ const providers = require('../out/aiSessions/providers');
 const workspaceSessionScope = require('../out/workspaces/sessionScope');
 const workspaceSessionAssignment = require('../out/workspaces/sessionAssignment');
 const workspaceSessionHydration = require('../out/workspaces/sessionHydration');
-const WorkspaceSessionHydrationController = require('../out/workspaces/sessionHydrationController')
-    .WorkspaceSessionHydrationController;
+const {
+    AiSessionProjectionCoordinator,
+    WorkspaceSessionHydrationController,
+} = require('../out/workspaces/sessionHydrationController');
 const WorkspacePendingSessionPromotionController = require('../out/workspaces/pendingSessionPromotionController')
     .WorkspacePendingSessionPromotionController;
 const workspacePrimaryRootStore = require('../out/workspaces/primaryRootStore');
@@ -629,6 +631,15 @@ function runWorkspaceSessionHydrationChecks() {
         }],
     };
     const readNotifications = [];
+    const projectionCoordinator = new AiSessionProjectionCoordinator({
+        getActiveRuntimes: () => activeRuntimes,
+        getPendingRuntimes: () => pendingRuntimes,
+        getExecutionSnapshot: () => ({}),
+        getFocusedIdentity: () => outsideNavigationRuntime.identity,
+        getAttentionAggregate: () => workspaceAttention,
+    });
+    assert.strictEqual(projectionCoordinator.capture().revision, 0);
+    assert.strictEqual(projectionCoordinator.captureNext().revision, 1);
     const controller = new WorkspaceSessionHydrationController({
         providers: providersForHydration,
         readCoordinator,
@@ -639,11 +650,7 @@ function runWorkspaceSessionHydrationChecks() {
         getAliases: () => ({}),
         getProviderSelection: () => ({ primaryProvider: 'codex', selectedProviders: ['codex'] }),
         getExpanded: () => true,
-        getActiveRuntimes: () => activeRuntimes,
-        getPendingRuntimes: () => pendingRuntimes,
-        getExecutionSnapshot: () => ({}),
-        getFocusedIdentity: () => outsideNavigationRuntime.identity,
-        getAttentionAggregate: () => workspaceAttention,
+        getProjectionSnapshot: () => projectionCoordinator.capture(),
         onDidReadSessions: (notifiedWorkspace, sessionResults, reason) => {
             readNotifications.push({ notifiedWorkspace, sessionResults, reason });
         },
@@ -6597,7 +6604,11 @@ function runBatchAiSessionWebviewChecks() {
                 setAttribute: () => {},
                 remove: () => {},
             }),
-            querySelector: () => null,
+            querySelector: selector => selector
+                === '.codex-session-row[data-session-focused][data-session-provider][data-session-id]'
+                ? projects.flatMap(project => project.rows)
+                    .find(row => row.hasAttribute('data-session-focused')) || null
+                : null,
             querySelectorAll: selector => {
                 if (selector === '.workspace-card[data-current-workspace][data-id]') {
                     return projects;
@@ -7040,6 +7051,13 @@ function runBatchAiSessionWebviewChecks() {
         provider: 'codex',
         sessionId: 'active-session',
     } });
+    windowEventListeners.message({ data: {
+        type: 'active-ai-session-terminal-changed',
+        provider: null,
+        sessionId: null,
+    } });
+    assert.strictEqual(activeRow.hasAttribute('data-ai-session-active-terminal'), false);
+    activeRow.setAttribute('data-session-focused', '');
     context.applyWorkspaceUpdate = message => message.type === 'workspace-updated'
         && message.version === 2
         && message.currentWorkspaceCount === 1
@@ -7048,6 +7066,7 @@ function runBatchAiSessionWebviewChecks() {
         type: 'ai-sessions-updated',
         version: 2,
         sequence: 1,
+        projectionRevision: 2,
         currentWorkspaceCount: 1,
         html: '<div class="open-current-workspace-group"></div>',
         searchCatalog: { version: 2, sessions: [], openWorkspaces: [], savedProjects: [], todos: TODO_SEARCH_ITEMS },
@@ -7058,6 +7077,27 @@ function runBatchAiSessionWebviewChecks() {
         'AI incremental rendering must preserve the non-empty TODO catalog replacement'
     );
     assert.strictEqual(activeRow.hasAttribute('data-ai-session-active-terminal'), true);
+    windowEventListeners.message({ data: {
+        type: 'active-ai-session-terminal-changed',
+        projectionRevision: 1,
+        provider: null,
+        sessionId: null,
+    } });
+    assert.strictEqual(
+        activeRow.hasAttribute('data-ai-session-active-terminal'),
+        true,
+        'ACTIVE-SESSION-FOCUS-REVEAL-001 a stale focus message must not override a newer rendered session projection'
+    );
+    windowEventListeners.message({ data: {
+        type: 'ai-session-attention-state',
+        projectionRevision: 1,
+        eventIds: ['stale-event'],
+        sessionEvents: [],
+    } });
+    assert.strictEqual(context.window.__agentPivotAttentionEvents['stale-event'], undefined,
+        'a stale attention message must not override a newer rendered session projection');
+    assert.strictEqual(context.window.__agentPivotAttentionEvents['existing-event'], true,
+        'rejecting stale attention must preserve the last accepted attention projection');
 
     const manager = context.window.__agentPivotBatchAiSessions;
     manager.enter('project-a');
@@ -7324,6 +7364,19 @@ function runAiSessionIncrementalRefreshSourceChecks() {
     assert.strictEqual((dashboard.match(/\.service\.getSessions\(/g) || []).length, 0);
 
     assert.ok(workspaceHydrationSource.includes('export class WorkspaceSessionHydrationController'));
+    assert.ok(workspaceHydrationSource.includes('export class AiSessionProjectionCoordinator'));
+    assert.ok(workspaceHydrationSource.includes('const projection = this.options.getProjectionSnapshot()'));
+    assert.strictEqual(dashboard.includes('getActiveRuntimes: () => aiSessionRuntimeCoordinator.getActive(),'), true);
+    assert.strictEqual(dashboard.includes('getProjectionSnapshot: () => aiSessionProjectionCoordinator.capture(),'), true);
+    assert.ok(dashboard.includes('projectionRevision: aiSessionProjectionCoordinator.nextRevision(),'));
+    assert.ok(projectWebviewSource.includes(
+        'aiSessionsUpdate.canApplyProjectionRevision(message.projectionRevision)'
+    ));
+    assert.strictEqual(
+        extractMethodBody(workspaceHydrationSource, 'hydrate').includes('this.options.getActiveRuntimes()'),
+        false,
+        'hydration must consume one projection snapshot instead of independently sampling runtime state',
+    );
     assert.ok(workspaceHydrationSource.includes('getWorkspaceAiSessionCandidatePaths(workspace)'));
     assert.ok(workspaceHydrationSource.includes('this.options.readCoordinator.getResults({ candidatePaths, reason, maxFiles })'));
     assert.ok(workspaceHydrationSource.includes('hydrateWorkspaceAiSessions({'));

--- a/scripts/run-workspace-parity-checks.js
+++ b/scripts/run-workspace-parity-checks.js
@@ -20,6 +20,7 @@ const {
     WorkspacePendingSessionPromotionController,
 } = require('../out/workspaces/pendingSessionPromotionController');
 const {
+    AiSessionProjectionCoordinator,
     WorkspaceSessionHydrationController,
 } = require('../out/workspaces/sessionHydrationController');
 Module._load = originalModuleLoad;
@@ -214,6 +215,13 @@ async function runShapeLifecycle(shape, index) {
         evaluateExecution: () => { evaluationCount++; },
         scheduleRefresh: reason => refreshReasons.push(reason),
     });
+    const projectionCoordinator = new AiSessionProjectionCoordinator({
+        getActiveRuntimes: () => active,
+        getPendingRuntimes: () => pending,
+        getExecutionSnapshot: () => execution,
+        getFocusedIdentity: () => null,
+        getAttentionAggregate: () => attention,
+    });
     const hydration = new WorkspaceSessionHydrationController({
         providers,
         readCoordinator: { getResults: () => results },
@@ -228,11 +236,7 @@ async function runShapeLifecycle(shape, index) {
             selectedProviders: ['codex'],
         }),
         getExpanded: () => true,
-        getActiveRuntimes: () => active,
-        getPendingRuntimes: () => pending,
-        getExecutionSnapshot: () => execution,
-        getFocusedIdentity: () => null,
-        getAttentionAggregate: () => attention,
+        getProjectionSnapshot: () => projectionCoordinator.capture(),
     });
 
     const starting = hydration.hydrate(workspace);

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -94,7 +94,6 @@ import {
 import {
     buildRunningSessionQueue,
 } from './aiSessions/runningQueue';
-import type { ActiveAiSessionTerminalIdentity } from './aiSessions/activeTerminalHighlight';
 import { getAiSessionKey } from './aiSessions/sessionHelpers';
 import { createAiSessionProviderRegistry } from './aiSessions/providers';
 import { ProviderDirectoryCapabilityProbe } from './aiSessions/providerDirectoryCapability';
@@ -208,7 +207,10 @@ import { WorkspacePrimaryRootStore } from './workspaces/primaryRootStore';
 import { PendingWorkspaceSaveStore } from './workspaces/pendingWorkspaceSaveStore';
 import { SavedWorkspaceProjectAdapter } from './workspaces/savedWorkspaceProjectAdapter';
 import { WorkspacePendingSessionPromotionController } from './workspaces/pendingSessionPromotionController';
-import { WorkspaceSessionHydrationController } from './workspaces/sessionHydrationController';
+import {
+    AiSessionProjectionCoordinator,
+    WorkspaceSessionHydrationController,
+} from './workspaces/sessionHydrationController';
 import type { OpenWorkspace } from './workspaces/types';
 import { buildWorkspaceDashboardSearchCatalog } from './webview/dashboardViewModel';
 
@@ -994,6 +996,7 @@ async function initializeDashboard(
         getAttachTerminalName: getAiSessionTmuxAttachTerminalName,
     });
     let publishRestoredTmuxAttachTerminal = (): void => undefined;
+    let aiSessionProjectionCoordinator: AiSessionProjectionCoordinator<vscode.Terminal>;
     const aiSessionAttentionEvent = ownResource(() => createAiSessionAttentionEventCapability({
         tmuxRuntimeDiscovery,
         tmuxRuntimeBackend,
@@ -1002,7 +1005,16 @@ async function initializeDashboard(
         getRuntimeConfiguration: () => aiSessionRuntimeConfiguration,
         getCurrentOpenWorkspace: () => getCurrentOpenWorkspace(),
         getActiveTerminal: () => vscode.window.activeTerminal || null,
-        postMessage: message => { void provider.postMessage(message); },
+        postMessage: message => {
+            const versionedMessage = message && typeof message === 'object'
+                && (message as { type?: unknown }).type === 'ai-session-attention-state'
+                ? {
+                    ...message,
+                    projectionRevision: aiSessionProjectionCoordinator.nextRevision(),
+                }
+                : message;
+            void provider.postMessage(versionedMessage);
+        },
         isVisible: () => provider.visible,
         assertActive: () => resources.assertActive(),
         createBridgeClient: (onAggregate, onError) => new AttentionBridgeClient(onAggregate, onError),
@@ -1172,11 +1184,7 @@ async function initializeDashboard(
                 : undefined;
         },
         getExpanded: scopeIdentity => aiSessionWorkspaceStateStore.getExpandedWorkspaces().has(scopeIdentity),
-        getActiveRuntimes: () => aiSessionRuntimeCoordinator.getActive(),
-        getPendingRuntimes: () => aiSessionRuntimeCoordinator.getPending(),
-        getExecutionSnapshot: () => aiSessionExecutionController.getSnapshot(),
-        getFocusedIdentity: () => getFocusedAiSessionRuntimeIdentity(),
-        getAttentionAggregate: () => aiSessionAttentionController.getEffectiveAggregate(),
+        getProjectionSnapshot: () => aiSessionProjectionCoordinator.capture(),
         onDidReadSessions: (workspace, sessionResults, reason) => {
             void workspacePendingSessionPromotionController.promote(
                 workspace,
@@ -1240,7 +1248,6 @@ async function initializeDashboard(
         focusTerminalView: () => vscode.commands.executeCommand('workbench.action.terminal.focus'),
         nowMs: () => Date.now(),
     });
-    let aiSessionUpdateSequence = 0;
     let currentAiSessionRefreshReason = 'refresh';
     const notifyConfiguration = ownResource(() => createNotifyConfiguration({
         context,
@@ -1338,6 +1345,13 @@ async function initializeDashboard(
         },
         nowMs: () => Date.now(),
     });
+    aiSessionProjectionCoordinator = new AiSessionProjectionCoordinator<vscode.Terminal>({
+        getActiveRuntimes: () => aiSessionRuntimeCoordinator.getActive(),
+        getPendingRuntimes: () => aiSessionRuntimeCoordinator.getPending(),
+        getExecutionSnapshot: () => aiSessionExecutionController.getSnapshot(),
+        getFocusedIdentity: () => getFocusedAiSessionRuntimeIdentity(),
+        getAttentionAggregate: () => aiSessionAttentionController.getEffectiveAggregate(),
+    });
     const aiSessionStatus = ownResource(() => createAiSessionStatusCapability({
         getProviders: getRegisteredAiSessionProviders,
         getLifecycleRequests: () => [
@@ -1402,8 +1416,11 @@ async function initializeDashboard(
         getCards: getOpenWorkspaceCards,
         getRunningCardAnimation: () => getEffectiveRunningCardAnimation(getAgentPivotConfiguration()),
         getRunningIconAnimation: () => getEffectiveRunningIconAnimation(getAgentPivotConfiguration()),
-        nextSequence: () => ++aiSessionUpdateSequence,
-        postMessage: message => provider.postMessage(message),
+        nextSequence: () => aiSessionProjectionCoordinator.nextRevision(),
+        postMessage: message => provider.postMessage({
+            ...(message as unknown as Record<string, unknown>),
+            projectionRevision: (message as AiSessionsUpdatedMessage).sequence,
+        }),
         refresh: refreshStewardViews,
         logError,
         logDiagnostic: logAiSessionDiagnostic,
@@ -1726,7 +1743,10 @@ async function initializeDashboard(
         getRunningIconAnimation: () => getEffectiveRunningIconAnimation(getAgentPivotConfiguration()),
         getAttentionAggregate: () => aiSessionAttentionController.getEffectiveAggregate(),
         getBridgeInstanceId: () => openWorkspaceBridgeClient.instanceId,
-        postMessage: message => provider.postMessage(message),
+        postMessage: message => provider.postMessage({
+            ...(message as Record<string, unknown>),
+            projectionRevision: aiSessionProjectionCoordinator.nextRevision(),
+        }),
         refresh: refreshStewardViews,
         isVisible: () => provider.visible,
         logDiagnostic: logOpenWorkspaceDiagnostic,
@@ -2037,7 +2057,7 @@ async function initializeDashboard(
             providerId => getAiSessionTerminalCandidates(providerId, aiSessionReadCoordinator)
         ),
         isComplete: resolution => aiSessionTerminalService.isComplete(resolution.entry),
-        publish: identity => postActiveAiSessionTerminalChanged(identity),
+        publish: () => postActiveAiSessionTerminalChanged(),
         onComplete: resolution => {
             if (!resolution.entry.runtimeIdentity) {
                 return;
@@ -2539,9 +2559,20 @@ async function initializeDashboard(
         dashboardRuntimeController.postBatchArchiveCompletion(message);
     }
 
-    function postActiveAiSessionTerminalChanged(identity: ActiveAiSessionTerminalIdentity | null) {
+    function postActiveAiSessionTerminalChanged() {
         void conversationCapability.reconcile();
-        dashboardRuntimeController.postActiveAiSessionTerminalChanged(identity);
+        const projection = aiSessionProjectionCoordinator.captureNext();
+        const focusedIdentity = projection.focusedIdentity;
+        dashboardRuntimeController.postActiveAiSessionTerminalChanged(
+            focusedIdentity?.sessionId
+                ? {
+                    provider: focusedIdentity.provider,
+                    sessionId: focusedIdentity.sessionId,
+                    workspaceScopeIdentity: focusedIdentity.workspaceScopeIdentity,
+                }
+                : null,
+            projection.revision,
+        );
     }
 
     function invalidateAiSessionCache(providerId: AiSessionProviderId) {

--- a/src/dashboard/runtimeController.ts
+++ b/src/dashboard/runtimeController.ts
@@ -115,9 +115,13 @@ export class DashboardRuntimeController<TProject extends Project = Project> {
         });
     }
 
-    postActiveAiSessionTerminalChanged(identity: ActiveAiSessionTerminalIdentity | null): void {
-        const message: AiSessionActiveTerminalChangedMessage = {
+    postActiveAiSessionTerminalChanged(
+        identity: ActiveAiSessionTerminalIdentity | null,
+        projectionRevision?: number,
+    ): void {
+        const message: AiSessionActiveTerminalChangedMessage & { projectionRevision?: number } = {
             type: 'active-ai-session-terminal-changed',
+            ...(Number.isSafeInteger(projectionRevision) ? { projectionRevision } : {}),
             provider: identity?.provider as AiSessionProviderId || null,
             sessionId: identity?.sessionId || null,
         };

--- a/src/webview/webviewProjectAiUpdateScripts.js
+++ b/src/webview/webviewProjectAiUpdateScripts.js
@@ -7,7 +7,7 @@ function initProjectAiSessionsUpdate(options) {
     var getPendingAiSessionProviderSelectionProjectId = options.getPendingAiSessionProviderSelectionProjectId;
     var getSelectedAiSessionProviders = options.getSelectedAiSessionProviders;
     var syncAiSessionBatchManagementDom = options.syncAiSessionBatchManagementDom;
-    var syncActiveAiSessionTerminalDom = options.syncActiveAiSessionTerminalDom;
+    var syncActiveAiSessionProjectionDom = options.syncActiveAiSessionProjectionDom;
     var reconcilePendingAiSessionProviderSelectionDom = options.reconcilePendingAiSessionProviderSelectionDom;
     var submitAiSessionProviderSelection = options.submitAiSessionProviderSelection;
     var toggleCodexSessions = options.toggleCodexSessions;
@@ -17,6 +17,30 @@ function initProjectAiSessionsUpdate(options) {
 
     var pendingWorkspaceSessionReveal = null;
     var latestAiSessionUpdateSequence = 0;
+    var latestAiSessionProjectionRevision = 0;
+
+    function canApplyProjectionRevision(revision) {
+        if (typeof revision === 'undefined') {
+            return latestAiSessionProjectionRevision === 0;
+        }
+        return Number.isSafeInteger(revision)
+            && revision > 0
+            && revision > latestAiSessionProjectionRevision;
+    }
+
+    function commitProjectionRevision(revision) {
+        if (Number.isSafeInteger(revision) && revision > 0) {
+            latestAiSessionProjectionRevision = revision;
+        }
+    }
+
+    function acceptProjectionRevision(revision) {
+        if (!canApplyProjectionRevision(revision)) {
+            return false;
+        }
+        commitProjectionRevision(revision);
+        return true;
+    }
 
     function applyAiSessionsUpdate(message) {
         if (message.version !== 2
@@ -31,6 +55,9 @@ function initProjectAiSessionsUpdate(options) {
         }
 
         if (message.sequence <= latestAiSessionUpdateSequence) {
+            return;
+        }
+        if (!canApplyProjectionRevision(message.projectionRevision)) {
             return;
         }
 
@@ -49,6 +76,7 @@ function initProjectAiSessionsUpdate(options) {
         }
 
         latestAiSessionUpdateSequence = message.sequence;
+        commitProjectionRevision(message.projectionRevision);
         if (batchAiSessionState.projectId) {
             var projectDiv = findCurrentWorkspaceDiv(batchAiSessionState.projectId);
             if (projectDiv) {
@@ -59,7 +87,7 @@ function initProjectAiSessionsUpdate(options) {
             }
         }
         reconcilePendingAiSessionProviderSelectionDom();
-        syncActiveAiSessionTerminalDom();
+        syncActiveAiSessionProjectionDom();
         updateStickyGroupHeaderOffset();
         if (window.__agentPivotDashboard) {
             window.__agentPivotDashboard.replaceSearchCatalog(message.searchCatalog);
@@ -168,6 +196,9 @@ function initProjectAiSessionsUpdate(options) {
 
     return {
         applyAiSessionsUpdate: applyAiSessionsUpdate,
+        acceptProjectionRevision: acceptProjectionRevision,
+        canApplyProjectionRevision: canApplyProjectionRevision,
+        commitProjectionRevision: commitProjectionRevision,
         findCurrentWorkspaceDiv: findCurrentWorkspaceDiv,
         findWorkspaceDiv: findWorkspaceDiv,
         focusSearchRevealTarget: focusSearchRevealTarget,

--- a/src/webview/webviewProjectScripts.js
+++ b/src/webview/webviewProjectScripts.js
@@ -258,13 +258,24 @@ function initProjects() {
         getArchiveAiSessionMessageType: aiSessionControls.getArchiveAiSessionMessageType,
         isAiSessionProvider: aiSessionControls.isAiSessionProvider,
     });
+    function syncActiveAiSessionProjectionDom() {
+        var focusedRow = document.querySelector(
+            '.codex-session-row[data-session-focused][data-session-provider][data-session-id]'
+        );
+        var provider = focusedRow && focusedRow.getAttribute('data-session-provider');
+        aiSessionControls.activeAiSessionTerminalState.provider =
+            aiSessionControls.isAiSessionProvider(provider) ? provider : null;
+        aiSessionControls.activeAiSessionTerminalState.sessionId = focusedRow
+            ? focusedRow.getAttribute('data-session-id') : null;
+        aiSessionControls.syncActiveAiSessionTerminalDom();
+    }
     var aiSessionsUpdate = initProjectAiSessionsUpdate({
         batchAiSessionState: aiSessionControls.batchAiSessionState,
         batchAiSessionManager: aiSessionControls.batchAiSessionManager,
         getPendingAiSessionProviderSelectionProjectId: () => aiSessionControls.getPendingAiSessionProviderSelectionProjectId(),
         getSelectedAiSessionProviders: aiSessionControls.getSelectedAiSessionProviders,
         syncAiSessionBatchManagementDom: aiSessionControls.syncAiSessionBatchManagementDom,
-        syncActiveAiSessionTerminalDom: aiSessionControls.syncActiveAiSessionTerminalDom,
+        syncActiveAiSessionProjectionDom: syncActiveAiSessionProjectionDom,
         reconcilePendingAiSessionProviderSelectionDom: aiSessionControls.reconcilePendingAiSessionProviderSelectionDom,
         submitAiSessionProviderSelection: aiSessionControls.submitAiSessionProviderSelection,
         toggleCodexSessions: aiSessionControls.toggleCodexSessions,
@@ -434,7 +445,7 @@ function initProjects() {
                 }
             }
             aiSessionControls.reconcilePendingAiSessionProviderSelectionDom();
-            aiSessionControls.syncActiveAiSessionTerminalDom();
+            syncActiveAiSessionProjectionDom();
             updateStickyGroupHeaderOffset();
             var renderedWorkspaceState = getWorkspaceUpdateDomState(document);
             window.vscode.postMessage({
@@ -445,11 +456,13 @@ function initProjects() {
             return;
         }
         if (message && message.type === 'open-workspaces-updated') {
+            if (!aiSessionsUpdate.canApplyProjectionRevision(message.projectionRevision)) return;
             if (!applyOpenWorkspacesUpdate(message)) {
                 aiSessionsUpdate.requestFullRefresh('invalid-open-workspaces-update');
                 return;
             }
-            aiSessionControls.syncActiveAiSessionTerminalDom();
+            aiSessionsUpdate.commitProjectionRevision(message.projectionRevision);
+            syncActiveAiSessionProjectionDom();
             updateStickyGroupHeaderOffset();
             var renderedOpenWorkspaceState = getOpenWorkspacesUpdateDomState();
             window.vscode.postMessage({
@@ -485,6 +498,7 @@ function initProjects() {
         }
 
         if (message && message.type === 'active-ai-session-terminal-changed') {
+            if (!aiSessionsUpdate.acceptProjectionRevision(message.projectionRevision)) return;
             aiSessionControls.activeAiSessionTerminalState.provider = aiSessionControls.isAiSessionProvider(message.provider) ? message.provider : null;
             aiSessionControls.activeAiSessionTerminalState.sessionId = typeof message.sessionId === 'string' ? message.sessionId : null;
             aiSessionControls.syncActiveAiSessionTerminalDom();
@@ -492,6 +506,7 @@ function initProjects() {
         }
 
         if (message && message.type === 'ai-session-attention-state') {
+            if (!aiSessionsUpdate.acceptProjectionRevision(message.projectionRevision)) return;
             window.__agentPivotAttentionEvents = window.__agentPivotAttentionEvents || {};
             window.__agentPivotAttentionSessionEvents = {};
             (Array.isArray(message.sessionEvents) ? message.sessionEvents.slice(0, 1000) : []).forEach(session => {

--- a/src/workspaces/sessionHydrationController.ts
+++ b/src/workspaces/sessionHydrationController.ts
@@ -29,6 +29,58 @@ export interface WorkspaceSessionHydrationReadCoordinator {
     }): Record<AiSessionProviderId, AiSessionReadResult>;
 }
 
+export interface AiSessionProjectionSnapshot<TTerminal = unknown> {
+    revision: number;
+    activeRuntimes: readonly AiSessionRuntimeSnapshot<TTerminal>[];
+    pendingRuntimes: readonly AiSessionPendingRuntimeSnapshot<TTerminal>[];
+    executionSnapshot: Readonly<Record<string, AiSessionExecutionSnapshot>>;
+    focusedIdentity: AiSessionRuntimeIdentity | ActiveAiSessionTerminalIdentity | null;
+    attentionAggregate: AttentionAggregate | null;
+}
+
+export interface AiSessionProjectionCoordinatorOptions<TTerminal = unknown> {
+    getActiveRuntimes: () => readonly AiSessionRuntimeSnapshot<TTerminal>[];
+    getPendingRuntimes: () => readonly AiSessionPendingRuntimeSnapshot<TTerminal>[];
+    getExecutionSnapshot: () => Readonly<Record<string, AiSessionExecutionSnapshot>>;
+    getFocusedIdentity: () => AiSessionRuntimeIdentity | ActiveAiSessionTerminalIdentity | null;
+    getAttentionAggregate: () => AttentionAggregate | null;
+}
+
+/**
+ * Owns the coherent, monotonically-versioned state projected into every
+ * current-workspace AI Session surface.
+ */
+export class AiSessionProjectionCoordinator<TTerminal = unknown> {
+    private revision = 0;
+
+    constructor(private readonly options: AiSessionProjectionCoordinatorOptions<TTerminal>) {
+    }
+
+    nextRevision(): number {
+        if (this.revision >= Number.MAX_SAFE_INTEGER) {
+            throw new Error('AI Session projection revision exhausted.');
+        }
+        this.revision += 1;
+        return this.revision;
+    }
+
+    capture(): AiSessionProjectionSnapshot<TTerminal> {
+        return {
+            revision: this.revision,
+            activeRuntimes: this.options.getActiveRuntimes(),
+            pendingRuntimes: this.options.getPendingRuntimes(),
+            executionSnapshot: this.options.getExecutionSnapshot(),
+            focusedIdentity: this.options.getFocusedIdentity(),
+            attentionAggregate: this.options.getAttentionAggregate(),
+        };
+    }
+
+    captureNext(): AiSessionProjectionSnapshot<TTerminal> {
+        this.nextRevision();
+        return this.capture();
+    }
+}
+
 export interface WorkspaceSessionHydrationControllerOptions<TTerminal = unknown> {
     providers: readonly HydrationProvider[];
     readCoordinator: WorkspaceSessionHydrationReadCoordinator;
@@ -41,11 +93,7 @@ export interface WorkspaceSessionHydrationControllerOptions<TTerminal = unknown>
         workspaceScopeIdentity: string
     ) => AiSessionProviderSelection | undefined;
     getExpanded: (workspaceScopeIdentity: string) => boolean;
-    getActiveRuntimes: () => readonly AiSessionRuntimeSnapshot<TTerminal>[];
-    getPendingRuntimes: () => readonly AiSessionPendingRuntimeSnapshot<TTerminal>[];
-    getExecutionSnapshot: () => Readonly<Record<string, AiSessionExecutionSnapshot>>;
-    getFocusedIdentity: () => AiSessionRuntimeIdentity | ActiveAiSessionTerminalIdentity | null;
-    getAttentionAggregate: () => AttentionAggregate | null;
+    getProjectionSnapshot: () => AiSessionProjectionSnapshot<TTerminal>;
     onDidReadSessions?: (
         workspace: OpenWorkspace,
         sessionResults: Record<AiSessionProviderId, AiSessionReadResult>,
@@ -79,6 +127,7 @@ export class WorkspaceSessionHydrationController<TTerminal = unknown> {
         const maxFiles = getAiSessionScanMaxFiles(reason, this.options.incrementalScanMaxFiles);
         const sessionResults = this.options.readCoordinator.getResults({ candidatePaths, reason, maxFiles });
         this.options.onDidReadSessions?.(workspace, sessionResults, reason);
+        const projection = this.options.getProjectionSnapshot();
         const result = hydrateWorkspaceAiSessions({
             workspace,
             providers: this.options.providers,
@@ -86,11 +135,11 @@ export class WorkspaceSessionHydrationController<TTerminal = unknown> {
             getSessionComparableCwd: this.options.getSessionComparableCwd,
             pinnedSessions: this.options.getPinnedSessions(),
             aliases: this.options.getAliases(),
-            activeRuntimes: this.options.getActiveRuntimes(),
-            pendingRuntimes: this.options.getPendingRuntimes(),
-            executionSnapshot: this.options.getExecutionSnapshot(),
-            focusedIdentity: this.options.getFocusedIdentity(),
-            attentionAggregate: this.options.getAttentionAggregate(),
+            activeRuntimes: projection.activeRuntimes,
+            pendingRuntimes: projection.pendingRuntimes,
+            executionSnapshot: projection.executionSnapshot,
+            focusedIdentity: projection.focusedIdentity,
+            attentionAggregate: projection.attentionAggregate,
             providerSelection: this.options.getProviderSelection(workspace.scopeIdentity),
             expanded: this.options.getExpanded(workspace.scopeIdentity),
         });

--- a/tests/contract/aiSessions/projectHydrationController.test.js
+++ b/tests/contract/aiSessions/projectHydrationController.test.js
@@ -68,33 +68,36 @@ test('PERSIST-AI-SESSION-PROJECT-HYDRATION-CONTROLLER-001 preserves scan, projec
             ? { primaryProvider: 'codex', selectedProviders: ['codex', 'kimi'] }
             : undefined,
         getExpanded: scope => scope === WORKSPACE.scopeIdentity,
-        getActiveRuntimes: () => [{
-            identity: activeIdentity,
-            backend: 'vscode', state: 'active', markerPath: '/tmp/a.done',
-            runStartedAtMs: 1, attached: true,
-        }],
-        getPendingRuntimes: () => [{
-            identity: pendingIdentity,
-            backend: 'tmux', state: 'pending', markerPath: '/tmp/pending.done',
-            runStartedAtMs: 2, attached: false, createdAt: '2026-07-16T10:01:00Z',
-            excludedSessionIds: [], title: 'New Kimi',
-            tmux: { layout: 'session', sessionName: 'fixture' },
-        }],
-        getExecutionSnapshot: () => ({
-            'codex:session-a': { state: 'running', token: 'run', occurredAtMs: 3 },
-        }),
-        getFocusedIdentity: () => activeIdentity,
-        getAttentionAggregate: () => ({
-            protocolVersion: 1,
-            aggregateRevision: 'a'.repeat(64),
-            generatedAtMs: 4,
-            sessions: [{
-                projectId: getAttentionProjectKeys(['file:///work/a'])[0],
-                sessionKey: 'codex:session-a',
-                reasons: ['completed'],
-                eventIds: ['event-a'],
-                observedAtMs: 4,
+        getProjectionSnapshot: () => ({
+            revision: 1,
+            activeRuntimes: [{
+                identity: activeIdentity,
+                backend: 'vscode', state: 'active', markerPath: '/tmp/a.done',
+                runStartedAtMs: 1, attached: true,
             }],
+            pendingRuntimes: [{
+                identity: pendingIdentity,
+                backend: 'tmux', state: 'pending', markerPath: '/tmp/pending.done',
+                runStartedAtMs: 2, attached: false, createdAt: '2026-07-16T10:01:00Z',
+                excludedSessionIds: [], title: 'New Kimi',
+                tmux: { layout: 'session', sessionName: 'fixture' },
+            }],
+            executionSnapshot: {
+                'codex:session-a': { state: 'running', token: 'run', occurredAtMs: 3 },
+            },
+            focusedIdentity: activeIdentity,
+            attentionAggregate: {
+                protocolVersion: 1,
+                aggregateRevision: 'a'.repeat(64),
+                generatedAtMs: 4,
+                sessions: [{
+                    projectId: getAttentionProjectKeys(['file:///work/a'])[0],
+                    sessionKey: 'codex:session-a',
+                    reasons: ['completed'],
+                    eventIds: ['event-a'],
+                    observedAtMs: 4,
+                }],
+            },
         }),
         nowMs: () => { nowMs += 7; return nowMs; },
         logDiagnostic: event => diagnostics.push(event),

--- a/tests/contract/aiSessions/runtimeComposition.test.js
+++ b/tests/contract/aiSessions/runtimeComposition.test.js
@@ -316,7 +316,7 @@ test('RUNTIME-HOST-RUNTIME-COMPOSITION-001 Direct recovery failure preserves ind
     assert.equal(result.events.includes('hydration-constructed'), true);
     assert.equal(result.rawDirectFailureExposedInHtml, false);
     assert.deepEqual(result.verified, [
-        'client-store-discovery', 'thread-switch-alias-wiring',
+        'client-store-discovery', 'direct-tmux-coordinator', 'thread-switch-alias-wiring',
         'tmux-backend',
     ]);
 });
@@ -529,14 +529,8 @@ test('RUNTIME-HOST-RUNTIME-COMPOSITION-001 production activation hydrates the wo
     assert.equal(result.failure, null);
     const hydration = result.hydrationDiagnostics.find(diagnostic => diagnostic.workspaceCount === 1);
     assert.ok(hydration, 'a workspace folder must hydrate through the workspace path');
-    assert.ok(
-        result.hydrationWiring.active >= 1 && result.hydrationWiring.pending >= 1,
-        'hydration must consume the dashboard runtime wiring'
-    );
-    assert.equal(result.hydrationWiring.activeViaCoordinator, result.hydrationWiring.active,
-        'every active-runtime read must be served by the runtime coordinator');
-    assert.equal(result.hydrationWiring.pendingViaCoordinator, result.hydrationWiring.pending,
-        'every pending-runtime read must be served by the runtime coordinator');
+    assert.ok(result.coordinatorGetActiveCalls >= 1 && result.coordinatorGetPendingCalls >= 1,
+        'the projection snapshot must consume both dashboard runtime coordinator views');
 });
 
 test('RUNTIME-HOST-RUNTIME-COMPOSITION-001 assembles real runtime components and restores ownership before hydration', async t => {


### PR DESCRIPTION
## Summary

- introduce one versioned projection snapshot for current-workspace runtime, execution, focus, and attention state
- route Session cards and navigation consumers through that snapshot and publish focus, attention, AI-session, and Open Workspaces updates on one monotonic revision timeline
- make the Webview reject stale projection messages and adopt the focused identity from newer authoritative HTML before applying local highlighting

## Skill harvest

no skill change — the existing refactoring and review skills already require characterization tests, architecture guards, and full-suite verification; the only CI retry migrated legacy structure assertions to the new snapshot boundary

## Verification

- npm run test-compile
- focused AI session safety, workspace parity, dashboard Webview, hydration contract, and runtime composition checks
- npm run lint
- npm run test:behavior-contracts
- npm run test:ci:linux
- changed line coverage: 96.92% (63/65)