### PR TITLE
fix: log silent worktree group provisioning failures

### DIFF
--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "e670a7b0b7d2d81297e1386eb7b5f809de181ee0",
+        "head": "ecdfa526e6a26c7c154b1d7bb0374219ffa0a36d",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -383,7 +383,8 @@
             "51207a59b712ab39095324473af1afb6097a2005",
             "bdefc9862f67b2b9b3fce6560c303aee3d37ac89",
             "3c1e35862df0cda3673d65dd6848538a2238b29b",
-            "8b8b497b025b98c26e551a31aefcf5cacdd0abda"
+            "8b8b497b025b98c26e551a31aefcf5cacdd0abda",
+            "6152c530e40b3a5c696da8ea35438d70484bddcf"
         ]
     },
     "capabilities": [
@@ -554,7 +555,8 @@
                 "0b0f431afcbeebf590b7e61a7740ccf895564112",
                 "afc81e5eef91f229419bd7df83f6cd169e36bf56",
                 "c2c694efbaf8661f6fe4b6eabfd2ad5e700a3c4d",
-                "e670a7b0b7d2d81297e1386eb7b5f809de181ee0"
+                "e670a7b0b7d2d81297e1386eb7b5f809de181ee0",
+                "ecdfa526e6a26c7c154b1d7bb0374219ffa0a36d"
             ],
             "behaviors": [
                 "PERSIST-AI-SESSION-PROJECT-HYDRATION-CONTROLLER-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "ecdfa526e6a26c7c154b1d7bb0374219ffa0a36d",
+        "head": "74140c81d3fdf8bb2c09c2684a47fa0a12ae701d",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -384,7 +384,8 @@
             "bdefc9862f67b2b9b3fce6560c303aee3d37ac89",
             "3c1e35862df0cda3673d65dd6848538a2238b29b",
             "8b8b497b025b98c26e551a31aefcf5cacdd0abda",
-            "6152c530e40b3a5c696da8ea35438d70484bddcf"
+            "6152c530e40b3a5c696da8ea35438d70484bddcf",
+            "5e55660b1986ba36929466ec8f989cfaf9657ef8"
         ]
     },
     "capabilities": [
@@ -556,7 +557,8 @@
                 "afc81e5eef91f229419bd7df83f6cd169e36bf56",
                 "c2c694efbaf8661f6fe4b6eabfd2ad5e700a3c4d",
                 "e670a7b0b7d2d81297e1386eb7b5f809de181ee0",
-                "ecdfa526e6a26c7c154b1d7bb0374219ffa0a36d"
+                "ecdfa526e6a26c7c154b1d7bb0374219ffa0a36d",
+                "74140c81d3fdf8bb2c09c2684a47fa0a12ae701d"
             ],
             "behaviors": [
                 "PERSIST-AI-SESSION-PROJECT-HYDRATION-CONTROLLER-001",

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1693,6 +1693,15 @@ async function initializeDashboard(
         runSetup: (_plan, worktreeKey, isCancelled, command) =>
             worktreeSetupRunner.run(command, worktreeKey.canonicalWorktreePath, isCancelled),
         publishRows: () => refreshAiSessionViewsIncrementally(),
+        onSettled: outcome => {
+            // Non-success settlements only surface as a transient row state;
+            // log them so post-hoc diagnosis does not depend on the UI.
+            if (outcome.kind !== 'succeeded') {
+                logError(
+                    `Worktree provisioning settled without success: kind=${outcome.kind} error=${outcome.errorCode} operationId=${outcome.operationId}`,
+                    undefined);
+            }
+        },
         recoveredOperations: worktreeProvisioningStore.read(),
         persistOperations: operations => worktreeProvisioningStore.replaceLive(operations),
         persistTombstones: records =>
@@ -1705,55 +1714,63 @@ async function initializeDashboard(
         onPersistenceError: error => logError(
             'Could not persist isolated worktree provisioning recovery state.', error),
         recordProvisionedWorktree: async info => {
-            const target = getCurrentWorkspaceActionTarget(info.projectId);
-            if (!target) {
-                const error = new Error('The workspace is unavailable for manifest recording.');
-                (error as Error & { code?: string }).code = 'manifest-unavailable';
-                throw error;
-            }
-            // Save Workspace As can reuse a legacy projectId for a different
-            // workspace; never write the old operation into the new bucket.
-            if (info.navigationIdentity
-                && target.workspace.navigationIdentity !== info.navigationIdentity) {
-                const error = new Error('The workspace changed since provisioning started.');
-                (error as Error & { code?: string }).code = 'manifest-unavailable';
-                throw error;
-            }
-            const bucket = target.workspace.navigationIdentity;
-            // A completed provisioning clears any tombstone claiming the
-            // worktree is half-initialized.
-            isolatedSessionController?.removeTombstonesForWorktree(
-                info.worktreeKey.repositoryKey,
-                info.worktreeKey.canonicalWorktreePath);
-            if (info.groupId && info.memberId) {
-                // Group creation (M2): the group already exists with this
-                // member planned; mark the member ready and apply the
-                // confirmed primary choice once its member is ready.
-                await worktreeGroupManifestStore.updateMember(
-                    bucket, info.groupId, info.memberId, {
-                        state: 'ready',
-                        worktreeKey: info.worktreeKey,
-                    });
-                if (info.preferredPrimary) {
-                    await worktreeGroupManifestStore.setPrimaryMember(
-                        bucket, info.groupId, info.memberId);
+            try {
+                const target = getCurrentWorkspaceActionTarget(info.projectId);
+                if (!target) {
+                    const error = new Error('The workspace is unavailable for manifest recording.');
+                    (error as Error & { code?: string }).code = 'manifest-unavailable';
+                    throw error;
                 }
-                return;
+                // Save Workspace As can reuse a legacy projectId for a different
+                // workspace; never write the old operation into the new bucket.
+                if (info.navigationIdentity
+                    && target.workspace.navigationIdentity !== info.navigationIdentity) {
+                    const error = new Error('The workspace changed since provisioning started.');
+                    (error as Error & { code?: string }).code = 'manifest-unavailable';
+                    throw error;
+                }
+                const bucket = target.workspace.navigationIdentity;
+                // A completed provisioning clears any tombstone claiming the
+                // worktree is half-initialized.
+                isolatedSessionController?.removeTombstonesForWorktree(
+                    info.worktreeKey.repositoryKey,
+                    info.worktreeKey.canonicalWorktreePath);
+                if (info.groupId && info.memberId) {
+                    // Group creation (M2): the group already exists with this
+                    // member planned; mark the member ready and apply the
+                    // confirmed primary choice once its member is ready.
+                    await worktreeGroupManifestStore.updateMember(
+                        bucket, info.groupId, info.memberId, {
+                            state: 'ready',
+                            worktreeKey: info.worktreeKey,
+                        });
+                    if (info.preferredPrimary) {
+                        await worktreeGroupManifestStore.setPrimaryMember(
+                            bucket, info.groupId, info.memberId);
+                    }
+                    return;
+                }
+                if (worktreeGroupManifestStore.findGroupByWorktreeKey(bucket, info.worktreeKey)) {
+                    return;
+                }
+                await worktreeGroupManifestStore.createGroup(bucket, {
+                    displayName: info.plan.taskName,
+                    suggestedSlug: info.plan.slug,
+                    members: [{
+                        repositoryKey: info.plan.repositoryKey,
+                        worktreeKey: info.worktreeKey,
+                        branchName: info.plan.branchName,
+                        path: info.worktreeKey.canonicalWorktreePath,
+                        state: 'ready',
+                    }],
+                });
+            } catch (error) {
+                // This throw degrades the operation to a retryable partial;
+                // log it here because the settlement path only persists the
+                // error code into the member record without logging.
+                logError('Failed to record provisioned worktree into the group manifest.', error);
+                throw error;
             }
-            if (worktreeGroupManifestStore.findGroupByWorktreeKey(bucket, info.worktreeKey)) {
-                return;
-            }
-            await worktreeGroupManifestStore.createGroup(bucket, {
-                displayName: info.plan.taskName,
-                suggestedSlug: info.plan.slug,
-                members: [{
-                    repositoryKey: info.plan.repositoryKey,
-                    worktreeKey: info.worktreeKey,
-                    branchName: info.plan.branchName,
-                    path: info.worktreeKey.canonicalWorktreePath,
-                    state: 'ready',
-                }],
-            });
         },
     });
     let managedWorktreeRemovalController: ManagedWorktreeRemovalController;
@@ -1811,6 +1828,7 @@ async function initializeDashboard(
             isolatedSessionController!.isTombstoneStoreFull(),
         writeSyntheticTombstone: input =>
             isolatedSessionController!.writeSyntheticTombstone(input),
+        onError: (message, error) => logError(message, error),
         onDidChange: () => {
             void aiSessionDashboardController.refreshNow(
                 'worktree-group-creation', { fallbackToFullRefresh: false });

--- a/src/dashboard/diagnostics.ts
+++ b/src/dashboard/diagnostics.ts
@@ -27,7 +27,9 @@ export default class DashboardDiagnostics {
 
     logError(message: string, error: unknown) {
         this.options.outputChannel.appendLine(message);
-        this.options.outputChannel.appendLine(error instanceof Error ? `${error.stack || error.message}` : String(error));
+        if (error !== undefined) {
+            this.options.outputChannel.appendLine(error instanceof Error ? `${error.stack || error.message}` : String(error));
+        }
     }
 
     logOpenWorkspaceBridgeError(_error: unknown) {

--- a/src/worktrees/groupCreationController.ts
+++ b/src/worktrees/groupCreationController.ts
@@ -130,6 +130,12 @@ export interface WorktreeGroupCreationControllerOptions {
         projectId: string;
         navigationIdentity: string;
     }) => Promise<boolean>;
+    /**
+     * Diagnostic sink for member failures. Settlement writes the error code
+     * into the member record but never logs it, so without this hook a
+     * failed finalize is invisible after the fact.
+     */
+    onError?: (message: string, error?: unknown) => void;
     onDidChange?: () => void;
 }
 
@@ -889,10 +895,16 @@ export class WorktreeGroupCreationController {
         try {
             await this.settleMemberOutcome(
                 navigationIdentity, groupId, input.memberId, outcome);
-        } catch (_error) {
+        } catch (error) {
             // The member record may be gone (dismissed after a spurious
             // downgrade raced the operation); the physical worktree is
             // re-seeded by reconciliation and never lost.
+            const outcomeSummary = outcome.kind === 'succeeded'
+                ? 'succeeded'
+                : `${outcome.kind}/${outcome.errorCode}`;
+            this.options.onError?.(
+                `Failed to persist worktree group member outcome: groupId=${groupId} memberId=${input.memberId} outcome=${outcomeSummary}`,
+                error);
         }
     }
 
@@ -908,6 +920,11 @@ export class WorktreeGroupCreationController {
             this.options.onDidChange?.();
             return;
         }
+        const completedSteps = outcome.kind === 'partial'
+            ? outcome.completedSteps.join(',') || '-'
+            : '-';
+        this.options.onError?.(
+            `Worktree group member settled without success: kind=${outcome.kind} error=${outcome.errorCode} completedSteps=${completedSteps} groupId=${groupId} memberId=${memberId}`);
         await this.options.manifestStore.updateMember(
             navigationIdentity, groupId, memberId, {
                 state: 'failed',

--- a/src/worktrees/groupCreationController.ts
+++ b/src/worktrees/groupCreationController.ts
@@ -899,11 +899,9 @@ export class WorktreeGroupCreationController {
             // The member record may be gone (dismissed after a spurious
             // downgrade raced the operation); the physical worktree is
             // re-seeded by reconciliation and never lost.
-            const outcomeSummary = outcome.kind === 'succeeded'
-                ? 'succeeded'
-                : `${outcome.kind}/${outcome.errorCode}`;
+            const errorCode = 'errorCode' in outcome ? outcome.errorCode : '-';
             this.options.onError?.(
-                `Failed to persist worktree group member outcome: groupId=${groupId} memberId=${input.memberId} outcome=${outcomeSummary}`,
+                `Failed to persist worktree group member outcome: groupId=${groupId} memberId=${input.memberId} outcome=${outcome.kind}/${errorCode}`,
                 error);
         }
     }

--- a/tests/contract/worktrees/groupCreationController.test.js
+++ b/tests/contract/worktrees/groupCreationController.test.js
@@ -302,6 +302,115 @@ test('WORKTREE-GROUPS-CREATE-001 a failed member stays in the group with its err
         member.repositoryKey === '/alpha/.git').state, 'ready');
 });
 
+test('WORKTREE-GROUPS-CREATE-001 a failed member settlement is logged with its error code', async () => {
+    const logged = [];
+    const current = fixture({
+        onError: (message, error) => logged.push([message, error]),
+        startMemberOperation: async input => {
+            if (input.plan.repositoryKey === '/beta/.git') {
+                return {
+                    kind: 'partial',
+                    operationId: input.operationId,
+                    worktreeKey: {
+                        repositoryKey: '/beta/.git',
+                        canonicalWorktreePath: input.plan.worktreePath,
+                    },
+                    errorCode: 'branch-conflict',
+                    completedSteps: ['worktree'],
+                };
+            }
+            await current.options.manifestStore.updateMember(
+                workspace.navigationIdentity, input.groupId, input.memberId, {
+                    state: 'ready',
+                    worktreeKey: {
+                        repositoryKey: input.plan.repositoryKey,
+                        canonicalWorktreePath: input.plan.worktreePath,
+                    },
+                });
+            return {
+                kind: 'succeeded', operationId: input.operationId,
+                worktreeKey: {}, plan: input.plan,
+            };
+        },
+    });
+    const result = await current.controller.confirm({
+        projectId: 'project',
+        previewId: await previewIdFor(current),
+        displayName: 'Fix login',
+        members: confirmedMembers(),
+    });
+    assert.equal(result.kind, 'created');
+    const group = current.manifestStore
+        .listGroups(workspace.navigationIdentity)[0];
+    const failed = group.members.find(member =>
+        member.repositoryKey === '/beta/.git');
+    const entry = logged.find(([message]) =>
+        message.includes('settled without success'));
+    assert.ok(entry, 'a non-success settlement must reach the diagnostic sink');
+    assert.ok(entry[0].includes('kind=partial'));
+    assert.ok(entry[0].includes('error=branch-conflict'));
+    assert.ok(entry[0].includes('completedSteps=worktree'));
+    assert.ok(entry[0].includes(`groupId=${group.groupId}`));
+    assert.ok(entry[0].includes(`memberId=${failed.memberId}`));
+});
+
+test('WORKTREE-GROUPS-CREATE-001 a settlement persist failure is logged without rejecting confirm', async () => {
+    const logged = [];
+    const current = fixture({
+        onError: (message, error) => logged.push([message, error]),
+        startMemberOperation: async input => {
+            if (input.plan.repositoryKey === '/beta/.git') {
+                return {
+                    kind: 'partial',
+                    operationId: input.operationId,
+                    worktreeKey: {
+                        repositoryKey: '/beta/.git',
+                        canonicalWorktreePath: input.plan.worktreePath,
+                    },
+                    errorCode: 'setup-failed',
+                    completedSteps: ['worktree'],
+                };
+            }
+            await current.options.manifestStore.updateMember(
+                workspace.navigationIdentity, input.groupId, input.memberId, {
+                    state: 'ready',
+                    worktreeKey: {
+                        repositoryKey: input.plan.repositoryKey,
+                        canonicalWorktreePath: input.plan.worktreePath,
+                    },
+                });
+            return {
+                kind: 'succeeded', operationId: input.operationId,
+                worktreeKey: {}, plan: input.plan,
+            };
+        },
+    });
+    // The settle-time state write races a dismissed record: updateMember
+    // throws, and runMember must log instead of swallowing silently.
+    const originalUpdateMember = current.manifestStore.updateMember.bind(
+        current.manifestStore);
+    current.manifestStore.updateMember = async (identity, groupId, memberId, patch) => {
+        if (patch && patch.state === 'failed') {
+            throw new Error('member-not-found');
+        }
+        return originalUpdateMember(identity, groupId, memberId, patch);
+    };
+    const result = await current.controller.confirm({
+        projectId: 'project',
+        previewId: await previewIdFor(current),
+        displayName: 'Fix login',
+        members: confirmedMembers(),
+    });
+    assert.equal(result.kind, 'created',
+        'a settle persist failure never rejects the whole confirm');
+    const entry = logged.find(([message]) =>
+        message.includes('Failed to persist worktree group member outcome'));
+    assert.ok(entry, 'a settlement persist failure must reach the diagnostic sink');
+    assert.ok(entry[0].includes('outcome=partial/setup-failed'));
+    assert.ok(entry[1] instanceof Error);
+    assert.equal(entry[1].message, 'member-not-found');
+});
+
 test('WORKTREE-GROUPS-CREATE-001 confirm rejects forged or duplicate member sets', async () => {
     const current = fixture();
     const duplicate = await current.controller.confirm({


### PR DESCRIPTION
## Summary

A worktree task whose member provisioning fails **after** the physical worktree was created (finalize / manifest write stage) only persisted an error code into the in-memory member record. Nothing reached the output channel, so post-hoc diagnosis was impossible — this made a real `arch-refactor` task failure undebuggable after the fact.

This change adds host-side logging to the silent paths, with no behavior change:

- `IsolatedSessionController` settles: log any non-success outcome with kind / errorCode / operationId via the previously unwired `onSettled` option.
- `WorktreeGroupCreationController.settleMemberOutcome`: log kind / errorCode / completedSteps / groupId / memberId before the failed state write.
- `runMember`: the settle-outcome persist catch no longer swallows silently; it logs with the outcome summary.
- `recordProvisionedWorktree`: wrap in try/catch and log the original stack before rethrowing (the throw degrades the operation to a retryable partial).
- `DashboardDiagnostics.logError`: tolerate a `undefined` error argument for message-only entries instead of printing a bare `undefined` line.

## Verification

- `npm run test-compile` (after rebase onto `origin/main` @ b67050dd)
- `node --test tests/contract/worktrees/groupCreationController.test.js tests/contract/worktrees/provisioningController.test.js tests/contract/aiSessions/runtimeComposition.test.js` — 56 pass
- `npm run test:behavior-contracts` — pass
- `git diff --check` — clean

## Skill harvest

none — the only process friction was a malformed patch hunk caught immediately by `test-compile`; `review-fix-commit-loop` already covers anchor verification, so no skill change is justified.