### PR TITLE
docs(architecture): mark MOD-AI-SESSION-CONTROL strict

### DIFF
--- a/docs/testing/architecture-modules.json
+++ b/docs/testing/architecture-modules.json
@@ -348,13 +348,12 @@
       "publicEntrypoints": [
         "src/aiSessions/sessionControllerComposition.ts",
         "src/aiSessions/commandController.ts",
-        "src/aiSessions/creationController.ts",
-        "src/aiSessions/resumeController.ts",
         "src/aiSessions/terminalCommandController.ts",
         "src/aiSessions/aliasController.ts",
         "src/aiSessions/pinController.ts",
         "src/aiSessions/sessionProfileController.ts",
-        "src/aiSessions/archive*"
+        "src/aiSessions/archiveController.ts",
+        "src/aiSessions/archiveBatchAcrossProviders.ts"
       ],
       "mayDependOn": [
         "MOD-AI-SESSION-PROVIDER",

--- a/docs/testing/architecture-program.json
+++ b/docs/testing/architecture-program.json
@@ -71,10 +71,13 @@
             "nextAction": "awaiting its Stage 5 wave"
         },
         "MOD-AI-SESSION-CONTROL": {
-            "state": "legacy",
-            "since": "initial coarse registry (Stage 1A/2)",
-            "evidence": [],
-            "nextAction": "awaiting its Stage 5 wave"
+            "state": "strict",
+            "since": "Stage 5 wave (2026-08-20): no direct 2-cycle names the module; all five declared dependencies carry real edges; entrypoints narrowed to the consumed surface (composition + four controllers + two archive entry points); SCC membership is cluster-level debt tracked by ARCH-WAIVER-004",
+            "evidence": [
+                "tests/unit/workspaces/sessionScope.test.js",
+                "tests/contract/aiSessions/archiveAndHydration.test.js"
+            ],
+            "nextAction": "none — strict; hold via the architecture policy checks"
         },
         "MOD-AI-SESSION-PROVIDER": {
             "state": "legacy",


### PR DESCRIPTION
## Summary

Stage 5 wave close-out for **MOD-AI-SESSION-CONTROL**. The investigation found nothing to cut: no direct 2-cycle names the module, every declared `mayDependOn` carries real edges, and all inbound value edges come from the composition root (the expected direction). Its SCC membership is cluster-level debt through the shell, tracked by ARCH-WAIVER-004 — per policy that blocks whole-program acceptance, not strict mode.

So this wave is bookkeeping only, no production code changes:

- Public entrypoints narrow from the whole controller glob to the consumed surface: `sessionControllerComposition`, the four controllers the shell value-imports (`sessionProfile`, `alias`, `pin`) or type-imports (`command`, `terminalCommand`), and the two archive entry points (`archiveController`, `archiveBatchAcrossProviders`). `creationController` / `resumeController` / the remaining archive internals become module-internal.
- Ledger flips `legacy → strict` (5th strict module of 16).

## Skill harvest

none

## Owner approvals

Copy the line below into a PR comment (binds the exact head SHA and expires when the head moves):

```
approve cf26979021eb75a6c10062bed3f46850bc11a65b
```

## Verification

- `npm run test:architecture-policy` — pass (closed-world, boundaries with the narrowed entrypoints, single-writers, webview manifest)
- `node --test tests/unit/**` — 1172 pass / `node --test tests/contract/**` — 1182 pass
- `npm run test:behavior-contracts` / `npm run lint:ci` — pass
- `git diff --check` — clean
