### PR TITLE
feat(architecture): invariant catalog and single-writer enforcement (Harness v0 PR 3)

### DIFF
--- a/docs/testing/architecture-invariants.json
+++ b/docs/testing/architecture-invariants.json
@@ -1,0 +1,207 @@
+{
+    "version": 1,
+    "title": "Architecture invariant catalog (pilot scope)",
+    "notes": [
+        "Normalized from docs/architecture/drafts/pilot-invariants.draft.json (approved at the Stage 1B gate).",
+        "Every reference is cross-validated: module ids exist in architecture-modules.json, capabilities exist in main-capability-coverage.json, and every path exists in the repository.",
+        "Records with a stateFamily block are mechanically checked by scripts/architecture/checkSingleWriters.js: a write-method call outside the declared writers fails. The writer set may only shrink during migration."
+    ],
+    "invariants": [
+        {
+            "id": "ARCH-WORKTREE-PREVIEW-TOKEN-001",
+            "module": "MOD-WORKTREE-LIFECYCLE",
+            "productCapabilities": ["MAIN-WORKTREE-CHANGES-PANEL"],
+            "priority": "P0",
+            "kind": "state-machine",
+            "statement": "A preview token is consumed exactly once, after validation and before the first manifest await; a replayed, concurrent, or superseded confirm fails closed as preview-stale.",
+            "authority": {
+                "path": "src/worktrees/groupCreationController.ts",
+                "symbol": "WorktreeGroupCreationController"
+            },
+            "writers": [],
+            "linearizationPoint": "The identity-checked snapshot delete precedes the manifest write.",
+            "enforcement": ["behavior"],
+            "behaviorOwners": ["tests/contract/worktrees/groupCreationController.test.js"],
+            "guardOwners": [],
+            "evidence": ["src/worktrees/groupCreationController.ts"]
+        },
+        {
+            "id": "ARCH-WORKTREE-MEMBER-WRITER-001",
+            "module": "MOD-WORKTREE-LIFECYCLE",
+            "productCapabilities": ["MAIN-WORKTREE-CHANGES-PANEL"],
+            "priority": "P0",
+            "kind": "concurrency",
+            "statement": "Manifest writes happen only in the declared writer set (store plus the enumerated callers); migration slice S2 shrinks the set to one coordinator.",
+            "authority": {
+                "path": "src/worktrees/groupManifestStore.ts",
+                "symbol": "WorktreeGroupManifestStore"
+            },
+            "writers": [
+                "src/dashboard.ts",
+                "src/worktrees/groupCreationController.ts",
+                "src/worktrees/groupDeletionHandler.ts",
+                "src/worktrees/deletionController.ts",
+                "src/worktrees/groupAdoptHandler.ts",
+                "src/worktrees/groupRenameHandler.ts",
+                "src/worktrees/groupManifestReconciliation.ts"
+            ],
+            "linearizationPoint": "The versioned manifest commit succeeds.",
+            "enforcement": ["single-writer", "behavior"],
+            "behaviorOwners": ["tests/unit/worktrees/groupManifestStore.test.js"],
+            "guardOwners": ["tests/unit/architecture/singleWriters.test.js"],
+            "evidence": ["src/worktrees/groupManifestStore.ts"],
+            "stateFamily": {
+                "storePath": "src/worktrees/groupManifestStore.ts",
+                "writeMethods": [
+                    "createGroup",
+                    "addPlannedMembers",
+                    "updateMember",
+                    "removeMember",
+                    "renameGroup",
+                    "setPrimaryMember",
+                    "mergeGroups",
+                    "adoptReadyMembers",
+                    "beginDeletion",
+                    "checkpointDeletedMember",
+                    "failDeletionMember",
+                    "retryDeletion",
+                    "completeDeletion",
+                    "abandonDeletion",
+                    "createGenerationClaim",
+                    "promoteGenerationClaim",
+                    "removeGenerationClaim",
+                    "reconcileGenerationClaims",
+                    "recordRetiredIdentity",
+                    "removeRetiredIdentity",
+                    "deleteGroup",
+                    "addMember",
+                    "setRepositoryDetached",
+                    "resetCorruptRetiredStore"
+                ]
+            }
+        },
+        {
+            "id": "ARCH-WORKTREE-CLAIM-ORDER-001",
+            "module": "MOD-WORKTREE-LIFECYCLE",
+            "productCapabilities": ["MAIN-WORKTREE-CHANGES-PANEL"],
+            "priority": "P0",
+            "kind": "recovery",
+            "statement": "A generation claim is durable before any terminal or provider side effect; claim removal requires proven-not-started evidence or an explicit user discard; ambiguity never auto-discards.",
+            "authority": {
+                "path": "src/aiSessions/creationController.ts",
+                "symbol": "AiSessionCreationController"
+            },
+            "writers": [],
+            "linearizationPoint": "createGenerationClaim commitBucket precedes coordinator.create.",
+            "enforcement": ["behavior", "fault-matrix"],
+            "behaviorOwners": ["tests/contract/aiSessions/sessionControllers.test.js"],
+            "guardOwners": [],
+            "evidence": ["src/aiSessions/creationController.ts", "src/worktrees/groupManifestStore.ts"]
+        },
+        {
+            "id": "ARCH-WORKTREE-TOMBSTONE-FIRST-001",
+            "module": "MOD-WORKTREE-LIFECYCLE",
+            "productCapabilities": ["MAIN-WORKTREE-CHANGES-PANEL"],
+            "priority": "P0",
+            "kind": "recovery",
+            "statement": "Dismissal persists the tombstone before removing any live row, context, or manifest member; a failed tombstone write refuses the whole dismissal.",
+            "authority": {
+                "path": "src/worktrees/isolatedSessionController.ts",
+                "symbol": "IsolatedSessionController"
+            },
+            "writers": [
+                "src/dashboard.ts",
+                "src/worktrees/isolatedSessionController.ts"
+            ],
+            "linearizationPoint": "appendTombstones memento update precedes live-row removal.",
+            "enforcement": ["single-writer", "behavior", "fault-matrix"],
+            "behaviorOwners": ["tests/contract/worktrees/isolatedSessionController.test.js"],
+            "guardOwners": ["tests/unit/architecture/singleWriters.test.js"],
+            "evidence": ["src/worktrees/isolatedSessionController.ts", "src/worktrees/provisioningStore.ts"],
+            "stateFamily": {
+                "storePath": "src/worktrees/provisioningStore.ts",
+                "writeMethods": [
+                    "replaceLive",
+                    "appendTombstones",
+                    "deleteTombstones",
+                    "pruneTombstones"
+                ]
+            }
+        },
+        {
+            "id": "ARCH-WORKTREE-BASELINE-FREEZE-001",
+            "module": "MOD-WORKTREE-LIFECYCLE",
+            "productCapabilities": ["MAIN-WORKTREE-CHANGES-PANEL"],
+            "priority": "P1",
+            "kind": "persistence",
+            "statement": "The base ref is frozen to an immutable commit SHA before git worktree add; a group never provisions from a moving ref.",
+            "authority": {
+                "path": "src/worktrees/groupCreationController.ts",
+                "symbol": "WorktreeGroupCreationController"
+            },
+            "writers": [],
+            "linearizationPoint": "resolveBaseCommit returns before createGroup.",
+            "enforcement": ["behavior"],
+            "behaviorOwners": ["tests/contract/worktrees/groupCreationController.test.js"],
+            "guardOwners": [],
+            "evidence": ["src/worktrees/groupCreationController.ts", "src/worktrees/gitWorktreeProvisioner.ts"]
+        },
+        {
+            "id": "ARCH-WORKTREE-RESTART-RECOVERY-001",
+            "module": "MOD-WORKTREE-LIFECYCLE",
+            "productCapabilities": ["MAIN-WORKTREE-CHANGES-PANEL"],
+            "priority": "P1",
+            "kind": "recovery",
+            "statement": "Every crash window between the linearization points has deterministic restart reconciliation: interrupted work demotes to failed/interrupted, tombstones prune only with positive evidence, unknown deletion observation keeps the lease.",
+            "authority": {
+                "path": "src/worktrees/groupManifestReconciliation.ts",
+                "symbol": "reconcileWorktreeGroupManifest"
+            },
+            "writers": [],
+            "linearizationPoint": "Snapshot-load reconciliation completes before new provisioning rows publish.",
+            "enforcement": ["behavior", "fault-matrix"],
+            "behaviorOwners": [
+                "tests/unit/worktrees/groupManifestReconciliation.test.js",
+                "tests/unit/worktrees/deletionController.test.js"
+            ],
+            "guardOwners": [],
+            "evidence": ["src/worktrees/groupManifestReconciliation.ts", "src/worktrees/deletionController.ts"]
+        },
+        {
+            "id": "ARCH-WORKTREE-PROTOCOL-ENVELOPE-001",
+            "module": "MOD-WORKTREE-LIFECYCLE",
+            "productCapabilities": ["MAIN-WORKTREE-CHANGES-PANEL"],
+            "priority": "P1",
+            "kind": "protocol",
+            "statement": "Every pilot mutation message carries a correlation envelope (requestId, version) and a documented exactly-once mechanism (replay cache or single-use token); the known gaps (confirm replay cache, set-primary/merge/adopt/discard-claim correlation, merge requestId) are migration slice S4 targets.",
+            "authority": {
+                "path": "src/worktrees/groupCreationProtocol.ts",
+                "symbol": "parseConfirmWorktreeGroupRequest"
+            },
+            "writers": [],
+            "linearizationPoint": "Protocol parse precedes any state mutation.",
+            "enforcement": ["behavior"],
+            "behaviorOwners": ["tests/browser/worktreeGroupForm.test.js"],
+            "guardOwners": [],
+            "evidence": ["src/worktrees/groupCreationProtocol.ts", "src/dashboard.ts"]
+        },
+        {
+            "id": "ARCH-WORKTREE-IDENTITY-CODEC-001",
+            "module": "MOD-WORKTREE-LIFECYCLE",
+            "productCapabilities": ["MAIN-WORKTREE-CHANGES-PANEL"],
+            "priority": "P1",
+            "kind": "identity",
+            "statement": "Domain identities (WorktreeKey, composite session identity, safe ids) use one canonical codec and equality policy owned by the domain layer; persisted encodings stay stable per usage context.",
+            "authority": {
+                "path": "src/worktrees/types.ts",
+                "symbol": "worktreeKeysEqual"
+            },
+            "writers": [],
+            "linearizationPoint": "Identity construction goes through the canonical codec.",
+            "enforcement": ["behavior"],
+            "behaviorOwners": ["tests/unit/worktrees/provisioningPlan.test.js"],
+            "guardOwners": [],
+            "evidence": ["src/worktrees/types.ts"]
+        }
+    ]
+}

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -6740,5 +6740,33 @@
       ".ci/architecture-debt-baseline.json",
       "docs/testing/architecture-waivers.json"
     ]
