### PR TITLE
feat: add toggle behavior to telemetry outline, comments, and subagents pills

### DIFF
--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "92d630e02c6b0ad915e47e130656caebaa2d1981",
+        "head": "fb534d8f247d68cb044527cbbcd42add309d71c4",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -299,7 +299,8 @@
             "a9bd4f778fbf3374980f59edc97f93eac2ad0989",
             "0dc784a3d38f9c1f34ef51cb962d5fd3daf746b3",
             "a91500128a1bf9892018b7523e8fffc2192ef4ef",
-            "727c0d86d15b48cb88612b0753e7477df42329b3"
+            "727c0d86d15b48cb88612b0753e7477df42329b3",
+            "c50235a8ad45dc430c1660675b1daa15f633d50f"
         ]
     },
     "capabilities": [
@@ -1658,7 +1659,8 @@
                 "ff7661f3f9116753719003fd6a9072b1a13ff442",
                 "484a18e4318a67ea65b9d3fbfc16d6ef70f9c0db",
                 "dcf5ab3b6351aee1741f5bbceee60f2883168b87",
-                "92d630e02c6b0ad915e47e130656caebaa2d1981"
+                "92d630e02c6b0ad915e47e130656caebaa2d1981",
+                "fb534d8f247d68cb044527cbbcd42add309d71c4"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",

--- a/media/conversationSidebarScripts.js
+++ b/media/conversationSidebarScripts.js
@@ -15,6 +15,9 @@
         var outlineQuery = options.outlineQuery;
         var subagentsRunningOnlyQuery = options.subagentsRunningOnlyQuery
             || function () { return false; };
+        var telemetryPosition = options.telemetryPosition;
+        var telemetryComments = options.telemetryComments;
+        var telemetrySubagents = options.telemetrySubagents;
         var commentsPanelMinWidth = 192;
         var commentsPanelMaxWidth = 420;
         var conversationMinWidth = 320;
@@ -101,6 +104,18 @@
                 tab.setAttribute('aria-selected', selected ? 'true' : 'false');
                 tab.tabIndex = selected ? 0 : -1;
             });
+            if (telemetryPosition) {
+                telemetryPosition.setAttribute('aria-pressed',
+                    state.commentsPanelOpen && state.sidebarView === 'outline' ? 'true' : 'false');
+            }
+            if (telemetryComments) {
+                telemetryComments.setAttribute('aria-pressed',
+                    state.commentsPanelOpen && state.sidebarView === 'comments' ? 'true' : 'false');
+            }
+            if (telemetrySubagents) {
+                telemetrySubagents.setAttribute('aria-pressed',
+                    state.commentsPanelOpen && state.sidebarView === 'subagents' ? 'true' : 'false');
+            }
         }
 
         function applyCommentsPanelLayout() {
@@ -273,6 +288,8 @@
             save: saveCommentsPanelState,
             setOpen: setCommentsPanelOpen,
             setView: setSidebarView,
+            isPanelOpen: function () { return state.commentsPanelOpen; },
+            getView: function () { return state.sidebarView; },
             updateToggle: updateCommentsToggle,
         });
     }

--- a/media/conversationTelemetry.css
+++ b/media/conversationTelemetry.css
@@ -462,6 +462,13 @@
         color: ButtonText;
     }
 
