### PR TITLE
feat(architecture): protect the harness surface in the change gate (review R2)

### DIFF
--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "e628ec8365f5312e5d547feef7b08606228e9d99",
+        "head": "2b7bdcc70d234bed812e572897b323623790eb9b",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -445,7 +445,8 @@
             "48eb792f04e8b8477bf5f8ffc0d7bd349ad6ddaa",
             "ddbf7acf78ff20f0e097bec3ae2e7e54e89980ae",
             "bfa2f05d2da81d2b51d1850d874b5389d5e286ee",
-            "3a984d357c94624d93434fa6e3b889cf201161a1"
+            "3a984d357c94624d93434fa6e3b889cf201161a1",
+            "88f31ce6c058b6bbfd44d104442c2d3f7c616fca"
         ]
     },
     "capabilities": [
@@ -2296,7 +2297,8 @@
                 "265ec508278a61fd080ff76ddd935b25b66cad94",
                 "6c0c2f0a131680005e50645aba9c61e2b880236f",
                 "73ac894df7047f36ade1fb750b70392ce28c6a2f",
-                "e628ec8365f5312e5d547feef7b08606228e9d99"
+                "e628ec8365f5312e5d547feef7b08606228e9d99",
+                "2b7bdcc70d234bed812e572897b323623790eb9b"
             ],
             "behaviors": [
                 "ARCH-POLICY-SCHEMA-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "bfa2f05d2da81d2b51d1850d874b5389d5e286ee",
+        "head": "e628ec8365f5312e5d547feef7b08606228e9d99",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -444,7 +444,8 @@
             "01061d13bee173467a7ddbdb7794af35cf7a44c9",
             "48eb792f04e8b8477bf5f8ffc0d7bd349ad6ddaa",
             "ddbf7acf78ff20f0e097bec3ae2e7e54e89980ae",
-            "bfa2f05d2da81d2b51d1850d874b5389d5e286ee"
+            "bfa2f05d2da81d2b51d1850d874b5389d5e286ee",
+            "3a984d357c94624d93434fa6e3b889cf201161a1"
         ]
     },
     "capabilities": [
@@ -2294,7 +2295,8 @@
                 "c34a293e6b62c4417790e6a47ab7bd35a4d8262c",
                 "265ec508278a61fd080ff76ddd935b25b66cad94",
                 "6c0c2f0a131680005e50645aba9c61e2b880236f",
-                "73ac894df7047f36ade1fb750b70392ce28c6a2f"
+                "73ac894df7047f36ade1fb750b70392ce28c6a2f",
+                "e628ec8365f5312e5d547feef7b08606228e9d99"
             ],
             "behaviors": [
                 "ARCH-POLICY-SCHEMA-001",

--- a/scripts/architecture/checkArchitectureChange.js
+++ b/scripts/architecture/checkArchitectureChange.js
@@ -3,13 +3,16 @@
 /**
  * Anti-self-amendment gate (Harness v0, program Stage 2 PR 4; charter 8.9).
  *
- * Classifies a change by its impact on protected architecture policy:
- * - product-only: no protected policy file touched — passes;
- * - tightening: protected files touched, but the policy only narrows
- *   (baseline/waiver/dependency/writer removals) — passes;
+ * Classifies a change by its impact on protected architecture policy and the
+ * harness surface (review R2):
+ * - product-only: neither policy files nor the harness surface touched;
+ * - tightening: policy only narrows, or the harness surface changes without
+ *   weakening;
  * - relaxing or registry re-partition: baseline grew, waivers added,
- *   mayDependOn broadened, writer sets grew, or module structure changed —
- *   requires an added docs/architecture/changes/ARCH-CHANGE-*.md record.
+ *   mayDependOn broadened, writer sets grew, module structure changed, or
+ *   the harness surface weakened (a guard file deleted, a guard id removed,
+ *   a lane or workflow invocation removed, mutation tests shrank) — requires
+ *   an added docs/architecture/changes/ARCH-CHANGE-*.md record.
  *
  * An agent cannot legalize its own violation: the classification is computed
  * from the diff, not declared.
@@ -36,7 +39,15 @@ function classifyArchitectureChange(report) {
     }
     const hasArchChangeRecord = report.newFiles
         .some(file => ARCH_CHANGE_PATTERN.test(file));
-    if (report.protectedTouched.length === 0) {
+    const harness = report.harnessDelta || {
+        touched: [], deletedFiles: [], removedGuardIds: [],
+        removedInvocations: [], shrunkMutationTests: [],
+    };
+    const harnessWeakened = harness.deletedFiles.length > 0
+        || harness.removedGuardIds.length > 0
+        || harness.removedInvocations.length > 0
+        || harness.shrunkMutationTests.length > 0;
+    if (report.protectedTouched.length === 0 && harness.touched.length === 0) {
         return { classification: 'product-only', errors };
     }
 
@@ -45,7 +56,8 @@ function classifyArchitectureChange(report) {
     const grownWriters = Object.keys(delta.writersGrown).length > 0;
     const grownBaseline = delta.baselineGrown.length > 0;
     const addedWaivers = delta.waiversAdded.length > 0;
-    const relaxing = grownMayDependOn || grownWriters || grownBaseline || addedWaivers;
+    const relaxing = grownMayDependOn || grownWriters || grownBaseline || addedWaivers
+        || harnessWeakened;
     const rePartition = !relaxing && delta.modulesChanged
         && report.protectedTouched
             .some(file => file.endsWith('architecture-modules.json'));
@@ -56,7 +68,7 @@ function classifyArchitectureChange(report) {
     const classification = relaxing ? 'relaxing' : 're-partition';
     if (!hasArchChangeRecord) {
         errors.push(`anti-self-amendment: this change ${classification === 'relaxing' ? 'relaxes' : 're-partitions'} `
-            + 'architecture policy without an Architecture Change record — add '
+            + 'architecture policy or weakens the harness without an Architecture Change record — add '
             + 'docs/architecture/changes/ARCH-CHANGE-<seq>.md with evidence, alternatives, '
             + 'compatibility impact, migration, tests, and rollback');
     }

--- a/scripts/architecture/reportArchitectureDiff.js
+++ b/scripts/architecture/reportArchitectureDiff.js
@@ -26,6 +26,42 @@ const PROTECTED_POLICY_PATHS = [
     '.ci/architecture-debt-baseline.json',
 ];
 
+/**
+ * The harness surface (review R2): guard implementations, guard tests, and
+ * CI wiring. Changes here can never classify as product-only — a weakened
+ * guard, a removed mutation test, or a dropped CI invocation must fail.
+ */
+const PROTECTED_HARNESS_PREFIXES = [
+    'scripts/architecture/',
+    'tests/unit/architecture/',
+    '.github/workflows/',
+];
+const PROTECTED_HARNESS_FILES = [
+    'scripts/run-architecture-guards.js',
+    'scripts/lib/ciContracts.js',
+    'package.json',
+];
+
+function isHarnessPath(file) {
+    return PROTECTED_HARNESS_PREFIXES.some(prefix => file.startsWith(prefix))
+        || PROTECTED_HARNESS_FILES.includes(file);
+}
+
+/** Guard ids declared by the legacy runner. */
+function guardIdsOf(text) {
+    return new Set([...text.matchAll(/'(ARCH-[A-Z0-9-]+)'\(root\)/g)].map(m => m[1]));
+}
+
+/** Check/lane invocations (node scripts/... and npm run test:...) in text. */
+function invocationsOf(text) {
+    return new Set([...text.matchAll(/node\s+scripts\/[a-zA-Z0-9/.-]+|npm\s+run\s+test:[a-zA-Z0-9:-]+/g)]
+        .map(m => m[0].replace(/\s+/g, ' ')));
+}
+
+function mutationTestCountOf(text) {
+    return (text.match(/controlled mutation/g) || []).length;
+}
+
 function defaultGit(rootDirectory) {
     return {
         changedFiles(baseRef) {
@@ -154,6 +190,45 @@ function collectArchitectureDiff({ rootDirectory, baseRef, git }) {
         .map(entry => entry.path)
         .filter(file => PROTECTED_POLICY_PATHS.includes(file));
 
+    // Harness surface delta (review R2): deletions and removals of guard
+    // ids, lane invocations, workflow invocations, or mutation tests.
+    const harnessDelta = {
+        touched: [],
+        deletedFiles: [],
+        removedGuardIds: [],
+        removedInvocations: [],
+        shrunkMutationTests: [],
+    };
+    for (const entry of changed) {
+        if (!isHarnessPath(entry.path)) { continue; }
+        harnessDelta.touched.push(entry.path);
+        if (entry.status === 'D') {
+            harnessDelta.deletedFiles.push(entry.path);
+            continue;
+        }
+        if (entry.status !== 'M') { continue; }
+        const baseText = git.fileAt(baseRef, entry.path);
+        const headText = git.fileAt('HEAD', entry.path);
+        if (baseText === null || headText === null) { continue; }
+        if (entry.path === 'scripts/run-architecture-guards.js') {
+            const removed = [...guardIdsOf(baseText)]
+                .filter(id => !guardIdsOf(headText).has(id));
+            harnessDelta.removedGuardIds.push(...removed);
+        }
+        if (entry.path === 'package.json' || entry.path.startsWith('.github/workflows/')) {
+            const removed = [...invocationsOf(baseText)]
+                .filter(invocation => !invocationsOf(headText).has(invocation));
+            harnessDelta.removedInvocations.push(...removed.map(invocation => `${entry.path}: ${invocation}`));
+        }
+        if (entry.path.startsWith('tests/unit/architecture/')) {
+            const baseCount = mutationTestCountOf(baseText);
+            const headCount = mutationTestCountOf(headText);
+            if (headCount < baseCount) {
+                harnessDelta.shrunkMutationTests.push(`${entry.path}: ${baseCount} -> ${headCount}`);
+            }
+        }
+    }
+
     return {
         baseRef,
         errors: policy.errors,
@@ -161,6 +236,7 @@ function collectArchitectureDiff({ rootDirectory, baseRef, git }) {
         newFiles: newFiles.sort(),
         removedFiles: removedFiles.sort(),
         protectedTouched,
+        harnessDelta,
         policyDelta,
     };
 }
@@ -193,6 +269,21 @@ function formatReport(report) {
     if (report.policyDelta.waiversAdded.length > 0) {
         lines.push(`  waivers added: ${report.policyDelta.waiversAdded.join(', ')}`);
     }
+    if (report.harnessDelta && report.harnessDelta.touched.length > 0) {
+        lines.push(`  harness surface touched: ${report.harnessDelta.touched.join(', ')}`);
+        for (const file of report.harnessDelta.deletedFiles) {
+            lines.push(`  harness file deleted: ${file}`);
+        }
+        for (const id of report.harnessDelta.removedGuardIds) {
+            lines.push(`  guard removed: ${id}`);
+        }
+        for (const invocation of report.harnessDelta.removedInvocations) {
+            lines.push(`  invocation removed: ${invocation}`);
+        }
+        for (const entry of report.harnessDelta.shrunkMutationTests) {
+            lines.push(`  mutation tests shrank: ${entry}`);
+        }
+    }
     return lines.join('\n');
 }
 
@@ -212,8 +303,11 @@ if (require.main === module) { main(); }
 
 module.exports = {
     PROTECTED_POLICY_PATHS,
+    PROTECTED_HARNESS_PREFIXES,
+    PROTECTED_HARNESS_FILES,
     collectArchitectureDiff,
     defaultGit,
     diffStringSets,
     formatReport,
+    isHarnessPath,
 };

--- a/tests/unit/architecture/architectureChange.test.js
+++ b/tests/unit/architecture/architectureChange.test.js
@@ -143,6 +143,67 @@ test('ARCH-CHANGE-GATE-001 controlled mutation: registry re-partition without a 
     assert.deepEqual(withRecord.errors, []);
 });
 
+test('ARCH-CHANGE-GATE-001 controlled mutation: deleting a harness guard file fails', () => {
+    const result = classifyArchitectureChange(report({
+        harnessDelta: {
+            touched: ['scripts/architecture/checkClosedWorld.js'],
+            deletedFiles: ['scripts/architecture/checkClosedWorld.js'],
+            removedGuardIds: [], removedInvocations: [], shrunkMutationTests: [],
+        },
+    }));
+    assert.equal(result.classification, 'relaxing');
+    assert.ok(result.errors.some(error => error.includes('ARCH-CHANGE')));
+});
+
+test('ARCH-CHANGE-GATE-001 controlled mutation: removing a guard id from the runner fails', () => {
+    const result = classifyArchitectureChange(report({
+        harnessDelta: {
+            touched: ['scripts/run-architecture-guards.js'],
+            deletedFiles: [], removedGuardIds: ['ARCH-PROTOCOL-001'],
+            removedInvocations: [], shrunkMutationTests: [],
+        },
+    }));
+    assert.equal(result.classification, 'relaxing');
+    assert.ok(result.errors.length > 0);
+});
+
+test('ARCH-CHANGE-GATE-001 controlled mutation: removing a lane invocation fails', () => {
+    const result = classifyArchitectureChange(report({
+        harnessDelta: {
+            touched: ['package.json'],
+            deletedFiles: [], removedGuardIds: [],
+            removedInvocations: ['package.json: node scripts/architecture/checkClosedWorld.js'],
+            shrunkMutationTests: [],
+        },
+    }));
+    assert.equal(result.classification, 'relaxing');
+    assert.ok(result.errors.length > 0);
+});
+
+test('ARCH-CHANGE-GATE-001 controlled mutation: shrinking mutation tests fails', () => {
+    const result = classifyArchitectureChange(report({
+        harnessDelta: {
+            touched: ['tests/unit/architecture/moduleBoundaries.test.js'],
+            deletedFiles: [], removedGuardIds: [], removedInvocations: [],
+            shrunkMutationTests: ['tests/unit/architecture/moduleBoundaries.test.js: 8 -> 4'],
+        },
+    }));
+    assert.equal(result.classification, 'relaxing');
+    assert.ok(result.errors.length > 0);
+});
+
+test('ARCH-CHANGE-GATE-001 a guard change with intact wiring classifies as tightening (its own mutation tests are the kill mechanism)', () => {
+    const result = classifyArchitectureChange(report({
+        harnessDelta: {
+            touched: ['scripts/run-architecture-guards.js'],
+            deletedFiles: [], removedGuardIds: [], removedInvocations: [],
+            shrunkMutationTests: [],
+        },
+    }));
+    assert.equal(result.classification, 'tightening');
+    assert.deepEqual(result.errors, []);
+});
+
 // ── collectArchitectureDiff with a fake git ──────────────────────────
 
 function fakeGit(root, { changed, atBase = {} }) {

--- a/tests/unit/architecture/architectureChange.test.js
+++ b/tests/unit/architecture/architectureChange.test.js
@@ -378,6 +378,59 @@ test('ARCH-CHANGE-GATE-001 the policy delta covers invariants, baseline, and wai
         'a shrunk writer set with a replacement is not broadening');
 });
 
+test('ARCH-CHANGE-GATE-001 the harness delta detects removed guard ids, invocations, and shrunk mutation tests', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'arch-diff-harness-'));
+    fs.mkdirSync(path.join(root, 'src'), { recursive: true });
+    fs.mkdirSync(path.join(root, 'docs/testing'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'src/a.ts'), '// a\n');
+    fs.writeFileSync(path.join(root, 'docs/testing/architecture-modules.json'), JSON.stringify({
+        version: 1, scope: { roots: ['src'] },
+        modules: [{
+            id: 'MOD-ALPHA', title: 'A', purpose: 'fixture',
+            source: { include: ['src/**'], exclude: [] }, publicEntrypoints: ['src/**'],
+            mayDependOn: [], roles: [{ role: 'application', include: ['src/**'] }],
+            productCapabilities: ['MAIN-TEST-001'],
+        }],
+    }));
+    fs.writeFileSync(path.join(root, 'docs/testing/main-capability-coverage.json'),
+        JSON.stringify({ version: 1, capabilities: [{ id: 'MAIN-TEST-001' }] }));
+    const headGuards = "class G { 'ARCH-ONE-001'(root) {} }";
+    const baseGuards = "class G { 'ARCH-ONE-001'(root) {} 'ARCH-TWO-001'(root) {} }";
+    const headPkg = JSON.stringify({ scripts: { 'test:architecture-policy': "node scripts/architecture/checkClosedWorld.js" } });
+    const basePkg = JSON.stringify({ scripts: { 'test:architecture-policy': "node scripts/architecture/checkClosedWorld.js && node scripts/architecture/checkModuleBoundaries.js" } });
+    const headTests = '// controlled mutation\n';
+    const baseTests = '// controlled mutation\n// controlled mutation\n// controlled mutation\n';
+    const git = {
+        changedFiles: () => [
+            { status: 'M', path: 'scripts/run-architecture-guards.js' },
+            { status: 'M', path: 'package.json' },
+            { status: 'M', path: 'tests/unit/architecture/moduleBoundaries.test.js' },
+            { status: 'D', path: 'scripts/architecture/checkWebviewManifest.js' },
+        ],
+        fileAt: (ref, relativePath) => {
+            if (relativePath.endsWith('run-architecture-guards.js')) {
+                return ref === 'base' ? baseGuards : headGuards;
+            }
+            if (relativePath === 'package.json') { return ref === 'base' ? basePkg : headPkg; }
+            if (relativePath.endsWith('moduleBoundaries.test.js')) {
+                return ref === 'base' ? baseTests : headTests;
+            }
+            return null;
+        },
+    };
+    const report = collectArchitectureDiff({ rootDirectory: root, baseRef: 'base', git });
+    assert.deepEqual(report.harnessDelta.deletedFiles,
+        ['scripts/architecture/checkWebviewManifest.js']);
+    assert.deepEqual(report.harnessDelta.removedGuardIds, ['ARCH-TWO-001']);
+    assert.deepEqual(report.harnessDelta.removedInvocations,
+        ['package.json: node scripts/architecture/checkModuleBoundaries.js']);
+    assert.deepEqual(report.harnessDelta.shrunkMutationTests,
+        ['tests/unit/architecture/moduleBoundaries.test.js: 3 -> 1']);
+    const { classification, errors } = classifyArchitectureChange(report);
+    assert.equal(classification, 'relaxing');
+    assert.ok(errors.some(error => error.includes('ARCH-CHANGE')));
+});
+
 test('ARCH-CHANGE-GATE-001 a self-diff against HEAD is a clean product-only report', () => {
     const report = collectArchitectureDiff({
         rootDirectory: repoRoot,


### PR DESCRIPTION
## Summary

W1 review Blocker 2: the anti-self-amendment gate only protected the policy JSONs — guard implementations, guard tests, and CI wiring could be weakened inside a product-only PR.

- **`reportArchitectureDiff.js`** gains the protected harness surface (`scripts/architecture/**`, `tests/unit/architecture/**`, `.github/workflows/**`, `run-architecture-guards.js`, `ciContracts.js`, `package.json`) and computes the weakening delta: deleted harness files, removed guard ids, removed lane/workflow invocations, shrunk mutation tests.
- **`checkArchitectureChange.js`**: any harness weakening classifies as relaxing and requires an ARCH-CHANGE record; a guard-logic change with intact wiring is tightening (the kill mechanism is the guard's own mutation tests).
- Controlled mutations for all four review scenarios (guard file deleted, guard id removed, lane invocation removed, mutation tests shrunk) plus the intact-wiring tightening case and a fake-git end-to-end delta test.

## Skill harvest

no skill change.

## Verification

- Architecture unit 17/17 green; policy lane 69/69 green; the gate self-classifies this PR.
- Full coverage gate locally: baseline passed, changed-line coverage 87.83% against origin/main.
- `npm run test:behavior-contracts` green after the audit commits; `git diff --check` clean.