+  },
+  {
+    "id": "ARCH-INVARIANT-CATALOG-001",
+    "domain": "architecture",
+    "title": "The architecture invariant catalog validates its schema and every module, capability, and path reference resolves",
+    "priority": "P1",
+    "status": "automated",
+    "owners": [
+      "tests/unit/architecture/singleWriters.test.js"
+    ],
+    "evidence": [
+      "scripts/architecture/checkSingleWriters.js",
+      "docs/testing/architecture-invariants.json"
+    ]
+  },
+  {
+    "id": "ARCH-SINGLE-WRITER-001",
+    "domain": "architecture",
+    "title": "A declared state family's write methods are only called from its declared writer set; same-named methods without a store reference are not bypasses",
+    "priority": "P0",
+    "status": "automated",
+    "owners": [
+      "tests/unit/architecture/singleWriters.test.js"
+    ],
+    "evidence": [
+      "scripts/architecture/checkSingleWriters.js",
+      "docs/testing/architecture-invariants.json"
+    ]
   }
 ]

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "fd471497a9991819c63c8efbfac06f4bd385a240",
+        "head": "9cc798e174564d2cc3274b139d7c3fe64a875064",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -420,7 +420,8 @@
             "357082a4822ee89163c66805ebaa59000b7df731",
             "dd3efc003679aa153fe5018bd40110364573d91e",
             "64430b4980005eb195d4a0fff85fb8f716e65a21",
