### PR TITLE
perf: reload large Codex conversations incrementally via thread/turns/list

### DIFF
--- a/.ci/conversation-performance.json
+++ b/.ci/conversation-performance.json
@@ -3,7 +3,7 @@
   "adapterCachedOutlineMs": 100,
   "adapterAppendMs": 250,
   "codexStatValidatedReloadMs": 50,
-  "codexAppendReloadMs": 500,
+  "codexAppendReloadMs": 50,
   "hostInitialPublicationMs": 250,
   "hostIncrementalRefreshMs": 150,
   "hostSessionSwitchMs": 250,

--- a/.skills/developing-provider-conversation-adapters/SKILL.md
+++ b/.skills/developing-provider-conversation-adapters/SKILL.md
@@ -47,7 +47,14 @@ Green self-authored fixtures alone are not evidence.
 |---|---|---|
 | Kimi | `<kimiHome>/sessions/<workdirHash>/<sessionUuid>/wire.jsonl` | `<sessionDir>/subagents/<id>/{meta.json,wire.jsonl}`; meta carries explicit `status` + `created_at`. The Shell tool is **stateless per command** — every invocation runs with `cwd = session.work_dir` (kimi_cli/tools/shell source), so relative `cd` targets resolve against the session workdir, not the previous command |
 | Claude | `<claudeHome>/projects/<slug>/<sessionId>.jsonl` | `<slug>/<sessionId>/subagents/agent-<id>.{jsonl,meta.json}`, flat across spawnDepths; meta has `agentType`/`description`/`spawnDepth`/`toolUseId` but **no status** — infer from the transcript tail plus mtime; SendMessage resumes arrive as `origin.kind === 'coordinator'` user records |
-| Codex | rollout JSONL under `<codexHome>/sessions/YYYY/MM/DD/`; conversation content is app-server-only (`thread/read`) | Independent rollout files per thread; `session_meta.payload.source.subagent.thread_spawn` carries `parent_thread_id`/`depth`/`agent_nickname`/`agent_path`; discovery scans first lines by parent id; `thread/read` accepts subagent thread ids (verified 0.146); no userMessage in subagent threads — seed the dispatch interaction from metadata; status = last `event_msg` is `task_complete` → finished, else mtime freshness |
+| Codex | rollout JSONL under `<codexHome>/sessions/YYYY/MM/DD/`; conversation content is app-server-only (`thread/read`); incremental reloads of large cached root threads page the tail via `thread/turns/list` (experimentalApi-gated, version-allowlisted, full-read fallback — surface probed in `spikes/codex-paginated-read/`) | Independent rollout files per thread; `session_meta.payload.source.subagent.thread_spawn` carries `parent_thread_id`/`depth`/`agent_nickname`/`agent_path`; discovery scans first lines by parent id; `thread/read` accepts subagent thread ids (verified 0.146); no userMessage in subagent threads — seed the dispatch interaction from metadata; status = last `event_msg` is `task_complete` → finished, else mtime freshness |
+
+Codex app-server 0.147+ answers `initialize` without `serverInfo`: the
+server version rides in the `userAgent` product token
+(`<originator>/<major.minor.patch> …`). Version-gated protocol features
+must parse it from there — stub handshakes that keep the old `serverInfo`
+shape pass every test while the real server leaves the gate permanently
+off.
 
 Subagent transcripts reuse the provider's main record envelope; Claude
 subagent files consist entirely of `isSidechain: true` records, so any

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "899fe88432fa890144b6e11a2f6d0a0ee64ef11c",
+        "head": "256953a4ca8e7da6a02b90f52fcc19ef4f37ca33",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -284,7 +284,8 @@
             "7a60d37ad9b714e28ffb57619150db73614be1cc",
             "6bbb559253df44785d82366f8ad3446a109d5fa8",
             "2ff0df3fccbad238cbe2e8f2fb5ce79cbcaf1bfd",
-            "495d0e2ee45c66cd9655b5329b5d98058fe5d700"
+            "495d0e2ee45c66cd9655b5329b5d98058fe5d700",
+            "60baa83d42d31be81d8d8272092f45b1697478d0"
         ]
     },
     "capabilities": [
@@ -1614,7 +1615,12 @@
                 "99ce103b2a74b987d842df244c1175f800f4f7cb",
                 "5d150586155b53cce689f8a689e61a2c2627e024",
                 "dd9fc5a3064da04edac20f989183cb5af53551fa",
-                "899fe88432fa890144b6e11a2f6d0a0ee64ef11c"
+                "899fe88432fa890144b6e11a2f6d0a0ee64ef11c",
+                "9c75b6fe7e951f39ce754d560047a55f47c2a315",
+                "60b2e2de67a89f25a4420362df4ea0795bc9ccb5",
+                "80f927de1c0258eb3c339fdc5efe686a402654cd",
+                "c26983832fa4967261e7134463bffc75729d905b",
+                "256953a4ca8e7da6a02b90f52fcc19ef4f37ca33"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "256953a4ca8e7da6a02b90f52fcc19ef4f37ca33",
+        "head": "3ccd04e1cc21b789fd185da0b36f9dbcabebf0a8",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -285,7 +285,8 @@
             "6bbb559253df44785d82366f8ad3446a109d5fa8",
             "2ff0df3fccbad238cbe2e8f2fb5ce79cbcaf1bfd",
             "495d0e2ee45c66cd9655b5329b5d98058fe5d700",
-            "60baa83d42d31be81d8d8272092f45b1697478d0"
+            "60baa83d42d31be81d8d8272092f45b1697478d0",
+            "0f1b5cdb56fcceac286e26b273e52ec31fee1003"
         ]
     },
     "capabilities": [
@@ -1620,7 +1621,10 @@
                 "60b2e2de67a89f25a4420362df4ea0795bc9ccb5",
                 "80f927de1c0258eb3c339fdc5efe686a402654cd",
                 "c26983832fa4967261e7134463bffc75729d905b",
-                "256953a4ca8e7da6a02b90f52fcc19ef4f37ca33"
+                "256953a4ca8e7da6a02b90f52fcc19ef4f37ca33",
+                "7e7aeeff4a328fa0cce0fbda5473fa799bb2560a",
+                "2481f9410d9ee051891687b03d16061499c63e46",
+                "3ccd04e1cc21b789fd185da0b36f9dbcabebf0a8"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",

--- a/scripts/run-conversation-performance-checks.js
+++ b/scripts/run-conversation-performance-checks.js
@@ -73,23 +73,50 @@ function createCodexPerfThread(threadId, turns, textBytes) {
     };
 }
 
