### PR TITLE
fix(architecture): enforce exact-one role and revert W1 strict to migrating (review R1)

### DIFF
--- a/docs/architecture/changes/ARCH-CHANGE-003.md
+++ b/docs/architecture/changes/ARCH-CHANGE-003.md
@@ -1,0 +1,51 @@
+# ARCH-CHANGE-003 — Role semantics: exact partition with a remainder role
+
+Date: 2026-08-18
+Status: approved by repository owner (review repair R1)
+Module: all (registry-wide semantics)
+
+## Problem and evidence
+
+W1 review Blocker 1: the closed-world loader used first-match-wins for
+roles — 106 production files matched multiple roles while red line 1 claims
+exactly one per file. The registry note even documented "the first matching
+role wins", contradicting the red line.
+
+## Old rule → new rule
+
+- Old: roles evaluated in order, first match wins; overlaps silently
+  tolerated.
+- New: roles form an exact partition. Specific role globs must be disjoint
+  (an overlap fails with file, module, both roles, and the matching
+  patterns). A role with `include: ["**"]` is the remainder role — last
+  position only — and catches the module's unclaimed files. Empty role
+  include lists are rejected.
+- `MOD-SHARED-KERNEL` keeps a single explicit domain role (no remainder).
+
+## Alternatives considered
+
+- Per-role exclude lists: equivalent power but harder to read and easier to
+  game; the remainder marker is one declared mechanism with an obvious
+  position rule.
+- Keeping first-match: rejected; it is the defect being removed.
+
+## Compatibility and migration
+
+No production source or persisted data changed. The registry's role lists
+were rewritten to the partition semantics; classification results are
+unchanged except that overlaps now fail instead of silently first-matching.
+`ntc.ts` left a double assignment (domain+infrastructure) and sits in
+infrastructure; the shell's empty domain role was removed.
+
+## Tests
+
+- New controlled mutations in `tests/unit/architecture/closedWorld.test.js`:
+  role overlap fails with both roles and patterns, misplaced remainder role
+  fails, remainder catches only unclaimed files.
+- `tests/unit/architecture/programLedger.test.js`: strict fails while the
+  classification has any error.
+
+## Rollback
+
+Revert the merge commit: the loader returns to first-match and the registry
+to the coarse role lists.

--- a/docs/testing/architecture-modules.json
+++ b/docs/testing/architecture-modules.json
@@ -5,7 +5,7 @@
         "Approved at the Stage 1A checkpoint; normalized in Stage 2 from docs/architecture/drafts/architecture-modules.draft.json.",
         "Coarse phase: module boundaries are directory-aligned and publicEntrypoints declare the whole module surface; PR 2-2 introduces edge evaluation.",
         "Scope roots cover production TypeScript/JavaScript only. media/ is generated output, spikes/ is non-production, scripts/ and tests/ are harness code governed by the reviewability rule.",
-        "Roles are ordered: the first matching role wins. MOD-AI-SESSION-PROVIDER is the residual module for src/aiSessions root files — new files land there by default until re-partition."
+        "Roles form an exact partition: specific role globs must be disjoint; a role with include [\"**\"] is the remainder role (last position only) and catches the module's unclaimed files. Overlap between non-remainder roles fails CI."
     ],
     "scope": {
         "roots": [
@@ -65,10 +65,6 @@
                     ]
                 },
                 {
-                    "role": "domain",
-                    "include": []
-                },
-                {
                     "role": "presentation",
                     "include": [
                         "src/webview/**"
@@ -77,8 +73,7 @@
                 {
                     "role": "application",
                     "include": [
-                        "src/dashboard/**",
-                        "src/sponsor.ts"
+                        "**"
                     ]
                 }
             ],
@@ -151,7 +146,7 @@
                 {
                     "role": "application",
                     "include": [
-                        "src/aiSessions/conversation/**"
+                        "**"
                     ]
                 }
             ],
@@ -196,7 +191,7 @@
                 {
                     "role": "application",
                     "include": [
-                        "src/aiSessions/attention*"
+                        "**"
                     ]
                 }
             ],
@@ -244,9 +239,7 @@
                 {
                     "role": "application",
                     "include": [
-                        "src/aiSessions/notify/**",
-                        "src/aiSessions/notifyIntegration/**",
-                        "src/aiSessions/notifyConfiguration.ts"
+                        "**"
                     ]
                 }
             ],
