### PR TITLE
feat: switch the conversation bottom rails to previous and next window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to the "Agent Pivot" extension will be documented in this fi
 
 ### Changed
 
+- The AI Conversation bottom corner rails now switch between open WINDOWS
+  instead of adjacent Sessions: Previous/Next Window walk one shared,
+  identity-sorted ring of every open window — each window anchors on its own
+  identity, so the cycle continues naturally as focus moves. With no other
+  window open the rails explain themselves instead of switching. The
+  Previous/Next Active Session commands remain available in the Command
+  Palette, and per-state Session cycling lives on the status dots.
 - The AI Conversation status indicators moved from the header into the bottom
   session-navigation row — alongside Previous/Next Active Session — and are
   now clickable badges that count this window's Sessions by lifecycle —

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -3946,6 +3946,27 @@
     "manualReason": "Requires two interactive VS Code UI windows and observable operating-system focus changes."
   },
   {
+    "id": "OPEN-WINDOW-CYCLE-RAILS-001",
+    "domain": "open-project",
+    "title": "The AI Conversation bottom rails switch focus to the previous or next open window on one identity-sorted ring every window computes identically, with an empty-ring hint when no other window is open",
+    "priority": "P1",
+    "status": "automated",
+    "owners": [
+      "tests/unit/dashboard/windowCycleSwitch.test.js",
+      "tests/integration/dashboard/conversationViewer.test.js",
+      "tests/browser/conversationViewer.test.js"
+    ],
+    "evidence": [
+      "src/dashboard/windowCycleSwitch.ts",
+      "src/aiSessions/conversation/viewerProtocol.ts",
+      "src/aiSessions/conversation/viewer.ts",
+      "src/aiSessions/conversation/viewerDocument.ts",
+      "src/aiSessions/conversation/composition.ts",
+      "src/dashboard.ts",
+      "src/webview/conversationViewerScripts.js"
+    ]
+  },
+  {
     "id": "OPEN-SAME-WORKSPACE-WINDOWS-001",
     "domain": "open-project",
     "title": "Two windows for the same workspace retain distinct live identities",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "99fbc6beb8f4cff409637cc6e1e34170f7cf6918",
+        "head": "982241093a3fe5d58074c3f1f630b8899c73a398",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -488,7 +488,8 @@
             "e6fa3a6941c3f8a6704adeb844bb35fafb691caf",
             "bb83e39f0c129104ef25be5b123bbb2038dc0b6a",
             "25393e066279a6fdd2672698a8d73938a6500584",
-            "745e97a22d044861e00e4e7f6e789109f1d1d25a"
+            "745e97a22d044861e00e4e7f6e789109f1d1d25a",
+            "449d66444fa7278526c56d55457dbca0004071ef"
         ]
     },
     "capabilities": [
@@ -1969,7 +1970,8 @@
                 "3b8064d460afec74027e39d4c8f7e8120e9658af",
                 "eaf81001f659b19d7dec593da7d33ec78c8d2a8d",
                 "89d6b3997d108414e1106096e6e99d5812bbfe02",
-                "e1eb9700202d611754e14e1900fdf0fc06eb358d"
+                "e1eb9700202d611754e14e1900fdf0fc06eb358d",
+                "982241093a3fe5d58074c3f1f630b8899c73a398"
             ],
             "behaviors": [
                 "SESSION-AI-SESSION-CONVERSATION-ADAPTER-001",
@@ -2022,7 +2024,8 @@
                 "CONVERSATION-FOLLOW-DIAGNOSTICS-001",
                 "CONVERSATION-OVERSIZED-TURN-001",
                 "SESSION-AI-SESSION-CONVERSATION-FENCED-CODE-001",
-                "WEBVIEW-AI-SESSION-CONVERSATION-CODE-HIGHLIGHT-001"
+                "WEBVIEW-AI-SESSION-CONVERSATION-CODE-HIGHLIGHT-001",
+                "OPEN-WINDOW-CYCLE-RAILS-001"
             ],
             "prGates": [
                 "test:ci:linux"

--- a/media/conversationViewerScripts.js
+++ b/media/conversationViewerScripts.js
@@ -1706,7 +1706,7 @@
     sessionNavButtons.forEach(function (button) {
         button.addEventListener('click', function () {
             post({
-                type: 'conversation-viewer-switch-session',
+                type: 'conversation-viewer-switch-window',
                 version: 1,
                 direction: button.getAttribute('data-session-nav'),
             });

--- a/src/aiSessions/conversation/composition.ts
+++ b/src/aiSessions/conversation/composition.ts
@@ -164,6 +164,7 @@ export interface ConversationCapabilityOptions {
     getShowThinking?: () => boolean;
     readSessionStatus?: ConversationViewerOptions['readSessionStatus'];
     cycleLocalSessionStatus?: ConversationViewerOptions['cycleLocalSessionStatus'];
+    switchAdjacentWindow?: ConversationViewerOptions['switchAdjacentWindow'];
     /**
      * The context window declared by the Codex profile overlay a session runs
      * with, if any. Injected for the codex adapter's telemetry display: the
@@ -398,6 +399,7 @@ function createAvailableConversationCapability(
         showThinking: options.getShowThinking,
         readSessionStatus: options.readSessionStatus,
         cycleLocalSessionStatus: options.cycleLocalSessionStatus,
+        switchAdjacentWindow: options.switchAdjacentWindow,
         submitPrompt: options.submitPrompt,
         focusSession: options.focusSession,
         commentStore: options.commentStore,

--- a/src/aiSessions/conversation/viewer.ts
+++ b/src/aiSessions/conversation/viewer.ts
@@ -116,6 +116,10 @@ export interface ConversationViewerOptions {
         kind: ConversationSessionStatusKind,
         currentTarget: ConversationViewerTarget | undefined
     ) => PromiseLike<void> | Promise<void> | void;
+    /** Focus the previous/next open window (the bottom window rails). */
+    switchAdjacentWindow?: (
+        direction: ConversationSessionSwitchDirection
+    ) => PromiseLike<void> | Promise<void> | void;
     watch: (
         provider: AiSessionProviderId,
         sessionId: string,
@@ -1025,6 +1029,10 @@ export class ConversationViewer implements ConversationViewerApi {
                 parsed.kind,
                 currentTarget
             );
+            return;
+        }
+        if (parsed.type === 'conversation-viewer-switch-window') {
+            await this.options.switchAdjacentWindow?.(parsed.direction);
             return;
         }
         if (parsed.type === 'conversation-viewer-applied') {

--- a/src/aiSessions/conversation/viewerDocument.ts
+++ b/src/aiSessions/conversation/viewerDocument.ts
@@ -234,8 +234,8 @@ export function renderConversationViewerDocument(
         <div class="conversation-session-nav-layer">
             <button class="conversation-session-nav conversation-session-nav-previous"
                 type="button" data-session-nav="previous"
-                title="Previous active session"
-                aria-label="Previous active session">${CONVERSATION_SESSION_NAV_ICON_PREVIOUS}</button>
+                title="Previous window"
+                aria-label="Previous window">${CONVERSATION_SESSION_NAV_ICON_PREVIOUS}</button>
             <div class="conversation-session-status" data-conversation-session-status
                 role="group" aria-label="AI session status in this window">
                 ${renderSessionStatusDot('running', sessionStatus.runningSessionsLocal)}
@@ -244,8 +244,8 @@ export function renderConversationViewerDocument(
             </div>
             <button class="conversation-session-nav conversation-session-nav-next"
                 type="button" data-session-nav="next"
-                title="Next active session"
-                aria-label="Next active session">${CONVERSATION_SESSION_NAV_ICON_NEXT}</button>
+                title="Next window"
+                aria-label="Next window">${CONVERSATION_SESSION_NAV_ICON_NEXT}</button>
         </div>
         <div class="conversation-find" data-conversation-find hidden>
             <label class="conversation-find-field">

--- a/src/aiSessions/conversation/viewerProtocol.ts
+++ b/src/aiSessions/conversation/viewerProtocol.ts
@@ -191,6 +191,13 @@ export interface ConversationViewerSwitchSessionMessage {
     direction: ConversationSessionSwitchDirection;
 }
 
+/** Click a bottom window rail: focus the previous/next open window. */
+export interface ConversationViewerSwitchWindowMessage {
+    type: 'conversation-viewer-switch-window';
+    version: 1;
+    direction: ConversationSessionSwitchDirection;
+}
+
 /** Click a header status button: cycle to the next session of that lifecycle
  * group within this window. */
 export interface ConversationViewerCycleStatusSessionMessage {
@@ -256,6 +263,7 @@ export type ConversationViewerMessage =
     | ConversationViewerOpenLinkMessage
     | ConversationViewerSendSelectionMessage
     | ConversationViewerSwitchSessionMessage
+    | ConversationViewerSwitchWindowMessage
     | ConversationViewerCycleStatusSessionMessage
     | ConversationViewerRequestSyncMessage
     | ConversationViewerAppliedMessage
@@ -375,6 +383,14 @@ export function parseConversationViewerMessage(
             return undefined;
         }
         return value as unknown as ConversationViewerSwitchSessionMessage;
+    }
+    if (value.type === 'conversation-viewer-switch-window') {
+        if (!hasExactKeys(value, ['type', 'version', 'direction'])
+            || (value.direction !== 'previous'
+                && value.direction !== 'next')) {
+            return undefined;
+        }
+        return value as unknown as ConversationViewerSwitchWindowMessage;
     }
     if (value.type === 'conversation-viewer-cycle-status-session') {
         if (!hasExactKeys(value, ['type', 'version', 'kind'])

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -108,6 +108,9 @@ import {
     createSessionStatusCycleHandler,
 } from './dashboard/sessionStatusCycle';
 import {
+    createWindowCycleSwitchHandler,
+} from './dashboard/windowCycleSwitch';
+import {
     createAiSessionQuickSwitchHandlers,
 } from './dashboard/sessionQuickSwitch';
 import {
@@ -2197,6 +2200,8 @@ async function initializeDashboard(
         services: aiSessionServices,
         cycleLocalSessionStatus: (kind, currentTarget) =>
             sessionStatusCycleHandler.cycleToNext(kind, currentTarget),
+        switchAdjacentWindow: direction =>
+            windowCycleSwitchHandler.switchWindow(direction),
         resolveTarget: (projectId, providerId, sessionId) => {
             const target = getCurrentWorkspaceActionTarget(projectId);
             // The conversation header reads project · task · session: the
@@ -3168,6 +3173,19 @@ async function initializeDashboard(
             vscode.window.showInformationMessage(message),
         showWarningMessage: message =>
             vscode.window.showWarningMessage(message),
+    });
+    const windowCycleSwitchHandler = createWindowCycleSwitchHandler({
+        listOtherWindows: () => openWorkspaceDashboardController.getCards()
+            .filter(card => card.kind === 'navigation')
+            .map(card => ({
+                cardId: card.id,
+                navigationIdentity: card.navigationIdentity,
+            })),
+        getSelfNavigationIdentity: () =>
+            getCurrentOpenWorkspace()?.navigationIdentity,
+        openWindow: cardId => workspaceNavigationController.open(cardId),
+        showInformationMessage: message =>
+            vscode.window.showInformationMessage(message),
     });
     const aiSessionQuickSwitchHandlers = createAiSessionQuickSwitchHandlers({
         navigationCoordinator: sessionNavigationCoordinator,

--- a/src/dashboard/windowCycleSwitch.ts
+++ b/src/dashboard/windowCycleSwitch.ts
@@ -1,0 +1,73 @@
+'use strict';
+
+export type WindowCycleDirection = 'previous' | 'next';
+
+export interface WindowCycleTarget {
+    cardId: string;
+    navigationIdentity: string;
+}
+
+export interface WindowCycleSwitchHandlerOptions {
+    /** Other open windows (navigation cards), in dashboard card order. */
+    listOtherWindows: () => WindowCycleTarget[];
+    /** This window's navigation identity, when known. */
+    getSelfNavigationIdentity: () => string | undefined;
+    openWindow: (cardId: string) => Promise<void>;
+    showInformationMessage: (message: string) => void;
+}
+
+export interface WindowCycleSwitchHandler {
+    switchWindow(direction: WindowCycleDirection): Promise<void>;
+}
+
+/**
+ * Moves focus one window per invocation around a ring built from every
+ * registered open window. The ring is sorted by navigation identity, so all
+ * windows compute the same cycle without a shared cursor: each window anchors
+ * on its own identity and steps to its neighbour. Opening a workspace that
+ * already has a window focuses that window, so a single press lands there.
+ */
+export function createWindowCycleSwitchHandler(
+    options: WindowCycleSwitchHandlerOptions
+): WindowCycleSwitchHandler {
+    return {
+        async switchWindow(direction: WindowCycleDirection): Promise<void> {
+            const others = options.listOtherWindows()
+                .filter(window => Boolean(window)
+                    && typeof window.cardId === 'string'
+                    && window.cardId.length > 0
+                    && typeof window.navigationIdentity === 'string'
+                    && window.navigationIdentity.length > 0);
+            if (!others.length) {
+                options.showInformationMessage(
+                    'No other open windows to switch to.'
+                );
+                return;
+            }
+            const self = options.getSelfNavigationIdentity();
+            const identities = Array.from(new Set([
+                ...others.map(window => window.navigationIdentity),
+                ...(self ? [self] : []),
+            ])).sort();
+            const selfIndex = self ? identities.indexOf(self) : -1;
+            const targetIdentity = selfIndex === -1
+                ? identities[direction === 'next' ? 0 : identities.length - 1]
+                : identities[
+                    (selfIndex + (direction === 'next' ? 1 : -1)
+                        + identities.length) % identities.length
+                ];
+            const target = others.find(
+                window => window.navigationIdentity === targetIdentity
+            );
+            // With at least one other window in the ring the stepped target is
+            // never this window, so a missing card means a stale projection.
+            if (!target) {
+                options.showInformationMessage(
+                    'Agent Pivot: the next window is no longer open.'
+                );
+                return;
+            }
+            await options.openWindow(target.cardId);
+        },
+    };
+}

--- a/src/webview/conversationViewerScripts.js
+++ b/src/webview/conversationViewerScripts.js
@@ -1706,7 +1706,7 @@
     sessionNavButtons.forEach(function (button) {
         button.addEventListener('click', function () {
             post({
-                type: 'conversation-viewer-switch-session',
+                type: 'conversation-viewer-switch-window',
                 version: 1,
                 direction: button.getAttribute('data-session-nav'),
             });

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -4494,6 +4494,10 @@ test('CONVERSATION-OUTLINE-NAVIGATION-001 keeps every side-panel view usable acr
             ''
         )
         .replace(
+            "                type: 'conversation-viewer-switch-window',\n",
+            "                type: 'conversation-viewer-switch-session',\n"
+        )
+        .replace(
             "        latestStatusRequestId: Number(document.body.getAttribute(\n"
                 + "            'data-session-status-request-id'\n"
                 + "        )) || 0,\n",
@@ -6701,7 +6705,7 @@ test('CONVERSATION-COMMENTS-ORDERING-001 drags cards into a Host-authoritative o
     ]);
 });
 
-test('WEBVIEW-AI-SESSION-CONVERSATION-VIEWER-001 renders ghost session-switch rails that post exact switch intents', async t => {
+test('WEBVIEW-AI-SESSION-CONVERSATION-VIEWER-001 OPEN-WINDOW-CYCLE-RAILS-001 renders ghost window-switch rails that post exact switch intents', async t => {
     const { page } = await openHostViewerDocument(t, {
         includeStyles: true,
         themeFixture: viewerThemeFixtures[0],
@@ -6723,16 +6727,16 @@ test('WEBVIEW-AI-SESSION-CONVERSATION-VIEWER-001 renders ghost session-switch ra
         [
             {
                 direction: 'previous',
-                label: 'Previous active session',
+                label: 'Previous window',
                 iconOnly: true,
             },
             {
                 direction: 'next',
-                label: 'Next active session',
+                label: 'Next window',
                 iconOnly: true,
             },
         ],
-        'session rails must be two icon-only buttons'
+        'window rails must be two icon-only buttons'
     );
 
     const rail = page.locator('.conversation-session-nav-layer');
@@ -6760,7 +6764,7 @@ test('WEBVIEW-AI-SESSION-CONVERSATION-VIEWER-001 renders ghost session-switch ra
             borderRadius: '50%',
             opacity: '0.3',
         },
-        'session rails must render as compact translucent circles'
+        'window rails must render as compact translucent circles'
     );
 
     const previousBox = await page.locator('[data-session-nav="previous"]')
@@ -6778,23 +6782,23 @@ test('WEBVIEW-AI-SESSION-CONVERSATION-VIEWER-001 renders ghost session-switch ra
     );
     assert.equal(await next.evaluate(element =>
         getComputedStyle(element).opacity
-    ), '1', 'session rails must become fully opaque on hover');
+    ), '1', 'window rails must become fully opaque on hover');
 
     await next.click();
     assert.deepEqual((await postedMessages(page)).at(-1), {
-        type: 'conversation-viewer-switch-session',
+        type: 'conversation-viewer-switch-window',
         version: 1,
         direction: 'next',
     });
     await page.locator('[data-session-nav="previous"]').click();
     assert.deepEqual((await postedMessages(page)).at(-1), {
-        type: 'conversation-viewer-switch-session',
+        type: 'conversation-viewer-switch-window',
         version: 1,
         direction: 'previous',
     });
 });
 
-test('WEBVIEW-AI-SESSION-CONVERSATION-VIEWER-001 keeps session rails inside the conversation column when the side panel is open', async t => {
+test('WEBVIEW-AI-SESSION-CONVERSATION-VIEWER-001 OPEN-WINDOW-CYCLE-RAILS-001 keeps window rails inside the conversation column when the side panel is open', async t => {
     const { page } = await openHostViewerDocument(t, {
         includeStyles: true,
         themeFixture: viewerThemeFixtures[0],

--- a/tests/integration/dashboard/conversationViewer.test.js
+++ b/tests/integration/dashboard/conversationViewer.test.js
@@ -303,6 +303,7 @@ function createViewer(options = {}) {
         readTelemetry: options.readTelemetry,
         readSessionStatus: options.readSessionStatus,
         cycleLocalSessionStatus: options.cycleLocalSessionStatus,
+        switchAdjacentWindow: options.switchAdjacentWindow,
         watch: options.watch || ((_provider, sessionId) => ({
             dispose() {
                 watchDisposals.push(sessionId);
@@ -537,6 +538,42 @@ test('CONVERSATION-SESSION-STATUS-001 renders a disabled status button for an em
     assert.ok(!/data-session-status-running[^>]*disabled/.test(
         panel.webview.html
     ), 'a non-empty kind stays clickable');
+});
+
+test('OPEN-WINDOW-CYCLE-RAILS-001 routes window rail clicks to the window cycle', async () => {
+    const switches = [];
+    const { viewer, panel } = createViewer({
+        switchAdjacentWindow: async direction => {
+            switches.push(direction);
+        },
+    });
+    await viewer.open(target('session-a', 'input-1'));
+
+    await panel.receive({
+        type: 'conversation-viewer-switch-window',
+        version: 1,
+        direction: 'previous',
+    });
+    assert.deepEqual(switches, ['previous']);
+
+    for (const message of [
+        { type: 'conversation-viewer-switch-window', version: 1 },
+        {
+            type: 'conversation-viewer-switch-window',
+            version: 1,
+            direction: 'up',
+        },
+        {
+            type: 'conversation-viewer-switch-window',
+            version: 1,
+            direction: 'next',
+            extra: true,
+        },
+    ]) {
+        await panel.receive(message);
+    }
+    assert.equal(switches.length, 1,
+        'malformed or spoofed directions are dropped by the protocol validator');
 });
 
 test('CONVERSATION-SESSION-STATUS-001 routes status button clicks to the local session cycle', async () => {

--- a/tests/unit/aiSessions/conversationViewerProtocol.test.js
+++ b/tests/unit/aiSessions/conversationViewerProtocol.test.js
@@ -39,6 +39,14 @@ test('CONVERSATION-PROTOCOL-VALIDATOR-001 accepts every exact version-1 viewer i
         version: 1,
         direction: 'next',
     }, {
+        type: 'conversation-viewer-switch-window',
+        version: 1,
+        direction: 'previous',
+    }, {
+        type: 'conversation-viewer-switch-window',
+        version: 1,
+        direction: 'next',
+    }, {
         type: 'conversation-viewer-request-sync',
         version: 1,
         subscriptionGeneration: 4,
@@ -264,6 +272,21 @@ test('CONVERSATION-PROTOCOL-VALIDATOR-001 rejects malformed, inherited, and over
             type: 'conversation-viewer-switch-session',
             version: 1,
             direction: 'next',
+            extra: true,
+        },
+        {
+            type: 'conversation-viewer-switch-window',
+            version: 1,
+        },
+        {
+            type: 'conversation-viewer-switch-window',
+            version: 1,
+            direction: 'up',
+        },
+        {
+            type: 'conversation-viewer-switch-window',
+            version: 1,
+            direction: 'previous',
             extra: true,
         },
         {

--- a/tests/unit/dashboard/windowCycleSwitch.test.js
+++ b/tests/unit/dashboard/windowCycleSwitch.test.js
@@ -1,0 +1,101 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+    createWindowCycleSwitchHandler,
+} = require('../../../out/dashboard/windowCycleSwitch');
+
+function win(cardId, navigationIdentity) {
+    return { cardId, navigationIdentity };
+}
+
+function makeHandler(overrides = {}) {
+    const calls = [];
+    const handler = createWindowCycleSwitchHandler({
+        listOtherWindows: () => overrides.others || [],
+        getSelfNavigationIdentity: () => overrides.self,
+        openWindow: cardId => {
+            calls.push(['open', cardId]);
+            return Promise.resolve();
+        },
+        showInformationMessage: message => calls.push(['info', message]),
+    });
+    return { calls, handler };
+}
+
+test('OPEN-WINDOW-CYCLE-RAILS-001 reports when there is no other window to switch to', async () => {
+    const { calls, handler } = makeHandler({ self: 'self' });
+
+    await handler.switchWindow('next');
+    await handler.switchWindow('previous');
+
+    assert.deepEqual(calls, [
+        ['info', 'No other open windows to switch to.'],
+        ['info', 'No other open windows to switch to.'],
+    ]);
+});
+
+test('OPEN-WINDOW-CYCLE-RAILS-001 steps to this window\'s neighbour on a shared stable ring', async () => {
+    // The ring sorts by navigation identity: aaa < self < zzz. The handler is
+    // stateless: each window anchors on its own identity, and the focus move
+    // itself carries the cycle forward — the next press happens in the
+    // destination window, which steps from its own position on the same ring.
+    const others = [win('card-z', 'zzz'), win('card-a', 'aaa')];
+    const { calls, handler } = makeHandler({ others, self: 'self' });
+
+    await handler.switchWindow('next');
+    await handler.switchWindow('previous');
+    await handler.switchWindow('next');
+
+    assert.deepEqual(calls, [
+        ['open', 'card-z'],
+        ['open', 'card-a'],
+        ['open', 'card-z'],
+    ]);
+});
+
+test('OPEN-WINDOW-CYCLE-RAILS-001 wraps around both ends of the ring', async () => {
+    const others = [win('card-a', 'aaa'), win('card-b', 'bbb')];
+
+    // Ring: 000 < aaa < bbb. Self leads, so next wraps to the first other.
+    const next = makeHandler({ others, self: '000' });
+    await next.handler.switchWindow('next');
+    assert.deepEqual(next.calls, [['open', 'card-a']]);
+
+    // Previous from self wraps to the ring's end.
+    const previous = makeHandler({ others, self: '000' });
+    await previous.handler.switchWindow('previous');
+    assert.deepEqual(previous.calls, [['open', 'card-b']]);
+});
+
+test('OPEN-WINDOW-CYCLE-RAILS-001 starts at a ring end when this window is unknown', async () => {
+    const others = [win('card-b', 'bbb'), win('card-a', 'aaa')];
+    const { calls, handler } = makeHandler({ others, self: undefined });
+
+    await handler.switchWindow('next');
+    await handler.switchWindow('previous');
+
+    assert.deepEqual(calls, [
+        ['open', 'card-a'],
+        ['open', 'card-b'],
+    ]);
+});
+
+test('OPEN-WINDOW-CYCLE-RAILS-001 drops duplicate and invalid window entries', async () => {
+    const others = [
+        win('card-a', 'aaa'),
+        win('card-a2', 'aaa'),
+        win('', 'bbb'),
+        win('card-c', ''),
+        null,
+    ];
+    const { calls, handler } = makeHandler({ others, self: 'self' });
+
+    // Ring: aaa < self — exactly one aaa entry survives, and the first card
+    // wins the open.
+    await handler.switchWindow('previous');
+
+    assert.deepEqual(calls, [['open', 'card-a']]);
+});

--- a/tests/unit/tooling/architectureGuards.test.js
+++ b/tests/unit/tooling/architectureGuards.test.js
@@ -51,6 +51,7 @@ function copyGuardFixture(t, mutationPath, mutate = source => source) {
         'src/aiSessions/runtimeTypes.ts',
         'src/dashboard/sessionQuickSwitch.ts',
         'src/dashboard/sessionStatusCycle.ts',
+        'src/dashboard/windowCycleSwitch.ts',
         'src/dashboard/webviewUpdateMessages.ts',
         'src/constants.ts',
         'src/models.ts',


### PR DESCRIPTION
## Summary

The AI Conversation bottom corner rails rarely paid off as session switchers — per-state session cycling now lives on the status dots, and the Previous/Next Active Session commands remain in the Command Palette — while moving between open windows is the everyday action. The rails now switch focus between open WINDOWS.

- One shared identity-sorted ring of every registered open window: each window anchors on its own navigation identity and steps to its neighbour, so the cycle continues naturally as focus moves (A → B → C → A) with no shared cursor or handoff channel.
- Switching reuses the open-workspaces bridge navigate command (focuses the existing window for the workspace, including SSH/WSL/Dev Container targets); empty registrations and untitled multi-root workspaces are excluded.
- With no other window open, the rails show 'No other open windows to switch to.' instead of switching.
- New behavior contract OPEN-WINDOW-CYCLE-RAILS-001 covers the ring logic, the viewer message dispatch, and the rendered rails.

## Architecture impact report

<!--
No body declaration is required: the merge-approval gate regenerates the
architecture impact report for the exact head and maintains it as a standing
PR comment. Review it before approving.
-->

## Owner approvals

```
approve-architecture 8dd0fc43ba6766488bbff23cc7e5ebb1dd4cf367
```

```
approve 8dd0fc43ba6766488bbff23cc7e5ebb1dd4cf367
```

## Skill harvest

no skill change — the workflow followed existing skills (webview mutation protocols, review-fix-commit-loop) without new lessons worth recording.

## Verification

- `npm run test-compile`, `npm run lint`, `git diff --check`
- Focused suites after the final rebase: unit (windowCycleSwitch ring logic, protocol validation, architecture guards), integration dispatch, browser rails tests
- Full browser suite (322) including the updated rails tests and the version-skew fixture chain
- `npm run test:behavior-contracts` after the capability-audit commit
- `SKIP_NPM_CI=1 npm run install-local` — installed and byte-verified