### PR TITLE
refactor(worktrees): consolidate worktree-key codecs into the domain layer (pilot S1)

### DIFF
--- a/docs/testing/architecture-invariants.json
+++ b/docs/testing/architecture-invariants.json
@@ -199,7 +199,10 @@
             "writers": [],
             "linearizationPoint": "Identity construction goes through the canonical codec.",
             "enforcement": ["behavior"],
-            "behaviorOwners": ["tests/unit/worktrees/provisioningPlan.test.js"],
+            "behaviorOwners": [
+                "tests/unit/worktrees/provisioningPlan.test.js",
+                "tests/unit/worktrees/worktreeKeyCodecs.test.js"
+            ],
             "guardOwners": [],
             "evidence": ["src/worktrees/types.ts"]
         }

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "33dd08d563b7d9e1e04352c4869af6f10fad9b2e",
+        "head": "1b69d7ed8be4f331227185c364ea43a1259a9688",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -426,7 +426,8 @@
             "cfb96fd65d4c9c5ed6453ae6f607290dbb86d6ff",
             "15e02b1fc1d28814f08b3b734d6bf710ddebf640",
             "45c402334a7218788172c849f46da67a73696268",
-            "d0639576ebd5e5fb1a207e991dc15f479ad935bb"
+            "d0639576ebd5e5fb1a207e991dc15f479ad935bb",
+            "88aed14d522c5f67189379584128227e8e8b953e"
         ]
     },
     "capabilities": [
@@ -2235,7 +2236,8 @@
                 "bb90d8af28fc1f539b638c11ec25c924ac90ed08",
                 "b76f4ba375337b0674dc846d119d5ce7f5c46ba8",
                 "8d27256aaefe7d1eee5c021cf8058da9e2a58c8c",
-                "33dd08d563b7d9e1e04352c4869af6f10fad9b2e"
+                "33dd08d563b7d9e1e04352c4869af6f10fad9b2e",
+                "1b69d7ed8be4f331227185c364ea43a1259a9688"
             ],
             "behaviors": [
                 "WORKTREE-GROUPS-BASELINE-001",

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -260,7 +260,7 @@ import {
     GitRepositoryStateMonitor,
 } from './worktrees/gitRepositoryStateMonitor';
 import { WorktreeSnapshotCoordinator } from './worktrees/snapshotCoordinator';
-import { worktreeKeysEqual } from './worktrees/types';
+import { worktreeKeysEqual, worktreeKeysMatch, worktreeKeyTombstoneKey } from './worktrees/types';
 import type { WorktreeKey } from './worktrees/types';
 import { WorktreeBaseRefStore } from './worktrees/baseRefStore';
 import {
@@ -1370,7 +1370,9 @@ async function initializeDashboard(
                             discoveredRepositories.add(repository.repositoryKey);
                             for (const worktree of repository.worktrees) {
                                 snapshotPaths.add(
-                                    `${worktree.key.repositoryKey} ${worktree.key.canonicalWorktreePath}`);
+                                    worktreeKeyTombstoneKey(
+                                        worktree.key.repositoryKey,
+                                        worktree.key.canonicalWorktreePath));
                             }
                         }
                         // Prune through the controller: it drops in-memory
@@ -1454,10 +1456,7 @@ async function initializeDashboard(
             if (existing && (existing.sessionId !== binding.sessionId
                 || existing.provider !== binding.providerId
                 || existing.navigationIdentity !== binding.workspaceNavigationIdentity
-                || (existing.worktreeKey?.canonicalWorktreePath
-                        !== binding.worktreeKey?.canonicalWorktreePath)
-                || (existing.worktreeKey?.repositoryKey
-                        !== binding.worktreeKey?.repositoryKey))) {
+                || !worktreeKeysMatch(existing.worktreeKey, binding.worktreeKey))) {
                 ambiguous = true;
                 break;
             }

--- a/src/webview/webviewAiSessionContent.ts
+++ b/src/webview/webviewAiSessionContent.ts
@@ -17,6 +17,7 @@ import type {
     WorktreeRepositoryChip,
     WorktreeRowViewModel,
 } from '../aiSessions/types';
+import { worktreeKeysMatch } from '../worktrees/types';
 import type { ProvisioningWorktreeRow, WorktreeKey } from '../worktrees/types';
 import { projectAiSessionHistory } from '../aiSessions/historyProjection';
 import { escapeAttribute } from './webviewHtmlEscape';
@@ -656,11 +657,6 @@ function getWorktreeLabel(worktree: ReadyWorktreeRow): string {
     return pathName || worktree.git.head.substring(0, 8) || 'worktree';
 }
 
-function worktreeKeysEqual(left: WorktreeKey | undefined, right: WorktreeKey): boolean {
-    return !!left
-        && left.repositoryKey === right.repositoryKey
-        && left.canonicalWorktreePath === right.canonicalWorktreePath;
-}
 
 function getWorktreeGroupsHtml(
     worktrees: readonly ReadyWorktreeRow[],
@@ -672,7 +668,7 @@ function getWorktreeGroupsHtml(
 ): string {
     const rendered: string[] = [];
     worktrees.forEach((worktree, index) => {
-        const matched = entries.filter(entry => worktreeKeysEqual(entry.worktreeKey, worktree.git.key));
+        const matched = entries.filter(entry => worktreeKeysMatch(entry.worktreeKey, worktree.git.key));
         if (tab === 'active' && !matched.length) {
             return;
         }
@@ -682,7 +678,7 @@ function getWorktreeGroupsHtml(
         ));
     });
     const unmanaged = entries.filter(entry => !entry.worktreeKey
-        || !worktrees.some(worktree => worktreeKeysEqual(entry.worktreeKey, worktree.git.key)));
+        || !worktrees.some(worktree => worktreeKeysMatch(entry.worktreeKey, worktree.git.key)));
     if (unmanaged.length) {
         rendered.push(getUnmanagedWorktreeGroupHtml(unmanaged, worktrees.length));
     }
@@ -761,7 +757,7 @@ function getWorktreeAnchorHtml(
 ): string {
     const keys = anchor.worktreeKeys || [];
     const matched = entries.filter(entry => keys.some(key =>
-        worktreeKeysEqual(entry.worktreeKey, key)));
+        worktreeKeysMatch(entry.worktreeKey, key)));
     const inlineSummary = anchor.entries
         .map(entry => `${entry.repositoryLabel}: ${entry.branch}`)
         .join(' · ');
