### PR TITLE
refactor(worktrees): route the group merge write through the module handler (pilot S3)

### DIFF
--- a/docs/architecture/changes/ARCH-CHANGE-001.md
+++ b/docs/architecture/changes/ARCH-CHANGE-001.md
@@ -1,0 +1,50 @@
+# ARCH-CHANGE-001 — Route the worktree-group merge write through the module handler
+
+Date: 2026-08-18
+Status: approved by repository owner (pilot slice S3)
+Module: MOD-WORKTREE-LIFECYCLE
+
+## Problem and evidence
+
+Stage 1B finding P2: the composition root (`src/dashboard.ts`) called
+`worktreeGroupManifestStore.mergeGroups` directly from the
+`merge-worktree-groups` message handler — a bypass around the module's
+handler pattern (rename/deletion already route through
+`src/worktrees/group*Handler.ts`).
+
+## Old rule → new rule
+
+- Old: `ARCH-WORKTREE-MANIFEST-STRUCTURE-001` writers included
+  `src/dashboard.ts` as the caller of `mergeGroups`.
+- New: the merge write lives in `src/worktrees/groupMergeHandler.ts`;
+  `src/dashboard.ts` only wires it. The structural writer set changes from
+  seven files to eight because `src/dashboard.ts` remains a writer for the
+  generation-claim family (its composition closures are the ports).
+  Logical writers did not grow: the merge authority moved from the
+  composition root into the owning module.
+
+## Alternatives considered
+
+- Removing `src/dashboard.ts` from the set entirely: not possible yet — the
+  generation-claim admission closures still write there (a later pilot
+  slice addresses the claim family).
+- Keeping the merge call in the composition root: rejected; that is the
+  bypass being removed.
+
+## Compatibility and migration
+
+No protocol or persisted-format change. Behavior identical; the handler body
+moved verbatim. The settlement semantics are unchanged.
+
+## Tests
+
+- New `tests/unit/worktrees/groupMergeHandler.test.js` covers the seam
+  (drop-on-malformed, candidate re-derivation, double revision binding,
+  stale-revision fail-closed, warning copy).
+- `tests/unit/architecture/singleWriters.test.js` proves the writer set is
+  coherent.
+
+## Rollback
+
+Revert the merge commit; the former inline handler is restored and the
+writer-set entry returns to `src/dashboard.ts`.

--- a/docs/testing/architecture-invariants.json
+++ b/docs/testing/architecture-invariants.json
@@ -269,12 +269,13 @@
             },
             "writers": [
                 "src/dashboard.ts",
-                "src/worktrees/groupCreationController.ts",
-                "src/worktrees/groupDeletionHandler.ts",
                 "src/worktrees/deletionController.ts",
                 "src/worktrees/groupAdoptHandler.ts",
-                "src/worktrees/groupRenameHandler.ts",
-                "src/worktrees/groupManifestReconciliation.ts"
+                "src/worktrees/groupCreationController.ts",
+                "src/worktrees/groupDeletionHandler.ts",
+                "src/worktrees/groupManifestReconciliation.ts",
+                "src/worktrees/groupMergeHandler.ts",
+                "src/worktrees/groupRenameHandler.ts"
             ],
             "linearizationPoint": "The versioned manifest commit succeeds.",
             "enforcement": [
@@ -313,7 +314,8 @@
                     "setRepositoryDetached",
                     "resetCorruptRetiredStore"
                 ]
-            }
+            },
+            "tracking": "ARCH-CHANGE-001"
         }
     ]
 }

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -6811,5 +6811,19 @@
       "src/dashboard/worktreeGroupFormHandlers.ts",
       "src/dashboard.ts"
     ]
+  },
+  {
+    "id": "WORKTREE-GROUPS-MERGE-001",
+    "domain": "session",
+    "title": "The worktree group merge handler drops malformed or unroutable messages, re-derives candidates host-side, binds both revisions captured when the dialog opened, and fails closed with a warning on drift",
+    "priority": "P1",
+    "status": "automated",
+    "owners": [
+      "tests/unit/worktrees/groupMergeHandler.test.js"
+    ],
+    "evidence": [
+      "src/worktrees/groupMergeHandler.ts",
+      "src/dashboard.ts"
+    ]
   }
 ]

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "eaf81001f659b19d7dec593da7d33ec78c8d2a8d",
+        "head": "6b7f25cd3c95201996caeb0879f7c7c00da4fd65",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -2245,7 +2245,7 @@
                 "33dd08d563b7d9e1e04352c4869af6f10fad9b2e",
                 "1b69d7ed8be4f331227185c364ea43a1259a9688",
                 "fce4b85cacbaae9b3d7d74404c8f21ec6ace1b3d",
