### PR TITLE
feat(worktrees): replay caches for adopt and claim-discard (pilot S4a)

### DIFF
--- a/docs/testing/architecture-invariants.json
+++ b/docs/testing/architecture-invariants.json
@@ -208,7 +208,7 @@
             ],
             "priority": "P1",
             "kind": "protocol",
-            "statement": "Every pilot mutation message carries a correlation envelope (requestId, version) and a documented exactly-once mechanism (replay cache or single-use token); the known gaps (confirm replay cache, set-primary/merge/adopt/discard-claim correlation, merge requestId) are migration slice S4 targets.",
+            "statement": "Every pilot mutation message carries a correlation envelope (requestId, version) and a documented exactly-once mechanism: confirm uses the single-use preview token; rename, deletion, adopt, and claim-discard use settlement replay caches; set-primary is an idempotent write; retry/dismiss are gated by member state. The merge family envelope is slice S4b.",
             "authority": {
                 "path": "src/worktrees/groupCreationProtocol.ts",
                 "symbol": "parseConfirmWorktreeGroupRequest"
@@ -219,6 +219,8 @@
                 "behavior"
             ],
             "behaviorOwners": [
+                "tests/unit/worktrees/groupAdoptMerge.test.js",
+                "tests/unit/worktrees/groupDeletionHandler.test.js",
                 "tests/browser/worktreeGroupForm.test.js"
             ],
             "guardOwners": [],

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -6825,5 +6825,21 @@
       "src/worktrees/groupMergeHandler.ts",
       "src/dashboard.ts"
     ]
+  },
+  {
+    "id": "WORKTREE-GROUPS-REPLAY-001",
+    "domain": "session",
+    "title": "Adopt and claim-discard mutations settle replays from the cache without re-executing; expired request ids fail closed as request-expired",
+    "priority": "P1",
+    "status": "automated",
+    "owners": [
+      "tests/unit/worktrees/groupAdoptMerge.test.js",
+      "tests/unit/worktrees/groupDeletionHandler.test.js"
+    ],
+    "evidence": [
+      "src/worktrees/groupAdoptHandler.ts",
+      "src/worktrees/groupDeletionHandler.ts",
+      "src/worktrees/settlementReplayCache.ts"
+    ]
   }
 ]

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "6b7f25cd3c95201996caeb0879f7c7c00da4fd65",
+        "head": "7aa265837b767e4406b39b67b0e0a7c9e0573201",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -431,7 +431,10 @@
             "8177023cc05077c52c9d013a0945bbb88a50ac71",
             "6f8a932716f4ddfeef19ec73db3db7fe208881f9",
             "e98ea7f14b1c7d153526be0a3064797ee85ba6d2",
