### PR TITLE
docs+refactor: PR state guidance and pilot S2 member lifecycle authority

### DIFF
--- a/.skills/publishing-and-merging-github-prs/SKILL.md
+++ b/.skills/publishing-and-merging-github-prs/SKILL.md
@@ -52,6 +52,16 @@ after every GitHub write.
 7. Prefer connector PR creation if available and authorized.
 8. If connector fails with permission or repository ambiguity, use `gh pr create`.
 9. Default to draft for "open a PR" requests unless the user explicitly asks for ready-for-review or the same request includes merging after validation.
+10. **After creating or updating a PR, verify it actually works before
+    handing off**: `gh pr view <n> --json mergeable,mergeStateStatus` and
+    `gh pr checks <n>` — the PR must be mergeable with checks running or
+    green. If `origin/main` moved and the PR conflicts, rebase immediately
+    and re-push; never leave a PR conflicting, red, or stale.
+11. When a rebase follows another merge to main, expect the capability-audit
+    commit to conflict on `docs/testing/main-capability-coverage.json`:
+    keep main's `audit.head`, finish the rebase, then regenerate the audit
+    with `scripts/regenerate-capability-audit.js` so the new commit SHAs are
+    referenced; rerun `npm run test:behavior-contracts` before pushing.
 
 If push reports HTTP 408, `unexpected EOF`, or an RPC disconnect:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,8 +24,9 @@ making any change.
    `origin/main` in `hzcheng/agent-pivot`. This repo has two remotes
    (`origin` = fork, `upstream` = original project) — pass
    `--repo hzcheng/agent-pivot` to every `gh` command. Write PR titles, PR
-   bodies, and commit messages in English. Details: skill
-   `publishing-and-merging-github-prs`.
+   bodies, and commit messages in English. After opening or updating a PR,
+   verify it is mergeable with checks running — never leave a PR
+   conflicting or red. Details: skill `publishing-and-merging-github-prs`.
 
 3. **Load the matching skill before acting.** Project skills live in
    `.skills/` (canonical) and are mirrored into `.kimi/skills/`,

--- a/docs/testing/architecture-invariants.json
+++ b/docs/testing/architecture-invariants.json
@@ -10,7 +10,9 @@
         {
             "id": "ARCH-WORKTREE-PREVIEW-TOKEN-001",
             "module": "MOD-WORKTREE-LIFECYCLE",
-            "productCapabilities": ["MAIN-WORKTREE-CHANGES-PANEL"],
+            "productCapabilities": [
+                "MAIN-WORKTREE-CHANGES-PANEL"
+            ],
             "priority": "P0",
             "kind": "state-machine",
             "statement": "A preview token is consumed exactly once, after validation and before the first manifest await; a replayed, concurrent, or superseded confirm fails closed as preview-stale.",
@@ -20,18 +22,247 @@
             },
             "writers": [],
             "linearizationPoint": "The identity-checked snapshot delete precedes the manifest write.",
-            "enforcement": ["behavior"],
-            "behaviorOwners": ["tests/contract/worktrees/groupCreationController.test.js"],
+            "enforcement": [
+                "behavior"
+            ],
+            "behaviorOwners": [
+                "tests/contract/worktrees/groupCreationController.test.js"
+            ],
             "guardOwners": [],
