### PR TITLE
Centralize active session presentation projection

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -1284,6 +1284,10 @@
       "src/aiSessions/runtimeSettlementCapability.ts"
     ,
       "src/aiSessions/attentionEventCapability.ts"
+    ,
+      "src/workspaces/activeSessionPresentation.ts"
+    ,
+      "src/webview/webviewProjectScripts.js"
     ]
   },
   {

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "5a6571198bc5c396db1fbd2ac45ae12c26f1a1b1",
+        "head": "869d520b640f56e8db2b1f1e3b71b081625c7874",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -251,7 +251,8 @@
             "dbf89c05a5b34dfcaabb1daf9aa5f1e28f76cdb9",
             "1e47d70675ea31304f5cc6394fed4fb9955037e3",
             "643e0775788e7da09b914cc7b7526bb3909ff3db",
-            "7ab84c7fb628f73041909c12f3055124e4cca81c"
+            "7ab84c7fb628f73041909c12f3055124e4cca81c",
+            "e8c8f7b9467d1afb3fc15b30ae41fe9b5409a142"
         ]
     },
     "capabilities": [
@@ -888,7 +889,8 @@
                 "f3e53a32c81c87dc0df919c8f0d3355c37ca69fb",
                 "687e3f6959ffce62db59daed3fc785a78a284ed1",
                 "f45c91eb03a0dd604ea8cc3b667b4972327a1efa",
-                "5a6571198bc5c396db1fbd2ac45ae12c26f1a1b1"
+                "5a6571198bc5c396db1fbd2ac45ae12c26f1a1b1",
+                "869d520b640f56e8db2b1f1e3b71b081625c7874"
             ],
             "behaviors": [
                 "ATTENTION-ACTIVE-UNREGISTER-ON-DEACTIVATE-001",

--- a/media/webviewDashboardBundle.js
+++ b/media/webviewDashboardBundle.js
@@ -1686,12 +1686,7 @@ function initProjectAiSessionsUpdate(options) {
     var pendingWorkspaceSessionReveal = null;
     var latestAiSessionUpdateSequence = 0;
     var latestAiSessionProjectionRevision = 0;
-    var latestAiSessionFocusProjectionRevision = 0;
-    var latestAiSessionAttentionProjectionRevision = 0;
-    // Rendered HTML bootstraps attention only until the dedicated stream arrives.
-    // Later content replacements can carry an older snapshot with a newer delivery
-    // revision, so they must preserve the direct stream instead of reviving stale dots.
-    var hasDirectAiSessionAttentionProjection = false;
+    var latestAiSessionPresentationProjectionRevision = 0;
 
     function canApplyRevision(revision, latestRevision) {
         if (typeof revision === 'undefined') {
@@ -1706,50 +1701,28 @@ function initProjectAiSessionsUpdate(options) {
         return canApplyRevision(revision, latestAiSessionProjectionRevision);
     }
 
-    function canApplyFocusProjectionRevision(revision) {
-        return canApplyRevision(revision, latestAiSessionFocusProjectionRevision);
+    function canApplyPresentationProjectionRevision(revision) {
+        return canApplyRevision(revision, latestAiSessionPresentationProjectionRevision);
     }
 
-    function canApplyAttentionProjectionRevision(revision) {
-        return !hasDirectAiSessionAttentionProjection
-            && canApplyRevision(revision, latestAiSessionAttentionProjectionRevision);
-    }
-
-    function commitProjectionRevision(revision, adoptedFocus, adoptedAttention) {
+    function commitProjectionRevision(revision, adoptedPresentation) {
         if (Number.isSafeInteger(revision) && revision > 0) {
             latestAiSessionProjectionRevision = revision;
-            if (adoptedFocus) {
-                latestAiSessionFocusProjectionRevision = Math.max(
-                    latestAiSessionFocusProjectionRevision,
-                    revision
-                );
-            }
-            if (adoptedAttention) {
-                latestAiSessionAttentionProjectionRevision = Math.max(
-                    latestAiSessionAttentionProjectionRevision,
+            if (adoptedPresentation) {
+                latestAiSessionPresentationProjectionRevision = Math.max(
+                    latestAiSessionPresentationProjectionRevision,
                     revision
                 );
             }
         }
     }
 
-    function acceptFocusProjectionRevision(revision) {
-        if (!canApplyFocusProjectionRevision(revision)) {
+    function acceptPresentationProjectionRevision(revision) {
+        if (!canApplyPresentationProjectionRevision(revision)) {
             return false;
         }
         if (Number.isSafeInteger(revision) && revision > 0) {
-            latestAiSessionFocusProjectionRevision = revision;
-        }
-        return true;
-    }
-
-    function acceptAttentionProjectionRevision(revision) {
-        if (!canApplyRevision(revision, latestAiSessionAttentionProjectionRevision)) {
-            return false;
-        }
-        hasDirectAiSessionAttentionProjection = true;
-        if (Number.isSafeInteger(revision) && revision > 0) {
-            latestAiSessionAttentionProjectionRevision = revision;
+            latestAiSessionPresentationProjectionRevision = revision;
         }
         return true;
     }
@@ -1772,8 +1745,7 @@ function initProjectAiSessionsUpdate(options) {
         if (!canApplyProjectionRevision(message.projectionRevision)) {
             return;
         }
-        var adoptRenderedFocus = canApplyFocusProjectionRevision(message.projectionRevision);
-        var adoptRenderedAttention = canApplyAttentionProjectionRevision(
+        var adoptRenderedPresentation = canApplyPresentationProjectionRevision(
             message.projectionRevision
         );
 
@@ -1794,8 +1766,7 @@ function initProjectAiSessionsUpdate(options) {
         latestAiSessionUpdateSequence = message.sequence;
         commitProjectionRevision(
             message.projectionRevision,
-            adoptRenderedFocus,
-            adoptRenderedAttention
+            adoptRenderedPresentation
         );
         if (batchAiSessionState.projectId) {
             var projectDiv = findCurrentWorkspaceDiv(batchAiSessionState.projectId);
@@ -1807,7 +1778,7 @@ function initProjectAiSessionsUpdate(options) {
             }
         }
         reconcilePendingAiSessionProviderSelectionDom();
-        syncAiSessionProjectionDom(adoptRenderedFocus, adoptRenderedAttention);
+        syncAiSessionProjectionDom(adoptRenderedPresentation);
         updateStickyGroupHeaderOffset();
         if (window.__agentPivotDashboard) {
             window.__agentPivotDashboard.replaceSearchCatalog(message.searchCatalog);
@@ -1916,10 +1887,8 @@ function initProjectAiSessionsUpdate(options) {
 
     return {
         applyAiSessionsUpdate: applyAiSessionsUpdate,
-        acceptAttentionProjectionRevision: acceptAttentionProjectionRevision,
-        acceptFocusProjectionRevision: acceptFocusProjectionRevision,
-        canApplyAttentionProjectionRevision: canApplyAttentionProjectionRevision,
-        canApplyFocusProjectionRevision: canApplyFocusProjectionRevision,
+        acceptPresentationProjectionRevision: acceptPresentationProjectionRevision,
+        canApplyPresentationProjectionRevision: canApplyPresentationProjectionRevision,
         canApplyProjectionRevision: canApplyProjectionRevision,
         commitProjectionRevision: commitProjectionRevision,
         findCurrentWorkspaceDiv: findCurrentWorkspaceDiv,
@@ -1943,7 +1912,7 @@ function initProjectAiSessionControls(options) {
         pending: false,
         requestId: null,
     };
-    var activeAiSessionTerminalState = { provider: null, sessionId: null };
+    var activeAiSessionTerminalState = { provider: null, sessionId: null, pendingId: null };
     var nextAiSessionBatchArchiveRequestId = 0;
     var nextAiSessionProviderSelectionRequestId = 0;
     var pendingAiSessionProviderSelectionProjectId = null;
@@ -2898,23 +2867,34 @@ function initProjects() {
         getArchiveAiSessionMessageType: aiSessionControls.getArchiveAiSessionMessageType,
         isAiSessionProvider: aiSessionControls.isAiSessionProvider,
     });
-    function syncActiveAiSessionProjectionDom(adoptRenderedFocus) {
+    function syncActiveAiSessionProjectionDom(adoptRenderedFocus, revealFocused) {
         if (adoptRenderedFocus !== false) {
             var focusedRow = document.querySelector(
-                '.codex-session-row[data-session-focused][data-session-provider][data-session-id]'
+                '.codex-session-row[data-session-focused][data-session-provider]'
             );
             var provider = focusedRow && focusedRow.getAttribute('data-session-provider');
             aiSessionControls.activeAiSessionTerminalState.provider =
                 aiSessionControls.isAiSessionProvider(provider) ? provider : null;
             aiSessionControls.activeAiSessionTerminalState.sessionId = focusedRow
                 ? focusedRow.getAttribute('data-session-id') : null;
+            aiSessionControls.activeAiSessionTerminalState.pendingId = focusedRow
+                ? focusedRow.getAttribute('data-pending-id') : null;
         } else {
             var projectedFocusedRow = null;
-            document.querySelectorAll('.codex-session-row[data-session-id]').forEach(row => {
-                var focused = row.getAttribute('data-session-provider')
-                    === aiSessionControls.activeAiSessionTerminalState.provider
-                    && row.getAttribute('data-session-id')
-                    === aiSessionControls.activeAiSessionTerminalState.sessionId;
+            document.querySelectorAll(
+                '.codex-session-row[data-session-provider][data-session-id],'
+                    + '.codex-session-row[data-session-provider][data-pending-id]'
+            ).forEach(row => {
+                var providerMatches = row.getAttribute('data-session-provider')
+                    === aiSessionControls.activeAiSessionTerminalState.provider;
+                var focused = providerMatches && (
+                    (aiSessionControls.activeAiSessionTerminalState.sessionId !== null
+                        && row.getAttribute('data-session-id')
+                            === aiSessionControls.activeAiSessionTerminalState.sessionId)
+                    || (aiSessionControls.activeAiSessionTerminalState.pendingId !== null
+                        && row.getAttribute('data-pending-id')
+                            === aiSessionControls.activeAiSessionTerminalState.pendingId)
+                );
                 if (focused) projectedFocusedRow = row;
                 row.toggleAttribute(
                     'data-session-focused',
@@ -2922,7 +2902,8 @@ function initProjects() {
                 );
                 var primaryAction = row.querySelector('.ai-session-primary-action');
                 if (primaryAction) {
-                    var actionState = focused ? 'conversation' : 'focus';
+                    var focusedConversation = focused && row.hasAttribute('data-session-id');
+                    var actionState = focusedConversation ? 'conversation' : 'focus';
                     var actionAriaLabel = primaryAction.getAttribute(
                         'data-' + actionState + '-aria-label'
                     );
@@ -2933,7 +2914,8 @@ function initProjects() {
                     if (actionTitle) primaryAction.setAttribute('title', actionTitle);
                 }
                 var conversationHint = row.querySelector('.ai-session-open-conversation-hint');
-                if (focused && primaryAction && !conversationHint) {
+                if (focusedConversation
+                    && primaryAction && !conversationHint) {
                     conversationHint = document.createElement('span');
                     conversationHint.className = 'ai-session-open-conversation-hint';
                     conversationHint.setAttribute('aria-hidden', 'true');
@@ -2943,48 +2925,250 @@ function initProjects() {
                     conversationHint.remove();
                 }
             });
-            if (projectedFocusedRow) {
+            if (projectedFocusedRow && revealFocused) {
                 projectedFocusedRow.scrollIntoView({ block: 'nearest' });
             }
         }
         aiSessionControls.syncActiveAiSessionTerminalDom();
     }
-    function syncAiSessionAttentionProjectionDom(adoptRenderedAttention) {
-        if (adoptRenderedAttention !== false) return;
-        window.__agentPivotAttentionSessionEvents =
-            window.__agentPivotAttentionSessionEvents || {};
-        document.querySelectorAll(
+    function setAiSessionAttentionDom(row, eventIds, needsAttention) {
+        row.toggleAttribute('data-session-needs-attention', needsAttention);
+        row.toggleAttribute('data-ai-session-attention', needsAttention);
+        if (needsAttention && eventIds.length) {
+            row.setAttribute('data-session-event-id', eventIds[0]);
+        } else {
+            row.removeAttribute('data-session-event-id');
+        }
+        var primaryAction = row.querySelector('.ai-session-primary-action');
+        var indicator = row.querySelector('.ai-session-attention-indicator');
+        if (needsAttention && primaryAction && !indicator) {
+            indicator = document.createElement('span');
+            indicator.className = 'ai-session-attention-indicator';
+            indicator.title = 'AI session needs attention';
+            indicator.setAttribute('aria-label', 'AI session needs attention');
+            primaryAction.insertBefore(indicator, primaryAction.firstChild);
+        } else if (!needsAttention && indicator) {
+            indicator.remove();
+        }
+    }
+    function setAiSessionExecutionDom(row, presentation, iconAnimation) {
+        row.setAttribute('data-execution-state', presentation.executionState);
+        if (presentation.executionState === 'running' && iconAnimation !== 'none') {
+            row.setAttribute('data-session-icon-fx', iconAnimation);
+        } else {
+            row.removeAttribute('data-session-icon-fx');
+        }
+        row.toggleAttribute('data-session-conflict', presentation.conflict);
+        var status = row.querySelector('.ai-session-execution-status');
+        if (status) {
+            var running = presentation.executionState === 'running';
+            status.setAttribute(
+                'aria-label',
+                running ? 'AI is currently executing' : 'AI is not currently executing'
+            );
+            var label = status.lastChild;
+            if (label && label.nodeType === Node.TEXT_NODE) {
+                label.nodeValue = running ? 'Running' : 'Stopped';
+            }
+        }
+    }
+    function setActiveSessionTabAttentionDom(projectDiv, attentionCount) {
+        var tab = projectDiv.querySelector('[data-ai-session-tab="active"]');
+        if (!tab) return;
+        var dot = tab.querySelector('.ai-session-tab-attention');
+        if (attentionCount > 0 && !dot) {
+            dot = document.createElement('span');
+            dot.className = 'ai-session-tab-attention';
+            tab.appendChild(dot);
+        } else if (attentionCount === 0 && dot) {
+            dot.remove();
+            return;
+        }
+        if (dot) {
+            dot.setAttribute(
+                'aria-label',
+                attentionCount + ' active AI session'
+                    + (attentionCount === 1 ? ' needs' : 's need') + ' attention'
+            );
+        }
+    }
+    function setCurrentWorkspaceSummaryAttentionDom(projectDiv, attentionCount) {
+        var summary = projectDiv.querySelector('.project-codex-badge');
+        if (!summary && attentionCount > 0) {
+            summary = document.createElement('span');
+            summary.className = 'project-codex-badge';
+            summary.setAttribute('data-ai-session-total-count', '0');
+            summary.setAttribute('data-ai-session-active-count', '0');
+            projectDiv.appendChild(summary);
+        }
+        if (!summary) return;
+        summary.setAttribute('data-ai-session-attention-count', String(attentionCount));
+        var count = summary.querySelector('.ai-session-attention-count');
+        if (attentionCount > 0 && !count) {
+            count = document.createElement('b');
+            count.className = 'ai-session-attention-count';
+            summary.appendChild(count);
+        } else if (attentionCount === 0 && count) {
+            count.remove();
+            count = null;
+        }
+        if (count) {
+            count.textContent = String(attentionCount);
+            count.setAttribute(
+                'aria-label',
+                attentionCount + ' AI session'
+                    + (attentionCount === 1 ? ' needs' : 's need') + ' attention'
+            );
+        }
+        var total = Number(summary.getAttribute('data-ai-session-total-count')) || 0;
+        var active = Number(summary.getAttribute('data-ai-session-active-count')) || 0;
+        var parts = [];
+        if (total) parts.push(total + ' AI session' + (total === 1 ? '' : 's'));
+        if (active) parts.push(active + ' active AI session' + (active === 1 ? '' : 's'));
+        if (attentionCount) parts.push(attentionCount + ' AI session'
+            + (attentionCount === 1 ? ' needs' : 's need') + ' attention');
+        if (!parts.length) {
+            summary.remove();
+            projectDiv.removeAttribute('data-has-ai-session-badge');
+            return;
+        }
+        projectDiv.setAttribute('data-has-ai-session-badge', '');
+        summary.title = parts.join(', ');
+        summary.setAttribute('aria-label', parts.join(', '));
+    }
+    function setCurrentWorkspaceRunningDom(projectDiv, message) {
+        var running = message.runningSessionCount > 0;
+        projectDiv.classList.toggle('session-running', running);
+        if (running) {
+            projectDiv.setAttribute('data-session-fx', message.runningCardAnimation);
+            projectDiv.title = 'Workspace — ' + message.runningSessionCount + ' active session'
+                + (message.runningSessionCount === 1 ? '' : 's') + ' running';
+        } else {
+            projectDiv.removeAttribute('data-session-fx');
+            projectDiv.removeAttribute('title');
+        }
+        var effect = projectDiv.querySelector('.project-session-fx');
+        var showEffect = running && message.runningCardAnimation !== 'none';
+        if (showEffect && !effect) {
+            effect = document.createElement('div');
+            effect.className = 'project-session-fx';
+            projectDiv.appendChild(effect);
+        } else if (!showEffect && effect) {
+            effect.remove();
+        }
+    }
+    function setCurrentOpenWorkspaceSummaryDom(projectDiv, message) {
+        var runningBadge = projectDiv.querySelector('.project-codex-badge');
+        if (message.runningSessionCount > 0 && !runningBadge) {
+            runningBadge = document.createElement('span');
+            runningBadge.className = 'project-codex-badge';
+            var runningCount = document.createElement('span');
+            runningCount.className = 'ai-session-active-count';
+            runningBadge.appendChild(runningCount);
+            projectDiv.appendChild(runningBadge);
+        } else if (message.runningSessionCount === 0 && runningBadge) {
+            runningBadge.remove();
+            runningBadge = null;
+        }
+        if (runningBadge) {
+            var runningLabel = message.runningSessionCount + ' active AI session'
+                + (message.runningSessionCount === 1 ? '' : 's');
+            runningBadge.setAttribute(
+                'data-ai-session-active-count', String(message.runningSessionCount)
+            );
+            runningBadge.title = runningLabel;
+            runningBadge.setAttribute('aria-label', runningLabel);
+            var runningCount = runningBadge.querySelector('.ai-session-active-count');
+            runningCount.textContent = '●' + message.runningSessionCount;
+            runningCount.setAttribute('aria-label', runningLabel);
+        }
+        var attentionBadge = projectDiv.querySelector('.project-ai-attention-badge');
+        if (message.attentionCount > 0 && !attentionBadge) {
+            attentionBadge = document.createElement('span');
+            attentionBadge.className = 'project-ai-attention-badge';
+            projectDiv.appendChild(attentionBadge);
+        } else if (message.attentionCount === 0 && attentionBadge) {
+            attentionBadge.remove();
+            attentionBadge = null;
+        }
+        if (attentionBadge) {
+            var attentionLabel = message.attentionCount + ' item'
+                + (message.attentionCount === 1 ? '' : 's') + ' need'
+                + (message.attentionCount === 1 ? 's' : '') + ' attention';
+            attentionBadge.textContent = String(message.attentionCount);
+            attentionBadge.title = attentionLabel;
+            attentionBadge.setAttribute('aria-label', attentionLabel);
+        }
+        projectDiv.toggleAttribute(
+            'data-has-ai-session-badge',
+            message.runningSessionCount > 0 || message.attentionCount > 0
+        );
+        setCurrentWorkspaceRunningDom(projectDiv, message);
+    }
+    function applyAiSessionPresentationDom(message) {
+        var currentCards = Array.from(document.querySelectorAll(
+            '.workspace-card[data-workspace-navigation-identity="'
+                + CSS.escape(message.workspaceNavigationIdentity || '') + '"]'
+                + '[data-current-workspace],'
+                + '.workspace-card[data-workspace-navigation-identity="'
+                + CSS.escape(message.workspaceNavigationIdentity || '') + '"]'
+                + '[data-open-workspace-current]'
+        ));
+        if (!currentCards.length) return;
+        var projectDiv = currentCards.find(card => card.hasAttribute('data-current-workspace'));
+        var presentations = {};
+        message.sessions.forEach(presentation => {
+            presentations[presentation.provider + ':' + presentation.sessionId] = presentation;
+        });
+        var attentionEvents = {};
+        message.attentionSessions.forEach(session => {
+            attentionEvents[session.sessionKey] = session.eventIds.slice();
+        });
+        window.__agentPivotAttentionSessionEvents = attentionEvents;
+        var focused = message.focusedTarget;
+        aiSessionControls.activeAiSessionTerminalState.provider = focused ? focused.provider : null;
+        aiSessionControls.activeAiSessionTerminalState.sessionId = focused?.sessionId || null;
+        aiSessionControls.activeAiSessionTerminalState.pendingId = focused?.pendingId || null;
+        syncActiveAiSessionProjectionDom(false, message.revealFocused);
+        projectDiv?.querySelectorAll(
             '.codex-session-row[data-session-provider][data-session-id]'
         ).forEach(row => {
             var sessionKey = row.getAttribute('data-session-provider')
                 + ':' + row.getAttribute('data-session-id');
-            var eventIds = window.__agentPivotAttentionSessionEvents[sessionKey] || [];
-            var visibleEventIds = row.getAttribute('data-execution-state') === 'running'
-                ? []
-                : eventIds;
-            row.toggleAttribute('data-session-needs-attention', visibleEventIds.length > 0);
-            row.toggleAttribute('data-ai-session-attention', visibleEventIds.length > 0);
-            if (visibleEventIds.length) {
-                row.setAttribute('data-session-event-id', visibleEventIds[0]);
+            var presentation = presentations[sessionKey];
+            var eventIds = attentionEvents[sessionKey] || [];
+            if (presentation) {
+                setAiSessionExecutionDom(row, presentation, message.runningIconAnimation);
+                setAiSessionAttentionDom(
+                    row,
+                    presentation.eventIds,
+                    presentation.needsAttention
+                );
+            } else if (row.classList.contains('active-ai-session-row')) {
+                setAiSessionAttentionDom(row, [], false);
             } else {
-                row.removeAttribute('data-session-event-id');
-            }
-            var primaryAction = row.querySelector('.ai-session-primary-action');
-            var indicator = row.querySelector('.ai-session-attention-indicator');
-            if (visibleEventIds.length && primaryAction && !indicator) {
-                indicator = document.createElement('span');
-                indicator.className = 'ai-session-attention-indicator';
-                indicator.title = 'AI session needs attention';
-                indicator.setAttribute('aria-label', 'AI session needs attention');
-                primaryAction.insertBefore(indicator, primaryAction.firstChild);
-            } else if (!visibleEventIds.length && indicator) {
-                indicator.remove();
+                setAiSessionAttentionDom(row, eventIds, eventIds.length > 0);
             }
         });
+        if (projectDiv) {
+            setActiveSessionTabAttentionDom(projectDiv, message.activeAttentionCount);
+            setCurrentWorkspaceSummaryAttentionDom(projectDiv, message.attentionCount);
+            setCurrentWorkspaceRunningDom(projectDiv, message);
+        }
+        currentCards.filter(card => card.hasAttribute('data-open-workspace-current'))
+            .forEach(card => setCurrentOpenWorkspaceSummaryDom(card, message));
     }
-    function syncAiSessionProjectionDom(adoptRenderedFocus, adoptRenderedAttention) {
-        syncActiveAiSessionProjectionDom(adoptRenderedFocus);
-        syncAiSessionAttentionProjectionDom(adoptRenderedAttention);
+    function syncAiSessionProjectionDom(adoptRenderedPresentation) {
+        if (adoptRenderedPresentation !== false) {
+            window.__agentPivotAiSessionPresentationState = null;
+            syncActiveAiSessionProjectionDom(true, false);
+            return;
+        }
+        if (window.__agentPivotAiSessionPresentationState) {
+            applyAiSessionPresentationDom(window.__agentPivotAiSessionPresentationState);
+        } else {
+            syncActiveAiSessionProjectionDom(true, false);
+        }
     }
     var aiSessionsUpdate = initProjectAiSessionsUpdate({
         batchAiSessionState: aiSessionControls.batchAiSessionState,
@@ -3162,7 +3346,9 @@ function initProjects() {
                 }
             }
             aiSessionControls.reconcilePendingAiSessionProviderSelectionDom();
-            syncActiveAiSessionProjectionDom();
+            syncAiSessionProjectionDom(
+                window.__agentPivotAiSessionPresentationState ? false : true
+            );
             updateStickyGroupHeaderOffset();
             var renderedWorkspaceState = getWorkspaceUpdateDomState(document);
             window.vscode.postMessage({
@@ -3174,10 +3360,7 @@ function initProjects() {
         }
         if (message && message.type === 'open-workspaces-updated') {
             if (!aiSessionsUpdate.canApplyProjectionRevision(message.projectionRevision)) return;
-            var adoptOpenWorkspaceFocus = aiSessionsUpdate.canApplyFocusProjectionRevision(
-                message.projectionRevision
-            );
-            var adoptOpenWorkspaceAttention = aiSessionsUpdate.canApplyAttentionProjectionRevision(
+            var adoptOpenWorkspacePresentation = aiSessionsUpdate.canApplyPresentationProjectionRevision(
                 message.projectionRevision
             );
             if (!applyOpenWorkspacesUpdate(message)) {
@@ -3186,13 +3369,9 @@ function initProjects() {
             }
             aiSessionsUpdate.commitProjectionRevision(
                 message.projectionRevision,
-                adoptOpenWorkspaceFocus,
-                adoptOpenWorkspaceAttention
+                adoptOpenWorkspacePresentation
             );
-            syncAiSessionProjectionDom(
-                adoptOpenWorkspaceFocus,
-                adoptOpenWorkspaceAttention
-            );
+            syncAiSessionProjectionDom(adoptOpenWorkspacePresentation);
             updateStickyGroupHeaderOffset();
             var renderedOpenWorkspaceState = getOpenWorkspacesUpdateDomState();
             window.vscode.postMessage({
@@ -3227,31 +3406,51 @@ function initProjects() {
             return;
         }
 
-        if (message && message.type === 'active-ai-session-terminal-changed') {
-            if (!aiSessionsUpdate.acceptFocusProjectionRevision(message.projectionRevision)) return;
-            aiSessionControls.activeAiSessionTerminalState.provider = aiSessionControls.isAiSessionProvider(message.provider) ? message.provider : null;
-            aiSessionControls.activeAiSessionTerminalState.sessionId = typeof message.sessionId === 'string' ? message.sessionId : null;
-            syncActiveAiSessionProjectionDom(false);
-            return;
-        }
-
-        if (message && message.type === 'ai-session-attention-state') {
-            if (!aiSessionsUpdate.acceptAttentionProjectionRevision(message.projectionRevision)) return;
-            window.__agentPivotAttentionEvents = window.__agentPivotAttentionEvents || {};
-            window.__agentPivotAttentionSessionEvents = {};
-            (Array.isArray(message.sessionEvents) ? message.sessionEvents.slice(0, 1000) : []).forEach(session => {
-                if (!session || typeof session.sessionKey !== 'string' || !Array.isArray(session.eventIds)) return;
-                var separator = session.sessionKey.indexOf(':');
-                if (separator <= 0 || !aiSessionControls.isAiSessionProvider(session.sessionKey.slice(0, separator))) return;
-                var eventIds = Array.from(new Set(session.eventIds
-                    .slice(0, 1000)
-                    .filter(eventId => typeof eventId === 'string' && !!eventId)));
-                if (eventIds.length) window.__agentPivotAttentionSessionEvents[session.sessionKey] = eventIds;
-            });
-            (message.eventIds || []).forEach(eventId => {
-                if (typeof eventId === 'string') window.__agentPivotAttentionEvents[eventId] = true;
-            });
-            syncAiSessionAttentionProjectionDom(false);
+        if (message && message.type === 'ai-session-presentation-state') {
+            var validPresentation = message.version === 1
+                && Number.isSafeInteger(message.projectionRevision)
+                && message.projectionRevision > 0
+                && (typeof message.workspaceScopeIdentity === 'string'
+                    || message.workspaceScopeIdentity === null)
+                && (typeof message.workspaceNavigationIdentity === 'string'
+                    || message.workspaceNavigationIdentity === null)
+                && Number.isSafeInteger(message.attentionCount) && message.attentionCount >= 0
+                && Number.isSafeInteger(message.activeAttentionCount)
+                && message.activeAttentionCount >= 0
+                && Number.isSafeInteger(message.runningSessionCount)
+                && message.runningSessionCount >= 0
+                && ['current', 'sweep', 'orbit', 'halo', 'ripple', 'breath', 'custom', 'none']
+                    .includes(message.runningCardAnimation)
+                && ['current', 'halo', 'custom', 'none'].includes(message.runningIconAnimation)
+                && typeof message.revealFocused === 'boolean'
+                && Array.isArray(message.sessions) && message.sessions.length <= 1000
+                && message.sessions.every(session => session
+                    && aiSessionControls.isAiSessionProvider(session.provider)
+                    && typeof session.sessionId === 'string' && !!session.sessionId
+                    && (session.executionState === 'running'
+                        || session.executionState === 'stopped')
+                    && typeof session.focused === 'boolean'
+                    && typeof session.needsAttention === 'boolean'
+                    && typeof session.conflict === 'boolean'
+                    && Array.isArray(session.eventIds)
+                    && session.eventIds.length <= 1000
+                    && session.eventIds.every(eventId => typeof eventId === 'string' && !!eventId))
+                && Array.isArray(message.attentionSessions)
+                && message.attentionSessions.length <= 1000
+                && message.attentionSessions.every(session => session
+                    && typeof session.sessionKey === 'string' && !!session.sessionKey
+                    && Array.isArray(session.eventIds)
+                    && session.eventIds.length <= 1000
+                    && session.eventIds.every(eventId => typeof eventId === 'string' && !!eventId));
+            if (!validPresentation) {
+                aiSessionsUpdate.requestFullRefresh('invalid-ai-session-presentation-state');
+                return;
+            }
+            if (!aiSessionsUpdate.acceptPresentationProjectionRevision(
+                message.projectionRevision
+            )) return;
+            window.__agentPivotAiSessionPresentationState = message;
+            applyAiSessionPresentationDom(message);
             return;
         }
 

--- a/media/webviewProjectAiSessionControlsScripts.js
+++ b/media/webviewProjectAiSessionControlsScripts.js
@@ -11,7 +11,7 @@ function initProjectAiSessionControls(options) {
         pending: false,
         requestId: null,
     };
-    var activeAiSessionTerminalState = { provider: null, sessionId: null };
+    var activeAiSessionTerminalState = { provider: null, sessionId: null, pendingId: null };
     var nextAiSessionBatchArchiveRequestId = 0;
     var nextAiSessionProviderSelectionRequestId = 0;
     var pendingAiSessionProviderSelectionProjectId = null;

--- a/media/webviewProjectAiUpdateScripts.js
+++ b/media/webviewProjectAiUpdateScripts.js
@@ -18,12 +18,7 @@ function initProjectAiSessionsUpdate(options) {
     var pendingWorkspaceSessionReveal = null;
     var latestAiSessionUpdateSequence = 0;
     var latestAiSessionProjectionRevision = 0;
-    var latestAiSessionFocusProjectionRevision = 0;
-    var latestAiSessionAttentionProjectionRevision = 0;
-    // Rendered HTML bootstraps attention only until the dedicated stream arrives.
-    // Later content replacements can carry an older snapshot with a newer delivery
-    // revision, so they must preserve the direct stream instead of reviving stale dots.
-    var hasDirectAiSessionAttentionProjection = false;
+    var latestAiSessionPresentationProjectionRevision = 0;
 
     function canApplyRevision(revision, latestRevision) {
         if (typeof revision === 'undefined') {
@@ -38,50 +33,28 @@ function initProjectAiSessionsUpdate(options) {
         return canApplyRevision(revision, latestAiSessionProjectionRevision);
     }
 
-    function canApplyFocusProjectionRevision(revision) {
-        return canApplyRevision(revision, latestAiSessionFocusProjectionRevision);
+    function canApplyPresentationProjectionRevision(revision) {
+        return canApplyRevision(revision, latestAiSessionPresentationProjectionRevision);
     }
 
-    function canApplyAttentionProjectionRevision(revision) {
-        return !hasDirectAiSessionAttentionProjection
-            && canApplyRevision(revision, latestAiSessionAttentionProjectionRevision);
-    }
-
-    function commitProjectionRevision(revision, adoptedFocus, adoptedAttention) {
+    function commitProjectionRevision(revision, adoptedPresentation) {
         if (Number.isSafeInteger(revision) && revision > 0) {
             latestAiSessionProjectionRevision = revision;
-            if (adoptedFocus) {
-                latestAiSessionFocusProjectionRevision = Math.max(
-                    latestAiSessionFocusProjectionRevision,
-                    revision
-                );
-            }
-            if (adoptedAttention) {
-                latestAiSessionAttentionProjectionRevision = Math.max(
-                    latestAiSessionAttentionProjectionRevision,
+            if (adoptedPresentation) {
+                latestAiSessionPresentationProjectionRevision = Math.max(
+                    latestAiSessionPresentationProjectionRevision,
                     revision
                 );
             }
         }
     }
 
-    function acceptFocusProjectionRevision(revision) {
-        if (!canApplyFocusProjectionRevision(revision)) {
+    function acceptPresentationProjectionRevision(revision) {
+        if (!canApplyPresentationProjectionRevision(revision)) {
             return false;
         }
         if (Number.isSafeInteger(revision) && revision > 0) {
-            latestAiSessionFocusProjectionRevision = revision;
-        }
-        return true;
-    }
-
-    function acceptAttentionProjectionRevision(revision) {
-        if (!canApplyRevision(revision, latestAiSessionAttentionProjectionRevision)) {
-            return false;
-        }
-        hasDirectAiSessionAttentionProjection = true;
-        if (Number.isSafeInteger(revision) && revision > 0) {
-            latestAiSessionAttentionProjectionRevision = revision;
+            latestAiSessionPresentationProjectionRevision = revision;
         }
         return true;
     }
@@ -104,8 +77,7 @@ function initProjectAiSessionsUpdate(options) {
         if (!canApplyProjectionRevision(message.projectionRevision)) {
             return;
         }
-        var adoptRenderedFocus = canApplyFocusProjectionRevision(message.projectionRevision);
-        var adoptRenderedAttention = canApplyAttentionProjectionRevision(
+        var adoptRenderedPresentation = canApplyPresentationProjectionRevision(
             message.projectionRevision
         );
 
@@ -126,8 +98,7 @@ function initProjectAiSessionsUpdate(options) {
         latestAiSessionUpdateSequence = message.sequence;
         commitProjectionRevision(
             message.projectionRevision,
-            adoptRenderedFocus,
-            adoptRenderedAttention
+            adoptRenderedPresentation
         );
         if (batchAiSessionState.projectId) {
             var projectDiv = findCurrentWorkspaceDiv(batchAiSessionState.projectId);
@@ -139,7 +110,7 @@ function initProjectAiSessionsUpdate(options) {
             }
         }
         reconcilePendingAiSessionProviderSelectionDom();
-        syncAiSessionProjectionDom(adoptRenderedFocus, adoptRenderedAttention);
+        syncAiSessionProjectionDom(adoptRenderedPresentation);
         updateStickyGroupHeaderOffset();
         if (window.__agentPivotDashboard) {
             window.__agentPivotDashboard.replaceSearchCatalog(message.searchCatalog);
@@ -248,10 +219,8 @@ function initProjectAiSessionsUpdate(options) {
 
     return {
         applyAiSessionsUpdate: applyAiSessionsUpdate,
-        acceptAttentionProjectionRevision: acceptAttentionProjectionRevision,
-        acceptFocusProjectionRevision: acceptFocusProjectionRevision,
-        canApplyAttentionProjectionRevision: canApplyAttentionProjectionRevision,
-        canApplyFocusProjectionRevision: canApplyFocusProjectionRevision,
+        acceptPresentationProjectionRevision: acceptPresentationProjectionRevision,
+        canApplyPresentationProjectionRevision: canApplyPresentationProjectionRevision,
         canApplyProjectionRevision: canApplyProjectionRevision,
         commitProjectionRevision: commitProjectionRevision,
         findCurrentWorkspaceDiv: findCurrentWorkspaceDiv,

--- a/media/webviewProjectScripts.js
+++ b/media/webviewProjectScripts.js
@@ -258,23 +258,34 @@ function initProjects() {
         getArchiveAiSessionMessageType: aiSessionControls.getArchiveAiSessionMessageType,
         isAiSessionProvider: aiSessionControls.isAiSessionProvider,
     });
-    function syncActiveAiSessionProjectionDom(adoptRenderedFocus) {
+    function syncActiveAiSessionProjectionDom(adoptRenderedFocus, revealFocused) {
         if (adoptRenderedFocus !== false) {
             var focusedRow = document.querySelector(
-                '.codex-session-row[data-session-focused][data-session-provider][data-session-id]'
+                '.codex-session-row[data-session-focused][data-session-provider]'
             );
             var provider = focusedRow && focusedRow.getAttribute('data-session-provider');
             aiSessionControls.activeAiSessionTerminalState.provider =
                 aiSessionControls.isAiSessionProvider(provider) ? provider : null;
             aiSessionControls.activeAiSessionTerminalState.sessionId = focusedRow
                 ? focusedRow.getAttribute('data-session-id') : null;
+            aiSessionControls.activeAiSessionTerminalState.pendingId = focusedRow
+                ? focusedRow.getAttribute('data-pending-id') : null;
         } else {
             var projectedFocusedRow = null;
-            document.querySelectorAll('.codex-session-row[data-session-id]').forEach(row => {
-                var focused = row.getAttribute('data-session-provider')
-                    === aiSessionControls.activeAiSessionTerminalState.provider
-                    && row.getAttribute('data-session-id')
-                    === aiSessionControls.activeAiSessionTerminalState.sessionId;
+            document.querySelectorAll(
+                '.codex-session-row[data-session-provider][data-session-id],'
+                    + '.codex-session-row[data-session-provider][data-pending-id]'
+            ).forEach(row => {
+                var providerMatches = row.getAttribute('data-session-provider')
+                    === aiSessionControls.activeAiSessionTerminalState.provider;
+                var focused = providerMatches && (
+                    (aiSessionControls.activeAiSessionTerminalState.sessionId !== null
+                        && row.getAttribute('data-session-id')
+                            === aiSessionControls.activeAiSessionTerminalState.sessionId)
+                    || (aiSessionControls.activeAiSessionTerminalState.pendingId !== null
+                        && row.getAttribute('data-pending-id')
+                            === aiSessionControls.activeAiSessionTerminalState.pendingId)
+                );
                 if (focused) projectedFocusedRow = row;
                 row.toggleAttribute(
                     'data-session-focused',
@@ -282,7 +293,8 @@ function initProjects() {
                 );
                 var primaryAction = row.querySelector('.ai-session-primary-action');
                 if (primaryAction) {
-                    var actionState = focused ? 'conversation' : 'focus';
+                    var focusedConversation = focused && row.hasAttribute('data-session-id');
+                    var actionState = focusedConversation ? 'conversation' : 'focus';
                     var actionAriaLabel = primaryAction.getAttribute(
                         'data-' + actionState + '-aria-label'
                     );
@@ -293,7 +305,8 @@ function initProjects() {
                     if (actionTitle) primaryAction.setAttribute('title', actionTitle);
                 }
                 var conversationHint = row.querySelector('.ai-session-open-conversation-hint');
-                if (focused && primaryAction && !conversationHint) {
+                if (focusedConversation
+                    && primaryAction && !conversationHint) {
                     conversationHint = document.createElement('span');
                     conversationHint.className = 'ai-session-open-conversation-hint';
                     conversationHint.setAttribute('aria-hidden', 'true');
@@ -303,48 +316,250 @@ function initProjects() {
                     conversationHint.remove();
                 }
             });
-            if (projectedFocusedRow) {
+            if (projectedFocusedRow && revealFocused) {
                 projectedFocusedRow.scrollIntoView({ block: 'nearest' });
             }
         }
         aiSessionControls.syncActiveAiSessionTerminalDom();
     }
-    function syncAiSessionAttentionProjectionDom(adoptRenderedAttention) {
-        if (adoptRenderedAttention !== false) return;
-        window.__agentPivotAttentionSessionEvents =
-            window.__agentPivotAttentionSessionEvents || {};
-        document.querySelectorAll(
+    function setAiSessionAttentionDom(row, eventIds, needsAttention) {
+        row.toggleAttribute('data-session-needs-attention', needsAttention);
+        row.toggleAttribute('data-ai-session-attention', needsAttention);
+        if (needsAttention && eventIds.length) {
+            row.setAttribute('data-session-event-id', eventIds[0]);
+        } else {
+            row.removeAttribute('data-session-event-id');
+        }
+        var primaryAction = row.querySelector('.ai-session-primary-action');
+        var indicator = row.querySelector('.ai-session-attention-indicator');
+        if (needsAttention && primaryAction && !indicator) {
+            indicator = document.createElement('span');
+            indicator.className = 'ai-session-attention-indicator';
+            indicator.title = 'AI session needs attention';
+            indicator.setAttribute('aria-label', 'AI session needs attention');
+            primaryAction.insertBefore(indicator, primaryAction.firstChild);
+        } else if (!needsAttention && indicator) {
+            indicator.remove();
+        }
+    }
+    function setAiSessionExecutionDom(row, presentation, iconAnimation) {
+        row.setAttribute('data-execution-state', presentation.executionState);
+        if (presentation.executionState === 'running' && iconAnimation !== 'none') {
+            row.setAttribute('data-session-icon-fx', iconAnimation);
+        } else {
+            row.removeAttribute('data-session-icon-fx');
+        }
+        row.toggleAttribute('data-session-conflict', presentation.conflict);
+        var status = row.querySelector('.ai-session-execution-status');
+        if (status) {
+            var running = presentation.executionState === 'running';
+            status.setAttribute(
+                'aria-label',
+                running ? 'AI is currently executing' : 'AI is not currently executing'
+            );
+            var label = status.lastChild;
+            if (label && label.nodeType === Node.TEXT_NODE) {
+                label.nodeValue = running ? 'Running' : 'Stopped';
+            }
+        }
+    }
+    function setActiveSessionTabAttentionDom(projectDiv, attentionCount) {
+        var tab = projectDiv.querySelector('[data-ai-session-tab="active"]');
+        if (!tab) return;
+        var dot = tab.querySelector('.ai-session-tab-attention');
+        if (attentionCount > 0 && !dot) {
+            dot = document.createElement('span');
+            dot.className = 'ai-session-tab-attention';
+            tab.appendChild(dot);
+        } else if (attentionCount === 0 && dot) {
+            dot.remove();
+            return;
+        }
+        if (dot) {
+            dot.setAttribute(
+                'aria-label',
+                attentionCount + ' active AI session'
+                    + (attentionCount === 1 ? ' needs' : 's need') + ' attention'
+            );
+        }
+    }
+    function setCurrentWorkspaceSummaryAttentionDom(projectDiv, attentionCount) {
+        var summary = projectDiv.querySelector('.project-codex-badge');
+        if (!summary && attentionCount > 0) {
+            summary = document.createElement('span');
+            summary.className = 'project-codex-badge';
+            summary.setAttribute('data-ai-session-total-count', '0');
+            summary.setAttribute('data-ai-session-active-count', '0');
+            projectDiv.appendChild(summary);
+        }
+        if (!summary) return;
+        summary.setAttribute('data-ai-session-attention-count', String(attentionCount));
+        var count = summary.querySelector('.ai-session-attention-count');
+        if (attentionCount > 0 && !count) {
+            count = document.createElement('b');
+            count.className = 'ai-session-attention-count';
+            summary.appendChild(count);
+        } else if (attentionCount === 0 && count) {
+            count.remove();
+            count = null;
+        }
+        if (count) {
+            count.textContent = String(attentionCount);
+            count.setAttribute(
+                'aria-label',
+                attentionCount + ' AI session'
+                    + (attentionCount === 1 ? ' needs' : 's need') + ' attention'
+            );
+        }
+        var total = Number(summary.getAttribute('data-ai-session-total-count')) || 0;
+        var active = Number(summary.getAttribute('data-ai-session-active-count')) || 0;
+        var parts = [];
+        if (total) parts.push(total + ' AI session' + (total === 1 ? '' : 's'));
+        if (active) parts.push(active + ' active AI session' + (active === 1 ? '' : 's'));
+        if (attentionCount) parts.push(attentionCount + ' AI session'
+            + (attentionCount === 1 ? ' needs' : 's need') + ' attention');
+        if (!parts.length) {
+            summary.remove();
+            projectDiv.removeAttribute('data-has-ai-session-badge');
+            return;
+        }
+        projectDiv.setAttribute('data-has-ai-session-badge', '');
+        summary.title = parts.join(', ');
+        summary.setAttribute('aria-label', parts.join(', '));
+    }
+    function setCurrentWorkspaceRunningDom(projectDiv, message) {
+        var running = message.runningSessionCount > 0;
+        projectDiv.classList.toggle('session-running', running);
+        if (running) {
+            projectDiv.setAttribute('data-session-fx', message.runningCardAnimation);
+            projectDiv.title = 'Workspace — ' + message.runningSessionCount + ' active session'
+                + (message.runningSessionCount === 1 ? '' : 's') + ' running';
+        } else {
+            projectDiv.removeAttribute('data-session-fx');
+            projectDiv.removeAttribute('title');
+        }
+        var effect = projectDiv.querySelector('.project-session-fx');
+        var showEffect = running && message.runningCardAnimation !== 'none';
+        if (showEffect && !effect) {
+            effect = document.createElement('div');
+            effect.className = 'project-session-fx';
+            projectDiv.appendChild(effect);
+        } else if (!showEffect && effect) {
+            effect.remove();
+        }
+    }
+    function setCurrentOpenWorkspaceSummaryDom(projectDiv, message) {
+        var runningBadge = projectDiv.querySelector('.project-codex-badge');
+        if (message.runningSessionCount > 0 && !runningBadge) {
+            runningBadge = document.createElement('span');
+            runningBadge.className = 'project-codex-badge';
+            var runningCount = document.createElement('span');
+            runningCount.className = 'ai-session-active-count';
+            runningBadge.appendChild(runningCount);
+            projectDiv.appendChild(runningBadge);
+        } else if (message.runningSessionCount === 0 && runningBadge) {
+            runningBadge.remove();
+            runningBadge = null;
+        }
+        if (runningBadge) {
+            var runningLabel = message.runningSessionCount + ' active AI session'
+                + (message.runningSessionCount === 1 ? '' : 's');
+            runningBadge.setAttribute(
+                'data-ai-session-active-count', String(message.runningSessionCount)
+            );
+            runningBadge.title = runningLabel;
+            runningBadge.setAttribute('aria-label', runningLabel);
+            var runningCount = runningBadge.querySelector('.ai-session-active-count');
+            runningCount.textContent = '●' + message.runningSessionCount;
+            runningCount.setAttribute('aria-label', runningLabel);
+        }
+        var attentionBadge = projectDiv.querySelector('.project-ai-attention-badge');
+        if (message.attentionCount > 0 && !attentionBadge) {
+            attentionBadge = document.createElement('span');
+            attentionBadge.className = 'project-ai-attention-badge';
+            projectDiv.appendChild(attentionBadge);
+        } else if (message.attentionCount === 0 && attentionBadge) {
+            attentionBadge.remove();
+            attentionBadge = null;
+        }
+        if (attentionBadge) {
+            var attentionLabel = message.attentionCount + ' item'
+                + (message.attentionCount === 1 ? '' : 's') + ' need'
+                + (message.attentionCount === 1 ? 's' : '') + ' attention';
+            attentionBadge.textContent = String(message.attentionCount);
+            attentionBadge.title = attentionLabel;
+            attentionBadge.setAttribute('aria-label', attentionLabel);
+        }
+        projectDiv.toggleAttribute(
+            'data-has-ai-session-badge',
+            message.runningSessionCount > 0 || message.attentionCount > 0
+        );
+        setCurrentWorkspaceRunningDom(projectDiv, message);
+    }
+    function applyAiSessionPresentationDom(message) {
+        var currentCards = Array.from(document.querySelectorAll(
+            '.workspace-card[data-workspace-navigation-identity="'
+                + CSS.escape(message.workspaceNavigationIdentity || '') + '"]'
+                + '[data-current-workspace],'
+                + '.workspace-card[data-workspace-navigation-identity="'
+                + CSS.escape(message.workspaceNavigationIdentity || '') + '"]'
+                + '[data-open-workspace-current]'
+        ));
+        if (!currentCards.length) return;
+        var projectDiv = currentCards.find(card => card.hasAttribute('data-current-workspace'));
+        var presentations = {};
+        message.sessions.forEach(presentation => {
+            presentations[presentation.provider + ':' + presentation.sessionId] = presentation;
+        });
+        var attentionEvents = {};
+        message.attentionSessions.forEach(session => {
+            attentionEvents[session.sessionKey] = session.eventIds.slice();
+        });
+        window.__agentPivotAttentionSessionEvents = attentionEvents;
+        var focused = message.focusedTarget;
+        aiSessionControls.activeAiSessionTerminalState.provider = focused ? focused.provider : null;
+        aiSessionControls.activeAiSessionTerminalState.sessionId = focused?.sessionId || null;
+        aiSessionControls.activeAiSessionTerminalState.pendingId = focused?.pendingId || null;
+        syncActiveAiSessionProjectionDom(false, message.revealFocused);
+        projectDiv?.querySelectorAll(
             '.codex-session-row[data-session-provider][data-session-id]'
         ).forEach(row => {
             var sessionKey = row.getAttribute('data-session-provider')
                 + ':' + row.getAttribute('data-session-id');
-            var eventIds = window.__agentPivotAttentionSessionEvents[sessionKey] || [];
-            var visibleEventIds = row.getAttribute('data-execution-state') === 'running'
-                ? []
-                : eventIds;
-            row.toggleAttribute('data-session-needs-attention', visibleEventIds.length > 0);
-            row.toggleAttribute('data-ai-session-attention', visibleEventIds.length > 0);
-            if (visibleEventIds.length) {
-                row.setAttribute('data-session-event-id', visibleEventIds[0]);
+            var presentation = presentations[sessionKey];
+            var eventIds = attentionEvents[sessionKey] || [];
+            if (presentation) {
+                setAiSessionExecutionDom(row, presentation, message.runningIconAnimation);
+                setAiSessionAttentionDom(
+                    row,
+                    presentation.eventIds,
+                    presentation.needsAttention
+                );
+            } else if (row.classList.contains('active-ai-session-row')) {
+                setAiSessionAttentionDom(row, [], false);
             } else {
-                row.removeAttribute('data-session-event-id');
-            }
-            var primaryAction = row.querySelector('.ai-session-primary-action');
-            var indicator = row.querySelector('.ai-session-attention-indicator');
-            if (visibleEventIds.length && primaryAction && !indicator) {
-                indicator = document.createElement('span');
-                indicator.className = 'ai-session-attention-indicator';
-                indicator.title = 'AI session needs attention';
-                indicator.setAttribute('aria-label', 'AI session needs attention');
-                primaryAction.insertBefore(indicator, primaryAction.firstChild);
-            } else if (!visibleEventIds.length && indicator) {
-                indicator.remove();
+                setAiSessionAttentionDom(row, eventIds, eventIds.length > 0);
             }
         });
+        if (projectDiv) {
+            setActiveSessionTabAttentionDom(projectDiv, message.activeAttentionCount);
+            setCurrentWorkspaceSummaryAttentionDom(projectDiv, message.attentionCount);
+            setCurrentWorkspaceRunningDom(projectDiv, message);
+        }
+        currentCards.filter(card => card.hasAttribute('data-open-workspace-current'))
+            .forEach(card => setCurrentOpenWorkspaceSummaryDom(card, message));
     }
-    function syncAiSessionProjectionDom(adoptRenderedFocus, adoptRenderedAttention) {
-        syncActiveAiSessionProjectionDom(adoptRenderedFocus);
-        syncAiSessionAttentionProjectionDom(adoptRenderedAttention);
+    function syncAiSessionProjectionDom(adoptRenderedPresentation) {
+        if (adoptRenderedPresentation !== false) {
+            window.__agentPivotAiSessionPresentationState = null;
+            syncActiveAiSessionProjectionDom(true, false);
+            return;
+        }
+        if (window.__agentPivotAiSessionPresentationState) {
+            applyAiSessionPresentationDom(window.__agentPivotAiSessionPresentationState);
+        } else {
+            syncActiveAiSessionProjectionDom(true, false);
+        }
     }
     var aiSessionsUpdate = initProjectAiSessionsUpdate({
         batchAiSessionState: aiSessionControls.batchAiSessionState,
@@ -522,7 +737,9 @@ function initProjects() {
                 }
             }
             aiSessionControls.reconcilePendingAiSessionProviderSelectionDom();
-            syncActiveAiSessionProjectionDom();
+            syncAiSessionProjectionDom(
+                window.__agentPivotAiSessionPresentationState ? false : true
+            );
             updateStickyGroupHeaderOffset();
             var renderedWorkspaceState = getWorkspaceUpdateDomState(document);
             window.vscode.postMessage({
@@ -534,10 +751,7 @@ function initProjects() {
         }
         if (message && message.type === 'open-workspaces-updated') {
             if (!aiSessionsUpdate.canApplyProjectionRevision(message.projectionRevision)) return;
-            var adoptOpenWorkspaceFocus = aiSessionsUpdate.canApplyFocusProjectionRevision(
-                message.projectionRevision
-            );
-            var adoptOpenWorkspaceAttention = aiSessionsUpdate.canApplyAttentionProjectionRevision(
+            var adoptOpenWorkspacePresentation = aiSessionsUpdate.canApplyPresentationProjectionRevision(
                 message.projectionRevision
             );
             if (!applyOpenWorkspacesUpdate(message)) {
@@ -546,13 +760,9 @@ function initProjects() {
             }
             aiSessionsUpdate.commitProjectionRevision(
                 message.projectionRevision,
-                adoptOpenWorkspaceFocus,
-                adoptOpenWorkspaceAttention
+                adoptOpenWorkspacePresentation
             );
-            syncAiSessionProjectionDom(
-                adoptOpenWorkspaceFocus,
-                adoptOpenWorkspaceAttention
-            );
+            syncAiSessionProjectionDom(adoptOpenWorkspacePresentation);
             updateStickyGroupHeaderOffset();
             var renderedOpenWorkspaceState = getOpenWorkspacesUpdateDomState();
             window.vscode.postMessage({
@@ -587,31 +797,51 @@ function initProjects() {
             return;
         }
 
-        if (message && message.type === 'active-ai-session-terminal-changed') {
-            if (!aiSessionsUpdate.acceptFocusProjectionRevision(message.projectionRevision)) return;
-            aiSessionControls.activeAiSessionTerminalState.provider = aiSessionControls.isAiSessionProvider(message.provider) ? message.provider : null;
-            aiSessionControls.activeAiSessionTerminalState.sessionId = typeof message.sessionId === 'string' ? message.sessionId : null;
-            syncActiveAiSessionProjectionDom(false);
-            return;
-        }
-
-        if (message && message.type === 'ai-session-attention-state') {
-            if (!aiSessionsUpdate.acceptAttentionProjectionRevision(message.projectionRevision)) return;
-            window.__agentPivotAttentionEvents = window.__agentPivotAttentionEvents || {};
-            window.__agentPivotAttentionSessionEvents = {};
-            (Array.isArray(message.sessionEvents) ? message.sessionEvents.slice(0, 1000) : []).forEach(session => {
-                if (!session || typeof session.sessionKey !== 'string' || !Array.isArray(session.eventIds)) return;
-                var separator = session.sessionKey.indexOf(':');
-                if (separator <= 0 || !aiSessionControls.isAiSessionProvider(session.sessionKey.slice(0, separator))) return;
-                var eventIds = Array.from(new Set(session.eventIds
-                    .slice(0, 1000)
-                    .filter(eventId => typeof eventId === 'string' && !!eventId)));
-                if (eventIds.length) window.__agentPivotAttentionSessionEvents[session.sessionKey] = eventIds;
-            });
-            (message.eventIds || []).forEach(eventId => {
-                if (typeof eventId === 'string') window.__agentPivotAttentionEvents[eventId] = true;
-            });
-            syncAiSessionAttentionProjectionDom(false);
+        if (message && message.type === 'ai-session-presentation-state') {
+            var validPresentation = message.version === 1
+                && Number.isSafeInteger(message.projectionRevision)
+                && message.projectionRevision > 0
+                && (typeof message.workspaceScopeIdentity === 'string'
+                    || message.workspaceScopeIdentity === null)
+                && (typeof message.workspaceNavigationIdentity === 'string'
+                    || message.workspaceNavigationIdentity === null)
+                && Number.isSafeInteger(message.attentionCount) && message.attentionCount >= 0
+                && Number.isSafeInteger(message.activeAttentionCount)
+                && message.activeAttentionCount >= 0
+                && Number.isSafeInteger(message.runningSessionCount)
+                && message.runningSessionCount >= 0
+                && ['current', 'sweep', 'orbit', 'halo', 'ripple', 'breath', 'custom', 'none']
+                    .includes(message.runningCardAnimation)
+                && ['current', 'halo', 'custom', 'none'].includes(message.runningIconAnimation)
+                && typeof message.revealFocused === 'boolean'
+                && Array.isArray(message.sessions) && message.sessions.length <= 1000
+                && message.sessions.every(session => session
+                    && aiSessionControls.isAiSessionProvider(session.provider)
+                    && typeof session.sessionId === 'string' && !!session.sessionId
+                    && (session.executionState === 'running'
+                        || session.executionState === 'stopped')
+                    && typeof session.focused === 'boolean'
+                    && typeof session.needsAttention === 'boolean'
+                    && typeof session.conflict === 'boolean'
+                    && Array.isArray(session.eventIds)
+                    && session.eventIds.length <= 1000
+                    && session.eventIds.every(eventId => typeof eventId === 'string' && !!eventId))
+                && Array.isArray(message.attentionSessions)
+                && message.attentionSessions.length <= 1000
+                && message.attentionSessions.every(session => session
+                    && typeof session.sessionKey === 'string' && !!session.sessionKey
+                    && Array.isArray(session.eventIds)
+                    && session.eventIds.length <= 1000
+                    && session.eventIds.every(eventId => typeof eventId === 'string' && !!eventId));
+            if (!validPresentation) {
+                aiSessionsUpdate.requestFullRefresh('invalid-ai-session-presentation-state');
+                return;
+            }
+            if (!aiSessionsUpdate.acceptPresentationProjectionRevision(
+                message.projectionRevision
+            )) return;
+            window.__agentPivotAiSessionPresentationState = message;
+            applyAiSessionPresentationDom(message);
             return;
         }
 

--- a/scripts/run-ai-session-safety-checks.js
+++ b/scripts/run-ai-session-safety-checks.js
@@ -692,7 +692,9 @@ function runWorkspaceSessionHydrationChecks() {
         && session.backend === 'tmux' && session.primaryRootId === 'root-web'));
     const activeWeb = result.activeSessions.find(session => session.sessionId === 'web-history');
     assert.strictEqual(activeWeb.needsAttention, true);
-    assert.strictEqual(activeWeb.status, 'needsAttention');
+    assert.strictEqual(activeWeb.executionState, 'stopped');
+    assert.strictEqual(activeWeb.focused, false);
+    assert.strictEqual(activeWeb.conflict, undefined);
     assert.strictEqual(activeWeb.attentionEventId, 'event-web-new');
     assert.strictEqual(result.attentionCount, 2);
     assert.strictEqual(result.activeAttentionCount, 1);
@@ -4961,6 +4963,14 @@ function runWebviewContentChecks() {
     const attentionMonitorSource = fs.readFileSync(path.join(__dirname, '..', 'src', 'aiSessions', 'attentionMonitor.ts'), 'utf8');
     const executionControllerSource = fs.readFileSync(path.join(__dirname, '..', 'src', 'aiSessions', 'executionController.ts'), 'utf8');
     const dashboardRuntimeControllerSource = fs.readFileSync(path.join(__dirname, '..', 'src', 'dashboard', 'runtimeController.ts'), 'utf8');
+    const activeSessionPresentationSource = fs.readFileSync(
+        path.join(__dirname, '..', 'src', 'workspaces', 'activeSessionPresentation.ts'),
+        'utf8'
+    );
+    const openWorkspaceDashboardSource = fs.readFileSync(
+        path.join(__dirname, '..', 'src', 'openWorkspaces', 'dashboardController.ts'),
+        'utf8'
+    );
     const dashboardLifecycleControllerSource = fs.readFileSync(path.join(__dirname, '..', 'src', 'dashboard', 'lifecycleController.ts'), 'utf8');
     const evaluateAttentionFunction = extractMethodBody(attentionControllerSource, 'evaluate');
     const evaluateAttentionMonitorFunction = extractMethodBody(attentionMonitorSource, 'evaluate');
@@ -5062,6 +5072,7 @@ function runWebviewContentChecks() {
             },
             {
                 key: 'pending:claude:2026-07-18T03:00:00Z', provider: 'claude', name: 'New Claude',
+                pendingId: 'pending-claude',
                 executionState: 'starting', focused: false, needsAttention: false, pending: true,
                 createdAt: '2026-07-18T03:00:00Z',
                 backend: 'vscode', attached: true,
@@ -5162,6 +5173,7 @@ function runWebviewContentChecks() {
     assert.ok(attentionRows[0].includes('data-session-needs-attention'));
     assert.ok(!sessionTabsHtml.includes('data-session-status='));
     assert.ok(sessionTabsHtml.includes('data-session-pending'));
+    assert.ok(sessionTabsHtml.includes('data-pending-id="pending-claude"'));
     assert.ok(sessionTabsHtml.includes('data-session-active'));
     assert.ok(sessionTabsHtml.includes('Stop the active runtime before archiving.'));
     assert.ok(sessionTabsHtml.includes('aria-live="polite"'));
@@ -5219,7 +5231,31 @@ function runWebviewContentChecks() {
     assert.ok(!pendingTerminalResolverSource.includes('.terminal'));
     assert.ok(resumeControllerSource.includes('runtimeCoordinator.resume(request)'));
     assert.ok(!dashboardRuntimeControllerSource.includes("type: 'ai-session-attention-projects-updated'"));
-    assert.ok(webviewProjectScripts.includes('message.sessionEvents'));
+    assert.ok(webviewProjectScripts.includes('message.attentionSessions'));
+    assert.ok(!webviewProjectScripts.includes('message.sessionEvents'));
+    assert.ok(dashboard.includes("type: 'ai-session-presentation-state'"));
+    assert.ok(webviewProjectScripts.includes("message.type === 'ai-session-presentation-state'"));
+    assert.ok(!webviewProjectScripts.includes("message.type === 'ai-session-attention-state'"));
+    assert.ok(!webviewProjectScripts.includes("message.type === 'active-ai-session-terminal-changed'"));
+    assert.ok(activeSessionPresentationSource.includes(
+        "needsAttention: executionState !== 'running' && eventIds.length > 0"
+    ));
+    assert.ok(activeSessionPresentationSource.includes('focusedTarget,'));
+    assert.ok(webviewProjectScripts.includes('message.focusedTarget'));
+    assert.ok(webviewContent.includes(
+        'runtime ? runtime.needsAttention : !!session.attention?.unread'
+    ));
+    assert.ok(openWorkspaceDashboardSource.includes(
+        'attentionCount: aiSessions?.attentionCount || 0'
+    ));
+    assert.ok(openWorkspaceDashboardSource.includes(
+        'this.options.getAiSessionProjectionRevision?.() ?? null'
+    ));
+    assert.ok(!openWorkspaceDashboardSource.includes('getWorkspaceAttentionSummary'));
+    assert.ok(!webviewProjectScripts.includes("data-execution-state') === 'running'"),
+        'the Webview must apply Host presentation decisions without recombining lifecycle state');
+    assert.ok(!webviewProjectScripts.includes('latestAiSessionFocusProjectionRevision'));
+    assert.ok(!webviewProjectScripts.includes('latestAiSessionAttentionProjectionRevision'));
     assert.ok(runtimeSettlement.includes('settleAiSessionRuntimeLifecycles'));
     assert.match(runtimeSettlement,
         /for \(const runtime of runtimes\) \{\s*if \(!runtimeBelongsToCurrentWorkspace\(runtime\)\) \{\s*continue;\s*\}/,
@@ -5386,9 +5422,9 @@ function runWebviewContentChecks() {
     assert.ok(messageHandlersSource.includes("'request-active-ai-session-terminal': () =>"));
     assert.ok(dashboard.includes('requestActiveAiSessionTerminalHighlight: () => activeAiSessionTerminalHighlighter.request()'),
         'the dashboard wires the highlighter request into the extracted handlers');
-    assert.ok(dashboardRuntimeControllerSource.includes("type: 'active-ai-session-terminal-changed'"));
+    assert.ok(!dashboardRuntimeControllerSource.includes("type: 'active-ai-session-terminal-changed'"));
     assert.ok(webviewProjectScripts.includes("type: 'request-active-ai-session-terminal'"));
-    assert.ok(webviewProjectScripts.includes("message.type === 'active-ai-session-terminal-changed'"));
+    assert.ok(webviewProjectScripts.includes("message.type === 'ai-session-presentation-state'"));
     assert.ok(webviewProjectScripts.includes('data-ai-session-active-terminal'));
     assert.ok(dashboard.includes('onVisibleChanged: async visible =>'));
     assert.ok(dashboard.includes('activeAiSessionTerminalHighlighter.setVisible(visible)'));
@@ -6616,7 +6652,7 @@ function runBatchAiSessionWebviewChecks() {
                 remove: () => {},
             }),
             querySelector: selector => selector
-                === '.codex-session-row[data-session-focused][data-session-provider][data-session-id]'
+                === '.codex-session-row[data-session-focused][data-session-provider]'
                 ? projects.flatMap(project => project.rows)
                     .find(row => row.hasAttribute('data-session-focused')) || null
                 : null,
@@ -6630,6 +6666,10 @@ function runBatchAiSessionWebviewChecks() {
                 if (selector === '.project[data-ai-session-managing], .project[data-ai-session-pending]') {
                     return projects.filter(project => project.hasAttribute('data-ai-session-managing')
                         || project.hasAttribute('data-ai-session-pending'));
+                }
+                if (selector === '.codex-session-row[data-session-provider][data-session-id],'
+                    + '.codex-session-row[data-session-provider][data-pending-id]') {
+                    return projects.flatMap(project => project.rows);
                 }
                 if (selector === '.codex-session-row[data-session-id]') {
                     return projects.flatMap(project => project.rows);
@@ -6830,6 +6870,7 @@ function runBatchAiSessionWebviewChecks() {
     const pendingRow = createSessionRow('claude', '');
     pendingRow.project = projectA;
     pendingRow.setAttribute('data-session-pending', '');
+    pendingRow.setAttribute('data-pending-id', 'pending-claude');
     pendingRow.setAttribute('data-pending-created-at', '2026-07-18T08:00:00Z');
     let primarySpacePrevented = false;
     eventListeners.keydown({
@@ -7026,14 +7067,9 @@ function runBatchAiSessionWebviewChecks() {
 
     attentionRow.setAttribute('data-ai-session-attention', '');
     attentionRow.setAttribute('data-session-event-id', 'full-owner-event-a');
-    windowEventListeners.message({ data: {
-        type: 'ai-session-attention-state',
-        eventIds: ['full-owner-event-a', 'full-owner-event-b', 'existing-event'],
-        sessionEvents: [{
-            sessionKey: 'codex:attention-session',
-            eventIds: ['full-owner-event-a', 'full-owner-event-b'],
-        }],
-    } });
+    context.window.__agentPivotAttentionSessionEvents = {
+        'codex:attention-session': ['full-owner-event-a', 'full-owner-event-b'],
+    };
     messages.length = 0;
     eventListeners.click({ button: 0, target: attentionRow.primaryAction });
     assert.deepStrictEqual(JSON.parse(JSON.stringify(messages[0])), {
@@ -7041,33 +7077,6 @@ function runBatchAiSessionWebviewChecks() {
         eventIds: ['full-owner-event-a', 'full-owner-event-b'],
     }, 'a fresh full render must acknowledge every current owner event before an incremental update');
     messages.length = 0;
-    windowEventListeners.message({ data: {
-        type: 'active-ai-session-terminal-changed',
-        provider: 'codex',
-        sessionId: 'active-session',
-    } });
-    assert.strictEqual(activeRow.hasAttribute('data-ai-session-active-terminal'), true);
-    assert.strictEqual(otherCodexRow.hasAttribute('data-ai-session-active-terminal'), false);
-    assert.strictEqual(sameIdOtherProviderRow.hasAttribute('data-ai-session-active-terminal'), false);
-
-    windowEventListeners.message({ data: {
-        type: 'active-ai-session-terminal-changed',
-        provider: null,
-        sessionId: null,
-    } });
-    assert.strictEqual(activeRow.hasAttribute('data-ai-session-active-terminal'), false);
-
-    windowEventListeners.message({ data: {
-        type: 'active-ai-session-terminal-changed',
-        provider: 'codex',
-        sessionId: 'active-session',
-    } });
-    windowEventListeners.message({ data: {
-        type: 'active-ai-session-terminal-changed',
-        provider: null,
-        sessionId: null,
-    } });
-    assert.strictEqual(activeRow.hasAttribute('data-ai-session-active-terminal'), false);
     activeRow.setAttribute('data-session-focused', '');
     context.applyWorkspaceUpdate = message => message.type === 'workspace-updated'
         && message.version === 2
@@ -7088,28 +7097,6 @@ function runBatchAiSessionWebviewChecks() {
         'AI incremental rendering must preserve the non-empty TODO catalog replacement'
     );
     assert.strictEqual(activeRow.hasAttribute('data-ai-session-active-terminal'), true);
-    windowEventListeners.message({ data: {
-        type: 'active-ai-session-terminal-changed',
-        projectionRevision: 1,
-        provider: null,
-        sessionId: null,
-    } });
-    assert.strictEqual(
-        activeRow.hasAttribute('data-ai-session-active-terminal'),
-        true,
-        'ACTIVE-SESSION-FOCUS-REVEAL-001 a stale focus message must not override a newer rendered session projection'
-    );
-    windowEventListeners.message({ data: {
-        type: 'ai-session-attention-state',
-        projectionRevision: 1,
-        eventIds: ['newer-direct-event'],
-        sessionEvents: [],
-    } });
-    assert.strictEqual(context.window.__agentPivotAttentionEvents['newer-direct-event'], true,
-        'a rendered content revision must not suppress the independent direct attention stream');
-    assert.strictEqual(context.window.__agentPivotAttentionEvents['existing-event'], true,
-        'accepting the next direct attention projection must preserve known event identities');
-
     const manager = context.window.__agentPivotBatchAiSessions;
     manager.enter('project-a');
     manager.toggle('codex', 'plain');

--- a/scripts/run-dashboard-webview-checks.js
+++ b/scripts/run-dashboard-webview-checks.js
@@ -3307,16 +3307,10 @@ async function runDashboardRuntimeControllerChecks() {
     assert.deepStrictEqual(commands[commands.length - 1], ['workbench.action.openSettings', '@ext:hzcheng.agent-pivot']);
 
     controller.postBatchArchiveCompletion({ type: 'ai-session-batch-archive-completed', projectId: 'p', provider: 'codex', status: 'finished' });
-    controller.postActiveAiSessionTerminalChanged({ provider: 'codex', sessionId: 's1' });
-    controller.postActiveAiSessionTerminalChanged(null);
     await new Promise(resolve => setImmediate(resolve));
     assert.deepStrictEqual(posted.map(message => message.type), [
         'ai-session-batch-archive-completed',
-        'active-ai-session-terminal-changed',
-        'active-ai-session-terminal-changed',
     ]);
-    assert.deepStrictEqual(posted[1], { type: 'active-ai-session-terminal-changed', provider: 'codex', sessionId: 's1' });
-    assert.deepStrictEqual(posted[2], { type: 'active-ai-session-terminal-changed', provider: null, sessionId: null });
 
     controller.applyProjectColorToCurrentWindow();
     controller.applyProjectColorToCurrentWindow({ id: 'save', showSaveAction: true });

--- a/scripts/run-open-project-safety-checks.js
+++ b/scripts/run-open-project-safety-checks.js
@@ -1166,7 +1166,22 @@ async function runOpenWorkspaceClientAndControllerChecks() {
             if (workspace.navigationUri === duplicateNewer.navigationUri) return '#abcdef';
             return '';
         },
-        getCurrentWorkspaceAiSessions: () => null,
+        getCurrentWorkspaceAiSessions: () => ({
+            workspaceScopeIdentity: current.scopeIdentity,
+            workspaceNavigationIdentity: current.navigationIdentity,
+            activeProvider: 'codex',
+            selectedProviders: ['codex'],
+            expanded: false,
+            providers: [],
+            sessionsByProvider: {},
+            unavailableProviders: [],
+            aiSessionCount: 0,
+            activeSessions: [],
+            activeSessionCount: 0,
+            activeAttentionCount: 0,
+            defaultTab: 'active',
+            attentionCount: dashboardAttention ? 1 : 0,
+        }),
         getGroups: () => [],
         getTodoSearchItems: () => [],
         getCollapsed: () => false,

--- a/scripts/run-release-packaging-checks.js
+++ b/scripts/run-release-packaging-checks.js
@@ -105,6 +105,7 @@ const EXPECTED_MAIN_ENTRIES = Object.freeze([
     'extension/out/openWorkspaces/protocol.js',
     'extension/out/openWorkspaces/runningFocusProtocol.js',
     'extension/out/openWorkspaces/workspaceController.js',
+    'extension/out/workspaces/activeSessionPresentation.js',
     'extension/out/workspaces/attentionProjection.js',
     'extension/out/workspaces/contextResolver.js',
     'extension/out/workspaces/identity.js',

--- a/src/aiSessions/attentionEventCapability.ts
+++ b/src/aiSessions/attentionEventCapability.ts
@@ -44,7 +44,7 @@ export interface AiSessionAttentionEventCapabilityOptions {
     getRuntimeConfiguration: () => AiSessionRuntimeConfiguration;
     getCurrentOpenWorkspace: () => OpenWorkspace | null;
     getActiveTerminal: () => vscode.Terminal | null;
-    postMessage: (message: unknown) => void;
+    postAttentionState: () => void;
     isVisible: () => boolean;
     assertActive: () => void;
     createBridgeClient: (
@@ -130,7 +130,7 @@ export function createAiSessionAttentionEventCapability(
     const getRuntimeConfiguration = options.getRuntimeConfiguration;
     const getCurrentOpenWorkspace = options.getCurrentOpenWorkspace;
     const getActiveTerminal = options.getActiveTerminal;
-    const postMessage = options.postMessage;
+    const postAttentionState = options.postAttentionState;
     const isVisible = options.isVisible;
     const assertActive = options.assertActive;
     const createBridgeClient = options.createBridgeClient;
@@ -324,11 +324,7 @@ export function createAiSessionAttentionEventCapability(
     }
 
     function postAiSessionAttentionState() {
-        void postMessage({
-            type: 'ai-session-attention-state',
-            sessionEvents: getAttentionController().getRecoverySessionEvents(),
-            eventIds: getAttentionController().getAttentionEventIds(),
-        });
+        postAttentionState();
     }
 
     const getAiSessionAttentionEventIds = (identity: ActiveAiSessionTerminalIdentity): string[] => {

--- a/src/aiSessions/conversation/submission.ts
+++ b/src/aiSessions/conversation/submission.ts
@@ -44,7 +44,7 @@ export async function submitConversationPrompt<
     if (!workspace || !session || typeof prompt !== 'string' || !prompt.trim()) {
         throw new ConversationCommentError('unavailable');
     }
-    if (session.conflict || session.status === 'conflict') {
+    if (session.conflict) {
         throw new ConversationCommentError('conflict');
     }
     if (session.executionState === 'running'

--- a/src/aiSessions/types.ts
+++ b/src/aiSessions/types.ts
@@ -34,7 +34,6 @@ export interface AiSessionDirectoryScope {
 
 export type AiSessionTabId = 'active' | 'sessions';
 export type ActiveAiSessionExecutionState = 'starting' | AiSessionExecutionState;
-export type ActiveAiSessionStatus = 'starting' | 'running' | 'focused' | 'needsAttention' | 'conflict';
 
 export interface AiSessionActiveTerminalRuntime {
     provider: AiSessionProviderId;
@@ -48,9 +47,9 @@ export interface ActiveAiSessionViewModel {
     key: string;
     provider: AiSessionProviderId;
     sessionId?: string;
+    pendingId?: string;
     name: string;
     executionState: ActiveAiSessionExecutionState;
-    status: ActiveAiSessionStatus;
     focused: boolean;
     needsAttention: boolean;
     pending: boolean;
@@ -214,10 +213,35 @@ export interface AiSessionsUpdatedMessage {
     searchCatalog: DashboardWorkspaceSearchCatalog;
 }
 
-export interface AiSessionActiveTerminalChangedMessage {
-    type: 'active-ai-session-terminal-changed';
-    provider: AiSessionProviderId | null;
-    sessionId: string | null;
+export interface ActiveAiSessionPresentation {
+    provider: AiSessionProviderId;
+    sessionId: string;
+    executionState: AiSessionExecutionState;
+    focused: boolean;
+    needsAttention: boolean;
+    conflict: boolean;
+    eventIds: string[];
+}
+
+export type ActiveAiSessionFocusedTarget =
+    | { provider: AiSessionProviderId; sessionId: string; pendingId?: never }
+    | { provider: AiSessionProviderId; pendingId: string; sessionId?: never };
+
+export interface AiSessionPresentationStateMessage {
+    type: 'ai-session-presentation-state';
+    version: 1;
+    projectionRevision: number;
+    workspaceScopeIdentity: string | null;
+    workspaceNavigationIdentity: string | null;
+    attentionCount: number;
+    activeAttentionCount: number;
+    runningSessionCount: number;
+    runningCardAnimation: string;
+    runningIconAnimation: string;
+    revealFocused: boolean;
+    focusedTarget: ActiveAiSessionFocusedTarget | null;
+    attentionSessions: Array<{ sessionKey: string; eventIds: string[] }>;
+    sessions: ActiveAiSessionPresentation[];
 }
 
 export interface AiSessionAssignmentCandidate<TProject = { id: string }> {

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -124,7 +124,7 @@ import {
 import { TmuxRuntimeBackend } from './aiSessions/tmuxRuntimeBackend';
 import { TmuxFocusedRuntimeMonitor } from './aiSessions/tmuxFocusedRuntimeMonitor';
 import { withTmuxCreationLock } from './aiSessions/tmuxCreationLock';
-import type { AiSessionBatchArchiveCompletedMessage, AiSessionProvider, AiSessionService, AiSessionTerminalEntry, AiSessionsUpdatedMessage, WorkspaceAiSessionActionTarget } from './aiSessions/types';
+import type { AiSessionBatchArchiveCompletedMessage, AiSessionPresentationStateMessage, AiSessionProvider, AiSessionService, AiSessionTerminalEntry, AiSessionsUpdatedMessage, WorkspaceAiSessionActionTarget } from './aiSessions/types';
 import {
     ConversationCapability,
     createConversationCapability,
@@ -208,6 +208,7 @@ import { PendingWorkspaceSaveStore } from './workspaces/pendingWorkspaceSaveStor
 import { SavedWorkspaceProjectAdapter } from './workspaces/savedWorkspaceProjectAdapter';
 import { WorkspacePendingSessionPromotionController } from './workspaces/pendingSessionPromotionController';
 import { hasWorkspaceRuntimeContinuity } from './workspaces/runtimeOwnership';
+import { projectWorkspaceActiveSessions } from './workspaces/activeSessionPresentation';
 import {
     AiSessionProjectionCoordinator,
     WorkspaceSessionHydrationController,
@@ -1006,16 +1007,7 @@ async function initializeDashboard(
         getRuntimeConfiguration: () => aiSessionRuntimeConfiguration,
         getCurrentOpenWorkspace: () => getCurrentOpenWorkspace(),
         getActiveTerminal: () => vscode.window.activeTerminal || null,
-        postMessage: message => {
-            const versionedMessage = message && typeof message === 'object'
-                && (message as { type?: unknown }).type === 'ai-session-attention-state'
-                ? {
-                    ...message,
-                    projectionRevision: aiSessionProjectionCoordinator.nextRevision(),
-                }
-                : message;
-            void provider.postMessage(versionedMessage);
-        },
+        postAttentionState: () => postAiSessionPresentationState(false),
         isVisible: () => provider.visible,
         assertActive: () => resources.assertActive(),
         createBridgeClient: (onAggregate, onError) => new AttentionBridgeClient(onAggregate, onError),
@@ -1736,6 +1728,7 @@ async function initializeDashboard(
         getWorkspaceProjectColor: workspace => getSavedProjectForWorkspace(workspace)?.color || '',
         getWorkspaceProjectName: workspace => getSavedProjectForWorkspace(workspace)?.name || '',
         getCurrentWorkspaceAiSessions: workspace => workspaceSessionHydrationController.hydrate(workspace),
+        getAiSessionProjectionRevision: () => aiSessionProjectionCoordinator.capture().revision,
         getGroups: () => projectService.getGroups(),
         getTodoSearchItems: () => todoService.getSearchItems(),
         getSkillRecords: () => skillPanel.getRecords(),
@@ -2569,18 +2562,36 @@ async function initializeDashboard(
 
     function postActiveAiSessionTerminalChanged() {
         void conversationCapability.reconcile();
-        const projection = aiSessionProjectionCoordinator.captureNext();
-        const focusedIdentity = projection.focusedIdentity;
-        dashboardRuntimeController.postActiveAiSessionTerminalChanged(
-            focusedIdentity?.sessionId
-                ? {
-                    provider: focusedIdentity.provider,
-                    sessionId: focusedIdentity.sessionId,
-                    workspaceScopeIdentity: focusedIdentity.workspaceScopeIdentity,
-                }
-                : null,
-            projection.revision,
-        );
+        postAiSessionPresentationState(true);
+    }
+
+    function postAiSessionPresentationState(revealFocused: boolean = false): void {
+        const snapshot = aiSessionProjectionCoordinator.captureNext();
+        const presentation = projectWorkspaceActiveSessions({
+            workspace: getCurrentOpenWorkspace(),
+            activeRuntimes: snapshot.activeRuntimes,
+            pendingRuntimes: snapshot.pendingRuntimes,
+            executionSnapshot: snapshot.executionSnapshot,
+            focusedIdentity: snapshot.focusedIdentity,
+            attentionAggregate: snapshot.attentionAggregate,
+        });
+        const configuration = getAgentPivotConfiguration();
+        const message: AiSessionPresentationStateMessage = {
+            type: 'ai-session-presentation-state',
+            version: 1,
+            projectionRevision: snapshot.revision,
+            ...presentation,
+            runningCardAnimation: getEffectiveRunningCardAnimation(configuration),
+            runningIconAnimation: getEffectiveRunningIconAnimation(configuration),
+            revealFocused,
+        };
+        try {
+            void provider.postMessage(message).then(undefined, error => {
+                logError('Failed to post the Active Session presentation.', error);
+            });
+        } catch (error) {
+            logError('Failed to post the Active Session presentation.', error);
+        }
     }
 
     function invalidateAiSessionCache(providerId: AiSessionProviderId) {

--- a/src/dashboard/runtimeController.ts
+++ b/src/dashboard/runtimeController.ts
@@ -1,8 +1,7 @@
 'use strict';
 
-import type { AiSessionProviderId, Project } from '../models';
-import type { AiSessionActiveTerminalChangedMessage, AiSessionBatchArchiveCompletedMessage } from '../aiSessions/types';
-import type { ActiveAiSessionTerminalIdentity } from '../aiSessions/activeTerminalHighlight';
+import type { Project } from '../models';
+import type { AiSessionBatchArchiveCompletedMessage } from '../aiSessions/types';
 import {
     AGENT_PIVOT_EXTENSION_ID,
     AGENT_PIVOT_VIEW_CONTAINER_ID,
@@ -112,21 +111,6 @@ export class DashboardRuntimeController<TProject extends Project = Project> {
     postBatchArchiveCompletion(message: AiSessionBatchArchiveCompletedMessage): void {
         this.runAsync(() => this.options.postMessage(message)).then(undefined, error => {
             this.options.logError('Failed to post batch AI session archive completion.', error);
-        });
-    }
-
-    postActiveAiSessionTerminalChanged(
-        identity: ActiveAiSessionTerminalIdentity | null,
-        projectionRevision?: number,
-    ): void {
-        const message: AiSessionActiveTerminalChangedMessage & { projectionRevision?: number } = {
-            type: 'active-ai-session-terminal-changed',
-            ...(Number.isSafeInteger(projectionRevision) ? { projectionRevision } : {}),
-            provider: identity?.provider as AiSessionProviderId || null,
-            sessionId: identity?.sessionId || null,
-        };
-        this.runAsync(() => this.options.postMessage(message)).then(undefined, error => {
-            this.options.logError('Failed to post the active AI session terminal.', error);
         });
     }
 

--- a/src/openWorkspaces/dashboardController.ts
+++ b/src/openWorkspaces/dashboardController.ts
@@ -8,7 +8,6 @@ import { PREDEFINED_COLORS } from '../constants';
 import type { Group, WorkspaceCardViewModel } from '../models';
 import { buildOpenWorkspacesUpdatedMessage } from '../dashboard/webviewUpdateMessages';
 import type { TodoSearchCatalogItem } from '../todos/types';
-import { getWorkspaceAttentionSummary } from '../workspaces/attentionProjection';
 import type { OpenWorkspace } from '../workspaces/types';
 import type { OpenWorkspaceBridgeStatus } from './bridgeClient';
 import {
@@ -36,6 +35,7 @@ export interface OpenWorkspaceDashboardControllerOptions {
     getWorkspaceProjectColor: (workspace: Pick<OpenWorkspace, 'kind' | 'navigationUri'>) => string;
     getWorkspaceProjectName?: (workspace: Pick<OpenWorkspace, 'kind' | 'navigationUri'>) => string;
     getCurrentWorkspaceAiSessions: (workspace: OpenWorkspace) => WorkspaceAiSessionViewModel | null;
+    getAiSessionProjectionRevision?: () => number;
     getGroups: () => Group[];
     getTodoSearchItems: () => TodoSearchCatalogItem[];
     getSkillRecords?: () => import('../skills/types').SkillRecord[];
@@ -136,7 +136,6 @@ export class OpenWorkspaceDashboardController {
         const currentCard = currentWorkspace
             ? this.createCurrentCard(
                 currentWorkspace,
-                attentionAggregate,
                 currentNavigationIdentity || currentWorkspace.navigationIdentity,
                 pinTimes.has(currentNavigationIdentity || currentWorkspace.navigationIdentity),
             )
@@ -283,7 +282,6 @@ export class OpenWorkspaceDashboardController {
 
     private createCurrentCard(
         workspace: OpenWorkspace,
-        attentionAggregate: AttentionAggregate | null,
         navigationIdentity: string,
         pinned: boolean,
     ): WorkspaceCardViewModel {
@@ -309,7 +307,7 @@ export class OpenWorkspaceDashboardController {
                 .sort((left, right) => left.ordinal - right.ordinal || left.id.localeCompare(right.id))
                 .map(root => ({ id: root.id, name: root.name, ordinal: root.ordinal })),
             aiSessions,
-            attentionCount: getWorkspaceAttentionSummary(workspace, attentionAggregate).attentionCount,
+            attentionCount: aiSessions?.attentionCount || 0,
         };
     }
 
@@ -385,6 +383,7 @@ export class OpenWorkspaceDashboardController {
             this.aggregate?.semanticRevision || null,
             this.pinSnapshot.revision,
             attentionAggregate?.aggregateRevision || null,
+            this.options.getAiSessionProjectionRevision?.() ?? null,
             workspace ? {
                 navigationIdentity: workspace.navigationIdentity,
                 scopeIdentity: workspace.scopeIdentity,

--- a/src/webview/webviewAiSessionContent.ts
+++ b/src/webview/webviewAiSessionContent.ts
@@ -335,7 +335,8 @@ function getCodexSessionRow(
     var metadata = [staleStatus, updatedAt, shortId].filter(value => !!value).join(' · ');
     var providerLabel = getAiProviderLabel(provider);
     var pinned = !!session.pinned;
-    var needsAttention = !!session.attention?.unread;
+    var needsAttention = runtime ? runtime.needsAttention : !!session.attention?.unread;
+    var attentionEventId = runtime?.attentionEventId || session.attention?.eventId || '';
     var attentionIndicator = needsAttention
         ? '<span class="ai-session-attention-indicator" title="AI session needs attention" aria-label="AI session needs attention"></span>'
         : '';
@@ -375,7 +376,7 @@ function getCodexSessionRow(
     var providerBadge = `<span class="ai-session-provider-badge">${providerLabel}</span>`;
 
     return `
-<div class="codex-session-row" role="group" aria-label="${providerLabel} session ${sessionName}"${runtimeAttributes}${rootAttributes}${pinned ? ' data-session-pinned' : ''}${active ? ' data-session-active' : ''}${needsAttention ? ' data-ai-session-attention data-session-event-id="' + escapeAttribute(session.attention.eventId) + '"' : ''} data-session-id="${sessionId}" data-session-provider="${provider}">
+<div class="codex-session-row" role="group" aria-label="${providerLabel} session ${sessionName}"${runtimeAttributes}${rootAttributes}${pinned ? ' data-session-pinned' : ''}${active ? ' data-session-active' : ''}${needsAttention ? ' data-ai-session-attention data-session-event-id="' + escapeAttribute(attentionEventId) + '"' : ''} data-session-id="${sessionId}" data-session-provider="${provider}">
     ${batchCheckbox}
     <button type="button" class="ai-session-primary-action" data-action="activate-ai-session" aria-label="${primaryAriaLabel}" title="${primaryAction} ${providerLabel} Session">
         ${attentionIndicator}
@@ -413,7 +414,7 @@ function getActiveAiSessionRow(
         ? normalizeRunningIconAnimation(runningIconAnimation)
         : '';
     var executionStatus = `<span class="ai-session-execution-status" aria-label="${executionAriaLabel}"><span class="ai-session-execution-dot" aria-hidden="true"></span>${executionLabel}</span>`;
-    var runtimeStatusLabel = model.status === 'conflict' || model.conflict ? 'Runtime conflict' : '';
+    var runtimeStatusLabel = model.conflict ? 'Runtime conflict' : '';
     var runtimeBadgeDescription = model.backend === 'tmux'
         ? 'Managed tmux runtime'
         : 'Direct VS Code terminal';
@@ -429,12 +430,12 @@ function getActiveAiSessionRow(
     var pinAction = model.pending
         ? ''
         : `<button type="button" class="codex-session-pin ${model.pinned ? 'active' : ''}" data-action="toggle-ai-session-pin" title="${pinTitle}" aria-label="${pinTitle}">${Icons.pin}</button>`;
-    var conflict = model.status === 'conflict' || model.conflict === true;
+    var conflict = model.conflict === true;
     var terminalAction = conflict ? '' : model.backend === 'tmux'
         ? `<button type="button" class="ai-session-close-terminal ai-session-stop-session" data-action="stop-ai-session-runtime" title="Stop Session… Terminates the AI task running in tmux." aria-label="Stop Session">${Icons.remove}</button>`
         : `<button type="button" class="ai-session-close-terminal" data-action="close-ai-session-terminal" title="Close Terminal…" aria-label="Close Terminal">${Icons.remove}</button>`;
     var pendingAttributes = model.pending
-        ? ` data-session-pending data-pending-created-at="${escapeAttribute(model.createdAt || '')}"`
+        ? ` data-session-pending data-pending-id="${escapeAttribute(model.pendingId || '')}" data-pending-created-at="${escapeAttribute(model.createdAt || '')}"`
         : ` data-session-active data-session-id="${sessionId}"`;
     var attentionAttributes = model.needsAttention && model.attentionEventId
         ? ` data-ai-session-attention data-session-event-id="${escapeAttribute(model.attentionEventId)}"`

--- a/src/webview/webviewProjectAiSessionControlsScripts.js
+++ b/src/webview/webviewProjectAiSessionControlsScripts.js
@@ -11,7 +11,7 @@ function initProjectAiSessionControls(options) {
         pending: false,
         requestId: null,
     };
-    var activeAiSessionTerminalState = { provider: null, sessionId: null };
+    var activeAiSessionTerminalState = { provider: null, sessionId: null, pendingId: null };
     var nextAiSessionBatchArchiveRequestId = 0;
     var nextAiSessionProviderSelectionRequestId = 0;
     var pendingAiSessionProviderSelectionProjectId = null;

--- a/src/webview/webviewProjectAiUpdateScripts.js
+++ b/src/webview/webviewProjectAiUpdateScripts.js
@@ -18,12 +18,7 @@ function initProjectAiSessionsUpdate(options) {
     var pendingWorkspaceSessionReveal = null;
     var latestAiSessionUpdateSequence = 0;
     var latestAiSessionProjectionRevision = 0;
-    var latestAiSessionFocusProjectionRevision = 0;
-    var latestAiSessionAttentionProjectionRevision = 0;
-    // Rendered HTML bootstraps attention only until the dedicated stream arrives.
-    // Later content replacements can carry an older snapshot with a newer delivery
-    // revision, so they must preserve the direct stream instead of reviving stale dots.
-    var hasDirectAiSessionAttentionProjection = false;
+    var latestAiSessionPresentationProjectionRevision = 0;
 
     function canApplyRevision(revision, latestRevision) {
         if (typeof revision === 'undefined') {
@@ -38,50 +33,28 @@ function initProjectAiSessionsUpdate(options) {
         return canApplyRevision(revision, latestAiSessionProjectionRevision);
     }
 
-    function canApplyFocusProjectionRevision(revision) {
-        return canApplyRevision(revision, latestAiSessionFocusProjectionRevision);
+    function canApplyPresentationProjectionRevision(revision) {
+        return canApplyRevision(revision, latestAiSessionPresentationProjectionRevision);
     }
 
-    function canApplyAttentionProjectionRevision(revision) {
-        return !hasDirectAiSessionAttentionProjection
-            && canApplyRevision(revision, latestAiSessionAttentionProjectionRevision);
-    }
-
-    function commitProjectionRevision(revision, adoptedFocus, adoptedAttention) {
+    function commitProjectionRevision(revision, adoptedPresentation) {
         if (Number.isSafeInteger(revision) && revision > 0) {
             latestAiSessionProjectionRevision = revision;
-            if (adoptedFocus) {
-                latestAiSessionFocusProjectionRevision = Math.max(
-                    latestAiSessionFocusProjectionRevision,
-                    revision
-                );
-            }
-            if (adoptedAttention) {
-                latestAiSessionAttentionProjectionRevision = Math.max(
-                    latestAiSessionAttentionProjectionRevision,
+            if (adoptedPresentation) {
+                latestAiSessionPresentationProjectionRevision = Math.max(
+                    latestAiSessionPresentationProjectionRevision,
                     revision
                 );
             }
         }
     }
 
-    function acceptFocusProjectionRevision(revision) {
-        if (!canApplyFocusProjectionRevision(revision)) {
+    function acceptPresentationProjectionRevision(revision) {
+        if (!canApplyPresentationProjectionRevision(revision)) {
             return false;
         }
         if (Number.isSafeInteger(revision) && revision > 0) {
-            latestAiSessionFocusProjectionRevision = revision;
-        }
-        return true;
-    }
-
-    function acceptAttentionProjectionRevision(revision) {
-        if (!canApplyRevision(revision, latestAiSessionAttentionProjectionRevision)) {
-            return false;
-        }
-        hasDirectAiSessionAttentionProjection = true;
-        if (Number.isSafeInteger(revision) && revision > 0) {
-            latestAiSessionAttentionProjectionRevision = revision;
+            latestAiSessionPresentationProjectionRevision = revision;
         }
         return true;
     }
@@ -104,8 +77,7 @@ function initProjectAiSessionsUpdate(options) {
         if (!canApplyProjectionRevision(message.projectionRevision)) {
             return;
         }
-        var adoptRenderedFocus = canApplyFocusProjectionRevision(message.projectionRevision);
-        var adoptRenderedAttention = canApplyAttentionProjectionRevision(
+        var adoptRenderedPresentation = canApplyPresentationProjectionRevision(
             message.projectionRevision
         );
 
@@ -126,8 +98,7 @@ function initProjectAiSessionsUpdate(options) {
         latestAiSessionUpdateSequence = message.sequence;
         commitProjectionRevision(
             message.projectionRevision,
-            adoptRenderedFocus,
-            adoptRenderedAttention
+            adoptRenderedPresentation
         );
         if (batchAiSessionState.projectId) {
             var projectDiv = findCurrentWorkspaceDiv(batchAiSessionState.projectId);
@@ -139,7 +110,7 @@ function initProjectAiSessionsUpdate(options) {
             }
         }
         reconcilePendingAiSessionProviderSelectionDom();
-        syncAiSessionProjectionDom(adoptRenderedFocus, adoptRenderedAttention);
+        syncAiSessionProjectionDom(adoptRenderedPresentation);
         updateStickyGroupHeaderOffset();
         if (window.__agentPivotDashboard) {
             window.__agentPivotDashboard.replaceSearchCatalog(message.searchCatalog);
@@ -248,10 +219,8 @@ function initProjectAiSessionsUpdate(options) {
 
     return {
         applyAiSessionsUpdate: applyAiSessionsUpdate,
-        acceptAttentionProjectionRevision: acceptAttentionProjectionRevision,
-        acceptFocusProjectionRevision: acceptFocusProjectionRevision,
-        canApplyAttentionProjectionRevision: canApplyAttentionProjectionRevision,
-        canApplyFocusProjectionRevision: canApplyFocusProjectionRevision,
+        acceptPresentationProjectionRevision: acceptPresentationProjectionRevision,
+        canApplyPresentationProjectionRevision: canApplyPresentationProjectionRevision,
         canApplyProjectionRevision: canApplyProjectionRevision,
         commitProjectionRevision: commitProjectionRevision,
         findCurrentWorkspaceDiv: findCurrentWorkspaceDiv,

--- a/src/webview/webviewProjectScripts.js
+++ b/src/webview/webviewProjectScripts.js
@@ -258,23 +258,34 @@ function initProjects() {
         getArchiveAiSessionMessageType: aiSessionControls.getArchiveAiSessionMessageType,
         isAiSessionProvider: aiSessionControls.isAiSessionProvider,
     });
-    function syncActiveAiSessionProjectionDom(adoptRenderedFocus) {
+    function syncActiveAiSessionProjectionDom(adoptRenderedFocus, revealFocused) {
         if (adoptRenderedFocus !== false) {
             var focusedRow = document.querySelector(
-                '.codex-session-row[data-session-focused][data-session-provider][data-session-id]'
+                '.codex-session-row[data-session-focused][data-session-provider]'
             );
             var provider = focusedRow && focusedRow.getAttribute('data-session-provider');
             aiSessionControls.activeAiSessionTerminalState.provider =
                 aiSessionControls.isAiSessionProvider(provider) ? provider : null;
             aiSessionControls.activeAiSessionTerminalState.sessionId = focusedRow
                 ? focusedRow.getAttribute('data-session-id') : null;
+            aiSessionControls.activeAiSessionTerminalState.pendingId = focusedRow
+                ? focusedRow.getAttribute('data-pending-id') : null;
         } else {
             var projectedFocusedRow = null;
-            document.querySelectorAll('.codex-session-row[data-session-id]').forEach(row => {
-                var focused = row.getAttribute('data-session-provider')
-                    === aiSessionControls.activeAiSessionTerminalState.provider
-                    && row.getAttribute('data-session-id')
-                    === aiSessionControls.activeAiSessionTerminalState.sessionId;
+            document.querySelectorAll(
+                '.codex-session-row[data-session-provider][data-session-id],'
+                    + '.codex-session-row[data-session-provider][data-pending-id]'
+            ).forEach(row => {
+                var providerMatches = row.getAttribute('data-session-provider')
+                    === aiSessionControls.activeAiSessionTerminalState.provider;
+                var focused = providerMatches && (
+                    (aiSessionControls.activeAiSessionTerminalState.sessionId !== null
+                        && row.getAttribute('data-session-id')
+                            === aiSessionControls.activeAiSessionTerminalState.sessionId)
+                    || (aiSessionControls.activeAiSessionTerminalState.pendingId !== null
+                        && row.getAttribute('data-pending-id')
+                            === aiSessionControls.activeAiSessionTerminalState.pendingId)
+                );
                 if (focused) projectedFocusedRow = row;
                 row.toggleAttribute(
                     'data-session-focused',
@@ -282,7 +293,8 @@ function initProjects() {
                 );
                 var primaryAction = row.querySelector('.ai-session-primary-action');
                 if (primaryAction) {
-                    var actionState = focused ? 'conversation' : 'focus';
+                    var focusedConversation = focused && row.hasAttribute('data-session-id');
+                    var actionState = focusedConversation ? 'conversation' : 'focus';
                     var actionAriaLabel = primaryAction.getAttribute(
                         'data-' + actionState + '-aria-label'
                     );
@@ -293,7 +305,8 @@ function initProjects() {
                     if (actionTitle) primaryAction.setAttribute('title', actionTitle);
                 }
                 var conversationHint = row.querySelector('.ai-session-open-conversation-hint');
-                if (focused && primaryAction && !conversationHint) {
+                if (focusedConversation
+                    && primaryAction && !conversationHint) {
                     conversationHint = document.createElement('span');
                     conversationHint.className = 'ai-session-open-conversation-hint';
                     conversationHint.setAttribute('aria-hidden', 'true');
@@ -303,48 +316,250 @@ function initProjects() {
                     conversationHint.remove();
                 }
             });
-            if (projectedFocusedRow) {
+            if (projectedFocusedRow && revealFocused) {
                 projectedFocusedRow.scrollIntoView({ block: 'nearest' });
             }
         }
         aiSessionControls.syncActiveAiSessionTerminalDom();
     }
-    function syncAiSessionAttentionProjectionDom(adoptRenderedAttention) {
-        if (adoptRenderedAttention !== false) return;
-        window.__agentPivotAttentionSessionEvents =
-            window.__agentPivotAttentionSessionEvents || {};
-        document.querySelectorAll(
+    function setAiSessionAttentionDom(row, eventIds, needsAttention) {
+        row.toggleAttribute('data-session-needs-attention', needsAttention);
+        row.toggleAttribute('data-ai-session-attention', needsAttention);
+        if (needsAttention && eventIds.length) {
+            row.setAttribute('data-session-event-id', eventIds[0]);
+        } else {
+            row.removeAttribute('data-session-event-id');
+        }
+        var primaryAction = row.querySelector('.ai-session-primary-action');
+        var indicator = row.querySelector('.ai-session-attention-indicator');
+        if (needsAttention && primaryAction && !indicator) {
+            indicator = document.createElement('span');
+            indicator.className = 'ai-session-attention-indicator';
+            indicator.title = 'AI session needs attention';
+            indicator.setAttribute('aria-label', 'AI session needs attention');
+            primaryAction.insertBefore(indicator, primaryAction.firstChild);
+        } else if (!needsAttention && indicator) {
+            indicator.remove();
+        }
+    }
+    function setAiSessionExecutionDom(row, presentation, iconAnimation) {
+        row.setAttribute('data-execution-state', presentation.executionState);
+        if (presentation.executionState === 'running' && iconAnimation !== 'none') {
+            row.setAttribute('data-session-icon-fx', iconAnimation);
+        } else {
+            row.removeAttribute('data-session-icon-fx');
+        }
+        row.toggleAttribute('data-session-conflict', presentation.conflict);
+        var status = row.querySelector('.ai-session-execution-status');
+        if (status) {
+            var running = presentation.executionState === 'running';
+            status.setAttribute(
+                'aria-label',
+                running ? 'AI is currently executing' : 'AI is not currently executing'
+            );
+            var label = status.lastChild;
+            if (label && label.nodeType === Node.TEXT_NODE) {
+                label.nodeValue = running ? 'Running' : 'Stopped';
+            }
+        }
+    }
+    function setActiveSessionTabAttentionDom(projectDiv, attentionCount) {
+        var tab = projectDiv.querySelector('[data-ai-session-tab="active"]');
+        if (!tab) return;
+        var dot = tab.querySelector('.ai-session-tab-attention');
+        if (attentionCount > 0 && !dot) {
+            dot = document.createElement('span');
+            dot.className = 'ai-session-tab-attention';
+            tab.appendChild(dot);
+        } else if (attentionCount === 0 && dot) {
+            dot.remove();
+            return;
+        }
+        if (dot) {
+            dot.setAttribute(
+                'aria-label',
+                attentionCount + ' active AI session'
+                    + (attentionCount === 1 ? ' needs' : 's need') + ' attention'
+            );
+        }
+    }
+    function setCurrentWorkspaceSummaryAttentionDom(projectDiv, attentionCount) {
+        var summary = projectDiv.querySelector('.project-codex-badge');
+        if (!summary && attentionCount > 0) {
+            summary = document.createElement('span');
+            summary.className = 'project-codex-badge';
+            summary.setAttribute('data-ai-session-total-count', '0');
+            summary.setAttribute('data-ai-session-active-count', '0');
+            projectDiv.appendChild(summary);
+        }
+        if (!summary) return;
+        summary.setAttribute('data-ai-session-attention-count', String(attentionCount));
+        var count = summary.querySelector('.ai-session-attention-count');
+        if (attentionCount > 0 && !count) {
+            count = document.createElement('b');
+            count.className = 'ai-session-attention-count';
+            summary.appendChild(count);
+        } else if (attentionCount === 0 && count) {
+            count.remove();
+            count = null;
+        }
+        if (count) {
+            count.textContent = String(attentionCount);
+            count.setAttribute(
+                'aria-label',
+                attentionCount + ' AI session'
+                    + (attentionCount === 1 ? ' needs' : 's need') + ' attention'
+            );
+        }
+        var total = Number(summary.getAttribute('data-ai-session-total-count')) || 0;
+        var active = Number(summary.getAttribute('data-ai-session-active-count')) || 0;
+        var parts = [];
+        if (total) parts.push(total + ' AI session' + (total === 1 ? '' : 's'));
+        if (active) parts.push(active + ' active AI session' + (active === 1 ? '' : 's'));
+        if (attentionCount) parts.push(attentionCount + ' AI session'
+            + (attentionCount === 1 ? ' needs' : 's need') + ' attention');
+        if (!parts.length) {
+            summary.remove();
+            projectDiv.removeAttribute('data-has-ai-session-badge');
+            return;
+        }
+        projectDiv.setAttribute('data-has-ai-session-badge', '');
+        summary.title = parts.join(', ');
+        summary.setAttribute('aria-label', parts.join(', '));
+    }
+    function setCurrentWorkspaceRunningDom(projectDiv, message) {
+        var running = message.runningSessionCount > 0;
+        projectDiv.classList.toggle('session-running', running);
+        if (running) {
+            projectDiv.setAttribute('data-session-fx', message.runningCardAnimation);
+            projectDiv.title = 'Workspace — ' + message.runningSessionCount + ' active session'
+                + (message.runningSessionCount === 1 ? '' : 's') + ' running';
+        } else {
+            projectDiv.removeAttribute('data-session-fx');
+            projectDiv.removeAttribute('title');
+        }
+        var effect = projectDiv.querySelector('.project-session-fx');
+        var showEffect = running && message.runningCardAnimation !== 'none';
+        if (showEffect && !effect) {
+            effect = document.createElement('div');
+            effect.className = 'project-session-fx';
+            projectDiv.appendChild(effect);
+        } else if (!showEffect && effect) {
+            effect.remove();
+        }
+    }
+    function setCurrentOpenWorkspaceSummaryDom(projectDiv, message) {
+        var runningBadge = projectDiv.querySelector('.project-codex-badge');
+        if (message.runningSessionCount > 0 && !runningBadge) {
+            runningBadge = document.createElement('span');
+            runningBadge.className = 'project-codex-badge';
+            var runningCount = document.createElement('span');
+            runningCount.className = 'ai-session-active-count';
+            runningBadge.appendChild(runningCount);
+            projectDiv.appendChild(runningBadge);
+        } else if (message.runningSessionCount === 0 && runningBadge) {
+            runningBadge.remove();
+            runningBadge = null;
+        }
+        if (runningBadge) {
+            var runningLabel = message.runningSessionCount + ' active AI session'
+                + (message.runningSessionCount === 1 ? '' : 's');
+            runningBadge.setAttribute(
+                'data-ai-session-active-count', String(message.runningSessionCount)
+            );
+            runningBadge.title = runningLabel;
+            runningBadge.setAttribute('aria-label', runningLabel);
+            var runningCount = runningBadge.querySelector('.ai-session-active-count');
+            runningCount.textContent = '●' + message.runningSessionCount;
+            runningCount.setAttribute('aria-label', runningLabel);
+        }
+        var attentionBadge = projectDiv.querySelector('.project-ai-attention-badge');
+        if (message.attentionCount > 0 && !attentionBadge) {
+            attentionBadge = document.createElement('span');
+            attentionBadge.className = 'project-ai-attention-badge';
+            projectDiv.appendChild(attentionBadge);
+        } else if (message.attentionCount === 0 && attentionBadge) {
+            attentionBadge.remove();
+            attentionBadge = null;
+        }
+        if (attentionBadge) {
+            var attentionLabel = message.attentionCount + ' item'
+                + (message.attentionCount === 1 ? '' : 's') + ' need'
+                + (message.attentionCount === 1 ? 's' : '') + ' attention';
+            attentionBadge.textContent = String(message.attentionCount);
+            attentionBadge.title = attentionLabel;
+            attentionBadge.setAttribute('aria-label', attentionLabel);
+        }
+        projectDiv.toggleAttribute(
+            'data-has-ai-session-badge',
+            message.runningSessionCount > 0 || message.attentionCount > 0
+        );
+        setCurrentWorkspaceRunningDom(projectDiv, message);
+    }
+    function applyAiSessionPresentationDom(message) {
+        var currentCards = Array.from(document.querySelectorAll(
+            '.workspace-card[data-workspace-navigation-identity="'
+                + CSS.escape(message.workspaceNavigationIdentity || '') + '"]'
+                + '[data-current-workspace],'
+                + '.workspace-card[data-workspace-navigation-identity="'
+                + CSS.escape(message.workspaceNavigationIdentity || '') + '"]'
+                + '[data-open-workspace-current]'
+        ));
+        if (!currentCards.length) return;
+        var projectDiv = currentCards.find(card => card.hasAttribute('data-current-workspace'));
+        var presentations = {};
+        message.sessions.forEach(presentation => {
+            presentations[presentation.provider + ':' + presentation.sessionId] = presentation;
+        });
+        var attentionEvents = {};
+        message.attentionSessions.forEach(session => {
+            attentionEvents[session.sessionKey] = session.eventIds.slice();
+        });
+        window.__agentPivotAttentionSessionEvents = attentionEvents;
+        var focused = message.focusedTarget;
+        aiSessionControls.activeAiSessionTerminalState.provider = focused ? focused.provider : null;
+        aiSessionControls.activeAiSessionTerminalState.sessionId = focused?.sessionId || null;
+        aiSessionControls.activeAiSessionTerminalState.pendingId = focused?.pendingId || null;
+        syncActiveAiSessionProjectionDom(false, message.revealFocused);
+        projectDiv?.querySelectorAll(
             '.codex-session-row[data-session-provider][data-session-id]'
         ).forEach(row => {
             var sessionKey = row.getAttribute('data-session-provider')
                 + ':' + row.getAttribute('data-session-id');
-            var eventIds = window.__agentPivotAttentionSessionEvents[sessionKey] || [];
-            var visibleEventIds = row.getAttribute('data-execution-state') === 'running'
-                ? []
-                : eventIds;
-            row.toggleAttribute('data-session-needs-attention', visibleEventIds.length > 0);
-            row.toggleAttribute('data-ai-session-attention', visibleEventIds.length > 0);
-            if (visibleEventIds.length) {
-                row.setAttribute('data-session-event-id', visibleEventIds[0]);
+            var presentation = presentations[sessionKey];
+            var eventIds = attentionEvents[sessionKey] || [];
+            if (presentation) {
+                setAiSessionExecutionDom(row, presentation, message.runningIconAnimation);
+                setAiSessionAttentionDom(
+                    row,
+                    presentation.eventIds,
+                    presentation.needsAttention
+                );
+            } else if (row.classList.contains('active-ai-session-row')) {
+                setAiSessionAttentionDom(row, [], false);
             } else {
-                row.removeAttribute('data-session-event-id');
-            }
-            var primaryAction = row.querySelector('.ai-session-primary-action');
-            var indicator = row.querySelector('.ai-session-attention-indicator');
-            if (visibleEventIds.length && primaryAction && !indicator) {
-                indicator = document.createElement('span');
-                indicator.className = 'ai-session-attention-indicator';
-                indicator.title = 'AI session needs attention';
-                indicator.setAttribute('aria-label', 'AI session needs attention');
-                primaryAction.insertBefore(indicator, primaryAction.firstChild);
-            } else if (!visibleEventIds.length && indicator) {
-                indicator.remove();
+                setAiSessionAttentionDom(row, eventIds, eventIds.length > 0);
             }
         });
+        if (projectDiv) {
+            setActiveSessionTabAttentionDom(projectDiv, message.activeAttentionCount);
+            setCurrentWorkspaceSummaryAttentionDom(projectDiv, message.attentionCount);
+            setCurrentWorkspaceRunningDom(projectDiv, message);
+        }
+        currentCards.filter(card => card.hasAttribute('data-open-workspace-current'))
+            .forEach(card => setCurrentOpenWorkspaceSummaryDom(card, message));
     }
-    function syncAiSessionProjectionDom(adoptRenderedFocus, adoptRenderedAttention) {
-        syncActiveAiSessionProjectionDom(adoptRenderedFocus);
-        syncAiSessionAttentionProjectionDom(adoptRenderedAttention);
+    function syncAiSessionProjectionDom(adoptRenderedPresentation) {
+        if (adoptRenderedPresentation !== false) {
+            window.__agentPivotAiSessionPresentationState = null;
+            syncActiveAiSessionProjectionDom(true, false);
+            return;
+        }
+        if (window.__agentPivotAiSessionPresentationState) {
+            applyAiSessionPresentationDom(window.__agentPivotAiSessionPresentationState);
+        } else {
+            syncActiveAiSessionProjectionDom(true, false);
+        }
     }
     var aiSessionsUpdate = initProjectAiSessionsUpdate({
         batchAiSessionState: aiSessionControls.batchAiSessionState,
@@ -522,7 +737,9 @@ function initProjects() {
                 }
             }
             aiSessionControls.reconcilePendingAiSessionProviderSelectionDom();
-            syncActiveAiSessionProjectionDom();
+            syncAiSessionProjectionDom(
+                window.__agentPivotAiSessionPresentationState ? false : true
+            );
             updateStickyGroupHeaderOffset();
             var renderedWorkspaceState = getWorkspaceUpdateDomState(document);
             window.vscode.postMessage({
@@ -534,10 +751,7 @@ function initProjects() {
         }
         if (message && message.type === 'open-workspaces-updated') {
             if (!aiSessionsUpdate.canApplyProjectionRevision(message.projectionRevision)) return;
-            var adoptOpenWorkspaceFocus = aiSessionsUpdate.canApplyFocusProjectionRevision(
-                message.projectionRevision
-            );
-            var adoptOpenWorkspaceAttention = aiSessionsUpdate.canApplyAttentionProjectionRevision(
+            var adoptOpenWorkspacePresentation = aiSessionsUpdate.canApplyPresentationProjectionRevision(
                 message.projectionRevision
             );
             if (!applyOpenWorkspacesUpdate(message)) {
@@ -546,13 +760,9 @@ function initProjects() {
             }
             aiSessionsUpdate.commitProjectionRevision(
                 message.projectionRevision,
-                adoptOpenWorkspaceFocus,
-                adoptOpenWorkspaceAttention
+                adoptOpenWorkspacePresentation
             );
-            syncAiSessionProjectionDom(
-                adoptOpenWorkspaceFocus,
-                adoptOpenWorkspaceAttention
-            );
+            syncAiSessionProjectionDom(adoptOpenWorkspacePresentation);
             updateStickyGroupHeaderOffset();
             var renderedOpenWorkspaceState = getOpenWorkspacesUpdateDomState();
             window.vscode.postMessage({
@@ -587,31 +797,51 @@ function initProjects() {
             return;
         }
 
-        if (message && message.type === 'active-ai-session-terminal-changed') {
-            if (!aiSessionsUpdate.acceptFocusProjectionRevision(message.projectionRevision)) return;
-            aiSessionControls.activeAiSessionTerminalState.provider = aiSessionControls.isAiSessionProvider(message.provider) ? message.provider : null;
-            aiSessionControls.activeAiSessionTerminalState.sessionId = typeof message.sessionId === 'string' ? message.sessionId : null;
-            syncActiveAiSessionProjectionDom(false);
-            return;
-        }
-
-        if (message && message.type === 'ai-session-attention-state') {
-            if (!aiSessionsUpdate.acceptAttentionProjectionRevision(message.projectionRevision)) return;
-            window.__agentPivotAttentionEvents = window.__agentPivotAttentionEvents || {};
-            window.__agentPivotAttentionSessionEvents = {};
-            (Array.isArray(message.sessionEvents) ? message.sessionEvents.slice(0, 1000) : []).forEach(session => {
-                if (!session || typeof session.sessionKey !== 'string' || !Array.isArray(session.eventIds)) return;
-                var separator = session.sessionKey.indexOf(':');
-                if (separator <= 0 || !aiSessionControls.isAiSessionProvider(session.sessionKey.slice(0, separator))) return;
-                var eventIds = Array.from(new Set(session.eventIds
-                    .slice(0, 1000)
-                    .filter(eventId => typeof eventId === 'string' && !!eventId)));
-                if (eventIds.length) window.__agentPivotAttentionSessionEvents[session.sessionKey] = eventIds;
-            });
-            (message.eventIds || []).forEach(eventId => {
-                if (typeof eventId === 'string') window.__agentPivotAttentionEvents[eventId] = true;
-            });
-            syncAiSessionAttentionProjectionDom(false);
+        if (message && message.type === 'ai-session-presentation-state') {
+            var validPresentation = message.version === 1
+                && Number.isSafeInteger(message.projectionRevision)
+                && message.projectionRevision > 0
+                && (typeof message.workspaceScopeIdentity === 'string'
+                    || message.workspaceScopeIdentity === null)
+                && (typeof message.workspaceNavigationIdentity === 'string'
+                    || message.workspaceNavigationIdentity === null)
+                && Number.isSafeInteger(message.attentionCount) && message.attentionCount >= 0
+                && Number.isSafeInteger(message.activeAttentionCount)
+                && message.activeAttentionCount >= 0
+                && Number.isSafeInteger(message.runningSessionCount)
+                && message.runningSessionCount >= 0
+                && ['current', 'sweep', 'orbit', 'halo', 'ripple', 'breath', 'custom', 'none']
+                    .includes(message.runningCardAnimation)
+                && ['current', 'halo', 'custom', 'none'].includes(message.runningIconAnimation)
+                && typeof message.revealFocused === 'boolean'
+                && Array.isArray(message.sessions) && message.sessions.length <= 1000
+                && message.sessions.every(session => session
+                    && aiSessionControls.isAiSessionProvider(session.provider)
+                    && typeof session.sessionId === 'string' && !!session.sessionId
+                    && (session.executionState === 'running'
+                        || session.executionState === 'stopped')
+                    && typeof session.focused === 'boolean'
+                    && typeof session.needsAttention === 'boolean'
+                    && typeof session.conflict === 'boolean'
+                    && Array.isArray(session.eventIds)
+                    && session.eventIds.length <= 1000
+                    && session.eventIds.every(eventId => typeof eventId === 'string' && !!eventId))
+                && Array.isArray(message.attentionSessions)
+                && message.attentionSessions.length <= 1000
+                && message.attentionSessions.every(session => session
+                    && typeof session.sessionKey === 'string' && !!session.sessionKey
+                    && Array.isArray(session.eventIds)
+                    && session.eventIds.length <= 1000
+                    && session.eventIds.every(eventId => typeof eventId === 'string' && !!eventId));
+            if (!validPresentation) {
+                aiSessionsUpdate.requestFullRefresh('invalid-ai-session-presentation-state');
+                return;
+            }
+            if (!aiSessionsUpdate.acceptPresentationProjectionRevision(
+                message.projectionRevision
+            )) return;
+            window.__agentPivotAiSessionPresentationState = message;
+            applyAiSessionPresentationDom(message);
             return;
         }
 

--- a/src/workspaces/activeSessionPresentation.ts
+++ b/src/workspaces/activeSessionPresentation.ts
@@ -1,0 +1,144 @@
+'use strict';
+
+import type { ActiveAiSessionTerminalIdentity } from '../aiSessions/activeTerminalHighlight';
+import type { AttentionAggregate } from '../aiSessions/attentionAggregate';
+import { getLogicalAttentionSessionKey } from '../aiSessions/attentionProject';
+import type { AiSessionExecutionSnapshot } from '../aiSessions/executionMonitor';
+import { getAiSessionKey } from '../aiSessions/sessionHelpers';
+import type {
+    AiSessionPendingRuntimeSnapshot,
+    AiSessionRuntimeIdentity,
+    AiSessionRuntimeSnapshot,
+} from '../aiSessions/runtimeTypes';
+import type {
+    ActiveAiSessionFocusedTarget,
+    ActiveAiSessionPresentation,
+} from '../aiSessions/types';
+import { getWorkspaceAttentionSummary } from './attentionProjection';
+import { hasWorkspaceRuntimeContinuity } from './runtimeOwnership';
+import type { OpenWorkspace } from './types';
+
+export interface WorkspaceActiveSessionPresentation {
+    workspaceScopeIdentity: string | null;
+    workspaceNavigationIdentity: string | null;
+    attentionCount: number;
+    activeAttentionCount: number;
+    runningSessionCount: number;
+    focusedTarget: ActiveAiSessionFocusedTarget | null;
+    attentionSessions: Array<{ sessionKey: string; eventIds: string[] }>;
+    sessions: ActiveAiSessionPresentation[];
+}
+
+export interface ProjectWorkspaceActiveSessionsInput<TTerminal = unknown> {
+    workspace: OpenWorkspace | null;
+    activeRuntimes: readonly AiSessionRuntimeSnapshot<TTerminal>[];
+    pendingRuntimes?: readonly AiSessionPendingRuntimeSnapshot<TTerminal>[];
+    executionSnapshot: Readonly<Record<string, AiSessionExecutionSnapshot>>;
+    focusedIdentity: AiSessionRuntimeIdentity | ActiveAiSessionTerminalIdentity | null;
+    attentionAggregate: AttentionAggregate | null;
+}
+
+/**
+ * The sole owner of the user-visible Active Session lifecycle projection.
+ * Consumers must render these decisions instead of recombining runtime,
+ * execution, focus, and Attention state themselves.
+ */
+export function projectWorkspaceActiveSessions<TTerminal = unknown>(
+    input: ProjectWorkspaceActiveSessionsInput<TTerminal>
+): WorkspaceActiveSessionPresentation {
+    if (!input.workspace) {
+        return {
+            workspaceScopeIdentity: null,
+            workspaceNavigationIdentity: null,
+            attentionCount: 0,
+            activeAttentionCount: 0,
+            runningSessionCount: 0,
+            focusedTarget: null,
+            attentionSessions: [],
+            sessions: [],
+        };
+    }
+
+    const runtimeGroups = new Map<string, AiSessionRuntimeSnapshot<TTerminal>[]>();
+    for (const runtime of input.activeRuntimes || []) {
+        const sessionId = runtime.identity.sessionId;
+        if (!sessionId || !hasWorkspaceRuntimeContinuity(input.workspace, runtime)) {
+            continue;
+        }
+        const key = getAiSessionKey(runtime.identity.provider, sessionId);
+        const group = runtimeGroups.get(key) || [];
+        group.push(runtime);
+        runtimeGroups.set(key, group);
+    }
+
+    const workspaceAttention = getWorkspaceAttentionSummary(
+        input.workspace,
+        input.attentionAggregate
+    );
+    const attentionBySession = new Map(workspaceAttention.sessions.map(session => [
+        getLogicalAttentionSessionKey(session.sessionKey),
+        session.eventIds.slice(),
+    ]));
+    const runningSessionKeys = new Set<string>();
+    const sessions = Array.from(runtimeGroups.entries()).map(([key, runtimes]) => {
+        const runtime = runtimes[0];
+        const sessionId = runtime.identity.sessionId as string;
+        const executionState = input.executionSnapshot[key]?.state || 'stopped';
+        const focused = runtimes.some(candidate =>
+            input.focusedIdentity?.provider === candidate.identity.provider
+            && input.focusedIdentity.sessionId === sessionId
+            && input.focusedIdentity.workspaceScopeIdentity
+                === candidate.identity.workspaceScopeIdentity
+        );
+        const eventIds = attentionBySession.get(key) || [];
+        if (executionState === 'running') {
+            runningSessionKeys.add(key);
+        }
+        return {
+            provider: runtime.identity.provider,
+            sessionId,
+            executionState,
+            focused,
+            needsAttention: executionState !== 'running' && eventIds.length > 0,
+            conflict: runtimes.length > 1 || runtime.state === 'conflict',
+            eventIds: executionState === 'running' ? [] : eventIds,
+        };
+    }).sort((left, right) => getAiSessionKey(left.provider, left.sessionId)
+        .localeCompare(getAiSessionKey(right.provider, right.sessionId)));
+    const attentionSessions = workspaceAttention.sessions
+        .map(session => ({
+            sessionKey: getLogicalAttentionSessionKey(session.sessionKey),
+            eventIds: session.eventIds.slice(),
+        }))
+        .filter(session => !runningSessionKeys.has(session.sessionKey));
+    const focusedSession = sessions.find(session => session.focused);
+    const focusedPendingId = input.focusedIdentity && 'pendingId' in input.focusedIdentity
+        ? input.focusedIdentity.pendingId
+        : undefined;
+    const focusedPending = !focusedSession && focusedPendingId
+        ? (input.pendingRuntimes || []).find(runtime =>
+            hasWorkspaceRuntimeContinuity(input.workspace as OpenWorkspace, runtime)
+            && runtime.identity.provider === input.focusedIdentity?.provider
+            && runtime.identity.pendingId === focusedPendingId
+            && runtime.identity.workspaceScopeIdentity
+                === input.focusedIdentity?.workspaceScopeIdentity)
+        : undefined;
+    const focusedTarget: ActiveAiSessionFocusedTarget | null = focusedSession ? {
+        provider: focusedSession.provider,
+        sessionId: focusedSession.sessionId,
+    } : focusedPending ? {
+        provider: focusedPending.identity.provider,
+        pendingId: focusedPending.identity.pendingId,
+    } : null;
+
+    return {
+        workspaceScopeIdentity: input.workspace.scopeIdentity,
+        workspaceNavigationIdentity: input.workspace.navigationIdentity,
+        attentionCount: attentionSessions.length,
+        activeAttentionCount: sessions.filter(session => session.needsAttention).length,
+        runningSessionCount: sessions.filter(session => session.executionState === 'running').length,
+        focusedTarget,
+        attentionSessions,
+        sessions,
+    };
+}

--- a/src/workspaces/sessionHydration.ts
+++ b/src/workspaces/sessionHydration.ts
@@ -10,7 +10,6 @@ import type {
     AiSessionRuntimeSnapshot,
 } from '../aiSessions/runtimeTypes';
 import type {
-    ActiveAiSessionStatus,
     ActiveAiSessionViewModel,
     AiSessionProviderDefinition,
     AiSessionReadResult,
@@ -26,6 +25,10 @@ import {
 } from './sessionAssignment';
 import { hasWorkspaceRuntimeContinuity } from './runtimeOwnership';
 export { hasWorkspaceRuntimeContinuity } from './runtimeOwnership';
+import {
+    projectWorkspaceActiveSessions,
+    WorkspaceActiveSessionPresentation,
+} from './activeSessionPresentation';
 import type { OpenWorkspace, WorkspaceRoot } from './types';
 import {
     buildWorkspaceSessionAttentionIndex,
@@ -85,6 +88,14 @@ interface ProjectablePendingRuntime<TTerminal> extends AiSessionPendingRuntimeSn
 export function hydrateWorkspaceAiSessions<TTerminal = unknown>(
     input: HydrateWorkspaceAiSessionsInput<TTerminal>
 ): WorkspaceAiSessionViewModel {
+    const activePresentation = projectWorkspaceActiveSessions({
+        workspace: input.workspace,
+        activeRuntimes: input.activeRuntimes || [],
+        pendingRuntimes: input.pendingRuntimes || [],
+        executionSnapshot: input.executionSnapshot || {},
+        focusedIdentity: input.focusedIdentity || null,
+        attentionAggregate: input.attentionAggregate || null,
+    });
     const attentionByRootAndSession = buildWorkspaceSessionAttentionIndex(
         input.attentionAggregate || null
     );
@@ -96,8 +107,13 @@ export function hydrateWorkspaceAiSessions<TTerminal = unknown>(
     const activeSessionKeys = new Set(activeRuntimes
         .filter(runtime => !!runtime.identity.sessionId)
         .map(runtime => getAiSessionKey(runtime.identity.provider, runtime.identity.sessionId)));
-    const focusedSessionKey = getFocusedSessionKey(input.focusedIdentity, activeRuntimes);
-    const focusedPendingKey = getFocusedPendingKey(input.focusedIdentity, pendingRuntimes);
+    const focusedTarget = activePresentation.focusedTarget;
+    const focusedSessionKey = focusedTarget?.sessionId
+        ? getAiSessionKey(focusedTarget.provider, focusedTarget.sessionId)
+        : null;
+    const focusedPendingKey = focusedTarget?.pendingId
+        ? pendingKey(focusedTarget.provider, focusedTarget.pendingId)
+        : null;
     const sessionsByProvider: Partial<Record<AiSessionProviderId, AiSessionViewModel[]>> = {};
     const unavailableProviders: AiSessionProviderId[] = [];
 
@@ -146,7 +162,7 @@ export function hydrateWorkspaceAiSessions<TTerminal = unknown>(
         sessionsByProvider,
         activeRuntimes,
         pendingRuntimes,
-        focusedSessionKey,
+        activePresentation,
         focusedPendingKey,
     });
     return buildWorkspaceAiSessionViewModel({
@@ -155,6 +171,7 @@ export function hydrateWorkspaceAiSessions<TTerminal = unknown>(
         sessionsByProvider,
         unavailableProviders,
         activeSessions,
+        attentionCount: activePresentation.attentionCount,
         activeProvider: input.activeProvider,
         providerSelection: input.providerSelection,
         expanded: input.expanded,
@@ -187,7 +204,7 @@ function buildActiveSessions<TTerminal>(input: {
     sessionsByProvider: Partial<Record<AiSessionProviderId, AiSessionViewModel[]>>;
     activeRuntimes: AiSessionRuntimeSnapshot<TTerminal>[];
     pendingRuntimes: ProjectablePendingRuntime<TTerminal>[];
-    focusedSessionKey: string | null;
+    activePresentation: WorkspaceActiveSessionPresentation;
     focusedPendingKey: string | null;
 }): ActiveAiSessionViewModel[] {
     const active = input.activeRuntimes
@@ -199,18 +216,19 @@ function buildActiveSessions<TTerminal>(input: {
             const session = input.sessionsByProvider[providerId]
                 ?.find(candidate => candidate.id === sessionId);
             const root = assignPathToWorkspaceRoot(runtime.identity.cwd, input.input.workspace.roots);
-            const focused = input.focusedSessionKey === key;
-            const executionState = input.input.executionSnapshot?.[key]?.state || 'stopped';
-            const needsAttention = executionState !== 'running'
-                && session?.attention?.unread === true;
-            const conflict = runtime.state === 'conflict';
+            const presentation = input.activePresentation.sessions.find(candidate =>
+                candidate.provider === providerId && candidate.sessionId === sessionId
+            );
+            const focused = presentation?.focused === true;
+            const executionState = presentation?.executionState || 'stopped';
+            const needsAttention = presentation?.needsAttention === true;
+            const conflict = presentation?.conflict === true;
             return {
                 key,
                 provider: providerId,
                 sessionId,
                 name: session?.name || `${providerLabel(input.input.providers, providerId)} ${shortId(sessionId)}`,
                 executionState,
-                status: establishedStatus(needsAttention, focused, conflict),
                 focused,
                 needsAttention,
                 pending: false,
@@ -221,8 +239,8 @@ function buildActiveSessions<TTerminal>(input: {
                 ...(runtime.stale ? { stale: true } : {}),
                 ...(session?.updatedAt ? { updatedAt: session.updatedAt } : {}),
                 ...(session?.pinned !== undefined ? { pinned: session.pinned } : {}),
-                ...(needsAttention && session?.attention?.eventId
-                    ? { attentionEventId: session.attention.eventId }
+                ...(needsAttention && presentation?.eventIds[0]
+                    ? { attentionEventId: presentation.eventIds[0] }
                     : {}),
                 ...rootMetadata(root),
                 activityMs: finiteNumber(runtime.runStartedAtMs),
@@ -239,9 +257,9 @@ function buildActiveSessions<TTerminal>(input: {
         return {
             key,
             provider: providerId,
+            pendingId,
             name: runtime.title || `New ${providerLabel(input.input.providers, providerId)} session`,
             executionState: 'starting',
-            status: conflict ? 'conflict' : focused ? 'focused' : 'starting',
             focused,
             needsAttention: false,
             pending: true,
@@ -337,37 +355,8 @@ function cloneRuntime<TTerminal>(runtime: AiSessionRuntimeSnapshot<TTerminal>): 
     };
 }
 
-function getFocusedSessionKey<TTerminal>(
-    focused: AiSessionRuntimeIdentity | ActiveAiSessionTerminalIdentity | null | undefined,
-    runtimes: readonly AiSessionRuntimeSnapshot<TTerminal>[]
-): string | null {
-    if (!focused?.sessionId || !runtimes.some(runtime => runtime.identity.provider === focused.provider
-        && runtime.identity.sessionId === focused.sessionId
-        && runtime.identity.workspaceScopeIdentity === focused.workspaceScopeIdentity)) {
-        return null;
-    }
-    return getAiSessionKey(focused.provider, focused.sessionId);
-}
-
-function getFocusedPendingKey<TTerminal>(
-    focused: AiSessionRuntimeIdentity | ActiveAiSessionTerminalIdentity | null | undefined,
-    runtimes: readonly ProjectablePendingRuntime<TTerminal>[]
-): string | null {
-    if (!focused || !('pendingId' in focused) || !focused.pendingId
-        || !runtimes.some(runtime => runtime.identity.provider === focused.provider
-            && runtime.identity.pendingId === focused.pendingId
-            && runtime.identity.workspaceScopeIdentity === focused.workspaceScopeIdentity)) {
-        return null;
-    }
-    return pendingKey(focused.provider, focused.pendingId);
-}
-
 function providerLabel(providers: readonly HydrationProvider[], providerId: AiSessionProviderId): string {
     return providers.find(provider => provider.id === providerId)?.label || 'AI';
-}
-
-function establishedStatus(needsAttention: boolean, focused: boolean, conflict: boolean): ActiveAiSessionStatus {
-    return conflict ? 'conflict' : needsAttention ? 'needsAttention' : focused ? 'focused' : 'running';
 }
 
 function compareActiveSessions(left: SortableActiveSession, right: SortableActiveSession): number {

--- a/src/workspaces/viewModels.ts
+++ b/src/workspaces/viewModels.ts
@@ -17,6 +17,7 @@ export interface BuildWorkspaceAiSessionViewModelInput {
     sessionsByProvider: Partial<Record<AiSessionProviderId, AiSessionViewModel[]>>;
     unavailableProviders: readonly AiSessionProviderId[];
     activeSessions: readonly ActiveAiSessionViewModel[];
+    attentionCount: number;
     activeProvider?: AiSessionProviderId;
     providerSelection?: AiSessionProviderSelection;
     expanded?: boolean;
@@ -60,9 +61,7 @@ export function buildWorkspaceAiSessionViewModel(
             .filter(provider => unavailableProviders.has(provider.id))
             .map(provider => provider.id),
         aiSessionCount: providers.reduce((count, provider) => count + provider.count, 0),
-        attentionCount: Object.values(sessionsByProvider)
-            .reduce((count, sessions) => count + (sessions || [])
-                .filter(session => session.attention?.unread).length, 0),
+        attentionCount: input.attentionCount,
         defaultTab: activeSessions.length ? 'active' : 'sessions',
         activeSessions,
         activeSessionCount: activeSessions.length,

--- a/tests/browser/activeSessionCardInteraction.test.js
+++ b/tests/browser/activeSessionCardInteraction.test.js
@@ -25,7 +25,7 @@ function loadWebviewContent() {
     }
 }
 
-const { getAiSessionsDiv } = loadWebviewContent();
+const { getAiSessionsDiv, getCurrentWorkspaceGroupContent } = loadWebviewContent();
 const viewStateScript = fs.readFileSync(
     path.join(__dirname, '../../src/webview/webviewAiSessionViewStateScripts.js'),
     'utf8'
@@ -155,6 +155,37 @@ function projectMarkup(activeAiSessions) {
     </div>`;
 }
 
+function currentWorkspaceGroupMarkup(activeAiSessions, attentionCount = 0) {
+    return getCurrentWorkspaceGroupContent({
+        id: 'project-a',
+        kind: 'current',
+        workspaceKind: 'singleFolder',
+        showSaveAction: false,
+        runningSessionCount: activeAiSessions
+            .filter(entry => entry.executionState === 'running').length,
+        navigationIdentity: 'navigation-project-a',
+        scopeIdentity: 'scope-project-a',
+        name: 'Project A',
+        environment: 'local',
+        environmentLabel: 'Local',
+        color: '',
+        roots: [{ id: 'root-project-a', name: 'Project A', ordinal: 0 }],
+        attentionCount,
+        aiSessions: {
+            activeProvider: 'codex',
+            selectedProviders: ['codex'],
+            expanded: true,
+            sessionsByProvider: { codex: [], kimi: [], claude: [] },
+            unavailableProviders: [],
+            activeSessions: activeAiSessions,
+            aiSessionCount: 1,
+            activeSessionCount: activeAiSessions.length,
+            activeAttentionCount: activeAiSessions
+                .filter(entry => entry.needsAttention).length,
+        },
+    });
+}
+
 function listProjectMarkup(activeAiSessions, historySessions, selectedTab = 'active') {
     return `<div class="project workspace-card" data-id="project-a" data-current-workspace
         data-codex-expanded
@@ -221,26 +252,31 @@ async function isRowFullyVisibleInList(rowLocator) {
     });
 }
 
-function documentMarkup(activeAiSessions) {
+function documentMarkup(activeAiSessions, currentWorkspaceMarkup) {
     return `<!doctype html>
         <html>
             <head><style>${styles}</style></head>
             <body class="steward-sidebar">
                 <div class="steward-sticky-header"></div>
                 <div class="sticky-groups-wrapper">
-                    <div class="open-current-workspace-group">
+                    ${currentWorkspaceMarkup || `<div class="open-current-workspace-group">
                         ${projectMarkup(activeAiSessions)}
-                    </div>
+                    </div>`}
                 </div>
             </body>
         </html>`;
 }
 
-async function openCardPage(t, activeAiSessions, viewport = { width: 360, height: 900 }) {
+async function openCardPage(
+    t,
+    activeAiSessions,
+    viewport = { width: 360, height: 900 },
+    currentWorkspaceMarkup
+) {
     const page = await browser.newPage({ viewport });
     t.after(() => page.close());
     page.setDefaultTimeout(BROWSER_CONDITION_TIMEOUT_MS);
-    await page.setContent(documentMarkup(activeAiSessions));
+    await page.setContent(documentMarkup(activeAiSessions, currentWorkspaceMarkup));
     await page.evaluate(() => {
         window.__postedMessages = [];
         window.normalizeDashboardSearchCatalog = catalog => catalog;
@@ -307,6 +343,51 @@ async function postHostMessage(page, message) {
     await page.evaluate(value => {
         window.dispatchEvent(new MessageEvent('message', { data: value }));
     }, message);
+}
+
+function presentationMessage(activeSessions, projectionRevision, options = {}) {
+    const attention = options.attention || {};
+    const attentionSessions = Object.entries(attention).map(([sessionKey, eventIds]) => ({
+        sessionKey,
+        eventIds,
+    }));
+    const focusedEntry = activeSessions.find(entry => entry.focused);
+    const focusedTarget = options.focusedTarget ?? (focusedEntry
+        ? focusedEntry.pending
+            ? { provider: focusedEntry.provider, pendingId: focusedEntry.pendingId }
+            : { provider: focusedEntry.provider, sessionId: focusedEntry.sessionId }
+        : null);
+    return {
+        type: 'ai-session-presentation-state',
+        version: 1,
+        projectionRevision,
+        workspaceScopeIdentity: 'scope-project-a',
+        workspaceNavigationIdentity: 'navigation-project-a',
+        attentionCount: options.attentionCount ?? attentionSessions.length,
+        activeAttentionCount: activeSessions.filter(entry =>
+            (attention[`${entry.provider}:${entry.sessionId}`] || []).length > 0
+        ).length,
+        runningSessionCount: activeSessions.filter(entry =>
+            entry.executionState === 'running'
+        ).length,
+        runningCardAnimation: 'current',
+        runningIconAnimation: 'current',
+        revealFocused: options.revealFocused === true,
+        focusedTarget,
+        attentionSessions,
+        sessions: activeSessions.filter(entry => !entry.pending).map(entry => {
+            const eventIds = attention[`${entry.provider}:${entry.sessionId}`] || [];
+            return {
+                provider: entry.provider,
+                sessionId: entry.sessionId,
+                executionState: entry.executionState,
+                focused: entry.focused,
+                needsAttention: eventIds.length > 0,
+                conflict: entry.conflict === true,
+                eventIds,
+            };
+        }),
+    };
 }
 
 function focusOrigin(overrides = {}) {
@@ -410,17 +491,13 @@ test('ACTIVE-SESSION-FOCUS-REVEAL-001 reveals the newly focused card when a work
     assert.equal(await isRowFullyVisibleInList(row(page, 'codex', 'active-2')), true);
 });
 
-test('ACTIVE-SESSION-FOCUS-REVEAL-001 keeps a newer focus projection when an independent Attention message arrives first', async t => {
-    const page = await openCardPage(t, [
+test('ACTIVE-SESSION-FOCUS-REVEAL-001 keeps a newer complete presentation when older HTML arrives later', async t => {
+    const initial = [
         session('codex', 'session-a', true),
         session('codex', 'session-b', false),
-    ]);
-    await postHostMessage(page, {
-        type: 'ai-session-attention-state',
-        projectionRevision: 2,
-        eventIds: [],
-        sessionEvents: [],
-    });
+    ];
+    const page = await openCardPage(t, initial);
+    await postHostMessage(page, presentationMessage(initial, 2));
     await postHostMessage(page, {
         type: 'ai-sessions-updated',
         version: 2,
@@ -440,22 +517,17 @@ test('ACTIVE-SESSION-FOCUS-REVEAL-001 keeps a newer focus projection when an ind
         },
     });
 
-    assert.equal(await row(page, 'codex', 'session-b').getAttribute('data-session-focused'), '');
+    assert.equal(await row(page, 'codex', 'session-a').getAttribute('data-session-focused'), '');
     assert.equal(
-        await row(page, 'codex', 'session-b').getAttribute('data-ai-session-active-terminal'),
+        await row(page, 'codex', 'session-a').getAttribute('data-ai-session-active-terminal'),
         ''
     );
     assert.equal(
-        await row(page, 'codex', 'session-a').getAttribute('data-ai-session-active-terminal'),
+        await row(page, 'codex', 'session-b').getAttribute('data-ai-session-active-terminal'),
         null
     );
 
-    await postHostMessage(page, {
-        type: 'active-ai-session-terminal-changed',
-        projectionRevision: 4,
-        provider: 'codex',
-        sessionId: 'session-a',
-    });
+    await postHostMessage(page, presentationMessage(initial, 4, { revealFocused: true }));
     await postHostMessage(page, {
         type: 'ai-sessions-updated',
         version: 2,
@@ -488,12 +560,13 @@ test('ACTIVE-SESSION-FOCUS-REVEAL-001 keeps a newer focus projection when an ind
         0
     );
 
-    await postHostMessage(page, {
-        type: 'ai-session-attention-state',
-        projectionRevision: 6,
-        eventIds: ['event-b'],
-        sessionEvents: [{ sessionKey: 'codex:session-b', eventIds: ['event-b'] }],
-    });
+    const attentionState = [
+        session('codex', 'session-a', true),
+        { ...session('codex', 'session-b', false), executionState: 'stopped' },
+    ];
+    await postHostMessage(page, presentationMessage(attentionState, 6, {
+        attention: { 'codex:session-b': ['event-b'] },
+    }));
     await postHostMessage(page, {
         type: 'ai-sessions-updated',
         version: 2,
@@ -529,18 +602,64 @@ test('ACTIVE-SESSION-FOCUS-REVEAL-001 keeps a newer focus projection when an ind
     );
 });
 
-test('ATTENTION-EXECUTION-STATE-SYNC-001 ignores stale Attention DOM state while an Active Session is running', async t => {
-    const page = await openCardPage(t, [session('codex', 'current-session', true)]);
+test('ACTIVE-SESSION-FOCUS-REVEAL-001 transfers pending focus through the complete presentation', async t => {
+    const pending = {
+        key: 'pending:codex:pending-one',
+        provider: 'codex',
+        pendingId: 'pending-one',
+        name: 'New Codex session',
+        executionState: 'starting',
+        focused: true,
+        needsAttention: false,
+        pending: true,
+        backend: 'tmux',
+        tmuxLayout: 'project',
+        attached: true,
+        createdAt: '2026-08-10T00:00:00.000Z',
+    };
+    const established = session('codex', 'established-one', false);
+    const page = await openCardPage(t, [pending, established]);
+    const pendingRow = page.locator(
+        '.active-ai-session-row[data-session-provider="codex"][data-pending-id="pending-one"]'
+    );
+    assert.equal(await pendingRow.getAttribute('data-session-focused'), '');
+    await postHostMessage(page, presentationMessage(
+        [pending, established],
+        2,
+        { focusedTarget: { provider: 'codex', pendingId: 'pending-one' } }
+    ));
+    assert.equal(
+        await pendingRow.locator('.ai-session-primary-action').getAttribute('title'),
+        'Focus pending Codex Session'
+    );
+    assert.equal(
+        await pendingRow.locator('.ai-session-open-conversation-hint').count(),
+        0
+    );
 
-    await postHostMessage(page, {
-        type: 'ai-session-attention-state',
-        projectionRevision: 2,
-        eventIds: ['stale-event'],
-        sessionEvents: [{
-            sessionKey: 'codex:current-session',
-            eventIds: ['stale-event'],
-        }],
-    });
+    const focusedEstablished = { ...established, focused: true };
+    await postHostMessage(page, presentationMessage(
+        [pending, focusedEstablished],
+        3,
+        { focusedTarget: { provider: 'codex', sessionId: 'established-one' } }
+    ));
+
+    assert.equal(await pendingRow.getAttribute('data-session-focused'), null);
+    assert.equal(
+        await row(page, 'codex', 'established-one').getAttribute('data-session-focused'),
+        ''
+    );
+    assert.equal(
+        await page.locator('.codex-session-row[data-session-focused]').count(),
+        1
+    );
+});
+
+test('ATTENTION-EXECUTION-STATE-SYNC-001 ignores stale Attention DOM state while an Active Session is running', async t => {
+    const running = session('codex', 'current-session', true);
+    const page = await openCardPage(t, [running]);
+
+    await postHostMessage(page, presentationMessage([running], 2));
 
     const currentRow = row(page, 'codex', 'current-session');
     assert.equal(await currentRow.getAttribute('data-execution-state'), 'running');
@@ -550,24 +669,10 @@ test('ATTENTION-EXECUTION-STATE-SYNC-001 ignores stale Attention DOM state while
     assert.equal(await currentRow.getAttribute('data-session-event-id'), null);
     assert.equal(await currentRow.locator('.ai-session-attention-indicator').count(), 0);
 
-    await postHostMessage(page, {
-        type: 'ai-sessions-updated',
-        version: 2,
-        sequence: 1,
-        projectionRevision: 3,
-        currentWorkspaceCount: 1,
-        html: `<div class="open-current-workspace-group">${projectMarkup([{
-            ...session('codex', 'current-session', true),
-            executionState: 'stopped',
-        }])}</div>`,
-        searchCatalog: {
-            version: 2,
-            sessions: [],
-            openWorkspaces: [],
-            savedProjects: [],
-            todos: [],
-        },
-    });
+    const stopped = { ...running, executionState: 'stopped' };
+    await postHostMessage(page, presentationMessage([stopped], 3, {
+        attention: { 'codex:current-session': ['stale-event'] },
+    }));
 
     const stoppedRow = row(page, 'codex', 'current-session');
     assert.equal(await stoppedRow.getAttribute('data-session-icon-fx'), null);
@@ -577,6 +682,163 @@ test('ATTENTION-EXECUTION-STATE-SYNC-001 ignores stale Attention DOM state while
         'suppressing the running dot does not discard the authoritative Attention event');
 });
 
+test('ATTENTION-EXECUTION-STATE-SYNC-001 applies every Active Session presentation surface atomically', async t => {
+    const stoppedSession = {
+        ...session('codex', 'current-session', true),
+        executionState: 'stopped',
+    };
+    const page = await openCardPage(
+        t,
+        [stoppedSession],
+        { width: 360, height: 900 },
+        `${currentWorkspaceGroupMarkup([stoppedSession])}
+            <div class="open-other-windows-group">${currentOpenWorkspaceProjectMarkup()}</div>`
+    );
+    await page.evaluate(() => {
+        document.querySelector('.workspace-card[data-current-workspace]')
+            .setAttribute('data-workspace-scope-identity', 'scope-before-root-change');
+        window.__activeSessionPresentationSnapshots = [];
+        window.__readActiveSessionPresentation = () => {
+            const card = document.querySelector('.workspace-card[data-current-workspace]');
+            const row = card.querySelector('.active-ai-session-row[data-session-id="current-session"]');
+            const summary = card.querySelector('.project-codex-badge');
+            const compact = document.querySelector(
+                '.workspace-card[data-open-workspace-current]'
+            );
+            return {
+                rowAttention: row.hasAttribute('data-ai-session-attention'),
+                tabAttention: !!card.querySelector('[data-ai-session-tab="active"] .ai-session-tab-attention'),
+                summaryAttention: Number(summary.getAttribute('data-ai-session-attention-count')),
+                rowRunning: row.getAttribute('data-execution-state') === 'running'
+                    && row.getAttribute('data-session-icon-fx') === 'current',
+                cardRunning: card.classList.contains('session-running')
+                    && card.getAttribute('data-session-fx') === 'current'
+                    && !!card.querySelector('.project-session-fx'),
+                compactAttention: Number(
+                    compact.querySelector('.project-ai-attention-badge')?.textContent || 0
+                ),
+                compactRunning: compact.classList.contains('session-running')
+                    && compact.getAttribute('data-session-fx') === 'current'
+                    && Number(compact.querySelector(
+                        '.project-codex-badge[data-ai-session-active-count]'
+                    )?.getAttribute('data-ai-session-active-count') || 0) === 1,
+            };
+        };
+        window.__activeSessionPresentationObserver = new MutationObserver(() => {
+            window.__activeSessionPresentationSnapshots.push(
+                window.__readActiveSessionPresentation()
+            );
+        });
+        window.__activeSessionPresentationObserver.observe(
+            document.querySelector('.workspace-card[data-current-workspace]'),
+            { attributes: true, childList: true, subtree: true }
+        );
+    });
+
+    await postHostMessage(page, {
+        type: 'ai-session-presentation-state',
+        version: 1,
+        projectionRevision: 2,
+        workspaceScopeIdentity: 'scope-project-a',
+        workspaceNavigationIdentity: 'navigation-project-a',
+        attentionCount: 1,
+        activeAttentionCount: 1,
+        runningSessionCount: 0,
+        runningCardAnimation: 'current',
+        runningIconAnimation: 'current',
+        revealFocused: false,
+        focusedTarget: { provider: 'codex', sessionId: 'current-session' },
+        attentionSessions: [{
+            sessionKey: 'codex:current-session',
+            eventIds: ['attention-event'],
+        }],
+        sessions: [{
+            provider: 'codex',
+            sessionId: 'current-session',
+            executionState: 'stopped',
+            focused: true,
+            needsAttention: true,
+            conflict: false,
+            eventIds: ['attention-event'],
+        }],
+    });
+    await page.evaluate(() => new Promise(resolve => requestAnimationFrame(resolve)));
+    const attentionState = {
+        rowAttention: true,
+        tabAttention: true,
+        summaryAttention: 1,
+        rowRunning: false,
+        cardRunning: false,
+        compactAttention: 1,
+        compactRunning: false,
+    };
+    assert.deepEqual(await page.evaluate(() => window.__readActiveSessionPresentation()), attentionState);
+    assert.deepEqual(
+        await page.evaluate(() => window.__activeSessionPresentationSnapshots),
+        [attentionState]
+    );
+
+    await page.evaluate(() => { window.__activeSessionPresentationSnapshots = []; });
+    await postHostMessage(page, {
+        type: 'ai-session-presentation-state',
+        version: 1,
+        projectionRevision: 3,
+        workspaceScopeIdentity: 'scope-project-a',
+        workspaceNavigationIdentity: 'navigation-project-a',
+        attentionCount: 0,
+        activeAttentionCount: 0,
+        runningSessionCount: 1,
+        runningCardAnimation: 'current',
+        runningIconAnimation: 'current',
+        revealFocused: false,
+        focusedTarget: { provider: 'codex', sessionId: 'current-session' },
+        attentionSessions: [],
+        sessions: [{
+            provider: 'codex',
+            sessionId: 'current-session',
+            executionState: 'running',
+            focused: true,
+            needsAttention: false,
+            conflict: false,
+            eventIds: [],
+        }],
+    });
+    await page.evaluate(() => new Promise(resolve => requestAnimationFrame(resolve)));
+    const runningState = {
+        rowAttention: false,
+        tabAttention: false,
+        summaryAttention: 0,
+        rowRunning: true,
+        cardRunning: true,
+        compactAttention: 0,
+        compactRunning: true,
+    };
+    assert.deepEqual(await page.evaluate(() => window.__readActiveSessionPresentation()), runningState);
+    assert.deepEqual(
+        await page.evaluate(() => window.__activeSessionPresentationSnapshots),
+        [runningState]
+    );
+});
+
+test('ATTENTION-EXECUTION-STATE-SYNC-001 creates and clears a previously empty current summary', async t => {
+    const page = await openCardPage(t, []);
+    const card = page.locator('.workspace-card[data-current-workspace]');
+    assert.equal(await card.locator('.project-codex-badge').count(), 0);
+
+    await postHostMessage(page, presentationMessage([], 2, {
+        attention: { 'codex:history-only': ['history-attention'] },
+    }));
+    assert.equal(
+        await card.locator('.ai-session-attention-count').textContent(),
+        '1'
+    );
+    assert.equal(await card.getAttribute('data-has-ai-session-badge'), '');
+
+    await postHostMessage(page, presentationMessage([], 3));
+    assert.equal(await card.locator('.project-codex-badge').count(), 0);
+    assert.equal(await card.getAttribute('data-has-ai-session-badge'), null);
+});
+
 test('ACTIVE-SESSION-ATTENTION-PROJECTION-001 never flashes stale attention during a window-switch projection', async t => {
     const active = [
         session('codex', 'session-a', false),
@@ -584,12 +846,9 @@ test('ACTIVE-SESSION-ATTENTION-PROJECTION-001 never flashes stale attention duri
         session('codex', 'session-c', false),
     ].map(entry => ({ ...entry, executionState: 'stopped' }));
     const page = await openCardPage(t, active);
-    await postHostMessage(page, {
-        type: 'ai-session-attention-state',
-        projectionRevision: 2,
-        eventIds: ['event-b'],
-        sessionEvents: [{ sessionKey: 'codex:session-b', eventIds: ['event-b'] }],
-    });
+    await postHostMessage(page, presentationMessage(active, 2, {
+        attention: { 'codex:session-b': ['event-b'] },
+    }));
     await page.evaluate(() => {
         window.__attentionProjectionSnapshots = [];
         const recordAttentionProjection = () => {
@@ -604,10 +863,10 @@ test('ACTIVE-SESSION-ATTENTION-PROJECTION-001 never flashes stale attention duri
         );
     });
 
-    const staleAttention = active.map(entry => ({
+    const authoritativeAttention = active.map(entry => ({
         ...entry,
-        needsAttention: true,
-        attentionEventId: `stale-${entry.sessionId}`,
+        needsAttention: entry.sessionId === 'session-c',
+        ...(entry.sessionId === 'session-c' ? { attentionEventId: 'event-c' } : {}),
     }));
     await postHostMessage(page, {
         type: 'open-workspaces-updated',
@@ -617,7 +876,7 @@ test('ACTIVE-SESSION-ATTENTION-PROJECTION-001 never flashes stale attention duri
         currentWorkspaceCount: 1,
         navigationWorkspaceCount: 0,
         otherWindowsStatus: 'ready',
-        html: `<div class="open-current-workspace-group">${projectMarkup(staleAttention)}</div>
+        html: `<div class="open-current-workspace-group">${projectMarkup(authoritativeAttention)}</div>
             <div class="open-other-windows-group" data-other-windows-status="ready">
                 ${currentOpenWorkspaceProjectMarkup()}
             </div>`,
@@ -630,12 +889,9 @@ test('ACTIVE-SESSION-ATTENTION-PROJECTION-001 never flashes stale attention duri
         },
     });
     await page.evaluate(() => new Promise(resolve => requestAnimationFrame(resolve)));
-    await postHostMessage(page, {
-        type: 'ai-session-attention-state',
-        projectionRevision: 3,
-        eventIds: ['event-c'],
-        sessionEvents: [{ sessionKey: 'codex:session-c', eventIds: ['event-c'] }],
-    });
+    await postHostMessage(page, presentationMessage(active, 3, {
+        attention: { 'codex:session-b': ['stale-event-b'] },
+    }));
     await page.evaluate(() => new Promise(resolve => requestAnimationFrame(resolve)));
 
     const snapshots = await page.evaluate(() => {
@@ -669,12 +925,10 @@ test('ACTIVE-SESSION-FOCUS-REVEAL-001 reveals a newer direct focus projection in
     });
     assert.equal(await isRowFullyVisibleInList(row(page, 'codex', 'active-7')), false);
 
-    await postHostMessage(page, {
-        type: 'active-ai-session-terminal-changed',
-        projectionRevision: 2,
-        provider: 'codex',
-        sessionId: 'active-7',
-    });
+    await postHostMessage(page, presentationMessage(active.map((entry, index) => ({
+        ...entry,
+        focused: index === 6,
+    })), 2, { revealFocused: true }));
 
     assert.equal(await row(page, 'codex', 'active-7').getAttribute('data-session-focused'), '');
     assert.equal(await isRowFullyVisibleInList(row(page, 'codex', 'active-7')), true);

--- a/tests/contract/aiSessions/attentionEventCapability.test.js
+++ b/tests/contract/aiSessions/attentionEventCapability.test.js
@@ -165,9 +165,7 @@ function createFixture(overrides = {}) {
             ? { scopeIdentity: 'scope-1' }
             : overrides.workspace,
         getActiveTerminal: () => overrides.activeTerminal === undefined ? terminal : overrides.activeTerminal,
-        postMessage: message => {
-            calls.push(['post-message', message]);
-        },
+        postAttentionState: () => { calls.push(['post-attention-state']); },
         isVisible: () => overrides.visible !== false,
         assertActive: () => {
             if (overrides.assertActiveError) {
@@ -581,12 +579,10 @@ test('RUNTIME-WORKSPACE-TOPOLOGY-CONTINUITY-001 keeps attention ownership after 
         'attention must surface cross-scope ambiguity instead of selecting the newer scope');
 });
 
-test('ATTENTION-EXECUTION-STATE-SYNC-001 attention state posts the recovery session events and event ids', () => {
+test('ATTENTION-EXECUTION-STATE-SYNC-001 attention mutations request one authoritative presentation snapshot', () => {
     const { capability, calls } = createFixture({});
     capability.postAttentionState();
-    assert.deepEqual(calls.filter(call => call[0] === 'post-message'), [['post-message', {
-        type: 'ai-session-attention-state',
-        sessionEvents: [{ sessionKey: 'codex:session-a', eventIds: ['evt-1', 'evt-1', 'evt-2'] }],
-        eventIds: ['evt-1', 'evt-2'],
-    }]]);
+    assert.deepEqual(calls.filter(call => call[0] === 'post-attention-state'), [
+        ['post-attention-state'],
+    ]);
 });

--- a/tests/contract/dashboardBoundaries.test.js
+++ b/tests/contract/dashboardBoundaries.test.js
@@ -161,12 +161,10 @@ test('RUNTIME-DASHBOARD-RUNTIME-CONTROLLER-001 refreshes and reveals only throug
     await assert.doesNotReject(revealThrows.controller.revealAgentPivotDashboard());
 });
 
-test('RUNTIME-DASHBOARD-RUNTIME-CONTROLLER-001 publishes exact batch, terminal, mutation, color, and visibility effects', async () => {
+test('RUNTIME-DASHBOARD-RUNTIME-CONTROLLER-001 publishes exact batch, mutation, color, and visibility effects', async () => {
     const harness = runtimeHarness();
     const batch = { type: 'ai-session-batch-archive-completed', archived: 2 };
     harness.controller.postBatchArchiveCompletion(batch);
-    harness.controller.postActiveAiSessionTerminalChanged({ provider: 'codex', sessionId: 's1' });
-    harness.controller.postActiveAiSessionTerminalChanged(null);
     harness.controller.applyProjectColorToCurrentWindow();
     harness.controller.applyProjectColorToCurrentWindow({ id: 'save', showSaveAction: true });
     harness.controller.refreshAfterMutation('saved');
@@ -174,8 +172,6 @@ test('RUNTIME-DASHBOARD-RUNTIME-CONTROLLER-001 publishes exact batch, terminal, 
 
     assert.deepEqual(harness.events, [
         ['message', batch],
-        ['message', { type: 'active-ai-session-terminal-changed', provider: 'codex', sessionId: 's1' }],
-        ['message', { type: 'active-ai-session-terminal-changed', provider: null, sessionId: null }],
         ['color', 'project'],
         ['color', 'save'],
         ['color', 'project'],
@@ -232,12 +228,10 @@ test('RUNTIME-DASHBOARD-RUNTIME-CONTROLLER-001 maps rejected promises and synchr
             logError: (message, error) => errors.push([message, error.message]),
         });
         controller.postBatchArchiveCompletion({ type: 'batch' });
-        controller.postActiveAiSessionTerminalChanged(null);
         controller.applyProjectColorToCurrentWindow();
         await flushAsync();
         assert.deepEqual(errors, [
             ['Failed to post batch AI session archive completion.', `${mode} failure`],
-            ['Failed to post the active AI session terminal.', `${mode} failure`],
             ['Failed to apply project color to current window.', `${mode} failure`],
         ]);
     }

--- a/tests/contract/openProjects/dashboardController.test.js
+++ b/tests/contract/openProjects/dashboardController.test.js
@@ -139,6 +139,7 @@ test('WEBVIEW-SIDEBAR-VISIBILITY-RETENTION-001 coalesces rapid OPEN revisions be
 
 test('WEBVIEW-SIDEBAR-VISIBILITY-RETENTION-001 reuses one card projection across a burst of sidebar consumers', () => {
     let nowMs = 5_000;
+    let aiSessionProjectionRevision = 1;
     let hydrationCalls = 0;
     let savedAsProject = false;
     const controller = new OpenWorkspaceDashboardController(createOptions({
@@ -147,6 +148,7 @@ test('WEBVIEW-SIDEBAR-VISIBILITY-RETENTION-001 reuses one card projection across
             hydrationCalls += 1;
             return null;
         },
+        getAiSessionProjectionRevision: () => aiSessionProjectionRevision,
         nowMs: () => nowMs,
     }));
 
@@ -157,17 +159,34 @@ test('WEBVIEW-SIDEBAR-VISIBILITY-RETENTION-001 reuses one card projection across
     assert.equal(hydrationCalls, 1,
         'parallel dashboard consumers must share one expensive session projection');
 
+    aiSessionProjectionRevision += 1;
+    const freshAiProjection = controller.getCards();
+    assert.notStrictEqual(freshAiProjection, first,
+        'a newer AI Session projection must never reuse stale cached card HTML');
+    assert.equal(hydrationCalls, 2);
+
     savedAsProject = true;
     const savedProjection = controller.getCards();
-    assert.notStrictEqual(savedProjection, first,
+    assert.notStrictEqual(savedProjection, freshAiProjection,
         'a semantic workspace change must invalidate the burst immediately');
     assert.equal(savedProjection[0].showSaveAction, false);
-    assert.equal(hydrationCalls, 2);
+    assert.equal(hydrationCalls, 3);
 
     nowMs += 1_000;
     assert.notStrictEqual(controller.getCards(), savedProjection,
         'the burst cache must not become an authoritative long-lived snapshot');
-    assert.equal(hydrationCalls, 3);
+    assert.equal(hydrationCalls, 4);
+});
+
+test('ATTENTION-EXECUTION-STATE-SYNC-001 current cards consume the hydrated attention projection', () => {
+    const controller = new OpenWorkspaceDashboardController(createOptions({
+        getCurrentWorkspaceAiSessions: () => ({
+            activeSessions: [],
+            attentionCount: 2,
+        }),
+    }));
+
+    assert.equal(controller.getCards()[0].attentionCount, 2);
 });
 
 test('OPEN-ALL-WINDOWS-LIST-001 orders current and navigation cards together without focus-driven movement', () => {

--- a/tests/integration/dashboard/attentionRendering.test.js
+++ b/tests/integration/dashboard/attentionRendering.test.js
@@ -332,6 +332,8 @@ test('ATTENTION-EXECUTION-STATE-SYNC-001 never renders a running animation and s
     assert.match(sessionRow, /data-session-icon-fx=/);
     assert.doesNotMatch(sessionRow,
         /data-ai-session-attention|data-session-needs-attention|ai-session-attention-indicator/);
+    assert.doesNotMatch(html, new RegExp(`data-session-event-id="${eventId}"`),
+        'the History row must consume the same running-state attention projection');
     assert.doesNotMatch(html, /class="ai-session-attention-count"/);
 });
 

--- a/tests/integration/dashboard/helpers/terminalCloseHarness.js
+++ b/tests/integration/dashboard/helpers/terminalCloseHarness.js
@@ -423,19 +423,17 @@ async function runTerminalCloseContract(transform = source => source, scenario =
                 'incremental AI-session render after the active terminal change',
             );
             const renderedMessages = postedMessages.slice(messageMark);
-            const attentionStateIndex = renderedMessages
-                .findIndex(message => message && message.type === 'ai-session-attention-state');
+            const presentationStateIndex = renderedMessages
+                .findIndex(message => message && message.type === 'ai-session-presentation-state');
             const updateIndex = renderedMessages
                 .findIndex(message => message && message.type === 'ai-sessions-updated');
-            assert.ok(attentionStateIndex >= 0,
-                'WEBVIEW-AI-SESSION-DASHBOARD-CONTROLLER-001 every incremental render must publish the current attention event map');
-            assert.ok(updateIndex > attentionStateIndex,
-                'WEBVIEW-AI-SESSION-DASHBOARD-CONTROLLER-001 the attention event map must reach the webview before the HTML update');
-            assert.deepEqual(renderedMessages[attentionStateIndex].sessionEvents,
-                [{ sessionKey: 'codex:session', eventIds: ['attention-event'] }],
-                'WEBVIEW-AI-SESSION-DASHBOARD-CONTROLLER-001 the attention state must carry every recovery session event');
-            assert.deepEqual(renderedMessages[attentionStateIndex].eventIds, ['attention-event'],
-                'WEBVIEW-AI-SESSION-DASHBOARD-CONTROLLER-001 the attention state must carry the current attention event ids');
+            assert.ok(presentationStateIndex >= 0,
+                'WEBVIEW-AI-SESSION-DASHBOARD-CONTROLLER-001 every incremental render must publish the current presentation snapshot');
+            assert.ok(updateIndex > presentationStateIndex,
+                'WEBVIEW-AI-SESSION-DASHBOARD-CONTROLLER-001 the presentation snapshot must reach the webview before the HTML update');
+            assert.deepEqual(renderedMessages[presentationStateIndex].attentionSessions, [],
+                'WEBVIEW-AI-SESSION-DASHBOARD-CONTROLLER-001 the snapshot must not revive stale Attention owners');
+            assert.equal(renderedMessages[presentationStateIndex].attentionCount, 0);
             return calls;
         }
 

--- a/tests/integration/dashboard/sessionRuntimeFlow.test.js
+++ b/tests/integration/dashboard/sessionRuntimeFlow.test.js
@@ -10,6 +10,9 @@ const { hydrateWorkspaceAiSessions } = require('../../../out/workspaces/sessionH
 const { getAttentionProjectKeys } = require('../../../out/aiSessions/attentionProject');
 const { getAiSessionTerminalCandidates } = require('../../../out/aiSessions/terminalCandidates');
 const ActiveAiSessionTerminalHighlighter = require('../../../out/aiSessions/activeTerminalHighlight').default;
+const {
+    projectWorkspaceActiveSessions,
+} = require('../../../out/workspaces/activeSessionPresentation');
 
 test('PROJECT-TERMINAL-CANDIDATE-001 reads provider sessions through the terminal-candidate cache reason', () => {
     const sessions = [{ id: 'candidate', name: 'Candidate' }];
@@ -97,6 +100,12 @@ test('PROJECT-ACTIVE-AI-SESSION-PROJECTION-001 OPEN-OPEN-PROJECT-AI-SESSION-VIEW
                 reasons: ['input-required'],
                 eventIds: ['attention'],
                 observedAtMs: 1,
+            }, {
+                projectId: getAttentionProjectKeys(['file:///fixtures/app'])[0],
+                sessionKey: 'codex:direct',
+                reasons: ['completed'],
+                eventIds: ['stale-running-attention'],
+                observedAtMs: 1,
             }],
         },
     });
@@ -104,22 +113,79 @@ test('PROJECT-ACTIVE-AI-SESSION-PROJECTION-001 OPEN-OPEN-PROJECT-AI-SESSION-VIEW
     assert.deepEqual(projected.activeSessions.map(runtime => ({
         provider: runtime.provider,
         backend: runtime.backend,
-        status: runtime.status,
+        executionState: runtime.executionState,
+        focused: runtime.focused,
+        needsAttention: runtime.needsAttention,
         attached: runtime.attached,
         conflict: runtime.conflict || false,
         stale: runtime.stale || false,
     })), [{
-        provider: 'kimi', backend: 'tmux', status: 'conflict', attached: false,
+        provider: 'kimi', backend: 'tmux', executionState: 'stopped', focused: false,
+        needsAttention: true, attached: false,
         conflict: true, stale: true,
     }, {
-        provider: 'codex', backend: 'vscode', status: 'focused', attached: true,
+        provider: 'codex', backend: 'vscode', executionState: 'running', focused: true,
+        needsAttention: false, attached: true,
         conflict: false, stale: false,
     }, {
-        provider: 'claude', backend: 'tmux', status: 'starting', attached: false,
+        provider: 'claude', backend: 'tmux', executionState: 'starting', focused: false,
+        needsAttention: false, attached: false,
         conflict: false, stale: false,
     }]);
+    assert.equal(projected.attentionCount, 1,
+        'a running Active Session suppresses its stale Attention from the card summary too');
     assert.equal(projected.sessionsByProvider.codex[0].active, true);
     assert.equal(projected.sessionsByProvider.kimi[0].attention.eventId, 'attention');
+});
+
+test('PROJECT-ACTIVE-AI-SESSION-PROJECTION-001 projects pending focus as an authoritative target', () => {
+    const workspace = {
+        navigationIdentity: 'navigation:pending-focus',
+        scopeIdentity: 'scope:pending-focus',
+        kind: 'singleFolder',
+        displayName: 'Pending Focus',
+        navigationUri: 'file:///fixtures/pending-focus',
+        environment: 'local',
+        roots: [{
+            id: 'root:pending-focus',
+            name: 'pending-focus',
+            uri: 'file:///fixtures/pending-focus',
+            hostPath: '/fixtures/pending-focus',
+            ordinal: 0,
+        }],
+    };
+    const identity = {
+        provider: 'codex',
+        workspaceScopeIdentity: workspace.scopeIdentity,
+        workspaceNavigationIdentity: workspace.navigationIdentity,
+        workspaceRootHostPaths: ['/fixtures/pending-focus'],
+        cwd: '/fixtures/pending-focus',
+        pendingId: 'pending-focus-one',
+    };
+
+    const presentation = projectWorkspaceActiveSessions({
+        workspace,
+        activeRuntimes: [],
+        pendingRuntimes: [{
+            identity,
+            backend: 'tmux',
+            state: 'pending',
+            markerPath: '/tmp/pending-focus.done',
+            runStartedAtMs: 30,
+            attached: true,
+            createdAt: '2026-08-10T00:00:00.000Z',
+            excludedSessionIds: [],
+            tmux: { layout: 'project', sessionName: 'pending-focus' },
+        }],
+        executionSnapshot: {},
+        focusedIdentity: identity,
+        attentionAggregate: null,
+    });
+
+    assert.deepEqual(presentation.focusedTarget, {
+        provider: 'codex',
+        pendingId: 'pending-focus-one',
+    });
 });
 
 test('PROJECT-ACTIVE-AI-SESSION-PROJECTION-001 keeps active session cards stable when terminal focus changes', () => {

--- a/tests/integration/dashboard/terminalCloseWiring.test.js
+++ b/tests/integration/dashboard/terminalCloseWiring.test.js
@@ -39,14 +39,14 @@ test('ATTENTION-USER-TERMINAL-CLOSE-001 controlled bridge-first acknowledgement 
         /must be awaited only after the local refresh/);
 });
 
-test('WEBVIEW-AI-SESSION-DASHBOARD-CONTROLLER-001 attention state publication precedes the incremental render', async () => {
+test('WEBVIEW-AI-SESSION-DASHBOARD-CONTROLLER-001 presentation publication precedes the incremental render', async () => {
     await execFile(process.execPath, [harnessPath, 'attention-state-order'], { env: harnessEnvironment() });
 });
 
-test('WEBVIEW-AI-SESSION-DASHBOARD-CONTROLLER-001 controlled render-before-attention-state mutation is rejected', async () => {
+test('WEBVIEW-AI-SESSION-DASHBOARD-CONTROLLER-001 controlled render-before-presentation mutation is rejected', async () => {
     await assert.rejects(
         execFile(process.execPath, [harnessPath, 'mutation:attention-state-before-render'], { env: harnessEnvironment() }),
-        /must publish the current attention event map/);
+        /must publish the current presentation snapshot/);
 });
 
 test('ATTENTION-PRODUCTION-ATTENTION-BRIDGE-INTEGRATION-001 remote aggregate schedules a refresh without auto-acknowledging', async () => {


### PR DESCRIPTION
## Summary

- make the Host projection the single owner of Active Session focus, execution, attention, conflict, and workspace summary state
- replace separate focus and attention responses with one revisioned presentation snapshot applied atomically to detail, history, and compact current-window surfaces
- prevent stale cached HTML from overriding newer runtime state and preserve pending-session focus through promotion
- add regression coverage for running/attention exclusivity, cache invalidation, pending focus semantics, compact cards, and empty summary transitions

## Skill harvest

no skill change — the review findings were product architecture defects, while the existing release and review workflows correctly detected packaging and consistency gaps

## Verification

- npm run test:ci:linux
- npm run test:behavior-contracts
- node --test tests/browser/activeSessionCardInteraction.test.js
- node scripts/run-ai-session-safety-checks.js
- node scripts/run-dashboard-webview-checks.js
- independent read-only review found no remaining Critical or Important issues
- installed Agent Pivot 1.1.0 into the active VS Code Server and verified representative VSIX-to-install hashes