+    .conversation-telemetry-position[aria-pressed="true"],
+    .conversation-telemetry-subagents[aria-pressed="true"],
+    .conversation-telemetry-comments[aria-pressed="true"] {
+        border-color: Highlight;
+        color: Highlight;
+    }
+
     .conversation-telemetry-ring-track {
         stroke: GrayText;
         opacity: 1;

--- a/media/conversationViewerScripts.js
+++ b/media/conversationViewerScripts.js
@@ -340,6 +340,9 @@
         subagentsRunningOnlyQuery: function () {
             return !!subagentsRunningOnly && subagentsRunningOnly.checked;
         },
+        telemetryPosition: position,
+        telemetryComments: telemetryComments,
+        telemetrySubagents: telemetrySubagents,
     });
     var outlineController = window.__agentPivotConversationOutline.create({
         available: sidebarUiAvailable,
@@ -390,17 +393,29 @@
             });
         });
         telemetrySubagents.addEventListener('click', function () {
-            sidebarController.setView('subagents', true, true);
+            if (sidebarController.isPanelOpen() && sidebarController.getView() === 'subagents') {
+                sidebarController.setView('subagents', false, true);
+            } else {
+                sidebarController.setView('subagents', true, true);
+            }
         });
     }
     if (commentUiAvailable) {
         telemetryComments.addEventListener('click', function () {
-            sidebarController.setView('comments', true, true);
+            if (sidebarController.isPanelOpen() && sidebarController.getView() === 'comments') {
+                sidebarController.setView('comments', false, true);
+            } else {
+                sidebarController.setView('comments', true, true);
+            }
         });
     }
     if (sidebarUiAvailable && position) {
         position.addEventListener('click', function () {
-            sidebarController.setView('outline', true, true);
+            if (sidebarController.isPanelOpen() && sidebarController.getView() === 'outline') {
+                sidebarController.setView('outline', false, true);
+            } else {
+                sidebarController.setView('outline', true, true);
+            }
         });
     }
     var telemetryController = window.__agentPivotConversationTelemetry.create({

--- a/src/aiSessions/conversation/conversationTelemetryController.ts
+++ b/src/aiSessions/conversation/conversationTelemetryController.ts
@@ -445,6 +445,7 @@ export function renderConversationTelemetry(
         <button type="button"
             class="conversation-telemetry-position conversation-telemetry-tooltip"
             data-conversation-position
+            aria-pressed="false"
             aria-label="Input 0 of 0 — click to open the outline"
             title="Input 0 of 0 — click to open the outline"
             data-tooltip="Input 0 of 0 — click to open the outline">
@@ -453,6 +454,7 @@ export function renderConversationTelemetry(
         <button type="button"
             class="conversation-telemetry-comments conversation-telemetry-tooltip"
             data-telemetry-comments
+            aria-pressed="false"
             aria-label="0 comments — click to review"
             title="0 comments — click to review"
             data-tooltip="0 comments — click to review">
@@ -461,6 +463,7 @@ export function renderConversationTelemetry(
         <button type="button"
             class="conversation-telemetry-subagents conversation-telemetry-tooltip"
             data-telemetry-subagents
+            aria-pressed="false"
             aria-label="0 running of 0 subagents — click to view"
             title="0 running of 0 subagents — click to view"
             data-tooltip="0 running of 0 subagents — click to view">

--- a/src/webview/conversationSidebarScripts.js
+++ b/src/webview/conversationSidebarScripts.js
@@ -15,6 +15,9 @@
         var outlineQuery = options.outlineQuery;
         var subagentsRunningOnlyQuery = options.subagentsRunningOnlyQuery
             || function () { return false; };
+        var telemetryPosition = options.telemetryPosition;
+        var telemetryComments = options.telemetryComments;
+        var telemetrySubagents = options.telemetrySubagents;
         var commentsPanelMinWidth = 192;
         var commentsPanelMaxWidth = 420;
         var conversationMinWidth = 320;
@@ -101,6 +104,18 @@
                 tab.setAttribute('aria-selected', selected ? 'true' : 'false');
                 tab.tabIndex = selected ? 0 : -1;
             });
+            if (telemetryPosition) {
+                telemetryPosition.setAttribute('aria-pressed',
+                    state.commentsPanelOpen && state.sidebarView === 'outline' ? 'true' : 'false');
+            }
+            if (telemetryComments) {
+                telemetryComments.setAttribute('aria-pressed',
+                    state.commentsPanelOpen && state.sidebarView === 'comments' ? 'true' : 'false');
+            }
+            if (telemetrySubagents) {
+                telemetrySubagents.setAttribute('aria-pressed',
+                    state.commentsPanelOpen && state.sidebarView === 'subagents' ? 'true' : 'false');
+            }
         }
 
         function applyCommentsPanelLayout() {
@@ -273,6 +288,8 @@
             save: saveCommentsPanelState,
             setOpen: setCommentsPanelOpen,
             setView: setSidebarView,
+            isPanelOpen: function () { return state.commentsPanelOpen; },
+            getView: function () { return state.sidebarView; },
             updateToggle: updateCommentsToggle,
         });
     }

--- a/src/webview/conversationViewerScripts.js
+++ b/src/webview/conversationViewerScripts.js
@@ -340,6 +340,9 @@
         subagentsRunningOnlyQuery: function () {
             return !!subagentsRunningOnly && subagentsRunningOnly.checked;
         },
