### PR TITLE
fix(worktrees): narrow the member lifecycle to its own write family (W1 authority)

### DIFF
--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "e6fa3a6941c3f8a6704adeb844bb35fafb691caf",
+        "head": "fa834b9d7f1a7da76995f6fe3cb5fb8486ca7397",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -485,7 +485,8 @@
             "9d8b0e6ab57351b0f48848849be5f518ec8917e9",
             "c7033e76275cfd4aa48e267a49a61f86cb347b39",
             "d53805b56ac91709530c9575b7b4bd9074d592a3",
-            "e6fa3a6941c3f8a6704adeb844bb35fafb691caf"
+            "e6fa3a6941c3f8a6704adeb844bb35fafb691caf",
+            "bb83e39f0c129104ef25be5b123bbb2038dc0b6a"
         ]
     },
     "capabilities": [
@@ -2309,7 +2310,8 @@
                 "2d133a0a0cb3883d94e5ea2590b1ad9e39b8f927",
                 "c27b66f8efb2dff402e5d1be2969b410fd12023c",
                 "32e4d5c3058a0d12a7cb03d9b5b1501d3ead3a6e",
-                "d96a51d839cfdd9ac36b6827f8816ef39016cfaf"
+                "d96a51d839cfdd9ac36b6827f8816ef39016cfaf",
+                "fa834b9d7f1a7da76995f6fe3cb5fb8486ca7397"
             ],
             "behaviors": [
                 "WORKTREE-GROUPS-BASELINE-001",

--- a/src/worktrees/groupManifestStore.ts
+++ b/src/worktrees/groupManifestStore.ts
@@ -2699,6 +2699,17 @@ export type WorktreeGroupManifestWriter = Pick<WorktreeGroupManifestStore,
     | 'removeGenerationClaim'
     | 'reconcileGenerationClaims'>;
 
+/**
+ * The member-lifecycle family's write surface (ARCH-WORKTREE-MEMBER-WRITER-001).
+ * Two single-writer families share this store; the member authority may only
+ * reach its own four methods — anything else is a compile error on this view.
+ */
+export type WorktreeGroupMemberWriter = Pick<WorktreeGroupManifestStore,
+    | 'transitionMember'
+    | 'updateMember'
+    | 'setPrimaryMember'
+    | 'removeMember'>;
+
 /** Provision a store and hand out the capability-free handle. */
 export function createWorktreeGroupManifestStore(
     memento: MementoLike
@@ -2728,5 +2739,15 @@ export function worktreeGroupManifestReaderOf(
 export function worktreeGroupManifestWriterOf(
     handle: WorktreeGroupManifestStoreHandle
 ): WorktreeGroupManifestWriter {
+    return worktreeGroupManifestStoreOf(handle);
+}
+
+/**
+ * The member-lifecycle view of the handle. Module-internal like the full
+ * unwrap: only the declared member authority consumes it.
+ */
+export function worktreeGroupMemberWriterOf(
+    handle: WorktreeGroupManifestStoreHandle
+): WorktreeGroupMemberWriter {
     return worktreeGroupManifestStoreOf(handle);
 }

--- a/src/worktrees/memberLifecycle.ts
+++ b/src/worktrees/memberLifecycle.ts
@@ -3,11 +3,12 @@
 import type { WorktreeKey } from './types';
 import {
     WorktreeGroupManifestError,
-    worktreeGroupManifestStoreOf,
+    worktreeGroupMemberWriterOf,
 } from './groupManifestStore';
 import type {
     WorktreeGroupManifestStore,
     WorktreeGroupManifestStoreHandle,
+    WorktreeGroupMemberWriter,
 } from './groupManifestStore';
 
 export class IllegalMemberTransitionError extends Error {
@@ -43,10 +44,14 @@ export class IllegalMemberTransitionError extends Error {
  * and the journal primitives only act on members in the deleting state.
  */
 export class WorktreeMemberLifecycle {
-    private readonly store: WorktreeGroupManifestStore;
+    // Member-authority view only (ARCH-WORKTREE-MEMBER-WRITER-001): this
+    // family shares the store with the manifest-structure family, and the
+    // view is what keeps it off the other family's write methods — calling
+    // one is a compile error here, not a scanner finding.
+    private readonly store: WorktreeGroupMemberWriter;
 
     constructor(storeHandle: WorktreeGroupManifestStoreHandle) {
-        this.store = worktreeGroupManifestStoreOf(storeHandle);
+        this.store = worktreeGroupMemberWriterOf(storeHandle);
     }
 
     private async transition(


### PR DESCRIPTION
## Summary

Two single-writer families share the worktree group manifest store. The member authority (`WorktreeMemberLifecycle`) unwrapped its handle to the **full** store, so it could reach the manifest-structure family's 20 write methods — the cross-family hole the writer union left behind.

Fix in code structure, not process:

- The store gains a `WorktreeGroupMemberWriter` view (exactly the member family's four declared methods: `transitionMember`, `updateMember`, `setPrimaryMember`, `removeMember`).
- `WorktreeMemberLifecycle` now holds that view. Calling another family's method is a compile error, not a scanner finding.

Mutation-sensitivity proof: adding `this.store.deleteGroup(...)` inside `memberLifecycle.ts` fails compilation with TS2339; the probe was removed after the check.

## Skill harvest

no skill change — the fix reuses the facade view pattern from PR 5/6.

## Owner approvals

Copy each line into a separate PR comment below (both bind the exact head SHA and expire when the head moves):

```
approve-architecture 25393e066279a6fdd2672698a8d73938a6500584
```

```
approve 25393e066279a6fdd2672698a8d73938a6500584
```

## Verification

- `npm run test-compile` — clean (the narrowing compiles; probe mutation fails as expected)
- `node --test tests/unit/worktrees/**` — 191 pass
- `npm run test:architecture-policy` / `npm run test:behavior-contracts` / `npm run lint` — pass
