### PR TITLE
Centralize session presentation state

### DIFF
--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "1c3abe48263f7eb628cffb807ed473cd40e28c66",
+        "head": "728a73d7ba099bea2949b29e96e0748b18d760d6",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -274,7 +274,8 @@
             "bc0439f51e63e03021cbff91824c386b4685dfd6",
             "806d58b9ad6bad2931da41093bdab3600852be37",
             "52883dd9c3680cd9cf40446941fef3dee3062c34",
-            "18ecf2273167690e3399c82a1b2b5d408a9661d6"
+            "18ecf2273167690e3399c82a1b2b5d408a9661d6",
+            "0ffa4a9095be981c3034c98ef5b4cd2dc530ca81"
         ]
     },
     "capabilities": [
@@ -934,7 +935,8 @@
                 "e42e41de76fb98abdcee947959f88373a562a8b8",
                 "b2bddc70c874d4c7a3543f9d3da558d88ff4faf2",
                 "fdb205f8fa06a52fe09d24a6f794d4c71da6956a",
-                "1c3abe48263f7eb628cffb807ed473cd40e28c66"
+                "1c3abe48263f7eb628cffb807ed473cd40e28c66",
+                "728a73d7ba099bea2949b29e96e0748b18d760d6"
             ],
             "behaviors": [
                 "ATTENTION-ACTIVE-UNREGISTER-ON-DEACTIVATE-001",

--- a/media/webviewDashboardBundle.js
+++ b/media/webviewDashboardBundle.js
@@ -2007,6 +2007,88 @@ function initProjectContextMenus(options) {
 }
 
 /* src/webview/webviewProjectAiUpdateScripts.js */
+function initAiSessionPresentationStateStore(options) {
+    'use strict';
+
+    options = options || {};
+    var isAiSessionProvider = options.isAiSessionProvider;
+    var currentPresentation = null;
+
+    function isValid(message) {
+        return message && message.type === 'ai-session-presentation-state'
+            && message.version === 1
+            && Number.isSafeInteger(message.projectionRevision)
+            && message.projectionRevision > 0
+            && (typeof message.workspaceScopeIdentity === 'string'
+                || message.workspaceScopeIdentity === null)
+            && (typeof message.workspaceNavigationIdentity === 'string'
+                || message.workspaceNavigationIdentity === null)
+            && Number.isSafeInteger(message.attentionCount) && message.attentionCount >= 0
+            && Number.isSafeInteger(message.activeAttentionCount)
+            && message.activeAttentionCount >= 0
+            && Number.isSafeInteger(message.runningSessionCount)
+            && message.runningSessionCount >= 0
+            && ['current', 'sweep', 'orbit', 'halo', 'ripple', 'breath', 'custom', 'none']
+                .includes(message.runningCardAnimation)
+            && ['current', 'halo', 'custom', 'none'].includes(message.runningIconAnimation)
+            && typeof message.revealFocused === 'boolean'
+            && (message.focusedTarget === null
+                || (message.focusedTarget
+                    && isAiSessionProvider(message.focusedTarget.provider)
+                    && ((typeof message.focusedTarget.sessionId === 'string'
+                        && !!message.focusedTarget.sessionId
+                        && typeof message.focusedTarget.pendingId === 'undefined')
+                        || (typeof message.focusedTarget.pendingId === 'string'
+                            && !!message.focusedTarget.pendingId
+                            && typeof message.focusedTarget.sessionId === 'undefined'))))
+            && Array.isArray(message.sessions) && message.sessions.length <= 1000
+            && message.sessions.every(session => session
+                && isAiSessionProvider(session.provider)
+                && typeof session.sessionId === 'string' && !!session.sessionId
+                && (session.executionState === 'running'
+                    || session.executionState === 'stopped')
+                && typeof session.focused === 'boolean'
+                && typeof session.needsAttention === 'boolean'
+                && typeof session.conflict === 'boolean'
+                && Array.isArray(session.eventIds)
+                && session.eventIds.length <= 1000
+                && session.eventIds.every(eventId => typeof eventId === 'string' && !!eventId))
+            && Array.isArray(message.attentionSessions)
+            && message.attentionSessions.length <= 1000
+            && message.attentionSessions.every(session => session
+                && typeof session.sessionKey === 'string' && !!session.sessionKey
+                && Array.isArray(session.eventIds)
+                && session.eventIds.length <= 1000
+                && session.eventIds.every(eventId => typeof eventId === 'string' && !!eventId));
+    }
+
+    function adopt(message) {
+        if (!isValid(message)) return false;
+        currentPresentation = message;
+        return true;
+    }
+
+    function getCurrent() {
+        return currentPresentation;
+    }
+
+    function getAttentionEventIds(provider, sessionId) {
+        if (!currentPresentation) return [];
+        var sessionKey = provider + ':' + sessionId;
+        var owner = currentPresentation.attentionSessions.find(session =>
+            session && session.sessionKey === sessionKey
+        );
+        return owner ? owner.eventIds.slice() : [];
+    }
+
+    return {
+        adopt: adopt,
+        getAttentionEventIds: getAttentionEventIds,
+        getCurrent: getCurrent,
+        isValid: isValid,
+    };
+}
+
 function initAiSessionPresentationTransactions(options) {
     'use strict';
 
@@ -2404,7 +2486,6 @@ function initAiSessionPresentationDom(options) {
         message.attentionSessions.forEach(session => {
             attentionEvents[session.sessionKey] = session.eventIds.slice();
         });
-        window.__agentPivotAttentionSessionEvents = attentionEvents;
         var focused = message.focusedTarget;
         aiSessionControls.activeAiSessionTerminalState.provider = focused ? focused.provider : null;
         aiSessionControls.activeAiSessionTerminalState.sessionId = focused?.sessionId || null;
@@ -2629,6 +2710,7 @@ function initProjectAiSessionControls(options) {
 
     options = options || {};
     var getAiSessionsUpdate = options.getAiSessionsUpdate;
+    var getAiSessionPresentationStateStore = options.getAiSessionPresentationStateStore;
     var updateStickyGroupHeaderOffset = options.updateStickyGroupHeaderOffset;
 
     var batchAiSessionState = {
@@ -2974,14 +3056,16 @@ function initProjectAiSessionControls(options) {
 
     function acknowledgeAiSession(provider, sessionId, fallbackEventId) {
         var sessionKey = provider + ':' + sessionId;
-        window.__agentPivotAttentionSessionEvents = window.__agentPivotAttentionSessionEvents || {};
-        var eventIds = window.__agentPivotAttentionSessionEvents[sessionKey] || [];
+        var stateStore = typeof getAiSessionPresentationStateStore === 'function'
+            ? getAiSessionPresentationStateStore() : null;
+        var eventIds = stateStore
+            ? stateStore.getAttentionEventIds(provider, sessionId) : [];
         if (!eventIds.length && fallbackEventId) {
             eventIds = [fallbackEventId];
         }
         eventIds = Array.from(new Set(eventIds.filter(eventId => typeof eventId === 'string' && !!eventId)));
         if (eventIds.length) {
-            var presentation = window.__agentPivotAiSessionPresentationState;
+            var presentation = stateStore ? stateStore.getCurrent() : null;
             if (!presentation
                 || presentation.type !== 'ai-session-presentation-state'
                 || presentation.version !== 1
@@ -3010,7 +3094,7 @@ function initProjectAiSessionControls(options) {
             if (typeof window.setTimeout === 'function') {
                 pending.timeoutHandle = window.setTimeout(() => {
                     if (pendingAiSessionAttentionAcknowledgements.get(pendingKey) !== pending) return;
-                    var currentPresentation = window.__agentPivotAiSessionPresentationState;
+                    var currentPresentation = stateStore ? stateStore.getCurrent() : null;
                     if (!currentPresentation
                         || currentPresentation.workspaceScopeIdentity
                             !== pending.workspaceScopeIdentity) {
@@ -3052,7 +3136,9 @@ function initProjectAiSessionControls(options) {
     }
 
     function announceAiSessionAttentionAcknowledgement(pending, message) {
-        var presentation = window.__agentPivotAiSessionPresentationState;
+        var stateStore = typeof getAiSessionPresentationStateStore === 'function'
+            ? getAiSessionPresentationStateStore() : null;
+        var presentation = stateStore ? stateStore.getCurrent() : null;
         if (!presentation
             || presentation.workspaceScopeIdentity !== pending.workspaceScopeIdentity) return;
         var row = document.querySelector(
@@ -3067,7 +3153,9 @@ function initProjectAiSessionControls(options) {
     function syncAiSessionAttentionAcknowledgementDom() {
         document.querySelectorAll('.codex-session-row[data-attention-acknowledgement-pending]')
             .forEach(row => row.removeAttribute('data-attention-acknowledgement-pending'));
-        var presentation = window.__agentPivotAiSessionPresentationState;
+        var stateStore = typeof getAiSessionPresentationStateStore === 'function'
+            ? getAiSessionPresentationStateStore() : null;
+        var presentation = stateStore ? stateStore.getCurrent() : null;
         pendingAiSessionAttentionAcknowledgements.forEach(pending => {
             if (!presentation
                 || presentation.workspaceScopeIdentity !== pending.workspaceScopeIdentity) return;
@@ -3081,7 +3169,10 @@ function initProjectAiSessionControls(options) {
         });
     }
 
-    function reconcileAiSessionAttentionAcknowledgements(presentation) {
+    function reconcileAiSessionAttentionAcknowledgements() {
+        var stateStore = typeof getAiSessionPresentationStateStore === 'function'
+            ? getAiSessionPresentationStateStore() : null;
+        var presentation = stateStore ? stateStore.getCurrent() : null;
         if (!presentation || presentation.type !== 'ai-session-presentation-state') return;
         pendingAiSessionAttentionAcknowledgements.forEach((pending, pendingKey) => {
             if (presentation.workspaceScopeIdentity !== pending.workspaceScopeIdentity) {
@@ -3090,11 +3181,10 @@ function initProjectAiSessionControls(options) {
             }
             if (!pending.committed
                 || presentation.projectionRevision < pending.projectionRevision) return;
-            var ownerSessionKey = pending.provider + ':' + pending.sessionId;
-            var owner = presentation.attentionSessions.find(session =>
-                session && session.sessionKey === ownerSessionKey
+            var currentEventIds = stateStore.getAttentionEventIds(
+                pending.provider,
+                pending.sessionId
             );
-            var currentEventIds = owner && Array.isArray(owner.eventIds) ? owner.eventIds : [];
             if (pending.eventIds.some(eventId => currentEventIds.includes(eventId))) return;
             clearAiSessionAttentionAcknowledgement(pendingKey, pending);
         });
@@ -3126,9 +3216,7 @@ function initProjectAiSessionControls(options) {
             || pending.projectionRevision !== message.projectionRevision) return true;
         if (message.outcome === 'committed') {
             pending.committed = true;
-            reconcileAiSessionAttentionAcknowledgements(
-                window.__agentPivotAiSessionPresentationState
-            );
+            reconcileAiSessionAttentionAcknowledgements();
             return true;
         }
         clearAiSessionAttentionAcknowledgement(pendingKey, pending);
@@ -3742,8 +3830,10 @@ function initProjects() {
     var todoControls = initProjectTodoControls({
         syncCollapseButton: () => groupCollapse.syncCollapseButton(),
     });
+    var aiSessionPresentationStateStore = null;
     var aiSessionControls = initProjectAiSessionControls({
         getAiSessionsUpdate: () => aiSessionsUpdate,
+        getAiSessionPresentationStateStore: () => aiSessionPresentationStateStore,
         updateStickyGroupHeaderOffset: updateStickyGroupHeaderOffset,
     });
     var contextMenus = initProjectContextMenus({
@@ -3753,11 +3843,14 @@ function initProjects() {
         getArchiveAiSessionMessageType: aiSessionControls.getArchiveAiSessionMessageType,
         isAiSessionProvider: aiSessionControls.isAiSessionProvider,
     });
+    aiSessionPresentationStateStore = initAiSessionPresentationStateStore({
+        isAiSessionProvider: aiSessionControls.isAiSessionProvider,
+    });
     var aiSessionPresentationDom = initAiSessionPresentationDom({
         aiSessionControls: aiSessionControls,
     });
     var presentationTransactions = initAiSessionPresentationTransactions({
-        isValidAiSessionPresentationState: isValidAiSessionPresentationState,
+        isValidAiSessionPresentationState: aiSessionPresentationStateStore.isValid,
         applyValidatedAiSessionPresentationState: applyValidatedAiSessionPresentationState,
     });
     var aiSessionsUpdate = initProjectAiSessionsUpdate({
@@ -3775,60 +3868,10 @@ function initProjects() {
         presentationTransactions: presentationTransactions,
     });
 
-    function isValidAiSessionPresentationState(message) {
-        return message && message.type === 'ai-session-presentation-state'
-            && message.version === 1
-            && Number.isSafeInteger(message.projectionRevision)
-            && message.projectionRevision > 0
-            && (typeof message.workspaceScopeIdentity === 'string'
-                || message.workspaceScopeIdentity === null)
-            && (typeof message.workspaceNavigationIdentity === 'string'
-                || message.workspaceNavigationIdentity === null)
-            && Number.isSafeInteger(message.attentionCount) && message.attentionCount >= 0
-            && Number.isSafeInteger(message.activeAttentionCount)
-            && message.activeAttentionCount >= 0
-            && Number.isSafeInteger(message.runningSessionCount)
-            && message.runningSessionCount >= 0
-            && ['current', 'sweep', 'orbit', 'halo', 'ripple', 'breath', 'custom', 'none']
-                .includes(message.runningCardAnimation)
-            && ['current', 'halo', 'custom', 'none'].includes(message.runningIconAnimation)
-            && typeof message.revealFocused === 'boolean'
-            && (message.focusedTarget === null
-                || (message.focusedTarget
-                    && aiSessionControls.isAiSessionProvider(
-                        message.focusedTarget.provider
-                    )
-                    && ((typeof message.focusedTarget.sessionId === 'string'
-                        && !!message.focusedTarget.sessionId
-                        && typeof message.focusedTarget.pendingId === 'undefined')
-                        || (typeof message.focusedTarget.pendingId === 'string'
-                            && !!message.focusedTarget.pendingId
-                            && typeof message.focusedTarget.sessionId === 'undefined'))))
-            && Array.isArray(message.sessions) && message.sessions.length <= 1000
-            && message.sessions.every(session => session
-                && aiSessionControls.isAiSessionProvider(session.provider)
-                && typeof session.sessionId === 'string' && !!session.sessionId
-                && (session.executionState === 'running'
-                    || session.executionState === 'stopped')
-                && typeof session.focused === 'boolean'
-                && typeof session.needsAttention === 'boolean'
-                && typeof session.conflict === 'boolean'
-                && Array.isArray(session.eventIds)
-                && session.eventIds.length <= 1000
-                && session.eventIds.every(eventId => typeof eventId === 'string' && !!eventId))
-            && Array.isArray(message.attentionSessions)
-            && message.attentionSessions.length <= 1000
-            && message.attentionSessions.every(session => session
-                && typeof session.sessionKey === 'string' && !!session.sessionKey
-                && Array.isArray(session.eventIds)
-                && session.eventIds.length <= 1000
-                && session.eventIds.every(eventId => typeof eventId === 'string' && !!eventId));
-    }
-
     function applyValidatedAiSessionPresentationState(message) {
-        window.__agentPivotAiSessionPresentationState = message;
+        if (!aiSessionPresentationStateStore.adopt(message)) return;
         aiSessionPresentationDom.apply(message);
-        aiSessionControls.reconcileAiSessionAttentionAcknowledgements(message);
+        aiSessionControls.reconcileAiSessionAttentionAcknowledgements();
     }
 
     function readInitialAiSessionPresentationState() {

--- a/media/webviewProjectAiSessionControlsScripts.js
+++ b/media/webviewProjectAiSessionControlsScripts.js
@@ -3,6 +3,7 @@ function initProjectAiSessionControls(options) {
 
     options = options || {};
     var getAiSessionsUpdate = options.getAiSessionsUpdate;
+    var getAiSessionPresentationStateStore = options.getAiSessionPresentationStateStore;
     var updateStickyGroupHeaderOffset = options.updateStickyGroupHeaderOffset;
 
     var batchAiSessionState = {
@@ -348,14 +349,16 @@ function initProjectAiSessionControls(options) {
 
     function acknowledgeAiSession(provider, sessionId, fallbackEventId) {
         var sessionKey = provider + ':' + sessionId;
-        window.__agentPivotAttentionSessionEvents = window.__agentPivotAttentionSessionEvents || {};
-        var eventIds = window.__agentPivotAttentionSessionEvents[sessionKey] || [];
+        var stateStore = typeof getAiSessionPresentationStateStore === 'function'
+            ? getAiSessionPresentationStateStore() : null;
+        var eventIds = stateStore
+            ? stateStore.getAttentionEventIds(provider, sessionId) : [];
         if (!eventIds.length && fallbackEventId) {
             eventIds = [fallbackEventId];
         }
         eventIds = Array.from(new Set(eventIds.filter(eventId => typeof eventId === 'string' && !!eventId)));
         if (eventIds.length) {
-            var presentation = window.__agentPivotAiSessionPresentationState;
+            var presentation = stateStore ? stateStore.getCurrent() : null;
             if (!presentation
                 || presentation.type !== 'ai-session-presentation-state'
                 || presentation.version !== 1
@@ -384,7 +387,7 @@ function initProjectAiSessionControls(options) {
             if (typeof window.setTimeout === 'function') {
                 pending.timeoutHandle = window.setTimeout(() => {
                     if (pendingAiSessionAttentionAcknowledgements.get(pendingKey) !== pending) return;
-                    var currentPresentation = window.__agentPivotAiSessionPresentationState;
+                    var currentPresentation = stateStore ? stateStore.getCurrent() : null;
                     if (!currentPresentation
                         || currentPresentation.workspaceScopeIdentity
                             !== pending.workspaceScopeIdentity) {
@@ -426,7 +429,9 @@ function initProjectAiSessionControls(options) {
     }
 
     function announceAiSessionAttentionAcknowledgement(pending, message) {
-        var presentation = window.__agentPivotAiSessionPresentationState;
+        var stateStore = typeof getAiSessionPresentationStateStore === 'function'
+            ? getAiSessionPresentationStateStore() : null;
+        var presentation = stateStore ? stateStore.getCurrent() : null;
         if (!presentation
             || presentation.workspaceScopeIdentity !== pending.workspaceScopeIdentity) return;
         var row = document.querySelector(
@@ -441,7 +446,9 @@ function initProjectAiSessionControls(options) {
     function syncAiSessionAttentionAcknowledgementDom() {
         document.querySelectorAll('.codex-session-row[data-attention-acknowledgement-pending]')
             .forEach(row => row.removeAttribute('data-attention-acknowledgement-pending'));
-        var presentation = window.__agentPivotAiSessionPresentationState;
+        var stateStore = typeof getAiSessionPresentationStateStore === 'function'
+            ? getAiSessionPresentationStateStore() : null;
+        var presentation = stateStore ? stateStore.getCurrent() : null;
         pendingAiSessionAttentionAcknowledgements.forEach(pending => {
             if (!presentation
                 || presentation.workspaceScopeIdentity !== pending.workspaceScopeIdentity) return;
@@ -455,7 +462,10 @@ function initProjectAiSessionControls(options) {
         });
     }
 
-    function reconcileAiSessionAttentionAcknowledgements(presentation) {
+    function reconcileAiSessionAttentionAcknowledgements() {
+        var stateStore = typeof getAiSessionPresentationStateStore === 'function'
+            ? getAiSessionPresentationStateStore() : null;
+        var presentation = stateStore ? stateStore.getCurrent() : null;
         if (!presentation || presentation.type !== 'ai-session-presentation-state') return;
         pendingAiSessionAttentionAcknowledgements.forEach((pending, pendingKey) => {
             if (presentation.workspaceScopeIdentity !== pending.workspaceScopeIdentity) {
@@ -464,11 +474,10 @@ function initProjectAiSessionControls(options) {
             }
             if (!pending.committed
                 || presentation.projectionRevision < pending.projectionRevision) return;
-            var ownerSessionKey = pending.provider + ':' + pending.sessionId;
-            var owner = presentation.attentionSessions.find(session =>
-                session && session.sessionKey === ownerSessionKey
+            var currentEventIds = stateStore.getAttentionEventIds(
+                pending.provider,
+                pending.sessionId
             );
-            var currentEventIds = owner && Array.isArray(owner.eventIds) ? owner.eventIds : [];
             if (pending.eventIds.some(eventId => currentEventIds.includes(eventId))) return;
             clearAiSessionAttentionAcknowledgement(pendingKey, pending);
         });
@@ -500,9 +509,7 @@ function initProjectAiSessionControls(options) {
             || pending.projectionRevision !== message.projectionRevision) return true;
         if (message.outcome === 'committed') {
             pending.committed = true;
-            reconcileAiSessionAttentionAcknowledgements(
-                window.__agentPivotAiSessionPresentationState
-            );
+            reconcileAiSessionAttentionAcknowledgements();
             return true;
         }
         clearAiSessionAttentionAcknowledgement(pendingKey, pending);

--- a/media/webviewProjectAiUpdateScripts.js
+++ b/media/webviewProjectAiUpdateScripts.js
@@ -1,3 +1,85 @@
+function initAiSessionPresentationStateStore(options) {
+    'use strict';
+
+    options = options || {};
+    var isAiSessionProvider = options.isAiSessionProvider;
+    var currentPresentation = null;
+
+    function isValid(message) {
+        return message && message.type === 'ai-session-presentation-state'
+            && message.version === 1
+            && Number.isSafeInteger(message.projectionRevision)
+            && message.projectionRevision > 0
+            && (typeof message.workspaceScopeIdentity === 'string'
+                || message.workspaceScopeIdentity === null)
+            && (typeof message.workspaceNavigationIdentity === 'string'
+                || message.workspaceNavigationIdentity === null)
+            && Number.isSafeInteger(message.attentionCount) && message.attentionCount >= 0
+            && Number.isSafeInteger(message.activeAttentionCount)
+            && message.activeAttentionCount >= 0
+            && Number.isSafeInteger(message.runningSessionCount)
+            && message.runningSessionCount >= 0
+            && ['current', 'sweep', 'orbit', 'halo', 'ripple', 'breath', 'custom', 'none']
+                .includes(message.runningCardAnimation)
+            && ['current', 'halo', 'custom', 'none'].includes(message.runningIconAnimation)
+            && typeof message.revealFocused === 'boolean'
+            && (message.focusedTarget === null
+                || (message.focusedTarget
+                    && isAiSessionProvider(message.focusedTarget.provider)
+                    && ((typeof message.focusedTarget.sessionId === 'string'
+                        && !!message.focusedTarget.sessionId
+                        && typeof message.focusedTarget.pendingId === 'undefined')
+                        || (typeof message.focusedTarget.pendingId === 'string'
+                            && !!message.focusedTarget.pendingId
+                            && typeof message.focusedTarget.sessionId === 'undefined'))))
+            && Array.isArray(message.sessions) && message.sessions.length <= 1000
+            && message.sessions.every(session => session
+                && isAiSessionProvider(session.provider)
+                && typeof session.sessionId === 'string' && !!session.sessionId
+                && (session.executionState === 'running'
+                    || session.executionState === 'stopped')
+                && typeof session.focused === 'boolean'
+                && typeof session.needsAttention === 'boolean'
+                && typeof session.conflict === 'boolean'
+                && Array.isArray(session.eventIds)
+                && session.eventIds.length <= 1000
+                && session.eventIds.every(eventId => typeof eventId === 'string' && !!eventId))
+            && Array.isArray(message.attentionSessions)
+            && message.attentionSessions.length <= 1000
+            && message.attentionSessions.every(session => session
+                && typeof session.sessionKey === 'string' && !!session.sessionKey
+                && Array.isArray(session.eventIds)
+                && session.eventIds.length <= 1000
+                && session.eventIds.every(eventId => typeof eventId === 'string' && !!eventId));
+    }
+
+    function adopt(message) {
+        if (!isValid(message)) return false;
+        currentPresentation = message;
+        return true;
+    }
+
+    function getCurrent() {
+        return currentPresentation;
+    }
+
+    function getAttentionEventIds(provider, sessionId) {
+        if (!currentPresentation) return [];
+        var sessionKey = provider + ':' + sessionId;
+        var owner = currentPresentation.attentionSessions.find(session =>
+            session && session.sessionKey === sessionKey
+        );
+        return owner ? owner.eventIds.slice() : [];
+    }
+
+    return {
+        adopt: adopt,
+        getAttentionEventIds: getAttentionEventIds,
+        getCurrent: getCurrent,
+        isValid: isValid,
+    };
+}
+
 function initAiSessionPresentationTransactions(options) {
     'use strict';
 
@@ -395,7 +477,6 @@ function initAiSessionPresentationDom(options) {
         message.attentionSessions.forEach(session => {
             attentionEvents[session.sessionKey] = session.eventIds.slice();
         });
-        window.__agentPivotAttentionSessionEvents = attentionEvents;
         var focused = message.focusedTarget;
         aiSessionControls.activeAiSessionTerminalState.provider = focused ? focused.provider : null;
         aiSessionControls.activeAiSessionTerminalState.sessionId = focused?.sessionId || null;

--- a/media/webviewProjectScripts.js
+++ b/media/webviewProjectScripts.js
@@ -248,8 +248,10 @@ function initProjects() {
     var todoControls = initProjectTodoControls({
         syncCollapseButton: () => groupCollapse.syncCollapseButton(),
     });
+    var aiSessionPresentationStateStore = null;
     var aiSessionControls = initProjectAiSessionControls({
         getAiSessionsUpdate: () => aiSessionsUpdate,
+        getAiSessionPresentationStateStore: () => aiSessionPresentationStateStore,
         updateStickyGroupHeaderOffset: updateStickyGroupHeaderOffset,
     });
     var contextMenus = initProjectContextMenus({
@@ -259,11 +261,14 @@ function initProjects() {
         getArchiveAiSessionMessageType: aiSessionControls.getArchiveAiSessionMessageType,
         isAiSessionProvider: aiSessionControls.isAiSessionProvider,
     });
+    aiSessionPresentationStateStore = initAiSessionPresentationStateStore({
+        isAiSessionProvider: aiSessionControls.isAiSessionProvider,
+    });
     var aiSessionPresentationDom = initAiSessionPresentationDom({
         aiSessionControls: aiSessionControls,
     });
     var presentationTransactions = initAiSessionPresentationTransactions({
-        isValidAiSessionPresentationState: isValidAiSessionPresentationState,
+        isValidAiSessionPresentationState: aiSessionPresentationStateStore.isValid,
         applyValidatedAiSessionPresentationState: applyValidatedAiSessionPresentationState,
     });
     var aiSessionsUpdate = initProjectAiSessionsUpdate({
@@ -281,60 +286,10 @@ function initProjects() {
         presentationTransactions: presentationTransactions,
     });
 
-    function isValidAiSessionPresentationState(message) {
-        return message && message.type === 'ai-session-presentation-state'
-            && message.version === 1
-            && Number.isSafeInteger(message.projectionRevision)
-            && message.projectionRevision > 0
-            && (typeof message.workspaceScopeIdentity === 'string'
-                || message.workspaceScopeIdentity === null)
-            && (typeof message.workspaceNavigationIdentity === 'string'
-                || message.workspaceNavigationIdentity === null)
-            && Number.isSafeInteger(message.attentionCount) && message.attentionCount >= 0
-            && Number.isSafeInteger(message.activeAttentionCount)
-            && message.activeAttentionCount >= 0
-            && Number.isSafeInteger(message.runningSessionCount)
-            && message.runningSessionCount >= 0
-            && ['current', 'sweep', 'orbit', 'halo', 'ripple', 'breath', 'custom', 'none']
-                .includes(message.runningCardAnimation)
-            && ['current', 'halo', 'custom', 'none'].includes(message.runningIconAnimation)
-            && typeof message.revealFocused === 'boolean'
-            && (message.focusedTarget === null
-                || (message.focusedTarget
-                    && aiSessionControls.isAiSessionProvider(
-                        message.focusedTarget.provider
-                    )
-                    && ((typeof message.focusedTarget.sessionId === 'string'
-                        && !!message.focusedTarget.sessionId
-                        && typeof message.focusedTarget.pendingId === 'undefined')
-                        || (typeof message.focusedTarget.pendingId === 'string'
-                            && !!message.focusedTarget.pendingId
-                            && typeof message.focusedTarget.sessionId === 'undefined'))))
-            && Array.isArray(message.sessions) && message.sessions.length <= 1000
-            && message.sessions.every(session => session
-                && aiSessionControls.isAiSessionProvider(session.provider)
-                && typeof session.sessionId === 'string' && !!session.sessionId
-                && (session.executionState === 'running'
-                    || session.executionState === 'stopped')
-                && typeof session.focused === 'boolean'
-                && typeof session.needsAttention === 'boolean'
-                && typeof session.conflict === 'boolean'
-                && Array.isArray(session.eventIds)
-                && session.eventIds.length <= 1000
-                && session.eventIds.every(eventId => typeof eventId === 'string' && !!eventId))
-            && Array.isArray(message.attentionSessions)
-            && message.attentionSessions.length <= 1000
-            && message.attentionSessions.every(session => session
-                && typeof session.sessionKey === 'string' && !!session.sessionKey
-                && Array.isArray(session.eventIds)
-                && session.eventIds.length <= 1000
-                && session.eventIds.every(eventId => typeof eventId === 'string' && !!eventId));
-    }
-
     function applyValidatedAiSessionPresentationState(message) {
-        window.__agentPivotAiSessionPresentationState = message;
+        if (!aiSessionPresentationStateStore.adopt(message)) return;
         aiSessionPresentationDom.apply(message);
-        aiSessionControls.reconcileAiSessionAttentionAcknowledgements(message);
+        aiSessionControls.reconcileAiSessionAttentionAcknowledgements();
     }
 
     function readInitialAiSessionPresentationState() {

--- a/scripts/run-ai-session-safety-checks.js
+++ b/scripts/run-ai-session-safety-checks.js
@@ -6649,6 +6649,31 @@ function runBatchAiSessionWebviewChecks() {
                     : selector === '.custom-context-menu-item[data-action]:not(.disabled)'
                         ? aiSessionMenuItems.find(item => !item.classList.contains('disabled')) : null,
     };
+    const initialAiSessionPresentation = {
+        type: 'ai-session-presentation-state',
+        version: 1,
+        projectionRevision: 1,
+        workspaceScopeIdentity: null,
+        workspaceNavigationIdentity: null,
+        attentionCount: 3,
+        activeAttentionCount: 3,
+        runningSessionCount: 1,
+        runningCardAnimation: 'current',
+        runningIconAnimation: 'current',
+        revealFocused: false,
+        focusedTarget: null,
+        attentionSessions: [{
+            sessionKey: 'codex:active-session',
+            eventIds: ['attention-active-old', 'attention-active-new'],
+        }, {
+            sessionKey: 'kimi:tmux-session',
+            eventIds: ['attention-tmux-old', 'attention-tmux-new'],
+        }, {
+            sessionKey: 'codex:attention-session',
+            eventIds: ['full-owner-event-a', 'full-owner-event-b'],
+        }],
+        sessions: [],
+    };
     const context = {
         CSS: { escape: value => String(value) },
         Node: { TEXT_NODE: 3 },
@@ -6666,7 +6691,10 @@ function runBatchAiSessionWebviewChecks() {
                 style: { setProperty: () => {} },
             },
             addEventListener: (event, listener) => { eventListeners[event] = listener; },
-            getElementById: id => id === 'aiSessionContextMenu' ? aiSessionMenu : null,
+            getElementById: id => id === 'aiSessionContextMenu' ? aiSessionMenu
+                : id === 'dashboard-ai-session-presentation'
+                    ? { textContent: JSON.stringify(initialAiSessionPresentation) }
+                    : null,
             createElement: () => ({
                 className: '',
                 title: '',
@@ -6944,10 +6972,6 @@ function runBatchAiSessionWebviewChecks() {
     activeRow.setAttribute('data-session-event-id', 'attention-active-session');
     tmuxRow.setAttribute('data-ai-session-attention', '');
     tmuxRow.setAttribute('data-session-event-id', 'attention-tmux-session');
-    context.window.__agentPivotAttentionSessionEvents = {
-        'codex:active-session': ['attention-active-old', 'attention-active-new'],
-        'kimi:tmux-session': ['attention-tmux-old', 'attention-tmux-new'],
-    };
     const stopTmuxTarget = {
         getAttribute: attribute => attribute === 'data-action' ? 'stop-ai-session-runtime' : null,
         closest: selector => {
@@ -7088,9 +7112,6 @@ function runBatchAiSessionWebviewChecks() {
 
     attentionRow.setAttribute('data-ai-session-attention', '');
     attentionRow.setAttribute('data-session-event-id', 'full-owner-event-a');
-    context.window.__agentPivotAttentionSessionEvents = {
-        'codex:attention-session': ['full-owner-event-a', 'full-owner-event-b'],
-    };
     messages.length = 0;
     eventListeners.click({ button: 0, target: attentionRow.primaryAction });
     assert.deepStrictEqual(JSON.parse(JSON.stringify(messages[0])), {

--- a/scripts/run-architecture-guards.js
+++ b/scripts/run-architecture-guards.js
@@ -844,6 +844,154 @@ const guards = {
         const projectWebviewSource = projectWebview.getFullText();
         const workspaceWebviewSource = workspaceWebview.getFullText();
         const updateMessageSource = updateMessages.getFullText();
+        const aiSessionControlsWebview = parseJavascript(
+            root,
+            'src/webview/webviewProjectAiSessionControlsScripts.js',
+            this.id,
+            risk
+        );
+        const aiSessionControlsSource = aiSessionControlsWebview.getFullText();
+        const presentationStateOwner = uniqueAstNode(
+            webview,
+            node => ts.isFunctionDeclaration(node)
+                && node.name?.text === 'initAiSessionPresentationStateStore',
+            this.id,
+            risk,
+            'AI session Presentation state store owner'
+        );
+        const presentationStateHelperNames = [
+            'isValid',
+            'adopt',
+            'getCurrent',
+            'getAttentionEventIds',
+        ];
+        const presentationStateHelpers = presentationStateHelperNames.map(name =>
+            uniqueAstNode(
+                presentationStateOwner,
+                node => ts.isFunctionDeclaration(node) && node.name?.text === name,
+                this.id,
+                risk,
+                `AI session Presentation state helper ${name}`
+            )
+        );
+        const presentationStateReturn = uniqueAstNode(
+            presentationStateOwner,
+            node => ts.isReturnStatement(node)
+                && node.expression
+                && ts.isObjectLiteralExpression(node.expression)
+                && presentationStateHelperNames.every(name =>
+                    node.expression.properties.some(property =>
+                        property.name?.getText(webview) === name)),
+            this.id,
+            risk,
+            'AI session Presentation state store public API'
+        );
+        const presentationStateApi = presentationStateReturn.expression.properties;
+        const currentPresentationState = findVariable(
+            presentationStateOwner,
+            'currentPresentation',
+            this.id,
+            risk
+        );
+        const adoptPresentationState = presentationStateHelpers[
+            presentationStateHelperNames.indexOf('adopt')
+        ];
+        const currentPresentationAssignments = [];
+        walk(presentationStateOwner, node => {
+            if (ts.isAssignmentExpression(node, false)
+                && ts.isIdentifier(node.left)
+                && node.left.text === 'currentPresentation') {
+                currentPresentationAssignments.push(node);
+            }
+        });
+        const presentationStateCalls = callArguments(
+            projectWebview,
+            'initAiSessionPresentationStateStore'
+        );
+        const presentationStateOptions = presentationStateCalls.length === 1
+            ? presentationStateCalls[0][0]
+            : null;
+        const presentationStateProviderOption = presentationStateOptions
+            && ts.isObjectLiteralExpression(presentationStateOptions)
+            ? presentationStateOptions.properties.find(property =>
+                ts.isPropertyAssignment(property)
+                    && property.name.getText(projectWebview) === 'isAiSessionProvider')
+            : null;
+        const controlsCalls = callArguments(projectWebview, 'initProjectAiSessionControls');
+        const controlsOptions = controlsCalls.length === 1 ? controlsCalls[0][0] : null;
+        const controlsPresentationStoreOption = controlsOptions
+            && ts.isObjectLiteralExpression(controlsOptions)
+            ? controlsOptions.properties.find(property =>
+                ts.isPropertyAssignment(property)
+                    && property.name.getText(projectWebview)
+                        === 'getAiSessionPresentationStateStore')
+            : null;
+        const transactionCalls = callArguments(
+            projectWebview,
+            'initAiSessionPresentationTransactions'
+        );
+        const transactionOptions = transactionCalls.length === 1
+            ? transactionCalls[0][0]
+            : null;
+        const transactionValidatorOption = transactionOptions
+            && ts.isObjectLiteralExpression(transactionOptions)
+            ? transactionOptions.properties.find(property =>
+                ts.isPropertyAssignment(property)
+                    && property.name.getText(projectWebview)
+                        === 'isValidAiSessionPresentationState')
+            : null;
+        const legacyPresentationGlobals = [
+            '__agentPivotAiSessionPresentationState',
+            '__agentPivotAttentionSessionEvents',
+        ];
+        const webviewScriptsDirectory = path.join(root, 'src', 'webview');
+        const webviewScriptFileNames = fs.readdirSync(webviewScriptsDirectory)
+            .filter(name => name.endsWith('Scripts.js'));
+        const webviewScriptSources = webviewScriptFileNames.map(fileName =>
+            fs.readFileSync(path.join(webviewScriptsDirectory, fileName), 'utf8')
+        );
+        if (presentationStateHelpers.some(helper =>
+            helper.pos < presentationStateOwner.pos || helper.end > presentationStateOwner.end)
+            || currentPresentationState.initializer?.getText(webview) !== 'null'
+            || currentPresentationAssignments.length !== 1
+            || currentPresentationAssignments[0].operatorToken.kind
+                !== ts.SyntaxKind.EqualsToken
+            || currentPresentationAssignments[0].pos < adoptPresentationState.pos
+            || currentPresentationAssignments[0].end > adoptPresentationState.end
+            || currentPresentationAssignments[0].right.getText(webview) !== 'message'
+            || presentationStateHelperNames.some(name => {
+                const property = presentationStateApi.find(candidate =>
+                    candidate.name?.getText(webview) === name
+                );
+                return !property
+                    || !ts.isPropertyAssignment(property)
+                    || property.initializer.getText(webview) !== name;
+            })
+            || !presentationStateProviderOption
+            || !ts.isPropertyAssignment(presentationStateProviderOption)
+            || presentationStateProviderOption.initializer.getText(projectWebview)
+                !== 'aiSessionControls.isAiSessionProvider'
+            || !controlsPresentationStoreOption
+            || !ts.isPropertyAssignment(controlsPresentationStoreOption)
+            || controlsPresentationStoreOption.initializer.getText(projectWebview)
+                !== '() => aiSessionPresentationStateStore'
+            || !transactionValidatorOption
+            || !ts.isPropertyAssignment(transactionValidatorOption)
+            || transactionValidatorOption.initializer.getText(projectWebview)
+                !== 'aiSessionPresentationStateStore.isValid'
+            || !aiSessionControlsSource.includes(
+                'stateStore.getAttentionEventIds(provider, sessionId)'
+            )
+            || !aiSessionControlsSource.includes('stateStore.getCurrent()')
+            || aiSessionControlsSource.includes('.attentionSessions')
+            || !presentationStateOwner.getText(webview).includes(
+                'currentPresentation.attentionSessions.find('
+            )
+            || legacyPresentationGlobals.some(globalName =>
+                webviewScriptSources.some(source => source.includes(globalName)))) {
+            fail(this.id, risk,
+                'every accepted Session Presentation and attention owner lookup must belong to the single state store');
+        }
         const presentationDomOwner = uniqueAstNode(
             webview,
             node => ts.isFunctionDeclaration(node)
@@ -908,14 +1056,14 @@ const guards = {
             'validated AI session Presentation applicator'
         );
         const applyValidatedPresentationSource = applyValidatedPresentation.getText(projectWebview);
-        const cachePresentationIndex = applyValidatedPresentationSource.indexOf(
-            'window.__agentPivotAiSessionPresentationState = message;'
+        const adoptPresentationIndex = applyValidatedPresentationSource.indexOf(
+            'aiSessionPresentationStateStore.adopt(message)'
         );
         const projectPresentationIndex = applyValidatedPresentationSource.indexOf(
             'aiSessionPresentationDom.apply(message);'
         );
         const reconcileAcknowledgementsIndex = applyValidatedPresentationSource.indexOf(
-            'aiSessionControls.reconcileAiSessionAttentionAcknowledgements(message);'
+            'aiSessionControls.reconcileAiSessionAttentionAcknowledgements();'
         );
         const protectedPresentationAttributes = new Set([
             'data-session-focused',
@@ -941,9 +1089,7 @@ const guards = {
             'project-ai-attention-badge',
         ]);
         const presentationMutationNodes = [];
-        const webviewScriptsDirectory = path.join(root, 'src', 'webview');
-        for (const fileName of fs.readdirSync(webviewScriptsDirectory)
-            .filter(name => name.endsWith('Scripts.js'))) {
+        for (const fileName of webviewScriptFileNames) {
             const relativePath = path.join('src', 'webview', fileName);
             const sourceFile = relativePath === webview.fileName
                 ? webview
@@ -992,14 +1138,11 @@ const guards = {
                 applyValidatedPresentation,
                 'aiSessionPresentationDom.apply'
             ).length !== 1
-            || cachePresentationIndex < 0
-            || projectPresentationIndex <= cachePresentationIndex
+            || adoptPresentationIndex < 0
+            || projectPresentationIndex <= adoptPresentationIndex
             || reconcileAcknowledgementsIndex <= projectPresentationIndex
             || presentationDomHelperNames.slice(0, -1).some(name =>
                 callArguments(presentationApplyOwner, name).length < 1)
-            || !presentationApplySource.includes(
-                'window.__agentPivotAttentionSessionEvents = attentionEvents;'
-            )
             || !presentationApplySource.includes('[data-current-workspace]')
             || !presentationApplySource.includes('[data-open-workspace-current]')
             || presentationMutationNodes.length !== 27

--- a/src/webview/webviewProjectAiSessionControlsScripts.js
+++ b/src/webview/webviewProjectAiSessionControlsScripts.js
@@ -3,6 +3,7 @@ function initProjectAiSessionControls(options) {
 
     options = options || {};
     var getAiSessionsUpdate = options.getAiSessionsUpdate;
+    var getAiSessionPresentationStateStore = options.getAiSessionPresentationStateStore;
     var updateStickyGroupHeaderOffset = options.updateStickyGroupHeaderOffset;
 
     var batchAiSessionState = {
@@ -348,14 +349,16 @@ function initProjectAiSessionControls(options) {
 
     function acknowledgeAiSession(provider, sessionId, fallbackEventId) {
         var sessionKey = provider + ':' + sessionId;
-        window.__agentPivotAttentionSessionEvents = window.__agentPivotAttentionSessionEvents || {};
-        var eventIds = window.__agentPivotAttentionSessionEvents[sessionKey] || [];
+        var stateStore = typeof getAiSessionPresentationStateStore === 'function'
+            ? getAiSessionPresentationStateStore() : null;
+        var eventIds = stateStore
+            ? stateStore.getAttentionEventIds(provider, sessionId) : [];
         if (!eventIds.length && fallbackEventId) {
             eventIds = [fallbackEventId];
         }
         eventIds = Array.from(new Set(eventIds.filter(eventId => typeof eventId === 'string' && !!eventId)));
         if (eventIds.length) {
-            var presentation = window.__agentPivotAiSessionPresentationState;
+            var presentation = stateStore ? stateStore.getCurrent() : null;
             if (!presentation
                 || presentation.type !== 'ai-session-presentation-state'
                 || presentation.version !== 1
@@ -384,7 +387,7 @@ function initProjectAiSessionControls(options) {
             if (typeof window.setTimeout === 'function') {
                 pending.timeoutHandle = window.setTimeout(() => {
                     if (pendingAiSessionAttentionAcknowledgements.get(pendingKey) !== pending) return;
-                    var currentPresentation = window.__agentPivotAiSessionPresentationState;
+                    var currentPresentation = stateStore ? stateStore.getCurrent() : null;
                     if (!currentPresentation
                         || currentPresentation.workspaceScopeIdentity
                             !== pending.workspaceScopeIdentity) {
@@ -426,7 +429,9 @@ function initProjectAiSessionControls(options) {
     }
 
     function announceAiSessionAttentionAcknowledgement(pending, message) {
-        var presentation = window.__agentPivotAiSessionPresentationState;
+        var stateStore = typeof getAiSessionPresentationStateStore === 'function'
+            ? getAiSessionPresentationStateStore() : null;
+        var presentation = stateStore ? stateStore.getCurrent() : null;
         if (!presentation
             || presentation.workspaceScopeIdentity !== pending.workspaceScopeIdentity) return;
         var row = document.querySelector(
@@ -441,7 +446,9 @@ function initProjectAiSessionControls(options) {
     function syncAiSessionAttentionAcknowledgementDom() {
         document.querySelectorAll('.codex-session-row[data-attention-acknowledgement-pending]')
             .forEach(row => row.removeAttribute('data-attention-acknowledgement-pending'));
-        var presentation = window.__agentPivotAiSessionPresentationState;
+        var stateStore = typeof getAiSessionPresentationStateStore === 'function'
+            ? getAiSessionPresentationStateStore() : null;
+        var presentation = stateStore ? stateStore.getCurrent() : null;
         pendingAiSessionAttentionAcknowledgements.forEach(pending => {
             if (!presentation
                 || presentation.workspaceScopeIdentity !== pending.workspaceScopeIdentity) return;
@@ -455,7 +462,10 @@ function initProjectAiSessionControls(options) {
         });
     }
 
-    function reconcileAiSessionAttentionAcknowledgements(presentation) {
+    function reconcileAiSessionAttentionAcknowledgements() {
+        var stateStore = typeof getAiSessionPresentationStateStore === 'function'
+            ? getAiSessionPresentationStateStore() : null;
+        var presentation = stateStore ? stateStore.getCurrent() : null;
         if (!presentation || presentation.type !== 'ai-session-presentation-state') return;
         pendingAiSessionAttentionAcknowledgements.forEach((pending, pendingKey) => {
             if (presentation.workspaceScopeIdentity !== pending.workspaceScopeIdentity) {
@@ -464,11 +474,10 @@ function initProjectAiSessionControls(options) {
             }
             if (!pending.committed
                 || presentation.projectionRevision < pending.projectionRevision) return;
-            var ownerSessionKey = pending.provider + ':' + pending.sessionId;
-            var owner = presentation.attentionSessions.find(session =>
-                session && session.sessionKey === ownerSessionKey
+            var currentEventIds = stateStore.getAttentionEventIds(
+                pending.provider,
+                pending.sessionId
             );
-            var currentEventIds = owner && Array.isArray(owner.eventIds) ? owner.eventIds : [];
             if (pending.eventIds.some(eventId => currentEventIds.includes(eventId))) return;
             clearAiSessionAttentionAcknowledgement(pendingKey, pending);
         });
@@ -500,9 +509,7 @@ function initProjectAiSessionControls(options) {
             || pending.projectionRevision !== message.projectionRevision) return true;
         if (message.outcome === 'committed') {
             pending.committed = true;
-            reconcileAiSessionAttentionAcknowledgements(
-                window.__agentPivotAiSessionPresentationState
-            );
+            reconcileAiSessionAttentionAcknowledgements();
             return true;
         }
         clearAiSessionAttentionAcknowledgement(pendingKey, pending);

--- a/src/webview/webviewProjectAiUpdateScripts.js
+++ b/src/webview/webviewProjectAiUpdateScripts.js
@@ -1,3 +1,85 @@
+function initAiSessionPresentationStateStore(options) {
+    'use strict';
+
+    options = options || {};
+    var isAiSessionProvider = options.isAiSessionProvider;
+    var currentPresentation = null;
+
+    function isValid(message) {
+        return message && message.type === 'ai-session-presentation-state'
+            && message.version === 1
+            && Number.isSafeInteger(message.projectionRevision)
+            && message.projectionRevision > 0
+            && (typeof message.workspaceScopeIdentity === 'string'
+                || message.workspaceScopeIdentity === null)
+            && (typeof message.workspaceNavigationIdentity === 'string'
+                || message.workspaceNavigationIdentity === null)
+            && Number.isSafeInteger(message.attentionCount) && message.attentionCount >= 0
+            && Number.isSafeInteger(message.activeAttentionCount)
+            && message.activeAttentionCount >= 0
+            && Number.isSafeInteger(message.runningSessionCount)
+            && message.runningSessionCount >= 0
+            && ['current', 'sweep', 'orbit', 'halo', 'ripple', 'breath', 'custom', 'none']
+                .includes(message.runningCardAnimation)
+            && ['current', 'halo', 'custom', 'none'].includes(message.runningIconAnimation)
+            && typeof message.revealFocused === 'boolean'
+            && (message.focusedTarget === null
+                || (message.focusedTarget
+                    && isAiSessionProvider(message.focusedTarget.provider)
+                    && ((typeof message.focusedTarget.sessionId === 'string'
+                        && !!message.focusedTarget.sessionId
+                        && typeof message.focusedTarget.pendingId === 'undefined')
+                        || (typeof message.focusedTarget.pendingId === 'string'
+                            && !!message.focusedTarget.pendingId
+                            && typeof message.focusedTarget.sessionId === 'undefined'))))
+            && Array.isArray(message.sessions) && message.sessions.length <= 1000
+            && message.sessions.every(session => session
+                && isAiSessionProvider(session.provider)
+                && typeof session.sessionId === 'string' && !!session.sessionId
+                && (session.executionState === 'running'
+                    || session.executionState === 'stopped')
+                && typeof session.focused === 'boolean'
+                && typeof session.needsAttention === 'boolean'
+                && typeof session.conflict === 'boolean'
+                && Array.isArray(session.eventIds)
+                && session.eventIds.length <= 1000
+                && session.eventIds.every(eventId => typeof eventId === 'string' && !!eventId))
+            && Array.isArray(message.attentionSessions)
+            && message.attentionSessions.length <= 1000
+            && message.attentionSessions.every(session => session
+                && typeof session.sessionKey === 'string' && !!session.sessionKey
+                && Array.isArray(session.eventIds)
+                && session.eventIds.length <= 1000
+                && session.eventIds.every(eventId => typeof eventId === 'string' && !!eventId));
+    }
+
+    function adopt(message) {
+        if (!isValid(message)) return false;
+        currentPresentation = message;
+        return true;
+    }
+
+    function getCurrent() {
+        return currentPresentation;
+    }
+
+    function getAttentionEventIds(provider, sessionId) {
+        if (!currentPresentation) return [];
+        var sessionKey = provider + ':' + sessionId;
+        var owner = currentPresentation.attentionSessions.find(session =>
+            session && session.sessionKey === sessionKey
+        );
+        return owner ? owner.eventIds.slice() : [];
+    }
+
+    return {
+        adopt: adopt,
+        getAttentionEventIds: getAttentionEventIds,
+        getCurrent: getCurrent,
+        isValid: isValid,
+    };
+}
+
 function initAiSessionPresentationTransactions(options) {
     'use strict';
 
@@ -395,7 +477,6 @@ function initAiSessionPresentationDom(options) {
         message.attentionSessions.forEach(session => {
             attentionEvents[session.sessionKey] = session.eventIds.slice();
         });
-        window.__agentPivotAttentionSessionEvents = attentionEvents;
         var focused = message.focusedTarget;
         aiSessionControls.activeAiSessionTerminalState.provider = focused ? focused.provider : null;
         aiSessionControls.activeAiSessionTerminalState.sessionId = focused?.sessionId || null;

--- a/src/webview/webviewProjectScripts.js
+++ b/src/webview/webviewProjectScripts.js
@@ -248,8 +248,10 @@ function initProjects() {
     var todoControls = initProjectTodoControls({
         syncCollapseButton: () => groupCollapse.syncCollapseButton(),
     });
+    var aiSessionPresentationStateStore = null;
     var aiSessionControls = initProjectAiSessionControls({
         getAiSessionsUpdate: () => aiSessionsUpdate,
+        getAiSessionPresentationStateStore: () => aiSessionPresentationStateStore,
         updateStickyGroupHeaderOffset: updateStickyGroupHeaderOffset,
     });
     var contextMenus = initProjectContextMenus({
@@ -259,11 +261,14 @@ function initProjects() {
         getArchiveAiSessionMessageType: aiSessionControls.getArchiveAiSessionMessageType,
         isAiSessionProvider: aiSessionControls.isAiSessionProvider,
     });
+    aiSessionPresentationStateStore = initAiSessionPresentationStateStore({
+        isAiSessionProvider: aiSessionControls.isAiSessionProvider,
+    });
     var aiSessionPresentationDom = initAiSessionPresentationDom({
         aiSessionControls: aiSessionControls,
     });
     var presentationTransactions = initAiSessionPresentationTransactions({
-        isValidAiSessionPresentationState: isValidAiSessionPresentationState,
+        isValidAiSessionPresentationState: aiSessionPresentationStateStore.isValid,
         applyValidatedAiSessionPresentationState: applyValidatedAiSessionPresentationState,
     });
     var aiSessionsUpdate = initProjectAiSessionsUpdate({
@@ -281,60 +286,10 @@ function initProjects() {
         presentationTransactions: presentationTransactions,
     });
 
-    function isValidAiSessionPresentationState(message) {
-        return message && message.type === 'ai-session-presentation-state'
-            && message.version === 1
-            && Number.isSafeInteger(message.projectionRevision)
-            && message.projectionRevision > 0
-            && (typeof message.workspaceScopeIdentity === 'string'
-                || message.workspaceScopeIdentity === null)
-            && (typeof message.workspaceNavigationIdentity === 'string'
-                || message.workspaceNavigationIdentity === null)
-            && Number.isSafeInteger(message.attentionCount) && message.attentionCount >= 0
-            && Number.isSafeInteger(message.activeAttentionCount)
-            && message.activeAttentionCount >= 0
-            && Number.isSafeInteger(message.runningSessionCount)
-            && message.runningSessionCount >= 0
-            && ['current', 'sweep', 'orbit', 'halo', 'ripple', 'breath', 'custom', 'none']
-                .includes(message.runningCardAnimation)
-            && ['current', 'halo', 'custom', 'none'].includes(message.runningIconAnimation)
-            && typeof message.revealFocused === 'boolean'
-            && (message.focusedTarget === null
-                || (message.focusedTarget
-                    && aiSessionControls.isAiSessionProvider(
-                        message.focusedTarget.provider
-                    )
-                    && ((typeof message.focusedTarget.sessionId === 'string'
-                        && !!message.focusedTarget.sessionId
-                        && typeof message.focusedTarget.pendingId === 'undefined')
-                        || (typeof message.focusedTarget.pendingId === 'string'
-                            && !!message.focusedTarget.pendingId
-                            && typeof message.focusedTarget.sessionId === 'undefined'))))
-            && Array.isArray(message.sessions) && message.sessions.length <= 1000
-            && message.sessions.every(session => session
-                && aiSessionControls.isAiSessionProvider(session.provider)
-                && typeof session.sessionId === 'string' && !!session.sessionId
-                && (session.executionState === 'running'
-                    || session.executionState === 'stopped')
-                && typeof session.focused === 'boolean'
-                && typeof session.needsAttention === 'boolean'
-                && typeof session.conflict === 'boolean'
-                && Array.isArray(session.eventIds)
-                && session.eventIds.length <= 1000
-                && session.eventIds.every(eventId => typeof eventId === 'string' && !!eventId))
-            && Array.isArray(message.attentionSessions)
-            && message.attentionSessions.length <= 1000
-            && message.attentionSessions.every(session => session
-                && typeof session.sessionKey === 'string' && !!session.sessionKey
-                && Array.isArray(session.eventIds)
-                && session.eventIds.length <= 1000
-                && session.eventIds.every(eventId => typeof eventId === 'string' && !!eventId));
-    }
-
     function applyValidatedAiSessionPresentationState(message) {
-        window.__agentPivotAiSessionPresentationState = message;
+        if (!aiSessionPresentationStateStore.adopt(message)) return;
         aiSessionPresentationDom.apply(message);
-        aiSessionControls.reconcileAiSessionAttentionAcknowledgements(message);
+        aiSessionControls.reconcileAiSessionAttentionAcknowledgements();
     }
 
     function readInitialAiSessionPresentationState() {

--- a/tests/browser/activeSessionCardInteraction.test.js
+++ b/tests/browser/activeSessionCardInteraction.test.js
@@ -1946,11 +1946,16 @@ test('ATTENTION-SESSION-CARD-ACKNOWLEDGEMENT-001 clears a stopped Kimi card thro
         message.version === 3 && message.presentation.attentionSessions.length === 0
     ));
     const finalEnvelope = deliveredEnvelopes[deliveredEnvelopes.length - 1];
-    assert.equal(
-        await page.evaluate(() => window.__agentPivotAiSessionPresentationState.projectionRevision),
-        finalEnvelope.projectionRevision,
-        'the final production v3 envelope must be fully applied before DOM assertions'
-    );
+    assert.equal(finalEnvelope.presentation.attentionSessions.length, 0);
+    await waitForPageCondition(page, ({ provider, id }) => {
+        var currentRow = document.querySelector(
+            '.active-ai-session-row[data-session-provider="' + provider
+                + '"][data-session-id="' + CSS.escape(id) + '"]'
+        );
+        return currentRow
+            && !currentRow.hasAttribute('data-ai-session-attention')
+            && !currentRow.hasAttribute('data-attention-acknowledgement-pending');
+    }, { provider: 'kimi', id: sessionId });
     await assertAttentionCleared(page, 'kimi', sessionId);
 });
 

--- a/tests/unit/tooling/architectureGuards.test.js
+++ b/tests/unit/tooling/architectureGuards.test.js
@@ -894,9 +894,93 @@ for (const mutation of [
         mutate: source => replaceFixtureSource(
             source,
             'aiSessionPresentationDom.apply(message);\n'
-                + '        aiSessionControls.reconcileAiSessionAttentionAcknowledgements(message);',
-            'aiSessionControls.reconcileAiSessionAttentionAcknowledgements(message);\n'
+                + '        aiSessionControls.reconcileAiSessionAttentionAcknowledgements();',
+            'aiSessionControls.reconcileAiSessionAttentionAcknowledgements();\n'
                 + '        aiSessionPresentationDom.apply(message);'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectScripts.js',
+        expectedDetail: 'every Session Presentation DOM surface must belong to the single AI update projector',
+        mutate: source => replaceFixtureSource(
+            source,
+            'if (!aiSessionPresentationStateStore.adopt(message)) return;\n'
+                + '        aiSessionPresentationDom.apply(message);',
+            'aiSessionPresentationDom.apply(message);\n'
+                + '        if (!aiSessionPresentationStateStore.adopt(message)) return;'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectScripts.js',
+        expectedDetail: 'every accepted Session Presentation and attention owner lookup must belong to the single state store',
+        mutate: source => replaceFixtureSource(
+            source,
+            'getAiSessionPresentationStateStore: () => aiSessionPresentationStateStore,',
+            'getAiSessionPresentationStateStore: () => null,'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectScripts.js',
+        expectedDetail: 'every accepted Session Presentation and attention owner lookup must belong to the single state store',
+        mutate: source => replaceFixtureSource(
+            source,
+            'isValidAiSessionPresentationState: aiSessionPresentationStateStore.isValid,',
+            'isValidAiSessionPresentationState: () => true,'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectAiSessionControlsScripts.js',
+        expectedDetail: 'every accepted Session Presentation and attention owner lookup must belong to the single state store',
+        mutate: source => replaceFixtureSource(
+            source,
+            'stateStore.getAttentionEventIds(provider, sessionId)',
+            '[]'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectAiSessionControlsScripts.js',
+        expectedDetail: 'every accepted Session Presentation and attention owner lookup must belong to the single state store',
+        mutate: source => replaceFixtureSource(
+            source,
+            "    'use strict';",
+            "    'use strict';\n\n    window.__agentPivotAttentionSessionEvents = {};"
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectAiUpdateScripts.js',
+        expectedDetail: 'every accepted Session Presentation and attention owner lookup must belong to the single state store',
+        mutate: source => replaceFixtureSource(
+            source,
+            'currentPresentation = message;',
+            'void message;'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectAiUpdateScripts.js',
+        expectedDetail: 'every accepted Session Presentation and attention owner lookup must belong to the single state store',
+        mutate: source => replaceFixtureSource(
+            source,
+            'currentPresentation = message;',
+            'currentPresentation ||= message;'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectAiUpdateScripts.js',
+        expectedDetail: 'every accepted Session Presentation and attention owner lookup must belong to the single state store',
+        mutate: source => replaceFixtureSource(
+            source,
+            'function getCurrent() {\n        return currentPresentation;',
+            'function getCurrent() {\n'
+                + '        currentPresentation = null;\n'
+                + '        return currentPresentation;'
         ),
     },
     {


### PR DESCRIPTION
## Summary

- introduce a single Webview Presentation State Store for validation, accepted state, and attention owner lookup
- remove legacy global Presentation and attention-owner state while preserving the atomic adopt, DOM projection, and acknowledgement reconciliation order
- add architecture guards and controlled mutations that prevent duplicate ownership, stale assignments, and transaction reordering
- keep Host protocols, UI Bridge protocols, DOM schema, and user-visible behavior unchanged

## Skill harvest

no skill change — the existing independent review loop caught and closed the architecture-guard gaps, while the dependency installation retry was a one-off environment issue rather than a reusable instruction gap

## Verification

- npm run test-compile
- npm run test:deterministic:run (404 passed)
- npm run test:browser:run (210 passed)
- node scripts/run-ai-session-safety-checks.js
- node scripts/run-dashboard-webview-checks.js
- node scripts/run-architecture-guards.js
- node --test tests/unit/tooling/architectureGuards.test.js (114 passed)
- npm run lint (exit 0; existing warnings only)
- npm run test:behavior-contracts (41 catalog tests and 4 release journey tests passed)
- SKIP_NPM_CI=1 npm run install-local
- source/media byte identity and independently rebuilt Dashboard bundle SHA verified
- git diff --check origin/main..HEAD
- independent review: 0 Critical, 0 Important