+        telemetryPosition: position,
+        telemetryComments: telemetryComments,
+        telemetrySubagents: telemetrySubagents,
     });
     var outlineController = window.__agentPivotConversationOutline.create({
         available: sidebarUiAvailable,
@@ -390,17 +393,29 @@
             });
         });
         telemetrySubagents.addEventListener('click', function () {
-            sidebarController.setView('subagents', true, true);
+            if (sidebarController.isPanelOpen() && sidebarController.getView() === 'subagents') {
+                sidebarController.setView('subagents', false, true);
+            } else {
+                sidebarController.setView('subagents', true, true);
+            }
         });
     }
     if (commentUiAvailable) {
         telemetryComments.addEventListener('click', function () {
-            sidebarController.setView('comments', true, true);
+            if (sidebarController.isPanelOpen() && sidebarController.getView() === 'comments') {
+                sidebarController.setView('comments', false, true);
+            } else {
+                sidebarController.setView('comments', true, true);
+            }
         });
     }
     if (sidebarUiAvailable && position) {
         position.addEventListener('click', function () {
-            sidebarController.setView('outline', true, true);
+            if (sidebarController.isPanelOpen() && sidebarController.getView() === 'outline') {
+                sidebarController.setView('outline', false, true);
+            } else {
+                sidebarController.setView('outline', true, true);
+            }
         });
     }
     var telemetryController = window.__agentPivotConversationTelemetry.create({

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -2203,6 +2203,52 @@ test('WEBVIEW-AI-SESSION-SUBAGENT-VIEWER-001 lists subagents, opens a transcript
     assert.equal(await counter.isVisible(), true);
     assert.equal(await counter.innerText(), '0/0');
 });
+test('CONVERSATION-TELEMETRY-TOGGLE-001 telemetry subagents pill toggles the sidebar panel open and closed', async t => {
+    const { page } = await openHostViewerDocument(t, {
+        includeStyles: true,
+        themeFixture: viewerThemeFixtures[0],
+    });
+    const subagents = [{
+        id: 'a11111111',
+        label: 'Explore the parser',
+        agentType: 'explore',
+        status: 'running',
+        updatedAt: 1_780_000_000_000,
+    }];
+    await sendPage(page, {
+        ...hostileConversationPage,
+        requestId: 50,
+        updateKind: 'initial',
+        html: messageHtml('main-session-message', 2),
+        subagents,
+        activeSubagent: null,
+    });
+
+    const sidebar = page.locator('[data-conversation-sidebar]');
+    const telemetrySubagents = page.locator('[data-telemetry-subagents]');
+    const subagentsTab = page.locator('[data-sidebar-tab="subagents"]');
+
+    // Sidebar starts closed
+    assert.equal(await sidebar.isHidden(), true);
+
+    // Click telemetry subagents pill → sidebar opens with subagents tab
+    await telemetrySubagents.click();
+    assert.equal(await sidebar.isVisible(), true);
+    assert.equal(await subagentsTab.getAttribute('aria-selected'), 'true');
+    assert.equal(await telemetrySubagents.getAttribute('aria-pressed'), 'true');
+
+    // Click same pill again → sidebar closes (toggle)
+    await telemetrySubagents.click();
+    assert.equal(await sidebar.isHidden(), true);
+    assert.equal(await telemetrySubagents.getAttribute('aria-pressed'), 'false');
+
+    // Click again → reopens, verifying the toggle is reversible
+    await telemetrySubagents.click();
+    assert.equal(await sidebar.isVisible(), true);
+    assert.equal(await subagentsTab.getAttribute('aria-selected'), 'true');
+    assert.equal(await telemetrySubagents.getAttribute('aria-pressed'), 'true');
+});
+
 
 test('CONVERSATION-FOLLOW-FEEDBACK-001 shows a dismissible follow notice and clears it on the next page', async t => {
     const { page } = await openHostViewerDocument(t, {
@@ -4621,7 +4667,7 @@ test('CONVERSATION-OUTLINE-NAVIGATION-001 keeps every side-panel view usable acr
         .digest('hex');
     assert.equal(
         sha256(previousViewerScript),
-        '9033d91105cd0f01abbf26831b5d459f279f3b8be8d68bf68577835f9bb92117',
+        '0565696a49b5650821460bb0f9551d0d80418bf280844a21f94682aa8574477f',
         'the previous Viewer fixture must stay byte-exact'
     );
     assert.equal(


### PR DESCRIPTION
Clicking the same telemetry pill (outline, comments, subagents) now closes the sidebar panel when it is already open on that tab. Switching between tabs keeps the panel open. Sidebar tab clicks and keyboard navigation are unchanged.

## Changes

- Add `isPanelOpen()` and `getView()` to sidebar controller
- Handle toggle in telemetry button click handlers
- Add `aria-pressed` active state on telemetry buttons
- Add CSS for `[aria-pressed="true"]` visual feedback
- Add browser test `CONVERSATION-TELEMETRY-TOGGLE-001`

## Skill harvest

none