### PR TITLE
feat(architecture): webview declared-manifest policy (Harness v0 PR 5 — kernel complete)

### DIFF
--- a/docs/testing/architecture-webview-manifest.json
+++ b/docs/testing/architecture-webview-manifest.json
@@ -1,0 +1,103 @@
+{
+    "version": 1,
+    "title": "Webview script manifest (declared bundles, load order, permitted globals)",
+    "notes": [
+        "The 37 src/webview/*.js scripts carry no static imports; they couple through script load order and window globals. This manifest declares both, and scripts/architecture/checkWebviewManifest.js enforces them (charter v3 Section 8.6).",
+        "Membership is exact-once: every production webview script belongs to exactly one bundle. Load order is mirrored from the builders and drift-checked against them.",
+        "A cross-script global reference (window.__agentPivot* or vendor globals) must be declared in permittedGlobals; dynamic window[...] access fails closed.",
+        "Adding a global or reordering a bundle is a deliberate policy change visible in review."
+    ],
+    "bundles": [
+        {
+            "id": "dashboard",
+            "builtBy": "scripts/build-dashboard-webview-bundle.js",
+            "vendor": [
+                "node_modules/fitty/dist/fitty.min.js",
+                "node_modules/dragula/dist/dragula.min.js",
+                "node_modules/dom-autoscroller/dist/dom-autoscroller.min.js"
+            ],
+            "scripts": [
+                "src/webview/webviewScrollStateScripts.js",
+                "src/webview/webviewAiSessionViewStateScripts.js",
+                "src/webview/webviewWorkspaceUpdateScripts.js",
+                "src/webview/webviewTodoGroupScripts.js",
+                "src/webview/webviewProjectCollapseScripts.js",
+                "src/webview/webviewOpenTabSplitScripts.js",
+                "src/webview/webviewTodoControlScripts.js",
+                "src/webview/webviewProjectContextMenuScripts.js",
+                "src/webview/webviewProjectAiUpdateScripts.js",
+                "src/webview/webviewGroupFormScripts.js",
+                "src/webview/webviewProjectAiSessionControlsScripts.js",
+                "src/webview/webviewProjectScripts.js",
+                "src/webview/webviewSkillPanelScripts.js",
+                "src/webview/webviewProjectsPanelScripts.js",
+                "src/webview/webviewDashboardValidationScripts.js",
+                "src/webview/webviewDashboardSearchScripts.js",
+                "src/webview/webviewDashboardProjectsPanelScripts.js",
+                "src/webview/webviewDashboardTodoPanelScripts.js",
+                "src/webview/webviewDashboardAiPanelScripts.js",
+                "src/webview/webviewDashboardScripts.js",
+                "src/webview/webviewPromptProtocolScripts.js",
+                "src/webview/webviewPromptScripts.js",
+                "src/webview/webviewTodoRenderScripts.js",
+                "src/webview/webviewTodoScripts.js",
+                "src/webview/webviewDnDScripts.js",
+                "src/webview/webviewFilterScripts.js"
+            ]
+        },
+        {
+            "id": "conversation-viewer",
+            "builtBy": "src/aiSessions/conversation/viewerDocument.ts",
+            "vendor": ["media/purify.min.js"],
+            "lazyVendor": ["media/mermaid.min.js"],
+            "scripts": [
+                "src/webview/conversationReadingAnchorScripts.js",
+                "src/webview/conversationMermaidScripts.js",
+                "src/webview/conversationOutlineScripts.js",
+                "src/webview/conversationSubagentsScripts.js",
+                "src/webview/conversationChangesScripts.js",
+                "src/webview/conversationTelemetryScripts.js",
+                "src/webview/conversationCommentsScripts.js",
+                "src/webview/conversationSidebarScripts.js",
+                "src/webview/conversationReconcileScripts.js",
+                "src/webview/conversationFindScripts.js",
+                "src/webview/conversationViewerScripts.js"
+            ]
+        }
+    ],
+    "permittedGlobals": [
+        "window.__agentPivotAcknowledgeSession",
+        "window.__agentPivotAttentionAcknowledgementTimeoutMs",
+        "window.__agentPivotBatchAiSessions",
+        "window.__agentPivotContextMenus",
+        "window.__agentPivotConversationChanges",
+        "window.__agentPivotConversationComments",
+        "window.__agentPivotConversationFind",
+        "window.__agentPivotConversationMermaid",
+        "window.__agentPivotConversationOutline",
+        "window.__agentPivotConversationReadingAnchor",
+        "window.__agentPivotConversationReconcile",
+        "window.__agentPivotConversationSidebar",
+        "window.__agentPivotConversationSubagents",
+        "window.__agentPivotConversationTelemetry",
+        "window.__agentPivotDashboard",
+        "window.__agentPivotOpenTabSplit",
+        "window.__agentPivotPrompts",
+        "window.__agentPivotReadyDocumentGeneration",
+        "window.__agentPivotRevealPendingWorkspaceSession",
+        "window.__agentPivotRevealWorkspace",
+        "window.__agentPivotRevealWorkspaceSession",
+        "window.__agentPivotRevealWorkspaceWorktree",
+        "window.__agentPivotScrollState",
+        "window.__agentPivotSyncCollapseButton",
+        "window.__agentPivotTodo",
+        "window.__agentPivotWorktreeAdopt",
+        "window.__agentPivotWorktreeGroupAggregateRevision",
+        "window.__agentPivotWorktreeGroupDeletion",
+        "window.__agentPivotWorktreeGroupForm",
+        "window.__agentPivotWorktreeGroupRename",
+        "window.vscode",
+        "window.DOMPurify",
+        "window.mermaid"
+    ]
+}

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -6782,5 +6782,19 @@
       "scripts/architecture/checkArchitectureChange.js",
       "scripts/architecture/reportArchitectureDiff.js"
     ]