+// Mirrors the verified 0.147 app-server pagination: descending by
+// default, an opaque inclusive cursor, nextCursor while older turns remain.
+function serveCodexTurnsListPage(turns, params) {
+    const ordered = [...turns].reverse();
+    let start = 0;
+    if (typeof params.cursor === 'string') {
+        const at = ordered.findIndex(turn => turn.id === params.cursor);
+        assert.notEqual(at, -1, `unknown cursor ${params.cursor}`);
+        start = at + 1;
+    }
+    const limit = params.limit || ordered.length;
+    const data = ordered.slice(start, start + limit);
+    const more = start + data.length < ordered.length;
+    return JSON.parse(JSON.stringify({
+        data,
+        nextCursor: more && data.length ? data[data.length - 1].id : null,
+        backwardsCursor: data.length ? data[0].id : null,
+    }));
+}
+
 async function measureCodexStatValidatedReload() {
     const threadId = '99999999-9999-4999-8999-999999999999';
     // ~12 MiB of normalized agent text across 205 turns mirrors the large
     // real thread/read payloads that dominate Codex switch latency.
     const payload = createCodexPerfThread(threadId, 205, 60 * 1024);
-    let requests = 0;
+    const methods = [];
     let signature = 'stat-1';
     const adapter = new CodexConversationAdapter({
         client: {
             async request(method, params) {
-                requests += 1;
-                assert.equal(method, 'thread/read');
+                methods.push(method);
                 assert.equal(params.threadId, threadId);
-                // Re-serialize per call so each full read pays a realistic
+                // Re-serialize per call so each read pays a realistic
                 // transport-shaped parse cost.
+                if (method === 'thread/turns/list') {
+                    return serveCodexTurnsListPage(
+                        payload.thread.turns,
+                        params
+                    );
+                }
+                assert.equal(method, 'thread/read');
                 return JSON.parse(JSON.stringify(payload));
             },
+            getServerVersion: () => '0.147',
             dispose() {},
         },
         watchSessionChanges: () => ({ dispose() {} }),
@@ -105,23 +132,39 @@ async function measureCodexStatValidatedReload() {
         const outline = await adapter.readOutline(threadId);
         const fullReadMs = elapsedMs(startedAt);
         assert.equal(outline.totalInteractions, 205);
-        assert.equal(requests, 1);
+        assert.deepEqual(methods, ['thread/read']);
 
         startedAt = process.hrtime.bigint();
         const cached = await adapter.readOutline(threadId);
         const statValidatedReloadMs = elapsedMs(startedAt);
         assert.equal(cached.sourceRevision, outline.sourceRevision);
-        assert.equal(requests, 1,
+        assert.equal(methods.length, 1,
             'an unchanged rollout stat must skip the provider read');
         assertBudget('codex stat-validated reload', statValidatedReloadMs,
             PERFORMANCE_BUDGETS.codexStatValidatedReloadMs);
 
+        // An appended turn with a moved stat reloads through the paginated
+        // tail page instead of a full thread/read.
+        payload.thread.turns.push({
+            id: 'perf-turn-205',
+            status: 'completed',
+            items: [{
+                id: 'perf-user-205',
+                type: 'userMessage',
+                content: [{ type: 'text', text: 'Performance request 205' }],
+            }, {
+                id: 'perf-agent-205',
+                type: 'agentMessage',
+                text: 'a'.repeat(60 * 1024),
+            }],
+        });
         signature = 'stat-2';
         startedAt = process.hrtime.bigint();
-        await adapter.readOutline(threadId);
+        const appended = await adapter.readOutline(threadId);
         const appendReloadMs = elapsedMs(startedAt);
-        assert.equal(requests, 2,
-            'a changed rollout stat forces a fresh thread/read');
+        assert.equal(appended.totalInteractions, 206);
+        assert.deepEqual(methods.slice(1), ['thread/turns/list'],
+            'an appended rollout reloads through the tail page only');
         assertBudget('codex append reload', appendReloadMs,
             PERFORMANCE_BUDGETS.codexAppendReloadMs);
         const cachedEntries = [...adapter.loadedConversationCache.values()];

--- a/spikes/codex-paginated-read/README.md
+++ b/spikes/codex-paginated-read/README.md
@@ -1,0 +1,103 @@
+# Spike: Codex app-server paginated history reads (0.147.0)
+
+Read-only probe assessing whether `thread/turns/list` / `thread/items/list`
+can replace full `thread/read` reloads for large Codex sessions
+(Phase 2 of the conversation-loading incrementalization work).
+
+Scripts (run with `node`, require a real `codex` 0.147.0 on this machine):
+
+- `probe.js` — gating, pagination semantics, shape identity, timing, live turn.
+- `probe-followup.js` — 175MB-session scaling + 62-turn shape identity.
+- `probe-diff.js` / `probe-diff2.js` — item-level diff of the two mismatched turns.
+
+## Protocol surface (verified against openai/codex @ rust-v0.147.0 source)
+
+- `thread/turns/list` exists and works; params
+  `{threadId, cursor?, limit?, sortDirection? = desc, itemsView? = summary}`,
+  response `{data: Turn[], nextCursor?, backwardsCursor?}`.
+  `itemsView: "full"` embeds complete `ThreadItem`s per turn, so
+  `thread/items/list` is not needed for incremental reads.
+- `thread/items/list` is **not implemented** in 0.147.0
+  (`method_not_found("thread/items/list is not supported yet")`).
+- Both methods are **`#[experimental]`-gated**: the client must send
+  `capabilities.experimentalApi: true` in `initialize`, otherwise the server
+  rejects with `-32600 "thread/turns/list requires experimentalApi capability"`
+  (clean, detectable; verified in probe phase A).
+- `backwardsCursor` + `sortDirection: "asc"` re-includes the anchor turn —
+  documented and verified mechanism to catch updates to the newest
+  (e.g. in-flight) turn.
+- `thread/resume` has experimental `initialTurnsPage` / `turnsBackwardsCursor`
+  for cold-start paging (not probed).
+- Errors: before the first user message, `thread/turns/list` fails with
+  `-32600 "... is not materialized yet ..."` (verified in phase F).
+
+## Server-side cost model (the decisive finding)
+
+`thread/turns/list` has two backends, chosen by the session's
+`history_mode` (set at session creation by the writing codex):
+
+| Session kind | Backend | Cost per call | Measured |
+|---|---|---|---|
+| `Paginated` (written by current codex, indexed in `~/.codex/thread_history_1.sqlite` with rollout byte offsets) | sqlite projection, true O(page) seeks | **flat, independent of history size** | **21.8ms / 7.1ms on the 175MB session** |
+| `Legacy` (pre-index rollouts) | full rollout replay **on every call** | O(history), ~10ms/MB | ~600ms flat on the 60MB session (limit 1 = limit 25 = 601–668ms) |
+
+Only `019fe66d…` (175MB, written 2026-08-09) has rows in
+`thread_history_1.sqlite`; the July sessions do not. Actively-streaming
+sessions going forward are exactly the paginated kind.
+
+## Measured timings (this machine, real sessions)
+
+| Operation | 60MB / 503 turns (legacy) | 175MB / 211 turns (paginated) |
+|---|---|---|
+| `thread/read` full | 1050–1203ms (6.1MB response) | **37960ms (51.4MB response)** |
+| `turns/list` tail page, 1 turn, full items | ~601–612ms (4KB) | **21.8ms (1.6KB)** |
+| `turns/list` 25 turns, summary | ~590ms (29KB) | — |
+
+Adapter-level context: the full pipeline (RPC + parse + normalize +
+fingerprint) for a ~50MB session was ~3.1s; with a tail-page read the
+post-RPC work drops to ~0 (KBs), so a refresh becomes ~25ms for paginated
+sessions — **~3 orders of magnitude, and it makes live-following a 175MB
+session feasible at all** (today each refresh costs ~38s of RPC alone).
+For legacy sessions the gain is only ~1.7–2× (server still replays), but
+the stat-signature cache from PR #227 already covers the unchanged case.
+
+## Shape identity (turns/list full vs thread/read)
+
+- Small session (1 turn) and medium session (62 turns): item type sequences,
+  turn ids, statuses all match; **deep-equal except 2 items**, both of which
+  are **`thread/read` replay corruption**: multibyte UTF-8 split across
+  streamed chunks surfaces as U+FFFD runs in `thread/read` output, while the
+  `turns/list` paths return the correct text (e.g. `新` → `��`).
+  So `turns/list` is equal-or-more-correct, not merely equal.
+- Pagination integrity verified: no overlap across `nextCursor` pages,
+  total turn count via paging (503) matches, `backwardsCursor` re-includes
+  the anchor turn.
+
+## Live turn (phase E, fresh thread via `thread/start` + `turn/start`)
+
+- Notification stream works over stdio: `turn/started`, `item/started`,
+  `item/agentMessage/delta`, `item/completed`, `turn/completed`,
+  `thread/status/changed`, `thread/tokenUsage/updated`.
+- `thread/turns/list` (desc, limit 1, full) shows the **in-flight turn**
+  immediately; polling observed items growing 0 → 1 → 2 and status
+  `inProgress → completed`. (Server merges the live `ThreadState` snapshot
+  for threads loaded in-process; for threads owned by another process the
+  paginated path reads the WAL sqlite projection.)
+
+## Feasibility verdict for Phase 2
+
+1. **Viable and transformative for paginated sessions** (all sessions written
+   by codex ≥ the projection-DB era): tail-page reads are flat ~7–25ms
+   regardless of history size. Design: stat-signature gate (PR #227) → on
+   change, fetch tail page via `backwardsCursor` (re-reads the in-flight
+   turn); if the anchor turn id unexpectedly changed (compaction/rollback),
+   fall back to a full re-read. Per-turn fingerprints compose into the
+   existing opaque revision string.
+2. **Requires opting into `experimentalApi`** — a deliberate deviation from
+   the repo's current policy. Mitigations: detect `-32600` and any shape
+   anomaly → fall back to `thread/read` + stat cache; gate by the server
+   version reported at `initialize`.
+3. **Cold path can additionally page** (`summary` view ≈ outline data,
+   `initialTurnsPage` on resume), but that multiplies the experimental
+   surface — keep as a separate decision.
+4. `thread/items/list` cannot be relied on (unimplemented in 0.147.0).

--- a/spikes/codex-paginated-read/probe-diff.js
+++ b/spikes/codex-paginated-read/probe-diff.js
@@ -1,0 +1,167 @@
+'use strict';
+
+/* Diff the two mismatching turns between thread/read and thread/turns/list. */
+
+const { spawn } = require('node:child_process');
+
+const CODEX_EXECUTABLE = '/usr/bin/codex';
+const MEDIUM_THREAD = '019f96d5-d6a5-7482-9f6d-b9f14a38aea4';
+const SUSPECT_TURNS = [
+    '019f9740-264d-7bd2-bac4-fc8e5eae2c29',
+    '019f9791-0f4e-7d33-b8c6-dc7a85ee7907',
+];
+
+function canonical(value) {
+    if (Array.isArray(value)) {
+        return `[${value.map(canonical).join(',')}]`;
+    }
+    if (value && typeof value === 'object') {
+        const keys = Object.keys(value).sort();
+        return `{${keys.map(k => `${JSON.stringify(k)}:${canonical(value[k])}`).join(',')}}`;
+    }
+    return JSON.stringify(value);
+}
+
+class RpcClient {
+    constructor() {
+        this.nextId = 1;
+        this.pending = new Map();
+        this.buffer = '';
+        this.child = spawn(
+            CODEX_EXECUTABLE,
+            ['app-server', '--listen', 'stdio://'],
+            { shell: false, stdio: ['pipe', 'pipe', 'pipe'] }
+        );
+        this.child.stderr.on('data', () => undefined);
+        this.child.stdout.on('data', chunk => this.accept(chunk));
+    }
+
+    accept(chunk) {
+        this.buffer += chunk.toString('utf8');
+        for (;;) {
+            const newline = this.buffer.indexOf('\n');
+            if (newline < 0) {
+                return;
+            }
+            const line = this.buffer.slice(0, newline);
+            this.buffer = this.buffer.slice(newline + 1);
+            if (!line.trim()) {
+                continue;
+            }
+            const message = JSON.parse(line);
+            if (typeof message.method === 'string' && message.id === undefined) {
+                continue;
+            }
+            const entry = this.pending.get(message.id);
+            if (!entry) {
+                continue;
+            }
+            this.pending.delete(message.id);
+            if (message.error) {
+                const error = new Error(message.error.message);
+                error.code = message.error.code;
+                entry.reject(error);
+            } else {
+                entry.resolve(message.result);
+            }
+        }
+    }
+
+    write(message) {
+        this.child.stdin.write(`${JSON.stringify(message)}\n`);
+    }
+
+    async connect() {
+        await this.request('initialize', {
+            clientInfo: { name: 'agent_pivot_probe', title: 'Probe', version: '0.0.1' },
+            capabilities: { experimentalApi: true },
+        });
+        this.write({ method: 'initialized', params: {} });
+    }
+
+    request(method, params) {
+        const id = this.nextId++;
+        return new Promise((resolve, reject) => {
+            this.pending.set(id, { resolve, reject });
+            this.write({ method, id, params });
+        });
+    }
+
+    close() {
+        try {
+            this.child.kill();
+        } catch (_error) {
+            // best effort
+        }
+    }
+}
+
+function itemTypes(items) {
+    return (items || []).map(item => item && item.type);
+}
+
+function truncate(text, max = 600) {
+    return text.length > max ? `${text.slice(0, max)}…[${text.length} chars]` : text;
+}
+
+async function main() {
+    const client = new RpcClient();
+    await client.connect();
+
+    const read = await client.request('thread/read', {
+        threadId: MEDIUM_THREAD,
+        includeTurns: true,
+    });
+    const readTurns = read.thread.turns || [];
+
+    const pagedTurns = [];
+    let cursor;
+    for (;;) {
+        const page = await client.request('thread/turns/list', {
+            threadId: MEDIUM_THREAD,
+            cursor,
+            limit: 10,
+            sortDirection: 'asc',
+            itemsView: 'full',
+        });
+        pagedTurns.push(...page.data);
+        cursor = page.nextCursor || undefined;
+        if (!cursor) {
+            break;
+        }
+    }
+
+    const out = {};
+    for (const turnId of SUSPECT_TURNS) {
+        const a = readTurns.find(turn => turn.id === turnId);
+        const b = pagedTurns.find(turn => turn.id === turnId);
+        const entry = {
+            readStatus: a && a.status,
+            pagedStatus: b && b.status,
+            readItemTypes: a && itemTypes(a.items),
+            pagedItemTypes: b && itemTypes(b.items),
+        };
+        if (a && b) {
+            const max = Math.max(a.items.length, b.items.length);
+            entry.firstDiffIndex = -1;
+            for (let index = 0; index < max; index += 1) {
+                if (canonical(a.items[index]) !== canonical(b.items[index])) {
+                    entry.firstDiffIndex = index;
+                    entry.readItem = truncate(canonical(a.items[index]));
+                    entry.pagedItem = truncate(canonical(b.items[index]));
+                    break;
+                }
+            }
+        }
+        out[turnId] = entry;
+    }
+    console.log(JSON.stringify(out, null, 2));
+    client.close();
+}
+
+main().catch(error => {
+    console.error('probe failed:', error);
+    process.exitCode = 1;
+}).finally(() => {
+    process.exit(process.exitCode || 0);
+});

--- a/spikes/codex-paginated-read/probe-diff2.js
+++ b/spikes/codex-paginated-read/probe-diff2.js
@@ -1,0 +1,169 @@
+'use strict';
+
+/* Locate exact first-difference offsets between thread/read and turns/list items. */
+
+const { spawn } = require('node:child_process');
+
+const CODEX_EXECUTABLE = '/usr/bin/codex';
+const MEDIUM_THREAD = '019f96d5-d6a5-7482-9f6d-b9f14a38aea4';
+const SUSPECT_TURNS = [
+    '019f9740-264d-7bd2-bac4-fc8e5eae2c29',
+    '019f9791-0f4e-7d33-b8c6-dc7a85ee7907',
+];
+
+class RpcClient {
+    constructor() {
+        this.nextId = 1;
+        this.pending = new Map();
+        this.buffer = '';
+        this.child = spawn(
+            CODEX_EXECUTABLE,
+            ['app-server', '--listen', 'stdio://'],
+            { shell: false, stdio: ['pipe', 'pipe', 'pipe'] }
+        );
+        this.child.stderr.on('data', () => undefined);
+        this.child.stdout.on('data', chunk => this.accept(chunk));
+    }
+
+    accept(chunk) {
+        this.buffer += chunk.toString('utf8');
+        for (;;) {
+            const newline = this.buffer.indexOf('\n');
+            if (newline < 0) {
+                return;
+            }
+            const line = this.buffer.slice(0, newline);
+            this.buffer = this.buffer.slice(newline + 1);
+            if (!line.trim()) {
+                continue;
+            }
+            const message = JSON.parse(line);
+            if (typeof message.method === 'string' && message.id === undefined) {
+                continue;
+            }
+            const entry = this.pending.get(message.id);
+            if (!entry) {
+                continue;
+            }
+            this.pending.delete(message.id);
+            if (message.error) {
+                const error = new Error(message.error.message);
+                error.code = message.error.code;
+                entry.reject(error);
+            } else {
+                entry.resolve(message.result);
+            }
+        }
+    }
+
+    write(message) {
+        this.child.stdin.write(`${JSON.stringify(message)}\n`);
+    }
+
+    async connect() {
+        await this.request('initialize', {
+            clientInfo: { name: 'agent_pivot_probe', title: 'Probe', version: '0.0.1' },
+            capabilities: { experimentalApi: true },
+        });
+        this.write({ method: 'initialized', params: {} });
+    }
+
+    request(method, params) {
+        const id = this.nextId++;
+        return new Promise((resolve, reject) => {
+            this.pending.set(id, { resolve, reject });
+            this.write({ method, id, params });
+        });
+    }
+
+    close() {
+        try {
+            this.child.kill();
+        } catch (_error) {
+            // best effort
+        }
+    }
+}
+
+function firstDiff(a, b) {
+    const limit = Math.min(a.length, b.length);
+    for (let index = 0; index < limit; index += 1) {
+        if (a[index] !== b[index]) {
+            return index;
+        }
+    }
+    return a.length === b.length ? -1 : limit;
+}
+
+function context(text, at, radius = 80) {
+    const start = Math.max(0, at - radius);
+    const end = Math.min(text.length, at + radius);
+    return {
+        offset: at,
+        codes: Array.from(text.slice(Math.max(0, at - 2), at + 3))
+            .map(ch => `U+${ch.codePointAt(0).toString(16).toUpperCase()}`),
+        snippet: text.slice(start, end),
+    };
+}
+
+async function main() {
+    const client = new RpcClient();
+    await client.connect();
+
+    const read = await client.request('thread/read', {
+        threadId: MEDIUM_THREAD,
+        includeTurns: true,
+    });
+    const readTurns = read.thread.turns || [];
+
+    const pagedTurns = [];
+    let cursor;
+    for (;;) {
+        const page = await client.request('thread/turns/list', {
+            threadId: MEDIUM_THREAD,
+            cursor,
+            limit: 10,
+            sortDirection: 'asc',
+            itemsView: 'full',
+        });
+        pagedTurns.push(...page.data);
+        cursor = page.nextCursor || undefined;
+        if (!cursor) {
+            break;
+        }
+    }
+
+    const out = {};
+    for (const turnId of SUSPECT_TURNS) {
+        const a = (readTurns.find(turn => turn.id === turnId) || {}).items || [];
+        const b = (pagedTurns.find(turn => turn.id === turnId) || {}).items || [];
+        const diffs = [];
+        const max = Math.max(a.length, b.length);
+        for (let index = 0; index < max; index += 1) {
+            const sa = JSON.stringify(a[index]);
+            const sb = JSON.stringify(b[index]);
+            if (sa === sb) {
+                continue;
+            }
+            const at = firstDiff(sa, sb);
+            diffs.push({
+                itemIndex: index,
+                itemType: a[index] && a[index].type,
+                readLength: sa.length,
+                pagedLength: sb.length,
+                read: context(sa, at),
+                paged: context(sb, at),
+            });
+        }
+        out[turnId] = { differingItems: diffs.length, diffs: diffs.slice(0, 3) };
+    }
+    console.log(JSON.stringify(out, null, 2));
+    client.close();
+}
+
+main().catch(error => {
+    console.error('probe failed:', error);
+    process.exitCode = 1;
+}).finally(() => {
+    process.exit(process.exitCode || 0);
+});

--- a/spikes/codex-paginated-read/probe-followup.js
+++ b/spikes/codex-paginated-read/probe-followup.js
@@ -1,0 +1,230 @@
+'use strict';
+
+/*
+ * Follow-up probe (round 2):
+ *   G. Server-side scaling: `thread/turns/list` tail page + `thread/read`
+ *      on the 175MB session (does the store scan the whole rollout?).
+ *   H. Shape identity on a medium multi-turn session (all turns, all items).
+ */
+
+const { spawn } = require('node:child_process');
+const { performance } = require('node:perf_hooks');
+
+const CODEX_EXECUTABLE = '/usr/bin/codex';
+const HUGE_THREAD = '019fe66d-bd70-73e3-85a8-e92ac1b19f92'; // ~175MB rollout
+const MEDIUM_THREAD = '019f96d5-d6a5-7482-9f6d-b9f14a38aea4'; // ~9.6MB rollout
+
+const report = { phases: {} };
+let currentPhase = 'setup';
+
+function record(key, value) {
+    report.phases[currentPhase][key] = value;
+}
+
+function canonical(value) {
+    if (Array.isArray(value)) {
+        return `[${value.map(canonical).join(',')}]`;
+    }
+    if (value && typeof value === 'object') {
+        const keys = Object.keys(value).sort();
+        return `{${keys.map(k => `${JSON.stringify(k)}:${canonical(value[k])}`).join(',')}}`;
+    }
+    return JSON.stringify(value);
+}
+
+class RpcClient {
+    constructor(capabilities) {
+        this.capabilities = capabilities;
+        this.nextId = 1;
+        this.pending = new Map();
+        this.buffer = '';
+        this.child = spawn(
+            CODEX_EXECUTABLE,
+            ['app-server', '--listen', 'stdio://'],
+            { shell: false, stdio: ['pipe', 'pipe', 'pipe'] }
+        );
+        this.child.stderr.on('data', () => undefined);
+        this.child.stdout.on('data', chunk => this.accept(chunk));
+    }
+
+    accept(chunk) {
+        this.buffer += chunk.toString('utf8');
+        for (;;) {
+            const newline = this.buffer.indexOf('\n');
+            if (newline < 0) {
+                return;
+            }
+            const line = this.buffer.slice(0, newline);
+            this.buffer = this.buffer.slice(newline + 1);
+            if (!line.trim()) {
+                continue;
+            }
+            const message = JSON.parse(line);
+            if (typeof message.method === 'string' && message.id === undefined) {
+                continue;
+            }
+            const entry = this.pending.get(message.id);
+            if (!entry) {
+                continue;
+            }
+            this.pending.delete(message.id);
+            if (message.error) {
+                const error = new Error(message.error.message);
+                error.code = message.error.code;
+                entry.reject(error);
+            } else {
+                entry.resolve(message.result);
+            }
+        }
+    }
+
+    write(message) {
+        this.child.stdin.write(`${JSON.stringify(message)}\n`);
+    }
+
+    async connect() {
+        await this.request('initialize', {
+            clientInfo: { name: 'agent_pivot_probe', title: 'Probe', version: '0.0.1' },
+            capabilities: this.capabilities,
+        });
+        this.write({ method: 'initialized', params: {} });
+    }
+
+    request(method, params) {
+        const id = this.nextId++;
+        return new Promise((resolve, reject) => {
+            this.pending.set(id, { resolve, reject });
+            this.write({ method, id, params });
+        });
+    }
+
+    close() {
+        try {
+            this.child.kill();
+        } catch (_error) {
+            // best effort
+        }
+    }
+}
+
+async function timed(fn) {
+    const started = performance.now();
+    const result = await fn();
+    const elapsedMs = Math.round((performance.now() - started) * 100) / 100;
+    const bytes = Buffer.byteLength(JSON.stringify(result));
+    return { elapsedMs, bytes, result };
+}
+
+async function phaseG() {
+    currentPhase = 'G_scaling_175mb_session';
+    report.phases[currentPhase] = {};
+    const client = new RpcClient({ experimentalApi: true });
+    await client.connect();
+
+    const tail = await timed(() => client.request('thread/turns/list', {
+        threadId: HUGE_THREAD,
+        limit: 1,
+        sortDirection: 'desc',
+        itemsView: 'full',
+    }));
+    record('tailPageFull', {
+        elapsedMs: tail.elapsedMs,
+        bytes: tail.bytes,
+        turns: tail.result.data.length,
+    });
+
+    const tail2 = await timed(() => client.request('thread/turns/list', {
+        threadId: HUGE_THREAD,
+        limit: 1,
+        sortDirection: 'desc',
+        itemsView: 'summary',
+    }));
+    record('tailPageSummaryRepeat', { elapsedMs: tail2.elapsedMs, bytes: tail2.bytes });
+
+    const read = await timed(() => client.request('thread/read', {
+        threadId: HUGE_THREAD,
+        includeTurns: true,
+    }));
+    record('threadRead', {
+        elapsedMs: read.elapsedMs,
+        bytes: read.bytes,
+        turns: (read.result.thread.turns || []).length,
+    });
+
+    client.close();
+}
+
+async function phaseH() {
+    currentPhase = 'H_shape_identity_medium_session';
+    report.phases[currentPhase] = {};
+    const client = new RpcClient({ experimentalApi: true });
+    await client.connect();
+
+    const read = await timed(() => client.request('thread/read', {
+        threadId: MEDIUM_THREAD,
+        includeTurns: true,
+    }));
+    const readTurns = read.result.thread.turns || [];
+
+    const pagedTurns = [];
+    let cursor;
+    for (;;) {
+        const page = await client.request('thread/turns/list', {
+            threadId: MEDIUM_THREAD,
+            cursor,
+            limit: 10,
+            sortDirection: 'asc',
+            itemsView: 'full',
+        });
+        pagedTurns.push(...page.data);
+        cursor = page.nextCursor || undefined;
+        if (!cursor) {
+            break;
+        }
+    }
+
+    const mismatches = [];
+    const count = Math.max(readTurns.length, pagedTurns.length);
+    for (let index = 0; index < count; index += 1) {
+        const a = readTurns[index];
+        const b = pagedTurns[index];
+        if (!a || !b) {
+            mismatches.push({ index, reason: 'missing turn', read: !!a, paged: !!b });
+            continue;
+        }
+        if (a.id !== b.id) {
+            mismatches.push({ index, reason: 'turn id', read: a.id, paged: b.id });
+            continue;
+        }
+        if (canonical(a.items) !== canonical(b.items)) {
+            mismatches.push({ index, reason: 'items differ', turnId: a.id });
+        }
+        if (a.status !== b.status) {
+            mismatches.push({ index, reason: 'status', read: a.status, paged: b.status });
+        }
+    }
+    record('threadRead', { elapsedMs: read.elapsedMs, bytes: read.bytes, turns: readTurns.length });
+    record('paged', { turns: pagedTurns.length });
+    record('mismatchCount', mismatches.length);
+    record('mismatches', mismatches.slice(0, 10));
+    record('identical', mismatches.length === 0 && readTurns.length === pagedTurns.length);
+
+    client.close();
+}
+
+async function main() {
+    for (const fn of [phaseG, phaseH]) {
+        try {
+            await fn();
+        } catch (error) {
+            report.phases[currentPhase] = report.phases[currentPhase] || {};
+            report.phases[currentPhase].fatal = String(error && error.stack || error);
+        }
+    }
+    console.log(JSON.stringify(report, null, 2));
+}
+
+main().catch(error => {
+    console.error('probe failed:', error);
+    process.exitCode = 1;
+});

--- a/spikes/codex-paginated-read/probe.js
+++ b/spikes/codex-paginated-read/probe.js
@@ -1,0 +1,451 @@
+'use strict';
+
+/*
+ * Read-only probe for codex app-server 0.147.0 paginated history APIs.
+ *
+ * Verifies, against real session data:
+ *   A. `thread/turns/list` gating without the experimentalApi capability.
+ *   B. Pagination semantics (sortDirection / cursor / nextCursor /
+ *      backwardsCursor / itemsView) on a real large session.
+ *   C. Shape identity: turns/items from `thread/turns/list` (itemsView=full)
+ *      vs `thread/read` (includeTurns=true) on a small session.
+ *   D. Timing: full `thread/read` vs tail-page `thread/turns/list`.
+ *   E. Live turn: notification stream + in-flight turn visibility via
+ *      `thread/turns/list`.
+ *   F. `thread/turns/list` before the first user message (error shape).
+ *
+ * The probe never writes to sessions under test. Phase E creates one tiny
+ * throwaway thread and archives it afterwards.
+ */
+
+const { spawn } = require('node:child_process');
+const { performance } = require('node:perf_hooks');
+
+const CODEX_EXECUTABLE = '/usr/bin/codex';
+const BIG_THREAD = '019f1c4a-6553-7892-9c45-eb0b9be05bf6'; // ~59.9MB rollout
+const SMALL_THREAD = '019f975c-0b47-7370-bd44-40ee72e9b6f1'; // ~408KB rollout
+
+const report = { phases: {} };
+let currentPhase = 'setup';
+
+function record(key, value) {
+    report.phases[currentPhase][key] = value;
+}
+
+function canonical(value) {
+    if (Array.isArray(value)) {
+        return `[${value.map(canonical).join(',')}]`;
+    }
+    if (value && typeof value === 'object') {
+        const keys = Object.keys(value).sort();
+        return `{${keys.map(k => `${JSON.stringify(k)}:${canonical(value[k])}`).join(',')}}`;
+    }
+    return JSON.stringify(value);
+}
+
+class RpcClient {
+    constructor(capabilities) {
+        this.capabilities = capabilities;
+        this.nextId = 1;
+        this.pending = new Map();
+        this.notificationLog = [];
+        this.buffer = '';
+        this.child = spawn(
+            CODEX_EXECUTABLE,
+            ['app-server', '--listen', 'stdio://'],
+            { shell: false, stdio: ['pipe', 'pipe', 'pipe'] }
+        );
+        this.child.stderr.on('data', () => undefined);
+        this.child.stdout.on('data', chunk => this.accept(chunk));
+    }
+
+    accept(chunk) {
+        this.buffer += chunk.toString('utf8');
+        for (;;) {
+            const newline = this.buffer.indexOf('\n');
+            if (newline < 0) {
+                return;
+            }
+            const line = this.buffer.slice(0, newline);
+            this.buffer = this.buffer.slice(newline + 1);
+            if (!line.trim()) {
+                continue;
+            }
+            let message;
+            try {
+                message = JSON.parse(line);
+            } catch (error) {
+                throw new Error(`unparsable line: ${error.message}`);
+            }
+            if (typeof message.method === 'string' && message.id === undefined) {
+                this.notificationLog.push({
+                    at: performance.now(),
+                    method: message.method,
+                    params: message.params,
+                });
+                continue;
+            }
+            const entry = this.pending.get(message.id);
+            if (!entry) {
+                continue;
+            }
+            this.pending.delete(message.id);
+            if (message.error) {
+                const error = new Error(message.error.message);
+                error.code = message.error.code;
+                entry.reject(error);
+            } else {
+                entry.resolve(message.result);
+            }
+        }
+    }
+
+    write(message) {
+        this.child.stdin.write(`${JSON.stringify(message)}\n`);
+    }
+
+    async connect() {
+        await this.request('initialize', {
+            clientInfo: { name: 'agent_pivot_probe', title: 'Probe', version: '0.0.1' },
+            capabilities: this.capabilities,
+        });
+        this.write({ method: 'initialized', params: {} });
+    }
+
+    request(method, params) {
+        const id = this.nextId++;
+        return new Promise((resolve, reject) => {
+            this.pending.set(id, { resolve, reject });
+            this.write({ method, id, params });
+        });
+    }
+
+    close() {
+        try {
+            this.child.kill();
+        } catch (_error) {
+            // best effort
+        }
+    }
+}
+
+async function timed(label, fn) {
+    const started = performance.now();
+    const result = await fn();
+    const elapsedMs = Math.round((performance.now() - started) * 100) / 100;
+    const bytes = Buffer.byteLength(JSON.stringify(result));
+    return { label, elapsedMs, bytes, result };
+}
+
+function summarizeTurn(turn) {
+    return {
+        id: turn.id,
+        status: turn.status,
+        itemsView: turn.itemsView,
+        items: Array.isArray(turn.items) ? turn.items.length : null,
+        itemChars: Array.isArray(turn.items)
+            ? turn.items.reduce((sum, item) => sum + JSON.stringify(item).length, 0)
+            : null,
+    };
+}
+
+async function phaseA() {
+    currentPhase = 'A_gating_without_capability';
+    report.phases[currentPhase] = {};
+    const client = new RpcClient({});
+    await client.connect();
+    try {
+        await client.request('thread/turns/list', { threadId: BIG_THREAD, limit: 1 });
+        record('error', null);
+    } catch (error) {
+        record('error', { code: error.code, message: error.message });
+    }
+    client.close();
+}
+
+async function phaseB() {
+    currentPhase = 'B_pagination_semantics';
+    report.phases[currentPhase] = {};
+    const client = new RpcClient({ experimentalApi: true });
+    await client.connect();
+
+    const first = await timed('turnsList_desc_limit3_full', () => client.request(
+        'thread/turns/list',
+        { threadId: BIG_THREAD, limit: 3, sortDirection: 'desc', itemsView: 'full' }
+    ));
+    record('firstPage', {
+        elapsedMs: first.elapsedMs,
+        bytes: first.bytes,
+        turns: first.result.data.map(summarizeTurn),
+        hasNextCursor: typeof first.result.nextCursor === 'string',
+        hasBackwardsCursor: typeof first.result.backwardsCursor === 'string',
+    });
+
+    // Follow backwardsCursor with ascending order: the anchor turn must be
+    // included again (the documented "catch updates to that turn" path).
+    const backwards = await timed('turnsList_asc_backwardsCursor', () => client.request(
+        'thread/turns/list',
+        {
+            threadId: BIG_THREAD,
+            cursor: first.result.backwardsCursor,
+            limit: 3,
+            sortDirection: 'asc',
+            itemsView: 'summary',
+        }
+    ));
+    const anchorId = first.result.data[0] && first.result.data[0].id;
+    record('backwardsPage', {
+        elapsedMs: backwards.elapsedMs,
+        turnIds: backwards.result.data.map(turn => turn.id),
+        anchorTurnId: anchorId,
+        anchorIncluded: backwards.result.data.some(turn => turn.id === anchorId),
+        itemsViewEcho: backwards.result.data[0] && backwards.result.data[0].itemsView,
+    });
+
+    // Follow nextCursor descending: older turns, no overlap with first page.
+    const older = await timed('turnsList_desc_nextCursor', () => client.request(
+        'thread/turns/list',
+        {
+            threadId: BIG_THREAD,
+            cursor: first.result.nextCursor,
+            limit: 5,
+            sortDirection: 'desc',
+            itemsView: 'summary',
+        }
+    ));
+    const firstPageIds = new Set(first.result.data.map(turn => turn.id));
+    record('nextPage', {
+        elapsedMs: older.elapsedMs,
+        turnCount: older.result.data.length,
+        overlapsFirstPage: older.result.data.some(turn => firstPageIds.has(turn.id)),
+        hasNextCursor: typeof older.result.nextCursor === 'string',
+    });
+
+    // Count total turns by paging ascending in summary mode.
+    let total = 0;
+    let cursor;
+    for (;;) {
+        const page = await client.request('thread/turns/list', {
+            threadId: BIG_THREAD,
+            cursor,
+            limit: 100,
+            sortDirection: 'asc',
+            itemsView: 'summary',
+        });
+        total += page.data.length;
+        cursor = page.nextCursor || undefined;
+        if (!cursor) {
+            break;
+        }
+    }
+    record('totalTurnsViaPaging', total);
+
+    client.close();
+}
+
+async function phaseC() {
+    currentPhase = 'C_shape_identity_small_session';
+    report.phases[currentPhase] = {};
+    const client = new RpcClient({ experimentalApi: true });
+    await client.connect();
+
+    const read = await timed('threadRead_full', () => client.request(
+        'thread/read',
+        { threadId: SMALL_THREAD, includeTurns: true }
+    ));
+    const readTurns = read.result.thread.turns || [];
+
+    const pagedTurns = [];
+    let cursor;
+    for (;;) {
+        const page = await client.request('thread/turns/list', {
+            threadId: SMALL_THREAD,
+            cursor,
+            limit: 10,
+            sortDirection: 'asc',
+            itemsView: 'full',
+        });
+        pagedTurns.push(...page.data);
+        cursor = page.nextCursor || undefined;
+        if (!cursor) {
+            break;
+        }
+    }
+
+    const mismatches = [];
+    const count = Math.max(readTurns.length, pagedTurns.length);
+    for (let index = 0; index < count; index += 1) {
+        const a = readTurns[index];
+        const b = pagedTurns[index];
+        if (!a || !b) {
+            mismatches.push({ index, reason: 'missing turn', read: !!a, paged: !!b });
+            continue;
+        }
+        if (a.id !== b.id) {
+            mismatches.push({ index, reason: 'turn id', read: a.id, paged: b.id });
+            continue;
+        }
+        if (canonical(a.items) !== canonical(b.items)) {
+            mismatches.push({ index, reason: 'items differ', turnId: a.id });
+        }
+        if (a.status !== b.status) {
+            mismatches.push({ index, reason: 'status', read: a.status, paged: b.status });
+        }
+    }
+    record('threadRead', { elapsedMs: read.elapsedMs, bytes: read.bytes, turns: readTurns.length });
+    record('paged', { turns: pagedTurns.length });
+    record('mismatches', mismatches);
+    record('identical', mismatches.length === 0 && readTurns.length === pagedTurns.length);
+
+    client.close();
+}
+
+async function phaseD() {
+    currentPhase = 'D_timing_large_session';
+    report.phases[currentPhase] = {};
+    const client = new RpcClient({ experimentalApi: true });
+    await client.connect();
+
+    const reads = [];
+    for (let run = 0; run < 3; run += 1) {
+        const sample = await timed('threadRead', () => client.request(
+            'thread/read',
+            { threadId: BIG_THREAD, includeTurns: true }
+        ));
+        reads.push({ elapsedMs: sample.elapsedMs, bytes: sample.bytes });
+    }
+    record('threadReadRuns', reads);
+
+    const tailFull = [];
+    for (let run = 0; run < 3; run += 1) {
+        const sample = await timed('turnsListTailFull', () => client.request(
+            'thread/turns/list',
+            { threadId: BIG_THREAD, limit: 1, sortDirection: 'desc', itemsView: 'full' }
+        ));
+        tailFull.push({ elapsedMs: sample.elapsedMs, bytes: sample.bytes });
+    }
+    record('tailPageFullRuns', tailFull);
+
+    const tailSummary = await timed('turnsListTailSummary', () => client.request(
+        'thread/turns/list',
+        { threadId: BIG_THREAD, limit: 25, sortDirection: 'desc', itemsView: 'summary' }
+    ));
+    record('tailSummary25', { elapsedMs: tailSummary.elapsedMs, bytes: tailSummary.bytes });
+
+    client.close();
+}
+
+async function phasesEF() {
+    currentPhase = 'EF_live_turn';
+    report.phases[currentPhase] = {};
+    const client = new RpcClient({ experimentalApi: true });
+    await client.connect();
+
+    const started = await client.request('thread/start', {});
+    const threadId = started.thread.id;
+    record('liveThreadId', threadId);
+
+    // Phase F: turns/list before the first user message.
+    try {
+        await client.request('thread/turns/list', { threadId, limit: 1 });
+        record('beforeFirstMessage', { error: null });
+    } catch (error) {
+        record('beforeFirstMessage', { error: { code: error.code, message: error.message } });
+    }
+
+    const notificationStart = client.notificationLog.length;
+    const turn = await client.request('turn/start', {
+        threadId,
+        cwd: '/tmp',
+        input: [{ type: 'text', text: 'Reply with exactly: OK' }],
+    });
+    record('turnStart', { turnId: turn.turn && turn.turn.id, status: turn.turn && turn.turn.status });
+
+    // Poll the tail page while the turn runs.
+    const polls = [];
+    let completed = false;
+    const deadline = performance.now() + 90_000;
+    while (!completed && performance.now() < deadline) {
+        const page = await client.request('thread/turns/list', {
+            threadId,
+            limit: 1,
+            sortDirection: 'desc',
+            itemsView: 'full',
+        });
+        const summary = page.data[0] ? summarizeTurn(page.data[0]) : null;
+        const previous = polls[polls.length - 1];
+        if (summary && (!previous
+            || previous.status !== summary.status
+            || previous.items !== summary.items
+            || previous.itemChars !== summary.itemChars)) {
+            polls.push(summary);
+        }
+        completed = client.notificationLog.slice(notificationStart).some(
+            entry => entry.method === 'turn/completed'
+        );
+        if (!completed) {
+            await new Promise(resolve => setTimeout(resolve, 200));
+        }
+    }
+    record('completed', completed);
+    record('pollProgression', polls);
+
+    const liveNotifications = client.notificationLog.slice(notificationStart);
+    const methods = {};
+    let deltaChars = 0;
+    for (const entry of liveNotifications) {
+        methods[entry.method] = (methods[entry.method] || 0) + 1;
+        if (entry.method === 'item/agentMessage/delta' && entry.params
+            && typeof entry.params.delta === 'string') {
+            deltaChars += entry.params.delta.length;
+        }
+    }
+    record('notificationCounts', methods);
+    record('agentMessageDeltaChars', deltaChars);
+
+    const finalPage = await client.request('thread/turns/list', {
+        threadId,
+        limit: 1,
+        sortDirection: 'desc',
+        itemsView: 'full',
+    });
+    const finalTurn = finalPage.data[0];
+    const finalMessage = finalTurn && (finalTurn.items || [])
+        .filter(item => item && item.type === 'agentMessage')
+        .map(item => item.text)
+        .join('');
+    record('finalTurn', finalTurn ? summarizeTurn(finalTurn) : null);
+    record('finalAgentMessage', finalMessage);
+
+    try {
+        await client.request('thread/archive', { threadId });
+        record('archived', true);
+    } catch (error) {
+        record('archived', { error: error.message });
+    }
+    client.close();
+}
+
+async function main() {
+    const phases = [
+        ['A', phaseA],
+        ['B', phaseB],
+        ['C', phaseC],
+        ['D', phaseD],
+        ['EF', phasesEF],
+    ];
+    for (const [name, fn] of phases) {
+        try {
+            await fn();
+        } catch (error) {
+            report.phases[currentPhase] = report.phases[currentPhase] || {};
+            report.phases[currentPhase].fatal = String(error && error.stack || error);
+        }
+    }
+    console.log(JSON.stringify(report, null, 2));
+}
+
+main().catch(error => {
+    console.error('probe failed:', error);
+    process.exitCode = 1;
+});

--- a/src/aiSessions/conversation/codexAdapter.ts
+++ b/src/aiSessions/conversation/codexAdapter.ts
@@ -1296,14 +1296,17 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
     }
 
     /**
-     * Reloads a cached root-thread conversation by fetching only the tail of
-     * the thread through thread/turns/list. Returns null when the tail was
-     * rewritten (compaction/rollback), when a transient transport error
-     * ('unavailable'/'timeout') interrupts the page read, or when the
-     * content would equally fail the stable path — the caller then falls
-     * back to a full thread/read. Method-level rejections and malformed
-     * pages additionally disable the paginated path for the lifetime of
-     * this adapter; transient errors do not.
+     * Reloads a cached root-thread conversation by paging the thread tail
+     * through thread/turns/list. When the cached anchor turn survives, only
+     * the turns from the anchor forward are re-normalized; when the (fast,
+     * indexed) walk reaches the end of the thread without it, the whole
+     * conversation is rebuilt from the fetched pages. Returns null — so the
+     * caller falls back to a full thread/read — on slow (legacy replay)
+     * backends, over-budget walks, anomalous pages, transient transport
+     * errors ('unavailable'/'timeout'), or content the stable path would
+     * equally reject. Method-level rejections and malformed pages
+     * additionally disable the paginated path for the lifetime of this
+     * adapter; transient errors do not.
      */
     private async loadIncremental(
         sessionId: string,
@@ -1369,8 +1372,14 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
             if (anchorIndex >= 0) {
                 break;
             }
-            if (!nextCursor || pageTurns.length === 0) {
+            if (!nextCursor) {
                 break;
+            }
+            if (pageTurns.length === 0) {
+                // An empty page with a live cursor is outside the verified
+                // pagination semantics: settle on the stable full read
+                // rather than rebuilding from a possibly truncated walk.
+                return null;
             }
             if (firstPageMs >= PAGINATED_READ_SLOW_PAGE_MS) {
                 return null;

--- a/src/aiSessions/conversation/codexAdapter.ts
+++ b/src/aiSessions/conversation/codexAdapter.ts
@@ -1266,10 +1266,12 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
     /**
      * Reloads a cached root-thread conversation by fetching only the tail of
      * the thread through thread/turns/list. Returns null when the tail was
-     * rewritten (compaction/rollback) or the content would equally fail the
-     * stable path — the caller then falls back to a full thread/read. Any
-     * transport- or page-level anomaly additionally disables the paginated
-     * path for the lifetime of this adapter.
+     * rewritten (compaction/rollback), when a transient transport error
+     * ('unavailable'/'timeout') interrupts the page read, or when the
+     * content would equally fail the stable path — the caller then falls
+     * back to a full thread/read. Method-level rejections and malformed
+     * pages additionally disable the paginated path for the lifetime of
+     * this adapter; transient errors do not.
      */
     private async loadIncremental(
         sessionId: string,

--- a/src/aiSessions/conversation/codexAdapter.ts
+++ b/src/aiSessions/conversation/codexAdapter.ts
@@ -1250,11 +1250,6 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
                 return { ...incremental, kind: 'incremental' };
             }
         }
-        if (stale) {
-            // A stale or unverifiable entry is released rather than
-            // lingering beside — or instead of — its replacement.
-            this.deleteLoadedConversationCacheEntry(sessionId, stale);
-        }
         const fresh = await this.loadFresh(sessionId, signal);
         return { ...fresh, kind: 'fresh' };
     }
@@ -1310,6 +1305,14 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
                         'unavailable',
                         'reconnectingCodex'
                     );
+                }
+                if (error instanceof ConversationError
+                    && (error.code === 'unavailable'
+                        || error.code === 'timeout')) {
+                    // Transient transport failure (child restart, an
+                    // unrelated request timing out the shared child): fall
+                    // back for this load without retiring the accelerator.
+                    return null;
                 }
                 this.paginatedReadsDisabled = true;
                 return null;
@@ -1380,9 +1383,14 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
         );
         if (sourceRevision === cached.value.sourceRevision) {
             // The stat moved but the visible content did not: keep the
-            // cached value (its identity is pinned to the revision) and let
-            // the caller re-anchor the entry to the new signature.
-            return { value: cached.value, turns, characters };
+            // cached value (its identity is pinned to the revision) and its
+            // chunks (their interactions share the value's objects), and
+            // let the caller re-anchor the entry to the new signature.
+            return {
+                value: cached.value,
+                turns: cached.turns,
+                characters: cached.characters,
+            };
         }
         const interactions = this.promoteRunningLifecycle(
             sessionId,

--- a/src/aiSessions/conversation/codexAdapter.ts
+++ b/src/aiSessions/conversation/codexAdapter.ts
@@ -1198,7 +1198,9 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
                 cached.lastTouchedAt = this.now();
                 this.loadedConversationCache.delete(sessionId);
                 this.loadedConversationCache.set(sessionId, cached);
-                return Promise.resolve(cached.value);
+                return Promise.resolve(
+                    this.withRunningLifecycle(sessionId, cached.value)
+                );
             }
             // A stale or unverifiable entry is released immediately rather
             // than lingering beside — or instead of — its replacement.
@@ -1222,8 +1224,29 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
                     turns: outcome.turns,
                 });
             }
