### PR TITLE
docs(architecture): mark MOD-AI-SESSION-CONVERSATION strict

### DIFF
--- a/docs/testing/architecture-modules.json
+++ b/docs/testing/architecture-modules.json
@@ -95,8 +95,16 @@
         ],
         "exclude": []
       },
-      "publicEntrypoints": [
-        "src/aiSessions/conversation/**"
+"publicEntrypoints": [
+        "src/aiSessions/conversation/bookmarkStore.ts",
+        "src/aiSessions/conversation/commentStore.ts",
+        "src/aiSessions/conversation/composition.ts",
+        "src/aiSessions/conversation/displayMetadata.ts",
+        "src/aiSessions/conversation/panelRestoreCoordinator.ts",
+        "src/aiSessions/conversation/projectCommentStore.ts",
+        "src/aiSessions/conversation/sessionRebindCoordinator.ts",
+        "src/aiSessions/conversation/sessionStatusController.ts",
+        "src/aiSessions/conversation/submission.ts"
       ],
       "mayDependOn": [
         "MOD-AI-SESSION-PROVIDER",

--- a/docs/testing/architecture-program.json
+++ b/docs/testing/architecture-program.json
@@ -43,10 +43,13 @@
             "nextAction": "awaiting its Stage 5 wave"
         },
         "MOD-AI-SESSION-CONVERSATION": {
-            "state": "legacy",
-            "since": "initial coarse registry (Stage 1A/2)",
-            "evidence": [],
-            "nextAction": "awaiting its Stage 5 wave"
+            "state": "strict",
+            "since": "Stage 5 wave (2026-08-21): no cycle names the module; inbound value edges come only from the composition root; entrypoints narrowed from the whole-surface glob to the 9 consumed files (stores, composition, coordinators, submission)",
+            "evidence": [
+                "tests/contract/aiSessions/attention.test.js",
+                "tests/unit/aiSessions/conversationChangesController.test.js"
+            ],
+            "nextAction": "none — strict; hold via the architecture policy checks"
         },
         "MOD-AI-SESSION-ATTENTION": {
             "state": "strict",


### PR DESCRIPTION
## Summary

Stage 5 wave close-out for **MOD-AI-SESSION-CONVERSATION** (43 files). The module is already clean: no cycle names it, its outbound value edges land on the kernel/worktree/provider surfaces it declares, and all inbound value edges come from the composition root.

Bookkeeping only, no production code changes:

- Public entrypoints narrow from `src/aiSessions/conversation/**` to the 9 consumed files (the stores, `composition`, the three coordinators, `sessionStatusController`, `submission`); the 34 viewer/adapter/controller internals become module-internal, so future deep imports fail CI.
- Ledger flips `legacy → strict` (14th strict module of 16).

## Skill harvest

none

## Owner approvals

Copy the line below into a PR comment (binds the exact head SHA and expires when the head moves):

```
approve 91a24d0d0a4bd8cf89e941fe5fe2af94da552356
```

## Verification

- `npm run test:architecture-policy` — pass (closed-world, boundaries with the narrowed entrypoints, single-writers, webview manifest)
- `node --test tests/unit/**` — 1172 pass / `tests/contract/**` — 1182 pass
- `npm run test:behavior-contracts` / `npm run lint:ci` — pass
- `git diff --check` — clean
