### PR TITLE
fix(worktrees): nonce merge request ids and await the authoritative refresh (review R6)

### DIFF
--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "2d133a0a0cb3883d94e5ea2590b1ad9e39b8f927",
+        "head": "c27b66f8efb2dff402e5d1be2969b410fd12023c",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -451,7 +451,8 @@
             "6a7edd4573fa675486c124e4e68061ac0b78a962",
             "84a05bfff1d31c5a4bc98b25ebf24e95789d0aa2",
             "0cb69481a754d9f14793e2c5737503e47d8eaaab",
-            "1975a18661f7e1f916e5657436b5c12a2f788be2"
+            "1975a18661f7e1f916e5657436b5c12a2f788be2",
+            "256af5a77c1f758a37421fdf10242cf6d8d9b2ad"
         ]
     },
     "capabilities": [
@@ -2269,7 +2270,8 @@
                 "7aa265837b767e4406b39b67b0e0a7c9e0573201",
                 "b6284995ef315fae40d8e1e803b2eb1adacfc650",
                 "e5b496b8f2a345cf704643d473139a2ba87a3e76",
-                "2d133a0a0cb3883d94e5ea2590b1ad9e39b8f927"
+                "2d133a0a0cb3883d94e5ea2590b1ad9e39b8f927",
+                "c27b66f8efb2dff402e5d1be2969b410fd12023c"
             ],
             "behaviors": [
                 "WORKTREE-GROUPS-BASELINE-001",

--- a/media/webviewDashboardBundle.js
+++ b/media/webviewDashboardBundle.js
@@ -4566,6 +4566,12 @@ function initProjectAiSessionControls(options) {
     var pendingManagedWorktreeRemovalRequests = new Map();
     var nextMergeWorktreeGroupsRequestId = 0;
     var pendingMergeWorktreeGroupsRequests = new Map();
+    // A per-document nonce keeps merge request ids unique across webview
+    // reloads (review R6): the host replay cache outlives the document, so
+    // without it a reloaded document's `worktree-merge-1` would correlate
+    // with the previous document's cached settlement and never execute.
+    // Same pattern as rename/adopt/deletion.
+    var worktreeMergeDocumentNonce = Math.random().toString(36).slice(2, 10);
     var nextSetGroupPrimaryRequestId = 0;
     var pendingSetGroupPrimaryRequests = new Map();
     var worktreeGroupForm = null;
@@ -5443,7 +5449,8 @@ function initProjectAiSessionControls(options) {
         if (pendingMergeWorktreeGroupsRequests.size > 0) return;
         nextMergeWorktreeGroupsRequestId = nextMergeWorktreeGroupsRequestId
             >= Number.MAX_SAFE_INTEGER ? 1 : nextMergeWorktreeGroupsRequestId + 1;
-        var requestId = 'worktree-merge-' + nextMergeWorktreeGroupsRequestId.toString(36);
+        var requestId = 'worktree-merge-' + worktreeMergeDocumentNonce
+            + '-' + nextMergeWorktreeGroupsRequestId.toString(36);
         actionElement.setAttribute('aria-disabled', 'true');
         pendingMergeWorktreeGroupsRequests.set(requestId, {
             actionElement: actionElement,

--- a/media/webviewProjectAiSessionControlsScripts.js
+++ b/media/webviewProjectAiSessionControlsScripts.js
@@ -82,6 +82,12 @@ function initProjectAiSessionControls(options) {
     var pendingManagedWorktreeRemovalRequests = new Map();
     var nextMergeWorktreeGroupsRequestId = 0;
     var pendingMergeWorktreeGroupsRequests = new Map();
+    // A per-document nonce keeps merge request ids unique across webview
+    // reloads (review R6): the host replay cache outlives the document, so
+    // without it a reloaded document's `worktree-merge-1` would correlate
+    // with the previous document's cached settlement and never execute.
+    // Same pattern as rename/adopt/deletion.
+    var worktreeMergeDocumentNonce = Math.random().toString(36).slice(2, 10);
     var nextSetGroupPrimaryRequestId = 0;
     var pendingSetGroupPrimaryRequests = new Map();
     var worktreeGroupForm = null;
@@ -959,7 +965,8 @@ function initProjectAiSessionControls(options) {
         if (pendingMergeWorktreeGroupsRequests.size > 0) return;
         nextMergeWorktreeGroupsRequestId = nextMergeWorktreeGroupsRequestId
             >= Number.MAX_SAFE_INTEGER ? 1 : nextMergeWorktreeGroupsRequestId + 1;
-        var requestId = 'worktree-merge-' + nextMergeWorktreeGroupsRequestId.toString(36);
+        var requestId = 'worktree-merge-' + worktreeMergeDocumentNonce
+            + '-' + nextMergeWorktreeGroupsRequestId.toString(36);
         actionElement.setAttribute('aria-disabled', 'true');
         pendingMergeWorktreeGroupsRequests.set(requestId, {
             actionElement: actionElement,

--- a/src/webview/webviewProjectAiSessionControlsScripts.js
+++ b/src/webview/webviewProjectAiSessionControlsScripts.js
@@ -82,6 +82,12 @@ function initProjectAiSessionControls(options) {
     var pendingManagedWorktreeRemovalRequests = new Map();
     var nextMergeWorktreeGroupsRequestId = 0;
     var pendingMergeWorktreeGroupsRequests = new Map();
+    // A per-document nonce keeps merge request ids unique across webview
+    // reloads (review R6): the host replay cache outlives the document, so
+    // without it a reloaded document's `worktree-merge-1` would correlate
+    // with the previous document's cached settlement and never execute.
+    // Same pattern as rename/adopt/deletion.
+    var worktreeMergeDocumentNonce = Math.random().toString(36).slice(2, 10);
     var nextSetGroupPrimaryRequestId = 0;
     var pendingSetGroupPrimaryRequests = new Map();
     var worktreeGroupForm = null;
@@ -959,7 +965,8 @@ function initProjectAiSessionControls(options) {
         if (pendingMergeWorktreeGroupsRequests.size > 0) return;
         nextMergeWorktreeGroupsRequestId = nextMergeWorktreeGroupsRequestId
             >= Number.MAX_SAFE_INTEGER ? 1 : nextMergeWorktreeGroupsRequestId + 1;
-        var requestId = 'worktree-merge-' + nextMergeWorktreeGroupsRequestId.toString(36);
+        var requestId = 'worktree-merge-' + worktreeMergeDocumentNonce
+            + '-' + nextMergeWorktreeGroupsRequestId.toString(36);
         actionElement.setAttribute('aria-disabled', 'true');
         pendingMergeWorktreeGroupsRequests.set(requestId, {
             actionElement: actionElement,

--- a/src/worktrees/groupMergeHandler.ts
+++ b/src/worktrees/groupMergeHandler.ts
@@ -131,8 +131,10 @@ async function executeMergeWorktreeGroups(
                 errorCode: /^[a-z0-9-]{1,64}$/u.test(code) ? code : 'merge-failed',
             });
     }
-    // Fire-and-forget, exactly as the inline handler did.
-    void deps.refreshNow();
+    // The pending merge resolves only through the authoritative
+    // replacement, so delivery must be awaited before the terminal
+    // settlement posts (review R6) — same ordering as rename/adopt/deletion.
+    await deps.refreshNow();
     return settledWorktreeGroupMergeSettlement(
         request, { kind: 'merged', groupId: chosen.groupId });
 }

--- a/tests/browser/worktreeGroups.test.js
+++ b/tests/browser/worktreeGroups.test.js
@@ -414,6 +414,42 @@ test('WORKTREE-GROUPS-UI-001 shows the merge affordance and stable discriminator
         'colliding display names carry a stable branch discriminator');
 });
 
+test('WORKTREE-GROUPS-UI-001 merge request ids carry a per-document nonce (review R6)', async t => {
+    const sessionHtml = () => surface({
+        selectedSurface: 'worktree',
+        worktreeGroups: [
+            groupRow({ mergeCandidateGroupIds: ['g-2'] }),
+            groupRow({ groupId: 'g-2', mergeCandidateGroupIds: ['g-1'] }),
+        ],
+    });
+    const firstDocument = await openGroupActionsPage(t, sessionHtml);
+    await firstDocument.page.locator(
+        '[data-action="merge-worktree-groups"][data-group-id="g-1"]')
+        .evaluate(button => button.click());
+    const first = await firstDocument.page.evaluate(() => window.__postedMessages.at(-1));
+    assert.match(first.requestId, /^worktree-merge-[a-z0-9]+-1$/,
+        'the merge request id carries a per-document nonce');
+    assert.deepEqual({ ...first, requestId: '<nonce>' }, {
+        type: 'merge-worktree-groups',
+        version: 1,
+        requestId: '<nonce>',
+        projectId: 'project-a',
+        sourceGroupId: 'g-1',
+    });
+
+    // The host replay cache outlives the document: a rebuilt document must
+    // never regenerate the previous document's first request id and be
+    // answered from the stale cache without executing.
+    const secondDocument = await openGroupActionsPage(t, sessionHtml);
+    await secondDocument.page.locator(
+        '[data-action="merge-worktree-groups"][data-group-id="g-1"]')
+        .evaluate(button => button.click());
+    const second = await secondDocument.page.evaluate(() => window.__postedMessages.at(-1));
+    assert.match(second.requestId, /^worktree-merge-[a-z0-9]+-1$/);
+    assert.notEqual(second.requestId, first.requestId,
+        'a rebuilt document starts its own nonce-namespaced sequence');
+});
+
 test('WORKTREE-GROUPS-UI-001 flags legacy-scope sessions until restart', async t => {
     const page = await openSurfacePage(surface({
         worktreeGroups: [groupRow()],

--- a/tests/unit/worktrees/groupMergeHandler.test.js
+++ b/tests/unit/worktrees/groupMergeHandler.test.js
@@ -116,6 +116,21 @@ test('WORKTREE-GROUPS-MERGE-001 the host re-derives candidates, merges with the 
     assert.equal(shown.refreshed, 1);
 });
 
+test('WORKTREE-GROUPS-MERGE-001 the merged settlement waits for the authoritative refresh (review R6)', async () => {
+    const { store, deps, posted } = await fixture();
+    let releaseRefresh;
+    deps.refreshNow = () => new Promise(resolve => { releaseRefresh = resolve; });
+    const groups = store.listGroups(WORKSPACE);
+    deps.pickResult = { label: 'Fix login (2)', groupId: groups[1].groupId };
+    const handler = handleMergeWorktreeGroups(mergeRequest(groups[0].groupId), deps);
+    await new Promise(resolve => setTimeout(resolve, 0));
+    assert.deepEqual(statuses(posted), ['accepted'],
+        'the terminal settlement is not posted before the refresh completes');
+    releaseRefresh();
+    await handler;
+    assert.deepEqual(statuses(posted), ['accepted', 'merged']);
+});
+
 test('WORKTREE-GROUPS-MERGE-001 a replay is settled from the cache and never re-executes', async () => {
     const { store, deps, posted } = await fixture();
     const groups = store.listGroups(WORKSPACE);


### PR DESCRIPTION
## Summary

Fixes W1 review Blocker 6 + Important 1 (merge protocol):

- **Blocker 6 (requestId collision)**: the merge request counter restarted at 0 on every webview document init, while the host replay cache (`dashboard.ts`) outlives the document — a reloaded document's first merge (`worktree-merge-1`) could correlate with the previous document's cached settlement and return a stale `merged` without executing. The request id now carries a per-document nonce (`worktree-merge-<nonce>-<serial>`), the same pattern rename/adopt/deletion already use; the family prefix stays explicit.
- **Important 1 (settlement ordering)**: a successful merge posted its terminal settlement while the authoritative refresh was fire-and-forget (`void deps.refreshNow()`), so the webview cleared its pending entry before the replacement HTML could arrive. The handler now `await deps.refreshNow()` before settling `merged` — matching rename/adopt/deletion and the interface contract ("Awaits publication of the authoritative replacement").

Media mirror and the dashboard bundle are regenerated byte-for-byte.

## Change impact declaration

```change-impact-declaration
{
  "headSha": "e6dff0ec0219113da692140b90183f41228a2a1c",
  "capabilities": [
    "MAIN-WORKTREE-CHANGES-PANEL"
  ],
  "modules": [
    "MOD-DASHBOARD-SHELL",
    "MOD-WORKTREE-LIFECYCLE"
  ],
  "invariants": [],
  "policyDelta": "product-only",
  "baselineWaiverDelta": "zero",
  "newFiles": []
}
```

## Skill harvest

none — no skill change justified; the verification-masking lesson from R5 maps to existing guidance (`.skills/review-fix-commit-loop` already forbids exit-code-masking pipes), so the fix was behavioral, not documentary.

## Verification

- `npm run test-compile` ✅
- `node --test tests/browser/worktreeGroups.test.js` — 38/38 ✅ (new: nonce format + rebuilt-document sequence)
- `node --test tests/unit/worktrees/groupMergeHandler.test.js` ✅ (new: deferred-refresh — no terminal settlement before refresh completes)
- `npm run test:deterministic:run` ✅ — unit 1189 + contract 1170 + integration 435
- `node scripts/run-dashboard-webview-checks.js` ✅ (mirror/bundle byte-identity)
- `npm run test:architecture-policy` ✅ (webview manifest exact-once + load order)
- `npm run test:coverage:ci` ✅ — changed-line 100% (4/4), real exit code verified
- `git diff --check` ✅