-            "cd361291398dd7ba884cfc37b45b807ba015bcf1"
+            "cd361291398dd7ba884cfc37b45b807ba015bcf1",
+            "da3b97d09f3f6af8b735ed6988b3b7423f3bb0f3"
         ]
     },
     "capabilities": [
@@ -2248,13 +2249,16 @@
             "requirement": "Closed-world architecture classification and module registry schema validation stay enforced: every production file has exactly one module and role, and policy references resolve.",
             "commits": [
                 "a76abb00ff83dd937011ac4afcd1f60d88dc473e",
-                "fd471497a9991819c63c8efbfac06f4bd385a240"
+                "fd471497a9991819c63c8efbfac06f4bd385a240",
+                "9cc798e174564d2cc3274b139d7c3fe64a875064"
             ],
             "behaviors": [
                 "ARCH-POLICY-SCHEMA-001",
                 "ARCH-CLOSED-WORLD-001",
                 "ARCH-MODULE-BOUNDARY-001",
-                "ARCH-MODULE-CYCLE-001"
+                "ARCH-MODULE-CYCLE-001",
+                "ARCH-INVARIANT-CATALOG-001",
+                "ARCH-SINGLE-WRITER-001"
             ],
             "prGates": [
                 "test:architecture-policy"

--- a/package.json
+++ b/package.json
@@ -606,7 +606,7 @@
         "test:tmux:smoke": "npm run test-compile && node scripts/run-ai-session-tmux-smoke-checks.js",
         "test:architecture-baseline": "node scripts/run-performance-architecture-baseline-checks.js",
         "test:architecture-guards": "node scripts/run-architecture-guards.js",
-        "test:architecture-policy": "node --test 'tests/unit/architecture/**/*.test.js' && node scripts/architecture/checkClosedWorld.js && node scripts/architecture/checkModuleBoundaries.js",
+        "test:architecture-policy": "node --test 'tests/unit/architecture/**/*.test.js' && node scripts/architecture/checkClosedWorld.js && node scripts/architecture/checkModuleBoundaries.js && node scripts/architecture/checkSingleWriters.js",
         "test:release-notes": "node scripts/run-release-notes-checks.js",
         "test:release-packaging": "node scripts/seed-release-packaging-stale-output.js && npm run package:release && node scripts/run-release-packaging-checks.js",
         "test:conversation-performance": "node scripts/run-conversation-performance-checks.js",

--- a/scripts/architecture/checkSingleWriters.js
+++ b/scripts/architecture/checkSingleWriters.js
@@ -1,0 +1,175 @@
+'use strict';
+
+/**
+ * Single-writer enforcement (Harness v0, program Stage 2 PR 3).
+ *
+ * Validates the invariant catalog (docs/testing/architecture-invariants.json)
+ * structurally and cross-file, then mechanically checks every invariant whose
+ * enforcement includes "single-writer": a write-method call on the state
+ * family's store outside the declared writer set fails. The writer set is a
+ * ratchet — it may only shrink during migration, never grow.
+ *
+ * Bypass check: the store's persistence key may not be referenced outside the
+ * store file at all.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { loadArchitecturePolicy } = require('./loadArchitecturePolicy');
+
+const INVARIANTS_PATH = path.join('docs', 'testing', 'architecture-invariants.json');
+const INVARIANT_ID_PATTERN = /^ARCH-[A-Z0-9]+(?:-[A-Z0-9]+)*-\d{3}$/;
+const PRIORITIES = ['P0', 'P1', 'P2'];
+const KINDS = ['product', 'state-machine', 'identity', 'persistence', 'protocol',
+    'concurrency', 'recovery', 'dependency', 'performance', 'security'];
+const ENFORCEMENTS = ['module-boundary', 'single-writer', 'behavior', 'fault-matrix'];
+
+function readJson(rootDirectory, relativePath, errors) {
+    try {
+        return JSON.parse(fs.readFileSync(path.join(rootDirectory, relativePath), 'utf8'));
+    } catch (error) {
+        errors.push(`invariants: cannot read ${relativePath}: ${error.message}`);
+        return null;
+    }
+}
+
+function validateCatalog(rootDirectory, policy) {
+    const errors = [];
+    const catalog = readJson(rootDirectory, INVARIANTS_PATH, errors);
+    if (!catalog) { return { catalog: null, errors }; }
+    if (catalog.version !== 1) {
+        errors.push('invariants: version must be 1');
+    }
+    const invariants = Array.isArray(catalog.invariants) ? catalog.invariants : [];
+    if (invariants.length === 0) {
+        errors.push('invariants: invariants must be a non-empty array');
+    }
+
+    const moduleIds = new Set(policy.modules.map(module => module.id));
+    const capabilityManifest = readJson(
+        rootDirectory, path.join('docs', 'testing', 'main-capability-coverage.json'), errors);
+    const capabilityIds = new Set((capabilityManifest ? capabilityManifest.capabilities : [])
+        .map(capability => capability.id));
+    const invariantIds = new Set();
+
+    const requirePath = (owner, file, field) => {
+        if (typeof file !== 'string' || !file || !fs.existsSync(path.join(rootDirectory, file))) {
+            errors.push(`${owner}: ${field} path '${file}' does not exist`);
+        }
+    };
+
+    for (const invariant of invariants) {
+        const owner = `invariant ${invariant && invariant.id ? invariant.id : '<missing id>'}`;
+        if (!invariant.id || !INVARIANT_ID_PATTERN.test(invariant.id)) {
+            errors.push(`${owner}: id must match ${INVARIANT_ID_PATTERN}`);
+        }
+        if (invariantIds.has(invariant.id)) {
+            errors.push(`${owner}: duplicate invariant id`);
+        }
+        invariantIds.add(invariant.id);
+        if (!moduleIds.has(invariant.module)) {
+            errors.push(`${owner}: unknown module '${invariant.module}'`);
+        }
+        for (const capability of invariant.productCapabilities || []) {
+            if (!capabilityIds.has(capability)) {
+                errors.push(`${owner}: unknown product capability '${capability}'`);
+            }
+        }
+        if (!PRIORITIES.includes(invariant.priority)) {
+            errors.push(`${owner}: priority must be one of ${PRIORITIES.join(', ')}`);
+        }
+        if (!KINDS.includes(invariant.kind)) {
+            errors.push(`${owner}: kind must be one of ${KINDS.join(', ')}`);
+        }
+        if (typeof invariant.statement !== 'string' || !invariant.statement) {
+            errors.push(`${owner}: statement is required`);
+        }
+        if (!invariant.authority || typeof invariant.authority.path !== 'string') {
+            errors.push(`${owner}: authority.path is required`);
+        } else {
+            requirePath(owner, invariant.authority.path, 'authority.path');
+        }
+        for (const enforcement of invariant.enforcement || []) {
+            if (!ENFORCEMENTS.includes(enforcement)) {
+                errors.push(`${owner}: unknown enforcement '${enforcement}'`);
+            }
+        }
+        for (const field of ['writers', 'behaviorOwners', 'guardOwners', 'evidence']) {
+            for (const file of invariant[field] || []) {
+                requirePath(owner, file, field);
+            }
+        }
+        const hasSingleWriter = (invariant.enforcement || []).includes('single-writer');
+        if (hasSingleWriter) {
+            const family = invariant.stateFamily;
+            if (!family || !family.storePath || !Array.isArray(family.writeMethods)
+                || family.writeMethods.length === 0) {
+                errors.push(`${owner}: single-writer enforcement requires a stateFamily `
+                    + 'with storePath and writeMethods');
+            } else {
+                requirePath(owner, family.storePath, 'stateFamily.storePath');
+            }
+            if (!Array.isArray(invariant.writers) || invariant.writers.length === 0) {
+                errors.push(`${owner}: single-writer enforcement requires a non-empty writers set`);
+            }
+        }
+    }
+    return { catalog, errors };
+}
+
+/** Scan declared state families for write-method calls outside the writers. */
+function checkWriters(rootDirectory, catalog, policy) {
+    const errors = [];
+    const invariants = (catalog.invariants || [])
+        .filter(invariant => invariant.stateFamily
+            && (invariant.enforcement || []).includes('single-writer'));
+    for (const invariant of invariants) {
+        const family = invariant.stateFamily;
+        const writers = new Set([...invariant.writers, family.storePath]);
+        const storeReference = path.basename(family.storePath).replace(/\.[^.]+$/, '');
+        const callPattern = new RegExp(
+            `\\.(?:${family.writeMethods.join('|')})\\s*\\(`);
+        for (const file of policy.files) {
+            if (writers.has(file)) { continue; }
+            const text = fs.readFileSync(path.join(rootDirectory, file), 'utf8');
+            // A same-named method on an unrelated store is not a bypass: the
+            // file must also reference the state family's store.
+            if (!text.includes(storeReference)) { continue; }
+            const match = callPattern.exec(text);
+            if (match) {
+                errors.push(`single-writer: ${file} calls '${match[0].slice(1, -1).trim()}' on the `
+                    + `${family.storePath} state family outside the declared writers of `
+                    + `${invariant.id} — route the write through the authority or land an `
+                    + 'approved architecture change that amends the writer set');
+            }
+        }
+    }
+    return errors;
+}
+
+function runSingleWriterCheck(rootDirectory) {
+    const policy = loadArchitecturePolicy(rootDirectory);
+    const errors = [...policy.errors];
+    const { catalog, errors: catalogErrors } = validateCatalog(rootDirectory, policy);
+    errors.push(...catalogErrors);
+    if (catalog) {
+        errors.push(...checkWriters(rootDirectory, catalog, policy));
+    }
+    return { errors };
+}
+
+function main() {
+    const { errors } = runSingleWriterCheck(path.resolve(__dirname, '..', '..'));
+    if (errors.length > 0) {
+        console.error('Single-writer checks FAILED:');
+        for (const error of errors) { console.error(`  ✗ ${error}`); }
+        process.exitCode = 1;
+        return;
+    }
+    console.log('Single-writer checks passed: invariant catalog valid, '
+        + 'declared state families have no undeclared writers.');
+}
+
+if (require.main === module) { main(); }
+
+module.exports = { INVARIANTS_PATH, runSingleWriterCheck };

--- a/tests/unit/architecture/singleWriters.test.js
+++ b/tests/unit/architecture/singleWriters.test.js
@@ -1,0 +1,158 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const test = require('node:test');
+
+const {
+    runSingleWriterCheck,
+} = require('../../../scripts/architecture/checkSingleWriters');
+
+const repoRoot = path.resolve(__dirname, '..', '..', '..');
+
+function makeFixture({ invariants, sources }) {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'arch-writers-'));
+    const writeJson = (relative, value) => {
+        fs.mkdirSync(path.join(root, path.dirname(relative)), { recursive: true });
+        fs.writeFileSync(path.join(root, relative), JSON.stringify(value, null, 2));
+    };
+    writeJson('docs/testing/architecture-modules.json', {
+        version: 1,
+        scope: { roots: ['src'] },
+        modules: [{
+            id: 'MOD-ALPHA',
+            title: 'Alpha',
+            purpose: 'fixture',
+            source: { include: ['src/**'], exclude: [] },
+            mayDependOn: [],
+            roles: [{ role: 'application', include: ['src/**'] }],
+            productCapabilities: ['MAIN-TEST-001'],
+        }],
+    });
+    writeJson('docs/testing/main-capability-coverage.json', {
+        version: 1, capabilities: [{ id: 'MAIN-TEST-001' }],
+    });
+    writeJson('docs/testing/architecture-invariants.json', {
+        version: 1, invariants,
+    });
+    for (const [file, content] of Object.entries(sources)) {
+        fs.mkdirSync(path.join(root, path.dirname(file)), { recursive: true });
+        fs.writeFileSync(path.join(root, file), content);
+    }
+    return root;
+}
+
+function validInvariant(overrides = {}) {
+    return {
+        id: 'ARCH-TEST-FAMILY-001',
+        module: 'MOD-ALPHA',
+        productCapabilities: ['MAIN-TEST-001'],
+        priority: 'P0',
+        kind: 'concurrency',
+        statement: 'fixture invariant',
+        authority: { path: 'src/store.ts', symbol: 'Store' },
+        writers: ['src/writer.ts'],
+        linearizationPoint: 'fixture',
+        enforcement: ['single-writer'],
+        behaviorOwners: ['src/store.ts'],
+        guardOwners: [],
+        evidence: ['src/store.ts'],
+        stateFamily: { storePath: 'src/store.ts', writeMethods: ['writeThing'] },
+        ...overrides,
+    };
+}
+
+const baseSources = {
+    'src/store.ts': 'export class Store { writeThing() {} }\n',
+    'src/writer.ts': 'import { Store } from \'./store\';\nexport const run = (s: Store) => s.writeThing();\n',
+    'src/quiet.ts': 'export const nothing = 1;\n',
+};
+
+test('ARCH-INVARIANT-CATALOG-001 ARCH-SINGLE-WRITER-001 the real repository catalog validates and no state family has an undeclared writer', () => {
+    const { errors } = runSingleWriterCheck(repoRoot);
+    assert.deepEqual(errors, []);
+});
+
+test('ARCH-INVARIANT-CATALOG-001 a valid synthetic catalog passes', () => {
+    const root = makeFixture({ invariants: [validInvariant()], sources: baseSources });
+    assert.deepEqual(runSingleWriterCheck(root).errors, []);
+});
+
+test('ARCH-SINGLE-WRITER-001 controlled mutation: a writer outside the declared set fails', () => {
+    const root = makeFixture({
+        invariants: [validInvariant()],
+        sources: {
+            ...baseSources,
+            'src/bypass.ts': 'import { Store } from \'./store\';\nexport const evil = (s: Store) => s.writeThing();\n',
+        },
+    });
+    const { errors } = runSingleWriterCheck(root);
+    assert.ok(errors.some(error => error.includes('src/bypass.ts')
+        && error.includes('writeThing') && error.includes('ARCH-TEST-FAMILY-001')));
+});
+
+test('ARCH-SINGLE-WRITER-001 a same-named method without a store reference is not a bypass', () => {
+    const root = makeFixture({
+        invariants: [validInvariant()],
+        sources: {
+            ...baseSources,
+            'src/other.ts': 'export const fine = (todoService) => todoService.writeThing();\n',
+        },
+    });
+    assert.deepEqual(runSingleWriterCheck(root).errors, []);
+});
+
+test('ARCH-INVARIANT-CATALOG-001 controlled mutation: duplicate invariant id is rejected', () => {
+    const root = makeFixture({
+        invariants: [validInvariant(), validInvariant()],
+        sources: baseSources,
+    });
+    assert.ok(runSingleWriterCheck(root).errors
+        .some(error => error.includes('duplicate invariant id')));
+});
+
+test('ARCH-INVARIANT-CATALOG-001 controlled mutation: unknown module reference is rejected', () => {
+    const root = makeFixture({
+        invariants: [validInvariant({ module: 'MOD-NOPE' })],
+        sources: baseSources,
+    });
+    assert.ok(runSingleWriterCheck(root).errors
+        .some(error => error.includes("unknown module 'MOD-NOPE'")));
+});
+
+test('ARCH-INVARIANT-CATALOG-001 controlled mutation: unknown capability reference is rejected', () => {
+    const root = makeFixture({
+        invariants: [validInvariant({ productCapabilities: ['MAIN-NOPE'] })],
+        sources: baseSources,
+    });
+    assert.ok(runSingleWriterCheck(root).errors
+        .some(error => error.includes("unknown product capability 'MAIN-NOPE'")));
+});
+
+test('ARCH-INVARIANT-CATALOG-001 controlled mutation: invalid priority is rejected', () => {
+    const root = makeFixture({
+        invariants: [validInvariant({ priority: 'P9' })],
+        sources: baseSources,
+    });
+    assert.ok(runSingleWriterCheck(root).errors
+        .some(error => error.includes('priority must be one of')));
+});
+
+test('ARCH-INVARIANT-CATALOG-001 controlled mutation: single-writer enforcement without a state family is rejected', () => {
+    const invariant = validInvariant();
+    delete invariant.stateFamily;
+    const root = makeFixture({ invariants: [invariant], sources: baseSources });
+    assert.ok(runSingleWriterCheck(root).errors
+        .some(error => error.includes('requires a stateFamily')));
+});
+
+test('ARCH-INVARIANT-CATALOG-001 controlled mutation: a missing authority path is rejected', () => {
+    const root = makeFixture({
+        invariants: [validInvariant({ authority: { path: 'src/nope.ts', symbol: 'Nope' } })],
+        sources: baseSources,
+    });
+    assert.ok(runSingleWriterCheck(root).errors
+        .some(error => error.includes("authority.path") && error.includes('does not exist')));
+});


