### PR TITLE
feat(architecture): require ready-to-copy owner approval commands in PR bodies

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,6 +16,26 @@ policyDelta, baselineWaiverDelta, newFiles, behaviors, semanticImpact,
 coordinators, verification.
 -->
 
+## Owner approvals
+
+<!--
+Required; CI rejects pull requests without this section.
+Copy-paste commands for the owner, each bound to the exact head SHA
+(regenerate whenever the head moves, same rule as the declaration):
+
+```
+approve-architecture <full-head-sha>
+```
+
+```
+approve <full-head-sha>
+```
+
+The gates read only PR comments — these body lines are never consumed as
+approvals. `approve-architecture` is required only when protected paths
+change, but always list both so the owner never has to reconstruct them.
+-->
+
 ## Skill harvest
 
 <!--

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -2,6 +2,9 @@ name: Verify
 
 on:
   pull_request:
+    # edited: the PR body conventions check (CID block, owner approvals)
+    # binds the body text; editing the body must re-run the lane.
+    types: [opened, synchronize, reopened, edited]
   push:
     branches:
       - main
@@ -88,11 +91,12 @@ jobs:
         run: npm run test:ci:linux
         env:
           COVERAGE_DIFF_BASE: ${{ github.event.pull_request.base.sha }}
-      - name: Check PR skill harvest section
+      - name: Check PR body conventions
         if: github.event_name == 'pull_request'
         run: node scripts/check-pr-body.js
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
 
   platform-windows:
     name: platform-windows

--- a/.skills/publishing-and-merging-github-prs/SKILL.md
+++ b/.skills/publishing-and-merging-github-prs/SKILL.md
@@ -48,16 +48,27 @@ after every GitHub write.
    implementation or skill-owner commit.
 5. Write PR titles, PR bodies, and commit messages in English, regardless of
    the conversation language.
-6. Push with tracking: `git push -u origin <branch>`.
-7. Prefer connector PR creation if available and authorized.
-8. If connector fails with permission or repository ambiguity, use `gh pr create`.
-9. Default to draft for "open a PR" requests unless the user explicitly asks for ready-for-review or the same request includes merging after validation.
-10. **After creating or updating a PR, verify it actually works before
+6. Every PR body must carry an `## Owner approvals` section with the
+   ready-to-copy commands bound to the exact head SHA — one fenced line
+   `approve-architecture <full-head-sha>` and one fenced line
+   `approve <full-head-sha>` — so the owner never reconstructs them by hand.
+   Post each as a SEPARATE comment: the merge-approval gate and the trusted
+   kernel match whole comment bodies, not lines inside a combined comment.
+   Regenerate the section whenever the head moves (same rule as the
+   change-impact declaration); CI enforces it via
+   `scripts/check-pr-body.js` (ARCH-PR-OWNER-APPROVALS-001). Because the
+   quality lane's event payload captures the body at trigger time, edit the
+   PR body BEFORE pushing the head it names whenever the PR already exists.
+7. Push with tracking: `git push -u origin <branch>`.
+8. Prefer connector PR creation if available and authorized.
+9. If connector fails with permission or repository ambiguity, use `gh pr create`.
+10. Default to draft for "open a PR" requests unless the user explicitly asks for ready-for-review or the same request includes merging after validation.
+11. **After creating or updating a PR, verify it actually works before
     handing off**: `gh pr view <n> --json mergeable,mergeStateStatus` and
     `gh pr checks <n>` — the PR must be mergeable with checks running or
     green. If `origin/main` moved and the PR conflicts, rebase immediately
     and re-push; never leave a PR conflicting, red, or stale.
-11. When a rebase follows another merge to main, expect the capability-audit
+12. When a rebase follows another merge to main, expect the capability-audit
     commit to conflict on `docs/testing/main-capability-coverage.json`:
     keep main's `audit.head`, finish the rebase, then regenerate the audit
     with `scripts/regenerate-capability-audit.js` so the new commit SHAs are

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -245,8 +245,7 @@
       "tests/unit/aiSessions/sessionBoundaries.test.js"
     ],
     "evidence": [
-      "scripts/run-ai-session-safety-checks.js"
-    ,
+      "scripts/run-ai-session-safety-checks.js",
       "src/aiSessions/sessionHelpers.ts"
     ]
   },
@@ -393,13 +392,11 @@
     "priority": "P1",
     "status": "automated",
     "owners": [
-      "tests/contract/aiSessions/sessionControllers.test.js"
-    ,
+      "tests/contract/aiSessions/sessionControllers.test.js",
       "tests/contract/aiSessions/sessionControllerComposition.test.js"
     ],
     "evidence": [
-      "scripts/run-ai-session-safety-checks.js"
-    ,
+      "scripts/run-ai-session-safety-checks.js",
       "src/aiSessions/sessionControllerComposition.ts"
     ]
   },
@@ -542,14 +539,12 @@
     "priority": "P1",
     "status": "automated",
     "owners": [
-      "tests/unit/aiSessions/sessionBoundaries.test.js"
-    ,
+      "tests/unit/aiSessions/sessionBoundaries.test.js",
       "tests/contract/aiSessions/sessionControllerComposition.test.js"
     ],
     "evidence": [
       "src/aiSessions/providers.ts",
-      "src/dashboard.ts"
-    ,
+      "src/dashboard.ts",
       "src/aiSessions/sessionControllerComposition.ts"
     ]
   },
@@ -560,13 +555,11 @@
     "priority": "P1",
     "status": "automated",
     "owners": [
-      "tests/contract/aiSessions/sessionControllers.test.js"
-    ,
+      "tests/contract/aiSessions/sessionControllers.test.js",
       "tests/contract/aiSessions/sessionControllerComposition.test.js"
     ],
     "evidence": [
-      "scripts/run-ai-session-safety-checks.js"
-    ,
+      "scripts/run-ai-session-safety-checks.js",
       "src/aiSessions/sessionControllerComposition.ts"
     ]
   },
