### PR TITLE
feat(worktrees): correlated envelope and replay cache for group merge (pilot S4b)

### DIFF
--- a/docs/testing/architecture-invariants.json
+++ b/docs/testing/architecture-invariants.json
@@ -208,7 +208,7 @@
             ],
             "priority": "P1",
             "kind": "protocol",
-            "statement": "Every pilot mutation message carries a correlation envelope (requestId, version) and a documented exactly-once mechanism: confirm uses the single-use preview token; rename, deletion, adopt, and claim-discard use settlement replay caches; set-primary is an idempotent write; retry/dismiss are gated by member state. The merge family envelope is slice S4b.",
+            "statement": "Every pilot mutation message carries a correlation envelope (requestId, version) and a documented exactly-once mechanism: confirm uses the single-use preview token; rename, deletion, adopt, claim-discard, and merge use settlement replay caches; set-primary is an idempotent write; retry/dismiss are gated by member state.",
             "authority": {
                 "path": "src/worktrees/groupCreationProtocol.ts",
                 "symbol": "parseConfirmWorktreeGroupRequest"
@@ -226,6 +226,7 @@
             "guardOwners": [],
             "evidence": [
                 "src/worktrees/groupCreationProtocol.ts",
+                "src/worktrees/groupMergeProtocol.ts",
                 "src/dashboard.ts"
             ]
         },

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -6815,14 +6815,16 @@
   {
     "id": "WORKTREE-GROUPS-MERGE-001",
     "domain": "session",
-    "title": "The worktree group merge handler drops malformed or unroutable messages, re-derives candidates host-side, binds both revisions captured when the dialog opened, and fails closed with a warning on drift",
+    "title": "The worktree group merge family carries a versioned correlated envelope (accepted to merged/cancelled/failed) with replay-cache exactly-once semantics, re-derives candidates host-side, binds both revisions captured when the dialog opened, and fails closed on drift",
     "priority": "P1",
     "status": "automated",
     "owners": [
-      "tests/unit/worktrees/groupMergeHandler.test.js"
+      "tests/unit/worktrees/groupMergeHandler.test.js",
+      "tests/unit/worktrees/groupMergeProtocol.test.js"
     ],
     "evidence": [
       "src/worktrees/groupMergeHandler.ts",
+      "src/worktrees/groupMergeProtocol.ts",
       "src/dashboard.ts"
     ]
   },

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "7aa265837b767e4406b39b67b0e0a7c9e0573201",
+        "head": "b6284995ef315fae40d8e1e803b2eb1adacfc650",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -434,7 +434,8 @@
             "1947acf22b7aa1834ad3925ddc71f89eb315319a",
             "496dbb7e3b5c6045c060ca2107c2cb434668db37",
             "93c6e7aa8df4cddcca48803963be4179f65873e6",
