### PR TITLE
feat(architecture): type-resolve the single-writer guard (round-2 Important 1)

### DIFF
--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "0b255233c0d74e05f662c66a52c7e6725e602357",
+        "head": "fc8b08177c37bd47ad7ff2175900a2ad4b6bb573",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -468,7 +468,8 @@
             "652850ba83815a11b8046dea9f0518fa43031dec",
             "1c35fe854cdc8e7597c8efe1a1766eaa49cd4307",
             "0549f5c2ebbf766e6fb714f8fa567fa1a5ef7aa2",
-            "e65fc81ecaa5ceeff4ed80fd477c7cc798d1e4f9"
+            "e65fc81ecaa5ceeff4ed80fd477c7cc798d1e4f9",
+            "b8d2652e37dc6b43bf6629444ac41c1e0213d6ef"
         ]
     },
     "capabilities": [
@@ -2338,7 +2339,8 @@
                 "11cc54362856716f04bd96cbb8b3fcf64d1dbbba",
                 "c293c4832683f6bf5a2570102bb96862659156c5",
                 "196c1214cc12536928f34524d7848fe024c715b0",
-                "0b255233c0d74e05f662c66a52c7e6725e602357"
+                "0b255233c0d74e05f662c66a52c7e6725e602357",
+                "fc8b08177c37bd47ad7ff2175900a2ad4b6bb573"
             ],
             "behaviors": [
                 "ARCH-POLICY-SCHEMA-001",

--- a/scripts/architecture/checkSingleWriters.js
+++ b/scripts/architecture/checkSingleWriters.js
@@ -9,14 +9,16 @@
  * family's store outside the declared writer set fails. The writer set is a
  * ratchet — it may only shrink during migration, never grow.
  *
- * The write-method scan is AST-based (review R7): property access
- * (`store.updateMember(...)`), element access (`store['updateMember'](...)`),
- * and destructuring (`const { updateMember } = store`, including aliased)
- * are all detected, so renaming the receiver or re-binding the method cannot
- * launder a write past the guard. What it cannot detect: a write through a
- * mock-typed double in a file that never mentions the store module — such a
- * file would also fail the module-boundary guard on the import edge, and the
- * behavior owner tests pin the authority semantics.
+ * The write-method scan uses the TypeScript type checker (round-2 review
+ * Important 1, superseding the R7 name-matching pass): the receiver of a
+ * write-method call is resolved to its declaring class through barrels,
+ * aliases, element access, destructuring, and import renames, so only a
+ * receiver whose type is actually the store class trips the guard — and a
+ * store value passed as an argument into a non-writer file is flagged as a
+ * provision bypass (structural-typing injections need a provision site to
+ * do harm). What it cannot detect: a writer deliberately handing the store
+ * to a helper inside another file — that is writer discipline, covered by
+ * review.
  *
  * Bypass check: every literal in stateFamily.persistenceKeys may appear only
  * inside the store file — a memento-key reference is a raw write path around
@@ -204,37 +206,107 @@ function validateCatalog(rootDirectory, policy) {
 }
 
 /**
- * AST scan: every property access, element access, or destructuring binding
- * that names a write method — resilient to import aliases, receiver renames,
- * .bind extraction, and bracket access (review R7).
+ * One shared TypeScript program per run (round-2 review Important 1): type
+ * resolution sees through barrels, aliases, and re-exports. Local
+ * class/interface types resolve without lib types; unresolved externals
+ * become `any` and simply never match the store class.
  */
-function findWriteMethodTouches(file, text, writeMethods) {
-    const sourceFile = ts.createSourceFile(
-        file, text, ts.ScriptTarget.Latest, true,
-        file.endsWith('.js') ? ts.ScriptKind.JS : ts.ScriptKind.TS);
-    const touches = new Set();
+function buildTypeContext(rootDirectory, files) {
+    const program = ts.createProgram(files.map(file => path.join(rootDirectory, file)), {
+        noEmit: true,
+        allowJs: true,
+        checkJs: false,
+        skipLibCheck: true,
+        target: ts.ScriptTarget.ES2020,
+        module: ts.ModuleKind.CommonJS,
+        moduleResolution: ts.ModuleResolutionKind.NodeJs,
+        strict: false,
+        types: [],
+    });
+    return { program, checker: program.getTypeChecker() };
+}
+
+/** The file that declares the CLASS of the expression's type, or null. */
+function declaringFileOf(rootDirectory, checker, node) {
+    const type = checker.getTypeAtLocation(node);
+    const symbol = type && (type.getSymbol() || type.symbol);
+    const declaration = symbol && symbol.declarations && symbol.declarations[0];
+    // Only class instances carry write capability; plain interfaces declared
+    // in the store file (member records etc.) are data, not the store.
+    if (!declaration || !ts.isClassDeclaration(declaration)) { return null; }
+    const fileName = declaration.getSourceFile().fileName;
+    const relative = path.relative(rootDirectory, fileName).split(path.sep).join('/');
+    return relative.startsWith('..') ? null : relative;
+}
+
+/**
+ * Type-resolved scan: write-method calls whose receiver is actually the
+ * store class (barrels and aliases included), destructuring off a
+ * store-typed value, and store-class values provisioned as call arguments
+ * into files outside the store's writer union.
+ */
+function findTypeResolvedViolations(rootDirectory, typeContext, file, families, unionWriters) {
+    const sourceFile = typeContext.program.getSourceFile(path.join(rootDirectory, file));
+    if (!sourceFile) { return []; }
+    const violations = [];
+    const { checker } = typeContext;
     const visit = node => {
-        if (ts.isPropertyAccessExpression(node) && writeMethods.has(node.name.text)) {
-            touches.add(`touches write method '${node.name.text}'`);
-        } else if (ts.isElementAccessExpression(node)) {
-            const argument = node.argumentExpression;
-            if (argument && (ts.isStringLiteral(argument)
-                || ts.isNoSubstitutionTemplateLiteral(argument))
-                && writeMethods.has(argument.text)) {
-                touches.add(`touches write method '${argument.text}' via element access`);
+        if ((ts.isPropertyAccessExpression(node)
+                && families.some(family => family.writeMethods.has(node.name.text)))
+            || (ts.isElementAccessExpression(node)
+                && ts.isStringLiteral(node.argumentExpression)
+                && families.some(family =>
+                    family.writeMethods.has(node.argumentExpression.text)))) {
+            const declaringFile = declaringFileOf(rootDirectory, checker, node.expression);
+            for (const family of families) {
+                const isElement = ts.isElementAccessExpression(node);
+                const methodName = isElement ? node.argumentExpression.text : node.name.text;
+                if (!family.writeMethods.has(methodName)) { continue; }
+                if (declaringFile === family.storePath && !family.writers.has(file)) {
+                    // Message keeps the historical 'touches write method' /
+                    // 'via element access' substrings: the guard mutation
+                    // parity lane re-runs base suites against this guard.
+                    violations.push(`touches write method '${methodName}'`
+                        + `${isElement ? ' via element access' : ''} on a ${family.storePath}-typed`
+                        + ` receiver outside the declared writers of ${family.id}`);
+                }
             }
         } else if (ts.isBindingElement(node)) {
             const name = node.propertyName && ts.isIdentifier(node.propertyName)
                 ? node.propertyName.text
                 : (ts.isIdentifier(node.name) ? node.name.text : null);
-            if (name && writeMethods.has(name)) {
-                touches.add(`destructures write method '${name}'`);
+            if (!name || !families.some(family => family.writeMethods.has(name))) { return; }
+            const declaration = node.parent && node.parent.parent;
+            const initializer = declaration && ts.isVariableDeclaration(declaration)
+                ? declaration.initializer
+                : null;
+            if (!initializer) { return; }
+            for (const family of families) {
+                if (!family.writeMethods.has(name)) { continue; }
+                const declaringFile = declaringFileOf(rootDirectory, checker, initializer);
+                if (declaringFile === family.storePath && !family.writers.has(file)) {
+                    violations.push(`destructures write method '${name}' off a `
+                        + `${family.storePath}-typed value outside the declared writers of ${family.id}`);
+                }
+            }
+        } else if (ts.isCallExpression(node) || ts.isNewExpression(node)) {
+            if (unionWriters.has(file)) { return; }
+            for (const argument of node.arguments || []) {
+                const declaringFile = declaringFileOf(rootDirectory, checker, argument);
+                for (const family of families) {
+                    if (declaringFile === family.storePath) {
+                        violations.push(`provisions a ${family.storePath}-typed value into `
+                            + `a call outside the declared writers of ${family.id} (structural `
+                            + 'injection bypass)');
+                        break;
+                    }
+                }
             }
         }
         ts.forEachChild(node, visit);
     };
     visit(sourceFile);
-    return [...touches].sort();
+    return violations;
 }
 
 /** Scan declared state families for write-method touches outside the writers. */
@@ -243,30 +315,47 @@ function checkWriters(rootDirectory, catalog, policy) {
     const invariants = (catalog.invariants || [])
         .filter(invariant => invariant.stateFamily
             && (invariant.enforcement || []).includes('single-writer'));
+    // Group by store: the writer union across families sharing one store
+    // governs the provision rule; per-family sets govern write calls.
+    const familiesByStore = new Map();
     for (const invariant of invariants) {
         const family = invariant.stateFamily;
-        const writers = new Set([...invariant.writers, family.storePath]);
-        const storeReference = path.basename(family.storePath).replace(/\.[^.]+$/, '');
-        const writeMethods = new Set(family.writeMethods);
-        const persistenceKeys = family.persistenceKeys || [];
+        if (!familiesByStore.has(family.storePath)) {
+            familiesByStore.set(family.storePath, []);
+        }
+        familiesByStore.get(family.storePath).push({
+            id: invariant.id,
+            storePath: family.storePath,
+            writeMethods: new Set(family.writeMethods),
+            writers: new Set([...invariant.writers, family.storePath]),
+            persistenceKeys: family.persistenceKeys || [],
+        });
+    }
+    let typeContext = null;
+    const typeContextLazy = () => {
+        if (!typeContext) { typeContext = buildTypeContext(rootDirectory, policy.files); }
+        return typeContext;
+    };
+    for (const [storePath, families] of familiesByStore) {
+        const unionWriters = new Set(families.flatMap(family => [...family.writers]));
+        const persistenceKeys = [...new Set(families.flatMap(family => family.persistenceKeys))];
         for (const file of policy.files) {
-            if (writers.has(file)) { continue; }
-            const text = fs.readFileSync(path.join(rootDirectory, file), 'utf8');
-            for (const key of persistenceKeys) {
-                if (text.includes(key)) {
-                    errors.push(`single-writer: ${file} references persistence key '${key}' of the `
-                        + `${family.storePath} state family outside the store — a raw storage write `
-                        + `bypasses the authority of ${invariant.id}`);
+            if (!unionWriters.has(file)) {
+                const text = fs.readFileSync(path.join(rootDirectory, file), 'utf8');
+                for (const key of persistenceKeys) {
+                    if (text.includes(key)) {
+                        errors.push(`single-writer: ${file} references persistence key '${key}' of the `
+                            + `${storePath} state family outside the store — a raw storage write `
+                            + 'bypasses the authority');
+                    }
                 }
             }
-            // A same-named method on an unrelated store is not a bypass: the
-            // file must also reference the state family's store.
-            if (!text.includes(storeReference)) { continue; }
-            for (const touch of findWriteMethodTouches(file, text, writeMethods)) {
-                errors.push(`single-writer: ${file} ${touch} on the `
-                    + `${family.storePath} state family outside the declared writers of `
-                    + `${invariant.id} — route the write through the authority or land an `
-                    + 'approved architecture change that amends the writer set');
+            if (unionWriters.has(file)) { continue; }
+            for (const violation of findTypeResolvedViolations(
+                rootDirectory, typeContextLazy(), file, families, unionWriters)) {
+                errors.push(`single-writer: ${file} ${violation} — route the write through `
+                    + 'the authority or land an approved architecture change that amends the '
+                    + 'writer set');
             }
         }
     }

--- a/tests/unit/architecture/singleWriters.test.js
+++ b/tests/unit/architecture/singleWriters.test.js
@@ -184,7 +184,7 @@ test('ARCH-SINGLE-WRITER-001 controlled mutation: element access cannot launder 
         },
     });
     assert.ok(runSingleWriterCheck(root).errors
-        .some(error => error.includes('src/bypass.ts') && error.includes('element access')));
+        .some(error => error.includes('src/bypass.ts') && error.includes('typed receiver')));
 });
 
 test('ARCH-SINGLE-WRITER-001 controlled mutation: destructuring cannot launder a write', () => {
@@ -343,4 +343,55 @@ test('ARCH-INVARIANT-CATALOG-001 controlled mutation: an unknown participating m
     });
     assert.ok(runSingleWriterCheck(root).errors
         .some(error => error.includes('participatingModules must be a non-empty array')));
+});
+
+
+// ── round-2 review Important 1: type-resolved bypass forms ───────────
+
+test('ARCH-SINGLE-WRITER-001 controlled mutation: a barrel import cannot launder a write', () => {
+    const root = makeFixture({
+        invariants: [validInvariant()],
+        sources: {
+            ...baseSources,
+            'src/barrel.ts': 'export { Store } from \'./store\';\n',
+            // The bypass file never mentions 'store' textually: only the
+            // barrel. Type resolution must see through the re-export.
+            'src/bypass.ts': 'import { Store } from \'./barrel\';\n'
+                + 'export const evil = (s: Store) => s.writeThing();\n',
+        },
+    });
+    assert.ok(runSingleWriterCheck(root).errors
+        .some(error => error.includes('src/bypass.ts') && error.includes('typed receiver')));
+});
+
+test('ARCH-SINGLE-WRITER-001 controlled mutation: structural injection dies at the provision site', () => {
+    const root = makeFixture({
+        invariants: [validInvariant()],
+        sources: {
+            ...baseSources,
+            // The helper writes through an anonymously typed parameter — the
+            // receiver is not the store class, so the call itself is clean;
+            // the provision site passing a store-class value must fail.
+            'src/helper.ts': 'export function bypass(store: { writeThing(): void }) { store.writeThing(); }\n',
+            'src/provision.ts': 'import { Store } from \'./store\';\n'
+                + 'import { bypass } from \'./helper\';\n'
+                + 'export const go = (s: Store) => bypass(s);\n',
+        },
+    });
+    const errors = runSingleWriterCheck(root).errors;
+    assert.ok(errors.some(error => error.includes('src/provision.ts')
+        && error.includes('provisions') && error.includes('structural')),
+        JSON.stringify(errors));
+});
+
+test('ARCH-SINGLE-WRITER-001 reading a store-typed value is not a violation', () => {
+    const root = makeFixture({
+        invariants: [validInvariant()],
+        sources: {
+            ...baseSources,
+            'src/reader.ts': 'import { Store } from \'./store\';\n'
+                + 'export const read = (s: Store) => s.toString();\n',
+        },
+    });
+    assert.deepEqual(runSingleWriterCheck(root).errors, []);
 });


### PR DESCRIPTION
## Summary

Fixes round-2 review Important 1: the single-writer guard's name-matching scan could be laundered by barrel imports (the file never mentions the store's lowercase basename) and structural-typing injections (an anonymously typed parameter).

The guard now resolves the receiver's declaring class through the TypeScript checker:

- write-method calls on a store-class-typed receiver fail outside the declared writers — through barrels, aliases, element access, and destructuring;
- a store-class value passed as a call argument into a non-writer file is a provision bypass (structural injections need a provision site to do harm);
- only class instances carry write capability — plain interfaces declared in the store file (member records) are data and do not false-positive (this refinement was caught by the guard firing on real code during development);
- violation messages keep the historical substrings so the guard mutation parity lane's base suites still kill.

Residual documented in the guard header: a writer deliberately handing the store to a helper in another file is writer discipline, covered by review.

## Change impact declaration

```change-impact-declaration
{
  "headSha": "38d6e57fb33d6c246c215e0af747320606ce21d6",
  "capabilities": [
    "MAIN-ARCHITECTURE-HARNESS"
  ],
  "modules": [],
  "invariants": [],
  "policyDelta": "tightening",
  "baselineWaiverDelta": "zero",
  "newFiles": []
}
```

## Skill harvest

none — no skill change justified; the slice followed the established review-fix-commit loop.

## Verification

- `node --test tests/unit/architecture/singleWriters.test.js` — 25/25 ✅ (new controlled mutations: barrel import, structural injection provision site, read-not-flagged)
- `node scripts/run-guard-mutation-parity.js` ✅ — base suites green against the new guard (message-compatible strengthening)
- `npm run test:architecture-policy` ✅ / real-repo single-writer check ✅
- `npm run test:coverage:ci` ✅ — changed-line 100% (135/135), real exit code
- `git diff --check` ✅
