### PR TITLE
feat(architecture): AST-harden writer, dependency, and webview guards (review R7)

### DIFF
--- a/docs/testing/architecture-invariants.json
+++ b/docs/testing/architecture-invariants.json
@@ -71,6 +71,9 @@
                     "updateMember",
                     "setPrimaryMember",
                     "removeMember"
+                ],
+                "persistenceKeys": [
+                    "agentPivot.worktreeGroups.v1"
                 ]
             }
         },
@@ -142,6 +145,10 @@
                     "appendTombstones",
                     "deleteTombstones",
                     "pruneTombstones"
+                ],
+                "persistenceKeys": [
+                    "agentPivot.worktreeProvisioning.v1",
+                    "agentPivot.worktreeProvisioningTombstones.v1"
                 ]
             }
         },
@@ -317,6 +324,9 @@
                     "addMember",
                     "setRepositoryDetached",
                     "resetCorruptRetiredStore"
+                ],
+                "persistenceKeys": [
+                    "agentPivot.worktreeGroups.v1"
                 ]
             },
             "tracking": "ARCH-CHANGE-001"

--- a/docs/testing/architecture-webview-manifest.json
+++ b/docs/testing/architecture-webview-manifest.json
@@ -1,103 +1,348 @@
 {
-    "version": 1,
-    "title": "Webview script manifest (declared bundles, load order, permitted globals)",
-    "notes": [
-        "The 37 src/webview/*.js scripts carry no static imports; they couple through script load order and window globals. This manifest declares both, and scripts/architecture/checkWebviewManifest.js enforces them (charter v3 Section 8.6).",
-        "Membership is exact-once: every production webview script belongs to exactly one bundle. Load order is mirrored from the builders and drift-checked against them.",
-        "A cross-script global reference (window.__agentPivot* or vendor globals) must be declared in permittedGlobals; dynamic window[...] access fails closed.",
-        "Adding a global or reordering a bundle is a deliberate policy change visible in review."
-    ],
-    "bundles": [
-        {
-            "id": "dashboard",
-            "builtBy": "scripts/build-dashboard-webview-bundle.js",
-            "vendor": [
-                "node_modules/fitty/dist/fitty.min.js",
-                "node_modules/dragula/dist/dragula.min.js",
-                "node_modules/dom-autoscroller/dist/dom-autoscroller.min.js"
-            ],
-            "scripts": [
-                "src/webview/webviewScrollStateScripts.js",
-                "src/webview/webviewAiSessionViewStateScripts.js",
-                "src/webview/webviewWorkspaceUpdateScripts.js",
-                "src/webview/webviewTodoGroupScripts.js",
-                "src/webview/webviewProjectCollapseScripts.js",
-                "src/webview/webviewOpenTabSplitScripts.js",
-                "src/webview/webviewTodoControlScripts.js",
-                "src/webview/webviewProjectContextMenuScripts.js",
-                "src/webview/webviewProjectAiUpdateScripts.js",
-                "src/webview/webviewGroupFormScripts.js",
-                "src/webview/webviewProjectAiSessionControlsScripts.js",
-                "src/webview/webviewProjectScripts.js",
-                "src/webview/webviewSkillPanelScripts.js",
-                "src/webview/webviewProjectsPanelScripts.js",
-                "src/webview/webviewDashboardValidationScripts.js",
-                "src/webview/webviewDashboardSearchScripts.js",
-                "src/webview/webviewDashboardProjectsPanelScripts.js",
-                "src/webview/webviewDashboardTodoPanelScripts.js",
-                "src/webview/webviewDashboardAiPanelScripts.js",
-                "src/webview/webviewDashboardScripts.js",
-                "src/webview/webviewPromptProtocolScripts.js",
-                "src/webview/webviewPromptScripts.js",
-                "src/webview/webviewTodoRenderScripts.js",
-                "src/webview/webviewTodoScripts.js",
-                "src/webview/webviewDnDScripts.js",
-                "src/webview/webviewFilterScripts.js"
-            ]
-        },
-        {
-            "id": "conversation-viewer",
-            "builtBy": "src/aiSessions/conversation/viewerDocument.ts",
-            "vendor": ["media/purify.min.js"],
-            "lazyVendor": ["media/mermaid.min.js"],
-            "scripts": [
-                "src/webview/conversationReadingAnchorScripts.js",
-                "src/webview/conversationMermaidScripts.js",
-                "src/webview/conversationOutlineScripts.js",
-                "src/webview/conversationSubagentsScripts.js",
-                "src/webview/conversationChangesScripts.js",
-                "src/webview/conversationTelemetryScripts.js",
-                "src/webview/conversationCommentsScripts.js",
-                "src/webview/conversationSidebarScripts.js",
-                "src/webview/conversationReconcileScripts.js",
-                "src/webview/conversationFindScripts.js",
-                "src/webview/conversationViewerScripts.js"
-            ]
-        }
-    ],
-    "permittedGlobals": [
-        "window.__agentPivotAcknowledgeSession",
-        "window.__agentPivotAttentionAcknowledgementTimeoutMs",
-        "window.__agentPivotBatchAiSessions",
-        "window.__agentPivotContextMenus",
-        "window.__agentPivotConversationChanges",
-        "window.__agentPivotConversationComments",
-        "window.__agentPivotConversationFind",
-        "window.__agentPivotConversationMermaid",
-        "window.__agentPivotConversationOutline",
-        "window.__agentPivotConversationReadingAnchor",
-        "window.__agentPivotConversationReconcile",
-        "window.__agentPivotConversationSidebar",
-        "window.__agentPivotConversationSubagents",
-        "window.__agentPivotConversationTelemetry",
-        "window.__agentPivotDashboard",
-        "window.__agentPivotOpenTabSplit",
-        "window.__agentPivotPrompts",
-        "window.__agentPivotReadyDocumentGeneration",
-        "window.__agentPivotRevealPendingWorkspaceSession",
-        "window.__agentPivotRevealWorkspace",
-        "window.__agentPivotRevealWorkspaceSession",
-        "window.__agentPivotRevealWorkspaceWorktree",
-        "window.__agentPivotScrollState",
-        "window.__agentPivotSyncCollapseButton",
-        "window.__agentPivotTodo",
-        "window.__agentPivotWorktreeAdopt",
-        "window.__agentPivotWorktreeGroupAggregateRevision",
-        "window.__agentPivotWorktreeGroupDeletion",
-        "window.__agentPivotWorktreeGroupForm",
-        "window.__agentPivotWorktreeGroupRename",
-        "window.vscode",
-        "window.DOMPurify",
-        "window.mermaid"
-    ]
+  "version": 2,
+  "title": "Webview script manifest (declared bundles, load order, permitted globals)",
+  "notes": [
+    "Bundles: exact-once membership over src/webview/*.js and load-order fidelity with scripts/build-dashboard-webview-bundle.js (dashboard) and src/aiSessions/conversation/viewerDocument.ts (conversation-viewer).",
+    "Globals (review R7): every window.*/globalThis.* reference must be declared here. A script-produced symbol has exactly one producer script and an exact consumers set; producer and consumers must share a bundle, and a consumer with a load-time (top-level) read must load after the producer. 'host' symbols are injected by the extension backend HTML (e.g. window.vscode), 'vendor' symbols by media vendor files, 'builtin' symbols are platform APIs. Unused entries are stale and fail."
+  ],
+  "bundles": [
+    {
+      "id": "dashboard",
+      "builtBy": "scripts/build-dashboard-webview-bundle.js",
+      "vendor": [
+        "node_modules/fitty/dist/fitty.min.js",
+        "node_modules/dragula/dist/dragula.min.js",
+        "node_modules/dom-autoscroller/dist/dom-autoscroller.min.js"
+      ],
+      "scripts": [
+        "src/webview/webviewScrollStateScripts.js",
+        "src/webview/webviewAiSessionViewStateScripts.js",
+        "src/webview/webviewWorkspaceUpdateScripts.js",
+        "src/webview/webviewTodoGroupScripts.js",
+        "src/webview/webviewProjectCollapseScripts.js",
+        "src/webview/webviewOpenTabSplitScripts.js",
+        "src/webview/webviewTodoControlScripts.js",
+        "src/webview/webviewProjectContextMenuScripts.js",
+        "src/webview/webviewProjectAiUpdateScripts.js",
+        "src/webview/webviewGroupFormScripts.js",
+        "src/webview/webviewProjectAiSessionControlsScripts.js",
+        "src/webview/webviewProjectScripts.js",
+        "src/webview/webviewSkillPanelScripts.js",
+        "src/webview/webviewProjectsPanelScripts.js",
+        "src/webview/webviewDashboardValidationScripts.js",
+        "src/webview/webviewDashboardSearchScripts.js",
+        "src/webview/webviewDashboardProjectsPanelScripts.js",
+        "src/webview/webviewDashboardTodoPanelScripts.js",
+        "src/webview/webviewDashboardAiPanelScripts.js",
+        "src/webview/webviewDashboardScripts.js",
+        "src/webview/webviewPromptProtocolScripts.js",
+        "src/webview/webviewPromptScripts.js",
+        "src/webview/webviewTodoRenderScripts.js",
+        "src/webview/webviewTodoScripts.js",
+        "src/webview/webviewDnDScripts.js",
+        "src/webview/webviewFilterScripts.js"
+      ]
+    },
+    {
+      "id": "conversation-viewer",
+      "builtBy": "src/aiSessions/conversation/viewerDocument.ts",
+      "vendor": [
+        "media/purify.min.js"
+      ],
+      "lazyVendor": [
+        "media/mermaid.min.js"
+      ],
+      "scripts": [
+        "src/webview/conversationReadingAnchorScripts.js",
+        "src/webview/conversationMermaidScripts.js",
+        "src/webview/conversationOutlineScripts.js",
+        "src/webview/conversationSubagentsScripts.js",
+        "src/webview/conversationChangesScripts.js",
+        "src/webview/conversationTelemetryScripts.js",
+        "src/webview/conversationCommentsScripts.js",
+        "src/webview/conversationSidebarScripts.js",
+        "src/webview/conversationReconcileScripts.js",
+        "src/webview/conversationFindScripts.js",
+        "src/webview/conversationViewerScripts.js"
+      ]
+    }
+  ],
+  "globals": [
+    {
+      "symbol": "window.CSS",
+      "producer": "builtin"
+    },
+    {
+      "symbol": "window.DOMPurify",
+      "producer": "vendor"
+    },
+    {
+      "symbol": "window.__agentPivotAcknowledgeSession",
+      "producer": "src/webview/webviewProjectAiSessionControlsScripts.js",
+      "consumers": [
+        "src/webview/webviewDashboardScripts.js"
+      ]
+    },
+    {
+      "symbol": "window.__agentPivotAttentionAcknowledgementTimeoutMs",
+      "producer": "host"
+    },
+    {
+      "symbol": "window.__agentPivotBatchAiSessions",
+      "producer": "src/webview/webviewProjectAiSessionControlsScripts.js",
+      "consumers": []
+    },
+    {
+      "symbol": "window.__agentPivotContextMenus",
+      "producer": "src/webview/webviewProjectScripts.js",
+      "consumers": [
+        "src/webview/webviewProjectAiSessionControlsScripts.js"
+      ]
+    },
+    {
+      "symbol": "window.__agentPivotConversationChanges",
+      "producer": "src/webview/conversationChangesScripts.js",
+      "consumers": [
+        "src/webview/conversationViewerScripts.js"
+      ]
+    },
+    {
+      "symbol": "window.__agentPivotConversationComments",
+      "producer": "src/webview/conversationCommentsScripts.js",
+      "consumers": [
+        "src/webview/conversationViewerScripts.js"
+      ]
+    },
+    {
+      "symbol": "window.__agentPivotConversationFind",
+      "producer": "src/webview/conversationFindScripts.js",
+      "consumers": [
+        "src/webview/conversationViewerScripts.js"
+      ]
+    },
+    {
+      "symbol": "window.__agentPivotConversationMermaid",
+      "producer": "src/webview/conversationMermaidScripts.js",
+      "consumers": [
+        "src/webview/conversationViewerScripts.js"
+      ]
+    },
+    {
+      "symbol": "window.__agentPivotConversationOutline",
+      "producer": "src/webview/conversationOutlineScripts.js",
+      "consumers": [
+        "src/webview/conversationViewerScripts.js"
+      ]
+    },
+    {
+      "symbol": "window.__agentPivotConversationReadingAnchor",
+      "producer": "src/webview/conversationReadingAnchorScripts.js",
+      "consumers": [
+        "src/webview/conversationViewerScripts.js"
+      ]
+    },
+    {
+      "symbol": "window.__agentPivotConversationReconcile",
+      "producer": "src/webview/conversationReconcileScripts.js",
+      "consumers": [
+        "src/webview/conversationViewerScripts.js"
+      ]
+    },
+    {
+      "symbol": "window.__agentPivotConversationSidebar",
+      "producer": "src/webview/conversationSidebarScripts.js",
+      "consumers": [
+        "src/webview/conversationViewerScripts.js"
+      ]
+    },
+    {
+      "symbol": "window.__agentPivotConversationSubagents",
+      "producer": "src/webview/conversationSubagentsScripts.js",
+      "consumers": [
+        "src/webview/conversationViewerScripts.js"
+      ]
+    },
+    {
+      "symbol": "window.__agentPivotConversationTelemetry",
+      "producer": "src/webview/conversationTelemetryScripts.js",
+      "consumers": [
+        "src/webview/conversationViewerScripts.js"
+      ]
+    },
+    {
+      "symbol": "window.__agentPivotDashboard",
+      "producer": "host"
+    },
+    {
+      "symbol": "window.__agentPivotOpenTabSplit",
+      "producer": "src/webview/webviewOpenTabSplitScripts.js",
+      "consumers": [
+        "src/webview/webviewProjectAiSessionControlsScripts.js"
+      ]
+    },
+    {
+      "symbol": "window.__agentPivotPrompts",
+      "producer": "src/webview/webviewPromptScripts.js",
+      "consumers": [
+        "src/webview/webviewDashboardAiPanelScripts.js"
+      ]
+    },
+    {
+      "symbol": "window.__agentPivotReadyDocumentGeneration",
+      "producer": "host"
+    },
+    {
+      "symbol": "window.__agentPivotRevealPendingWorkspaceSession",
+      "producer": "src/webview/webviewProjectAiUpdateScripts.js",
+      "consumers": [
+        "src/webview/webviewWorkspaceUpdateScripts.js"
+      ]
+    },
+    {
+      "symbol": "window.__agentPivotRevealWorkspace",
+      "producer": "src/webview/webviewProjectAiUpdateScripts.js",
+      "consumers": [
+        "src/webview/webviewDashboardScripts.js"
+      ]
+    },
+    {
+      "symbol": "window.__agentPivotRevealWorkspaceSession",
+      "producer": "src/webview/webviewProjectAiUpdateScripts.js",
+      "consumers": [
+        "src/webview/webviewDashboardScripts.js"
+      ]
+    },
+    {
+      "symbol": "window.__agentPivotRevealWorkspaceWorktree",
+      "producer": "src/webview/webviewProjectAiUpdateScripts.js",
+      "consumers": [
+        "src/webview/webviewDashboardScripts.js"
+      ]
+    },
+    {
+      "symbol": "window.__agentPivotScrollState",
+      "producer": "src/webview/webviewScrollStateScripts.js",
+      "consumers": [
+        "src/webview/webviewAiSessionViewStateScripts.js",
+        "src/webview/webviewProjectsPanelScripts.js",
+        "src/webview/webviewSkillPanelScripts.js",
+        "src/webview/webviewTodoScripts.js",
+        "src/webview/webviewWorkspaceUpdateScripts.js"
+      ]
+    },
+    {
+      "symbol": "window.__agentPivotSyncCollapseButton",
+      "producer": "src/webview/webviewProjectCollapseScripts.js",
+      "consumers": [
+        "src/webview/webviewWorkspaceUpdateScripts.js"
+      ]
+    },
+    {
+      "symbol": "window.__agentPivotTodo",
+      "producer": "src/webview/webviewTodoScripts.js",
+      "consumers": [
+        "src/webview/webviewDashboardTodoPanelScripts.js",
+        "src/webview/webviewDnDScripts.js",
+        "src/webview/webviewProjectCollapseScripts.js",
+        "src/webview/webviewTodoControlScripts.js"
+      ]
+    },
+    {
+      "symbol": "window.__agentPivotWorktreeAdopt",
+      "producer": "src/webview/webviewProjectAiSessionControlsScripts.js",
+      "consumers": [
+        "src/webview/webviewAiSessionViewStateScripts.js"
+      ]
+    },
+    {
+      "symbol": "window.__agentPivotWorktreeGroupAggregateRevision",
+      "producer": "src/webview/webviewProjectScripts.js",
+      "consumers": [
+        "src/webview/webviewProjectAiSessionControlsScripts.js",
+        "src/webview/webviewProjectScripts.js"
+      ]
+    },
+    {
+      "symbol": "window.__agentPivotWorktreeGroupDeletion",
+      "producer": "src/webview/webviewProjectAiSessionControlsScripts.js",
+      "consumers": [
+        "src/webview/webviewAiSessionViewStateScripts.js"
+      ]
+    },
+    {
+      "symbol": "window.__agentPivotWorktreeGroupForm",
+      "producer": "src/webview/webviewProjectScripts.js",
+      "consumers": [
+        "src/webview/webviewWorkspaceUpdateScripts.js"
+      ]
+    },
+    {
+      "symbol": "window.__agentPivotWorktreeGroupRename",
+      "producer": "src/webview/webviewProjectAiSessionControlsScripts.js",
+      "consumers": [
+        "src/webview/webviewAiSessionViewStateScripts.js"
+      ]
+    },
+    {
+      "symbol": "window.__stewardStickyHeaderObserver",
+      "producer": "src/webview/webviewProjectScripts.js",
+      "consumers": []
+    },
+    {
+      "symbol": "window.addEventListener",
+      "producer": "builtin"
+    },
+    {
+      "symbol": "window.clearTimeout",
+      "producer": "builtin"
+    },
+    {
+      "symbol": "window.getComputedStyle",
+      "producer": "builtin"
+    },
+    {
+      "symbol": "window.getSelection",
+      "producer": "builtin"
+    },
+    {
+      "symbol": "window.innerHeight",
+      "producer": "builtin"
+    },
+    {
+      "symbol": "window.innerWidth",
+      "producer": "builtin"
+    },
+    {
+      "symbol": "window.mermaid",
+      "producer": "vendor"
+    },
+    {
+      "symbol": "window.pageYOffset",
+      "producer": "builtin"
+    },
+    {
+      "symbol": "window.removeEventListener",
+      "producer": "builtin"
+    },
+    {
+      "symbol": "window.requestAnimationFrame",
+      "producer": "builtin"
+    },
+    {
+      "symbol": "window.scrollTo",
+      "producer": "builtin"
+    },
+    {
+      "symbol": "window.scrollY",
+      "producer": "builtin"
+    },
+    {
+      "symbol": "window.setTimeout",
+      "producer": "builtin"
+    },
+    {
+      "symbol": "window.vscode",
+      "producer": "host"
+    }
+  ]
 }

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "c27b66f8efb2dff402e5d1be2969b410fd12023c",
+        "head": "7d6ba8f3bb67f33104cfc8a9b03ad915a397e103",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -452,7 +452,8 @@
             "84a05bfff1d31c5a4bc98b25ebf24e95789d0aa2",
             "0cb69481a754d9f14793e2c5737503e47d8eaaab",
             "1975a18661f7e1f916e5657436b5c12a2f788be2",
