### PR TITLE
feat(architecture): trusted merge-gate evaluator and guard mutation parity (round-2 Blocker 1)

### DIFF
--- a/.github/workflows/merge-approval-gate.yml
+++ b/.github/workflows/merge-approval-gate.yml
@@ -1,7 +1,11 @@
 name: Merge approval gate
 
 on:
-  pull_request:
+  # pull_request_target: the workflow AND the gate code always come from the
+  # default branch (round-2 review Blocker 1). The gate reads the PR head as
+  # data only — it never checks the head out over the workspace and never
+  # executes head code, so a PR cannot approve itself by editing the gate.
+  pull_request_target:
     # edited: declaration blocks bind the head SHA and are re-evaluated when
     # the body changes.
     types: [opened, synchronize, reopened, ready_for_review, edited]

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "c293c4832683f6bf5a2570102bb96862659156c5",
+        "head": "196c1214cc12536928f34524d7848fe024c715b0",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -466,7 +466,8 @@
             "ebc73178ab41f663c638c3b69f80f9c7f27af8cf",
             "a8b8512c2fd19f38980f27c1b5b1368c218c162e",
             "652850ba83815a11b8046dea9f0518fa43031dec",
-            "1c35fe854cdc8e7597c8efe1a1766eaa49cd4307"
+            "1c35fe854cdc8e7597c8efe1a1766eaa49cd4307",
+            "0549f5c2ebbf766e6fb714f8fa567fa1a5ef7aa2"
         ]
     },
     "capabilities": [
@@ -2334,7 +2335,8 @@
                 "fffb1cc98b31298695c4d6c59361bf4899e582b8",
                 "c4a9c36f0aa62daca62f6b91f6b0fa8cc3259d71",
                 "11cc54362856716f04bd96cbb8b3fcf64d1dbbba",
-                "c293c4832683f6bf5a2570102bb96862659156c5"
+                "c293c4832683f6bf5a2570102bb96862659156c5",
+                "196c1214cc12536928f34524d7848fe024c715b0"
             ],
             "behaviors": [
                 "ARCH-POLICY-SCHEMA-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "196c1214cc12536928f34524d7848fe024c715b0",
+        "head": "0b255233c0d74e05f662c66a52c7e6725e602357",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -467,7 +467,8 @@
             "a8b8512c2fd19f38980f27c1b5b1368c218c162e",
             "652850ba83815a11b8046dea9f0518fa43031dec",
             "1c35fe854cdc8e7597c8efe1a1766eaa49cd4307",
-            "0549f5c2ebbf766e6fb714f8fa567fa1a5ef7aa2"
+            "0549f5c2ebbf766e6fb714f8fa567fa1a5ef7aa2",
+            "e65fc81ecaa5ceeff4ed80fd477c7cc798d1e4f9"
         ]
     },
     "capabilities": [
@@ -2336,7 +2337,8 @@
                 "c4a9c36f0aa62daca62f6b91f6b0fa8cc3259d71",
                 "11cc54362856716f04bd96cbb8b3fcf64d1dbbba",
                 "c293c4832683f6bf5a2570102bb96862659156c5",
-                "196c1214cc12536928f34524d7848fe024c715b0"
+                "196c1214cc12536928f34524d7848fe024c715b0",
+                "0b255233c0d74e05f662c66a52c7e6725e602357"
             ],
             "behaviors": [
                 "ARCH-POLICY-SCHEMA-001",

--- a/package.json
+++ b/package.json
@@ -612,7 +612,7 @@
         "test:conversation-performance": "node scripts/run-conversation-performance-checks.js",
         "test:conversation-sources:remote": "node --test tests/platform/remote/conversationSources.test.js",
         "test:extension-host": "npm run package:release && node scripts/run-extension-host-tests.js",
-        "test:ci:linux": "npm run test-compile && npm run brand:verify && npm run brand:check && npm run test:behavior-contracts && npm run lint:ci && npm run test:coverage:run && npm run test:conversation-sources:remote && npm run test:conversation-performance && npm run test:browser:run && npm run test:safety:run && npm run test:dashboard:run && npm run test:architecture-baseline && npm run test:architecture-guards && npm run test:architecture-policy && npm run test:release-notes && npm run test:release-packaging && node scripts/check-coverage-baseline.js && node scripts/check-changed-coverage.js",
+        "test:ci:linux": "npm run test-compile && npm run brand:verify && npm run brand:check && npm run test:behavior-contracts && npm run lint:ci && npm run test:coverage:run && npm run test:conversation-sources:remote && npm run test:conversation-performance && npm run test:browser:run && npm run test:safety:run && npm run test:dashboard:run && npm run test:architecture-baseline && npm run test:architecture-guards && npm run test:architecture-policy && node scripts/run-guard-mutation-parity.js && npm run test:release-notes && npm run test:release-packaging && node scripts/check-coverage-baseline.js && node scripts/check-changed-coverage.js",
         "brand:check": "node scripts/check-brand-identity.js",
         "brand:generate": "node scripts/generate-brand-assets.js",
         "brand:verify": "node scripts/generate-brand-assets.js --check",

--- a/scripts/run-guard-mutation-parity.js
+++ b/scripts/run-guard-mutation-parity.js
@@ -1,0 +1,137 @@
+'use strict';
+
+/**
+ * Guard mutation parity (round-2 review Blocker 1, second half).
+ *
+ * A PR can weaken a protected guard AND gut its tests while preserving the
+ * 'controlled mutation' text count, and the harness-surface delta would stay
+ * "tightening". The independent kill: when a PR touches the protected harness
+ * surface WITHOUT a record-authorized relaxation, re-run the BASE versions of
+ * the guard test suites against the HEAD guard code. The PR's own test edits
+ * are irrelevant — the base suites are materialized from the base ref and
+ * executed against the head scripts. A guard turned constant-true stops
+ * killing its base mutations and fails here.
+ *
+ * Record-authorized relaxing/re-partition changes are exempt: guard semantic
+ * changes go through the Architecture Change record flow (owner review), not
+ * through this ratchet.
+ *
+ * Usage: node scripts/run-guard-mutation-parity.js  (quality-linux lane)
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+const {
+    runArchitectureChangeCheck,
+} = require('./architecture/checkArchitectureChange');
+
+const BASE_TEST_GLOBS = [
+    'tests/unit/architecture/',
+    'tests/unit/tooling/architectureGuards.test.js',
+];
+
+function git(rootDirectory, args) {
+    return execFileSync('git', args, { cwd: rootDirectory, encoding: 'utf8' }).trim();
+}
+
+function listBaseTestFiles(rootDirectory, baseRef) {
+    const files = [];
+    for (const entry of BASE_TEST_GLOBS) {
+        if (entry.endsWith('.test.js')) {
+            files.push(entry);
+            continue;
+        }
+        const listing = git(rootDirectory, ['ls-tree', '-r', '--name-only', baseRef, '--', entry]);
+        if (listing) {
+            files.push(...listing.split('\n').filter(name => name.endsWith('.test.js')));
+        }
+    }
+    return files;
+}
+
+/**
+ * Materialize the base test suites at the same relative depth so their
+ * relative requires ('../../../scripts/...', '../../helpers/...') resolve
+ * against the HEAD tree, and run them against the HEAD guard code.
+ */
+function runParity(rootDirectory, baseRef) {
+    const parityDirectory = path.join(rootDirectory, 'tests', 'unit', 'architecture-parity');
+    fs.rmSync(parityDirectory, { recursive: true, force: true });
+    fs.mkdirSync(parityDirectory, { recursive: true });
+    const materialized = [];
+    try {
+        for (const testFile of listBaseTestFiles(rootDirectory, baseRef)) {
+            let text;
+            try {
+                text = git(rootDirectory, ['show', `${baseRef}:${testFile}`]);
+            } catch {
+                continue; // the test did not exist at the base ref
+            }
+            const target = path.join(parityDirectory, path.basename(testFile));
+            fs.writeFileSync(target, text);
+            materialized.push(target);
+        }
+        if (materialized.length === 0) {
+            return { passed: true, note: 'no base guard tests found', tested: 0 };
+        }
+        const result = (() => {
+            try {
+                execFileSync('node', ['--test', ...materialized.map(file => path.basename(file))], {
+                    cwd: parityDirectory,
+                    encoding: 'utf8',
+                    stdio: ['pipe', 'pipe', 'pipe'],
+                });
+                return { failed: false };
+            } catch (error) {
+                return { failed: true, output: `${error.stdout || ''}${error.stderr || ''}` };
+            }
+        })();
+        if (result.failed) {
+            return {
+                passed: false,
+                note: 'base guard tests failed against the head guard code:\n'
+                    + (result.output || '').split('\n').slice(-30).join('\n'),
+                tested: materialized.length,
+            };
+        }
+        return { passed: true, tested: materialized.length };
+    } finally {
+        fs.rmSync(parityDirectory, { recursive: true, force: true });
+    }
+}
+
+function main() {
+    const rootDirectory = path.resolve(__dirname, '..');
+    const { classification, report } = runArchitectureChangeCheck(rootDirectory);
+    const harnessTouched = (report.harnessDelta && report.harnessDelta.touched) || [];
+    if (harnessTouched.length === 0) {
+        console.log('Guard mutation parity: no harness surface change; nothing to verify.');
+        return;
+    }
+    if (classification === 'relaxing' || classification === 're-partition') {
+        console.log(`Guard mutation parity: harness change is ${classification} — covered by the `
+            + 'Architecture Change record flow; the base-suite ratchet does not apply.');
+        return;
+    }
+    const baseRef = process.env.COVERAGE_DIFF_BASE
+        || (process.env.GITHUB_BASE_REF && `origin/${process.env.GITHUB_BASE_REF}`)
+        || 'origin/main';
+    const result = runParity(rootDirectory, baseRef);
+    if (!result.passed) {
+        console.error(`Guard mutation parity FAILED for ${classification} harness change: `
+            + 'the head guard code no longer satisfies the base test suites.');
+        console.error(result.note);
+        console.error('Fix the guard change, or land an Architecture Change record first if the '
+            + 'guard semantics intentionally change.');
+        process.exitCode = 1;
+        return;
+    }
+    console.log(`Guard mutation parity passed: ${result.tested} base guard test file(s) green `
+        + `against the head guard code (${classification}).`);
+}
+
+if (require.main === module) { main(); }
+
+module.exports = { runParity };

--- a/scripts/run-merge-approval-gate.js
+++ b/scripts/run-merge-approval-gate.js
@@ -1,12 +1,17 @@
 'use strict';
 
 // Posts the `merge-approval` commit status on a PR head after evaluating the
-// owner approval comment. Runs from the merge-approval-gate workflow on
-// pull_request and issue_comment events. Fail-closed: unexpected errors post
-// a failure status and exit non-zero, so a broken gate blocks merges loudly
-// instead of silently opening them.
+// owner approval comment and the change-impact declaration. Runs from the
+// merge-approval-gate workflow on pull_request_target and issue_comment
+// events: the workflow file and this script always come from the default
+// branch, and the PR head is only ever read as data (round-2 review
+// Blocker 1 — a PR must not approve itself by editing the gate). Fail-closed:
+// unexpected errors exit non-zero without posting, so a broken gate blocks
+// merges loudly instead of silently opening them.
 
 const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 const { execFileSync } = require('node:child_process');
 const { evaluateMergeApproval } = require('./lib/mergeApprovals');
 const { evaluateChangeImpactDeclaration } = require('./lib/changeImpactDeclaration');
@@ -70,8 +75,11 @@ function git(args) {
 }
 
 /**
- * Fetch the PR head and base, check out the exact head being evaluated, and
- * compare the PR body declaration with the regenerated impact report.
+ * Evaluate the PR body declaration against the regenerated impact report for
+ * the exact head — without ever executing head code (round-2 review
+ * Blocker 1). The head tree is materialized as a detached, read-only git
+ * worktree used purely as data; the evaluator code itself comes from the
+ * default-branch checkout (the workflow runs on pull_request_target).
  */
 function evaluateDeclarationForPullRequest({ pullRequest, prNumber }) {
     const baseRefName = pullRequest.base?.ref;
@@ -80,19 +88,24 @@ function evaluateDeclarationForPullRequest({ pullRequest, prNumber }) {
         return ['PR is missing base/head information for the declaration check'];
     }
     git(['fetch', 'origin', baseRefName, `pull/${prNumber}/head`]);
-    git(['-c', 'advice.detachedHead=false', 'checkout', headSha]);
-    const context = collectChangeImpactContext({
-        rootDirectory: process.cwd(),
-        baseRef: `origin/${baseRefName}`,
-    });
-    const { errors } = evaluateChangeImpactDeclaration({
-        body: pullRequest.body || '',
-        headSha,
-        classification: context.classification,
-        report: context.report,
-        assignedCapabilities: context.assignedCapabilities,
-    });
-    return [...context.errors, ...errors];
+    const worktreeDir = path.join(os.tmpdir(), `gate-head-${process.pid}`);
+    try {
+        git(['worktree', 'add', '--detach', worktreeDir, headSha]);
+        const context = collectChangeImpactContext({
+            rootDirectory: worktreeDir,
+            baseRef: `origin/${baseRefName}`,
+        });
+        const { errors } = evaluateChangeImpactDeclaration({
+            body: pullRequest.body || '',
+            headSha,
+            classification: context.classification,
+            report: context.report,
+            assignedCapabilities: context.assignedCapabilities,
+        });
+        return [...context.errors, ...errors];
+    } finally {
+        git(['worktree', 'remove', '--force', worktreeDir]);
+    }
 }
 
 async function main() {

--- a/scripts/run-release-packaging-checks.js
+++ b/scripts/run-release-packaging-checks.js
@@ -807,7 +807,7 @@ function run() {
     );
     assert.strictEqual(
         mainPackage.scripts['test:ci:linux'],
-        'npm run test-compile && npm run brand:verify && npm run brand:check && npm run test:behavior-contracts && npm run lint:ci && npm run test:coverage:run && npm run test:conversation-sources:remote && npm run test:conversation-performance && npm run test:browser:run && npm run test:safety:run && npm run test:dashboard:run && npm run test:architecture-baseline && npm run test:architecture-guards && npm run test:architecture-policy && npm run test:release-notes && npm run test:release-packaging && node scripts/check-coverage-baseline.js && node scripts/check-changed-coverage.js',
+        'npm run test-compile && npm run brand:verify && npm run brand:check && npm run test:behavior-contracts && npm run lint:ci && npm run test:coverage:run && npm run test:conversation-sources:remote && npm run test:conversation-performance && npm run test:browser:run && npm run test:safety:run && npm run test:dashboard:run && npm run test:architecture-baseline && npm run test:architecture-guards && npm run test:architecture-policy && node scripts/run-guard-mutation-parity.js && npm run test:release-notes && npm run test:release-packaging && node scripts/check-coverage-baseline.js && node scripts/check-changed-coverage.js',
         'Linux CI must run each quality gate once while retaining coverage enforcement',
     );
     assert.strictEqual(mainPackage.devDependencies['@vscode/test-electron'], '3.0.0',

--- a/tests/unit/tooling/mergeApprovalGate.test.js
+++ b/tests/unit/tooling/mergeApprovalGate.test.js
@@ -21,20 +21,45 @@ function loadWorkflow(name) {
 test('ARCH-PR-MERGE-APPROVAL-GATE-001 wires the gate workflow to PRs and comments', () => {
     const workflow = loadWorkflow('merge-approval-gate.yml');
     const triggers = workflow.on;
-    assert.ok(triggers.pull_request, 'gate must evaluate on pull_request events');
-    assert.ok(triggers.pull_request.types.includes('synchronize'),
+    // Round-2 review Blocker 1: the gate must run from the default branch
+    // (pull_request_target), never from the PR's own workflow definition.
+    assert.ok(triggers.pull_request_target, 'the gate must evaluate on pull_request_target events');
+    assert.ok(!triggers.pull_request, 'pull_request would execute the PR\'s own workflow file');
+    assert.ok(triggers.pull_request_target.types.includes('synchronize'),
         'new pushes must re-evaluate (stale approvals)');
-    assert.ok(triggers.issue_comment, 'gate must re-evaluate when approval comments arrive');
+    assert.ok(triggers.issue_comment, 'the gate must re-evaluate when approval comments arrive');
 
     assert.strictEqual(workflow.permissions.statuses, 'write', 'the job posts a commit status');
     const gate = workflow.jobs.gate;
     assert.ok(gate, 'gate job exists');
+    assert.ok(gate['timeout-minutes'] >= 10, 'full-history checkout and regeneration need budget');
+    const checkout = gate.steps.find(step => step.uses && step.uses.startsWith('actions/checkout'));
+    assert.ok(checkout && checkout.with && checkout.with['fetch-depth'] === 0,
+        'the gate regenerates the impact report and needs full history');
     const runSteps = gate.steps.map(step => step.run || '').join('\n');
     assert.match(runSteps, /run-merge-approval-gate\.js/, 'the job runs the gate script');
 
     const script = fs.readFileSync(path.join(repositoryRoot, 'scripts', 'run-merge-approval-gate.js'), 'utf8');
     assert.match(script, /STATUS_CONTEXT = 'merge-approval'/,
         'the posted status context is the required-check name');
+    assert.match(script, /worktree', 'add', '--detach/,
+        'the head is materialized as a detached read-only worktree, never checked out over the workspace');
+    assert.ok(!/checkout', headSha/.test(script),
+        'the gate must not check out the PR head over the evaluator workspace');
+});
+
+test('ARCH-PR-MERGE-APPROVAL-GATE-001 guard mutation parity is wired into the Linux lane (round-2 Blocker 1)', () => {
+    // The independent kill for 'guard turned constant-true with gutted
+    // tests': the base test suites re-run against the head guard code.
+    const pkg = JSON.parse(fs.readFileSync(
+        path.join(repositoryRoot, 'package.json'), 'utf8'));
+    assert.match(pkg.scripts['test:ci:linux'], /run-guard-mutation-parity\.js/,
+        'the Linux quality lane must run the guard mutation parity check');
+    const script = fs.readFileSync(
+        path.join(repositoryRoot, 'scripts', 'run-guard-mutation-parity.js'), 'utf8');
+    assert.match(script, /architecture-parity/, 'the parity suite materializes base tests');
+    assert.match(script, /classification === 'relaxing' \|\| classification === 're-partition'/,
+        'record-authorized changes are exempt (they carry owner review)');
 });
 
 test('ARCH-PR-MERGE-APPROVAL-GATE-001 audits recent merges on main pushes', () => {
@@ -59,7 +84,7 @@ test('ARCH-PR-MERGE-APPROVAL-GATE-001 audits recent merges on main pushes', () =
 
 test('ARCH-PR-CHANGE-IMPACT-GATE-001 wires the declaration check into the gate (review R4)', () => {
     const workflow = loadWorkflow('merge-approval-gate.yml');
-    assert.ok(workflow.on.pull_request.types.includes('edited'),
+    assert.ok(workflow.on.pull_request_target.types.includes('edited'),
         'body edits re-evaluate the head-bound declaration');
     const gate = workflow.jobs.gate;
     assert.ok(gate['timeout-minutes'] >= 10, 'full-history checkout and regeneration need budget');


### PR DESCRIPTION
## Summary

Fixes round-2 review Blocker 1: the merge-approval gate ran on `pull_request`, executing the PR's own workflow file and gate script with `statuses: write` — a PR could approve itself. And a guard turned constant-true with text-count-preserving test edits passed the harness delta checks.

- **Trusted evaluator**: the gate workflow now runs on `pull_request_target` — the workflow file and gate code always come from the default branch. The declaration evaluation materializes the PR head as a detached **read-only git worktree** used purely as data; the head is never checked out over the evaluator workspace and head code never executes.
- **Guard mutation parity** (new lane in `test:ci:linux`): when a change touches the protected harness surface without a record-authorized relaxation, the BASE guard test suites are materialized and re-run against the HEAD guard code — the PR's own test edits cannot launder a weakened guard. Record-authorized guard semantic changes are exempt (they carry owner review through the Architecture Change flow).

## Change impact declaration

```change-impact-declaration
{
  "headSha": "b8d2652e37dc6b43bf6629444ac41c1e0213d6ef",
  "capabilities": [
    "MAIN-ARCHITECTURE-HARNESS"
  ],
  "modules": [],
  "invariants": [],
  "policyDelta": "tightening",
  "baselineWaiverDelta": "zero",
  "newFiles": []
}
```

## Skill harvest

none — no skill change justified; the slice followed the established review-fix-commit loop.

## Verification

- `npm run test:deterministic:run` ✅ — unit 1235 + contract 1170 + integration 435, real EXIT=0
- `node --test tests/unit/tooling/mergeApprovalGate.test.js` — 4/4 ✅ (pull_request_target wiring, read-only worktree, no head checkout, parity lane wiring)
- `node scripts/run-guard-mutation-parity.js` on this branch's own harness diff ✅ — 9 base guard test files green against head guard code
- `npm run test:architecture-policy` ✅ / `npm run test:behavior-contracts` ✅
- `npm run test:coverage:ci` ✅ — changed-line 96.61%, real exit code
- `git diff --check` ✅
