### PR TITLE
feat(architecture): declaration v2 + skip-state ledger validation (round-2 Important 7+9)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,9 +7,13 @@
 <!--
 Required; the merge-approval gate rejects pull requests without it.
 Run `node scripts/generate-change-impact-declaration.js` right before pushing
-and paste the generated block below, filling every newFiles reason first.
+and paste the generated block below, filling every newFiles reason first,
+the coordinators list for multi-module changes, and the verification note.
 The declaration binds the head SHA: regenerate it whenever the head moves
 (rebase, new commits), otherwise the gate rejects it as stale.
+Charter 8.10 fields are all mandatory: capabilities, modules, invariants,
+policyDelta, baselineWaiverDelta, newFiles, behaviors, semanticImpact,
+coordinators, verification.
 -->
 
 ## Skill harvest

--- a/docs/testing/architecture-program.json
+++ b/docs/testing/architecture-program.json
@@ -1,127 +1,128 @@
 {
-  "version": 1,
-  "title": "Architecture program ledger",
-  "notes": [
-    "Module states follow legacy -> inventoried -> characterized -> guarded -> migrating -> strict (charter Section 8.5).",
-    "strict is validated mechanically by scripts/architecture/checkProgramLedger.js: no baseline fingerprint or waiver naming the module, P0/P1 invariants have behavior owners, single-writer families declare writers, and the module stays classified exact-once.",
-    "SCC cluster membership is cluster-level debt and does not block per-module strict (waiver ledger note)."
-  ],
-  "states": [
-    "legacy",
-    "inventoried",
-    "characterized",
-    "guarded",
-    "migrating",
-    "strict"
-  ],
-  "modules": {
-    "MOD-WORKTREE-LIFECYCLE": {
-      "state": "migrating",
-      "since": "pilot slices S1-S5 (PRs #262-#268) + W1 review repairs R1-R10 (PRs #270-#283); strict reverted per the round-2 review (trust chain open)",
-      "evidence": [
-        "docs/architecture/stage-1b-pilot-rfc.md",
-        "docs/architecture/changes/ARCH-CHANGE-001.md",
-        "docs/architecture/changes/ARCH-CHANGE-002.md",
-        "docs/architecture/changes/ARCH-CHANGE-003.md",
-        "docs/architecture/changes/ARCH-CHANGE-004.md",
-        "docs/architecture/changes/ARCH-CHANGE-005.md"
-      ],
-      "nextAction": "round-2 repairs T1-T7 (trust chain), then strict re-acceptance",
-      "target": {
-        "publicEntrypoints": [
-          "src/worktrees/index.ts"
-        ]
-      }
-    },
-    "MOD-DASHBOARD-SHELL": {
-      "state": "legacy",
-      "since": "initial coarse registry (Stage 1A/2)",
-      "evidence": [],
-      "nextAction": "awaiting its Stage 5 wave"
-    },
-    "MOD-AI-SESSION-CONVERSATION": {
-      "state": "legacy",
-      "since": "initial coarse registry (Stage 1A/2)",
-      "evidence": [],
-      "nextAction": "awaiting its Stage 5 wave"
-    },
-    "MOD-AI-SESSION-ATTENTION": {
-      "state": "legacy",
-      "since": "initial coarse registry (Stage 1A/2)",
-      "evidence": [],
-      "nextAction": "awaiting its Stage 5 wave"
-    },
-    "MOD-AI-SESSION-NOTIFY": {
-      "state": "legacy",
-      "since": "initial coarse registry (Stage 1A/2)",
-      "evidence": [],
-      "nextAction": "awaiting its Stage 5 wave"
-    },
-    "MOD-AI-SESSION-RUNTIME": {
-      "state": "legacy",
-      "since": "initial coarse registry (Stage 1A/2)",
-      "evidence": [],
-      "nextAction": "awaiting its Stage 5 wave"
-    },
-    "MOD-AI-SESSION-CONTROL": {
-      "state": "legacy",
-      "since": "initial coarse registry (Stage 1A/2)",
-      "evidence": [],
-      "nextAction": "awaiting its Stage 5 wave"
-    },
-    "MOD-AI-SESSION-PROVIDER": {
-      "state": "legacy",
-      "since": "initial coarse registry (Stage 1A/2)",
-      "evidence": [],
-      "nextAction": "awaiting its Stage 5 wave"
-    },
-    "MOD-WORKSPACE-IDENTITY": {
-      "state": "legacy",
-      "since": "initial coarse registry (Stage 1A/2)",
-      "evidence": [],
-      "nextAction": "awaiting its Stage 5 wave"
-    },
-    "MOD-OPEN-WORKSPACE": {
-      "state": "legacy",
-      "since": "initial coarse registry (Stage 1A/2)",
-      "evidence": [],
-      "nextAction": "awaiting its Stage 5 wave"
-    },
-    "MOD-PROJECT-CATALOG": {
-      "state": "legacy",
-      "since": "initial coarse registry (Stage 1A/2)",
-      "evidence": [],
-      "nextAction": "awaiting its Stage 5 wave"
-    },
-    "MOD-SKILL-MANAGEMENT": {
-      "state": "legacy",
-      "since": "initial coarse registry (Stage 1A/2)",
-      "evidence": [],
-      "nextAction": "awaiting its Stage 5 wave"
-    },
-    "MOD-TODO": {
-      "state": "legacy",
-      "since": "initial coarse registry (Stage 1A/2)",
-      "evidence": [],
-      "nextAction": "awaiting its Stage 5 wave"
-    },
-    "MOD-PROMPT-LIBRARY": {
-      "state": "legacy",
-      "since": "initial coarse registry (Stage 1A/2)",
-      "evidence": [],
-      "nextAction": "awaiting its Stage 5 wave"
-    },
-    "MOD-ATTENTION-BRIDGE-EXT": {
-      "state": "legacy",
-      "since": "initial coarse registry (Stage 1A/2)",
-      "evidence": [],
-      "nextAction": "awaiting its Stage 5 wave"
-    },
-    "MOD-SHARED-KERNEL": {
-      "state": "legacy",
-      "since": "initial coarse registry (Stage 1A/2)",
-      "evidence": [],
-      "nextAction": "awaiting its Stage 5 wave"
+    "version": 1,
+    "title": "Architecture program ledger",
+    "notes": [
+        "Module states follow legacy -> inventoried -> characterized -> guarded -> migrating -> strict (charter Section 8.5).",
+        "strict is validated mechanically by scripts/architecture/checkProgramLedger.js: no baseline fingerprint or waiver naming the module, P0/P1 invariants have behavior owners, single-writer families declare writers, and the module stays classified exact-once.",
+        "SCC cluster membership is cluster-level debt and does not block per-module strict (waiver ledger note).",
+        "State migration graph (forward-only, one step at a time): legacy -> inventoried -> characterized -> guarded -> migrating -> strict. Skip-states (e.g. legacy -> strict) are rejected. Regressions (e.g. strict -> migrating) are relaxing and require an Architecture Change record in the base."
+    ],
+    "states": [
+        "legacy",
+        "inventoried",
+        "characterized",
+        "guarded",
+        "migrating",
+        "strict"
+    ],
+    "modules": {
+        "MOD-WORKTREE-LIFECYCLE": {
+            "state": "migrating",
+            "since": "pilot slices S1-S5 (PRs #262-#268) + W1 review repairs R1-R10 (PRs #270-#283); strict reverted per the round-2 review (trust chain open)",
+            "evidence": [
+                "docs/architecture/stage-1b-pilot-rfc.md",
+                "docs/architecture/changes/ARCH-CHANGE-001.md",
+                "docs/architecture/changes/ARCH-CHANGE-002.md",
+                "docs/architecture/changes/ARCH-CHANGE-003.md",
+                "docs/architecture/changes/ARCH-CHANGE-004.md",
+                "docs/architecture/changes/ARCH-CHANGE-005.md"
+            ],
+            "nextAction": "round-2 repairs T1-T7 (trust chain), then strict re-acceptance",
+            "target": {
+                "publicEntrypoints": [
+                    "src/worktrees/index.ts"
+                ]
+            }
+        },
+        "MOD-DASHBOARD-SHELL": {
+            "state": "legacy",
+            "since": "initial coarse registry (Stage 1A/2)",
+            "evidence": [],
+            "nextAction": "awaiting its Stage 5 wave"
+        },
+        "MOD-AI-SESSION-CONVERSATION": {
+            "state": "legacy",
+            "since": "initial coarse registry (Stage 1A/2)",
+            "evidence": [],
+            "nextAction": "awaiting its Stage 5 wave"
+        },
+        "MOD-AI-SESSION-ATTENTION": {
+            "state": "legacy",
+            "since": "initial coarse registry (Stage 1A/2)",
+            "evidence": [],
+            "nextAction": "awaiting its Stage 5 wave"
+        },
+        "MOD-AI-SESSION-NOTIFY": {
+            "state": "legacy",
+            "since": "initial coarse registry (Stage 1A/2)",
+            "evidence": [],
+            "nextAction": "awaiting its Stage 5 wave"
+        },
+        "MOD-AI-SESSION-RUNTIME": {
+            "state": "legacy",
+            "since": "initial coarse registry (Stage 1A/2)",
+            "evidence": [],
+            "nextAction": "awaiting its Stage 5 wave"
+        },
+        "MOD-AI-SESSION-CONTROL": {
+            "state": "legacy",
+            "since": "initial coarse registry (Stage 1A/2)",
+            "evidence": [],
+            "nextAction": "awaiting its Stage 5 wave"
+        },
+        "MOD-AI-SESSION-PROVIDER": {
+            "state": "legacy",
+            "since": "initial coarse registry (Stage 1A/2)",
+            "evidence": [],
+            "nextAction": "awaiting its Stage 5 wave"
+        },
+        "MOD-WORKSPACE-IDENTITY": {
+            "state": "legacy",
+            "since": "initial coarse registry (Stage 1A/2)",
+            "evidence": [],
+            "nextAction": "awaiting its Stage 5 wave"
+        },
+        "MOD-OPEN-WORKSPACE": {
+            "state": "legacy",
+            "since": "initial coarse registry (Stage 1A/2)",
+            "evidence": [],
+            "nextAction": "awaiting its Stage 5 wave"
+        },
+        "MOD-PROJECT-CATALOG": {
+            "state": "legacy",
+            "since": "initial coarse registry (Stage 1A/2)",
+            "evidence": [],
+            "nextAction": "awaiting its Stage 5 wave"
+        },
+        "MOD-SKILL-MANAGEMENT": {
+            "state": "legacy",
+            "since": "initial coarse registry (Stage 1A/2)",
+            "evidence": [],
+            "nextAction": "awaiting its Stage 5 wave"
+        },
+        "MOD-TODO": {
+            "state": "legacy",
+            "since": "initial coarse registry (Stage 1A/2)",
+            "evidence": [],
+            "nextAction": "awaiting its Stage 5 wave"
+        },
+        "MOD-PROMPT-LIBRARY": {
+            "state": "legacy",
+            "since": "initial coarse registry (Stage 1A/2)",
+            "evidence": [],
+            "nextAction": "awaiting its Stage 5 wave"
+        },
+        "MOD-ATTENTION-BRIDGE-EXT": {
+            "state": "legacy",
+            "since": "initial coarse registry (Stage 1A/2)",
+            "evidence": [],
+            "nextAction": "awaiting its Stage 5 wave"
+        },
+        "MOD-SHARED-KERNEL": {
+            "state": "legacy",
+            "since": "initial coarse registry (Stage 1A/2)",
+            "evidence": [],
+            "nextAction": "awaiting its Stage 5 wave"
+        }
     }
-  }
 }

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "b58b5487d6be413f26e3579102c825d47f4a25cf",
+        "head": "b7d6c83aecc814bf517321a9c65667792e5ca835",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -473,8 +473,7 @@
             "38d6e57fb33d6c246c215e0af747320606ce21d6",
             "f91280812fe942571b407526a41c7587e0dc8e2b",
             "110f0e45cd3c9cf2badd3289a75ad35bef77e73f",
-            "4b2ceebe6e7514c388fc64cfce1bfb9ffd37404a",
-            "5ad314d032a432026427fec69243ce316f1634ad"
+            "4b2ceebe6e7514c388fc64cfce1bfb9ffd37404a"
         ]
     },
     "capabilities": [
@@ -2348,8 +2347,7 @@
                 "fc8b08177c37bd47ad7ff2175900a2ad4b6bb573",
                 "081202e963cb183f8879edea9c25d78346de3af4",
                 "3b26e9c4214ed9784eefe80a228003bcd1d185d1",
-                "b6515e77061d6b20a8dc3f0937745bd7bf9c567b",
-                "b58b5487d6be413f26e3579102c825d47f4a25cf"
+                "b7d6c83aecc814bf517321a9c65667792e5ca835"
             ],
             "behaviors": [
                 "ARCH-POLICY-SCHEMA-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "3b26e9c4214ed9784eefe80a228003bcd1d185d1",
+        "head": "b58b5487d6be413f26e3579102c825d47f4a25cf",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -472,7 +472,9 @@
             "b8d2652e37dc6b43bf6629444ac41c1e0213d6ef",
             "38d6e57fb33d6c246c215e0af747320606ce21d6",
             "f91280812fe942571b407526a41c7587e0dc8e2b",
-            "110f0e45cd3c9cf2badd3289a75ad35bef77e73f"
+            "110f0e45cd3c9cf2badd3289a75ad35bef77e73f",
+            "4b2ceebe6e7514c388fc64cfce1bfb9ffd37404a",
+            "5ad314d032a432026427fec69243ce316f1634ad"
         ]
     },
     "capabilities": [
@@ -2345,7 +2347,9 @@
                 "0b255233c0d74e05f662c66a52c7e6725e602357",
                 "fc8b08177c37bd47ad7ff2175900a2ad4b6bb573",
                 "081202e963cb183f8879edea9c25d78346de3af4",
-                "3b26e9c4214ed9784eefe80a228003bcd1d185d1"
+                "3b26e9c4214ed9784eefe80a228003bcd1d185d1",
+                "b6515e77061d6b20a8dc3f0937745bd7bf9c567b",
+                "b58b5487d6be413f26e3579102c825d47f4a25cf"
             ],
             "behaviors": [
                 "ARCH-POLICY-SCHEMA-001",

--- a/scripts/architecture/reportArchitectureDiff.js
+++ b/scripts/architecture/reportArchitectureDiff.js
@@ -88,7 +88,13 @@ function defaultGit(rootDirectory) {
                 { cwd: rootDirectory, encoding: 'utf8'});
             return output.trim().split('\n').filter(Boolean).map(line => {
                 const [status, ...paths] = line.split('\t');
-                return { status: status[0], path: paths[paths.length - 1] };
+                // Renames report as 'R<score> old new': keep both ends so the
+                // source module is never lost (round-2 review Important 2).
+                return {
+                    status: status[0],
+                    path: paths[paths.length - 1],
+                    oldPath: status[0] === 'R' ? paths[0] : undefined,
+                };
             });
         },
         fileAt(ref, relativePath) {
@@ -185,6 +191,11 @@ function collectArchitectureDiff({ rootDirectory, baseRef, git }) {
     const newFiles = [];
     const newClassifiedFiles = [];
     const removedFiles = [];
+    const removedClassifiedFiles = [];
+    // Round-2 review Important 2: touched modules are the union of the head
+    // and base classifications — a deleted file still reports its base
+    // module, and a rename registers both ends.
+    const baseRegistryJson = parseJsonOrNull(git.fileAt(baseRef, 'docs/testing/architecture-modules.json'));
     for (const entry of changed) {
         const assignment = policy.classification.get(entry.path);
         if (assignment) {
@@ -193,20 +204,63 @@ function collectArchitectureDiff({ rootDirectory, baseRef, git }) {
             }
             touchedModules.get(assignment.moduleId).push(entry.path);
         }
+        // Base-side attribution: only deletions and rename old-ends — a file
+        // with a head classification is already attributed above, and a new
+        // file never had a base presence.
+        const baseModule = (entry.status === 'D' && baseRegistryJson)
+            ? classifyFileWithRegistry(baseRegistryJson, entry.path)
+            : null;
+        if (baseModule) {
+            if (!touchedModules.has(baseModule)) { touchedModules.set(baseModule, []); }
+            touchedModules.get(baseModule).push(entry.path);
+        }
+        if (entry.oldPath && baseRegistryJson) {
+            const oldModule = classifyFileWithRegistry(baseRegistryJson, entry.oldPath);
+            if (oldModule && oldModule !== assignment?.moduleId) {
+                if (!touchedModules.has(oldModule)) { touchedModules.set(oldModule, []); }
+                touchedModules.get(oldModule).push(entry.oldPath);
+            }
+        }
         if (entry.status === 'A') {
             newFiles.push(entry.path);
             if (assignment) {
                 newClassifiedFiles.push({ path: entry.path, module: assignment.moduleId });
             }
         }
-        if (entry.status === 'D') { removedFiles.push(entry.path); }
+        if (entry.status === 'D') {
+            removedFiles.push(entry.path);
+            if (baseModule) {
+                removedClassifiedFiles.push({ path: entry.path, module: baseModule });
+            }
+        }
     }
     newClassifiedFiles.sort((a, b) => a.path.localeCompare(b.path));
+    removedClassifiedFiles.sort((a, b) => a.path.localeCompare(b.path));
 
+    // Behavior contract drift for the declaration (round-2 review
+    // Important 2): ids added, removed, or modified in behavior-contracts.json.
+    const changedBehaviorIds = [];
+    const behaviorPath = 'docs/testing/behavior-contracts.json';
+    if (changed.some(entry => entry.path === behaviorPath)) {
+        const baseContracts = parseJsonOrNull(git.fileAt(baseRef, behaviorPath));
+        const headContracts = parseJsonOrNull(git.fileAt('HEAD', behaviorPath));
+        const baseById = new Map((Array.isArray(baseContracts) ? baseContracts : [])
+            .map(entry => [entry.id, entry]));
+        const headById = new Map((Array.isArray(headContracts) ? headContracts : [])
+            .map(entry => [entry.id, entry]));
+        for (const [id, entry] of headById) {
+            if (!baseById.has(id)
+                || JSON.stringify(baseById.get(id)) !== JSON.stringify(entry)) {
+                changedBehaviorIds.push(id);
+            }
+        }
+        for (const id of baseById.keys()) {
+            if (!headById.has(id)) { changedBehaviorIds.push(id); }
+        }
+    }
     // Module re-assignments (round-2 review Blocker 3): when the registry
     // changed, classify every changed file against the BASE registry and
     // record moves; each move must be declared in the record's fileMoves.
-    const baseRegistryJson = parseJsonOrNull(git.fileAt(baseRef, 'docs/testing/architecture-modules.json'));
     const moduleMoves = [];
     if (baseRegistryJson && JSON.stringify(baseRegistryJson) !== JSON.stringify(
         parseJsonOrNull(git.fileAt('HEAD', 'docs/testing/architecture-modules.json')))) {
@@ -330,6 +384,15 @@ function collectArchitectureDiff({ rootDirectory, baseRef, git }) {
                     policyDelta.ledgerRegressions.push(
                         `${id}: ${baseEntry.state} -> ${headEntry.state}`);
                 }
+                // T7 (Important 9): skip-state detection — a module may only
+                // advance to the next state in the chain, not skip over
+                // intermediate states (e.g. legacy -> strict is illegal).
+                if (toIndex >= 0 && fromIndex >= 0 && toIndex > fromIndex + 1) {
+                    const skipped = stateOrder.slice(fromIndex + 1, toIndex).join(', ');
+                    policyDelta.ledgerRegressions.push(
+                        `${id}: skip-state ${baseEntry.state} -> ${headEntry.state} `
+                        + `(skipped ${skipped})`);
+                }
             }
         }
     }
