### PR TITLE
docs: adopt the serial single-worktree program workflow

### DIFF
--- a/.skills/protecting-main-with-worktrees/SKILL.md
+++ b/.skills/protecting-main-with-worktrees/SKILL.md
@@ -26,9 +26,10 @@ job.
    - identify the intended repository remote and base branch from the user request, local tracking branch, or remote default
 
 2. If the user asks for a worktree under the current project, place it under
-   `.worktree/<topic>` — worktree creation happens once per line of work.
-   - Do not add `.worktree/` to tracked `.gitignore` unless the user explicitly wants a repo change.
-   - Prefer local ignore: `printf '.worktree/\n' >> .git/info/exclude` if needed.
+   `.worktrees/<topic>` (plural — the product's own default and the layout in
+   use) — worktree creation happens once per line of work.
+   - Do not add `.worktrees/` to tracked `.gitignore` unless the user explicitly wants a repo change.
+   - Prefer local ignore: `printf '.worktrees/\n' >> .git/info/exclude` if needed.
 
 3. Create from the protected base:
    - `git fetch <remote> <base>`

--- a/.skills/protecting-main-with-worktrees/SKILL.md
+++ b/.skills/protecting-main-with-worktrees/SKILL.md
@@ -10,6 +10,12 @@ description: Use when working in this repository and main/master is protected, m
 Keep Agent Pivot's protected branches and the user's primary checkout clean by
 doing feature work in an isolated git worktree under the project.
 
+One line of work = one worktree = one branch: make every commit for the job
+on that worktree's branch, and cut serial PRs from that same branch as
+earlier ones merge. Do not switch branches inside the worktree, do not spread
+one job across worktrees, and do not create another worktree for the same
+job.
+
 ## Workflow
 
 1. Inspect state before creating anything:
@@ -19,7 +25,8 @@ doing feature work in an isolated git worktree under the project.
    - `git worktree list`
    - identify the intended repository remote and base branch from the user request, local tracking branch, or remote default
 
-2. If the user asks for a worktree under the current project, place it under `.worktree/<topic>`.
+2. If the user asks for a worktree under the current project, place it under
+   `.worktree/<topic>` — worktree creation happens once per line of work.
    - Do not add `.worktree/` to tracked `.gitignore` unless the user explicitly wants a repo change.
    - Prefer local ignore: `printf '.worktree/\n' >> .git/info/exclude` if needed.
 
@@ -43,6 +50,8 @@ doing feature work in an isolated git worktree under the project.
 ## Guardrails
 
 - Never push directly to `main`/`master` when the user said it is protected.
+- An open PR absorbs anything pushed to its branch: push the next slice's
+  commits only after the branch's previous PR has merged.
 - Never repair the `.gitignore` mistake by committing ignore-only churn to protected main.
 - Never assume `origin/main` when the repo also has `upstream` or the user named a different target.
 - If a feature branch tracks a deleted remote after merge, that is expected; remove the worktree after checking it is clean.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,18 +5,21 @@ making any change.
 
 ## Non-negotiables
 
-1. **Never edit files directly in the primary checkout on `main`.** Do all
-   work in the dedicated program worktree `.worktrees/arch-refact`, one
-   branch at a time (serial):
+1. **Never edit files directly in the primary checkout on `main`.** Work in
+   a feature worktree, and confine each line of work to the worktree you are
+   already in — switch branches inside it serially instead of creating more
+   worktrees:
    ```sh
    git fetch origin main
-   git -C .worktrees/arch-refact switch -c <branch> origin/main
+   git switch -c <branch> origin/main   # inside your current worktree
    ```
-   Create an additional worktree only when genuine parallelism requires it.
-   Run `npm ci` inside the worktree before verifying anything — npm
-   silently resolves binaries from the primary checkout's `node_modules`
-   otherwise. Dirty files in the primary checkout are user changes; do not
-   revert them. Details: skill `protecting-main-with-worktrees`.
+   Create an additional worktree only when genuine parallelism requires it
+   (for example, an independent urgent fix while this worktree carries
+   unmerged work). Run `npm ci` inside the worktree before verifying
+   anything — npm silently resolves binaries from the primary checkout's
+   `node_modules` otherwise. Dirty files in the primary checkout are user
+   changes; do not revert them. Details: skill
+   `protecting-main-with-worktrees`.
 
 2. **Never push directly to `main`.** Publish through a PR against
    `origin/main` in `hzcheng/agent-pivot`. This repo has two remotes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,12 +6,14 @@ making any change.
 ## Non-negotiables
 
 1. **Never edit files directly in the primary checkout on `main`.** Do all
