### PR TITLE
feat(architecture): detect invariant semantic changes precisely (review R9)

### DIFF
--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "32e4d5c3058a0d12a7cb03d9b5b1501d3ead3a6e",
+        "head": "a17fa079dee87f2c359a20903c9bb5e353d303de",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -457,7 +457,8 @@
             "a933a1c989dcd146a4bf6e65f3caad0bc4226dbf",
             "0cfef2b250d7db4a3056629acf7fc03bd86e99a0",
             "e9a82b9cb18f3c076e7f605ec4b18b71cf190f32",
-            "4c1385aeed4c77d1e7b9ceca1d63536723c6acd4"
+            "4c1385aeed4c77d1e7b9ceca1d63536723c6acd4",
+            "6c8b1352d6a5d70129ea942f204059253a8d6792"
         ]
     },
     "capabilities": [
@@ -2320,7 +2321,8 @@
                 "9366094ff487c644d9d44abdd3ad3aed574b573c",
                 "96180ff29ff10eefd1aeb55274027cf5005b2297",
                 "4bec57e837bfc81a04470c057d7d4533588d2edc",
-                "38b091a8cb6f00e5fcaf085342285a0ba0eda1ba"
+                "38b091a8cb6f00e5fcaf085342285a0ba0eda1ba",
+                "a17fa079dee87f2c359a20903c9bb5e353d303de"
             ],
             "behaviors": [
                 "ARCH-POLICY-SCHEMA-001",

--- a/scripts/architecture/architectureChangeRecords.js
+++ b/scripts/architecture/architectureChangeRecords.js
@@ -30,8 +30,8 @@ const ARCH_CHANGE_ID_PATTERN = /^ARCH-CHANGE-[A-Z0-9-]+$/;
 const RECORDS_DIRECTORY = 'docs/architecture/changes/';
 const BLOCK_PATTERN = /```arch-change\s*\r?\n([\s\S]*?)```/;
 
-const DELTA_MAP_KEYS = ['mayDependOnGrown', 'writersGrown'];
-const DELTA_LIST_KEYS = ['baselineGrown', 'waiversAdded'];
+const DELTA_MAP_KEYS = ['mayDependOnGrown'];
+const DELTA_LIST_KEYS = ['baselineGrown', 'waiversAdded', 'invariantChanges'];
 const DELTA_FLAG_KEYS = ['rePartition', 'harnessWeakening'];
 const DELTA_KEYS = [...DELTA_MAP_KEYS, ...DELTA_LIST_KEYS, ...DELTA_FLAG_KEYS];
 
@@ -122,9 +122,9 @@ function parseArchitectureChangeRecord({ path: recordPath, text }) {
 
     const delta = {
         mayDependOnGrown: rawDelta.mayDependOnGrown || {},
-        writersGrown: rawDelta.writersGrown || {},
         baselineGrown: rawDelta.baselineGrown || [],
         waiversAdded: rawDelta.waiversAdded || [],
+        invariantChanges: rawDelta.invariantChanges || [],
         rePartition: rawDelta.rePartition === true,
         harnessWeakening: rawDelta.harnessWeakening === true,
     };
@@ -162,16 +162,18 @@ function missingListEntries(actual, declared, label) {
 /**
  * Does the record's declared delta cover the actual policy delta?
  * coversPolicyDelta(record, actual) -> { covered, missing } where actual is
- * { policyDelta, harnessWeakened, rePartition }.
+ * { policyDelta, harnessWeakened, rePartition, relaxingInvariantIds }.
+ * Invariant coverage is by id: every invariant whose semantic fields changed
+ * (or that was removed) must be declared in the record's invariantChanges.
  */
 function coversPolicyDelta(record, actual) {
-    const { policyDelta, harnessWeakened, rePartition } = actual;
+    const { policyDelta, harnessWeakened, rePartition, relaxingInvariantIds } = actual;
     const { delta } = record;
     const missing = [
         ...missingMapEntries(policyDelta.mayDependOnGrown, delta.mayDependOnGrown, 'mayDependOn broadened'),
-        ...missingMapEntries(policyDelta.writersGrown, delta.writersGrown, 'writers broadened'),
         ...missingListEntries(policyDelta.baselineGrown, delta.baselineGrown, 'baseline grew'),
         ...missingListEntries(policyDelta.waiversAdded, delta.waiversAdded, 'waiver added'),
+        ...missingListEntries(relaxingInvariantIds || [], delta.invariantChanges, 'invariant changed'),
     ];
     if (rePartition && !delta.rePartition) {
         missing.push('registry re-partition not declared');

--- a/scripts/architecture/checkArchitectureChange.js
+++ b/scripts/architecture/checkArchitectureChange.js
@@ -53,7 +53,7 @@ function harnessWeakenedOf(harness) {
  * Change records present in the base. Returns the error list (empty when
  * authorized).
  */
-function authorizeWithBaseRecords(report, classification, harnessWeakened) {
+function authorizeWithBaseRecords(report, classification, harnessWeakened, relaxingInvariantIds) {
     const baseRecords = report.baseRecords || [];
     const candidates = [];
     const invalid = [];
@@ -66,6 +66,7 @@ function authorizeWithBaseRecords(report, classification, harnessWeakened) {
         policyDelta: report.policyDelta,
         harnessWeakened,
         rePartition: classification === 're-partition',
+        relaxingInvariantIds: [...relaxingInvariantIds].sort(),
     };
     let bestMissing = null;
     for (const record of candidates) {
@@ -120,10 +121,19 @@ function classifyArchitectureChange(report) {
 
     const delta = report.policyDelta;
     const grownMayDependOn = Object.keys(delta.mayDependOnGrown).length > 0;
-    const grownWriters = Object.keys(delta.writersGrown).length > 0;
+    // Review R9 (Important 4): only a pure writer removal with an unchanged
+    // authority is tightening; any addition, replacement, authority,
+    // statement, linearization-point, or state-family change is relaxing.
+    const relaxingInvariantIds = Object.entries(delta.invariantChanges || {})
+        .filter(([, change]) => change.writersAdded || change.authorityChanged
+            || change.statementChanged || change.linearizationPointChanged
+            || change.stateFamilyChanged)
+        .map(([id]) => id);
+    const removedInvariants = (delta.invariantsRemoved || []);
     const grownBaseline = delta.baselineGrown.length > 0;
     const addedWaivers = delta.waiversAdded.length > 0;
-    const relaxing = grownMayDependOn || grownWriters || grownBaseline || addedWaivers
+    const relaxing = grownMayDependOn || relaxingInvariantIds.length > 0
+        || removedInvariants.length > 0 || grownBaseline || addedWaivers
         || harnessWeakened;
     const rePartition = !relaxing && delta.modulesChanged
         && report.protectedTouched
@@ -133,7 +143,8 @@ function classifyArchitectureChange(report) {
         return { classification: 'tightening', errors };
     }
     const classification = relaxing ? 'relaxing' : 're-partition';
-    errors.push(...authorizeWithBaseRecords(report, classification, harnessWeakened));
+    errors.push(...authorizeWithBaseRecords(report, classification, harnessWeakened,
+        [...relaxingInvariantIds, ...removedInvariants]));
     return { classification, errors };
 }
 

--- a/scripts/architecture/reportArchitectureDiff.js
+++ b/scripts/architecture/reportArchitectureDiff.js
@@ -165,7 +165,8 @@ function collectArchitectureDiff({ rootDirectory, baseRef, git }) {
 
     const policyDelta = {
         mayDependOnGrown: {},
-        writersGrown: {},
+        invariantChanges: {},
+        invariantsRemoved: [],
         baselineGrown: [],
         waiversAdded: [],
         modulesChanged: false,
@@ -199,21 +200,41 @@ function collectArchitectureDiff({ rootDirectory, baseRef, git }) {
                     changedInvariantIds.push(id);
                     continue;
                 }
-                if (JSON.stringify(baseInvariant) !== JSON.stringify(headInvariant)) {
-                    changedInvariantIds.push(id);
+                const baseJsonText = JSON.stringify(baseInvariant);
+                if (baseJsonText === JSON.stringify(headInvariant)) { continue; }
+                changedInvariantIds.push(id);
+                // Review R9 (Important 4): every semantic field of an
+                // invariant is diffed separately. Only a pure writer removal
+                // with an unchanged authority is a tightening; a same-size
+                // writer replacement, an authority move, or a statement,
+                // linearization-point, or state-family change is a semantic
+                // architecture change and requires a record.
+                const change = {};
+                const writers = diffStringSets(
+                    baseInvariant.writers || [], headInvariant.writers || []);
+                if (writers.added.length > 0) { change.writersAdded = writers.added; }
+                if (writers.removed.length > 0) { change.writersRemoved = writers.removed; }
+                if (JSON.stringify(baseInvariant.authority)
+                    !== JSON.stringify(headInvariant.authority)) {
+                    change.authorityChanged = true;
                 }
-                // Writer sets ratchet by net size: an authority move replaces
-                // old writers with fewer new ones (tightening); only net
-                // growth beyond the base size is broadening.
-                const baseWriters = baseInvariant.writers || [];
-                const headWriters = headInvariant.writers || [];
-                const added = diffStringSets(baseWriters, headWriters).added;
-                if (added.length > 0 && headWriters.length > baseWriters.length) {
-                    policyDelta.writersGrown[id] = added;
+                if (baseInvariant.statement !== headInvariant.statement) {
+                    change.statementChanged = true;
                 }
+                if (baseInvariant.linearizationPoint !== headInvariant.linearizationPoint) {
+                    change.linearizationPointChanged = true;
+                }
+                if (JSON.stringify(baseInvariant.stateFamily)
+                    !== JSON.stringify(headInvariant.stateFamily)) {
+                    change.stateFamilyChanged = true;
+                }
+                policyDelta.invariantChanges[id] = change;
             }
             for (const id of baseInvariants.keys()) {
-                if (!headInvariants.has(id)) { changedInvariantIds.push(id); }
+                if (!headInvariants.has(id)) {
+                    changedInvariantIds.push(id);
+                    policyDelta.invariantsRemoved.push(id);
+                }
             }
         }
         if (protectedPath.endsWith('architecture-debt-baseline.json')) {
@@ -312,9 +333,18 @@ function formatReport(report) {
     for (const [id, edges] of grown) {
         lines.push(`  mayDependOn broadened: ${id} += ${edges.join(', ')}`);
     }
-    const writersGrown = Object.entries(report.policyDelta.writersGrown);
-    for (const [id, writers] of writersGrown) {
-        lines.push(`  writers broadened: ${id} += ${writers.join(', ')}`);
+    for (const [id, change] of Object.entries(report.policyDelta.invariantChanges || {})) {
+        const parts = [];
+        if (change.writersAdded) { parts.push(`writers += ${change.writersAdded.join(', ')}`); }
+        if (change.writersRemoved) { parts.push(`writers -= ${change.writersRemoved.join(', ')}`); }
+        if (change.authorityChanged) { parts.push('authority changed'); }
+        if (change.statementChanged) { parts.push('statement changed'); }
+        if (change.linearizationPointChanged) { parts.push('linearization point changed'); }
+        if (change.stateFamilyChanged) { parts.push('state family changed'); }
+        lines.push(`  invariant changed: ${id} (${parts.join('; ')})`);
+    }
+    for (const id of report.policyDelta.invariantsRemoved || []) {
+        lines.push(`  invariant removed: ${id}`);
     }
     if (report.policyDelta.baselineGrown.length > 0) {
         lines.push(`  baseline grew: ${report.policyDelta.baselineGrown.join(', ')}`);

--- a/tests/unit/architecture/architectureChange.test.js
+++ b/tests/unit/architecture/architectureChange.test.js
@@ -30,7 +30,8 @@ function report(overrides = {}) {
         protectedTouched: [],
         policyDelta: {
             mayDependOnGrown: {},
-            writersGrown: {},
+            invariantChanges: {},
+            invariantsRemoved: [],
             baselineGrown: [],
             waiversAdded: [],
             modulesChanged: false,
@@ -53,7 +54,21 @@ test('ARCH-CHANGE-GATE-001 tightening (baseline shrink) passes without a record'
     const result = classifyArchitectureChange(report({
         protectedTouched: ['.ci/architecture-debt-baseline.json'],
         policyDelta: {
-            mayDependOnGrown: {}, writersGrown: {}, waiversAdded: [],
+            mayDependOnGrown: {}, invariantChanges: {}, invariantsRemoved: [], waiversAdded: [],
+            baselineGrown: [], modulesChanged: true,
+        },
+    }));
+    assert.equal(result.classification, 'tightening');
+    assert.deepEqual(result.errors, []);
+});
+
+test('ARCH-CHANGE-GATE-001 tightening (pure writer removal) passes without a record (review R9)', () => {
+    const result = classifyArchitectureChange(report({
+        protectedTouched: ['docs/testing/architecture-invariants.json'],
+        policyDelta: {
+            mayDependOnGrown: {},
+            invariantChanges: { 'ARCH-X-001': { writersRemoved: ['src/old-writer.ts'] } },
+            invariantsRemoved: [], waiversAdded: [],
             baselineGrown: [], modulesChanged: true,
         },
     }));
@@ -65,7 +80,7 @@ test('ARCH-CHANGE-GATE-001 controlled mutation: baseline growth without a record
     const result = classifyArchitectureChange(report({
         protectedTouched: ['.ci/architecture-debt-baseline.json'],
         policyDelta: {
-            mayDependOnGrown: {}, writersGrown: {}, waiversAdded: [],
+            mayDependOnGrown: {}, invariantChanges: {}, invariantsRemoved: [], waiversAdded: [],
             baselineGrown: ['2:MOD-A->MOD-B'], modulesChanged: true,
         },
     }));
@@ -77,7 +92,7 @@ test('ARCH-CHANGE-GATE-001 controlled mutation: baseline growth without a record
         newFiles: RECORD,
         protectedTouched: ['.ci/architecture-debt-baseline.json'],
         policyDelta: {
-            mayDependOnGrown: {}, writersGrown: {}, waiversAdded: [],
+            mayDependOnGrown: {}, invariantChanges: {}, invariantsRemoved: [], waiversAdded: [],
             baselineGrown: ['2:MOD-A->MOD-B'], modulesChanged: true,
         },
     }));
@@ -90,7 +105,7 @@ test('ARCH-CHANGE-GATE-001 controlled mutation: broadening mayDependOn without a
     const result = classifyArchitectureChange(report({
         protectedTouched: ['docs/testing/architecture-modules.json'],
         policyDelta: {
-            mayDependOnGrown: { 'MOD-A': ['MOD-B'] }, writersGrown: {},
+            mayDependOnGrown: { 'MOD-A': ['MOD-B'] }, invariantChanges: {}, invariantsRemoved: [],
             baselineGrown: [], waiversAdded: [], modulesChanged: true,
         },
     }));
@@ -98,12 +113,64 @@ test('ARCH-CHANGE-GATE-001 controlled mutation: broadening mayDependOn without a
     assert.ok(result.errors.some(error => error.includes('ARCH-CHANGE')));
 });
 
+test('ARCH-CHANGE-GATE-001 controlled mutation: a same-size writer replacement is relaxing (review R9)', () => {
+    const result = classifyArchitectureChange(report({
+        protectedTouched: ['docs/testing/architecture-invariants.json'],
+        policyDelta: {
+            mayDependOnGrown: {},
+            invariantChanges: {
+                'ARCH-X-001': {
+                    writersAdded: ['src/new-writer.ts'],
+                    writersRemoved: ['src/old-writer.ts'],
+                },
+            },
+            invariantsRemoved: [], baselineGrown: [], waiversAdded: [], modulesChanged: true,
+        },
+    }));
+    assert.equal(result.classification, 'relaxing');
+    assert.ok(result.errors.length > 0);
+});
+
+test('ARCH-CHANGE-GATE-001 controlled mutation: authority, statement, and state-family edits are relaxing (review R9)', () => {
+    for (const change of [
+        { authorityChanged: true },
+        { statementChanged: true },
+        { linearizationPointChanged: true },
+        { stateFamilyChanged: true },
+    ]) {
+        const result = classifyArchitectureChange(report({
+            protectedTouched: ['docs/testing/architecture-invariants.json'],
+            policyDelta: {
+                mayDependOnGrown: {},
+                invariantChanges: { 'ARCH-X-001': change },
+                invariantsRemoved: [], baselineGrown: [], waiversAdded: [], modulesChanged: true,
+            },
+        }));
+        assert.equal(result.classification, 'relaxing', JSON.stringify(change));
+        assert.ok(result.errors.length > 0, JSON.stringify(change));
+    }
+});
+
+test('ARCH-CHANGE-GATE-001 controlled mutation: removing an invariant is relaxing (review R9)', () => {
+    const result = classifyArchitectureChange(report({
+        protectedTouched: ['docs/testing/architecture-invariants.json'],
+        policyDelta: {
+            mayDependOnGrown: {}, invariantChanges: {},
+            invariantsRemoved: ['ARCH-X-001'],
+            baselineGrown: [], waiversAdded: [], modulesChanged: true,
+        },
+    }));
+    assert.equal(result.classification, 'relaxing');
+    assert.ok(result.errors.length > 0);
+});
+
 test('ARCH-CHANGE-GATE-001 controlled mutation: growing a writer set without a record fails', () => {
     const result = classifyArchitectureChange(report({
         protectedTouched: ['docs/testing/architecture-invariants.json'],
         policyDelta: {
-            mayDependOnGrown: {}, writersGrown: { 'ARCH-X-001': ['src/new-writer.ts'] },
-            baselineGrown: [], waiversAdded: [], modulesChanged: true,
+            mayDependOnGrown: {},
+            invariantChanges: { 'ARCH-X-001': { writersAdded: ['src/new-writer.ts'] } },
+            invariantsRemoved: [], baselineGrown: [], waiversAdded: [], modulesChanged: true,
         },
     }));
     assert.equal(result.classification, 'relaxing');
@@ -114,7 +181,7 @@ test('ARCH-CHANGE-GATE-001 controlled mutation: adding a waiver without a record
     const result = classifyArchitectureChange(report({
         protectedTouched: ['docs/testing/architecture-waivers.json'],
         policyDelta: {
-            mayDependOnGrown: {}, writersGrown: {},
+            mayDependOnGrown: {}, invariantChanges: {}, invariantsRemoved: [],
             baselineGrown: [], waiversAdded: ['ARCH-WAIVER-009'], modulesChanged: true,
         },
     }));
@@ -126,7 +193,7 @@ test('ARCH-CHANGE-GATE-001 controlled mutation: registry re-partition without a 
     const result = classifyArchitectureChange(report({
         protectedTouched: ['docs/testing/architecture-modules.json'],
         policyDelta: {
-            mayDependOnGrown: {}, writersGrown: {},
+            mayDependOnGrown: {}, invariantChanges: {}, invariantsRemoved: [],
             baselineGrown: [], waiversAdded: [], modulesChanged: true,
         },
     }));
@@ -138,7 +205,7 @@ test('ARCH-CHANGE-GATE-001 controlled mutation: registry re-partition without a 
         newFiles: RECORD,
         protectedTouched: ['docs/testing/architecture-modules.json'],
         policyDelta: {
-            mayDependOnGrown: {}, writersGrown: {},
+            mayDependOnGrown: {}, invariantChanges: {}, invariantsRemoved: [],
             baselineGrown: [], waiversAdded: [], modulesChanged: true,
         },
     }));
@@ -293,7 +360,8 @@ test('ARCH-CHANGE-GATE-001 formatReport renders every delta section', () => {
         baseRecords: [{ path: 'docs/architecture/changes/ARCH-CHANGE-001.md', text: 'x' }],
         policyDelta: {
             mayDependOnGrown: { 'MOD-ALPHA': ['MOD-BETA'] },
-            writersGrown: { 'ARCH-X-001': ['src/writer.ts'] },
+            invariantChanges: { 'ARCH-X-001': { writersAdded: ['src/writer.ts'] } },
+            invariantsRemoved: [],
             baselineGrown: ['2:MOD-A->MOD-B'],
             waiversAdded: ['ARCH-WAIVER-009'],
             modulesChanged: true,
@@ -302,7 +370,7 @@ test('ARCH-CHANGE-GATE-001 formatReport renders every delta section', () => {
     for (const fragment of [
         'MOD-ALPHA', 'src/alpha/new.ts', 'src/alpha/old.ts',
         'architecture-modules.json', 'mayDependOn broadened: MOD-ALPHA += MOD-BETA',
-        'writers broadened: ARCH-X-001 += src/writer.ts',
+        'invariant changed: ARCH-X-001 (writers += src/writer.ts)',
         'baseline grew: 2:MOD-A->MOD-B', 'waivers added: ARCH-WAIVER-009',
         'architecture change records in base: 1',
     ]) {
@@ -372,19 +440,46 @@ test('ARCH-CHANGE-GATE-001 the policy delta covers invariants, baseline, and wai
         { version: 1, rules: { 'module-cycle': { fingerprints: ['2:MOD-A->MOD-B'] } } });
 
     const report = collectArchitectureDiff({ rootDirectory: root, baseRef: 'base', git });
-    assert.deepEqual(report.policyDelta.writersGrown, { 'ARCH-TEST-001': ['src/alpha/b.ts'] });
+    assert.deepEqual(report.policyDelta.invariantChanges, {
+        'ARCH-TEST-001': { writersAdded: ['src/alpha/b.ts'] },
+    });
     assert.deepEqual(report.policyDelta.waiversAdded, ['ARCH-WAIVER-009']);
     assert.deepEqual(report.policyDelta.baselineGrown, ['2:MOD-A->MOD-B']);
 
-    // An authority move (writer set shrinks while gaining the new authority
-    // file) is tightening, not broadening.
+    // Review R9 (Important 4): a same-size writer replacement is a semantic
+    // change, not a tightening — only a pure removal with an unchanged
+    // authority shrinks the writer set.
     write('docs/testing/architecture-invariants.json', {
         version: 1,
         invariants: [{ ...invariant, writers: ['src/alpha/coordinator.ts'] }],
     });
     const moved = collectArchitectureDiff({ rootDirectory: root, baseRef: 'base', git });
-    assert.deepEqual(moved.policyDelta.writersGrown, {},
-        'a shrunk writer set with a replacement is not broadening');
+    assert.deepEqual(moved.policyDelta.invariantChanges, {
+        'ARCH-TEST-001': {
+            writersAdded: ['src/alpha/coordinator.ts'],
+            writersRemoved: ['src/alpha/a.ts'],
+        },
+    }, 'a replaced writer is detected as change, never silently tightening');
+    write('docs/testing/architecture-invariants.json', {
+        version: 1,
+        invariants: [{ ...invariant, writers: [] }],
+    });
+    const shrunk = collectArchitectureDiff({ rootDirectory: root, baseRef: 'base', git });
+    assert.deepEqual(shrunk.policyDelta.invariantChanges, {
+        'ARCH-TEST-001': { writersRemoved: ['src/alpha/a.ts'] },
+    }, 'a pure writer removal is the only tightening form');
+    // Authority, statement, and removal detection.
+    write('docs/testing/architecture-invariants.json', {
+        version: 1,
+        invariants: [{ ...invariant, authority: { path: 'src/alpha/a.ts', symbol: 'b' } }],
+    });
+    const authorityMoved = collectArchitectureDiff({ rootDirectory: root, baseRef: 'base', git });
+    assert.deepEqual(authorityMoved.policyDelta.invariantChanges, {
+        'ARCH-TEST-001': { authorityChanged: true },
+    });
+    write('docs/testing/architecture-invariants.json', { version: 1, invariants: [] });
+    const removed = collectArchitectureDiff({ rootDirectory: root, baseRef: 'base', git });
+    assert.deepEqual(removed.policyDelta.invariantsRemoved, ['ARCH-TEST-001']);
 });
 
 test('ARCH-CHANGE-GATE-001 the harness delta detects removed guard ids, invocations, and shrunk mutation tests', () => {
@@ -480,7 +575,8 @@ function relaxingReport({ delta = {}, baseRecords = [], newFiles = [] } = {}) {
         protectedTouched: ['docs/testing/architecture-modules.json'],
         policyDelta: {
             mayDependOnGrown: { 'MOD-A': ['MOD-B'] },
-            writersGrown: {}, baselineGrown: [], waiversAdded: [],
+            invariantChanges: {}, invariantsRemoved: [],
+            baselineGrown: [], waiversAdded: [],
             modulesChanged: true,
             ...delta,
         },
@@ -498,8 +594,8 @@ test('ARCH-CHANGE-GATE-001 parser accepts a valid machine-summary block and appl
     assert.equal(record.status, 'approved');
     assert.deepEqual(record.modules, ['MOD-A']);
     assert.deepEqual(record.delta, {
-        mayDependOnGrown: {}, writersGrown: {}, baselineGrown: [],
-        waiversAdded: [], rePartition: false, harnessWeakening: false,
+        mayDependOnGrown: {}, baselineGrown: [],
+        waiversAdded: [], invariantChanges: [], rePartition: false, harnessWeakening: false,
     });
 });
 
@@ -576,7 +672,7 @@ test('ARCH-CHANGE-GATE-001 a re-partition requires a record declaring rePartitio
     const rePartitionReport = delta => report({
         protectedTouched: ['docs/testing/architecture-modules.json'],
         policyDelta: {
-            mayDependOnGrown: {}, writersGrown: {}, baselineGrown: [],
+            mayDependOnGrown: {}, invariantChanges: {}, invariantsRemoved: [], baselineGrown: [],
             waiversAdded: [], modulesChanged: true,
         },
         baseRecords: [{ path: RECORD_PATH, text: recordMarkdown({ delta }) }],
@@ -618,7 +714,7 @@ test('ARCH-CHANGE-GATE-001 coversPolicyDelta checks every delta dimension', () =
         text: recordMarkdown({
             delta: {
                 mayDependOnGrown: { 'MOD-A': ['MOD-B'] },
-                writersGrown: { 'ARCH-X-001': ['src/writer.ts'] },
+                invariantChanges: ['ARCH-X-001'],
                 baselineGrown: ['2:MOD-A->MOD-B'],
                 waiversAdded: ['ARCH-WAIVER-009'],
                 rePartition: true,
@@ -626,24 +722,46 @@ test('ARCH-CHANGE-GATE-001 coversPolicyDelta checks every delta dimension', () =
             },
         }),
     }).record;
-    const actualFor = overrides => ({
+    const actualFor = (overrides, relaxingInvariantIds = []) => ({
         policyDelta: {
-            mayDependOnGrown: {}, writersGrown: {}, baselineGrown: [],
+            mayDependOnGrown: {}, invariantChanges: {}, invariantsRemoved: [], baselineGrown: [],
             waiversAdded: [], modulesChanged: true,
             ...overrides,
         },
         harnessWeakened: false,
         rePartition: false,
+        relaxingInvariantIds,
     });
     assert.equal(coversPolicyDelta(record, actualFor({ mayDependOnGrown: { 'MOD-A': ['MOD-B'] } })).covered, true);
     assert.equal(coversPolicyDelta(record, actualFor({ mayDependOnGrown: { 'MOD-A': ['MOD-Z'] } })).covered, false);
-    assert.equal(coversPolicyDelta(record, actualFor({ writersGrown: { 'ARCH-X-001': ['src/other.ts'] } })).covered, false);
+    assert.equal(coversPolicyDelta(record, actualFor({}, ['ARCH-X-001'])).covered, true);
+    assert.equal(coversPolicyDelta(record, actualFor({}, ['ARCH-X-002'])).covered, false);
     assert.equal(coversPolicyDelta(record, actualFor({ baselineGrown: ['2:MOD-X->MOD-Y'] })).covered, false);
     assert.equal(coversPolicyDelta(record, actualFor({ waiversAdded: ['ARCH-WAIVER-010'] })).covered, false);
     assert.equal(coversPolicyDelta(record, { ...actualFor({}), rePartition: false }).covered, true);
     assert.equal(coversPolicyDelta(
         parseArchitectureChangeRecord({ path: RECORD_PATH, text: recordMarkdown() }).record,
         { ...actualFor({}), rePartition: true }).covered, false);
+});
+
+test('ARCH-CHANGE-GATE-001 an invariant semantic change is covered only by a declared invariantChanges entry (review R9)', () => {
+    const invariantReport = (change, recordDelta) => classifyArchitectureChange(report({
+        protectedTouched: ['docs/testing/architecture-invariants.json'],
+        policyDelta: {
+            mayDependOnGrown: {},
+            invariantChanges: { 'ARCH-X-001': change },
+            invariantsRemoved: [],
+            baselineGrown: [], waiversAdded: [], modulesChanged: true,
+        },
+        baseRecords: [{ path: RECORD_PATH, text: recordMarkdown({ delta: recordDelta }) }],
+    }));
+    const covered = invariantReport({ authorityChanged: true }, { invariantChanges: ['ARCH-X-001'] });
+    assert.deepEqual(covered.errors, []);
+    const uncovered = invariantReport({ authorityChanged: true }, { invariantChanges: ['ARCH-X-002'] });
+    assert.ok(uncovered.errors.some(error => error.includes('invariant changed: ARCH-X-001')),
+        JSON.stringify(uncovered.errors));
+    const undeclared = invariantReport({ authorityChanged: true }, {});
+    assert.ok(undeclared.errors.length > 0);
 });
 
 test('ARCH-CHANGE-GATE-001 collectArchitectureDiff reads records from the base ref only', () => {


### PR DESCRIPTION
## Summary

Fixes W1 review Important 4 (detection half): the policy delta only ratcheted writer-set **net growth**, so an authority/writer replacement (same size, different identity) was misclassified as tightening, and statement, linearization-point, state-family, and invariant-removal edits were invisible to the gate.

- `reportArchitectureDiff` now diffs every semantic field per invariant: `writersAdded`/`writersRemoved`, `authorityChanged`, `statementChanged`, `linearizationPointChanged`, `stateFamilyChanged`, plus `invariantsRemoved`.
- Classification: only a **pure writer removal with an unchanged authority** is tightening; every other semantic change is relaxing and requires a base-landed record. The previously pinned "authority move is tightening" behavior is inverted (the review names the old test as wrong).
- Record schema gains `invariantChanges` (declared invariant ids); the coverage check maps every relaxing invariant id against it.
- The stale-authority corrections (review Important 3) land separately after their record — see below.

## Change impact declaration

```change-impact-declaration
{
  "headSha": "241dcc68f3da26e521913bb68039155dd80a3824",
  "capabilities": [
    "MAIN-ARCHITECTURE-HARNESS"
  ],
  "modules": [],
  "invariants": [],
  "policyDelta": "tightening",
  "baselineWaiverDelta": "zero",
  "newFiles": []
}
```
```

## Skill harvest

none — no skill change justified; the slice followed the established review-fix-commit loop.

## Verification

- `node --test 'tests/unit/architecture/**/*.test.js'` — 115/115 ✅ (new mutations: writer replacement, authority/statement/state-family edits, invariant removal, record coverage by invariantChanges)
- `npm run test:architecture-policy` ✅ (gate self-classification: tightening)
- `npm run test:coverage:ci` ✅ — changed-line 92.65% (63/68), real exit code
- `npm run test:behavior-contracts` ✅
- `git diff --check` ✅
