### PR TITLE
Fix lingering Extension Host workers after successful tests

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -3562,6 +3562,23 @@
     ]
   },
   {
+    "id": "RELEASE-EXTENSION-HOST-WORKER-COMPLETION-001",
+    "domain": "release",
+    "title": "A successful real Extension Host run settles even when the worker retains cleanup handles",
+    "priority": "P1",
+    "status": "automated",
+    "owners": [
+      "tests/unit/tooling/extensionHostLauncher.test.js",
+      "tests/unit/tooling/extensionHostRunner.test.js",
+      "tests/unit/tooling/extensionHostWorker.test.js"
+    ],
+    "evidence": [
+      "scripts/lib/extensionHostLauncher.js",
+      "scripts/run-extension-host-tests.js",
+      "scripts/run-extension-host-worker.js"
+    ]
+  },
+  {
     "id": "ARCH-EXTENSION-HOST-PLACEMENT-001",
     "domain": "architecture",
     "title": "Session and filesystem ownership remains in the workspace extension host",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "c8df4355af418e21ca9efc6ff1511b05e85c21a4",
+        "head": "769e02650fbfbfce96a47e3a3798a8ab93e9b8ad",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -255,7 +255,8 @@
             "e8c8f7b9467d1afb3fc15b30ae41fe9b5409a142",
             "70ac4fa2ff17fceb29d84ba9193c9d31541a3124",
             "ed622f02fb6d6a352d954c46c45003e1bb30ff75",
-            "69238185ffd3617c9ce247520e8a6da0d4c0366c"
+            "69238185ffd3617c9ce247520e8a6da0d4c0366c",
+            "e2f2356d250624dfedf359e34375933b03589dcd"
         ]
     },
     "capabilities": [
@@ -741,11 +742,13 @@
                 "04b08eea061cc8f848bbadbe98e374603e99a3f0",
                 "ee64dfaeb58eb3578a780d787af5cd77403b51c2",
                 "e0dbdfc03bc83c2bbebb278dde6efdb350c71c06",
-                "47312e9a48be6aacebd147e4cb717727e49c0b2e"
+                "47312e9a48be6aacebd147e4cb717727e49c0b2e",
+                "769e02650fbfbfce96a47e3a3798a8ab93e9b8ad"
             ],
             "behaviors": [
                 "ARCH-CI-QUALITY-GATE-001",
-                "RUNTIME-REAL-TMUX-CI-GATE-001"
+                "RUNTIME-REAL-TMUX-CI-GATE-001",
+                "RELEASE-EXTENSION-HOST-WORKER-COMPLETION-001"
             ],
             "prGates": [
                 "test:ci:linux"

--- a/scripts/lib/extensionHostLauncher.js
+++ b/scripts/lib/extensionHostLauncher.js
@@ -12,6 +12,10 @@ const {
 const VSCODE_STABLE_VERSION = '1.130.0';
 const EXTENSION_HOST_TIMEOUT_MS = 120000;
 const EXTENSION_HOST_WORKER_TIMEOUT_MS = 480000;
+const EXTENSION_HOST_WORKER_COMPLETED_MESSAGE = Object.freeze({
+    type: 'agent-pivot-extension-host-worker-completed',
+    version: 1,
+});
 const HOSTILE_EXTENSION_HOST_ENVIRONMENT_KEYS = Object.freeze([
     'ELECTRON_RUN_AS_NODE',
     'VSCODE_ESM_ENTRYPOINT',
@@ -365,6 +369,7 @@ function runWorkerWithWatchdog(spawnWorker, options = {}) {
     const clearTimeoutFn = options.clearTimeout || clearTimeout;
     return new Promise((resolve, reject) => {
         let child;
+        let completionReported = false;
         let timedOut = false;
         let forceTimer;
         let timeoutTimer;
@@ -384,6 +389,7 @@ function runWorkerWithWatchdog(spawnWorker, options = {}) {
             if (child) {
                 child.removeListener('error', onError);
                 child.removeListener('close', onClose);
+                child.removeListener('message', onMessage);
             }
             error ? reject(error) : resolve();
         };
@@ -397,8 +403,34 @@ function runWorkerWithWatchdog(spawnWorker, options = {}) {
         };
         const onClose = (code, signal) => {
             if (timedOut) return;
+            if (completionReported) {
+                finish();
+                return;
+            }
             if (code === 0) finish();
             else finish(new Error(`Extension Host worker failed with code ${code === null ? signal : code}`));
+        };
+        const onMessage = message => {
+            if (timedOut || completionReported
+                || !isExtensionHostWorkerCompletedMessage(message)) return;
+            completionReported = true;
+            if (timeoutTimer !== undefined) {
+                clearTimeoutFn(timeoutTimer);
+                timeoutTimer = undefined;
+            }
+            forceTimer = setTimeoutFn(() => {
+                try {
+                    terminate('SIGKILL');
+                    finish();
+                } catch (error) {
+                    finish(isMissingProcessGroup(error) ? undefined : error);
+                }
+            }, 5000);
+            try {
+                terminate('SIGTERM');
+            } catch (error) {
+                finish(isMissingProcessGroup(error) ? undefined : error);
+            }
         };
         try {
             child = spawnWorker();
@@ -408,6 +440,7 @@ function runWorkerWithWatchdog(spawnWorker, options = {}) {
         }
         child.once('error', onError);
         child.once('close', onClose);
+        child.on('message', onMessage);
         timeoutTimer = setTimeoutFn(() => {
             timedOut = true;
             try {
@@ -427,6 +460,16 @@ function runWorkerWithWatchdog(spawnWorker, options = {}) {
     });
 }
 
+function isExtensionHostWorkerCompletedMessage(message) {
+    if (!message || typeof message !== 'object' || Array.isArray(message)) return false;
+    const keys = Object.keys(message);
+    return keys.length === 2
+        && keys.includes('type')
+        && keys.includes('version')
+        && message.type === EXTENSION_HOST_WORKER_COMPLETED_MESSAGE.type
+        && message.version === EXTENSION_HOST_WORKER_COMPLETED_MESSAGE.version;
+}
+
 function removeExtensionHostTestEnvironment(isolatedRoot) {
     const markerPath = path.join(isolatedRoot, OWNERSHIP_MARKER);
     if (!path.isAbsolute(isolatedRoot) || !fs.existsSync(markerPath)
@@ -438,6 +481,7 @@ function removeExtensionHostTestEnvironment(isolatedRoot) {
 
 module.exports = {
     EXTENSION_HOST_TIMEOUT_MS,
+    EXTENSION_HOST_WORKER_COMPLETED_MESSAGE,
     EXTENSION_HOST_WORKER_TIMEOUT_MS,
     HOSTILE_EXTENSION_HOST_ENVIRONMENT_KEYS,
     BRIDGE_EXTENSION_ID,
@@ -450,6 +494,7 @@ module.exports = {
     createRunTestsOptions,
     extensionHostTemporaryRootPrefix,
     installPackagedExtensions,
+    isExtensionHostWorkerCompletedMessage,
     removeExtensionHostTestEnvironment,
     runWorkerWithWatchdog,
     resolveInstalledExtensionRoots,

--- a/scripts/run-extension-host-tests.js
+++ b/scripts/run-extension-host-tests.js
@@ -40,7 +40,7 @@ async function main(options = {}) {
             ], {
                 detached: process.platform !== 'win32',
                 env: { ...process.env },
-                stdio: 'inherit',
+                stdio: ['inherit', 'inherit', 'inherit', 'ipc'],
             }),
             { timeoutMs: EXTENSION_HOST_WORKER_TIMEOUT_MS }
         ));

--- a/scripts/run-extension-host-worker.js
+++ b/scripts/run-extension-host-worker.js
@@ -5,11 +5,23 @@ const {
     runTests,
 } = require('@vscode/test-electron');
 const {
+    EXTENSION_HOST_WORKER_COMPLETED_MESSAGE,
     VSCODE_STABLE_VERSION,
     createExtensionHostTestHarness,
     createRunTestsOptions,
     installPackagedExtensions,
 } = require('./lib/extensionHostLauncher');
+
+function notifyParentOfCompletion(message) {
+    if (typeof process.send !== 'function') return Promise.resolve();
+    return new Promise((resolve, reject) => {
+        try {
+            process.send(message, error => error ? reject(error) : resolve());
+        } catch (error) {
+            reject(error);
+        }
+    });
+}
 
 async function runExtensionHostWorker(repositoryRoot, environment, options = {}) {
     if (!repositoryRoot || !environment || typeof environment.workspace !== 'string') {
@@ -57,6 +69,8 @@ async function main(argv = process.argv.slice(2), options = {}) {
     const [repositoryRoot, serializedEnvironment] = argv;
     const environment = JSON.parse(serializedEnvironment || 'null');
     await runExtensionHostWorker(repositoryRoot, environment, options);
+    const notifyCompletion = options.notifyCompletion || notifyParentOfCompletion;
+    await notifyCompletion(EXTENSION_HOST_WORKER_COMPLETED_MESSAGE);
 }
 
 if (require.main === module) {

--- a/tests/unit/tooling/extensionHostLauncher.test.js
+++ b/tests/unit/tooling/extensionHostLauncher.test.js
@@ -9,6 +9,7 @@ const { EventEmitter } = require('node:events');
 
 const {
     EXTENSION_HOST_TIMEOUT_MS,
+    EXTENSION_HOST_WORKER_COMPLETED_MESSAGE,
     EXTENSION_HOST_WORKER_TIMEOUT_MS,
     HOSTILE_EXTENSION_HOST_ENVIRONMENT_KEYS,
     BRIDGE_EXTENSION_ID,
@@ -427,6 +428,73 @@ test('RELEASE-SCHEDULED-EXTENSION-HOST-001 watchdog treats ESRCH as a cleanly ab
     assert.equal(timers[0].cleared, true);
     assert.equal(child.listenerCount('error'), 0);
     assert.equal(child.listenerCount('close'), 0);
+});
+
+// RELEASE-EXTENSION-HOST-WORKER-COMPLETION-001
+test('RELEASE-EXTENSION-HOST-WORKER-COMPLETION-001 watchdog accepts authenticated completion and terminates a lingering POSIX worker', async () => {
+    const child = new EventEmitter();
+    child.pid = 2468;
+    const kills = [];
+    const timers = [];
+    const promise = runWorkerWithWatchdog(() => child, {
+        timeoutMs: 25,
+        platform: 'linux',
+        killProcess: (pid, signal) => { kills.push([pid, signal]); },
+        setTimeout: (callback, delay) => {
+            const timer = { callback, cleared: false, delay };
+            timers.push(timer);
+            return timer;
+        },
+        clearTimeout: timer => { timer.cleared = true; },
+    });
+
+    try {
+        assert.equal(child.listenerCount('message'), 1);
+        child.emit('message', { type: 'untrusted-completion', version: 1 });
+        assert.deepEqual(kills, [], 'unknown worker messages must not settle the run');
+
+        child.emit('message', EXTENSION_HOST_WORKER_COMPLETED_MESSAGE);
+        assert.deepEqual(kills, [[-2468, 'SIGTERM']]);
+        assert.equal(timers[0].cleared, true, 'completion must clear the failure watchdog');
+        assert.equal(timers[1].delay, 5000, 'completion cleanup retains force-kill protection');
+
+        child.emit('close', null, 'SIGTERM');
+        await promise;
+        assert.equal(timers[1].cleared, true);
+        assert.equal(child.listenerCount('error'), 0);
+        assert.equal(child.listenerCount('close'), 0);
+        assert.equal(child.listenerCount('message'), 0);
+    } finally {
+        child.emit('close', 0, null);
+        await promise.catch(() => {});
+    }
+});
+
+// RELEASE-EXTENSION-HOST-WORKER-COMPLETION-001
+test('RELEASE-EXTENSION-HOST-WORKER-COMPLETION-001 authenticated completion survives force-kill cleanup', async () => {
+    const child = new EventEmitter();
+    child.pid = 1357;
+    const kills = [];
+    const timers = [];
+    const promise = runWorkerWithWatchdog(() => child, {
+        timeoutMs: 25,
+        platform: 'linux',
+        killProcess: (pid, signal) => { kills.push([pid, signal]); },
+        setTimeout: (callback, delay) => {
+            const timer = { callback, cleared: false, delay };
+            timers.push(timer);
+            return timer;
+        },
+        clearTimeout: timer => { timer.cleared = true; },
+    });
+
+    child.emit('message', EXTENSION_HOST_WORKER_COMPLETED_MESSAGE);
+    timers[1].callback();
+
+    await promise;
+    assert.deepEqual(kills, [[-1357, 'SIGTERM'], [-1357, 'SIGKILL']]);
+    assert.equal(timers.every(timer => timer.cleared), true);
+    assert.equal(child.listenerCount('message'), 0);
 });
 
 // RELEASE-SCHEDULED-EXTENSION-HOST-001

--- a/tests/unit/tooling/extensionHostRunner.test.js
+++ b/tests/unit/tooling/extensionHostRunner.test.js
@@ -56,5 +56,11 @@ test('RELEASE-SCHEDULED-EXTENSION-HOST-001 runner uses the short macOS root and 
         JSON.stringify(environment),
     ]);
     assert.equal(calls[4][3].detached, process.platform !== 'win32');
+    // RELEASE-EXTENSION-HOST-WORKER-COMPLETION-001
+    assert.deepEqual(
+        calls[4][3].stdio,
+        ['inherit', 'inherit', 'inherit', 'ipc'],
+        'the worker must be able to report authenticated completion over IPC'
+    );
     assert.equal(calls[5][1], isolatedRoot);
 });

--- a/tests/unit/tooling/extensionHostWorker.test.js
+++ b/tests/unit/tooling/extensionHostWorker.test.js
@@ -7,6 +7,9 @@ const {
     main,
     runExtensionHostWorker,
 } = require('../../../scripts/run-extension-host-worker');
+const {
+    EXTENSION_HOST_WORKER_COMPLETED_MESSAGE,
+} = require('../../../scripts/lib/extensionHostLauncher');
 
 // RELEASE-SCHEDULED-EXTENSION-HOST-001
 test('RELEASE-SCHEDULED-EXTENSION-HOST-001 installs verified VSIX bytes before Host activation', async () => {
@@ -101,5 +104,39 @@ test('RELEASE-SCHEDULED-EXTENSION-HOST-001 worker rejects malformed isolation in
     await assert.rejects(
         main(['/repository', '{not-json']),
         /JSON/
+    );
+});
+
+// RELEASE-EXTENSION-HOST-WORKER-COMPLETION-001
+test('RELEASE-EXTENSION-HOST-WORKER-COMPLETION-001 worker reports completion only after tests succeed', async () => {
+    const calls = [];
+    const environment = { workspace: '/isolated/workspace' };
+    const successfulOptions = {
+        downloadAndUnzipVSCode: async () => '/downloaded/code',
+        installPackagedExtensions: () => ({ evidence: [], installedRoots: {} }),
+        createExtensionHostTestHarness: () => ({ runnerPath: '/harness/index.js' }),
+        createRunTestsOptions: () => ({}),
+        runTests: async () => { calls.push('run-tests'); },
+        notifyCompletion: async message => { calls.push(['notify', message]); },
+        logger: { log: () => {} },
+    };
+
+    await main(['/repository', JSON.stringify(environment)], successfulOptions);
+    assert.deepEqual(calls, [
+        'run-tests',
+        ['notify', EXTENSION_HOST_WORKER_COMPLETED_MESSAGE],
+    ]);
+
+    await assert.rejects(
+        main(['/repository', JSON.stringify(environment)], {
+            ...successfulOptions,
+            runTests: async () => { throw new Error('real test failure'); },
+        }),
+        /real test failure/
+    );
+    assert.equal(
+        calls.filter(call => Array.isArray(call) && call[0] === 'notify').length,
+        1,
+        'a failed test run must not report completion'
     );
 });


### PR DESCRIPTION
## Summary

- add a versioned IPC completion signal that is sent only after the real Extension Host test succeeds
- let the parent watchdog terminate a completed worker that retains cleanup handles without masking failures or unknown messages
- add deterministic launcher, runner, and worker coverage plus a CI-owned behavior contract

## Verification

- `npm run test-compile`
- focused Extension Host tooling tests (15 passed)
- `npm run test:behavior-contracts`
- `npm run test:ci:linux` (changed-line coverage 91.11%)
- `xvfb-run -a npm run test:extension-host` with VS Code 1.130.0; the real smoke passed and exited immediately
- `git diff --check`

## Skill harvest

None. The existing regression/CI skill already requires reproducing and tracing the root cause; the earlier ambiguity was a compliance issue rather than missing reusable guidance.