### PR TITLE
fix: honor the Codex profile's declared context window in telemetry

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -5258,6 +5258,7 @@
       "tests/contract/aiSessions/kimiConversationAdapter.test.js",
       "tests/contract/aiSessions/claudeConversationAdapter.test.js",
       "tests/unit/aiSessions/codexRolloutWorkdir.test.js",
+      "tests/unit/aiSessions/codexProfiles.test.js",
       "tests/browser/conversationViewer.test.js"
     ],
     "evidence": [
@@ -5270,6 +5271,7 @@
       "src/aiSessions/conversation/viewerProtocol.ts",
       "src/aiSessions/conversation/worktreeResolver.ts",
       "src/aiSessions/codexRolloutWorkdir.ts",
+      "src/aiSessions/codexProfiles.ts",
       "src/services/sourceControl.ts",
       "src/webview/conversationViewerScripts.js",
       "src/aiSessions/conversation/conversationTelemetryController.ts",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "dcf5ab3b6351aee1741f5bbceee60f2883168b87",
+        "head": "92d630e02c6b0ad915e47e130656caebaa2d1981",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -298,7 +298,8 @@
             "2790114bbfc3cac65c99c70da8feff2b191461e2",
             "a9bd4f778fbf3374980f59edc97f93eac2ad0989",
             "0dc784a3d38f9c1f34ef51cb962d5fd3daf746b3",
-            "a91500128a1bf9892018b7523e8fffc2192ef4ef"
+            "a91500128a1bf9892018b7523e8fffc2192ef4ef",
+            "727c0d86d15b48cb88612b0753e7477df42329b3"
         ]
     },
     "capabilities": [
@@ -1656,7 +1657,8 @@
                 "aecacbe0c6edaf93832ead08b5b279a9731d1355",
                 "ff7661f3f9116753719003fd6a9072b1a13ff442",
                 "484a18e4318a67ea65b9d3fbfc16d6ef70f9c0db",
-                "dcf5ab3b6351aee1741f5bbceee60f2883168b87"
+                "dcf5ab3b6351aee1741f5bbceee60f2883168b87",
+                "92d630e02c6b0ad915e47e130656caebaa2d1981"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "1fe3abb99888b24c1d5b7533656bb5474706995f",
+        "head": "dcf5ab3b6351aee1741f5bbceee60f2883168b87",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -297,7 +297,8 @@
             "c13fabff5e6f5c8d9242d3c4e9955fc43a81b961",
             "2790114bbfc3cac65c99c70da8feff2b191461e2",
             "a9bd4f778fbf3374980f59edc97f93eac2ad0989",
-            "0dc784a3d38f9c1f34ef51cb962d5fd3daf746b3"
+            "0dc784a3d38f9c1f34ef51cb962d5fd3daf746b3",
+            "a91500128a1bf9892018b7523e8fffc2192ef4ef"
         ]
     },
     "capabilities": [
@@ -1654,7 +1655,8 @@
                 "7471ec6d918175b048f962cddc2c8e374dae7390",
                 "aecacbe0c6edaf93832ead08b5b279a9731d1355",
                 "ff7661f3f9116753719003fd6a9072b1a13ff442",
-                "484a18e4318a67ea65b9d3fbfc16d6ef70f9c0db"
+                "484a18e4318a67ea65b9d3fbfc16d6ef70f9c0db",
+                "dcf5ab3b6351aee1741f5bbceee60f2883168b87"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",

--- a/src/aiSessions/codexProfiles.ts
+++ b/src/aiSessions/codexProfiles.ts
@@ -248,3 +248,53 @@ export class CodexProfileSupportProbe {
         }
     }
 }
