### PR TITLE
feat(architecture): wire the change impact declaration into the merge gate (review R4)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,16 @@
 
 <!-- What changed and why. Pull request titles and bodies are written in English. -->
 
+## Change impact declaration
+
+<!--
+Required; the merge-approval gate rejects pull requests without it.
+Run `node scripts/generate-change-impact-declaration.js` right before pushing
+and paste the generated block below, filling every newFiles reason first.
+The declaration binds the head SHA: regenerate it whenever the head moves
+(rebase, new commits), otherwise the gate rejects it as stale.
+-->
+
 ## Skill harvest
 
 <!--

--- a/.github/workflows/merge-approval-gate.yml
+++ b/.github/workflows/merge-approval-gate.yml
@@ -2,7 +2,9 @@ name: Merge approval gate
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    # edited: declaration blocks bind the head SHA and are re-evaluated when
+    # the body changes.
+    types: [opened, synchronize, reopened, ready_for_review, edited]
   issue_comment:
     types: [created]
 
@@ -16,10 +18,15 @@ jobs:
   gate:
     name: gate
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # The gate regenerates the architecture impact report for the PR
+          # base..head range and checks out the exact head being evaluated,
+          # so it needs full history.
+          fetch-depth: 0
       - name: Evaluate and post the merge-approval status
         run: node scripts/run-merge-approval-gate.js
         env:

--- a/docs/architecture-harness-refactor-program.md
+++ b/docs/architecture-harness-refactor-program.md
@@ -652,6 +652,22 @@ name the coordinator or public API that owns the interaction. The declaration
 does not replace enforcement; it makes semantic intent visible to the owner
 before approval.
 
