### PR TITLE
fix: converge oversized conversation turns instead of failing the read

### DIFF
--- a/.skills/developing-provider-conversation-adapters/SKILL.md
+++ b/.skills/developing-provider-conversation-adapters/SKILL.md
@@ -130,3 +130,24 @@ within the first waves while the serialized fix is deterministically
 green. Record `lastReadContinuation` on the entry and expose
 `getCacheDiagnostics` so an empty follow is diagnosable from the local
 log without raw identifiers.
+
+## Page-Budget Convergence and Endpoint-Less Turns
+
+Per-field caps (64k-grapheme messages, 4k tool details) do NOT bound an
+interaction's aggregate size: 100+ tool calls or merged thinking runs sum
+past `maxPageBytes`, and `buildConversationPage` used to have no
+in-interaction lever — it threw `tooLarge` and the whole conversation
+reported unavailable. Converge inside the interaction instead: keep the
+user message and the latest assistant/plan/question endpoints, truncate
+only allowlisted content fields (`markdown`/`text`/`detail`/`question`/
+`label`/`description`/`otherLabel` — never tool names, diff paths, plan
+file paths, or outcomes), insert an explicit omission notice, and
+backfill the tail greedily. Two calibration lessons from real incident
+data: (1) size synthetic oversized fixtures empirically — per-field caps
+shrink naive fixtures below the page budget (130 capped 4KB tool details
+≈ 504KB < 510KB; 160 needed), so measure the built block before trusting
+a RED; (2) real sessions contain complete turns with NO
+assistant/plan/question message at all (orchestrator turns whose content
+lives in provider events the adapter skips) — endpoint preservation must
+fall back to the turn's last message or those turns render as a bare
+omission.

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -4984,6 +4984,23 @@
     ]
   },
   {
+    "id": "CONVERSATION-OVERSIZED-TURN-001",
+    "domain": "session",
+    "title": "A single turn whose serialized content exceeds the page budget is deterministically converged instead of failing the whole read: the user input and the final assistant, plan, and question endpoints stay visible with tool, diff, and plan identities intact, oversized tool output, diff, thinking, and progress content is byte-truncated or replaced by an explicit omission notice, the page always fits the protocol budget, and the outline keeps every interaction",
+    "priority": "P0",
+    "status": "automated",
+    "owners": [
+      "tests/unit/aiSessions/conversationModel.test.js",
+      "tests/unit/aiSessions/conversationText.test.js",
+      "tests/contract/aiSessions/kimiConversationAdapter.test.js",
+      "tests/integration/dashboard/conversationViewer.test.js"
+    ],
+    "evidence": [
+      "src/aiSessions/conversation/model.ts",
+      "src/aiSessions/conversation/text.ts"
+    ]
+  },
+  {
     "id": "CONVERSATION-LIVE-UPDATE-JOURNEY-001",
     "domain": "webview",
     "title": "A live response preserves telemetry, follows from the end, preserves historical reading position, and transitions Working to complete without a manual new-content control",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "ff7661f3f9116753719003fd6a9072b1a13ff442",
+        "head": "484a18e4318a67ea65b9d3fbfc16d6ef70f9c0db",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -291,7 +291,8 @@
             "8d354e7c2d1e7a7ff528e6ed2dfd495a37a19415",
             "bf5af003d36a5f5e813df7802762e75a3ab2215e",
             "8a289bd48012003108121fb5d491fbb730807dca",
-            "1af3c8bb4e04601e75d8eb163c5e8834b8790abc"
+            "1af3c8bb4e04601e75d8eb163c5e8834b8790abc",
+            "215eb2dd8e0e9c58dbe9f3a331a4915817321e23"
         ]
     },
     "capabilities": [
@@ -1639,7 +1640,8 @@
                 "2accfd46a0909f5e810ef6484d42677868c952e1",
                 "7471ec6d918175b048f962cddc2c8e374dae7390",
                 "aecacbe0c6edaf93832ead08b5b279a9731d1355",
-                "ff7661f3f9116753719003fd6a9072b1a13ff442"
+                "ff7661f3f9116753719003fd6a9072b1a13ff442",
+                "484a18e4318a67ea65b9d3fbfc16d6ef70f9c0db"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",
@@ -1689,7 +1691,8 @@
                 "CONVERSATION-FOLLOW-FEEDBACK-001",
                 "CONVERSATION-SESSION-STATUS-001",
                 "CONVERSATION-CACHE-CONVERGENCE-001",
-                "CONVERSATION-FOLLOW-DIAGNOSTICS-001"
+                "CONVERSATION-FOLLOW-DIAGNOSTICS-001",
+                "CONVERSATION-OVERSIZED-TURN-001"
             ],
             "prGates": [
                 "test:ci:linux"

--- a/src/aiSessions/conversation/model.ts
+++ b/src/aiSessions/conversation/model.ts
@@ -13,11 +13,16 @@ import {
     ConversationPageRequest,
     ConversationResponseState,
 } from './types';
+import { truncateUtf8Bytes } from './text';
 
 export type EncodeConversationCursor = (
     anchorInteractionId: string,
     direction: 'before' | 'after'
 ) => string;
+
+const PAGE_ENVELOPE_RESERVE_BYTES = 2 * 1024;
+const OVERSIZED_TURN_OMISSION =
+    'Work was omitted to keep this turn within the conversation size limit.';
 
 export function buildConversationOutline(
     provider: AiSessionProviderId,
@@ -189,6 +194,244 @@ function assistantPhase(
     return interaction.toolCalls?.some(toolCall => toolCall.position > index)
         ? 'progress'
         : 'answer';
+}
+
+function serializedMessageBytes(message: ConversationMessage): number {
+    return Buffer.byteLength(JSON.stringify(message), 'utf8');
+}
+
+/** Free-form display content eligible for byte-budget truncation. */
+const CONTENT_STRING_FIELDS = new Set([
+    'markdown',
+    'text',
+    'detail',
+    'question',
+    'label',
+    'description',
+    'otherLabel',
+]);
+
+function contentStringFields(
+    value: unknown,
+    fields: Array<{
+        get(): string;
+        set(value: string): void;
+    }> = []
+): Array<{ get(): string; set(value: string): void }> {
+    if (!value || typeof value !== 'object') {
+        return fields;
+    }
+    const record = value as Record<string, any>;
+    for (const property of Object.keys(record)) {
+        const child = record[property];
+        if (typeof child === 'string') {
+            // Only content fields shrink. Identifiers and structural
+            // strings (tool names, diff paths, plan file paths, question
+            // sources, outcomes) must survive bounding verbatim.
+            if (CONTENT_STRING_FIELDS.has(property)) {
+                fields.push({
+                    get: () => record[property],
+                    set: next => {
+                        record[property] = next;
+                    },
+                });
+            }
+        } else if (child && typeof child === 'object') {
+            contentStringFields(child, fields);
+        }
+    }
+    return fields;
+}
+
+function boundMessageToBytes(
+    message: ConversationMessage,
+    maxBytes: number
+): ConversationMessage | undefined {
+    const bounded = copyConversationMessage(message);
+    if (serializedMessageBytes(bounded) <= maxBytes) {
+        return bounded;
+    }
+    const fields = contentStringFields(bounded);
+    let minimumFieldBytes = 32;
+    while (serializedMessageBytes(bounded) > maxBytes) {
+        const currentBytes = serializedMessageBytes(bounded);
+        const ratio = Math.max(0.1, Math.min(0.9, maxBytes / currentBytes * 0.9));
+        let changed = false;
+        for (const field of fields) {
+            const value = field.get();
+            const valueBytes = Buffer.byteLength(value, 'utf8');
+            if (valueBytes <= minimumFieldBytes) {
+                continue;
+            }
+            const nextLimit = Math.max(
+                minimumFieldBytes,
+                Math.floor(valueBytes * ratio)
+            );
+            const next = truncateUtf8Bytes(value, nextLimit);
+            if (next !== value) {
+                field.set(next);
+                changed = true;
+            }
+        }
+        if (changed) {
+            continue;
+        }
+        if (minimumFieldBytes > Buffer.byteLength('…', 'utf8')) {
+            minimumFieldBytes = Buffer.byteLength('…', 'utf8');
+            continue;
+        }
+        return undefined;
+    }
+    return bounded;
+}
+
+function semanticEndpointIndices(
+    messages: readonly ConversationMessage[]
+): number[] {
+    const latestByRole = new Map<ConversationMessage['role'], number>();
+    for (let index = 1; index < messages.length; index += 1) {
+        const role = messages[index].role;
+        if (role === 'assistant' || role === 'question' || role === 'plan') {
+            latestByRole.set(role, index);
+        }
+    }
+    if (latestByRole.size > 0) {
+        return Array.from(latestByRole.values()).sort((left, right) => left - right);
+    }
+    return messages.length > 1 ? [messages.length - 1] : [];
+}
+
+function allocateMessageBudgets(
+    rawBytes: readonly number[],
+    totalBudget: number
+): number[] {
+    const budgets = Array(rawBytes.length).fill(0) as number[];
+    const unassigned = new Set(rawBytes.map((_bytes, index) => index));
+    let remaining = totalBudget;
+    while (unassigned.size > 0) {
+        const share = Math.floor(remaining / unassigned.size);
+        const fitting = Array.from(unassigned).filter(
+            index => rawBytes[index] <= share
+        );
+        if (fitting.length === 0) {
+            for (const index of unassigned) {
+                budgets[index] = share;
+            }
+            let remainder = remaining - share * unassigned.size;
+            for (const index of unassigned) {
+                if (remainder <= 0) {
+                    break;
+                }
+                budgets[index] += 1;
+                remainder -= 1;
+            }
+            break;
+        }
+        for (const index of fitting) {
+            budgets[index] = rawBytes[index];
+            remaining -= rawBytes[index];
+            unassigned.delete(index);
+        }
+    }
+    return budgets;
+}
+
+/**
+ * Deterministically converges one interaction's messages into the page byte
+ * budget: the user input and the latest assistant, plan, and question
+ * endpoints stay visible, everything else is byte-truncated or replaced by
+ * an explicit omission notice. Never throws; the page builder's shrink loop
+ * only decides how many interactions fit, never whether one can.
+ */
+function boundInteractionMessages(
+    messages: readonly ConversationMessage[],
+    state: {
+        interactionId: string;
+        responseState: ConversationResponseState;
+        timestamp?: number;
+        completedAt?: number;
+    },
+    maxBytes: number
+): { messages: ConversationMessage[]; serializedBytes: number } {
+    const serializedMessages = messages.map(message => JSON.stringify(message));
+    const emptyEnvelopeBytes = Buffer.byteLength(JSON.stringify({
+        messages: [],
+        state,
+    }), 'utf8');
+    const fullBytes = emptyEnvelopeBytes + serializedMessages.reduce(
+        (total, message, index) => total
+            + Buffer.byteLength(message, 'utf8')
+            + (index > 0 ? 1 : 0),
+        0
+    );
+    if (fullBytes <= maxBytes) {
+        return { messages: messages.slice(), serializedBytes: fullBytes };
+    }
+
+    const user = messages[0];
+    const endpointIndices = semanticEndpointIndices(messages);
+    const preservedEntries = [
+        ...(user ? [{ index: 0, message: user }] : []),
+        ...endpointIndices.map(index => ({ index, message: messages[index] })),
+    ];
+    const omission: ConversationMessage = {
+        id: `${state.interactionId}:progress:omitted`,
+        interactionId: state.interactionId,
+        role: 'progress',
+        timestamp: user?.timestamp,
+        markdown: OVERSIZED_TURN_OMISSION,
+    };
+    const omissionBytes = serializedMessageBytes(omission);
+    const preservedCount = preservedEntries.length;
+    const contentBudget = Math.max(0,
+        maxBytes - emptyEnvelopeBytes - omissionBytes - preservedCount
+    );
+    const preservedBudgets = allocateMessageBudgets(
+        preservedEntries.map(entry => serializedMessageBytes(entry.message)),
+        contentBudget
+    );
+    const retained = new Map<number, ConversationMessage>();
+    preservedEntries.forEach((entry, entryIndex) => {
+        const bounded = boundMessageToBytes(
+            entry.message,
+            preservedBudgets[entryIndex]
+        );
+        if (bounded) {
+            retained.set(entry.index, bounded);
+        }
+    });
+    const boundedUser = retained.get(0);
+    if (boundedUser) {
+        retained.delete(0);
+    }
+    let serializedBytes = emptyEnvelopeBytes + omissionBytes;
+    if (boundedUser) {
+        serializedBytes += serializedMessageBytes(boundedUser);
+    }
+    for (const message of retained.values()) {
+        serializedBytes += serializedMessageBytes(message);
+    }
+    serializedBytes += retained.size + (boundedUser ? 1 : 0);
+    for (let index = messages.length - 1; index >= (user ? 1 : 0); index -= 1) {
+        if (retained.has(index)) {
+            continue;
+        }
+        const messageBytes = Buffer.byteLength(serializedMessages[index], 'utf8')
+            + 1;
+        if (serializedBytes + messageBytes > maxBytes) {
+            continue;
+        }
+        retained.set(index, messages[index]);
+        serializedBytes += messageBytes;
+    }
+    const bounded = [
+        ...(boundedUser ? [boundedUser] : []),
+        omission,
+        ...Array.from(retained.entries())
+            .sort((left, right) => left[0] - right[0])
+            .map(([, message]) => message),
+    ];
+    return { messages: bounded, serializedBytes };
 }
 
 export function buildConversationPage(
@@ -364,24 +607,26 @@ export function buildConversationPage(
     let estimatedBytes = 0;
     for (let index = start; index < end; index += 1) {
         const interaction = interactions[index];
-        const block = {
-            messages: messagesForInteraction(interaction),
-            state: {
-                interactionId: interaction.id,
-                responseState: interaction.responseState,
-                ...(interaction.timestamp !== undefined
-                    ? { timestamp: interaction.timestamp }
-                    : {}),
-                ...(interaction.completedAt !== undefined
-                    ? { completedAt: interaction.completedAt }
-                    : {}),
-            },
-            serializedBytes: 0,
+        const state = {
+            interactionId: interaction.id,
+            responseState: interaction.responseState,
+            ...(interaction.timestamp !== undefined
+                ? { timestamp: interaction.timestamp }
+                : {}),
+            ...(interaction.completedAt !== undefined
+                ? { completedAt: interaction.completedAt }
+                : {}),
         };
-        block.serializedBytes = Buffer.byteLength(JSON.stringify({
-            messages: block.messages,
-            state: block.state,
-        }), 'utf8');
+        const bounded = boundInteractionMessages(
+            messagesForInteraction(interaction),
+            state,
+            CONVERSATION_LIMITS.maxPageBytes - PAGE_ENVELOPE_RESERVE_BYTES
+        );
+        const block = {
+            messages: bounded.messages,
+            state,
+            serializedBytes: bounded.serializedBytes,
+        };
         blocks.set(index, block);
         estimatedBytes += block.serializedBytes;
     }
@@ -402,7 +647,6 @@ export function buildConversationPage(
         }
         estimatedBytes -= blocks.get(removedIndex)?.serializedBytes || 0;
     };
-    const PAGE_ENVELOPE_RESERVE_BYTES = 2 * 1024;
     while (estimatedBytes
         > CONVERSATION_LIMITS.maxPageBytes - PAGE_ENVELOPE_RESERVE_BYTES
         && end - start > 1) {

--- a/src/aiSessions/conversation/text.ts
+++ b/src/aiSessions/conversation/text.ts
@@ -112,6 +112,31 @@ export function truncateGraphemes(value: string, limit: number): string {
     return source;
 }
 
+export function truncateUtf8Bytes(value: string, limit: number): string {
+    const source = String(value || '');
+    const safeLimit = Math.max(0, Math.floor(limit));
+    if (Buffer.byteLength(source, 'utf8') <= safeLimit) {
+        return source;
+    }
+    const ellipsis = '…';
+    const ellipsisBytes = Buffer.byteLength(ellipsis, 'utf8');
+    if (safeLimit < ellipsisBytes) {
+        return '';
+    }
+    const contentLimit = safeLimit - ellipsisBytes;
+    const parts: string[] = [];
+    let bytes = 0;
+    for (const part of graphemes(source)) {
+        const partBytes = Buffer.byteLength(part, 'utf8');
+        if (bytes + partBytes > contentLimit) {
+            break;
+        }
+        parts.push(part);
+        bytes += partBytes;
+    }
+    return `${parts.join('')}${ellipsis}`;
+}
+
 export function normalizeVisibleText(value: string): string {
     return String(value || '')
         .replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f\ufffe\uffff]/g, '')

--- a/tests/contract/aiSessions/kimiConversationAdapter.test.js
+++ b/tests/contract/aiSessions/kimiConversationAdapter.test.js
@@ -2201,3 +2201,179 @@ test('CONVERSATION-FOLLOW-DIAGNOSTICS-001 Kimi exposes sanitized cache diagnosti
     assert.equal(incremental.cachedInteractions, 3);
     assert.equal(incremental.cachedNextOffset, fs.statSync(source.sourcePath).size);
 });
+
+test('CONVERSATION-OVERSIZED-TURN-001 Kimi bounds one oversized tool-heavy turn without hiding its conversation', async t => {
+    const source = await createFixture(t);
+    const toolCalls = Array.from({ length: 160 }, (_item, index) => ({
+        timestamp: 1_001 + index,
+        message: {
+            type: 'ToolCall',
+            payload: {
+                id: `call-${index}`,
+                function: {
+                    name: 'Shell',
+                    arguments: JSON.stringify({
+                        command: `printf ${'x'.repeat(3_900)}`,
+                    }),
+                },
+            },
+        },
+    }));
+    await fs.promises.writeFile(source.sourcePath, [
+        {
+            timestamp: 1_000,
+            message: {
+                type: 'TurnBegin',
+                payload: { user_input: [{ type: 'text', text: 'Inspect the large run' }] },
+            },
+        },
+        ...toolCalls,
+        {
+            timestamp: 2_000,
+            message: {
+                type: 'ContentPart',
+                payload: { type: 'text', text: 'Final bounded answer.' },
+            },
+        },
+        {
+            timestamp: 2_001,
+            message: { type: 'TurnEnd', payload: {} },
+        },
+    ].map(record => JSON.stringify(record)).join('\n') + '\n');
+    const adapter = createAdapter(source);
+    t.after(() => adapter.dispose());
+
+    const snapshot = await adapter.readSnapshot(sessionId);
+
+    assert.ok(
+        Buffer.byteLength(JSON.stringify(snapshot.page), 'utf8')
+            <= CONVERSATION_LIMITS.maxPageBytes
+    );
+    assert.equal(snapshot.outline.interactions.length, 1);
+    assert.equal(snapshot.page.messages[0].markdown, 'Inspect the large run');
+    assert.equal(snapshot.page.messages.at(-1).markdown, 'Final bounded answer.');
+    assert.equal(
+        snapshot.page.messages.some(message =>
+            message.markdown === 'Work was omitted to keep this turn within the conversation size limit.'
+        ),
+        true
+    );
+    assert.ok(
+        snapshot.page.messages.filter(message => message.role === 'tool').length
+            < toolCalls.length
+    );
+});
+
+// Shape measured from a real incident session (70ce2ce2-…, turn #2):
+// one turn with 100+ tool calls, ~255KB of streamed thinking, ~278KB of
+// tool output (including very large ReadFile results), and ~100KB of
+// arguments — individually capped fields still sum past 512KB.
+test('CONVERSATION-OVERSIZED-TURN-001 Kimi bounds a real-shaped oversized turn and keeps the outline intact', async t => {
+    const source = await createFixture(t);
+    const records = [{
+        timestamp: 1_000,
+        message: {
+            type: 'TurnBegin',
+            payload: { user_input: 'Review the oversized turn' },
+        },
+    }];
+    for (let index = 0; index < 20; index += 1) {
+        records.push({
+            timestamp: 1_001 + index,
+            message: {
+                type: 'ContentPart',
+                payload: { type: 'think', think: `thought ${index} ${'t'.repeat(12 * 1024)}` },
+            },
+        });
+    }
+    for (let index = 0; index < 160; index += 1) {
+        const big = index < 2;
+        records.push({
+            timestamp: 1_100 + index * 2,
+            message: {
+                type: 'ToolCall',
+                payload: {
+                    id: `read-${index}`,
+                    function: {
+                        name: 'ReadFile',
+                        arguments: JSON.stringify({
+                            path: `/repo/src/module-${index}.ts`,
+                        }),
+                    },
+                },
+            },
+        }, {
+            timestamp: 1_101 + index * 2,
+            message: {
+                type: 'ToolResult',
+                payload: {
+                    tool_call_id: `read-${index}`,
+                    return_value: {
+                        output: `file ${index}\n${'r'.repeat(big ? 80 * 1024 : 3 * 1024)}`,
+                    },
+                },
+            },
+        });
+    }
+    records.push({
+        timestamp: 2_000,
+        message: {
+            type: 'ContentPart',
+            payload: { type: 'text', text: 'Final review verdict.' },
+        },
+    }, {
+        timestamp: 2_001,
+        message: { type: 'TurnEnd', payload: {} },
+    }, {
+        timestamp: 3_000,
+        message: {
+            type: 'TurnBegin',
+            payload: { user_input: 'A normal follow-up turn' },
+        },
+    }, {
+        timestamp: 3_001,
+        message: { type: 'TurnEnd', payload: {} },
+    });
+    await fs.promises.writeFile(
+        source.sourcePath,
+        records.map(record => JSON.stringify(record)).join('\n') + '\n'
+    );
+    const adapter = createAdapter(source);
+    t.after(() => adapter.dispose());
+
+    const snapshot = await adapter.readSnapshot(sessionId);
+    assert.deepEqual(
+        snapshot.outline.interactions.map(item => item.userPreview),
+        ['Review the oversized turn', 'A normal follow-up turn']
+    );
+
+    const oversizedId = snapshot.outline.interactions[0].id;
+    const page = await adapter.readPage({
+        provider: 'kimi',
+        sessionId,
+        anchorInteractionId: oversizedId,
+        direction: 'around',
+    });
+    assert.ok(
+        Buffer.byteLength(JSON.stringify(page), 'utf8')
+            <= CONVERSATION_LIMITS.maxPageBytes
+    );
+    const oversizedMessages = page.messages.filter(
+        message => message.interactionId === oversizedId
+    );
+    assert.equal(oversizedMessages[0].markdown, 'Review the oversized turn');
+    assert.equal(
+        oversizedMessages.some(message =>
+            message.markdown === 'Final review verdict.'),
+        true
+    );
+    assert.equal(
+        oversizedMessages.some(message =>
+            message.markdown === 'Work was omitted to keep this turn within the conversation size limit.'
+        ),
+        true
+    );
+
+    const outline = await adapter.readOutline(sessionId);
+    assert.equal(outline.interactions.length, 2);
+});

--- a/tests/integration/dashboard/conversationViewer.test.js
+++ b/tests/integration/dashboard/conversationViewer.test.js
@@ -47,6 +47,9 @@ const {
 const {
     CodexConversationAdapter,
 } = require('../../../out/aiSessions/conversation/codexAdapter');
+const {
+    buildConversationPage,
+} = require('../../../out/aiSessions/conversation/model');
 
 const timedCodexFixture = JSON.parse(fs.readFileSync(path.resolve(
     __dirname,
@@ -4934,4 +4937,68 @@ test('CONVERSATION-COPY-ACTIONS-001 settles copies through the Host clipboard', 
         error: 'invalid',
     }, 'wrong-target copies settle as invalid without touching the clipboard');
     assert.equal(clips.length, 2);
+});
+
+test('CONVERSATION-OVERSIZED-TURN-001 renders a bounded oversized turn with its input, omission notice, and final answer', async () => {
+    const sessionId = 'oversized-kimi-turn';
+    const interactionId = 'input-oversized';
+    const interaction = {
+        id: interactionId,
+        timestamp: 1_000,
+        completedAt: 2_000,
+        userMarkdown: 'Inspect the large run',
+        userPreview: 'Inspect the large run',
+        userGraphemeCount: 21,
+        assistantMarkdown: ['Final bounded answer.'],
+        toolCalls: Array.from({ length: 160 }, (_item, index) => ({
+            position: 0,
+            name: 'Shell',
+            summary: `Shell command ${index}`,
+            detail: 'x'.repeat(4_000),
+        })),
+        responseState: 'complete',
+    };
+    const boundedPage = buildConversationPage([interaction], {
+        provider: 'kimi',
+        sessionId,
+        anchorInteractionId: interactionId,
+        direction: 'around',
+    }, 'r1');
+    const { viewer, panel } = createViewer({
+        readOutline: async () => ({
+            provider: 'kimi',
+            sessionId,
+            sourceRevision: 'r1',
+            interactions: [{
+                id: interactionId,
+                timestamp: interaction.timestamp,
+                completedAt: interaction.completedAt,
+                userPreview: interaction.userPreview,
+                userGraphemeCount: interaction.userGraphemeCount,
+                responseState: interaction.responseState,
+            }],
+            totalInteractions: 1,
+            partial: false,
+        }),
+        readPage: async () => boundedPage,
+    });
+
+    await viewer.open(target(sessionId, interactionId, { provider: 'kimi' }));
+
+    assert.match(panel.webview.html, /Inspect the large run/);
+    assert.match(
+        panel.webview.html,
+        /Work was omitted to keep this turn within the conversation size limit\./
+    );
+    assert.match(panel.webview.html, /Final bounded answer\./);
+    assert.match(panel.webview.html, /conversation-message-worklog/);
+    const inputIndex = panel.webview.html.indexOf('Inspect the large run');
+    const omissionIndex = panel.webview.html.indexOf(
+        'Work was omitted to keep this turn within the conversation size limit.'
+    );
+    const answerIndex = panel.webview.html.indexOf('Final bounded answer.');
+    assert.ok(
+        inputIndex >= 0 && omissionIndex > inputIndex && answerIndex > omissionIndex,
+        `bounded turn order was ${inputIndex}/${omissionIndex}/${answerIndex}`
+    );
 });

--- a/tests/unit/aiSessions/conversationModel.test.js
+++ b/tests/unit/aiSessions/conversationModel.test.js
@@ -400,3 +400,166 @@ test('CONVERSATION-WORKLOG-COLLAPSE-001 page interaction states carry turn timin
         responseState: 'complete',
     }]);
 });
