### PR TITLE
feat(architecture): wire approve-architecture consumption (transition to PR 3/6)

### DIFF
--- a/.github/workflows/trusted-kernel.yml
+++ b/.github/workflows/trusted-kernel.yml
@@ -2,7 +2,15 @@ name: Trusted Kernel
 
 on:
   pull_request_target:
+    # edited: an approval comment is evaluated against the body/head state;
+    # synchronize invalidates approvals automatically because they bind the
+    # exact head SHA.
     types: [opened, synchronize]
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
 
 jobs:
   evaluate:
@@ -16,10 +24,17 @@ jobs:
         with:
           node-version: 22
       - run: npm ci
+        # The default-branch checkout fetches only the base ref; the kernel
+        # materializes the PR head as data, so the head commit must exist
+        # locally first.
+      - name: Fetch PR head
+        run: git fetch origin +refs/pull/${{ github.event.pull_request.number }}/head
       - name: Run trusted kernel
         env:
           PR_HEAD_REF: ${{ github.event.pull_request.head.sha }}
           PR_BASE_REF: origin/${{ github.base_ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node scripts/run-trusted-kernel.js
 
   architecture-approval:
@@ -33,6 +48,10 @@ jobs:
         with:
           node-version: 22
       - run: npm ci
+        # Same reason as the evaluate job: the gate diffs the base against
+        # the fetched PR head SHA.
+      - name: Fetch PR head
+        run: git fetch origin +refs/pull/${{ github.event.pull_request.number }}/head
       - name: Check architecture approval
         env:
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -20,6 +20,12 @@ jobs:
     name: quality-linux
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
+      # issues: read lets the quality lane detect the owner's
+      # `approve-architecture <full-head-sha>` comment (developer feedback
+      # only; the merge-approval gate re-verifies from the default branch).
+      issues: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -43,6 +49,41 @@ jobs:
             echo "::warning::Chromium install attempt ${attempt} failed"
           done
           exit 1
+      - name: Detect owner architecture approval
+        if: github.event_name == 'pull_request'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          OWNER: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+          gh api "repos/${REPO}/issues/${PR_NUMBER}/comments?per_page=100" --paginate --slurp > "${RUNNER_TEMP}/pr-comments.json"
+          count=$(node -e '
+            const fs = require("fs");
+            const pages = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+            const owner = process.argv[2].toLowerCase();
+            const headSha = process.argv[3].toLowerCase();
+            const pattern = /^\s*approve-architecture\s+([0-9a-f]{40})\s*$/i;
+            let count = 0;
+            for (const page of pages) for (const comment of page) {
+              if (String(comment?.user?.login || "").toLowerCase() !== owner) continue;
+              const matched = String(comment.body || "").split("\n").some(line => {
+                const m = pattern.exec(line);
+                return m && m[1].toLowerCase() === headSha;
+              });
+              if (matched) count += 1;
+            }
+            console.log(count);
+          ' "${RUNNER_TEMP}/pr-comments.json" "$OWNER" "$HEAD_SHA")
+          if [ "$count" -gt 0 ]; then
+            echo "Owner architecture approval found for ${HEAD_SHA}"
+            echo "ARCHITECTURE_APPROVED=true" >> "$GITHUB_ENV"
+          else
+            echo "No owner architecture approval for ${HEAD_SHA}"
+          fi
       - name: Run Linux quality gate
         run: npm run test:ci:linux
         env:

--- a/.skills/fixing-regressions-with-ci/SKILL.md
+++ b/.skills/fixing-regressions-with-ci/SKILL.md
@@ -18,6 +18,13 @@ Turn every confirmed regression into a CI-owned behavior before changing product
 1. **Diagnose**
    - Reproduce the symptom and trace the root cause.
    - Define the user-visible expected behavior. Do not freeze accidental current behavior.
+   - Identify which side of the PR supplies the failing check's code before
+     editing: `pull_request` checks run PR-head files, but
+     `pull_request_target` checks (merge-approval gate, trusted kernel) run
+     default-branch files, so a PR-head edit cannot change a default-branch
+     check's behavior until it merges. Confirm against the failed run's log
+     line provenance; when the fix must land on the default branch first,
+     sequence a dedicated PR instead of iterating on the blocked one.
 2. **Own the behavior**
    - Read `docs/testing/README.md`.
    - Select an existing behavior ID or add one to `docs/testing/behavior-contracts.json`.

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -6773,7 +6773,7 @@
   {
     "id": "ARCH-CHANGE-GATE-001",
     "domain": "architecture",
-    "title": "Changes to protected architecture policy are classified as product-only, tightening, relaxing, or registry re-partition; relaxing and re-partition require an ARCH-CHANGE record",
+    "title": "Changes to protected architecture policy are classified as product-only, tightening, relaxing, or registry re-partition; relaxing and re-partition require an owner architecture approval (approve-architecture <sha>) or an ARCH-CHANGE record in the base",
     "priority": "P0",
     "status": "automated",
     "owners": [

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "19665f5f28fa4ef94bc529847fa1260b9a98456c",
+        "head": "86a597dbe65633fd3328534788890febeb1644fd",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -2352,7 +2352,7 @@
                 "3b26e9c4214ed9784eefe80a228003bcd1d185d1",
                 "b7d6c83aecc814bf517321a9c65667792e5ca835",
                 "630595db25f3f3723c85aa863de001982a1f6aaa",
-                "19665f5f28fa4ef94bc529847fa1260b9a98456c"
+                "86a597dbe65633fd3328534788890febeb1644fd"
             ],
             "behaviors": [
                 "ARCH-POLICY-SCHEMA-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "630595db25f3f3723c85aa863de001982a1f6aaa",
+        "head": "19665f5f28fa4ef94bc529847fa1260b9a98456c",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -475,7 +475,8 @@
             "110f0e45cd3c9cf2badd3289a75ad35bef77e73f",
             "4b2ceebe6e7514c388fc64cfce1bfb9ffd37404a",
             "156080d8a49e51ec8f86d77538c428cde7831bd4",
-            "4cf025e589a2f7426ae1f68d40c774429b6b9855"
+            "4cf025e589a2f7426ae1f68d40c774429b6b9855",
+            "8aeef7b953132be14677977d21d41ffe1e051dd0"
         ]
     },
     "capabilities": [
@@ -2350,7 +2351,8 @@
                 "081202e963cb183f8879edea9c25d78346de3af4",
                 "3b26e9c4214ed9784eefe80a228003bcd1d185d1",
                 "b7d6c83aecc814bf517321a9c65667792e5ca835",
-                "630595db25f3f3723c85aa863de001982a1f6aaa"
+                "630595db25f3f3723c85aa863de001982a1f6aaa",
+                "19665f5f28fa4ef94bc529847fa1260b9a98456c"
             ],
             "behaviors": [
                 "ARCH-POLICY-SCHEMA-001",

--- a/scripts/architecture/checkArchitectureChange.js
+++ b/scripts/architecture/checkArchitectureChange.js
@@ -13,18 +13,27 @@
  *   the harness surface weakened (a guard file deleted, a guard id removed,
  *   a lane or workflow invocation removed, mutation tests shrank).
  *
- * A relaxing or re-partition change is authorized only by an Architecture
- * Change record that already exists in the PR base (review R3; charter 8.9:
- * the record lands in its own earlier PR before product work consumes it).
- * The record must carry a valid ```arch-change machine-summary block whose
- * declared delta covers the actual policy delta; an empty markdown file, a
- * bare filename match, or a record added in the same PR never authorizes.
- * Because every merge requires the merge-approval status (owner comment
- * newer than the PR head), a record present in the base was necessarily
- * approved after its final commit — approval timing holds transitively.
+ * A relaxing or re-partition change is authorized in one of two ways:
+ *
+ * 1. Owner architecture approval (Harness Simplification decision,
+ *    docs/architecture/harness-simplification-decision.md): the repository
+ *    owner comments `approve-architecture <full-head-sha>` on the PR. The
+ *    approval binds the exact head and expires when the head moves. This is
+ *    the transitional replacement for machine authorization and the only
+ *    path once Architecture Change records become historical ADRs.
+ * 2. An Architecture Change record that already exists in the PR base
+ *    (review R3; charter 8.9: the record lands in its own earlier PR before
+ *    product work consumes it). The record must carry a valid ```arch-change
+ *    machine-summary block whose declared delta covers the actual policy
+ *    delta; an empty markdown file, a bare filename match, or a record added
+ *    in the same PR never authorizes. Because every merge requires the
+ *    merge-approval status (owner comment newer than the PR head), a record
+ *    present in the base was necessarily approved after its final commit —
+ *    approval timing holds transitively.
  *
  * An agent cannot legalize its own violation: the classification is computed
- * from the diff, not declared.
+ * from the diff, not declared, and both authorization paths live outside the
+ * PR head (owner comment on the PR, record in the base).
  */
 
 const path = require('path');
@@ -100,8 +109,9 @@ function computeActualDelta(report, classification, harnessWeakened) {
  * Change records present in the base. Returns the error list (empty when
  * authorized).
  */
-function authorizeWithBaseRecords(report, classification, harnessWeakened) {
+function authorizeWithBaseRecords(report, classification, harnessWeakened, options) {
     const baseRecords = report.baseRecords || [];
+    const architectureApproved = Boolean(options && options.architectureApproved);
     const candidates = [];
     const invalid = [];
     for (const { path: recordPath, text } of baseRecords) {
@@ -121,18 +131,28 @@ function authorizeWithBaseRecords(report, classification, harnessWeakened) {
 
     const verb = classification === 'relaxing' ? 'relaxes' : 're-partitions';
     const errors = [];
+    if (architectureApproved) {
+        // Owner architecture approval (approve-architecture <full-head-sha>)
+        // authorizes the relaxation; the approval is verified by the caller
+        // against the exact head SHA and never by PR-head content.
+        return errors;
+    }
     if (candidates.length === 0) {
         errors.push(`anti-self-amendment: this change ${verb} architecture policy or weakens the `
             + 'harness, and no valid approved Architecture Change record exists in the PR base '
-            + `(found ${baseRecords.length} record file(s), ${invalid.length} invalid). Land a `
+            + `(found ${baseRecords.length} record file(s), ${invalid.length} invalid). Owner `
+            + 'architecture approval required — comment '
+            + '\'approve-architecture <full-head-sha>\' on the pull request; alternatively land a '
             + 'docs-only PR adding docs/architecture/changes/ARCH-CHANGE-<seq>.md with an '
             + '```arch-change machine-summary block (id, status "approved", modules, declared '
             + 'delta) first; a record added in the same PR never authorizes consumption.');
     } else {
         errors.push(`anti-self-amendment: this change ${verb} architecture policy or weakens the `
             + `harness beyond every approved Architecture Change record in the PR base. Uncovered `
-            + `delta: ${bestMissing.join('; ')}. Land a docs-only record PR declaring this delta `
-            + 'first, or narrow the change to what an existing record declares.');
+            + `delta: ${bestMissing.join('; ')}. Owner architecture approval required — comment `
+            + '\'approve-architecture <full-head-sha>\' on the pull request; alternatively land a '
+            + 'docs-only record PR declaring this delta first, or narrow the change to what an '
+            + 'existing record declares.');
     }
     if (report.newFiles.some(file => ARCH_CHANGE_RECORD_PATTERN.test(file))) {
         errors.push('anti-self-amendment: this PR adds an Architecture Change record and consumes '
@@ -142,12 +162,15 @@ function authorizeWithBaseRecords(report, classification, harnessWeakened) {
 }
 
 /**
- * classifyArchitectureChange(report) -> {
+ * classifyArchitectureChange(report, options) -> {
  *   classification: 'product-only' | 'tightening' | 'relaxing' | 're-partition',
  *   errors: string[]
  * }
+ * options.architectureApproved: the owner has bound an architecture approval
+ * comment to the exact head SHA (verified by the caller, never by PR-head
+ * content).
  */
-function classifyArchitectureChange(report) {
+function classifyArchitectureChange(report, options) {
     const errors = [];
     if (report.errors && report.errors.length > 0) {
         errors.push(...report.errors);
@@ -191,11 +214,11 @@ function classifyArchitectureChange(report) {
         return { classification: 'tightening', errors };
     }
     const classification = relaxing ? 'relaxing' : 're-partition';
-    errors.push(...authorizeWithBaseRecords(report, classification, harnessWeakened));
+    errors.push(...authorizeWithBaseRecords(report, classification, harnessWeakened, options));
     return { classification, errors };
 }
 
-function runArchitectureChangeCheck(rootDirectory, baseRef) {
+function runArchitectureChangeCheck(rootDirectory, baseRef, options) {
     const report = collectArchitectureDiff({
         rootDirectory,
         baseRef: baseRef || process.env.COVERAGE_DIFF_BASE
@@ -203,13 +226,17 @@ function runArchitectureChangeCheck(rootDirectory, baseRef) {
             || 'origin/main',
         git: defaultGit(rootDirectory),
     });
-    const { classification, errors } = classifyArchitectureChange(report);
+    const { classification, errors } = classifyArchitectureChange(report, options);
     return { classification, errors, report };
 }
 
 function main() {
+    // The quality lane runs PR-head code, so this env flag is developer
+    // feedback only: the merge-approval gate re-verifies the same owner
+    // comment from the default branch before the PR can merge.
+    const architectureApproved = process.env.ARCHITECTURE_APPROVED === 'true';
     const { classification, errors } = runArchitectureChangeCheck(
-        path.resolve(__dirname, '..', '..'));
+        path.resolve(__dirname, '..', '..'), undefined, { architectureApproved });
     if (errors.length > 0) {
         console.error(`Architecture change gate FAILED (classification: ${classification}):`);
         for (const error of errors) { console.error(`  ✗ ${error}`); }

--- a/scripts/lib/changeImpactContext.js
+++ b/scripts/lib/changeImpactContext.js
@@ -94,11 +94,13 @@ function expectedBehaviors(rootDirectory, assignedCapabilities, report) {
 }
 
 /**
- * collectChangeImpactContext({ rootDirectory, baseRef }) -> {
+ * collectChangeImpactContext({ rootDirectory, baseRef, architectureApproved }) -> {
  *   headSha, report, classification, assignedCapabilities, expectedBehaviors, errors,
  * }
+ * architectureApproved: the owner has bound an `approve-architecture
+ * <full-head-sha>` comment to the exact head (verified by the caller).
  */
-function collectChangeImpactContext({ rootDirectory, baseRef }) {
+function collectChangeImpactContext({ rootDirectory, baseRef, architectureApproved }) {
     const headSha = git(rootDirectory, ['rev-parse', 'HEAD']);
     const commits = git(rootDirectory, ['rev-list', '--no-merges', `${baseRef}..HEAD`])
         .split('\n').filter(Boolean);
@@ -107,7 +109,8 @@ function collectChangeImpactContext({ rootDirectory, baseRef }) {
         baseRef,
         git: defaultGit(rootDirectory),
     });
-    const { classification, errors: classificationErrors } = classifyArchitectureChange(report);
+    const { classification, errors: classificationErrors } = classifyArchitectureChange(
+        report, { architectureApproved: Boolean(architectureApproved) });
     const capabilities = capabilityAssignments(rootDirectory, commits);
     return {
         headSha,

--- a/scripts/lib/mergeApprovals.js
+++ b/scripts/lib/mergeApprovals.js
@@ -10,6 +10,13 @@
 // The binding form: a first-word marker, then the full 40-hex head SHA.
 const MERGE_APPROVAL_PATTERN = /^\s*(?:合并|批准|lgtm|approve[ds]?|merge)\s+([0-9a-f]{40})\s*$/i;
 
+// Architecture approval (Harness Simplification, see
+// docs/architecture/harness-simplification-decision.md): a distinct owner
+// comment authorizing relaxing/re-partition changes and protected-path
+// edits. Standard `approve <sha>` never substitutes for it; both bind the
+// exact head SHA and expire when the head moves.
+const ARCHITECTURE_APPROVAL_PATTERN = /^\s*approve-architecture\s+([0-9a-f]{40})\s*$/i;
+
 // Legacy free-form markers, recognized only to explain the failure and for
 // merges that predate the SHA binding (the audit switches per merge by
 // content marker, not by date).
@@ -31,6 +38,12 @@ function approvalBoundSha(body) {
 /** Legacy free-form marker (no SHA binding). */
 function isApprovalComment(body) {
     return LEGACY_APPROVAL_PATTERN.test(String(body || ''));
+}
+
+/** The full head SHA an architecture approval comment binds, or null. */
+function architectureApprovalBoundSha(body) {
+    const match = ARCHITECTURE_APPROVAL_PATTERN.exec(String(body || ''));
+    return match ? match[1].toLowerCase() : null;
 }
 
 /** Latest owner comment that binds expectedSha, or null. */
@@ -102,6 +115,25 @@ function evaluateMergeApproval(options) {
     };
 }
 
+/** Latest owner architecture approval comment that binds expectedSha, or null. */
+function findArchitectureApprovalComment(comments, options) {
+    const authorLogin = String(options.authorLogin || '').toLowerCase();
+    const expectedSha = String(options.headSha || '').toLowerCase();
+    let latest = null;
+    for (const comment of comments || []) {
+        if (!comment || String(comment?.user?.login || '').toLowerCase() !== authorLogin) {
+            continue;
+        }
+        if (architectureApprovalBoundSha(comment.body) !== expectedSha) {
+            continue;
+        }
+        if (!latest || Date.parse(comment.created_at || '') > Date.parse(latest.created_at || '')) {
+            latest = comment;
+        }
+    }
+    return latest;
+}
+
 /** Audit predicate: merges at or after the activation date must be approved. */
 function mergeRequiresApproval(mergedAt) {
     const mergedAtMs = Date.parse(mergedAt || '');
@@ -113,10 +145,13 @@ function mergeRequiresApproval(mergedAt) {
 
 module.exports = {
     MERGE_APPROVAL_PATTERN,
+    ARCHITECTURE_APPROVAL_PATTERN,
     MERGE_APPROVAL_REQUIRED_SINCE,
     approvalBoundSha,
+    architectureApprovalBoundSha,
     isApprovalComment,
     findApprovalComment,
+    findArchitectureApprovalComment,
     evaluateMergeApproval,
     mergeRequiresApproval,
 };

--- a/scripts/run-architecture-approval-gate.js
+++ b/scripts/run-architecture-approval-gate.js
@@ -42,8 +42,10 @@ function main() {
         process.exit(1);
     }
 
-    // Check if any protected files changed
-    const changed = execFileSync('git', ['diff', '--name-only', baseRef, 'HEAD'], {
+    // Check if any protected files changed. The workflow checks out the base
+    // branch (pull_request_target), so the PR head is diffed via its fetched
+    // SHA — diffing baseRef against HEAD would compare the base to itself.
+    const changed = execFileSync('git', ['diff', '--name-only', baseRef, headSha], {
         encoding: 'utf8', maxBuffer: 10 * 1024 * 1024,
     }).trim().split('\n').filter(Boolean);
 

--- a/scripts/run-merge-approval-gate.js
+++ b/scripts/run-merge-approval-gate.js
@@ -13,7 +13,7 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 const { execFileSync } = require('node:child_process');
-const { evaluateMergeApproval } = require('./lib/mergeApprovals');
+const { evaluateMergeApproval, findArchitectureApprovalComment } = require('./lib/mergeApprovals');
 const { evaluateChangeImpactDeclaration } = require('./lib/changeImpactDeclaration');
 const { collectChangeImpactContext } = require('./lib/changeImpactContext');
 
@@ -81,7 +81,7 @@ function git(args) {
  * worktree used purely as data; the evaluator code itself comes from the
  * default-branch checkout (the workflow runs on pull_request_target).
  */
-function evaluateDeclarationForPullRequest({ pullRequest, prNumber }) {
+function evaluateDeclarationForPullRequest({ pullRequest, prNumber, architectureApproved }) {
     const baseRefName = pullRequest.base?.ref;
     const headSha = pullRequest.head?.sha;
     if (!baseRefName || !headSha) {
@@ -94,6 +94,7 @@ function evaluateDeclarationForPullRequest({ pullRequest, prNumber }) {
         const context = collectChangeImpactContext({
             rootDirectory: worktreeDir,
             baseRef: `origin/${baseRefName}`,
+            architectureApproved,
         });
         const { errors } = evaluateChangeImpactDeclaration({
             body: pullRequest.body || '',
@@ -137,12 +138,23 @@ async function main() {
         authorLogin: ownerLogin,
         headSha,
     });
+    // Harness Simplification: a relaxing/re-partition classification is
+    // authorized by the owner's `approve-architecture <full-head-sha>`
+    // comment (replacing Architecture Change record machine authorization).
+    const architectureApproval = findArchitectureApprovalComment(comments, {
+        authorLogin: ownerLogin,
+        headSha,
+    });
 
     // Review R4 (charter 8.10): the PR body declaration is compared with the
     // regenerated architecture impact for the exact head being approved.
     // Git failures crash the job before posting, which blocks the merge
     // (fail-closed); declaration mismatches post a failure status.
-    const declarationErrors = evaluateDeclarationForPullRequest({ pullRequest, prNumber });
+    const declarationErrors = evaluateDeclarationForPullRequest({
+        pullRequest,
+        prNumber,
+        architectureApproved: Boolean(architectureApproval),
+    });
 
     const reasons = [];
     if (!verdict.approved) { reasons.push(verdict.reason); }

--- a/scripts/run-trusted-kernel.js
+++ b/scripts/run-trusted-kernel.js
@@ -10,6 +10,7 @@ const fs = require('fs');
 const path = require('path');
 const { execFileSync } = require('child_process');
 const { runKernel, discoverFiles } = require('./architecture/trustedKernel');
+const { architectureApprovalBoundSha } = require('./lib/mergeApprovals');
 
 const ROOT = path.resolve(__dirname, '..');
 
@@ -64,10 +65,47 @@ function materializeHead(headRef, baseRef) {
     }
 }
 
-function main() {
+/**
+ * The kernel consumes the owner's `approve-architecture <full-head-sha>`
+ * comment directly from the PR (Harness Simplification decision: protected
+ * path changes require architecture approval bound to the exact head).
+ * Fail-closed: when the lookup cannot run (missing token/PR context), the
+ * approval is treated as absent. `ARCHITECTURE_APPROVED=true` remains as a
+ * local-development override.
+ */
+async function detectArchitectureApproval(headRef) {
+    if (process.env.ARCHITECTURE_APPROVED === 'true') { return true; }
+    const token = process.env.GITHUB_TOKEN;
+    const repo = process.env.GITHUB_REPOSITORY;
+    const prNumber = process.env.PR_NUMBER;
+    if (!token || !repo || !prNumber) { return false; }
+    const ownerLogin = repo.split('/')[0].toLowerCase();
+    const expected = String(headRef || '').toLowerCase();
+    for (let page = 1; page <= 10; page += 1) {
+        const response = await fetch(
+            `https://api.github.com/repos/${repo}/issues/${prNumber}/comments?per_page=100&page=${page}`,
+            {
+                headers: {
+                    Accept: 'application/vnd.github+json',
+                    Authorization: `Bearer ${token}`,
+                    'X-GitHub-Api-Version': '2022-11-28',
+                },
+            });
+        if (!response.ok) { return false; }
+        const batch = await response.json();
+        for (const comment of batch) {
+            if (String(comment?.user?.login || '').toLowerCase() !== ownerLogin) { continue; }
+            if (architectureApprovalBoundSha(comment.body) === expected) { return true; }
+        }
+        if (batch.length < 100) { break; }
+    }
+    return false;
+}
+
+async function main() {
     const headRef = process.env.PR_HEAD_REF || 'HEAD';
     const baseRef = process.env.PR_BASE_REF || 'origin/main';
-    const hasArchitectureApproval = process.env.ARCHITECTURE_APPROVED === 'true';
+    const hasArchitectureApproval = await detectArchitectureApproval(headRef);
 
     const { headDir, error } = materializeHead(headRef, baseRef);
     try {
@@ -89,4 +127,9 @@ function main() {
     }
 }
 
-if (require.main === module) { main(); }
+if (require.main === module) {
+    main().catch(error => {
+        console.error('Trusted kernel FAILED: ' + (error instanceof Error ? error.message : String(error)));
+        process.exit(1);
+    });
+}

--- a/tests/unit/architecture/architectureChange.test.js
+++ b/tests/unit/architecture/architectureChange.test.js
@@ -700,6 +700,25 @@ test('ARCH-CHANGE-GATE-001 a covering record in the base authorizes the relaxati
     assert.deepEqual(result.errors, []);
 });
 
+test('ARCH-CHANGE-GATE-001 owner architecture approval authorizes the relaxation without a record', () => {
+    // Harness Simplification decision: `approve-architecture <full-head-sha>`
+    // replaces record machine authorization. The caller verifies the comment
+    // binds the exact head; the classifier only receives the verdict.
+    const result = classifyArchitectureChange(relaxingReport(), { architectureApproved: true });
+    assert.equal(result.classification, 'relaxing',
+        'the classification is computed from the diff, never weakened by the approval');
+    assert.deepEqual(result.errors, []);
+});
+
+test('ARCH-CHANGE-GATE-001 controlled mutation: without approval or record the relaxation still fails', () => {
+    const result = classifyArchitectureChange(relaxingReport(), { architectureApproved: false });
+    assert.equal(result.classification, 'relaxing');
+    assert.ok(result.errors.some(error => error.includes('anti-self-amendment')
+        && error.includes('approve-architecture')), JSON.stringify(result.errors));
+    const defaulted = classifyArchitectureChange(relaxingReport());
+    assert.ok(defaulted.errors.length > 0, 'the option defaults to unapproved');
+});
+
 test('ARCH-CHANGE-GATE-001 controlled mutation: a record declaring a superset fails (exact equality, round-2 Blocker 3)', () => {
     const result = classifyArchitectureChange(relaxingReport({
         baseRecords: [{

--- a/tests/unit/tooling/mergeApprovals.test.js
+++ b/tests/unit/tooling/mergeApprovals.test.js
@@ -5,8 +5,10 @@ const test = require('node:test');
 
 const {
     approvalBoundSha,
+    architectureApprovalBoundSha,
     evaluateMergeApproval,
     findApprovalComment,
+    findArchitectureApprovalComment,
     isApprovalComment,
     mergeRequiresApproval,
     MERGE_APPROVAL_REQUIRED_SINCE,
@@ -98,4 +100,30 @@ test('ARCH-PR-MERGE-APPROVAL-GATE-001 legacy markers are still recognized for pr
         assert.ok(isApprovalComment(body), `legacy recognized: ${body}`);
     }
     assert.ok(!isApprovalComment('looks good'), 'non-markers rejected');
+});
+
+test('ARCH-PR-MERGE-APPROVAL-GATE-001 architecture approval binds the full head SHA', () => {
+    assert.equal(architectureApprovalBoundSha(`approve-architecture ${HEAD}`), HEAD);
+    assert.equal(architectureApprovalBoundSha(`  approve-architecture  ${HEAD.toUpperCase()}  `), HEAD,
+        'whitespace is free and the SHA normalizes to lowercase');
+    for (const body of ['approve-architecture', `approve-architecture ${HEAD.slice(0, 8)}`,
+        `approve-architecture ${HEAD} extra`, `please approve-architecture ${HEAD}`,
+        `approve ${HEAD}`, '', null, undefined]) {
+        assert.equal(architectureApprovalBoundSha(body), null, `no binding: ${body}`);
+    }
+});
+
+test('ARCH-PR-MERGE-APPROVAL-GATE-001 standard approval never substitutes for architecture approval', () => {
+    const comments = [
+        { user: { login: 'hzcheng' }, body: `approve ${HEAD}`, created_at: '2026-08-19T10:00:00Z' },
+        { user: { login: 'someone-else' }, body: `approve-architecture ${HEAD}`, created_at: '2026-08-19T11:00:00Z' },
+        { user: { login: 'hzcheng' }, body: `approve-architecture ${OTHER}`, created_at: '2026-08-19T12:00:00Z' },
+    ];
+    assert.equal(findArchitectureApprovalComment(comments, { authorLogin: 'hzcheng', headSha: HEAD }), null,
+        'standard approval, another user\'s architecture approval, and a stale head binding all fail');
+    const found = findArchitectureApprovalComment(
+        [...comments, { user: { login: 'HZCHENG' }, body: `approve-architecture ${HEAD}`, created_at: '2026-08-19T13:00:00Z', html_url: 'x' }],
+        { authorLogin: 'hzcheng', headSha: HEAD },
+    );
+    assert.equal(found.html_url, 'x', 'owner login comparison is case-insensitive');
 });

--- a/tests/unit/tooling/repositorySkills.test.js
+++ b/tests/unit/tooling/repositorySkills.test.js
@@ -52,6 +52,7 @@ test('ARCH-REPOSITORY-SKILL-GUIDANCE-001 keeps regression audits path-based and 
         ['user-visible rendered owner', /every user-visible UI\/Webview regression[\s\S]*automated owner[\s\S]*final rendered or interaction surface[\s\S]*ViewModel[\s\S]*insufficient/i],
         ['cross-feature rendered journey', /cross-feature journey[\s\S]*real rendered surface[\s\S]*provider[\s\S]*viewport\s+matrix/i],
         ['post-repair mutation sensitivity', /implementation is already repaired[\s\S]*mutation sensitivity[\s\S]*reintroduce each causal defect/i],
+        ['default-branch check ownership', /pull_request_target[\s\S]*default-branch files/i],
     ]);
 });
 


### PR DESCRIPTION
## Summary

Transition PR for the Harness Simplification program (between PR 2/6 and PR 3/6). The decision record (docs/architecture/harness-simplification-decision.md) replaced Architecture Change record machine authorization with owner architecture approval (`approve-architecture <full-head-sha>`), but the merged gates never consumed it. This wires the consumption path so PR 3/6 (which deletes the record machinery and therefore cannot be authorized by a record) can be evaluated and merged.

Root causes fixed:

- **merge-approval gate**: evaluated only `approve <sha>` and base records — a relaxing change that may not add records (ADR: no new records during the window) could never be authorized. The gate now detects the owner's `approve-architecture <full-head-sha>` comment and threads the verdict into the declaration evaluation.
- **quality lane**: the architecture change gate demanded `approve-architecture <sha>` but nothing consumed the comment. The classifier now accepts an `architectureApproved` verdict; the verify workflow detects the owner comment and exports `ARCHITECTURE_APPROVED` (PR-lane feedback only — the merge gate re-verifies from the default branch).
- **trusted kernel**: could not materialize the PR head (the `pull_request_target` checkout fetches only the base ref, so both `git checkout <sha>` and `git diff base...head` failed) and never received the approval flag. The workflow now fetches the PR head first; the kernel looks up the owner's approval comment via the GitHub API (fail-closed).
- **architecture-approval job**: diffed the base branch against itself (`git diff origin/main HEAD` where HEAD is the base checkout) and always passed vacuously. It now diffs the base against the fetched PR head SHA.

## Skill harvest

Updated `.skills/fixing-regressions-with-ci`: when a CI check fails, first identify which side of the PR supplies the check's code — `pull_request` checks run PR-head files, `pull_request_target` checks (merge-approval gate, trusted kernel) run default-branch files, so a PR-head edit cannot change a default-branch check until it merges. This is the lesson from PR #296's repeated CI failures.

## Known red check (bootstrap)

`trusted-kernel` will fail on this PR: the check runs the **default branch's** kernel, which cannot yet fetch the PR head (this PR is the fix). After this PR merges, the kernel on main becomes functional and evaluates PR #296 with the approval consumption above.

## Change impact declaration

```change-impact-declaration
{
  "headSha": "6cc7fca077b4929411d6dbaede79e8e560346ece",
  "capabilities": [
    "MAIN-ARCHITECTURE-HARNESS"
  ],
  "modules": [],
  "invariants": [],
  "policyDelta": "tightening",
  "baselineWaiverDelta": "zero",
  "newFiles": [],
  "behaviors": [
    "ARCH-CHANGE-GATE-001",
    "ARCH-CLOSED-WORLD-001",
    "ARCH-INVARIANT-CATALOG-001",
    "ARCH-MODULE-BOUNDARY-001",
    "ARCH-MODULE-CYCLE-001",
    "ARCH-POLICY-SCHEMA-001",
    "ARCH-PROGRAM-LEDGER-001",
    "ARCH-SINGLE-WRITER-001",
    "ARCH-WEBVIEW-MANIFEST-001"
  ],
  "semanticImpact": {
    "stateAuthority": false,
    "writerSet": false,
    "protocol": false,
    "persistence": false,
    "identity": false,
    "recovery": false
  },
  "coordinators": [],
  "verification": "npm run test-compile; node --test tests/unit/tooling/** tests/unit/architecture/** (565 pass); npm run test:architecture-policy; npm run test:behavior-contracts; npm run lint; node scripts/architecture/checkArchitectureChange.js (classification: tightening)"
}
```