### PR DESCRIPTION
## Summary

Stage 2 PR-3 of the architecture harness program, on top of the merged boundary guards (#256).

- **`docs/testing/architecture-invariants.json`**: the eight approved pilot invariants normalized from the RFC draft — structured authority/writers/enforcement, every module/capability/path reference cross-validated.
- **`scripts/architecture/checkSingleWriters.js`**: catalog schema validation plus the mechanical single-writer check: a write-method call on a declared state family's store outside its writer set fails. The check requires a store reference alongside the method call, so same-named methods on unrelated services (todo groups) are not false positives — verified by a dedicated mutation test.
- **Measured pilot writer sets declared**: the worktree manifest family (7 writer files — the multi-writer reality behind findings P1/P2, ratcheted so migration can only shrink it) and the provisioning store family (2 writer files).
- **`tests/unit/architecture/singleWriters.test.js`**: 10 tests covering catalog schema mutations and the writer scan.
- Lane `test:architecture-policy` now runs all three checkers (closed-world, module boundaries, single-writer).

No production source file changed; observable behavior untouched.

## Skill harvest

no skill change — no new workflow lesson beyond what the harness itself now encodes.

## Verification

- `npm run test:architecture-policy`: 40/40 green; all three checkers pass on the real repository.
- `npm run test:behavior-contracts` green after the audit commit; `npm run test-compile` clean; `git diff --check` clean.
- Architecture scripts line coverage: 87.7%.