@@ -321,15 +314,7 @@
                 {
                     "role": "application",
                     "include": [
-                        "src/aiSessions/tmux*",
-                        "src/aiSessions/runtime*",
-                        "src/aiSessions/directTerminalRuntimeBackend.ts",
-                        "src/aiSessions/terminal*",
-                        "src/aiSessions/pendingTerminal*",
-                        "src/aiSessions/execution*",
-                        "src/aiSessions/runningQueue.ts",
-                        "src/aiSessions/launch*",
-                        "src/aiSessions/commandBuilders.ts"
+                        "**"
                     ]
                 }
             ],
@@ -387,14 +372,7 @@
                 {
                     "role": "application",
                     "include": [
-                        "src/aiSessions/commandController.ts",
-                        "src/aiSessions/creationController.ts",
-                        "src/aiSessions/resumeController.ts",
-                        "src/aiSessions/terminalCommandController.ts",
-                        "src/aiSessions/aliasController.ts",
-                        "src/aiSessions/pinController.ts",
-                        "src/aiSessions/sessionProfileController.ts",
-                        "src/aiSessions/archive*"
+                        "**"
                     ]
                 }
             ],
@@ -484,10 +462,7 @@
                 {
                     "role": "application",
                     "include": [
-                        "src/aiSessions/**",
-                        "src/services/codexSessionService.ts",
-                        "src/services/kimiSessionService.ts",
-                        "src/services/claudeSessionService.ts"
+                        "**"
                     ]
                 }
             ],
@@ -540,7 +515,7 @@
                 {
                     "role": "application",
                     "include": [
-                        "src/worktrees/**"
+                        "**"
                     ]
                 }
             ],
@@ -586,7 +561,7 @@
                 {
                     "role": "application",
                     "include": [
-                        "src/workspaces/**"
+                        "**"
                     ]
                 }
             ],
@@ -636,7 +611,7 @@
                 {
                     "role": "application",
                     "include": [
-                        "src/openWorkspaces/**"
+                        "**"
                     ]
                 }
             ],
@@ -690,8 +665,7 @@
                         "src/projects/projectPathUtils.ts",
                         "src/projects/favoriteProjectOrder.ts",
                         "src/projects/projectNavigationProtocol.ts",
-                        "src/projects/projectCatalogSync.ts",
-                        "src/services/ntc.ts"
+                        "src/projects/projectCatalogSync.ts"
                     ]
                 },
                 {
@@ -704,7 +678,7 @@
                 {
                     "role": "application",
                     "include": [
-                        "src/projects/**"
+                        "**"
                     ]
                 }
             ],
@@ -747,7 +721,7 @@
                 {
                     "role": "application",
                     "include": [
-                        "src/skills/**"
+                        "**"
                     ]
                 }
             ],
@@ -788,7 +762,7 @@
                 {
                     "role": "application",
                     "include": [
-                        "src/todos/**"
+                        "**"
                     ]
                 }
             ],
@@ -828,7 +802,7 @@
                 {
                     "role": "application",
                     "include": [
-                        "src/prompts/**"
+                        "**"
                     ]
                 }
             ],
@@ -883,7 +857,7 @@
                 {
                     "role": "application",
                     "include": [
-                        "extensions/attention-ui-bridge/src/**"
+                        "**"
                     ]
                 }
             ],

--- a/docs/testing/architecture-program.json
+++ b/docs/testing/architecture-program.json
@@ -6,17 +6,22 @@
         "strict is validated mechanically by scripts/architecture/checkProgramLedger.js: no baseline fingerprint or waiver naming the module, P0/P1 invariants have behavior owners, single-writer families declare writers, and the module stays classified exact-once.",
         "SCC cluster membership is cluster-level debt and does not block per-module strict (waiver ledger note)."
     ],
