### PR TITLE
refactor: centralize presentation transactions

### DIFF
--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "e42e41de76fb98abdcee947959f88373a562a8b8",
+        "head": "b2bddc70c874d4c7a3543f9d3da558d88ff4faf2",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -271,7 +271,8 @@
             "2798f545688f46f633d18a95d20f16400f13db27",
             "639b4b720bb2987becc200334d21944b71d61598",
             "7e6bbfd491daa0e36072bb6a55d3564eed4ee731",
-            "bc0439f51e63e03021cbff91824c386b4685dfd6"
+            "bc0439f51e63e03021cbff91824c386b4685dfd6",
+            "806d58b9ad6bad2931da41093bdab3600852be37"
         ]
     },
     "capabilities": [
@@ -928,7 +929,8 @@
                 "464afaaa5924f5834da6ec428c5f805e05514093",
                 "47cb385c19b44554d7598f081caf38ffb873cf36",
                 "26ce7197d0d43018b1bae358817ac18374df345e",
-                "e42e41de76fb98abdcee947959f88373a562a8b8"
+                "e42e41de76fb98abdcee947959f88373a562a8b8",
+                "b2bddc70c874d4c7a3543f9d3da558d88ff4faf2"
             ],
             "behaviors": [
                 "ATTENTION-ACTIVE-UNREGISTER-ON-DEACTIVATE-001",

--- a/media/webviewDashboardBundle.js
+++ b/media/webviewDashboardBundle.js
@@ -2007,29 +2007,22 @@ function initProjectContextMenus(options) {
 }
 
 /* src/webview/webviewProjectAiUpdateScripts.js */
-function initProjectAiSessionsUpdate(options) {
+function initAiSessionPresentationTransactions(options) {
     'use strict';
 
     options = options || {};
-    var batchAiSessionState = options.batchAiSessionState;
-    var batchAiSessionManager = options.batchAiSessionManager;
-    var getPendingAiSessionProviderSelectionProjectId = options.getPendingAiSessionProviderSelectionProjectId;
-    var getSelectedAiSessionProviders = options.getSelectedAiSessionProviders;
-    var syncAiSessionBatchManagementDom = options.syncAiSessionBatchManagementDom;
-    var syncAiSessionProjectionDom = options.syncAiSessionProjectionDom;
-    var reconcilePendingAiSessionProviderSelectionDom = options.reconcilePendingAiSessionProviderSelectionDom;
-    var submitAiSessionProviderSelection = options.submitAiSessionProviderSelection;
-    var toggleCodexSessions = options.toggleCodexSessions;
-    var exitAiSessionBatchManagement = options.exitAiSessionBatchManagement;
-    var isAiSessionProvider = options.isAiSessionProvider;
-    var updateStickyGroupHeaderOffset = options.updateStickyGroupHeaderOffset;
     var isValidAiSessionPresentationState = options.isValidAiSessionPresentationState;
     var applyValidatedAiSessionPresentationState = options.applyValidatedAiSessionPresentationState;
-
-    var pendingWorkspaceSessionReveal = null;
     var latestAiSessionProjectionRevision = 0;
     var latestAiSessionPresentationProjectionRevision = 0;
     var latestAiSessionClosedPresentationRevision = 0;
+
+    function requestFullRefresh(reason) {
+        window.vscode.postMessage({
+            type: 'request-full-refresh',
+            reason,
+        });
+    }
 
     function canApplyRevision(revision, latestRevision) {
         if (typeof revision === 'undefined') {
@@ -2052,17 +2045,15 @@ function initProjectAiSessionsUpdate(options) {
     }
 
     function commitAtomicProjectionRevision(revision) {
-        if (Number.isSafeInteger(revision) && revision > 0) {
-            latestAiSessionProjectionRevision = revision;
-            latestAiSessionPresentationProjectionRevision = Math.max(
-                latestAiSessionPresentationProjectionRevision,
-                revision
-            );
-            latestAiSessionClosedPresentationRevision = Math.max(
-                latestAiSessionClosedPresentationRevision,
-                revision
-            );
-        }
+        latestAiSessionProjectionRevision = revision;
+        latestAiSessionPresentationProjectionRevision = Math.max(
+            latestAiSessionPresentationProjectionRevision,
+            revision
+        );
+        latestAiSessionClosedPresentationRevision = Math.max(
+            latestAiSessionClosedPresentationRevision,
+            revision
+        );
     }
 
     function acceptPresentationProjectionRevision(revision) {
@@ -2091,6 +2082,85 @@ function initProjectAiSessionsUpdate(options) {
         return true;
     }
 
+    function applyInitialPresentation(message) {
+        if (!isValidAiSessionPresentationState(message)) {
+            requestFullRefresh('invalid-initial-ai-session-presentation-state');
+            return false;
+        }
+        if (!acceptInitialPresentationProjectionRevision(message.projectionRevision)) {
+            return false;
+        }
+        applyValidatedAiSessionPresentationState(message);
+        return true;
+    }
+
+    function applyDirectPresentation(message) {
+        if (!isValidAiSessionPresentationState(message)
+            || message.revealFocused !== true) {
+            requestFullRefresh('invalid-direct-ai-session-presentation-state');
+            return false;
+        }
+        if (!acceptPresentationProjectionRevision(message.projectionRevision)) {
+            return false;
+        }
+        applyValidatedAiSessionPresentationState(message);
+        return true;
+    }
+
+    function applyAtomicEnvelope(input) {
+        var message = input.message;
+        if (!Number.isSafeInteger(message.projectionRevision)
+            || message.projectionRevision <= 0
+            || !isValidAiSessionPresentationState(message.presentation)
+            || message.presentation.projectionRevision !== message.projectionRevision
+            || message.presentation.revealFocused !== false) {
+            requestFullRefresh(input.invalidPresentationReason);
+            return false;
+        }
+        if (!canApplyProjectionRevision(message.projectionRevision)
+            || !canApplyAtomicPresentationProjectionRevision(message.projectionRevision)) {
+            return false;
+        }
+        if (!input.replaceContent()) {
+            requestFullRefresh(input.invalidReplacementReason);
+            return false;
+        }
+        commitAtomicProjectionRevision(message.projectionRevision);
+        if (typeof input.afterReplacement === 'function') {
+            input.afterReplacement();
+        }
+        applyValidatedAiSessionPresentationState(message.presentation);
+        return true;
+    }
+
+    return {
+        applyAtomicEnvelope: applyAtomicEnvelope,
+        applyDirectPresentation: applyDirectPresentation,
+        applyInitialPresentation: applyInitialPresentation,
+        requestFullRefresh: requestFullRefresh,
+    };
+}
+
+function initProjectAiSessionsUpdate(options) {
+    'use strict';
+
+    options = options || {};
+    var batchAiSessionState = options.batchAiSessionState;
+    var batchAiSessionManager = options.batchAiSessionManager;
+    var getPendingAiSessionProviderSelectionProjectId = options.getPendingAiSessionProviderSelectionProjectId;
+    var getSelectedAiSessionProviders = options.getSelectedAiSessionProviders;
+    var syncAiSessionBatchManagementDom = options.syncAiSessionBatchManagementDom;
+    var syncAiSessionProjectionDom = options.syncAiSessionProjectionDom;
+    var reconcilePendingAiSessionProviderSelectionDom = options.reconcilePendingAiSessionProviderSelectionDom;
+    var submitAiSessionProviderSelection = options.submitAiSessionProviderSelection;
+    var toggleCodexSessions = options.toggleCodexSessions;
+    var exitAiSessionBatchManagement = options.exitAiSessionBatchManagement;
+    var isAiSessionProvider = options.isAiSessionProvider;
+    var updateStickyGroupHeaderOffset = options.updateStickyGroupHeaderOffset;
+    var presentationTransactions = options.presentationTransactions;
+
+    var pendingWorkspaceSessionReveal = null;
+
     function applyAiSessionsUpdate(message) {
         if (message.version !== 3
             || typeof message.sequence !== 'number'
@@ -2099,7 +2169,7 @@ function initProjectAiSessionsUpdate(options) {
             || typeof normalizeDashboardSearchCatalog !== 'function'
             || normalizeDashboardSearchCatalog(message.searchCatalog) !== message.searchCatalog
             || message.searchCatalog.version !== 2) {
-            requestFullRefresh('unsupported-ai-session-message');
+            presentationTransactions.requestFullRefresh('unsupported-ai-session-message');
             return;
         }
 
@@ -2107,49 +2177,42 @@ function initProjectAiSessionsUpdate(options) {
                 || message.projectionRevision <= 0
                 || message.sequence !== message.projectionRevision
                 || typeof message.generatedAt !== 'string'
-                || !message.generatedAt
-                || typeof isValidAiSessionPresentationState !== 'function'
-                || !isValidAiSessionPresentationState(message.presentation)
-                || message.presentation.projectionRevision !== message.projectionRevision
-                || message.presentation.revealFocused !== false
-                || typeof applyValidatedAiSessionPresentationState !== 'function') {
-            requestFullRefresh('invalid-ai-session-presentation-envelope');
+                || !message.generatedAt) {
+            presentationTransactions.requestFullRefresh(
+                'invalid-ai-session-presentation-envelope'
+            );
             return;
         }
 
-        if (!canApplyProjectionRevision(message.projectionRevision)) {
-            return;
-        }
-        if (!canApplyAtomicPresentationProjectionRevision(message.projectionRevision)) {
-            return;
-        }
-
-        if (!applyWorkspaceUpdate({
-            type: 'workspace-updated',
-            version: 2,
-            currentWorkspaceCount: message.currentWorkspaceCount,
-            html: message.html,
-        }, {
-            canRestoreAiSessionProviderMenu: () =>
-                !getPendingAiSessionProviderSelectionProjectId()
-                && !batchAiSessionState.pending,
+        if (!presentationTransactions.applyAtomicEnvelope({
+            message: message,
+            invalidPresentationReason: 'invalid-ai-session-presentation-envelope',
+            invalidReplacementReason: 'invalid-ai-session-workspace-update',
+            replaceContent: () => applyWorkspaceUpdate({
+                type: 'workspace-updated',
+                version: 2,
+                currentWorkspaceCount: message.currentWorkspaceCount,
+                html: message.html,
+            }, {
+                canRestoreAiSessionProviderMenu: () =>
+                    !getPendingAiSessionProviderSelectionProjectId()
+                    && !batchAiSessionState.pending,
+            }),
+            afterReplacement: () => {
+                if (batchAiSessionState.projectId) {
+                    var projectDiv = findCurrentWorkspaceDiv(batchAiSessionState.projectId);
+                    if (projectDiv) {
+                        batchAiSessionManager.reconcileVisible(projectDiv);
+                        syncAiSessionBatchManagementDom(projectDiv);
+                    } else {
+                        exitAiSessionBatchManagement();
+                    }
+                }
+                reconcilePendingAiSessionProviderSelectionDom();
+            },
         })) {
-            requestFullRefresh('invalid-ai-session-workspace-update');
             return;
         }
-
-        commitAtomicProjectionRevision(message.projectionRevision);
-        if (batchAiSessionState.projectId) {
-            var projectDiv = findCurrentWorkspaceDiv(batchAiSessionState.projectId);
-            if (projectDiv) {
-                batchAiSessionManager.reconcileVisible(projectDiv);
-                syncAiSessionBatchManagementDom(projectDiv);
-            } else {
-                exitAiSessionBatchManagement();
-            }
-        }
-        reconcilePendingAiSessionProviderSelectionDom();
-        applyValidatedAiSessionPresentationState(message.presentation);
         updateStickyGroupHeaderOffset();
         if (window.__agentPivotDashboard) {
             window.__agentPivotDashboard.replaceSearchCatalog(message.searchCatalog);
@@ -2249,24 +2312,12 @@ function initProjectAiSessionsUpdate(options) {
         );
     };
 
-    function requestFullRefresh(reason) {
-        window.vscode.postMessage({
-            type: 'request-full-refresh',
-            reason,
-        });
-    }
-
     return {
         applyAiSessionsUpdate: applyAiSessionsUpdate,
-        acceptInitialPresentationProjectionRevision: acceptInitialPresentationProjectionRevision,
-        acceptPresentationProjectionRevision: acceptPresentationProjectionRevision,
-        canApplyAtomicPresentationProjectionRevision: canApplyAtomicPresentationProjectionRevision,
-        canApplyProjectionRevision: canApplyProjectionRevision,
-        commitAtomicProjectionRevision: commitAtomicProjectionRevision,
         findCurrentWorkspaceDiv: findCurrentWorkspaceDiv,
         findWorkspaceDiv: findWorkspaceDiv,
         focusSearchRevealTarget: focusSearchRevealTarget,
-        requestFullRefresh: requestFullRefresh,
+        requestFullRefresh: presentationTransactions.requestFullRefresh,
     };
 }
 
@@ -3703,6 +3754,10 @@ function initProjects() {
             syncActiveAiSessionProjectionDom(true, false);
         }
     }
+    var presentationTransactions = initAiSessionPresentationTransactions({
+        isValidAiSessionPresentationState: isValidAiSessionPresentationState,
+        applyValidatedAiSessionPresentationState: applyValidatedAiSessionPresentationState,
+    });
     var aiSessionsUpdate = initProjectAiSessionsUpdate({
         batchAiSessionState: aiSessionControls.batchAiSessionState,
         batchAiSessionManager: aiSessionControls.batchAiSessionManager,
@@ -3716,8 +3771,7 @@ function initProjects() {
         exitAiSessionBatchManagement: aiSessionControls.exitAiSessionBatchManagement,
         isAiSessionProvider: aiSessionControls.isAiSessionProvider,
         updateStickyGroupHeaderOffset: updateStickyGroupHeaderOffset,
-        isValidAiSessionPresentationState: isValidAiSessionPresentationState,
-        applyValidatedAiSessionPresentationState: applyValidatedAiSessionPresentationState,
+        presentationTransactions: presentationTransactions,
     });
 
     function isValidAiSessionPresentationState(message) {
@@ -3770,36 +3824,6 @@ function initProjects() {
                 && session.eventIds.every(eventId => typeof eventId === 'string' && !!eventId));
     }
 
-    function applyAiSessionPresentationState(message, initialDocument) {
-        if (!isValidAiSessionPresentationState(message)) {
-            aiSessionsUpdate.requestFullRefresh(initialDocument
-                ? 'invalid-initial-ai-session-presentation-state'
-                : 'invalid-ai-session-presentation-state');
-            return false;
-        }
-        var accepted = initialDocument
-            ? aiSessionsUpdate.acceptInitialPresentationProjectionRevision(
-                message.projectionRevision
-            )
-            : aiSessionsUpdate.acceptPresentationProjectionRevision(
-                message.projectionRevision
-            );
-        if (!accepted) return false;
-        applyValidatedAiSessionPresentationState(message);
-        return true;
-    }
-
-    function applyDirectAiSessionPresentationState(message) {
-        if (!isValidAiSessionPresentationState(message)
-            || message.revealFocused !== true) {
-            aiSessionsUpdate.requestFullRefresh(
-                'invalid-direct-ai-session-presentation-state'
-            );
-            return false;
-        }
-        return applyAiSessionPresentationState(message, false);
-    }
-
     function applyValidatedAiSessionPresentationState(message) {
         window.__agentPivotAiSessionPresentationState = message;
         applyAiSessionPresentationDom(message);
@@ -3818,7 +3842,9 @@ function initProjects() {
 
     var initialAiSessionPresentationState = readInitialAiSessionPresentationState();
     if (initialAiSessionPresentationState) {
-        applyAiSessionPresentationState(initialAiSessionPresentationState, true);
+        presentationTransactions.applyInitialPresentation(
+            initialAiSessionPresentationState
+        );
     }
 
     function onMouseEvent(e) {
@@ -4008,25 +4034,14 @@ function initProjects() {
                 );
                 return;
             }
-            if (!isValidAiSessionPresentationState(message.presentation)
-                    || message.presentation.projectionRevision
-                        !== message.projectionRevision
-                    || message.presentation.revealFocused !== false) {
-                aiSessionsUpdate.requestFullRefresh(
-                    'invalid-open-workspaces-presentation-envelope'
-                );
+            if (!presentationTransactions.applyAtomicEnvelope({
+                message: message,
+                invalidPresentationReason: 'invalid-open-workspaces-presentation-envelope',
+                invalidReplacementReason: 'invalid-open-workspaces-update',
+                replaceContent: () => applyOpenWorkspacesUpdate(message),
+            })) {
                 return;
             }
-            if (!aiSessionsUpdate.canApplyProjectionRevision(message.projectionRevision)) return;
-            if (!aiSessionsUpdate.canApplyAtomicPresentationProjectionRevision(
-                message.projectionRevision
-            )) return;
-            if (!applyOpenWorkspacesUpdate(message)) {
-                aiSessionsUpdate.requestFullRefresh('invalid-open-workspaces-update');
-                return;
-            }
-            aiSessionsUpdate.commitAtomicProjectionRevision(message.projectionRevision);
-            applyValidatedAiSessionPresentationState(message.presentation);
             updateStickyGroupHeaderOffset();
             if (openTabSplit && typeof openTabSplit.syncResizer === 'function') {
                 openTabSplit.syncResizer();
@@ -4065,7 +4080,7 @@ function initProjects() {
         }
 
         if (message && message.type === 'ai-session-presentation-state') {
-            applyDirectAiSessionPresentationState(message);
+            presentationTransactions.applyDirectPresentation(message);
             return;
         }
 

--- a/media/webviewProjectAiUpdateScripts.js
+++ b/media/webviewProjectAiUpdateScripts.js
@@ -1,26 +1,19 @@
-function initProjectAiSessionsUpdate(options) {
+function initAiSessionPresentationTransactions(options) {
     'use strict';
 
     options = options || {};
-    var batchAiSessionState = options.batchAiSessionState;
-    var batchAiSessionManager = options.batchAiSessionManager;
-    var getPendingAiSessionProviderSelectionProjectId = options.getPendingAiSessionProviderSelectionProjectId;
-    var getSelectedAiSessionProviders = options.getSelectedAiSessionProviders;
-    var syncAiSessionBatchManagementDom = options.syncAiSessionBatchManagementDom;
-    var syncAiSessionProjectionDom = options.syncAiSessionProjectionDom;
-    var reconcilePendingAiSessionProviderSelectionDom = options.reconcilePendingAiSessionProviderSelectionDom;
-    var submitAiSessionProviderSelection = options.submitAiSessionProviderSelection;
-    var toggleCodexSessions = options.toggleCodexSessions;
-    var exitAiSessionBatchManagement = options.exitAiSessionBatchManagement;
-    var isAiSessionProvider = options.isAiSessionProvider;
-    var updateStickyGroupHeaderOffset = options.updateStickyGroupHeaderOffset;
     var isValidAiSessionPresentationState = options.isValidAiSessionPresentationState;
     var applyValidatedAiSessionPresentationState = options.applyValidatedAiSessionPresentationState;
-
-    var pendingWorkspaceSessionReveal = null;
     var latestAiSessionProjectionRevision = 0;
     var latestAiSessionPresentationProjectionRevision = 0;
     var latestAiSessionClosedPresentationRevision = 0;
+
+    function requestFullRefresh(reason) {
+        window.vscode.postMessage({
+            type: 'request-full-refresh',
+            reason,
+        });
+    }
 
     function canApplyRevision(revision, latestRevision) {
         if (typeof revision === 'undefined') {
@@ -43,17 +36,15 @@ function initProjectAiSessionsUpdate(options) {
     }
 
     function commitAtomicProjectionRevision(revision) {
-        if (Number.isSafeInteger(revision) && revision > 0) {
-            latestAiSessionProjectionRevision = revision;
-            latestAiSessionPresentationProjectionRevision = Math.max(
-                latestAiSessionPresentationProjectionRevision,
-                revision
-            );
-            latestAiSessionClosedPresentationRevision = Math.max(
-                latestAiSessionClosedPresentationRevision,
-                revision
-            );
-        }
+        latestAiSessionProjectionRevision = revision;
+        latestAiSessionPresentationProjectionRevision = Math.max(
+            latestAiSessionPresentationProjectionRevision,
+            revision
+        );
+        latestAiSessionClosedPresentationRevision = Math.max(
+            latestAiSessionClosedPresentationRevision,
+            revision
+        );
     }
 
     function acceptPresentationProjectionRevision(revision) {
@@ -82,6 +73,85 @@ function initProjectAiSessionsUpdate(options) {
         return true;
     }
 
+    function applyInitialPresentation(message) {
+        if (!isValidAiSessionPresentationState(message)) {
+            requestFullRefresh('invalid-initial-ai-session-presentation-state');
+            return false;
+        }
+        if (!acceptInitialPresentationProjectionRevision(message.projectionRevision)) {
+            return false;
+        }
+        applyValidatedAiSessionPresentationState(message);
+        return true;
+    }
+
+    function applyDirectPresentation(message) {
+        if (!isValidAiSessionPresentationState(message)
+            || message.revealFocused !== true) {
+            requestFullRefresh('invalid-direct-ai-session-presentation-state');
+            return false;
+        }
+        if (!acceptPresentationProjectionRevision(message.projectionRevision)) {
+            return false;
+        }
+        applyValidatedAiSessionPresentationState(message);
+        return true;
+    }
+
+    function applyAtomicEnvelope(input) {
+        var message = input.message;
+        if (!Number.isSafeInteger(message.projectionRevision)
+            || message.projectionRevision <= 0
+            || !isValidAiSessionPresentationState(message.presentation)
+            || message.presentation.projectionRevision !== message.projectionRevision
+            || message.presentation.revealFocused !== false) {
+            requestFullRefresh(input.invalidPresentationReason);
+            return false;
+        }
+        if (!canApplyProjectionRevision(message.projectionRevision)
+            || !canApplyAtomicPresentationProjectionRevision(message.projectionRevision)) {
+            return false;
+        }
+        if (!input.replaceContent()) {
+            requestFullRefresh(input.invalidReplacementReason);
+            return false;
+        }
+        commitAtomicProjectionRevision(message.projectionRevision);
+        if (typeof input.afterReplacement === 'function') {
+            input.afterReplacement();
+        }
+        applyValidatedAiSessionPresentationState(message.presentation);
+        return true;
+    }
+
+    return {
+        applyAtomicEnvelope: applyAtomicEnvelope,
+        applyDirectPresentation: applyDirectPresentation,
+        applyInitialPresentation: applyInitialPresentation,
+        requestFullRefresh: requestFullRefresh,
+    };
+}
+
+function initProjectAiSessionsUpdate(options) {
+    'use strict';
+
+    options = options || {};
+    var batchAiSessionState = options.batchAiSessionState;
+    var batchAiSessionManager = options.batchAiSessionManager;
+    var getPendingAiSessionProviderSelectionProjectId = options.getPendingAiSessionProviderSelectionProjectId;
+    var getSelectedAiSessionProviders = options.getSelectedAiSessionProviders;
+    var syncAiSessionBatchManagementDom = options.syncAiSessionBatchManagementDom;
+    var syncAiSessionProjectionDom = options.syncAiSessionProjectionDom;
+    var reconcilePendingAiSessionProviderSelectionDom = options.reconcilePendingAiSessionProviderSelectionDom;
+    var submitAiSessionProviderSelection = options.submitAiSessionProviderSelection;
+    var toggleCodexSessions = options.toggleCodexSessions;
+    var exitAiSessionBatchManagement = options.exitAiSessionBatchManagement;
+    var isAiSessionProvider = options.isAiSessionProvider;
+    var updateStickyGroupHeaderOffset = options.updateStickyGroupHeaderOffset;
+    var presentationTransactions = options.presentationTransactions;
+
+    var pendingWorkspaceSessionReveal = null;
+
     function applyAiSessionsUpdate(message) {
         if (message.version !== 3
             || typeof message.sequence !== 'number'
@@ -90,7 +160,7 @@ function initProjectAiSessionsUpdate(options) {
             || typeof normalizeDashboardSearchCatalog !== 'function'
             || normalizeDashboardSearchCatalog(message.searchCatalog) !== message.searchCatalog
             || message.searchCatalog.version !== 2) {
-            requestFullRefresh('unsupported-ai-session-message');
+            presentationTransactions.requestFullRefresh('unsupported-ai-session-message');
             return;
         }
 
@@ -98,49 +168,42 @@ function initProjectAiSessionsUpdate(options) {
                 || message.projectionRevision <= 0
                 || message.sequence !== message.projectionRevision
                 || typeof message.generatedAt !== 'string'
-                || !message.generatedAt
-                || typeof isValidAiSessionPresentationState !== 'function'
-                || !isValidAiSessionPresentationState(message.presentation)
-                || message.presentation.projectionRevision !== message.projectionRevision
-                || message.presentation.revealFocused !== false
-                || typeof applyValidatedAiSessionPresentationState !== 'function') {
-            requestFullRefresh('invalid-ai-session-presentation-envelope');
+                || !message.generatedAt) {
+            presentationTransactions.requestFullRefresh(
+                'invalid-ai-session-presentation-envelope'
+            );
             return;
         }
 
-        if (!canApplyProjectionRevision(message.projectionRevision)) {
-            return;
-        }
-        if (!canApplyAtomicPresentationProjectionRevision(message.projectionRevision)) {
-            return;
-        }
-
-        if (!applyWorkspaceUpdate({
-            type: 'workspace-updated',
-            version: 2,
-            currentWorkspaceCount: message.currentWorkspaceCount,
-            html: message.html,
-        }, {
-            canRestoreAiSessionProviderMenu: () =>
-                !getPendingAiSessionProviderSelectionProjectId()
-                && !batchAiSessionState.pending,
+        if (!presentationTransactions.applyAtomicEnvelope({
+            message: message,
+            invalidPresentationReason: 'invalid-ai-session-presentation-envelope',
+            invalidReplacementReason: 'invalid-ai-session-workspace-update',
+            replaceContent: () => applyWorkspaceUpdate({
+                type: 'workspace-updated',
+                version: 2,
+                currentWorkspaceCount: message.currentWorkspaceCount,
+                html: message.html,
+            }, {
+                canRestoreAiSessionProviderMenu: () =>
+                    !getPendingAiSessionProviderSelectionProjectId()
+                    && !batchAiSessionState.pending,
+            }),
+            afterReplacement: () => {
+                if (batchAiSessionState.projectId) {
+                    var projectDiv = findCurrentWorkspaceDiv(batchAiSessionState.projectId);
+                    if (projectDiv) {
+                        batchAiSessionManager.reconcileVisible(projectDiv);
+                        syncAiSessionBatchManagementDom(projectDiv);
+                    } else {
+                        exitAiSessionBatchManagement();
+                    }
+                }
+                reconcilePendingAiSessionProviderSelectionDom();
+            },
         })) {
-            requestFullRefresh('invalid-ai-session-workspace-update');
             return;
         }
-
-        commitAtomicProjectionRevision(message.projectionRevision);
-        if (batchAiSessionState.projectId) {
-            var projectDiv = findCurrentWorkspaceDiv(batchAiSessionState.projectId);
-            if (projectDiv) {
-                batchAiSessionManager.reconcileVisible(projectDiv);
-                syncAiSessionBatchManagementDom(projectDiv);
-            } else {
-                exitAiSessionBatchManagement();
-            }
-        }
-        reconcilePendingAiSessionProviderSelectionDom();
-        applyValidatedAiSessionPresentationState(message.presentation);
         updateStickyGroupHeaderOffset();
         if (window.__agentPivotDashboard) {
             window.__agentPivotDashboard.replaceSearchCatalog(message.searchCatalog);
@@ -240,23 +303,11 @@ function initProjectAiSessionsUpdate(options) {
         );
     };
 
-    function requestFullRefresh(reason) {
-        window.vscode.postMessage({
-            type: 'request-full-refresh',
-            reason,
-        });
-    }
-
     return {
         applyAiSessionsUpdate: applyAiSessionsUpdate,
-        acceptInitialPresentationProjectionRevision: acceptInitialPresentationProjectionRevision,
-        acceptPresentationProjectionRevision: acceptPresentationProjectionRevision,
-        canApplyAtomicPresentationProjectionRevision: canApplyAtomicPresentationProjectionRevision,
-        canApplyProjectionRevision: canApplyProjectionRevision,
-        commitAtomicProjectionRevision: commitAtomicProjectionRevision,
         findCurrentWorkspaceDiv: findCurrentWorkspaceDiv,
         findWorkspaceDiv: findWorkspaceDiv,
         focusSearchRevealTarget: focusSearchRevealTarget,
-        requestFullRefresh: requestFullRefresh,
+        requestFullRefresh: presentationTransactions.requestFullRefresh,
     };
 }

--- a/media/webviewProjectScripts.js
+++ b/media/webviewProjectScripts.js
@@ -562,6 +562,10 @@ function initProjects() {
             syncActiveAiSessionProjectionDom(true, false);
         }
     }
+    var presentationTransactions = initAiSessionPresentationTransactions({
+        isValidAiSessionPresentationState: isValidAiSessionPresentationState,
+        applyValidatedAiSessionPresentationState: applyValidatedAiSessionPresentationState,
+    });
     var aiSessionsUpdate = initProjectAiSessionsUpdate({
         batchAiSessionState: aiSessionControls.batchAiSessionState,
         batchAiSessionManager: aiSessionControls.batchAiSessionManager,
@@ -575,8 +579,7 @@ function initProjects() {
         exitAiSessionBatchManagement: aiSessionControls.exitAiSessionBatchManagement,
         isAiSessionProvider: aiSessionControls.isAiSessionProvider,
         updateStickyGroupHeaderOffset: updateStickyGroupHeaderOffset,
-        isValidAiSessionPresentationState: isValidAiSessionPresentationState,
-        applyValidatedAiSessionPresentationState: applyValidatedAiSessionPresentationState,
+        presentationTransactions: presentationTransactions,
     });
 
     function isValidAiSessionPresentationState(message) {
@@ -629,36 +632,6 @@ function initProjects() {
                 && session.eventIds.every(eventId => typeof eventId === 'string' && !!eventId));
     }
 
-    function applyAiSessionPresentationState(message, initialDocument) {
-        if (!isValidAiSessionPresentationState(message)) {
-            aiSessionsUpdate.requestFullRefresh(initialDocument
-                ? 'invalid-initial-ai-session-presentation-state'
-                : 'invalid-ai-session-presentation-state');
-            return false;
-        }
-        var accepted = initialDocument
-            ? aiSessionsUpdate.acceptInitialPresentationProjectionRevision(
-                message.projectionRevision
-            )
-            : aiSessionsUpdate.acceptPresentationProjectionRevision(
-                message.projectionRevision
-            );
-        if (!accepted) return false;
-        applyValidatedAiSessionPresentationState(message);
-        return true;
-    }
-
-    function applyDirectAiSessionPresentationState(message) {
-        if (!isValidAiSessionPresentationState(message)
-            || message.revealFocused !== true) {
-            aiSessionsUpdate.requestFullRefresh(
-                'invalid-direct-ai-session-presentation-state'
-            );
-            return false;
-        }
-        return applyAiSessionPresentationState(message, false);
-    }
-
     function applyValidatedAiSessionPresentationState(message) {
         window.__agentPivotAiSessionPresentationState = message;
         applyAiSessionPresentationDom(message);
@@ -677,7 +650,9 @@ function initProjects() {
 
     var initialAiSessionPresentationState = readInitialAiSessionPresentationState();
     if (initialAiSessionPresentationState) {
-        applyAiSessionPresentationState(initialAiSessionPresentationState, true);
+        presentationTransactions.applyInitialPresentation(
+            initialAiSessionPresentationState
+        );
     }
 
     function onMouseEvent(e) {
@@ -867,25 +842,14 @@ function initProjects() {
                 );
                 return;
             }
-            if (!isValidAiSessionPresentationState(message.presentation)
-                    || message.presentation.projectionRevision
-                        !== message.projectionRevision
-                    || message.presentation.revealFocused !== false) {
-                aiSessionsUpdate.requestFullRefresh(
-                    'invalid-open-workspaces-presentation-envelope'
-                );
+            if (!presentationTransactions.applyAtomicEnvelope({
+                message: message,
+                invalidPresentationReason: 'invalid-open-workspaces-presentation-envelope',
+                invalidReplacementReason: 'invalid-open-workspaces-update',
+                replaceContent: () => applyOpenWorkspacesUpdate(message),
+            })) {
                 return;
             }
-            if (!aiSessionsUpdate.canApplyProjectionRevision(message.projectionRevision)) return;
-            if (!aiSessionsUpdate.canApplyAtomicPresentationProjectionRevision(
-                message.projectionRevision
-            )) return;
-            if (!applyOpenWorkspacesUpdate(message)) {
-                aiSessionsUpdate.requestFullRefresh('invalid-open-workspaces-update');
-                return;
-            }
-            aiSessionsUpdate.commitAtomicProjectionRevision(message.projectionRevision);
-            applyValidatedAiSessionPresentationState(message.presentation);
             updateStickyGroupHeaderOffset();
             if (openTabSplit && typeof openTabSplit.syncResizer === 'function') {
                 openTabSplit.syncResizer();
@@ -924,7 +888,7 @@ function initProjects() {
         }
 
         if (message && message.type === 'ai-session-presentation-state') {
-            applyDirectAiSessionPresentationState(message);
+            presentationTransactions.applyDirectPresentation(message);
             return;
         }
 

--- a/scripts/run-ai-session-safety-checks.js
+++ b/scripts/run-ai-session-safety-checks.js
@@ -7419,7 +7419,7 @@ function runAiSessionIncrementalRefreshSourceChecks() {
         false
     );
     assert.ok(projectWebviewSource.includes(
-        'aiSessionsUpdate.canApplyProjectionRevision(message.projectionRevision)'
+        'presentationTransactions.applyAtomicEnvelope({'
     ));
     assert.strictEqual(
         extractMethodBody(workspaceHydrationSource, 'hydrate').includes('this.options.getActiveRuntimes()'),

--- a/scripts/run-architecture-guards.js
+++ b/scripts/run-architecture-guards.js
@@ -742,6 +742,65 @@ const guards = {
                 'hydration must consume the transaction presentation with only an explicit fallback');
         }
         const webviewSource = webview.getFullText();
+        const transactionOwner = uniqueAstNode(
+            webview,
+            node => ts.isFunctionDeclaration(node)
+                && node.name?.text === 'initAiSessionPresentationTransactions',
+            this.id,
+            risk,
+            'AI session Presentation transaction owner'
+        );
+        const transactionOwnerSource = transactionOwner.getText(webview);
+        const aiUpdateOwner = uniqueAstNode(
+            webview,
+            node => ts.isFunctionDeclaration(node)
+                && node.name?.text === 'initProjectAiSessionsUpdate',
+            this.id,
+            risk,
+            'AI sessions incremental update owner'
+        );
+        const aiUpdateOwnerSource = aiUpdateOwner.getText(webview);
+        const aiAtomicCalls = callArguments(
+            aiUpdateOwner,
+            'presentationTransactions.applyAtomicEnvelope'
+        );
+        const aiAtomicInput = aiAtomicCalls.length === 1
+            ? aiAtomicCalls[0][0]
+            : null;
+        const aiAfterReplacement = aiAtomicInput
+            && ts.isObjectLiteralExpression(aiAtomicInput)
+            ? aiAtomicInput.properties.find(property =>
+                ts.isPropertyAssignment(property)
+                    && property.name.getText(webview) === 'afterReplacement')
+            : null;
+        const aiAfterReplacementSource = aiAfterReplacement
+            && ts.isPropertyAssignment(aiAfterReplacement)
+            && ts.isArrowFunction(aiAfterReplacement.initializer)
+            ? aiAfterReplacement.initializer.getText(webview)
+            : '';
+        if (!aiAfterReplacementSource.includes(
+            'batchAiSessionManager.reconcileVisible(projectDiv)'
+        ) || !aiAfterReplacementSource.includes(
+            'syncAiSessionBatchManagementDom(projectDiv)'
+        ) || !aiAfterReplacementSource.includes(
+            'exitAiSessionBatchManagement()'
+        ) || !aiAfterReplacementSource.includes(
+            'reconcilePendingAiSessionProviderSelectionDom()'
+        )) {
+            fail(this.id, risk,
+                'AI atomic replacement must reconcile batch and provider state inside the transaction hook');
+        }
+        for (const counterName of [
+            'latestAiSessionProjectionRevision',
+            'latestAiSessionPresentationProjectionRevision',
+            'latestAiSessionClosedPresentationRevision',
+        ]) {
+            const counter = findVariable(webview, counterName, this.id, risk);
+            if (counter.pos < transactionOwner.pos || counter.end > transactionOwner.end) {
+                fail(this.id, risk,
+                    'all Presentation revision counters must belong to the shared transaction owner');
+            }
+        }
         if (!webviewSource.includes('latestAiSessionClosedPresentationRevision')
             || !webviewSource.includes('revision < latestAiSessionProjectionRevision')
             || !webviewSource.includes(
@@ -779,7 +838,7 @@ const guards = {
                 "getElementById('dashboard-ai-session-presentation')"
             )
             || !projectWebviewSource.includes(
-                'applyAiSessionPresentationState(initialAiSessionPresentationState, true)'
+                'presentationTransactions.applyInitialPresentation('
             )) {
             fail(this.id, risk,
                 'the Webview must seed revision and complete owners from the full document');
@@ -805,29 +864,44 @@ const guards = {
             fail(this.id, risk,
                 'OPEN HTML and Presentation must share one Host message');
         }
-        if (!webviewSource.includes(
+        const transactionOrder = [
+            '!isValidAiSessionPresentationState(message.presentation)',
+            '!canApplyProjectionRevision(message.projectionRevision)',
+            '!canApplyAtomicPresentationProjectionRevision(message.projectionRevision)',
+            '!input.replaceContent()',
+            'commitAtomicProjectionRevision(message.projectionRevision)',
+            "typeof input.afterReplacement === 'function'",
+            'applyValidatedAiSessionPresentationState(message.presentation)',
+        ].map(fragment => transactionOwnerSource.indexOf(fragment));
+        if (transactionOrder.some(index => index < 0)
+            || transactionOrder.some((index, position) =>
+                position > 0 && index <= transactionOrder[position - 1])
+            || (webviewSource.match(/commitAtomicProjectionRevision\(message\.projectionRevision\)/g) || []).length !== 1
+            || (webviewSource.match(/applyValidatedAiSessionPresentationState\(message\.presentation\)/g) || []).length !== 1
+            || !aiUpdateOwnerSource.includes(
+                'presentationTransactions.applyAtomicEnvelope({'
+            )
+            || aiUpdateOwnerSource.includes('commitAtomicProjectionRevision(')
+            || !projectWebviewSource.includes(
+                'presentationTransactions.applyAtomicEnvelope({'
+            )
+            || projectWebviewSource.includes(
+                'aiSessionsUpdate.commitAtomicProjectionRevision('
+            )
+            || !projectWebviewSource.includes(
+                'presentationTransactions.applyDirectPresentation(message)'
+            )
+            || !transactionOwnerSource.includes('message.revealFocused !== true')
+            || !webviewSource.includes(
             'message.presentation.projectionRevision !== message.projectionRevision'
         ) || !webviewSource.includes(
             'message.presentation.revealFocused !== false'
         ) || !webviewSource.includes(
             'applyValidatedAiSessionPresentationState(message.presentation);'
-        ) || !webviewSource.includes(
-            'canApplyAtomicPresentationProjectionRevision(message.projectionRevision)'
-        ) || !webviewSource.includes(
-            'commitAtomicProjectionRevision(message.projectionRevision)'
         ) || !projectWebviewSource.includes(
             'invalid-open-workspaces-presentation-envelope'
-        ) || !projectWebviewSource.includes(
-            'message.presentation.revealFocused !== false'
-        ) || !projectWebviewSource.includes(
-            'applyValidatedAiSessionPresentationState(message.presentation);'
-        ) || !projectWebviewSource.includes(
-            'aiSessionsUpdate.canApplyAtomicPresentationProjectionRevision('
-        ) || !projectWebviewSource.includes(
-            'aiSessionsUpdate.commitAtomicProjectionRevision(message.projectionRevision)'
         ) || !projectWebviewSource.includes('message.version !== 3')
             || projectWebviewSource.includes('isAtomicOpenWorkspacesEnvelope')
-            || !projectWebviewSource.includes('message.revealFocused !== true')
             || projectWebviewSource.includes(
                 "type: 'request-ai-session-attention-state'"
             ) || !workspaceWebviewSource.includes(

--- a/src/webview/webviewProjectAiUpdateScripts.js
+++ b/src/webview/webviewProjectAiUpdateScripts.js
@@ -1,26 +1,19 @@
-function initProjectAiSessionsUpdate(options) {
+function initAiSessionPresentationTransactions(options) {
     'use strict';
 
     options = options || {};
-    var batchAiSessionState = options.batchAiSessionState;
-    var batchAiSessionManager = options.batchAiSessionManager;
-    var getPendingAiSessionProviderSelectionProjectId = options.getPendingAiSessionProviderSelectionProjectId;
-    var getSelectedAiSessionProviders = options.getSelectedAiSessionProviders;
-    var syncAiSessionBatchManagementDom = options.syncAiSessionBatchManagementDom;
-    var syncAiSessionProjectionDom = options.syncAiSessionProjectionDom;
-    var reconcilePendingAiSessionProviderSelectionDom = options.reconcilePendingAiSessionProviderSelectionDom;
-    var submitAiSessionProviderSelection = options.submitAiSessionProviderSelection;
-    var toggleCodexSessions = options.toggleCodexSessions;
-    var exitAiSessionBatchManagement = options.exitAiSessionBatchManagement;
-    var isAiSessionProvider = options.isAiSessionProvider;
-    var updateStickyGroupHeaderOffset = options.updateStickyGroupHeaderOffset;
     var isValidAiSessionPresentationState = options.isValidAiSessionPresentationState;
     var applyValidatedAiSessionPresentationState = options.applyValidatedAiSessionPresentationState;
-
-    var pendingWorkspaceSessionReveal = null;
     var latestAiSessionProjectionRevision = 0;
     var latestAiSessionPresentationProjectionRevision = 0;
     var latestAiSessionClosedPresentationRevision = 0;
+
+    function requestFullRefresh(reason) {
+        window.vscode.postMessage({
+            type: 'request-full-refresh',
+            reason,
+        });
+    }
 
     function canApplyRevision(revision, latestRevision) {
         if (typeof revision === 'undefined') {
@@ -43,17 +36,15 @@ function initProjectAiSessionsUpdate(options) {
     }
 
     function commitAtomicProjectionRevision(revision) {
-        if (Number.isSafeInteger(revision) && revision > 0) {
-            latestAiSessionProjectionRevision = revision;
-            latestAiSessionPresentationProjectionRevision = Math.max(
-                latestAiSessionPresentationProjectionRevision,
-                revision
-            );
-            latestAiSessionClosedPresentationRevision = Math.max(
-                latestAiSessionClosedPresentationRevision,
-                revision
-            );
-        }
+        latestAiSessionProjectionRevision = revision;
+        latestAiSessionPresentationProjectionRevision = Math.max(
+            latestAiSessionPresentationProjectionRevision,
+            revision
+        );
+        latestAiSessionClosedPresentationRevision = Math.max(
+            latestAiSessionClosedPresentationRevision,
+            revision
+        );
     }
 
     function acceptPresentationProjectionRevision(revision) {
@@ -82,6 +73,85 @@ function initProjectAiSessionsUpdate(options) {
         return true;
     }
 
+    function applyInitialPresentation(message) {
+        if (!isValidAiSessionPresentationState(message)) {
+            requestFullRefresh('invalid-initial-ai-session-presentation-state');
+            return false;
+        }
+        if (!acceptInitialPresentationProjectionRevision(message.projectionRevision)) {
+            return false;
+        }
+        applyValidatedAiSessionPresentationState(message);
+        return true;
+    }
+
+    function applyDirectPresentation(message) {
+        if (!isValidAiSessionPresentationState(message)
+            || message.revealFocused !== true) {
+            requestFullRefresh('invalid-direct-ai-session-presentation-state');
+            return false;
+        }
+        if (!acceptPresentationProjectionRevision(message.projectionRevision)) {
+            return false;
+        }
+        applyValidatedAiSessionPresentationState(message);
+        return true;
+    }
+
+    function applyAtomicEnvelope(input) {
+        var message = input.message;
+        if (!Number.isSafeInteger(message.projectionRevision)
+            || message.projectionRevision <= 0
+            || !isValidAiSessionPresentationState(message.presentation)
+            || message.presentation.projectionRevision !== message.projectionRevision
+            || message.presentation.revealFocused !== false) {
+            requestFullRefresh(input.invalidPresentationReason);
+            return false;
+        }
+        if (!canApplyProjectionRevision(message.projectionRevision)
+            || !canApplyAtomicPresentationProjectionRevision(message.projectionRevision)) {
+            return false;
+        }
+        if (!input.replaceContent()) {
+            requestFullRefresh(input.invalidReplacementReason);
+            return false;
+        }
+        commitAtomicProjectionRevision(message.projectionRevision);
+        if (typeof input.afterReplacement === 'function') {
+            input.afterReplacement();
+        }
+        applyValidatedAiSessionPresentationState(message.presentation);
+        return true;
+    }
+
+    return {
+        applyAtomicEnvelope: applyAtomicEnvelope,
+        applyDirectPresentation: applyDirectPresentation,
+        applyInitialPresentation: applyInitialPresentation,
+        requestFullRefresh: requestFullRefresh,
+    };
+}
+
+function initProjectAiSessionsUpdate(options) {
+    'use strict';
+
+    options = options || {};
+    var batchAiSessionState = options.batchAiSessionState;
+    var batchAiSessionManager = options.batchAiSessionManager;
+    var getPendingAiSessionProviderSelectionProjectId = options.getPendingAiSessionProviderSelectionProjectId;
+    var getSelectedAiSessionProviders = options.getSelectedAiSessionProviders;
+    var syncAiSessionBatchManagementDom = options.syncAiSessionBatchManagementDom;
+    var syncAiSessionProjectionDom = options.syncAiSessionProjectionDom;
+    var reconcilePendingAiSessionProviderSelectionDom = options.reconcilePendingAiSessionProviderSelectionDom;
+    var submitAiSessionProviderSelection = options.submitAiSessionProviderSelection;
+    var toggleCodexSessions = options.toggleCodexSessions;
+    var exitAiSessionBatchManagement = options.exitAiSessionBatchManagement;
+    var isAiSessionProvider = options.isAiSessionProvider;
+    var updateStickyGroupHeaderOffset = options.updateStickyGroupHeaderOffset;
+    var presentationTransactions = options.presentationTransactions;
+
+    var pendingWorkspaceSessionReveal = null;
+
     function applyAiSessionsUpdate(message) {
         if (message.version !== 3
             || typeof message.sequence !== 'number'
@@ -90,7 +160,7 @@ function initProjectAiSessionsUpdate(options) {
             || typeof normalizeDashboardSearchCatalog !== 'function'
             || normalizeDashboardSearchCatalog(message.searchCatalog) !== message.searchCatalog
             || message.searchCatalog.version !== 2) {
-            requestFullRefresh('unsupported-ai-session-message');
+            presentationTransactions.requestFullRefresh('unsupported-ai-session-message');
             return;
         }
 
@@ -98,49 +168,42 @@ function initProjectAiSessionsUpdate(options) {
                 || message.projectionRevision <= 0
                 || message.sequence !== message.projectionRevision
                 || typeof message.generatedAt !== 'string'
-                || !message.generatedAt
-                || typeof isValidAiSessionPresentationState !== 'function'
-                || !isValidAiSessionPresentationState(message.presentation)
-                || message.presentation.projectionRevision !== message.projectionRevision
-                || message.presentation.revealFocused !== false
-                || typeof applyValidatedAiSessionPresentationState !== 'function') {
-            requestFullRefresh('invalid-ai-session-presentation-envelope');
+                || !message.generatedAt) {
+            presentationTransactions.requestFullRefresh(
+                'invalid-ai-session-presentation-envelope'
+            );
             return;
         }
 
-        if (!canApplyProjectionRevision(message.projectionRevision)) {
-            return;
-        }
-        if (!canApplyAtomicPresentationProjectionRevision(message.projectionRevision)) {
-            return;
-        }
-
-        if (!applyWorkspaceUpdate({
-            type: 'workspace-updated',
-            version: 2,
-            currentWorkspaceCount: message.currentWorkspaceCount,
-            html: message.html,
-        }, {
-            canRestoreAiSessionProviderMenu: () =>
-                !getPendingAiSessionProviderSelectionProjectId()
-                && !batchAiSessionState.pending,
+        if (!presentationTransactions.applyAtomicEnvelope({
+            message: message,
+            invalidPresentationReason: 'invalid-ai-session-presentation-envelope',
+            invalidReplacementReason: 'invalid-ai-session-workspace-update',
+            replaceContent: () => applyWorkspaceUpdate({
+                type: 'workspace-updated',
+                version: 2,
+                currentWorkspaceCount: message.currentWorkspaceCount,
+                html: message.html,
+            }, {
+                canRestoreAiSessionProviderMenu: () =>
+                    !getPendingAiSessionProviderSelectionProjectId()
+                    && !batchAiSessionState.pending,
+            }),
+            afterReplacement: () => {
+                if (batchAiSessionState.projectId) {
+                    var projectDiv = findCurrentWorkspaceDiv(batchAiSessionState.projectId);
+                    if (projectDiv) {
+                        batchAiSessionManager.reconcileVisible(projectDiv);
+                        syncAiSessionBatchManagementDom(projectDiv);
+                    } else {
+                        exitAiSessionBatchManagement();
+                    }
+                }
+                reconcilePendingAiSessionProviderSelectionDom();
+            },
         })) {
-            requestFullRefresh('invalid-ai-session-workspace-update');
             return;
         }
-
-        commitAtomicProjectionRevision(message.projectionRevision);
-        if (batchAiSessionState.projectId) {
-            var projectDiv = findCurrentWorkspaceDiv(batchAiSessionState.projectId);
-            if (projectDiv) {
-                batchAiSessionManager.reconcileVisible(projectDiv);
-                syncAiSessionBatchManagementDom(projectDiv);
-            } else {
-                exitAiSessionBatchManagement();
-            }
-        }
-        reconcilePendingAiSessionProviderSelectionDom();
-        applyValidatedAiSessionPresentationState(message.presentation);
         updateStickyGroupHeaderOffset();
         if (window.__agentPivotDashboard) {
             window.__agentPivotDashboard.replaceSearchCatalog(message.searchCatalog);
@@ -240,23 +303,11 @@ function initProjectAiSessionsUpdate(options) {
         );
     };
 
-    function requestFullRefresh(reason) {
-        window.vscode.postMessage({
-            type: 'request-full-refresh',
-            reason,
-        });
-    }
-
     return {
         applyAiSessionsUpdate: applyAiSessionsUpdate,
-        acceptInitialPresentationProjectionRevision: acceptInitialPresentationProjectionRevision,
-        acceptPresentationProjectionRevision: acceptPresentationProjectionRevision,
-        canApplyAtomicPresentationProjectionRevision: canApplyAtomicPresentationProjectionRevision,
-        canApplyProjectionRevision: canApplyProjectionRevision,
-        commitAtomicProjectionRevision: commitAtomicProjectionRevision,
         findCurrentWorkspaceDiv: findCurrentWorkspaceDiv,
         findWorkspaceDiv: findWorkspaceDiv,
         focusSearchRevealTarget: focusSearchRevealTarget,
-        requestFullRefresh: requestFullRefresh,
+        requestFullRefresh: presentationTransactions.requestFullRefresh,
     };
 }

--- a/src/webview/webviewProjectScripts.js
+++ b/src/webview/webviewProjectScripts.js
@@ -562,6 +562,10 @@ function initProjects() {
             syncActiveAiSessionProjectionDom(true, false);
         }
     }
+    var presentationTransactions = initAiSessionPresentationTransactions({
+        isValidAiSessionPresentationState: isValidAiSessionPresentationState,
+        applyValidatedAiSessionPresentationState: applyValidatedAiSessionPresentationState,
+    });
     var aiSessionsUpdate = initProjectAiSessionsUpdate({
         batchAiSessionState: aiSessionControls.batchAiSessionState,
         batchAiSessionManager: aiSessionControls.batchAiSessionManager,
@@ -575,8 +579,7 @@ function initProjects() {
         exitAiSessionBatchManagement: aiSessionControls.exitAiSessionBatchManagement,
         isAiSessionProvider: aiSessionControls.isAiSessionProvider,
         updateStickyGroupHeaderOffset: updateStickyGroupHeaderOffset,
-        isValidAiSessionPresentationState: isValidAiSessionPresentationState,
-        applyValidatedAiSessionPresentationState: applyValidatedAiSessionPresentationState,
+        presentationTransactions: presentationTransactions,
     });
 
     function isValidAiSessionPresentationState(message) {
@@ -629,36 +632,6 @@ function initProjects() {
                 && session.eventIds.every(eventId => typeof eventId === 'string' && !!eventId));
     }
 
-    function applyAiSessionPresentationState(message, initialDocument) {
-        if (!isValidAiSessionPresentationState(message)) {
-            aiSessionsUpdate.requestFullRefresh(initialDocument
-                ? 'invalid-initial-ai-session-presentation-state'
-                : 'invalid-ai-session-presentation-state');
-            return false;
-        }
-        var accepted = initialDocument
-            ? aiSessionsUpdate.acceptInitialPresentationProjectionRevision(
-                message.projectionRevision
-            )
-            : aiSessionsUpdate.acceptPresentationProjectionRevision(
-                message.projectionRevision
-            );
-        if (!accepted) return false;
-        applyValidatedAiSessionPresentationState(message);
-        return true;
-    }
-
-    function applyDirectAiSessionPresentationState(message) {
-        if (!isValidAiSessionPresentationState(message)
-            || message.revealFocused !== true) {
-            aiSessionsUpdate.requestFullRefresh(
-                'invalid-direct-ai-session-presentation-state'
-            );
-            return false;
-        }
-        return applyAiSessionPresentationState(message, false);
-    }
-
     function applyValidatedAiSessionPresentationState(message) {
         window.__agentPivotAiSessionPresentationState = message;
         applyAiSessionPresentationDom(message);
@@ -677,7 +650,9 @@ function initProjects() {
 
     var initialAiSessionPresentationState = readInitialAiSessionPresentationState();
     if (initialAiSessionPresentationState) {
-        applyAiSessionPresentationState(initialAiSessionPresentationState, true);
+        presentationTransactions.applyInitialPresentation(
+            initialAiSessionPresentationState
+        );
     }
 
     function onMouseEvent(e) {
@@ -867,25 +842,14 @@ function initProjects() {
                 );
                 return;
             }
-            if (!isValidAiSessionPresentationState(message.presentation)
-                    || message.presentation.projectionRevision
-                        !== message.projectionRevision
-                    || message.presentation.revealFocused !== false) {
-                aiSessionsUpdate.requestFullRefresh(
-                    'invalid-open-workspaces-presentation-envelope'
-                );
+            if (!presentationTransactions.applyAtomicEnvelope({
+                message: message,
+                invalidPresentationReason: 'invalid-open-workspaces-presentation-envelope',
+                invalidReplacementReason: 'invalid-open-workspaces-update',
+                replaceContent: () => applyOpenWorkspacesUpdate(message),
+            })) {
                 return;
             }
-            if (!aiSessionsUpdate.canApplyProjectionRevision(message.projectionRevision)) return;
-            if (!aiSessionsUpdate.canApplyAtomicPresentationProjectionRevision(
-                message.projectionRevision
-            )) return;
-            if (!applyOpenWorkspacesUpdate(message)) {
-                aiSessionsUpdate.requestFullRefresh('invalid-open-workspaces-update');
-                return;
-            }
-            aiSessionsUpdate.commitAtomicProjectionRevision(message.projectionRevision);
-            applyValidatedAiSessionPresentationState(message.presentation);
             updateStickyGroupHeaderOffset();
             if (openTabSplit && typeof openTabSplit.syncResizer === 'function') {
                 openTabSplit.syncResizer();
@@ -924,7 +888,7 @@ function initProjects() {
         }
 
         if (message && message.type === 'ai-session-presentation-state') {
-            applyDirectAiSessionPresentationState(message);
+            presentationTransactions.applyDirectPresentation(message);
             return;
         }
 

--- a/tests/browser/activeSessionCardInteraction.test.js
+++ b/tests/browser/activeSessionCardInteraction.test.js
@@ -332,7 +332,8 @@ async function openCardPage(
     activeAiSessions,
     viewport = { width: 360, height: 900 },
     currentWorkspaceMarkup,
-    initialPresentation
+    initialPresentation,
+    preserveInitialMessages = false
 ) {
     const page = await browser.newPage({ viewport });
     t.after(() => page.close());
@@ -361,10 +362,10 @@ async function openCardPage(
     await page.addScriptTag({ content: projectAiUpdateScript });
     await page.addScriptTag({ content: aiSessionControlsScript });
     await page.addScriptTag({ content: projectScript });
-    await page.evaluate(() => {
+    await page.evaluate(preserveMessages => {
         initProjects();
-        window.__postedMessages.length = 0;
-    });
+        if (!preserveMessages) window.__postedMessages.length = 0;
+    }, preserveInitialMessages);
     return page;
 }
 
@@ -1242,6 +1243,32 @@ test('ACTIVE-SESSION-INCREMENTAL-PRESENTATION-ENVELOPE-001 rejects an invalid OP
     }]);
 });
 
+test('ACTIVE-SESSION-INCREMENTAL-PRESENTATION-ENVELOPE-001 rolls back an invalid OPEN replacement without committing its revision', async t => {
+    const initial = [session('codex', 'session-a', true)];
+    const replacement = [session('codex', 'session-b', true)];
+    const page = await openCardPage(t, initial);
+    const invalidReplacement = openWorkspacesEnvelope(replacement, 2, {
+        semanticRevision: 'invalid-open-replacement',
+    });
+    invalidReplacement.html = '<div data-invalid-open-replacement></div>';
+
+    await postHostMessage(page, invalidReplacement);
+
+    assert.equal(await row(page, 'codex', 'session-a').count(), 1);
+    assert.equal(await row(page, 'codex', 'session-b').count(), 0);
+    assert.deepEqual(await postedMessages(page), [{
+        type: 'request-full-refresh',
+        reason: 'invalid-open-workspaces-update',
+    }]);
+
+    await page.evaluate(() => { window.__postedMessages.length = 0; });
+    await postHostMessage(page, openWorkspacesEnvelope(replacement, 2, {
+        semanticRevision: 'valid-open-replacement',
+    }));
+    assert.equal(await row(page, 'codex', 'session-a').count(), 0);
+    assert.equal(await row(page, 'codex', 'session-b').count(), 1);
+});
+
 test('ACTIVE-SESSION-INCREMENTAL-PRESENTATION-ENVELOPE-001 rejects focus reveal inside an AI envelope', async t => {
     const initial = [session('codex', 'session-a', true)];
     const replacement = [session('codex', 'session-b', true)];
@@ -1311,6 +1338,35 @@ test('ACTIVE-SESSION-FULL-RENDER-TRANSACTION-001 seeds the full document revisio
     assert.deepEqual(acknowledgements.map(message => message.eventIds), [
         ['event-a', 'event-b'],
     ]);
+});
+
+test('ACTIVE-SESSION-FULL-RENDER-TRANSACTION-001 rejects an invalid initial presentation without committing its revision', async t => {
+    const initial = [session('codex', 'session-a', true)];
+    const replacement = [session('codex', 'session-b', true)];
+    const invalidInitialPresentation = {
+        ...presentationMessage(initial, 1),
+        version: 2,
+    };
+    const page = await openCardPage(
+        t,
+        initial,
+        { width: 360, height: 900 },
+        undefined,
+        invalidInitialPresentation,
+        true
+    );
+
+    assert.deepEqual((await postedMessages(page)).filter(message =>
+        message.type === 'request-full-refresh'
+    ), [{
+        type: 'request-full-refresh',
+        reason: 'invalid-initial-ai-session-presentation-state',
+    }]);
+
+    await page.evaluate(() => { window.__postedMessages.length = 0; });
+    await postHostMessage(page, aiSessionsEnvelope(replacement, 1));
+    assert.equal(await row(page, 'codex', 'session-a').count(), 0);
+    assert.equal(await row(page, 'codex', 'session-b').count(), 1);
 });
 
 test('ATTENTION-SESSION-CARD-ACKNOWLEDGEMENT-001 keeps acknowledgement pending until its committed v3 presentation is applied', async t => {

--- a/tests/unit/tooling/architectureGuards.test.js
+++ b/tests/unit/tooling/architectureGuards.test.js
@@ -808,6 +808,26 @@ for (const mutation of [
     {
         id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
         file: 'src/webview/webviewProjectAiUpdateScripts.js',
+        expectedDetail: 'AI atomic replacement must reconcile batch and provider state inside the transaction hook',
+        mutate: source => replaceFixtureSource(
+            source,
+            'afterReplacement: () => {',
+            'detachedAfterReplacement: () => {'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectAiUpdateScripts.js',
+        expectedDetail: 'AI atomic replacement must reconcile batch and provider state inside the transaction hook',
+        mutate: source => replaceFixtureSource(
+            source,
+            'syncAiSessionBatchManagementDom(projectDiv);',
+            'syncAiSessionProjectionDom(false);'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectAiUpdateScripts.js',
         expectedDetail: 'Webview must validate v3 envelopes atomically and reserve direct Presentation for focus',
         mutate: source => replaceFixtureSource(
             source,
@@ -831,8 +851,8 @@ for (const mutation of [
         expectedDetail: 'Webview must validate v3 envelopes atomically and reserve direct Presentation for focus',
         mutate: source => replaceFixtureSource(
             source,
-            'message.presentation.revealFocused !== false',
-            'message.presentation.revealFocused !== true'
+            'presentationTransactions.applyAtomicEnvelope({',
+            'presentationTransactions.applyDirectPresentation({'
         ),
     },
     {
@@ -851,18 +871,18 @@ for (const mutation of [
         expectedDetail: 'Webview must validate v3 envelopes atomically and reserve direct Presentation for focus',
         mutate: source => replaceFixtureSource(
             source,
-            'if (!canApplyAtomicPresentationProjectionRevision(message.projectionRevision))',
-            'if (!canApplyProjectionRevision(message.projectionRevision))'
+            '|| !canApplyAtomicPresentationProjectionRevision(message.projectionRevision)',
+            '|| !canApplyProjectionRevision(message.projectionRevision)'
         ),
     },
     {
         id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
-        file: 'src/webview/webviewProjectScripts.js',
-        expectedDetail: 'Webview must validate v3 envelopes atomically and reserve direct Presentation for focus',
+        file: 'src/webview/webviewProjectAiUpdateScripts.js',
+        expectedDetail: 'AI atomic replacement must reconcile batch and provider state inside the transaction hook',
         mutate: source => replaceFixtureSource(
             source,
-            'aiSessionsUpdate.commitAtomicProjectionRevision(message.projectionRevision)',
-            'aiSessionsUpdate.commitAtomicProjectionRevision(message.projectionRevision - 1)'
+            'presentationTransactions.applyAtomicEnvelope({',
+            'presentationTransactions.applyDirectPresentation({'
         ),
     },
     {
@@ -887,22 +907,61 @@ for (const mutation of [
     },
     {
         id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
-        file: 'src/webview/webviewProjectScripts.js',
-        expectedDetail: 'Webview must validate v3 envelopes atomically and reserve direct Presentation for focus',
+        file: 'src/webview/webviewProjectAiUpdateScripts.js',
+        expectedDetail: 'all Presentation revision counters must belong to the shared transaction owner',
         mutate: source => replaceFixtureSource(
-            source,
-            'if (!aiSessionsUpdate.canApplyAtomicPresentationProjectionRevision(',
-            'if (!aiSessionsUpdate.canApplyProjectionRevision('
+            replaceFixtureSource(
+                source,
+                '    var latestAiSessionProjectionRevision = 0;\n',
+                ''
+            ),
+            'function initAiSessionPresentationTransactions(options) {',
+            'var latestAiSessionProjectionRevision = 0;\n\n'
+                + 'function initAiSessionPresentationTransactions(options) {'
         ),
     },
     {
         id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
-        file: 'src/webview/webviewProjectScripts.js',
+        file: 'src/webview/webviewProjectAiUpdateScripts.js',
         expectedDetail: 'Webview must validate v3 envelopes atomically and reserve direct Presentation for focus',
         mutate: source => replaceFixtureSource(
             source,
             'message.revealFocused !== true',
             'message.revealFocused === undefined'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectAiUpdateScripts.js',
+        expectedDetail: 'Webview must validate v3 envelopes atomically and reserve direct Presentation for focus',
+        mutate: source => replaceFixtureSource(
+            source,
+            "if (!input.replaceContent()) {\n"
+                + "            requestFullRefresh(input.invalidReplacementReason);\n"
+                + "            return false;\n"
+                + "        }\n"
+                + "        commitAtomicProjectionRevision(message.projectionRevision);",
+            "commitAtomicProjectionRevision(message.projectionRevision);\n"
+                + "        if (!input.replaceContent()) {\n"
+                + "            requestFullRefresh(input.invalidReplacementReason);\n"
+                + "            return false;\n"
+                + "        }"
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectAiUpdateScripts.js',
+        expectedDetail: 'Webview must validate v3 envelopes atomically and reserve direct Presentation for focus',
+        mutate: source => replaceFixtureSource(
+            source,
+            "if (typeof input.afterReplacement === 'function') {\n"
+                + "            input.afterReplacement();\n"
+                + "        }\n"
+                + "        applyValidatedAiSessionPresentationState(message.presentation);",
+            "applyValidatedAiSessionPresentationState(message.presentation);\n"
+                + "        if (typeof input.afterReplacement === 'function') {\n"
+                + "            input.afterReplacement();\n"
+                + "        }"
         ),
     },
     {


### PR DESCRIPTION
## Summary

- centralize AI Session Presentation revision ownership in one Webview transaction applicator
- route initial render, direct focus, AI v3, and Open Workspaces v3 through the shared validation, replacement, commit, reconciliation, and apply sequence
- add mutation-sensitive architecture guards and rollback characterization coverage for invalid initial and Open Workspaces replacements
- preserve existing Host protocols, Session Navigation, and Attention UI Bridge behavior

## Validation

- `npm run test-compile`
- `npm run test:deterministic:run`
- `npm run test:browser:run` (209 tests)
- `npm run test:safety:run`
- `npm run test:dashboard:run`
- `npm run test:architecture-guards`
- `npm run test:behavior-contracts`
- `npm run test:architecture-baseline`
- `npm run lint`
- `SKIP_NPM_CI=1 npm run install-local`
- independent architecture review: PASS with no remaining Critical or Important findings

## Skill harvest

No skill update was justified. The existing review-fix workflow already required independent review; its findings were closed with focused browser coverage and controlled architecture mutations.

## Scope

No Host wire protocol, UI Bridge runtime, or Session Navigation behavior changes.