### PR TITLE
feat(architecture): validate invariant authorities against reality (review R9)

### DIFF
--- a/docs/testing/architecture-invariants.json
+++ b/docs/testing/architecture-invariants.json
@@ -103,6 +103,9 @@
             "evidence": [
                 "src/aiSessions/creationController.ts",
                 "src/worktrees/groupManifestStore.ts"
+            ],
+            "participatingModules": [
+                "MOD-AI-SESSION-CONTROL"
             ]
         },
         {
@@ -248,7 +251,7 @@
             "kind": "identity",
             "statement": "Domain identities (WorktreeKey, composite session identity, safe ids) use one canonical codec and equality policy owned by the domain layer; persisted encodings stay stable per usage context.",
             "authority": {
-                "path": "src/worktrees/types.ts",
+                "path": "src/worktreeIdentity.ts",
                 "symbol": "worktreeKeysEqual"
             },
             "writers": [],
@@ -262,7 +265,10 @@
             ],
             "guardOwners": [],
             "evidence": [
-                "src/worktrees/types.ts"
+                "src/worktreeIdentity.ts"
+            ],
+            "participatingModules": [
+                "MOD-SHARED-KERNEL"
             ]
         },
         {

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "a17fa079dee87f2c359a20903c9bb5e353d303de",
+        "head": "fffb1cc98b31298695c4d6c59361bf4899e582b8",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -458,7 +458,9 @@
             "0cfef2b250d7db4a3056629acf7fc03bd86e99a0",
             "e9a82b9cb18f3c076e7f605ec4b18b71cf190f32",
             "4c1385aeed4c77d1e7b9ceca1d63536723c6acd4",
-            "6c8b1352d6a5d70129ea942f204059253a8d6792"
+            "6c8b1352d6a5d70129ea942f204059253a8d6792",
+            "241dcc68f3da26e521913bb68039155dd80a3824",
+            "bea6bb114a3d18e8c3025d43c15dbf8a90a9c1a9"
         ]
     },
     "capabilities": [
@@ -2322,7 +2324,8 @@
                 "96180ff29ff10eefd1aeb55274027cf5005b2297",
                 "4bec57e837bfc81a04470c057d7d4533588d2edc",
                 "38b091a8cb6f00e5fcaf085342285a0ba0eda1ba",
-                "a17fa079dee87f2c359a20903c9bb5e353d303de"
+                "a17fa079dee87f2c359a20903c9bb5e353d303de",
+                "fffb1cc98b31298695c4d6c59361bf4899e582b8"
             ],
             "behaviors": [
                 "ARCH-POLICY-SCHEMA-001",

--- a/scripts/architecture/checkArchitectureChange.js
+++ b/scripts/architecture/checkArchitectureChange.js
@@ -127,7 +127,7 @@ function classifyArchitectureChange(report) {
     const relaxingInvariantIds = Object.entries(delta.invariantChanges || {})
         .filter(([, change]) => change.writersAdded || change.authorityChanged
             || change.statementChanged || change.linearizationPointChanged
-            || change.stateFamilyChanged)
+            || change.stateFamilyChanged || change.participatingModulesChanged)
         .map(([id]) => id);
     const removedInvariants = (delta.invariantsRemoved || []);
     const grownBaseline = delta.baselineGrown.length > 0;

--- a/scripts/architecture/checkSingleWriters.js
+++ b/scripts/architecture/checkSingleWriters.js
@@ -35,6 +35,33 @@ const KINDS = ['product', 'state-machine', 'identity', 'persistence', 'protocol'
     'concurrency', 'recovery', 'dependency', 'performance', 'security'];
 const ENFORCEMENTS = ['module-boundary', 'single-writer', 'behavior', 'fault-matrix'];
 
+/** Top-level exported symbol names defined (never merely re-exported) in a file. */
+function definedExportedSymbols(rootDirectory, relativePath) {
+    const text = fs.readFileSync(path.join(rootDirectory, relativePath), 'utf8');
+    const sourceFile = ts.createSourceFile(
+        relativePath, text, ts.ScriptTarget.Latest, true,
+        relativePath.endsWith('.js') ? ts.ScriptKind.JS : ts.ScriptKind.TS);
+    const defined = new Set();
+    const isExported = node => node.modifiers
+        && node.modifiers.some(modifier => modifier.kind === ts.SyntaxKind.ExportKeyword);
+    const visit = node => {
+        if (isExported(node) && node.name && ts.isIdentifier(node.name)
+            && (ts.isClassDeclaration(node) || ts.isFunctionDeclaration(node)
+                || ts.isInterfaceDeclaration(node) || ts.isTypeAliasDeclaration(node)
+                || ts.isEnumDeclaration(node))) {
+            defined.add(node.name.text);
+        }
+        if (ts.isVariableStatement(node) && isExported(node)) {
+            for (const declaration of node.declarationList.declarations) {
+                if (ts.isIdentifier(declaration.name)) { defined.add(declaration.name.text); }
+            }
+        }
+        ts.forEachChild(node, visit);
+    };
+    visit(sourceFile);
+    return defined;
+}
+
 function readJson(rootDirectory, relativePath, errors) {
     try {
         return JSON.parse(fs.readFileSync(path.join(rootDirectory, relativePath), 'utf8'));
@@ -99,6 +126,34 @@ function validateCatalog(rootDirectory, policy) {
             errors.push(`${owner}: authority.path is required`);
         } else {
             requirePath(owner, invariant.authority.path, 'authority.path');
+            // Review R9 (Important 3): the authority symbol must be defined
+            // in the authority file — a re-export is not an authority — and
+            // the file's module must be the invariant's module or an
+            // explicitly declared participant.
+            if (typeof invariant.authority.symbol === 'string' && invariant.authority.symbol
+                && fs.existsSync(path.join(rootDirectory, invariant.authority.path))) {
+                const defined = definedExportedSymbols(rootDirectory, invariant.authority.path);
+                if (!defined.has(invariant.authority.symbol)) {
+                    errors.push(`${owner}: authority.symbol '${invariant.authority.symbol}' is not `
+                        + `defined in ${invariant.authority.path} (a re-export is not an authority)`);
+                }
+            }
+            const authorityModule = policy.classification.get(invariant.authority.path)?.moduleId;
+            const participants = invariant.participatingModules || [];
+            if (authorityModule && authorityModule !== invariant.module
+                && !participants.includes(authorityModule)) {
+                errors.push(`${owner}: authority path ${invariant.authority.path} belongs to `
+                    + `${authorityModule}, not ${invariant.module} — declare the cross-module `
+                    + 'participation in participatingModules');
+            }
+        }
+        if (invariant.participatingModules !== undefined) {
+            if (!Array.isArray(invariant.participatingModules)
+                || invariant.participatingModules.length === 0
+                || invariant.participatingModules.some(moduleId => !moduleIds.has(moduleId))) {
+                errors.push(`${owner}: participatingModules must be a non-empty array of known `
+                    + 'module ids');
+            }
         }
         for (const enforcement of invariant.enforcement || []) {
             if (!ENFORCEMENTS.includes(enforcement)) {

--- a/scripts/architecture/reportArchitectureDiff.js
+++ b/scripts/architecture/reportArchitectureDiff.js
@@ -228,6 +228,10 @@ function collectArchitectureDiff({ rootDirectory, baseRef, git }) {
                     !== JSON.stringify(headInvariant.stateFamily)) {
                     change.stateFamilyChanged = true;
                 }
+                if (JSON.stringify(baseInvariant.participatingModules)
+                    !== JSON.stringify(headInvariant.participatingModules)) {
+                    change.participatingModulesChanged = true;
+                }
                 policyDelta.invariantChanges[id] = change;
             }
             for (const id of baseInvariants.keys()) {

--- a/tests/unit/architecture/singleWriters.test.js
+++ b/tests/unit/architecture/singleWriters.test.js
@@ -12,24 +12,27 @@ const {
 
 const repoRoot = path.resolve(__dirname, '..', '..', '..');
 
-function makeFixture({ invariants, sources }) {
+function makeFixture({ invariants, sources, twoModules = false }) {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'arch-writers-'));
     const writeJson = (relative, value) => {
         fs.mkdirSync(path.join(root, path.dirname(relative)), { recursive: true });
         fs.writeFileSync(path.join(root, relative), JSON.stringify(value, null, 2));
     };
+    const moduleEntry = (id, glob) => ({
+        id,
+        title: id,
+        purpose: 'fixture',
+        source: { include: [glob], exclude: [] },
+        mayDependOn: [],
+        roles: [{ role: 'application', include: [glob] }],
+        productCapabilities: ['MAIN-TEST-001'],
+    });
     writeJson('docs/testing/architecture-modules.json', {
         version: 1,
         scope: { roots: ['src'] },
-        modules: [{
-            id: 'MOD-ALPHA',
-            title: 'Alpha',
-            purpose: 'fixture',
-            source: { include: ['src/**'], exclude: [] },
-            mayDependOn: [],
-            roles: [{ role: 'application', include: ['src/**'] }],
-            productCapabilities: ['MAIN-TEST-001'],
-        }],
+        modules: twoModules
+            ? [moduleEntry('MOD-ALPHA', 'src/alpha/**'), moduleEntry('MOD-BETA', 'src/beta/**')]
+            : [moduleEntry('MOD-ALPHA', 'src/**')],
     });
     writeJson('docs/testing/main-capability-coverage.json', {
         version: 1, capabilities: [{ id: 'MAIN-TEST-001' }],
@@ -274,4 +277,69 @@ test('ARCH-INVARIANT-CATALOG-001 controlled mutation: malformed persistenceKeys 
     });
     assert.ok(runSingleWriterCheck(stale).errors
         .some(error => error.includes('persistence key') && error.includes('does not appear')));
+});
+
+
+// ── review R9: authority rigor (Important 3) ─────────────────────────
+
+const twoModuleSources = {
+    'src/alpha/store.ts': 'export class Store { writeThing() {} }\n',
+    'src/alpha/writer.ts': 'import { Store } from \'./store\';\nexport const run = (s: Store) => s.writeThing();\n',
+    'src/beta/kernel.ts': 'export function sharedCodec() { return 1; }\n',
+    'src/beta/reExports.ts': 'export { sharedCodec } from \'./kernel\';\n',
+};
+
+function twoModuleInvariant(overrides = {}) {
+    return validInvariant({
+        authority: { path: 'src/beta/kernel.ts', symbol: 'sharedCodec' },
+        writers: ['src/alpha/writer.ts'],
+        participatingModules: ['MOD-BETA'],
+        behaviorOwners: ['src/alpha/store.ts'],
+        evidence: ['src/alpha/store.ts'],
+        stateFamily: { storePath: 'src/alpha/store.ts', writeMethods: ['writeThing'] },
+        ...overrides,
+    });
+}
+
+test('ARCH-INVARIANT-CATALOG-001 a declared cross-module authority passes', () => {
+    const root = makeFixture({
+        invariants: [twoModuleInvariant()],
+        sources: twoModuleSources,
+        twoModules: true,
+    });
+    assert.deepEqual(runSingleWriterCheck(root).errors, []);
+});
+
+test('ARCH-INVARIANT-CATALOG-001 controlled mutation: a re-exported authority symbol fails', () => {
+    const root = makeFixture({
+        invariants: [twoModuleInvariant({
+            authority: { path: 'src/beta/reExports.ts', symbol: 'sharedCodec' },
+        })],
+        sources: twoModuleSources,
+        twoModules: true,
+    });
+    assert.ok(runSingleWriterCheck(root).errors
+        .some(error => error.includes('reExports.ts') && error.includes('re-export is not an authority')));
+});
+
+test('ARCH-INVARIANT-CATALOG-001 controlled mutation: an undeclared cross-module authority fails', () => {
+    const invariant = twoModuleInvariant();
+    delete invariant.participatingModules;
+    const root = makeFixture({
+        invariants: [invariant],
+        sources: twoModuleSources,
+        twoModules: true,
+    });
+    assert.ok(runSingleWriterCheck(root).errors
+        .some(error => error.includes('MOD-BETA') && error.includes('participatingModules')));
+});
+
+test('ARCH-INVARIANT-CATALOG-001 controlled mutation: an unknown participating module fails', () => {
+    const root = makeFixture({
+        invariants: [twoModuleInvariant({ participatingModules: ['MOD-NOPE'] })],
+        sources: twoModuleSources,
+        twoModules: true,
+    });
+    assert.ok(runSingleWriterCheck(root).errors
+        .some(error => error.includes('participatingModules must be a non-empty array')));
 });


### PR DESCRIPTION
## Summary

Consumes ARCH-CHANGE-005 (merged in #280). Fixes W1 review Important 3: the invariant catalog only verified that `authority.path` exists, so authorities went stale as code moved.

- Catalog now validates: the authority **symbol must be defined** (not re-exported) in the authority file (AST check), and the file's module must be the invariant's module or an explicitly declared `participatingModules` entry (new catalog field, validated against the registry).
- Stale corrections: `ARCH-WORKTREE-IDENTITY-CODEC-001` authority → `src/worktreeIdentity.ts / worktreeKeysEqual` (+ MOD-SHARED-KERNEL participant); `ARCH-WORKTREE-CLAIM-ORDER-001` declares MOD-AI-SESSION-CONTROL as the authority's participant.
- `participatingModules` joins the policy-delta semantic fields so it cannot change invisibly.

## Change impact declaration

```change-impact-declaration
{
  "headSha": "4db1b31c291c9db57628d87a1bee872cfcfaeea1",
  "capabilities": [
    "MAIN-ARCHITECTURE-HARNESS"
  ],
  "modules": [],
  "invariants": [
    "ARCH-WORKTREE-CLAIM-ORDER-001",
    "ARCH-WORKTREE-IDENTITY-CODEC-001"
  ],
  "policyDelta": "relaxing",
  "baselineWaiverDelta": "zero",
  "newFiles": []
}
```

## Skill harvest

none — no skill change justified; the slice followed the established review-fix-commit loop.

## Verification

- `node --test 'tests/unit/architecture/**/*.test.js'` — 119/119 ✅ (new mutations: re-exported authority, undeclared cross-module authority, unknown participant, declared cross-module pass)
- `node scripts/architecture/checkSingleWriters.js` on the real catalog: both stale authorities caught before the fix, green after ✅
- Gate classification: relaxing, authorized by ARCH-CHANGE-005 in base (verified on the exact PR head) ✅
- `npm run test-compile` ✅ / `git diff --check` ✅
