### PR TITLE
Refactor session updates onto atomic presentation envelopes

### DIFF
--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "b2bddc70c874d4c7a3543f9d3da558d88ff4faf2",
+        "head": "fdb205f8fa06a52fe09d24a6f794d4c71da6956a",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -272,7 +272,8 @@
             "639b4b720bb2987becc200334d21944b71d61598",
             "7e6bbfd491daa0e36072bb6a55d3564eed4ee731",
             "bc0439f51e63e03021cbff91824c386b4685dfd6",
-            "806d58b9ad6bad2931da41093bdab3600852be37"
+            "806d58b9ad6bad2931da41093bdab3600852be37",
+            "52883dd9c3680cd9cf40446941fef3dee3062c34"
         ]
     },
     "capabilities": [
@@ -930,7 +931,8 @@
                 "47cb385c19b44554d7598f081caf38ffb873cf36",
                 "26ce7197d0d43018b1bae358817ac18374df345e",
                 "e42e41de76fb98abdcee947959f88373a562a8b8",
-                "b2bddc70c874d4c7a3543f9d3da558d88ff4faf2"
+                "b2bddc70c874d4c7a3543f9d3da558d88ff4faf2",
+                "fdb205f8fa06a52fe09d24a6f794d4c71da6956a"
             ],
             "behaviors": [
                 "ATTENTION-ACTIVE-UNREGISTER-ON-DEACTIVATE-001",

--- a/media/webviewDashboardBundle.js
+++ b/media/webviewDashboardBundle.js
@@ -2150,7 +2150,6 @@ function initProjectAiSessionsUpdate(options) {
     var getPendingAiSessionProviderSelectionProjectId = options.getPendingAiSessionProviderSelectionProjectId;
     var getSelectedAiSessionProviders = options.getSelectedAiSessionProviders;
     var syncAiSessionBatchManagementDom = options.syncAiSessionBatchManagementDom;
-    var syncAiSessionProjectionDom = options.syncAiSessionProjectionDom;
     var reconcilePendingAiSessionProviderSelectionDom = options.reconcilePendingAiSessionProviderSelectionDom;
     var submitAiSessionProviderSelection = options.submitAiSessionProviderSelection;
     var toggleCodexSessions = options.toggleCodexSessions;
@@ -3742,18 +3741,6 @@ function initProjects() {
         currentCards.filter(card => card.hasAttribute('data-open-workspace-current'))
             .forEach(card => setCurrentOpenWorkspaceSummaryDom(card, message));
     }
-    function syncAiSessionProjectionDom(adoptRenderedPresentation) {
-        if (adoptRenderedPresentation !== false) {
-            window.__agentPivotAiSessionPresentationState = null;
-            syncActiveAiSessionProjectionDom(true, false);
-            return;
-        }
-        if (window.__agentPivotAiSessionPresentationState) {
-            applyAiSessionPresentationDom(window.__agentPivotAiSessionPresentationState);
-        } else {
-            syncActiveAiSessionProjectionDom(true, false);
-        }
-    }
     var presentationTransactions = initAiSessionPresentationTransactions({
         isValidAiSessionPresentationState: isValidAiSessionPresentationState,
         applyValidatedAiSessionPresentationState: applyValidatedAiSessionPresentationState,
@@ -3764,7 +3751,6 @@ function initProjects() {
         getPendingAiSessionProviderSelectionProjectId: () => aiSessionControls.getPendingAiSessionProviderSelectionProjectId(),
         getSelectedAiSessionProviders: aiSessionControls.getSelectedAiSessionProviders,
         syncAiSessionBatchManagementDom: aiSessionControls.syncAiSessionBatchManagementDom,
-        syncAiSessionProjectionDom: syncAiSessionProjectionDom,
         reconcilePendingAiSessionProviderSelectionDom: aiSessionControls.reconcilePendingAiSessionProviderSelectionDom,
         submitAiSessionProviderSelection: aiSessionControls.submitAiSessionProviderSelection,
         toggleCodexSessions: aiSessionControls.toggleCodexSessions,
@@ -3992,40 +3978,6 @@ function initProjects() {
                     groupCollapse.syncCollapseButton();
                 }
             }, 0);
-        }
-        if (message && message.type === 'workspace-updated') {
-            if (!applyWorkspaceUpdate(message, {
-                canRestoreAiSessionProviderMenu: () =>
-                    !aiSessionControls.getPendingAiSessionProviderSelectionProjectId()
-                    && !aiSessionControls.batchAiSessionState.pending,
-            })) {
-                aiSessionsUpdate.requestFullRefresh('invalid-workspace-update');
-                return;
-            }
-            if (aiSessionControls.batchAiSessionState.projectId) {
-                var managedProjectDiv = aiSessionsUpdate.findCurrentWorkspaceDiv(aiSessionControls.batchAiSessionState.projectId);
-                if (managedProjectDiv) {
-                    aiSessionControls.batchAiSessionManager.reconcileVisible(managedProjectDiv);
-                    aiSessionControls.syncAiSessionBatchManagementDom(managedProjectDiv);
-                } else {
-                    aiSessionControls.exitAiSessionBatchManagement();
-                }
-            }
-            aiSessionControls.reconcilePendingAiSessionProviderSelectionDom();
-            syncAiSessionProjectionDom(
-                window.__agentPivotAiSessionPresentationState ? false : true
-            );
-            updateStickyGroupHeaderOffset();
-            if (openTabSplit && typeof openTabSplit.syncResizer === 'function') {
-                openTabSplit.syncResizer();
-            }
-            var renderedWorkspaceState = getWorkspaceUpdateDomState(document);
-            window.vscode.postMessage({
-                type: 'workspace-rendered',
-                version: 2,
-                currentWorkspaceCount: renderedWorkspaceState.currentWorkspaceCount,
-            });
-            return;
         }
         if (message && message.type === 'open-workspaces-updated') {
             if (message.version !== 3) {

--- a/media/webviewProjectAiUpdateScripts.js
+++ b/media/webviewProjectAiUpdateScripts.js
@@ -141,7 +141,6 @@ function initProjectAiSessionsUpdate(options) {
     var getPendingAiSessionProviderSelectionProjectId = options.getPendingAiSessionProviderSelectionProjectId;
     var getSelectedAiSessionProviders = options.getSelectedAiSessionProviders;
     var syncAiSessionBatchManagementDom = options.syncAiSessionBatchManagementDom;
-    var syncAiSessionProjectionDom = options.syncAiSessionProjectionDom;
     var reconcilePendingAiSessionProviderSelectionDom = options.reconcilePendingAiSessionProviderSelectionDom;
     var submitAiSessionProviderSelection = options.submitAiSessionProviderSelection;
     var toggleCodexSessions = options.toggleCodexSessions;

--- a/media/webviewProjectScripts.js
+++ b/media/webviewProjectScripts.js
@@ -550,18 +550,6 @@ function initProjects() {
         currentCards.filter(card => card.hasAttribute('data-open-workspace-current'))
             .forEach(card => setCurrentOpenWorkspaceSummaryDom(card, message));
     }
-    function syncAiSessionProjectionDom(adoptRenderedPresentation) {
-        if (adoptRenderedPresentation !== false) {
-            window.__agentPivotAiSessionPresentationState = null;
-            syncActiveAiSessionProjectionDom(true, false);
-            return;
-        }
-        if (window.__agentPivotAiSessionPresentationState) {
-            applyAiSessionPresentationDom(window.__agentPivotAiSessionPresentationState);
-        } else {
-            syncActiveAiSessionProjectionDom(true, false);
-        }
-    }
     var presentationTransactions = initAiSessionPresentationTransactions({
         isValidAiSessionPresentationState: isValidAiSessionPresentationState,
         applyValidatedAiSessionPresentationState: applyValidatedAiSessionPresentationState,
@@ -572,7 +560,6 @@ function initProjects() {
         getPendingAiSessionProviderSelectionProjectId: () => aiSessionControls.getPendingAiSessionProviderSelectionProjectId(),
         getSelectedAiSessionProviders: aiSessionControls.getSelectedAiSessionProviders,
         syncAiSessionBatchManagementDom: aiSessionControls.syncAiSessionBatchManagementDom,
-        syncAiSessionProjectionDom: syncAiSessionProjectionDom,
         reconcilePendingAiSessionProviderSelectionDom: aiSessionControls.reconcilePendingAiSessionProviderSelectionDom,
         submitAiSessionProviderSelection: aiSessionControls.submitAiSessionProviderSelection,
         toggleCodexSessions: aiSessionControls.toggleCodexSessions,
@@ -800,40 +787,6 @@ function initProjects() {
                     groupCollapse.syncCollapseButton();
                 }
             }, 0);
-        }
-        if (message && message.type === 'workspace-updated') {
-            if (!applyWorkspaceUpdate(message, {
-                canRestoreAiSessionProviderMenu: () =>
-                    !aiSessionControls.getPendingAiSessionProviderSelectionProjectId()
-                    && !aiSessionControls.batchAiSessionState.pending,
-            })) {
-                aiSessionsUpdate.requestFullRefresh('invalid-workspace-update');
-                return;
-            }
-            if (aiSessionControls.batchAiSessionState.projectId) {
-                var managedProjectDiv = aiSessionsUpdate.findCurrentWorkspaceDiv(aiSessionControls.batchAiSessionState.projectId);
-                if (managedProjectDiv) {
-                    aiSessionControls.batchAiSessionManager.reconcileVisible(managedProjectDiv);
-                    aiSessionControls.syncAiSessionBatchManagementDom(managedProjectDiv);
-                } else {
-                    aiSessionControls.exitAiSessionBatchManagement();
-                }
-            }
-            aiSessionControls.reconcilePendingAiSessionProviderSelectionDom();
-            syncAiSessionProjectionDom(
-                window.__agentPivotAiSessionPresentationState ? false : true
-            );
-            updateStickyGroupHeaderOffset();
-            if (openTabSplit && typeof openTabSplit.syncResizer === 'function') {
-                openTabSplit.syncResizer();
-            }
-            var renderedWorkspaceState = getWorkspaceUpdateDomState(document);
-            window.vscode.postMessage({
-                type: 'workspace-rendered',
-                version: 2,
-                currentWorkspaceCount: renderedWorkspaceState.currentWorkspaceCount,
-            });
-            return;
         }
         if (message && message.type === 'open-workspaces-updated') {
             if (message.version !== 3) {

--- a/scripts/run-architecture-guards.js
+++ b/scripts/run-architecture-guards.js
@@ -767,6 +767,17 @@ const guards = {
         const aiAtomicInput = aiAtomicCalls.length === 1
             ? aiAtomicCalls[0][0]
             : null;
+        const aiReplaceContent = aiAtomicInput
+            && ts.isObjectLiteralExpression(aiAtomicInput)
+            ? aiAtomicInput.properties.find(property =>
+                ts.isPropertyAssignment(property)
+                    && property.name.getText(webview) === 'replaceContent')
+            : null;
+        const aiReplaceContentCalls = aiReplaceContent
+            && ts.isPropertyAssignment(aiReplaceContent)
+            && ts.isArrowFunction(aiReplaceContent.initializer)
+            ? callArguments(aiReplaceContent.initializer, 'applyWorkspaceUpdate')
+            : [];
         const aiAfterReplacement = aiAtomicInput
             && ts.isObjectLiteralExpression(aiAtomicInput)
             ? aiAtomicInput.properties.find(property =>
@@ -832,6 +843,20 @@ const guards = {
         }
         const projectWebviewSource = projectWebview.getFullText();
         const workspaceWebviewSource = workspaceWebview.getFullText();
+        const updateMessageSource = updateMessages.getFullText();
+        if (updateMessageSource.includes('WorkspaceUpdatedMessage')
+            || updateMessageSource.includes('buildWorkspaceUpdatedMessage')
+            || projectWebviewSource.includes(
+                "message && message.type === 'workspace-updated'"
+            )
+            || projectWebviewSource.includes('syncAiSessionProjectionDom')
+            || webviewSource.includes('syncAiSessionProjectionDom')
+            || callArguments(webview, 'applyWorkspaceUpdate').length !== 1
+            || callArguments(aiUpdateOwner, 'applyWorkspaceUpdate').length !== 1
+            || aiReplaceContentCalls.length !== 1) {
+            fail(this.id, risk,
+                'session-bearing workspace HTML must have no standalone replacement path outside atomic Presentation envelopes');
+        }
         if (!webviewSource.includes('acceptInitialPresentationProjectionRevision')
             || !webviewSource.includes('latestAiSessionProjectionRevision = revision;')
             || !projectWebviewSource.includes(
@@ -844,7 +869,6 @@ const guards = {
                 'the Webview must seed revision and complete owners from the full document');
         }
         const openWorkspaceSource = openWorkspaceController.getFullText();
-        const updateMessageSource = updateMessages.getFullText();
         if (!openWorkspaceSource.includes(
             'const projection = this.options.beginAiSessionProjection()'
         ) || !openWorkspaceSource.includes('cards: this.getCards(projection)')

--- a/scripts/run-dashboard-webview-checks.js
+++ b/scripts/run-dashboard-webview-checks.js
@@ -401,11 +401,6 @@ function runDashboardUpdateMessageChecks() {
         runningIconAnimation: 'halo',
         presentation: makePresentation(7),
     });
-    const workspaceMessage = dashboardUpdateMessages.buildWorkspaceUpdatedMessage({
-        card: workspaceCard,
-        runningCardAnimation: 'ripple',
-        runningIconAnimation: 'custom',
-    });
     const navigationCard = {
         ...makeWorkspaceCardFixture(2),
         id: 'workspace-other',
@@ -444,21 +439,10 @@ function runDashboardUpdateMessageChecks() {
         'AI session incremental updates must use the configured running icon animation');
     assert.ok(aiMessage.html.includes('data-session-fx="custom"'),
         'AI session incremental updates must preserve the independent running card animation');
-    assert.strictEqual(workspaceMessage.type, 'workspace-updated');
-    assert.strictEqual(workspaceMessage.version, 2);
     assert.strictEqual(workspaceSearchCatalog.version, 2);
     assert.deepStrictEqual(workspaceSearchCatalog.openWorkspaces.map(item => item.current), [true]);
     assert.deepStrictEqual(workspaceSearchCatalog.sessions.map(item => item.action), ['reveal-workspace-session']);
     assert.deepStrictEqual(workspaceSearchCatalog.todos, todoSearchItems);
-    assert.strictEqual(workspaceMessage.currentWorkspaceCount, 1);
-    assert.ok(workspaceMessage.html.includes('data-workspace-scope-identity="scope-dashboard"'));
-    assert.ok(workspaceMessage.html.includes('data-session-icon-fx="custom"'),
-        'workspace incremental updates must use the configured running icon animation');
-    assert.ok(workspaceMessage.html.includes('data-session-fx="ripple"'),
-        'workspace incremental updates must preserve the independent running card animation');
-    const emptyWorkspaceMessage = dashboardUpdateMessages.buildWorkspaceUpdatedMessage({ card: null });
-    assert.strictEqual(emptyWorkspaceMessage.currentWorkspaceCount, 0);
-    assert.strictEqual(emptyWorkspaceMessage.html.includes('class="workspace-card'), false);
     assert.strictEqual(openWorkspacesMessage.type, 'open-workspaces-updated');
     assert.strictEqual(openWorkspacesMessage.version, 3);
     assert.strictEqual(openWorkspacesMessage.presentation.projectionRevision, 1);
@@ -4556,7 +4540,9 @@ function runSourceContractChecks(source) {
     assert.ok(updateMessages.includes("type: 'open-workspaces-updated'"));
     assert.ok(!updateMessages.includes("type: 'open-projects-updated'"));
     assert.ok(updateMessages.includes("type: 'ai-sessions-updated'"));
-    assert.ok(updateMessages.includes('version: 2'));
+    assert.ok(updateMessages.includes('version: 3'));
+    assert.ok(!updateMessages.includes('WorkspaceUpdatedMessage'));
+    assert.ok(!updateMessages.includes('buildWorkspaceUpdatedMessage'));
     const viewProviderPath = path.join(root, 'src', 'dashboard', 'viewProvider.ts');
     assert.ok(fs.existsSync(viewProviderPath));
     const viewProviderSource = fs.readFileSync(viewProviderPath, 'utf8');

--- a/src/dashboard/webviewUpdateMessages.ts
+++ b/src/dashboard/webviewUpdateMessages.ts
@@ -43,13 +43,6 @@ export interface BuildProjectsPanelUpdatedMessageInput {
     favoriteProjectIds: string[];
 }
 
-export interface WorkspaceUpdatedMessage {
-    type: 'workspace-updated';
-    version: 2;
-    currentWorkspaceCount: 0 | 1;
-    html: string;
-}
-
 export function buildProjectsPanelUpdatedMessage(
     input: BuildProjectsPanelUpdatedMessageInput
 ): ProjectsPanelUpdatedMessage {
@@ -66,12 +59,6 @@ export function buildProjectsPanelUpdatedMessage(
         })),
         favoriteProjectIds: [...input.favoriteProjectIds],
     };
-}
-
-export interface BuildWorkspaceUpdatedMessageInput {
-    card: WorkspaceCardViewModel | null;
-    runningCardAnimation?: string;
-    runningIconAnimation?: string;
 }
 
 export interface OpenWorkspacesUpdatedMessage {
@@ -140,23 +127,6 @@ export function buildOpenWorkspacesUpdatedMessage(
             input.runningIconAnimation,
         ),
         presentation: input.presentation,
-    };
-}
-
-export function buildWorkspaceUpdatedMessage(input: BuildWorkspaceUpdatedMessageInput): WorkspaceUpdatedMessage {
-    const card = input.card && input.card.kind === 'current'
-        ? input.card
-        : null;
-    return {
-        type: 'workspace-updated',
-        version: 2,
-        currentWorkspaceCount: card ? 1 : 0,
-        html: getCurrentWorkspaceGroupContent(
-            card,
-            false,
-            input.runningCardAnimation,
-            input.runningIconAnimation,
-        ),
     };
 }
 

--- a/src/webview/webviewProjectAiUpdateScripts.js
+++ b/src/webview/webviewProjectAiUpdateScripts.js
@@ -141,7 +141,6 @@ function initProjectAiSessionsUpdate(options) {
     var getPendingAiSessionProviderSelectionProjectId = options.getPendingAiSessionProviderSelectionProjectId;
     var getSelectedAiSessionProviders = options.getSelectedAiSessionProviders;
     var syncAiSessionBatchManagementDom = options.syncAiSessionBatchManagementDom;
-    var syncAiSessionProjectionDom = options.syncAiSessionProjectionDom;
     var reconcilePendingAiSessionProviderSelectionDom = options.reconcilePendingAiSessionProviderSelectionDom;
     var submitAiSessionProviderSelection = options.submitAiSessionProviderSelection;
     var toggleCodexSessions = options.toggleCodexSessions;

--- a/src/webview/webviewProjectScripts.js
+++ b/src/webview/webviewProjectScripts.js
@@ -550,18 +550,6 @@ function initProjects() {
         currentCards.filter(card => card.hasAttribute('data-open-workspace-current'))
             .forEach(card => setCurrentOpenWorkspaceSummaryDom(card, message));
     }
-    function syncAiSessionProjectionDom(adoptRenderedPresentation) {
-        if (adoptRenderedPresentation !== false) {
-            window.__agentPivotAiSessionPresentationState = null;
-            syncActiveAiSessionProjectionDom(true, false);
-            return;
-        }
-        if (window.__agentPivotAiSessionPresentationState) {
-            applyAiSessionPresentationDom(window.__agentPivotAiSessionPresentationState);
-        } else {
-            syncActiveAiSessionProjectionDom(true, false);
-        }
-    }
     var presentationTransactions = initAiSessionPresentationTransactions({
         isValidAiSessionPresentationState: isValidAiSessionPresentationState,
         applyValidatedAiSessionPresentationState: applyValidatedAiSessionPresentationState,
@@ -572,7 +560,6 @@ function initProjects() {
         getPendingAiSessionProviderSelectionProjectId: () => aiSessionControls.getPendingAiSessionProviderSelectionProjectId(),
         getSelectedAiSessionProviders: aiSessionControls.getSelectedAiSessionProviders,
         syncAiSessionBatchManagementDom: aiSessionControls.syncAiSessionBatchManagementDom,
-        syncAiSessionProjectionDom: syncAiSessionProjectionDom,
         reconcilePendingAiSessionProviderSelectionDom: aiSessionControls.reconcilePendingAiSessionProviderSelectionDom,
         submitAiSessionProviderSelection: aiSessionControls.submitAiSessionProviderSelection,
         toggleCodexSessions: aiSessionControls.toggleCodexSessions,
@@ -800,40 +787,6 @@ function initProjects() {
                     groupCollapse.syncCollapseButton();
                 }
             }, 0);
-        }
-        if (message && message.type === 'workspace-updated') {
-            if (!applyWorkspaceUpdate(message, {
-                canRestoreAiSessionProviderMenu: () =>
-                    !aiSessionControls.getPendingAiSessionProviderSelectionProjectId()
-                    && !aiSessionControls.batchAiSessionState.pending,
-            })) {
-                aiSessionsUpdate.requestFullRefresh('invalid-workspace-update');
-                return;
-            }
-            if (aiSessionControls.batchAiSessionState.projectId) {
-                var managedProjectDiv = aiSessionsUpdate.findCurrentWorkspaceDiv(aiSessionControls.batchAiSessionState.projectId);
-                if (managedProjectDiv) {
-                    aiSessionControls.batchAiSessionManager.reconcileVisible(managedProjectDiv);
-                    aiSessionControls.syncAiSessionBatchManagementDom(managedProjectDiv);
-                } else {
-                    aiSessionControls.exitAiSessionBatchManagement();
-                }
-            }
-            aiSessionControls.reconcilePendingAiSessionProviderSelectionDom();
-            syncAiSessionProjectionDom(
-                window.__agentPivotAiSessionPresentationState ? false : true
-            );
-            updateStickyGroupHeaderOffset();
-            if (openTabSplit && typeof openTabSplit.syncResizer === 'function') {
-                openTabSplit.syncResizer();
-            }
-            var renderedWorkspaceState = getWorkspaceUpdateDomState(document);
-            window.vscode.postMessage({
-                type: 'workspace-rendered',
-                version: 2,
-                currentWorkspaceCount: renderedWorkspaceState.currentWorkspaceCount,
-            });
-            return;
         }
         if (message && message.type === 'open-workspaces-updated') {
             if (message.version !== 3) {

--- a/tests/browser/activeSessionCardInteraction.test.js
+++ b/tests/browser/activeSessionCardInteraction.test.js
@@ -253,29 +253,50 @@ function currentOpenWorkspaceProjectMarkup() {
         data-workspace-navigation-identity="navigation-project-a"></div>`;
 }
 
-async function postListWorkspaceUpdate(page, activeAiSessions, historySessions, selectedTab = 'active') {
+async function postListAiSessionsUpdate(
+    page,
+    activeAiSessions,
+    historySessions,
+    selectedTab = 'active',
+    projectionRevision = 2
+) {
     const html = `<div class="open-current-workspace-group">
         ${listProjectMarkup(activeAiSessions, historySessions, selectedTab)}
     </div>`;
-    await page.evaluate(htmlValue => {
+    const presentation = presentationMessage(activeAiSessions, projectionRevision);
+    await page.evaluate(({ htmlValue, presentationValue, revision }) => {
         window.dispatchEvent(new MessageEvent('message', { data: {
-            type: 'workspace-updated', version: 2, currentWorkspaceCount: 1, html: htmlValue,
+            type: 'ai-sessions-updated', version: 3,
+            sequence: revision, projectionRevision: revision,
+            generatedAt: '2026-08-11T00:00:00.000Z',
+            currentWorkspaceCount: 1, html: htmlValue,
+            searchCatalog: {
+                version: 2, sessions: [], openWorkspaces: [], savedProjects: [], todos: [],
+            },
+            presentation: presentationValue,
         } }));
-    }, html);
+    }, { htmlValue: html, presentationValue: presentation, revision: projectionRevision });
 }
 
-async function postListOpenWorkspacesUpdate(page, activeAiSessions, historySessions, selectedTab = 'active') {
+async function postListOpenWorkspacesUpdate(
+    page,
+    activeAiSessions,
+    historySessions,
+    selectedTab = 'active',
+    projectionRevision = 2
+) {
     const html = `<div class="open-current-workspace-group">
         ${listProjectMarkup(activeAiSessions, historySessions, selectedTab)}
     </div>
     <div class="open-other-windows-group" data-other-windows-status="ready">
         ${currentOpenWorkspaceProjectMarkup()}
     </div>`;
-    const presentation = presentationMessage(activeAiSessions, 2);
-    await page.evaluate(({ htmlValue, presentationValue }) => {
+    const presentation = presentationMessage(activeAiSessions, projectionRevision);
+    await page.evaluate(({ htmlValue, presentationValue, revision }) => {
         window.dispatchEvent(new MessageEvent('message', { data: {
-            type: 'open-workspaces-updated', version: 3, semanticRevision: 'list-replacement',
-            projectionRevision: 2,
+            type: 'open-workspaces-updated', version: 3,
+            semanticRevision: `list-replacement-${revision}`,
+            projectionRevision: revision,
             currentWorkspaceCount: 1, navigationWorkspaceCount: 0, otherWindowsStatus: 'ready',
             html: htmlValue,
             searchCatalog: {
@@ -284,7 +305,7 @@ async function postListOpenWorkspacesUpdate(page, activeAiSessions, historySessi
             },
             presentation: presentationValue,
         } }));
-    }, { htmlValue: html, presentationValue: presentation });
+    }, { htmlValue: html, presentationValue: presentation, revision: projectionRevision });
 }
 
 async function relativeTop(locator) {
@@ -596,7 +617,7 @@ async function assertAttentionCleared(page, provider, sessionId) {
     assert.equal(await compact.locator('.project-ai-attention-badge').count(), 0);
 }
 
-test('WEBVIEW-AI-SESSION-LIST-SCROLL-001 preserves semantic Active and History anchors through both workspace replacement paths', async t => {
+test('WEBVIEW-AI-SESSION-LIST-SCROLL-001 preserves semantic Active and History anchors through both atomic replacement paths', async t => {
     const active = Array.from({ length: 8 }, (_, index) => session(
         'codex', `active-${index + 1}`, index === 4
     ));
@@ -615,7 +636,7 @@ test('WEBVIEW-AI-SESSION-LIST-SCROLL-001 preserves semantic Active and History a
         node.querySelector('.ai-session-primary-action').focus();
         return node.getBoundingClientRect().top - list.getBoundingClientRect().top;
     });
-    await postListWorkspaceUpdate(page, [
+    await postListAiSessionsUpdate(page, [
         session('codex', 'active-inserted', false), ...active,
     ], history);
     const activeRestored = row(page, 'codex', 'active-5');
@@ -640,7 +661,7 @@ test('WEBVIEW-AI-SESSION-LIST-SCROLL-001 preserves semantic Active and History a
     await postListOpenWorkspacesUpdate(page, active, [
         history[3], history[1], historySession('codex', 'history-inserted'),
         history[0], history[2], ...history.slice(4),
-    ]);
+    ], 'active', 3);
     const historyRestored = page.locator(
         '.ai-session-history-panel .codex-session-row[data-session-id="history-5"]'
     );
@@ -649,7 +670,7 @@ test('WEBVIEW-AI-SESSION-LIST-SCROLL-001 preserves semantic Active and History a
     assert.equal(await historyRestored.locator('.ai-session-primary-action').evaluate(node => document.activeElement === node), true);
 });
 
-test('ACTIVE-SESSION-FOCUS-REVEAL-001 reveals the newly focused card when a workspace or open-workspaces refresh moves focus', async t => {
+test('ACTIVE-SESSION-FOCUS-REVEAL-001 reveals the newly focused card when an AI or open-workspaces refresh moves focus', async t => {
     const active = Array.from({ length: 8 }, (_, index) => session(
         'codex', `active-${index + 1}`, index === 0
     ));
@@ -663,7 +684,7 @@ test('ACTIVE-SESSION-FOCUS-REVEAL-001 reveals the newly focused card when a work
     });
     assert.equal(await isRowFullyVisibleInList(row(page, 'codex', 'active-7')), false);
 
-    await postListWorkspaceUpdate(page, active.map((entry, index) => ({
+    await postListAiSessionsUpdate(page, active.map((entry, index) => ({
         ...entry,
         focused: index === 6,
     })), history);
@@ -677,7 +698,7 @@ test('ACTIVE-SESSION-FOCUS-REVEAL-001 reveals the newly focused card when a work
     await postListOpenWorkspacesUpdate(page, active.map((entry, index) => ({
         ...entry,
         focused: index === 1,
-    })), history);
+    })), history, 'active', 3);
     assert.equal(
         await page.locator('[data-ai-session-tab="active"]').getAttribute('aria-selected'),
         'true'
@@ -822,6 +843,24 @@ test('ACTIVE-SESSION-INCREMENTAL-PRESENTATION-ENVELOPE-001 rejects legacy OPEN u
             .map(message => message.reason),
         ['unsupported-open-workspaces-message'],
     );
+});
+
+test('ACTIVE-SESSION-INCREMENTAL-PRESENTATION-ENVELOPE-001 ignores standalone workspace replacement messages', async t => {
+    const initial = [session('codex', 'session-a', true)];
+    const page = await openCardPage(t, initial);
+
+    await postHostMessage(page, {
+        type: 'workspace-updated',
+        version: 2,
+        currentWorkspaceCount: 1,
+        html: `<div class="open-current-workspace-group">${projectMarkup([
+            session('codex', 'legacy-session', true),
+        ])}</div>`,
+    });
+
+    assert.equal(await row(page, 'codex', 'session-a').count(), 1);
+    assert.equal(await row(page, 'codex', 'legacy-session').count(), 0);
+    assert.deepEqual(await postedMessages(page), []);
 });
 
 test('ACTIVE-SESSION-FOCUS-REVEAL-001 rejects non-focus standalone presentation messages', async t => {
@@ -2290,9 +2329,12 @@ test('ACTIVE-SESSION-CONVERSATION-OPEN-001 RUNTIME-WORKSPACE-TOPOLOGY-CONTINUITY
     });
 
     await postHostMessage(page, {
-        type: 'workspace-updated',
-        version: 2,
-        currentWorkspaceCount: 1,
+        ...aiSessionsEnvelope(active, 2, {
+            presentationOverrides: {
+                workspaceScopeIdentity: 'scope:five-roots',
+                workspaceNavigationIdentity: 'navigation:reddb-dev',
+            },
+        }),
         html: currentWorkspaceGroupMarkup(active, 0, {
             projectId: afterProjectId,
             scopeIdentity: 'scope:five-roots',

--- a/tests/browser/sessionProviderMenu.test.js
+++ b/tests/browser/sessionProviderMenu.test.js
@@ -187,18 +187,6 @@ async function postAiSessionsUpdate(page, selectedProviders, sequence) {
     }, { html, sequence });
 }
 
-async function postWorkspaceUpdate(page, selectedProviders) {
-    const html = getAiSessionsUpdateHtml(selectedProviders);
-    await page.evaluate(html => {
-        window.dispatchEvent(new MessageEvent('message', { data: {
-            type: 'workspace-updated',
-            version: 2,
-            currentWorkspaceCount: 1,
-            html,
-        } }));
-    }, html);
-}
-
 test('WEBVIEW-MULTI-PROVIDER-SESSION-HISTORY-001 AI-SESSION-PROVIDER-MENU-001 opens and posts the complete selected provider set', async t => {
     const page = await openMenuPage(t);
     const project = page.locator('.project[data-id="project-a"]');
@@ -470,14 +458,14 @@ test('WEBVIEW-MULTI-PROVIDER-SESSION-HISTORY-001 preserves an open provider popu
     const trigger = project.locator('[data-ai-provider-menu-trigger]');
 
     await trigger.click();
-    await postWorkspaceUpdate(page, ['codex', 'claude']);
+    await postAiSessionsUpdate(page, ['codex', 'claude'], 1);
     assert.equal(await trigger.getAttribute('aria-expanded'), 'true');
     assert.equal(await project.locator('[data-ai-provider-menu]').isHidden(), false);
     assert.equal(await trigger.evaluate(element => document.activeElement === element), true);
 
     const claude = project.locator('[data-ai-provider-option][data-provider="claude"]');
     await claude.focus();
-    await postAiSessionsUpdate(page, ['codex', 'claude'], 1);
+    await postAiSessionsUpdate(page, ['codex', 'claude'], 2);
     assert.equal(await trigger.getAttribute('aria-expanded'), 'true');
     assert.equal(await project.locator('[data-ai-provider-menu]').isHidden(), false);
     assert.equal(await claude.evaluate(element => document.activeElement === element), true);
@@ -521,7 +509,7 @@ test('WEBVIEW-MULTI-PROVIDER-SESSION-HISTORY-001 does not restore a provider pop
         projectElement.querySelector('[data-ai-provider-menu]').hidden = false;
         projectElement.querySelector('[data-ai-provider-option][data-provider="kimi"]').focus();
     });
-    await postWorkspaceUpdate(page, ['codex']);
+    await postAiSessionsUpdate(page, ['codex'], 1);
 
     assert.equal(await trigger.getAttribute('aria-expanded'), 'false');
     assert.equal(await project.locator('[data-ai-provider-menu]').isHidden(), true);

--- a/tests/integration/dashboard/webviewState.test.js
+++ b/tests/integration/dashboard/webviewState.test.js
@@ -2337,12 +2337,9 @@ function assertBatchSelectionReconcilesAuthoritativeRows(source = projectVmSourc
         { provider: 'claude', sessionId: 'same', active: true },
     ]);
     harness.context.applyWorkspaceUpdate = () => true;
-    harness.windowListeners.message({ data: {
-        type: 'workspace-updated',
-        version: 2,
-        currentWorkspaceCount: 1,
-        html: '<div class="open-current-workspace-group"></div>',
-    } });
+    harness.windowListeners.message({ data: makeAiSessionsUpdatedMessage(1, {
+        searchCatalog: makeCatalog('batch-first'),
+    }) });
     assert.deepEqual(toPlain(manager.snapshot().selectedItems), [
         { provider: 'codex', sessionId: 'pinned' },
     ]);
@@ -2354,8 +2351,8 @@ function assertBatchSelectionReconcilesAuthoritativeRows(source = projectVmSourc
         { provider: 'claude', sessionId: 'same', active: true },
     ]);
     harness.context.applyWorkspaceUpdate = () => true;
-    harness.windowListeners.message({ data: makeAiSessionsUpdatedMessage(1, {
-        searchCatalog: makeCatalog('batch'),
+    harness.windowListeners.message({ data: makeAiSessionsUpdatedMessage(2, {
+        searchCatalog: makeCatalog('batch-second'),
     }) });
     assert.deepEqual(toPlain(manager.snapshot().selectedItems), [
         { provider: 'codex', sessionId: 'pinned' },

--- a/tests/unit/tooling/architectureGuards.test.js
+++ b/tests/unit/tooling/architectureGuards.test.js
@@ -808,6 +808,48 @@ for (const mutation of [
     {
         id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
         file: 'src/webview/webviewProjectAiUpdateScripts.js',
+        expectedDetail: 'session-bearing workspace HTML must have no standalone replacement path outside atomic Presentation envelopes',
+        mutate: source => replaceFixtureSource(
+            source,
+            'replaceContent: () => applyWorkspaceUpdate({',
+            'replaceContent: () => applyOpenWorkspacesUpdate({'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectAiUpdateScripts.js',
+        expectedDetail: 'session-bearing workspace HTML must have no standalone replacement path outside atomic Presentation envelopes',
+        mutate: source => replaceFixtureSource(
+            source,
+            'replaceContent: () => applyWorkspaceUpdate({',
+            'replaceContent: () => true,\n'
+                + '            detachedWorkspaceReplacement: () => applyWorkspaceUpdate({'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectScripts.js',
+        expectedDetail: 'session-bearing workspace HTML must have no standalone replacement path outside atomic Presentation envelopes',
+        mutate: source => replaceFixtureSource(
+            source,
+            "message && message.type === 'open-workspaces-updated'",
+            "message && message.type === 'workspace-updated'"
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/dashboard/webviewUpdateMessages.ts',
+        expectedDetail: 'session-bearing workspace HTML must have no standalone replacement path outside atomic Presentation envelopes',
+        mutate: source => replaceFixtureSource(
+            source,
+            'export interface OpenWorkspacesUpdatedMessage {',
+            'export interface WorkspaceUpdatedMessage {}\n\n'
+                + 'export interface OpenWorkspacesUpdatedMessage {'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectAiUpdateScripts.js',
         expectedDetail: 'AI atomic replacement must reconcile batch and provider state inside the transaction hook',
         mutate: source => replaceFixtureSource(
             source,


### PR DESCRIPTION
## Summary

- retire the unused top-level workspace-updated Session HTML message
- route all current Session HTML replacements through AI/Open v3 atomic Presentation envelopes
- bind the internal workspace DOM primitive to the AI atomic replaceContent callback with mutation-sensitive architecture guards
- migrate scroll, focus, provider-menu, batch-state, and topology coverage to the current protocol

## Validation

- npm run test-compile
- focused browser owners: 35/35 and 15/15
- focused Webview state: 63/63
- architecture mutation owners: 98/98
- npm run test:deterministic:run: 404/404
- npm run test:browser:run: 210/210
- npm run test:safety:run
- npm run test:dashboard:run
- npm run test:architecture-baseline
- npm run lint
- npm run test:behavior-contracts
- git diff --check
- independent read-only architecture review: no Critical or Important findings

## Skill harvest

No skill change was justified. The only verification retry came from violating an existing producer-before-consumer rule for test-compile and out consumers; the repository skill already states the correct ordering.