### PR TITLE
Fix focused session card continuity across workspace updates

### DIFF
--- a/.skills/installing-vscode-extensions-locally/SKILL.md
+++ b/.skills/installing-vscode-extensions-locally/SKILL.md
@@ -96,6 +96,20 @@ Build and install the Agent Pivot extension that matches the current VS Code env
      establish only packaging or attempted installation, never verified bytes.
    - if a script exits 0 with warnings, report warnings separately from failure
 
+8. Verify runtime activation before asking the user to test behavior:
+   - compare the active Extension Host process start time with the verified
+     installed-file timestamp. Installed bytes newer than the Host prove only
+     that the next Host can load the build; the current window is still
+     running the previous extension code.
+   - when the Host predates the install, explicitly ask the user to run
+     `Developer: Reload Window` in every target window. Do not classify UI or
+     Webview behavior observed before that reload as evidence against the new
+     build.
+   - after reload, rediscover the active Host and require its start time to be
+     newer than the install before reporting the build as active. If the
+     environment cannot expose process timing, report verified installation
+     separately from unverified activation.
+
 ## Reporting
 
 Always tell the user:
@@ -107,6 +121,8 @@ Always tell the user:
   and extension directory were discovered
 - representative VSIX-to-installed file hash evidence for the workspace
   extension, or why that evidence could not be collected
+- whether the target Extension Host was restarted after installation, or that
+  `Developer: Reload Window` is still required before behavioral testing
 - which checks were run
 - any extension that was packaged but not installable in the current host
 
@@ -125,6 +141,9 @@ Always tell the user:
 - Do not claim that the current VSIX was installed without ID/version and
   representative hash comparison against the active Server installation.
 - Do not claim install success from packaging success alone.
+- Do not treat verified disk bytes as verified runtime activation: an
+  Extension Host that predates the installed files is still executing the old
+  extension until its window reloads.
 - Parallel agent sessions installing the same extension version race on the live extensions directory: an `install-local` from another worktree can overwrite every installed byte seconds after a verified install, and each installer's own byte verification still passes. Immediately before reporting an install as ready for user verification, re-hash the task-critical installed files (the changed runtime or webview bundle) against the VSIX; on mismatch, reinstall and re-verify instead of trusting the earlier success.
 - Do not skip the repo's packaging script in favor of a generic VSIX command unless the repo lacks one.
 - Do not run bare `npx gulp` to rebuild webview assets (SCSS or `src/webview` copies): the default development mode starts watchers and never exits. Use `npx gulp --production` for one-shot builds, matching `vscode:prepublish`.

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "7eb81756963bad157f7839e06bad931f7374b9d2",
+        "head": "0d96cc1c2a41e56dded2f4608e64a3dfabbfce8d",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -276,7 +276,8 @@
             "52883dd9c3680cd9cf40446941fef3dee3062c34",
             "18ecf2273167690e3399c82a1b2b5d408a9661d6",
             "0ffa4a9095be981c3034c98ef5b4cd2dc530ca81",