-   work in a feature worktree:
+   work in the dedicated program worktree `.worktrees/arch-refact`, one
+   branch at a time (serial):
    ```sh
    git fetch origin main
-   git worktree add -b <branch> .worktree/<topic> origin/main
+   git -C .worktrees/arch-refact switch -c <branch> origin/main
    ```
-   Run `npm ci` inside the new worktree before verifying anything — npm
+   Create an additional worktree only when genuine parallelism requires it.
+   Run `npm ci` inside the worktree before verifying anything — npm
    silently resolves binaries from the primary checkout's `node_modules`
    otherwise. Dirty files in the primary checkout are user changes; do not
    revert them. Details: skill `protecting-main-with-worktrees`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,21 +5,20 @@ making any change.
 
 ## Non-negotiables
 
-1. **Never edit files directly in the primary checkout on `main`.** Work in
-   a feature worktree, and confine each line of work to the worktree you are
-   already in — switch branches inside it serially instead of creating more
-   worktrees:
+1. **Never edit files directly in the primary checkout on `main`.** Each
+   line of work runs in its own worktree on that worktree's branch: make
+   every commit for the job on that branch and cut serial PRs from it as
+   earlier ones merge. Do not switch branches inside the worktree, do not
+   spread one job across worktrees, and do not start another worktree for
+   the same job:
    ```sh
    git fetch origin main
-   git switch -c <branch> origin/main   # inside your current worktree
+   git worktree add -b <branch> .worktree/<topic> origin/main   # once per job
    ```
-   Create an additional worktree only when genuine parallelism requires it
-   (for example, an independent urgent fix while this worktree carries
-   unmerged work). Run `npm ci` inside the worktree before verifying
-   anything — npm silently resolves binaries from the primary checkout's
-   `node_modules` otherwise. Dirty files in the primary checkout are user
-   changes; do not revert them. Details: skill
-   `protecting-main-with-worktrees`.
+   Run `npm ci` inside the worktree before verifying anything — npm
+   silently resolves binaries from the primary checkout's `node_modules`
+   otherwise. Dirty files in the primary checkout are user changes; do not
+   revert them. Details: skill `protecting-main-with-worktrees`.
 
 2. **Never push directly to `main`.** Publish through a PR against
    `origin/main` in `hzcheng/agent-pivot`. This repo has two remotes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ making any change.
    the same job:
    ```sh
    git fetch origin main
-   git worktree add -b <branch> .worktree/<topic> origin/main   # once per job
+   git worktree add -b <branch> .worktrees/<topic> origin/main  # once per job
    ```
    Run `npm ci` inside the worktree before verifying anything — npm
    silently resolves binaries from the primary checkout's `node_modules`

--- a/docs/architecture-current-state.md
+++ b/docs/architecture-current-state.md
@@ -76,7 +76,7 @@
 
 ## Conventions For Contributors (human or agent)
 
-1. Work in `.worktree/<topic>` off `origin/main`; `npm ci` inside the worktree; never push to `main` directly.
+1. Work in `.worktrees/<topic>` off `origin/main`; `npm ci` inside the worktree; never push to `main` directly.
 2. Every PR: English title/body, `## Skill harvest` section, capability audit commit (`scripts/regenerate-capability-audit.js`), full local gate suite green.
 3. Merges require the owner approval comment (the `merge-approval` status must be green); agents never self-approve.
 4. Webview scripts keep `src/webview` and `media/` byte-identical; TS-side webview code has no mirror.

--- a/docs/architecture-harness-refactor-program.md
+++ b/docs/architecture-harness-refactor-program.md
@@ -1136,10 +1136,10 @@ The program is delivered through short-lived PRs based on the latest
 
 Harness v0 merges early so concurrent work is protected. Each implementation
 slice uses a fresh topic branch off the latest `origin/main`, checked out