-            return outcome.value;
+            return this.withRunningLifecycle(sessionId, outcome.value);
         });
+    }
+
+    // The rollout lifecycle is external, time-varying state — never part of
+    // the cached content. It is re-applied to the cached base interactions
+    // on every read, so a stopped/started session reflects the current
+    // signal even when the conversation bytes (and revision) are unchanged.
+    private withRunningLifecycle(
+        sessionId: string,
+        value: LoadedConversation
+    ): LoadedConversation {
+        const split = splitSubagentSessionId(sessionId);
+        if (split.subagentId || !value.interactions.length) {
+            return value;
+        }
+        const interactions = this.promoteRunningLifecycle(
+            split.sessionId,
+            value.interactions
+        );
+        return interactions === value.interactions
+            ? value
+            : { interactions, sourceRevision: value.sourceRevision };
     }
 
     private async loadConversation(
@@ -1394,12 +1417,9 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
                 characters: cached.characters,
             };
         }
-        const interactions = this.promoteRunningLifecycle(
-            sessionId,
-            turns.reduce<ConversationInteraction[]>(
-                (all, turn) => all.concat(turn.interactions),
-                []
-            )
+        const interactions = turns.reduce<ConversationInteraction[]>(
+            (all, turn) => all.concat(turn.interactions),
+            []
         );
         return { value: { interactions, sourceRevision }, turns, characters };
     }
