### PR TITLE
Refactor active session presentation transactions

### DIFF
--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "7a89af3d4230e843f4d33aa37e5583d57361cbd0",
+        "head": "bc6b1625e112e39d6aae8534e718bee9628ecae0",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -261,7 +261,8 @@
             "f2e803793868d93772ddd3a78c8bb3f00fc00e99",
             "713e563edec30161b5a34c45a4cabca4bab0263b",
             "b8351a89e297c70998cad5c4aa2ec375b1885288",
-            "d1c0e2a4a5fe4846847ff21b604a7a26684a955d"
+            "d1c0e2a4a5fe4846847ff21b604a7a26684a955d",
+            "1138487a7f97024092f1f362e8990b2b63883282"
         ]
     },
     "capabilities": [
@@ -907,7 +908,8 @@
                 "f45c91eb03a0dd604ea8cc3b667b4972327a1efa",
                 "5a6571198bc5c396db1fbd2ac45ae12c26f1a1b1",
                 "869d520b640f56e8db2b1f1e3b71b081625c7874",
-                "7a89af3d4230e843f4d33aa37e5583d57361cbd0"
+                "7a89af3d4230e843f4d33aa37e5583d57361cbd0",
+                "bc6b1625e112e39d6aae8534e718bee9628ecae0"
             ],
             "behaviors": [
                 "ATTENTION-ACTIVE-UNREGISTER-ON-DEACTIVATE-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "736d1b87398bf0bd75f171a3c4698295aff38c32",
+        "head": "7a89af3d4230e843f4d33aa37e5583d57361cbd0",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -260,7 +260,8 @@
             "790c4275073bd2be05735c12fe714b9bee27e231",
             "f2e803793868d93772ddd3a78c8bb3f00fc00e99",
             "713e563edec30161b5a34c45a4cabca4bab0263b",
-            "b8351a89e297c70998cad5c4aa2ec375b1885288"
+            "b8351a89e297c70998cad5c4aa2ec375b1885288",
+            "d1c0e2a4a5fe4846847ff21b604a7a26684a955d"
         ]
     },
     "capabilities": [
@@ -905,7 +906,8 @@
                 "687e3f6959ffce62db59daed3fc785a78a284ed1",
                 "f45c91eb03a0dd604ea8cc3b667b4972327a1efa",
                 "5a6571198bc5c396db1fbd2ac45ae12c26f1a1b1",
-                "869d520b640f56e8db2b1f1e3b71b081625c7874"
+                "869d520b640f56e8db2b1f1e3b71b081625c7874",
+                "7a89af3d4230e843f4d33aa37e5583d57361cbd0"
             ],
             "behaviors": [
                 "ATTENTION-ACTIVE-UNREGISTER-ON-DEACTIVATE-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "bc6b1625e112e39d6aae8534e718bee9628ecae0",
+        "head": "21a524b74b4eabde5a125bbe62469b89fa2d5fea",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -262,7 +262,8 @@
             "713e563edec30161b5a34c45a4cabca4bab0263b",
             "b8351a89e297c70998cad5c4aa2ec375b1885288",
             "d1c0e2a4a5fe4846847ff21b604a7a26684a955d",
-            "1138487a7f97024092f1f362e8990b2b63883282"
+            "1138487a7f97024092f1f362e8990b2b63883282",
+            "00eb53cec68ca367088a5cce19bc2f2944d300e2"
         ]
     },
     "capabilities": [
@@ -909,7 +910,8 @@
                 "5a6571198bc5c396db1fbd2ac45ae12c26f1a1b1",
                 "869d520b640f56e8db2b1f1e3b71b081625c7874",
                 "7a89af3d4230e843f4d33aa37e5583d57361cbd0",
-                "bc6b1625e112e39d6aae8534e718bee9628ecae0"
+                "bc6b1625e112e39d6aae8534e718bee9628ecae0",
+                "21a524b74b4eabde5a125bbe62469b89fa2d5fea"
             ],
             "behaviors": [
                 "ATTENTION-ACTIVE-UNREGISTER-ON-DEACTIVATE-001",

--- a/media/webviewDashboardBundle.js
+++ b/media/webviewDashboardBundle.js
@@ -1687,6 +1687,7 @@ function initProjectAiSessionsUpdate(options) {
     var latestAiSessionUpdateSequence = 0;
     var latestAiSessionProjectionRevision = 0;
     var latestAiSessionPresentationProjectionRevision = 0;
+    var latestAiSessionDirectPresentationRevision = 0;
 
     function canApplyRevision(revision, latestRevision) {
         if (typeof revision === 'undefined') {
@@ -1718,12 +1719,18 @@ function initProjectAiSessionsUpdate(options) {
     }
 
     function acceptPresentationProjectionRevision(revision) {
-        if (!canApplyPresentationProjectionRevision(revision)) {
+        if (!Number.isSafeInteger(revision)
+            || revision <= 0
+            || revision < latestAiSessionProjectionRevision
+            || revision < latestAiSessionPresentationProjectionRevision
+            || revision <= latestAiSessionDirectPresentationRevision) {
             return false;
         }
-        if (Number.isSafeInteger(revision) && revision > 0) {
-            latestAiSessionPresentationProjectionRevision = revision;
-        }
+        latestAiSessionPresentationProjectionRevision = Math.max(
+            latestAiSessionPresentationProjectionRevision,
+            revision
+        );
+        latestAiSessionDirectPresentationRevision = revision;
         return true;
     }
 

--- a/media/webviewProjectAiUpdateScripts.js
+++ b/media/webviewProjectAiUpdateScripts.js
@@ -19,6 +19,7 @@ function initProjectAiSessionsUpdate(options) {
     var latestAiSessionUpdateSequence = 0;
     var latestAiSessionProjectionRevision = 0;
     var latestAiSessionPresentationProjectionRevision = 0;
+    var latestAiSessionDirectPresentationRevision = 0;
 
     function canApplyRevision(revision, latestRevision) {
         if (typeof revision === 'undefined') {
@@ -50,12 +51,18 @@ function initProjectAiSessionsUpdate(options) {
     }
 
     function acceptPresentationProjectionRevision(revision) {
-        if (!canApplyPresentationProjectionRevision(revision)) {
+        if (!Number.isSafeInteger(revision)
+            || revision <= 0
+            || revision < latestAiSessionProjectionRevision
+            || revision < latestAiSessionPresentationProjectionRevision
+            || revision <= latestAiSessionDirectPresentationRevision) {
             return false;
         }
-        if (Number.isSafeInteger(revision) && revision > 0) {
-            latestAiSessionPresentationProjectionRevision = revision;
-        }
+        latestAiSessionPresentationProjectionRevision = Math.max(
+            latestAiSessionPresentationProjectionRevision,
+            revision
+        );
+        latestAiSessionDirectPresentationRevision = revision;
         return true;
     }
 

--- a/scripts/run-ai-session-safety-checks.js
+++ b/scripts/run-ai-session-safety-checks.js
@@ -7382,7 +7382,11 @@ function runAiSessionIncrementalRefreshSourceChecks() {
     assert.ok(dashboard.includes('const transaction = aiSessionProjectionCoordinator.captureNext('));
     assert.ok(dashboard.includes('postAiSessionPresentationState(false, transaction);'));
     assert.ok(workspaceHydrationSource.includes('activePresentation,'));
-    assert.ok(dashboard.includes('projectionRevision: aiSessionProjectionCoordinator.nextRevision(),'));
+    assert.ok(dashboard.includes('beginAiSessionProjection: () => {'));
+    assert.strictEqual(
+        dashboard.includes('projectionRevision: aiSessionProjectionCoordinator.nextRevision(),'),
+        false
+    );
     assert.ok(projectWebviewSource.includes(
         'aiSessionsUpdate.canApplyProjectionRevision(message.projectionRevision)'
     ));

--- a/scripts/run-ai-session-safety-checks.js
+++ b/scripts/run-ai-session-safety-checks.js
@@ -639,7 +639,15 @@ function runWorkspaceSessionHydrationChecks() {
         getAttentionAggregate: () => workspaceAttention,
     });
     assert.strictEqual(projectionCoordinator.capture().revision, 0);
-    assert.strictEqual(projectionCoordinator.captureNext().revision, 1);
+    const presentationTransaction = projectionCoordinator.captureNext(workspace);
+    assert.strictEqual(presentationTransaction.revision, 1);
+    assert.strictEqual(
+        presentationTransaction.presentation.workspaceNavigationIdentity,
+        workspace.navigationIdentity
+    );
+    assert.ok(presentationTransaction.presentation.sessions.some(session =>
+        session.provider === 'codex' && session.sessionId === 'web-history'
+    ));
     const controller = new WorkspaceSessionHydrationController({
         providers: providersForHydration,
         readCoordinator,
@@ -5248,9 +5256,8 @@ function runWebviewContentChecks() {
     assert.ok(openWorkspaceDashboardSource.includes(
         'attentionCount: aiSessions?.attentionCount || 0'
     ));
-    assert.ok(openWorkspaceDashboardSource.includes(
-        'this.options.getAiSessionProjectionRevision?.() ?? null'
-    ));
+    assert.match(openWorkspaceDashboardSource,
+        /projectionRevision\s*\?\? this\.options\.getAiSessionProjectionRevision\?\.\(\)\s*\?\? null/);
     assert.ok(!openWorkspaceDashboardSource.includes('getWorkspaceAttentionSummary'));
     assert.ok(!webviewProjectScripts.includes("data-execution-state') === 'running'"),
         'the Webview must apply Host presentation decisions without recombining lifecycle state');
@@ -7314,7 +7321,9 @@ function runAiSessionIncrementalRefreshSourceChecks() {
 
     assert.ok(controllerSource.includes('export class AiSessionDashboardController'));
     assert.ok(controllerSource.includes('buildAiSessionsUpdatedMessage'));
-    assert.ok(controllerSource.includes('getCards: () => WorkspaceCardViewModel[];'));
+    assert.ok(controllerSource.includes(
+        'getCards: (projection: TProjection) => WorkspaceCardViewModel[];'
+    ));
     assert.match(
         controllerSource,
         /async refreshNow\(\s*reason = 'refresh',\s*refreshOptions: AiSessionDashboardRefreshOptions = \{\}\s*\): Promise<void>/
@@ -7341,7 +7350,8 @@ function runAiSessionIncrementalRefreshSourceChecks() {
         'const refreshAiSessionViewsIncrementally = aiSessionAttentionEvent.refreshViewsIncrementally;'
     ), 'the incremental refresh alias must reach the extracted attention event capability');
     assert.ok(dashboard.includes('new WorkspaceSessionHydrationController<vscode.Terminal>({'));
-    assert.ok(dashboard.includes('getCurrentWorkspaceAiSessions: workspace => workspaceSessionHydrationController.hydrate(workspace)'));
+    assert.match(dashboard,
+        /getCurrentWorkspaceAiSessions: \(workspace, projection\) =>\s*workspaceSessionHydrationController\.hydrate\(workspace, projection\)/);
     const sessionControllerCompositionSource = fs.readFileSync(
         path.join(root, 'src', 'aiSessions', 'sessionControllerComposition.ts'), 'utf8'
     );
@@ -7363,9 +7373,15 @@ function runAiSessionIncrementalRefreshSourceChecks() {
 
     assert.ok(workspaceHydrationSource.includes('export class WorkspaceSessionHydrationController'));
     assert.ok(workspaceHydrationSource.includes('export class AiSessionProjectionCoordinator'));
-    assert.ok(workspaceHydrationSource.includes('const projection = this.options.getProjectionSnapshot()'));
+    assert.ok(workspaceHydrationSource.includes(
+        'const projection = projectionOverride || this.options.getProjectionSnapshot()'
+    ));
     assert.strictEqual(dashboard.includes('getActiveRuntimes: () => aiSessionRuntimeCoordinator.getActive(),'), true);
     assert.strictEqual(dashboard.includes('getProjectionSnapshot: () => aiSessionProjectionCoordinator.capture(),'), true);
+    assert.ok(dashboard.includes('getCards: projection => getOpenWorkspaceCards(projection),'));
+    assert.ok(dashboard.includes('const transaction = aiSessionProjectionCoordinator.captureNext('));
+    assert.ok(dashboard.includes('postAiSessionPresentationState(false, transaction);'));
+    assert.ok(workspaceHydrationSource.includes('activePresentation,'));
     assert.ok(dashboard.includes('projectionRevision: aiSessionProjectionCoordinator.nextRevision(),'));
     assert.ok(projectWebviewSource.includes(
         'aiSessionsUpdate.canApplyProjectionRevision(message.projectionRevision)'
@@ -7892,14 +7908,16 @@ function runAiSessionDashboardControllerChecks() {
         getCards: () => [],
         getRunningCardAnimation: () => 'halo',
         getRunningIconAnimation: () => undefined,
-        nextSequence: () => 1,
+        beginProjection: reason => {
+            refreshReasons.push(reason);
+            return { revision: 1 };
+        },
         postMessage: message => {
             messages.push(message);
             return Promise.resolve(true);
         },
         refresh: () => undefined,
         logError: error => { throw new Error(`Unexpected logError: ${error}`); },
-        beforeRefresh: reason => refreshReasons.push(reason),
         afterRefresh: () => undefined,
         nowMs: () => {
             nowMs += 5;
@@ -7956,14 +7974,16 @@ function runAiSessionDashboardWatcherCoalescingChecks() {
         getCards: () => [],
         getRunningCardAnimation: () => 'ripple',
         getRunningIconAnimation: () => undefined,
-        nextSequence: () => messages.length + 1,
+        beginProjection: reason => {
+            refreshReasons.push(reason);
+            return { revision: messages.length + 1 };
+        },
         postMessage: message => {
             messages.push(message);
             return Promise.resolve(true);
         },
         refresh: () => undefined,
         logError: error => { throw new Error(`Unexpected logError: ${error}`); },
-        beforeRefresh: reason => refreshReasons.push(reason),
         afterRefresh: () => undefined,
         nowMs: () => nowMs,
         debounceMs: 100,
@@ -8057,7 +8077,7 @@ async function runAiSessionDashboardUnchangedMessageSkipChecks() {
         getCards: () => [workspace()],
         getRunningCardAnimation: () => runningCardAnimation,
         getRunningIconAnimation: () => runningIconAnimation,
-        nextSequence: () => messages.length + 1,
+        beginProjection: () => ({ revision: messages.length + 1 }),
         postMessage: message => {
             messages.push(message);
             return Promise.resolve(true);

--- a/scripts/run-architecture-guards.js
+++ b/scripts/run-architecture-guards.js
@@ -652,6 +652,18 @@ const guards = {
             this.id,
             risk
         );
+        const openWorkspaceController = parseTypescript(
+            root,
+            'src/openWorkspaces/dashboardController.ts',
+            this.id,
+            risk
+        );
+        const updateMessages = parseTypescript(
+            root,
+            'src/dashboard/webviewUpdateMessages.ts',
+            this.id,
+            risk
+        );
         const hydrationController = parseTypescript(
             root,
             'src/workspaces/sessionHydrationController.ts',
@@ -716,6 +728,22 @@ const guards = {
             || !webviewSource.includes('revision <= latestAiSessionDirectPresentationRevision')) {
             fail(this.id, risk,
                 'the Webview must accept one same-revision direct Presentation after HTML');
+        }
+        const openWorkspaceSource = openWorkspaceController.getFullText();
+        const updateMessageSource = updateMessages.getFullText();
+        if (!openWorkspaceSource.includes(
+            'const projection = this.options.beginAiSessionProjection()'
+        ) || !openWorkspaceSource.includes('cards: this.getCards(projection)')
+            || !openWorkspaceSource.includes('projectionRevision: projection.revision')
+            || !updateMessageSource.includes(
+                'projectionRevision: input.projectionRevision'
+            ) || dashboardSource.includes(
+                'projectionRevision: aiSessionProjectionCoordinator.nextRevision()'
+            ) || !/beginAiSessionProjection:\s*\(\)\s*=>\s*\{[\s\S]*?postAiSessionPresentationState\(false,\s*transaction\);[\s\S]*?return transaction;\s*\},\s*getGroups:/
+                .test(dashboardSource)
+            ) {
+            fail(this.id, risk,
+                'OPEN HTML must capture, hydrate, and publish the same Presentation transaction');
         }
     },
 

--- a/scripts/run-architecture-guards.js
+++ b/scripts/run-architecture-guards.js
@@ -642,6 +642,83 @@ const guards = {
         }
     },
 
+    // ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001
+    'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001'(root) {
+        const risk = 'separately sampled HTML and Presentation can publish conflicting state at adjacent revisions';
+        const dashboard = parseTypescript(root, 'src/dashboard.ts', this.id, risk);
+        const controller = parseTypescript(
+            root,
+            'src/aiSessions/dashboardController.ts',
+            this.id,
+            risk
+        );
+        const hydrationController = parseTypescript(
+            root,
+            'src/workspaces/sessionHydrationController.ts',
+            this.id,
+            risk
+        );
+        const hydration = parseTypescript(
+            root,
+            'src/workspaces/sessionHydration.ts',
+            this.id,
+            risk
+        );
+        const webview = parseJavascript(
+            root,
+            'src/webview/webviewProjectAiUpdateScripts.js',
+            this.id,
+            risk
+        );
+        const controllerSource = controller.getFullText();
+        if (controllerSource.includes('nextSequence')
+            || controllerSource.includes('beforeRefresh')) {
+            fail(this.id, risk,
+                'the incremental controller must begin one explicit projection transaction');
+        }
+        const cardCalls = callArguments(controller, 'this.options.getCards');
+        const buildCalls = callArguments(controller, 'buildAiSessionsUpdatedMessage');
+        const buildInput = buildCalls.length === 1 ? buildCalls[0][0] : null;
+        const sequenceAssignment = buildInput && ts.isObjectLiteralExpression(buildInput)
+            ? buildInput.properties.find(property =>
+                ts.isPropertyAssignment(property)
+                    && property.name.getText(controller) === 'sequence')
+            : null;
+        if (cardCalls.length !== 1
+            || cardCalls[0].length !== 1
+            || cardCalls[0][0].getText(controller) !== 'projection'
+            || !sequenceAssignment
+            || !ts.isPropertyAssignment(sequenceAssignment)
+            || sequenceAssignment.initializer.getText(controller)
+                !== 'projection.revision') {
+            fail(this.id, risk,
+                'cards and HTML must consume the transaction and publish its revision');
+        }
+        const dashboardSource = dashboard.getFullText();
+        if (!/getCards:\s*projection\s*=>\s*getOpenWorkspaceCards\(projection\)/
+            .test(dashboardSource)
+            || !/postAiSessionPresentationState\(false,\s*transaction\);\s*return transaction;/
+                .test(dashboardSource)) {
+            fail(this.id, risk,
+                'Dashboard composition must pass one captured transaction to both channels');
+        }
+        const hydrationControllerSource = hydrationController.getFullText();
+        const hydrationSource = hydration.getFullText();
+        if (!hydrationControllerSource.includes('activePresentation,')
+            || !hydrationSource.includes('input.activePresentation')
+            || !hydrationSource.includes('projectWorkspaceActiveSessions({')) {
+            fail(this.id, risk,
+                'hydration must consume the transaction presentation with only an explicit fallback');
+        }
+        const webviewSource = webview.getFullText();
+        if (!webviewSource.includes('latestAiSessionDirectPresentationRevision')
+            || !webviewSource.includes('revision < latestAiSessionProjectionRevision')
+            || !webviewSource.includes('revision <= latestAiSessionDirectPresentationRevision')) {
+            fail(this.id, risk,
+                'the Webview must accept one same-revision direct Presentation after HTML');
+        }
+    },
+
     // ARCH-AI-SESSION-NAVIGATION-OWNERSHIP-001
     'ARCH-AI-SESSION-NAVIGATION-OWNERSHIP-001'(root) {
         const risk = 'terminal-moving session commands can race and project different targets';

--- a/scripts/run-dashboard-webview-checks.js
+++ b/scripts/run-dashboard-webview-checks.js
@@ -409,6 +409,7 @@ function runDashboardUpdateMessageChecks() {
         cards: [workspaceCard, navigationCard],
         collapsed: false,
         semanticRevision: 'b'.repeat(64),
+        projectionRevision: 1,
         otherWindowsStatus: 'ready',
         todoSearchItems,
         runningCardAnimation: 'breath',
@@ -4879,7 +4880,10 @@ function runSourceContractChecks(source) {
     assert.ok(openWorkspacesMessageBody.includes('openWorkspaceDashboardController.postUpdated()'));
     assert.ok(openWorkspaceControllerSource.includes('buildOpenWorkspacesUpdatedMessage({'));
     assert.ok(openWorkspaceControllerSource.includes('groups: this.options.getGroups()'));
-    assert.ok(openWorkspaceControllerSource.includes('cards: this.getCards()'));
+    assert.ok(openWorkspaceControllerSource.includes('cards: this.getCards(projection)'));
+    assert.ok(openWorkspaceControllerSource.includes(
+        'projectionRevision: projection.revision'
+    ));
     assert.ok(openWorkspaceControllerSource.includes('semanticRevision,'));
     assert.ok(openWorkspaceControllerSource.includes('otherWindowsStatus: this.bridgeStatus'));
     assert.ok(openWorkspaceControllerSource.includes('getViewSemanticRevision()'));

--- a/scripts/run-dashboard-webview-checks.js
+++ b/scripts/run-dashboard-webview-checks.js
@@ -4887,7 +4887,8 @@ function runSourceContractChecks(source) {
     assert.ok(aiSessionControllerSource.includes('buildAiSessionsUpdatedMessage({'));
     assert.ok(aiSessionControllerSource.includes('groups: this.options.getGroups()'));
     assert.ok(aiSessionControllerSource.includes('cards'));
-    assert.ok(aiSessionControllerSource.includes('sequence: this.options.nextSequence()'));
+    assert.ok(aiSessionControllerSource.includes('sequence: projection.revision'));
+    assert.ok(aiSessionControllerSource.includes('this.options.getCards(projection)'));
     assert.ok(projectSource.includes('replaceSearchCatalog(message.searchCatalog)'));
     assert.ok(projectSource.includes("type: 'open-bridge-extension'"));
     assert.ok(extensionHostSource.includes("'workbench.extensions.action.showExtensionsWithIds'"));

--- a/scripts/run-open-project-safety-checks.js
+++ b/scripts/run-open-project-safety-checks.js
@@ -1158,6 +1158,7 @@ async function runOpenWorkspaceClientAndControllerChecks() {
     const colorRequests = [];
     let dashboardAttention = null;
     const dashboard = new OpenWorkspaceDashboardController({
+        beginAiSessionProjection: () => ({ revision: 1 }),
         getCurrentWorkspace: () => current,
         isWorkspaceSavedAsProject: () => false,
         getWorkspaceProjectColor: workspace => {
@@ -1233,6 +1234,7 @@ async function runOpenWorkspaceClientAndControllerChecks() {
     };
     let identitySavedAsProject = false;
     const identityDashboard = new OpenWorkspaceDashboardController({
+        beginAiSessionProjection: () => ({ revision: 1 }),
         getCurrentWorkspace: () => identityWorkspace,
         isWorkspaceSavedAsProject: () => identitySavedAsProject,
         getWorkspaceProjectColor: () => '',
@@ -2096,6 +2098,7 @@ async function runOpenWorkspaceHardeningChecks() {
     let runningCardAnimation = 'custom';
     let runningIconAnimation = 'halo';
     const dashboard = new OpenWorkspaceDashboardController({
+        beginAiSessionProjection: () => ({ revision: 1 }),
         getCurrentWorkspace: () => current,
         isWorkspaceSavedAsProject: () => true,
         getWorkspaceProjectColor: () => '',
@@ -2297,6 +2300,7 @@ async function runWorkspaceContextResolverChecks() {
 
     const zeroRootMessages = [];
     const zeroRootDashboard = new OpenWorkspaceDashboardController({
+        beginAiSessionProjection: () => ({ revision: 1 }),
         getCurrentWorkspace: () => resolver.resolve({
             workspaceFile: uri('file:///work/no-roots.code-workspace'),
             workspaceFolders: [],
@@ -3251,7 +3255,9 @@ function runDashboardBridgeLifecycleChecks() {
     assert.ok(dashboard.includes('const projectMutationController = new ProjectMutationController({'));
     assert.ok(dashboard.includes('const projectPromptController = new ProjectPromptController({'));
     assert.ok(dashboard.includes('new DashboardCommandRegistration<vscode.Disposable>({'));
-    assert.ok(dashboard.includes('openWorkspaceDashboardController = new OpenWorkspaceDashboardController({'));
+    assert.ok(dashboard.includes(
+        'openWorkspaceDashboardController = new OpenWorkspaceDashboardController<vscode.Terminal>({'
+    ));
     assert.ok(dashboard.includes('openWorkspaceController = new OpenWorkspaceController({'));
     assert.ok(dashboard.includes('new OpenWorkspaceBridgeClient('));
     assert.ok(dashboard.includes(
@@ -3294,7 +3300,9 @@ function runDashboardBridgeLifecycleChecks() {
     assert.ok(!dashboard.includes('function logOpenWorkspaceDiagnostic('));
     assert.ok(dashboard.includes('openWorkspaceController.publish('));
     assert.ok(!dashboard.includes('get openProjects()'));
-    assert.ok(projectedOpenWorkspaces.includes('openWorkspaceDashboardController.getCards()'));
+    assert.ok(projectedOpenWorkspaces.includes(
+        'openWorkspaceDashboardController.getCards(projection)'
+    ));
     assert.ok(selectedProjectHandler.includes("projectId.startsWith('__openWorkspaceNavigation-')"));
     assert.ok(selectedProjectHandler.includes('await getWorkspaceNavigationController().open(projectId);'));
     assert.strictEqual(selectedProjectHandler.includes('getNavigationWorkspace(projectId)'), false);

--- a/scripts/run-workspace-parity-checks.js
+++ b/scripts/run-workspace-parity-checks.js
@@ -282,6 +282,7 @@ async function runShapeLifecycle(shape, index) {
     let collapsed = false;
     const posts = [];
     const remoteDashboard = new OpenWorkspaceDashboardController({
+        beginAiSessionProjection: () => ({ revision: 1 }),
         getCurrentWorkspace: () => null,
         isWorkspaceSavedAsProject: () => false,
         getWorkspaceProjectColor: () => '',

--- a/src/aiSessions/dashboardController.ts
+++ b/src/aiSessions/dashboardController.ts
@@ -9,7 +9,9 @@ interface DisposableLike {
     dispose(): void;
 }
 
-export interface AiSessionDashboardControllerOptions {
+export interface AiSessionDashboardControllerOptions<
+    TProjection extends AiSessionDashboardProjection = AiSessionDashboardProjection
+> {
     providerIds: AiSessionProviderId[];
     isVisible: () => boolean;
     invalidateCache: (providerId: AiSessionProviderId) => void;
@@ -17,16 +19,15 @@ export interface AiSessionDashboardControllerOptions {
     getGroups: () => Group[];
     getTodoSearchItems: () => TodoSearchCatalogItem[];
     getSkillRecords?: () => import('../skills/types').SkillRecord[];
-    getCards: () => WorkspaceCardViewModel[];
+    getCards: (projection: TProjection) => WorkspaceCardViewModel[];
     getRunningCardAnimation: () => string | undefined;
     getRunningIconAnimation: () => string | undefined;
-    nextSequence: () => number;
+    beginProjection: (reason: string) => TProjection;
     postMessage: (message: unknown) => Thenable<boolean>;
     refresh: (reason: string) => void;
     logError: (message: string, error: unknown) => void;
     logDiagnostic?: (event: Record<string, unknown>) => void;
     nowMs?: () => number;
-    beforeRefresh?: (reason: string) => void;
     afterRefresh?: () => void;
     debounceMs: number;
     watcherRefreshMinIntervalMs?: number;
@@ -36,11 +37,17 @@ export interface AiSessionDashboardControllerOptions {
     clearTimeout: (handle: NodeJS.Timeout) => void;
 }
 
+export interface AiSessionDashboardProjection {
+    revision: number;
+}
+
 export interface AiSessionDashboardRefreshOptions {
     fallbackToFullRefresh?: boolean;
 }
 
-export class AiSessionDashboardController {
+export class AiSessionDashboardController<
+    TProjection extends AiSessionDashboardProjection = AiSessionDashboardProjection
+> {
     private refreshTimeout: NodeJS.Timeout = null;
     private watcherStopTimeout: NodeJS.Timeout = null;
     private newSessionRefreshTimeouts: NodeJS.Timeout[] = [];
@@ -50,7 +57,7 @@ export class AiSessionDashboardController {
     private lastWatcherRefreshAtMs: number | null = null;
     private lastPostedIncrementalMessageSignature: string | null = null;
 
-    constructor(private readonly options: AiSessionDashboardControllerOptions) {
+    constructor(private readonly options: AiSessionDashboardControllerOptions<TProjection>) {
     }
 
     scheduleRefresh(reason = 'refresh'): void {
@@ -117,9 +124,9 @@ export class AiSessionDashboardController {
         }
 
         const fallbackToFullRefresh = refreshOptions.fallbackToFullRefresh !== false;
-        this.options.beforeRefresh?.(reason);
+        const projection = this.options.beginProjection(reason);
         try {
-            const message = this.getUpdatedMessage(reason);
+            const message = this.buildUpdatedMessage(reason, projection);
             const signature = this.getIncrementalMessageSignature(message);
             if (this.shouldSkipUnchangedMessage(reason) && signature === this.lastPostedIncrementalMessageSignature) {
                 this.options.logDiagnostic?.({
@@ -163,12 +170,24 @@ export class AiSessionDashboardController {
     }
 
     getUpdatedMessage(reason = 'refresh'): AiSessionsUpdatedMessage {
+        const projection = this.options.beginProjection(reason);
+        try {
+            return this.buildUpdatedMessage(reason, projection);
+        } finally {
+            this.options.afterRefresh?.();
+        }
+    }
+
+    private buildUpdatedMessage(
+        reason: string,
+        projection: TProjection
+    ): AiSessionsUpdatedMessage {
         const startedAt = this.nowMs();
-        const cards = this.options.getCards();
+        const cards = this.options.getCards(projection);
         const message = buildAiSessionsUpdatedMessage({
             groups: this.options.getGroups(),
             cards,
-            sequence: this.options.nextSequence(),
+            sequence: projection.revision,
             generatedAt: new Date().toISOString(),
             todoSearchItems: this.options.getTodoSearchItems(),
             skills: this.options.getSkillRecords ? this.options.getSkillRecords() : [],

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1766,6 +1766,13 @@ async function initializeDashboard(
         getCurrentWorkspaceSessionProjectId: identity =>
             currentWorkspaceSessionAuthority.getProjectId(identity),
         getAiSessionProjectionRevision: () => aiSessionProjectionCoordinator.capture().revision,
+        beginAiSessionProjection: () => {
+            const transaction = aiSessionProjectionCoordinator.captureNext(
+                getCurrentOpenWorkspace()
+            );
+            postAiSessionPresentationState(false, transaction);
+            return transaction;
+        },
         getGroups: () => projectService.getGroups(),
         getTodoSearchItems: () => todoService.getSearchItems(),
         getSkillRecords: () => skillPanel.getRecords(),
@@ -1774,10 +1781,7 @@ async function initializeDashboard(
         getRunningIconAnimation: () => getEffectiveRunningIconAnimation(getAgentPivotConfiguration()),
         getAttentionAggregate: () => aiSessionAttentionController.getEffectiveAggregate(),
         getBridgeInstanceId: () => openWorkspaceBridgeClient.instanceId,
-        postMessage: message => provider.postMessage({
-            ...(message as Record<string, unknown>),
-            projectionRevision: aiSessionProjectionCoordinator.nextRevision(),
-        }),
+        postMessage: message => provider.postMessage(message),
         refresh: refreshStewardViews,
         isVisible: () => provider.visible,
         logDiagnostic: logOpenWorkspaceDiagnostic,

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -211,9 +211,9 @@ import {
     CurrentWorkspaceSessionAuthority,
 } from './workspaces/currentWorkspaceSessionAuthority';
 import { hasWorkspaceRuntimeContinuity } from './workspaces/runtimeOwnership';
-import { projectWorkspaceActiveSessions } from './workspaces/activeSessionPresentation';
 import {
     AiSessionProjectionCoordinator,
+    AiSessionPresentationTransaction,
     WorkspaceSessionHydrationController,
 } from './workspaces/sessionHydrationController';
 import type { OpenWorkspace } from './workspaces/types';
@@ -1151,7 +1151,7 @@ async function initializeDashboard(
     const aiSessionWorkspaceStateStore = new AiSessionWorkspaceStateStore(context.globalState, isAiSessionProviderId);
     const workspacePrimaryRootStore = new WorkspacePrimaryRootStore(context.globalState);
     let openWorkspaceController: OpenWorkspaceController;
-    let openWorkspaceDashboardController: OpenWorkspaceDashboardController;
+    let openWorkspaceDashboardController: OpenWorkspaceDashboardController<vscode.Terminal>;
     let projectsPanelController: ProjectsPanelController | undefined;
     let workspaceNavigationController: WorkspaceNavigationController;
     let openWorkspacePinController: OpenWorkspacePinController;
@@ -1427,7 +1427,9 @@ async function initializeDashboard(
         handle => clearTimeout(handle),
     );
     let conversationCapability: ConversationCapability;
-    const aiSessionDashboardController = ownResource(() => new AiSessionDashboardController({
+    const aiSessionDashboardController = ownResource(() => new AiSessionDashboardController<
+        AiSessionPresentationTransaction<vscode.Terminal>
+    >({
         providerIds: aiSessionProviders.map(provider => provider.id),
         isVisible: () => provider.visible,
         invalidateCache: providerId => invalidateAiSessionCache(providerId),
@@ -1435,10 +1437,18 @@ async function initializeDashboard(
         getGroups: () => projectService.getGroups(),
         getTodoSearchItems: () => todoService.getSearchItems(),
         getSkillRecords: () => skillPanel.getRecords(),
-        getCards: getOpenWorkspaceCards,
+        getCards: projection => getOpenWorkspaceCards(projection),
         getRunningCardAnimation: () => getEffectiveRunningCardAnimation(getAgentPivotConfiguration()),
         getRunningIconAnimation: () => getEffectiveRunningIconAnimation(getAgentPivotConfiguration()),
-        nextSequence: () => aiSessionProjectionCoordinator.nextRevision(),
+        beginProjection: reason => {
+            aiSessionAttentionController.invalidateWorkspaceTarget();
+            currentAiSessionRefreshReason = reason;
+            const transaction = aiSessionProjectionCoordinator.captureNext(
+                getCurrentOpenWorkspace()
+            );
+            postAiSessionPresentationState(false, transaction);
+            return transaction;
+        },
         postMessage: message => provider.postMessage({
             ...(message as unknown as Record<string, unknown>),
             projectionRevision: (message as AiSessionsUpdatedMessage).sequence,
@@ -1446,11 +1456,6 @@ async function initializeDashboard(
         refresh: refreshStewardViews,
         logError,
         logDiagnostic: logAiSessionDiagnostic,
-        beforeRefresh: reason => {
-            aiSessionAttentionController.invalidateWorkspaceTarget();
-            currentAiSessionRefreshReason = reason;
-            postAiSessionAttentionState();
-        },
         afterRefresh: () => {
             currentAiSessionRefreshReason = 'refresh';
             void conversationCapability.reconcile();
@@ -1751,12 +1756,13 @@ async function initializeDashboard(
         refreshAiSessionRuntimes: (_reason, force) => aiSessionRuntimeCoordinator.refreshForHost(force),
         logAiSessionRuntimeFailure,
     });
-    openWorkspaceDashboardController = new OpenWorkspaceDashboardController({
+    openWorkspaceDashboardController = new OpenWorkspaceDashboardController<vscode.Terminal>({
         getCurrentWorkspace: getCurrentOpenWorkspace,
         isWorkspaceSavedAsProject: workspace => Boolean(getSavedProjectForWorkspace(workspace)),
         getWorkspaceProjectColor: workspace => getSavedProjectForWorkspace(workspace)?.color || '',
         getWorkspaceProjectName: workspace => getSavedProjectForWorkspace(workspace)?.name || '',
-        getCurrentWorkspaceAiSessions: workspace => workspaceSessionHydrationController.hydrate(workspace),
+        getCurrentWorkspaceAiSessions: (workspace, projection) =>
+            workspaceSessionHydrationController.hydrate(workspace, projection),
         getCurrentWorkspaceSessionProjectId: identity =>
             currentWorkspaceSessionAuthority.getProjectId(identity),
         getAiSessionProjectionRevision: () => aiSessionProjectionCoordinator.capture().revision,
@@ -2603,22 +2609,17 @@ async function initializeDashboard(
         postAiSessionPresentationState(true);
     }
 
-    function postAiSessionPresentationState(revealFocused: boolean = false): void {
-        const snapshot = aiSessionProjectionCoordinator.captureNext();
-        const presentation = projectWorkspaceActiveSessions({
-            workspace: getCurrentOpenWorkspace(),
-            activeRuntimes: snapshot.activeRuntimes,
-            pendingRuntimes: snapshot.pendingRuntimes,
-            executionSnapshot: snapshot.executionSnapshot,
-            focusedIdentity: snapshot.focusedIdentity,
-            attentionAggregate: snapshot.attentionAggregate,
-        });
+    function postAiSessionPresentationState(
+        revealFocused: boolean = false,
+        transaction: AiSessionPresentationTransaction<vscode.Terminal>
+            = aiSessionProjectionCoordinator.captureNext(getCurrentOpenWorkspace())
+    ): void {
         const configuration = getAgentPivotConfiguration();
         const message: AiSessionPresentationStateMessage = {
             type: 'ai-session-presentation-state',
             version: 1,
-            projectionRevision: snapshot.revision,
-            ...presentation,
+            projectionRevision: transaction.revision,
+            ...transaction.presentation,
             runningCardAnimation: getEffectiveRunningCardAnimation(configuration),
             runningIconAnimation: getEffectiveRunningIconAnimation(configuration),
             revealFocused,
@@ -2644,8 +2645,10 @@ async function initializeDashboard(
         return gitRepositoryDetector.isGitRepositoryPath(fPath);
     }
 
-    function getOpenWorkspaceCards() {
-        return openWorkspaceDashboardController.getCards();
+    function getOpenWorkspaceCards(
+        projection?: AiSessionPresentationTransaction<vscode.Terminal>
+    ) {
+        return openWorkspaceDashboardController.getCards(projection);
     }
 
     function getSavedProjectForCurrentWorkspace(): Project | null {

--- a/src/dashboard/webviewUpdateMessages.ts
+++ b/src/dashboard/webviewUpdateMessages.ts
@@ -75,6 +75,7 @@ export interface OpenWorkspacesUpdatedMessage {
     type: 'open-workspaces-updated';
     version: 2;
     semanticRevision: string;
+    projectionRevision: number;
     currentWorkspaceCount: 0 | 1;
     navigationWorkspaceCount: number;
     otherWindowsStatus: OpenWorkspaceBridgeStatus;
@@ -87,6 +88,7 @@ export interface BuildOpenWorkspacesUpdatedMessageInput {
     cards: WorkspaceCardViewModel[];
     collapsed: boolean;
     semanticRevision: string;
+    projectionRevision: number;
     otherWindowsStatus: OpenWorkspaceBridgeStatus;
     todoSearchItems: TodoSearchCatalogItem[];
     skills?: import('../skills/types').SkillRecord[];
@@ -114,6 +116,7 @@ export function buildOpenWorkspacesUpdatedMessage(
         type: 'open-workspaces-updated',
         version: 2,
         semanticRevision: input.semanticRevision,
+        projectionRevision: input.projectionRevision,
         currentWorkspaceCount,
         navigationWorkspaceCount,
         otherWindowsStatus: input.otherWindowsStatus,

--- a/src/openWorkspaces/dashboardController.ts
+++ b/src/openWorkspaces/dashboardController.ts
@@ -9,6 +9,7 @@ import type { Group, WorkspaceCardViewModel } from '../models';
 import { buildOpenWorkspacesUpdatedMessage } from '../dashboard/webviewUpdateMessages';
 import type { TodoSearchCatalogItem } from '../todos/types';
 import type { OpenWorkspace } from '../workspaces/types';
+import type { AiSessionProjectionSnapshot } from '../workspaces/sessionHydrationController';
 import {
     CurrentWorkspaceSessionAuthority,
 } from '../workspaces/currentWorkspaceSessionAuthority';
@@ -32,12 +33,15 @@ export interface OpenWorkspaceDashboardState {
     otherWindows: { status: OpenWorkspaceBridgeStatus };
 }
 
-export interface OpenWorkspaceDashboardControllerOptions {
+export interface OpenWorkspaceDashboardControllerOptions<TTerminal = unknown> {
     getCurrentWorkspace: () => OpenWorkspace | null;
     isWorkspaceSavedAsProject: (workspace: OpenWorkspace) => boolean;
     getWorkspaceProjectColor: (workspace: Pick<OpenWorkspace, 'kind' | 'navigationUri'>) => string;
     getWorkspaceProjectName?: (workspace: Pick<OpenWorkspace, 'kind' | 'navigationUri'>) => string;
-    getCurrentWorkspaceAiSessions: (workspace: OpenWorkspace) => WorkspaceAiSessionViewModel | null;
+    getCurrentWorkspaceAiSessions: (
+        workspace: OpenWorkspace,
+        projection?: AiSessionProjectionSnapshot<TTerminal>
+    ) => WorkspaceAiSessionViewModel | null;
     getCurrentWorkspaceSessionProjectId?: (
         identity: {
             workspaceNavigationIdentity: string;
@@ -61,7 +65,7 @@ export interface OpenWorkspaceDashboardControllerOptions {
     nowMs?: () => number;
 }
 
-export class OpenWorkspaceDashboardController {
+export class OpenWorkspaceDashboardController<TTerminal = unknown> {
     private aggregate: OpenWorkspaceAggregate | null = null;
     private pinSnapshot: OpenWorkspacePinSnapshot = createOpenWorkspacePinSnapshot([]);
     private bridgeStatus: OpenWorkspaceBridgeStatus = 'connecting';
@@ -79,7 +83,7 @@ export class OpenWorkspaceDashboardController {
     private readonly fallbackCurrentWorkspaceSessionAuthority =
         new CurrentWorkspaceSessionAuthority();
 
-    constructor(private readonly options: OpenWorkspaceDashboardControllerOptions) {
+    constructor(private readonly options: OpenWorkspaceDashboardControllerOptions<TTerminal>) {
         this.fallbackOpenedAtMs = this.nowMs();
     }
 
@@ -124,13 +128,16 @@ export class OpenWorkspaceDashboardController {
         return this.pinNavigationIdentityById.get(cardId) || null;
     }
 
-    getCards(): WorkspaceCardViewModel[] {
+    getCards(
+        projection?: AiSessionProjectionSnapshot<TTerminal>
+    ): WorkspaceCardViewModel[] {
         const startedAt = this.nowMs();
         const currentWorkspace = this.options.getCurrentWorkspace();
         const attentionAggregate = this.options.getAttentionAggregate();
         const cacheKey = this.getCardProjectionCacheKey(
             currentWorkspace,
             attentionAggregate,
+            projection?.revision,
         );
         if (this.cachedCards
             && cacheKey === this.cachedCardsKey
@@ -149,6 +156,7 @@ export class OpenWorkspaceDashboardController {
                 currentWorkspace,
                 currentNavigationIdentity || currentWorkspace.navigationIdentity,
                 pinTimes.has(currentNavigationIdentity || currentWorkspace.navigationIdentity),
+                projection,
             )
             : null;
         const navigationProjections = projectOpenWorkspaceNavigationCards(
@@ -295,6 +303,7 @@ export class OpenWorkspaceDashboardController {
         workspace: OpenWorkspace,
         navigationIdentity: string,
         pinned: boolean,
+        projection?: AiSessionProjectionSnapshot<TTerminal>,
     ): WorkspaceCardViewModel {
         const projectId = (
             this.options.getCurrentWorkspaceSessionProjectId
@@ -304,7 +313,10 @@ export class OpenWorkspaceDashboardController {
             workspaceNavigationIdentity: navigationIdentity,
             workspaceScopeIdentity: workspace.scopeIdentity,
         });
-        const aiSessions = this.options.getCurrentWorkspaceAiSessions(workspace) || undefined;
+        const aiSessions = this.options.getCurrentWorkspaceAiSessions(
+            workspace,
+            projection
+        ) || undefined;
         return {
             id: projectId,
             kind: 'current',
@@ -395,13 +407,16 @@ export class OpenWorkspaceDashboardController {
     private getCardProjectionCacheKey(
         workspace: OpenWorkspace | null,
         attentionAggregate: AttentionAggregate | null,
+        projectionRevision?: number,
     ): string {
         return JSON.stringify([
             this.bridgeStatus,
             this.aggregate?.semanticRevision || null,
             this.pinSnapshot.revision,
             attentionAggregate?.aggregateRevision || null,
-            this.options.getAiSessionProjectionRevision?.() ?? null,
+            projectionRevision
+                ?? this.options.getAiSessionProjectionRevision?.()
+                ?? null,
             workspace ? {
                 navigationIdentity: workspace.navigationIdentity,
                 scopeIdentity: workspace.scopeIdentity,

--- a/src/openWorkspaces/dashboardController.ts
+++ b/src/openWorkspaces/dashboardController.ts
@@ -9,7 +9,10 @@ import type { Group, WorkspaceCardViewModel } from '../models';
 import { buildOpenWorkspacesUpdatedMessage } from '../dashboard/webviewUpdateMessages';
 import type { TodoSearchCatalogItem } from '../todos/types';
 import type { OpenWorkspace } from '../workspaces/types';
-import type { AiSessionProjectionSnapshot } from '../workspaces/sessionHydrationController';
+import type {
+    AiSessionPresentationTransaction,
+    AiSessionProjectionSnapshot,
+} from '../workspaces/sessionHydrationController';
 import {
     CurrentWorkspaceSessionAuthority,
 } from '../workspaces/currentWorkspaceSessionAuthority';
@@ -49,6 +52,7 @@ export interface OpenWorkspaceDashboardControllerOptions<TTerminal = unknown> {
         }
     ) => string;
     getAiSessionProjectionRevision?: () => number;
+    beginAiSessionProjection: () => AiSessionPresentationTransaction<TTerminal>;
     getGroups: () => Group[];
     getTodoSearchItems: () => TodoSearchCatalogItem[];
     getSkillRecords?: () => import('../skills/types').SkillRecord[];
@@ -256,11 +260,13 @@ export class OpenWorkspaceDashboardController<TTerminal = unknown> {
         if (!this.options.isVisible()) { return Promise.resolve(); }
         const semanticRevision = this.getViewSemanticRevision();
         if (semanticRevision === this.lastPostedSemanticRevision) { return Promise.resolve(); }
+        const projection = this.options.beginAiSessionProjection();
         const message = buildOpenWorkspacesUpdatedMessage({
             groups: this.options.getGroups(),
-            cards: this.getCards(),
+            cards: this.getCards(projection),
             collapsed: this.options.getCollapsed(),
             semanticRevision,
+            projectionRevision: projection.revision,
             otherWindowsStatus: this.bridgeStatus,
             todoSearchItems: this.options.getTodoSearchItems(),
             skills: this.options.getSkillRecords ? this.options.getSkillRecords() : [],

--- a/src/webview/webviewProjectAiUpdateScripts.js
+++ b/src/webview/webviewProjectAiUpdateScripts.js
@@ -19,6 +19,7 @@ function initProjectAiSessionsUpdate(options) {
     var latestAiSessionUpdateSequence = 0;
     var latestAiSessionProjectionRevision = 0;
     var latestAiSessionPresentationProjectionRevision = 0;
+    var latestAiSessionDirectPresentationRevision = 0;
 
     function canApplyRevision(revision, latestRevision) {
         if (typeof revision === 'undefined') {
@@ -50,12 +51,18 @@ function initProjectAiSessionsUpdate(options) {
     }
 
     function acceptPresentationProjectionRevision(revision) {
-        if (!canApplyPresentationProjectionRevision(revision)) {
+        if (!Number.isSafeInteger(revision)
+            || revision <= 0
+            || revision < latestAiSessionProjectionRevision
+            || revision < latestAiSessionPresentationProjectionRevision
+            || revision <= latestAiSessionDirectPresentationRevision) {
             return false;
         }
-        if (Number.isSafeInteger(revision) && revision > 0) {
-            latestAiSessionPresentationProjectionRevision = revision;
-        }
+        latestAiSessionPresentationProjectionRevision = Math.max(
+            latestAiSessionPresentationProjectionRevision,
+            revision
+        );
+        latestAiSessionDirectPresentationRevision = revision;
         return true;
     }
 

--- a/src/workspaces/sessionHydration.ts
+++ b/src/workspaces/sessionHydration.ts
@@ -50,6 +50,7 @@ export interface HydrateWorkspaceAiSessionsInput<TTerminal = unknown> {
     executionSnapshot?: Readonly<Record<string, AiSessionExecutionSnapshot>>;
     focusedIdentity?: AiSessionRuntimeIdentity | ActiveAiSessionTerminalIdentity | null;
     attentionAggregate?: AttentionAggregate | null;
+    activePresentation?: WorkspaceActiveSessionPresentation;
     activeProvider?: AiSessionProviderId;
     providerSelection?: AiSessionProviderSelection;
     expanded?: boolean;
@@ -88,14 +89,15 @@ interface ProjectablePendingRuntime<TTerminal> extends AiSessionPendingRuntimeSn
 export function hydrateWorkspaceAiSessions<TTerminal = unknown>(
     input: HydrateWorkspaceAiSessionsInput<TTerminal>
 ): WorkspaceAiSessionViewModel {
-    const activePresentation = projectWorkspaceActiveSessions({
-        workspace: input.workspace,
-        activeRuntimes: input.activeRuntimes || [],
-        pendingRuntimes: input.pendingRuntimes || [],
-        executionSnapshot: input.executionSnapshot || {},
-        focusedIdentity: input.focusedIdentity || null,
-        attentionAggregate: input.attentionAggregate || null,
-    });
+    const activePresentation = input.activePresentation
+        || projectWorkspaceActiveSessions({
+            workspace: input.workspace,
+            activeRuntimes: input.activeRuntimes || [],
+            pendingRuntimes: input.pendingRuntimes || [],
+            executionSnapshot: input.executionSnapshot || {},
+            focusedIdentity: input.focusedIdentity || null,
+            attentionAggregate: input.attentionAggregate || null,
+        });
     const attentionByRootAndSession = buildWorkspaceSessionAttentionIndex(
         input.attentionAggregate || null
     );

--- a/src/workspaces/sessionHydrationController.ts
+++ b/src/workspaces/sessionHydrationController.ts
@@ -17,6 +17,8 @@ import type {
 } from '../aiSessions/types';
 import type { AiSessionProviderSelection } from '../aiSessions/providerSelection';
 import type { OpenWorkspace } from './types';
+import { projectWorkspaceActiveSessions } from './activeSessionPresentation';
+import type { WorkspaceActiveSessionPresentation } from './activeSessionPresentation';
 import { getWorkspaceAiSessionCandidatePaths, hydrateWorkspaceAiSessions } from './sessionHydration';
 
 type HydrationProvider = Pick<AiSessionProviderDefinition, 'id' | 'label' | 'terminalCwdFields'>;
@@ -36,6 +38,11 @@ export interface AiSessionProjectionSnapshot<TTerminal = unknown> {
     executionSnapshot: Readonly<Record<string, AiSessionExecutionSnapshot>>;
     focusedIdentity: AiSessionRuntimeIdentity | ActiveAiSessionTerminalIdentity | null;
     attentionAggregate: AttentionAggregate | null;
+}
+
+export interface AiSessionPresentationTransaction<TTerminal = unknown>
+    extends AiSessionProjectionSnapshot<TTerminal> {
+    presentation: WorkspaceActiveSessionPresentation;
 }
 
 export interface AiSessionProjectionCoordinatorOptions<TTerminal = unknown> {
@@ -75,9 +82,22 @@ export class AiSessionProjectionCoordinator<TTerminal = unknown> {
         };
     }
 
-    captureNext(): AiSessionProjectionSnapshot<TTerminal> {
+    captureNext(
+        workspace: OpenWorkspace | null = null
+    ): AiSessionPresentationTransaction<TTerminal> {
         this.nextRevision();
-        return this.capture();
+        const snapshot = this.capture();
+        return {
+            ...snapshot,
+            presentation: projectWorkspaceActiveSessions({
+                workspace,
+                activeRuntimes: snapshot.activeRuntimes,
+                pendingRuntimes: snapshot.pendingRuntimes,
+                executionSnapshot: snapshot.executionSnapshot,
+                focusedIdentity: snapshot.focusedIdentity,
+                attentionAggregate: snapshot.attentionAggregate,
+            }),
+        };
     }
 }
 
@@ -107,7 +127,11 @@ export class WorkspaceSessionHydrationController<TTerminal = unknown> {
     constructor(private readonly options: WorkspaceSessionHydrationControllerOptions<TTerminal>) {
     }
 
-    hydrate(workspace: OpenWorkspace | null): WorkspaceAiSessionViewModel | null {
+    hydrate(
+        workspace: OpenWorkspace | null,
+        projectionOverride?: AiSessionProjectionSnapshot<TTerminal>
+            | AiSessionPresentationTransaction<TTerminal>
+    ): WorkspaceAiSessionViewModel | null {
         const startedAt = this.nowMs();
         const reason = this.options.getRefreshReason();
         if (!workspace) {
@@ -127,7 +151,19 @@ export class WorkspaceSessionHydrationController<TTerminal = unknown> {
         const maxFiles = getAiSessionScanMaxFiles(reason, this.options.incrementalScanMaxFiles);
         const sessionResults = this.options.readCoordinator.getResults({ candidatePaths, reason, maxFiles });
         this.options.onDidReadSessions?.(workspace, sessionResults, reason);
-        const projection = this.options.getProjectionSnapshot();
+        const projection = projectionOverride || this.options.getProjectionSnapshot();
+        const activePresentation = Object.prototype.hasOwnProperty.call(
+            projection,
+            'presentation'
+        )
+            ? (projection as AiSessionPresentationTransaction<TTerminal>).presentation
+            : undefined;
+        if (activePresentation
+            && (activePresentation.workspaceScopeIdentity !== workspace.scopeIdentity
+                || activePresentation.workspaceNavigationIdentity
+                    !== workspace.navigationIdentity)) {
+            throw new Error('AI Session presentation transaction does not match the hydrated workspace.');
+        }
         const result = hydrateWorkspaceAiSessions({
             workspace,
             providers: this.options.providers,
@@ -140,6 +176,7 @@ export class WorkspaceSessionHydrationController<TTerminal = unknown> {
             executionSnapshot: projection.executionSnapshot,
             focusedIdentity: projection.focusedIdentity,
             attentionAggregate: projection.attentionAggregate,
+            activePresentation,
             providerSelection: this.options.getProviderSelection(workspace.scopeIdentity),
             expanded: this.options.getExpanded(workspace.scopeIdentity),
         });

--- a/tests/browser/activeSessionCardInteraction.test.js
+++ b/tests/browser/activeSessionCardInteraction.test.js
@@ -653,6 +653,53 @@ test('ACTIVE-SESSION-PRESENTATION-TRANSACTION-001 accepts same-revision owner ev
     }]);
 });
 
+test('ACTIVE-SESSION-PRESENTATION-TRANSACTION-001 keeps OPEN HTML and owner events in one revision', async t => {
+    const attentionSession = {
+        ...session('codex', 'session-a', true),
+        executionState: 'stopped',
+        status: 'stopped',
+        needsAttention: true,
+        attentionEventId: 'open-event-a',
+    };
+    const page = await openCardPage(t, [session('codex', 'session-a', true)]);
+    await postHostMessage(page, {
+        type: 'open-workspaces-updated',
+        version: 2,
+        projectionRevision: 2,
+        semanticRevision: 'open-transaction-revision',
+        currentWorkspaceCount: 1,
+        navigationWorkspaceCount: 0,
+        otherWindowsStatus: 'ready',
+        html: `<div class="open-current-workspace-group">${projectMarkup([
+            attentionSession,
+        ])}</div>
+            <div class="open-other-windows-group" data-other-windows-status="ready">
+                ${currentOpenWorkspaceProjectMarkup()}
+            </div>`,
+        searchCatalog: {
+            version: 2,
+            sessions: [],
+            openWorkspaces: [{ identity: 'project-a' }],
+            savedProjects: [],
+            todos: [],
+        },
+    });
+    await postHostMessage(page, presentationMessage([attentionSession], 2, {
+        attention: {
+            'codex:session-a': ['open-event-a', 'open-event-b'],
+        },
+    }));
+
+    await row(page, 'codex', 'session-a').locator('.ai-session-primary-action').click();
+    const acknowledgements = (await postedMessages(page)).filter(message =>
+        message.type === 'acknowledge-ai-session-attention'
+    );
+    assert.deepEqual(acknowledgements, [{
+        type: 'acknowledge-ai-session-attention',
+        eventIds: ['open-event-a', 'open-event-b'],
+    }]);
+});
+
 test('ACTIVE-SESSION-FOCUS-REVEAL-001 transfers pending focus through the complete presentation', async t => {
     const pending = {
         key: 'pending:codex:pending-one',

--- a/tests/browser/activeSessionCardInteraction.test.js
+++ b/tests/browser/activeSessionCardInteraction.test.js
@@ -613,6 +613,46 @@ test('ACTIVE-SESSION-FOCUS-REVEAL-001 keeps a newer complete presentation when o
     );
 });
 
+test('ACTIVE-SESSION-PRESENTATION-TRANSACTION-001 accepts same-revision owner events after HTML arrives first', async t => {
+    const attentionSession = {
+        ...session('codex', 'session-a', true),
+        executionState: 'stopped',
+        status: 'stopped',
+        needsAttention: true,
+        attentionEventId: 'event-a',
+    };
+    const page = await openCardPage(t, [session('codex', 'session-a', true)]);
+    await postHostMessage(page, {
+        type: 'ai-sessions-updated',
+        version: 2,
+        sequence: 1,
+        projectionRevision: 2,
+        currentWorkspaceCount: 1,
+        html: `<div class="open-current-workspace-group">${projectMarkup([
+            attentionSession,
+        ])}</div>`,
+        searchCatalog: {
+            version: 2,
+            sessions: [],
+            openWorkspaces: [],
+            savedProjects: [],
+            todos: [],
+        },
+    });
+    await postHostMessage(page, presentationMessage([attentionSession], 2, {
+        attention: { 'codex:session-a': ['event-a', 'event-b'] },
+    }));
+
+    await row(page, 'codex', 'session-a').locator('.ai-session-primary-action').click();
+    const acknowledgements = (await postedMessages(page)).filter(message =>
+        message.type === 'acknowledge-ai-session-attention'
+    );
+    assert.deepEqual(acknowledgements, [{
+        type: 'acknowledge-ai-session-attention',
+        eventIds: ['event-a', 'event-b'],
+    }]);
+});
+
 test('ACTIVE-SESSION-FOCUS-REVEAL-001 transfers pending focus through the complete presentation', async t => {
     const pending = {
         key: 'pending:codex:pending-one',

--- a/tests/contract/aiSessions/projectHydrationController.test.js
+++ b/tests/contract/aiSessions/projectHydrationController.test.js
@@ -146,3 +146,77 @@ test('PERSIST-AI-SESSION-PROJECT-HYDRATION-CONTROLLER-001 preserves scan, projec
     controller.hydrate(WORKSPACE);
     assert.equal(reads[1].maxFiles, 0);
 });
+
+test('ACTIVE-SESSION-PRESENTATION-TRANSACTION-001 hydration consumes the captured presentation without recomputing it', () => {
+    const identity = {
+        provider: 'codex',
+        sessionId: 'session-a',
+        workspaceScopeIdentity: WORKSPACE.scopeIdentity,
+        workspaceNavigationIdentity: WORKSPACE.navigationIdentity,
+        workspaceRootHostPaths: ['/work/a', '/work/b'],
+        cwd: '/work/a',
+    };
+    const projection = {
+        revision: 7,
+        activeRuntimes: [{
+            identity,
+            backend: 'vscode', state: 'active', markerPath: '/tmp/a.done',
+            runStartedAtMs: 1, attached: true,
+        }],
+        pendingRuntimes: [],
+        executionSnapshot: {
+            'codex:session-a': { state: 'running', token: 'run', occurredAtMs: 3 },
+        },
+        focusedIdentity: identity,
+        attentionAggregate: null,
+        presentation: {
+            workspaceScopeIdentity: WORKSPACE.scopeIdentity,
+            workspaceNavigationIdentity: WORKSPACE.navigationIdentity,
+            attentionCount: 1,
+            activeAttentionCount: 1,
+            runningSessionCount: 0,
+            focusedTarget: { provider: 'codex', sessionId: 'session-a' },
+            attentionSessions: [{
+                sessionKey: 'codex:session-a', eventIds: ['captured-event'],
+            }],
+            sessions: [{
+                provider: 'codex', sessionId: 'session-a', executionState: 'stopped',
+                focused: true, needsAttention: true, conflict: false,
+                eventIds: ['captured-event'],
+            }],
+        },
+    };
+    const controller = new WorkspaceSessionHydrationController({
+        providers: [{ id: 'codex', label: 'Codex', terminalCwdFields: ['cwd'] }],
+        readCoordinator: {
+            getResults: () => ({
+                codex: {
+                    available: true, scannedFiles: 1, parsedFiles: 1,
+                    sessions: [{ id: 'session-a', name: 'Session A', cwd: '/work/a' }],
+                },
+            }),
+        },
+        incrementalScanMaxFiles: 10,
+        getRefreshReason: () => 'transaction-test',
+        getSessionComparableCwd: (_provider, session) => session.cwd,
+        getPinnedSessions: () => new Set(),
+        getAliases: () => ({}),
+        getProviderSelection: () => undefined,
+        getExpanded: () => true,
+        getProjectionSnapshot: () => projection,
+    });
+
+    const hydrated = controller.hydrate(WORKSPACE, projection);
+    assert.equal(hydrated.attentionCount, 1);
+    assert.deepEqual(hydrated.activeSessions.map(session => ({
+        executionState: session.executionState,
+        focused: session.focused,
+        needsAttention: session.needsAttention,
+        attentionEventId: session.attentionEventId,
+    })), [{
+        executionState: 'stopped',
+        focused: true,
+        needsAttention: true,
+        attentionEventId: 'captured-event',
+    }]);
+});

--- a/tests/contract/openProjects/dashboardConnectingStatus.test.js
+++ b/tests/contract/openProjects/dashboardConnectingStatus.test.js
@@ -20,6 +20,7 @@ function createController(overrides = {}) {
         isWorkspaceSavedAsProject: () => true,
         getWorkspaceProjectColor: () => '',
         getCurrentWorkspaceAiSessions: () => null,
+        beginAiSessionProjection: () => ({ revision: 1 }),
         getGroups: () => [],
         getTodoSearchItems: () => [],
         getCollapsed: () => false,

--- a/tests/contract/openProjects/dashboardController.test.js
+++ b/tests/contract/openProjects/dashboardController.test.js
@@ -22,6 +22,7 @@ const {
 
 function createOptions(overrides = {}) {
     const currentWorkspace = makeRecord({ name: 'Current', uri: '/work/current' });
+    let projectionRevision = 0;
     return {
         getCurrentWorkspace: () => ({
             ...currentWorkspace,
@@ -30,6 +31,7 @@ function createOptions(overrides = {}) {
         isWorkspaceSavedAsProject: () => true,
         getWorkspaceProjectColor: () => '',
         getCurrentWorkspaceAiSessions: () => null,
+        beginAiSessionProjection: () => ({ revision: ++projectionRevision }),
         getGroups: () => [],
         getTodoSearchItems: () => [{
             key: 'todo:open-workspaces',
@@ -104,6 +106,29 @@ test('OPEN-OPEN-PROJECT-DASHBOARD-CONTROLLER-001 posts each semantic revision on
     await flushAsync();
     assert.equal(posted.length, 2);
     assert.notEqual(posted[0].semanticRevision, posted[1].semanticRevision);
+});
+
+test('ACTIVE-SESSION-PRESENTATION-TRANSACTION-001 OPEN updates hydrate and publish one projection transaction', async () => {
+    const transaction = { revision: 41, marker: 'open-workspaces-transaction' };
+    const posted = [];
+    let hydrationProjection = null;
+    const controller = new OpenWorkspaceDashboardController(createOptions({
+        beginAiSessionProjection: () => transaction,
+        getCurrentWorkspaceAiSessions: (_workspace, projection) => {
+            hydrationProjection = projection;
+            return null;
+        },
+        postMessage: message => { posted.push(message); return Promise.resolve(true); },
+    }));
+    controller.setAggregate(makeAggregate([
+        makeRegistration(SELF, 4000, '/work/current'),
+    ], { semanticRevision: 'transaction-revision' }));
+
+    await controller.postUpdated();
+
+    assert.equal(hydrationProjection, transaction);
+    assert.equal(posted.length, 1);
+    assert.equal(posted[0].projectionRevision, transaction.revision);
 });
 
 test('WEBVIEW-SIDEBAR-VISIBILITY-RETENTION-001 coalesces rapid OPEN revisions behind one delivery', async () => {

--- a/tests/integration/dashboard/helpers/terminalCloseHarness.js
+++ b/tests/integration/dashboard/helpers/terminalCloseHarness.js
@@ -147,10 +147,9 @@ const mutations = {
         scenario: 'attention-state-order',
         transform: source => replaceOnce(
             source,
-            'currentAiSessionRefreshReason = reason;\n'
-                + '                        postAiSessionAttentionState();',
-            'currentAiSessionRefreshReason = reason;',
-            'attention state publication',
+            'postAiSessionPresentationState(false, transaction);',
+            '',
+            'presentation transaction publication',
         ),
     },
     'aggregate-auto-acknowledge': {

--- a/tests/integration/dashboard/sessionRuntimeFlow.test.js
+++ b/tests/integration/dashboard/sessionRuntimeFlow.test.js
@@ -369,11 +369,13 @@ test('WEBVIEW-AI-SESSION-DASHBOARD-WATCHER-COALESCING-001 coalesces watcher refr
         getGroups: () => [], getTodoSearchItems: () => [], getCards: () => [],
         getRunningCardAnimation: () => undefined,
         getRunningIconAnimation: () => undefined,
-        nextSequence: () => messages.length + 1,
+        beginProjection: reason => {
+            reasons.push(reason);
+            return { revision: messages.length + 1 };
+        },
         postMessage: message => { messages.push(message); return Promise.resolve(true); },
         refresh: () => undefined,
         logError: (_message, error) => { throw error; },
-        beforeRefresh: reason => reasons.push(reason),
         afterRefresh: () => undefined,
         nowMs: () => clock.nowMs,
         debounceMs: 100,
@@ -403,6 +405,42 @@ test('WEBVIEW-AI-SESSION-DASHBOARD-WATCHER-COALESCING-001 coalesces watcher refr
     assert.deepEqual(reasons, ['watcher', 'watcher', 'attention']);
 });
 
+test('ACTIVE-SESSION-PRESENTATION-TRANSACTION-001 builds cards and HTML with one projection revision', () => {
+    const { AiSessionDashboardController } = loadFreshWithFakeVscode(
+        '../../../out/aiSessions/dashboardController', {}, __dirname
+    );
+    const projection = { revision: 17, marker: 'same-transaction' };
+    let cardsProjection = null;
+    let completed = 0;
+    const controller = new AiSessionDashboardController({
+        providerIds: ['codex'],
+        isVisible: () => true,
+        invalidateCache: () => undefined,
+        watchSessionChanges: () => ({ dispose() {} }),
+        getGroups: () => [], getTodoSearchItems: () => [],
+        getCards: value => { cardsProjection = value; return []; },
+        getRunningCardAnimation: () => undefined,
+        getRunningIconAnimation: () => undefined,
+        beginProjection: reason => {
+            assert.equal(reason, 'transaction-test');
+            return projection;
+        },
+        postMessage: () => Promise.resolve(true),
+        refresh: () => undefined,
+        logError: (_message, error) => { throw error; },
+        afterRefresh: () => { completed += 1; },
+        debounceMs: 1,
+        newSessionRefreshDelaysMs: [],
+        setTimeout: () => ({}),
+        clearTimeout: () => undefined,
+    });
+
+    const message = controller.getUpdatedMessage('transaction-test');
+    assert.equal(cardsProjection, projection);
+    assert.equal(message.sequence, projection.revision);
+    assert.equal(completed, 1);
+});
+
 test('WEBVIEW-SIDEBAR-VISIBILITY-RETENTION-001 reuses provider watchers across rapid sidebar visibility changes', () => {
     const clock = createFakeClock(1000);
     let visible = true;
@@ -422,7 +460,7 @@ test('WEBVIEW-SIDEBAR-VISIBILITY-RETENTION-001 reuses provider watchers across r
         getGroups: () => [], getTodoSearchItems: () => [], getCards: () => [],
         getRunningCardAnimation: () => undefined,
         getRunningIconAnimation: () => undefined,
-        nextSequence: () => 1,
+        beginProjection: () => ({ revision: 1 }),
         postMessage: () => Promise.resolve(true),
         refresh: () => undefined,
         logError: (_message, error) => { throw error; },
@@ -471,11 +509,13 @@ test('WEBVIEW-AI-SESSION-DASHBOARD-WATCHER-COALESCING-001 never postpones a pend
         getCards: () => { cardRevision += 1; return []; },
         getRunningCardAnimation: () => `revision-${cardRevision}`,
         getRunningIconAnimation: () => undefined,
-        nextSequence: () => reasons.length + 1,
+        beginProjection: reason => {
+            reasons.push({ reason, atMs: clock.nowMs });
+            return { revision: reasons.length + 1 };
+        },
         postMessage: () => Promise.resolve(true),
         refresh: () => undefined,
         logError: (_message, error) => { throw error; },
-        beforeRefresh: reason => reasons.push({ reason, atMs: clock.nowMs }),
         afterRefresh: () => undefined,
         nowMs: () => clock.nowMs,
         debounceMs: 100,
@@ -533,11 +573,13 @@ test('WEBVIEW-AI-SESSION-DASHBOARD-CONTROLLER-001 invalidates and refreshes for 
         getTodoSearchItems: () => [{ todoId: 'fixture-todo' }], getCards: () => [],
         getRunningCardAnimation: () => undefined,
         getRunningIconAnimation: () => undefined,
-        nextSequence: () => messages.length + 1,
+        beginProjection: reason => {
+            reasons.push(reason);
+            return { revision: messages.length + 1 };
+        },
         postMessage: message => { messages.push(message); return Promise.resolve(true); },
         refresh: () => undefined,
         logError: (_message, error) => { throw error; },
-        beforeRefresh: reason => reasons.push(reason),
         debounceMs: 1,
         newSessionRefreshDelaysMs: [1, 2],
         setTimeout: callback => { callback(); return {}; },
@@ -568,7 +610,7 @@ test('WEBVIEW-AI-SESSION-DASHBOARD-UNCHANGED-MESSAGE-SKIP-001 retries an unchang
         getTodoSearchItems: () => [], getCards: () => [],
         getRunningCardAnimation: () => undefined,
         getRunningIconAnimation: () => undefined,
-        nextSequence: () => deliveries.length + 1,
+        beginProjection: () => ({ revision: deliveries.length + 1 }),
         postMessage: message => { deliveries.push(message); return Promise.resolve(delivered); },
         refresh: () => undefined,
         logError: (_message, error) => { throw error; },
@@ -608,7 +650,7 @@ test('WEBVIEW-NONBLOCKING-FIRST-PAINT-001 keeps dashboard-visible delivery failu
         },
         getRunningCardAnimation: () => undefined,
         getRunningIconAnimation: () => undefined,
-        nextSequence: () => 1,
+        beginProjection: () => ({ revision: 1 }),
         postMessage: () => failureMode === 'rejected'
             ? Promise.reject(new Error('delivery failed'))
             : Promise.resolve(false),

--- a/tests/integration/dashboard/webviewState.test.js
+++ b/tests/integration/dashboard/webviewState.test.js
@@ -488,7 +488,8 @@ test('WEBVIEW-DASHBOARD-UPDATE-MESSAGE-001 preserves TODO catalog entries in inc
     const cards = [makeWorkspaceCard()];
     const openMessage = webviewModules.updateMessages.buildOpenWorkspacesUpdatedMessage({
         groups: [], cards: [], collapsed: false,
-        semanticRevision: 'revision', otherWindowsStatus: 'ready', todoSearchItems,
+        semanticRevision: 'revision', projectionRevision: 1,
+        otherWindowsStatus: 'ready', todoSearchItems,
     });
     const sessionsMessage = webviewModules.updateMessages.buildAiSessionsUpdatedMessage({
         groups: [], cards: [], sequence: 7, generatedAt: NOW,

--- a/tests/unit/tooling/architectureGuards.test.js
+++ b/tests/unit/tooling/architectureGuards.test.js
@@ -44,6 +44,7 @@ function copyGuardFixture(t, mutationPath, mutate = source => source) {
         'src/aiSessions/lifecycle.ts',
         'src/aiSessions/runtimeTypes.ts',
         'src/dashboard/sessionQuickSwitch.ts',
+        'src/dashboard/webviewUpdateMessages.ts',
         'src/constants.ts',
         'src/models.ts',
         'src/todos/types.ts',
@@ -729,6 +730,16 @@ for (const mutation of [
             source,
             'revision <= latestAiSessionDirectPresentationRevision',
             'revision < latestAiSessionDirectPresentationRevision'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/openWorkspaces/dashboardController.ts',
+        expectedDetail: 'OPEN HTML must capture, hydrate, and publish the same Presentation transaction',
+        mutate: source => replaceFixtureSource(
+            source,
+            'cards: this.getCards(projection)',
+            'cards: this.getCards()'
         ),
     },
     {

--- a/tests/unit/tooling/architectureGuards.test.js
+++ b/tests/unit/tooling/architectureGuards.test.js
@@ -26,6 +26,7 @@ function copyGuardFixture(t, mutationPath, mutate = source => source) {
         'src/workspaces/currentWorkspaceSessionAuthority.ts',
         'src/openWorkspaces/dashboardController.ts',
         'src/workspaces/sessionHydrationController.ts',
+        'src/workspaces/sessionHydration.ts',
         'src/aiSessions/dashboardController.ts',
         'src/aiSessions/providers.ts',
         'src/aiSessions/conversation/types.ts',
@@ -709,6 +710,26 @@ for (const mutation of [
         mutate: source => replaceFixtureSource(source,
             "this.scheduleRefresh('watcher')", "this.options.refresh('watcher')",
             "\n// this.scheduleRefresh('watcher')\n"),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/aiSessions/dashboardController.ts',
+        expectedDetail: 'cards and HTML must consume the transaction and publish its revision',
+        mutate: source => replaceFixtureSource(
+            source,
+            'sequence: projection.revision',
+            'sequence: projection.revision + 1'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectAiUpdateScripts.js',
+        expectedDetail: 'Webview must accept one same-revision direct Presentation after HTML',
+        mutate: source => replaceFixtureSource(
+            source,
+            'revision <= latestAiSessionDirectPresentationRevision',
+            'revision < latestAiSessionDirectPresentationRevision'
+        ),
     },
     {
         id: 'ARCH-AI-SESSION-FALLBACK-REASON-001',


### PR DESCRIPTION
## Summary

- capture one versioned AI session presentation transaction per incremental refresh
- reuse that transaction across direct presentation, current-card hydration, AI session HTML, and Open Windows HTML
- accept one same-revision direct presentation after HTML so the complete attention-owner event set is preserved
- enforce the transaction boundary with `ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001`

## Why

Direct presentation and authoritative HTML previously sampled state and advanced revisions independently. If HTML arrived first, the later direct presentation could be discarded, leaving incomplete attention-owner events in the DOM and allowing acknowledged attention to reappear.

## Testing

- `npm run test-compile`
- focused AI session and Open Windows Host contract/integration tests
- `node scripts/run-ai-session-safety-checks.js`
- `node scripts/run-open-project-safety-checks.js`
- `node scripts/run-workspace-parity-checks.js`
- `node scripts/run-dashboard-webview-checks.js`
- `node scripts/run-architecture-guards.js`
- `node --test tests/browser/activeSessionCardInteraction.test.js`
- `node --test tests/integration/dashboard/terminalCloseWiring.test.js`
- `npm run test:behavior-contracts`
- `npm run test:ci:linux`
- `npm run lint`
- `git diff --check`

## Skill harvest

No skill update was justified. Existing regression and review skills already require the branch-level CI equivalent and controlled-mutation sensitivity; the stale mutation needle was a compliance gap, and the corrected full Linux gate now passes.
