### PR TITLE
fix: serialize Claude conversation loads per session

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -4956,10 +4956,12 @@
     "priority": "P0",
     "status": "automated",
     "owners": [
-      "tests/contract/aiSessions/kimiConversationAdapter.test.js"
+      "tests/contract/aiSessions/kimiConversationAdapter.test.js",
+      "tests/contract/aiSessions/claudeConversationAdapter.test.js"
     ],
     "evidence": [
-      "src/aiSessions/conversation/kimiAdapter.ts"
+      "src/aiSessions/conversation/kimiAdapter.ts",
+      "src/aiSessions/conversation/claudeAdapter.ts"
     ]
   },
   {
@@ -4970,12 +4972,14 @@
     "status": "automated",
     "owners": [
       "tests/integration/dashboard/conversationOpenLatest.test.js",
-      "tests/contract/aiSessions/kimiConversationAdapter.test.js"
+      "tests/contract/aiSessions/kimiConversationAdapter.test.js",
+      "tests/contract/aiSessions/claudeConversationAdapter.test.js"
     ],
     "evidence": [
       "src/aiSessions/conversation/composition.ts",
       "src/aiSessions/conversation/coordinator.ts",
       "src/aiSessions/conversation/kimiAdapter.ts",
+      "src/aiSessions/conversation/claudeAdapter.ts",
       "src/aiSessions/conversation/types.ts"
     ]
   },

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "aecacbe0c6edaf93832ead08b5b279a9731d1355",
+        "head": "ff7661f3f9116753719003fd6a9072b1a13ff442",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -290,7 +290,8 @@
             "f83afd43b4cf0781339818992498d673a1b83411",
             "8d354e7c2d1e7a7ff528e6ed2dfd495a37a19415",
             "bf5af003d36a5f5e813df7802762e75a3ab2215e",
