### PR TITLE
perf: validate the Codex conversation cache by rollout stat instead of TTL

### DIFF
--- a/.ci/conversation-performance.json
+++ b/.ci/conversation-performance.json
@@ -2,6 +2,7 @@
   "adapterColdOutlineMs": 1500,
   "adapterCachedOutlineMs": 100,
   "adapterAppendMs": 250,
+  "codexStatValidatedReloadMs": 50,
   "hostInitialPublicationMs": 250,
   "hostIncrementalRefreshMs": 150,
   "hostSessionSwitchMs": 250,

--- a/.ci/conversation-performance.json
+++ b/.ci/conversation-performance.json
@@ -3,6 +3,7 @@
   "adapterCachedOutlineMs": 100,
   "adapterAppendMs": 250,
   "codexStatValidatedReloadMs": 50,
+  "codexAppendReloadMs": 500,
   "hostInitialPublicationMs": 250,
   "hostIncrementalRefreshMs": 150,
   "hostSessionSwitchMs": 250,

--- a/.skills/review-fix-commit-loop/SKILL.md
+++ b/.skills/review-fix-commit-loop/SKILL.md
@@ -120,6 +120,11 @@ Summarize:
   selectors before trusting tests: a replacement anchor like `.foo {` also
   matches inside a longer selector such as `.bar .foo {`, and Sass happily
   compiles the mangled nesting.
