### PR TITLE
feat(architecture): re-accept MOD-WORKTREE-LIFECYCLE as strict (review R10)

### DIFF
--- a/docs/testing/architecture-program.json
+++ b/docs/testing/architecture-program.json
@@ -16,12 +16,17 @@
   ],
   "modules": {
     "MOD-WORKTREE-LIFECYCLE": {
-      "state": "migrating",
-      "since": "pilot slices S1-S5 (PRs #262-#268); strict declaration #269 reverted per W1 review",
+      "state": "strict",
+      "since": "pilot slices S1-S5 (PRs #262-#268) + W1 review repairs R1-R9 (PRs #270-#282)",
       "evidence": [
-        "docs/architecture/stage-1b-pilot-rfc.md"
+        "docs/architecture/stage-1b-pilot-rfc.md",
+        "docs/architecture/changes/ARCH-CHANGE-001.md",
+        "docs/architecture/changes/ARCH-CHANGE-002.md",
+        "docs/architecture/changes/ARCH-CHANGE-003.md",
+        "docs/architecture/changes/ARCH-CHANGE-004.md",
+        "docs/architecture/changes/ARCH-CHANGE-005.md"
       ],
-      "nextAction": "W1 review repair R9/R10, then strict re-acceptance",
+      "nextAction": "none \u2014 pilot complete, strict re-accepted after the W1 review repairs",
       "target": {
         "publicEntrypoints": [
           "src/worktrees/index.ts"


### PR DESCRIPTION
## Summary

W1 review 收官：re-accept MOD-WORKTREE-LIFECYCLE as **strict** (ledger state `migrating -> strict`, a forward transition — tightening, no record needed).

Every acceptance criterion from the review is now mechanically enforced in CI:

| Criterion | Enforcement |
|---|---|
| role overlap / unclassified / multi-module = 0 | exact-one role partition (R1) + closed-world |
| deep imports into W1 internals = 0 | R8 entrypoint + R-ENTRYPOINT + strict target contract vs the dependency graph (R9b) |
| W1 public entrypoint = `src/worktrees/index.ts` only | registry + boundary check |
| unprotected guard/wiring files = 0 | R2 protected harness surface |
| same-PR Architecture Change consumption = rejected | R3 base-record gate |
| stale invariant authorities = 0 | R9a symbol-definition + module-participation validation |
| undeclared/bypass writers = 0 | R7a AST single-writer guard + persistence-key bypass |
| member transition concurrency failures = 0 | R5 atomic `transitionMember` + concurrency matrix |
| merge requestId reload collisions = 0 | R6 per-document nonce + browser test |
| settlement before authoritative replacement = 0 | R6 awaited refresh + deferred-refresh test |
| controlled mutation kill rate = 100% | every claimed guard dimension ships a killed mutation |

The strict preconditions (no baseline/waiver naming the module, P0/P1 behavior owners, writer sets, exact-once classification, target contract, zero deep imports) are enforced by `checkProgramLedger.js` — an agent cannot flip this state back without a base-landed record (ledger regressions are relaxing).

## Change impact declaration

```change-impact-declaration
{
  "headSha": "a8b8512c2fd19f38980f27c1b5b1368c218c162e",
  "capabilities": [],
  "modules": [],
  "invariants": [],
  "policyDelta": "tightening",
  "baselineWaiverDelta": "zero",
  "newFiles": []
}
```

## Skill harvest

none — no skill change justified; the two verification-discipline lessons from this series (pipe-masked exit codes, coverage re-run after the final rebase) already exist in `.skills/review-fix-commit-loop` and `.skills/publishing-and-merging-github-prs`.

## Verification

- `npm run test:architecture-policy` ✅ (strict preconditions validated mechanically)
- `npm run test:architecture-guards` ✅ / `npm run test:behavior-contracts` ✅
- `npm run test:deterministic:run` ✅ — unit 1231 + contract 1170 + integration 435
- Gate classification: tightening ✅
- `git diff --check` ✅
