### PR TITLE
perf: window Codex cold starts behind summary skeletons

### DIFF
--- a/.ci/conversation-performance.json
+++ b/.ci/conversation-performance.json
@@ -9,5 +9,7 @@
   "hostSessionSwitchMs": 250,
   "webviewInitialPublicationMs": 500,
   "webviewIncrementalRefreshMs": 250,
-  "webviewWarmFrameRestoreMs": 100
+  "webviewWarmFrameRestoreMs": 100,
+  "codexWindowedColdStartMs": 300,
+  "codexLegacyColdStartMs": 2500
 }

--- a/.skills/developing-provider-conversation-adapters/SKILL.md
+++ b/.skills/developing-provider-conversation-adapters/SKILL.md
@@ -89,6 +89,13 @@ From `spikes/codex-paginated-read` and `spikes/codex-cold-start`:
   recorded on a `limit:100` summary walk seeks the same turn boundary
   with `limit:4, itemsView:"full"` and returns items byte-identical to
   the full walk.
+- Item ids are NOT reliably turn-scoped while a session is live: a
+  response-spanning item (e.g. a reasoning block) can be projected into
+  different turns by fetches taken at different times (observed on a real
+  183MB session). Treat cross-turn id collisions between separately
+  fetched pages as a mixed-epoch signal (invalidate + re-read), never as
+  a protocol violation — circuit-breaking on a transient kills the
+  accelerator.
 - Version gates need the **completed handshake**: `serverInfo.version` /
   `userAgent` parsing only has a value after `initialize` returns, which
   the first `request()` triggers. Any feature gate evaluated before the

--- a/.skills/developing-provider-conversation-adapters/SKILL.md
+++ b/.skills/developing-provider-conversation-adapters/SKILL.md
@@ -73,3 +73,32 @@ the transcript tail:
 
 Read bounded head/tail windows (a single record can exceed 200KB); never
 scan whole transcripts in the listing path.
+
+## Codex App-Server Pagination Facts (0.147, probe-verified)
+
+From `spikes/codex-paginated-read` and `spikes/codex-cold-start`:
+
+- `thread/turns/list` summary view carries the **first** userMessage
+  per turn (projection schema: `thread_turns.first_user_item_id`),
+  **verbatim** — plus a final agentMessage that is UNRELIABLE: omitted
+  for interrupted turns and divergent in ~1/218 real turns. Never derive
+  fingerprints from the summary agent text. Multi-userMessage turns exist
+  in real data (mid-turn steering messages) and collapse to their first
+  message in summary view — never assume one user message per turn.
+- Page cursors are **portable across `limit` and `itemsView`**: a cursor
+  recorded on a `limit:100` summary walk seeks the same turn boundary
+  with `limit:4, itemsView:"full"` and returns items byte-identical to
+  the full walk.
+- Version gates need the **completed handshake**: `serverInfo.version` /
+  `userAgent` parsing only has a value after `initialize` returns, which
+  the first `request()` triggers. Any feature gate evaluated before the
+  first request is circular — expose an async `ensureReady()` that
+  attaches to the shared in-flight handshake.
+- Handshake cost contaminates first-page latency (~300ms vs ~20ms steady
+  state). Backend verdicts (paginated vs legacy replay) must exclude it
+  and tolerate single-page jitter (e.g. verdict only after two
+  consecutive slow pages).
+- The extension-host viewer skips refreshes whose revision, interaction
+  ids, and responseStates are all unchanged. Adapter revisions must
+  therefore move on **any** provider content change — including
+  summary-invisible tool output — or the webview never re-reads the page.

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "0ebedabc4113fa22c8243e58106f51abfb4c032b",
+        "head": "7471ec6d918175b048f962cddc2c8e374dae7390",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -288,7 +288,8 @@
             "60baa83d42d31be81d8d8272092f45b1697478d0",
             "0f1b5cdb56fcceac286e26b273e52ec31fee1003",
             "f83afd43b4cf0781339818992498d673a1b83411",
