### PR TITLE
feat(architecture): require base-landed Architecture Change records (review R3)

### DIFF
--- a/docs/architecture-harness-refactor-program.md
+++ b/docs/architecture-harness-refactor-program.md
@@ -599,6 +599,25 @@ fails. A product PR cannot bundle and consume a relaxation. Tightening may
 travel with the migration that removes the final bypass when the diff only
 reduces debt and keeps the commit independently reviewable.
 
+The gate enforces the landing order mechanically (review R3):
+
+- the `ARCH-CHANGE-*` record must already exist in the PR base — it landed
+  through its own earlier, documentation-only PR. A record added in the same
+  PR that consumes the relaxation never authorizes it and fails the gate;
+- the record must carry exactly one fenced ```` ```arch-change ````
+  machine-summary block with a structured `id` (matching the filename),
+  `status: "approved"`, a non-empty `modules` list, and a declared `delta`
+  (`mayDependOnGrown`, `writersGrown`, `baselineGrown`, `waiversAdded`,
+  `rePartition`, `harnessWeakening`). An empty markdown file or a bare
+  filename match is not a candidate;
+- the declared delta must cover the actual policy delta computed from the
+  diff (subset semantics: a record may declare more than a consuming PR
+  realizes, never less);
+- owner approval timing holds transitively: a record present in the base
+  necessarily merged through an earlier PR whose merge-approval status was
+  green, which requires the owner comment to be newer than that PR's final
+  commit.
+
 CI recognizes a fourth classification: **registry re-partition** — splitting,
 merging, or renaming architecture modules, or re-assigning files between them,
 without broadening any allowed edge, writer set, or waiver. Re-partitioning the

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "2b7bdcc70d234bed812e572897b323623790eb9b",
+        "head": "d1f7ab3f8aa0900af3bc03cbac0dc684c1d87652",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -446,7 +446,8 @@
             "ddbf7acf78ff20f0e097bec3ae2e7e54e89980ae",
             "bfa2f05d2da81d2b51d1850d874b5389d5e286ee",
             "3a984d357c94624d93434fa6e3b889cf201161a1",
-            "88f31ce6c058b6bbfd44d104442c2d3f7c616fca"
+            "88f31ce6c058b6bbfd44d104442c2d3f7c616fca",
+            "9228479e990290a8bd207ea189981cc5de9b4709"
         ]
     },
     "capabilities": [
@@ -2298,7 +2299,8 @@
                 "6c0c2f0a131680005e50645aba9c61e2b880236f",
                 "73ac894df7047f36ade1fb750b70392ce28c6a2f",
                 "e628ec8365f5312e5d547feef7b08606228e9d99",
-                "2b7bdcc70d234bed812e572897b323623790eb9b"
+                "2b7bdcc70d234bed812e572897b323623790eb9b",
+                "d1f7ab3f8aa0900af3bc03cbac0dc684c1d87652"
             ],
             "behaviors": [
                 "ARCH-POLICY-SCHEMA-001",

--- a/scripts/architecture/architectureChangeRecords.js
+++ b/scripts/architecture/architectureChangeRecords.js
@@ -1,0 +1,190 @@
+'use strict';
+
+/**
+ * Architecture Change record parsing and coverage matching (review R3;
+ * charter 8.9).
+ *
+ * An Architecture Change record authorizes a relaxation or re-partition only
+ * when all of the following hold:
+ *
+ * 1. The record file already exists in the PR base — it landed through its
+ *    own earlier pull request (charter 8.9: the change lands before product
+ *    work consumes it). A record added in the same pull request never
+ *    authorizes anything.
+ * 2. The record carries exactly one machine-readable ```arch-change fenced
+ *    JSON block with a structured id, status, module list, and target delta.
+ *    An empty markdown file or a bare filename match is not a candidate.
+ * 3. The declared delta covers the actual policy delta computed from the
+ *    diff (subset semantics: the record may declare more than a consuming
+ *    PR realizes, never less).
+ *
+ * Approval timing is transitive by construction: a record in the base
+ * necessarily merged through an earlier PR, and every merge requires the
+ * merge-approval status, which is green only when the owner approval comment
+ * is newer than that PR's head commit. Hence the owner approval for the
+ * record is always newer than the record's final commit.
+ */
+
+const ARCH_CHANGE_RECORD_PATTERN = /^docs\/architecture\/changes\/ARCH-CHANGE-[A-Z0-9-]+\.md$/;
+const ARCH_CHANGE_ID_PATTERN = /^ARCH-CHANGE-[A-Z0-9-]+$/;
+const RECORDS_DIRECTORY = 'docs/architecture/changes/';
+const BLOCK_PATTERN = /```arch-change\s*\r?\n([\s\S]*?)```/;
+
+const DELTA_MAP_KEYS = ['mayDependOnGrown', 'writersGrown'];
+const DELTA_LIST_KEYS = ['baselineGrown', 'waiversAdded'];
+const DELTA_FLAG_KEYS = ['rePartition', 'harnessWeakening'];
+const DELTA_KEYS = [...DELTA_MAP_KEYS, ...DELTA_LIST_KEYS, ...DELTA_FLAG_KEYS];
+
+function isStringArray(value) {
+    return Array.isArray(value) && value.every(item => typeof item === 'string' && item.length > 0);
+}
+
+function isStringArrayMap(value) {
+    return value !== null && typeof value === 'object' && !Array.isArray(value)
+        && Object.values(value).every(isStringArray);
+}
+
+function recordIdFromPath(recordPath) {
+    const match = recordPath.match(/ARCH-CHANGE-[A-Z0-9-]+(?=\.md$)/);
+    return match ? match[0] : null;
+}
+
+/**
+ * parseArchitectureChangeRecord({ path, text }) -> { record | null, errors }.
+ * Fail-closed: any schema violation makes the record unusable.
+ */
+function parseArchitectureChangeRecord({ path: recordPath, text }) {
+    const errors = [];
+    const blocks = [...text.matchAll(new RegExp(BLOCK_PATTERN.source, 'g'))];
+    if (blocks.length === 0) {
+        errors.push(`${recordPath}: no \`\`\`arch-change machine-summary block`);
+        return { record: null, errors };
+    }
+    if (blocks.length > 1) {
+        errors.push(`${recordPath}: multiple arch-change machine-summary blocks`);
+        return { record: null, errors };
+    }
+    let parsed;
+    try {
+        parsed = JSON.parse(blocks[0][1]);
+    } catch (error) {
+        errors.push(`${recordPath}: arch-change block is not valid JSON (${error.message})`);
+        return { record: null, errors };
+    }
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        errors.push(`${recordPath}: arch-change block must be a JSON object`);
+        return { record: null, errors };
+    }
+
+    const expectedId = recordIdFromPath(recordPath);
+    if (typeof parsed.id !== 'string' || !ARCH_CHANGE_ID_PATTERN.test(parsed.id)) {
+        errors.push(`${recordPath}: id must match ${ARCH_CHANGE_ID_PATTERN}`);
+    } else if (parsed.id !== expectedId) {
+        errors.push(`${recordPath}: id ${parsed.id} does not match the filename ${expectedId}`);
+    }
+    if (parsed.status !== 'approved') {
+        errors.push(`${recordPath}: status must be exactly "approved" (found ${JSON.stringify(parsed.status)})`);
+    }
+    if (!Array.isArray(parsed.modules) || parsed.modules.length === 0
+        || !parsed.modules.every(moduleId => typeof moduleId === 'string' && moduleId.length > 0)) {
+        errors.push(`${recordPath}: modules must be a non-empty array of module ids`);
+    }
+
+    const rawDelta = parsed.delta === undefined ? {} : parsed.delta;
+    if (rawDelta === null || typeof rawDelta !== 'object' || Array.isArray(rawDelta)) {
+        errors.push(`${recordPath}: delta must be an object`);
+        return { record: null, errors };
+    }
+    for (const key of Object.keys(rawDelta)) {
+        if (!DELTA_KEYS.includes(key)) {
+            errors.push(`${recordPath}: unknown delta key ${JSON.stringify(key)} `
+                + `(allowed: ${DELTA_KEYS.join(', ')})`);
+        }
+    }
+    for (const key of DELTA_MAP_KEYS) {
+        if (rawDelta[key] !== undefined && !isStringArrayMap(rawDelta[key])) {
+            errors.push(`${recordPath}: delta.${key} must map ids to non-empty string arrays`);
+        }
+    }
+    for (const key of DELTA_LIST_KEYS) {
+        if (rawDelta[key] !== undefined && !isStringArray(rawDelta[key])) {
+            errors.push(`${recordPath}: delta.${key} must be an array of strings`);
+        }
+    }
+    for (const key of DELTA_FLAG_KEYS) {
+        if (rawDelta[key] !== undefined && typeof rawDelta[key] !== 'boolean') {
+            errors.push(`${recordPath}: delta.${key} must be a boolean`);
+        }
+    }
+    if (errors.length > 0) {
+        return { record: null, errors };
+    }
+
+    const delta = {
+        mayDependOnGrown: rawDelta.mayDependOnGrown || {},
+        writersGrown: rawDelta.writersGrown || {},
+        baselineGrown: rawDelta.baselineGrown || [],
+        waiversAdded: rawDelta.waiversAdded || [],
+        rePartition: rawDelta.rePartition === true,
+        harnessWeakening: rawDelta.harnessWeakening === true,
+    };
+    return {
+        record: {
+            id: parsed.id,
+            path: recordPath,
+            status: parsed.status,
+            modules: [...parsed.modules],
+            delta,
+        },
+        errors: [],
+    };
+}
+
+function missingMapEntries(actual, declared, label) {
+    const missing = [];
+    for (const [id, values] of Object.entries(actual)) {
+        const declaredValues = new Set((declared && declared[id]) || []);
+        for (const value of values) {
+            if (!declaredValues.has(value)) {
+                missing.push(`${label}: ${id} += ${value}`);
+            }
+        }
+    }
+    return missing;
+}
+
+function missingListEntries(actual, declared, label) {
+    const declaredSet = new Set(declared || []);
+    return actual.filter(value => !declaredSet.has(value))
+        .map(value => `${label}: ${value}`);
+}
+
+/**
+ * Does the record's declared delta cover the actual policy delta?
+ * coversPolicyDelta(record, actual) -> { covered, missing } where actual is
+ * { policyDelta, harnessWeakened, rePartition }.
+ */
+function coversPolicyDelta(record, actual) {
+    const { policyDelta, harnessWeakened, rePartition } = actual;
+    const { delta } = record;
+    const missing = [
+        ...missingMapEntries(policyDelta.mayDependOnGrown, delta.mayDependOnGrown, 'mayDependOn broadened'),
+        ...missingMapEntries(policyDelta.writersGrown, delta.writersGrown, 'writers broadened'),
+        ...missingListEntries(policyDelta.baselineGrown, delta.baselineGrown, 'baseline grew'),
+        ...missingListEntries(policyDelta.waiversAdded, delta.waiversAdded, 'waiver added'),
+    ];
+    if (rePartition && !delta.rePartition) {
+        missing.push('registry re-partition not declared');
+    }
+    if (harnessWeakened && !delta.harnessWeakening) {
+        missing.push('harness weakening not declared');
+    }
+    return { covered: missing.length === 0, missing };
+}
+
+module.exports = {
+    ARCH_CHANGE_RECORD_PATTERN,
+    RECORDS_DIRECTORY,
+    coversPolicyDelta,
+    parseArchitectureChangeRecord,
+};