-serially in the dedicated program worktree `.worktrees/arch-refact` (one
-branch at a time; rerun `npm ci` when a branch switch changes dependencies).
-The whole program lives in this one worktree; an additional worktree requires
-an explicit parallelism need.
+serially in the worktree the program already occupies (one branch at a time;
+rerun `npm ci` when a branch switch changes dependencies). The whole program
+lives in that one worktree; an additional worktree requires an explicit
+parallelism need.
 
 The program ledger is updated only with evidence from merged or reviewed
 changes. Before starting a dependent slice, rebase the plan against current
@@ -1311,8 +1311,8 @@ implementation change until that checkpoint is approved.
 ```
 
 Prompts for later slices must additionally require `git fetch origin main`, a
-fresh topic branch per slice checked out in the program worktree, and
-revalidation of the approved boundary and metric baseline against current
+fresh topic branch per slice checked out in the program's current worktree,
+and revalidation of the approved boundary and metric baseline against current
 `origin/main` (Section 16). The chat
 rollout reference in the prompt is optional history; this document and the
 versioned findings remain the authoritative handoff.

--- a/docs/architecture-harness-refactor-program.md
+++ b/docs/architecture-harness-refactor-program.md
@@ -1134,12 +1134,11 @@ The program is delivered through short-lived PRs based on the latest
 5. pilot strict-mode completion;
 6. subsequent module safety-net and migration slices.
 
-Harness v0 merges early so concurrent work is protected. Each implementation
-slice uses a fresh topic branch off the latest `origin/main`, checked out
-serially in the worktree the program already occupies (one branch at a time;
-rerun `npm ci` when a branch switch changes dependencies). The whole program
-lives in that one worktree; an additional worktree requires an explicit
-parallelism need.
+Harness v0 merges early so concurrent work is protected. The whole program
+runs on the program worktree's branch (`agent-pivot/arch-refact`): every
+slice commits there, and PRs are cut serially from that branch as earlier
+ones merge, each rebased onto the latest `origin/main` first. No branch
+switching and no additional worktrees inside the program.
 
 The program ledger is updated only with evidence from merged or reviewed
 changes. Before starting a dependent slice, rebase the plan against current
@@ -1310,10 +1309,10 @@ scope. Do not perform the pilot deep dive, design final Harness v0, or make any
 implementation change until that checkpoint is approved.
 ```
 
-Prompts for later slices must additionally require `git fetch origin main`, a
-fresh topic branch per slice checked out in the program's current worktree,
-and revalidation of the approved boundary and metric baseline against current
-`origin/main` (Section 16). The chat
+Prompts for later slices must additionally require `git fetch origin main`,
+rebasing the program branch onto it, work committed on the program branch in
+the program worktree, and revalidation of the approved boundary and metric
+baseline against current `origin/main` (Section 16). The chat
 rollout reference in the prompt is optional history; this document and the
 versioned findings remain the authoritative handoff.
 

--- a/docs/architecture-harness-refactor-program.md
+++ b/docs/architecture-harness-refactor-program.md
@@ -1135,9 +1135,11 @@ The program is delivered through short-lived PRs based on the latest
 6. subsequent module safety-net and migration slices.
 
 Harness v0 merges early so concurrent work is protected. Each implementation
-slice uses a new feature worktree after `git fetch origin main` and `npm ci`.
-Do not keep the entire program on `agent-pivot/arch-refact` after the charter
-and initial investigation work is handed off.
+slice uses a fresh topic branch off the latest `origin/main`, checked out
+serially in the dedicated program worktree `.worktrees/arch-refact` (one
+branch at a time; rerun `npm ci` when a branch switch changes dependencies).
+The whole program lives in this one worktree; an additional worktree requires
+an explicit parallelism need.
 
 The program ledger is updated only with evidence from merged or reviewed
 changes. Before starting a dependent slice, rebase the plan against current
