### PR TITLE
Fix session runtime continuity and conversation recovery

### DIFF
--- a/.skills/developing-provider-conversation-adapters/SKILL.md
+++ b/.skills/developing-provider-conversation-adapters/SKILL.md
@@ -21,6 +21,9 @@ Green self-authored fixtures alone are not evidence.
    docs, or a sibling provider's layout:
    - census record shapes: `type` distribution, field presence per record
      kind, single-record size bounds
+   - for a framed protocol, record the sanitized full response byte size and
+     duration of a valid large live response, verify it remains below a
+     bounded transport cap, and never infer response size from source-file size
    - find lifecycle markers (start / finish / interrupt) and cross-file
      links (toolUseId, promptId, sidechain flags)
    - detect continuation records (distinct promptIds, injected user turns)

--- a/docs/superpowers/specs/2026-07-25-active-session-conversation-outline-design.md
+++ b/docs/superpowers/specs/2026-07-25-active-session-conversation-outline-design.md
@@ -728,7 +728,7 @@ authoritative update.
   payload. The viewer retains at most 100 interactions or 4 MiB, whichever is
   reached first, evicting the farthest page while preserving the selected
   anchor.
-- One Codex app-server response is capped at 16 MiB and every request has a
+- One Codex app-server response is capped at 64 MiB and every request has a
   ten-second deadline.
 - Each provider retains at most eight inactive session indexes for ten minutes.
   There is one shared provider poller per extension host and one ref-counted

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -1272,6 +1272,10 @@
       "tests/contract/aiSessions/runtimeSettlement.test.js"
     ,
       "tests/contract/aiSessions/attentionEventCapability.test.js"
+    ,
+      "tests/integration/dashboard/attentionRendering.test.js"
+    ,
+      "tests/browser/activeSessionCardInteraction.test.js"
     ],
     "evidence": [
       "src/aiSessions/attentionEvaluationQueue.ts",

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -4023,13 +4023,16 @@
       "tests/integration/dashboard/sessionCardInteraction.test.js",
       "tests/integration/dashboard/webviewState.test.js",
       "tests/integration/dashboard/conversationRouting.test.js",
-      "tests/browser/activeSessionCardInteraction.test.js"
+      "tests/browser/activeSessionCardInteraction.test.js",
+      "tests/contract/aiSessions/codexAppServerClient.test.js"
     ],
     "evidence": [
       "src/webview/webviewContent.ts",
       "src/webview/webviewProjectScripts.js",
       "src/dashboard.ts",
-      "src/aiSessions/conversation/composition.ts"
+      "src/aiSessions/conversation/composition.ts",
+      "src/aiSessions/conversation/codexAppServerClient.ts",
+      "src/aiSessions/conversation/types.ts"
     ]
   },
   {

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -4062,6 +4062,24 @@
     ]
   },
   {
+    "id": "RUNTIME-WORKSPACE-TOPOLOGY-CONTINUITY-001",
+    "domain": "runtime",
+    "title": "Active Session and attention actions survive workspace root additions and removals",
+    "priority": "P0",
+    "status": "automated",
+    "owners": [
+      "tests/integration/dashboard/sessionRuntimeFlow.test.js",
+      "tests/contract/aiSessions/attentionEventCapability.test.js"
+    ],
+    "evidence": [
+      "src/workspaces/runtimeOwnership.ts",
+      "src/workspaces/sessionHydration.ts",
+      "src/aiSessions/terminalCommandController.ts",
+      "src/aiSessions/attentionEventCapability.ts",
+      "src/dashboard.ts"
+    ]
+  },
+  {
     "id": "WEBVIEW-PROJECTS-PANEL-SCROLL-001",
     "domain": "webview",
     "title": "Required Projects panel replacement preserves semantic group-list and Dashboard positions",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "f45c91eb03a0dd604ea8cc3b667b4972327a1efa",
+        "head": "5a6571198bc5c396db1fbd2ac45ae12c26f1a1b1",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -250,7 +250,8 @@
             "91c9ca51ea7e3fdd0500f4ea1f14f2f233039839",
             "dbf89c05a5b34dfcaabb1daf9aa5f1e28f76cdb9",
             "1e47d70675ea31304f5cc6394fed4fb9955037e3",
-            "643e0775788e7da09b914cc7b7526bb3909ff3db"
+            "643e0775788e7da09b914cc7b7526bb3909ff3db",
+            "7ab84c7fb628f73041909c12f3055124e4cca81c"
         ]
     },
     "capabilities": [
@@ -886,7 +887,8 @@
                 "16dc36ed5da9f6ba589fb8b748f723056657bcef",
                 "f3e53a32c81c87dc0df919c8f0d3355c37ca69fb",
                 "687e3f6959ffce62db59daed3fc785a78a284ed1",
-                "f45c91eb03a0dd604ea8cc3b667b4972327a1efa"
+                "f45c91eb03a0dd604ea8cc3b667b4972327a1efa",
+                "5a6571198bc5c396db1fbd2ac45ae12c26f1a1b1"
             ],
             "behaviors": [
                 "ATTENTION-ACTIVE-UNREGISTER-ON-DEACTIVATE-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "2867df3c5ac0cd2ee69e6cb6d91fde9f53e26369",
+        "head": "48ecf9d5e2127ab94879a7a899789892881b7fe5",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -247,7 +247,8 @@
             "d9187a4aa59e8c81a4b906732164f4425a0c1ac0",
             "49a6d3494a6d88b7e31f16bd2183b177ec19e07f",
             "258e6f3b76492528a4ca798842dfb448cd6f6e77",
-            "91c9ca51ea7e3fdd0500f4ea1f14f2f233039839"
+            "91c9ca51ea7e3fdd0500f4ea1f14f2f233039839",
+            "dbf89c05a5b34dfcaabb1daf9aa5f1e28f76cdb9"
         ]
     },
     "capabilities": [
@@ -701,7 +702,8 @@
                 "fcc2af40ea5c3a4941dfe13be97e16c9a0c10b20",
                 "91094fccf74d20e553514ebfbb3705be7c5c1556",
                 "b388dee9464be7e0ac6850cd12c3a943b5868f3b",
-                "9c6a7223c606f3cdaaa2e3a3ef6f9a38f239a7c2"
+                "9c6a7223c606f3cdaaa2e3a3ef6f9a38f239a7c2",
+                "48ecf9d5e2127ab94879a7a899789892881b7fe5"
             ],
             "behaviors": [
                 "RELEASE-VSIX-PACKAGING-001",
@@ -1506,7 +1508,8 @@
                 "b012cd88e557d70cc0d459727c71cccbc4acc3f8",
                 "2390fc13ca86aeadd6c470a92bbff673855f4310",
                 "17cf2c716dbf8b28e2f95c5f6a5de1dc14452c68",
-                "1cd090c4fcd84dd94b28f5a26117c6525958572c"
+                "1cd090c4fcd84dd94b28f5a26117c6525958572c",
+                "7f160387ab60ba5d22730b7be8978b10ae6fa949"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "b55f68c5d67b705d3f0edabc01183788f5146b2a",
+        "head": "f45c91eb03a0dd604ea8cc3b667b4972327a1efa",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -249,7 +249,8 @@
             "258e6f3b76492528a4ca798842dfb448cd6f6e77",
             "91c9ca51ea7e3fdd0500f4ea1f14f2f233039839",
             "dbf89c05a5b34dfcaabb1daf9aa5f1e28f76cdb9",
-            "1e47d70675ea31304f5cc6394fed4fb9955037e3"
+            "1e47d70675ea31304f5cc6394fed4fb9955037e3",
+            "643e0775788e7da09b914cc7b7526bb3909ff3db"
         ]
     },
     "capabilities": [
@@ -884,7 +885,8 @@
                 "b3af83ee68f9eac78dcf7c0f49d6401494b1884c",
                 "16dc36ed5da9f6ba589fb8b748f723056657bcef",
                 "f3e53a32c81c87dc0df919c8f0d3355c37ca69fb",
-                "687e3f6959ffce62db59daed3fc785a78a284ed1"
+                "687e3f6959ffce62db59daed3fc785a78a284ed1",
+                "f45c91eb03a0dd604ea8cc3b667b4972327a1efa"
             ],
             "behaviors": [
                 "ATTENTION-ACTIVE-UNREGISTER-ON-DEACTIVATE-001",
@@ -902,7 +904,8 @@
                 "PERSIST-LIFECYCLE-PARSER-001"
             ],
             "prGates": [
-                "test:deterministic:run"
+                "test:deterministic:run",
+                "test:ci:linux"
             ],
             "scheduledJobs": [],
             "realEnvironmentRequired": false

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "48ecf9d5e2127ab94879a7a899789892881b7fe5",
+        "head": "b55f68c5d67b705d3f0edabc01183788f5146b2a",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -248,7 +248,8 @@
             "49a6d3494a6d88b7e31f16bd2183b177ec19e07f",
             "258e6f3b76492528a4ca798842dfb448cd6f6e77",
             "91c9ca51ea7e3fdd0500f4ea1f14f2f233039839",
