### PR TITLE
docs(architecture): W1 strict re-acceptance (PR 6/6)

### DIFF
--- a/docs/testing/architecture-program.json
+++ b/docs/testing/architecture-program.json
@@ -19,8 +19,8 @@
     ],
     "modules": {
         "MOD-WORKTREE-LIFECYCLE": {
-            "state": "migrating",
-            "since": "pilot slices S1-S5 (PRs #262-#268) + round-1 repairs R1-R10 (PRs #270-#283) + round-2 repairs T1-T7 (PRs #284-#293)",
+            "state": "strict",
+            "since": "pilot slices S1-S5 (PRs #262-#268) + round-1 repairs R1-R10 (PRs #270-#283) + round-2 repairs T1-T7 (PRs #284-#293) + harness simplification (PRs #294-#302); strict re-accepted after the narrow writer facade (PR #302)",
             "evidence": [
                 "docs/architecture/changes/ARCH-CHANGE-001.md",
                 "docs/architecture/changes/ARCH-CHANGE-002.md",
@@ -31,7 +31,7 @@
                 "docs/architecture/changes/ARCH-CHANGE-007.md",
                 "docs/architecture/harness-simplification-decision.md"
             ],
-            "nextAction": "harness simplification (PRs #294-#299), then strict re-acceptance",
+            "nextAction": "none — strict; hold via the trusted kernel. Webview global convergence is out of W1 scope (MOD-DASHBOARD-SHELL independent wave, see the simplification decision)",
             "target": {
                 "publicEntrypoints": [
                     "src/worktrees/index.ts"

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "e1eb9700202d611754e14e1900fdf0fc06eb358d",
+        "head": "e6fa3a6941c3f8a6704adeb844bb35fafb691caf",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -483,7 +483,9 @@
             "6af42109faaf686b8d6d8a1f107b243bb22a745a",
             "cd0dda6cf6fbd015822f343eec5f7faa7e4b52c8",
             "9d8b0e6ab57351b0f48848849be5f518ec8917e9",
-            "c7033e76275cfd4aa48e267a49a61f86cb347b39"
+            "c7033e76275cfd4aa48e267a49a61f86cb347b39",
+            "d53805b56ac91709530c9575b7b4bd9074d592a3",
+            "e6fa3a6941c3f8a6704adeb844bb35fafb691caf"
         ]
     },
     "capabilities": [


### PR DESCRIPTION
## Summary

PR 6/6 of the Harness Simplification program — final slice. W1 (MOD-WORKTREE-LIFECYCLE) moves `migrating → strict`. No new design; the fixed acceptance checklist only, verified mechanically by `checkProgramLedger.js`:

- `target.publicEntrypoints` matches the registry exactly;
- zero deep imports into module internals;
- no baseline fingerprint or waiver names the module;
- every P0/P1 invariant has a behavior owner;
- single-writer families declare writers — now facade-backed (PR 5/6).

The forward one-step transition satisfies the state graph. With this, the six-PR simplification program is complete: the trusted kernel is the required gate, machine authorization/parity/guardSemantics/CID are gone, and W1 holds strict.

## Skill harvest

no skill change — a mechanical ledger transition verified by existing checks.

## Owner approvals

Copy each line into a separate PR comment below (both bind the exact head SHA and expire when the head moves):

```
approve-architecture bb83e39f0c129104ef25be5b123bbb2038dc0b6a
```

```
approve bb83e39f0c129104ef25be5b123bbb2038dc0b6a
```

## Verification

- `npm run test:architecture-policy` — pass (including the strict preconditions for W1)
- `node --test tests/unit/architecture/**` — 152 pass
- `npm run test:behavior-contracts` — pass
