### PR TITLE
feat: split conversation status dots into this-window and all-window counts

### DIFF
--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "8c8f510f3fba3d5e6c95ea9c0bacc9238308b55d",
+        "head": "eaf81001f659b19d7dec593da7d33ec78c8d2a8d",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -430,7 +430,8 @@
             "88aed14d522c5f67189379584128227e8e8b953e",
             "8177023cc05077c52c9d013a0945bbb88a50ac71",
             "6f8a932716f4ddfeef19ec73db3db7fe208881f9",
-            "e98ea7f14b1c7d153526be0a3064797ee85ba6d2"
+            "e98ea7f14b1c7d153526be0a3064797ee85ba6d2",
+            "1947acf22b7aa1834ad3925ddc71f89eb315319a"
         ]
     },
     "capabilities": [
@@ -1907,7 +1908,8 @@
                 "6d2e4a699102a51e6fa14a4bf02b078970e70fad",
                 "46a7343292593e6f4894ba2634d0cae2226b51f3",
                 "0fed732eee67b22fe3e041711a80f16b213fc52b",
-                "3b8064d460afec74027e39d4c8f7e8120e9658af"
+                "3b8064d460afec74027e39d4c8f7e8120e9658af",
+                "eaf81001f659b19d7dec593da7d33ec78c8d2a8d"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",

--- a/media/conversationViewerScripts.js
+++ b/media/conversationViewerScripts.js
@@ -1801,42 +1801,48 @@
         if (commentsController.handleEscape(event)) return;
         sidebarController.handleEscape(event);
     });