-            "evidence": ["src/worktrees/groupCreationController.ts"]
+            "evidence": [
+                "src/worktrees/groupCreationController.ts"
+            ]
         },
         {
             "id": "ARCH-WORKTREE-MEMBER-WRITER-001",
             "module": "MOD-WORKTREE-LIFECYCLE",
-            "productCapabilities": ["MAIN-WORKTREE-CHANGES-PANEL"],
+            "productCapabilities": [
+                "MAIN-WORKTREE-CHANGES-PANEL"
+            ],
             "priority": "P0",
             "kind": "concurrency",
-            "statement": "Manifest writes happen only in the declared writer set (store plus the enumerated callers); migration slice S2 shrinks the set to one coordinator.",
+            "statement": "Manifest member state transitions route through WorktreeMemberLifecycle, which enforces the legal pre-states at the boundary; the store member-transition methods have exactly one writer.",
+            "authority": {
+                "path": "src/worktrees/memberLifecycle.ts",
+                "symbol": "WorktreeMemberLifecycle"
+            },
+            "writers": [
+                "src/worktrees/memberLifecycle.ts"
+            ],
+            "linearizationPoint": "The versioned manifest commit succeeds.",
+            "enforcement": [
+                "single-writer",
+                "behavior"
+            ],
+            "behaviorOwners": [
+                "tests/unit/worktrees/memberLifecycle.test.js",
+                "tests/unit/worktrees/groupManifestStore.test.js"
+            ],
+            "guardOwners": [
+                "tests/unit/architecture/singleWriters.test.js"
+            ],
+            "evidence": [
+                "src/worktrees/groupManifestStore.ts"
+            ],
+            "stateFamily": {
+                "storePath": "src/worktrees/groupManifestStore.ts",
+                "writeMethods": [
+                    "updateMember",
+                    "setPrimaryMember",
+                    "removeMember"
+                ]
+            }
+        },
+        {
+            "id": "ARCH-WORKTREE-CLAIM-ORDER-001",
+            "module": "MOD-WORKTREE-LIFECYCLE",
+            "productCapabilities": [
+                "MAIN-WORKTREE-CHANGES-PANEL"
+            ],
+            "priority": "P0",
+            "kind": "recovery",
+            "statement": "A generation claim is durable before any terminal or provider side effect; claim removal requires proven-not-started evidence or an explicit user discard; ambiguity never auto-discards.",
+            "authority": {
+                "path": "src/aiSessions/creationController.ts",
+                "symbol": "AiSessionCreationController"
+            },
+            "writers": [],
+            "linearizationPoint": "createGenerationClaim commitBucket precedes coordinator.create.",
+            "enforcement": [
+                "behavior",
+                "fault-matrix"
+            ],
+            "behaviorOwners": [
+                "tests/contract/aiSessions/sessionControllers.test.js"
+            ],
+            "guardOwners": [],
+            "evidence": [
+                "src/aiSessions/creationController.ts",
+                "src/worktrees/groupManifestStore.ts"
+            ]
+        },
+        {
+            "id": "ARCH-WORKTREE-TOMBSTONE-FIRST-001",
+            "module": "MOD-WORKTREE-LIFECYCLE",
+            "productCapabilities": [
+                "MAIN-WORKTREE-CHANGES-PANEL"
+            ],
+            "priority": "P0",
+            "kind": "recovery",
+            "statement": "Dismissal persists the tombstone before removing any live row, context, or manifest member; a failed tombstone write refuses the whole dismissal.",
+            "authority": {
+                "path": "src/worktrees/isolatedSessionController.ts",
+                "symbol": "IsolatedSessionController"
+            },
+            "writers": [
+                "src/dashboard.ts",
+                "src/worktrees/isolatedSessionController.ts"
+            ],
+            "linearizationPoint": "appendTombstones memento update precedes live-row removal.",
+            "enforcement": [
+                "single-writer",
+                "behavior",
+                "fault-matrix"
+            ],
+            "behaviorOwners": [
+                "tests/contract/worktrees/isolatedSessionController.test.js"
+            ],
+            "guardOwners": [
+                "tests/unit/architecture/singleWriters.test.js"
+            ],
+            "evidence": [
+                "src/worktrees/isolatedSessionController.ts",
+                "src/worktrees/provisioningStore.ts"
+            ],
+            "stateFamily": {
+                "storePath": "src/worktrees/provisioningStore.ts",
+                "writeMethods": [
+                    "replaceLive",
+                    "appendTombstones",
+                    "deleteTombstones",
+                    "pruneTombstones"
+                ]
+            }
+        },
+        {
+            "id": "ARCH-WORKTREE-BASELINE-FREEZE-001",
+            "module": "MOD-WORKTREE-LIFECYCLE",
+            "productCapabilities": [
+                "MAIN-WORKTREE-CHANGES-PANEL"
+            ],
+            "priority": "P1",
+            "kind": "persistence",
+            "statement": "The base ref is frozen to an immutable commit SHA before git worktree add; a group never provisions from a moving ref.",
+            "authority": {
+                "path": "src/worktrees/groupCreationController.ts",
+                "symbol": "WorktreeGroupCreationController"
+            },
+            "writers": [],
+            "linearizationPoint": "resolveBaseCommit returns before createGroup.",
+            "enforcement": [
+                "behavior"
+            ],
+            "behaviorOwners": [
+                "tests/contract/worktrees/groupCreationController.test.js"
+            ],
+            "guardOwners": [],
+            "evidence": [
+                "src/worktrees/groupCreationController.ts",
+                "src/worktrees/gitWorktreeProvisioner.ts"
+            ]
+        },
+        {
+            "id": "ARCH-WORKTREE-RESTART-RECOVERY-001",
+            "module": "MOD-WORKTREE-LIFECYCLE",
+            "productCapabilities": [
+                "MAIN-WORKTREE-CHANGES-PANEL"
+            ],
+            "priority": "P1",
+            "kind": "recovery",
+            "statement": "Every crash window between the linearization points has deterministic restart reconciliation: interrupted work demotes to failed/interrupted, tombstones prune only with positive evidence, unknown deletion observation keeps the lease.",
+            "authority": {
+                "path": "src/worktrees/groupManifestReconciliation.ts",
+                "symbol": "reconcileWorktreeGroupManifest"
+            },
+            "writers": [],
+            "linearizationPoint": "Snapshot-load reconciliation completes before new provisioning rows publish.",
+            "enforcement": [
+                "behavior",
+                "fault-matrix"
+            ],
+            "behaviorOwners": [
+                "tests/unit/worktrees/groupManifestReconciliation.test.js",
+                "tests/unit/worktrees/deletionController.test.js"
+            ],
+            "guardOwners": [],
+            "evidence": [
+                "src/worktrees/groupManifestReconciliation.ts",
+                "src/worktrees/deletionController.ts"
+            ]
+        },
+        {
+            "id": "ARCH-WORKTREE-PROTOCOL-ENVELOPE-001",
+            "module": "MOD-WORKTREE-LIFECYCLE",
+            "productCapabilities": [
+                "MAIN-WORKTREE-CHANGES-PANEL"
+            ],
+            "priority": "P1",
+            "kind": "protocol",
+            "statement": "Every pilot mutation message carries a correlation envelope (requestId, version) and a documented exactly-once mechanism (replay cache or single-use token); the known gaps (confirm replay cache, set-primary/merge/adopt/discard-claim correlation, merge requestId) are migration slice S4 targets.",
+            "authority": {
+                "path": "src/worktrees/groupCreationProtocol.ts",
+                "symbol": "parseConfirmWorktreeGroupRequest"
+            },
+            "writers": [],
+            "linearizationPoint": "Protocol parse precedes any state mutation.",
+            "enforcement": [
+                "behavior"
+            ],
+            "behaviorOwners": [
+                "tests/browser/worktreeGroupForm.test.js"
+            ],
+            "guardOwners": [],
+            "evidence": [
+                "src/worktrees/groupCreationProtocol.ts",
+                "src/dashboard.ts"
+            ]
+        },
+        {
+            "id": "ARCH-WORKTREE-IDENTITY-CODEC-001",
+            "module": "MOD-WORKTREE-LIFECYCLE",
+            "productCapabilities": [
+                "MAIN-WORKTREE-CHANGES-PANEL"
+            ],
+            "priority": "P1",
+            "kind": "identity",
+            "statement": "Domain identities (WorktreeKey, composite session identity, safe ids) use one canonical codec and equality policy owned by the domain layer; persisted encodings stay stable per usage context.",
+            "authority": {
+                "path": "src/worktrees/types.ts",
+                "symbol": "worktreeKeysEqual"
+            },
+            "writers": [],
+            "linearizationPoint": "Identity construction goes through the canonical codec.",
+            "enforcement": [
+                "behavior"
+            ],
+            "behaviorOwners": [
+                "tests/unit/worktrees/provisioningPlan.test.js",
+                "tests/unit/worktrees/worktreeKeyCodecs.test.js"
+            ],
+            "guardOwners": [],
+            "evidence": [
+                "src/worktrees/types.ts"
+            ]
+        },
+        {
+            "id": "ARCH-WORKTREE-MANIFEST-STRUCTURE-001",
+            "module": "MOD-WORKTREE-LIFECYCLE",
+            "productCapabilities": [
+                "MAIN-WORKTREE-CHANGES-PANEL"
+            ],
+            "priority": "P0",
+            "kind": "concurrency",
+            "statement": "Structural manifest writes (group creation, adoption, merge, claims, and the deletion journal) happen only in the declared writer set; migration waves shrink it.",
             "authority": {
                 "path": "src/worktrees/groupManifestStore.ts",
                 "symbol": "WorktreeGroupManifestStore"
@@ -46,19 +277,23 @@
                 "src/worktrees/groupManifestReconciliation.ts"
             ],
             "linearizationPoint": "The versioned manifest commit succeeds.",
-            "enforcement": ["single-writer", "behavior"],
-            "behaviorOwners": ["tests/unit/worktrees/groupManifestStore.test.js"],
-            "guardOwners": ["tests/unit/architecture/singleWriters.test.js"],
-            "evidence": ["src/worktrees/groupManifestStore.ts"],
+            "enforcement": [
+                "single-writer"
+            ],
+            "behaviorOwners": [
+                "tests/unit/worktrees/groupManifestStore.test.js"
+            ],
+            "guardOwners": [
+                "tests/unit/architecture/singleWriters.test.js"
+            ],
+            "evidence": [
+                "src/worktrees/groupManifestStore.ts"
+            ],
             "stateFamily": {
                 "storePath": "src/worktrees/groupManifestStore.ts",
                 "writeMethods": [
                     "createGroup",
                     "addPlannedMembers",
-                    "updateMember",
-                    "removeMember",
-                    "renameGroup",
-                    "setPrimaryMember",
                     "mergeGroups",
                     "adoptReadyMembers",
                     "beginDeletion",
@@ -79,132 +314,6 @@
                     "resetCorruptRetiredStore"
                 ]
             }
-        },
-        {
-            "id": "ARCH-WORKTREE-CLAIM-ORDER-001",
-            "module": "MOD-WORKTREE-LIFECYCLE",
-            "productCapabilities": ["MAIN-WORKTREE-CHANGES-PANEL"],
-            "priority": "P0",
-            "kind": "recovery",
-            "statement": "A generation claim is durable before any terminal or provider side effect; claim removal requires proven-not-started evidence or an explicit user discard; ambiguity never auto-discards.",
-            "authority": {
-                "path": "src/aiSessions/creationController.ts",
-                "symbol": "AiSessionCreationController"
-            },
-            "writers": [],
-            "linearizationPoint": "createGenerationClaim commitBucket precedes coordinator.create.",
-            "enforcement": ["behavior", "fault-matrix"],
-            "behaviorOwners": ["tests/contract/aiSessions/sessionControllers.test.js"],
-            "guardOwners": [],
-            "evidence": ["src/aiSessions/creationController.ts", "src/worktrees/groupManifestStore.ts"]
-        },
-        {
-            "id": "ARCH-WORKTREE-TOMBSTONE-FIRST-001",
-            "module": "MOD-WORKTREE-LIFECYCLE",
-            "productCapabilities": ["MAIN-WORKTREE-CHANGES-PANEL"],
-            "priority": "P0",
-            "kind": "recovery",
-            "statement": "Dismissal persists the tombstone before removing any live row, context, or manifest member; a failed tombstone write refuses the whole dismissal.",
-            "authority": {
-                "path": "src/worktrees/isolatedSessionController.ts",
-                "symbol": "IsolatedSessionController"
-            },
-            "writers": [
-                "src/dashboard.ts",
-                "src/worktrees/isolatedSessionController.ts"
-            ],
-            "linearizationPoint": "appendTombstones memento update precedes live-row removal.",
-            "enforcement": ["single-writer", "behavior", "fault-matrix"],
-            "behaviorOwners": ["tests/contract/worktrees/isolatedSessionController.test.js"],
-            "guardOwners": ["tests/unit/architecture/singleWriters.test.js"],
-            "evidence": ["src/worktrees/isolatedSessionController.ts", "src/worktrees/provisioningStore.ts"],
-            "stateFamily": {
-                "storePath": "src/worktrees/provisioningStore.ts",
-                "writeMethods": [
-                    "replaceLive",
-                    "appendTombstones",
-                    "deleteTombstones",
-                    "pruneTombstones"
-                ]
-            }
-        },
-        {
-            "id": "ARCH-WORKTREE-BASELINE-FREEZE-001",
-            "module": "MOD-WORKTREE-LIFECYCLE",
-            "productCapabilities": ["MAIN-WORKTREE-CHANGES-PANEL"],
-            "priority": "P1",
-            "kind": "persistence",
-            "statement": "The base ref is frozen to an immutable commit SHA before git worktree add; a group never provisions from a moving ref.",
-            "authority": {
-                "path": "src/worktrees/groupCreationController.ts",
-                "symbol": "WorktreeGroupCreationController"
-            },
-            "writers": [],
-            "linearizationPoint": "resolveBaseCommit returns before createGroup.",
-            "enforcement": ["behavior"],
-            "behaviorOwners": ["tests/contract/worktrees/groupCreationController.test.js"],
-            "guardOwners": [],
-            "evidence": ["src/worktrees/groupCreationController.ts", "src/worktrees/gitWorktreeProvisioner.ts"]
-        },
-        {
-            "id": "ARCH-WORKTREE-RESTART-RECOVERY-001",
-            "module": "MOD-WORKTREE-LIFECYCLE",
-            "productCapabilities": ["MAIN-WORKTREE-CHANGES-PANEL"],
-            "priority": "P1",
-            "kind": "recovery",
-            "statement": "Every crash window between the linearization points has deterministic restart reconciliation: interrupted work demotes to failed/interrupted, tombstones prune only with positive evidence, unknown deletion observation keeps the lease.",
-            "authority": {
-                "path": "src/worktrees/groupManifestReconciliation.ts",
-                "symbol": "reconcileWorktreeGroupManifest"
-            },
-            "writers": [],
-            "linearizationPoint": "Snapshot-load reconciliation completes before new provisioning rows publish.",
-            "enforcement": ["behavior", "fault-matrix"],
-            "behaviorOwners": [
-                "tests/unit/worktrees/groupManifestReconciliation.test.js",
-                "tests/unit/worktrees/deletionController.test.js"
-            ],
-            "guardOwners": [],
-            "evidence": ["src/worktrees/groupManifestReconciliation.ts", "src/worktrees/deletionController.ts"]
-        },
-        {
-            "id": "ARCH-WORKTREE-PROTOCOL-ENVELOPE-001",
-            "module": "MOD-WORKTREE-LIFECYCLE",
-            "productCapabilities": ["MAIN-WORKTREE-CHANGES-PANEL"],
-            "priority": "P1",
-            "kind": "protocol",
-            "statement": "Every pilot mutation message carries a correlation envelope (requestId, version) and a documented exactly-once mechanism (replay cache or single-use token); the known gaps (confirm replay cache, set-primary/merge/adopt/discard-claim correlation, merge requestId) are migration slice S4 targets.",
-            "authority": {
-                "path": "src/worktrees/groupCreationProtocol.ts",
-                "symbol": "parseConfirmWorktreeGroupRequest"
-            },
-            "writers": [],
-            "linearizationPoint": "Protocol parse precedes any state mutation.",
-            "enforcement": ["behavior"],
-            "behaviorOwners": ["tests/browser/worktreeGroupForm.test.js"],
-            "guardOwners": [],
-            "evidence": ["src/worktrees/groupCreationProtocol.ts", "src/dashboard.ts"]
-        },
-        {
-            "id": "ARCH-WORKTREE-IDENTITY-CODEC-001",
-            "module": "MOD-WORKTREE-LIFECYCLE",
-            "productCapabilities": ["MAIN-WORKTREE-CHANGES-PANEL"],
-            "priority": "P1",
-            "kind": "identity",
-            "statement": "Domain identities (WorktreeKey, composite session identity, safe ids) use one canonical codec and equality policy owned by the domain layer; persisted encodings stay stable per usage context.",
-            "authority": {
-                "path": "src/worktrees/types.ts",
-                "symbol": "worktreeKeysEqual"
-            },
-            "writers": [],
-            "linearizationPoint": "Identity construction goes through the canonical codec.",
-            "enforcement": ["behavior"],
-            "behaviorOwners": [
-                "tests/unit/worktrees/provisioningPlan.test.js",
-                "tests/unit/worktrees/worktreeKeyCodecs.test.js"
-            ],
-            "guardOwners": [],
-            "evidence": ["src/worktrees/types.ts"]
         }
     ]
 }

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "1b69d7ed8be4f331227185c364ea43a1259a9688",
+        "head": "19f2c80fd79ef0a9392595259e9367c09c26404c",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -427,7 +427,8 @@
             "15e02b1fc1d28814f08b3b734d6bf710ddebf640",
             "45c402334a7218788172c849f46da67a73696268",
             "d0639576ebd5e5fb1a207e991dc15f479ad935bb",