+- A multi-edit replace call reports applied replacements, not matched
+  edits: an edit whose anchor does not match is silently skipped and only
+  shows up as a lower replacement count than the edit count. Compare the
+  two numbers and grep the anchors before running tests, or an unapplied
+  hunk rides into the commit unnoticed.
 - Adding a Dashboard command or an activation-time `vscode` API (e.g.
   `createStatusBarItem`) fails activation-harness and integration tests with
   opaque `waitFor` timeouts far from the cause: bootstrap errors are swallowed

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -4254,12 +4254,14 @@
     "owners": [
       "tests/contract/aiSessions/codexConversationAdapter.test.js",
       "tests/contract/aiSessions/kimiConversationAdapter.test.js",
-      "tests/contract/aiSessions/claudeConversationAdapter.test.js"
+      "tests/contract/aiSessions/claudeConversationAdapter.test.js",
+      "tests/unit/aiSessions/codexRolloutContentSignature.test.js"
     ],
     "evidence": [
       "src/aiSessions/conversation/codexAdapter.ts",
       "src/aiSessions/conversation/kimiAdapter.ts",
-      "src/aiSessions/conversation/claudeAdapter.ts"
+      "src/aiSessions/conversation/claudeAdapter.ts",
+      "src/aiSessions/codexRolloutContentSignature.ts"
     ]
   },
   {

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "5d150586155b53cce689f8a689e61a2c2627e024",
+        "head": "899fe88432fa890144b6e11a2f6d0a0ee64ef11c",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -283,7 +283,8 @@
             "9e90dcfaf5b533967cece88038cce676e5547f90",
             "7a60d37ad9b714e28ffb57619150db73614be1cc",
             "6bbb559253df44785d82366f8ad3446a109d5fa8",
-            "2ff0df3fccbad238cbe2e8f2fb5ce79cbcaf1bfd"
+            "2ff0df3fccbad238cbe2e8f2fb5ce79cbcaf1bfd",
+            "495d0e2ee45c66cd9655b5329b5d98058fe5d700"
         ]
     },
     "capabilities": [
@@ -1611,7 +1612,9 @@
                 "834d5a7b38c402bb9cc106c62e110a199ff7e2ae",
                 "dec9295fe8ff3110b3fba14b5069296e174ea51e",
                 "99ce103b2a74b987d842df244c1175f800f4f7cb",
-                "5d150586155b53cce689f8a689e61a2c2627e024"
+                "5d150586155b53cce689f8a689e61a2c2627e024",
+                "dd9fc5a3064da04edac20f989183cb5af53551fa",
+                "899fe88432fa890144b6e11a2f6d0a0ee64ef11c"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "834d5a7b38c402bb9cc106c62e110a199ff7e2ae",
+        "head": "5d150586155b53cce689f8a689e61a2c2627e024",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -282,7 +282,8 @@
             "7f9b487793d811df8a983b741ab07f7dad2fbff9",
             "9e90dcfaf5b533967cece88038cce676e5547f90",
             "7a60d37ad9b714e28ffb57619150db73614be1cc",
-            "6bbb559253df44785d82366f8ad3446a109d5fa8"
+            "6bbb559253df44785d82366f8ad3446a109d5fa8",
+            "2ff0df3fccbad238cbe2e8f2fb5ce79cbcaf1bfd"
         ]
     },
     "capabilities": [
@@ -1607,7 +1608,10 @@
                 "1d11e9209941297b4b1e7d37402e18475fd2a81c",
                 "486b81f4e8c09ca59d8daa49ccf784a72789fcc2",
                 "c837faa9c945a1bb584adfabc0343e289809dce2",
-                "834d5a7b38c402bb9cc106c62e110a199ff7e2ae"
+                "834d5a7b38c402bb9cc106c62e110a199ff7e2ae",
+                "dec9295fe8ff3110b3fba14b5069296e174ea51e",
+                "99ce103b2a74b987d842df244c1175f800f4f7cb",
+                "5d150586155b53cce689f8a689e61a2c2627e024"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",

--- a/scripts/run-conversation-performance-checks.js
+++ b/scripts/run-conversation-performance-checks.js
@@ -131,6 +131,8 @@ async function measureCodexStatValidatedReload() {
             'over-budget pressure keeps only the newest entry');
         assert.ok(cachedCharacters > 8 * 1024 * 1024,
             'the single kept entry may itself exceed the budget');
+        assert.equal(adapter.loadedConversationCacheChars, cachedCharacters,
+            'the shared character counter tracks the entries exactly');
         return {
             fullReadMs,
             statValidatedReloadMs,

--- a/scripts/run-conversation-performance-checks.js
+++ b/scripts/run-conversation-performance-checks.js
@@ -117,9 +117,92 @@ async function measureCodexStatValidatedReload() {
             PERFORMANCE_BUDGETS.codexStatValidatedReloadMs);
 
         signature = 'stat-2';
+        startedAt = process.hrtime.bigint();
         await adapter.readOutline(threadId);
+        const appendReloadMs = elapsedMs(startedAt);
         assert.equal(requests, 2,
             'a changed rollout stat forces a fresh thread/read');
+        assertBudget('codex append reload', appendReloadMs,
+            PERFORMANCE_BUDGETS.codexAppendReloadMs);
+        const cachedEntries = [...adapter.loadedConversationCache.values()];
+        const cachedCharacters = cachedEntries
+            .reduce((total, entry) => total + entry.characters, 0);
+        assert.equal(cachedEntries.length, 1,
+            'over-budget pressure keeps only the newest entry');
+        assert.ok(cachedCharacters > 8 * 1024 * 1024,
+            'the single kept entry may itself exceed the budget');
+        return {
+            fullReadMs,
+            statValidatedReloadMs,
+            appendReloadMs,
+            cachedCharacters,
+        };
+    } finally {
+        adapter.dispose();
+    }
+}
+
+async function measureCodexToolHeavyReload() {
+    const threadId = '88888888-8888-4888-8888-888888888888';
+    // 1500 turns of tool-record-heavy items with little visible text:
+    // below the 512KiB character gate, yet each full thread/read still
+    // pays the whole transfer and normalize cost, so the read-duration
+    // gate is what caches it.
+    const payload = {
+        thread: {
+            id: threadId,
+            turns: Array.from({ length: 1500 }, (_unused, index) => ({
+                id: `th-turn-${index}`,
+                status: 'completed',
+                items: [{
+                    id: `th-user-${index}`,
+                    type: 'userMessage',
+                    content: [{ type: 'text', text: `request ${index}` }],
+                }, {
+                    id: `th-cmd-${index}`,
+                    type: 'commandExecution',
+                    command: `test --filter case-${index}`,
+                    aggregatedOutput: 'o'.repeat(200),
+                }, {
+                    id: `th-agent-${index}`,
+                    type: 'agentMessage',
+                    text: 'done',
+                }],
+            })),
+        },
+    };
+    let now = 1_000_000;
+    let requests = 0;
+    const adapter = new CodexConversationAdapter({
+        client: {
+            async request() {
+                requests += 1;
+                // A realistically expensive read for the duration gate.
+                now += 400;
+                return JSON.parse(JSON.stringify(payload));
+            },
+            dispose() {},
+        },
+        watchSessionChanges: () => ({ dispose() {} }),
+        setTimeout: callback => {
+            callback();
+            return 1;
+        },
+        clearTimeout: () => undefined,
+        readContentSignature: () => 'stat-1',
+        now: () => now,
+    });
+    try {
+        let startedAt = process.hrtime.bigint();
+        await adapter.readOutline(threadId);
+        const fullReadMs = elapsedMs(startedAt);
+        assert.equal(requests, 1);
+
+        startedAt = process.hrtime.bigint();
+        await adapter.readOutline(threadId);
+        const statValidatedReloadMs = elapsedMs(startedAt);
+        assert.equal(requests, 1,
+            'an expensive tool-heavy read is cached below the character gate');
         return { fullReadMs, statValidatedReloadMs };
     } finally {
         adapter.dispose();
@@ -577,6 +660,7 @@ async function run() {
             assert.equal(retention.retainedAnchor, true);
             const viewerBudgets = await measureViewerPublicationBudgets();
             const codexBudgets = await measureCodexStatValidatedReload();
+            const codexToolHeavy = await measureCodexToolHeavyReload();
 
             console.log(JSON.stringify({
                 coldMs: Number(coldMs.toFixed(3)),
@@ -607,6 +691,16 @@ async function run() {
                 codexFullReadMs: Number(codexBudgets.fullReadMs.toFixed(3)),
                 codexStatValidatedReloadMs: Number(
                     codexBudgets.statValidatedReloadMs.toFixed(3)
+                ),
+                codexAppendReloadMs: Number(
+                    codexBudgets.appendReloadMs.toFixed(3)
+                ),
+                codexCachedCharacters: codexBudgets.cachedCharacters,
+                codexToolHeavyFullReadMs: Number(
+                    codexToolHeavy.fullReadMs.toFixed(3)
+                ),
+                codexToolHeavyStatValidatedReloadMs: Number(
+                    codexToolHeavy.statValidatedReloadMs.toFixed(3)
                 ),
                 ...retention,
             }));

--- a/scripts/run-conversation-performance-checks.js
+++ b/scripts/run-conversation-performance-checks.js
@@ -10,6 +10,9 @@ const {
     KimiConversationAdapter,
 } = require('../out/aiSessions/conversation/kimiAdapter');
 const {
+    CodexConversationAdapter,
+} = require('../out/aiSessions/conversation/codexAdapter');
+const {
     getConversationReadStart,
     readConversationJsonl,
 } = require('../out/aiSessions/conversation/jsonlReader');
@@ -44,6 +47,83 @@ const canonicalKimiFixturePath = path.join(
 
 function elapsedMs(startedAt) {
     return Number(process.hrtime.bigint() - startedAt) / 1_000_000;
+}
+
+function createCodexPerfThread(threadId, turns, textBytes) {
+    return {
+        thread: {
+            id: threadId,
+            turns: Array.from({ length: turns }, (_unused, index) => ({
+                id: `perf-turn-${index}`,
+                status: 'completed',
+                items: [{
+                    id: `perf-user-${index}`,
+                    type: 'userMessage',
+                    content: [{
+                        type: 'text',
+                        text: `Performance request ${index}`,
+                    }],
+                }, {
+                    id: `perf-agent-${index}`,
+                    type: 'agentMessage',
+                    text: 'a'.repeat(textBytes),
+                }],
+            })),
+        },
+    };
+}
+
+async function measureCodexStatValidatedReload() {
+    const threadId = '99999999-9999-4999-8999-999999999999';
+    // ~12 MiB of normalized agent text across 205 turns mirrors the large
+    // real thread/read payloads that dominate Codex switch latency.
+    const payload = createCodexPerfThread(threadId, 205, 60 * 1024);
+    let requests = 0;
+    let signature = 'stat-1';
+    const adapter = new CodexConversationAdapter({
+        client: {
+            async request(method, params) {
+                requests += 1;
+                assert.equal(method, 'thread/read');
+                assert.equal(params.threadId, threadId);
+                // Re-serialize per call so each full read pays a realistic
+                // transport-shaped parse cost.
+                return JSON.parse(JSON.stringify(payload));
+            },
+            dispose() {},
+        },
+        watchSessionChanges: () => ({ dispose() {} }),
+        setTimeout: callback => {
+            callback();
+            return 1;
+        },
+        clearTimeout: () => undefined,
+        readContentSignature: () => signature,
+    });
+    try {
+        let startedAt = process.hrtime.bigint();
+        const outline = await adapter.readOutline(threadId);
+        const fullReadMs = elapsedMs(startedAt);
+        assert.equal(outline.totalInteractions, 205);
+        assert.equal(requests, 1);
+
+        startedAt = process.hrtime.bigint();
+        const cached = await adapter.readOutline(threadId);
+        const statValidatedReloadMs = elapsedMs(startedAt);
+        assert.equal(cached.sourceRevision, outline.sourceRevision);
+        assert.equal(requests, 1,
+            'an unchanged rollout stat must skip the provider read');
+        assertBudget('codex stat-validated reload', statValidatedReloadMs,
+            PERFORMANCE_BUDGETS.codexStatValidatedReloadMs);
+
+        signature = 'stat-2';
+        await adapter.readOutline(threadId);
+        assert.equal(requests, 2,
+            'a changed rollout stat forces a fresh thread/read');
+        return { fullReadMs, statValidatedReloadMs };
+    } finally {
+        adapter.dispose();
+    }
 }
 
 function eventLine(value) {
@@ -496,6 +576,7 @@ async function run() {
             assert.ok(retention.retainedBytes <= 4 * 1024 * 1024);
             assert.equal(retention.retainedAnchor, true);
             const viewerBudgets = await measureViewerPublicationBudgets();
+            const codexBudgets = await measureCodexStatValidatedReload();
 
             console.log(JSON.stringify({
                 coldMs: Number(coldMs.toFixed(3)),
@@ -522,6 +603,10 @@ async function run() {
                 ),
                 hostSessionSwitchMs: Number(
                     viewerBudgets.hostSessionSwitchMs.toFixed(3)
+                ),
+                codexFullReadMs: Number(codexBudgets.fullReadMs.toFixed(3)),
+                codexStatValidatedReloadMs: Number(
+                    codexBudgets.statValidatedReloadMs.toFixed(3)
                 ),
                 ...retention,
             }));

--- a/src/aiSessions/codexRolloutContentSignature.ts
+++ b/src/aiSessions/codexRolloutContentSignature.ts
@@ -1,0 +1,26 @@
+'use strict';
+
+import { statSync } from 'fs';
+
+// Conversation content remains app-server-only; this signature never feeds
+// messages or outline data. It is only the validity signal for the Codex
+// normalized-conversation cache — the same size+mtime assurance level the
+// session watch already polls to detect provider-side changes.
+export function readCodexRolloutContentSignature(
+    rolloutPath: string
+): string | undefined {
+    if (!rolloutPath) {
+        return undefined;
+    }
+    try {
+        const stat = statSync(rolloutPath);
+        if (!stat.isFile()) {
+            return undefined;
+        }
+        return `${stat.size}:${stat.mtimeMs}`;
+    } catch (_error) {
+        // An unreadable rollout must degrade to an always-fresh full read,
+        // never to a poisoned cache entry.
+        return undefined;
+    }
+}

--- a/src/aiSessions/conversation/codexAdapter.ts
+++ b/src/aiSessions/conversation/codexAdapter.ts
@@ -91,12 +91,22 @@ export interface CodexConversationAdapterOptions {
     listSubagentThreads?(
         sessionId: string
     ): AiSessionCodexSubagentThread[] | Promise<AiSessionCodexSubagentThread[]>;
+    now?(): number;
 }
 
 const MAX_LISTED_SUBAGENTS = 64;
 const SUBAGENT_RUNNING_FRESHNESS_MS = 5 * 60 * 1000;
 const LARGE_CONVERSATION_CACHE_CHARS = 512 * 1024;
+// A read this expensive is worth caching even when its visible text stays
+// below the character gate (tool-record-heavy threads normalize little
+// visible text but still pay the full transfer and normalize cost).
+const LARGE_CONVERSATION_CACHE_MIN_READ_MS = 100;
 const LARGE_CONVERSATION_CACHE_ENTRIES = 2;
+// Total cached visible-text characters across entries: the hard memory
+// bound for the cache (roughly 16MiB of string payload).
+const LARGE_CONVERSATION_CACHE_BUDGET_CHARS = 8 * 1024 * 1024;
+// Entries unused for this long are released on the next read.
+const LARGE_CONVERSATION_CACHE_IDLE_MS = 10 * 60 * 1000;
 
 interface LoadedConversation {
     interactions: ConversationInteraction[];
@@ -106,6 +116,8 @@ interface LoadedConversation {
 interface CachedLoadedConversation {
     value: LoadedConversation;
     contentSignature: string;
+    characters: number;
+    lastTouchedAt: number;
 }
 
 function asRecord(value: unknown): Record<string, any> | undefined {
@@ -622,6 +634,7 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
         string,
         CachedLoadedConversation
     >();
+    private loadedConversationCacheChars = 0;
     private conversationCacheGeneration = 0;
     private disposed = false;
 
@@ -957,6 +970,7 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
         this.telemetryReads.clear();
         this.invalidateLoadedConversationCache();
         this.loadedConversationCache.clear();
+        this.loadedConversationCacheChars = 0;
         this.subscriptions.clear();
         this.options.client.dispose();
     }
@@ -1016,39 +1030,91 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
         if (signal?.aborted) {
             return Promise.reject(new ConversationAbortError());
         }
+        this.evictIdleLoadedConversations();
         // The rollout stat signature is captured before the (potentially
         // multi-second) provider read: an append landing mid-read makes the
         // next probe mismatch and forces a fresh read, so the entry can
         // never serve content newer than what it claims.
         const signature = this.contentSignature(sessionId);
         const cached = this.loadedConversationCache.get(sessionId);
-        if (cached && signature !== undefined
-            && signature === cached.contentSignature) {
-            return Promise.resolve(cached.value);
+        if (cached) {
+            if (signature !== undefined
+                && signature === cached.contentSignature) {
+                cached.lastTouchedAt = this.now();
+                this.loadedConversationCache.delete(sessionId);
+                this.loadedConversationCache.set(sessionId, cached);
+                return Promise.resolve(cached.value);
+            }
+            // A stale or unverifiable entry is released immediately rather
+            // than lingering beside — or instead of — its replacement.
+            this.deleteLoadedConversationCacheEntry(sessionId, cached);
         }
         const generation = this.conversationCacheGeneration;
+        const startedAt = this.now();
         return this.loadFresh(sessionId, signal).then(value => {
             if (!this.disposed
                 && generation === this.conversationCacheGeneration
-                && signature !== undefined
-                && this.isLargeConversation(value)) {
-                this.loadedConversationCache.delete(sessionId);
-                this.loadedConversationCache.set(sessionId, {
-                    value,
-                    contentSignature: signature,
-                });
-                while (this.loadedConversationCache.size
-                    > LARGE_CONVERSATION_CACHE_ENTRIES) {
-                    const oldest = this.loadedConversationCache.keys()
-                        .next().value;
-                    if (typeof oldest !== 'string') {
-                        break;
-                    }
-                    this.loadedConversationCache.delete(oldest);
+                && signature !== undefined) {
+                const characters = this.conversationCharacters(value);
+                if (characters >= LARGE_CONVERSATION_CACHE_CHARS
+                    || this.now() - startedAt
+                        >= LARGE_CONVERSATION_CACHE_MIN_READ_MS) {
+                    this.storeLoadedConversationCacheEntry(sessionId, {
+                        value,
+                        contentSignature: signature,
+                        characters,
+                        lastTouchedAt: this.now(),
+                    });
                 }
             }
             return value;
         });
+    }
+
+    private storeLoadedConversationCacheEntry(
+        sessionId: string,
+        entry: CachedLoadedConversation
+    ): void {
+        const previous = this.loadedConversationCache.get(sessionId);
+        if (previous) {
+            this.deleteLoadedConversationCacheEntry(sessionId, previous);
+        }
+        this.loadedConversationCache.set(sessionId, entry);
+        this.loadedConversationCacheChars += entry.characters;
+        while ((this.loadedConversationCache.size
+                > LARGE_CONVERSATION_CACHE_ENTRIES
+            || this.loadedConversationCacheChars
+                > LARGE_CONVERSATION_CACHE_BUDGET_CHARS)
+            && this.loadedConversationCache.size > 1) {
+            const oldest = this.loadedConversationCache.keys().next().value;
+            if (typeof oldest !== 'string') {
+                break;
+            }
+            const evicted = this.loadedConversationCache.get(oldest);
+            if (evicted) {
+                this.deleteLoadedConversationCacheEntry(oldest, evicted);
+            }
+        }
+    }
+
+    private deleteLoadedConversationCacheEntry(
+        sessionId: string,
+        entry: CachedLoadedConversation
+    ): void {
+        if (this.loadedConversationCache.get(sessionId) === entry) {
+            this.loadedConversationCache.delete(sessionId);
+            this.loadedConversationCacheChars -= entry.characters;
+        }
+    }
+
+    private evictIdleLoadedConversations(): void {
+        const now = this.now();
+        for (const [sessionId, entry] of this.loadedConversationCache) {
+            if (now - entry.lastTouchedAt
+                > LARGE_CONVERSATION_CACHE_IDLE_MS) {
+                this.deleteLoadedConversationCacheEntry(sessionId, entry);
+            }
+        }
     }
 
     private contentSignature(sessionId: string): string | undefined {
@@ -1151,33 +1217,26 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
         return { interactions, sourceRevision };
     }
 
-    private isLargeConversation(value: LoadedConversation): boolean {
+    private conversationCharacters(value: LoadedConversation): number {
         let characters = 0;
-        const add = (text: string | undefined): boolean => {
-            characters += text?.length || 0;
-            return characters >= LARGE_CONVERSATION_CACHE_CHARS;
-        };
         for (const interaction of value.interactions) {
-            if (add(interaction.userMarkdown)) {
-                return true;
-            }
+            characters += interaction.userMarkdown?.length || 0;
             for (const markdown of interaction.assistantMarkdown) {
-                if (add(markdown)) {
-                    return true;
-                }
+                characters += markdown.length;
             }
             for (const tool of interaction.toolCalls || []) {
-                if (add(tool.summary) || add(tool.detail)) {
-                    return true;
-                }
+                characters += (tool.summary?.length || 0)
+                    + (tool.detail?.length || 0);
             }
             for (const thinking of interaction.thinking || []) {
-                if (add(thinking.text)) {
-                    return true;
-                }
+                characters += thinking.text?.length || 0;
             }
         }
-        return false;
+        return characters;
+    }
+
+    private now(): number {
+        return this.options.now ? this.options.now() : Date.now();
     }
 
     private ensureProviderWatch(): void {

--- a/src/aiSessions/conversation/codexAdapter.ts
+++ b/src/aiSessions/conversation/codexAdapter.ts
@@ -75,12 +75,16 @@ export interface CodexConversationAdapterOptions {
     watchSessionChanges(onDidChange: () => void): AiSessionDisposable;
     setTimeout(callback: () => void, delayMs: number): TimerHandle;
     clearTimeout(handle: TimerHandle): void;
-    setCacheTimeout?(callback: () => void, delayMs: number): TimerHandle;
-    clearCacheTimeout?(handle: TimerHandle): void;
     resolveWorktree?: ResolveWorktree;
     readRolloutTelemetry?(
         sessionId: string
     ): CodexRolloutTelemetrySnapshot | undefined;
+    // Rollout stat signature used solely as the validity signal for the
+    // normalized-conversation cache: identical stat means the app-server
+    // content cannot have changed, so the cached conversation is reused
+    // without another full thread/read. An undefined/unreadable signature
+    // bypasses the cache entirely.
+    readContentSignature?(sessionId: string): string | undefined;
     readLifecycleSignal?(
         sessionId: string
     ): AiSessionLifecycleSignal | undefined;
@@ -93,7 +97,6 @@ export interface CodexConversationAdapterOptions {
 const MAX_LISTED_SUBAGENTS = 64;
 const SUBAGENT_RUNNING_FRESHNESS_MS = 5 * 60 * 1000;
 const LARGE_CONVERSATION_CACHE_CHARS = 512 * 1024;
-const LARGE_CONVERSATION_CACHE_TTL_MS = 15_000;
 const LARGE_CONVERSATION_CACHE_ENTRIES = 2;
 
 interface LoadedConversation {
@@ -103,8 +106,7 @@ interface LoadedConversation {
 
 interface CachedLoadedConversation {
     value: LoadedConversation;
-    expiresAt: number;
-    expiryTimer?: TimerHandle;
+    contentSignature: string;
 }
 
 function asRecord(value: unknown): Record<string, any> | undefined {
@@ -1014,87 +1016,59 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
         if (signal?.aborted) {
             return Promise.reject(new ConversationAbortError());
         }
+        // The rollout stat signature is captured before the (potentially
+        // multi-second) provider read: an append landing mid-read makes the
+        // next probe mismatch and forces a fresh read, so the entry can
+        // never serve content newer than what it claims.
+        const signature = this.contentSignature(sessionId);
         const cached = this.loadedConversationCache.get(sessionId);
-        if (cached && cached.expiresAt > this.now()) {
+        if (cached && signature !== undefined
+            && signature === cached.contentSignature) {
             return Promise.resolve(cached.value);
-        }
-        if (cached) {
-            this.deleteLoadedConversationCacheEntry(sessionId, cached);
         }
         const generation = this.conversationCacheGeneration;
         return this.loadFresh(sessionId, signal).then(value => {
             if (!this.disposed
                 && generation === this.conversationCacheGeneration
+                && signature !== undefined
                 && this.isLargeConversation(value)) {
-                const previous = this.loadedConversationCache.get(sessionId);
-                if (previous) {
-                    this.deleteLoadedConversationCacheEntry(sessionId, previous);
-                }
-                const entry: CachedLoadedConversation = {
+                this.loadedConversationCache.delete(sessionId);
+                this.loadedConversationCache.set(sessionId, {
                     value,
-                    expiresAt: this.now() + LARGE_CONVERSATION_CACHE_TTL_MS,
-                };
-                this.loadedConversationCache.set(sessionId, entry);
-                this.scheduleLoadedConversationCacheExpiry(sessionId, entry);
+                    contentSignature: signature,
+                });
                 while (this.loadedConversationCache.size
                     > LARGE_CONVERSATION_CACHE_ENTRIES) {
-                    const oldest = this.loadedConversationCache.keys().next().value;
+                    const oldest = this.loadedConversationCache.keys()
+                        .next().value;
                     if (typeof oldest !== 'string') {
                         break;
                     }
-                    const evicted = this.loadedConversationCache.get(oldest);
-                    if (evicted) {
-                        this.deleteLoadedConversationCacheEntry(oldest, evicted);
-                    }
+                    this.loadedConversationCache.delete(oldest);
                 }
             }
             return value;
         });
     }
 
-    private scheduleLoadedConversationCacheExpiry(
-        sessionId: string,
-        entry: CachedLoadedConversation
-    ): void {
-        let firedSynchronously = false;
-        const setTimer = this.options.setCacheTimeout
-            && this.options.clearCacheTimeout
-            ? this.options.setCacheTimeout
-            : this.options.setTimeout;
-        const handle = setTimer(() => {
-            firedSynchronously = true;
-            entry.expiryTimer = undefined;
-            if (this.loadedConversationCache.get(sessionId) === entry) {
-                this.loadedConversationCache.delete(sessionId);
-            }
-        }, LARGE_CONVERSATION_CACHE_TTL_MS);
-        if (!firedSynchronously) {
-            entry.expiryTimer = handle;
-        }
-    }
-
-    private deleteLoadedConversationCacheEntry(
-        sessionId: string,
-        entry: CachedLoadedConversation
-    ): void {
-        if (entry.expiryTimer !== undefined) {
-            const clearTimer = this.options.setCacheTimeout
-                && this.options.clearCacheTimeout
-                ? this.options.clearCacheTimeout
-                : this.options.clearTimeout;
-            clearTimer(entry.expiryTimer);
-            entry.expiryTimer = undefined;
-        }
-        if (this.loadedConversationCache.get(sessionId) === entry) {
-            this.loadedConversationCache.delete(sessionId);
+    private contentSignature(sessionId: string): string | undefined {
+        try {
+            const split = splitSubagentSessionId(sessionId);
+            return this.options.readContentSignature?.(
+                split.subagentId || split.sessionId
+            );
+        } catch (_error) {
+            // A failing probe must never break a read: degrade to an
+            // always-fresh full provider read instead.
+            return undefined;
         }
     }
 
     private invalidateLoadedConversationCache(): void {
+        // Entries self-validate against the rollout stat on every read, so
+        // an invalidation only needs to guard reads currently in flight
+        // from caching a change they raced.
         this.conversationCacheGeneration += 1;
-        for (const [sessionId, entry] of this.loadedConversationCache) {
-            this.deleteLoadedConversationCacheEntry(sessionId, entry);
-        }
     }
 
     private async loadFresh(

--- a/src/aiSessions/conversation/codexAdapter.ts
+++ b/src/aiSessions/conversation/codexAdapter.ts
@@ -91,7 +91,6 @@ export interface CodexConversationAdapterOptions {
     listSubagentThreads?(
         sessionId: string
     ): AiSessionCodexSubagentThread[] | Promise<AiSessionCodexSubagentThread[]>;
-    now?(): number;
 }
 
 const MAX_LISTED_SUBAGENTS = 64;
@@ -957,6 +956,7 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
         this.telemetryCache.clear();
         this.telemetryReads.clear();
         this.invalidateLoadedConversationCache();
+        this.loadedConversationCache.clear();
         this.subscriptions.clear();
         this.options.client.dispose();
     }
@@ -1178,10 +1178,6 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
             }
         }
         return false;
-    }
-
-    private now(): number {
-        return this.options.now ? this.options.now() : Date.now();
     }
 
     private ensureProviderWatch(): void {

--- a/src/aiSessions/conversation/composition.ts
+++ b/src/aiSessions/conversation/composition.ts
@@ -55,6 +55,9 @@ import {
 } from './viewerRestoreState';
 import { ConversationWorktreeResolver } from './worktreeResolver';
 import { readCodexRolloutTelemetry } from '../codexRolloutWorkdir';
+import {
+    readCodexRolloutContentSignature,
+} from '../codexRolloutContentSignature';
 import { encodeSubagentSessionId } from './subagentSessions';
 
 export interface ConversationSessionOpenTarget {
@@ -224,6 +227,13 @@ function createAvailableConversationCapability(
                 .resolveSessionFilePath?.(sessionId);
             return rolloutPath
                 ? readCodexRolloutTelemetry(rolloutPath)
+                : undefined;
+        },
+        readContentSignature: sessionId => {
+            const rolloutPath = options.services.codex
+                .resolveSessionFilePath?.(sessionId);
+            return rolloutPath
+                ? readCodexRolloutContentSignature(rolloutPath)
                 : undefined;
         },
         readLifecycleSignal: sessionId =>

--- a/src/services/codexSessionService.ts
+++ b/src/services/codexSessionService.ts
@@ -184,7 +184,19 @@ export default class CodexSessionService {
         if (!codexHome) {
             return null;
         }
-        return this.getSessionFiles(codexHome).get(sessionId) || null;
+        // Repeat resolutions hit the lifecycle reader's path cache: one
+        // existence revalidation instead of a full sessions-tree scan per
+        // call. A stale or missing entry falls back to discovery.
+        let sessionFile = this.lifecycleSessionFiles.get(sessionId) || null;
+        if (sessionFile && !fs.existsSync(sessionFile)) {
+            this.lifecycleSessionFiles.delete(sessionId);
+            sessionFile = null;
+        }
+        if (!sessionFile) {
+            sessionFile = this.getSessionFiles(codexHome).get(sessionId)
+                || null;
+        }
+        return sessionFile;
     }
 
     getConversationLifecycleSignal(

--- a/tests/contract/aiSessions/codexConversationAdapter.test.js
+++ b/tests/contract/aiSessions/codexConversationAdapter.test.js
@@ -53,6 +53,7 @@ function createAdapter(result = fixture, overrides = {}) {
         readLifecycleSignal: overrides.readLifecycleSignal,
         readContentSignature: overrides.readContentSignature,
         listSubagentThreads: overrides.listSubagentThreads,
+        now: overrides.now,
     });
     return {
         adapter,
@@ -476,6 +477,148 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 bounds the stat-validated large
     await harness.adapter.readOutline(ids[0]);
     assert.equal(requests.length, 4,
         'the evicted oldest entry reads from the provider again');
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 releases a large Codex cache entry as soon as its rollout stat moves on', async t => {
+    const large = createLargeThread();
+    let signature = 'stat-1';
+    const harness = createAdapter(() => large, {
+        readContentSignature: () => signature,
+    });
+    t.after(() => harness.adapter.dispose());
+
+    await harness.adapter.readOutline(sessionId);
+    assert.equal(harness.adapter.loadedConversationCache.size, 1);
+
+    // A changed stat releases the stale entry immediately rather than
+    // letting it linger next to its fresh replacement.
+    signature = 'stat-2';
+    await harness.adapter.readOutline(sessionId);
+    assert.equal(harness.requests.length, 2);
+    assert.equal(harness.adapter.loadedConversationCache.size, 1);
+
+    // An unreadable stat releases it too: the entry can no longer prove
+    // its content is current, and the bypassed read leaves nothing behind.
+    signature = undefined;
+    await harness.adapter.readOutline(sessionId);
+    assert.equal(harness.requests.length, 3);
+    assert.equal(harness.adapter.loadedConversationCache.size, 0);
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 caches a Codex conversation whose read was expensive even when its visible text is small', async t => {
+    // Many tool records with little visible text stay below the 512KiB
+    // character gate, yet each thread/read still costs real transfer and
+    // normalize time: a slow read is eligibility enough.
+    const smallButSlow = {
+        thread: {
+            id: sessionId,
+            turns: [{
+                id: 'turn-1',
+                status: 'completed',
+                items: [{
+                    id: 'user-1',
+                    type: 'userMessage',
+                    content: [{ type: 'text', text: 'request' }],
+                }, {
+                    id: 'agent-1',
+                    type: 'agentMessage',
+                    text: 'short answer',
+                }],
+            }],
+        },
+    };
+    let now = 1_000;
+    const requests = [];
+    const harness = createAdapter(smallButSlow, {
+        client: {
+            async request(method, params) {
+                requests.push({ method, params });
+                now += 400;
+                return clone(smallButSlow);
+            },
+            dispose() {},
+        },
+        readContentSignature: () => 'stat-1',
+        now: () => now,
+    });
+    t.after(() => harness.adapter.dispose());
+
+    await harness.adapter.readOutline(sessionId);
+    assert.equal(harness.adapter.loadedConversationCache.size, 1,
+        'a >=100ms read is cached even below the character gate');
+    await harness.adapter.readOutline(sessionId);
+    assert.equal(requests.length, 1);
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 evicts a large Codex cache entry after ten idle minutes', async t => {
+    const large = createLargeThread();
+    let now = 1_000_000;
+    const harness = createAdapter(() => large, {
+        readContentSignature: () => 'stat-1',
+        now: () => now,
+    });
+    t.after(() => harness.adapter.dispose());
+
+    await harness.adapter.readOutline(sessionId);
+    assert.equal(harness.adapter.loadedConversationCache.size, 1);
+
+    // Repeated use keeps the entry alive.
+    now += 9 * 60 * 1000;
+    await harness.adapter.readOutline(sessionId);
+    assert.equal(harness.requests.length, 1);
+
+    // Ten idle minutes release it; the next read pays a fresh thread/read.
+    now += 10 * 60 * 1000 + 1;
+    await harness.adapter.readOutline(sessionId);
+    assert.equal(harness.requests.length, 2);
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 bounds the total cached Codex conversation characters', async t => {
+    // Two ~4.3M-character conversations fit the entry count but not the
+    // total byte budget: caching the second evicts the first.
+    const bigThread = threadId => ({
+        thread: {
+            id: threadId,
+            turns: Array.from({ length: 72 }, (_unused, index) => ({
+                id: `turn-${index}`,
+                status: 'completed',
+                items: [{
+                    id: `user-${index}`,
+                    type: 'userMessage',
+                    content: [{ type: 'text', text: `request ${index}` }],
+                }, {
+                    id: `agent-${index}`,
+                    type: 'agentMessage',
+                    text: 'x'.repeat(60 * 1024),
+                }],
+            })),
+        },
+    });
+    const ids = [
+        'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+        'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+    ];
+    const requests = [];
+    const harness = createAdapter(undefined, {
+        client: {
+            async request(method, params) {
+                requests.push({ method, params });
+                return bigThread(params.threadId);
+            },
+            dispose() {},
+        },
+        readContentSignature: id => `stat-${id}`,
+    });
+    t.after(() => harness.adapter.dispose());
+
+    await harness.adapter.readOutline(ids[0]);
+    await harness.adapter.readOutline(ids[1]);
+    assert.equal(harness.adapter.loadedConversationCache.size, 1,
+        'the byte budget evicts the older entry even below the count cap');
+    assert.deepEqual(
+        [...harness.adapter.loadedConversationCache.keys()],
+        [ids[1]]
+    );
 });
 
 test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 does not cache a large Codex read invalidated while pending', async t => {

--- a/tests/contract/aiSessions/codexConversationAdapter.test.js
+++ b/tests/contract/aiSessions/codexConversationAdapter.test.js
@@ -48,11 +48,10 @@ function createAdapter(result = fixture, overrides = {}) {
             return 1;
         }),
         clearTimeout: overrides.clearTimeout || (() => undefined),
-        setCacheTimeout: overrides.setCacheTimeout || (() => 2),
-        clearCacheTimeout: overrides.clearCacheTimeout || (() => undefined),
         resolveWorktree: overrides.resolveWorktree,
         readRolloutTelemetry: overrides.readRolloutTelemetry,
         readLifecycleSignal: overrides.readLifecycleSignal,
+        readContentSignature: overrides.readContentSignature,
         listSubagentThreads: overrides.listSubagentThreads,
         now: overrides.now,
     });
@@ -63,10 +62,10 @@ function createAdapter(result = fixture, overrides = {}) {
     };
 }
 
-function createLargeThread() {
+function createLargeThread(threadId = sessionId) {
     return {
         thread: {
-            id: sessionId,
+            id: threadId,
             turns: Array.from({ length: 12 }, (_, index) => ({
                 id: `turn-${index}`,
                 status: 'completed',
@@ -285,18 +284,35 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 Codex returns one correlated ou
     );
 });
 
-test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 throttles repeated full reads of a large Codex thread', async t => {
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 serves a large Codex thread from cache while its rollout stat is unchanged', async t => {
     const large = createLargeThread();
     let now = 1_000;
-    const harness = createAdapter(large, { now: () => now });
+    let signature = 'stat-1';
+    const probedIds = [];
+    const harness = createAdapter(large, {
+        now: () => now,
+        readContentSignature: id => {
+            probedIds.push(id);
+            return signature;
+        },
+    });
     t.after(() => harness.adapter.dispose());
 
     const first = await harness.adapter.readOutline(sessionId);
     const cached = await harness.adapter.readOutline(sessionId);
     assert.equal(cached.sourceRevision, first.sourceRevision);
     assert.equal(harness.requests.length, 1);
+    assert.ok(probedIds.length > 0
+        && probedIds.every(id => id === sessionId));
 
-    now += 15_001;
+    // No expiry: an unchanged rollout stat keeps the normalized
+    // conversation authoritative indefinitely.
+    now += 60_001;
+    await harness.adapter.readOutline(sessionId);
+    assert.equal(harness.requests.length, 1);
+
+    // A changed rollout stat forces the next read back to the provider.
+    signature = 'stat-2';
     await harness.adapter.readOutline(sessionId);
     assert.equal(harness.requests.length, 2);
 });
@@ -304,8 +320,10 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 throttles repeated full reads o
 test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 invalidates a large Codex thread before publishing a provider change', async t => {
     const large = createLargeThread();
     let current = large;
+    let signature = 'stat-1';
     let providerCallback;
     const harness = createAdapter(() => current, {
+        readContentSignature: () => signature,
         watchSessionChanges(callback) {
             providerCallback = callback;
             return { dispose() {} };
@@ -319,6 +337,7 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 invalidates a large Codex threa
     current = clone(large);
     current.thread.turns.at(-1).items.at(-1).text =
         `${'x'.repeat(60 * 1024)} changed`;
+    signature = 'stat-2';
     providerCallback();
     const updated = await harness.adapter.readOutline(sessionId);
 
@@ -326,11 +345,13 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 invalidates a large Codex threa
     assert.equal(harness.requests.length, 2);
 });
 
-test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 serves repeated reads from cache within a provider-change debounce window', async t => {
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 keeps stat-validated large Codex cache entries across provider invalidations', async t => {
     const large = createLargeThread();
+    let signature = 'stat-1';
     let providerCallback;
     let debounceCallback;
     const harness = createAdapter(() => large, {
+        readContentSignature: () => signature,
         watchSessionChanges(callback) {
             providerCallback = callback;
             return { dispose() {} };
@@ -348,22 +369,28 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 serves repeated reads from cach
     assert.equal(harness.requests.length, 1);
     assert.equal(harness.adapter.loadedConversationCache.size, 1);
 
-    // A provider change inside the debounce window keeps the warm cache so
-    // back-to-back reads (switch, revalidation, warmup) share one thread/read.
+    // Provider invalidations no longer discard entries: while the rollout
+    // stat is unchanged, the cached normalized conversation stays
+    // authoritative, so back-to-back reads (switch, revalidation, warmup)
+    // share one thread/read across the whole invalidation cycle.
     providerCallback();
+    await harness.adapter.readOutline(sessionId);
+    debounceCallback();
     await harness.adapter.readOutline(sessionId);
     assert.equal(harness.requests.length, 1);
 
-    // The cache is invalidated right before subscribers are notified.
-    debounceCallback();
+    // A changed rollout stat is what actually forces a fresh thread/read.
+    signature = 'stat-2';
     await harness.adapter.readOutline(sessionId);
     assert.equal(harness.requests.length, 2);
 });
 
-test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 invalidates a canceled debounce when the watch is released', async t => {
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 retains stat-validated large Codex cache entries when the watch is released', async t => {
     const large = createLargeThread();
+    let signature = 'stat-1';
     let providerCallback;
     const harness = createAdapter(() => large, {
+        readContentSignature: () => signature,
         watchSessionChanges(callback) {
             providerCallback = callback;
             return { dispose() {} };
@@ -380,30 +407,78 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 invalidates a canceled debounce
 
     providerCallback();
     // Releasing the last subscription cancels the pending debounce; the
-    // change event must still invalidate the cache.
+    // invalidation still lands (guarding in-flight reads), but the
+    // stat-validated entry survives.
     subscription.dispose();
-    assert.equal(harness.adapter.loadedConversationCache.size, 0);
+    assert.equal(harness.adapter.loadedConversationCache.size, 1);
 
+    await harness.adapter.readOutline(sessionId);
+    assert.equal(harness.requests.length, 1);
+
+    signature = 'stat-2';
     await harness.adapter.readOutline(sessionId);
     assert.equal(harness.requests.length, 2);
 });
 
-test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 actively releases an unread expired Codex thread', async t => {
-    const large = createLargeThread();
-    let expiryCallback;
-    const harness = createAdapter(large, {
-        setCacheTimeout(callback, delayMs) {
-            assert.equal(delayMs, 15_000);
-            expiryCallback = callback;
-            return 42;
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 bypasses the large Codex cache while the rollout stat is unreadable', async t => {
+    const unreadable = createAdapter(createLargeThread(), {
+        readContentSignature: () => undefined,
+    });
+    t.after(() => unreadable.adapter.dispose());
+
+    await unreadable.adapter.readOutline(sessionId);
+    await unreadable.adapter.readOutline(sessionId);
+    assert.equal(unreadable.requests.length, 2);
+    assert.equal(unreadable.adapter.loadedConversationCache.size, 0);
+
+    // A failing probe must never break or poison a read either.
+    const throwing = createAdapter(createLargeThread(), {
+        readContentSignature() {
+            throw new Error('stat gone');
         },
+    });
+    t.after(() => throwing.adapter.dispose());
+
+    await throwing.adapter.readOutline(sessionId);
+    await throwing.adapter.readOutline(sessionId);
+    assert.equal(throwing.requests.length, 2);
+    assert.equal(throwing.adapter.loadedConversationCache.size, 0);
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 bounds the stat-validated large Codex cache to two entries', async t => {
+    const ids = [
+        'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+        'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+        'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+    ];
+    const requests = [];
+    const harness = createAdapter(undefined, {
+        client: {
+            async request(method, params) {
+                requests.push({ method, params });
+                return createLargeThread(params.threadId);
+            },
+            dispose() {},
+        },
+        readContentSignature: id => `stat-${id}`,
     });
     t.after(() => harness.adapter.dispose());
 
-    await harness.adapter.readOutline(sessionId);
-    assert.equal(harness.adapter.loadedConversationCache.size, 1);
-    expiryCallback();
-    assert.equal(harness.adapter.loadedConversationCache.size, 0);
+    for (const id of ids) {
+        await harness.adapter.readOutline(id);
+    }
+    assert.equal(harness.adapter.loadedConversationCache.size, 2);
+    assert.deepEqual(
+        [...harness.adapter.loadedConversationCache.keys()],
+        ids.slice(1)
+    );
+
+    await harness.adapter.readOutline(ids[1]);
+    assert.equal(requests.length, 3,
+        'a stat-validated hit skips the provider entirely');
+    await harness.adapter.readOutline(ids[0]);
+    assert.equal(requests.length, 4,
+        'the evicted oldest entry reads from the provider again');
 });
 
 test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 does not cache a large Codex read invalidated while pending', async t => {
@@ -419,6 +494,7 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 does not cache a large Codex re
             },
             dispose() {},
         },
+        readContentSignature: () => 'stat-1',
         watchSessionChanges(callback) {
             providerCallback = callback;
             return { dispose() {} };
@@ -434,25 +510,6 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 does not cache a large Codex re
     await pending;
 
     assert.equal(harness.adapter.loadedConversationCache.size, 0);
-});
-
-test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 handles a synchronous Codex cache expiry timer without retaining its handle', async t => {
-    let clearCalls = 0;
-    const harness = createAdapter(createLargeThread(), {
-        setCacheTimeout(callback) {
-            callback();
-            return 42;
-        },
-        clearCacheTimeout() {
-            clearCalls += 1;
-        },
-    });
-    t.after(() => harness.adapter.dispose());
-
-    await harness.adapter.readOutline(sessionId);
-
-    assert.equal(harness.adapter.loadedConversationCache.size, 0);
-    assert.equal(clearCalls, 0);
 });
 
 test('SESSION-AI-SESSION-CONVERSATION-ADAPTER-001 CONVERSATION-PLAN-QUESTION-VISIBILITY-001 Codex normalizes only stable visible user and agent items', async t => {

--- a/tests/contract/aiSessions/codexConversationAdapter.test.js
+++ b/tests/contract/aiSessions/codexConversationAdapter.test.js
@@ -53,7 +53,6 @@ function createAdapter(result = fixture, overrides = {}) {
         readLifecycleSignal: overrides.readLifecycleSignal,
         readContentSignature: overrides.readContentSignature,
         listSubagentThreads: overrides.listSubagentThreads,
-        now: overrides.now,
     });
     return {
         adapter,
@@ -286,11 +285,9 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 Codex returns one correlated ou
 
 test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 serves a large Codex thread from cache while its rollout stat is unchanged', async t => {
     const large = createLargeThread();
-    let now = 1_000;
     let signature = 'stat-1';
     const probedIds = [];
     const harness = createAdapter(large, {
-        now: () => now,
         readContentSignature: id => {
             probedIds.push(id);
             return signature;
@@ -305,9 +302,9 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 serves a large Codex thread fro
     assert.ok(probedIds.length > 0
         && probedIds.every(id => id === sessionId));
 
-    // No expiry: an unchanged rollout stat keeps the normalized
-    // conversation authoritative indefinitely.
-    now += 60_001;
+    // There is no expiry: an unchanged rollout stat keeps the normalized
+    // conversation authoritative indefinitely. The harness timer fires
+    // synchronously, so any scheduled expiry would have run by now.
     await harness.adapter.readOutline(sessionId);
     assert.equal(harness.requests.length, 1);
 

--- a/tests/integration/dashboard/conversationViewer.test.js
+++ b/tests/integration/dashboard/conversationViewer.test.js
@@ -4089,8 +4089,6 @@ test('CONVERSATION-WORKLOG-COLLAPSE-001 renders Codex app-server duration in the
             return 1;
         },
         clearTimeout() {},
-        setCacheTimeout: () => 2,
-        clearCacheTimeout() {},
     });
     t.after(() => adapter.dispose());
     const { viewer, panel } = createViewer({
@@ -4155,8 +4153,6 @@ test('CONVERSATION-WORKLOG-COLLAPSE-001 renders the sum of Codex subagent turn d
                 return 1;
             },
             clearTimeout() {},
-            setCacheTimeout: () => 2,
-            clearCacheTimeout() {},
         });
         t.after(() => adapter.dispose());
         const { viewer, panel } = createViewer({

--- a/tests/unit/aiSessions/codexRolloutContentSignature.test.js
+++ b/tests/unit/aiSessions/codexRolloutContentSignature.test.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const {
+    readCodexRolloutContentSignature,
+} = require('../../../out/aiSessions/codexRolloutContentSignature');
+
+test('SESSION-AI-SESSION-CONVERSATION-ADAPTER-001 rollout content signature tracks file size and mtime', async t => {
+    const dir = await fs.promises.mkdtemp(
+        path.join(os.tmpdir(), 'steward-codex-content-signature-')
+    );
+    t.after(() => fs.promises.rm(dir, { recursive: true, force: true }));
+    const rolloutPath = path.join(dir, 'rollout.jsonl');
+
+    // A missing rollout degrades to an always-fresh full provider read.
+    assert.equal(readCodexRolloutContentSignature(rolloutPath), undefined);
+    assert.equal(readCodexRolloutContentSignature(''), undefined);
+    assert.equal(readCodexRolloutContentSignature(dir), undefined);
+
+    await fs.promises.writeFile(rolloutPath, '{"type":"session_meta"}\n');
+    const first = readCodexRolloutContentSignature(rolloutPath);
+    assert.equal(typeof first, 'string');
+    const stat = fs.statSync(rolloutPath);
+    assert.equal(first, `${stat.size}:${stat.mtimeMs}`);
+
+    // An untouched file keeps its signature stable across probes.
+    assert.equal(readCodexRolloutContentSignature(rolloutPath), first);
+
+    // Any append changes the signature, which is what forces the next
+    // conversation read back to the app server.
+    await fs.promises.appendFile(rolloutPath, '{"type":"event_msg"}\n');
+    const updated = readCodexRolloutContentSignature(rolloutPath);
+    assert.notEqual(updated, first);
+});

--- a/tests/unit/aiSessions/codexSessionFilePath.test.js
+++ b/tests/unit/aiSessions/codexSessionFilePath.test.js
@@ -34,6 +34,13 @@ test('CONVERSATION-TELEMETRY-001 resolveSessionFilePath locates rollout files by
     assert.equal(service.resolveSessionFilePath(sessionId), rolloutPath);
     assert.equal(service.resolveSessionFilePath('missing-session'), null);
     assert.equal(service.resolveSessionFilePath(''), null);
+
+    // The cached path is revalidated by existence: a disappeared rollout
+    // falls out of the cache, and a recreated one is discovered again.
+    await fs.promises.rm(rolloutPath);
+    assert.equal(service.resolveSessionFilePath(sessionId), null);
+    await fs.promises.writeFile(rolloutPath, '{}\n');
+    assert.equal(service.resolveSessionFilePath(sessionId), rolloutPath);
 });
 
 test('CONVERSATION-WORKING-INDICATOR-001 reads the current Codex rollout lifecycle independently', async t => {

--- a/tests/unit/tooling/architectureGuards.test.js
+++ b/tests/unit/tooling/architectureGuards.test.js
@@ -56,6 +56,7 @@ function copyGuardFixture(t, mutationPath, mutate = source => source) {
         'src/aiSessions/conversation/composition.ts',
         'src/aiSessions/conversation/worktreeResolver.ts',
         'src/aiSessions/codexRolloutWorkdir.ts',
+        'src/aiSessions/codexRolloutContentSignature.ts',
         'src/aiSessions/conversation/kimiAdapter.ts',
         'src/aiSessions/conversation/claudeAdapter.ts',
         'src/aiSessions/conversation/coordinator.ts',


### PR DESCRIPTION
## Summary

Codex conversation content can only be read through a full `thread/read` (includeTurns) RPC — measured ~3.1s for a 50MB / 205-turn session. The adapter's large-conversation cache previously expired every 15s and was discarded wholesale on every provider invalidation, so switching back to a big stopped session — or any unrelated session activity in the store — forced the full read again even when the content provably had not changed.

The cache is now **validated by the rollout's stat signature** instead of a TTL, with explicit memory bounds and cost-based eligibility:

- Each entry stores the rollout file's `${size}:${mtimeMs}` signature, captured before the provider read. A read hits only when a fresh probe returns the identical signature — an unchanged stat means the app-server content cannot have changed, which is exactly the assurance level the session watch already polls (`id:path:size:mtime` diff). A signature captured mid-read can never serve newer content than it claims: any append invalidates the next probe.
- **Eligibility matches real read cost**: cached when visible text ≥ 512KiB *or* the full read took ≥ 100ms — tool-record-heavy threads with little visible text (real reads of ~350–730ms) are covered too.
- **Memory is explicitly bounded**: 2 entries max, a shared 8Mi-character budget (evict oldest, keep newest), a ten-minute idle sweep on reads, immediate release when an entry's stat mismatches or becomes unreadable, and deterministic release on `dispose()`. A viewer-idle release hook was evaluated and rejected: session switches momentarily empty the watch subscription set, so it would have cleared the cache on every switch.
- `resolveSessionFilePath` revalidates the lifecycle path cache with a single `existsSync` instead of re-scanning the whole sessions tree per call, so each probe costs one `existsSync` + one `statSync`.
- Conversation content itself remains app-server-only by design — the stat is a cache-validity signal, never a content source.

Measured effect (synthetic 205-turn / ~12MiB-normalized scenario): full read 105.5ms → stat-validated reload **0.051ms**; the stat-changed full reload is now budgeted (`codexAppendReloadMs: 500`) instead of merely counted. Warm switches then compose with the webview frame cache (~13ms restore) end to end.

Honest scope: this is memoization, not incremental transfer — an actively appending large session still pays a full read per change (cost grows with history). Closing that needs the app-server's paginated/item-level reads (`thread/turns/list` / `thread/items/list`, binary-string evidence in codex 0.147.0), which stay unprobed and out of scope here. The `size+mtimeMs` signature cannot detect a same-size same-mtime file replacement (inode/boundary-hash hardening noted as follow-up, non-blocking).

## Tests

- Contract tests rewritten from TTL semantics to stat semantics: unchanged stat ⇒ cached indefinitely (the harness's synchronous timers would fire any hidden expiry); changed stat ⇒ fresh read; unreadable/throwing probe ⇒ bypassed and released; invalidations retain stat-valid entries; watch release retains them; in-flight invalidation still prevents caching; two-entry FIFO, 8Mi-character budget eviction, ten-minute idle eviction, and duration-based eligibility each pinned. Probe receives the native (subagent-split) thread id.
- New probe module unit test (size+mtime signature, missing/dir/empty paths) and `resolveSessionFilePath` revalidation test (deleted rollout ⇒ null; recreated ⇒ resolves).
- Perf harness gains two Codex scenarios (large shape; tool-heavy shape pinned to the duration gate via an injected clock) with budget keys `codexStatValidatedReloadMs: 50` / `codexAppendReloadMs: 500`, plus cached-character and counter-invariant assertions.

## Real-data verification (per adapter skill)

Compiled adapter against the live codex app-server (0.147.0) and real on-disk rollouts, read-only:

- Small session: outline interaction count matches the raw `thread/read` user-turn ground truth; fast small reads correctly stay uncached.
- Large session (59.9MB rollout, 502 interactions): first read 1 RPC; second read **0 RPCs**, byte-identical output; forged stat forces a fresh read with an identical content revision.
- Tool-heavy session (36MB rollout, 200 interactions, sub-gate visible text): first read 730ms; second read **0ms, 0 extra RPCs** — the duration gate covers the exact shape the old char gate missed.
- 175MiB live session: read succeeds (its sanitized response fits the 64MiB frame cap); no hang or failure-path change.

## Review

Two read-only review rounds plus the owner's review. Fixed along the way: probe paid a full recursive sessions-tree scan per read (now the lifecycle path cache fast path); then the owner's two Importants — unbounded cache memory (now byte budget + idle sweep + immediate stale release) and eligibility/perf gates not reflecting real read cost (now duration-based eligibility + append-reload and tool-heavy budgets). Final re-review: no Critical/Important.

## Skill harvest

`updated:.skills/review-fix-commit-loop` (multi-edit replace calls report replacements, not matched edits) — recorded in the first audit commit trailer; the bounds follow-up round recorded `none`.
