### PR TITLE
Refactor attention acknowledgements into correlated transactions

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -4109,14 +4109,18 @@
   {
     "id": "ATTENTION-SESSION-CARD-ACKNOWLEDGEMENT-001",
     "domain": "attention",
-    "title": "Clicking a stopped Active Session card acknowledges every authoritative owner event and clears all Dashboard attention surfaces without stale bridge resurrection",
+    "title": "A stopped Active Session card clears attention through one correlated authoritative acknowledgement transaction",
     "priority": "P0",
     "status": "automated",
     "owners": [
-      "tests/browser/activeSessionCardInteraction.test.js"
+      "tests/browser/activeSessionCardInteraction.test.js",
+      "tests/contract/aiSessions/attentionEventCapability.test.js",
+      "tests/contract/dashboard/messageHandlers.test.js",
+      "tests/integration/dashboard/productionAttentionBridge.test.js"
     ],
     "evidence": [
       "src/dashboard/messageHandlers.ts",
+      "src/aiSessions/attentionBridgeClient.ts",
       "src/aiSessions/attentionEventCapability.ts",
       "src/aiSessions/attentionController.ts",
       "src/aiSessions/dashboardController.ts",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "25387e0263a57236e6706446f8ed8d92f1a3827e",
+        "head": "47cb385c19b44554d7598f081caf38ffb873cf36",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -268,7 +268,8 @@
             "23b03b8d4e540b534452dfa03ebc5608a667a260",
             "a514850f0b36137007a6e25aca0e093114aaa5cd",
             "aed096b76c6458b956a0749528d68c634381fb55",
-            "2798f545688f46f633d18a95d20f16400f13db27"
+            "2798f545688f46f633d18a95d20f16400f13db27",
+            "639b4b720bb2987becc200334d21944b71d61598"
         ]
     },
     "capabilities": [
@@ -921,7 +922,8 @@
                 "9387594a7a8a9310621f5da0fa675e0fe90564fa",
                 "c39b9f1d5a38563194b6d4423e91f89c4897212d",
                 "fe852b6268c76ca437c49b628189ae1439bce0f3",
-                "464afaaa5924f5834da6ec428c5f805e05514093"
+                "464afaaa5924f5834da6ec428c5f805e05514093",
+                "47cb385c19b44554d7598f081caf38ffb873cf36"
             ],
             "behaviors": [
                 "ATTENTION-ACTIVE-UNREGISTER-ON-DEACTIVATE-001",

--- a/media/webviewDashboardBundle.js
+++ b/media/webviewDashboardBundle.js
@@ -1979,6 +1979,8 @@ function initProjectAiSessionControls(options) {
     var activeAiSessionTerminalState = { provider: null, sessionId: null, pendingId: null };
     var nextAiSessionBatchArchiveRequestId = 0;
     var nextAiSessionProviderSelectionRequestId = 0;
+    var nextAiSessionAttentionAcknowledgementRequestId = 0;
+    var pendingAiSessionAttentionAcknowledgements = new Map();
     var pendingAiSessionProviderSelectionProjectId = null;
     var pendingAiSessionProviderSelectionRequestId = null;
     var pendingAiSessionProviderSelectionProviders = [];
@@ -2318,8 +2320,164 @@ function initProjectAiSessionControls(options) {
         }
         eventIds = Array.from(new Set(eventIds.filter(eventId => typeof eventId === 'string' && !!eventId)));
         if (eventIds.length) {
-            window.vscode.postMessage({ type: 'acknowledge-ai-session-attention', eventIds: eventIds });
+            var presentation = window.__agentPivotAiSessionPresentationState;
+            if (!presentation
+                || presentation.type !== 'ai-session-presentation-state'
+                || presentation.version !== 1
+                || !Number.isSafeInteger(presentation.projectionRevision)
+                || presentation.projectionRevision < 1
+                || typeof presentation.workspaceScopeIdentity !== 'string'
+                || !presentation.workspaceScopeIdentity) {
+                window.vscode.postMessage({ type: 'acknowledge-ai-session-attention', eventIds: eventIds });
+                return;
+            }
+            var pendingKey = presentation.workspaceScopeIdentity + '|' + sessionKey;
+            if (pendingAiSessionAttentionAcknowledgements.has(pendingKey)) return;
+            nextAiSessionAttentionAcknowledgementRequestId =
+                nextAiSessionAttentionAcknowledgementRequestId >= Number.MAX_SAFE_INTEGER
+                    ? 1 : nextAiSessionAttentionAcknowledgementRequestId + 1;
+            var pending = {
+                requestId: nextAiSessionAttentionAcknowledgementRequestId,
+                provider: provider,
+                sessionId: sessionId,
+                workspaceScopeIdentity: presentation.workspaceScopeIdentity,
+                projectionRevision: presentation.projectionRevision,
+                eventIds: eventIds.slice(),
+                committed: false,
+                timeoutHandle: null,
+            };
+            if (typeof window.setTimeout === 'function') {
+                pending.timeoutHandle = window.setTimeout(() => {
+                    if (pendingAiSessionAttentionAcknowledgements.get(pendingKey) !== pending) return;
+                    var currentPresentation = window.__agentPivotAiSessionPresentationState;
+                    if (!currentPresentation
+                        || currentPresentation.workspaceScopeIdentity
+                            !== pending.workspaceScopeIdentity) {
+                        clearAiSessionAttentionAcknowledgement(pendingKey, pending);
+                        return;
+                    }
+                    clearAiSessionAttentionAcknowledgement(pendingKey, pending);
+                    announceAiSessionAttentionAcknowledgement(
+                        pending,
+                        'Attention update timed out. Refreshing…'
+                    );
+                    getAiSessionsUpdate().requestFullRefresh('ai-session-attention-acknowledgement-timeout');
+                }, Number.isSafeInteger(window.__agentPivotAttentionAcknowledgementTimeoutMs)
+                    && window.__agentPivotAttentionAcknowledgementTimeoutMs > 0
+                    ? window.__agentPivotAttentionAcknowledgementTimeoutMs : 15_000);
+            }
+            pendingAiSessionAttentionAcknowledgements.set(pendingKey, pending);
+            syncAiSessionAttentionAcknowledgementDom();
+            window.vscode.postMessage({
+                type: 'acknowledge-ai-session-attention',
+                version: 1,
+                requestId: pending.requestId,
+                provider: provider,
+                sessionId: sessionId,
+                workspaceScopeIdentity: pending.workspaceScopeIdentity,
+                projectionRevision: pending.projectionRevision,
+                eventIds: pending.eventIds,
+            });
         }
+    }
+
+    function clearAiSessionAttentionAcknowledgement(sessionKey, pending) {
+        if (pendingAiSessionAttentionAcknowledgements.get(sessionKey) !== pending) return;
+        if (pending.timeoutHandle !== null && typeof window.clearTimeout === 'function') {
+            window.clearTimeout(pending.timeoutHandle);
+        }
+        pendingAiSessionAttentionAcknowledgements.delete(sessionKey);
+        syncAiSessionAttentionAcknowledgementDom();
+    }
+
+    function announceAiSessionAttentionAcknowledgement(pending, message) {
+        var presentation = window.__agentPivotAiSessionPresentationState;
+        if (!presentation
+            || presentation.workspaceScopeIdentity !== pending.workspaceScopeIdentity) return;
+        var row = document.querySelector(
+            '.codex-session-row[data-session-provider="' + pending.provider
+                + '"][data-session-id="' + CSS.escape(pending.sessionId) + '"]'
+        );
+        var project = row && row.closest('.workspace-card[data-current-workspace]');
+        var liveRegion = project && project.querySelector('[data-ai-session-live-region]');
+        if (liveRegion) liveRegion.textContent = message;
+    }
+
+    function syncAiSessionAttentionAcknowledgementDom() {
+        document.querySelectorAll('.codex-session-row[data-attention-acknowledgement-pending]')
+            .forEach(row => row.removeAttribute('data-attention-acknowledgement-pending'));
+        var presentation = window.__agentPivotAiSessionPresentationState;
+        pendingAiSessionAttentionAcknowledgements.forEach(pending => {
+            if (!presentation
+                || presentation.workspaceScopeIdentity !== pending.workspaceScopeIdentity) return;
+            document.querySelectorAll('.codex-session-row[data-session-provider][data-session-id]')
+                .forEach(row => {
+                    if (row.getAttribute('data-session-provider') === pending.provider
+                        && row.getAttribute('data-session-id') === pending.sessionId) {
+                        row.setAttribute('data-attention-acknowledgement-pending', '');
+                    }
+                });
+        });
+    }
+
+    function reconcileAiSessionAttentionAcknowledgements(presentation) {
+        if (!presentation || presentation.type !== 'ai-session-presentation-state') return;
+        pendingAiSessionAttentionAcknowledgements.forEach((pending, pendingKey) => {
+            if (presentation.workspaceScopeIdentity !== pending.workspaceScopeIdentity) {
+                clearAiSessionAttentionAcknowledgement(pendingKey, pending);
+                return;
+            }
+            if (!pending.committed
+                || presentation.projectionRevision < pending.projectionRevision) return;
+            var ownerSessionKey = pending.provider + ':' + pending.sessionId;
+            var owner = presentation.attentionSessions.find(session =>
+                session && session.sessionKey === ownerSessionKey
+            );
+            var currentEventIds = owner && Array.isArray(owner.eventIds) ? owner.eventIds : [];
+            if (pending.eventIds.some(eventId => currentEventIds.includes(eventId))) return;
+            clearAiSessionAttentionAcknowledgement(pendingKey, pending);
+        });
+        syncAiSessionAttentionAcknowledgementDom();
+    }
+
+    function applyAiSessionAttentionAcknowledgementResult(message) {
+        if (!message
+            || Object.keys(message).sort().join('\n') !== [
+                'outcome', 'projectionRevision', 'provider', 'requestId', 'sessionId',
+                'type', 'version', 'workspaceScopeIdentity',
+            ].sort().join('\n')
+            || message.type !== 'ai-session-attention-acknowledgement-result'
+            || message.version !== 1
+            || !Number.isSafeInteger(message.requestId) || message.requestId < 1
+            || !isAiSessionProvider(message.provider)
+            || typeof message.sessionId !== 'string' || !message.sessionId
+            || typeof message.workspaceScopeIdentity !== 'string' || !message.workspaceScopeIdentity
+            || !Number.isSafeInteger(message.projectionRevision) || message.projectionRevision < 1
+            || !['committed', 'degraded-local', 'rejected'].includes(message.outcome)) {
+            return false;
+        }
+        var pendingKey = message.workspaceScopeIdentity + '|'
+            + message.provider + ':' + message.sessionId;
+        var pending = pendingAiSessionAttentionAcknowledgements.get(pendingKey);
+        if (!pending
+            || pending.requestId !== message.requestId
+            || pending.workspaceScopeIdentity !== message.workspaceScopeIdentity
+            || pending.projectionRevision !== message.projectionRevision) return true;
+        if (message.outcome === 'committed') {
+            pending.committed = true;
+            reconcileAiSessionAttentionAcknowledgements(
+                window.__agentPivotAiSessionPresentationState
+            );
+            return true;
+        }
+        clearAiSessionAttentionAcknowledgement(pendingKey, pending);
+        announceAiSessionAttentionAcknowledgement(
+            pending,
+            message.outcome === 'degraded-local'
+                ? 'Attention cleared in this window, but cross-window sync could not be confirmed.'
+                : 'Could not clear session attention. Try again.'
+        );
+        return true;
     }
 
     window.__agentPivotAcknowledgeSession = (provider, sessionId) => {
@@ -2648,6 +2806,7 @@ function initProjectAiSessionControls(options) {
         batchAiSessionManager: batchAiSessionManager,
         batchAiSessionState: batchAiSessionState,
         activeAiSessionTerminalState: activeAiSessionTerminalState,
+        applyAiSessionAttentionAcknowledgementResult: applyAiSessionAttentionAcknowledgementResult,
         getPendingAiSessionProviderSelectionProjectId: getPendingAiSessionProviderSelectionProjectId,
         activateAiSessionProviderOption: activateAiSessionProviderOption,
         applyAiSessionProviderSelectionResult: applyAiSessionProviderSelectionResult,
@@ -2661,6 +2820,7 @@ function initProjectAiSessionControls(options) {
         isAiSessionProvider: isAiSessionProvider,
         onTriggerAiSessionAction: onTriggerAiSessionAction,
         reconcilePendingAiSessionProviderSelectionDom: reconcilePendingAiSessionProviderSelectionDom,
+        reconcileAiSessionAttentionAcknowledgements: reconcileAiSessionAttentionAcknowledgements,
         setAiSessionProviderMenuOpen: setAiSessionProviderMenuOpen,
         submitAiSessionProviderSelection: submitAiSessionProviderSelection,
         syncActiveAiSessionTerminalDom: syncActiveAiSessionTerminalDom,
@@ -3323,6 +3483,7 @@ function initProjects() {
     function applyValidatedAiSessionPresentationState(message) {
         window.__agentPivotAiSessionPresentationState = message;
         applyAiSessionPresentationDom(message);
+        aiSessionControls.reconcileAiSessionAttentionAcknowledgements(message);
     }
 
     function readInitialAiSessionPresentationState() {
@@ -3470,6 +3631,10 @@ function initProjects() {
         }
         if (message && message.type === 'ai-session-provider-selection-result') {
             aiSessionControls.applyAiSessionProviderSelectionResult(message);
+            return;
+        }
+        if (message && message.type === 'ai-session-attention-acknowledgement-result') {
+            aiSessionControls.applyAiSessionAttentionAcknowledgementResult(message);
             return;
         }
         if (message && (message.type === 'todo-panel-content' || message.type === 'todo-panel-updated')) {

--- a/media/webviewProjectAiSessionControlsScripts.js
+++ b/media/webviewProjectAiSessionControlsScripts.js
@@ -14,6 +14,8 @@ function initProjectAiSessionControls(options) {
     var activeAiSessionTerminalState = { provider: null, sessionId: null, pendingId: null };
     var nextAiSessionBatchArchiveRequestId = 0;
     var nextAiSessionProviderSelectionRequestId = 0;
+    var nextAiSessionAttentionAcknowledgementRequestId = 0;
+    var pendingAiSessionAttentionAcknowledgements = new Map();
     var pendingAiSessionProviderSelectionProjectId = null;
     var pendingAiSessionProviderSelectionRequestId = null;
     var pendingAiSessionProviderSelectionProviders = [];
@@ -353,8 +355,164 @@ function initProjectAiSessionControls(options) {
         }
         eventIds = Array.from(new Set(eventIds.filter(eventId => typeof eventId === 'string' && !!eventId)));
         if (eventIds.length) {
-            window.vscode.postMessage({ type: 'acknowledge-ai-session-attention', eventIds: eventIds });
+            var presentation = window.__agentPivotAiSessionPresentationState;
+            if (!presentation
+                || presentation.type !== 'ai-session-presentation-state'
+                || presentation.version !== 1
+                || !Number.isSafeInteger(presentation.projectionRevision)
+                || presentation.projectionRevision < 1
+                || typeof presentation.workspaceScopeIdentity !== 'string'
+                || !presentation.workspaceScopeIdentity) {
+                window.vscode.postMessage({ type: 'acknowledge-ai-session-attention', eventIds: eventIds });
+                return;
+            }
+            var pendingKey = presentation.workspaceScopeIdentity + '|' + sessionKey;
+            if (pendingAiSessionAttentionAcknowledgements.has(pendingKey)) return;
+            nextAiSessionAttentionAcknowledgementRequestId =
+                nextAiSessionAttentionAcknowledgementRequestId >= Number.MAX_SAFE_INTEGER
+                    ? 1 : nextAiSessionAttentionAcknowledgementRequestId + 1;
+            var pending = {
+                requestId: nextAiSessionAttentionAcknowledgementRequestId,
+                provider: provider,
+                sessionId: sessionId,
+                workspaceScopeIdentity: presentation.workspaceScopeIdentity,
+                projectionRevision: presentation.projectionRevision,
+                eventIds: eventIds.slice(),
+                committed: false,
+                timeoutHandle: null,
+            };
+            if (typeof window.setTimeout === 'function') {
+                pending.timeoutHandle = window.setTimeout(() => {
+                    if (pendingAiSessionAttentionAcknowledgements.get(pendingKey) !== pending) return;
+                    var currentPresentation = window.__agentPivotAiSessionPresentationState;
+                    if (!currentPresentation
+                        || currentPresentation.workspaceScopeIdentity
+                            !== pending.workspaceScopeIdentity) {
+                        clearAiSessionAttentionAcknowledgement(pendingKey, pending);
+                        return;
+                    }
+                    clearAiSessionAttentionAcknowledgement(pendingKey, pending);
+                    announceAiSessionAttentionAcknowledgement(
+                        pending,
+                        'Attention update timed out. Refreshing…'
+                    );
+                    getAiSessionsUpdate().requestFullRefresh('ai-session-attention-acknowledgement-timeout');
+                }, Number.isSafeInteger(window.__agentPivotAttentionAcknowledgementTimeoutMs)
+                    && window.__agentPivotAttentionAcknowledgementTimeoutMs > 0
+                    ? window.__agentPivotAttentionAcknowledgementTimeoutMs : 15_000);
+            }
+            pendingAiSessionAttentionAcknowledgements.set(pendingKey, pending);
+            syncAiSessionAttentionAcknowledgementDom();
+            window.vscode.postMessage({
+                type: 'acknowledge-ai-session-attention',
+                version: 1,
+                requestId: pending.requestId,
+                provider: provider,
+                sessionId: sessionId,
+                workspaceScopeIdentity: pending.workspaceScopeIdentity,
+                projectionRevision: pending.projectionRevision,
+                eventIds: pending.eventIds,
+            });
         }
+    }
+
+    function clearAiSessionAttentionAcknowledgement(sessionKey, pending) {
+        if (pendingAiSessionAttentionAcknowledgements.get(sessionKey) !== pending) return;
+        if (pending.timeoutHandle !== null && typeof window.clearTimeout === 'function') {
+            window.clearTimeout(pending.timeoutHandle);
+        }
+        pendingAiSessionAttentionAcknowledgements.delete(sessionKey);
+        syncAiSessionAttentionAcknowledgementDom();
+    }
+
+    function announceAiSessionAttentionAcknowledgement(pending, message) {
+        var presentation = window.__agentPivotAiSessionPresentationState;
+        if (!presentation
+            || presentation.workspaceScopeIdentity !== pending.workspaceScopeIdentity) return;
+        var row = document.querySelector(
+            '.codex-session-row[data-session-provider="' + pending.provider
+                + '"][data-session-id="' + CSS.escape(pending.sessionId) + '"]'
+        );
+        var project = row && row.closest('.workspace-card[data-current-workspace]');
+        var liveRegion = project && project.querySelector('[data-ai-session-live-region]');
+        if (liveRegion) liveRegion.textContent = message;
+    }
+
+    function syncAiSessionAttentionAcknowledgementDom() {
+        document.querySelectorAll('.codex-session-row[data-attention-acknowledgement-pending]')
+            .forEach(row => row.removeAttribute('data-attention-acknowledgement-pending'));
+        var presentation = window.__agentPivotAiSessionPresentationState;
+        pendingAiSessionAttentionAcknowledgements.forEach(pending => {
+            if (!presentation
+                || presentation.workspaceScopeIdentity !== pending.workspaceScopeIdentity) return;
+            document.querySelectorAll('.codex-session-row[data-session-provider][data-session-id]')
+                .forEach(row => {
+                    if (row.getAttribute('data-session-provider') === pending.provider
+                        && row.getAttribute('data-session-id') === pending.sessionId) {
+                        row.setAttribute('data-attention-acknowledgement-pending', '');
+                    }
+                });
+        });
+    }
+
+    function reconcileAiSessionAttentionAcknowledgements(presentation) {
+        if (!presentation || presentation.type !== 'ai-session-presentation-state') return;
+        pendingAiSessionAttentionAcknowledgements.forEach((pending, pendingKey) => {
+            if (presentation.workspaceScopeIdentity !== pending.workspaceScopeIdentity) {
+                clearAiSessionAttentionAcknowledgement(pendingKey, pending);
+                return;
+            }
+            if (!pending.committed
+                || presentation.projectionRevision < pending.projectionRevision) return;
+            var ownerSessionKey = pending.provider + ':' + pending.sessionId;
+            var owner = presentation.attentionSessions.find(session =>
+                session && session.sessionKey === ownerSessionKey
+            );
+            var currentEventIds = owner && Array.isArray(owner.eventIds) ? owner.eventIds : [];
+            if (pending.eventIds.some(eventId => currentEventIds.includes(eventId))) return;
+            clearAiSessionAttentionAcknowledgement(pendingKey, pending);
+        });
+        syncAiSessionAttentionAcknowledgementDom();
+    }
+
+    function applyAiSessionAttentionAcknowledgementResult(message) {
+        if (!message
+            || Object.keys(message).sort().join('\n') !== [
+                'outcome', 'projectionRevision', 'provider', 'requestId', 'sessionId',
+                'type', 'version', 'workspaceScopeIdentity',
+            ].sort().join('\n')
+            || message.type !== 'ai-session-attention-acknowledgement-result'
+            || message.version !== 1
+            || !Number.isSafeInteger(message.requestId) || message.requestId < 1
+            || !isAiSessionProvider(message.provider)
+            || typeof message.sessionId !== 'string' || !message.sessionId
+            || typeof message.workspaceScopeIdentity !== 'string' || !message.workspaceScopeIdentity
+            || !Number.isSafeInteger(message.projectionRevision) || message.projectionRevision < 1
+            || !['committed', 'degraded-local', 'rejected'].includes(message.outcome)) {
+            return false;
+        }
+        var pendingKey = message.workspaceScopeIdentity + '|'
+            + message.provider + ':' + message.sessionId;
+        var pending = pendingAiSessionAttentionAcknowledgements.get(pendingKey);
+        if (!pending
+            || pending.requestId !== message.requestId
+            || pending.workspaceScopeIdentity !== message.workspaceScopeIdentity
+            || pending.projectionRevision !== message.projectionRevision) return true;
+        if (message.outcome === 'committed') {
+            pending.committed = true;
+            reconcileAiSessionAttentionAcknowledgements(
+                window.__agentPivotAiSessionPresentationState
+            );
+            return true;
+        }
+        clearAiSessionAttentionAcknowledgement(pendingKey, pending);
+        announceAiSessionAttentionAcknowledgement(
+            pending,
+            message.outcome === 'degraded-local'
+                ? 'Attention cleared in this window, but cross-window sync could not be confirmed.'
+                : 'Could not clear session attention. Try again.'
+        );
+        return true;
     }
 
     window.__agentPivotAcknowledgeSession = (provider, sessionId) => {
@@ -683,6 +841,7 @@ function initProjectAiSessionControls(options) {
         batchAiSessionManager: batchAiSessionManager,
         batchAiSessionState: batchAiSessionState,
         activeAiSessionTerminalState: activeAiSessionTerminalState,
+        applyAiSessionAttentionAcknowledgementResult: applyAiSessionAttentionAcknowledgementResult,
         getPendingAiSessionProviderSelectionProjectId: getPendingAiSessionProviderSelectionProjectId,
         activateAiSessionProviderOption: activateAiSessionProviderOption,
         applyAiSessionProviderSelectionResult: applyAiSessionProviderSelectionResult,
@@ -696,6 +855,7 @@ function initProjectAiSessionControls(options) {
         isAiSessionProvider: isAiSessionProvider,
         onTriggerAiSessionAction: onTriggerAiSessionAction,
         reconcilePendingAiSessionProviderSelectionDom: reconcilePendingAiSessionProviderSelectionDom,
+        reconcileAiSessionAttentionAcknowledgements: reconcileAiSessionAttentionAcknowledgements,
         setAiSessionProviderMenuOpen: setAiSessionProviderMenuOpen,
         submitAiSessionProviderSelection: submitAiSessionProviderSelection,
         syncActiveAiSessionTerminalDom: syncActiveAiSessionTerminalDom,

--- a/media/webviewProjectScripts.js
+++ b/media/webviewProjectScripts.js
@@ -650,6 +650,7 @@ function initProjects() {
     function applyValidatedAiSessionPresentationState(message) {
         window.__agentPivotAiSessionPresentationState = message;
         applyAiSessionPresentationDom(message);
+        aiSessionControls.reconcileAiSessionAttentionAcknowledgements(message);
     }
 
     function readInitialAiSessionPresentationState() {
@@ -797,6 +798,10 @@ function initProjects() {
         }
         if (message && message.type === 'ai-session-provider-selection-result') {
             aiSessionControls.applyAiSessionProviderSelectionResult(message);
+            return;
+        }
+        if (message && message.type === 'ai-session-attention-acknowledgement-result') {
+            aiSessionControls.applyAiSessionAttentionAcknowledgementResult(message);
             return;
         }
         if (message && (message.type === 'todo-panel-content' || message.type === 'todo-panel-updated')) {

--- a/src/aiSessions/attentionBridgeClient.ts
+++ b/src/aiSessions/attentionBridgeClient.ts
@@ -21,6 +21,8 @@ export interface AttentionBridgeClientOptions {
     mainExtensionVersion?: string;
 }
 
+export type AttentionBridgeAcknowledgementOutcome = 'committed' | 'degraded-local';
+
 export default class AttentionBridgeClient implements vscode.Disposable {
     private readonly instanceId = crypto.randomBytes(16).toString('hex');
     private sequence = 0;
@@ -87,21 +89,34 @@ export default class AttentionBridgeClient implements vscode.Disposable {
         return this.shutdownFlight;
     }
 
-    async acknowledge(eventIds: string[]): Promise<void> {
+    async acknowledge(eventIds: string[]): Promise<AttentionBridgeAcknowledgementOutcome> {
         const ids = new Set(eventIds || []);
         const acknowledgements = this.lastItems
             .filter(item => item.eventId && ids.has(item.eventId))
             .map(item => ({ ...item, state: 'acknowledged' as const, observedAtMs: this.now() }));
-        if (!ids.size) return;
+        if (!ids.size) return 'committed';
+        let persisted = false;
         try {
-            await vscode.commands.executeCommand(ACKNOWLEDGE_COMMAND, { eventIds: Array.from(ids) });
+            const result = await vscode.commands.executeCommand<{ acknowledged?: unknown }>(
+                ACKNOWLEDGE_COMMAND,
+                { eventIds: Array.from(ids) }
+            );
+            persisted = Boolean(result)
+                && typeof result === 'object'
+                && !Array.isArray(result)
+                && Object.keys(result).length === 1
+                && Object.prototype.hasOwnProperty.call(result, 'acknowledged')
+                && Number.isSafeInteger(result.acknowledged)
+                && result.acknowledged === ids.size;
         } catch (error) {
             this.reportError(error);
         }
-        if (!acknowledgements.length) return;
-        const bySession = new Map(this.latestItems.map(item => [item.sessionKey, item]));
-        acknowledgements.forEach(item => bySession.set(item.sessionKey, item));
-        await this.publish(Array.from(bySession.values()), true);
+        if (acknowledgements.length) {
+            const bySession = new Map(this.latestItems.map(item => [item.sessionKey, item]));
+            acknowledgements.forEach(item => bySession.set(item.sessionKey, item));
+            await this.publish(Array.from(bySession.values()), true);
+        }
+        return persisted ? 'committed' : 'degraded-local';
     }
 
     private enqueuePublication(items: AttentionPayloadItem[], forceHeartbeat: boolean): Promise<boolean> {

--- a/src/aiSessions/attentionEventCapability.ts
+++ b/src/aiSessions/attentionEventCapability.ts
@@ -10,6 +10,7 @@ import type { AttentionAggregate } from './attentionAggregate';
 import type { AiSessionAttentionController, AiSessionAttentionEvaluation } from './attentionController';
 import type AttentionBridgeClient from './attentionBridgeClient';
 import type { AttentionPayloadItem } from './attentionPayload';
+import { getAttentionProjectKeys, getAttentionSummaryForProjectKeys } from './attentionProject';
 import type { AiSessionRuntimeCoordinator } from './runtimeCoordinator';
 import { cloneAiSessionRuntimeIdentity } from './runtimeTypes';
 import type {
@@ -35,6 +36,17 @@ export interface AiSessionAttentionRuntimeOverride {
     attentionKey: string;
     runtime: AiSessionRuntimeSnapshot<vscode.Terminal>;
 }
+
+export interface AiSessionAttentionAcknowledgementTarget {
+    provider: AiSessionProviderId;
+    sessionId: string;
+    workspaceScopeIdentity: string;
+}
+
+export type AiSessionAttentionAcknowledgementOutcome =
+    | 'committed'
+    | 'degraded-local'
+    | 'rejected';
 
 export interface AiSessionAttentionEventCapabilityOptions {
     tmuxRuntimeDiscovery: TmuxRuntimeDiscovery;
@@ -100,7 +112,10 @@ export interface AiSessionAttentionEventCapability {
     refreshViewsIncrementally(): void;
     scheduleViewsRefresh(): void;
     postAttentionState(): void;
-    acknowledgeEventIds(eventIds: string[]): Promise<void>;
+    acknowledgeEventIds(
+        eventIds: string[],
+        target?: AiSessionAttentionAcknowledgementTarget
+    ): Promise<void | AiSessionAttentionAcknowledgementOutcome>;
     acknowledgeAttention(identity: ActiveAiSessionTerminalIdentity): Promise<void>;
     publish(items: AttentionPayloadItem[], forceHeartbeat?: boolean): Promise<boolean>;
     readonly bridgeClient: AttentionBridgeClient;
@@ -332,14 +347,40 @@ export function createAiSessionAttentionEventCapability(
         return getAttentionController().getRecoverySessionEvents()
             .find(session => session.sessionKey === sessionKey)?.eventIds || [];
     };
-    const acknowledgeAiSessionAttentionEventIds = async (eventIds: string[]): Promise<void> => {
+    const acknowledgeAiSessionAttentionEventIds = async (
+        eventIds: string[],
+        target?: AiSessionAttentionAcknowledgementTarget
+    ): Promise<void | AiSessionAttentionAcknowledgementOutcome> => {
         const uniqueEventIds = Array.from(new Set(eventIds.filter(eventId => Boolean(eventId))));
         if (!uniqueEventIds.length) {
             return;
         }
-        getAttentionController().acknowledge(uniqueEventIds);
+        let authoritativeEventIds = uniqueEventIds;
+        if (target) {
+            const workspace = getCurrentOpenWorkspace();
+            const sessionKey = getAiSessionKey(target.provider, target.sessionId);
+            const projectKeys = getAttentionProjectKeys(
+                workspace?.roots.map(root => root.uri) || []
+            );
+            authoritativeEventIds = getAttentionSummaryForProjectKeys(
+                projectKeys,
+                getAttentionController().getEffectiveAggregate()
+            ).sessions
+                .find(session => session.sessionKey === sessionKey)?.eventIds || [];
+            const observed = [...uniqueEventIds].sort();
+            const authoritative = Array.from(new Set(authoritativeEventIds)).sort();
+            if (!workspace
+                || workspace.scopeIdentity !== target.workspaceScopeIdentity
+                || authoritative.length === 0
+                || observed.length !== authoritative.length
+                || observed.some((eventId, index) => eventId !== authoritative[index])) {
+                return 'rejected';
+            }
+            authoritativeEventIds = authoritative;
+        }
+        getAttentionController().acknowledge(authoritativeEventIds);
         refreshAiSessionViewsIncrementally();
-        await aiSessionAttentionBridgeClient.acknowledge(uniqueEventIds);
+        return aiSessionAttentionBridgeClient.acknowledge(authoritativeEventIds);
     };
     const acknowledgeAiSessionAttention = async (
         identity: ActiveAiSessionTerminalIdentity

--- a/src/dashboard/messageHandlers.ts
+++ b/src/dashboard/messageHandlers.ts
@@ -6,6 +6,7 @@ import type { AiSessionCommandController } from '../aiSessions/commandController
 import type { ConversationCapability } from '../aiSessions/conversation/composition';
 import type { AiSessionRuntimeSnapshot } from '../aiSessions/runtimeTypes';
 import type { AiSessionTerminalCommandController } from '../aiSessions/terminalCommandController';
+import { isAiSessionProviderId } from '../models';
 import type { AiSessionProviderId, StewardInfos } from '../models';
 import type { PromptDashboardController } from '../prompts/dashboardController';
 import type { PromptTerminalCommandController } from '../prompts/terminalCommandController';
@@ -25,7 +26,14 @@ export interface DashboardMessageHandlersOptions {
     aiSessionTerminalCommandController: AiSessionTerminalCommandController<vscode.Terminal>;
     conversationCapability: ConversationCapability;
     aiSessionArchiveController: AiSessionArchiveController<AiSessionRuntimeSnapshot<vscode.Terminal>>;
-    acknowledgeAiSessionAttentionEventIds: (eventIds: string[]) => Promise<void>;
+    acknowledgeAiSessionAttentionEventIds: (
+        eventIds: string[],
+        target?: {
+            provider: AiSessionProviderId;
+            sessionId: string;
+            workspaceScopeIdentity: string;
+        }
+    ) => Promise<void | 'committed' | 'degraded-local' | 'rejected'>;
     logOpenWorkspaceDiagnostic: (component: string, event: unknown) => void;
     refreshStewardViews: (reason?: string) => void;
     onOpenWorkspacesRendererReady: () => void;
@@ -71,6 +79,21 @@ export function createDashboardMessageHandlers(
     const showBridgeExtension = options.showBridgeExtension;
     const showSponsorOptions = options.showSponsorOptions;
     const showWarningMessage = options.showWarningMessage;
+    const attentionAcknowledgementFlights = new Map<string, {
+        eventIdsFingerprint: string;
+        flight: Promise<'committed' | 'degraded-local' | 'rejected'>;
+        settled: boolean;
+    }>();
+    const pruneAttentionAcknowledgementFlights = () => {
+        while (attentionAcknowledgementFlights.size > 256) {
+            const settledKey = Array.from(attentionAcknowledgementFlights.entries())
+                .find(([, entry]) => entry.settled)?.[0];
+            if (!settledKey) {
+                return;
+            }
+            attentionAcknowledgementFlights.delete(settledKey);
+        }
+    };
 
     return {
         'request-projects-panel': async e => {
@@ -180,7 +203,96 @@ export function createDashboardMessageHandlers(
             await aiSessionCommandController.togglePin(e.provider as string, e.sessionId as string);
         },
         'acknowledge-ai-session-attention': async e => {
-            const attentionEventIds = Array.isArray(e.eventIds) ? e.eventIds.filter((id: unknown): id is string => typeof id === 'string') : [];
+            const transactionCandidate = [
+                'version', 'requestId', 'provider', 'sessionId',
+                'workspaceScopeIdentity', 'projectionRevision',
+            ].some(key => Object.prototype.hasOwnProperty.call(e, key));
+            if (transactionCandidate) {
+                if (e.version !== 1
+                    || !Number.isSafeInteger(e.requestId)
+                    || (e.requestId as number) < 1) {
+                    return;
+                }
+                const correlated = {
+                    type: 'ai-session-attention-acknowledgement-result',
+                    version: 1,
+                    requestId: e.requestId as number,
+                    provider: typeof e.provider === 'string' ? e.provider : '',
+                    sessionId: typeof e.sessionId === 'string' ? e.sessionId : '',
+                    workspaceScopeIdentity: typeof e.workspaceScopeIdentity === 'string'
+                        ? e.workspaceScopeIdentity : '',
+                    projectionRevision: Number.isSafeInteger(e.projectionRevision)
+                        ? e.projectionRevision as number : 0,
+                };
+                const exactKeys = [
+                    'eventIds', 'projectionRevision', 'provider', 'requestId', 'sessionId',
+                    'type', 'version', 'workspaceScopeIdentity',
+                ];
+                const eventIds = Array.isArray(e.eventIds) ? e.eventIds : [];
+                const valid = Object.keys(e).sort().join('\n') === exactKeys.sort().join('\n')
+                    && typeof e.provider === 'string' && isAiSessionProviderId(e.provider)
+                    && typeof e.sessionId === 'string' && e.sessionId.length > 0 && e.sessionId.length <= 512
+                    && typeof e.workspaceScopeIdentity === 'string'
+                    && e.workspaceScopeIdentity.length > 0 && e.workspaceScopeIdentity.length <= 1024
+                    && Number.isSafeInteger(e.projectionRevision) && (e.projectionRevision as number) > 0
+                    && eventIds.length > 0 && eventIds.length <= 1000
+                    && eventIds.every((id: unknown) => typeof id === 'string'
+                        && id.length > 0 && id.length <= 1024)
+                    && new Set(eventIds).size === eventIds.length;
+                if (!valid) {
+                    await postMessage({ ...correlated, outcome: 'rejected' });
+                    return;
+                }
+                const flightKey = JSON.stringify([
+                    correlated.workspaceScopeIdentity, correlated.provider,
+                    correlated.sessionId, correlated.requestId,
+                    correlated.projectionRevision,
+                ]);
+                const eventIdsFingerprint = JSON.stringify(eventIds);
+                let entry = attentionAcknowledgementFlights.get(flightKey);
+                if (entry && entry.eventIdsFingerprint !== eventIdsFingerprint) {
+                    await postMessage({ ...correlated, outcome: 'rejected' });
+                    return;
+                }
+                if (!entry) {
+                    entry = {
+                        eventIdsFingerprint,
+                        settled: false,
+                        flight: (async () => {
+                        try {
+                            const outcome = await acknowledgeAiSessionAttentionEventIds(
+                                eventIds as string[],
+                                {
+                                    provider: e.provider as AiSessionProviderId,
+                                    sessionId: e.sessionId as string,
+                                    workspaceScopeIdentity: e.workspaceScopeIdentity as string,
+                                }
+                            );
+                            return outcome === 'committed'
+                                || outcome === 'degraded-local'
+                                || outcome === 'rejected'
+                                ? outcome : 'rejected';
+                        } catch (_error) {
+                            return 'rejected';
+                        }
+                        })(),
+                    };
+                    attentionAcknowledgementFlights.set(flightKey, entry);
+                    pruneAttentionAcknowledgementFlights();
+                }
+                const outcome = await entry.flight;
+                if (attentionAcknowledgementFlights.get(flightKey) === entry) {
+                    entry.settled = true;
+                    pruneAttentionAcknowledgementFlights();
+                }
+                await postMessage({ ...correlated, outcome });
+                return;
+            }
+            if (Object.keys(e).sort().join('\n') !== ['eventIds', 'type'].sort().join('\n')) {
+                return;
+            }
+            const attentionEventIds = Array.isArray(e.eventIds)
+                ? e.eventIds.filter((id: unknown): id is string => typeof id === 'string') : [];
             await acknowledgeAiSessionAttentionEventIds(attentionEventIds);
         },
         'rename-ai-session': async e => {

--- a/src/webview/webviewProjectAiSessionControlsScripts.js
+++ b/src/webview/webviewProjectAiSessionControlsScripts.js
@@ -14,6 +14,8 @@ function initProjectAiSessionControls(options) {
     var activeAiSessionTerminalState = { provider: null, sessionId: null, pendingId: null };
     var nextAiSessionBatchArchiveRequestId = 0;
     var nextAiSessionProviderSelectionRequestId = 0;
+    var nextAiSessionAttentionAcknowledgementRequestId = 0;
+    var pendingAiSessionAttentionAcknowledgements = new Map();
     var pendingAiSessionProviderSelectionProjectId = null;
     var pendingAiSessionProviderSelectionRequestId = null;
     var pendingAiSessionProviderSelectionProviders = [];
@@ -353,8 +355,164 @@ function initProjectAiSessionControls(options) {
         }
         eventIds = Array.from(new Set(eventIds.filter(eventId => typeof eventId === 'string' && !!eventId)));
         if (eventIds.length) {
-            window.vscode.postMessage({ type: 'acknowledge-ai-session-attention', eventIds: eventIds });
+            var presentation = window.__agentPivotAiSessionPresentationState;
+            if (!presentation
+                || presentation.type !== 'ai-session-presentation-state'
+                || presentation.version !== 1
+                || !Number.isSafeInteger(presentation.projectionRevision)
+                || presentation.projectionRevision < 1
+                || typeof presentation.workspaceScopeIdentity !== 'string'
+                || !presentation.workspaceScopeIdentity) {
+                window.vscode.postMessage({ type: 'acknowledge-ai-session-attention', eventIds: eventIds });
+                return;
+            }
+            var pendingKey = presentation.workspaceScopeIdentity + '|' + sessionKey;
+            if (pendingAiSessionAttentionAcknowledgements.has(pendingKey)) return;
+            nextAiSessionAttentionAcknowledgementRequestId =
+                nextAiSessionAttentionAcknowledgementRequestId >= Number.MAX_SAFE_INTEGER
+                    ? 1 : nextAiSessionAttentionAcknowledgementRequestId + 1;
+            var pending = {
+                requestId: nextAiSessionAttentionAcknowledgementRequestId,
+                provider: provider,
+                sessionId: sessionId,
+                workspaceScopeIdentity: presentation.workspaceScopeIdentity,
+                projectionRevision: presentation.projectionRevision,
+                eventIds: eventIds.slice(),
+                committed: false,
+                timeoutHandle: null,
+            };
+            if (typeof window.setTimeout === 'function') {
+                pending.timeoutHandle = window.setTimeout(() => {
+                    if (pendingAiSessionAttentionAcknowledgements.get(pendingKey) !== pending) return;
+                    var currentPresentation = window.__agentPivotAiSessionPresentationState;
+                    if (!currentPresentation
+                        || currentPresentation.workspaceScopeIdentity
+                            !== pending.workspaceScopeIdentity) {
+                        clearAiSessionAttentionAcknowledgement(pendingKey, pending);
+                        return;
+                    }
+                    clearAiSessionAttentionAcknowledgement(pendingKey, pending);
+                    announceAiSessionAttentionAcknowledgement(
+                        pending,
+                        'Attention update timed out. Refreshing…'
+                    );
+                    getAiSessionsUpdate().requestFullRefresh('ai-session-attention-acknowledgement-timeout');
+                }, Number.isSafeInteger(window.__agentPivotAttentionAcknowledgementTimeoutMs)
+                    && window.__agentPivotAttentionAcknowledgementTimeoutMs > 0
+                    ? window.__agentPivotAttentionAcknowledgementTimeoutMs : 15_000);
+            }
+            pendingAiSessionAttentionAcknowledgements.set(pendingKey, pending);
+            syncAiSessionAttentionAcknowledgementDom();
+            window.vscode.postMessage({
+                type: 'acknowledge-ai-session-attention',
+                version: 1,
+                requestId: pending.requestId,
+                provider: provider,
+                sessionId: sessionId,
+                workspaceScopeIdentity: pending.workspaceScopeIdentity,
+                projectionRevision: pending.projectionRevision,
+                eventIds: pending.eventIds,
+            });
         }
+    }
+
+    function clearAiSessionAttentionAcknowledgement(sessionKey, pending) {
+        if (pendingAiSessionAttentionAcknowledgements.get(sessionKey) !== pending) return;
+        if (pending.timeoutHandle !== null && typeof window.clearTimeout === 'function') {
+            window.clearTimeout(pending.timeoutHandle);
+        }
+        pendingAiSessionAttentionAcknowledgements.delete(sessionKey);
+        syncAiSessionAttentionAcknowledgementDom();
+    }
+
+    function announceAiSessionAttentionAcknowledgement(pending, message) {
+        var presentation = window.__agentPivotAiSessionPresentationState;
+        if (!presentation
+            || presentation.workspaceScopeIdentity !== pending.workspaceScopeIdentity) return;
+        var row = document.querySelector(
+            '.codex-session-row[data-session-provider="' + pending.provider
+                + '"][data-session-id="' + CSS.escape(pending.sessionId) + '"]'
+        );
+        var project = row && row.closest('.workspace-card[data-current-workspace]');
+        var liveRegion = project && project.querySelector('[data-ai-session-live-region]');
+        if (liveRegion) liveRegion.textContent = message;
+    }
+
+    function syncAiSessionAttentionAcknowledgementDom() {
+        document.querySelectorAll('.codex-session-row[data-attention-acknowledgement-pending]')
+            .forEach(row => row.removeAttribute('data-attention-acknowledgement-pending'));
+        var presentation = window.__agentPivotAiSessionPresentationState;
+        pendingAiSessionAttentionAcknowledgements.forEach(pending => {
+            if (!presentation
+                || presentation.workspaceScopeIdentity !== pending.workspaceScopeIdentity) return;
+            document.querySelectorAll('.codex-session-row[data-session-provider][data-session-id]')
+                .forEach(row => {
+                    if (row.getAttribute('data-session-provider') === pending.provider
+                        && row.getAttribute('data-session-id') === pending.sessionId) {
+                        row.setAttribute('data-attention-acknowledgement-pending', '');
+                    }
+                });
+        });
+    }
+
+    function reconcileAiSessionAttentionAcknowledgements(presentation) {
+        if (!presentation || presentation.type !== 'ai-session-presentation-state') return;
+        pendingAiSessionAttentionAcknowledgements.forEach((pending, pendingKey) => {
+            if (presentation.workspaceScopeIdentity !== pending.workspaceScopeIdentity) {
+                clearAiSessionAttentionAcknowledgement(pendingKey, pending);
+                return;
+            }
+            if (!pending.committed
+                || presentation.projectionRevision < pending.projectionRevision) return;
+            var ownerSessionKey = pending.provider + ':' + pending.sessionId;
+            var owner = presentation.attentionSessions.find(session =>
+                session && session.sessionKey === ownerSessionKey
+            );
+            var currentEventIds = owner && Array.isArray(owner.eventIds) ? owner.eventIds : [];
+            if (pending.eventIds.some(eventId => currentEventIds.includes(eventId))) return;
+            clearAiSessionAttentionAcknowledgement(pendingKey, pending);
+        });
+        syncAiSessionAttentionAcknowledgementDom();
+    }
+
+    function applyAiSessionAttentionAcknowledgementResult(message) {
+        if (!message
+            || Object.keys(message).sort().join('\n') !== [
+                'outcome', 'projectionRevision', 'provider', 'requestId', 'sessionId',
+                'type', 'version', 'workspaceScopeIdentity',
+            ].sort().join('\n')
+            || message.type !== 'ai-session-attention-acknowledgement-result'
+            || message.version !== 1
+            || !Number.isSafeInteger(message.requestId) || message.requestId < 1
+            || !isAiSessionProvider(message.provider)
+            || typeof message.sessionId !== 'string' || !message.sessionId
+            || typeof message.workspaceScopeIdentity !== 'string' || !message.workspaceScopeIdentity
+            || !Number.isSafeInteger(message.projectionRevision) || message.projectionRevision < 1
+            || !['committed', 'degraded-local', 'rejected'].includes(message.outcome)) {
+            return false;
+        }
+        var pendingKey = message.workspaceScopeIdentity + '|'
+            + message.provider + ':' + message.sessionId;
+        var pending = pendingAiSessionAttentionAcknowledgements.get(pendingKey);
+        if (!pending
+            || pending.requestId !== message.requestId
+            || pending.workspaceScopeIdentity !== message.workspaceScopeIdentity
+            || pending.projectionRevision !== message.projectionRevision) return true;
+        if (message.outcome === 'committed') {
+            pending.committed = true;
+            reconcileAiSessionAttentionAcknowledgements(
+                window.__agentPivotAiSessionPresentationState
+            );
+            return true;
+        }
+        clearAiSessionAttentionAcknowledgement(pendingKey, pending);
+        announceAiSessionAttentionAcknowledgement(
+            pending,
+            message.outcome === 'degraded-local'
+                ? 'Attention cleared in this window, but cross-window sync could not be confirmed.'
+                : 'Could not clear session attention. Try again.'
+        );
+        return true;
     }
 
     window.__agentPivotAcknowledgeSession = (provider, sessionId) => {
@@ -683,6 +841,7 @@ function initProjectAiSessionControls(options) {
         batchAiSessionManager: batchAiSessionManager,
         batchAiSessionState: batchAiSessionState,
         activeAiSessionTerminalState: activeAiSessionTerminalState,
+        applyAiSessionAttentionAcknowledgementResult: applyAiSessionAttentionAcknowledgementResult,
         getPendingAiSessionProviderSelectionProjectId: getPendingAiSessionProviderSelectionProjectId,
         activateAiSessionProviderOption: activateAiSessionProviderOption,
         applyAiSessionProviderSelectionResult: applyAiSessionProviderSelectionResult,
@@ -696,6 +855,7 @@ function initProjectAiSessionControls(options) {
         isAiSessionProvider: isAiSessionProvider,
         onTriggerAiSessionAction: onTriggerAiSessionAction,
         reconcilePendingAiSessionProviderSelectionDom: reconcilePendingAiSessionProviderSelectionDom,
+        reconcileAiSessionAttentionAcknowledgements: reconcileAiSessionAttentionAcknowledgements,
         setAiSessionProviderMenuOpen: setAiSessionProviderMenuOpen,
         submitAiSessionProviderSelection: submitAiSessionProviderSelection,
         syncActiveAiSessionTerminalDom: syncActiveAiSessionTerminalDom,

--- a/src/webview/webviewProjectScripts.js
+++ b/src/webview/webviewProjectScripts.js
@@ -650,6 +650,7 @@ function initProjects() {
     function applyValidatedAiSessionPresentationState(message) {
         window.__agentPivotAiSessionPresentationState = message;
         applyAiSessionPresentationDom(message);
+        aiSessionControls.reconcileAiSessionAttentionAcknowledgements(message);
     }
 
     function readInitialAiSessionPresentationState() {
@@ -797,6 +798,10 @@ function initProjects() {
         }
         if (message && message.type === 'ai-session-provider-selection-result') {
             aiSessionControls.applyAiSessionProviderSelectionResult(message);
+            return;
+        }
+        if (message && message.type === 'ai-session-attention-acknowledgement-result') {
+            aiSessionControls.applyAiSessionAttentionAcknowledgementResult(message);
             return;
         }
         if (message && (message.type === 'todo-panel-content' || message.type === 'todo-panel-updated')) {

--- a/tests/browser/activeSessionCardInteraction.test.js
+++ b/tests/browser/activeSessionCardInteraction.test.js
@@ -479,10 +479,10 @@ function attentionAggregate(revision, projectId, sessionKey, eventIds) {
     };
 }
 
-function createAttentionAcknowledgementHandler(acknowledgeEventIds) {
+function createAttentionAcknowledgementHandler(acknowledgeEventIds, postMessage) {
     const ignored = async () => undefined;
     return createDashboardMessageHandlers({
-        postMessage: ignored,
+        postMessage: postMessage || ignored,
         getStewardInfos: () => ({ config: { get: (_key, fallback) => fallback } }),
         projectService: { getGroups: () => [] },
         promptDashboardController: { getPanelContent: ignored, handle: ignored },
@@ -522,6 +522,7 @@ async function assertAttentionCleared(page, provider, sessionId) {
     assert.equal(await sessionRow.getAttribute('data-session-needs-attention'), null);
     assert.equal(await sessionRow.getAttribute('data-ai-session-attention'), null);
     assert.equal(await sessionRow.getAttribute('data-session-event-id'), null);
+    assert.equal(await sessionRow.getAttribute('data-attention-acknowledgement-pending'), null);
     assert.equal(await sessionRow.locator('.ai-session-attention-indicator').count(), 0);
     assert.equal(await project.locator('[data-ai-session-tab="active"] .ai-session-tab-attention').count(), 0);
     assert.equal(await project.locator('.ai-session-attention-count').count(), 0);
@@ -770,10 +771,9 @@ test('ACTIVE-SESSION-PRESENTATION-TRANSACTION-001 accepts same-revision owner ev
     const acknowledgements = (await postedMessages(page)).filter(message =>
         message.type === 'acknowledge-ai-session-attention'
     );
-    assert.deepEqual(acknowledgements, [{
-        type: 'acknowledge-ai-session-attention',
-        eventIds: ['event-a', 'event-b'],
-    }]);
+    assert.deepEqual(acknowledgements.map(message => message.eventIds), [
+        ['event-a', 'event-b'],
+    ]);
 });
 
 test('ACTIVE-SESSION-PRESENTATION-TRANSACTION-001 keeps OPEN HTML and owner events in one revision', async t => {
@@ -817,10 +817,9 @@ test('ACTIVE-SESSION-PRESENTATION-TRANSACTION-001 keeps OPEN HTML and owner even
     const acknowledgements = (await postedMessages(page)).filter(message =>
         message.type === 'acknowledge-ai-session-attention'
     );
-    assert.deepEqual(acknowledgements, [{
-        type: 'acknowledge-ai-session-attention',
-        eventIds: ['open-event-a', 'open-event-b'],
-    }]);
+    assert.deepEqual(acknowledgements.map(message => message.eventIds), [
+        ['open-event-a', 'open-event-b'],
+    ]);
 });
 
 test('ACTIVE-SESSION-INCREMENTAL-PRESENTATION-ENVELOPE-001 applies AI HTML and complete attention owners from one message', async t => {
@@ -862,10 +861,9 @@ test('ACTIVE-SESSION-INCREMENTAL-PRESENTATION-ENVELOPE-001 applies AI HTML and c
     const acknowledgements = (await postedMessages(page)).filter(message =>
         message.type === 'acknowledge-ai-session-attention'
     );
-    assert.deepEqual(acknowledgements, [{
-        type: 'acknowledge-ai-session-attention',
-        eventIds: ['event-a', 'event-b'],
-    }]);
+    assert.deepEqual(acknowledgements.map(message => message.eventIds), [
+        ['event-a', 'event-b'],
+    ]);
 });
 
 test('ACTIVE-SESSION-INCREMENTAL-PRESENTATION-ENVELOPE-001 applies OPEN HTML and complete attention owners from one message', async t => {
@@ -913,10 +911,9 @@ test('ACTIVE-SESSION-INCREMENTAL-PRESENTATION-ENVELOPE-001 applies OPEN HTML and
     const acknowledgements = (await postedMessages(page)).filter(message =>
         message.type === 'acknowledge-ai-session-attention'
     );
-    assert.deepEqual(acknowledgements, [{
-        type: 'acknowledge-ai-session-attention',
-        eventIds: ['open-event-a', 'open-event-b'],
-    }]);
+    assert.deepEqual(acknowledgements.map(message => message.eventIds), [
+        ['open-event-a', 'open-event-b'],
+    ]);
 });
 
 test('ACTIVE-SESSION-INCREMENTAL-PRESENTATION-ENVELOPE-001 closes an AI envelope revision against conflicting direct presentation', async t => {
@@ -963,10 +960,9 @@ test('ACTIVE-SESSION-INCREMENTAL-PRESENTATION-ENVELOPE-001 closes an AI envelope
     const acknowledgements = (await postedMessages(page)).filter(message =>
         message.type === 'acknowledge-ai-session-attention'
     );
-    assert.deepEqual(acknowledgements, [{
-        type: 'acknowledge-ai-session-attention',
-        eventIds: ['event-a', 'event-b'],
-    }]);
+    assert.deepEqual(acknowledgements.map(message => message.eventIds), [
+        ['event-a', 'event-b'],
+    ]);
 });
 
 test('ACTIVE-SESSION-INCREMENTAL-PRESENTATION-ENVELOPE-001 closes an OPEN envelope revision against conflicting direct presentation', async t => {
@@ -1019,10 +1015,9 @@ test('ACTIVE-SESSION-INCREMENTAL-PRESENTATION-ENVELOPE-001 closes an OPEN envelo
     const acknowledgements = (await postedMessages(page)).filter(message =>
         message.type === 'acknowledge-ai-session-attention'
     );
-    assert.deepEqual(acknowledgements, [{
-        type: 'acknowledge-ai-session-attention',
-        eventIds: ['open-event-a', 'open-event-b'],
-    }]);
+    assert.deepEqual(acknowledgements.map(message => message.eventIds), [
+        ['open-event-a', 'open-event-b'],
+    ]);
 });
 
 test('ACTIVE-SESSION-INCREMENTAL-PRESENTATION-ENVELOPE-001 applies and closes AI envelope after matching direct presentation', async t => {
@@ -1085,10 +1080,9 @@ test('ACTIVE-SESSION-INCREMENTAL-PRESENTATION-ENVELOPE-001 applies and closes AI
     const acknowledgements = (await postedMessages(page)).filter(message =>
         message.type === 'acknowledge-ai-session-attention'
     );
-    assert.deepEqual(acknowledgements, [{
-        type: 'acknowledge-ai-session-attention',
-        eventIds: ['event-a', 'event-b'],
-    }]);
+    assert.deepEqual(acknowledgements.map(message => message.eventIds), [
+        ['event-a', 'event-b'],
+    ]);
 });
 
 test('ACTIVE-SESSION-INCREMENTAL-PRESENTATION-ENVELOPE-001 applies and closes OPEN envelope after matching direct presentation', async t => {
@@ -1157,10 +1151,9 @@ test('ACTIVE-SESSION-INCREMENTAL-PRESENTATION-ENVELOPE-001 applies and closes OP
     const acknowledgements = (await postedMessages(page)).filter(message =>
         message.type === 'acknowledge-ai-session-attention'
     );
-    assert.deepEqual(acknowledgements, [{
-        type: 'acknowledge-ai-session-attention',
-        eventIds: ['open-event-a', 'open-event-b'],
-    }]);
+    assert.deepEqual(acknowledgements.map(message => message.eventIds), [
+        ['open-event-a', 'open-event-b'],
+    ]);
 });
 
 test('ACTIVE-SESSION-INCREMENTAL-PRESENTATION-ENVELOPE-001 rejects an invalid presentation before replacing HTML', async t => {
@@ -1277,10 +1270,255 @@ test('ACTIVE-SESSION-FULL-RENDER-TRANSACTION-001 seeds the full document revisio
     const acknowledgements = (await postedMessages(page)).filter(message =>
         message.type === 'acknowledge-ai-session-attention'
     );
-    assert.deepEqual(acknowledgements, [{
+    assert.deepEqual(acknowledgements.map(message => message.eventIds), [
+        ['event-a', 'event-b'],
+    ]);
+});
+
+test('ATTENTION-SESSION-CARD-ACKNOWLEDGEMENT-001 keeps acknowledgement pending until its committed v3 presentation is applied', async t => {
+    const eventIds = ['event-a', 'event-b'];
+    const attentionSession = {
+        ...session('codex', 'session-a', true),
+        executionState: 'stopped',
+        status: 'stopped',
+        needsAttention: true,
+        attentionEventId: eventIds[0],
+    };
+    const page = await openCardPage(
+        t,
+        [attentionSession],
+        undefined,
+        undefined,
+        presentationMessage([attentionSession], 5, {
+            attention: { 'codex:session-a': eventIds },
+        })
+    );
+    const primaryAction = row(page, 'codex', 'session-a')
+        .locator('.ai-session-primary-action');
+
+    await primaryAction.click();
+    await primaryAction.click();
+    const posted = await postedMessages(page);
+    const acknowledgements = posted.filter(message =>
+        message.type === 'acknowledge-ai-session-attention'
+    );
+    assert.equal(acknowledgements.length, 1,
+        'rapid activation must share the pending acknowledgement request');
+    const request = acknowledgements[0];
+    assert.deepEqual(request, {
         type: 'acknowledge-ai-session-attention',
-        eventIds: ['event-a', 'event-b'],
-    }]);
+        version: 1,
+        requestId: request.requestId,
+        provider: 'codex',
+        sessionId: 'session-a',
+        workspaceScopeIdentity: 'scope-project-a',
+        projectionRevision: 5,
+        eventIds,
+    });
+    assert.ok(Number.isSafeInteger(request.requestId) && request.requestId > 0,
+        'the acknowledgement requestId must be a safe positive integer');
+    assert.equal(posted.filter(message =>
+        message.type === 'open-active-ai-session-conversation'
+    ).length, 2, 'pending acknowledgement must not suppress the independent open action');
+
+    const result = overrides => ({
+        type: 'ai-session-attention-acknowledgement-result',
+        version: 1,
+        requestId: request.requestId,
+        provider: request.provider,
+        sessionId: request.sessionId,
+        workspaceScopeIdentity: request.workspaceScopeIdentity,
+        projectionRevision: request.projectionRevision,
+        outcome: 'committed',
+        ...overrides,
+    });
+    const retry = async () => {
+        await page.evaluate(() => {
+            window.__agentPivotAcknowledgeSession('codex', 'session-a');
+        });
+        return (await postedMessages(page)).filter(message =>
+            message.type === 'acknowledge-ai-session-attention'
+        ).length;
+    };
+    await postHostMessage(page, result({ projectionRevision: 4 }));
+    assert.equal(await retry(), 1, 'an old settlement cannot release pending');
+    await postHostMessage(page, result({ sessionId: 'session-b' }));
+    assert.equal(await retry(), 1, 'an unrelated settlement cannot release pending');
+    await postHostMessage(page, result({}));
+    assert.equal(await retry(), 1,
+        'a matching committed settlement alone cannot release pending');
+
+    const postV3 = async (projectionRevision, renderedSession, attention) => {
+        await postHostMessage(page, {
+            type: 'ai-sessions-updated',
+            version: 3,
+            sequence: projectionRevision,
+            projectionRevision,
+            generatedAt: '2026-08-11T00:00:00.000Z',
+            currentWorkspaceCount: 1,
+            html: `<div class="open-current-workspace-group">${projectMarkup([
+                renderedSession,
+            ])}</div>`,
+            searchCatalog: {
+                version: 2, sessions: [], openWorkspaces: [], savedProjects: [], todos: [],
+            },
+            presentation: presentationMessage([renderedSession], projectionRevision, {
+                attention: { 'codex:session-a': attention },
+            }),
+        });
+    };
+    await postV3(6, attentionSession, eventIds);
+    assert.equal(await retry(), 1,
+        'a newer presentation retaining an observed event cannot release pending');
+
+    const clearedSession = { ...attentionSession, needsAttention: false };
+    delete clearedSession.attentionEventId;
+    await postV3(7, clearedSession, []);
+    const nextEventIds = ['event-c'];
+    await postV3(8, {
+        ...attentionSession,
+        attentionEventId: nextEventIds[0],
+    }, nextEventIds);
+    await row(page, 'codex', 'session-a').locator('.ai-session-primary-action').click();
+    let finalAcknowledgements = (await postedMessages(page)).filter(message =>
+        message.type === 'acknowledge-ai-session-attention'
+    );
+    assert.equal(finalAcknowledgements.length, 2,
+        'matching committed outcome plus applied cleared v3 presentation releases pending');
+    assert.deepEqual(finalAcknowledgements[1].eventIds, nextEventIds);
+    assert.equal(finalAcknowledgements[1].projectionRevision, 8);
+
+    await postV3(9, clearedSession, []);
+    assert.equal(await retry(), 2,
+        'a cleared v3 presentation alone cannot release pending before its result');
+    await postHostMessage(page, result({
+        requestId: finalAcknowledgements[1].requestId,
+        projectionRevision: finalAcknowledgements[1].projectionRevision,
+    }));
+    await postHostMessage(page, result({
+        requestId: finalAcknowledgements[1].requestId,
+        projectionRevision: finalAcknowledgements[1].projectionRevision,
+    }));
+    const degradedEventIds = ['event-d'];
+    await postV3(10, {
+        ...attentionSession, attentionEventId: degradedEventIds[0],
+    }, degradedEventIds);
+    await retry();
+    finalAcknowledgements = (await postedMessages(page)).filter(message =>
+        message.type === 'acknowledge-ai-session-attention'
+    );
+    const degradedRequest = finalAcknowledgements.at(-1);
+    await postHostMessage(page, result({
+        requestId: degradedRequest.requestId,
+        projectionRevision: degradedRequest.projectionRevision,
+        outcome: 'degraded-local',
+    }));
+    assert.equal(await row(page, 'codex', 'session-a')
+        .getAttribute('data-attention-acknowledgement-pending'), null);
+    assert.match(await page.locator('[data-ai-session-live-region]').textContent(),
+        /cross-window sync could not be confirmed/i);
+
+    const rejectedEventIds = ['event-e'];
+    await postV3(11, {
+        ...attentionSession, attentionEventId: rejectedEventIds[0],
+    }, rejectedEventIds);
+    await retry();
+    finalAcknowledgements = (await postedMessages(page)).filter(message =>
+        message.type === 'acknowledge-ai-session-attention'
+    );
+    const rejectedRequest = finalAcknowledgements.at(-1);
+    await postHostMessage(page, result({
+        requestId: rejectedRequest.requestId,
+        projectionRevision: rejectedRequest.projectionRevision,
+        outcome: 'rejected',
+    }));
+    assert.match(await page.locator('[data-ai-session-live-region]').textContent(),
+        /could not clear session attention/i);
+
+    const timeoutEventIds = ['event-f'];
+    await postV3(12, {
+        ...attentionSession, attentionEventId: timeoutEventIds[0],
+    }, timeoutEventIds);
+    await page.evaluate(() => {
+        window.__agentPivotAttentionAcknowledgementTimeoutMs = 10;
+        window.__agentPivotAcknowledgeSession('codex', 'session-a');
+    });
+    await waitForPageCondition(page, () => window.__postedMessages.some(message =>
+        message.type === 'request-full-refresh'
+            && message.reason === 'ai-session-attention-acknowledgement-timeout'
+    ));
+    assert.equal(await row(page, 'codex', 'session-a')
+        .getAttribute('data-attention-acknowledgement-pending'), null);
+    assert.match(await page.locator('[data-ai-session-live-region]').textContent(),
+        /timed out/i);
+});
+
+test('ATTENTION-SESSION-CARD-ACKNOWLEDGEMENT-001 scopes pending acknowledgement to one workspace presentation', async t => {
+    const attentionSession = {
+        ...session('codex', 'session-a', true),
+        executionState: 'stopped', status: 'stopped', needsAttention: true,
+        attentionEventId: 'event-a',
+    };
+    const initial = presentationMessage([attentionSession], 5, {
+        attention: { 'codex:session-a': ['event-a'] },
+    });
+    const page = await openCardPage(t, [attentionSession], undefined, undefined, initial);
+    await page.evaluate(() => {
+        window.__attentionAcknowledgementTimers = [];
+        window.setTimeout = callback => {
+            var handle = { callback: callback, cleared: false };
+            window.__attentionAcknowledgementTimers.push(handle);
+            return handle;
+        };
+        window.clearTimeout = handle => { handle.cleared = true; };
+        window.__agentPivotAttentionAcknowledgementTimeoutMs = 10;
+        window.__agentPivotAcknowledgeSession('codex', 'session-a');
+    });
+    const firstRequest = (await postedMessages(page)).find(message =>
+        message.type === 'acknowledge-ai-session-attention'
+    );
+
+    await postHostMessage(page, {
+        ...presentationMessage([attentionSession], 6, {
+            attention: { 'codex:session-a': ['event-a'] },
+        }),
+        workspaceScopeIdentity: 'scope-project-b',
+    });
+    await page.evaluate(() => {
+        window.__agentPivotAttentionAcknowledgementTimeoutMs = 1_000;
+        window.__agentPivotAcknowledgeSession('codex', 'session-a');
+        var oldTimer = window.__attentionAcknowledgementTimers[0];
+        if (!oldTimer.cleared) throw new Error('the old workspace timer was not cancelled');
+        oldTimer.callback();
+    });
+    const requests = (await postedMessages(page)).filter(message =>
+        message.type === 'acknowledge-ai-session-attention'
+    );
+    assert.deepEqual(requests.map(message => message.workspaceScopeIdentity), [
+        'scope-project-a', 'scope-project-b',
+    ], 'an old workspace pending entry cannot suppress the same session identity in a new scope');
+    assert.equal((await postedMessages(page)).filter(message =>
+        message.type === 'request-full-refresh'
+            && message.reason === 'ai-session-attention-acknowledgement-timeout'
+    ).length, 0, 'the old workspace timeout must be cancelled silently');
+    assert.equal(await page.locator('[data-ai-session-live-region]').textContent(), '');
+    assert.equal(await row(page, 'codex', 'session-a')
+        .getAttribute('data-attention-acknowledgement-pending'), '');
+    await postHostMessage(page, {
+        type: 'ai-session-attention-acknowledgement-result',
+        version: 1,
+        requestId: firstRequest.requestId,
+        provider: firstRequest.provider,
+        sessionId: firstRequest.sessionId,
+        workspaceScopeIdentity: firstRequest.workspaceScopeIdentity,
+        projectionRevision: firstRequest.projectionRevision,
+        outcome: 'degraded-local',
+    });
+    assert.equal(await page.locator('[data-ai-session-live-region]').textContent(), '',
+        'a late result from the old workspace must not announce in the new workspace');
+    assert.equal(await row(page, 'codex', 'session-a')
+        .getAttribute('data-attention-acknowledgement-pending'), '',
+    'a late old-workspace result must not clear the new workspace request');
 });
 
 test('ATTENTION-SESSION-CARD-ACKNOWLEDGEMENT-001 clears a stopped Kimi card through the production v3 refresh', async t => {
@@ -1439,6 +1677,7 @@ test('ATTENTION-SESSION-CARD-ACKNOWLEDGEMENT-001 clears a stopped Kimi card thro
             bridgeAggregateListener(attentionAggregate(
                 'stale-fixture-replay', projectId, sessionKey, eventIds
             ));
+            return 'committed';
         },
         publish: async () => true,
         dispose() {},
@@ -1518,8 +1757,13 @@ test('ATTENTION-SESSION-CARD-ACKNOWLEDGEMENT-001 clears a stopped Kimi card thro
         await compact.locator('.project-ai-attention-badge').getAttribute('aria-label'),
         '1 item needs attention'
     );
+    const acknowledgementResults = [];
     const hostHandler = createAttentionAcknowledgementHandler(
-        ids => attentionCapability.acknowledgeEventIds(ids)
+        (ids, target) => attentionCapability.acknowledgeEventIds(ids, target),
+        message => {
+            acknowledgementResults.push(message);
+            return postHostMessage(page, message);
+        }
     );
     const exposedName = '__hostAttentionMessage_fixture';
     await page.exposeFunction(exposedName, message => {
@@ -1558,6 +1802,8 @@ test('ATTENTION-SESSION-CARD-ACKNOWLEDGEMENT-001 clears a stopped Kimi card thro
     }
     await Promise.all(deliveryPromises);
 
+    assert.deepEqual(acknowledgementResults.map(message => message.outcome), ['committed'],
+        'the Host must settle the authoritative acknowledgement as committed');
     assert.deepEqual(bridgeAcknowledgements, [eventIds],
         'the Host acknowledges the complete presentation owner, not only the row fallback');
     assert.deepEqual(attentionController.getEffectiveAggregate().sessions, [],

--- a/tests/contract/aiSessions/attentionEventCapability.test.js
+++ b/tests/contract/aiSessions/attentionEventCapability.test.js
@@ -6,6 +6,7 @@ const test = require('node:test');
 const {
     createAiSessionAttentionEventCapability,
 } = require('../../../out/aiSessions/attentionEventCapability');
+const { getAttentionProjectKey } = require('../../../out/aiSessions/attentionProject');
 
 function flushAsync() {
     return new Promise(resolve => setImmediate(resolve));
@@ -54,6 +55,7 @@ function createFixture(overrides = {}) {
         },
         acknowledge: async eventIds => {
             calls.push(['bridge-acknowledge', eventIds]);
+            return overrides.bridgeAcknowledgementOutcome;
         },
         dispose: () => {
             calls.push(['bridge-dispose']);
@@ -83,6 +85,12 @@ function createFixture(overrides = {}) {
         },
         getRecoverySessionEvents: () => overrides.recoverySessionEvents
             || [{ sessionKey: 'codex:session-a', eventIds: ['evt-1', 'evt-1', 'evt-2'] }],
+        getEffectiveAggregate: () => overrides.effectiveAggregate || {
+            protocolVersion: 1,
+            aggregateRevision: 'fixture-attention-aggregate',
+            generatedAtMs: 1,
+            sessions: [],
+        },
         getAttentionEventIds: () => ['evt-1', 'evt-2'],
         setRemoteAggregate: aggregate => {
             calls.push(['set-remote-aggregate', aggregate]);
@@ -416,6 +424,47 @@ test('ATTENTION-USER-TERMINAL-CLOSE-001 a user close acknowledges locally, refre
     });
     assert.equal(empty.calls.some(call => call[0] === 'local-acknowledge'), false,
         'an empty event id list skips the acknowledgement entirely');
+});
+
+test('ATTENTION-SESSION-CARD-ACKNOWLEDGEMENT-001 resolves a complete authoritative owner before acknowledgement', async () => {
+    const target = {
+        provider: 'codex', sessionId: 'session-a', workspaceScopeIdentity: 'scope-1',
+    };
+    const fixture = createFixture({
+        bridgeAcknowledgementOutcome: 'committed',
+        workspace: { scopeIdentity: 'scope-1', roots: [{ uri: '/work' }] },
+        effectiveAggregate: {
+            protocolVersion: 1,
+            aggregateRevision: 'fixture-authoritative-attention',
+            generatedAtMs: 1,
+            sessions: [{
+                projectId: getAttentionProjectKey('/work'),
+                sessionKey: 'codex:session-a',
+                reasons: ['completed'],
+                eventIds: ['evt-1', 'evt-2'],
+                observedAtMs: 1,
+            }],
+        },
+    });
+    fixture.capability.startBridgeClient();
+
+    assert.equal(await fixture.capability.acknowledgeEventIds(['evt-1'], target), 'rejected');
+    assert.equal(await fixture.capability.acknowledgeEventIds(
+        ['evt-1', 'evt-2'], { ...target, workspaceScopeIdentity: 'stale-scope' }
+    ), 'rejected');
+    assert.equal(fixture.calls.some(call => call[0] === 'local-acknowledge'), false,
+        'partial or stale observations cannot mutate the authoritative owner');
+
+    assert.equal(
+        await fixture.capability.acknowledgeEventIds(['evt-2', 'evt-1'], target),
+        'committed'
+    );
+    assert.deepEqual(fixture.calls.filter(call => call[0] === 'local-acknowledge'), [
+        ['local-acknowledge', ['evt-1', 'evt-2']],
+    ]);
+    assert.deepEqual(fixture.calls.filter(call => call[0] === 'bridge-acknowledge'), [
+        ['bridge-acknowledge', ['evt-1', 'evt-2']],
+    ]);
 });
 
 test('ATTENTION-EXECUTION-STATE-SYNC-001 the open terminal handler restores attach candidates and reports failures', async () => {

--- a/tests/contract/dashboard/messageHandlers.test.js
+++ b/tests/contract/dashboard/messageHandlers.test.js
@@ -60,7 +60,8 @@ function createFixture(overrides = {}) {
         },
         conversationCapability: { followActiveConversation: record('followActiveConversation') },
         aiSessionArchiveController: { archiveSessions: record('archiveSessions') },
-        acknowledgeAiSessionAttentionEventIds: record('acknowledgeAttention'),
+        acknowledgeAiSessionAttentionEventIds: overrides.acknowledgeAttention
+            || record('acknowledgeAttention'),
         logOpenWorkspaceDiagnostic: (component, event) => calls.push(['rendererDiagnostic', component, event]),
         refreshStewardViews: reason => calls.push(['refreshStewardViews', reason]),
         requestActiveAiSessionTerminalHighlight: () => calls.push(['requestHighlight']),
@@ -204,7 +205,9 @@ test('WEBVIEW-DASHBOARD-MESSAGE-ROUTER-001 delegates the simple openers and stat
     await handlers['open-bridge-extension']({});
     // WEBVIEW-SPONSOR-ENTRY-001 the toolbar sponsor button delegates to the sponsor picker.
     await handlers['sponsor']({});
-    await handlers['acknowledge-ai-session-attention']({ eventIds: ['a', 1, 'b'] });
+    await handlers['acknowledge-ai-session-attention']({
+        type: 'acknowledge-ai-session-attention', eventIds: ['a', 1, 'b'],
+    });
 
     assert.deepEqual(calls, [
         ['requestHighlight'],
@@ -218,6 +221,121 @@ test('WEBVIEW-DASHBOARD-MESSAGE-ROUTER-001 delegates the simple openers and stat
         ['showSponsorOptions'],
         ['acknowledgeAttention', ['a', 'b']],
     ], 'non-string attention event ids are filtered before acknowledgement');
+});
+
+test('ATTENTION-SESSION-CARD-ACKNOWLEDGEMENT-001 validates requests and posts one correlated outcome', async () => {
+    const request = {
+        type: 'acknowledge-ai-session-attention',
+        version: 1,
+        requestId: 7,
+        provider: 'codex',
+        sessionId: 'session-a',
+        workspaceScopeIdentity: 'scope-project-a',
+        projectionRevision: 5,
+        eventIds: ['event-a', 'event-b'],
+    };
+    const expected = outcome => ({
+        type: 'ai-session-attention-acknowledgement-result',
+        version: 1,
+        requestId: request.requestId,
+        provider: request.provider,
+        sessionId: request.sessionId,
+        workspaceScopeIdentity: request.workspaceScopeIdentity,
+        projectionRevision: request.projectionRevision,
+        outcome,
+    });
+
+    const malformed = createFixture();
+    await malformed.handlers['acknowledge-ai-session-attention']({
+        ...request, unexpected: true,
+    });
+    assert.deepEqual(malformed.calls, [], 'strict validation rejects unknown request fields');
+    assert.deepEqual(malformed.posted, [expected('rejected')],
+        'a recognized invalid request receives exactly one correlated rejection');
+
+    const invalidCorrelation = createFixture();
+    await invalidCorrelation.handlers['acknowledge-ai-session-attention']({
+        ...request, requestId: 0,
+    });
+    assert.deepEqual(invalidCorrelation.calls, []);
+    assert.deepEqual(invalidCorrelation.posted, [],
+        'an unsafe correlation is ignored without falling through to legacy mutation');
+
+    for (const outcome of ['committed', 'degraded-local']) {
+        const fixture = createFixture({
+            acknowledgeAttention: async eventIds => {
+                fixture.calls.push(['acknowledgeAttention', eventIds]);
+                return outcome;
+            },
+        });
+        await fixture.handlers['acknowledge-ai-session-attention'](request);
+        assert.deepEqual(fixture.calls, [['acknowledgeAttention', request.eventIds]]);
+        assert.deepEqual(fixture.posted, [expected(outcome)],
+            `${outcome} is posted exactly once with the complete correlation identity`);
+    }
+
+    let executions = 0;
+    const duplicate = createFixture({
+        acknowledgeAttention: async () => {
+            executions += 1;
+            return 'committed';
+        },
+    });
+    await Promise.all([
+        duplicate.handlers['acknowledge-ai-session-attention'](request),
+        duplicate.handlers['acknowledge-ai-session-attention'](request),
+    ]);
+    assert.equal(executions, 1, 'a replayed request shares one Host mutation flight');
+    assert.deepEqual(duplicate.posted, [expected('committed'), expected('committed')],
+        'each delivery receives the same idempotent correlated outcome');
+
+    const conflicting = createFixture({
+        acknowledgeAttention: async () => {
+            executions += 1;
+            return 'committed';
+        },
+    });
+    executions = 0;
+    await Promise.all([
+        conflicting.handlers['acknowledge-ai-session-attention'](request),
+        conflicting.handlers['acknowledge-ai-session-attention']({
+            ...request, eventIds: [...request.eventIds].reverse(),
+        }),
+    ]);
+    assert.equal(executions, 1, 'one correlation cannot start a second payload flight');
+    assert.deepEqual(conflicting.posted.map(message => message.outcome).sort(), [
+        'committed', 'rejected',
+    ]);
+
+    executions = 0;
+    const degraded = createFixture({
+        acknowledgeAttention: async () => {
+            executions += 1;
+            return 'degraded-local';
+        },
+    });
+    await degraded.handlers['acknowledge-ai-session-attention'](request);
+    await degraded.handlers['acknowledge-ai-session-attention'](request);
+    assert.equal(executions, 1, 'a degraded correlation remains an idempotent terminal result');
+
+    const releases = [];
+    let pendingExecutions = 0;
+    const crowded = createFixture({
+        acknowledgeAttention: () => new Promise(resolve => {
+            pendingExecutions += 1;
+            releases.push(resolve);
+        }),
+    });
+    const crowdedRequests = Array.from({ length: 257 }, (_, index) => ({
+        ...request, requestId: index + 1,
+    }));
+    const crowdedFlights = crowdedRequests.map(item =>
+        crowded.handlers['acknowledge-ai-session-attention'](item)
+    );
+    const firstReplay = crowded.handlers['acknowledge-ai-session-attention'](crowdedRequests[0]);
+    assert.equal(pendingExecutions, 257, 'capacity pruning cannot evict an unresolved flight');
+    releases.forEach(resolve => resolve('committed'));
+    await Promise.all([...crowdedFlights, firstReplay]);
 });
 
 test('WEBVIEW-DASHBOARD-MESSAGE-ROUTER-001 rejects malformed open-workspaces renderer readiness', async () => {

--- a/tests/integration/dashboard/helpers/terminalCloseHarness.js
+++ b/tests/integration/dashboard/helpers/terminalCloseHarness.js
@@ -134,11 +134,11 @@ const mutations = {
         scenario: 'user-close',
         transform: source => replaceOnce(
             source,
-            'getAttentionController().acknowledge(uniqueEventIds);\n'
+            'getAttentionController().acknowledge(authoritativeEventIds);\n'
                 + '        refreshAiSessionViewsIncrementally();\n'
-                + '        yield aiSessionAttentionBridgeClient.acknowledge(uniqueEventIds);',
-            'getAttentionController().acknowledge(uniqueEventIds);\n'
-                + '        yield aiSessionAttentionBridgeClient.acknowledge(uniqueEventIds);\n'
+                + '        return aiSessionAttentionBridgeClient.acknowledge(authoritativeEventIds);',
+            'getAttentionController().acknowledge(authoritativeEventIds);\n'
+                + '        yield aiSessionAttentionBridgeClient.acknowledge(authoritativeEventIds);\n'
                 + '        refreshAiSessionViewsIncrementally();',
             'acknowledgement ordering',
         ),

--- a/tests/integration/dashboard/productionAttentionBridge.test.js
+++ b/tests/integration/dashboard/productionAttentionBridge.test.js
@@ -7,7 +7,7 @@ const path = require('node:path');
 const test = require('node:test');
 const { makeTempDirectory } = require('../../helpers/tempDirectory');
 
-test('ATTENTION-PRODUCTION-ATTENTION-BRIDGE-INTEGRATION-001 OPEN-WORKSPACE-UI-HOST-NAVIGATION-001 OPEN-WORKSPACE-BRIDGE-COMPATIBILITY-001 OPEN-PROJECT-UI-HOST-NAVIGATION-001 activates the production bridge and opens workspaces and saved projects from the UI host', async t => {
+test('ATTENTION-PRODUCTION-ATTENTION-BRIDGE-INTEGRATION-001 ATTENTION-SESSION-CARD-ACKNOWLEDGEMENT-001 OPEN-WORKSPACE-UI-HOST-NAVIGATION-001 OPEN-WORKSPACE-BRIDGE-COMPATIBILITY-001 OPEN-PROJECT-UI-HOST-NAVIGATION-001 activates the production bridge and opens workspaces and saved projects from the UI host', async t => {
     const root = makeTempDirectory(t, 'production-attention-bridge-');
     const registered = new Map();
     const executed = [];
@@ -168,6 +168,36 @@ test('ATTENTION-PRODUCTION-ATTENTION-BRIDGE-INTEGRATION-001 OPEN-WORKSPACE-UI-HO
         assert.deepEqual(errors, []);
         assert.ok(aggregates.length > 0);
         assert.deepEqual(aggregates.at(-1).sessions[0].eventIds, ['integration-event']);
+        assert.equal(await client.acknowledge(['integration-event']), 'committed');
+        assert.deepEqual(aggregates.at(-1).sessions, [],
+            'a committed acknowledgement is persisted and broadcast by the production bridge');
+        const acknowledgeCommand = '_agentPivotAttention.bridge.acknowledge';
+        const productionAcknowledge = registered.get(acknowledgeCommand);
+        await client.publish([{
+            projectId: 'a'.repeat(64), sessionKey: 'codex:malformed-result',
+            state: 'needsAttention', eventId: 'malformed-result-event',
+            reason: 'completed', observedAtMs: 2,
+        }]);
+        registered.set(acknowledgeCommand, async raw => {
+            await productionAcknowledge(raw);
+            return { acknowledged: raw.eventIds.length, unexpected: true };
+        });
+        assert.equal(await client.acknowledge(['malformed-result-event']), 'degraded-local',
+            'a malformed bridge result must fail closed even after persistence');
+        registered.set(acknowledgeCommand, async raw => {
+            const malformed = [];
+            malformed.acknowledged = raw.eventIds.length;
+            return malformed;
+        });
+        assert.equal(await client.acknowledge(['array-result-event']), 'degraded-local',
+            'an array with an acknowledged property is not a valid bridge result record');
+        registered.set(acknowledgeCommand, async () => {
+            throw new Error('fixture acknowledgement failure');
+        });
+        assert.equal(await client.acknowledge(['missing-event']), 'degraded-local');
+        assert.match(String(errors.at(-1)), /fixture acknowledgement failure/,
+            'a rejected acknowledgement is reported before local degradation');
+        registered.set(acknowledgeCommand, productionAcknowledge);
 
         const handshake = registered.get('_agentPivotAttention.bridge.handshake');
         const publish = registered.get('_agentPivotAttention.bridge.publish');


### PR DESCRIPTION
## Summary

- Replace fire-and-forget card acknowledgements with a versioned, request-correlated transaction.
- Resolve the complete attention owner from current Host workspace authority and reject stale, partial, malformed, or conflicting requests.
- Keep Webview pending state until a committed authoritative v3 presentation is applied, with bounded failure recovery and workspace-scope isolation.
- Make bridge persistence outcomes explicit and retain idempotent Host settlements for duplicate delivery.

## Testing

- npm run test:ci:linux
- npm run test:behavior-contracts
- Focused attention transaction suite: 56/56
- Repeated workspace-scope and production v3 browser paths: 20/20
- Changed-line coverage: 97.79% (177/181)

## Review

Independent protocol and test reviews found no remaining Critical or Important findings. Final merge-base-to-HEAD integration review passed.

## Skill harvest

No skill change was justified. The only reusable workflow failure was overlapping commands that clean and consume the shared out directory; review-fix-commit-loop already explicitly prohibits this scheduling pattern. The full Linux gate subsequently passed when run in dependency order.