### PR TITLE
chore: prepare Agent Pivot 1.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,24 @@ All notable changes to the "Agent Pivot" extension will be documented in this fi
 
 ## [Unreleased]
 
+## [1.1.1] - 2026-08-13
+
 ### Added
 
+- AI SESSIONS now has a keyboard-accessible split create button: one click
+  starts a new Session without opening any picker, using the provider last
+  started in that workspace and the default Codex profile when applicable.
+  The adjacent menu can quickly choose Codex, Claude, or Kimi, or open the
+  full customized creation flow; its caption always shows what the next
+  one-click launch will use.
+- Codex configuration profiles are now first-class Session options. Creation
+  discovers profile overlays, remembers the chosen profile with the Session,
+  resumes with the same configuration, marks missing profiles, and shows the
+  profile on Session rows. Older Codex CLIs keep the existing profile-free
+  flow and receive a one-time upgrade hint.
+- New `Agent Pivot: Seek to Latest Conversation Interaction` command exposes
+  the AI Conversation viewer's Latest action to the Command Palette and
+  custom keybindings.
 - The AI Conversation header carries a pair of global Session status dots
   between the title and the navigation buttons: a green dot pulses while AI
   Sessions are running in any open window and a red dot pulses while
@@ -15,6 +31,18 @@ All notable changes to the "Agent Pivot" extension will be documented in this fi
 
 ### Changed
 
+- Large Codex conversations now open behind an outline-complete summary
+  window and load older content on demand. Subsequent refreshes validate and
+  incrementally update bounded caches, cutting cold starts and switch-back
+  waits without loading the entire conversation into the Webview at once.
+- Switching back to a recently viewed conversation restores its retained
+  frame, reading position, and expanded work entries when the content is
+  unchanged. While a different Session is loading, the previous conversation
+  remains visible in a dimmed busy state instead of appearing frozen.
+- Clicking the active Outline, Comments, or Subagents telemetry pill now
+  closes the AI Conversation sidebar; clicking a different pill switches tabs
+  while keeping the sidebar open, and the pressed state is exposed to
+  assistive technology.
 - On the OPEN tab, expanding the CURRENT WINDOW card now fits the card to
   its window region (half the pane by default, or the dragged separator
   share): the visible AI session panel fills the remaining card height and
@@ -47,6 +75,19 @@ All notable changes to the "Agent Pivot" extension will be documented in this fi
 
 ### Fixed
 
+- Oversized conversation turns with hundreds of tool events are now reduced
+  deterministically while preserving the user request, latest answer, key
+  identifiers, and an explicit omission notice, so one very large turn no
+  longer prevents the entire conversation from opening.
+- Rapid Session switches no longer leave Kimi or Claude conversations showing
+  stale content, and failed frame restores now request a fresh document only
+  for the Session generation that still owns the viewer.
+- Codex telemetry now honors a selected profile's declared context window,
+  including Sessions started outside Agent Pivot when their rollout model
+  matches one unambiguous profile.
+- Cross-window running/attention rotation, focus handoff, and acknowledgement
+  recovery are more reliable under concurrent refreshes; background worker
+  completion no longer leaves the Extension Host waiting indefinitely.
 - SKILL.md frontmatter parsing understands YAML block scalars
   (`description: >-` folded and `|` literal) and a UTF-8 BOM, so vendored
   skills with multi-line descriptions show their real summary instead of

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "fb534d8f247d68cb044527cbbcd42add309d71c4",
+        "head": "c9fba076c91ed50d61af21ef040d31c0c71a903c",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -300,7 +300,8 @@
             "0dc784a3d38f9c1f34ef51cb962d5fd3daf746b3",
             "a91500128a1bf9892018b7523e8fffc2192ef4ef",
             "727c0d86d15b48cb88612b0753e7477df42329b3",
