### PR TITLE
feat: merge untracked into Changes and compress single-child folder chains

### DIFF
--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "8d27256aaefe7d1eee5c021cf8058da9e2a58c8c",
+        "head": "33dd08d563b7d9e1e04352c4869af6f10fad9b2e",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -425,7 +425,8 @@
             "13bd18ac4e7f75a14926bd837d137c102f8ecc08",
             "cfb96fd65d4c9c5ed6453ae6f607290dbb86d6ff",
             "15e02b1fc1d28814f08b3b734d6bf710ddebf640",
-            "45c402334a7218788172c849f46da67a73696268"
+            "45c402334a7218788172c849f46da67a73696268",
+            "d0639576ebd5e5fb1a207e991dc15f479ad935bb"
         ]
     },
     "capabilities": [
@@ -2233,7 +2234,8 @@
                 "e332a22ca94bd7e9ad0614fe36c554a9f4209c6b",
                 "bb90d8af28fc1f539b638c11ec25c924ac90ed08",
                 "b76f4ba375337b0674dc846d119d5ce7f5c46ba8",
-                "8d27256aaefe7d1eee5c021cf8058da9e2a58c8c"
+                "8d27256aaefe7d1eee5c021cf8058da9e2a58c8c",
+                "33dd08d563b7d9e1e04352c4869af6f10fad9b2e"
             ],
             "behaviors": [
                 "WORKTREE-GROUPS-BASELINE-001",

--- a/docs/worktree-changes-panel-prd.md
+++ b/docs/worktree-changes-panel-prd.md
@@ -208,7 +208,7 @@ Last commit: "fix: token refresh race" · 2h ago   ← P1
 - **member 下拉选择框**：每次只选一个 member。选项文案 = `repo · branch · <workingItemCount> · ↑<aheadCount>`。单 member 退化为只读标题。P0 默认选中 = 上次选择可用则恢复，否则 primary member；智能优先级（conflict → 有改动 → 有 ahead）与按 session 持久化的完整版在 P1。
 - **跨 member 提示**：按钮聚合与当前 member 不一致时，面板顶部显示 "N changes in M other repositories"；"跳到下一个有改动的仓库"导航在 P1。
 - **Task result 层**：选中 member 的净结果摘要（`N files · M commits`，注明 "Includes committed and uncommitted changes"）+ **Review this repository**（打开 baseline → 当前工作树的原生 multi-diff，经 `vscode.changes` 命令；capability 缺失时 fallback 为逐文件 diff 列表）。跨 member 统一 Review all 在 P1。baseline 缺失 / 历史改写时整层显示 "Baseline unavailable" / "History rewritten"。
-- **Working changes 层**：固定组序 Merge → Staged → Changes → Untracked；空组折叠不渲染。
+- **Working changes 层**：固定组序 Merge → Staged → Changes（Untracked 并入 Changes——行级 U 徽标已承载区分，不再单列组头）；空组折叠不渲染。目录树对齐 Source Control 的压缩行为：只含单子目录且无直属文件的目录链合并为一行（`a/b/c`），折叠状态锚定链尾目录。
 - **文件点击行为矩阵**（P0 验收标准）：
   | 状态 | 点击行为 |
   | --- | --- |

--- a/media/conversationChangesScripts.js
+++ b/media/conversationChangesScripts.js
@@ -8,6 +8,10 @@
         changes: 'Changes',
         untracked: 'Untracked Changes',
     };
+    // Display sections (PRD 体验反馈): Untracked merges into Changes — the
+    // per-row U badge already carries the distinction, so a split section
+    // only repeats information. The first entry names the section.
+    var SECTION_GROUPS = [['merge'], ['staged'], ['changes', 'untracked']];
     var MAX_TOOLTIP_MEMBER_LINES = 8;
 
     function create(options) {
@@ -379,9 +383,24 @@
             });
         }
 