@@ -577,17 +570,13 @@
     "priority": "P1",
     "status": "automated",
     "owners": [
-      "tests/contract/aiSessions/sessionControllers.test.js"
-    ,
-      "tests/contract/dashboard/messageHandlers.test.js"
-    ,
+      "tests/contract/aiSessions/sessionControllers.test.js",
+      "tests/contract/dashboard/messageHandlers.test.js",
       "tests/contract/aiSessions/sessionControllerComposition.test.js"
     ],
     "evidence": [
-      "scripts/run-ai-session-safety-checks.js"
-    ,
-      "src/dashboard/messageHandlers.ts"
-    ,
+      "scripts/run-ai-session-safety-checks.js",
+      "src/dashboard/messageHandlers.ts",
       "src/aiSessions/sessionControllerComposition.ts"
     ]
   },
@@ -625,13 +614,11 @@
     "priority": "P0",
     "status": "automated",
     "owners": [
-      "tests/contract/aiSessions/attention.test.js"
-    ,
+      "tests/contract/aiSessions/attention.test.js",
       "tests/contract/aiSessions/runtimeSettlement.test.js"
     ],
     "evidence": [
-      "src/aiSessions/attentionController.ts"
-    ,
+      "src/aiSessions/attentionController.ts",
       "src/aiSessions/runtimeSettlementCapability.ts"
     ]
   },
@@ -1415,26 +1402,18 @@
     "priority": "P0",
     "status": "automated",
     "owners": [
-      "tests/contract/aiSessions/attention.test.js"
-    ,
-      "tests/contract/aiSessions/runtimeSettlement.test.js"
-    ,
-      "tests/contract/aiSessions/attentionEventCapability.test.js"
-    ,
-      "tests/integration/dashboard/attentionRendering.test.js"
-    ,
+      "tests/contract/aiSessions/attention.test.js",
+      "tests/contract/aiSessions/runtimeSettlement.test.js",
+      "tests/contract/aiSessions/attentionEventCapability.test.js",
+      "tests/integration/dashboard/attentionRendering.test.js",
       "tests/browser/activeSessionCardInteraction.test.js"
     ],
     "evidence": [
       "src/aiSessions/attentionEvaluationQueue.ts",
-      "src/aiSessions/executionController.ts"
-    ,
-      "src/aiSessions/runtimeSettlementCapability.ts"
-    ,
-      "src/aiSessions/attentionEventCapability.ts"
-    ,
-      "src/workspaces/activeSessionPresentation.ts"
-    ,
+      "src/aiSessions/executionController.ts",
+      "src/aiSessions/runtimeSettlementCapability.ts",
+      "src/aiSessions/attentionEventCapability.ts",
+      "src/workspaces/activeSessionPresentation.ts",
       "src/webview/webviewProjectScripts.js"
     ]
   },
@@ -1460,13 +1439,11 @@
     "priority": "P1",
     "status": "automated",
     "owners": [
-      "tests/contract/aiSessions/providerSpecificBehavior.test.js"
-    ,
+      "tests/contract/aiSessions/providerSpecificBehavior.test.js",
       "tests/unit/aiSessions/sessionBoundaries.test.js"
     ],
     "evidence": [
-      "src/services/codexSessionService.ts"
-    ,
+      "src/services/codexSessionService.ts",
       "src/aiSessions/sessionHelpers.ts"
     ]
   },
@@ -1477,13 +1454,11 @@
     "priority": "P1",
     "status": "automated",
     "owners": [
-      "tests/contract/aiSessions/providerSpecificBehavior.test.js"
-    ,
+      "tests/contract/aiSessions/providerSpecificBehavior.test.js",
       "tests/unit/aiSessions/sessionBoundaries.test.js"
     ],
     "evidence": [
-      "src/services/claudeSessionService.ts"
-    ,
+      "src/services/claudeSessionService.ts",
       "src/aiSessions/sessionHelpers.ts"
     ]
   },
@@ -1494,16 +1469,14 @@
     "priority": "P1",
     "status": "automated",
     "owners": [
-      "tests/contract/aiSessions/providerSpecificBehavior.test.js"
-    ,
+      "tests/contract/aiSessions/providerSpecificBehavior.test.js",
       "tests/unit/aiSessions/sessionBoundaries.test.js"
     ],
     "evidence": [
       "src/aiSessions/sessionFingerprint.ts",
       "src/services/claudeSessionService.ts",
       "src/services/codexSessionService.ts",
-      "src/services/kimiSessionService.ts"
-    ,
+      "src/services/kimiSessionService.ts",
       "src/aiSessions/sessionHelpers.ts"
     ]
   },
