### PR TITLE
fix(ci): gate crash — remove the leftover REPORT_MARKER reference

### DIFF
--- a/.skills/fixing-regressions-with-ci/SKILL.md
+++ b/.skills/fixing-regressions-with-ci/SKILL.md
@@ -25,6 +25,10 @@ Turn every confirmed regression into a CI-owned behavior before changing product
      check's behavior until it merges. Confirm against the failed run's log
      line provenance; when the fix must land on the default branch first,
      sequence a dedicated PR instead of iterating on the blocked one.
+   - The same blind spot applies to GREEN: when the changed code path only
+     executes from the default branch after the merge, CI on the PR cannot
+     exercise it — verify by directly invoking the changed entry point
+     locally (unit-level call, not only pattern assertions on the source).
 2. **Own the behavior**
    - Read `docs/testing/README.md`.
    - Select an existing behavior ID or add one to `docs/testing/behavior-contracts.json`.

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "183dfe84c0ab58645b6bab01d4f71aa7d5ce6e2e",
+        "head": "99fbc6beb8f4cff409637cc6e1e34170f7cf6918",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -487,7 +487,8 @@
             "d53805b56ac91709530c9575b7b4bd9074d592a3",
             "e6fa3a6941c3f8a6704adeb844bb35fafb691caf",
             "bb83e39f0c129104ef25be5b123bbb2038dc0b6a",
-            "25393e066279a6fdd2672698a8d73938a6500584"
+            "25393e066279a6fdd2672698a8d73938a6500584",
+            "745e97a22d044861e00e4e7f6e789109f1d1d25a"
         ]
     },
     "capabilities": [
@@ -2373,7 +2374,8 @@
                 "0accf78e1919556c57dd08a4d055bc5bfa6419ae",
                 "66fbdbcf0e6b9d26768ce432fe0e0a49dad2e8db",
                 "7001f89501a6891f83796de732f0b0cf7f25f722",
-                "183dfe84c0ab58645b6bab01d4f71aa7d5ce6e2e"
+                "183dfe84c0ab58645b6bab01d4f71aa7d5ce6e2e",
+                "99fbc6beb8f4cff409637cc6e1e34170f7cf6918"
             ],
             "behaviors": [
                 "ARCH-POLICY-SCHEMA-001",

--- a/scripts/run-merge-approval-gate.js
+++ b/scripts/run-merge-approval-gate.js
@@ -88,7 +88,6 @@ function renderImpactReport({ pullRequest, context }) {
     const { classification, report, assignedCapabilities, expectedBehaviors } = context;
     const delta = report.policyDelta || {};
     const lines = [
-        `${REPORT_MARKER}`,
         `### Architecture impact report — \`${pullRequest.head.sha.substring(0, 8)}\``,
         `- classification: **${classification}**`,
         `- touched modules: ${Object.keys(report.touchedModules || {}).join(', ') || '(none)'}`,
@@ -222,7 +221,11 @@ async function main() {
     // posting, the missing status still blocks the merge (fail-closed).
 }
 
-main().catch(error => {
-    console.error(error instanceof Error ? error.message : String(error));
-    process.exitCode = 1;
-});
+if (require.main === module) {
+    main().catch(error => {
+        console.error(error instanceof Error ? error.message : String(error));
+        process.exitCode = 1;
+    });
+}
+
+module.exports = { renderImpactReport };

--- a/tests/unit/tooling/mergeApprovalGate.test.js
+++ b/tests/unit/tooling/mergeApprovalGate.test.js
@@ -100,6 +100,22 @@ test('ARCH-PR-MERGE-APPROVAL-GATE-001 posts a read-only impact report instead of
         'the gate must not post PR comments (notification-free review aid)');
     assert.match(script, /GITHUB_STEP_SUMMARY/,
         'the gate publishes the report to the job summary');
+
+    // Regression: the renderer must actually run — a wiring-only assertion
+    // shipped a REPORT_MARKER ReferenceError to production once (#306).
+    const { renderImpactReport } = require(path.join(
+        repositoryRoot, 'scripts', 'run-merge-approval-gate.js'));
+    const report = renderImpactReport({
+        pullRequest: { head: { sha: 'a'.repeat(40) } },
+        context: {
+            classification: 'tightening',
+            report: { policyDelta: {}, touchedModules: {}, protectedTouched: [] },
+            assignedCapabilities: [],
+            expectedBehaviors: [],
+        },
+    });
+    assert.ok(report.includes('aaaaaaaa'), 'the report names the head');
+    assert.ok(report.includes('tightening'));
     assert.match(script, /pull\/\$\{prNumber\}\/head/,
         'the gate fetches and checks out the exact PR head');
 

--- a/tests/unit/tooling/repositorySkills.test.js
+++ b/tests/unit/tooling/repositorySkills.test.js
@@ -53,6 +53,7 @@ test('ARCH-REPOSITORY-SKILL-GUIDANCE-001 keeps regression audits path-based and 
         ['cross-feature rendered journey', /cross-feature journey[\s\S]*real rendered surface[\s\S]*provider[\s\S]*viewport\s+matrix/i],
         ['post-repair mutation sensitivity', /implementation is already repaired[\s\S]*mutation sensitivity[\s\S]*reintroduce each causal defect/i],
         ['default-branch check ownership', /pull_request_target[\s\S]*default-branch files/i],
+        ['post-merge GREEN blind spot', /executes from the default branch after the merge[\s\S]*directly invoking the changed entry point/i],
     ]);
 });
 


### PR DESCRIPTION
## Summary

The merge-approval gate crashes on every PR right now: #306 removed the `REPORT_MARKER` constant but left a reference in `renderImpactReport`, so the gate dies with `ReferenceError: REPORT_MARKER is not defined` before posting any status (blocking #307 and everything else).

Pattern-matching wiring tests could not catch it — the gate's new code only executes from the default branch **after** the merge. Fixes:

- `renderImpactReport` no longer emits the removed marker line.
- The gate's `main()` is guarded by `require.main` so the module can be required in tests.
- The wiring test now **calls** `renderImpactReport` — a pattern-only assertion shipped this exact bug once already.
- Skill harvest records the post-merge GREEN blind spot for default-branch-only code paths.

Verified locally: `renderImpactReport` invoked directly renders the report; before this fix it throws the ReferenceError.

## Skill harvest

updated .skills/fixing-regressions-with-ci — post-merge GREEN blind spot: when the changed code path only executes from the default branch after merge, verify by directly invoking the changed entry point locally.

## Owner approvals

Copy each line into a separate PR comment below (both bind the exact head SHA and expire when the head moves):

```
approve-architecture 449d66444fa7278526c56d55457dbca0004071ef
```

```
approve 449d66444fa7278526c56d55457dbca0004071ef
```

## Verification

- `node --test tests/unit/tooling/mergeApprovalGate.test.js` — pass (now calls the renderer)
- `node --test tests/unit/tooling/repositorySkills.test.js` — pass
- `npm run test:behavior-contracts` / `npm run lint` — pass
- Direct invocation smoke: renderer output verified