-    "states": ["legacy", "inventoried", "characterized", "guarded", "migrating", "strict"],
+    "states": [
+        "legacy",
+        "inventoried",
+        "characterized",
+        "guarded",
+        "migrating",
+        "strict"
+    ],
     "modules": {
         "MOD-WORKTREE-LIFECYCLE": {
-            "state": "strict",
-            "since": "pilot slices S1-S5 (PRs #262-#268)",
+            "state": "migrating",
+            "since": "pilot slices S1-S5 (PRs #262-#268); strict declaration #269 reverted per W1 review",
             "evidence": [
-                "docs/architecture/stage-1b-pilot-rfc.md",
-                "docs/architecture/changes/ARCH-CHANGE-001.md",
-                "docs/architecture/changes/ARCH-CHANGE-002.md"
+                "docs/architecture/stage-1b-pilot-rfc.md"
             ],
-            "nextAction": "none — pilot complete"
+            "nextAction": "W1 review repair R1-R10, then strict re-acceptance"
         }
     }
 }

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "73ac894df7047f36ade1fb750b70392ce28c6a2f",
+        "head": "bfa2f05d2da81d2b51d1850d874b5389d5e286ee",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -442,7 +442,9 @@
             "80a7527fc16ca396a5bc1a7ff998265b4d72587b",
             "3b41cd7b3c639f61d2c42a9c2ad515380885fea9",
             "01061d13bee173467a7ddbdb7794af35cf7a44c9",
