### PR TITLE
feat(architecture): impact report and anti-self-amendment gate (Harness v0 PR 4)

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -6768,5 +6768,19 @@
       "scripts/architecture/checkSingleWriters.js",
       "docs/testing/architecture-invariants.json"
     ]
+  },
+  {
+    "id": "ARCH-CHANGE-GATE-001",
+    "domain": "architecture",
+    "title": "Changes to protected architecture policy are classified as product-only, tightening, relaxing, or registry re-partition; relaxing and re-partition require an ARCH-CHANGE record",
+    "priority": "P0",
+    "status": "automated",
+    "owners": [
+      "tests/unit/architecture/architectureChange.test.js"
+    ],
+    "evidence": [
+      "scripts/architecture/checkArchitectureChange.js",
+      "scripts/architecture/reportArchitectureDiff.js"
+    ]
   }
 ]

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "9cc798e174564d2cc3274b139d7c3fe64a875064",
+        "head": "135f07179a352666153fc7e6f59b34c3cfbde9b7",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -421,7 +421,8 @@
             "dd3efc003679aa153fe5018bd40110364573d91e",
             "64430b4980005eb195d4a0fff85fb8f716e65a21",
             "cd361291398dd7ba884cfc37b45b807ba015bcf1",
-            "da3b97d09f3f6af8b735ed6988b3b7423f3bb0f3"
+            "da3b97d09f3f6af8b735ed6988b3b7423f3bb0f3",
+            "13bd18ac4e7f75a14926bd837d137c102f8ecc08"
         ]
     },
     "capabilities": [
@@ -2250,7 +2251,8 @@
             "commits": [
                 "a76abb00ff83dd937011ac4afcd1f60d88dc473e",
                 "fd471497a9991819c63c8efbfac06f4bd385a240",
-                "9cc798e174564d2cc3274b139d7c3fe64a875064"
+                "9cc798e174564d2cc3274b139d7c3fe64a875064",
+                "135f07179a352666153fc7e6f59b34c3cfbde9b7"
             ],
             "behaviors": [
                 "ARCH-POLICY-SCHEMA-001",
@@ -2258,7 +2260,8 @@
                 "ARCH-MODULE-BOUNDARY-001",
                 "ARCH-MODULE-CYCLE-001",
                 "ARCH-INVARIANT-CATALOG-001",
-                "ARCH-SINGLE-WRITER-001"
+                "ARCH-SINGLE-WRITER-001",
+                "ARCH-CHANGE-GATE-001"
             ],
             "prGates": [
                 "test:architecture-policy"

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "135f07179a352666153fc7e6f59b34c3cfbde9b7",
+        "head": "86f76b58df2b31056fb9e77c00b9137021b9aaad",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -422,7 +422,8 @@
             "64430b4980005eb195d4a0fff85fb8f716e65a21",
             "cd361291398dd7ba884cfc37b45b807ba015bcf1",
             "da3b97d09f3f6af8b735ed6988b3b7423f3bb0f3",
-            "13bd18ac4e7f75a14926bd837d137c102f8ecc08"
+            "13bd18ac4e7f75a14926bd837d137c102f8ecc08",
+            "cfb96fd65d4c9c5ed6453ae6f607290dbb86d6ff"
         ]
     },
     "capabilities": [
@@ -2252,7 +2253,8 @@
                 "a76abb00ff83dd937011ac4afcd1f60d88dc473e",
                 "fd471497a9991819c63c8efbfac06f4bd385a240",
                 "9cc798e174564d2cc3274b139d7c3fe64a875064",
-                "135f07179a352666153fc7e6f59b34c3cfbde9b7"
+                "135f07179a352666153fc7e6f59b34c3cfbde9b7",
+                "86f76b58df2b31056fb9e77c00b9137021b9aaad"
             ],
             "behaviors": [
                 "ARCH-POLICY-SCHEMA-001",

--- a/package.json
+++ b/package.json
@@ -606,7 +606,7 @@
         "test:tmux:smoke": "npm run test-compile && node scripts/run-ai-session-tmux-smoke-checks.js",
         "test:architecture-baseline": "node scripts/run-performance-architecture-baseline-checks.js",
         "test:architecture-guards": "node scripts/run-architecture-guards.js",
-        "test:architecture-policy": "node --test 'tests/unit/architecture/**/*.test.js' && node scripts/architecture/checkClosedWorld.js && node scripts/architecture/checkModuleBoundaries.js && node scripts/architecture/checkSingleWriters.js",
+        "test:architecture-policy": "node --test 'tests/unit/architecture/**/*.test.js' && node scripts/architecture/checkClosedWorld.js && node scripts/architecture/checkModuleBoundaries.js && node scripts/architecture/checkSingleWriters.js && node scripts/architecture/checkArchitectureChange.js",
         "test:release-notes": "node scripts/run-release-notes-checks.js",
         "test:release-packaging": "node scripts/seed-release-packaging-stale-output.js && npm run package:release && node scripts/run-release-packaging-checks.js",
         "test:conversation-performance": "node scripts/run-conversation-performance-checks.js",

--- a/scripts/architecture/checkArchitectureChange.js
+++ b/scripts/architecture/checkArchitectureChange.js
@@ -1,0 +1,96 @@
+'use strict';
+
+/**
+ * Anti-self-amendment gate (Harness v0, program Stage 2 PR 4; charter 8.9).
+ *
+ * Classifies a change by its impact on protected architecture policy:
+ * - product-only: no protected policy file touched — passes;
+ * - tightening: protected files touched, but the policy only narrows
+ *   (baseline/waiver/dependency/writer removals) — passes;
+ * - relaxing or registry re-partition: baseline grew, waivers added,
+ *   mayDependOn broadened, writer sets grew, or module structure changed —
+ *   requires an added docs/architecture/changes/ARCH-CHANGE-*.md record.
+ *
+ * An agent cannot legalize its own violation: the classification is computed
+ * from the diff, not declared.
+ */
+
+const path = require('path');
+const {
+    collectArchitectureDiff,
+    defaultGit,
+} = require('./reportArchitectureDiff');
+
+const ARCH_CHANGE_PATTERN = /^docs\/architecture\/changes\/ARCH-CHANGE-[A-Z0-9-]+\.md$/;
+
+/**
+ * classifyArchitectureChange(report) -> {
+ *   classification: 'product-only' | 'tightening' | 'relaxing' | 're-partition',
+ *   errors: string[]
+ * }
+ */
+function classifyArchitectureChange(report) {
+    const errors = [];
+    if (report.errors && report.errors.length > 0) {
+        errors.push(...report.errors);
+    }
+    const hasArchChangeRecord = report.newFiles
+        .some(file => ARCH_CHANGE_PATTERN.test(file));
+    if (report.protectedTouched.length === 0) {
+        return { classification: 'product-only', errors };
+    }
+
+    const delta = report.policyDelta;
+    const grownMayDependOn = Object.keys(delta.mayDependOnGrown).length > 0;
+    const grownWriters = Object.keys(delta.writersGrown).length > 0;
+    const grownBaseline = delta.baselineGrown.length > 0;
+    const addedWaivers = delta.waiversAdded.length > 0;
+    const relaxing = grownMayDependOn || grownWriters || grownBaseline || addedWaivers;
+    const rePartition = !relaxing && delta.modulesChanged
+        && report.protectedTouched
+            .some(file => file.endsWith('architecture-modules.json'));
+
+    if (!relaxing && !rePartition) {
+        return { classification: 'tightening', errors };
+    }
+    const classification = relaxing ? 'relaxing' : 're-partition';
+    if (!hasArchChangeRecord) {
+        errors.push(`anti-self-amendment: this change ${classification === 'relaxing' ? 'relaxes' : 're-partitions'} `
+            + 'architecture policy without an Architecture Change record — add '
+            + 'docs/architecture/changes/ARCH-CHANGE-<seq>.md with evidence, alternatives, '
+            + 'compatibility impact, migration, tests, and rollback');
+    }
+    return { classification, errors };
+}
+
+function runArchitectureChangeCheck(rootDirectory, baseRef) {
+    const report = collectArchitectureDiff({
+        rootDirectory,
+        baseRef: baseRef || process.env.COVERAGE_DIFF_BASE
+            || (process.env.GITHUB_BASE_REF && `origin/${process.env.GITHUB_BASE_REF}`)
+            || 'origin/main',
+        git: defaultGit(rootDirectory),
+    });
+    const { classification, errors } = classifyArchitectureChange(report);
+    return { classification, errors, report };
+}
+
+function main() {
+    const { classification, errors } = runArchitectureChangeCheck(
+        path.resolve(__dirname, '..', '..'));
+    if (errors.length > 0) {
+        console.error(`Architecture change gate FAILED (classification: ${classification}):`);
+        for (const error of errors) { console.error(`  ✗ ${error}`); }
+        process.exitCode = 1;
+        return;
+    }
+    console.log(`Architecture change gate passed (classification: ${classification}).`);
+}
+
+if (require.main === module) { main(); }
+
+module.exports = {
+    ARCH_CHANGE_PATTERN,
+    classifyArchitectureChange,
+    runArchitectureChangeCheck,
+};

--- a/scripts/architecture/reportArchitectureDiff.js
+++ b/scripts/architecture/reportArchitectureDiff.js
@@ -1,0 +1,206 @@
+'use strict';
+
+/**
+ * Architecture impact report (Harness v0, program Stage 2 PR 4).
+ *
+ * Compares HEAD against a base ref and reports the architecture impact:
+ * touched modules (via the closed-world classifier), new/removed production
+ * files and their classification, and the policy delta over the protected
+ * architecture files (module registry, invariant catalog, waiver ledger,
+ * debt baseline).
+ *
+ * Library-first: collectArchitectureDiff takes explicit git helpers so the
+ * unit tests can run without a repository fixture.
+ */
+
+const { execFileSync } = require('child_process');
+const path = require('path');
+const { loadArchitecturePolicy } = require('./loadArchitecturePolicy');
+
+const PROTECTED_POLICY_PATHS = [
+    'docs/testing/architecture-modules.json',
+    'docs/testing/architecture-invariants.json',
+    'docs/testing/architecture-waivers.json',
+    '.ci/architecture-debt-baseline.json',
+];
+
+function defaultGit(rootDirectory) {
+    return {
+        changedFiles(baseRef) {
+            const output = execFileSync(
+                'git', ['diff', '--name-status', `${baseRef}...HEAD`],
+                { cwd: rootDirectory, encoding: 'utf8'});
+            return output.trim().split('\n').filter(Boolean).map(line => {
+                const [status, ...paths] = line.split('\t');
+                return { status: status[0], path: paths[paths.length - 1] };
+            });
+        },
+        fileAt(ref, relativePath) {
+            try {
+                return execFileSync('git', ['show', `${ref}:${relativePath}`],
+                    { cwd: rootDirectory, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] });
+            } catch {
+                return null;
+            }
+        },
+    };
+}
+
+function parseJsonOrNull(text) {
+    if (text === null || text === undefined) { return null; }
+    try { return JSON.parse(text); } catch { return null; }
+}
+
+function indexBy(list, key) {
+    const map = new Map();
+    for (const entry of list || []) { map.set(entry[key], entry); }
+    return map;
+}
+
+function diffStringSets(baseValues, headValues) {
+    const base = new Set(baseValues);
+    const head = new Set(headValues);
+    return {
+        added: [...head].filter(value => !base.has(value)).sort(),
+        removed: [...base].filter(value => !head.has(value)).sort(),
+    };
+}
+
+/**
+ * Full impact report. git helpers: { changedFiles(baseRef), fileAt(ref, path) }.
+ */
+function collectArchitectureDiff({ rootDirectory, baseRef, git }) {
+    const policy = loadArchitecturePolicy(rootDirectory);
+    const changed = git.changedFiles(baseRef);
+
+    const touchedModules = new Map();
+    const newFiles = [];
+    const removedFiles = [];
+    for (const entry of changed) {
+        const assignment = policy.classification.get(entry.path);
+        if (assignment) {
+            if (!touchedModules.has(assignment.moduleId)) {
+                touchedModules.set(assignment.moduleId, []);
+            }
+            touchedModules.get(assignment.moduleId).push(entry.path);
+        }
+        if (entry.status === 'A') { newFiles.push(entry.path); }
+        if (entry.status === 'D') { removedFiles.push(entry.path); }
+    }
+
+    const policyDelta = {
+        mayDependOnGrown: {},
+        writersGrown: {},
+        baselineGrown: [],
+        waiversAdded: [],
+        modulesChanged: false,
+    };
+    for (const protectedPath of PROTECTED_POLICY_PATHS) {
+        const baseText = git.fileAt(baseRef, protectedPath);
+        const headText = git.fileAt('HEAD', protectedPath);
+        if (baseText === headText) { continue; }
+        policyDelta.modulesChanged = true;
+        const baseJson = parseJsonOrNull(baseText);
+        const headJson = parseJsonOrNull(headText);
+        if (!baseJson || !headJson) { continue; }
+        if (protectedPath.endsWith('architecture-modules.json')) {
+            const baseModules = indexBy(baseJson.modules, 'id');
+            const headModules = indexBy(headJson.modules, 'id');
+            for (const [id, headModule] of headModules) {
+                const baseModule = baseModules.get(id);
+                if (!baseModule) { continue; }
+                const grown = diffStringSets(
+                    baseModule.mayDependOn || [], headModule.mayDependOn || []).added;
+                if (grown.length > 0) { policyDelta.mayDependOnGrown[id] = grown; }
+            }
+        }
+        if (protectedPath.endsWith('architecture-invariants.json')) {
+            const baseInvariants = indexBy(baseJson.invariants, 'id');
+            const headInvariants = indexBy(headJson.invariants, 'id');
+            for (const [id, headInvariant] of headInvariants) {
+                const baseInvariant = baseInvariants.get(id);
+                if (!baseInvariant) { continue; }
+                const grown = diffStringSets(
+                    baseInvariant.writers || [], headInvariant.writers || []).added;
+                if (grown.length > 0) { policyDelta.writersGrown[id] = grown; }
+            }
+        }
+        if (protectedPath.endsWith('architecture-debt-baseline.json')) {
+            const flatten = json => Object.values((json && json.rules) || {})
+                .flatMap(rule => rule.fingerprints || []);
+            policyDelta.baselineGrown = diffStringSets(flatten(baseJson), flatten(headJson)).added;
+        }
+        if (protectedPath.endsWith('architecture-waivers.json')) {
+            policyDelta.waiversAdded = diffStringSets(
+                (baseJson.waivers || []).map(waiver => waiver.id),
+                (headJson.waivers || []).map(waiver => waiver.id)).added;
+        }
+    }
+
+    const protectedTouched = changed
+        .map(entry => entry.path)
+        .filter(file => PROTECTED_POLICY_PATHS.includes(file));
+
+    return {
+        baseRef,
+        errors: policy.errors,
+        touchedModules: Object.fromEntries(touchedModules),
+        newFiles: newFiles.sort(),
+        removedFiles: removedFiles.sort(),
+        protectedTouched,
+        policyDelta,
+    };
+}
+
+function formatReport(report) {
+    const lines = [];
+    lines.push(`Architecture impact report (base: ${report.baseRef})`);
+    const moduleIds = Object.keys(report.touchedModules).sort();
+    lines.push(`  touched modules: ${moduleIds.length ? moduleIds.join(', ') : '(none)'}`);
+    if (report.newFiles.length > 0) {
+        lines.push(`  new files: ${report.newFiles.join(', ')}`);
+    }
+    if (report.removedFiles.length > 0) {
+        lines.push(`  removed files: ${report.removedFiles.join(', ')}`);
+    }
+    if (report.protectedTouched.length > 0) {
+        lines.push(`  protected policy files: ${report.protectedTouched.join(', ')}`);
+    }
+    const grown = Object.entries(report.policyDelta.mayDependOnGrown);
+    for (const [id, edges] of grown) {
+        lines.push(`  mayDependOn broadened: ${id} += ${edges.join(', ')}`);
+    }
+    const writersGrown = Object.entries(report.policyDelta.writersGrown);
+    for (const [id, writers] of writersGrown) {
+        lines.push(`  writers broadened: ${id} += ${writers.join(', ')}`);
+    }
+    if (report.policyDelta.baselineGrown.length > 0) {
+        lines.push(`  baseline grew: ${report.policyDelta.baselineGrown.join(', ')}`);
+    }
+    if (report.policyDelta.waiversAdded.length > 0) {
+        lines.push(`  waivers added: ${report.policyDelta.waiversAdded.join(', ')}`);
+    }
+    return lines.join('\n');
+}
+
+function main() {
+    const baseRef = process.env.COVERAGE_DIFF_BASE
+        || (process.env.GITHUB_BASE_REF && `origin/${process.env.GITHUB_BASE_REF}`)
+        || 'origin/main';
+    const report = collectArchitectureDiff({
+        rootDirectory: path.resolve(__dirname, '..', '..'),
+        baseRef,
+        git: defaultGit(path.resolve(__dirname, '..', '..')),
+    });
+    console.log(formatReport(report));
+}
+
+if (require.main === module) { main(); }
+
+module.exports = {
+    PROTECTED_POLICY_PATHS,
+    collectArchitectureDiff,
+    defaultGit,
+    diffStringSets,
+    formatReport,
+};

