### PR TITLE
docs(skill): keep merged feature branches unless cleanup is requested

### DIFF
--- a/.skills/publishing-and-merging-github-prs/SKILL.md
+++ b/.skills/publishing-and-merging-github-prs/SKILL.md
@@ -75,12 +75,16 @@ If push reports HTTP 408, `unexpected EOF`, or an RPC disconnect:
 4. Honor approval gates exactly. If the user said "merge after I approve", stop until that approval is present in the conversation.
 5. If draft and user approved/asked to merge, run `gh pr ready <n>`.
 6. Merge with the repository's expected strategy, or default to merge commit:
-   - `gh pr merge <n> --merge --delete-branch`
+   - `gh pr merge <n> --merge`
+   - Keep the feature branch by default: a worktree-backed branch is a
+     long-lived work surface reused across consecutive fixes, so deleting
+     the remote branch breaks that loop. Pass `--delete-branch` only when
+     the user explicitly asks for branch cleanup.
 7. GitHub GraphQL can return `unexpected EOF` after a successful mutation. Always re-check:
    - `gh pr view <n> --json state,mergedAt,mergeCommit,isDraft`
    - `git fetch origin <base> --prune`
    - `git log --oneline -1 origin/<base>`
-8. If `--delete-branch` did not run because of a transient API failure, delete the remote feature branch explicitly after confirming the PR is merged:
+8. When the user did request branch cleanup and `--delete-branch` did not run because of a transient API failure, delete the remote feature branch explicitly after confirming the PR is merged:
    - `git push origin --delete <branch>`
    - `git ls-remote --heads origin <branch>`
 
@@ -89,5 +93,5 @@ If push reports HTTP 408, `unexpected EOF`, or an RPC disconnect:
 - Never merge a PR whose target repository or base branch is ambiguous.
 - Never merge a PR without an explicit in-conversation approval for that PR; green checks are not approval.
 - Never treat an API transport error as failure or success without checking PR state.
-- Never delete the local worktree or branch until the merge commit is confirmed.
+- Never delete the remote branch, local branch, or worktree unless the user explicitly asks; even then, never delete the local worktree or branch until the merge commit is confirmed.
 - Do not force push or force update refs unless the user explicitly asks.

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "74140c81d3fdf8bb2c09c2684a47fa0a12ae701d",
+        "head": "534b86f41a7a8a172332d0b67e9d16a944e9df5c",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -385,7 +385,8 @@
             "3c1e35862df0cda3673d65dd6848538a2238b29b",
             "8b8b497b025b98c26e551a31aefcf5cacdd0abda",
             "6152c530e40b3a5c696da8ea35438d70484bddcf",
-            "5e55660b1986ba36929466ec8f989cfaf9657ef8"
+            "5e55660b1986ba36929466ec8f989cfaf9657ef8",
+            "1a83abc5e2b2776c6710340bb5957c406846cd85"
         ]
     },
     "capabilities": [
@@ -1468,7 +1469,8 @@
                 "0d96cc1c2a41e56dded2f4608e64a3dfabbfce8d",
                 "49aef514839e2702baf1ee295ccbf4791be82280",
                 "2a6ed05a8160df4018e20a09dc09d76378d9a82e",
-                "18281dc9400c3800e88f68d866f4cb827b4e54e6"
+                "18281dc9400c3800e88f68d866f4cb827b4e54e6",
+                "534b86f41a7a8a172332d0b67e9d16a944e9df5c"
             ],
             "behaviors": [
                 "ARCH-CI-QUALITY-GATE-001",


### PR DESCRIPTION
## Summary

The publishing skill's merge step defaulted to `gh pr merge <n> --merge --delete-branch`, so every merged PR deleted its remote feature branch. That default predates the worktree workflow: a worktree-backed branch is a long-lived work surface reused across consecutive small fixes, and deleting the remote branch on merge breaks that loop (the next fix has to recreate and re-push the branch). It already caused an unintended deletion on #243.

Changes to `.skills/publishing-and-merging-github-prs/SKILL.md`:

- Merge step: default is now plain `gh pr merge <n> --merge`; `--delete-branch` requires an explicit user request.
- The transient-failure branch-deletion retry step now applies only when cleanup was actually requested.
- Guardrails: never delete the remote branch, local branch, or worktree unless the user explicitly asks; even then, local cleanup waits until the merge commit is confirmed.

## Verification

- `npm run test:skills` (compile + skill management checks) — pass
- `npm run test:behavior-contracts` — pass
- `git diff --check` — clean
- No script or test anchors `delete-branch` (verified by grep over `scripts/` and `tests/`).

## Skill harvest

updated:.skills/publishing-and-merging-github-prs — this PR *is* the harvest: user correction on #243 ("one worktree serves many consecutive small fixes") exposed that the skill's delete-on-merge default contradicts the worktree workflow. Evidence: the remote `agent-pivot/quick-fix` branch was deleted by the #243 merge without the user wanting it.