### PR TITLE
docs(architecture): mark MOD-AI-SESSION-NOTIFY strict

### DIFF
--- a/docs/testing/architecture-modules.json
+++ b/docs/testing/architecture-modules.json
@@ -214,9 +214,9 @@
         "exclude": []
       },
       "publicEntrypoints": [
-        "src/aiSessions/notify/**",
-        "src/aiSessions/notifyIntegration/**",
-        "src/aiSessions/notifyConfiguration.ts"
+        "src/aiSessions/notify/eventIdentity.ts",
+        "src/aiSessions/notifyConfiguration.ts",
+        "src/aiSessions/notifyIntegration/notifier.ts"
       ],
       "mayDependOn": [
         "MOD-AI-SESSION-ATTENTION"

--- a/docs/testing/architecture-program.json
+++ b/docs/testing/architecture-program.json
@@ -59,10 +59,12 @@
             "nextAction": "none — strict; hold via the architecture policy checks"
         },
         "MOD-AI-SESSION-NOTIFY": {
-            "state": "legacy",
-            "since": "initial coarse registry (Stage 1A/2)",
-            "evidence": [],
-            "nextAction": "awaiting its Stage 5 wave"
+            "state": "strict",
+            "since": "Stage 5 wave (2026-08-20): zero value-level outbound edges and no cycle names the module; entrypoints narrowed to the three consumed files",
+            "evidence": [
+                "tests/contract/aiSessions/attention.test.js"
+            ],
+            "nextAction": "none — strict; hold via the architecture policy checks"
         },
         "MOD-AI-SESSION-RUNTIME": {
             "state": "legacy",


### PR DESCRIPTION
## Summary

Stage 5 wave close-out for **MOD-AI-SESSION-NOTIFY**. Investigation found the module already clean: zero value-level outbound edges, no 2-cycle names it, inbound value edges come only from the attention monitor and the composition root (the expected direction).

Bookkeeping only, no production code changes:

- Public entrypoints narrow from the whole-module globs to the three consumed files (`notify/eventIdentity.ts`, `notifyConfiguration.ts`, `notifyIntegration/notifier.ts`); the dispatcher, store, policy, templates, and the remaining integration files become module-internal.
- Ledger flips `legacy → strict` (10th strict module of 16).

## Skill harvest

none

## Owner approvals

Copy the line below into a PR comment (binds the exact head SHA and expires when the head moves):

```
approve ed348b3821fa9e125269709a674710e63cecd930
```

## Verification

- `npm run test:architecture-policy` — pass (closed-world, boundaries with the narrowed entrypoints, single-writers, webview manifest)
- `node --test tests/unit/**` — 1172 pass / `tests/contract/**` — 1182 pass
- `npm run test:behavior-contracts` / `npm run lint:ci` — pass
- `git diff --check` — clean
