### PR TITLE
feat(architecture): program ledger and strict-mode preconditions (pilot closure)

### DIFF
--- a/docs/testing/architecture-program.json
+++ b/docs/testing/architecture-program.json
@@ -1,0 +1,22 @@
+{
+    "version": 1,
+    "title": "Architecture program ledger",
+    "notes": [
+        "Module states follow legacy -> inventoried -> characterized -> guarded -> migrating -> strict (charter Section 8.5).",
+        "strict is validated mechanically by scripts/architecture/checkProgramLedger.js: no baseline fingerprint or waiver naming the module, P0/P1 invariants have behavior owners, single-writer families declare writers, and the module stays classified exact-once.",
+        "SCC cluster membership is cluster-level debt and does not block per-module strict (waiver ledger note)."
+    ],
+    "states": ["legacy", "inventoried", "characterized", "guarded", "migrating", "strict"],
+    "modules": {
+        "MOD-WORKTREE-LIFECYCLE": {
+            "state": "strict",
+            "since": "pilot slices S1-S5 (PRs #262-#268)",
+            "evidence": [
+                "docs/architecture/stage-1b-pilot-rfc.md",
+                "docs/architecture/changes/ARCH-CHANGE-001.md",
+                "docs/architecture/changes/ARCH-CHANGE-002.md"
+            ],
+            "nextAction": "none — pilot complete"
+        }
+    }
+}

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -6843,5 +6843,19 @@
       "src/worktrees/groupDeletionHandler.ts",
       "src/worktrees/settlementReplayCache.ts"
     ]
+  },
+  {
+    "id": "ARCH-PROGRAM-LEDGER-001",
+    "domain": "architecture",
+    "title": "The program ledger validates module states and mechanically enforces strict-mode preconditions: no baseline fingerprint or waiver names the module, P0/P1 invariants have behavior owners, single-writer families declare writers",
+    "priority": "P0",
+    "status": "automated",
+    "owners": [
+      "tests/unit/architecture/programLedger.test.js"
+    ],
+    "evidence": [
+      "scripts/architecture/checkProgramLedger.js",
+      "docs/testing/architecture-program.json"
+    ]
   }
 ]

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "265ec508278a61fd080ff76ddd935b25b66cad94",
+        "head": "6c0c2f0a131680005e50645aba9c61e2b880236f",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -440,7 +440,8 @@
             "a1121f7d70745288c9ecaf1c517c9fa7f696b018",
             "af29601c9d5ee277974f8903968d40f10431d388",
             "80a7527fc16ca396a5bc1a7ff998265b4d72587b",
