### PR TITLE
Fix stale attention projection during session switching

### DIFF
--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "6cfca9f8c5e127ee675bd217eaaa7cdf92d39032",
+        "head": "94bb7eb3c9881f960a04567bfaea8010fae538e2",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -245,7 +245,8 @@
             "a760309127206890f64a3fa5e1439e75261f067e",
             "3363eb2837186021d1342c708533e1636ad080d5",
             "d9187a4aa59e8c81a4b906732164f4425a0c1ac0",
-            "49a6d3494a6d88b7e31f16bd2183b177ec19e07f"
+            "49a6d3494a6d88b7e31f16bd2183b177ec19e07f",
+            "258e6f3b76492528a4ca798842dfb448cd6f6e77"
         ]
     },
     "capabilities": [
@@ -550,7 +551,8 @@
                 "c96f1b291f18ce611c100ccdf62e97610d5fe01d",
                 "c36c1862eca52f445d217c8d353f1b115f1ea74a",
                 "4da8c5f062d86ea3812752b8c5827f63585274d0",
-                "6cfca9f8c5e127ee675bd217eaaa7cdf92d39032"
+                "6cfca9f8c5e127ee675bd217eaaa7cdf92d39032",
+                "94bb7eb3c9881f960a04567bfaea8010fae538e2"
             ],
             "behaviors": [
                 "ATTENTION-ATTENTION-PROJECTION-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "660ab41e2ff0da8f0c4b0f0abeed8a2a97ee87e1",
+        "head": "6cfca9f8c5e127ee675bd217eaaa7cdf92d39032",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -244,7 +244,8 @@
             "2c5f31a95dbd671b637cf5013789826ed1bedb10",
             "a760309127206890f64a3fa5e1439e75261f067e",
             "3363eb2837186021d1342c708533e1636ad080d5",
-            "d9187a4aa59e8c81a4b906732164f4425a0c1ac0"
+            "d9187a4aa59e8c81a4b906732164f4425a0c1ac0",
+            "49a6d3494a6d88b7e31f16bd2183b177ec19e07f"
         ]
     },
     "capabilities": [
@@ -548,7 +549,8 @@
                 "1408a8ba6970a622e5657364dac9df59b09f6b3e",
                 "c96f1b291f18ce611c100ccdf62e97610d5fe01d",
                 "c36c1862eca52f445d217c8d353f1b115f1ea74a",
-                "4da8c5f062d86ea3812752b8c5827f63585274d0"
+                "4da8c5f062d86ea3812752b8c5827f63585274d0",
+                "6cfca9f8c5e127ee675bd217eaaa7cdf92d39032"
             ],
             "behaviors": [
                 "ATTENTION-ATTENTION-PROJECTION-001",

--- a/media/webviewDashboardBundle.js
+++ b/media/webviewDashboardBundle.js
@@ -1688,6 +1688,10 @@ function initProjectAiSessionsUpdate(options) {
     var latestAiSessionProjectionRevision = 0;
     var latestAiSessionFocusProjectionRevision = 0;
     var latestAiSessionAttentionProjectionRevision = 0;
+    // Rendered HTML bootstraps attention only until the dedicated stream arrives.
+    // Later content replacements can carry an older snapshot with a newer delivery
+    // revision, so they must preserve the direct stream instead of reviving stale dots.
+    var hasDirectAiSessionAttentionProjection = false;
 
     function canApplyRevision(revision, latestRevision) {
         if (typeof revision === 'undefined') {
@@ -1707,20 +1711,25 @@ function initProjectAiSessionsUpdate(options) {
     }
 
     function canApplyAttentionProjectionRevision(revision) {
-        return canApplyRevision(revision, latestAiSessionAttentionProjectionRevision);
+        return !hasDirectAiSessionAttentionProjection
+            && canApplyRevision(revision, latestAiSessionAttentionProjectionRevision);
     }
 
-    function commitProjectionRevision(revision) {
+    function commitProjectionRevision(revision, adoptedFocus, adoptedAttention) {
         if (Number.isSafeInteger(revision) && revision > 0) {
             latestAiSessionProjectionRevision = revision;
-            latestAiSessionFocusProjectionRevision = Math.max(
-                latestAiSessionFocusProjectionRevision,
-                revision
-            );
-            latestAiSessionAttentionProjectionRevision = Math.max(
-                latestAiSessionAttentionProjectionRevision,
-                revision
-            );
+            if (adoptedFocus) {
+                latestAiSessionFocusProjectionRevision = Math.max(
+                    latestAiSessionFocusProjectionRevision,
+                    revision
+                );
+            }
+            if (adoptedAttention) {
+                latestAiSessionAttentionProjectionRevision = Math.max(
+                    latestAiSessionAttentionProjectionRevision,
+                    revision
+                );
+            }
         }
     }
 
@@ -1735,9 +1744,10 @@ function initProjectAiSessionsUpdate(options) {
     }
 
     function acceptAttentionProjectionRevision(revision) {
-        if (!canApplyAttentionProjectionRevision(revision)) {
+        if (!canApplyRevision(revision, latestAiSessionAttentionProjectionRevision)) {
             return false;
         }
+        hasDirectAiSessionAttentionProjection = true;
         if (Number.isSafeInteger(revision) && revision > 0) {
             latestAiSessionAttentionProjectionRevision = revision;
         }
@@ -1782,7 +1792,11 @@ function initProjectAiSessionsUpdate(options) {
         }
 
         latestAiSessionUpdateSequence = message.sequence;
-        commitProjectionRevision(message.projectionRevision);
+        commitProjectionRevision(
+            message.projectionRevision,
+            adoptRenderedFocus,
+            adoptRenderedAttention
+        );
         if (batchAiSessionState.projectId) {
             var projectDiv = findCurrentWorkspaceDiv(batchAiSessionState.projectId);
             if (projectDiv) {
@@ -3167,7 +3181,11 @@ function initProjects() {
                 aiSessionsUpdate.requestFullRefresh('invalid-open-workspaces-update');
                 return;
             }
-            aiSessionsUpdate.commitProjectionRevision(message.projectionRevision);
+            aiSessionsUpdate.commitProjectionRevision(
+                message.projectionRevision,
+                adoptOpenWorkspaceFocus,
+                adoptOpenWorkspaceAttention
+            );
             syncAiSessionProjectionDom(
                 adoptOpenWorkspaceFocus,
                 adoptOpenWorkspaceAttention

--- a/media/webviewProjectAiUpdateScripts.js
+++ b/media/webviewProjectAiUpdateScripts.js
@@ -20,6 +20,10 @@ function initProjectAiSessionsUpdate(options) {
     var latestAiSessionProjectionRevision = 0;
     var latestAiSessionFocusProjectionRevision = 0;
     var latestAiSessionAttentionProjectionRevision = 0;
+    // Rendered HTML bootstraps attention only until the dedicated stream arrives.
+    // Later content replacements can carry an older snapshot with a newer delivery
+    // revision, so they must preserve the direct stream instead of reviving stale dots.
+    var hasDirectAiSessionAttentionProjection = false;
 
     function canApplyRevision(revision, latestRevision) {
         if (typeof revision === 'undefined') {
@@ -39,20 +43,25 @@ function initProjectAiSessionsUpdate(options) {
     }
 
     function canApplyAttentionProjectionRevision(revision) {
-        return canApplyRevision(revision, latestAiSessionAttentionProjectionRevision);
+        return !hasDirectAiSessionAttentionProjection
+            && canApplyRevision(revision, latestAiSessionAttentionProjectionRevision);
     }
 
-    function commitProjectionRevision(revision) {
+    function commitProjectionRevision(revision, adoptedFocus, adoptedAttention) {
         if (Number.isSafeInteger(revision) && revision > 0) {
             latestAiSessionProjectionRevision = revision;
-            latestAiSessionFocusProjectionRevision = Math.max(
-                latestAiSessionFocusProjectionRevision,
-                revision
-            );
-            latestAiSessionAttentionProjectionRevision = Math.max(
-                latestAiSessionAttentionProjectionRevision,
-                revision
-            );
+            if (adoptedFocus) {
+                latestAiSessionFocusProjectionRevision = Math.max(
+                    latestAiSessionFocusProjectionRevision,
+                    revision
+                );
+            }
+            if (adoptedAttention) {
+                latestAiSessionAttentionProjectionRevision = Math.max(
+                    latestAiSessionAttentionProjectionRevision,
+                    revision
+                );
+            }
         }
     }
 
@@ -67,9 +76,10 @@ function initProjectAiSessionsUpdate(options) {
     }
 
     function acceptAttentionProjectionRevision(revision) {
-        if (!canApplyAttentionProjectionRevision(revision)) {
+        if (!canApplyRevision(revision, latestAiSessionAttentionProjectionRevision)) {
             return false;
         }
+        hasDirectAiSessionAttentionProjection = true;
         if (Number.isSafeInteger(revision) && revision > 0) {
             latestAiSessionAttentionProjectionRevision = revision;
         }
@@ -114,7 +124,11 @@ function initProjectAiSessionsUpdate(options) {
         }
 
         latestAiSessionUpdateSequence = message.sequence;
-        commitProjectionRevision(message.projectionRevision);
+        commitProjectionRevision(
+            message.projectionRevision,
+            adoptRenderedFocus,
+            adoptRenderedAttention
+        );
         if (batchAiSessionState.projectId) {
             var projectDiv = findCurrentWorkspaceDiv(batchAiSessionState.projectId);
             if (projectDiv) {

--- a/media/webviewProjectScripts.js
+++ b/media/webviewProjectScripts.js
@@ -541,7 +541,11 @@ function initProjects() {
                 aiSessionsUpdate.requestFullRefresh('invalid-open-workspaces-update');
                 return;
             }
-            aiSessionsUpdate.commitProjectionRevision(message.projectionRevision);
+            aiSessionsUpdate.commitProjectionRevision(
+                message.projectionRevision,
+                adoptOpenWorkspaceFocus,
+                adoptOpenWorkspaceAttention
+            );
             syncAiSessionProjectionDom(
                 adoptOpenWorkspaceFocus,
                 adoptOpenWorkspaceAttention

--- a/scripts/run-ai-session-safety-checks.js
+++ b/scripts/run-ai-session-safety-checks.js
@@ -7102,13 +7102,13 @@ function runBatchAiSessionWebviewChecks() {
     windowEventListeners.message({ data: {
         type: 'ai-session-attention-state',
         projectionRevision: 1,
-        eventIds: ['stale-event'],
+        eventIds: ['newer-direct-event'],
         sessionEvents: [],
     } });
-    assert.strictEqual(context.window.__agentPivotAttentionEvents['stale-event'], undefined,
-        'a stale attention message must not override a newer rendered session projection');
+    assert.strictEqual(context.window.__agentPivotAttentionEvents['newer-direct-event'], true,
+        'a rendered content revision must not suppress the independent direct attention stream');
     assert.strictEqual(context.window.__agentPivotAttentionEvents['existing-event'], true,
-        'rejecting stale attention must preserve the last accepted attention projection');
+        'accepting the next direct attention projection must preserve known event identities');
 
     const manager = context.window.__agentPivotBatchAiSessions;
     manager.enter('project-a');

--- a/src/aiSessions/attentionController.ts
+++ b/src/aiSessions/attentionController.ts
@@ -315,11 +315,9 @@ export class AiSessionAttentionController<TRuntime extends AiSessionAttentionRun
             bySession.set(sessionKey, eventIds);
         };
 
-        Object.entries(this.monitor.getSnapshot()).forEach(([sessionKey, snapshot]) => {
-            if (snapshot.state === 'needsAttention' && snapshot.event?.eventId) {
-                addEvent(this.getLogicalSessionKey(sessionKey), snapshot.event.eventId);
-            }
-        });
+        // The effective aggregate is the sole UI authority. Reading the monitor
+        // directly here used to resurrect historical completion events that a
+        // peer window had already acknowledged in the bridge aggregate.
         this.getEffectiveAggregate().sessions.forEach(session => {
             session.eventIds.forEach(eventId => addEvent(
                 this.getLogicalSessionKey(session.sessionKey),

--- a/src/webview/webviewProjectAiUpdateScripts.js
+++ b/src/webview/webviewProjectAiUpdateScripts.js
@@ -20,6 +20,10 @@ function initProjectAiSessionsUpdate(options) {
     var latestAiSessionProjectionRevision = 0;
     var latestAiSessionFocusProjectionRevision = 0;
     var latestAiSessionAttentionProjectionRevision = 0;
+    // Rendered HTML bootstraps attention only until the dedicated stream arrives.
+    // Later content replacements can carry an older snapshot with a newer delivery
+    // revision, so they must preserve the direct stream instead of reviving stale dots.
+    var hasDirectAiSessionAttentionProjection = false;
 
     function canApplyRevision(revision, latestRevision) {
         if (typeof revision === 'undefined') {
@@ -39,20 +43,25 @@ function initProjectAiSessionsUpdate(options) {
     }
 
     function canApplyAttentionProjectionRevision(revision) {
-        return canApplyRevision(revision, latestAiSessionAttentionProjectionRevision);
+        return !hasDirectAiSessionAttentionProjection
+            && canApplyRevision(revision, latestAiSessionAttentionProjectionRevision);
     }
 
-    function commitProjectionRevision(revision) {
+    function commitProjectionRevision(revision, adoptedFocus, adoptedAttention) {
         if (Number.isSafeInteger(revision) && revision > 0) {
             latestAiSessionProjectionRevision = revision;
-            latestAiSessionFocusProjectionRevision = Math.max(
-                latestAiSessionFocusProjectionRevision,
-                revision
-            );
-            latestAiSessionAttentionProjectionRevision = Math.max(
-                latestAiSessionAttentionProjectionRevision,
-                revision
-            );
+            if (adoptedFocus) {
+                latestAiSessionFocusProjectionRevision = Math.max(
+                    latestAiSessionFocusProjectionRevision,
+                    revision
+                );
+            }
+            if (adoptedAttention) {
+                latestAiSessionAttentionProjectionRevision = Math.max(
+                    latestAiSessionAttentionProjectionRevision,
+                    revision
+                );
+            }
         }
     }
 
@@ -67,9 +76,10 @@ function initProjectAiSessionsUpdate(options) {
     }
 
     function acceptAttentionProjectionRevision(revision) {
-        if (!canApplyAttentionProjectionRevision(revision)) {
+        if (!canApplyRevision(revision, latestAiSessionAttentionProjectionRevision)) {
             return false;
         }
+        hasDirectAiSessionAttentionProjection = true;
         if (Number.isSafeInteger(revision) && revision > 0) {
             latestAiSessionAttentionProjectionRevision = revision;
         }
@@ -114,7 +124,11 @@ function initProjectAiSessionsUpdate(options) {
         }
 
         latestAiSessionUpdateSequence = message.sequence;
-        commitProjectionRevision(message.projectionRevision);
+        commitProjectionRevision(
+            message.projectionRevision,
+            adoptRenderedFocus,
+            adoptRenderedAttention
+        );
         if (batchAiSessionState.projectId) {
             var projectDiv = findCurrentWorkspaceDiv(batchAiSessionState.projectId);
             if (projectDiv) {

--- a/src/webview/webviewProjectScripts.js
+++ b/src/webview/webviewProjectScripts.js
@@ -541,7 +541,11 @@ function initProjects() {
                 aiSessionsUpdate.requestFullRefresh('invalid-open-workspaces-update');
                 return;
             }
-            aiSessionsUpdate.commitProjectionRevision(message.projectionRevision);
+            aiSessionsUpdate.commitProjectionRevision(
+                message.projectionRevision,
+                adoptOpenWorkspaceFocus,
+                adoptOpenWorkspaceAttention
+            );
             syncAiSessionProjectionDom(
                 adoptOpenWorkspaceFocus,
                 adoptOpenWorkspaceAttention

--- a/tests/browser/activeSessionCardInteraction.test.js
+++ b/tests/browser/activeSessionCardInteraction.test.js
@@ -526,6 +526,84 @@ test('ACTIVE-SESSION-FOCUS-REVEAL-001 keeps a newer focus projection when an ind
     );
 });
 
+test('ACTIVE-SESSION-ATTENTION-PROJECTION-001 never flashes stale attention during a window-switch projection', async t => {
+    const active = [
+        session('codex', 'session-a', false),
+        session('codex', 'session-b', true),
+        session('codex', 'session-c', false),
+    ];
+    const page = await openCardPage(t, active);
+    await postHostMessage(page, {
+        type: 'ai-session-attention-state',
+        projectionRevision: 2,
+        eventIds: ['event-b'],
+        sessionEvents: [{ sessionKey: 'codex:session-b', eventIds: ['event-b'] }],
+    });
+    await page.evaluate(() => {
+        window.__attentionProjectionSnapshots = [];
+        const recordAttentionProjection = () => {
+            window.__attentionProjectionSnapshots.push(Array.from(document.querySelectorAll(
+                '.active-ai-session-row[data-ai-session-attention][data-session-id]'
+            ), candidate => candidate.getAttribute('data-session-id')).sort());
+        };
+        window.__attentionProjectionObserver = new MutationObserver(recordAttentionProjection);
+        window.__attentionProjectionObserver.observe(
+            document.querySelector('.sticky-groups-wrapper'),
+            { attributes: true, childList: true, subtree: true }
+        );
+    });
+
+    const staleAttention = active.map(entry => ({
+        ...entry,
+        needsAttention: true,
+        attentionEventId: `stale-${entry.sessionId}`,
+    }));
+    await postHostMessage(page, {
+        type: 'open-workspaces-updated',
+        version: 2,
+        projectionRevision: 4,
+        semanticRevision: 'stale-window-switch-attention',
+        currentWorkspaceCount: 1,
+        navigationWorkspaceCount: 0,
+        otherWindowsStatus: 'ready',
+        html: `<div class="open-current-workspace-group">${projectMarkup(staleAttention)}</div>
+            <div class="open-other-windows-group" data-other-windows-status="ready">
+                ${currentOpenWorkspaceProjectMarkup()}
+            </div>`,
+        searchCatalog: {
+            version: 2,
+            sessions: [],
+            openWorkspaces: [{ identity: 'project-a' }],
+            savedProjects: [],
+            todos: [],
+        },
+    });
+    await page.evaluate(() => new Promise(resolve => requestAnimationFrame(resolve)));
+    await postHostMessage(page, {
+        type: 'ai-session-attention-state',
+        projectionRevision: 3,
+        eventIds: ['event-c'],
+        sessionEvents: [{ sessionKey: 'codex:session-c', eventIds: ['event-c'] }],
+    });
+    await page.evaluate(() => new Promise(resolve => requestAnimationFrame(resolve)));
+
+    const snapshots = await page.evaluate(() => {
+        window.__attentionProjectionObserver.disconnect();
+        return window.__attentionProjectionSnapshots;
+    });
+    assert.ok(snapshots.length > 0);
+    assert.deepEqual(
+        snapshots.filter(snapshot => snapshot.join(',') !== 'session-b'
+            && snapshot.join(',') !== 'session-c'),
+        [],
+        `stale attention became observable: ${JSON.stringify(snapshots)}`
+    );
+    assert.equal(
+        await row(page, 'codex', 'session-c').locator('.ai-session-attention-indicator').count(),
+        1
+    );
+});
+
 test('ACTIVE-SESSION-FOCUS-REVEAL-001 reveals a newer direct focus projection inside the bounded Active list', async t => {
     const active = Array.from({ length: 8 }, (_, index) => session(
         'codex', `active-${index + 1}`, index === 0

--- a/tests/contract/aiSessions/attention.test.js
+++ b/tests/contract/aiSessions/attention.test.js
@@ -1320,6 +1320,8 @@ test('ATTENTION-BRIDGE-STALENESS-001 never resurrects a dot another window ackno
 
     assert.deepEqual(f.dotSessions(), [],
         'a cross-window acknowledgement must stay acknowledged');
+    assert.deepEqual(f.controller.getRecoverySessionEvents(), [],
+        'the direct Webview projection must not bypass the authoritative aggregate');
 });
 
 test('ATTENTION-BRIDGE-STALENESS-001 leaves sessions owned by other windows untouched', async () => {


### PR DESCRIPTION
## Summary
- keep the dedicated attention projection authoritative across asynchronous workspace HTML replacement
- prevent cross-window acknowledged completion events from being replayed by the local recovery projection
- add browser and controller regressions for stale attention flashes and aggregate authority

## Verification
- npm run test:ci:linux
- manual multi-window Next Attention Session verification
- installed VSIX byte verification against the active VS Code Server

## Skill harvest
No skill change was justified. The regression workflow already requires a RED user-visible test, final verification, and review; the remaining lesson is product-specific projection protocol design and is covered by the follow-up architecture refactor.