-            "48eb792f04e8b8477bf5f8ffc0d7bd349ad6ddaa"
+            "48eb792f04e8b8477bf5f8ffc0d7bd349ad6ddaa",
+            "ddbf7acf78ff20f0e097bec3ae2e7e54e89980ae",
+            "bfa2f05d2da81d2b51d1850d874b5389d5e286ee"
         ]
     },
     "capabilities": [

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "6c0c2f0a131680005e50645aba9c61e2b880236f",
+        "head": "73ac894df7047f36ade1fb750b70392ce28c6a2f",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -441,7 +441,8 @@
             "af29601c9d5ee277974f8903968d40f10431d388",
             "80a7527fc16ca396a5bc1a7ff998265b4d72587b",
             "3b41cd7b3c639f61d2c42a9c2ad515380885fea9",
-            "01061d13bee173467a7ddbdb7794af35cf7a44c9"
+            "01061d13bee173467a7ddbdb7794af35cf7a44c9",
+            "48eb792f04e8b8477bf5f8ffc0d7bd349ad6ddaa"
         ]
     },
     "capabilities": [
@@ -2290,7 +2291,8 @@
                 "cb6dbde98b52fd19da24b6225596715f65f367c8",
                 "c34a293e6b62c4417790e6a47ab7bd35a4d8262c",
                 "265ec508278a61fd080ff76ddd935b25b66cad94",
-                "6c0c2f0a131680005e50645aba9c61e2b880236f"
+                "6c0c2f0a131680005e50645aba9c61e2b880236f",
+                "73ac894df7047f36ade1fb750b70392ce28c6a2f"
             ],
             "behaviors": [
                 "ARCH-POLICY-SCHEMA-001",

--- a/scripts/architecture/checkProgramLedger.js
+++ b/scripts/architecture/checkProgramLedger.js
@@ -68,6 +68,11 @@ function runProgramLedgerCheck(rootDirectory) {
 
     for (const [moduleId, entry] of Object.entries(modules)) {
         if (!entry || entry.state !== 'strict') { continue; }
+        // Exact-once classification is a strict precondition (red line 1).
+        if (policy.errors.length > 0) {
+            errors.push(`ledger: ${moduleId} cannot be strict while the closed-world `
+                + 'classification has errors');
+        }
         const namingBaseline = baselineFingerprints.filter(fingerprint =>
             namesModule(fingerprint, moduleId));
         for (const fingerprint of namingBaseline) {

--- a/scripts/architecture/loadArchitecturePolicy.js
+++ b/scripts/architecture/loadArchitecturePolicy.js
@@ -77,9 +77,10 @@ function readJson(rootDirectory, relativePath, errors) {
     }
 }
 
-function validatePatternList(owner, field, value, errors) {
-    if (!Array.isArray(value) || value.some(entry => typeof entry !== 'string' || entry.length === 0)) {
-        errors.push(`${owner}: ${field} must be an array of non-empty glob strings`);
+function validatePatternList(owner, field, value, errors, allowEmpty = false) {
+    if (!Array.isArray(value) || (!allowEmpty && value.length === 0)
+        || value.some(entry => typeof entry !== 'string' || entry.length === 0)) {
+        errors.push(`${owner}: ${field} must be ${allowEmpty ? 'an' : 'a non-empty'} array of non-empty glob strings`);
         return false;
     }
     return true;
@@ -134,7 +135,7 @@ function loadArchitecturePolicy(rootDirectory) {
             continue;
         }
         if (source.exclude !== undefined
-            && !validatePatternList(owner, 'source.exclude', source.exclude, errors)) {
+            && !validatePatternList(owner, 'source.exclude', source.exclude, errors, true)) {
             continue;
         }
         if (module.publicEntrypoints !== undefined
@@ -179,6 +180,7 @@ function loadArchitecturePolicy(rootDirectory) {
             roles: roles.map(roleEntry => ({
                 role: roleEntry.role,
                 include: roleEntry.include.map(compileGlob),
+                rawInclude: roleEntry.include.slice(),
             })),
         };
     }
@@ -211,8 +213,8 @@ function loadArchitecturePolicy(rootDirectory) {
                 + 'extend the policy deliberately or move it out of the production roots');
             continue;
         }
-        const owners = modules.filter(module =>
-            module._compiled.include.some(pattern => pattern.test(file))
+        const owners = modules.filter(module => module._compiled
+            && module._compiled.include.some(pattern => pattern.test(file))
             && !module._compiled.exclude.some(pattern => pattern.test(file)));
         if (owners.length === 0) {
             errors.push(`closed-world: ${file} is not classified by any module`);
@@ -224,13 +226,41 @@ function loadArchitecturePolicy(rootDirectory) {
             continue;
         }
         const module = owners[0];
-        const roleEntry = module._compiled.roles.find(candidate =>
-            candidate.include.some(pattern => pattern.test(file)));
-        if (!roleEntry) {
-            errors.push(`closed-world: ${file} has no role in module ${module.id}`);
+        // Exactly one role per file (red line 1): a role whose include is
+        // exactly ["**"] is the remainder role — it must be last and matches
+        // only module files no earlier role claimed. Overlap between
+        // non-remainder roles is an error, never silently first-match.
+        const roleMatchers = module._compiled.roles;
+        const remainderIndex = roleMatchers.findIndex(candidate =>
+            candidate.rawInclude.length === 1 && candidate.rawInclude[0] === '**');
+        if (remainderIndex !== -1 && remainderIndex !== roleMatchers.length - 1) {
+            errors.push(`module ${module.id}: the '**' remainder role must be the last role`);
             continue;
         }
-        classification.set(file, { moduleId: module.id, role: roleEntry.role });
+        const specific = remainderIndex === -1
+            ? roleMatchers
+            : roleMatchers.slice(0, remainderIndex);
+        const matches = specific.filter(candidate =>
+            candidate.include.some(pattern => pattern.test(file)));
+        if (matches.length > 1) {
+            errors.push(`closed-world: ${file} matches multiple roles in module ${module.id}: `
+                + matches.map(candidate => `${candidate.role} (via ${candidate.rawInclude.join(', ')})`)
+                    .join('; '));
+            continue;
+        }
+        if (matches.length === 1) {
+            classification.set(file, { moduleId: module.id, role: matches[0].role });
+            continue;
+        }
+        if (remainderIndex !== -1) {
+            classification.set(file, {
+                moduleId: module.id,
+                role: roleMatchers[remainderIndex].role,
+            });
+            continue;
+        }
+        errors.push(`closed-world: ${file} has no role in module ${module.id}`);
+        continue;
     }
 
     // ── Stale pattern detection: every declared pattern must match ────

--- a/tests/unit/architecture/closedWorld.test.js
+++ b/tests/unit/architecture/closedWorld.test.js
@@ -48,7 +48,7 @@ function twoModuleRegistry() {
                 mayDependOn: [],
                 roles: [
                     { role: 'domain', include: ['src/beta/types.ts'] },
-                    { role: 'application', include: ['src/beta/**'] },
+                    { role: 'application', include: ['**'] },
                 ],
                 productCapabilities: ['MAIN-TEST-001'],
             },
@@ -149,6 +149,45 @@ test('ARCH-CLOSED-WORLD-001 controlled mutation: a stale pattern that matches no
         files: ['src/alpha/index.ts', 'src/beta/index.ts', 'src/beta/types.ts'],
     }));
     assert.ok(errors.some(e => e.includes('stale source.include pattern src/alpha/legacy/**')));
+});
+
+test('ARCH-CLOSED-WORLD-001 controlled mutation: a file matching two specific roles fails with both roles and patterns', () => {
+    const registry = twoModuleRegistry();
+    registry.modules[1].roles = [
+        { role: 'domain', include: ['src/beta/types.ts', 'src/beta/index.ts'] },
+        { role: 'application', include: ['src/beta/index.ts'] },
+    ];
+    const { errors } = loadArchitecturePolicy(makeFixture({
+        registry,
+        files: ['src/alpha/index.ts', 'src/beta/index.ts', 'src/beta/types.ts'],
+    }));
+    assert.ok(errors.some(error => error.includes('src/beta/index.ts')
+        && error.includes('multiple roles') && error.includes('domain')
+        && error.includes('application')), JSON.stringify(errors));
+});
+
+test('ARCH-CLOSED-WORLD-001 controlled mutation: a remainder role not in last position fails', () => {
+    const registry = twoModuleRegistry();
+    registry.modules[1].roles = [
+        { role: 'application', include: ['**'] },
+        { role: 'domain', include: ['src/beta/types.ts'] },
+    ];
+    const { errors } = loadArchitecturePolicy(makeFixture({
+        registry,
+        files: ['src/alpha/index.ts', 'src/beta/index.ts', 'src/beta/types.ts'],
+    }));
+    assert.ok(errors.some(error => error.includes('remainder role')
+        && error.includes('last')), JSON.stringify(errors));
+});
+
+test('ARCH-CLOSED-WORLD-001 the remainder role catches only unclaimed files', () => {
+    const { errors, classification } = loadArchitecturePolicy(makeFixture({
+        registry: twoModuleRegistry(),
+        files: ['src/alpha/index.ts', 'src/beta/index.ts', 'src/beta/types.ts'],
+    }));
+    assert.deepEqual(errors, []);
+    assert.equal(classification.get('src/beta/types.ts').role, 'domain');
+    assert.equal(classification.get('src/beta/index.ts').role, 'application');
 });
 
 test('ARCH-CLOSED-WORLD-001 controlled mutation: an entrypoint outside the module fails', () => {

--- a/tests/unit/architecture/programLedger.test.js
+++ b/tests/unit/architecture/programLedger.test.js
@@ -100,6 +100,15 @@ test('ARCH-PROGRAM-LEDGER-001 controlled mutation: strict with a P0 invariant la
         .some(error => error.includes('ARCH-TEST-001') && error.includes('no behavior owner')));
 });
 
+test('ARCH-PROGRAM-LEDGER-001 controlled mutation: strict with classification errors fails', () => {
+    // An unclassified file in the fixture breaks exact-once; strict must fail.
+    const root = makeFixture({ ledger: ledgerWith('strict'), invariants: [validInvariant] });
+    fs.writeFileSync(path.join(root, 'src/a.py'), '# unknown file kind\n');
+    const { errors } = runProgramLedgerCheck(root);
+    assert.ok(errors.some(error => error.includes('MOD-ALPHA')
+        && error.includes('closed-world')), JSON.stringify(errors));
+});
+
 test('ARCH-PROGRAM-LEDGER-001 controlled mutation: unknown module and unknown state fail', () => {
     const bad = ledgerWith('strict');
     bad.modules['MOD-GHOST'] = { state: 'strict', since: 'x', evidence: [], nextAction: 'x' };


### PR DESCRIPTION
## Summary

W1 review Blocker 1 + the ledger revert. The closed-world loader used first-match-wins for roles, so 106 production files matched multiple roles while red line 1 claims exactly one.

- **`loadArchitecturePolicy.js`**: roles now form an exact partition — specific role globs must be disjoint (an overlap fails with file, module, both roles, and the matching patterns); a role with `include: ["**"]` is the remainder role, allowed only in last position, catching the module's unclaimed files. Empty role include lists are now rejected (they previously passed), and an invalid module can no longer crash classification mid-run.
- **Registry**: remainder roles applied across modules; `ntc.ts` removed from its double assignment; the shell's empty domain role removed; the 'first matching role wins' note is gone.
- **`checkProgramLedger.js`**: a strict module now fails while the closed-world classification has any error — red line 1 is a mechanical strict precondition.
- **W1 ledger reverted to `migrating`** per the review; strict re-acceptance follows the repair list (R1–R10).
- New controlled mutations: role overlap fails, misplaced remainder role fails, remainder catches only unclaimed files, strict-with-classification-errors fails.

No production source file changed; harness and policy data only.

## Skill harvest

no skill change — the failure mode (partition claims without partition enforcement) is exactly what the harness now encodes.

## Verification

- Architecture policy lane 69/69 green; classification passes with 371 files / 16 modules and zero role overlaps.
- Full coverage gate locally: baseline passed, changed-line coverage 97.78% against origin/main.
- `npm run test:behavior-contracts` green after the audit commit; `git diff --check` clean.