@@ -1864,33 +1837,21 @@
     "priority": "P1",
     "status": "automated",
     "owners": [
-      "tests/contract/aiSessions/sessionControllers.test.js"
-    ,
-      "tests/contract/aiSessions/runtimeCoordinator.test.js"
-    ,
-      "tests/contract/aiSessions/runtimeBackends.test.js"
-    ,
-      "tests/contract/aiSessions/tmuxClientBehavior.test.js"
-    ,
-      "tests/contract/dashboard/messageHandlers.test.js"
-    ,
+      "tests/contract/aiSessions/sessionControllers.test.js",
+      "tests/contract/aiSessions/runtimeCoordinator.test.js",
+      "tests/contract/aiSessions/runtimeBackends.test.js",
+      "tests/contract/aiSessions/tmuxClientBehavior.test.js",
+      "tests/contract/dashboard/messageHandlers.test.js",
       "tests/integration/dashboard/terminalCloseWiring.test.js"
     ],
     "evidence": [
-      "scripts/run-ai-session-tmux-checks.js"
-    ,
-      "scripts/run-ai-session-safety-checks.js"
-    ,
-      "src/aiSessions/tmuxClient.ts"
-    ,
-      "src/aiSessions/tmuxRuntimeBackend.ts"
-    ,
-      "src/aiSessions/runtimeCoordinator.ts"
-    ,
-      "src/aiSessions/terminalCommandController.ts"
-    ,
-      "src/dashboard/messageHandlers.ts"
-    ,
+      "scripts/run-ai-session-tmux-checks.js",
+      "scripts/run-ai-session-safety-checks.js",
+      "src/aiSessions/tmuxClient.ts",
+      "src/aiSessions/tmuxRuntimeBackend.ts",
+      "src/aiSessions/runtimeCoordinator.ts",
+      "src/aiSessions/terminalCommandController.ts",
+      "src/dashboard/messageHandlers.ts",
       "src/webview/webviewContent.ts"
     ]
   },
@@ -3524,13 +3485,11 @@
     "priority": "P1",
     "status": "automated",
     "owners": [
-      "tests/contract/projects/controllers.test.js"
-    ,
+      "tests/contract/projects/controllers.test.js",
       "tests/contract/projects/projectMessageHandlers.test.js"
     ],
     "evidence": [
-      "scripts/run-dashboard-webview-checks.js"
-    ,
+      "scripts/run-dashboard-webview-checks.js",
       "src/projects/projectMessageHandlers.ts"
     ]
   },
@@ -3541,13 +3500,11 @@
     "priority": "P1",
     "status": "automated",
     "owners": [
-      "tests/contract/projects/controllers.test.js"
-    ,
+      "tests/contract/projects/controllers.test.js",
       "tests/contract/projects/projectMessageHandlers.test.js"
     ],
     "evidence": [
-      "scripts/run-dashboard-webview-checks.js"
-    ,
+      "scripts/run-dashboard-webview-checks.js",
       "src/projects/projectMessageHandlers.ts"
     ]
   },
@@ -3558,13 +3515,11 @@
     "priority": "P1",
     "status": "automated",
     "owners": [
-      "tests/contract/projects/controllers.test.js"
-    ,
+      "tests/contract/projects/controllers.test.js",
       "tests/contract/projects/projectMessageHandlers.test.js"
     ],
     "evidence": [
-      "scripts/run-dashboard-webview-checks.js"
-    ,
+      "scripts/run-dashboard-webview-checks.js",
       "src/projects/projectMessageHandlers.ts"
     ]
   },
@@ -3917,14 +3872,12 @@
     "status": "automated",
     "owners": [
       "tests/contract/aiSessions/attention.test.js",
-      "tests/integration/dashboard/terminalCloseWiring.test.js"
-    ,
+      "tests/integration/dashboard/terminalCloseWiring.test.js",
       "tests/contract/aiSessions/attentionEventCapability.test.js"
     ],
     "evidence": [
       "src/aiSessions/attentionController.ts",
-      "src/dashboard.ts"
-    ,
+      "src/dashboard.ts",
       "src/aiSessions/attentionEventCapability.ts"
     ]
   },
@@ -3941,8 +3894,7 @@
     "evidence": [
       "src/aiSessions/attentionController.ts",
       "src/aiSessions/terminalCommandController.ts",
-      "src/dashboard.ts"
-    ,
+      "src/dashboard.ts",
       "src/aiSessions/runtimeSettlementCapability.ts"
     ]
   },
@@ -3953,15 +3905,12 @@
     "priority": "P0",
     "status": "automated",
     "owners": [
-      "tests/integration/dashboard/terminalCloseWiring.test.js"
-    ,
+      "tests/integration/dashboard/terminalCloseWiring.test.js",
       "tests/contract/aiSessions/attentionEventCapability.test.js"
     ],
     "evidence": [
-      "src/dashboard.ts"
-    ,
-      "src/aiSessions/runtimeSettlementCapability.ts"
-    ,
+      "src/dashboard.ts",
+      "src/aiSessions/runtimeSettlementCapability.ts",
       "src/aiSessions/attentionEventCapability.ts"
     ]
   },
@@ -3972,17 +3921,13 @@
     "priority": "P1",
     "status": "automated",
     "owners": [
-      "tests/integration/dashboard/messageRouter.test.js"
-    ,
-      "tests/contract/projects/projectMessageHandlers.test.js"
-    ,
+      "tests/integration/dashboard/messageRouter.test.js",
+      "tests/contract/projects/projectMessageHandlers.test.js",
       "tests/contract/dashboard/messageHandlers.test.js"
     ],
     "evidence": [
-      "src/dashboard/messageRouter.ts"
-    ,
-      "src/projects/projectMessageHandlers.ts"
-    ,
+      "src/dashboard/messageRouter.ts",
+      "src/projects/projectMessageHandlers.ts",
       "src/dashboard/messageHandlers.ts"
     ]
   },
