### PR TITLE
Fix OPEN dashboard refresh storms

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -5407,6 +5407,22 @@
     ]
   },
   {
+    "id": "OPEN-WORKSPACE-PRESENTATION-CONVERGENCE-001",
+    "domain": "webview",
+    "title": "OPEN transactions align Session Presentation with the rendered current workspace identity while UI-host registration converges",
+    "priority": "P0",
+    "status": "automated",
+    "owners": [
+      "tests/contract/openProjects/dashboardController.test.js",
+      "tests/browser/activeSessionCardInteraction.test.js"
+    ],
+    "evidence": [
+      "src/openWorkspaces/dashboardController.ts",
+      "src/dashboard/webviewUpdateMessages.ts",
+      "src/webview/webviewProjectAiUpdateScripts.js"
+    ]
+  },
+  {
     "id": "OPEN-WORKSPACE-PIN-WEBVIEW-001",
     "domain": "webview",
     "title": "Pin UI waits for authoritative HTML and preserves pending state across acknowledgements",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "0d96cc1c2a41e56dded2f4608e64a3dfabbfce8d",
+        "head": "5f1b9ee8ecea224fc60b977de21759327128b51b",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -277,7 +277,8 @@
             "18ecf2273167690e3399c82a1b2b5d408a9661d6",
             "0ffa4a9095be981c3034c98ef5b4cd2dc530ca81",
             "b803fe787f08b6460d1f1e72ffa01d1e0865ba5e",
-            "12017e9f4031a0a74003dde0a12d68c7171b1852"
+            "12017e9f4031a0a74003dde0a12d68c7171b1852",
+            "c6bd9d89b371004a2a63d438f220a46f9ee2b61c"
         ]
     },
     "capabilities": [
@@ -531,7 +532,8 @@
                 "680cda193f6fb74064502fe463da5fb9b5154251",
                 "660ab41e2ff0da8f0c4b0f0abeed8a2a97ee87e1",
                 "83910c204b19ba0daace9cce51b8d2c741dcca63",
-                "f21da330003a44dc7e5eff624d36453bd7627884"
+                "f21da330003a44dc7e5eff624d36453bd7627884",
+                "5f1b9ee8ecea224fc60b977de21759327128b51b"
             ],
             "behaviors": [
                 "WEBVIEW-CURRENT-WORKSPACE-RENDERING-001",
@@ -539,7 +541,8 @@
                 "CUSTOM-RUNNING-IMAGE-001",
                 "CUSTOM-RUNNING-IMAGE-RESOLVER-001",
                 "WEBVIEW-AI-SESSION-LIST-SCROLL-001",
-                "ACTIVE-SESSION-FOCUS-REVEAL-001"
+                "ACTIVE-SESSION-FOCUS-REVEAL-001",
+                "OPEN-WORKSPACE-PRESENTATION-CONVERGENCE-001"
             ],
             "prGates": [
                 "test:deterministic:run",

--- a/scripts/run-architecture-guards.js
+++ b/scripts/run-architecture-guards.js
@@ -690,6 +690,12 @@ const guards = {
             this.id,
             risk
         );
+        const presentationMessage = parseTypescript(
+            root,
+            'src/aiSessions/presentationMessage.ts',
+            this.id,
+            risk
+        );
         const updateMessages = parseTypescript(
             root,
             'src/dashboard/webviewUpdateMessages.ts',
@@ -757,6 +763,7 @@ const guards = {
                 'cards and HTML must consume the transaction and publish its revision');
         }
         const dashboardSource = dashboard.getFullText();
+        const presentationMessageSource = presentationMessage.getFullText();
         if (!/getCards:\s*projection\s*=>\s*getOpenWorkspaceCards\(projection\)/
             .test(dashboardSource)
             || !/presentation:\s*buildAiSessionPresentationState\(\s*false,\s*projection,/
@@ -1512,7 +1519,8 @@ const guards = {
         const openWorkspaceSource = openWorkspaceController.getFullText();
         if (!openWorkspaceSource.includes(
             'const projection = this.options.beginAiSessionProjection()'
-        ) || !openWorkspaceSource.includes('cards: this.getCards(projection)')
+        ) || !openWorkspaceSource.includes('const cards = this.getCards(projection)')
+            || !openWorkspaceSource.includes('cards,')
             || !openWorkspaceSource.includes('projectionRevision: projection.revision')
             || !updateMessageSource.includes(
                 'projectionRevision: input.projectionRevision'
@@ -1528,6 +1536,37 @@ const guards = {
             ) {
             fail(this.id, risk,
                 'OPEN HTML and Presentation must share one Host message');
+        }
+        if ((controllerSource.match(
+            /getRenderedCurrentWorkspaceNavigationIdentity\(cards\)/g
+        ) || []).length !== 1
+            || (openWorkspaceSource.match(
+                /getRenderedCurrentWorkspaceNavigationIdentity\(cards\)/g
+            ) || []).length !== 1
+            || (dashboardSource.match(
+                /getRenderedCurrentWorkspaceNavigationIdentity\(cards\)/g
+            ) || []).length !== 1
+            || !/const cards = this\.options\.getCards\(projection\)[\s\S]*?presentation:\s*buildAiSessionPresentationState\(\s*false,\s*projection,[\s\S]*?getRenderedCurrentWorkspaceNavigationIdentity\(cards\),/
+                .test(controllerSource)
+            || !/const cards = this\.getCards\(projection\)[\s\S]*?presentation:\s*buildAiSessionPresentationState\(\s*false,\s*projection,[\s\S]*?getRenderedCurrentWorkspaceNavigationIdentity\(cards\),/
+                .test(openWorkspaceSource)
+            || !/renderContent:\s*\(webview,\s*documentGeneration\)\s*=>\s*\{[\s\S]*?const cards = getOpenWorkspaceCards\(transaction\)[\s\S]*?buildAiSessionPresentationState\(\s*false,\s*transaction,[\s\S]*?getRenderedCurrentWorkspaceNavigationIdentity\(cards\),/
+                .test(dashboardSource)
+            || !/function postActiveAiSessionTerminalPresentation\([\s\S]*?buildAiSessionPresentationState\(\s*true,\s*transaction,[\s\S]*?openWorkspaceDashboardController\.getCurrentRenderedWorkspaceNavigationIdentity\(\),/
+                .test(dashboardSource)
+            || /function postActiveAiSessionTerminalPresentation\([\s\S]*?getOpenWorkspaceCards\(transaction\)/
+                .test(dashboardSource)
+            || !openWorkspaceSource.includes(
+                'getCurrentRenderedWorkspaceNavigationIdentity(): string | null'
+            )
+            || !presentationMessageSource.includes(
+                "cards.find(card => card.kind === 'current')?.navigationIdentity || null"
+            )
+            || !presentationMessageSource.includes(
+                'workspaceNavigationIdentity: renderedWorkspaceNavigationIdentity,'
+            )) {
+            fail(this.id, risk,
+                'every Host Presentation producer must align with its rendered current card identity');
         }
         const initialWorkspaceIndex = initialPresentationSource.indexOf(
             '!hasMatchingPresentationWorkspace(message)'

--- a/scripts/run-dashboard-webview-checks.js
+++ b/scripts/run-dashboard-webview-checks.js
@@ -4886,7 +4886,11 @@ function runSourceContractChecks(source) {
     assert.ok(openWorkspacesMessageBody.includes('openWorkspaceDashboardController.postUpdated()'));
     assert.ok(openWorkspaceControllerSource.includes('buildOpenWorkspacesUpdatedMessage({'));
     assert.ok(openWorkspaceControllerSource.includes('groups: this.options.getGroups()'));
-    assert.ok(openWorkspaceControllerSource.includes('cards: this.getCards(projection)'));
+    assert.ok(openWorkspaceControllerSource.includes('const cards = this.getCards(projection)'));
+    assert.ok(openWorkspaceControllerSource.includes('cards,'));
+    assert.ok(openWorkspaceControllerSource.includes(
+        'getRenderedCurrentWorkspaceNavigationIdentity(cards)'
+    ));
     assert.ok(openWorkspaceControllerSource.includes(
         'projectionRevision: projection.revision'
     ));
@@ -4899,6 +4903,15 @@ function runSourceContractChecks(source) {
     assert.ok(aiSessionControllerSource.includes('cards'));
     assert.ok(aiSessionControllerSource.includes('sequence: projection.revision'));
     assert.ok(aiSessionControllerSource.includes('this.options.getCards(projection)'));
+    assert.ok(aiSessionControllerSource.includes(
+        'getRenderedCurrentWorkspaceNavigationIdentity(cards)'
+    ));
+    assert.equal((extensionHostSource.match(
+        /getRenderedCurrentWorkspaceNavigationIdentity\(cards\)/g
+    ) || []).length, 1);
+    assert.ok(extensionHostSource.includes(
+        'openWorkspaceDashboardController.getCurrentRenderedWorkspaceNavigationIdentity()'
+    ));
     assert.ok(projectSource.includes('replaceSearchCatalog(message.searchCatalog)'));
     assert.ok(projectSource.includes("type: 'open-bridge-extension'"));
     assert.ok(extensionHostSource.includes("'workbench.extensions.action.showExtensionsWithIds'"));

--- a/src/aiSessions/dashboardController.ts
+++ b/src/aiSessions/dashboardController.ts
@@ -2,7 +2,10 @@
 
 import type { AiSessionProviderId, Group, WorkspaceCardViewModel } from '../models';
 import type { AiSessionsUpdatedMessage } from './types';
-import { buildAiSessionPresentationState } from './presentationMessage';
+import {
+    buildAiSessionPresentationState,
+    getRenderedCurrentWorkspaceNavigationIdentity,
+} from './presentationMessage';
 import { buildAiSessionsUpdatedMessage } from '../dashboard/webviewUpdateMessages';
 import type { TodoSearchCatalogItem } from '../todos/types';
 import type { AiSessionPresentationTransaction } from '../workspaces/sessionHydrationController';
@@ -196,6 +199,7 @@ export class AiSessionDashboardController<
             presentation: buildAiSessionPresentationState(
                 false,
                 projection,
+                getRenderedCurrentWorkspaceNavigationIdentity(cards),
                 runningCardAnimation,
                 runningIconAnimation,
             ),

--- a/src/aiSessions/presentationMessage.ts
+++ b/src/aiSessions/presentationMessage.ts
@@ -1,11 +1,19 @@
 'use strict';
 
 import type { AiSessionPresentationStateMessage } from './types';
+import type { WorkspaceCardViewModel } from '../models';
 import type { AiSessionPresentationTransaction } from '../workspaces/sessionHydrationController';
+
+export function getRenderedCurrentWorkspaceNavigationIdentity(
+    cards: readonly Pick<WorkspaceCardViewModel, 'kind' | 'navigationIdentity'>[]
+): string | null {
+    return cards.find(card => card.kind === 'current')?.navigationIdentity || null;
+}
 
 export function buildAiSessionPresentationState<TTerminal>(
     revealFocused: boolean,
     transaction: AiSessionPresentationTransaction<TTerminal>,
+    renderedWorkspaceNavigationIdentity: string | null,
     runningCardAnimation: string = 'current',
     runningIconAnimation: string = 'current',
 ): AiSessionPresentationStateMessage {
@@ -17,5 +25,6 @@ export function buildAiSessionPresentationState<TTerminal>(
         runningCardAnimation,
         runningIconAnimation,
         revealFocused,
+        workspaceNavigationIdentity: renderedWorkspaceNavigationIdentity,
     };
 }

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -125,7 +125,10 @@ import { TmuxRuntimeBackend } from './aiSessions/tmuxRuntimeBackend';
 import { TmuxFocusedRuntimeMonitor } from './aiSessions/tmuxFocusedRuntimeMonitor';
 import { withTmuxCreationLock } from './aiSessions/tmuxCreationLock';
 import type { AiSessionBatchArchiveCompletedMessage, AiSessionProvider, AiSessionService, AiSessionTerminalEntry, AiSessionsUpdatedMessage, WorkspaceAiSessionActionTarget } from './aiSessions/types';
-import { buildAiSessionPresentationState } from './aiSessions/presentationMessage';
+import {
+    buildAiSessionPresentationState,
+    getRenderedCurrentWorkspaceNavigationIdentity,
+} from './aiSessions/presentationMessage';
 import {
     ConversationCapability,
     createConversationCapability,
@@ -1696,18 +1699,20 @@ async function initializeDashboard(
                 getCurrentOpenWorkspace()
             );
             const configuration = getAgentPivotConfiguration();
+            const cards = getOpenWorkspaceCards(transaction);
             return getStewardContent(
                 context,
                 webview,
                 projectService.getGroups(),
                 stewardInfos,
                 true,
-                getOpenWorkspaceCards(transaction),
+                cards,
                 openWorkspaceDashboardController.getState().otherWindows.status,
                 documentGeneration,
                 buildAiSessionPresentationState(
                     false,
                     transaction,
+                    getRenderedCurrentWorkspaceNavigationIdentity(cards),
                     getEffectiveRunningCardAnimation(configuration),
                     getEffectiveRunningIconAnimation(configuration),
                 ),
@@ -2654,6 +2659,7 @@ async function initializeDashboard(
         const message = buildAiSessionPresentationState(
             true,
             transaction,
+            openWorkspaceDashboardController.getCurrentRenderedWorkspaceNavigationIdentity(),
             getEffectiveRunningCardAnimation(configuration),
             getEffectiveRunningIconAnimation(configuration),
         );

--- a/src/openWorkspaces/dashboardController.ts
+++ b/src/openWorkspaces/dashboardController.ts
@@ -4,7 +4,10 @@ import * as crypto from 'crypto';
 
 import type { AttentionAggregate } from '../aiSessions/attentionAggregate';
 import type { WorkspaceAiSessionViewModel } from '../aiSessions/types';
-import { buildAiSessionPresentationState } from '../aiSessions/presentationMessage';
+import {
+    buildAiSessionPresentationState,
+    getRenderedCurrentWorkspaceNavigationIdentity,
+} from '../aiSessions/presentationMessage';
 import { PREDEFINED_COLORS } from '../constants';
 import type { Group, WorkspaceCardViewModel } from '../models';
 import { buildOpenWorkspacesUpdatedMessage } from '../dashboard/webviewUpdateMessages';
@@ -133,6 +136,16 @@ export class OpenWorkspaceDashboardController<TTerminal = unknown> {
         return this.pinNavigationIdentityById.get(cardId) || null;
     }
 
+    getCurrentRenderedWorkspaceNavigationIdentity(): string | null {
+        const currentWorkspace = this.options.getCurrentWorkspace();
+        if (!currentWorkspace) { return null; }
+        const ownRegistration = this.aggregate?.registrations.find(
+            registration => registration.instanceId === this.options.getBridgeInstanceId()
+        );
+        return ownRegistration?.workspace?.navigationIdentity
+            || currentWorkspace.navigationIdentity;
+    }
+
     getCards(
         projection?: AiSessionProjectionSnapshot<TTerminal>
     ): WorkspaceCardViewModel[] {
@@ -150,12 +163,8 @@ export class OpenWorkspaceDashboardController<TTerminal = unknown> {
             return this.cachedCards;
         }
         const pinTimes = getOpenWorkspacePinTimes(this.pinSnapshot);
-        const ownRegistration = this.aggregate?.registrations.find(
-            registration => registration.instanceId === this.options.getBridgeInstanceId()
-        );
-        const currentNavigationIdentity = ownRegistration?.workspace?.navigationIdentity
-            || currentWorkspace?.navigationIdentity
-            || null;
+        const currentNavigationIdentity =
+            this.getCurrentRenderedWorkspaceNavigationIdentity();
         const currentCard = currentWorkspace
             ? this.createCurrentCard(
                 currentWorkspace,
@@ -264,9 +273,10 @@ export class OpenWorkspaceDashboardController<TTerminal = unknown> {
         const projection = this.options.beginAiSessionProjection();
         const runningCardAnimation = this.options.getRunningCardAnimation();
         const runningIconAnimation = this.options.getRunningIconAnimation();
+        const cards = this.getCards(projection);
         const message = buildOpenWorkspacesUpdatedMessage({
             groups: this.options.getGroups(),
-            cards: this.getCards(projection),
+            cards,
             collapsed: this.options.getCollapsed(),
             semanticRevision,
             projectionRevision: projection.revision,
@@ -278,6 +288,7 @@ export class OpenWorkspaceDashboardController<TTerminal = unknown> {
             presentation: buildAiSessionPresentationState(
                 false,
                 projection,
+                getRenderedCurrentWorkspaceNavigationIdentity(cards),
                 runningCardAnimation,
                 runningIconAnimation,
             ),

--- a/tests/browser/activeSessionCardInteraction.test.js
+++ b/tests/browser/activeSessionCardInteraction.test.js
@@ -43,8 +43,27 @@ function loadDashboardMessageHandlers() {
     }
 }
 
-const { getAiSessionsDiv, getCurrentWorkspaceGroupContent } = loadWebviewContent();
+function loadOpenWorkspaceDashboardController() {
+    const vscode = createFakeVscode({});
+    const previousLoad = Module._load;
+    try {
+        Module._load = function (request, parent, isMain) {
+            if (request === 'vscode') return vscode;
+            return previousLoad.call(this, request, parent, isMain);
+        };
+        return require('../../out/openWorkspaces/dashboardController');
+    } finally {
+        Module._load = previousLoad;
+    }
+}
+
+const {
+    getAiSessionsDiv,
+    getCurrentWorkspaceGroupContent,
+    getStewardContent,
+} = loadWebviewContent();
 const { createDashboardMessageHandlers } = loadDashboardMessageHandlers();
+const { OpenWorkspaceDashboardController } = loadOpenWorkspaceDashboardController();
 const {
     AiSessionAttentionController,
 } = require('../../out/aiSessions/attentionController');
@@ -69,6 +88,10 @@ const {
 const {
     buildOpenWorkspacesUpdatedMessage,
 } = require('../../out/dashboard/webviewUpdateMessages');
+const {
+    getRenderedCurrentWorkspaceNavigationIdentity,
+    buildAiSessionPresentationState,
+} = require('../../out/aiSessions/presentationMessage');
 const viewStateScript = fs.readFileSync(
     path.join(__dirname, '../../src/webview/webviewAiSessionViewStateScripts.js'),
     'utf8'
@@ -364,6 +387,11 @@ async function openCardPage(
         currentWorkspaceMarkup,
         initialPresentation
     ));
+    await bootCardPageScripts(page, preserveInitialMessages);
+    return page;
+}
+
+async function bootCardPageScripts(page, preserveInitialMessages = false) {
     await page.evaluate(() => {
         window.__postedMessages = [];
         window.normalizeDashboardSearchCatalog = catalog => catalog;
@@ -387,7 +415,34 @@ async function openCardPage(
         initProjects();
         if (!preserveMessages) window.__postedMessages.length = 0;
     }, preserveInitialMessages);
-    return page;
+}
+
+function productionDashboardDocumentMarkup(cards, presentation) {
+    return getStewardContent(
+        { extensionPath: '/extension' },
+        {
+            cspSource: 'https://assets.test',
+            asWebviewUri: resource => ({
+                toString: () => `https://assets.test/${path.basename(resource.fsPath)}`,
+            }),
+        },
+        [],
+        {
+            config: { get: (_key, fallback) => fallback },
+            relevantExtensionsInstalls: { remoteSSH: false, remoteContainers: false },
+            otherStorageHasData: false,
+        },
+        true,
+        cards,
+        'ready',
+        2,
+        presentation,
+    )
+        .replace(/<meta[^>]*Content-Security-Policy[^>]*>/, '')
+        .replace(/<link[^>]*rel="stylesheet"[^>]*>/, '')
+        .replace(/<script(?![^>]*type="application\/json")[\s\S]*?<\/script>/g, '')
+        .replace('</head>', `<style>${styles}</style></head>`)
+        .replace('class="dashboard-styles-pending"', '');
 }
 
 async function openListPage(t, activeAiSessions, historySessions) {
@@ -474,6 +529,35 @@ function presentationMessage(activeSessions, projectionRevision, options = {}) {
                 eventIds,
             };
         }),
+    };
+}
+
+function presentationSnapshot(activeSessions, options = {}) {
+    const message = presentationMessage(activeSessions, 1, options);
+    return {
+        workspaceScopeIdentity: message.workspaceScopeIdentity,
+        workspaceNavigationIdentity: message.workspaceNavigationIdentity,
+        attentionCount: message.attentionCount,
+        activeAttentionCount: message.activeAttentionCount,
+        runningSessionCount: message.runningSessionCount,
+        focusedTarget: message.focusedTarget,
+        attentionSessions: message.attentionSessions,
+        sessions: message.sessions,
+    };
+}
+
+function aiSessionViewModel(activeSessions) {
+    return {
+        activeProvider: 'codex',
+        selectedProviders: ['codex'],
+        expanded: true,
+        sessionsByProvider: { codex: [], kimi: [], claude: [] },
+        unavailableProviders: [],
+        activeSessions,
+        aiSessionCount: activeSessions.length,
+        activeSessionCount: activeSessions.length,
+        activeAttentionCount: activeSessions.filter(entry => entry.needsAttention).length,
+        attentionCount: activeSessions.filter(entry => entry.needsAttention).length,
     };
 }
 
@@ -860,6 +944,152 @@ test('ACTIVE-SESSION-FOCUS-REVEAL-001 keeps the focused card highlight when anot
         'a rejected workspace envelope must not commit its projection revision');
     await primaryAction.click();
     assert.equal((await postedMessages(page)).at(-1).type, 'open-active-ai-session-conversation');
+});
+
+test('OPEN-WORKSPACE-PRESENTATION-CONVERGENCE-001 applies a production OPEN transaction without refreshing when the Bridge self-registration lags', async t => {
+    const initial = [session('codex', 'session-a', true)];
+    const replacement = [session('codex', 'session-b', true)];
+    const page = await openCardPage(t, initial);
+    await page.addStyleTag({
+        content: ':root { --vscode-focusBorder: rgb(0, 127, 212); }'
+            + ' *, *::before, *::after { transition: none !important; }',
+    });
+    const currentWorkspace = {
+        navigationIdentity: 'navigation-project-a',
+        scopeIdentity: 'scope-project-a',
+        kind: 'singleFolder',
+        displayName: 'Project A',
+        navigationUri: 'file:///work/project-a',
+        environment: 'local',
+        roots: [{
+            id: 'root-project-a',
+            name: 'Project A',
+            uri: 'file:///work/project-a',
+            hostPath: '/work/project-a',
+            ordinal: 0,
+        }],
+    };
+    const staleBridgeWorkspace = {
+        ...currentWorkspace,
+        navigationIdentity: 'navigation-stale-bridge',
+        scopeIdentity: 'scope-stale-bridge',
+    };
+    const transaction = {
+        revision: 2,
+        presentation: presentationSnapshot(replacement),
+    };
+    const delivered = [];
+    const controller = new OpenWorkspaceDashboardController({
+        getCurrentWorkspace: () => currentWorkspace,
+        isWorkspaceSavedAsProject: () => true,
+        getWorkspaceProjectColor: () => '',
+        getCurrentWorkspaceAiSessions: () => aiSessionViewModel(replacement),
+        beginAiSessionProjection: () => transaction,
+        getGroups: () => [],
+        getTodoSearchItems: () => [],
+        getCollapsed: () => false,
+        getRunningCardAnimation: () => 'current',
+        getRunningIconAnimation: () => 'current',
+        getAttentionAggregate: () => null,
+        getBridgeInstanceId: () => '11111111111111111111111111111111',
+        postMessage: message => { delivered.push(message); return Promise.resolve(true); },
+        refresh() {},
+        isVisible: () => true,
+        logDiagnostic() {},
+        logError(error) { throw error; },
+        nowMs: () => 5_000,
+    });
+    controller.setAggregate({
+        protocolVersion: 4,
+        semanticRevision: 'b'.repeat(64),
+        observedAtMs: 5_000,
+        registrations: [{
+            protocolVersion: 4,
+            instanceId: '11111111111111111111111111111111',
+            sequence: 1,
+            openedAtMs: 1_000,
+            lastFocusedAtMs: 4_000,
+            leaseUpdatedAtMs: 4_500,
+            workspace: staleBridgeWorkspace,
+        }],
+    });
+
+    await controller.postUpdated();
+    assert.equal(delivered.length, 1);
+    assert.equal(
+        delivered[0].presentation.workspaceScopeIdentity,
+        currentWorkspace.scopeIdentity,
+    );
+    await postHostMessage(page, delivered[0]);
+
+    const focusedRow = row(page, 'codex', 'session-b');
+    assert.equal(await row(page, 'codex', 'session-a').count(), 0);
+    assert.equal(await focusedRow.getAttribute('data-session-focused'), '');
+    assert.match(
+        await focusedRow.evaluate(element => getComputedStyle(element).boxShadow),
+        /rgba?\(0, 127, 212/,
+    );
+    assert.equal(
+        await page.locator('[data-current-workspace]')
+            .getAttribute('data-workspace-navigation-identity'),
+        staleBridgeWorkspace.navigationIdentity,
+    );
+    assert.equal(
+        await page.locator('[data-current-workspace]')
+            .getAttribute('data-workspace-scope-identity'),
+        currentWorkspace.scopeIdentity,
+    );
+    assert.deepEqual((await postedMessages(page)).filter(message =>
+        message.type === 'request-full-refresh'
+    ), []);
+
+    const mismatchedEnvelope = {
+        ...delivered[0],
+        projectionRevision: 3,
+        semanticRevision: 'c'.repeat(64),
+        presentation: {
+            ...delivered[0].presentation,
+            projectionRevision: 3,
+            workspaceScopeIdentity: currentWorkspace.scopeIdentity,
+            workspaceNavigationIdentity: currentWorkspace.navigationIdentity,
+        },
+    };
+    await postHostMessage(page, mismatchedEnvelope);
+    assert.deepEqual((await postedMessages(page)).filter(message =>
+        message.type === 'request-full-refresh'
+    ), [{
+        type: 'request-full-refresh',
+        reason: 'mismatched-ai-session-presentation-workspace',
+    }]);
+
+    const cards = controller.getCards(transaction);
+    const fullDocumentPresentation = buildAiSessionPresentationState(
+        false,
+        transaction,
+        getRenderedCurrentWorkspaceNavigationIdentity(cards),
+        'current',
+        'current',
+    );
+    await page.setContent(productionDashboardDocumentMarkup(
+        cards,
+        fullDocumentPresentation,
+    ));
+    await bootCardPageScripts(page, true);
+
+    assert.equal(await row(page, 'codex', 'session-b').getAttribute('data-session-focused'), '');
+    assert.equal(
+        await page.locator('[data-current-workspace]')
+            .getAttribute('data-workspace-navigation-identity'),
+        staleBridgeWorkspace.navigationIdentity,
+    );
+    assert.equal(
+        await page.locator('[data-current-workspace]')
+            .getAttribute('data-workspace-scope-identity'),
+        currentWorkspace.scopeIdentity,
+    );
+    assert.deepEqual((await postedMessages(page)).filter(message =>
+        message.type === 'request-full-refresh'
+    ), [], 'the production full-refresh response must converge in one document generation');
 });
 
 test('ACTIVE-SESSION-FOCUS-REVEAL-001 rejects a reused OPEN semantic revision before adopting another workspace focus', async t => {

--- a/tests/contract/openProjects/dashboardController.test.js
+++ b/tests/contract/openProjects/dashboardController.test.js
@@ -146,6 +146,72 @@ test('ACTIVE-SESSION-PRESENTATION-TRANSACTION-001 OPEN updates hydrate and publi
     assert.equal(posted[0].version, 3);
 });
 
+test('OPEN-WORKSPACE-PRESENTATION-CONVERGENCE-001 aligns Presentation with the rendered current identity while the Bridge lags', async () => {
+    const current = makeRecord({
+        name: 'Current',
+        navigationIdentity: 'navigation:live-current',
+        scopeIdentity: 'scope:live-current',
+        uri: '/work/current',
+    });
+    const staleBridgeWorkspace = makeRecord({
+        name: 'Current',
+        navigationIdentity: 'navigation:stale-bridge',
+        scopeIdentity: 'scope:stale-bridge',
+        uri: '/work/current',
+    });
+    const posted = [];
+    const controller = new OpenWorkspaceDashboardController(createOptions({
+        getCurrentWorkspace: () => ({
+            ...current,
+            roots: current.roots.map(root => ({ ...root, hostPath: '/work/current' })),
+        }),
+        beginAiSessionProjection: () => ({
+            revision: 7,
+            presentation: {
+                workspaceScopeIdentity: current.scopeIdentity,
+                workspaceNavigationIdentity: current.navigationIdentity,
+                attentionCount: 0,
+                activeAttentionCount: 0,
+                runningSessionCount: 0,
+                focusedTarget: null,
+                attentionSessions: [],
+                sessions: [],
+            },
+        }),
+        postMessage: message => { posted.push(message); return Promise.resolve(true); },
+    }));
+    controller.setAggregate(makeAggregate([
+        makeRegistration(SELF, 4000, staleBridgeWorkspace.navigationUri, {
+            workspace: staleBridgeWorkspace,
+        }),
+    ], { semanticRevision: 'bridge-still-publishing-the-previous-identity' }));
+
+    assert.equal(
+        controller.getCurrentRenderedWorkspaceNavigationIdentity(),
+        staleBridgeWorkspace.navigationIdentity,
+        'direct focus publication must reuse the rendered identity without hydrating cards',
+    );
+
+    await controller.postUpdated();
+
+    assert.equal(posted.length, 1);
+    assert.equal(
+        posted[0].presentation.workspaceNavigationIdentity,
+        staleBridgeWorkspace.navigationIdentity,
+    );
+    assert.match(posted[0].html, new RegExp(
+        `data-workspace-navigation-identity="${staleBridgeWorkspace.navigationIdentity}"`,
+    ));
+    assert.doesNotMatch(posted[0].html, new RegExp(
+        `data-workspace-navigation-identity="${current.navigationIdentity}"`,
+    ));
+    assert.equal(
+        posted[0].presentation.workspaceScopeIdentity,
+        current.scopeIdentity,
+        'runtime ownership must remain scoped to the live Extension Host workspace',
+    );
+});
+
 test('WEBVIEW-SIDEBAR-VISIBILITY-RETENTION-001 coalesces rapid OPEN revisions behind one delivery', async () => {
     const firstDelivery = createDeferred();
     const posted = [];

--- a/tests/unit/tooling/architectureGuards.test.js
+++ b/tests/unit/tooling/architectureGuards.test.js
@@ -788,8 +788,58 @@ for (const mutation of [
         expectedDetail: 'OPEN HTML and Presentation must share one Host message',
         mutate: source => replaceFixtureSource(
             source,
-            'cards: this.getCards(projection)',
-            'cards: this.getCards()'
+            'const cards = this.getCards(projection)',
+            'const cards = this.getCards()'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/aiSessions/dashboardController.ts',
+        expectedDetail: 'every Host Presentation producer must align with its rendered current card identity',
+        mutate: source => replaceFixtureSource(
+            source,
+            'getRenderedCurrentWorkspaceNavigationIdentity(cards),',
+            'projection.presentation.workspaceNavigationIdentity,'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/openWorkspaces/dashboardController.ts',
+        expectedDetail: 'every Host Presentation producer must align with its rendered current card identity',
+        mutate: source => replaceFixtureSource(
+            source,
+            'getRenderedCurrentWorkspaceNavigationIdentity(cards),',
+            'projection.presentation.workspaceNavigationIdentity,'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/dashboard.ts',
+        expectedDetail: 'every Host Presentation producer must align with its rendered current card identity',
+        mutate: source => replaceFixtureSource(
+            source,
+            'openWorkspaceDashboardController.getCurrentRenderedWorkspaceNavigationIdentity(),',
+            'transaction.presentation.workspaceNavigationIdentity,'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/aiSessions/presentationMessage.ts',
+        expectedDetail: 'every Host Presentation producer must align with its rendered current card identity',
+        mutate: source => replaceFixtureSource(
+            source,
+            "cards.find(card => card.kind === 'current')?.navigationIdentity || null",
+            'null'
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-PRESENTATION-TRANSACTION-001',
+        file: 'src/aiSessions/presentationMessage.ts',
+        expectedDetail: 'every Host Presentation producer must align with its rendered current card identity',
+        mutate: source => replaceFixtureSource(
+            source,
+            'workspaceNavigationIdentity: renderedWorkspaceNavigationIdentity,',
+            'workspaceNavigationIdentity: transaction.presentation.workspaceNavigationIdentity,'
         ),
     },
     {
@@ -1621,8 +1671,8 @@ for (const mutation of [
         expectedDetail: 'full Dashboard document must capture and embed one Presentation transaction',
         mutate: source => replaceFixtureSource(
             source,
-            'getOpenWorkspaceCards(transaction),',
-            'getOpenWorkspaceCards(),'
+            'const cards = getOpenWorkspaceCards(transaction);',
+            'const cards = getOpenWorkspaceCards();'
         ),
     },
     {


### PR DESCRIPTION
## Summary
- align Session Presentation navigation identity with the current workspace card rendered from UI Bridge registration
- keep live Extension Host workspace scope as the session authority
- avoid full card hydration on direct focus publication and add architecture guards
- cover mismatch-to-full-document convergence so refresh requests cannot self-amplify

## Root cause
The OPEN card used the UI-host normalized navigation identity while Session Presentation used the local Extension Host identity. During registration convergence, the Webview rejected otherwise valid updates and repeatedly requested full refreshes, causing card and page flicker.

## Verification
- `npm run test:ci:linux`
- `npm run test:behavior-contracts`
- focused OPEN convergence contract and browser owners
- 153 architecture guard tests
- Dashboard Webview, AI session safety, and OPEN workspace safety checks
- independent exact-SHA integration review: PASS

## Skill harvest
- none: existing regression, resilient Webview mutation, review, installation, and publication skills already covered the reusable workflow; no instruction gap was found.