### PR TITLE
fix: recover AI session runtime creation on macOS

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -1709,6 +1709,19 @@
     ]
   },
   {
+    "id": "RUNTIME-FILESYSTEM-MUTATION-LOCK-001",
+    "domain": "runtime",
+    "title": "Filesystem mutation locks recover stale unpublished claims without admitting concurrent owners",
+    "priority": "P0",
+    "status": "automated",
+    "owners": [
+      "tests/contract/aiSessions/tmuxCreationLock.test.js"
+    ],
+    "evidence": [
+      "src/aiSessions/tmuxCreationLock.ts"
+    ]
+  },
+  {
     "id": "RUNTIME-LAUNCH-SPEC-001",
     "domain": "runtime",
     "title": "Launch Spec behavior",
@@ -1893,6 +1906,19 @@
     ],
     "evidence": [
       "scripts/run-ai-session-tmux-checks.js"
+    ]
+  },
+  {
+    "id": "RUNTIME-DIRECT-CREATE-TMUX-FAULT-ISOLATION-001",
+    "domain": "runtime",
+    "title": "Direct Terminal session creation is not blocked by an unrelated tmux refresh failure",
+    "priority": "P0",
+    "status": "automated",
+    "owners": [
+      "tests/contract/aiSessions/runtimeCoordinator.test.js"
+    ],
+    "evidence": [
+      "src/aiSessions/runtimeCoordinator.ts"
     ]
   },
   {

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "cef78fdf85403a352c65ec51dba00e46f83952d4",
+        "head": "f083befd7350c2cd8702f1cfb91fc49e0ffefb09",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -490,7 +490,8 @@
             "25393e066279a6fdd2672698a8d73938a6500584",
             "745e97a22d044861e00e4e7f6e789109f1d1d25a",
             "449d66444fa7278526c56d55457dbca0004071ef",
-            "8dd0fc43ba6766488bbff23cc7e5ebb1dd4cf367"
+            "8dd0fc43ba6766488bbff23cc7e5ebb1dd4cf367",
+            "4c5dc7f0bac0ba60f7e51f2267a15c0133b82006"
         ]
     },
     "capabilities": [
@@ -1387,7 +1388,8 @@
                 "4ea1cdb42f68bd853797824a5b976f3049dbba3d",
                 "b5833dc9dbabe561820ff330db4354e836859767",
                 "fb76fbaed8adbae010148a9d0322e7c9f3a40a9f",
-                "cef78fdf85403a352c65ec51dba00e46f83952d4"
+                "cef78fdf85403a352c65ec51dba00e46f83952d4",
+                "f083befd7350c2cd8702f1cfb91fc49e0ffefb09"
             ],
             "behaviors": [
                 "RUNTIME-TMUX-BACKEND-001",

--- a/docs/testing/main-capability-coverage.json
+++ b/docs/testing/main-capability-coverage.json
@@ -2,7 +2,7 @@
     "version": 1,
     "audit": {
         "base": "2b34c653119bdf480f2af0330ee3809b51441807",
-        "head": "982241093a3fe5d58074c3f1f630b8899c73a398",
+        "head": "cef78fdf85403a352c65ec51dba00e46f83952d4",
         "ignoredDocumentationCommits": [
             "dd86a325e3db5aa013ffa18a647e67e9fa279c10",
             "0b0e12b4d97ec7d77a8a93076459fdaad2e52070",
@@ -489,7 +489,8 @@
             "bb83e39f0c129104ef25be5b123bbb2038dc0b6a",
             "25393e066279a6fdd2672698a8d73938a6500584",
             "745e97a22d044861e00e4e7f6e789109f1d1d25a",
-            "449d66444fa7278526c56d55457dbca0004071ef"
+            "449d66444fa7278526c56d55457dbca0004071ef",
+            "8dd0fc43ba6766488bbff23cc7e5ebb1dd4cf367"
         ]
     },
     "capabilities": [
@@ -1385,7 +1386,8 @@
                 "f0a0a93cd0b01d606d4f3479f6d60a3c7c8f63a6",
                 "4ea1cdb42f68bd853797824a5b976f3049dbba3d",
                 "b5833dc9dbabe561820ff330db4354e836859767",
-                "fb76fbaed8adbae010148a9d0322e7c9f3a40a9f"
+                "fb76fbaed8adbae010148a9d0322e7c9f3a40a9f",
+                "cef78fdf85403a352c65ec51dba00e46f83952d4"
             ],
             "behaviors": [
                 "RUNTIME-TMUX-BACKEND-001",
@@ -1405,7 +1407,9 @@
                 "PERSIST-MULTI-PROVIDER-BATCH-ARCHIVE-001",
                 "AI-SESSION-PROVIDER-ICON-001",
                 "RUNTIME-TMUX-TERMINATE-SESSION-001",
-                "RUNTIME-TMUX-ATTACH-RESTORE-CONCURRENCY-001"
+                "RUNTIME-TMUX-ATTACH-RESTORE-CONCURRENCY-001",
+                "RUNTIME-FILESYSTEM-MUTATION-LOCK-001",
+                "RUNTIME-DIRECT-CREATE-TMUX-FAULT-ISOLATION-001"
             ],
             "prGates": [
                 "test:ci:linux",

--- a/scripts/run-ai-session-tmux-checks.js
+++ b/scripts/run-ai-session-tmux-checks.js
@@ -4608,6 +4608,8 @@ async function runTmuxStoreChecks() {
         fs.mkdirSync(staleLockPath);
         const staleHeldPath = path.join(staleLockPath, 'held');
         fs.mkdirSync(staleHeldPath);
+        const staleTime = new Date(Date.now() - 31000);
+        fs.utimesSync(staleHeldPath, staleTime, staleTime);
         const staleContainerIdentity = fs.lstatSync(staleLockPath);
         const staleHeldIdentity = fs.lstatSync(staleHeldPath);
         const staleClaimPath = path.join(staleHeldPath, `${'0'.repeat(64)}.claim`);
@@ -4620,7 +4622,6 @@ async function runTmuxStoreChecks() {
             heldIno: staleHeldIdentity.ino,
             heldBirthtimeMs: staleHeldIdentity.birthtimeMs,
         }));
-        const staleTime = new Date(Date.now() - 31000);
         fs.utimesSync(staleClaimPath, staleTime, staleTime);
         fs.utimesSync(staleHeldPath, staleTime, staleTime);
         let recovered = false;

--- a/src/aiSessions/runtimeCoordinator.ts
+++ b/src/aiSessions/runtimeCoordinator.ts
@@ -439,14 +439,13 @@ export class AiSessionRuntimeCoordinator<TTerminal = vscode.Terminal> {
             return { status: 'focused', runtime: cloneRuntime(existing[0]) };
         }
 
-        if (refresh.tmuxError && !this.isTmuxUnavailable(refresh.tmuxError)) {
-            throw refresh.tmuxError;
-        }
-
         const configuration = snapshotConfiguration(this.dependencies.getConfiguration());
         if (configuration.mode === 'vscode') {
             const runtime = await this.dependencies.direct.ensurePending(request);
             return { status: 'started', runtime: cloneRuntime(runtime) };
+        }
+        if (refresh.tmuxError && !this.isTmuxUnavailable(refresh.tmuxError)) {
+            throw refresh.tmuxError;
         }
         if (refresh.tmuxError && this.isTmuxUnavailable(refresh.tmuxError)) {
             return this.createViaExplicitDirect(request, refresh.tmuxError);

--- a/src/aiSessions/tmuxCreationLock.ts
+++ b/src/aiSessions/tmuxCreationLock.ts
@@ -290,7 +290,14 @@ async function recoverStaleHeld(
         }
         const claimPath = path.join(heldPath, name);
         const claim = await readClaim(claimPath);
-        if (!claim || !claimMatchesIdentity(claim.record, identity)
+        if (!claim) {
+            if (!await isStaleUnpublishedClaim(claimPath)) {
+                return;
+            }
+            staleClaims.push(claimPath);
+            continue;
+        }
+        if (!claimMatchesIdentity(claim.record, identity)
             || Date.now() - claim.stat.mtimeMs <= STALE_AFTER_MS) {
             return;
         }
@@ -331,6 +338,19 @@ async function readClaim(claimPath: string): Promise<{ record: LockClaimRecord; 
     } catch (error) {
         if (isNodeError(error, 'ENOENT') || error instanceof SyntaxError) {
             return null;
+        }
+        throw error;
+    }
+}
+
+async function isStaleUnpublishedClaim(claimPath: string): Promise<boolean> {
+    try {
+        const stat = await fs.lstat(claimPath);
+        return stat.isFile() && stat.size === 0
+            && Date.now() - stat.mtimeMs > STALE_AFTER_MS;
+    } catch (error) {
+        if (isNodeError(error, 'ENOENT')) {
+            return false;
         }
         throw error;
     }

--- a/tests/contract/aiSessions/runtimeCoordinator.test.js
+++ b/tests/contract/aiSessions/runtimeCoordinator.test.js
@@ -131,6 +131,24 @@ test('RUNTIME-RUNTIME-COORDINATOR-001 maps tmux unavailable choices without hidi
     await assert.rejects(failing.resume(fakeResumeRequest('fail-closed')), error => error === unexpected);
 });
 
+test('RUNTIME-DIRECT-CREATE-TMUX-FAULT-ISOLATION-001 creates directly when tmux refresh fails unexpectedly', async () => {
+    const direct = createFakeRuntimeBackend('vscode');
+    const tmuxFailure = new Error('stale tmux persistence lock');
+    const tmux = createFakeRuntimeBackend('tmux', { refreshError: tmuxFailure });
+    const coordinator = createCoordinator(direct, tmux, {
+        getConfiguration: () => ({
+            mode: 'vscode', tmuxLayout: 'project', tmuxPath: 'tmux',
+        }),
+    });
+
+    const result = await coordinator.create(fakeCreateRequest('direct-tmux-fault-isolation'));
+
+    assert.equal(result.status, 'started');
+    assert.equal(result.runtime.backend, 'vscode');
+    assert.equal(direct.ensurePendingCalls, 1);
+    assert.equal(tmux.ensurePendingCalls, 0);
+});
+
 test('SESSION-AI-SESSION-YOLO-LAZY-002 materializes resume specs once only on provider-dispatch branches', async () => {
     const focusedDirect = createFakeRuntimeBackend('vscode');
     focusedDirect.active.push(fakeRuntime('vscode', 'lazy-focused'));

--- a/tests/contract/aiSessions/runtimeCoordinator.test.js
+++ b/tests/contract/aiSessions/runtimeCoordinator.test.js
@@ -149,6 +149,20 @@ test('RUNTIME-DIRECT-CREATE-TMUX-FAULT-ISOLATION-001 creates directly when tmux 
     assert.equal(tmux.ensurePendingCalls, 0);
 });
 
+test('RUNTIME-RUNTIME-COORDINATOR-001 keeps tmux creation fail-closed on an unexpected refresh error', async () => {
+    const direct = createFakeRuntimeBackend('vscode');
+    const tmuxFailure = new Error('tmux persistence failed');
+    const tmux = createFakeRuntimeBackend('tmux', { refreshError: tmuxFailure });
+    const coordinator = createCoordinator(direct, tmux);
+
+    await assert.rejects(
+        coordinator.create(fakeCreateRequest('tmux-refresh-fail-closed')),
+        error => error === tmuxFailure
+    );
+    assert.equal(direct.ensurePendingCalls, 0);
+    assert.equal(tmux.ensurePendingCalls, 0);
+});
+
 test('SESSION-AI-SESSION-YOLO-LAZY-002 materializes resume specs once only on provider-dispatch branches', async () => {
     const focusedDirect = createFakeRuntimeBackend('vscode');
     focusedDirect.active.push(fakeRuntime('vscode', 'lazy-focused'));

--- a/tests/contract/aiSessions/tmuxCreationLock.test.js
+++ b/tests/contract/aiSessions/tmuxCreationLock.test.js
@@ -9,11 +9,10 @@ const test = require('node:test');
 
 const { withTmuxCreationLock } = require('../../../out/aiSessions/tmuxCreationLock');
 
-test('RUNTIME-FILESYSTEM-MUTATION-LOCK-001 recovers a stale zero-byte unpublished claim', async t => {
+function createStaleZeroByteClaim(t, key) {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-pivot-lock-recovery-'));
     t.after(() => fs.rmSync(root, { recursive: true, force: true }));
 
-    const key = 'runtime-binding-final-records';
     const digest = crypto.createHash('sha256').update(key, 'utf8').digest('hex');
     const lockPath = path.join(root, 'ai-session-tmux-locks', `${digest}.lock`);
     const heldPath = path.join(lockPath, 'held');
@@ -23,9 +22,16 @@ test('RUNTIME-FILESYSTEM-MUTATION-LOCK-001 recovers a stale zero-byte unpublishe
     const staleTime = new Date(Date.now() - 31_000);
     fs.utimesSync(claimPath, staleTime, staleTime);
     fs.utimesSync(heldPath, staleTime, staleTime);
+    return { root, lockPath, heldPath, claimPath };
+}
+
+test('RUNTIME-FILESYSTEM-MUTATION-LOCK-001 recovers a stale zero-byte unpublished claim', async t => {
+    const { root, lockPath, heldPath, claimPath } = createStaleZeroByteClaim(
+        t, 'runtime-binding-final-records'
+    );
 
     let entered = false;
-    await withTmuxCreationLock(root, key, async () => {
+    await withTmuxCreationLock(root, 'runtime-binding-final-records', async () => {
         entered = true;
     });
 
@@ -33,4 +39,60 @@ test('RUNTIME-FILESYSTEM-MUTATION-LOCK-001 recovers a stale zero-byte unpublishe
     assert.equal(fs.existsSync(claimPath), false);
     assert.equal(fs.existsSync(heldPath), false);
     assert.equal(fs.lstatSync(lockPath).isDirectory(), true);
+});
+
+test('RUNTIME-FILESYSTEM-MUTATION-LOCK-001 retries a transient missing claim during stale inspection', async t => {
+    const key = 'transient-missing-stale-claim';
+    const { root, claimPath } = createStaleZeroByteClaim(t, key);
+    const originalLstat = fs.promises.lstat;
+    let claimInspections = 0;
+    fs.promises.lstat = async target => {
+        if (target === claimPath && ++claimInspections === 2) {
+            const error = new Error('claim disappeared during inspection');
+            error.code = 'ENOENT';
+            throw error;
+        }
+        return originalLstat.call(fs.promises, target);
+    };
+
+    let entered = false;
+    try {
+        await withTmuxCreationLock(root, key, async () => {
+            entered = true;
+        });
+    } finally {
+        fs.promises.lstat = originalLstat;
+    }
+
+    assert.equal(entered, true);
+    assert.ok(claimInspections >= 4);
+});
+
+test('RUNTIME-FILESYSTEM-MUTATION-LOCK-001 propagates an unexpected stale-claim inspection error', async t => {
+    const key = 'stale-claim-inspection-error';
+    const { root, claimPath } = createStaleZeroByteClaim(t, key);
+    const originalLstat = fs.promises.lstat;
+    const expected = new Error('claim inspection denied');
+    expected.code = 'EACCES';
+    let claimInspections = 0;
+    fs.promises.lstat = async target => {
+        if (target === claimPath && ++claimInspections === 2) {
+            throw expected;
+        }
+        return originalLstat.call(fs.promises, target);
+    };
+
+    let entered = false;
+    try {
+        await assert.rejects(
+            withTmuxCreationLock(root, key, async () => {
+                entered = true;
+            }),
+            error => error === expected
+        );
+    } finally {
+        fs.promises.lstat = originalLstat;
+    }
+
+    assert.equal(entered, false);
 });

--- a/tests/contract/aiSessions/tmuxCreationLock.test.js
+++ b/tests/contract/aiSessions/tmuxCreationLock.test.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const { withTmuxCreationLock } = require('../../../out/aiSessions/tmuxCreationLock');
+
+test('RUNTIME-FILESYSTEM-MUTATION-LOCK-001 recovers a stale zero-byte unpublished claim', async t => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-pivot-lock-recovery-'));
+    t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+    const key = 'runtime-binding-final-records';
+    const digest = crypto.createHash('sha256').update(key, 'utf8').digest('hex');
+    const lockPath = path.join(root, 'ai-session-tmux-locks', `${digest}.lock`);
+    const heldPath = path.join(lockPath, 'held');
+    const claimPath = path.join(heldPath, `${'a'.repeat(64)}.claim`);
+    fs.mkdirSync(heldPath, { recursive: true });
+    fs.writeFileSync(claimPath, '');
+    const staleTime = new Date(Date.now() - 31_000);
+    fs.utimesSync(claimPath, staleTime, staleTime);
+    fs.utimesSync(heldPath, staleTime, staleTime);
+
+    let entered = false;
+    await withTmuxCreationLock(root, key, async () => {
+        entered = true;
+    });
+
+    assert.equal(entered, true);
+    assert.equal(fs.existsSync(claimPath), false);
+    assert.equal(fs.existsSync(heldPath), false);
+    assert.equal(fs.lstatSync(lockPath).isDirectory(), true);
+});


### PR DESCRIPTION
## Summary

- Recover stale zero-byte filesystem mutation claims left when the extension host exits between claim creation and publication.
- Keep VS Code Terminal session creation independent from unrelated tmux refresh failures while preserving pending/conflict checks.
- Make the stale-lock regression fixture stable on APFS, where backdating a directory can also change its birth time.
- Add P0 behavior contracts, regression coverage for CI-exposed branches, and main-capability audit coverage for both recovery paths.

## Architecture impact report

The merge-approval gate will regenerate the architecture impact report for this exact head.

## Owner approvals

```
approve-architecture 8a03495ebcb60c6b82c8c16fc0bbe822a9664d18
```

```
approve 8a03495ebcb60c6b82c8c16fc0bbe822a9664d18
```

## Skill harvest

no skill change — the existing regression, worktree, review, and publishing skills covered the workflow; no reusable instruction gap remained.

## Verification

- `npm ci`
- `npm run test-compile`
- `node --test --test-concurrency=1 tests/contract/aiSessions/tmuxCreationLock.test.js tests/contract/aiSessions/runtimeCoordinator.test.js` (19 passed)
- `node scripts/check-changed-coverage.js` (100.00%, 24/24 changed lines)
- `npm run lint:ci`
- `npm run test:behavior-contracts`
- `TMPDIR=/tmp AGENT_PIVOT_TMUX_PATH=/opt/homebrew/bin/tmux npm run test:tmux:smoke`
- Full coverage suite: 1181/1182 passed locally; the only failure is the unchanged macOS case-insensitive `SKILL.md`/`skill.md` fixture, which does not apply to Linux CI.
- `npm run test:safety:run`: workspace parity, AI session tmux/safety, and open-project safety passed; the unchanged skill-management fixture fails on macOS because the case-insensitive filesystem aliases `skill.md` to `SKILL.md` (same inode).
- Local VSIX packaging, installation, and installed-byte verification passed for Agent Pivot 1.1.1 and the Attention UI Bridge.