-    function sessionStatusDotLabel(kind, count) {
-        if (kind === 'running') {
-            if (count === 0) return 'No AI sessions running';
-            return count === 1
-                ? '1 AI session running across all windows'
-                : count + ' AI sessions running across all windows';
+    function sessionStatusDotLabel(kind, localCount, totalCount) {
+        if (totalCount === 0) {
+            return kind === 'running'
+                ? 'No AI sessions running'
+                : 'No AI sessions need attention';
         }
-        if (count === 0) return 'No AI sessions need attention';
-        return count === 1
-            ? '1 AI session needs attention across all windows'
-            : count + ' AI sessions need attention across all windows';
+        return kind === 'running'
+            ? localCount + ' running in this window · ' + totalCount + ' across all windows'
+            : localCount + ' need attention in this window · ' + totalCount + ' across all windows';
     }
     function validSessionStatus(value) {
         if (!value || typeof value !== 'object' || Array.isArray(value)) {
             return false;
         }
         var keys = Object.keys(value);
-        return keys.length === 2
+        return keys.length === 4
             && keys.indexOf('runningSessions') !== -1
             && keys.indexOf('attentionSessions') !== -1
+            && keys.indexOf('runningSessionsLocal') !== -1
+            && keys.indexOf('attentionSessionsLocal') !== -1
             && Number.isSafeInteger(value.runningSessions)
             && value.runningSessions >= 0
             && value.runningSessions <= 100000
             && Number.isSafeInteger(value.attentionSessions)
             && value.attentionSessions >= 0
-            && value.attentionSessions <= 100000;
+            && value.attentionSessions <= 100000
+            && Number.isSafeInteger(value.runningSessionsLocal)
+            && value.runningSessionsLocal >= 0
+            && value.runningSessionsLocal <= value.runningSessions
+            && Number.isSafeInteger(value.attentionSessionsLocal)
+            && value.attentionSessionsLocal >= 0
+            && value.attentionSessionsLocal <= value.attentionSessions;
     }
-    function applySessionStatusDot(element, countElement, kind, count) {
-        var label = sessionStatusDotLabel(kind, count);
+    function applySessionStatusDot(element, countElement, kind, localCount, totalCount) {
+        var label = sessionStatusDotLabel(kind, localCount, totalCount);
         element.classList.toggle(
             'conversation-session-status-active',
-            count > 0
+            totalCount > 0
         );
         element.title = label;
         element.setAttribute('aria-label', label);
-        countElement.textContent = String(count);
+        countElement.textContent = localCount + '/' + totalCount;
     }
     function applySessionStatusMessage(message) {
         if (!message || typeof message !== 'object'
@@ -1855,12 +1861,14 @@
             sessionStatusRunning,
             sessionStatusRunningCount,
             'running',
+            message.status.runningSessionsLocal,
             message.status.runningSessions
         );
         applySessionStatusDot(
             sessionStatusAttention,
             sessionStatusAttentionCount,
             'attention',
+            message.status.attentionSessionsLocal,
             message.status.attentionSessions
         );
         return true;

--- a/src/aiSessions/conversation/sessionStatusController.ts
+++ b/src/aiSessions/conversation/sessionStatusController.ts
@@ -3,8 +3,14 @@
 import type * as vscode from 'vscode';
 
 export interface ConversationSessionStatus {
+    /** Running sessions across all windows. */
     runningSessions: number;
+    /** Sessions needing attention across all windows. */
     attentionSessions: number;
+    /** Running sessions in this window's workspace. */
+    runningSessionsLocal: number;
+    /** Sessions needing attention in this window's workspace. */
+    attentionSessionsLocal: number;
 }
 
 export interface ConversationViewerSessionStatusMessage {
@@ -35,31 +41,40 @@ function sanitizeSessionCount(value: unknown): number {
 export function sanitizeConversationSessionStatus(
     status: ConversationSessionStatus | undefined
 ): ConversationSessionStatus {
+    const runningSessions = sanitizeSessionCount(status?.runningSessions);
+    const attentionSessions = sanitizeSessionCount(status?.attentionSessions);
     return {
-        runningSessions: sanitizeSessionCount(status?.runningSessions),
-        attentionSessions: sanitizeSessionCount(status?.attentionSessions),
+        runningSessions,
+        attentionSessions,
+        // A window's own sessions are a subset of the cross-window total:
+        // never let a desynced reader report more local than global.
+        runningSessionsLocal: Math.min(
+            sanitizeSessionCount(status?.runningSessionsLocal),
+            runningSessions
+        ),
+        attentionSessionsLocal: Math.min(
+            sanitizeSessionCount(status?.attentionSessionsLocal),
+            attentionSessions
+        ),
     };
 }
 
 export function formatConversationSessionStatusLabel(
     kind: 'running' | 'attention',
-    count: number
+    localCount: number,
+    totalCount: number
 ): string {
-    const safeCount = sanitizeSessionCount(count);
+    const total = sanitizeSessionCount(totalCount);
+    const local = Math.min(sanitizeSessionCount(localCount), total);
+    if (total === 0) {
+        return kind === 'running'
+            ? 'No AI sessions running'
+            : 'No AI sessions need attention';
+    }
     if (kind === 'running') {
-        if (safeCount === 0) {
-            return 'No AI sessions running';
-        }
-        return safeCount === 1
-            ? '1 AI session running across all windows'
-            : `${safeCount} AI sessions running across all windows`;
+        return `${local} running in this window · ${total} across all windows`;
     }
-    if (safeCount === 0) {
-        return 'No AI sessions need attention';
-    }
-    return safeCount === 1
-        ? '1 AI session needs attention across all windows'
-        : `${safeCount} AI sessions need attention across all windows`;
+    return `${local} need attention in this window · ${total} across all windows`;
 }
 
 export class ConversationSessionStatusController {
@@ -94,7 +109,8 @@ export class ConversationSessionStatusController {
         if (!status) {
             return;
         }
-        const deliveryKey = `${status.runningSessions}:${status.attentionSessions}`;
+        const deliveryKey = `${status.runningSessions}:${status.attentionSessions}`
+            + `:${status.runningSessionsLocal}:${status.attentionSessionsLocal}`;
         if (deliveryKey === this.lastDeliveredKey) {
             return;
         }

--- a/src/aiSessions/conversation/viewerDocument.ts
+++ b/src/aiSessions/conversation/viewerDocument.ts
@@ -185,8 +185,8 @@ export function renderConversationViewerDocument(
         </div>
         <div class="conversation-session-status" data-conversation-session-status
             role="group" aria-label="Global AI session status">
-            ${renderSessionStatusDot('running', sessionStatus.runningSessions)}
-            ${renderSessionStatusDot('attention', sessionStatus.attentionSessions)}
+            ${renderSessionStatusDot('running', sessionStatus.runningSessionsLocal, sessionStatus.runningSessions)}
+            ${renderSessionStatusDot('attention', sessionStatus.attentionSessionsLocal, sessionStatus.attentionSessions)}
         </div>
         <nav class="conversation-navigation" aria-label="Conversation navigation">
             <button class="conversation-icon-button" type="button"
@@ -613,17 +613,18 @@ export function renderConversationViewerDocument(
 
 function renderSessionStatusDot(
     kind: 'running' | 'attention',
-    count: number
+    localCount: number,
+    totalCount: number
 ): string {
-    const label = formatConversationSessionStatusLabel(kind, count);
-    return `<span class="conversation-session-status-dot conversation-session-status-${kind}${count > 0
+    const label = formatConversationSessionStatusLabel(kind, localCount, totalCount);
+    return `<span class="conversation-session-status-dot conversation-session-status-${kind}${totalCount > 0
         ? ' conversation-session-status-active'
         : ''}"
         data-session-status-${kind} role="img"
         title="${escapeAttribute(label)}"
         aria-label="${escapeAttribute(label)}"></span><span
         class="conversation-session-status-count"
-        data-session-status-${kind}-count>${count}</span>`;
+        data-session-status-${kind}-count>${localCount}/${totalCount}</span>`;
 }
 
 function providerLabel(provider: AiSessionProviderId): string {

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -80,6 +80,8 @@ import AttentionBridgeClient from './aiSessions/attentionBridgeClient';
 import {
     getAttentionProjectKey,
     getAttentionProjectPath,
+    getAttentionProjectKeys,
+    getAttentionSummaryForProjectKeys,
     getLogicalAttentionSessionKey,
 } from './aiSessions/attentionProject';
 import { buildAttentionQueue } from './aiSessions/attentionQueue';
@@ -2348,13 +2350,30 @@ async function initializeDashboard(
                 ? readCodexProfileContextWindowForModel(model)
                 : undefined;
         },
-        readSessionStatus: () => ({
-            runningSessions: sumOpenWorkspaceRunningAiSessionCounts(
-                latestOpenWorkspaceAggregate
-            ),
-            attentionSessions: aiSessionAttentionController
-                .getEffectiveAggregate()?.sessions.length ?? 0,
-        }),
+        readSessionStatus: () => {
+            const attentionAggregate = aiSessionAttentionController
+                .getEffectiveAggregate();
+            // This window's workspace: running counts come from the bridge
+            // registration carrying our own instanceId; attention sessions
+            // filter by this window's root-derived project keys.
+            const ownRegistration = latestOpenWorkspaceAggregate?.registrations
+                .find(registration =>
+                    registration.instanceId === openWorkspaceBridgeClient?.instanceId);
+            const ownProjectKeys = getAttentionProjectKeys(
+                (getCurrentOpenWorkspace()?.roots || []).map(root => root.uri));
+            return {
+                runningSessions: sumOpenWorkspaceRunningAiSessionCounts(
+                    latestOpenWorkspaceAggregate
+                ),
+                attentionSessions: attentionAggregate?.sessions.length ?? 0,
+                runningSessionsLocal:
+                    ownRegistration?.workspace?.runningAiSessionCount ?? 0,
+                attentionSessionsLocal: attentionAggregate
+                    ? getAttentionSummaryForProjectKeys(
+                        ownProjectKeys, attentionAggregate).attentionCount
+                    : 0,
+            };
+        },
         submitPrompt: (viewerTarget, prompt) => submitConversationPrompt({
             getWorkspaceTarget: getCurrentWorkspaceActionTarget,
             getRuntime: getAiSessionRuntimeById,

--- a/src/webview/conversationViewerScripts.js
+++ b/src/webview/conversationViewerScripts.js
@@ -1801,42 +1801,48 @@
         if (commentsController.handleEscape(event)) return;
         sidebarController.handleEscape(event);
     });
-    function sessionStatusDotLabel(kind, count) {
-        if (kind === 'running') {
-            if (count === 0) return 'No AI sessions running';
-            return count === 1
-                ? '1 AI session running across all windows'
-                : count + ' AI sessions running across all windows';
+    function sessionStatusDotLabel(kind, localCount, totalCount) {
+        if (totalCount === 0) {
+            return kind === 'running'
+                ? 'No AI sessions running'
+                : 'No AI sessions need attention';
         }
-        if (count === 0) return 'No AI sessions need attention';
-        return count === 1
-            ? '1 AI session needs attention across all windows'
-            : count + ' AI sessions need attention across all windows';
+        return kind === 'running'
+            ? localCount + ' running in this window · ' + totalCount + ' across all windows'
+            : localCount + ' need attention in this window · ' + totalCount + ' across all windows';
     }
     function validSessionStatus(value) {
         if (!value || typeof value !== 'object' || Array.isArray(value)) {
             return false;
         }
         var keys = Object.keys(value);
-        return keys.length === 2
+        return keys.length === 4
             && keys.indexOf('runningSessions') !== -1
             && keys.indexOf('attentionSessions') !== -1
+            && keys.indexOf('runningSessionsLocal') !== -1
+            && keys.indexOf('attentionSessionsLocal') !== -1
             && Number.isSafeInteger(value.runningSessions)
             && value.runningSessions >= 0
             && value.runningSessions <= 100000
             && Number.isSafeInteger(value.attentionSessions)
             && value.attentionSessions >= 0
-            && value.attentionSessions <= 100000;
+            && value.attentionSessions <= 100000
+            && Number.isSafeInteger(value.runningSessionsLocal)
+            && value.runningSessionsLocal >= 0
+            && value.runningSessionsLocal <= value.runningSessions
+            && Number.isSafeInteger(value.attentionSessionsLocal)
+            && value.attentionSessionsLocal >= 0
+            && value.attentionSessionsLocal <= value.attentionSessions;
     }
-    function applySessionStatusDot(element, countElement, kind, count) {
-        var label = sessionStatusDotLabel(kind, count);
+    function applySessionStatusDot(element, countElement, kind, localCount, totalCount) {
+        var label = sessionStatusDotLabel(kind, localCount, totalCount);
         element.classList.toggle(
             'conversation-session-status-active',
-            count > 0
+            totalCount > 0
         );
         element.title = label;
         element.setAttribute('aria-label', label);
-        countElement.textContent = String(count);
+        countElement.textContent = localCount + '/' + totalCount;
     }
     function applySessionStatusMessage(message) {
         if (!message || typeof message !== 'object'
@@ -1855,12 +1861,14 @@
             sessionStatusRunning,
             sessionStatusRunningCount,
             'running',
+            message.status.runningSessionsLocal,
             message.status.runningSessions
         );
         applySessionStatusDot(
             sessionStatusAttention,
             sessionStatusAttentionCount,
             'attention',
+            message.status.attentionSessionsLocal,
             message.status.attentionSessions
         );
         return true;

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -4865,7 +4865,7 @@ test('CONVERSATION-OUTLINE-NAVIGATION-001 keeps every side-panel view usable acr
         .digest('hex');
     assert.equal(
         sha256(previousViewerScript),
-        '8a7392a219578d8656d7536763ea539e177b0756cab7ab68355f8268cf32c562',
+        '8bb72241064f277b57081af0ab80720bbefad27c8f0eea23fb7dbf6b0455c33f',
         'the previous Viewer fixture must stay byte-exact'
     );
     assert.equal(
@@ -11037,6 +11037,8 @@ test('CONVERSATION-SESSION-STATUS-001 renders reduced-motion-safe global Session
         readSessionStatus: () => ({
             runningSessions: 2,
             attentionSessions: 1,
+            runningSessionsLocal: 1,
+            attentionSessionsLocal: 1,
         }),
     });
     const running = page.locator('[data-session-status-running]');
@@ -11048,13 +11050,13 @@ test('CONVERSATION-SESSION-STATUS-001 renders reduced-motion-safe global Session
 
     assert.equal(
         await running.getAttribute('title'),
-        '2 AI sessions running across all windows'
+        '1 running in this window · 2 across all windows'
     );
-    assert.equal(await runningCount.textContent(), '2');
-    assert.equal(await attentionCount.textContent(), '1');
+    assert.equal(await runningCount.textContent(), '1/2');
+    assert.equal(await attentionCount.textContent(), '1/1');
     assert.equal(
         await attention.getAttribute('aria-label'),
-        '1 AI session needs attention across all windows'
+        '1 need attention in this window · 1 across all windows'
     );
     assert.equal(await running.evaluate(element =>
         element.classList.contains('conversation-session-status-active')
@@ -11076,20 +11078,25 @@ test('CONVERSATION-SESSION-STATUS-001 renders reduced-motion-safe global Session
         version: 1,
         requestId: correlation.requestId,
         subscriptionGeneration: correlation.generation,
-        status: { runningSessions: 0, attentionSessions: 3 },
+        status: {
+            runningSessions: 0,
+            attentionSessions: 3,
+            runningSessionsLocal: 0,
+            attentionSessionsLocal: 1,
+        },
     });
     assert.equal(
         await running.getAttribute('title'),
         'No AI sessions running'
     );
-    assert.equal(await runningCount.textContent(), '0');
-    assert.equal(await attentionCount.textContent(), '3');
+    assert.equal(await runningCount.textContent(), '0/0');
+    assert.equal(await attentionCount.textContent(), '1/3');
     assert.equal(await running.evaluate(element =>
         element.classList.contains('conversation-session-status-active')
     ), false);
     assert.equal(
         await attention.getAttribute('title'),
-        '3 AI sessions need attention across all windows'
+        '1 need attention in this window · 3 across all windows'
     );
 
     await sendPage(page, {
@@ -11097,18 +11104,28 @@ test('CONVERSATION-SESSION-STATUS-001 renders reduced-motion-safe global Session
         version: 1,
         requestId: correlation.requestId - 1,
         subscriptionGeneration: correlation.generation,
-        status: { runningSessions: 9, attentionSessions: 9 },
+        status: {
+            runningSessions: 9,
+            attentionSessions: 9,
+            runningSessionsLocal: 9,
+            attentionSessionsLocal: 9,
+        },
     });
     await sendPage(page, {
         type: 'conversation-viewer-session-status',
         version: 1,
         requestId: correlation.requestId + 1,
         subscriptionGeneration: correlation.generation + 1,
-        status: { runningSessions: 9, attentionSessions: 9 },
+        status: {
+            runningSessions: 9,
+            attentionSessions: 9,
+            runningSessionsLocal: 9,
+            attentionSessionsLocal: 9,
+        },
     });
     assert.equal(
         await attention.getAttribute('title'),
-        '3 AI sessions need attention across all windows',
+        '1 need attention in this window · 3 across all windows',
         'stale requestIds and foreign generations must be ignored'
     );
 

--- a/tests/integration/dashboard/conversationViewer.test.js
+++ b/tests/integration/dashboard/conversationViewer.test.js
@@ -435,8 +435,13 @@ test('WEBVIEW-AI-SESSION-CONVERSATION-VIEWER-001 opens and reuses one viewer in 
     ]);
 });
 
-test('CONVERSATION-SESSION-STATUS-001 embeds and publishes the correlated global Session status', async () => {
-    let status = { runningSessions: 2, attentionSessions: 1 };
+test('CONVERSATION-SESSION-STATUS-001 embeds and publishes the correlated local/global Session status', async () => {
+    let status = {
+        runningSessions: 2,
+        attentionSessions: 1,
+        runningSessionsLocal: 1,
+        attentionSessionsLocal: 1,
+    };
     const { viewer, panel } = createViewer({
         readSessionStatus: () => status,
     });
@@ -446,16 +451,16 @@ test('CONVERSATION-SESSION-STATUS-001 embeds and publishes the correlated global
         'data-conversation-session-status'
     ));
     assert.ok(panel.webview.html.includes(
-        '2 AI sessions running across all windows'
+        '1 running in this window · 2 across all windows'
     ));
     assert.ok(panel.webview.html.includes(
-        '1 AI session needs attention across all windows'
+        '1 need attention in this window · 1 across all windows'
     ));
     assert.ok(panel.webview.html.includes(
-        'data-session-status-running-count>2</span>'
+        'data-session-status-running-count>1/2</span>'
     ));
     assert.ok(panel.webview.html.includes(
-        'data-session-status-attention-count>1</span>'
+        'data-session-status-attention-count>1/1</span>'
     ));
     assert.ok(panel.webview.html.includes(
         'data-session-status-request-id'
@@ -473,23 +478,37 @@ test('CONVERSATION-SESSION-STATUS-001 embeds and publishes the correlated global
     assert.deepEqual(message.status, {
         runningSessions: 2,
         attentionSessions: 1,
+        runningSessionsLocal: 1,
+        attentionSessionsLocal: 1,
     });
 
     await viewer.publishSessionStatus();
     assert.equal(statusMessages().length, 1,
         'an unchanged status must not be reposted');
 
-    status = { runningSessions: 3, attentionSessions: 0 };
+    status = {
+        runningSessions: 3,
+        attentionSessions: 0,
+        runningSessionsLocal: 2,
+        attentionSessionsLocal: 0,
+    };
     await viewer.publishSessionStatus();
     assert.equal(statusMessages().length, 2);
     assert.deepEqual(statusMessages()[1].status, {
         runningSessions: 3,
         attentionSessions: 0,
+        runningSessionsLocal: 2,
+        attentionSessionsLocal: 0,
     });
 });
 
 test('CONVERSATION-SESSION-STATUS-001 republishes the status after a retarget even when unchanged', async () => {
-    const status = { runningSessions: 1, attentionSessions: 1 };
+    const status = {
+        runningSessions: 1,
+        attentionSessions: 1,
+        runningSessionsLocal: 1,
+        attentionSessionsLocal: 1,
+    };
     const { viewer, panel } = createViewer({
         readSessionStatus: () => status,
     });

--- a/tests/unit/aiSessions/conversationSessionStatusController.test.js
+++ b/tests/unit/aiSessions/conversationSessionStatusController.test.js
@@ -42,7 +42,7 @@ function createHarness(options = {}) {
 }
 
 test('CONVERSATION-SESSION-STATUS-001 publishes only changed correlated statuses', async () => {
-    let status = { runningSessions: 2, attentionSessions: 1 };
+    let status = { runningSessions: 2, attentionSessions: 1, runningSessionsLocal: 1, attentionSessionsLocal: 1 };
     const { controller, posted } = createHarness({
         readStatus: () => status,
     });
@@ -53,23 +53,25 @@ test('CONVERSATION-SESSION-STATUS-001 publishes only changed correlated statuses
         version: 1,
         requestId: 7,
         subscriptionGeneration: 2,
-        status: { runningSessions: 2, attentionSessions: 1 },
+        status: { runningSessions: 2, attentionSessions: 1, runningSessionsLocal: 1, attentionSessionsLocal: 1 },
     }]);
 
     await controller.publish();
     assert.equal(posted.length, 1, 'unchanged status must not be reposted');
 
-    status = { runningSessions: 3, attentionSessions: 0 };
+    status = { runningSessions: 3, attentionSessions: 0, runningSessionsLocal: 0, attentionSessionsLocal: 0 };
     await controller.publish();
     assert.equal(posted.length, 2);
     assert.deepEqual(posted[1].status, {
         runningSessions: 3,
         attentionSessions: 0,
+        runningSessionsLocal: 0,
+        attentionSessionsLocal: 0,
     });
 });
 
 test('CONVERSATION-SESSION-STATUS-001 retries after delivery failure and rebuilds only when current', async () => {
-    const status = { runningSessions: 1, attentionSessions: 1 };
+    const status = { runningSessions: 1, attentionSessions: 1, runningSessionsLocal: 1, attentionSessionsLocal: 0 };
     const current = createHarness({
         readStatus: () => status,
         delivered: false,
@@ -94,7 +96,7 @@ test('CONVERSATION-SESSION-STATUS-001 retries after delivery failure and rebuild
 });
 
 test('CONVERSATION-SESSION-STATUS-001 skips publishing without a panel, reader, or while suspended', async () => {
-    const status = { runningSessions: 1, attentionSessions: 0 };
+    const status = { runningSessions: 1, attentionSessions: 0, runningSessionsLocal: 1, attentionSessionsLocal: 0 };
     const noPanel = createHarness({ readStatus: () => status, noPanel: true });
     await noPanel.controller.publish();
     assert.equal(noPanel.posted.length, 0);
@@ -111,7 +113,7 @@ test('CONVERSATION-SESSION-STATUS-001 skips publishing without a panel, reader, 
 });
 
 test('CONVERSATION-SESSION-STATUS-001 republishes after target transitions even when unchanged', async () => {
-    const status = { runningSessions: 1, attentionSessions: 1 };
+    const status = { runningSessions: 1, attentionSessions: 1, runningSessionsLocal: 1, attentionSessionsLocal: 0 };
     const { controller, posted } = createHarness({
         readStatus: () => status,
     });
@@ -126,7 +128,7 @@ test('CONVERSATION-SESSION-STATUS-001 republishes after target transitions even 
 });
 
 test('CONVERSATION-SESSION-STATUS-001 does not rebuild when the panel changed during a failed delivery', async () => {
-    const status = { runningSessions: 1, attentionSessions: 1 };
+    const status = { runningSessions: 1, attentionSessions: 1, runningSessionsLocal: 1, attentionSessionsLocal: 0 };
     const harness = createHarness({
         readStatus: () => status,
         delivered: false,
@@ -145,19 +147,58 @@ test('CONVERSATION-SESSION-STATUS-001 sanitizes counts and formats labels', () =
     assert.deepEqual(sanitizeConversationSessionStatus(undefined), {
         runningSessions: 0,
         attentionSessions: 0,
+        runningSessionsLocal: 0,
+        attentionSessionsLocal: 0,
     });
     assert.deepEqual(sanitizeConversationSessionStatus({
         runningSessions: 1.9,
         attentionSessions: -2,
-    }), { runningSessions: 1, attentionSessions: 0 });
+    }), {
+        runningSessions: 1,
+        attentionSessions: 0,
+        runningSessionsLocal: 0,
+        attentionSessionsLocal: 0,
+    });
+    assert.deepEqual(sanitizeConversationSessionStatus({
+        runningSessions: 2,
+        attentionSessions: 3,
+        runningSessionsLocal: 1.9,
+        attentionSessionsLocal: 1,
+    }), {
+        runningSessions: 2,
+        attentionSessions: 3,
+        runningSessionsLocal: 1,
+        attentionSessionsLocal: 1,
+    });
+    assert.deepEqual(sanitizeConversationSessionStatus({
+        runningSessions: 2,
+        attentionSessions: 3,
+        runningSessionsLocal: 5,
+        attentionSessionsLocal: 4,
+    }), {
+        runningSessions: 2,
+        attentionSessions: 3,
+        runningSessionsLocal: 2,
+        attentionSessionsLocal: 3,
+    }, 'local counts clamp to the total — a window can never exceed it');
     assert.deepEqual(sanitizeConversationSessionStatus({
         runningSessions: Number.NaN,
         attentionSessions: Number.POSITIVE_INFINITY,
-    }), { runningSessions: 0, attentionSessions: 0 });
+    }), {
+        runningSessions: 0,
+        attentionSessions: 0,
+        runningSessionsLocal: 0,
+        attentionSessionsLocal: 0,
+    });
     assert.deepEqual(sanitizeConversationSessionStatus({
         runningSessions: 100001,
         attentionSessions: 250000.8,
-    }), { runningSessions: 100000, attentionSessions: 100000 },
+    }), {
+        runningSessions: 100000,
+        attentionSessions: 100000,
+        runningSessionsLocal: 0,
+        attentionSessionsLocal: 0,
+    },
     'counts must clamp to the Webview validator bound');
 
     const throwing = createHarness({
@@ -168,23 +209,31 @@ test('CONVERSATION-SESSION-STATUS-001 sanitizes counts and formats labels', () =
     assert.equal(throwing.controller.snapshot, undefined);
 
     const fractional = createHarness({
-        readStatus: () => ({ runningSessions: 2.7, attentionSessions: -1 }),
+        readStatus: () => ({
+            runningSessions: 2.7,
+            attentionSessions: -1,
+            runningSessionsLocal: 1.2,
+            attentionSessionsLocal: 0,
+        }),
     });
     assert.deepEqual(fractional.controller.snapshot, {
         runningSessions: 2,
         attentionSessions: 0,
+        runningSessionsLocal: 1,
+        attentionSessionsLocal: 0,
     });
 
-    assert.equal(formatConversationSessionStatusLabel('running', 0),
+    assert.equal(formatConversationSessionStatusLabel('running', 0, 0),
         'No AI sessions running');
-    assert.equal(formatConversationSessionStatusLabel('running', 1),
-        '1 AI session running across all windows');
-    assert.equal(formatConversationSessionStatusLabel('running', 4),
-        '4 AI sessions running across all windows');
-    assert.equal(formatConversationSessionStatusLabel('attention', 0),
+    assert.equal(formatConversationSessionStatusLabel('running', 1, 1),
+        '1 running in this window · 1 across all windows');
+    assert.equal(formatConversationSessionStatusLabel('running', 2, 4),
+        '2 running in this window · 4 across all windows');
+    assert.equal(formatConversationSessionStatusLabel('attention', 0, 0),
         'No AI sessions need attention');
-    assert.equal(formatConversationSessionStatusLabel('attention', 1),
-        '1 AI session needs attention across all windows');
-    assert.equal(formatConversationSessionStatusLabel('attention', 3),
-        '3 AI sessions need attention across all windows');
+    assert.equal(formatConversationSessionStatusLabel('attention', 1, 3),
+        '1 need attention in this window · 3 across all windows');
+    assert.equal(formatConversationSessionStatusLabel('attention', 5, 3),
+        '3 need attention in this window · 3 across all windows',
+        'labels clamp the local count to the total');
 });


### PR DESCRIPTION
## Summary

The AI Conversation header's status dots only carried **cross-window totals**. Each dot now shows the **local/total** pair (e.g. `2/5`), with the tooltip spelling both numbers out.

Data sources — no bridge or protocol changes:

- **Running**: this window's share comes from the bridge registration carrying our own `instanceId`; the total keeps summing every registration.
- **Attention**: this window's share filters the effective aggregate by this window's root-derived project keys (`getAttentionSummaryForProjectKeys`).

Details:

- Local counts sanitize clamped to their totals — a window never reports more local than global.
- Labels move from `2 AI sessions running across all windows` to `1 running in this window · 2 across all windows`; the zero state keeps the previous wording.
- The dot's active styling still follows the total (any window running lights the dot).
- Webview message validator gains the two local fields (exact-keys, range-checked, local ≤ total).
- The previous-generation script fixture hash is re-pinned after the webview script change.

## Verification

- `tests/unit/aiSessions/conversationSessionStatusController.test.js` — sanitize/clamp/label/publish-dedup updated and extended (local > total clamps).
- `tests/browser/conversationViewer.test.js` — 114/114, including the status-dot rendering and delta-application assertions for the `local/total` display.
- `tests/integration/dashboard/conversationViewer.test.js` — 95/95.
- Dashboard webview checks pass; `npm run test:coverage:ci` changed-line coverage 98.75%; `npm run test:behavior-contracts` pass; `git diff --check` clean.

## Skill harvest

none — incremental feature within the existing status pipeline; no reusable workflow gap.