+  },
+  {
+    "id": "ARCH-WEBVIEW-MANIFEST-001",
+    "domain": "architecture",
+    "title": "Every webview script belongs to exactly one declared bundle with builder-faithful load order, and every cross-script window global is declared; dynamic window access fails closed",
+    "priority": "P0",
+    "status": "automated",
+    "owners": [
+      "tests/unit/architecture/webviewManifest.test.js"
+    ],
+    "evidence": [
+      "scripts/architecture/checkWebviewManifest.js",
+      "docs/testing/architecture-webview-manifest.json"
+    ]
   }
 ]

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "86f76b58df2b31056fb9e77c00b9137021b9aaad",
+        "head": "99666fe7bd595cc977c7b7b583fdf1f3238b4413",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -423,7 +423,8 @@
             "cd361291398dd7ba884cfc37b45b807ba015bcf1",
             "da3b97d09f3f6af8b735ed6988b3b7423f3bb0f3",
             "13bd18ac4e7f75a14926bd837d137c102f8ecc08",
-            "cfb96fd65d4c9c5ed6453ae6f607290dbb86d6ff"
+            "cfb96fd65d4c9c5ed6453ae6f607290dbb86d6ff",
+            "15e02b1fc1d28814f08b3b734d6bf710ddebf640"
         ]
     },
     "capabilities": [
@@ -2254,7 +2255,8 @@
                 "fd471497a9991819c63c8efbfac06f4bd385a240",
                 "9cc798e174564d2cc3274b139d7c3fe64a875064",
                 "135f07179a352666153fc7e6f59b34c3cfbde9b7",
-                "86f76b58df2b31056fb9e77c00b9137021b9aaad"
+                "86f76b58df2b31056fb9e77c00b9137021b9aaad",
+                "99666fe7bd595cc977c7b7b583fdf1f3238b4413"
             ],
             "behaviors": [
                 "ARCH-POLICY-SCHEMA-001",
@@ -2263,7 +2265,8 @@
                 "ARCH-MODULE-CYCLE-001",
                 "ARCH-INVARIANT-CATALOG-001",
                 "ARCH-SINGLE-WRITER-001",
-                "ARCH-CHANGE-GATE-001"
+                "ARCH-CHANGE-GATE-001",
+                "ARCH-WEBVIEW-MANIFEST-001"
             ],
             "prGates": [
                 "test:architecture-policy"

--- a/package.json
+++ b/package.json
@@ -606,7 +606,7 @@
         "test:tmux:smoke": "npm run test-compile && node scripts/run-ai-session-tmux-smoke-checks.js",
         "test:architecture-baseline": "node scripts/run-performance-architecture-baseline-checks.js",
         "test:architecture-guards": "node scripts/run-architecture-guards.js",
-        "test:architecture-policy": "node --test 'tests/unit/architecture/**/*.test.js' && node scripts/architecture/checkClosedWorld.js && node scripts/architecture/checkModuleBoundaries.js && node scripts/architecture/checkSingleWriters.js && node scripts/architecture/checkArchitectureChange.js",
+        "test:architecture-policy": "node --test 'tests/unit/architecture/**/*.test.js' && node scripts/architecture/checkClosedWorld.js && node scripts/architecture/checkModuleBoundaries.js && node scripts/architecture/checkSingleWriters.js && node scripts/architecture/checkArchitectureChange.js && node scripts/architecture/checkWebviewManifest.js",
         "test:release-notes": "node scripts/run-release-notes-checks.js",
         "test:release-packaging": "node scripts/seed-release-packaging-stale-output.js && npm run package:release && node scripts/run-release-packaging-checks.js",
         "test:conversation-performance": "node scripts/run-conversation-performance-checks.js",

--- a/scripts/architecture/checkWebviewManifest.js
+++ b/scripts/architecture/checkWebviewManifest.js
@@ -1,0 +1,134 @@
+'use strict';
+
+/**
+ * Webview declared-manifest enforcement (Harness v0, program Stage 2 PR 5;
+ * charter v3 Section 8.6).
+ *
+ * The 37 src/webview/*.js scripts carry no static imports, so the module
+ * graph cannot police them. This check enforces the declared manifest
+ * (docs/testing/architecture-webview-manifest.json):
+ * - membership: every production webview script belongs to exactly one bundle;
+ * - load order: the manifest mirrors the builders (bundle inputPaths and the
+ *   conversation viewer document) and drift in either direction fails;
+ * - globals: every cross-script window.* reference must be declared in
+ *   permittedGlobals, and dynamic window[...] access fails closed.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const MANIFEST_PATH = path.join('docs', 'testing', 'architecture-webview-manifest.json');
+const BUNDLE_BUILDER = path.join('scripts', 'build-dashboard-webview-bundle.js');
+const VIEWER_DOCUMENT = path.join('src', 'aiSessions', 'conversation', 'viewerDocument.ts');
+const GLOBAL_REFERENCE = /window\.(__agentPivot[A-Za-z0-9]*|vscode|mermaid|DOMPurify|fitty|dragula|domAutoscroller)\b/g;
+const DYNAMIC_GLOBAL_ACCESS = /window\s*\[/g;
+
+function readJson(rootDirectory, relativePath, errors) {
+    try {
+        return JSON.parse(fs.readFileSync(path.join(rootDirectory, relativePath), 'utf8'));
+    } catch (error) {
+        errors.push(`webview-manifest: cannot read ${relativePath}: ${error.message}`);
+        return null;
+    }
+}
+
+function checkBundleOrder(rootDirectory, errors) {
+    const builderText = fs.readFileSync(path.join(rootDirectory, BUNDLE_BUILDER), 'utf8');
+    const builderOrder = [...builderText.matchAll(/'(src\/webview\/[^']+\.js)'/g)]
+        .map(match => match[1]);
+    const viewerText = fs.readFileSync(path.join(rootDirectory, VIEWER_DOCUMENT), 'utf8');
+    const viewerOrder = [...viewerText.matchAll(/mediaUri\('(conversation[A-Za-z]+Scripts\.js)'\)/g)]
+        .map(match => `src/webview/${match[1]}`);
+    return { builderOrder, viewerOrder };
+}
+
+function runWebviewManifestCheck(rootDirectory) {
+    const errors = [];
+    const manifest = readJson(rootDirectory, MANIFEST_PATH, errors);
+    if (!manifest) { return { errors }; }
+    if (manifest.version !== 1) {
+        errors.push('webview-manifest: version must be 1');
+    }
+    const bundles = Array.isArray(manifest.bundles) ? manifest.bundles : [];
+    const permittedGlobals = new Set(
+        Array.isArray(manifest.permittedGlobals) ? manifest.permittedGlobals : []);
+
+    // Membership: exact-once over src/webview/*.js, and every entry exists.
+    const membership = new Map();
+    const webviewDirectory = path.join(rootDirectory, 'src', 'webview');
+    const scriptsOnDisk = fs.readdirSync(webviewDirectory)
+        .filter(name => name.endsWith('.js'))
+        .map(name => `src/webview/${name}`)
+        .sort();
+    for (const bundle of bundles) {
+        for (const script of bundle.scripts || []) {
+            if (!fs.existsSync(path.join(rootDirectory, script))) {
+                errors.push(`webview-manifest: bundle '${bundle.id}' lists ${script}, `
+                    + 'which does not exist');
+            }
+            if (membership.has(script)) {
+                errors.push(`webview-manifest: ${script} is in bundles '${membership.get(script)}' `
+                    + `and '${bundle.id}' (membership is exact-once)`);
+            }
+            membership.set(script, bundle.id);
+        }
+    }
+    for (const script of scriptsOnDisk) {
+        if (!membership.has(script)) {
+            errors.push(`webview-manifest: ${script} is not declared in any bundle`);
+        }
+    }
+
+    // Load-order fidelity with the builders.
+    const { builderOrder, viewerOrder } = checkBundleOrder(rootDirectory, errors);
+    for (const bundle of bundles) {
+        if (bundle.id === 'dashboard') {
+            if (JSON.stringify(bundle.scripts) !== JSON.stringify(builderOrder)) {
+                errors.push('webview-manifest: dashboard bundle order differs from '
+                    + `${BUNDLE_BUILDER} inputPaths`);
+            }
+        }
+        if (bundle.id === 'conversation-viewer') {
+            if (JSON.stringify(bundle.scripts) !== JSON.stringify(viewerOrder)) {
+                errors.push('webview-manifest: conversation-viewer bundle order differs from '
+                    + `${VIEWER_DOCUMENT} script emission order`);
+            }
+        }
+    }
+
+    // Cross-script globals must be declared; dynamic access fails closed.
+    for (const script of scriptsOnDisk) {
+        const text = fs.readFileSync(path.join(rootDirectory, script), 'utf8');
+        DYNAMIC_GLOBAL_ACCESS.lastIndex = 0;
+        if (DYNAMIC_GLOBAL_ACCESS.test(text)) {
+            errors.push(`webview-manifest: ${script} uses dynamic window[...] access, `
+                + 'which evades the declared-global policy');
+        }
+        GLOBAL_REFERENCE.lastIndex = 0;
+        let match;
+        while ((match = GLOBAL_REFERENCE.exec(text))) {
+            const global_ = `window.${match[1]}`;
+            if (!permittedGlobals.has(global_)) {
+                errors.push(`webview-manifest: ${script} references undeclared global `
+                    + `${global_} — declare it in ${MANIFEST_PATH}`);
+            }
+        }
+    }
+    return { errors };
+}
+
+function main() {
+    const { errors } = runWebviewManifestCheck(path.resolve(__dirname, '..', '..'));
+    if (errors.length > 0) {
+        console.error('Webview manifest checks FAILED:');
+        for (const error of errors) { console.error(`  ✗ ${error}`); }
+        process.exitCode = 1;
+        return;
+    }
+    console.log('Webview manifest checks passed: exact-once membership, load-order '
+        + 'fidelity with both builders, and all cross-script globals declared.');
+}
+
+if (require.main === module) { main(); }
+
+module.exports = { MANIFEST_PATH, runWebviewManifestCheck };

--- a/scripts/architecture/reportArchitectureDiff.js
+++ b/scripts/architecture/reportArchitectureDiff.js
@@ -21,6 +21,7 @@ const PROTECTED_POLICY_PATHS = [
     'docs/testing/architecture-modules.json',
     'docs/testing/architecture-invariants.json',
     'docs/testing/architecture-waivers.json',
+    'docs/testing/architecture-webview-manifest.json',
     '.ci/architecture-debt-baseline.json',
 ];
 

--- a/tests/unit/architecture/webviewManifest.test.js
+++ b/tests/unit/architecture/webviewManifest.test.js
@@ -1,0 +1,124 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const test = require('node:test');
+
+const {
+    runWebviewManifestCheck,
+} = require('../../../scripts/architecture/checkWebviewManifest');
+
+const repoRoot = path.resolve(__dirname, '..', '..', '..');
+
+/**
+ * Synthetic webview fixture: two dashboard scripts and one conversation
+ * script, with the builders mirroring the manifest order.
+ */
+function makeFixture({ manifestBundles, scripts = {}, builderOrder, viewerOrder }) {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'arch-webview-'));
+    const write = (relative, content) => {
+        fs.mkdirSync(path.join(root, path.dirname(relative)), { recursive: true });
+        fs.writeFileSync(path.join(root, relative), content);
+    };
+    write('docs/testing/architecture-webview-manifest.json', JSON.stringify({
+        version: 1,
+        bundles: manifestBundles,
+        permittedGlobals: ['window.__agentPivotAlpha', 'window.vscode'],
+    }));
+    const builder = (builderOrder || ['src/webview/aScripts.js', 'src/webview/bScripts.js'])
+        .map(file => `    '${file}',`).join('\n');
+    write('scripts/build-dashboard-webview-bundle.js', `const inputPaths = [\n${builder}\n];\n`);
+    const viewer = (viewerOrder || ['src/webview/conversationCScripts.js'])
+        .map(file => `options.mediaUri('${path.basename(file)}')`).join('\n');
+    write('src/aiSessions/conversation/viewerDocument.ts', viewer + '\n');
+    for (const [file, content] of Object.entries(scripts)) {
+        write(file, content);
+    }
+    return root;
+}
+
+const baseBundles = [
+    { id: 'dashboard', scripts: ['src/webview/aScripts.js', 'src/webview/bScripts.js'] },
+    { id: 'conversation-viewer', scripts: ['src/webview/conversationCScripts.js'] },
+];
+const baseScripts = {
+    'src/webview/aScripts.js': 'window.__agentPivotAlpha = {};\n',
+    'src/webview/bScripts.js': 'window.vscode.postMessage({});\n',
+    'src/webview/conversationCScripts.js': '// viewer\n',
+};
+
+test('ARCH-WEBVIEW-MANIFEST-001 the real repository satisfies the declared manifest', () => {
+    const { errors } = runWebviewManifestCheck(repoRoot);
+    assert.deepEqual(errors, []);
+});
+
+test('ARCH-WEBVIEW-MANIFEST-001 a consistent synthetic manifest passes', () => {
+    const root = makeFixture({ manifestBundles: baseBundles, scripts: baseScripts });
+    assert.deepEqual(runWebviewManifestCheck(root).errors, []);
+});
+
+test('ARCH-WEBVIEW-MANIFEST-001 controlled mutation: an undeclared script fails', () => {
+    const root = makeFixture({
+        manifestBundles: baseBundles,
+        scripts: { ...baseScripts, 'src/webview/sneakyScripts.js': '// new\n' },
+    });
+    assert.ok(runWebviewManifestCheck(root).errors
+        .some(error => error.includes('sneakyScripts.js') && error.includes('not declared')));
+});
+
+test('ARCH-WEBVIEW-MANIFEST-001 controlled mutation: double membership fails', () => {
+    const bundles = [
+        { id: 'dashboard', scripts: ['src/webview/aScripts.js', 'src/webview/bScripts.js'] },
+        { id: 'conversation-viewer', scripts: ['src/webview/conversationCScripts.js', 'src/webview/aScripts.js'] },
+    ];
+    const root = makeFixture({ manifestBundles: bundles, scripts: baseScripts });
+    assert.ok(runWebviewManifestCheck(root).errors
+        .some(error => error.includes('aScripts.js') && error.includes('exact-once')));
+});
+
+test('ARCH-WEBVIEW-MANIFEST-001 controlled mutation: load-order drift from the builder fails', () => {
+    const root = makeFixture({
+        manifestBundles: baseBundles,
+        scripts: baseScripts,
+        builderOrder: ['src/webview/bScripts.js', 'src/webview/aScripts.js'],
+    });
+    assert.ok(runWebviewManifestCheck(root).errors
+        .some(error => error.includes('dashboard bundle order differs')));
+});
+
+test('ARCH-WEBVIEW-MANIFEST-001 controlled mutation: an undeclared global reference fails', () => {
+    const root = makeFixture({
+        manifestBundles: baseBundles,
+        scripts: {
+            ...baseScripts,
+            'src/webview/aScripts.js': 'window.__agentPivotUndeclared = {};\n',
+        },
+    });
+    assert.ok(runWebviewManifestCheck(root).errors
+        .some(error => error.includes('window.__agentPivotUndeclared')
+            && error.includes('undeclared global')));
+});
+
+test('ARCH-WEBVIEW-MANIFEST-001 controlled mutation: dynamic window access fails closed', () => {
+    const root = makeFixture({
+        manifestBundles: baseBundles,
+        scripts: {
+            ...baseScripts,
+            'src/webview/aScripts.js': 'const x = window[\'__agentPivot\' + name];\n',
+        },
+    });
+    assert.ok(runWebviewManifestCheck(root).errors
+        .some(error => error.includes('dynamic window[...] access')));
+});
+
+test('ARCH-WEBVIEW-MANIFEST-001 controlled mutation: a manifest entry for a missing file fails', () => {
+    const bundles = [
+        { id: 'dashboard', scripts: ['src/webview/aScripts.js', 'src/webview/bScripts.js', 'src/webview/goneScripts.js'] },
+        { id: 'conversation-viewer', scripts: ['src/webview/conversationCScripts.js'] },
+    ];
+    const root = makeFixture({ manifestBundles: bundles, scripts: baseScripts });
+    assert.ok(runWebviewManifestCheck(root).errors
+        .some(error => error.includes('goneScripts.js') && error.includes('does not exist')));
+});