+The gate enforces the comparison mechanically (review R4):
+
+- the PR body carries exactly one fenced ```` ```change-impact-declaration
+  ```` JSON block, produced by `scripts/generate-change-impact-declaration.js`
+  for the current head; the block binds `headSha`, so a body edit cannot make
+  an old declaration look fresh for a new head;
+- the merge-approval gate checks out the exact head being approved,
+  regenerates the impact report for base..head, and compares: touched
+  architecture modules, changed invariant ids, capability assignments from
+  the main-capability audit (unaudited implementation commits fail), the
+  policy-delta classification, the baseline/waiver delta, and every new
+  classified file with a non-empty reason and a module matching the registry;
+- under-reporting, over-reporting, stale, or malformed declarations post a
+  failure status; the merge-approval status is green only when both the owner
+  approval and the declaration check pass.
+
 ## 9. Invariant Discovery Method
 
 Invariant discovery is performed from repository evidence, not generated from

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "d1f7ab3f8aa0900af3bc03cbac0dc684c1d87652",
+        "head": "51db84eb828bd5ce4d0f773d571329fb569ffc1e",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -447,7 +447,8 @@
             "bfa2f05d2da81d2b51d1850d874b5389d5e286ee",
             "3a984d357c94624d93434fa6e3b889cf201161a1",
             "88f31ce6c058b6bbfd44d104442c2d3f7c616fca",
-            "9228479e990290a8bd207ea189981cc5de9b4709"
+            "9228479e990290a8bd207ea189981cc5de9b4709",
+            "6a7edd4573fa675486c124e4e68061ac0b78a962"
         ]
     },
     "capabilities": [
@@ -2300,7 +2301,8 @@
                 "73ac894df7047f36ade1fb750b70392ce28c6a2f",
                 "e628ec8365f5312e5d547feef7b08606228e9d99",
                 "2b7bdcc70d234bed812e572897b323623790eb9b",
-                "d1f7ab3f8aa0900af3bc03cbac0dc684c1d87652"
+                "d1f7ab3f8aa0900af3bc03cbac0dc684c1d87652",
+                "51db84eb828bd5ce4d0f773d571329fb569ffc1e"
             ],
             "behaviors": [
                 "ARCH-POLICY-SCHEMA-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "51db84eb828bd5ce4d0f773d571329fb569ffc1e",
+        "head": "a7afab45ea326f4b9bf9bfa3245c2580aa89f31e",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -448,7 +448,8 @@
             "3a984d357c94624d93434fa6e3b889cf201161a1",
             "88f31ce6c058b6bbfd44d104442c2d3f7c616fca",
             "9228479e990290a8bd207ea189981cc5de9b4709",
-            "6a7edd4573fa675486c124e4e68061ac0b78a962"
+            "6a7edd4573fa675486c124e4e68061ac0b78a962",
+            "84a05bfff1d31c5a4bc98b25ebf24e95789d0aa2"
         ]
     },
     "capabilities": [
@@ -2302,7 +2303,8 @@
                 "e628ec8365f5312e5d547feef7b08606228e9d99",
                 "2b7bdcc70d234bed812e572897b323623790eb9b",
                 "d1f7ab3f8aa0900af3bc03cbac0dc684c1d87652",
-                "51db84eb828bd5ce4d0f773d571329fb569ffc1e"
+                "51db84eb828bd5ce4d0f773d571329fb569ffc1e",
+                "a7afab45ea326f4b9bf9bfa3245c2580aa89f31e"
             ],
             "behaviors": [
                 "ARCH-POLICY-SCHEMA-001",

--- a/scripts/architecture/reportArchitectureDiff.js
+++ b/scripts/architecture/reportArchitectureDiff.js
@@ -44,6 +44,17 @@ const PROTECTED_HARNESS_FILES = [
     'scripts/run-architecture-guards.js',
     'scripts/lib/ciContracts.js',
     'package.json',
+    // The merge-approval gate and the Change Impact Declaration machinery
+    // (review R4): the last enforcement line must not be weakenable by an
+    // ordinary product change.
+    'scripts/run-merge-approval-gate.js',
+    'scripts/lib/mergeApprovals.js',
+    'scripts/lib/changeImpactDeclaration.js',
+    'scripts/lib/changeImpactContext.js',
+    'scripts/generate-change-impact-declaration.js',
+    'tests/unit/tooling/mergeApprovals.test.js',
+    'tests/unit/tooling/mergeApprovalGate.test.js',
+    'tests/unit/tooling/changeImpactDeclaration.test.js',
 ];
 
 function isHarnessPath(file) {
@@ -132,6 +143,7 @@ function collectArchitectureDiff({ rootDirectory, baseRef, git }) {
 
     const touchedModules = new Map();
     const newFiles = [];
+    const newClassifiedFiles = [];
     const removedFiles = [];
     for (const entry of changed) {
         const assignment = policy.classification.get(entry.path);
@@ -141,9 +153,15 @@ function collectArchitectureDiff({ rootDirectory, baseRef, git }) {
             }
             touchedModules.get(assignment.moduleId).push(entry.path);
         }
-        if (entry.status === 'A') { newFiles.push(entry.path); }
+        if (entry.status === 'A') {
+            newFiles.push(entry.path);
+            if (assignment) {
+                newClassifiedFiles.push({ path: entry.path, module: assignment.moduleId });
+            }
+        }
         if (entry.status === 'D') { removedFiles.push(entry.path); }
     }
+    newClassifiedFiles.sort((a, b) => a.path.localeCompare(b.path));
 
     const policyDelta = {
         mayDependOnGrown: {},
@@ -152,6 +170,7 @@ function collectArchitectureDiff({ rootDirectory, baseRef, git }) {
         waiversAdded: [],
         modulesChanged: false,
     };
+    const changedInvariantIds = [];
     for (const protectedPath of PROTECTED_POLICY_PATHS) {
         const baseText = git.fileAt(baseRef, protectedPath);
         const headText = git.fileAt('HEAD', protectedPath);
@@ -176,7 +195,13 @@ function collectArchitectureDiff({ rootDirectory, baseRef, git }) {
             const headInvariants = indexBy(headJson.invariants, 'id');
             for (const [id, headInvariant] of headInvariants) {
                 const baseInvariant = baseInvariants.get(id);
-                if (!baseInvariant) { continue; }
+                if (!baseInvariant) {
+                    changedInvariantIds.push(id);
+                    continue;
+                }
+                if (JSON.stringify(baseInvariant) !== JSON.stringify(headInvariant)) {
+                    changedInvariantIds.push(id);
+                }
                 // Writer sets ratchet by net size: an authority move replaces
                 // old writers with fewer new ones (tightening); only net
                 // growth beyond the base size is broadening.
@@ -186,6 +211,9 @@ function collectArchitectureDiff({ rootDirectory, baseRef, git }) {
                 if (added.length > 0 && headWriters.length > baseWriters.length) {
                     policyDelta.writersGrown[id] = added;
                 }
+            }
+            for (const id of baseInvariants.keys()) {
+                if (!headInvariants.has(id)) { changedInvariantIds.push(id); }
             }
         }
         if (protectedPath.endsWith('architecture-debt-baseline.json')) {
@@ -253,10 +281,12 @@ function collectArchitectureDiff({ rootDirectory, baseRef, git }) {
         errors: policy.errors,
         touchedModules: Object.fromEntries(touchedModules),
         newFiles: newFiles.sort(),
+        newClassifiedFiles,
         removedFiles: removedFiles.sort(),
         protectedTouched,
         harnessDelta,
         policyDelta,
+        changedInvariantIds: changedInvariantIds.sort(),
         baseRecords,
     };
 }

--- a/scripts/generate-change-impact-declaration.js
+++ b/scripts/generate-change-impact-declaration.js
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Generates the ```change-impact-declaration block for the current head
+ * (review R4; charter 8.10). Run this right before pushing a pull request
+ * and paste the block into the PR body. The declaration binds the head SHA:
+ * regenerate it whenever the head moves, otherwise the merge-approval gate
+ * rejects it as stale.
+ *
+ * Every new classified file is emitted with an empty reason placeholder —
+ * fill each one with why the file belongs to its module before pasting; the
+ * gate rejects empty reasons.
+ *
+ * Usage: node scripts/generate-change-impact-declaration.js [base-ref]
+ */
+
+const path = require('path');
+const { collectChangeImpactContext } = require('./lib/changeImpactContext');
+
+function buildDeclaration({ rootDirectory, baseRef }) {
+    const context = collectChangeImpactContext({ rootDirectory, baseRef });
+    const declaration = {
+        headSha: context.headSha,
+        capabilities: context.assignedCapabilities,
+        modules: Object.keys(context.report.touchedModules).sort(),
+        invariants: context.report.changedInvariantIds || [],
+        policyDelta: context.classification,
+        baselineWaiverDelta: (context.report.protectedTouched || [])
+            .some(file => file.endsWith('architecture-debt-baseline.json')
+                || file.endsWith('architecture-waivers.json'))
+            ? 'changed'
+            : 'zero',
+        newFiles: (context.report.newClassifiedFiles || [])
+            .map(entry => ({ path: entry.path, module: entry.module, reason: '' })),
+    };
+    const block = '```change-impact-declaration\n'
+        + `${JSON.stringify(declaration, null, 2)}\n`
+        + '```';
+    return { block, declaration, context };
+}
+
+function main() {
+    const baseRef = process.argv[2] || process.env.COVERAGE_DIFF_BASE
+        || (process.env.GITHUB_BASE_REF && `origin/${process.env.GITHUB_BASE_REF}`)
+        || 'origin/main';
+    const rootDirectory = path.resolve(__dirname, '..');
+    const { block, declaration, context } = buildDeclaration({ rootDirectory, baseRef });
+
+    console.log(block);
+
+    if (declaration.newFiles.length > 0) {
+        console.error('\nFill every empty newFiles reason before pasting — the gate rejects empty reasons.');
+    }
+    if (context.errors.length > 0) {
+        console.error('\nResolve these issues before publishing:');
+        for (const error of context.errors) { console.error(`  ✗ ${error}`); }
+        process.exitCode = 1;
+    }
+}
+
+if (require.main === module) { main(); }
+
+module.exports = { buildDeclaration };

