### PR TITLE
Refactor full dashboard session presentation transaction

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -4090,6 +4090,23 @@
     ]
   },
   {
+    "id": "ACTIVE-SESSION-FULL-RENDER-TRANSACTION-001",
+    "domain": "webview",
+    "title": "A full Dashboard document preserves its presentation revision and complete attention ownership",
+    "priority": "P0",
+    "status": "automated",
+    "owners": [
+      "tests/browser/activeSessionCardInteraction.test.js",
+      "tests/integration/dashboard/webviewState.test.js"
+    ],
+    "evidence": [
+      "src/dashboard.ts",
+      "src/webview/webviewContent.ts",
+      "src/webview/webviewProjectAiUpdateScripts.js",
+      "src/webview/webviewProjectScripts.js"
+    ]
+  },
+  {
     "id": "ACTIVE-SESSION-FOCUS-REVEAL-001",
     "domain": "webview",
     "title": "Sidebar reveals and marks the focused Active Session card after terminal focus settles, including Next Attention Session jumps",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "21a524b74b4eabde5a125bbe62469b89fa2d5fea",
+        "head": "1c7cc4b8df13cc66d60b1e2352f3b2d7ca20f5c3",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -263,7 +263,8 @@
             "b8351a89e297c70998cad5c4aa2ec375b1885288",
             "d1c0e2a4a5fe4846847ff21b604a7a26684a955d",
             "1138487a7f97024092f1f362e8990b2b63883282",
-            "00eb53cec68ca367088a5cce19bc2f2944d300e2"
+            "00eb53cec68ca367088a5cce19bc2f2944d300e2",
+            "41fa71745aaa981a03af4bbb7d0b8f2f6ba92e4b"
         ]
     },
     "capabilities": [
@@ -911,7 +912,8 @@
                 "869d520b640f56e8db2b1f1e3b71b081625c7874",
                 "7a89af3d4230e843f4d33aa37e5583d57361cbd0",
                 "bc6b1625e112e39d6aae8534e718bee9628ecae0",
-                "21a524b74b4eabde5a125bbe62469b89fa2d5fea"
+                "21a524b74b4eabde5a125bbe62469b89fa2d5fea",
+                "1c7cc4b8df13cc66d60b1e2352f3b2d7ca20f5c3"
             ],
             "behaviors": [
                 "ATTENTION-ACTIVE-UNREGISTER-ON-DEACTIVATE-001",
@@ -926,7 +928,8 @@
                 "SESSION-CLAUDE-SESSION-SERVICE-001",
                 "SESSION-CODEX-SESSION-SERVICE-001",
                 "SESSION-FINGERPRINT-HASH-001",
-                "PERSIST-LIFECYCLE-PARSER-001"
+                "PERSIST-LIFECYCLE-PARSER-001",
+                "ACTIVE-SESSION-FULL-RENDER-TRANSACTION-001"
             ],
             "prGates": [
                 "test:deterministic:run",

--- a/media/webviewDashboardBundle.js
+++ b/media/webviewDashboardBundle.js
@@ -1734,6 +1734,20 @@ function initProjectAiSessionsUpdate(options) {
         return true;
     }
 
+    function acceptInitialPresentationProjectionRevision(revision) {
+        if (!Number.isSafeInteger(revision)
+            || revision <= 0
+            || latestAiSessionProjectionRevision !== 0
+            || latestAiSessionPresentationProjectionRevision !== 0
+            || latestAiSessionDirectPresentationRevision !== 0) {
+            return false;
+        }
+        latestAiSessionProjectionRevision = revision;
+        latestAiSessionPresentationProjectionRevision = revision;
+        latestAiSessionDirectPresentationRevision = revision;
+        return true;
+    }
+
     function applyAiSessionsUpdate(message) {
         if (message.version !== 2
             || typeof message.sequence !== 'number'
@@ -1894,6 +1908,7 @@ function initProjectAiSessionsUpdate(options) {
 
     return {
         applyAiSessionsUpdate: applyAiSessionsUpdate,
+        acceptInitialPresentationProjectionRevision: acceptInitialPresentationProjectionRevision,
         acceptPresentationProjectionRevision: acceptPresentationProjectionRevision,
         canApplyPresentationProjectionRevision: canApplyPresentationProjectionRevision,
         canApplyProjectionRevision: canApplyProjectionRevision,
@@ -3192,6 +3207,80 @@ function initProjects() {
         updateStickyGroupHeaderOffset: updateStickyGroupHeaderOffset,
     });
 
+    function isValidAiSessionPresentationState(message) {
+        return message && message.type === 'ai-session-presentation-state'
+            && message.version === 1
+            && Number.isSafeInteger(message.projectionRevision)
+            && message.projectionRevision > 0
+            && (typeof message.workspaceScopeIdentity === 'string'
+                || message.workspaceScopeIdentity === null)
+            && (typeof message.workspaceNavigationIdentity === 'string'
+                || message.workspaceNavigationIdentity === null)
+            && Number.isSafeInteger(message.attentionCount) && message.attentionCount >= 0
+            && Number.isSafeInteger(message.activeAttentionCount)
+            && message.activeAttentionCount >= 0
+            && Number.isSafeInteger(message.runningSessionCount)
+            && message.runningSessionCount >= 0
+            && ['current', 'sweep', 'orbit', 'halo', 'ripple', 'breath', 'custom', 'none']
+                .includes(message.runningCardAnimation)
+            && ['current', 'halo', 'custom', 'none'].includes(message.runningIconAnimation)
+            && typeof message.revealFocused === 'boolean'
+            && Array.isArray(message.sessions) && message.sessions.length <= 1000
+            && message.sessions.every(session => session
+                && aiSessionControls.isAiSessionProvider(session.provider)
+                && typeof session.sessionId === 'string' && !!session.sessionId
+                && (session.executionState === 'running'
+                    || session.executionState === 'stopped')
+                && typeof session.focused === 'boolean'
+                && typeof session.needsAttention === 'boolean'
+                && typeof session.conflict === 'boolean'
+                && Array.isArray(session.eventIds)
+                && session.eventIds.length <= 1000
+                && session.eventIds.every(eventId => typeof eventId === 'string' && !!eventId))
+            && Array.isArray(message.attentionSessions)
+            && message.attentionSessions.length <= 1000
+            && message.attentionSessions.every(session => session
+                && typeof session.sessionKey === 'string' && !!session.sessionKey
+                && Array.isArray(session.eventIds)
+                && session.eventIds.length <= 1000
+                && session.eventIds.every(eventId => typeof eventId === 'string' && !!eventId));
+    }
+
+    function applyAiSessionPresentationState(message, initialDocument) {
+        if (!isValidAiSessionPresentationState(message)) {
+            aiSessionsUpdate.requestFullRefresh(initialDocument
+                ? 'invalid-initial-ai-session-presentation-state'
+                : 'invalid-ai-session-presentation-state');
+            return false;
+        }
+        var accepted = initialDocument
+            ? aiSessionsUpdate.acceptInitialPresentationProjectionRevision(
+                message.projectionRevision
+            )
+            : aiSessionsUpdate.acceptPresentationProjectionRevision(
+                message.projectionRevision
+            );
+        if (!accepted) return false;
+        window.__agentPivotAiSessionPresentationState = message;
+        applyAiSessionPresentationDom(message);
+        return true;
+    }
+
+    function readInitialAiSessionPresentationState() {
+        var element = document.getElementById('dashboard-ai-session-presentation');
+        if (!element) return null;
+        try {
+            return JSON.parse(element.textContent || '');
+        } catch (_error) {
+            return {};
+        }
+    }
+
+    var initialAiSessionPresentationState = readInitialAiSessionPresentationState();
+    if (initialAiSessionPresentationState) {
+        applyAiSessionPresentationState(initialAiSessionPresentationState, true);
+    }
+
     function onMouseEvent(e) {
         if (!e.target || e.target.closest(".disabled"))
             return;
@@ -3414,50 +3503,7 @@ function initProjects() {
         }
 
         if (message && message.type === 'ai-session-presentation-state') {
-            var validPresentation = message.version === 1
-                && Number.isSafeInteger(message.projectionRevision)
-                && message.projectionRevision > 0
-                && (typeof message.workspaceScopeIdentity === 'string'
-                    || message.workspaceScopeIdentity === null)
-                && (typeof message.workspaceNavigationIdentity === 'string'
-                    || message.workspaceNavigationIdentity === null)
-                && Number.isSafeInteger(message.attentionCount) && message.attentionCount >= 0
-                && Number.isSafeInteger(message.activeAttentionCount)
-                && message.activeAttentionCount >= 0
-                && Number.isSafeInteger(message.runningSessionCount)
-                && message.runningSessionCount >= 0
-                && ['current', 'sweep', 'orbit', 'halo', 'ripple', 'breath', 'custom', 'none']
-                    .includes(message.runningCardAnimation)
-                && ['current', 'halo', 'custom', 'none'].includes(message.runningIconAnimation)
-                && typeof message.revealFocused === 'boolean'
-                && Array.isArray(message.sessions) && message.sessions.length <= 1000
-                && message.sessions.every(session => session
-                    && aiSessionControls.isAiSessionProvider(session.provider)
-                    && typeof session.sessionId === 'string' && !!session.sessionId
-                    && (session.executionState === 'running'
-                        || session.executionState === 'stopped')
-                    && typeof session.focused === 'boolean'
-                    && typeof session.needsAttention === 'boolean'
-                    && typeof session.conflict === 'boolean'
-                    && Array.isArray(session.eventIds)
-                    && session.eventIds.length <= 1000
-                    && session.eventIds.every(eventId => typeof eventId === 'string' && !!eventId))
-                && Array.isArray(message.attentionSessions)
-                && message.attentionSessions.length <= 1000
-                && message.attentionSessions.every(session => session
-                    && typeof session.sessionKey === 'string' && !!session.sessionKey
-                    && Array.isArray(session.eventIds)
-                    && session.eventIds.length <= 1000
-                    && session.eventIds.every(eventId => typeof eventId === 'string' && !!eventId));
-            if (!validPresentation) {
-                aiSessionsUpdate.requestFullRefresh('invalid-ai-session-presentation-state');
-                return;
-            }
-            if (!aiSessionsUpdate.acceptPresentationProjectionRevision(
-                message.projectionRevision
-            )) return;
-            window.__agentPivotAiSessionPresentationState = message;
-            applyAiSessionPresentationDom(message);
+            applyAiSessionPresentationState(message, false);
             return;
         }
 

--- a/media/webviewProjectAiUpdateScripts.js
+++ b/media/webviewProjectAiUpdateScripts.js
@@ -66,6 +66,20 @@ function initProjectAiSessionsUpdate(options) {
         return true;
     }
 
+    function acceptInitialPresentationProjectionRevision(revision) {
+        if (!Number.isSafeInteger(revision)
+            || revision <= 0
+            || latestAiSessionProjectionRevision !== 0
+            || latestAiSessionPresentationProjectionRevision !== 0
+            || latestAiSessionDirectPresentationRevision !== 0) {
+            return false;
+        }
+        latestAiSessionProjectionRevision = revision;
+        latestAiSessionPresentationProjectionRevision = revision;
+        latestAiSessionDirectPresentationRevision = revision;
+        return true;
+    }
+
     function applyAiSessionsUpdate(message) {
         if (message.version !== 2
             || typeof message.sequence !== 'number'
@@ -226,6 +240,7 @@ function initProjectAiSessionsUpdate(options) {
 
     return {
         applyAiSessionsUpdate: applyAiSessionsUpdate,
+        acceptInitialPresentationProjectionRevision: acceptInitialPresentationProjectionRevision,
         acceptPresentationProjectionRevision: acceptPresentationProjectionRevision,
         canApplyPresentationProjectionRevision: canApplyPresentationProjectionRevision,
         canApplyProjectionRevision: canApplyProjectionRevision,

--- a/media/webviewProjectScripts.js
+++ b/media/webviewProjectScripts.js
@@ -576,6 +576,80 @@ function initProjects() {
         updateStickyGroupHeaderOffset: updateStickyGroupHeaderOffset,
     });
 
+    function isValidAiSessionPresentationState(message) {
+        return message && message.type === 'ai-session-presentation-state'
+            && message.version === 1
+            && Number.isSafeInteger(message.projectionRevision)
+            && message.projectionRevision > 0
+            && (typeof message.workspaceScopeIdentity === 'string'
+                || message.workspaceScopeIdentity === null)
+            && (typeof message.workspaceNavigationIdentity === 'string'
+                || message.workspaceNavigationIdentity === null)
+            && Number.isSafeInteger(message.attentionCount) && message.attentionCount >= 0
+            && Number.isSafeInteger(message.activeAttentionCount)
+            && message.activeAttentionCount >= 0
+            && Number.isSafeInteger(message.runningSessionCount)
+            && message.runningSessionCount >= 0
+            && ['current', 'sweep', 'orbit', 'halo', 'ripple', 'breath', 'custom', 'none']
+                .includes(message.runningCardAnimation)
+            && ['current', 'halo', 'custom', 'none'].includes(message.runningIconAnimation)
+            && typeof message.revealFocused === 'boolean'
+            && Array.isArray(message.sessions) && message.sessions.length <= 1000
+            && message.sessions.every(session => session
+                && aiSessionControls.isAiSessionProvider(session.provider)
+                && typeof session.sessionId === 'string' && !!session.sessionId
+                && (session.executionState === 'running'
+                    || session.executionState === 'stopped')
+                && typeof session.focused === 'boolean'
+                && typeof session.needsAttention === 'boolean'
+                && typeof session.conflict === 'boolean'
+                && Array.isArray(session.eventIds)
+                && session.eventIds.length <= 1000
+                && session.eventIds.every(eventId => typeof eventId === 'string' && !!eventId))
+            && Array.isArray(message.attentionSessions)
+            && message.attentionSessions.length <= 1000
+            && message.attentionSessions.every(session => session
+                && typeof session.sessionKey === 'string' && !!session.sessionKey
+                && Array.isArray(session.eventIds)
+                && session.eventIds.length <= 1000
+                && session.eventIds.every(eventId => typeof eventId === 'string' && !!eventId));
+    }
+
+    function applyAiSessionPresentationState(message, initialDocument) {
+        if (!isValidAiSessionPresentationState(message)) {
+            aiSessionsUpdate.requestFullRefresh(initialDocument
+                ? 'invalid-initial-ai-session-presentation-state'
+                : 'invalid-ai-session-presentation-state');
+            return false;
+        }
+        var accepted = initialDocument
+            ? aiSessionsUpdate.acceptInitialPresentationProjectionRevision(
+                message.projectionRevision
+            )
+            : aiSessionsUpdate.acceptPresentationProjectionRevision(
+                message.projectionRevision
+            );
+        if (!accepted) return false;
+        window.__agentPivotAiSessionPresentationState = message;
+        applyAiSessionPresentationDom(message);
+        return true;
+    }
+
+    function readInitialAiSessionPresentationState() {
+        var element = document.getElementById('dashboard-ai-session-presentation');
+        if (!element) return null;
+        try {
+            return JSON.parse(element.textContent || '');
+        } catch (_error) {
+            return {};
+        }
+    }
+
+    var initialAiSessionPresentationState = readInitialAiSessionPresentationState();
+    if (initialAiSessionPresentationState) {
+        applyAiSessionPresentationState(initialAiSessionPresentationState, true);
+    }
+
     function onMouseEvent(e) {
         if (!e.target || e.target.closest(".disabled"))
             return;
@@ -798,50 +872,7 @@ function initProjects() {
         }
 
         if (message && message.type === 'ai-session-presentation-state') {
-            var validPresentation = message.version === 1
-                && Number.isSafeInteger(message.projectionRevision)
-                && message.projectionRevision > 0
-                && (typeof message.workspaceScopeIdentity === 'string'
-                    || message.workspaceScopeIdentity === null)
-                && (typeof message.workspaceNavigationIdentity === 'string'
-                    || message.workspaceNavigationIdentity === null)
-                && Number.isSafeInteger(message.attentionCount) && message.attentionCount >= 0
-                && Number.isSafeInteger(message.activeAttentionCount)
-                && message.activeAttentionCount >= 0
-                && Number.isSafeInteger(message.runningSessionCount)
-                && message.runningSessionCount >= 0
-                && ['current', 'sweep', 'orbit', 'halo', 'ripple', 'breath', 'custom', 'none']
-                    .includes(message.runningCardAnimation)
-                && ['current', 'halo', 'custom', 'none'].includes(message.runningIconAnimation)
-                && typeof message.revealFocused === 'boolean'
-                && Array.isArray(message.sessions) && message.sessions.length <= 1000
-                && message.sessions.every(session => session
-                    && aiSessionControls.isAiSessionProvider(session.provider)
-                    && typeof session.sessionId === 'string' && !!session.sessionId
-                    && (session.executionState === 'running'
-                        || session.executionState === 'stopped')
-                    && typeof session.focused === 'boolean'
-                    && typeof session.needsAttention === 'boolean'
-                    && typeof session.conflict === 'boolean'
-                    && Array.isArray(session.eventIds)
-                    && session.eventIds.length <= 1000
-                    && session.eventIds.every(eventId => typeof eventId === 'string' && !!eventId))
-                && Array.isArray(message.attentionSessions)
-                && message.attentionSessions.length <= 1000
-                && message.attentionSessions.every(session => session
-                    && typeof session.sessionKey === 'string' && !!session.sessionKey
-                    && Array.isArray(session.eventIds)
-                    && session.eventIds.length <= 1000
-                    && session.eventIds.every(eventId => typeof eventId === 'string' && !!eventId));
-            if (!validPresentation) {
-                aiSessionsUpdate.requestFullRefresh('invalid-ai-session-presentation-state');
-                return;
-            }
-            if (!aiSessionsUpdate.acceptPresentationProjectionRevision(
-                message.projectionRevision
-            )) return;
-            window.__agentPivotAiSessionPresentationState = message;
-            applyAiSessionPresentationDom(message);
+            applyAiSessionPresentationState(message, false);
             return;
         }
 

--- a/scripts/run-architecture-guards.js
+++ b/scripts/run-architecture-guards.js
@@ -682,6 +682,18 @@ const guards = {
             this.id,
             risk
         );
+        const fullDocument = parseTypescript(
+            root,
+            'src/webview/webviewContent.ts',
+            this.id,
+            risk
+        );
+        const projectWebview = parseJavascript(
+            root,
+            'src/webview/webviewProjectScripts.js',
+            this.id,
+            risk
+        );
         const controllerSource = controller.getFullText();
         if (controllerSource.includes('nextSequence')
             || controllerSource.includes('beforeRefresh')) {
@@ -728,6 +740,26 @@ const guards = {
             || !webviewSource.includes('revision <= latestAiSessionDirectPresentationRevision')) {
             fail(this.id, risk,
                 'the Webview must accept one same-revision direct Presentation after HTML');
+        }
+        if (!/renderContent:\s*\(webview,\s*documentGeneration\)\s*=>\s*\{[\s\S]*?const transaction = aiSessionProjectionCoordinator\.captureNext\([\s\S]*?getOpenWorkspaceCards\(transaction\)[\s\S]*?buildAiSessionPresentationState\(false,\s*transaction\)/
+            .test(dashboardSource)
+            || !fullDocument.getFullText().includes(
+                'id="dashboard-ai-session-presentation"'
+            )) {
+            fail(this.id, risk,
+                'the full Dashboard document must capture and embed one Presentation transaction');
+        }
+        const projectWebviewSource = projectWebview.getFullText();
+        if (!webviewSource.includes('acceptInitialPresentationProjectionRevision')
+            || !webviewSource.includes('latestAiSessionProjectionRevision = revision;')
+            || !projectWebviewSource.includes(
+                "getElementById('dashboard-ai-session-presentation')"
+            )
+            || !projectWebviewSource.includes(
+                'applyAiSessionPresentationState(initialAiSessionPresentationState, true)'
+            )) {
+            fail(this.id, risk,
+                'the Webview must seed revision and complete owners from the full document');
         }
         const openWorkspaceSource = openWorkspaceController.getFullText();
         const updateMessageSource = updateMessages.getFullText();

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1685,16 +1685,22 @@ async function initializeDashboard(
     });
     const providerOptions: AgentPivotViewProviderOptions = {
         getWebviewOptions: () => getDashboardWebviewOptions(context.extensionPath, vscode.Uri.file),
-        renderContent: (webview, documentGeneration) => getStewardContent(
-            context,
-            webview,
-            projectService.getGroups(),
-            stewardInfos,
-            true,
-            getOpenWorkspaceCards(),
-            openWorkspaceDashboardController.getState().otherWindows.status,
-            documentGeneration,
-        ),
+        renderContent: (webview, documentGeneration) => {
+            const transaction = aiSessionProjectionCoordinator.captureNext(
+                getCurrentOpenWorkspace()
+            );
+            return getStewardContent(
+                context,
+                webview,
+                projectService.getGroups(),
+                stewardInfos,
+                true,
+                getOpenWorkspaceCards(transaction),
+                openWorkspaceDashboardController.getState().otherWindows.status,
+                documentGeneration,
+                buildAiSessionPresentationState(false, transaction),
+            );
+        },
         renderError: getErrorContent,
         onMessage: message => messageRequiresStorageMigration(message)
             ? runAfterStorageMigration(() => dashboardMessageRouter(message))
@@ -2618,8 +2624,22 @@ async function initializeDashboard(
         transaction: AiSessionPresentationTransaction<vscode.Terminal>
             = aiSessionProjectionCoordinator.captureNext(getCurrentOpenWorkspace())
     ): void {
+        const message = buildAiSessionPresentationState(revealFocused, transaction);
+        try {
+            void provider.postMessage(message).then(undefined, error => {
+                logError('Failed to post the Active Session presentation.', error);
+            });
+        } catch (error) {
+            logError('Failed to post the Active Session presentation.', error);
+        }
+    }
+
+    function buildAiSessionPresentationState(
+        revealFocused: boolean,
+        transaction: AiSessionPresentationTransaction<vscode.Terminal>
+    ): AiSessionPresentationStateMessage {
         const configuration = getAgentPivotConfiguration();
-        const message: AiSessionPresentationStateMessage = {
+        return {
             type: 'ai-session-presentation-state',
             version: 1,
             projectionRevision: transaction.revision,
@@ -2628,13 +2648,6 @@ async function initializeDashboard(
             runningIconAnimation: getEffectiveRunningIconAnimation(configuration),
             revealFocused,
         };
-        try {
-            void provider.postMessage(message).then(undefined, error => {
-                logError('Failed to post the Active Session presentation.', error);
-            });
-        } catch (error) {
-            logError('Failed to post the Active Session presentation.', error);
-        }
     }
 
     function invalidateAiSessionCache(providerId: AiSessionProviderId) {

--- a/src/webview/webviewContent.ts
+++ b/src/webview/webviewContent.ts
@@ -38,6 +38,7 @@ import {
 } from './runningAnimationImages';
 import * as Icons from './webviewIcons';
 import type { OpenWorkspaceBridgeStatus } from '../openWorkspaces/bridgeClient';
+import type { AiSessionPresentationStateMessage } from '../aiSessions/types';
 import { removeWorkspaceWindowDecorations } from '../workspaces/contextResolver';
 
 const FAVORITES_GROUP_NAME = 'FAVORITES';
@@ -69,6 +70,7 @@ export function getStewardContent(
     workspaceCards: WorkspaceCardViewModel[] = [],
     otherWindowsStatus: OpenWorkspaceBridgeStatus = 'ready',
     readyDocumentGeneration: number = 1,
+    initialAiSessionPresentation?: AiSessionPresentationStateMessage,
 ): string {
     var safeReadyDocumentGeneration = Number.isSafeInteger(readyDocumentGeneration)
         && readyDocumentGeneration > 0
@@ -89,6 +91,12 @@ export function getStewardContent(
     var searchCatalog = serializeDashboardSearchCatalog(
         buildWorkspaceDashboardSearchCatalog(groups, workspaceCards, infos.todoSearchItems || [], infos.skills || [])
     );
+    var serializedAiSessionPresentation = initialAiSessionPresentation
+        ? JSON.stringify(initialAiSessionPresentation)
+            .replace(/</g, '\\u003c')
+            .replace(/>/g, '\\u003e')
+            .replace(/&/g, '\\u0026')
+        : '';
     var runningAnimationImages = readRunningAnimationImages(infos.config);
     var openWorkspacesContent = getOpenWorkspacesGroupContent(
         workspaceCards,
@@ -189,6 +197,9 @@ export function getStewardContent(
             <section id="dashboard-search-results" class="dashboard-search-results" aria-label="Search results" hidden></section>
         </main>
         <script id="dashboard-search-catalog" type="application/json">${searchCatalog}</script>
+        ${serializedAiSessionPresentation
+            ? `<script id="dashboard-ai-session-presentation" type="application/json">${serializedAiSessionPresentation}</script>`
+            : ''}
 
         ${getProjectContextMenu()}
         ${getGroupContextMenu()}

--- a/src/webview/webviewProjectAiUpdateScripts.js
+++ b/src/webview/webviewProjectAiUpdateScripts.js
@@ -66,6 +66,20 @@ function initProjectAiSessionsUpdate(options) {
         return true;
     }
 
+    function acceptInitialPresentationProjectionRevision(revision) {
+        if (!Number.isSafeInteger(revision)
+            || revision <= 0
+            || latestAiSessionProjectionRevision !== 0
+            || latestAiSessionPresentationProjectionRevision !== 0
+            || latestAiSessionDirectPresentationRevision !== 0) {
+            return false;
+        }
+        latestAiSessionProjectionRevision = revision;
+        latestAiSessionPresentationProjectionRevision = revision;
+        latestAiSessionDirectPresentationRevision = revision;
+        return true;
+    }
+
     function applyAiSessionsUpdate(message) {
         if (message.version !== 2
             || typeof message.sequence !== 'number'
@@ -226,6 +240,7 @@ function initProjectAiSessionsUpdate(options) {
 
     return {
         applyAiSessionsUpdate: applyAiSessionsUpdate,
+        acceptInitialPresentationProjectionRevision: acceptInitialPresentationProjectionRevision,
         acceptPresentationProjectionRevision: acceptPresentationProjectionRevision,
         canApplyPresentationProjectionRevision: canApplyPresentationProjectionRevision,
         canApplyProjectionRevision: canApplyProjectionRevision,

--- a/src/webview/webviewProjectScripts.js
+++ b/src/webview/webviewProjectScripts.js
@@ -576,6 +576,80 @@ function initProjects() {
         updateStickyGroupHeaderOffset: updateStickyGroupHeaderOffset,
     });
 
+    function isValidAiSessionPresentationState(message) {
+        return message && message.type === 'ai-session-presentation-state'
+            && message.version === 1
+            && Number.isSafeInteger(message.projectionRevision)
+            && message.projectionRevision > 0
+            && (typeof message.workspaceScopeIdentity === 'string'
+                || message.workspaceScopeIdentity === null)
+            && (typeof message.workspaceNavigationIdentity === 'string'
+                || message.workspaceNavigationIdentity === null)
+            && Number.isSafeInteger(message.attentionCount) && message.attentionCount >= 0
+            && Number.isSafeInteger(message.activeAttentionCount)
+            && message.activeAttentionCount >= 0
+            && Number.isSafeInteger(message.runningSessionCount)
+            && message.runningSessionCount >= 0
+            && ['current', 'sweep', 'orbit', 'halo', 'ripple', 'breath', 'custom', 'none']
+                .includes(message.runningCardAnimation)
+            && ['current', 'halo', 'custom', 'none'].includes(message.runningIconAnimation)
+            && typeof message.revealFocused === 'boolean'
+            && Array.isArray(message.sessions) && message.sessions.length <= 1000
+            && message.sessions.every(session => session
+                && aiSessionControls.isAiSessionProvider(session.provider)
+                && typeof session.sessionId === 'string' && !!session.sessionId
+                && (session.executionState === 'running'
+                    || session.executionState === 'stopped')
+                && typeof session.focused === 'boolean'
+                && typeof session.needsAttention === 'boolean'
+                && typeof session.conflict === 'boolean'
+                && Array.isArray(session.eventIds)
+                && session.eventIds.length <= 1000
+                && session.eventIds.every(eventId => typeof eventId === 'string' && !!eventId))
+            && Array.isArray(message.attentionSessions)
+            && message.attentionSessions.length <= 1000
+            && message.attentionSessions.every(session => session
+                && typeof session.sessionKey === 'string' && !!session.sessionKey
+                && Array.isArray(session.eventIds)
+                && session.eventIds.length <= 1000
+                && session.eventIds.every(eventId => typeof eventId === 'string' && !!eventId));
+    }
+
+    function applyAiSessionPresentationState(message, initialDocument) {
+        if (!isValidAiSessionPresentationState(message)) {
+            aiSessionsUpdate.requestFullRefresh(initialDocument
+                ? 'invalid-initial-ai-session-presentation-state'
+                : 'invalid-ai-session-presentation-state');
+            return false;
+        }
+        var accepted = initialDocument
+            ? aiSessionsUpdate.acceptInitialPresentationProjectionRevision(
+                message.projectionRevision
+            )
+            : aiSessionsUpdate.acceptPresentationProjectionRevision(
+                message.projectionRevision
+            );
+        if (!accepted) return false;
+        window.__agentPivotAiSessionPresentationState = message;
+        applyAiSessionPresentationDom(message);
+        return true;
+    }
+
+    function readInitialAiSessionPresentationState() {
+        var element = document.getElementById('dashboard-ai-session-presentation');
+        if (!element) return null;
+        try {
+            return JSON.parse(element.textContent || '');
+        } catch (_error) {
+            return {};
+        }
+    }
+
+    var initialAiSessionPresentationState = readInitialAiSessionPresentationState();
+    if (initialAiSessionPresentationState) {
+        applyAiSessionPresentationState(initialAiSessionPresentationState, true);
+    }
+
     function onMouseEvent(e) {
         if (!e.target || e.target.closest(".disabled"))
             return;
@@ -798,50 +872,7 @@ function initProjects() {
         }
 
         if (message && message.type === 'ai-session-presentation-state') {
-            var validPresentation = message.version === 1
-                && Number.isSafeInteger(message.projectionRevision)
-                && message.projectionRevision > 0
-                && (typeof message.workspaceScopeIdentity === 'string'
-                    || message.workspaceScopeIdentity === null)
-                && (typeof message.workspaceNavigationIdentity === 'string'
-                    || message.workspaceNavigationIdentity === null)
-                && Number.isSafeInteger(message.attentionCount) && message.attentionCount >= 0
-                && Number.isSafeInteger(message.activeAttentionCount)
-                && message.activeAttentionCount >= 0
-                && Number.isSafeInteger(message.runningSessionCount)
-                && message.runningSessionCount >= 0
-                && ['current', 'sweep', 'orbit', 'halo', 'ripple', 'breath', 'custom', 'none']
-                    .includes(message.runningCardAnimation)
-                && ['current', 'halo', 'custom', 'none'].includes(message.runningIconAnimation)
-                && typeof message.revealFocused === 'boolean'
-                && Array.isArray(message.sessions) && message.sessions.length <= 1000
-                && message.sessions.every(session => session
-                    && aiSessionControls.isAiSessionProvider(session.provider)
-                    && typeof session.sessionId === 'string' && !!session.sessionId
-                    && (session.executionState === 'running'
-                        || session.executionState === 'stopped')
-                    && typeof session.focused === 'boolean'
-                    && typeof session.needsAttention === 'boolean'
-                    && typeof session.conflict === 'boolean'
-                    && Array.isArray(session.eventIds)
-                    && session.eventIds.length <= 1000
-                    && session.eventIds.every(eventId => typeof eventId === 'string' && !!eventId))
-                && Array.isArray(message.attentionSessions)
-                && message.attentionSessions.length <= 1000
-                && message.attentionSessions.every(session => session
-                    && typeof session.sessionKey === 'string' && !!session.sessionKey
-                    && Array.isArray(session.eventIds)
-                    && session.eventIds.length <= 1000
-                    && session.eventIds.every(eventId => typeof eventId === 'string' && !!eventId));
-            if (!validPresentation) {
-                aiSessionsUpdate.requestFullRefresh('invalid-ai-session-presentation-state');
-                return;
-            }
-            if (!aiSessionsUpdate.acceptPresentationProjectionRevision(
-                message.projectionRevision
-            )) return;
-            window.__agentPivotAiSessionPresentationState = message;
-            applyAiSessionPresentationDom(message);
+            applyAiSessionPresentationState(message, false);
             return;
         }
 

--- a/tests/browser/activeSessionCardInteraction.test.js
+++ b/tests/browser/activeSessionCardInteraction.test.js
@@ -263,11 +263,17 @@ async function isRowFullyVisibleInList(rowLocator) {
     });
 }
 
-function documentMarkup(activeAiSessions, currentWorkspaceMarkup) {
+function documentMarkup(activeAiSessions, currentWorkspaceMarkup, initialPresentation) {
+    const initialPresentationMarkup = initialPresentation
+        ? `<script id="dashboard-ai-session-presentation" type="application/json">${JSON.stringify(
+            initialPresentation
+        ).replace(/</g, '\\u003c')}</script>`
+        : '';
     return `<!doctype html>
         <html>
             <head><style>${styles}</style></head>
             <body class="steward-sidebar">
+                ${initialPresentationMarkup}
                 <div class="steward-sticky-header"></div>
                 <div class="sticky-groups-wrapper">
                     ${currentWorkspaceMarkup || `<div class="open-current-workspace-group">
@@ -282,12 +288,17 @@ async function openCardPage(
     t,
     activeAiSessions,
     viewport = { width: 360, height: 900 },
-    currentWorkspaceMarkup
+    currentWorkspaceMarkup,
+    initialPresentation
 ) {
     const page = await browser.newPage({ viewport });
     t.after(() => page.close());
     page.setDefaultTimeout(BROWSER_CONDITION_TIMEOUT_MS);
-    await page.setContent(documentMarkup(activeAiSessions, currentWorkspaceMarkup));
+    await page.setContent(documentMarkup(
+        activeAiSessions,
+        currentWorkspaceMarkup,
+        initialPresentation
+    ));
     await page.evaluate(() => {
         window.__postedMessages = [];
         window.normalizeDashboardSearchCatalog = catalog => catalog;
@@ -697,6 +708,58 @@ test('ACTIVE-SESSION-PRESENTATION-TRANSACTION-001 keeps OPEN HTML and owner even
     assert.deepEqual(acknowledgements, [{
         type: 'acknowledge-ai-session-attention',
         eventIds: ['open-event-a', 'open-event-b'],
+    }]);
+});
+
+test('ACTIVE-SESSION-FULL-RENDER-TRANSACTION-001 seeds the full document revision and complete attention owners', async t => {
+    const attentionSession = {
+        ...session('codex', 'session-a', true),
+        executionState: 'stopped',
+        status: 'stopped',
+        needsAttention: true,
+        attentionEventId: 'event-a',
+    };
+    const initialPresentation = presentationMessage([attentionSession], 5, {
+        attention: { 'codex:session-a': ['event-a', 'event-b'] },
+    });
+    const page = await openCardPage(
+        t,
+        [attentionSession],
+        { width: 360, height: 900 },
+        undefined,
+        initialPresentation
+    );
+
+    await postHostMessage(page, {
+        type: 'ai-sessions-updated',
+        version: 2,
+        sequence: 4,
+        projectionRevision: 4,
+        currentWorkspaceCount: 1,
+        html: `<div class="open-current-workspace-group">${projectMarkup([{
+            ...attentionSession,
+            attentionEventId: 'stale-event',
+        }])}</div>`,
+        searchCatalog: {
+            version: 2,
+            sessions: [],
+            openWorkspaces: [],
+            savedProjects: [],
+            todos: [],
+        },
+    });
+
+    assert.equal(
+        await row(page, 'codex', 'session-a').getAttribute('data-session-event-id'),
+        'event-a'
+    );
+    await row(page, 'codex', 'session-a').locator('.ai-session-primary-action').click();
+    const acknowledgements = (await postedMessages(page)).filter(message =>
+        message.type === 'acknowledge-ai-session-attention'
+    );
+    assert.deepEqual(acknowledgements, [{
+        type: 'acknowledge-ai-session-attention',
+        eventIds: ['event-a', 'event-b'],
     }]);
 });
 

--- a/tests/integration/dashboard/webviewState.test.js
+++ b/tests/integration/dashboard/webviewState.test.js
@@ -860,6 +860,60 @@ test('CUSTOM-RUNNING-IMAGE-001 full render injects user artwork as CSS variables
         'custom without a readable icon image must fall back to the current animation');
 });
 
+test('ACTIVE-SESSION-FULL-RENDER-TRANSACTION-001 embeds a safe complete presentation in the full document', () => {
+    const presentation = {
+        type: 'ai-session-presentation-state',
+        version: 1,
+        projectionRevision: 9,
+        workspaceScopeIdentity: 'scope:full-render',
+        workspaceNavigationIdentity: 'navigation:full-render',
+        attentionCount: 1,
+        activeAttentionCount: 1,
+        runningSessionCount: 0,
+        runningCardAnimation: 'current',
+        runningIconAnimation: 'current',
+        revealFocused: false,
+        focusedTarget: { provider: 'codex', sessionId: 'full-render' },
+        attentionSessions: [{
+            sessionKey: 'codex:full-render',
+            eventIds: ['event-a', 'event</script><script>hostile'],
+        }],
+        sessions: [{
+            provider: 'codex',
+            sessionId: 'full-render',
+            executionState: 'stopped',
+            focused: true,
+            needsAttention: true,
+            conflict: false,
+            eventIds: ['event-a', 'event</script><script>hostile'],
+        }],
+    };
+    const html = webviewModules.content.getStewardContent(
+        { extensionPath: '/extension' },
+        { cspSource: 'test', asWebviewUri: uri => uri.toString() },
+        [],
+        {
+            config: { get: (_key, fallback) => fallback },
+            relevantExtensionsInstalls: { remoteSSH: false, remoteContainers: false },
+            otherStorageHasData: false,
+            todoSearchItems: [],
+        },
+        true,
+        [],
+        'ready',
+        3,
+        presentation,
+    );
+
+    assert.match(
+        html,
+        /<script id="dashboard-ai-session-presentation" type="application\/json">/
+    );
+    assert.match(html, /"projectionRevision":9/);
+    assert.match(html, /event\\u003c\/script\\u003e\\u003cscript\\u003ehostile/);
+    assert.doesNotMatch(html, /event<\/script><script>hostile/);
+});
+
 test('RUNTIME-TMUX-WEBVIEW-EXPERIENCE-001 renders semantic tmux, direct, stale, attached, and conflict controls', () => {
     const base = {
         id: 'p', name: 'App', path: '/work/app', activeAiSessionTab: 'active',

--- a/tests/unit/tooling/architectureGuards.test.js
+++ b/tests/unit/tooling/architectureGuards.test.js
@@ -64,6 +64,7 @@ function copyGuardFixture(t, mutationPath, mutate = source => source) {
         'src/webview/webviewProjectCollapseScripts.js',
         'src/webview/webviewTodoControlScripts.js',
         'src/webview/webviewProjectContextMenuScripts.js',
+        'src/webview/webviewContent.ts',
         'src/webview/webviewProjectAiUpdateScripts.js',
         'src/webview/webviewProjectAiSessionControlsScripts.js',
         'src/webview/webviewProjectScripts.js',
@@ -740,6 +741,26 @@ for (const mutation of [
             source,
             'cards: this.getCards(projection)',
             'cards: this.getCards()'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/dashboard.ts',
+        expectedDetail: 'full Dashboard document must capture and embed one Presentation transaction',
+        mutate: source => replaceFixtureSource(
+            source,
+            'buildAiSessionPresentationState(false, transaction),',
+            'undefined,'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectScripts.js',
+        expectedDetail: 'Webview must seed revision and complete owners from the full document',
+        mutate: source => replaceFixtureSource(
+            source,
+            "getElementById('dashboard-ai-session-presentation')",
+            "getElementById('missing-ai-session-presentation')"
         ),
     },
     {


### PR DESCRIPTION
## Summary

- capture one AI session presentation transaction for the full Dashboard document
- embed the complete presentation snapshot and seed Webview revision watermarks before incremental updates
- preserve every attention owner across a full render and reject stale queued updates
- add a P0 behavior contract, rendered-browser regression coverage, and mutation-sensitive architecture guards

## Skill harvest

no skill change — the only workflow retry was a build-producer/consumer ordering mistake already covered explicitly by review-fix-commit-loop

## Verification

- npm run test:ci:linux
- npm run test:behavior-contracts
- node --test tests/unit/tooling/architectureGuards.test.js
- node --test tests/integration/dashboard/webviewState.test.js
- node --test tests/browser/activeSessionCardInteraction.test.js
- git diff --check
- local VSIX installation with matching hashes for the changed Webview bundle and scripts