### PR TITLE
test(worktrees): close the pilot safety-net gaps (Stage 3)

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -2178,7 +2178,8 @@
     "priority": "P0",
     "status": "automated",
     "owners": [
-      "tests/contract/worktrees/gitWorktreeProvisioner.test.js"
+      "tests/contract/worktrees/gitWorktreeProvisioner.test.js",
+      "tests/contract/worktrees/groupCreationRealGit.test.js"
     ],
     "evidence": [
       "src/worktrees/gitWorktreeProvisioner.ts"
@@ -6795,6 +6796,20 @@
     "evidence": [
       "scripts/architecture/checkWebviewManifest.js",
       "docs/testing/architecture-webview-manifest.json"
+    ]
+  },
+  {
+    "id": "WORKTREE-GROUPS-CREATE-HANDLER-001",
+    "domain": "session",
+    "title": "The worktree group form message family (open/preview/confirm/retry/dismiss) follows the accepted-to-settled chain: parse fail-closed, every accepted request owes exactly one terminal settlement, and the confirm family has no replay cache (the single-use preview token rejects replays)",
+    "priority": "P0",
+    "status": "automated",
+    "owners": [
+      "tests/integration/dashboard/worktreeGroupFormHandlers.test.js"
+    ],
+    "evidence": [
+      "src/dashboard/worktreeGroupFormHandlers.ts",
+      "src/dashboard.ts"
     ]
   }
 ]

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "99666fe7bd595cc977c7b7b583fdf1f3238b4413",
+        "head": "8d27256aaefe7d1eee5c021cf8058da9e2a58c8c",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -424,7 +424,8 @@
             "da3b97d09f3f6af8b735ed6988b3b7423f3bb0f3",
             "13bd18ac4e7f75a14926bd837d137c102f8ecc08",
             "cfb96fd65d4c9c5ed6453ae6f607290dbb86d6ff",