+
+test('CONVERSATION-OVERSIZED-TURN-001 preserves a multibyte user input and final answer when one turn must shrink', () => {
+    const [interaction] = makeInteractions(1);
+    interaction.userMarkdown = '👨‍👩‍👧‍👦'.repeat(12_500);
+    interaction.userGraphemeCount = 12_500;
+    interaction.assistantMarkdown = ['👩‍👩‍👧‍👦'.repeat(12_500)];
+    const page = model.buildConversationPage([interaction], {
+        provider: 'kimi',
+        sessionId: 'session',
+        anchorInteractionId: interaction.id,
+        direction: 'around',
+    }, 'r1');
+
+    assert.ok(
+        Buffer.byteLength(JSON.stringify(page), 'utf8')
+            <= CONVERSATION_LIMITS.maxPageBytes
+    );
+    assert.deepEqual(page.messages.map(message => message.role), [
+        'user', 'progress', 'assistant',
+    ]);
+    assert.equal(new Set(page.messages.map(message => message.id)).size, 3);
+});
+
+test('CONVERSATION-OVERSIZED-TURN-001 truncates one individually oversized message before fitting the semantic endpoint', () => {
+    const [interaction] = makeInteractions(1);
+    interaction.userMarkdown = '👨‍👩‍👧‍👦'.repeat(25_000);
+    interaction.userGraphemeCount = 25_000;
+    interaction.assistantMarkdown = ['Final answer survives.'];
+    const page = model.buildConversationPage([interaction], {
+        provider: 'kimi',
+        sessionId: 'session',
+        anchorInteractionId: interaction.id,
+        direction: 'around',
+    }, 'r1');
+
+    assert.ok(
+        Buffer.byteLength(JSON.stringify(page), 'utf8')
+            <= CONVERSATION_LIMITS.maxPageBytes
+    );
+    assert.equal(page.messages[0].role, 'user');
+    assert.match(page.messages[0].markdown, /…$/);
+    assert.equal(page.messages.at(-1).markdown, 'Final answer survives.');
+});
+
+test('CONVERSATION-OVERSIZED-TURN-001 keeps a bounded provider question when its nested text exceeds one page', () => {
+    const [interaction] = makeInteractions(1);
+    interaction.assistantMarkdown = ['Final answer after the question.'];
+    interaction.questions = [{
+        position: 0,
+        source: 'AskUserQuestion',
+        questions: Array.from({ length: 8 }, (_item, questionIndex) => ({
+            question: `Question ${questionIndex} ${'😀'.repeat(2_000)}`,
+            options: Array.from({ length: 8 }, (_option, optionIndex) => ({
+                label: `Option ${optionIndex} ${'🧭'.repeat(500)}`,
+                description: '🔎'.repeat(2_000),
+            })),
+            multiSelect: false,
+            answers: ['✅'.repeat(2_000)],
+        })),
+        outcome: 'answered',
+    }];
+    const page = model.buildConversationPage([interaction], {
+        provider: 'kimi',
+        sessionId: 'session',
+        anchorInteractionId: interaction.id,
+        direction: 'around',
+    }, 'r1');
+
+    assert.ok(
+        Buffer.byteLength(JSON.stringify(page), 'utf8')
+            <= CONVERSATION_LIMITS.maxPageBytes
+    );
+    const question = page.messages.find(message => message.role === 'question');
+    assert.ok(question, 'the semantic question endpoint must remain visible');
+    assert.equal(question.question.source, 'AskUserQuestion');
+    assert.equal(question.question.questions.length, 8);
+    assert.deepEqual(
+        page.messages.filter(message =>
+            message.role === 'question' || message.role === 'assistant'
+        ).map(message => message.role),
+        ['question', 'assistant']
+    );
+    assert.equal(
+        page.messages.find(message => message.role === 'assistant').markdown,
+        'Final answer after the question.'
+    );
+    assert.equal(
+        new Set(page.messages.map(message => message.id)).size,
+        page.messages.length
+    );
+});
+
+test('CONVERSATION-OVERSIZED-TURN-001 bounding truncates plan content but keeps the plan file path', () => {
+    const [interaction] = makeInteractions(1);
+    interaction.userMarkdown = 'U'.repeat(200 * 1024);
+    interaction.userGraphemeCount = 200 * 1024;
+    interaction.assistantMarkdown = [];
+    interaction.plans = [{
+        position: 0,
+        markdown: 'P'.repeat(450 * 1024),
+        filePath: '/home/user/.kimi/plans/keep-me.md',
+    }];
+    const page = model.buildConversationPage([interaction], {
+        provider: 'kimi',
+        sessionId: 'session',
+        anchorInteractionId: interaction.id,
+        direction: 'around',
+    }, 'r1');
+
+    assert.ok(
+        Buffer.byteLength(JSON.stringify(page), 'utf8')
+            <= CONVERSATION_LIMITS.maxPageBytes
+    );
+    const plan = page.messages.find(message => message.role === 'plan');
+    assert.ok(plan, 'the plan endpoint must remain visible');
+    assert.match(plan.plan.markdown, /…$/);
+    assert.equal(plan.plan.filePath, '/home/user/.kimi/plans/keep-me.md');
+    assert.equal(page.messages[0].role, 'user');
+    assert.equal(
+        page.messages.some(message =>
+            message.markdown === 'Work was omitted to keep this turn within the conversation size limit.'),
+        true
+    );
+});
+
+test('CONVERSATION-OVERSIZED-TURN-001 a worklog-only oversized turn keeps its user input and latest work entry', () => {
+    // Real sessions contain complete turns with no assistant, plan, or
+    // question message at all (e.g. orchestrator turns whose content lives
+    // in provider events the adapter skips). The fallback endpoint is the
+    // turn's last message.
+    const [interaction] = makeInteractions(1);
+    interaction.userMarkdown = 'U'.repeat(200 * 1024);
+    interaction.userGraphemeCount = 200 * 1024;
+    interaction.assistantMarkdown = [];
+    interaction.toolCalls = [{
+        position: 0,
+        name: 'Shell',
+        summary: 'the final work entry',
+        detail: 'D'.repeat(400 * 1024),
+    }];
+    const page = model.buildConversationPage([interaction], {
+        provider: 'kimi',
+        sessionId: 'session',
+        anchorInteractionId: interaction.id,
+        direction: 'around',
+    }, 'r1');
+
+    assert.ok(
+        Buffer.byteLength(JSON.stringify(page), 'utf8')
+            <= CONVERSATION_LIMITS.maxPageBytes
+    );
+    assert.equal(page.messages[0].role, 'user');
+    assert.equal(
+        page.messages.some(message =>
+            message.markdown === 'Work was omitted to keep this turn within the conversation size limit.'),
+        true
+    );
+    const tool = page.messages.find(message => message.role === 'tool');
+    assert.ok(tool, 'the fallback endpoint must remain visible');
+    assert.equal(tool.tool.name, 'Shell');
+    assert.equal(tool.tool.summary, 'the final work entry');
+    assert.match(tool.tool.detail, /…$/);
+});

