### PR TITLE
Refactor session presentation focus ownership

### DIFF
--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "728a73d7ba099bea2949b29e96e0748b18d760d6",
+        "head": "7eb81756963bad157f7839e06bad931f7374b9d2",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -275,7 +275,8 @@
             "806d58b9ad6bad2931da41093bdab3600852be37",
             "52883dd9c3680cd9cf40446941fef3dee3062c34",
             "18ecf2273167690e3399c82a1b2b5d408a9661d6",
-            "0ffa4a9095be981c3034c98ef5b4cd2dc530ca81"
+            "0ffa4a9095be981c3034c98ef5b4cd2dc530ca81",
+            "b803fe787f08b6460d1f1e72ffa01d1e0865ba5e"
         ]
     },
     "capabilities": [
@@ -936,7 +937,8 @@
                 "b2bddc70c874d4c7a3543f9d3da558d88ff4faf2",
                 "fdb205f8fa06a52fe09d24a6f794d4c71da6956a",
                 "1c3abe48263f7eb628cffb807ed473cd40e28c66",
-                "728a73d7ba099bea2949b29e96e0748b18d760d6"
+                "728a73d7ba099bea2949b29e96e0748b18d760d6",
+                "7eb81756963bad157f7839e06bad931f7374b9d2"
             ],
             "behaviors": [
                 "ATTENTION-ACTIVE-UNREGISTER-ON-DEACTIVATE-001",

--- a/media/webviewDashboardBundle.js
+++ b/media/webviewDashboardBundle.js
@@ -2072,6 +2072,10 @@ function initAiSessionPresentationStateStore(options) {
         return currentPresentation;
     }
 
+    function getFocusedTarget() {
+        return currentPresentation ? currentPresentation.focusedTarget : null;
+    }
+
     function getAttentionEventIds(provider, sessionId) {
         if (!currentPresentation) return [];
         var sessionKey = provider + ':' + sessionId;
@@ -2085,6 +2089,7 @@ function initAiSessionPresentationStateStore(options) {
         adopt: adopt,
         getAttentionEventIds: getAttentionEventIds,
         getCurrent: getCurrent,
+        getFocusedTarget: getFocusedTarget,
         isValid: isValid,
     };
 }
@@ -2227,71 +2232,55 @@ function initAiSessionPresentationDom(options) {
     'use strict';
 
     options = options || {};
-    var aiSessionControls = options.aiSessionControls;
+    var presentationStateStore = options.presentationStateStore;
 
-    function syncActiveAiSessionProjectionDom(adoptRenderedFocus, revealFocused) {
-        if (adoptRenderedFocus !== false) {
-            var focusedRow = document.querySelector(
-                '.codex-session-row[data-session-focused][data-session-provider]'
+    function syncActiveAiSessionProjectionDom(hasMatchingWorkspace, revealFocused) {
+        var focusedTarget = hasMatchingWorkspace
+            ? presentationStateStore.getFocusedTarget()
+            : null;
+        var projectedFocusedRow = null;
+        document.querySelectorAll(
+            '.codex-session-row[data-session-provider][data-session-id],'
+                + '.codex-session-row[data-session-provider][data-pending-id]'
+        ).forEach(row => {
+            var providerMatches = focusedTarget
+                && row.getAttribute('data-session-provider') === focusedTarget.provider;
+            var focused = providerMatches && (
+                (typeof focusedTarget.sessionId === 'string'
+                    && row.getAttribute('data-session-id') === focusedTarget.sessionId)
+                || (typeof focusedTarget.pendingId === 'string'
+                    && row.getAttribute('data-pending-id') === focusedTarget.pendingId)
             );
-            var provider = focusedRow && focusedRow.getAttribute('data-session-provider');
-            aiSessionControls.activeAiSessionTerminalState.provider =
-                aiSessionControls.isAiSessionProvider(provider) ? provider : null;
-            aiSessionControls.activeAiSessionTerminalState.sessionId = focusedRow
-                ? focusedRow.getAttribute('data-session-id') : null;
-            aiSessionControls.activeAiSessionTerminalState.pendingId = focusedRow
-                ? focusedRow.getAttribute('data-pending-id') : null;
-        } else {
-            var projectedFocusedRow = null;
-            document.querySelectorAll(
-                '.codex-session-row[data-session-provider][data-session-id],'
-                    + '.codex-session-row[data-session-provider][data-pending-id]'
-            ).forEach(row => {
-                var providerMatches = row.getAttribute('data-session-provider')
-                    === aiSessionControls.activeAiSessionTerminalState.provider;
-                var focused = providerMatches && (
-                    (aiSessionControls.activeAiSessionTerminalState.sessionId !== null
-                        && row.getAttribute('data-session-id')
-                            === aiSessionControls.activeAiSessionTerminalState.sessionId)
-                    || (aiSessionControls.activeAiSessionTerminalState.pendingId !== null
-                        && row.getAttribute('data-pending-id')
-                            === aiSessionControls.activeAiSessionTerminalState.pendingId)
+            if (focused) projectedFocusedRow = row;
+            row.toggleAttribute('data-session-focused', focused);
+            var focusedConversation = focused && row.hasAttribute('data-session-id');
+            row.toggleAttribute('data-ai-session-active-terminal', focusedConversation);
+            var primaryAction = row.querySelector('.ai-session-primary-action');
+            if (primaryAction) {
+                var actionState = focusedConversation ? 'conversation' : 'focus';
+                var actionAriaLabel = primaryAction.getAttribute(
+                    'data-' + actionState + '-aria-label'
                 );
-                if (focused) projectedFocusedRow = row;
-                row.toggleAttribute(
-                    'data-session-focused',
-                    focused
+                var actionTitle = primaryAction.getAttribute(
+                    'data-' + actionState + '-title'
                 );
-                var primaryAction = row.querySelector('.ai-session-primary-action');
-                if (primaryAction) {
-                    var focusedConversation = focused && row.hasAttribute('data-session-id');
-                    var actionState = focusedConversation ? 'conversation' : 'focus';
-                    var actionAriaLabel = primaryAction.getAttribute(
-                        'data-' + actionState + '-aria-label'
-                    );
-                    var actionTitle = primaryAction.getAttribute(
-                        'data-' + actionState + '-title'
-                    );
-                    if (actionAriaLabel) primaryAction.setAttribute('aria-label', actionAriaLabel);
-                    if (actionTitle) primaryAction.setAttribute('title', actionTitle);
-                }
-                var conversationHint = row.querySelector('.ai-session-open-conversation-hint');
-                if (focusedConversation
-                    && primaryAction && !conversationHint) {
-                    conversationHint = document.createElement('span');
-                    conversationHint.className = 'ai-session-open-conversation-hint';
-                    conversationHint.setAttribute('aria-hidden', 'true');
-                    conversationHint.textContent = '›';
-                    primaryAction.appendChild(conversationHint);
-                } else if (!focused && conversationHint) {
-                    conversationHint.remove();
-                }
-            });
-            if (projectedFocusedRow && revealFocused) {
-                projectedFocusedRow.scrollIntoView({ block: 'nearest' });
+                if (actionAriaLabel) primaryAction.setAttribute('aria-label', actionAriaLabel);
+                if (actionTitle) primaryAction.setAttribute('title', actionTitle);
             }
+            var conversationHint = row.querySelector('.ai-session-open-conversation-hint');
+            if (focusedConversation && primaryAction && !conversationHint) {
+                conversationHint = document.createElement('span');
+                conversationHint.className = 'ai-session-open-conversation-hint';
+                conversationHint.setAttribute('aria-hidden', 'true');
+                conversationHint.textContent = '›';
+                primaryAction.appendChild(conversationHint);
+            } else if (!focused && conversationHint) {
+                conversationHint.remove();
+            }
+        });
+        if (projectedFocusedRow && revealFocused) {
+            projectedFocusedRow.scrollIntoView({ block: 'nearest' });
         }
-        aiSessionControls.syncActiveAiSessionTerminalDom();
     }
     function setAiSessionAttentionDom(row, eventIds, needsAttention) {
         row.toggleAttribute('data-session-needs-attention', needsAttention);
@@ -2476,6 +2465,7 @@ function initAiSessionPresentationDom(options) {
                 + CSS.escape(message.workspaceNavigationIdentity || '') + '"]'
                 + '[data-open-workspace-current]'
         ));
+        syncActiveAiSessionProjectionDom(currentCards.length > 0, message.revealFocused);
         if (!currentCards.length) return;
         var projectDiv = currentCards.find(card => card.hasAttribute('data-current-workspace'));
         var presentations = {};
@@ -2486,11 +2476,6 @@ function initAiSessionPresentationDom(options) {
         message.attentionSessions.forEach(session => {
             attentionEvents[session.sessionKey] = session.eventIds.slice();
         });
-        var focused = message.focusedTarget;
-        aiSessionControls.activeAiSessionTerminalState.provider = focused ? focused.provider : null;
-        aiSessionControls.activeAiSessionTerminalState.sessionId = focused?.sessionId || null;
-        aiSessionControls.activeAiSessionTerminalState.pendingId = focused?.pendingId || null;
-        syncActiveAiSessionProjectionDom(false, message.revealFocused);
         projectDiv?.querySelectorAll(
             '.codex-session-row[data-session-provider][data-session-id]'
         ).forEach(row => {
@@ -2719,7 +2704,6 @@ function initProjectAiSessionControls(options) {
         pending: false,
         requestId: null,
     };
-    var activeAiSessionTerminalState = { provider: null, sessionId: null, pendingId: null };
     var nextAiSessionBatchArchiveRequestId = 0;
     var nextAiSessionProviderSelectionRequestId = 0;
     var nextAiSessionAttentionAcknowledgementRequestId = 0;
@@ -3381,18 +3365,6 @@ function initProjectAiSessionControls(options) {
         return selectedProviders.split(',').find(isAiSessionProvider) || null;
     }
 
-    function syncActiveAiSessionTerminalDom() {
-        document.querySelectorAll('.codex-session-row[data-session-id]').forEach(row => {
-            var provider = row.getAttribute('data-session-provider') || 'codex';
-            var sessionId = row.getAttribute('data-session-id');
-            row.toggleAttribute(
-                'data-ai-session-active-terminal',
-                provider === activeAiSessionTerminalState.provider
-                    && sessionId === activeAiSessionTerminalState.sessionId
-            );
-        });
-    }
-
     function syncAiSessionBatchManagementDom(projectDiv) {
         var snapshot = batchAiSessionManager.snapshot();
         document.querySelectorAll('.project[data-ai-session-managing], .project[data-ai-session-pending]').forEach(project => {
@@ -3554,7 +3526,6 @@ function initProjectAiSessionControls(options) {
     return {
         batchAiSessionManager: batchAiSessionManager,
         batchAiSessionState: batchAiSessionState,
-        activeAiSessionTerminalState: activeAiSessionTerminalState,
         applyAiSessionAttentionAcknowledgementResult: applyAiSessionAttentionAcknowledgementResult,
         getPendingAiSessionProviderSelectionProjectId: getPendingAiSessionProviderSelectionProjectId,
         activateAiSessionProviderOption: activateAiSessionProviderOption,
@@ -3572,7 +3543,6 @@ function initProjectAiSessionControls(options) {
         reconcileAiSessionAttentionAcknowledgements: reconcileAiSessionAttentionAcknowledgements,
         setAiSessionProviderMenuOpen: setAiSessionProviderMenuOpen,
         submitAiSessionProviderSelection: submitAiSessionProviderSelection,
-        syncActiveAiSessionTerminalDom: syncActiveAiSessionTerminalDom,
         syncAiSessionBatchManagementDom: syncAiSessionBatchManagementDom,
         toggleAiSessionProviderMenu: toggleAiSessionProviderMenu,
         toggleCodexSessions: toggleCodexSessions,
@@ -3847,7 +3817,7 @@ function initProjects() {
         isAiSessionProvider: aiSessionControls.isAiSessionProvider,
     });
     var aiSessionPresentationDom = initAiSessionPresentationDom({
-        aiSessionControls: aiSessionControls,
+        presentationStateStore: aiSessionPresentationStateStore,
     });
     var presentationTransactions = initAiSessionPresentationTransactions({
         isValidAiSessionPresentationState: aiSessionPresentationStateStore.isValid,

--- a/media/webviewProjectAiSessionControlsScripts.js
+++ b/media/webviewProjectAiSessionControlsScripts.js
@@ -12,7 +12,6 @@ function initProjectAiSessionControls(options) {
         pending: false,
         requestId: null,
     };
-    var activeAiSessionTerminalState = { provider: null, sessionId: null, pendingId: null };
     var nextAiSessionBatchArchiveRequestId = 0;
     var nextAiSessionProviderSelectionRequestId = 0;
     var nextAiSessionAttentionAcknowledgementRequestId = 0;
@@ -674,18 +673,6 @@ function initProjectAiSessionControls(options) {
         return selectedProviders.split(',').find(isAiSessionProvider) || null;
     }
 
-    function syncActiveAiSessionTerminalDom() {
-        document.querySelectorAll('.codex-session-row[data-session-id]').forEach(row => {
-            var provider = row.getAttribute('data-session-provider') || 'codex';
-            var sessionId = row.getAttribute('data-session-id');
-            row.toggleAttribute(
-                'data-ai-session-active-terminal',
-                provider === activeAiSessionTerminalState.provider
-                    && sessionId === activeAiSessionTerminalState.sessionId
-            );
-        });
-    }
-
     function syncAiSessionBatchManagementDom(projectDiv) {
         var snapshot = batchAiSessionManager.snapshot();
         document.querySelectorAll('.project[data-ai-session-managing], .project[data-ai-session-pending]').forEach(project => {
@@ -847,7 +834,6 @@ function initProjectAiSessionControls(options) {
     return {
         batchAiSessionManager: batchAiSessionManager,
         batchAiSessionState: batchAiSessionState,
-        activeAiSessionTerminalState: activeAiSessionTerminalState,
         applyAiSessionAttentionAcknowledgementResult: applyAiSessionAttentionAcknowledgementResult,
         getPendingAiSessionProviderSelectionProjectId: getPendingAiSessionProviderSelectionProjectId,
         activateAiSessionProviderOption: activateAiSessionProviderOption,
@@ -865,7 +851,6 @@ function initProjectAiSessionControls(options) {
         reconcileAiSessionAttentionAcknowledgements: reconcileAiSessionAttentionAcknowledgements,
         setAiSessionProviderMenuOpen: setAiSessionProviderMenuOpen,
         submitAiSessionProviderSelection: submitAiSessionProviderSelection,
-        syncActiveAiSessionTerminalDom: syncActiveAiSessionTerminalDom,
         syncAiSessionBatchManagementDom: syncAiSessionBatchManagementDom,
         toggleAiSessionProviderMenu: toggleAiSessionProviderMenu,
         toggleCodexSessions: toggleCodexSessions,

--- a/media/webviewProjectAiUpdateScripts.js
+++ b/media/webviewProjectAiUpdateScripts.js
@@ -63,6 +63,10 @@ function initAiSessionPresentationStateStore(options) {
         return currentPresentation;
     }
 
+    function getFocusedTarget() {
+        return currentPresentation ? currentPresentation.focusedTarget : null;
+    }
+
     function getAttentionEventIds(provider, sessionId) {
         if (!currentPresentation) return [];
         var sessionKey = provider + ':' + sessionId;
@@ -76,6 +80,7 @@ function initAiSessionPresentationStateStore(options) {
         adopt: adopt,
         getAttentionEventIds: getAttentionEventIds,
         getCurrent: getCurrent,
+        getFocusedTarget: getFocusedTarget,
         isValid: isValid,
     };
 }
@@ -218,71 +223,55 @@ function initAiSessionPresentationDom(options) {
     'use strict';
 
     options = options || {};
-    var aiSessionControls = options.aiSessionControls;
+    var presentationStateStore = options.presentationStateStore;
 
-    function syncActiveAiSessionProjectionDom(adoptRenderedFocus, revealFocused) {
-        if (adoptRenderedFocus !== false) {
-            var focusedRow = document.querySelector(
-                '.codex-session-row[data-session-focused][data-session-provider]'
+    function syncActiveAiSessionProjectionDom(hasMatchingWorkspace, revealFocused) {
+        var focusedTarget = hasMatchingWorkspace
+            ? presentationStateStore.getFocusedTarget()
+            : null;
+        var projectedFocusedRow = null;
+        document.querySelectorAll(
+            '.codex-session-row[data-session-provider][data-session-id],'
+                + '.codex-session-row[data-session-provider][data-pending-id]'
+        ).forEach(row => {
+            var providerMatches = focusedTarget
+                && row.getAttribute('data-session-provider') === focusedTarget.provider;
+            var focused = providerMatches && (
+                (typeof focusedTarget.sessionId === 'string'
+                    && row.getAttribute('data-session-id') === focusedTarget.sessionId)
+                || (typeof focusedTarget.pendingId === 'string'
+                    && row.getAttribute('data-pending-id') === focusedTarget.pendingId)
             );
-            var provider = focusedRow && focusedRow.getAttribute('data-session-provider');
-            aiSessionControls.activeAiSessionTerminalState.provider =
-                aiSessionControls.isAiSessionProvider(provider) ? provider : null;
-            aiSessionControls.activeAiSessionTerminalState.sessionId = focusedRow
-                ? focusedRow.getAttribute('data-session-id') : null;
-            aiSessionControls.activeAiSessionTerminalState.pendingId = focusedRow
-                ? focusedRow.getAttribute('data-pending-id') : null;
-        } else {
-            var projectedFocusedRow = null;
-            document.querySelectorAll(
-                '.codex-session-row[data-session-provider][data-session-id],'
-                    + '.codex-session-row[data-session-provider][data-pending-id]'
-            ).forEach(row => {
-                var providerMatches = row.getAttribute('data-session-provider')
-                    === aiSessionControls.activeAiSessionTerminalState.provider;
-                var focused = providerMatches && (
-                    (aiSessionControls.activeAiSessionTerminalState.sessionId !== null
-                        && row.getAttribute('data-session-id')
-                            === aiSessionControls.activeAiSessionTerminalState.sessionId)
-                    || (aiSessionControls.activeAiSessionTerminalState.pendingId !== null
-                        && row.getAttribute('data-pending-id')
-                            === aiSessionControls.activeAiSessionTerminalState.pendingId)
+            if (focused) projectedFocusedRow = row;
+            row.toggleAttribute('data-session-focused', focused);
+            var focusedConversation = focused && row.hasAttribute('data-session-id');
+            row.toggleAttribute('data-ai-session-active-terminal', focusedConversation);
+            var primaryAction = row.querySelector('.ai-session-primary-action');
+            if (primaryAction) {
+                var actionState = focusedConversation ? 'conversation' : 'focus';
+                var actionAriaLabel = primaryAction.getAttribute(
+                    'data-' + actionState + '-aria-label'
                 );
-                if (focused) projectedFocusedRow = row;
-                row.toggleAttribute(
-                    'data-session-focused',
-                    focused
+                var actionTitle = primaryAction.getAttribute(
+                    'data-' + actionState + '-title'
                 );
-                var primaryAction = row.querySelector('.ai-session-primary-action');
-                if (primaryAction) {
-                    var focusedConversation = focused && row.hasAttribute('data-session-id');
-                    var actionState = focusedConversation ? 'conversation' : 'focus';
-                    var actionAriaLabel = primaryAction.getAttribute(
-                        'data-' + actionState + '-aria-label'
-                    );
-                    var actionTitle = primaryAction.getAttribute(
-                        'data-' + actionState + '-title'
-                    );
-                    if (actionAriaLabel) primaryAction.setAttribute('aria-label', actionAriaLabel);
-                    if (actionTitle) primaryAction.setAttribute('title', actionTitle);
-                }
-                var conversationHint = row.querySelector('.ai-session-open-conversation-hint');
-                if (focusedConversation
-                    && primaryAction && !conversationHint) {
-                    conversationHint = document.createElement('span');
-                    conversationHint.className = 'ai-session-open-conversation-hint';
-                    conversationHint.setAttribute('aria-hidden', 'true');
-                    conversationHint.textContent = '›';
-                    primaryAction.appendChild(conversationHint);
-                } else if (!focused && conversationHint) {
-                    conversationHint.remove();
-                }
-            });
-            if (projectedFocusedRow && revealFocused) {
-                projectedFocusedRow.scrollIntoView({ block: 'nearest' });
+                if (actionAriaLabel) primaryAction.setAttribute('aria-label', actionAriaLabel);
+                if (actionTitle) primaryAction.setAttribute('title', actionTitle);
             }
+            var conversationHint = row.querySelector('.ai-session-open-conversation-hint');
+            if (focusedConversation && primaryAction && !conversationHint) {
+                conversationHint = document.createElement('span');
+                conversationHint.className = 'ai-session-open-conversation-hint';
+                conversationHint.setAttribute('aria-hidden', 'true');
+                conversationHint.textContent = '›';
+                primaryAction.appendChild(conversationHint);
+            } else if (!focused && conversationHint) {
+                conversationHint.remove();
+            }
+        });
+        if (projectedFocusedRow && revealFocused) {
+            projectedFocusedRow.scrollIntoView({ block: 'nearest' });
         }
-        aiSessionControls.syncActiveAiSessionTerminalDom();
     }
     function setAiSessionAttentionDom(row, eventIds, needsAttention) {
         row.toggleAttribute('data-session-needs-attention', needsAttention);
@@ -467,6 +456,7 @@ function initAiSessionPresentationDom(options) {
                 + CSS.escape(message.workspaceNavigationIdentity || '') + '"]'
                 + '[data-open-workspace-current]'
         ));
+        syncActiveAiSessionProjectionDom(currentCards.length > 0, message.revealFocused);
         if (!currentCards.length) return;
         var projectDiv = currentCards.find(card => card.hasAttribute('data-current-workspace'));
         var presentations = {};
@@ -477,11 +467,6 @@ function initAiSessionPresentationDom(options) {
         message.attentionSessions.forEach(session => {
             attentionEvents[session.sessionKey] = session.eventIds.slice();
         });
-        var focused = message.focusedTarget;
-        aiSessionControls.activeAiSessionTerminalState.provider = focused ? focused.provider : null;
-        aiSessionControls.activeAiSessionTerminalState.sessionId = focused?.sessionId || null;
-        aiSessionControls.activeAiSessionTerminalState.pendingId = focused?.pendingId || null;
-        syncActiveAiSessionProjectionDom(false, message.revealFocused);
         projectDiv?.querySelectorAll(
             '.codex-session-row[data-session-provider][data-session-id]'
         ).forEach(row => {

--- a/media/webviewProjectScripts.js
+++ b/media/webviewProjectScripts.js
@@ -265,7 +265,7 @@ function initProjects() {
         isAiSessionProvider: aiSessionControls.isAiSessionProvider,
     });
     var aiSessionPresentationDom = initAiSessionPresentationDom({
-        aiSessionControls: aiSessionControls,
+        presentationStateStore: aiSessionPresentationStateStore,
     });
     var presentationTransactions = initAiSessionPresentationTransactions({
         isValidAiSessionPresentationState: aiSessionPresentationStateStore.isValid,

--- a/scripts/run-architecture-guards.js
+++ b/scripts/run-architecture-guards.js
@@ -107,6 +107,38 @@ function stringArgument(argument) {
         : undefined;
 }
 
+function accessMemberName(node) {
+    if (ts.isPropertyAccessExpression(node)) return node.name.text;
+    if (ts.isElementAccessExpression(node)) return stringArgument(node.argumentExpression);
+    return undefined;
+}
+
+function bindingMemberName(node) {
+    if (!ts.isBindingElement(node)) return undefined;
+    const propertyName = node.propertyName || node.name;
+    if (ts.isIdentifier(propertyName)) return propertyName.text;
+    const literalName = stringArgument(propertyName);
+    if (literalName !== undefined) return literalName;
+    return ts.isComputedPropertyName(propertyName)
+        ? stringArgument(propertyName.expression)
+        : undefined;
+}
+
+function datasetMemberName(node) {
+    if (!ts.isPropertyAccessExpression(node) && !ts.isElementAccessExpression(node)) {
+        return undefined;
+    }
+    const datasetExpression = node.expression;
+    const isDataset = ts.isPropertyAccessExpression(datasetExpression)
+        ? datasetExpression.name.text === 'dataset'
+        : ts.isElementAccessExpression(datasetExpression)
+            && stringArgument(datasetExpression.argumentExpression) === 'dataset';
+    if (!isDataset) return undefined;
+    return ts.isPropertyAccessExpression(node)
+        ? node.name.text
+        : stringArgument(node.argumentExpression);
+}
+
 function normalizedAstText(node, sourceFile) {
     return node.getText(sourceFile).replace(/\s+/g, ' ').trim();
 }
@@ -851,6 +883,21 @@ const guards = {
             risk
         );
         const aiSessionControlsSource = aiSessionControlsWebview.getFullText();
+        const projectInitOwner = uniqueAstNode(
+            projectWebview,
+            node => ts.isFunctionDeclaration(node) && node.name?.text === 'initProjects',
+            this.id,
+            risk,
+            'Dashboard Projects composition owner'
+        );
+        const aiSessionControlsOwner = uniqueAstNode(
+            aiSessionControlsWebview,
+            node => ts.isFunctionDeclaration(node)
+                && node.name?.text === 'initProjectAiSessionControls',
+            this.id,
+            risk,
+            'AI session controls owner'
+        );
         const presentationStateOwner = uniqueAstNode(
             webview,
             node => ts.isFunctionDeclaration(node)
@@ -863,6 +910,7 @@ const guards = {
             'isValid',
             'adopt',
             'getCurrent',
+            'getFocusedTarget',
             'getAttentionEventIds',
         ];
         const presentationStateHelpers = presentationStateHelperNames.map(name =>
@@ -896,6 +944,35 @@ const guards = {
         const adoptPresentationState = presentationStateHelpers[
             presentationStateHelperNames.indexOf('adopt')
         ];
+        const getFocusedTargetState = presentationStateHelpers[
+            presentationStateHelperNames.indexOf('getFocusedTarget')
+        ];
+        const focusedTargetStateReturns = [];
+        walk(getFocusedTargetState, node => {
+            if (ts.isReturnStatement(node)) {
+                focusedTargetStateReturns.push(node);
+            }
+        });
+        const focusedTargetStateReturn = focusedTargetStateReturns.length === 1
+            ? focusedTargetStateReturns[0].expression
+            : null;
+        const isCurrentPresentationFocusedTarget = expression =>
+            ts.isPropertyAccessExpression(expression)
+                && ts.isIdentifier(expression.expression)
+                && expression.expression.text === 'currentPresentation'
+                && expression.name.text === 'focusedTarget';
+        const hasValidFocusedTargetReturn = focusedTargetStateReturn
+            && ((ts.isConditionalExpression(focusedTargetStateReturn)
+                && ts.isIdentifier(focusedTargetStateReturn.condition)
+                && focusedTargetStateReturn.condition.text === 'currentPresentation'
+                && isCurrentPresentationFocusedTarget(focusedTargetStateReturn.whenTrue)
+                && focusedTargetStateReturn.whenFalse.kind === ts.SyntaxKind.NullKeyword)
+                || (ts.isBinaryExpression(focusedTargetStateReturn)
+                    && focusedTargetStateReturn.operatorToken.kind
+                        === ts.SyntaxKind.QuestionQuestionToken
+                    && isCurrentPresentationFocusedTarget(focusedTargetStateReturn.left)
+                    && focusedTargetStateReturn.left.questionDotToken
+                    && focusedTargetStateReturn.right.kind === ts.SyntaxKind.NullKeyword));
         const currentPresentationAssignments = [];
         walk(presentationStateOwner, node => {
             if (ts.isAssignmentExpression(node, false)
@@ -950,6 +1027,66 @@ const guards = {
         const webviewScriptSources = webviewScriptFileNames.map(fileName =>
             fs.readFileSync(path.join(webviewScriptsDirectory, fileName), 'utf8')
         );
+        const focusMarkerReadOwners = [];
+        const focusedTargetStoreCalls = [];
+        const presentationStateAdoptCalls = [];
+        const presentationStateAdoptMembers = [];
+        const presentationStateAdoptBindings = [];
+        for (const fileName of webviewScriptFileNames) {
+            const relativePath = path.join('src', 'webview', fileName);
+            const sourceFile = relativePath === webview.fileName
+                ? webview
+                : relativePath === projectWebview.fileName
+                    ? projectWebview
+                    : parseJavascript(root, relativePath, this.id, risk);
+            walk(sourceFile, node => {
+                if ((ts.isPropertyAccessExpression(node)
+                    || ts.isElementAccessExpression(node))
+                    && accessMemberName(node) === 'adopt') {
+                    presentationStateAdoptMembers.push({ node, sourceFile });
+                }
+                if (bindingMemberName(node) === 'adopt') {
+                    presentationStateAdoptBindings.push({ node, sourceFile });
+                }
+                const datasetField = datasetMemberName(node);
+                if (datasetField === 'sessionFocused'
+                    || datasetField === 'aiSessionActiveTerminal') {
+                    const isWrite = ts.isBinaryExpression(node.parent)
+                        && node.parent.left === node
+                        && ts.isAssignmentExpression(node.parent, false);
+                    if (!isWrite) {
+                        let owner = node.parent;
+                        while (owner && !ts.isFunctionDeclaration(owner)) {
+                            owner = owner.parent;
+                        }
+                        focusMarkerReadOwners.push(owner?.name?.text || null);
+                    }
+                }
+                if (!ts.isCallExpression(node)) {
+                    return;
+                }
+                const method = accessMemberName(node.expression);
+                if (!method) return;
+                if (['querySelector', 'querySelectorAll', 'closest', 'matches', 'hasAttribute',
+                    'getAttribute']
+                    .includes(method)
+                    && node.arguments[0]?.getText(sourceFile).includes(
+                        'data-session-focused'
+                    )) {
+                    let owner = node.parent;
+                    while (owner && !ts.isFunctionDeclaration(owner)) {
+                        owner = owner.parent;
+                    }
+                    focusMarkerReadOwners.push(owner?.name?.text || null);
+                }
+                if (method === 'getFocusedTarget') {
+                    focusedTargetStoreCalls.push({ node, sourceFile });
+                }
+                if (method === 'adopt') {
+                    presentationStateAdoptCalls.push({ node, sourceFile });
+                }
+            });
+        }
         if (presentationStateHelpers.some(helper =>
             helper.pos < presentationStateOwner.pos || helper.end > presentationStateOwner.end)
             || currentPresentationState.initializer?.getText(webview) !== 'null'
@@ -991,6 +1128,22 @@ const guards = {
                 webviewScriptSources.some(source => source.includes(globalName)))) {
             fail(this.id, risk,
                 'every accepted Session Presentation and attention owner lookup must belong to the single state store');
+        }
+        if (!presentationStateOwner.getText(webview).includes(
+            'function getFocusedTarget()'
+        ) || !hasValidFocusedTargetReturn
+            || webviewScriptSources.some(source =>
+                source.includes('activeAiSessionTerminalState'))
+            || focusMarkerReadOwners.length !== 4
+            || ![
+                'focusAiSessionConversationOrigin',
+                'getAiSessionCardActivation',
+                'getFocusedAiSessionCardIdentity',
+                'revealChangedFocusedAiSessionCard',
+            ].every(owner => focusMarkerReadOwners.filter(candidate =>
+                candidate === owner).length === 1)) {
+            fail(this.id, risk,
+                'the accepted Presentation focused target must be the only Webview focus state');
         }
         const presentationDomOwner = uniqueAstNode(
             webview,
@@ -1041,12 +1194,48 @@ const guards = {
         const presentationDomOptions = presentationDomCalls.length === 1
             ? presentationDomCalls[0][0]
             : null;
-        const aiSessionControlsOption = presentationDomOptions
+        const presentationDomStateStoreOption = presentationDomOptions
             && ts.isObjectLiteralExpression(presentationDomOptions)
             ? presentationDomOptions.properties.find(property =>
                 ts.isPropertyAssignment(property)
-                    && property.name.getText(projectWebview) === 'aiSessionControls')
+                    && property.name.getText(projectWebview) === 'presentationStateStore')
             : null;
+        const focusProjectionOwner = presentationDomHelpers[0];
+        const focusProjectionSource = focusProjectionOwner.getText(webview);
+        const focusedTargetProjectionCalls = focusedTargetStoreCalls.filter(({ node, sourceFile }) =>
+            sourceFile.fileName === webview.fileName
+                && node.pos >= focusProjectionOwner.pos
+                && node.end <= focusProjectionOwner.end
+        );
+        const focusedTargetDomOwnerCalls = focusedTargetStoreCalls.filter(({ node, sourceFile }) =>
+            sourceFile.fileName === webview.fileName
+                && node.pos >= presentationDomOwner.pos
+                && node.end <= presentationDomOwner.end
+        );
+        const focusedTargetControlsCalls = focusedTargetStoreCalls.filter(({ node, sourceFile }) =>
+            sourceFile.fileName === aiSessionControlsWebview.fileName
+                && node.pos >= aiSessionControlsOwner.pos
+                && node.end <= aiSessionControlsOwner.end
+        );
+        const focusedTargetProjectInitCalls = focusedTargetStoreCalls.filter(({ node, sourceFile }) =>
+            sourceFile.fileName === projectWebview.fileName
+                && node.pos >= projectInitOwner.pos
+                && node.end <= projectInitOwner.end
+        );
+        const focusedTargetProjectionState = findVariable(
+            focusProjectionOwner,
+            'focusedTarget',
+            this.id,
+            risk
+        );
+        const focusedTargetProjectionAssignments = [];
+        walk(focusProjectionOwner, node => {
+            if (ts.isAssignmentExpression(node, false)
+                && ts.isIdentifier(node.left)
+                && node.left.text === 'focusedTarget') {
+                focusedTargetProjectionAssignments.push(node);
+            }
+        });
         const applyValidatedPresentation = uniqueAstNode(
             projectWebview,
             node => ts.isFunctionDeclaration(node)
@@ -1067,6 +1256,7 @@ const guards = {
         );
         const protectedPresentationAttributes = new Set([
             'data-session-focused',
+            'data-ai-session-active-terminal',
             'data-session-needs-attention',
             'data-ai-session-attention',
             'data-session-event-id',
@@ -1097,11 +1287,14 @@ const guards = {
                     ? projectWebview
                     : parseJavascript(root, relativePath, this.id, risk);
             walk(sourceFile, node => {
-                if (ts.isCallExpression(node)
-                    && ts.isPropertyAccessExpression(node.expression)) {
-                    const method = node.expression.name.text;
-                    const marker = stringArgument(node.arguments[0]);
+                if (ts.isCallExpression(node)) {
+                    const method = accessMemberName(node.expression);
+                    const markerArgument = method === 'setAttributeNS'
+                        ? node.arguments[1]
+                        : node.arguments[0];
+                    const marker = stringArgument(markerArgument);
                     if ((method === 'setAttribute'
+                            || method === 'setAttributeNS'
                             || method === 'toggleAttribute'
                             || method === 'removeAttribute')
                         && protectedPresentationAttributes.has(marker)) {
@@ -1110,6 +1303,26 @@ const guards = {
                     if (method === 'toggle' && marker === 'session-running') {
                         presentationMutationNodes.push({ node, sourceFile });
                     }
+                    if (node.expression.getText(sourceFile) === 'Object.assign'
+                        && (ts.isPropertyAccessExpression(node.arguments[0])
+                            || ts.isElementAccessExpression(node.arguments[0]))
+                        && accessMemberName(node.arguments[0]) === 'dataset'
+                        && node.arguments[1]
+                        && ts.isObjectLiteralExpression(node.arguments[1])
+                        && node.arguments[1].properties.some(property =>
+                            property.name
+                                && ['sessionFocused', 'aiSessionActiveTerminal']
+                                    .includes(ts.isIdentifier(property.name)
+                                        ? property.name.text
+                                        : stringArgument(property.name)))) {
+                        presentationMutationNodes.push({ node, sourceFile });
+                    }
+                }
+                if (ts.isBinaryExpression(node)
+                    && ts.isAssignmentExpression(node, false)
+                    && (datasetMemberName(node.left) === 'sessionFocused'
+                        || datasetMemberName(node.left) === 'aiSessionActiveTerminal')) {
+                    presentationMutationNodes.push({ node, sourceFile });
                 }
                 if (ts.isBinaryExpression(node)
                     && node.operatorToken.kind === ts.SyntaxKind.EqualsToken
@@ -1130,14 +1343,56 @@ const guards = {
                 !== 'applyAiSessionPresentationDom'
             || !presentationDomOptions
             || !ts.isObjectLiteralExpression(presentationDomOptions)
-            || !aiSessionControlsOption
-            || !ts.isPropertyAssignment(aiSessionControlsOption)
-            || aiSessionControlsOption.initializer.getText(projectWebview)
-                !== 'aiSessionControls'
+            || !presentationDomStateStoreOption
+            || !ts.isPropertyAssignment(presentationDomStateStoreOption)
+            || presentationDomStateStoreOption.initializer.getText(projectWebview)
+                !== 'aiSessionPresentationStateStore'
+            || !focusedTargetProjectionState.initializer
+            || !ts.isConditionalExpression(focusedTargetProjectionState.initializer)
+            || !ts.isIdentifier(focusedTargetProjectionState.initializer.condition)
+            || focusedTargetProjectionState.initializer.condition.text
+                !== 'hasMatchingWorkspace'
+            || !ts.isCallExpression(focusedTargetProjectionState.initializer.whenTrue)
+            || focusedTargetProjectionState.initializer.whenTrue.arguments.length !== 0
+            || !ts.isPropertyAccessExpression(
+                focusedTargetProjectionState.initializer.whenTrue.expression
+            )
+            || focusedTargetProjectionState.initializer.whenTrue.expression.getText(webview)
+                !== 'presentationStateStore.getFocusedTarget'
+            || focusedTargetProjectionState.initializer.whenFalse.kind
+                !== ts.SyntaxKind.NullKeyword
+            || focusedTargetProjectionAssignments.length !== 0
+            || focusedTargetProjectionCalls.length !== 1
+            || focusedTargetDomOwnerCalls.length !== 1
+            || focusedTargetControlsCalls.length !== 0
+            || focusedTargetProjectInitCalls.length !== 0
+            || focusProjectionSource.includes('[data-session-focused]')
+            || focusProjectionOwner.parameters.length !== 2
+            || focusProjectionOwner.parameters[0].name.getText(webview)
+                !== 'hasMatchingWorkspace'
+            || focusProjectionOwner.parameters[1].name.getText(webview) !== 'revealFocused'
             || callArguments(
                 applyValidatedPresentation,
                 'aiSessionPresentationDom.apply'
             ).length !== 1
+            || presentationStateAdoptMembers.filter(({ sourceFile }) =>
+                sourceFile.fileName === projectWebview.fileName).length !== 1
+            || presentationStateAdoptMembers.some(({ sourceFile }) =>
+                sourceFile.fileName === webview.fileName
+                    || sourceFile.fileName === aiSessionControlsWebview.fileName)
+            || presentationStateAdoptBindings.some(({ sourceFile }) =>
+                sourceFile.fileName === projectWebview.fileName
+                    || sourceFile.fileName === webview.fileName
+                    || sourceFile.fileName === aiSessionControlsWebview.fileName)
+            || presentationStateAdoptCalls.filter(({ node, sourceFile }) =>
+                sourceFile.fileName === projectWebview.fileName
+                    && node.pos >= applyValidatedPresentation.pos
+                    && node.end <= applyValidatedPresentation.end
+                    && (ts.isPropertyAccessExpression(node.expression)
+                        || ts.isElementAccessExpression(node.expression))
+                    && ts.isIdentifier(node.expression.expression)
+                    && node.expression.expression.text
+                        === 'aiSessionPresentationStateStore').length !== 1
             || adoptPresentationIndex < 0
             || projectPresentationIndex <= adoptPresentationIndex
             || reconcileAcknowledgementsIndex <= projectPresentationIndex
@@ -1145,7 +1400,7 @@ const guards = {
                 callArguments(presentationApplyOwner, name).length < 1)
             || !presentationApplySource.includes('[data-current-workspace]')
             || !presentationApplySource.includes('[data-open-workspace-current]')
-            || presentationMutationNodes.length !== 27
+            || presentationMutationNodes.length !== 28
             || presentationMutationNodes.some(({ node, sourceFile }) =>
                 sourceFile.fileName !== webview.fileName
                     || node.pos < presentationDomOwner.pos

--- a/src/webview/webviewProjectAiSessionControlsScripts.js
+++ b/src/webview/webviewProjectAiSessionControlsScripts.js
@@ -12,7 +12,6 @@ function initProjectAiSessionControls(options) {
         pending: false,
         requestId: null,
     };
-    var activeAiSessionTerminalState = { provider: null, sessionId: null, pendingId: null };
     var nextAiSessionBatchArchiveRequestId = 0;
     var nextAiSessionProviderSelectionRequestId = 0;
     var nextAiSessionAttentionAcknowledgementRequestId = 0;
@@ -674,18 +673,6 @@ function initProjectAiSessionControls(options) {
         return selectedProviders.split(',').find(isAiSessionProvider) || null;
     }
 
-    function syncActiveAiSessionTerminalDom() {
-        document.querySelectorAll('.codex-session-row[data-session-id]').forEach(row => {
-            var provider = row.getAttribute('data-session-provider') || 'codex';
-            var sessionId = row.getAttribute('data-session-id');
-            row.toggleAttribute(
-                'data-ai-session-active-terminal',
-                provider === activeAiSessionTerminalState.provider
-                    && sessionId === activeAiSessionTerminalState.sessionId
-            );
-        });
-    }
-
     function syncAiSessionBatchManagementDom(projectDiv) {
         var snapshot = batchAiSessionManager.snapshot();
         document.querySelectorAll('.project[data-ai-session-managing], .project[data-ai-session-pending]').forEach(project => {
@@ -847,7 +834,6 @@ function initProjectAiSessionControls(options) {
     return {
         batchAiSessionManager: batchAiSessionManager,
         batchAiSessionState: batchAiSessionState,
-        activeAiSessionTerminalState: activeAiSessionTerminalState,
         applyAiSessionAttentionAcknowledgementResult: applyAiSessionAttentionAcknowledgementResult,
         getPendingAiSessionProviderSelectionProjectId: getPendingAiSessionProviderSelectionProjectId,
         activateAiSessionProviderOption: activateAiSessionProviderOption,
@@ -865,7 +851,6 @@ function initProjectAiSessionControls(options) {
         reconcileAiSessionAttentionAcknowledgements: reconcileAiSessionAttentionAcknowledgements,
         setAiSessionProviderMenuOpen: setAiSessionProviderMenuOpen,
         submitAiSessionProviderSelection: submitAiSessionProviderSelection,
-        syncActiveAiSessionTerminalDom: syncActiveAiSessionTerminalDom,
         syncAiSessionBatchManagementDom: syncAiSessionBatchManagementDom,
         toggleAiSessionProviderMenu: toggleAiSessionProviderMenu,
         toggleCodexSessions: toggleCodexSessions,

--- a/src/webview/webviewProjectAiUpdateScripts.js
+++ b/src/webview/webviewProjectAiUpdateScripts.js
@@ -63,6 +63,10 @@ function initAiSessionPresentationStateStore(options) {
         return currentPresentation;
     }
 
+    function getFocusedTarget() {
+        return currentPresentation ? currentPresentation.focusedTarget : null;
+    }
+
     function getAttentionEventIds(provider, sessionId) {
         if (!currentPresentation) return [];
         var sessionKey = provider + ':' + sessionId;
@@ -76,6 +80,7 @@ function initAiSessionPresentationStateStore(options) {
         adopt: adopt,
         getAttentionEventIds: getAttentionEventIds,
         getCurrent: getCurrent,
+        getFocusedTarget: getFocusedTarget,
         isValid: isValid,
     };
 }
@@ -218,71 +223,55 @@ function initAiSessionPresentationDom(options) {
     'use strict';
 
     options = options || {};
-    var aiSessionControls = options.aiSessionControls;
+    var presentationStateStore = options.presentationStateStore;
 
-    function syncActiveAiSessionProjectionDom(adoptRenderedFocus, revealFocused) {
-        if (adoptRenderedFocus !== false) {
-            var focusedRow = document.querySelector(
-                '.codex-session-row[data-session-focused][data-session-provider]'
+    function syncActiveAiSessionProjectionDom(hasMatchingWorkspace, revealFocused) {
+        var focusedTarget = hasMatchingWorkspace
+            ? presentationStateStore.getFocusedTarget()
+            : null;
+        var projectedFocusedRow = null;
+        document.querySelectorAll(
+            '.codex-session-row[data-session-provider][data-session-id],'
+                + '.codex-session-row[data-session-provider][data-pending-id]'
+        ).forEach(row => {
+            var providerMatches = focusedTarget
+                && row.getAttribute('data-session-provider') === focusedTarget.provider;
+            var focused = providerMatches && (
+                (typeof focusedTarget.sessionId === 'string'
+                    && row.getAttribute('data-session-id') === focusedTarget.sessionId)
+                || (typeof focusedTarget.pendingId === 'string'
+                    && row.getAttribute('data-pending-id') === focusedTarget.pendingId)
             );
-            var provider = focusedRow && focusedRow.getAttribute('data-session-provider');
-            aiSessionControls.activeAiSessionTerminalState.provider =
-                aiSessionControls.isAiSessionProvider(provider) ? provider : null;
-            aiSessionControls.activeAiSessionTerminalState.sessionId = focusedRow
-                ? focusedRow.getAttribute('data-session-id') : null;
-            aiSessionControls.activeAiSessionTerminalState.pendingId = focusedRow
-                ? focusedRow.getAttribute('data-pending-id') : null;
-        } else {
-            var projectedFocusedRow = null;
-            document.querySelectorAll(
-                '.codex-session-row[data-session-provider][data-session-id],'
-                    + '.codex-session-row[data-session-provider][data-pending-id]'
-            ).forEach(row => {
-                var providerMatches = row.getAttribute('data-session-provider')
-                    === aiSessionControls.activeAiSessionTerminalState.provider;
-                var focused = providerMatches && (
-                    (aiSessionControls.activeAiSessionTerminalState.sessionId !== null
-                        && row.getAttribute('data-session-id')
-                            === aiSessionControls.activeAiSessionTerminalState.sessionId)
-                    || (aiSessionControls.activeAiSessionTerminalState.pendingId !== null
-                        && row.getAttribute('data-pending-id')
-                            === aiSessionControls.activeAiSessionTerminalState.pendingId)
+            if (focused) projectedFocusedRow = row;
+            row.toggleAttribute('data-session-focused', focused);
+            var focusedConversation = focused && row.hasAttribute('data-session-id');
+            row.toggleAttribute('data-ai-session-active-terminal', focusedConversation);
+            var primaryAction = row.querySelector('.ai-session-primary-action');
+            if (primaryAction) {
+                var actionState = focusedConversation ? 'conversation' : 'focus';
+                var actionAriaLabel = primaryAction.getAttribute(
+                    'data-' + actionState + '-aria-label'
                 );
-                if (focused) projectedFocusedRow = row;
-                row.toggleAttribute(
-                    'data-session-focused',
-                    focused
+                var actionTitle = primaryAction.getAttribute(
+                    'data-' + actionState + '-title'
                 );
-                var primaryAction = row.querySelector('.ai-session-primary-action');
-                if (primaryAction) {
-                    var focusedConversation = focused && row.hasAttribute('data-session-id');
-                    var actionState = focusedConversation ? 'conversation' : 'focus';
-                    var actionAriaLabel = primaryAction.getAttribute(
-                        'data-' + actionState + '-aria-label'
-                    );
-                    var actionTitle = primaryAction.getAttribute(
-                        'data-' + actionState + '-title'
-                    );
-                    if (actionAriaLabel) primaryAction.setAttribute('aria-label', actionAriaLabel);
-                    if (actionTitle) primaryAction.setAttribute('title', actionTitle);
-                }
-                var conversationHint = row.querySelector('.ai-session-open-conversation-hint');
-                if (focusedConversation
-                    && primaryAction && !conversationHint) {
-                    conversationHint = document.createElement('span');
-                    conversationHint.className = 'ai-session-open-conversation-hint';
-                    conversationHint.setAttribute('aria-hidden', 'true');
-                    conversationHint.textContent = '›';
-                    primaryAction.appendChild(conversationHint);
-                } else if (!focused && conversationHint) {
-                    conversationHint.remove();
-                }
-            });
-            if (projectedFocusedRow && revealFocused) {
-                projectedFocusedRow.scrollIntoView({ block: 'nearest' });
+                if (actionAriaLabel) primaryAction.setAttribute('aria-label', actionAriaLabel);
+                if (actionTitle) primaryAction.setAttribute('title', actionTitle);
             }
+            var conversationHint = row.querySelector('.ai-session-open-conversation-hint');
+            if (focusedConversation && primaryAction && !conversationHint) {
+                conversationHint = document.createElement('span');
+                conversationHint.className = 'ai-session-open-conversation-hint';
+                conversationHint.setAttribute('aria-hidden', 'true');
+                conversationHint.textContent = '›';
+                primaryAction.appendChild(conversationHint);
+            } else if (!focused && conversationHint) {
+                conversationHint.remove();
+            }
+        });
+        if (projectedFocusedRow && revealFocused) {
+            projectedFocusedRow.scrollIntoView({ block: 'nearest' });
         }
-        aiSessionControls.syncActiveAiSessionTerminalDom();
     }
     function setAiSessionAttentionDom(row, eventIds, needsAttention) {
         row.toggleAttribute('data-session-needs-attention', needsAttention);
@@ -467,6 +456,7 @@ function initAiSessionPresentationDom(options) {
                 + CSS.escape(message.workspaceNavigationIdentity || '') + '"]'
                 + '[data-open-workspace-current]'
         ));
+        syncActiveAiSessionProjectionDom(currentCards.length > 0, message.revealFocused);
         if (!currentCards.length) return;
         var projectDiv = currentCards.find(card => card.hasAttribute('data-current-workspace'));
         var presentations = {};
@@ -477,11 +467,6 @@ function initAiSessionPresentationDom(options) {
         message.attentionSessions.forEach(session => {
             attentionEvents[session.sessionKey] = session.eventIds.slice();
         });
-        var focused = message.focusedTarget;
-        aiSessionControls.activeAiSessionTerminalState.provider = focused ? focused.provider : null;
-        aiSessionControls.activeAiSessionTerminalState.sessionId = focused?.sessionId || null;
-        aiSessionControls.activeAiSessionTerminalState.pendingId = focused?.pendingId || null;
-        syncActiveAiSessionProjectionDom(false, message.revealFocused);
         projectDiv?.querySelectorAll(
             '.codex-session-row[data-session-provider][data-session-id]'
         ).forEach(row => {

--- a/src/webview/webviewProjectScripts.js
+++ b/src/webview/webviewProjectScripts.js
@@ -265,7 +265,7 @@ function initProjects() {
         isAiSessionProvider: aiSessionControls.isAiSessionProvider,
     });
     var aiSessionPresentationDom = initAiSessionPresentationDom({
-        aiSessionControls: aiSessionControls,
+        presentationStateStore: aiSessionPresentationStateStore,
     });
     var presentationTransactions = initAiSessionPresentationTransactions({
         isValidAiSessionPresentationState: aiSessionPresentationStateStore.isValid,

--- a/tests/browser/activeSessionCardInteraction.test.js
+++ b/tests/browser/activeSessionCardInteraction.test.js
@@ -776,6 +776,39 @@ test('ACTIVE-SESSION-FOCUS-REVEAL-001 keeps a newer complete presentation when o
     );
 });
 
+test('ACTIVE-SESSION-FOCUS-REVEAL-001 clears stale card focus when another workspace has the same session identity', async t => {
+    const initial = [
+        session('codex', 'session-a', true),
+        session('codex', 'session-b', false),
+    ];
+    const page = await openCardPage(t, initial);
+    const focusedRow = row(page, 'codex', 'session-a');
+    const primaryAction = focusedRow.locator('.ai-session-primary-action');
+    await postHostMessage(page, presentationMessage(initial, 2, { revealFocused: true }));
+    assert.equal(await focusedRow.getAttribute('data-session-focused'), '');
+    assert.equal(await focusedRow.getAttribute('data-ai-session-active-terminal'), '');
+    assert.equal(await primaryAction.getAttribute('title'), 'Open AI conversation for Codex Session');
+
+    const otherWorkspacePresentation = presentationMessage(
+        initial,
+        3,
+        {
+            focusedTarget: { provider: 'codex', sessionId: 'session-a' },
+            revealFocused: true,
+        }
+    );
+    otherWorkspacePresentation.workspaceScopeIdentity = 'scope-project-b';
+    otherWorkspacePresentation.workspaceNavigationIdentity = 'navigation-project-b';
+    await postHostMessage(page, otherWorkspacePresentation);
+
+    assert.equal(await focusedRow.getAttribute('data-session-focused'), null);
+    assert.equal(await focusedRow.getAttribute('data-ai-session-active-terminal'), null);
+    assert.equal(await focusedRow.locator('.ai-session-open-conversation-hint').count(), 0);
+    assert.equal(await primaryAction.getAttribute('title'), 'Focus Codex Session');
+    await primaryAction.click();
+    assert.equal((await postedMessages(page)).at(-1).type, 'focus-ai-session-terminal');
+});
+
 test('ACTIVE-SESSION-INCREMENTAL-PRESENTATION-ENVELOPE-001 rejects legacy AI update messages', async t => {
     const initial = [session('codex', 'session-a', true)];
     const page = await openCardPage(t, initial);

--- a/tests/unit/tooling/architectureGuards.test.js
+++ b/tests/unit/tooling/architectureGuards.test.js
@@ -113,6 +113,33 @@ test('SECURITY-AI-SESSION-CONVERSATION-SOURCE-001 complete production fixture sa
     validateArchitectureGuards(copyGuardFixture(t));
 });
 
+test('ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001 accepts an equivalent focused target getter', t => {
+    const root = copyGuardFixture(
+        t,
+        'src/webview/webviewProjectAiUpdateScripts.js',
+        source => replaceFixtureSource(
+            source,
+            'return currentPresentation ? currentPresentation.focusedTarget : null;',
+            'return currentPresentation?.focusedTarget ?? null;'
+        )
+    );
+    validateArchitectureGuards(root, {
+        ids: ['ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001'],
+    });
+});
+
+test('ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001 permits unrelated focused target methods', t => {
+    const root = copyGuardFixture(
+        t,
+        'src/webview/webviewProjectContextMenuScripts.js',
+        source => `${source}\nfunction readUnrelatedFocusedTarget(controller) {\n`
+            + '    return controller.getFocusedTarget();\n}\n'
+    );
+    validateArchitectureGuards(root, {
+        ids: ['ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001'],
+    });
+});
+
 test('ARCH-CURRENT-WORKSPACE-SESSION-AUTHORITY-001 rejects scope identity at the current-card authority boundary', t => {
     const root = copyGuardFixture(
         t,
@@ -949,6 +976,291 @@ for (const mutation of [
             source,
             "    'use strict';",
             "    'use strict';\n\n    window.__agentPivotAttentionSessionEvents = {};"
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectAiUpdateScripts.js',
+        expectedDetail: 'the accepted Presentation focused target must be the only Webview focus state',
+        mutate: source => replaceFixtureSource(
+            source,
+            'return currentPresentation ? currentPresentation.focusedTarget : null;',
+            'return null;'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectAiUpdateScripts.js',
+        expectedDetail: 'the accepted Presentation focused target must be the only Webview focus state',
+        mutate: source => replaceFixtureSource(
+            source,
+            'return currentPresentation ? currentPresentation.focusedTarget : null;',
+            'return null && currentPresentation.focusedTarget;'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectAiSessionControlsScripts.js',
+        expectedDetail: 'the accepted Presentation focused target must be the only Webview focus state',
+        mutate: source => replaceFixtureSource(
+            source,
+            "    'use strict';",
+            "    'use strict';\n\n    var activeAiSessionTerminalState = {};"
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectAiSessionControlsScripts.js',
+        expectedDetail: 'the accepted Presentation focused target must be the only Webview focus state',
+        mutate: source => replaceFixtureSource(
+            source,
+            'function initProjectAiSessionControls(options) {',
+            'var focusedAiSessionState = {};\n\n'
+                + 'function captureFocusedAiSessionAttribute() {\n'
+                + "    var row = Array.from(document.querySelectorAll('.codex-session-row'))\n"
+                + "        .find(candidate => candidate.getAttribute('data-session-focused') !== null);\n"
+                + "    focusedAiSessionState.provider = row?.getAttribute('data-session-provider');\n"
+                + '}\n\n'
+                + 'function initProjectAiSessionControls(options) {'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectAiSessionControlsScripts.js',
+        expectedDetail: 'the accepted Presentation focused target must be the only Webview focus state',
+        mutate: source => replaceFixtureSource(
+            source,
+            'function initProjectAiSessionControls(options) {',
+            'var focusedAiSessionState = {};\n\n'
+                + 'function captureFocusedAiSessionDataset() {\n'
+                + "    var row = Array.from(document.querySelectorAll('.codex-session-row'))\n"
+                + '        .find(candidate => candidate.dataset.sessionFocused !== undefined);\n'
+                + '    focusedAiSessionState.provider = row?.dataset.sessionProvider;\n'
+                + '}\n\n'
+                + 'function initProjectAiSessionControls(options) {'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectAiSessionControlsScripts.js',
+        expectedDetail: 'the accepted Presentation focused target must be the only Webview focus state',
+        mutate: source => replaceFixtureSource(
+            source,
+            'function initProjectAiSessionControls(options) {',
+            'var focusedAiSessionState = {};\n\n'
+                + 'function captureFocusedAiSessionState() {\n'
+                + "    var row = document.querySelector('[data-session-focused]');\n"
+                + "    focusedAiSessionState.provider = row?.getAttribute('data-session-provider');\n"
+                + '}\n\n'
+                + 'function initProjectAiSessionControls(options) {'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectScripts.js',
+        expectedDetail: 'every Session Presentation DOM surface must belong to the single AI update projector',
+        mutate: source => replaceFixtureSource(
+            source,
+            'presentationStateStore: aiSessionPresentationStateStore,',
+            'presentationStateStore: null,'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectScripts.js',
+        expectedDetail: 'every Session Presentation DOM surface must belong to the single AI update projector',
+        mutate: source => replaceFixtureSource(
+            source,
+            'if (!aiSessionPresentationStateStore.adopt(message)) return;',
+            'if (!aiSessionPresentationStateStore.adopt(message)) return;\n'
+                + '        var stateStoreAlias = aiSessionPresentationStateStore;\n'
+                + '        stateStoreAlias.adopt({ ...message, focusedTarget: null });'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectAiSessionControlsScripts.js',
+        expectedDetail: 'every Session Presentation DOM surface must belong to the single AI update projector',
+        mutate: source => replaceFixtureSource(
+            source,
+            'function initProjectAiSessionControls(options) {',
+            'function initProjectAiSessionControls(options) {\n'
+                + '    var presentationStore = getAiSessionPresentationStateStore();\n'
+                + '    presentationStore.adopt({ revision: 999 });'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectAiUpdateScripts.js',
+        expectedDetail: 'every Session Presentation DOM surface must belong to the single AI update projector',
+        mutate: source => replaceFixtureSource(
+            source,
+            'var presentationStateStore = options.presentationStateStore;',
+            'var presentationStateStore = options.presentationStateStore;\n'
+                + '    presentationStateStore.adopt({ revision: 999 });'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectAiSessionControlsScripts.js',
+        expectedDetail: 'every Session Presentation DOM surface must belong to the single AI update projector',
+        mutate: source => replaceFixtureSource(
+            source,
+            'function initProjectAiSessionControls(options) {',
+            'function initProjectAiSessionControls(options) {\n'
+                + '    var presentationStore = getAiSessionPresentationStateStore();\n'
+                + '    presentationStore.adopt.call(presentationStore, { revision: 999 });'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectAiSessionControlsScripts.js',
+        expectedDetail: 'every Session Presentation DOM surface must belong to the single AI update projector',
+        mutate: source => replaceFixtureSource(
+            source,
+            'function initProjectAiSessionControls(options) {',
+            'function initProjectAiSessionControls(options) {\n'
+                + '    var presentationStore = getAiSessionPresentationStateStore();\n'
+                + '    var { adopt } = presentationStore;\n'
+                + '    adopt({ revision: 999 });'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectAiSessionControlsScripts.js',
+        expectedDetail: 'every Session Presentation DOM surface must belong to the single AI update projector',
+        mutate: source => replaceFixtureSource(
+            source,
+            'function initProjectAiSessionControls(options) {',
+            'function initProjectAiSessionControls(options) {\n'
+                + '    var presentationStore = getAiSessionPresentationStateStore();\n'
+                + "    var { 'adopt': accept } = presentationStore;\n"
+                + '    accept({ revision: 999 });'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectAiSessionControlsScripts.js',
+        expectedDetail: 'every Session Presentation DOM surface must belong to the single AI update projector',
+        mutate: source => replaceFixtureSource(
+            source,
+            'function initProjectAiSessionControls(options) {',
+            'function initProjectAiSessionControls(options) {\n'
+                + '    var presentationStore = getAiSessionPresentationStateStore();\n'
+                + "    var { ['adopt']: accept } = presentationStore;\n"
+                + '    accept({ revision: 999 });'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectAiUpdateScripts.js',
+        expectedDetail: 'every Session Presentation DOM surface must belong to the single AI update projector',
+        mutate: source => replaceFixtureSource(
+            source,
+            'var presentationStateStore = options.presentationStateStore;',
+            'var presentationStateStore = options.presentationStateStore;\n'
+                + '    var hiddenAdopt = presentationStateStore.adopt.bind(presentationStateStore);\n'
+                + '    hiddenAdopt({ revision: 999 });'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectAiUpdateScripts.js',
+        expectedDetail: 'the accepted Presentation focused target must be the only Webview focus state',
+        mutate: source => replaceFixtureSource(
+            source,
+            'presentationStateStore.getFocusedTarget()',
+            "document.querySelector('[data-session-focused]')"
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectAiUpdateScripts.js',
+        expectedDetail: 'every Session Presentation DOM surface must belong to the single AI update projector',
+        mutate: source => replaceFixtureSource(
+            source,
+            'presentationStateStore.getFocusedTarget()',
+            'presentationStateStore.getFocusedTarget()\n'
+                + '                || presentationStateStore.getFocusedTarget()'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectAiUpdateScripts.js',
+        expectedDetail: 'every Session Presentation DOM surface must belong to the single AI update projector',
+        mutate: source => replaceFixtureSource(
+            source,
+            'var focusedTarget = hasMatchingWorkspace\n'
+                + '            ? presentationStateStore.getFocusedTarget()\n'
+                + '            : null;',
+            'var focusedTarget = hasMatchingWorkspace\n'
+                + '            ? presentationStateStore.getFocusedTarget()\n'
+                + '            : null;\n'
+                + '        focusedTarget = null;'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectScripts.js',
+        expectedDetail: 'every Session Presentation DOM surface must belong to the single AI update projector',
+        mutate: source => replaceFixtureSource(
+            source,
+            'if (!aiSessionPresentationStateStore.adopt(message)) return;',
+            'if (!aiSessionPresentationStateStore.adopt(message)) return;\n'
+                + '        aiSessionPresentationStateStore.adopt(message);'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectAiSessionControlsScripts.js',
+        expectedDetail: 'every Session Presentation DOM surface must belong to the single AI update projector',
+        mutate: source => replaceFixtureSource(
+            source,
+            'function initProjectAiSessionControls(options) {',
+            'function mutateActiveTerminal(row) {\n'
+                + "    row.toggleAttribute('data-ai-session-active-terminal', false);\n"
+                + '}\n\n'
+                + 'function initProjectAiSessionControls(options) {'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectAiSessionControlsScripts.js',
+        expectedDetail: 'every Session Presentation DOM surface must belong to the single AI update projector',
+        mutate: source => replaceFixtureSource(
+            source,
+            'function initProjectAiSessionControls(options) {',
+            'function mutateActiveTerminalObjectAssign(row) {\n'
+                + "    Object.assign(row.dataset, { sessionFocused: '', aiSessionActiveTerminal: '' });\n"
+                + '}\n\n'
+                + 'function initProjectAiSessionControls(options) {'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectAiSessionControlsScripts.js',
+        expectedDetail: 'every Session Presentation DOM surface must belong to the single AI update projector',
+        mutate: source => replaceFixtureSource(
+            source,
+            'function initProjectAiSessionControls(options) {',
+            'function mutateActiveTerminalNamespace(row) {\n'
+                + "    row.setAttributeNS(null, 'data-session-focused', '');\n"
+                + '}\n\n'
+                + 'function initProjectAiSessionControls(options) {'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectAiSessionControlsScripts.js',
+        expectedDetail: 'every Session Presentation DOM surface must belong to the single AI update projector',
+        mutate: source => replaceFixtureSource(
+            source,
+            'function initProjectAiSessionControls(options) {',
+            'function mutateActiveTerminalDataset(row) {\n'
+                + "    row.dataset.sessionFocused = '';\n"
+                + "    row.dataset.aiSessionActiveTerminal = '';\n"
+                + '}\n\n'
+                + 'function initProjectAiSessionControls(options) {'
         ),
     },
     {


### PR DESCRIPTION
## Summary

- make the accepted Session Presentation the single source of truth for focused-session state
- remove the duplicate Webview focus cache and project focus through the shared Presentation DOM owner
- clear stale focus when an accepted Presentation belongs to another workspace, including same-provider and same-session identity collisions
- harden architecture guards so Presentation adoption remains confined to the validated applicator

## Regression fixed

A Presentation for one workspace could leave or apply focused and active-terminal markers on another workspace's row when both workspaces exposed the same logical session identity. The projector now requires a matching workspace navigation identity; otherwise it projects an effective null focus and clears stale DOM state.

## Verification

- npm run test-compile
- activeSessionCardInteraction browser owner: 36/36
- full deterministic suite: 404/404
- full browser suite: 211/211
- architecture mutation tests: 139/139
- architecture guard runner
- Dashboard Webview checks
- safety checks
- lint (existing warnings only)
- npm run test:behavior-contracts
- independent architecture review: no Critical or Important findings

## Skill harvest

No skill update was justified. The existing architecture-refactor, resilient Webview protocol, worktree, review/fix, and publishing workflows covered the task; the capability audit records Skill-Harvest: none.
