### PR TITLE
Refactor incremental session presentation updates

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -4107,6 +4107,27 @@
     ]
   },
   {
+    "id": "ACTIVE-SESSION-INCREMENTAL-PRESENTATION-ENVELOPE-001",
+    "domain": "webview",
+    "title": "Incremental workspace HTML and complete AI Session presentation arrive and apply atomically",
+    "priority": "P0",
+    "status": "automated",
+    "owners": [
+      "tests/browser/activeSessionCardInteraction.test.js",
+      "tests/integration/dashboard/sessionRuntimeFlow.test.js"
+    ],
+    "evidence": [
+      "src/dashboard.ts",
+      "src/aiSessions/dashboardController.ts",
+      "src/aiSessions/presentationMessage.ts",
+      "src/dashboard/webviewUpdateMessages.ts",
+      "src/openWorkspaces/dashboardController.ts",
+      "src/webview/webviewProjectAiUpdateScripts.js",
+      "src/webview/webviewProjectScripts.js",
+      "src/webview/webviewWorkspaceUpdateScripts.js"
+    ]
+  },
+  {
     "id": "ACTIVE-SESSION-FOCUS-REVEAL-001",
     "domain": "webview",
     "title": "Sidebar reveals and marks the focused Active Session card after terminal focus settles, including Next Attention Session jumps",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "40ed025328778dd8d6dc30d8983cec0e714b2abf",
+        "head": "fe852b6268c76ca437c49b628189ae1439bce0f3",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -265,7 +265,8 @@
             "1138487a7f97024092f1f362e8990b2b63883282",
             "00eb53cec68ca367088a5cce19bc2f2944d300e2",
             "41fa71745aaa981a03af4bbb7d0b8f2f6ba92e4b",
-            "23b03b8d4e540b534452dfa03ebc5608a667a260"
+            "23b03b8d4e540b534452dfa03ebc5608a667a260",
+            "a514850f0b36137007a6e25aca0e093114aaa5cd"
         ]
     },
     "capabilities": [
@@ -914,7 +915,10 @@
                 "7a89af3d4230e843f4d33aa37e5583d57361cbd0",
                 "bc6b1625e112e39d6aae8534e718bee9628ecae0",
                 "21a524b74b4eabde5a125bbe62469b89fa2d5fea",
-                "1c7cc4b8df13cc66d60b1e2352f3b2d7ca20f5c3"
+                "1c7cc4b8df13cc66d60b1e2352f3b2d7ca20f5c3",
+                "9387594a7a8a9310621f5da0fa675e0fe90564fa",
+                "c39b9f1d5a38563194b6d4423e91f89c4897212d",
+                "fe852b6268c76ca437c49b628189ae1439bce0f3"
             ],
             "behaviors": [
                 "ATTENTION-ACTIVE-UNREGISTER-ON-DEACTIVATE-001",
@@ -930,7 +934,8 @@
                 "SESSION-CODEX-SESSION-SERVICE-001",
                 "SESSION-FINGERPRINT-HASH-001",
                 "PERSIST-LIFECYCLE-PARSER-001",
-                "ACTIVE-SESSION-FULL-RENDER-TRANSACTION-001"
+                "ACTIVE-SESSION-FULL-RENDER-TRANSACTION-001",
+                "ACTIVE-SESSION-INCREMENTAL-PRESENTATION-ENVELOPE-001"
             ],
             "prGates": [
                 "test:deterministic:run",

--- a/media/webviewDashboardBundle.js
+++ b/media/webviewDashboardBundle.js
@@ -644,7 +644,7 @@ function completeOpenWorkspacePin(message) {
 function applyOpenWorkspacesUpdate(message) {
     if (!message
         || message.type !== 'open-workspaces-updated'
-        || message.version !== 2
+        || (message.version !== 2 && message.version !== 3)
         || typeof message.semanticRevision !== 'string'
         || !message.semanticRevision
         || (message.currentWorkspaceCount !== 0 && message.currentWorkspaceCount !== 1)
@@ -1682,6 +1682,8 @@ function initProjectAiSessionsUpdate(options) {
     var exitAiSessionBatchManagement = options.exitAiSessionBatchManagement;
     var isAiSessionProvider = options.isAiSessionProvider;
     var updateStickyGroupHeaderOffset = options.updateStickyGroupHeaderOffset;
+    var isValidAiSessionPresentationState = options.isValidAiSessionPresentationState;
+    var applyValidatedAiSessionPresentationState = options.applyValidatedAiSessionPresentationState;
 
     var pendingWorkspaceSessionReveal = null;
     var latestAiSessionUpdateSequence = 0;
@@ -1749,7 +1751,8 @@ function initProjectAiSessionsUpdate(options) {
     }
 
     function applyAiSessionsUpdate(message) {
-        if (message.version !== 2
+        var isAtomicEnvelope = message.version === 3;
+        if ((message.version !== 2 && !isAtomicEnvelope)
             || typeof message.sequence !== 'number'
             || (message.currentWorkspaceCount !== 0 && message.currentWorkspaceCount !== 1)
             || typeof message.html !== 'string'
@@ -1760,10 +1763,28 @@ function initProjectAiSessionsUpdate(options) {
             return;
         }
 
+        if (isAtomicEnvelope
+            && (!Number.isSafeInteger(message.projectionRevision)
+                || message.projectionRevision <= 0
+                || message.sequence !== message.projectionRevision
+                || typeof message.generatedAt !== 'string'
+                || !message.generatedAt
+                || typeof isValidAiSessionPresentationState !== 'function'
+                || !isValidAiSessionPresentationState(message.presentation)
+                || message.presentation.projectionRevision !== message.projectionRevision
+                || typeof applyValidatedAiSessionPresentationState !== 'function')) {
+            requestFullRefresh('invalid-ai-session-presentation-envelope');
+            return;
+        }
+
         if (message.sequence <= latestAiSessionUpdateSequence) {
             return;
         }
         if (!canApplyProjectionRevision(message.projectionRevision)) {
+            return;
+        }
+        if (isAtomicEnvelope
+            && !canApplyPresentationProjectionRevision(message.projectionRevision)) {
             return;
         }
         var adoptRenderedPresentation = canApplyPresentationProjectionRevision(
@@ -1799,7 +1820,11 @@ function initProjectAiSessionsUpdate(options) {
             }
         }
         reconcilePendingAiSessionProviderSelectionDom();
-        syncAiSessionProjectionDom(adoptRenderedPresentation);
+        if (isAtomicEnvelope) {
+            applyValidatedAiSessionPresentationState(message.presentation);
+        } else {
+            syncAiSessionProjectionDom(adoptRenderedPresentation);
+        }
         updateStickyGroupHeaderOffset();
         if (window.__agentPivotDashboard) {
             window.__agentPivotDashboard.replaceSearchCatalog(message.searchCatalog);
@@ -3205,6 +3230,8 @@ function initProjects() {
         exitAiSessionBatchManagement: aiSessionControls.exitAiSessionBatchManagement,
         isAiSessionProvider: aiSessionControls.isAiSessionProvider,
         updateStickyGroupHeaderOffset: updateStickyGroupHeaderOffset,
+        isValidAiSessionPresentationState: isValidAiSessionPresentationState,
+        applyValidatedAiSessionPresentationState: applyValidatedAiSessionPresentationState,
     });
 
     function isValidAiSessionPresentationState(message) {
@@ -3225,6 +3252,17 @@ function initProjects() {
                 .includes(message.runningCardAnimation)
             && ['current', 'halo', 'custom', 'none'].includes(message.runningIconAnimation)
             && typeof message.revealFocused === 'boolean'
+            && (message.focusedTarget === null
+                || (message.focusedTarget
+                    && aiSessionControls.isAiSessionProvider(
+                        message.focusedTarget.provider
+                    )
+                    && ((typeof message.focusedTarget.sessionId === 'string'
+                        && !!message.focusedTarget.sessionId
+                        && typeof message.focusedTarget.pendingId === 'undefined')
+                        || (typeof message.focusedTarget.pendingId === 'string'
+                            && !!message.focusedTarget.pendingId
+                            && typeof message.focusedTarget.sessionId === 'undefined'))))
             && Array.isArray(message.sessions) && message.sessions.length <= 1000
             && message.sessions.every(session => session
                 && aiSessionControls.isAiSessionProvider(session.provider)
@@ -3261,9 +3299,13 @@ function initProjects() {
                 message.projectionRevision
             );
         if (!accepted) return false;
+        applyValidatedAiSessionPresentationState(message);
+        return true;
+    }
+
+    function applyValidatedAiSessionPresentationState(message) {
         window.__agentPivotAiSessionPresentationState = message;
         applyAiSessionPresentationDom(message);
-        return true;
     }
 
     function readInitialAiSessionPresentationState() {
@@ -3455,7 +3497,21 @@ function initProjects() {
             return;
         }
         if (message && message.type === 'open-workspaces-updated') {
+            var isAtomicOpenWorkspacesEnvelope = message.version === 3;
+            if (isAtomicOpenWorkspacesEnvelope
+                && (!isValidAiSessionPresentationState(message.presentation)
+                    || message.presentation.projectionRevision
+                        !== message.projectionRevision)) {
+                aiSessionsUpdate.requestFullRefresh(
+                    'invalid-open-workspaces-presentation-envelope'
+                );
+                return;
+            }
             if (!aiSessionsUpdate.canApplyProjectionRevision(message.projectionRevision)) return;
+            if (isAtomicOpenWorkspacesEnvelope
+                && !aiSessionsUpdate.canApplyPresentationProjectionRevision(
+                    message.projectionRevision
+                )) return;
             var adoptOpenWorkspacePresentation = aiSessionsUpdate.canApplyPresentationProjectionRevision(
                 message.projectionRevision
             );
@@ -3467,7 +3523,11 @@ function initProjects() {
                 message.projectionRevision,
                 adoptOpenWorkspacePresentation
             );
-            syncAiSessionProjectionDom(adoptOpenWorkspacePresentation);
+            if (isAtomicOpenWorkspacesEnvelope) {
+                applyValidatedAiSessionPresentationState(message.presentation);
+            } else {
+                syncAiSessionProjectionDom(adoptOpenWorkspacePresentation);
+            }
             updateStickyGroupHeaderOffset();
             var renderedOpenWorkspaceState = getOpenWorkspacesUpdateDomState();
             window.vscode.postMessage({

--- a/media/webviewDashboardBundle.js
+++ b/media/webviewDashboardBundle.js
@@ -1709,6 +1709,13 @@ function initProjectAiSessionsUpdate(options) {
         return canApplyRevision(revision, latestAiSessionPresentationProjectionRevision);
     }
 
+    function canApplyAtomicPresentationProjectionRevision(revision) {
+        return Number.isSafeInteger(revision)
+            && revision > 0
+            && revision >= latestAiSessionPresentationProjectionRevision
+            && revision > latestAiSessionClosedPresentationRevision;
+    }
+
     function commitProjectionRevision(revision, adoptedPresentation, closePresentation) {
         if (Number.isSafeInteger(revision) && revision > 0) {
             latestAiSessionProjectionRevision = revision;
@@ -1791,13 +1798,13 @@ function initProjectAiSessionsUpdate(options) {
         if (!canApplyProjectionRevision(message.projectionRevision)) {
             return;
         }
-        if (isAtomicEnvelope
-            && !canApplyPresentationProjectionRevision(message.projectionRevision)) {
+        var canApplyMessagePresentation = isAtomicEnvelope
+            ? canApplyAtomicPresentationProjectionRevision(message.projectionRevision)
+            : canApplyPresentationProjectionRevision(message.projectionRevision);
+        if (isAtomicEnvelope && !canApplyMessagePresentation) {
             return;
         }
-        var adoptRenderedPresentation = canApplyPresentationProjectionRevision(
-            message.projectionRevision
-        );
+        var adoptRenderedPresentation = canApplyMessagePresentation;
 
         if (!applyWorkspaceUpdate({
             type: 'workspace-updated',
@@ -1944,6 +1951,7 @@ function initProjectAiSessionsUpdate(options) {
         applyAiSessionsUpdate: applyAiSessionsUpdate,
         acceptInitialPresentationProjectionRevision: acceptInitialPresentationProjectionRevision,
         acceptPresentationProjectionRevision: acceptPresentationProjectionRevision,
+        canApplyAtomicPresentationProjectionRevision: canApplyAtomicPresentationProjectionRevision,
         canApplyPresentationProjectionRevision: canApplyPresentationProjectionRevision,
         canApplyProjectionRevision: canApplyProjectionRevision,
         commitProjectionRevision: commitProjectionRevision,
@@ -3517,13 +3525,16 @@ function initProjects() {
                 return;
             }
             if (!aiSessionsUpdate.canApplyProjectionRevision(message.projectionRevision)) return;
-            if (isAtomicOpenWorkspacesEnvelope
-                && !aiSessionsUpdate.canApplyPresentationProjectionRevision(
+            var canApplyOpenWorkspacePresentation = isAtomicOpenWorkspacesEnvelope
+                ? aiSessionsUpdate.canApplyAtomicPresentationProjectionRevision(
                     message.projectionRevision
-                )) return;
-            var adoptOpenWorkspacePresentation = aiSessionsUpdate.canApplyPresentationProjectionRevision(
-                message.projectionRevision
-            );
+                )
+                : aiSessionsUpdate.canApplyPresentationProjectionRevision(
+                    message.projectionRevision
+                );
+            if (isAtomicOpenWorkspacesEnvelope
+                && !canApplyOpenWorkspacePresentation) return;
+            var adoptOpenWorkspacePresentation = canApplyOpenWorkspacePresentation;
             if (!applyOpenWorkspacesUpdate(message)) {
                 aiSessionsUpdate.requestFullRefresh('invalid-open-workspaces-update');
                 return;

--- a/media/webviewDashboardBundle.js
+++ b/media/webviewDashboardBundle.js
@@ -1690,6 +1690,7 @@ function initProjectAiSessionsUpdate(options) {
     var latestAiSessionProjectionRevision = 0;
     var latestAiSessionPresentationProjectionRevision = 0;
     var latestAiSessionDirectPresentationRevision = 0;
+    var latestAiSessionClosedPresentationRevision = 0;
 
     function canApplyRevision(revision, latestRevision) {
         if (typeof revision === 'undefined') {
@@ -1708,12 +1709,18 @@ function initProjectAiSessionsUpdate(options) {
         return canApplyRevision(revision, latestAiSessionPresentationProjectionRevision);
     }
 
-    function commitProjectionRevision(revision, adoptedPresentation) {
+    function commitProjectionRevision(revision, adoptedPresentation, closePresentation) {
         if (Number.isSafeInteger(revision) && revision > 0) {
             latestAiSessionProjectionRevision = revision;
             if (adoptedPresentation) {
                 latestAiSessionPresentationProjectionRevision = Math.max(
                     latestAiSessionPresentationProjectionRevision,
+                    revision
+                );
+            }
+            if (closePresentation) {
+                latestAiSessionClosedPresentationRevision = Math.max(
+                    latestAiSessionClosedPresentationRevision,
                     revision
                 );
             }
@@ -1725,6 +1732,7 @@ function initProjectAiSessionsUpdate(options) {
             || revision <= 0
             || revision < latestAiSessionProjectionRevision
             || revision < latestAiSessionPresentationProjectionRevision
+            || revision <= latestAiSessionClosedPresentationRevision
             || revision <= latestAiSessionDirectPresentationRevision) {
             return false;
         }
@@ -1808,7 +1816,8 @@ function initProjectAiSessionsUpdate(options) {
         latestAiSessionUpdateSequence = message.sequence;
         commitProjectionRevision(
             message.projectionRevision,
-            adoptRenderedPresentation
+            adoptRenderedPresentation,
+            isAtomicEnvelope
         );
         if (batchAiSessionState.projectId) {
             var projectDiv = findCurrentWorkspaceDiv(batchAiSessionState.projectId);
@@ -3521,7 +3530,8 @@ function initProjects() {
             }
             aiSessionsUpdate.commitProjectionRevision(
                 message.projectionRevision,
-                adoptOpenWorkspacePresentation
+                adoptOpenWorkspacePresentation,
+                isAtomicOpenWorkspacesEnvelope
             );
             if (isAtomicOpenWorkspacesEnvelope) {
                 applyValidatedAiSessionPresentationState(message.presentation);

--- a/media/webviewProjectAiUpdateScripts.js
+++ b/media/webviewProjectAiUpdateScripts.js
@@ -41,6 +41,13 @@ function initProjectAiSessionsUpdate(options) {
         return canApplyRevision(revision, latestAiSessionPresentationProjectionRevision);
     }
 
+    function canApplyAtomicPresentationProjectionRevision(revision) {
+        return Number.isSafeInteger(revision)
+            && revision > 0
+            && revision >= latestAiSessionPresentationProjectionRevision
+            && revision > latestAiSessionClosedPresentationRevision;
+    }
+
     function commitProjectionRevision(revision, adoptedPresentation, closePresentation) {
         if (Number.isSafeInteger(revision) && revision > 0) {
             latestAiSessionProjectionRevision = revision;
@@ -123,13 +130,13 @@ function initProjectAiSessionsUpdate(options) {
         if (!canApplyProjectionRevision(message.projectionRevision)) {
             return;
         }
-        if (isAtomicEnvelope
-            && !canApplyPresentationProjectionRevision(message.projectionRevision)) {
+        var canApplyMessagePresentation = isAtomicEnvelope
+            ? canApplyAtomicPresentationProjectionRevision(message.projectionRevision)
+            : canApplyPresentationProjectionRevision(message.projectionRevision);
+        if (isAtomicEnvelope && !canApplyMessagePresentation) {
             return;
         }
-        var adoptRenderedPresentation = canApplyPresentationProjectionRevision(
-            message.projectionRevision
-        );
+        var adoptRenderedPresentation = canApplyMessagePresentation;
 
         if (!applyWorkspaceUpdate({
             type: 'workspace-updated',
@@ -276,6 +283,7 @@ function initProjectAiSessionsUpdate(options) {
         applyAiSessionsUpdate: applyAiSessionsUpdate,
         acceptInitialPresentationProjectionRevision: acceptInitialPresentationProjectionRevision,
         acceptPresentationProjectionRevision: acceptPresentationProjectionRevision,
+        canApplyAtomicPresentationProjectionRevision: canApplyAtomicPresentationProjectionRevision,
         canApplyPresentationProjectionRevision: canApplyPresentationProjectionRevision,
         canApplyProjectionRevision: canApplyProjectionRevision,
         commitProjectionRevision: commitProjectionRevision,

--- a/media/webviewProjectAiUpdateScripts.js
+++ b/media/webviewProjectAiUpdateScripts.js
@@ -22,6 +22,7 @@ function initProjectAiSessionsUpdate(options) {
     var latestAiSessionProjectionRevision = 0;
     var latestAiSessionPresentationProjectionRevision = 0;
     var latestAiSessionDirectPresentationRevision = 0;
+    var latestAiSessionClosedPresentationRevision = 0;
 
     function canApplyRevision(revision, latestRevision) {
         if (typeof revision === 'undefined') {
@@ -40,12 +41,18 @@ function initProjectAiSessionsUpdate(options) {
         return canApplyRevision(revision, latestAiSessionPresentationProjectionRevision);
     }
 
-    function commitProjectionRevision(revision, adoptedPresentation) {
+    function commitProjectionRevision(revision, adoptedPresentation, closePresentation) {
         if (Number.isSafeInteger(revision) && revision > 0) {
             latestAiSessionProjectionRevision = revision;
             if (adoptedPresentation) {
                 latestAiSessionPresentationProjectionRevision = Math.max(
                     latestAiSessionPresentationProjectionRevision,
+                    revision
+                );
+            }
+            if (closePresentation) {
+                latestAiSessionClosedPresentationRevision = Math.max(
+                    latestAiSessionClosedPresentationRevision,
                     revision
                 );
             }
@@ -57,6 +64,7 @@ function initProjectAiSessionsUpdate(options) {
             || revision <= 0
             || revision < latestAiSessionProjectionRevision
             || revision < latestAiSessionPresentationProjectionRevision
+            || revision <= latestAiSessionClosedPresentationRevision
             || revision <= latestAiSessionDirectPresentationRevision) {
             return false;
         }
@@ -140,7 +148,8 @@ function initProjectAiSessionsUpdate(options) {
         latestAiSessionUpdateSequence = message.sequence;
         commitProjectionRevision(
             message.projectionRevision,
-            adoptRenderedPresentation
+            adoptRenderedPresentation,
+            isAtomicEnvelope
         );
         if (batchAiSessionState.projectId) {
             var projectDiv = findCurrentWorkspaceDiv(batchAiSessionState.projectId);

--- a/media/webviewProjectAiUpdateScripts.js
+++ b/media/webviewProjectAiUpdateScripts.js
@@ -14,6 +14,8 @@ function initProjectAiSessionsUpdate(options) {
     var exitAiSessionBatchManagement = options.exitAiSessionBatchManagement;
     var isAiSessionProvider = options.isAiSessionProvider;
     var updateStickyGroupHeaderOffset = options.updateStickyGroupHeaderOffset;
+    var isValidAiSessionPresentationState = options.isValidAiSessionPresentationState;
+    var applyValidatedAiSessionPresentationState = options.applyValidatedAiSessionPresentationState;
 
     var pendingWorkspaceSessionReveal = null;
     var latestAiSessionUpdateSequence = 0;
@@ -81,7 +83,8 @@ function initProjectAiSessionsUpdate(options) {
     }
 
     function applyAiSessionsUpdate(message) {
-        if (message.version !== 2
+        var isAtomicEnvelope = message.version === 3;
+        if ((message.version !== 2 && !isAtomicEnvelope)
             || typeof message.sequence !== 'number'
             || (message.currentWorkspaceCount !== 0 && message.currentWorkspaceCount !== 1)
             || typeof message.html !== 'string'
@@ -92,10 +95,28 @@ function initProjectAiSessionsUpdate(options) {
             return;
         }
 
+        if (isAtomicEnvelope
+            && (!Number.isSafeInteger(message.projectionRevision)
+                || message.projectionRevision <= 0
+                || message.sequence !== message.projectionRevision
+                || typeof message.generatedAt !== 'string'
+                || !message.generatedAt
+                || typeof isValidAiSessionPresentationState !== 'function'
+                || !isValidAiSessionPresentationState(message.presentation)
+                || message.presentation.projectionRevision !== message.projectionRevision
+                || typeof applyValidatedAiSessionPresentationState !== 'function')) {
+            requestFullRefresh('invalid-ai-session-presentation-envelope');
+            return;
+        }
+
         if (message.sequence <= latestAiSessionUpdateSequence) {
             return;
         }
         if (!canApplyProjectionRevision(message.projectionRevision)) {
+            return;
+        }
+        if (isAtomicEnvelope
+            && !canApplyPresentationProjectionRevision(message.projectionRevision)) {
             return;
         }
         var adoptRenderedPresentation = canApplyPresentationProjectionRevision(
@@ -131,7 +152,11 @@ function initProjectAiSessionsUpdate(options) {
             }
         }
         reconcilePendingAiSessionProviderSelectionDom();
-        syncAiSessionProjectionDom(adoptRenderedPresentation);
+        if (isAtomicEnvelope) {
+            applyValidatedAiSessionPresentationState(message.presentation);
+        } else {
+            syncAiSessionProjectionDom(adoptRenderedPresentation);
+        }
         updateStickyGroupHeaderOffset();
         if (window.__agentPivotDashboard) {
             window.__agentPivotDashboard.replaceSearchCatalog(message.searchCatalog);

--- a/media/webviewProjectScripts.js
+++ b/media/webviewProjectScripts.js
@@ -852,13 +852,16 @@ function initProjects() {
                 return;
             }
             if (!aiSessionsUpdate.canApplyProjectionRevision(message.projectionRevision)) return;
-            if (isAtomicOpenWorkspacesEnvelope
-                && !aiSessionsUpdate.canApplyPresentationProjectionRevision(
+            var canApplyOpenWorkspacePresentation = isAtomicOpenWorkspacesEnvelope
+                ? aiSessionsUpdate.canApplyAtomicPresentationProjectionRevision(
                     message.projectionRevision
-                )) return;
-            var adoptOpenWorkspacePresentation = aiSessionsUpdate.canApplyPresentationProjectionRevision(
-                message.projectionRevision
-            );
+                )
+                : aiSessionsUpdate.canApplyPresentationProjectionRevision(
+                    message.projectionRevision
+                );
+            if (isAtomicOpenWorkspacesEnvelope
+                && !canApplyOpenWorkspacePresentation) return;
+            var adoptOpenWorkspacePresentation = canApplyOpenWorkspacePresentation;
             if (!applyOpenWorkspacesUpdate(message)) {
                 aiSessionsUpdate.requestFullRefresh('invalid-open-workspaces-update');
                 return;

--- a/media/webviewProjectScripts.js
+++ b/media/webviewProjectScripts.js
@@ -574,6 +574,8 @@ function initProjects() {
         exitAiSessionBatchManagement: aiSessionControls.exitAiSessionBatchManagement,
         isAiSessionProvider: aiSessionControls.isAiSessionProvider,
         updateStickyGroupHeaderOffset: updateStickyGroupHeaderOffset,
+        isValidAiSessionPresentationState: isValidAiSessionPresentationState,
+        applyValidatedAiSessionPresentationState: applyValidatedAiSessionPresentationState,
     });
 
     function isValidAiSessionPresentationState(message) {
@@ -594,6 +596,17 @@ function initProjects() {
                 .includes(message.runningCardAnimation)
             && ['current', 'halo', 'custom', 'none'].includes(message.runningIconAnimation)
             && typeof message.revealFocused === 'boolean'
+            && (message.focusedTarget === null
+                || (message.focusedTarget
+                    && aiSessionControls.isAiSessionProvider(
+                        message.focusedTarget.provider
+                    )
+                    && ((typeof message.focusedTarget.sessionId === 'string'
+                        && !!message.focusedTarget.sessionId
+                        && typeof message.focusedTarget.pendingId === 'undefined')
+                        || (typeof message.focusedTarget.pendingId === 'string'
+                            && !!message.focusedTarget.pendingId
+                            && typeof message.focusedTarget.sessionId === 'undefined'))))
             && Array.isArray(message.sessions) && message.sessions.length <= 1000
             && message.sessions.every(session => session
                 && aiSessionControls.isAiSessionProvider(session.provider)
@@ -630,9 +643,13 @@ function initProjects() {
                 message.projectionRevision
             );
         if (!accepted) return false;
+        applyValidatedAiSessionPresentationState(message);
+        return true;
+    }
+
+    function applyValidatedAiSessionPresentationState(message) {
         window.__agentPivotAiSessionPresentationState = message;
         applyAiSessionPresentationDom(message);
-        return true;
     }
 
     function readInitialAiSessionPresentationState() {
@@ -824,7 +841,21 @@ function initProjects() {
             return;
         }
         if (message && message.type === 'open-workspaces-updated') {
+            var isAtomicOpenWorkspacesEnvelope = message.version === 3;
+            if (isAtomicOpenWorkspacesEnvelope
+                && (!isValidAiSessionPresentationState(message.presentation)
+                    || message.presentation.projectionRevision
+                        !== message.projectionRevision)) {
+                aiSessionsUpdate.requestFullRefresh(
+                    'invalid-open-workspaces-presentation-envelope'
+                );
+                return;
+            }
             if (!aiSessionsUpdate.canApplyProjectionRevision(message.projectionRevision)) return;
+            if (isAtomicOpenWorkspacesEnvelope
+                && !aiSessionsUpdate.canApplyPresentationProjectionRevision(
+                    message.projectionRevision
+                )) return;
             var adoptOpenWorkspacePresentation = aiSessionsUpdate.canApplyPresentationProjectionRevision(
                 message.projectionRevision
             );
@@ -836,7 +867,11 @@ function initProjects() {
                 message.projectionRevision,
                 adoptOpenWorkspacePresentation
             );
-            syncAiSessionProjectionDom(adoptOpenWorkspacePresentation);
+            if (isAtomicOpenWorkspacesEnvelope) {
+                applyValidatedAiSessionPresentationState(message.presentation);
+            } else {
+                syncAiSessionProjectionDom(adoptOpenWorkspacePresentation);
+            }
             updateStickyGroupHeaderOffset();
             var renderedOpenWorkspaceState = getOpenWorkspacesUpdateDomState();
             window.vscode.postMessage({

--- a/media/webviewProjectScripts.js
+++ b/media/webviewProjectScripts.js
@@ -865,7 +865,8 @@ function initProjects() {
             }
             aiSessionsUpdate.commitProjectionRevision(
                 message.projectionRevision,
-                adoptOpenWorkspacePresentation
+                adoptOpenWorkspacePresentation,
+                isAtomicOpenWorkspacesEnvelope
             );
             if (isAtomicOpenWorkspacesEnvelope) {
                 applyValidatedAiSessionPresentationState(message.presentation);

--- a/media/webviewWorkspaceUpdateScripts.js
+++ b/media/webviewWorkspaceUpdateScripts.js
@@ -196,7 +196,7 @@ function completeOpenWorkspacePin(message) {
 function applyOpenWorkspacesUpdate(message) {
     if (!message
         || message.type !== 'open-workspaces-updated'
-        || message.version !== 2
+        || (message.version !== 2 && message.version !== 3)
         || typeof message.semanticRevision !== 'string'
         || !message.semanticRevision
         || (message.currentWorkspaceCount !== 0 && message.currentWorkspaceCount !== 1)

--- a/scripts/run-ai-session-safety-checks.js
+++ b/scripts/run-ai-session-safety-checks.js
@@ -4966,6 +4966,10 @@ function runWebviewContentChecks() {
     assert.ok(sessionReducedMotionStyles.includes('.codex-sessions'));
     assert.ok(sessionReducedMotionStyles.includes('transition: none !important'));
     const dashboard = fs.readFileSync(path.join(__dirname, '..', 'src', 'dashboard.ts'), 'utf8');
+    const presentationMessageSource = fs.readFileSync(
+        path.join(__dirname, '..', 'src', 'aiSessions', 'presentationMessage.ts'),
+        'utf8'
+    );
     const insideProjectClick = extractFunctionBody(webviewProjectScripts, 'onInsideProjectClick');
     const attentionControllerSource = fs.readFileSync(path.join(__dirname, '..', 'src', 'aiSessions', 'attentionController.ts'), 'utf8');
     const attentionMonitorSource = fs.readFileSync(path.join(__dirname, '..', 'src', 'aiSessions', 'attentionMonitor.ts'), 'utf8');
@@ -5241,7 +5245,7 @@ function runWebviewContentChecks() {
     assert.ok(!dashboardRuntimeControllerSource.includes("type: 'ai-session-attention-projects-updated'"));
     assert.ok(webviewProjectScripts.includes('message.attentionSessions'));
     assert.ok(!webviewProjectScripts.includes('message.sessionEvents'));
-    assert.ok(dashboard.includes("type: 'ai-session-presentation-state'"));
+    assert.ok(presentationMessageSource.includes("type: 'ai-session-presentation-state'"));
     assert.ok(webviewProjectScripts.includes("message.type === 'ai-session-presentation-state'"));
     assert.ok(!webviewProjectScripts.includes("message.type === 'ai-session-attention-state'"));
     assert.ok(!webviewProjectScripts.includes("message.type === 'active-ai-session-terminal-changed'"));
@@ -7380,7 +7384,8 @@ function runAiSessionIncrementalRefreshSourceChecks() {
     assert.strictEqual(dashboard.includes('getProjectionSnapshot: () => aiSessionProjectionCoordinator.capture(),'), true);
     assert.ok(dashboard.includes('getCards: projection => getOpenWorkspaceCards(projection),'));
     assert.ok(dashboard.includes('const transaction = aiSessionProjectionCoordinator.captureNext('));
-    assert.ok(dashboard.includes('postAiSessionPresentationState(false, transaction);'));
+    assert.ok(!dashboard.includes('postAiSessionPresentationState(false, transaction);'));
+    assert.ok(controllerSource.includes('presentation: buildAiSessionPresentationState('));
     assert.ok(workspaceHydrationSource.includes('activePresentation,'));
     assert.ok(dashboard.includes('beginAiSessionProjection: () => {'));
     assert.strictEqual(
@@ -8116,7 +8121,8 @@ async function runAiSessionDashboardUnchangedMessageSkipChecks() {
     sessionName = 'Codex Two';
     await controller.refreshNow('watcher');
     assert.strictEqual(messages.length, 3, 'changed watcher messages must still be posted');
-    assert.strictEqual(messages[2].version, 2);
+    assert.strictEqual(messages[2].version, 3);
+    assert.strictEqual(messages[2].presentation.projectionRevision, messages[2].projectionRevision);
     assert.strictEqual(messages[2].currentWorkspaceCount, 1);
     assert.strictEqual(messages[2].searchCatalog.version, 2);
     assert.deepStrictEqual(messages[2].searchCatalog.openWorkspaces.map(item => item.current), [true]);

--- a/scripts/run-architecture-guards.js
+++ b/scripts/run-architecture-guards.js
@@ -745,6 +745,12 @@ const guards = {
             || !webviewSource.includes(
                 'revision <= latestAiSessionClosedPresentationRevision'
             )
+            || !webviewSource.includes(
+                'revision >= latestAiSessionPresentationProjectionRevision'
+            )
+            || !webviewSource.includes(
+                'revision > latestAiSessionClosedPresentationRevision'
+            )
             || !webviewSource.includes('revision <= latestAiSessionDirectPresentationRevision')) {
             fail(this.id, risk,
                 'the Webview must close v3 envelopes while preserving v2 same-revision Presentation');
@@ -796,12 +802,16 @@ const guards = {
             'applyValidatedAiSessionPresentationState(message.presentation);'
         ) || !webviewSource.includes(
             'adoptRenderedPresentation,\n            isAtomicEnvelope'
+        ) || !webviewSource.includes(
+            '? canApplyAtomicPresentationProjectionRevision(message.projectionRevision)'
         ) || !projectWebviewSource.includes(
             'invalid-open-workspaces-presentation-envelope'
         ) || !projectWebviewSource.includes(
             'applyValidatedAiSessionPresentationState(message.presentation);'
         ) || !projectWebviewSource.includes(
             'adoptOpenWorkspacePresentation,\n                isAtomicOpenWorkspacesEnvelope'
+        ) || !projectWebviewSource.includes(
+            '? aiSessionsUpdate.canApplyAtomicPresentationProjectionRevision('
         )) {
             fail(this.id, risk,
                 'the Webview must validate and apply each HTML-Presentation envelope atomically');

--- a/scripts/run-architecture-guards.js
+++ b/scripts/run-architecture-guards.js
@@ -644,7 +644,7 @@ const guards = {
 
     // ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001
     'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001'(root) {
-        const risk = 'separately sampled HTML and Presentation can publish conflicting state at adjacent revisions';
+        const risk = 'separate HTML and Presentation deliveries can expose partial or conflicting session state';
         const dashboard = parseTypescript(root, 'src/dashboard.ts', this.id, risk);
         const controller = parseTypescript(
             root,
@@ -721,10 +721,14 @@ const guards = {
         const dashboardSource = dashboard.getFullText();
         if (!/getCards:\s*projection\s*=>\s*getOpenWorkspaceCards\(projection\)/
             .test(dashboardSource)
-            || !/postAiSessionPresentationState\(false,\s*transaction\);\s*return transaction;/
-                .test(dashboardSource)) {
+            || !controllerSource.includes(
+                'presentation: buildAiSessionPresentationState('
+            )
+            || dashboardSource.includes(
+                'postAiSessionPresentationState(false, transaction);'
+            )) {
             fail(this.id, risk,
-                'Dashboard composition must pass one captured transaction to both channels');
+                'AI incremental HTML and Presentation must share one Host message');
         }
         const hydrationControllerSource = hydrationController.getFullText();
         const hydrationSource = hydration.getFullText();
@@ -741,7 +745,7 @@ const guards = {
             fail(this.id, risk,
                 'the Webview must accept one same-revision direct Presentation after HTML');
         }
-        if (!/renderContent:\s*\(webview,\s*documentGeneration\)\s*=>\s*\{[\s\S]*?const transaction = aiSessionProjectionCoordinator\.captureNext\([\s\S]*?getOpenWorkspaceCards\(transaction\)[\s\S]*?buildAiSessionPresentationState\(false,\s*transaction\)/
+        if (!/renderContent:\s*\(webview,\s*documentGeneration\)\s*=>\s*\{[\s\S]*?const transaction = aiSessionProjectionCoordinator\.captureNext\([\s\S]*?getOpenWorkspaceCards\(transaction\)[\s\S]*?buildAiSessionPresentationState\(\s*false,\s*transaction,/
             .test(dashboardSource)
             || !fullDocument.getFullText().includes(
                 'id="dashboard-ai-session-presentation"'
@@ -769,13 +773,30 @@ const guards = {
             || !openWorkspaceSource.includes('projectionRevision: projection.revision')
             || !updateMessageSource.includes(
                 'projectionRevision: input.projectionRevision'
-            ) || dashboardSource.includes(
+            ) || !openWorkspaceSource.includes(
+                'presentation: buildAiSessionPresentationState('
+            ) || !updateMessageSource.includes('presentation: input.presentation')
+            || !updateMessageSource.includes('version: 3')
+            || dashboardSource.includes(
                 'projectionRevision: aiSessionProjectionCoordinator.nextRevision()'
-            ) || !/beginAiSessionProjection:\s*\(\)\s*=>\s*\{[\s\S]*?postAiSessionPresentationState\(false,\s*transaction\);[\s\S]*?return transaction;\s*\},\s*getGroups:/
-                .test(dashboardSource)
+            ) || dashboardSource.includes(
+                'postAiSessionPresentationState(false, transaction);'
+            )
             ) {
             fail(this.id, risk,
-                'OPEN HTML must capture, hydrate, and publish the same Presentation transaction');
+                'OPEN HTML and Presentation must share one Host message');
+        }
+        if (!webviewSource.includes(
+            'message.presentation.projectionRevision !== message.projectionRevision'
+        ) || !webviewSource.includes(
+            'applyValidatedAiSessionPresentationState(message.presentation);'
+        ) || !projectWebviewSource.includes(
+            'invalid-open-workspaces-presentation-envelope'
+        ) || !projectWebviewSource.includes(
+            'applyValidatedAiSessionPresentationState(message.presentation);'
+        )) {
+            fail(this.id, risk,
+                'the Webview must validate and apply each HTML-Presentation envelope atomically');
         }
     },
 

--- a/scripts/run-architecture-guards.js
+++ b/scripts/run-architecture-guards.js
@@ -740,10 +740,14 @@ const guards = {
         }
         const webviewSource = webview.getFullText();
         if (!webviewSource.includes('latestAiSessionDirectPresentationRevision')
+            || !webviewSource.includes('latestAiSessionClosedPresentationRevision')
             || !webviewSource.includes('revision < latestAiSessionProjectionRevision')
+            || !webviewSource.includes(
+                'revision <= latestAiSessionClosedPresentationRevision'
+            )
             || !webviewSource.includes('revision <= latestAiSessionDirectPresentationRevision')) {
             fail(this.id, risk,
-                'the Webview must accept one same-revision direct Presentation after HTML');
+                'the Webview must close v3 envelopes while preserving v2 same-revision Presentation');
         }
         if (!/renderContent:\s*\(webview,\s*documentGeneration\)\s*=>\s*\{[\s\S]*?const transaction = aiSessionProjectionCoordinator\.captureNext\([\s\S]*?getOpenWorkspaceCards\(transaction\)[\s\S]*?buildAiSessionPresentationState\(\s*false,\s*transaction,/
             .test(dashboardSource)
@@ -790,10 +794,14 @@ const guards = {
             'message.presentation.projectionRevision !== message.projectionRevision'
         ) || !webviewSource.includes(
             'applyValidatedAiSessionPresentationState(message.presentation);'
+        ) || !webviewSource.includes(
+            'adoptRenderedPresentation,\n            isAtomicEnvelope'
         ) || !projectWebviewSource.includes(
             'invalid-open-workspaces-presentation-envelope'
         ) || !projectWebviewSource.includes(
             'applyValidatedAiSessionPresentationState(message.presentation);'
+        ) || !projectWebviewSource.includes(
+            'adoptOpenWorkspacePresentation,\n                isAtomicOpenWorkspacesEnvelope'
         )) {
             fail(this.id, risk,
                 'the Webview must validate and apply each HTML-Presentation envelope atomically');

--- a/scripts/run-dashboard-webview-checks.js
+++ b/scripts/run-dashboard-webview-checks.js
@@ -379,6 +379,14 @@ function runDashboardUpdateMessageChecks() {
     }
     const todoSearchItems = makeDashboardCatalog().todos;
     const workspaceCard = makeWorkspaceCardFixture(3);
+    const makePresentation = projectionRevision => ({
+        type: 'ai-session-presentation-state', version: 1, projectionRevision,
+        workspaceScopeIdentity: 'scope-dashboard',
+        workspaceNavigationIdentity: 'navigation-current',
+        attentionCount: 0, activeAttentionCount: 0, runningSessionCount: 0,
+        runningCardAnimation: 'current', runningIconAnimation: 'current',
+        revealFocused: false, focusedTarget: null, attentionSessions: [], sessions: [],
+    });
     const aiMessage = dashboardUpdateMessages.buildAiSessionsUpdatedMessage({
         groups: [],
         cards: [workspaceCard],
@@ -387,6 +395,7 @@ function runDashboardUpdateMessageChecks() {
         todoSearchItems,
         runningCardAnimation: 'custom',
         runningIconAnimation: 'halo',
+        presentation: makePresentation(7),
     });
     const workspaceMessage = dashboardUpdateMessages.buildWorkspaceUpdatedMessage({
         card: workspaceCard,
@@ -414,12 +423,15 @@ function runDashboardUpdateMessageChecks() {
         todoSearchItems,
         runningCardAnimation: 'breath',
         runningIconAnimation: 'custom',
+        presentation: makePresentation(1),
     });
     const workspaceSearchCatalog = buildWorkspaceDashboardSearchCatalog([], [workspaceCard], todoSearchItems);
 
     assert.deepStrictEqual(aiMessage.searchCatalog.todos, todoSearchItems,
         'AI incremental catalog rebuilds must preserve real TODO search items');
-    assert.strictEqual(aiMessage.version, 2);
+    assert.strictEqual(aiMessage.version, 3);
+    assert.strictEqual(aiMessage.projectionRevision, 7);
+    assert.strictEqual(aiMessage.presentation.projectionRevision, 7);
     assert.strictEqual(aiMessage.currentWorkspaceCount, 1);
     assert.strictEqual(aiMessage.searchCatalog.version, 2);
     assert.deepStrictEqual(aiMessage.searchCatalog.openWorkspaces.map(item => item.current), [true]);
@@ -444,7 +456,8 @@ function runDashboardUpdateMessageChecks() {
     assert.strictEqual(emptyWorkspaceMessage.currentWorkspaceCount, 0);
     assert.strictEqual(emptyWorkspaceMessage.html.includes('class="workspace-card'), false);
     assert.strictEqual(openWorkspacesMessage.type, 'open-workspaces-updated');
-    assert.strictEqual(openWorkspacesMessage.version, 2);
+    assert.strictEqual(openWorkspacesMessage.version, 3);
+    assert.strictEqual(openWorkspacesMessage.presentation.projectionRevision, 1);
     assert.strictEqual(openWorkspacesMessage.currentWorkspaceCount, 1);
     assert.strictEqual(openWorkspacesMessage.navigationWorkspaceCount, 1);
     assert.strictEqual(openWorkspacesMessage.searchCatalog.version, 2);

--- a/scripts/run-open-project-safety-checks.js
+++ b/scripts/run-open-project-safety-checks.js
@@ -1291,7 +1291,11 @@ async function runOpenWorkspaceClientAndControllerChecks() {
     await new Promise(resolve => setImmediate(resolve));
     assert.strictEqual(posted.length, 1);
     assert.strictEqual(posted[0].type, 'open-workspaces-updated');
-    assert.strictEqual(posted[0].version, 2);
+    assert.strictEqual(posted[0].version, 3);
+    assert.strictEqual(
+        posted[0].presentation.projectionRevision,
+        posted[0].projectionRevision
+    );
     assert.strictEqual(posted[0].currentWorkspaceCount, 1);
     assert.strictEqual(posted[0].navigationWorkspaceCount, 2);
     assert.strictEqual(posted[0].searchCatalog.version, 2);

--- a/src/aiSessions/dashboardController.ts
+++ b/src/aiSessions/dashboardController.ts
@@ -2,15 +2,17 @@
 
 import type { AiSessionProviderId, Group, WorkspaceCardViewModel } from '../models';
 import type { AiSessionsUpdatedMessage } from './types';
+import { buildAiSessionPresentationState } from './presentationMessage';
 import { buildAiSessionsUpdatedMessage } from '../dashboard/webviewUpdateMessages';
 import type { TodoSearchCatalogItem } from '../todos/types';
+import type { AiSessionPresentationTransaction } from '../workspaces/sessionHydrationController';
 
 interface DisposableLike {
     dispose(): void;
 }
 
 export interface AiSessionDashboardControllerOptions<
-    TProjection extends AiSessionDashboardProjection = AiSessionDashboardProjection
+    TProjection extends AiSessionPresentationTransaction = AiSessionPresentationTransaction
 > {
     providerIds: AiSessionProviderId[];
     isVisible: () => boolean;
@@ -37,16 +39,12 @@ export interface AiSessionDashboardControllerOptions<
     clearTimeout: (handle: NodeJS.Timeout) => void;
 }
 
-export interface AiSessionDashboardProjection {
-    revision: number;
-}
-
 export interface AiSessionDashboardRefreshOptions {
     fallbackToFullRefresh?: boolean;
 }
 
 export class AiSessionDashboardController<
-    TProjection extends AiSessionDashboardProjection = AiSessionDashboardProjection
+    TProjection extends AiSessionPresentationTransaction = AiSessionPresentationTransaction
 > {
     private refreshTimeout: NodeJS.Timeout = null;
     private watcherStopTimeout: NodeJS.Timeout = null;
@@ -184,6 +182,8 @@ export class AiSessionDashboardController<
     ): AiSessionsUpdatedMessage {
         const startedAt = this.nowMs();
         const cards = this.options.getCards(projection);
+        const runningCardAnimation = this.options.getRunningCardAnimation();
+        const runningIconAnimation = this.options.getRunningIconAnimation();
         const message = buildAiSessionsUpdatedMessage({
             groups: this.options.getGroups(),
             cards,
@@ -191,8 +191,14 @@ export class AiSessionDashboardController<
             generatedAt: new Date().toISOString(),
             todoSearchItems: this.options.getTodoSearchItems(),
             skills: this.options.getSkillRecords ? this.options.getSkillRecords() : [],
-            runningCardAnimation: this.options.getRunningCardAnimation(),
-            runningIconAnimation: this.options.getRunningIconAnimation(),
+            runningCardAnimation,
+            runningIconAnimation,
+            presentation: buildAiSessionPresentationState(
+                false,
+                projection,
+                runningCardAnimation,
+                runningIconAnimation,
+            ),
         });
         this.options.logDiagnostic?.({
             event: 'ai-session-message-build',
@@ -278,10 +284,15 @@ export class AiSessionDashboardController<
     }
 
     private getIncrementalMessageSignature(message: AiSessionsUpdatedMessage): string {
+        const {
+            projectionRevision: _projectionRevision,
+            ...presentation
+        } = message.presentation;
         return JSON.stringify({
             currentWorkspaceCount: message.currentWorkspaceCount,
             html: message.html,
             searchCatalog: this.stableValue(message.searchCatalog),
+            presentation: this.stableValue(presentation),
         });
     }
 

--- a/src/aiSessions/presentationMessage.ts
+++ b/src/aiSessions/presentationMessage.ts
@@ -1,0 +1,21 @@
+'use strict';
+
+import type { AiSessionPresentationStateMessage } from './types';
+import type { AiSessionPresentationTransaction } from '../workspaces/sessionHydrationController';
+
+export function buildAiSessionPresentationState<TTerminal>(
+    revealFocused: boolean,
+    transaction: AiSessionPresentationTransaction<TTerminal>,
+    runningCardAnimation: string = 'current',
+    runningIconAnimation: string = 'current',
+): AiSessionPresentationStateMessage {
+    return {
+        type: 'ai-session-presentation-state',
+        version: 1,
+        projectionRevision: transaction.revision,
+        ...transaction.presentation,
+        runningCardAnimation,
+        runningIconAnimation,
+        revealFocused,
+    };
+}

--- a/src/aiSessions/types.ts
+++ b/src/aiSessions/types.ts
@@ -205,12 +205,14 @@ export interface WorkspaceAiSessionActionTarget {
 
 export interface AiSessionsUpdatedMessage {
     type: 'ai-sessions-updated';
-    version: 2;
+    version: 3;
     sequence: number;
+    projectionRevision: number;
     generatedAt: string;
     currentWorkspaceCount: 0 | 1;
     html: string;
     searchCatalog: DashboardWorkspaceSearchCatalog;
+    presentation: AiSessionPresentationStateMessage;
 }
 
 export interface ActiveAiSessionPresentation {

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -124,7 +124,8 @@ import {
 import { TmuxRuntimeBackend } from './aiSessions/tmuxRuntimeBackend';
 import { TmuxFocusedRuntimeMonitor } from './aiSessions/tmuxFocusedRuntimeMonitor';
 import { withTmuxCreationLock } from './aiSessions/tmuxCreationLock';
-import type { AiSessionBatchArchiveCompletedMessage, AiSessionPresentationStateMessage, AiSessionProvider, AiSessionService, AiSessionTerminalEntry, AiSessionsUpdatedMessage, WorkspaceAiSessionActionTarget } from './aiSessions/types';
+import type { AiSessionBatchArchiveCompletedMessage, AiSessionProvider, AiSessionService, AiSessionTerminalEntry, AiSessionsUpdatedMessage, WorkspaceAiSessionActionTarget } from './aiSessions/types';
+import { buildAiSessionPresentationState } from './aiSessions/presentationMessage';
 import {
     ConversationCapability,
     createConversationCapability,
@@ -1446,13 +1447,9 @@ async function initializeDashboard(
             const transaction = aiSessionProjectionCoordinator.captureNext(
                 getCurrentOpenWorkspace()
             );
-            postAiSessionPresentationState(false, transaction);
             return transaction;
         },
-        postMessage: message => provider.postMessage({
-            ...(message as unknown as Record<string, unknown>),
-            projectionRevision: (message as AiSessionsUpdatedMessage).sequence,
-        }),
+        postMessage: message => provider.postMessage(message),
         refresh: refreshStewardViews,
         logError,
         logDiagnostic: logAiSessionDiagnostic,
@@ -1689,6 +1686,7 @@ async function initializeDashboard(
             const transaction = aiSessionProjectionCoordinator.captureNext(
                 getCurrentOpenWorkspace()
             );
+            const configuration = getAgentPivotConfiguration();
             return getStewardContent(
                 context,
                 webview,
@@ -1698,7 +1696,12 @@ async function initializeDashboard(
                 getOpenWorkspaceCards(transaction),
                 openWorkspaceDashboardController.getState().otherWindows.status,
                 documentGeneration,
-                buildAiSessionPresentationState(false, transaction),
+                buildAiSessionPresentationState(
+                    false,
+                    transaction,
+                    getEffectiveRunningCardAnimation(configuration),
+                    getEffectiveRunningIconAnimation(configuration),
+                ),
             );
         },
         renderError: getErrorContent,
@@ -1776,7 +1779,6 @@ async function initializeDashboard(
             const transaction = aiSessionProjectionCoordinator.captureNext(
                 getCurrentOpenWorkspace()
             );
-            postAiSessionPresentationState(false, transaction);
             return transaction;
         },
         getGroups: () => projectService.getGroups(),
@@ -2637,7 +2639,13 @@ async function initializeDashboard(
         transaction: AiSessionPresentationTransaction<vscode.Terminal>
             = aiSessionProjectionCoordinator.captureNext(getCurrentOpenWorkspace())
     ): void {
-        const message = buildAiSessionPresentationState(revealFocused, transaction);
+        const configuration = getAgentPivotConfiguration();
+        const message = buildAiSessionPresentationState(
+            revealFocused,
+            transaction,
+            getEffectiveRunningCardAnimation(configuration),
+            getEffectiveRunningIconAnimation(configuration),
+        );
         try {
             void provider.postMessage(message).then(undefined, error => {
                 logError('Failed to post the Active Session presentation.', error);
@@ -2645,22 +2653,6 @@ async function initializeDashboard(
         } catch (error) {
             logError('Failed to post the Active Session presentation.', error);
         }
-    }
-
-    function buildAiSessionPresentationState(
-        revealFocused: boolean,
-        transaction: AiSessionPresentationTransaction<vscode.Terminal>
-    ): AiSessionPresentationStateMessage {
-        const configuration = getAgentPivotConfiguration();
-        return {
-            type: 'ai-session-presentation-state',
-            version: 1,
-            projectionRevision: transaction.revision,
-            ...transaction.presentation,
-            runningCardAnimation: getEffectiveRunningCardAnimation(configuration),
-            runningIconAnimation: getEffectiveRunningIconAnimation(configuration),
-            revealFocused,
-        };
     }
 
     function invalidateAiSessionCache(providerId: AiSessionProviderId) {

--- a/src/dashboard/webviewUpdateMessages.ts
+++ b/src/dashboard/webviewUpdateMessages.ts
@@ -1,7 +1,10 @@
 'use strict';
 
 import { Group, WorkspaceCardViewModel } from '../models';
-import type { AiSessionsUpdatedMessage } from '../aiSessions/types';
+import type {
+    AiSessionPresentationStateMessage,
+    AiSessionsUpdatedMessage,
+} from '../aiSessions/types';
 import type { OpenWorkspaceBridgeStatus } from '../openWorkspaces/bridgeClient';
 import type { TodoSearchCatalogItem } from '../todos/types';
 import {
@@ -73,7 +76,7 @@ export interface BuildWorkspaceUpdatedMessageInput {
 
 export interface OpenWorkspacesUpdatedMessage {
     type: 'open-workspaces-updated';
-    version: 2;
+    version: 3;
     semanticRevision: string;
     projectionRevision: number;
     currentWorkspaceCount: 0 | 1;
@@ -81,6 +84,7 @@ export interface OpenWorkspacesUpdatedMessage {
     otherWindowsStatus: OpenWorkspaceBridgeStatus;
     searchCatalog: DashboardWorkspaceSearchCatalog;
     html: string;
+    presentation: AiSessionPresentationStateMessage;
 }
 
 export interface BuildOpenWorkspacesUpdatedMessageInput {
@@ -94,6 +98,7 @@ export interface BuildOpenWorkspacesUpdatedMessageInput {
     skills?: import('../skills/types').SkillRecord[];
     runningCardAnimation?: string;
     runningIconAnimation?: string;
+    presentation: AiSessionPresentationStateMessage;
 }
 
 export interface BuildAiSessionsUpdatedMessageInput {
@@ -105,6 +110,7 @@ export interface BuildAiSessionsUpdatedMessageInput {
     skills?: import('../skills/types').SkillRecord[];
     runningCardAnimation?: string;
     runningIconAnimation?: string;
+    presentation: AiSessionPresentationStateMessage;
 }
 
 export function buildOpenWorkspacesUpdatedMessage(
@@ -114,7 +120,7 @@ export function buildOpenWorkspacesUpdatedMessage(
     const navigationWorkspaceCount = input.cards.filter(card => card.kind === 'navigation').length;
     return {
         type: 'open-workspaces-updated',
-        version: 2,
+        version: 3,
         semanticRevision: input.semanticRevision,
         projectionRevision: input.projectionRevision,
         currentWorkspaceCount,
@@ -133,6 +139,7 @@ export function buildOpenWorkspacesUpdatedMessage(
             input.runningCardAnimation,
             input.runningIconAnimation,
         ),
+        presentation: input.presentation,
     };
 }
 
@@ -157,8 +164,9 @@ export function buildAiSessionsUpdatedMessage(input: BuildAiSessionsUpdatedMessa
     const current = input.cards.find(card => card.kind === 'current') || null;
     return {
         type: 'ai-sessions-updated',
-        version: 2,
+        version: 3,
         sequence: input.sequence,
+        projectionRevision: input.sequence,
         generatedAt: input.generatedAt,
         currentWorkspaceCount: current ? 1 : 0,
         html: getCurrentWorkspaceGroupContent(
@@ -173,5 +181,6 @@ export function buildAiSessionsUpdatedMessage(input: BuildAiSessionsUpdatedMessa
             input.todoSearchItems,
             input.skills,
         ),
+        presentation: input.presentation,
     };
 }

--- a/src/openWorkspaces/dashboardController.ts
+++ b/src/openWorkspaces/dashboardController.ts
@@ -4,6 +4,7 @@ import * as crypto from 'crypto';
 
 import type { AttentionAggregate } from '../aiSessions/attentionAggregate';
 import type { WorkspaceAiSessionViewModel } from '../aiSessions/types';
+import { buildAiSessionPresentationState } from '../aiSessions/presentationMessage';
 import { PREDEFINED_COLORS } from '../constants';
 import type { Group, WorkspaceCardViewModel } from '../models';
 import { buildOpenWorkspacesUpdatedMessage } from '../dashboard/webviewUpdateMessages';
@@ -261,6 +262,8 @@ export class OpenWorkspaceDashboardController<TTerminal = unknown> {
         const semanticRevision = this.getViewSemanticRevision();
         if (semanticRevision === this.lastPostedSemanticRevision) { return Promise.resolve(); }
         const projection = this.options.beginAiSessionProjection();
+        const runningCardAnimation = this.options.getRunningCardAnimation();
+        const runningIconAnimation = this.options.getRunningIconAnimation();
         const message = buildOpenWorkspacesUpdatedMessage({
             groups: this.options.getGroups(),
             cards: this.getCards(projection),
@@ -270,8 +273,14 @@ export class OpenWorkspaceDashboardController<TTerminal = unknown> {
             otherWindowsStatus: this.bridgeStatus,
             todoSearchItems: this.options.getTodoSearchItems(),
             skills: this.options.getSkillRecords ? this.options.getSkillRecords() : [],
-            runningCardAnimation: this.options.getRunningCardAnimation(),
-            runningIconAnimation: this.options.getRunningIconAnimation(),
+            runningCardAnimation,
+            runningIconAnimation,
+            presentation: buildAiSessionPresentationState(
+                false,
+                projection,
+                runningCardAnimation,
+                runningIconAnimation,
+            ),
         });
         this.lastPostedSemanticRevision = message.semanticRevision;
         const deliveryGeneration = this.deliveryGeneration;

--- a/src/webview/webviewProjectAiUpdateScripts.js
+++ b/src/webview/webviewProjectAiUpdateScripts.js
@@ -41,6 +41,13 @@ function initProjectAiSessionsUpdate(options) {
         return canApplyRevision(revision, latestAiSessionPresentationProjectionRevision);
     }
 
+    function canApplyAtomicPresentationProjectionRevision(revision) {
+        return Number.isSafeInteger(revision)
+            && revision > 0
+            && revision >= latestAiSessionPresentationProjectionRevision
+            && revision > latestAiSessionClosedPresentationRevision;
+    }
+
     function commitProjectionRevision(revision, adoptedPresentation, closePresentation) {
         if (Number.isSafeInteger(revision) && revision > 0) {
             latestAiSessionProjectionRevision = revision;
@@ -123,13 +130,13 @@ function initProjectAiSessionsUpdate(options) {
         if (!canApplyProjectionRevision(message.projectionRevision)) {
             return;
         }
-        if (isAtomicEnvelope
-            && !canApplyPresentationProjectionRevision(message.projectionRevision)) {
+        var canApplyMessagePresentation = isAtomicEnvelope
+            ? canApplyAtomicPresentationProjectionRevision(message.projectionRevision)
+            : canApplyPresentationProjectionRevision(message.projectionRevision);
+        if (isAtomicEnvelope && !canApplyMessagePresentation) {
             return;
         }
-        var adoptRenderedPresentation = canApplyPresentationProjectionRevision(
-            message.projectionRevision
-        );
+        var adoptRenderedPresentation = canApplyMessagePresentation;
 
         if (!applyWorkspaceUpdate({
             type: 'workspace-updated',
@@ -276,6 +283,7 @@ function initProjectAiSessionsUpdate(options) {
         applyAiSessionsUpdate: applyAiSessionsUpdate,
         acceptInitialPresentationProjectionRevision: acceptInitialPresentationProjectionRevision,
         acceptPresentationProjectionRevision: acceptPresentationProjectionRevision,
+        canApplyAtomicPresentationProjectionRevision: canApplyAtomicPresentationProjectionRevision,
         canApplyPresentationProjectionRevision: canApplyPresentationProjectionRevision,
         canApplyProjectionRevision: canApplyProjectionRevision,
         commitProjectionRevision: commitProjectionRevision,

--- a/src/webview/webviewProjectAiUpdateScripts.js
+++ b/src/webview/webviewProjectAiUpdateScripts.js
@@ -22,6 +22,7 @@ function initProjectAiSessionsUpdate(options) {
     var latestAiSessionProjectionRevision = 0;
     var latestAiSessionPresentationProjectionRevision = 0;
     var latestAiSessionDirectPresentationRevision = 0;
+    var latestAiSessionClosedPresentationRevision = 0;
 
     function canApplyRevision(revision, latestRevision) {
         if (typeof revision === 'undefined') {
@@ -40,12 +41,18 @@ function initProjectAiSessionsUpdate(options) {
         return canApplyRevision(revision, latestAiSessionPresentationProjectionRevision);
     }
 
-    function commitProjectionRevision(revision, adoptedPresentation) {
+    function commitProjectionRevision(revision, adoptedPresentation, closePresentation) {
         if (Number.isSafeInteger(revision) && revision > 0) {
             latestAiSessionProjectionRevision = revision;
             if (adoptedPresentation) {
                 latestAiSessionPresentationProjectionRevision = Math.max(
                     latestAiSessionPresentationProjectionRevision,
+                    revision
+                );
+            }
+            if (closePresentation) {
+                latestAiSessionClosedPresentationRevision = Math.max(
+                    latestAiSessionClosedPresentationRevision,
                     revision
                 );
             }
@@ -57,6 +64,7 @@ function initProjectAiSessionsUpdate(options) {
             || revision <= 0
             || revision < latestAiSessionProjectionRevision
             || revision < latestAiSessionPresentationProjectionRevision
+            || revision <= latestAiSessionClosedPresentationRevision
             || revision <= latestAiSessionDirectPresentationRevision) {
             return false;
         }
@@ -140,7 +148,8 @@ function initProjectAiSessionsUpdate(options) {
         latestAiSessionUpdateSequence = message.sequence;
         commitProjectionRevision(
             message.projectionRevision,
-            adoptRenderedPresentation
+            adoptRenderedPresentation,
+            isAtomicEnvelope
         );
         if (batchAiSessionState.projectId) {
             var projectDiv = findCurrentWorkspaceDiv(batchAiSessionState.projectId);

--- a/src/webview/webviewProjectAiUpdateScripts.js
+++ b/src/webview/webviewProjectAiUpdateScripts.js
@@ -14,6 +14,8 @@ function initProjectAiSessionsUpdate(options) {
     var exitAiSessionBatchManagement = options.exitAiSessionBatchManagement;
     var isAiSessionProvider = options.isAiSessionProvider;
     var updateStickyGroupHeaderOffset = options.updateStickyGroupHeaderOffset;
+    var isValidAiSessionPresentationState = options.isValidAiSessionPresentationState;
+    var applyValidatedAiSessionPresentationState = options.applyValidatedAiSessionPresentationState;
 
     var pendingWorkspaceSessionReveal = null;
     var latestAiSessionUpdateSequence = 0;
@@ -81,7 +83,8 @@ function initProjectAiSessionsUpdate(options) {
     }
 
     function applyAiSessionsUpdate(message) {
-        if (message.version !== 2
+        var isAtomicEnvelope = message.version === 3;
+        if ((message.version !== 2 && !isAtomicEnvelope)
             || typeof message.sequence !== 'number'
             || (message.currentWorkspaceCount !== 0 && message.currentWorkspaceCount !== 1)
             || typeof message.html !== 'string'
@@ -92,10 +95,28 @@ function initProjectAiSessionsUpdate(options) {
             return;
         }
 
+        if (isAtomicEnvelope
+            && (!Number.isSafeInteger(message.projectionRevision)
+                || message.projectionRevision <= 0
+                || message.sequence !== message.projectionRevision
+                || typeof message.generatedAt !== 'string'
+                || !message.generatedAt
+                || typeof isValidAiSessionPresentationState !== 'function'
+                || !isValidAiSessionPresentationState(message.presentation)
+                || message.presentation.projectionRevision !== message.projectionRevision
+                || typeof applyValidatedAiSessionPresentationState !== 'function')) {
+            requestFullRefresh('invalid-ai-session-presentation-envelope');
+            return;
+        }
+
         if (message.sequence <= latestAiSessionUpdateSequence) {
             return;
         }
         if (!canApplyProjectionRevision(message.projectionRevision)) {
+            return;
+        }
+        if (isAtomicEnvelope
+            && !canApplyPresentationProjectionRevision(message.projectionRevision)) {
             return;
         }
         var adoptRenderedPresentation = canApplyPresentationProjectionRevision(
@@ -131,7 +152,11 @@ function initProjectAiSessionsUpdate(options) {
             }
         }
         reconcilePendingAiSessionProviderSelectionDom();
-        syncAiSessionProjectionDom(adoptRenderedPresentation);
+        if (isAtomicEnvelope) {
+            applyValidatedAiSessionPresentationState(message.presentation);
+        } else {
+            syncAiSessionProjectionDom(adoptRenderedPresentation);
+        }
         updateStickyGroupHeaderOffset();
         if (window.__agentPivotDashboard) {
             window.__agentPivotDashboard.replaceSearchCatalog(message.searchCatalog);

--- a/src/webview/webviewProjectScripts.js
+++ b/src/webview/webviewProjectScripts.js
@@ -852,13 +852,16 @@ function initProjects() {
                 return;
             }
             if (!aiSessionsUpdate.canApplyProjectionRevision(message.projectionRevision)) return;
-            if (isAtomicOpenWorkspacesEnvelope
-                && !aiSessionsUpdate.canApplyPresentationProjectionRevision(
+            var canApplyOpenWorkspacePresentation = isAtomicOpenWorkspacesEnvelope
+                ? aiSessionsUpdate.canApplyAtomicPresentationProjectionRevision(
                     message.projectionRevision
-                )) return;
-            var adoptOpenWorkspacePresentation = aiSessionsUpdate.canApplyPresentationProjectionRevision(
-                message.projectionRevision
-            );
+                )
+                : aiSessionsUpdate.canApplyPresentationProjectionRevision(
+                    message.projectionRevision
+                );
+            if (isAtomicOpenWorkspacesEnvelope
+                && !canApplyOpenWorkspacePresentation) return;
+            var adoptOpenWorkspacePresentation = canApplyOpenWorkspacePresentation;
             if (!applyOpenWorkspacesUpdate(message)) {
                 aiSessionsUpdate.requestFullRefresh('invalid-open-workspaces-update');
                 return;

--- a/src/webview/webviewProjectScripts.js
+++ b/src/webview/webviewProjectScripts.js
@@ -574,6 +574,8 @@ function initProjects() {
         exitAiSessionBatchManagement: aiSessionControls.exitAiSessionBatchManagement,
         isAiSessionProvider: aiSessionControls.isAiSessionProvider,
         updateStickyGroupHeaderOffset: updateStickyGroupHeaderOffset,
+        isValidAiSessionPresentationState: isValidAiSessionPresentationState,
+        applyValidatedAiSessionPresentationState: applyValidatedAiSessionPresentationState,
     });
 
     function isValidAiSessionPresentationState(message) {
@@ -594,6 +596,17 @@ function initProjects() {
                 .includes(message.runningCardAnimation)
             && ['current', 'halo', 'custom', 'none'].includes(message.runningIconAnimation)
             && typeof message.revealFocused === 'boolean'
+            && (message.focusedTarget === null
+                || (message.focusedTarget
+                    && aiSessionControls.isAiSessionProvider(
+                        message.focusedTarget.provider
+                    )
+                    && ((typeof message.focusedTarget.sessionId === 'string'
+                        && !!message.focusedTarget.sessionId
+                        && typeof message.focusedTarget.pendingId === 'undefined')
+                        || (typeof message.focusedTarget.pendingId === 'string'
+                            && !!message.focusedTarget.pendingId
+                            && typeof message.focusedTarget.sessionId === 'undefined'))))
             && Array.isArray(message.sessions) && message.sessions.length <= 1000
             && message.sessions.every(session => session
                 && aiSessionControls.isAiSessionProvider(session.provider)
@@ -630,9 +643,13 @@ function initProjects() {
                 message.projectionRevision
             );
         if (!accepted) return false;
+        applyValidatedAiSessionPresentationState(message);
+        return true;
+    }
+
+    function applyValidatedAiSessionPresentationState(message) {
         window.__agentPivotAiSessionPresentationState = message;
         applyAiSessionPresentationDom(message);
-        return true;
     }
 
     function readInitialAiSessionPresentationState() {
@@ -824,7 +841,21 @@ function initProjects() {
             return;
         }
         if (message && message.type === 'open-workspaces-updated') {
+            var isAtomicOpenWorkspacesEnvelope = message.version === 3;
+            if (isAtomicOpenWorkspacesEnvelope
+                && (!isValidAiSessionPresentationState(message.presentation)
+                    || message.presentation.projectionRevision
+                        !== message.projectionRevision)) {
+                aiSessionsUpdate.requestFullRefresh(
+                    'invalid-open-workspaces-presentation-envelope'
+                );
+                return;
+            }
             if (!aiSessionsUpdate.canApplyProjectionRevision(message.projectionRevision)) return;
+            if (isAtomicOpenWorkspacesEnvelope
+                && !aiSessionsUpdate.canApplyPresentationProjectionRevision(
+                    message.projectionRevision
+                )) return;
             var adoptOpenWorkspacePresentation = aiSessionsUpdate.canApplyPresentationProjectionRevision(
                 message.projectionRevision
             );
@@ -836,7 +867,11 @@ function initProjects() {
                 message.projectionRevision,
                 adoptOpenWorkspacePresentation
             );
-            syncAiSessionProjectionDom(adoptOpenWorkspacePresentation);
+            if (isAtomicOpenWorkspacesEnvelope) {
+                applyValidatedAiSessionPresentationState(message.presentation);
+            } else {
+                syncAiSessionProjectionDom(adoptOpenWorkspacePresentation);
+            }
             updateStickyGroupHeaderOffset();
             var renderedOpenWorkspaceState = getOpenWorkspacesUpdateDomState();
             window.vscode.postMessage({

--- a/src/webview/webviewProjectScripts.js
+++ b/src/webview/webviewProjectScripts.js
@@ -865,7 +865,8 @@ function initProjects() {
             }
             aiSessionsUpdate.commitProjectionRevision(
                 message.projectionRevision,
-                adoptOpenWorkspacePresentation
+                adoptOpenWorkspacePresentation,
+                isAtomicOpenWorkspacesEnvelope
             );
             if (isAtomicOpenWorkspacesEnvelope) {
                 applyValidatedAiSessionPresentationState(message.presentation);

--- a/src/webview/webviewWorkspaceUpdateScripts.js
+++ b/src/webview/webviewWorkspaceUpdateScripts.js
@@ -196,7 +196,7 @@ function completeOpenWorkspacePin(message) {
 function applyOpenWorkspacesUpdate(message) {
     if (!message
         || message.type !== 'open-workspaces-updated'
-        || message.version !== 2
+        || (message.version !== 2 && message.version !== 3)
         || typeof message.semanticRevision !== 'string'
         || !message.semanticRevision
         || (message.currentWorkspaceCount !== 0 && message.currentWorkspaceCount !== 1)

--- a/tests/browser/activeSessionCardInteraction.test.js
+++ b/tests/browser/activeSessionCardInteraction.test.js
@@ -807,6 +807,112 @@ test('ACTIVE-SESSION-INCREMENTAL-PRESENTATION-ENVELOPE-001 applies OPEN HTML and
     }]);
 });
 
+test('ACTIVE-SESSION-INCREMENTAL-PRESENTATION-ENVELOPE-001 closes an AI envelope revision against conflicting direct presentation', async t => {
+    const attentionSession = {
+        ...session('codex', 'session-a', true),
+        executionState: 'stopped',
+        status: 'stopped',
+        needsAttention: true,
+        attentionEventId: 'event-a',
+    };
+    const otherSession = session('codex', 'session-b', false);
+    const page = await openCardPage(t, [session('codex', 'session-a', true)]);
+    await postHostMessage(page, {
+        type: 'ai-sessions-updated',
+        version: 3,
+        sequence: 2,
+        projectionRevision: 2,
+        generatedAt: '2026-08-11T00:00:00.000Z',
+        currentWorkspaceCount: 1,
+        html: `<div class="open-current-workspace-group">${projectMarkup([
+            attentionSession,
+            otherSession,
+        ])}</div>`,
+        searchCatalog: {
+            version: 2,
+            sessions: [],
+            openWorkspaces: [],
+            savedProjects: [],
+            todos: [],
+        },
+        presentation: presentationMessage([attentionSession, otherSession], 2, {
+            attention: { 'codex:session-a': ['event-a', 'event-b'] },
+        }),
+    });
+    await postHostMessage(page, presentationMessage([
+        { ...attentionSession, focused: false },
+        { ...otherSession, focused: true },
+    ], 2));
+
+    assert.equal(await row(page, 'codex', 'session-a').getAttribute('data-session-focused'), '');
+    assert.equal(await row(page, 'codex', 'session-b').getAttribute('data-session-focused'), null);
+    assert.equal(await row(page, 'codex', 'session-a').getAttribute('data-ai-session-attention'), '');
+    await row(page, 'codex', 'session-a').locator('.ai-session-primary-action').click();
+    const acknowledgements = (await postedMessages(page)).filter(message =>
+        message.type === 'acknowledge-ai-session-attention'
+    );
+    assert.deepEqual(acknowledgements, [{
+        type: 'acknowledge-ai-session-attention',
+        eventIds: ['event-a', 'event-b'],
+    }]);
+});
+
+test('ACTIVE-SESSION-INCREMENTAL-PRESENTATION-ENVELOPE-001 closes an OPEN envelope revision against conflicting direct presentation', async t => {
+    const attentionSession = {
+        ...session('codex', 'session-a', true),
+        executionState: 'stopped',
+        status: 'stopped',
+        needsAttention: true,
+        attentionEventId: 'open-event-a',
+    };
+    const otherSession = session('codex', 'session-b', false);
+    const page = await openCardPage(t, [session('codex', 'session-a', true)]);
+    await postHostMessage(page, {
+        type: 'open-workspaces-updated',
+        version: 3,
+        projectionRevision: 2,
+        semanticRevision: 'closed-open-envelope-revision',
+        currentWorkspaceCount: 1,
+        navigationWorkspaceCount: 0,
+        otherWindowsStatus: 'ready',
+        html: `<div class="open-current-workspace-group">${projectMarkup([
+            attentionSession,
+            otherSession,
+        ])}</div>
+            <div class="open-other-windows-group" data-other-windows-status="ready">
+                ${currentOpenWorkspaceProjectMarkup()}
+            </div>`,
+        searchCatalog: {
+            version: 2,
+            sessions: [],
+            openWorkspaces: [{ identity: 'project-a' }],
+            savedProjects: [],
+            todos: [],
+        },
+        presentation: presentationMessage([attentionSession, otherSession], 2, {
+            attention: {
+                'codex:session-a': ['open-event-a', 'open-event-b'],
+            },
+        }),
+    });
+    await postHostMessage(page, presentationMessage([
+        { ...attentionSession, focused: false },
+        { ...otherSession, focused: true },
+    ], 2));
+
+    assert.equal(await row(page, 'codex', 'session-a').getAttribute('data-session-focused'), '');
+    assert.equal(await row(page, 'codex', 'session-b').getAttribute('data-session-focused'), null);
+    assert.equal(await row(page, 'codex', 'session-a').getAttribute('data-ai-session-attention'), '');
+    await row(page, 'codex', 'session-a').locator('.ai-session-primary-action').click();
+    const acknowledgements = (await postedMessages(page)).filter(message =>
+        message.type === 'acknowledge-ai-session-attention'
+    );
+    assert.deepEqual(acknowledgements, [{
+        type: 'acknowledge-ai-session-attention',
+        eventIds: ['open-event-a', 'open-event-b'],
+    }]);
+});
+
 test('ACTIVE-SESSION-INCREMENTAL-PRESENTATION-ENVELOPE-001 rejects an invalid presentation before replacing HTML', async t => {
     const initial = [session('codex', 'session-a', true)];
     const replacement = [session('codex', 'session-b', true)];

--- a/tests/browser/activeSessionCardInteraction.test.js
+++ b/tests/browser/activeSessionCardInteraction.test.js
@@ -913,6 +913,144 @@ test('ACTIVE-SESSION-INCREMENTAL-PRESENTATION-ENVELOPE-001 closes an OPEN envelo
     }]);
 });
 
+test('ACTIVE-SESSION-INCREMENTAL-PRESENTATION-ENVELOPE-001 applies and closes AI envelope after matching direct presentation', async t => {
+    const initialSessions = [
+        session('codex', 'session-a', true),
+        session('codex', 'session-b', false),
+    ];
+    const attentionSession = {
+        ...initialSessions[0],
+        executionState: 'stopped',
+        status: 'stopped',
+        needsAttention: true,
+        attentionEventId: 'event-a',
+    };
+    const otherSession = initialSessions[1];
+    const addedSession = session('codex', 'session-c', false);
+    const conflictingPresentation = presentationMessage([
+        { ...attentionSession, focused: false },
+        { ...otherSession, focused: true },
+    ], 2);
+    const page = await openCardPage(t, initialSessions);
+
+    await postHostMessage(page, conflictingPresentation);
+    assert.equal(await row(page, 'codex', 'session-b').getAttribute('data-session-focused'), '');
+    await postHostMessage(page, {
+        type: 'ai-sessions-updated',
+        version: 3,
+        sequence: 2,
+        projectionRevision: 2,
+        generatedAt: '2026-08-11T00:00:00.000Z',
+        currentWorkspaceCount: 1,
+        html: `<div class="open-current-workspace-group">${projectMarkup([
+            attentionSession,
+            otherSession,
+            addedSession,
+        ])}</div>`,
+        searchCatalog: {
+            version: 2,
+            sessions: [],
+            openWorkspaces: [],
+            savedProjects: [],
+            todos: [],
+        },
+        presentation: presentationMessage([
+            attentionSession,
+            otherSession,
+            addedSession,
+        ], 2, {
+            attention: { 'codex:session-a': ['event-a', 'event-b'] },
+        }),
+    });
+
+    assert.equal(await row(page, 'codex', 'session-c').count(), 1);
+    assert.equal(await row(page, 'codex', 'session-a').getAttribute('data-session-focused'), '');
+    assert.equal(await row(page, 'codex', 'session-b').getAttribute('data-session-focused'), null);
+    await postHostMessage(page, conflictingPresentation);
+    assert.equal(await row(page, 'codex', 'session-a').getAttribute('data-ai-session-attention'), '');
+    assert.equal(await row(page, 'codex', 'session-a').getAttribute('data-session-focused'), '');
+    await row(page, 'codex', 'session-a').locator('.ai-session-primary-action').click();
+    const acknowledgements = (await postedMessages(page)).filter(message =>
+        message.type === 'acknowledge-ai-session-attention'
+    );
+    assert.deepEqual(acknowledgements, [{
+        type: 'acknowledge-ai-session-attention',
+        eventIds: ['event-a', 'event-b'],
+    }]);
+});
+
+test('ACTIVE-SESSION-INCREMENTAL-PRESENTATION-ENVELOPE-001 applies and closes OPEN envelope after matching direct presentation', async t => {
+    const initialSessions = [
+        session('codex', 'session-a', true),
+        session('codex', 'session-b', false),
+    ];
+    const attentionSession = {
+        ...initialSessions[0],
+        executionState: 'stopped',
+        status: 'stopped',
+        needsAttention: true,
+        attentionEventId: 'open-event-a',
+    };
+    const otherSession = initialSessions[1];
+    const addedSession = session('codex', 'session-c', false);
+    const conflictingPresentation = presentationMessage([
+        { ...attentionSession, focused: false },
+        { ...otherSession, focused: true },
+    ], 2);
+    const page = await openCardPage(t, initialSessions);
+
+    await postHostMessage(page, conflictingPresentation);
+    assert.equal(await row(page, 'codex', 'session-b').getAttribute('data-session-focused'), '');
+    await postHostMessage(page, {
+        type: 'open-workspaces-updated',
+        version: 3,
+        projectionRevision: 2,
+        semanticRevision: 'direct-first-open-envelope-revision',
+        currentWorkspaceCount: 1,
+        navigationWorkspaceCount: 0,
+        otherWindowsStatus: 'ready',
+        html: `<div class="open-current-workspace-group">${projectMarkup([
+            attentionSession,
+            otherSession,
+            addedSession,
+        ])}</div>
+            <div class="open-other-windows-group" data-other-windows-status="ready">
+                ${currentOpenWorkspaceProjectMarkup()}
+            </div>`,
+        searchCatalog: {
+            version: 2,
+            sessions: [],
+            openWorkspaces: [{ identity: 'project-a' }],
+            savedProjects: [],
+            todos: [],
+        },
+        presentation: presentationMessage([
+            attentionSession,
+            otherSession,
+            addedSession,
+        ], 2, {
+            attention: {
+                'codex:session-a': ['open-event-a', 'open-event-b'],
+            },
+        }),
+    });
+
+    assert.equal(await row(page, 'codex', 'session-c').count(), 1);
+    assert.equal(await row(page, 'codex', 'session-a').getAttribute('data-session-focused'), '');
+    assert.equal(await row(page, 'codex', 'session-b').getAttribute('data-session-focused'), null);
+    await postHostMessage(page, conflictingPresentation);
+    assert.equal(await row(page, 'codex', 'session-a').getAttribute('data-ai-session-attention'), '');
+    assert.equal(await row(page, 'codex', 'session-a').getAttribute('data-session-focused'), '');
+    await row(page, 'codex', 'session-a').locator('.ai-session-primary-action').click();
+    const acknowledgements = (await postedMessages(page)).filter(message =>
+        message.type === 'acknowledge-ai-session-attention'
+    );
+    assert.deepEqual(acknowledgements, [{
+        type: 'acknowledge-ai-session-attention',
+        eventIds: ['open-event-a', 'open-event-b'],
+    }]);
+});
+
 test('ACTIVE-SESSION-INCREMENTAL-PRESENTATION-ENVELOPE-001 rejects an invalid presentation before replacing HTML', async t => {
     const initial = [session('codex', 'session-a', true)];
     const replacement = [session('codex', 'session-b', true)];

--- a/tests/browser/activeSessionCardInteraction.test.js
+++ b/tests/browser/activeSessionCardInteraction.test.js
@@ -711,6 +711,170 @@ test('ACTIVE-SESSION-PRESENTATION-TRANSACTION-001 keeps OPEN HTML and owner even
     }]);
 });
 
+test('ACTIVE-SESSION-INCREMENTAL-PRESENTATION-ENVELOPE-001 applies AI HTML and complete attention owners from one message', async t => {
+    const attentionSession = {
+        ...session('codex', 'session-a', true),
+        executionState: 'stopped',
+        status: 'stopped',
+        needsAttention: true,
+        attentionEventId: 'event-a',
+    };
+    const page = await openCardPage(t, [session('codex', 'session-a', true)]);
+    await postHostMessage(page, {
+        type: 'ai-sessions-updated',
+        version: 3,
+        sequence: 2,
+        projectionRevision: 2,
+        generatedAt: '2026-08-10T00:00:00.000Z',
+        currentWorkspaceCount: 1,
+        html: `<div class="open-current-workspace-group">${projectMarkup([
+            attentionSession,
+        ])}</div>`,
+        searchCatalog: {
+            version: 2,
+            sessions: [],
+            openWorkspaces: [],
+            savedProjects: [],
+            todos: [],
+        },
+        presentation: presentationMessage([attentionSession], 2, {
+            attention: { 'codex:session-a': ['event-a', 'event-b'] },
+        }),
+    });
+
+    assert.equal(
+        await row(page, 'codex', 'session-a').getAttribute('data-ai-session-attention'),
+        ''
+    );
+    await row(page, 'codex', 'session-a').locator('.ai-session-primary-action').click();
+    const acknowledgements = (await postedMessages(page)).filter(message =>
+        message.type === 'acknowledge-ai-session-attention'
+    );
+    assert.deepEqual(acknowledgements, [{
+        type: 'acknowledge-ai-session-attention',
+        eventIds: ['event-a', 'event-b'],
+    }]);
+});
+
+test('ACTIVE-SESSION-INCREMENTAL-PRESENTATION-ENVELOPE-001 applies OPEN HTML and complete attention owners from one message', async t => {
+    const attentionSession = {
+        ...session('codex', 'session-a', true),
+        executionState: 'stopped',
+        status: 'stopped',
+        needsAttention: true,
+        attentionEventId: 'open-event-a',
+    };
+    const page = await openCardPage(t, [session('codex', 'session-a', true)]);
+    await postHostMessage(page, {
+        type: 'open-workspaces-updated',
+        version: 3,
+        projectionRevision: 2,
+        semanticRevision: 'open-envelope-revision',
+        currentWorkspaceCount: 1,
+        navigationWorkspaceCount: 0,
+        otherWindowsStatus: 'ready',
+        html: `<div class="open-current-workspace-group">${projectMarkup([
+            attentionSession,
+        ])}</div>
+            <div class="open-other-windows-group" data-other-windows-status="ready">
+                ${currentOpenWorkspaceProjectMarkup()}
+            </div>`,
+        searchCatalog: {
+            version: 2,
+            sessions: [],
+            openWorkspaces: [{ identity: 'project-a' }],
+            savedProjects: [],
+            todos: [],
+        },
+        presentation: presentationMessage([attentionSession], 2, {
+            attention: {
+                'codex:session-a': ['open-event-a', 'open-event-b'],
+            },
+        }),
+    });
+
+    assert.equal(
+        await row(page, 'codex', 'session-a').getAttribute('data-ai-session-attention'),
+        ''
+    );
+    await row(page, 'codex', 'session-a').locator('.ai-session-primary-action').click();
+    const acknowledgements = (await postedMessages(page)).filter(message =>
+        message.type === 'acknowledge-ai-session-attention'
+    );
+    assert.deepEqual(acknowledgements, [{
+        type: 'acknowledge-ai-session-attention',
+        eventIds: ['open-event-a', 'open-event-b'],
+    }]);
+});
+
+test('ACTIVE-SESSION-INCREMENTAL-PRESENTATION-ENVELOPE-001 rejects an invalid presentation before replacing HTML', async t => {
+    const initial = [session('codex', 'session-a', true)];
+    const replacement = [session('codex', 'session-b', true)];
+    const page = await openCardPage(t, initial);
+    await postHostMessage(page, {
+        type: 'ai-sessions-updated',
+        version: 3,
+        sequence: 2,
+        projectionRevision: 2,
+        generatedAt: '2026-08-10T00:00:00.000Z',
+        currentWorkspaceCount: 1,
+        html: `<div class="open-current-workspace-group">${projectMarkup(
+            replacement
+        )}</div>`,
+        searchCatalog: {
+            version: 2,
+            sessions: [],
+            openWorkspaces: [],
+            savedProjects: [],
+            todos: [],
+        },
+        presentation: presentationMessage(replacement, 3),
+    });
+
+    assert.equal(await row(page, 'codex', 'session-a').count(), 1);
+    assert.equal(await row(page, 'codex', 'session-b').count(), 0);
+    assert.deepEqual(await postedMessages(page), [{
+        type: 'request-full-refresh',
+        reason: 'invalid-ai-session-presentation-envelope',
+    }]);
+});
+
+test('ACTIVE-SESSION-INCREMENTAL-PRESENTATION-ENVELOPE-001 rejects an invalid OPEN presentation before replacing HTML', async t => {
+    const initial = [session('codex', 'session-a', true)];
+    const replacement = [session('codex', 'session-b', true)];
+    const page = await openCardPage(t, initial);
+    await postHostMessage(page, {
+        type: 'open-workspaces-updated',
+        version: 3,
+        projectionRevision: 2,
+        semanticRevision: 'invalid-open-envelope',
+        currentWorkspaceCount: 1,
+        navigationWorkspaceCount: 0,
+        otherWindowsStatus: 'ready',
+        html: `<div class="open-current-workspace-group">${projectMarkup(
+            replacement
+        )}</div>
+            <div class="open-other-windows-group" data-other-windows-status="ready">
+                ${currentOpenWorkspaceProjectMarkup()}
+            </div>`,
+        searchCatalog: {
+            version: 2,
+            sessions: [],
+            openWorkspaces: [{ identity: 'project-a' }],
+            savedProjects: [],
+            todos: [],
+        },
+        presentation: presentationMessage(replacement, 3),
+    });
+
+    assert.equal(await row(page, 'codex', 'session-a').count(), 1);
+    assert.equal(await row(page, 'codex', 'session-b').count(), 0);
+    assert.deepEqual(await postedMessages(page), [{
+        type: 'request-full-refresh',
+        reason: 'invalid-open-workspaces-presentation-envelope',
+    }]);
+});
+
 test('ACTIVE-SESSION-FULL-RENDER-TRANSACTION-001 seeds the full document revision and complete attention owners', async t => {
     const attentionSession = {
         ...session('codex', 'session-a', true),

--- a/tests/contract/openProjects/dashboardController.test.js
+++ b/tests/contract/openProjects/dashboardController.test.js
@@ -109,7 +109,20 @@ test('OPEN-OPEN-PROJECT-DASHBOARD-CONTROLLER-001 posts each semantic revision on
 });
 
 test('ACTIVE-SESSION-PRESENTATION-TRANSACTION-001 OPEN updates hydrate and publish one projection transaction', async () => {
-    const transaction = { revision: 41, marker: 'open-workspaces-transaction' };
+    const transaction = {
+        revision: 41,
+        marker: 'open-workspaces-transaction',
+        presentation: {
+            workspaceScopeIdentity: null,
+            workspaceNavigationIdentity: null,
+            attentionCount: 0,
+            activeAttentionCount: 0,
+            runningSessionCount: 0,
+            focusedTarget: null,
+            attentionSessions: [],
+            sessions: [],
+        },
+    };
     const posted = [];
     let hydrationProjection = null;
     const controller = new OpenWorkspaceDashboardController(createOptions({
@@ -129,6 +142,8 @@ test('ACTIVE-SESSION-PRESENTATION-TRANSACTION-001 OPEN updates hydrate and publi
     assert.equal(hydrationProjection, transaction);
     assert.equal(posted.length, 1);
     assert.equal(posted[0].projectionRevision, transaction.revision);
+    assert.equal(posted[0].presentation.projectionRevision, transaction.revision);
+    assert.equal(posted[0].version, 3);
 });
 
 test('WEBVIEW-SIDEBAR-VISIBILITY-RETENTION-001 coalesces rapid OPEN revisions behind one delivery', async () => {

--- a/tests/integration/dashboard/helpers/terminalCloseHarness.js
+++ b/tests/integration/dashboard/helpers/terminalCloseHarness.js
@@ -147,9 +147,17 @@ const mutations = {
         scenario: 'attention-state-order',
         transform: source => replaceOnce(
             source,
-            'postAiSessionPresentationState(false, transaction);',
-            '',
-            'presentation transaction publication',
+            'currentAiSessionRefreshReason = reason;\n'
+                + '                        const transaction = aiSessionProjectionCoordinator.captureNext(getCurrentOpenWorkspace());\n'
+                + '                        return transaction;\n'
+                + '                    },\n'
+                + '                    postMessage: message => provider.postMessage(message),',
+            'currentAiSessionRefreshReason = reason;\n'
+                + '                        const transaction = aiSessionProjectionCoordinator.captureNext(getCurrentOpenWorkspace());\n'
+                + '                        return transaction;\n'
+                + '                    },\n'
+                + '                    postMessage: message => provider.postMessage(Object.assign({}, message, { presentation: undefined })),',
+            'presentation envelope publication',
         ),
     },
     'aggregate-auto-acknowledge': {
@@ -422,17 +430,18 @@ async function runTerminalCloseContract(transform = source => source, scenario =
                 'incremental AI-session render after the active terminal change',
             );
             const renderedMessages = postedMessages.slice(messageMark);
-            const presentationStateIndex = renderedMessages
-                .findIndex(message => message && message.type === 'ai-session-presentation-state');
             const updateIndex = renderedMessages
                 .findIndex(message => message && message.type === 'ai-sessions-updated');
-            assert.ok(presentationStateIndex >= 0,
-                'WEBVIEW-AI-SESSION-DASHBOARD-CONTROLLER-001 every incremental render must publish the current presentation snapshot');
-            assert.ok(updateIndex > presentationStateIndex,
-                'WEBVIEW-AI-SESSION-DASHBOARD-CONTROLLER-001 the presentation snapshot must reach the webview before the HTML update');
-            assert.deepEqual(renderedMessages[presentationStateIndex].attentionSessions, [],
-                'WEBVIEW-AI-SESSION-DASHBOARD-CONTROLLER-001 the snapshot must not revive stale Attention owners');
-            assert.equal(renderedMessages[presentationStateIndex].attentionCount, 0);
+            assert.ok(updateIndex >= 0);
+            const update = renderedMessages[updateIndex];
+            assert.equal(update.version, 3);
+            assert.ok(update.presentation,
+                'WEBVIEW-AI-SESSION-DASHBOARD-CONTROLLER-001 every incremental render must publish one coherent presentation envelope');
+            assert.equal(update.presentation.projectionRevision, update.projectionRevision,
+                'WEBVIEW-AI-SESSION-DASHBOARD-CONTROLLER-001 every incremental render must publish one coherent presentation envelope');
+            assert.deepEqual(update.presentation.attentionSessions, [],
+                'WEBVIEW-AI-SESSION-DASHBOARD-CONTROLLER-001 the envelope must not revive stale Attention owners');
+            assert.equal(update.presentation.attentionCount, 0);
             return calls;
         }
 

--- a/tests/integration/dashboard/sessionRuntimeFlow.test.js
+++ b/tests/integration/dashboard/sessionRuntimeFlow.test.js
@@ -14,6 +14,28 @@ const {
     projectWorkspaceActiveSessions,
 } = require('../../../out/workspaces/activeSessionPresentation');
 
+function makeProjection(revision, eventIds = []) {
+    return {
+        revision,
+        presentation: {
+            workspaceScopeIdentity: 'scope:app',
+            workspaceNavigationIdentity: 'navigation:app',
+            attentionCount: eventIds.length ? 1 : 0,
+            activeAttentionCount: eventIds.length ? 1 : 0,
+            runningSessionCount: 0,
+            focusedTarget: { provider: 'codex', sessionId: 'session-a' },
+            attentionSessions: eventIds.length
+                ? [{ sessionKey: 'codex:session-a', eventIds }]
+                : [],
+            sessions: [{
+                provider: 'codex', sessionId: 'session-a',
+                executionState: 'stopped', focused: true,
+                needsAttention: eventIds.length > 0, conflict: false, eventIds,
+            }],
+        },
+    };
+}
+
 test('PROJECT-TERMINAL-CANDIDATE-001 reads provider sessions through the terminal-candidate cache reason', () => {
     const sessions = [{ id: 'candidate', name: 'Candidate' }];
     const calls = [];
@@ -409,7 +431,10 @@ test('ACTIVE-SESSION-PRESENTATION-TRANSACTION-001 builds cards and HTML with one
     const { AiSessionDashboardController } = loadFreshWithFakeVscode(
         '../../../out/aiSessions/dashboardController', {}, __dirname
     );
-    const projection = { revision: 17, marker: 'same-transaction' };
+    const projection = {
+        ...makeProjection(17),
+        marker: 'same-transaction',
+    };
     let cardsProjection = null;
     let completed = 0;
     const controller = new AiSessionDashboardController({
@@ -438,7 +463,42 @@ test('ACTIVE-SESSION-PRESENTATION-TRANSACTION-001 builds cards and HTML with one
     const message = controller.getUpdatedMessage('transaction-test');
     assert.equal(cardsProjection, projection);
     assert.equal(message.sequence, projection.revision);
+    assert.equal(message.projectionRevision, projection.revision);
+    assert.equal(message.presentation.projectionRevision, projection.revision);
+    assert.equal(message.version, 3);
     assert.equal(completed, 1);
+});
+
+test('ACTIVE-SESSION-INCREMENTAL-PRESENTATION-ENVELOPE-001 posts changed owner events even when rendered HTML is unchanged', async () => {
+    const deliveries = [];
+    let projection = makeProjection(1, ['event-a']);
+    const { AiSessionDashboardController } = loadFreshWithFakeVscode(
+        '../../../out/aiSessions/dashboardController', {}, __dirname
+    );
+    const controller = new AiSessionDashboardController({
+        providerIds: ['codex'], isVisible: () => true,
+        invalidateCache: () => undefined,
+        watchSessionChanges: () => ({ dispose() {} }),
+        getGroups: () => [], getTodoSearchItems: () => [], getCards: () => [],
+        getRunningCardAnimation: () => undefined,
+        getRunningIconAnimation: () => undefined,
+        beginProjection: () => projection,
+        postMessage: message => { deliveries.push(message); return Promise.resolve(true); },
+        refresh: () => undefined,
+        logError: (_message, error) => { throw error; },
+        debounceMs: 1, newSessionRefreshDelaysMs: [],
+        setTimeout: callback => { callback(); return {}; }, clearTimeout: () => undefined,
+    });
+
+    await controller.refreshNow('attention');
+    projection = makeProjection(2, ['event-a', 'event-b']);
+    await controller.refreshNow('attention');
+
+    assert.equal(deliveries.length, 2);
+    assert.deepEqual(
+        deliveries[1].presentation.attentionSessions[0].eventIds,
+        ['event-a', 'event-b']
+    );
 });
 
 test('WEBVIEW-SIDEBAR-VISIBILITY-RETENTION-001 reuses provider watchers across rapid sidebar visibility changes', () => {

--- a/tests/integration/dashboard/terminalCloseWiring.test.js
+++ b/tests/integration/dashboard/terminalCloseWiring.test.js
@@ -39,14 +39,14 @@ test('ATTENTION-USER-TERMINAL-CLOSE-001 controlled bridge-first acknowledgement 
         /must be awaited only after the local refresh/);
 });
 
-test('WEBVIEW-AI-SESSION-DASHBOARD-CONTROLLER-001 presentation publication precedes the incremental render', async () => {
+test('WEBVIEW-AI-SESSION-DASHBOARD-CONTROLLER-001 presentation ships inside the incremental render envelope', async () => {
     await execFile(process.execPath, [harnessPath, 'attention-state-order'], { env: harnessEnvironment() });
 });
 
-test('WEBVIEW-AI-SESSION-DASHBOARD-CONTROLLER-001 controlled render-before-presentation mutation is rejected', async () => {
+test('WEBVIEW-AI-SESSION-DASHBOARD-CONTROLLER-001 controlled missing envelope presentation is rejected', async () => {
     await assert.rejects(
         execFile(process.execPath, [harnessPath, 'mutation:attention-state-before-render'], { env: harnessEnvironment() }),
-        /must publish the current presentation snapshot/);
+        /must publish one coherent presentation envelope/);
 });
 
 test('ATTENTION-PRODUCTION-ATTENTION-BRIDGE-INTEGRATION-001 remote aggregate schedules a refresh without auto-acknowledging', async () => {

--- a/tests/integration/dashboard/webviewState.test.js
+++ b/tests/integration/dashboard/webviewState.test.js
@@ -486,14 +486,22 @@ test('TODO-TODO-SEARCH-RESULT-RENDERING-001 locks catalog v2 section order and a
 test('WEBVIEW-DASHBOARD-UPDATE-MESSAGE-001 preserves TODO catalog entries in incremental messages', () => {
     const todoSearchItems = makeCatalog().todos;
     const cards = [makeWorkspaceCard()];
+    const presentation = {
+        type: 'ai-session-presentation-state', version: 1, projectionRevision: 1,
+        workspaceScopeIdentity: null, workspaceNavigationIdentity: null,
+        attentionCount: 0, activeAttentionCount: 0, runningSessionCount: 0,
+        runningCardAnimation: 'current', runningIconAnimation: 'current',
+        revealFocused: false, focusedTarget: null, attentionSessions: [], sessions: [],
+    };
     const openMessage = webviewModules.updateMessages.buildOpenWorkspacesUpdatedMessage({
         groups: [], cards: [], collapsed: false,
         semanticRevision: 'revision', projectionRevision: 1,
-        otherWindowsStatus: 'ready', todoSearchItems,
+        otherWindowsStatus: 'ready', todoSearchItems, presentation,
     });
     const sessionsMessage = webviewModules.updateMessages.buildAiSessionsUpdatedMessage({
         groups: [], cards: [], sequence: 7, generatedAt: NOW,
         cards, todoSearchItems,
+        presentation: { ...presentation, projectionRevision: 7 },
     });
     assert.deepEqual(openMessage.searchCatalog.todos, todoSearchItems);
     assert.deepEqual(sessionsMessage.searchCatalog.todos, todoSearchItems);

--- a/tests/unit/tooling/architectureGuards.test.js
+++ b/tests/unit/tooling/architectureGuards.test.js
@@ -727,11 +727,21 @@ for (const mutation of [
     {
         id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
         file: 'src/webview/webviewProjectAiUpdateScripts.js',
-        expectedDetail: 'Webview must accept one same-revision direct Presentation after HTML',
+        expectedDetail: 'Webview must close v3 envelopes while preserving v2 same-revision Presentation',
         mutate: source => replaceFixtureSource(
             source,
             'revision <= latestAiSessionDirectPresentationRevision',
             'revision < latestAiSessionDirectPresentationRevision'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectAiUpdateScripts.js',
+        expectedDetail: 'Webview must close v3 envelopes while preserving v2 same-revision Presentation',
+        mutate: source => replaceFixtureSource(
+            source,
+            'revision <= latestAiSessionClosedPresentationRevision',
+            'revision < latestAiSessionClosedPresentationRevision'
         ),
     },
     {
@@ -762,6 +772,26 @@ for (const mutation of [
             source,
             'message.presentation.projectionRevision !== message.projectionRevision',
             'message.presentation.projectionRevision < message.projectionRevision'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectAiUpdateScripts.js',
+        expectedDetail: 'Webview must validate and apply each HTML-Presentation envelope atomically',
+        mutate: source => replaceFixtureSource(
+            source,
+            'adoptRenderedPresentation,\n            isAtomicEnvelope',
+            'adoptRenderedPresentation,\n            false'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectScripts.js',
+        expectedDetail: 'Webview must validate and apply each HTML-Presentation envelope atomically',
+        mutate: source => replaceFixtureSource(
+            source,
+            'adoptOpenWorkspacePresentation,\n                isAtomicOpenWorkspacesEnvelope',
+            'adoptOpenWorkspacePresentation,\n                false'
         ),
     },
     {

--- a/tests/unit/tooling/architectureGuards.test.js
+++ b/tests/unit/tooling/architectureGuards.test.js
@@ -28,6 +28,7 @@ function copyGuardFixture(t, mutationPath, mutate = source => source) {
         'src/workspaces/sessionHydrationController.ts',
         'src/workspaces/sessionHydration.ts',
         'src/aiSessions/dashboardController.ts',
+        'src/aiSessions/presentationMessage.ts',
         'src/aiSessions/providers.ts',
         'src/aiSessions/conversation/types.ts',
         'src/aiSessions/conversation/diffs.ts',
@@ -736,7 +737,7 @@ for (const mutation of [
     {
         id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
         file: 'src/openWorkspaces/dashboardController.ts',
-        expectedDetail: 'OPEN HTML must capture, hydrate, and publish the same Presentation transaction',
+        expectedDetail: 'OPEN HTML and Presentation must share one Host message',
         mutate: source => replaceFixtureSource(
             source,
             'cards: this.getCards(projection)',
@@ -745,12 +746,32 @@ for (const mutation of [
     },
     {
         id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/aiSessions/dashboardController.ts',
+        expectedDetail: 'AI incremental HTML and Presentation must share one Host message',
+        mutate: source => replaceFixtureSource(
+            source,
+            'presentation: buildAiSessionPresentationState(',
+            'detachedPresentation: buildAiSessionPresentationState('
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectAiUpdateScripts.js',
+        expectedDetail: 'Webview must validate and apply each HTML-Presentation envelope atomically',
+        mutate: source => replaceFixtureSource(
+            source,
+            'message.presentation.projectionRevision !== message.projectionRevision',
+            'message.presentation.projectionRevision < message.projectionRevision'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
         file: 'src/dashboard.ts',
         expectedDetail: 'full Dashboard document must capture and embed one Presentation transaction',
         mutate: source => replaceFixtureSource(
             source,
-            'buildAiSessionPresentationState(false, transaction),',
-            'undefined,'
+            'getOpenWorkspaceCards(transaction),',
+            'getOpenWorkspaceCards(),'
         ),
     },
     {

--- a/tests/unit/tooling/architectureGuards.test.js
+++ b/tests/unit/tooling/architectureGuards.test.js
@@ -746,6 +746,16 @@ for (const mutation of [
     },
     {
         id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectAiUpdateScripts.js',
+        expectedDetail: 'Webview must close v3 envelopes while preserving v2 same-revision Presentation',
+        mutate: source => replaceFixtureSource(
+            source,
+            'revision >= latestAiSessionPresentationProjectionRevision',
+            'revision > latestAiSessionPresentationProjectionRevision'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
         file: 'src/openWorkspaces/dashboardController.ts',
         expectedDetail: 'OPEN HTML and Presentation must share one Host message',
         mutate: source => replaceFixtureSource(
@@ -786,12 +796,32 @@ for (const mutation of [
     },
     {
         id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectAiUpdateScripts.js',
+        expectedDetail: 'Webview must validate and apply each HTML-Presentation envelope atomically',
+        mutate: source => replaceFixtureSource(
+            source,
+            '? canApplyAtomicPresentationProjectionRevision(message.projectionRevision)',
+            '? canApplyPresentationProjectionRevision(message.projectionRevision)'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
         file: 'src/webview/webviewProjectScripts.js',
         expectedDetail: 'Webview must validate and apply each HTML-Presentation envelope atomically',
         mutate: source => replaceFixtureSource(
             source,
             'adoptOpenWorkspacePresentation,\n                isAtomicOpenWorkspacesEnvelope',
             'adoptOpenWorkspacePresentation,\n                false'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectScripts.js',
+        expectedDetail: 'Webview must validate and apply each HTML-Presentation envelope atomically',
+        mutate: source => replaceFixtureSource(
+            source,
+            '? aiSessionsUpdate.canApplyAtomicPresentationProjectionRevision(',
+            '? aiSessionsUpdate.canApplyPresentationProjectionRevision('
         ),
     },
     {


### PR DESCRIPTION
## Summary

- publish AI Sessions and Open Workspaces incremental HTML, search data, and complete session presentation as one versioned v3 envelope
- validate the complete envelope before replacing Webview HTML and preserve v2 compatibility
- close adopted presentation revisions so delayed or reordered direct presentation messages cannot overwrite authoritative focus, running, or attention state
- cover both envelope-first and presentation-first delivery orders for AI Sessions and Open Workspaces

## Testing

- `npm run test-compile`
- focused browser presentation-envelope tests: 10/10
- architecture guards: 82/82
- deterministic suites: 2009/2009
- browser suite: 195/195
- AI session, Open Workspace, and Dashboard Webview safety checks
- `npm run test:behavior-contracts`: 41/41 plus release journeys 4/4
- exact-SHA independent review and validation

## Skill harvest

No skill change was justified. Existing resilient Webview protocol guidance already requires atomic authoritative replacement and stale/out-of-order rejection; this change adds product-level regression tests and mutation guards for the missing implementation behavior.