### PR TITLE
docs(architecture): mark MOD-ATTENTION-BRIDGE-EXT strict

### DIFF
--- a/docs/testing/architecture-modules.json
+++ b/docs/testing/architecture-modules.json
@@ -869,7 +869,7 @@
         "exclude": []
       },
       "publicEntrypoints": [
-        "extensions/attention-ui-bridge/src/**",
+        "extensions/attention-ui-bridge/src/extension.ts",
         "shared/attention-bridge/**"
       ],
       "mayDependOn": [

--- a/docs/testing/architecture-program.json
+++ b/docs/testing/architecture-program.json
@@ -136,10 +136,12 @@
             "nextAction": "none — strict; hold via the architecture policy checks"
         },
         "MOD-ATTENTION-BRIDGE-EXT": {
-            "state": "legacy",
-            "since": "initial coarse registry (Stage 1A/2)",
-            "evidence": [],
-            "nextAction": "awaiting its Stage 5 wave"
+            "state": "strict",
+            "since": "Stage 5 wave (2026-08-20): no inbound value edges and no cycle names the module (the companion extension is a separate compile unit consumed only through the wire); entrypoints narrowed to the composition entry plus the shared bridge protocol",
+            "evidence": [
+                "tests/contract/openProjects/workspaceController.test.js"
+            ],
+            "nextAction": "none — strict; hold via the architecture policy checks"
         },
         "MOD-SHARED-KERNEL": {
             "state": "strict",


### PR DESCRIPTION
## Summary

Stage 5 wave close-out for **MOD-ATTENTION-BRIDGE-EXT**. Investigation found nothing to cut: the companion extension is a separate compile unit consumed only through the wire — zero inbound value edges, no 2-cycle names it, and all five declared dependencies carry real edges.

Bookkeeping only, no production code changes:

- Public entrypoints narrow from the whole-module glob to the composition entry (`extension.ts`) plus the shared bridge protocol (`shared/attention-bridge/**`).
- Ledger flips `legacy → strict` (9th strict module of 16).
- No bridge source or protocol changes, so no companion-extension version bump is required by the release policy.

## Skill harvest

none

## Owner approvals

Copy the line below into a PR comment (binds the exact head SHA and expires when the head moves):

```
approve 4a893c96e06ae15831f71f6f5dfbcbc5d9c39e21
```

## Verification

- `npm run test:architecture-policy` — pass (closed-world, boundaries with the narrowed entrypoints, single-writers, webview manifest)
- `node --test tests/unit/**` — 1172 pass / `tests/contract/**` — 1182 pass
- `npm run test:behavior-contracts` / `npm run lint:ci` — pass
- `git diff --check` — clean