-            "3b41cd7b3c639f61d2c42a9c2ad515380885fea9"
+            "3b41cd7b3c639f61d2c42a9c2ad515380885fea9",
+            "01061d13bee173467a7ddbdb7794af35cf7a44c9"
         ]
     },
     "capabilities": [
@@ -2288,7 +2289,8 @@
                 "8c8f510f3fba3d5e6c95ea9c0bacc9238308b55d",
                 "cb6dbde98b52fd19da24b6225596715f65f367c8",
                 "c34a293e6b62c4417790e6a47ab7bd35a4d8262c",
-                "265ec508278a61fd080ff76ddd935b25b66cad94"
+                "265ec508278a61fd080ff76ddd935b25b66cad94",
+                "6c0c2f0a131680005e50645aba9c61e2b880236f"
             ],
             "behaviors": [
                 "ARCH-POLICY-SCHEMA-001",
@@ -2298,7 +2300,8 @@
                 "ARCH-INVARIANT-CATALOG-001",
                 "ARCH-SINGLE-WRITER-001",
                 "ARCH-CHANGE-GATE-001",
-                "ARCH-WEBVIEW-MANIFEST-001"
+                "ARCH-WEBVIEW-MANIFEST-001",
+                "ARCH-PROGRAM-LEDGER-001"
             ],
             "prGates": [
                 "test:architecture-policy"

--- a/package.json
+++ b/package.json
@@ -606,7 +606,7 @@
         "test:tmux:smoke": "npm run test-compile && node scripts/run-ai-session-tmux-smoke-checks.js",
         "test:architecture-baseline": "node scripts/run-performance-architecture-baseline-checks.js",
         "test:architecture-guards": "node scripts/run-architecture-guards.js",
-        "test:architecture-policy": "node --test 'tests/unit/architecture/**/*.test.js' && node scripts/architecture/checkClosedWorld.js && node scripts/architecture/checkModuleBoundaries.js && node scripts/architecture/checkSingleWriters.js && node scripts/architecture/checkArchitectureChange.js && node scripts/architecture/checkWebviewManifest.js",
+        "test:architecture-policy": "node --test 'tests/unit/architecture/**/*.test.js' && node scripts/architecture/checkClosedWorld.js && node scripts/architecture/checkModuleBoundaries.js && node scripts/architecture/checkSingleWriters.js && node scripts/architecture/checkArchitectureChange.js && node scripts/architecture/checkWebviewManifest.js && node scripts/architecture/checkProgramLedger.js",
         "test:release-notes": "node scripts/run-release-notes-checks.js",
         "test:release-packaging": "node scripts/seed-release-packaging-stale-output.js && npm run package:release && node scripts/run-release-packaging-checks.js",
         "test:conversation-performance": "node scripts/run-conversation-performance-checks.js",

--- a/scripts/architecture/checkProgramLedger.js
+++ b/scripts/architecture/checkProgramLedger.js
@@ -1,0 +1,114 @@
+'use strict';
+
+/**
+ * Program ledger enforcement (Harness v0; charter Section 8.5).
+ *
+ * docs/testing/architecture-program.json records each module's migration
+ * state. This check validates the ledger schema, the state vocabulary, and
+ * mechanically enforces strict-mode preconditions: a strict module has no
+ * baseline fingerprint or waiver naming it, its P0/P1 invariants have
+ * behavior owners, and its single-writer families declare writers. An agent
+ * cannot mark a module strict while debt still names it.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { loadArchitecturePolicy } = require('./loadArchitecturePolicy');
+
+const LEDGER_PATH = path.join('docs', 'testing', 'architecture-program.json');
+const BASELINE_PATH = path.join('.ci', 'architecture-debt-baseline.json');
+const WAIVERS_PATH = path.join('docs', 'testing', 'architecture-waivers.json');
+const INVARIANTS_PATH = path.join('docs', 'testing', 'architecture-invariants.json');
+
+function readJson(rootDirectory, relativePath, errors, label) {
+    try {
+        return JSON.parse(fs.readFileSync(path.join(rootDirectory, relativePath), 'utf8'));
+    } catch (error) {
+        errors.push(`ledger: cannot read ${relativePath}: ${error.message}`);
+        return null;
+    }
+}
+
+function runProgramLedgerCheck(rootDirectory) {
+    const errors = [];
+    const policy = loadArchitecturePolicy(rootDirectory);
+    errors.push(...policy.errors);
+    const ledger = readJson(rootDirectory, LEDGER_PATH, errors, 'ledger');
+    const baseline = readJson(rootDirectory, BASELINE_PATH, errors, 'baseline');
+    const waivers = readJson(rootDirectory, WAIVERS_PATH, errors, 'waivers');
+    const invariants = readJson(rootDirectory, INVARIANTS_PATH, errors, 'invariants');
+    if (!ledger || !baseline || !waivers || !invariants) { return { errors }; }
+
+    const states = Array.isArray(ledger.states) ? ledger.states : [];
+    const modules = ledger.modules && typeof ledger.modules === 'object'
+        ? ledger.modules : {};
+    const registryIds = new Set(policy.modules.map(module => module.id));
+
+    for (const [moduleId, entry] of Object.entries(modules)) {
+        if (!registryIds.has(moduleId)) {
+            errors.push(`ledger: ${moduleId} is not a registered module`);
+        }
+        if (!entry || !states.includes(entry.state)) {
+            errors.push(`ledger: ${moduleId} has an unknown state '${entry && entry.state}'`);
+        }
+    }
+
+    const baselineFingerprints = Object.values((baseline && baseline.rules) || {})
+        .flatMap(rule => rule.fingerprints || []);
+    const waiverFingerprints = new Set(((waivers && waivers.waivers) || [])
+        .flatMap(waiver => waiver.fingerprints || []));
+    const invariantList = Array.isArray(invariants.invariants) ? invariants.invariants : [];
+    const fingerprintModules = fingerprint => {
+        if (fingerprint.startsWith('2:')) { return fingerprint.slice(2).split('->'); }
+        if (fingerprint.startsWith('scc:')) { return fingerprint.slice(4).split('|'); }
+        return [];
+    };
+    const namesModule = (fingerprint, moduleId) =>
+        fingerprintModules(fingerprint).includes(moduleId);
+
+    for (const [moduleId, entry] of Object.entries(modules)) {
+        if (!entry || entry.state !== 'strict') { continue; }
+        const namingBaseline = baselineFingerprints.filter(fingerprint =>
+            namesModule(fingerprint, moduleId));
+        for (const fingerprint of namingBaseline) {
+            errors.push(`ledger: ${moduleId} cannot be strict while baseline entry `
+                + `'${fingerprint}' names it`);
+        }
+        const namingWaivers = [...waiverFingerprints].filter(fingerprint =>
+            namesModule(fingerprint, moduleId));
+        for (const fingerprint of namingWaivers) {
+            errors.push(`ledger: ${moduleId} cannot be strict while waiver-covered `
+                + `fingerprint '${fingerprint}' names it`);
+        }
+        for (const invariant of invariantList.filter(item => item.module === moduleId)) {
+            if ((invariant.priority === 'P0' || invariant.priority === 'P1')
+                && (!Array.isArray(invariant.behaviorOwners)
+                    || invariant.behaviorOwners.length === 0)) {
+                errors.push(`ledger: ${moduleId} cannot be strict while ${invariant.id} `
+                    + 'has no behavior owner');
+            }
+            if ((invariant.enforcement || []).includes('single-writer')
+                && (!Array.isArray(invariant.writers) || invariant.writers.length === 0)) {
+                errors.push(`ledger: ${moduleId} cannot be strict while ${invariant.id} `
+                    + 'declares no writer set');
+            }
+        }
+    }
+    return { errors };
+}
+
+function main() {
+    const { errors } = runProgramLedgerCheck(path.resolve(__dirname, '..', '..'));
+    if (errors.length > 0) {
+        console.error('Program ledger checks FAILED:');
+        for (const error of errors) { console.error(`  ✗ ${error}`); }
+        process.exitCode = 1;
+        return;
+    }
+    console.log('Program ledger checks passed: module states valid, '
+        + 'strict-mode preconditions hold.');
+}
+
+if (require.main === module) { main(); }
+
+module.exports = { runProgramLedgerCheck };

--- a/scripts/architecture/reportArchitectureDiff.js
+++ b/scripts/architecture/reportArchitectureDiff.js
@@ -22,6 +22,7 @@ const PROTECTED_POLICY_PATHS = [
     'docs/testing/architecture-invariants.json',
     'docs/testing/architecture-waivers.json',
     'docs/testing/architecture-webview-manifest.json',
+    'docs/testing/architecture-program.json',
     '.ci/architecture-debt-baseline.json',
 ];
 

--- a/tests/unit/architecture/programLedger.test.js
+++ b/tests/unit/architecture/programLedger.test.js
@@ -1,0 +1,114 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const test = require('node:test');
+
+const {
+    runProgramLedgerCheck,
+} = require('../../../scripts/architecture/checkProgramLedger');
+
+const repoRoot = path.resolve(__dirname, '..', '..', '..');
+
+function makeFixture({ ledger, baselineFingerprints = [], waiverFingerprints = [], invariants = [] }) {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'arch-ledger-'));
+    const writeJson = (relative, value) => {
+        fs.mkdirSync(path.join(root, path.dirname(relative)), { recursive: true });
+        fs.writeFileSync(path.join(root, relative), JSON.stringify(value, null, 2));
+    };
+    fs.mkdirSync(path.join(root, 'src'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'src/a.ts'), '// fixture\n');
+    writeJson('docs/testing/architecture-modules.json', {
+        version: 1, scope: { roots: ['src'] },
+        modules: [{
+            id: 'MOD-ALPHA', title: 'Alpha', purpose: 'fixture',
+            source: { include: ['src/**'], exclude: [] }, publicEntrypoints: ['src/**'],
+            mayDependOn: [], roles: [{ role: 'application', include: ['src/**'] }],
+            productCapabilities: ['MAIN-TEST-001'],
+        }],
+    });
+    writeJson('docs/testing/main-capability-coverage.json',
+        { version: 1, capabilities: [{ id: 'MAIN-TEST-001' }] });
+    writeJson('docs/testing/architecture-program.json', ledger);
+    writeJson('.ci/architecture-debt-baseline.json',
+        { version: 1, rules: { 'module-cycle': { fingerprints: baselineFingerprints } } });
+    writeJson('docs/testing/architecture-waivers.json', {
+        version: 1,
+        waivers: waiverFingerprints.map(fingerprint => ({
+            id: 'ARCH-WAIVER-T', rule: 'module-cycle', fingerprints: [fingerprint],
+            owner: 'o', reason: 'r', tracking: 't', createdAt: 'x', retiresWith: 'W', expiresAt: null,
+        })),
+    });
+    writeJson('docs/testing/architecture-invariants.json', { version: 1, invariants });
+    return root;
+}
+
+function ledgerWith(state) {
+    return {
+        version: 1,
+        states: ['legacy', 'inventoried', 'characterized', 'guarded', 'migrating', 'strict'],
+        modules: { 'MOD-ALPHA': { state, since: 'fixture', evidence: [], nextAction: 'none' } },
+    };
+}
+
+const validInvariant = {
+    id: 'ARCH-TEST-001', module: 'MOD-ALPHA', productCapabilities: ['MAIN-TEST-001'],
+    priority: 'P0', kind: 'concurrency', statement: 'fixture',
+    authority: { path: 'src/a.ts', symbol: 'a' }, writers: ['src/a.ts'],
+    linearizationPoint: 'x', enforcement: ['single-writer'],
+    behaviorOwners: ['src/a.ts'], guardOwners: [], evidence: [],
+};
+
+test('ARCH-PROGRAM-LEDGER-001 the real ledger is valid and the pilot module is strict-clean', () => {
+    assert.deepEqual(runProgramLedgerCheck(repoRoot).errors, []);
+});
+
+test('ARCH-PROGRAM-LEDGER-001 a clean strict module passes', () => {
+    const root = makeFixture({ ledger: ledgerWith('strict'), invariants: [validInvariant] });
+    assert.deepEqual(runProgramLedgerCheck(root).errors, []);
+});
+
+test('ARCH-PROGRAM-LEDGER-001 controlled mutation: strict with a naming baseline entry fails', () => {
+    const root = makeFixture({
+        ledger: ledgerWith('strict'),
+        baselineFingerprints: ['2:MOD-ALPHA->MOD-BETA'],
+        waiverFingerprints: ['2:MOD-ALPHA->MOD-BETA'],
+        invariants: [validInvariant],
+    });
+    assert.ok(runProgramLedgerCheck(root).errors
+        .some(error => error.includes('MOD-ALPHA') && error.includes('baseline entry')));
+});
+
+test('ARCH-PROGRAM-LEDGER-001 controlled mutation: strict with a naming waiver fails', () => {
+    const root = makeFixture({
+        ledger: ledgerWith('strict'),
+        waiverFingerprints: ['scc:MOD-ALPHA|MOD-BETA'],
+        invariants: [validInvariant],
+    });
+    assert.ok(runProgramLedgerCheck(root).errors
+        .some(error => error.includes('waiver-covered')));
+});
+
+test('ARCH-PROGRAM-LEDGER-001 controlled mutation: strict with a P0 invariant lacking behavior owner fails', () => {
+    const root = makeFixture({
+        ledger: ledgerWith('strict'),
+        invariants: [{ ...validInvariant, behaviorOwners: [] }],
+    });
+    assert.ok(runProgramLedgerCheck(root).errors
+        .some(error => error.includes('ARCH-TEST-001') && error.includes('no behavior owner')));
+});
+
+test('ARCH-PROGRAM-LEDGER-001 controlled mutation: unknown module and unknown state fail', () => {
+    const bad = ledgerWith('strict');
+    bad.modules['MOD-GHOST'] = { state: 'strict', since: 'x', evidence: [], nextAction: 'x' };
+    const root = makeFixture({ ledger: bad, invariants: [validInvariant] });
+    assert.ok(runProgramLedgerCheck(root).errors
+        .some(error => error.includes('MOD-GHOST') && error.includes('not a registered module')));
+
+    const unknownState = ledgerWith('halfway');
+    const root2 = makeFixture({ ledger: unknownState, invariants: [validInvariant] });
+    assert.ok(runProgramLedgerCheck(root2).errors
+        .some(error => error.includes("unknown state 'halfway'")));
+});


### PR DESCRIPTION
## Summary

The pilot's closing slice: MOD-WORKTREE-LIFECYCLE enters **strict mode** — the program's first strict module.

- **`docs/testing/architecture-program.json`**: the program ledger (charter Section 8.5 state machine: legacy → inventoried → characterized → guarded → migrating → strict).
- **`scripts/architecture/checkProgramLedger.js`**: mechanically enforces strict-mode preconditions — no baseline fingerprint or waiver names the module, P0/P1 invariants have behavior owners, single-writer families declare writers. An agent cannot mark a module strict while debt still names it.
- The ledger joins the anti-self-amendment gate's protected policy set.
- New `tests/unit/architecture/programLedger.test.js`: clean strict pass plus controlled mutations (naming baseline entry, naming waiver, ownerless P0, unknown module/state). Registers `ARCH-PROGRAM-LEDGER-001`.

Pilot qualification evidence: cycle debt retired (ARCH-WAIVER-003 in #268), member writes route through one lifecycle authority (#263), protocol envelopes unified (#266/#267), safety net closed (#260), codec ownership in the kernel (#268).

## Skill harvest

no skill change.

## Verification

- Architecture policy lane: all six checkers pass; architecture unit 65/65; worktrees unit 184/184; contract 115/115.
- `npm run test:behavior-contracts` green after the audit commit; `git diff --check` clean.
- Architecture scripts line coverage: 88.2%.