### PR TITLE
fix: serialize Kimi conversation loads per session to keep the cache converged

### DIFF
--- a/.skills/developing-provider-conversation-adapters/SKILL.md
+++ b/.skills/developing-provider-conversation-adapters/SKILL.md
@@ -109,3 +109,24 @@ From `spikes/codex-paginated-read` and `spikes/codex-cold-start`:
   ids, and responseStates are all unchanged. Adapter revisions must
   therefore move on **any** provider content change — including
   summary-invisible tool output — or the webview never re-reads the page.
+
+## Incremental Cache Concurrency
+
+Kimi and Claude adapters keep a per-session incremental index
+(`nextOffset` + parsed interactions) and commit it **in place**. Warmup,
+telemetry polls, watch refreshes, and authoritative clicks all call
+`load()` concurrently, so an unguarded check-then-act across the
+continuation hash await lets a racing load flip `continuing`, re-read a
+file suffix as if it were the whole file, and write the truncated index
+back with an end-of-file offset — the session then reports empty
+forever while every later click refreshes the poisoned entry's TTL.
+Serialize `load()` per session id (a trailing promise chain that
+survives rejections) so every read observes a fully committed entry.
+Regression-test with staggered concurrent waves (0..N `setImmediate`
+ticks apart) of mixed `readOutline`/`readSnapshot`/`readTelemetry` after
+each append, then compare against a cold-read truth adapter — the flip
+window is only a few event-loop ticks wide, so unserialized code fails
+within the first waves while the serialized fix is deterministically
+green. Record `lastReadContinuation` on the entry and expose
+`getCacheDiagnostics` so an empty follow is diagnosable from the local
+log without raw identifiers.

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -4950,6 +4950,36 @@
     ]
   },
   {
+    "id": "CONVERSATION-CACHE-CONVERGENCE-001",
+    "domain": "session",
+    "title": "Incremental conversation index caches converge to on-disk truth: same-session reads are serialized so racing warmup, telemetry, watch, and authoritative reads never truncate or roll back the cached interaction index, an empty source picks up appended turns on the next read, and replaced or truncated sources are cold re-read",
+    "priority": "P0",
+    "status": "automated",
+    "owners": [
+      "tests/contract/aiSessions/kimiConversationAdapter.test.js"
+    ],
+    "evidence": [
+      "src/aiSessions/conversation/kimiAdapter.ts"
+    ]
+  },
+  {
+    "id": "CONVERSATION-FOLLOW-DIAGNOSTICS-001",
+    "domain": "session",
+    "title": "Follow failures emit sanitized but diagnosable conversation-follow events: session id hashes, warm/fresh provenance, discarded-empty-warm flag, outline size, source revision, and adapter cache state (source size, cached offset, cached interaction count, continuation, partial), without raw identifiers, paths, or conversation content",
+    "priority": "P1",
+    "status": "automated",
+    "owners": [
+      "tests/integration/dashboard/conversationOpenLatest.test.js",
+      "tests/contract/aiSessions/kimiConversationAdapter.test.js"
+    ],
+    "evidence": [
+      "src/aiSessions/conversation/composition.ts",
+      "src/aiSessions/conversation/coordinator.ts",
+      "src/aiSessions/conversation/kimiAdapter.ts",
+      "src/aiSessions/conversation/types.ts"
+    ]
+  },
+  {
     "id": "CONVERSATION-LIVE-UPDATE-JOURNEY-001",
     "domain": "webview",
     "title": "A live response preserves telemetry, follows from the end, preserves historical reading position, and transitions Working to complete without a manual new-content control",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "7471ec6d918175b048f962cddc2c8e374dae7390",
+        "head": "aecacbe0c6edaf93832ead08b5b279a9731d1355",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -289,7 +289,8 @@
             "0f1b5cdb56fcceac286e26b273e52ec31fee1003",
             "f83afd43b4cf0781339818992498d673a1b83411",
             "8d354e7c2d1e7a7ff528e6ed2dfd495a37a19415",
-            "bf5af003d36a5f5e813df7802762e75a3ab2215e"
+            "bf5af003d36a5f5e813df7802762e75a3ab2215e",
+            "8a289bd48012003108121fb5d491fbb730807dca"
         ]
     },
     "capabilities": [
@@ -1635,7 +1636,8 @@
                 "887b8877965c074b915f85986dfbdc60cdcaa530",
                 "ed74fee09373347dad2da1bb17493d5fbf960d4c",
                 "2accfd46a0909f5e810ef6484d42677868c952e1",
-                "7471ec6d918175b048f962cddc2c8e374dae7390"
+                "7471ec6d918175b048f962cddc2c8e374dae7390",
+                "aecacbe0c6edaf93832ead08b5b279a9731d1355"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",
@@ -1683,7 +1685,9 @@
                 "CONVERSATION-PLAN-QUESTION-VISIBILITY-001",
                 "CONVERSATION-DIFF-VISIBILITY-001",
                 "CONVERSATION-FOLLOW-FEEDBACK-001",
-                "CONVERSATION-SESSION-STATUS-001"
+                "CONVERSATION-SESSION-STATUS-001",
+                "CONVERSATION-CACHE-CONVERGENCE-001",
+                "CONVERSATION-FOLLOW-DIAGNOSTICS-001"
             ],
             "prGates": [
                 "test:ci:linux"

--- a/src/aiSessions/conversation/composition.ts
+++ b/src/aiSessions/conversation/composition.ts
@@ -449,7 +449,8 @@ function createAvailableConversationCapability(
                 reportFollowFailure(
                     options.onDiagnostic,
                     target.provider,
-                    resolution.result
+                    resolution.result,
+                    resolution.diagnostic
                 );
                 viewer.showNotice(
                     conversationFollowNoticeText(resolution.result)
@@ -739,6 +740,7 @@ type LatestConversationTargetResolution =
         viewerTarget?: undefined;
         snapshot?: undefined;
         prefetchedSnapshot?: undefined;
+        diagnostic?: Partial<SanitizedConversationDiagnostic>;
     };
 
 async function followAdjacentConversation(
@@ -1207,7 +1209,10 @@ async function resolveLatestConversationTarget(
 ): Promise<LatestConversationTargetResolution> {
     const authoritativeTarget = resolveExactTarget(options, target);
     if (!authoritativeTarget) {
-        return { result: 'unknownSession' };
+        return {
+            result: 'unknownSession',
+            diagnostic: conversationFollowDiagnosticBase(target),
+        };
     }
     coordinator.setSessionStopped(
         target.provider,
@@ -1224,13 +1229,19 @@ async function resolveLatestConversationTarget(
                 target.sessionId
             );
         } catch (_error) {
-            return { result: 'unavailable' };
+            return {
+                result: 'unavailable',
+                diagnostic: conversationFollowDiagnosticBase(target),
+            };
         }
         const authoritativeSubagent = subagents.find(entry =>
             entry.id === subagentId
         );
         if (!authoritativeSubagent) {
-            return { result: 'unavailable' };
+            return {
+                result: 'unavailable',
+                diagnostic: conversationFollowDiagnosticBase(target),
+            };
         }
         subagent = {
             id: authoritativeSubagent.id,
@@ -1243,6 +1254,7 @@ async function resolveLatestConversationTarget(
     }
     let snapshot: ConversationSnapshot;
     let prefetchedSnapshot = false;
+    let discardedEmptyWarmSnapshot = false;
     try {
         const warmSnapshot = preferredInteractionId === undefined
             && subagentId === undefined
@@ -1253,7 +1265,13 @@ async function resolveLatestConversationTarget(
             : undefined;
         if (warmSnapshot && !resolvedWarmSnapshot
             && snapshotWarmup?.isDisposed()) {
-            return { result: 'unavailable' };
+            return {
+                result: 'unavailable',
+                diagnostic: conversationFollowDiagnosticBase(
+                    target,
+                    effectiveSessionId
+                ),
+            };
         }
         // A speculative read can finish before a newly started provider has
         // persisted its first user turn. Never let that empty warm snapshot
@@ -1263,6 +1281,9 @@ async function resolveLatestConversationTarget(
             && resolvedWarmSnapshot.outline.interactions.length
             ? resolvedWarmSnapshot
             : undefined;
+        discardedEmptyWarmSnapshot = Boolean(
+            resolvedWarmSnapshot && !usableWarmSnapshot
+        );
         prefetchedSnapshot = Boolean(usableWarmSnapshot);
         snapshot = usableWarmSnapshot || (
             typeof coordinator.readSnapshot === 'function'
@@ -1278,7 +1299,17 @@ async function resolveLatestConversationTarget(
                 ),
             });
     } catch (_error) {
-        return { result: 'unavailable' };
+        return {
+            result: 'unavailable',
+            diagnostic: {
+                ...conversationFollowDiagnosticBase(target, effectiveSessionId),
+                ...conversationCacheDiagnostics(
+                    coordinator,
+                    target.provider,
+                    effectiveSessionId
+                ),
+            },
+        };
     }
     const selected = snapshot.outline.interactions.find(interaction =>
         interaction.id === preferredInteractionId
@@ -1286,7 +1317,21 @@ async function resolveLatestConversationTarget(
         snapshot.outline.interactions.length - 1
     ];
     if (!selected) {
-        return { result: 'empty' };
+        return {
+            result: 'empty',
+            diagnostic: {
+                ...conversationFollowDiagnosticBase(target, effectiveSessionId),
+                snapshotSource: 'fresh',
+                discardedEmptyWarmSnapshot,
+                outlineInteractions: snapshot.outline.interactions.length,
+                sourceRevision: snapshot.outline.sourceRevision,
+                ...conversationCacheDiagnostics(
+                    coordinator,
+                    target.provider,
+                    effectiveSessionId
+                ),
+            },
+        };
     }
     const displayMetadata = authoritativeTarget as ActiveAiSessionViewModel & {
         conversationDisplayName?: string;
@@ -1418,6 +1463,40 @@ function reportUnavailable(
     }
 }
 
+function hashConversationSessionId(value: string): string {
+    return createHash('sha256').update(value).digest('hex').slice(0, 12);
+}
+
+function conversationFollowDiagnosticBase(
+    target: ConversationSessionOpenTarget,
+    effectiveSessionId?: string
+): Partial<SanitizedConversationDiagnostic> {
+    return {
+        sessionIdHash: hashConversationSessionId(target.sessionId),
+        ...(effectiveSessionId !== undefined
+            && effectiveSessionId !== target.sessionId
+            ? {
+                effectiveSessionIdHash:
+                    hashConversationSessionId(effectiveSessionId),
+            }
+            : {}),
+    };
+}
+
+function conversationCacheDiagnostics(
+    coordinator: ConversationCoordinator,
+    provider: AiSessionProviderId,
+    sessionId: string
+): Partial<SanitizedConversationDiagnostic> {
+    try {
+        return {
+            ...(coordinator.readCacheDiagnostics(provider, sessionId) || {}),
+        };
+    } catch (_error) {
+        return {};
+    }
+}
+
 function conversationFollowNoticeText(
     result: 'empty' | 'unavailable' | 'unknownSession'
 ): string {
@@ -1434,13 +1513,15 @@ function conversationFollowNoticeText(
 function reportFollowFailure(
     onDiagnostic: ConversationCapabilityOptions['onDiagnostic'],
     provider: AiSessionProviderId,
-    result: 'empty' | 'unavailable' | 'unknownSession'
+    result: 'empty' | 'unavailable' | 'unknownSession',
+    detail?: Partial<SanitizedConversationDiagnostic>
 ): void {
     try {
         onDiagnostic({
             event: 'conversation-follow',
             category: result,
             provider,
+            ...detail,
         });
     } catch (_error) {
         // Optional diagnostics never block Dashboard activation.

--- a/src/aiSessions/conversation/coordinator.ts
+++ b/src/aiSessions/conversation/coordinator.ts
@@ -19,6 +19,7 @@ import {
     ConversationFileDiff,
     ConversationMessage,
     ConversationOutline,
+    ConversationCacheDiagnostics,
     ConversationPage,
     ConversationPageRequest,
     ConversationProviderAdapter,
@@ -182,6 +183,17 @@ export class ConversationCoordinator implements AiSessionDisposable {
             };
         } catch (error) {
             throw this.toSafeError(provider, error);
+        }
+    }
+
+    readCacheDiagnostics(
+        provider: AiSessionProviderId,
+        sessionId: string
+    ): ConversationCacheDiagnostics | undefined {
+        try {
+            return this.getAdapter(provider).getCacheDiagnostics?.(sessionId);
+        } catch (_error) {
+            return undefined;
         }
     }
 

--- a/src/aiSessions/conversation/kimiAdapter.ts
+++ b/src/aiSessions/conversation/kimiAdapter.ts
@@ -40,6 +40,7 @@ import { synthesizeFragmentDiff, synthesizeFragmentDiffs } from './diffs';
 import {
     CONVERSATION_LIMITS,
     ConversationAbortSignal,
+    ConversationCacheDiagnostics,
     ConversationError,
     ConversationFileDiff,
     ConversationInteraction,
@@ -137,6 +138,8 @@ interface KimiConversationIndex extends AiSessionDisposable {
     /** approval request id → gated tool_call_id, for ApprovalResponse. */
     approvalTracker?: Map<string, string>;
     pendingThinking?: { position: number; text: string } | null;
+    /** Whether the most recent load read incrementally from the cache. */
+    lastReadContinuation: boolean;
     revision: number;
     partial: boolean;
 }
@@ -377,6 +380,7 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
     private readonly cache: ConversationIndexCache<KimiConversationIndex>;
     private readonly subscriptions = new Map<string, Set<() => void>>();
     private readonly revisionCounters = new Map<string, number>();
+    private readonly loadQueues = new Map<string, Promise<void>>();
     private providerWatch?: AiSessionDisposable;
     private invalidationTimer?: TimerHandle;
     private disposed = false;
@@ -586,9 +590,48 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
         this.subscriptions.clear();
         this.cache.clear();
         this.revisionCounters.clear();
+        this.loadQueues.clear();
     }
 
-    private async load(
+    getCacheDiagnostics(
+        sessionId: string
+    ): ConversationCacheDiagnostics | undefined {
+        const entry = this.cache.get(sessionId);
+        if (!entry) {
+            return undefined;
+        }
+        return {
+            sourceSize: entry.source.size,
+            cachedNextOffset: entry.nextOffset,
+            cachedInteractions: entry.interactions.length,
+            continuation: entry.lastReadContinuation,
+            partial: entry.partial,
+        };
+    }
+
+    private load(
+        sessionId: string,
+        signal?: ConversationAbortSignal
+    ): Promise<LoadedConversation> {
+        // Warmup, telemetry polls, watch refreshes, and authoritative clicks
+        // share one cache entry per session and each load commits it in
+        // place. Serialize loads so a read can never capture a stale
+        // nextOffset, flip a continuation into a suffix-only cold read, or
+        // overwrite a newer commit with an older one.
+        const queued = this.loadQueues.get(sessionId) || Promise.resolve();
+        const run = queued.then(() => this.loadExclusive(sessionId, signal));
+        // A rejected load must not jam the queue for the next caller.
+        const settled = run.then(() => undefined, () => undefined);
+        this.loadQueues.set(sessionId, settled);
+        void settled.then(() => {
+            if (this.loadQueues.get(sessionId) === settled) {
+                this.loadQueues.delete(sessionId);
+            }
+        });
+        return run;
+    }
+
+    private async loadExclusive(
         sessionId: string,
         signal?: ConversationAbortSignal
     ): Promise<LoadedConversation> {
@@ -1134,6 +1177,7 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                 previous.questionTracker = questionTracker;
                 previous.approvalTracker = approvalTracker;
                 previous.pendingThinking = pendingThinking;
+                previous.lastReadContinuation = continuing;
                 previous.revision = revision;
                 previous.partial = partial;
             } else {
@@ -1148,6 +1192,7 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                     questionTracker,
                     approvalTracker,
                     pendingThinking,
+                    lastReadContinuation: continuing,
                     revision,
                     partial,
                     dispose() {},

--- a/src/aiSessions/conversation/types.ts
+++ b/src/aiSessions/conversation/types.ts
@@ -289,6 +289,30 @@ export interface SanitizedConversationDiagnostic {
     count?: number;
     durationMs?: number;
     version?: string;
+    /** First 12 hex chars of the sha256 of the clicked session id. */
+    sessionIdHash?: string;
+    /** Present only when a subagent effective id differs from sessionId. */
+    effectiveSessionIdHash?: string;
+    /** Whether the authoritative snapshot came from warmup or a fresh read. */
+    snapshotSource?: 'warm' | 'fresh';
+    /** An empty warm snapshot was discarded and confirmed by a fresh read. */
+    discardedEmptyWarmSnapshot?: boolean;
+    outlineInteractions?: number;
+    sourceRevision?: string;
+    sourceSize?: number;
+    cachedNextOffset?: number;
+    cachedInteractions?: number;
+    continuation?: boolean;
+    partial?: boolean;
+}
+
+/** Read-only cache introspection for diagnosing empty/stale follows. */
+export interface ConversationCacheDiagnostics {
+    sourceSize?: number;
+    cachedNextOffset?: number;
+    cachedInteractions?: number;
+    continuation?: boolean;
+    partial?: boolean;
 }
 
 export interface ConversationAbortSignal {
@@ -368,5 +392,8 @@ export interface ConversationProviderAdapter extends AiSessionDisposable {
         sessionId: string,
         signal?: ConversationAbortSignal
     ): Promise<ConversationTelemetry | undefined>;
+    getCacheDiagnostics?(
+        sessionId: string
+    ): ConversationCacheDiagnostics | undefined;
     watch(sessionId: string, onChange: () => void): AiSessionDisposable;
 }

--- a/tests/contract/aiSessions/kimiConversationAdapter.test.js
+++ b/tests/contract/aiSessions/kimiConversationAdapter.test.js
@@ -2046,3 +2046,158 @@ test('CONVERSATION-WORKLOG-COLLAPSE-001 Kimi stamps completedAt from the last tu
     assert.equal(page.interactionStates[0].timestamp, 1_784_505_600_000);
     assert.equal(page.interactionStates[0].completedAt, 1_784_505_625_000);
 });
+
+function wireTurn(index, input) {
+    const base = 20_000 + index * 10;
+    return [
+        JSON.stringify({ timestamp: base, message: { type: 'TurnBegin',
+            payload: { user_input: input || `turn ${index}` } } }),
+        JSON.stringify({ timestamp: base + 1, message: { type: 'ContentPart',
+            payload: { type: 'text', text: `answer ${index}` } } }),
+        JSON.stringify({ timestamp: base + 2, message: { type: 'TurnEnd',
+            payload: {} } }),
+        '',
+    ].join('\n');
+}
+
+test('CONVERSATION-CACHE-CONVERGENCE-001 racing incremental reads never truncate the cached outline', async t => {
+    const source = await createFixture(t);
+    await fs.promises.writeFile(
+        source.sourcePath,
+        [0, 1, 2].map(index => wireTurn(index)).join('')
+    );
+    const adapter = createAdapter(source);
+    t.after(() => adapter.dispose());
+
+    const initial = await adapter.readOutline(sessionId);
+    assert.equal(initial.interactions.length, 3);
+
+    const tick = () => new Promise(resolve => setImmediate(resolve));
+    let expected = 3;
+    for (let round = 0; round < 12; round += 1) {
+        expected += 1;
+        await fs.promises.appendFile(
+            source.sourcePath,
+            wireTurn(100 + round)
+        );
+        // Warmup, telemetry polls, watch refreshes, and authoritative clicks
+        // all share the per-session cache. Stagger a wave of reads so some
+        // of them commit while others are mid-read.
+        const wave = [];
+        for (let stagger = 0; stagger < 5; stagger += 1) {
+            wave.push((async () => {
+                for (let pause = 0; pause < stagger; pause += 1) {
+                    await tick();
+                }
+                return stagger % 2 === 0
+                    ? adapter.readOutline(sessionId)
+                    : adapter.readSnapshot(sessionId);
+            })());
+        }
+        const results = await Promise.all(wave);
+        for (const result of results) {
+            const outline = result.outline || result;
+            assert.equal(
+                outline.interactions.length,
+                expected,
+                `round ${round} returned a truncated outline`
+            );
+        }
+    }
+
+    const truth = createAdapter(source);
+    t.after(() => truth.dispose());
+    const expectedOutline = await truth.readOutline(sessionId);
+    const converged = await adapter.readOutline(sessionId);
+    assert.deepEqual(
+        converged.interactions.map(item => item.id),
+        expectedOutline.interactions.map(item => item.id)
+    );
+});
+
+test('CONVERSATION-CACHE-CONVERGENCE-001 an empty source picks up appended turns on the next read', async t => {
+    const source = await createFixture(t);
+    // A brand-new Kimi session starts with only the metadata record.
+    await fs.promises.writeFile(
+        source.sourcePath,
+        `${JSON.stringify({ type: 'metadata', protocol_version: '1.10' })}\n`
+    );
+    const adapter = createAdapter(source);
+    t.after(() => adapter.dispose());
+
+    const empty = await adapter.readOutline(sessionId);
+    assert.equal(empty.interactions.length, 0);
+
+    await fs.promises.appendFile(source.sourcePath, wireTurn(1, 'first turn'));
+    const grown = await adapter.readOutline(sessionId);
+    assert.deepEqual(
+        grown.interactions.map(item => item.userPreview),
+        ['first turn']
+    );
+});
+
+test('CONVERSATION-CACHE-CONVERGENCE-001 replaced or truncated sources are cold re-read', async t => {
+    const source = await createFixture(t);
+    await fs.promises.writeFile(
+        source.sourcePath,
+        [0, 1, 2].map(index => wireTurn(index)).join('')
+    );
+    const adapter = createAdapter(source);
+    t.after(() => adapter.dispose());
+    assert.equal((await adapter.readOutline(sessionId)).interactions.length, 3);
+
+    // Atomic replacement swaps the inode: the cache must cold re-read.
+    const replacementPath = path.join(source.providerHome, 'wire.jsonl.next');
+    await fs.promises.writeFile(
+        replacementPath,
+        wireTurn(7, 'replacement turn')
+    );
+    await fs.promises.rename(replacementPath, source.sourcePath);
+    const replaced = await adapter.readOutline(sessionId);
+    assert.deepEqual(
+        replaced.interactions.map(item => item.userPreview),
+        ['replacement turn']
+    );
+
+    // Truncation shrinks the file in place: the cache must cold re-read too.
+    await fs.promises.writeFile(source.sourcePath, wireTurn(9, 'truncated turn'));
+    const truncated = await adapter.readOutline(sessionId);
+    assert.deepEqual(
+        truncated.interactions.map(item => item.userPreview),
+        ['truncated turn']
+    );
+});
+
+test('CONVERSATION-FOLLOW-DIAGNOSTICS-001 Kimi exposes sanitized cache diagnostics for empty follows', async t => {
+    const source = await createFixture(t);
+    await fs.promises.writeFile(
+        source.sourcePath,
+        [0, 1].map(index => wireTurn(index)).join('')
+    );
+    const adapter = createAdapter(source);
+    t.after(() => adapter.dispose());
+
+    assert.equal(adapter.getCacheDiagnostics(sessionId), undefined);
+
+    await adapter.readOutline(sessionId);
+    const cold = adapter.getCacheDiagnostics(sessionId);
+    assert.deepEqual(Object.keys(cold).sort(), [
+        'cachedInteractions',
+        'cachedNextOffset',
+        'continuation',
+        'partial',
+        'sourceSize',
+    ]);
+    assert.equal(cold.cachedInteractions, 2);
+    assert.equal(cold.cachedNextOffset, fs.statSync(source.sourcePath).size);
+    assert.equal(cold.sourceSize, fs.statSync(source.sourcePath).size);
+    assert.equal(cold.continuation, false);
+    assert.equal(cold.partial, false);
+
+    await fs.promises.appendFile(source.sourcePath, wireTurn(2));
+    await adapter.readOutline(sessionId);
+    const incremental = adapter.getCacheDiagnostics(sessionId);
+    assert.equal(incremental.continuation, true);
+    assert.equal(incremental.cachedInteractions, 3);
+    assert.equal(incremental.cachedNextOffset, fs.statSync(source.sourcePath).size);
+});

--- a/tests/integration/dashboard/conversationOpenLatest.test.js
+++ b/tests/integration/dashboard/conversationOpenLatest.test.js
@@ -1,10 +1,15 @@
 'use strict';
 
 const assert = require('node:assert/strict');
+const { createHash } = require('node:crypto');
 const fs = require('node:fs');
 const Module = require('node:module');
 const path = require('node:path');
 const test = require('node:test');
+
+function hashSessionId(value) {
+    return createHash('sha256').update(value).digest('hex').slice(0, 12);
+}
 
 function fakeUri(value) {
     return {
@@ -186,6 +191,9 @@ function createHarness(options = {}) {
         async readPage() {
             throw new Error('readPage is not used by openLatestConversation');
         },
+        ...(options.cacheDiagnostics ? {
+            getCacheDiagnostics: () => options.cacheDiagnostics,
+        } : {}),
         watch() {
             return { dispose() {} };
         },
@@ -1000,7 +1008,85 @@ test('CONVERSATION-FOLLOW-FEEDBACK-001 surfaces an in-panel notice and sanitized
         event: 'conversation-follow',
         category: 'empty',
         provider: 'codex',
+        sessionIdHash: hashSessionId('session-a'),
+        snapshotSource: 'fresh',
+        discardedEmptyWarmSnapshot: false,
+        outlineInteractions: 0,
+        sourceRevision: 'r1',
     }]);
+    harness.capability.dispose();
+});
+
+test('CONVERSATION-FOLLOW-DIAGNOSTICS-001 an empty follow reports warm provenance and sanitized cache state', async () => {
+    const sessions = ['codex', 'kimi'].map((provider, index) => makeSession({
+        key: `${provider}:session-${index}`,
+        provider,
+        sessionId: `session-${index}`,
+        name: `${provider} Session`,
+    }));
+    const diagnostics = [];
+    const harness = createHarness({
+        enableSnapshots: true,
+        viewerOpen: true,
+        session: sessions[0],
+        resolveTarget: (_projectId, provider, sessionId) =>
+            sessions.find(session => session.provider === provider
+                && session.sessionId === sessionId) || null,
+        resolveActiveTargets: () => sessions,
+        readSnapshot: async (provider, sessionId) => {
+            if (provider === 'kimi') {
+                return { outline: makeOutline(provider, sessionId, []) };
+            }
+            return {
+                outline: makeOutline(provider, sessionId, ['input-a']),
+                page: makePage(provider, sessionId, 'input-a'),
+            };
+        },
+        cacheDiagnostics: {
+            cachedInteractions: 0,
+            cachedNextOffset: 4096,
+            continuation: true,
+            partial: false,
+            sourceSize: 4096,
+        },
+        onDiagnostic: event => diagnostics.push(event),
+    });
+
+    assert.equal(await harness.capability.openLatestConversation({
+        projectId: 'project-a',
+        provider: 'codex',
+        sessionId: 'session-0',
+    }), 'opened');
+    while (!harness.snapshotReadTargets.includes('kimi:session-1')) {
+        await new Promise(resolve => setImmediate(resolve));
+    }
+
+    assert.equal(await harness.capability.followActiveConversation({
+        projectId: 'project-a',
+        provider: 'kimi',
+        sessionId: 'session-1',
+    }), 'empty');
+    assert.deepEqual(harness.viewerNotices, [
+        'This AI session has no conversation yet.',
+    ]);
+    assert.deepEqual(
+        diagnostics.find(event => event.event === 'conversation-follow'),
+        {
+            event: 'conversation-follow',
+            category: 'empty',
+            provider: 'kimi',
+            sessionIdHash: hashSessionId('session-1'),
+            snapshotSource: 'fresh',
+            discardedEmptyWarmSnapshot: true,
+            outlineInteractions: 0,
+            sourceRevision: 'r1',
+            cachedInteractions: 0,
+            cachedNextOffset: 4096,
+            continuation: true,
+            partial: false,
+            sourceSize: 4096,
+        }
+    );
     harness.capability.dispose();
 });
 
@@ -1024,11 +1110,26 @@ test('CONVERSATION-FOLLOW-FEEDBACK-001 surfaces a retry hint notice when a follo
         event: 'conversation-follow',
         category: 'unavailable',
         provider: 'codex',
+        sessionIdHash: hashSessionId('session-a'),
     });
+    const allowedKeys = new Set([
+        'event', 'category', 'provider', 'count', 'durationMs', 'version',
+        'sessionIdHash', 'effectiveSessionIdHash', 'snapshotSource',
+        'discardedEmptyWarmSnapshot', 'outlineInteractions', 'sourceRevision',
+        'sourceSize', 'cachedNextOffset', 'cachedInteractions',
+        'continuation', 'partial',
+    ]);
     for (const event of diagnostics) {
-        assert.deepEqual(Object.keys(event).sort(), [
-            'category', 'event', 'provider',
-        ], 'follow diagnostics must stay sanitized');
+        for (const key of Object.keys(event)) {
+            assert.ok(
+                allowedKeys.has(key),
+                `follow diagnostics must stay sanitized, found ${key}`
+            );
+        }
+        assert.ok(
+            !JSON.stringify(event).includes('session-a'),
+            'raw session identifiers must stay out of follow diagnostics'
+        );
     }
     harness.capability.dispose();
 });
@@ -1053,6 +1154,7 @@ test('CONVERSATION-FOLLOW-FEEDBACK-001 surfaces a notice when the followed sessi
         event: 'conversation-follow',
         category: 'unknownSession',
         provider: 'claude',
+        sessionIdHash: hashSessionId('session-a'),
     }]);
     harness.capability.dispose();
 });


### PR DESCRIPTION
## Summary

Fixes a live incident where a healthy, non-empty Kimi session was persistently misreported as "This AI session has no conversation yet." (`conversation-follow / category: empty / provider: kimi` on every click) while a fresh adapter read the same `wire.jsonl` fine.

**Root cause:** warmup, telemetry polls, watch refreshes, and authoritative clicks all share one `KimiConversationIndex` entry per session, and every `load()` committed that entry in place with no ordering. A read that captured the cached `nextOffset` before a racing commit but re-checked it afterwards flipped its continuation decision, re-read a suffix of `wire.jsonl` as if it were the whole file, and wrote the truncated index back with an end-of-file offset. Every later incremental read returned empty, and each click refreshed the poisoned entry's TTL so it never self-healed.

**Fix:**
- Serialize `KimiConversationAdapter.load()` per session id on a rejection-tolerant promise chain, so every read observes a fully committed entry.
- Record `lastReadContinuation` and expose sanitized `getCacheDiagnostics` (source size, cached offset, cached interaction count, continuation, partial) through a new optional adapter method + coordinator passthrough.
- Enrich `conversation-follow` failure diagnostics with session id hashes, warm/fresh provenance, the discarded-empty-warm flag, outline size, source revision, and the cache state above — a genuinely empty session is now distinguishable from a diverged cache in the local log, with tests pinning that no raw identifiers, paths, or content leak.

**Known follow-ups (not in this PR):**
- `claudeAdapter.ts` has the identical unguarded in-place commit pattern and gets the same serialization treatment next.
- Oversized single interactions (>512KB serialized) still throw `tooLarge` and surface as unavailable; deterministic per-interaction content convergence is a separate PR.

**Behaviors:** `CONVERSATION-CACHE-CONVERGENCE-001` (P0), `CONVERSATION-FOLLOW-DIAGNOSTICS-001` (P1). RED evidence: the staggered-wave race test fails on unfixed code within the first round (3/3 runs, truncated `1 !== 4`); recovery guards and diagnostic-shape tests pass only with the fix.

## Skill harvest

updated .skills/developing-provider-conversation-adapters — recorded the incremental-cache concurrency hazard (in-place commits need per-session serialization) and the staggered-wave RED construction, verified against real on-disk Kimi sessions. Recorded as the `Skill-Harvest` trailer of the capability audit commit.

## Verification

- RED before fix: `node --test tests/contract/aiSessions/kimiConversationAdapter.test.js` — race test fails 3/3 with truncated outline; `getCacheDiagnostics` absent; follow-diagnostic shape tests fail.
- GREEN after fix: focused contract (35) + integration (43) pass; race test stable 5/5; full `npm run test:deterministic:run` 413/413.
- `npm run test:behavior-contracts`, `npm run lint`, `npm run test:architecture-guards`, `npm run test:skills`, `git diff --check` all pass.
- Real-data validation with the compiled adapter against the two incident sessions on disk (`409493a4…` live-growing, `70ce2ce2…` 14.5MB): cold reads + staggered concurrent waves + append waves all converge to cold-read truth; cache diagnostics report expected values.