-            "dbf89c05a5b34dfcaabb1daf9aa5f1e28f76cdb9"
+            "dbf89c05a5b34dfcaabb1daf9aa5f1e28f76cdb9",
+            "1e47d70675ea31304f5cc6394fed4fb9955037e3"
         ]
     },
     "capabilities": [
@@ -1189,7 +1190,8 @@
                 "a9ab1f23959547152581dd031c131a9ff21acc82",
                 "09932f96ba19f74b57eb2ddffa482b182d32fee5",
                 "c79183114269860b29eec03d0d316899072b16b9",
-                "0b06155e7043d14ece0d17ca682d09c6c0d8bdcb"
+                "0b06155e7043d14ece0d17ca682d09c6c0d8bdcb",
+                "b55f68c5d67b705d3f0edabc01183788f5146b2a"
             ],
             "behaviors": [
                 "ARCH-CI-QUALITY-GATE-001",
@@ -1509,7 +1511,8 @@
                 "2390fc13ca86aeadd6c470a92bbff673855f4310",
                 "17cf2c716dbf8b28e2f95c5f6a5de1dc14452c68",
                 "1cd090c4fcd84dd94b28f5a26117c6525958572c",
-                "7f160387ab60ba5d22730b7be8978b10ae6fa949"
+                "7f160387ab60ba5d22730b7be8978b10ae6fa949",
+                "a9c981442fa9166f9a34ec2f9ea832f5ee9dc711"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "94bb7eb3c9881f960a04567bfaea8010fae538e2",
+        "head": "2867df3c5ac0cd2ee69e6cb6d91fde9f53e26369",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -246,7 +246,8 @@
             "3363eb2837186021d1342c708533e1636ad080d5",
             "d9187a4aa59e8c81a4b906732164f4425a0c1ac0",
             "49a6d3494a6d88b7e31f16bd2183b177ec19e07f",
-            "258e6f3b76492528a4ca798842dfb448cd6f6e77"
+            "258e6f3b76492528a4ca798842dfb448cd6f6e77",
+            "91c9ca51ea7e3fdd0500f4ea1f14f2f233039839"
         ]
     },
     "capabilities": [
@@ -300,10 +301,12 @@
                 "dcd46f63711ea800a07e4bdcba2a123c44c4d64d",
                 "b2f672bd1182df7d1088a2e4c8e3e5f8d3ee7e27",
                 "6b9a8fa2697ab7aa0a79da5a589c538f1e51c564",
-                "7e307205e7ff42e9acb30431051fecd4c379a0ed"
+                "7e307205e7ff42e9acb30431051fecd4c379a0ed",
+                "2867df3c5ac0cd2ee69e6cb6d91fde9f53e26369"
             ],
             "behaviors": [
-                "RUNTIME-RUNTIME-PROJECTION-001"
+                "RUNTIME-RUNTIME-PROJECTION-001",
+                "RUNTIME-WORKSPACE-TOPOLOGY-CONTINUITY-001"
             ],
             "prGates": [
                 "test:deterministic:run"

--- a/media/webviewDashboardBundle.js
+++ b/media/webviewDashboardBundle.js
@@ -2959,22 +2959,25 @@ function initProjects() {
             var sessionKey = row.getAttribute('data-session-provider')
                 + ':' + row.getAttribute('data-session-id');
             var eventIds = window.__agentPivotAttentionSessionEvents[sessionKey] || [];
-            row.toggleAttribute('data-session-needs-attention', eventIds.length > 0);
-            row.toggleAttribute('data-ai-session-attention', eventIds.length > 0);
-            if (eventIds.length) {
-                row.setAttribute('data-session-event-id', eventIds[0]);
+            var visibleEventIds = row.getAttribute('data-execution-state') === 'running'
+                ? []
+                : eventIds;
+            row.toggleAttribute('data-session-needs-attention', visibleEventIds.length > 0);
+            row.toggleAttribute('data-ai-session-attention', visibleEventIds.length > 0);
+            if (visibleEventIds.length) {
+                row.setAttribute('data-session-event-id', visibleEventIds[0]);
             } else {
                 row.removeAttribute('data-session-event-id');
             }
             var primaryAction = row.querySelector('.ai-session-primary-action');
             var indicator = row.querySelector('.ai-session-attention-indicator');
-            if (eventIds.length && primaryAction && !indicator) {
+            if (visibleEventIds.length && primaryAction && !indicator) {
                 indicator = document.createElement('span');
                 indicator.className = 'ai-session-attention-indicator';
                 indicator.title = 'AI session needs attention';
                 indicator.setAttribute('aria-label', 'AI session needs attention');
                 primaryAction.insertBefore(indicator, primaryAction.firstChild);
-            } else if (!eventIds.length && indicator) {
+            } else if (!visibleEventIds.length && indicator) {
                 indicator.remove();
             }
         });

--- a/media/webviewProjectScripts.js
+++ b/media/webviewProjectScripts.js
@@ -319,22 +319,25 @@ function initProjects() {
             var sessionKey = row.getAttribute('data-session-provider')
                 + ':' + row.getAttribute('data-session-id');
             var eventIds = window.__agentPivotAttentionSessionEvents[sessionKey] || [];
-            row.toggleAttribute('data-session-needs-attention', eventIds.length > 0);
-            row.toggleAttribute('data-ai-session-attention', eventIds.length > 0);
-            if (eventIds.length) {
-                row.setAttribute('data-session-event-id', eventIds[0]);
+            var visibleEventIds = row.getAttribute('data-execution-state') === 'running'
+                ? []
+                : eventIds;
+            row.toggleAttribute('data-session-needs-attention', visibleEventIds.length > 0);
+            row.toggleAttribute('data-ai-session-attention', visibleEventIds.length > 0);
+            if (visibleEventIds.length) {
+                row.setAttribute('data-session-event-id', visibleEventIds[0]);
             } else {
                 row.removeAttribute('data-session-event-id');
             }
             var primaryAction = row.querySelector('.ai-session-primary-action');
             var indicator = row.querySelector('.ai-session-attention-indicator');
-            if (eventIds.length && primaryAction && !indicator) {
+            if (visibleEventIds.length && primaryAction && !indicator) {
                 indicator = document.createElement('span');
                 indicator.className = 'ai-session-attention-indicator';
                 indicator.title = 'AI session needs attention';
                 indicator.setAttribute('aria-label', 'AI session needs attention');
                 primaryAction.insertBefore(indicator, primaryAction.firstChild);
-            } else if (!eventIds.length && indicator) {
+            } else if (!visibleEventIds.length && indicator) {
                 indicator.remove();
             }
         });

--- a/scripts/run-architecture-guards.js
+++ b/scripts/run-architecture-guards.js
@@ -872,7 +872,7 @@ const guards = {
             ['jsonlScanTimeoutMs', '5_000'],
             ['maxViewerInteractions', '100'],
             ['maxViewerBytes', '4 * 1024 * 1024'],
-            ['maxCodexResponseBytes', '16 * 1024 * 1024'],
+            ['maxCodexResponseBytes', '64 * 1024 * 1024'],
             ['codexRequestTimeoutMs', '10_000'],
             ['autoScrollThresholdPx', '8'],
             ['minRequestId', '1'],

--- a/scripts/run-release-packaging-checks.js
+++ b/scripts/run-release-packaging-checks.js
@@ -111,6 +111,7 @@ const EXPECTED_MAIN_ENTRIES = Object.freeze([
     'extension/out/workspaces/pendingSessionPromotionController.js',
     'extension/out/workspaces/pendingWorkspaceSaveStore.js',
     'extension/out/workspaces/primaryRootStore.js',
+    'extension/out/workspaces/runtimeOwnership.js',
     'extension/out/workspaces/savedWorkspaceProjectAdapter.js',
     'extension/out/workspaces/sessionAssignment.js',
     'extension/out/workspaces/sessionAttention.js',

--- a/src/aiSessions/attentionEventCapability.ts
+++ b/src/aiSessions/attentionEventCapability.ts
@@ -3,6 +3,7 @@
 import type * as vscode from 'vscode';
 import type { AiSessionProviderId } from '../models';
 import type { OpenWorkspace } from '../workspaces/types';
+import { hasWorkspaceRuntimeContinuity } from '../workspaces/runtimeOwnership';
 import type ActiveAiSessionTerminalHighlighter from './activeTerminalHighlight';
 import type { ActiveAiSessionTerminalIdentity } from './activeTerminalHighlight';
 import type { AttentionAggregate } from './attentionAggregate';
@@ -214,10 +215,11 @@ export function createAiSessionAttentionEventCapability(
         providerId: AiSessionProviderId,
         sessionId: string
     ): AiSessionRuntimeSnapshot<vscode.Terminal> | null {
-        const workspaceScopeIdentity = getCurrentOpenWorkspace()?.scopeIdentity;
-        if (!workspaceScopeIdentity) {
+        const workspace = getCurrentOpenWorkspace();
+        if (!workspace) {
             return null;
         }
+        const workspaceScopeIdentity = workspace.scopeIdentity;
         const collision = getAiSessionRuntimeCollision(
             providerId, sessionId, workspaceScopeIdentity
         );
@@ -227,19 +229,22 @@ export function createAiSessionAttentionEventCapability(
         const live = getRuntimeCoordinator().getById(
             providerId, sessionId, workspaceScopeIdentity
         );
-        if (live) {
-            return live;
-        }
         const liveConflicts = getRuntimeCoordinator().getActive().filter(runtime =>
             runtime.identity.provider === providerId && runtime.identity.sessionId === sessionId
-            && runtime.identity.workspaceScopeIdentity === workspaceScopeIdentity);
+            && hasWorkspaceRuntimeContinuity(workspace, runtime));
+        if (liveConflicts.length === 1) {
+            return liveConflicts[0];
+        }
         if (liveConflicts.length > 1) {
             return { ...liveConflicts[0], state: 'conflict' };
+        }
+        if (live) {
+            return live;
         }
         const inactiveTmux: AiSessionRuntimeSnapshot<vscode.Terminal>[] = tmuxRuntimeDiscovery.getInactive()
             .filter(runtime => runtime.identity.provider === providerId
                 && runtime.identity.sessionId === sessionId
-                && runtime.identity.workspaceScopeIdentity === workspaceScopeIdentity)
+                && hasWorkspaceRuntimeContinuity(workspace, runtime))
             .map(runtime => {
                 const { terminal: _terminal, ...detached } = runtime;
                 return {
@@ -251,7 +256,9 @@ export function createAiSessionAttentionEventCapability(
         const completedDirect = aiSessionTerminalService.getTrackedTerminalEntries()
             .filter(entry => entry.provider === providerId && entry.sessionId === sessionId
                 && aiSessionTerminalService.isComplete(entry) && !!entry.runtimeIdentity
-                && entry.runtimeIdentity.workspaceScopeIdentity === workspaceScopeIdentity)
+                && hasWorkspaceRuntimeContinuity(workspace, {
+                    identity: entry.runtimeIdentity,
+                }))
             .map(entry => ({
                 identity: cloneAiSessionRuntimeIdentity(entry.runtimeIdentity),
                 backend: 'vscode' as const,
@@ -287,9 +294,8 @@ export function createAiSessionAttentionEventCapability(
     function runtimeBelongsToCurrentWorkspace(
         runtime: AiSessionRuntimeSnapshot<vscode.Terminal>
     ): boolean {
-        const workspaceScopeIdentity = getCurrentOpenWorkspace()?.scopeIdentity;
-        return !!workspaceScopeIdentity
-            && runtime.identity.workspaceScopeIdentity === workspaceScopeIdentity;
+        const workspace = getCurrentOpenWorkspace();
+        return !!workspace && hasWorkspaceRuntimeContinuity(workspace, runtime);
     }
 
     function scheduleAttentionViewsRefresh() {

--- a/src/aiSessions/conversation/composition.ts
+++ b/src/aiSessions/conversation/composition.ts
@@ -668,7 +668,7 @@ async function openLatestConversation(
     isCurrent: () => boolean,
     snapshotWarmup?: ConversationSnapshotWarmup
 ): Promise<OpenLatestConversationResult> {
-    const resolution = await resolveLatestConversationTarget(
+    let resolution = await resolveLatestConversationTarget(
         options,
         coordinator,
         target,
@@ -676,6 +676,16 @@ async function openLatestConversation(
         undefined,
         snapshotWarmup
     );
+    if (resolution.result === 'unavailable' && isCurrent()) {
+        resolution = await resolveLatestConversationTarget(
+            options,
+            coordinator,
+            target,
+            undefined,
+            undefined,
+            snapshotWarmup
+        );
+    }
     if (!isCurrent()) {
         return 'superseded';
     }

--- a/src/aiSessions/conversation/types.ts
+++ b/src/aiSessions/conversation/types.ts
@@ -32,7 +32,8 @@ export const CONVERSATION_LIMITS = Object.freeze({
     diffSynthesizeMaxLines: 400,
     maxViewerInteractions: 100,
     maxViewerBytes: 4 * 1024 * 1024,
-    maxCodexResponseBytes: 16 * 1024 * 1024,
+    // thread/read returns the complete normalized history in one JSONL frame.
+    maxCodexResponseBytes: 64 * 1024 * 1024,
     codexRequestTimeoutMs: 10_000,
     invalidationDebounceMs: 250,
     invalidationMinIntervalMs: 1_000,

--- a/src/aiSessions/terminalCommandController.ts
+++ b/src/aiSessions/terminalCommandController.ts
@@ -9,8 +9,10 @@ import type {
 } from './runtimeTypes';
 import type { WorkspaceAiSessionActionTarget } from './types';
 import { aiSessionRuntimeIdentitiesEqual, cloneAiSessionRuntimeIdentity } from './runtimeTypes';
+import { hasWorkspaceRuntimeContinuity } from '../workspaces/runtimeOwnership';
 
 export interface AiSessionTerminalCommandRuntimeCoordinator<TTerminal> {
+    getActive?(): AiSessionRuntimeSnapshot<TTerminal>[];
     getById(
         provider: AiSessionProviderId,
         sessionId: string,
@@ -416,9 +418,18 @@ export class AiSessionTerminalCommandController<
         options: AiSessionTerminalCommandRuntimeControllerOptions<TTerminal>
     ): AiSessionRuntimeSnapshot<TTerminal> | null {
         const ownership = this.getRuntimeWorkspaceOwnership(projectId, options);
-        const runtime = ownership ? options.runtimeCoordinator.getById(
+        const scopedRuntime = ownership ? options.runtimeCoordinator.getById(
             providerId, sessionId, ownership.workspaceScopeIdentity
         ) : null;
+        const continuityMatches = ownership && options.runtimeCoordinator.getActive
+            ? options.runtimeCoordinator.getActive().filter(runtime =>
+                runtime.identity.provider === providerId
+                && runtime.identity.sessionId === sessionId
+                && this.runtimeBelongsToWorkspace(
+                    ownership, providerId, sessionId, runtime
+                ))
+            : (scopedRuntime ? [scopedRuntime] : []);
+        const runtime = continuityMatches.length === 1 ? continuityMatches[0] : null;
         return ownership && runtime && this.runtimeBelongsToWorkspace(
             ownership, providerId, sessionId, runtime
         )
@@ -437,13 +448,21 @@ export class AiSessionTerminalCommandController<
             return [];
         }
         const coordinator = options.runtimeCoordinator;
-        const candidates = coordinator.getActiveCandidates
+        const scopedCandidates = coordinator.getActiveCandidates
             ? coordinator.getActiveCandidates(
                 providerId, sessionId, ownership.workspaceScopeIdentity
             )
             : [coordinator.getById(
                 providerId, sessionId, ownership.workspaceScopeIdentity
             )].filter(Boolean) as AiSessionRuntimeSnapshot<TTerminal>[];
+        const continuityCandidates = (coordinator.getActive?.() || []).filter(runtime =>
+            runtime.identity.workspaceScopeIdentity !== ownership.workspaceScopeIdentity
+            && runtime.identity.provider === providerId
+            && runtime.identity.sessionId === sessionId
+            && this.runtimeBelongsToWorkspace(
+                ownership, providerId, sessionId, runtime
+            ));
+        const candidates = [...scopedCandidates, ...continuityCandidates];
         return candidates.filter(runtime => this.runtimeBelongsToWorkspace(
             ownership, providerId, sessionId, runtime
         )).map(cloneRuntime);
@@ -502,7 +521,7 @@ export class AiSessionTerminalCommandController<
         sessionId: string | undefined,
         runtime: AiSessionRuntimeSnapshot<TTerminal>
     ): boolean {
-        if (runtime.identity.workspaceScopeIdentity !== ownership.workspaceScopeIdentity) {
+        if (!hasWorkspaceRuntimeContinuity(ownership.workspaceTarget.workspace, runtime)) {
             return false;
         }
         return !sessionId

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -207,6 +207,7 @@ import { WorkspacePrimaryRootStore } from './workspaces/primaryRootStore';
 import { PendingWorkspaceSaveStore } from './workspaces/pendingWorkspaceSaveStore';
 import { SavedWorkspaceProjectAdapter } from './workspaces/savedWorkspaceProjectAdapter';
 import { WorkspacePendingSessionPromotionController } from './workspaces/pendingSessionPromotionController';
+import { hasWorkspaceRuntimeContinuity } from './workspaces/runtimeOwnership';
 import {
     AiSessionProjectionCoordinator,
     WorkspaceSessionHydrationController,
@@ -1700,7 +1701,7 @@ async function initializeDashboard(
             const executionSnapshot = aiSessionExecutionController.getSnapshot();
             return aiSessionRuntimeCoordinator.getActive().filter(runtime => {
                 const sessionId = runtime.identity.sessionId;
-                return runtime.identity.workspaceScopeIdentity === workspace.scopeIdentity
+                return hasWorkspaceRuntimeContinuity(workspace, runtime)
                     && Boolean(sessionId)
                     && executionSnapshot[getAiSessionKey(
                         runtime.identity.provider,

--- a/src/webview/webviewProjectScripts.js
+++ b/src/webview/webviewProjectScripts.js
@@ -319,22 +319,25 @@ function initProjects() {
             var sessionKey = row.getAttribute('data-session-provider')
                 + ':' + row.getAttribute('data-session-id');
             var eventIds = window.__agentPivotAttentionSessionEvents[sessionKey] || [];
-            row.toggleAttribute('data-session-needs-attention', eventIds.length > 0);
-            row.toggleAttribute('data-ai-session-attention', eventIds.length > 0);
-            if (eventIds.length) {
-                row.setAttribute('data-session-event-id', eventIds[0]);
+            var visibleEventIds = row.getAttribute('data-execution-state') === 'running'
+                ? []
+                : eventIds;
+            row.toggleAttribute('data-session-needs-attention', visibleEventIds.length > 0);
+            row.toggleAttribute('data-ai-session-attention', visibleEventIds.length > 0);
+            if (visibleEventIds.length) {
+                row.setAttribute('data-session-event-id', visibleEventIds[0]);
             } else {
                 row.removeAttribute('data-session-event-id');
             }
             var primaryAction = row.querySelector('.ai-session-primary-action');
             var indicator = row.querySelector('.ai-session-attention-indicator');
-            if (eventIds.length && primaryAction && !indicator) {
+            if (visibleEventIds.length && primaryAction && !indicator) {
                 indicator = document.createElement('span');
                 indicator.className = 'ai-session-attention-indicator';
                 indicator.title = 'AI session needs attention';
                 indicator.setAttribute('aria-label', 'AI session needs attention');
                 primaryAction.insertBefore(indicator, primaryAction.firstChild);
-            } else if (!eventIds.length && indicator) {
+            } else if (!visibleEventIds.length && indicator) {
                 indicator.remove();
             }
         });

--- a/src/workspaces/runtimeOwnership.ts
+++ b/src/workspaces/runtimeOwnership.ts
@@ -1,0 +1,26 @@
+'use strict';
+
+import type { AiSessionRuntimeSnapshot } from '../aiSessions/runtimeTypes';
+import {
+    getWorkspaceHostPathComparisonKey,
+} from './sessionAssignment';
+import type { OpenWorkspace } from './types';
+
+export function hasWorkspaceRuntimeContinuity(
+    workspace: Pick<OpenWorkspace, 'scopeIdentity' | 'navigationIdentity' | 'roots'>,
+    runtime: Pick<AiSessionRuntimeSnapshot, 'identity'>
+): boolean {
+    const identity = runtime?.identity;
+    if (!workspace || !identity) {
+        return false;
+    }
+    if (identity.workspaceScopeIdentity === workspace.scopeIdentity
+        || identity.workspaceNavigationIdentity === workspace.navigationIdentity) {
+        return true;
+    }
+    const currentRoots = new Set((workspace.roots || [])
+        .map(root => getWorkspaceHostPathComparisonKey(root.hostPath))
+        .filter(Boolean));
+    return (identity.workspaceRootHostPaths || [])
+        .some(root => currentRoots.has(getWorkspaceHostPathComparisonKey(root)));
+}

--- a/src/workspaces/sessionHydration.ts
+++ b/src/workspaces/sessionHydration.ts
@@ -200,14 +200,16 @@ function buildActiveSessions<TTerminal>(input: {
                 ?.find(candidate => candidate.id === sessionId);
             const root = assignPathToWorkspaceRoot(runtime.identity.cwd, input.input.workspace.roots);
             const focused = input.focusedSessionKey === key;
-            const needsAttention = session?.attention?.unread === true;
+            const executionState = input.input.executionSnapshot?.[key]?.state || 'stopped';
+            const needsAttention = executionState !== 'running'
+                && session?.attention?.unread === true;
             const conflict = runtime.state === 'conflict';
             return {
                 key,
                 provider: providerId,
                 sessionId,
                 name: session?.name || `${providerLabel(input.input.providers, providerId)} ${shortId(sessionId)}`,
-                executionState: input.input.executionSnapshot?.[key]?.state || 'stopped',
+                executionState,
                 status: establishedStatus(needsAttention, focused, conflict),
                 focused,
                 needsAttention,
@@ -219,7 +221,9 @@ function buildActiveSessions<TTerminal>(input: {
                 ...(runtime.stale ? { stale: true } : {}),
                 ...(session?.updatedAt ? { updatedAt: session.updatedAt } : {}),
                 ...(session?.pinned !== undefined ? { pinned: session.pinned } : {}),
-                ...(session?.attention?.eventId ? { attentionEventId: session.attention.eventId } : {}),
+                ...(needsAttention && session?.attention?.eventId
+                    ? { attentionEventId: session.attention.eventId }
+                    : {}),
                 ...rootMetadata(root),
                 activityMs: finiteNumber(runtime.runStartedAtMs),
                 sourceOrder,

--- a/src/workspaces/sessionHydration.ts
+++ b/src/workspaces/sessionHydration.ts
@@ -24,6 +24,8 @@ import {
     getWorkspaceHostPathComparisonKey,
     normalizeWorkspaceHostPath,
 } from './sessionAssignment';
+import { hasWorkspaceRuntimeContinuity } from './runtimeOwnership';
+export { hasWorkspaceRuntimeContinuity } from './runtimeOwnership';
 import type { OpenWorkspace, WorkspaceRoot } from './types';
 import {
     buildWorkspaceSessionAttentionIndex,
@@ -89,7 +91,7 @@ export function hydrateWorkspaceAiSessions<TTerminal = unknown>(
     const activeRuntimes = deduplicateActiveRuntimes((input.activeRuntimes || [])
         .filter(runtime => hasWorkspaceRuntimeContinuity(input.workspace, runtime)));
     const pendingRuntimes = deduplicatePendingRuntimes((input.pendingRuntimes || [])
-        .filter(runtime => runtime.identity.workspaceScopeIdentity === input.workspace.scopeIdentity
+        .filter(runtime => hasWorkspaceRuntimeContinuity(input.workspace, runtime)
             && !!assignPathToWorkspaceRoot(runtime.identity.cwd, input.workspace.roots)));
     const activeSessionKeys = new Set(activeRuntimes
         .filter(runtime => !!runtime.identity.sessionId)
@@ -157,25 +159,6 @@ export function hydrateWorkspaceAiSessions<TTerminal = unknown>(
         providerSelection: input.providerSelection,
         expanded: input.expanded,
     });
-}
-
-export function hasWorkspaceRuntimeContinuity(
-    workspace: OpenWorkspace,
-    runtime: Pick<AiSessionRuntimeSnapshot, 'identity'>
-): boolean {
-    const identity = runtime?.identity;
-    if (!workspace || !identity) {
-        return false;
-    }
-    if (identity.workspaceScopeIdentity === workspace.scopeIdentity
-        || identity.workspaceNavigationIdentity === workspace.navigationIdentity) {
-        return true;
-    }
-    const currentRoots = new Set(workspace.roots
-        .map(root => getWorkspaceHostPathComparisonKey(root.hostPath))
-        .filter(Boolean));
-    return (identity.workspaceRootHostPaths || [])
-        .some(root => currentRoots.has(getWorkspaceHostPathComparisonKey(root)));
 }
 
 function assignHistorySessions(

--- a/tests/browser/activeSessionCardInteraction.test.js
+++ b/tests/browser/activeSessionCardInteraction.test.js
@@ -502,7 +502,10 @@ test('ACTIVE-SESSION-FOCUS-REVEAL-001 keeps a newer focus projection when an ind
         currentWorkspaceCount: 1,
         html: `<div class="open-current-workspace-group">${projectMarkup([
             session('codex', 'session-a', true),
-            session('codex', 'session-b', false),
+            {
+                ...session('codex', 'session-b', false),
+                executionState: 'stopped',
+            },
         ])}</div>`,
         searchCatalog: {
             version: 2,
@@ -526,12 +529,60 @@ test('ACTIVE-SESSION-FOCUS-REVEAL-001 keeps a newer focus projection when an ind
     );
 });
 
+test('ATTENTION-EXECUTION-STATE-SYNC-001 ignores stale Attention DOM state while an Active Session is running', async t => {
+    const page = await openCardPage(t, [session('codex', 'current-session', true)]);
+
+    await postHostMessage(page, {
+        type: 'ai-session-attention-state',
+        projectionRevision: 2,
+        eventIds: ['stale-event'],
+        sessionEvents: [{
+            sessionKey: 'codex:current-session',
+            eventIds: ['stale-event'],
+        }],
+    });
+
+    const currentRow = row(page, 'codex', 'current-session');
+    assert.equal(await currentRow.getAttribute('data-execution-state'), 'running');
+    assert.notEqual(await currentRow.getAttribute('data-session-icon-fx'), null);
+    assert.equal(await currentRow.getAttribute('data-session-needs-attention'), null);
+    assert.equal(await currentRow.getAttribute('data-ai-session-attention'), null);
+    assert.equal(await currentRow.getAttribute('data-session-event-id'), null);
+    assert.equal(await currentRow.locator('.ai-session-attention-indicator').count(), 0);
+
+    await postHostMessage(page, {
+        type: 'ai-sessions-updated',
+        version: 2,
+        sequence: 1,
+        projectionRevision: 3,
+        currentWorkspaceCount: 1,
+        html: `<div class="open-current-workspace-group">${projectMarkup([{
+            ...session('codex', 'current-session', true),
+            executionState: 'stopped',
+        }])}</div>`,
+        searchCatalog: {
+            version: 2,
+            sessions: [],
+            openWorkspaces: [],
+            savedProjects: [],
+            todos: [],
+        },
+    });
+
+    const stoppedRow = row(page, 'codex', 'current-session');
+    assert.equal(await stoppedRow.getAttribute('data-session-icon-fx'), null);
+    assert.equal(await stoppedRow.getAttribute('data-ai-session-attention'), '');
+    assert.equal(await stoppedRow.getAttribute('data-session-event-id'), 'stale-event');
+    assert.equal(await stoppedRow.locator('.ai-session-attention-indicator').count(), 1,
+        'suppressing the running dot does not discard the authoritative Attention event');
+});
+
 test('ACTIVE-SESSION-ATTENTION-PROJECTION-001 never flashes stale attention during a window-switch projection', async t => {
     const active = [
         session('codex', 'session-a', false),
         session('codex', 'session-b', true),
         session('codex', 'session-c', false),
-    ];
+    ].map(entry => ({ ...entry, executionState: 'stopped' }));
     const page = await openCardPage(t, active);
     await postHostMessage(page, {
         type: 'ai-session-attention-state',

--- a/tests/contract/aiSessions/attentionEventCapability.test.js
+++ b/tests/contract/aiSessions/attentionEventCapability.test.js
@@ -543,6 +543,44 @@ test('ATTENTION-EXECUTION-STATE-SYNC-001 runtime lookups resolve collision, live
     ), false);
 });
 
+test('RUNTIME-WORKSPACE-TOPOLOGY-CONTINUITY-001 keeps attention ownership after workspace roots change', () => {
+    const runtime = makeRuntime({ identity: makeIdentity({
+        workspaceScopeIdentity: 'scope-three-roots',
+        workspaceNavigationIdentity: 'nav-1',
+        workspaceRootHostPaths: ['/work'],
+    }) });
+    const workspace = {
+        scopeIdentity: 'scope-five-roots',
+        navigationIdentity: 'nav-1',
+        roots: [{ hostPath: '/work' }, { hostPath: '/work/added' }],
+    };
+    const fixture = createFixture({
+        workspace,
+        activeRuntimes: [runtime],
+        focusedTmuxRuntime: runtime,
+    });
+
+    assert.equal(fixture.capability.getRuntimeById('codex', 'session-a'), runtime,
+        'attention evaluation must still resolve the live runtime');
+    assert.equal(fixture.capability.belongsToCurrentWorkspace(runtime), true,
+        'attention focus must use the same continuity rule as Active Session projection');
+    assert.deepEqual(fixture.capability.getFocusedRuntimeIdentity(), runtime.identity,
+        'the focused runtime must not fall back to a stale highlighter identity');
+
+    const replacement = makeRuntime({ identity: makeIdentity({
+        workspaceScopeIdentity: workspace.scopeIdentity,
+        workspaceNavigationIdentity: workspace.navigationIdentity,
+        workspaceRootHostPaths: ['/work', '/work/added'],
+    }), runStartedAtMs: 800 });
+    const ambiguous = createFixture({
+        workspace,
+        liveRuntime: replacement,
+        activeRuntimes: [runtime, replacement],
+    });
+    assert.equal(ambiguous.capability.getRuntimeById('codex', 'session-a').state, 'conflict',
+        'attention must surface cross-scope ambiguity instead of selecting the newer scope');
+});
+
 test('ATTENTION-EXECUTION-STATE-SYNC-001 attention state posts the recovery session events and event ids', () => {
     const { capability, calls } = createFixture({});
     capability.postAttentionState();

--- a/tests/contract/aiSessions/codexAppServerClient.test.js
+++ b/tests/contract/aiSessions/codexAppServerClient.test.js
@@ -346,7 +346,29 @@ test('SESSION-AI-SESSION-CODEX-APP-SERVER-002A keeps fragmented response copying
     );
 });
 
-test('SESSION-AI-SESSION-CODEX-APP-SERVER-003 enforces the 16 MiB limit before parsing framed or unterminated lines', async t => {
+test('ACTIVE-SESSION-CONVERSATION-OPEN-001 accepts a valid Codex thread/read response above the legacy 16 MiB budget', async t => {
+    const harness = createHarness();
+    t.after(() => harness.client.dispose());
+    const request = harness.client.request('thread/read', {
+        threadId: SESSION_ID,
+    });
+    await finishHandshake(harness.child);
+
+    const legacyMaxResponseBytes = 16 * 1024 * 1024;
+    const prefix = Buffer.from('{"id":2,"result":{"text":"', 'utf8');
+    const suffix = Buffer.from('"}}\n', 'utf8');
+    const response = Buffer.concat([
+        prefix,
+        Buffer.alloc(legacyMaxResponseBytes, 0x78),
+        suffix,
+    ]);
+    harness.child.stdout.emit('data', response);
+
+    assert.equal((await request).text.length, legacyMaxResponseBytes);
+    assert.equal(harness.child.killCount, 0);
+});
+
+test('SESSION-AI-SESSION-CODEX-APP-SERVER-003 enforces the 64 MiB limit before parsing framed or unterminated lines', async t => {
     for (const terminated of [false, true]) {
         await t.test(terminated ? 'terminated line' : 'unterminated line', async t => {
             const harness = createHarness();

--- a/tests/integration/dashboard/attentionRendering.test.js
+++ b/tests/integration/dashboard/attentionRendering.test.js
@@ -247,6 +247,94 @@ test('ATTENTION-BRIDGE-STALENESS-001 an acknowledged completion stays absent fro
     assert.doesNotMatch(html, /class="ai-session-attention-count"/);
 });
 
+test('ATTENTION-EXECUTION-STATE-SYNC-001 never renders a running animation and stale attention dot together', () => {
+    const workspacePath = '/work/execution-attention-sync';
+    const eventId = 'codex:current-session:completed:stale-event';
+    const aggregate = aggregateAttentionSnapshots([{
+        version: 1,
+        generatedAtMs: 1_000,
+        items: [{
+            projectId: getAttentionProjectKey(workspacePath),
+            sessionKey: 'codex:current-session',
+            state: 'needsAttention',
+            eventId,
+            reason: 'completed',
+            observedAtMs: 1_000,
+        }],
+        instanceId: 'c'.repeat(32),
+        sequence: 1,
+        heartbeat: 1,
+    }], new Set(), 1_000);
+    const workspace = {
+        navigationIdentity: 'navigation:execution-attention-sync',
+        scopeIdentity: 'scope:execution-attention-sync',
+        kind: 'singleFolder',
+        displayName: 'Execution Attention Sync',
+        navigationUri: `file://${workspacePath}`,
+        environment: 'local',
+        roots: [{
+            id: 'root:execution-attention-sync',
+            name: 'execution-attention-sync',
+            uri: `file://${workspacePath}`,
+            hostPath: workspacePath,
+            ordinal: 0,
+        }],
+    };
+    const projected = hydrateWorkspaceAiSessions({
+        workspace,
+        providers: [{ id: 'codex', label: 'Codex' }],
+        sessionResults: {
+            codex: {
+                available: true,
+                sessions: [{ id: 'current-session', name: 'Current Session', cwd: workspacePath }],
+            },
+        },
+        getSessionComparableCwd: (_provider, session) => session.cwd,
+        pinnedSessions: new Set(),
+        aliases: {},
+        activeRuntimes: [{
+            identity: {
+                provider: 'codex',
+                workspaceScopeIdentity: workspace.scopeIdentity,
+                workspaceNavigationIdentity: workspace.navigationIdentity,
+                workspaceRootHostPaths: [workspacePath],
+                cwd: workspacePath,
+                sessionId: 'current-session',
+            },
+            backend: 'vscode',
+            state: 'active',
+            markerPath: '/tmp/current-session.done',
+            runStartedAtMs: 900,
+            attached: true,
+        }],
+        executionSnapshot: {
+            'codex:current-session': { state: 'running', stateChangedAt: 1_100 },
+        },
+        attentionAggregate: aggregate,
+    });
+    const activeSession = projected.activeSessions[0];
+    const html = stewardContent([{
+        id: 'execution-attention-sync',
+        name: workspace.displayName,
+        color: '#00aacc',
+        codexSessions: projected.sessionsByProvider.codex,
+        activeAiSessions: projected.activeSessions,
+    }]);
+    const sessionRow = html.match(
+        /<div class="codex-session-row active-ai-session-row"[^>]*data-session-id="current-session"[^>]*>[\s\S]*?<\/div><\/div>/
+    )?.[0];
+
+    assert.equal(activeSession.executionState, 'running');
+    assert.equal(activeSession.needsAttention, false,
+        'the newer running state suppresses stale aggregate attention in the Active projection');
+    assert.ok(sessionRow, 'the current running session remains rendered');
+    assert.match(sessionRow, /data-execution-state="running"/);
+    assert.match(sessionRow, /data-session-icon-fx=/);
+    assert.doesNotMatch(sessionRow,
+        /data-ai-session-attention|data-session-needs-attention|ai-session-attention-indicator/);
+    assert.doesNotMatch(html, /class="ai-session-attention-count"/);
+});
+
 test('OPEN-OTHER-WINDOWS-SUMMARY-001 renders shared attention as a summary without session ownership', () => {
     const html = stewardContent([{
         id: 'current',

--- a/tests/integration/dashboard/conversationRouting.test.js
+++ b/tests/integration/dashboard/conversationRouting.test.js
@@ -704,6 +704,47 @@ test('PRODUCTION-CONVERSATION-COMPOSITION-002 surfaces unknown and empty convers
     await emptyHarness.dispose();
 });
 
+test('ACTIVE-SESSION-CONVERSATION-OPEN-001 retries one transient authoritative read before reporting unavailable', async () => {
+    let readAttempts = 0;
+    const harness = createDashboardConversationHarness({
+        readOutline(provider, sessionId) {
+            readAttempts += 1;
+            if (readAttempts === 1) {
+                throw new Error('transient provider read failure');
+            }
+            return fakeConversationOutline(provider, sessionId);
+        },
+    });
+    await harness.activate();
+
+    assert.equal(await harness.openActiveConversation(), 'opened');
+    assert.equal(readAttempts, 2);
+    assert.deepEqual(
+        harness.viewerTargets.map(target => target.interactionId),
+        ['input-b']
+    );
+
+    await harness.dispose();
+
+    let unavailableAttempts = 0;
+    const unavailableHarness = createDashboardConversationHarness({
+        readOutline() {
+            unavailableAttempts += 1;
+            throw new Error('persistent provider read failure');
+        },
+    });
+    await unavailableHarness.activate();
+
+    assert.equal(
+        await unavailableHarness.openActiveConversation(),
+        'unavailable'
+    );
+    assert.equal(unavailableAttempts, 2);
+    assert.equal(unavailableHarness.viewerTargets.length, 0);
+
+    await unavailableHarness.dispose();
+});
+
 test('ACTIVE-SESSION-CONVERSATION-OPEN-001 routes validated open requests and ignores malformed envelopes', async () => {
     const harness = createDashboardConversationHarness();
     await harness.activate();

--- a/tests/integration/dashboard/sessionRuntimeFlow.test.js
+++ b/tests/integration/dashboard/sessionRuntimeFlow.test.js
@@ -5,6 +5,7 @@ const test = require('node:test');
 const { createFakeClock } = require('../../helpers/fakeClock');
 const { loadFreshWithFakeVscode } = require('../../helpers/runtimeContract');
 const { AI_SESSION_PROVIDER_DEFINITIONS } = require('../../../out/aiSessions/providers');
+const { AiSessionTerminalCommandController } = require('../../../out/aiSessions/terminalCommandController');
 const { hydrateWorkspaceAiSessions } = require('../../../out/workspaces/sessionHydration');
 const { getAttentionProjectKeys } = require('../../../out/aiSessions/attentionProject');
 const { getAiSessionTerminalCandidates } = require('../../../out/aiSessions/terminalCandidates');
@@ -194,6 +195,97 @@ test('PROJECT-ACTIVE-AI-SESSION-PROJECTION-001 keeps active session cards stable
     assert.deepEqual(before.activeSessions.map(session => session.sessionId), ['newer', 'older']);
     assert.deepEqual(after.activeSessions.map(session => session.sessionId), ['newer', 'older']);
     assert.equal(after.activeSessions.find(session => session.sessionId === 'older').focused, true);
+});
+
+test('RUNTIME-WORKSPACE-TOPOLOGY-CONTINUITY-001 keeps a projected Active Session actionable after workspace roots change', async () => {
+    const workspace = {
+        navigationIdentity: 'navigation:reddb-dev',
+        scopeIdentity: 'scope:five-roots',
+        kind: 'savedMultiRoot',
+        displayName: 'reddb-dev',
+        navigationUri: 'file:///work/reddb-dev.code-workspace',
+        environment: 'local',
+        roots: [{
+            id: 'root:existing', name: 'existing', uri: 'file:///work/existing',
+            hostPath: '/work/existing', ordinal: 0,
+        }, {
+            id: 'root:added', name: 'added', uri: 'file:///work/added',
+            hostPath: '/work/added', ordinal: 1,
+        }],
+    };
+    const runtime = {
+        identity: {
+            provider: 'codex',
+            sessionId: 'still-active',
+            workspaceScopeIdentity: 'scope:three-roots',
+            workspaceNavigationIdentity: workspace.navigationIdentity,
+            workspaceRootHostPaths: ['/work/existing'],
+            cwd: '/work/existing',
+        },
+        backend: 'tmux', state: 'active', markerPath: '/tmp/still-active.done',
+        runStartedAtMs: 10, attached: true,
+        tmux: { layout: 'project', sessionName: 'reddb-dev', windowName: 'still-active' },
+    };
+    const projected = hydrateWorkspaceAiSessions({
+        workspace,
+        providers: [{ id: 'codex', label: 'Codex' }],
+        sessionResults: {
+            codex: { available: true, sessions: [{
+                id: 'still-active', name: 'Still active', cwd: '/work/existing',
+            }] },
+        },
+        getSessionComparableCwd: (_provider, session) => session.cwd,
+        pinnedSessions: new Set(), aliases: {}, activeRuntimes: [runtime],
+    });
+    assert.equal(projected.activeSessions.length, 1,
+        'the navigation identity keeps the runtime visible after the scope changes');
+
+    const focused = [];
+    const detached = [];
+    let activeRuntimes = [runtime];
+    const controller = new AiSessionTerminalCommandController({
+        isProviderId: value => value === 'codex',
+        getWorkspaceTarget: projectId => projectId === 'current-card' ? {
+            cardId: projectId,
+            workspace,
+            sessions: projected,
+        } : null,
+        showErrorMessage: async () => undefined,
+        getProviderLabel: () => 'Codex',
+        refresh: () => undefined,
+        runtimeCoordinator: {
+            getById: (provider, sessionId, scopeIdentity) => activeRuntimes.find(candidate =>
+                candidate.identity.provider === provider
+                && candidate.identity.sessionId === sessionId
+                && candidate.identity.workspaceScopeIdentity === scopeIdentity) || null,
+            getActive: () => activeRuntimes,
+            getPending: () => [],
+            focus: async identity => focused.push(identity),
+            detach: async identity => detached.push(identity),
+            terminate: async () => undefined,
+        },
+        confirmRuntimeClose: async (_message, action) => action,
+        announceStatus: async () => undefined,
+    });
+
+    assert.equal(await controller.focusActive('current-card', 'codex', 'still-active'), true);
+    assert.deepEqual(focused, [runtime.identity],
+        'the action must use the surviving runtime identity instead of the new workspace scope');
+
+    activeRuntimes = [runtime, {
+        ...runtime,
+        identity: {
+            ...runtime.identity,
+            workspaceScopeIdentity: workspace.scopeIdentity,
+            workspaceRootHostPaths: workspace.roots.map(root => root.hostPath),
+        },
+        runStartedAtMs: 20,
+    }];
+    await controller.closeTerminal({
+        projectId: 'current-card', providerId: 'codex', sessionId: 'still-active',
+    });
+    assert.deepEqual(detached, [],
+        'an ambiguous pre-change and post-change runtime must fail closed');
 });
 
 test('WEBVIEW-AI-SESSION-DASHBOARD-WATCHER-COALESCING-001 coalesces watcher refreshes and preserves attention refresh priority', async () => {

--- a/tests/unit/tooling/repositorySkills.test.js
+++ b/tests/unit/tooling/repositorySkills.test.js
@@ -142,6 +142,7 @@ test('ARCH-REPOSITORY-SKILL-GUIDANCE-001 verifies provider adapters against real
         ['real data verification rule', /real on-disk provider data/i],
         ['self-consistent fixture trap', /self-consistent trap/i],
         ['probe before assuming', /probe real data first/i],
+        ['large framed responses are measured against the transport cap', /framed protocol[\s\S]*full response byte size[\s\S]*large live response[\s\S]*transport cap/i],
         ['layout mirroring', /mirror the real layout/i],
         ['status inference guidance', /no status[\s\S]*transcript tail/i],
         ['type imports remain inside the Codex boundary', /full relative-import graph[\s\S]*type-only imports[\s\S]*architecture-guarded/i],


### PR DESCRIPTION
## Summary

- Preserve active AI session actions when workspace roots are added or removed.
- Restore attention lookup, focus ownership, pending projection, and running counts across workspace scope changes.
- Fail closed when old and new scopes contain ambiguous runtimes for the same session.
- Retry one transient authoritative Conversation read before reporting it unavailable.
- Accept valid large Codex thread/read responses while retaining a bounded transport limit.
- Prevent a running Active Session card from showing stale Attention through either authoritative rendering or an incremental Webview update.
- Keep release VSIX assets synchronized with their source files.

## Root causes

Workspace root changes create a new scope identity while existing runtimes retain their original identity. Session hydration already accepted navigation and root continuity, but command and attention paths still required exact scope equality. The sidebar could therefore show an Active session that the host rejected as inactive, and attention stopped resolving the same runtime.

Conversation opening had two independent failure modes. Transient app-server failures were surfaced without a bounded retry. After that retry was added, the real current Codex 0.147.0 thread/read response had grown to 17.25 MiB and was rejected by the legacy 16 MiB frame limit before JSON parsing.

The running-card regression had two paths. Host hydration independently combined a newer running execution snapshot with an older Attention aggregate, and the direct Webview Attention stream reapplied stale event IDs without checking the rendered execution state. Existing controller tests did not own the final rendered race, while older browser Attention fixtures incorrectly modeled sessions as running while expecting red dots.

## Architecture

One shared workspace runtime continuity rule is reused across hydration, terminal commands, attention handling, and dashboard running counts. Exact backend identity operations remain strict; continuity is limited to workspace ownership and candidate resolution.

Conversation recovery stays bounded: only unavailable reads are retried, once. Unknown sessions, empty conversations, superseded intents, and persistent failures keep their existing outcomes. Codex thread/read accepts frames up to the existing 64 MiB conversation-source safety boundary and continues to reject larger or unterminated responses before parsing.

The Active Session projection now enforces the user-visible invariant that running and Attention are mutually exclusive. Incremental DOM reconciliation applies the same invariant without deleting the authoritative event, so the red dot can appear after the session actually stops.

## Testing

- npm run test:ci:linux
- Unit tests: 704 passed
- Contract tests: 873 passed
- Integration tests: 397 passed
- Browser tests: 180 passed
- npm run test:release-packaging
- npm run test:behavior-contracts
- npm run test:architecture-guards
- Changed-line coverage: 97.73 percent
- Compiled production client read the real 17.25 MiB Codex 0.147.0 thread/read response with 58 turns and no diagnostics; no conversation content was logged
- Running/Attention exclusivity is covered at Host-rendered and live browser-interaction surfaces

## Skill harvest

none — no additional skill change was justified for the running/Attention follow-up because fixing-regressions-with-ci already requires RED first, final rendered or interaction ownership, and verification after the final fix. Earlier work in this PR updated .skills/developing-provider-conversation-adapters for framed-response byte and duration probes.