--- a/scripts/architecture/checkArchitectureChange.js
+++ b/scripts/architecture/checkArchitectureChange.js
@@ -11,8 +11,17 @@
  * - relaxing or registry re-partition: baseline grew, waivers added,
  *   mayDependOn broadened, writer sets grew, module structure changed, or
  *   the harness surface weakened (a guard file deleted, a guard id removed,
- *   a lane or workflow invocation removed, mutation tests shrank) — requires
- *   an added docs/architecture/changes/ARCH-CHANGE-*.md record.
+ *   a lane or workflow invocation removed, mutation tests shrank).
+ *
+ * A relaxing or re-partition change is authorized only by an Architecture
+ * Change record that already exists in the PR base (review R3; charter 8.9:
+ * the record lands in its own earlier PR before product work consumes it).
+ * The record must carry a valid ```arch-change machine-summary block whose
+ * declared delta covers the actual policy delta; an empty markdown file, a
+ * bare filename match, or a record added in the same PR never authorizes.
+ * Because every merge requires the merge-approval status (owner comment
+ * newer than the PR head), a record present in the base was necessarily
+ * approved after its final commit — approval timing holds transitively.
  *
  * An agent cannot legalize its own violation: the classification is computed
  * from the diff, not declared.
@@ -23,8 +32,71 @@ const {
     collectArchitectureDiff,
     defaultGit,
 } = require('./reportArchitectureDiff');
+const {
+    ARCH_CHANGE_RECORD_PATTERN,
+    coversPolicyDelta,
+    parseArchitectureChangeRecord,
+} = require('./architectureChangeRecords');
 
-const ARCH_CHANGE_PATTERN = /^docs\/architecture\/changes\/ARCH-CHANGE-[A-Z0-9-]+\.md$/;
+// Kept for backward compatibility with existing imports.
+const ARCH_CHANGE_PATTERN = ARCH_CHANGE_RECORD_PATTERN;
+
+function harnessWeakenedOf(harness) {
+    return harness.deletedFiles.length > 0
+        || harness.removedGuardIds.length > 0
+        || harness.removedInvocations.length > 0
+        || harness.shrunkMutationTests.length > 0;
+}
+
+/**
+ * Authorize a relaxing/re-partition classification against the Architecture
+ * Change records present in the base. Returns the error list (empty when
+ * authorized).
+ */
+function authorizeWithBaseRecords(report, classification, harnessWeakened) {
+    const baseRecords = report.baseRecords || [];
+    const candidates = [];
+    const invalid = [];
+    for (const { path: recordPath, text } of baseRecords) {
+        const { record, errors } = parseArchitectureChangeRecord({ path: recordPath, text });
+        if (record) { candidates.push(record); }
+        if (errors.length > 0) { invalid.push(...errors); }
+    }
+    const actual = {
+        policyDelta: report.policyDelta,
+        harnessWeakened,
+        rePartition: classification === 're-partition',
+    };
+    let bestMissing = null;
+    for (const record of candidates) {
+        const { covered, missing } = coversPolicyDelta(record, actual);
+        if (covered) { return []; }
+        if (bestMissing === null || missing.length < bestMissing.length) {
+            bestMissing = missing;
+        }
+    }
+
+    const verb = classification === 'relaxing' ? 'relaxes' : 're-partitions';
+    const errors = [];
+    if (candidates.length === 0) {
+        errors.push(`anti-self-amendment: this change ${verb} architecture policy or weakens the `
+            + 'harness, and no valid approved Architecture Change record exists in the PR base '
+            + `(found ${baseRecords.length} record file(s), ${invalid.length} invalid). Land a `
+            + 'docs-only PR adding docs/architecture/changes/ARCH-CHANGE-<seq>.md with an '
+            + '```arch-change machine-summary block (id, status "approved", modules, declared '
+            + 'delta) first; a record added in the same PR never authorizes consumption.');
+    } else {
+        errors.push(`anti-self-amendment: this change ${verb} architecture policy or weakens the `
+            + `harness beyond every approved Architecture Change record in the PR base. Uncovered `
+            + `delta: ${bestMissing.join('; ')}. Land a docs-only record PR declaring this delta `
+            + 'first, or narrow the change to what an existing record declares.');
+    }
+    if (report.newFiles.some(file => ARCH_CHANGE_RECORD_PATTERN.test(file))) {
+        errors.push('anti-self-amendment: this PR adds an Architecture Change record and consumes '
+            + 'a relaxation in the same diff — the record must land in an earlier PR (charter 8.9).');
+    }
+    return errors;
+}
 
 /**
  * classifyArchitectureChange(report) -> {
@@ -37,16 +109,11 @@ function classifyArchitectureChange(report) {
     if (report.errors && report.errors.length > 0) {
         errors.push(...report.errors);
     }
-    const hasArchChangeRecord = report.newFiles
-        .some(file => ARCH_CHANGE_PATTERN.test(file));
     const harness = report.harnessDelta || {
         touched: [], deletedFiles: [], removedGuardIds: [],
         removedInvocations: [], shrunkMutationTests: [],
     };
-    const harnessWeakened = harness.deletedFiles.length > 0
-        || harness.removedGuardIds.length > 0
-        || harness.removedInvocations.length > 0
-        || harness.shrunkMutationTests.length > 0;
+    const harnessWeakened = harnessWeakenedOf(harness);
     if (report.protectedTouched.length === 0 && harness.touched.length === 0) {
         return { classification: 'product-only', errors };
     }
@@ -66,12 +133,7 @@ function classifyArchitectureChange(report) {
         return { classification: 'tightening', errors };
     }
     const classification = relaxing ? 'relaxing' : 're-partition';
-    if (!hasArchChangeRecord) {
-        errors.push(`anti-self-amendment: this change ${classification === 'relaxing' ? 'relaxes' : 're-partitions'} `
-            + 'architecture policy or weakens the harness without an Architecture Change record — add '
-            + 'docs/architecture/changes/ARCH-CHANGE-<seq>.md with evidence, alternatives, '
-            + 'compatibility impact, migration, tests, and rollback');
-    }
+    errors.push(...authorizeWithBaseRecords(report, classification, harnessWeakened));
     return { classification, errors };
 }
 

--- a/scripts/architecture/reportArchitectureDiff.js
+++ b/scripts/architecture/reportArchitectureDiff.js
@@ -16,6 +16,10 @@
 const { execFileSync } = require('child_process');
 const path = require('path');
 const { loadArchitecturePolicy } = require('./loadArchitecturePolicy');
+const {
+    ARCH_CHANGE_RECORD_PATTERN,
+    RECORDS_DIRECTORY,
+} = require('./architectureChangeRecords');
 
 const PROTECTED_POLICY_PATHS = [
     'docs/testing/architecture-modules.json',
@@ -81,6 +85,12 @@ function defaultGit(rootDirectory) {
                 return null;
             }
         },
+        listFiles(ref, prefix) {
+            const output = execFileSync(
+                'git', ['ls-tree', '-r', '--name-only', ref, '--', prefix],
+                { cwd: rootDirectory, encoding: 'utf8'});
+            return output.trim().split('\n').filter(Boolean);
+        },
     };
 }
 
@@ -105,11 +115,20 @@ function diffStringSets(baseValues, headValues) {
 }
 
 /**
- * Full impact report. git helpers: { changedFiles(baseRef), fileAt(ref, path) }.
+ * Full impact report. git helpers: { changedFiles(baseRef), fileAt(ref, path),
+ * listFiles(ref, prefix) }.
  */
 function collectArchitectureDiff({ rootDirectory, baseRef, git }) {
     const policy = loadArchitecturePolicy(rootDirectory);
     const changed = git.changedFiles(baseRef);
+
+    // Architecture Change records that already exist in the base (review R3):
+    // only these can authorize a relaxation; records added by this change
+    // never count.
+    const baseRecords = git.listFiles(baseRef, RECORDS_DIRECTORY)
+        .filter(recordPath => ARCH_CHANGE_RECORD_PATTERN.test(recordPath))
+        .map(recordPath => ({ path: recordPath, text: git.fileAt(baseRef, recordPath) }))
+        .filter(record => record.text !== null);
 
     const touchedModules = new Map();
     const newFiles = [];
@@ -238,6 +257,7 @@ function collectArchitectureDiff({ rootDirectory, baseRef, git }) {
         protectedTouched,
         harnessDelta,
         policyDelta,
+        baseRecords,
     };
 }
 