-            "02177bb71f45a6426a23a60a82f40b722408ec3d"
+            "02177bb71f45a6426a23a60a82f40b722408ec3d",
+            "3ed5c0b0d8097a25017a522680c82218f90571b4"
         ]
     },
     "capabilities": [
@@ -2249,7 +2250,8 @@
                 "1b69d7ed8be4f331227185c364ea43a1259a9688",
                 "fce4b85cacbaae9b3d7d74404c8f21ec6ace1b3d",
                 "6b7f25cd3c95201996caeb0879f7c7c00da4fd65",
-                "7aa265837b767e4406b39b67b0e0a7c9e0573201"
+                "7aa265837b767e4406b39b67b0e0a7c9e0573201",
+                "b6284995ef315fae40d8e1e803b2eb1adacfc650"
             ],
             "behaviors": [
                 "WORKTREE-GROUPS-BASELINE-001",

--- a/media/webviewDashboardBundle.js
+++ b/media/webviewDashboardBundle.js
@@ -4564,6 +4564,8 @@ function initProjectAiSessionControls(options) {
     var pendingIsolatedSessionRequests = new Map();
     var nextManagedWorktreeRemovalRequestId = 0;
     var pendingManagedWorktreeRemovalRequests = new Map();
+    var nextMergeWorktreeGroupsRequestId = 0;
+    var pendingMergeWorktreeGroupsRequests = new Map();
     var nextSetGroupPrimaryRequestId = 0;
     var pendingSetGroupPrimaryRequests = new Map();
     var worktreeGroupForm = null;
@@ -4775,11 +4777,10 @@ function initProjectAiSessionControls(options) {
             '[data-action="merge-worktree-groups"][data-group-id]'
         );
         if (mergeGroupsAction) {
-            window.vscode.postMessage({
-                type: 'merge-worktree-groups',
-                projectId: projectId,
-                sourceGroupId: mergeGroupsAction.getAttribute('data-group-id'),
-            });
+            submitMergeWorktreeGroups(
+                projectId,
+                mergeGroupsAction.getAttribute('data-group-id'),
+                mergeGroupsAction);
             return true;
         }
         var setPrimaryAction = target.closest(
@@ -5435,6 +5436,55 @@ function initProjectAiSessionControls(options) {
             return;
         }
         closeAiSessionWorktreeMenu();
+    }
+
+    function submitMergeWorktreeGroups(projectId, sourceGroupId, actionElement) {
+        if (!projectId || !sourceGroupId || !actionElement) return;
+        if (pendingMergeWorktreeGroupsRequests.size > 0) return;
+        nextMergeWorktreeGroupsRequestId = nextMergeWorktreeGroupsRequestId
+            >= Number.MAX_SAFE_INTEGER ? 1 : nextMergeWorktreeGroupsRequestId + 1;
+        var requestId = 'worktree-merge-' + nextMergeWorktreeGroupsRequestId.toString(36);
+        actionElement.setAttribute('aria-disabled', 'true');
+        pendingMergeWorktreeGroupsRequests.set(requestId, {
+            actionElement: actionElement,
+            projectId: projectId,
+        });
+        window.vscode.postMessage({
+            type: 'merge-worktree-groups', version: 1,
+            requestId: requestId, projectId: projectId,
+            sourceGroupId: sourceGroupId,
+        });
+    }
+
+    function applyWorktreeGroupMergeSettlement(message) {
+        var expectedKeys = message && typeof message.errorCode === 'string'
+            ? ['errorCode', 'requestId', 'status', 'type', 'version']
+            : message && typeof message.groupId === 'string'
+                ? ['groupId', 'requestId', 'status', 'type', 'version']
+                : ['requestId', 'status', 'type', 'version'];
+        if (!message || message.type !== 'worktree-group-merge-settlement'
+            || message.version !== 1
+            || Object.keys(message).length !== expectedKeys.length
+            || Object.keys(message).sort().some((key, index) => key !== expectedKeys[index])
+            || typeof message.requestId !== 'string' || !message.requestId
+            || !['accepted', 'merged', 'cancelled', 'failed'].includes(message.status)
+            || (Object.prototype.hasOwnProperty.call(message, 'errorCode')
+                && !/^[a-z0-9-]{1,64}$/.test(message.errorCode))) return false;
+        var pending = pendingMergeWorktreeGroupsRequests.get(message.requestId);
+        if (!pending) return true;
+        if (message.status === 'accepted') return true;
+        pendingMergeWorktreeGroupsRequests.delete(message.requestId);
+        if (pending.actionElement && pending.actionElement.isConnected) {
+            pending.actionElement.removeAttribute('aria-disabled');
+        }
+        var projectDiv = getAiSessionsUpdate().findCurrentWorkspaceDiv(pending.projectId);
+        var liveRegion = projectDiv?.querySelector('[data-ai-session-live-region]');
+        if (liveRegion && message.status !== 'cancelled') {
+            liveRegion.textContent = message.status === 'merged'
+                ? 'Worktree groups merged.'
+                : `Worktree group merge failed: ${message.errorCode || 'unknown'}`;
+        }
+        return true;
     }
 
     function submitManagedWorktreeRemoval(projectId, group, button) {
@@ -7401,6 +7451,7 @@ function initProjectAiSessionControls(options) {
         applyIsolatedSessionSettlement: applyIsolatedSessionSettlement,
         applyManagedWorktreeRemovalSettlement: applyManagedWorktreeRemovalSettlement,
         applySetGroupPrimarySettlement: applySetGroupPrimarySettlement,
+        applyWorktreeGroupMergeSettlement: applyWorktreeGroupMergeSettlement,
         applyWorktreeGroupRenameSettlement: applyWorktreeGroupRenameSettlement,
         applyWorktreeGroupDeletionPreview: applyWorktreeGroupDeletionPreview,
         applyWorktreeGroupDeletionSettlement: applyWorktreeGroupDeletionSettlement,
@@ -8051,6 +8102,11 @@ function initProjects() {
 
         if (message && message.type === 'managed-worktree-removal-settlement') {
             aiSessionControls.applyManagedWorktreeRemovalSettlement(message);
+            return;
+        }
+
+        if (message && message.type === 'worktree-group-merge-settlement') {
+            aiSessionControls.applyWorktreeGroupMergeSettlement(message);
             return;
         }
 

--- a/media/webviewProjectAiSessionControlsScripts.js
+++ b/media/webviewProjectAiSessionControlsScripts.js
@@ -80,6 +80,8 @@ function initProjectAiSessionControls(options) {
     var pendingIsolatedSessionRequests = new Map();
     var nextManagedWorktreeRemovalRequestId = 0;
     var pendingManagedWorktreeRemovalRequests = new Map();
+    var nextMergeWorktreeGroupsRequestId = 0;
+    var pendingMergeWorktreeGroupsRequests = new Map();
     var nextSetGroupPrimaryRequestId = 0;
     var pendingSetGroupPrimaryRequests = new Map();
     var worktreeGroupForm = null;
@@ -291,11 +293,10 @@ function initProjectAiSessionControls(options) {
             '[data-action="merge-worktree-groups"][data-group-id]'
         );
         if (mergeGroupsAction) {
-            window.vscode.postMessage({
-                type: 'merge-worktree-groups',
-                projectId: projectId,
-                sourceGroupId: mergeGroupsAction.getAttribute('data-group-id'),
-            });
+            submitMergeWorktreeGroups(
+                projectId,
+                mergeGroupsAction.getAttribute('data-group-id'),
+                mergeGroupsAction);
             return true;
         }
         var setPrimaryAction = target.closest(
@@ -951,6 +952,55 @@ function initProjectAiSessionControls(options) {
             return;
         }
         closeAiSessionWorktreeMenu();
+    }
+
+    function submitMergeWorktreeGroups(projectId, sourceGroupId, actionElement) {
+        if (!projectId || !sourceGroupId || !actionElement) return;
+        if (pendingMergeWorktreeGroupsRequests.size > 0) return;
+        nextMergeWorktreeGroupsRequestId = nextMergeWorktreeGroupsRequestId
+            >= Number.MAX_SAFE_INTEGER ? 1 : nextMergeWorktreeGroupsRequestId + 1;
+        var requestId = 'worktree-merge-' + nextMergeWorktreeGroupsRequestId.toString(36);
+        actionElement.setAttribute('aria-disabled', 'true');
+        pendingMergeWorktreeGroupsRequests.set(requestId, {
+            actionElement: actionElement,
+            projectId: projectId,
+        });
+        window.vscode.postMessage({
+            type: 'merge-worktree-groups', version: 1,
+            requestId: requestId, projectId: projectId,
+            sourceGroupId: sourceGroupId,
+        });
+    }
+
+    function applyWorktreeGroupMergeSettlement(message) {
+        var expectedKeys = message && typeof message.errorCode === 'string'
+            ? ['errorCode', 'requestId', 'status', 'type', 'version']
+            : message && typeof message.groupId === 'string'
+                ? ['groupId', 'requestId', 'status', 'type', 'version']
+                : ['requestId', 'status', 'type', 'version'];
+        if (!message || message.type !== 'worktree-group-merge-settlement'
+            || message.version !== 1
+            || Object.keys(message).length !== expectedKeys.length
+            || Object.keys(message).sort().some((key, index) => key !== expectedKeys[index])
+            || typeof message.requestId !== 'string' || !message.requestId
+            || !['accepted', 'merged', 'cancelled', 'failed'].includes(message.status)
+            || (Object.prototype.hasOwnProperty.call(message, 'errorCode')
+                && !/^[a-z0-9-]{1,64}$/.test(message.errorCode))) return false;
+        var pending = pendingMergeWorktreeGroupsRequests.get(message.requestId);
+        if (!pending) return true;
+        if (message.status === 'accepted') return true;
+        pendingMergeWorktreeGroupsRequests.delete(message.requestId);
+        if (pending.actionElement && pending.actionElement.isConnected) {
+            pending.actionElement.removeAttribute('aria-disabled');
+        }
+        var projectDiv = getAiSessionsUpdate().findCurrentWorkspaceDiv(pending.projectId);
+        var liveRegion = projectDiv?.querySelector('[data-ai-session-live-region]');
+        if (liveRegion && message.status !== 'cancelled') {
+            liveRegion.textContent = message.status === 'merged'
+                ? 'Worktree groups merged.'
+                : `Worktree group merge failed: ${message.errorCode || 'unknown'}`;
+        }
+        return true;
     }
 
     function submitManagedWorktreeRemoval(projectId, group, button) {
@@ -2917,6 +2967,7 @@ function initProjectAiSessionControls(options) {
         applyIsolatedSessionSettlement: applyIsolatedSessionSettlement,
         applyManagedWorktreeRemovalSettlement: applyManagedWorktreeRemovalSettlement,
         applySetGroupPrimarySettlement: applySetGroupPrimarySettlement,
+        applyWorktreeGroupMergeSettlement: applyWorktreeGroupMergeSettlement,
         applyWorktreeGroupRenameSettlement: applyWorktreeGroupRenameSettlement,
         applyWorktreeGroupDeletionPreview: applyWorktreeGroupDeletionPreview,
         applyWorktreeGroupDeletionSettlement: applyWorktreeGroupDeletionSettlement,

--- a/media/webviewProjectScripts.js
+++ b/media/webviewProjectScripts.js
@@ -620,6 +620,11 @@ function initProjects() {
             return;
         }
 
+        if (message && message.type === 'worktree-group-merge-settlement') {
+            aiSessionControls.applyWorktreeGroupMergeSettlement(message);
+            return;
+        }
+
         if (message && message.type === 'worktree-group-primary-settlement') {
             aiSessionControls.applySetGroupPrimarySettlement(message);
             return;

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -314,6 +314,7 @@ import type { WorktreeGroupDeletionSettlement } from './worktrees/groupDeletionP
 import { fallbackRepositoryLabel } from './workspaces/worktreeGroupProjection';
 import { handleAdoptWorktrees } from './worktrees/groupAdoptHandler';
 import type { WorktreeAdoptSettlement } from './worktrees/groupAdoptProtocol';
+import type { WorktreeGroupMergeSettlement } from './worktrees/groupMergeProtocol';
 import { resolveGenerationClaimDisposition } from './worktrees/generationClaimReconciliation';
 import {
     acceptedIsolatedSessionSettlement,
@@ -2484,6 +2485,8 @@ async function initializeDashboard(
     // Idempotency cache for group rename settlements (PRD §6.4 protocol
     // rules): replays re-receive the recorded terminal settlement and are
     // never re-executed.
+    const worktreeGroupMergeSettlements = createSettlementReplayCache<
+        WorktreeGroupMergeSettlement>();
     const worktreeAdoptSettlements = createSettlementReplayCache<
         WorktreeAdoptSettlement>();
     const worktreeGroupRenameSettlements = createSettlementReplayCache<
@@ -2590,6 +2593,7 @@ async function initializeDashboard(
         },
         'merge-worktree-groups': async (message: unknown) => {
             await handleMergeWorktreeGroups(message, {
+                postMessage: outgoing => provider.postMessage(outgoing),
                 getNavigationIdentity: projectId =>
                     getCurrentWorkspaceActionTarget(projectId)
                         ?.workspace.navigationIdentity || null,
@@ -2603,6 +2607,7 @@ async function initializeDashboard(
                 refreshNow: () => aiSessionDashboardController.refreshNow(
                     'worktree-groups-merged', { fallbackToFullRefresh: false }),
                 logError,
+                replayCache: worktreeGroupMergeSettlements,
             });
         },
         'rename-worktree-group': async (message: unknown) => {

--- a/src/webview/webviewProjectAiSessionControlsScripts.js
+++ b/src/webview/webviewProjectAiSessionControlsScripts.js
@@ -80,6 +80,8 @@ function initProjectAiSessionControls(options) {
     var pendingIsolatedSessionRequests = new Map();
     var nextManagedWorktreeRemovalRequestId = 0;
     var pendingManagedWorktreeRemovalRequests = new Map();
+    var nextMergeWorktreeGroupsRequestId = 0;
+    var pendingMergeWorktreeGroupsRequests = new Map();
     var nextSetGroupPrimaryRequestId = 0;
     var pendingSetGroupPrimaryRequests = new Map();
     var worktreeGroupForm = null;
@@ -291,11 +293,10 @@ function initProjectAiSessionControls(options) {
             '[data-action="merge-worktree-groups"][data-group-id]'
         );
         if (mergeGroupsAction) {
-            window.vscode.postMessage({
-                type: 'merge-worktree-groups',
-                projectId: projectId,
-                sourceGroupId: mergeGroupsAction.getAttribute('data-group-id'),
-            });
+            submitMergeWorktreeGroups(
+                projectId,
+                mergeGroupsAction.getAttribute('data-group-id'),
+                mergeGroupsAction);
             return true;
         }
         var setPrimaryAction = target.closest(
@@ -951,6 +952,55 @@ function initProjectAiSessionControls(options) {
             return;
         }
         closeAiSessionWorktreeMenu();
+    }
+
+    function submitMergeWorktreeGroups(projectId, sourceGroupId, actionElement) {
+        if (!projectId || !sourceGroupId || !actionElement) return;
+        if (pendingMergeWorktreeGroupsRequests.size > 0) return;
+        nextMergeWorktreeGroupsRequestId = nextMergeWorktreeGroupsRequestId
+            >= Number.MAX_SAFE_INTEGER ? 1 : nextMergeWorktreeGroupsRequestId + 1;
+        var requestId = 'worktree-merge-' + nextMergeWorktreeGroupsRequestId.toString(36);
+        actionElement.setAttribute('aria-disabled', 'true');
+        pendingMergeWorktreeGroupsRequests.set(requestId, {
+            actionElement: actionElement,
+            projectId: projectId,
+        });
+        window.vscode.postMessage({
+            type: 'merge-worktree-groups', version: 1,
+            requestId: requestId, projectId: projectId,
+            sourceGroupId: sourceGroupId,
+        });
+    }
+
+    function applyWorktreeGroupMergeSettlement(message) {
+        var expectedKeys = message && typeof message.errorCode === 'string'
+            ? ['errorCode', 'requestId', 'status', 'type', 'version']
+            : message && typeof message.groupId === 'string'
+                ? ['groupId', 'requestId', 'status', 'type', 'version']
+                : ['requestId', 'status', 'type', 'version'];
+        if (!message || message.type !== 'worktree-group-merge-settlement'
+            || message.version !== 1
+            || Object.keys(message).length !== expectedKeys.length
+            || Object.keys(message).sort().some((key, index) => key !== expectedKeys[index])
+            || typeof message.requestId !== 'string' || !message.requestId
+            || !['accepted', 'merged', 'cancelled', 'failed'].includes(message.status)
+            || (Object.prototype.hasOwnProperty.call(message, 'errorCode')
+                && !/^[a-z0-9-]{1,64}$/.test(message.errorCode))) return false;
+        var pending = pendingMergeWorktreeGroupsRequests.get(message.requestId);
+        if (!pending) return true;
+        if (message.status === 'accepted') return true;
+        pendingMergeWorktreeGroupsRequests.delete(message.requestId);
+        if (pending.actionElement && pending.actionElement.isConnected) {
+            pending.actionElement.removeAttribute('aria-disabled');
+        }
+        var projectDiv = getAiSessionsUpdate().findCurrentWorkspaceDiv(pending.projectId);
+        var liveRegion = projectDiv?.querySelector('[data-ai-session-live-region]');
+        if (liveRegion && message.status !== 'cancelled') {
+            liveRegion.textContent = message.status === 'merged'
+                ? 'Worktree groups merged.'
+                : `Worktree group merge failed: ${message.errorCode || 'unknown'}`;
+        }
+        return true;
     }
 
     function submitManagedWorktreeRemoval(projectId, group, button) {
@@ -2917,6 +2967,7 @@ function initProjectAiSessionControls(options) {
         applyIsolatedSessionSettlement: applyIsolatedSessionSettlement,
         applyManagedWorktreeRemovalSettlement: applyManagedWorktreeRemovalSettlement,
         applySetGroupPrimarySettlement: applySetGroupPrimarySettlement,
+        applyWorktreeGroupMergeSettlement: applyWorktreeGroupMergeSettlement,
         applyWorktreeGroupRenameSettlement: applyWorktreeGroupRenameSettlement,
         applyWorktreeGroupDeletionPreview: applyWorktreeGroupDeletionPreview,
         applyWorktreeGroupDeletionSettlement: applyWorktreeGroupDeletionSettlement,

--- a/src/webview/webviewProjectScripts.js
+++ b/src/webview/webviewProjectScripts.js
@@ -620,6 +620,11 @@ function initProjects() {
             return;
         }
 
+        if (message && message.type === 'worktree-group-merge-settlement') {
+            aiSessionControls.applyWorktreeGroupMergeSettlement(message);
+            return;
+        }
+
         if (message && message.type === 'worktree-group-primary-settlement') {
             aiSessionControls.applySetGroupPrimarySettlement(message);
             return;

--- a/src/worktrees/groupMergeHandler.ts
+++ b/src/worktrees/groupMergeHandler.ts
@@ -1,5 +1,15 @@
 'use strict';
 
+import {
+    acceptedWorktreeGroupMergeSettlement,
+    parseMergeWorktreeGroupsRequest,
+    settledWorktreeGroupMergeSettlement,
+} from './groupMergeProtocol';
+import type {
+    MergeWorktreeGroupsRequest,
+    WorktreeGroupMergeSettlement,
+} from './groupMergeProtocol';
+import type { SettlementReplayCache } from './settlementReplayCache';
 import type { WorktreeGroupManifestStore } from './groupManifestStore';
 
 export interface MergeWorktreeGroupsPick {
@@ -9,6 +19,7 @@ export interface MergeWorktreeGroupsPick {
 }
 
 export interface MergeWorktreeGroupsHandlerDeps {
+    postMessage: (message: unknown) => Thenable<unknown>;
     /** Resolves the caller's project to the current workspace bucket. */
     getNavigationIdentity: (projectId: string) => string | null;
     store: WorktreeGroupManifestStore;
@@ -20,6 +31,8 @@ export interface MergeWorktreeGroupsHandlerDeps {
     /** Awaits publication of the authoritative replacement. */
     refreshNow: () => Promise<void>;
     logError: (message: string, error: unknown) => void;
+    /** Exactly-once replay protection (rename/deletion family pattern). */
+    replayCache: SettlementReplayCache<WorktreeGroupMergeSettlement>;
 }
 
 /**
@@ -37,22 +50,44 @@ export async function handleMergeWorktreeGroups(
     message: unknown,
     deps: MergeWorktreeGroupsHandlerDeps
 ): Promise<void> {
-    const request = (message && typeof message === 'object')
-        ? message as { projectId?: unknown; sourceGroupId?: unknown }
-        : {};
-    if (typeof request.projectId !== 'string'
-        || typeof request.sourceGroupId !== 'string'
-        || !request.sourceGroupId) {
+    const request = parseMergeWorktreeGroupsRequest(message);
+    if (!request) {
         return;
     }
+    // Single-flight per request id: a replay — even a concurrent one —
+    // awaits and re-receives the first execution's terminal settlement.
+    const replayed = deps.replayCache.get(request.requestId);
+    if (replayed) {
+        await deps.postMessage(await replayed);
+        return;
+    }
+    if (deps.replayCache.isExpired(request.requestId)) {
+        // The settlement aged out of the bounded cache: re-executing could
+        // flip an old outcome, so expired replays fail closed.
+        await deps.postMessage(settledWorktreeGroupMergeSettlement(
+            request, { kind: 'failed', errorCode: 'request-expired' }));
+        return;
+    }
+    const terminal = executeMergeWorktreeGroups(request, deps);
+    deps.replayCache.remember(request.requestId, terminal);
+    await deps.postMessage(await terminal);
+}
+
+async function executeMergeWorktreeGroups(
+    request: MergeWorktreeGroupsRequest,
+    deps: MergeWorktreeGroupsHandlerDeps
+): Promise<WorktreeGroupMergeSettlement> {
+    await deps.postMessage(acceptedWorktreeGroupMergeSettlement(request));
     const bucket = deps.getNavigationIdentity(request.projectId);
     if (!bucket) {
-        return;
+        return settledWorktreeGroupMergeSettlement(
+            request, { kind: 'failed', errorCode: 'workspace-unavailable' });
     }
     const groups = deps.store.listGroups(bucket);
     const source = groups.find(group => group.groupId === request.sourceGroupId);
     if (!source) {
-        return;
+        return settledWorktreeGroupMergeSettlement(
+            request, { kind: 'failed', errorCode: 'group-not-found' });
     }
     const candidates = groups
         .filter(group => group.groupId !== source.groupId)
@@ -60,7 +95,8 @@ export async function handleMergeWorktreeGroups(
             Number(right.suggestedSlug === source.suggestedSlug)
             - Number(left.suggestedSlug === source.suggestedSlug));
     if (candidates.length === 0) {
-        return;
+        return settledWorktreeGroupMergeSettlement(
+            request, { kind: 'failed', errorCode: 'no-candidates' });
     }
     const picks: MergeWorktreeGroupsPick[] = candidates.map(group => ({
         label: group.displayName,
@@ -70,7 +106,7 @@ export async function handleMergeWorktreeGroups(
     const chosen = await deps.showQuickPick(picks,
         `Merge "${source.displayName}" into…`);
     if (!chosen) {
-        return;
+        return settledWorktreeGroupMergeSettlement(request, { kind: 'cancelled' });
     }
     const expectedRevisions = {
         targetRevision: chosen.groupId
@@ -89,8 +125,14 @@ export async function handleMergeWorktreeGroups(
                 : code === 'group-changed'
                     ? 'A group changed while the merge was open. Review and try again.'
                     : 'The groups could not be merged. Try again.');
-        return;
+        return settledWorktreeGroupMergeSettlement(
+            request, {
+                kind: 'failed',
+                errorCode: /^[a-z0-9-]{1,64}$/u.test(code) ? code : 'merge-failed',
+            });
     }
     // Fire-and-forget, exactly as the inline handler did.
     void deps.refreshNow();
+    return settledWorktreeGroupMergeSettlement(
+        request, { kind: 'merged', groupId: chosen.groupId });
 }

--- a/src/worktrees/groupMergeProtocol.ts
+++ b/src/worktrees/groupMergeProtocol.ts
@@ -1,0 +1,85 @@
+'use strict';
+
+/**
+ * Request/settlement protocol for merging a worktree group into another
+ * (PRD §6.5). Same envelope family as rename/deletion: version 1, exact key
+ * sets, requestId correlation, and an accepted→settled pair so the webview
+ * never hangs.
+ */
+
+export interface MergeWorktreeGroupsRequest {
+    type: 'merge-worktree-groups';
+    version: 1;
+    requestId: string;
+    projectId: string;
+    sourceGroupId: string;
+}
+
+export interface WorktreeGroupMergeSettlement {
+    type: 'worktree-group-merge-settlement';
+    version: 1;
+    requestId: string;
+    status: 'accepted' | 'merged' | 'cancelled' | 'failed';
+    groupId?: string;
+    errorCode?: string;
+}
+
+const REQUEST_KEYS = ['projectId', 'requestId', 'sourceGroupId', 'type', 'version'];
+const ERROR_CODE = /^[a-z0-9-]{1,64}$/u;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function sameKeys(record: Record<string, unknown>, expected: readonly string[]): boolean {
+    const keys = Object.keys(record).sort();
+    return keys.length === expected.length
+        && keys.every((key, index) => key === expected[index]);
+}
+
+function isSafeId(value: unknown): value is string {
+    return typeof value === 'string' && /^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,127}$/u.test(value);
+}
+
+function isSafeString(value: unknown): value is string {
+    return typeof value === 'string' && value.length > 0 && value.length <= 32768
+        && !/[\0\r\n]/u.test(value);
+}
+
+export function parseMergeWorktreeGroupsRequest(
+    value: unknown
+): MergeWorktreeGroupsRequest | null {
+    if (!isRecord(value) || value.type !== 'merge-worktree-groups'
+        || value.version !== 1
+        || !isSafeId(value.requestId) || !isSafeString(value.projectId)
+        || !isSafeId(value.sourceGroupId)
+        || !sameKeys(value, REQUEST_KEYS)) {
+        return null;
+    }
+    return value as unknown as MergeWorktreeGroupsRequest;
+}
+
+export function acceptedWorktreeGroupMergeSettlement(
+    request: MergeWorktreeGroupsRequest
+): WorktreeGroupMergeSettlement {
+    return {
+        type: 'worktree-group-merge-settlement', version: 1,
+        requestId: request.requestId, status: 'accepted',
+    };
+}
+
+export function settledWorktreeGroupMergeSettlement(
+    request: MergeWorktreeGroupsRequest,
+    outcome: { kind: 'merged'; groupId: string }
+        | { kind: 'cancelled' }
+        | { kind: 'failed'; errorCode: string }
+): WorktreeGroupMergeSettlement {
+    return {
+        type: 'worktree-group-merge-settlement', version: 1,
+        requestId: request.requestId,
+        status: outcome.kind,
+        ...(outcome.kind === 'merged' ? { groupId: outcome.groupId } : {}),
+        ...(outcome.kind === 'failed' && ERROR_CODE.test(outcome.errorCode)
+            ? { errorCode: outcome.errorCode } : {}),
+    };
+}

--- a/tests/unit/worktrees/groupMergeHandler.test.js
+++ b/tests/unit/worktrees/groupMergeHandler.test.js
@@ -9,6 +9,9 @@ const {
 const {
     handleMergeWorktreeGroups,
 } = require('../../../out/worktrees/groupMergeHandler');
+const {
+    createSettlementReplayCache,
+} = require('../../../out/worktrees/settlementReplayCache');
 
 const WORKSPACE = 'navigation:unit';
 
@@ -44,68 +47,98 @@ async function fixture(twoGroups = true) {
             members: [readyMember('/beta/.git', 'fix-login-2')],
         });
     }
-    const shown = { picks: null, placeHolder: null, warnings: [], refreshed: 0 };
+    const posted = [];
+    const shown = { picks: null, warnings: [], refreshed: 0 };
     const deps = {
+        postMessage: async message => { posted.push(message); },
         getNavigationIdentity: projectId => (projectId === 'project' ? WORKSPACE : null),
         store,
-        showQuickPick: async (picks, placeHolder) => {
+        showQuickPick: async (picks, _placeHolder) => {
             shown.picks = picks;
-            shown.placeHolder = placeHolder;
             return deps.pickResult;
         },
         showWarning: message => shown.warnings.push(message),
         refreshNow: async () => { shown.refreshed += 1; },
         logError: () => {},
+        replayCache: createSettlementReplayCache(),
         pickResult: undefined,
     };
-    return { store, deps, shown };
+    return { store, deps, posted, shown };
 }
 
+const mergeRequest = (sourceGroupId, overrides = {}) => ({
+    type: 'merge-worktree-groups', version: 1,
+    requestId: 'merge-n1-1', projectId: 'project', sourceGroupId,
+    ...overrides,
+});
 const sourceGroupId = store => store.listGroups(WORKSPACE)[0].groupId;
+const statuses = posted => posted.map(message => message.status);
 
-test('WORKTREE-GROUPS-MERGE-001 malformed or unroutable messages are dropped without any UI', async () => {
-    const { deps, shown } = await fixture();
+test('WORKTREE-GROUPS-MERGE-001 malformed messages are dropped without any settlement or UI', async () => {
+    const { deps, posted, shown } = await fixture();
     await handleMergeWorktreeGroups(null, deps);
     await handleMergeWorktreeGroups({ type: 'merge-worktree-groups' }, deps);
-    await handleMergeWorktreeGroups(
-        { projectId: 'project', sourceGroupId: 'missing' }, deps);
-    await handleMergeWorktreeGroups(
-        { projectId: 'other-project', sourceGroupId: 'x' }, deps);
+    await handleMergeWorktreeGroups(mergeRequest(sourceGroupId(deps.store), { version: 2 }), deps);
+    await handleMergeWorktreeGroups(mergeRequest(sourceGroupId(deps.store), { requestId: 'bad id!' }), deps);
+    assert.deepEqual(posted, []);
     assert.equal(shown.picks, null);
-    assert.equal(shown.refreshed, 0);
 });
 
-test('WORKTREE-GROUPS-MERGE-001 the host re-derives candidates and merges with the double revision binding', async () => {
-    const { store, deps, shown } = await fixture();
-    deps.pickResult = undefined; // first: dialog dismissed
-    await handleMergeWorktreeGroups(
-        { projectId: 'project', sourceGroupId: sourceGroupId(store) }, deps);
+test('WORKTREE-GROUPS-MERGE-001 unroutable and stale-source requests settle failed, never silently', async () => {
+    const { store, deps, posted } = await fixture();
+    await handleMergeWorktreeGroups(mergeRequest('g-any', { projectId: 'other' }), deps);
+    await handleMergeWorktreeGroups(mergeRequest('g-missing', { requestId: 'merge-n1-2' }), deps);
+    assert.deepEqual(statuses(posted), ['accepted', 'failed', 'accepted', 'failed']);
+    assert.equal(posted[1].errorCode, 'workspace-unavailable');
+    assert.equal(posted[3].errorCode, 'group-not-found');
+    assert.equal(store.listGroups(WORKSPACE).length, 2, 'nothing was written');
+});
+
+test('WORKTREE-GROUPS-MERGE-001 the host re-derives candidates, merges with the double revision binding, and settles merged', async () => {
+    const { store, deps, posted, shown } = await fixture();
+    deps.pickResult = undefined; // dialog dismissed
+    await handleMergeWorktreeGroups(mergeRequest(sourceGroupId(store)), deps);
     assert.equal(shown.picks.length, 1);
-    assert.equal(shown.refreshed, 0, 'a dismissed dialog changes nothing');
+    assert.deepEqual(statuses(posted), ['accepted', 'cancelled'],
+        'a dismissed dialog settles cancelled so the webview never hangs');
+    assert.equal(shown.refreshed, 0);
 
     const groups = store.listGroups(WORKSPACE);
     deps.pickResult = { label: 'Fix login (2)', groupId: groups[1].groupId };
     await handleMergeWorktreeGroups(
-        { projectId: 'project', sourceGroupId: groups[0].groupId }, deps);
+        mergeRequest(groups[0].groupId, { requestId: 'merge-n1-2' }), deps);
     const merged = store.listGroups(WORKSPACE);
     assert.equal(merged.length, 1);
     assert.equal(merged[0].groupId, groups[1].groupId, 'source merged into the chosen target');
     assert.equal(merged[0].members.length, 2);
+    assert.deepEqual(statuses(posted), ['accepted', 'cancelled', 'accepted', 'merged']);
+    assert.equal(posted[3].groupId, groups[1].groupId);
     assert.equal(shown.refreshed, 1);
 });
 
-test('WORKTREE-GROUPS-MERGE-001 a revision drift between dialog and write warns and writes nothing', async () => {
-    const { store, deps, shown } = await fixture();
+test('WORKTREE-GROUPS-MERGE-001 a replay is settled from the cache and never re-executes', async () => {
+    const { store, deps, posted } = await fixture();
     const groups = store.listGroups(WORKSPACE);
-    deps.showQuickPick = async (picks) => {
-        // The source group changes while the dialog is open.
+    deps.pickResult = { label: 'Fix login (2)', groupId: groups[1].groupId };
+    const request = mergeRequest(groups[0].groupId);
+    await handleMergeWorktreeGroups(request, deps);
+    assert.equal(store.listGroups(WORKSPACE).length, 1);
+    await handleMergeWorktreeGroups(request, deps);
+    assert.equal(store.listGroups(WORKSPACE).length, 1, 'no second merge');
+    assert.deepEqual(statuses(posted), ['accepted', 'merged', 'merged'],
+        'the replay re-receives the recorded terminal settlement');
+});
+
+test('WORKTREE-GROUPS-MERGE-001 a revision drift between dialog and write settles failed and warns', async () => {
+    const { store, deps, posted, shown } = await fixture();
+    const groups = store.listGroups(WORKSPACE);
+    deps.showQuickPick = async () => {
         await store.renameGroup(WORKSPACE, groups[0].groupId, 'Renamed while open');
         return { label: 'target', groupId: groups[1].groupId };
     };
-    await handleMergeWorktreeGroups(
-        { projectId: 'project', sourceGroupId: groups[0].groupId }, deps);
+    await handleMergeWorktreeGroups(mergeRequest(groups[0].groupId), deps);
     assert.equal(store.listGroups(WORKSPACE).length, 2, 'stale merge writes nothing');
-    assert.equal(shown.warnings.length, 1);
+    assert.deepEqual(statuses(posted), ['accepted', 'failed']);
+    assert.equal(posted[1].errorCode, 'group-changed');
     assert.ok(shown.warnings[0].includes('changed while the merge was open'));
-    assert.equal(shown.refreshed, 0);
 });

--- a/tests/unit/worktrees/groupMergeProtocol.test.js
+++ b/tests/unit/worktrees/groupMergeProtocol.test.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+    acceptedWorktreeGroupMergeSettlement,
+    parseMergeWorktreeGroupsRequest,
+    settledWorktreeGroupMergeSettlement,
+} = require('../../../out/worktrees/groupMergeProtocol');
+
+const valid = () => ({
+    type: 'merge-worktree-groups', version: 1,
+    requestId: 'worktree-merge-1', projectId: '/repo/main', sourceGroupId: 'g-1',
+});
+
+test('WORKTREE-GROUPS-MERGE-001 the merge request parses fail-closed with an exact key set', () => {
+    assert.ok(parseMergeWorktreeGroupsRequest(valid()));
+    assert.equal(parseMergeWorktreeGroupsRequest(null), null);
+    assert.equal(parseMergeWorktreeGroupsRequest({}), null);
+    assert.equal(parseMergeWorktreeGroupsRequest({ ...valid(), version: 2 }), null);
+    assert.equal(parseMergeWorktreeGroupsRequest({ ...valid(), extra: 1 }), null,
+        'an extra key is rejected');
+    assert.equal(parseMergeWorktreeGroupsRequest({ ...valid(), requestId: 'bad id!' }), null);
+    const without = valid();
+    delete without.sourceGroupId;
+    assert.equal(parseMergeWorktreeGroupsRequest(without), null);
+});
+
+test('WORKTREE-GROUPS-MERGE-001 merge settlements carry the correlation and exact outcomes', () => {
+    assert.deepEqual(acceptedWorktreeGroupMergeSettlement(valid()), {
+        type: 'worktree-group-merge-settlement', version: 1,
+        requestId: 'worktree-merge-1', status: 'accepted',
+    });
+    assert.deepEqual(settledWorktreeGroupMergeSettlement(valid(), {
+        kind: 'merged', groupId: 'g-2',
+    }), {
+        type: 'worktree-group-merge-settlement', version: 1,
+        requestId: 'worktree-merge-1', status: 'merged', groupId: 'g-2',
+    });
+    assert.deepEqual(settledWorktreeGroupMergeSettlement(valid(), { kind: 'cancelled' }), {
+        type: 'worktree-group-merge-settlement', version: 1,
+        requestId: 'worktree-merge-1', status: 'cancelled',
+    });
+    assert.deepEqual(settledWorktreeGroupMergeSettlement(valid(), {
+        kind: 'failed', errorCode: 'group-changed',
+    }).errorCode, 'group-changed');
+    assert.equal(settledWorktreeGroupMergeSettlement(valid(), {
+        kind: 'failed', errorCode: 'not a code!',
+    }).errorCode, undefined, 'a malformed error code never ships');
+});


### PR DESCRIPTION
## Summary

Stage 4 pilot migration, slice S4b — the merge family was the last pilot mutation without correlation (the webview sent `merge-worktree-groups` fire-and-forget with no requestId).

- **`src/worktrees/groupMergeProtocol.ts`**: versioned request (exact key set) and the accepted → merged/cancelled/failed settlement family.
- **`groupMergeHandler.ts`** gains the envelope plus the settlement replay cache; a dismissed QuickPick settles `cancelled` so the webview never hangs; revision drift settles `failed` in addition to the host warning.
- **Webview**: the sender tracks pending merges (one in flight), disables the affordance until the terminal settlement, and applies settlements through the same exact-key validated path as the other families. `media/` mirrors stay byte-identical.
- Invariant `ARCH-WORKTREE-PROTOCOL-ENVELOPE-001` now records every pilot family's exactly-once mechanism — the pilot's protocol slice is complete.
- `WORKTREE-GROUPS-MERGE-001` extends to the envelope; new `groupMergeProtocol.test.js` pins parse fail-closed and settlement shapes.

**Behavior change** (protocol evolution, per the approved invariant): merge requests now carry requestId/version and receive settlements; the webview disables the affordance until the terminal settlement. Honest gap: a browser click-through test for the envelope proved flaky against the hidden-menu mechanics and was dropped — coverage rests on the handler/protocol unit tests plus the vm-executed webview checks.

## Skill harvest

no skill change.

## Verification

- worktrees unit 182/182 + merge protocol 2/2; worktrees contract 115/115; browser 37/37; dashboard webview checks pass; architecture policy lane 59/59; behavior contracts green.
- Full coverage gate locally: baseline passed, changed-line coverage 94.20% against origin/main; `git diff --check` clean.