### PR TITLE
fix: allow removing worktree records whose directory is already gone

### DIFF
--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "17ab4dde576090e944e6ea67c3db8133929a3ffb",
+        "head": "e55c43231f82f1e8cd61bf0c99f95f098e38773e",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -417,7 +417,8 @@
             "56133fb62bf2cf670a0533461cce2f641661e112",
             "639efb7583f297d7e2cc44bd122aad92f88b410e",
             "f66ba4e15f3a1bb8914fa09344fdc37b22141b0f",
-            "357082a4822ee89163c66805ebaa59000b7df731"
+            "357082a4822ee89163c66805ebaa59000b7df731",
+            "dd3efc003679aa153fe5018bd40110364573d91e"
         ]
     },
     "capabilities": [
@@ -592,7 +593,8 @@
                 "ecdfa526e6a26c7c154b1d7bb0374219ffa0a36d",
                 "74140c81d3fdf8bb2c09c2684a47fa0a12ae701d",
                 "a3176e7580c734b7c12ee2217ddbd0bd7dbe83d8",
-                "bb7ff16c4a79e62015446e44022d85c3e35c399a"
+                "bb7ff16c4a79e62015446e44022d85c3e35c399a",
+                "e55c43231f82f1e8cd61bf0c99f95f098e38773e"
             ],
             "behaviors": [
                 "PERSIST-AI-SESSION-PROJECT-HYDRATION-CONTROLLER-001",

--- a/src/worktrees/managedWorktreeRemovalController.ts
+++ b/src/worktrees/managedWorktreeRemovalController.ts
@@ -1,6 +1,7 @@
 'use strict';
 
 import * as fs from 'fs';
+import * as path from 'path';
 import type { RunGitCommand } from './gitWorktreeDiscovery';
 import { runProvisioningGitCommand } from './gitWorktreeProvisioner';
 import type {
@@ -74,8 +75,16 @@ export class ManagedWorktreeRemovalController {
             if (blocked) {
                 return { kind: 'rejected', errorCode: blocked };
             }
-            const branch = initial!.worktree.branchRef?.replace(/^refs\/heads\//u, '')
-                || initial!.worktree.head.substring(0, 8);
+            // The confirm label tolerates a stale/prunable snapshot entry:
+            // a worktree whose directory is already gone still needs a
+            // readable name in the dialog.
+            const snapshotWorktree = this.options.getSnapshot()?.repositories
+                .find(candidate => candidate.repositoryKey === key.repositoryKey)
+                ?.worktrees.find(candidate => worktreeKeysEqual(candidate.key, key));
+            const branch = (initial?.worktree || snapshotWorktree)?.branchRef
+                ?.replace(/^refs\/heads\//u, '')
+                || initial?.worktree.head.substring(0, 8)
+                || path.basename(key.canonicalWorktreePath);
             const confirmation = await this.options.confirm(
                 `Remove the worktree “${branch}” at ${key.canonicalWorktreePath}? `
                     + 'Only clean, idle worktrees can be removed; the local branch is kept.',
@@ -88,6 +97,17 @@ export class ManagedWorktreeRemovalController {
             const currentBlocker = await this.getBlocker(current, key);
             if (currentBlocker) {
                 return { kind: 'rejected', errorCode: currentBlocker };
+            }
+            if (!(await this.pathExists(key.canonicalWorktreePath))) {
+                // The directory vanished (or was never there): prune stale
+                // git metadata and succeed — only record cleanup remains.
+                await this.pruneStaleMetadata(key);
+                try {
+                    await this.options.refresh(key, workspaceIdentity);
+                } catch (_error) {
+                    return { kind: 'partial', errorCode: 'worktree-removed-refresh-failed' };
+                }
+                return { kind: 'succeeded' };
             }
             const result = await this.runGit(current!.commandCwd, [
                 '-C', current!.commandCwd,
@@ -130,6 +150,14 @@ export class ManagedWorktreeRemovalController {
     async removeVerified(
         key: WorktreeKey
     ): Promise<{ kind: 'removed' } | { kind: 'failed'; errorCode: string }> {
+        if (!(await this.pathExists(key.canonicalWorktreePath))) {
+            // The directory is already gone (deleted externally): prune the
+            // stale git administrative entry and report the verified
+            // absence — a missing path is a certain observation, so record
+            // cleanup must not fail-closed (PRD §6.4).
+            await this.pruneStaleMetadata(key);
+            return { kind: 'removed' };
+        }
         const target = this.resolveTarget(key);
         const blocker = await this.getBlocker(target, key);
         if (blocker) {
@@ -169,8 +197,37 @@ export class ManagedWorktreeRemovalController {
         return commandCwd ? { repository, worktree, commandCwd } : null;
     }
 
+    /**
+     * Best-effort cleanup of the git administrative entry after the
+     * worktree directory disappeared externally. Skipped silently when the
+     * repository itself is out of view — the path is already gone either
+     * way.
+     */
+    private async pruneStaleMetadata(key: WorktreeKey): Promise<void> {
+        const snapshot = this.options.getSnapshot();
+        const repository = snapshot?.repositories.find(candidate =>
+            candidate.repositoryKey === key.repositoryKey);
+        const commandCwd = repository?.worktrees.find(candidate =>
+            candidate.isMain && !candidate.isBare)?.key.canonicalWorktreePath
+            || repository?.worktrees.find(candidate => !candidate.isBare)
+                ?.key.canonicalWorktreePath;
+        if (!commandCwd) {
+            return;
+        }
+        try {
+            await this.runGit(commandCwd, ['-C', commandCwd, 'worktree', 'prune']);
+        } catch (_error) { /* best-effort */ }
+    }
+
     private async getBlocker(target: RemovalTarget | null, key: WorktreeKey): Promise<string | null> {
         if (!target) {
+            // A physically absent directory is a certain observation:
+            // nothing blocks the removal; only record cleanup remains.
+            // Anything else (detached repository, truncated discovery)
+            // stays fail-closed.
+            if (!(await this.pathExists(key.canonicalWorktreePath))) {
+                return null;
+            }
             return 'worktree-not-removable';
         }
         if (this.options.isActive(key)) {

--- a/tests/contract/worktrees/managedWorktreeRemovalController.test.js
+++ b/tests/contract/worktrees/managedWorktreeRemovalController.test.js
@@ -206,3 +206,48 @@ test('WORKTREE-MANAGED-CLEANUP-001 passes the removed key to refresh so the mani
     assert.deepEqual(refreshedKeys, [current.key],
         'the manifest retirement hook learns exactly which worktree was removed');
 });
+
+test('WORKTREE-MANAGED-CLEANUP-001 removes a worktree whose directory is already gone', async t => {
+    const current = await fixture(t);
+    // External deletion: the directory is gone but git still lists the
+    // stale administrative entry as prunable until a prune runs.
+    await fs.promises.rm(current.worktreePath, { recursive: true, force: true });
+    const stale = current.snapshot.repositories[0].worktrees[1];
+    stale.health = 'prunable';
+
+    assert.equal(await current.controller.getRemovalBlocker(current.key), null,
+        'a physically absent directory never blocks record cleanup');
+    assert.deepEqual(await current.controller.removeVerified(current.key),
+        { kind: 'removed' },
+        'verified removal short-circuits to the verified absence');
+    assert.ok(
+        !git(current.repositoryPath, ['worktree', 'list', '--porcelain'])
+            .includes('cleanup-task'),
+        'the stale git worktree metadata is pruned'
+    );
+
+    // Variant: the stale entry was already pruned from the snapshot.
+    const second = await fixture(t);
+    await fs.promises.rm(second.worktreePath, { recursive: true, force: true });
+    second.snapshot.repositories[0].worktrees.pop();
+    assert.equal(await second.controller.getRemovalBlocker(second.key), null);
+    assert.deepEqual(await second.controller.removeVerified(second.key),
+        { kind: 'removed' });
+});
+
+test('WORKTREE-MANAGED-CLEANUP-001 interactive removal of a missing directory confirms and succeeds', async t => {
+    const current = await fixture(t);
+    await fs.promises.rm(current.worktreePath, { recursive: true, force: true });
+    current.snapshot.repositories[0].worktrees[1].health = 'prunable';
+
+    const outcome = await current.controller.remove('project', current.key);
+
+    assert.equal(outcome.kind, 'succeeded');
+    assert.deepEqual(current.effects.map(effect => effect[0]), ['confirm', 'refresh'],
+        'the removal still confirms, then refreshes');
+    assert.ok(
+        !git(current.repositoryPath, ['worktree', 'list', '--porcelain'])
+            .includes('cleanup-task'),
+        'the stale git worktree metadata is pruned'
+    );
+});


### PR DESCRIPTION
## Summary

A worktree deleted externally (`rm -rf`, or pruned elsewhere) left its group member **impossible to remove** from the CURRENT WINDOW task view: the snapshot resolves the entry as `prunable`/`missing`, `resolveTarget` rejects non-normal health, and the blocker check answered `worktree-not-removable` at deletion admission — so both the journaled group-member deletion and the interactive removal were stuck forever (reported against the `harness-registry` and `fix-preview-token-consumption` tasks).

A physically absent directory is a *certain* observation, not an uncertain one — it must not fail-closed:

- `getBlocker` answers `null` when the path is missing (still fail-closed for detached repositories / truncated discovery where the path exists).
- `removeVerified` short-circuits to the verified absence.
- The interactive `remove()` still confirms, then succeeds.
- All three paths prune the stale git administrative entry (best-effort; skipped when the repository itself is out of view).
- The confirm dialog label falls back to the stale snapshot branch ref, then the path basename, instead of dereferencing a null target.

## Verification

- New RED→GREEN contract tests with a real git repository: externally deleted directory marked `prunable` in the snapshot (and a fully-pruned variant) no longer block `getRemovalBlocker`, `removeVerified` reports `removed`, interactive removal confirms and succeeds, and the stale `git worktree` metadata is pruned.
- Worktrees contract + unit suites: 282/282 pass.
- `npm run test:coverage:ci`: changed-line coverage 88.14% (gate: 80%).
- `npm run test:behavior-contracts` — pass; `git diff --check` — clean.

## Skill harvest

none — straightforward RED→GREEN fix against an existing behavior (`WORKTREE-MANAGED-CLEANUP-001`); no workflow friction worth codifying.