### PR TITLE
refactor(worktrees): land src/worktrees/index.ts as the only public entrypoint (review R8)

### DIFF
--- a/docs/testing/architecture-modules.json
+++ b/docs/testing/architecture-modules.json
@@ -1,914 +1,920 @@
 {
-    "version": 1,
-    "title": "Architecture module registry (Harness v0, coarse phase)",
-    "notes": [
-        "Approved at the Stage 1A checkpoint; normalized in Stage 2 from docs/architecture/drafts/architecture-modules.draft.json.",
-        "Coarse phase: module boundaries are directory-aligned and publicEntrypoints declare the whole module surface; PR 2-2 introduces edge evaluation.",
-        "Scope roots cover production TypeScript/JavaScript only. media/ is generated output, spikes/ is non-production, scripts/ and tests/ are harness code governed by the reviewability rule.",
-        "Roles form an exact partition: specific role globs must be disjoint; a role with include [\"**\"] is the remainder role (last position only) and catches the module's unclaimed files. Overlap between non-remainder roles fails CI."
+  "version": 1,
+  "title": "Architecture module registry (Harness v0, coarse phase)",
+  "notes": [
+    "Approved at the Stage 1A checkpoint; normalized in Stage 2 from docs/architecture/drafts/architecture-modules.draft.json.",
+    "Coarse phase: module boundaries are directory-aligned and publicEntrypoints declare the whole module surface; PR 2-2 introduces edge evaluation.",
+    "Scope roots cover production TypeScript/JavaScript only. media/ is generated output, spikes/ is non-production, scripts/ and tests/ are harness code governed by the reviewability rule.",
+    "Roles form an exact partition: specific role globs must be disjoint; a role with include [\"**\"] is the remainder role (last position only) and catches the module's unclaimed files. Overlap between non-remainder roles fails CI."
+  ],
+  "scope": {
+    "roots": [
+      "src",
+      "extensions/attention-ui-bridge/src",
+      "shared/attention-bridge"
     ],
-    "scope": {
-        "roots": [
-            "src",
-            "extensions/attention-ui-bridge/src",
-            "shared/attention-bridge"
-        ],
-        "exclusions": [
-            "media/ (generated: byte-mirrored webview scripts, bundle, vendor)",
-            "spikes/ (non-production experiments)",
-            "scripts/ (harness/tooling)",
-            "tests/ (test code)",
-            "out/, dist/ (build output)"
-        ]
-    },
-    "modules": [
-        {
-            "id": "MOD-DASHBOARD-SHELL",
-            "title": "Dashboard shell",
-            "purpose": "Sidebar webview host, message routing, startup/lifecycle, webview presentation assets, and the root composition (dashboard.ts) plus the shared type/constant kernel.",
-            "source": {
-                "include": [
-                    "src/dashboard.ts",
-                    "src/sponsor.ts",
-                    "src/dashboard/**",
-                    "src/webview/**"
-                ],
-                "exclude": []
-            },
-            "publicEntrypoints": [
-                "src/dashboard.ts",
-                "src/sponsor.ts",
-                "src/dashboard/**",
-                "src/webview/**"
-            ],
-            "mayDependOn": [
-                "MOD-AI-SESSION-ATTENTION",
-                "MOD-AI-SESSION-CONTROL",
-                "MOD-AI-SESSION-CONVERSATION",
-                "MOD-AI-SESSION-NOTIFY",
-                "MOD-AI-SESSION-PROVIDER",
-                "MOD-AI-SESSION-RUNTIME",
-                "MOD-OPEN-WORKSPACE",
-                "MOD-PROJECT-CATALOG",
-                "MOD-PROMPT-LIBRARY",
-                "MOD-SHARED-KERNEL",
-                "MOD-SKILL-MANAGEMENT",
-                "MOD-TODO",
-                "MOD-WORKSPACE-IDENTITY",
-                "MOD-WORKTREE-LIFECYCLE"
-            ],
-            "roles": [
-                {
-                    "role": "composition",
-                    "include": [
-                        "src/dashboard.ts"
-                    ]
-                },
-                {
-                    "role": "presentation",
-                    "include": [
-                        "src/webview/**"
-                    ]
-                },
-                {
-                    "role": "application",
-                    "include": [
-                        "**"
-                    ]
-                }
-            ],
-            "productCapabilities": [
-                "MAIN-WORKSPACE-WEBVIEW",
-                "MAIN-DASHBOARD-WEBVIEW-RECOVERY",
-                "MAIN-WORKSPACE-SEARCH",
-                "MAIN-WORKSPACE-NAVIGATION",
-                "MAIN-SPONSOR-ENTRY"
-            ]
-        },
-        {
-            "id": "MOD-AI-SESSION-CONVERSATION",
-            "title": "AI session conversation",
-            "purpose": "Conversation provider adapters, read coordinator, viewer, and viewer protocol. Active feature area: no restructuring while it is being built.",
-            "source": {
-                "include": [
-                    "src/aiSessions/conversation/**"
-                ],
-                "exclude": []
-            },
-            "publicEntrypoints": [
-                "src/aiSessions/conversation/**"
-            ],
-            "mayDependOn": [
-                "MOD-AI-SESSION-PROVIDER",
-                "MOD-AI-SESSION-RUNTIME",
-                "MOD-DASHBOARD-SHELL",
-                "MOD-SHARED-KERNEL",
-                "MOD-WORKTREE-LIFECYCLE"
-            ],
-            "roles": [
-                {
-                    "role": "domain",
-                    "include": [
-                        "src/aiSessions/conversation/types.ts",
-                        "src/aiSessions/conversation/model.ts",
-                        "src/aiSessions/conversation/viewerProtocol.ts",
-                        "src/aiSessions/conversation/viewerTarget.ts",
-                        "src/aiSessions/conversation/diffs.ts",
-                        "src/aiSessions/conversation/questions.ts",
-                        "src/aiSessions/conversation/text.ts",
-                        "src/aiSessions/conversation/commentPrimitives.ts"
-                    ]
-                },
-                {
-                    "role": "presentation",
-                    "include": [
-                        "src/aiSessions/conversation/viewerDocument.ts"
-                    ]
-                },
-                {
-                    "role": "infrastructure",
-                    "include": [
-                        "src/aiSessions/conversation/*Store.ts",
-                        "src/aiSessions/conversation/codexAppServerClient.ts",
-                        "src/aiSessions/conversation/jsonlReader.ts",
-                        "src/aiSessions/conversation/markdown.ts",
-                        "src/aiSessions/conversation/snapshotFileStore.ts",
-                        "src/aiSessions/conversation/worktreeResolver.ts",
-                        "src/aiSessions/conversation/source.ts"
-                    ]
-                },
-                {
-                    "role": "composition",
-                    "include": [
-                        "src/aiSessions/conversation/composition.ts"
-                    ]
-                },
-                {
-                    "role": "application",
-                    "include": [
-                        "**"
-                    ]
-                }
-            ],
-            "productCapabilities": [
-                "MAIN-AI-SESSION-CONVERSATION-OUTLINE"
-            ]
-        },
-        {
-            "id": "MOD-AI-SESSION-ATTENTION",
-            "title": "AI session attention",
-            "purpose": "Attention pipeline: aggregation, evaluation queue, monitor, payload, status bar, and bridge client.",
-            "source": {
-                "include": [
-                    "src/aiSessions/attention*"
-                ],
-                "exclude": []
-            },
-            "publicEntrypoints": [
-                "src/aiSessions/attention*"
-            ],
-            "mayDependOn": [
-                "MOD-AI-SESSION-NOTIFY",
-                "MOD-AI-SESSION-PROVIDER",
-                "MOD-AI-SESSION-RUNTIME",
-                "MOD-SHARED-KERNEL",
-                "MOD-WORKSPACE-IDENTITY"
-            ],
-            "roles": [
-                {
-                    "role": "domain",
-                    "include": [
-                        "src/aiSessions/attentionPayload.ts",
-                        "src/aiSessions/attentionProject.ts"
-                    ]
-                },
-                {
-                    "role": "infrastructure",
-                    "include": [
-                        "src/aiSessions/attentionBridgeClient.ts"
-                    ]
-                },
-                {
-                    "role": "application",
-                    "include": [
-                        "**"
-                    ]
-                }
-            ],
-            "productCapabilities": [
-                "MAIN-WORKSPACE-ATTENTION",
-                "MAIN-ATTENTION-LIFECYCLE-HARDENING"
-            ]
-        },
-        {
-            "id": "MOD-AI-SESSION-NOTIFY",
-            "title": "Session stop notification",
-            "purpose": "Stop-notification pipeline: policy, dispatcher, templates, credential storage — the extension's only outbound network egress.",
-            "source": {
-                "include": [
-                    "src/aiSessions/notify/**",
-                    "src/aiSessions/notifyIntegration/**",
-                    "src/aiSessions/notifyConfiguration.ts"
-                ],
-                "exclude": []
-            },
-            "publicEntrypoints": [
-                "src/aiSessions/notify/**",
-                "src/aiSessions/notifyIntegration/**",
-                "src/aiSessions/notifyConfiguration.ts"
-            ],
-            "mayDependOn": [
-                "MOD-AI-SESSION-ATTENTION"
-            ],
-            "roles": [
-                {
-                    "role": "domain",
-                    "include": [
-                        "src/aiSessions/notify/types.ts",
-                        "src/aiSessions/notify/templates/types.ts"
-                    ]
-                },
-                {
-                    "role": "infrastructure",
-                    "include": [
-                        "src/aiSessions/notify/httpClient.ts",
-                        "src/aiSessions/notify/store.ts",
-                        "src/aiSessions/notifyIntegration/credentials.ts"
-                    ]
-                },
-                {
-                    "role": "application",
-                    "include": [
-                        "**"
-                    ]
-                }
-            ],
-            "productCapabilities": [
-                "MAIN-SESSION-STOP-NOTIFICATION"
-            ]
-        },
-        {
-            "id": "MOD-AI-SESSION-RUNTIME",
-            "title": "AI session runtime",
-            "purpose": "Runtime backends (direct terminal and tmux), runtime coordination, launch specs, execution monitoring, and binding stores.",
-            "source": {
-                "include": [
-                    "src/aiSessions/tmux*",
-                    "src/aiSessions/runtime*",
-                    "src/aiSessions/directTerminalRuntimeBackend.ts",
-                    "src/aiSessions/terminalService.ts",
-                    "src/aiSessions/terminalBindingStore.ts",
-                    "src/aiSessions/terminalCandidates.ts",
-                    "src/aiSessions/terminalCwd.ts",
-                    "src/aiSessions/pendingTerminal*",
-                    "src/aiSessions/execution*",
-                    "src/aiSessions/runningQueue.ts",
-                    "src/aiSessions/launch*",
-                    "src/aiSessions/commandBuilders.ts"
-                ],
-                "exclude": []
-            },
-            "publicEntrypoints": [
-                "src/aiSessions/tmux*",
-                "src/aiSessions/runtime*",
-                "src/aiSessions/directTerminalRuntimeBackend.ts",
-                "src/aiSessions/terminalService.ts",
-                "src/aiSessions/terminalBindingStore.ts",
-                "src/aiSessions/terminalCandidates.ts",
-                "src/aiSessions/terminalCwd.ts",
-                "src/aiSessions/pendingTerminal*",
-                "src/aiSessions/execution*",
-                "src/aiSessions/runningQueue.ts",
-                "src/aiSessions/launch*",
-                "src/aiSessions/commandBuilders.ts"
-            ],
-            "mayDependOn": [
-                "MOD-AI-SESSION-ATTENTION",
-                "MOD-AI-SESSION-PROVIDER",
-                "MOD-PROJECT-CATALOG",
-                "MOD-SHARED-KERNEL",
-                "MOD-WORKTREE-LIFECYCLE"
-            ],
-            "roles": [
-                {
-                    "role": "domain",
-                    "include": [
-                        "src/aiSessions/runtimeTypes.ts",
-                        "src/aiSessions/launchSpec.ts",
-                        "src/aiSessions/commandBuilders.ts",
-                        "src/aiSessions/tmuxNaming.ts",
-                        "src/aiSessions/tmuxLayout.ts"
-                    ]
-                },
-                {
-                    "role": "infrastructure",
-                    "include": [
-                        "src/aiSessions/tmuxClient.ts",
-                        "src/aiSessions/terminalService.ts",
-                        "src/aiSessions/terminalBindingStore.ts",
-                        "src/aiSessions/tmuxAttachBindingStore.ts",
-                        "src/aiSessions/tmuxRuntimeBindingStore.ts",
-                        "src/aiSessions/tmuxRuntimeDiscovery.ts"
-                    ]
-                },
-                {
-                    "role": "application",
-                    "include": [
-                        "**"
-                    ]
-                }
-            ],
-            "productCapabilities": [
-                "MAIN-RUNTIME-OWNERSHIP",
-                "MAIN-TMUX-FOCUS",
-                "MAIN-TMUX-NAMING",
-                "MAIN-TMUX-CLEANUP",
-                "MAIN-RUNTIME-SESSION-RECOVERY"
-            ]
-        },
-        {
-            "id": "MOD-AI-SESSION-CONTROL",
-            "title": "AI session control",
-            "purpose": "Session controllers (create, command, archive, resume, terminal command, alias, pin, profile) and their composition.",
-            "source": {
-                "include": [
-                    "src/aiSessions/sessionControllerComposition.ts",
-                    "src/aiSessions/commandController.ts",
-                    "src/aiSessions/creationController.ts",
-                    "src/aiSessions/resumeController.ts",
-                    "src/aiSessions/terminalCommandController.ts",
-                    "src/aiSessions/aliasController.ts",
-                    "src/aiSessions/pinController.ts",
-                    "src/aiSessions/sessionProfileController.ts",
-                    "src/aiSessions/archive*"
-                ],
-                "exclude": []
-            },
-            "publicEntrypoints": [
-                "src/aiSessions/sessionControllerComposition.ts",
-                "src/aiSessions/commandController.ts",
-                "src/aiSessions/creationController.ts",
-                "src/aiSessions/resumeController.ts",
-                "src/aiSessions/terminalCommandController.ts",
-                "src/aiSessions/aliasController.ts",
-                "src/aiSessions/pinController.ts",
-                "src/aiSessions/sessionProfileController.ts",
-                "src/aiSessions/archive*"
-            ],
-            "mayDependOn": [
-                "MOD-AI-SESSION-PROVIDER",
-                "MOD-AI-SESSION-RUNTIME",
-                "MOD-SHARED-KERNEL",
-                "MOD-WORKSPACE-IDENTITY",
-                "MOD-WORKTREE-LIFECYCLE"
-            ],
-            "roles": [
-                {
-                    "role": "composition",
-                    "include": [
-                        "src/aiSessions/sessionControllerComposition.ts"
-                    ]
-                },
-                {
-                    "role": "application",
-                    "include": [
-                        "**"
-                    ]
-                }
-            ],
-            "productCapabilities": [
-                "MAIN-AI-SESSION-QUICK-CREATE",
-                "MAIN-AI-SESSION-QUICK-SWITCH",
-                "MAIN-RUNNING-SESSION-NAVIGATION"
-            ]
-        },
-        {
-            "id": "MOD-AI-SESSION-PROVIDER",
-            "title": "AI session provider core",
-            "purpose": "Provider registry, provider session services (codex/kimi/claude), lifecycle readers, session identity and fingerprinting, and residual aiSessions root support files. Residual module: new src/aiSessions root files land here by default until re-partition.",
-            "source": {
-                "include": [
-                    "src/aiSessions/**",
-                    "src/services/codexSessionService.ts",
-                    "src/services/kimiSessionService.ts",
-                    "src/services/claudeSessionService.ts"
-                ],
-                "exclude": [
-                    "src/aiSessions/conversation/**",
-                    "src/aiSessions/notify/**",
-                    "src/aiSessions/notifyIntegration/**",
-                    "src/aiSessions/notifyConfiguration.ts",
-                    "src/aiSessions/attention*",
-                    "src/aiSessions/tmux*",
-                    "src/aiSessions/runtime*",
-                    "src/aiSessions/directTerminalRuntimeBackend.ts",
-                    "src/aiSessions/terminal*",
-                    "src/aiSessions/pendingTerminal*",
-                    "src/aiSessions/execution*",
-                    "src/aiSessions/runningQueue.ts",
-                    "src/aiSessions/launch*",
-                    "src/aiSessions/commandBuilders.ts",
-                    "src/aiSessions/sessionControllerComposition.ts",
-                    "src/aiSessions/commandController.ts",
-                    "src/aiSessions/creationController.ts",
-                    "src/aiSessions/resumeController.ts",
-                    "src/aiSessions/terminalCommandController.ts",
-                    "src/aiSessions/aliasController.ts",
-                    "src/aiSessions/pinController.ts",
-                    "src/aiSessions/sessionProfileController.ts",
-                    "src/aiSessions/archive*"
-                ]
-            },
-            "publicEntrypoints": [
-                "src/aiSessions/**",
-                "src/services/codexSessionService.ts",
-                "src/services/kimiSessionService.ts",
-                "src/services/claudeSessionService.ts"
-            ],
-            "mayDependOn": [
-                "MOD-AI-SESSION-ATTENTION",
-                "MOD-AI-SESSION-CONTROL",
-                "MOD-AI-SESSION-RUNTIME",
-                "MOD-DASHBOARD-SHELL",
-                "MOD-SHARED-KERNEL",
-                "MOD-SKILL-MANAGEMENT",
-                "MOD-TODO",
-                "MOD-WORKSPACE-IDENTITY",
-                "MOD-WORKTREE-LIFECYCLE"
-            ],
-            "roles": [
-                {
-                    "role": "domain",
-                    "include": [
-                        "src/aiSessions/types.ts",
-                        "src/aiSessions/providers.ts"
-                    ]
-                },
-                {
-                    "role": "infrastructure",
-                    "include": [
-                        "src/aiSessions/aliasStore.ts",
-                        "src/aiSessions/sessionProfileStore.ts",
-                        "src/aiSessions/pinStore.ts",
-                        "src/aiSessions/workspaceStateStore.ts",
-                        "src/aiSessions/jsonlTail.ts",
-                        "src/aiSessions/incrementalJsonlLifecycleReader.ts",
-                        "src/aiSessions/lifecycleSignalReader.ts",
-                        "src/services/codexSessionService.ts",
-                        "src/services/kimiSessionService.ts",
-                        "src/services/claudeSessionService.ts"
-                    ]
-                },
-                {
-                    "role": "application",
-                    "include": [
-                        "**"
-                    ]
-                }
-            ],
-            "productCapabilities": [
-                "MAIN-AI-SESSION-QUICK-CREATE",
-                "MAIN-RUNTIME-SESSION-RECOVERY"
-            ]
-        },
-        {
-            "id": "MOD-WORKTREE-LIFECYCLE",
-            "title": "Worktree lifecycle",
-            "purpose": "Worktree group and member lifecycle, provisioning, generation claims, deletion journal, and the changes panel collector.",
-            "source": {
-                "include": [
-                    "src/worktrees/**"
-                ],
-                "exclude": []
-            },
-            "publicEntrypoints": [
-                "src/worktrees/**"
-            ],
-            "mayDependOn": [
-                "MOD-SHARED-KERNEL",
-                "MOD-WORKSPACE-IDENTITY"
-            ],
-            "roles": [
-                {
-                    "role": "domain",
-                    "include": [
-                        "src/worktrees/types.ts",
-                        "src/worktrees/baseline.ts",
-                        "src/worktrees/porcelainParser.ts",
-                        "src/worktrees/provisioningPlan.ts",
-                        "src/worktrees/*Protocol.ts",
-                        "src/worktrees/deletionJournal.ts",
-                        "src/worktrees/settlementReplayCache.ts",
-                        "src/worktrees/retiredWorktrees.ts"
-                    ]
-                },
-                {
-                    "role": "infrastructure",
-                    "include": [
-                        "src/worktrees/*Store.ts",
-                        "src/worktrees/gitWorktree*.ts",
-                        "src/worktrees/worktreeSetupRunner.ts",
-                        "src/worktrees/changesCollector.ts",
-                        "src/worktrees/gitRepositoryStateMonitor.ts"
-                    ]
-                },
-                {
-                    "role": "application",
-                    "include": [
-                        "**"
-                    ]
-                }
-            ],
-            "productCapabilities": [
-                "MAIN-WORKTREE-CHANGES-PANEL"
-            ]
-        },
-        {
-            "id": "MOD-WORKSPACE-IDENTITY",
-            "title": "Workspace identity",
-            "purpose": "Workspace identity, hydration, session scoping, and workspace-level projections.",
-            "source": {
-                "include": [
-                    "src/workspaces/**"
-                ],
-                "exclude": []
-            },
-            "publicEntrypoints": [
-                "src/workspaces/**"
-            ],
-            "mayDependOn": [
-                "MOD-AI-SESSION-ATTENTION",
-                "MOD-AI-SESSION-PROVIDER",
-                "MOD-AI-SESSION-RUNTIME",
-                "MOD-PROJECT-CATALOG",
-                "MOD-SHARED-KERNEL",
-                "MOD-WORKTREE-LIFECYCLE"
-            ],
-            "roles": [
-                {
-                    "role": "domain",
-                    "include": [
-                        "src/workspaces/types.ts",
-                        "src/workspaces/identity.ts"
-                    ]
-                },
-                {
-                    "role": "infrastructure",
-                    "include": [
-                        "src/workspaces/*Store.ts"
-                    ]
-                },
-                {
-                    "role": "application",
-                    "include": [
-                        "**"
-                    ]
-                }
-            ],
-            "productCapabilities": [
-                "MAIN-WORKSPACE-IDENTITY",
-                "MAIN-WORKSPACE-SCOPE",
-                "MAIN-WORKSPACE-HYDRATION"
-            ]
-        },
-        {
-            "id": "MOD-OPEN-WORKSPACE",
-            "title": "Open workspace bridge",
-            "purpose": "Open-workspace bridge client and cross-window protocols.",
-            "source": {
-                "include": [
-                    "src/openWorkspaces/**"
-                ],
-                "exclude": []
-            },
-            "publicEntrypoints": [
-                "src/openWorkspaces/**"
-            ],
-            "mayDependOn": [
-                "MOD-AI-SESSION-ATTENTION",
-                "MOD-AI-SESSION-PROVIDER",
-                "MOD-DASHBOARD-SHELL",
-                "MOD-SHARED-KERNEL",
-                "MOD-SKILL-MANAGEMENT",
-                "MOD-TODO",
-                "MOD-WORKSPACE-IDENTITY"
-            ],
-            "roles": [
-                {
-                    "role": "domain",
-                    "include": [
-                        "src/openWorkspaces/*Protocol.ts"
-                    ]
-                },
-                {
-                    "role": "infrastructure",
-                    "include": [
-                        "src/openWorkspaces/bridgeClient.ts",
-                        "src/openWorkspaces/earlyBridge.ts",
-                        "src/openWorkspaces/focusBridgeChannel.ts"
-                    ]
-                },
-                {
-                    "role": "application",
-                    "include": [
-                        "**"
-                    ]
-                }
-            ],
-            "productCapabilities": [
-                "MAIN-OPEN-WORKSPACE-PROTOCOL",
-                "MAIN-OTHER-WINDOWS"
-            ]
-        },
-        {
-            "id": "MOD-PROJECT-CATALOG",
-            "title": "Project catalog",
-            "purpose": "Project CRUD, favorites, ordering, remote resolution, and the legacy project/color/file services (vendored ntc.ts included, coverage-exempt).",
-            "source": {
-                "include": [
-                    "src/projects/**",
-                    "src/services/baseService.ts",
-                    "src/services/projectService.ts",
-                    "src/services/colorService.ts",
-                    "src/services/fileService.ts",
-                    "src/services/projectWindowColorService.ts",
-                    "src/services/projectCatalogSyncService.ts",
-                    "src/services/sourceControl.ts",
-                    "src/services/gitChangesDiff.ts",
-                    "src/services/ntc.ts"
-                ],
-                "exclude": []
-            },
-            "publicEntrypoints": [
-                "src/projects/**",
-                "src/services/baseService.ts",
-                "src/services/projectService.ts",
-                "src/services/colorService.ts",
-                "src/services/fileService.ts",
-                "src/services/projectWindowColorService.ts",
-                "src/services/projectCatalogSyncService.ts",
-                "src/services/sourceControl.ts",
-                "src/services/gitChangesDiff.ts",
-                "src/services/ntc.ts"
-            ],
-            "mayDependOn": [
-                "MOD-AI-SESSION-ATTENTION",
-                "MOD-DASHBOARD-SHELL",
-                "MOD-OPEN-WORKSPACE",
-                "MOD-SHARED-KERNEL",
-                "MOD-WORKTREE-LIFECYCLE"
-            ],
-            "roles": [
-                {
-                    "role": "domain",
-                    "include": [
-                        "src/projects/projectPathUtils.ts",
-                        "src/projects/favoriteProjectOrder.ts",
-                        "src/projects/projectNavigationProtocol.ts",
-                        "src/projects/projectCatalogSync.ts"
-                    ]
-                },
-                {
-                    "role": "infrastructure",
-                    "include": [
-                        "src/services/**",
-                        "src/projects/gitRepositoryDetector.ts"
-                    ]
-                },
-                {
-                    "role": "application",
-                    "include": [
-                        "**"
-                    ]
-                }
-            ],
-            "productCapabilities": [
-                "MAIN-PROJECT-CATALOG-CONSISTENCY",
-                "MAIN-WORKSPACE-SAVE"
-            ]
-        },
-        {
-            "id": "MOD-SKILL-MANAGEMENT",
-            "title": "Skill management",
-            "purpose": "Skills central store, scope actions, discovery, migration, and the skills panel.",
-            "source": {
-                "include": [
-                    "src/skills/**"
-                ],
-                "exclude": []
-            },
-            "publicEntrypoints": [
-                "src/skills/**"
-            ],
-            "mayDependOn": [
-                "MOD-DASHBOARD-SHELL"
-            ],
-            "roles": [
-                {
-                    "role": "domain",
-                    "include": [
-                        "src/skills/types.ts",
-                        "src/skills/frontmatter.ts",
-                        "src/skills/knownCollections.ts"
-                    ]
-                },
-                {
-                    "role": "infrastructure",
-                    "include": [
-                        "src/skills/roots.ts"
-                    ]
-                },
-                {
-                    "role": "application",
-                    "include": [
-                        "**"
-                    ]
-                }
-            ],
-            "productCapabilities": [
-                "MAIN-AI-SKILL-MANAGEMENT"
-            ]
-        },
-        {
-            "id": "MOD-TODO",
-            "title": "Todo list",
-            "purpose": "Todo store, service, and panel capability.",
-            "source": {
-                "include": [
-                    "src/todos/**"
-                ],
-                "exclude": []
-            },
-            "publicEntrypoints": [
-                "src/todos/**"
-            ],
-            "mayDependOn": [
-                "MOD-DASHBOARD-SHELL",
-                "MOD-SHARED-KERNEL"
-            ],
-            "roles": [
-                {
-                    "role": "domain",
-                    "include": [
-                        "src/todos/types.ts"
-                    ]
-                },
-                {
-                    "role": "presentation",
-                    "include": [
-                        "src/todos/webviewContent.ts"
-                    ]
-                },
-                {
-                    "role": "application",
-                    "include": [
-                        "**"
-                    ]
-                }
-            ],
-            "productCapabilities": [
-                "MAIN-TODO-CONTINUOUS-EXPERIENCE"
-            ]
-        },
-        {
-            "id": "MOD-PROMPT-LIBRARY",
-            "title": "Prompt library",
-            "purpose": "Prompt library service and webview content.",
-            "source": {
-                "include": [
-                    "src/prompts/**"
-                ],
-                "exclude": []
-            },
-            "publicEntrypoints": [
-                "src/prompts/**"
-            ],
-            "mayDependOn": [
-                "MOD-DASHBOARD-SHELL"
-            ],
-            "roles": [
-                {
-                    "role": "domain",
-                    "include": [
-                        "src/prompts/types.ts"
-                    ]
-                },
-                {
-                    "role": "presentation",
-                    "include": [
-                        "src/prompts/webviewContent.ts"
-                    ]
-                },
-                {
-                    "role": "application",
-                    "include": [
-                        "**"
-                    ]
-                }
-            ],
-            "productCapabilities": [
-                "MAIN-AI-PROMPT-LIBRARY"
-            ]
-        },
-        {
-            "id": "MOD-ATTENTION-BRIDGE-EXT",
-            "title": "Attention UI bridge extension",
-            "purpose": "Companion attention UI bridge extension and the shared bridge protocol (separate compile units).",
-            "source": {
-                "include": [
-                    "extensions/attention-ui-bridge/src/**",
-                    "shared/attention-bridge/**"
-                ],
-                "exclude": []
-            },
-            "publicEntrypoints": [
-                "extensions/attention-ui-bridge/src/**",
-                "shared/attention-bridge/**"
-            ],
-            "mayDependOn": [
-                "MOD-AI-SESSION-ATTENTION",
-                "MOD-AI-SESSION-RUNTIME",
-                "MOD-OPEN-WORKSPACE",
-                "MOD-PROJECT-CATALOG",
-                "MOD-WORKSPACE-IDENTITY"
-            ],
-            "roles": [
-                {
-                    "role": "composition",
-                    "include": [
-                        "extensions/attention-ui-bridge/src/extension.ts"
-                    ]
-                },
-                {
-                    "role": "domain",
-                    "include": [
-                        "shared/attention-bridge/**"
-                    ]
-                },
-                {
-                    "role": "infrastructure",
-                    "include": [
-                        "extensions/attention-ui-bridge/src/localStore.ts",
-                        "extensions/attention-ui-bridge/src/bridgeStorageRoot.ts",
-                        "extensions/attention-ui-bridge/src/productionAttentionStore.ts",
-                        "extensions/attention-ui-bridge/src/openWorkspace*Store.ts"
-                    ]
-                },
-                {
-                    "role": "application",
-                    "include": [
-                        "**"
-                    ]
-                }
-            ],
-            "productCapabilities": [
-                "MAIN-OPEN-WORKSPACE-PROTOCOL"
-            ]
-        },
-        {
-            "id": "MOD-SHARED-KERNEL",
-            "title": "Shared kernel",
-            "purpose": "Module-bottom shared types, constants, workspace path assignment, and the worktree identity codecs. Depends on nothing at value level; every module may depend on it.",
-            "source": {
-                "include": [
-                    "src/models.ts",
-                    "src/constants.ts",
-                    "src/sessionAssignment.ts",
-                    "src/worktreeSessionAssignment.ts",
-                    "src/worktreeIdentity.ts"
-                ],
-                "exclude": []
-            },
-            "publicEntrypoints": [
-                "src/models.ts",
-                "src/constants.ts",
-                "src/sessionAssignment.ts",
-                "src/worktreeSessionAssignment.ts",
-                "src/worktreeIdentity.ts"
-            ],
-            "mayDependOn": [
-                "MOD-AI-SESSION-PROVIDER",
-                "MOD-SKILL-MANAGEMENT",
-                "MOD-TODO",
-                "MOD-WORKSPACE-IDENTITY",
-                "MOD-WORKTREE-LIFECYCLE"
-            ],
-            "roles": [
-                {
-                    "role": "domain",
-                    "include": [
-                        "src/models.ts",
-                        "src/constants.ts",
-                        "src/sessionAssignment.ts",
-                        "src/worktreeSessionAssignment.ts",
-                        "src/worktreeIdentity.ts"
-                    ]
-                }
-            ],
-            "productCapabilities": [
-                "MAIN-WORKSPACE-IDENTITY",
-                "MAIN-WORKTREE-CHANGES-PANEL"
-            ]
-        }
+    "exclusions": [
+      "media/ (generated: byte-mirrored webview scripts, bundle, vendor)",
+      "spikes/ (non-production experiments)",
+      "scripts/ (harness/tooling)",
+      "tests/ (test code)",
+      "out/, dist/ (build output)"
     ]
+  },
+  "modules": [
+    {
+      "id": "MOD-DASHBOARD-SHELL",
+      "title": "Dashboard shell",
+      "purpose": "Sidebar webview host, message routing, startup/lifecycle, webview presentation assets, and the root composition (dashboard.ts) plus the shared type/constant kernel.",
+      "source": {
+        "include": [
+          "src/dashboard.ts",
+          "src/sponsor.ts",
+          "src/dashboard/**",
+          "src/webview/**"
+        ],
+        "exclude": []
+      },
+      "publicEntrypoints": [
+        "src/dashboard.ts",
+        "src/sponsor.ts",
+        "src/dashboard/**",
+        "src/webview/**"
+      ],
+      "mayDependOn": [
+        "MOD-AI-SESSION-ATTENTION",
+        "MOD-AI-SESSION-CONTROL",
+        "MOD-AI-SESSION-CONVERSATION",
+        "MOD-AI-SESSION-NOTIFY",
+        "MOD-AI-SESSION-PROVIDER",
+        "MOD-AI-SESSION-RUNTIME",
+        "MOD-OPEN-WORKSPACE",
+        "MOD-PROJECT-CATALOG",
+        "MOD-PROMPT-LIBRARY",
+        "MOD-SHARED-KERNEL",
+        "MOD-SKILL-MANAGEMENT",
+        "MOD-TODO",
+        "MOD-WORKSPACE-IDENTITY",
+        "MOD-WORKTREE-LIFECYCLE"
+      ],
+      "roles": [
+        {
+          "role": "composition",
+          "include": [
+            "src/dashboard.ts"
+          ]
+        },
+        {
+          "role": "presentation",
+          "include": [
+            "src/webview/**"
+          ]
+        },
+        {
+          "role": "application",
+          "include": [
+            "**"
+          ]
+        }
+      ],
+      "productCapabilities": [
+        "MAIN-WORKSPACE-WEBVIEW",
+        "MAIN-DASHBOARD-WEBVIEW-RECOVERY",
+        "MAIN-WORKSPACE-SEARCH",
+        "MAIN-WORKSPACE-NAVIGATION",
+        "MAIN-SPONSOR-ENTRY"
+      ]
+    },
+    {
+      "id": "MOD-AI-SESSION-CONVERSATION",
+      "title": "AI session conversation",
+      "purpose": "Conversation provider adapters, read coordinator, viewer, and viewer protocol. Active feature area: no restructuring while it is being built.",
+      "source": {
+        "include": [
+          "src/aiSessions/conversation/**"
+        ],
+        "exclude": []
+      },
+      "publicEntrypoints": [
+        "src/aiSessions/conversation/**"
+      ],
+      "mayDependOn": [
+        "MOD-AI-SESSION-PROVIDER",
+        "MOD-AI-SESSION-RUNTIME",
+        "MOD-DASHBOARD-SHELL",
+        "MOD-SHARED-KERNEL",
+        "MOD-WORKTREE-LIFECYCLE"
+      ],
+      "roles": [
+        {
+          "role": "domain",
+          "include": [
+            "src/aiSessions/conversation/types.ts",
+            "src/aiSessions/conversation/model.ts",
+            "src/aiSessions/conversation/viewerProtocol.ts",
+            "src/aiSessions/conversation/viewerTarget.ts",
+            "src/aiSessions/conversation/diffs.ts",
+            "src/aiSessions/conversation/questions.ts",
+            "src/aiSessions/conversation/text.ts",
+            "src/aiSessions/conversation/commentPrimitives.ts"
+          ]
+        },
+        {
+          "role": "presentation",
+          "include": [
+            "src/aiSessions/conversation/viewerDocument.ts"
+          ]
+        },
+        {
+          "role": "infrastructure",
+          "include": [
+            "src/aiSessions/conversation/*Store.ts",
+            "src/aiSessions/conversation/codexAppServerClient.ts",
+            "src/aiSessions/conversation/jsonlReader.ts",
+            "src/aiSessions/conversation/markdown.ts",
+            "src/aiSessions/conversation/snapshotFileStore.ts",
+            "src/aiSessions/conversation/worktreeResolver.ts",
+            "src/aiSessions/conversation/source.ts"
+          ]
+        },
+        {
+          "role": "composition",
+          "include": [
+            "src/aiSessions/conversation/composition.ts"
+          ]
+        },
+        {
+          "role": "application",
+          "include": [
+            "**"
+          ]
+        }
+      ],
+      "productCapabilities": [
+        "MAIN-AI-SESSION-CONVERSATION-OUTLINE"
+      ]
+    },
+    {
+      "id": "MOD-AI-SESSION-ATTENTION",
+      "title": "AI session attention",
+      "purpose": "Attention pipeline: aggregation, evaluation queue, monitor, payload, status bar, and bridge client.",
+      "source": {
+        "include": [
+          "src/aiSessions/attention*"
+        ],
+        "exclude": []
+      },
+      "publicEntrypoints": [
+        "src/aiSessions/attention*"
+      ],
+      "mayDependOn": [
+        "MOD-AI-SESSION-NOTIFY",
+        "MOD-AI-SESSION-PROVIDER",
+        "MOD-AI-SESSION-RUNTIME",
+        "MOD-SHARED-KERNEL",
+        "MOD-WORKSPACE-IDENTITY"
+      ],
+      "roles": [
+        {
+          "role": "domain",
+          "include": [
+            "src/aiSessions/attentionPayload.ts",
+            "src/aiSessions/attentionProject.ts"
+          ]
+        },
+        {
+          "role": "infrastructure",
+          "include": [
+            "src/aiSessions/attentionBridgeClient.ts"
+          ]
+        },
+        {
+          "role": "application",
+          "include": [
+            "**"
+          ]
+        }
+      ],
+      "productCapabilities": [
+        "MAIN-WORKSPACE-ATTENTION",
+        "MAIN-ATTENTION-LIFECYCLE-HARDENING"
+      ]
+    },
+    {
+      "id": "MOD-AI-SESSION-NOTIFY",
+      "title": "Session stop notification",
+      "purpose": "Stop-notification pipeline: policy, dispatcher, templates, credential storage \u2014 the extension's only outbound network egress.",
+      "source": {
+        "include": [
+          "src/aiSessions/notify/**",
+          "src/aiSessions/notifyIntegration/**",
+          "src/aiSessions/notifyConfiguration.ts"
+        ],
+        "exclude": []
+      },
+      "publicEntrypoints": [
+        "src/aiSessions/notify/**",
+        "src/aiSessions/notifyIntegration/**",
+        "src/aiSessions/notifyConfiguration.ts"
+      ],
+      "mayDependOn": [
+        "MOD-AI-SESSION-ATTENTION"
+      ],
+      "roles": [
+        {
+          "role": "domain",
+          "include": [
+            "src/aiSessions/notify/types.ts",
+            "src/aiSessions/notify/templates/types.ts"
+          ]
+        },
+        {
+          "role": "infrastructure",
+          "include": [
+            "src/aiSessions/notify/httpClient.ts",
+            "src/aiSessions/notify/store.ts",
+            "src/aiSessions/notifyIntegration/credentials.ts"
+          ]
+        },
+        {
+          "role": "application",
+          "include": [
+            "**"
+          ]
+        }
+      ],
+      "productCapabilities": [
+        "MAIN-SESSION-STOP-NOTIFICATION"
+      ]
+    },
+    {
+      "id": "MOD-AI-SESSION-RUNTIME",
+      "title": "AI session runtime",
+      "purpose": "Runtime backends (direct terminal and tmux), runtime coordination, launch specs, execution monitoring, and binding stores.",
+      "source": {
+        "include": [
+          "src/aiSessions/tmux*",
+          "src/aiSessions/runtime*",
+          "src/aiSessions/directTerminalRuntimeBackend.ts",
+          "src/aiSessions/terminalService.ts",
+          "src/aiSessions/terminalBindingStore.ts",
+          "src/aiSessions/terminalCandidates.ts",
+          "src/aiSessions/terminalCwd.ts",
+          "src/aiSessions/pendingTerminal*",
+          "src/aiSessions/execution*",
+          "src/aiSessions/runningQueue.ts",
+          "src/aiSessions/launch*",
+          "src/aiSessions/commandBuilders.ts"
+        ],
+        "exclude": []
+      },
+      "publicEntrypoints": [
+        "src/aiSessions/tmux*",
+        "src/aiSessions/runtime*",
+        "src/aiSessions/directTerminalRuntimeBackend.ts",
+        "src/aiSessions/terminalService.ts",
+        "src/aiSessions/terminalBindingStore.ts",
+        "src/aiSessions/terminalCandidates.ts",
+        "src/aiSessions/terminalCwd.ts",
+        "src/aiSessions/pendingTerminal*",
+        "src/aiSessions/execution*",
+        "src/aiSessions/runningQueue.ts",
+        "src/aiSessions/launch*",
+        "src/aiSessions/commandBuilders.ts"
+      ],
+      "mayDependOn": [
+        "MOD-AI-SESSION-ATTENTION",
+        "MOD-AI-SESSION-PROVIDER",
+        "MOD-PROJECT-CATALOG",
+        "MOD-SHARED-KERNEL",
+        "MOD-WORKTREE-LIFECYCLE"
+      ],
+      "roles": [
+        {
+          "role": "domain",
+          "include": [
+            "src/aiSessions/runtimeTypes.ts",
+            "src/aiSessions/launchSpec.ts",
+            "src/aiSessions/commandBuilders.ts",
+            "src/aiSessions/tmuxNaming.ts",
+            "src/aiSessions/tmuxLayout.ts"
+          ]
+        },
+        {
+          "role": "infrastructure",
+          "include": [
+            "src/aiSessions/tmuxClient.ts",
+            "src/aiSessions/terminalService.ts",
+            "src/aiSessions/terminalBindingStore.ts",
+            "src/aiSessions/tmuxAttachBindingStore.ts",
+            "src/aiSessions/tmuxRuntimeBindingStore.ts",
+            "src/aiSessions/tmuxRuntimeDiscovery.ts"
+          ]
+        },
+        {
+          "role": "application",
+          "include": [
+            "**"
+          ]
+        }
+      ],
+      "productCapabilities": [
+        "MAIN-RUNTIME-OWNERSHIP",
+        "MAIN-TMUX-FOCUS",
+        "MAIN-TMUX-NAMING",
+        "MAIN-TMUX-CLEANUP",
+        "MAIN-RUNTIME-SESSION-RECOVERY"
+      ]
+    },
+    {
+      "id": "MOD-AI-SESSION-CONTROL",
+      "title": "AI session control",
+      "purpose": "Session controllers (create, command, archive, resume, terminal command, alias, pin, profile) and their composition.",
+      "source": {
+        "include": [
+          "src/aiSessions/sessionControllerComposition.ts",
+          "src/aiSessions/commandController.ts",
+          "src/aiSessions/creationController.ts",
+          "src/aiSessions/resumeController.ts",
+          "src/aiSessions/terminalCommandController.ts",
+          "src/aiSessions/aliasController.ts",
+          "src/aiSessions/pinController.ts",
+          "src/aiSessions/sessionProfileController.ts",
+          "src/aiSessions/archive*"
+        ],
+        "exclude": []
+      },
+      "publicEntrypoints": [
+        "src/aiSessions/sessionControllerComposition.ts",
+        "src/aiSessions/commandController.ts",
+        "src/aiSessions/creationController.ts",
+        "src/aiSessions/resumeController.ts",
+        "src/aiSessions/terminalCommandController.ts",
+        "src/aiSessions/aliasController.ts",
+        "src/aiSessions/pinController.ts",
+        "src/aiSessions/sessionProfileController.ts",
+        "src/aiSessions/archive*"
+      ],
+      "mayDependOn": [
+        "MOD-AI-SESSION-PROVIDER",
+        "MOD-AI-SESSION-RUNTIME",
+        "MOD-SHARED-KERNEL",
+        "MOD-WORKSPACE-IDENTITY",
+        "MOD-WORKTREE-LIFECYCLE"
+      ],
+      "roles": [
+        {
+          "role": "composition",
+          "include": [
+            "src/aiSessions/sessionControllerComposition.ts"
+          ]
+        },
+        {
+          "role": "application",
+          "include": [
+            "**"
+          ]
+        }
+      ],
+      "productCapabilities": [
+        "MAIN-AI-SESSION-QUICK-CREATE",
+        "MAIN-AI-SESSION-QUICK-SWITCH",
+        "MAIN-RUNNING-SESSION-NAVIGATION"
+      ]
+    },
+    {
+      "id": "MOD-AI-SESSION-PROVIDER",
+      "title": "AI session provider core",
+      "purpose": "Provider registry, provider session services (codex/kimi/claude), lifecycle readers, session identity and fingerprinting, and residual aiSessions root support files. Residual module: new src/aiSessions root files land here by default until re-partition.",
+      "source": {
+        "include": [
+          "src/aiSessions/**",
+          "src/services/codexSessionService.ts",
+          "src/services/kimiSessionService.ts",
+          "src/services/claudeSessionService.ts"
+        ],
+        "exclude": [
+          "src/aiSessions/conversation/**",
+          "src/aiSessions/notify/**",
+          "src/aiSessions/notifyIntegration/**",
+          "src/aiSessions/notifyConfiguration.ts",
+          "src/aiSessions/attention*",
+          "src/aiSessions/tmux*",
+          "src/aiSessions/runtime*",
+          "src/aiSessions/directTerminalRuntimeBackend.ts",
+          "src/aiSessions/terminal*",
+          "src/aiSessions/pendingTerminal*",
+          "src/aiSessions/execution*",
+          "src/aiSessions/runningQueue.ts",
+          "src/aiSessions/launch*",
+          "src/aiSessions/commandBuilders.ts",
+          "src/aiSessions/sessionControllerComposition.ts",
+          "src/aiSessions/commandController.ts",
+          "src/aiSessions/creationController.ts",
+          "src/aiSessions/resumeController.ts",
+          "src/aiSessions/terminalCommandController.ts",
+          "src/aiSessions/aliasController.ts",
+          "src/aiSessions/pinController.ts",
+          "src/aiSessions/sessionProfileController.ts",
+          "src/aiSessions/archive*"
+        ]
+      },
+      "publicEntrypoints": [
+        "src/aiSessions/**",
+        "src/services/codexSessionService.ts",
+        "src/services/kimiSessionService.ts",
+        "src/services/claudeSessionService.ts"
+      ],
+      "mayDependOn": [
+        "MOD-AI-SESSION-ATTENTION",
+        "MOD-AI-SESSION-CONTROL",
+        "MOD-AI-SESSION-RUNTIME",
+        "MOD-DASHBOARD-SHELL",
+        "MOD-SHARED-KERNEL",
+        "MOD-SKILL-MANAGEMENT",
+        "MOD-TODO",
+        "MOD-WORKSPACE-IDENTITY",
+        "MOD-WORKTREE-LIFECYCLE"
+      ],
+      "roles": [
+        {
+          "role": "domain",
+          "include": [
+            "src/aiSessions/types.ts",
+            "src/aiSessions/providers.ts"
+          ]
+        },
+        {
+          "role": "infrastructure",
+          "include": [
+            "src/aiSessions/aliasStore.ts",
+            "src/aiSessions/sessionProfileStore.ts",
+            "src/aiSessions/pinStore.ts",
+            "src/aiSessions/workspaceStateStore.ts",
+            "src/aiSessions/jsonlTail.ts",
+            "src/aiSessions/incrementalJsonlLifecycleReader.ts",
+            "src/aiSessions/lifecycleSignalReader.ts",
+            "src/services/codexSessionService.ts",
+            "src/services/kimiSessionService.ts",
+            "src/services/claudeSessionService.ts"
+          ]
+        },
+        {
+          "role": "application",
+          "include": [
+            "**"
+          ]
+        }
+      ],
+      "productCapabilities": [
+        "MAIN-AI-SESSION-QUICK-CREATE",
+        "MAIN-RUNTIME-SESSION-RECOVERY"
+      ]
+    },
+    {
+      "id": "MOD-WORKTREE-LIFECYCLE",
+      "title": "Worktree lifecycle",
+      "purpose": "Worktree group and member lifecycle, provisioning, generation claims, deletion journal, and the changes panel collector.",
+      "source": {
+        "include": [
+          "src/worktrees/**"
+        ],
+        "exclude": []
+      },
+      "publicEntrypoints": [
+        "src/worktrees/index.ts"
+      ],
+      "mayDependOn": [
+        "MOD-SHARED-KERNEL",
+        "MOD-WORKSPACE-IDENTITY"
+      ],
+      "roles": [
+        {
+          "role": "domain",
+          "include": [
+            "src/worktrees/types.ts",
+            "src/worktrees/baseline.ts",
+            "src/worktrees/porcelainParser.ts",
+            "src/worktrees/provisioningPlan.ts",
+            "src/worktrees/*Protocol.ts",
+            "src/worktrees/deletionJournal.ts",
+            "src/worktrees/settlementReplayCache.ts",
+            "src/worktrees/retiredWorktrees.ts"
+          ]
+        },
+        {
+          "role": "infrastructure",
+          "include": [
+            "src/worktrees/*Store.ts",
+            "src/worktrees/gitWorktree*.ts",
+            "src/worktrees/worktreeSetupRunner.ts",
+            "src/worktrees/changesCollector.ts",
+            "src/worktrees/gitRepositoryStateMonitor.ts"
+          ]
+        },
+        {
+          "role": "composition",
+          "include": [
+            "src/worktrees/index.ts"
+          ]
+        },
+        {
+          "role": "application",
+          "include": [
+            "**"
+          ]
+        }
+      ],
+      "productCapabilities": [
+        "MAIN-WORKTREE-CHANGES-PANEL"
+      ]
+    },
+    {
+      "id": "MOD-WORKSPACE-IDENTITY",
+      "title": "Workspace identity",
+      "purpose": "Workspace identity, hydration, session scoping, and workspace-level projections.",
+      "source": {
+        "include": [
+          "src/workspaces/**"
+        ],
+        "exclude": []
+      },
+      "publicEntrypoints": [
+        "src/workspaces/**"
+      ],
+      "mayDependOn": [
+        "MOD-AI-SESSION-ATTENTION",
+        "MOD-AI-SESSION-PROVIDER",
+        "MOD-AI-SESSION-RUNTIME",
+        "MOD-PROJECT-CATALOG",
+        "MOD-SHARED-KERNEL",
+        "MOD-WORKTREE-LIFECYCLE"
+      ],
+      "roles": [
+        {
+          "role": "domain",
+          "include": [
+            "src/workspaces/types.ts",
+            "src/workspaces/identity.ts"
+          ]
+        },
+        {
+          "role": "infrastructure",
+          "include": [
+            "src/workspaces/*Store.ts"
+          ]
+        },
+        {
+          "role": "application",
+          "include": [
+            "**"
+          ]
+        }
+      ],
+      "productCapabilities": [
+        "MAIN-WORKSPACE-IDENTITY",
+        "MAIN-WORKSPACE-SCOPE",
+        "MAIN-WORKSPACE-HYDRATION"
+      ]
+    },
+    {
+      "id": "MOD-OPEN-WORKSPACE",
+      "title": "Open workspace bridge",
+      "purpose": "Open-workspace bridge client and cross-window protocols.",
+      "source": {
+        "include": [
+          "src/openWorkspaces/**"
+        ],
+        "exclude": []
+      },
+      "publicEntrypoints": [
+        "src/openWorkspaces/**"
+      ],
+      "mayDependOn": [
+        "MOD-AI-SESSION-ATTENTION",
+        "MOD-AI-SESSION-PROVIDER",
+        "MOD-DASHBOARD-SHELL",
+        "MOD-SHARED-KERNEL",
+        "MOD-SKILL-MANAGEMENT",
+        "MOD-TODO",
+        "MOD-WORKSPACE-IDENTITY"
+      ],
+      "roles": [
+        {
+          "role": "domain",
+          "include": [
+            "src/openWorkspaces/*Protocol.ts"
+          ]
+        },
+        {
+          "role": "infrastructure",
+          "include": [
+            "src/openWorkspaces/bridgeClient.ts",
+            "src/openWorkspaces/earlyBridge.ts",
+            "src/openWorkspaces/focusBridgeChannel.ts"
+          ]
+        },
+        {
+          "role": "application",
+          "include": [
+            "**"
+          ]
+        }
+      ],
+      "productCapabilities": [
+        "MAIN-OPEN-WORKSPACE-PROTOCOL",
+        "MAIN-OTHER-WINDOWS"
+      ]
+    },
+    {
+      "id": "MOD-PROJECT-CATALOG",
+      "title": "Project catalog",
+      "purpose": "Project CRUD, favorites, ordering, remote resolution, and the legacy project/color/file services (vendored ntc.ts included, coverage-exempt).",
+      "source": {
+        "include": [
+          "src/projects/**",
+          "src/services/baseService.ts",
+          "src/services/projectService.ts",
+          "src/services/colorService.ts",
+          "src/services/fileService.ts",
+          "src/services/projectWindowColorService.ts",
+          "src/services/projectCatalogSyncService.ts",
+          "src/services/sourceControl.ts",
+          "src/services/gitChangesDiff.ts",
+          "src/services/ntc.ts"
+        ],
+        "exclude": []
+      },
+      "publicEntrypoints": [
+        "src/projects/**",
+        "src/services/baseService.ts",
+        "src/services/projectService.ts",
+        "src/services/colorService.ts",
+        "src/services/fileService.ts",
+        "src/services/projectWindowColorService.ts",
+        "src/services/projectCatalogSyncService.ts",
+        "src/services/sourceControl.ts",
+        "src/services/gitChangesDiff.ts",
+        "src/services/ntc.ts"
+      ],
+      "mayDependOn": [
+        "MOD-AI-SESSION-ATTENTION",
+        "MOD-DASHBOARD-SHELL",
+        "MOD-OPEN-WORKSPACE",
+        "MOD-SHARED-KERNEL",
+        "MOD-WORKTREE-LIFECYCLE"
+      ],
+      "roles": [
+        {
+          "role": "domain",
+          "include": [
+            "src/projects/projectPathUtils.ts",
+            "src/projects/favoriteProjectOrder.ts",
+            "src/projects/projectNavigationProtocol.ts",
+            "src/projects/projectCatalogSync.ts"
+          ]
+        },
+        {
+          "role": "infrastructure",
+          "include": [
+            "src/services/**",
+            "src/projects/gitRepositoryDetector.ts"
+          ]
+        },
+        {
+          "role": "application",
+          "include": [
+            "**"
+          ]
+        }
+      ],
+      "productCapabilities": [
+        "MAIN-PROJECT-CATALOG-CONSISTENCY",
+        "MAIN-WORKSPACE-SAVE"
+      ]
+    },
+    {
+      "id": "MOD-SKILL-MANAGEMENT",
+      "title": "Skill management",
+      "purpose": "Skills central store, scope actions, discovery, migration, and the skills panel.",
+      "source": {
+        "include": [
+          "src/skills/**"
+        ],
+        "exclude": []
+      },
+      "publicEntrypoints": [
+        "src/skills/**"
+      ],
+      "mayDependOn": [
+        "MOD-DASHBOARD-SHELL"
+      ],
+      "roles": [
+        {
+          "role": "domain",
+          "include": [
+            "src/skills/types.ts",
+            "src/skills/frontmatter.ts",
+            "src/skills/knownCollections.ts"
+          ]
+        },
+        {
+          "role": "infrastructure",
+          "include": [
+            "src/skills/roots.ts"
+          ]
+        },
+        {
+          "role": "application",
+          "include": [
+            "**"
+          ]
+        }
+      ],
+      "productCapabilities": [
+        "MAIN-AI-SKILL-MANAGEMENT"
+      ]
+    },
+    {
+      "id": "MOD-TODO",
+      "title": "Todo list",
+      "purpose": "Todo store, service, and panel capability.",
+      "source": {
+        "include": [
+          "src/todos/**"
+        ],
+        "exclude": []
+      },
+      "publicEntrypoints": [
+        "src/todos/**"
+      ],
+      "mayDependOn": [
+        "MOD-DASHBOARD-SHELL",
+        "MOD-SHARED-KERNEL"
+      ],
+      "roles": [
+        {
+          "role": "domain",
+          "include": [
+            "src/todos/types.ts"
+          ]
+        },
+        {
+          "role": "presentation",
+          "include": [
+            "src/todos/webviewContent.ts"
+          ]
+        },
+        {
+          "role": "application",
+          "include": [
+            "**"
+          ]
+        }
+      ],
+      "productCapabilities": [
+        "MAIN-TODO-CONTINUOUS-EXPERIENCE"
+      ]
+    },
+    {
+      "id": "MOD-PROMPT-LIBRARY",
+      "title": "Prompt library",
+      "purpose": "Prompt library service and webview content.",
+      "source": {
+        "include": [
+          "src/prompts/**"
+        ],
+        "exclude": []
+      },
+      "publicEntrypoints": [
+        "src/prompts/**"
+      ],
+      "mayDependOn": [
+        "MOD-DASHBOARD-SHELL"
+      ],
+      "roles": [
+        {
+          "role": "domain",
+          "include": [
+            "src/prompts/types.ts"
+          ]
+        },
+        {
+          "role": "presentation",
+          "include": [
+            "src/prompts/webviewContent.ts"
+          ]
+        },
+        {
+          "role": "application",
+          "include": [
+            "**"
+          ]
+        }
+      ],
+      "productCapabilities": [
+        "MAIN-AI-PROMPT-LIBRARY"
+      ]
+    },
+    {
+      "id": "MOD-ATTENTION-BRIDGE-EXT",
+      "title": "Attention UI bridge extension",
+      "purpose": "Companion attention UI bridge extension and the shared bridge protocol (separate compile units).",
+      "source": {
+        "include": [
+          "extensions/attention-ui-bridge/src/**",
+          "shared/attention-bridge/**"
+        ],
+        "exclude": []
+      },
+      "publicEntrypoints": [
+        "extensions/attention-ui-bridge/src/**",
+        "shared/attention-bridge/**"
+      ],
+      "mayDependOn": [
+        "MOD-AI-SESSION-ATTENTION",
+        "MOD-AI-SESSION-RUNTIME",
+        "MOD-OPEN-WORKSPACE",
+        "MOD-PROJECT-CATALOG",
+        "MOD-WORKSPACE-IDENTITY"
+      ],
+      "roles": [
+        {
+          "role": "composition",
+          "include": [
+            "extensions/attention-ui-bridge/src/extension.ts"
+          ]
+        },
+        {
+          "role": "domain",
+          "include": [
+            "shared/attention-bridge/**"
+          ]
+        },
+        {
+          "role": "infrastructure",
+          "include": [
+            "extensions/attention-ui-bridge/src/localStore.ts",
+            "extensions/attention-ui-bridge/src/bridgeStorageRoot.ts",
+            "extensions/attention-ui-bridge/src/productionAttentionStore.ts",
+            "extensions/attention-ui-bridge/src/openWorkspace*Store.ts"
+          ]
+        },
+        {
+          "role": "application",
+          "include": [
+            "**"
+          ]
+        }
+      ],
+      "productCapabilities": [
+        "MAIN-OPEN-WORKSPACE-PROTOCOL"
+      ]
+    },
+    {
+      "id": "MOD-SHARED-KERNEL",
+      "title": "Shared kernel",
+      "purpose": "Module-bottom shared types, constants, workspace path assignment, and the worktree identity codecs. Depends on nothing at value level; every module may depend on it.",
+      "source": {
+        "include": [
+          "src/models.ts",
+          "src/constants.ts",
+          "src/sessionAssignment.ts",
+          "src/worktreeSessionAssignment.ts",
+          "src/worktreeIdentity.ts"
+        ],
+        "exclude": []
+      },
+      "publicEntrypoints": [
+        "src/models.ts",
+        "src/constants.ts",
+        "src/sessionAssignment.ts",
+        "src/worktreeSessionAssignment.ts",
+        "src/worktreeIdentity.ts"
+      ],
+      "mayDependOn": [
+        "MOD-AI-SESSION-PROVIDER",
+        "MOD-SKILL-MANAGEMENT",
+        "MOD-TODO",
+        "MOD-WORKSPACE-IDENTITY",
+        "MOD-WORKTREE-LIFECYCLE"
+      ],
+      "roles": [
+        {
+          "role": "domain",
+          "include": [
+            "src/models.ts",
+            "src/constants.ts",
+            "src/sessionAssignment.ts",
+            "src/worktreeSessionAssignment.ts",
+            "src/worktreeIdentity.ts"
+          ]
+        }
+      ],
+      "productCapabilities": [
+        "MAIN-WORKSPACE-IDENTITY",
+        "MAIN-WORKTREE-CHANGES-PANEL"
+      ]
+    }
+  ]
 }

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "38b091a8cb6f00e5fcaf085342285a0ba0eda1ba",
+        "head": "32e4d5c3058a0d12a7cb03d9b5b1501d3ead3a6e",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -455,7 +455,9 @@
             "256af5a77c1f758a37421fdf10242cf6d8d9b2ad",
             "e6dff0ec0219113da692140b90183f41228a2a1c",
             "a933a1c989dcd146a4bf6e65f3caad0bc4226dbf",
-            "0cfef2b250d7db4a3056629acf7fc03bd86e99a0"
+            "0cfef2b250d7db4a3056629acf7fc03bd86e99a0",
+            "e9a82b9cb18f3c076e7f605ec4b18b71cf190f32",
+            "4c1385aeed4c77d1e7b9ceca1d63536723c6acd4"
         ]
     },
     "capabilities": [
@@ -2274,7 +2276,8 @@
                 "b6284995ef315fae40d8e1e803b2eb1adacfc650",
                 "e5b496b8f2a345cf704643d473139a2ba87a3e76",
                 "2d133a0a0cb3883d94e5ea2590b1ad9e39b8f927",
-                "c27b66f8efb2dff402e5d1be2969b410fd12023c"
+                "c27b66f8efb2dff402e5d1be2969b410fd12023c",
+                "32e4d5c3058a0d12a7cb03d9b5b1501d3ead3a6e"
             ],
             "behaviors": [
                 "WORKTREE-GROUPS-BASELINE-001",

--- a/scripts/run-architecture-guards.js
+++ b/scripts/run-architecture-guards.js
@@ -342,6 +342,10 @@ function listFiles(root, relativeDirectory, extension) {
 function importModules(sourceFile) {
     return sourceFile.statements
         .filter(ts.isImportDeclaration)
+        // `import type` has no runtime footprint; reachability walks follow
+        // value edges only (a type-only import of a module entrypoint must
+        // not drag the module's runtime into the reachable set).
+        .filter(statement => !statement.importClause || !statement.importClause.isTypeOnly)
         .map(statement => statement.moduleSpecifier)
         .filter(ts.isStringLiteral)
         .map(moduleSpecifier => moduleSpecifier.text);
@@ -353,6 +357,7 @@ function moduleReferences(sourceFile) {
         if (ts.isExportDeclaration(node)
             && node.moduleSpecifier
             && ts.isStringLiteral(node.moduleSpecifier)) {
+            if (node.isTypeOnly) { return; }
             modules.push(node.moduleSpecifier.text);
             return;
         }

--- a/src/aiSessions/commandController.ts
+++ b/src/aiSessions/commandController.ts
@@ -16,7 +16,7 @@ import {
 } from '../workspaces/sessionScope';
 import type { ActiveEditorUri } from '../workspaces/sessionScope';
 import type { OpenWorkspace, RepositoryRootBinding } from '../workspaces/types';
-import type { WorktreeKey, WorktreeSnapshot } from '../worktrees/types';
+import type { WorktreeKey, WorktreeSnapshot } from '../worktrees';
 import { sanitizeAiSessionAlias } from './aliasStore';
 import { normalizeAiSessionProviderSelection } from './providerSelection';
 import type { AiSessionProviderSelection } from './providerSelection';

--- a/src/aiSessions/conversation/composition.ts
+++ b/src/aiSessions/conversation/composition.ts
@@ -56,7 +56,7 @@ import {
 } from './viewerRestoreState';
 import { ConversationWorktreeResolver } from './worktreeResolver';
 import type { ConversationChangesControllerOptions } from './conversationChangesController';
-import { ChangesCollector } from '../../worktrees/changesCollector';
+import { ChangesCollector } from '../../worktrees';
 import { readCodexRolloutTelemetry } from '../codexRolloutWorkdir';
 import CodexRolloutGoalTurnsReader from '../codexRolloutGoalTurns';
 import {

--- a/src/aiSessions/conversation/conversationChangesController.ts
+++ b/src/aiSessions/conversation/conversationChangesController.ts
@@ -7,13 +7,13 @@ import {
     aggregateMemberChanges,
     ChangesCollector,
     MemberChangesSnapshot,
-} from '../../worktrees/changesCollector';
+} from '../../worktrees';
 import type {
     WorktreeGroup,
     WorktreeGroupMember,
-} from '../../worktrees/groupManifestStore';
-import type { RetiredWorktreeIdentity } from '../../worktrees/retiredWorktrees';
-import type { MemberBaseline, WorktreeKey } from '../../worktrees/types';
+} from '../../worktrees';
+import type { RetiredWorktreeIdentity } from '../../worktrees';
+import type { MemberBaseline, WorktreeKey } from '../../worktrees';
 import type {
     ConversationChangesFileItem,
     ConversationChangesMemberView,

--- a/src/aiSessions/conversation/worktreeResolver.ts
+++ b/src/aiSessions/conversation/worktreeResolver.ts
@@ -2,7 +2,7 @@
 
 import { execFile } from 'child_process';
 import * as path from 'path';
-import type { WorktreeKey } from '../../worktrees/types';
+import type { WorktreeKey } from '../../worktrees';
 
 export interface ConversationWorktreeInfo {
     branch: string;

--- a/src/aiSessions/creationController.ts
+++ b/src/aiSessions/creationController.ts
@@ -19,7 +19,7 @@ import type {
     AiSessionRuntimeSnapshot,
 } from './runtimeTypes';
 import type { AiSessionDirectoryScope, SessionProfileDecision, WorkspaceAiSessionActionTarget } from './types';
-import type { WorktreeKey } from '../worktrees/types';
+import type { WorktreeKey } from '../worktrees';
 import type { AiSessionCreationScopeTarget } from './worktreeCreationTarget';
 
 interface AiSessionCreationTarget {

--- a/src/aiSessions/runtimeTypes.ts
+++ b/src/aiSessions/runtimeTypes.ts
@@ -3,8 +3,8 @@
 import * as path from 'path';
 import type { AiSessionProviderId } from '../models';
 import type { AiSessionLaunchSpec } from './launchSpec';
-import type { WorktreeKey } from '../worktrees/types';
-import { cloneWorktreeKey, worktreeKeysEqual } from '../worktrees/types';
+import type { WorktreeKey } from '../worktrees';
+import { cloneWorktreeKey, worktreeKeysEqual } from '../worktrees';
 import type { AiSessionDirectoryScope } from './types';
 import {
     getWorkspaceHostPathComparisonKey,

--- a/src/aiSessions/sessionControllerComposition.ts
+++ b/src/aiSessions/sessionControllerComposition.ts
@@ -6,7 +6,7 @@ import type * as vscode from 'vscode';
 import { isAiSessionProviderId } from '../models';
 import type { AiSessionProviderId } from '../models';
 import type { OpenWorkspace } from '../workspaces/types';
-import type { WorktreeSnapshot } from '../worktrees/types';
+import type { WorktreeSnapshot } from '../worktrees';
 import type { WorkspacePrimaryRootStore } from '../workspaces/primaryRootStore';
 import type { ActiveAiSessionTerminalIdentity } from './activeTerminalHighlight';
 import type AiSessionAliasController from './aliasController';
@@ -26,9 +26,9 @@ import {
     resolveAiSessionWorktreeCreationTarget,
 } from './worktreeCreationTarget';
 import type { AiSessionCreationScopeTarget } from './worktreeCreationTarget';
-import type { WorktreeKey } from '../worktrees/types';
-import type { RetiredWorktreeIdentity } from '../worktrees/retiredWorktrees';
-import { findLatestRetirementForKey } from '../worktrees/retiredWorktrees';
+import type { WorktreeKey } from '../worktrees';
+import type { RetiredWorktreeIdentity } from '../worktrees';
+import { findLatestRetirementForKey } from '../worktrees';
 import type { ProviderDirectoryCapabilityProbe } from './providerDirectoryCapability';
 import { buildAiSessionProviderPicks, getAiSessionProviderLabel } from './providers';
 import type { AiSessionReadCoordinator } from './readCoordinator';

--- a/src/aiSessions/terminalBindingStore.ts
+++ b/src/aiSessions/terminalBindingStore.ts
@@ -2,7 +2,7 @@
 
 import type { AiSessionProviderId } from '../models';
 import type { AiSessionRuntimeIdentity } from './runtimeTypes';
-import type { WorktreeKey } from '../worktrees/types';
+import type { WorktreeKey } from '../worktrees';
 import {
     cloneAiSessionRuntimeIdentity,
     getAiSessionRuntimeIdentityPersistenceFields,

--- a/src/aiSessions/types.ts
+++ b/src/aiSessions/types.ts
@@ -13,11 +13,11 @@ import type { DashboardWorkspaceSearchCatalog } from '../webview/dashboardViewMo
 import type { AiSessionLaunchOptions } from './launchOptions';
 import type { AiSessionLaunchSpec } from './launchSpec';
 import type { AiSessionRuntimeBackendId, AiSessionRuntimeIdentity, AiSessionTmuxLayout } from './runtimeTypes';
-import type { WorktreeKey } from '../worktrees/types';
+import type { WorktreeKey } from '../worktrees';
 import type {
     ProvisioningWorktreeRow,
     WorktreeGitSnapshot,
-} from '../worktrees/types';
+} from '../worktrees';
 
 export interface AiSessionTerminalEntry<TTerminal = unknown> {
     terminal: TTerminal;

--- a/src/aiSessions/worktreeCreationTarget.ts
+++ b/src/aiSessions/worktreeCreationTarget.ts
@@ -7,8 +7,8 @@ import type {
     WorktreeKey,
     WorktreeRepositorySnapshot,
     WorktreeSnapshot,
-} from '../worktrees/types';
-import { worktreeKeysEqual } from '../worktrees/types';
+} from '../worktrees';
+import { worktreeKeysEqual } from '../worktrees';
 
 export interface AiSessionWorktreeCreationCandidate {
     key: WorktreeKey;

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -256,52 +256,52 @@ import {
 } from './sessionAssignment';
 import type { OpenWorkspace } from './workspaces/types';
 import { buildWorkspaceDashboardSearchCatalog } from './webview/dashboardViewModel';
-import { GitWorktreeDiscovery } from './worktrees/gitWorktreeDiscovery';
+import { GitWorktreeDiscovery } from './worktrees';
 import {
     GitApiLike,
     GitRepositoryStateMonitor,
-} from './worktrees/gitRepositoryStateMonitor';
-import { WorktreeMemberLifecycle } from './worktrees/memberLifecycle';
-import { handleMergeWorktreeGroups } from './worktrees/groupMergeHandler';
-import type { MergeWorktreeGroupsPick } from './worktrees/groupMergeHandler';
-import { WorktreeSnapshotCoordinator } from './worktrees/snapshotCoordinator';
-import { worktreeKeysEqual, worktreeKeysMatch, worktreeKeyTombstoneKey } from './worktrees/types';
-import type { WorktreeKey } from './worktrees/types';
-import { WorktreeBaseRefStore } from './worktrees/baseRefStore';
+} from './worktrees';
+import { WorktreeMemberLifecycle } from './worktrees';
+import { handleMergeWorktreeGroups } from './worktrees';
+import type { MergeWorktreeGroupsPick } from './worktrees';
+import { WorktreeSnapshotCoordinator } from './worktrees';
+import { worktreeKeysEqual, worktreeKeysMatch, worktreeKeyTombstoneKey } from './worktrees';
+import type { WorktreeKey } from './worktrees';
+import { WorktreeBaseRefStore } from './worktrees';
 import {
     WorktreeGroupManifestError,
     WorktreeGroupManifestStore,
-} from './worktrees/groupManifestStore';
-import { WorktreeDeletionController } from './worktrees/deletionController';
-import { reconcileWorktreeGroupManifest } from './worktrees/groupManifestReconciliation';
-import { IsolatedSessionController } from './worktrees/isolatedSessionController';
-import { WorktreeProvisioningStore } from './worktrees/provisioningStore';
-import { normalizeWorktreeDirectory } from './worktrees/provisioningPlan';
-import { GitWorktreeProvisioner } from './worktrees/gitWorktreeProvisioner';
+} from './worktrees';
+import { WorktreeDeletionController } from './worktrees';
+import { reconcileWorktreeGroupManifest } from './worktrees';
+import { IsolatedSessionController } from './worktrees';
+import { WorktreeProvisioningStore } from './worktrees';
+import { normalizeWorktreeDirectory } from './worktrees';
+import { GitWorktreeProvisioner } from './worktrees';
 import {
     WorktreeGroupCreationController,
-} from './worktrees/groupCreationController';
+} from './worktrees';
 import {
     createWorktreeGroupFormHandlers,
 } from './dashboard/worktreeGroupFormHandlers';
 import {
     normalizeWorktreeSetupCommand,
     WorktreeSetupRunner,
-} from './worktrees/worktreeSetupRunner';
-import { ManagedWorktreeRemovalController } from './worktrees/managedWorktreeRemovalController';
+} from './worktrees';
+import { ManagedWorktreeRemovalController } from './worktrees';
 import {
     acceptedManagedWorktreeRemovalSettlement,
     parseManagedWorktreeRemovalRequest,
     settledManagedWorktreeRemovalSettlement,
-} from './worktrees/removalProtocol';
+} from './worktrees';
 import {
     acceptedWorktreeGroupPrimarySettlement,
     parseSetWorktreeGroupPrimaryRequest,
     settledWorktreeGroupPrimarySettlement,
-} from './worktrees/groupPrimaryProtocol';
-import type { WorktreeGroupRenameSettlement } from './worktrees/groupRenameProtocol';
-import { handleRenameWorktreeGroup } from './worktrees/groupRenameHandler';
-import { createSettlementReplayCache } from './worktrees/settlementReplayCache';
+} from './worktrees';
+import type { WorktreeGroupRenameSettlement } from './worktrees';
+import { handleRenameWorktreeGroup } from './worktrees';
+import { createSettlementReplayCache } from './worktrees';
 import {
     handleAbandonWorktreeGroupDeletion,
     handleDeleteWorktreeGroupMember,
@@ -309,19 +309,19 @@ import {
     handlePreviewWorktreeGroupDeletion,
     handleRetryWorktreeGroupDeletion,
     WorktreeGroupDeletionHandlerDeps,
-} from './worktrees/groupDeletionHandler';
-import type { WorktreeGroupDeletionSettlement } from './worktrees/groupDeletionProtocol';
+} from './worktrees';
+import type { WorktreeGroupDeletionSettlement } from './worktrees';
 import { fallbackRepositoryLabel } from './workspaces/worktreeGroupProjection';
-import { handleAdoptWorktrees } from './worktrees/groupAdoptHandler';
-import type { WorktreeAdoptSettlement } from './worktrees/groupAdoptProtocol';
-import type { WorktreeGroupMergeSettlement } from './worktrees/groupMergeProtocol';
-import { resolveGenerationClaimDisposition } from './worktrees/generationClaimReconciliation';
+import { handleAdoptWorktrees } from './worktrees';
+import type { WorktreeAdoptSettlement } from './worktrees';
+import type { WorktreeGroupMergeSettlement } from './worktrees';
+import { resolveGenerationClaimDisposition } from './worktrees';
 import {
     acceptedIsolatedSessionSettlement,
     cancelledMutationSettlement,
     parseIsolatedSessionRequest,
     settledIsolatedSessionSettlement,
-} from './worktrees/provisioningProtocol';
+} from './worktrees';
 
 const NEW_AI_SESSION_REFRESH_DELAYS_MS = [250, 1000, 2500, 5000];
 const AI_SESSION_REFRESH_DEBOUNCE_MS = 3000;
@@ -1313,7 +1313,7 @@ async function initializeDashboard(
     const gitWorktreeDiscovery = new GitWorktreeDiscovery({
         getBaseRef: repositoryKey => worktreeBaseRefStore.get(repositoryKey),
     });
-    const getPriorityWorktreeKeys = (): import('./worktrees/types').WorktreeKey[] => [
+    const getPriorityWorktreeKeys = (): import('./worktrees').WorktreeKey[] => [
         ...aiSessionRuntimeCoordinator.getActive(),
         ...aiSessionRuntimeCoordinator.getPending(),
     ].reduce((keys, runtime) => {
@@ -1322,7 +1322,7 @@ async function initializeDashboard(
             keys.push({ ...key });
         }
         return keys;
-    }, [] as import('./worktrees/types').WorktreeKey[]);
+    }, [] as import('./worktrees').WorktreeKey[]);
     const getWorktreePrioritySignature = (): string => JSON.stringify(
         getPriorityWorktreeKeys()
             .map(key => [key.repositoryKey, key.canonicalWorktreePath])
@@ -1450,7 +1450,7 @@ async function initializeDashboard(
             provider: string;
             sessionId: string;
             navigationIdentity: string;
-            worktreeKey?: import('./worktrees/types').WorktreeKey;
+            worktreeKey?: import('./worktrees').WorktreeKey;
         }>();
         let ambiguous = false;
         for (const binding of bindings) {

--- a/src/dashboard/worktreeGroupFormHandlers.ts
+++ b/src/dashboard/worktreeGroupFormHandlers.ts
@@ -1,4 +1,4 @@
-import type { WorktreeGroupCreationController } from '../worktrees/groupCreationController';
+import type { WorktreeGroupCreationController } from '../worktrees';
 import {
     acceptedWorktreeGroupCreationSettlement,
     acceptedWorktreeGroupMemberSettlement,
@@ -8,8 +8,8 @@ import {
     parseWorktreeGroupMemberRequest,
     settledWorktreeGroupCreationSettlement,
     settledWorktreeGroupMemberSettlement,
-} from '../worktrees/groupCreationProtocol';
-import type { WorktreeSnapshot } from '../worktrees/types';
+} from '../worktrees';
+import type { WorktreeSnapshot } from '../worktrees';
 
 export interface WorktreeGroupFormHandlersOptions {
     controller: WorktreeGroupCreationController;

--- a/src/dashboard/worktreeQuickSwitch.ts
+++ b/src/dashboard/worktreeQuickSwitch.ts
@@ -6,8 +6,8 @@ import type {
     ReadyWorktreeRow,
     WorkspaceAiSessionActionTarget,
 } from '../aiSessions/types';
-import type { WorktreeKey } from '../worktrees/types';
-import { worktreeKeysEqual } from '../worktrees/types';
+import type { WorktreeKey } from '../worktrees';
+import { worktreeKeysEqual } from '../worktrees';
 
 export type WorktreeOrSessionSwitchTarget =
     | {

--- a/src/services/gitChangesDiff.ts
+++ b/src/services/gitChangesDiff.ts
@@ -4,7 +4,7 @@ import { execFile } from 'child_process';
 import { existsSync } from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import type { WorkingChangeItem } from '../worktrees/changesCollector';
+import type { WorkingChangeItem } from '../worktrees';
 
 /**
  * Read-only git object content for diff editors (changes-panel PRD §5.3).

--- a/src/webview/dashboardViewModel.ts
+++ b/src/webview/dashboardViewModel.ts
@@ -3,7 +3,7 @@
 import type { AiSessionProviderId, Group, Project } from '../models';
 import type { TodoSearchCatalogItem } from '../todos/types';
 import type { WorktreeActivity, WorktreeRowViewModel } from '../aiSessions/types';
-import type { WorktreeKey } from '../worktrees/types';
+import type { WorktreeKey } from '../worktrees';
 
 export interface DashboardWorkspaceSearchSessionItem {
     key: string;

--- a/src/webview/webviewAiSessionContent.ts
+++ b/src/webview/webviewAiSessionContent.ts
@@ -17,8 +17,8 @@ import type {
     WorktreeRepositoryChip,
     WorktreeRowViewModel,
 } from '../aiSessions/types';
-import { worktreeKeysMatch } from '../worktrees/types';
-import type { ProvisioningWorktreeRow, WorktreeKey } from '../worktrees/types';
+import { worktreeKeysMatch } from '../worktrees';
+import type { ProvisioningWorktreeRow, WorktreeKey } from '../worktrees';
 import { projectAiSessionHistory } from '../aiSessions/historyProjection';
 import { escapeAttribute } from './webviewHtmlEscape';
 import {

--- a/src/workspaces/sessionHydration.ts
+++ b/src/workspaces/sessionHydration.ts
@@ -36,19 +36,19 @@ import {
     buildWorkspaceSessionAttentionIndex,
     getWorkspaceSessionAttention,
 } from './sessionAttention';
-import type { ProvisioningWorktreeRow, WorktreeSnapshot } from '../worktrees/types';
-import type { WorktreeGroup } from '../worktrees/groupManifestStore';
-import type { WorktreeKey } from '../worktrees/types';
+import type { ProvisioningWorktreeRow, WorktreeSnapshot } from '../worktrees';
+import type { WorktreeGroup } from '../worktrees';
+import type { WorktreeKey } from '../worktrees';
 import { mapWorktreeBoundHostPaths } from './sessionScope';
-import type { DeletionJournalEntry } from '../worktrees/deletionJournal';
+import type { DeletionJournalEntry } from '../worktrees';
 import type {
     GenerationClaim,
     RetiredWorktreeIdentity,
-} from '../worktrees/retiredWorktrees';
+} from '../worktrees';
 import {
     findLatestRetirementForPath,
     judgeSessionGeneration,
-} from '../worktrees/retiredWorktrees';
+} from '../worktrees';
 import {
     findGroupMemberWorktreeKeyForPath,
     manifestClaimsWorktreeKey,
@@ -119,7 +119,7 @@ export function getWorkspaceAiSessionCandidatePaths(
 interface AssignedHistory {
     session: CodexSession;
     root: WorkspaceRoot | null;
-    worktreeKey?: import('../worktrees/types').WorktreeKey;
+    worktreeKey?: import('../worktrees').WorktreeKey;
     worktreeUnavailable?: boolean;
 }
 

--- a/src/workspaces/sessionHydrationController.ts
+++ b/src/workspaces/sessionHydrationController.ts
@@ -21,13 +21,13 @@ import type { OpenWorkspace } from './types';
 import { projectWorkspaceActiveSessions } from './activeSessionPresentation';
 import type { WorkspaceActiveSessionPresentation } from './activeSessionPresentation';
 import { getWorkspaceAiSessionCandidatePaths, hydrateWorkspaceAiSessions } from './sessionHydration';
-import type { ProvisioningWorktreeRow, WorktreeSnapshot } from '../worktrees/types';
-import type { WorktreeGroup } from '../worktrees/groupManifestStore';
-import type { DeletionJournalEntry } from '../worktrees/deletionJournal';
+import type { ProvisioningWorktreeRow, WorktreeSnapshot } from '../worktrees';
+import type { WorktreeGroup } from '../worktrees';
+import type { DeletionJournalEntry } from '../worktrees';
 import type {
     GenerationClaim,
     RetiredWorktreeIdentity,
-} from '../worktrees/retiredWorktrees';
+} from '../worktrees';
 
 type HydrationProvider = Pick<AiSessionProviderDefinition, 'id' | 'label' | 'terminalCwdFields'>;
 

--- a/src/workspaces/sessionScope.ts
+++ b/src/workspaces/sessionScope.ts
@@ -10,7 +10,7 @@ import {
     normalizeWorkspaceHostPath,
 } from '../sessionAssignment';
 import type { OpenWorkspace, RepositoryRootBinding, WorkspaceRoot } from './types';
-import type { WorktreeKey } from '../worktrees/types';
+import type { WorktreeKey } from '../worktrees';
 
 export interface ActiveEditorUri {
     fsPath: string;

--- a/src/workspaces/viewModels.ts
+++ b/src/workspaces/viewModels.ts
@@ -11,12 +11,12 @@ import type {
     WorkspaceAiSessionViewModel,
 } from '../aiSessions/types';
 import type { OpenWorkspace } from './types';
-import type { ProvisioningWorktreeRow, WorktreeSnapshot } from '../worktrees/types';
-import { worktreeKeysEqual } from '../worktrees/types';
+import type { ProvisioningWorktreeRow, WorktreeSnapshot } from '../worktrees';
+import { worktreeKeysEqual } from '../worktrees';
 import { isWorkspaceHostPathContained } from '../sessionAssignment';
-import type { WorktreeGroup } from '../worktrees/groupManifestStore';
+import type { WorktreeGroup } from '../worktrees';
 import { buildWorktreeGroupProjection } from './worktreeGroupProjection';
-import type { DeletionJournalEntry } from '../worktrees/deletionJournal';
+import type { DeletionJournalEntry } from '../worktrees';
 
 export interface BuildWorkspaceAiSessionViewModelInput {
     workspace: OpenWorkspace;

--- a/src/workspaces/worktreeGroupProjection.ts
+++ b/src/workspaces/worktreeGroupProjection.ts
@@ -11,20 +11,20 @@ import type {
     WorktreeGroupRowViewModel,
     WorktreeRepositoryChip,
 } from '../aiSessions/types';
-import type { WorktreeGroup, WorktreeGroupMember } from '../worktrees/groupManifestStore';
+import type { WorktreeGroup, WorktreeGroupMember } from '../worktrees';
 import type {
     WorktreeGitSnapshot,
     WorktreeKey,
     WorktreeRepositorySnapshot,
     WorktreeSnapshot,
-} from '../worktrees/types';
-import { worktreeKeysEqual, worktreeKeyToString } from '../worktrees/types';
+} from '../worktrees';
+import { worktreeKeysEqual, worktreeKeyToString } from '../worktrees';
 import type { OpenWorkspace } from './types';
 import {
     isWorkspaceHostPathContained,
     normalizeWorkspaceHostPath,
 } from '../sessionAssignment';
-import type { DeletionJournalEntry } from '../worktrees/deletionJournal';
+import type { DeletionJournalEntry } from '../worktrees';
 
 /**
  * Manifest fallback for history identity (PRD §6.4): a session whose

--- a/src/worktreeSessionAssignment.ts
+++ b/src/worktreeSessionAssignment.ts
@@ -6,7 +6,7 @@ import type {
     WorktreeKey,
     WorktreeRepositorySnapshot,
     WorktreeSnapshot,
-} from './worktrees/types';
+} from './worktrees';
 import { worktreeKeysEqual } from './worktreeIdentity';
 import {
     getWorkspaceHostPathComparisonKey,

--- a/src/worktrees/index.ts
+++ b/src/worktrees/index.ts
@@ -1,0 +1,105 @@
+'use strict';
+
+/**
+ * The only public entrypoint of MOD-WORKTREE-LIFECYCLE (Stage 1B pilot RFC;
+ * ARCH-CHANGE-004). Cross-module consumers import from here, never from the
+ * internal files. The surface is exactly what the composition root and the
+ * sibling modules consume today — widening it is an architecture change.
+ */
+
+// Stores and persistence-bound authorities.
+export { WorktreeGroupManifestStore, WorktreeGroupManifestError } from './groupManifestStore';
+export type { WorktreeGroup, WorktreeGroupMember } from './groupManifestStore';
+export { WorktreeProvisioningStore } from './provisioningStore';
+export { WorktreeBaseRefStore } from './baseRefStore';
+
+// Lifecycle, reconciliation, and settlement primitives.
+export { WorktreeMemberLifecycle } from './memberLifecycle';
+export { reconcileWorktreeGroupManifest } from './groupManifestReconciliation';
+export { resolveGenerationClaimDisposition } from './generationClaimReconciliation';
+export { createSettlementReplayCache } from './settlementReplayCache';
+export {
+    findLatestRetirementForKey,
+    findLatestRetirementForPath,
+    judgeSessionGeneration,
+} from './retiredWorktrees';
+export type { GenerationClaim, RetiredWorktreeIdentity } from './retiredWorktrees';
+export type { DeletionJournalEntry } from './deletionJournal';
+
+// Controllers and coordinators.
+export { WorktreeGroupCreationController } from './groupCreationController';
+export { IsolatedSessionController } from './isolatedSessionController';
+export { WorktreeDeletionController } from './deletionController';
+export { ManagedWorktreeRemovalController } from './managedWorktreeRemovalController';
+export { WorktreeSnapshotCoordinator } from './snapshotCoordinator';
+export { ChangesCollector, aggregateMemberChanges } from './changesCollector';
+export type { MemberChangesSnapshot, WorkingChangeItem } from './changesCollector';
+
+// Git and setup infrastructure.
+export { GitWorktreeProvisioner } from './gitWorktreeProvisioner';
+export { GitWorktreeDiscovery } from './gitWorktreeDiscovery';
+export { GitRepositoryStateMonitor } from './gitRepositoryStateMonitor';
+export type { GitApiLike } from './gitRepositoryStateMonitor';
+export { WorktreeSetupRunner, normalizeWorktreeSetupCommand } from './worktreeSetupRunner';
+export { normalizeWorktreeDirectory } from './provisioningPlan';
+
+// Webview message handlers and their protocol settlements.
+export { handleAdoptWorktrees } from './groupAdoptHandler';
+export type { WorktreeAdoptSettlement } from './groupAdoptProtocol';
+export {
+    handleAbandonWorktreeGroupDeletion,
+    handleDeleteWorktreeGroupMember,
+    handleDiscardWorktreeGenerationClaim,
+    handlePreviewWorktreeGroupDeletion,
+    handleRetryWorktreeGroupDeletion,
+} from './groupDeletionHandler';
+export type { WorktreeGroupDeletionHandlerDeps } from './groupDeletionHandler';
+export type { WorktreeGroupDeletionSettlement } from './groupDeletionProtocol';
+export { handleMergeWorktreeGroups } from './groupMergeHandler';
+export type { MergeWorktreeGroupsPick } from './groupMergeHandler';
+export type { WorktreeGroupMergeSettlement } from './groupMergeProtocol';
+export { handleRenameWorktreeGroup } from './groupRenameHandler';
+export type { WorktreeGroupRenameSettlement } from './groupRenameProtocol';
+export {
+    acceptedWorktreeGroupCreationSettlement,
+    acceptedWorktreeGroupMemberSettlement,
+    parseConfirmWorktreeGroupRequest,
+    parseOpenWorktreeGroupFormRequest,
+    parsePreviewWorktreeGroupRequest,
+    parseWorktreeGroupMemberRequest,
+    settledWorktreeGroupCreationSettlement,
+    settledWorktreeGroupMemberSettlement,
+} from './groupCreationProtocol';
+export {
+    acceptedIsolatedSessionSettlement,
+    cancelledMutationSettlement,
+    parseIsolatedSessionRequest,
+    settledIsolatedSessionSettlement,
+} from './provisioningProtocol';
+export {
+    acceptedWorktreeGroupPrimarySettlement,
+    parseSetWorktreeGroupPrimaryRequest,
+    settledWorktreeGroupPrimarySettlement,
+} from './groupPrimaryProtocol';
+export {
+    acceptedManagedWorktreeRemovalSettlement,
+    parseManagedWorktreeRemovalRequest,
+    settledManagedWorktreeRemovalSettlement,
+} from './removalProtocol';
+
+// Shared types and the canonical WorktreeKey codecs (kernel re-exports).
+export type {
+    MemberBaseline,
+    ProvisioningWorktreeRow,
+    WorktreeGitSnapshot,
+    WorktreeKey,
+    WorktreeRepositorySnapshot,
+    WorktreeSnapshot,
+} from './types';
+export {
+    cloneWorktreeKey,
+    worktreeKeyToString,
+    worktreeKeyTombstoneKey,
+    worktreeKeysEqual,
+    worktreeKeysMatch,
+} from './types';


### PR DESCRIPTION
## Summary

Fixes W1 review Blocker 4 (second half): lands `src/worktrees/index.ts` as the **only** public entrypoint of MOD-WORKTREE-LIFECYCLE, consuming the pre-landed ARCH-CHANGE-004 record (the R3 gate verified it exists in this PR's base).

- New entrypoint re-exports exactly the consumed surface — stores, controllers, handlers, protocol functions, identity codecs, types — nothing more.
- All 22 external consumer files rewired (79 import specifiers + 4 type-position `import()` references, mechanical codemod + manual fix); `publicEntrypoints` narrows from `src/worktrees/**` to the entrypoint; a composition role claims `index.ts`.
- `run-architecture-guards.js`: type-only imports/exports no longer count as runtime reachability in the Codex boundary walk (an `import type` has no runtime footprint; without this, importing a type from an entrypoint would drag the module's fs-touching runtime into the reachable set — a false positive class the entrypoint pattern makes structural).

Deep imports into `src/worktrees/` internals are now **zero**, mechanically enforced by R-ENTRYPOINT.

## Change impact declaration

```change-impact-declaration
{
  "headSha": "6c8b1352d6a5d70129ea942f204059253a8d6792",
  "capabilities": [
    "MAIN-WORKTREE-CHANGES-PANEL"
  ],
  "modules": [
    "MOD-AI-SESSION-CONTROL",
    "MOD-AI-SESSION-CONVERSATION",
    "MOD-AI-SESSION-PROVIDER",
    "MOD-AI-SESSION-RUNTIME",
    "MOD-DASHBOARD-SHELL",
    "MOD-PROJECT-CATALOG",
    "MOD-SHARED-KERNEL",
    "MOD-WORKSPACE-IDENTITY",
    "MOD-WORKTREE-LIFECYCLE"
  ],
  "invariants": [],
  "policyDelta": "re-partition",
  "baselineWaiverDelta": "zero",
  "newFiles": [
    {
      "path": "src/worktrees/index.ts",
      "module": "MOD-WORKTREE-LIFECYCLE",
      "reason": "The module's only public entrypoint (composition role) per the Stage 1B pilot RFC and ARCH-CHANGE-004."
    }
  ]
}
```

## Skill harvest

none — no skill change justified; the guard type-awareness fix is encoded in the guard itself, and the rebase-prune playbook already lives in the publishing skill.

## Verification

- `npm run test-compile` ✅
- `npm run test:deterministic:run` ✅ — unit 1214 + contract 1170 + integration 435, real EXIT=0
- `npm run test:architecture-policy` ✅ — **zero deep imports into worktrees internals**; gate classification: re-partition, authorized by ARCH-CHANGE-004 in base ✅
- `npm run test:architecture-guards` ✅ (153 mutation tests incl. the Codex boundary walk)
- `npm run test:coverage:ci` ✅ — changed-line 100% (154/154), real exit code
- `npm run test:behavior-contracts` ✅ (audit current)
- `git diff --check` ✅