-                "2808223b86429bdc11bb7bf3e61d81e225e43a2f"
+                "6b7f25cd3c95201996caeb0879f7c7c00da4fd65"
             ],
             "behaviors": [
                 "WORKTREE-GROUPS-BASELINE-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2244,14 +2244,16 @@
                 "8d27256aaefe7d1eee5c021cf8058da9e2a58c8c",
                 "33dd08d563b7d9e1e04352c4869af6f10fad9b2e",
                 "1b69d7ed8be4f331227185c364ea43a1259a9688",
-                "fce4b85cacbaae9b3d7d74404c8f21ec6ace1b3d"
+                "fce4b85cacbaae9b3d7d74404c8f21ec6ace1b3d",
+                "2808223b86429bdc11bb7bf3e61d81e225e43a2f"
             ],
             "behaviors": [
                 "WORKTREE-GROUPS-BASELINE-001",
                 "WORKTREE-CHANGES-COLLECT-001",
                 "WORKTREE-CHANGES-PANEL-001",
                 "WORKTREE-GROUPS-CREATE-001",
-                "WORKTREE-GROUPS-CREATE-HANDLER-001"
+                "WORKTREE-GROUPS-CREATE-HANDLER-001",
+                "WORKTREE-GROUPS-MERGE-001"
             ],
             "prGates": [
                 "test:deterministic:run",

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -262,6 +262,8 @@ import {
     GitRepositoryStateMonitor,
 } from './worktrees/gitRepositoryStateMonitor';
 import { WorktreeMemberLifecycle } from './worktrees/memberLifecycle';
+import { handleMergeWorktreeGroups } from './worktrees/groupMergeHandler';
+import type { MergeWorktreeGroupsPick } from './worktrees/groupMergeHandler';
 import { WorktreeSnapshotCoordinator } from './worktrees/snapshotCoordinator';
 import { worktreeKeysEqual, worktreeKeysMatch, worktreeKeyTombstoneKey } from './worktrees/types';
 import type { WorktreeKey } from './worktrees/types';
@@ -2584,73 +2586,20 @@ async function initializeDashboard(
                 settledManagedWorktreeRemovalSettlement(request, outcome));
         },
         'merge-worktree-groups': async (message: unknown) => {
-            // Migration-suggested group → group merge (PRD §6.5): the webview
-            // submits only the source group; the host stays authoritative by
-            // re-deriving same-slug candidates and confirming via QuickPick.
-            const request = (message && typeof message === 'object')
-                ? message as { projectId?: unknown; sourceGroupId?: unknown }
-                : {};
-            if (typeof request.projectId !== 'string'
-                || typeof request.sourceGroupId !== 'string'
-                || !request.sourceGroupId) {
-                return;
-            }
-            const target = getCurrentWorkspaceActionTarget(request.projectId);
-            if (!target) {
-                return;
-            }
-            const bucket = target.workspace.navigationIdentity;
-            const groups = worktreeGroupManifestStore.listGroups(bucket);
-            const source = groups.find(group => group.groupId === request.sourceGroupId);
-            if (!source) {
-                return;
-            }
-            // M3 batch 8 (PRD §6.5): merge is no longer slug-gated — any
-            // other group is a candidate; same-slug groups sort first as
-            // the migration-era hint.
-            const candidates = groups
-                .filter(group => group.groupId !== source.groupId)
-                .sort((left, right) =>
-                    Number(right.suggestedSlug === source.suggestedSlug)
-                    - Number(left.suggestedSlug === source.suggestedSlug));
-            if (candidates.length === 0) {
-                return;
-            }
-            type MergePick = vscode.QuickPickItem & { groupId: string };
-            const picks: MergePick[] = candidates.map(group => ({
-                label: group.displayName,
-                description: group.members.map(member => member.branchName).join(' · '),
-                groupId: group.groupId,
-            }));
-            const chosen = await vscode.window.showQuickPick(picks, {
-                placeHolder: `Merge "${source.displayName}" into…`,
-            });
-            if (!chosen) {
-                return;
-            }
-            // Double revision binding (decision G): the revisions captured
-            // when the dialog opened must still hold at the write.
-            const expectedRevisions = {
-                targetRevision: chosen.groupId
-                    ? groups.find(group => group.groupId === chosen.groupId)?.revision ?? -1
-                    : -1,
-                sourceRevision: source.revision,
-            };
-            try {
-                await worktreeGroupManifestStore.mergeGroups(
-                    bucket, chosen.groupId, source.groupId, expectedRevisions);
-            } catch (error) {
-                const code = (error as { code?: string })?.code || 'merge-failed';
-                void vscode.window.showWarningMessage(
-                    code === 'repository-conflict'
-                        ? 'These groups cannot be merged: both contain a worktree of the same repository. Remove one of them first.'
-                        : code === 'group-changed'
-                            ? 'A group changed while the merge was open. Review and try again.'
-                            : 'The groups could not be merged. Try again.');
-                return;
-            }
-            void aiSessionDashboardController.refreshNow('worktree-groups-merged', {
-                fallbackToFullRefresh: false,
+            await handleMergeWorktreeGroups(message, {
+                getNavigationIdentity: projectId =>
+                    getCurrentWorkspaceActionTarget(projectId)
+                        ?.workspace.navigationIdentity || null,
+                store: worktreeGroupManifestStore,
+                showQuickPick: (items, placeHolder) =>
+                    vscode.window.showQuickPick<MergeWorktreeGroupsPick>(
+                        items, { placeHolder }),
+                showWarning: warning => {
+                    void vscode.window.showWarningMessage(warning);
+                },
+                refreshNow: () => aiSessionDashboardController.refreshNow(
+                    'worktree-groups-merged', { fallbackToFullRefresh: false }),
+                logError,
             });
         },
         'rename-worktree-group': async (message: unknown) => {

--- a/src/worktrees/groupMergeHandler.ts
+++ b/src/worktrees/groupMergeHandler.ts
@@ -1,0 +1,96 @@
+'use strict';
+
+import type { WorktreeGroupManifestStore } from './groupManifestStore';
+
+export interface MergeWorktreeGroupsPick {
+    label: string;
+    description?: string;
+    groupId: string;
+}
+
+export interface MergeWorktreeGroupsHandlerDeps {
+    /** Resolves the caller's project to the current workspace bucket. */
+    getNavigationIdentity: (projectId: string) => string | null;
+    store: WorktreeGroupManifestStore;
+    showQuickPick: (
+        items: MergeWorktreeGroupsPick[],
+        placeHolder: string
+    ) => Thenable<MergeWorktreeGroupsPick | undefined>;
+    showWarning: (message: string) => void;
+    /** Awaits publication of the authoritative replacement. */
+    refreshNow: () => Promise<void>;
+    logError: (message: string, error: unknown) => void;
+}
+
+/**
+ * Migration-suggested group → group merge (PRD §6.5): the webview submits
+ * only the source group; the host stays authoritative by re-deriving the
+ * candidates and confirming via QuickPick. M3 batch 8: merge is no longer
+ * slug-gated — any other group is a candidate; same-slug groups sort first
+ * as the migration-era hint. Double revision binding (decision G): the
+ * revisions captured when the dialog opened must still hold at the write.
+ *
+ * Extracted verbatim from the composition root so the merge seam is
+ * testable; behavior is identical to the former inline handler.
+ */
+export async function handleMergeWorktreeGroups(
+    message: unknown,
+    deps: MergeWorktreeGroupsHandlerDeps
+): Promise<void> {
+    const request = (message && typeof message === 'object')
+        ? message as { projectId?: unknown; sourceGroupId?: unknown }
+        : {};
+    if (typeof request.projectId !== 'string'
+        || typeof request.sourceGroupId !== 'string'
+        || !request.sourceGroupId) {
+        return;
+    }
+    const bucket = deps.getNavigationIdentity(request.projectId);
+    if (!bucket) {
+        return;
+    }
+    const groups = deps.store.listGroups(bucket);
+    const source = groups.find(group => group.groupId === request.sourceGroupId);
+    if (!source) {
+        return;
+    }
+    const candidates = groups
+        .filter(group => group.groupId !== source.groupId)
+        .sort((left, right) =>
+            Number(right.suggestedSlug === source.suggestedSlug)
+            - Number(left.suggestedSlug === source.suggestedSlug));
+    if (candidates.length === 0) {
+        return;
+    }
+    const picks: MergeWorktreeGroupsPick[] = candidates.map(group => ({
+        label: group.displayName,
+        description: group.members.map(member => member.branchName).join(' · '),
+        groupId: group.groupId,
+    }));
+    const chosen = await deps.showQuickPick(picks,
+        `Merge "${source.displayName}" into…`);
+    if (!chosen) {
+        return;
+    }
+    const expectedRevisions = {
+        targetRevision: chosen.groupId
+            ? groups.find(group => group.groupId === chosen.groupId)?.revision ?? -1
+            : -1,
+        sourceRevision: source.revision,
+    };
+    try {
+        await deps.store.mergeGroups(
+            bucket, chosen.groupId, source.groupId, expectedRevisions);
+    } catch (error) {
+        const code = (error as { code?: string })?.code || 'merge-failed';
+        deps.showWarning(
+            code === 'repository-conflict'
+                ? 'These groups cannot be merged: both contain a worktree of the same repository. Remove one of them first.'
+                : code === 'group-changed'
+                    ? 'A group changed while the merge was open. Review and try again.'
+                    : 'The groups could not be merged. Try again.');
+        return;
+    }
+    // Fire-and-forget, exactly as the inline handler did.
+    void deps.refreshNow();
+}

--- a/tests/unit/worktrees/groupMergeHandler.test.js
+++ b/tests/unit/worktrees/groupMergeHandler.test.js
@@ -1,0 +1,111 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+    WorktreeGroupManifestStore,
+} = require('../../../out/worktrees/groupManifestStore');
+const {
+    handleMergeWorktreeGroups,
+} = require('../../../out/worktrees/groupMergeHandler');
+
+const WORKSPACE = 'navigation:unit';
+
+function memento() {
+    const values = new Map();
+    return {
+        get: (key, fallback) => (values.has(key) ? values.get(key) : fallback),
+        update: async (key, value) => {
+            values.set(key, JSON.parse(JSON.stringify(value)));
+        },
+    };
+}
+
+function readyMember(repositoryKey, slug) {
+    return {
+        repositoryKey,
+        branchName: `agent-pivot/${slug}`,
+        path: `/repo/.worktrees/${slug}`,
+        state: 'ready',
+        worktreeKey: { repositoryKey, canonicalWorktreePath: `/repo/.worktrees/${slug}` },
+    };
+}
+
+async function fixture(twoGroups = true) {
+    const store = new WorktreeGroupManifestStore(memento());
+    await store.createGroup(WORKSPACE, {
+        displayName: 'Fix login', suggestedSlug: 'fix-login',
+        members: [readyMember('/alpha/.git', 'fix-login')],
+    });
+    if (twoGroups) {
+        await store.createGroup(WORKSPACE, {
+            displayName: 'Fix login (2)', suggestedSlug: 'fix-login',
+            members: [readyMember('/beta/.git', 'fix-login-2')],
+        });
+    }
+    const shown = { picks: null, placeHolder: null, warnings: [], refreshed: 0 };
+    const deps = {
+        getNavigationIdentity: projectId => (projectId === 'project' ? WORKSPACE : null),
+        store,
+        showQuickPick: async (picks, placeHolder) => {
+            shown.picks = picks;
+            shown.placeHolder = placeHolder;
+            return deps.pickResult;
+        },
+        showWarning: message => shown.warnings.push(message),
+        refreshNow: async () => { shown.refreshed += 1; },
+        logError: () => {},
+        pickResult: undefined,
+    };
+    return { store, deps, shown };
+}
+
+const sourceGroupId = store => store.listGroups(WORKSPACE)[0].groupId;
+
+test('WORKTREE-GROUPS-MERGE-001 malformed or unroutable messages are dropped without any UI', async () => {
+    const { deps, shown } = await fixture();
+    await handleMergeWorktreeGroups(null, deps);
+    await handleMergeWorktreeGroups({ type: 'merge-worktree-groups' }, deps);
+    await handleMergeWorktreeGroups(
+        { projectId: 'project', sourceGroupId: 'missing' }, deps);
+    await handleMergeWorktreeGroups(
+        { projectId: 'other-project', sourceGroupId: 'x' }, deps);
+    assert.equal(shown.picks, null);
+    assert.equal(shown.refreshed, 0);
+});
+
+test('WORKTREE-GROUPS-MERGE-001 the host re-derives candidates and merges with the double revision binding', async () => {
+    const { store, deps, shown } = await fixture();
+    deps.pickResult = undefined; // first: dialog dismissed
+    await handleMergeWorktreeGroups(
+        { projectId: 'project', sourceGroupId: sourceGroupId(store) }, deps);
+    assert.equal(shown.picks.length, 1);
+    assert.equal(shown.refreshed, 0, 'a dismissed dialog changes nothing');
+
+    const groups = store.listGroups(WORKSPACE);
+    deps.pickResult = { label: 'Fix login (2)', groupId: groups[1].groupId };
+    await handleMergeWorktreeGroups(
+        { projectId: 'project', sourceGroupId: groups[0].groupId }, deps);
+    const merged = store.listGroups(WORKSPACE);
+    assert.equal(merged.length, 1);
+    assert.equal(merged[0].groupId, groups[1].groupId, 'source merged into the chosen target');
+    assert.equal(merged[0].members.length, 2);
+    assert.equal(shown.refreshed, 1);
+});
+
+test('WORKTREE-GROUPS-MERGE-001 a revision drift between dialog and write warns and writes nothing', async () => {
+    const { store, deps, shown } = await fixture();
+    const groups = store.listGroups(WORKSPACE);
+    deps.showQuickPick = async (picks) => {
+        // The source group changes while the dialog is open.
+        await store.renameGroup(WORKSPACE, groups[0].groupId, 'Renamed while open');
+        return { label: 'target', groupId: groups[1].groupId };
+    };
+    await handleMergeWorktreeGroups(
+        { projectId: 'project', sourceGroupId: groups[0].groupId }, deps);
+    assert.equal(store.listGroups(WORKSPACE).length, 2, 'stale merge writes nothing');
+    assert.equal(shown.warnings.length, 1);
+    assert.ok(shown.warnings[0].includes('changed while the merge was open'));
+    assert.equal(shown.refreshed, 0);
+});


### PR DESCRIPTION
## Summary

Stage 4 pilot migration, slice S3 (Stage 1B finding P2): the composition root called `worktreeGroupManifestStore.mergeGroups` directly from the `merge-worktree-groups` message handler.

- The handler body moves **verbatim** into `src/worktrees/groupMergeHandler.ts` — the module's handler pattern, matching rename/deletion. `src/dashboard.ts` only wires it (host QuickPick/warning/refresh injected as deps).
- **ARCH-CHANGE-001** records the accompanying policy move: `groupMergeHandler.ts` joins the structural writer set; the merge authority moved from the composition root into the module (logical writers did not grow). The anti-self-amendment gate classifies this PR as relaxing-with-record and passes.
- New `tests/unit/worktrees/groupMergeHandler.test.js`: drop-on-malformed, candidate re-derivation, double revision binding, stale-revision fail-closed with the exact warning copy.
- Behavior contract `WORKTREE-GROUPS-MERGE-001` registers the seam.

Deferred with evidence (not in this slice): manifest-store dead-API removal — the no-caller methods (`addMember`, `deleteGroup`, `recordRetiredIdentity`, `removeRetiredIdentity`, `resetCorruptRetiredStore`, `nextGenerationCutoff`, `listDeletionHistory`) are used as probe instruments by journal-lease tests, so removal needs test-instrument rework in its own slice.

## Skill harvest

no skill change — the slice followed the encoded flows; nothing new to harvest.

## Verification

- Compile clean; worktrees unit 177/177; worktrees contract 115/115; integration lane 435/435; architecture policy lane green (gate classifies relaxing + record present); architecture guards pass.
- Full coverage gate locally: baseline passed, changed-line coverage 96.88% against origin/main.
- `npm run test:behavior-contracts` green after the audit commits; `git diff --check` clean.