### PR TITLE
feat(architecture): close the MOD-SHARED-KERNEL wave as strict

### DIFF
--- a/.skills/review-fix-commit-loop/SKILL.md
+++ b/.skills/review-fix-commit-loop/SKILL.md
@@ -92,10 +92,9 @@ commit only the intended files.
      contract pairs (availability guards, message shapes, shared markup):
      coupled markup and script changes belong in the same commit, so no
      intermediate commit leaves the Webview gated off by missing elements.
-   - After the final implementation or skill-owner commit exists, complete the
-     main-capability assignment and `audit.head` update in a separate
-     documentation-only audit commit, then rerun
-     `npm run test:behavior-contracts` before push.
+   - The capability manifest (`docs/testing/main-capability-coverage.json`) is
+     a read-only historical record since the harness pruning (PR #309): do not
+     add audit commits, capability assignments, or `audit.head` updates.
 
 ## Reporting
 
@@ -114,7 +113,7 @@ Summarize:
   --production` — the same mode CI uses.
 - Do not bury review fixes inside unrelated feature commits unless the user requested squashing.
 - Do not trust subagent output blindly; inspect the actual diff and rerun evidence-producing commands.
-- Do not treat a pre-commit behavior-contract pass as proof of commit-level audit currency.
+- Do not treat a pre-commit behavior-contract pass as proof of commit-level audit currency (the audit itself was pruned in PR #309; the manifest is historical).
 - Before moving, renaming, or deleting repository content, grep `scripts/` and
   `tests/` for strings anchored to that content (changelog entries, README
   phrases, shipped file paths) and update every anchored reader in the same

--- a/docs/testing/architecture-program.json
+++ b/docs/testing/architecture-program.json
@@ -121,10 +121,15 @@
             "nextAction": "awaiting its Stage 5 wave"
         },
         "MOD-SHARED-KERNEL": {
-            "state": "legacy",
-            "since": "initial coarse registry (Stage 1A/2)",
-            "evidence": [],
-            "nextAction": "awaiting its Stage 5 wave"
+            "state": "strict",
+            "since": "Stage 5 wave (2026-08-20): zero value-level outbound edges confirmed; all 8 cross-module edges are type-only and truthfully declared; no baseline or waiver debt names the module",
+            "evidence": [
+                "docs/architecture/changes/ARCH-CHANGE-002.md",
+                "tests/unit/sharedKernel/sessionAssignment.test.js",
+                "tests/unit/workspaces/worktreeSessionAssignment.test.js",
+                "tests/unit/worktrees/worktreeKeyCodecs.test.js"
+            ],
+            "nextAction": "none — strict; hold via the architecture policy checks"
         }
     }
 }

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import * as vscode from 'vscode';
+import type * as vscode from 'vscode';
 import type { TodoSearchCatalogItem } from './todos/types';
 import { StorageOption, VSCODE_REMOTE_PREFIX, WSL_DEFAULT_REGEX } from "./constants";
 import type { AiSessionAttentionReason } from './aiSessions/lifecycle';

--- a/tests/unit/sharedKernel/sessionAssignment.test.js
+++ b/tests/unit/sharedKernel/sessionAssignment.test.js
@@ -1,0 +1,88 @@
+'use strict';
+
+// Characterization tests for the MOD-SHARED-KERNEL path assignment utilities.
+// They pin the CURRENT behavior of src/sessionAssignment.ts (posix and
+// windows branches alike — the host OS is irrelevant because the module picks
+// the path API from the string shape) so the module's strict-mode claim rests
+// on direct coverage, not only on indirect worktree-assignment tests.
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {
+    assignPathToWorkspaceRoot,
+    getWorkspaceHostPathComparisonKey,
+    isWorkspaceHostPathContained,
+    normalizeWorkspaceHostPath,
+} = require('../../../out/sessionAssignment');
+
+test('normalizeWorkspaceHostPath blanks non-path input', () => {
+    assert.equal(normalizeWorkspaceHostPath(''), '');
+    assert.equal(normalizeWorkspaceHostPath('   '), '');
+    assert.equal(normalizeWorkspaceHostPath(null), '');
+    assert.equal(normalizeWorkspaceHostPath(undefined), '');
+});
+
+test('normalizeWorkspaceHostPath normalizes posix paths and strips trailing separators', () => {
+    assert.equal(normalizeWorkspaceHostPath('/a/b/'), '/a/b');
+    assert.equal(normalizeWorkspaceHostPath('/a/./b'), '/a/b');
+    assert.equal(normalizeWorkspaceHostPath('/a/b/../c'), '/a/c');
+    assert.equal(normalizeWorkspaceHostPath('/'), '/');
+});
+
+test('normalizeWorkspaceHostPath selects the win32 API from the string shape', () => {
+    assert.equal(normalizeWorkspaceHostPath('C:\\foo\\bar\\'), 'C:\\foo\\bar');
+    assert.equal(normalizeWorkspaceHostPath('c:/foo/bar'), 'c:\\foo\\bar');
+    assert.equal(normalizeWorkspaceHostPath('D:\\'), 'D:\\');
+});
+
+test('getWorkspaceHostPathComparisonKey lowercases windows and preserves posix case', () => {
+    assert.equal(getWorkspaceHostPathComparisonKey('C:\\Foo\\Bar'), 'windows:c:\\foo\\bar');
+    assert.equal(getWorkspaceHostPathComparisonKey('/Foo/Bar'), 'posix:/Foo/Bar');
+    assert.equal(getWorkspaceHostPathComparisonKey(''), '');
+});
+
+test('isWorkspaceHostPathContained matches the root itself and descendants only', () => {
+    assert.equal(isWorkspaceHostPathContained('/a/b', '/a/b'), true);
+    assert.equal(isWorkspaceHostPathContained('/a/b', '/a/b/c/d'), true);
+    assert.equal(isWorkspaceHostPathContained('/a/b', '/a/b2'), false);
+    assert.equal(isWorkspaceHostPathContained('/a/b', '/a'), false);
+    assert.equal(isWorkspaceHostPathContained('/a/b', ''), false);
+});
+
+test('isWorkspaceHostPathContained is case-insensitive on windows and never crosses path kinds', () => {
+    assert.equal(isWorkspaceHostPathContained('C:\\Foo', 'c:\\foo\\bar'), true);
+    assert.equal(isWorkspaceHostPathContained('C:\\foo', '/c/foo'), false);
+});
+
+test('assignPathToWorkspaceRoot prefers the longest containing root, then ordinal, then declaration order', () => {
+    const roots = [
+        { id: 'outer', hostPath: '/repo', ordinal: 0 },
+        { id: 'inner', hostPath: '/repo/packages/api', ordinal: 1 },
+    ];
+    assert.equal(assignPathToWorkspaceRoot('/repo/packages/api/src', roots)?.id, 'inner');
+    assert.equal(assignPathToWorkspaceRoot('/repo/tools', roots)?.id, 'outer');
+
+    const tied = [
+        { id: 'second', hostPath: '/repo', ordinal: 1 },
+        { id: 'first', hostPath: '/repo', ordinal: 0 },
+    ];
+    assert.equal(assignPathToWorkspaceRoot('/repo/x', tied)?.id, 'first');
+
+    const sameOrdinal = [
+        { id: 'declared-first', hostPath: '/repo', ordinal: 0 },
+        { id: 'declared-second', hostPath: '/repo', ordinal: 0 },
+    ];
+    assert.equal(assignPathToWorkspaceRoot('/repo/x', sameOrdinal)?.id, 'declared-first');
+});
+
+test('assignPathToWorkspaceRoot rejects empty candidates and skips unusable roots', () => {
+    const roots = [{ id: 'usable', hostPath: '/repo', ordinal: 0 }];
+    assert.equal(assignPathToWorkspaceRoot('', roots), null);
+    assert.equal(assignPathToWorkspaceRoot('/repo/x', []), null);
+    assert.equal(assignPathToWorkspaceRoot('/elsewhere/x', roots), null);
+    const degraded = [
+        { id: 'blank', hostPath: '', ordinal: 0 },
+        { id: 'usable', hostPath: '/repo', ordinal: 1 },
+    ];
+    assert.equal(assignPathToWorkspaceRoot('/repo/x', degraded)?.id, 'usable');
+});

--- a/tests/unit/tooling/repositorySkills.test.js
+++ b/tests/unit/tooling/repositorySkills.test.js
@@ -82,7 +82,6 @@ test('ARCH-REPOSITORY-SKILL-GUIDANCE-001 requires whole-branch review and blocks
         ['build-cleaner dependency ordering', /cleans or rebuilds `out\/`[\s\S]*consume `out\/`/i],
         ['performance-threshold isolation', /browser performance-threshold tests[\s\S]*without concurrent CPU-intensive[\s\S]*coverage[\s\S]*rerun[\s\S]*browser suite alone/i],
         ['aggregate runtime safety gate', /runtime identity[\s\S]*tmux metadata versions[\s\S]*runtime-binding[\s\S]*npm run test:safety:run[\s\S]*migration[\s\S]*recovery[\s\S]*cross-host race/i],
-        ['post-implementation capability audit', /final implementation or skill-owner commit[\s\S]*audit\.head/i],
         ['exit-code-gated verification', /own exit code[\s\S]*pipefail[\s\S]*never `;`/i],
     ]);
 });


### PR DESCRIPTION
## Summary

Stage 5 wave close-out for **MOD-SHARED-KERNEL** (`src/models.ts`, `src/constants.ts`, `src/sessionAssignment.ts`, `src/worktreeSessionAssignment.ts`, `src/worktreeIdentity.ts`).

Wave findings:

- The kernel's defining contract already holds: **zero value-level outbound edges**; all 8 cross-module edges are type-only and exactly match the declared `mayDependOn` (no unused, no undeclared).
- No debt names the module: no cycle-baseline fingerprints, no waivers; closed-world, boundary, and single-writer checks are green.
- Coverage: `worktreeIdentity` codecs are byte-pinned by `tests/unit/worktrees/worktreeKeyCodecs.test.js`, `worktreeSessionAssignment` has direct tests, `models.ts` is exercised by contract tests. The one gap — `src/sessionAssignment.ts` had only indirect coverage — is now locked by a direct characterization test (8 cases, posix + windows branches).

Changes:

1. `test:` new `tests/unit/sharedKernel/sessionAssignment.test.js` (characterization only, current behavior pinned, no production change).
2. `refactor:` `models.ts` imports `vscode` type-only (its single use is a type position); compiled `out/models.js` drops the host-runtime require.
3. `docs:` program ledger flips MOD-SHARED-KERNEL `legacy → strict` with evidence. 1/16 modules strict alongside MOD-WORKTREE-LIFECYCLE.
4. `docs(skill):` review-fix-commit-loop no longer instructs the capability-audit commit (machinery deleted in #309).

Out of scope (deliberate): inverting the kernel's type-level imports (the owner-approved purpose tolerates "nothing at value level"; moving provider/todo view types would churn 100+ consumers for no behavioral gain) and narrowing public entrypoints (the whole 5-file surface is the kernel's contract).

## Skill harvest

Updated `.skills/review-fix-commit-loop` — removed the stale capability-audit commit step and marked audit-currency language historical (the manifest is read-only since #309).

## Owner approvals

Copy the line below into a PR comment (binds the exact head SHA and expires when the head moves):

```
approve c604644d53788ccbb9cc21a27cf5964abd7ad4be
```

## Verification

- `npm run test-compile` — pass; `out/models.js` contains zero `vscode` references
- `node --test tests/unit/**` — 1169 pass, 0 fail (8 new)
- `node --test tests/contract/**` — 1182 pass, 0 fail
- `npm run test:architecture-policy` — pass (closed-world, boundaries, single-writers, webview manifest)
- `npm run test:behavior-contracts` / `npm run lint` / `npm run lint:ci` — pass
- `git diff --check` — clean
