### PR TITLE
feat(architecture): publish the impact report to the job summary, never as a PR comment

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,8 +6,8 @@
 
 <!--
 No body declaration is required: the merge-approval gate regenerates the
-architecture impact report for the exact head and maintains it as a standing
-PR comment. Review it before approving.
+architecture impact report for the exact head and publishes it to the job
+summary of the gate run (never a PR comment — no notification email).
 -->
 
 ## Owner approvals

--- a/.github/workflows/merge-approval-gate.yml
+++ b/.github/workflows/merge-approval-gate.yml
@@ -14,13 +14,10 @@ on:
 
 permissions:
   contents: read
-  # issues: write lets the gate create/update the standing architecture
-  # impact report comment (PR 4/6: the report replaces the AI-authored
-  # change-impact declaration block). pull-requests: write is required as
-  # well: the issue-comments endpoint on a pull request is governed by the
-  # pull-requests scope for the Actions token (issues: write alone 403s).
-  issues: write
-  pull-requests: write
+  # Read-only comment access for approval detection; the impact report goes
+  # to the job summary, never to the PR (no notification email per PR).
+  issues: read
+  pull-requests: read
   statuses: write
 
 jobs:

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "fa834b9d7f1a7da76995f6fe3cb5fb8486ca7397",
+        "head": "183dfe84c0ab58645b6bab01d4f71aa7d5ce6e2e",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -486,7 +486,8 @@
             "c7033e76275cfd4aa48e267a49a61f86cb347b39",
             "d53805b56ac91709530c9575b7b4bd9074d592a3",
             "e6fa3a6941c3f8a6704adeb844bb35fafb691caf",