--- a/scripts/lib/changeImpactContext.js
+++ b/scripts/lib/changeImpactContext.js
@@ -1,0 +1,94 @@
+'use strict';
+
+/**
+ * Shared glue for the Change Impact Declaration (review R4): collects the
+ * regenerated truth for a base..head range — the architecture impact report,
+ * the gate classification, and the capability assignments recorded by the
+ * main-capability audit. Consumed by the declaration generator (local) and
+ * the merge-approval gate (CI). The caller ensures the working tree is
+ * checked out at the head being evaluated.
+ */
+
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const {
+    collectArchitectureDiff,
+    defaultGit,
+} = require('../architecture/reportArchitectureDiff');
+const { classifyArchitectureChange } = require('../architecture/checkArchitectureChange');
+
+const CAPABILITY_AUDIT_PATH = 'docs/testing/main-capability-coverage.json';
+
+function git(rootDirectory, args) {
+    return execFileSync('git', args, { cwd: rootDirectory, encoding: 'utf8' }).trim();
+}
+
+/** Capability assignments for every commit in the range, from the audit file. */
+function capabilityAssignments(rootDirectory, commits) {
+    const auditPath = path.join(rootDirectory, CAPABILITY_AUDIT_PATH);
+    if (!fs.existsSync(auditPath)) {
+        return { assignedCapabilities: [], errors: [`${CAPABILITY_AUDIT_PATH} is missing at the PR head`] };
+    }
+    let audit;
+    try {
+        audit = JSON.parse(fs.readFileSync(auditPath, 'utf8'));
+    } catch (error) {
+        return { assignedCapabilities: [], errors: [`${CAPABILITY_AUDIT_PATH} is not valid JSON (${error.message})`] };
+    }
+    const documentationCommits = new Set((audit.audit && audit.audit.ignoredDocumentationCommits) || []);
+    const capabilityByCommit = new Map();
+    for (const capability of audit.capabilities || []) {
+        for (const sha of capability.commits || []) {
+            capabilityByCommit.set(sha, capability.id);
+        }
+    }
+    const assigned = new Set();
+    const errors = [];
+    for (const sha of commits) {
+        if (documentationCommits.has(sha)) { continue; }
+        const capability = capabilityByCommit.get(sha);
+        if (!capability) {
+            errors.push(`commit ${sha} is not assigned to any MAIN-* capability in`
+                + ` ${CAPABILITY_AUDIT_PATH} — run scripts/regenerate-capability-audit.js`);
+            continue;
+        }
+        assigned.add(capability);
+    }
+    return { assignedCapabilities: [...assigned].sort(), errors };
+}
+
+/**
+ * collectChangeImpactContext({ rootDirectory, baseRef }) -> {
+ *   headSha, report, classification, assignedCapabilities, errors,
+ * }
+ */
+function collectChangeImpactContext({ rootDirectory, baseRef }) {
+    const headSha = git(rootDirectory, ['rev-parse', 'HEAD']);
+    const commits = git(rootDirectory, ['rev-list', '--no-merges', `${baseRef}..HEAD`])
+        .split('\n').filter(Boolean);
+    const report = collectArchitectureDiff({
+        rootDirectory,
+        baseRef,
+        git: defaultGit(rootDirectory),
+    });
+    const { classification, errors: classificationErrors } = classifyArchitectureChange(report);
+    const capabilities = capabilityAssignments(rootDirectory, commits);
+    return {
+        headSha,
+        report,
+        classification,
+        assignedCapabilities: capabilities.assignedCapabilities,
+        errors: [
+            ...(report.errors || []),
+            ...classificationErrors,
+            ...capabilities.errors,
+        ],
+    };
+}
+
+module.exports = {
+    CAPABILITY_AUDIT_PATH,
+    capabilityAssignments,
+    collectChangeImpactContext,
+};

--- a/scripts/lib/changeImpactContext.js
+++ b/scripts/lib/changeImpactContext.js
@@ -17,6 +17,7 @@ const {
     defaultGit,
 } = require('../architecture/reportArchitectureDiff');
 const { classifyArchitectureChange } = require('../architecture/checkArchitectureChange');
+const { isDocumentationPath } = require('./mainCapabilityCoverage');
 
 const CAPABILITY_AUDIT_PATH = 'docs/testing/main-capability-coverage.json';
 
@@ -24,8 +25,16 @@ function git(rootDirectory, args) {
     return execFileSync('git', args, { cwd: rootDirectory, encoding: 'utf8' }).trim();
 }
 