@@ -254,6 +274,9 @@ function formatReport(report) {
     }
     if (report.protectedTouched.length > 0) {
         lines.push(`  protected policy files: ${report.protectedTouched.join(', ')}`);
+    }
+    if (report.baseRecords) {
+        lines.push(`  architecture change records in base: ${report.baseRecords.length}`);
     }
     const grown = Object.entries(report.policyDelta.mayDependOnGrown);
     for (const [id, edges] of grown) {

--- a/tests/unit/architecture/architectureChange.test.js
+++ b/tests/unit/architecture/architectureChange.test.js
@@ -72,16 +72,18 @@ test('ARCH-CHANGE-GATE-001 controlled mutation: baseline growth without a record
     assert.equal(result.classification, 'relaxing');
     assert.ok(result.errors.some(error => error.includes('ARCH-CHANGE')));
 
+    // Review R3: a record added in the same PR never authorizes consumption.
     const withRecord = classifyArchitectureChange(report({
         newFiles: RECORD,
         protectedTouched: ['.ci/architecture-debt-baseline.json'],
         policyDelta: {
-            mayDependOn: {}, mayDependOnGrown: {}, writersGrown: {}, waiversAdded: [],
+            mayDependOnGrown: {}, writersGrown: {}, waiversAdded: [],
             baselineGrown: ['2:MOD-A->MOD-B'], modulesChanged: true,
         },
     }));
     assert.equal(withRecord.classification, 'relaxing');
-    assert.deepEqual(withRecord.errors, []);
+    assert.ok(withRecord.errors.some(error => error.includes('same PR')
+        || error.includes('same diff')), JSON.stringify(withRecord.errors));
 });
 
 test('ARCH-CHANGE-GATE-001 controlled mutation: broadening mayDependOn without a record fails', () => {
@@ -131,6 +133,7 @@ test('ARCH-CHANGE-GATE-001 controlled mutation: registry re-partition without a 
     assert.equal(result.classification, 're-partition');
     assert.ok(result.errors.some(error => error.includes('ARCH-CHANGE')));
 
+    // Review R3: a record added in the same PR never authorizes consumption.
     const withRecord = classifyArchitectureChange(report({
         newFiles: RECORD,
         protectedTouched: ['docs/testing/architecture-modules.json'],
@@ -140,7 +143,8 @@ test('ARCH-CHANGE-GATE-001 controlled mutation: registry re-partition without a 
         },
     }));
     assert.equal(withRecord.classification, 're-partition');
-    assert.deepEqual(withRecord.errors, []);
+    assert.ok(withRecord.errors.some(error => error.includes('same PR')
+        || error.includes('same diff')), JSON.stringify(withRecord.errors));
 });
 
 test('ARCH-CHANGE-GATE-001 controlled mutation: deleting a harness guard file fails', () => {
@@ -206,7 +210,7 @@ test('ARCH-CHANGE-GATE-001 a guard change with intact wiring classifies as tight
 
 // ── collectArchitectureDiff with a fake git ──────────────────────────
 
-function fakeGit(root, { changed, atBase = {} }) {
+function fakeGit(root, { changed, atBase = {}, baseRecords = [] }) {
     return {
         changedFiles: () => changed,
         fileAt: (ref, relativePath) => {
@@ -214,6 +218,8 @@ function fakeGit(root, { changed, atBase = {} }) {
             const absolute = path.join(root, relativePath);
             return fs.existsSync(absolute) ? fs.readFileSync(absolute, 'utf8') : null;
         },
+        listFiles: (ref, prefix) => (ref === 'base' && prefix.startsWith('docs/architecture/changes')
+            ? baseRecords : []),
     };
 }
 
@@ -284,6 +290,7 @@ test('ARCH-CHANGE-GATE-001 formatReport renders every delta section', () => {
         newFiles: ['src/alpha/new.ts'],
         removedFiles: ['src/alpha/old.ts'],
         protectedTouched: ['docs/testing/architecture-modules.json'],
+        baseRecords: [{ path: 'docs/architecture/changes/ARCH-CHANGE-001.md', text: 'x' }],
         policyDelta: {
             mayDependOnGrown: { 'MOD-ALPHA': ['MOD-BETA'] },
             writersGrown: { 'ARCH-X-001': ['src/writer.ts'] },
@@ -297,6 +304,7 @@ test('ARCH-CHANGE-GATE-001 formatReport renders every delta section', () => {
         'architecture-modules.json', 'mayDependOn broadened: MOD-ALPHA += MOD-BETA',
         'writers broadened: ARCH-X-001 += src/writer.ts',
         'baseline grew: 2:MOD-A->MOD-B', 'waivers added: ARCH-WAIVER-009',
+        'architecture change records in base: 1',
     ]) {
         assert.ok(text.includes(fragment), fragment);
     }
@@ -339,6 +347,7 @@ test('ARCH-CHANGE-GATE-001 the policy delta covers invariants, baseline, and wai
             { status: 'M', path: 'docs/testing/architecture-waivers.json' },
             { status: 'M', path: '.ci/architecture-debt-baseline.json' },
         ],
+        listFiles: () => [],
         fileAt: (ref, relativePath) => {
             if (ref !== 'base') {
                 const absolute = path.join(root, relativePath);
@@ -407,6 +416,7 @@ test('ARCH-CHANGE-GATE-001 the harness delta detects removed guard ids, invocati
             { status: 'M', path: 'tests/unit/architecture/moduleBoundaries.test.js' },
             { status: 'D', path: 'scripts/architecture/checkWebviewManifest.js' },
         ],
+        listFiles: () => [],
         fileAt: (ref, relativePath) => {
             if (relativePath.endsWith('run-architecture-guards.js')) {
                 return ref === 'base' ? baseGuards : headGuards;
@@ -443,4 +453,242 @@ test('ARCH-CHANGE-GATE-001 a self-diff against HEAD is a clean product-only repo
     const result = runArchitectureChangeCheck(repoRoot, 'HEAD');
     assert.equal(result.classification, 'product-only');
     assert.deepEqual(result.errors, []);
+});
+
+// ── review R3: base-record authorization ─────────────────────────────
+
+const {
+    coversPolicyDelta,
+    parseArchitectureChangeRecord,
+} = require('../../../scripts/architecture/architectureChangeRecords');
+
+function recordMarkdown({ id = 'ARCH-CHANGE-001', status = 'approved', modules = ['MOD-A'], delta = {} } = {}) {
+    return [
+        `# ${id} — fixture record`, '',
+        '## Machine summary', '',
+        '```arch-change',
+        JSON.stringify({ id, status, modules, delta }, null, 2),
+        '```', '',
+    ].join('\n');
+}
+
+const RECORD_PATH = 'docs/architecture/changes/ARCH-CHANGE-001.md';
+
+function relaxingReport({ delta = {}, baseRecords = [], newFiles = [] } = {}) {
+    return report({
+        newFiles,
+        protectedTouched: ['docs/testing/architecture-modules.json'],
+        policyDelta: {
+            mayDependOnGrown: { 'MOD-A': ['MOD-B'] },
+            writersGrown: {}, baselineGrown: [], waiversAdded: [],
+            modulesChanged: true,
+            ...delta,
+        },
+        baseRecords,
+    });
+}
+
+test('ARCH-CHANGE-GATE-001 parser accepts a valid machine-summary block and applies defaults', () => {
+    const { record, errors } = parseArchitectureChangeRecord({
+        path: RECORD_PATH,
+        text: recordMarkdown(),
+    });
+    assert.deepEqual(errors, []);
+    assert.equal(record.id, 'ARCH-CHANGE-001');
+    assert.equal(record.status, 'approved');
+    assert.deepEqual(record.modules, ['MOD-A']);
+    assert.deepEqual(record.delta, {
+        mayDependOnGrown: {}, writersGrown: {}, baselineGrown: [],
+        waiversAdded: [], rePartition: false, harnessWeakening: false,
+    });
+});
+
+test('ARCH-CHANGE-GATE-001 controlled mutation: a record without a machine block cannot authorize', () => {
+    const result = classifyArchitectureChange(relaxingReport({
+        baseRecords: [{ path: RECORD_PATH, text: '# ARCH-CHANGE-001 — empty prose only\n' }],
+    }));
+    assert.equal(result.classification, 'relaxing');
+    assert.ok(result.errors.some(error => error.includes('no valid approved')), JSON.stringify(result.errors));
+    const { record, errors } = parseArchitectureChangeRecord({
+        path: RECORD_PATH, text: '# prose only\n',
+    });
+    assert.equal(record, null);
+    assert.ok(errors.some(error => error.includes('machine-summary')));
+});
+
+test('ARCH-CHANGE-GATE-001 controlled mutation: invalid machine blocks are rejected', () => {
+    const cases = {
+        'not json': recordMarkdown().replace(/\{[\s\S]*\}/, '{oops'),
+        'two blocks': `${recordMarkdown()}\n\`\`\`arch-change\n{}\n\`\`\`\n`,
+        'id mismatch': recordMarkdown({ id: 'ARCH-CHANGE-009' }),
+        'status pending': recordMarkdown({ status: 'proposed' }),
+        'empty modules': recordMarkdown({ modules: [] }),
+        'unknown delta key': recordMarkdown({ delta: { anythingGoes: true } }),
+        'bad map value': recordMarkdown({ delta: { mayDependOnGrown: { 'MOD-A': 'MOD-B' } } }),
+        'bad flag type': recordMarkdown({ delta: { rePartition: 'yes' } }),
+        'non-object root': '```arch-change\n[]\n```\n',
+        'non-object delta': recordMarkdown().replace('"delta": {}', '"delta": []'),
+    };
+    for (const [name, text] of Object.entries(cases)) {
+        const { record, errors } = parseArchitectureChangeRecord({ path: RECORD_PATH, text });
+        assert.equal(record, null, name);
+        assert.ok(errors.length > 0, name);
+        const result = classifyArchitectureChange(relaxingReport({
+            baseRecords: [{ path: RECORD_PATH, text }],
+        }));
+        assert.ok(result.errors.length > 0, `gate must fail for ${name}`);
+    }
+});
+
+test('ARCH-CHANGE-GATE-001 a covering record in the base authorizes the relaxation', () => {
+    const result = classifyArchitectureChange(relaxingReport({
+        baseRecords: [{
+            path: RECORD_PATH,
+            text: recordMarkdown({ delta: { mayDependOnGrown: { 'MOD-A': ['MOD-B'] } } }),
+        }],
+    }));
+    assert.equal(result.classification, 'relaxing');
+    assert.deepEqual(result.errors, []);
+});
+
+test('ARCH-CHANGE-GATE-001 subset semantics: a record declaring a superset covers the realized delta', () => {
+    const result = classifyArchitectureChange(relaxingReport({
+        baseRecords: [{
+            path: RECORD_PATH,
+            text: recordMarkdown({ delta: { mayDependOnGrown: { 'MOD-A': ['MOD-B', 'MOD-C'] } } }),
+        }],
+    }));
+    assert.deepEqual(result.errors, []);
+});
+
+test('ARCH-CHANGE-GATE-001 controlled mutation: an under-declaring record fails and names the uncovered delta', () => {
+    const result = classifyArchitectureChange(relaxingReport({
+        baseRecords: [{
+            path: RECORD_PATH,
+            text: recordMarkdown({ delta: { mayDependOnGrown: { 'MOD-A': ['MOD-C'] } } }),
+        }],
+    }));
+    assert.equal(result.classification, 'relaxing');
+    assert.ok(result.errors.some(error => error.includes('MOD-A += MOD-B')), JSON.stringify(result.errors));
+});
+
+test('ARCH-CHANGE-GATE-001 a re-partition requires a record declaring rePartition', () => {
+    const rePartitionReport = delta => report({
+        protectedTouched: ['docs/testing/architecture-modules.json'],
+        policyDelta: {
+            mayDependOnGrown: {}, writersGrown: {}, baselineGrown: [],
+            waiversAdded: [], modulesChanged: true,
+        },
+        baseRecords: [{ path: RECORD_PATH, text: recordMarkdown({ delta }) }],
+    });
+    const denied = classifyArchitectureChange(rePartitionReport({}));
+    assert.equal(denied.classification, 're-partition');
+    assert.ok(denied.errors.some(error => error.includes('re-partition')), JSON.stringify(denied.errors));
+    const allowed = classifyArchitectureChange(rePartitionReport({ rePartition: true }));
+    assert.deepEqual(allowed.errors, []);
+});
+
+test('ARCH-CHANGE-GATE-001 harness weakening requires a record declaring harnessWeakening', () => {
+    const harnessReport = delta => report({
+        harnessDelta: {
+            touched: ['scripts/architecture/checkClosedWorld.js'],
+            deletedFiles: ['scripts/architecture/checkClosedWorld.js'],
+            removedGuardIds: [], removedInvocations: [], shrunkMutationTests: [],
+        },
+        baseRecords: [{ path: RECORD_PATH, text: recordMarkdown({ delta }) }],
+    });
+    const denied = classifyArchitectureChange(harnessReport({}));
+    assert.ok(denied.errors.some(error => error.includes('harness weakening')), JSON.stringify(denied.errors));
+    const allowed = classifyArchitectureChange(harnessReport({ harnessWeakening: true }));
+    assert.deepEqual(allowed.errors, []);
+});
+
+test('ARCH-CHANGE-GATE-001 controlled mutation: a same-PR record fails even when its content would cover', () => {
+    const result = classifyArchitectureChange(relaxingReport({
+        newFiles: [RECORD_PATH],
+        baseRecords: [],
+    }));
+    assert.equal(result.classification, 'relaxing');
+    assert.ok(result.errors.some(error => error.includes('same PR')), JSON.stringify(result.errors));
+});
+
+test('ARCH-CHANGE-GATE-001 coversPolicyDelta checks every delta dimension', () => {
+    const record = parseArchitectureChangeRecord({
+        path: RECORD_PATH,
+        text: recordMarkdown({
+            delta: {
+                mayDependOnGrown: { 'MOD-A': ['MOD-B'] },
+                writersGrown: { 'ARCH-X-001': ['src/writer.ts'] },
+                baselineGrown: ['2:MOD-A->MOD-B'],
+                waiversAdded: ['ARCH-WAIVER-009'],
+                rePartition: true,
+                harnessWeakening: true,
+            },
+        }),
+    }).record;
+    const actualFor = overrides => ({
+        policyDelta: {
+            mayDependOnGrown: {}, writersGrown: {}, baselineGrown: [],
+            waiversAdded: [], modulesChanged: true,
+            ...overrides,
+        },
+        harnessWeakened: false,
+        rePartition: false,
+    });
+    assert.equal(coversPolicyDelta(record, actualFor({ mayDependOnGrown: { 'MOD-A': ['MOD-B'] } })).covered, true);
+    assert.equal(coversPolicyDelta(record, actualFor({ mayDependOnGrown: { 'MOD-A': ['MOD-Z'] } })).covered, false);
+    assert.equal(coversPolicyDelta(record, actualFor({ writersGrown: { 'ARCH-X-001': ['src/other.ts'] } })).covered, false);
+    assert.equal(coversPolicyDelta(record, actualFor({ baselineGrown: ['2:MOD-X->MOD-Y'] })).covered, false);
+    assert.equal(coversPolicyDelta(record, actualFor({ waiversAdded: ['ARCH-WAIVER-010'] })).covered, false);
+    assert.equal(coversPolicyDelta(record, { ...actualFor({}), rePartition: false }).covered, true);
+    assert.equal(coversPolicyDelta(
+        parseArchitectureChangeRecord({ path: RECORD_PATH, text: recordMarkdown() }).record,
+        { ...actualFor({}), rePartition: true }).covered, false);
+});
+
+test('ARCH-CHANGE-GATE-001 collectArchitectureDiff reads records from the base ref only', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'arch-diff-records-'));
+    fs.mkdirSync(path.join(root, 'src/alpha'), { recursive: true });
+    fs.mkdirSync(path.join(root, 'src/beta'), { recursive: true });
+    fs.mkdirSync(path.join(root, 'docs/testing'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'src/alpha/a.ts'), '// a\n');
+    fs.writeFileSync(path.join(root, 'src/beta/b.ts'), '// b\n');
+    const moduleEntry = {
+        id: 'MOD-ALPHA', title: 'A', purpose: 'fixture',
+        source: { include: ['src/alpha/**'], exclude: [] },
+        publicEntrypoints: ['src/alpha/**'],
+        mayDependOn: ['MOD-BETA'], roles: [{ role: 'application', include: ['src/alpha/**'] }],
+        productCapabilities: ['MAIN-TEST-001'],
+    };
+    const betaEntry = {
+        id: 'MOD-BETA', title: 'B', purpose: 'fixture',
+        source: { include: ['src/beta/**'], exclude: [] },
+        publicEntrypoints: ['src/beta/**'],
+        mayDependOn: [], roles: [{ role: 'application', include: ['src/beta/**'] }],
+        productCapabilities: ['MAIN-TEST-001'],
+    };
+    fs.writeFileSync(path.join(root, 'docs/testing/architecture-modules.json'), JSON.stringify({
+        version: 1, scope: { roots: ['src'] },
+        modules: [moduleEntry, betaEntry],
+    }));
+    fs.writeFileSync(path.join(root, 'docs/testing/main-capability-coverage.json'),
+        JSON.stringify({ version: 1, capabilities: [{ id: 'MAIN-TEST-001' }] }));
+    const baseRegistry = {
+        version: 1, scope: { roots: ['src'] },
+        modules: [{ ...moduleEntry, mayDependOn: [] }, betaEntry],
+    };
+    const coveringRecord = recordMarkdown({ delta: { mayDependOnGrown: { 'MOD-ALPHA': ['MOD-BETA'] } } });
+    const git = fakeGit(root, {
+        changed: [{ status: 'M', path: 'docs/testing/architecture-modules.json' }],
+        atBase: {
+            'docs/testing/architecture-modules.json': JSON.stringify(baseRegistry, null, 4) + '\n',
+            [RECORD_PATH]: coveringRecord,
+        },
+        baseRecords: [RECORD_PATH],
+    });
+    const diff = collectArchitectureDiff({ rootDirectory: root, baseRef: 'base', git });
+    assert.deepEqual(diff.baseRecords, [{ path: RECORD_PATH, text: coveringRecord }]);
+    const { classification, errors } = classifyArchitectureChange(diff);
+    assert.equal(classification, 'relaxing');
+    assert.deepEqual(errors, []);
 });


### PR DESCRIPTION
## Summary

Fixes W1 review Blocker 3: the anti-self-amendment gate authorized any same-PR file named `ARCH-CHANGE-*.md`, so a product PR could add a record and consume the relaxation in one diff.

- `collectArchitectureDiff` now collects Architecture Change records present in the **PR base**; only those can authorize a relaxing / re-partition classification.
- Records must carry exactly one valid ```arch-change machine-summary block (id matching filename, `status: "approved"`, non-empty `modules`, declared `delta`). Empty markdown or a bare filename match is never a candidate.
- The declared delta must cover the actual policy delta (subset semantics across mayDependOn / writers / baseline / waivers / rePartition / harnessWeakening).
- A record added in the same PR that consumes a relaxation produces a dedicated failure.
- Approval timing holds transitively: a base record merged through an earlier PR whose merge-approval status required an owner comment newer than its final commit.
- Charter Section 8.9 documents the mechanical record format.

## Change impact declaration

- Main capability: MAIN-ARCHITECTURE-HARNESS
- Architecture modules touched: none (harness surface only)
- Invariants / behaviors touched: ARCH-CHANGE-GATE-001 (test id)
- State authority / protocol / persistence / identity / recovery semantics: unchanged
- Architecture-policy delta classification: tightening (harness surface strengthened; no policy JSON touched)
- Baseline / waiver delta: zero

## Verification

- `npm run test-compile` ✅
- `node --test 'tests/unit/architecture/**/*.test.js'` — 86/86 ✅ (15 controlled mutations incl. same-PR record, invalid blocks, under-declared delta)
- `npm run test:architecture-policy` ✅ (gate self-classification: tightening)
- `npm run test:architecture-guards` ✅
- `npm run test:behavior-contracts` ✅
- `npm run test:coverage:ci` ✅ — changed-line coverage 98.97% (288/291), baseline checks pass
- `git diff --check` ✅

## Skill harvest

none — no skill change justified; the task followed the established review-fix-commit loop without guidance gaps.