### PR TITLE
fix(worktrees): consume preview token atomically across the baseline window

### DIFF
--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "3b8064d460afec74027e39d4c8f7e8120e9658af",
+        "head": "bb90d8af28fc1f539b638c11ec25c924ac90ed08",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -408,7 +408,8 @@
             "c96e7c64349e222b936028f53dfdadb7d5bda8aa",
             "98edde499337cf10e858efc3de2839d476506f23",
             "3829b1e86bb097a62dc3afc49cbb517747c92e74",
-            "26a36ba1395101aa72c8c55f2000edc0198bc32f"
+            "26a36ba1395101aa72c8c55f2000edc0198bc32f",
+            "522b035f70a9de8d9e71908652e943bc158d79b0"
         ]
     },
     "capabilities": [
@@ -2207,12 +2208,14 @@
                 "70039ba891864d9c98616c3bf03ac32ce35dac37",
                 "73e96b7ba54483c1250b0d3aa58d2bc7d33fe64c",
                 "f7a968b0242728dbdc61500531e07ed71f2df2a0",
-                "e332a22ca94bd7e9ad0614fe36c554a9f4209c6b"
+                "e332a22ca94bd7e9ad0614fe36c554a9f4209c6b",
+                "bb90d8af28fc1f539b638c11ec25c924ac90ed08"
             ],
             "behaviors": [
                 "WORKTREE-GROUPS-BASELINE-001",
                 "WORKTREE-CHANGES-COLLECT-001",
-                "WORKTREE-CHANGES-PANEL-001"
+                "WORKTREE-CHANGES-PANEL-001",
+                "WORKTREE-GROUPS-CREATE-001"
             ],
             "prGates": [
                 "test:deterministic:run",

--- a/src/worktrees/groupCreationController.ts
+++ b/src/worktrees/groupCreationController.ts
@@ -683,9 +683,14 @@ export class WorktreeGroupCreationController {
             }
         }
         const navigationIdentity = target.workspace.navigationIdentity;
-        // Preview tokens are single-use: consume atomically (synchronously,
-        // before the first manifest await) so a replayed or concurrent
-        // confirm can never provision the same plan twice.
+        // Preview tokens are single-use: consume atomically — synchronously,
+        // before the first manifest await — so a replayed or concurrent
+        // confirm can never provision the same plan twice. Baseline
+        // resolution above awaits, so consumption must re-validate identity:
+        // a superseded or already-consumed snapshot fails closed as stale.
+        if (this.previewSnapshots.get(request.projectId) !== previewSnapshot) {
+            return { kind: 'failed', errorCode: 'preview-stale' };
+        }
         this.previewSnapshots.delete(request.projectId);
         let group: WorktreeGroup;
         let newMembers: WorktreeGroup['members'];

--- a/tests/contract/worktrees/groupCreationController.test.js
+++ b/tests/contract/worktrees/groupCreationController.test.js
@@ -738,6 +738,82 @@ test('WORKTREE-GROUPS-CREATE-001 a preview token is single-use across replays an
         'concurrent confirms settle exactly once');
 });
 