--- a/tests/unit/aiSessions/conversationText.test.js
+++ b/tests/unit/aiSessions/conversationText.test.js
@@ -121,3 +121,20 @@ test('CONVERSATION-COPY-ACTIONS-001 formats the action row clock time', () => {
         'finite values beyond the Date range still render no clock'
     );
 });
+
+test('CONVERSATION-OVERSIZED-TURN-001 truncateUtf8Bytes bounds bytes without splitting graphemes', () => {
+    const family = '👨‍👩‍👧‍👦';
+    const byteLimit = Buffer.byteLength(`A${family}…`, 'utf8');
+    assert.equal(
+        text.truncateUtf8Bytes(`A${family}BCDE`, byteLimit),
+        `A${family}…`
+    );
+    assert.ok(
+        Buffer.byteLength(
+            text.truncateUtf8Bytes(`A${family}BCDE`, byteLimit),
+            'utf8'
+        ) <= byteLimit
+    );
+    assert.equal(text.truncateUtf8Bytes('short', 100), 'short');
+    assert.equal(text.truncateUtf8Bytes('abc', 2), '');
+});


### PR DESCRIPTION
## Summary

Fixes the second incident from the field: a Kimi session whose conversation could not be opened at all — "Unable to read the AI session conversation. Click the session again to retry." — because one serialized interaction exceeds the 512KB `maxPageBytes` protocol budget.

