### PR TITLE
feat(architecture): close the entrypoint fail-open and complete the program ledger (review R9)

### DIFF
--- a/docs/testing/architecture-program.json
+++ b/docs/testing/architecture-program.json
@@ -1,27 +1,122 @@
 {
-    "version": 1,
-    "title": "Architecture program ledger",
-    "notes": [
-        "Module states follow legacy -> inventoried -> characterized -> guarded -> migrating -> strict (charter Section 8.5).",
-        "strict is validated mechanically by scripts/architecture/checkProgramLedger.js: no baseline fingerprint or waiver naming the module, P0/P1 invariants have behavior owners, single-writer families declare writers, and the module stays classified exact-once.",
-        "SCC cluster membership is cluster-level debt and does not block per-module strict (waiver ledger note)."
-    ],
-    "states": [
-        "legacy",
-        "inventoried",
-        "characterized",
-        "guarded",
-        "migrating",
-        "strict"
-    ],
-    "modules": {
-        "MOD-WORKTREE-LIFECYCLE": {
-            "state": "migrating",
-            "since": "pilot slices S1-S5 (PRs #262-#268); strict declaration #269 reverted per W1 review",
-            "evidence": [
-                "docs/architecture/stage-1b-pilot-rfc.md"
-            ],
-            "nextAction": "W1 review repair R1-R10, then strict re-acceptance"
-        }
+  "version": 1,
+  "title": "Architecture program ledger",
+  "notes": [
+    "Module states follow legacy -> inventoried -> characterized -> guarded -> migrating -> strict (charter Section 8.5).",
+    "strict is validated mechanically by scripts/architecture/checkProgramLedger.js: no baseline fingerprint or waiver naming the module, P0/P1 invariants have behavior owners, single-writer families declare writers, and the module stays classified exact-once.",
+    "SCC cluster membership is cluster-level debt and does not block per-module strict (waiver ledger note)."
+  ],
+  "states": [
+    "legacy",
+    "inventoried",
+    "characterized",
+    "guarded",
+    "migrating",
+    "strict"
+  ],
+  "modules": {
+    "MOD-WORKTREE-LIFECYCLE": {
+      "state": "migrating",
+      "since": "pilot slices S1-S5 (PRs #262-#268); strict declaration #269 reverted per W1 review",
+      "evidence": [
+        "docs/architecture/stage-1b-pilot-rfc.md"
+      ],
+      "nextAction": "W1 review repair R9/R10, then strict re-acceptance",
+      "target": {
+        "publicEntrypoints": [
+          "src/worktrees/index.ts"
+        ]
+      }
+    },
+    "MOD-DASHBOARD-SHELL": {
+      "state": "legacy",
+      "since": "initial coarse registry (Stage 1A/2)",
+      "evidence": [],
+      "nextAction": "awaiting its Stage 5 wave"
+    },
+    "MOD-AI-SESSION-CONVERSATION": {
+      "state": "legacy",
+      "since": "initial coarse registry (Stage 1A/2)",
+      "evidence": [],
+      "nextAction": "awaiting its Stage 5 wave"
+    },
+    "MOD-AI-SESSION-ATTENTION": {
+      "state": "legacy",
+      "since": "initial coarse registry (Stage 1A/2)",
+      "evidence": [],
+      "nextAction": "awaiting its Stage 5 wave"
+    },
+    "MOD-AI-SESSION-NOTIFY": {
+      "state": "legacy",
+      "since": "initial coarse registry (Stage 1A/2)",
+      "evidence": [],
+      "nextAction": "awaiting its Stage 5 wave"
+    },
+    "MOD-AI-SESSION-RUNTIME": {
+      "state": "legacy",
+      "since": "initial coarse registry (Stage 1A/2)",
+      "evidence": [],
+      "nextAction": "awaiting its Stage 5 wave"
+    },
+    "MOD-AI-SESSION-CONTROL": {
+      "state": "legacy",
+      "since": "initial coarse registry (Stage 1A/2)",
+      "evidence": [],
+      "nextAction": "awaiting its Stage 5 wave"
+    },
+    "MOD-AI-SESSION-PROVIDER": {
+      "state": "legacy",
+      "since": "initial coarse registry (Stage 1A/2)",
+      "evidence": [],
+      "nextAction": "awaiting its Stage 5 wave"
+    },
+    "MOD-WORKSPACE-IDENTITY": {
+      "state": "legacy",
+      "since": "initial coarse registry (Stage 1A/2)",
+      "evidence": [],
+      "nextAction": "awaiting its Stage 5 wave"
+    },
+    "MOD-OPEN-WORKSPACE": {
+      "state": "legacy",
+      "since": "initial coarse registry (Stage 1A/2)",
+      "evidence": [],
+      "nextAction": "awaiting its Stage 5 wave"
+    },
+    "MOD-PROJECT-CATALOG": {
+      "state": "legacy",
+      "since": "initial coarse registry (Stage 1A/2)",
+      "evidence": [],
+      "nextAction": "awaiting its Stage 5 wave"
+    },
+    "MOD-SKILL-MANAGEMENT": {
+      "state": "legacy",
+      "since": "initial coarse registry (Stage 1A/2)",
+      "evidence": [],
+      "nextAction": "awaiting its Stage 5 wave"
+    },
+    "MOD-TODO": {
+      "state": "legacy",
+      "since": "initial coarse registry (Stage 1A/2)",
+      "evidence": [],
+      "nextAction": "awaiting its Stage 5 wave"
+    },
+    "MOD-PROMPT-LIBRARY": {
+      "state": "legacy",
+      "since": "initial coarse registry (Stage 1A/2)",
+      "evidence": [],
+      "nextAction": "awaiting its Stage 5 wave"
+    },
+    "MOD-ATTENTION-BRIDGE-EXT": {
+      "state": "legacy",
+      "since": "initial coarse registry (Stage 1A/2)",
+      "evidence": [],
+      "nextAction": "awaiting its Stage 5 wave"
+    },
+    "MOD-SHARED-KERNEL": {
+      "state": "legacy",
+      "since": "initial coarse registry (Stage 1A/2)",
+      "evidence": [],
+      "nextAction": "awaiting its Stage 5 wave"
     }
+  }
 }

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "fffb1cc98b31298695c4d6c59361bf4899e582b8",
+        "head": "c4a9c36f0aa62daca62f6b91f6b0fa8cc3259d71",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -460,7 +460,8 @@
             "4c1385aeed4c77d1e7b9ceca1d63536723c6acd4",
             "6c8b1352d6a5d70129ea942f204059253a8d6792",
             "241dcc68f3da26e521913bb68039155dd80a3824",
-            "bea6bb114a3d18e8c3025d43c15dbf8a90a9c1a9"
+            "bea6bb114a3d18e8c3025d43c15dbf8a90a9c1a9",
+            "4db1b31c291c9db57628d87a1bee872cfcfaeea1"
         ]
     },
     "capabilities": [
@@ -2325,7 +2326,8 @@
                 "4bec57e837bfc81a04470c057d7d4533588d2edc",
                 "38b091a8cb6f00e5fcaf085342285a0ba0eda1ba",
                 "a17fa079dee87f2c359a20903c9bb5e353d303de",
-                "fffb1cc98b31298695c4d6c59361bf4899e582b8"
+                "fffb1cc98b31298695c4d6c59361bf4899e582b8",
+                "c4a9c36f0aa62daca62f6b91f6b0fa8cc3259d71"
             ],
             "behaviors": [
                 "ARCH-POLICY-SCHEMA-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "c4a9c36f0aa62daca62f6b91f6b0fa8cc3259d71",
+        "head": "11cc54362856716f04bd96cbb8b3fcf64d1dbbba",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -461,7 +461,8 @@
             "6c8b1352d6a5d70129ea942f204059253a8d6792",
             "241dcc68f3da26e521913bb68039155dd80a3824",
             "bea6bb114a3d18e8c3025d43c15dbf8a90a9c1a9",
-            "4db1b31c291c9db57628d87a1bee872cfcfaeea1"
+            "4db1b31c291c9db57628d87a1bee872cfcfaeea1",
+            "19eb6c7b0d43e28696c3baf1ce985b0cf2792ad1"
         ]
     },
     "capabilities": [
@@ -2327,7 +2328,8 @@
                 "38b091a8cb6f00e5fcaf085342285a0ba0eda1ba",
                 "a17fa079dee87f2c359a20903c9bb5e353d303de",
                 "fffb1cc98b31298695c4d6c59361bf4899e582b8",
-                "c4a9c36f0aa62daca62f6b91f6b0fa8cc3259d71"
+                "c4a9c36f0aa62daca62f6b91f6b0fa8cc3259d71",
+                "11cc54362856716f04bd96cbb8b3fcf64d1dbbba"
             ],
             "behaviors": [
                 "ARCH-POLICY-SCHEMA-001",

--- a/scripts/architecture/architectureChangeRecords.js
+++ b/scripts/architecture/architectureChangeRecords.js
@@ -30,8 +30,8 @@ const ARCH_CHANGE_ID_PATTERN = /^ARCH-CHANGE-[A-Z0-9-]+$/;
 const RECORDS_DIRECTORY = 'docs/architecture/changes/';
 const BLOCK_PATTERN = /```arch-change\s*\r?\n([\s\S]*?)```/;
 
-const DELTA_MAP_KEYS = ['mayDependOnGrown'];
-const DELTA_LIST_KEYS = ['baselineGrown', 'waiversAdded', 'invariantChanges'];
+const DELTA_MAP_KEYS = ['mayDependOnGrown', 'entrypointsGrown'];
+const DELTA_LIST_KEYS = ['baselineGrown', 'waiversAdded', 'invariantChanges', 'ledgerRegressions'];
 const DELTA_FLAG_KEYS = ['rePartition', 'harnessWeakening'];
 const DELTA_KEYS = [...DELTA_MAP_KEYS, ...DELTA_LIST_KEYS, ...DELTA_FLAG_KEYS];
 
@@ -122,9 +122,11 @@ function parseArchitectureChangeRecord({ path: recordPath, text }) {
 
     const delta = {
         mayDependOnGrown: rawDelta.mayDependOnGrown || {},
+        entrypointsGrown: rawDelta.entrypointsGrown || {},
         baselineGrown: rawDelta.baselineGrown || [],
         waiversAdded: rawDelta.waiversAdded || [],
         invariantChanges: rawDelta.invariantChanges || [],
+        ledgerRegressions: rawDelta.ledgerRegressions || [],
         rePartition: rawDelta.rePartition === true,
         harnessWeakening: rawDelta.harnessWeakening === true,
     };
@@ -171,9 +173,11 @@ function coversPolicyDelta(record, actual) {
     const { delta } = record;
     const missing = [
         ...missingMapEntries(policyDelta.mayDependOnGrown, delta.mayDependOnGrown, 'mayDependOn broadened'),
+        ...missingMapEntries(policyDelta.entrypointsGrown || {}, delta.entrypointsGrown, 'entrypoints broadened'),
         ...missingListEntries(policyDelta.baselineGrown, delta.baselineGrown, 'baseline grew'),
         ...missingListEntries(policyDelta.waiversAdded, delta.waiversAdded, 'waiver added'),
         ...missingListEntries(relaxingInvariantIds || [], delta.invariantChanges, 'invariant changed'),
+        ...missingListEntries(policyDelta.ledgerRegressions || [], delta.ledgerRegressions, 'ledger regression'),
     ];
     if (rePartition && !delta.rePartition) {
         missing.push('registry re-partition not declared');

--- a/scripts/architecture/checkArchitectureChange.js
+++ b/scripts/architecture/checkArchitectureChange.js
@@ -121,6 +121,8 @@ function classifyArchitectureChange(report) {
 
     const delta = report.policyDelta;
     const grownMayDependOn = Object.keys(delta.mayDependOnGrown).length > 0;
+    const grownEntrypoints = Object.keys(delta.entrypointsGrown || {}).length > 0;
+    const ledgerRegressions = (delta.ledgerRegressions || []);
     // Review R9 (Important 4): only a pure writer removal with an unchanged
     // authority is tightening; any addition, replacement, authority,
     // statement, linearization-point, or state-family change is relaxing.
@@ -132,7 +134,8 @@ function classifyArchitectureChange(report) {
     const removedInvariants = (delta.invariantsRemoved || []);
     const grownBaseline = delta.baselineGrown.length > 0;
     const addedWaivers = delta.waiversAdded.length > 0;
-    const relaxing = grownMayDependOn || relaxingInvariantIds.length > 0
+    const relaxing = grownMayDependOn || grownEntrypoints || ledgerRegressions.length > 0
+        || relaxingInvariantIds.length > 0
         || removedInvariants.length > 0 || grownBaseline || addedWaivers
         || harnessWeakened;
     const rePartition = !relaxing && delta.modulesChanged

--- a/scripts/architecture/checkModuleBoundaries.js
+++ b/scripts/architecture/checkModuleBoundaries.js
@@ -73,7 +73,10 @@ function runModuleBoundaryCheck(rootDirectory) {
                 + 'declare the edge in ' + REGISTRY_PATH + ' via an approved architecture change');
         }
         const entrypoints = entrypointMatchers.get(edge.targetModule) || [];
-        if (entrypoints.length > 0 && !entrypoints.some(pattern => pattern.test(edge.target))) {
+        // Review R9 (Important 6): the entrypoint check never fails open —
+        // the loader rejects empty entrypoint lists, and an empty matcher
+        // here still fails the edge rather than skipping the check.
+        if (!entrypoints.some(pattern => pattern.test(edge.target))) {
             errors.push(`module-boundary: ${edge.source} deep-imports ${edge.target}, which is not a `
                 + `declared public entrypoint of ${edge.targetModule}`);
         }

--- a/scripts/architecture/checkProgramLedger.js
+++ b/scripts/architecture/checkProgramLedger.js
@@ -9,11 +9,18 @@
  * baseline fingerprint or waiver naming it, its P0/P1 invariants have
  * behavior owners, and its single-writer families declare writers. An agent
  * cannot mark a module strict while debt still names it.
+ *
+ * Review R9 (Important 9): every registered module must have exactly one
+ * ledger entry; a strict entry must carry a structured target contract
+ * (target.publicEntrypoints matching the registry exactly) and zero deep
+ * imports into module internals, computed from the dependency graph — the
+ * strict claim is verified against the graph, not asserted in prose.
  */
 
 const fs = require('fs');
 const path = require('path');
-const { loadArchitecturePolicy } = require('./loadArchitecturePolicy');
+const { loadArchitecturePolicy, compileGlob } = require('./loadArchitecturePolicy');
+const { buildDependencyGraph } = require('./buildDependencyGraph');
 
 const LEDGER_PATH = path.join('docs', 'testing', 'architecture-program.json');
 const BASELINE_PATH = path.join('.ci', 'architecture-debt-baseline.json');
@@ -27,6 +34,16 @@ function readJson(rootDirectory, relativePath, errors, label) {
         errors.push(`ledger: cannot read ${relativePath}: ${error.message}`);
         return null;
     }
+}
+
+/** External edges into a module's files that bypass its declared entrypoints. */
+function countDeepImports(rootDirectory, moduleId, publicEntrypoints) {
+    const { edges, errors } = buildDependencyGraph(rootDirectory);
+    if (errors.length > 0) { return -1; }
+    const entrypoints = publicEntrypoints.map(compileGlob);
+    return edges.filter(edge => edge.targetModule === moduleId
+        && edge.sourceModule !== moduleId
+        && !entrypoints.some(pattern => pattern.test(edge.target))).length;
 }
 
 function runProgramLedgerCheck(rootDirectory) {
@@ -52,6 +69,15 @@ function runProgramLedgerCheck(rootDirectory) {
             errors.push(`ledger: ${moduleId} has an unknown state '${entry && entry.state}'`);
         }
     }
+    // Review R9 (Important 9): every registered module has exactly one
+    // ledger entry — an untracked module escapes the program's progress
+    // accounting.
+    for (const moduleId of registryIds) {
+        if (!(moduleId in modules)) {
+            errors.push(`ledger: ${moduleId} has no ledger entry (every registered `
+                + 'module must be tracked)');
+        }
+    }
 
     const baselineFingerprints = Object.values((baseline && baseline.rules) || {})
         .flatMap(rule => rule.fingerprints || []);
@@ -72,6 +98,32 @@ function runProgramLedgerCheck(rootDirectory) {
         if (policy.errors.length > 0) {
             errors.push(`ledger: ${moduleId} cannot be strict while the closed-world `
                 + 'classification has errors');
+        }
+        // Structured target contract (review R9): the strict claim must
+        // name the approved entrypoint surface and prove it against the
+        // dependency graph.
+        const module = policy.modules.find(candidate => candidate.id === moduleId);
+        const target = entry.target;
+        if (!target || !Array.isArray(target.publicEntrypoints)
+            || target.publicEntrypoints.length === 0) {
+            errors.push(`ledger: ${moduleId} is strict but declares no target.publicEntrypoints `
+                + '— the strict claim must reference the structured target contract');
+        } else {
+            const registryEntrypoints = [...(module.publicEntrypoints || [])].sort();
+            const declared = [...target.publicEntrypoints].sort();
+            if (JSON.stringify(registryEntrypoints) !== JSON.stringify(declared)) {
+                errors.push(`ledger: ${moduleId} target.publicEntrypoints `
+                    + `(${declared.join(', ')}) do not match the registry `
+                    + `(${registryEntrypoints.join(', ')})`);
+            }
+            const deepImports = countDeepImports(rootDirectory, moduleId, target.publicEntrypoints);
+            if (deepImports < 0) {
+                errors.push(`ledger: ${moduleId} strict target cannot be evaluated while the `
+                    + 'dependency graph has errors');
+            } else if (deepImports > 0) {
+                errors.push(`ledger: ${moduleId} claims strict but ${deepImports} external `
+                    + 'edge(s) deep-import its internals');
+            }
         }
         const namingBaseline = baselineFingerprints.filter(fingerprint =>
             namesModule(fingerprint, moduleId));

--- a/scripts/architecture/loadArchitecturePolicy.js
+++ b/scripts/architecture/loadArchitecturePolicy.js
@@ -138,8 +138,14 @@ function loadArchitecturePolicy(rootDirectory) {
             && !validatePatternList(owner, 'source.exclude', source.exclude, errors, true)) {
             continue;
         }
-        if (module.publicEntrypoints !== undefined
-            && !validatePatternList(owner, 'publicEntrypoints', module.publicEntrypoints, errors)) {
+        // Review R9 (Important 6): every module must declare at least one
+        // public entrypoint — a missing or empty list is a schema failure,
+        // never fail-open.
+        if (module.publicEntrypoints === undefined) {
+            errors.push(`${owner}: publicEntrypoints is required (at least one entrypoint)`);
+            continue;
+        }
+        if (!validatePatternList(owner, 'publicEntrypoints', module.publicEntrypoints, errors)) {
             continue;
         }
         const roles = Array.isArray(module.roles) ? module.roles : [];

--- a/scripts/architecture/reportArchitectureDiff.js
+++ b/scripts/architecture/reportArchitectureDiff.js
@@ -165,10 +165,12 @@ function collectArchitectureDiff({ rootDirectory, baseRef, git }) {
 
     const policyDelta = {
         mayDependOnGrown: {},
+        entrypointsGrown: {},
         invariantChanges: {},
         invariantsRemoved: [],
         baselineGrown: [],
         waiversAdded: [],
+        ledgerRegressions: [],
         modulesChanged: false,
     };
     const changedInvariantIds = [];
@@ -189,6 +191,13 @@ function collectArchitectureDiff({ rootDirectory, baseRef, git }) {
                 const grown = diffStringSets(
                     baseModule.mayDependOn || [], headModule.mayDependOn || []).added;
                 if (grown.length > 0) { policyDelta.mayDependOnGrown[id] = grown; }
+                // Review R9 (Important 6): a new public entrypoint broadens
+                // the module surface — relaxing; removing one narrows it.
+                const entrypointsGrown = diffStringSets(
+                    baseModule.publicEntrypoints || [], headModule.publicEntrypoints || []).added;
+                if (entrypointsGrown.length > 0) {
+                    policyDelta.entrypointsGrown[id] = entrypointsGrown;
+                }
             }
         }
         if (protectedPath.endsWith('architecture-invariants.json')) {
@@ -254,6 +263,24 @@ function collectArchitectureDiff({ rootDirectory, baseRef, git }) {
             const added = diffStringSets(baseWaivers, headWaivers).added;
             if (added.length > 0 && headWaivers.length > baseWaivers.length) {
                 policyDelta.waiversAdded = added;
+            }
+        }
+        if (protectedPath.endsWith('architecture-program.json')) {
+            // Review R9 (Important 9): ledger state regressions are relaxing
+            // (a module stepping backwards cannot ride a product change);
+            // forward moves along the declared chain are progress.
+            const baseModules = baseJson.modules || {};
+            const headModules = headJson.modules || {};
+            const stateOrder = Array.isArray(headJson.states) ? headJson.states : [];
+            for (const [id, headEntry] of Object.entries(headModules)) {
+                const baseEntry = baseModules[id];
+                if (!baseEntry || !headEntry || baseEntry.state === headEntry.state) { continue; }
+                const fromIndex = stateOrder.indexOf(baseEntry.state);
+                const toIndex = stateOrder.indexOf(headEntry.state);
+                if (fromIndex < 0 || toIndex < 0 || toIndex < fromIndex) {
+                    policyDelta.ledgerRegressions.push(
+                        `${id}: ${baseEntry.state} -> ${headEntry.state}`);
+                }
             }
         }
     }
@@ -336,6 +363,12 @@ function formatReport(report) {
     const grown = Object.entries(report.policyDelta.mayDependOnGrown);
     for (const [id, edges] of grown) {
         lines.push(`  mayDependOn broadened: ${id} += ${edges.join(', ')}`);
+    }
+    for (const [id, entrypoints] of Object.entries(report.policyDelta.entrypointsGrown || {})) {
+        lines.push(`  entrypoints broadened: ${id} += ${entrypoints.join(', ')}`);
+    }
+    for (const regression of report.policyDelta.ledgerRegressions || []) {
+        lines.push(`  ledger regression: ${regression}`);
     }
     for (const [id, change] of Object.entries(report.policyDelta.invariantChanges || {})) {
         const parts = [];

--- a/tests/unit/architecture/architectureChange.test.js
+++ b/tests/unit/architecture/architectureChange.test.js
@@ -594,8 +594,9 @@ test('ARCH-CHANGE-GATE-001 parser accepts a valid machine-summary block and appl
     assert.equal(record.status, 'approved');
     assert.deepEqual(record.modules, ['MOD-A']);
     assert.deepEqual(record.delta, {
-        mayDependOnGrown: {}, baselineGrown: [],
-        waiversAdded: [], invariantChanges: [], rePartition: false, harnessWeakening: false,
+        mayDependOnGrown: {}, entrypointsGrown: {}, baselineGrown: [],
+        waiversAdded: [], invariantChanges: [], ledgerRegressions: [],
+        rePartition: false, harnessWeakening: false,
     });
 });
 
@@ -809,4 +810,83 @@ test('ARCH-CHANGE-GATE-001 collectArchitectureDiff reads records from the base r
     const { classification, errors } = classifyArchitectureChange(diff);
     assert.equal(classification, 'relaxing');
     assert.deepEqual(errors, []);
+});
+
+
+// ── review R9: entrypoint growth and ledger regressions (Important 6/9) ──
+
+test('ARCH-CHANGE-GATE-001 controlled mutation: broadening public entrypoints is relaxing', () => {
+    const result = classifyArchitectureChange(report({
+        protectedTouched: ['docs/testing/architecture-modules.json'],
+        policyDelta: {
+            mayDependOnGrown: {},
+            entrypointsGrown: { 'MOD-A': ['src/a/newEntrypoint.ts'] },
+            invariantChanges: {}, invariantsRemoved: [],
+            baselineGrown: [], waiversAdded: [], modulesChanged: true,
+        },
+    }));
+    assert.equal(result.classification, 'relaxing');
+    assert.ok(result.errors.length > 0);
+
+    const covered = classifyArchitectureChange(report({
+        protectedTouched: ['docs/testing/architecture-modules.json'],
+        policyDelta: {
+            mayDependOnGrown: {},
+            entrypointsGrown: { 'MOD-A': ['src/a/newEntrypoint.ts'] },
+            invariantChanges: {}, invariantsRemoved: [],
+            baselineGrown: [], waiversAdded: [], modulesChanged: true,
+        },
+        baseRecords: [{
+            path: RECORD_PATH,
+            text: recordMarkdown({
+                delta: { entrypointsGrown: { 'MOD-A': ['src/a/newEntrypoint.ts'] } },
+            }),
+        }],
+    }));
+    assert.deepEqual(covered.errors, []);
+});
+
+test('ARCH-CHANGE-GATE-001 controlled mutation: a ledger state regression is relaxing', () => {
+    const result = classifyArchitectureChange(report({
+        protectedTouched: ['docs/testing/architecture-program.json'],
+        policyDelta: {
+            mayDependOnGrown: {}, entrypointsGrown: {},
+            invariantChanges: {}, invariantsRemoved: [],
+            baselineGrown: [], waiversAdded: [],
+            ledgerRegressions: ['MOD-A: strict -> migrating'],
+            modulesChanged: true,
+        },
+    }));
+    assert.equal(result.classification, 'relaxing');
+    assert.ok(result.errors.length > 0);
+
+    const covered = classifyArchitectureChange(report({
+        protectedTouched: ['docs/testing/architecture-program.json'],
+        policyDelta: {
+            mayDependOnGrown: {}, entrypointsGrown: {},
+            invariantChanges: {}, invariantsRemoved: [],
+            baselineGrown: [], waiversAdded: [],
+            ledgerRegressions: ['MOD-A: strict -> migrating'],
+            modulesChanged: true,
+        },
+        baseRecords: [{
+            path: RECORD_PATH,
+            text: recordMarkdown({ delta: { ledgerRegressions: ['MOD-A: strict -> migrating'] } }),
+        }],
+    }));
+    assert.deepEqual(covered.errors, []);
+});
+
+test('ARCH-CHANGE-GATE-001 a forward ledger transition with no other delta stays tightening', () => {
+    const result = classifyArchitectureChange(report({
+        protectedTouched: ['docs/testing/architecture-program.json'],
+        policyDelta: {
+            mayDependOnGrown: {}, entrypointsGrown: {},
+            invariantChanges: {}, invariantsRemoved: [],
+            baselineGrown: [], waiversAdded: [], ledgerRegressions: [],
+            modulesChanged: true,
+        },
+    }));
+    assert.equal(result.classification, 'tightening');
+    assert.deepEqual(result.errors, []);
 });

--- a/tests/unit/architecture/architectureChange.test.js
+++ b/tests/unit/architecture/architectureChange.test.js
@@ -890,3 +890,101 @@ test('ARCH-CHANGE-GATE-001 a forward ledger transition with no other delta stays
     assert.equal(result.classification, 'tightening');
     assert.deepEqual(result.errors, []);
 });
+
+
+// ── review R9: entrypoint and ledger policy deltas (collect level) ────
+
+test('ARCH-CHANGE-GATE-001 the policy delta computes entrypoint growth and ledger regressions', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'arch-diff-ledger-'));
+    const write = (relative, value) => {
+        fs.mkdirSync(path.join(root, path.dirname(relative)), { recursive: true });
+        fs.writeFileSync(path.join(root, relative),
+            typeof value === 'string' ? value : JSON.stringify(value, null, 4) + '\n');
+    };
+    write('src/alpha/a.ts', '// a\n');
+    const moduleEntry = entrypoints => ({
+        id: 'MOD-ALPHA', title: 'A', purpose: 'fixture',
+        source: { include: ['src/**'], exclude: [] }, publicEntrypoints: entrypoints,
+        mayDependOn: [], roles: [{ role: 'application', include: ['src/**'] }],
+        productCapabilities: ['MAIN-TEST-001'],
+    });
+    write('docs/testing/architecture-modules.json', {
+        version: 1, scope: { roots: ['src'] }, modules: [moduleEntry(['src/**'])],
+    });
+    write('docs/testing/main-capability-coverage.json',
+        { version: 1, capabilities: [{ id: 'MAIN-TEST-001' }] });
+    const ledger = modules => ({
+        version: 1,
+        states: ['legacy', 'inventoried', 'characterized', 'guarded', 'migrating', 'strict'],
+        modules,
+    });
+    write('docs/testing/architecture-program.json', ledger({
+        'MOD-ALPHA': { state: 'migrating', since: 'x', evidence: [], nextAction: 'y' },
+    }));
+    let changed = [
+        { status: 'M', path: 'docs/testing/architecture-modules.json' },
+        { status: 'M', path: 'docs/testing/architecture-program.json' },
+    ];
+    const git = {
+        changedFiles: () => changed,
+        listFiles: () => [],
+        fileAt: (ref, relativePath) => {
+            if (ref !== 'base') {
+                const absolute = path.join(root, relativePath);
+                return fs.existsSync(absolute) ? fs.readFileSync(absolute, 'utf8') : null;
+            }
+            if (relativePath.endsWith('architecture-modules.json')) {
+                return JSON.stringify({ version: 1, scope: { roots: ['src'] }, modules: [moduleEntry(['src/**'])] });
+            }
+            return JSON.stringify(ledger({
+                'MOD-ALPHA': { state: 'guarded', since: 'x', evidence: [], nextAction: 'y' },
+            }));
+        },
+    };
+    // Head broadens the entrypoints and regresses the ledger state.
+    write('docs/testing/architecture-modules.json', {
+        version: 1, scope: { roots: ['src'] }, modules: [moduleEntry(['src/**', 'src/new-entry.ts'])],
+    });
+    write('docs/testing/architecture-program.json', ledger({
+        'MOD-ALPHA': { state: 'inventoried', since: 'x', evidence: [], nextAction: 'y' },
+    }));
+    const report = collectArchitectureDiff({ rootDirectory: root, baseRef: 'base', git });
+    assert.deepEqual(report.policyDelta.entrypointsGrown, { 'MOD-ALPHA': ['src/new-entry.ts'] });
+    assert.deepEqual(report.policyDelta.ledgerRegressions, ['MOD-ALPHA: guarded -> inventoried']);
+    const { classification, errors } = classifyArchitectureChange(report);
+    assert.equal(classification, 'relaxing');
+    assert.ok(errors.length > 0);
+
+    // A forward ledger move alone stays tightening.
+    changed = [{ status: 'M', path: 'docs/testing/architecture-program.json' }];
+    write('docs/testing/architecture-modules.json', {
+        version: 1, scope: { roots: ['src'] }, modules: [moduleEntry(['src/**'])],
+    });
+    write('docs/testing/architecture-program.json', ledger({
+        'MOD-ALPHA': { state: 'strict', since: 'x', evidence: [], nextAction: 'y' },
+    }));
+    const forward = collectArchitectureDiff({ rootDirectory: root, baseRef: 'base', git });
+    assert.deepEqual(forward.policyDelta.ledgerRegressions, []);
+    assert.equal(classifyArchitectureChange(forward).classification, 'tightening');
+});
+
+test('ARCH-CHANGE-GATE-001 formatReport renders entrypoint and ledger sections', () => {
+    const text = formatReport({
+        baseRef: 'origin/main',
+        errors: [],
+        touchedModules: {},
+        newFiles: [],
+        removedFiles: [],
+        protectedTouched: ['docs/testing/architecture-modules.json'],
+        policyDelta: {
+            mayDependOnGrown: {},
+            entrypointsGrown: { 'MOD-A': ['src/a/entry.ts'] },
+            invariantChanges: {}, invariantsRemoved: [],
+            baselineGrown: [], waiversAdded: [],
+            ledgerRegressions: ['MOD-A: strict -> migrating'],
+            modulesChanged: true,
+        },
+    });
+    assert.ok(text.includes('entrypoints broadened: MOD-A += src/a/entry.ts'));
+    assert.ok(text.includes('ledger regression: MOD-A: strict -> migrating'));
+});

--- a/tests/unit/architecture/closedWorld.test.js
+++ b/tests/unit/architecture/closedWorld.test.js
@@ -36,6 +36,7 @@ function twoModuleRegistry() {
                 title: 'Alpha',
                 purpose: 'Alpha files.',
                 source: { include: ['src/alpha/**'], exclude: [] },
+                publicEntrypoints: ['src/alpha/**'],
                 mayDependOn: [],
                 roles: [{ role: 'application', include: ['src/alpha/**'] }],
                 productCapabilities: ['MAIN-TEST-001'],
@@ -45,6 +46,7 @@ function twoModuleRegistry() {
                 title: 'Beta',
                 purpose: 'Beta files.',
                 source: { include: ['src/beta/**'], exclude: [] },
+                publicEntrypoints: ['src/beta/**'],
                 mayDependOn: [],
                 roles: [
                     { role: 'domain', include: ['src/beta/types.ts'] },
@@ -198,4 +200,23 @@ test('ARCH-CLOSED-WORLD-001 controlled mutation: an entrypoint outside the modul
         files: ['src/alpha/index.ts', 'src/beta/index.ts', 'src/beta/types.ts'],
     }));
     assert.ok(errors.some(e => e.includes('public entrypoint src/nope/**')));
+});
+
+test('ARCH-CLOSED-WORLD-001 controlled mutation: missing or empty publicEntrypoints fail closed (review R9)', () => {
+    const missing = twoModuleRegistry();
+    delete missing.modules[0].publicEntrypoints;
+    const { errors: missingErrors } = loadArchitecturePolicy(makeFixture({
+        registry: missing,
+        files: ['src/alpha/index.ts', 'src/beta/index.ts', 'src/beta/types.ts'],
+    }));
+    assert.ok(missingErrors.some(e => e.includes('MOD-ALPHA')
+        && e.includes('publicEntrypoints is required')), JSON.stringify(missingErrors));
+    const empty = twoModuleRegistry();
+    empty.modules[0].publicEntrypoints = [];
+    const { errors: emptyErrors } = loadArchitecturePolicy(makeFixture({
+        registry: empty,
+        files: ['src/alpha/index.ts', 'src/beta/index.ts', 'src/beta/types.ts'],
+    }));
+    assert.ok(emptyErrors.some(e => e.includes('MOD-ALPHA')
+        && e.includes('publicEntrypoints')), JSON.stringify(emptyErrors));
 });

--- a/tests/unit/architecture/programLedger.test.js
+++ b/tests/unit/architecture/programLedger.test.js
@@ -46,10 +46,14 @@ function makeFixture({ ledger, baselineFingerprints = [], waiverFingerprints = [
 }
 
 function ledgerWith(state) {
+    const entry = { state, since: 'fixture', evidence: [], nextAction: 'none' };
+    if (state === 'strict') {
+        entry.target = { publicEntrypoints: ['src/**'] };
+    }
     return {
         version: 1,
         states: ['legacy', 'inventoried', 'characterized', 'guarded', 'migrating', 'strict'],
-        modules: { 'MOD-ALPHA': { state, since: 'fixture', evidence: [], nextAction: 'none' } },
+        modules: { 'MOD-ALPHA': entry },
     };
 }
 
@@ -68,6 +72,76 @@ test('ARCH-PROGRAM-LEDGER-001 the real ledger is valid and the pilot module is s
 test('ARCH-PROGRAM-LEDGER-001 a clean strict module passes', () => {
     const root = makeFixture({ ledger: ledgerWith('strict'), invariants: [validInvariant] });
     assert.deepEqual(runProgramLedgerCheck(root).errors, []);
+});
+
+test('ARCH-PROGRAM-LEDGER-001 controlled mutation: a registered module without a ledger entry fails', () => {
+    const ledger = ledgerWith('legacy');
+    ledger.modules = {};
+    const root = makeFixture({ ledger });
+    assert.ok(runProgramLedgerCheck(root).errors
+        .some(error => error.includes('MOD-ALPHA') && error.includes('no ledger entry')));
+});
+
+test('ARCH-PROGRAM-LEDGER-001 controlled mutation: strict without a target contract fails', () => {
+    const ledger = ledgerWith('strict');
+    delete ledger.modules['MOD-ALPHA'].target;
+    const root = makeFixture({ ledger, invariants: [validInvariant] });
+    assert.ok(runProgramLedgerCheck(root).errors
+        .some(error => error.includes('target.publicEntrypoints')));
+});
+
+test('ARCH-PROGRAM-LEDGER-001 controlled mutation: a target contract mismatched with the registry fails', () => {
+    const ledger = ledgerWith('strict');
+    ledger.modules['MOD-ALPHA'].target = { publicEntrypoints: ['src/public-only.ts'] };
+    const root = makeFixture({ ledger, invariants: [validInvariant] });
+    assert.ok(runProgramLedgerCheck(root).errors
+        .some(error => error.includes('do not match the registry')));
+});
+
+test('ARCH-PROGRAM-LEDGER-001 controlled mutation: strict with a deep import into internals fails', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'arch-ledger-deep-'));
+    const writeJson = (relative, value) => {
+        fs.mkdirSync(path.join(root, path.dirname(relative)), { recursive: true });
+        fs.writeFileSync(path.join(root, relative), JSON.stringify(value, null, 2));
+    };
+    fs.mkdirSync(path.join(root, 'src/alpha'), { recursive: true });
+    fs.mkdirSync(path.join(root, 'src/beta'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'src/alpha/index.ts'), 'export {};' + '\n');
+    fs.writeFileSync(path.join(root, 'src/alpha/internal.ts'), 'export {};' + '\n');
+    fs.writeFileSync(path.join(root, 'src/beta/b.ts'),
+        'import {} from "../alpha/internal";' + '\n' + 'export {};' + '\n');
+    writeJson('docs/testing/architecture-modules.json', {
+        version: 1, scope: { roots: ['src'] },
+        modules: [
+            {
+                id: 'MOD-ALPHA', title: 'A', purpose: 'fixture',
+                source: { include: ['src/alpha/**'], exclude: [] },
+                publicEntrypoints: ['src/alpha/index.ts'],
+                mayDependOn: [], roles: [{ role: 'application', include: ['src/alpha/**'] }],
+                productCapabilities: ['MAIN-TEST-001'],
+            },
+            {
+                id: 'MOD-BETA', title: 'B', purpose: 'fixture',
+                source: { include: ['src/beta/**'], exclude: [] },
+                publicEntrypoints: ['src/beta/**'],
+                mayDependOn: ['MOD-ALPHA'],
+                roles: [{ role: 'application', include: ['src/beta/**'] }],
+                productCapabilities: ['MAIN-TEST-001'],
+            },
+        ],
+    });
+    writeJson('docs/testing/main-capability-coverage.json',
+        { version: 1, capabilities: [{ id: 'MAIN-TEST-001' }] });
+    const ledger = ledgerWith('strict');
+    ledger.modules['MOD-ALPHA'].target = { publicEntrypoints: ['src/alpha/index.ts'] };
+    ledger.modules['MOD-BETA'] = { state: 'legacy', since: 'fixture', evidence: [], nextAction: 'x' };
+    writeJson('docs/testing/architecture-program.json', ledger);
+    writeJson('.ci/architecture-debt-baseline.json',
+        { version: 1, rules: { 'module-cycle': { fingerprints: [] } } });
+    writeJson('docs/testing/architecture-waivers.json', { version: 1, waivers: [] });
+    writeJson('docs/testing/architecture-invariants.json', { version: 1, invariants: [validInvariant] });
+    assert.ok(runProgramLedgerCheck(root).errors
+        .some(error => error.includes('MOD-ALPHA') && error.includes('deep-import')));
 });
 
 test('ARCH-PROGRAM-LEDGER-001 controlled mutation: strict with a naming baseline entry fails', () => {

--- a/tests/unit/architecture/singleWriters.test.js
+++ b/tests/unit/architecture/singleWriters.test.js
@@ -23,6 +23,7 @@ function makeFixture({ invariants, sources, twoModules = false }) {
         title: id,
         purpose: 'fixture',
         source: { include: [glob], exclude: [] },
+        publicEntrypoints: [glob],
         mayDependOn: [],
         roles: [{ role: 'application', include: [glob] }],
         productCapabilities: ['MAIN-TEST-001'],


### PR DESCRIPTION
## Summary

Fixes W1 review Important 6 + 9 (harness completeness half):

- **Important 6 (entrypoint fail-open)**: `publicEntrypoints` is now a required non-empty array in the registry schema (missing/empty fails closed-world validation), and the boundary check never skips entrypoint enforcement — a module can no longer make its internals importable by emptying its entrypoints. Growing an entrypoint list is a detected relaxing delta (`entrypointsGrown`) requiring a base-landed record.
- **Important 9 (ledger completeness)**: every registered module must have exactly one ledger entry (all 16 now tracked); state regressions are detected in the policy diff (`ledgerRegressions`) and are relaxing; a strict entry must carry a structured `target.publicEntrypoints` contract matching the registry AND prove **zero deep imports into internals** computed from the dependency graph — the strict claim is verified, not asserted.
- MOD-WORKTREE-LIFECYCLE's ledger entry now declares its approved target contract (`src/worktrees/index.ts`) ahead of the R10 re-acceptance.

## Change impact declaration

```change-impact-declaration
{
  "headSha": "ebc73178ab41f663c638c3b69f80f9c7f27af8cf",
  "capabilities": [
    "MAIN-ARCHITECTURE-HARNESS"
  ],
  "modules": [],
  "invariants": [],
  "policyDelta": "tightening",
  "baselineWaiverDelta": "zero",
  "newFiles": []
}
```

## Skill harvest

none — no skill change justified; the slice followed the established review-fix-commit loop.

## Verification

- `node --test 'tests/unit/architecture/**/*.test.js'` — 127/127 ✅ (new mutations: missing/empty entrypoints, entrypoint growth, ledger regression, missing ledger entry, missing/mismatched target contract, deep import into strict module)
- `npm run test:deterministic:run` ✅ — unit 1231 + contract 1170 + integration 435, real EXIT=0
- `npm run test:architecture-policy` ✅ (gate self-classification: tightening)
- `npm run test:coverage:ci` ✅ — changed-line 82.74%, real exit code
- `npm run test:behavior-contracts` ✅ (audit current)
- `git diff --check` ✅
