### PR TITLE
fix: merge streamed Kimi text deltas into one conversation block

### DIFF
--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "0fed732eee67b22fe3e041711a80f16b213fc52b",
+        "head": "3b8064d460afec74027e39d4c8f7e8120e9658af",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -407,7 +407,8 @@
             "bbdddd86e704b20776364fe0592816b7d81d8cba",
             "c96e7c64349e222b936028f53dfdadb7d5bda8aa",
             "98edde499337cf10e858efc3de2839d476506f23",
-            "3829b1e86bb097a62dc3afc49cbb517747c92e74"
+            "3829b1e86bb097a62dc3afc49cbb517747c92e74",
+            "26a36ba1395101aa72c8c55f2000edc0198bc32f"
         ]
     },
     "capabilities": [
@@ -1876,7 +1877,8 @@
                 "f6775a1a2e74527be5983a051cf3974581814ce6",
                 "6d2e4a699102a51e6fa14a4bf02b078970e70fad",
                 "46a7343292593e6f4894ba2634d0cae2226b51f3",
-                "0fed732eee67b22fe3e041711a80f16b213fc52b"
+                "0fed732eee67b22fe3e041711a80f16b213fc52b",
+                "3b8064d460afec74027e39d4c8f7e8120e9658af"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",

--- a/src/aiSessions/conversation/kimiAdapter.ts
+++ b/src/aiSessions/conversation/kimiAdapter.ts
@@ -138,6 +138,14 @@ interface KimiConversationIndex extends AiSessionDisposable {
     /** approval request id → gated tool_call_id, for ApprovalResponse. */
     approvalTracker?: Map<string, string>;
     pendingThinking?: { position: number; text: string } | null;
+    /**
+     * Raw buffered text deltas of the open run. The Kimi wire streams
+     * token-sized ContentPart deltas; each delta must not render as its own
+     * line. Persisted across incremental loads like pendingThinking; once
+     * published, entryIndex points at the trailing assistant block so the
+     * next load replaces it instead of appending.
+     */
+    pendingText?: { text: string; entryIndex?: number } | null;
     /** Whether the most recent load read incrementally from the cache. */
     lastReadContinuation: boolean;
     revision: number;
@@ -700,6 +708,35 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
             // Consecutive think deltas merge into one block per run.
             let pendingThinking: { position: number; text: string } | null =
                 (continuing && previous?.pendingThinking) || null;
+            // Consecutive text deltas merge into one block per run; the raw
+            // buffer normalizes once per published block so whitespace-only
+            // deltas (e.g. a space between words) survive.
+            let pendingText: { text: string; entryIndex?: number } | null =
+                (continuing && previous?.pendingText) || null;
+            const publishText = (): void => {
+                if (!pendingText || openInteractionIndex === undefined) {
+                    return;
+                }
+                const text = visibleMessage(pendingText.text);
+                if (!text) {
+                    return;
+                }
+                const interaction = interactions[openInteractionIndex];
+                if (pendingText.entryIndex !== undefined) {
+                    // The run already rendered in a previous load: replace
+                    // its trailing block instead of appending a new one.
+                    interaction.assistantMarkdown[pendingText.entryIndex] = text;
+                    return;
+                }
+                appendConversationAssistantText(interaction, text);
+                pendingText.entryIndex = interaction.assistantMarkdown.length - 1;
+            };
+            // A non-text event closes the run; the next delta starts a new
+            // block.
+            const flushText = (): void => {
+                publishText();
+                pendingText = null;
+            };
             const flushThinking = (): void => {
                 if (!pendingThinking || openInteractionIndex === undefined) {
                     pendingThinking = null;
@@ -723,6 +760,7 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                 }
                 if (event.type === 'TurnBegin') {
                     flushThinking();
+                    flushText();
                     const payload = asRecord(event.payload);
                     const userInput = payload?.user_input;
                     const visibleInput = typeof userInput === 'string'
@@ -784,6 +822,12 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                         : undefined;
                     if (openInteractionIndex !== undefined
                         && thinkText !== undefined) {
+                        if (thinkText === '') {
+                            // Streaming keep-alives must not split the
+                            // surrounding text run.
+                            return;
+                        }
+                        flushText();
                         if (!pendingThinking) {
                             pendingThinking = {
                                 position: interactions[openInteractionIndex]
@@ -798,16 +842,16 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                     if (openInteractionIndex !== undefined
                         && payload?.type === 'text'
                         && typeof payload.text === 'string') {
-                        const text = visibleMessage(payload.text);
-                        if (text) {
-                            appendConversationAssistantText(
-                                interactions[openInteractionIndex],
-                                text
-                            );
+                        if (!pendingText) {
+                            pendingText = { text: '' };
                         }
+                        pendingText.text += payload.text;
+                        return;
                     }
+                    flushText();
                 } else if (event.type === 'PlanDisplay') {
                     flushThinking();
+                    flushText();
                     stampActivity(envelope);
                     const payload = asRecord(event.payload);
                     if (openInteractionIndex !== undefined
@@ -834,6 +878,7 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                     }
                 } else if (event.type === 'QuestionRequest') {
                     flushThinking();
+                    flushText();
                     stampActivity(envelope);
                     const payload = asRecord(event.payload);
                     if (openInteractionIndex !== undefined) {
@@ -885,6 +930,7 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                     }
                 } else if (event.type === 'ApprovalRequest') {
                     flushThinking();
+                    flushText();
                     stampActivity(envelope);
                     const payload = asRecord(event.payload);
                     if (openInteractionIndex !== undefined) {
@@ -985,6 +1031,7 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                     }
                 } else if (event.type === 'ToolCall') {
                     flushThinking();
+                    flushText();
                     stampActivity(envelope);
                     const payload = asRecord(event.payload);
                     const toolFunction = asRecord(payload?.function);
@@ -1105,6 +1152,7 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                 state: ConversationResponseState
             ): void => {
                 flushThinking();
+                flushText();
                 if (openInteractionIndex === undefined) {
                     return;
                 }
@@ -1154,6 +1202,10 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                 };
             }
             const partial = continuing ? previous.partial : result.partial;
+            // Publish the in-progress text run so a streaming answer stays
+            // visible between loads; the buffer itself stays open for later
+            // deltas.
+            publishText();
             const changed = !previous
                 || previous.source.identity !== source.identity
                 || previous.source.portableFirstHash
@@ -1177,6 +1229,7 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                 previous.questionTracker = questionTracker;
                 previous.approvalTracker = approvalTracker;
                 previous.pendingThinking = pendingThinking;
+                previous.pendingText = pendingText;
                 previous.lastReadContinuation = continuing;
                 previous.revision = revision;
                 previous.partial = partial;
@@ -1192,6 +1245,7 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                     questionTracker,
                     approvalTracker,
                     pendingThinking,
+                    pendingText,
                     lastReadContinuation: continuing,
                     revision,
                     partial,

--- a/tests/contract/aiSessions/kimiConversationAdapter.test.js
+++ b/tests/contract/aiSessions/kimiConversationAdapter.test.js
@@ -139,6 +139,67 @@ test('SESSION-AI-SESSION-CONVERSATION-ADAPTER-001 Kimi normalizes only visible t
     assert.equal(new Set(appended.interactions.map(item => item.id)).size, 4);
 });
 
+test('SESSION-AI-SESSION-CONVERSATION-ADAPTER-001 Kimi merges streamed text deltas into one block across incremental loads', async t => {
+    const source = await createFixture(t);
+    // The Kimi wire streams token-sized text deltas interleaved with empty
+    // think parts; each delta must not become its own rendered line.
+    const deltaRecords = chunks => chunks.flatMap(chunk => [
+        JSON.stringify({
+            timestamp: 4000,
+            message: { type: 'ContentPart', payload: { type: 'think', think: '' } },
+        }),
+        JSON.stringify({
+            timestamp: 4000,
+            message: { type: 'ContentPart', payload: { type: 'text', text: chunk } },
+        }),
+    ]);
+    await fs.promises.appendFile(source.sourcePath, [
+        JSON.stringify({
+            timestamp: 4000,
+            message: { type: 'TurnBegin', payload: { user_input: 'stream' } },
+        }),
+        ...deltaRecords(['**', '3', 'c']),
+        '',
+    ].join('\n'));
+    const adapter = createAdapter(source);
+    t.after(() => adapter.dispose());
+
+    const readLastPage = async () => {
+        const outline = await adapter.readOutline(sessionId);
+        const page = await adapter.readPage({
+            provider: 'kimi',
+            sessionId,
+            anchorInteractionId: outline.interactions.at(-1).id,
+            direction: 'around',
+        });
+        const lastId = outline.interactions.at(-1).id;
+        return page.messages.filter(message => message.interactionId === lastId);
+    };
+    const firstMessages = await readLastPage();
+    assert.deepEqual(
+        firstMessages.filter(message => message.role === 'assistant')
+            .map(message => message.markdown),
+        ['**3c'],
+        'a partial delta run still renders as one block'
+    );
+
+    await fs.promises.appendFile(source.sourcePath, [
+        ...deltaRecords([' ', '完成', '**']),
+        JSON.stringify({
+            timestamp: 4001,
+            message: { type: 'TurnEnd', payload: {} },
+        }),
+        '',
+    ].join('\n'));
+    const secondMessages = await readLastPage();
+    assert.deepEqual(
+        secondMessages.filter(message => message.role === 'assistant')
+            .map(message => message.markdown),
+        ['**3c 完成**'],
+        'deltas merge across incremental loads and whitespace-only deltas survive'
+    );
+});
+
 test('SESSION-AI-SESSION-CONVERSATION-ADAPTER-001 CONVERSATION-PLAN-QUESTION-VISIBILITY-001 Kimi surfaces PlanDisplay markdown as plan blocks', async t => {
     const source = await createFixture(t);
     await fs.promises.writeFile(source.sourcePath, [


### PR DESCRIPTION
## Summary

A Kimi session's AI Conversation rendered **every one or two characters as its own line** (reported against session `c6113be4`).

Root cause, confirmed against the session's `wire.jsonl`: the Kimi wire protocol streams assistant text as **token-sized `ContentPart` deltas** (this session had a run of 406 one-to-two-character deltas) interleaved with empty `think` keep-alives. The adapter coalesced *thinking* deltas via `pendingThinking` but appended every *text* delta as a separate `assistantMarkdown` entry, so each delta rendered as its own block. The per-delta `normalizeVisibleText` pass also trimmed whitespace-only deltas, silently eating the spaces between words.

Fix (mirrors the existing thinking path):

- Buffer raw text deltas per run (`pendingText`); publish them as one normalized block so whitespace-only deltas survive.
- The buffer persists across incremental loads; a partial run **replaces** its trailing block on the next load instead of appending.
- Empty think parts are streaming keep-alives and no longer split the surrounding text run.
- Any non-text event (tool call, plan, question, approval, turn boundary) closes the run.

## Verification

- New RED→GREEN contract test: token deltas + a space + empty think keep-alives, split across two incremental loads, render as exactly one `**3c 完成**` block.
- Real-session verification: the reported session's delta-storm turn now renders as a single 873-character assistant block.
- `tests/contract/aiSessions` + `tests/unit/aiSessions`: 929/929 pass.
- `npm run test:coverage:ci`: changed-line coverage 96.09% (gate: 80%).
- `npm run test:behavior-contracts` — pass; `git diff --check` — clean.

## Skill harvest

none — the investigation followed existing debugging/verification skills; no reusable workflow gap surfaced.