**Root cause:** per-field caps (64k-grapheme messages, 4k tool call details) never bound an interaction's *aggregate* size. The incident session (14.5MB `wire.jsonl`, 45 turns) carries four turns with 100+ tool calls and 200–300KB of merged thinking each. `buildConversationPage` could only drop whole interactions; with one oversized interaction left it threw `tooLarge`, `readSnapshot` failed, the outline vanished with it, and composition mapped the error to `unavailable` (with a pointless retry).

**Fix (deterministic in-interaction convergence, `model.ts`):**
- Keep the user message and the latest assistant/plan/question endpoints; turns with no semantic endpoint (real orchestrator turns whose content lives in provider events the adapter skips) fall back to the last worklog entry.
- Water-fill byte budgets across preserved messages; truncate only allowlisted content fields (`markdown`/`text`/`detail`/`question`/`label`/`description`/`otherLabel`) with grapheme-safe UTF-8 byte truncation; tool names, diff paths, plan file paths, question sources, and outcomes survive verbatim.
- Insert an explicit omission notice ("Work was omitted to keep this turn within the conversation size limit.") and greedily backfill recent messages that still fit.
- Every interaction block is bounded to `maxPageBytes − 2KB`, so a single-interaction page always fits; the shrink loop now only decides how many interactions fit, and `tooLarge` remains as unreachable defense. Outline construction is untouched and keeps all 45 interactions.