@@ -1538,14 +1558,8 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
         // Keep the protocol fingerprint content-only, then let the rollout's
         // authoritative lifecycle promote the latest visible interaction.
         const sourceRevision = composeConversationRevision(turns);
-        const interactions = split.subagentId || !normalized.interactions.length
-            ? normalized.interactions
-            : this.promoteRunningLifecycle(
-                split.sessionId,
-                normalized.interactions
-            );
         return {
-            value: { interactions, sourceRevision },
+            value: { interactions: normalized.interactions, sourceRevision },
             // Turn chunks only serve the incremental paginated reload path,
             // which is limited to root threads: a subagent's seeded dispatch
             // interaction accumulates items across turns, so its chunks are

--- a/src/aiSessions/conversation/codexAdapter.ts
+++ b/src/aiSessions/conversation/codexAdapter.ts
@@ -118,10 +118,19 @@ const LARGE_CONVERSATION_CACHE_IDLE_MS = 10 * 60 * 1000;
 // on any anomaly.
 const PAGINATED_READ_SERVER_VERSIONS = new Set(['0.147']);
 const PAGINATED_READ_PAGE_SIZE = 4;
-// How many turns an incremental reload walks back looking for the cached
-// anchor turn before treating the tail as rewritten (compaction/rollback)
-// and falling back to a full read.
-const PAGINATED_READ_WALK_LIMIT = 64;
+// First-page latency separates the two server backends (spike
+// measurements): the indexed paginated backend answers in tens of ms,
+// while the legacy rollout-replay backend needs hundreds of ms PER PAGE —
+// each page costs a full replay, as much as one full thread/read. A slow
+// first page therefore ends the anchor walk immediately: further paging
+// can only lose against the full-read fallback.
+const PAGINATED_READ_SLOW_PAGE_MS = 250;
+// Bounds for anchor walks on the fast paginated backend. Compaction makes
+// the walk run to the end of the thread and rebuilds from the fetched
+// pages — for huge paginated sessions a full thread/read would exceed the
+// request timeout outright, so the walk must be allowed to be generous.
+const PAGINATED_READ_WALK_TURN_LIMIT = 1024;
+const PAGINATED_READ_WALK_BUDGET_MS = 3000;
 
 interface LoadedConversation {
     interactions: ConversationInteraction[];
@@ -1310,7 +1319,9 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
         const fetched: Record<string, any>[] = [];
         let cursor: string | undefined;
         let anchorIndex = -1;
-        while (anchorIndex < 0 && fetched.length < PAGINATED_READ_WALK_LIMIT) {
+        const walkStartedAt = this.now();
+        let firstPageMs: number | undefined;
+        for (;;) {
             let page: unknown;
             try {
                 page = await this.options.client.request('thread/turns/list', {
@@ -1350,57 +1361,44 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
                 this.paginatedReadsDisabled = true;
                 return null;
             }
+            if (firstPageMs === undefined) {
+                firstPageMs = this.now() - walkStartedAt;
+            }
             fetched.push(...pageTurns);
             anchorIndex = fetched.findIndex(turn => turn.id === anchorTurnId);
+            if (anchorIndex >= 0) {
+                break;
+            }
             if (!nextCursor || pageTurns.length === 0) {
                 break;
             }
+            if (firstPageMs >= PAGINATED_READ_SLOW_PAGE_MS) {
+                return null;
+            }
+            if (fetched.length >= PAGINATED_READ_WALK_TURN_LIMIT
+                || this.now() - walkStartedAt
+                    >= PAGINATED_READ_WALK_BUDGET_MS) {
+                return null;
+            }
             cursor = nextCursor;
         }
-        if (anchorIndex < 0) {
+        // `fetched` is newest-first. When the anchor survived, only the
+        // turns from the anchor forward are re-normalized (the anchor may
+        // have grown since it was cached). When the walk ran to the end of
+        // the thread without finding it, the tail was rewritten
+        // (compaction/rollback) and every chunk is rebuilt from the fetched
+        // pages — the paginated backend serves them cheaply, while a full
+        // thread/read of a huge paginated session would exceed the request
+        // timeout outright.
+        const kept = anchorIndex >= 0 ? cached.turns.slice(0, -1) : [];
+        const reloaded = (anchorIndex >= 0
+            ? fetched.slice(0, anchorIndex + 1)
+            : fetched
+        ).reverse();
+        const turns = this.normalizeReloadedTurns(kept, reloaded);
+        if (!turns) {
             return null;
         }
-        // `fetched` is newest-first: re-read the anchor turn (it may have
-        // grown since it was cached) plus every turn appended after it,
-        // in chronological order.
-        const replaced = fetched.slice(0, anchorIndex + 1).reverse();
-        const kept = cached.turns.slice(0, -1);
-        const itemIds = new Set<string>();
-        for (const chunk of kept) {
-            for (const itemId of chunk.itemIds) {
-                itemIds.add(itemId);
-            }
-        }
-        const keptTurnIds = new Set(kept.map(chunk => chunk.turnId));
-        const newTurns: LoadedConversationTurn[] = [];
-        try {
-            for (const turn of replaced) {
-                if (keptTurnIds.has(turn.id)) {
-                    // A supposedly immutable earlier turn reappeared: the
-                    // history was rewritten, which only a full read settles.
-                    return null;
-                }
-                const context: NormalizeTurnContext = {
-                    interactions: [],
-                    itemIds,
-                    newItemIds: [],
-                    seededDispatchTimingComplete: true,
-                };
-                normalizeTurnItems(turn, context);
-                newTurns.push({
-                    turnId: turn.id,
-                    interactions: context.interactions,
-                    itemIds: context.newItemIds,
-                    fingerprint: fingerprintInteractions(context.interactions),
-                    characters: conversationCharacters(context.interactions),
-                });
-            }
-        } catch (_error) {
-            // Content the stable path would reject as well: fall back so the
-            // full read surfaces the canonical error.
-            return null;
-        }
-        const turns = [...kept, ...newTurns];
         const sourceRevision = composeConversationRevision(turns);
         const characters = turns.reduce(
             (sum, turn) => sum + turn.characters,
@@ -1422,6 +1420,50 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
             []
         );
         return { value: { interactions, sourceRevision }, turns, characters };
+    }
+
+    // Normalizes re-fetched turns (chronological) on top of the kept cached
+    // chunks, preserving the full read's thread-wide turn-id and item-id
+    // invariants. Returns null when the content conflicts with the kept
+    // history or would equally fail the stable path, so the caller falls
+    // back to a full read that settles (or canonically rejects) it.
+    private normalizeReloadedTurns(
+        kept: LoadedConversationTurn[],
+        reloaded: Record<string, any>[]
+    ): LoadedConversationTurn[] | null {
+        const itemIds = new Set<string>();
+        for (const chunk of kept) {
+            for (const itemId of chunk.itemIds) {
+                itemIds.add(itemId);
+            }
+        }
+        const knownTurnIds = new Set(kept.map(chunk => chunk.turnId));
+        const rebuilt: LoadedConversationTurn[] = [];
+        try {
+            for (const turn of reloaded) {
+                if (knownTurnIds.has(turn.id)) {
+                    return null;
+                }
+                knownTurnIds.add(turn.id);
+                const context: NormalizeTurnContext = {
+                    interactions: [],
+                    itemIds,
+                    newItemIds: [],
+                    seededDispatchTimingComplete: true,
+                };
+                normalizeTurnItems(turn, context);
+                rebuilt.push({
+                    turnId: turn.id,
+                    interactions: context.interactions,
+                    itemIds: context.newItemIds,
+                    fingerprint: fingerprintInteractions(context.interactions),
+                    characters: conversationCharacters(context.interactions),
+                });
+            }
+        } catch (_error) {
+            return null;
+        }
+        return [...kept, ...rebuilt];
     }
 
     private storeLoadedConversationCacheEntry(

--- a/src/aiSessions/conversation/codexAdapter.ts
+++ b/src/aiSessions/conversation/codexAdapter.ts
@@ -59,6 +59,10 @@ export interface CodexConversationClient extends AiSessionDisposable {
     watchNotifications?(
         listener: (method: string, params: unknown) => void
     ): AiSessionDisposable;
+    // Sanitized `major.minor` server version captured at initialize time,
+    // when the client exposes it. Gates version-sensitive protocol
+    // accelerators such as thread/turns/list.
+    getServerVersion?(): string | undefined;
 }
 
 interface CodexRolloutTelemetrySnapshot {
@@ -107,10 +111,33 @@ const LARGE_CONVERSATION_CACHE_ENTRIES = 2;
 const LARGE_CONVERSATION_CACHE_BUDGET_CHARS = 8 * 1024 * 1024;
 // Entries unused for this long are released on the next read.
 const LARGE_CONVERSATION_CACHE_IDLE_MS = 10 * 60 * 1000;
+// Server versions whose thread/turns/list behavior was verified against a
+// real app-server (spikes/codex-paginated-read). The method is gated behind
+// the experimentalApi capability and may drift at any release, so paginated
+// reloads only run on verified versions and fall back to a full thread/read
+// on any anomaly.
+const PAGINATED_READ_SERVER_VERSIONS = new Set(['0.147']);
+const PAGINATED_READ_PAGE_SIZE = 4;
+// How many turns an incremental reload walks back looking for the cached
+// anchor turn before treating the tail as rewritten (compaction/rollback)
+// and falling back to a full read.
+const PAGINATED_READ_WALK_LIMIT = 64;
 
 interface LoadedConversation {
     interactions: ConversationInteraction[];
     sourceRevision: string;
+}
+
+// Per-turn normalized chunks of a cached root-thread conversation. Chunk
+// interactions share objects with `value.interactions` (no string payload
+// is duplicated); they let an incremental reload re-normalize only the
+// turns that actually changed.
+interface LoadedConversationTurn {
+    turnId: string;
+    itemIds: string[];
+    interactions: ConversationInteraction[];
+    fingerprint: string;
+    characters: number;
 }
 
 interface CachedLoadedConversation {
@@ -118,6 +145,7 @@ interface CachedLoadedConversation {
     contentSignature: string;
     characters: number;
     lastTouchedAt: number;
+    turns?: LoadedConversationTurn[];
 }
 
 function asRecord(value: unknown): Record<string, any> | undefined {
@@ -232,11 +260,195 @@ function appendTurnTiming(
     return true;
 }
 
+// Mutable state shared across the per-turn normalization passes of one
+// thread. `itemIds` rejects duplicate item ids thread-wide; `newItemIds`
+// collects the ids contributed by the current turn so a cached turn chunk
+// can be re-normalized without tripping its own ids.
+interface NormalizeTurnContext {
+    interactions: ConversationInteraction[];
+    itemIds: Set<string>;
+    newItemIds: string[];
+    seededDispatchIndex?: number;
+    seededDispatchTimingComplete: boolean;
+}
+
+function normalizeTurnItems(
+    turn: Record<string, any>,
+    context: NormalizeTurnContext
+): void {
+    const interactions = context.interactions;
+    const itemIds = context.itemIds;
+    const seededDispatchIndex = context.seededDispatchIndex;
+    const responseState = turnResponseState(turn.status);
+    if (seededDispatchIndex !== undefined) {
+        interactions[seededDispatchIndex].responseState = responseState;
+    }
+    const timing = turnTiming(turn);
+    let timingAssigned = false;
+    let currentInteractionIndex: number | undefined = seededDispatchIndex;
+    for (const rawItem of turn.items) {
+        const item = asRecord(rawItem);
+        if (!item
+            || typeof item.id !== 'string'
+            || !item.id
+            || itemIds.has(item.id)
+            || typeof item.type !== 'string') {
+            throw protocolError();
+        }
+        itemIds.add(item.id);
+        context.newItemIds.push(item.id);
+        if (item.type === 'userMessage') {
+            currentInteractionIndex = undefined;
+            if (!Array.isArray(item.content)) {
+                throw protocolError();
+            }
+            const parts: VisibleUserInputPart[] = [];
+            for (const rawPart of item.content) {
+                const part = asRecord(rawPart);
+                if (!part || typeof part.type !== 'string') {
+                    throw protocolError();
+                }
+                if (part.type === 'text') {
+                    if (typeof part.text !== 'string') {
+                        throw protocolError();
+                    }
+                    parts.push({ kind: 'text', text: part.text });
+                } else if (
+                    part.type === 'image'
+                    || part.type === 'audio'
+                ) {
+                    if (typeof part.url !== 'string') {
+                        throw protocolError();
+                    }
+                    parts.push({ kind: 'attachment' });
+                } else if (
+                    part.type === 'localImage'
+                    || part.type === 'localAudio'
+                ) {
+                    if (typeof part.path !== 'string') {
+                        throw protocolError();
+                    }
+                    parts.push({ kind: 'attachment' });
+                }
+            }
+            const userMarkdown = visibleMessage(
+                buildVisibleUserInput(parts)
+            );
+            if (!userMarkdown) {
+                continue;
+            }
+            interactions.push({
+                id: item.id,
+                providerTurnId: turn.id,
+                ...(!timingAssigned ? timing : {}),
+                userMarkdown,
+                userPreview: buildUserPreview(userMarkdown),
+                userGraphemeCount: countGraphemes(userMarkdown),
+                assistantMarkdown: [],
+                responseState,
+            });
+            currentInteractionIndex = interactions.length - 1;
+            timingAssigned = true;
+        } else if (item.type === 'reasoning') {
+            if (currentInteractionIndex === undefined) {
+                continue;
+            }
+            // App-server exposes readable summaries separately from raw
+            // reasoning content. Only the summary is safe viewer output;
+            // never fall back to `content` or legacy `text` fields.
+            const text = normalizeReasoningSummary(item.summary);
+            if (text) {
+                const interaction = interactions[currentInteractionIndex];
+                (interaction.thinking ||= []).push({
+                    position: interaction.assistantMarkdown.length,
+                    text,
+                });
+            }
+        } else if (item.type === 'commandExecution'
+            || item.type === 'fileChange') {
+            if (currentInteractionIndex === undefined) {
+                continue;
+            }
+            const tool = normalizeToolItem(item);
+            if (!tool) {
+                continue;
+            }
+            const interaction = interactions[currentInteractionIndex];
+            (interaction.toolCalls ||= []).push({
+                position: interaction.assistantMarkdown.length,
+                ...tool,
+            });
+        } else if (item.type === 'plan') {
+            if (currentInteractionIndex === undefined) {
+                continue;
+            }
+            const planText = typeof item.text === 'string'
+                ? visibleMessage(item.text)
+                : '';
+            if (!planText) {
+                continue;
+            }
+            const interaction = interactions[currentInteractionIndex];
+            (interaction.plans ||= []).push({
+                position: interaction.assistantMarkdown.length,
+                markdown: planText,
+            });
+        } else if (item.type === 'agentMessage') {
+            if (typeof item.text !== 'string') {
+                throw protocolError();
+            }
+            if (currentInteractionIndex === undefined) {
+                continue;
+            }
+            const text = visibleMessage(item.text);
+            if (!text) {
+                continue;
+            }
+            const interaction = interactions[currentInteractionIndex];
+            if (item.phase === 'commentary') {
+                appendConversationAssistantText(
+                    interaction,
+                    text,
+                    'progress'
+                );
+            } else {
+                appendConversationAssistantText(interaction, text);
+            }
+        }
+    }
+    if (seededDispatchIndex !== undefined && !timingAssigned) {
+        // A Codex subagent transcript can span several provider turns
+        // while still representing one synthetic dispatch interaction.
+        // Sum active turn durations so the UI reports actual work time,
+        // excluding idle gaps between those turns.
+        if (context.seededDispatchTimingComplete
+            && !appendTurnTiming(
+                interactions[seededDispatchIndex],
+                timing
+            )) {
+            context.seededDispatchTimingComplete = false;
+            delete interactions[seededDispatchIndex].completedAt;
+        }
+    }
+}
+
+// One provider turn's contribution to a conversation: the interactions it
+// created (a subagent turn can instead mutate the seeded dispatch
+// interaction, captured separately) plus the item ids it consumed.
+interface NormalizedConversationTurn {
+    turnId: string;
+    interactions: ConversationInteraction[];
+    itemIds: string[];
+}
+
 function normalizeThreadRead(
     value: unknown,
     sessionId: string,
     dispatch?: { label: string; timestamp?: number }
-): ConversationInteraction[] {
+): {
+    interactions: ConversationInteraction[];
+    turns: NormalizedConversationTurn[];
+} {
     const result = asRecord(value);
     const thread = asRecord(result?.thread);
     if (!thread
@@ -246,15 +458,18 @@ function normalizeThreadRead(
         throw protocolError();
     }
     const turnIds = new Set<string>();
-    const itemIds = new Set<string>();
-    const interactions: ConversationInteraction[] = [];
+    const context: NormalizeTurnContext = {
+        interactions: [],
+        itemIds: new Set<string>(),
+        newItemIds: [],
+        seededDispatchTimingComplete: true,
+    };
+    const turns: NormalizedConversationTurn[] = [];
     // A subagent thread exposes no userMessage for its dispatch prompt
     // (the app-server strips it), so seed one from the thread metadata to
     // give the subagent's agentMessages an interaction to attach to.
-    let seededDispatchIndex: number | undefined;
-    let seededDispatchTimingComplete = true;
     if (dispatch) {
-        interactions.push({
+        context.interactions.push({
             id: `${sessionId}-dispatch`,
             ...(dispatch.timestamp !== undefined
                 ? { timestamp: dispatch.timestamp }
@@ -265,7 +480,7 @@ function normalizeThreadRead(
             assistantMarkdown: [],
             responseState: 'unknown',
         });
-        seededDispatchIndex = 0;
+        context.seededDispatchIndex = 0;
     }
     for (const rawTurn of thread.turns) {
         const turn = asRecord(rawTurn);
@@ -278,158 +493,26 @@ function normalizeThreadRead(
             throw protocolError();
         }
         turnIds.add(turn.id);
-        const responseState = turnResponseState(turn.status);
-        if (seededDispatchIndex !== undefined) {
-            interactions[seededDispatchIndex].responseState = responseState;
-        }
-        const timing = turnTiming(turn);
-        let timingAssigned = false;
-        let currentInteractionIndex: number | undefined = seededDispatchIndex;
-        for (const rawItem of turn.items) {
-            const item = asRecord(rawItem);
-            if (!item
-                || typeof item.id !== 'string'
-                || !item.id
-                || itemIds.has(item.id)
-                || typeof item.type !== 'string') {
-                throw protocolError();
-            }
-            itemIds.add(item.id);
-            if (item.type === 'userMessage') {
-                currentInteractionIndex = undefined;
-                if (!Array.isArray(item.content)) {
-                    throw protocolError();
-                }
-                const parts: VisibleUserInputPart[] = [];
-                for (const rawPart of item.content) {
-                    const part = asRecord(rawPart);
-                    if (!part || typeof part.type !== 'string') {
-                        throw protocolError();
-                    }
-                    if (part.type === 'text') {
-                        if (typeof part.text !== 'string') {
-                            throw protocolError();
-                        }
-                        parts.push({ kind: 'text', text: part.text });
-                    } else if (
-                        part.type === 'image'
-                        || part.type === 'audio'
-                    ) {
-                        if (typeof part.url !== 'string') {
-                            throw protocolError();
-                        }
-                        parts.push({ kind: 'attachment' });
-                    } else if (
-                        part.type === 'localImage'
-                        || part.type === 'localAudio'
-                    ) {
-                        if (typeof part.path !== 'string') {
-                            throw protocolError();
-                        }
-                        parts.push({ kind: 'attachment' });
-                    }
-                }
-                const userMarkdown = visibleMessage(
-                    buildVisibleUserInput(parts)
-                );
-                if (!userMarkdown) {
-                    continue;
-                }
-                interactions.push({
-                    id: item.id,
-                    providerTurnId: turn.id,
-                    ...(!timingAssigned ? timing : {}),
-                    userMarkdown,
-                    userPreview: buildUserPreview(userMarkdown),
-                    userGraphemeCount: countGraphemes(userMarkdown),
-                    assistantMarkdown: [],
-                    responseState,
-                });
-                currentInteractionIndex = interactions.length - 1;
-                timingAssigned = true;
-            } else if (item.type === 'reasoning') {
-                if (currentInteractionIndex === undefined) {
-                    continue;
-                }
-                // App-server exposes readable summaries separately from raw
-                // reasoning content. Only the summary is safe viewer output;
-                // never fall back to `content` or legacy `text` fields.
-                const text = normalizeReasoningSummary(item.summary);
-                if (text) {
-                    const interaction = interactions[currentInteractionIndex];
-                    (interaction.thinking ||= []).push({
-                        position: interaction.assistantMarkdown.length,
-                        text,
-                    });
-                }
-            } else if (item.type === 'commandExecution'
-                || item.type === 'fileChange') {
-                if (currentInteractionIndex === undefined) {
-                    continue;
-                }
-                const tool = normalizeToolItem(item);
-                if (!tool) {
-                    continue;
-                }
-                const interaction = interactions[currentInteractionIndex];
-                (interaction.toolCalls ||= []).push({
-                    position: interaction.assistantMarkdown.length,
-                    ...tool,
-                });
-            } else if (item.type === 'plan') {
-                if (currentInteractionIndex === undefined) {
-                    continue;
-                }
-                const planText = typeof item.text === 'string'
-                    ? visibleMessage(item.text)
-                    : '';
-                if (!planText) {
-                    continue;
-                }
-                const interaction = interactions[currentInteractionIndex];
-                (interaction.plans ||= []).push({
-                    position: interaction.assistantMarkdown.length,
-                    markdown: planText,
-                });
-            } else if (item.type === 'agentMessage') {
-                if (typeof item.text !== 'string') {
-                    throw protocolError();
-                }
-                if (currentInteractionIndex === undefined) {
-                    continue;
-                }
-                const text = visibleMessage(item.text);
-                if (!text) {
-                    continue;
-                }
-                const interaction = interactions[currentInteractionIndex];
-                if (item.phase === 'commentary') {
-                    appendConversationAssistantText(
-                        interaction,
-                        text,
-                        'progress'
-                    );
-                } else {
-                    appendConversationAssistantText(interaction, text);
-                }
-            }
-        }
-        if (seededDispatchIndex !== undefined && !timingAssigned) {
-            // A Codex subagent transcript can span several provider turns
-            // while still representing one synthetic dispatch interaction.
-            // Sum active turn durations so the UI reports actual work time,
-            // excluding idle gaps between those turns.
-            if (seededDispatchTimingComplete
-                && !appendTurnTiming(
-                    interactions[seededDispatchIndex],
-                    timing
-                )) {
-                seededDispatchTimingComplete = false;
-                delete interactions[seededDispatchIndex].completedAt;
-            }
-        }
+        context.newItemIds = [];
+        const startIndex = context.interactions.length;
+        normalizeTurnItems(turn, context);
+        turns.push({
+            turnId: turn.id,
+            interactions: context.interactions.slice(startIndex),
+            itemIds: context.newItemIds,
+        });
     }
-    return interactions;
+    if (dispatch) {
+        // The seed interaction is mutated by later turns, so its chunk is
+        // captured after the loop with its final state. Keeping it as chunk
+        // zero makes the chunk list partition the flat interaction array.
+        turns.unshift({
+            turnId: '',
+            interactions: [context.interactions[0]],
+            itemIds: [],
+        });
+    }
+    return { interactions: context.interactions, turns };
 }
 
 function fingerprintInteractions(
@@ -438,6 +521,73 @@ function fingerprintInteractions(
     return createHash('sha256')
         .update(JSON.stringify(interactions), 'utf8')
         .digest('hex');
+}
+
+// The conversation revision is composed from per-turn fingerprints so an
+// incremental reload only hashes the turns it re-read. The composition is
+// opaque downstream and identical across the full and incremental paths for
+// identical content.
+function composeConversationRevision(
+    turns: readonly LoadedConversationTurn[]
+): string {
+    return createHash('sha256')
+        .update(turns.map(turn => turn.fingerprint).join(':'), 'utf8')
+        .digest('hex');
+}
+
+function conversationCharacters(
+    interactions: readonly ConversationInteraction[]
+): number {
+    let characters = 0;
+    for (const interaction of interactions) {
+        characters += interaction.userMarkdown?.length || 0;
+        for (const markdown of interaction.assistantMarkdown) {
+            characters += markdown.length;
+        }
+        for (const tool of interaction.toolCalls || []) {
+            characters += (tool.summary?.length || 0)
+                + (tool.detail?.length || 0);
+        }
+        for (const thinking of interaction.thinking || []) {
+            characters += thinking.text?.length || 0;
+        }
+    }
+    return characters;
+}
+
+// Validates one thread/turns/list page. Turn-level checks mirror
+// normalizeThreadRead so a turn that passes here is safe to feed into
+// normalizeTurnItems.
+function parseTurnsListPage(
+    value: unknown
+): { turns: Record<string, any>[]; nextCursor?: string } {
+    const page = asRecord(value);
+    if (!page || !Array.isArray(page.data)) {
+        throw protocolError();
+    }
+    if (page.nextCursor !== undefined
+        && page.nextCursor !== null
+        && typeof page.nextCursor !== 'string') {
+        throw protocolError();
+    }
+    const turns: Record<string, any>[] = [];
+    for (const rawTurn of page.data) {
+        const turn = asRecord(rawTurn);
+        if (!turn
+            || typeof turn.id !== 'string'
+            || !turn.id
+            || typeof turn.status !== 'string'
+            || !Array.isArray(turn.items)) {
+            throw protocolError();
+        }
+        turns.push(turn);
+    }
+    return {
+        turns,
+        nextCursor: typeof page.nextCursor === 'string'
+            ? page.nextCursor
+            : undefined,
+    };
 }
 
 function normalizeToolItem(
@@ -637,6 +787,11 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
     private loadedConversationCacheChars = 0;
     private conversationCacheGeneration = 0;
     private disposed = false;
+    // Circuit breaker for the experimental thread/turns/list accelerator:
+    // once the server rejects the method or answers with a malformed page,
+    // the paginated path is disabled for the lifetime of this adapter and
+    // every reload uses the stable full thread/read instead.
+    private paginatedReadsDisabled = false;
 
     constructor(private readonly options: CodexConversationAdapterOptions) {
         this.notificationWatch = options.client.watchNotifications?.(
@@ -1051,24 +1206,192 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
         }
         const generation = this.conversationCacheGeneration;
         const startedAt = this.now();
-        return this.loadFresh(sessionId, signal).then(value => {
+        return this.loadConversation(sessionId, cached, signal).then(outcome => {
             if (!this.disposed
                 && generation === this.conversationCacheGeneration
-                && signature !== undefined) {
-                const characters = this.conversationCharacters(value);
-                if (characters >= LARGE_CONVERSATION_CACHE_CHARS
+                && signature !== undefined
+                && (outcome.kind === 'incremental'
+                    || outcome.characters >= LARGE_CONVERSATION_CACHE_CHARS
                     || this.now() - startedAt
-                        >= LARGE_CONVERSATION_CACHE_MIN_READ_MS) {
-                    this.storeLoadedConversationCacheEntry(sessionId, {
-                        value,
-                        contentSignature: signature,
-                        characters,
-                        lastTouchedAt: this.now(),
-                    });
-                }
+                        >= LARGE_CONVERSATION_CACHE_MIN_READ_MS)) {
+                this.storeLoadedConversationCacheEntry(sessionId, {
+                    value: outcome.value,
+                    contentSignature: signature,
+                    characters: outcome.characters,
+                    lastTouchedAt: this.now(),
+                    turns: outcome.turns,
+                });
             }
-            return value;
+            return outcome.value;
         });
+    }
+
+    private async loadConversation(
+        sessionId: string,
+        stale: CachedLoadedConversation | undefined,
+        signal?: ConversationAbortSignal
+    ): Promise<{
+        value: LoadedConversation;
+        turns?: LoadedConversationTurn[];
+        characters: number;
+        kind: 'fresh' | 'incremental';
+    }> {
+        const split = splitSubagentSessionId(sessionId);
+        if (stale?.turns?.length
+            && !split.subagentId
+            && this.paginatedReadsUsable()) {
+            const incremental = await this.loadIncremental(
+                sessionId,
+                stale as CachedLoadedConversation
+                    & { turns: LoadedConversationTurn[] },
+                signal
+            );
+            if (incremental) {
+                return { ...incremental, kind: 'incremental' };
+            }
+        }
+        if (stale) {
+            // A stale or unverifiable entry is released rather than
+            // lingering beside — or instead of — its replacement.
+            this.deleteLoadedConversationCacheEntry(sessionId, stale);
+        }
+        const fresh = await this.loadFresh(sessionId, signal);
+        return { ...fresh, kind: 'fresh' };
+    }
+
+    private paginatedReadsUsable(): boolean {
+        if (this.paginatedReadsDisabled) {
+            return false;
+        }
+        const version = this.options.client.getServerVersion?.();
+        return version !== undefined
+            && PAGINATED_READ_SERVER_VERSIONS.has(version);
+    }
+
+    /**
+     * Reloads a cached root-thread conversation by fetching only the tail of
+     * the thread through thread/turns/list. Returns null when the tail was
+     * rewritten (compaction/rollback) or the content would equally fail the
+     * stable path — the caller then falls back to a full thread/read. Any
+     * transport- or page-level anomaly additionally disables the paginated
+     * path for the lifetime of this adapter.
+     */
+    private async loadIncremental(
+        sessionId: string,
+        cached: CachedLoadedConversation
+            & { turns: LoadedConversationTurn[] },
+        signal?: ConversationAbortSignal
+    ): Promise<{
+        value: LoadedConversation;
+        turns: LoadedConversationTurn[];
+        characters: number;
+    } | null> {
+        const anchorTurnId = cached.turns[cached.turns.length - 1].turnId;
+        const fetched: Record<string, any>[] = [];
+        let cursor: string | undefined;
+        let anchorIndex = -1;
+        while (anchorIndex < 0 && fetched.length < PAGINATED_READ_WALK_LIMIT) {
+            let page: unknown;
+            try {
+                page = await this.options.client.request('thread/turns/list', {
+                    threadId: sessionId,
+                    cursor,
+                    limit: PAGINATED_READ_PAGE_SIZE,
+                    sortDirection: 'desc',
+                    itemsView: 'full',
+                }, signal);
+            } catch (error) {
+                if (error instanceof ConversationAbortError
+                    || error?.name === 'AbortError') {
+                    throw error;
+                }
+                if (this.disposed) {
+                    throw new ConversationError(
+                        'unavailable',
+                        'reconnectingCodex'
+                    );
+                }
+                this.paginatedReadsDisabled = true;
+                return null;
+            }
+            let pageTurns: Record<string, any>[];
+            let nextCursor: string | undefined;
+            try {
+                ({ turns: pageTurns, nextCursor } = parseTurnsListPage(page));
+            } catch (_error) {
+                this.paginatedReadsDisabled = true;
+                return null;
+            }
+            fetched.push(...pageTurns);
+            anchorIndex = fetched.findIndex(turn => turn.id === anchorTurnId);
+            if (!nextCursor || pageTurns.length === 0) {
+                break;
+            }
+            cursor = nextCursor;
+        }
+        if (anchorIndex < 0) {
+            return null;
+        }
+        // `fetched` is newest-first: re-read the anchor turn (it may have
+        // grown since it was cached) plus every turn appended after it,
+        // in chronological order.
+        const replaced = fetched.slice(0, anchorIndex + 1).reverse();
+        const kept = cached.turns.slice(0, -1);
+        const itemIds = new Set<string>();
+        for (const chunk of kept) {
+            for (const itemId of chunk.itemIds) {
+                itemIds.add(itemId);
+            }
+        }
+        const keptTurnIds = new Set(kept.map(chunk => chunk.turnId));
+        const newTurns: LoadedConversationTurn[] = [];
+        try {
+            for (const turn of replaced) {
+                if (keptTurnIds.has(turn.id)) {
+                    // A supposedly immutable earlier turn reappeared: the
+                    // history was rewritten, which only a full read settles.
+                    return null;
+                }
+                const context: NormalizeTurnContext = {
+                    interactions: [],
+                    itemIds,
+                    newItemIds: [],
+                    seededDispatchTimingComplete: true,
+                };
+                normalizeTurnItems(turn, context);
+                newTurns.push({
+                    turnId: turn.id,
+                    interactions: context.interactions,
+                    itemIds: context.newItemIds,
+                    fingerprint: fingerprintInteractions(context.interactions),
+                    characters: conversationCharacters(context.interactions),
+                });
+            }
+        } catch (_error) {
+            // Content the stable path would reject as well: fall back so the
+            // full read surfaces the canonical error.
+            return null;
+        }
+        const turns = [...kept, ...newTurns];
+        const sourceRevision = composeConversationRevision(turns);
+        const characters = turns.reduce(
+            (sum, turn) => sum + turn.characters,
+            0
+        );
+        if (sourceRevision === cached.value.sourceRevision) {
+            // The stat moved but the visible content did not: keep the
+            // cached value (its identity is pinned to the revision) and let
+            // the caller re-anchor the entry to the new signature.
+            return { value: cached.value, turns, characters };
+        }
+        const interactions = this.promoteRunningLifecycle(
+            sessionId,
+            turns.reduce<ConversationInteraction[]>(
+                (all, turn) => all.concat(turn.interactions),
+                []
+            )
+        );
+        return { value: { interactions, sourceRevision }, turns, characters };
     }
 
     private storeLoadedConversationCacheEntry(
@@ -1140,7 +1463,11 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
     private async loadFresh(
         sessionId: string,
         signal?: ConversationAbortSignal
-    ): Promise<LoadedConversation> {
+    ): Promise<{
+        value: LoadedConversation;
+        turns?: LoadedConversationTurn[];
+        characters: number;
+    }> {
         if (this.disposed) {
             throw new ConversationError(
                 'unavailable',
@@ -1169,7 +1496,7 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
                 ? new ConversationError('unavailable', 'missingSource')
                 : protocolError();
         }
-        let interactions: ConversationInteraction[];
+        let normalized: ReturnType<typeof normalizeThreadRead>;
         try {
             if (split.subagentId) {
                 const thread = asRecord(asRecord(result)?.thread);
@@ -1183,56 +1510,61 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
                     threadId
                 )
                 : undefined;
-            interactions = normalizeThreadRead(result, threadId, dispatch);
+            normalized = normalizeThreadRead(result, threadId, dispatch);
         } catch (error) {
             if (error instanceof ConversationError) {
                 throw error;
             }
             throw protocolError();
         }
+        const turns: LoadedConversationTurn[] = normalized.turns.map(chunk => ({
+            ...chunk,
+            fingerprint: fingerprintInteractions(chunk.interactions),
+            characters: conversationCharacters(chunk.interactions),
+        }));
         // App Server instances do not share live turn state. When another
         // extension owns the running turn, thread/read can persist it as
         // interrupted even while its rollout is still receiving events.
         // Keep the protocol fingerprint content-only, then let the rollout's
         // authoritative lifecycle promote the latest visible interaction.
-        const sourceRevision = fingerprintInteractions(interactions);
-        if (!split.subagentId && interactions.length) {
-            let lifecycleSignal: AiSessionLifecycleSignal | undefined;
-            try {
-                lifecycleSignal = this.options.readLifecycleSignal?.(
-                    split.sessionId
-                );
-            } catch (_error) {
-                // Lifecycle enrichment is best effort. Protocol content must
-                // remain readable if the rollout disappears during a refresh.
-            }
-            if (lifecycleSignal?.executionState === 'running') {
-                const latest = interactions[interactions.length - 1];
-                interactions = [
-                    ...interactions.slice(0, -1),
-                    { ...latest, responseState: 'inProgress' },
-                ];
-            }
-        }
-        return { interactions, sourceRevision };
+        const sourceRevision = composeConversationRevision(turns);
+        const interactions = split.subagentId || !normalized.interactions.length
+            ? normalized.interactions
+            : this.promoteRunningLifecycle(
+                split.sessionId,
+                normalized.interactions
+            );
+        return {
+            value: { interactions, sourceRevision },
+            // Turn chunks only serve the incremental paginated reload path,
+            // which is limited to root threads: a subagent's seeded dispatch
+            // interaction accumulates items across turns, so its chunks are
+            // not independently re-normalizable.
+            turns: split.subagentId ? undefined : turns,
+            characters: turns.reduce((sum, turn) => sum + turn.characters, 0),
+        };
     }
 
-    private conversationCharacters(value: LoadedConversation): number {
-        let characters = 0;
-        for (const interaction of value.interactions) {
-            characters += interaction.userMarkdown?.length || 0;
-            for (const markdown of interaction.assistantMarkdown) {
-                characters += markdown.length;
-            }
-            for (const tool of interaction.toolCalls || []) {
-                characters += (tool.summary?.length || 0)
-                    + (tool.detail?.length || 0);
-            }
-            for (const thinking of interaction.thinking || []) {
-                characters += thinking.text?.length || 0;
-            }
+    private promoteRunningLifecycle(
+        sessionId: string,
+        interactions: ConversationInteraction[]
+    ): ConversationInteraction[] {
+        let lifecycleSignal: AiSessionLifecycleSignal | undefined;
+        try {
+            lifecycleSignal = this.options.readLifecycleSignal?.(sessionId);
+        } catch (_error) {
+            // Lifecycle enrichment is best effort. Protocol content must
+            // remain readable if the rollout disappears during a refresh.
         }
-        return characters;
+        if (lifecycleSignal?.executionState !== 'running'
+            || !interactions.length) {
+            return interactions;
+        }
+        const latest = interactions[interactions.length - 1];
+        return [
+            ...interactions.slice(0, -1),
+            { ...latest, responseState: 'inProgress' },
+        ];
     }
 
     private now(): number {

--- a/src/aiSessions/conversation/codexAppServerClient.ts
+++ b/src/aiSessions/conversation/codexAppServerClient.ts
@@ -46,6 +46,11 @@ export interface CodexAppServerChild {
 }
 
 export interface CodexAppServerClientOptions {
+    // Opts the handshake into experimental app-server methods (for example
+    // thread/turns/list). Callers must treat those methods as accelerators
+    // with a stable fallback: the server may reject or change them at any
+    // version boundary.
+    experimentalApi?: boolean;
     spawn(
         executable: string,
         args: string[],
@@ -77,12 +82,10 @@ interface RestartDelay {
 
 const RESTART_WINDOW_MS = 60_000;
 const RESTART_DELAYS_MS = [1_000, 4_000] as const;
-const INITIALIZE_PARAMS = Object.freeze({
-    clientInfo: Object.freeze({
-        name: 'project_steward',
-        title: 'Agent Pivot',
-        version: '2.1.6',
-    }),
+const INITIALIZE_CLIENT_INFO = Object.freeze({
+    name: 'project_steward',
+    title: 'Agent Pivot',
+    version: '2.1.6',
 });
 
 function asRecord(value: unknown): Record<string, any> | undefined {
@@ -103,6 +106,21 @@ function sanitizedMajorMinor(value: unknown): string | undefined {
         return undefined;
     }
     const match = /^(\d{1,6})\.(\d{1,6})(?:\.|$)/.exec(value.trim());
+    return match ? `${match[1]}.${match[2]}` : undefined;
+}
+
+// Newer app-servers (0.147+) answer initialize without `serverInfo`; the
+// server version then rides in the userAgent product token, built as
+// `<originator>/<major.minor.patch> (<os> ...) <terminal> (<client>; …)`.
+// The parse is deliberately tolerant: the version only gates optional
+// accelerators, so an unrecognizable userAgent simply leaves them off.
+function sanitizedUserAgentVersion(value: unknown): string | undefined {
+    if (typeof value !== 'string') {
+        return undefined;
+    }
+    const match = /^[^/\s]+\/(\d{1,6})\.(\d{1,6})(?:\.|\s|$)/.exec(
+        value.trim()
+    );
     return match ? `${match[1]}.${match[2]}` : undefined;
 }
 
@@ -178,6 +196,25 @@ export class CodexAppServerClient implements AiSessionDisposable {
     }
 
     constructor(private readonly options: CodexAppServerClientOptions) {}
+
+    /**
+     * Sanitized `major.minor` reported by the server at initialize time,
+     * or undefined until the handshake completes. Lets callers gate
+     * version-sensitive protocol features.
+     */
+    getServerVersion(): string | undefined {
+        return this.serverVersion;
+    }
+
+    private initializeParams(): Record<string, unknown> {
+        if (!this.options.experimentalApi) {
+            return { clientInfo: INITIALIZE_CLIENT_INFO };
+        }
+        return {
+            clientInfo: INITIALIZE_CLIENT_INFO,
+            capabilities: { experimentalApi: true },
+        };
+    }
 
     async request<T = unknown>(
         method: string,
@@ -352,7 +389,10 @@ export class CodexAppServerClient implements AiSessionDisposable {
 
         let result: unknown;
         try {
-            result = await this.sendRequest('initialize', INITIALIZE_PARAMS);
+            result = await this.sendRequest(
+                'initialize',
+                this.initializeParams()
+            );
         } catch (error) {
             if (this.child === child) {
                 this.releaseChild(
@@ -386,7 +426,8 @@ export class CodexAppServerClient implements AiSessionDisposable {
             this.releaseChild(child, error, true);
             throw error;
         }
-        this.serverVersion = sanitizedMajorMinor(serverInfo?.version);
+        this.serverVersion = sanitizedMajorMinor(serverInfo?.version)
+            ?? sanitizedUserAgentVersion(initializeResult.userAgent);
         try {
             await this.enqueueWrite({ method: 'initialized', params: {} }, child);
         } catch (_error) {

--- a/src/aiSessions/conversation/composition.ts
+++ b/src/aiSessions/conversation/composition.ts
@@ -204,6 +204,10 @@ function createAvailableConversationCapability(
     ownership: ConstructionOwnership
 ): ConversationCapability {
     const codexClient = ownership.own(factories.createCodexClient({
+        // Unlocks thread/turns/list for incremental large-session reloads.
+        // The adapter treats it strictly as an accelerator: version-gated
+        // and backed by the stable thread/read fallback on any anomaly.
+        experimentalApi: true,
         spawn: options.spawnCodex as unknown as CodexAppServerClientOptions['spawn'],
         resolveExecutable: () => 'codex',
         now: options.now,

--- a/tests/contract/aiSessions/codexAppServerClient.test.js
+++ b/tests/contract/aiSessions/codexAppServerClient.test.js
@@ -113,6 +113,7 @@ function createHarness(overrides = {}) {
         onDiagnostic(diagnostic) {
             diagnostics.push(diagnostic);
         },
+        ...(overrides.experimentalApi ? { experimentalApi: true } : {}),
     });
     return {
         child,
@@ -240,6 +241,88 @@ test('SESSION-AI-SESSION-CODEX-APP-SERVER-001 performs one stable handshake and 
             stdio: ['pipe', 'pipe', 'pipe'],
         },
     });
+});
+
+test('SESSION-AI-SESSION-CODEX-APP-SERVER-001 declares the experimentalApi capability only when opted in', async t => {
+    const plain = createHarness();
+    t.after(() => plain.client.dispose());
+    assert.equal(plain.client.getServerVersion(), undefined);
+    const plainRequest = plain.client.request('thread/read', {
+        threadId: SESSION_ID,
+        includeTurns: true,
+    });
+    await finishHandshake(plain.child);
+    assert.equal(plain.client.getServerVersion(), '1.42');
+    emitResponse(plain.child, { id: 2, result: { ok: true } });
+    assert.deepEqual(await plainRequest, { ok: true });
+
+    const optedIn = createHarness({ experimentalApi: true });
+    t.after(() => optedIn.client.dispose());
+    const optedInRequest = optedIn.client.request('thread/turns/list', {
+        threadId: SESSION_ID,
+        limit: 1,
+    });
+    await settle();
+    assert.deepEqual(parsedWrites(optedIn.child)[0], {
+        method: 'initialize',
+        id: 1,
+        params: {
+            clientInfo: {
+                name: 'project_steward',
+                title: 'Agent Pivot',
+                version: '2.1.6',
+            },
+            capabilities: { experimentalApi: true },
+        },
+    });
+    emitResponse(optedIn.child, {
+        id: 1,
+        result: { serverInfo: { name: 'codex-app-server', version: '0.147.0' } },
+    });
+    await settle();
+    assert.equal(optedIn.client.getServerVersion(), '0.147');
+    emitResponse(optedIn.child, { id: 2, result: { data: [] } });
+    assert.deepEqual(await optedInRequest, { data: [] });
+
+    // 0.147+ servers omit serverInfo entirely; the version is parsed from
+    // the userAgent product token instead.
+    const userAgentOnly = createHarness({ experimentalApi: true });
+    t.after(() => userAgentOnly.client.dispose());
+    const userAgentRequest = userAgentOnly.client.request('thread/turns/list', {
+        threadId: SESSION_ID,
+        limit: 1,
+    });
+    await settle();
+    emitResponse(userAgentOnly.child, {
+        id: 1,
+        result: {
+            userAgent: 'project_steward/0.147.0 (Ubuntu 22.4.0; x86_64) '
+                + 'xterm.js_6.1.0-beta.291_ (project_steward; 2.1.6)',
+            codexHome: '/home/user/.codex',
+            platformFamily: 'unix',
+            platformOs: 'linux',
+        },
+    });
+    await settle();
+    assert.equal(userAgentOnly.client.getServerVersion(), '0.147');
+    emitResponse(userAgentOnly.child, { id: 2, result: { data: [] } });
+    assert.deepEqual(await userAgentRequest, { data: [] });
+
+    const unversioned = createHarness();
+    t.after(() => unversioned.client.dispose());
+    const unversionedRequest = unversioned.client.request('thread/read', {
+        threadId: SESSION_ID,
+        includeTurns: true,
+    });
+    await settle();
+    emitResponse(unversioned.child, {
+        id: 1,
+        result: { userAgent: 'no-version-here' },
+    });
+    await settle();
+    assert.equal(unversioned.client.getServerVersion(), undefined);
+    emitResponse(unversioned.child, { id: 2, result: { ok: true } });
+    assert.deepEqual(await unversionedRequest, { ok: true });
 });
 
 test('CONVERSATION-TELEMETRY-001 publishes structured App Server notifications without affecting requests', async t => {

--- a/tests/contract/aiSessions/codexConversationAdapter.test.js
+++ b/tests/contract/aiSessions/codexConversationAdapter.test.js
@@ -2026,6 +2026,10 @@ function createPaginatedHarness(t, options = {}) {
                 if (state.turnsListFailure === 'malformed') {
                     return { data: [{ id: 'broken' }] };
                 }
+                if (state.turnsListFailure === 'empty-page-with-cursor'
+                    && typeof params.cursor === 'string') {
+                    return { data: [], nextCursor: 'ghost' };
+                }
                 return serveTurnsListPage(state.turns, params);
             }
             throw new Error(`unexpected method ${method}`);
@@ -2217,6 +2221,27 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 falls back to a full read after
         ['thread/read', 'thread/turns/list', 'thread/read']
     );
     assert.equal(compacted.totalInteractions, 12);
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 falls back to a full read on an empty page with a live cursor', async t => {
+    const harness = createPaginatedHarness(t);
+    await harness.adapter.readOutline(sessionId);
+
+    harness.state.turns = Array.from(
+        { length: 12 },
+        (_, index) => createPaginatedTurn(index, 'rewritten')
+    );
+    harness.state.signature = 'stat-2';
+    // Outside the verified semantics: an empty page that still claims more
+    // turns. The adapter must not rebuild from a truncated walk.
+    harness.state.turnsListFailure = 'empty-page-with-cursor';
+    const recovered = await harness.adapter.readOutline(sessionId);
+
+    assert.deepEqual(
+        harness.methods(),
+        ['thread/read', 'thread/turns/list', 'thread/turns/list', 'thread/read']
+    );
+    assert.equal(recovered.totalInteractions, 12);
 });
 
 test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 walks deep append bursts on the fast paginated backend', async t => {

--- a/tests/contract/aiSessions/codexConversationAdapter.test.js
+++ b/tests/contract/aiSessions/codexConversationAdapter.test.js
@@ -10,6 +10,7 @@ const {
 } = require('../../../out/aiSessions/conversation/codexAdapter');
 const {
     CONVERSATION_LIMITS,
+    ConversationError,
 } = require('../../../out/aiSessions/conversation/types');
 
 const fixturePath = path.resolve(
@@ -2016,6 +2017,12 @@ function createPaginatedHarness(t, options = {}) {
                         'thread/turns/list requires experimentalApi capability'
                     );
                 }
+                if (state.turnsListFailure === 'transient') {
+                    throw new ConversationError(
+                        'unavailable',
+                        'reconnectingCodex'
+                    );
+                }
                 if (state.turnsListFailure === 'malformed') {
                     return { data: [{ id: 'broken' }] };
                 }
@@ -2179,6 +2186,31 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 disables paginated reloads afte
     assert.deepEqual(harness.methods().slice(3), ['thread/read']);
 });
 
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 falls back without disabling paginated reloads on transient transport errors', async t => {
+    const harness = createPaginatedHarness(t);
+    await harness.adapter.readOutline(sessionId);
+
+    // A child restart rejects the in-flight tail page with a transient
+    // 'unavailable': the load falls back to a full read, but the
+    // accelerator stays enabled.
+    harness.state.turns.push(createPaginatedTurn(12));
+    harness.state.signature = 'stat-2';
+    harness.state.turnsListFailure = 'transient';
+    const recovered = await harness.adapter.readOutline(sessionId);
+    assert.equal(recovered.totalInteractions, 13);
+    assert.deepEqual(
+        harness.methods(),
+        ['thread/read', 'thread/turns/list', 'thread/read']
+    );
+
+    harness.state.turnsListFailure = undefined;
+    harness.state.turns.push(createPaginatedTurn(13));
+    harness.state.signature = 'stat-3';
+    const reloaded = await harness.adapter.readOutline(sessionId);
+    assert.equal(reloaded.totalInteractions, 14);
+    assert.deepEqual(harness.methods().slice(3), ['thread/turns/list']);
+});
+
 test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 disables paginated reloads after a malformed thread/turns/list page', async t => {
     const harness = createPaginatedHarness(t);
     await harness.adapter.readOutline(sessionId);
@@ -2244,7 +2276,13 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 walks older pages when many tur
         harness.methods().slice(1),
         ['thread/turns/list', 'thread/turns/list']
     );
-    assert.equal(harness.requests[1].params.cursor, undefined);
+    assert.deepEqual(harness.requests[1].params, {
+        threadId: sessionId,
+        cursor: undefined,
+        limit: 4,
+        sortDirection: 'desc',
+        itemsView: 'full',
+    });
     assert.equal(harness.requests[2].params.cursor, 'turn-14');
     assert.equal(updated.totalInteractions, 18);
     const expected = await createFullReadProof(t, harness.state)

--- a/tests/contract/aiSessions/codexConversationAdapter.test.js
+++ b/tests/contract/aiSessions/codexConversationAdapter.test.js
@@ -2130,7 +2130,7 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 re-anchors the cache when the s
     assert.equal(harness.requests.length, 2);
 });
 
-test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 falls back to a full read when compaction rewrites the thread tail', async t => {
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 rebuilds a compacted large Codex thread from fast paginated pages', async t => {
     const harness = createPaginatedHarness(t);
     await harness.adapter.readOutline(sessionId);
 
@@ -2141,14 +2141,22 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 falls back to a full read when 
     harness.state.signature = 'stat-2';
     const compacted = await harness.adapter.readOutline(sessionId);
 
-    const methods = harness.methods();
-    assert.deepEqual(methods[0], 'thread/read');
-    assert.ok(methods.slice(1, -1).every(method => method === 'thread/turns/list'));
-    assert.deepEqual(methods.at(-1), 'thread/read');
+    // The anchor is gone, but the indexed backend serves pages cheaply, so
+    // the walk runs to the end of the thread and rebuilds from the pages
+    // — a full read of a huge paginated session could never finish within
+    // the request timeout.
+    assert.deepEqual(harness.methods(), [
+        'thread/read',
+        'thread/turns/list',
+        'thread/turns/list',
+        'thread/turns/list',
+    ]);
     assert.equal(compacted.totalInteractions, 12);
+    const expected = await createFullReadProof(t, harness.state)
+        .readOutline(sessionId);
+    assert.deepEqual(compacted, expected);
 
-    // A per-load fallback must not disable the paginated path: the next
-    // append is incremental again.
+    // Incremental reloads resume from the rebuilt anchor.
     harness.state.turns.push(createPaginatedTurn(12, 'rewritten'));
     harness.state.signature = 'stat-3';
     const requestCount = harness.requests.length;
@@ -2157,9 +2165,81 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 falls back to a full read when 
         harness.methods().slice(requestCount),
         ['thread/turns/list']
     );
+    const expectedAppended = await createFullReadProof(t, harness.state)
+        .readOutline(sessionId);
+    assert.deepEqual(appended, expectedAppended);
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 falls back to a full read after one slow legacy page', async t => {
+    // The legacy rollout-replay backend needs hundreds of ms per page, so
+    // the walk exits after the first page: further paging costs as much as
+    // the full read that settles the load anyway.
+    let now = 1_000_000;
+    const state = {
+        turns: Array.from(
+            { length: 12 },
+            (_, index) => createPaginatedTurn(index)
+        ),
+        signature: 'stat-1',
+    };
+    const requests = [];
+    const client = {
+        async request(method, params) {
+            requests.push({ method, params });
+            if (method === 'thread/read') {
+                return clone({
+                    thread: { id: params.threadId, turns: state.turns },
+                });
+            }
+            now += 600;
+            return serveTurnsListPage(state.turns, params);
+        },
+        getServerVersion: () => '0.147',
+        dispose() {},
+    };
+    const harness = createAdapter(undefined, {
+        client,
+        readContentSignature: () => state.signature,
+        now: () => now,
+    });
+    t.after(() => harness.adapter.dispose());
+
+    await harness.adapter.readOutline(sessionId);
+    state.turns = Array.from(
+        { length: 12 },
+        (_, index) => createPaginatedTurn(index, 'rewritten')
+    );
+    state.signature = 'stat-2';
+    const compacted = await harness.adapter.readOutline(sessionId);
+
+    assert.deepEqual(
+        requests.map(entry => entry.method),
+        ['thread/read', 'thread/turns/list', 'thread/read']
+    );
+    assert.equal(compacted.totalInteractions, 12);
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 walks deep append bursts on the fast paginated backend', async t => {
+    const harness = createPaginatedHarness(t);
+    await harness.adapter.readOutline(sessionId);
+
+    for (let index = 12; index < 112; index += 1) {
+        harness.state.turns.push(createPaginatedTurn(index));
+    }
+    harness.state.signature = 'stat-2';
+    const updated = await harness.adapter.readOutline(sessionId);
+
+    const methods = harness.methods();
+    assert.equal(methods[0], 'thread/read');
+    assert.equal(
+        methods.filter(method => method === 'thread/turns/list').length,
+        26
+    );
+    assert.ok(!methods.slice(1).includes('thread/read'));
+    assert.equal(updated.totalInteractions, 112);
     const expected = await createFullReadProof(t, harness.state)
         .readOutline(sessionId);
-    assert.deepEqual(appended, expected);
+    assert.deepEqual(updated, expected);
 });
 
 test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 disables paginated reloads after the server rejects thread/turns/list', async t => {

--- a/tests/contract/aiSessions/codexConversationAdapter.test.js
+++ b/tests/contract/aiSessions/codexConversationAdapter.test.js
@@ -1950,3 +1950,362 @@ test('CONVERSATION-TOOL-CALL-VISIBILITY-001 Codex renders command executions and
         ]
     );
 });
+
+function createPaginatedTurn(index, prefix = 'turn') {
+    return {
+        id: `${prefix}-${index}`,
+        status: 'completed',
+        items: [{
+            id: `${prefix}-user-${index}`,
+            type: 'userMessage',
+            content: [{ type: 'text', text: `request ${index}` }],
+        }, {
+            id: `${prefix}-agent-${index}`,
+            type: 'agentMessage',
+            text: 'x'.repeat(60 * 1024),
+        }],
+    };
+}
+
+// Emulates the verified 0.147 app-server pagination semantics: descending
+// by default, an opaque inclusive cursor that continues strictly after it,
+// and nextCursor present only while older turns remain.
+function serveTurnsListPage(turns, params) {
+    const ordered = params.sortDirection === 'asc'
+        ? [...turns]
+        : [...turns].reverse();
+    let start = 0;
+    if (typeof params.cursor === 'string') {
+        const at = ordered.findIndex(turn => turn.id === params.cursor);
+        if (at < 0) {
+            throw new Error(`unknown cursor ${params.cursor}`);
+        }
+        start = at + 1;
+    }
+    const limit = params.limit || ordered.length;
+    const data = ordered.slice(start, start + limit);
+    const more = start + data.length < ordered.length;
+    return clone({
+        data,
+        nextCursor: more && data.length ? data[data.length - 1].id : null,
+        backwardsCursor: data.length ? data[0].id : null,
+    });
+}
+
+function createPaginatedHarness(t, options = {}) {
+    const state = {
+        turns: Array.from(
+            { length: options.initialTurns || 12 },
+            (_, index) => createPaginatedTurn(index)
+        ),
+        signature: 'stat-1',
+        turnsListFailure: undefined,
+    };
+    const requests = [];
+    const client = {
+        async request(method, params) {
+            requests.push({ method, params });
+            if (method === 'thread/read') {
+                return clone({
+                    thread: { id: params.threadId, turns: state.turns },
+                });
+            }
+            if (method === 'thread/turns/list') {
+                if (state.turnsListFailure === 'error') {
+                    throw new Error(
+                        'thread/turns/list requires experimentalApi capability'
+                    );
+                }
+                if (state.turnsListFailure === 'malformed') {
+                    return { data: [{ id: 'broken' }] };
+                }
+                return serveTurnsListPage(state.turns, params);
+            }
+            throw new Error(`unexpected method ${method}`);
+        },
+        getServerVersion: () => options.serverVersion === undefined
+            ? '0.147'
+            : options.serverVersion,
+        dispose() {},
+    };
+    const harness = createAdapter(undefined, {
+        client,
+        readContentSignature: () => state.signature,
+    });
+    t.after(() => harness.adapter.dispose());
+    return {
+        adapter: harness.adapter,
+        requests,
+        state,
+        methods: () => requests.map(entry => entry.method),
+    };
+}
+
+// Ground truth: the same content loaded through the stable full-read path
+// (no server version → the paginated accelerator never engages).
+function createFullReadProof(t, state) {
+    const requests = [];
+    const client = {
+        async request(method, params) {
+            requests.push({ method, params });
+            if (method === 'thread/read') {
+                return clone({
+                    thread: { id: params.threadId, turns: state.turns },
+                });
+            }
+            throw new Error(`unexpected method ${method}`);
+        },
+        dispose() {},
+    };
+    const harness = createAdapter(undefined, {
+        client,
+        readContentSignature: () => state.signature,
+    });
+    t.after(() => harness.adapter.dispose());
+    return harness.adapter;
+}
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 reloads an appended large Codex thread through thread/turns/list only', async t => {
+    const harness = createPaginatedHarness(t);
+    const first = await harness.adapter.readOutline(sessionId);
+    assert.deepEqual(harness.methods(), ['thread/read']);
+
+    harness.state.turns.push(createPaginatedTurn(12));
+    harness.state.signature = 'stat-2';
+    const updated = await harness.adapter.readOutline(sessionId);
+
+    assert.deepEqual(harness.methods().slice(1), ['thread/turns/list']);
+    assert.notEqual(updated.sourceRevision, first.sourceRevision);
+    assert.equal(updated.totalInteractions, 13);
+    const expected = await createFullReadProof(t, harness.state)
+        .readOutline(sessionId);
+    assert.deepEqual(updated, expected);
+
+    // The re-anchored entry serves the next read without any RPC.
+    const again = await harness.adapter.readOutline(sessionId);
+    assert.equal(again.sourceRevision, updated.sourceRevision);
+    assert.equal(harness.requests.length, 2);
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 re-reads a grown in-flight anchor turn of a large Codex thread incrementally', async t => {
+    const harness = createPaginatedHarness(t);
+    const first = await harness.adapter.readOutline(sessionId);
+
+    harness.state.turns.at(-1).items.push({
+        id: 'turn-11-agent-late',
+        type: 'agentMessage',
+        text: 'late tail output',
+    });
+    harness.state.signature = 'stat-2';
+    const updated = await harness.adapter.readOutline(sessionId);
+
+    assert.deepEqual(harness.methods().slice(1), ['thread/turns/list']);
+    assert.notEqual(updated.sourceRevision, first.sourceRevision);
+    const expected = await createFullReadProof(t, harness.state)
+        .readOutline(sessionId);
+    assert.deepEqual(updated, expected);
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 re-anchors the cache when the stat moves but the content does not', async t => {
+    const harness = createPaginatedHarness(t);
+    const first = await harness.adapter.readOutline(sessionId);
+
+    harness.state.signature = 'stat-2';
+    const updated = await harness.adapter.readOutline(sessionId);
+
+    assert.deepEqual(harness.methods().slice(1), ['thread/turns/list']);
+    assert.equal(updated.sourceRevision, first.sourceRevision);
+
+    // The false alarm is healed: the entry now validates against stat-2, so
+    // the next read needs no RPC at all.
+    const again = await harness.adapter.readOutline(sessionId);
+    assert.equal(again.sourceRevision, first.sourceRevision);
+    assert.equal(harness.requests.length, 2);
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 falls back to a full read when compaction rewrites the thread tail', async t => {
+    const harness = createPaginatedHarness(t);
+    await harness.adapter.readOutline(sessionId);
+
+    harness.state.turns = Array.from(
+        { length: 12 },
+        (_, index) => createPaginatedTurn(index, 'rewritten')
+    );
+    harness.state.signature = 'stat-2';
+    const compacted = await harness.adapter.readOutline(sessionId);
+
+    const methods = harness.methods();
+    assert.deepEqual(methods[0], 'thread/read');
+    assert.ok(methods.slice(1, -1).every(method => method === 'thread/turns/list'));
+    assert.deepEqual(methods.at(-1), 'thread/read');
+    assert.equal(compacted.totalInteractions, 12);
+
+    // A per-load fallback must not disable the paginated path: the next
+    // append is incremental again.
+    harness.state.turns.push(createPaginatedTurn(12, 'rewritten'));
+    harness.state.signature = 'stat-3';
+    const requestCount = harness.requests.length;
+    const appended = await harness.adapter.readOutline(sessionId);
+    assert.deepEqual(
+        harness.methods().slice(requestCount),
+        ['thread/turns/list']
+    );
+    const expected = await createFullReadProof(t, harness.state)
+        .readOutline(sessionId);
+    assert.deepEqual(appended, expected);
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 disables paginated reloads after the server rejects thread/turns/list', async t => {
+    const harness = createPaginatedHarness(t);
+    await harness.adapter.readOutline(sessionId);
+
+    harness.state.turns.push(createPaginatedTurn(12));
+    harness.state.signature = 'stat-2';
+    harness.state.turnsListFailure = 'error';
+    const recovered = await harness.adapter.readOutline(sessionId);
+    assert.equal(recovered.totalInteractions, 13);
+    assert.deepEqual(
+        harness.methods(),
+        ['thread/read', 'thread/turns/list', 'thread/read']
+    );
+
+    // The circuit breaker sticks: later reloads use the stable path
+    // directly without probing the rejected method again.
+    harness.state.turnsListFailure = undefined;
+    harness.state.turns.push(createPaginatedTurn(13));
+    harness.state.signature = 'stat-3';
+    const reloaded = await harness.adapter.readOutline(sessionId);
+    assert.equal(reloaded.totalInteractions, 14);
+    assert.deepEqual(harness.methods().slice(3), ['thread/read']);
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 disables paginated reloads after a malformed thread/turns/list page', async t => {
+    const harness = createPaginatedHarness(t);
+    await harness.adapter.readOutline(sessionId);
+
+    harness.state.turns.push(createPaginatedTurn(12));
+    harness.state.signature = 'stat-2';
+    harness.state.turnsListFailure = 'malformed';
+    const recovered = await harness.adapter.readOutline(sessionId);
+    assert.equal(recovered.totalInteractions, 13);
+    assert.deepEqual(
+        harness.methods(),
+        ['thread/read', 'thread/turns/list', 'thread/read']
+    );
+
+    harness.state.turnsListFailure = undefined;
+    harness.state.turns.push(createPaginatedTurn(13));
+    harness.state.signature = 'stat-3';
+    await harness.adapter.readOutline(sessionId);
+    assert.deepEqual(harness.methods().slice(3), ['thread/read']);
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 never calls thread/turns/list on an unverified server version', async t => {
+    for (const serverVersion of ['0.148', undefined, null]) {
+        const requests = [];
+        const client = {
+            async request(method, params) {
+                requests.push({ method, params });
+                return clone(createLargeThread(params.threadId));
+            },
+            getServerVersion: () => serverVersion,
+            dispose() {},
+        };
+        let signature = 'stat-1';
+        const harness = createAdapter(undefined, {
+            client,
+            readContentSignature: () => signature,
+        });
+        const adapter = harness.adapter;
+        await adapter.readOutline(sessionId);
+        signature = 'stat-2';
+        await adapter.readOutline(sessionId);
+        assert.deepEqual(
+            requests.map(entry => entry.method),
+            ['thread/read', 'thread/read'],
+            `server version ${serverVersion}`
+        );
+        adapter.dispose();
+    }
+    t.after(() => undefined);
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 walks older pages when many turns appended at once', async t => {
+    const harness = createPaginatedHarness(t);
+    await harness.adapter.readOutline(sessionId);
+
+    for (let index = 12; index < 18; index += 1) {
+        harness.state.turns.push(createPaginatedTurn(index));
+    }
+    harness.state.signature = 'stat-2';
+    const updated = await harness.adapter.readOutline(sessionId);
+
+    assert.deepEqual(
+        harness.methods().slice(1),
+        ['thread/turns/list', 'thread/turns/list']
+    );
+    assert.equal(harness.requests[1].params.cursor, undefined);
+    assert.equal(harness.requests[2].params.cursor, 'turn-14');
+    assert.equal(updated.totalInteractions, 18);
+    const expected = await createFullReadProof(t, harness.state)
+        .readOutline(sessionId);
+    assert.deepEqual(updated, expected);
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 keeps subagent thread reloads on the stable full-read path', async t => {
+    const childTurns = Array.from(
+        { length: 12 },
+        (_, index) => ({
+            id: `child-turn-${index}`,
+            status: 'completed',
+            items: [{
+                id: `child-agent-${index}`,
+                type: 'agentMessage',
+                text: 'y'.repeat(60 * 1024),
+            }],
+        })
+    );
+    const signatures = { [childThreadId]: 'child-stat-1' };
+    const requests = [];
+    const client = {
+        async request(method, params) {
+            requests.push({ method, params });
+            if (method !== 'thread/read' || params.threadId !== childThreadId) {
+                throw new Error(`unexpected ${method} for ${params.threadId}`);
+            }
+            return clone(createThreadReadResult(childThreadId, sessionId, {
+                turns: childTurns,
+            }));
+        },
+        getServerVersion: () => '0.147',
+        dispose() {},
+    };
+    const harness = createAdapter(undefined, {
+        client,
+        readContentSignature: id => signatures[id],
+        listSubagentThreads: () => [],
+    });
+    t.after(() => harness.adapter.dispose());
+
+    const encodedId = `${sessionId}#agent:${childThreadId}`;
+    const first = await harness.adapter.readOutline(encodedId);
+    assert.equal(first.totalInteractions, 1);
+
+    childTurns.push({
+        id: 'child-turn-12',
+        status: 'completed',
+        items: [{
+            id: 'child-agent-12',
+            type: 'agentMessage',
+            text: 'z'.repeat(60 * 1024),
+        }],
+    });
+    signatures[childThreadId] = 'child-stat-2';
+    const updated = await harness.adapter.readOutline(encodedId);
+
+    assert.notEqual(updated.sourceRevision, first.sourceRevision);
+    assert.deepEqual(
+        requests.map(entry => entry.method),
+        ['thread/read', 'thread/read']
+    );
+});

--- a/tests/contract/aiSessions/codexConversationAdapter.test.js
+++ b/tests/contract/aiSessions/codexConversationAdapter.test.js
@@ -2290,6 +2290,87 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 walks older pages when many tur
     assert.deepEqual(updated, expected);
 });
 
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 re-applies the rollout lifecycle when an unchanged tail re-anchors the cache', async t => {
+    let executionState = 'running';
+    const state = {
+        turns: Array.from({ length: 12 }, (_, index) => {
+            const turn = createPaginatedTurn(index);
+            turn.status = 'interrupted';
+            return turn;
+        }),
+        signature: 'stat-1',
+        turnsListFailure: undefined,
+    };
+    const requests = [];
+    const client = {
+        async request(method, params) {
+            requests.push({ method, params });
+            if (method === 'thread/read') {
+                return clone({
+                    thread: { id: params.threadId, turns: state.turns },
+                });
+            }
+            return serveTurnsListPage(state.turns, params);
+        },
+        getServerVersion: () => '0.147',
+        dispose() {},
+    };
+    const harness = createAdapter(undefined, {
+        client,
+        readContentSignature: () => state.signature,
+        readLifecycleSignal: () => ({
+            token: `codex:lifecycle:1:${executionState}`,
+            phase: executionState === 'running' ? 'running' : 'idle',
+            executionState,
+            occurredAtMs: 1,
+        }),
+    });
+    t.after(() => harness.adapter.dispose());
+
+    // A running rollout promotes the externally interrupted tail turn.
+    const running = await harness.adapter.readOutline(sessionId);
+    assert.equal(running.interactions.at(-1).responseState, 'inProgress');
+
+    // The rollout stops: the stat moves but the visible content does not,
+    // so the tail page re-anchors the cache. The lifecycle must still be
+    // re-evaluated — the cached 'inProgress' must not stick.
+    executionState = 'stopped';
+    state.signature = 'stat-2';
+    const stopped = await harness.adapter.readOutline(sessionId);
+    assert.equal(requests.filter(entry => entry.method === 'thread/turns/list').length, 1);
+    assert.equal(stopped.sourceRevision, running.sourceRevision);
+    assert.equal(stopped.interactions.at(-1).responseState, 'interrupted');
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 re-applies the rollout lifecycle on stat-validated cache hits', async t => {
+    let executionState = 'running';
+    const large = createLargeThread();
+    large.thread.turns.forEach(turn => {
+        turn.status = 'interrupted';
+    });
+    const harness = createAdapter(large, {
+        readContentSignature: () => 'stat-1',
+        readLifecycleSignal: () => ({
+            token: `codex:lifecycle:1:${executionState}`,
+            phase: executionState === 'running' ? 'running' : 'idle',
+            executionState,
+            occurredAtMs: 1,
+        }),
+    });
+    t.after(() => harness.adapter.dispose());
+
+    const running = await harness.adapter.readOutline(sessionId);
+    assert.equal(running.interactions.at(-1).responseState, 'inProgress');
+
+    // Same stat, pure cache hit — the lifecycle is still re-read, so a
+    // stopped session settles even while its bytes are untouched.
+    executionState = 'stopped';
+    const stopped = await harness.adapter.readOutline(sessionId);
+    assert.equal(harness.requests.length, 1);
+    assert.equal(stopped.sourceRevision, running.sourceRevision);
+    assert.equal(stopped.interactions.at(-1).responseState, 'interrupted');
+});
+
 test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 keeps subagent thread reloads on the stable full-read path', async t => {
     const childTurns = Array.from(
         { length: 12 },


### PR DESCRIPTION
## Summary

Large Codex conversations previously paid a full `thread/read` on every content change (~1s at 60MB; the 175MB session cannot even finish within the 10s request timeout). This PR reloads cached root-thread conversations incrementally through the experimental `thread/turns/list` tail page, re-normalizing only the turns that changed.

- Client: opts into `capabilities.experimentalApi` at initialize and reports the server version. 0.147+ omits `serverInfo` from the initialize response, so the version is parsed from the `userAgent` product token (`<originator>/<major.minor.patch> …`).
- Adapter: normalization splits into per-turn chunks behind one shared code path, and the source revision is composed from per-turn fingerprints — full and incremental loads of identical content produce byte-identical output and identical revisions.
- Accelerator discipline, since the method is experimental: a version allowlist (0.147 only, re-probed in the included spike), a process-lifetime circuit breaker on method rejections/malformed pages (transient `unavailable`/`timeout` transport errors deliberately do **not** trip it), and subagent threads always stay on the stable full read (their seeded dispatch interaction accumulates across turns).
- The anchor walk is cost-aware: a slow first page (≥250ms = the legacy rollout-replay backend) exits to a full read after one probe, fast pages walk within a 1024-turn/3s budget, and a tail rewritten by compaction/rollback on the indexed backend is **rebuilt from the fetched pages** — a full `thread/read` of a 175MB-class session would exceed the 10s request timeout outright.
- The rollout lifecycle is re-applied on every read (cache entries hold base interactions only): a session that stops while its visible content is unchanged still settles its Working indicator, even when the tail page re-anchors the cache without re-reading content.
- Perf: the synthetic 12MiB append reload drops ~96ms → ~2ms, and the `codexAppendReloadMs` budget tightens 500ms → 50ms.

Known limits: cold (first) loads still use `thread/read`, so a 175MB-class session still exceeds the 10s request timeout on first load (cold-path paging via `thread/resume.initialTurnsPage` is documented in the spike as a separate, larger experimental surface). Legacy pre-index sessions pay a server-side full rollout replay per tail page — never worse than the status quo, and the stat-signature cache still covers the unchanged case.

## Skill harvest

updated .skills/developing-provider-conversation-adapters — the Codex row now covers the `thread/turns/list` incremental surface, and a new note records the 0.147 initialize lesson (no `serverInfo`; parse the version from `userAgent`) that real-data validation caught while stub tests stayed green.

## Verification

- `npm run test:ci:linux` exit 0 (includes unit 811 / contract+integration 1315, architecture guards, behavior contracts, capability audit currency).
- Focused: `codexConversationAdapter.test.js` 71/71, `codexAppServerClient.test.js` 28/28; perf script green (`codexAppendReloadMs` ~1.7ms vs 50ms budget).
- Mutation-tested: anchor-miss rebuild, slow-page early exit, empty-page-with-cursor fallback, circuit breaker, lifecycle re-application, and cross-path revision equality assertions each fail when the corresponding source line is reverted.
- Real-data validation against codex 0.147.0 and real sessions (compiled `out/` adapter, real app-server):
  - live thread: a real `turn/start` append reloads via `thread/turns/list` only and deep-equals a fresh full-read outline (identical revision);
  - legacy 60MB session: stat flip with unchanged content re-anchors in ~614ms vs ~1023ms full read (server-side replay bound);
  - paginated 10.9MB session: same re-anchor in ~7ms vs ~443ms;
  - capability-less client: a real `-32600` rejection trips the breaker, falls back, and sticks.
- The probe behind the protocol claims is committed under `spikes/codex-paginated-read/`.