+        // SCM-style compression (PRD 体验反馈): a directory chain whose
+        // levels each hold a single child directory and no files renders as
+        // one row (a/b/c) instead of one indented row per level. The chain's
+        // final directory keeps the collapse key and title.
+        function compressDir(dir) {
+            var names = [dir.name];
+            var node = dir;
+            while (node.files.length === 0 && node.dirOrder.length === 1) {
+                node = node.dirs[node.dirOrder[0]];
+                names.push(node.name);
+            }
+            return { name: names.join('/'), node: node };
+        }
+
         function renderTreeNode(group, node, container, memberId, depth) {
             node.dirOrder.forEach(function (name) {
-                var dir = node.dirs[name];
+                var compressed = compressDir(node.dirs[name]);
+                var dir = compressed.node;
                 var key = folderKey(group, dir.fullPath);
                 var collapsed = !!collapsedFolders[key];
                 var folderRow = document.createElement('button');
@@ -397,7 +416,7 @@
                 folderRow.appendChild(chevron);
                 var label = document.createElement('span');
                 label.className = 'conversation-changes-folder-name';
-                label.textContent = name;
+                label.textContent = compressed.name;
                 folderRow.appendChild(label);
                 var children = document.createElement('div');
                 children.hidden = collapsed;
@@ -422,9 +441,10 @@
         function renderGroups(detail) {
             if (!groupsRoot) return;
             clearChildren(groupsRoot);
-            GROUPS.forEach(function (group) {
+            SECTION_GROUPS.forEach(function (sectionGroups) {
+                var group = sectionGroups[0];
                 var items = detail.items.filter(function (item) {
-                    return item.group === group;
+                    return sectionGroups.indexOf(item.group) !== -1;
                 });
                 if (!items.length) return;
                 var section = document.createElement('div');

--- a/src/webview/conversationChangesScripts.js
+++ b/src/webview/conversationChangesScripts.js
@@ -8,6 +8,10 @@
         changes: 'Changes',
         untracked: 'Untracked Changes',
     };
+    // Display sections (PRD 体验反馈): Untracked merges into Changes — the
+    // per-row U badge already carries the distinction, so a split section
+    // only repeats information. The first entry names the section.
+    var SECTION_GROUPS = [['merge'], ['staged'], ['changes', 'untracked']];
     var MAX_TOOLTIP_MEMBER_LINES = 8;
 
     function create(options) {
@@ -379,9 +383,24 @@
             });
         }
 
+        // SCM-style compression (PRD 体验反馈): a directory chain whose
+        // levels each hold a single child directory and no files renders as
+        // one row (a/b/c) instead of one indented row per level. The chain's
+        // final directory keeps the collapse key and title.
+        function compressDir(dir) {
+            var names = [dir.name];
+            var node = dir;
+            while (node.files.length === 0 && node.dirOrder.length === 1) {
+                node = node.dirs[node.dirOrder[0]];
+                names.push(node.name);
+            }
+            return { name: names.join('/'), node: node };
+        }
+
         function renderTreeNode(group, node, container, memberId, depth) {
             node.dirOrder.forEach(function (name) {
-                var dir = node.dirs[name];
+                var compressed = compressDir(node.dirs[name]);
+                var dir = compressed.node;
                 var key = folderKey(group, dir.fullPath);
                 var collapsed = !!collapsedFolders[key];
                 var folderRow = document.createElement('button');
@@ -397,7 +416,7 @@
                 folderRow.appendChild(chevron);
                 var label = document.createElement('span');
                 label.className = 'conversation-changes-folder-name';
-                label.textContent = name;
+                label.textContent = compressed.name;
                 folderRow.appendChild(label);
                 var children = document.createElement('div');
                 children.hidden = collapsed;
@@ -422,9 +441,10 @@
         function renderGroups(detail) {
             if (!groupsRoot) return;
             clearChildren(groupsRoot);
-            GROUPS.forEach(function (group) {
+            SECTION_GROUPS.forEach(function (sectionGroups) {
+                var group = sectionGroups[0];
                 var items = detail.items.filter(function (item) {
-                    return item.group === group;
+                    return sectionGroups.indexOf(item.group) !== -1;
                 });
                 if (!items.length) return;
                 var section = document.createElement('div');

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -11795,33 +11795,40 @@ test('WORKTREE-CHANGES-PANEL-001 renders the telemetry button, sidebar tab, grou
         .getAttribute('title'))
         .includes('includes committed and uncommitted changes'));
 
-    // Working groups render in the SCM order with the untracked group split.
+    // Working groups render in SCM order; Untracked merges into Changes —
+    // the U badge already marks untracked rows, so a separate section only
+    // repeats information.
     const groupHeaders = await page.locator(
         '.conversation-changes-group-header').allInnerTexts();
-    assert.deepEqual(groupHeaders, ['Staged Changes', 'Changes', 'Untracked Changes']);
+    assert.deepEqual(groupHeaders, ['Staged Changes', 'Changes']);
     const rows = await page.locator('.conversation-changes-file').allInnerTexts();
     assert.equal(rows.length, 3);
-    // Tree view: file rows show basenames, folders render above them.
+    // Tree view: file rows show basenames; single-child directory chains
+    // compress into one row (src/auth), like Source Control.
     assert.ok(rows.some(row => row.includes('login.test.ts')));
-    const folders = await page.locator(
-        '.conversation-changes-folder').allInnerTexts();
-    assert.ok(folders.some(text => text.includes('src'))
-        && folders.some(text => text.includes('auth')));
 
-    // Collapsing a folder hides its files without losing the row state.
-    // (Scoped to the Changes group: 'login.ts' also matches
-    // 'login.test.ts' under Untracked.)
     const changesGroup = page.locator('.conversation-changes-group', {
         has: page.locator('.conversation-changes-group-header', {
             hasText: /^Changes$/,
         }),
     });
+    const folders = await changesGroup.locator(
+        '.conversation-changes-folder').allInnerTexts();
+    assert.equal(folders.length, 1,
+        'the src/auth chain compresses into a single folder row');
+    assert.ok(folders[0].includes('src/auth'));
+    const untrackedBadge = changesGroup.locator(
+        '.conversation-changes-file[title="src/auth/login.test.ts"] '
+            + '.conversation-changes-file-status-untracked');
+    assert.equal(await untrackedBadge.innerText(), 'U',
+        'the untracked row keeps its badge inside the merged section');
+
+    // Collapsing a folder hides its files without losing the row state.
     const authFolder = changesGroup.locator('.conversation-changes-folder', {
-        hasText: 'auth',
+        hasText: 'src/auth',
     });
-    const loginRow = changesGroup.locator('.conversation-changes-file', {
-        hasText: 'login.ts',
-    });
+    const loginRow = changesGroup.locator(
+        '.conversation-changes-file[title="src/auth/login.ts"]');
     await authFolder.click();
     assert.equal(await loginRow.isVisible(), false);
     await authFolder.click();
@@ -11859,6 +11866,48 @@ test('WORKTREE-CHANGES-PANEL-001 renders the telemetry button, sidebar tab, grou
     assert.deepEqual((await postedMessages(page)).at(-1), {
         type: 'conversation-viewer-changes-select', version: 1, memberId: 'm-web',
     });
+});
+
+test('WORKTREE-CHANGES-PANEL-001 compresses single-child directory chains like Source Control', async t => {
+    const { page } = await openHostViewerDocument(t, {});
+    await sendChanges(page, changesFixture({
+        detail: {
+            memberId: 'm-api', availability: 'available',
+            baselineSha: 'a'.repeat(40), aheadCount: 0, taskFileCount: 2,
+            items: [
+                { group: 'changes', xy: ' M', path: 'com/xhs/reddb/service/impl/Foo.java' },
+                { group: 'changes', xy: ' M', path: 'com/xhs/reddb/App.java' },
+            ],
+            truncated: false,
+        },
+    }));
+    await page.locator('[data-telemetry-changes]').click();
+
+    const folders = await page.locator('.conversation-changes-folder')
+        .allInnerTexts();
+    assert.deepEqual(
+        folders.map(text => text.replace(/[▾▸]/gu, '').trim()),
+        ['com/xhs/reddb', 'service/impl'],
+        'com → xhs → reddb and service → impl render as two compressed rows'
+    );
+    const fooRow = page.locator(
+        '.conversation-changes-file[title="com/xhs/reddb/service/impl/Foo.java"]');
+    assert.equal(await fooRow.isVisible(), true);
+    assert.equal(
+        await fooRow.evaluate(element => element.style.paddingLeft),
+        '1.6rem',
+        'Foo.java indents two levels (compressed rows), not five'
+    );
+
+    // Compression keeps collapse state on the chain's final directory.
+    await page.locator('.conversation-changes-folder', {
+        hasText: 'service/impl',
+    }).click();
+    assert.equal(await fooRow.isVisible(), false);
+    await page.locator('.conversation-changes-folder', {
+        hasText: 'service/impl',
+    }).click();
+    assert.equal(await fooRow.isVisible(), true);
 });
 
 test('WORKTREE-CHANGES-PANEL-001 never rebuilds the member dropdown while it is open', async t => {


### PR DESCRIPTION
## Summary

Two working-changes panel density fixes from UX feedback:

1. **Untracked merges into Changes.** The working-changes layer rendered four sections (Merge → Staged → Changes → Untracked); the untracked section only repeated what the per-row `U` badge already says. Sections now render Merge → Staged → Changes with untracked rows inside Changes, badges intact. Row click semantics stay exact: `item.group` still flows to the open-file intent.
2. **Single-child directory chains compress into one row** (`a/b/c`), aligned with Source Control's tree. A chain level qualifies only while it holds one child directory and no direct files; deep Java paths (`com/xhs/reddb/service/impl/Foo.java`) now take two folder rows instead of five indented ones. Collapse state keys anchor to the chain's final directory.

PRD §行为明细 updated to match.

## Verification

- RED→GREEN in `tests/browser/conversationViewer.test.js` (real Chromium): group headers are now `['Staged Changes', 'Changes']`, the untracked row keeps its `U` badge inside the merged section, `src/auth` renders as one folder row, and the deep-path fixture renders exactly `['com/xhs/reddb', 'service/impl']` with the file row at two indent levels; compressed rows keep working collapse toggles.
- Full `conversationViewer.test.js`: 114/114 pass; dashboard webview checks pass.
- `npm run test:coverage:ci` pass; `npm run test:behavior-contracts` pass; `git diff --check` clean.

## Skill harvest

none — small UX iteration with the existing RED→GREEN loop; no reusable workflow gap.