+
+// A profile-declared model_context_window is authoritative for the telemetry
+// display: the app-server reports its built-in default (258400) for custom
+// provider models, ignoring the profile overlay. Files change rarely, so
+// reads are cached briefly per resolved path.
+const PROFILE_CONTEXT_WINDOW_CACHE_TTL_MS = 10 * 1000;
+const MAX_MODEL_CONTEXT_WINDOW = 100_000_000;
+const TOP_LEVEL_CONTEXT_WINDOW_PATTERN = /^\s*model_context_window\s*=\s*([0-9]+)\s*(?:#.*)?$/m;
+
+const profileContextWindowCache = new Map<string, { at: number; value: number | undefined }>();
+
+/**
+ * Reads the top-level `model_context_window` from a profile's
+ * `<name>.config.toml` overlay. Returns undefined for unknown names, missing
+ * files, and absent or implausible values.
+ */
+export function readCodexProfileContextWindow(
+    name: string,
+    env: NodeJS.ProcessEnv = process.env,
+    homedir: string = os.homedir(),
+    nowMs: number = Date.now()
+): number | undefined {
+    if (!isValidCodexProfileName(name)) {
+        return undefined;
+    }
+    const filePath = path.join(
+        resolveCodexHome(env, homedir),
+        `${name}${CODEX_PROFILE_CONFIG_SUFFIX}`
+    );
+    const cached = profileContextWindowCache.get(filePath);
+    if (cached && nowMs - cached.at < PROFILE_CONTEXT_WINDOW_CACHE_TTL_MS) {
+        return cached.value;
+    }
+    let value: number | undefined;
+    try {
+        const content = fs.readFileSync(filePath, 'utf8');
+        // Only top-level keys count: a model_context_window inside a
+        // [model_providers.*] table configures something else entirely.
+        const topLevel = content.split(/^\s*\[/m, 1)[0];
+        const match = TOP_LEVEL_CONTEXT_WINDOW_PATTERN.exec(topLevel ?? '');
+        const parsed = match ? Number(match[1]) : Number.NaN;
+        if (Number.isSafeInteger(parsed) && parsed > 0 && parsed <= MAX_MODEL_CONTEXT_WINDOW) {
+            value = parsed;
+        }
+    } catch {
+        value = undefined;
+    }
+    profileContextWindowCache.set(filePath, { at: nowMs, value });
+    return value;
+}

--- a/src/aiSessions/codexProfiles.ts
+++ b/src/aiSessions/codexProfiles.ts
@@ -256,8 +256,57 @@ export class CodexProfileSupportProbe {
 const PROFILE_CONTEXT_WINDOW_CACHE_TTL_MS = 10 * 1000;
 const MAX_MODEL_CONTEXT_WINDOW = 100_000_000;
 const TOP_LEVEL_CONTEXT_WINDOW_PATTERN = /^\s*model_context_window\s*=\s*([0-9]+)\s*(?:#.*)?$/m;
+const TOP_LEVEL_MODEL_PATTERN = /^\s*model\s*=\s*"([^"]+)"\s*(?:#.*)?$/m;
 
-const profileContextWindowCache = new Map<string, { at: number; value: number | undefined }>();
+export interface CodexProfileModelConfig {
+    model?: string;
+    contextWindow?: number;
+}
+
+const profileModelConfigCache = new Map<string, { at: number; value: CodexProfileModelConfig }>();
+
+/**
+ * Reads the top-level `model` and `model_context_window` from a profile's
+ * `<name>.config.toml` overlay. Section-scoped keys (e.g. inside
+ * `[model_providers.*]`) never count. Invalid names and missing files yield
+ * an empty record.
+ */
+export function readCodexProfileModelConfig(
+    name: string,
+    env: NodeJS.ProcessEnv = process.env,
+    homedir: string = os.homedir(),
+    nowMs: number = Date.now()
+): CodexProfileModelConfig {
+    if (!isValidCodexProfileName(name)) {
+        return {};
+    }
+    const filePath = path.join(
+        resolveCodexHome(env, homedir),
+        `${name}${CODEX_PROFILE_CONFIG_SUFFIX}`
+    );
+    const cached = profileModelConfigCache.get(filePath);
+    if (cached && nowMs - cached.at < PROFILE_CONTEXT_WINDOW_CACHE_TTL_MS) {
+        return cached.value;
+    }
+    const value: CodexProfileModelConfig = {};
+    try {
+        const content = fs.readFileSync(filePath, 'utf8');
+        const topLevel = content.split(/^\s*\[/m, 1)[0] ?? '';
+        const modelMatch = TOP_LEVEL_MODEL_PATTERN.exec(topLevel);
+        if (modelMatch?.[1]?.trim()) {
+            value.model = modelMatch[1].trim().slice(0, 128);
+        }
+        const windowMatch = TOP_LEVEL_CONTEXT_WINDOW_PATTERN.exec(topLevel);
+        const parsed = windowMatch ? Number(windowMatch[1]) : Number.NaN;
+        if (Number.isSafeInteger(parsed) && parsed > 0 && parsed <= MAX_MODEL_CONTEXT_WINDOW) {
+            value.contextWindow = parsed;
+        }
+    } catch {
+        // Missing or unreadable files leave the record empty.
+    }
+    profileModelConfigCache.set(filePath, { at: nowMs, value });
+    return value;
+}
 
 /**
  * Reads the top-level `model_context_window` from a profile's
@@ -270,31 +319,32 @@ export function readCodexProfileContextWindow(
     homedir: string = os.homedir(),
     nowMs: number = Date.now()
 ): number | undefined {
-    if (!isValidCodexProfileName(name)) {
+    return readCodexProfileModelConfig(name, env, homedir, nowMs).contextWindow;
+}
+
+/**
+ * Resolves the context window for a session whose model string is known but
+ * whose profile is not recorded (e.g. started via the Codex CLI directly):
+ * the window declared by the profiles whose top-level `model` matches.
+ * Returns undefined when no profile declares the model or when matching
+ * profiles disagree on the window.
+ */
+export function readCodexProfileContextWindowForModel(
+    model: string,
+    env: NodeJS.ProcessEnv = process.env,
+    homedir: string = os.homedir(),
+    nowMs: number = Date.now()
+): number | undefined {
+    if (typeof model !== 'string' || !model.trim()) {
         return undefined;
     }
-    const filePath = path.join(
-        resolveCodexHome(env, homedir),
-        `${name}${CODEX_PROFILE_CONFIG_SUFFIX}`
-    );
-    const cached = profileContextWindowCache.get(filePath);
-    if (cached && nowMs - cached.at < PROFILE_CONTEXT_WINDOW_CACHE_TTL_MS) {
-        return cached.value;
-    }
-    let value: number | undefined;
-    try {
-        const content = fs.readFileSync(filePath, 'utf8');
-        // Only top-level keys count: a model_context_window inside a
-        // [model_providers.*] table configures something else entirely.
-        const topLevel = content.split(/^\s*\[/m, 1)[0];
-        const match = TOP_LEVEL_CONTEXT_WINDOW_PATTERN.exec(topLevel ?? '');
-        const parsed = match ? Number(match[1]) : Number.NaN;
-        if (Number.isSafeInteger(parsed) && parsed > 0 && parsed <= MAX_MODEL_CONTEXT_WINDOW) {
-            value = parsed;
+    const normalized = model.trim();
+    const windows = new Set<number>();
+    for (const name of listCodexConfigProfiles(env, homedir)) {
+        const config = readCodexProfileModelConfig(name, env, homedir, nowMs);
+        if (config.model === normalized && config.contextWindow) {
+            windows.add(config.contextWindow);
         }
-    } catch {
-        value = undefined;
     }
-    profileContextWindowCache.set(filePath, { at: nowMs, value });
-    return value;
+    return windows.size === 1 ? [...windows][0] : undefined;
 }

--- a/src/aiSessions/conversation/codexAdapter.ts
+++ b/src/aiSessions/conversation/codexAdapter.ts
@@ -111,8 +111,10 @@ export interface CodexConversationAdapterOptions {
     ): AiSessionCodexSubagentThread[] | Promise<AiSessionCodexSubagentThread[]>;
     // The context window declared by the session's Codex profile overlay, if
     // any. The app-server reports its built-in default for custom provider
-    // models, so a declared profile value takes precedence for display.
-    getSessionProfileContextWindow?(sessionId: string): number | undefined;
+    // models, so a declared profile value takes precedence for display. The
+    // model (when known) lets the host match sessions started outside the
+    // extension, which have no recorded profile decision.
+    getSessionProfileContextWindow?(sessionId: string, model?: string): number | undefined;
     now?(): number;
 }
 
@@ -1514,7 +1516,11 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
         const context = rollout?.context
             || this.tokenUsageBySession.get(sessionId);
         if (context) {
-            telemetry.context = this.applyProfileContextWindow(sessionId, context);
+            telemetry.context = this.applyProfileContextWindow(
+                sessionId,
+                rollout?.model,
+                context
+            );
         }
         return telemetry.model || telemetry.context || telemetry.worktree
             || telemetry.rateLimits.length
@@ -1574,7 +1580,11 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
                 telemetry.model = rollout.model;
             }
             if (rollout.context) {
-                telemetry.context = { ...rollout.context };
+                telemetry.context = this.applyProfileContextWindow(
+                    sessionId,
+                    rollout.model || telemetry.model,
+                    rollout.context
+                );
             }
         }
         if (!rollout?.currentWorkdir || !this.options.resolveWorktree) {
@@ -1664,9 +1674,10 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
 
     private applyProfileContextWindow(
         sessionId: string,
+        model: string | undefined,
         context: { usedTokens: number; maxTokens: number }
     ): { usedTokens: number; maxTokens: number } {
-        const override = this.options.getSessionProfileContextWindow?.(sessionId);
+        const override = this.options.getSessionProfileContextWindow?.(sessionId, model);
         return typeof override === 'number'
             && Number.isSafeInteger(override)
             && override > 0
@@ -1690,10 +1701,14 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
             || usage.modelContextWindow <= 0) {
             return;
         }
-        const context = this.applyProfileContextWindow(params.threadId, {
-            usedTokens: Math.floor(last.totalTokens),
-            maxTokens: Math.floor(usage.modelContextWindow),
-        });
+        const context = this.applyProfileContextWindow(
+            params.threadId,
+            this.telemetryCache.get(params.threadId)?.value?.model,
+            {
+                usedTokens: Math.floor(last.totalTokens),
+                maxTokens: Math.floor(usage.modelContextWindow),
+            }
+        );
         this.makeRoomForTelemetrySession(params.threadId);
         this.tokenUsageBySession.set(params.threadId, context);
         const cached = this.telemetryCache.get(params.threadId);

--- a/src/aiSessions/conversation/codexAdapter.ts
+++ b/src/aiSessions/conversation/codexAdapter.ts
@@ -109,6 +109,10 @@ export interface CodexConversationAdapterOptions {
     listSubagentThreads?(
         sessionId: string
     ): AiSessionCodexSubagentThread[] | Promise<AiSessionCodexSubagentThread[]>;
+    // The context window declared by the session's Codex profile overlay, if
+    // any. The app-server reports its built-in default for custom provider
+    // models, so a declared profile value takes precedence for display.
+    getSessionProfileContextWindow?(sessionId: string): number | undefined;
     now?(): number;
 }
 
@@ -1510,7 +1514,7 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
         const context = rollout?.context
             || this.tokenUsageBySession.get(sessionId);
         if (context) {
-            telemetry.context = { ...context };
+            telemetry.context = this.applyProfileContextWindow(sessionId, context);
         }
         return telemetry.model || telemetry.context || telemetry.worktree
             || telemetry.rateLimits.length
@@ -1658,6 +1662,18 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
         this.options.client.dispose();
     }
 
+    private applyProfileContextWindow(
+        sessionId: string,
+        context: { usedTokens: number; maxTokens: number }
+    ): { usedTokens: number; maxTokens: number } {
+        const override = this.options.getSessionProfileContextWindow?.(sessionId);
+        return typeof override === 'number'
+            && Number.isSafeInteger(override)
+            && override > 0
+            ? { ...context, maxTokens: override }
+            : { ...context };
+    }
+
     private acceptNotification(method: string, value: unknown): void {
         if (method !== 'thread/tokenUsage/updated') {
             return;
@@ -1674,10 +1690,10 @@ export class CodexConversationAdapter implements ConversationProviderAdapter {
             || usage.modelContextWindow <= 0) {
             return;
         }
-        const context = {
+        const context = this.applyProfileContextWindow(params.threadId, {
             usedTokens: Math.floor(last.totalTokens),
             maxTokens: Math.floor(usage.modelContextWindow),
-        };
+        });
         this.makeRoomForTelemetrySession(params.threadId);
         this.tokenUsageBySession.set(params.threadId, context);
         const cached = this.telemetryCache.get(params.threadId);

--- a/src/aiSessions/conversation/composition.ts
+++ b/src/aiSessions/conversation/composition.ts
@@ -142,6 +142,12 @@ export interface ConversationCapabilityOptions {
     bookmarkStore?: ConversationBookmarkStore;
     getShowThinking?: () => boolean;
     readSessionStatus?: ConversationViewerOptions['readSessionStatus'];
+    /**
+     * The context window declared by the Codex profile overlay a session runs
+     * with, if any. Injected for the codex adapter's telemetry display: the
+     * app-server under-reports custom provider model windows.
+     */
+    getCodexSessionProfileContextWindow?: (sessionId: string) => number | undefined;
     setConversationFocusContext?: (
         focused: boolean
     ) => PromiseLike<void> | Promise<void> | void;
@@ -254,6 +260,7 @@ function createAvailableConversationCapability(
             ),
         listSubagentThreads: sessionId =>
             options.services.codex.listSubagentThreads?.(sessionId) || [],
+        getSessionProfileContextWindow: options.getCodexSessionProfileContextWindow,
     }));
     ownership.transfer(codexClient);
     const kimiAdapter = ownership.own(factories.createKimiAdapter({

--- a/src/aiSessions/conversation/composition.ts
+++ b/src/aiSessions/conversation/composition.ts
@@ -145,9 +145,10 @@ export interface ConversationCapabilityOptions {
     /**
      * The context window declared by the Codex profile overlay a session runs
      * with, if any. Injected for the codex adapter's telemetry display: the
-     * app-server under-reports custom provider model windows.
+     * app-server under-reports custom provider model windows. The model lets
+     * the implementation match sessions started outside the extension.
      */
-    getCodexSessionProfileContextWindow?: (sessionId: string) => number | undefined;
+    getCodexSessionProfileContextWindow?: (sessionId: string, model?: string) => number | undefined;
     setConversationFocusContext?: (
         focused: boolean
     ) => PromiseLike<void> | Promise<void> | void;

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -49,6 +49,7 @@ import {
     codexProfileFileExists,
     listCodexConfigProfiles,
     readCodexProfileContextWindow,
+    readCodexProfileContextWindowForModel,
 } from './aiSessions/codexProfiles';
 import AiSessionAliasController from './aiSessions/aliasController';
 import AiSessionPinStore from './aiSessions/pinStore';
@@ -1600,10 +1601,19 @@ async function initializeDashboard(
             conversationSessionRebindCoordinator.resolve(target),
         getShowThinking: () => getAgentPivotConfiguration()
             .get<unknown>('aiConversation.showThinking', false) === true,
-        getCodexSessionProfileContextWindow: sessionId => {
+        getCodexSessionProfileContextWindow: (sessionId, model) => {
             const decision = aiSessionProfileController.getDecision('codex', sessionId);
-            return decision?.kind === 'profile'
-                ? readCodexProfileContextWindow(decision.name)
+            if (decision?.kind === 'profile') {
+                const declared = readCodexProfileContextWindow(decision.name);
+                if (declared) {
+                    return declared;
+                }
+            }
+            // Sessions started outside the extension (e.g. codex CLI -p) have
+            // no recorded decision: match their rollout model against the
+            // profiles' declared models instead.
+            return model
+                ? readCodexProfileContextWindowForModel(model)
                 : undefined;
         },
         readSessionStatus: () => ({

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -48,6 +48,7 @@ import {
     CodexProfileSupportProbe,
     codexProfileFileExists,
     listCodexConfigProfiles,
+    readCodexProfileContextWindow,
 } from './aiSessions/codexProfiles';
 import AiSessionAliasController from './aiSessions/aliasController';
 import AiSessionPinStore from './aiSessions/pinStore';
@@ -1599,6 +1600,12 @@ async function initializeDashboard(
             conversationSessionRebindCoordinator.resolve(target),
         getShowThinking: () => getAgentPivotConfiguration()
             .get<unknown>('aiConversation.showThinking', false) === true,
+        getCodexSessionProfileContextWindow: sessionId => {
+            const decision = aiSessionProfileController.getDecision('codex', sessionId);
+            return decision?.kind === 'profile'
+                ? readCodexProfileContextWindow(decision.name)
+                : undefined;
+        },
         readSessionStatus: () => ({
             runningSessions: sumOpenWorkspaceRunningAiSessionCounts(
                 latestOpenWorkspaceAggregate

--- a/tests/contract/aiSessions/codexConversationAdapter.test.js
+++ b/tests/contract/aiSessions/codexConversationAdapter.test.js
@@ -57,6 +57,7 @@ function createAdapter(result = fixture, overrides = {}) {
         readContentSignature: overrides.readContentSignature,
         readSourceBytes: overrides.readSourceBytes,
         listSubagentThreads: overrides.listSubagentThreads,
+        getSessionProfileContextWindow: overrides.getSessionProfileContextWindow,
         now: overrides.now,
     });
     return {
@@ -1084,6 +1085,78 @@ test('CONVERSATION-TELEMETRY-001 keeps an observed token notification when the r
         usedTokens: 33_000,
         maxTokens: 128_000,
     });
+});
+
+test('CONVERSATION-TELEMETRY-001 a declared profile context window overrides the under-reported server window', async t => {
+    const harness = createAdapter(fixture, {
+        readRolloutTelemetry: () => ({
+            model: 'codewiz:deepseek-pro',
+            context: { usedTokens: 48_000, maxTokens: 258_400 },
+        }),
+        getSessionProfileContextWindow: id => id === sessionId ? 1_000_000 : undefined,
+    });
+    t.after(() => harness.adapter.dispose());
+
+    const telemetry = await harness.adapter.readTelemetry(sessionId);
+    assert.deepEqual(telemetry.context, {
+        usedTokens: 48_000,
+        maxTokens: 1_000_000,
+    }, 'the profile-declared window replaces the server default for custom models');
+    assert.equal(telemetry.model, 'codewiz:deepseek-pro');
+});
+
+test('CONVERSATION-TELEMETRY-001 the profile window also overrides live token notifications', async t => {
+    let notificationListener;
+    const harness = createAdapter(fixture, {
+        client: {
+            watchNotifications(listener) {
+                notificationListener = listener;
+                return { dispose() {} };
+            },
+            async request(method) {
+                if (method === 'thread/read') {
+                    return { thread: { cwd: '/repo' } };
+                }
+                assert.equal(method, 'account/rateLimits/read');
+                return { rateLimits: null, rateLimitsByLimitId: null };
+            },
+            dispose() {},
+        },
+        getSessionProfileContextWindow: () => 1_000_000,
+    });
+    t.after(() => harness.adapter.dispose());
+
+    notificationListener('thread/tokenUsage/updated', {
+        threadId: sessionId,
+        tokenUsage: {
+            last: { totalTokens: 33_000 },
+            modelContextWindow: 258_400,
+        },
+    });
+
+    const telemetry = await harness.adapter.readTelemetry(sessionId);
+    assert.deepEqual(telemetry.context, {
+        usedTokens: 33_000,
+        maxTokens: 1_000_000,
+    }, 'a live notification must not revert the display to the server default');
+});
+
+test('CONVERSATION-TELEMETRY-001 without a valid declared window the server report stands', async t => {
+    for (const override of [undefined, 0, -5, 1.5, Number.NaN]) {
+        const harness = createAdapter(fixture, {
+            readRolloutTelemetry: () => ({
+                context: { usedTokens: 48_000, maxTokens: 258_400 },
+            }),
+            getSessionProfileContextWindow: () => override,
+        });
+        t.after(() => harness.adapter.dispose());
+
+        const telemetry = await harness.adapter.readTelemetry(sessionId);
+        assert.deepEqual(telemetry.context, {
+            usedTokens: 48_000,
+            maxTokens: 258_400,
+        }, `override ${String(override)} must not touch the server value`);
+    }
 });
 
 test('CONVERSATION-TELEMETRY-001 isolates rollout telemetry reads by session', async t => {

--- a/tests/contract/aiSessions/codexConversationAdapter.test.js
+++ b/tests/contract/aiSessions/codexConversationAdapter.test.js
@@ -1088,12 +1088,16 @@ test('CONVERSATION-TELEMETRY-001 keeps an observed token notification when the r
 });
 
 test('CONVERSATION-TELEMETRY-001 a declared profile context window overrides the under-reported server window', async t => {
+    const seen = [];
     const harness = createAdapter(fixture, {
         readRolloutTelemetry: () => ({
             model: 'codewiz:deepseek-pro',
             context: { usedTokens: 48_000, maxTokens: 258_400 },
         }),
-        getSessionProfileContextWindow: id => id === sessionId ? 1_000_000 : undefined,
+        getSessionProfileContextWindow: (id, model) => {
+            seen.push([id, model]);
+            return id === sessionId ? 1_000_000 : undefined;
+        },
     });
     t.after(() => harness.adapter.dispose());
 
@@ -1103,6 +1107,66 @@ test('CONVERSATION-TELEMETRY-001 a declared profile context window overrides the
         maxTokens: 1_000_000,
     }, 'the profile-declared window replaces the server default for custom models');
     assert.equal(telemetry.model, 'codewiz:deepseek-pro');
+    assert.deepEqual(seen, [[sessionId, 'codewiz:deepseek-pro']],
+        'the host hook receives the rollout model for sessions without a recorded profile');
+});
+
+test('CONVERSATION-TELEMETRY-001 cached refreshes keep the profile window override', async t => {
+    const harness = createAdapter(fixture, {
+        readRolloutTelemetry: () => ({
+            model: 'codewiz:deepseek-pro',
+            context: { usedTokens: 48_000, maxTokens: 258_400 },
+        }),
+        getSessionProfileContextWindow: () => 1_000_000,
+    });
+    t.after(() => harness.adapter.dispose());
+
+    const initial = await harness.adapter.readTelemetry(sessionId);
+    assert.equal(initial.context.maxTokens, 1_000_000);
+    const refreshed = await harness.adapter.readTelemetry(sessionId);
+    assert.deepEqual(refreshed.context, {
+        usedTokens: 48_000,
+        maxTokens: 1_000_000,
+    }, 'a cached refresh must not revert the display to the server default');
+});
+
+test('CONVERSATION-TELEMETRY-001 live notifications apply the override with the cached model', async t => {
+    let notificationListener;
+    const harness = createAdapter(fixture, {
+        client: {
+            watchNotifications(listener) {
+                notificationListener = listener;
+                return { dispose() {} };
+            },
+            async request(method) {
+                if (method === 'thread/read') {
+                    return { thread: { cwd: '/repo' } };
+                }
+                assert.equal(method, 'account/rateLimits/read');
+                return { rateLimits: null, rateLimitsByLimitId: null };
+            },
+            dispose() {},
+        },
+        readRolloutTelemetry: () => ({ model: 'codewiz:deepseek-pro' }),
+        getSessionProfileContextWindow: (id, model) =>
+            model === 'codewiz:deepseek-pro' ? 1_000_000 : undefined,
+    });
+    t.after(() => harness.adapter.dispose());
+
+    await harness.adapter.readTelemetry(sessionId);
+    notificationListener('thread/tokenUsage/updated', {
+        threadId: sessionId,
+        tokenUsage: {
+            last: { totalTokens: 33_000 },
+            modelContextWindow: 258_400,
+        },
+    });
+
+    const telemetry = await harness.adapter.readTelemetry(sessionId);
+    assert.deepEqual(telemetry.context, {
+        usedTokens: 33_000,
+        maxTokens: 1_000_000,
+    }, 'a notification after a model-known read must keep the profile window');
 });
 
 test('CONVERSATION-TELEMETRY-001 the profile window also overrides live token notifications', async t => {

--- a/tests/unit/aiSessions/codexProfiles.test.js
+++ b/tests/unit/aiSessions/codexProfiles.test.js
@@ -239,3 +239,53 @@ test('SESSION-CODEX-PROFILE-DISCOVERY-001 reads and validates the default profil
     assert.equal(readCodexDefaultProfile(makeWorkspaceConfiguration({ codexDefaultProfile: '' })), undefined);
     assert.equal(readCodexDefaultProfile(makeWorkspaceConfiguration({})), undefined);
 });
+
+test('CONVERSATION-TELEMETRY-001 reads a profile top-level model_context_window', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-profile-window-'));
+    try {
+        fs.writeFileSync(path.join(home, 'deepseek.config.toml'), [
+            'model_provider = "codewiz"',
+            'model = "codewiz:deepseek-pro"',
+            'model_context_window = 1000000',
+            'model_auto_compact_token_limit = 900000',
+            '',
+            '[model_providers.codewiz]',
+            'name = "codewiz"',
+            'base_url = "http://localhost:18089"',
+        ].join('\n'));
+        fs.writeFileSync(path.join(home, 'sectioned.config.toml'), [
+            '[model_providers.codewiz]',
+            'model_context_window = 512000',
+        ].join('\n'));
+        fs.writeFileSync(path.join(home, 'huge.config.toml'), 'model_context_window = 999999999999');
+        fs.writeFileSync(path.join(home, 'commented.config.toml'), '# model_context_window = 128000\nmodel_context_window = 64000 # cap');
+
+        assert.equal(profiles.readCodexProfileContextWindow('deepseek', { CODEX_HOME: home }, '/x'), 1000000);
+        assert.equal(profiles.readCodexProfileContextWindow('sectioned', { CODEX_HOME: home }, '/x'), undefined,
+            'a window inside a [model_providers.*] table is not the top-level override');
+        assert.equal(profiles.readCodexProfileContextWindow('huge', { CODEX_HOME: home }, '/x'), undefined,
+            'implausible values are rejected');
+        assert.equal(profiles.readCodexProfileContextWindow('commented', { CODEX_HOME: home }, '/x'), 64000);
+        assert.equal(profiles.readCodexProfileContextWindow('missing', { CODEX_HOME: home }, '/x'), undefined);
+        assert.equal(profiles.readCodexProfileContextWindow('../etc', { CODEX_HOME: home }, '/x'), undefined);
+    } finally {
+        fs.rmSync(home, { recursive: true, force: true });
+    }
+});
+
+test('CONVERSATION-TELEMETRY-001 caches the profile context window briefly per resolved path', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-profile-window-cache-'));
+    try {
+        const filePath = path.join(home, 'deepseek.config.toml');
+        fs.writeFileSync(filePath, 'model_context_window = 1000000\n');
+        assert.equal(profiles.readCodexProfileContextWindow('deepseek', { CODEX_HOME: home }, '/x', 1000), 1000000);
+
+        fs.writeFileSync(filePath, 'model_context_window = 2000000\n');
+        assert.equal(profiles.readCodexProfileContextWindow('deepseek', { CODEX_HOME: home }, '/x', 1000 + 5000), 1000000,
+            'a fresh write inside the TTL still serves the cached value');
+        assert.equal(profiles.readCodexProfileContextWindow('deepseek', { CODEX_HOME: home }, '/x', 1000 + 11000), 2000000,
+            'the value re-reads after the TTL expires');
+    } finally {
+        fs.rmSync(home, { recursive: true, force: true });
+    }
+});

--- a/tests/unit/aiSessions/codexProfiles.test.js
+++ b/tests/unit/aiSessions/codexProfiles.test.js
@@ -289,3 +289,43 @@ test('CONVERSATION-TELEMETRY-001 caches the profile context window briefly per r
         fs.rmSync(home, { recursive: true, force: true });
     }
 });
+
+test('CONVERSATION-TELEMETRY-001 resolves the context window for a model declared by exactly one profile window', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-profile-model-window-'));
+    try {
+        const write = (name, lines) => fs.writeFileSync(path.join(home, `${name}.config.toml`), lines.join('\n'));
+        write('deepseek', [
+            'model_provider = "codewiz"',
+            'model = "codewiz:deepseek-pro"',
+            'model_context_window = 1000000',
+        ]);
+        write('deepseek-fast', [
+            'model = "codewiz:deepseek-flash"',
+            'model_context_window = 1000000',
+        ]);
+        write('dots', [
+            'model = "codewiz:dots"',
+            'model_context_window = 256000',
+        ]);
+        write('dots-mirror', [
+            'model = "codewiz:dots"',
+            'model_context_window = 256000',
+        ]);
+        write('conflicted-a', ['model = "same:model"', 'model_context_window = 100000']);
+        write('conflicted-b', ['model = "same:model"', 'model_context_window = 200000']);
+        write('windowless', ['model = "codewiz:windowless"']);
+
+        const env = { CODEX_HOME: home };
+        assert.equal(profiles.readCodexProfileContextWindowForModel('codewiz:deepseek-pro', env, '/x'), 1000000);
+        assert.equal(profiles.readCodexProfileContextWindowForModel('codewiz:dots', env, '/x'), 256000,
+            'profiles agreeing on the window are unambiguous');
+        assert.equal(profiles.readCodexProfileContextWindowForModel('same:model', env, '/x'), undefined,
+            'conflicting windows leave the server-reported value in place');
+        assert.equal(profiles.readCodexProfileContextWindowForModel('codewiz:windowless', env, '/x'), undefined,
+            'a model without a declared window cannot override');
+        assert.equal(profiles.readCodexProfileContextWindowForModel('codewiz:unknown', env, '/x'), undefined);
+        assert.equal(profiles.readCodexProfileContextWindowForModel('', env, '/x'), undefined);
+    } finally {
+        fs.rmSync(home, { recursive: true, force: true });
+    }
+});


### PR DESCRIPTION
## Summary

Codex sessions running under a profile with a custom provider model displayed the app-server's built-in default context window (258400) instead of the profile's declared `model_context_window` — a deepseek-pro session showed 256K while `deepseek.config.toml` declares 1000000. A probe of real rollouts confirmed the app-server ignores the profile overlay's window for unknown models.

- `readCodexProfileContextWindow` parses the top-level `model_context_window` from `<name>.config.toml` (section-scoped keys ignored, implausible values rejected, briefly cached per resolved path); the codex adapter applies the declared window over the rollout-tail snapshot, cached-refresh, and live `thread/tokenUsage/updated` paths so nothing reverts the display.
- Sessions started outside the extension (e.g. `codex -p deepseek`, no recorded profile decision) fall back to matching the rollout's `turn_context` model against the profiles' declared top-level `model` keys; a single distinct declared window wins, conflicting windows keep the server value.
- dashboard resolves the window from the recorded profile decision first, then the model match; base/legacy sessions keep the server-reported value.

Verified against the real overlays: `deepseek`/`deepseek-fast` resolve to 1000000, `dots`/`dots22` to their declared 256000, undeclared models unchanged. Reported by user session `019ff8e9` (CLI-started, model `codewiz:deepseek-pro`).

Extends `CONVERSATION-TELEMETRY-001`; commits assigned to `MAIN-AI-SESSION-CONVERSATION-OUTLINE`.

## Skill harvest

no skill change — the workflow rules involved (probe real provider data before adapter changes, inject readers through composition) are already stated in developing-provider-conversation-adapters and were followed.

## Verification

- Real-data probes: rollout tail `model_context_window=258400` for `codewiz:deepseek-pro`; compiled reader against the real `~/.codex` overlays returns 1000000 for deepseek/deepseek-fast and 256000 for dots/dots22
- New tests: profile config reader (top-level only, TTL cache, path safety), model-window matching (unique/agreeing/conflicting/undeclared), adapter override on rollout read, cached refresh, and live notification paths
- `npm run test:deterministic:run`: 834 unit + 999 contract + 415 integration, 0 failures; browser suite 237 passed
- `npm run test:safety:run`, `node scripts/run-dashboard-webview-checks.js`, `npm run test:architecture-guards`, `npm run lint` (baseline warnings only), `npm run test:behavior-contracts` — all green
- Built via `npm run install-local`; installed `dist/dashboard.js` hash-verified against the VSIX
