### PR TITLE
refactor: converge AI session presentation delivery

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -4147,7 +4147,7 @@
   {
     "id": "ACTIVE-SESSION-INCREMENTAL-PRESENTATION-ENVELOPE-001",
     "domain": "webview",
-    "title": "Incremental workspace HTML and complete AI Session presentation arrive and apply atomically",
+    "title": "Only v3 incremental workspace envelopes apply HTML and complete AI Session presentation atomically",
     "priority": "P0",
     "status": "automated",
     "owners": [

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "83910c204b19ba0daace9cce51b8d2c741dcca63",
+        "head": "e42e41de76fb98abdcee947959f88373a562a8b8",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -270,7 +270,8 @@
             "aed096b76c6458b956a0749528d68c634381fb55",
             "2798f545688f46f633d18a95d20f16400f13db27",
             "639b4b720bb2987becc200334d21944b71d61598",
-            "7e6bbfd491daa0e36072bb6a55d3564eed4ee731"
+            "7e6bbfd491daa0e36072bb6a55d3564eed4ee731",
+            "bc0439f51e63e03021cbff91824c386b4685dfd6"
         ]
     },
     "capabilities": [
@@ -925,7 +926,9 @@
                 "c39b9f1d5a38563194b6d4423e91f89c4897212d",
                 "fe852b6268c76ca437c49b628189ae1439bce0f3",
                 "464afaaa5924f5834da6ec428c5f805e05514093",
-                "47cb385c19b44554d7598f081caf38ffb873cf36"
+                "47cb385c19b44554d7598f081caf38ffb873cf36",
+                "26ce7197d0d43018b1bae358817ac18374df345e",
+                "e42e41de76fb98abdcee947959f88373a562a8b8"
             ],
             "behaviors": [
                 "ATTENTION-ACTIVE-UNREGISTER-ON-DEACTIVATE-001",

--- a/media/webviewDashboardBundle.js
+++ b/media/webviewDashboardBundle.js
@@ -705,7 +705,7 @@ function completeOpenWorkspacePin(message) {
 function applyOpenWorkspacesUpdate(message) {
     if (!message
         || message.type !== 'open-workspaces-updated'
-        || (message.version !== 2 && message.version !== 3)
+        || message.version !== 3
         || typeof message.semanticRevision !== 'string'
         || !message.semanticRevision
         || (message.currentWorkspaceCount !== 0 && message.currentWorkspaceCount !== 1)
@@ -2027,10 +2027,8 @@ function initProjectAiSessionsUpdate(options) {
     var applyValidatedAiSessionPresentationState = options.applyValidatedAiSessionPresentationState;
 
     var pendingWorkspaceSessionReveal = null;
-    var latestAiSessionUpdateSequence = 0;
     var latestAiSessionProjectionRevision = 0;
     var latestAiSessionPresentationProjectionRevision = 0;
-    var latestAiSessionDirectPresentationRevision = 0;
     var latestAiSessionClosedPresentationRevision = 0;
 
     function canApplyRevision(revision, latestRevision) {
@@ -2046,10 +2044,6 @@ function initProjectAiSessionsUpdate(options) {
         return canApplyRevision(revision, latestAiSessionProjectionRevision);
     }
 
-    function canApplyPresentationProjectionRevision(revision) {
-        return canApplyRevision(revision, latestAiSessionPresentationProjectionRevision);
-    }
-
     function canApplyAtomicPresentationProjectionRevision(revision) {
         return Number.isSafeInteger(revision)
             && revision > 0
@@ -2057,21 +2051,17 @@ function initProjectAiSessionsUpdate(options) {
             && revision > latestAiSessionClosedPresentationRevision;
     }
 
-    function commitProjectionRevision(revision, adoptedPresentation, closePresentation) {
+    function commitAtomicProjectionRevision(revision) {
         if (Number.isSafeInteger(revision) && revision > 0) {
             latestAiSessionProjectionRevision = revision;
-            if (adoptedPresentation) {
-                latestAiSessionPresentationProjectionRevision = Math.max(
-                    latestAiSessionPresentationProjectionRevision,
-                    revision
-                );
-            }
-            if (closePresentation) {
-                latestAiSessionClosedPresentationRevision = Math.max(
-                    latestAiSessionClosedPresentationRevision,
-                    revision
-                );
-            }
+            latestAiSessionPresentationProjectionRevision = Math.max(
+                latestAiSessionPresentationProjectionRevision,
+                revision
+            );
+            latestAiSessionClosedPresentationRevision = Math.max(
+                latestAiSessionClosedPresentationRevision,
+                revision
+            );
         }
     }
 
@@ -2079,16 +2069,11 @@ function initProjectAiSessionsUpdate(options) {
         if (!Number.isSafeInteger(revision)
             || revision <= 0
             || revision < latestAiSessionProjectionRevision
-            || revision < latestAiSessionPresentationProjectionRevision
-            || revision <= latestAiSessionClosedPresentationRevision
-            || revision <= latestAiSessionDirectPresentationRevision) {
+            || revision <= latestAiSessionPresentationProjectionRevision
+            || revision <= latestAiSessionClosedPresentationRevision) {
             return false;
         }
-        latestAiSessionPresentationProjectionRevision = Math.max(
-            latestAiSessionPresentationProjectionRevision,
-            revision
-        );
-        latestAiSessionDirectPresentationRevision = revision;
+        latestAiSessionPresentationProjectionRevision = revision;
         return true;
     }
 
@@ -2097,18 +2082,17 @@ function initProjectAiSessionsUpdate(options) {
             || revision <= 0
             || latestAiSessionProjectionRevision !== 0
             || latestAiSessionPresentationProjectionRevision !== 0
-            || latestAiSessionDirectPresentationRevision !== 0) {
+            || latestAiSessionClosedPresentationRevision !== 0) {
             return false;
         }
         latestAiSessionProjectionRevision = revision;
         latestAiSessionPresentationProjectionRevision = revision;
-        latestAiSessionDirectPresentationRevision = revision;
+        latestAiSessionClosedPresentationRevision = revision;
         return true;
     }
 
     function applyAiSessionsUpdate(message) {
-        var isAtomicEnvelope = message.version === 3;
-        if ((message.version !== 2 && !isAtomicEnvelope)
+        if (message.version !== 3
             || typeof message.sequence !== 'number'
             || (message.currentWorkspaceCount !== 0 && message.currentWorkspaceCount !== 1)
             || typeof message.html !== 'string'
@@ -2119,8 +2103,7 @@ function initProjectAiSessionsUpdate(options) {
             return;
         }
 
-        if (isAtomicEnvelope
-            && (!Number.isSafeInteger(message.projectionRevision)
+        if (!Number.isSafeInteger(message.projectionRevision)
                 || message.projectionRevision <= 0
                 || message.sequence !== message.projectionRevision
                 || typeof message.generatedAt !== 'string'
@@ -2128,24 +2111,18 @@ function initProjectAiSessionsUpdate(options) {
                 || typeof isValidAiSessionPresentationState !== 'function'
                 || !isValidAiSessionPresentationState(message.presentation)
                 || message.presentation.projectionRevision !== message.projectionRevision
-                || typeof applyValidatedAiSessionPresentationState !== 'function')) {
+                || message.presentation.revealFocused !== false
+                || typeof applyValidatedAiSessionPresentationState !== 'function') {
             requestFullRefresh('invalid-ai-session-presentation-envelope');
             return;
         }
 
-        if (message.sequence <= latestAiSessionUpdateSequence) {
-            return;
-        }
         if (!canApplyProjectionRevision(message.projectionRevision)) {
             return;
         }
-        var canApplyMessagePresentation = isAtomicEnvelope
-            ? canApplyAtomicPresentationProjectionRevision(message.projectionRevision)
-            : canApplyPresentationProjectionRevision(message.projectionRevision);
-        if (isAtomicEnvelope && !canApplyMessagePresentation) {
+        if (!canApplyAtomicPresentationProjectionRevision(message.projectionRevision)) {
             return;
         }
-        var adoptRenderedPresentation = canApplyMessagePresentation;
 
         if (!applyWorkspaceUpdate({
             type: 'workspace-updated',
@@ -2161,12 +2138,7 @@ function initProjectAiSessionsUpdate(options) {
             return;
         }
 
-        latestAiSessionUpdateSequence = message.sequence;
-        commitProjectionRevision(
-            message.projectionRevision,
-            adoptRenderedPresentation,
-            isAtomicEnvelope
-        );
+        commitAtomicProjectionRevision(message.projectionRevision);
         if (batchAiSessionState.projectId) {
             var projectDiv = findCurrentWorkspaceDiv(batchAiSessionState.projectId);
             if (projectDiv) {
@@ -2177,11 +2149,7 @@ function initProjectAiSessionsUpdate(options) {
             }
         }
         reconcilePendingAiSessionProviderSelectionDom();
-        if (isAtomicEnvelope) {
-            applyValidatedAiSessionPresentationState(message.presentation);
-        } else {
-            syncAiSessionProjectionDom(adoptRenderedPresentation);
-        }
+        applyValidatedAiSessionPresentationState(message.presentation);
         updateStickyGroupHeaderOffset();
         if (window.__agentPivotDashboard) {
             window.__agentPivotDashboard.replaceSearchCatalog(message.searchCatalog);
@@ -2293,9 +2261,8 @@ function initProjectAiSessionsUpdate(options) {
         acceptInitialPresentationProjectionRevision: acceptInitialPresentationProjectionRevision,
         acceptPresentationProjectionRevision: acceptPresentationProjectionRevision,
         canApplyAtomicPresentationProjectionRevision: canApplyAtomicPresentationProjectionRevision,
-        canApplyPresentationProjectionRevision: canApplyPresentationProjectionRevision,
         canApplyProjectionRevision: canApplyProjectionRevision,
-        commitProjectionRevision: commitProjectionRevision,
+        commitAtomicProjectionRevision: commitAtomicProjectionRevision,
         findCurrentWorkspaceDiv: findCurrentWorkspaceDiv,
         findWorkspaceDiv: findWorkspaceDiv,
         focusSearchRevealTarget: focusSearchRevealTarget,
@@ -3822,6 +3789,17 @@ function initProjects() {
         return true;
     }
 
+    function applyDirectAiSessionPresentationState(message) {
+        if (!isValidAiSessionPresentationState(message)
+            || message.revealFocused !== true) {
+            aiSessionsUpdate.requestFullRefresh(
+                'invalid-direct-ai-session-presentation-state'
+            );
+            return false;
+        }
+        return applyAiSessionPresentationState(message, false);
+    }
+
     function applyValidatedAiSessionPresentationState(message) {
         window.__agentPivotAiSessionPresentationState = message;
         applyAiSessionPresentationDom(message);
@@ -4024,41 +4002,31 @@ function initProjects() {
             return;
         }
         if (message && message.type === 'open-workspaces-updated') {
-            var isAtomicOpenWorkspacesEnvelope = message.version === 3;
-            if (isAtomicOpenWorkspacesEnvelope
-                && (!isValidAiSessionPresentationState(message.presentation)
+            if (message.version !== 3) {
+                aiSessionsUpdate.requestFullRefresh(
+                    'unsupported-open-workspaces-message'
+                );
+                return;
+            }
+            if (!isValidAiSessionPresentationState(message.presentation)
                     || message.presentation.projectionRevision
-                        !== message.projectionRevision)) {
+                        !== message.projectionRevision
+                    || message.presentation.revealFocused !== false) {
                 aiSessionsUpdate.requestFullRefresh(
                     'invalid-open-workspaces-presentation-envelope'
                 );
                 return;
             }
             if (!aiSessionsUpdate.canApplyProjectionRevision(message.projectionRevision)) return;
-            var canApplyOpenWorkspacePresentation = isAtomicOpenWorkspacesEnvelope
-                ? aiSessionsUpdate.canApplyAtomicPresentationProjectionRevision(
-                    message.projectionRevision
-                )
-                : aiSessionsUpdate.canApplyPresentationProjectionRevision(
-                    message.projectionRevision
-                );
-            if (isAtomicOpenWorkspacesEnvelope
-                && !canApplyOpenWorkspacePresentation) return;
-            var adoptOpenWorkspacePresentation = canApplyOpenWorkspacePresentation;
+            if (!aiSessionsUpdate.canApplyAtomicPresentationProjectionRevision(
+                message.projectionRevision
+            )) return;
             if (!applyOpenWorkspacesUpdate(message)) {
                 aiSessionsUpdate.requestFullRefresh('invalid-open-workspaces-update');
                 return;
             }
-            aiSessionsUpdate.commitProjectionRevision(
-                message.projectionRevision,
-                adoptOpenWorkspacePresentation,
-                isAtomicOpenWorkspacesEnvelope
-            );
-            if (isAtomicOpenWorkspacesEnvelope) {
-                applyValidatedAiSessionPresentationState(message.presentation);
-            } else {
-                syncAiSessionProjectionDom(adoptOpenWorkspacePresentation);
-            }
+            aiSessionsUpdate.commitAtomicProjectionRevision(message.projectionRevision);
+            applyValidatedAiSessionPresentationState(message.presentation);
             updateStickyGroupHeaderOffset();
             if (openTabSplit && typeof openTabSplit.syncResizer === 'function') {
                 openTabSplit.syncResizer();
@@ -4097,7 +4065,7 @@ function initProjects() {
         }
 
         if (message && message.type === 'ai-session-presentation-state') {
-            applyAiSessionPresentationState(message, false);
+            applyDirectAiSessionPresentationState(message);
             return;
         }
 
@@ -4313,7 +4281,6 @@ function initProjects() {
     });
     restoreAiSessionTabsFromState(document, window.vscode);
     window.vscode.postMessage({ type: 'request-active-ai-session-terminal' });
-    window.vscode.postMessage({ type: 'request-ai-session-attention-state' });
 
     observeStickyGroupHeaderOffset();
 }

--- a/media/webviewProjectAiUpdateScripts.js
+++ b/media/webviewProjectAiUpdateScripts.js
@@ -18,10 +18,8 @@ function initProjectAiSessionsUpdate(options) {
     var applyValidatedAiSessionPresentationState = options.applyValidatedAiSessionPresentationState;
 
     var pendingWorkspaceSessionReveal = null;
-    var latestAiSessionUpdateSequence = 0;
     var latestAiSessionProjectionRevision = 0;
     var latestAiSessionPresentationProjectionRevision = 0;
-    var latestAiSessionDirectPresentationRevision = 0;
     var latestAiSessionClosedPresentationRevision = 0;
 
     function canApplyRevision(revision, latestRevision) {
@@ -37,10 +35,6 @@ function initProjectAiSessionsUpdate(options) {
         return canApplyRevision(revision, latestAiSessionProjectionRevision);
     }
 
-    function canApplyPresentationProjectionRevision(revision) {
-        return canApplyRevision(revision, latestAiSessionPresentationProjectionRevision);
-    }
-
     function canApplyAtomicPresentationProjectionRevision(revision) {
         return Number.isSafeInteger(revision)
             && revision > 0
@@ -48,21 +42,17 @@ function initProjectAiSessionsUpdate(options) {
             && revision > latestAiSessionClosedPresentationRevision;
     }
 
-    function commitProjectionRevision(revision, adoptedPresentation, closePresentation) {
+    function commitAtomicProjectionRevision(revision) {
         if (Number.isSafeInteger(revision) && revision > 0) {
             latestAiSessionProjectionRevision = revision;
-            if (adoptedPresentation) {
-                latestAiSessionPresentationProjectionRevision = Math.max(
-                    latestAiSessionPresentationProjectionRevision,
-                    revision
-                );
-            }
-            if (closePresentation) {
-                latestAiSessionClosedPresentationRevision = Math.max(
-                    latestAiSessionClosedPresentationRevision,
-                    revision
-                );
-            }
+            latestAiSessionPresentationProjectionRevision = Math.max(
+                latestAiSessionPresentationProjectionRevision,
+                revision
+            );
+            latestAiSessionClosedPresentationRevision = Math.max(
+                latestAiSessionClosedPresentationRevision,
+                revision
+            );
         }
     }
 
@@ -70,16 +60,11 @@ function initProjectAiSessionsUpdate(options) {
         if (!Number.isSafeInteger(revision)
             || revision <= 0
             || revision < latestAiSessionProjectionRevision
-            || revision < latestAiSessionPresentationProjectionRevision
-            || revision <= latestAiSessionClosedPresentationRevision
-            || revision <= latestAiSessionDirectPresentationRevision) {
+            || revision <= latestAiSessionPresentationProjectionRevision
+            || revision <= latestAiSessionClosedPresentationRevision) {
             return false;
         }
-        latestAiSessionPresentationProjectionRevision = Math.max(
-            latestAiSessionPresentationProjectionRevision,
-            revision
-        );
-        latestAiSessionDirectPresentationRevision = revision;
+        latestAiSessionPresentationProjectionRevision = revision;
         return true;
     }
 
@@ -88,18 +73,17 @@ function initProjectAiSessionsUpdate(options) {
             || revision <= 0
             || latestAiSessionProjectionRevision !== 0
             || latestAiSessionPresentationProjectionRevision !== 0
-            || latestAiSessionDirectPresentationRevision !== 0) {
+            || latestAiSessionClosedPresentationRevision !== 0) {
             return false;
         }
         latestAiSessionProjectionRevision = revision;
         latestAiSessionPresentationProjectionRevision = revision;
-        latestAiSessionDirectPresentationRevision = revision;
+        latestAiSessionClosedPresentationRevision = revision;
         return true;
     }
 
     function applyAiSessionsUpdate(message) {
-        var isAtomicEnvelope = message.version === 3;
-        if ((message.version !== 2 && !isAtomicEnvelope)
+        if (message.version !== 3
             || typeof message.sequence !== 'number'
             || (message.currentWorkspaceCount !== 0 && message.currentWorkspaceCount !== 1)
             || typeof message.html !== 'string'
@@ -110,8 +94,7 @@ function initProjectAiSessionsUpdate(options) {
             return;
         }
 
-        if (isAtomicEnvelope
-            && (!Number.isSafeInteger(message.projectionRevision)
+        if (!Number.isSafeInteger(message.projectionRevision)
                 || message.projectionRevision <= 0
                 || message.sequence !== message.projectionRevision
                 || typeof message.generatedAt !== 'string'
@@ -119,24 +102,18 @@ function initProjectAiSessionsUpdate(options) {
                 || typeof isValidAiSessionPresentationState !== 'function'
                 || !isValidAiSessionPresentationState(message.presentation)
                 || message.presentation.projectionRevision !== message.projectionRevision
-                || typeof applyValidatedAiSessionPresentationState !== 'function')) {
+                || message.presentation.revealFocused !== false
+                || typeof applyValidatedAiSessionPresentationState !== 'function') {
             requestFullRefresh('invalid-ai-session-presentation-envelope');
             return;
         }
 
-        if (message.sequence <= latestAiSessionUpdateSequence) {
-            return;
-        }
         if (!canApplyProjectionRevision(message.projectionRevision)) {
             return;
         }
-        var canApplyMessagePresentation = isAtomicEnvelope
-            ? canApplyAtomicPresentationProjectionRevision(message.projectionRevision)
-            : canApplyPresentationProjectionRevision(message.projectionRevision);
-        if (isAtomicEnvelope && !canApplyMessagePresentation) {
+        if (!canApplyAtomicPresentationProjectionRevision(message.projectionRevision)) {
             return;
         }
-        var adoptRenderedPresentation = canApplyMessagePresentation;
 
         if (!applyWorkspaceUpdate({
             type: 'workspace-updated',
@@ -152,12 +129,7 @@ function initProjectAiSessionsUpdate(options) {
             return;
         }
 
-        latestAiSessionUpdateSequence = message.sequence;
-        commitProjectionRevision(
-            message.projectionRevision,
-            adoptRenderedPresentation,
-            isAtomicEnvelope
-        );
+        commitAtomicProjectionRevision(message.projectionRevision);
         if (batchAiSessionState.projectId) {
             var projectDiv = findCurrentWorkspaceDiv(batchAiSessionState.projectId);
             if (projectDiv) {
@@ -168,11 +140,7 @@ function initProjectAiSessionsUpdate(options) {
             }
         }
         reconcilePendingAiSessionProviderSelectionDom();
-        if (isAtomicEnvelope) {
-            applyValidatedAiSessionPresentationState(message.presentation);
-        } else {
-            syncAiSessionProjectionDom(adoptRenderedPresentation);
-        }
+        applyValidatedAiSessionPresentationState(message.presentation);
         updateStickyGroupHeaderOffset();
         if (window.__agentPivotDashboard) {
             window.__agentPivotDashboard.replaceSearchCatalog(message.searchCatalog);
@@ -284,9 +252,8 @@ function initProjectAiSessionsUpdate(options) {
         acceptInitialPresentationProjectionRevision: acceptInitialPresentationProjectionRevision,
         acceptPresentationProjectionRevision: acceptPresentationProjectionRevision,
         canApplyAtomicPresentationProjectionRevision: canApplyAtomicPresentationProjectionRevision,
-        canApplyPresentationProjectionRevision: canApplyPresentationProjectionRevision,
         canApplyProjectionRevision: canApplyProjectionRevision,
-        commitProjectionRevision: commitProjectionRevision,
+        commitAtomicProjectionRevision: commitAtomicProjectionRevision,
         findCurrentWorkspaceDiv: findCurrentWorkspaceDiv,
         findWorkspaceDiv: findWorkspaceDiv,
         focusSearchRevealTarget: focusSearchRevealTarget,

--- a/media/webviewProjectScripts.js
+++ b/media/webviewProjectScripts.js
@@ -648,6 +648,17 @@ function initProjects() {
         return true;
     }
 
+    function applyDirectAiSessionPresentationState(message) {
+        if (!isValidAiSessionPresentationState(message)
+            || message.revealFocused !== true) {
+            aiSessionsUpdate.requestFullRefresh(
+                'invalid-direct-ai-session-presentation-state'
+            );
+            return false;
+        }
+        return applyAiSessionPresentationState(message, false);
+    }
+
     function applyValidatedAiSessionPresentationState(message) {
         window.__agentPivotAiSessionPresentationState = message;
         applyAiSessionPresentationDom(message);
@@ -850,41 +861,31 @@ function initProjects() {
             return;
         }
         if (message && message.type === 'open-workspaces-updated') {
-            var isAtomicOpenWorkspacesEnvelope = message.version === 3;
-            if (isAtomicOpenWorkspacesEnvelope
-                && (!isValidAiSessionPresentationState(message.presentation)
+            if (message.version !== 3) {
+                aiSessionsUpdate.requestFullRefresh(
+                    'unsupported-open-workspaces-message'
+                );
+                return;
+            }
+            if (!isValidAiSessionPresentationState(message.presentation)
                     || message.presentation.projectionRevision
-                        !== message.projectionRevision)) {
+                        !== message.projectionRevision
+                    || message.presentation.revealFocused !== false) {
                 aiSessionsUpdate.requestFullRefresh(
                     'invalid-open-workspaces-presentation-envelope'
                 );
                 return;
             }
             if (!aiSessionsUpdate.canApplyProjectionRevision(message.projectionRevision)) return;
-            var canApplyOpenWorkspacePresentation = isAtomicOpenWorkspacesEnvelope
-                ? aiSessionsUpdate.canApplyAtomicPresentationProjectionRevision(
-                    message.projectionRevision
-                )
-                : aiSessionsUpdate.canApplyPresentationProjectionRevision(
-                    message.projectionRevision
-                );
-            if (isAtomicOpenWorkspacesEnvelope
-                && !canApplyOpenWorkspacePresentation) return;
-            var adoptOpenWorkspacePresentation = canApplyOpenWorkspacePresentation;
+            if (!aiSessionsUpdate.canApplyAtomicPresentationProjectionRevision(
+                message.projectionRevision
+            )) return;
             if (!applyOpenWorkspacesUpdate(message)) {
                 aiSessionsUpdate.requestFullRefresh('invalid-open-workspaces-update');
                 return;
             }
-            aiSessionsUpdate.commitProjectionRevision(
-                message.projectionRevision,
-                adoptOpenWorkspacePresentation,
-                isAtomicOpenWorkspacesEnvelope
-            );
-            if (isAtomicOpenWorkspacesEnvelope) {
-                applyValidatedAiSessionPresentationState(message.presentation);
-            } else {
-                syncAiSessionProjectionDom(adoptOpenWorkspacePresentation);
-            }
+            aiSessionsUpdate.commitAtomicProjectionRevision(message.projectionRevision);
+            applyValidatedAiSessionPresentationState(message.presentation);
             updateStickyGroupHeaderOffset();
             if (openTabSplit && typeof openTabSplit.syncResizer === 'function') {
                 openTabSplit.syncResizer();
@@ -923,7 +924,7 @@ function initProjects() {
         }
 
         if (message && message.type === 'ai-session-presentation-state') {
-            applyAiSessionPresentationState(message, false);
+            applyDirectAiSessionPresentationState(message);
             return;
         }
 
@@ -1139,7 +1140,6 @@ function initProjects() {
     });
     restoreAiSessionTabsFromState(document, window.vscode);
     window.vscode.postMessage({ type: 'request-active-ai-session-terminal' });
-    window.vscode.postMessage({ type: 'request-ai-session-attention-state' });
 
     observeStickyGroupHeaderOffset();
 }

--- a/media/webviewWorkspaceUpdateScripts.js
+++ b/media/webviewWorkspaceUpdateScripts.js
@@ -257,7 +257,7 @@ function completeOpenWorkspacePin(message) {
 function applyOpenWorkspacesUpdate(message) {
     if (!message
         || message.type !== 'open-workspaces-updated'
-        || (message.version !== 2 && message.version !== 3)
+        || message.version !== 3
         || typeof message.semanticRevision !== 'string'
         || !message.semanticRevision
         || (message.currentWorkspaceCount !== 0 && message.currentWorkspaceCount !== 1)

--- a/scripts/run-ai-session-safety-checks.js
+++ b/scripts/run-ai-session-safety-checks.js
@@ -6650,6 +6650,8 @@ function runBatchAiSessionWebviewChecks() {
                         ? aiSessionMenuItems.find(item => !item.classList.contains('disabled')) : null,
     };
     const context = {
+        CSS: { escape: value => String(value) },
+        Node: { TEXT_NODE: 3 },
         normalizeDashboardSearchCatalog: value => value
             && Array.isArray(value.sessions)
             && Array.isArray(value.savedProjects)
@@ -6815,9 +6817,8 @@ function runBatchAiSessionWebviewChecks() {
     assert.deepStrictEqual(JSON.parse(JSON.stringify(messages.shift())), {
         type: 'request-active-ai-session-terminal',
     });
-    assert.deepStrictEqual(JSON.parse(JSON.stringify(messages.shift())), {
-        type: 'request-ai-session-attention-state',
-    });
+    assert.strictEqual(messages.length, 0,
+        'initial attention is embedded in the document and must not request a second direct projection');
     messages.length = 0;
 
     assert.strictEqual(context.window.__agentPivotRevealWorkspaceSession(
@@ -7104,19 +7105,32 @@ function runBatchAiSessionWebviewChecks() {
         && typeof message.html === 'string';
     windowEventListeners.message({ data: {
         type: 'ai-sessions-updated',
-        version: 2,
-        sequence: 1,
+        version: 3,
+        sequence: 2,
         projectionRevision: 2,
+        generatedAt: '2026-08-11T00:00:00.000Z',
         currentWorkspaceCount: 1,
         html: '<div class="open-current-workspace-group"></div>',
         searchCatalog: { version: 2, sessions: [], openWorkspaces: [], savedProjects: [], todos: TODO_SEARCH_ITEMS },
+        presentation: {
+            type: 'ai-session-presentation-state', version: 1, projectionRevision: 2,
+            workspaceScopeIdentity: null, workspaceNavigationIdentity: null,
+            attentionCount: 0, activeAttentionCount: 0, runningSessionCount: 1,
+            runningCardAnimation: 'current', runningIconAnimation: 'current',
+            revealFocused: false,
+            focusedTarget: { provider: 'codex', sessionId: 'active-session' },
+            attentionSessions: [],
+            sessions: [{
+                provider: 'codex', sessionId: 'active-session', executionState: 'running',
+                focused: true, needsAttention: false, conflict: false, eventIds: [],
+            }],
+        },
     } });
     assert.deepStrictEqual(
         JSON.parse(JSON.stringify(replacedSearchCatalog.todos)),
         TODO_SEARCH_ITEMS,
         'AI incremental rendering must preserve the non-empty TODO catalog replacement'
     );
-    assert.strictEqual(activeRow.hasAttribute('data-ai-session-active-terminal'), true);
     const manager = context.window.__agentPivotBatchAiSessions;
     manager.enter('project-a');
     manager.toggle('codex', 'plain');
@@ -7356,7 +7370,8 @@ function runAiSessionIncrementalRefreshSourceChecks() {
     const aiSessionUpdateBody = extractFunctionBody(projectWebviewSource, 'applyAiSessionsUpdate');
     assert.ok(aiSessionUpdateBody.includes('syncAiSessionBatchManagementDom(projectDiv)'));
     assert.ok(projectWebviewSource.includes("message.type !== 'ai-sessions-updated'"));
-    assert.ok(aiSessionUpdateBody.includes('message.version !== 2'));
+    assert.ok(aiSessionUpdateBody.includes('message.version !== 3'));
+    assert.strictEqual(aiSessionUpdateBody.includes('message.version !== 2'), false);
 
     assert.ok(dashboard.includes('AI_SESSION_WATCHER_REFRESH_MIN_INTERVAL_MS'));
     assert.ok(dashboard.includes('watcherRefreshMinIntervalMs: AI_SESSION_WATCHER_REFRESH_MIN_INTERVAL_MS'));
@@ -7394,7 +7409,8 @@ function runAiSessionIncrementalRefreshSourceChecks() {
     assert.strictEqual(dashboard.includes('getProjectionSnapshot: () => aiSessionProjectionCoordinator.capture(),'), true);
     assert.ok(dashboard.includes('getCards: projection => getOpenWorkspaceCards(projection),'));
     assert.ok(dashboard.includes('const transaction = aiSessionProjectionCoordinator.captureNext('));
-    assert.ok(!dashboard.includes('postAiSessionPresentationState(false, transaction);'));
+    assert.ok(!dashboard.includes('postAiSessionPresentationState('));
+    assert.ok(dashboard.includes('postActiveAiSessionTerminalPresentation()'));
     assert.ok(controllerSource.includes('presentation: buildAiSessionPresentationState('));
     assert.ok(workspaceHydrationSource.includes('activePresentation,'));
     assert.ok(dashboard.includes('beginAiSessionProjection: () => {'));

--- a/scripts/run-architecture-guards.js
+++ b/scripts/run-architecture-guards.js
@@ -694,6 +694,12 @@ const guards = {
             this.id,
             risk
         );
+        const workspaceWebview = parseJavascript(
+            root,
+            'src/webview/webviewWorkspaceUpdateScripts.js',
+            this.id,
+            risk
+        );
         const controllerSource = controller.getFullText();
         if (controllerSource.includes('nextSequence')
             || controllerSource.includes('beforeRefresh')) {
@@ -721,12 +727,9 @@ const guards = {
         const dashboardSource = dashboard.getFullText();
         if (!/getCards:\s*projection\s*=>\s*getOpenWorkspaceCards\(projection\)/
             .test(dashboardSource)
-            || !controllerSource.includes(
-                'presentation: buildAiSessionPresentationState('
-            )
-            || dashboardSource.includes(
-                'postAiSessionPresentationState(false, transaction);'
-            )) {
+            || !/presentation:\s*buildAiSessionPresentationState\(\s*false,\s*projection,/
+                .test(controllerSource)
+            || dashboardSource.includes('postAiSessionPresentationState(')) {
             fail(this.id, risk,
                 'AI incremental HTML and Presentation must share one Host message');
         }
@@ -739,8 +742,7 @@ const guards = {
                 'hydration must consume the transaction presentation with only an explicit fallback');
         }
         const webviewSource = webview.getFullText();
-        if (!webviewSource.includes('latestAiSessionDirectPresentationRevision')
-            || !webviewSource.includes('latestAiSessionClosedPresentationRevision')
+        if (!webviewSource.includes('latestAiSessionClosedPresentationRevision')
             || !webviewSource.includes('revision < latestAiSessionProjectionRevision')
             || !webviewSource.includes(
                 'revision <= latestAiSessionClosedPresentationRevision'
@@ -751,9 +753,15 @@ const guards = {
             || !webviewSource.includes(
                 'revision > latestAiSessionClosedPresentationRevision'
             )
-            || !webviewSource.includes('revision <= latestAiSessionDirectPresentationRevision')) {
+            || !webviewSource.includes(
+                'revision <= latestAiSessionPresentationProjectionRevision'
+            )
+            || webviewSource.includes('latestAiSessionDirectPresentationRevision')
+            || webviewSource.includes('canApplyPresentationProjectionRevision')
+            || !webviewSource.includes('message.version !== 3')
+            || webviewSource.includes('message.version !== 2')) {
             fail(this.id, risk,
-                'the Webview must close v3 envelopes while preserving v2 same-revision Presentation');
+                'the Webview must accept only v3 envelopes and close each revision against direct Presentation');
         }
         if (!/renderContent:\s*\(webview,\s*documentGeneration\)\s*=>\s*\{[\s\S]*?const transaction = aiSessionProjectionCoordinator\.captureNext\([\s\S]*?getOpenWorkspaceCards\(transaction\)[\s\S]*?buildAiSessionPresentationState\(\s*false,\s*transaction,/
             .test(dashboardSource)
@@ -764,6 +772,7 @@ const guards = {
                 'the full Dashboard document must capture and embed one Presentation transaction');
         }
         const projectWebviewSource = projectWebview.getFullText();
+        const workspaceWebviewSource = workspaceWebview.getFullText();
         if (!webviewSource.includes('acceptInitialPresentationProjectionRevision')
             || !webviewSource.includes('latestAiSessionProjectionRevision = revision;')
             || !projectWebviewSource.includes(
@@ -783,15 +792,15 @@ const guards = {
             || !openWorkspaceSource.includes('projectionRevision: projection.revision')
             || !updateMessageSource.includes(
                 'projectionRevision: input.projectionRevision'
-            ) || !openWorkspaceSource.includes(
-                'presentation: buildAiSessionPresentationState('
-            ) || !updateMessageSource.includes('presentation: input.presentation')
+            ) || !/presentation:\s*buildAiSessionPresentationState\(\s*false,\s*projection,/
+                .test(openWorkspaceSource)
+            || !updateMessageSource.includes('presentation: input.presentation')
             || !updateMessageSource.includes('version: 3')
             || dashboardSource.includes(
                 'projectionRevision: aiSessionProjectionCoordinator.nextRevision()'
-            ) || dashboardSource.includes(
-                'postAiSessionPresentationState(false, transaction);'
-            )
+            ) || dashboardSource.includes('postAiSessionPresentationState(')
+            || !/function postActiveAiSessionTerminalPresentation\([\s\S]*?buildAiSessionPresentationState\(\s*true,\s*transaction,/
+                .test(dashboardSource)
             ) {
             fail(this.id, risk,
                 'OPEN HTML and Presentation must share one Host message');
@@ -799,22 +808,33 @@ const guards = {
         if (!webviewSource.includes(
             'message.presentation.projectionRevision !== message.projectionRevision'
         ) || !webviewSource.includes(
+            'message.presentation.revealFocused !== false'
+        ) || !webviewSource.includes(
             'applyValidatedAiSessionPresentationState(message.presentation);'
         ) || !webviewSource.includes(
-            'adoptRenderedPresentation,\n            isAtomicEnvelope'
+            'canApplyAtomicPresentationProjectionRevision(message.projectionRevision)'
         ) || !webviewSource.includes(
-            '? canApplyAtomicPresentationProjectionRevision(message.projectionRevision)'
+            'commitAtomicProjectionRevision(message.projectionRevision)'
         ) || !projectWebviewSource.includes(
             'invalid-open-workspaces-presentation-envelope'
         ) || !projectWebviewSource.includes(
+            'message.presentation.revealFocused !== false'
+        ) || !projectWebviewSource.includes(
             'applyValidatedAiSessionPresentationState(message.presentation);'
         ) || !projectWebviewSource.includes(
-            'adoptOpenWorkspacePresentation,\n                isAtomicOpenWorkspacesEnvelope'
+            'aiSessionsUpdate.canApplyAtomicPresentationProjectionRevision('
         ) || !projectWebviewSource.includes(
-            '? aiSessionsUpdate.canApplyAtomicPresentationProjectionRevision('
-        )) {
+            'aiSessionsUpdate.commitAtomicProjectionRevision(message.projectionRevision)'
+        ) || !projectWebviewSource.includes('message.version !== 3')
+            || projectWebviewSource.includes('isAtomicOpenWorkspacesEnvelope')
+            || !projectWebviewSource.includes('message.revealFocused !== true')
+            || projectWebviewSource.includes(
+                "type: 'request-ai-session-attention-state'"
+            ) || !workspaceWebviewSource.includes(
+                "message.type !== 'open-workspaces-updated'\n        || message.version !== 3"
+            )) {
             fail(this.id, risk,
-                'the Webview must validate and apply each HTML-Presentation envelope atomically');
+                'the Webview must validate v3 envelopes atomically and reserve direct Presentation for focus');
         }
     },
 

--- a/src/aiSessions/attentionEventCapability.ts
+++ b/src/aiSessions/attentionEventCapability.ts
@@ -56,7 +56,6 @@ export interface AiSessionAttentionEventCapabilityOptions {
     getRuntimeConfiguration: () => AiSessionRuntimeConfiguration;
     getCurrentOpenWorkspace: () => OpenWorkspace | null;
     getActiveTerminal: () => vscode.Terminal | null;
-    postAttentionState: () => void;
     isVisible: () => boolean;
     assertActive: () => void;
     createBridgeClient: (
@@ -111,7 +110,6 @@ export interface AiSessionAttentionEventCapability {
     belongsToCurrentWorkspace(runtime: AiSessionRuntimeSnapshot<vscode.Terminal>): boolean;
     refreshViewsIncrementally(): void;
     scheduleViewsRefresh(): void;
-    postAttentionState(): void;
     acknowledgeEventIds(
         eventIds: string[],
         target?: AiSessionAttentionAcknowledgementTarget
@@ -145,7 +143,6 @@ export function createAiSessionAttentionEventCapability(
     const getRuntimeConfiguration = options.getRuntimeConfiguration;
     const getCurrentOpenWorkspace = options.getCurrentOpenWorkspace;
     const getActiveTerminal = options.getActiveTerminal;
-    const postAttentionState = options.postAttentionState;
     const isVisible = options.isVisible;
     const assertActive = options.assertActive;
     const createBridgeClient = options.createBridgeClient;
@@ -338,10 +335,6 @@ export function createAiSessionAttentionEventCapability(
         void refreshViewsNow('tmux-bootstrap-restore');
     }
 
-    function postAiSessionAttentionState() {
-        postAttentionState();
-    }
-
     const getAiSessionAttentionEventIds = (identity: ActiveAiSessionTerminalIdentity): string[] => {
         const sessionKey = getAiSessionKey(identity.provider, identity.sessionId);
         return getAttentionController().getRecoverySessionEvents()
@@ -485,7 +478,6 @@ export function createAiSessionAttentionEventCapability(
         belongsToCurrentWorkspace: runtimeBelongsToCurrentWorkspace,
         refreshViewsIncrementally: refreshAiSessionViewsIncrementally,
         scheduleViewsRefresh: scheduleAttentionViewsRefresh,
-        postAttentionState: postAiSessionAttentionState,
         acknowledgeEventIds: acknowledgeAiSessionAttentionEventIds,
         acknowledgeAttention: acknowledgeAiSessionAttention,
         publish: (items, forceHeartbeat) => aiSessionAttentionBridgeClient.publish(items, forceHeartbeat),

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1042,7 +1042,6 @@ async function initializeDashboard(
         getRuntimeConfiguration: () => aiSessionRuntimeConfiguration,
         getCurrentOpenWorkspace: () => getCurrentOpenWorkspace(),
         getActiveTerminal: () => vscode.window.activeTerminal || null,
-        postAttentionState: () => postAiSessionPresentationState(false),
         isVisible: () => provider.visible,
         assertActive: () => resources.assertActive(),
         createBridgeClient: (onAggregate, onError) => new AttentionBridgeClient(onAggregate, onError),
@@ -1070,7 +1069,6 @@ async function initializeDashboard(
     const getFocusedAiSessionRuntimeIdentity = aiSessionAttentionEvent.getFocusedRuntimeIdentity;
     const runtimeBelongsToCurrentWorkspace = aiSessionAttentionEvent.belongsToCurrentWorkspace;
     const refreshAiSessionViewsIncrementally = aiSessionAttentionEvent.refreshViewsIncrementally;
-    const postAiSessionAttentionState = aiSessionAttentionEvent.postAttentionState;
     const acknowledgeAiSessionAttentionEventIds = aiSessionAttentionEvent.acknowledgeEventIds;
     const acknowledgeAiSessionAttention = aiSessionAttentionEvent.acknowledgeAttention;
     const publishDeferredTmuxRestoreIfReady = aiSessionAttentionEvent.publishDeferredRestoreIfReady;
@@ -1653,7 +1651,6 @@ async function initializeDashboard(
             });
         },
         requestActiveAiSessionTerminalHighlight: () => activeAiSessionTerminalHighlighter.request(),
-        postAiSessionAttentionState,
         showAgentPivotSettings,
         showBridgeExtension: () => vscode.commands.executeCommand(
             'workbench.extensions.action.showExtensionsWithIds',
@@ -2646,17 +2643,16 @@ async function initializeDashboard(
 
     function postActiveAiSessionTerminalChanged() {
         void conversationCapability.reconcile();
-        postAiSessionPresentationState(true);
+        postActiveAiSessionTerminalPresentation();
     }
 
-    function postAiSessionPresentationState(
-        revealFocused: boolean = false,
+    function postActiveAiSessionTerminalPresentation(
         transaction: AiSessionPresentationTransaction<vscode.Terminal>
             = aiSessionProjectionCoordinator.captureNext(getCurrentOpenWorkspace())
     ): void {
         const configuration = getAgentPivotConfiguration();
         const message = buildAiSessionPresentationState(
-            revealFocused,
+            true,
             transaction,
             getEffectiveRunningCardAnimation(configuration),
             getEffectiveRunningIconAnimation(configuration),

--- a/src/dashboard/messageHandlers.ts
+++ b/src/dashboard/messageHandlers.ts
@@ -39,7 +39,6 @@ export interface DashboardMessageHandlersOptions {
     onOpenWorkspacesRendererReady: () => void;
     /** Late-bound: the highlighter is constructed after the message router. */
     requestActiveAiSessionTerminalHighlight: () => void;
-    postAiSessionAttentionState: () => void;
     showAgentPivotSettings: () => Promise<void>;
     showBridgeExtension: () => Thenable<unknown>;
     showSponsorOptions: () => Promise<void>;
@@ -74,7 +73,6 @@ export function createDashboardMessageHandlers(
     const refreshStewardViews = options.refreshStewardViews;
     const onOpenWorkspacesRendererReady = options.onOpenWorkspacesRendererReady;
     const requestActiveAiSessionTerminalHighlight = options.requestActiveAiSessionTerminalHighlight;
-    const postAiSessionAttentionState = options.postAiSessionAttentionState;
     const showAgentPivotSettings = options.showAgentPivotSettings;
     const showBridgeExtension = options.showBridgeExtension;
     const showSponsorOptions = options.showSponsorOptions;
@@ -343,9 +341,6 @@ export function createDashboardMessageHandlers(
         },
         'request-active-ai-session-terminal': () => {
             requestActiveAiSessionTerminalHighlight();
-        },
-        'request-ai-session-attention-state': () => {
-            postAiSessionAttentionState();
         },
         'open-settings': async () => {
             await showAgentPivotSettings();

--- a/src/webview/webviewProjectAiUpdateScripts.js
+++ b/src/webview/webviewProjectAiUpdateScripts.js
@@ -18,10 +18,8 @@ function initProjectAiSessionsUpdate(options) {
     var applyValidatedAiSessionPresentationState = options.applyValidatedAiSessionPresentationState;
 
     var pendingWorkspaceSessionReveal = null;
-    var latestAiSessionUpdateSequence = 0;
     var latestAiSessionProjectionRevision = 0;
     var latestAiSessionPresentationProjectionRevision = 0;
-    var latestAiSessionDirectPresentationRevision = 0;
     var latestAiSessionClosedPresentationRevision = 0;
 
     function canApplyRevision(revision, latestRevision) {
@@ -37,10 +35,6 @@ function initProjectAiSessionsUpdate(options) {
         return canApplyRevision(revision, latestAiSessionProjectionRevision);
     }
 
-    function canApplyPresentationProjectionRevision(revision) {
-        return canApplyRevision(revision, latestAiSessionPresentationProjectionRevision);
-    }
-
     function canApplyAtomicPresentationProjectionRevision(revision) {
         return Number.isSafeInteger(revision)
             && revision > 0
@@ -48,21 +42,17 @@ function initProjectAiSessionsUpdate(options) {
             && revision > latestAiSessionClosedPresentationRevision;
     }
 
-    function commitProjectionRevision(revision, adoptedPresentation, closePresentation) {
+    function commitAtomicProjectionRevision(revision) {
         if (Number.isSafeInteger(revision) && revision > 0) {
             latestAiSessionProjectionRevision = revision;
-            if (adoptedPresentation) {
-                latestAiSessionPresentationProjectionRevision = Math.max(
-                    latestAiSessionPresentationProjectionRevision,
-                    revision
-                );
-            }
-            if (closePresentation) {
-                latestAiSessionClosedPresentationRevision = Math.max(
-                    latestAiSessionClosedPresentationRevision,
-                    revision
-                );
-            }
+            latestAiSessionPresentationProjectionRevision = Math.max(
+                latestAiSessionPresentationProjectionRevision,
+                revision
+            );
+            latestAiSessionClosedPresentationRevision = Math.max(
+                latestAiSessionClosedPresentationRevision,
+                revision
+            );
         }
     }
 
@@ -70,16 +60,11 @@ function initProjectAiSessionsUpdate(options) {
         if (!Number.isSafeInteger(revision)
             || revision <= 0
             || revision < latestAiSessionProjectionRevision
-            || revision < latestAiSessionPresentationProjectionRevision
-            || revision <= latestAiSessionClosedPresentationRevision
-            || revision <= latestAiSessionDirectPresentationRevision) {
+            || revision <= latestAiSessionPresentationProjectionRevision
+            || revision <= latestAiSessionClosedPresentationRevision) {
             return false;
         }
-        latestAiSessionPresentationProjectionRevision = Math.max(
-            latestAiSessionPresentationProjectionRevision,
-            revision
-        );
-        latestAiSessionDirectPresentationRevision = revision;
+        latestAiSessionPresentationProjectionRevision = revision;
         return true;
     }
 
@@ -88,18 +73,17 @@ function initProjectAiSessionsUpdate(options) {
             || revision <= 0
             || latestAiSessionProjectionRevision !== 0
             || latestAiSessionPresentationProjectionRevision !== 0
-            || latestAiSessionDirectPresentationRevision !== 0) {
+            || latestAiSessionClosedPresentationRevision !== 0) {
             return false;
         }
         latestAiSessionProjectionRevision = revision;
         latestAiSessionPresentationProjectionRevision = revision;
-        latestAiSessionDirectPresentationRevision = revision;
+        latestAiSessionClosedPresentationRevision = revision;
         return true;
     }
 
     function applyAiSessionsUpdate(message) {
-        var isAtomicEnvelope = message.version === 3;
-        if ((message.version !== 2 && !isAtomicEnvelope)
+        if (message.version !== 3
             || typeof message.sequence !== 'number'
             || (message.currentWorkspaceCount !== 0 && message.currentWorkspaceCount !== 1)
             || typeof message.html !== 'string'
@@ -110,8 +94,7 @@ function initProjectAiSessionsUpdate(options) {
             return;
         }
 
-        if (isAtomicEnvelope
-            && (!Number.isSafeInteger(message.projectionRevision)
+        if (!Number.isSafeInteger(message.projectionRevision)
                 || message.projectionRevision <= 0
                 || message.sequence !== message.projectionRevision
                 || typeof message.generatedAt !== 'string'
@@ -119,24 +102,18 @@ function initProjectAiSessionsUpdate(options) {
                 || typeof isValidAiSessionPresentationState !== 'function'
                 || !isValidAiSessionPresentationState(message.presentation)
                 || message.presentation.projectionRevision !== message.projectionRevision
-                || typeof applyValidatedAiSessionPresentationState !== 'function')) {
+                || message.presentation.revealFocused !== false
+                || typeof applyValidatedAiSessionPresentationState !== 'function') {
             requestFullRefresh('invalid-ai-session-presentation-envelope');
             return;
         }
 
-        if (message.sequence <= latestAiSessionUpdateSequence) {
-            return;
-        }
         if (!canApplyProjectionRevision(message.projectionRevision)) {
             return;
         }
-        var canApplyMessagePresentation = isAtomicEnvelope
-            ? canApplyAtomicPresentationProjectionRevision(message.projectionRevision)
-            : canApplyPresentationProjectionRevision(message.projectionRevision);
-        if (isAtomicEnvelope && !canApplyMessagePresentation) {
+        if (!canApplyAtomicPresentationProjectionRevision(message.projectionRevision)) {
             return;
         }
-        var adoptRenderedPresentation = canApplyMessagePresentation;
 
         if (!applyWorkspaceUpdate({
             type: 'workspace-updated',
@@ -152,12 +129,7 @@ function initProjectAiSessionsUpdate(options) {
             return;
         }
 
-        latestAiSessionUpdateSequence = message.sequence;
-        commitProjectionRevision(
-            message.projectionRevision,
-            adoptRenderedPresentation,
-            isAtomicEnvelope
-        );
+        commitAtomicProjectionRevision(message.projectionRevision);
         if (batchAiSessionState.projectId) {
             var projectDiv = findCurrentWorkspaceDiv(batchAiSessionState.projectId);
             if (projectDiv) {
@@ -168,11 +140,7 @@ function initProjectAiSessionsUpdate(options) {
             }
         }
         reconcilePendingAiSessionProviderSelectionDom();
-        if (isAtomicEnvelope) {
-            applyValidatedAiSessionPresentationState(message.presentation);
-        } else {
-            syncAiSessionProjectionDom(adoptRenderedPresentation);
-        }
+        applyValidatedAiSessionPresentationState(message.presentation);
         updateStickyGroupHeaderOffset();
         if (window.__agentPivotDashboard) {
             window.__agentPivotDashboard.replaceSearchCatalog(message.searchCatalog);
@@ -284,9 +252,8 @@ function initProjectAiSessionsUpdate(options) {
         acceptInitialPresentationProjectionRevision: acceptInitialPresentationProjectionRevision,
         acceptPresentationProjectionRevision: acceptPresentationProjectionRevision,
         canApplyAtomicPresentationProjectionRevision: canApplyAtomicPresentationProjectionRevision,
-        canApplyPresentationProjectionRevision: canApplyPresentationProjectionRevision,
         canApplyProjectionRevision: canApplyProjectionRevision,
-        commitProjectionRevision: commitProjectionRevision,
+        commitAtomicProjectionRevision: commitAtomicProjectionRevision,
         findCurrentWorkspaceDiv: findCurrentWorkspaceDiv,
         findWorkspaceDiv: findWorkspaceDiv,
         focusSearchRevealTarget: focusSearchRevealTarget,

--- a/src/webview/webviewProjectScripts.js
+++ b/src/webview/webviewProjectScripts.js
@@ -648,6 +648,17 @@ function initProjects() {
         return true;
     }
 
+    function applyDirectAiSessionPresentationState(message) {
+        if (!isValidAiSessionPresentationState(message)
+            || message.revealFocused !== true) {
+            aiSessionsUpdate.requestFullRefresh(
+                'invalid-direct-ai-session-presentation-state'
+            );
+            return false;
+        }
+        return applyAiSessionPresentationState(message, false);
+    }
+
     function applyValidatedAiSessionPresentationState(message) {
         window.__agentPivotAiSessionPresentationState = message;
         applyAiSessionPresentationDom(message);
@@ -850,41 +861,31 @@ function initProjects() {
             return;
         }
         if (message && message.type === 'open-workspaces-updated') {
-            var isAtomicOpenWorkspacesEnvelope = message.version === 3;
-            if (isAtomicOpenWorkspacesEnvelope
-                && (!isValidAiSessionPresentationState(message.presentation)
+            if (message.version !== 3) {
+                aiSessionsUpdate.requestFullRefresh(
+                    'unsupported-open-workspaces-message'
+                );
+                return;
+            }
+            if (!isValidAiSessionPresentationState(message.presentation)
                     || message.presentation.projectionRevision
-                        !== message.projectionRevision)) {
+                        !== message.projectionRevision
+                    || message.presentation.revealFocused !== false) {
                 aiSessionsUpdate.requestFullRefresh(
                     'invalid-open-workspaces-presentation-envelope'
                 );
                 return;
             }
             if (!aiSessionsUpdate.canApplyProjectionRevision(message.projectionRevision)) return;
-            var canApplyOpenWorkspacePresentation = isAtomicOpenWorkspacesEnvelope
-                ? aiSessionsUpdate.canApplyAtomicPresentationProjectionRevision(
-                    message.projectionRevision
-                )
-                : aiSessionsUpdate.canApplyPresentationProjectionRevision(
-                    message.projectionRevision
-                );
-            if (isAtomicOpenWorkspacesEnvelope
-                && !canApplyOpenWorkspacePresentation) return;
-            var adoptOpenWorkspacePresentation = canApplyOpenWorkspacePresentation;
+            if (!aiSessionsUpdate.canApplyAtomicPresentationProjectionRevision(
+                message.projectionRevision
+            )) return;
             if (!applyOpenWorkspacesUpdate(message)) {
                 aiSessionsUpdate.requestFullRefresh('invalid-open-workspaces-update');
                 return;
             }
-            aiSessionsUpdate.commitProjectionRevision(
-                message.projectionRevision,
-                adoptOpenWorkspacePresentation,
-                isAtomicOpenWorkspacesEnvelope
-            );
-            if (isAtomicOpenWorkspacesEnvelope) {
-                applyValidatedAiSessionPresentationState(message.presentation);
-            } else {
-                syncAiSessionProjectionDom(adoptOpenWorkspacePresentation);
-            }
+            aiSessionsUpdate.commitAtomicProjectionRevision(message.projectionRevision);
+            applyValidatedAiSessionPresentationState(message.presentation);
             updateStickyGroupHeaderOffset();
             if (openTabSplit && typeof openTabSplit.syncResizer === 'function') {
                 openTabSplit.syncResizer();
@@ -923,7 +924,7 @@ function initProjects() {
         }
 
         if (message && message.type === 'ai-session-presentation-state') {
-            applyAiSessionPresentationState(message, false);
+            applyDirectAiSessionPresentationState(message);
             return;
         }
 
@@ -1139,7 +1140,6 @@ function initProjects() {
     });
     restoreAiSessionTabsFromState(document, window.vscode);
     window.vscode.postMessage({ type: 'request-active-ai-session-terminal' });
-    window.vscode.postMessage({ type: 'request-ai-session-attention-state' });
 
     observeStickyGroupHeaderOffset();
 }

--- a/src/webview/webviewWorkspaceUpdateScripts.js
+++ b/src/webview/webviewWorkspaceUpdateScripts.js
@@ -257,7 +257,7 @@ function completeOpenWorkspacePin(message) {
 function applyOpenWorkspacesUpdate(message) {
     if (!message
         || message.type !== 'open-workspaces-updated'
-        || (message.version !== 2 && message.version !== 3)
+        || message.version !== 3
         || typeof message.semanticRevision !== 'string'
         || !message.semanticRevision
         || (message.currentWorkspaceCount !== 0 && message.currentWorkspaceCount !== 1)

--- a/tests/browser/activeSessionCardInteraction.test.js
+++ b/tests/browser/activeSessionCardInteraction.test.js
@@ -229,7 +229,7 @@ function currentWorkspaceGroupMarkup(
             sessionsByProvider: { codex: [], kimi: [], claude: [] },
             unavailableProviders: [],
             activeSessions: activeAiSessions,
-            aiSessionCount: 1,
+            aiSessionCount: activeAiSessions.length,
             activeSessionCount: activeAiSessions.length,
             activeAttentionCount: activeAiSessions
                 .filter(entry => entry.needsAttention).length,
@@ -271,17 +271,20 @@ async function postListOpenWorkspacesUpdate(page, activeAiSessions, historySessi
     <div class="open-other-windows-group" data-other-windows-status="ready">
         ${currentOpenWorkspaceProjectMarkup()}
     </div>`;
-    await page.evaluate(htmlValue => {
+    const presentation = presentationMessage(activeAiSessions, 2);
+    await page.evaluate(({ htmlValue, presentationValue }) => {
         window.dispatchEvent(new MessageEvent('message', { data: {
-            type: 'open-workspaces-updated', version: 2, semanticRevision: 'list-replacement',
+            type: 'open-workspaces-updated', version: 3, semanticRevision: 'list-replacement',
+            projectionRevision: 2,
             currentWorkspaceCount: 1, navigationWorkspaceCount: 0, otherWindowsStatus: 'ready',
             html: htmlValue,
             searchCatalog: {
                 version: 2, sessions: [], openWorkspaces: [{ identity: 'project-a' }],
                 savedProjects: [], todos: [],
             },
+            presentation: presentationValue,
         } }));
-    }, html);
+    }, { htmlValue: html, presentationValue: presentation });
 }
 
 async function relativeTop(locator) {
@@ -452,6 +455,62 @@ function presentationMessage(activeSessions, projectionRevision, options = {}) {
     };
 }
 
+function aiSessionsEnvelope(activeSessions, projectionRevision, options = {}) {
+    const presentation = {
+        ...presentationMessage(activeSessions, projectionRevision, options),
+        ...(options.presentationOverrides || {}),
+    };
+    const attentionCount = options.attentionCount
+        ?? Object.keys(options.attention || {}).length;
+    return {
+        type: 'ai-sessions-updated',
+        version: 3,
+        sequence: projectionRevision,
+        projectionRevision,
+        generatedAt: '2026-08-11T00:00:00.000Z',
+        currentWorkspaceCount: 1,
+        html: currentWorkspaceGroupMarkup(activeSessions, attentionCount),
+        searchCatalog: {
+            version: 2,
+            sessions: [],
+            openWorkspaces: [],
+            savedProjects: [],
+            todos: [],
+        },
+        presentation,
+    };
+}
+
+function openWorkspacesEnvelope(activeSessions, projectionRevision, options = {}) {
+    const presentation = {
+        ...presentationMessage(activeSessions, projectionRevision, options),
+        ...(options.presentationOverrides || {}),
+    };
+    const attentionCount = options.attentionCount
+        ?? Object.keys(options.attention || {}).length;
+    return {
+        type: 'open-workspaces-updated',
+        version: 3,
+        projectionRevision,
+        semanticRevision: options.semanticRevision || `open-revision-${projectionRevision}`,
+        currentWorkspaceCount: 1,
+        navigationWorkspaceCount: 0,
+        otherWindowsStatus: 'ready',
+        html: `${currentWorkspaceGroupMarkup(activeSessions, attentionCount)}
+            <div class="open-other-windows-group" data-other-windows-status="ready">
+                ${currentOpenWorkspaceProjectMarkup()}
+            </div>`,
+        searchCatalog: {
+            version: 2,
+            sessions: [],
+            openWorkspaces: [{ identity: 'project-a' }],
+            savedProjects: [],
+            todos: [],
+        },
+        presentation,
+    };
+}
+
 function focusOrigin(overrides = {}) {
     return {
         type: 'focus-ai-session-conversation-origin',
@@ -506,7 +565,6 @@ function createAttentionAcknowledgementHandler(acknowledgeEventIds, postMessage)
         logOpenWorkspaceDiagnostic() {},
         refreshStewardViews() {},
         requestActiveAiSessionTerminalHighlight() {},
-        postAiSessionAttentionState() {},
         onOpenWorkspacesRendererReady() {},
         showAgentPivotSettings: ignored,
         showBridgeExtension: ignored,
@@ -632,25 +690,11 @@ test('ACTIVE-SESSION-FOCUS-REVEAL-001 keeps a newer complete presentation when o
         session('codex', 'session-b', false),
     ];
     const page = await openCardPage(t, initial);
-    await postHostMessage(page, presentationMessage(initial, 2));
-    await postHostMessage(page, {
-        type: 'ai-sessions-updated',
-        version: 2,
-        sequence: 1,
-        projectionRevision: 1,
-        currentWorkspaceCount: 1,
-        html: `<div class="open-current-workspace-group">${projectMarkup([
-            session('codex', 'session-a', false),
-            session('codex', 'session-b', true),
-        ])}</div>`,
-        searchCatalog: {
-            version: 2,
-            sessions: [],
-            openWorkspaces: [],
-            savedProjects: [],
-            todos: [],
-        },
-    });
+    await postHostMessage(page, presentationMessage(initial, 2, { revealFocused: true }));
+    await postHostMessage(page, aiSessionsEnvelope([
+        session('codex', 'session-a', false),
+        session('codex', 'session-b', true),
+    ], 1));
 
     assert.equal(await row(page, 'codex', 'session-a').getAttribute('data-session-focused'), '');
     assert.equal(
@@ -663,24 +707,10 @@ test('ACTIVE-SESSION-FOCUS-REVEAL-001 keeps a newer complete presentation when o
     );
 
     await postHostMessage(page, presentationMessage(initial, 4, { revealFocused: true }));
-    await postHostMessage(page, {
-        type: 'ai-sessions-updated',
-        version: 2,
-        sequence: 3,
-        projectionRevision: 3,
-        currentWorkspaceCount: 1,
-        html: `<div class="open-current-workspace-group">${projectMarkup([
-            session('codex', 'session-a', false),
-            session('codex', 'session-b', true),
-        ])}</div>`,
-        searchCatalog: {
-            version: 2,
-            sessions: [],
-            openWorkspaces: [],
-            savedProjects: [],
-            todos: [],
-        },
-    });
+    await postHostMessage(page, aiSessionsEnvelope([
+        session('codex', 'session-a', false),
+        session('codex', 'session-b', true),
+    ], 3));
     assert.equal(await row(page, 'codex', 'session-a').getAttribute('data-session-focused'), '');
     assert.equal(
         await row(page, 'codex', 'session-a').getAttribute('data-ai-session-active-terminal'),
@@ -701,28 +731,15 @@ test('ACTIVE-SESSION-FOCUS-REVEAL-001 keeps a newer complete presentation when o
     ];
     await postHostMessage(page, presentationMessage(attentionState, 6, {
         attention: { 'codex:session-b': ['event-b'] },
+        revealFocused: true,
     }));
-    await postHostMessage(page, {
-        type: 'ai-sessions-updated',
-        version: 2,
-        sequence: 5,
-        projectionRevision: 5,
-        currentWorkspaceCount: 1,
-        html: `<div class="open-current-workspace-group">${projectMarkup([
-            session('codex', 'session-a', true),
-            {
-                ...session('codex', 'session-b', false),
-                executionState: 'stopped',
-            },
-        ])}</div>`,
-        searchCatalog: {
-            version: 2,
-            sessions: [],
-            openWorkspaces: [],
-            savedProjects: [],
-            todos: [],
+    await postHostMessage(page, aiSessionsEnvelope([
+        session('codex', 'session-a', true),
+        {
+            ...session('codex', 'session-b', false),
+            executionState: 'stopped',
         },
-    });
+    ], 5));
     assert.equal(
         await row(page, 'codex', 'session-b').getAttribute('data-ai-session-attention'),
         ''
@@ -737,23 +754,18 @@ test('ACTIVE-SESSION-FOCUS-REVEAL-001 keeps a newer complete presentation when o
     );
 });
 
-test('ACTIVE-SESSION-PRESENTATION-TRANSACTION-001 accepts same-revision owner events after HTML arrives first', async t => {
-    const attentionSession = {
-        ...session('codex', 'session-a', true),
-        executionState: 'stopped',
-        status: 'stopped',
-        needsAttention: true,
-        attentionEventId: 'event-a',
-    };
-    const page = await openCardPage(t, [session('codex', 'session-a', true)]);
+test('ACTIVE-SESSION-INCREMENTAL-PRESENTATION-ENVELOPE-001 rejects legacy AI update messages', async t => {
+    const initial = [session('codex', 'session-a', true)];
+    const page = await openCardPage(t, initial);
+
     await postHostMessage(page, {
         type: 'ai-sessions-updated',
         version: 2,
-        sequence: 1,
+        sequence: 2,
         projectionRevision: 2,
         currentWorkspaceCount: 1,
         html: `<div class="open-current-workspace-group">${projectMarkup([
-            attentionSession,
+            session('codex', 'legacy-session', true),
         ])}</div>`,
         searchCatalog: {
             version: 2,
@@ -763,38 +775,31 @@ test('ACTIVE-SESSION-PRESENTATION-TRANSACTION-001 accepts same-revision owner ev
             todos: [],
         },
     });
-    await postHostMessage(page, presentationMessage([attentionSession], 2, {
-        attention: { 'codex:session-a': ['event-a', 'event-b'] },
-    }));
 
-    await row(page, 'codex', 'session-a').locator('.ai-session-primary-action').click();
-    const acknowledgements = (await postedMessages(page)).filter(message =>
-        message.type === 'acknowledge-ai-session-attention'
+    assert.equal(await row(page, 'codex', 'session-a').count(), 1);
+    assert.equal(await row(page, 'codex', 'legacy-session').count(), 0);
+    assert.deepEqual(
+        (await postedMessages(page))
+            .filter(message => message.type === 'request-full-refresh')
+            .map(message => message.reason),
+        ['unsupported-ai-session-message'],
     );
-    assert.deepEqual(acknowledgements.map(message => message.eventIds), [
-        ['event-a', 'event-b'],
-    ]);
 });
 
-test('ACTIVE-SESSION-PRESENTATION-TRANSACTION-001 keeps OPEN HTML and owner events in one revision', async t => {
-    const attentionSession = {
-        ...session('codex', 'session-a', true),
-        executionState: 'stopped',
-        status: 'stopped',
-        needsAttention: true,
-        attentionEventId: 'open-event-a',
-    };
-    const page = await openCardPage(t, [session('codex', 'session-a', true)]);
+test('ACTIVE-SESSION-INCREMENTAL-PRESENTATION-ENVELOPE-001 rejects legacy OPEN update messages', async t => {
+    const initial = [session('codex', 'session-a', true)];
+    const page = await openCardPage(t, initial);
+
     await postHostMessage(page, {
         type: 'open-workspaces-updated',
         version: 2,
         projectionRevision: 2,
-        semanticRevision: 'open-transaction-revision',
+        semanticRevision: 'legacy-open-update',
         currentWorkspaceCount: 1,
         navigationWorkspaceCount: 0,
         otherWindowsStatus: 'ready',
         html: `<div class="open-current-workspace-group">${projectMarkup([
-            attentionSession,
+            session('codex', 'legacy-session', true),
         ])}</div>
             <div class="open-other-windows-group" data-other-windows-status="ready">
                 ${currentOpenWorkspaceProjectMarkup()}
@@ -807,19 +812,32 @@ test('ACTIVE-SESSION-PRESENTATION-TRANSACTION-001 keeps OPEN HTML and owner even
             todos: [],
         },
     });
-    await postHostMessage(page, presentationMessage([attentionSession], 2, {
-        attention: {
-            'codex:session-a': ['open-event-a', 'open-event-b'],
-        },
-    }));
 
-    await row(page, 'codex', 'session-a').locator('.ai-session-primary-action').click();
-    const acknowledgements = (await postedMessages(page)).filter(message =>
-        message.type === 'acknowledge-ai-session-attention'
+    assert.equal(await row(page, 'codex', 'session-a').count(), 1);
+    assert.equal(await row(page, 'codex', 'legacy-session').count(), 0);
+    assert.deepEqual(
+        (await postedMessages(page))
+            .filter(message => message.type === 'request-full-refresh')
+            .map(message => message.reason),
+        ['unsupported-open-workspaces-message'],
     );
-    assert.deepEqual(acknowledgements.map(message => message.eventIds), [
-        ['open-event-a', 'open-event-b'],
-    ]);
+});
+
+test('ACTIVE-SESSION-FOCUS-REVEAL-001 rejects non-focus standalone presentation messages', async t => {
+    const initial = [session('codex', 'session-a', true)];
+    const page = await openCardPage(t, initial);
+
+    await postHostMessage(page, presentationMessage([
+        session('codex', 'session-a', false),
+    ], 2, { revealFocused: false }));
+
+    assert.equal(await row(page, 'codex', 'session-a').getAttribute('data-session-focused'), '');
+    assert.deepEqual(
+        (await postedMessages(page))
+            .filter(message => message.type === 'request-full-refresh')
+            .map(message => message.reason),
+        ['invalid-direct-ai-session-presentation-state'],
+    );
 });
 
 test('ACTIVE-SESSION-INCREMENTAL-PRESENTATION-ENVELOPE-001 applies AI HTML and complete attention owners from one message', async t => {
@@ -951,7 +969,7 @@ test('ACTIVE-SESSION-INCREMENTAL-PRESENTATION-ENVELOPE-001 closes an AI envelope
     await postHostMessage(page, presentationMessage([
         { ...attentionSession, focused: false },
         { ...otherSession, focused: true },
-    ], 2));
+    ], 2, { revealFocused: true }));
 
     assert.equal(await row(page, 'codex', 'session-a').getAttribute('data-session-focused'), '');
     assert.equal(await row(page, 'codex', 'session-b').getAttribute('data-session-focused'), null);
@@ -1006,7 +1024,7 @@ test('ACTIVE-SESSION-INCREMENTAL-PRESENTATION-ENVELOPE-001 closes an OPEN envelo
     await postHostMessage(page, presentationMessage([
         { ...attentionSession, focused: false },
         { ...otherSession, focused: true },
-    ], 2));
+    ], 2, { revealFocused: true }));
 
     assert.equal(await row(page, 'codex', 'session-a').getAttribute('data-session-focused'), '');
     assert.equal(await row(page, 'codex', 'session-b').getAttribute('data-session-focused'), null);
@@ -1037,7 +1055,7 @@ test('ACTIVE-SESSION-INCREMENTAL-PRESENTATION-ENVELOPE-001 applies and closes AI
     const conflictingPresentation = presentationMessage([
         { ...attentionSession, focused: false },
         { ...otherSession, focused: true },
-    ], 2);
+    ], 2, { revealFocused: true });
     const page = await openCardPage(t, initialSessions);
 
     await postHostMessage(page, conflictingPresentation);
@@ -1102,7 +1120,7 @@ test('ACTIVE-SESSION-INCREMENTAL-PRESENTATION-ENVELOPE-001 applies and closes OP
     const conflictingPresentation = presentationMessage([
         { ...attentionSession, focused: false },
         { ...otherSession, focused: true },
-    ], 2);
+    ], 2, { revealFocused: true });
     const page = await openCardPage(t, initialSessions);
 
     await postHostMessage(page, conflictingPresentation);
@@ -1224,6 +1242,40 @@ test('ACTIVE-SESSION-INCREMENTAL-PRESENTATION-ENVELOPE-001 rejects an invalid OP
     }]);
 });
 
+test('ACTIVE-SESSION-INCREMENTAL-PRESENTATION-ENVELOPE-001 rejects focus reveal inside an AI envelope', async t => {
+    const initial = [session('codex', 'session-a', true)];
+    const replacement = [session('codex', 'session-b', true)];
+    const page = await openCardPage(t, initial);
+
+    await postHostMessage(page, aiSessionsEnvelope(replacement, 2, {
+        presentationOverrides: { revealFocused: true },
+    }));
+
+    assert.equal(await row(page, 'codex', 'session-a').count(), 1);
+    assert.equal(await row(page, 'codex', 'session-b').count(), 0);
+    assert.deepEqual(await postedMessages(page), [{
+        type: 'request-full-refresh',
+        reason: 'invalid-ai-session-presentation-envelope',
+    }]);
+});
+
+test('ACTIVE-SESSION-INCREMENTAL-PRESENTATION-ENVELOPE-001 rejects focus reveal inside an OPEN envelope', async t => {
+    const initial = [session('codex', 'session-a', true)];
+    const replacement = [session('codex', 'session-b', true)];
+    const page = await openCardPage(t, initial);
+
+    await postHostMessage(page, openWorkspacesEnvelope(replacement, 2, {
+        presentationOverrides: { revealFocused: true },
+    }));
+
+    assert.equal(await row(page, 'codex', 'session-a').count(), 1);
+    assert.equal(await row(page, 'codex', 'session-b').count(), 0);
+    assert.deepEqual(await postedMessages(page), [{
+        type: 'request-full-refresh',
+        reason: 'invalid-open-workspaces-presentation-envelope',
+    }]);
+});
+
 test('ACTIVE-SESSION-FULL-RENDER-TRANSACTION-001 seeds the full document revision and complete attention owners', async t => {
     const attentionSession = {
         ...session('codex', 'session-a', true),
@@ -1243,24 +1295,10 @@ test('ACTIVE-SESSION-FULL-RENDER-TRANSACTION-001 seeds the full document revisio
         initialPresentation
     );
 
-    await postHostMessage(page, {
-        type: 'ai-sessions-updated',
-        version: 2,
-        sequence: 4,
-        projectionRevision: 4,
-        currentWorkspaceCount: 1,
-        html: `<div class="open-current-workspace-group">${projectMarkup([{
+    await postHostMessage(page, aiSessionsEnvelope([{
             ...attentionSession,
             attentionEventId: 'stale-event',
-        }])}</div>`,
-        searchCatalog: {
-            version: 2,
-            sessions: [],
-            openWorkspaces: [],
-            savedProjects: [],
-            todos: [],
-        },
-    });
+        }], 4, { attention: { 'codex:session-a': ['stale-event'] } }));
 
     assert.equal(
         await row(page, 'codex', 'session-a').getAttribute('data-session-event-id'),
@@ -1478,12 +1516,13 @@ test('ATTENTION-SESSION-CARD-ACKNOWLEDGEMENT-001 scopes pending acknowledgement 
         message.type === 'acknowledge-ai-session-attention'
     );
 
-    await postHostMessage(page, {
-        ...presentationMessage([attentionSession], 6, {
+    await postHostMessage(page, aiSessionsEnvelope([attentionSession], 6, {
             attention: { 'codex:session-a': ['event-a'] },
-        }),
-        workspaceScopeIdentity: 'scope-project-b',
-    });
+            presentationOverrides: {
+                workspaceScopeIdentity: 'scope-project-b',
+                workspaceNavigationIdentity: 'navigation-project-b',
+            },
+        }));
     await page.evaluate(() => {
         window.__agentPivotAttentionAcknowledgementTimeoutMs = 1_000;
         window.__agentPivotAcknowledgeSession('codex', 'session-a');
@@ -1702,7 +1741,6 @@ test('ATTENTION-SESSION-CARD-ACKNOWLEDGEMENT-001 clears a stopped Kimi card thro
         getRuntimeConfiguration: () => ({ mode: 'vscode' }),
         getCurrentOpenWorkspace: () => workspace,
         getActiveTerminal: () => null,
-        postAttentionState() {},
         isVisible: () => true,
         assertActive() {},
         createBridgeClient: onAggregate => {
@@ -1845,7 +1883,10 @@ test('ACTIVE-SESSION-FOCUS-REVEAL-001 transfers pending focus through the comple
     await postHostMessage(page, presentationMessage(
         [pending, established],
         2,
-        { focusedTarget: { provider: 'codex', pendingId: 'pending-one' } }
+        {
+            focusedTarget: { provider: 'codex', pendingId: 'pending-one' },
+            revealFocused: true,
+        }
     ));
     assert.equal(
         await pendingRow.locator('.ai-session-primary-action').getAttribute('title'),
@@ -1860,7 +1901,10 @@ test('ACTIVE-SESSION-FOCUS-REVEAL-001 transfers pending focus through the comple
     await postHostMessage(page, presentationMessage(
         [pending, focusedEstablished],
         3,
-        { focusedTarget: { provider: 'codex', sessionId: 'established-one' } }
+        {
+            focusedTarget: { provider: 'codex', sessionId: 'established-one' },
+            revealFocused: true,
+        }
     ));
 
     assert.equal(await pendingRow.getAttribute('data-session-focused'), null);
@@ -1878,7 +1922,7 @@ test('ATTENTION-EXECUTION-STATE-SYNC-001 ignores stale Attention DOM state while
     const running = session('codex', 'current-session', true);
     const page = await openCardPage(t, [running]);
 
-    await postHostMessage(page, presentationMessage([running], 2));
+    await postHostMessage(page, aiSessionsEnvelope([running], 2));
 
     const currentRow = row(page, 'codex', 'current-session');
     assert.equal(await currentRow.getAttribute('data-execution-state'), 'running');
@@ -1889,7 +1933,7 @@ test('ATTENTION-EXECUTION-STATE-SYNC-001 ignores stale Attention DOM state while
     assert.equal(await currentRow.locator('.ai-session-attention-indicator').count(), 0);
 
     const stopped = { ...running, executionState: 'stopped' };
-    await postHostMessage(page, presentationMessage([stopped], 3, {
+    await postHostMessage(page, aiSessionsEnvelope([stopped], 3, {
         attention: { 'codex:current-session': ['stale-event'] },
     }));
 
@@ -1949,38 +1993,14 @@ test('ATTENTION-EXECUTION-STATE-SYNC-001 applies every Active Session presentati
             );
         });
         window.__activeSessionPresentationObserver.observe(
-            document.querySelector('.workspace-card[data-current-workspace]'),
+            document.querySelector('.sticky-groups-wrapper'),
             { attributes: true, childList: true, subtree: true }
         );
     });
 
-    await postHostMessage(page, {
-        type: 'ai-session-presentation-state',
-        version: 1,
-        projectionRevision: 2,
-        workspaceScopeIdentity: 'scope-project-a',
-        workspaceNavigationIdentity: 'navigation-project-a',
-        attentionCount: 1,
-        activeAttentionCount: 1,
-        runningSessionCount: 0,
-        runningCardAnimation: 'current',
-        runningIconAnimation: 'current',
-        revealFocused: false,
-        focusedTarget: { provider: 'codex', sessionId: 'current-session' },
-        attentionSessions: [{
-            sessionKey: 'codex:current-session',
-            eventIds: ['attention-event'],
-        }],
-        sessions: [{
-            provider: 'codex',
-            sessionId: 'current-session',
-            executionState: 'stopped',
-            focused: true,
-            needsAttention: true,
-            conflict: false,
-            eventIds: ['attention-event'],
-        }],
-    });
+    await postHostMessage(page, aiSessionsEnvelope([stoppedSession], 2, {
+        attention: { 'codex:current-session': ['attention-event'] },
+    }));
     await page.evaluate(() => new Promise(resolve => requestAnimationFrame(resolve)));
     const attentionState = {
         rowAttention: true,
@@ -1998,30 +2018,9 @@ test('ATTENTION-EXECUTION-STATE-SYNC-001 applies every Active Session presentati
     );
 
     await page.evaluate(() => { window.__activeSessionPresentationSnapshots = []; });
-    await postHostMessage(page, {
-        type: 'ai-session-presentation-state',
-        version: 1,
-        projectionRevision: 3,
-        workspaceScopeIdentity: 'scope-project-a',
-        workspaceNavigationIdentity: 'navigation-project-a',
-        attentionCount: 0,
-        activeAttentionCount: 0,
-        runningSessionCount: 1,
-        runningCardAnimation: 'current',
-        runningIconAnimation: 'current',
-        revealFocused: false,
-        focusedTarget: { provider: 'codex', sessionId: 'current-session' },
-        attentionSessions: [],
-        sessions: [{
-            provider: 'codex',
-            sessionId: 'current-session',
-            executionState: 'running',
-            focused: true,
-            needsAttention: false,
-            conflict: false,
-            eventIds: [],
-        }],
-    });
+    await postHostMessage(page, aiSessionsEnvelope([
+        { ...stoppedSession, executionState: 'running' },
+    ], 3));
     await page.evaluate(() => new Promise(resolve => requestAnimationFrame(resolve)));
     const runningState = {
         rowAttention: false,
@@ -2044,7 +2043,7 @@ test('ATTENTION-EXECUTION-STATE-SYNC-001 creates and clears a previously empty c
     const card = page.locator('.workspace-card[data-current-workspace]');
     assert.equal(await card.locator('.project-codex-badge').count(), 0);
 
-    await postHostMessage(page, presentationMessage([], 2, {
+    await postHostMessage(page, aiSessionsEnvelope([], 2, {
         attention: { 'codex:history-only': ['history-attention'] },
     }));
     assert.equal(
@@ -2053,7 +2052,7 @@ test('ATTENTION-EXECUTION-STATE-SYNC-001 creates and clears a previously empty c
     );
     assert.equal(await card.getAttribute('data-has-ai-session-badge'), '');
 
-    await postHostMessage(page, presentationMessage([], 3));
+    await postHostMessage(page, aiSessionsEnvelope([], 3));
     assert.equal(await card.locator('.project-codex-badge').count(), 0);
     assert.equal(await card.getAttribute('data-has-ai-session-badge'), null);
 });
@@ -2065,7 +2064,7 @@ test('ACTIVE-SESSION-ATTENTION-PROJECTION-001 never flashes stale attention duri
         session('codex', 'session-c', false),
     ].map(entry => ({ ...entry, executionState: 'stopped' }));
     const page = await openCardPage(t, active);
-    await postHostMessage(page, presentationMessage(active, 2, {
+    await postHostMessage(page, aiSessionsEnvelope(active, 2, {
         attention: { 'codex:session-b': ['event-b'] },
     }));
     await page.evaluate(() => {
@@ -2087,29 +2086,14 @@ test('ACTIVE-SESSION-ATTENTION-PROJECTION-001 never flashes stale attention duri
         needsAttention: entry.sessionId === 'session-c',
         ...(entry.sessionId === 'session-c' ? { attentionEventId: 'event-c' } : {}),
     }));
-    await postHostMessage(page, {
-        type: 'open-workspaces-updated',
-        version: 2,
-        projectionRevision: 4,
+    await postHostMessage(page, openWorkspacesEnvelope(authoritativeAttention, 4, {
         semanticRevision: 'stale-window-switch-attention',
-        currentWorkspaceCount: 1,
-        navigationWorkspaceCount: 0,
-        otherWindowsStatus: 'ready',
-        html: `<div class="open-current-workspace-group">${projectMarkup(authoritativeAttention)}</div>
-            <div class="open-other-windows-group" data-other-windows-status="ready">
-                ${currentOpenWorkspaceProjectMarkup()}
-            </div>`,
-        searchCatalog: {
-            version: 2,
-            sessions: [],
-            openWorkspaces: [{ identity: 'project-a' }],
-            savedProjects: [],
-            todos: [],
-        },
-    });
+        attention: { 'codex:session-c': ['event-c'] },
+    }));
     await page.evaluate(() => new Promise(resolve => requestAnimationFrame(resolve)));
     await postHostMessage(page, presentationMessage(active, 3, {
         attention: { 'codex:session-b': ['stale-event-b'] },
+        revealFocused: true,
     }));
     await page.evaluate(() => new Promise(resolve => requestAnimationFrame(resolve)));
 

--- a/tests/browser/dashboardOpenTabSplit.test.js
+++ b/tests/browser/dashboardOpenTabSplit.test.js
@@ -480,7 +480,7 @@ test('WEBVIEW-OPEN-TAB-SPLIT-001 keeps the OPEN WINDOWS scroll anchor across aut
     const after = await page.evaluate(payload => {
         const applied = window.applyOpenWorkspacesUpdate({
             type: 'open-workspaces-updated',
-            version: 2,
+            version: 3,
             semanticRevision: 'scroll-restore',
             currentWorkspaceCount: 1,
             navigationWorkspaceCount: payload.navigationCount,

--- a/tests/browser/sessionProviderMenu.test.js
+++ b/tests/browser/sessionProviderMenu.test.js
@@ -154,8 +154,10 @@ async function postAiSessionsUpdate(page, selectedProviders, sequence) {
     await page.evaluate(({ html, sequence }) => {
         window.dispatchEvent(new MessageEvent('message', { data: {
             type: 'ai-sessions-updated',
-            version: 2,
+            version: 3,
             sequence,
+            projectionRevision: sequence,
+            generatedAt: '2026-08-11T00:00:00.000Z',
             currentWorkspaceCount: 1,
             html,
             searchCatalog: {
@@ -164,6 +166,22 @@ async function postAiSessionsUpdate(page, selectedProviders, sequence) {
                 openWorkspaces: [],
                 savedProjects: [],
                 todos: [],
+            },
+            presentation: {
+                type: 'ai-session-presentation-state',
+                version: 1,
+                projectionRevision: sequence,
+                workspaceScopeIdentity: 'scope-project-a',
+                workspaceNavigationIdentity: 'navigation-project-a',
+                attentionCount: 0,
+                activeAttentionCount: 0,
+                runningSessionCount: 0,
+                runningCardAnimation: 'current',
+                runningIconAnimation: 'current',
+                revealFocused: false,
+                focusedTarget: null,
+                attentionSessions: [],
+                sessions: [],
             },
         } }));
     }, { html, sequence });

--- a/tests/contract/aiSessions/attentionEventCapability.test.js
+++ b/tests/contract/aiSessions/attentionEventCapability.test.js
@@ -173,7 +173,6 @@ function createFixture(overrides = {}) {
             ? { scopeIdentity: 'scope-1' }
             : overrides.workspace,
         getActiveTerminal: () => overrides.activeTerminal === undefined ? terminal : overrides.activeTerminal,
-        postAttentionState: () => { calls.push(['post-attention-state']); },
         isVisible: () => overrides.visible !== false,
         assertActive: () => {
             if (overrides.assertActiveError) {
@@ -626,12 +625,4 @@ test('RUNTIME-WORKSPACE-TOPOLOGY-CONTINUITY-001 keeps attention ownership after 
     });
     assert.equal(ambiguous.capability.getRuntimeById('codex', 'session-a').state, 'conflict',
         'attention must surface cross-scope ambiguity instead of selecting the newer scope');
-});
-
-test('ATTENTION-EXECUTION-STATE-SYNC-001 attention mutations request one authoritative presentation snapshot', () => {
-    const { capability, calls } = createFixture({});
-    capability.postAttentionState();
-    assert.deepEqual(calls.filter(call => call[0] === 'post-attention-state'), [
-        ['post-attention-state'],
-    ]);
 });

--- a/tests/contract/dashboard/messageHandlers.test.js
+++ b/tests/contract/dashboard/messageHandlers.test.js
@@ -65,7 +65,6 @@ function createFixture(overrides = {}) {
         logOpenWorkspaceDiagnostic: (component, event) => calls.push(['rendererDiagnostic', component, event]),
         refreshStewardViews: reason => calls.push(['refreshStewardViews', reason]),
         requestActiveAiSessionTerminalHighlight: () => calls.push(['requestHighlight']),
-        postAiSessionAttentionState: () => calls.push(['postAttentionState']),
         onOpenWorkspacesRendererReady: () => calls.push(['openWorkspacesRendererReady']),
         showAgentPivotSettings: async () => { calls.push(['showSettings']); },
         showBridgeExtension: async () => { calls.push(['showBridgeExtension']); },
@@ -98,7 +97,6 @@ test('WEBVIEW-DASHBOARD-MESSAGE-ROUTER-001 exposes every extracted handler key',
         'open-workspaces-renderer-ready',
         'open-workspaces-rendered',
         'request-active-ai-session-terminal',
-        'request-ai-session-attention-state',
         'open-settings',
         'open-bridge-extension',
         'sponsor',
@@ -193,11 +191,10 @@ test('WEBVIEW-DASHBOARD-MESSAGE-ROUTER-001 sanitizes renderer diagnostics and re
     }, 'malformed renderer reports sanitize to invalid markers');
 });
 
-test('WEBVIEW-DASHBOARD-MESSAGE-ROUTER-001 delegates the simple openers and state requests', async () => {
+test('WEBVIEW-DASHBOARD-MESSAGE-ROUTER-001 delegates the simple openers and focus projection request', async () => {
     const { handlers, calls } = createFixture();
 
     await handlers['request-active-ai-session-terminal']({});
-    await handlers['request-ai-session-attention-state']({});
     await handlers['open-workspaces-renderer-ready']({
         type: 'open-workspaces-renderer-ready', version: 1,
     });
@@ -211,7 +208,6 @@ test('WEBVIEW-DASHBOARD-MESSAGE-ROUTER-001 delegates the simple openers and stat
 
     assert.deepEqual(calls, [
         ['requestHighlight'],
-        ['postAttentionState'],
         ['rendererDiagnostic', 'Renderer', {
             event: 'open-workspaces-renderer-ready',
         }],

--- a/tests/integration/dashboard/openProjectFlow.test.js
+++ b/tests/integration/dashboard/openProjectFlow.test.js
@@ -318,7 +318,7 @@ test('OPEN-OPEN-PROJECT-INCREMENTAL-RENDERING-001 applies consistent updates and
 
     assert.equal(context.applyOpenWorkspacesUpdate({
         type: 'open-workspaces-updated',
-        version: 2,
+        version: 3,
         semanticRevision: 'valid',
         currentWorkspaceCount: 1,
         navigationWorkspaceCount: 2,
@@ -334,7 +334,7 @@ test('OPEN-OPEN-PROJECT-INCREMENTAL-RENDERING-001 applies consistent updates and
     );
     assert.equal(context.applyOpenWorkspacesUpdate({
         type: 'open-workspaces-updated',
-        version: 2,
+        version: 3,
         semanticRevision: 'attention-only',
         currentWorkspaceCount: 1,
         navigationWorkspaceCount: 2,
@@ -349,7 +349,7 @@ test('OPEN-OPEN-PROJECT-INCREMENTAL-RENDERING-001 applies consistent updates and
     );
     assert.equal(context.applyOpenWorkspacesUpdate({
         type: 'open-workspaces-updated',
-        version: 2,
+        version: 3,
         semanticRevision: 'running-only',
         currentWorkspaceCount: 1,
         navigationWorkspaceCount: 2,
@@ -366,7 +366,7 @@ test('OPEN-OPEN-PROJECT-INCREMENTAL-RENDERING-001 applies consistent updates and
     );
     assert.equal(context.applyOpenWorkspacesUpdate({
         type: 'open-workspaces-updated',
-        version: 2,
+        version: 3,
         semanticRevision: 'duplicate-navigation',
         currentWorkspaceCount: 1,
         navigationWorkspaceCount: 2,
@@ -378,7 +378,7 @@ test('OPEN-OPEN-PROJECT-INCREMENTAL-RENDERING-001 applies consistent updates and
 
     assert.equal(context.applyOpenWorkspacesUpdate({
         type: 'open-workspaces-updated',
-        version: 2,
+        version: 3,
         semanticRevision: 'lost-peer',
         currentWorkspaceCount: 1,
         navigationWorkspaceCount: 2,

--- a/tests/integration/dashboard/webviewState.test.js
+++ b/tests/integration/dashboard/webviewState.test.js
@@ -167,6 +167,40 @@ function makeCatalog(suffix = '') {
     };
 }
 
+function makeAiSessionPresentation(projectionRevision) {
+    return {
+        type: 'ai-session-presentation-state',
+        version: 1,
+        projectionRevision,
+        workspaceScopeIdentity: null,
+        workspaceNavigationIdentity: null,
+        attentionCount: 0,
+        activeAttentionCount: 0,
+        runningSessionCount: 0,
+        runningCardAnimation: 'current',
+        runningIconAnimation: 'current',
+        revealFocused: false,
+        focusedTarget: null,
+        attentionSessions: [],
+        sessions: [],
+    };
+}
+
+function makeAiSessionsUpdatedMessage(projectionRevision, overrides = {}) {
+    return {
+        type: 'ai-sessions-updated',
+        version: 3,
+        sequence: projectionRevision,
+        projectionRevision,
+        generatedAt: NOW,
+        currentWorkspaceCount: 1,
+        html: '<div class="open-current-workspace-group"></div>',
+        searchCatalog: makeCatalog(),
+        presentation: makeAiSessionPresentation(projectionRevision),
+        ...overrides,
+    };
+}
+
 function makePromptSnapshot(revision = 0) {
     return {
         version: 1,
@@ -1954,6 +1988,8 @@ function createProjectVm({
     const replacedCatalogs = [];
     let webviewState = { unrelated: 'preserved' };
     const context = {
+        CSS: { escape: value => String(value) },
+        Node: { TEXT_NODE: 3 },
         normalizeDashboardSearchCatalog: value => value
             && value.version === 2
             && Array.isArray(value.sessions)
@@ -2318,14 +2354,9 @@ function assertBatchSelectionReconcilesAuthoritativeRows(source = projectVmSourc
         { provider: 'claude', sessionId: 'same', active: true },
     ]);
     harness.context.applyWorkspaceUpdate = () => true;
-    harness.windowListeners.message({ data: {
-        type: 'ai-sessions-updated',
-        version: 2,
-        sequence: 1,
-        currentWorkspaceCount: 1,
-        html: '<div class="open-current-workspace-group"></div>',
+    harness.windowListeners.message({ data: makeAiSessionsUpdatedMessage(1, {
         searchCatalog: makeCatalog('batch'),
-    } });
+    }) });
     assert.deepEqual(toPlain(manager.snapshot().selectedItems), [
         { provider: 'codex', sessionId: 'pinned' },
     ]);
@@ -2567,22 +2598,14 @@ test('WEBVIEW-AI-DASHBOARD-001 and TODO-AUTHORITATIVE-REFRESH-STATE-001 preserve
 test('WEBVIEW-BATCH-AI-SESSION-WEBVIEW-001 rejects stale AI session update sequences', () => {
     const harness = createProjectVm();
     harness.context.applyWorkspaceUpdate = () => true;
-    harness.windowListeners.message({ data: {
-        type: 'ai-sessions-updated',
-        version: 2,
-        sequence: 2,
+    harness.windowListeners.message({ data: makeAiSessionsUpdatedMessage(2, {
         currentWorkspaceCount: 0,
-        html: '<div class="open-current-workspace-group"></div>',
         searchCatalog: makeCatalog('new'),
-    } });
-    harness.windowListeners.message({ data: {
-        type: 'ai-sessions-updated',
-        version: 2,
-        sequence: 1,
+    }) });
+    harness.windowListeners.message({ data: makeAiSessionsUpdatedMessage(1, {
         currentWorkspaceCount: 0,
-        html: '<div class="open-current-workspace-group"></div>',
         searchCatalog: makeCatalog('stale'),
-    } });
+    }) });
 
     assert.equal(harness.replacedCatalogs.length, 1);
     assert.equal(harness.replacedCatalogs[0].todos[0].todoId, 'tnew');
@@ -2591,14 +2614,9 @@ test('WEBVIEW-BATCH-AI-SESSION-WEBVIEW-001 rejects stale AI session update seque
 test('WEBVIEW-BATCH-AI-SESSION-WEBVIEW-001 requests full refresh when the workspace replacement is invalid', () => {
     const harness = createProjectVm();
     harness.context.applyWorkspaceUpdate = () => false;
-    harness.windowListeners.message({ data: {
-        type: 'ai-sessions-updated',
-        version: 2,
-        sequence: 1,
-        currentWorkspaceCount: 1,
+    harness.windowListeners.message({ data: makeAiSessionsUpdatedMessage(1, {
         html: '<div class="invalid-workspace"></div>',
-        searchCatalog: makeCatalog(),
-    } });
+    }) });
     assert.deepEqual(toPlain(harness.messages), [{
         type: 'request-full-refresh', reason: 'invalid-ai-session-workspace-update',
     }]);

--- a/tests/unit/tooling/architectureGuards.test.js
+++ b/tests/unit/tooling/architectureGuards.test.js
@@ -728,17 +728,17 @@ for (const mutation of [
     {
         id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
         file: 'src/webview/webviewProjectAiUpdateScripts.js',
-        expectedDetail: 'Webview must close v3 envelopes while preserving v2 same-revision Presentation',
+        expectedDetail: 'Webview must accept only v3 envelopes and close each revision against direct Presentation',
         mutate: source => replaceFixtureSource(
             source,
-            'revision <= latestAiSessionDirectPresentationRevision',
-            'revision < latestAiSessionDirectPresentationRevision'
+            'revision <= latestAiSessionPresentationProjectionRevision',
+            'revision < latestAiSessionPresentationProjectionRevision'
         ),
     },
     {
         id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
         file: 'src/webview/webviewProjectAiUpdateScripts.js',
-        expectedDetail: 'Webview must close v3 envelopes while preserving v2 same-revision Presentation',
+        expectedDetail: 'Webview must accept only v3 envelopes and close each revision against direct Presentation',
         mutate: source => replaceFixtureSource(
             source,
             'revision <= latestAiSessionClosedPresentationRevision',
@@ -748,7 +748,7 @@ for (const mutation of [
     {
         id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
         file: 'src/webview/webviewProjectAiUpdateScripts.js',
-        expectedDetail: 'Webview must close v3 envelopes while preserving v2 same-revision Presentation',
+        expectedDetail: 'Webview must accept only v3 envelopes and close each revision against direct Presentation',
         mutate: source => replaceFixtureSource(
             source,
             'revision >= latestAiSessionPresentationProjectionRevision',
@@ -777,8 +777,38 @@ for (const mutation of [
     },
     {
         id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/aiSessions/dashboardController.ts',
+        expectedDetail: 'AI incremental HTML and Presentation must share one Host message',
+        mutate: source => replaceFixtureSource(
+            source,
+            'presentation: buildAiSessionPresentationState(\n                false,\n                projection,',
+            'presentation: buildAiSessionPresentationState(\n                true,\n                projection,'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/openWorkspaces/dashboardController.ts',
+        expectedDetail: 'OPEN HTML and Presentation must share one Host message',
+        mutate: source => replaceFixtureSource(
+            source,
+            'presentation: buildAiSessionPresentationState(\n                false,\n                projection,',
+            'presentation: buildAiSessionPresentationState(\n                true,\n                projection,'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/dashboard.ts',
+        expectedDetail: 'OPEN HTML and Presentation must share one Host message',
+        mutate: source => replaceFixtureSource(
+            source,
+            'const message = buildAiSessionPresentationState(\n            true,\n            transaction,',
+            'const message = buildAiSessionPresentationState(\n            false,\n            transaction,'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
         file: 'src/webview/webviewProjectAiUpdateScripts.js',
-        expectedDetail: 'Webview must validate and apply each HTML-Presentation envelope atomically',
+        expectedDetail: 'Webview must validate v3 envelopes atomically and reserve direct Presentation for focus',
         mutate: source => replaceFixtureSource(
             source,
             'message.presentation.projectionRevision !== message.projectionRevision',
@@ -788,41 +818,91 @@ for (const mutation of [
     {
         id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
         file: 'src/webview/webviewProjectAiUpdateScripts.js',
-        expectedDetail: 'Webview must validate and apply each HTML-Presentation envelope atomically',
+        expectedDetail: 'Webview must validate v3 envelopes atomically and reserve direct Presentation for focus',
         mutate: source => replaceFixtureSource(
             source,
-            'adoptRenderedPresentation,\n            isAtomicEnvelope',
-            'adoptRenderedPresentation,\n            false'
+            'message.presentation.revealFocused !== false',
+            'message.presentation.revealFocused !== true'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectScripts.js',
+        expectedDetail: 'Webview must validate v3 envelopes atomically and reserve direct Presentation for focus',
+        mutate: source => replaceFixtureSource(
+            source,
+            'message.presentation.revealFocused !== false',
+            'message.presentation.revealFocused !== true'
         ),
     },
     {
         id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
         file: 'src/webview/webviewProjectAiUpdateScripts.js',
-        expectedDetail: 'Webview must validate and apply each HTML-Presentation envelope atomically',
+        expectedDetail: 'Webview must validate v3 envelopes atomically and reserve direct Presentation for focus',
         mutate: source => replaceFixtureSource(
             source,
-            '? canApplyAtomicPresentationProjectionRevision(message.projectionRevision)',
-            '? canApplyPresentationProjectionRevision(message.projectionRevision)'
+            'commitAtomicProjectionRevision(message.projectionRevision)',
+            'commitAtomicProjectionRevision(message.projectionRevision - 1)'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectAiUpdateScripts.js',
+        expectedDetail: 'Webview must validate v3 envelopes atomically and reserve direct Presentation for focus',
+        mutate: source => replaceFixtureSource(
+            source,
+            'if (!canApplyAtomicPresentationProjectionRevision(message.projectionRevision))',
+            'if (!canApplyProjectionRevision(message.projectionRevision))'
         ),
     },
     {
         id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
         file: 'src/webview/webviewProjectScripts.js',
-        expectedDetail: 'Webview must validate and apply each HTML-Presentation envelope atomically',
+        expectedDetail: 'Webview must validate v3 envelopes atomically and reserve direct Presentation for focus',
         mutate: source => replaceFixtureSource(
             source,
-            'adoptOpenWorkspacePresentation,\n                isAtomicOpenWorkspacesEnvelope',
-            'adoptOpenWorkspacePresentation,\n                false'
+            'aiSessionsUpdate.commitAtomicProjectionRevision(message.projectionRevision)',
+            'aiSessionsUpdate.commitAtomicProjectionRevision(message.projectionRevision - 1)'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectAiUpdateScripts.js',
+        expectedDetail: 'Webview must accept only v3 envelopes and close each revision against direct Presentation',
+        mutate: source => replaceFixtureSource(
+            source,
+            'message.version !== 3',
+            'message.version !== 2'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewWorkspaceUpdateScripts.js',
+        expectedDetail: 'Webview must validate v3 envelopes atomically and reserve direct Presentation for focus',
+        mutate: source => replaceFixtureSource(
+            source,
+            "message.type !== 'open-workspaces-updated'\n        || message.version !== 3",
+            "message.type !== 'open-workspaces-updated'\n        || message.version !== 2"
         ),
     },
     {
         id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
         file: 'src/webview/webviewProjectScripts.js',
-        expectedDetail: 'Webview must validate and apply each HTML-Presentation envelope atomically',
+        expectedDetail: 'Webview must validate v3 envelopes atomically and reserve direct Presentation for focus',
         mutate: source => replaceFixtureSource(
             source,
-            '? aiSessionsUpdate.canApplyAtomicPresentationProjectionRevision(',
-            '? aiSessionsUpdate.canApplyPresentationProjectionRevision('
+            'if (!aiSessionsUpdate.canApplyAtomicPresentationProjectionRevision(',
+            'if (!aiSessionsUpdate.canApplyProjectionRevision('
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectScripts.js',
+        expectedDetail: 'Webview must validate v3 envelopes atomically and reserve direct Presentation for focus',
+        mutate: source => replaceFixtureSource(
+            source,
+            'message.revealFocused !== true',
+            'message.revealFocused === undefined'
         ),
     },
     {


### PR DESCRIPTION
## Summary

- retire legacy v2 AI Sessions and Open Workspaces incremental consumers in favor of v3 atomic HTML and presentation envelopes
- reserve standalone presentation messages for focus reveal and remove the redundant attention-state bootstrap request
- simplify presentation revision tracking and lock the protocol direction with browser regressions and mutation-sensitive architecture guards
- migrate the OPEN tab split replacement fixture to the v3 protocol after rebasing onto current main

## Testing

- npm run test-compile
- npm run test:deterministic:run
- npm run test:browser:run
- node scripts/run-architecture-guards.js
- node scripts/run-ai-session-safety-checks.js
- node scripts/run-open-project-safety-checks.js
- node scripts/run-dashboard-webview-checks.js
- npm run test:behavior-contracts
- npm run package:release
- installed hzcheng.agent-pivot@1.1.0 into the active remote VS Code Server and verified representative VSIX-to-installed hashes

## Skill harvest

None. Independent architecture review and exact-SHA post-rebase verification already covered the task-local review and compatibility issues; no reusable skill gap was found.