-            "bb83e39f0c129104ef25be5b123bbb2038dc0b6a"
+            "bb83e39f0c129104ef25be5b123bbb2038dc0b6a",
+            "25393e066279a6fdd2672698a8d73938a6500584"
         ]
     },
     "capabilities": [
@@ -2371,7 +2372,8 @@
                 "4b3d7e25531865cbdd203830e71c964a57207de8",
                 "0accf78e1919556c57dd08a4d055bc5bfa6419ae",
                 "66fbdbcf0e6b9d26768ce432fe0e0a49dad2e8db",
-                "7001f89501a6891f83796de732f0b0cf7f25f722"
+                "7001f89501a6891f83796de732f0b0cf7f25f722",
+                "183dfe84c0ab58645b6bab01d4f71aa7d5ce6e2e"
             ],
             "behaviors": [
                 "ARCH-POLICY-SCHEMA-001",

--- a/scripts/run-merge-approval-gate.js
+++ b/scripts/run-merge-approval-gate.js
@@ -13,7 +13,8 @@
 //
 // Harness Simplification PR 4/6: the AI-authored change-impact declaration
 // is gone. The gate regenerates the architecture impact report for the exact
-// head and posts it as a standing PR comment for owner review; only
+// head and publishes it to the job summary ($GITHUB_STEP_SUMMARY) for owner
+// review — never as a PR comment, so no notification email per PR; only
 // mechanical errors block the status (classification errors such as a
 // relaxing change without architecture approval, capability audit gaps,
 // report collection failures).
@@ -26,7 +27,6 @@ const { evaluateMergeApproval, findArchitectureApprovalComment } = require('./li
 const { collectChangeImpactContext } = require('./lib/changeImpactContext');
 
 const STATUS_CONTEXT = 'merge-approval';
-const REPORT_MARKER = '<!-- architecture-impact-report -->';
 
 function readEventPayload() {
     const eventPath = process.env.GITHUB_EVENT_PATH;
@@ -109,13 +109,17 @@ function renderImpactReport({ pullRequest, context }) {
     return lines.join('\n');
 }
 
-/** Create or update the standing impact-report comment. */
-async function upsertReportComment(token, repo, prNumber, markdown, comments) {
-    const existing = (comments || []).find(comment => String(comment.body || '').includes(REPORT_MARKER));
-    if (existing) {
-        await api(token, 'PATCH', `/repos/${repo}/issues/comments/${existing.id}`, { body: markdown });
-    } else {
-        await api(token, 'POST', `/repos/${repo}/issues/${prNumber}/comments`, { body: markdown });
+/** Write the report to the job summary (and the log) — never to the PR,
+ * so review aids never generate notification email. */
+function publishReport(markdown) {
+    console.log(markdown);
+    const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+    if (summaryPath) {
+        try {
+            fs.appendFileSync(summaryPath, markdown + '\n');
+        } catch (error) {
+            console.error(`warning: could not write the job summary: ${error instanceof Error ? error.message : String(error)}`);
+        }
     }
 }
 
@@ -185,28 +189,17 @@ async function main() {
         headSha,
     });
 
-    // PR 4/6: no AI-authored declaration is compared anymore. The gate
-    // regenerates the impact report for the exact head, posts it as a
-    // standing comment for owner review, and blocks only on mechanical
-    // errors. Git failures crash the job before posting, which blocks the
-    // merge (fail-closed).
+    // The impact report is a read-only review aid: the gate regenerates it
+    // from the exact head and publishes it to the job summary — never as a
+    // PR comment, so no notification email per PR. Evaluation errors still
+    // block (fail-closed); publishing never does.
     const { errors: headErrors, reportMarkdown } = evaluateHeadForPullRequest({
         pullRequest,
         prNumber,
         architectureApproved: Boolean(architectureApproval),
     });
-    // The report comment is advisory: its delivery failure must never block
-    // the merge status (the evaluation completed; fail-closed applies to the
-    // verdict, not to the review aid). A broken comment path would otherwise
-    // take down the gate for every PR — as it did when the token lacked
-    // pull-requests: write.
     if (reportMarkdown) {
-        try {
-            await upsertReportComment(token, repo, prNumber, reportMarkdown, comments);
-        } catch (error) {
-            console.error(`warning: could not post the impact report comment: ${error instanceof Error ? error.message : String(error)}`);
-            console.error(reportMarkdown);
-        }
+        publishReport(reportMarkdown);
     }
 
     const reasons = [];

--- a/tests/unit/tooling/mergeApprovalGate.test.js
+++ b/tests/unit/tooling/mergeApprovalGate.test.js
@@ -87,8 +87,8 @@ test('ARCH-PR-MERGE-APPROVAL-GATE-001 posts a read-only impact report instead of
     const checkout = gate.steps.find(step => step.uses && step.uses.startsWith('actions/checkout'));
     assert.ok(checkout && checkout.with && checkout.with['fetch-depth'] === 0,
         'the gate regenerates the impact report and needs full history');
-    assert.strictEqual(workflow.permissions.issues, 'write',
-        'the gate creates/updates the standing impact-report comment');
+    assert.strictEqual(workflow.permissions.issues, 'read',
+        'the gate never writes PR comments — the report goes to the job summary (no notification email)');
 
     const script = fs.readFileSync(
         path.join(repositoryRoot, 'scripts', 'run-merge-approval-gate.js'), 'utf8');
@@ -96,12 +96,10 @@ test('ARCH-PR-MERGE-APPROVAL-GATE-001 posts a read-only impact report instead of
         'the AI-authored change-impact declaration is no longer evaluated (PR 4/6)');
     assert.match(script, /collectChangeImpactContext/,
         'the gate regenerates the impact report for the PR head');
-    assert.match(script, /upsertReportComment/,
-        'the gate posts the report as a standing PR comment for owner review');
-    assert.match(script, /try \{[\s\S]*?upsertReportComment[\s\S]*?catch/,
-        'the advisory report comment is fail-soft: its delivery failure must not block the verdict status');
-    assert.match(script, /architecture-impact-report/,
-        'the standing comment carries a stable marker for upserts');
+    assert.ok(!/upsertReportComment|issues\/comments.*POST/.test(script),
+        'the gate must not post PR comments (notification-free review aid)');
+    assert.match(script, /GITHUB_STEP_SUMMARY/,
+        'the gate publishes the report to the job summary');
     assert.match(script, /pull\/\$\{prNumber\}\/head/,
         'the gate fetches and checks out the exact PR head');
 


### PR DESCRIPTION
## Summary

The standing impact-report comment (introduced in #300) generated one notification email per PR for the owner. The report is a review aid, not a conversation — the merge-approval gate now writes it to the workflow **job summary** ($GITHUB_STEP_SUMMARY) and the job log instead of the PR comment thread.

- No more per-PR email from the gate.
- The gate's token drops `issues: write` / `pull-requests: write` (read-only comment access is all approval detection needs) — a nice permission tightening after #303's incident fix.
- The report is still regenerated from the exact head on every gate run; find it under the gate job's "Summary" page.

## Skill harvest

no skill change — owner-feedback-driven UX fix, no reusable workflow lesson beyond the recorded ones.

## Owner approvals

Copy each line into a separate PR comment below (both bind the exact head SHA and expire when the head moves):

```
approve-architecture 745e97a22d044861e00e4e7f6e789109f1d1d25a
```

```
approve 745e97a22d044861e00e4e7f6e789109f1d1d25a
```

## Verification

- `node --test tests/unit/tooling/mergeApprovalGate.test.js` — 5/5 pass (wiring now asserts no PR-comment posting + job-summary publishing)
- `npm run test:behavior-contracts` / `npm run lint` — pass