-            "b803fe787f08b6460d1f1e72ffa01d1e0865ba5e"
+            "b803fe787f08b6460d1f1e72ffa01d1e0865ba5e",
+            "12017e9f4031a0a74003dde0a12d68c7171b1852"
         ]
     },
     "capabilities": [
@@ -529,7 +530,8 @@
                 "d2b9b3ad677d546a781265603fad088101616133",
                 "680cda193f6fb74064502fe463da5fb9b5154251",
                 "660ab41e2ff0da8f0c4b0f0abeed8a2a97ee87e1",
-                "83910c204b19ba0daace9cce51b8d2c741dcca63"
+                "83910c204b19ba0daace9cce51b8d2c741dcca63",
+                "f21da330003a44dc7e5eff624d36453bd7627884"
             ],
             "behaviors": [
                 "WEBVIEW-CURRENT-WORKSPACE-RENDERING-001",
@@ -1250,7 +1252,8 @@
                 "c79183114269860b29eec03d0d316899072b16b9",
                 "0b06155e7043d14ece0d17ca682d09c6c0d8bdcb",
                 "b55f68c5d67b705d3f0edabc01183788f5146b2a",
-                "5b308c507e0e21eab46aa1ee6103728a10cda243"
+                "5b308c507e0e21eab46aa1ee6103728a10cda243",
+                "0d96cc1c2a41e56dded2f4608e64a3dfabbfce8d"
             ],
             "behaviors": [
                 "ARCH-CI-QUALITY-GATE-001",

--- a/media/webviewDashboardBundle.js
+++ b/media/webviewDashboardBundle.js
@@ -541,6 +541,10 @@ function applyWorkspaceUpdate(message, options) {
         || !isWorkspaceUpdateDomConsistent(message, replacement)) {
         return false;
     }
+    if (options && typeof options.validateReplacement === 'function'
+        && !options.validateReplacement(replacement)) {
+        return false;
+    }
 
     var aiSessionStates = captureCurrentWorkspaceAiSessionStates(currentGroup);
     var currentListScroll = captureOpenTabListScroll(
@@ -702,7 +706,7 @@ function completeOpenWorkspacePin(message) {
     return true;
 }
 
-function applyOpenWorkspacesUpdate(message) {
+function applyOpenWorkspacesUpdate(message, options) {
     if (!message
         || message.type !== 'open-workspaces-updated'
         || message.version !== 3
@@ -727,6 +731,18 @@ function applyOpenWorkspacesUpdate(message) {
     }
     var wrapper = document.querySelector('.sticky-groups-wrapper');
     if (!wrapper) return false;
+    var holder = null;
+    if (typeof document.createElement === 'function') {
+        holder = document.createElement('div');
+        holder.innerHTML = message.html;
+        if (!isOpenWorkspacesUpdateDomConsistent(message, holder)
+            || (options && typeof options.validateReplacement === 'function'
+                && !options.validateReplacement(holder))) {
+            return false;
+        }
+    } else if (options && typeof options.validateReplacement === 'function') {
+        return false;
+    }
     var previousHtml = wrapper.innerHTML;
     var focusedPinButton = document.activeElement
         && document.activeElement.matches?.(
@@ -740,7 +756,7 @@ function applyOpenWorkspacesUpdate(message) {
         OPEN_TAB_OTHER_ITEM_SELECTOR,
         'data-workspace-navigation-identity'
     );
-    wrapper.innerHTML = message.html;
+    wrapper.innerHTML = holder ? holder.innerHTML : message.html;
     if (!isOpenWorkspacesUpdateDomConsistent(message)) {
         wrapper.innerHTML = previousHtml;
         restoreOpenTabListScroll(
@@ -785,12 +801,14 @@ function applyOpenWorkspacesUpdate(message) {
     return true;
 }
 
-function getOpenWorkspacesUpdateDomState() {
-    var otherWindowsGroup = document.querySelector(
-        '.sticky-groups-wrapper .open-other-windows-group[data-other-windows-status]'
+function getOpenWorkspacesUpdateDomState(root) {
+    var projectionRoot = root || document;
+    var wrapperPrefix = root ? '' : '.sticky-groups-wrapper ';
+    var otherWindowsGroup = projectionRoot.querySelector(
+        wrapperPrefix + '.open-other-windows-group[data-other-windows-status]'
     );
-    var openWorkspaceCards = Array.from(document.querySelectorAll(
-        '.sticky-groups-wrapper .open-other-windows-group '
+    var openWorkspaceCards = Array.from(projectionRoot.querySelectorAll(
+        wrapperPrefix + '.open-other-windows-group '
         + '.workspace-card[data-open-workspace-list-card][data-workspace-navigation-identity]'
     ));
     var navigationCards = openWorkspaceCards.filter(card =>
@@ -800,15 +818,16 @@ function getOpenWorkspacesUpdateDomState() {
         card.getAttribute('data-workspace-navigation-identity')
     );
     return {
-        currentWorkspaceCount: document.querySelectorAll(
-            '.sticky-groups-wrapper .workspace-card[data-current-workspace][data-workspace-scope-identity]'
+        currentWorkspaceCount: projectionRoot.querySelectorAll(
+            wrapperPrefix
+                + '.workspace-card[data-current-workspace][data-workspace-scope-identity]'
         ).length,
         navigationWorkspaceCount: navigationCards.length,
         openWorkspaceListCount: openWorkspaceCards.length,
         hasUniqueNavigationIdentities: navigationIdentities.every(identity => !!identity)
             && new Set(navigationIdentities).size === navigationIdentities.length,
-        hasOtherWindowsGroup: document.querySelectorAll(
-            '.sticky-groups-wrapper .open-other-windows-group'
+        hasOtherWindowsGroup: projectionRoot.querySelectorAll(
+            wrapperPrefix + '.open-other-windows-group'
         ).length > 0,
         otherWindowsStatus: otherWindowsGroup
             ? otherWindowsGroup.getAttribute('data-other-windows-status')
@@ -816,8 +835,8 @@ function getOpenWorkspacesUpdateDomState() {
     };
 }
 
-function isOpenWorkspacesUpdateDomConsistent(message) {
-    var rendered = getOpenWorkspacesUpdateDomState();
+function isOpenWorkspacesUpdateDomConsistent(message, root) {
+    var rendered = getOpenWorkspacesUpdateDomState(root);
     return rendered.currentWorkspaceCount === message.currentWorkspaceCount
         && rendered.navigationWorkspaceCount === message.navigationWorkspaceCount
         && rendered.hasUniqueNavigationIdentities
@@ -2099,6 +2118,7 @@ function initAiSessionPresentationTransactions(options) {
 
     options = options || {};
     var isValidAiSessionPresentationState = options.isValidAiSessionPresentationState;
+    var canApplyAiSessionPresentationState = options.canApplyAiSessionPresentationState;
     var applyValidatedAiSessionPresentationState = options.applyValidatedAiSessionPresentationState;
     var latestAiSessionProjectionRevision = 0;
     var latestAiSessionPresentationProjectionRevision = 0;
@@ -2109,6 +2129,12 @@ function initAiSessionPresentationTransactions(options) {
             type: 'request-full-refresh',
             reason,
         });
+    }
+
+    function hasMatchingPresentationWorkspace(message) {
+        if (canApplyAiSessionPresentationState(message)) return true;
+        requestFullRefresh('mismatched-ai-session-presentation-workspace');
+        return false;
     }
 
     function canApplyRevision(revision, latestRevision) {
@@ -2174,6 +2200,7 @@ function initAiSessionPresentationTransactions(options) {
             requestFullRefresh('invalid-initial-ai-session-presentation-state');
             return false;
         }
+        if (!hasMatchingPresentationWorkspace(message)) return false;
         if (!acceptInitialPresentationProjectionRevision(message.projectionRevision)) {
             return false;
         }
@@ -2187,6 +2214,7 @@ function initAiSessionPresentationTransactions(options) {
             requestFullRefresh('invalid-direct-ai-session-presentation-state');
             return false;
         }
+        if (!hasMatchingPresentationWorkspace(message)) return false;
         if (!acceptPresentationProjectionRevision(message.projectionRevision)) {
             return false;
         }
@@ -2208,10 +2236,20 @@ function initAiSessionPresentationTransactions(options) {
             || !canApplyAtomicPresentationProjectionRevision(message.projectionRevision)) {
             return false;
         }
-        if (!input.replaceContent()) {
-            requestFullRefresh(input.invalidReplacementReason);
+        var replacementWorkspaceMatches = null;
+        if (!input.replaceContent(replacementRoot => {
+            replacementWorkspaceMatches = canApplyAiSessionPresentationState(
+                message.presentation,
+                replacementRoot
+            );
+            return replacementWorkspaceMatches;
+        })) {
+            requestFullRefresh(replacementWorkspaceMatches === false
+                ? 'mismatched-ai-session-presentation-workspace'
+                : input.invalidReplacementReason);
             return false;
         }
+        if (!hasMatchingPresentationWorkspace(message.presentation)) return false;
         commitAtomicProjectionRevision(message.projectionRevision);
         if (typeof input.afterReplacement === 'function') {
             input.afterReplacement();
@@ -2234,10 +2272,8 @@ function initAiSessionPresentationDom(options) {
     options = options || {};
     var presentationStateStore = options.presentationStateStore;
 
-    function syncActiveAiSessionProjectionDom(hasMatchingWorkspace, revealFocused) {
-        var focusedTarget = hasMatchingWorkspace
-            ? presentationStateStore.getFocusedTarget()
-            : null;
+    function syncActiveAiSessionProjectionDom(revealFocused) {
+        var focusedTarget = presentationStateStore.getFocusedTarget();
         var projectedFocusedRow = null;
         document.querySelectorAll(
             '.codex-session-row[data-session-provider][data-session-id],'
@@ -2456,8 +2492,10 @@ function initAiSessionPresentationDom(options) {
         );
         setCurrentWorkspaceRunningDom(projectDiv, message);
     }
-    function applyAiSessionPresentationDom(message) {
-        var currentCards = Array.from(document.querySelectorAll(
+    function getAiSessionPresentationCurrentCards(message, root) {
+        if (typeof message.workspaceNavigationIdentity !== 'string'
+            || !message.workspaceNavigationIdentity) return [];
+        return Array.from((root || document).querySelectorAll(
             '.workspace-card[data-workspace-navigation-identity="'
                 + CSS.escape(message.workspaceNavigationIdentity || '') + '"]'
                 + '[data-current-workspace],'
@@ -2465,7 +2503,20 @@ function initAiSessionPresentationDom(options) {
                 + CSS.escape(message.workspaceNavigationIdentity || '') + '"]'
                 + '[data-open-workspace-current]'
         ));
-        syncActiveAiSessionProjectionDom(currentCards.length > 0, message.revealFocused);
+    }
+    function canApplyAiSessionPresentationDom(message, root) {
+        var projectionRoot = root || document;
+        if (message.workspaceNavigationIdentity === null) {
+            return !projectionRoot.querySelector(
+                '.workspace-card[data-current-workspace],'
+                    + '.workspace-card[data-open-workspace-current]'
+            );
+        }
+        return getAiSessionPresentationCurrentCards(message, projectionRoot).length > 0;
+    }
+    function applyAiSessionPresentationDom(message) {
+        var currentCards = getAiSessionPresentationCurrentCards(message);
+        syncActiveAiSessionProjectionDom(message.revealFocused);
         if (!currentCards.length) return;
         var projectDiv = currentCards.find(card => card.hasAttribute('data-current-workspace'));
         var presentations = {};
@@ -2507,6 +2558,7 @@ function initAiSessionPresentationDom(options) {
 
     return {
         apply: applyAiSessionPresentationDom,
+        canApply: canApplyAiSessionPresentationDom,
     };
 }
 
@@ -2556,7 +2608,7 @@ function initProjectAiSessionsUpdate(options) {
             message: message,
             invalidPresentationReason: 'invalid-ai-session-presentation-envelope',
             invalidReplacementReason: 'invalid-ai-session-workspace-update',
-            replaceContent: () => applyWorkspaceUpdate({
+            replaceContent: validateReplacement => applyWorkspaceUpdate({
                 type: 'workspace-updated',
                 version: 2,
                 currentWorkspaceCount: message.currentWorkspaceCount,
@@ -2565,6 +2617,7 @@ function initProjectAiSessionsUpdate(options) {
                 canRestoreAiSessionProviderMenu: () =>
                     !getPendingAiSessionProviderSelectionProjectId()
                     && !batchAiSessionState.pending,
+                validateReplacement: validateReplacement,
             }),
             afterReplacement: () => {
                 if (batchAiSessionState.projectId) {
@@ -3821,6 +3874,7 @@ function initProjects() {
     });
     var presentationTransactions = initAiSessionPresentationTransactions({
         isValidAiSessionPresentationState: aiSessionPresentationStateStore.isValid,
+        canApplyAiSessionPresentationState: aiSessionPresentationDom.canApply,
         applyValidatedAiSessionPresentationState: applyValidatedAiSessionPresentationState,
     });
     var aiSessionsUpdate = initProjectAiSessionsUpdate({
@@ -4018,7 +4072,10 @@ function initProjects() {
                 message: message,
                 invalidPresentationReason: 'invalid-open-workspaces-presentation-envelope',
                 invalidReplacementReason: 'invalid-open-workspaces-update',
-                replaceContent: () => applyOpenWorkspacesUpdate(message),
+                replaceContent: validateReplacement => applyOpenWorkspacesUpdate(
+                    message,
+                    { validateReplacement: validateReplacement }
+                ),
             })) {
                 return;
             }

--- a/media/webviewProjectAiUpdateScripts.js
+++ b/media/webviewProjectAiUpdateScripts.js
@@ -90,6 +90,7 @@ function initAiSessionPresentationTransactions(options) {
 
     options = options || {};
     var isValidAiSessionPresentationState = options.isValidAiSessionPresentationState;
+    var canApplyAiSessionPresentationState = options.canApplyAiSessionPresentationState;
     var applyValidatedAiSessionPresentationState = options.applyValidatedAiSessionPresentationState;
     var latestAiSessionProjectionRevision = 0;
     var latestAiSessionPresentationProjectionRevision = 0;
@@ -100,6 +101,12 @@ function initAiSessionPresentationTransactions(options) {
             type: 'request-full-refresh',
             reason,
         });
+    }
+
+    function hasMatchingPresentationWorkspace(message) {
+        if (canApplyAiSessionPresentationState(message)) return true;
+        requestFullRefresh('mismatched-ai-session-presentation-workspace');
+        return false;
     }
 
     function canApplyRevision(revision, latestRevision) {
@@ -165,6 +172,7 @@ function initAiSessionPresentationTransactions(options) {
             requestFullRefresh('invalid-initial-ai-session-presentation-state');
             return false;
         }
+        if (!hasMatchingPresentationWorkspace(message)) return false;
         if (!acceptInitialPresentationProjectionRevision(message.projectionRevision)) {
             return false;
         }
@@ -178,6 +186,7 @@ function initAiSessionPresentationTransactions(options) {
             requestFullRefresh('invalid-direct-ai-session-presentation-state');
             return false;
         }
+        if (!hasMatchingPresentationWorkspace(message)) return false;
         if (!acceptPresentationProjectionRevision(message.projectionRevision)) {
             return false;
         }
@@ -199,10 +208,20 @@ function initAiSessionPresentationTransactions(options) {
             || !canApplyAtomicPresentationProjectionRevision(message.projectionRevision)) {
             return false;
         }
-        if (!input.replaceContent()) {
-            requestFullRefresh(input.invalidReplacementReason);
+        var replacementWorkspaceMatches = null;
+        if (!input.replaceContent(replacementRoot => {
+            replacementWorkspaceMatches = canApplyAiSessionPresentationState(
+                message.presentation,
+                replacementRoot
+            );
+            return replacementWorkspaceMatches;
+        })) {
+            requestFullRefresh(replacementWorkspaceMatches === false
+                ? 'mismatched-ai-session-presentation-workspace'
+                : input.invalidReplacementReason);
             return false;
         }
+        if (!hasMatchingPresentationWorkspace(message.presentation)) return false;
         commitAtomicProjectionRevision(message.projectionRevision);
         if (typeof input.afterReplacement === 'function') {
             input.afterReplacement();
@@ -225,10 +244,8 @@ function initAiSessionPresentationDom(options) {
     options = options || {};
     var presentationStateStore = options.presentationStateStore;
 
-    function syncActiveAiSessionProjectionDom(hasMatchingWorkspace, revealFocused) {
-        var focusedTarget = hasMatchingWorkspace
-            ? presentationStateStore.getFocusedTarget()
-            : null;
+    function syncActiveAiSessionProjectionDom(revealFocused) {
+        var focusedTarget = presentationStateStore.getFocusedTarget();
         var projectedFocusedRow = null;
         document.querySelectorAll(
             '.codex-session-row[data-session-provider][data-session-id],'
@@ -447,8 +464,10 @@ function initAiSessionPresentationDom(options) {
         );
         setCurrentWorkspaceRunningDom(projectDiv, message);
     }
-    function applyAiSessionPresentationDom(message) {
-        var currentCards = Array.from(document.querySelectorAll(
+    function getAiSessionPresentationCurrentCards(message, root) {
+        if (typeof message.workspaceNavigationIdentity !== 'string'
+            || !message.workspaceNavigationIdentity) return [];
+        return Array.from((root || document).querySelectorAll(
             '.workspace-card[data-workspace-navigation-identity="'
                 + CSS.escape(message.workspaceNavigationIdentity || '') + '"]'
                 + '[data-current-workspace],'
@@ -456,7 +475,20 @@ function initAiSessionPresentationDom(options) {
                 + CSS.escape(message.workspaceNavigationIdentity || '') + '"]'
                 + '[data-open-workspace-current]'
         ));
-        syncActiveAiSessionProjectionDom(currentCards.length > 0, message.revealFocused);
+    }
+    function canApplyAiSessionPresentationDom(message, root) {
+        var projectionRoot = root || document;
+        if (message.workspaceNavigationIdentity === null) {
+            return !projectionRoot.querySelector(
+                '.workspace-card[data-current-workspace],'
+                    + '.workspace-card[data-open-workspace-current]'
+            );
+        }
+        return getAiSessionPresentationCurrentCards(message, projectionRoot).length > 0;
+    }
+    function applyAiSessionPresentationDom(message) {
+        var currentCards = getAiSessionPresentationCurrentCards(message);
+        syncActiveAiSessionProjectionDom(message.revealFocused);
         if (!currentCards.length) return;
         var projectDiv = currentCards.find(card => card.hasAttribute('data-current-workspace'));
         var presentations = {};
@@ -498,6 +530,7 @@ function initAiSessionPresentationDom(options) {
 
     return {
         apply: applyAiSessionPresentationDom,
+        canApply: canApplyAiSessionPresentationDom,
     };
 }
 
@@ -547,7 +580,7 @@ function initProjectAiSessionsUpdate(options) {
             message: message,
             invalidPresentationReason: 'invalid-ai-session-presentation-envelope',
             invalidReplacementReason: 'invalid-ai-session-workspace-update',
-            replaceContent: () => applyWorkspaceUpdate({
+            replaceContent: validateReplacement => applyWorkspaceUpdate({
                 type: 'workspace-updated',
                 version: 2,
                 currentWorkspaceCount: message.currentWorkspaceCount,
@@ -556,6 +589,7 @@ function initProjectAiSessionsUpdate(options) {
                 canRestoreAiSessionProviderMenu: () =>
                     !getPendingAiSessionProviderSelectionProjectId()
                     && !batchAiSessionState.pending,
+                validateReplacement: validateReplacement,
             }),
             afterReplacement: () => {
                 if (batchAiSessionState.projectId) {

--- a/media/webviewProjectScripts.js
+++ b/media/webviewProjectScripts.js
@@ -269,6 +269,7 @@ function initProjects() {
     });
     var presentationTransactions = initAiSessionPresentationTransactions({
         isValidAiSessionPresentationState: aiSessionPresentationStateStore.isValid,
+        canApplyAiSessionPresentationState: aiSessionPresentationDom.canApply,
         applyValidatedAiSessionPresentationState: applyValidatedAiSessionPresentationState,
     });
     var aiSessionsUpdate = initProjectAiSessionsUpdate({
@@ -466,7 +467,10 @@ function initProjects() {
                 message: message,
                 invalidPresentationReason: 'invalid-open-workspaces-presentation-envelope',
                 invalidReplacementReason: 'invalid-open-workspaces-update',
-                replaceContent: () => applyOpenWorkspacesUpdate(message),
+                replaceContent: validateReplacement => applyOpenWorkspacesUpdate(
+                    message,
+                    { validateReplacement: validateReplacement }
+                ),
             })) {
                 return;
             }

--- a/media/webviewWorkspaceUpdateScripts.js
+++ b/media/webviewWorkspaceUpdateScripts.js
@@ -93,6 +93,10 @@ function applyWorkspaceUpdate(message, options) {
         || !isWorkspaceUpdateDomConsistent(message, replacement)) {
         return false;
     }
+    if (options && typeof options.validateReplacement === 'function'
+        && !options.validateReplacement(replacement)) {
+        return false;
+    }
 
     var aiSessionStates = captureCurrentWorkspaceAiSessionStates(currentGroup);
     var currentListScroll = captureOpenTabListScroll(
@@ -254,7 +258,7 @@ function completeOpenWorkspacePin(message) {
     return true;
 }
 
-function applyOpenWorkspacesUpdate(message) {
+function applyOpenWorkspacesUpdate(message, options) {
     if (!message
         || message.type !== 'open-workspaces-updated'
         || message.version !== 3
@@ -279,6 +283,18 @@ function applyOpenWorkspacesUpdate(message) {
     }
     var wrapper = document.querySelector('.sticky-groups-wrapper');
     if (!wrapper) return false;
+    var holder = null;
+    if (typeof document.createElement === 'function') {
+        holder = document.createElement('div');
+        holder.innerHTML = message.html;
+        if (!isOpenWorkspacesUpdateDomConsistent(message, holder)
+            || (options && typeof options.validateReplacement === 'function'
+                && !options.validateReplacement(holder))) {
+            return false;
+        }
+    } else if (options && typeof options.validateReplacement === 'function') {
+        return false;
+    }
     var previousHtml = wrapper.innerHTML;
     var focusedPinButton = document.activeElement
         && document.activeElement.matches?.(
@@ -292,7 +308,7 @@ function applyOpenWorkspacesUpdate(message) {
         OPEN_TAB_OTHER_ITEM_SELECTOR,
         'data-workspace-navigation-identity'
     );
-    wrapper.innerHTML = message.html;
+    wrapper.innerHTML = holder ? holder.innerHTML : message.html;
     if (!isOpenWorkspacesUpdateDomConsistent(message)) {
         wrapper.innerHTML = previousHtml;
         restoreOpenTabListScroll(
@@ -337,12 +353,14 @@ function applyOpenWorkspacesUpdate(message) {
     return true;
 }
 
-function getOpenWorkspacesUpdateDomState() {
-    var otherWindowsGroup = document.querySelector(
-        '.sticky-groups-wrapper .open-other-windows-group[data-other-windows-status]'
+function getOpenWorkspacesUpdateDomState(root) {
+    var projectionRoot = root || document;
+    var wrapperPrefix = root ? '' : '.sticky-groups-wrapper ';
+    var otherWindowsGroup = projectionRoot.querySelector(
+        wrapperPrefix + '.open-other-windows-group[data-other-windows-status]'
     );
-    var openWorkspaceCards = Array.from(document.querySelectorAll(
-        '.sticky-groups-wrapper .open-other-windows-group '
+    var openWorkspaceCards = Array.from(projectionRoot.querySelectorAll(
+        wrapperPrefix + '.open-other-windows-group '
         + '.workspace-card[data-open-workspace-list-card][data-workspace-navigation-identity]'
     ));
     var navigationCards = openWorkspaceCards.filter(card =>
@@ -352,15 +370,16 @@ function getOpenWorkspacesUpdateDomState() {
         card.getAttribute('data-workspace-navigation-identity')
     );
     return {
-        currentWorkspaceCount: document.querySelectorAll(
-            '.sticky-groups-wrapper .workspace-card[data-current-workspace][data-workspace-scope-identity]'
+        currentWorkspaceCount: projectionRoot.querySelectorAll(
+            wrapperPrefix
+                + '.workspace-card[data-current-workspace][data-workspace-scope-identity]'
         ).length,
         navigationWorkspaceCount: navigationCards.length,
         openWorkspaceListCount: openWorkspaceCards.length,
         hasUniqueNavigationIdentities: navigationIdentities.every(identity => !!identity)
             && new Set(navigationIdentities).size === navigationIdentities.length,
-        hasOtherWindowsGroup: document.querySelectorAll(
-            '.sticky-groups-wrapper .open-other-windows-group'
+        hasOtherWindowsGroup: projectionRoot.querySelectorAll(
+            wrapperPrefix + '.open-other-windows-group'
         ).length > 0,
         otherWindowsStatus: otherWindowsGroup
             ? otherWindowsGroup.getAttribute('data-other-windows-status')
@@ -368,8 +387,8 @@ function getOpenWorkspacesUpdateDomState() {
     };
 }
 
-function isOpenWorkspacesUpdateDomConsistent(message) {
-    var rendered = getOpenWorkspacesUpdateDomState();
+function isOpenWorkspacesUpdateDomConsistent(message, root) {
+    var rendered = getOpenWorkspacesUpdateDomState(root);
     return rendered.currentWorkspaceCount === message.currentWorkspaceCount
         && rendered.navigationWorkspaceCount === message.navigationWorkspaceCount
         && rendered.hasUniqueNavigationIdentities

--- a/scripts/run-architecture-guards.js
+++ b/scripts/run-architecture-guards.js
@@ -783,6 +783,52 @@ const guards = {
             'AI session Presentation transaction owner'
         );
         const transactionOwnerSource = transactionOwner.getText(webview);
+        const matchingWorkspaceOwner = uniqueAstNode(
+            transactionOwner,
+            node => ts.isFunctionDeclaration(node)
+                && node.name?.text === 'hasMatchingPresentationWorkspace',
+            this.id,
+            risk,
+            'Presentation workspace precondition owner'
+        );
+        const initialPresentationOwner = uniqueAstNode(
+            transactionOwner,
+            node => ts.isFunctionDeclaration(node)
+                && node.name?.text === 'applyInitialPresentation',
+            this.id,
+            risk,
+            'initial Presentation transaction owner'
+        );
+        const directPresentationOwner = uniqueAstNode(
+            transactionOwner,
+            node => ts.isFunctionDeclaration(node)
+                && node.name?.text === 'applyDirectPresentation',
+            this.id,
+            risk,
+            'direct Presentation transaction owner'
+        );
+        const initialPresentationSource = initialPresentationOwner.getText(webview);
+        const directPresentationSource = directPresentationOwner.getText(webview);
+        const matchingWorkspaceSource = matchingWorkspaceOwner.getText(webview);
+        const applyWorkspaceUpdateOwner = uniqueAstNode(
+            workspaceWebview,
+            node => ts.isFunctionDeclaration(node)
+                && node.name?.text === 'applyWorkspaceUpdate',
+            this.id,
+            risk,
+            'current workspace replacement owner'
+        );
+        const applyOpenWorkspacesUpdateOwner = uniqueAstNode(
+            workspaceWebview,
+            node => ts.isFunctionDeclaration(node)
+                && node.name?.text === 'applyOpenWorkspacesUpdate',
+            this.id,
+            risk,
+            'open workspaces replacement owner'
+        );
+        const applyWorkspaceUpdateSource = applyWorkspaceUpdateOwner.getText(workspaceWebview);
+        const applyOpenWorkspacesUpdateSource =
+            applyOpenWorkspacesUpdateOwner.getText(workspaceWebview);
         const aiUpdateOwner = uniqueAstNode(
             webview,
             node => ts.isFunctionDeclaration(node)
@@ -810,6 +856,11 @@ const guards = {
             && ts.isArrowFunction(aiReplaceContent.initializer)
             ? callArguments(aiReplaceContent.initializer, 'applyWorkspaceUpdate')
             : [];
+        const aiReplaceContentSource = aiReplaceContent
+            && ts.isPropertyAssignment(aiReplaceContent)
+            && ts.isArrowFunction(aiReplaceContent.initializer)
+            ? aiReplaceContent.initializer.getText(webview)
+            : '';
         const aiAfterReplacement = aiAtomicInput
             && ts.isObjectLiteralExpression(aiAtomicInput)
             ? aiAtomicInput.properties.find(property =>
@@ -1017,6 +1068,13 @@ const guards = {
                     && property.name.getText(projectWebview)
                         === 'isValidAiSessionPresentationState')
             : null;
+        const transactionWorkspaceOption = transactionOptions
+            && ts.isObjectLiteralExpression(transactionOptions)
+            ? transactionOptions.properties.find(property =>
+                ts.isPropertyAssignment(property)
+                    && property.name.getText(projectWebview)
+                        === 'canApplyAiSessionPresentationState')
+            : null;
         const legacyPresentationGlobals = [
             '__agentPivotAiSessionPresentationState',
             '__agentPivotAttentionSessionEvents',
@@ -1116,6 +1174,10 @@ const guards = {
             || !ts.isPropertyAssignment(transactionValidatorOption)
             || transactionValidatorOption.initializer.getText(projectWebview)
                 !== 'aiSessionPresentationStateStore.isValid'
+            || !transactionWorkspaceOption
+            || !ts.isPropertyAssignment(transactionWorkspaceOption)
+            || transactionWorkspaceOption.initializer.getText(projectWebview)
+                !== 'aiSessionPresentationDom.canApply'
             || !aiSessionControlsSource.includes(
                 'stateStore.getAttentionEventIds(provider, sessionId)'
             )
@@ -1161,6 +1223,8 @@ const guards = {
             'setCurrentWorkspaceSummaryAttentionDom',
             'setCurrentWorkspaceRunningDom',
             'setCurrentOpenWorkspaceSummaryDom',
+            'getAiSessionPresentationCurrentCards',
+            'canApplyAiSessionPresentationDom',
             'applyAiSessionPresentationDom',
         ];
         const presentationDomHelpers = presentationDomHelperNames.map(name =>
@@ -1173,7 +1237,11 @@ const guards = {
             )
         );
         const presentationApplyOwner = presentationDomHelpers.at(-1);
+        const presentationCanApplyOwner = presentationDomHelpers.at(-2);
+        const presentationCurrentCardsOwner = presentationDomHelpers.at(-3);
         const presentationApplySource = presentationApplyOwner.getText(webview);
+        const presentationCanApplySource = presentationCanApplyOwner.getText(webview);
+        const presentationCurrentCardsSource = presentationCurrentCardsOwner.getText(webview);
         const presentationDomPublicReturn = uniqueAstNode(
             presentationDomOwner,
             node => ts.isReturnStatement(node)
@@ -1187,6 +1255,8 @@ const guards = {
         );
         const presentationDomPublicApply = presentationDomPublicReturn.expression.properties
             .find(property => property.name?.getText(webview) === 'apply');
+        const presentationDomPublicCanApply = presentationDomPublicReturn.expression.properties
+            .find(property => property.name?.getText(webview) === 'canApply');
         const presentationDomCalls = callArguments(
             projectWebview,
             'initAiSessionPresentationDom'
@@ -1348,29 +1418,35 @@ const guards = {
             || presentationDomStateStoreOption.initializer.getText(projectWebview)
                 !== 'aiSessionPresentationStateStore'
             || !focusedTargetProjectionState.initializer
-            || !ts.isConditionalExpression(focusedTargetProjectionState.initializer)
-            || !ts.isIdentifier(focusedTargetProjectionState.initializer.condition)
-            || focusedTargetProjectionState.initializer.condition.text
-                !== 'hasMatchingWorkspace'
-            || !ts.isCallExpression(focusedTargetProjectionState.initializer.whenTrue)
-            || focusedTargetProjectionState.initializer.whenTrue.arguments.length !== 0
+            || !ts.isCallExpression(focusedTargetProjectionState.initializer)
+            || focusedTargetProjectionState.initializer.arguments.length !== 0
             || !ts.isPropertyAccessExpression(
-                focusedTargetProjectionState.initializer.whenTrue.expression
+                focusedTargetProjectionState.initializer.expression
             )
-            || focusedTargetProjectionState.initializer.whenTrue.expression.getText(webview)
+            || focusedTargetProjectionState.initializer.expression.getText(webview)
                 !== 'presentationStateStore.getFocusedTarget'
-            || focusedTargetProjectionState.initializer.whenFalse.kind
-                !== ts.SyntaxKind.NullKeyword
             || focusedTargetProjectionAssignments.length !== 0
             || focusedTargetProjectionCalls.length !== 1
             || focusedTargetDomOwnerCalls.length !== 1
             || focusedTargetControlsCalls.length !== 0
             || focusedTargetProjectInitCalls.length !== 0
             || focusProjectionSource.includes('[data-session-focused]')
-            || focusProjectionOwner.parameters.length !== 2
+            || focusProjectionOwner.parameters.length !== 1
             || focusProjectionOwner.parameters[0].name.getText(webview)
-                !== 'hasMatchingWorkspace'
-            || focusProjectionOwner.parameters[1].name.getText(webview) !== 'revealFocused'
+                !== 'revealFocused'
+            || !presentationDomPublicCanApply
+            || !ts.isPropertyAssignment(presentationDomPublicCanApply)
+            || presentationDomPublicCanApply.initializer.getText(webview)
+                !== 'canApplyAiSessionPresentationDom'
+            || !presentationCanApplySource.includes(
+                'message.workspaceNavigationIdentity === null'
+            )
+            || !presentationCanApplySource.includes('[data-current-workspace]')
+            || !presentationCanApplySource.includes('[data-open-workspace-current]')
+            || callArguments(
+                presentationCanApplyOwner,
+                'getAiSessionPresentationCurrentCards'
+            ).length !== 1
             || callArguments(
                 applyValidatedPresentation,
                 'aiSessionPresentationDom.apply'
@@ -1396,10 +1472,11 @@ const guards = {
             || adoptPresentationIndex < 0
             || projectPresentationIndex <= adoptPresentationIndex
             || reconcileAcknowledgementsIndex <= projectPresentationIndex
-            || presentationDomHelperNames.slice(0, -1).some(name =>
+            || presentationDomHelperNames.slice(0, -1)
+                .filter(name => name !== 'canApplyAiSessionPresentationDom').some(name =>
                 callArguments(presentationApplyOwner, name).length < 1)
-            || !presentationApplySource.includes('[data-current-workspace]')
-            || !presentationApplySource.includes('[data-open-workspace-current]')
+            || !presentationCurrentCardsSource.includes('[data-current-workspace]')
+            || !presentationCurrentCardsSource.includes('[data-open-workspace-current]')
             || presentationMutationNodes.length !== 28
             || presentationMutationNodes.some(({ node, sourceFile }) =>
                 sourceFile.fileName !== webview.fileName
@@ -1452,11 +1529,80 @@ const guards = {
             fail(this.id, risk,
                 'OPEN HTML and Presentation must share one Host message');
         }
+        const initialWorkspaceIndex = initialPresentationSource.indexOf(
+            '!hasMatchingPresentationWorkspace(message)'
+        );
+        const initialRevisionIndex = initialPresentationSource.indexOf(
+            'acceptInitialPresentationProjectionRevision(message.projectionRevision)'
+        );
+        const directWorkspaceIndex = directPresentationSource.indexOf(
+            '!hasMatchingPresentationWorkspace(message)'
+        );
+        const directRevisionIndex = directPresentationSource.indexOf(
+            'acceptPresentationProjectionRevision(message.projectionRevision)'
+        );
+        if (!matchingWorkspaceSource.includes(
+            'canApplyAiSessionPresentationState(message)'
+        ) || !matchingWorkspaceSource.includes(
+            "requestFullRefresh('mismatched-ai-session-presentation-workspace')"
+        ) || callArguments(
+            transactionOwner,
+            'hasMatchingPresentationWorkspace'
+        ).length !== 3
+            || !transactionOwnerSource.includes(
+                'replacementWorkspaceMatches = canApplyAiSessionPresentationState('
+            )
+            || !transactionOwnerSource.includes('replacementWorkspaceMatches === false')
+            || aiReplaceContentSource.includes('() => applyWorkspaceUpdate(')
+            || !aiReplaceContentSource.includes('validateReplacement => applyWorkspaceUpdate(')
+            || !aiReplaceContentSource.includes(
+                'validateReplacement: validateReplacement'
+            )
+            || !projectWebviewSource.includes(
+                'replaceContent: validateReplacement => applyOpenWorkspacesUpdate('
+            )
+            || !projectWebviewSource.includes(
+                '{ validateReplacement: validateReplacement }'
+            )
+            || callArguments(
+                applyWorkspaceUpdateOwner,
+                'options.validateReplacement'
+            ).length !== 1
+            || callArguments(
+                applyOpenWorkspacesUpdateOwner,
+                'options.validateReplacement'
+            ).length !== 1
+            || applyWorkspaceUpdateSource.indexOf(
+                '!isWorkspaceUpdateDomConsistent(message, replacement)'
+            ) >= applyWorkspaceUpdateSource.indexOf(
+                '!options.validateReplacement(replacement)'
+            )
+            || applyWorkspaceUpdateSource.indexOf(
+                '!options.validateReplacement(replacement)'
+            ) >= applyWorkspaceUpdateSource.indexOf('currentGroup.replaceWith(replacement)')
+            || applyOpenWorkspacesUpdateSource.indexOf(
+                '!isOpenWorkspacesUpdateDomConsistent(message, holder)'
+            ) >= applyOpenWorkspacesUpdateSource.indexOf(
+                '!options.validateReplacement(holder)'
+            )
+            || applyOpenWorkspacesUpdateSource.indexOf(
+                '!options.validateReplacement(holder)'
+            ) >= applyOpenWorkspacesUpdateSource.indexOf(
+                'wrapper.innerHTML = holder ? holder.innerHTML : message.html'
+            )
+            || initialWorkspaceIndex < 0
+            || initialRevisionIndex <= initialWorkspaceIndex
+            || directWorkspaceIndex < 0
+            || directRevisionIndex <= directWorkspaceIndex) {
+            fail(this.id, risk,
+                'every Presentation must match the rendered workspace before revision adoption');
+        }
         const transactionOrder = [
             '!isValidAiSessionPresentationState(message.presentation)',
             '!canApplyProjectionRevision(message.projectionRevision)',
             '!canApplyAtomicPresentationProjectionRevision(message.projectionRevision)',
-            '!input.replaceContent()',
+            '!input.replaceContent(replacementRoot =>',
+            '!hasMatchingPresentationWorkspace(message.presentation)',
             'commitAtomicProjectionRevision(message.projectionRevision)',
             "typeof input.afterReplacement === 'function'",
             'applyValidatedAiSessionPresentationState(message.presentation)',

--- a/src/webview/webviewProjectAiUpdateScripts.js
+++ b/src/webview/webviewProjectAiUpdateScripts.js
@@ -90,6 +90,7 @@ function initAiSessionPresentationTransactions(options) {
 
     options = options || {};
     var isValidAiSessionPresentationState = options.isValidAiSessionPresentationState;
+    var canApplyAiSessionPresentationState = options.canApplyAiSessionPresentationState;
     var applyValidatedAiSessionPresentationState = options.applyValidatedAiSessionPresentationState;
     var latestAiSessionProjectionRevision = 0;
     var latestAiSessionPresentationProjectionRevision = 0;
@@ -100,6 +101,12 @@ function initAiSessionPresentationTransactions(options) {
             type: 'request-full-refresh',
             reason,
         });
+    }
+
+    function hasMatchingPresentationWorkspace(message) {
+        if (canApplyAiSessionPresentationState(message)) return true;
+        requestFullRefresh('mismatched-ai-session-presentation-workspace');
+        return false;
     }
 
     function canApplyRevision(revision, latestRevision) {
@@ -165,6 +172,7 @@ function initAiSessionPresentationTransactions(options) {
             requestFullRefresh('invalid-initial-ai-session-presentation-state');
             return false;
         }
+        if (!hasMatchingPresentationWorkspace(message)) return false;
         if (!acceptInitialPresentationProjectionRevision(message.projectionRevision)) {
             return false;
         }
@@ -178,6 +186,7 @@ function initAiSessionPresentationTransactions(options) {
             requestFullRefresh('invalid-direct-ai-session-presentation-state');
             return false;
         }
+        if (!hasMatchingPresentationWorkspace(message)) return false;
         if (!acceptPresentationProjectionRevision(message.projectionRevision)) {
             return false;
         }
@@ -199,10 +208,20 @@ function initAiSessionPresentationTransactions(options) {
             || !canApplyAtomicPresentationProjectionRevision(message.projectionRevision)) {
             return false;
         }
-        if (!input.replaceContent()) {
-            requestFullRefresh(input.invalidReplacementReason);
+        var replacementWorkspaceMatches = null;
+        if (!input.replaceContent(replacementRoot => {
+            replacementWorkspaceMatches = canApplyAiSessionPresentationState(
+                message.presentation,
+                replacementRoot
+            );
+            return replacementWorkspaceMatches;
+        })) {
+            requestFullRefresh(replacementWorkspaceMatches === false
+                ? 'mismatched-ai-session-presentation-workspace'
+                : input.invalidReplacementReason);
             return false;
         }
+        if (!hasMatchingPresentationWorkspace(message.presentation)) return false;
         commitAtomicProjectionRevision(message.projectionRevision);
         if (typeof input.afterReplacement === 'function') {
             input.afterReplacement();
@@ -225,10 +244,8 @@ function initAiSessionPresentationDom(options) {
     options = options || {};
     var presentationStateStore = options.presentationStateStore;
 
-    function syncActiveAiSessionProjectionDom(hasMatchingWorkspace, revealFocused) {
-        var focusedTarget = hasMatchingWorkspace
-            ? presentationStateStore.getFocusedTarget()
-            : null;
+    function syncActiveAiSessionProjectionDom(revealFocused) {
+        var focusedTarget = presentationStateStore.getFocusedTarget();
         var projectedFocusedRow = null;
         document.querySelectorAll(
             '.codex-session-row[data-session-provider][data-session-id],'
@@ -447,8 +464,10 @@ function initAiSessionPresentationDom(options) {
         );
         setCurrentWorkspaceRunningDom(projectDiv, message);
     }
-    function applyAiSessionPresentationDom(message) {
-        var currentCards = Array.from(document.querySelectorAll(
+    function getAiSessionPresentationCurrentCards(message, root) {
+        if (typeof message.workspaceNavigationIdentity !== 'string'
+            || !message.workspaceNavigationIdentity) return [];
+        return Array.from((root || document).querySelectorAll(
             '.workspace-card[data-workspace-navigation-identity="'
                 + CSS.escape(message.workspaceNavigationIdentity || '') + '"]'
                 + '[data-current-workspace],'
@@ -456,7 +475,20 @@ function initAiSessionPresentationDom(options) {
                 + CSS.escape(message.workspaceNavigationIdentity || '') + '"]'
                 + '[data-open-workspace-current]'
         ));
-        syncActiveAiSessionProjectionDom(currentCards.length > 0, message.revealFocused);
+    }
+    function canApplyAiSessionPresentationDom(message, root) {
+        var projectionRoot = root || document;
+        if (message.workspaceNavigationIdentity === null) {
+            return !projectionRoot.querySelector(
+                '.workspace-card[data-current-workspace],'
+                    + '.workspace-card[data-open-workspace-current]'
+            );
+        }
+        return getAiSessionPresentationCurrentCards(message, projectionRoot).length > 0;
+    }
+    function applyAiSessionPresentationDom(message) {
+        var currentCards = getAiSessionPresentationCurrentCards(message);
+        syncActiveAiSessionProjectionDom(message.revealFocused);
         if (!currentCards.length) return;
         var projectDiv = currentCards.find(card => card.hasAttribute('data-current-workspace'));
         var presentations = {};
@@ -498,6 +530,7 @@ function initAiSessionPresentationDom(options) {
 
     return {
         apply: applyAiSessionPresentationDom,
+        canApply: canApplyAiSessionPresentationDom,
     };
 }
 
@@ -547,7 +580,7 @@ function initProjectAiSessionsUpdate(options) {
             message: message,
             invalidPresentationReason: 'invalid-ai-session-presentation-envelope',
             invalidReplacementReason: 'invalid-ai-session-workspace-update',
-            replaceContent: () => applyWorkspaceUpdate({
+            replaceContent: validateReplacement => applyWorkspaceUpdate({
                 type: 'workspace-updated',
                 version: 2,
                 currentWorkspaceCount: message.currentWorkspaceCount,
@@ -556,6 +589,7 @@ function initProjectAiSessionsUpdate(options) {
                 canRestoreAiSessionProviderMenu: () =>
                     !getPendingAiSessionProviderSelectionProjectId()
                     && !batchAiSessionState.pending,
+                validateReplacement: validateReplacement,
             }),
             afterReplacement: () => {
                 if (batchAiSessionState.projectId) {

--- a/src/webview/webviewProjectScripts.js
+++ b/src/webview/webviewProjectScripts.js
@@ -269,6 +269,7 @@ function initProjects() {
     });
     var presentationTransactions = initAiSessionPresentationTransactions({
         isValidAiSessionPresentationState: aiSessionPresentationStateStore.isValid,
+        canApplyAiSessionPresentationState: aiSessionPresentationDom.canApply,
         applyValidatedAiSessionPresentationState: applyValidatedAiSessionPresentationState,
     });
     var aiSessionsUpdate = initProjectAiSessionsUpdate({
@@ -466,7 +467,10 @@ function initProjects() {
                 message: message,
                 invalidPresentationReason: 'invalid-open-workspaces-presentation-envelope',
                 invalidReplacementReason: 'invalid-open-workspaces-update',
-                replaceContent: () => applyOpenWorkspacesUpdate(message),
+                replaceContent: validateReplacement => applyOpenWorkspacesUpdate(
+                    message,
+                    { validateReplacement: validateReplacement }
+                ),
             })) {
                 return;
             }

--- a/src/webview/webviewWorkspaceUpdateScripts.js
+++ b/src/webview/webviewWorkspaceUpdateScripts.js
@@ -93,6 +93,10 @@ function applyWorkspaceUpdate(message, options) {
         || !isWorkspaceUpdateDomConsistent(message, replacement)) {
         return false;
     }
+    if (options && typeof options.validateReplacement === 'function'
+        && !options.validateReplacement(replacement)) {
+        return false;
+    }
 
     var aiSessionStates = captureCurrentWorkspaceAiSessionStates(currentGroup);
     var currentListScroll = captureOpenTabListScroll(
@@ -254,7 +258,7 @@ function completeOpenWorkspacePin(message) {
     return true;
 }
 
-function applyOpenWorkspacesUpdate(message) {
+function applyOpenWorkspacesUpdate(message, options) {
     if (!message
         || message.type !== 'open-workspaces-updated'
         || message.version !== 3
@@ -279,6 +283,18 @@ function applyOpenWorkspacesUpdate(message) {
     }
     var wrapper = document.querySelector('.sticky-groups-wrapper');
     if (!wrapper) return false;
+    var holder = null;
+    if (typeof document.createElement === 'function') {
+        holder = document.createElement('div');
+        holder.innerHTML = message.html;
+        if (!isOpenWorkspacesUpdateDomConsistent(message, holder)
+            || (options && typeof options.validateReplacement === 'function'
+                && !options.validateReplacement(holder))) {
+            return false;
+        }
+    } else if (options && typeof options.validateReplacement === 'function') {
+        return false;
+    }
     var previousHtml = wrapper.innerHTML;
     var focusedPinButton = document.activeElement
         && document.activeElement.matches?.(
@@ -292,7 +308,7 @@ function applyOpenWorkspacesUpdate(message) {
         OPEN_TAB_OTHER_ITEM_SELECTOR,
         'data-workspace-navigation-identity'
     );
-    wrapper.innerHTML = message.html;
+    wrapper.innerHTML = holder ? holder.innerHTML : message.html;
     if (!isOpenWorkspacesUpdateDomConsistent(message)) {
         wrapper.innerHTML = previousHtml;
         restoreOpenTabListScroll(
@@ -337,12 +353,14 @@ function applyOpenWorkspacesUpdate(message) {
     return true;
 }
 
-function getOpenWorkspacesUpdateDomState() {
-    var otherWindowsGroup = document.querySelector(
-        '.sticky-groups-wrapper .open-other-windows-group[data-other-windows-status]'
+function getOpenWorkspacesUpdateDomState(root) {
+    var projectionRoot = root || document;
+    var wrapperPrefix = root ? '' : '.sticky-groups-wrapper ';
+    var otherWindowsGroup = projectionRoot.querySelector(
+        wrapperPrefix + '.open-other-windows-group[data-other-windows-status]'
     );
-    var openWorkspaceCards = Array.from(document.querySelectorAll(
-        '.sticky-groups-wrapper .open-other-windows-group '
+    var openWorkspaceCards = Array.from(projectionRoot.querySelectorAll(
+        wrapperPrefix + '.open-other-windows-group '
         + '.workspace-card[data-open-workspace-list-card][data-workspace-navigation-identity]'
     ));
     var navigationCards = openWorkspaceCards.filter(card =>
@@ -352,15 +370,16 @@ function getOpenWorkspacesUpdateDomState() {
         card.getAttribute('data-workspace-navigation-identity')
     );
     return {
-        currentWorkspaceCount: document.querySelectorAll(
-            '.sticky-groups-wrapper .workspace-card[data-current-workspace][data-workspace-scope-identity]'
+        currentWorkspaceCount: projectionRoot.querySelectorAll(
+            wrapperPrefix
+                + '.workspace-card[data-current-workspace][data-workspace-scope-identity]'
         ).length,
         navigationWorkspaceCount: navigationCards.length,
         openWorkspaceListCount: openWorkspaceCards.length,
         hasUniqueNavigationIdentities: navigationIdentities.every(identity => !!identity)
             && new Set(navigationIdentities).size === navigationIdentities.length,
-        hasOtherWindowsGroup: document.querySelectorAll(
-            '.sticky-groups-wrapper .open-other-windows-group'
+        hasOtherWindowsGroup: projectionRoot.querySelectorAll(
+            wrapperPrefix + '.open-other-windows-group'
         ).length > 0,
         otherWindowsStatus: otherWindowsGroup
             ? otherWindowsGroup.getAttribute('data-other-windows-status')
@@ -368,8 +387,8 @@ function getOpenWorkspacesUpdateDomState() {
     };
 }
 
-function isOpenWorkspacesUpdateDomConsistent(message) {
-    var rendered = getOpenWorkspacesUpdateDomState();
+function isOpenWorkspacesUpdateDomConsistent(message, root) {
+    var rendered = getOpenWorkspacesUpdateDomState(root);
     return rendered.currentWorkspaceCount === message.currentWorkspaceCount
         && rendered.navigationWorkspaceCount === message.navigationWorkspaceCount
         && rendered.hasUniqueNavigationIdentities

--- a/tests/browser/activeSessionCardInteraction.test.js
+++ b/tests/browser/activeSessionCardInteraction.test.js
@@ -776,18 +776,26 @@ test('ACTIVE-SESSION-FOCUS-REVEAL-001 keeps a newer complete presentation when o
     );
 });
 
-test('ACTIVE-SESSION-FOCUS-REVEAL-001 clears stale card focus when another workspace has the same session identity', async t => {
+test('ACTIVE-SESSION-FOCUS-REVEAL-001 keeps the focused card highlight when another workspace has the same session identity', async t => {
     const initial = [
         session('codex', 'session-a', true),
         session('codex', 'session-b', false),
     ];
     const page = await openCardPage(t, initial);
+    await page.addStyleTag({
+        content: ':root { --vscode-focusBorder: rgb(0, 127, 212); }'
+            + ' *, *::before, *::after { transition: none !important; }',
+    });
     const focusedRow = row(page, 'codex', 'session-a');
     const primaryAction = focusedRow.locator('.ai-session-primary-action');
     await postHostMessage(page, presentationMessage(initial, 2, { revealFocused: true }));
     assert.equal(await focusedRow.getAttribute('data-session-focused'), '');
     assert.equal(await focusedRow.getAttribute('data-ai-session-active-terminal'), '');
     assert.equal(await primaryAction.getAttribute('title'), 'Open AI conversation for Codex Session');
+    assert.match(
+        await focusedRow.evaluate(element => getComputedStyle(element).boxShadow),
+        /rgba?\(0, 127, 212/
+    );
 
     const otherWorkspacePresentation = presentationMessage(
         initial,
@@ -801,12 +809,109 @@ test('ACTIVE-SESSION-FOCUS-REVEAL-001 clears stale card focus when another works
     otherWorkspacePresentation.workspaceNavigationIdentity = 'navigation-project-b';
     await postHostMessage(page, otherWorkspacePresentation);
 
-    assert.equal(await focusedRow.getAttribute('data-session-focused'), null);
-    assert.equal(await focusedRow.getAttribute('data-ai-session-active-terminal'), null);
-    assert.equal(await focusedRow.locator('.ai-session-open-conversation-hint').count(), 0);
-    assert.equal(await primaryAction.getAttribute('title'), 'Focus Codex Session');
+    assert.equal(await focusedRow.getAttribute('data-session-focused'), '');
+    assert.equal(await focusedRow.getAttribute('data-ai-session-active-terminal'), '');
+    assert.equal(await focusedRow.locator('.ai-session-open-conversation-hint').count(), 1);
+    assert.equal(await primaryAction.getAttribute('title'), 'Open AI conversation for Codex Session');
+    assert.match(
+        await focusedRow.evaluate(element => getComputedStyle(element).boxShadow),
+        /rgba?\(0, 127, 212/
+    );
+    await page.setViewportSize({ width: 240, height: 900 });
+    assert.match(
+        await focusedRow.evaluate(element => getComputedStyle(element).boxShadow),
+        /rgba?\(0, 127, 212/
+    );
+    assert.deepEqual((await postedMessages(page)).at(-1), {
+        type: 'request-full-refresh',
+        reason: 'mismatched-ai-session-presentation-workspace',
+    });
+
+    await page.evaluate(() => { window.__postedMessages.length = 0; });
+    const replacement = [session('codex', 'session-c', true)];
+    for (const envelope of [
+        aiSessionsEnvelope(replacement, 4, {
+            presentationOverrides: {
+                workspaceScopeIdentity: 'scope-project-b',
+                workspaceNavigationIdentity: 'navigation-project-b',
+            },
+        }),
+        openWorkspacesEnvelope(replacement, 5, {
+            presentationOverrides: {
+                workspaceScopeIdentity: 'scope-project-b',
+                workspaceNavigationIdentity: 'navigation-project-b',
+            },
+        }),
+    ]) {
+        await postHostMessage(page, envelope);
+        assert.equal(await row(page, 'codex', 'session-c').count(), 0);
+        assert.equal(await focusedRow.getAttribute('data-session-focused'), '');
+        assert.match(
+            await focusedRow.evaluate(element => getComputedStyle(element).boxShadow),
+            /rgba?\(0, 127, 212/
+        );
+        assert.deepEqual((await postedMessages(page)).at(-1), {
+            type: 'request-full-refresh',
+            reason: 'mismatched-ai-session-presentation-workspace',
+        });
+    }
+    await postHostMessage(page, presentationMessage(initial, 5, { revealFocused: true }));
+    assert.equal(await focusedRow.getAttribute('data-session-focused'), '',
+        'a rejected workspace envelope must not commit its projection revision');
     await primaryAction.click();
-    assert.equal((await postedMessages(page)).at(-1).type, 'focus-ai-session-terminal');
+    assert.equal((await postedMessages(page)).at(-1).type, 'open-active-ai-session-conversation');
+});
+
+test('ACTIVE-SESSION-FOCUS-REVEAL-001 rejects a reused OPEN semantic revision before adopting another workspace focus', async t => {
+    const initial = [session('codex', 'session-a', true)];
+    const page = await openCardPage(t, initial);
+    await page.addStyleTag({
+        content: ':root { --vscode-focusBorder: rgb(0, 127, 212); }'
+            + ' *, *::before, *::after { transition: none !important; }',
+    });
+    await postHostMessage(page, openWorkspacesEnvelope(initial, 2, {
+        semanticRevision: 'reused-open-revision',
+    }));
+    await page.evaluate(() => { window.__postedMessages.length = 0; });
+
+    const otherWorkspace = openWorkspacesEnvelope(
+        [session('codex', 'session-b', true)],
+        3,
+        {
+            semanticRevision: 'reused-open-revision',
+            presentationOverrides: {
+                workspaceScopeIdentity: 'scope-project-b',
+                workspaceNavigationIdentity: 'navigation-project-b',
+            },
+        }
+    );
+    otherWorkspace.html = `${currentWorkspaceGroupMarkup(
+        [session('codex', 'session-b', true)],
+        0,
+        {
+            scopeIdentity: 'scope-project-b',
+            navigationIdentity: 'navigation-project-b',
+        }
+    )}<div class="open-other-windows-group" data-other-windows-status="ready">
+        ${currentOpenWorkspaceProjectMarkup()}
+    </div>`;
+    await postHostMessage(page, otherWorkspace);
+
+    const focusedRow = row(page, 'codex', 'session-a');
+    assert.equal(await focusedRow.getAttribute('data-session-focused'), '');
+    assert.equal(await row(page, 'codex', 'session-b').count(), 0);
+    assert.match(
+        await focusedRow.evaluate(element => getComputedStyle(element).boxShadow),
+        /rgba?\(0, 127, 212/
+    );
+    assert.deepEqual(await postedMessages(page), [{
+        type: 'request-full-refresh',
+        reason: 'mismatched-ai-session-presentation-workspace',
+    }]);
+
+    await postHostMessage(page, presentationMessage(initial, 3, { revealFocused: true }));
+    assert.equal(await focusedRow.getAttribute('data-session-focused'), '',
+        'the rejected no-op replacement must not commit its projection revision');
 });
 
 test('ACTIVE-SESSION-INCREMENTAL-PRESENTATION-ENVELOPE-001 rejects legacy AI update messages', async t => {
@@ -1644,13 +1749,18 @@ test('ATTENTION-SESSION-CARD-ACKNOWLEDGEMENT-001 scopes pending acknowledgement 
         message.type === 'acknowledge-ai-session-attention'
     );
 
-    await postHostMessage(page, aiSessionsEnvelope([attentionSession], 6, {
+    const workspaceBEnvelope = aiSessionsEnvelope([attentionSession], 6, {
             attention: { 'codex:session-a': ['event-a'] },
             presentationOverrides: {
                 workspaceScopeIdentity: 'scope-project-b',
                 workspaceNavigationIdentity: 'navigation-project-b',
             },
-        }));
+        });
+    workspaceBEnvelope.html = currentWorkspaceGroupMarkup([attentionSession], 1, {
+        scopeIdentity: 'scope-project-b',
+        navigationIdentity: 'navigation-project-b',
+    });
+    await postHostMessage(page, workspaceBEnvelope);
     await page.evaluate(() => {
         window.__agentPivotAttentionAcknowledgementTimeoutMs = 1_000;
         window.__agentPivotAcknowledgeSession('codex', 'session-a');

--- a/tests/unit/tooling/architectureGuards.test.js
+++ b/tests/unit/tooling/architectureGuards.test.js
@@ -838,8 +838,8 @@ for (const mutation of [
         expectedDetail: 'session-bearing workspace HTML must have no standalone replacement path outside atomic Presentation envelopes',
         mutate: source => replaceFixtureSource(
             source,
-            'replaceContent: () => applyWorkspaceUpdate({',
-            'replaceContent: () => applyOpenWorkspacesUpdate({'
+            'replaceContent: validateReplacement => applyWorkspaceUpdate({',
+            'replaceContent: validateReplacement => applyOpenWorkspacesUpdate({'
         ),
     },
     {
@@ -848,9 +848,9 @@ for (const mutation of [
         expectedDetail: 'session-bearing workspace HTML must have no standalone replacement path outside atomic Presentation envelopes',
         mutate: source => replaceFixtureSource(
             source,
-            'replaceContent: () => applyWorkspaceUpdate({',
-            'replaceContent: () => true,\n'
-                + '            detachedWorkspaceReplacement: () => applyWorkspaceUpdate({'
+            'replaceContent: validateReplacement => applyWorkspaceUpdate({',
+            'replaceContent: validateReplacement => true,\n'
+                + '            detachedWorkspaceReplacement: validateReplacement => applyWorkspaceUpdate({'
         ),
     },
     {
@@ -1190,12 +1190,8 @@ for (const mutation of [
         expectedDetail: 'every Session Presentation DOM surface must belong to the single AI update projector',
         mutate: source => replaceFixtureSource(
             source,
-            'var focusedTarget = hasMatchingWorkspace\n'
-                + '            ? presentationStateStore.getFocusedTarget()\n'
-                + '            : null;',
-            'var focusedTarget = hasMatchingWorkspace\n'
-                + '            ? presentationStateStore.getFocusedTarget()\n'
-                + '            : null;\n'
+            'var focusedTarget = presentationStateStore.getFocusedTarget();',
+            'var focusedTarget = presentationStateStore.getFocusedTarget();\n'
                 + '        focusedTarget = null;'
         ),
     },
@@ -1451,6 +1447,112 @@ for (const mutation of [
     },
     {
         id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectScripts.js',
+        expectedDetail: 'every accepted Session Presentation and attention owner lookup must belong to the single state store',
+        mutate: source => replaceFixtureSource(
+            source,
+            'canApplyAiSessionPresentationState: aiSessionPresentationDom.canApply,',
+            'canApplyAiSessionPresentationState: () => true,'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectAiUpdateScripts.js',
+        expectedDetail: 'every Session Presentation DOM surface must belong to the single AI update projector',
+        mutate: source => replaceFixtureSource(
+            source,
+            'return getAiSessionPresentationCurrentCards(message, projectionRoot).length > 0;',
+            'return true;'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectAiUpdateScripts.js',
+        expectedDetail: 'every Presentation must match the rendered workspace before revision adoption',
+        mutate: source => replaceFixtureSource(
+            source,
+            'validateReplacement: validateReplacement,',
+            'validateReplacement: () => true,'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectScripts.js',
+        expectedDetail: 'every Presentation must match the rendered workspace before revision adoption',
+        mutate: source => replaceFixtureSource(
+            source,
+            '{ validateReplacement: validateReplacement }',
+            '{ validateReplacement: () => true }'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewWorkspaceUpdateScripts.js',
+        expectedDetail: 'every Presentation must match the rendered workspace before revision adoption',
+        mutate: source => replaceFixtureSource(
+            source,
+            '&& !options.validateReplacement(replacement)',
+            '&& false'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewWorkspaceUpdateScripts.js',
+        expectedDetail: 'every Presentation must match the rendered workspace before revision adoption',
+        mutate: source => replaceFixtureSource(
+            source,
+            '&& !options.validateReplacement(holder)',
+            '&& false'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectAiUpdateScripts.js',
+        expectedDetail: 'every Presentation must match the rendered workspace before revision adoption',
+        mutate: source => replaceFixtureSource(
+            source,
+            "requestFullRefresh('invalid-direct-ai-session-presentation-state');\n"
+                + '            return false;\n'
+                + '        }\n'
+                + '        if (!hasMatchingPresentationWorkspace(message)) return false;\n'
+                + '        if (!acceptPresentationProjectionRevision(message.projectionRevision)) {',
+            "requestFullRefresh('invalid-direct-ai-session-presentation-state');\n"
+                + '            return false;\n'
+                + '        }\n'
+                + '        if (!acceptPresentationProjectionRevision(message.projectionRevision)) {'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectAiUpdateScripts.js',
+        expectedDetail: 'every Presentation must match the rendered workspace before revision adoption',
+        mutate: source => replaceFixtureSource(
+            source,
+            "requestFullRefresh('invalid-initial-ai-session-presentation-state');\n"
+                + '            return false;\n'
+                + '        }\n'
+                + '        if (!hasMatchingPresentationWorkspace(message)) return false;\n'
+                + '        if (!acceptInitialPresentationProjectionRevision(message.projectionRevision)) {',
+            "requestFullRefresh('invalid-initial-ai-session-presentation-state');\n"
+                + '            return false;\n'
+                + '        }\n'
+                + '        if (!acceptInitialPresentationProjectionRevision(message.projectionRevision)) {'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/webview/webviewProjectAiUpdateScripts.js',
+        expectedDetail: 'Webview must validate v3 envelopes atomically and reserve direct Presentation for focus',
+        mutate: source => replaceFixtureSource(
+            source,
+            'if (!hasMatchingPresentationWorkspace(message.presentation)) return false;\n'
+                + '        commitAtomicProjectionRevision(message.projectionRevision);',
+            'commitAtomicProjectionRevision(message.projectionRevision);\n'
+                + '        if (!hasMatchingPresentationWorkspace(message.presentation)) return false;'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
         file: 'src/webview/webviewProjectAiUpdateScripts.js',
         expectedDetail: 'Webview must validate v3 envelopes atomically and reserve direct Presentation for focus',
         mutate: source => replaceFixtureSource(
@@ -1465,16 +1567,36 @@ for (const mutation of [
         expectedDetail: 'Webview must validate v3 envelopes atomically and reserve direct Presentation for focus',
         mutate: source => replaceFixtureSource(
             source,
-            "if (!input.replaceContent()) {\n"
-                + "            requestFullRefresh(input.invalidReplacementReason);\n"
+            "var replacementWorkspaceMatches = null;\n"
+                + "        if (!input.replaceContent(replacementRoot => {\n"
+                + "            replacementWorkspaceMatches = canApplyAiSessionPresentationState(\n"
+                + "                message.presentation,\n"
+                + "                replacementRoot\n"
+                + "            );\n"
+                + "            return replacementWorkspaceMatches;\n"
+                + "        })) {\n"
+                + "            requestFullRefresh(replacementWorkspaceMatches === false\n"
+                + "                ? 'mismatched-ai-session-presentation-workspace'\n"
+                + "                : input.invalidReplacementReason);\n"
                 + "            return false;\n"
                 + "        }\n"
+                + "        if (!hasMatchingPresentationWorkspace(message.presentation)) return false;\n"
                 + "        commitAtomicProjectionRevision(message.projectionRevision);",
             "commitAtomicProjectionRevision(message.projectionRevision);\n"
-                + "        if (!input.replaceContent()) {\n"
-                + "            requestFullRefresh(input.invalidReplacementReason);\n"
+                + "        var replacementWorkspaceMatches = null;\n"
+                + "        if (!input.replaceContent(replacementRoot => {\n"
+                + "            replacementWorkspaceMatches = canApplyAiSessionPresentationState(\n"
+                + "                message.presentation,\n"
+                + "                replacementRoot\n"
+                + "            );\n"
+                + "            return replacementWorkspaceMatches;\n"
+                + "        })) {\n"
+                + "            requestFullRefresh(replacementWorkspaceMatches === false\n"
+                + "                ? 'mismatched-ai-session-presentation-workspace'\n"
+                + "                : input.invalidReplacementReason);\n"
                 + "            return false;\n"
-                + "        }"
+                + "        }\n"
+                + "        if (!hasMatchingPresentationWorkspace(message.presentation)) return false;"
         ),
     },
     {

--- a/tests/unit/tooling/repositorySkills.test.js
+++ b/tests/unit/tooling/repositorySkills.test.js
@@ -67,6 +67,8 @@ test('ARCH-REPOSITORY-SKILL-GUIDANCE-001 verifies remote extension installation 
         ['wrapper resolves to active Server installation', /wrapper[\s\S]*resolve[\s\S]*verify[\s\S]*active Server installation/i],
         ['remote-cli active IPC gate', /remote-cli[\s\S]*(?:only|unless)[\s\S]*reachable[\s\S]*active host/i],
         ['representative hash comparison', /representative[\s\S]*hash/i],
+        ['post-install Extension Host activation', /Extension Host process start time[\s\S]*installed-file timestamp[\s\S]*Developer: Reload Window[\s\S]*observed before that reload/i],
+        ['installation versus runtime activation', /verified disk bytes[\s\S]*verified runtime activation/i],
     ]);
 });
 


### PR DESCRIPTION
## Summary

- reject AI Session presentations that belong to a different rendered workspace before adopting their revision or focus state
- validate atomic AI and OPEN workspace replacements both before mutation and against the resulting DOM, including reused semantic-revision no-op updates
- preserve the focused card highlight and focused-card Conversation action while requesting an authoritative refresh for mismatched updates
- strengthen architecture mutation guards for workspace-scoped Presentation adoption

## Verification

- `npm run test:ci:linux`
- `npm run test:behavior-contracts`
- focused Chromium coverage for focused-card highlight, reused OPEN semantic revisions, and focused-card Conversation opening
- source/media byte identity and `git diff --check`

## Skill harvest

Updated `.skills/installing-vscode-extensions-locally`: verified installed bytes can still be inactive when the Extension Host predates the install, so the workflow now requires `Developer: Reload Window` and post-reload activation evidence before behavioral testing. Validated with `quick_validate.py` and the repository skill owner tests.