-/** Capability assignments for every commit in the range, from the audit file. */
-function capabilityAssignments(rootDirectory, commits) {
+/**
+ * Capability assignments for every commit in the range, from the audit file.
+ * A commit whose own diff touches only documentation paths needs no
+ * assignment — the audit commit itself always qualifies (it is registered
+ * into ignoredDocumentationCommits only by the next regeneration).
+ */
+function capabilityAssignments(rootDirectory, commits, options = {}) {
+    const listCommitFiles = options.listCommitFiles || (sha => git(rootDirectory, [
+        'show', '--name-only', '--format=', sha,
+    ]).split('\n').filter(Boolean));
     const auditPath = path.join(rootDirectory, CAPABILITY_AUDIT_PATH);
     if (!fs.existsSync(auditPath)) {
         return { assignedCapabilities: [], errors: [`${CAPABILITY_AUDIT_PATH} is missing at the PR head`] };
@@ -47,6 +56,8 @@ function capabilityAssignments(rootDirectory, commits) {
     const errors = [];
     for (const sha of commits) {
         if (documentationCommits.has(sha)) { continue; }
+        const files = listCommitFiles(sha);
+        if (files.length > 0 && files.every(isDocumentationPath)) { continue; }
         const capability = capabilityByCommit.get(sha);
         if (!capability) {
             errors.push(`commit ${sha} is not assigned to any MAIN-* capability in`

--- a/scripts/lib/changeImpactDeclaration.js
+++ b/scripts/lib/changeImpactDeclaration.js
@@ -1,0 +1,191 @@
+'use strict';
+
+/**
+ * Change Impact Declaration (review R4; charter 8.10).
+ *
+ * Every pull request body must carry exactly one fenced
+ * ```change-impact-declaration JSON block, generated for the current head by
+ * scripts/generate-change-impact-declaration.js. The merge-approval gate
+ * regenerates the architecture impact report for the PR and compares it with
+ * the declaration: a stale head SHA, under-reported modules/new files, a
+ * wrong policy-delta classification, or wrong capability/invariant sets fail
+ * the gate. Editing the PR body does not retrigger push workflows, so the
+ * declaration binds the head SHA — a body edit can never make an old
+ * declaration look fresh for a new head.
+ */
+
+const DECLARATION_BLOCK_PATTERN = /```change-impact-declaration\s*\r?\n([\s\S]*?)```/;
+
+const POLICY_DELTA_VALUES = ['product-only', 'tightening', 'relaxing', 're-partition'];
+const BASELINE_WAIVER_VALUES = ['zero', 'changed'];
+
+const DECLARATION_KEYS = [
+    'headSha',
+    'capabilities',
+    'modules',
+    'invariants',
+    'policyDelta',
+    'baselineWaiverDelta',
+    'newFiles',
+];
+
+function isStringArray(value) {
+    return Array.isArray(value) && value.every(item => typeof item === 'string');
+}
+
+/**
+ * parseChangeImpactDeclaration(body) -> { declaration | null, errors }.
+ * Fail-closed: no block, multiple blocks, invalid JSON, or any schema
+ * violation makes the declaration unusable.
+ */
+function parseChangeImpactDeclaration(body) {
+    const text = String(body || '');
+    const blocks = [...text.matchAll(new RegExp(DECLARATION_BLOCK_PATTERN.source, 'g'))];
+    if (blocks.length === 0) {
+        return { declaration: null, errors: ['PR body has no ```change-impact-declaration block'
+            + ' — generate one with scripts/generate-change-impact-declaration.js'] };
+    }
+    if (blocks.length > 1) {
+        return { declaration: null, errors: ['PR body has multiple change-impact-declaration blocks'] };
+    }
+    let parsed;
+    try {
+        parsed = JSON.parse(blocks[0][1]);
+    } catch (error) {
+        return { declaration: null, errors: [`change-impact-declaration is not valid JSON (${error.message})`] };
+    }
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        return { declaration: null, errors: ['change-impact-declaration must be a JSON object'] };
+    }
+    const errors = [];
+    for (const key of Object.keys(parsed)) {
+        if (!DECLARATION_KEYS.includes(key)) {
+            errors.push(`unknown declaration key ${JSON.stringify(key)} (allowed: ${DECLARATION_KEYS.join(', ')})`);
+        }
+    }
+    if (typeof parsed.headSha !== 'string' || !/^[0-9a-f]{40}$/.test(parsed.headSha)) {
+        errors.push('headSha must be a 40-character lowercase hex commit sha');
+    }
+    for (const key of ['capabilities', 'modules', 'invariants']) {
+        if (!isStringArray(parsed[key])) {
+            errors.push(`${key} must be an array of strings`);
+        }
+    }
+    if (!POLICY_DELTA_VALUES.includes(parsed.policyDelta)) {
+        errors.push(`policyDelta must be one of ${POLICY_DELTA_VALUES.join(', ')}`);
+    }
+    if (!BASELINE_WAIVER_VALUES.includes(parsed.baselineWaiverDelta)) {
+        errors.push(`baselineWaiverDelta must be one of ${BASELINE_WAIVER_VALUES.join(', ')}`);
+    }
+    if (!Array.isArray(parsed.newFiles)) {
+        errors.push('newFiles must be an array');
+    } else {
+        for (const entry of parsed.newFiles) {
+            if (entry === null || typeof entry !== 'object' || Array.isArray(entry)) {
+                errors.push('every newFiles entry must be an object { path, module, reason }');
+                break;
+            }
+            if (typeof entry.path !== 'string' || entry.path.length === 0
+                || typeof entry.module !== 'string' || entry.module.length === 0) {
+                errors.push('every newFiles entry needs non-empty path and module strings');
+                break;
+            }
+            if (typeof entry.reason !== 'string' || entry.reason.trim().length === 0) {
+                errors.push(`newFiles entry ${entry.path} needs a non-empty reason`
+                    + ' (why this file belongs to the declared module)');
+                break;
+            }
+        }
+    }
+    if (errors.length > 0) {
+        return { declaration: null, errors };
+    }
+    return {
+        declaration: {
+            headSha: parsed.headSha,
+            capabilities: [...parsed.capabilities].sort(),
+            modules: [...parsed.modules].sort(),
+            invariants: [...parsed.invariants].sort(),
+            policyDelta: parsed.policyDelta,
+            baselineWaiverDelta: parsed.baselineWaiverDelta,
+            newFiles: parsed.newFiles
+                .map(entry => ({ path: entry.path, module: entry.module, reason: entry.reason.trim() }))
+                .sort((a, b) => a.path.localeCompare(b.path)),
+        },
+        errors: [],
+    };
+}
+
+function setDiff(actual, declared) {
+    const actualSet = new Set(actual);
+    const declaredSet = new Set(declared);
+    return {
+        missing: [...actualSet].filter(value => !declaredSet.has(value)).sort(),
+        extra: [...declaredSet].filter(value => !actualSet.has(value)).sort(),
+    };
+}
+
+function pushSetMismatch(errors, label, actual, declared) {
+    const { missing, extra } = setDiff(actual, declared);
+    if (missing.length > 0) {
+        errors.push(`declaration under-reports ${label}: ${missing.join(', ')}`);
+    }
+    if (extra.length > 0) {
+        errors.push(`declaration over-reports ${label}: ${extra.join(', ')}`);
+    }
+}
+
+/**
+ * Compare the declaration with the regenerated truth.
+ * evaluateChangeImpactDeclaration({
+ *   body, headSha, classification, report, assignedCapabilities,
+ * }) -> { declaration | null, errors }.
+ */
+function evaluateChangeImpactDeclaration({ body, headSha, classification, report, assignedCapabilities }) {
+    const { declaration, errors } = parseChangeImpactDeclaration(body);
+    if (!declaration) {
+        return { declaration: null, errors };
+    }
+    const evaluationErrors = [];
+    if (declaration.headSha !== headSha) {
+        evaluationErrors.push(`declaration is stale: it binds head ${declaration.headSha}`
+            + ` but the current PR head is ${headSha} — regenerate the declaration for the`
+            + ' current head');
+    }
+    pushSetMismatch(evaluationErrors, 'touched modules',
+        Object.keys(report.touchedModules || {}), declaration.modules);
+    pushSetMismatch(evaluationErrors, 'changed invariants',
+        report.changedInvariantIds || [], declaration.invariants);
+    pushSetMismatch(evaluationErrors, 'capabilities',
+        assignedCapabilities || [], declaration.capabilities);
+    pushSetMismatch(evaluationErrors, 'new classified files (path)',
+        (report.newClassifiedFiles || []).map(entry => entry.path),
+        declaration.newFiles.map(entry => entry.path));
+    const declaredModulesByPath = new Map(declaration.newFiles.map(entry => [entry.path, entry.module]));
+    for (const entry of report.newClassifiedFiles || []) {
+        const declaredModule = declaredModulesByPath.get(entry.path);
+        if (declaredModule && declaredModule !== entry.module) {
+            evaluationErrors.push(`new file ${entry.path} declares module ${declaredModule}`
+                + ` but the registry classifies it as ${entry.module}`);
+        }
+    }
+    if (declaration.policyDelta !== classification) {
+        evaluationErrors.push(`declaration claims policyDelta ${declaration.policyDelta}`
+            + ` but the gate computes ${classification}`);
+    }
+    const baselineWaiverTouched = (report.protectedTouched || [])
+        .some(file => file.endsWith('architecture-debt-baseline.json')
+            || file.endsWith('architecture-waivers.json'));
+    const expectedBaselineWaiver = baselineWaiverTouched ? 'changed' : 'zero';
+    if (declaration.baselineWaiverDelta !== expectedBaselineWaiver) {
+        evaluationErrors.push(`declaration claims baselineWaiverDelta ${declaration.baselineWaiverDelta}`
+            + ` but the diff shows ${expectedBaselineWaiver}`);
+    }
+    return { declaration, errors: evaluationErrors };
+}
+
+module.exports = {
+    DECLARATION_BLOCK_PATTERN,
+    evaluateChangeImpactDeclaration,
+    parseChangeImpactDeclaration,
+};

--- a/scripts/run-merge-approval-gate.js
+++ b/scripts/run-merge-approval-gate.js
@@ -7,7 +7,10 @@
 // instead of silently opening them.
 
 const fs = require('node:fs');
+const { execFileSync } = require('node:child_process');
 const { evaluateMergeApproval } = require('./lib/mergeApprovals');
+const { evaluateChangeImpactDeclaration } = require('./lib/changeImpactDeclaration');
+const { collectChangeImpactContext } = require('./lib/changeImpactContext');
 
 const STATUS_CONTEXT = 'merge-approval';
 
@@ -62,6 +65,36 @@ async function listAllComments(token, repo, prNumber) {
     return comments;
 }
 
+function git(args) {
+    return execFileSync('git', args, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
+}
+
+/**
+ * Fetch the PR head and base, check out the exact head being evaluated, and
+ * compare the PR body declaration with the regenerated impact report.
+ */
+function evaluateDeclarationForPullRequest({ pullRequest, prNumber }) {
+    const baseRefName = pullRequest.base?.ref;
+    const headSha = pullRequest.head?.sha;
+    if (!baseRefName || !headSha) {
+        return ['PR is missing base/head information for the declaration check'];
+    }
+    git(['fetch', 'origin', baseRefName, `pull/${prNumber}/head`]);
+    git(['-c', 'advice.detachedHead=false', 'checkout', headSha]);
+    const context = collectChangeImpactContext({
+        rootDirectory: process.cwd(),
+        baseRef: `origin/${baseRefName}`,
+    });
+    const { errors } = evaluateChangeImpactDeclaration({
+        body: pullRequest.body || '',
+        headSha,
+        classification: context.classification,
+        report: context.report,
+        assignedCapabilities: context.assignedCapabilities,
+    });
+    return [...context.errors, ...errors];
+}
+
 async function main() {
     const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
     const repo = process.env.GITHUB_REPOSITORY;
@@ -91,10 +124,22 @@ async function main() {
         headCommittedAtMs,
     });
 
+    // Review R4 (charter 8.10): the PR body declaration is compared with the
+    // regenerated architecture impact for the exact head being approved.
+    // Git failures crash the job before posting, which blocks the merge
+    // (fail-closed); declaration mismatches post a failure status.
+    const declarationErrors = evaluateDeclarationForPullRequest({ pullRequest, prNumber });
+
+    const reasons = [];
+    if (!verdict.approved) { reasons.push(verdict.reason); }
+    reasons.push(...declarationErrors.slice(0, 3));
+    if (declarationErrors.length > 3) {
+        reasons.push(`+${declarationErrors.length - 3} more declaration errors`);
+    }
     const status = {
         context: STATUS_CONTEXT,
-        state: verdict.approved ? 'success' : 'failure',
-        description: verdict.reason.slice(0, 140),
+        state: verdict.approved && declarationErrors.length === 0 ? 'success' : 'failure',
+        description: (reasons.join(' | ') || 'approved by owner comment').slice(0, 140),
         target_url: verdict.commentUrl || payload.comment?.html_url || undefined,
     };
     await api(token, 'POST', `/repos/${repo}/statuses/${headSha}`, status);

--- a/tests/unit/tooling/changeImpactDeclaration.test.js
+++ b/tests/unit/tooling/changeImpactDeclaration.test.js
@@ -192,14 +192,25 @@ test('ARCH-PR-CHANGE-IMPACT-GATE-001 capabilityAssignments maps commits and flag
         audit: { base: 'x', head: 'y', ignoredDocumentationCommits: ['d'.repeat(40)] },
         capabilities: [{ id: 'MAIN-TEST-001', commits: ['a'.repeat(40)] }],
     }));
-    const { assignedCapabilities, errors } = capabilityAssignments(root, [
-        'a'.repeat(40), 'd'.repeat(40), 'e'.repeat(40),
-    ]);
+    const filesByCommit = {
+        ['a'.repeat(40)]: ['src/alpha/a.ts'],
+        ['d'.repeat(40)]: ['docs/anything.md'],
+        ['e'.repeat(40)]: ['src/alpha/b.ts'],
+        // The audit commit of the current PR: not yet registered in the audit
+        // file, but its own diff is documentation-only.
+        ['f'.repeat(40)]: ['docs/testing/main-capability-coverage.json'],
+    };
+    const { assignedCapabilities, errors } = capabilityAssignments(
+        root,
+        ['a'.repeat(40), 'd'.repeat(40), 'e'.repeat(40), 'f'.repeat(40)],
+        { listCommitFiles: sha => filesByCommit[sha] || [] },
+    );
     assert.deepEqual(assignedCapabilities, ['MAIN-TEST-001']);
     assert.equal(errors.length, 1);
     assert.ok(errors[0].includes('e'.repeat(40)));
 
-    const missing = capabilityAssignments(root, ['f'.repeat(40)]);
+    const missing = capabilityAssignments(root, ['f'.repeat(40)],
+        { listCommitFiles: () => ['src/alpha/c.ts'] });
     assert.equal(missing.assignedCapabilities.length, 0);
 
     const noAudit = capabilityAssignments(fs.mkdtempSync(path.join(os.tmpdir(), 'impact-empty-')), ['a'.repeat(40)]);

--- a/tests/unit/tooling/changeImpactDeclaration.test.js
+++ b/tests/unit/tooling/changeImpactDeclaration.test.js
@@ -1,0 +1,229 @@
+'use strict';
+
+// ARCH-PR-CHANGE-IMPACT-GATE-001: the Change Impact Declaration parser and
+// evaluator (review R4). The merge-approval gate must reject missing, stale,
+// under-reported, over-reported, or malformed declarations.
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const {
+    evaluateChangeImpactDeclaration,
+    parseChangeImpactDeclaration,
+} = require('../../../scripts/lib/changeImpactDeclaration');
+const {
+    capabilityAssignments,
+    collectChangeImpactContext,
+} = require('../../../scripts/lib/changeImpactContext');
+const { buildDeclaration } = require('../../../scripts/generate-change-impact-declaration');
+
+const repoRoot = path.resolve(__dirname, '..', '..', '..');
+const HEAD_SHA = 'a'.repeat(40);
+
+function bodyWith(declaration) {
+    return `## Summary\n\nfixture\n\n## Change impact declaration\n\n`
+        + '```change-impact-declaration\n'
+        + `${JSON.stringify(declaration, null, 2)}\n`
+        + '```\n\n## Skill harvest\n\nnone\n';
+}
+
+function validDeclaration(overrides = {}) {
+    return {
+        headSha: HEAD_SHA,
+        capabilities: ['MAIN-ARCHITECTURE-HARNESS'],
+        modules: ['MOD-A'],
+        invariants: ['ARCH-X-001'],
+        policyDelta: 'tightening',
+        baselineWaiverDelta: 'zero',
+        newFiles: [{ path: 'src/a/new.ts', module: 'MOD-A', reason: 'owns the new codec' }],
+        ...overrides,
+    };
+}
+
+function truth(overrides = {}) {
+    return {
+        body: bodyWith(validDeclaration()),
+        headSha: HEAD_SHA,
+        classification: 'tightening',
+        report: {
+            touchedModules: { 'MOD-A': ['src/a/a.ts'] },
+            changedInvariantIds: ['ARCH-X-001'],
+            newClassifiedFiles: [{ path: 'src/a/new.ts', module: 'MOD-A' }],
+            protectedTouched: [],
+        },
+        assignedCapabilities: ['MAIN-ARCHITECTURE-HARNESS'],
+        ...overrides,
+    };
+}
+
+// ── parser ────────────────────────────────────────────────────────────
+
+test('ARCH-PR-CHANGE-IMPACT-GATE-001 parser accepts a valid declaration and normalizes it', () => {
+    const { declaration, errors } = parseChangeImpactDeclaration(bodyWith(validDeclaration({
+        modules: ['MOD-B', 'MOD-A'],
+        newFiles: [
+            { path: 'src/b.ts', module: 'MOD-B', reason: '  second  ' },
+            { path: 'src/a.ts', module: 'MOD-A', reason: 'first' },
+        ],
+    })));
+    assert.deepEqual(errors, []);
+    assert.deepEqual(declaration.modules, ['MOD-A', 'MOD-B']);
+    assert.deepEqual(declaration.newFiles.map(entry => entry.path), ['src/a.ts', 'src/b.ts']);
+    assert.equal(declaration.newFiles[1].reason, 'second');
+});
+
+test('ARCH-PR-CHANGE-IMPACT-GATE-001 controlled mutation: missing or duplicated block is rejected', () => {
+    assert.ok(parseChangeImpactDeclaration('no block here').errors[0].includes('no ```change-impact-declaration'));
+    const two = `${bodyWith(validDeclaration())}\n${bodyWith(validDeclaration())}`;
+    assert.ok(parseChangeImpactDeclaration(two).errors[0].includes('multiple'));
+});
+
+test('ARCH-PR-CHANGE-IMPACT-GATE-001 controlled mutation: malformed JSON and non-object roots are rejected', () => {
+    assert.ok(parseChangeImpactDeclaration('```change-impact-declaration\n{oops\n```').errors[0]
+        .includes('not valid JSON'));
+    assert.ok(parseChangeImpactDeclaration('```change-impact-declaration\n[]\n```').errors[0]
+        .includes('must be a JSON object'));
+});
+
+test('ARCH-PR-CHANGE-IMPACT-GATE-001 controlled mutation: schema violations are rejected', () => {
+    const cases = {
+        'unknown key': validDeclaration({ surprise: true }),
+        'bad headSha': validDeclaration({ headSha: 'HEAD' }),
+        'capabilities not an array': validDeclaration({ capabilities: 'MAIN-X' }),
+        'modules not an array': validDeclaration({ modules: 'MOD-A' }),
+        'invariants not an array': validDeclaration({ invariants: 'ARCH-X-001' }),
+        'bad policyDelta': validDeclaration({ policyDelta: 'none' }),
+        'bad baselineWaiverDelta': validDeclaration({ baselineWaiverDelta: 'none' }),
+        'newFiles not an array': validDeclaration({ newFiles: {} }),
+        'newFiles entry not an object': validDeclaration({ newFiles: ['src/a.ts'] }),
+        'newFiles entry missing module': validDeclaration({ newFiles: [{ path: 'src/a.ts', reason: 'r' }] }),
+        'newFiles entry empty reason': validDeclaration({ newFiles: [{ path: 'src/a.ts', module: 'MOD-A', reason: '  ' }] }),
+    };
+    for (const [name, declaration] of Object.entries(cases)) {
+        const { declaration: parsed, errors } = parseChangeImpactDeclaration(bodyWith(declaration));
+        assert.equal(parsed, null, name);
+        assert.ok(errors.length > 0, name);
+    }
+});
+
+// ── evaluator ─────────────────────────────────────────────────────────
+
+test('ARCH-PR-CHANGE-IMPACT-GATE-001 a declaration matching the regenerated truth passes', () => {
+    const { errors } = evaluateChangeImpactDeclaration(truth());
+    assert.deepEqual(errors, []);
+});
+
+test('ARCH-PR-CHANGE-IMPACT-GATE-001 controlled mutation: a stale headSha is rejected', () => {
+    const { errors } = evaluateChangeImpactDeclaration(truth({ headSha: 'b'.repeat(40) }));
+    assert.ok(errors.some(error => error.includes('stale') && error.includes('b'.repeat(40))),
+        JSON.stringify(errors));
+});
+
+test('ARCH-PR-CHANGE-IMPACT-GATE-001 controlled mutation: under- and over-reported fields are rejected', () => {
+    const under = evaluateChangeImpactDeclaration(truth({
+        body: bodyWith(validDeclaration({ modules: [], invariants: [], capabilities: [] })),
+    }));
+    assert.ok(under.errors.some(error => error.includes('under-reports touched modules: MOD-A')));
+    assert.ok(under.errors.some(error => error.includes('under-reports changed invariants: ARCH-X-001')));
+    assert.ok(under.errors.some(error => error.includes('under-reports capabilities: MAIN-ARCHITECTURE-HARNESS')));
+
+    const over = evaluateChangeImpactDeclaration(truth({
+        body: bodyWith(validDeclaration({ modules: ['MOD-A', 'MOD-B'], capabilities: ['MAIN-ARCHITECTURE-HARNESS', 'MAIN-TODO'] })),
+    }));
+    assert.ok(over.errors.some(error => error.includes('over-reports touched modules: MOD-B')));
+    assert.ok(over.errors.some(error => error.includes('over-reports capabilities: MAIN-TODO')));
+});
+
+test('ARCH-PR-CHANGE-IMPACT-GATE-001 controlled mutation: new-file coverage is exact', () => {
+    const missing = evaluateChangeImpactDeclaration(truth({
+        body: bodyWith(validDeclaration({ newFiles: [] })),
+    }));
+    assert.ok(missing.errors.some(error => error.includes('under-reports new classified files')));
+    const extra = evaluateChangeImpactDeclaration(truth({
+        body: bodyWith(validDeclaration({
+            newFiles: [
+                { path: 'src/a/new.ts', module: 'MOD-A', reason: 'owns the new codec' },
+                { path: 'src/a/other.ts', module: 'MOD-A', reason: 'phantom' },
+            ],
+        })),
+    }));
+    assert.ok(extra.errors.some(error => error.includes('over-reports new classified files')));
+    const wrongModule = evaluateChangeImpactDeclaration(truth({
+        body: bodyWith(validDeclaration({
+            newFiles: [{ path: 'src/a/new.ts', module: 'MOD-B', reason: 'misplaced' }],
+        })),
+    }));
+    assert.ok(wrongModule.errors.some(error => error.includes('classifies it as MOD-A')));
+});
+
+test('ARCH-PR-CHANGE-IMPACT-GATE-001 controlled mutation: policy delta and baseline/waiver misreports are rejected', () => {
+    const wrongDelta = evaluateChangeImpactDeclaration(truth({
+        body: bodyWith(validDeclaration({ policyDelta: 'product-only' })),
+    }));
+    assert.ok(wrongDelta.errors.some(error => error.includes('claims policyDelta product-only')
+        && error.includes('computes tightening')));
+    const wrongBaseline = evaluateChangeImpactDeclaration(truth({
+        body: bodyWith(validDeclaration({ baselineWaiverDelta: 'changed' })),
+    }));
+    assert.ok(wrongBaseline.errors.some(error => error.includes('baselineWaiverDelta changed')
+        && error.includes('zero')));
+    const baselineTouched = evaluateChangeImpactDeclaration(truth({
+        report: {
+            touchedModules: { 'MOD-A': ['src/a/a.ts'] },
+            changedInvariantIds: ['ARCH-X-001'],
+            newClassifiedFiles: [{ path: 'src/a/new.ts', module: 'MOD-A' }],
+            protectedTouched: ['.ci/architecture-debt-baseline.json'],
+        },
+    }));
+    assert.ok(baselineTouched.errors.some(error => error.includes('baselineWaiverDelta zero')
+        && error.includes('changed')));
+});
+
+// ── capability assignment glue ────────────────────────────────────────
+
+test('ARCH-PR-CHANGE-IMPACT-GATE-001 capabilityAssignments maps commits and flags unaudited ones', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'impact-audit-'));
+    fs.mkdirSync(path.join(root, 'docs/testing'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'docs/testing/main-capability-coverage.json'), JSON.stringify({
+        version: 1,
+        audit: { base: 'x', head: 'y', ignoredDocumentationCommits: ['d'.repeat(40)] },
+        capabilities: [{ id: 'MAIN-TEST-001', commits: ['a'.repeat(40)] }],
+    }));
+    const { assignedCapabilities, errors } = capabilityAssignments(root, [
+        'a'.repeat(40), 'd'.repeat(40), 'e'.repeat(40),
+    ]);
+    assert.deepEqual(assignedCapabilities, ['MAIN-TEST-001']);
+    assert.equal(errors.length, 1);
+    assert.ok(errors[0].includes('e'.repeat(40)));
+
+    const missing = capabilityAssignments(root, ['f'.repeat(40)]);
+    assert.equal(missing.assignedCapabilities.length, 0);
+
+    const noAudit = capabilityAssignments(fs.mkdtempSync(path.join(os.tmpdir(), 'impact-empty-')), ['a'.repeat(40)]);
+    assert.ok(noAudit.errors[0].includes('missing'));
+});
+
+test('ARCH-PR-CHANGE-IMPACT-GATE-001 a HEAD self-diff yields an empty, valid context and declaration', () => {
+    const context = collectChangeImpactContext({ rootDirectory: repoRoot, baseRef: 'HEAD' });
+    assert.equal(context.classification, 'product-only');
+    assert.deepEqual(context.assignedCapabilities, []);
+    assert.deepEqual(context.errors, []);
+    const { block, declaration } = buildDeclaration({ rootDirectory: repoRoot, baseRef: 'HEAD' });
+    assert.deepEqual(declaration.modules, []);
+    assert.deepEqual(declaration.newFiles, []);
+    assert.equal(declaration.policyDelta, 'product-only');
+    assert.equal(declaration.baselineWaiverDelta, 'zero');
+    const { declaration: parsed, errors } = parseChangeImpactDeclaration(block);
+    assert.deepEqual(errors, []);
+    assert.deepEqual(evaluateChangeImpactDeclaration({
+        body: block,
+        headSha: context.headSha,
+        classification: context.classification,
+        report: context.report,
+        assignedCapabilities: context.assignedCapabilities,
+    }).errors, []);
+    assert.ok(parsed);
+});

--- a/tests/unit/tooling/mergeApprovalGate.test.js
+++ b/tests/unit/tooling/mergeApprovalGate.test.js
@@ -55,3 +55,39 @@ test('ARCH-PR-MERGE-APPROVAL-GATE-001 audits recent merges on main pushes', () =
     assert.ok(!scheduled.jobs['merge-approval-audit'],
         'the secret-free scheduled workflow must not carry the token-using audit');
 });
+
+
+test('ARCH-PR-CHANGE-IMPACT-GATE-001 wires the declaration check into the gate (review R4)', () => {
+    const workflow = loadWorkflow('merge-approval-gate.yml');
+    assert.ok(workflow.on.pull_request.types.includes('edited'),
+        'body edits re-evaluate the head-bound declaration');
+    const gate = workflow.jobs.gate;
+    assert.ok(gate['timeout-minutes'] >= 10, 'full-history checkout and regeneration need budget');
+    const checkout = gate.steps.find(step => step.uses && step.uses.startsWith('actions/checkout'));
+    assert.ok(checkout && checkout.with && checkout.with['fetch-depth'] === 0,
+        'the gate regenerates the impact report and needs full history');
+
+    const script = fs.readFileSync(
+        path.join(repositoryRoot, 'scripts', 'run-merge-approval-gate.js'), 'utf8');
+    assert.match(script, /evaluateChangeImpactDeclaration/,
+        'the gate compares the PR body declaration with the regenerated truth');
+    assert.match(script, /collectChangeImpactContext/,
+        'the gate regenerates the impact report for the PR head');
+    assert.match(script, /pull\/\$\{prNumber\}\/head/,
+        'the gate fetches and checks out the exact PR head');
+
+    // The declaration machinery sits on the protected harness surface (R2
+    // surface extended in R4): weakening it is never product-only.
+    const surface = fs.readFileSync(
+        path.join(repositoryRoot, 'scripts', 'architecture', 'reportArchitectureDiff.js'), 'utf8');
+    for (const protectedFile of [
+        'scripts/run-merge-approval-gate.js',
+        'scripts/lib/mergeApprovals.js',
+        'scripts/lib/changeImpactDeclaration.js',
+        'scripts/lib/changeImpactContext.js',
+        'scripts/generate-change-impact-declaration.js',
+        'tests/unit/tooling/changeImpactDeclaration.test.js',
+    ]) {
+        assert.ok(surface.includes(`'${protectedFile}'`), `${protectedFile} must be protected`);
+    }
+});


### PR DESCRIPTION
## Summary

Fixes W1 review Important 7: the charter 8.10 Change Impact Declaration lived in PR bodies as unchecked prose — the merge-approval gate evaluated only the owner approval comment.

- Every PR body must now carry one ` ```change-impact-declaration ` JSON block binding the **head SHA**, produced by `scripts/generate-change-impact-declaration.js`.
- The merge-approval gate fetches and checks out the exact PR head, regenerates the architecture impact report for base..head, and compares: touched modules, changed invariant ids, capability assignments from the audit (unaudited implementation commits fail; documentation commits are classified structurally from their own diff), the policy-delta classification, the baseline/waiver delta, and every new classified file with a non-empty reason and the registry module.
- Stale (old head), under-reported, over-reported, or malformed declarations post a failure status. `pull_request.edited` re-evaluates because the block binds the head SHA; body edits can never make an old declaration look fresh.
- The declaration machinery itself (gate script, evaluator, context, generator, tests) joins the R2 protected harness surface — weakening it is never product-only.
- Charter 8.10 documents the mechanical contract; the PR template gains the declaration section.

## Change impact declaration

```change-impact-declaration
{
  "headSha": "0cb69481a754d9f14793e2c5737503e47d8eaaab",
  "capabilities": [
    "MAIN-ARCHITECTURE-HARNESS"
  ],
  "modules": [],
  "invariants": [],
  "policyDelta": "tightening",
  "baselineWaiverDelta": "zero",
  "newFiles": []
}
```

## Skill harvest

none — no skill change justified; the slice followed the established review-fix-commit loop without guidance gaps.

## Verification

- `npm run test-compile` ✅
- `node --test 'tests/unit/tooling/**/*.test.js'` — 391/391 ✅ (incl. 11 declaration tests with 8 controlled-mutation groups)
- `node --test 'tests/unit/architecture/**/*.test.js'` — 86/86 ✅
- `node scripts/architecture/checkArchitectureChange.js` — self-classification: tightening ✅
- `npm run test:coverage:ci` ✅ — changed-line 92.86% (364/392), baseline checks pass
- `npm run test:behavior-contracts` ✅ (audit current)
- `npm run lint` ✅ (only pre-existing warnings)
- Dogfood: this PR body carries the declaration block generated for its head.