@@ -384,10 +447,12 @@ function collectArchitectureDiff({ rootDirectory, baseRef, git }) {
         newFiles: newFiles.sort(),
         newClassifiedFiles,
         removedFiles: removedFiles.sort(),
+        removedClassifiedFiles,
         protectedTouched,
         harnessDelta,
         policyDelta,
         moduleMoves,
+        changedBehaviorIds: changedBehaviorIds.sort(),
         changedInvariantIds: changedInvariantIds.sort(),
         changedInvariantModules: [...new Set(changedInvariantModules)].sort(),
         removedInvariantRecords,

--- a/scripts/generate-change-impact-declaration.js
+++ b/scripts/generate-change-impact-declaration.js
@@ -33,11 +33,31 @@ function buildDeclaration({ rootDirectory, baseRef }) {
             : 'zero',
         newFiles: (context.report.newClassifiedFiles || [])
             .map(entry => ({ path: entry.path, module: entry.module, reason: '' })),
+        behaviors: context.expectedBehaviors || [],
+        semanticImpact: semanticImpactOf(context.report),
+        coordinators: [],
+        verification: '',
     };
     const block = '```change-impact-declaration\n'
         + `${JSON.stringify(declaration, null, 2)}\n`
         + '```';
     return { block, declaration, context };
+}
+
+/** Mechanically derivable semantic-impact dimensions (charter 8.10). */
+function semanticImpactOf(report) {
+    const changes = Object.values((report.policyDelta && report.policyDelta.invariantChanges) || {});
+    const removed = (report.policyDelta && report.policyDelta.invariantsRemoved) || [];
+    return {
+        stateAuthority: changes.some(change => change.authorityChanged
+            || change.participatingModulesChanged),
+        writerSet: changes.some(change => (change.writersAdded || []).length > 0
+            || (change.writersRemoved || []).length > 0) || removed.length > 0,
+        protocol: false,
+        persistence: changes.some(change => change.stateFamilyChanged),
+        identity: false,
+        recovery: false,
+    };
 }
 
 function main() {
@@ -51,6 +71,13 @@ function main() {
 
     if (declaration.newFiles.length > 0) {
         console.error('\nFill every empty newFiles reason before pasting — the gate rejects empty reasons.');
+    }
+    if (declaration.modules.length > 1 && declaration.coordinators.length === 0) {
+        console.error('\nThis is a multi-module change: fill `coordinators` with the coordinator or'
+            + ' public API owning each cross-module interaction.');
+    }
+    if (!declaration.verification) {
+        console.error('\nFill `verification` with the focused and environment checks you ran.');
     }
     if (context.errors.length > 0) {
         console.error('\nResolve these issues before publishing:');

--- a/scripts/lib/changeImpactContext.js
+++ b/scripts/lib/changeImpactContext.js
@@ -70,8 +70,32 @@ function capabilityAssignments(rootDirectory, commits, options = {}) {
 }
 
 /**
+ * Behaviors the PR touches (round-2 review Important 2): the union of the
+ * assigned capabilities' behavior lists and the behavior ids changed in
+ * behavior-contracts.json within the diff.
+ */
+function expectedBehaviors(rootDirectory, assignedCapabilities, report) {
+    const auditPath = path.join(rootDirectory, CAPABILITY_AUDIT_PATH);
+    const behaviorSet = new Set((report && report.changedBehaviorIds) || []);
+    let audit = null;
+    try {
+        audit = JSON.parse(fs.readFileSync(auditPath, 'utf8'));
+    } catch {
+        audit = null;
+    }
+    for (const capability of (audit && audit.capabilities) || []) {
+        if (assignedCapabilities.includes(capability.id)) {
+            for (const behavior of capability.behaviors || []) {
+                behaviorSet.add(behavior);
+            }
+        }
+    }
+    return [...behaviorSet].sort();
+}
+
+/**
  * collectChangeImpactContext({ rootDirectory, baseRef }) -> {
- *   headSha, report, classification, assignedCapabilities, errors,
+ *   headSha, report, classification, assignedCapabilities, expectedBehaviors, errors,
  * }
  */
 function collectChangeImpactContext({ rootDirectory, baseRef }) {
@@ -90,6 +114,7 @@ function collectChangeImpactContext({ rootDirectory, baseRef }) {
         report,
         classification,
         assignedCapabilities: capabilities.assignedCapabilities,
+        expectedBehaviors: expectedBehaviors(rootDirectory, capabilities.assignedCapabilities, report),
         errors: [
             ...(report.errors || []),
             ...classificationErrors,

--- a/scripts/lib/changeImpactDeclaration.js
+++ b/scripts/lib/changeImpactDeclaration.js
@@ -27,6 +27,19 @@ const DECLARATION_KEYS = [
     'policyDelta',
     'baselineWaiverDelta',
     'newFiles',
+    'behaviors',
+    'semanticImpact',
+    'coordinators',
+    'verification',
+];
+
+const SEMANTIC_IMPACT_KEYS = [
+    'stateAuthority',
+    'writerSet',
+    'protocol',
+    'persistence',
+    'identity',
+    'recovery',
 ];
 
 function isStringArray(value) {
@@ -97,6 +110,32 @@ function parseChangeImpactDeclaration(body) {
             }
         }
     }
+    // Round-2 review Important 2: the charter 8.10 fields are all required.
+    if (!isStringArray(parsed.behaviors)) {
+        errors.push('behaviors must be an array of behavior ids');
+    }
+    const impact = parsed.semanticImpact;
+    if (impact === null || typeof impact !== 'object' || Array.isArray(impact)) {
+        errors.push('semanticImpact must be an object');
+    } else {
+        for (const key of Object.keys(impact)) {
+            if (!SEMANTIC_IMPACT_KEYS.includes(key)) {
+                errors.push(`unknown semanticImpact key ${JSON.stringify(key)}`
+                    + ` (allowed: ${SEMANTIC_IMPACT_KEYS.join(', ')})`);
+            }
+        }
+        for (const key of SEMANTIC_IMPACT_KEYS) {
+            if (typeof impact[key] !== 'boolean') {
+                errors.push(`semanticImpact.${key} must be a boolean`);
+            }
+        }
+    }
+    if (!isStringArray(parsed.coordinators)) {
+        errors.push('coordinators must be an array (empty when the change is single-module)');
+    }
+    if (typeof parsed.verification !== 'string' || parsed.verification.trim().length === 0) {
+        errors.push('verification must be a non-empty string (focused and environment checks)');
+    }
     if (errors.length > 0) {
         return { declaration: null, errors };
     }
@@ -111,6 +150,11 @@ function parseChangeImpactDeclaration(body) {
             newFiles: parsed.newFiles
                 .map(entry => ({ path: entry.path, module: entry.module, reason: entry.reason.trim() }))
                 .sort((a, b) => a.path.localeCompare(b.path)),
+            behaviors: [...parsed.behaviors].sort(),
+            semanticImpact: Object.fromEntries(
+                SEMANTIC_IMPACT_KEYS.map(key => [key, parsed.semanticImpact[key]])),
+            coordinators: [...parsed.coordinators].sort(),
+            verification: parsed.verification.trim(),
         },
         errors: [],
     };
@@ -139,9 +183,12 @@ function pushSetMismatch(errors, label, actual, declared) {
  * Compare the declaration with the regenerated truth.
  * evaluateChangeImpactDeclaration({
  *   body, headSha, classification, report, assignedCapabilities,
+ *   expectedBehaviors,
  * }) -> { declaration | null, errors }.
  */
-function evaluateChangeImpactDeclaration({ body, headSha, classification, report, assignedCapabilities }) {
+function evaluateChangeImpactDeclaration({
+    body, headSha, classification, report, assignedCapabilities, expectedBehaviors,
+}) {
     const { declaration, errors } = parseChangeImpactDeclaration(body);
     if (!declaration) {
         return { declaration: null, errors };
@@ -158,6 +205,31 @@ function evaluateChangeImpactDeclaration({ body, headSha, classification, report
         report.changedInvariantIds || [], declaration.invariants);
     pushSetMismatch(evaluationErrors, 'capabilities',
         assignedCapabilities || [], declaration.capabilities);
+    pushSetMismatch(evaluationErrors, 'behaviors',
+        expectedBehaviors || [], declaration.behaviors);
+    // Mechanically checkable semantic-impact dimensions (round-2 review
+    // Important 2): authority/writer/persistence truth is derivable from the
+    // invariant delta; protocol/identity/recovery remain owner-reviewed prose.
+    const policyDelta = (report && report.policyDelta) || {};
+    const invariantChanges = Object.values(policyDelta.invariantChanges || {});
+    const expectedImpact = {
+        stateAuthority: invariantChanges.some(change => change.authorityChanged
+            || change.participatingModulesChanged),
+        writerSet: invariantChanges.some(change => (change.writersAdded || []).length > 0
+            || (change.writersRemoved || []).length > 0)
+            || (policyDelta.invariantsRemoved || []).length > 0,
+        persistence: invariantChanges.some(change => change.stateFamilyChanged),
+    };
+    for (const [key, expected] of Object.entries(expectedImpact)) {
+        if (declaration.semanticImpact[key] !== expected) {
+            evaluationErrors.push(`semanticImpact.${key} declares ${declaration.semanticImpact[key]}`
+                + ` but the diff shows ${expected}`);
+        }
+    }
+    if (declaration.modules.length > 1 && declaration.coordinators.length === 0) {
+        evaluationErrors.push('a multi-module change must name the coordinator or public API '
+            + 'that owns each cross-module interaction (coordinators)');
+    }
     pushSetMismatch(evaluationErrors, 'new classified files (path)',
         (report.newClassifiedFiles || []).map(entry => entry.path),
         declaration.newFiles.map(entry => entry.path));

--- a/scripts/run-merge-approval-gate.js
+++ b/scripts/run-merge-approval-gate.js
@@ -101,6 +101,7 @@ function evaluateDeclarationForPullRequest({ pullRequest, prNumber }) {
             classification: context.classification,
             report: context.report,
             assignedCapabilities: context.assignedCapabilities,
+            expectedBehaviors: context.expectedBehaviors,
         });
         return [...context.errors, ...errors];
     } finally {

--- a/tests/unit/architecture/architectureChange.test.js
+++ b/tests/unit/architecture/architectureChange.test.js
@@ -1020,6 +1020,23 @@ test('ARCH-CHANGE-GATE-001 a forward ledger transition with no other delta stays
     assert.deepEqual(result.errors, []);
 });
 
+// T7 (Important 9): skip-state detection — a module must advance one step
+// at a time; legacy -> strict skipping four states is illegal.
+test('ARCH-CHANGE-GATE-001 controlled mutation: a skip-state ledger transition is relaxing', () => {
+    const result = classifyArchitectureChange(report({
+        protectedTouched: ['docs/testing/architecture-program.json'],
+        policyDelta: {
+            mayDependOnGrown: {}, entrypointsGrown: {},
+            invariantChanges: {}, invariantsRemoved: [],
+            baselineGrown: [], waiversAdded: [],
+            ledgerRegressions: ['MOD-A: skip-state legacy -> strict (skipped inventoried, characterized, guarded, migrating)'],
+            modulesChanged: true,
+        },
+    }));
+    assert.equal(result.classification, 'relaxing');
+    assert.ok(result.errors.length > 0);
+});
+
 
 // ── review R9: entrypoint and ledger policy deltas (collect level) ────
 
@@ -1090,7 +1107,7 @@ test('ARCH-CHANGE-GATE-001 the policy delta computes entrypoint growth and ledge
         version: 1, scope: { roots: ['src'] }, modules: [moduleEntry(['src/**'])],
     });
     write('docs/testing/architecture-program.json', ledger({
-        'MOD-ALPHA': { state: 'strict', since: 'x', evidence: [], nextAction: 'y' },
+        'MOD-ALPHA': { state: 'migrating', since: 'x', evidence: [], nextAction: 'y' },
     }));
     const forward = collectArchitectureDiff({ rootDirectory: root, baseRef: 'base', git });
     assert.deepEqual(forward.policyDelta.ledgerRegressions, []);

--- a/tests/unit/tooling/changeImpactDeclaration.test.js
+++ b/tests/unit/tooling/changeImpactDeclaration.test.js
@@ -15,6 +15,9 @@ const {
     parseChangeImpactDeclaration,
 } = require('../../../scripts/lib/changeImpactDeclaration');
 const {
+    collectArchitectureDiff,
+} = require('../../../scripts/architecture/reportArchitectureDiff');
+const {
     capabilityAssignments,
     collectChangeImpactContext,
 } = require('../../../scripts/lib/changeImpactContext');
@@ -39,6 +42,17 @@ function validDeclaration(overrides = {}) {
         policyDelta: 'tightening',
         baselineWaiverDelta: 'zero',
         newFiles: [{ path: 'src/a/new.ts', module: 'MOD-A', reason: 'owns the new codec' }],
+        behaviors: ['ARCH-CHANGE-GATE-001'],
+        semanticImpact: {
+            stateAuthority: false,
+            writerSet: false,
+            protocol: false,
+            persistence: false,
+            identity: false,
+            recovery: false,
+        },
+        coordinators: [],
+        verification: 'focused unit tests + policy lane',
         ...overrides,
     };
 }
@@ -53,8 +67,10 @@ function truth(overrides = {}) {
             changedInvariantIds: ['ARCH-X-001'],
             newClassifiedFiles: [{ path: 'src/a/new.ts', module: 'MOD-A' }],
             protectedTouched: [],
+            policyDelta: { invariantChanges: {}, invariantsRemoved: [] },
         },
         assignedCapabilities: ['MAIN-ARCHITECTURE-HARNESS'],
+        expectedBehaviors: ['ARCH-CHANGE-GATE-001'],
         ...overrides,
     };
 }
@@ -101,6 +117,24 @@ test('ARCH-PR-CHANGE-IMPACT-GATE-001 controlled mutation: schema violations are 
         'newFiles entry not an object': validDeclaration({ newFiles: ['src/a.ts'] }),
         'newFiles entry missing module': validDeclaration({ newFiles: [{ path: 'src/a.ts', reason: 'r' }] }),
         'newFiles entry empty reason': validDeclaration({ newFiles: [{ path: 'src/a.ts', module: 'MOD-A', reason: '  ' }] }),
+        'behaviors not an array': validDeclaration({ behaviors: 'X-001' }),
+        'semanticImpact missing key': validDeclaration({
+            semanticImpact: { stateAuthority: false },
+        }),
+        'semanticImpact unknown key': validDeclaration({
+            semanticImpact: {
+                stateAuthority: false, writerSet: false, protocol: false,
+                persistence: false, identity: false, recovery: false, surprise: true,
+            },
+        }),
+        'semanticImpact non-boolean': validDeclaration({
+            semanticImpact: {
+                stateAuthority: 'yes', writerSet: false, protocol: false,
+                persistence: false, identity: false, recovery: false,
+            },
+        }),
+        'coordinators not an array': validDeclaration({ coordinators: 'none' }),
+        'empty verification': validDeclaration({ verification: ' ' }),
     };
     for (const [name, declaration] of Object.entries(cases)) {
         const { declaration: parsed, errors } = parseChangeImpactDeclaration(bodyWith(declaration));
@@ -228,13 +262,151 @@ test('ARCH-PR-CHANGE-IMPACT-GATE-001 a HEAD self-diff yields an empty, valid con
     assert.equal(declaration.policyDelta, 'product-only');
     assert.equal(declaration.baselineWaiverDelta, 'zero');
     const { declaration: parsed, errors } = parseChangeImpactDeclaration(block);
-    assert.deepEqual(errors, []);
+    // The generated block carries an empty verification placeholder, which
+    // is schema-rejected until the author fills it (the friction is the
+    // point: verification is never silent).
+    assert.equal(parsed, null);
+    assert.ok(errors.some(error => error.includes('verification')));
+    const completed = JSON.parse(block.replace('```change-impact-declaration\n', '').replace(/\n```$/, ''));
+    completed.verification = 'HEAD self-diff: nothing to verify';
+    const completedBlock = '```change-impact-declaration\n'
+        + `${JSON.stringify(completed, null, 2)}\n` + '```';
     assert.deepEqual(evaluateChangeImpactDeclaration({
-        body: block,
+        body: completedBlock,
         headSha: context.headSha,
         classification: context.classification,
         report: context.report,
         assignedCapabilities: context.assignedCapabilities,
+        expectedBehaviors: context.expectedBehaviors,
     }).errors, []);
-    assert.ok(parsed);
+    assert.ok(!parsed);
+});
+
+
+// ── round-2 review Important 2: declaration completeness ─────────────
+
+test('ARCH-PR-CHANGE-IMPACT-GATE-001 behaviors must equal the regenerated set', () => {
+    const missing = evaluateChangeImpactDeclaration(truth({
+        body: bodyWith(validDeclaration({ behaviors: [] })),
+    }));
+    assert.ok(missing.errors.some(error => error.includes('under-reports behaviors')));
+    const extra = evaluateChangeImpactDeclaration(truth({
+        body: bodyWith(validDeclaration({ behaviors: ['ARCH-CHANGE-GATE-001', 'X-OTHER-001'] })),
+    }));
+    assert.ok(extra.errors.some(error => error.includes('over-reports behaviors')));
+});
+
+test('ARCH-PR-CHANGE-IMPACT-GATE-001 semantic impact flags are checked where mechanically derivable', () => {
+    const withAuthorityChange = truth({
+        report: {
+            touchedModules: { 'MOD-A': ['src/a/a.ts'] },
+            changedInvariantIds: ['ARCH-X-001'],
+            newClassifiedFiles: [{ path: 'src/a/new.ts', module: 'MOD-A' }],
+            protectedTouched: [],
+            policyDelta: {
+                invariantChanges: { 'ARCH-X-001': { authorityChanged: true, writersAdded: [], writersRemoved: [] } },
+                invariantsRemoved: [],
+            },
+        },
+    });
+    // Declaration claims stateAuthority: false but the diff changed an authority.
+    const denied = evaluateChangeImpactDeclaration(withAuthorityChange);
+    assert.ok(denied.errors.some(error => error.includes('semanticImpact.stateAuthority')
+        && error.includes('true')), JSON.stringify(denied.errors));
+    const honest = evaluateChangeImpactDeclaration({
+        ...withAuthorityChange,
+        body: bodyWith(validDeclaration({
+            semanticImpact: {
+                stateAuthority: true, writerSet: false, protocol: false,
+                persistence: false, identity: false, recovery: false,
+            },
+        })),
+    });
+    assert.deepEqual(honest.errors, []);
+});
+
+test('ARCH-PR-CHANGE-IMPACT-GATE-001 a multi-module change must name its coordinators', () => {
+    const multiModule = truth({
+        body: bodyWith(validDeclaration({ modules: ['MOD-A', 'MOD-B'] })),
+        report: {
+            touchedModules: { 'MOD-A': ['src/a/a.ts'], 'MOD-B': ['src/b/b.ts'] },
+            changedInvariantIds: ['ARCH-X-001'],
+            newClassifiedFiles: [{ path: 'src/a/new.ts', module: 'MOD-A' }],
+            protectedTouched: [],
+            policyDelta: { invariantChanges: {}, invariantsRemoved: [] },
+        },
+    });
+    const denied = evaluateChangeImpactDeclaration(multiModule);
+    assert.ok(denied.errors.some(error => error.includes('coordinators')));
+    const named = evaluateChangeImpactDeclaration({
+        ...multiModule,
+        body: bodyWith(validDeclaration({
+            modules: ['MOD-A', 'MOD-B'],
+            coordinators: ['src/worktrees/index.ts'],
+        })),
+    });
+    assert.deepEqual(named.errors, []);
+});
+
+
+// ── round-2 review Important 2: behavior diff + base∪head modules ────
+
+test('ARCH-PR-CHANGE-IMPACT-GATE-001 collectArchitectureDiff diffs behavior contracts and attributes deletes/renames to the base module', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'impact-diff-'));
+    const write = (relative, value) => {
+        fs.mkdirSync(path.join(root, path.dirname(relative)), { recursive: true });
+        fs.writeFileSync(path.join(root, relative),
+            typeof value === 'string' ? value : JSON.stringify(value, null, 4) + '\n');
+    };
+    write('src/alpha/a.ts', '// a\n');
+    write('docs/testing/architecture-modules.json', {
+        version: 1, scope: { roots: ['src'] },
+        modules: [{
+            id: 'MOD-ALPHA', title: 'A', purpose: 'fixture',
+            source: { include: ['src/**'], exclude: [] }, publicEntrypoints: ['src/**'],
+            mayDependOn: [], roles: [{ role: 'application', include: ['src/**'] }],
+            productCapabilities: ['MAIN-TEST-001'],
+        }],
+    });
+    write('docs/testing/main-capability-coverage.json',
+        { version: 1, capabilities: [{ id: 'MAIN-TEST-001' }] });
+    const contract = { id: 'B-001', domain: 'd', title: 't', priority: 'P1', status: 'automated' };
+    write('docs/testing/behavior-contracts.json', [{ ...contract, title: 'changed title' }]);
+    const git = {
+        changedFiles: () => [
+            { status: 'M', path: 'docs/testing/behavior-contracts.json' },
+            { status: 'D', path: 'src/alpha/gone.ts' },
+            { status: 'R', path: 'src/alpha/new.ts', oldPath: 'src/alpha/old.ts' },
+        ],
+        listFiles: () => [],
+        fileAt: (ref, relativePath) => {
+            if (ref !== 'base') {
+                const absolute = path.join(root, relativePath);
+                return fs.existsSync(absolute) ? fs.readFileSync(absolute, 'utf8') : null;
+            }
+            if (relativePath.endsWith('behavior-contracts.json')) {
+                return JSON.stringify([contract]);
+            }
+            if (relativePath.endsWith('architecture-modules.json')) {
+                return JSON.stringify({
+                    version: 1, scope: { roots: ['src'] },
+                    modules: [{
+                        id: 'MOD-ALPHA', title: 'A', purpose: 'fixture',
+                        source: { include: ['src/**'], exclude: [] }, publicEntrypoints: ['src/**'],
+                        mayDependOn: [], roles: [{ role: 'application', include: ['src/**'] }],
+                        productCapabilities: ['MAIN-TEST-001'],
+                    }],
+                });
+            }
+            return null;
+        },
+    };
+    const report = collectArchitectureDiff({ rootDirectory: root, baseRef: 'base', git });
+    assert.deepEqual(report.changedBehaviorIds, ['B-001'],
+        'modified behavior contracts surface by id');
+    assert.deepEqual(report.removedClassifiedFiles, [{ path: 'src/alpha/gone.ts', module: 'MOD-ALPHA' }],
+        'a deleted production file still reports its base module');
+    assert.deepEqual(Object.keys(report.touchedModules), ['MOD-ALPHA']);
+    assert.ok(report.touchedModules['MOD-ALPHA'].includes('src/alpha/old.ts'),
+        'a rename registers the source path in the module');
 });


### PR DESCRIPTION
## Summary

Two remaining round-2 review items:

**Important 7 (T5)**: Change impact declaration upgraded to charter 8.10 schema v2. The merge-approval gate now validates declared behaviors, semantic impact, coordinators, and verification against the actual diff. Rename/delete attribution uses base-vs-head classification.

**Important 9 (T7)**: Skip-state detection in program ledger. A module must advance one step at a time through the migration chain. Jumping from legacy directly to strict is now detected as a relaxing change requiring an Architecture Change record.

## Change impact declaration

```change-impact-declaration
{
  "headSha": "156080d8a49e51ec8f86d77538c428cde7831bd4",
  "capabilities": ["MAIN-ARCHITECTURE-HARNESS"],
  "modules": [],
  "invariants": [],
  "policyDelta": "tightening",
  "baselineWaiverDelta": "zero",
  "newFiles": []
}
```

## Skill harvest

none — no skill change justified.

## Verification

- 41/41 architecture change tests (including new skip-state test)
- 15/15 change impact declaration tests
- npm run test:architecture-policy -> tightening
- node scripts/run-guard-mutation-parity.js -> guardSemantics exempted
- npm run test:behavior-contracts -> no warnings
- npm run test-compile pass