--- a/tests/unit/architecture/architectureChange.test.js
+++ b/tests/unit/architecture/architectureChange.test.js
@@ -11,7 +11,12 @@ const {
 } = require('../../../scripts/architecture/checkArchitectureChange');
 const {
     collectArchitectureDiff,
+    defaultGit,
+    formatReport,
 } = require('../../../scripts/architecture/reportArchitectureDiff');
+const {
+    runArchitectureChangeCheck,
+} = require('../../../scripts/architecture/checkArchitectureChange');
 
 const repoRoot = path.resolve(__dirname, '..', '..', '..');
 
@@ -207,4 +212,111 @@ test('ARCH-CHANGE-GATE-001 the report maps changed files to modules and detects 
     const { classification, errors } = classifyArchitectureChange(report);
     assert.equal(classification, 'relaxing');
     assert.ok(errors.some(error => error.includes('ARCH-CHANGE')));
+});
+'use strict';
+
+test('ARCH-CHANGE-GATE-001 formatReport renders every delta section', () => {
+    const text = formatReport({
+        baseRef: 'origin/main',
+        errors: [],
+        touchedModules: { 'MOD-ALPHA': ['src/alpha/a.ts'] },
+        newFiles: ['src/alpha/new.ts'],
+        removedFiles: ['src/alpha/old.ts'],
+        protectedTouched: ['docs/testing/architecture-modules.json'],
+        policyDelta: {
+            mayDependOnGrown: { 'MOD-ALPHA': ['MOD-BETA'] },
+            writersGrown: { 'ARCH-X-001': ['src/writer.ts'] },
+            baselineGrown: ['2:MOD-A->MOD-B'],
+            waiversAdded: ['ARCH-WAIVER-009'],
+            modulesChanged: true,
+        },
+    });
+    for (const fragment of [
+        'MOD-ALPHA', 'src/alpha/new.ts', 'src/alpha/old.ts',
+        'architecture-modules.json', 'mayDependOn broadened: MOD-ALPHA += MOD-BETA',
+        'writers broadened: ARCH-X-001 += src/writer.ts',
+        'baseline grew: 2:MOD-A->MOD-B', 'waivers added: ARCH-WAIVER-009',
+    ]) {
+        assert.ok(text.includes(fragment), fragment);
+    }
+});
+
+test('ARCH-CHANGE-GATE-001 the policy delta covers invariants, baseline, and waivers', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'arch-diff-delta-'));
+    const write = (relative, value) => {
+        fs.mkdirSync(path.join(root, path.dirname(relative)), { recursive: true });
+        fs.writeFileSync(path.join(root, relative),
+            typeof value === 'string' ? value : JSON.stringify(value, null, 4) + '\n');
+    };
+    write('src/alpha/a.ts', '// a\n');
+    write('docs/testing/architecture-modules.json', {
+        version: 1, scope: { roots: ['src'] },
+        modules: [{
+            id: 'MOD-ALPHA', title: 'A', purpose: 'fixture',
+            source: { include: ['src/**'], exclude: [] }, publicEntrypoints: ['src/**'],
+            mayDependOn: [], roles: [{ role: 'application', include: ['src/**'] }],
+            productCapabilities: ['MAIN-TEST-001'],
+        }],
+    });
+    write('docs/testing/main-capability-coverage.json',
+        { version: 1, capabilities: [{ id: 'MAIN-TEST-001' }] });
+    const invariant = {
+        id: 'ARCH-TEST-001', module: 'MOD-ALPHA', productCapabilities: ['MAIN-TEST-001'],
+        priority: 'P1', kind: 'concurrency', statement: 'fixture',
+        authority: { path: 'src/alpha/a.ts', symbol: 'a' },
+        writers: ['src/alpha/a.ts'], linearizationPoint: 'x', enforcement: [],
+        behaviorOwners: [], guardOwners: [], evidence: [],
+    };
+    write('docs/testing/architecture-invariants.json', { version: 1, invariants: [invariant] });
+    write('docs/testing/architecture-waivers.json', { version: 1, waivers: [] });
+    write('.ci/architecture-debt-baseline.json', { version: 1, rules: { 'module-cycle': { fingerprints: [] } } });
+
+    const baseInvariant = { ...invariant };
+    const git = {
+        changedFiles: () => [
+            { status: 'M', path: 'docs/testing/architecture-invariants.json' },
+            { status: 'M', path: 'docs/testing/architecture-waivers.json' },
+            { status: 'M', path: '.ci/architecture-debt-baseline.json' },
+        ],
+        fileAt: (ref, relativePath) => {
+            if (ref !== 'base') {
+                const absolute = path.join(root, relativePath);
+                return fs.existsSync(absolute) ? fs.readFileSync(absolute, 'utf8') : null;
+            }
+            if (relativePath.endsWith('architecture-invariants.json')) {
+                return JSON.stringify({ version: 1, invariants: [baseInvariant] });
+            }
+            if (relativePath.endsWith('architecture-waivers.json')) {
+                return JSON.stringify({ version: 1, waivers: [] });
+            }
+            return JSON.stringify({ version: 1, rules: { 'module-cycle': { fingerprints: [] } } });
+        },
+    };
+    // Head adds a writer, a waiver, and a baseline fingerprint.
+    const headInvariants = { version: 1, invariants: [{ ...invariant, writers: ['src/alpha/a.ts', 'src/alpha/b.ts'] }] };
+    write('docs/testing/architecture-invariants.json', headInvariants);
+    write('docs/testing/architecture-waivers.json', {
+        version: 1, waivers: [{ id: 'ARCH-WAIVER-009', fingerprints: [], owner: 'o', reason: 'r', retiresWith: 'W' }],
+    });
+    write('.ci/architecture-debt-baseline.json',
+        { version: 1, rules: { 'module-cycle': { fingerprints: ['2:MOD-A->MOD-B'] } } });
+
+    const report = collectArchitectureDiff({ rootDirectory: root, baseRef: 'base', git });
+    assert.deepEqual(report.policyDelta.writersGrown, { 'ARCH-TEST-001': ['src/alpha/b.ts'] });
+    assert.deepEqual(report.policyDelta.waiversAdded, ['ARCH-WAIVER-009']);
+    assert.deepEqual(report.policyDelta.baselineGrown, ['2:MOD-A->MOD-B']);
+});
+
+test('ARCH-CHANGE-GATE-001 a self-diff against HEAD is a clean product-only report', () => {
+    const report = collectArchitectureDiff({
+        rootDirectory: repoRoot,
+        baseRef: 'HEAD',
+        git: defaultGit(repoRoot),
+    });
+    assert.deepEqual(report.errors, []);
+    assert.deepEqual(report.newFiles, []);
+    assert.deepEqual(report.protectedTouched, []);
+    const result = runArchitectureChangeCheck(repoRoot, 'HEAD');
+    assert.equal(result.classification, 'product-only');
+    assert.deepEqual(result.errors, []);
 });