@@ -4239,20 +4184,20 @@
     ]
   },
   {
-   "id": "WORKTREE-GROUPS-UI-001",
-   "domain": "webview",
-   "title": "The Worktree surface unifies row behavior: every row carries the same actions menu (no standalone + or surface-level New-worktree button), the Current anchor menu offers session creation and new-worktree creation but never removal, group rows show chips and merge affordances, legacy-scope badges, and the surface stays usable at the minimum sidebar width",
-   "priority": "P0",
-   "status": "automated",
-   "owners": [
-     "tests/browser/worktreeGroups.test.js"
-   ],
-   "evidence": [
-     "src/webview/webviewAiSessionContent.ts",
-     "src/webview/webviewProjectAiSessionControlsScripts.js",
-     "media/styles.scss"
-   ]
- },
+    "id": "WORKTREE-GROUPS-UI-001",
+    "domain": "webview",
+    "title": "The Worktree surface unifies row behavior: every row carries the same actions menu (no standalone + or surface-level New-worktree button), the Current anchor menu offers session creation and new-worktree creation but never removal, group rows show chips and merge affordances, legacy-scope badges, and the surface stays usable at the minimum sidebar width",
+    "priority": "P0",
+    "status": "automated",
+    "owners": [
+      "tests/browser/worktreeGroups.test.js"
+    ],
+    "evidence": [
+      "src/webview/webviewAiSessionContent.ts",
+      "src/webview/webviewProjectAiSessionControlsScripts.js",
+      "media/styles.scss"
+    ]
+  },
   {
     "id": "WORKTREE-GROUPS-CREATE-001",
     "domain": "session",
@@ -4387,8 +4332,7 @@
       "tests/contract/projects/panelController.test.js",
       "tests/contract/openProjects/dashboardController.test.js",
       "tests/integration/dashboard/errorRecovery.test.js",
-      "tests/integration/dashboard/webviewState.test.js"
-    ,
+      "tests/integration/dashboard/webviewState.test.js",
       "tests/contract/projects/projectMessageHandlers.test.js"
     ],
     "evidence": [
@@ -4397,8 +4341,7 @@
       "src/dashboard/projectsPanelController.ts",
       "src/openWorkspaces/dashboardController.ts",
       "src/webview/webviewDashboardScripts.js",
-      "src/dashboard.ts"
-    ,
+      "src/dashboard.ts",
       "src/projects/projectMessageHandlers.ts"
     ]
   },
@@ -4424,15 +4367,13 @@
     "owners": [
       "tests/contract/projects/controllers.test.js",
       "tests/contract/openProjects/workspaceController.test.js",
-      "tests/integration/dashboard/productionAttentionBridge.test.js"
-    ,
+      "tests/integration/dashboard/productionAttentionBridge.test.js",
       "tests/contract/projects/projectMessageHandlers.test.js"
     ],
     "evidence": [
       "src/projects/projectOpenController.ts",
       "src/projects/projectNavigationProtocol.ts",
-      "extensions/attention-ui-bridge/src/extension.ts"
-    ,
+      "extensions/attention-ui-bridge/src/extension.ts",
       "src/projects/projectMessageHandlers.ts"
     ]
   },
@@ -4485,6 +4426,21 @@
     "id": "ARCH-PR-SKILL-HARVEST-GATE-001",
     "domain": "architecture",
     "title": "Pull request bodies record the skill harvest decision through a required template section",
+    "priority": "P1",
+    "status": "automated",
+    "owners": [
+      "tests/unit/tooling/prBody.test.js"
+    ],
+    "evidence": [
+      "scripts/check-pr-body.js",
+      ".github/pull_request_template.md",
+      ".github/workflows/verify.yml"
+    ]
+  },
+  {
+    "id": "ARCH-PR-OWNER-APPROVALS-001",
+    "domain": "architecture",
+    "title": "Pull request bodies carry ready-to-copy owner approval commands (approve and approve-architecture) bound to the exact head SHA",
     "priority": "P1",
     "status": "automated",
     "owners": [
@@ -4660,19 +4616,15 @@
     "status": "automated",
     "owners": [
       "tests/contract/aiSessions/archiveAndHydration.test.js",
-      "tests/integration/dashboard/webviewState.test.js"
-    ,
-      "tests/contract/dashboard/messageHandlers.test.js"
-    ,
+      "tests/integration/dashboard/webviewState.test.js",
+      "tests/contract/dashboard/messageHandlers.test.js",
       "tests/contract/aiSessions/sessionControllerComposition.test.js"
     ],
     "evidence": [
       "src/aiSessions/archiveBatchAcrossProviders.ts",
       "src/aiSessions/archiveController.ts",
-      "scripts/run-ai-session-safety-checks.js"
-    ,
-      "src/dashboard/messageHandlers.ts"
-    ,
+      "scripts/run-ai-session-safety-checks.js",
+      "src/dashboard/messageHandlers.ts",
       "src/aiSessions/sessionControllerComposition.ts"
     ]
   },
@@ -6014,8 +5966,7 @@
     "priority": "P1",
     "status": "automated",
     "owners": [
-      "scripts/run-skill-management-checks.js"
-    ,
+      "scripts/run-skill-management-checks.js",
       "tests/contract/skills/skillPanelCapability.test.js",
       "tests/contract/skills/skillCentralAndScope.test.js"
     ],
@@ -6023,8 +5974,7 @@
       "src/skills/centralService.ts",
       "src/skills/dashboardController.ts",
       "src/skills/migrateService.ts",
-      "src/skills/syncService.ts"
-    ,
+      "src/skills/syncService.ts",
       "src/skills/skillPanelCapability.ts"
     ]
   },
@@ -6071,8 +6021,7 @@
     "status": "automated",
     "owners": [
       "scripts/run-skill-management-checks.js",
-      "tests/browser/skillsFolderTree.test.js"
-    ,
+      "tests/browser/skillsFolderTree.test.js",
       "tests/contract/skills/skillPanelCapability.test.js",
       "tests/contract/skills/skillCentralAndScope.test.js"
     ],
@@ -6081,8 +6030,7 @@
       "src/skills/centralService.ts",
       "src/skills/dashboardController.ts",
       "src/webview/webviewSkillContent.ts",
-      "src/webview/webviewDashboardScripts.js"
-    ,
+      "src/webview/webviewDashboardScripts.js",
       "src/skills/skillPanelCapability.ts"
     ]
   },