-            "8d354e7c2d1e7a7ff528e6ed2dfd495a37a19415"
+            "8d354e7c2d1e7a7ff528e6ed2dfd495a37a19415",
+            "bf5af003d36a5f5e813df7802762e75a3ab2215e"
         ]
     },
     "capabilities": [
@@ -1630,7 +1631,11 @@
                 "256953a4ca8e7da6a02b90f52fcc19ef4f37ca33",
                 "7e7aeeff4a328fa0cce0fbda5473fa799bb2560a",
                 "2481f9410d9ee051891687b03d16061499c63e46",
-                "3ccd04e1cc21b789fd185da0b36f9dbcabebf0a8"
+                "3ccd04e1cc21b789fd185da0b36f9dbcabebf0a8",
+                "887b8877965c074b915f85986dfbdc60cdcaa530",
+                "ed74fee09373347dad2da1bb17493d5fbf960d4c",
+                "2accfd46a0909f5e810ef6484d42677868c952e1",
+                "7471ec6d918175b048f962cddc2c8e374dae7390"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",

--- a/scripts/run-conversation-performance-checks.js
+++ b/scripts/run-conversation-performance-checks.js
@@ -87,10 +87,140 @@ function serveCodexTurnsListPage(turns, params) {
     const data = ordered.slice(start, start + limit);
     const more = start + data.length < ordered.length;
     return JSON.parse(JSON.stringify({
-        data,
+        data: params.itemsView === 'summary'
+            ? data.map(toCodexSummaryTurn)
+            : data,
         nextCursor: more && data.length ? data[data.length - 1].id : null,
         backwardsCursor: data.length ? data[0].id : null,
     }));
+}
+
+// The summary view keeps the first userMessage and the final agentMessage
+// per turn (schema-verified server projection rule).
+function toCodexSummaryTurn(turn) {
+    const items = [];
+    const user = turn.items.find(item => item.type === 'userMessage');
+    const agents = turn.items.filter(item => item.type === 'agentMessage');
+    if (user) {
+        items.push(user);
+    }
+    if (agents.length) {
+        items.push(agents[agents.length - 1]);
+    }
+    return { id: turn.id, status: turn.status, items };
+}
+
+async function measureCodexWindowedColdStart() {
+    const threadId = '88888888-8888-4888-8888-888888888888';
+    // Same ~12 MiB / 205-turn payload as the full-read scenario.
+    const payload = createCodexPerfThread(threadId, 205, 60 * 1024);
+    const methods = [];
+    const adapter = new CodexConversationAdapter({
+        client: {
+            async ensureReady() {
+                methods.push('ensureReady');
+                return '0.147';
+            },
+            async request(method, params) {
+                methods.push(method);
+                assert.equal(params.threadId, threadId);
+                // Re-serialize per call so each read pays a realistic
+                // transport-shaped parse cost.
+                if (method === 'thread/turns/list') {
+                    return serveCodexTurnsListPage(
+                        payload.thread.turns,
+                        params
+                    );
+                }
+                assert.equal(method, 'thread/read');
+                return JSON.parse(JSON.stringify(payload));
+            },
+            getServerVersion: () => '0.147',
+            dispose() {},
+        },
+        watchSessionChanges: () => ({ dispose() {} }),
+        setTimeout: callback => {
+            callback();
+            return 1;
+        },
+        clearTimeout: () => undefined,
+        readContentSignature: () => 'stat-1',
+        readSourceBytes: () => 12 * 1024 * 1024,
+    });
+    try {
+        const startedAt = process.hrtime.bigint();
+        const outline = await adapter.readOutline(threadId);
+        const windowedColdStartMs = elapsedMs(startedAt);
+        assert.equal(outline.totalInteractions, 205);
+        assert.equal(methods.includes('thread/read'), false,
+            'a paginated cold start must not pay the full frame');
+        assertBudget('codex windowed cold start', windowedColdStartMs,
+            PERFORMANCE_BUDGETS.codexWindowedColdStartMs);
+        return { windowedColdStartMs };
+    } finally {
+        adapter.dispose();
+    }
+}
+
+async function measureCodexLegacyColdStart() {
+    const threadId = '77777777-7777-4777-8777-777777777777';
+    const payload = createCodexPerfThread(threadId, 205, 60 * 1024);
+    const methods = [];
+    // Simulated wall clock: every thread/turns/list page costs a full
+    // replay (600ms on a 60MB-class legacy rollout, per the spike).
+    let simulatedMs = 1_000;
+    const adapter = new CodexConversationAdapter({
+        client: {
+            async ensureReady() {
+                methods.push('ensureReady');
+                return '0.147';
+            },
+            async request(method, params) {
+                methods.push(method);
+                assert.equal(params.threadId, threadId);
+                if (method === 'thread/turns/list') {
+                    simulatedMs += 600;
+                    return serveCodexTurnsListPage(
+                        payload.thread.turns,
+                        params
+                    );
+                }
+                assert.equal(method, 'thread/read');
+                return JSON.parse(JSON.stringify(payload));
+            },
+            getServerVersion: () => '0.147',
+            dispose() {},
+        },
+        watchSessionChanges: () => ({ dispose() {} }),
+        setTimeout: callback => {
+            callback();
+            return 1;
+        },
+        clearTimeout: () => undefined,
+        readContentSignature: () => 'stat-1',
+        readSourceBytes: () => 60 * 1024 * 1024,
+        now: () => simulatedMs,
+    });
+    try {
+        const startedAt = process.hrtime.bigint();
+        const outline = await adapter.readOutline(threadId);
+        const realMs = elapsedMs(startedAt);
+        assert.equal(outline.totalInteractions, 205);
+        // The legacy verdict must fall back to one full read after exactly
+        // two replay-priced pages — not walk the whole history.
+        assert.deepEqual(methods, [
+            'ensureReady',
+            'thread/turns/list',
+            'thread/turns/list',
+            'thread/read',
+        ]);
+        const legacyColdStartMs = (simulatedMs - 1_000) + realMs;
+        assertBudget('codex legacy cold start', legacyColdStartMs,
+            PERFORMANCE_BUDGETS.codexLegacyColdStartMs);
+        return { legacyColdStartMs };
+    } finally {
+        adapter.dispose();
+    }
 }
 
 async function measureCodexStatValidatedReload() {
@@ -706,6 +836,8 @@ async function run() {
             const viewerBudgets = await measureViewerPublicationBudgets();
             const codexBudgets = await measureCodexStatValidatedReload();
             const codexToolHeavy = await measureCodexToolHeavyReload();
+            const codexWindowed = await measureCodexWindowedColdStart();
+            const codexLegacy = await measureCodexLegacyColdStart();
 
             console.log(JSON.stringify({
                 coldMs: Number(coldMs.toFixed(3)),
@@ -741,6 +873,12 @@ async function run() {
                     codexBudgets.appendReloadMs.toFixed(3)
                 ),
                 codexCachedCharacters: codexBudgets.cachedCharacters,
+                codexWindowedColdStartMs: Number(
+                    codexWindowed.windowedColdStartMs.toFixed(3)
+                ),
+                codexLegacyColdStartMs: Number(
+                    codexLegacy.legacyColdStartMs.toFixed(3)
+                ),
                 codexToolHeavyFullReadMs: Number(
                     codexToolHeavy.fullReadMs.toFixed(3)
                 ),

--- a/scripts/run-conversation-performance-checks.js
+++ b/scripts/run-conversation-performance-checks.js
@@ -166,9 +166,12 @@ async function measureCodexLegacyColdStart() {
     const threadId = '77777777-7777-4777-8777-777777777777';
     const payload = createCodexPerfThread(threadId, 205, 60 * 1024);
     const methods = [];
-    // Simulated wall clock: every thread/turns/list page costs a full
-    // replay (600ms on a 60MB-class legacy rollout, per the spike).
+    // Simulated wall clock: the first page is cache-warm fast, every
+    // later page costs a full replay (600ms on a 60MB-class legacy
+    // rollout, per the spike) — the rolling median must verdict on the
+    // third page, never walk the whole history slowly.
     let simulatedMs = 1_000;
+    let pageCount = 0;
     const adapter = new CodexConversationAdapter({
         client: {
             async ensureReady() {
@@ -179,7 +182,8 @@ async function measureCodexLegacyColdStart() {
                 methods.push(method);
                 assert.equal(params.threadId, threadId);
                 if (method === 'thread/turns/list') {
-                    simulatedMs += 600;
+                    pageCount += 1;
+                    simulatedMs += pageCount === 1 ? 20 : 600;
                     return serveCodexTurnsListPage(
                         payload.thread.turns,
                         params
@@ -206,10 +210,12 @@ async function measureCodexLegacyColdStart() {
         const outline = await adapter.readOutline(threadId);
         const realMs = elapsedMs(startedAt);
         assert.equal(outline.totalInteractions, 205);
-        // The legacy verdict must fall back to one full read after exactly
-        // two replay-priced pages — not walk the whole history.
+        // The legacy verdict must fall back to one full read after the
+        // fast first page plus two replay-priced pages — never walk the
+        // whole history at replay prices.
         assert.deepEqual(methods, [
             'ensureReady',
+            'thread/turns/list',
             'thread/turns/list',
             'thread/turns/list',
             'thread/read',

--- a/spikes/codex-cold-start/README.md
+++ b/spikes/codex-cold-start/README.md
@@ -80,6 +80,17 @@ and legacy sessions are a shrinking, pre-0.147 population).
 - Not needed for the adapter: driving `thread/turns/list` directly gives the
   same bootstrap with fewer experimental params and identical page semantics.
 
+## Live-session hazard (found during adapter validation)
+
+Item ids are not reliably turn-scoped while a session is being written:
+a response-spanning reasoning item was projected into turn 218 by one
+fetch and turn 90 by another (real 183MB session, 2026-08-12). Pages
+fetched at different times can disagree about item→turn assignment, so
+cross-page item-id collisions must be treated as a mixed-epoch signal
+(invalidate the assembled state and re-read), not as a protocol
+violation. Quiescent sessions are fully consistent (zero collisions in
+repeated censuses).
+
 ## Feasibility verdict for Phase 3
 
 1. **Windowed cold start is viable and transformative for paginated

--- a/spikes/codex-cold-start/README.md
+++ b/spikes/codex-cold-start/README.md
@@ -1,0 +1,99 @@
+# Spike: Codex app-server cold-start pagination (0.147.0)
+
+Read-only probe assessing whether `thread/turns/list` can replace the cold-start
+full `thread/read` for large Codex sessions (Phase 3 of the
+conversation-loading incrementalization work, after PR #227 stat-signature
+cache and PR #228 incremental paginated reload).
+
+Scripts (run with `node`, require a real `codex` 0.147.0 on this machine):
+
+- `probe.js` — summary-vs-full shapes, big-session walks, thread/read pain,
+  `thread/resume` bootstrap surface.
+- `probe2.js` — cursor portability across limit/itemsView, summary text
+  fidelity.
+- `probe3.js` — per-turn summary-vs-full projection divergence census
+  (finds the summary agentMessage unreliable).
+
+## The pain (re-confirmed)
+
+| Session | Backend | `thread/read` cold start |
+|---|---|---|
+| 183MB / 213 turns (`019fe66d…`) | paginated (sqlite projection) | **40.6s / 52.4MB** — exceeds the 10s client timeout, so the session cannot be opened at all |
+| 60MB / 503 turns (`019f1c4a…`) | legacy (replay per call) | ~1.05s (tolerable today) |
+
+`thread/read` always transfers the whole history in one JSONL frame regardless
+of backend, so the paginated backend does NOT rescue cold start on its own.
+
+## Walk timings (183MB paginated session, this machine)
+
+| Operation | Time | Bytes |
+|---|---|---|
+| tail page, 25 turns, summary | 31ms | 59KB |
+| **full summary walk, asc limit 100 (all 213 turns)** | **111ms / 3 pages** | **331KB** |
+| full-items walk, asc limit 25 (all 213 turns) | 5.5s / 9 pages | 52.4MB |
+| seek: recorded page cursor → limit 4 full | 23.8ms | 474KB |
+
+Legacy 60MB session: summary walk 3.7s (6 pages × ~600ms replay — every page
+replays the whole rollout), tail 25-turn full page 573ms. Cold-start paging is
+therefore only attractive on the paginated backend; legacy stays on the plain
+`thread/read` path (its cost is identical to what the reload path already pays,
+and legacy sessions are a shrinking, pre-0.147 population).
+
+## Summary view shape (verified)
+
+- Per turn the summary view returns exactly 2 items: the `userMessage`
+  (`{type,id,content,clientId}`) and the **final** `agentMessage`
+  (`{type,id,text,phase,memoryCitation}`). Turns without a user message simply
+  omit it. Turn-level fields (`id, status, error, startedAt, completedAt,
+  durationMs`) are present in both views.
+- **User-side text fidelity: verbatim.** Summary userMessage text ===
+  full userMessage text — every outline input (userPreview, timestamp,
+  responseState) is present. The **final agentMessage is NOT reliable**:
+  the summary omits it for interrupted turns, and 1 of 213 completed
+  turns diverged in text (probe3 on the 183MB session: 9/218 turns
+  agent-side mismatches, all interrupted + one completed; user side and
+  turn-level fields identical everywhere). Consequence: skeletons and
+  summary fingerprints must derive only from turn fields + first
+  userMessage; content changes are still caught by the stat epoch and by
+  full-chunk fingerprints for materialized turns.
+- One turn in a `turn/start`-created thread had no userMessage at all (in
+  both views) — do not assume every turn has one. Multi-userMessage turns
+  exist (3 steering messages in one turn of the 183MB session); the
+  summary collapses them to the first.
+
+## Cursor portability (the linchpin for on-demand materialization)
+
+- A `nextCursor` recorded during a `limit:100` summary walk can be reused with
+  a **different limit and itemsView**: re-requesting with `limit:4,
+  itemsView:"full"` seeks to the exact same turn boundary and returns items
+  **byte-identical** to the full walk (`itemsIdenticalToFullWalk: true`).
+- So a cold start can record one cursor per summary page boundary and later
+  materialize any window of turns with a single ~25ms seek.
+
+## `thread/resume` bootstrap surface (verified shape, not adopted)
+
+- `thread/resume {threadId, excludeTurns:true, initialTurnsPage:{limit,
+  sortDirection, itemsView}}` returns `thread.turns: []` plus
+  `initialTurnsPage: TurnsPage` and (when older history exists)
+  `turnsBackwardsCursor` — an opaque head cursor for desc hydration.
+  140ms / 2.4KB on the small session.
+- Not needed for the adapter: driving `thread/turns/list` directly gives the
+  same bootstrap with fewer experimental params and identical page semantics.
+
+## Feasibility verdict for Phase 3
+
+1. **Windowed cold start is viable and transformative for paginated
+   sessions**: skeleton interactions for all turns from one summary walk
+   (~111ms for 213 turns) + full items only for the initial viewer window
+   (~25ms per 4-turn seek; one viewer page ≈ 20 turns) replaces a 40.6s
+   `thread/read` with **well under 1s** of RPC.
+2. On-demand materialization (`readPage` on a skeleton anchor) is one cursor
+   seek away and returns full-view-identical items — no fidelity loss.
+3. Gate on the same version allowlist + slow-page legacy detector as PR #228;
+   legacy/slow → keep today's full `thread/read` cold start.
+4. Revision stability across materialization: materializing a skeleton must
+   NOT change the conversation revision (otherwise every scroll-up looks like
+   a concurrent edit and invalidates retained pages). Compose the revision
+   from per-turn summary-level fingerprints (turn id, status, timestamps,
+   error, user text, final agent text) — computable identically from raw turns
+   on both the windowed and the full-read paths.

--- a/spikes/codex-cold-start/probe.js
+++ b/spikes/codex-cold-start/probe.js
@@ -1,0 +1,367 @@
+'use strict';
+
+/*
+ * Read-only probe for codex app-server 0.147.0 cold-start pagination.
+ *
+ * Verifies, against real session data:
+ *   A. `itemsView:"summary"` item shapes vs `full` on a small session —
+ *      is the summary enough to build outline entries (userPreview etc.)?
+ *   B. Big PAGINATED session (183MB): summary tail page, full asc summary
+ *      walk, full asc full-items walk, and the current `thread/read` pain.
+ *   C. Big LEGACY session (60MB): summary walk + tail window cost.
+ *   D. `thread/resume` with excludeTurns + initialTurnsPage +
+ *      turnsBackwardsCursor — one-shot cold-start bootstrap surface.
+ *
+ * The probe never writes to sessions under test.
+ */
+
+const { spawn } = require('node:child_process');
+const { performance } = require('node:perf_hooks');
+
+const CODEX_EXECUTABLE = '/usr/bin/codex';
+const SMALL_THREAD = '019f975c-0b47-7370-bd44-40ee72e9b6f1'; // ~408KB
+const BIG_PAGINATED = '019fe66d-bd70-73e3-85a8-e92ac1b19f92'; // ~183MB, 213 turns, in sqlite projection
+const BIG_LEGACY = '019f1c4a-6553-7892-9c45-eb0b9be05bf6'; // ~60MB, 503 turns, replay backend
+
+const report = { phases: {} };
+let currentPhase = 'setup';
+
+function record(key, value) {
+    report.phases[currentPhase][key] = value;
+}
+
+class RpcClient {
+    constructor() {
+        this.nextId = 1;
+        this.pending = new Map();
+        this.buffer = '';
+        this.child = spawn(
+            CODEX_EXECUTABLE,
+            ['app-server', '--listen', 'stdio://'],
+            { shell: false, stdio: ['pipe', 'pipe', 'pipe'] }
+        );
+        this.child.stderr.on('data', () => undefined);
+        this.child.stdout.on('data', chunk => this.accept(chunk));
+    }
+
+    accept(chunk) {
+        this.buffer += chunk.toString('utf8');
+        for (;;) {
+            const newline = this.buffer.indexOf('\n');
+            if (newline < 0) {
+                return;
+            }
+            const line = this.buffer.slice(0, newline);
+            this.buffer = this.buffer.slice(newline + 1);
+            if (!line.trim()) {
+                continue;
+            }
+            const message = JSON.parse(line);
+            if (typeof message.method === 'string' && message.id === undefined) {
+                continue; // notifications not needed here
+            }
+            const entry = this.pending.get(message.id);
+            if (!entry) {
+                continue;
+            }
+            this.pending.delete(message.id);
+            if (message.error) {
+                const error = new Error(message.error.message);
+                error.code = message.error.code;
+                entry.reject(error);
+            } else {
+                entry.resolve(message.result);
+            }
+        }
+    }
+
+    write(message) {
+        this.child.stdin.write(`${JSON.stringify(message)}\n`);
+    }
+
+    async connect() {
+        await this.request('initialize', {
+            clientInfo: { name: 'agent_pivot_probe', title: 'Probe', version: '0.0.1' },
+            capabilities: { experimentalApi: true },
+        });
+        this.write({ method: 'initialized', params: {} });
+    }
+
+    request(method, params) {
+        const id = this.nextId++;
+        return new Promise((resolve, reject) => {
+            this.pending.set(id, { resolve, reject });
+            this.write({ method, id, params });
+        });
+    }
+
+    close() {
+        try {
+            this.child.kill();
+        } catch (_error) {
+            // best effort
+        }
+    }
+}
+
+async function timed(fn) {
+    const started = performance.now();
+    const result = await fn();
+    const elapsedMs = Math.round((performance.now() - started) * 100) / 100;
+    const bytes = Buffer.byteLength(JSON.stringify(result));
+    return { elapsedMs, bytes, result };
+}
+
+async function walk(client, threadId, pageParams) {
+    const pages = [];
+    let cursor;
+    for (;;) {
+        const sample = await timed(() => client.request('thread/turns/list', {
+            threadId,
+            cursor,
+            ...pageParams,
+        }));
+        pages.push(sample);
+        cursor = sample.result.nextCursor || undefined;
+        if (!cursor) {
+            break;
+        }
+    }
+    const turns = pages.flatMap(page => page.result.data);
+    return {
+        pages: pages.length,
+        turns: turns.length,
+        totalMs: Math.round(pages.reduce((sum, page) => sum + page.elapsedMs, 0) * 100) / 100,
+        maxPageMs: Math.max(...pages.map(page => page.elapsedMs)),
+        totalBytes: pages.reduce((sum, page) => sum + page.bytes, 0),
+        pageTurns: pages.map(page => page.result.data.length),
+        itemsViewEcho: turns[0] && turns[0].itemsView,
+        allTurns: turns,
+    };
+}
+
+function itemKeyCensus(turns) {
+    const census = {};
+    for (const turn of turns) {
+        for (const item of turn.items || []) {
+            const type = item && item.type || 'unknown';
+            census[type] = census[type] || { count: 0, keys: new Set() };
+            census[type].count += 1;
+            for (const key of Object.keys(item || {})) {
+                census[type].keys.add(key);
+            }
+        }
+    }
+    return Object.fromEntries(Object.entries(census).map(([type, entry]) => [
+        type,
+        { count: entry.count, keys: [...entry.keys].sort() },
+    ]));
+}
+
+function textOf(item) {
+    if (!item || typeof item !== 'object') {
+        return undefined;
+    }
+    if (typeof item.text === 'string') {
+        return item.text;
+    }
+    if (Array.isArray(item.content)) {
+        return item.content.map(part => part && part.text || '').join('');
+    }
+    return undefined;
+}
+
+function preview(value, max = 120) {
+    if (typeof value !== 'string') {
+        return value;
+    }
+    return value.length > max ? `${value.slice(0, max)}…(${value.length} chars)` : value;
+}
+
+async function phaseA(client) {
+    currentPhase = 'A_summary_vs_full_shapes';
+    report.phases[currentPhase] = {};
+    const full = await walk(client, SMALL_THREAD, {
+        limit: 10, sortDirection: 'asc', itemsView: 'full',
+    });
+    const summary = await walk(client, SMALL_THREAD, {
+        limit: 10, sortDirection: 'asc', itemsView: 'summary',
+    });
+    record('full', { turns: full.turns, totalBytes: full.totalBytes });
+    record('summary', { turns: summary.turns, totalBytes: summary.totalBytes });
+    record('summaryKeyCensus', itemKeyCensus(summary.allTurns));
+    record('fullKeyCensus', itemKeyCensus(full.allTurns));
+
+    // Per-turn item type sequence comparison.
+    const sequenceMismatches = [];
+    for (let index = 0; index < Math.max(full.turns, summary.turns); index += 1) {
+        const a = full.allTurns[index];
+        const b = summary.allTurns[index];
+        if (!a || !b || a.id !== b.id) {
+            sequenceMismatches.push({ index, reason: 'turn mismatch' });
+            continue;
+        }
+        const aTypes = (a.items || []).map(item => item.type).join(',');
+        const bTypes = (b.items || []).map(item => item.type).join(',');
+        if (aTypes !== bTypes) {
+            sequenceMismatches.push({ index, turnId: a.id, full: aTypes, summary: bTypes });
+        }
+    }
+    record('itemTypeSequenceMismatches', sequenceMismatches);
+
+    // Text presence per item type in summary view, and whether short texts
+    // survive verbatim (vs truncated).
+    const textStats = {};
+    for (let index = 0; index < summary.turns; index += 1) {
+        const sTurn = summary.allTurns[index];
+        const fTurn = full.allTurns[index];
+        if (!sTurn || !fTurn) {
+            continue;
+        }
+        for (let itemIndex = 0; itemIndex < (sTurn.items || []).length; itemIndex += 1) {
+            const sItem = sTurn.items[itemIndex];
+            const fItem = (fTurn.items || [])[itemIndex];
+            const type = sItem && sItem.type || 'unknown';
+            textStats[type] = textStats[type] || { items: 0, withText: 0, identical: 0, truncated: 0 };
+            textStats[type].items += 1;
+            const sText = textOf(sItem);
+            const fText = textOf(fItem);
+            if (typeof sText === 'string' && sText.length > 0) {
+                textStats[type].withText += 1;
+                if (sText === fText) {
+                    textStats[type].identical += 1;
+                } else if (typeof fText === 'string' && fText.startsWith(sText.replace(/…$/, ''))) {
+                    textStats[type].truncated += 1;
+                }
+            }
+        }
+    }
+    record('summaryTextStats', textStats);
+
+    // A couple of sanitized samples for eyeballing.
+    const samples = [];
+    for (const turn of summary.allTurns) {
+        for (const item of turn.items || []) {
+            if ((item.type === 'userMessage' || item.type === 'agentMessage') && samples.length < 4) {
+                samples.push({ type: item.type, keys: Object.keys(item), text: preview(textOf(item)) });
+            }
+        }
+    }
+    record('summarySamples', samples);
+}
+
+async function phaseB(client) {
+    currentPhase = 'B_big_paginated_183MB';
+    report.phases[currentPhase] = {};
+
+    const tailSummary = await timed(() => client.request('thread/turns/list', {
+        threadId: BIG_PAGINATED, limit: 25, sortDirection: 'desc', itemsView: 'summary',
+    }));
+    record('tailSummary25', {
+        elapsedMs: tailSummary.elapsedMs,
+        bytes: tailSummary.bytes,
+        keyCensus: itemKeyCensus(tailSummary.result.data),
+    });
+
+    const summaryWalk = await walk(client, BIG_PAGINATED, {
+        limit: 100, sortDirection: 'asc', itemsView: 'summary',
+    });
+    record('summaryWalkAsc100', { ...summaryWalk, allTurns: undefined, pageTurns: summaryWalk.pageTurns });
+
+    const fullWalk = await walk(client, BIG_PAGINATED, {
+        limit: 25, sortDirection: 'asc', itemsView: 'full',
+    });
+    record('fullWalkAsc25', { ...fullWalk, allTurns: undefined, pageTurns: fullWalk.pageTurns });
+
+    const read = await timed(() => client.request(
+        'thread/read', { threadId: BIG_PAGINATED, includeTurns: true }
+    ));
+    record('threadRead', { elapsedMs: read.elapsedMs, bytes: read.bytes });
+}
+
+async function phaseC(client) {
+    currentPhase = 'C_big_legacy_60MB';
+    report.phases[currentPhase] = {};
+
+    const summaryWalk = await walk(client, BIG_LEGACY, {
+        limit: 100, sortDirection: 'asc', itemsView: 'summary',
+    });
+    record('summaryWalkAsc100', { ...summaryWalk, allTurns: undefined, pageTurns: summaryWalk.pageTurns });
+
+    const tailFull = await timed(() => client.request('thread/turns/list', {
+        threadId: BIG_LEGACY, limit: 25, sortDirection: 'desc', itemsView: 'full',
+    }));
+    record('tailFull25', { elapsedMs: tailFull.elapsedMs, bytes: tailFull.bytes });
+}
+
+async function phaseD(client) {
+    currentPhase = 'D_thread_resume_bootstrap';
+    report.phases[currentPhase] = {};
+    try {
+        const resume = await timed(() => client.request('thread/resume', {
+            threadId: SMALL_THREAD,
+            excludeTurns: true,
+            initialTurnsPage: { limit: 4, sortDirection: 'desc', itemsView: 'summary' },
+        }));
+        const response = resume.result;
+        record('resume', {
+            elapsedMs: resume.elapsedMs,
+            bytes: resume.bytes,
+            topLevelKeys: Object.keys(response).sort(),
+            threadTurns: response.thread && Array.isArray(response.thread.turns)
+                ? response.thread.turns.length : null,
+            initialTurnsPage: response.initialTurnsPage ? {
+                turns: response.initialTurnsPage.data.length,
+                turnIds: response.initialTurnsPage.data.map(turn => turn.id),
+                itemsView: response.initialTurnsPage.data[0]
+                    && response.initialTurnsPage.data[0].itemsView,
+                hasNextCursor: typeof response.initialTurnsPage.nextCursor === 'string',
+            } : null,
+            hasTurnsBackwardsCursor: typeof response.turnsBackwardsCursor === 'string',
+        });
+        if (typeof response.turnsBackwardsCursor === 'string') {
+            const older = await timed(() => client.request('thread/turns/list', {
+                threadId: SMALL_THREAD,
+                cursor: response.turnsBackwardsCursor,
+                limit: 4,
+                sortDirection: 'desc',
+                itemsView: 'summary',
+            }));
+            const pageIds = response.initialTurnsPage
+                ? new Set(response.initialTurnsPage.data.map(turn => turn.id)) : new Set();
+            record('backwardsCursorPage', {
+                elapsedMs: older.elapsedMs,
+                turnIds: older.result.data.map(turn => turn.id),
+                overlapsInitialPage: older.result.data.some(turn => pageIds.has(turn.id)),
+            });
+        }
+    } catch (error) {
+        record('error', { code: error.code, message: error.message });
+    }
+}
+
+async function main() {
+    const phases = [
+        ['A', phaseA],
+        ['B', phaseB],
+        ['C', phaseC],
+        ['D', phaseD],
+    ];
+    for (const [name, fn] of phases) {
+        const client = new RpcClient();
+        await client.connect();
+        try {
+            await fn(client);
+        } catch (error) {
+            report.phases[currentPhase] = report.phases[currentPhase] || {};
+            report.phases[currentPhase].fatal = String(error && error.stack || error);
+        }
+        client.close();
+    }
+    console.log(JSON.stringify(report, null, 2));
+}
+
+main().catch(error => {
+    console.error('probe failed:', error);
+    process.exitCode = 1;
+});

--- a/spikes/codex-cold-start/probe2.js
+++ b/spikes/codex-cold-start/probe2.js
@@ -1,0 +1,236 @@
+'use strict';
+
+/*
+ * Probe 2 — linchpin questions for windowed cold start:
+ *   A. Cursor portability: a nextCursor recorded during a limit=100 summary
+ *      walk, reused with limit=4 itemsView=full — does it seek to the same
+ *      turn boundary and return identical items to the full walk?
+ *   B. Summary text fidelity: are summary userMessage/agentMessage texts
+ *      verbatim copies of full-view texts (same turn), or truncated/digested?
+ */
+
+const { spawn } = require('node:child_process');
+const { performance } = require('node:perf_hooks');
+
+const CODEX_EXECUTABLE = '/usr/bin/codex';
+const BIG_PAGINATED = '019fe66d-bd70-73e3-85a8-e92ac1b19f92'; // 183MB, 213 turns
+
+const report = {};
+let client;
+
+class RpcClient {
+    constructor() {
+        this.nextId = 1;
+        this.pending = new Map();
+        this.buffer = '';
+        this.child = spawn(
+            CODEX_EXECUTABLE,
+            ['app-server', '--listen', 'stdio://'],
+            { shell: false, stdio: ['pipe', 'pipe', 'pipe'] }
+        );
+        this.child.stderr.on('data', () => undefined);
+        this.child.stdout.on('data', chunk => this.accept(chunk));
+    }
+
+    accept(chunk) {
+        this.buffer += chunk.toString('utf8');
+        for (;;) {
+            const newline = this.buffer.indexOf('\n');
+            if (newline < 0) {
+                return;
+            }
+            const line = this.buffer.slice(0, newline);
+            this.buffer = this.buffer.slice(newline + 1);
+            if (!line.trim()) {
+                continue;
+            }
+            const message = JSON.parse(line);
+            if (typeof message.method === 'string' && message.id === undefined) {
+                continue;
+            }
+            const entry = this.pending.get(message.id);
+            if (!entry) {
+                continue;
+            }
+            this.pending.delete(message.id);
+            if (message.error) {
+                const error = new Error(message.error.message);
+                error.code = message.error.code;
+                entry.reject(error);
+            } else {
+                entry.resolve(message.result);
+            }
+        }
+    }
+
+    write(message) {
+        this.child.stdin.write(`${JSON.stringify(message)}\n`);
+    }
+
+    async connect() {
+        await this.request('initialize', {
+            clientInfo: { name: 'agent_pivot_probe', title: 'Probe', version: '0.0.1' },
+            capabilities: { experimentalApi: true },
+        });
+        this.write({ method: 'initialized', params: {} });
+    }
+
+    request(method, params) {
+        const id = this.nextId++;
+        return new Promise((resolve, reject) => {
+            this.pending.set(id, { resolve, reject });
+            this.write({ method, id, params });
+        });
+    }
+
+    close() {
+        try {
+            this.child.kill();
+        } catch (_error) {
+            // best effort
+        }
+    }
+}
+
+function canonical(value) {
+    if (Array.isArray(value)) {
+        return `[${value.map(canonical).join(',')}]`;
+    }
+    if (value && typeof value === 'object') {
+        const keys = Object.keys(value).sort();
+        return `{${keys.map(k => `${JSON.stringify(k)}:${canonical(value[k])}`).join(',')}}`;
+    }
+    return JSON.stringify(value);
+}
+
+function textOf(item) {
+    if (!item || typeof item !== 'object') {
+        return undefined;
+    }
+    if (typeof item.text === 'string') {
+        return item.text;
+    }
+    if (Array.isArray(item.content)) {
+        return item.content.map(part => part && part.text || '').join('');
+    }
+    return undefined;
+}
+
+function textsByTurn(turns) {
+    const map = new Map();
+    for (const turn of turns) {
+        const entry = { user: [], agent: [] };
+        for (const item of turn.items || []) {
+            if (item.type === 'userMessage') {
+                entry.user.push(textOf(item));
+            } else if (item.type === 'agentMessage') {
+                entry.agent.push(textOf(item));
+            }
+        }
+        map.set(turn.id, entry);
+    }
+    return map;
+}
+
+async function main() {
+    client = new RpcClient();
+    await client.connect();
+
+    // --- A. Cursor portability -------------------------------------------
+    // Summary walk with limit 100; record the first nextCursor (boundary at
+    // turn index 100).
+    const page1 = await client.request('thread/turns/list', {
+        threadId: BIG_PAGINATED, limit: 100, sortDirection: 'asc', itemsView: 'summary',
+    });
+    const boundaryCursor = page1.nextCursor;
+    const page2 = await client.request('thread/turns/list', {
+        threadId: BIG_PAGINATED, cursor: boundaryCursor,
+        limit: 100, sortDirection: 'asc', itemsView: 'summary',
+    });
+    const boundaryTurnIds = page2.data.slice(0, 4).map(turn => turn.id);
+
+    // Reuse the same cursor with different limit AND different itemsView.
+    const started = performance.now();
+    const seekedFull = await client.request('thread/turns/list', {
+        threadId: BIG_PAGINATED, cursor: boundaryCursor,
+        limit: 4, sortDirection: 'asc', itemsView: 'full',
+    });
+    const seekMs = Math.round((performance.now() - started) * 100) / 100;
+    const seekedIds = seekedFull.data.map(turn => turn.id);
+
+    // Ground truth: full walk asc limit 25, turns 100..103.
+    let fullWalkTurns = [];
+    let cursor;
+    for (;;) {
+        const page = await client.request('thread/turns/list', {
+            threadId: BIG_PAGINATED, cursor,
+            limit: 25, sortDirection: 'asc', itemsView: 'full',
+        });
+        fullWalkTurns.push(...page.data);
+        cursor = page.nextCursor || undefined;
+        if (!cursor || fullWalkTurns.length >= 125) {
+            break;
+        }
+    }
+    const truthTurns = fullWalkTurns.slice(100, 104);
+    const truthIds = truthTurns.map(turn => turn.id);
+
+    const itemsIdentical = seekedFull.data.length === truthTurns.length
+        && seekedFull.data.every((turn, index) =>
+            turn.id === truthTurns[index].id
+            && canonical(turn.items) === canonical(truthTurns[index].items));
+
+    report.A_cursorPortability = {
+        boundaryTurnIds,
+        seekedIds,
+        truthIds,
+        sameBoundary: JSON.stringify(seekedIds) === JSON.stringify(boundaryTurnIds)
+            && JSON.stringify(seekedIds) === JSON.stringify(truthIds),
+        itemsIdenticalToFullWalk: itemsIdentical,
+        seekMs,
+        seekBytes: Buffer.byteLength(JSON.stringify(seekedFull)),
+    };
+
+    // --- B. Summary text fidelity ----------------------------------------
+    const tailSummary = await client.request('thread/turns/list', {
+        threadId: BIG_PAGINATED, limit: 4, sortDirection: 'desc', itemsView: 'summary',
+    });
+    const tailFull = await client.request('thread/turns/list', {
+        threadId: BIG_PAGINATED, limit: 4, sortDirection: 'desc', itemsView: 'full',
+    });
+    const summaryTexts = textsByTurn(tailSummary.data);
+    const fullTexts = textsByTurn(tailFull.data);
+    const comparisons = [];
+    for (const [turnId, s] of summaryTexts) {
+        const f = fullTexts.get(turnId);
+        if (!f) {
+            comparisons.push({ turnId, error: 'missing in full' });
+            continue;
+        }
+        const sUser = s.user.join('');
+        const fUser = f.user.join('');
+        const sAgent = s.agent.join('');
+        const fAgentLast = f.agent[f.agent.length - 1] || '';
+        comparisons.push({
+            turnId,
+            summaryItems: tailSummary.data.find(t => t.id === turnId).items.length,
+            fullItems: tailFull.data.find(t => t.id === turnId).items.length,
+            userIdentical: sUser === fUser,
+            userChars: { summary: sUser.length, full: fUser.length },
+            agentEqualsLastFull: sAgent === fAgentLast,
+            agentChars: { summary: sAgent.length, fullLast: fAgentLast.length },
+        });
+    }
+    report.B_summaryTextFidelity = comparisons;
+
+    client.close();
+    console.log(JSON.stringify(report, null, 2));
+}
+
+main().catch(error => {
+    console.error('probe2 failed:', error);
+    if (client) {
+        client.close();
+    }
+    process.exitCode = 1;
+});

--- a/spikes/codex-cold-start/probe3.js
+++ b/spikes/codex-cold-start/probe3.js
@@ -1,0 +1,139 @@
+'use strict';
+
+/*
+ * probe3 — per-turn summary-vs-full projection divergence census.
+ *
+ * Walks the 183MB paginated session in both itemsView modes and compares
+ * the summary-level projection (turn fields, first userMessage, final
+ * agentMessage) per turn. Finding: the summary agentMessage is
+ * UNRELIABLE (omitted for interrupted turns, divergent in 1/213 completed
+ * turns); the user side and turn-level fields are verbatim everywhere.
+ *
+ * Read-only; requires a real codex 0.147.0 on this machine.
+ */
+const { spawn } = require('node:child_process');
+const { createHash } = require('node:crypto');
+const child = spawn('/usr/bin/codex', ['app-server', '--listen', 'stdio://'], { stdio: ['pipe', 'pipe', 'pipe'] });
+let buffer = '';
+const pending = new Map();
+let nextId = 1;
+child.stdout.on('data', chunk => {
+    buffer += chunk.toString('utf8');
+    for (;;) {
+        const nl = buffer.indexOf('\n');
+        if (nl < 0) return;
+        const line = buffer.slice(0, nl);
+        buffer = buffer.slice(nl + 1);
+        if (!line.trim()) continue;
+        const message = JSON.parse(line);
+        const entry = pending.get(message.id);
+        if (!entry) continue;
+        pending.delete(message.id);
+        entry(message);
+    }
+});
+function request(method, params) {
+    const id = nextId++;
+    return new Promise(resolve => {
+        pending.set(id, resolve);
+        child.stdin.write(`${JSON.stringify({ method, id, params })}\n`);
+    });
+}
+function canonicalJson(value) {
+    if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
+    if (value && typeof value === 'object') {
+        const keys = Object.keys(value).sort();
+        return `{${keys.map(k => `${JSON.stringify(k)}:${canonicalJson(value[k])}`).join(',')}}`;
+    }
+    return JSON.stringify(value) ?? 'null';
+}
+function rawUserMessageText(item) {
+    if (!Array.isArray(item.content)) return '';
+    let text = '';
+    for (const part of item.content) {
+        if (part && part.type === 'text' && typeof part.text === 'string') text += part.text;
+    }
+    return text;
+}
+function fp(turn) {
+    let firstUser = null;
+    let finalAgent = null;
+    for (const item of turn.items) {
+        if (!item || typeof item.id !== 'string') continue;
+        if (item.type === 'userMessage' && !firstUser) {
+            firstUser = { id: item.id, text: rawUserMessageText(item) };
+        } else if (item.type === 'agentMessage') {
+            finalAgent = { id: item.id, text: typeof item.text === 'string' ? item.text : '' };
+        }
+    }
+    return createHash('sha256').update(canonicalJson({
+        id: turn.id, status: turn.status,
+        startedAt: turn.startedAt ?? null, completedAt: turn.completedAt ?? null,
+        error: turn.error ?? null, firstUser, finalAgent,
+    }), 'utf8').digest('hex');
+}
+(async () => {
+    await request('initialize', { clientInfo: { name: 'probe', title: 'probe', version: '0.0.1' }, capabilities: { experimentalApi: true } });
+    child.stdin.write(`${JSON.stringify({ method: 'initialized', params: {} })}\n`);
+    const threadId = '019fe66d-bd70-73e3-85a8-e92ac1b19f92';
+    // probe3 — summary-vs-full fingerprint divergence census:
+// per-turn comparison of the summary-level projection across both views.
+// Finding: the summary agentMessage is unreliable (omitted for interrupted
+// turns, divergent elsewhere); the user side is verbatim everywhere.
+
+// asc summary walk → per-turn summary fingerprints
+    const summary = [];
+    let cursor;
+    for (;;) {
+        const page = await request('thread/turns/list', { threadId, cursor, limit: 100, sortDirection: 'asc', itemsView: 'summary' });
+        summary.push(...page.result.data);
+        cursor = page.result.nextCursor || undefined;
+        if (!cursor) break;
+    }
+    // full fetch of turns 40..90 (the validation's safe window area)
+    const mismatches = [];
+    for (let i = 40; i <= 90; i += 1) {
+        const target = summary[i];
+        // fetch that single turn full via a desc seek: walk from head asc is expensive; use summary cursor trick — simply fetch asc pages of 1 starting at a boundary… simpler: fetch all full pages asc limit 25 until i+1
+    }
+    // simpler: full walk asc limit 25 and compare all
+    const full = [];
+    cursor = undefined;
+    for (;;) {
+        const page = await request('thread/turns/list', { threadId, cursor, limit: 25, sortDirection: 'asc', itemsView: 'full' });
+        full.push(...page.result.data);
+        cursor = page.result.nextCursor || undefined;
+        if (!cursor) break;
+    }
+    console.log('summary turns:', summary.length, 'full turns:', full.length);
+    for (let i = 0; i < Math.min(summary.length, full.length); i += 1) {
+        const a = fp(summary[i]);
+        const b = fp(full[i]);
+        if (a !== b) {
+            mismatches.push({ index: i, id: summary[i].id });
+        }
+    }
+    console.log('fingerprint mismatches:', JSON.stringify(mismatches));
+    const divergent = [];
+    for (let i = 0; i < Math.min(summary.length, full.length); i += 1) {
+        const s = summary[i]; const f = full[i];
+        const sUser = s.items.find(x => x.type === 'userMessage');
+        const fUsers = f.items.filter(x => x.type === 'userMessage');
+        const sHas = !!sUser;
+        const fHas = fUsers.length > 0;
+        if (sHas !== fHas || fUsers.length > 1
+            || (sHas && sUser.id !== fUsers[0].id)
+            || (sHas && rawUserMessageText(sUser) !== rawUserMessageText(fUsers[0]))) {
+            divergent.push({
+                index: i, id: s.id, status: s.status,
+                summaryUser: sUser?.id ?? null,
+                fullUserCount: fUsers.length,
+                fullUserIds: fUsers.map(u => u.id),
+                textEqual: sHas && fHas ? rawUserMessageText(sUser) === rawUserMessageText(fUsers[0]) : null,
+            });
+        }
+    }
+    console.log('user-side divergent turns:', JSON.stringify(divergent, null, 1));
+    child.kill();
+})();
+// classification rerun

--- a/src/aiSessions/codexRolloutContentSignature.ts
+++ b/src/aiSessions/codexRolloutContentSignature.ts
@@ -24,3 +24,22 @@ export function readCodexRolloutContentSignature(
         return undefined;
     }
 }
+
+// Byte size of the rollout backing a session. This is purely an
+// optimization-choosing heuristic (is a windowed cold start worth it for
+// this session): the framed app-server response size and duration cannot
+// be inferred from the source size, so it must never feed correctness or
+// fallback-feasibility decisions.
+export function readCodexRolloutSourceBytes(
+    rolloutPath: string
+): number | undefined {
+    if (!rolloutPath) {
+        return undefined;
+    }
+    try {
+        const stat = statSync(rolloutPath);
+        return stat.isFile() ? stat.size : undefined;
+    } catch (_error) {
+        return undefined;
+    }
+}

--- a/src/aiSessions/conversation/codexAdapter.ts
+++ b/src/aiSessions/conversation/codexAdapter.ts
@@ -63,6 +63,14 @@ export interface CodexConversationClient extends AiSessionDisposable {
     // when the client exposes it. Gates version-sensitive protocol
     // accelerators such as thread/turns/list.
     getServerVersion?(): string | undefined;
+    // Resolves the shared initialize handshake and returns the server
+    // version. Concurrent callers attach to the same handshake; a caller's
+    // abort cancels only its own wait, never the handshake. Cold-start
+    // paths must await this before version-gating: getServerVersion() is
+    // undefined until the first request triggers the handshake.
+    ensureReady?(
+        signal?: ConversationAbortSignal
+    ): Promise<string | undefined>;
 }
 
 interface CodexRolloutTelemetrySnapshot {
@@ -89,6 +97,12 @@ export interface CodexConversationAdapterOptions {
     // without another full thread/read. An undefined/unreadable signature
     // bypasses the cache entirely.
     readContentSignature?(sessionId: string): string | undefined;
+    // Rollout byte size. Pure optimization-choosing heuristic for the
+    // windowed cold start (is paging worth it for this session) — the
+    // framed app-server response size/duration cannot be inferred from
+    // the source size, so this never feeds correctness or
+    // fallback-feasibility decisions.
+    readSourceBytes?(sessionId: string): number | undefined;
     readLifecycleSignal?(
         sessionId: string
     ): AiSessionLifecycleSignal | undefined;
@@ -131,22 +145,94 @@ const PAGINATED_READ_SLOW_PAGE_MS = 250;
 // request timeout outright, so the walk must be allowed to be generous.
 const PAGINATED_READ_WALK_TURN_LIMIT = 1024;
 const PAGINATED_READ_WALK_BUDGET_MS = 3000;
+// Windowed cold start (spikes/codex-cold-start): on a verified paginated
+// backend, the first load of a large session lists every turn as a
+// summary skeleton and materializes full items only for the tail window;
+// older windows are fetched on demand through readPage/readSnapshot.
+// Below this rollout size the plain thread/read cold start stays as is.
+const COLD_START_WINDOW_MIN_SOURCE_BYTES = 4 * 1024 * 1024;
+// Summary walk page size; one boundary cursor is recorded per page, so
+// this is also the seek granularity of on-demand materialization.
+const COLD_START_SUMMARY_PAGE_TURNS = 50;
+// Legacy-verdict latency: the legacy replay backend costs a full replay
+// PER PAGE (hundreds of ms), the indexed paginated backend answers in
+// tens of ms. The verdict requires BOTH of the first two pages to be
+// slow — a single jittery page must not decide. The handshake is already
+// excluded (ensureReady settles before the walk starts).
+const COLD_START_SLOW_PAGE_MS = 250;
+// Runaway safety valves (resource bounds, not heuristics): a paginated
+// backend serves flat ~tens-of-ms pages, so these trip only on
+// server-side pathology.
+const COLD_START_MAX_WALK_PAGES = 4000;
+const COLD_START_MAX_WALK_MS = 120_000;
+// Tail window materialized eagerly at cold start (~one retained viewer
+// page set) and the full-turn page size of on-demand materialization
+// (keeps single responses ~2MB even for the heaviest turns).
+const COLD_START_TAIL_TURNS = 40;
+const COLD_START_TAIL_BYTES = 1536 * 1024;
+const COLD_START_MATERIALIZE_PAGE_TURNS = 8;
 
 interface LoadedConversation {
     interactions: ConversationInteraction[];
     sourceRevision: string;
 }
 
+// One cold-start/reload's result plus the state a windowed entry must
+// persist (see CachedLoadedConversation).
+interface LoadConversationOutcome {
+    value: LoadedConversation;
+    turns?: LoadedConversationTurn[];
+    characters: number;
+    // Windowed entries must keep their basis across incremental reloads —
+    // losing it would strand skeleton chunks without a materialization
+    // path.
+    revisionBasis?: 'full' | 'windowed';
+    structureGen?: number;
+    walkPages?: { startCursor?: string; turnCount: number }[];
+    walkNewerTurns?: number;
+    contentEpochSignature?: string;
+}
+
+// loadWindowed either loads, verdicts the backend as legacy replay (both
+// first pages slow), or returns null when gated/failing transiently.
+type WindowedLoadResult =
+    | (LoadConversationOutcome & {
+        turns: LoadedConversationTurn[];
+        legacy?: false;
+    })
+    | { legacy: true }
+    | null;
+
+// loadIncremental either produces an outcome or asks the caller to
+// rebuild a windowed entry through a fresh summary walk.
+type IncrementalLoadResult =
+    | (LoadConversationOutcome & {
+        turns: LoadedConversationTurn[];
+        rebuild?: false;
+    })
+    | { rebuild: true }
+    | null;
+
 // Per-turn normalized chunks of a cached root-thread conversation. Chunk
 // interactions share objects with `value.interactions` (no string payload
 // is duplicated); they let an incremental reload re-normalize only the
-// turns that actually changed.
+// turns that actually changed. `kind: 'skeleton'` chunks come from the
+// windowed cold start's summary walk: they carry only the
+// outline-level projection (first user message + turn fields) and are
+// materialized into full chunks on demand.
 interface LoadedConversationTurn {
     turnId: string;
     itemIds: string[];
     interactions: ConversationInteraction[];
+    // Full chunks: hash of the normalized interactions. Skeleton chunks
+    // leave this empty — they join reuse decisions via summaryFingerprint.
     fingerprint: string;
+    // Hash of the turn's summary-level projection (turn fields + first
+    // user message + final agent message), derived identically from a
+    // summary page or a full turn. Stable across materialization.
+    summaryFingerprint: string;
     characters: number;
+    kind: 'full' | 'skeleton';
 }
 
 interface CachedLoadedConversation {
@@ -155,6 +241,25 @@ interface CachedLoadedConversation {
     characters: number;
     lastTouchedAt: number;
     turns?: LoadedConversationTurn[];
+    // Windowed-entry state (undefined for full-read entries). The
+    // windowed revision is a PROJECTION revision: it covers the
+    // outline-level turn structure plus materialized content — never the
+    // bytes of unmaterized turns, whose freshness is guaranteed by
+    // fetching them live at materialization time.
+    revisionBasis?: 'full' | 'windowed';
+    // Bumped when materialization changes the interaction-id set of a
+    // turn (a multi-user-message turn expanding). Keeps cursors truthful:
+    // a changed id set must invalidate cursors anchored at new ids.
+    structureGen?: number;
+    // One entry per summary walk page (walk order = newest first),
+    // giving each skeleton page the request cursor that reproduces it.
+    walkPages?: { startCursor?: string; turnCount: number }[];
+    // Turns appended after the walk: they shift every walked chunk's
+    // newest-first index, so page mapping rebases by this count.
+    walkNewerTurns?: number;
+    // Stat signature as of the last observed projection change — the
+    // content-epoch component of the windowed revision.
+    contentEpochSignature?: string;
 }
 
 function asRecord(value: unknown): Record<string, any> | undefined {
@@ -544,6 +649,166 @@ function composeConversationRevision(
         .digest('hex');
 }
 
+// Stable JSON with sorted object keys: the fingerprint input for
+// summary-level turn projections (whose `error` field is a nested object).
+function canonicalJson(value: unknown): string {
+    if (Array.isArray(value)) {
+        return `[${value.map(canonicalJson).join(',')}]`;
+    }
+    if (value && typeof value === 'object') {
+        const record = value as Record<string, unknown>;
+        const keys = Object.keys(record).sort();
+        return `{${keys.map(key =>
+            `${JSON.stringify(key)}:${canonicalJson(record[key])}`
+        ).join(',')}}`;
+    }
+    return JSON.stringify(value) ?? 'null';
+}
+
+// Raw text of a userMessage item (no visible-message capping): the
+// summary and full views carry the item verbatim (spike-verified), so
+// raw text keeps the fingerprint identical across both derivations.
+function rawUserMessageText(item: Record<string, any>): string {
+    if (!Array.isArray(item.content)) {
+        return '';
+    }
+    let text = '';
+    for (const rawPart of item.content) {
+        const part = asRecord(rawPart);
+        if (part?.type === 'text' && typeof part.text === 'string') {
+            text += part.text;
+        }
+    }
+    return text;
+}
+
+// Hash of a turn's summary-level projection: turn fields plus the FIRST
+// userMessage. Mirrors the server projection's summary rule
+// (first_user_item_id, schema-verified in spikes/codex-cold-start).
+// The final agentMessage is deliberately EXCLUDED: the summary view
+// omits it for interrupted turns and can otherwise diverge from the full
+// view (real-data probe: 9/218 turns), while the user side is verbatim
+// everywhere. Content changes still move the revision through the
+// content-epoch (stat) component; this fingerprint only pins the
+// outline-level turn structure.
+function turnSummaryFingerprint(turn: Record<string, any>): string {
+    let firstUser: { id: string; text: string } | null = null;
+    for (const rawItem of turn.items as unknown[]) {
+        const item = asRecord(rawItem);
+        if (!item || typeof item.id !== 'string') {
+            continue;
+        }
+        if (item.type === 'userMessage') {
+            firstUser = { id: item.id, text: rawUserMessageText(item) };
+            break;
+        }
+    }
+    return createHash('sha256')
+        .update(canonicalJson({
+            id: turn.id,
+            status: turn.status,
+            startedAt: turn.startedAt ?? null,
+            completedAt: turn.completedAt ?? null,
+            error: turn.error ?? null,
+            firstUser,
+        }), 'utf8')
+        .digest('hex');
+}
+
+// The windowed revision: a PROJECTION revision covering the outline-level
+// turn structure (summary fingerprints) and the materialized content
+// epoch (stat signature as of the last observed change), plus the
+// structure generation (interaction-id set changes). Materializing a
+// skeleton without an id-set change alters none of the inputs, so
+// retained-page cursors survive scrolling-driven materialization.
+function composeWindowedRevision(
+    contentEpochSignature: string,
+    turns: readonly LoadedConversationTurn[],
+    structureGen: number
+): string {
+    return createHash('sha256')
+        .update(`${contentEpochSignature}|${structureGen}|`, 'utf8')
+        .update(turns.map(turn => turn.summaryFingerprint).join(':'), 'utf8')
+        .digest('hex');
+}
+
+// Builds the skeleton chunk content for one turn from its summary view:
+// zero or one interaction mirroring normalizeTurnItems' userMessage
+// branch exactly (same id, same visible-text filtering, same timing and
+// response state), minus all assistant content. The skeleton interaction
+// id equals the id the full path assigns, so anchors survive
+// materialization.
+function skeletonTurnInteractions(
+    turn: Record<string, any>
+): { interactions: ConversationInteraction[]; itemIds: string[] } {
+    let userItem: Record<string, any> | undefined;
+    let agentItemId: string | undefined;
+    for (const rawItem of turn.items as unknown[]) {
+        const item = asRecord(rawItem);
+        if (!item
+            || typeof item.id !== 'string'
+            || !item.id
+            || typeof item.type !== 'string') {
+            throw protocolError();
+        }
+        if (item.type === 'userMessage' && !userItem) {
+            userItem = item;
+        } else if (item.type === 'agentMessage') {
+            agentItemId = item.id;
+        }
+    }
+    const itemIds = userItem
+        ? (agentItemId ? [userItem.id as string, agentItemId]
+            : [userItem.id as string])
+        : (agentItemId ? [agentItemId] : []);
+    if (!userItem) {
+        return { interactions: [], itemIds };
+    }
+    if (!Array.isArray(userItem.content)) {
+        throw protocolError();
+    }
+    const parts: VisibleUserInputPart[] = [];
+    for (const rawPart of userItem.content) {
+        const part = asRecord(rawPart);
+        if (!part || typeof part.type !== 'string') {
+            throw protocolError();
+        }
+        if (part.type === 'text') {
+            if (typeof part.text !== 'string') {
+                throw protocolError();
+            }
+            parts.push({ kind: 'text', text: part.text });
+        } else if (part.type === 'image' || part.type === 'audio') {
+            if (typeof part.url !== 'string') {
+                throw protocolError();
+            }
+            parts.push({ kind: 'attachment' });
+        } else if (part.type === 'localImage' || part.type === 'localAudio') {
+            if (typeof part.path !== 'string') {
+                throw protocolError();
+            }
+            parts.push({ kind: 'attachment' });
+        }
+    }
+    const userMarkdown = visibleMessage(buildVisibleUserInput(parts));
+    if (!userMarkdown) {
+        return { interactions: [], itemIds };
+    }
+    return {
+        interactions: [{
+            id: userItem.id as string,
+            providerTurnId: turn.id,
+            ...turnTiming(turn),
+            userMarkdown,
+            userPreview: buildUserPreview(userMarkdown),
+            userGraphemeCount: countGraphemes(userMarkdown),
+            assistantMarkdown: [],
+            responseState: turnResponseState(turn.status),
+        }],
+        itemIds,
+    };
+}
+
 function conversationCharacters(
     interactions: readonly ConversationInteraction[]
 ): number {
@@ -795,6 +1060,10 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
     >();
     private loadedConversationCacheChars = 0;
     private conversationCacheGeneration = 0;
+    private readonly materializationQueues = new Map<
+        string,
+        Promise<void>
+    >();
     private disposed = false;
     // Circuit breaker for the experimental thread/turns/list accelerator:
     // once the server rejects the method or answers with a malformed page,
@@ -814,28 +1083,67 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
         signal?: ConversationAbortSignal
     ): Promise<ConversationSnapshot> {
         const loaded = await this.load(sessionId, signal);
+        let working = loaded;
+        const entry = this.loadedConversationCache.get(sessionId);
+        if (entry?.revisionBasis === 'windowed' && entry.turns?.length) {
+            const interactions = entry.value.interactions;
+            const selectedId = preferredInteractionId
+                && interactions.some(
+                    interaction => interaction.id === preferredInteractionId
+                )
+                ? preferredInteractionId
+                : interactions[interactions.length - 1]?.id;
+            if (selectedId) {
+                // The snapshot's page must never contain skeletons:
+                // materialize around the selected interaction first.
+                working = await this.materializeAround(
+                    sessionId,
+                    entry as CachedLoadedConversation
+                        & { turns: LoadedConversationTurn[] },
+                    selectedId,
+                    'around',
+                    signal
+                ) ?? working;
+            }
+        }
         const outline = buildConversationOutline(
             'codex',
             sessionId,
-            loaded.sourceRevision,
-            loaded.interactions,
+            working.sourceRevision,
+            working.interactions,
             false
         );
         const selected = outline.interactions.find(interaction =>
             interaction.id === preferredInteractionId
         ) || outline.interactions[outline.interactions.length - 1];
+        if (!selected) {
+            return { outline };
+        }
+        const pageRequest: ConversationPageRequest = {
+            provider: 'codex',
+            sessionId,
+            anchorInteractionId: selected.id,
+            direction: 'around',
+            expectedRevision: working.sourceRevision,
+            limit: CONVERSATION_LIMITS.maxPageInteractions,
+        };
+        const page = buildConversationPage(
+            working.interactions,
+            pageRequest,
+            working.sourceRevision
+        );
         return {
             outline,
-            ...(selected ? {
-                page: buildConversationPage(loaded.interactions, {
-                    provider: 'codex',
+            page: entry?.revisionBasis === 'windowed' && entry.turns?.length
+                ? await this.ensurePageFreeOfSkeletons(
                     sessionId,
-                    anchorInteractionId: selected.id,
-                    direction: 'around',
-                    expectedRevision: loaded.sourceRevision,
-                    limit: CONVERSATION_LIMITS.maxPageInteractions,
-                }, loaded.sourceRevision),
-            } : {}),
+                    entry as CachedLoadedConversation
+                        & { turns: LoadedConversationTurn[] },
+                    page,
+                    pageRequest,
+                    signal
+                )
+                : page,
         };
     }
 
@@ -858,10 +1166,157 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
         signal?: ConversationAbortSignal
     ): Promise<ConversationPage> {
         const loaded = await this.load(request.sessionId, signal);
+        let working = loaded;
+        let expectedRevision = request.expectedRevision;
+        const entry = this.loadedConversationCache.get(request.sessionId);
+        if (entry?.revisionBasis === 'windowed' && entry.turns?.length) {
+            const revisionBefore = entry.value.sourceRevision;
+            working = await this.materializeAround(
+                request.sessionId,
+                entry as CachedLoadedConversation
+                    & { turns: LoadedConversationTurn[] },
+                request.anchorInteractionId,
+                request.direction,
+                signal,
+                request.limit
+            ) ?? working;
+            if (entry.value.sourceRevision !== revisionBefore) {
+                // Materialization changed the revision under the client's
+                // expectation (a turn expanded its interaction-id set):
+                // do not pin the expected revision — the coordinator
+                // observes the new revision and settles its cursors.
+                expectedRevision = undefined;
+            }
+        }
+        const page = buildConversationPage(
+            working.interactions,
+            { ...request, provider: 'codex', expectedRevision },
+            working.sourceRevision
+        );
+        if (entry?.revisionBasis === 'windowed' && entry.turns?.length) {
+            return this.ensurePageFreeOfSkeletons(
+                request.sessionId,
+                entry as CachedLoadedConversation
+                    & { turns: LoadedConversationTurn[] },
+                page,
+                { ...request, provider: 'codex' },
+                signal
+            );
+        }
+        return page;
+    }
+
+    // Materializes every skeleton chunk overlapping the page range around
+    // an anchor interaction. Returns the up-to-date (lifecycle-applied)
+    // conversation, or undefined when the anchor cannot be resolved — in
+    // which case buildConversationPage produces the canonical
+    // staleRevision.
+    private async materializeAround(
+        sessionId: string,
+        entry: CachedLoadedConversation
+            & { turns: LoadedConversationTurn[] },
+        anchorInteractionId: string,
+        direction: ConversationPageRequest['direction'],
+        signal: ConversationAbortSignal | undefined,
+        limit?: number
+    ): Promise<LoadedConversation | undefined> {
+        if (!entry.turns.some(chunk => chunk.kind === 'skeleton')) {
+            return this.withRunningLifecycle(sessionId, entry.value);
+        }
+        const interactions = entry.value.interactions;
+        const anchorIndex = interactions.findIndex(
+            interaction => interaction.id === anchorInteractionId
+        );
+        if (anchorIndex < 0) {
+            return undefined;
+        }
+        // Interaction index → chunk index (zero-interaction chunks never
+        // contain the anchor and are skipped by the walk).
+        let chunkIndex = 0;
+        let remaining = anchorIndex;
+        while (chunkIndex < entry.turns.length - 1
+            && remaining >= entry.turns[chunkIndex].interactions.length) {
+            remaining -= entry.turns[chunkIndex].interactions.length;
+            chunkIndex += 1;
+        }
+        const pageLimit = Math.max(1, Math.min(
+            CONVERSATION_LIMITS.maxPageInteractions,
+            Math.floor(limit || CONVERSATION_LIMITS.maxPageInteractions)
+        ));
+        // Skeleton chunks hold at most one interaction, so an interaction
+        // radius maps directly onto chunks; the margin absorbs full
+        // chunks with several interactions.
+        const margin = 5;
+        let fromChunk: number;
+        let toChunk: number;
+        if (direction === 'before') {
+            fromChunk = chunkIndex - 2 * pageLimit - margin;
+            toChunk = chunkIndex - 1;
+        } else if (direction === 'after') {
+            fromChunk = chunkIndex + 1;
+            toChunk = chunkIndex + 2 * pageLimit + margin;
+        } else {
+            fromChunk = chunkIndex - pageLimit - margin;
+            toChunk = chunkIndex + pageLimit + margin;
+        }
+        await this.enqueueMaterialization(
+            sessionId,
+            entry,
+            { fromChunk, toChunk },
+            signal
+        );
+        return this.withRunningLifecycle(sessionId, entry.value);
+    }
+
+    // Interaction ids still backed by skeleton chunks. Anything in this
+    // set must never reach the webview (a skeleton renders as an empty
+    // assistant response).
+    private skeletonInteractionIds(
+        turns: readonly LoadedConversationTurn[]
+    ): Set<string> {
+        const ids = new Set<string>();
+        for (const chunk of turns) {
+            if (chunk.kind === 'skeleton') {
+                for (const interaction of chunk.interactions) {
+                    ids.add(interaction.id);
+                }
+            }
+        }
+        return ids;
+    }
+
+    // Absolute backstop for the radius heuristic: if a built page still
+    // references a skeleton-owned interaction (pathological expansion
+    // shifts), materialize the whole skeleton set and rebuild the page
+    // once. Correctness over laziness; expected to never run.
+    private async ensurePageFreeOfSkeletons(
+        sessionId: string,
+        entry: CachedLoadedConversation
+            & { turns: LoadedConversationTurn[] },
+        page: ConversationPage,
+        request: ConversationPageRequest,
+        signal: ConversationAbortSignal | undefined
+    ): Promise<ConversationPage> {
+        const skeletonIds = this.skeletonInteractionIds(entry.turns);
+        if (!skeletonIds.size
+            || !page.interactionStates.some(
+                state => skeletonIds.has(state.interactionId)
+            )) {
+            return page;
+        }
+        await this.enqueueMaterialization(
+            sessionId,
+            entry,
+            { fromChunk: 0, toChunk: entry.turns.length - 1 },
+            signal
+        );
+        const working = this.withRunningLifecycle(sessionId, entry.value);
+        // The revision may have moved (expansions); do not pin the
+        // request's expectation on the rebuild.
         return buildConversationPage(
-            loaded.interactions,
-            { ...request, provider: 'codex' },
-            loaded.sourceRevision
+            working.interactions,
+            { ...request, provider: 'codex', expectedRevision: undefined },
+            working.sourceRevision
         );
     }
 
@@ -1135,6 +1590,7 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
         this.invalidateLoadedConversationCache();
         this.loadedConversationCache.clear();
         this.loadedConversationCacheChars = 0;
+        this.materializationQueues.clear();
         this.subscriptions.clear();
         this.options.client.dispose();
     }
@@ -1217,11 +1673,12 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
         }
         const generation = this.conversationCacheGeneration;
         const startedAt = this.now();
-        return this.loadConversation(sessionId, cached, signal).then(outcome => {
+        return this.loadConversation(sessionId, cached, signal, signature).then(outcome => {
             if (!this.disposed
                 && generation === this.conversationCacheGeneration
                 && signature !== undefined
                 && (outcome.kind === 'incremental'
+                    || outcome.kind === 'windowed'
                     || outcome.characters >= LARGE_CONVERSATION_CACHE_CHARS
                     || this.now() - startedAt
                         >= LARGE_CONVERSATION_CACHE_MIN_READ_MS)) {
@@ -1231,6 +1688,14 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
                     characters: outcome.characters,
                     lastTouchedAt: this.now(),
                     turns: outcome.turns,
+                    revisionBasis: outcome.revisionBasis
+                        ?? (outcome.kind === 'windowed'
+                            ? 'windowed'
+                            : (outcome.turns ? 'full' : undefined)),
+                    structureGen: outcome.structureGen,
+                    walkPages: outcome.walkPages,
+                    walkNewerTurns: outcome.walkNewerTurns,
+                    contentEpochSignature: outcome.contentEpochSignature,
                 });
             }
             return this.withRunningLifecycle(sessionId, outcome.value);
@@ -1261,14 +1726,14 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
     private async loadConversation(
         sessionId: string,
         stale: CachedLoadedConversation | undefined,
-        signal?: ConversationAbortSignal
-    ): Promise<{
-        value: LoadedConversation;
-        turns?: LoadedConversationTurn[];
-        characters: number;
-        kind: 'fresh' | 'incremental';
+        signal: ConversationAbortSignal | undefined,
+        signature: string | undefined
+    ): Promise<LoadConversationOutcome & {
+        kind: 'fresh' | 'incremental' | 'windowed';
     }> {
         const split = splitSubagentSessionId(sessionId);
+        const windowedEntry = stale?.revisionBasis === 'windowed'
+            && !!stale.turns?.length;
         if (stale?.turns?.length
             && !split.subagentId
             && this.paginatedReadsUsable()) {
@@ -1276,10 +1741,56 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
                 sessionId,
                 stale as CachedLoadedConversation
                     & { turns: LoadedConversationTurn[] },
-                signal
+                signal,
+                signature
             );
-            if (incremental) {
+            if (incremental && incremental.rebuild !== true) {
                 return { ...incremental, kind: 'incremental' };
+            }
+            // A windowed entry never falls back to the full read: the
+            // session's size may exceed the request timeout outright.
+            // Anchor loss (compaction) or any incremental failure re-walks
+            // the summary pages instead.
+            if ((incremental?.rebuild === true) || windowedEntry) {
+                const rebuilt = await this.loadWindowed(
+                    sessionId,
+                    signal,
+                    true
+                );
+                if (rebuilt && rebuilt.legacy !== true) {
+                    return { ...rebuilt, kind: 'windowed' };
+                }
+            }
+        }
+        if (!split.subagentId) {
+            const windowed = await this.loadWindowed(sessionId, signal, false);
+            if (windowed && windowed.legacy !== true) {
+                return { ...windowed, kind: 'windowed' };
+            }
+            if (windowed?.legacy === true) {
+                // Legacy replay backend: one full read beats per-page
+                // replays. When the read cannot complete (timeout /
+                // tooLarge), the slow walk is the only remaining path —
+                // huge legacy sessions become openable (slowly) instead
+                // of failing outright.
+                try {
+                    const fresh = await this.loadFresh(sessionId, signal);
+                    return { ...fresh, kind: 'fresh' };
+                } catch (error) {
+                    if (error instanceof ConversationError
+                        && (error.code === 'timeout'
+                            || error.code === 'tooLarge')) {
+                        const forced = await this.loadWindowed(
+                            sessionId,
+                            signal,
+                            true
+                        );
+                        if (forced && forced.legacy !== true) {
+                            return { ...forced, kind: 'windowed' };
+                        }
+                    }
+                    throw error;
+                }
             }
         }
         const fresh = await this.loadFresh(sessionId, signal);
@@ -1312,12 +1823,10 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
         sessionId: string,
         cached: CachedLoadedConversation
             & { turns: LoadedConversationTurn[] },
-        signal?: ConversationAbortSignal
-    ): Promise<{
-        value: LoadedConversation;
-        turns: LoadedConversationTurn[];
-        characters: number;
-    } | null> {
+        signal: ConversationAbortSignal | undefined,
+        signature: string | undefined
+    ): Promise<IncrementalLoadResult> {
+        const isWindowed = cached.revisionBasis === 'windowed';
         const anchorTurnId = cached.turns[cached.turns.length - 1].turnId;
         const fetched: Record<string, any>[] = [];
         let cursor: string | undefined;
@@ -1384,21 +1893,34 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
             if (firstPageMs >= PAGINATED_READ_SLOW_PAGE_MS) {
                 return null;
             }
+            if (isWindowed
+                && anchorIndex < 0
+                && fetched.length >= 3 * PAGINATED_READ_PAGE_SIZE) {
+                // The anchor is the tail turn: absent from the first pages,
+                // the tail was rewritten (compaction). Rebuild through a
+                // fresh summary walk — rebuilding a huge windowed entry
+                // from full pages would defeat the whole design.
+                return { rebuild: true };
+            }
             if (fetched.length >= PAGINATED_READ_WALK_TURN_LIMIT
                 || this.now() - walkStartedAt
                     >= PAGINATED_READ_WALK_BUDGET_MS) {
-                return null;
+                return isWindowed ? { rebuild: true } : null;
             }
             cursor = nextCursor;
         }
         // `fetched` is newest-first. When the anchor survived, only the
         // turns from the anchor forward are re-normalized (the anchor may
         // have grown since it was cached). When the walk ran to the end of
-        // the thread without finding it, the tail was rewritten
-        // (compaction/rollback) and every chunk is rebuilt from the fetched
-        // pages — the paginated backend serves them cheaply, while a full
-        // thread/read of a huge paginated session would exceed the request
-        // timeout outright.
+        // the thread without it, the tail was rewritten
+        // (compaction/rollback): windowed entries rebuild through a fresh
+        // summary walk, while full entries rebuild every chunk from the
+        // fetched pages — the paginated backend serves them cheaply, and
+        // a full thread/read of a huge paginated session would exceed the
+        // request timeout outright.
+        if (anchorIndex < 0 && isWindowed) {
+            return { rebuild: true };
+        }
         const kept = anchorIndex >= 0 ? cached.turns.slice(0, -1) : [];
         const reloaded = (anchorIndex >= 0
             ? fetched.slice(0, anchorIndex + 1)
@@ -1407,6 +1929,61 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
         const turns = this.normalizeReloadedTurns(kept, reloaded);
         if (!turns) {
             return null;
+        }
+        if (isWindowed) {
+            // Projection revision: unchanged when neither the outline-level
+            // turn structure nor any materialized chunk's content moved.
+            let unchanged = turns.length === cached.turns.length;
+            for (let index = 0; unchanged && index < turns.length; index += 1) {
+                const next = turns[index];
+                const prev = cached.turns[index];
+                unchanged = next.summaryFingerprint === prev.summaryFingerprint
+                    && (next.kind === 'skeleton'
+                        ? prev.kind === 'skeleton'
+                        : next.fingerprint === prev.fingerprint);
+            }
+            if (unchanged) {
+                return {
+                    value: cached.value,
+                    turns: cached.turns,
+                    characters: cached.characters,
+                    revisionBasis: 'windowed',
+                    structureGen: cached.structureGen,
+                    walkPages: cached.walkPages,
+                    walkNewerTurns: cached.walkNewerTurns,
+                    contentEpochSignature: cached.contentEpochSignature,
+                };
+            }
+            const structureGen = cached.structureGen ?? 0;
+            const epochSignature = signature
+                ?? cached.contentEpochSignature
+                ?? '';
+            const sourceRevision = composeWindowedRevision(
+                epochSignature,
+                turns,
+                structureGen
+            );
+            const characters = turns.reduce(
+                (sum, turn) => sum + turn.characters,
+                0
+            );
+            const interactions = turns.reduce<ConversationInteraction[]>(
+                (all, turn) => all.concat(turn.interactions),
+                []
+            );
+            return {
+                value: { interactions, sourceRevision },
+                turns,
+                characters,
+                revisionBasis: 'windowed',
+                structureGen,
+                walkPages: cached.walkPages,
+                // Anchor reloads replace the tail in place; every turn
+                // beyond the cached length is new since the walk.
+                walkNewerTurns: (cached.walkNewerTurns ?? 0)
+                    + Math.max(0, turns.length - cached.turns.length),
+                contentEpochSignature: epochSignature,
+            };
         }
         const sourceRevision = composeConversationRevision(turns);
         const characters = turns.reduce(
@@ -1466,13 +2043,553 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
                     interactions: context.interactions,
                     itemIds: context.newItemIds,
                     fingerprint: fingerprintInteractions(context.interactions),
+                    summaryFingerprint: turnSummaryFingerprint(turn),
                     characters: conversationCharacters(context.interactions),
+                    kind: 'full' as const,
                 });
             }
         } catch (_error) {
             return null;
         }
         return [...kept, ...rebuilt];
+    }
+
+    /**
+     * Windowed cold start (spikes/codex-cold-start): lists every turn as a
+     * summary skeleton (flat ~tens-of-ms pages on the indexed paginated
+     * backend), then materializes full items only for the tail window.
+     * Older turns materialize on demand through readPage/readSnapshot.
+     *
+     * Returns null when the path is gated (unverified server version, no
+     * content signature, small rollout, transient transport failure) — the
+     * caller then uses the stable full thread/read. A `{legacy: true}`
+     * verdict means both first summary pages cost a full replay each, so a
+     * single full read is cheaper; `force` skips that verdict (used when
+     * the full read already failed, or when re-walking a windowed entry).
+     * Method-level rejections and malformed pages disable the paginated
+     * path for the lifetime of this adapter.
+     */
+    private async loadWindowed(
+        sessionId: string,
+        signal: ConversationAbortSignal | undefined,
+        force: boolean
+    ): Promise<WindowedLoadResult> {
+        if (this.disposed) {
+            throw new ConversationError('unavailable', 'reconnectingCodex');
+        }
+        if (this.paginatedReadsDisabled) {
+            return null;
+        }
+        const client = this.options.client;
+        if (typeof client.ensureReady !== 'function'
+            || typeof this.options.readSourceBytes !== 'function') {
+            return null;
+        }
+        // The handshake MUST complete before version gating: the version
+        // is unknown until initialize returns, and its cost must not
+        // contaminate the per-page latency the legacy verdict relies on.
+        let version: string | undefined;
+        try {
+            version = await client.ensureReady(signal);
+        } catch (error) {
+            if (error instanceof ConversationAbortError
+                || error?.name === 'AbortError') {
+                throw error;
+            }
+            if (this.disposed) {
+                throw new ConversationError('unavailable', 'reconnectingCodex');
+            }
+            return null;
+        }
+        if (version === undefined
+            || !PAGINATED_READ_SERVER_VERSIONS.has(version)) {
+            return null;
+        }
+        const sourceBytes = this.options.readSourceBytes(sessionId);
+        if (sourceBytes === undefined
+            || sourceBytes < COLD_START_WINDOW_MIN_SOURCE_BYTES) {
+            return null;
+        }
+        // No content signature, no windowing: the revision's content epoch
+        // and every commit rule below depend on it.
+        const signature = this.contentSignature(sessionId);
+        if (signature === undefined) {
+            return null;
+        }
+
+        // Summary walk, newest first. Every page boundary cursor is
+        // recorded so any walk page can later be re-fetched in full view.
+        const pages: {
+            turns: Record<string, any>[];
+            nextCursor?: string;
+            startCursor?: string;
+        }[] = [];
+        let cursor: string | undefined;
+        const walkStartedAt = this.now();
+        let slowPages = 0;
+        for (;;) {
+            if (pages.length >= COLD_START_MAX_WALK_PAGES
+                || this.now() - walkStartedAt >= COLD_START_MAX_WALK_MS) {
+                // Runaway safety valve (resource bound, not a heuristic):
+                // a paginated backend serves flat fast pages, so this can
+                // only trip on server-side pathology.
+                throw new ConversationError('tooLarge');
+            }
+            const pageStartedAt = this.now();
+            let page: unknown;
+            try {
+                page = await client.request('thread/turns/list', {
+                    threadId: sessionId,
+                    cursor,
+                    limit: COLD_START_SUMMARY_PAGE_TURNS,
+                    sortDirection: 'desc',
+                    itemsView: 'summary',
+                }, signal);
+            } catch (error) {
+                if (error instanceof ConversationAbortError
+                    || error?.name === 'AbortError') {
+                    throw error;
+                }
+                if (this.disposed) {
+                    throw new ConversationError(
+                        'unavailable',
+                        'reconnectingCodex'
+                    );
+                }
+                if (error instanceof ConversationError
+                    && (error.code === 'unavailable'
+                        || error.code === 'timeout')) {
+                    return null;
+                }
+                this.paginatedReadsDisabled = true;
+                return null;
+            }
+            const pageMs = this.now() - pageStartedAt;
+            let parsed: ReturnType<typeof parseTurnsListPage>;
+            try {
+                parsed = parseTurnsListPage(page);
+            } catch (_error) {
+                this.paginatedReadsDisabled = true;
+                return null;
+            }
+            pages.push({
+                turns: parsed.turns,
+                nextCursor: parsed.nextCursor,
+                startCursor: cursor,
+            });
+            if (pageMs >= COLD_START_SLOW_PAGE_MS) {
+                slowPages += 1;
+            }
+            if (!force && pages.length === 2 && slowPages === 2) {
+                return { legacy: true };
+            }
+            if (!parsed.nextCursor) {
+                break;
+            }
+            if (parsed.turns.length === 0) {
+                // Empty page with a live cursor: outside the verified
+                // pagination semantics — settle on the stable full read.
+                this.paginatedReadsDisabled = true;
+                return null;
+            }
+            cursor = parsed.nextCursor;
+        }
+
+        // Skeleton chunks in chronological order. Summary item ids join
+        // the thread-wide duplicate-item invariant from the start.
+        const chunks: LoadedConversationTurn[] = [];
+        const itemIds = new Set<string>();
+        const turnIds = new Set<string>();
+        try {
+            for (let pageIndex = pages.length - 1; pageIndex >= 0; pageIndex -= 1) {
+                const pageTurns = pages[pageIndex].turns;
+                for (let index = pageTurns.length - 1; index >= 0; index -= 1) {
+                    const turn = pageTurns[index];
+                    if (turnIds.has(turn.id)) {
+                        throw protocolError();
+                    }
+                    turnIds.add(turn.id);
+                    const skeleton = skeletonTurnInteractions(turn);
+                    for (const itemId of skeleton.itemIds) {
+                        if (itemIds.has(itemId)) {
+                            throw protocolError();
+                        }
+                        itemIds.add(itemId);
+                    }
+                    chunks.push({
+                        turnId: turn.id,
+                        kind: 'skeleton',
+                        interactions: skeleton.interactions,
+                        itemIds: skeleton.itemIds,
+                        fingerprint: '',
+                        summaryFingerprint: turnSummaryFingerprint(turn),
+                        characters: conversationCharacters(
+                            skeleton.interactions
+                        ),
+                    });
+                }
+            }
+        } catch (_error) {
+            this.paginatedReadsDisabled = true;
+            return null;
+        }
+
+        // Eagerly materialize the tail window (~one retained viewer page
+        // set) so the initial snapshot needs no second round trip.
+        if (!await this.materializeTailWindow(sessionId, chunks, itemIds, signal)) {
+            return null;
+        }
+        const structureGen = 0;
+        const sourceRevision = composeWindowedRevision(
+            signature,
+            chunks,
+            structureGen
+        );
+        const interactions = chunks.reduce<ConversationInteraction[]>(
+            (all, chunk) => all.concat(chunk.interactions),
+            []
+        );
+        return {
+            value: { interactions, sourceRevision },
+            turns: chunks,
+            characters: chunks.reduce((sum, chunk) => sum + chunk.characters, 0),
+            structureGen,
+            walkPages: pages.map(page => ({
+                startCursor: page.startCursor,
+                turnCount: page.turns.length,
+            })),
+            walkNewerTurns: 0,
+            contentEpochSignature: signature,
+        };
+    }
+
+    // One thread/turns/list page with the failure taxonomy shared by every
+    // paginated call: abort/disposal propagate, transient transport
+    // failures return null for a one-off fallback, and method-level
+    // rejections or malformed pages retire the accelerator.
+    private async requestTurnsPage(
+        params: Record<string, unknown>,
+        signal: ConversationAbortSignal | undefined
+    ): Promise<{ turns: Record<string, any>[]; nextCursor?: string } | null> {
+        let page: unknown;
+        try {
+            page = await this.options.client.request(
+                'thread/turns/list',
+                params,
+                signal
+            );
+        } catch (error) {
+            if (error instanceof ConversationAbortError
+                || error?.name === 'AbortError') {
+                throw error;
+            }
+            if (this.disposed) {
+                throw new ConversationError('unavailable', 'reconnectingCodex');
+            }
+            if (error instanceof ConversationError
+                && (error.code === 'unavailable'
+                    || error.code === 'timeout')) {
+                return null;
+            }
+            this.paginatedReadsDisabled = true;
+            return null;
+        }
+        try {
+            return parseTurnsListPage(page);
+        } catch (_error) {
+            this.paginatedReadsDisabled = true;
+            return null;
+        }
+    }
+
+    // Normalizes one full-view turn over the skeleton chunk of the same
+    // turn id and commits it as a full chunk. The thread-wide item-id
+    // invariant is preserved: the turn's items are checked against every
+    // other chunk's ids (the replaced skeleton's own two summary ids are
+    // an expected subset of the full turn and are exempted). Returns
+    // 'skipped' for turns the walk never saw or already-full chunks, and
+    // 'expanded' when the full turn's interaction-id set differs from the
+    // skeleton's prediction (a multi-user-message turn).
+    private commitFullTurn(
+        chunks: LoadedConversationTurn[],
+        chunkIndexByTurnId: Map<string, number>,
+        itemIds: Set<string>,
+        turn: Record<string, any>
+    ): 'committed' | 'skipped' | 'expanded' {
+        const index = chunkIndexByTurnId.get(turn.id);
+        if (index === undefined) {
+            return 'skipped';
+        }
+        const existing = chunks[index];
+        if (existing.kind === 'full') {
+            return 'skipped';
+        }
+        const ownIds = new Set(existing.itemIds);
+        const context: NormalizeTurnContext = {
+            interactions: [],
+            itemIds: new Set(
+                [...itemIds].filter(itemId => !ownIds.has(itemId))
+            ),
+            newItemIds: [],
+            seededDispatchTimingComplete: true,
+        };
+        normalizeTurnItems(turn, context);
+        for (const itemId of context.newItemIds) {
+            itemIds.add(itemId);
+        }
+        chunks[index] = {
+            turnId: turn.id,
+            kind: 'full',
+            interactions: context.interactions,
+            itemIds: context.newItemIds,
+            fingerprint: fingerprintInteractions(context.interactions),
+            // A mismatch with the skeleton's fingerprint means the source
+            // moved mid-load; taking the fresh one is safe because the
+            // stat signature check reconciles the entry on the next load.
+            summaryFingerprint: turnSummaryFingerprint(turn),
+            characters: conversationCharacters(context.interactions),
+        };
+        const predicted = existing.interactions.map(interaction => interaction.id);
+        const actual = context.interactions.map(interaction => interaction.id);
+        const expanded = predicted.length !== actual.length
+            || actual.some((id, position) => predicted[position] !== id);
+        return expanded ? 'expanded' : 'committed';
+    }
+
+    // Fetches full turns descending from the tail and commits them until
+    // the turn/byte budget is exhausted. Returns false on transient
+    // failure so the caller falls back to the stable full read.
+    private async materializeTailWindow(
+        sessionId: string,
+        chunks: LoadedConversationTurn[],
+        itemIds: Set<string>,
+        signal: ConversationAbortSignal | undefined
+    ): Promise<boolean> {
+        const chunkIndexByTurnId = new Map(
+            chunks.map((chunk, index) => [chunk.turnId, index] as const)
+        );
+        let cursor: string | undefined;
+        let fetchedTurns = 0;
+        let fetchedBytes = 0;
+        for (;;) {
+            const parsed = await this.requestTurnsPage({
+                threadId: sessionId,
+                cursor,
+                limit: COLD_START_MATERIALIZE_PAGE_TURNS,
+                sortDirection: 'desc',
+                itemsView: 'full',
+            }, signal);
+            if (!parsed) {
+                return false;
+            }
+            if (parsed.turns.length === 0) {
+                return true;
+            }
+            try {
+                for (const turn of parsed.turns) {
+                    fetchedBytes += JSON.stringify(turn).length;
+                    fetchedTurns += 1;
+                    this.commitFullTurn(
+                        chunks,
+                        chunkIndexByTurnId,
+                        itemIds,
+                        turn
+                    );
+                }
+            } catch (_error) {
+                this.paginatedReadsDisabled = true;
+                return false;
+            }
+            if (!parsed.nextCursor
+                || fetchedTurns >= COLD_START_TAIL_TURNS
+                || fetchedBytes >= COLD_START_TAIL_BYTES) {
+                return true;
+            }
+            cursor = parsed.nextCursor;
+        }
+    }
+
+    // Serialized on-demand materialization for readPage/readSnapshot.
+    // Requests for one session queue up; a request re-checks coverage
+    // when it acquires the queue (earlier requests may have covered its
+    // range), and each fetched page commits only while the entry still
+    // matches its load-time stat signature and cache slot — a session-
+    // scoped validity rule that needs no global generation.
+    private enqueueMaterialization(
+        sessionId: string,
+        entry: CachedLoadedConversation
+            & { turns: LoadedConversationTurn[] },
+        range: { fromChunk: number; toChunk: number },
+        signal: ConversationAbortSignal | undefined
+    ): Promise<void> {
+        const previous = this.materializationQueues.get(sessionId)
+            ?? Promise.resolve();
+        const next = previous.catch(() => undefined).then(() =>
+            this.runMaterialization(sessionId, entry, range, signal));
+        this.materializationQueues.set(sessionId, next);
+        const cleanup = () => {
+            if (this.materializationQueues.get(sessionId) === next) {
+                this.materializationQueues.delete(sessionId);
+            }
+        };
+        next.then(cleanup, cleanup);
+        return next;
+    }
+
+    private async runMaterialization(
+        sessionId: string,
+        entry: CachedLoadedConversation
+            & { turns: LoadedConversationTurn[] },
+        range: { fromChunk: number; toChunk: number },
+        signal: ConversationAbortSignal | undefined
+    ): Promise<void> {
+        if (this.disposed) {
+            throw new ConversationError('unavailable', 'reconnectingCodex');
+        }
+        if (signal?.aborted) {
+            throw new ConversationAbortError();
+        }
+        const chunks = entry.turns;
+        const walkPages = entry.walkPages ?? [];
+        if (!walkPages.length) {
+            return;
+        }
+        const from = Math.max(0, range.fromChunk);
+        const to = Math.min(chunks.length - 1, range.toChunk);
+        const targets: number[] = [];
+        for (let index = from; index <= to; index += 1) {
+            if (chunks[index].kind === 'skeleton') {
+                targets.push(index);
+            }
+        }
+        if (!targets.length) {
+            return;
+        }
+        const chunkIndexByTurnId = new Map(
+            chunks.map((chunk, index) => [chunk.turnId, index] as const)
+        );
+        // Maps a chunk index to its summary walk page (page 0 = newest).
+        // Turns appended after the walk shift the newest-first index, so
+        // rebase by their count; they are full chunks themselves and can
+        // never be skeleton targets.
+        const walkNewerTurns = entry.walkNewerTurns ?? 0;
+        const pageOfChunk = (chunkIndex: number): number => {
+            let descIndex = chunks.length - 1 - chunkIndex - walkNewerTurns;
+            let page = 0;
+            while (page < walkPages.length - 1
+                && descIndex >= walkPages[page].turnCount) {
+                descIndex -= walkPages[page].turnCount;
+                page += 1;
+            }
+            return page;
+        };
+        // Group target chunks by their walk page.
+        const targetsByPage = new Map<number, number[]>();
+        for (const chunkIndex of targets) {
+            const page = pageOfChunk(chunkIndex);
+            const list = targetsByPage.get(page) ?? [];
+            list.push(chunkIndex);
+            targetsByPage.set(page, list);
+        }
+        const itemIds = new Set<string>();
+        for (const chunk of chunks) {
+            for (const itemId of chunk.itemIds) {
+                itemIds.add(itemId);
+            }
+        }
+        for (const [page, pageTargets] of targetsByPage) {
+            let covered = new Set(
+                pageTargets.filter(index => chunks[index].kind === 'full')
+            );
+            let cursor = walkPages[page].startCursor;
+            while (covered.size < pageTargets.length) {
+                if (signal?.aborted) {
+                    throw new ConversationAbortError();
+                }
+                // Commit rule, checked per page: the adapter must be
+                // alive, and the entry must still sit in its cache slot
+                // under its load-time signature.
+                if (this.disposed) {
+                    throw new ConversationError(
+                        'unavailable',
+                        'reconnectingCodex'
+                    );
+                }
+                if (this.loadedConversationCache.get(sessionId) !== entry
+                    || this.contentSignature(sessionId)
+                        !== entry.contentSignature) {
+                    throw new ConversationError('staleRevision');
+                }
+                const parsed = await this.requestTurnsPage({
+                    threadId: sessionId,
+                    cursor,
+                    limit: COLD_START_MATERIALIZE_PAGE_TURNS,
+                    sortDirection: 'desc',
+                    itemsView: 'full',
+                }, signal);
+                if (!parsed) {
+                    throw new ConversationError('unavailable', 'missingSource');
+                }
+                if (parsed.turns.length === 0) {
+                    throw new ConversationError('staleRevision');
+                }
+                let expanded = false;
+                try {
+                    for (const turn of parsed.turns) {
+                        if (this.commitFullTurn(
+                            chunks,
+                            chunkIndexByTurnId,
+                            itemIds,
+                            turn
+                        ) === 'expanded') {
+                            expanded = true;
+                        }
+                    }
+                } catch (_error) {
+                    this.paginatedReadsDisabled = true;
+                    throw protocolError();
+                }
+                covered = new Set(
+                    pageTargets.filter(index => chunks[index].kind === 'full')
+                );
+                this.commitMaterializedEntry(entry, expanded);
+                if (!parsed.nextCursor) {
+                    break;
+                }
+                cursor = parsed.nextCursor;
+            }
+        }
+    }
+
+    // Rebuilds a windowed entry's flat interaction array and revision
+    // after one materialization page, and keeps the character accounting
+    // in sync with the chunk replacements.
+    private commitMaterializedEntry(
+        entry: CachedLoadedConversation
+            & { turns: LoadedConversationTurn[] },
+        expanded: boolean
+    ): void {
+        const characters = entry.turns.reduce(
+            (sum, chunk) => sum + chunk.characters,
+            0
+        );
+        this.loadedConversationCacheChars += characters - entry.characters;
+        entry.characters = characters;
+        if (expanded) {
+            entry.structureGen = (entry.structureGen ?? 0) + 1;
+        }
+        const sourceRevision = composeWindowedRevision(
+            entry.contentEpochSignature ?? entry.contentSignature,
+            entry.turns,
+            entry.structureGen ?? 0
+        );
+        entry.value = {
+            interactions: entry.turns.reduce<ConversationInteraction[]>(
+                (all, chunk) => all.concat(chunk.interactions),
+                []
+            ),
+            sourceRevision,
+        };
     }
 
     private storeLoadedConversationCacheEntry(
@@ -1601,7 +2718,11 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
         const turns: LoadedConversationTurn[] = normalized.turns.map(chunk => ({
             ...chunk,
             fingerprint: fingerprintInteractions(chunk.interactions),
+            // Full-read entries compose the revision from full
+            // fingerprints only; the summary projection is not tracked.
+            summaryFingerprint: '',
             characters: conversationCharacters(chunk.interactions),
+            kind: 'full' as const,
         }));
         // App Server instances do not share live turn state. When another
         // extension owns the running turn, thread/read can persist it as

--- a/src/aiSessions/conversation/codexAdapter.ts
+++ b/src/aiSessions/conversation/codexAdapter.ts
@@ -171,6 +171,12 @@ const COLD_START_MAX_WALK_MS = 120_000;
 const COLD_START_TAIL_TURNS = 40;
 const COLD_START_TAIL_BYTES = 1536 * 1024;
 const COLD_START_MATERIALIZE_PAGE_TURNS = 8;
+// Per-entry budget for materialized (full-chunk) characters, on the
+// order of the viewer's retained window: scrolling history materializes
+// chunks, and least-recently-used full chunks fall back to skeletons
+// beyond this budget so a long browsing session cannot re-inflate the
+// entry toward the whole conversation.
+const WINDOWED_ENTRY_MATERIALIZED_CHARS = 4 * 1024 * 1024;
 
 interface LoadedConversation {
     interactions: ConversationInteraction[];
@@ -228,11 +234,18 @@ interface LoadedConversationTurn {
     // leave this empty — they join reuse decisions via summaryFingerprint.
     fingerprint: string;
     // Hash of the turn's summary-level projection (turn fields + first
-    // user message + final agent message), derived identically from a
-    // summary page or a full turn. Stable across materialization.
+    // user message), derived identically from a summary page or a full
+    // turn. Stable across materialization.
     summaryFingerprint: string;
+    // The skeleton's summary item ids, kept on full chunks so a chunk
+    // can be demoted back to a skeleton (freshness invalidation or the
+    // materialized-window LRU) without another fetch.
+    skeletonItemIds: string[];
     characters: number;
     kind: 'full' | 'skeleton';
+    // Full chunks only: last time the chunk was materialized or covered
+    // by a served page; drives the materialized-window LRU.
+    lastTouchedAt?: number;
 }
 
 interface CachedLoadedConversation {
@@ -721,6 +734,46 @@ function turnSummaryFingerprint(turn: Record<string, any>): string {
 // structure generation (interaction-id set changes). Materializing a
 // skeleton without an id-set change alters none of the inputs, so
 // retained-page cursors survive scrolling-driven materialization.
+// Rebuilds a full chunk's interactions into skeleton form (the
+// outline-level projection of its FIRST interaction) and demotes it.
+// Demotion is how materialized content re-enters the
+// "fetched live before it is shown" state: the summary fingerprint and
+// skeleton item ids are inherited, so the projection revision only moves
+// when the demotion shrinks the interaction-id set (an expanded
+// multi-user-message turn), which the caller reports through the
+// structure generation.
+function demoteToSkeleton(
+    chunk: LoadedConversationTurn
+): LoadedConversationTurn {
+    const first = chunk.interactions[0];
+    const interactions: ConversationInteraction[] = first
+        ? [{
+            id: first.id,
+            ...(first.providerTurnId !== undefined
+                ? { providerTurnId: first.providerTurnId } : {}),
+            ...(first.timestamp !== undefined
+                ? { timestamp: first.timestamp } : {}),
+            ...(first.completedAt !== undefined
+                ? { completedAt: first.completedAt } : {}),
+            userMarkdown: first.userMarkdown,
+            userPreview: first.userPreview,
+            userGraphemeCount: first.userGraphemeCount,
+            assistantMarkdown: [],
+            responseState: first.responseState,
+        }]
+        : [];
+    return {
+        turnId: chunk.turnId,
+        kind: 'skeleton',
+        interactions,
+        itemIds: [...chunk.skeletonItemIds],
+        fingerprint: '',
+        summaryFingerprint: chunk.summaryFingerprint,
+        skeletonItemIds: [...chunk.skeletonItemIds],
+        characters: conversationCharacters(interactions),
+    };
+}
+
 function composeWindowedRevision(
     contentEpochSignature: string,
     turns: readonly LoadedConversationTurn[],
@@ -1265,6 +1318,16 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
             { fromChunk, toChunk },
             signal
         );
+        // Serving a window keeps its full chunks alive for the LRU.
+        const touchedAt = this.now();
+        for (let index = Math.max(0, fromChunk);
+            index <= Math.min(entry.turns.length - 1, toChunk);
+            index += 1) {
+            const chunk = entry.turns[index];
+            if (chunk.kind === 'full') {
+                chunk.lastTouchedAt = touchedAt;
+            }
+        }
         return this.withRunningLifecycle(sessionId, entry.value);
     }
 
@@ -1921,7 +1984,30 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
         if (anchorIndex < 0 && isWindowed) {
             return { rebuild: true };
         }
-        const kept = anchorIndex >= 0 ? cached.turns.slice(0, -1) : [];
+        // Windowed freshness closure: a moved stat means any materialized
+        // chunk the anchor walk does not re-verify can hold stale content
+        // (in-place history edits exist: updated_at_ordinal). Demote kept
+        // full chunks back to skeletons — they re-materialize live before
+        // they are shown again. The anchor chunk itself is re-fetched
+        // below, so it is never demoted here. Full-basis entries keep
+        // their exact previous behavior.
+        let demotedMaterialized = false;
+        let demotionShrunkIdSets = false;
+        let kept = anchorIndex >= 0 ? cached.turns.slice(0, -1) : [];
+        if (isWindowed && anchorIndex >= 0) {
+            kept = kept.map(chunk => {
+                if (chunk.kind !== 'full') {
+                    return chunk;
+                }
+                demotedMaterialized = true;
+                const demotedChunk = demoteToSkeleton(chunk);
+                if (demotedChunk.interactions.length
+                    !== chunk.interactions.length) {
+                    demotionShrunkIdSets = true;
+                }
+                return demotedChunk;
+            });
+        }
         const reloaded = (anchorIndex >= 0
             ? fetched.slice(0, anchorIndex + 1)
             : fetched
@@ -1933,7 +2019,11 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
         if (isWindowed) {
             // Projection revision: unchanged when neither the outline-level
             // turn structure nor any materialized chunk's content moved.
-            let unchanged = turns.length === cached.turns.length;
+            // Any demotion counts as a change: demoted content was not
+            // re-verified, so the revision must move and let the viewer
+            // re-read visible pages (they re-materialize fresh).
+            let unchanged = !demotedMaterialized
+                && turns.length === cached.turns.length;
             for (let index = 0; unchanged && index < turns.length; index += 1) {
                 const next = turns[index];
                 const prev = cached.turns[index];
@@ -1954,7 +2044,8 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
                     contentEpochSignature: cached.contentEpochSignature,
                 };
             }
-            const structureGen = cached.structureGen ?? 0;
+            const structureGen = (cached.structureGen ?? 0)
+                + (demotionShrunkIdSets ? 1 : 0);
             const epochSignature = signature
                 ?? cached.contentEpochSignature
                 ?? '';
@@ -2044,8 +2135,10 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
                     itemIds: context.newItemIds,
                     fingerprint: fingerprintInteractions(context.interactions),
                     summaryFingerprint: turnSummaryFingerprint(turn),
+                    skeletonItemIds: skeletonTurnInteractions(turn).itemIds,
                     characters: conversationCharacters(context.interactions),
                     kind: 'full' as const,
+                    lastTouchedAt: this.now(),
                 });
             }
         } catch (_error) {
@@ -2074,6 +2167,27 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
         signal: ConversationAbortSignal | undefined,
         force: boolean
     ): Promise<WindowedLoadResult> {
+        // One retry against a source that moved mid-load: the closure
+        // checks in the attempt reject mixed-epoch entries, and the
+        // retry simply re-walks under a fresh signature.
+        for (let attempt = 0; attempt < 2; attempt += 1) {
+            const result = await this.loadWindowedAttempt(
+                sessionId,
+                signal,
+                force
+            );
+            if (result !== 'stale') {
+                return result;
+            }
+        }
+        return null;
+    }
+
+    private async loadWindowedAttempt(
+        sessionId: string,
+        signal: ConversationAbortSignal | undefined,
+        force: boolean
+    ): Promise<WindowedLoadResult | 'stale'> {
         if (this.disposed) {
             throw new ConversationError('unavailable', 'reconnectingCodex');
         }
@@ -2126,7 +2240,7 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
         }[] = [];
         let cursor: string | undefined;
         const walkStartedAt = this.now();
-        let slowPages = 0;
+        const recentPageMs: number[] = [];
         for (;;) {
             if (pages.length >= COLD_START_MAX_WALK_PAGES
                 || this.now() - walkStartedAt >= COLD_START_MAX_WALK_MS) {
@@ -2177,11 +2291,18 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
                 nextCursor: parsed.nextCursor,
                 startCursor: cursor,
             });
-            if (pageMs >= COLD_START_SLOW_PAGE_MS) {
-                slowPages += 1;
-            }
-            if (!force && pages.length === 2 && slowPages === 2) {
-                return { legacy: true };
+            recentPageMs.push(pageMs);
+            // Legacy verdict: the median of the recent pages (up to 3,
+            // at least 2 — a two-page window takes the SMALLER, i.e.
+            // both pages must be slow) costs a full replay each. A fast
+            // first page followed by sustained replay pricing verdicts
+            // on page three; a single jittery page never does.
+            if (!force && recentPageMs.length >= 2) {
+                const windowMs = recentPageMs.slice(-3).sort((a, b) => a - b);
+                if (windowMs[Math.floor((windowMs.length - 1) / 2)]
+                    >= COLD_START_SLOW_PAGE_MS) {
+                    return { legacy: true };
+                }
             }
             if (!parsed.nextCursor) {
                 break;
@@ -2193,6 +2314,11 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
                 return null;
             }
             cursor = parsed.nextCursor;
+        }
+        // Walk closure: the stat signature must still be the one the walk
+        // started under, or the skeleton set mixes epochs.
+        if (this.contentSignature(sessionId) !== signature) {
+            return 'stale';
         }
 
         // Skeleton chunks in chronological order. Summary item ids join
@@ -2223,6 +2349,7 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
                         itemIds: skeleton.itemIds,
                         fingerprint: '',
                         summaryFingerprint: turnSummaryFingerprint(turn),
+                        skeletonItemIds: [...skeleton.itemIds],
                         characters: conversationCharacters(
                             skeleton.interactions
                         ),
@@ -2235,9 +2362,23 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
         }
 
         // Eagerly materialize the tail window (~one retained viewer page
-        // set) so the initial snapshot needs no second round trip.
-        if (!await this.materializeTailWindow(sessionId, chunks, itemIds, signal)) {
+        // set) so the initial snapshot needs no second round trip. Every
+        // landed page is checked against the walk's signature.
+        const tail = await this.materializeTailWindow(
+            sessionId,
+            chunks,
+            itemIds,
+            signal,
+            signature
+        );
+        if (tail === 'stale') {
+            return 'stale';
+        }
+        if (!tail) {
             return null;
+        }
+        if (this.contentSignature(sessionId) !== signature) {
+            return 'stale';
         }
         const structureGen = 0;
         const sourceRevision = composeWindowedRevision(
@@ -2325,6 +2466,24 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
             return 'skipped';
         }
         const ownIds = new Set(existing.itemIds);
+        // A response-spanning item can be projected into different turns
+        // by fetches taken at different times (observed on a live 183MB
+        // session: a reasoning item shared between turns 90 and 218).
+        // Colliding with another chunk's ids means the fetched page and
+        // the cached skeleton set come from different projection epochs —
+        // NOT a protocol violation. Report it as staleness so the caller
+        // re-reads a consistent snapshot, never circuit-breaking the
+        // accelerator on a transient.
+        for (const rawItem of turn.items as unknown[]) {
+            const item = asRecord(rawItem);
+            if (item
+                && typeof item.id === 'string'
+                && item.id
+                && itemIds.has(item.id)
+                && !ownIds.has(item.id)) {
+                throw new ConversationError('staleRevision');
+            }
+        }
         const context: NormalizeTurnContext = {
             interactions: [],
             itemIds: new Set(
@@ -2347,7 +2506,9 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
             // moved mid-load; taking the fresh one is safe because the
             // stat signature check reconciles the entry on the next load.
             summaryFingerprint: turnSummaryFingerprint(turn),
+            skeletonItemIds: [...existing.skeletonItemIds],
             characters: conversationCharacters(context.interactions),
+            lastTouchedAt: this.now(),
         };
         const predicted = existing.interactions.map(interaction => interaction.id);
         const actual = context.interactions.map(interaction => interaction.id);
@@ -2358,13 +2519,15 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
 
     // Fetches full turns descending from the tail and commits them until
     // the turn/byte budget is exhausted. Returns false on transient
-    // failure so the caller falls back to the stable full read.
+    // failure (caller falls back) and 'stale' when the source moved
+    // under the walk's signature mid-flight.
     private async materializeTailWindow(
         sessionId: string,
         chunks: LoadedConversationTurn[],
         itemIds: Set<string>,
-        signal: ConversationAbortSignal | undefined
-    ): Promise<boolean> {
+        signal: ConversationAbortSignal | undefined,
+        signature: string
+    ): Promise<boolean | 'stale'> {
         const chunkIndexByTurnId = new Map(
             chunks.map((chunk, index) => [chunk.turnId, index] as const)
         );
@@ -2382,6 +2545,9 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
             if (!parsed) {
                 return false;
             }
+            if (this.contentSignature(sessionId) !== signature) {
+                return 'stale';
+            }
             if (parsed.turns.length === 0) {
                 return true;
             }
@@ -2396,7 +2562,12 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
                         turn
                     );
                 }
-            } catch (_error) {
+            } catch (error) {
+                if (error instanceof ConversationError
+                    && error.code === 'staleRevision') {
+                    // Mixed projection epochs; the wrapper re-walks once.
+                    return 'stale';
+                }
                 this.paginatedReadsDisabled = true;
                 return false;
             }
@@ -2506,9 +2677,12 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
                 if (signal?.aborted) {
                     throw new ConversationAbortError();
                 }
-                // Commit rule, checked per page: the adapter must be
-                // alive, and the entry must still sit in its cache slot
-                // under its load-time signature.
+                // Commit rule, checked per page BEFORE the fetch and
+                // again AFTER the page lands: the adapter must be alive,
+                // and the entry must still sit in its cache slot under
+                // its load-time signature. The source moving mid-flight
+                // must never see its content committed under the old
+                // epoch.
                 if (this.disposed) {
                     throw new ConversationError(
                         'unavailable',
@@ -2530,6 +2704,17 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
                 if (!parsed) {
                     throw new ConversationError('unavailable', 'missingSource');
                 }
+                if (this.disposed) {
+                    throw new ConversationError(
+                        'unavailable',
+                        'reconnectingCodex'
+                    );
+                }
+                if (this.loadedConversationCache.get(sessionId) !== entry
+                    || this.contentSignature(sessionId)
+                        !== entry.contentSignature) {
+                    throw new ConversationError('staleRevision');
+                }
                 if (parsed.turns.length === 0) {
                     throw new ConversationError('staleRevision');
                 }
@@ -2545,14 +2730,27 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
                             expanded = true;
                         }
                     }
-                } catch (_error) {
+                } catch (error) {
+                    if (error instanceof ConversationError
+                        && error.code === 'staleRevision') {
+                        // Mixed projection epochs: drop the entry so the
+                        // next read re-walks a consistent snapshot. The
+                        // accelerator survives.
+                        this.deleteLoadedConversationCacheEntry(
+                            sessionId,
+                            entry
+                        );
+                        throw error;
+                    }
                     this.paginatedReadsDisabled = true;
-                    throw protocolError();
+                    throw error instanceof ConversationError
+                        ? error
+                        : protocolError();
                 }
                 covered = new Set(
                     pageTargets.filter(index => chunks[index].kind === 'full')
                 );
-                this.commitMaterializedEntry(entry, expanded);
+                this.commitMaterializedEntry(entry, expanded, from, to);
                 if (!parsed.nextCursor) {
                     break;
                 }
@@ -2562,14 +2760,20 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
     }
 
     // Rebuilds a windowed entry's flat interaction array and revision
-    // after one materialization page, and keeps the character accounting
-    // in sync with the chunk replacements.
+    // after one materialization page, keeps the character accounting in
+    // sync, and enforces the per-entry materialized-window budget: the
+    // least-recently-touched full chunks outside the protected ranges
+    // (the served range and the tail window zone) demote back to
+    // skeletons, so long browsing cannot re-inflate the entry toward the
+    // whole conversation.
     private commitMaterializedEntry(
         entry: CachedLoadedConversation
             & { turns: LoadedConversationTurn[] },
-        expanded: boolean
+        expanded: boolean,
+        protectFrom: number,
+        protectTo: number
     ): void {
-        const characters = entry.turns.reduce(
+        let characters = entry.turns.reduce(
             (sum, chunk) => sum + chunk.characters,
             0
         );
@@ -2577,6 +2781,44 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
         entry.characters = characters;
         if (expanded) {
             entry.structureGen = (entry.structureGen ?? 0) + 1;
+        }
+        if (characters > WINDOWED_ENTRY_MATERIALIZED_CHARS) {
+            const tailFrom = Math.max(
+                0,
+                entry.turns.length - COLD_START_TAIL_TURNS
+            );
+            const candidates: number[] = [];
+            for (let index = 0; index < entry.turns.length; index += 1) {
+                if (index >= tailFrom
+                    || (index >= protectFrom && index <= protectTo)) {
+                    continue;
+                }
+                if (entry.turns[index].kind === 'full') {
+                    candidates.push(index);
+                }
+            }
+            candidates.sort((left, right) =>
+                (entry.turns[left].lastTouchedAt ?? 0)
+                - (entry.turns[right].lastTouchedAt ?? 0));
+            let shrunkIdSets = false;
+            for (const index of candidates) {
+                if (entry.characters <= WINDOWED_ENTRY_MATERIALIZED_CHARS) {
+                    break;
+                }
+                const before = entry.turns[index];
+                const demoted = demoteToSkeleton(before);
+                if (demoted.interactions.length
+                    !== before.interactions.length) {
+                    shrunkIdSets = true;
+                }
+                entry.turns[index] = demoted;
+                entry.characters -= before.characters - demoted.characters;
+                this.loadedConversationCacheChars -= before.characters
+                    - demoted.characters;
+            }
+            if (shrunkIdSets) {
+                entry.structureGen = (entry.structureGen ?? 0) + 1;
+            }
         }
         const sourceRevision = composeWindowedRevision(
             entry.contentEpochSignature ?? entry.contentSignature,
@@ -2719,8 +2961,10 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
             ...chunk,
             fingerprint: fingerprintInteractions(chunk.interactions),
             // Full-read entries compose the revision from full
-            // fingerprints only; the summary projection is not tracked.
+            // fingerprints only; the summary projection is not tracked
+            // and full-basis chunks are never demoted.
             summaryFingerprint: '',
+            skeletonItemIds: [],
             characters: conversationCharacters(chunk.interactions),
             kind: 'full' as const,
         }));

--- a/src/aiSessions/conversation/codexAppServerClient.ts
+++ b/src/aiSessions/conversation/codexAppServerClient.ts
@@ -206,6 +206,29 @@ export class CodexAppServerClient implements AiSessionDisposable {
         return this.serverVersion;
     }
 
+    /**
+     * Resolves once the initialize handshake has completed and returns the
+     * sanitized server version (undefined when the server reports none).
+     * Shares the same in-flight handshake as request(): concurrent callers
+     * attach to one connection attempt, and a caller's abort cancels only
+     * its own wait, never the shared handshake.
+     */
+    async ensureReady(
+        signal?: ConversationAbortSignal
+    ): Promise<string | undefined> {
+        if (this.disposed) {
+            throw new ConversationError('unavailable', 'reconnectingCodex');
+        }
+        if (signal?.aborted) {
+            throw new ConversationAbortError();
+        }
+        await this.waitForConnection(this.ensureConnection(), signal);
+        if (signal?.aborted) {
+            throw new ConversationAbortError();
+        }
+        return this.serverVersion;
+    }
+
     private initializeParams(): Record<string, unknown> {
         if (!this.options.experimentalApi) {
             return { clientInfo: INITIALIZE_CLIENT_INFO };

--- a/src/aiSessions/conversation/composition.ts
+++ b/src/aiSessions/conversation/composition.ts
@@ -57,6 +57,7 @@ import { ConversationWorktreeResolver } from './worktreeResolver';
 import { readCodexRolloutTelemetry } from '../codexRolloutWorkdir';
 import {
     readCodexRolloutContentSignature,
+    readCodexRolloutSourceBytes,
 } from '../codexRolloutContentSignature';
 import { encodeSubagentSessionId } from './subagentSessions';
 
@@ -238,6 +239,13 @@ function createAvailableConversationCapability(
                 .resolveSessionFilePath?.(sessionId);
             return rolloutPath
                 ? readCodexRolloutContentSignature(rolloutPath)
+                : undefined;
+        },
+        readSourceBytes: sessionId => {
+            const rolloutPath = options.services.codex
+                .resolveSessionFilePath?.(sessionId);
+            return rolloutPath
+                ? readCodexRolloutSourceBytes(rolloutPath)
                 : undefined;
         },
         readLifecycleSignal: sessionId =>

--- a/tests/contract/aiSessions/codexAppServerClient.test.js
+++ b/tests/contract/aiSessions/codexAppServerClient.test.js
@@ -325,6 +325,89 @@ test('SESSION-AI-SESSION-CODEX-APP-SERVER-001 declares the experimentalApi capab
     assert.deepEqual(await unversionedRequest, { ok: true });
 });
 
+test('SESSION-AI-SESSION-CODEX-APP-SERVER-001 ensureReady shares one handshake and reports the version', async t => {
+    const harness = createHarness({ experimentalApi: true });
+    t.after(() => harness.client.dispose());
+
+    // Concurrent waiters attach to the same handshake; no application
+    // request is sent before it completes.
+    const first = harness.client.ensureReady();
+    const second = harness.client.ensureReady();
+    await settle();
+    assert.deepEqual(
+        parsedWrites(harness.child).map(message => message.method),
+        ['initialize']
+    );
+    emitResponse(harness.child, {
+        id: 1,
+        result: {
+            userAgent: 'project_steward/0.147.0 (Ubuntu 22.4.0; x86_64) '
+                + 'xterm.js_6.1.0-beta.291_ (project_steward; 2.1.6)',
+        },
+    });
+    await settle();
+    assert.equal(await first, '0.147');
+    assert.equal(await second, '0.147');
+    assert.deepEqual(
+        parsedWrites(harness.child).map(message => message.method),
+        ['initialize', 'initialized']
+    );
+    // A later ensureReady resolves from the completed handshake.
+    assert.equal(await harness.client.ensureReady(), '0.147');
+    assert.equal(
+        parsedWrites(harness.child)
+            .filter(message => message.method === 'initialize').length,
+        1
+    );
+});
+
+test('SESSION-AI-SESSION-CODEX-APP-SERVER-006 aborting one ensureReady waiter keeps the shared handshake for others', async t => {
+    const harness = createHarness();
+    t.after(() => harness.client.dispose());
+    const controller = new ConversationAbortController();
+    const aborted = harness.client.ensureReady(controller.signal);
+    const surviving = harness.client.ensureReady();
+    await settle();
+    controller.abort();
+    await assert.rejects(aborted, error => error.name === 'AbortError');
+    // The abort cancels only that wait: the shared handshake completes and
+    // the surviving waiter still receives the version.
+    emitResponse(harness.child, {
+        id: 1,
+        result: {
+            serverInfo: { name: 'codex-app-server', version: '0.147.0' },
+        },
+    });
+    await settle();
+    assert.equal(await surviving, '0.147');
+    const request = harness.client.request('thread/read', {
+        threadId: SESSION_ID,
+    });
+    await settle();
+    emitResponse(harness.child, { id: 2, result: { ok: true } });
+    assert.deepEqual(await request, { ok: true });
+});
+
+test('SESSION-AI-SESSION-CODEX-APP-SERVER-006 ensureReady rejects abort and disposal before the handshake', async t => {
+    const aborted = createHarness();
+    t.after(() => aborted.client.dispose());
+    const controller = new ConversationAbortController();
+    controller.abort();
+    await assert.rejects(
+        aborted.client.ensureReady(controller.signal),
+        error => error.name === 'AbortError'
+    );
+    assert.equal(aborted.child.stdin.writes.length, 0);
+
+    const disposed = createHarness();
+    disposed.client.dispose();
+    await assert.rejects(
+        disposed.client.ensureReady(),
+        error => error.name === 'ConversationError'
+            && error.code === 'unavailable'
+    );
+});
+
 test('CONVERSATION-TELEMETRY-001 publishes structured App Server notifications without affecting requests', async t => {
     const harness = createHarness();
     t.after(() => harness.client.dispose());

--- a/tests/contract/aiSessions/codexConversationAdapter.test.js
+++ b/tests/contract/aiSessions/codexConversationAdapter.test.js
@@ -2963,12 +2963,14 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 moves the revision when a live 
         'the new tool item must render');
 });
 
-test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 materializes in-place skeleton updates fresh without a revision move', async t => {
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 materializes in-place skeleton updates fresh after invalidation', async t => {
     const harness = createWindowedHarness(t);
     const first = await harness.adapter.readOutline(sessionId);
 
     // An in-place update to an unmaterized turn's tool content: invisible
-    // to the summary projection; the stat still moves.
+    // to the summary projection; the stat still moves. The moved stat
+    // also demotes the materialized tail (unverified content), so the
+    // revision moves even though the outline projection is unchanged.
     harness.state.turns[40].items.push({
         id: 'turn-40-tool-1',
         type: 'commandExecution',
@@ -2977,8 +2979,13 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 materializes in-place skeleton 
     });
     harness.signatures[sessionId] = 'stat-2';
     const refreshed = await harness.adapter.readOutline(sessionId);
-    assert.equal(refreshed.sourceRevision, first.sourceRevision,
-        'projection unchanged: no revision churn');
+    assert.notEqual(refreshed.sourceRevision, first.sourceRevision,
+        'unverifiable materialized content demotes and moves the revision');
+    assert.deepEqual(
+        stripRevision(refreshed).interactions,
+        stripRevision(first).interactions,
+        'the outline projection itself is unchanged'
+    );
 
     const paged = await harness.adapter.readPage({
         provider: 'codex',
@@ -2990,27 +2997,45 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 materializes in-place skeleton 
     assert.ok(paged.messages.some(message =>
         message.role === 'tool' && message.tool?.detail === 'fresh output'),
         'materialization fetches the current server state');
-    const after = await harness.adapter.readOutline(sessionId);
-    assert.equal(after.sourceRevision, first.sourceRevision);
 });
 
-test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 re-anchors a windowed entry on a stat fake-out without churn', async t => {
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 demotes unverified materialized chunks on a stat move and re-materializes identical content', async t => {
     const harness = createWindowedHarness(t);
     const first = await harness.adapter.readOutline(sessionId);
     const requestsAtOpen = harness.requests.length;
 
+    // Stat fake-out with a materialized tail: the anchor walk cannot
+    // re-verify the kept full chunks, so they demote to skeletons and the
+    // revision moves — the viewer re-reads visible pages, which
+    // re-materialize live and render byte-identical HTML.
     harness.signatures[sessionId] = 'stat-2';
     const reanchored = await harness.adapter.readOutline(sessionId);
-    assert.equal(reanchored.sourceRevision, first.sourceRevision);
-    const anchorWalkCalls = harness.requests.length - requestsAtOpen;
-    assert.ok(anchorWalkCalls > 0 && anchorWalkCalls <= 2,
-        'only the tail anchor walk runs');
+    assert.notEqual(reanchored.sourceRevision, first.sourceRevision);
+    const entry = harness.adapter.loadedConversationCache.get(sessionId);
+    const skeletonCount = entry.turns.filter(
+        chunk => chunk.kind === 'skeleton'
+    ).length;
+    assert.ok(skeletonCount >= 119,
+        'all but the re-verified anchor turn demote back to skeletons');
 
-    // Re-anchored: a same-signature read is a pure cache hit.
-    const before = harness.requests.length;
-    const cached = await harness.adapter.readOutline(sessionId);
-    assert.equal(harness.requests.length, before);
-    assert.equal(cached.sourceRevision, first.sourceRevision);
+    // A second fake-out right away keeps the revision stable: the kept
+    // chunks are all skeletons now, and the anchor walk re-verifies the
+    // single materialized tail turn. Zero-churn is preserved exactly
+    // when nothing unverified remains materialized.
+    harness.signatures[sessionId] = 'stat-3';
+    const settled = await harness.adapter.readOutline(sessionId);
+    assert.equal(settled.sourceRevision, reanchored.sourceRevision);
+
+    const snapshot = await harness.adapter.readSnapshot(sessionId);
+    const expected = await createFullReadProof(t, harness.state)
+        .readSnapshot(sessionId);
+    assert.deepEqual(
+        stripRevision(snapshot.page),
+        stripRevision(expected.page),
+        're-materialized tail content is identical'
+    );
+    assert.ok(harness.requests.length - requestsAtOpen < 24,
+        'the whole cycle stays on cheap paginated calls');
 });
 
 test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 reloads an appended windowed entry incrementally and keeps deep seeks correct', async t => {
@@ -3286,4 +3311,187 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 falls back to the full read whe
     assert.equal(outline.totalInteractions, 120);
     assert.deepEqual(harness.methods(), ['ensureReady', 'thread/read']);
     assert.equal(harness.adapter.paginatedReadsDisabled, false);
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 re-reads edited history after a stat move instead of serving the old materialized content', async t => {
+    const harness = createWindowedHarness(t);
+    await harness.adapter.readOutline(sessionId);
+
+    // Materialize a historical window, then edit one of its turns in
+    // place (tool output revision): the summary projection is unchanged.
+    const before = await harness.adapter.readPage({
+        provider: 'codex',
+        sessionId,
+        anchorInteractionId: 'turn-user-79',
+        direction: 'around',
+        limit: 10,
+    });
+    assert.ok(before.messages.some(message =>
+        message.role === 'assistant'));
+    harness.state.turns[79].items.push({
+        id: 'turn-79-tool-late',
+        type: 'commandExecution',
+        command: 'late edit',
+        aggregatedOutput: 'NEW-79',
+    });
+    harness.signatures[sessionId] = 'stat-2';
+
+    // The refresh demotes every unverified full chunk and moves the
+    // revision; re-reading the window re-materializes the fresh content.
+    const refreshed = await harness.adapter.readOutline(sessionId);
+    const entry = harness.adapter.loadedConversationCache.get(sessionId);
+    assert.equal(entry.turns[79].kind, 'skeleton',
+        'the edited historical chunk demotes back to a skeleton');
+    const after = await harness.adapter.readPage({
+        provider: 'codex',
+        sessionId,
+        anchorInteractionId: 'turn-user-79',
+        direction: 'around',
+        limit: 10,
+    });
+    assert.ok(after.messages.some(message =>
+        message.role === 'tool' && message.tool?.detail === 'NEW-79'),
+        'the re-materialized window shows the edited content');
+    assert.notEqual(after.sourceRevision, before.sourceRevision);
+    void refreshed;
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 rejects a materialization page whose RPC outlived the entry signature', async t => {
+    const harness = createWindowedHarness(t);
+    await harness.adapter.readOutline(sessionId);
+    const entry = harness.adapter.loadedConversationCache.get(sessionId);
+
+    // The source moves while the LAST page of the window is in flight:
+    // the post-RPC check must refuse the commit.
+    let fullSeeks = 0;
+    harness.state.onRequest = (method, params) => {
+        if (method === 'thread/turns/list'
+            && params.itemsView === 'full'
+            && params.cursor !== undefined) {
+            fullSeeks += 1;
+            const isLast = params.cursor === 'turn-22';
+            if (isLast) {
+                harness.signatures[sessionId] = 'stat-2';
+            }
+        }
+    };
+    await assert.rejects(
+        harness.adapter.readPage({
+            provider: 'codex',
+            sessionId,
+            anchorInteractionId: 'turn-user-25',
+            direction: 'before',
+            limit: 20,
+        }),
+        error => error.name === 'ConversationError'
+            && error.code === 'staleRevision'
+    );
+    assert.ok(fullSeeks >= 2, 'the window took multiple pages');
+    assert.equal(entry.turns[20].kind, 'skeleton',
+        'the out-of-epoch page is never committed');
+    assert.equal(entry.turns[10].kind, 'full',
+        'pages committed while the signature was valid stay');
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 verdicts legacy when only the first page is fast', async t => {
+    const harness = createWindowedHarness(t, {
+        pageLatencies: [20, 600, 600, 600, 600],
+    });
+    const outline = await harness.adapter.readOutline(sessionId);
+    assert.deepEqual(harness.methods(), [
+        'ensureReady',
+        'thread/turns/list',
+        'thread/turns/list',
+        'thread/turns/list',
+        'thread/read',
+    ], 'the rolling median verdicts on the third page');
+    const expected = await createFullReadProof(t, harness.state)
+        .readOutline(sessionId);
+    assert.deepEqual(stripRevision(outline), stripRevision(expected));
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 demotes least-recently-viewed full chunks beyond the materialized-window budget', async t => {
+    const harness = createWindowedHarness(t);
+    await harness.adapter.readOutline(sessionId);
+    const entry = harness.adapter.loadedConversationCache.get(sessionId);
+
+    // Window A (~51 chunks × 60KB) then window B (~30 more chunks): the
+    // sum crosses the 4Mi per-entry materialized budget.
+    await harness.adapter.readPage({
+        provider: 'codex',
+        sessionId,
+        anchorInteractionId: 'turn-user-25',
+        direction: 'around',
+        limit: 20,
+    });
+    const afterA = entry.characters;
+    await harness.adapter.readPage({
+        provider: 'codex',
+        sessionId,
+        anchorInteractionId: 'turn-user-65',
+        direction: 'around',
+        limit: 20,
+    });
+    assert.ok(entry.characters < afterA + 31 * 60 * 1024,
+        'demotion offsets most of window B');
+    assert.equal(entry.turns[10].kind, 'skeleton',
+        'the oldest window demotes back to skeletons');
+    assert.equal(entry.turns[65].kind, 'full',
+        'the served window stays materialized');
+    assert.equal(entry.turns[119].kind, 'full',
+        'the tail zone stays materialized');
+    assert.ok(entry.characters > 0);
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 treats a cross-epoch item collision as staleness, never as a protocol failure', async t => {
+    const harness = createWindowedHarness(t);
+    await harness.adapter.readOutline(sessionId);
+
+    // A response-spanning item projected into different turns at
+    // different fetch times: the tail fetch (cold start) recorded it in
+    // turn 119's full chunk, but the live full fetch now returns the same
+    // item inside turn 60.
+    const migrated = {
+        id: 'shared-reasoning-1',
+        type: 'reasoning',
+        summary: ['migrated reasoning'],
+    };
+    harness.state.turns[60].items.push(migrated);
+    const entry = harness.adapter.loadedConversationCache.get(sessionId);
+    assert.equal(entry.turns[119].kind, 'full',
+        'the tail chunk is materialized at cold start');
+    entry.turns[119].itemIds.push('shared-reasoning-1');
+
+    await assert.rejects(
+        harness.adapter.readPage({
+            provider: 'codex',
+            sessionId,
+            anchorInteractionId: 'turn-user-60',
+            direction: 'around',
+            limit: 10,
+        }),
+        error => error.name === 'ConversationError'
+            && error.code === 'staleRevision'
+    );
+    assert.equal(harness.adapter.paginatedReadsDisabled, false,
+        'a transient collision must not circuit-break the accelerator');
+    assert.equal(
+        harness.adapter.loadedConversationCache.has(sessionId),
+        false,
+        'the mixed-epoch entry is invalidated'
+    );
+
+    // The next read re-walks a consistent snapshot and succeeds.
+    const outline = await harness.adapter.readOutline(sessionId);
+    assert.equal(outline.totalInteractions, 120);
+    const paged = await harness.adapter.readPage({
+        provider: 'codex',
+        sessionId,
+        anchorInteractionId: 'turn-user-60',
+        direction: 'around',
+        limit: 10,
+    });
+    assert.ok(paged.interactionStates.some(
+        state => state.interactionId === 'turn-user-60'
+    ));
 });

--- a/tests/contract/aiSessions/codexConversationAdapter.test.js
+++ b/tests/contract/aiSessions/codexConversationAdapter.test.js
@@ -10,6 +10,8 @@ const {
 } = require('../../../out/aiSessions/conversation/codexAdapter');
 const {
     CONVERSATION_LIMITS,
+    ConversationAbortController,
+    ConversationAbortError,
     ConversationError,
 } = require('../../../out/aiSessions/conversation/types');
 
@@ -53,6 +55,7 @@ function createAdapter(result = fixture, overrides = {}) {
         readRolloutTelemetry: overrides.readRolloutTelemetry,
         readLifecycleSignal: overrides.readLifecycleSignal,
         readContentSignature: overrides.readContentSignature,
+        readSourceBytes: overrides.readSourceBytes,
         listSubagentThreads: overrides.listSubagentThreads,
         now: overrides.now,
     });
@@ -647,6 +650,11 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 does not cache a large Codex re
 
     const pending = harness.adapter.readOutline(sessionId);
     providerCallback();
+    // The read reaches the provider asynchronously (cold-start probing may
+    // add microtasks before the first request); wait for it to start.
+    while (!resolveRead) {
+        await new Promise(resolve => setImmediate(resolve));
+    }
     resolveRead(large);
     await pending;
 
@@ -2532,4 +2540,750 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 keeps subagent thread reloads o
         requests.map(entry => entry.method),
         ['thread/read', 'thread/read']
     );
+});
+
+// --- Windowed cold start (spikes/codex-cold-start) -----------------------
+
+// The summary view keeps the first userMessage and the final agentMessage
+// per turn (schema-verified server projection rule).
+function toSummaryTurn(turn) {
+    const items = [];
+    const user = turn.items.find(item => item.type === 'userMessage');
+    const agents = turn.items.filter(item => item.type === 'agentMessage');
+    if (user) {
+        items.push(user);
+    }
+    if (agents.length) {
+        items.push(agents[agents.length - 1]);
+    }
+    const summary = { id: turn.id, status: turn.status, items };
+    for (const key of ['startedAt', 'completedAt', 'durationMs', 'error']) {
+        if (turn[key] !== undefined) {
+            summary[key] = turn[key];
+        }
+    }
+    return summary;
+}
+
+// Strips the (intentionally basis-dependent) revision so windowed results
+// can be compared with the full-read ground truth field by field.
+function stripRevision(value) {
+    if (Array.isArray(value)) {
+        return value.map(stripRevision);
+    }
+    if (value && typeof value === 'object') {
+        const copy = {};
+        for (const [key, entry] of Object.entries(value)) {
+            copy[key] = key === 'sourceRevision' ? '' : stripRevision(entry);
+        }
+        return copy;
+    }
+    return value;
+}
+
+function createWindowedHarness(t, options = {}) {
+    const state = {
+        turns: options.turns || Array.from(
+            { length: options.initialTurns ?? 120 },
+            (_item, index) => createPaginatedTurn(index)
+        ),
+        signature: 'stat-1',
+        sourceBytes: options.sourceBytes ?? 8 * 1024 * 1024,
+        turnsListFailure: undefined,
+        readFailure: undefined,
+        // Per-request artificial latency (ms) for thread/turns/list.
+        pageLatencies: options.pageLatencies
+            ? [...options.pageLatencies] : [],
+        onRequest: undefined,
+        ensureReadyFailure: undefined,
+    };
+    let now = 1_000;
+    const requests = [];
+    const client = {
+        async ensureReady(signal) {
+            requests.push({ method: 'ensureReady' });
+            if (signal?.aborted) {
+                throw new ConversationAbortError();
+            }
+            if (state.ensureReadyFailure) {
+                throw new ConversationError('unavailable', 'reconnectingCodex');
+            }
+            return options.serverVersion === undefined
+                ? '0.147'
+                : options.serverVersion;
+        },
+        async request(method, params, signal) {
+            requests.push({ method, params });
+            if (typeof state.onRequest === 'function') {
+                state.onRequest(method, params);
+            }
+            if (signal?.aborted) {
+                throw new ConversationAbortError();
+            }
+            if (method === 'thread/turns/list') {
+                now += state.pageLatencies.length
+                    ? state.pageLatencies.shift() : 0;
+            }
+            if (method === 'thread/read') {
+                if (state.readFailure === 'timeout') {
+                    throw new ConversationError('timeout');
+                }
+                if (state.readFailure === 'tooLarge') {
+                    throw new ConversationError('tooLarge');
+                }
+                return clone({
+                    thread: { id: params.threadId, turns: state.turns },
+                });
+            }
+            if (method === 'thread/turns/list') {
+                if (state.turnsListFailure === 'capability') {
+                    throw new ConversationError(
+                        'unsupportedVersion',
+                        'unsupportedCodexProtocol'
+                    );
+                }
+                if (state.turnsListFailure === 'transient') {
+                    state.turnsListFailure = undefined;
+                    throw new ConversationError(
+                        'unavailable',
+                        'reconnectingCodex'
+                    );
+                }
+                if (state.turnsListFailure === 'malformed') {
+                    return { data: [{ id: 'broken' }] };
+                }
+                if (state.turnsListFailure === 'empty-page-with-cursor'
+                    && typeof params.cursor === 'string') {
+                    return { data: [], nextCursor: 'ghost' };
+                }
+                const served = serveTurnsListPage(state.turns, params);
+                if (params.itemsView === 'summary') {
+                    served.data = served.data.map(toSummaryTurn);
+                }
+                return served;
+            }
+            throw new Error(`unexpected method ${method}`);
+        },
+        getServerVersion: () => options.serverVersion === undefined
+            ? '0.147'
+            : options.serverVersion,
+        dispose() {},
+    };
+    const signatures = options.signatures || { [sessionId]: state.signature };
+    const harness = createAdapter(undefined, {
+        client,
+        readContentSignature: id => signatures[id],
+        readSourceBytes: id => (
+            id === sessionId ? state.sourceBytes : 8 * 1024 * 1024
+        ),
+        now: () => now,
+    });
+    t.after(() => harness.adapter.dispose());
+    return {
+        adapter: harness.adapter,
+        requests,
+        state,
+        signatures,
+        methods: () => requests.map(entry => entry.method),
+        turnsListCalls: () => requests
+            .filter(entry => entry.method === 'thread/turns/list'),
+    };
+}
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 windowed cold start handshakes first and never calls thread/read', async t => {
+    const harness = createWindowedHarness(t);
+    const outline = await harness.adapter.readOutline(sessionId);
+    const methods = harness.methods();
+    assert.equal(methods[0], 'ensureReady',
+        'the handshake must settle before any version-gated call');
+    assert.equal(methods.includes('thread/read'), false);
+    const listCalls = harness.turnsListCalls();
+    const firstFull = listCalls.findIndex(
+        entry => entry.params.itemsView === 'full'
+    );
+    assert.ok(firstFull > 0, 'summary walk pages come first');
+    assert.ok(listCalls.slice(0, firstFull).every(
+        entry => entry.params.itemsView === 'summary'
+            && entry.params.sortDirection === 'desc'
+    ));
+
+    const proof = createFullReadProof(t, harness.state);
+    const expectedOutline = await proof.readOutline(sessionId);
+    assert.deepEqual(stripRevision(outline), stripRevision(expectedOutline));
+
+    const snapshot = await harness.adapter.readSnapshot(sessionId);
+    const expectedSnapshot = await proof.readSnapshot(sessionId);
+    assert.deepEqual(
+        stripRevision(snapshot.page),
+        stripRevision(expectedSnapshot.page)
+    );
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 keeps small rollouts on the plain full read', async t => {
+    const harness = createWindowedHarness(t, {
+        sourceBytes: 1024 * 1024,
+    });
+    await harness.adapter.readOutline(sessionId);
+    assert.deepEqual(harness.methods(), ['ensureReady', 'thread/read']);
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 disables windowing without a content signature and keeps revisions stable', async t => {
+    const state = { turns: Array.from(
+        { length: 30 },
+        (_item, index) => createPaginatedTurn(index)
+    ) };
+    const requests = [];
+    const client = {
+        async ensureReady() {
+            return '0.147';
+        },
+        async request(method, params) {
+            requests.push({ method, params });
+            if (method !== 'thread/read') {
+                throw new Error(`unexpected method ${method}`);
+            }
+            return clone({
+                thread: { id: params.threadId, turns: state.turns },
+            });
+        },
+        getServerVersion: () => '0.147',
+        dispose() {},
+    };
+    const harness = createAdapter(undefined, {
+        client,
+        readContentSignature: () => undefined,
+        readSourceBytes: () => 8 * 1024 * 1024,
+    });
+    t.after(() => harness.adapter.dispose());
+
+    const first = await harness.adapter.readOutline(sessionId);
+    const snapshot = await harness.adapter.readSnapshot(sessionId);
+    const anchor = snapshot.page.interactionStates[0].interactionId;
+    // The outline revision must stay valid for paging even though every
+    // load re-reads the provider.
+    const paged = await harness.adapter.readPage({
+        provider: 'codex',
+        sessionId,
+        anchorInteractionId: anchor,
+        direction: 'before',
+        limit: 5,
+        expectedRevision: first.sourceRevision,
+    });
+    assert.equal(paged.sourceRevision, first.sourceRevision);
+    const refreshed = await harness.adapter.readOutline(sessionId);
+    assert.equal(refreshed.sourceRevision, first.sourceRevision);
+    assert.equal(
+        requests.filter(entry => entry.method === 'thread/turns/list').length,
+        0
+    );
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 verdicts legacy after two slow pages and falls back to the full read', async t => {
+    const harness = createWindowedHarness(t, {
+        pageLatencies: [400, 400, 400, 400],
+    });
+    const outline = await harness.adapter.readOutline(sessionId);
+    assert.deepEqual(harness.methods(), [
+        'ensureReady',
+        'thread/turns/list',
+        'thread/turns/list',
+        'thread/read',
+    ]);
+    const expected = await createFullReadProof(t, harness.state)
+        .readOutline(sessionId);
+    assert.deepEqual(stripRevision(outline), stripRevision(expected));
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 tolerates a single jittery page without a legacy verdict', async t => {
+    const harness = createWindowedHarness(t, {
+        pageLatencies: [400, 20, 20, 20, 20, 20, 20, 20],
+    });
+    await harness.adapter.readOutline(sessionId);
+    assert.equal(harness.methods().includes('thread/read'), false);
+    assert.equal(harness.adapter.paginatedReadsDisabled, false);
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 walks a many-page session to the true start', async t => {
+    const turns = Array.from({ length: 10_250 }, (_item, index) => ({
+        id: `turn-${index}`,
+        status: 'completed',
+        items: [{
+            id: `turn-${index}-user`,
+            type: 'userMessage',
+            content: [{ type: 'text', text: `request ${index}` }],
+        }, {
+            id: `turn-${index}-agent`,
+            type: 'agentMessage',
+            text: `response ${index}`,
+        }],
+    }));
+    const harness = createWindowedHarness(t, { turns });
+    const outline = await harness.adapter.readOutline(sessionId);
+    assert.equal(outline.totalInteractions, 10_250);
+    assert.equal(harness.methods().includes('thread/read'), false);
+
+    // The oldest history is reachable and matches the ground truth page.
+    // (outline.interactions is clipped to the newest 2000 entries, so the
+    // anchor id is addressed directly.)
+    const anchor = 'turn-20-user';
+    const [paged, expected] = await Promise.all([
+        harness.adapter.readPage({
+            provider: 'codex',
+            sessionId,
+            anchorInteractionId: anchor,
+            direction: 'before',
+            limit: 20,
+        }),
+        createFullReadProof(t, harness.state).readPage({
+            provider: 'codex',
+            sessionId,
+            anchorInteractionId: anchor,
+            direction: 'before',
+            limit: 20,
+        }),
+    ]);
+    assert.deepEqual(stripRevision(paged), stripRevision(expected));
+    assert.equal(paged.isStart, true, 'the true first page marks isStart');
+    assert.equal(paged.interactionStates[0].interactionId, 'turn-0-user');
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 materializes skeleton windows through recorded cursors without moving the revision', async t => {
+    const harness = createWindowedHarness(t);
+    const first = await harness.adapter.readOutline(sessionId);
+    const fullCallsAtOpen = harness.turnsListCalls().filter(
+        entry => entry.params.itemsView === 'full'
+    ).length;
+
+    const anchor = first.interactions[40].id;
+    const paged = await harness.adapter.readPage({
+        provider: 'codex',
+        sessionId,
+        anchorInteractionId: anchor,
+        direction: 'before',
+        limit: 20,
+    });
+    // The seek replays the walk's recorded boundary cursor in full view.
+    const seekCalls = harness.turnsListCalls().filter(
+        entry => entry.params.itemsView === 'full'
+            && entry.params.cursor === 'turn-70'
+    );
+    assert.equal(seekCalls.length, 1,
+        'page 1 of the walk is re-fetched from its boundary cursor');
+    const expected = await createFullReadProof(t, harness.state).readPage({
+        provider: 'codex',
+        sessionId,
+        anchorInteractionId: anchor,
+        direction: 'before',
+        limit: 20,
+    });
+    assert.deepEqual(stripRevision(paged), stripRevision(expected));
+    assert.ok(harness.turnsListCalls().filter(
+        entry => entry.params.itemsView === 'full'
+    ).length > fullCallsAtOpen);
+
+    // Pure hydration must not move the revision.
+    const after = await harness.adapter.readOutline(sessionId);
+    assert.equal(after.sourceRevision, first.sourceRevision);
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 expands a multi-user-message turn on materialization and moves the revision', async t => {
+    const harness = createWindowedHarness(t);
+    harness.state.turns[30] = {
+        id: 'turn-30',
+        status: 'completed',
+        items: [
+            {
+                id: 'turn-30-user-a',
+                type: 'userMessage',
+                content: [{ type: 'text', text: 'first question' }],
+            },
+            { id: 'turn-30-agent-1', type: 'agentMessage', text: 'answer one' },
+            {
+                id: 'turn-30-user-b',
+                type: 'userMessage',
+                content: [{ type: 'text', text: 'steering' }],
+            },
+            { id: 'turn-30-agent-2', type: 'agentMessage', text: 'ack' },
+            {
+                id: 'turn-30-user-c',
+                type: 'userMessage',
+                content: [{ type: 'text', text: 'progress?' }],
+            },
+            { id: 'turn-30-agent-3', type: 'agentMessage', text: 'status' },
+        ],
+    };
+    const first = await harness.adapter.readOutline(sessionId);
+    // The skeleton folds the turn to its first user message.
+    assert.equal(first.interactions.filter(
+        interaction => interaction.providerTurnId === 'turn-30'
+    ).length, 1);
+    assert.equal(first.totalInteractions, 120);
+
+    const paged = await harness.adapter.readPage({
+        provider: 'codex',
+        sessionId,
+        anchorInteractionId: 'turn-30-user-a',
+        direction: 'around',
+        limit: 20,
+    });
+    const ids = paged.interactionStates.map(state => state.interactionId);
+    assert.ok(ids.includes('turn-30-user-b'));
+    assert.ok(ids.includes('turn-30-user-c'));
+
+    // The expansion changed the interaction-id set: the revision moved.
+    const after = await harness.adapter.readOutline(sessionId);
+    assert.notEqual(after.sourceRevision, first.sourceRevision);
+    assert.equal(after.interactions.filter(
+        interaction => interaction.providerTurnId === 'turn-30'
+    ).length, 3);
+    const expected = await createFullReadProof(t, harness.state)
+        .readOutline(sessionId);
+    assert.deepEqual(stripRevision(after), stripRevision(expected));
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 moves the revision when a live tail turn gains only tool items', async t => {
+    const harness = createWindowedHarness(t);
+    const first = await harness.adapter.readOutline(sessionId);
+
+    // Tool-only growth: user/agent texts (the summary projection) stay
+    // identical; only the stat moves.
+    harness.state.turns[119].items.push({
+        id: 'turn-119-tool-1',
+        type: 'commandExecution',
+        command: 'ls',
+        aggregatedOutput: 'ok',
+    });
+    harness.signatures[sessionId] = 'stat-2';
+    const updated = await harness.adapter.readOutline(sessionId);
+    assert.notEqual(updated.sourceRevision, first.sourceRevision);
+    assert.equal(harness.methods().includes('thread/read'), false);
+
+    const snapshot = await harness.adapter.readSnapshot(sessionId);
+    assert.ok(snapshot.page.messages.some(message => message.role === 'tool'),
+        'the new tool item must render');
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 materializes in-place skeleton updates fresh without a revision move', async t => {
+    const harness = createWindowedHarness(t);
+    const first = await harness.adapter.readOutline(sessionId);
+
+    // An in-place update to an unmaterized turn's tool content: invisible
+    // to the summary projection; the stat still moves.
+    harness.state.turns[40].items.push({
+        id: 'turn-40-tool-1',
+        type: 'commandExecution',
+        command: 'make test',
+        aggregatedOutput: 'fresh output',
+    });
+    harness.signatures[sessionId] = 'stat-2';
+    const refreshed = await harness.adapter.readOutline(sessionId);
+    assert.equal(refreshed.sourceRevision, first.sourceRevision,
+        'projection unchanged: no revision churn');
+
+    const paged = await harness.adapter.readPage({
+        provider: 'codex',
+        sessionId,
+        anchorInteractionId: 'turn-user-40',
+        direction: 'around',
+        limit: 10,
+    });
+    assert.ok(paged.messages.some(message =>
+        message.role === 'tool' && message.tool?.detail === 'fresh output'),
+        'materialization fetches the current server state');
+    const after = await harness.adapter.readOutline(sessionId);
+    assert.equal(after.sourceRevision, first.sourceRevision);
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 re-anchors a windowed entry on a stat fake-out without churn', async t => {
+    const harness = createWindowedHarness(t);
+    const first = await harness.adapter.readOutline(sessionId);
+    const requestsAtOpen = harness.requests.length;
+
+    harness.signatures[sessionId] = 'stat-2';
+    const reanchored = await harness.adapter.readOutline(sessionId);
+    assert.equal(reanchored.sourceRevision, first.sourceRevision);
+    const anchorWalkCalls = harness.requests.length - requestsAtOpen;
+    assert.ok(anchorWalkCalls > 0 && anchorWalkCalls <= 2,
+        'only the tail anchor walk runs');
+
+    // Re-anchored: a same-signature read is a pure cache hit.
+    const before = harness.requests.length;
+    const cached = await harness.adapter.readOutline(sessionId);
+    assert.equal(harness.requests.length, before);
+    assert.equal(cached.sourceRevision, first.sourceRevision);
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 reloads an appended windowed entry incrementally and keeps deep seeks correct', async t => {
+    const harness = createWindowedHarness(t);
+    const first = await harness.adapter.readOutline(sessionId);
+
+    harness.state.turns.push(createPaginatedTurn(120));
+    harness.signatures[sessionId] = 'stat-2';
+    const updated = await harness.adapter.readOutline(sessionId);
+    assert.notEqual(updated.sourceRevision, first.sourceRevision);
+    assert.equal(updated.totalInteractions, 121);
+    assert.equal(harness.methods().includes('thread/read'), false);
+
+    // The append shifts newest-first indexes: deep seeks must rebase.
+    const paged = await harness.adapter.readPage({
+        provider: 'codex',
+        sessionId,
+        anchorInteractionId: 'turn-user-30',
+        direction: 'around',
+        limit: 10,
+    });
+    assert.ok(paged.interactionStates.some(
+        state => state.interactionId === 'turn-user-30'
+    ));
+    assert.ok(paged.messages.some(message =>
+        message.role === 'assistant' && message.markdown.length > 1000),
+        'the sought window renders its assistant content');
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 rebuilds a windowed entry through a fresh summary walk after compaction', async t => {
+    const harness = createWindowedHarness(t);
+    const first = await harness.adapter.readOutline(sessionId);
+
+    harness.state.turns = Array.from(
+        { length: 10 },
+        (_item, index) => createPaginatedTurn(index, 'new-turn')
+    );
+    harness.signatures[sessionId] = 'stat-2';
+    const rebuilt = await harness.adapter.readOutline(sessionId);
+    assert.notEqual(rebuilt.sourceRevision, first.sourceRevision);
+    assert.equal(rebuilt.totalInteractions, 10);
+    assert.equal(harness.methods().includes('thread/read'), false);
+    const expected = await createFullReadProof(t, harness.state)
+        .readOutline(sessionId);
+    assert.deepEqual(stripRevision(rebuilt), stripRevision(expected));
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 serializes concurrent materialization of different windows', async t => {
+    const harness = createWindowedHarness(t);
+    await harness.adapter.readOutline(sessionId);
+
+    const proof = createFullReadProof(t, harness.state);
+    const [pageA, pageB] = await Promise.all([
+        harness.adapter.readPage({
+            provider: 'codex',
+            sessionId,
+            anchorInteractionId: 'turn-user-30',
+            direction: 'around',
+            limit: 10,
+        }),
+        harness.adapter.readPage({
+            provider: 'codex',
+            sessionId,
+            anchorInteractionId: 'turn-user-80',
+            direction: 'around',
+            limit: 10,
+        }),
+    ]);
+    const [expectedA, expectedB] = await Promise.all([
+        proof.readPage({
+            provider: 'codex',
+            sessionId,
+            anchorInteractionId: 'turn-user-30',
+            direction: 'around',
+            limit: 10,
+        }),
+        proof.readPage({
+            provider: 'codex',
+            sessionId,
+            anchorInteractionId: 'turn-user-80',
+            direction: 'around',
+            limit: 10,
+        }),
+    ]);
+    assert.deepEqual(stripRevision(pageA), stripRevision(expectedA));
+    assert.deepEqual(stripRevision(pageB), stripRevision(expectedB));
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 an aborted materialization does not disturb the queued request', async t => {
+    const harness = createWindowedHarness(t);
+    await harness.adapter.readOutline(sessionId);
+    const controller = new ConversationAbortController();
+    harness.state.onRequest = (method, params) => {
+        if (method === 'thread/turns/list'
+            && params.itemsView === 'full'
+            && params.cursor === 'turn-20') {
+            controller.abort();
+        }
+    };
+    const aborted = harness.adapter.readPage({
+        provider: 'codex',
+        sessionId,
+        anchorInteractionId: 'turn-user-10',
+        direction: 'around',
+        limit: 10,
+    }, controller.signal);
+    await assert.rejects(aborted, error => error.name === 'AbortError');
+
+    harness.state.onRequest = undefined;
+    const surviving = await harness.adapter.readPage({
+        provider: 'codex',
+        sessionId,
+        anchorInteractionId: 'turn-user-60',
+        direction: 'around',
+        limit: 10,
+    });
+    const expected = await createFullReadProof(t, harness.state).readPage({
+        provider: 'codex',
+        sessionId,
+        anchorInteractionId: 'turn-user-60',
+        direction: 'around',
+        limit: 10,
+    });
+    assert.deepEqual(stripRevision(surviving), stripRevision(expected));
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 discards in-flight materialization when the source moves', async t => {
+    const harness = createWindowedHarness(t);
+    await harness.adapter.readOutline(sessionId);
+    let fullPages = 0;
+    harness.state.onRequest = (method, params) => {
+        if (method === 'thread/turns/list'
+            && params.itemsView === 'full'
+            && params.cursor !== undefined) {
+            fullPages += 1;
+            if (fullPages === 2) {
+                harness.signatures[sessionId] = 'stat-2';
+            }
+        }
+    };
+    await assert.rejects(
+        harness.adapter.readPage({
+            provider: 'codex',
+            sessionId,
+            anchorInteractionId: 'turn-user-10',
+            direction: 'around',
+            limit: 10,
+        }),
+        error => error.name === 'ConversationError'
+            && error.code === 'staleRevision'
+    );
+
+    // The next read re-anchors through the incremental path and completes.
+    harness.state.onRequest = undefined;
+    const recovered = await harness.adapter.readPage({
+        provider: 'codex',
+        sessionId,
+        anchorInteractionId: 'turn-user-10',
+        direction: 'around',
+        limit: 10,
+    });
+    const expected = await createFullReadProof(t, harness.state).readPage({
+        provider: 'codex',
+        sessionId,
+        anchorInteractionId: 'turn-user-10',
+        direction: 'around',
+        limit: 10,
+    });
+    assert.deepEqual(stripRevision(recovered), stripRevision(expected));
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 another session moving does not disturb an in-flight materialization', async t => {
+    const otherSession = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+    const harness = createWindowedHarness(t, {
+        signatures: {
+            [sessionId]: 'stat-a1',
+            [otherSession]: 'stat-b1',
+        },
+    });
+    await harness.adapter.readOutline(sessionId);
+    let fullPages = 0;
+    harness.state.onRequest = (method, params) => {
+        if (params.threadId === sessionId
+            && params.itemsView === 'full'
+            && params.cursor !== undefined) {
+            fullPages += 1;
+            if (fullPages === 1) {
+                harness.signatures[otherSession] = 'stat-b2';
+            }
+        }
+    };
+    const paged = await harness.adapter.readPage({
+        provider: 'codex',
+        sessionId,
+        anchorInteractionId: 'turn-user-10',
+        direction: 'around',
+        limit: 10,
+    });
+    const expected = await createFullReadProof(t, harness.state).readPage({
+        provider: 'codex',
+        sessionId,
+        anchorInteractionId: 'turn-user-10',
+        direction: 'around',
+        limit: 10,
+    });
+    assert.deepEqual(stripRevision(paged), stripRevision(expected));
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 falls back from a failing full read to the forced slow walk', async t => {
+    const harness = createWindowedHarness(t, {
+        pageLatencies: [400, 400],
+    });
+    harness.state.readFailure = 'timeout';
+    const outline = await harness.adapter.readOutline(sessionId);
+    const methods = harness.methods();
+    assert.ok(methods.includes('thread/read'),
+        'the legacy verdict tries the stable read first');
+    const readIndex = methods.indexOf('thread/read');
+    assert.ok(methods.slice(readIndex + 1).some(
+        method => method === 'thread/turns/list'
+    ), 'the failed read re-enters the forced windowed walk');
+    const expected = await createFullReadProof(t, harness.state)
+        .readOutline(sessionId);
+    assert.deepEqual(stripRevision(outline), stripRevision(expected));
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 circuit-breaks the walk on capability rejection and stays on the stable path', async t => {
+    const harness = createWindowedHarness(t);
+    harness.state.turnsListFailure = 'capability';
+    const outline = await harness.adapter.readOutline(sessionId);
+    assert.equal(outline.totalInteractions, 120);
+    assert.equal(harness.adapter.paginatedReadsDisabled, true);
+
+    harness.signatures[sessionId] = 'stat-2';
+    await harness.adapter.readOutline(sessionId);
+    assert.deepEqual(
+        harness.methods().filter(method => method === 'thread/turns/list')
+            .length,
+        1,
+        'no further paginated calls after the circuit broke'
+    );
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 a transient walk failure falls back without retiring the accelerator', async t => {
+    const harness = createWindowedHarness(t);
+    harness.state.turnsListFailure = 'transient';
+    const outline = await harness.adapter.readOutline(sessionId);
+    assert.equal(outline.totalInteractions, 120);
+    assert.equal(harness.adapter.paginatedReadsDisabled, false);
+
+    harness.signatures[sessionId] = 'stat-2';
+    await harness.adapter.readOutline(sessionId);
+    assert.equal(harness.methods().includes('thread/turns/list'), true,
+        'the next load retries the paginated path');
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 circuit-breaks on malformed and empty summary pages', async t => {
+    const malformed = createWindowedHarness(t);
+    malformed.state.turnsListFailure = 'malformed';
+    await malformed.adapter.readOutline(sessionId);
+    assert.equal(malformed.adapter.paginatedReadsDisabled, true);
+
+    const emptyPage = createWindowedHarness(t);
+    emptyPage.state.turnsListFailure = 'empty-page-with-cursor';
+    await emptyPage.adapter.readOutline(sessionId);
+    assert.equal(emptyPage.adapter.paginatedReadsDisabled, true);
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 falls back to the full read when the handshake fails transiently', async t => {
+    const harness = createWindowedHarness(t);
+    harness.state.ensureReadyFailure = 'unavailable';
+    const outline = await harness.adapter.readOutline(sessionId);
+    assert.equal(outline.totalInteractions, 120);
+    assert.deepEqual(harness.methods(), ['ensureReady', 'thread/read']);
+    assert.equal(harness.adapter.paginatedReadsDisabled, false);
 });

--- a/tests/integration/dashboard/conversationViewer.test.js
+++ b/tests/integration/dashboard/conversationViewer.test.js
@@ -596,6 +596,64 @@ test('WEBVIEW-AI-SESSION-CONVERSATION-VIEWER-001 restores a retained panel witho
     viewer.dispose();
 });
 
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 republishes on revision-moving content growth even when the outline projection is unchanged', async () => {
+    const panel = fakePanel();
+    let onChange;
+    let revision = 1;
+    let toolMarker = '';
+    let readPageCalls = 0;
+    const { viewer } = createViewer({
+        panel,
+        readOutline: async (_provider, sessionId) => outline(
+            sessionId,
+            ['input-1'],
+            { sourceRevision: `r${revision}` }
+        ),
+        readPage: async request => {
+            readPageCalls += 1;
+            return page(
+                request.sessionId,
+                request.anchorInteractionId,
+                `visible${toolMarker}`,
+                { sourceRevision: `r${revision}` }
+            );
+        },
+        watch: (_provider, _sessionId, callback) => {
+            onChange = callback;
+            return { dispose() {} };
+        },
+    });
+    await viewer.open(target('session-a', 'input-1'));
+    const publications = () => panel.postedMessages.filter(message =>
+        message.type === 'conversation-viewer-page');
+    const baselinePublications = publications().length;
+    const baselineReadPages = readPageCalls;
+
+    // Same revision, same interaction ids, same responseState: the
+    // refresh must early-return without a page read or publication.
+    onChange();
+    await new Promise(resolve => setImmediate(resolve));
+    await new Promise(resolve => setImmediate(resolve));
+    assert.equal(readPageCalls, baselineReadPages,
+        'a projection-identical refresh must not re-read the page');
+    assert.equal(publications().length, baselinePublications);
+
+    // Tool-only growth: the outline projection (ids + states) is
+    // identical, but the revision moved with the content epoch — the
+    // viewer must re-read the page and publish the new HTML.
+    revision = 2;
+    toolMarker = '-with-tool';
+    onChange();
+    await new Promise(resolve => setImmediate(resolve));
+    await new Promise(resolve => setImmediate(resolve));
+    assert.ok(readPageCalls > baselineReadPages,
+        'a revision move must re-read the page even without outline changes');
+    const publication = publications().at(-1);
+    assert.ok(publication, 'the grown content must be published');
+    assert.match(publication.html, /visible-with-tool/);
+    viewer.dispose();
+});
+
 test('CONVERSATION-FOLLOW-ACTIVE-SESSION-001 follows another Session only when the viewer is open and does not reveal it again', async () => {
     const { viewer, panel } = createViewer({
         readOutline: async (_provider, sessionId) => outline(

--- a/tests/unit/aiSessions/codexRolloutContentSignature.test.js
+++ b/tests/unit/aiSessions/codexRolloutContentSignature.test.js
@@ -8,6 +8,7 @@ const test = require('node:test');
 
 const {
     readCodexRolloutContentSignature,
+    readCodexRolloutSourceBytes,
 } = require('../../../out/aiSessions/codexRolloutContentSignature');
 
 test('SESSION-AI-SESSION-CONVERSATION-ADAPTER-001 rollout content signature tracks file size and mtime', async t => {
@@ -36,4 +37,13 @@ test('SESSION-AI-SESSION-CONVERSATION-ADAPTER-001 rollout content signature trac
     await fs.promises.appendFile(rolloutPath, '{"type":"event_msg"}\n');
     const updated = readCodexRolloutContentSignature(rolloutPath);
     assert.notEqual(updated, first);
+
+    // The byte-size probe mirrors the same degradation rules and reports
+    // the plain file size for the windowing heuristic.
+    assert.equal(readCodexRolloutSourceBytes(''), undefined);
+    assert.equal(readCodexRolloutSourceBytes(dir), undefined);
+    assert.equal(
+        readCodexRolloutSourceBytes(rolloutPath),
+        fs.statSync(rolloutPath).size
+    );
 });


### PR DESCRIPTION
## Summary

Phase 3 of the Codex large-session loading work (after #227 stat-signature cache and #228 incremental paginated reload): **the cold start**. A 183MB paginated session's first `thread/read` takes 40.6s / 52.4MB and exceeds the 10s request timeout — today it cannot be opened at all.

On verified 0.147 paginated backends, the cold start now:

1. awaits the completed handshake (`client.ensureReady()`) before version gating — a sync gate can never engage on the first read;
2. walks **all** turns as summary skeletons (`itemsView:"summary"`, ~35ms/50-turn page, flat on the indexed backend) — outline-complete, so `isStart`/`totalInteractions` keep their exact local meaning;
3. materializes full items only for the tail window (~40 turns / 1.5MB raw);
4. materializes older windows on demand inside `readPage`/`readSnapshot` by replaying the walk's recorded boundary cursors with `itemsView:"full"` (probe-verified portable across limit/itemsView, byte-identical items).

Design invariants (four review rounds encoded):

- **Projection revision**: `sha256(content-epoch stat | per-turn summary fingerprints | structure generation)`. Any observed provider content change moves it (the viewer skips refreshes only when revision AND ids AND responseStates are unchanged — a tool-only append must still republish); pure hydration never moves it, so retained-page cursors survive scrolling.
- **Summary fingerprints exclude the agentMessage**: real-data census (218 turns) found the summary agent text unreliable — omitted for interrupted turns, divergent in one completed turn. The user side is verbatim everywhere.
- **Skeleton ids == full-path ids** (both are the first userMessage item id), so anchors survive materialization; a multi-userMessage turn (exists in real data) expands 1→N on materialization, bumps the structure generation, and moves the revision so cursors anchored at new ids are never left dangling across cache eviction.
- **Freshness closure**: on a stat move, every materialized chunk the incremental anchor walk does not re-verify demotes back to a skeleton — in-place historical edits (the protocol's `updated_at_ordinal` makes them real) can never serve stale content; the next view re-materializes live. Materialization commits re-verify the entry's cache slot AND stat signature after every landed RPC (the last-page race is closed), and the cold-start walk/tail close over their signature with one re-walk retry.
- **Materialized-window LRU**: a per-entry 4Mi budget demotes least-recently-served full chunks outside the protected ranges (served window + tail zone) back to skeletons — long scrolling cannot re-inflate an entry toward the whole conversation.
- **Legacy verdict**: rolling median page latency (up to 3 pages, min 2; handshake excluded). A fast first page no longer suppresses the verdict; a single jittery page never triggers it. Verdict → the stable full read (no size-based feasibility guessing); if that read times out / is too large, the forced slow walk still opens the session — huge legacy sessions go from "never opens" to "opens slowly". Runaway valves (4k pages / 120s) are resource bounds, not heuristics.
- **Live-session hazard** (found by real-data validation): item ids are not reliably turn-scoped while a session is being written — a response-spanning reasoning item was projected into different turns by fetches seconds apart. Cross-page id collisions invalidate the entry and re-walk a consistent snapshot; they never circuit-break the accelerator.

Deliberate trade-offs, called out honestly:

- The outline folds multi-userMessage turns to their first message until materialized (the server projection exposes only `first_user_item_id`); it self-heals on the next content change. Measured divergence on the biggest real session: exactly one turn, two folded entries.
- 60MB-class legacy cold starts cost ~2.1-2.5s instead of ~1.0s (verdict pages before the full read). Bounded and shrinking (legacy = pre-0.147 sessions); the alternative is misjudging paginated sessions into a guaranteed timeout.
- A stat move with materialized history beyond the anchor now moves the revision (demotion) — fake-out zero-churn is preserved only when nothing unverified remains materialized. Re-materialization is lazy and the viewer's HTML signature suppresses redundant publications, so the user-visible cost is nil; the RPC cost is a few small pages.
- The windowed revision basis differs from the full-read basis by construction; crossing bases is a one-time cursor reset on the standard stale-recovery path.

Small sessions (<4MiB rollout), subagent threads, unverified server versions, and signature-less environments all keep the previous full-read path byte-identical.

## Skill harvest

Updated `.skills/developing-provider-conversation-adapters` with probe-verified protocol facts: summary = first userMessage (+ unreliable final agentMessage), cursor portability across limit/itemsView, handshake-first version gating (sync gates are circular at cold start), handshake contamination of first-page latency, non-turn-scoped item ids on live sessions, and the viewer's revision+ids+responseState refresh-skip rule that forces revisions to move on any content change.

## Verification

- **Real data, production client** (codex 0.147.0, live 183MB paginated session): cold start **~420ms** (was 40.6s / guaranteed timeout); outline equal to the full-`itemsView:"full"`-walk ground truth except the known folded turn; tail page and a deep materialized page **byte-identical** to ground truth; revision stable across quiet hydration; expansion of the folded turn moves the revision as designed. 60MB legacy: ~2.1-2.5s total, outline exact. Telemetry `thread/read includeTurns:false` on the 183MB session: ~250ms (no residual issue).
- **Contract tests**: 98/98 Codex adapter (27 new: handshake ordering, window gates, legacy verdicts + jitter + late verdict, >200-page walk to the true start, seek cursors, revision stability, expansion, tool-only growth, in-place skeleton freshness, stat-move demotion + zero-churn re-anchor, append rebase, compaction rebuild, concurrent/aborted/preempted materialization, cross-session isolation, forced-walk fallback, circuit-breaker tiers, edited-history re-read, last-page-RPC race, materialized-window LRU, cross-epoch collision recovery) + 31/31 app-server client (3 new `ensureReady`) + viewer end-to-end test pinning that revision-moving tool-only growth republishes while projection-identical refreshes early-return.
- **Perf budgets**: `codexWindowedColdStartMs` 300 (measured ~56ms synthetic), `codexLegacyColdStartMs` 2500 (simulated ~1.3s with the late-verdict pattern); existing budgets unchanged and green.
- **Gates**: `test:ci:linux` exit 0 (unit 811, contract+integration 1352, browser, packaging, coverage), lint baseline, architecture guards, behavior contracts + capability audit (`audit.head` at the fix commit).
