### PR TITLE
feat(architecture): return MOD-WORKTREE-LIFECYCLE to migrating (round-2 review)

### DIFF
--- a/docs/testing/architecture-program.json
+++ b/docs/testing/architecture-program.json
@@ -16,8 +16,8 @@
   ],
   "modules": {
     "MOD-WORKTREE-LIFECYCLE": {
-      "state": "strict",
-      "since": "pilot slices S1-S5 (PRs #262-#268) + W1 review repairs R1-R9 (PRs #270-#282)",
+      "state": "migrating",
+      "since": "pilot slices S1-S5 (PRs #262-#268) + W1 review repairs R1-R10 (PRs #270-#283); strict reverted per the round-2 review (trust chain open)",
       "evidence": [
         "docs/architecture/stage-1b-pilot-rfc.md",
         "docs/architecture/changes/ARCH-CHANGE-001.md",
@@ -26,7 +26,7 @@
         "docs/architecture/changes/ARCH-CHANGE-004.md",
         "docs/architecture/changes/ARCH-CHANGE-005.md"
       ],
-      "nextAction": "none \u2014 pilot complete, strict re-accepted after the W1 review repairs",
+      "nextAction": "round-2 repairs T1-T7 (trust chain), then strict re-acceptance",
       "target": {
         "publicEntrypoints": [
           "src/worktrees/index.ts"


### PR DESCRIPTION
## Summary

Consumes ARCH-CHANGE-006 (merged in #284). The round-2 W1 review verdict: W1 must not stand as strict while the harness trust chain is open (gate executes PR-head code; approval bound to forgeable committer timestamps; records are reusable wildcard authorizations).

This flips MOD-WORKTREE-LIFECYCLE back to `migrating` until repairs T1–T7 land and strict re-acceptance reruns. The regression is detected by the R9 ledger machinery (`ledgerRegressions`) and authorized by the base-landed record.

## Change impact declaration

```change-impact-declaration
{
  "headSha": "1c35fe854cdc8e7597c8efe1a1766eaa49cd4307",
  "capabilities": [],
  "modules": [],
  "invariants": [],
  "policyDelta": "relaxing",
  "baselineWaiverDelta": "zero",
  "newFiles": []
}
```

## Skill harvest

none — ledger-only regression recorded per the review verdict.

## Verification

- `node scripts/architecture/checkArchitectureChange.js` — classification: relaxing, authorized by ARCH-CHANGE-006 in base ✅
- `npm run test:architecture-policy` ✅
- `git diff --check` ✅
