### PR TITLE
fix(worktrees): make member state transitions atomic in the store queue (review R5)

### DIFF
--- a/docs/testing/architecture-invariants.json
+++ b/docs/testing/architecture-invariants.json
@@ -41,7 +41,7 @@
             ],
             "priority": "P0",
             "kind": "concurrency",
-            "statement": "Manifest member state transitions route through WorktreeMemberLifecycle, which enforces the legal pre-states at the boundary; the store member-transition methods have exactly one writer.",
+            "statement": "Manifest member state transitions commit atomically through the store's transitionMember primitive inside its write queue (no TOCTOU between the pre-state check and the write); named transitions route through WorktreeMemberLifecycle, the single logical writer; the ready->deleting->ready/removed deletion sub-machine runs through the store's journal primitives (beginDeletion/checkpointDeletedMember/failDeletionMember), which are mechanically disjoint from lifecycle transitions via the journal lease.",
             "authority": {
                 "path": "src/worktrees/memberLifecycle.ts",
                 "symbol": "WorktreeMemberLifecycle"
@@ -67,6 +67,7 @@
             "stateFamily": {
                 "storePath": "src/worktrees/groupManifestStore.ts",
                 "writeMethods": [
+                    "transitionMember",
                     "updateMember",
                     "setPrimaryMember",
                     "removeMember"

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "e5b496b8f2a345cf704643d473139a2ba87a3e76",
+        "head": "2d133a0a0cb3883d94e5ea2590b1ad9e39b8f927",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -450,7 +450,8 @@
             "9228479e990290a8bd207ea189981cc5de9b4709",
             "6a7edd4573fa675486c124e4e68061ac0b78a962",
             "84a05bfff1d31c5a4bc98b25ebf24e95789d0aa2",
-            "0cb69481a754d9f14793e2c5737503e47d8eaaab"
+            "0cb69481a754d9f14793e2c5737503e47d8eaaab",
+            "1975a18661f7e1f916e5657436b5c12a2f788be2"
         ]
     },
     "capabilities": [
@@ -2267,7 +2268,8 @@
                 "6b7f25cd3c95201996caeb0879f7c7c00da4fd65",
                 "7aa265837b767e4406b39b67b0e0a7c9e0573201",
                 "b6284995ef315fae40d8e1e803b2eb1adacfc650",
-                "e5b496b8f2a345cf704643d473139a2ba87a3e76"
+                "e5b496b8f2a345cf704643d473139a2ba87a3e76",
+                "2d133a0a0cb3883d94e5ea2590b1ad9e39b8f927"
             ],
             "behaviors": [
                 "WORKTREE-GROUPS-BASELINE-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "a7afab45ea326f4b9bf9bfa3245c2580aa89f31e",
+        "head": "e5b496b8f2a345cf704643d473139a2ba87a3e76",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -449,7 +449,8 @@
             "88f31ce6c058b6bbfd44d104442c2d3f7c616fca",
             "9228479e990290a8bd207ea189981cc5de9b4709",
             "6a7edd4573fa675486c124e4e68061ac0b78a962",
-            "84a05bfff1d31c5a4bc98b25ebf24e95789d0aa2"
+            "84a05bfff1d31c5a4bc98b25ebf24e95789d0aa2",
+            "0cb69481a754d9f14793e2c5737503e47d8eaaab"
         ]
     },
     "capabilities": [
@@ -2265,7 +2266,8 @@
                 "fce4b85cacbaae9b3d7d74404c8f21ec6ace1b3d",
                 "6b7f25cd3c95201996caeb0879f7c7c00da4fd65",
                 "7aa265837b767e4406b39b67b0e0a7c9e0573201",
-                "b6284995ef315fae40d8e1e803b2eb1adacfc650"
+                "b6284995ef315fae40d8e1e803b2eb1adacfc650",
+                "e5b496b8f2a345cf704643d473139a2ba87a3e76"
             ],
             "behaviors": [
                 "WORKTREE-GROUPS-BASELINE-001",

--- a/src/worktrees/groupManifestStore.ts
+++ b/src/worktrees/groupManifestStore.ts
@@ -107,11 +107,15 @@ export type WorktreeGroupManifestErrorCode =
   | 'deletion-blocked'
   | 'member-detached'
   | 'store-corrupt'
-  | 'store-full';
+  | 'store-full'
+  | 'illegal-member-transition';
 
 export class WorktreeGroupManifestError extends Error {
-    constructor(readonly code: WorktreeGroupManifestErrorCode) {
-        super(code);
+    constructor(
+        readonly code: WorktreeGroupManifestErrorCode,
+        readonly detail?: string
+    ) {
+        super(detail ? `${code}: ${detail}` : code);
         this.name = 'WorktreeGroupManifestError';
         Object.setPrototypeOf(this, WorktreeGroupManifestError.prototype);
     }
@@ -120,6 +124,11 @@ export class WorktreeGroupManifestError extends Error {
 export type GenerationClaimResolution =
     | { kind: 'keep' }
     | { kind: 'promote'; provider: string; sessionId: string };
+
+/** Patchable member fields (updateMember / transitionMember). */
+export type WorktreeGroupMemberPatch = Partial<Pick<WorktreeGroupMember,
+    'state' | 'worktreeKey' | 'branchName' | 'path' | 'lastError'
+    | 'detached' | 'baseline'>>;
 
 export interface NewWorktreeGroupMember {
     repositoryKey: string;
@@ -346,13 +355,84 @@ export class WorktreeGroupManifestStore {
         });
     }
 
+    /** Shared patch application inside the write queue (updateMember/transitionMember). */
+    private applyMemberPatchUnlocked(
+        bucket: WorkspaceAggregate,
+        group: WorktreeGroup,
+        member: WorktreeGroupMember,
+        patch: WorktreeGroupMemberPatch
+    ): void {
+        if (patch.state !== undefined) {
+            member.state = patch.state;
+        }
+        if (patch.worktreeKey !== undefined) {
+            assertWorktreeKeysUnclaimed(
+                bucket.groups,
+                [{ ...member, worktreeKey: patch.worktreeKey }],
+                group.groupId);
+            member.worktreeKey = Object.freeze({ ...patch.worktreeKey });
+        }
+        if (patch.branchName !== undefined) {
+            member.branchName = requireBranchName(patch.branchName);
+        }
+        if (patch.path !== undefined) {
+            member.path = requirePath(patch.path);
+        }
+        if (patch.lastError !== undefined) {
+            member.lastError = patch.lastError
+                ? requireShortText(patch.lastError, MAX_ERROR_LENGTH, 'invalid-record')
+                : undefined;
+        }
+        if (patch.detached !== undefined) {
+            member.detached = patch.detached || undefined;
+        }
+        if (patch.baseline !== undefined) {
+            // The baseline is immutable (changes-panel PRD §4.2): it
+            // may be filled in once for a member that lacks it, but
+            // never moved or replaced.
+            if (member.baseline
+                && !memberBaselinesEqual(member.baseline, patch.baseline)) {
+                throw new WorktreeGroupManifestError('invalid-record');
+            }
+            member.baseline = sanitizeBaseline(patch.baseline);
+        }
+        if (group.primaryMemberId === member.memberId && member.state !== 'ready') {
+            group.primaryMemberId = null;
+        }
+    }
+
+    /**
+     * Shared member removal inside the write queue; returns null when the
+     * group disappeared with its last member.
+     */
+    private async removeMemberUnlocked(
+        manifest: ManifestShape,
+        bucket: WorkspaceAggregate,
+        group: WorktreeGroup,
+        member: WorktreeGroupMember
+    ): Promise<WorktreeGroup | null> {
+        group.members.splice(group.members.indexOf(member), 1);
+        if (group.primaryMemberId === member.memberId) {
+            group.primaryMemberId = null;
+        }
+        if (group.members.length === 0) {
+            // Empty groups disappear with their last member (PRD §4.2).
+            bucket.groups.splice(
+                bucket.groups.findIndex(candidate => candidate.groupId === group.groupId), 1);
+            await this.commitBucket(manifest, bucket);
+            return null;
+        }
+        bumpRevision(group);
+        assertGroupInvariants(group);
+        await this.commitBucket(manifest, bucket);
+        return cloneGroup(group);
+    }
+
     updateMember(
         workspaceIdentity: string,
         groupId: string,
         memberId: string,
-        patch: Partial<Pick<WorktreeGroupMember,
-            'state' | 'worktreeKey' | 'branchName' | 'path' | 'lastError'
-            | 'detached' | 'baseline'>>
+        patch: WorktreeGroupMemberPatch
     ): Promise<WorktreeGroup> {
         return this.enqueue(async () => {
             const manifest = this.readManifest();
@@ -371,42 +451,65 @@ export class WorktreeGroupManifestStore {
                 // could orphan the journal's frozen identity snapshot.
                 throw new WorktreeGroupManifestError('group-leased');
             }
-            if (patch.state !== undefined) {
-                member.state = patch.state;
+            this.applyMemberPatchUnlocked(bucket, group, member, patch);
+            bumpRevision(group);
+            assertGroupInvariants(group);
+            await this.commitBucket(manifest, bucket);
+            return cloneGroup(group);
+        });
+    }
+
+    /**
+     * Atomic member state transition (review R5, invariant
+     * ARCH-WORKTREE-MEMBER-WRITER-001): the expected-state check and the
+     * write commit inside the SAME write-queue entry, so concurrent
+     * transitions serialize — exactly one of two racing transitions can
+     * observe its legal pre-state. WorktreeMemberLifecycle routes every
+     * named transition here.
+     */
+    transitionMember(
+        workspaceIdentity: string,
+        groupId: string,
+        memberId: string,
+        options: {
+            expectedStates: readonly WorktreeGroupMemberState[],
+            transition: string,
+            patch?: WorktreeGroupMemberPatch,
+            remove?: boolean,
+            assignPrimary?: boolean,
+        }
+    ): Promise<WorktreeGroup | null> {
+        if (options.assignPrimary && (options.remove || options.patch !== undefined)) {
+            return Promise.reject(new WorktreeGroupManifestError('invalid-record'));
+        }
+        return this.enqueue(async () => {
+            const manifest = this.readManifest();
+            const bucket = this.getBucket(manifest, workspaceIdentity);
+            const group = bucket.groups.find(candidate => candidate.groupId === groupId);
+            if (!group) {
+                throw new WorktreeGroupManifestError('group-not-found');
             }
-            if (patch.worktreeKey !== undefined) {
-                assertWorktreeKeysUnclaimed(
-                    bucket.groups,
-                    [{ ...member, worktreeKey: patch.worktreeKey }],
-                    group.groupId);
-                member.worktreeKey = Object.freeze({ ...patch.worktreeKey });
+            const member = group.members.find(candidate => candidate.memberId === memberId);
+            const state = member?.state;
+            if (!state || !options.expectedStates.includes(state)) {
+                throw new WorktreeGroupManifestError(
+                    'illegal-member-transition',
+                    `${options.transition}: member ${memberId} is '${state ?? 'missing'}', `
+                    + `expected one of ${options.expectedStates.join(', ')}`);
             }
-            if (patch.branchName !== undefined) {
-                member.branchName = requireBranchName(patch.branchName);
+            if (options.assignPrimary) {
+                // Same lease rule as setPrimaryMember (decision J).
+                assertGroupNotLeased(bucket, groupId);
+            } else if (isJournalTarget(bucket, groupId, memberId)) {
+                throw new WorktreeGroupManifestError('group-leased');
             }
-            if (patch.path !== undefined) {
-                member.path = requirePath(patch.path);
+            if (options.remove) {
+                return this.removeMemberUnlocked(manifest, bucket, group, member);
             }
-            if (patch.lastError !== undefined) {
-                member.lastError = patch.lastError
-                    ? requireShortText(patch.lastError, MAX_ERROR_LENGTH, 'invalid-record')
-                    : undefined;
-            }
-            if (patch.detached !== undefined) {
-                member.detached = patch.detached || undefined;
-            }
-            if (patch.baseline !== undefined) {
-                // The baseline is immutable (changes-panel PRD §4.2): it
-                // may be filled in once for a member that lacks it, but
-                // never moved or replaced.
-                if (member.baseline
-                    && !memberBaselinesEqual(member.baseline, patch.baseline)) {
-                    throw new WorktreeGroupManifestError('invalid-record');
-                }
-                member.baseline = sanitizeBaseline(patch.baseline);
-            }
-            if (group.primaryMemberId === member.memberId && member.state !== 'ready') {
-                group.primaryMemberId = null;
+            if (options.assignPrimary) {
+                group.primaryMemberId = member.memberId;
+            } else {
+                this.applyMemberPatchUnlocked(bucket, group, member, options.patch ?? {});
             }
             bumpRevision(group);
             assertGroupInvariants(group);
@@ -503,8 +606,8 @@ export class WorktreeGroupManifestStore {
             if (!group) {
                 throw new WorktreeGroupManifestError('group-not-found');
             }
-            const index = group.members.findIndex(candidate => candidate.memberId === memberId);
-            if (index < 0) {
+            const member = group.members.find(candidate => candidate.memberId === memberId);
+            if (!member) {
                 throw new WorktreeGroupManifestError('member-not-found');
             }
             if (isJournalTarget(bucket, groupId, memberId)) {
@@ -512,21 +615,7 @@ export class WorktreeGroupManifestStore {
                 // journal; finish or abandon the operation first.
                 throw new WorktreeGroupManifestError('group-leased');
             }
-            group.members.splice(index, 1);
-            if (group.primaryMemberId === memberId) {
-                group.primaryMemberId = null;
-            }
-            if (group.members.length === 0) {
-                // Empty groups disappear with their last member (PRD §4.2).
-                bucket.groups.splice(
-                    bucket.groups.findIndex(candidate => candidate.groupId === groupId), 1);
-                await this.commitBucket(manifest, bucket);
-                return null;
-            }
-            bumpRevision(group);
-            assertGroupInvariants(group);
-            await this.commitBucket(manifest, bucket);
-            return cloneGroup(group);
+            return this.removeMemberUnlocked(manifest, bucket, group, member);
         });
     }
 

--- a/src/worktrees/memberLifecycle.ts
+++ b/src/worktrees/memberLifecycle.ts
@@ -1,6 +1,7 @@
 'use strict';
 
 import type { WorktreeKey } from './types';
+import { WorktreeGroupManifestError } from './groupManifestStore';
 import type { WorktreeGroupManifestStore } from './groupManifestStore';
 
 export class IllegalMemberTransitionError extends Error {
@@ -13,6 +14,12 @@ export class IllegalMemberTransitionError extends Error {
  * they mean; the legal pre-states are enforced here at the state-owning
  * boundary instead of being re-remembered at every call site.
  *
+ * Every transition commits through the store's atomic `transitionMember`
+ * primitive (review R5): the expected-state check and the write happen
+ * inside the same write-queue entry, so racing transitions serialize and
+ * only one can observe its legal pre-state (no TOCTOU between the check
+ * and the write).
+ *
  * Legal transitions (see the Stage 1B RFC state machine):
  *   provisioning|failed   -> ready   (finalize; requires a worktree key; a
  *                                    live operation wins the demotion race)
@@ -22,32 +29,33 @@ export class IllegalMemberTransitionError extends Error {
  *   failed                  -> provisioning (retry readmission)
  *   failed                  -> removed  (dismiss)
  *   ready                   -> removed  (physical worktree was removed)
+ *
+ * The ready -> deleting -> ready/removed deletion sub-machine runs through
+ * the store's journal primitives (beginDeletion / checkpointDeletedMember /
+ * failDeletionMember), which are mechanically disjoint from this authority:
+ * the journal lease blocks generic transitions on members under deletion,
+ * and the journal primitives only act on members in the deleting state.
  */
 export class WorktreeMemberLifecycle {
     constructor(private readonly store: WorktreeGroupManifestStore) {}
 
-    private memberState(
-        workspaceIdentity: string,
-        groupId: string,
-        memberId: string
-    ): string | undefined {
-        return this.store.listGroups(workspaceIdentity)
-            .find(group => group.groupId === groupId)
-            ?.members.find(member => member.memberId === memberId)?.state;
-    }
-
-    private requireState(
+    private async transition(
         workspaceIdentity: string,
         groupId: string,
         memberId: string,
-        allowed: readonly string[],
-        transition: string
-    ): void {
-        const state = this.memberState(workspaceIdentity, groupId, memberId);
-        if (!state || !allowed.includes(state)) {
-            throw new IllegalMemberTransitionError(
-                `${transition}: member ${memberId} is '${state ?? 'missing'}', `
-                + `expected one of ${allowed.join(', ')}`);
+        options: Parameters<WorktreeGroupManifestStore['transitionMember']>[3]
+    ): Promise<void> {
+        try {
+            await this.store.transitionMember(workspaceIdentity, groupId, memberId, options);
+        } catch (error) {
+            if (error instanceof WorktreeGroupManifestError
+                && error.code === 'illegal-member-transition') {
+                // Preserve the authority's coded-error contract: the check
+                // now happens atomically inside the store queue, but the
+                // error type and message stay the lifecycle's own.
+                throw new IllegalMemberTransitionError(error.detail ?? error.message);
+            }
+            throw error;
         }
     }
 
@@ -61,12 +69,10 @@ export class WorktreeMemberLifecycle {
         memberId: string,
         worktreeKey: WorktreeKey
     ): Promise<void> {
-        this.requireState(
-            workspaceIdentity, groupId, memberId,
-            ['provisioning', 'failed'], 'mark-ready');
-        await this.store.updateMember(workspaceIdentity, groupId, memberId, {
-            state: 'ready',
-            worktreeKey,
+        await this.transition(workspaceIdentity, groupId, memberId, {
+            expectedStates: ['provisioning', 'failed'],
+            transition: 'mark-ready',
+            patch: { state: 'ready', worktreeKey },
         });
     }
 
@@ -81,11 +87,10 @@ export class WorktreeMemberLifecycle {
         memberId: string,
         lastError: string
     ): Promise<void> {
-        this.requireState(workspaceIdentity, groupId, memberId,
-            ['provisioning', 'planned', 'failed'], 'mark-failed');
-        await this.store.updateMember(workspaceIdentity, groupId, memberId, {
-            state: 'failed',
-            lastError,
+        await this.transition(workspaceIdentity, groupId, memberId, {
+            expectedStates: ['provisioning', 'planned', 'failed'],
+            transition: 'mark-failed',
+            patch: { state: 'failed', lastError },
         });
     }
 
@@ -95,11 +100,10 @@ export class WorktreeMemberLifecycle {
         groupId: string,
         memberId: string
     ): Promise<void> {
-        this.requireState(workspaceIdentity, groupId, memberId,
-            ['provisioning', 'planned'], 'demote-interrupted');
-        await this.store.updateMember(workspaceIdentity, groupId, memberId, {
-            state: 'failed',
-            lastError: 'interrupted',
+        await this.transition(workspaceIdentity, groupId, memberId, {
+            expectedStates: ['provisioning', 'planned'],
+            transition: 'demote-interrupted',
+            patch: { state: 'failed', lastError: 'interrupted' },
         });
     }
 
@@ -109,11 +113,14 @@ export class WorktreeMemberLifecycle {
         groupId: string,
         memberId: string
     ): Promise<void> {
-        this.requireState(workspaceIdentity, groupId, memberId, ['failed'], 'retry-readmit');
-        await this.store.updateMember(workspaceIdentity, groupId, memberId, {
-            state: 'provisioning',
-            // The store treats undefined as "leave unchanged".
-            lastError: '',
+        await this.transition(workspaceIdentity, groupId, memberId, {
+            expectedStates: ['failed'],
+            transition: 'retry-readmit',
+            patch: {
+                state: 'provisioning',
+                // The store treats undefined as "leave unchanged".
+                lastError: '',
+            },
         });
     }
 
@@ -123,8 +130,11 @@ export class WorktreeMemberLifecycle {
         groupId: string,
         memberId: string
     ): Promise<void> {
-        this.requireState(workspaceIdentity, groupId, memberId, ['failed'], 'dismiss-member');
-        await this.store.removeMember(workspaceIdentity, groupId, memberId);
+        await this.transition(workspaceIdentity, groupId, memberId, {
+            expectedStates: ['failed'],
+            transition: 'dismiss-member',
+            remove: true,
+        });
     }
 
     /** The physical worktree is gone: the member record is removed from any state. */
@@ -136,13 +146,16 @@ export class WorktreeMemberLifecycle {
         await this.store.removeMember(workspaceIdentity, groupId, memberId);
     }
 
-    /** Assign the primary member; the store enforces the ready invariant. */
+    /** Assign the primary member: the ready pre-state is enforced atomically. */
     async assignPrimary(
         workspaceIdentity: string,
         groupId: string,
         memberId: string
     ): Promise<void> {
-        this.requireState(workspaceIdentity, groupId, memberId, ['ready'], 'assign-primary');
-        await this.store.setPrimaryMember(workspaceIdentity, groupId, memberId);
+        await this.transition(workspaceIdentity, groupId, memberId, {
+            expectedStates: ['ready'],
+            transition: 'assign-primary',
+            assignPrimary: true,
+        });
     }
 }

--- a/tests/contract/worktrees/groupCreationController.test.js
+++ b/tests/contract/worktrees/groupCreationController.test.js
@@ -389,15 +389,16 @@ test('WORKTREE-GROUPS-CREATE-001 a settlement persist failure is logged without 
             };
         },
     });
-    // The settle-time state write races a dismissed record: updateMember
-    // throws, and runMember must log instead of swallowing silently.
-    const originalUpdateMember = current.manifestStore.updateMember.bind(
+    // The settle-time state write races a dismissed record: the atomic
+    // transitionMember write throws, and runMember must log instead of
+    // swallowing silently.
+    const originalTransitionMember = current.manifestStore.transitionMember.bind(
         current.manifestStore);
-    current.manifestStore.updateMember = async (identity, groupId, memberId, patch) => {
-        if (patch && patch.state === 'failed') {
+    current.manifestStore.transitionMember = async (identity, groupId, memberId, options) => {
+        if (options && options.patch && options.patch.state === 'failed') {
             throw new Error('member-not-found');
         }
-        return originalUpdateMember(identity, groupId, memberId, patch);
+        return originalTransitionMember(identity, groupId, memberId, options);
     };
     const result = await current.controller.confirm({
         projectId: 'project',

--- a/tests/unit/worktrees/memberLifecycle.test.js
+++ b/tests/unit/worktrees/memberLifecycle.test.js
@@ -102,3 +102,124 @@ test('ARCH-WORKTREE-MEMBER-WRITER-001 a live finalize still wins the demotion ra
     await lifecycle.markMemberReady(WORKSPACE, groupId, memberId, key);
     assert.equal(memberState(store, groupId, memberId), 'ready');
 });
+
+
+// ── review R5: atomic transition concurrency matrix ──────────────────
+
+test('ARCH-WORKTREE-MEMBER-WRITER-001 racing readmit and dismiss: exactly one wins (review repro)', async () => {
+    const { store, lifecycle, groupId, memberId } = await fixture();
+    await lifecycle.markMemberFailed(WORKSPACE, groupId, memberId, 'setup-failed');
+
+    // The review's reproduction: failed -> provisioning racing
+    // failed -> removed must not both succeed.
+    const outcomes = await Promise.allSettled([
+        lifecycle.readmitMemberForRetry(WORKSPACE, groupId, memberId),
+        lifecycle.removeFailedMember(WORKSPACE, groupId, memberId),
+    ]);
+    const succeeded = outcomes.filter(outcome => outcome.status === 'fulfilled');
+    const rejected = outcomes.filter(outcome => outcome.status === 'rejected');
+    assert.equal(succeeded.length, 1, JSON.stringify(outcomes));
+    assert.equal(rejected.length, 1);
+    assert.match(String(rejected[0].reason), /illegal-member-transition|expected one of/);
+
+    const state = memberState(store, groupId, memberId);
+    if (state === undefined) {
+        // Dismiss won: the member (and the group) is gone, consistently.
+        assert.equal(store.listGroups(WORKSPACE).length, 0);
+    } else {
+        // Readmit won: the member is provisioning and still present.
+        assert.equal(state, 'provisioning');
+    }
+});
+
+test('ARCH-WORKTREE-MEMBER-WRITER-001 duplicate readmits: the second one fails closed', async () => {
+    const { store, lifecycle, groupId, memberId } = await fixture();
+    await lifecycle.markMemberFailed(WORKSPACE, groupId, memberId, 'setup-failed');
+
+    const outcomes = await Promise.allSettled([
+        lifecycle.readmitMemberForRetry(WORKSPACE, groupId, memberId),
+        lifecycle.readmitMemberForRetry(WORKSPACE, groupId, memberId),
+    ]);
+    assert.equal(outcomes.filter(outcome => outcome.status === 'fulfilled').length, 1);
+    assert.equal(outcomes.filter(outcome => outcome.status === 'rejected').length, 1);
+    assert.equal(memberState(store, groupId, memberId), 'provisioning');
+});
+
+test('ARCH-WORKTREE-MEMBER-WRITER-001 a live finalize always wins the demotion race', async () => {
+    const { store, lifecycle, groupId, memberId } = await fixture();
+    const key = { repositoryKey: '/alpha/.git', canonicalWorktreePath: '/alpha/.worktrees/fix-login' };
+
+    // mark-ready accepts provisioning|failed, demotion accepts
+    // provisioning|planned. Whichever order the queue serializes, the
+    // finalize always lands: demote-then-finalize means failed is a legal
+    // pre-state for the finalize; finalize-then-demote means the demotion
+    // correctly fails closed (a ready member cannot demote).
+    const outcomes = await Promise.allSettled([
+        lifecycle.markMemberReady(WORKSPACE, groupId, memberId, key),
+        lifecycle.demoteInterruptedMember(WORKSPACE, groupId, memberId),
+    ]);
+    assert.equal(outcomes[0].status, 'fulfilled', 'the finalize always lands');
+    if (outcomes[1].status === 'rejected') {
+        assert.match(String(outcomes[1].reason), /illegal-member-transition|expected one of/);
+    }
+    assert.equal(memberState(store, groupId, memberId), 'ready');
+});
+
+test('ARCH-WORKTREE-MEMBER-WRITER-001 settlement rewrite always wins against demotion', async () => {
+    const { store, lifecycle, groupId, memberId } = await fixture();
+
+    // mark-failed accepts provisioning|planned|failed, demotion accepts
+    // provisioning|planned. Either the settlement lands after the demotion
+    // (failed is legal) or before it (the demotion then fails closed) — in
+    // both serializations the settlement's outcome is the recorded one.
+    const outcomes = await Promise.allSettled([
+        lifecycle.markMemberFailed(WORKSPACE, groupId, memberId, 'setup-failed'),
+        lifecycle.demoteInterruptedMember(WORKSPACE, groupId, memberId),
+    ]);
+    assert.equal(outcomes[0].status, 'fulfilled', 'the settlement always lands');
+    if (outcomes[1].status === 'rejected') {
+        assert.match(String(outcomes[1].reason), /illegal-member-transition|expected one of/);
+    }
+    const member = store.listGroups(WORKSPACE)[0].members
+        .find(candidate => candidate.memberId === memberId);
+    assert.equal(member.state, 'failed');
+    assert.equal(member.lastError, 'setup-failed');
+});
+
+test('ARCH-WORKTREE-MEMBER-WRITER-001 dismiss racing finalize rejects the inconsistent one', async () => {
+    const { store, lifecycle, groupId, memberId } = await fixture();
+    await lifecycle.markMemberFailed(WORKSPACE, groupId, memberId, 'setup-failed');
+    const key = { repositoryKey: '/alpha/.git', canonicalWorktreePath: '/alpha/.worktrees/fix-login' };
+
+    // failed -> removed races failed -> ready (finalize accepts failed).
+    const outcomes = await Promise.allSettled([
+        lifecycle.removeFailedMember(WORKSPACE, groupId, memberId),
+        lifecycle.markMemberReady(WORKSPACE, groupId, memberId, key),
+    ]);
+    const succeeded = outcomes.filter(outcome => outcome.status === 'fulfilled').length;
+    assert.equal(succeeded, 1, JSON.stringify(outcomes));
+    const state = memberState(store, groupId, memberId);
+    assert.ok(state === undefined || state === 'ready', `unexpected final state ${state}`);
+});
+
+test('ARCH-WORKTREE-MEMBER-WRITER-001 transitionMember rejects contradictory option combos', async () => {
+    const { store, groupId, memberId } = await fixture();
+    await assert.rejects(
+        store.transitionMember(WORKSPACE, groupId, memberId, {
+            expectedStates: ['ready'],
+            transition: 'fixture',
+            assignPrimary: true,
+            patch: { state: 'ready' },
+        }),
+        /invalid-record/,
+    );
+    await assert.rejects(
+        store.transitionMember(WORKSPACE, groupId, memberId, {
+            expectedStates: ['ready'],
+            transition: 'fixture',
+            assignPrimary: true,
+            remove: true,
+        }),
+        /invalid-record/,
+    );
+});


### PR DESCRIPTION
## Summary

Fixes W1 review Blocker 5: `WorktreeMemberLifecycle` checked legal pre-states with `listGroups()` **outside** the store write queue, then wrote via `updateMember`/`removeMember` **inside** it — a TOCTOU window (review reproduced: racing `failed->provisioning` + `failed->removed` both committed and the member was wrongly deleted).

- New store primitive `transitionMember({ expectedStates, transition, patch, remove, assignPrimary })`: the pre-state check and the write commit inside the **same write-queue entry**, so racing transitions serialize and only one observes its legal pre-state. Patch/removal logic is shared with `updateMember`/`removeMember` via extracted helpers (behavior identical); the new `illegal-member-transition` error code carries an optional detail message identical to the lifecycle's previous format.
- `WorktreeMemberLifecycle` routes every named transition through the primitive and translates the coded error back to `IllegalMemberTransitionError`, preserving its public contract.
- `ARCH-WORKTREE-MEMBER-WRITER-001` now states the authority structure honestly (review's option b): named transitions via the lifecycle (single logical writer); the `ready->deleting->ready/removed` deletion sub-machine via the store's journal primitives (`beginDeletion`/`checkpointDeletedMember`/`failDeletionMember`), mechanically disjoint from lifecycle transitions via the journal lease. `stateFamily.writeMethods` gains `transitionMember`; `writers` unchanged.
- New concurrency matrix tests: the review's readmit/dismiss repro, duplicate readmits, live-finalize vs demotion, settlement vs demotion, dismiss vs finalize, contradictory-option rejection.

## Change impact declaration

```change-impact-declaration
{
  "headSha": "256af5a77c1f758a37421fdf10242cf6d8d9b2ad",
  "capabilities": [
    "MAIN-WORKTREE-CHANGES-PANEL"
  ],
  "modules": [
    "MOD-WORKTREE-LIFECYCLE"
  ],
  "invariants": [
    "ARCH-WORKTREE-MEMBER-WRITER-001"
  ],
  "policyDelta": "tightening",
  "baselineWaiverDelta": "zero",
  "newFiles": []
}
```

## Skill harvest

none — no skill change justified; the slice followed the established review-fix-commit loop without guidance gaps.

## Verification

- `npm run test-compile` ✅
- `node --test 'tests/unit/worktrees/**/*.test.js'` — 190/190 ✅ (6 new concurrency-matrix tests)
- `npm run test:architecture-policy` ✅ (single-writer guard green with the new writeMethods)
- `npm run test:architecture-guards` ✅ / `npm run test:behavior-contracts` ✅
- `node scripts/architecture/checkArchitectureChange.js` — self-classification: tightening ✅
- `npm run test:coverage:ci` ✅ (baseline + changed-line gates pass)
- `git diff --check` ✅