-            "8a289bd48012003108121fb5d491fbb730807dca"
+            "8a289bd48012003108121fb5d491fbb730807dca",
+            "1af3c8bb4e04601e75d8eb163c5e8834b8790abc"
         ]
     },
     "capabilities": [
@@ -1637,7 +1638,8 @@
                 "ed74fee09373347dad2da1bb17493d5fbf960d4c",
                 "2accfd46a0909f5e810ef6484d42677868c952e1",
                 "7471ec6d918175b048f962cddc2c8e374dae7390",
-                "aecacbe0c6edaf93832ead08b5b279a9731d1355"
+                "aecacbe0c6edaf93832ead08b5b279a9731d1355",
+                "ff7661f3f9116753719003fd6a9072b1a13ff442"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",

--- a/src/aiSessions/conversation/claudeAdapter.ts
+++ b/src/aiSessions/conversation/claudeAdapter.ts
@@ -37,6 +37,7 @@ import { synthesizeFragmentDiff } from './diffs';
 import {
     CONVERSATION_LIMITS,
     ConversationAbortSignal,
+    ConversationCacheDiagnostics,
     ConversationError,
     ConversationFileDiff,
     ConversationInteraction,
@@ -103,6 +104,8 @@ interface ClaudeConversationIndex extends AiSessionDisposable {
     toolTracker?: ToolCallTracker;
     /** tool_use id → question block, for tool_result answer pairing. */
     questionTracker?: Map<string, ConversationQuestionBlock>;
+    /** Whether the most recent load read incrementally from the cache. */
+    lastReadContinuation: boolean;
     revision: number;
     partial: boolean;
 }
@@ -352,6 +355,7 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
     private readonly cache: ConversationIndexCache<ClaudeConversationIndex>;
     private readonly subscriptions = new Map<string, Set<() => void>>();
     private readonly revisionCounters = new Map<string, number>();
+    private readonly loadQueues = new Map<string, Promise<void>>();
     private providerWatch?: AiSessionDisposable;
     private invalidationTimer?: TimerHandle;
     private disposed = false;
@@ -567,9 +571,48 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
         this.subscriptions.clear();
         this.cache.clear();
         this.revisionCounters.clear();
+        this.loadQueues.clear();
     }
 
-    private async load(
+    getCacheDiagnostics(
+        sessionId: string
+    ): ConversationCacheDiagnostics | undefined {
+        const entry = this.cache.get(sessionId);
+        if (!entry) {
+            return undefined;
+        }
+        return {
+            sourceSize: entry.source.size,
+            cachedNextOffset: entry.nextOffset,
+            cachedInteractions: entry.interactions.length,
+            continuation: entry.lastReadContinuation,
+            partial: entry.partial,
+        };
+    }
+
+    private load(
+        sessionId: string,
+        signal?: ConversationAbortSignal
+    ): Promise<LoadedConversation> {
+        // Warmup, telemetry polls, watch refreshes, and authoritative clicks
+        // share one cache entry per session and each load commits it in
+        // place. Serialize loads so a read can never capture a stale
+        // nextOffset, flip a continuation into a suffix-only cold read, or
+        // overwrite a newer commit with an older one.
+        const queued = this.loadQueues.get(sessionId) || Promise.resolve();
+        const run = queued.then(() => this.loadExclusive(sessionId, signal));
+        // A rejected load must not jam the queue for the next caller.
+        const settled = run.then(() => undefined, () => undefined);
+        this.loadQueues.set(sessionId, settled);
+        void settled.then(() => {
+            if (this.loadQueues.get(sessionId) === settled) {
+                this.loadQueues.delete(sessionId);
+            }
+        });
+        return run;
+    }
+
+    private async loadExclusive(
         sessionId: string,
         signal?: ConversationAbortSignal
     ): Promise<LoadedConversation> {
@@ -901,6 +944,7 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
                 previous.telemetryGitBranch = telemetryGitBranch;
                 previous.toolTracker = toolTracker;
                 previous.questionTracker = questionTracker;
+                previous.lastReadContinuation = continuing;
                 previous.revision = revision;
                 previous.partial = partial;
             } else {
@@ -915,6 +959,7 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
                     telemetryGitBranch,
                     toolTracker,
                     questionTracker,
+                    lastReadContinuation: continuing,
                     revision,
                     partial,
                     dispose() {},

--- a/tests/contract/aiSessions/claudeConversationAdapter.test.js
+++ b/tests/contract/aiSessions/claudeConversationAdapter.test.js
@@ -1644,3 +1644,160 @@ test('CONVERSATION-WORKLOG-COLLAPSE-001 Claude stamps completedAt from the last 
         Date.parse('2026-08-01T10:05:03.000Z')
     );
 });
+
+function claudeWireTurn(index, input) {
+    const base = new Date(1_800_000_000_000 + index * 10_000).toISOString();
+    return [
+        JSON.stringify({ type: 'user', uuid: `race-user-${index}`,
+            timestamp: base,
+            message: { role: 'user', content: input || `turn ${index}` } }),
+        JSON.stringify({ type: 'assistant', uuid: `race-assistant-${index}`,
+            timestamp: base,
+            message: { role: 'assistant', content: `answer ${index}` } }),
+        '',
+    ].join('\n');
+}
+
+test('CONVERSATION-CACHE-CONVERGENCE-001 Claude racing incremental reads never truncate the cached outline', async t => {
+    const source = await createFixture(t);
+    await fs.promises.writeFile(
+        source.sourcePath,
+        [0, 1, 2].map(index => claudeWireTurn(index)).join('')
+    );
+    const adapter = createAdapter(source);
+    t.after(() => adapter.dispose());
+
+    const initial = await adapter.readOutline(sessionId);
+    assert.equal(initial.interactions.length, 3);
+
+    const tick = () => new Promise(resolve => setImmediate(resolve));
+    let expected = 3;
+    for (let round = 0; round < 12; round += 1) {
+        expected += 1;
+        await fs.promises.appendFile(
+            source.sourcePath,
+            claudeWireTurn(100 + round)
+        );
+        // Warmup, telemetry polls, watch refreshes, and authoritative clicks
+        // all share the per-session cache. Stagger a wave of reads so some
+        // of them commit while others are mid-read.
+        const wave = [];
+        for (let stagger = 0; stagger < 5; stagger += 1) {
+            wave.push((async () => {
+                for (let pause = 0; pause < stagger; pause += 1) {
+                    await tick();
+                }
+                return stagger % 2 === 0
+                    ? adapter.readOutline(sessionId)
+                    : adapter.readSnapshot(sessionId);
+            })());
+        }
+        const results = await Promise.all(wave);
+        for (const result of results) {
+            const outline = result.outline || result;
+            assert.equal(
+                outline.interactions.length,
+                expected,
+                `round ${round} returned a truncated outline`
+            );
+        }
+    }
+
+    const truth = createAdapter(source);
+    t.after(() => truth.dispose());
+    const expectedOutline = await truth.readOutline(sessionId);
+    const converged = await adapter.readOutline(sessionId);
+    assert.deepEqual(
+        converged.interactions.map(item => item.id),
+        expectedOutline.interactions.map(item => item.id)
+    );
+});
+
+test('CONVERSATION-CACHE-CONVERGENCE-001 Claude an empty source picks up appended turns on the next read', async t => {
+    const source = await createFixture(t);
+    await fs.promises.writeFile(source.sourcePath, '');
+    const adapter = createAdapter(source);
+    t.after(() => adapter.dispose());
+
+    const empty = await adapter.readOutline(sessionId);
+    assert.equal(empty.interactions.length, 0);
+
+    await fs.promises.appendFile(
+        source.sourcePath,
+        claudeWireTurn(1, 'first turn')
+    );
+    const grown = await adapter.readOutline(sessionId);
+    assert.deepEqual(
+        grown.interactions.map(item => item.userPreview),
+        ['first turn']
+    );
+});
+
+test('CONVERSATION-CACHE-CONVERGENCE-001 Claude replaced or truncated sources are cold re-read', async t => {
+    const source = await createFixture(t);
+    await fs.promises.writeFile(
+        source.sourcePath,
+        [0, 1, 2].map(index => claudeWireTurn(index)).join('')
+    );
+    const adapter = createAdapter(source);
+    t.after(() => adapter.dispose());
+    assert.equal((await adapter.readOutline(sessionId)).interactions.length, 3);
+
+    // Atomic replacement swaps the inode: the cache must cold re-read.
+    const replacementPath = path.join(source.providerHome, 'session.jsonl.next');
+    await fs.promises.writeFile(
+        replacementPath,
+        claudeWireTurn(7, 'replacement turn')
+    );
+    await fs.promises.rename(replacementPath, source.sourcePath);
+    const replaced = await adapter.readOutline(sessionId);
+    assert.deepEqual(
+        replaced.interactions.map(item => item.userPreview),
+        ['replacement turn']
+    );
+
+    // Truncation shrinks the file in place: the cache must cold re-read too.
+    await fs.promises.writeFile(
+        source.sourcePath,
+        claudeWireTurn(9, 'truncated turn')
+    );
+    const truncated = await adapter.readOutline(sessionId);
+    assert.deepEqual(
+        truncated.interactions.map(item => item.userPreview),
+        ['truncated turn']
+    );
+});
+
+test('CONVERSATION-FOLLOW-DIAGNOSTICS-001 Claude exposes sanitized cache diagnostics for empty follows', async t => {
+    const source = await createFixture(t);
+    await fs.promises.writeFile(
+        source.sourcePath,
+        [0, 1].map(index => claudeWireTurn(index)).join('')
+    );
+    const adapter = createAdapter(source);
+    t.after(() => adapter.dispose());
+
+    assert.equal(adapter.getCacheDiagnostics(sessionId), undefined);
+
+    await adapter.readOutline(sessionId);
+    const cold = adapter.getCacheDiagnostics(sessionId);
+    assert.deepEqual(Object.keys(cold).sort(), [
+        'cachedInteractions',
+        'cachedNextOffset',
+        'continuation',
+        'partial',
+        'sourceSize',
+    ]);
+    assert.equal(cold.cachedInteractions, 2);
+    assert.equal(cold.cachedNextOffset, fs.statSync(source.sourcePath).size);
+    assert.equal(cold.sourceSize, fs.statSync(source.sourcePath).size);
+    assert.equal(cold.continuation, false);
+    assert.equal(cold.partial, false);
+
+    await fs.promises.appendFile(source.sourcePath, claudeWireTurn(2));
+    await adapter.readOutline(sessionId);
+    const incremental = adapter.getCacheDiagnostics(sessionId);
+    assert.equal(incremental.continuation, true);
+    assert.equal(incremental.cachedInteractions, 3);
+    assert.equal(incremental.cachedNextOffset, fs.statSync(source.sourcePath).size);
+});


### PR DESCRIPTION
## Summary

Follow-up to #231 (merged): `claudeAdapter.ts` had the identical unguarded in-place cache commit pattern fixed for Kimi there — a load capturing the cached `nextOffset` before a racing commit but re-checking it afterwards flips its continuation decision, re-reads a transcript suffix as if it were the whole file, and writes the truncated index back with an end-of-file offset. A healthy Claude session then reports "no conversation yet" forever while clicks refresh the poisoned entry's TTL.

**Fix (mirrors #231):**
- Serialize `ClaudeConversationAdapter.load()` per session id on a rejection-tolerant promise chain.
- Record `lastReadContinuation` and implement the sanitized `getCacheDiagnostics` introspection from #231, so empty Claude follows carry the same diagnosable cache state.
- `CONVERSATION-CACHE-CONVERGENCE-001` and `CONVERSATION-FOLLOW-DIAGNOSTICS-001` gain Claude owners/evidence.

RED evidence: the staggered-wave race test fails on the unfixed adapter (truncated outline in the first rounds); recovery guards pass pre-fix and pin the required append/replace/truncate semantics.

## Skill harvest

no skill change — the incremental-cache concurrency lesson was already recorded into `.skills/developing-provider-conversation-adapters` by #231; this branch adds no new workflow friction. Recorded as the `Skill-Harvest` trailer of the capability audit commit.

## Verification

- RED before fix: Claude race test fails with truncated outline; `getCacheDiagnostics` absent.
- GREEN after fix: focused contract suite 31/31; race test stable 3/3; full `npm run test:deterministic:run` 413/413.
- `npm run test:behavior-contracts`, `npm run lint`, `npm run test:architecture-guards`, `git diff --check` all pass.
- Real-data validation with the compiled adapter against real on-disk Claude sessions (16MB/49 turns, 23MB/215 turns): cold reads + staggered concurrent waves + append waves all converge to cold-read truth; cache diagnostics report expected values.