-            "1947acf22b7aa1834ad3925ddc71f89eb315319a"
+            "1947acf22b7aa1834ad3925ddc71f89eb315319a",
+            "496dbb7e3b5c6045c060ca2107c2cb434668db37",
+            "93c6e7aa8df4cddcca48803963be4179f65873e6",
+            "02177bb71f45a6426a23a60a82f40b722408ec3d"
         ]
     },
     "capabilities": [
@@ -2245,7 +2248,8 @@
                 "33dd08d563b7d9e1e04352c4869af6f10fad9b2e",
                 "1b69d7ed8be4f331227185c364ea43a1259a9688",
                 "fce4b85cacbaae9b3d7d74404c8f21ec6ace1b3d",
-                "6b7f25cd3c95201996caeb0879f7c7c00da4fd65"
+                "6b7f25cd3c95201996caeb0879f7c7c00da4fd65",
+                "7aa265837b767e4406b39b67b0e0a7c9e0573201"
             ],
             "behaviors": [
                 "WORKTREE-GROUPS-BASELINE-001",
@@ -2253,7 +2257,8 @@
                 "WORKTREE-CHANGES-PANEL-001",
                 "WORKTREE-GROUPS-CREATE-001",
                 "WORKTREE-GROUPS-CREATE-HANDLER-001",
-                "WORKTREE-GROUPS-MERGE-001"
+                "WORKTREE-GROUPS-MERGE-001",
+                "WORKTREE-GROUPS-REPLAY-001"
             ],
             "prGates": [
                 "test:deterministic:run",

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -313,6 +313,7 @@ import {
 import type { WorktreeGroupDeletionSettlement } from './worktrees/groupDeletionProtocol';
 import { fallbackRepositoryLabel } from './workspaces/worktreeGroupProjection';
 import { handleAdoptWorktrees } from './worktrees/groupAdoptHandler';
+import type { WorktreeAdoptSettlement } from './worktrees/groupAdoptProtocol';
 import { resolveGenerationClaimDisposition } from './worktrees/generationClaimReconciliation';
 import {
     acceptedIsolatedSessionSettlement,
@@ -2483,6 +2484,8 @@ async function initializeDashboard(
     // Idempotency cache for group rename settlements (PRD §6.4 protocol
     // rules): replays re-receive the recorded terminal settlement and are
     // never re-executed.
+    const worktreeAdoptSettlements = createSettlementReplayCache<
+        WorktreeAdoptSettlement>();
     const worktreeGroupRenameSettlements = createSettlementReplayCache<
         WorktreeGroupRenameSettlement>();
     const worktreeGroupDeletionSettlements = createSettlementReplayCache<
@@ -2646,6 +2649,7 @@ async function initializeDashboard(
                         ?.workspace.navigationIdentity || null,
                 store: worktreeGroupManifestStore,
                 getWorktreeSnapshot: () => worktreeSnapshotCoordinator.getSnapshot(),
+                replayCache: worktreeAdoptSettlements,
                 refreshNow: () => aiSessionDashboardController.refreshNow(
                     'worktrees-adopted', { fallbackToFullRefresh: true }),
                 logError,

--- a/src/worktrees/groupAdoptHandler.ts
+++ b/src/worktrees/groupAdoptHandler.ts
@@ -5,9 +5,11 @@ import {
     parseAdoptWorktreesRequest,
     settledWorktreeAdoptSettlement,
 } from './groupAdoptProtocol';
+import type { AdoptWorktreesRequest, WorktreeAdoptSettlement } from './groupAdoptProtocol';
 import type { WorktreeGroupManifestStore } from './groupManifestStore';
 import { WorktreeGroupManifestError } from './groupManifestStore';
 import { slugifyTaskName } from './provisioningPlan';
+import type { SettlementReplayCache } from './settlementReplayCache';
 import type { WorktreeSnapshot } from './types';
 import { worktreeKeysEqual } from './types';
 
@@ -24,6 +26,8 @@ export interface WorktreeAdoptHandlerDeps {
     getWorktreeSnapshot: () => WorktreeSnapshot | null;
     refreshNow: () => Promise<void>;
     logError: (message: string, error: unknown) => void;
+    /** Exactly-once replay protection (rename/deletion family pattern). */
+    replayCache: SettlementReplayCache<WorktreeAdoptSettlement>;
 }
 
 export async function handleAdoptWorktrees(
@@ -34,16 +38,36 @@ export async function handleAdoptWorktrees(
     if (!request) {
         return;
     }
-    await deps.postMessage(acceptedWorktreeAdoptSettlement(request));
-    const fail = async (errorCode: string) => {
+    // Single-flight per request id: a replay — even a concurrent one —
+    // awaits and re-receives the first execution's terminal settlement.
+    const replayed = deps.replayCache.get(request.requestId);
+    if (replayed) {
+        await deps.postMessage(await replayed);
+        return;
+    }
+    if (deps.replayCache.isExpired(request.requestId)) {
+        // The settlement aged out of the bounded cache: re-executing could
+        // flip an old outcome, so expired replays fail closed.
         await deps.postMessage(settledWorktreeAdoptSettlement(
-            request, { kind: 'failed', errorCode }));
-    };
+            request, { kind: 'failed', errorCode: 'request-expired' }));
+        return;
+    }
+    const terminal = executeAdoptWorktrees(request, deps);
+    deps.replayCache.remember(request.requestId, terminal);
+    await deps.postMessage(await terminal);
+}
+
+async function executeAdoptWorktrees(
+    request: AdoptWorktreesRequest,
+    deps: WorktreeAdoptHandlerDeps
+): Promise<WorktreeAdoptSettlement> {
+    await deps.postMessage(acceptedWorktreeAdoptSettlement(request));
+    const fail = (errorCode: string) =>
+        settledWorktreeAdoptSettlement(request, { kind: 'failed', errorCode });
     const navigationIdentity = deps.getNavigationIdentity(request.projectId);
     const snapshot = deps.getWorktreeSnapshot();
     if (!navigationIdentity || !snapshot) {
-        await fail('workspace-unavailable');
-        return;
+        return fail('workspace-unavailable');
     }
     const groups = deps.store.listGroups(navigationIdentity);
     const members = [];
@@ -57,8 +81,7 @@ export async function handleAdoptWorktrees(
             }));
         if (!worktree || worktree.isMain || worktree.isBare
             || worktree.health !== 'normal') {
-            await fail('worktree-unavailable');
-            return;
+            return fail('worktree-unavailable');
         }
         const claimed = groups.some(group => group.members.some(member =>
             member.worktreeKey && worktreeKeysEqual(member.worktreeKey, {
@@ -66,8 +89,7 @@ export async function handleAdoptWorktrees(
                 canonicalWorktreePath: key.canonicalWorktreePath,
             })));
         if (claimed) {
-            await fail('worktree-key-claimed');
-            return;
+            return fail('worktree-key-claimed');
         }
         members.push({
             repositoryKey: key.repositoryKey,
@@ -85,15 +107,13 @@ export async function handleAdoptWorktrees(
             const group = await deps.store.adoptReadyMembers(
                 navigationIdentity, request.targetGroupId, members);
             await deps.refreshNow();
-            await deps.postMessage(settledWorktreeAdoptSettlement(
-                request, { kind: 'settled', groupId: group.groupId }));
-            return;
+            return settledWorktreeAdoptSettlement(
+                request, { kind: 'settled', groupId: group.groupId });
         }
         const displayName = (request.displayName || '').trim();
         const slug = slugifyTaskName(displayName);
         if (!displayName || !slug) {
-            await fail('invalid-task');
-            return;
+            return fail('invalid-task');
         }
         const group = await deps.store.createGroup(navigationIdentity, {
             displayName,
@@ -101,11 +121,11 @@ export async function handleAdoptWorktrees(
             members,
         });
         await deps.refreshNow();
-        await deps.postMessage(settledWorktreeAdoptSettlement(
-            request, { kind: 'settled', groupId: group.groupId }));
+        return settledWorktreeAdoptSettlement(
+            request, { kind: 'settled', groupId: group.groupId });
     } catch (error) {
         deps.logError('Failed to adopt worktrees.', error);
-        await fail(error instanceof WorktreeGroupManifestError
+        return fail(error instanceof WorktreeGroupManifestError
             ? error.code
             : 'adopt-failed');
     }

--- a/src/worktrees/groupDeletionHandler.ts
+++ b/src/worktrees/groupDeletionHandler.ts
@@ -13,6 +13,7 @@ import {
     WorktreeGroupDeletionPreview,
     WorktreeGroupDeletionSettlement,
 } from './groupDeletionProtocol';
+import type { DiscardWorktreeGenerationClaimRequest } from './groupDeletionProtocol';
 import type { WorktreeGroupManifestStore } from './groupManifestStore';
 import { WorktreeGroupManifestError } from './groupManifestStore';
 import type { SettlementReplayCache } from './settlementReplayCache';
@@ -374,6 +375,34 @@ export async function handleDiscardWorktreeGenerationClaim(
     if (!request) {
         return;
     }
+    // Single-flight per request id: a replay — even a concurrent one —
+    // awaits and re-receives the first execution's terminal settlement.
+    const replayed = deps.replayCache.get(request.requestId);
+    if (replayed) {
+        await deps.postMessage(await replayed);
+        return;
+    }
+    if (deps.replayCache.isExpired(request.requestId)) {
+        // The settlement aged out of the bounded cache: re-executing could
+        // flip an old outcome, so expired replays fail closed.
+        await deps.postMessage({
+            type: 'worktree-group-deletion-settlement', version: 1,
+            requestId: request.requestId,
+            projectId: request.projectId,
+            groupId: request.groupId,
+            status: 'failed', errorCode: 'request-expired',
+        } as WorktreeGroupDeletionSettlement);
+        return;
+    }
+    const terminal = executeDiscardWorktreeGenerationClaim(request, deps);
+    deps.replayCache.remember(request.requestId, terminal);
+    await deps.postMessage(await terminal);
+}
+
+async function executeDiscardWorktreeGenerationClaim(
+    request: DiscardWorktreeGenerationClaimRequest,
+    deps: WorktreeGroupDeletionHandlerDeps
+): Promise<WorktreeGroupDeletionSettlement> {
     const navigationIdentity = deps.getNavigationIdentity(request.projectId);
     let status: 'settled' | 'failed' = 'settled';
     let errorCode: string | undefined;
@@ -394,15 +423,14 @@ export async function handleDiscardWorktreeGenerationClaim(
             const belongsToGroup = !!group && !!claim && group.members.some(member =>
                 member.worktreeKey && worktreeKeysEqual(member.worktreeKey, claim.worktreeKey));
             if (!claim || claim.state !== 'pending' || !belongsToGroup) {
-                await deps.postMessage({
+                return {
                     type: 'worktree-group-deletion-settlement', version: 1,
                     requestId: request.requestId,
                     projectId: request.projectId,
                     groupId: request.groupId,
                     status: 'failed',
                     errorCode: 'claim-not-found',
-                } as WorktreeGroupDeletionSettlement);
-                return;
+                } as WorktreeGroupDeletionSettlement;
             }
             const removed = await deps.store.removeGenerationClaim(
                 navigationIdentity, request.claimId);
@@ -416,7 +444,7 @@ export async function handleDiscardWorktreeGenerationClaim(
             errorCode = manifestErrorCode(error);
         }
     }
-    await deps.postMessage({
+    return {
         type: 'worktree-group-deletion-settlement', version: 1,
         requestId: request.requestId,
         projectId: request.projectId,
@@ -429,5 +457,5 @@ export async function handleDiscardWorktreeGenerationClaim(
                     deps.store.getAggregateRevision(navigationIdentity),
             }
             : {}),
-    } as WorktreeGroupDeletionSettlement);
+    } as WorktreeGroupDeletionSettlement;
 }

--- a/tests/unit/worktrees/groupAdoptMerge.test.js
+++ b/tests/unit/worktrees/groupAdoptMerge.test.js
@@ -7,6 +7,9 @@ const {
     WorktreeGroupManifestError,
 } = require('../../../out/worktrees/groupManifestStore');
 const {
+    createSettlementReplayCache,
+} = require('../../../out/worktrees/settlementReplayCache');
+const {
     handleAdoptWorktrees,
 } = require('../../../out/worktrees/groupAdoptHandler');
 
@@ -122,6 +125,7 @@ test('WORKTREE-GROUPS-ADOPT-MERGE-001 the handler re-validates keys against snap
         getWorktreeSnapshot: () => snapshot,
         refreshNow: async () => undefined,
         logError: () => undefined,
+        replayCache: createSettlementReplayCache(),
     };
     const key = { repositoryKey: '/repos/alpha/.git', canonicalWorktreePath: '/repos/alpha/.worktrees/fix-login' };
     const adoptRequest = overrides => ({
@@ -149,6 +153,56 @@ test('WORKTREE-GROUPS-ADOPT-MERGE-001 the handler re-validates keys against snap
         members: [{ repositoryKey: '/repos/alpha/.git', canonicalWorktreePath: '/gone' }],
     }), deps);
     assert.equal(posted[posted.length - 1].errorCode, 'worktree-unavailable');
+});
+
+test('WORKTREE-GROUPS-REPLAY-001 a replayed adopt is settled from the cache, never re-executed', async () => {
+    const store = new WorktreeGroupManifestStore(memento());
+    const snapshot = {
+        revision: 1,
+        truncatedWorktreeCount: 0,
+        repositories: [{
+            repositoryKey: '/repos/alpha/.git',
+            rootBindings: [{ workspaceRootId: 'root', repositoryRelativePath: '' }],
+            worktrees: [{
+                key: {
+                    repositoryKey: '/repos/alpha/.git',
+                    canonicalWorktreePath: '/repos/alpha/.worktrees/fix-login',
+                },
+                branchRef: 'refs/heads/agent-pivot/fix-login',
+                head: 'a'.repeat(40), isMain: false, isBare: false,
+                health: 'normal', headKind: 'branch',
+            }],
+        }],
+    };
+    const posted = [];
+    const deps = {
+        postMessage: async message => { posted.push(message); },
+        getNavigationIdentity: () => WORKSPACE,
+        store,
+        getWorktreeSnapshot: () => snapshot,
+        refreshNow: async () => undefined,
+        logError: () => undefined,
+        replayCache: createSettlementReplayCache(),
+    };
+    const request = {
+        type: 'adopt-worktrees', version: 1,
+        requestId: 'adopt-replay-n1-1', projectId: '/repo/main',
+        members: [{
+            repositoryKey: '/repos/alpha/.git',
+            canonicalWorktreePath: '/repos/alpha/.worktrees/fix-login',
+        }],
+        displayName: 'Fix login',
+    };
+    await handleAdoptWorktrees(request, deps);
+    assert.equal(store.listGroups(WORKSPACE).length, 1);
+    assert.deepEqual(posted.map(message => message.status), ['accepted', 'settled']);
+
+    await handleAdoptWorktrees(request, deps);
+    assert.equal(store.listGroups(WORKSPACE).length, 1,
+        'the replay never creates a second group');
+    assert.deepEqual(posted.map(message => message.status),
+        ['accepted', 'settled', 'settled'],
+        'the replay re-receives the recorded terminal settlement');
 });
 
 test('WORKTREE-GROUPS-ADOPT-MERGE-001 the handler adopts into an existing group', async () => {
@@ -187,6 +241,7 @@ test('WORKTREE-GROUPS-ADOPT-MERGE-001 the handler adopts into an existing group'
         getWorktreeSnapshot: () => snapshot,
         refreshNow: async () => undefined,
         logError: () => undefined,
+        replayCache: createSettlementReplayCache(),
     });
     assert.equal(posted[posted.length - 1].status, 'settled');
     assert.equal(posted[posted.length - 1].groupId, group.groupId);

--- a/tests/unit/worktrees/groupDeletionHandler.test.js
+++ b/tests/unit/worktrees/groupDeletionHandler.test.js
@@ -436,6 +436,82 @@ test('WORKTREE-GROUPS-GROUP-DELETE-001 partial group failure keeps residue and r
     assert.equal(store.listRetiredIdentities(WORKSPACE).length, 2);
 });
 
+test('WORKTREE-GROUPS-REPLAY-001 a replayed claim discard is settled from the cache, never re-executed', async () => {
+    const { store, group, deps, posted } = await fixture();
+    const target = group.members[0];
+    const first = await store.beginDeletion(WORKSPACE, {
+        groupId: group.groupId, mode: 'member', memberIds: [target.memberId],
+        replacementPrimaryMemberId: group.members[1].memberId, nowMs: 100,
+    });
+    await store.checkpointDeletedMember(WORKSPACE, first.operationId, target.memberId, 110);
+    const retired = store.listRetiredIdentities(WORKSPACE)[0];
+    const claim = await store.createGenerationClaim(WORKSPACE, {
+        pendingId: 'pending-1',
+        worktreeKey: target.worktreeKey,
+        createdAfterRetirementId: retired.retirementId,
+        createdAtMs: 200,
+        creatingProvider: 'codex',
+    });
+    await store.addMember(WORKSPACE, group.groupId, {
+        repositoryKey: target.repositoryKey,
+        worktreeKey: target.worktreeKey,
+        branchName: target.branchName,
+        path: target.path,
+        state: 'ready',
+    });
+    const request = {
+        type: 'discard-worktree-generation-claim',
+        version: 1,
+        requestId: 'group-claim-discard-replay-1',
+        projectId: '/repo/main',
+        groupId: group.groupId,
+        claimId: claim.claimId,
+    };
+    await handleDiscardWorktreeGenerationClaim(request, deps);
+    assert.equal(posted[posted.length - 1].status, 'settled');
+    assert.equal(store.listGenerationClaims(WORKSPACE).length, 0);
+
+    await handleDiscardWorktreeGenerationClaim(request, deps);
+    assert.equal(posted[posted.length - 1].status, 'settled',
+        'the replay re-receives the recorded settlement instead of failing claim-not-found');
+    assert.equal(
+        posted.filter(message => message.type === 'worktree-group-deletion-settlement').length,
+        2, 'exactly one execution plus one replayed settlement');
+});
+
+test('WORKTREE-GROUPS-REPLAY-001 an expired claim-discard replay fails closed and a missing claim fails without side effects', async () => {
+    const { store, group, deps, posted } = await fixture();
+    const request = overrides => ({
+        type: 'discard-worktree-generation-claim',
+        version: 1,
+        projectId: '/repo/main',
+        groupId: group.groupId,
+        claimId: 'claim-missing',
+        ...(overrides || {}),
+    });
+    // A missing claim settles failed as claim-not-found, changing nothing.
+    await handleDiscardWorktreeGenerationClaim(
+        request({ requestId: 'group-claim-discard-missing-1' }), deps);
+    let settled = posted[posted.length - 1];
+    assert.equal(settled.status, 'failed');
+    assert.equal(settled.errorCode, 'claim-not-found');
+
+    // Expiry: settle a request, age it out of a size-1 cache, then replay —
+    // the expired replay must fail closed rather than re-execute.
+    const tinyCache = createSettlementReplayCache(1);
+    deps.replayCache = tinyCache;
+    await handleDiscardWorktreeGenerationClaim(
+        request({ requestId: 'group-claim-discard-old-1' }), deps);
+    await handleDiscardWorktreeGenerationClaim(
+        request({ requestId: 'group-claim-discard-newer-1' }), deps);
+    assert.equal(tinyCache.isExpired('group-claim-discard-old-1'), true);
+    await handleDiscardWorktreeGenerationClaim(
+        request({ requestId: 'group-claim-discard-old-1' }), deps);
+    settled = posted[posted.length - 1];
+    assert.equal(settled.status, 'failed');
+    assert.equal(settled.errorCode, 'request-expired');
+});
+
 test('WORKTREE-GROUPS-MEMBER-DELETE-001 malformed messages are ignored without side effects', async () => {
     const { store, group, deps, posted } = await fixture();
     await handleDeleteWorktreeGroupMember({ type: 'delete-worktree-group-member' }, deps);


### PR DESCRIPTION
## Summary

Stage 4 pilot migration, slice S4a — uniform exactly-once semantics across the pilot mutation families (invariant `ARCH-WORKTREE-PROTOCOL-ENVELOPE-001`).

- **adopt** and **claim-discard** now use the settlement replay cache (the rename/deletion family pattern): a replay — even concurrent — re-receives the recorded terminal settlement and never re-executes; an expired request id fails closed as `request-expired`.
- The invariant record now documents each family's mechanism: confirm = single-use preview token; retry/dismiss = member-state gates; set-primary = idempotent write; rename/delete/adopt/discard-claim = replay caches. The merge family's envelope is slice S4b.
- New replay characterization tests for both families (cache re-service, no re-execution, expiry fail-closed, claim-not-found); registers `WORKTREE-GROUPS-REPLAY-001`.

Behavior change is limited to duplicate delivery: replays now re-receive the recorded settlement instead of failing `claim-not-found` / re-executing — the invariant's documented intent.

## Skill harvest

no skill change — the slice followed the encoded flows.

## Verification

- New/updated suites: adopt+merge 5/5, deletion handler 15/15; worktrees unit 179/179; worktrees contract 115/115.
- Architecture policy lane 59/59; architecture guards pass; `npm run test:behavior-contracts` green.
- Full coverage gate locally: baseline passed, changed-line coverage 88.73% against origin/main.
- `git diff --check` clean.