### PR TITLE
Refactor current workspace session authority

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -939,6 +939,22 @@
     ]
   },
   {
+    "id": "ARCH-CURRENT-WORKSPACE-SESSION-AUTHORITY-001",
+    "domain": "architecture",
+    "title": "Current workspace cards and Conversations share one navigation-scoped Session identity authority",
+    "priority": "P1",
+    "status": "automated",
+    "owners": [
+      "scripts/run-architecture-guards.js",
+      "tests/unit/tooling/architectureGuards.test.js"
+    ],
+    "evidence": [
+      "src/workspaces/currentWorkspaceSessionAuthority.ts",
+      "src/openWorkspaces/dashboardController.ts",
+      "src/dashboard.ts"
+    ]
+  },
+  {
     "id": "ARCH-OPEN-WORKSPACE-FOCUS-TRANSPORT-OWNERSHIP-001",
     "domain": "architecture",
     "title": "Running and Attention cross-window focus share one mailbox and delivery state machine",
@@ -4075,16 +4091,20 @@
   {
     "id": "RUNTIME-WORKSPACE-TOPOLOGY-CONTINUITY-001",
     "domain": "runtime",
-    "title": "Active Session and attention actions survive workspace root additions and removals",
+    "title": "Active Session, Conversation, and attention actions survive workspace root additions and removals",
     "priority": "P0",
     "status": "automated",
     "owners": [
       "tests/integration/dashboard/sessionRuntimeFlow.test.js",
-      "tests/contract/aiSessions/attentionEventCapability.test.js"
+      "tests/contract/aiSessions/attentionEventCapability.test.js",
+      "tests/contract/openProjects/dashboardController.test.js",
+      "tests/unit/workspaces/currentWorkspaceSessionAuthority.test.js"
     ],
     "evidence": [
+      "src/workspaces/currentWorkspaceSessionAuthority.ts",
       "src/workspaces/runtimeOwnership.ts",
       "src/workspaces/sessionHydration.ts",
+      "src/openWorkspaces/dashboardController.ts",
       "src/aiSessions/terminalCommandController.ts",
       "src/aiSessions/attentionEventCapability.ts",
       "src/dashboard.ts"

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "2db2a1571a238d1445e37ceaa35fb69371fe7871",
+        "head": "7f493f8ac1492c26fe0eacc3d637580de5f17da8",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -253,7 +253,8 @@
             "643e0775788e7da09b914cc7b7526bb3909ff3db",
             "7ab84c7fb628f73041909c12f3055124e4cca81c",
             "e8c8f7b9467d1afb3fc15b30ae41fe9b5409a142",
-            "70ac4fa2ff17fceb29d84ba9193c9d31541a3124"
+            "70ac4fa2ff17fceb29d84ba9193c9d31541a3124",
+            "ed622f02fb6d6a352d954c46c45003e1bb30ff75"
         ]
     },
     "capabilities": [
@@ -309,7 +310,8 @@
                 "6b9a8fa2697ab7aa0a79da5a589c538f1e51c564",
                 "7e307205e7ff42e9acb30431051fecd4c379a0ed",
                 "2867df3c5ac0cd2ee69e6cb6d91fde9f53e26369",
-                "2db2a1571a238d1445e37ceaa35fb69371fe7871"
+                "2db2a1571a238d1445e37ceaa35fb69371fe7871",
+                "7f493f8ac1492c26fe0eacc3d637580de5f17da8"
             ],
             "behaviors": [
                 "RUNTIME-RUNTIME-PROJECTION-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "869d520b640f56e8db2b1f1e3b71b081625c7874",
+        "head": "2db2a1571a238d1445e37ceaa35fb69371fe7871",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -252,7 +252,8 @@
             "1e47d70675ea31304f5cc6394fed4fb9955037e3",
             "643e0775788e7da09b914cc7b7526bb3909ff3db",
             "7ab84c7fb628f73041909c12f3055124e4cca81c",
-            "e8c8f7b9467d1afb3fc15b30ae41fe9b5409a142"
+            "e8c8f7b9467d1afb3fc15b30ae41fe9b5409a142",
+            "70ac4fa2ff17fceb29d84ba9193c9d31541a3124"
         ]
     },
     "capabilities": [
@@ -307,7 +308,8 @@
                 "b2f672bd1182df7d1088a2e4c8e3e5f8d3ee7e27",
                 "6b9a8fa2697ab7aa0a79da5a589c538f1e51c564",
                 "7e307205e7ff42e9acb30431051fecd4c379a0ed",
-                "2867df3c5ac0cd2ee69e6cb6d91fde9f53e26369"
+                "2867df3c5ac0cd2ee69e6cb6d91fde9f53e26369",
+                "2db2a1571a238d1445e37ceaa35fb69371fe7871"
             ],
             "behaviors": [
                 "RUNTIME-RUNTIME-PROJECTION-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "7f493f8ac1492c26fe0eacc3d637580de5f17da8",
+        "head": "c8df4355af418e21ca9efc6ff1511b05e85c21a4",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -254,7 +254,8 @@
             "7ab84c7fb628f73041909c12f3055124e4cca81c",
             "e8c8f7b9467d1afb3fc15b30ae41fe9b5409a142",
             "70ac4fa2ff17fceb29d84ba9193c9d31541a3124",
-            "ed622f02fb6d6a352d954c46c45003e1bb30ff75"
+            "ed622f02fb6d6a352d954c46c45003e1bb30ff75",
+            "69238185ffd3617c9ce247520e8a6da0d4c0366c"
         ]
     },
     "capabilities": [
@@ -711,7 +712,8 @@
                 "91094fccf74d20e553514ebfbb3705be7c5c1556",
                 "b388dee9464be7e0ac6850cd12c3a943b5868f3b",
                 "9c6a7223c606f3cdaaa2e3a3ef6f9a38f239a7c2",
-                "48ecf9d5e2127ab94879a7a899789892881b7fe5"
+                "48ecf9d5e2127ab94879a7a899789892881b7fe5",
+                "c8df4355af418e21ca9efc6ff1511b05e85c21a4"
             ],
             "behaviors": [
                 "RELEASE-VSIX-PACKAGING-001",

--- a/scripts/run-architecture-guards.js
+++ b/scripts/run-architecture-guards.js
@@ -563,6 +563,85 @@ function objectFreezeProperties(sourceFile, variableName, id, risk) {
 }
 
 const guards = {
+    // ARCH-CURRENT-WORKSPACE-SESSION-AUTHORITY-001
+    'ARCH-CURRENT-WORKSPACE-SESSION-AUTHORITY-001'(root) {
+        const risk = 'workspace root changes can rotate card and Conversation identity';
+        const authority = parseTypescript(
+            root,
+            'src/workspaces/currentWorkspaceSessionAuthority.ts',
+            this.id,
+            risk
+        );
+        const controller = parseTypescript(
+            root,
+            'src/openWorkspaces/dashboardController.ts',
+            this.id,
+            risk
+        );
+        const dashboard = parseTypescript(root, 'src/dashboard.ts', this.id, risk);
+        const getProjectId = classMethod(
+            authority,
+            'CurrentWorkspaceSessionAuthority',
+            'getProjectId',
+            this.id,
+            risk
+        );
+        if (!normalizedAstText(getProjectId, authority).includes(
+            'authorities.get( normalized.workspaceNavigationIdentity )'
+        )) {
+            fail(this.id, risk,
+                'the authority must retain identity by workspace navigation, not current root scope');
+        }
+
+        const createCurrentCard = classMethod(
+            controller,
+            'OpenWorkspaceDashboardController',
+            'createCurrentCard',
+            this.id,
+            risk
+        );
+        const navigationAssignments = [];
+        walkOwnScope(createCurrentCard, node => {
+            if (ts.isPropertyAssignment(node)
+                && node.name.getText(controller)
+                    === 'workspaceNavigationIdentity') {
+                navigationAssignments.push(node);
+            }
+        });
+        if (navigationAssignments.length !== 1
+            || normalizedAstText(
+                navigationAssignments[0].initializer,
+                controller
+            ) !== 'navigationIdentity'
+            || !normalizedAstText(createCurrentCard, controller).includes(
+                'id: projectId'
+            )) {
+            fail(this.id, risk,
+                'the current card must consume the shared navigation-scoped authority exactly once');
+        }
+
+        const dashboardSource = dashboard.getFullText();
+        if ((dashboardSource.match(/new CurrentWorkspaceSessionAuthority\s*\(/g) || []).length !== 1
+            || (dashboardSource.match(
+                /currentWorkspaceSessionAuthority\.getProjectId\s*\(/g
+            ) || []).length !== 5
+            || !dashboardSource.includes(
+                'getCurrentWorkspaceSessionProjectId: identity =>'
+            )
+            || dashboardSource.includes(
+                'function getCurrentWorkspaceConversationProjectId('
+            )
+            || (dashboardSource.match(
+                /previous\.workspaceNavigationIdentity\s*!==\s*next\.workspaceNavigationIdentity/g
+            ) || []).length !== 2
+            || /previous\.workspaceScopeIdentity\s*!==\s*next\.workspaceScopeIdentity/
+                .test(dashboardSource)
+            ) {
+            fail(this.id, risk,
+                'cards and Conversation rebinds must share one Host-owned authority');
+        }
+    },
+
     // ARCH-AI-SESSION-NAVIGATION-OWNERSHIP-001
     'ARCH-AI-SESSION-NAVIGATION-OWNERSHIP-001'(root) {
         const risk = 'terminal-moving session commands can race and project different targets';

--- a/scripts/run-open-project-safety-checks.js
+++ b/scripts/run-open-project-safety-checks.js
@@ -1272,7 +1272,7 @@ async function runOpenWorkspaceClientAndControllerChecks() {
         false,
         'the save action must disappear after the workspace is registered in Saved Projects');
     assert.strictEqual(savedCardId, untitledCardId,
-        'saving an untitled workspace must preserve the scope-owned current card ID');
+        'saving an untitled workspace must preserve the navigation-authority-owned current card ID');
     assert.deepStrictEqual(identityDashboard.getCards()
         .filter(card => card.kind === 'navigation').map(card => card.id).sort(), navigationCardIdsBeforeSave,
         'OTHER WINDOWS card IDs must remain navigation-owned across the current workspace save transition');
@@ -1281,10 +1281,10 @@ async function runOpenWorkspaceClientAndControllerChecks() {
         scopeIdentity: workspaceIdentity(932),
         roots: identityWorkspace.roots.concat(makeWorkspaceRoot(932)),
     };
-    assert.notStrictEqual(
+    assert.strictEqual(
         identityDashboard.getCards().find(card => card.kind === 'current').id,
         savedCardId,
-        'changing the root set must change the scope-owned current card ID');
+        'changing the root set must preserve the navigation-authority-owned current card ID');
     dashboard.postUpdated();
     await new Promise(resolve => setImmediate(resolve));
     assert.strictEqual(posted.length, 1);

--- a/scripts/run-release-packaging-checks.js
+++ b/scripts/run-release-packaging-checks.js
@@ -108,6 +108,7 @@ const EXPECTED_MAIN_ENTRIES = Object.freeze([
     'extension/out/workspaces/activeSessionPresentation.js',
     'extension/out/workspaces/attentionProjection.js',
     'extension/out/workspaces/contextResolver.js',
+    'extension/out/workspaces/currentWorkspaceSessionAuthority.js',
     'extension/out/workspaces/identity.js',
     'extension/out/workspaces/pendingSessionPromotionController.js',
     'extension/out/workspaces/pendingWorkspaceSaveStore.js',
@@ -988,6 +989,7 @@ function run() {
     for (const requiredArtifact of [
         'out/workspaces/types.js',
         'out/workspaces/contextResolver.js',
+        'out/workspaces/currentWorkspaceSessionAuthority.js',
         'out/workspaces/savedWorkspaceProjectAdapter.js',
         'out/openWorkspaces/attentionFocusProtocol.js',
         'out/openWorkspaces/protocol.js',

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1,7 +1,7 @@
 'use strict';
 import * as vscode from 'vscode';
 import * as childProcess from 'child_process';
-import { createHash, randomBytes } from 'crypto';
+import { randomBytes } from 'crypto';
 import { existsSync } from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -207,6 +207,9 @@ import { WorkspacePrimaryRootStore } from './workspaces/primaryRootStore';
 import { PendingWorkspaceSaveStore } from './workspaces/pendingWorkspaceSaveStore';
 import { SavedWorkspaceProjectAdapter } from './workspaces/savedWorkspaceProjectAdapter';
 import { WorkspacePendingSessionPromotionController } from './workspaces/pendingSessionPromotionController';
+import {
+    CurrentWorkspaceSessionAuthority,
+} from './workspaces/currentWorkspaceSessionAuthority';
 import { hasWorkspaceRuntimeContinuity } from './workspaces/runtimeOwnership';
 import { projectWorkspaceActiveSessions } from './workspaces/activeSessionPresentation';
 import {
@@ -801,6 +804,28 @@ async function initializeDashboard(
     const conversationCommentStore = new ConversationCommentFileStore(
         context.globalStoragePath
     );
+    const workspaceContextResolver = new WorkspaceContextResolver();
+    const currentWorkspaceSessionAuthority =
+        new CurrentWorkspaceSessionAuthority(
+            context.globalState,
+            error => logError(
+                'Failed to persist current workspace Session authority.',
+                error
+            )
+        );
+    const activationWorkspace = workspaceContextResolver.resolve({
+        workspaceFile: vscode.workspace.workspaceFile,
+        workspaceFolders: vscode.workspace.workspaceFolders,
+        workspaceName: vscode.workspace.name,
+        remoteName: vscode.env.remoteName,
+    });
+    if (activationWorkspace) {
+        currentWorkspaceSessionAuthority.getProjectId({
+            workspaceNavigationIdentity:
+                activationWorkspace.navigationIdentity,
+            workspaceScopeIdentity: activationWorkspace.scopeIdentity,
+        });
+    }
     const projectCommentStore = new ProjectCommentFileStore(
         context.globalStoragePath
     );
@@ -844,9 +869,12 @@ async function initializeDashboard(
                     (await tmuxRuntimeStore.listKnown()).map(binding => ({
                         provider: binding.provider,
                         sessionId: binding.sessionId,
-                        projectId: getCurrentWorkspaceConversationProjectId(
-                            binding.workspaceScopeIdentity
-                        ),
+                        projectId: currentWorkspaceSessionAuthority.getProjectId({
+                            workspaceScopeIdentity:
+                                binding.workspaceScopeIdentity,
+                            workspaceNavigationIdentity:
+                                binding.workspaceNavigationIdentity,
+                        }),
                     })),
                     previous,
                     next
@@ -903,12 +931,13 @@ async function initializeDashboard(
         bindingStore: tmuxRuntimeStore,
         codexRootThreadObserver: new ProcCodexRootThreadObserver(),
         onSessionRebinding: async (previous, next) => {
-            const projectId = getCurrentWorkspaceConversationProjectId(
-                previous.workspaceScopeIdentity
+            const projectId = currentWorkspaceSessionAuthority.getProjectId(
+                previous
             );
             if (!projectId || !previous.sessionId || !next.sessionId
                 || previous.provider !== next.provider
-                || previous.workspaceScopeIdentity !== next.workspaceScopeIdentity) {
+                || previous.workspaceNavigationIdentity
+                    !== next.workspaceNavigationIdentity) {
                 throw new Error('Invalid conversation Session rebind identity.');
             }
             await conversationSessionRebindCoordinator.prepare({
@@ -927,12 +956,13 @@ async function initializeDashboard(
                 previous.sessionId || '',
                 next.sessionId || ''
             );
-            const projectId = getCurrentWorkspaceConversationProjectId(
-                previous.workspaceScopeIdentity
+            const projectId = currentWorkspaceSessionAuthority.getProjectId(
+                previous
             );
             if (!projectId || !previous.sessionId || !next.sessionId
                 || previous.provider !== next.provider
-                || previous.workspaceScopeIdentity !== next.workspaceScopeIdentity) {
+                || previous.workspaceNavigationIdentity
+                    !== next.workspaceNavigationIdentity) {
                 return;
             }
             const previousTarget = {
@@ -1119,7 +1149,6 @@ async function initializeDashboard(
         showUpdateError: () => vscode.window.showErrorMessage('Could not update the pinned chat.'),
     });
     const aiSessionWorkspaceStateStore = new AiSessionWorkspaceStateStore(context.globalState, isAiSessionProviderId);
-    const workspaceContextResolver = new WorkspaceContextResolver();
     const workspacePrimaryRootStore = new WorkspacePrimaryRootStore(context.globalState);
     let openWorkspaceController: OpenWorkspaceController;
     let openWorkspaceDashboardController: OpenWorkspaceDashboardController;
@@ -1728,6 +1757,8 @@ async function initializeDashboard(
         getWorkspaceProjectColor: workspace => getSavedProjectForWorkspace(workspace)?.color || '',
         getWorkspaceProjectName: workspace => getSavedProjectForWorkspace(workspace)?.name || '',
         getCurrentWorkspaceAiSessions: workspace => workspaceSessionHydrationController.hydrate(workspace),
+        getCurrentWorkspaceSessionProjectId: identity =>
+            currentWorkspaceSessionAuthority.getProjectId(identity),
         getAiSessionProjectionRevision: () => aiSessionProjectionCoordinator.capture().revision,
         getGroups: () => projectService.getGroups(),
         getTodoSearchItems: () => todoService.getSearchItems(),
@@ -2673,20 +2704,4 @@ export async function deactivate(): Promise<void> {
     const openWorkspaceClient = activeOpenWorkspaceBridgeClient;
     activeOpenWorkspaceBridgeClient = null;
     await openWorkspaceClient?.shutdown();
-}
-
-function getCurrentWorkspaceConversationProjectId(
-    workspaceScopeIdentity: unknown
-): string | null {
-    if (typeof workspaceScopeIdentity !== 'string'
-        || workspaceScopeIdentity.length === 0
-        || workspaceScopeIdentity.length > 512
-        || /[\u0000-\u001f\u007f]/.test(workspaceScopeIdentity)) {
-        return null;
-    }
-    const digest = createHash('sha256')
-        .update(workspaceScopeIdentity)
-        .digest('hex')
-        .slice(0, 24);
-    return `__currentWorkspace-${digest}`;
 }

--- a/src/openWorkspaces/dashboardController.ts
+++ b/src/openWorkspaces/dashboardController.ts
@@ -9,6 +9,9 @@ import type { Group, WorkspaceCardViewModel } from '../models';
 import { buildOpenWorkspacesUpdatedMessage } from '../dashboard/webviewUpdateMessages';
 import type { TodoSearchCatalogItem } from '../todos/types';
 import type { OpenWorkspace } from '../workspaces/types';
+import {
+    CurrentWorkspaceSessionAuthority,
+} from '../workspaces/currentWorkspaceSessionAuthority';
 import type { OpenWorkspaceBridgeStatus } from './bridgeClient';
 import {
     compareOpenWorkspaceCardOrder,
@@ -35,6 +38,12 @@ export interface OpenWorkspaceDashboardControllerOptions {
     getWorkspaceProjectColor: (workspace: Pick<OpenWorkspace, 'kind' | 'navigationUri'>) => string;
     getWorkspaceProjectName?: (workspace: Pick<OpenWorkspace, 'kind' | 'navigationUri'>) => string;
     getCurrentWorkspaceAiSessions: (workspace: OpenWorkspace) => WorkspaceAiSessionViewModel | null;
+    getCurrentWorkspaceSessionProjectId?: (
+        identity: {
+            workspaceNavigationIdentity: string;
+            workspaceScopeIdentity: string;
+        }
+    ) => string;
     getAiSessionProjectionRevision?: () => number;
     getGroups: () => Group[];
     getTodoSearchItems: () => TodoSearchCatalogItem[];
@@ -67,6 +76,8 @@ export class OpenWorkspaceDashboardController {
     private cachedCards: WorkspaceCardViewModel[] | null = null;
     private cachedCardsKey: string | null = null;
     private cachedCardsExpiresAtMs = 0;
+    private readonly fallbackCurrentWorkspaceSessionAuthority =
+        new CurrentWorkspaceSessionAuthority();
 
     constructor(private readonly options: OpenWorkspaceDashboardControllerOptions) {
         this.fallbackOpenedAtMs = this.nowMs();
@@ -285,10 +296,17 @@ export class OpenWorkspaceDashboardController {
         navigationIdentity: string,
         pinned: boolean,
     ): WorkspaceCardViewModel {
-        const digest = crypto.createHash('sha256').update(workspace.scopeIdentity).digest('hex').slice(0, 24);
+        const projectId = (
+            this.options.getCurrentWorkspaceSessionProjectId
+            || (identity => this.fallbackCurrentWorkspaceSessionAuthority
+                .getProjectId(identity))
+        )({
+            workspaceNavigationIdentity: navigationIdentity,
+            workspaceScopeIdentity: workspace.scopeIdentity,
+        });
         const aiSessions = this.options.getCurrentWorkspaceAiSessions(workspace) || undefined;
         return {
-            id: `__currentWorkspace-${digest}`,
+            id: projectId,
             kind: 'current',
             workspaceKind: workspace.kind,
             showSaveAction: workspace.kind === 'untitledMultiRoot'

--- a/src/workspaces/currentWorkspaceSessionAuthority.ts
+++ b/src/workspaces/currentWorkspaceSessionAuthority.ts
@@ -1,0 +1,196 @@
+'use strict';
+
+import { createHash } from 'crypto';
+
+export const CURRENT_WORKSPACE_SESSION_AUTHORITY_STATE_KEY =
+    'agentPivot.currentWorkspaceSessionAuthority.v1';
+
+const MAX_NAVIGATION_IDENTITY_LENGTH = 4096;
+const MAX_SCOPE_IDENTITY_LENGTH = 512;
+// One authority per maximum durable known-runtime record keeps restore
+// complete while bounding Memento input and output.
+const MAX_WORKSPACE_AUTHORITIES = 512;
+const CURRENT_WORKSPACE_PROJECT_ID = /^__currentWorkspace-[a-f0-9]{24}$/;
+const CONTROL_CHARACTERS = /[\u0000-\u001f\u007f]/;
+
+interface MementoLike {
+    get<T>(key: string): T;
+    update(key: string, value: unknown): Thenable<void>;
+}
+
+export interface CurrentWorkspaceSessionIdentity {
+    workspaceNavigationIdentity: string;
+    workspaceScopeIdentity: string;
+}
+
+interface PersistedWorkspaceSessionAuthority {
+    workspaceNavigationIdentity: string;
+    projectId: string;
+}
+
+interface PersistedCurrentWorkspaceSessionAuthorities {
+    version: 1;
+    workspaces: PersistedWorkspaceSessionAuthority[];
+}
+
+export class CurrentWorkspaceSessionAuthority {
+    private authorities: Map<string, string> | undefined;
+    private persistQueue: Promise<void> = Promise.resolve();
+
+    constructor(
+        private readonly state?: MementoLike,
+        private readonly onPersistenceError?: (error: unknown) => void
+    ) { }
+
+    getProjectId(identity: CurrentWorkspaceSessionIdentity): string {
+        const normalized = normalizeIdentity(identity);
+        const authorities = this.getAuthorities();
+        const existing = authorities.get(
+            normalized.workspaceNavigationIdentity
+        );
+        if (existing) {
+            return existing;
+        }
+
+        // Preserve the pre-authority project ID on first adoption so existing
+        // Conversation metadata remains addressable.
+        const projectId = createLegacyCurrentWorkspaceProjectId(
+            normalized.workspaceScopeIdentity
+        );
+        while (authorities.size >= MAX_WORKSPACE_AUTHORITIES) {
+            const oldest = authorities.keys().next().value;
+            if (typeof oldest !== 'string') {
+                break;
+            }
+            authorities.delete(oldest);
+        }
+        authorities.set(normalized.workspaceNavigationIdentity, projectId);
+        this.persist(authorities);
+        return projectId;
+    }
+
+    private getAuthorities(): Map<string, string> {
+        if (this.authorities) {
+            return this.authorities;
+        }
+        try {
+            this.authorities = parsePersistedAuthorities(
+                this.state?.get<unknown>(
+                    CURRENT_WORKSPACE_SESSION_AUTHORITY_STATE_KEY
+                )
+            );
+        } catch (error) {
+            this.authorities = new Map();
+            this.onPersistenceError?.(error);
+        }
+        return this.authorities;
+    }
+
+    private persist(authorities: ReadonlyMap<string, string>): void {
+        if (!this.state) {
+            return;
+        }
+        const value: PersistedCurrentWorkspaceSessionAuthorities = {
+            version: 1,
+            workspaces: Array.from(authorities, (
+                [workspaceNavigationIdentity, projectId]
+            ) => ({ workspaceNavigationIdentity, projectId })),
+        };
+        this.persistQueue = this.persistQueue.then(() =>
+            Promise.resolve(this.state?.update(
+                CURRENT_WORKSPACE_SESSION_AUTHORITY_STATE_KEY,
+                value
+            ))
+        ).catch(error => {
+            this.onPersistenceError?.(error);
+        });
+    }
+}
+
+export function createLegacyCurrentWorkspaceProjectId(
+    workspaceScopeIdentity: string
+): string {
+    const normalized = normalizeIdentityPart(
+        workspaceScopeIdentity,
+        MAX_SCOPE_IDENTITY_LENGTH,
+        'workspace scope identity'
+    );
+    const digest = createHash('sha256')
+        .update(normalized)
+        .digest('hex')
+        .slice(0, 24);
+    return `__currentWorkspace-${digest}`;
+}
+
+function normalizeIdentity(
+    identity: CurrentWorkspaceSessionIdentity
+): CurrentWorkspaceSessionIdentity {
+    return {
+        workspaceNavigationIdentity: normalizeIdentityPart(
+            identity?.workspaceNavigationIdentity,
+            MAX_NAVIGATION_IDENTITY_LENGTH,
+            'workspace navigation identity'
+        ),
+        workspaceScopeIdentity: normalizeIdentityPart(
+            identity?.workspaceScopeIdentity,
+            MAX_SCOPE_IDENTITY_LENGTH,
+            'workspace scope identity'
+        ),
+    };
+}
+
+function normalizeIdentityPart(
+    value: unknown,
+    maxLength: number,
+    label: string
+): string {
+    if (typeof value !== 'string'
+        || value.length === 0
+        || value.length > maxLength
+        || CONTROL_CHARACTERS.test(value)) {
+        throw new Error(`Invalid ${label}.`);
+    }
+    return value;
+}
+
+function parsePersistedAuthorities(
+    value: unknown
+): Map<string, string> {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return new Map();
+    }
+    const record = value as Record<string, unknown>;
+    if (Object.keys(record).sort().join(',')
+            !== 'version,workspaces'
+        || record.version !== 1
+        || !Array.isArray(record.workspaces)
+        || record.workspaces.length > MAX_WORKSPACE_AUTHORITIES) {
+        return new Map();
+    }
+    const authorities = new Map<string, string>();
+    for (const value of record.workspaces) {
+        if (!value || typeof value !== 'object' || Array.isArray(value)) {
+            return new Map();
+        }
+        const authority = value as Record<string, unknown>;
+        if (Object.keys(authority).sort().join(',')
+                !== 'projectId,workspaceNavigationIdentity'
+            || typeof authority.workspaceNavigationIdentity !== 'string'
+            || authority.workspaceNavigationIdentity.length === 0
+            || authority.workspaceNavigationIdentity.length
+                > MAX_NAVIGATION_IDENTITY_LENGTH
+            || CONTROL_CHARACTERS.test(
+                authority.workspaceNavigationIdentity
+            )
+            || authorities.has(authority.workspaceNavigationIdentity)
+            || typeof authority.projectId !== 'string'
+            || !CURRENT_WORKSPACE_PROJECT_ID.test(authority.projectId)) {
+            return new Map();
+        }
+        authorities.set(
+            authority.workspaceNavigationIdentity,
+            authority.projectId
+        );
+    }
+    return authorities;
+}

--- a/tests/browser/activeSessionCardInteraction.test.js
+++ b/tests/browser/activeSessionCardInteraction.test.js
@@ -26,6 +26,9 @@ function loadWebviewContent() {
 }
 
 const { getAiSessionsDiv, getCurrentWorkspaceGroupContent } = loadWebviewContent();
+const {
+    CurrentWorkspaceSessionAuthority,
+} = require('../../out/workspaces/currentWorkspaceSessionAuthority');
 const viewStateScript = fs.readFileSync(
     path.join(__dirname, '../../src/webview/webviewAiSessionViewStateScripts.js'),
     'utf8'
@@ -155,16 +158,24 @@ function projectMarkup(activeAiSessions) {
     </div>`;
 }
 
-function currentWorkspaceGroupMarkup(activeAiSessions, attentionCount = 0) {
+function currentWorkspaceGroupMarkup(
+    activeAiSessions,
+    attentionCount = 0,
+    options = {}
+) {
+    const projectId = options.projectId || 'project-a';
+    const scopeIdentity = options.scopeIdentity || 'scope-project-a';
+    const navigationIdentity = options.navigationIdentity
+        || 'navigation-project-a';
     return getCurrentWorkspaceGroupContent({
-        id: 'project-a',
+        id: projectId,
         kind: 'current',
         workspaceKind: 'singleFolder',
         showSaveAction: false,
         runningSessionCount: activeAiSessions
             .filter(entry => entry.executionState === 'running').length,
-        navigationIdentity: 'navigation-project-a',
-        scopeIdentity: 'scope-project-a',
+        navigationIdentity,
+        scopeIdentity,
         name: 'Project A',
         environment: 'local',
         environmentLabel: 'Local',
@@ -1006,6 +1017,55 @@ test('ACTIVE-SESSION-CONVERSATION-OPEN-001 click focuses an unfocused card and o
             .locator('.ai-session-open-conversation-hint').count(),
         0
     );
+});
+
+test('ACTIVE-SESSION-CONVERSATION-OPEN-001 RUNTIME-WORKSPACE-TOPOLOGY-CONTINUITY-001 rendered Conversation actions keep one project authority when roots change', async t => {
+    const authority = new CurrentWorkspaceSessionAuthority();
+    const beforeProjectId = authority.getProjectId({
+        workspaceNavigationIdentity: 'navigation:reddb-dev',
+        workspaceScopeIdentity: 'scope:three-roots',
+    });
+    const active = [session('codex', 'session-a', true)];
+    const page = await openCardPage(
+        t,
+        active,
+        { width: 360, height: 900 },
+        currentWorkspaceGroupMarkup(active, 0, {
+            projectId: beforeProjectId,
+            scopeIdentity: 'scope:three-roots',
+            navigationIdentity: 'navigation:reddb-dev',
+        })
+    );
+    const afterProjectId = authority.getProjectId({
+        workspaceNavigationIdentity: 'navigation:reddb-dev',
+        workspaceScopeIdentity: 'scope:five-roots',
+    });
+
+    await postHostMessage(page, {
+        type: 'workspace-updated',
+        version: 2,
+        currentWorkspaceCount: 1,
+        html: currentWorkspaceGroupMarkup(active, 0, {
+            projectId: afterProjectId,
+            scopeIdentity: 'scope:five-roots',
+            navigationIdentity: 'navigation:reddb-dev',
+        }),
+    });
+    await row(page, 'codex', 'session-a')
+        .locator('.ai-session-primary-action')
+        .click();
+
+    assert.equal(
+        await page.locator('[data-current-workspace]').getAttribute('data-id'),
+        beforeProjectId
+    );
+    assert.deepEqual((await postedMessages(page)).at(-1), {
+        type: 'open-active-ai-session-conversation',
+        version: 1,
+        projectId: beforeProjectId,
+        provider: 'codex',
+        sessionId: 'session-a',
+    });
 });
 
 test('ACTIVE-SESSION-CONVERSATION-FOCUS-001 restores ACTIVE and the origin card header without focusing another session', async t => {

--- a/tests/contract/openProjects/dashboardController.test.js
+++ b/tests/contract/openProjects/dashboardController.test.js
@@ -189,6 +189,40 @@ test('ATTENTION-EXECUTION-STATE-SYNC-001 current cards consume the hydrated atte
     assert.equal(controller.getCards()[0].attentionCount, 2);
 });
 
+test('RUNTIME-WORKSPACE-TOPOLOGY-CONTINUITY-001 keeps the current card authority stable when workspace roots change', () => {
+    let nowMs = 5_000;
+    let workspace = {
+        ...makeRecord({ name: 'reddb-dev', uri: '/work/reddb-dev.code-workspace' }),
+        navigationIdentity: 'navigation:reddb-dev',
+        scopeIdentity: 'scope:three-roots',
+        roots: [{
+            id: 'root:existing', name: 'existing', uri: 'file:///work/existing',
+            hostPath: '/work/existing', ordinal: 0,
+        }],
+    };
+    const controller = new OpenWorkspaceDashboardController(createOptions({
+        getCurrentWorkspace: () => workspace,
+        nowMs: () => nowMs,
+    }));
+
+    const before = controller.getCards().find(card => card.kind === 'current');
+    workspace = {
+        ...workspace,
+        scopeIdentity: 'scope:five-roots',
+        roots: [...workspace.roots, {
+            id: 'root:added', name: 'added', uri: 'file:///work/added',
+            hostPath: '/work/added', ordinal: 1,
+        }],
+    };
+    nowMs += 1_000;
+    const after = controller.getCards().find(card => card.kind === 'current');
+
+    assert.ok(before && after);
+    assert.equal(after.navigationIdentity, before.navigationIdentity);
+    assert.equal(after.id, before.id,
+        'an in-flight card action must keep resolving after the workspace scope changes');
+});
+
 test('OPEN-ALL-WINDOWS-LIST-001 orders current and navigation cards together without focus-driven movement', () => {
     const current = makeRecord({ name: 'Current', uri: '/work/current' });
     const oldest = makeRecord({ name: 'Oldest', uri: '/work/oldest' });

--- a/tests/fixtures/aiSessions/runtimeHostActivationHarness.js
+++ b/tests/fixtures/aiSessions/runtimeHostActivationHarness.js
@@ -467,11 +467,13 @@ async function main() {
                     provider: 'codex',
                     sessionId: 'old-root',
                     workspaceScopeIdentity: 'workspace-scope-a',
+                    workspaceNavigationIdentity: 'workspace-navigation-a',
                 };
                 const next = {
                     provider: 'codex',
                     sessionId: 'new-root',
-                    workspaceScopeIdentity: 'workspace-scope-a',
+                    workspaceScopeIdentity: 'workspace-scope-after-roots-change',
+                    workspaceNavigationIdentity: 'workspace-navigation-a',
                 };
                 await this.options.onSessionRebinding(previous, next);
                 await this.options.onSessionRebound(previous, next);

--- a/tests/unit/tooling/architectureGuards.test.js
+++ b/tests/unit/tooling/architectureGuards.test.js
@@ -23,6 +23,8 @@ function writeFixture(t, files) {
 function copyGuardFixture(t, mutationPath, mutate = source => source) {
     const relativePaths = [
         'src/dashboard.ts',
+        'src/workspaces/currentWorkspaceSessionAuthority.ts',
+        'src/openWorkspaces/dashboardController.ts',
         'src/workspaces/sessionHydrationController.ts',
         'src/aiSessions/dashboardController.ts',
         'src/aiSessions/providers.ts',
@@ -104,6 +106,44 @@ function replaceFixtureSource(source, search, replacement, suffix = '') {
 
 test('SECURITY-AI-SESSION-CONVERSATION-SOURCE-001 complete production fixture satisfies every architecture guard', t => {
     validateArchitectureGuards(copyGuardFixture(t));
+});
+
+test('ARCH-CURRENT-WORKSPACE-SESSION-AUTHORITY-001 rejects scope identity at the current-card authority boundary', t => {
+    const root = copyGuardFixture(
+        t,
+        'src/openWorkspaces/dashboardController.ts',
+        source => replaceFixtureSource(
+            source,
+            'workspaceNavigationIdentity: navigationIdentity,',
+            'workspaceNavigationIdentity: workspace.scopeIdentity,'
+        )
+    );
+    assert.throws(
+        () => validateArchitectureGuards(root, {
+            ids: ['ARCH-CURRENT-WORKSPACE-SESSION-AUTHORITY-001'],
+        }),
+        error => /ARCH-CURRENT-WORKSPACE-SESSION-AUTHORITY-001/.test(error.message)
+            && /root changes/i.test(error.message)
+    );
+});
+
+test('ARCH-CURRENT-WORKSPACE-SESSION-AUTHORITY-001 rejects scope-based retention inside the authority', t => {
+    const root = copyGuardFixture(
+        t,
+        'src/workspaces/currentWorkspaceSessionAuthority.ts',
+        source => replaceFixtureSource(
+            source,
+            'normalized.workspaceNavigationIdentity\n        );',
+            'normalized.workspaceScopeIdentity\n        );'
+        )
+    );
+    assert.throws(
+        () => validateArchitectureGuards(root, {
+            ids: ['ARCH-CURRENT-WORKSPACE-SESSION-AUTHORITY-001'],
+        }),
+        error => /ARCH-CURRENT-WORKSPACE-SESSION-AUTHORITY-001/.test(error.message)
+            && /workspace navigation/i.test(error.message)
+    );
 });
 
 test('ARCH-AI-SESSION-FALLBACK-REASON-001 accepts an ownership-wrapped focused runtime monitor', t => {

--- a/tests/unit/workspaces/currentWorkspaceSessionAuthority.test.js
+++ b/tests/unit/workspaces/currentWorkspaceSessionAuthority.test.js
@@ -1,0 +1,94 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {
+    CURRENT_WORKSPACE_SESSION_AUTHORITY_STATE_KEY,
+    CurrentWorkspaceSessionAuthority,
+    createLegacyCurrentWorkspaceProjectId,
+} = require('../../../out/workspaces/currentWorkspaceSessionAuthority');
+
+function identity(scopeIdentity, navigationIdentity = 'navigation:reddb-dev') {
+    return {
+        workspaceNavigationIdentity: navigationIdentity,
+        workspaceScopeIdentity: scopeIdentity,
+    };
+}
+
+function createState(initialValue) {
+    let value = initialValue;
+    return {
+        get(key) {
+            assert.equal(key, CURRENT_WORKSPACE_SESSION_AUTHORITY_STATE_KEY);
+            return value;
+        },
+        update(key, next) {
+            assert.equal(key, CURRENT_WORKSPACE_SESSION_AUTHORITY_STATE_KEY);
+            value = next;
+            return Promise.resolve();
+        },
+        read: () => value,
+    };
+}
+
+test('RUNTIME-WORKSPACE-TOPOLOGY-CONTINUITY-001 assigns one Session authority across root topology changes and restarts', async () => {
+    const state = createState();
+    const authority = new CurrentWorkspaceSessionAuthority(state);
+    const initial = authority.getProjectId(identity('scope:three-roots'));
+
+    assert.equal(
+        initial,
+        createLegacyCurrentWorkspaceProjectId('scope:three-roots'),
+        'first adoption preserves the existing Conversation metadata key'
+    );
+    assert.equal(
+        authority.getProjectId(identity('scope:five-roots')),
+        initial,
+        'scope changes cannot rotate the logical workspace authority'
+    );
+    await new Promise(resolve => setImmediate(resolve));
+
+    const restarted = new CurrentWorkspaceSessionAuthority(state);
+    assert.equal(restarted.getProjectId(identity('scope:five-roots')), initial);
+    const other = restarted.getProjectId(
+        identity('scope:other', 'navigation:other')
+    );
+    assert.notEqual(
+        other,
+        initial,
+        'a real workspace navigation change must rotate authority'
+    );
+    await new Promise(resolve => setImmediate(resolve));
+
+    const returned = new CurrentWorkspaceSessionAuthority(state);
+    assert.equal(
+        returned.getProjectId(identity('scope:seven-roots')),
+        initial,
+        'restoring another workspace cannot overwrite the first authority'
+    );
+    assert.equal(
+        returned.getProjectId(identity('scope:other-changed', 'navigation:other')),
+        other
+    );
+});
+
+test('RUNTIME-WORKSPACE-TOPOLOGY-CONTINUITY-001 ignores malformed persisted Session authority', async () => {
+    const state = createState({
+        version: 1,
+        workspaces: [{
+            workspaceNavigationIdentity: 'navigation:reddb-dev',
+            projectId: '__currentWorkspace-not-a-digest',
+        }],
+    });
+    const authority = new CurrentWorkspaceSessionAuthority(state);
+
+    assert.equal(
+        authority.getProjectId(identity('scope:current')),
+        createLegacyCurrentWorkspaceProjectId('scope:current')
+    );
+    await new Promise(resolve => setImmediate(resolve));
+    assert.match(
+        state.read().workspaces[0].projectId,
+        /^__currentWorkspace-[a-f0-9]{24}$/
+    );
+});


### PR DESCRIPTION
## Summary

- centralize the current workspace card and AI Conversation project identity behind one Host-owned authority
- retain that authority by stable workspace navigation identity while workspace roots and execution scope change
- persist bounded per-workspace authorities, preserve legacy Conversation metadata keys on first adoption, and use the same authority for runtime rebinds
- add controller, activation, restart, rendered-interaction, safety, architecture-guard, and reviewed VSIX coverage for workspace topology changes

## Skill harvest

no skill change — the existing regression, architecture-refactor, publishing, and local-install skills already require stable-layer, rendered-surface, release-packaging, and branch-level CI coverage; both missed checks were execution gaps rather than missing reusable guidance.

## Verification

- `npm run test:ci:linux` (complete local quality-linux equivalent; changed-line coverage 92.59%, 200/216)
- `npm run test:behavior-contracts` (rerun after the final capability audit)
- `SKIP_NPM_CI=1 npm run install-local` (packaged, installed, and byte-verified Agent Pivot 1.1.0 and Attention UI Bridge 1.0.1 before the test-only CI follow-ups)