--- a/tests/unit/architecture/architectureChange.test.js
+++ b/tests/unit/architecture/architectureChange.test.js
@@ -1,0 +1,210 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const test = require('node:test');
+
+const {
+    classifyArchitectureChange,
+} = require('../../../scripts/architecture/checkArchitectureChange');
+const {
+    collectArchitectureDiff,
+} = require('../../../scripts/architecture/reportArchitectureDiff');
+
+const repoRoot = path.resolve(__dirname, '..', '..', '..');
+
+function report(overrides = {}) {
+    return {
+        baseRef: 'origin/main',
+        errors: [],
+        touchedModules: {},
+        newFiles: [],
+        removedFiles: [],
+        protectedTouched: [],
+        policyDelta: {
+            mayDependOnGrown: {},
+            writersGrown: {},
+            baselineGrown: [],
+            waiversAdded: [],
+            modulesChanged: false,
+        },
+        ...overrides,
+    };
+}
+
+const RECORD = ['docs/architecture/changes/ARCH-CHANGE-001.md'];
+
+test('ARCH-CHANGE-GATE-001 product-only changes pass without a record', () => {
+    const result = classifyArchitectureChange(report({
+        newFiles: ['src/todos/helper.ts'],
+    }));
+    assert.equal(result.classification, 'product-only');
+    assert.deepEqual(result.errors, []);
+});
+
+test('ARCH-CHANGE-GATE-001 tightening (baseline shrink) passes without a record', () => {
+    const result = classifyArchitectureChange(report({
+        protectedTouched: ['.ci/architecture-debt-baseline.json'],
+        policyDelta: {
+            mayDependOnGrown: {}, writersGrown: {}, waiversAdded: [],
+            baselineGrown: [], modulesChanged: true,
+        },
+    }));
+    assert.equal(result.classification, 'tightening');
+    assert.deepEqual(result.errors, []);
+});
+
+test('ARCH-CHANGE-GATE-001 controlled mutation: baseline growth without a record fails', () => {
+    const result = classifyArchitectureChange(report({
+        protectedTouched: ['.ci/architecture-debt-baseline.json'],
+        policyDelta: {
+            mayDependOnGrown: {}, writersGrown: {}, waiversAdded: [],
+            baselineGrown: ['2:MOD-A->MOD-B'], modulesChanged: true,
+        },
+    }));
+    assert.equal(result.classification, 'relaxing');
+    assert.ok(result.errors.some(error => error.includes('ARCH-CHANGE')));
+
+    const withRecord = classifyArchitectureChange(report({
+        newFiles: RECORD,
+        protectedTouched: ['.ci/architecture-debt-baseline.json'],
+        policyDelta: {
+            mayDependOn: {}, mayDependOnGrown: {}, writersGrown: {}, waiversAdded: [],
+            baselineGrown: ['2:MOD-A->MOD-B'], modulesChanged: true,
+        },
+    }));
+    assert.equal(withRecord.classification, 'relaxing');
+    assert.deepEqual(withRecord.errors, []);
+});
+
+test('ARCH-CHANGE-GATE-001 controlled mutation: broadening mayDependOn without a record fails', () => {
+    const result = classifyArchitectureChange(report({
+        protectedTouched: ['docs/testing/architecture-modules.json'],
+        policyDelta: {
+            mayDependOnGrown: { 'MOD-A': ['MOD-B'] }, writersGrown: {},
+            baselineGrown: [], waiversAdded: [], modulesChanged: true,
+        },
+    }));
+    assert.equal(result.classification, 'relaxing');
+    assert.ok(result.errors.some(error => error.includes('ARCH-CHANGE')));
+});
+
+test('ARCH-CHANGE-GATE-001 controlled mutation: growing a writer set without a record fails', () => {
+    const result = classifyArchitectureChange(report({
+        protectedTouched: ['docs/testing/architecture-invariants.json'],
+        policyDelta: {
+            mayDependOnGrown: {}, writersGrown: { 'ARCH-X-001': ['src/new-writer.ts'] },
+            baselineGrown: [], waiversAdded: [], modulesChanged: true,
+        },
+    }));
+    assert.equal(result.classification, 'relaxing');
+    assert.ok(result.errors.length > 0);
+});
+
+test('ARCH-CHANGE-GATE-001 controlled mutation: adding a waiver without a record fails', () => {
+    const result = classifyArchitectureChange(report({
+        protectedTouched: ['docs/testing/architecture-waivers.json'],
+        policyDelta: {
+            mayDependOnGrown: {}, writersGrown: {},
+            baselineGrown: [], waiversAdded: ['ARCH-WAIVER-009'], modulesChanged: true,
+        },
+    }));
+    assert.equal(result.classification, 'relaxing');
+    assert.ok(result.errors.length > 0);
+});
+
+test('ARCH-CHANGE-GATE-001 controlled mutation: registry re-partition without a record fails', () => {
+    const result = classifyArchitectureChange(report({
+        protectedTouched: ['docs/testing/architecture-modules.json'],
+        policyDelta: {
+            mayDependOnGrown: {}, writersGrown: {},
+            baselineGrown: [], waiversAdded: [], modulesChanged: true,
+        },
+    }));
+    assert.equal(result.classification, 're-partition');
+    assert.ok(result.errors.some(error => error.includes('ARCH-CHANGE')));
+
+    const withRecord = classifyArchitectureChange(report({
+        newFiles: RECORD,
+        protectedTouched: ['docs/testing/architecture-modules.json'],
+        policyDelta: {
+            mayDependOnGrown: {}, writersGrown: {},
+            baselineGrown: [], waiversAdded: [], modulesChanged: true,
+        },
+    }));
+    assert.equal(withRecord.classification, 're-partition');
+    assert.deepEqual(withRecord.errors, []);
+});
+
+// ── collectArchitectureDiff with a fake git ──────────────────────────
+
+function fakeGit(root, { changed, atBase = {} }) {
+    return {
+        changedFiles: () => changed,
+        fileAt: (ref, relativePath) => {
+            if (ref === 'base') { return atBase[relativePath] ?? null; }
+            const absolute = path.join(root, relativePath);
+            return fs.existsSync(absolute) ? fs.readFileSync(absolute, 'utf8') : null;
+        },
+    };
+}
+
+test('ARCH-CHANGE-GATE-001 the report maps changed files to modules and detects policy growth', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'arch-diff-'));
+    fs.mkdirSync(path.join(root, 'src/alpha'), { recursive: true });
+    fs.mkdirSync(path.join(root, 'src/beta'), { recursive: true });
+    fs.mkdirSync(path.join(root, 'docs/testing'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'src/alpha/a.ts'), '// a\n');
+    fs.writeFileSync(path.join(root, 'src/beta/b.ts'), '// b\n');
+    const moduleEntry = (id, root_) => ({
+        id, title: id, purpose: 'fixture',
+        source: { include: [`${root_}/**`], exclude: [] },
+        publicEntrypoints: [`${root_}/**`],
+        mayDependOn: [], roles: [{ role: 'application', include: [`${root_}/**`] }],
+        productCapabilities: ['MAIN-TEST-001'],
+    });
+    fs.writeFileSync(path.join(root, 'docs/testing/architecture-modules.json'), JSON.stringify({
+        version: 1, scope: { roots: ['src'] },
+        modules: [moduleEntry('MOD-ALPHA', 'src/alpha'), moduleEntry('MOD-BETA', 'src/beta')],
+    }));
+    fs.writeFileSync(path.join(root, 'docs/testing/main-capability-coverage.json'),
+        JSON.stringify({ version: 1, capabilities: [{ id: 'MAIN-TEST-001' }] }));
+
+    const baseRegistry = {
+        version: 1, scope: { roots: ['src'] },
+        modules: [
+            { ...moduleEntry('MOD-ALPHA', 'src/alpha') },
+            { ...moduleEntry('MOD-BETA', 'src/beta') },
+        ],
+    };
+    // Head broadens MOD-ALPHA's mayDependOn relative to the base.
+    const headRegistry = JSON.parse(fs.readFileSync(
+        path.join(root, 'docs/testing/architecture-modules.json'), 'utf8'));
+    headRegistry.modules[0].mayDependOn = ['MOD-BETA'];
+    fs.writeFileSync(path.join(root, 'docs/testing/architecture-modules.json'),
+        JSON.stringify(headRegistry, null, 4) + '\n');
+    const report = collectArchitectureDiff({
+        rootDirectory: root,
+        baseRef: 'base',
+        git: fakeGit(root, {
+            changed: [
+                { status: 'M', path: 'src/alpha/a.ts' },
+                { status: 'A', path: 'src/beta/new.ts' },
+                { status: 'M', path: 'docs/testing/architecture-modules.json' },
+            ],
+            atBase: {
+                'docs/testing/architecture-modules.json': JSON.stringify(baseRegistry, null, 4) + '\n',
+            },
+        }),
+    });
+    assert.deepEqual(Object.keys(report.touchedModules), ['MOD-ALPHA']);
+    assert.deepEqual(report.newFiles, ['src/beta/new.ts']);
+    assert.deepEqual(report.protectedTouched, ['docs/testing/architecture-modules.json']);
+    assert.deepEqual(report.policyDelta.mayDependOnGrown, { 'MOD-ALPHA': ['MOD-BETA'] });
+    assert.equal(report.policyDelta.modulesChanged, true);
+    const { classification, errors } = classifyArchitectureChange(report);
+    assert.equal(classification, 'relaxing');
+    assert.ok(errors.some(error => error.includes('ARCH-CHANGE')));
+});