+test('WORKTREE-GROUPS-CREATE-001 a confirm parked in baseline resolution never provisions twice', async () => {
+    let baselineGateOpen = false;
+    const parked = [];
+    const current = fixture({
+        resolveBaseCommit: (commandCwd, baseRef) => {
+            const baseline = {
+                commitSha: 'f'.repeat(40),
+                capturedAt: 1724000000000,
+                source: { kind: 'branch', fullRef: baseRef },
+            };
+            if (baselineGateOpen) { return Promise.resolve(baseline); }
+            return new Promise(resolve => parked.push(() => resolve(baseline)));
+        },
+    });
+    const previewId = await previewIdFor(current);
+    const first = current.controller.confirm({
+        projectId: 'project', previewId,
+        displayName: 'Fix login', members: confirmedMembers(),
+    });
+    const second = current.controller.confirm({
+        projectId: 'project', previewId,
+        displayName: 'Fix login', members: confirmedMembers(),
+    });
+    // Both confirms pass validation and park on their first member inside
+    // the baseline-resolution await window.
+    await new Promise(resolve => setImmediate(resolve));
+    assert.equal(parked.length, 2,
+        'both confirms reach the baseline-resolution window');
+    baselineGateOpen = true;
+    for (const release of parked) { release(); }
+    const outcomes = (await Promise.all([first, second]))
+        .map(outcome => outcome.kind === 'created' ? 'created' : outcome.errorCode)
+        .sort();
+    assert.deepEqual(outcomes, ['created', 'preview-stale'],
+        'the token is consumed atomically, so the parked confirm loses as preview-stale');
+    assert.equal(current.manifestStore.listGroups(workspace.navigationIdentity).length, 1,
+        'exactly one group is provisioned');
+});
+
+test('WORKTREE-GROUPS-CREATE-001 an in-flight confirm never consumes a newer preview snapshot', async () => {
+    let baselineGateOpen = false;
+    const parked = [];
+    const current = fixture({
+        resolveBaseCommit: (commandCwd, baseRef) => {
+            const baseline = {
+                commitSha: 'f'.repeat(40),
+                capturedAt: 1724000000000,
+                source: { kind: 'branch', fullRef: baseRef },
+            };
+            if (baselineGateOpen) { return Promise.resolve(baseline); }
+            return new Promise(resolve => parked.push(() => resolve(baseline)));
+        },
+    });
+    const previewId = await previewIdFor(current);
+    const inFlight = current.controller.confirm({
+        projectId: 'project', previewId,
+        displayName: 'Fix login', members: confirmedMembers(),
+    });
+    await new Promise(resolve => setImmediate(resolve));
+    assert.equal(parked.length, 1,
+        'the confirm parks in baseline resolution');
+    // A newer preview replaces the snapshot while the confirm is parked.
+    const newerPreviewId = await previewIdFor(current);
+    baselineGateOpen = true;
+    for (const release of parked) { release(); }
+    const stale = await inFlight;
+    assert.equal(stale.errorCode, 'preview-stale',
+        'the confirm bound to the superseded preview loses');
+    const confirmed = await current.controller.confirm({
+        projectId: 'project', previewId: newerPreviewId,
+        displayName: 'Fix login', members: confirmedMembers(),
+    });
+    assert.equal(confirmed.kind, 'created',
+        'the newer preview snapshot survives the in-flight confirm');
+});
+
 test('WORKTREE-GROUPS-CREATE-001 a full tombstone bucket refuses the dismiss as store-full', async () => {
     const current = fixture({
         startMemberOperation: async input => ({


### PR DESCRIPTION
## Summary

The worktree-group confirm path validated the preview snapshot, then awaited per-member baseline resolution, and only then deleted the preview snapshot. Two confirms carrying the same token could both pass validation while parked in the baseline-resolution window and provision the same plan twice (two groups with identical branches/paths; the second fails at git level and leaves failed member rows to dismiss). An in-flight confirm could also delete a newer preview snapshot that had replaced its own, making the user's next confirm fail with `preview-stale` despite confirming exactly what they saw.

The fix re-validates snapshot identity at the consumption point so a superseded or already-consumed token fails closed as `preview-stale`, matching the documented single-use semantics. Two regression tests pin the baseline-resolution window and the superseded-preview case.

Found during the architecture program pilot deep dive (documented as finding P5 in `docs/architecture/stage-1b-pilot-rfc.md`); handled as a standalone bug fix per the charter's bug-fix workflow, outside any migration slice.

## Skill harvest

no skill change — the existing fixing-regressions-with-ci and review-fix-commit-loop flows covered this fix; no new lesson justified a skill edit.

## Verification

- RED first: both new tests fail on the unfixed code with the expected defect signatures (`['created','created']` double provision; in-flight confirm wins over the newer preview).
- Focused: `tests/contract/worktrees/groupCreationController.test.js` 26/26; worktrees unit 168/168; worktrees contract 112/112.
- `npm run test:deterministic:run` green (exit 0); `npm run test:behavior-contracts` green; `git diff --check` clean.
- Capability audit commit: assigned to MAIN-WORKTREE-CHANGES-PANEL, with WORKTREE-GROUPS-CREATE-001 added to its behavior set.