-            "256af5a77c1f758a37421fdf10242cf6d8d9b2ad"
+            "256af5a77c1f758a37421fdf10242cf6d8d9b2ad",
+            "e6dff0ec0219113da692140b90183f41228a2a1c"
         ]
     },
     "capabilities": [
@@ -2310,7 +2311,10 @@
                 "2b7bdcc70d234bed812e572897b323623790eb9b",
                 "d1f7ab3f8aa0900af3bc03cbac0dc684c1d87652",
                 "51db84eb828bd5ce4d0f773d571329fb569ffc1e",
-                "a7afab45ea326f4b9bf9bfa3245c2580aa89f31e"
+                "a7afab45ea326f4b9bf9bfa3245c2580aa89f31e",
+                "b1f848b288979120ced07eba0551426532843b4b",
+                "9562798070e528aaed43c1c32cb6132ddcbcd49e",
+                "7d6ba8f3bb67f33104cfc8a9b03ad915a397e103"
             ],
             "behaviors": [
                 "ARCH-POLICY-SCHEMA-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "4bec57e837bfc81a04470c057d7d4533588d2edc",
+        "head": "38b091a8cb6f00e5fcaf085342285a0ba0eda1ba",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -453,7 +453,9 @@
             "0cb69481a754d9f14793e2c5737503e47d8eaaab",
             "1975a18661f7e1f916e5657436b5c12a2f788be2",
             "256af5a77c1f758a37421fdf10242cf6d8d9b2ad",
-            "e6dff0ec0219113da692140b90183f41228a2a1c"
+            "e6dff0ec0219113da692140b90183f41228a2a1c",
+            "a933a1c989dcd146a4bf6e65f3caad0bc4226dbf",
+            "0cfef2b250d7db4a3056629acf7fc03bd86e99a0"
         ]
     },
     "capabilities": [
@@ -2314,7 +2316,8 @@
                 "a7afab45ea326f4b9bf9bfa3245c2580aa89f31e",
                 "9366094ff487c644d9d44abdd3ad3aed574b573c",
                 "96180ff29ff10eefd1aeb55274027cf5005b2297",
-                "4bec57e837bfc81a04470c057d7d4533588d2edc"
+                "4bec57e837bfc81a04470c057d7d4533588d2edc",
+                "38b091a8cb6f00e5fcaf085342285a0ba0eda1ba"
             ],
             "behaviors": [
                 "ARCH-POLICY-SCHEMA-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "7d6ba8f3bb67f33104cfc8a9b03ad915a397e103",
+        "head": "4bec57e837bfc81a04470c057d7d4533588d2edc",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -2312,9 +2312,9 @@
                 "d1f7ab3f8aa0900af3bc03cbac0dc684c1d87652",
                 "51db84eb828bd5ce4d0f773d571329fb569ffc1e",
                 "a7afab45ea326f4b9bf9bfa3245c2580aa89f31e",
-                "b1f848b288979120ced07eba0551426532843b4b",
-                "9562798070e528aaed43c1c32cb6132ddcbcd49e",
-                "7d6ba8f3bb67f33104cfc8a9b03ad915a397e103"
+                "9366094ff487c644d9d44abdd3ad3aed574b573c",
+                "96180ff29ff10eefd1aeb55274027cf5005b2297",
+                "4bec57e837bfc81a04470c057d7d4533588d2edc"
             ],
             "behaviors": [
                 "ARCH-POLICY-SCHEMA-001",

--- a/scripts/architecture/buildDependencyGraph.js
+++ b/scripts/architecture/buildDependencyGraph.js
@@ -4,24 +4,23 @@
  * Dependency graph builder (Harness v0, program Stage 2 PR 2).
  *
  * Builds the complete local import graph over the classified production
- * files: static imports, re-exports, type-only imports, require() calls, and
- * type-position import('...') references. Every edge records its source file,
- * target file, both modules, and its kind (value | type).
+ * files with a TypeScript AST walk (review R7): static imports, re-exports,
+ * type-only imports, require() calls, type-position import('...') types, and
+ * runtime dynamic imports. Every edge records its source file, target file,
+ * both modules, and its kind (value | type).
  *
- * Fail closed: a relative specifier that does not resolve to a classified
- * file is an error, never silently skipped.
+ * A runtime `await import('./x')` is a value edge (the cycle ratchet
+ * analyzes value edges, so a dynamic import can never smuggle a runtime
+ * cycle past it); only type-position `import('./x').T` types stay type
+ * edges. Fail closed: a relative specifier that does not resolve to a
+ * classified file is an error, and any import/export/require form the
+ * walker does not recognize is an error, never silently skipped.
  */
 
 const fs = require('fs');
 const path = require('path');
+const ts = require('typescript');
 const { loadArchitecturePolicy } = require('./loadArchitecturePolicy');
-
-const IMPORT_PATTERN =
-    /(?:import|export)([^'"]*?)\bfrom\s*['"](\.[^'"]+)['"]|import\s+['"](\.[^'"]+)['"]|require\(\s*['"](\.[^'"]+)['"]\s*\)|import\(\s*['"](\.[^'"]+)['"]\s*\)/g;
-
-function edgeKind(importClause) {
-    return /^\s*type\b/.test(importClause || '') ? 'type' : 'value';
-}
 
 function resolveTarget(sourceFile, specifier, classifiedFiles) {
     const target = path.posix.normalize(path.posix.join(path.posix.dirname(sourceFile), specifier));
@@ -37,6 +36,93 @@ function resolveTarget(sourceFile, specifier, classifiedFiles) {
  * targetModule, kind }]. Module-less files never occur (classification is
  * exact-once), but resolution failures are errors.
  */
+function literalText(node) {
+    return node && (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node))
+        ? node.text
+        : null;
+}
+
+/**
+ * Extract { specifier, kind } edge candidates from one source file. Only
+ * relative specifiers become edges; bare package specifiers are out of
+ * scope. Unrecognized local-reference forms are errors (fail closed).
+ */
+function extractEdgeCandidates(file, text) {
+    const sourceFile = ts.createSourceFile(
+        file, text, ts.ScriptTarget.Latest, true,
+        file.endsWith('.js') ? ts.ScriptKind.JS : ts.ScriptKind.TS);
+    const candidates = [];
+    const errors = [];
+    const visit = node => {
+        if (ts.isImportDeclaration(node)) {
+            const specifier = literalText(node.moduleSpecifier);
+            if (specifier !== null) {
+                candidates.push({
+                    specifier,
+                    // `import type ...` is a pure type edge; any value
+                    // specifier (including a mixed clause) makes it a
+                    // value edge.
+                    kind: node.importClause && node.importClause.isTypeOnly ? 'type' : 'value',
+                });
+            }
+        } else if (ts.isExportDeclaration(node) && node.moduleSpecifier) {
+            const specifier = literalText(node.moduleSpecifier);
+            if (specifier !== null) {
+                candidates.push({
+                    specifier,
+                    kind: node.isTypeOnly ? 'type' : 'value',
+                });
+            }
+        } else if (ts.isImportEqualsDeclaration(node)) {
+            const reference = node.moduleReference;
+            if (ts.isExternalModuleReference(reference)) {
+                const specifier = literalText(reference.expression);
+                if (specifier !== null) {
+                    candidates.push({ specifier, kind: 'value' });
+                } else if (reference.expression
+                    && reference.expression.getText(sourceFile).startsWith('.')) {
+                    errors.push(`${file}: unrecognized import-require form '` +
+                        `${reference.expression.getText(sourceFile)}'`);
+                }
+            }
+            // Namespace aliases (import X = A.B) carry no module specifier;
+            // they are not edges.
+        } else if (ts.isImportTypeNode(node)) {
+            // Type-position import('./x').T — the only form that stays a
+            // type edge.
+            const argument = node.argument;
+            const specifier = ts.isLiteralTypeNode(argument)
+                ? literalText(argument.literal)
+                : null;
+            if (specifier !== null) {
+                candidates.push({ specifier, kind: 'type' });
+            } else {
+                errors.push(`${file}: unrecognized type-import form in import type`);
+            }
+        } else if (ts.isCallExpression(node)) {
+            if (node.expression.kind === ts.SyntaxKind.ImportKeyword) {
+                // Runtime dynamic import — a genuine value edge.
+                const specifier = literalText(node.arguments[0]);
+                if (specifier !== null) {
+                    candidates.push({ specifier, kind: 'value' });
+                } else {
+                    errors.push(`${file}: dynamic import() with a non-literal specifier`);
+                }
+            } else if (ts.isIdentifier(node.expression) && node.expression.text === 'require') {
+                const specifier = literalText(node.arguments[0]);
+                if (specifier !== null) {
+                    candidates.push({ specifier, kind: 'value' });
+                } else {
+                    errors.push(`${file}: require() with a non-literal specifier`);
+                }
+            }
+        }
+        ts.forEachChild(node, visit);
+    };
+    visit(sourceFile);
+    return { candidates, errors };
+}
+
 function buildDependencyGraph(rootDirectory) {
     const { classification, errors } = loadArchitecturePolicy(rootDirectory);
     const classifiedFiles = new Set(classification.keys());
@@ -44,14 +130,10 @@ function buildDependencyGraph(rootDirectory) {
 
     for (const [file, owner] of classification) {
         const text = fs.readFileSync(path.join(rootDirectory, file), 'utf8');
-        IMPORT_PATTERN.lastIndex = 0;
-        let match;
-        while ((match = IMPORT_PATTERN.exec(text))) {
-            const [, importClause, fromSpecifier, bareSpecifier, requireSpecifier, dynamicSpecifier] = match;
-            const specifier = fromSpecifier || bareSpecifier || requireSpecifier || dynamicSpecifier;
-            const kind = fromSpecifier
-                ? edgeKind(importClause)
-                : dynamicSpecifier ? 'type' : 'value';
+        const { candidates, errors: extractionErrors } = extractEdgeCandidates(file, text);
+        errors.push(...extractionErrors);
+        for (const { specifier, kind } of candidates) {
+            if (!specifier.startsWith('.')) { continue; }
             const target = resolveTarget(file, specifier, classifiedFiles);
             if (!target) {
                 errors.push(`dependency-graph: ${file} has an unresolvable local specifier '${specifier}'`);

--- a/scripts/architecture/checkSingleWriters.js
+++ b/scripts/architecture/checkSingleWriters.js
@@ -5,16 +5,27 @@
  *
  * Validates the invariant catalog (docs/testing/architecture-invariants.json)
  * structurally and cross-file, then mechanically checks every invariant whose
- * enforcement includes "single-writer": a write-method call on the state
+ * enforcement includes "single-writer": a write-method touch on the state
  * family's store outside the declared writer set fails. The writer set is a
  * ratchet — it may only shrink during migration, never grow.
  *
- * Bypass check: the store's persistence key may not be referenced outside the
- * store file at all.
+ * The write-method scan is AST-based (review R7): property access
+ * (`store.updateMember(...)`), element access (`store['updateMember'](...)`),
+ * and destructuring (`const { updateMember } = store`, including aliased)
+ * are all detected, so renaming the receiver or re-binding the method cannot
+ * launder a write past the guard. What it cannot detect: a write through a
+ * mock-typed double in a file that never mentions the store module — such a
+ * file would also fail the module-boundary guard on the import edge, and the
+ * behavior owner tests pin the authority semantics.
+ *
+ * Bypass check: every literal in stateFamily.persistenceKeys may appear only
+ * inside the store file — a memento-key reference is a raw write path around
+ * the authority.
  */
 
 const fs = require('fs');
 const path = require('path');
+const ts = require('typescript');
 const { loadArchitecturePolicy } = require('./loadArchitecturePolicy');
 
 const INVARIANTS_PATH = path.join('docs', 'testing', 'architecture-invariants.json');
@@ -108,6 +119,26 @@ function validateCatalog(rootDirectory, policy) {
                     + 'with storePath and writeMethods');
             } else {
                 requirePath(owner, family.storePath, 'stateFamily.storePath');
+                if (family.persistenceKeys !== undefined) {
+                    if (!Array.isArray(family.persistenceKeys)
+                        || family.persistenceKeys.length === 0
+                        || family.persistenceKeys.some(key => typeof key !== 'string' || !key)) {
+                        errors.push(`${owner}: stateFamily.persistenceKeys must be a non-empty `
+                            + 'array of strings');
+                    } else {
+                        // A declared key that no longer exists in the store is
+                        // stale policy, not protection.
+                        const storeText = fs.existsSync(path.join(rootDirectory, family.storePath))
+                            ? fs.readFileSync(path.join(rootDirectory, family.storePath), 'utf8')
+                            : '';
+                        for (const key of family.persistenceKeys) {
+                            if (!storeText.includes(key)) {
+                                errors.push(`${owner}: persistence key '${key}' does not appear in `
+                                    + `${family.storePath} — stale or mistyped keys protect nothing`);
+                            }
+                        }
+                    }
+                }
             }
             if (!Array.isArray(invariant.writers) || invariant.writers.length === 0) {
                 errors.push(`${owner}: single-writer enforcement requires a non-empty writers set`);
@@ -117,7 +148,41 @@ function validateCatalog(rootDirectory, policy) {
     return { catalog, errors };
 }
 
-/** Scan declared state families for write-method calls outside the writers. */
+/**
+ * AST scan: every property access, element access, or destructuring binding
+ * that names a write method — resilient to import aliases, receiver renames,
+ * .bind extraction, and bracket access (review R7).
+ */
+function findWriteMethodTouches(file, text, writeMethods) {
+    const sourceFile = ts.createSourceFile(
+        file, text, ts.ScriptTarget.Latest, true,
+        file.endsWith('.js') ? ts.ScriptKind.JS : ts.ScriptKind.TS);
+    const touches = new Set();
+    const visit = node => {
+        if (ts.isPropertyAccessExpression(node) && writeMethods.has(node.name.text)) {
+            touches.add(`touches write method '${node.name.text}'`);
+        } else if (ts.isElementAccessExpression(node)) {
+            const argument = node.argumentExpression;
+            if (argument && (ts.isStringLiteral(argument)
+                || ts.isNoSubstitutionTemplateLiteral(argument))
+                && writeMethods.has(argument.text)) {
+                touches.add(`touches write method '${argument.text}' via element access`);
+            }
+        } else if (ts.isBindingElement(node)) {
+            const name = node.propertyName && ts.isIdentifier(node.propertyName)
+                ? node.propertyName.text
+                : (ts.isIdentifier(node.name) ? node.name.text : null);
+            if (name && writeMethods.has(name)) {
+                touches.add(`destructures write method '${name}'`);
+            }
+        }
+        ts.forEachChild(node, visit);
+    };
+    visit(sourceFile);
+    return [...touches].sort();
+}
+
+/** Scan declared state families for write-method touches outside the writers. */
 function checkWriters(rootDirectory, catalog, policy) {
     const errors = [];
     const invariants = (catalog.invariants || [])
@@ -127,17 +192,23 @@ function checkWriters(rootDirectory, catalog, policy) {
         const family = invariant.stateFamily;
         const writers = new Set([...invariant.writers, family.storePath]);
         const storeReference = path.basename(family.storePath).replace(/\.[^.]+$/, '');
-        const callPattern = new RegExp(
-            `\\.(?:${family.writeMethods.join('|')})\\s*\\(`);
+        const writeMethods = new Set(family.writeMethods);
+        const persistenceKeys = family.persistenceKeys || [];
         for (const file of policy.files) {
             if (writers.has(file)) { continue; }
             const text = fs.readFileSync(path.join(rootDirectory, file), 'utf8');
+            for (const key of persistenceKeys) {
+                if (text.includes(key)) {
+                    errors.push(`single-writer: ${file} references persistence key '${key}' of the `
+                        + `${family.storePath} state family outside the store — a raw storage write `
+                        + `bypasses the authority of ${invariant.id}`);
+                }
+            }
             // A same-named method on an unrelated store is not a bypass: the
             // file must also reference the state family's store.
             if (!text.includes(storeReference)) { continue; }
-            const match = callPattern.exec(text);
-            if (match) {
-                errors.push(`single-writer: ${file} calls '${match[0].slice(1, -1).trim()}' on the `
+            for (const touch of findWriteMethodTouches(file, text, writeMethods)) {
+                errors.push(`single-writer: ${file} ${touch} on the `
                     + `${family.storePath} state family outside the declared writers of `
                     + `${invariant.id} — route the write through the authority or land an `
                     + 'approved architecture change that amends the writer set');

--- a/scripts/architecture/checkWebviewManifest.js
+++ b/scripts/architecture/checkWebviewManifest.js
@@ -2,7 +2,7 @@
 
 /**
  * Webview declared-manifest enforcement (Harness v0, program Stage 2 PR 5;
- * charter v3 Section 8.6).
+ * charter v3 Section 8.6; symbol-level model from review R7).
  *
  * The 37 src/webview/*.js scripts carry no static imports, so the module
  * graph cannot police them. This check enforces the declared manifest
@@ -10,18 +10,28 @@
  * - membership: every production webview script belongs to exactly one bundle;
  * - load order: the manifest mirrors the builders (bundle inputPaths and the
  *   conversation viewer document) and drift in either direction fails;
- * - globals: every cross-script window.* reference must be declared in
- *   permittedGlobals, and dynamic window[...] access fails closed.
+ * - globals, closed-world: EVERY window.* or globalThis.* reference must be
+ *   declared — an undeclared custom property fails. Script-produced symbols
+ *   have exactly one producer (proven by an assignment in that file) and an
+ *   exact consumers set; producer and consumers share one bundle; a consumer
+ *   with a load-time (top-level) read must load after the producer. host /
+ *   vendor / builtin entries model symbols the scripts never produce.
+ * - evasion forms fail closed: dynamic window[...] / globalThis[...] access,
+ *   bare (unprefixed) references to declared globals, and script writes to
+ *   host/vendor/builtin symbols.
+ * - staleness: a declared symbol nobody references fails; a declared consumer
+ *   that never reads fails; an undeclared reader fails.
  */
 
 const fs = require('fs');
 const path = require('path');
+const ts = require('typescript');
 
 const MANIFEST_PATH = path.join('docs', 'testing', 'architecture-webview-manifest.json');
 const BUNDLE_BUILDER = path.join('scripts', 'build-dashboard-webview-bundle.js');
 const VIEWER_DOCUMENT = path.join('src', 'aiSessions', 'conversation', 'viewerDocument.ts');
-const GLOBAL_REFERENCE = /window\.(__agentPivot[A-Za-z0-9]*|vscode|mermaid|DOMPurify|fitty|dragula|domAutoscroller)\b/g;
-const DYNAMIC_GLOBAL_ACCESS = /window\s*\[/g;
+const SYMBOL_PATTERN = /^window\.[A-Za-z_$][A-Za-z0-9_$]*$/;
+const PRODUCER_KINDS = ['host', 'vendor', 'builtin'];
 
 function readJson(rootDirectory, relativePath, errors) {
     try {
@@ -32,7 +42,7 @@ function readJson(rootDirectory, relativePath, errors) {
     }
 }
 
-function checkBundleOrder(rootDirectory, errors) {
+function checkBundleOrder(rootDirectory) {
     const builderText = fs.readFileSync(path.join(rootDirectory, BUNDLE_BUILDER), 'utf8');
     const builderOrder = [...builderText.matchAll(/'(src\/webview\/[^']+\.js)'/g)]
         .map(match => match[1]);
@@ -42,16 +52,119 @@ function checkBundleOrder(rootDirectory, errors) {
     return { builderOrder, viewerOrder };
 }
 
+/** window/globalThis usage in one script: writes, reads, load-time reads, dynamic access, bare references. */
+function analyzeScript(rootDirectory, script, declaredBareNames) {
+    const text = fs.readFileSync(path.join(rootDirectory, script), 'utf8');
+    const sourceFile = ts.createSourceFile(
+        script, text, ts.ScriptTarget.Latest, true, ts.ScriptKind.JS);
+    const writes = new Set();
+    const reads = new Set();
+    const loadTimeReads = new Set();
+    const dynamicAccess = [];
+    const bareReferences = [];
+    const visit = node => {
+        if (ts.isPropertyAccessExpression(node) && ts.isIdentifier(node.expression)
+            && (node.expression.text === 'window' || node.expression.text === 'globalThis')) {
+            const symbol = `window.${node.name.text}`;
+            const parent = node.parent;
+            const isWrite = parent && ts.isBinaryExpression(parent)
+                && parent.operatorToken.kind === ts.SyntaxKind.EqualsToken
+                && parent.left === node;
+            if (isWrite) {
+                writes.add(symbol);
+            } else {
+                reads.add(symbol);
+                let enclosing = node.parent;
+                let deferred = false;
+                while (enclosing) {
+                    if (ts.isFunctionLike(enclosing)) { deferred = true; break; }
+                    enclosing = enclosing.parent;
+                }
+                if (!deferred) { loadTimeReads.add(symbol); }
+            }
+        } else if (ts.isElementAccessExpression(node) && ts.isIdentifier(node.expression)
+            && (node.expression.text === 'window' || node.expression.text === 'globalThis')) {
+            dynamicAccess.push(`${node.expression.text}[...]`);
+        } else if (ts.isIdentifier(node) && declaredBareNames.has(node.text)) {
+            const parent = node.parent;
+            const isPropertyName = parent && ts.isPropertyAccessExpression(parent)
+                && parent.name === node;
+            const isAssignmentKey = parent && ts.isPropertyAssignment(parent)
+                && parent.name === node;
+            if (!isPropertyName && !isAssignmentKey) {
+                bareReferences.push(node.text);
+            }
+        }
+        ts.forEachChild(node, visit);
+    };
+    visit(sourceFile);
+    return {
+        writes, reads, loadTimeReads,
+        dynamicAccess: [...new Set(dynamicAccess)].sort(),
+        bareReferences: [...new Set(bareReferences)].sort(),
+    };
+}
+
+function validateGlobalsSchema(manifest, bundleOf, rootDirectory, errors) {
+    const globals = Array.isArray(manifest.globals) ? manifest.globals : [];
+    if (globals.length === 0) {
+        errors.push('webview-manifest: globals must be a non-empty array');
+        return new Map();
+    }
+    const seen = new Map();
+    for (const entry of globals) {
+        const label = `webview-manifest: global ${entry && entry.symbol ? entry.symbol : '<missing symbol>'}`;
+        if (!entry || typeof entry.symbol !== 'string' || !SYMBOL_PATTERN.test(entry.symbol)) {
+            errors.push(`${label}: symbol must match ${SYMBOL_PATTERN}`);
+            continue;
+        }
+        if (seen.has(entry.symbol)) {
+            errors.push(`${label}: duplicate symbol declaration`);
+            continue;
+        }
+        const producer = entry.producer;
+        const isScriptProducer = typeof producer === 'string'
+            && !PRODUCER_KINDS.includes(producer);
+        if (typeof producer !== 'string'
+            || (!isScriptProducer && !PRODUCER_KINDS.includes(producer))) {
+            errors.push(`${label}: producer must be a script path or one of ${PRODUCER_KINDS.join(', ')}`);
+            continue;
+        }
+        if (isScriptProducer) {
+            if (!bundleOf.has(producer)) {
+                errors.push(`${label}: producer ${producer} is not a bundle member`);
+            } else if (!fs.existsSync(path.join(rootDirectory, producer))) {
+                errors.push(`${label}: producer ${producer} does not exist`);
+            }
+            if (!Array.isArray(entry.consumers)) {
+                errors.push(`${label}: consumers must be an array of bundle member scripts`);
+            } else {
+                for (const consumer of entry.consumers) {
+                    if (!bundleOf.has(consumer)) {
+                        errors.push(`${label}: consumer ${consumer} is not a bundle member`);
+                    } else if (bundleOf.get(consumer) !== bundleOf.get(producer)) {
+                        errors.push(`${label}: consumer ${consumer} is in bundle `
+                            + `'${bundleOf.get(consumer)}' but the producer ${producer} is in `
+                            + `'${bundleOf.get(producer)}' (cross-bundle globals are forbidden)`);
+                    }
+                }
+            }
+        } else if (entry.consumers !== undefined) {
+            errors.push(`${label}: ${producer} symbols must not declare consumers`);
+        }
+        seen.set(entry.symbol, entry);
+    }
+    return seen;
+}
+
 function runWebviewManifestCheck(rootDirectory) {
     const errors = [];
     const manifest = readJson(rootDirectory, MANIFEST_PATH, errors);
     if (!manifest) { return { errors }; }
-    if (manifest.version !== 1) {
-        errors.push('webview-manifest: version must be 1');
+    if (manifest.version !== 2) {
+        errors.push('webview-manifest: version must be 2 (symbol-level globals, review R7)');
     }
     const bundles = Array.isArray(manifest.bundles) ? manifest.bundles : [];
-    const permittedGlobals = new Set(
-        Array.isArray(manifest.permittedGlobals) ? manifest.permittedGlobals : []);
 
     // Membership: exact-once over src/webview/*.js, and every entry exists.
     const membership = new Map();
@@ -80,7 +193,7 @@ function runWebviewManifestCheck(rootDirectory) {
     }
 
     // Load-order fidelity with the builders.
-    const { builderOrder, viewerOrder } = checkBundleOrder(rootDirectory, errors);
+    const { builderOrder, viewerOrder } = checkBundleOrder(rootDirectory);
     for (const bundle of bundles) {
         if (bundle.id === 'dashboard') {
             if (JSON.stringify(bundle.scripts) !== JSON.stringify(builderOrder)) {
@@ -96,22 +209,101 @@ function runWebviewManifestCheck(rootDirectory) {
         }
     }
 
-    // Cross-script globals must be declared; dynamic access fails closed.
+    // Symbol-level globals (review R7).
+    const globalsBySymbol = validateGlobalsSchema(manifest, membership, rootDirectory, errors);
+    const bundleIndex = new Map();
+    for (const bundle of bundles) {
+        (bundle.scripts || []).forEach((script, index) => bundleIndex.set(script, index));
+    }
+    const scriptGlobals = new Map([...globalsBySymbol]
+        .filter(([, entry]) => !PRODUCER_KINDS.includes(entry.producer)));
+    const declaredBareNames = new Set(
+        [...scriptGlobals.keys()].map(symbol => symbol.slice('window.'.length)));
+
+    const referencedSymbols = new Set();
+    const actualReaders = new Map();
+    const actualWriters = new Map();
     for (const script of scriptsOnDisk) {
-        const text = fs.readFileSync(path.join(rootDirectory, script), 'utf8');
-        DYNAMIC_GLOBAL_ACCESS.lastIndex = 0;
-        if (DYNAMIC_GLOBAL_ACCESS.test(text)) {
-            errors.push(`webview-manifest: ${script} uses dynamic window[...] access, `
+        const analysis = analyzeScript(rootDirectory, script, declaredBareNames);
+        for (const form of analysis.dynamicAccess) {
+            errors.push(`webview-manifest: ${script} uses dynamic ${form} access, `
                 + 'which evades the declared-global policy');
         }
-        GLOBAL_REFERENCE.lastIndex = 0;
-        let match;
-        while ((match = GLOBAL_REFERENCE.exec(text))) {
-            const global_ = `window.${match[1]}`;
-            if (!permittedGlobals.has(global_)) {
-                errors.push(`webview-manifest: ${script} references undeclared global `
-                    + `${global_} — declare it in ${MANIFEST_PATH}`);
+        for (const bare of analysis.bareReferences) {
+            errors.push(`webview-manifest: ${script} references the declared global `
+                + `window.${bare} without the window./globalThis. prefix — bare globals evade `
+                + 'the manifest policy');
+        }
+        for (const symbol of [...analysis.writes, ...analysis.reads]) {
+            referencedSymbols.add(symbol);
+        }
+        for (const symbol of analysis.writes) {
+            if (!actualWriters.has(symbol)) { actualWriters.set(symbol, new Set()); }
+            actualWriters.get(symbol).add(script);
+            const entry = globalsBySymbol.get(symbol);
+            if (!entry) {
+                errors.push(`webview-manifest: ${script} assigns undeclared global ${symbol}`
+                    + ` — declare it in ${MANIFEST_PATH}`);
+            } else if (PRODUCER_KINDS.includes(entry.producer)) {
+                errors.push(`webview-manifest: ${script} assigns ${symbol}, which is declared as `
+                    + `${entry.producer}-produced — a script must not spoof it`);
+            } else if (entry.producer !== script) {
+                errors.push(`webview-manifest: ${script} assigns ${symbol}, whose only declared `
+                    + `producer is ${entry.producer}`);
             }
+        }
+        for (const symbol of analysis.reads) {
+            if (!actualReaders.has(symbol)) { actualReaders.set(symbol, new Set()); }
+            actualReaders.get(symbol).add(script);
+            const entry = globalsBySymbol.get(symbol);
+            if (!entry) {
+                errors.push(`webview-manifest: ${script} references undeclared global `
+                    + `${symbol} — declare it in ${MANIFEST_PATH}`);
+                continue;
+            }
+            if (!PRODUCER_KINDS.includes(entry.producer)
+                && entry.producer !== script
+                && !(entry.consumers || []).includes(script)) {
+                errors.push(`webview-manifest: ${script} reads ${symbol} but is neither its `
+                    + 'producer nor a declared consumer');
+            }
+            if (!PRODUCER_KINDS.includes(entry.producer) && entry.producer !== script
+                && analysis.loadTimeReads.has(symbol)) {
+                const producerBundle = membership.get(entry.producer);
+                const consumerBundle = membership.get(script);
+                if (producerBundle && consumerBundle && producerBundle === consumerBundle
+                    && bundleIndex.get(entry.producer) > bundleIndex.get(script)) {
+                    errors.push(`webview-manifest: ${script} reads ${symbol} at load time but `
+                        + `loads before its producer ${entry.producer} in the ${producerBundle} `
+                        + 'bundle — defer the read or fix the load order');
+                }
+            }
+        }
+    }
+    for (const [symbol, entry] of globalsBySymbol) {
+        if (!referencedSymbols.has(symbol)) {
+            errors.push(`webview-manifest: ${symbol} is declared but never referenced — stale entry`);
+            continue;
+        }
+        if (PRODUCER_KINDS.includes(entry.producer)) { continue; }
+        const writers = actualWriters.get(symbol) || new Set();
+        if (!writers.has(entry.producer)) {
+            errors.push(`webview-manifest: ${entry.producer} never assigns ${symbol} `
+                + '— the declared producer must produce it');
+        }
+        const declaredConsumers = new Set(entry.consumers || []);
+        const readers = new Set(actualReaders.get(symbol) || []);
+        readers.delete(entry.producer);
+        const missing = [...readers].filter(script => !declaredConsumers.has(script));
+        const extra = [...declaredConsumers].filter(script => !readers.has(script)
+            && script !== entry.producer);
+        if (missing.length > 0) {
+            errors.push(`webview-manifest: ${symbol} is read by undeclared consumer(s): `
+                + missing.join(', '));
+        }
+        if (extra.length > 0) {
+            errors.push(`webview-manifest: ${symbol} declares consumer(s) that never read it: `
+                + extra.join(', '));
         }
     }
     return { errors };
@@ -126,7 +318,7 @@ function main() {
         return;
     }
     console.log('Webview manifest checks passed: exact-once membership, load-order '
-        + 'fidelity with both builders, and all cross-script globals declared.');
+        + 'fidelity with both builders, and closed-world symbol-level globals.');
 }
 
 if (require.main === module) { main(); }

--- a/scripts/regenerate-capability-audit.js
+++ b/scripts/regenerate-capability-audit.js
@@ -351,6 +351,22 @@ function planCapabilityAudit(repositoryRoot, cli) {
     if (errors.length) {
         throw new AuditRegenerationError(errors);
     }
+    // Rebase residue (review R7 follow-up): a rebase rewrites commit SHAs, so
+    // assignments and documentation exemptions recorded against pre-rebase
+    // SHAs fall outside the audited range and would fail the post-write
+    // validation. Prune them from the regenerated manifest; the rebased
+    // commits arrive through fresh --assign targets.
+    const auditedHashes = new Set(listRange(repositoryRoot, manifest.audit.base, newHead));
+    const staleAssignments = [];
+    for (const capability of manifest.capabilities) {
+        for (const hash of capability.commits) {
+            if (!auditedHashes.has(hash)) {
+                staleAssignments.push({ capabilityId: capability.id, hash });
+            }
+        }
+    }
+    const staleExemptions = (manifest.audit.ignoredDocumentationCommits || [])
+        .filter(hash => !auditedHashes.has(hash));
     // Only documentation commits covered by the new head may be registered:
     // an exemption outside the audited range is itself a validation error.
     // Tail documentation commits beyond the head stay unregistered until a
@@ -367,10 +383,36 @@ function planCapabilityAudit(repositoryRoot, cli) {
         docsToIgnore,
         deferredDocs,
         assignedInRange,
+        staleAssignments,
+        staleExemptions,
         assignments,
         harvestDecision,
         behaviorAdditions: cli.behaviors.map(({ left, right }) => ({ capabilityId: left, behaviorId: right })),
     };
+}
+
+/** Removes one JSON string element from an array, preserving formatting. */
+function removeJsonStringFromArray(text, value) {
+    const needle = JSON.stringify(value);
+    const index = text.indexOf(needle);
+    if (index < 0) {
+        throw new AuditRegenerationError(`could not find ${needle} to prune`);
+    }
+    const afterIndex = index + needle.length;
+    const trailing = /^[ \t]*,\r?\n[ \t]*/.exec(text.slice(afterIndex));
+    if (trailing) {
+        // Not the last element: drop the value, comma, and line break.
+        return text.slice(0, index) + text.slice(afterIndex + trailing[0].length);
+    }
+    const preceding = /,[ \t]*\r?\n[ \t]*$/.exec(text.slice(0, index));
+    if (preceding) {
+        // Last element: drop the preceding comma and line break as well.
+        return text.slice(0, index - preceding[0].length) + text.slice(afterIndex);
+    }
+    // Only element: collapse to an empty array.
+    const openIndex = text.lastIndexOf('[', index);
+    const closeIndex = findMatchingBracket(text, openIndex);
+    return text.slice(0, openIndex + 1) + text.slice(closeIndex);
 }
 
 /** Applies the planned edits text-surgically, preserving manifest formatting. */
@@ -382,6 +424,12 @@ function applyCapabilityAuditPlan(originalText, plan) {
     );
     if (!text.includes(`"head": "${plan.newHead}"`)) {
         throw new AuditRegenerationError('could not replace audit.head in the coverage manifest');
+    }
+    for (const { hash } of plan.staleAssignments || []) {
+        text = removeJsonStringFromArray(text, hash);
+    }
+    for (const hash of plan.staleExemptions || []) {
+        text = removeJsonStringFromArray(text, hash);
     }
     for (const commit of plan.docsToIgnore) {
         const openIndex = arrayOpenIndex(text, '"ignoredDocumentationCommits"', 0, 'audit.ignoredDocumentationCommits');
@@ -440,6 +488,12 @@ function summarizePlan(plan, output) {
     output(`audit.head: ${plan.manifest.audit.head} -> ${plan.newHead}`);
     for (const hash of plan.assignedInRange) {
         output(`assign ${hash} -> ${plan.assignments.get(hash).capabilityId}`);
+    }
+    for (const { capabilityId, hash } of plan.staleAssignments || []) {
+        output(`prune stale assignment ${hash} from ${capabilityId} (rewritten by rebase)`);
+    }
+    for (const hash of plan.staleExemptions || []) {
+        output(`prune stale documentation exemption ${hash} (rewritten by rebase)`);
     }
     for (const commit of plan.docsToIgnore) {
         output(`ignore documentation commit ${commit.hash}: ${commit.subject}`);

--- a/tests/unit/architecture/dependencyGraph.test.js
+++ b/tests/unit/architecture/dependencyGraph.test.js
@@ -1,0 +1,128 @@
+'use strict';
+
+// ARCH-DEPENDENCY-GRAPH-001: the dependency graph must classify edge kinds
+// from the AST (review R7): runtime `await import('./x')` is a value edge
+// (the cycle ratchet sees it), only type-position `import('./x').T` stays a
+// type edge, and unrecognized import/require forms fail closed.
+
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const test = require('node:test');
+
+const { buildDependencyGraph } = require('../../../scripts/architecture/buildDependencyGraph');
+
+function makeFixture(files) {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'arch-graph-'));
+    for (const [relative, content] of Object.entries(files)) {
+        fs.mkdirSync(path.join(root, path.dirname(relative)), { recursive: true });
+        fs.writeFileSync(path.join(root, relative), content);
+    }
+    fs.mkdirSync(path.join(root, 'docs/testing'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'docs/testing/architecture-modules.json'), JSON.stringify({
+        version: 1, scope: { roots: ['src'] },
+        modules: ['MOD-ALPHA', 'MOD-BETA'].map(id => ({
+            id, title: id, purpose: 'fixture',
+            source: { include: [`src/${id === 'MOD-ALPHA' ? 'alpha' : 'beta'}/**`], exclude: [] },
+            publicEntrypoints: [`src/${id === 'MOD-ALPHA' ? 'alpha' : 'beta'}/**`],
+            mayDependOn: [],
+            roles: [{ role: 'application', include: [`src/${id === 'MOD-ALPHA' ? 'alpha' : 'beta'}/**`] }],
+            productCapabilities: ['MAIN-TEST-001'],
+        })),
+    }));
+    fs.writeFileSync(path.join(root, 'docs/testing/main-capability-coverage.json'),
+        JSON.stringify({ version: 1, capabilities: [{ id: 'MAIN-TEST-001' }] }));
+    return root;
+}
+
+function edgeKinds(root) {
+    const { edges, errors } = buildDependencyGraph(root);
+    return { edges, errors };
+}
+
+test('ARCH-DEPENDENCY-GRAPH-001 runtime dynamic import is a value edge; type-position stays type', () => {
+    const root = makeFixture({
+        'src/alpha/a.ts': [
+            "export async function load() { return import('../beta/b'); }",
+            "export type B = import('../beta/b').B;",
+        ].join('\n'),
+        'src/beta/b.ts': 'export interface B { x: number }\n',
+    });
+    const { edges, errors } = edgeKinds(root);
+    assert.deepEqual(errors, []);
+    const byKind = edges.map(edge => edge.kind).sort();
+    assert.deepEqual(byKind, ['type', 'value'],
+        'one value edge (runtime import) and one type edge (import type)');
+});
+
+test('ARCH-DEPENDENCY-GRAPH-001 static forms keep their kinds', () => {
+    const root = makeFixture({
+        'src/alpha/a.ts': [
+            "import { b } from '../beta/b';",
+            "import type { B } from '../beta/b2';",
+            "import '../beta/sideEffect';",
+            "export * from '../beta/reExport';",
+            "export type { C } from '../beta/b3';",
+            "const legacy = require('../beta/legacy');",
+            'void legacy; void b;',
+        ].join('\n'),
+        'src/beta/b.ts': 'export const b = 1;\n',
+        'src/beta/b2.ts': 'export interface B { x: number }\n',
+        'src/beta/b3.ts': 'export interface C { y: number }\n',
+        'src/beta/sideEffect.ts': 'export {};\n',
+        'src/beta/reExport.ts': 'export {};\n',
+        'src/beta/legacy.ts': 'export {};\n',
+    });
+    const { edges, errors } = edgeKinds(root);
+    assert.deepEqual(errors, []);
+    assert.equal(edges.filter(edge => edge.kind === 'value').length, 4,
+        'import, side-effect import, export-from, and require are value edges');
+    assert.equal(edges.filter(edge => edge.kind === 'type').length, 2,
+        'import type and export type are type edges');
+});
+
+test('ARCH-DEPENDENCY-GRAPH-001 controlled mutation: a dynamic-import runtime cycle is detected as value debt', () => {
+    const root = makeFixture({
+        'src/alpha/a.ts': "export async function load() { return import('../beta/b'); }\n",
+        'src/beta/b.ts': "import { load } from '../alpha/a';\nexport function use() { return load; }\n",
+    });
+    const { edges, errors } = edgeKinds(root);
+    assert.deepEqual(errors, []);
+    const valuePairs = new Set(edges.filter(edge => edge.kind === 'value')
+        .map(edge => `${edge.sourceModule}->${edge.targetModule}`));
+    assert.ok(valuePairs.has('MOD-ALPHA->MOD-BETA'));
+    assert.ok(valuePairs.has('MOD-BETA->MOD-ALPHA'),
+        'the dynamic import participates in the value graph (2-cycle visible)');
+});
+
+test('ARCH-DEPENDENCY-GRAPH-001 controlled mutation: non-literal dynamic import and require fail closed', () => {
+    const root = makeFixture({
+        'src/alpha/a.ts': [
+            'declare const name: string;',
+            'export async function load() { return import(name); }',
+            "const legacy = require(`../beta/${'b'}`);",
+            'void legacy;',
+        ].join('\n'),
+        'src/beta/b.ts': 'export {};\n',
+    });
+    const { errors } = edgeKinds(root);
+    assert.ok(errors.some(error => error.includes('non-literal specifier')), JSON.stringify(errors));
+    assert.ok(errors.filter(error => error.includes('non-literal specifier')).length === 2,
+        'both the dynamic import and the template require fail closed');
+});
+
+test('ARCH-DEPENDENCY-GRAPH-001 package specifiers never become edges', () => {
+    const root = makeFixture({
+        'src/alpha/a.ts': [
+            "import fs from 'fs';",
+            "import { workspace } from 'vscode';",
+            "export async function load() { return import('fs'); }",
+            'void fs; void workspace;',
+        ].join('\n'),
+        'src/beta/b.ts': 'export {};\n',
+    });
+    const { edges, errors } = edgeKinds(root);
+    assert.deepEqual(errors, []);
+    assert.deepEqual(edges, []);
+});

--- a/tests/unit/architecture/singleWriters.test.js
+++ b/tests/unit/architecture/singleWriters.test.js
@@ -156,3 +156,122 @@ test('ARCH-INVARIANT-CATALOG-001 controlled mutation: a missing authority path i
     assert.ok(runSingleWriterCheck(root).errors
         .some(error => error.includes("authority.path") && error.includes('does not exist')));
 });
+
+
+// ── review R7: AST-hardened writer detection ─────────────────────────
+
+function familyWithKeys(keys) {
+    return validInvariant({
+        stateFamily: {
+            storePath: 'src/store.ts',
+            writeMethods: ['writeThing'],
+            persistenceKeys: keys,
+        },
+    });
+}
+
+test('ARCH-SINGLE-WRITER-001 controlled mutation: element access cannot launder a write', () => {
+    const root = makeFixture({
+        invariants: [validInvariant()],
+        sources: {
+            ...baseSources,
+            'src/bypass.ts': 'import { Store } from \'./store\';\n'
+                + 'export const evil = (s: Store) => s[\'writeThing\']();\n',
+        },
+    });
+    assert.ok(runSingleWriterCheck(root).errors
+        .some(error => error.includes('src/bypass.ts') && error.includes('element access')));
+});
+
+test('ARCH-SINGLE-WRITER-001 controlled mutation: destructuring cannot launder a write', () => {
+    const root = makeFixture({
+        invariants: [validInvariant()],
+        sources: {
+            ...baseSources,
+            'src/bypass.ts': 'import { Store } from \'./store\';\n'
+                + 'export const evil = (s: Store) => { const { writeThing } = s; writeThing(); };\n',
+        },
+    });
+    assert.ok(runSingleWriterCheck(root).errors
+        .some(error => error.includes('src/bypass.ts') && error.includes('destructures')));
+});
+
+test('ARCH-SINGLE-WRITER-001 controlled mutation: aliased destructuring cannot launder a write', () => {
+    const root = makeFixture({
+        invariants: [validInvariant()],
+        sources: {
+            ...baseSources,
+            'src/bypass.ts': 'import { Store } from \'./store\';\n'
+                + 'export const evil = (s: Store) => { const { writeThing: wt } = s; wt(); };\n',
+        },
+    });
+    assert.ok(runSingleWriterCheck(root).errors
+        .some(error => error.includes('src/bypass.ts') && error.includes('destructures')));
+});
+
+test('ARCH-SINGLE-WRITER-001 controlled mutation: bind extraction cannot launder a write', () => {
+    const root = makeFixture({
+        invariants: [validInvariant()],
+        sources: {
+            ...baseSources,
+            'src/bypass.ts': 'import { Store } from \'./store\';\n'
+                + 'export const evil = (s: Store) => { const write = s.writeThing.bind(s); write(); };\n',
+        },
+    });
+    assert.ok(runSingleWriterCheck(root).errors
+        .some(error => error.includes('src/bypass.ts') && error.includes('writeThing')));
+});
+
+test('ARCH-SINGLE-WRITER-001 controlled mutation: an import alias cannot launder a write', () => {
+    const root = makeFixture({
+        invariants: [validInvariant()],
+        sources: {
+            ...baseSources,
+            'src/bypass.ts': 'import { Store as Manifest } from \'./store\';\n'
+                + 'export const evil = (s: Manifest) => s.writeThing();\n',
+        },
+    });
+    assert.ok(runSingleWriterCheck(root).errors
+        .some(error => error.includes('src/bypass.ts') && error.includes('writeThing')));
+});
+
+test('ARCH-SINGLE-WRITER-001 controlled mutation: a persistence-key reference outside the store fails', () => {
+    const root = makeFixture({
+        invariants: [familyWithKeys(['agentPivot.fixture.v1'])],
+        sources: {
+            'src/store.ts': 'const KEY = \'agentPivot.fixture.v1\';\nexport class Store { writeThing() {} }\n',
+            'src/writer.ts': 'import { Store } from \'./store\';\nexport const run = (s: Store) => s.writeThing();\n',
+            'src/quiet.ts': 'export const nothing = 1;\n',
+            'src/bypass.ts': 'export const rawKey = \'agentPivot.fixture.v1\';\n',
+        },
+    });
+    assert.ok(runSingleWriterCheck(root).errors
+        .some(error => error.includes('src/bypass.ts') && error.includes('persistence key')));
+});
+
+test('ARCH-SINGLE-WRITER-001 a persistence key referenced only inside the store passes', () => {
+    const root = makeFixture({
+        invariants: [familyWithKeys(['agentPivot.fixture.v1'])],
+        sources: {
+            'src/store.ts': 'const KEY = \'agentPivot.fixture.v1\';\nexport class Store { writeThing() {} }\n',
+            'src/writer.ts': 'import { Store } from \'./store\';\nexport const run = (s: Store) => s.writeThing();\n',
+            'src/quiet.ts': 'export const nothing = 1;\n',
+        },
+    });
+    assert.deepEqual(runSingleWriterCheck(root).errors, []);
+});
+
+test('ARCH-INVARIANT-CATALOG-001 controlled mutation: malformed persistenceKeys are rejected', () => {
+    const empty = makeFixture({
+        invariants: [familyWithKeys([])],
+        sources: baseSources,
+    });
+    assert.ok(runSingleWriterCheck(empty).errors
+        .some(error => error.includes('persistenceKeys must be a non-empty array')));
+    const stale = makeFixture({
+        invariants: [familyWithKeys(['agentPivot.absent.v1'])],
+        sources: baseSources,
+    });
+    assert.ok(runSingleWriterCheck(stale).errors
+        .some(error => error.includes('persistence key') && error.includes('does not appear')));
+});

--- a/tests/unit/architecture/webviewManifest.test.js
+++ b/tests/unit/architecture/webviewManifest.test.js
@@ -16,17 +16,29 @@ const repoRoot = path.resolve(__dirname, '..', '..', '..');
  * Synthetic webview fixture: two dashboard scripts and one conversation
  * script, with the builders mirroring the manifest order.
  */
-function makeFixture({ manifestBundles, scripts = {}, builderOrder, viewerOrder }) {
+function makeFixture({ manifestBundles, scripts = {}, globals, builderOrder, viewerOrder, version = 2 }) {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'arch-webview-'));
     const write = (relative, content) => {
         fs.mkdirSync(path.join(root, path.dirname(relative)), { recursive: true });
         fs.writeFileSync(path.join(root, relative), content);
     };
-    write('docs/testing/architecture-webview-manifest.json', JSON.stringify({
-        version: 1,
+    const manifest = {
+        version,
         bundles: manifestBundles,
-        permittedGlobals: ['window.__agentPivotAlpha', 'window.vscode'],
-    }));
+        globals: globals || [
+            {
+                symbol: 'window.__agentPivotAlpha',
+                producer: 'src/webview/aScripts.js',
+                consumers: ['src/webview/bScripts.js'],
+            },
+            { symbol: 'window.vscode', producer: 'host' },
+        ],
+    };
+    if (version === 1) {
+        delete manifest.globals;
+        manifest.permittedGlobals = ['window.__agentPivotAlpha'];
+    }
+    write('docs/testing/architecture-webview-manifest.json', JSON.stringify(manifest));
     const builder = (builderOrder || ['src/webview/aScripts.js', 'src/webview/bScripts.js'])
         .map(file => `    '${file}',`).join('\n');
     write('scripts/build-dashboard-webview-bundle.js', `const inputPaths = [\n${builder}\n];\n`);
@@ -45,7 +57,8 @@ const baseBundles = [
 ];
 const baseScripts = {
     'src/webview/aScripts.js': 'window.__agentPivotAlpha = {};\n',
-    'src/webview/bScripts.js': 'window.vscode.postMessage({});\n',
+    'src/webview/bScripts.js':
+        'function read() { return window.__agentPivotAlpha.x + window.vscode; }\nread();\n',
     'src/webview/conversationCScripts.js': '// viewer\n',
 };
 
@@ -88,31 +101,6 @@ test('ARCH-WEBVIEW-MANIFEST-001 controlled mutation: load-order drift from the b
         .some(error => error.includes('dashboard bundle order differs')));
 });
 
-test('ARCH-WEBVIEW-MANIFEST-001 controlled mutation: an undeclared global reference fails', () => {
-    const root = makeFixture({
-        manifestBundles: baseBundles,
-        scripts: {
-            ...baseScripts,
-            'src/webview/aScripts.js': 'window.__agentPivotUndeclared = {};\n',
-        },
-    });
-    assert.ok(runWebviewManifestCheck(root).errors
-        .some(error => error.includes('window.__agentPivotUndeclared')
-            && error.includes('undeclared global')));
-});
-
-test('ARCH-WEBVIEW-MANIFEST-001 controlled mutation: dynamic window access fails closed', () => {
-    const root = makeFixture({
-        manifestBundles: baseBundles,
-        scripts: {
-            ...baseScripts,
-            'src/webview/aScripts.js': 'const x = window[\'__agentPivot\' + name];\n',
-        },
-    });
-    assert.ok(runWebviewManifestCheck(root).errors
-        .some(error => error.includes('dynamic window[...] access')));
-});
-
 test('ARCH-WEBVIEW-MANIFEST-001 controlled mutation: a manifest entry for a missing file fails', () => {
     const bundles = [
         { id: 'dashboard', scripts: ['src/webview/aScripts.js', 'src/webview/bScripts.js', 'src/webview/goneScripts.js'] },
@@ -121,4 +109,227 @@ test('ARCH-WEBVIEW-MANIFEST-001 controlled mutation: a manifest entry for a miss
     const root = makeFixture({ manifestBundles: bundles, scripts: baseScripts });
     assert.ok(runWebviewManifestCheck(root).errors
         .some(error => error.includes('goneScripts.js') && error.includes('does not exist')));
+});
+
+// ── review R7: symbol-level closed world ─────────────────────────────
+
+test('ARCH-WEBVIEW-MANIFEST-001 controlled mutation: an undeclared custom global fails (write and read)', () => {
+    const written = makeFixture({
+        manifestBundles: baseBundles,
+        scripts: {
+            ...baseScripts,
+            'src/webview/aScripts.js': 'window.__agentPivotAlpha = {};\nwindow.sharedArchitectureState = {};\n',
+        },
+    });
+    assert.ok(runWebviewManifestCheck(written).errors
+        .some(error => error.includes('window.sharedArchitectureState')
+            && error.includes('assigns undeclared global')));
+    const read = makeFixture({
+        manifestBundles: baseBundles,
+        scripts: {
+            ...baseScripts,
+            'src/webview/bScripts.js': 'function r() { return window.sneakyGlobal; }\nr();\n',
+        },
+    });
+    assert.ok(runWebviewManifestCheck(read).errors
+        .some(error => error.includes('window.sneakyGlobal') && error.includes('undeclared global')));
+});
+
+test('ARCH-WEBVIEW-MANIFEST-001 controlled mutation: dynamic window/globalThis access fails closed', () => {
+    const dynamicWindow = makeFixture({
+        manifestBundles: baseBundles,
+        scripts: {
+            ...baseScripts,
+            'src/webview/aScripts.js': 'const x = window[\'__agentPivot\' + name];\n',
+        },
+    });
+    assert.ok(runWebviewManifestCheck(dynamicWindow).errors
+        .some(error => error.includes('dynamic window[...] access')));
+    const dynamicGlobalThis = makeFixture({
+        manifestBundles: baseBundles,
+        scripts: {
+            ...baseScripts,
+            'src/webview/aScripts.js': 'const x = globalThis[\'__agentPivot\' + name];\n',
+        },
+    });
+    assert.ok(runWebviewManifestCheck(dynamicGlobalThis).errors
+        .some(error => error.includes('dynamic globalThis[...] access')));
+});
+
+test('ARCH-WEBVIEW-MANIFEST-001 controlled mutation: an undeclared consumer fails', () => {
+    const root = makeFixture({
+        manifestBundles: baseBundles,
+        scripts: baseScripts,
+        globals: [
+            { symbol: 'window.__agentPivotAlpha', producer: 'src/webview/aScripts.js', consumers: [] },
+            { symbol: 'window.vscode', producer: 'host' },
+        ],
+    });
+    assert.ok(runWebviewManifestCheck(root).errors
+        .some(error => error.includes('window.__agentPivotAlpha')
+            && error.includes('undeclared consumer')));
+});
+
+test('ARCH-WEBVIEW-MANIFEST-001 controlled mutation: a declared consumer that never reads fails', () => {
+    const root = makeFixture({
+        manifestBundles: baseBundles,
+        scripts: {
+            ...baseScripts,
+            'src/webview/bScripts.js': 'function r() { return window.vscode; }\nr();\n',
+        },
+    });
+    assert.ok(runWebviewManifestCheck(root).errors
+        .some(error => error.includes('window.__agentPivotAlpha')
+            && error.includes('never read it')));
+});
+
+test('ARCH-WEBVIEW-MANIFEST-001 controlled mutation: a producer that never assigns fails', () => {
+    const root = makeFixture({
+        manifestBundles: baseBundles,
+        scripts: {
+            ...baseScripts,
+            'src/webview/aScripts.js': '// nothing assigned\n',
+        },
+    });
+    assert.ok(runWebviewManifestCheck(root).errors
+        .some(error => error.includes('never assigns window.__agentPivotAlpha')));
+});
+
+test('ARCH-WEBVIEW-MANIFEST-001 controlled mutation: a write by a non-producer fails', () => {
+    const root = makeFixture({
+        manifestBundles: baseBundles,
+        scripts: {
+            ...baseScripts,
+            'src/webview/bScripts.js':
+                'window.__agentPivotAlpha = {};\nfunction r() { return window.vscode; }\nr();\n',
+        },
+    });
+    assert.ok(runWebviewManifestCheck(root).errors
+        .some(error => error.includes('bScripts.js') && error.includes('only declared producer')));
+});
+
+test('ARCH-WEBVIEW-MANIFEST-001 controlled mutation: spoofing a host symbol fails', () => {
+    const root = makeFixture({
+        manifestBundles: baseBundles,
+        scripts: {
+            ...baseScripts,
+            'src/webview/aScripts.js': 'window.__agentPivotAlpha = {};\nwindow.vscode = {};\n',
+        },
+    });
+    assert.ok(runWebviewManifestCheck(root).errors
+        .some(error => error.includes('window.vscode') && error.includes('must not spoof')));
+});
+
+test('ARCH-WEBVIEW-MANIFEST-001 controlled mutation: a bare global reference fails', () => {
+    const root = makeFixture({
+        manifestBundles: baseBundles,
+        scripts: {
+            ...baseScripts,
+            'src/webview/bScripts.js': 'function r() { return __agentPivotAlpha.x; }\nr();\n',
+        },
+    });
+    assert.ok(runWebviewManifestCheck(root).errors
+        .some(error => error.includes('window.__agentPivotAlpha')
+            && error.includes('without the window./globalThis. prefix')));
+});
+
+test('ARCH-WEBVIEW-MANIFEST-001 controlled mutation: a load-time read before the producer fails', () => {
+    const bundles = [
+        { id: 'dashboard', scripts: ['src/webview/bScripts.js', 'src/webview/aScripts.js'] },
+        { id: 'conversation-viewer', scripts: ['src/webview/conversationCScripts.js'] },
+    ];
+    const root = makeFixture({
+        manifestBundles: bundles,
+        builderOrder: ['src/webview/bScripts.js', 'src/webview/aScripts.js'],
+        scripts: {
+            ...baseScripts,
+            // Top-level (load-time) read in the consumer that loads first.
+            'src/webview/bScripts.js': 'const boot = window.__agentPivotAlpha.x;\n',
+        },
+    });
+    assert.ok(runWebviewManifestCheck(root).errors
+        .some(error => error.includes('window.__agentPivotAlpha')
+            && error.includes('loads before its producer')));
+});
+
+test('ARCH-WEBVIEW-MANIFEST-001 controlled mutation: a cross-bundle consumer fails', () => {
+    const root = makeFixture({
+        manifestBundles: baseBundles,
+        scripts: baseScripts,
+        globals: [
+            {
+                symbol: 'window.__agentPivotAlpha',
+                producer: 'src/webview/aScripts.js',
+                consumers: ['src/webview/bScripts.js', 'src/webview/conversationCScripts.js'],
+            },
+            { symbol: 'window.vscode', producer: 'host' },
+        ],
+    });
+    assert.ok(runWebviewManifestCheck(root).errors
+        .some(error => error.includes('conversationCScripts.js')
+            && error.includes('cross-bundle globals are forbidden')));
+});
+
+test('ARCH-WEBVIEW-MANIFEST-001 controlled mutation: a stale declaration fails', () => {
+    const root = makeFixture({
+        manifestBundles: baseBundles,
+        scripts: baseScripts,
+        globals: [
+            {
+                symbol: 'window.__agentPivotAlpha',
+                producer: 'src/webview/aScripts.js',
+                consumers: ['src/webview/bScripts.js'],
+            },
+            { symbol: 'window.vscode', producer: 'host' },
+            { symbol: 'window.__agentPivotGhost', producer: 'src/webview/aScripts.js', consumers: [] },
+        ],
+    });
+    assert.ok(runWebviewManifestCheck(root).errors
+        .some(error => error.includes('window.__agentPivotGhost') && error.includes('stale')));
+});
+
+test('ARCH-WEBVIEW-MANIFEST-001 controlled mutation: schema violations fail', () => {
+    const duplicated = makeFixture({
+        manifestBundles: baseBundles,
+        scripts: baseScripts,
+        globals: [
+            {
+                symbol: 'window.__agentPivotAlpha',
+                producer: 'src/webview/aScripts.js',
+                consumers: ['src/webview/bScripts.js'],
+            },
+            {
+                symbol: 'window.__agentPivotAlpha',
+                producer: 'src/webview/aScripts.js',
+                consumers: ['src/webview/bScripts.js'],
+            },
+            { symbol: 'window.vscode', producer: 'host' },
+        ],
+    });
+    assert.ok(runWebviewManifestCheck(duplicated).errors
+        .some(error => error.includes('duplicate symbol declaration')));
+    const hostWithConsumers = makeFixture({
+        manifestBundles: baseBundles,
+        scripts: baseScripts,
+        globals: [
+            {
+                symbol: 'window.__agentPivotAlpha',
+                producer: 'src/webview/aScripts.js',
+                consumers: ['src/webview/bScripts.js'],
+            },
+            { symbol: 'window.vscode', producer: 'host', consumers: ['src/webview/bScripts.js'] },
+        ],
+    });
+    assert.ok(runWebviewManifestCheck(hostWithConsumers).errors
+        .some(error => error.includes('window.vscode') && error.includes('must not declare consumers')));
+});
+
+test('ARCH-WEBVIEW-MANIFEST-001 controlled mutation: a v1 flat manifest is rejected', () => {
+    const root = makeFixture({
+        manifestBundles: baseBundles,
+        scripts: baseScripts,
+        version: 1,
+    });
+    assert.ok(runWebviewManifestCheck(root).errors
+        .some(error => error.includes('version must be 2')));
 });

--- a/tests/unit/tooling/regenerateCapabilityAudit.test.js
+++ b/tests/unit/tooling/regenerateCapabilityAudit.test.js
@@ -373,3 +373,35 @@ test('ARCH-MAIN-CAPABILITY-CURRENCY-001 parseArguments reads the CLI surface', (
     assert.throws(() => parseArguments(['--bogus']), AuditRegenerationError);
     assert.throws(() => parseArguments(['--harvest']), AuditRegenerationError);
 });
+
+
+test('ARCH-MAIN-CAPABILITY-CURRENCY-001 prunes rebase-rewritten assignments and exemptions', t => {
+    const fixture = createRepository(t);
+    const implementation = fixture.implement('feat: second implementation', 3);
+    // Simulate the post-rebase state: the manifest still lists SHAs that a
+    // rebase rewrote away (they no longer exist in the audited range).
+    const staleAssignment = '9'.repeat(40);
+    const staleExemption = '8'.repeat(40);
+    fixture.write(COVERAGE_PATH, fixture.readCoverage()
+        .replace(
+            `                "${fixture.firstImplementation}"\n            ],`,
+            `                "${fixture.firstImplementation}",\n                "${staleAssignment}"\n            ],`)
+        .replace(
+            '"ignoredDocumentationCommits": []',
+            `"ignoredDocumentationCommits": [\n            "${staleExemption}"\n        ]`));
+
+    const output = [];
+    regenerateCapabilityAudit(fixture.repositoryRoot, cli({
+        assignments: [{ left: implementation, right: 'MAIN-DEMO-CAPABILITY' }],
+    }), line => output.push(line));
+
+    assert.ok(output.some(line => line.includes(`prune stale assignment ${staleAssignment}`)),
+        JSON.stringify(output));
+    assert.ok(output.some(line => line.includes(`prune stale documentation exemption ${staleExemption}`)),
+        JSON.stringify(output));
+    assert.ok(output.some(line => line.includes('validation passed')), JSON.stringify(output));
+    const edited = JSON.parse(fixture.readCoverage());
+    const capability = edited.capabilities.find(entry => entry.id === 'MAIN-DEMO-CAPABILITY');
+    assert.deepEqual(capability.commits, [fixture.firstImplementation, implementation]);
+    assert.deepEqual(edited.audit.ignoredDocumentationCommits, [fixture.seedAuditCommit]);
+});


### PR DESCRIPTION
## Summary

Fixes W1 review Important 2 + 5 + 8 — three guards upgraded from weak text matching to AST enforcement:

- **Important 5 (dependency graph)**: edge extraction now walks the TypeScript AST. Runtime `await import('./x')` is a **value** edge (the cycle ratchet sees it — previously every dynamic import was misclassified as `type`, letting runtime cycles slip past); only type-position `import('./x').T` stays a type edge. Non-literal dynamic `import()`/`require()` specifiers fail closed.
- **Important 2 (single-writer guard)**: the write-method scan is now an AST walk — `store['updateMember'](...)`, `const { updateMember } = store`, aliased destructuring, `.bind` extraction, and import aliases can no longer launder a write past the guard. `stateFamily` gains `persistenceKeys`: a memento-key literal outside the store file is a raw write bypass and fails; stale declared keys fail.
- **Important 8 (webview globals)**: the manifest is now v2, per-symbol: 47 symbols over 37 scripts (28 script-produced with exactly one producer + exact consumer sets + same-bundle confinement + load-time reads must follow the producer; 4 host / 2 vendor / 13 builtin). Undeclared references or writes (the review's `window.sharedArchitectureState` example), dynamic `window[...]`/`globalThis[...]` access, bare unprefixed references, spoofed host symbols, stale entries, and phantom consumers all fail closed. The analysis also surfaced one genuinely undeclared legacy global (`window.__stewardStickyHeaderObserver`) — now declared as-is.
- **Bonus tooling fix**: the capability-audit regenerator now prunes rebase-rewritten assignments/exemptions instead of failing validation on them (hit live during this PR's own rebase).

## Change impact declaration

```change-impact-declaration
{
  "headSha": "e9a82b9cb18f3c076e7f605ec4b18b71cf190f32",
  "capabilities": [
    "MAIN-ARCHITECTURE-HARNESS"
  ],
  "modules": [],
  "invariants": [
    "ARCH-WORKTREE-MANIFEST-STRUCTURE-001",
    "ARCH-WORKTREE-MEMBER-WRITER-001",
    "ARCH-WORKTREE-TOMBSTONE-FIRST-001"
  ],
  "policyDelta": "tightening",
  "baselineWaiverDelta": "zero",
  "newFiles": []
}
```

## Skill harvest

none — no skill change justified; the verification-masking lesson from R5 and the rebase playbook for capability audits are already recorded in the existing skills.

## Verification

- `npm run test-compile` ✅
- `node --test 'tests/unit/architecture/**/*.test.js'` — 99+ ✅ (5 dependency-graph + 8 single-writer + 14 webview-manifest mutation tests, every claimed evasion form killed)
- `node --test tests/unit/tooling/regenerateCapabilityAudit.test.js` — 10/10 ✅ (new rebase-prune test)
- `npm run test:architecture-policy` ✅ / `npm run test:architecture-guards` ✅ / `npm run test:behavior-contracts` ✅
- `npm run test:coverage:ci` ✅ — changed-line 94.90% (428/451), real exit code verified
- Gate self-classification: tightening ✅ (no record required)
- `git diff --check` ✅
