### PR TITLE
fix: open task review as one multi-diff with valid vscode.changes triples

### DIFF
--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "a76abb00ff83dd937011ac4afcd1f60d88dc473e",
+        "head": "b76f4ba375337b0674dc846d119d5ce7f5c46ba8",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -419,7 +419,8 @@
             "f66ba4e15f3a1bb8914fa09344fdc37b22141b0f",
             "357082a4822ee89163c66805ebaa59000b7df731",
             "dd3efc003679aa153fe5018bd40110364573d91e",
-            "64430b4980005eb195d4a0fff85fb8f716e65a21"
+            "64430b4980005eb195d4a0fff85fb8f716e65a21",
+            "cd361291398dd7ba884cfc37b45b807ba015bcf1"
         ]
     },
     "capabilities": [
@@ -2225,7 +2226,8 @@
                 "73e96b7ba54483c1250b0d3aa58d2bc7d33fe64c",
                 "f7a968b0242728dbdc61500531e07ed71f2df2a0",
                 "e332a22ca94bd7e9ad0614fe36c554a9f4209c6b",
-                "bb90d8af28fc1f539b638c11ec25c924ac90ed08"
+                "bb90d8af28fc1f539b638c11ec25c924ac90ed08",
+                "b76f4ba375337b0674dc846d119d5ce7f5c46ba8"
             ],
             "behaviors": [
                 "WORKTREE-GROUPS-BASELINE-001",

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -2309,7 +2309,8 @@ async function initializeDashboard(
             openWorkingChangeDiff: (worktreePath, item) =>
                 openWorkingChangeDiff(worktreePath, item),
             openTaskResultReview: (worktreePath, baselineSha, title) =>
-                openTaskResultReview(worktreePath, baselineSha, title),
+                openTaskResultReview(worktreePath, baselineSha, title,
+                    (message, error) => logError(message, error)),
             showWorktreeInSourceControl: worktreeRoot =>
                 showWorktreeInSourceControl(worktreeRoot),
             watchRepositoryChanges: (paths, onChange) =>

--- a/src/services/gitChangesDiff.ts
+++ b/src/services/gitChangesDiff.ts
@@ -1,6 +1,7 @@
 'use strict';
 
 import { execFile } from 'child_process';
+import { existsSync } from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import type { WorkingChangeItem } from '../worktrees/changesCollector';
@@ -123,13 +124,18 @@ export async function openWorkingChangeDiff(
 /**
  * "Review this repository" (changes-panel PRD §5.3): one multi-diff of
  * baseline → current worktree for the selected member. Capability
- * detection: workbenches without `vscode.changes` fall back to opening
- * the first file's diff.
+ * detection: workbenches without `vscode.changes` fall back to a per-file
+ * list; the failure is logged, never swallowed silently.
+ *
+ * `vscode.changes` takes [label, original, modified] triples — the label
+ * URI names the entry, original is the baseline side, modified the
+ * worktree side. Anything else fails argument validation.
  */
 export async function openTaskResultReview(
     worktreePath: string,
     baselineSha: string,
-    title: string
+    title: string,
+    onError?: (message: string, error: unknown) => void
 ): Promise<void> {
     const files = await new Promise<string[]>(resolve => {
         execFile('git', [
@@ -149,15 +155,35 @@ export async function openTaskResultReview(
     if (!files.length) {
         return;
     }
-    const resources: [vscode.Uri, vscode.Uri][] = files.map(file => [
-        gitContentUri(worktreePath, baselineSha, file),
-        vscode.Uri.file(path.join(worktreePath, file)),
-    ]);
+    const resources: [vscode.Uri, vscode.Uri, vscode.Uri][] = files.map(file => {
+        const fileUri = vscode.Uri.file(path.join(worktreePath, file));
+        return [
+            fileUri,
+            gitContentUri(worktreePath, baselineSha, file),
+            // A deleted file has no working-tree document: render the
+            // modified side as empty content instead of a missing file.
+            existsSync(fileUri.fsPath)
+                ? fileUri
+                : gitContentUri(worktreePath, EMPTY_REF, file),
+        ];
+    });
     try {
         await vscode.commands.executeCommand('vscode.changes', title, resources);
-    } catch (_error) {
-        const [first] = resources;
+    } catch (error) {
+        onError?.(
+            'vscode.changes failed; falling back to a per-file diff list.',
+            error);
+        // Per-file diff list (changes-panel PRD §5.3 capability fallback):
+        // pick one file at a time, baseline → worktree.
+        const picked = await vscode.window.showQuickPick(
+            files.map((file, index) => ({ label: file, index })),
+            { placeHolder: title }
+        );
+        if (!picked) {
+            return;
+        }
+        const [, original, modified] = resources[picked.index];
         await vscode.commands.executeCommand(
-            'vscode.diff', first[0], first[1], files[0]);
+            'vscode.diff', original, modified, picked.label);
     }
 }

--- a/tests/unit/services/gitChangesDiff.test.js
+++ b/tests/unit/services/gitChangesDiff.test.js
@@ -1,10 +1,14 @@
 'use strict';
 
 const assert = require('node:assert/strict');
+const childProcess = require('node:child_process');
+const fs = require('node:fs');
 const Module = require('node:module');
+const os = require('node:os');
+const path = require('node:path');
 const test = require('node:test');
 
-function loadService(executed) {
+function loadService(executed, options = {}) {
     const fakeVscode = {
         Uri: {
             file: fsPath => ({
@@ -24,11 +28,14 @@ function loadService(executed) {
         commands: {
             executeCommand: async (command, ...args) => {
                 executed.push([command, ...args]);
-                if (command === 'vscode.changes') {
+                if (command === 'vscode.changes' && options.failChanges !== false) {
                     throw new Error('unknown command');
                 }
                 return undefined;
             },
+        },
+        window: {
+            showQuickPick: async () => options.quickPick,
         },
     };
     const previousLoad = Module._load;
@@ -110,4 +117,78 @@ test('WORKTREE-CHANGES-PANEL-001 renames carry the original path on the git side
     assert.equal(diffQuery(left).path, 'src/old.ts');
     assert.equal(diffQuery(right).path, 'src/new.ts');
     assert.equal(title, 'src/old.ts → src/new.ts');
+});
+
+async function repoFixture(t) {
+    const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-pivot-review-'));
+    const git = args => childProcess.execFileSync('git', ['-C', dir, ...args], {
+        encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+    git(['init', '-b', 'main']);
+    git(['config', 'user.name', 'Agent Pivot Tests']);
+    git(['config', 'user.email', 'tests@example.invalid']);
+    await fs.promises.writeFile(path.join(dir, 'a.txt'), 'a1\n');
+    await fs.promises.writeFile(path.join(dir, 'c.txt'), 'c1\n');
+    git(['add', '.']);
+    git(['commit', '-m', 'base']);
+    const baseline = git(['rev-parse', 'HEAD']);
+    // a.txt modified, c.txt deleted; untracked files never join a diff.
+    await fs.promises.writeFile(path.join(dir, 'a.txt'), 'a2\n');
+    await fs.promises.unlink(path.join(dir, 'c.txt'));
+    t.after(() => fs.promises.rm(dir, { recursive: true, force: true }));
+    return { dir, baseline };
+}
+
+function reviewEntries(executed) {
+    const call = executed.find(entry => entry[0] === 'vscode.changes');
+    return call ? call[2] : null;
+}
+
+test('WORKTREE-CHANGES-PANEL-001 task result review opens one multi-diff with [label, original, modified] triples', async t => {
+    const repo = await repoFixture(t);
+    const executed = [];
+    const service = loadService(executed, { failChanges: false });
+
+    await service.openTaskResultReview(repo.dir, repo.baseline, 'Task result');
+
+    assert.equal(executed.length, 1, 'the multi-diff opens without a diff fallback');
+    const [command, title, resources] = executed[0];
+    assert.equal(command, 'vscode.changes');
+    assert.equal(title, 'Task result');
+    // vscode.changes validates [label, original, modified] triples; pairs
+    // fail argument validation and silently opened only the first file.
+    assert.equal(resources.length, 2, 'a.txt modified + c.txt deleted');
+    for (const [label, original, modified] of resources) {
+        assert.equal(label.scheme, 'file', 'the label URI identifies the file');
+        assert.equal(diffQuery(original).ref, repo.baseline,
+            'the original side reads the baseline commit');
+    }
+    const modified = Object.fromEntries(
+        resources.map(entry => [path.basename(entry[0].fsPath), entry[2]]));
+    assert.equal(modified['a.txt'].scheme, 'file',
+        'an existing worktree file opens its working-tree document');
+    assert.equal(diffQuery(modified['c.txt']).ref, '~empty~',
+        'a deleted file renders an empty modified side instead of a missing file');
+});
+
+test('WORKTREE-CHANGES-PANEL-001 task result review falls back to a per-file list and reports the failure', async t => {
+    const repo = await repoFixture(t);
+    const executed = [];
+    const errors = [];
+    const service = loadService(executed, {
+        failChanges: true,
+        quickPick: { label: 'c.txt', index: 1 },
+    });
+
+    await service.openTaskResultReview(repo.dir, repo.baseline, 'Task result',
+        (message, error) => errors.push([message, error]));
+
+    assert.equal(errors.length, 1,
+        'a rejected vscode.changes must reach the log sink, never vanish');
+    assert.equal(errors[0][1].message, 'unknown command');
+    const diff = executed.find(entry => entry[0] === 'vscode.diff');
+    assert.ok(diff, 'the picked file opens a single diff');
+    assert.equal(diffQuery(diff[1]).path, 'c.txt');
+    assert.equal(diffQuery(diff[2]).ref, '~empty~');
+    assert.equal(diff[3], 'c.txt');
 });


### PR DESCRIPTION
## Summary

The worktree changes panel's **Review** button silently opened only the first changed file instead of the native multi-diff.

Root cause: `vscode.changes` validates its resource list as **[label, original, modified] triples** (see `extHostApiCommands.ts` → `_workbench.changes` → `editorCommands.ts`: each entry decomposes as `[label, original, modified]`, and the validator rejects any entry whose length is not exactly 3). The call passed two-element `[original, modified]` pairs, argument validation rejected the command, and the silent `catch` fell back to opening a single-file `vscode.diff` — with no log anywhere.

Fixes:

- Pass `[fileUri, baselineContentUri, worktreeUri]` triples so the native changes editor opens **every** changed file at once (baseline → worktree).
- Deleted files render an empty modified side instead of a missing working-tree document.
- The capability fallback now matches the PRD (§5.3): a per-file quick pick that opens the chosen diff — and the `vscode.changes` rejection is logged via the dashboard output channel instead of being swallowed.

## Verification

- New unit tests with a real git fixture: triple arity + per-side URIs (baseline ref on the original side, `~empty~` sentinel for deletions), no spurious `vscode.diff` on the primary path; fallback path asserts the quick pick, the chosen file's diff, and the logged error.
- `tests/unit/aiSessions/conversationChangesController.test.js` + `tests/integration/dashboard/conversationViewer.test.js`: 104/104 pass.
- `npm run test:coverage:ci`: changed-line coverage 94.44% (gate: 80%).
- `npm run lint`: 99 warnings — identical to the base (no new warnings).
- `npm run test:behavior-contracts` — pass; `git diff --check` — clean.

## Skill harvest

none — the fix followed the existing RED→GREEN and verification skills; no reusable workflow gap.