-            "88aed14d522c5f67189379584128227e8e8b953e"
+            "88aed14d522c5f67189379584128227e8e8b953e",
+            "8177023cc05077c52c9d013a0945bbb88a50ac71"
         ]
     },
     "capabilities": [
@@ -1522,7 +1523,8 @@
                 "bb67bbc1416b46a2038480649597aa553b0d7f7f",
                 "6cef6f649a14d34e27017d4a11fc88758c489b58",
                 "e67775d6c0f4827a62f002cd4812d353d6b6d0e7",
-                "17ab4dde576090e944e6ea67c3db8133929a3ffb"
+                "17ab4dde576090e944e6ea67c3db8133929a3ffb",
+                "19f2c80fd79ef0a9392595259e9367c09c26404c"
             ],
             "behaviors": [
                 "ARCH-CI-QUALITY-GATE-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "fce4b85cacbaae9b3d7d74404c8f21ec6ace1b3d",
+        "head": "8c8f510f3fba3d5e6c95ea9c0bacc9238308b55d",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -429,7 +429,8 @@
             "d0639576ebd5e5fb1a207e991dc15f479ad935bb",
             "88aed14d522c5f67189379584128227e8e8b953e",
             "8177023cc05077c52c9d013a0945bbb88a50ac71",
-            "6f8a932716f4ddfeef19ec73db3db7fe208881f9"
+            "6f8a932716f4ddfeef19ec73db3db7fe208881f9",
+            "e98ea7f14b1c7d153526be0a3064797ee85ba6d2"
         ]
     },
     "capabilities": [
@@ -2267,7 +2268,8 @@
                 "9cc798e174564d2cc3274b139d7c3fe64a875064",
                 "135f07179a352666153fc7e6f59b34c3cfbde9b7",
                 "86f76b58df2b31056fb9e77c00b9137021b9aaad",
-                "99666fe7bd595cc977c7b7b583fdf1f3238b4413"
+                "99666fe7bd595cc977c7b7b583fdf1f3238b4413",
+                "8c8f510f3fba3d5e6c95ea9c0bacc9238308b55d"
             ],
             "behaviors": [
                 "ARCH-POLICY-SCHEMA-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "19f2c80fd79ef0a9392595259e9367c09c26404c",
+        "head": "fce4b85cacbaae9b3d7d74404c8f21ec6ace1b3d",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -428,7 +428,8 @@
             "45c402334a7218788172c849f46da67a73696268",
             "d0639576ebd5e5fb1a207e991dc15f479ad935bb",
             "88aed14d522c5f67189379584128227e8e8b953e",
-            "8177023cc05077c52c9d013a0945bbb88a50ac71"
+            "8177023cc05077c52c9d013a0945bbb88a50ac71",
+            "6f8a932716f4ddfeef19ec73db3db7fe208881f9"
         ]
     },
     "capabilities": [
@@ -2239,7 +2240,8 @@
                 "b76f4ba375337b0674dc846d119d5ce7f5c46ba8",
                 "8d27256aaefe7d1eee5c021cf8058da9e2a58c8c",
                 "33dd08d563b7d9e1e04352c4869af6f10fad9b2e",
-                "1b69d7ed8be4f331227185c364ea43a1259a9688"
+                "1b69d7ed8be4f331227185c364ea43a1259a9688",
+                "fce4b85cacbaae9b3d7d74404c8f21ec6ace1b3d"
             ],
             "behaviors": [
                 "WORKTREE-GROUPS-BASELINE-001",

--- a/scripts/architecture/reportArchitectureDiff.js
+++ b/scripts/architecture/reportArchitectureDiff.js
@@ -121,9 +121,15 @@ function collectArchitectureDiff({ rootDirectory, baseRef, git }) {
             for (const [id, headInvariant] of headInvariants) {
                 const baseInvariant = baseInvariants.get(id);
                 if (!baseInvariant) { continue; }
-                const grown = diffStringSets(
-                    baseInvariant.writers || [], headInvariant.writers || []).added;
-                if (grown.length > 0) { policyDelta.writersGrown[id] = grown; }
+                // Writer sets ratchet by net size: an authority move replaces
+                // old writers with fewer new ones (tightening); only net
+                // growth beyond the base size is broadening.
+                const baseWriters = baseInvariant.writers || [];
+                const headWriters = headInvariant.writers || [];
+                const added = diffStringSets(baseWriters, headWriters).added;
+                if (added.length > 0 && headWriters.length > baseWriters.length) {
+                    policyDelta.writersGrown[id] = added;
+                }
             }
         }
         if (protectedPath.endsWith('architecture-debt-baseline.json')) {
@@ -132,9 +138,14 @@ function collectArchitectureDiff({ rootDirectory, baseRef, git }) {
             policyDelta.baselineGrown = diffStringSets(flatten(baseJson), flatten(headJson)).added;
         }
         if (protectedPath.endsWith('architecture-waivers.json')) {
-            policyDelta.waiversAdded = diffStringSets(
-                (baseJson.waivers || []).map(waiver => waiver.id),
-                (headJson.waivers || []).map(waiver => waiver.id)).added;
+            // Waivers pair bijectively with baseline fingerprints; only net
+            // growth beyond the base count is new debt.
+            const baseWaivers = (baseJson.waivers || []).map(waiver => waiver.id);
+            const headWaivers = (headJson.waivers || []).map(waiver => waiver.id);
+            const added = diffStringSets(baseWaivers, headWaivers).added;
+            if (added.length > 0 && headWaivers.length > baseWaivers.length) {
+                policyDelta.waiversAdded = added;
+            }
         }
     }
 

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -259,6 +259,7 @@ import {
     GitApiLike,
     GitRepositoryStateMonitor,
 } from './worktrees/gitRepositoryStateMonitor';
+import { WorktreeMemberLifecycle } from './worktrees/memberLifecycle';
 import { WorktreeSnapshotCoordinator } from './worktrees/snapshotCoordinator';
 import { worktreeKeysEqual, worktreeKeysMatch, worktreeKeyTombstoneKey } from './worktrees/types';
 import type { WorktreeKey } from './worktrees/types';
@@ -1302,6 +1303,7 @@ async function initializeDashboard(
     );
     const worktreeSetupRunner = new WorktreeSetupRunner();
     const worktreeGroupManifestStore = new WorktreeGroupManifestStore(context.globalState);
+    const worktreeMemberLifecycle = new WorktreeMemberLifecycle(worktreeGroupManifestStore);
     const gitWorktreeDiscovery = new GitWorktreeDiscovery({
         getBaseRef: repositoryKey => worktreeBaseRefStore.get(repositoryKey),
     });
@@ -1353,6 +1355,7 @@ async function initializeDashboard(
                     try {
                         await reconcileWorktreeGroupManifest({
                             store: worktreeGroupManifestStore,
+                            memberLifecycle: worktreeMemberLifecycle,
                             workspaceIdentity: workspace.navigationIdentity,
                             snapshot,
                             recoveryRecords: worktreeProvisioningStore.read(),
@@ -1742,13 +1745,10 @@ async function initializeDashboard(
                     // Group creation (M2): the group already exists with this
                     // member planned; mark the member ready and apply the
                     // confirmed primary choice once its member is ready.
-                    await worktreeGroupManifestStore.updateMember(
-                        bucket, info.groupId, info.memberId, {
-                            state: 'ready',
-                            worktreeKey: info.worktreeKey,
-                        });
+                    await worktreeMemberLifecycle.markMemberReady(
+                        bucket, info.groupId, info.memberId, info.worktreeKey);
                     if (info.preferredPrimary) {
-                        await worktreeGroupManifestStore.setPrimaryMember(
+                        await worktreeMemberLifecycle.assignPrimary(
                             bucket, info.groupId, info.memberId);
                     }
                     return;
@@ -1792,6 +1792,7 @@ async function initializeDashboard(
     };
     let currentAiSessionRefreshReason = 'refresh';
     const worktreeGroupCreationController = new WorktreeGroupCreationController({
+        memberLifecycle: worktreeMemberLifecycle,
         getWorkspaceTarget: getCurrentWorkspaceActionTarget,
         getWorktreeSnapshot: () => worktreeSnapshotCoordinator.getSnapshot(),
         listLocalBranches: commandCwd =>
@@ -2074,7 +2075,7 @@ async function initializeDashboard(
                 const member = group?.members.find(candidate => candidate.worktreeKey
                     && worktreeKeysEqual(candidate.worktreeKey, removedKey));
                 if (group && member) {
-                    await worktreeGroupManifestStore.removeMember(
+                    await worktreeMemberLifecycle.removeMemberRecord(
                         workspaceIdentity, group.groupId, member.memberId);
                 }
             }
@@ -2699,7 +2700,7 @@ async function initializeDashboard(
                 return;
             }
             try {
-                await worktreeGroupManifestStore.setPrimaryMember(
+                await worktreeMemberLifecycle.assignPrimary(
                     target.workspace.navigationIdentity, request.groupId, request.memberId);
             } catch (error) {
                 logError('Failed to set the worktree group primary member.', error);

--- a/src/worktrees/groupCreationController.ts
+++ b/src/worktrees/groupCreationController.ts
@@ -13,6 +13,7 @@ import type {
     WorktreeGroup,
     WorktreeGroupManifestStore,
 } from './groupManifestStore';
+import type { WorktreeMemberLifecycle } from './memberLifecycle';
 import type { WorktreeProvisioningOutcome } from './provisioningController';
 import type {
     WorktreeRepositorySnapshot,
@@ -106,6 +107,7 @@ export interface WorktreeGroupCreationControllerOptions {
     getWorktreeDirectory: () => string;
     getActiveEditorPath: () => string | undefined;
     manifestStore: WorktreeGroupManifestStore;
+    memberLifecycle: WorktreeMemberLifecycle;
     startMemberOperation: (input: {
         operationId: string;
         projectId: string;
@@ -811,12 +813,8 @@ export class WorktreeGroupCreationController {
             return { kind: 'failed', operationId: memberOperationId(memberId), errorCode: 'retry-unavailable' };
         }
         try {
-            await this.options.manifestStore.updateMember(
-                navigationIdentity, groupId, memberId, {
-                    state: 'provisioning',
-                    // The store treats undefined as "leave unchanged".
-                    lastError: '',
-                });
+            await this.options.memberLifecycle.readmitMemberForRetry(
+                navigationIdentity, groupId, memberId);
         } catch (_error) {
             return {
                 kind: 'failed',
@@ -893,7 +891,7 @@ export class WorktreeGroupCreationController {
             }
         }
         try {
-            await this.options.manifestStore.removeMember(
+            await this.options.memberLifecycle.removeFailedMember(
                 navigationIdentity, groupId, memberId);
         } catch (_error) {
             return 'unavailable';
@@ -965,11 +963,8 @@ export class WorktreeGroupCreationController {
             : '-';
         this.options.onError?.(
             `Worktree group member settled without success: kind=${outcome.kind} error=${outcome.errorCode} completedSteps=${completedSteps} groupId=${groupId} memberId=${memberId}`);
-        await this.options.manifestStore.updateMember(
-            navigationIdentity, groupId, memberId, {
-                state: 'failed',
-                lastError: outcome.errorCode,
-            });
+        await this.options.memberLifecycle.markMemberFailed(
+            navigationIdentity, groupId, memberId, outcome.errorCode);
         this.options.onDidChange?.();
     }
 }

--- a/src/worktrees/groupManifestReconciliation.ts
+++ b/src/worktrees/groupManifestReconciliation.ts
@@ -1,5 +1,6 @@
 'use strict';
 
+import type { WorktreeMemberLifecycle } from './memberLifecycle';
 import type { WorktreeGroupManifestStore } from './groupManifestStore';
 import type { PersistedWorktreeProvisioningOperation } from './provisioningStore';
 import type { WorktreeSnapshotContent } from './types';
@@ -24,6 +25,8 @@ export interface ReconcileWorktreeGroupManifestOptions {
      * crashed mid-creation and are downgraded to failed/interrupted.
      */
     activeGroupMemberIds?: readonly string[];
+    /** The single writer for member transitions (ARCH-WORKTREE-MEMBER-WRITER-001). */
+    memberLifecycle: WorktreeMemberLifecycle;
     onError?: (message: string, error: unknown) => void;
 }
 
@@ -66,11 +69,8 @@ export async function reconcileWorktreeGroupManifest(
                 // member; a live operation's own settlement wins the race
                 // because it rewrites the state on every outcome.
                 try {
-                    await store.updateMember(
-                        workspaceIdentity, group.groupId, member.memberId, {
-                            state: 'failed',
-                            lastError: 'interrupted',
-                        });
+                    await options.memberLifecycle.demoteInterruptedMember(
+                        workspaceIdentity, group.groupId, member.memberId);
                 } catch (error) {
                     options.onError?.(
                         'Failed to downgrade an interrupted group member.', error);

--- a/src/worktrees/memberLifecycle.ts
+++ b/src/worktrees/memberLifecycle.ts
@@ -1,0 +1,148 @@
+'use strict';
+
+import type { WorktreeKey } from './types';
+import type { WorktreeGroupManifestStore } from './groupManifestStore';
+
+export class IllegalMemberTransitionError extends Error {
+    readonly code = 'illegal-member-transition';
+}
+
+/**
+ * The single authority for worktree-group member state transitions
+ * (invariant ARCH-WORKTREE-MEMBER-WRITER-001). Callers name the transition
+ * they mean; the legal pre-states are enforced here at the state-owning
+ * boundary instead of being re-remembered at every call site.
+ *
+ * Legal transitions (see the Stage 1B RFC state machine):
+ *   provisioning|failed   -> ready   (finalize; requires a worktree key; a
+ *                                    live operation wins the demotion race)
+ *   provisioning|planned|failed -> failed (settlement rewrite; a live
+ *                                    operation's own settlement wins races)
+ *   provisioning|planned    -> failed/interrupted (restart reconciliation)
+ *   failed                  -> provisioning (retry readmission)
+ *   failed                  -> removed  (dismiss)
+ *   ready                   -> removed  (physical worktree was removed)
+ */
+export class WorktreeMemberLifecycle {
+    constructor(private readonly store: WorktreeGroupManifestStore) {}
+
+    private memberState(
+        workspaceIdentity: string,
+        groupId: string,
+        memberId: string
+    ): string | undefined {
+        return this.store.listGroups(workspaceIdentity)
+            .find(group => group.groupId === groupId)
+            ?.members.find(member => member.memberId === memberId)?.state;
+    }
+
+    private requireState(
+        workspaceIdentity: string,
+        groupId: string,
+        memberId: string,
+        allowed: readonly string[],
+        transition: string
+    ): void {
+        const state = this.memberState(workspaceIdentity, groupId, memberId);
+        if (!state || !allowed.includes(state)) {
+            throw new IllegalMemberTransitionError(
+                `${transition}: member ${memberId} is '${state ?? 'missing'}', `
+                + `expected one of ${allowed.join(', ')}`);
+        }
+    }
+
+    /** Finalize: provisioning -> ready with the materialized worktree key.
+     *  A member demoted to failed/interrupted by reconciliation while its
+     *  operation was still live still finalizes ready — a live operation's
+     *  own settlement wins that race. */
+    async markMemberReady(
+        workspaceIdentity: string,
+        groupId: string,
+        memberId: string,
+        worktreeKey: WorktreeKey
+    ): Promise<void> {
+        this.requireState(
+            workspaceIdentity, groupId, memberId,
+            ['provisioning', 'failed'], 'mark-ready');
+        await this.store.updateMember(workspaceIdentity, groupId, memberId, {
+            state: 'ready',
+            worktreeKey,
+        });
+    }
+
+    /**
+     * Settlement failure: -> failed with the outcome error code. Failed is
+     * a legal pre-state because a live operation's settlement rewrites the
+     * state on every outcome and wins races with reconciliation.
+     */
+    async markMemberFailed(
+        workspaceIdentity: string,
+        groupId: string,
+        memberId: string,
+        lastError: string
+    ): Promise<void> {
+        this.requireState(workspaceIdentity, groupId, memberId,
+            ['provisioning', 'planned', 'failed'], 'mark-failed');
+        await this.store.updateMember(workspaceIdentity, groupId, memberId, {
+            state: 'failed',
+            lastError,
+        });
+    }
+
+    /** Restart reconciliation: an in-flight member demotes to failed/interrupted. */
+    async demoteInterruptedMember(
+        workspaceIdentity: string,
+        groupId: string,
+        memberId: string
+    ): Promise<void> {
+        this.requireState(workspaceIdentity, groupId, memberId,
+            ['provisioning', 'planned'], 'demote-interrupted');
+        await this.store.updateMember(workspaceIdentity, groupId, memberId, {
+            state: 'failed',
+            lastError: 'interrupted',
+        });
+    }
+
+    /** Retry readmission: failed -> provisioning (the plan is never re-made). */
+    async readmitMemberForRetry(
+        workspaceIdentity: string,
+        groupId: string,
+        memberId: string
+    ): Promise<void> {
+        this.requireState(workspaceIdentity, groupId, memberId, ['failed'], 'retry-readmit');
+        await this.store.updateMember(workspaceIdentity, groupId, memberId, {
+            state: 'provisioning',
+            // The store treats undefined as "leave unchanged".
+            lastError: '',
+        });
+    }
+
+    /** Dismiss: failed -> removed. */
+    async removeFailedMember(
+        workspaceIdentity: string,
+        groupId: string,
+        memberId: string
+    ): Promise<void> {
+        this.requireState(workspaceIdentity, groupId, memberId, ['failed'], 'dismiss-member');
+        await this.store.removeMember(workspaceIdentity, groupId, memberId);
+    }
+
+    /** The physical worktree is gone: the member record is removed from any state. */
+    async removeMemberRecord(
+        workspaceIdentity: string,
+        groupId: string,
+        memberId: string
+    ): Promise<void> {
+        await this.store.removeMember(workspaceIdentity, groupId, memberId);
+    }
+
+    /** Assign the primary member; the store enforces the ready invariant. */
+    async assignPrimary(
+        workspaceIdentity: string,
+        groupId: string,
+        memberId: string
+    ): Promise<void> {
+        this.requireState(workspaceIdentity, groupId, memberId, ['ready'], 'assign-primary');
+        await this.store.setPrimaryMember(workspaceIdentity, groupId, memberId);
+    }
+}

--- a/tests/contract/worktrees/groupCreationController.test.js
+++ b/tests/contract/worktrees/groupCreationController.test.js
@@ -10,6 +10,9 @@ const {
 const {
     WorktreeGroupManifestStore,
 } = require('../../../out/worktrees/groupManifestStore');
+const {
+    WorktreeMemberLifecycle,
+} = require('../../../out/worktrees/memberLifecycle');
 
 const workspace = {
     navigationIdentity: 'navigation:workspace',
@@ -64,6 +67,7 @@ function fixture(overrides = {}) {
         ],
     };
     const options = {
+        memberLifecycle: new WorktreeMemberLifecycle(manifestStore),
         getWorkspaceTarget: projectId => projectId === 'project'
             ? { workspace } : null,
         getWorktreeSnapshot: () => snapshot,

--- a/tests/unit/architecture/architectureChange.test.js
+++ b/tests/unit/architecture/architectureChange.test.js
@@ -305,6 +305,16 @@ test('ARCH-CHANGE-GATE-001 the policy delta covers invariants, baseline, and wai
     assert.deepEqual(report.policyDelta.writersGrown, { 'ARCH-TEST-001': ['src/alpha/b.ts'] });
     assert.deepEqual(report.policyDelta.waiversAdded, ['ARCH-WAIVER-009']);
     assert.deepEqual(report.policyDelta.baselineGrown, ['2:MOD-A->MOD-B']);
+
+    // An authority move (writer set shrinks while gaining the new authority
+    // file) is tightening, not broadening.
+    write('docs/testing/architecture-invariants.json', {
+        version: 1,
+        invariants: [{ ...invariant, writers: ['src/alpha/coordinator.ts'] }],
+    });
+    const moved = collectArchitectureDiff({ rootDirectory: root, baseRef: 'base', git });
+    assert.deepEqual(moved.policyDelta.writersGrown, {},
+        'a shrunk writer set with a replacement is not broadening');
 });
 
 test('ARCH-CHANGE-GATE-001 a self-diff against HEAD is a clean product-only report', () => {

--- a/tests/unit/worktrees/groupManifestReconciliation.test.js
+++ b/tests/unit/worktrees/groupManifestReconciliation.test.js
@@ -3,6 +3,7 @@
 const assert = require('node:assert/strict');
 const test = require('node:test');
 const { WorktreeGroupManifestStore } = require('../../../out/worktrees/groupManifestStore');
+const { WorktreeMemberLifecycle } = require('../../../out/worktrees/memberLifecycle');
 const {
     reconcileWorktreeGroupManifest,
 } = require('../../../out/worktrees/groupManifestReconciliation');
@@ -58,7 +59,7 @@ test('WORKTREE-GROUPS-003 seeds extension-created worktrees as one-worktree grou
             }),
         ],
     }]);
-    await reconcileWorktreeGroupManifest({ store, workspaceIdentity: WORKSPACE, snapshot: content });
+    await reconcileWorktreeGroupManifest({ store, memberLifecycle: new WorktreeMemberLifecycle(store), workspaceIdentity: WORKSPACE, snapshot: content });
     const groups = store.listGroups(WORKSPACE);
     assert.equal(groups.length, 2,
         'same slug across repositories stays two separate authoritative groups');
@@ -80,9 +81,9 @@ test('WORKTREE-GROUPS-003 reconciliation is idempotent across repeated snapshots
             branchRef: 'refs/heads/agent-pivot/fix-login',
         })],
     }]);
-    await reconcileWorktreeGroupManifest({ store, workspaceIdentity: WORKSPACE, snapshot: content });
+    await reconcileWorktreeGroupManifest({ store, memberLifecycle: new WorktreeMemberLifecycle(store), workspaceIdentity: WORKSPACE, snapshot: content });
     const first = store.listGroups(WORKSPACE);
-    await reconcileWorktreeGroupManifest({ store, workspaceIdentity: WORKSPACE, snapshot: content });
+    await reconcileWorktreeGroupManifest({ store, memberLifecycle: new WorktreeMemberLifecycle(store), workspaceIdentity: WORKSPACE, snapshot: content });
     const second = store.listGroups(WORKSPACE);
     assert.deepEqual(second, first);
 });
@@ -120,7 +121,8 @@ test('WORKTREE-GROUPS-003 recovery records migrate renamed branches with their o
         },
     }];
     await reconcileWorktreeGroupManifest({
-        store, workspaceIdentity: WORKSPACE, snapshot: content, recoveryRecords,
+        store, memberLifecycle: new WorktreeMemberLifecycle(store),
+        workspaceIdentity: WORKSPACE, snapshot: content, recoveryRecords,
     });
     const groups = store.listGroups(WORKSPACE);
     assert.equal(groups.length, 1,
@@ -173,7 +175,7 @@ test('WORKTREE-GROUPS-003 a recovery record bound to another navigation identity
         },
     };
     await reconcileWorktreeGroupManifest({
-        store, workspaceIdentity: WORKSPACE, snapshot: content,
+        store, memberLifecycle: new WorktreeMemberLifecycle(store), workspaceIdentity: WORKSPACE, snapshot: content,
         recoveryRecords: [foreignRecord],
     });
     const groups = store.listGroups(WORKSPACE);
@@ -217,7 +219,7 @@ test('WORKTREE-GROUPS-003 a foreign incomplete recovery still blocks ready seedi
         },
     };
     await reconcileWorktreeGroupManifest({
-        store, workspaceIdentity: WORKSPACE, snapshot: content,
+        store, memberLifecycle: new WorktreeMemberLifecycle(store), workspaceIdentity: WORKSPACE, snapshot: content,
         recoveryRecords: [foreignIncomplete],
     });
     assert.deepEqual(store.listGroups(WORKSPACE), [],
@@ -246,7 +248,7 @@ test('WORKTREE-GROUPS-003 WORKTREE-GROUPS-CREATE-001 in-flight members without a
     });
     const content = snapshot([]);
     await reconcileWorktreeGroupManifest({
-        store, workspaceIdentity: WORKSPACE, snapshot: content,
+        store, memberLifecycle: new WorktreeMemberLifecycle(store), workspaceIdentity: WORKSPACE, snapshot: content,
         activeGroupMemberIds: [],
     });
     let group = store.listGroups(WORKSPACE)[0];
@@ -262,7 +264,7 @@ test('WORKTREE-GROUPS-003 WORKTREE-GROUPS-CREATE-001 in-flight members without a
         state: 'provisioning', lastError: '',
     });
     await reconcileWorktreeGroupManifest({
-        store, workspaceIdentity: WORKSPACE, snapshot: content,
+        store, memberLifecycle: new WorktreeMemberLifecycle(store), workspaceIdentity: WORKSPACE, snapshot: content,
         activeGroupMemberIds: [group.members[0].memberId],
     });
     group = store.listGroups(WORKSPACE)[0];
@@ -325,7 +327,7 @@ test('WORKTREE-GROUPS-003 WORKTREE-GROUPS-CREATE-001 a snapshot refresh racing g
         },
     };
     await reconcileWorktreeGroupManifest({
-        store, workspaceIdentity: WORKSPACE, snapshot: content,
+        store, memberLifecycle: new WorktreeMemberLifecycle(store), workspaceIdentity: WORKSPACE, snapshot: content,
         recoveryRecords: [groupRecord],
         activeGroupMemberIds: [memberId],
     });
@@ -380,7 +382,7 @@ test('WORKTREE-GROUPS-003 a dismissed setup-incomplete tombstone still blocks re
         },
     };
     await reconcileWorktreeGroupManifest({
-        store, workspaceIdentity: WORKSPACE, snapshot: content,
+        store, memberLifecycle: new WorktreeMemberLifecycle(store), workspaceIdentity: WORKSPACE, snapshot: content,
         recoveryRecords: [tombstone],
     });
     assert.deepEqual(store.listGroups(WORKSPACE), [],
@@ -420,7 +422,7 @@ test('WORKTREE-GROUPS-003 an interrupted provisioning record blocks ready seedin
         },
     };
     await reconcileWorktreeGroupManifest({
-        store, workspaceIdentity: WORKSPACE, snapshot: content,
+        store, memberLifecycle: new WorktreeMemberLifecycle(store), workspaceIdentity: WORKSPACE, snapshot: content,
         recoveryRecords: [interruptedRecord],
     });
     assert.equal(store.listGroups(WORKSPACE).length, 0,
@@ -429,7 +431,7 @@ test('WORKTREE-GROUPS-003 an interrupted provisioning record blocks ready seedin
     // Once the record completes (or is dismissed and the worktree is
     // finished by hand), the next reconcile seeds it normally.
     await reconcileWorktreeGroupManifest({
-        store, workspaceIdentity: WORKSPACE, snapshot: content,
+        store, memberLifecycle: new WorktreeMemberLifecycle(store), workspaceIdentity: WORKSPACE, snapshot: content,
         recoveryRecords: [{ ...interruptedRecord, completedSteps: ['worktree', 'setup'] }],
     });
     assert.equal(store.listGroups(WORKSPACE).length, 1);

--- a/tests/unit/worktrees/memberLifecycle.test.js
+++ b/tests/unit/worktrees/memberLifecycle.test.js
@@ -1,0 +1,104 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+    WorktreeGroupManifestStore,
+} = require('../../../out/worktrees/groupManifestStore');
+const {
+    WorktreeMemberLifecycle,
+} = require('../../../out/worktrees/memberLifecycle');
+
+const WORKSPACE = 'navigation:unit';
+
+function memento() {
+    const values = new Map();
+    return {
+        get: (key, fallback) => (values.has(key) ? values.get(key) : fallback),
+        update: async (key, value) => {
+            values.set(key, JSON.parse(JSON.stringify(value)));
+        },
+    };
+}
+
+async function fixture() {
+    const store = new WorktreeGroupManifestStore(memento());
+    const lifecycle = new WorktreeMemberLifecycle(store);
+    const group = await store.createGroup(WORKSPACE, {
+        displayName: 'Fix login',
+        suggestedSlug: 'fix-login',
+        members: [{
+            repositoryKey: '/alpha/.git',
+            branchName: 'agent-pivot/fix-login',
+            path: '/alpha/.worktrees/fix-login',
+            state: 'provisioning',
+        }],
+    });
+    return { store, lifecycle, memberId: group.members[0].memberId, groupId: group.groupId };
+}
+
+function memberState(store, groupId, memberId) {
+    return store.listGroups(WORKSPACE)[0]?.members
+        .find(member => member.memberId === memberId)?.state;
+}
+
+test('ARCH-WORKTREE-MEMBER-WRITER-001 the legal transition table runs through the coordinator', async () => {
+    const { store, lifecycle, groupId, memberId } = await fixture();
+    const key = { repositoryKey: '/alpha/.git', canonicalWorktreePath: '/alpha/.worktrees/fix-login' };
+
+    await lifecycle.markMemberReady(WORKSPACE, groupId, memberId, key);
+    assert.equal(memberState(store, groupId, memberId), 'ready');
+    await lifecycle.assignPrimary(WORKSPACE, groupId, memberId);
+    assert.equal(store.listGroups(WORKSPACE)[0].primaryMemberId, memberId);
+
+    await lifecycle.removeMemberRecord(WORKSPACE, groupId, memberId);
+    assert.equal(store.listGroups(WORKSPACE).length, 0,
+        'removing the last member removes the group record');
+});
+
+test('ARCH-WORKTREE-MEMBER-WRITER-001 retry readmission and dismissal stay on the failed rail', async () => {
+    const { store, lifecycle, groupId, memberId } = await fixture();
+    await lifecycle.markMemberFailed(WORKSPACE, groupId, memberId, 'setup-failed');
+    assert.equal(memberState(store, groupId, memberId), 'failed');
+
+    await lifecycle.readmitMemberForRetry(WORKSPACE, groupId, memberId);
+    assert.equal(memberState(store, groupId, memberId), 'provisioning');
+
+    await lifecycle.markMemberFailed(WORKSPACE, groupId, memberId, 'setup-failed');
+    await lifecycle.removeFailedMember(WORKSPACE, groupId, memberId);
+    assert.equal(store.listGroups(WORKSPACE).length, 0);
+});
+
+test('ARCH-WORKTREE-MEMBER-WRITER-001 illegal transitions fail closed with a coded error', async () => {
+    const { lifecycle, groupId, memberId } = await fixture();
+
+    await assert.rejects(
+        lifecycle.readmitMemberForRetry(WORKSPACE, groupId, memberId),
+        /illegal-member-transition|expected one of/,
+        'retry requires failed');
+    await assert.rejects(
+        lifecycle.removeFailedMember(WORKSPACE, groupId, memberId),
+        /expected one of/,
+        'dismiss requires failed');
+    await assert.rejects(
+        lifecycle.assignPrimary(WORKSPACE, groupId, memberId),
+        /expected one of/,
+        'primary requires ready');
+    await assert.rejects(
+        lifecycle.demoteInterruptedMember(WORKSPACE, groupId, memberId + '-missing'),
+        /expected one of/,
+        'demotion requires a known member');
+});
+
+test('ARCH-WORKTREE-MEMBER-WRITER-001 a live finalize still wins the demotion race', async () => {
+    const { store, lifecycle, groupId, memberId } = await fixture();
+    const key = { repositoryKey: '/alpha/.git', canonicalWorktreePath: '/alpha/.worktrees/fix-login' };
+
+    // Reconciliation demotes while the operation is still live…
+    await lifecycle.demoteInterruptedMember(WORKSPACE, groupId, memberId);
+    assert.equal(memberState(store, groupId, memberId), 'failed');
+    // …and the live operation's own finalize still lands ready.
+    await lifecycle.markMemberReady(WORKSPACE, groupId, memberId, key);
+    assert.equal(memberState(store, groupId, memberId), 'ready');
+});


### PR DESCRIPTION
## Summary

Two concerns landed on the shared program branch (owner accepted the mix for this PR):

**1. Guidance (docs)**
- `.skills/publishing-and-merging-github-prs`: after creating/updating a PR, verify it is mergeable with checks running — never leave a PR conflicting or red; plus the capability-audit rebase playbook (keep main's `audit.head`, regenerate with the tool, rerun behavior contracts before pushing).
- `AGENTS.md` non-negotiable 2 carries the one-line rule.

**2. Pilot S2 (production refactor, behavior-preserving)**
- New `src/worktrees/memberLifecycle.ts`: the single authority for member state transitions (invariant `ARCH-WORKTREE-MEMBER-WRITER-001`). Callers name the transition; legal pre-states are enforced at the boundary.
- Routed writers: dashboard finalize / removal callback / set-primary handler, creation-controller settle/retry/dismiss, reconciliation demotion. The demote-vs-finalize race keeps its documented winner (a live operation's finalize still lands ready), pinned by a dedicated test.
- Invariant catalog: member-writer family now declares exactly one writer; structural writes move to the new `ARCH-WORKTREE-MANIFEST-STRUCTURE-001` record (tightening; the single-writer guard confirms zero member-method calls outside the coordinator).

## Skill harvest

updated .skills/publishing-and-merging-github-prs — post-creation PR state check + audit-conflict playbook, from the #262 incident.

## Verification

- New coordinator tests 4/4; worktrees unit 170/170; worktrees contract 115/115; integration 435/435; architecture policy lane 59/59 (gate classifies the invariant-catalog tightening correctly).
- Full coverage gate locally: baseline passed, changed-line coverage 100% (160/160) against origin/main.
- `npm run test:behavior-contracts` green after the audit commits; `git diff --check` clean.