@@ -6094,8 +6042,7 @@
     "status": "automated",
     "owners": [
       "scripts/run-skill-management-checks.js",
-      "tests/contract/skills/globalStoreLocationController.test.js"
-    ,
+      "tests/contract/skills/globalStoreLocationController.test.js",
       "tests/contract/skills/skillPanelCapability.test.js"
     ],
     "evidence": [
@@ -6105,8 +6052,7 @@
       "src/skills/discovery.ts",
       "src/skills/dashboardController.ts",
       "src/dashboard.ts",
-      "src/webview/webviewDashboardScripts.js"
-    ,
+      "src/webview/webviewDashboardScripts.js",
       "src/skills/skillPanelCapability.ts"
     ]
   },
@@ -6116,8 +6062,12 @@
     "title": "Strict and deterministic open-window pin protocol",
     "priority": "P0",
     "status": "automated",
-    "owners": ["tests/contract/openProjects/pins.test.js"],
-    "evidence": ["src/openWorkspaces/pinProtocol.ts"]
+    "owners": [
+      "tests/contract/openProjects/pins.test.js"
+    ],
+    "evidence": [
+      "src/openWorkspaces/pinProtocol.ts"
+    ]
   },
   {
     "id": "OPEN-WORKSPACE-PIN-STORE-001",
@@ -6125,8 +6075,12 @@
     "title": "Concurrent open-window pin persistence preserves original pin order",
     "priority": "P0",
     "status": "automated",
-    "owners": ["tests/contract/openProjects/pins.test.js"],
-    "evidence": ["extensions/attention-ui-bridge/src/openWorkspacePinStore.ts"]
+    "owners": [
+      "tests/contract/openProjects/pins.test.js"
+    ],
+    "evidence": [
+      "extensions/attention-ui-bridge/src/openWorkspacePinStore.ts"
+    ]
   },
   {
     "id": "OPEN-WORKSPACE-PIN-COORDINATOR-001",
@@ -6134,8 +6088,12 @@
     "title": "Durable pin mutations survive transient cross-window delivery failures",
     "priority": "P0",
     "status": "automated",
-    "owners": ["tests/contract/openProjects/pins.test.js"],
-    "evidence": ["extensions/attention-ui-bridge/src/openWorkspacePinCoordinator.ts"]
+    "owners": [
+      "tests/contract/openProjects/pins.test.js"
+    ],
+    "evidence": [
+      "extensions/attention-ui-bridge/src/openWorkspacePinCoordinator.ts"
+    ]
   },
   {
     "id": "OPEN-WORKSPACE-PIN-CLIENT-001",
@@ -6143,8 +6101,12 @@
     "title": "Workspace bridge client validates correlated pin outcomes and snapshots",
     "priority": "P0",
     "status": "automated",
-    "owners": ["tests/contract/openProjects/bridgeClient.test.js"],
-    "evidence": ["src/openWorkspaces/bridgeClient.ts"]
+    "owners": [
+      "tests/contract/openProjects/bridgeClient.test.js"
+    ],
+    "evidence": [
+      "src/openWorkspaces/bridgeClient.ts"
+    ]
   },
   {
     "id": "OPEN-WORKSPACE-PIN-HOST-001",
@@ -6152,8 +6114,12 @@
     "title": "Host resolves pin targets authoritatively and settles every recognized mutation",
     "priority": "P0",
     "status": "automated",
-    "owners": ["tests/contract/openProjects/pins.test.js"],
-    "evidence": ["src/openWorkspaces/pinController.ts"]
+    "owners": [
+      "tests/contract/openProjects/pins.test.js"
+    ],
+    "evidence": [
+      "src/openWorkspaces/pinController.ts"
+    ]
   },
   {
     "id": "OPEN-WORKSPACE-PIN-SORT-001",
@@ -6161,8 +6127,12 @@
     "title": "Pinned windows keep original pin order while unpinned windows keep stable first-opened order",
     "priority": "P0",
     "status": "automated",
-    "owners": ["tests/contract/openProjects/projection.test.js"],
-    "evidence": ["src/openWorkspaces/projection.ts"]
+    "owners": [
+      "tests/contract/openProjects/projection.test.js"
+    ],
+    "evidence": [
+      "src/openWorkspaces/projection.ts"
+    ]
   },
   {
     "id": "OPEN-ALL-WINDOWS-LIST-001",
@@ -6202,7 +6172,9 @@
     "title": "Pin UI waits for authoritative HTML and preserves pending state across acknowledgements",
     "priority": "P0",
     "status": "automated",
-    "owners": ["tests/integration/dashboard/openProjectFlow.test.js"],
+    "owners": [
+      "tests/integration/dashboard/openProjectFlow.test.js"
+    ],
     "evidence": [
       "src/webview/webviewContent.ts",
       "src/webview/webviewProjectScripts.js"
@@ -6353,8 +6325,7 @@
       "tests/unit/aiSessions/notify/dispatcher.test.js"
     ],
     "evidence": [
-      "src/aiSessions/notify/dispatcher.ts"
-    ,
+      "src/aiSessions/notify/dispatcher.ts",
       "src/aiSessions/notifyConfiguration.ts"
     ]
   },
@@ -6392,13 +6363,11 @@
     "priority": "P0",
     "status": "automated",
     "owners": [
-      "tests/unit/aiSessions/notify/credentials.test.js"
-    ,
+      "tests/unit/aiSessions/notify/credentials.test.js",
       "tests/contract/aiSessions/notifyConfiguration.test.js"
     ],
     "evidence": [
-      "src/aiSessions/notifyIntegration/credentials.ts"
-    ,
+      "src/aiSessions/notifyIntegration/credentials.ts",
       "src/aiSessions/notifyConfiguration.ts"
     ]
   },