-            "c50235a8ad45dc430c1660675b1daa15f633d50f"
+            "c50235a8ad45dc430c1660675b1daa15f633d50f",
+            "3f9e51abe3cc6ffdba0d20838e736e434f93e28a"
         ]
     },
     "capabilities": [
@@ -775,7 +776,8 @@
                 "48ecf9d5e2127ab94879a7a899789892881b7fe5",
                 "c8df4355af418e21ca9efc6ff1511b05e85c21a4",
                 "5b3f34942480cfe1f3a695cb4114c0c64c62ca6b",
-                "736d1b87398bf0bd75f171a3c4698295aff38c32"
+                "736d1b87398bf0bd75f171a3c4698295aff38c32",
+                "c9fba076c91ed50d61af21ef040d31c0c71a903c"
             ],
             "behaviors": [
                 "RELEASE-VSIX-PACKAGING-001",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "agent-pivot",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "agent-pivot",
-            "version": "1.1.0",
+            "version": "1.1.1",
             "license": "MIT",
             "dependencies": {
                 "dom-autoscroller": "^2.3.4",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "agent-pivot",
     "displayName": "Agent Pivot",
     "description": "Switch, monitor, and resume Codex, Claude, and Kimi sessions across VS Code workspaces. Project manager, prompt library, and todos for AI coding agents.",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "publisher": "hzcheng",
     "license": "MIT",
     "icon": "media/extension_icon.png",

--- a/scripts/lib/brandIdentity.js
+++ b/scripts/lib/brandIdentity.js
@@ -10,7 +10,7 @@ const BRAND_IDENTITY = Object.freeze({
     publisher: 'hzcheng',
     mainPackageName: 'agent-pivot',
     mainExtensionId: 'hzcheng.agent-pivot',
-    mainVersion: '1.1.0',
+    mainVersion: '1.1.1',
     bridgePackageName: 'agent-pivot-attention-ui-bridge',
     bridgeExtensionId: 'hzcheng.agent-pivot-attention-ui-bridge',
     bridgeVersion: '1.0.2',

--- a/scripts/run-release-notes-checks.js
+++ b/scripts/run-release-notes-checks.js
@@ -14,14 +14,14 @@ const workflowPath = path.join(repositoryRoot, '.github', 'workflows', 'release-
 function validateReleaseContent({ readme, changelog, packageMetadata }) {
     assert.strictEqual(packageMetadata.displayName, 'Agent Pivot',
         'release metadata must use the Agent Pivot display name');
-    assert.strictEqual(packageMetadata.version, '1.1.0',
-        'the current Agent Pivot release must be version 1.1.0');
+    assert.strictEqual(packageMetadata.version, '1.1.1',
+        'the current Agent Pivot release must be version 1.1.1');
     const currentRelease = extractReleaseNotes(changelog, packageMetadata.version);
     const requiredReleaseFacts = [
-        ['sponsor entry points', /Agent Pivot: Sponsor/i],
-        ['marketplace discoverability', /discoverability/i],
-        ['workspace conversation comments', /Workspace section/i],
-        ['custom running animation', /aiSessionRunningCardCustomImage/i],
+        ['one-click session creation', /one click\s+starts a new Session/i],
+        ['Codex profile support', /Codex configuration profiles/i],
+        ['large Codex conversation performance', /large Codex conversations/i],
+        ['global Session status', /global Session status dots/i],
     ];
 
     for (const [label, pattern] of requiredReleaseFacts) {

--- a/scripts/run-release-packaging-checks.js
+++ b/scripts/run-release-packaging-checks.js
@@ -407,7 +407,7 @@ function runRealVsixArchiveChecks(mainPackage, bridgePackage) {
     );
     assert.strictEqual(
         path.basename(mainArtifact),
-        'agent-pivot-1.1.0.vsix',
+        'agent-pivot-1.1.1.vsix',
         'main release artifact name must remain exact',
     );
     assert.strictEqual(

--- a/tests/unit/tooling/brandIdentity.test.js
+++ b/tests/unit/tooling/brandIdentity.test.js
@@ -50,7 +50,7 @@ function manifests() {
             name: 'agent-pivot',
             displayName: 'Agent Pivot',
             publisher: 'hzcheng',
-            version: '1.1.0',
+            version: '1.1.1',
             icon: 'media/extension_icon.png',
             repository: {
                 type: 'git',
@@ -282,7 +282,7 @@ test('brand identity exposes the exact approved public contract', () => {
         publisher: 'hzcheng',
         mainPackageName: 'agent-pivot',
         mainExtensionId: 'hzcheng.agent-pivot',
-        mainVersion: '1.1.0',
+        mainVersion: '1.1.1',
         bridgePackageName: 'agent-pivot-attention-ui-bridge',
         bridgeExtensionId: 'hzcheng.agent-pivot-attention-ui-bridge',
         bridgeVersion: '1.0.2',

--- a/tests/unit/tooling/extensionHostLauncher.test.js
+++ b/tests/unit/tooling/extensionHostLauncher.test.js
@@ -150,7 +150,7 @@ test('RELEASE-SCHEDULED-EXTENSION-HOST-001 launches both extensions with pinned 
         ]);
         assert.deepEqual(packagePlan.map(item => path.basename(item.artifactPath)), [
             'agent-pivot-attention-ui-bridge-1.0.2.vsix',
-            'agent-pivot-1.1.0.vsix',
+            'agent-pivot-1.1.1.vsix',
         ]);
         assert.equal(options.extensionTestsPath,
             path.join(environment.testHarness, 'index.js'));

--- a/tests/unit/tooling/releaseNotes.test.js
+++ b/tests/unit/tooling/releaseNotes.test.js
@@ -14,7 +14,7 @@ test('release content validation cannot satisfy current facts from historical no
     const changelog = [
         '# Changelog',
         '',
-        '## [1.1.0] - 2026-08-09',
+        '## [1.1.1] - 2026-08-13',
         '',
         '- AI Conversation renders provider tool calls as collapsible entries.',
         '- Added context-window usage telemetry.',
@@ -33,10 +33,10 @@ test('release content validation cannot satisfy current facts from historical no
             changelog,
             packageMetadata: {
                 displayName: 'Agent Pivot',
-                version: '1.1.0',
+                version: '1.1.1',
                 description: 'Workspace command center.',
             },
         }),
-        /1\.1\.0 CHANGELOG release must document sponsor entry points/,
+        /1\.1\.1 CHANGELOG release must document one-click session creation/,
     );
 });


### PR DESCRIPTION
## Summary

- bump the main Agent Pivot extension from 1.1.0 to 1.1.1 while shipping the already-versioned Attention UI Bridge 1.0.2 companion
- promote the accumulated Unreleased changes into dated 1.1.1 release notes and add concise user-facing coverage for quick session creation, Codex profiles, large-conversation performance, and reliability fixes
- synchronize brand identity, release-note, release-packaging, and extension-host version contracts

## Skill harvest

no skill change — the only retry was a release-note line-wrap assertion caught by the existing focused check; no workflow instruction gap.

## Verification

- npm run test-compile
- npm run test:release-notes
- focused release notes, brand identity, and extension-host launcher tests (26 passed)
- npm run test:release-packaging
- npm run test:behavior-contracts
- npm run lint (exit 0; existing warnings only)
- git diff --check

## Release artifacts verified locally

- agent-pivot-1.1.1.vsix
- agent-pivot-attention-ui-bridge-1.0.2.vsix