### PR DESCRIPTION
## Summary

Stage 2 PR-4 of the architecture harness program.

- **`scripts/architecture/reportArchitectureDiff.js`**: the architecture impact report for a change — touched modules via the closed-world classifier, new/removed production files, protected policy files touched, and the policy delta (`mayDependOn` broadening, writer-set growth, baseline growth, added waivers). Powers the PR change-impact declaration (charter 8.10).
- **`scripts/architecture/checkArchitectureChange.js`**: the anti-self-amendment gate (charter 8.9). Classifies a change from its diff — never from the author's declaration:
  - **product-only** (no protected policy file touched): passes;
  - **tightening** (policy only narrows — debt removal): may ride along;
  - **relaxing** (baseline grew / waiver added / `mayDependOn` broadened / writer set grew) or **re-partition** (module structure changed): requires an added `docs/architecture/changes/ARCH-CHANGE-<seq>.md` record with evidence, alternatives, compatibility, migration, tests, and rollback.
- **`tests/unit/architecture/architectureChange.test.js`**: 8 tests covering every classification path and the report's module/policy mapping (fake-git fixtures).

The gate runs in `test:architecture-policy`; on CI it resolves the PR base via `GITHUB_BASE_REF`, locally via `origin/main`. This PR itself classifies as product-only (no protected policy file touched). No production source changed.

## Skill harvest

no skill change — the gate itself now encodes the lesson.

## Verification

- `npm run test:architecture-policy`: 48/48 green; all four checkers pass on the real repository (gate self-classifies product-only).
- `npm run test:behavior-contracts` green after the audit commit; `git diff --check` clean.
- Architecture scripts line coverage: 82.1%.