@@ -6437,14 +6406,12 @@
     "priority": "P1",
     "status": "automated",
     "owners": [
-      "tests/unit/aiSessions/notify/guidedSetup.test.js"
-    ,
+      "tests/unit/aiSessions/notify/guidedSetup.test.js",
       "tests/contract/aiSessions/notifyConfiguration.test.js"
     ],
     "evidence": [
       "src/aiSessions/notifyIntegration/commands.ts",
-      "src/aiSessions/notifyIntegration/output.ts"
-    ,
+      "src/aiSessions/notifyIntegration/output.ts",
       "src/aiSessions/notifyConfiguration.ts"
     ]
   },

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "4b3d7e25531865cbdd203830e71c964a57207de8",
+        "head": "0accf78e1919556c57dd08a4d055bc5bfa6419ae",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -477,7 +477,8 @@
             "156080d8a49e51ec8f86d77538c428cde7831bd4",
             "4cf025e589a2f7426ae1f68d40c774429b6b9855",
             "8aeef7b953132be14677977d21d41ffe1e051dd0",
-            "6cc7fca077b4929411d6dbaede79e8e560346ece"
+            "6cc7fca077b4929411d6dbaede79e8e560346ece",
+            "2cc5b47de6e8fe51b4998293b0dc224ea908fdf3"
         ]
     },
     "capabilities": [
@@ -2354,7 +2355,8 @@
                 "b7d6c83aecc814bf517321a9c65667792e5ca835",
                 "630595db25f3f3723c85aa863de001982a1f6aaa",
                 "86a597dbe65633fd3328534788890febeb1644fd",
-                "4b3d7e25531865cbdd203830e71c964a57207de8"
+                "4b3d7e25531865cbdd203830e71c964a57207de8",
+                "0accf78e1919556c57dd08a4d055bc5bfa6419ae"
             ],
             "behaviors": [
                 "ARCH-POLICY-SCHEMA-001",

--- a/scripts/check-pr-body.js
+++ b/scripts/check-pr-body.js
@@ -6,16 +6,23 @@
  * harvest decision in a "## Skill harvest" section so the review step from
  * .skills/harvesting-workflow-lessons leaves a checkable artifact.
  *
- * Usage: PR_BODY=<body> node scripts/check-pr-body.js
- *        node scripts/check-pr-body.js <body-file>
+ * ARCH-PR-OWNER-APPROVALS-001: a pull request body must carry an
+ * "## Owner approvals" section with the ready-to-copy approval commands
+ * bound to the exact head SHA — one `approve <full-sha>` line and one
+ * `approve-architecture <full-sha>` line — so the owner never has to
+ * reconstruct them by hand. The gates read only PR comments; the body
+ * section is never consumed as an approval.
+ *
+ * Usage: PR_BODY=<body> PR_HEAD_SHA=<full-sha> node scripts/check-pr-body.js
+ *        PR_HEAD_SHA=<full-sha> node scripts/check-pr-body.js <body-file>
  */
 
 const fs = require('node:fs');
 
 /** Returns the trimmed section content, or null when the heading is absent. */
-function findHarvestSection(body) {
+function findSection(body, name) {
     const text = String(body || '').replace(/<!--[\s\S]*?-->/g, '');
-    const heading = /^##[ \t]+Skill harvest[ \t]*$/im.exec(text);
+    const heading = new RegExp('^##[ \\t]+' + name + '[ \\t]*$', 'im').exec(text);
     if (!heading) {
         return null;
     }
@@ -24,8 +31,8 @@ function findHarvestSection(body) {
     return (next ? rest.slice(0, next.index) : rest).trim();
 }
 
-function checkPrBody(body) {
-    const section = findHarvestSection(body);
+function checkHarvestSection(body) {
+    const section = findSection(body, 'Skill harvest');
     if (section === null) {
         return ['PR body must contain a "## Skill harvest" section'
             + ' (see .github/pull_request_template.md).'];
@@ -37,12 +44,47 @@ function checkPrBody(body) {
     return [];
 }
 
+function checkOwnerApprovalsSection(body, headSha) {
+    if (!headSha || !/^[0-9a-f]{40}$/i.test(headSha)) {
+        return ['PR_HEAD_SHA is required to verify the "## Owner approvals" section.'];
+    }
+    const section = findSection(body, 'Owner approvals');
+    if (section === null) {
+        return ['PR body must contain an "## Owner approvals" section with the ready-to-copy'
+            + ' approval commands bound to the head SHA (see .github/pull_request_template.md).'];
+    }
+    const lines = section.split('\n')
+        .map(line => line.trim())
+        .filter(line => line.length > 0 && !line.startsWith('```'));
+    const expected = [
+        `approve ${headSha}`,
+        `approve-architecture ${headSha}`,
+    ];
+    const errors = [];
+    for (const command of expected) {
+        const wanted = command.toLowerCase();
+        if (!lines.some(line => line.toLowerCase() === wanted)) {
+            errors.push(`The "## Owner approvals" section must contain the exact line "${command}".`
+                + ' Regenerate it whenever the head moves (same rule as the change-impact'
+                + ' declaration).');
+        }
+    }
+    return errors;
+}
+
+function checkPrBody(body, options = {}) {
+    return [
+        ...checkHarvestSection(body),
+        ...checkOwnerApprovalsSection(body, options.headSha),
+    ];
+}
+
 function main() {
     const fileArgument = process.argv[2];
     const body = fileArgument
         ? fs.readFileSync(fileArgument, 'utf8')
         : (process.env.PR_BODY || '');
-    const errors = checkPrBody(body);
+    const errors = checkPrBody(body, { headSha: process.env.PR_HEAD_SHA });
     if (errors.length) {
         for (const error of errors) {
             console.error(error);
@@ -50,11 +92,11 @@ function main() {
         process.exitCode = 1;
         return;
     }
-    console.log('PR body skill harvest section present.');
+    console.log('PR body skill harvest and owner approvals sections present.');
 }
 
 if (require.main === module) {
     main();
 }
 
-module.exports = { checkPrBody, findHarvestSection };
+module.exports = { checkPrBody, findSection, findHarvestSection: body => findSection(body, 'Skill harvest') };

--- a/tests/unit/tooling/prBody.test.js
+++ b/tests/unit/tooling/prBody.test.js
@@ -3,10 +3,29 @@
 const assert = require('node:assert/strict');
 const test = require('node:test');
 
-const { checkPrBody, findHarvestSection } = require('../../../scripts/check-pr-body');
+const { checkPrBody, findSection, findHarvestSection } = require('../../../scripts/check-pr-body');
 
-test('ARCH-PR-SKILL-HARVEST-GATE-001 accepts a recorded no-change decision', () => {
-    const body = [
+const HEAD = 'a'.repeat(40);
+const OTHER = 'b'.repeat(40);
+
+function approvalsSection(headSha = HEAD) {
+    return [
+        '## Owner approvals',
+        '',
+        'Copy each line into a separate PR comment below:',
+        '',
+        '```',
+        `approve-architecture ${headSha}`,
+        '```',
+        '',
+        '```',
+        `approve ${headSha}`,
+        '```',
+    ].join('\n');
+}
+
+function validBody() {
+    return [
         '## Summary',
         '',
         'Fix the thing.',
@@ -15,11 +34,17 @@ test('ARCH-PR-SKILL-HARVEST-GATE-001 accepts a recorded no-change decision', () 
         '',
         'no skill change — the failure is already covered by run-ai-session-safety-checks.js',
         '',
+        approvalsSection(),
+        '',
         '## Verification',
         '',
         '- npm run test:ci:linux passes',
     ].join('\n');
-    assert.deepEqual(checkPrBody(body), []);
+}
+
+test('ARCH-PR-SKILL-HARVEST-GATE-001 accepts a recorded no-change decision', () => {
+    const body = validBody();
+    assert.deepEqual(checkPrBody(body, { headSha: HEAD }), []);
     assert.equal(
         findHarvestSection(body),
         'no skill change — the failure is already covered by run-ai-session-safety-checks.js'
@@ -27,14 +52,14 @@ test('ARCH-PR-SKILL-HARVEST-GATE-001 accepts a recorded no-change decision', () 
 });
 
 test('ARCH-PR-SKILL-HARVEST-GATE-001 accepts an updated-skills decision', () => {
-    const body = '## Skill harvest\n\nupdated .skills/publishing-and-merging-github-prs — PRs are English-only\n';
-    assert.deepEqual(checkPrBody(body), []);
+    const body = '## Skill harvest\n\nupdated .skills/publishing-and-merging-github-prs — PRs are English-only\n'
+        + '\n' + approvalsSection() + '\n';
+    assert.deepEqual(checkPrBody(body, { headSha: HEAD }), []);
 });
 
 test('ARCH-PR-SKILL-HARVEST-GATE-001 rejects a missing section', () => {
-    const errors = checkPrBody('## Summary\n\nNo harvest here.\n');
-    assert.equal(errors.length, 1);
-    assert.ok(errors[0].includes('## Skill harvest'));
+    const errors = checkPrBody('## Summary\n\nNo harvest here.\n\n' + approvalsSection() + '\n', { headSha: HEAD });
+    assert.ok(errors.some(error => error.includes('## Skill harvest')), JSON.stringify(errors));
 });
 
 test('ARCH-PR-SKILL-HARVEST-GATE-001 rejects a placeholder-only section', () => {
@@ -45,15 +70,76 @@ test('ARCH-PR-SKILL-HARVEST-GATE-001 rejects a placeholder-only section', () => 
         'Required; CI rejects pull requests without this section.',
         '-->',
         '',
+        approvalsSection(),
+        '',
         '## Verification',
     ].join('\n');
-    const errors = checkPrBody(body);
-    assert.equal(errors.length, 1);
-    assert.ok(errors[0].includes('empty'));
+    const errors = checkPrBody(body, { headSha: HEAD });
+    assert.ok(errors.some(error => error.includes('empty')), JSON.stringify(errors));
 });
 
 test('ARCH-PR-SKILL-HARVEST-GATE-001 stops section extraction at the next heading', () => {
-    assert.equal(findHarvestSection('## Skill harvest\n## Verification\n'), '');
-    assert.equal(findHarvestSection(''), null);
-    assert.equal(findHarvestSection(undefined), null);
+    assert.equal(findSection('## Skill harvest\n## Verification\n', 'Skill harvest'), '');
+    assert.equal(findSection('', 'Skill harvest'), null);
+    assert.equal(findSection(undefined, 'Skill harvest'), null);
+});
+
+test('ARCH-PR-OWNER-APPROVALS-001 accepts both commands bound to the head SHA', () => {
+    assert.deepEqual(checkPrBody(validBody(), { headSha: HEAD }), []);
+});
+
+test('ARCH-PR-OWNER-APPROVALS-001 rejects a missing "## Owner approvals" section', () => {
+    const body = '## Skill harvest\n\nno skill change — covered\n';
+    const errors = checkPrBody(body, { headSha: HEAD });
+    assert.ok(errors.some(error => error.includes('## Owner approvals')), JSON.stringify(errors));
+});
+
+test('ARCH-PR-OWNER-APPROVALS-001 rejects commands that bind a stale head SHA', () => {
+    const body = [
+        '## Skill harvest',
+        '',
+        'no skill change — covered',
+        '',
+        approvalsSection(OTHER),
+    ].join('\n');
+    const errors = checkPrBody(body, { headSha: HEAD });
+    assert.ok(errors.some(error => error.includes(`approve ${HEAD}`)), JSON.stringify(errors));
+    assert.ok(errors.some(error => error.includes(`approve-architecture ${HEAD}`)), JSON.stringify(errors));
+});
+
+test('ARCH-PR-OWNER-APPROVALS-001 rejects a section missing the architecture approval line', () => {
+    const body = [
+        '## Skill harvest',
+        '',
+        'no skill change — covered',
+        '',
+        '## Owner approvals',
+        '',
+        '```',
+        `approve ${HEAD}`,
+        '```',
+    ].join('\n');
+    const errors = checkPrBody(body, { headSha: HEAD });
+    assert.equal(errors.length, 1, JSON.stringify(errors));
+    assert.ok(errors[0].includes('approve-architecture'));
+});
+
+test('ARCH-PR-OWNER-APPROVALS-001 rejects a missing head SHA context (fail closed)', () => {
+    const errors = checkPrBody(validBody());
+    assert.ok(errors.some(error => error.includes('PR_HEAD_SHA')), JSON.stringify(errors));
+});
+
+test('ARCH-PR-OWNER-APPROVALS-001 short SHAs and prose do not satisfy the section', () => {
+    const body = [
+        '## Skill harvest',
+        '',
+        'no skill change — covered',
+        '',
+        '## Owner approvals',
+        '',
+        `approve ${HEAD.slice(0, 8)}`,
+        `please approve-architecture ${HEAD} soon`,
+    ].join('\n');
+    const errors = checkPrBody(body, { headSha: HEAD });
+    assert.equal(errors.length, 2, JSON.stringify(errors));
 });

--- a/tests/unit/tooling/repositorySkills.test.js
+++ b/tests/unit/tooling/repositorySkills.test.js
@@ -100,6 +100,7 @@ test('ARCH-REPOSITORY-SKILL-GUIDANCE-001 verifies ambiguous GitHub writes and tr
         ['transport result verification', /HTTP 408[\s\S]*unexpected EOF[\s\S]*remote branch SHA/i],
         ['HTTP/1.1 retry', /http\.version=HTTP\/1\.1 push/i],
         ['non-force retry', /same non-force refspec/i],
+        ['owner approvals section in PR body', /## Owner approvals[\s\S]*approve-architecture <full-head-sha>[\s\S]*approve <full-head-sha>[\s\S]*SEPARATE comment/i],
     ]);
 });
 


### PR DESCRIPTION
## Summary

The owner repeatedly had to ask how to phrase approval comments, and a combined multi-line comment silently failed the gates that match whole comment bodies. This makes the convention explicit and enforced, like the `## Skill harvest` section:

- `scripts/check-pr-body.js` now also requires an `## Owner approvals` section carrying the exact lines `approve <full-head-sha>` and `approve-architecture <full-head-sha>` (ARCH-PR-OWNER-APPROVALS-001). The gates read only PR **comments**, so body lines can never self-approve.
- `verify.yml` passes the pull_request head SHA to the check.
- `.github/pull_request_template.md` documents the section.
- `.skills/publishing-and-merging-github-prs` instructs agents to always include the section (regenerated on every head move) and to post approvals as **separate** comments, because the merge gate and the trusted kernel match whole comment bodies.

## Skill harvest

updated .skills/publishing-and-merging-github-prs — the owner could not know the required approval comment format from the PR itself; the skill now mandates the copy-ready block and separate comments.

## Owner approvals

Copy each line into a separate PR comment below (both bind the exact head SHA and expire when the head moves):

```
approve-architecture 37027f5c598f916c0656343248fb059be7ab8daf
```

```
approve 37027f5c598f916c0656343248fb059be7ab8daf
```

## Change impact declaration

```change-impact-declaration
{
  "headSha": "37027f5c598f916c0656343248fb059be7ab8daf",
  "capabilities": [
    "MAIN-ARCHITECTURE-HARNESS"
  ],
  "modules": [],
  "invariants": [],
  "policyDelta": "tightening",
  "baselineWaiverDelta": "zero",
  "newFiles": [],
  "behaviors": [
    "ARCH-CHANGE-GATE-001",
    "ARCH-CLOSED-WORLD-001",
    "ARCH-INVARIANT-CATALOG-001",
    "ARCH-MODULE-BOUNDARY-001",
    "ARCH-MODULE-CYCLE-001",
    "ARCH-POLICY-SCHEMA-001",
    "ARCH-PR-OWNER-APPROVALS-001",
    "ARCH-PROGRAM-LEDGER-001",
    "ARCH-SINGLE-WRITER-001",
    "ARCH-WEBVIEW-MANIFEST-001"
  ],
  "semanticImpact": {
    "stateAuthority": false,
    "writerSet": false,
    "protocol": false,
    "persistence": false,
    "identity": false,
    "recovery": false
  },
  "coordinators": [],
  "verification": "npm run test-compile; node --test tests/unit/tooling/** (406 pass, incl. 6 new ARCH-PR-OWNER-APPROVALS-001 cases); npm run test:behavior-contracts; npm run lint; node scripts/architecture/checkArchitectureChange.js (tightening)"
}
```

## Verification

- `npm run test-compile`
- `node --test tests/unit/tooling/**` — 406 pass (6 new cases for the approvals section)
- `npm run test:behavior-contracts`
- `npm run lint`
- `node scripts/architecture/checkArchitectureChange.js` — tightening