### PR DESCRIPTION
## Summary

Stage 2 PR-5 — the final Harness v0 kernel piece (charter v3 Section 8.6).

The 37 `src/webview/*.js` scripts carry no static imports, so the module graph cannot police them. This PR adds the declared manifest and its enforcement:

- **`docs/testing/architecture-webview-manifest.json`**: exact-once bundle membership (26 dashboard + 11 conversation-viewer scripts), load order mirrored from both builders, and the 31 permitted cross-script `window` globals.
- **`scripts/architecture/checkWebviewManifest.js`**: membership exact-once; load-order drift detection against `build-dashboard-webview-bundle.js` and `viewerDocument.ts`; undeclared `window.*` references fail; dynamic `window[...]` access fails closed (none exist today).
- The manifest joins the anti-self-amendment gate's protected policy set; adding it classifies as tightening. Known v0 limitation: later manifest *edits* (e.g. adding a permitted global) classify as tightening and do not require an ARCH-CHANGE record — the deliberate declaration in review is the control; the checker's referenced-must-be-declared rule is the enforcement.
- **`tests/unit/architecture/webviewManifest.test.js`**: 8 tests — real-repo pass plus controlled mutations (undeclared script, double membership, order drift, undeclared global, dynamic access, missing file).

With this PR the Harness v0 kernel is complete: closed-world classification, module boundary guards, cycle ratchet, invariant catalog, single-writer enforcement, architecture impact report, anti-self-amendment gate, and the webview manifest policy.

No production source file changed; observable behavior untouched.

## Skill harvest

no skill change — the coverage-gate lessons from PR 2-4 remain queued for the planned guardrails skill (charter Section 14).

## Verification

- `npm run test:architecture-policy`: 59/59 green; all five checkers pass on the real repository.
- `npm run test:behavior-contracts` green after the audit commit; `git diff --check` clean.
- Architecture scripts line coverage: 88.6%.