@@ -1309,8 +1311,9 @@ implementation change until that checkpoint is approved.
 ```
 
 Prompts for later slices must additionally require `git fetch origin main`, a
-fresh short-lived worktree per slice, and revalidation of the approved boundary
-and metric baseline against current `origin/main` (Section 16). The chat
+fresh topic branch per slice checked out in the program worktree, and
+revalidation of the approved boundary and metric baseline against current
+`origin/main` (Section 16). The chat
 rollout reference in the prompt is optional history; this document and the
 versioned findings remain the authoritative handoff.
 

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "e67775d6c0f4827a62f002cd4812d353d6b6d0e7",
+        "head": "17ab4dde576090e944e6ea67c3db8133929a3ffb",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -416,7 +416,8 @@
             "78059ae8528de2ca5896dfd1e5a2ec039e3d540f",
             "56133fb62bf2cf670a0533461cce2f641661e112",
             "639efb7583f297d7e2cc44bd122aad92f88b410e",
-            "f66ba4e15f3a1bb8914fa09344fdc37b22141b0f"
+            "f66ba4e15f3a1bb8914fa09344fdc37b22141b0f",
+            "357082a4822ee89163c66805ebaa59000b7df731"
         ]
     },
     "capabilities": [
@@ -1509,7 +1510,8 @@
                 "80786e500bebdf6974e25234214b91074b883431",
                 "bb67bbc1416b46a2038480649597aa553b0d7f7f",
                 "6cef6f649a14d34e27017d4a11fc88758c489b58",
-                "e67775d6c0f4827a62f002cd4812d353d6b6d0e7"
+                "e67775d6c0f4827a62f002cd4812d353d6b6d0e7",
+                "17ab4dde576090e944e6ea67c3db8133929a3ffb"
             ],
             "behaviors": [
                 "ARCH-CI-QUALITY-GATE-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "bb90d8af28fc1f539b638c11ec25c924ac90ed08",
+        "head": "80786e500bebdf6974e25234214b91074b883431",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -409,7 +409,11 @@
             "98edde499337cf10e858efc3de2839d476506f23",
             "3829b1e86bb097a62dc3afc49cbb517747c92e74",
             "26a36ba1395101aa72c8c55f2000edc0198bc32f",
-            "522b035f70a9de8d9e71908652e943bc158d79b0"
+            "522b035f70a9de8d9e71908652e943bc158d79b0",
+            "7ab8de4c870baa355450f5d88b5e1ec521f32c9f",
+            "a66867e625c9f638edd868a2d30ad07cd78b0850",
+            "019fa9a510dff03dd3b1b2cb204a6fcf6c0f25f1",
+            "78059ae8528de2ca5896dfd1e5a2ec039e3d540f"
         ]
     },
     "capabilities": [
@@ -1498,7 +1502,8 @@
                 "18281dc9400c3800e88f68d866f4cb827b4e54e6",
                 "534b86f41a7a8a172332d0b67e9d16a944e9df5c",
                 "ba6ab556e44a249788892a6fcba7277e2f927a58",
-                "aa40b009ba32eab805ac3d11c340825079f8a509"
+                "aa40b009ba32eab805ac3d11c340825079f8a509",
+                "80786e500bebdf6974e25234214b91074b883431"
             ],
             "behaviors": [
                 "ARCH-CI-QUALITY-GATE-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "bb67bbc1416b46a2038480649597aa553b0d7f7f",
+        "head": "6cef6f649a14d34e27017d4a11fc88758c489b58",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -414,7 +414,8 @@
             "a66867e625c9f638edd868a2d30ad07cd78b0850",
             "019fa9a510dff03dd3b1b2cb204a6fcf6c0f25f1",
             "78059ae8528de2ca5896dfd1e5a2ec039e3d540f",
-            "56133fb62bf2cf670a0533461cce2f641661e112"
+            "56133fb62bf2cf670a0533461cce2f641661e112",
+            "639efb7583f297d7e2cc44bd122aad92f88b410e"
         ]
     },
     "capabilities": [
@@ -1505,7 +1506,8 @@
                 "ba6ab556e44a249788892a6fcba7277e2f927a58",
                 "aa40b009ba32eab805ac3d11c340825079f8a509",
                 "80786e500bebdf6974e25234214b91074b883431",
-                "bb67bbc1416b46a2038480649597aa553b0d7f7f"
+                "bb67bbc1416b46a2038480649597aa553b0d7f7f",
+                "6cef6f649a14d34e27017d4a11fc88758c489b58"
             ],
             "behaviors": [
                 "ARCH-CI-QUALITY-GATE-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "6cef6f649a14d34e27017d4a11fc88758c489b58",
+        "head": "e67775d6c0f4827a62f002cd4812d353d6b6d0e7",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -415,7 +415,8 @@
             "019fa9a510dff03dd3b1b2cb204a6fcf6c0f25f1",
             "78059ae8528de2ca5896dfd1e5a2ec039e3d540f",
             "56133fb62bf2cf670a0533461cce2f641661e112",
-            "639efb7583f297d7e2cc44bd122aad92f88b410e"
+            "639efb7583f297d7e2cc44bd122aad92f88b410e",
+            "f66ba4e15f3a1bb8914fa09344fdc37b22141b0f"
         ]
     },
     "capabilities": [
@@ -1507,7 +1508,8 @@
                 "aa40b009ba32eab805ac3d11c340825079f8a509",
                 "80786e500bebdf6974e25234214b91074b883431",
                 "bb67bbc1416b46a2038480649597aa553b0d7f7f",
-                "6cef6f649a14d34e27017d4a11fc88758c489b58"
+                "6cef6f649a14d34e27017d4a11fc88758c489b58",
+                "e67775d6c0f4827a62f002cd4812d353d6b6d0e7"
             ],
             "behaviors": [
                 "ARCH-CI-QUALITY-GATE-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "80786e500bebdf6974e25234214b91074b883431",
+        "head": "bb67bbc1416b46a2038480649597aa553b0d7f7f",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -413,7 +413,8 @@
             "7ab8de4c870baa355450f5d88b5e1ec521f32c9f",
             "a66867e625c9f638edd868a2d30ad07cd78b0850",
             "019fa9a510dff03dd3b1b2cb204a6fcf6c0f25f1",
-            "78059ae8528de2ca5896dfd1e5a2ec039e3d540f"
+            "78059ae8528de2ca5896dfd1e5a2ec039e3d540f",
+            "56133fb62bf2cf670a0533461cce2f641661e112"
         ]
     },
     "capabilities": [
@@ -1503,7 +1504,8 @@
                 "534b86f41a7a8a172332d0b67e9d16a944e9df5c",
                 "ba6ab556e44a249788892a6fcba7277e2f927a58",
                 "aa40b009ba32eab805ac3d11c340825079f8a509",
-                "80786e500bebdf6974e25234214b91074b883431"
+                "80786e500bebdf6974e25234214b91074b883431",
+                "bb67bbc1416b46a2038480649597aa553b0d7f7f"
             ],
             "behaviors": [
                 "ARCH-CI-QUALITY-GATE-001",


### PR DESCRIPTION
## Summary

Owner decision: one job = one worktree = one branch. Every commit for a line of work lands on that worktree's branch, and PRs are cut serially from the same branch as earlier ones merge.

- `AGENTS.md` non-negotiable 1 now states the job-per-worktree rule: no branch switching inside the worktree, no spreading one job across worktrees, no second worktree for the same job. Worktree creation happens once per job. No specific worktree or branch path is baked into repo-level guidance.
- Charter Sections 16 and 20 updated to match: the architecture program runs entirely on the program worktree's branch, with each slice rebased onto the latest `origin/main` before its PR.
- `.skills/protecting-main-with-worktrees` now states the same rule and warns that an open PR absorbs anything pushed to its branch — this skill's per-topic creation example was the remaining guidance source that read as 'new task = new worktree'.

Process/documentation only; no production code or behavior changed.

## Skill harvest

updated .skills/protecting-main-with-worktrees — encoded the owner-confirmed job-per-worktree rule; the skill's per-topic worktree creation example was the remaining misleading guidance source.

## Verification

- `npm run test:behavior-contracts` green; `git diff --check` clean; `tests/unit/tooling/repositorySkills.test.js` 10/10 green (skill pins intact).
- Capability audit: commits assigned to MAIN-REGRESSION-CI-CURRENCY (guidance-layer currency convention).