### PR TITLE
Fix rapid AI session navigation and projection races

### DIFF
--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "911e592f02fd9fbc71c8f566d61074a3e96d263b",
+        "head": "660ab41e2ff0da8f0c4b0f0abeed8a2a97ee87e1",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -243,7 +243,8 @@
             "4aede6f792e9348697acfea174e308368f7157f7",
             "2c5f31a95dbd671b637cf5013789826ed1bedb10",
             "a760309127206890f64a3fa5e1439e75261f067e",
-            "3363eb2837186021d1342c708533e1636ad080d5"
+            "3363eb2837186021d1342c708533e1636ad080d5",
+            "d9187a4aa59e8c81a4b906732164f4425a0c1ac0"
         ]
     },
     "capabilities": [
@@ -490,7 +491,8 @@
                 "edf561e5d8404b0620e9b744c6d5b0bbb48ba936",
                 "6b1d7d6b074fef459a085181c4cc5f16b955831b",
                 "d2b9b3ad677d546a781265603fad088101616133",
-                "680cda193f6fb74064502fe463da5fb9b5154251"
+                "680cda193f6fb74064502fe463da5fb9b5154251",
+                "660ab41e2ff0da8f0c4b0f0abeed8a2a97ee87e1"
             ],
             "behaviors": [
                 "WEBVIEW-CURRENT-WORKSPACE-RENDERING-001",
@@ -1742,7 +1744,8 @@
                 "0eec5f1fdac5105b1a6139eb2125d565860ec16f",
                 "cc2e6152fa07e584611251ec3a984a13c3e0e95c",
                 "91984761d09cb71eabd73a5d33455f2f3bba6e73",
-                "26fb48d07086ecf8ebfe4a70d854cb7166204665"
+                "26fb48d07086ecf8ebfe4a70d854cb7166204665",
+                "7de73084d1a6e73b859861129ad40b17d6c768c1"
             ],
             "behaviors": [
                 "AI-SESSION-QUICK-SWITCH-COMMANDS-001"

--- a/media/webviewDashboardBundle.js
+++ b/media/webviewDashboardBundle.js
@@ -1675,7 +1675,7 @@ function initProjectAiSessionsUpdate(options) {
     var getPendingAiSessionProviderSelectionProjectId = options.getPendingAiSessionProviderSelectionProjectId;
     var getSelectedAiSessionProviders = options.getSelectedAiSessionProviders;
     var syncAiSessionBatchManagementDom = options.syncAiSessionBatchManagementDom;
-    var syncActiveAiSessionProjectionDom = options.syncActiveAiSessionProjectionDom;
+    var syncAiSessionProjectionDom = options.syncAiSessionProjectionDom;
     var reconcilePendingAiSessionProviderSelectionDom = options.reconcilePendingAiSessionProviderSelectionDom;
     var submitAiSessionProviderSelection = options.submitAiSessionProviderSelection;
     var toggleCodexSessions = options.toggleCodexSessions;
@@ -1686,27 +1686,61 @@ function initProjectAiSessionsUpdate(options) {
     var pendingWorkspaceSessionReveal = null;
     var latestAiSessionUpdateSequence = 0;
     var latestAiSessionProjectionRevision = 0;
+    var latestAiSessionFocusProjectionRevision = 0;
+    var latestAiSessionAttentionProjectionRevision = 0;
 
-    function canApplyProjectionRevision(revision) {
+    function canApplyRevision(revision, latestRevision) {
         if (typeof revision === 'undefined') {
-            return latestAiSessionProjectionRevision === 0;
+            return latestRevision === 0;
         }
         return Number.isSafeInteger(revision)
             && revision > 0
-            && revision > latestAiSessionProjectionRevision;
+            && revision > latestRevision;
+    }
+
+    function canApplyProjectionRevision(revision) {
+        return canApplyRevision(revision, latestAiSessionProjectionRevision);
+    }
+
+    function canApplyFocusProjectionRevision(revision) {
+        return canApplyRevision(revision, latestAiSessionFocusProjectionRevision);
+    }
+
+    function canApplyAttentionProjectionRevision(revision) {
+        return canApplyRevision(revision, latestAiSessionAttentionProjectionRevision);
     }
 
     function commitProjectionRevision(revision) {
         if (Number.isSafeInteger(revision) && revision > 0) {
             latestAiSessionProjectionRevision = revision;
+            latestAiSessionFocusProjectionRevision = Math.max(
+                latestAiSessionFocusProjectionRevision,
+                revision
+            );
+            latestAiSessionAttentionProjectionRevision = Math.max(
+                latestAiSessionAttentionProjectionRevision,
+                revision
+            );
         }
     }
 
-    function acceptProjectionRevision(revision) {
-        if (!canApplyProjectionRevision(revision)) {
+    function acceptFocusProjectionRevision(revision) {
+        if (!canApplyFocusProjectionRevision(revision)) {
             return false;
         }
-        commitProjectionRevision(revision);
+        if (Number.isSafeInteger(revision) && revision > 0) {
+            latestAiSessionFocusProjectionRevision = revision;
+        }
+        return true;
+    }
+
+    function acceptAttentionProjectionRevision(revision) {
+        if (!canApplyAttentionProjectionRevision(revision)) {
+            return false;
+        }
+        if (Number.isSafeInteger(revision) && revision > 0) {
+            latestAiSessionAttentionProjectionRevision = revision;
+        }
         return true;
     }
 
@@ -1728,6 +1762,10 @@ function initProjectAiSessionsUpdate(options) {
         if (!canApplyProjectionRevision(message.projectionRevision)) {
             return;
         }
+        var adoptRenderedFocus = canApplyFocusProjectionRevision(message.projectionRevision);
+        var adoptRenderedAttention = canApplyAttentionProjectionRevision(
+            message.projectionRevision
+        );
 
         if (!applyWorkspaceUpdate({
             type: 'workspace-updated',
@@ -1755,7 +1793,7 @@ function initProjectAiSessionsUpdate(options) {
             }
         }
         reconcilePendingAiSessionProviderSelectionDom();
-        syncActiveAiSessionProjectionDom();
+        syncAiSessionProjectionDom(adoptRenderedFocus, adoptRenderedAttention);
         updateStickyGroupHeaderOffset();
         if (window.__agentPivotDashboard) {
             window.__agentPivotDashboard.replaceSearchCatalog(message.searchCatalog);
@@ -1864,7 +1902,10 @@ function initProjectAiSessionsUpdate(options) {
 
     return {
         applyAiSessionsUpdate: applyAiSessionsUpdate,
-        acceptProjectionRevision: acceptProjectionRevision,
+        acceptAttentionProjectionRevision: acceptAttentionProjectionRevision,
+        acceptFocusProjectionRevision: acceptFocusProjectionRevision,
+        canApplyAttentionProjectionRevision: canApplyAttentionProjectionRevision,
+        canApplyFocusProjectionRevision: canApplyFocusProjectionRevision,
         canApplyProjectionRevision: canApplyProjectionRevision,
         commitProjectionRevision: commitProjectionRevision,
         findCurrentWorkspaceDiv: findCurrentWorkspaceDiv,
@@ -2843,16 +2884,90 @@ function initProjects() {
         getArchiveAiSessionMessageType: aiSessionControls.getArchiveAiSessionMessageType,
         isAiSessionProvider: aiSessionControls.isAiSessionProvider,
     });
-    function syncActiveAiSessionProjectionDom() {
-        var focusedRow = document.querySelector(
-            '.codex-session-row[data-session-focused][data-session-provider][data-session-id]'
-        );
-        var provider = focusedRow && focusedRow.getAttribute('data-session-provider');
-        aiSessionControls.activeAiSessionTerminalState.provider =
-            aiSessionControls.isAiSessionProvider(provider) ? provider : null;
-        aiSessionControls.activeAiSessionTerminalState.sessionId = focusedRow
-            ? focusedRow.getAttribute('data-session-id') : null;
+    function syncActiveAiSessionProjectionDom(adoptRenderedFocus) {
+        if (adoptRenderedFocus !== false) {
+            var focusedRow = document.querySelector(
+                '.codex-session-row[data-session-focused][data-session-provider][data-session-id]'
+            );
+            var provider = focusedRow && focusedRow.getAttribute('data-session-provider');
+            aiSessionControls.activeAiSessionTerminalState.provider =
+                aiSessionControls.isAiSessionProvider(provider) ? provider : null;
+            aiSessionControls.activeAiSessionTerminalState.sessionId = focusedRow
+                ? focusedRow.getAttribute('data-session-id') : null;
+        } else {
+            var projectedFocusedRow = null;
+            document.querySelectorAll('.codex-session-row[data-session-id]').forEach(row => {
+                var focused = row.getAttribute('data-session-provider')
+                    === aiSessionControls.activeAiSessionTerminalState.provider
+                    && row.getAttribute('data-session-id')
+                    === aiSessionControls.activeAiSessionTerminalState.sessionId;
+                if (focused) projectedFocusedRow = row;
+                row.toggleAttribute(
+                    'data-session-focused',
+                    focused
+                );
+                var primaryAction = row.querySelector('.ai-session-primary-action');
+                if (primaryAction) {
+                    var actionState = focused ? 'conversation' : 'focus';
+                    var actionAriaLabel = primaryAction.getAttribute(
+                        'data-' + actionState + '-aria-label'
+                    );
+                    var actionTitle = primaryAction.getAttribute(
+                        'data-' + actionState + '-title'
+                    );
+                    if (actionAriaLabel) primaryAction.setAttribute('aria-label', actionAriaLabel);
+                    if (actionTitle) primaryAction.setAttribute('title', actionTitle);
+                }
+                var conversationHint = row.querySelector('.ai-session-open-conversation-hint');
+                if (focused && primaryAction && !conversationHint) {
+                    conversationHint = document.createElement('span');
+                    conversationHint.className = 'ai-session-open-conversation-hint';
+                    conversationHint.setAttribute('aria-hidden', 'true');
+                    conversationHint.textContent = '›';
+                    primaryAction.appendChild(conversationHint);
+                } else if (!focused && conversationHint) {
+                    conversationHint.remove();
+                }
+            });
+            if (projectedFocusedRow) {
+                projectedFocusedRow.scrollIntoView({ block: 'nearest' });
+            }
+        }
         aiSessionControls.syncActiveAiSessionTerminalDom();
+    }
+    function syncAiSessionAttentionProjectionDom(adoptRenderedAttention) {
+        if (adoptRenderedAttention !== false) return;
+        window.__agentPivotAttentionSessionEvents =
+            window.__agentPivotAttentionSessionEvents || {};
+        document.querySelectorAll(
+            '.codex-session-row[data-session-provider][data-session-id]'
+        ).forEach(row => {
+            var sessionKey = row.getAttribute('data-session-provider')
+                + ':' + row.getAttribute('data-session-id');
+            var eventIds = window.__agentPivotAttentionSessionEvents[sessionKey] || [];
+            row.toggleAttribute('data-session-needs-attention', eventIds.length > 0);
+            row.toggleAttribute('data-ai-session-attention', eventIds.length > 0);
+            if (eventIds.length) {
+                row.setAttribute('data-session-event-id', eventIds[0]);
+            } else {
+                row.removeAttribute('data-session-event-id');
+            }
+            var primaryAction = row.querySelector('.ai-session-primary-action');
+            var indicator = row.querySelector('.ai-session-attention-indicator');
+            if (eventIds.length && primaryAction && !indicator) {
+                indicator = document.createElement('span');
+                indicator.className = 'ai-session-attention-indicator';
+                indicator.title = 'AI session needs attention';
+                indicator.setAttribute('aria-label', 'AI session needs attention');
+                primaryAction.insertBefore(indicator, primaryAction.firstChild);
+            } else if (!eventIds.length && indicator) {
+                indicator.remove();
+            }
+        });
+    }
+    function syncAiSessionProjectionDom(adoptRenderedFocus, adoptRenderedAttention) {
+        syncActiveAiSessionProjectionDom(adoptRenderedFocus);
+        syncAiSessionAttentionProjectionDom(adoptRenderedAttention);
     }
     var aiSessionsUpdate = initProjectAiSessionsUpdate({
         batchAiSessionState: aiSessionControls.batchAiSessionState,
@@ -2860,7 +2975,7 @@ function initProjects() {
         getPendingAiSessionProviderSelectionProjectId: () => aiSessionControls.getPendingAiSessionProviderSelectionProjectId(),
         getSelectedAiSessionProviders: aiSessionControls.getSelectedAiSessionProviders,
         syncAiSessionBatchManagementDom: aiSessionControls.syncAiSessionBatchManagementDom,
-        syncActiveAiSessionProjectionDom: syncActiveAiSessionProjectionDom,
+        syncAiSessionProjectionDom: syncAiSessionProjectionDom,
         reconcilePendingAiSessionProviderSelectionDom: aiSessionControls.reconcilePendingAiSessionProviderSelectionDom,
         submitAiSessionProviderSelection: aiSessionControls.submitAiSessionProviderSelection,
         toggleCodexSessions: aiSessionControls.toggleCodexSessions,
@@ -3042,12 +3157,21 @@ function initProjects() {
         }
         if (message && message.type === 'open-workspaces-updated') {
             if (!aiSessionsUpdate.canApplyProjectionRevision(message.projectionRevision)) return;
+            var adoptOpenWorkspaceFocus = aiSessionsUpdate.canApplyFocusProjectionRevision(
+                message.projectionRevision
+            );
+            var adoptOpenWorkspaceAttention = aiSessionsUpdate.canApplyAttentionProjectionRevision(
+                message.projectionRevision
+            );
             if (!applyOpenWorkspacesUpdate(message)) {
                 aiSessionsUpdate.requestFullRefresh('invalid-open-workspaces-update');
                 return;
             }
             aiSessionsUpdate.commitProjectionRevision(message.projectionRevision);
-            syncActiveAiSessionProjectionDom();
+            syncAiSessionProjectionDom(
+                adoptOpenWorkspaceFocus,
+                adoptOpenWorkspaceAttention
+            );
             updateStickyGroupHeaderOffset();
             var renderedOpenWorkspaceState = getOpenWorkspacesUpdateDomState();
             window.vscode.postMessage({
@@ -3083,15 +3207,15 @@ function initProjects() {
         }
 
         if (message && message.type === 'active-ai-session-terminal-changed') {
-            if (!aiSessionsUpdate.acceptProjectionRevision(message.projectionRevision)) return;
+            if (!aiSessionsUpdate.acceptFocusProjectionRevision(message.projectionRevision)) return;
             aiSessionControls.activeAiSessionTerminalState.provider = aiSessionControls.isAiSessionProvider(message.provider) ? message.provider : null;
             aiSessionControls.activeAiSessionTerminalState.sessionId = typeof message.sessionId === 'string' ? message.sessionId : null;
-            aiSessionControls.syncActiveAiSessionTerminalDom();
+            syncActiveAiSessionProjectionDom(false);
             return;
         }
 
         if (message && message.type === 'ai-session-attention-state') {
-            if (!aiSessionsUpdate.acceptProjectionRevision(message.projectionRevision)) return;
+            if (!aiSessionsUpdate.acceptAttentionProjectionRevision(message.projectionRevision)) return;
             window.__agentPivotAttentionEvents = window.__agentPivotAttentionEvents || {};
             window.__agentPivotAttentionSessionEvents = {};
             (Array.isArray(message.sessionEvents) ? message.sessionEvents.slice(0, 1000) : []).forEach(session => {
@@ -3106,6 +3230,7 @@ function initProjects() {
             (message.eventIds || []).forEach(eventId => {
                 if (typeof eventId === 'string') window.__agentPivotAttentionEvents[eventId] = true;
             });
+            syncAiSessionAttentionProjectionDom(false);
             return;
         }
 

--- a/media/webviewProjectAiUpdateScripts.js
+++ b/media/webviewProjectAiUpdateScripts.js
@@ -7,7 +7,7 @@ function initProjectAiSessionsUpdate(options) {
     var getPendingAiSessionProviderSelectionProjectId = options.getPendingAiSessionProviderSelectionProjectId;
     var getSelectedAiSessionProviders = options.getSelectedAiSessionProviders;
     var syncAiSessionBatchManagementDom = options.syncAiSessionBatchManagementDom;
-    var syncActiveAiSessionProjectionDom = options.syncActiveAiSessionProjectionDom;
+    var syncAiSessionProjectionDom = options.syncAiSessionProjectionDom;
     var reconcilePendingAiSessionProviderSelectionDom = options.reconcilePendingAiSessionProviderSelectionDom;
     var submitAiSessionProviderSelection = options.submitAiSessionProviderSelection;
     var toggleCodexSessions = options.toggleCodexSessions;
@@ -18,27 +18,61 @@ function initProjectAiSessionsUpdate(options) {
     var pendingWorkspaceSessionReveal = null;
     var latestAiSessionUpdateSequence = 0;
     var latestAiSessionProjectionRevision = 0;
+    var latestAiSessionFocusProjectionRevision = 0;
+    var latestAiSessionAttentionProjectionRevision = 0;
 
-    function canApplyProjectionRevision(revision) {
+    function canApplyRevision(revision, latestRevision) {
         if (typeof revision === 'undefined') {
-            return latestAiSessionProjectionRevision === 0;
+            return latestRevision === 0;
         }
         return Number.isSafeInteger(revision)
             && revision > 0
-            && revision > latestAiSessionProjectionRevision;
+            && revision > latestRevision;
+    }
+
+    function canApplyProjectionRevision(revision) {
+        return canApplyRevision(revision, latestAiSessionProjectionRevision);
+    }
+
+    function canApplyFocusProjectionRevision(revision) {
+        return canApplyRevision(revision, latestAiSessionFocusProjectionRevision);
+    }
+
+    function canApplyAttentionProjectionRevision(revision) {
+        return canApplyRevision(revision, latestAiSessionAttentionProjectionRevision);
     }
 
     function commitProjectionRevision(revision) {
         if (Number.isSafeInteger(revision) && revision > 0) {
             latestAiSessionProjectionRevision = revision;
+            latestAiSessionFocusProjectionRevision = Math.max(
+                latestAiSessionFocusProjectionRevision,
+                revision
+            );
+            latestAiSessionAttentionProjectionRevision = Math.max(
+                latestAiSessionAttentionProjectionRevision,
+                revision
+            );
         }
     }
 
-    function acceptProjectionRevision(revision) {
-        if (!canApplyProjectionRevision(revision)) {
+    function acceptFocusProjectionRevision(revision) {
+        if (!canApplyFocusProjectionRevision(revision)) {
             return false;
         }
-        commitProjectionRevision(revision);
+        if (Number.isSafeInteger(revision) && revision > 0) {
+            latestAiSessionFocusProjectionRevision = revision;
+        }
+        return true;
+    }
+
+    function acceptAttentionProjectionRevision(revision) {
+        if (!canApplyAttentionProjectionRevision(revision)) {
+            return false;
+        }
+        if (Number.isSafeInteger(revision) && revision > 0) {
+            latestAiSessionAttentionProjectionRevision = revision;
+        }
         return true;
     }
 
@@ -60,6 +94,10 @@ function initProjectAiSessionsUpdate(options) {
         if (!canApplyProjectionRevision(message.projectionRevision)) {
             return;
         }
+        var adoptRenderedFocus = canApplyFocusProjectionRevision(message.projectionRevision);
+        var adoptRenderedAttention = canApplyAttentionProjectionRevision(
+            message.projectionRevision
+        );
 
         if (!applyWorkspaceUpdate({
             type: 'workspace-updated',
@@ -87,7 +125,7 @@ function initProjectAiSessionsUpdate(options) {
             }
         }
         reconcilePendingAiSessionProviderSelectionDom();
-        syncActiveAiSessionProjectionDom();
+        syncAiSessionProjectionDom(adoptRenderedFocus, adoptRenderedAttention);
         updateStickyGroupHeaderOffset();
         if (window.__agentPivotDashboard) {
             window.__agentPivotDashboard.replaceSearchCatalog(message.searchCatalog);
@@ -196,7 +234,10 @@ function initProjectAiSessionsUpdate(options) {
 
     return {
         applyAiSessionsUpdate: applyAiSessionsUpdate,
-        acceptProjectionRevision: acceptProjectionRevision,
+        acceptAttentionProjectionRevision: acceptAttentionProjectionRevision,
+        acceptFocusProjectionRevision: acceptFocusProjectionRevision,
+        canApplyAttentionProjectionRevision: canApplyAttentionProjectionRevision,
+        canApplyFocusProjectionRevision: canApplyFocusProjectionRevision,
         canApplyProjectionRevision: canApplyProjectionRevision,
         commitProjectionRevision: commitProjectionRevision,
         findCurrentWorkspaceDiv: findCurrentWorkspaceDiv,

--- a/media/webviewProjectScripts.js
+++ b/media/webviewProjectScripts.js
@@ -258,16 +258,90 @@ function initProjects() {
         getArchiveAiSessionMessageType: aiSessionControls.getArchiveAiSessionMessageType,
         isAiSessionProvider: aiSessionControls.isAiSessionProvider,
     });
-    function syncActiveAiSessionProjectionDom() {
-        var focusedRow = document.querySelector(
-            '.codex-session-row[data-session-focused][data-session-provider][data-session-id]'
-        );
-        var provider = focusedRow && focusedRow.getAttribute('data-session-provider');
-        aiSessionControls.activeAiSessionTerminalState.provider =
-            aiSessionControls.isAiSessionProvider(provider) ? provider : null;
-        aiSessionControls.activeAiSessionTerminalState.sessionId = focusedRow
-            ? focusedRow.getAttribute('data-session-id') : null;
+    function syncActiveAiSessionProjectionDom(adoptRenderedFocus) {
+        if (adoptRenderedFocus !== false) {
+            var focusedRow = document.querySelector(
+                '.codex-session-row[data-session-focused][data-session-provider][data-session-id]'
+            );
+            var provider = focusedRow && focusedRow.getAttribute('data-session-provider');
+            aiSessionControls.activeAiSessionTerminalState.provider =
+                aiSessionControls.isAiSessionProvider(provider) ? provider : null;
+            aiSessionControls.activeAiSessionTerminalState.sessionId = focusedRow
+                ? focusedRow.getAttribute('data-session-id') : null;
+        } else {
+            var projectedFocusedRow = null;
+            document.querySelectorAll('.codex-session-row[data-session-id]').forEach(row => {
+                var focused = row.getAttribute('data-session-provider')
+                    === aiSessionControls.activeAiSessionTerminalState.provider
+                    && row.getAttribute('data-session-id')
+                    === aiSessionControls.activeAiSessionTerminalState.sessionId;
+                if (focused) projectedFocusedRow = row;
+                row.toggleAttribute(
+                    'data-session-focused',
+                    focused
+                );
+                var primaryAction = row.querySelector('.ai-session-primary-action');
+                if (primaryAction) {
+                    var actionState = focused ? 'conversation' : 'focus';
+                    var actionAriaLabel = primaryAction.getAttribute(
+                        'data-' + actionState + '-aria-label'
+                    );
+                    var actionTitle = primaryAction.getAttribute(
+                        'data-' + actionState + '-title'
+                    );
+                    if (actionAriaLabel) primaryAction.setAttribute('aria-label', actionAriaLabel);
+                    if (actionTitle) primaryAction.setAttribute('title', actionTitle);
+                }
+                var conversationHint = row.querySelector('.ai-session-open-conversation-hint');
+                if (focused && primaryAction && !conversationHint) {
+                    conversationHint = document.createElement('span');
+                    conversationHint.className = 'ai-session-open-conversation-hint';
+                    conversationHint.setAttribute('aria-hidden', 'true');
+                    conversationHint.textContent = '›';
+                    primaryAction.appendChild(conversationHint);
+                } else if (!focused && conversationHint) {
+                    conversationHint.remove();
+                }
+            });
+            if (projectedFocusedRow) {
+                projectedFocusedRow.scrollIntoView({ block: 'nearest' });
+            }
+        }
         aiSessionControls.syncActiveAiSessionTerminalDom();
+    }
+    function syncAiSessionAttentionProjectionDom(adoptRenderedAttention) {
+        if (adoptRenderedAttention !== false) return;
+        window.__agentPivotAttentionSessionEvents =
+            window.__agentPivotAttentionSessionEvents || {};
+        document.querySelectorAll(
+            '.codex-session-row[data-session-provider][data-session-id]'
+        ).forEach(row => {
+            var sessionKey = row.getAttribute('data-session-provider')
+                + ':' + row.getAttribute('data-session-id');
+            var eventIds = window.__agentPivotAttentionSessionEvents[sessionKey] || [];
+            row.toggleAttribute('data-session-needs-attention', eventIds.length > 0);
+            row.toggleAttribute('data-ai-session-attention', eventIds.length > 0);
+            if (eventIds.length) {
+                row.setAttribute('data-session-event-id', eventIds[0]);
+            } else {
+                row.removeAttribute('data-session-event-id');
+            }
+            var primaryAction = row.querySelector('.ai-session-primary-action');
+            var indicator = row.querySelector('.ai-session-attention-indicator');
+            if (eventIds.length && primaryAction && !indicator) {
+                indicator = document.createElement('span');
+                indicator.className = 'ai-session-attention-indicator';
+                indicator.title = 'AI session needs attention';
+                indicator.setAttribute('aria-label', 'AI session needs attention');
+                primaryAction.insertBefore(indicator, primaryAction.firstChild);
+            } else if (!eventIds.length && indicator) {
+                indicator.remove();
+            }
+        });
+    }
+    function syncAiSessionProjectionDom(adoptRenderedFocus, adoptRenderedAttention) {
+        syncActiveAiSessionProjectionDom(adoptRenderedFocus);
+        syncAiSessionAttentionProjectionDom(adoptRenderedAttention);
     }
     var aiSessionsUpdate = initProjectAiSessionsUpdate({
         batchAiSessionState: aiSessionControls.batchAiSessionState,
@@ -275,7 +349,7 @@ function initProjects() {
         getPendingAiSessionProviderSelectionProjectId: () => aiSessionControls.getPendingAiSessionProviderSelectionProjectId(),
         getSelectedAiSessionProviders: aiSessionControls.getSelectedAiSessionProviders,
         syncAiSessionBatchManagementDom: aiSessionControls.syncAiSessionBatchManagementDom,
-        syncActiveAiSessionProjectionDom: syncActiveAiSessionProjectionDom,
+        syncAiSessionProjectionDom: syncAiSessionProjectionDom,
         reconcilePendingAiSessionProviderSelectionDom: aiSessionControls.reconcilePendingAiSessionProviderSelectionDom,
         submitAiSessionProviderSelection: aiSessionControls.submitAiSessionProviderSelection,
         toggleCodexSessions: aiSessionControls.toggleCodexSessions,
@@ -457,12 +531,21 @@ function initProjects() {
         }
         if (message && message.type === 'open-workspaces-updated') {
             if (!aiSessionsUpdate.canApplyProjectionRevision(message.projectionRevision)) return;
+            var adoptOpenWorkspaceFocus = aiSessionsUpdate.canApplyFocusProjectionRevision(
+                message.projectionRevision
+            );
+            var adoptOpenWorkspaceAttention = aiSessionsUpdate.canApplyAttentionProjectionRevision(
+                message.projectionRevision
+            );
             if (!applyOpenWorkspacesUpdate(message)) {
                 aiSessionsUpdate.requestFullRefresh('invalid-open-workspaces-update');
                 return;
             }
             aiSessionsUpdate.commitProjectionRevision(message.projectionRevision);
-            syncActiveAiSessionProjectionDom();
+            syncAiSessionProjectionDom(
+                adoptOpenWorkspaceFocus,
+                adoptOpenWorkspaceAttention
+            );
             updateStickyGroupHeaderOffset();
             var renderedOpenWorkspaceState = getOpenWorkspacesUpdateDomState();
             window.vscode.postMessage({
@@ -498,15 +581,15 @@ function initProjects() {
         }
 
         if (message && message.type === 'active-ai-session-terminal-changed') {
-            if (!aiSessionsUpdate.acceptProjectionRevision(message.projectionRevision)) return;
+            if (!aiSessionsUpdate.acceptFocusProjectionRevision(message.projectionRevision)) return;
             aiSessionControls.activeAiSessionTerminalState.provider = aiSessionControls.isAiSessionProvider(message.provider) ? message.provider : null;
             aiSessionControls.activeAiSessionTerminalState.sessionId = typeof message.sessionId === 'string' ? message.sessionId : null;
-            aiSessionControls.syncActiveAiSessionTerminalDom();
+            syncActiveAiSessionProjectionDom(false);
             return;
         }
 
         if (message && message.type === 'ai-session-attention-state') {
-            if (!aiSessionsUpdate.acceptProjectionRevision(message.projectionRevision)) return;
+            if (!aiSessionsUpdate.acceptAttentionProjectionRevision(message.projectionRevision)) return;
             window.__agentPivotAttentionEvents = window.__agentPivotAttentionEvents || {};
             window.__agentPivotAttentionSessionEvents = {};
             (Array.isArray(message.sessionEvents) ? message.sessionEvents.slice(0, 1000) : []).forEach(session => {
@@ -521,6 +604,7 @@ function initProjects() {
             (message.eventIds || []).forEach(eventId => {
                 if (typeof eventId === 'string') window.__agentPivotAttentionEvents[eventId] = true;
             });
+            syncAiSessionAttentionProjectionDom(false);
             return;
         }
 

--- a/scripts/run-ai-session-safety-checks.js
+++ b/scripts/run-ai-session-safety-checks.js
@@ -6291,6 +6291,7 @@ function runBatchAiSessionWebviewChecks() {
         };
         const classes = new Set();
         let attentionIndicator = null;
+        let conversationHint = null;
         const row = {
             provider,
             sessionId,
@@ -6315,7 +6316,8 @@ function runBatchAiSessionWebviewChecks() {
                 indicator.remove = () => { attentionIndicator = null; };
             },
             querySelector: selector => selector === '.ai-session-attention-indicator' ? attentionIndicator
-                : selector === '.ai-session-primary-action' ? row.primaryAction : null,
+                : selector === '.ai-session-open-conversation-hint' ? conversationHint
+                    : selector === '.ai-session-primary-action' ? row.primaryAction : null,
             removeAttribute: attribute => {
                 attributes.delete(attribute);
                 delete attributeValues[attribute];
@@ -6341,10 +6343,19 @@ function runBatchAiSessionWebviewChecks() {
                 return null;
             },
             focus: () => {},
+            scrollIntoView: () => { row.scrolledIntoView = true; },
             getBoundingClientRect: () => ({ left: 10, top: 10 }),
         };
         row.primaryAction = {
+            firstChild: {},
+            appendChild: hint => {
+                conversationHint = hint;
+                hint.remove = () => { conversationHint = null; };
+            },
             focus: () => { row.primaryAction.focused = true; },
+            getAttribute: () => null,
+            insertBefore: indicator => row.insertBefore(indicator),
+            setAttribute: () => {},
             closest: selector => {
                 if (selector === '[data-action="activate-ai-session"]'
                     || selector === '.ai-session-primary-action'

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1810,6 +1810,7 @@ async function initializeDashboard(
         }
         return null;
     };
+    const aiSessionMru = createAiSessionMruTracker({ now: () => Date.now() });
     const sessionNavigationCoordinator = createSessionNavigationCoordinator();
     const sessionNavigationFocusExecutor = createSessionNavigationFocusExecutor({
         getProjectId: () => getCurrentWorkspaceActionTargetWithoutCardId()?.cardId || null,
@@ -1820,6 +1821,8 @@ async function initializeDashboard(
                 sessionId,
             ),
         openConversation: request => openAiSessionConversationWithFeedback(request),
+        onFocused: target =>
+            aiSessionMru.record(target.provider, target.sessionId),
     });
     const jumpToNextAttentionSession = createAttentionQueueJumpHandler({
         navigationCoordinator: sessionNavigationCoordinator,
@@ -1932,7 +1935,6 @@ async function initializeDashboard(
     // terminal focus events, so event-driven recording starves the tracker.
     // Sample the resolved focus instead: the tmux focused-runtime monitor
     // already polls every second, keeping this resolution fresh.
-    const aiSessionMru = createAiSessionMruTracker({ now: () => Date.now() });
     ownResource(() => {
         let lastSampledKey: string | null = null;
         const handle = setInterval(() => {
@@ -2466,7 +2468,12 @@ async function initializeDashboard(
     ): Promise<void> {
         const result = await conversationCapability
             .followAdjacentActiveConversation(direction);
-        if (result === 'inactive' || result === 'closed') {
+        if (result === 'opened') {
+            const identity = getFocusedAiSessionIdentity();
+            if (identity?.sessionId) {
+                aiSessionMru.record(identity.provider, identity.sessionId);
+            }
+        } else if (result === 'inactive' || result === 'closed') {
             void vscode.window.showInformationMessage(
                 'Agent Pivot: open an AI Conversation editor to switch active sessions.'
             );

--- a/src/dashboard/sessionNavigationFocusExecutor.ts
+++ b/src/dashboard/sessionNavigationFocusExecutor.ts
@@ -35,6 +35,7 @@ export interface SessionNavigationFocusExecutorOptions {
         provider: AiSessionProviderId;
         sessionId: string;
     }): Promise<boolean>;
+    onFocused?(target: SessionNavigationFocusTarget): void;
 }
 
 /**
@@ -62,6 +63,7 @@ export function createSessionNavigationFocusExecutor(
             if (!focused) {
                 return { focused: false, conversationOpened: false };
             }
+            options.onFocused?.(target);
             executionOptions.onFocused?.();
             const conversationOpened = await options.openConversation({
                 projectId,

--- a/src/webview/webviewAiSessionContent.ts
+++ b/src/webview/webviewAiSessionContent.ts
@@ -444,22 +444,24 @@ function getActiveAiSessionRow(
     var rowAction = model.backend === 'tmux'
         ? (model.attached ? 'Focus' : 'Attach or focus')
         : 'Focus';
-    var primaryAction = conflict ? 'Choose runtime' : model.pending ? 'Focus pending' : hasOpenConversationHint ? 'Open conversation' : rowAction;
+    var focusAction = conflict ? 'Choose runtime' : model.pending ? 'Focus pending' : rowAction;
     var runtimeDescription = conflict ? 'runtime conflict'
         : model.backend === 'tmux'
             ? `tmux ${model.tmuxLayout || 'unknown'} layout, ${model.attached ? 'attached' : 'detached'}`
             : `Direct VS Code terminal, ${model.attached ? 'attached' : 'detached'}`;
-    var primaryAriaLabel = conflict
+    var focusAriaLabel = conflict
         ? `Choose runtime for ${providerLabel} session ${sessionName}, runtime conflict`
-        : hasOpenConversationHint
-            ? `Open AI conversation for ${providerLabel} session ${sessionName}`
-            : `${primaryAction} ${providerLabel} session ${sessionName} using ${runtimeDescription}`;
-    var primaryTitle = hasOpenConversationHint
-        ? `Open AI conversation for ${providerLabel} Session`
-        : `${primaryAction} ${providerLabel} Session`;
+        : `${focusAction} ${providerLabel} session ${sessionName} using ${runtimeDescription}`;
+    var conversationAriaLabel = `Open AI conversation for ${providerLabel} session ${sessionName}`;
     if (model.stale) {
-        primaryAriaLabel += ', runtime status is stale';
+        focusAriaLabel += ', runtime status is stale';
     }
+    var focusTitle = `${focusAction} ${providerLabel} Session`;
+    var conversationTitle = `Open AI conversation for ${providerLabel} Session`;
+    var primaryAriaLabel = hasOpenConversationHint
+        ? conversationAriaLabel
+        : focusAriaLabel;
+    var primaryTitle = hasOpenConversationHint ? conversationTitle : focusTitle;
     var rootAttributes = showRootChip && model.primaryRootId
         ? ` data-primary-root-id="${escapeAttribute(model.primaryRootId)}"`
         : '';
@@ -470,7 +472,7 @@ function getActiveAiSessionRow(
         ? '<span class="ai-session-open-conversation-hint" aria-hidden="true">›</span>'
         : '';
     return `<div class="codex-session-row active-ai-session-row" role="group" aria-label="${providerLabel} session ${sessionName}" data-session-provider="${model.provider}" data-execution-state="${model.executionState}"${iconFx ? ` data-session-icon-fx="${iconFx}"` : ''}${runtimeAttributes}${rootAttributes}${pendingAttributes}${model.pinned ? ' data-session-pinned' : ''}${model.focused ? ' data-session-focused' : ''}${model.needsAttention ? ' data-session-needs-attention' : ''}${attentionAttributes}>
-        <button type="button" class="ai-session-primary-action" data-action="activate-ai-session" aria-label="${primaryAriaLabel}" title="${primaryTitle}">
+        <button type="button" class="ai-session-primary-action" data-action="activate-ai-session" aria-label="${primaryAriaLabel}" title="${primaryTitle}" data-focus-aria-label="${focusAriaLabel}" data-focus-title="${focusTitle}" data-conversation-aria-label="${conversationAriaLabel}" data-conversation-title="${conversationTitle}">
             ${attentionIndicator}
             <span class="codex-session-icon">${getAiProviderIcon(model.provider)}</span>
             <span class="codex-session-text">

--- a/src/webview/webviewProjectAiUpdateScripts.js
+++ b/src/webview/webviewProjectAiUpdateScripts.js
@@ -7,7 +7,7 @@ function initProjectAiSessionsUpdate(options) {
     var getPendingAiSessionProviderSelectionProjectId = options.getPendingAiSessionProviderSelectionProjectId;
     var getSelectedAiSessionProviders = options.getSelectedAiSessionProviders;
     var syncAiSessionBatchManagementDom = options.syncAiSessionBatchManagementDom;
-    var syncActiveAiSessionProjectionDom = options.syncActiveAiSessionProjectionDom;
+    var syncAiSessionProjectionDom = options.syncAiSessionProjectionDom;
     var reconcilePendingAiSessionProviderSelectionDom = options.reconcilePendingAiSessionProviderSelectionDom;
     var submitAiSessionProviderSelection = options.submitAiSessionProviderSelection;
     var toggleCodexSessions = options.toggleCodexSessions;
@@ -18,27 +18,61 @@ function initProjectAiSessionsUpdate(options) {
     var pendingWorkspaceSessionReveal = null;
     var latestAiSessionUpdateSequence = 0;
     var latestAiSessionProjectionRevision = 0;
+    var latestAiSessionFocusProjectionRevision = 0;
+    var latestAiSessionAttentionProjectionRevision = 0;
 
-    function canApplyProjectionRevision(revision) {
+    function canApplyRevision(revision, latestRevision) {
         if (typeof revision === 'undefined') {
-            return latestAiSessionProjectionRevision === 0;
+            return latestRevision === 0;
         }
         return Number.isSafeInteger(revision)
             && revision > 0
-            && revision > latestAiSessionProjectionRevision;
+            && revision > latestRevision;
+    }
+
+    function canApplyProjectionRevision(revision) {
+        return canApplyRevision(revision, latestAiSessionProjectionRevision);
+    }
+
+    function canApplyFocusProjectionRevision(revision) {
+        return canApplyRevision(revision, latestAiSessionFocusProjectionRevision);
+    }
+
+    function canApplyAttentionProjectionRevision(revision) {
+        return canApplyRevision(revision, latestAiSessionAttentionProjectionRevision);
     }
 
     function commitProjectionRevision(revision) {
         if (Number.isSafeInteger(revision) && revision > 0) {
             latestAiSessionProjectionRevision = revision;
+            latestAiSessionFocusProjectionRevision = Math.max(
+                latestAiSessionFocusProjectionRevision,
+                revision
+            );
+            latestAiSessionAttentionProjectionRevision = Math.max(
+                latestAiSessionAttentionProjectionRevision,
+                revision
+            );
         }
     }
 
-    function acceptProjectionRevision(revision) {
-        if (!canApplyProjectionRevision(revision)) {
+    function acceptFocusProjectionRevision(revision) {
+        if (!canApplyFocusProjectionRevision(revision)) {
             return false;
         }
-        commitProjectionRevision(revision);
+        if (Number.isSafeInteger(revision) && revision > 0) {
+            latestAiSessionFocusProjectionRevision = revision;
+        }
+        return true;
+    }
+
+    function acceptAttentionProjectionRevision(revision) {
+        if (!canApplyAttentionProjectionRevision(revision)) {
+            return false;
+        }
+        if (Number.isSafeInteger(revision) && revision > 0) {
+            latestAiSessionAttentionProjectionRevision = revision;
+        }
         return true;
     }
 
@@ -60,6 +94,10 @@ function initProjectAiSessionsUpdate(options) {
         if (!canApplyProjectionRevision(message.projectionRevision)) {
             return;
         }
+        var adoptRenderedFocus = canApplyFocusProjectionRevision(message.projectionRevision);
+        var adoptRenderedAttention = canApplyAttentionProjectionRevision(
+            message.projectionRevision
+        );
 
         if (!applyWorkspaceUpdate({
             type: 'workspace-updated',
@@ -87,7 +125,7 @@ function initProjectAiSessionsUpdate(options) {
             }
         }
         reconcilePendingAiSessionProviderSelectionDom();
-        syncActiveAiSessionProjectionDom();
+        syncAiSessionProjectionDom(adoptRenderedFocus, adoptRenderedAttention);
         updateStickyGroupHeaderOffset();
         if (window.__agentPivotDashboard) {
             window.__agentPivotDashboard.replaceSearchCatalog(message.searchCatalog);
@@ -196,7 +234,10 @@ function initProjectAiSessionsUpdate(options) {
 
     return {
         applyAiSessionsUpdate: applyAiSessionsUpdate,
-        acceptProjectionRevision: acceptProjectionRevision,
+        acceptAttentionProjectionRevision: acceptAttentionProjectionRevision,
+        acceptFocusProjectionRevision: acceptFocusProjectionRevision,
+        canApplyAttentionProjectionRevision: canApplyAttentionProjectionRevision,
+        canApplyFocusProjectionRevision: canApplyFocusProjectionRevision,
         canApplyProjectionRevision: canApplyProjectionRevision,
         commitProjectionRevision: commitProjectionRevision,
         findCurrentWorkspaceDiv: findCurrentWorkspaceDiv,

--- a/src/webview/webviewProjectScripts.js
+++ b/src/webview/webviewProjectScripts.js
@@ -258,16 +258,90 @@ function initProjects() {
         getArchiveAiSessionMessageType: aiSessionControls.getArchiveAiSessionMessageType,
         isAiSessionProvider: aiSessionControls.isAiSessionProvider,
     });
-    function syncActiveAiSessionProjectionDom() {
-        var focusedRow = document.querySelector(
-            '.codex-session-row[data-session-focused][data-session-provider][data-session-id]'
-        );
-        var provider = focusedRow && focusedRow.getAttribute('data-session-provider');
-        aiSessionControls.activeAiSessionTerminalState.provider =
-            aiSessionControls.isAiSessionProvider(provider) ? provider : null;
-        aiSessionControls.activeAiSessionTerminalState.sessionId = focusedRow
-            ? focusedRow.getAttribute('data-session-id') : null;
+    function syncActiveAiSessionProjectionDom(adoptRenderedFocus) {
+        if (adoptRenderedFocus !== false) {
+            var focusedRow = document.querySelector(
+                '.codex-session-row[data-session-focused][data-session-provider][data-session-id]'
+            );
+            var provider = focusedRow && focusedRow.getAttribute('data-session-provider');
+            aiSessionControls.activeAiSessionTerminalState.provider =
+                aiSessionControls.isAiSessionProvider(provider) ? provider : null;
+            aiSessionControls.activeAiSessionTerminalState.sessionId = focusedRow
+                ? focusedRow.getAttribute('data-session-id') : null;
+        } else {
+            var projectedFocusedRow = null;
+            document.querySelectorAll('.codex-session-row[data-session-id]').forEach(row => {
+                var focused = row.getAttribute('data-session-provider')
+                    === aiSessionControls.activeAiSessionTerminalState.provider
+                    && row.getAttribute('data-session-id')
+                    === aiSessionControls.activeAiSessionTerminalState.sessionId;
+                if (focused) projectedFocusedRow = row;
+                row.toggleAttribute(
+                    'data-session-focused',
+                    focused
+                );
+                var primaryAction = row.querySelector('.ai-session-primary-action');
+                if (primaryAction) {
+                    var actionState = focused ? 'conversation' : 'focus';
+                    var actionAriaLabel = primaryAction.getAttribute(
+                        'data-' + actionState + '-aria-label'
+                    );
+                    var actionTitle = primaryAction.getAttribute(
+                        'data-' + actionState + '-title'
+                    );
+                    if (actionAriaLabel) primaryAction.setAttribute('aria-label', actionAriaLabel);
+                    if (actionTitle) primaryAction.setAttribute('title', actionTitle);
+                }
+                var conversationHint = row.querySelector('.ai-session-open-conversation-hint');
+                if (focused && primaryAction && !conversationHint) {
+                    conversationHint = document.createElement('span');
+                    conversationHint.className = 'ai-session-open-conversation-hint';
+                    conversationHint.setAttribute('aria-hidden', 'true');
+                    conversationHint.textContent = '›';
+                    primaryAction.appendChild(conversationHint);
+                } else if (!focused && conversationHint) {
+                    conversationHint.remove();
+                }
+            });
+            if (projectedFocusedRow) {
+                projectedFocusedRow.scrollIntoView({ block: 'nearest' });
+            }
+        }
         aiSessionControls.syncActiveAiSessionTerminalDom();
+    }
+    function syncAiSessionAttentionProjectionDom(adoptRenderedAttention) {
+        if (adoptRenderedAttention !== false) return;
+        window.__agentPivotAttentionSessionEvents =
+            window.__agentPivotAttentionSessionEvents || {};
+        document.querySelectorAll(
+            '.codex-session-row[data-session-provider][data-session-id]'
+        ).forEach(row => {
+            var sessionKey = row.getAttribute('data-session-provider')
+                + ':' + row.getAttribute('data-session-id');
+            var eventIds = window.__agentPivotAttentionSessionEvents[sessionKey] || [];
+            row.toggleAttribute('data-session-needs-attention', eventIds.length > 0);
+            row.toggleAttribute('data-ai-session-attention', eventIds.length > 0);
+            if (eventIds.length) {
+                row.setAttribute('data-session-event-id', eventIds[0]);
+            } else {
+                row.removeAttribute('data-session-event-id');
+            }
+            var primaryAction = row.querySelector('.ai-session-primary-action');
+            var indicator = row.querySelector('.ai-session-attention-indicator');
+            if (eventIds.length && primaryAction && !indicator) {
+                indicator = document.createElement('span');
+                indicator.className = 'ai-session-attention-indicator';
+                indicator.title = 'AI session needs attention';
+                indicator.setAttribute('aria-label', 'AI session needs attention');
+                primaryAction.insertBefore(indicator, primaryAction.firstChild);
+            } else if (!eventIds.length && indicator) {
+                indicator.remove();
+            }
+        });
+    }
+    function syncAiSessionProjectionDom(adoptRenderedFocus, adoptRenderedAttention) {
+        syncActiveAiSessionProjectionDom(adoptRenderedFocus);
+        syncAiSessionAttentionProjectionDom(adoptRenderedAttention);
     }
     var aiSessionsUpdate = initProjectAiSessionsUpdate({
         batchAiSessionState: aiSessionControls.batchAiSessionState,
@@ -275,7 +349,7 @@ function initProjects() {
         getPendingAiSessionProviderSelectionProjectId: () => aiSessionControls.getPendingAiSessionProviderSelectionProjectId(),
         getSelectedAiSessionProviders: aiSessionControls.getSelectedAiSessionProviders,
         syncAiSessionBatchManagementDom: aiSessionControls.syncAiSessionBatchManagementDom,
-        syncActiveAiSessionProjectionDom: syncActiveAiSessionProjectionDom,
+        syncAiSessionProjectionDom: syncAiSessionProjectionDom,
         reconcilePendingAiSessionProviderSelectionDom: aiSessionControls.reconcilePendingAiSessionProviderSelectionDom,
         submitAiSessionProviderSelection: aiSessionControls.submitAiSessionProviderSelection,
         toggleCodexSessions: aiSessionControls.toggleCodexSessions,
@@ -457,12 +531,21 @@ function initProjects() {
         }
         if (message && message.type === 'open-workspaces-updated') {
             if (!aiSessionsUpdate.canApplyProjectionRevision(message.projectionRevision)) return;
+            var adoptOpenWorkspaceFocus = aiSessionsUpdate.canApplyFocusProjectionRevision(
+                message.projectionRevision
+            );
+            var adoptOpenWorkspaceAttention = aiSessionsUpdate.canApplyAttentionProjectionRevision(
+                message.projectionRevision
+            );
             if (!applyOpenWorkspacesUpdate(message)) {
                 aiSessionsUpdate.requestFullRefresh('invalid-open-workspaces-update');
                 return;
             }
             aiSessionsUpdate.commitProjectionRevision(message.projectionRevision);
-            syncActiveAiSessionProjectionDom();
+            syncAiSessionProjectionDom(
+                adoptOpenWorkspaceFocus,
+                adoptOpenWorkspaceAttention
+            );
             updateStickyGroupHeaderOffset();
             var renderedOpenWorkspaceState = getOpenWorkspacesUpdateDomState();
             window.vscode.postMessage({
@@ -498,15 +581,15 @@ function initProjects() {
         }
 
         if (message && message.type === 'active-ai-session-terminal-changed') {
-            if (!aiSessionsUpdate.acceptProjectionRevision(message.projectionRevision)) return;
+            if (!aiSessionsUpdate.acceptFocusProjectionRevision(message.projectionRevision)) return;
             aiSessionControls.activeAiSessionTerminalState.provider = aiSessionControls.isAiSessionProvider(message.provider) ? message.provider : null;
             aiSessionControls.activeAiSessionTerminalState.sessionId = typeof message.sessionId === 'string' ? message.sessionId : null;
-            aiSessionControls.syncActiveAiSessionTerminalDom();
+            syncActiveAiSessionProjectionDom(false);
             return;
         }
 
         if (message && message.type === 'ai-session-attention-state') {
-            if (!aiSessionsUpdate.acceptProjectionRevision(message.projectionRevision)) return;
+            if (!aiSessionsUpdate.acceptAttentionProjectionRevision(message.projectionRevision)) return;
             window.__agentPivotAttentionEvents = window.__agentPivotAttentionEvents || {};
             window.__agentPivotAttentionSessionEvents = {};
             (Array.isArray(message.sessionEvents) ? message.sessionEvents.slice(0, 1000) : []).forEach(session => {
@@ -521,6 +604,7 @@ function initProjects() {
             (message.eventIds || []).forEach(eventId => {
                 if (typeof eventId === 'string') window.__agentPivotAttentionEvents[eventId] = true;
             });
+            syncAiSessionAttentionProjectionDom(false);
             return;
         }
 

--- a/tests/browser/activeSessionCardInteraction.test.js
+++ b/tests/browser/activeSessionCardInteraction.test.js
@@ -410,6 +410,163 @@ test('ACTIVE-SESSION-FOCUS-REVEAL-001 reveals the newly focused card when a work
     assert.equal(await isRowFullyVisibleInList(row(page, 'codex', 'active-2')), true);
 });
 
+test('ACTIVE-SESSION-FOCUS-REVEAL-001 keeps a newer focus projection when an independent Attention message arrives first', async t => {
+    const page = await openCardPage(t, [
+        session('codex', 'session-a', true),
+        session('codex', 'session-b', false),
+    ]);
+    await postHostMessage(page, {
+        type: 'ai-session-attention-state',
+        projectionRevision: 2,
+        eventIds: [],
+        sessionEvents: [],
+    });
+    await postHostMessage(page, {
+        type: 'ai-sessions-updated',
+        version: 2,
+        sequence: 1,
+        projectionRevision: 1,
+        currentWorkspaceCount: 1,
+        html: `<div class="open-current-workspace-group">${projectMarkup([
+            session('codex', 'session-a', false),
+            session('codex', 'session-b', true),
+        ])}</div>`,
+        searchCatalog: {
+            version: 2,
+            sessions: [],
+            openWorkspaces: [],
+            savedProjects: [],
+            todos: [],
+        },
+    });
+
+    assert.equal(await row(page, 'codex', 'session-b').getAttribute('data-session-focused'), '');
+    assert.equal(
+        await row(page, 'codex', 'session-b').getAttribute('data-ai-session-active-terminal'),
+        ''
+    );
+    assert.equal(
+        await row(page, 'codex', 'session-a').getAttribute('data-ai-session-active-terminal'),
+        null
+    );
+
+    await postHostMessage(page, {
+        type: 'active-ai-session-terminal-changed',
+        projectionRevision: 4,
+        provider: 'codex',
+        sessionId: 'session-a',
+    });
+    await postHostMessage(page, {
+        type: 'ai-sessions-updated',
+        version: 2,
+        sequence: 3,
+        projectionRevision: 3,
+        currentWorkspaceCount: 1,
+        html: `<div class="open-current-workspace-group">${projectMarkup([
+            session('codex', 'session-a', false),
+            session('codex', 'session-b', true),
+        ])}</div>`,
+        searchCatalog: {
+            version: 2,
+            sessions: [],
+            openWorkspaces: [],
+            savedProjects: [],
+            todos: [],
+        },
+    });
+    assert.equal(await row(page, 'codex', 'session-a').getAttribute('data-session-focused'), '');
+    assert.equal(
+        await row(page, 'codex', 'session-a').getAttribute('data-ai-session-active-terminal'),
+        ''
+    );
+    assert.equal(
+        await row(page, 'codex', 'session-a').locator('.ai-session-open-conversation-hint').count(),
+        1
+    );
+    assert.equal(
+        await row(page, 'codex', 'session-b').locator('.ai-session-open-conversation-hint').count(),
+        0
+    );
+
+    await postHostMessage(page, {
+        type: 'ai-session-attention-state',
+        projectionRevision: 6,
+        eventIds: ['event-b'],
+        sessionEvents: [{ sessionKey: 'codex:session-b', eventIds: ['event-b'] }],
+    });
+    await postHostMessage(page, {
+        type: 'ai-sessions-updated',
+        version: 2,
+        sequence: 5,
+        projectionRevision: 5,
+        currentWorkspaceCount: 1,
+        html: `<div class="open-current-workspace-group">${projectMarkup([
+            session('codex', 'session-a', true),
+            session('codex', 'session-b', false),
+        ])}</div>`,
+        searchCatalog: {
+            version: 2,
+            sessions: [],
+            openWorkspaces: [],
+            savedProjects: [],
+            todos: [],
+        },
+    });
+    assert.equal(
+        await row(page, 'codex', 'session-b').getAttribute('data-ai-session-attention'),
+        ''
+    );
+    assert.equal(
+        await row(page, 'codex', 'session-b').getAttribute('data-session-event-id'),
+        'event-b'
+    );
+    assert.equal(
+        await row(page, 'codex', 'session-b').locator('.ai-session-attention-indicator').count(),
+        1
+    );
+});
+
+test('ACTIVE-SESSION-FOCUS-REVEAL-001 reveals a newer direct focus projection inside the bounded Active list', async t => {
+    const active = Array.from({ length: 8 }, (_, index) => session(
+        'codex', `active-${index + 1}`, index === 0
+    ));
+    const history = Array.from({ length: 8 }, (_, index) =>
+        historySession('codex', `history-${index + 1}`)
+    );
+    const page = await openListPage(t, active, history);
+    await waitForPageCondition(page, () => {
+        const list = document.querySelector('[data-ai-session-panel="active"] .codex-sessions-list');
+        return list && list.scrollHeight > list.clientHeight;
+    });
+    assert.equal(await isRowFullyVisibleInList(row(page, 'codex', 'active-7')), false);
+
+    await postHostMessage(page, {
+        type: 'active-ai-session-terminal-changed',
+        projectionRevision: 2,
+        provider: 'codex',
+        sessionId: 'active-7',
+    });
+
+    assert.equal(await row(page, 'codex', 'active-7').getAttribute('data-session-focused'), '');
+    assert.equal(await isRowFullyVisibleInList(row(page, 'codex', 'active-7')), true);
+    assert.equal(
+        await row(page, 'codex', 'active-7').locator('.ai-session-primary-action').getAttribute('title'),
+        'Open AI conversation for Codex Session'
+    );
+    assert.equal(
+        await row(page, 'codex', 'active-7').locator('.ai-session-primary-action').getAttribute('aria-label'),
+        'Open AI conversation for Codex session codex active-7'
+    );
+    assert.equal(
+        await row(page, 'codex', 'active-1').locator('.ai-session-primary-action').getAttribute('title'),
+        'Focus Codex Session'
+    );
+    assert.equal(
+        await row(page, 'codex', 'active-1').locator('.ai-session-primary-action').getAttribute('aria-label'),
+        'Focus Codex session codex active-1 using Direct VS Code terminal, attached'
+    );
+});
+
 test('ACTIVE-SESSION-FOCUS-REVEAL-001 scrolls the origin card into view when conversation focus returns to the sidebar', async t => {
     const active = Array.from({ length: 8 }, (_, index) => session(
         'codex', `active-${index + 1}`, index === 6

--- a/tests/contract/aiSessions/sessionQuickSwitch.test.js
+++ b/tests/contract/aiSessions/sessionQuickSwitch.test.js
@@ -16,8 +16,14 @@ const {
     createRunningSessionJumpHandler,
 } = require('../../../out/dashboard/runningSessionJump');
 const {
+    createAttentionQueueJumpHandler,
+} = require('../../../out/dashboard/attentionQueueJump');
+const {
     createSessionNavigationCoordinator,
 } = require('../../../out/dashboard/sessionNavigationCoordinator');
+const {
+    createSessionNavigationFocusExecutor,
+} = require('../../../out/dashboard/sessionNavigationFocusExecutor');
 
 const WINDOW_A = 'a'.repeat(64);
 const WINDOW_B = 'b'.repeat(64);
@@ -139,6 +145,16 @@ test('AI-SESSION-QUICK-SWITCH-COMMANDS-001 wires the MRU to a completion-indepen
         /navigateSession: \(target, executionOptions\) =>\s*sessionNavigationFocusExecutor\.execute\(target, executionOptions\)/
     );
     assert.match(source, /getFocusedSessionKey: \(\) => \{\s*const identity = getFocusedAiSessionIdentity\(\);/);
+    assert.match(
+        source,
+        /createSessionNavigationFocusExecutor\(\{[\s\S]*?onFocused: target =>\s*aiSessionMru\.record\(target\.provider, target\.sessionId\)/,
+        'every successful shared focus transaction must update Toggle Last synchronously'
+    );
+    assert.match(
+        source,
+        /followAdjacentActiveConversationWithFeedback[\s\S]*?result === 'opened'[\s\S]*?aiSessionMru\.record\(identity\.provider, identity\.sessionId\)/,
+        'Previous and Next Active Session must update Toggle Last synchronously'
+    );
 });
 
 test('AI-SESSION-QUICK-SWITCH-COMMANDS-001 tracker keeps a bounded deduplicated newest-first order', () => {
@@ -419,6 +435,94 @@ test('AI-SESSION-QUICK-SWITCH-COMMANDS-001 AI-SESSION-NEXT-RUNNING-COMMAND-001 r
 
     assert.deepEqual(settled, ['older', 'newer']);
     assert.equal(focusedKey, 'codex:newer');
+});
+
+test('AI-SESSION-QUICK-SWITCH-COMMANDS-001 ATTENTION-STATUS-BAR-QUEUE-001 alternates immediately after Attention navigation without waiting for focus sampling', async () => {
+    const coordinator = createSessionNavigationCoordinator();
+    const mru = makeMru(['codex:session-a']);
+    let focusedKey = 'codex:session-a';
+    let terminal = 'session-a';
+    let conversation = 'session-a';
+    const executor = createSessionNavigationFocusExecutor({
+        getProjectId: () => 'project-a',
+        focusActive: async (_projectId, provider, sessionId) => {
+            terminal = sessionId;
+            focusedKey = `${provider}:${sessionId}`;
+            return true;
+        },
+        openConversation: async target => {
+            conversation = target.sessionId;
+            return true;
+        },
+        onFocused: target => mru.record(target.provider, target.sessionId),
+    });
+    const attention = createAttentionQueueJumpHandler({
+        navigationCoordinator: coordinator,
+        buildQueue: () => ({
+            items: [{
+                provider: 'codex', sessionId: 'session-b', projectId: 'project-a',
+                eventIds: ['event-b'], reasons: ['completed'], observedAtMs: 1, local: true,
+            }],
+            localCount: 1,
+            remoteCount: 0,
+            total: 1,
+        }),
+        navigateSession: (target, executionOptions) =>
+            executor.execute(target, executionOptions),
+        acknowledge: async () => {},
+        shouldAcknowledge: () => false,
+        findNavigationCardId: () => null,
+        openNavigationCard: async () => {},
+        showInformationMessage: () => {},
+        showWarningMessage: () => {},
+        getCurrentIdentity: () => {
+            const separator = focusedKey.indexOf(':');
+            return {
+                provider: focusedKey.slice(0, separator),
+                sessionId: focusedKey.slice(separator + 1),
+            };
+        },
+    });
+    const messages = [];
+    const toggle = createAiSessionQuickSwitchHandlers({
+        navigationCoordinator: coordinator,
+        getLocalSessions: () => [
+            session('codex', 'session-a'),
+            session('codex', 'session-b'),
+        ],
+        getRemoteWindows: () => [],
+        getFocusedSessionKey: () => focusedKey,
+        mru,
+        showPick: async () => undefined,
+        navigateSession: (target, executionOptions) =>
+            executor.execute(target, executionOptions),
+        requestRemoteFocus: async () => false,
+        openNavigationCard: async () => {},
+        showInformationMessage: message => messages.push(message),
+        showWarningMessage: () => {},
+    });
+
+    await attention();
+    await toggle.toggleLastAiSession();
+    await toggle.toggleLastAiSession();
+
+    assert.deepEqual({ terminal, conversation, focusedKey }, {
+        terminal: 'session-b',
+        conversation: 'session-b',
+        focusedKey: 'codex:session-b',
+    });
+    assert.deepEqual(messages, []);
+
+    for (let index = 0; index < 100; index += 1) {
+        await toggle.toggleLastAiSession();
+        const expected = index % 2 === 0 ? 'session-a' : 'session-b';
+        assert.deepEqual({ terminal, conversation, focusedKey }, {
+            terminal: expected,
+            conversation: expected,
+            focusedKey: `codex:${expected}`,
+        });
+    }
+    assert.deepEqual(messages, []);
 });
 
 test('AI-SESSION-QUICK-SWITCH-COMMANDS-001 toggle prunes dead sessions and reports an empty history', async () => {


### PR DESCRIPTION
## Summary

- record every successful shared AI session focus immediately so Attention, Running, Previous/Next, and Toggle Last commands share current MRU state without waiting for polling
- track content, focus, and Attention projection revisions independently so out-of-order partial updates cannot overwrite or discard newer UI state
- keep directly focused cards visible and synchronize their visual hint, click action, title, and accessible label
- add rapid-toggle and real-browser regression coverage for projection ordering, bounded-list reveal, and repeated navigation

## Skill harvest

no skill change — the existing regression, review, and Webview verification skills already require RED-first reproduction, real consumer coverage, full integration review, and fresh CI; this task exposed product races rather than a reusable workflow gap

## Verification

- `npm run test-compile`
- 94 focused Attention, Running Session, and Quick Switch contract tests
- 9 focused Active Session browser interaction tests
- `node scripts/run-ai-session-safety-checks.js`
- `node scripts/run-dashboard-webview-checks.js`
- `npm run lint`
- `npm run test:behavior-contracts`
- `npm run test:ci:linux`
- changed line coverage: 100.00% (14/14)
- packaged and byte-verified `agent-pivot-1.1.0.vsix` in the active VS Code Server host