@@ -857,7 +853,7 @@ function getWorktreeGroupRowHtml(
         .filter(member => !!member.worktreeKey)
         .map(member => member.worktreeKey) as WorktreeKey[];
     const matched = entries.filter(entry => memberKeys.some(key =>
-        worktreeKeysEqual(entry.worktreeKey, key)));
+        worktreeKeysMatch(entry.worktreeKey, key)));
     const name = group.displayName;
     const count = matched.length;
     const activity = group.activity === 'attention' ? 'needs attention'

--- a/src/workspaces/worktreeGroupProjection.ts
+++ b/src/workspaces/worktreeGroupProjection.ts
@@ -18,7 +18,7 @@ import type {
     WorktreeRepositorySnapshot,
     WorktreeSnapshot,
 } from '../worktrees/types';
-import { worktreeKeysEqual } from '../worktrees/types';
+import { worktreeKeysEqual, worktreeKeyToString } from '../worktrees/types';
 import type { OpenWorkspace } from './types';
 import {
     isWorkspaceHostPathContained,
@@ -123,7 +123,7 @@ export function buildWorktreeGroupProjection(
     }>();
     for (const repository of repositories) {
         for (const worktree of repository.worktrees) {
-            worktreeByKey.set(lookupKey(worktree.key), { repository, worktree });
+            worktreeByKey.set(worktreeKeyToString(worktree.key), { repository, worktree });
         }
     }
     const repositoryLabels = buildRepositoryLabels(repositories);
@@ -167,13 +167,13 @@ export function buildWorktreeGroupProjection(
                 continue;
             }
             const visible = member.worktreeKey
-                ? worktreeByKey.get(lookupKey(member.worktreeKey))
+                ? worktreeByKey.get(worktreeKeyToString(member.worktreeKey))
                 : undefined;
             if (member.worktreeKey) {
                 // Sessions keep their worktree identity even when the
                 // physical worktree is gone (hydration manifest fallback),
                 // so aggregate by the member key, not by snapshot visibility.
-                claimedKeys.add(lookupKey(member.worktreeKey));
+                claimedKeys.add(worktreeKeyToString(member.worktreeKey));
                 groupSessions.push(...sessionsOfWorktree(input.sessions, member.worktreeKey));
                 if (visible) {
                     groupLive.push(...liveSessionsOfWorktree(input.activeSessions, member.worktreeKey));
@@ -288,7 +288,7 @@ export function buildWorktreeGroupProjection(
     for (const repository of repositories) {
         for (const worktree of repository.worktrees) {
             if (worktree.isMain || worktree.isBare
-                || claimedKeys.has(lookupKey(worktree.key))) {
+                || claimedKeys.has(worktreeKeyToString(worktree.key))) {
                 continue;
             }
             unmanaged.push(buildReadyRow(worktree, input.sessions, input.activeSessions));
@@ -426,10 +426,6 @@ function compareSessions(
 
 function createdAtOf(groups: readonly WorktreeGroup[], groupId: string): number {
     return groups.find(group => group.groupId === groupId)?.createdAt || 0;
-}
-
-function lookupKey(key: WorktreeKey): string {
-    return `${key.repositoryKey}::${key.canonicalWorktreePath}`;
 }
 
 /**

--- a/src/worktrees/groupDeletionHandler.ts
+++ b/src/worktrees/groupDeletionHandler.ts
@@ -1,5 +1,6 @@
 'use strict';
 
+import { worktreeKeysEqual } from '../worktrees/types';
 import type { WorktreeDeletionController } from './deletionController';
 import {
     acceptedWorktreeGroupDeletionSettlement,
@@ -101,9 +102,7 @@ export async function handlePreviewWorktreeGroupDeletion(
     const blockingClaimsFor = (target: typeof member) =>
         deps.store.listGenerationClaims(navigationIdentity)
             .filter(claim => claim.state === 'pending' && target.worktreeKey
-                && claim.worktreeKey.repositoryKey === target.worktreeKey.repositoryKey
-                && claim.worktreeKey.canonicalWorktreePath
-                    === target.worktreeKey.canonicalWorktreePath)
+                && worktreeKeysEqual(claim.worktreeKey, target.worktreeKey))
             .map(claim => ({
                 claimId: claim.claimId,
                 ...(claim.creatingProvider ? { provider: claim.creatingProvider } : {}),
@@ -393,10 +392,7 @@ export async function handleDiscardWorktreeGenerationClaim(
             const group = deps.store.listGroups(navigationIdentity)
                 .find(candidate => candidate.groupId === request.groupId);
             const belongsToGroup = !!group && !!claim && group.members.some(member =>
-                member.worktreeKey
-                && member.worktreeKey.repositoryKey === claim.worktreeKey.repositoryKey
-                && member.worktreeKey.canonicalWorktreePath
-                    === claim.worktreeKey.canonicalWorktreePath);
+                member.worktreeKey && worktreeKeysEqual(member.worktreeKey, claim.worktreeKey));
             if (!claim || claim.state !== 'pending' || !belongsToGroup) {
                 await deps.postMessage({
                     type: 'worktree-group-deletion-settlement', version: 1,

--- a/src/worktrees/groupManifestStore.ts
+++ b/src/worktrees/groupManifestStore.ts
@@ -1,6 +1,7 @@
 'use strict';
 
 import { randomBytes } from 'crypto';
+import { worktreeKeysEqual } from './types';
 import type { MemberBaseline, WorktreeKey } from './types';
 import {
     cloneMemberBaseline,
@@ -220,7 +221,7 @@ export class WorktreeGroupManifestStore {
     ): WorktreeGroup | null {
         const found = this.readAggregate(workspaceIdentity).groups.find(group =>
             group.members.some(member => member.worktreeKey
-                && worktreeKeyEquals(member.worktreeKey, key)));
+                && worktreeKeysEqual(member.worktreeKey, key)));
         return found ? cloneGroup(found) : null;
     }
 
@@ -1589,16 +1590,11 @@ function assertWorktreeKeysUnclaimed(
                 continue;
             }
             if (group.members.some(candidate => candidate.worktreeKey
-                && worktreeKeyEquals(candidate.worktreeKey, member.worktreeKey!))) {
+                && worktreeKeysEqual(candidate.worktreeKey, member.worktreeKey!))) {
                 throw new WorktreeGroupManifestError('worktree-key-claimed');
             }
         }
     }
-}
-
-function worktreeKeyEquals(left: WorktreeKey, right: WorktreeKey): boolean {
-    return left.repositoryKey === right.repositoryKey
-        && left.canonicalWorktreePath === right.canonicalWorktreePath;
 }
 
 function emptyAggregate(): WorkspaceAggregate {

--- a/src/worktrees/isolatedSessionController.ts
+++ b/src/worktrees/isolatedSessionController.ts
@@ -22,6 +22,7 @@ import type {
     WorktreeRepositorySnapshot,
     WorktreeSnapshot,
 } from './types';
+import { worktreeKeyTombstoneKey } from './types';
 import type { PersistedWorktreeProvisioningOperation } from './provisioningStore';
 import { MAX_PROVISIONING_TOMBSTONES } from './provisioningStore';
 
@@ -573,7 +574,8 @@ export class IsolatedSessionController {
             const keep = (record.tombstonedAt ?? 0) >= snapshotStartedAt
                 || !discoveredRepositoryKeys.has(record.plan.repositoryKey)
                 || existingWorktreePaths.has(
-                    `${record.plan.repositoryKey} ${record.plan.worktreePath}`);
+                    worktreeKeyTombstoneKey(
+                        record.plan.repositoryKey, record.plan.worktreePath));
             if (!keep) {
                 this.recoveryTombstones.delete(operationId);
             }
@@ -599,7 +601,7 @@ export class IsolatedSessionController {
         navigationIdentity: string;
     }): Promise<boolean> {
         const operationId = `tombstone-${createHash('sha1')
-            .update(`${input.repositoryKey} ${input.worktreePath}`)
+            .update(worktreeKeyTombstoneKey(input.repositoryKey, input.worktreePath))
             .digest('hex')
             .slice(0, 16)}`;
         // A concurrent write for the same path shares the in-flight

--- a/src/worktrees/provisioningStore.ts
+++ b/src/worktrees/provisioningStore.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import type { WorktreeProvisioningCompletedStep } from './provisioningController';
 import type { WorktreeProvisioningPlan } from './provisioningPlan';
 import type { ProvisioningWorktreeRow, WorktreeKey } from './types';
+import { worktreeKeyTombstoneKey } from './types';
 import { parseMemberBaseline } from './baseline';
 import { normalizeWorktreeSetupCommand } from './worktreeSetupRunner';
 import { isManagedWorktreePath } from './provisioningPlan';
@@ -155,7 +156,8 @@ export class WorktreeProvisioningStore {
                 || (discoveredRepositoryKeys
                     && !discoveredRepositoryKeys.has(record.plan.repositoryKey))
                 || existingWorktreePaths.has(
-                    `${record.plan.repositoryKey} ${record.plan.worktreePath}`));
+                    worktreeKeyTombstoneKey(
+                        record.plan.repositoryKey, record.plan.worktreePath)));
             const keptIds = new Set(kept.map(record => record.operationId));
             pruned = tombstones
                 .filter(record => !keptIds.has(record.operationId))

--- a/src/worktrees/retiredWorktrees.ts
+++ b/src/worktrees/retiredWorktrees.ts
@@ -1,5 +1,6 @@
 'use strict';
 
+import { worktreeKeysEqual } from './types';
 import type { WorktreeKey } from './types';
 
 /**
@@ -115,7 +116,7 @@ export function judgeSessionGeneration(
         candidate.state === 'promoted'
         && candidate.provider === subject.provider
         && candidate.sessionId === subject.sessionId
-        && worktreeKeyEquals(candidate.worktreeKey, {
+        && worktreeKeysEqual(candidate.worktreeKey, {
             repositoryKey: record.repositoryKey,
             canonicalWorktreePath: record.canonicalWorktreePath,
         }));
@@ -193,7 +194,3 @@ export function findLatestRetirementForKey(
     return best;
 }
 
-function worktreeKeyEquals(left: WorktreeKey, right: WorktreeKey): boolean {
-    return left.repositoryKey === right.repositoryKey
-        && left.canonicalWorktreePath === right.canonicalWorktreePath;
-}

--- a/src/worktrees/types.ts
+++ b/src/worktrees/types.ts
@@ -140,3 +140,29 @@ export function cloneWorktreeKey(key: WorktreeKey): WorktreeKey {
 export function worktreeKeyToString(key: WorktreeKey): string {
     return `${key.repositoryKey}::${key.canonicalWorktreePath}`;
 }
+
+/**
+ * Optional-field identity match: both keys undefined counts as matching
+ * (no difference to report); exactly one defined is a mismatch.
+ */
+export function worktreeKeysMatch(
+    left: WorktreeKey | undefined,
+    right: WorktreeKey | undefined
+): boolean {
+    if (!left || !right) {
+        return left === right;
+    }
+    return worktreeKeysEqual(left, right);
+}
+
+/**
+ * Tombstone path-matching key. PERSISTED CONTRACT: the space-joined
+ * repositoryKey + worktreePath feeds the tombstone pruning sets; the
+ * encoding is byte-stable and must not change without a migration.
+ */
+export function worktreeKeyTombstoneKey(
+    repositoryKey: string,
+    worktreePath: string
+): string {
+    return `${repositoryKey} ${worktreePath}`;
+}

--- a/tests/unit/worktrees/worktreeKeyCodecs.test.js
+++ b/tests/unit/worktrees/worktreeKeyCodecs.test.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+    worktreeKeysEqual,
+    worktreeKeysMatch,
+    worktreeKeyToString,
+    worktreeKeyTombstoneKey,
+} = require('../../../out/worktrees/types');
+
+const alpha = { repositoryKey: '/alpha/.git', canonicalWorktreePath: '/alpha/.worktrees/fix' };
+const alphaAgain = { ...alpha };
+const beta = { repositoryKey: '/beta/.git', canonicalWorktreePath: '/beta/.worktrees/fix' };
+
+test('ARCH-WORKTREE-IDENTITY-CODEC-001 canonical equality and the optional-field match', () => {
+    assert.ok(worktreeKeysEqual(alpha, alphaAgain));
+    assert.ok(!worktreeKeysEqual(alpha, beta));
+
+    // Optional-field rule: both undefined matches; exactly one is a mismatch.
+    assert.ok(worktreeKeysMatch(undefined, undefined));
+    assert.ok(!worktreeKeysMatch(alpha, undefined));
+    assert.ok(!worktreeKeysMatch(undefined, alpha));
+    assert.ok(worktreeKeysMatch(alpha, alphaAgain));
+    assert.ok(!worktreeKeysMatch(alpha, beta));
+});
+
+test('ARCH-WORKTREE-IDENTITY-CODEC-001 the string encodings are byte-stable contracts', () => {
+    assert.equal(worktreeKeyToString(alpha), '/alpha/.git::/alpha/.worktrees/fix');
+    // Persisted tombstone contract: space-joined, byte-stable; the synthetic
+    // tombstone sha1 input and the pruning sets both consume this form.
+    assert.equal(worktreeKeyTombstoneKey('/alpha/.git', '/alpha/.worktrees/fix'),
+        '/alpha/.git /alpha/.worktrees/fix');
+});


### PR DESCRIPTION
## Summary

Stage 4 pilot migration, slice S1 — identity codecs move to the canonical owner per invariant `ARCH-WORKTREE-IDENTITY-CODEC-001`. Behavior-preserving; every output is byte-identical.

- `worktreeKeysEqual` replaces the private duplicates in `groupManifestStore` and `retiredWorktrees` and the inline comparisons in `groupDeletionHandler`.
- `worktreeKeysMatch` (new canonical optional-field rule: both undefined matches, exactly one mismatches) replaces the guarded variant in `webviewAiSessionContent` and the dashboard claim-ambiguity comparison.
- `worktreeKeyToString` replaces `lookupKey` in `worktreeGroupProjection`.
- `worktreeKeyTombstoneKey` (new) owns the space-joined **persisted** tombstone encoding — pruning sets and the synthetic-tombstone sha1 input — replacing three ad-hoc concatenations. Byte-stability is pinned by test.
- The separator-less `memberPathClaim` stays local (single site, in-memory only).

New `tests/unit/worktrees/worktreeKeyCodecs.test.js` pins the codec contracts and is registered as a behavior owner of the invariant record.

## Skill harvest

no skill change — codec consolidation followed the approved pilot plan.

## Verification

- Compile clean; worktrees unit 170/170; worktrees contract 115/115; architecture policy lane 59/59 (invariant catalog updated and re-validated); dashboard webview checks pass.
- Full coverage gate locally: baseline passed, changed-line coverage 98.04% against origin/main.
- `npm run test:behavior-contracts` green after the audit commit; `git diff --check` clean.