-            "15e02b1fc1d28814f08b3b734d6bf710ddebf640"
+            "15e02b1fc1d28814f08b3b734d6bf710ddebf640",
+            "45c402334a7218788172c849f46da67a73696268"
         ]
     },
     "capabilities": [
@@ -2231,13 +2232,15 @@
                 "f7a968b0242728dbdc61500531e07ed71f2df2a0",
                 "e332a22ca94bd7e9ad0614fe36c554a9f4209c6b",
                 "bb90d8af28fc1f539b638c11ec25c924ac90ed08",
-                "b76f4ba375337b0674dc846d119d5ce7f5c46ba8"
+                "b76f4ba375337b0674dc846d119d5ce7f5c46ba8",
+                "8d27256aaefe7d1eee5c021cf8058da9e2a58c8c"
             ],
             "behaviors": [
                 "WORKTREE-GROUPS-BASELINE-001",
                 "WORKTREE-CHANGES-COLLECT-001",
                 "WORKTREE-CHANGES-PANEL-001",
-                "WORKTREE-GROUPS-CREATE-001"
+                "WORKTREE-GROUPS-CREATE-001",
+                "WORKTREE-GROUPS-CREATE-HANDLER-001"
             ],
             "prGates": [
                 "test:deterministic:run",

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -277,15 +277,8 @@ import {
     WorktreeGroupCreationController,
 } from './worktrees/groupCreationController';
 import {
-    acceptedWorktreeGroupCreationSettlement,
-    acceptedWorktreeGroupMemberSettlement,
-    parseConfirmWorktreeGroupRequest,
-    parseOpenWorktreeGroupFormRequest,
-    parsePreviewWorktreeGroupRequest,
-    parseWorktreeGroupMemberRequest,
-    settledWorktreeGroupCreationSettlement,
-    settledWorktreeGroupMemberSettlement,
-} from './worktrees/groupCreationProtocol';
+    createWorktreeGroupFormHandlers,
+} from './dashboard/worktreeGroupFormHandlers';
 import {
     normalizeWorktreeSetupCommand,
     WorktreeSetupRunner,
@@ -2507,6 +2500,12 @@ async function initializeDashboard(
         replayCache: worktreeGroupDeletionSettlements,
     };
 
+    const worktreeGroupFormHandlers = createWorktreeGroupFormHandlers({
+        controller: worktreeGroupCreationController,
+        postMessage: outgoing => provider.postMessage(outgoing),
+        getSnapshot: () => worktreeSnapshotCoordinator.getSnapshot(),
+        logError,
+    });
     const isolatedSessionHandlers = {
         'start-isolated-session': async (message: unknown) => {
             const request = parseIsolatedSessionRequest(message);
@@ -2548,158 +2547,7 @@ async function initializeDashboard(
                 request.operationId, request.projectId);
             await provider.postMessage(cancelledMutationSettlement(request, accepted));
         },
-        'open-worktree-group-form': async (message: unknown) => {
-            const request = parseOpenWorktreeGroupFormRequest(message);
-            if (!request) {
-                return;
-            }
-            // Add repo (PRD §6.3): the form lists only repositories not
-            // already in the group, locks the group name, and prechecks
-            // only the active editor's repository when eligible.
-            const addRepo = request.targetGroupId
-                ? await worktreeGroupCreationController.listAddRepoOptions(
-                    request.projectId, request.targetGroupId)
-                : null;
-            if (request.targetGroupId && !addRepo) {
-                return;
-            }
-            const repositories = addRepo
-                ? addRepo.options
-                : await worktreeGroupCreationController
-                    .listRepositoryOptions(request.projectId);
-            // Derive (PRD §6.2): prefill name, selection, and base refs
-            // from the source group; the group itself is never modified.
-            const derive = request.sourceGroupId
-                ? await worktreeGroupCreationController.deriveFormContext(
-                    request.projectId, request.sourceGroupId)
-                : null;
-            // Branch-from-here (PRD §6.1): resolve the seed worktree's
-            // branch so the form can prefill the base-ref override.
-            const seedWorktree = request.seedRepositoryKey
-                && request.seedWorktreePath
-                ? worktreeSnapshotCoordinator.getSnapshot()?.repositories
-                    .find(candidate =>
-                        candidate.repositoryKey === request.seedRepositoryKey)
-                    ?.worktrees.find(candidate =>
-                        candidate.key.canonicalWorktreePath
-                            === request.seedWorktreePath)
-                : undefined;
-            await provider.postMessage({
-                type: 'worktree-group-form-state',
-                version: 1,
-                projectId: request.projectId,
-                ...(addRepo
-                    ? {
-                        addRepo: {
-                            groupId: addRepo.group.groupId,
-                            displayName: addRepo.group.displayName,
-                        },
-                    }
-                    : {}),
-                ...(derive ? { derive } : {}),
-                ...(request.seedRepositoryKey && seedWorktree?.branchRef
-                    ? {
-                        seed: {
-                            repositoryKey: request.seedRepositoryKey,
-                            baseRef: seedWorktree.branchRef,
-                        },
-                    }
-                    : {}),
-                repositories,
-            });
-        },
-        'preview-worktree-group': async (message: unknown) => {
-            const request = parsePreviewWorktreeGroupRequest(message);
-            if (!request) {
-                return;
-            }
-            const preview = await worktreeGroupCreationController.preview(
-                request.projectId, request.displayName, request.selections,
-                request.sourceGroupId, request.targetGroupId);
-            await provider.postMessage({
-                type: 'worktree-group-preview',
-                version: 1,
-                requestId: request.requestId,
-                projectId: request.projectId,
-                previewId: preview.previewId,
-                slug: preview.slug,
-                ...(preview.formError ? { formError: preview.formError } : {}),
-                members: preview.members,
-            });
-        },
-        'confirm-worktree-group': async (message: unknown) => {
-            const request = parseConfirmWorktreeGroupRequest(message);
-            if (!request) {
-                return;
-            }
-            await provider.postMessage(
-                acceptedWorktreeGroupCreationSettlement(request));
-            // Every accepted request owes exactly one terminal settlement —
-            // the webview keeps its confirm button pending until it lands.
-            const result = await worktreeGroupCreationController.confirm({
-                projectId: request.projectId,
-                previewId: request.previewId,
-                displayName: request.displayName,
-                members: request.members,
-                ...(request.primaryRepositoryKey
-                    ? { primaryRepositoryKey: request.primaryRepositoryKey }
-                    : {}),
-                ...(request.targetGroupId
-                    ? { targetGroupId: request.targetGroupId }
-                    : {}),
-            }).catch(error => {
-                logError('Failed to confirm the worktree group creation.', error);
-                return { kind: 'failed' as const, errorCode: 'unexpected-error' };
-            });
-            await provider.postMessage(
-                settledWorktreeGroupCreationSettlement(request, result));
-        },
-        'retry-worktree-group-member': async (message: unknown) => {
-            const request = parseWorktreeGroupMemberRequest(message);
-            if (!request || request.type !== 'retry-worktree-group-member') {
-                return;
-            }
-            await provider.postMessage(
-                acceptedWorktreeGroupMemberSettlement(request));
-            const outcome = await worktreeGroupCreationController.retryMember(
-                request.projectId, request.groupId, request.memberId)
-                .catch(error => {
-                    logError('Failed to retry the worktree group member.', error);
-                    return {
-                        kind: 'failed' as const,
-                        operationId: request.memberId,
-                        errorCode: 'unexpected-error',
-                    };
-                });
-            await provider.postMessage(settledWorktreeGroupMemberSettlement(
-                request,
-                outcome.kind === 'succeeded'
-                    ? { kind: 'settled' }
-                    : { kind: 'failed', errorCode: outcome.errorCode }));
-        },
-        'dismiss-worktree-group-member': async (message: unknown) => {
-            const request = parseWorktreeGroupMemberRequest(message);
-            if (!request || request.type !== 'dismiss-worktree-group-member') {
-                return;
-            }
-            await provider.postMessage(
-                acceptedWorktreeGroupMemberSettlement(request));
-            const dismissed = await worktreeGroupCreationController.dismissMember(
-                request.projectId, request.groupId, request.memberId)
-                .catch(error => {
-                    logError('Failed to dismiss the worktree group member.', error);
-                    return 'unavailable' as const;
-                });
-            await provider.postMessage(settledWorktreeGroupMemberSettlement(
-                request,
-                dismissed === 'dismissed'
-                    ? { kind: 'settled' }
-                    : {
-                        kind: 'failed',
-                        errorCode: dismissed === 'store-full'
-                            ? 'store-full' : 'dismiss-unavailable',
-                    }));
-        },
+        ...worktreeGroupFormHandlers,
         'remove-managed-worktree': async (message: unknown) => {
             const request = parseManagedWorktreeRemovalRequest(message);
             if (!request) {

--- a/src/dashboard/worktreeGroupFormHandlers.ts
+++ b/src/dashboard/worktreeGroupFormHandlers.ts
@@ -1,0 +1,184 @@
+import type { WorktreeGroupCreationController } from '../worktrees/groupCreationController';
+import {
+    acceptedWorktreeGroupCreationSettlement,
+    acceptedWorktreeGroupMemberSettlement,
+    parseConfirmWorktreeGroupRequest,
+    parseOpenWorktreeGroupFormRequest,
+    parsePreviewWorktreeGroupRequest,
+    parseWorktreeGroupMemberRequest,
+    settledWorktreeGroupCreationSettlement,
+    settledWorktreeGroupMemberSettlement,
+} from '../worktrees/groupCreationProtocol';
+import type { WorktreeSnapshot } from '../worktrees/types';
+
+export interface WorktreeGroupFormHandlersOptions {
+    controller: WorktreeGroupCreationController;
+    postMessage: (message: unknown) => Thenable<boolean>;
+    getSnapshot: () => WorktreeSnapshot | null;
+    logError: (message: string, error: unknown) => void;
+}
+
+/**
+ * The worktree-group form message family (open/preview/confirm/retry/dismiss).
+ * Extracted verbatim from the composition root so the accepted→settled chain
+ * is unit-testable; behavior is byte-identical to the inline handlers.
+ */
+export function createWorktreeGroupFormHandlers(
+    options: WorktreeGroupFormHandlersOptions,
+): Record<string, (message: unknown) => Promise<void>> {
+    const { controller, postMessage, getSnapshot, logError } = options;
+    return {
+        'open-worktree-group-form': async (message: unknown) => {
+            const request = parseOpenWorktreeGroupFormRequest(message);
+            if (!request) {
+                return;
+            }
+            // Add repo (PRD §6.3): the form lists only repositories not
+            // already in the group, locks the group name, and prechecks
+            // only the active editor's repository when eligible.
+            const addRepo = request.targetGroupId
+                ? await controller.listAddRepoOptions(
+                    request.projectId, request.targetGroupId)
+                : null;
+            if (request.targetGroupId && !addRepo) {
+                return;
+            }
+            const repositories = addRepo
+                ? addRepo.options
+                : await controller
+                    .listRepositoryOptions(request.projectId);
+            // Derive (PRD §6.2): prefill name, selection, and base refs
+            // from the source group; the group itself is never modified.
+            const derive = request.sourceGroupId
+                ? await controller.deriveFormContext(
+                    request.projectId, request.sourceGroupId)
+                : null;
+            // Branch-from-here (PRD §6.1): resolve the seed worktree's
+            // branch so the form can prefill the base-ref override.
+            const seedWorktree = request.seedRepositoryKey
+                && request.seedWorktreePath
+                ? getSnapshot()?.repositories
+                    .find(candidate =>
+                        candidate.repositoryKey === request.seedRepositoryKey)
+                    ?.worktrees.find(candidate =>
+                        candidate.key.canonicalWorktreePath
+                            === request.seedWorktreePath)
+                : undefined;
+            await postMessage({
+                type: 'worktree-group-form-state',
+                version: 1,
+                projectId: request.projectId,
+                ...(addRepo
+                    ? {
+                        addRepo: {
+                            groupId: addRepo.group.groupId,
+                            displayName: addRepo.group.displayName,
+                        },
+                    }
+                    : {}),
+                ...(derive ? { derive } : {}),
+                ...(request.seedRepositoryKey && seedWorktree?.branchRef
+                    ? {
+                        seed: {
+                            repositoryKey: request.seedRepositoryKey,
+                            baseRef: seedWorktree.branchRef,
+                        },
+                    }
+                    : {}),
+                repositories,
+            });
+        },
+        'preview-worktree-group': async (message: unknown) => {
+            const request = parsePreviewWorktreeGroupRequest(message);
+            if (!request) {
+                return;
+            }
+            const preview = await controller.preview(
+                request.projectId, request.displayName, request.selections,
+                request.sourceGroupId, request.targetGroupId);
+            await postMessage({
+                type: 'worktree-group-preview',
+                version: 1,
+                requestId: request.requestId,
+                projectId: request.projectId,
+                previewId: preview.previewId,
+                slug: preview.slug,
+                ...(preview.formError ? { formError: preview.formError } : {}),
+                members: preview.members,
+            });
+        },
+        'confirm-worktree-group': async (message: unknown) => {
+            const request = parseConfirmWorktreeGroupRequest(message);
+            if (!request) {
+                return;
+            }
+            await postMessage(
+                acceptedWorktreeGroupCreationSettlement(request));
+            // Every accepted request owes exactly one terminal settlement —
+            // the webview keeps its confirm button pending until it lands.
+            const result = await controller.confirm({
+                projectId: request.projectId,
+                previewId: request.previewId,
+                displayName: request.displayName,
+                members: request.members,
+                ...(request.primaryRepositoryKey
+                    ? { primaryRepositoryKey: request.primaryRepositoryKey }
+                    : {}),
+                ...(request.targetGroupId
+                    ? { targetGroupId: request.targetGroupId }
+                    : {}),
+            }).catch(error => {
+                logError('Failed to confirm the worktree group creation.', error);
+                return { kind: 'failed' as const, errorCode: 'unexpected-error' };
+            });
+            await postMessage(
+                settledWorktreeGroupCreationSettlement(request, result));
+        },
+        'retry-worktree-group-member': async (message: unknown) => {
+            const request = parseWorktreeGroupMemberRequest(message);
+            if (!request || request.type !== 'retry-worktree-group-member') {
+                return;
+            }
+            await postMessage(
+                acceptedWorktreeGroupMemberSettlement(request));
+            const outcome = await controller.retryMember(
+                request.projectId, request.groupId, request.memberId)
+                .catch(error => {
+                    logError('Failed to retry the worktree group member.', error);
+                    return {
+                        kind: 'failed' as const,
+                        operationId: request.memberId,
+                        errorCode: 'unexpected-error',
+                    };
+                });
+            await postMessage(settledWorktreeGroupMemberSettlement(
+                request,
+                outcome.kind === 'succeeded'
+                    ? { kind: 'settled' }
+                    : { kind: 'failed', errorCode: outcome.errorCode }));
+        },
+        'dismiss-worktree-group-member': async (message: unknown) => {
+            const request = parseWorktreeGroupMemberRequest(message);
+            if (!request || request.type !== 'dismiss-worktree-group-member') {
+                return;
+            }
+            await postMessage(
+                acceptedWorktreeGroupMemberSettlement(request));
+            const dismissed = await controller.dismissMember(
+                request.projectId, request.groupId, request.memberId)
+                .catch(error => {
+                    logError('Failed to dismiss the worktree group member.', error);
+                    return 'unavailable' as const;
+                });
+            await postMessage(settledWorktreeGroupMemberSettlement(
+                request,
+                dismissed === 'dismissed'
+                    ? { kind: 'settled' }
+                    : {
+                        kind: 'failed',
+                        errorCode: dismissed === 'store-full'
+                            ? 'store-full' : 'dismiss-unavailable',
+                    }));
+        },
+    };
+}

--- a/tests/contract/worktrees/groupCreationRealGit.test.js
+++ b/tests/contract/worktrees/groupCreationRealGit.test.js
@@ -1,0 +1,172 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const childProcess = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const {
+    WorktreeGroupCreationController,
+} = require('../../../out/worktrees/groupCreationController');
+const {
+    GitWorktreeProvisioner,
+} = require('../../../out/worktrees/gitWorktreeProvisioner');
+const {
+    WorktreeGroupManifestStore,
+} = require('../../../out/worktrees/groupManifestStore');
+
+function git(cwd, args) {
+    return childProcess.execFileSync('git', ['-C', cwd, ...args], {
+        encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+}
+
+async function repositoryFixture(t, sandbox, name) {
+    const repositoryPath = path.join(sandbox, name);
+    await fs.promises.mkdir(repositoryPath);
+    git(repositoryPath, ['init', '-b', 'main']);
+    git(repositoryPath, ['config', 'user.name', 'Agent Pivot Tests']);
+    git(repositoryPath, ['config', 'user.email', 'tests@example.invalid']);
+    await fs.promises.writeFile(path.join(repositoryPath, 'README.md'), 'fixture\n');
+    git(repositoryPath, ['add', 'README.md']);
+    git(repositoryPath, ['commit', '-m', 'fixture']);
+    return {
+        repositoryPath,
+        repositoryKey: await fs.promises.realpath(path.join(repositoryPath, '.git')),
+        head: git(repositoryPath, ['rev-parse', 'refs/heads/main']),
+    };
+}
+
+function memento() {
+    const values = new Map();
+    return {
+        get: (key, fallback) => (values.has(key) ? values.get(key) : fallback),
+        update: async (key, value) => {
+            values.set(key, JSON.parse(JSON.stringify(value)));
+        },
+    };
+}
+
+/**
+ * A two-repository workspace whose repositories really exist on disk; the
+ * creation controller drives the REAL provisioner (no fakes anywhere in the
+ * side-effect path).
+ */
+async function workspaceFixture(t) {
+    const sandbox = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-pivot-group-e2e-'));
+    t.after(async () => fs.promises.rm(sandbox, { recursive: true, force: true }));
+    const alpha = await repositoryFixture(t, sandbox, 'alpha');
+    const beta = await repositoryFixture(t, sandbox, 'beta');
+    const workspace = {
+        navigationIdentity: 'navigation:e2e',
+        scopeIdentity: 'scope:e2e',
+        kind: 'multiRoot',
+        displayName: 'E2E',
+        navigationUri: 'file:///e2e.code-workspace',
+        environment: 'local',
+        roots: [
+            { id: 'root-alpha', name: 'alpha', uri: `file://${alpha.repositoryPath}`, hostPath: alpha.repositoryPath, ordinal: 0 },
+            { id: 'root-beta', name: 'beta', uri: `file://${beta.repositoryPath}`, hostPath: beta.repositoryPath, ordinal: 1 },
+        ],
+    };
+    const repositoryEntry = repository => ({
+        repositoryKey: repository.repositoryKey,
+        rootBindings: [{ workspaceRootId: repository.repositoryPath.endsWith('alpha') ? 'root-alpha' : 'root-beta', repositoryRelativePath: '' }],
+        baseRef: 'refs/heads/main',
+        worktrees: [{
+            key: { repositoryKey: repository.repositoryKey, canonicalWorktreePath: repository.repositoryPath },
+            branchRef: 'refs/heads/main', head: repository.head, isMain: true,
+            isBare: false, health: 'normal', headKind: 'branch',
+        }],
+    });
+    const snapshot = {
+        revision: 1,
+        truncatedWorktreeCount: 0,
+        repositories: [repositoryEntry(alpha), repositoryEntry(beta)],
+    };
+    return { sandbox, alpha, beta, workspace, snapshot };
+}
+
+test('WORKTREE-PROVISIONING-GIT-001 a group confirm provisions real worktrees from the frozen baseline', async t => {
+    const { alpha, beta, workspace, snapshot } = await workspaceFixture(t);
+    const provisioner = new GitWorktreeProvisioner();
+    const manifestStore = new WorktreeGroupManifestStore(memento());
+    const worktreeDirectory = '.agent-pivot/worktrees';
+    const controller = new WorktreeGroupCreationController({
+        getWorkspaceTarget: projectId => (projectId === 'project' ? { workspace } : null),
+        getWorktreeSnapshot: () => snapshot,
+        listLocalBranches: async commandCwd =>
+            git(commandCwd, ['for-each-ref', '--format=%(refname:short)', 'refs/heads']).split('\n'),
+        isBranchAvailable: (commandCwd, branchName) =>
+            provisioner.isBranchAvailable(commandCwd, branchName),
+        isPathAvailable: worktreePath => provisioner.isPathAvailable(worktreePath),
+        preflightPlan: plan => provisioner.preflightPlan(plan),
+        getSetupCommand: () => [],
+        getWorktreeDirectory: () => worktreeDirectory,
+        getActiveEditorPath: () => undefined,
+        manifestStore,
+        resolveBaseCommit: (commandCwd, baseRef) =>
+            provisioner.resolveBaseCommit(commandCwd, baseRef),
+        startMemberOperation: async input => {
+            // Mirror the production finalize path with the real provisioner.
+            const worktreeKey = await provisioner.createWorktree(input.plan, () => false);
+            await manifestStore.updateMember(
+                workspace.navigationIdentity, input.groupId, input.memberId, {
+                    state: 'ready',
+                    worktreeKey,
+                });
+            return {
+                kind: 'succeeded',
+                operationId: input.operationId,
+                worktreeKey,
+                plan: input.plan,
+            };
+        },
+        retryMemberOperation: async () => ({ kind: 'failed', operationId: 'x', errorCode: 'n/a' }),
+        dismissMemberOperation: () => true,
+        hasMemberOperation: () => false,
+        onDidChange: () => {},
+    });
+
+    const preview = await controller.preview('project', 'Fix login', [
+        { repositoryKey: alpha.repositoryKey },
+        { repositoryKey: beta.repositoryKey },
+    ]);
+    assert.ok(preview.previewId, 'preview issued');
+
+    const members = preview.members.map(member => ({
+        repositoryKey: member.repositoryKey,
+        baseRef: member.baseRef,
+        branchName: member.branchName,
+        worktreePath: member.worktreePath,
+        setupEnabled: false,
+    }));
+    const result = await controller.confirm({
+        projectId: 'project',
+        previewId: preview.previewId,
+        displayName: 'Fix login',
+        members,
+    });
+    assert.equal(result.kind, 'created');
+
+    // Both worktrees exist on disk, on branches cut from the frozen baseline.
+    for (const repository of [alpha, beta]) {
+        const worktreePath = path.join(repository.repositoryPath, worktreeDirectory, 'fix-login');
+        assert.ok(fs.existsSync(path.join(worktreePath, 'README.md')),
+            `${repository.repositoryPath} worktree materialized`);
+        assert.equal(git(worktreePath, ['rev-parse', 'HEAD']), repository.head,
+            'the new worktree HEAD is exactly the frozen baseline commit');
+        assert.equal(
+            git(repository.repositoryPath, ['rev-parse', 'refs/heads/agent-pivot/fix-login']),
+            repository.head, 'the branch was created at the frozen commit');
+    }
+
+    // The manifest converged to ready members carrying the real worktree keys.
+    const groups = manifestStore.listGroups(workspace.navigationIdentity);
+    assert.equal(groups.length, 1);
+    assert.ok(groups[0].members.every(member => member.state === 'ready'
+        && member.worktreeKey && member.baseline
+        && member.baseline.commitSha.length === 40));
+});

--- a/tests/integration/dashboard/worktreeGroupFormHandlers.test.js
+++ b/tests/integration/dashboard/worktreeGroupFormHandlers.test.js
@@ -1,0 +1,207 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+    createWorktreeGroupFormHandlers,
+} = require('../../../out/dashboard/worktreeGroupFormHandlers');
+
+function fixture(controllerOverrides = {}) {
+    const posted = [];
+    const confirmCalls = [];
+    const controller = {
+        listRepositoryOptions: async () => [],
+        listAddRepoOptions: async () => null,
+        deriveFormContext: async () => null,
+        preview: async () => ({ previewId: 'preview-1', slug: 'fix-login', members: [] }),
+        confirm: async request => {
+            confirmCalls.push(request);
+            return { kind: 'created', groupId: 'g1' };
+        },
+        retryMember: async () => ({ kind: 'succeeded', operationId: 'group-member-m1' }),
+        dismissMember: async () => 'dismissed',
+        ...controllerOverrides,
+    };
+    const handlers = createWorktreeGroupFormHandlers({
+        controller,
+        postMessage: async message => {
+            posted.push(message);
+            return true;
+        },
+        getSnapshot: () => null,
+        logError: () => {},
+    });
+    return { handlers, posted, confirmCalls };
+}
+
+function confirmMessage(overrides = {}) {
+    return {
+        type: 'confirm-worktree-group', version: 1, requestId: 'confirm-1',
+        projectId: 'project', previewId: 'preview-1', displayName: 'Fix login',
+        members: [{
+            repositoryKey: '/alpha/.git', baseRef: 'refs/heads/main',
+            branchName: 'agent-pivot/fix-login',
+            worktreePath: '/alpha/.worktrees/fix-login', setupEnabled: false,
+        }],
+        ...overrides,
+    };
+}
+
+const statuses = posted => posted.map(message => message.status);
+
+test('WORKTREE-GROUPS-CREATE-HANDLER-001 a valid confirm receives accepted then settled with the bound request', async () => {
+    const { handlers, posted, confirmCalls } = fixture();
+    await handlers['confirm-worktree-group'](confirmMessage());
+
+    assert.deepEqual(statuses(posted), ['accepted', 'created']);
+    assert.equal(posted[0].type, 'worktree-group-creation-settlement');
+    assert.equal(posted[0].requestId, 'confirm-1');
+    assert.equal(posted[1].groupId, 'g1');
+    assert.equal(confirmCalls.length, 1);
+    assert.equal(confirmCalls[0].previewId, 'preview-1',
+        'the handler passes the preview binding through untouched');
+    assert.equal(confirmCalls[0].members.length, 1);
+});
+
+test('WORKTREE-GROUPS-CREATE-HANDLER-001 a malformed confirm is dropped without any settlement', async () => {
+    const { handlers, posted, confirmCalls } = fixture();
+    await handlers['confirm-worktree-group']({ type: 'confirm-worktree-group' });
+    await handlers['confirm-worktree-group'](confirmMessage({ version: 2 }));
+    await handlers['confirm-worktree-group'](confirmMessage({ requestId: 'bad id!' }));
+
+    assert.deepEqual(posted, []);
+    assert.equal(confirmCalls.length, 0);
+});
+
+test('WORKTREE-GROUPS-CREATE-HANDLER-001 every accepted confirm owes exactly one terminal settlement, even when the controller throws', async () => {
+    const { handlers, posted } = fixture({
+        confirm: async () => { throw new Error('boom'); },
+    });
+    await handlers['confirm-worktree-group'](confirmMessage());
+
+    assert.deepEqual(statuses(posted), ['accepted', 'failed']);
+    assert.equal(posted[1].errorCode, 'unexpected-error');
+});
+
+test('WORKTREE-GROUPS-CREATE-HANDLER-001 a replayed confirm settles failed as preview-stale (no replay cache on this family)', async () => {
+    const replays = [];
+    const { handlers, posted } = fixture({
+        confirm: async request => {
+            replays.push(request);
+            return { kind: 'failed', errorCode: 'preview-stale' };
+        },
+    });
+    const message = confirmMessage();
+    await handlers['confirm-worktree-group'](message);
+    await handlers['confirm-worktree-group'](message);
+
+    assert.equal(replays.length, 2,
+        'the handler has no replay cache — the duplicate reaches the controller');
+    assert.deepEqual(statuses(posted), ['accepted', 'failed', 'accepted', 'failed']);
+    assert.equal(posted[1].errorCode, 'preview-stale');
+    assert.equal(posted[3].errorCode, 'preview-stale',
+        'the single-use preview token downstream rejects the replay');
+});
+
+test('WORKTREE-GROUPS-CREATE-HANDLER-001 retry and dismiss members follow the accepted→settled chain', async () => {
+    const { handlers, posted } = fixture();
+    const request = {
+        type: 'retry-worktree-group-member', version: 1, requestId: 'retry-1',
+        projectId: 'project', groupId: 'g1', memberId: 'm1',
+    };
+    await handlers['retry-worktree-group-member'](request);
+    await handlers['dismiss-worktree-group-member']({
+        ...request, type: 'dismiss-worktree-group-member', requestId: 'dismiss-1',
+    });
+
+    assert.deepEqual(posted.map(message => [message.type, message.status]), [
+        ['worktree-group-member-settlement', 'accepted'],
+        ['worktree-group-member-settlement', 'settled'],
+        ['worktree-group-member-settlement', 'accepted'],
+        ['worktree-group-member-settlement', 'settled'],
+    ]);
+});
+
+test('WORKTREE-GROUPS-CREATE-HANDLER-001 open-form rejects a forged add-repo target without posting state', async () => {
+    const { handlers, posted } = fixture();
+    // Open-form carries no requestId (exact-key protocol).
+    await handlers['open-worktree-group-form']({
+        type: 'open-worktree-group-form', version: 1,
+        projectId: 'project', targetGroupId: 'g-missing',
+    });
+    assert.deepEqual(posted, [],
+        'listAddRepoOptions returning null drops the message without a post');
+
+    const withRepos = fixture({
+        listRepositoryOptions: async () => [{ repositoryKey: '/alpha/.git' }],
+    });
+    await withRepos.handlers['open-worktree-group-form']({
+        type: 'open-worktree-group-form', version: 1, projectId: 'project',
+    });
+    assert.equal(withRepos.posted.length, 1);
+    assert.equal(withRepos.posted[0].type, 'worktree-group-form-state');
+    assert.deepEqual(withRepos.posted[0].repositories, [{ repositoryKey: '/alpha/.git' }]);
+});
+
+test('WORKTREE-GROUPS-CREATE-HANDLER-001 open-form carries derive, add-repo, and seed context', async () => {
+    const { handlers, posted } = fixture({
+        listAddRepoOptions: async () => ({
+            group: { groupId: 'g1', displayName: 'Core' },
+            options: [{ repositoryKey: '/beta/.git' }],
+        }),
+        deriveFormContext: async () => ({ sourceGroupId: 'g9' }),
+    });
+    await handlers['open-worktree-group-form']({
+        type: 'open-worktree-group-form', version: 1, projectId: 'project',
+        targetGroupId: 'g1',
+    });
+    assert.equal(posted[0].type, 'worktree-group-form-state');
+    assert.deepEqual(posted[0].addRepo, { groupId: 'g1', displayName: 'Core' });
+
+    const seeded = fixture({
+        deriveFormContext: async () => ({ sourceGroupId: 'g9' }),
+    });
+    // Seed resolution goes through the snapshot: seedRepositoryKey plus a
+    // matching worktree path surfaces the branch reference.
+    const snapshot = {
+        repositories: [{
+            repositoryKey: '/alpha/.git',
+            worktrees: [{ key: { canonicalWorktreePath: '/alpha/.worktrees/x' }, branchRef: 'refs/heads/feature' }],
+        }],
+    };
+    const seededHandlers = createWorktreeGroupFormHandlers({
+        controller: {
+            listRepositoryOptions: async () => [],
+            listAddRepoOptions: async () => null,
+            deriveFormContext: async () => null,
+            preview: async () => ({ previewId: 'p', slug: 's', members: [] }),
+            confirm: async () => ({ kind: 'created', groupId: 'g' }),
+            retryMember: async () => ({ kind: 'succeeded', operationId: 'o' }),
+            dismissMember: async () => 'dismissed',
+        },
+        postMessage: async message => { seeded.posted.push(message); return true; },
+        getSnapshot: () => snapshot,
+        logError: () => {},
+    });
+    await seededHandlers['open-worktree-group-form']({
+        type: 'open-worktree-group-form', version: 1, projectId: 'project',
+        seedRepositoryKey: '/alpha/.git', seedWorktreePath: '/alpha/.worktrees/x',
+    });
+    assert.deepEqual(seeded.posted[0].seed, {
+        repositoryKey: '/alpha/.git', baseRef: 'refs/heads/feature',
+    });
+});
+
+test('WORKTREE-GROUPS-CREATE-HANDLER-001 preview echoes the request correlation', async () => {
+    const { handlers, posted } = fixture();
+    await handlers['preview-worktree-group']({
+        type: 'preview-worktree-group', version: 1, requestId: 'preview-req-1',
+        projectId: 'project', displayName: 'Fix login',
+        selections: [{ repositoryKey: '/alpha/.git' }],
+    });
+    assert.equal(posted.length, 1);
+    assert.equal(posted[0].type, 'worktree-group-preview');
+    assert.equal(posted[0].requestId, 'preview-req-1');
+    assert.equal(posted[0].previewId, 'preview-1');
+});


### PR DESCRIPTION
## Summary

Stage 3 of the architecture program: the pilot safety net, closing the three failure-matrix blind spots recorded in the approved Stage 1B RFC.

1. **Real-git group creation end to end** (`tests/contract/worktrees/groupCreationRealGit.test.js`): preview and confirm run against two real on-disk repositories with the real provisioner — no fakes in the side-effect path. Asserts both worktrees materialize on branches cut at the frozen baseline SHA and the manifest converges to ready members carrying real worktree keys and baselines.
2. **Confirm handler chain**: the five worktree-group form handlers move **verbatim** from the composition root into `src/dashboard/worktreeGroupFormHandlers.ts` (pure move, no logic change), making the accepted→settled seam testable. `tests/integration/dashboard/worktreeGroupFormHandlers.test.js` locks the chain: parse fail-closed, every accepted request owes exactly one terminal settlement even when the controller throws, and add-repo target forgery is dropped.
3. **Replay asymmetry locked**: the confirm family has no replay cache; a duplicate confirm now has a message-level characterization test showing it reaches the controller and settles failed as `preview-stale` via the single-use preview token (fixed in #250).

Adds behavior contract `WORKTREE-GROUPS-CREATE-HANDLER-001`; extends `WORKTREE-PROVISIONING-GIT-001` owners. Capability audit assigns the change to `MAIN-WORKTREE-CHANGES-PANEL` and links the new behavior.

## Skill harvest

no skill change — the extraction followed the existing review loop; nothing new to encode.

## Verification

- New tests: real-git e2e 1/1, handler chain 8/8; focused suites: worktrees contract 115/115, dashboard integration 10/10.
- `npm run test:architecture-policy` green (the extracted handler file auto-classified into MOD-DASHBOARD-SHELL/application — closed-world working as designed); architecture guards green.
- New source file measures 89% statement coverage from the handler tests.
- `npm run test:behavior-contracts` green after the audit commit; `git diff --check` clean.