Credits: direction and byte accounting adapted from the uncommitted candidate in `.worktree/kimi-conversation-empty`, simplified (allowlist field truncation instead of reflective blacklisting) and extended (endpoint-less turns, real-shaped fixtures).

**Behavior:** `CONVERSATION-OVERSIZED-TURN-001` (P0). RED evidence: all 8 new tests fail on unfixed code — the real-shaped contract test throws exactly `ConversationError: tooLarge` at `buildConversationPage`. Mutation check: adding `filePath` to the truncation allowlist makes the plan-identity test fail.

## Skill harvest

updated .skills/developing-provider-conversation-adapters — recorded the aggregate-budget gap behind `tooLarge`, empirical fixture calibration (130 capped 4KB details ≈ 504KB < 510KB budget; 160 needed), and endpoint-less complete turns from real data. Recorded as the `Skill-Harvest` trailer of the capability audit commit.

## Verification

- RED before fix: 5 unit + 2 contract + 1 integration tests fail (tooLarge / missing function); real-shaped fixture calibrated against the incident turn's measured shape (128 tool calls, ~255KB thinking, ~278KB tool output).
- GREEN after fix: focused suites pass (unit 15, contract 37, integration 93); full `npm run test:deterministic:run` 817+950+414, zero failures.
- `npm run test:behavior-contracts`, `npm run test:skills`, `npm run test:architecture-guards`, `npm run lint`, `git diff --check` all pass.
- Real-data end-to-end with the compiled adapter on the incident session: snapshot opens (45 interactions, default page 419KB), all 45 anchored pages fit the budget, exactly the 4 oversized turns render bounded with user-first + omission + tail content preserved.
