### PR TITLE
refactor(architecture): converge the shell wave and empty the waiver ledger (MOD-DASHBOARD-SHELL)

### DIFF
--- a/.ci/architecture-debt-baseline.json
+++ b/.ci/architecture-debt-baseline.json
@@ -4,9 +4,7 @@
   "note": "Exact violation fingerprints per implemented rule. Debt may shrink or stay; it may never grow, move, or change identity invisibly.",
   "rules": {
     "module-cycle": {
-      "fingerprints": [
-        "scc:MOD-AI-SESSION-ATTENTION|MOD-AI-SESSION-RUNTIME|MOD-PROJECT-CATALOG"
-      ]
+      "fingerprints": []
     }
   }
 }

--- a/docs/testing/architecture-modules.json
+++ b/docs/testing/architecture-modules.json
@@ -37,9 +37,11 @@
       },
       "publicEntrypoints": [
         "src/dashboard.ts",
-        "src/sponsor.ts",
-        "src/dashboard/**",
-        "src/webview/**"
+        "src/dashboard/groupCollapseController.ts",
+        "src/dashboard/messageRouter.ts",
+        "src/dashboard/projectsPanelController.ts",
+        "src/dashboard/webviewUpdateMessages.ts",
+        "src/webview/dashboardViewModel.ts"
       ],
       "mayDependOn": [
         "MOD-AI-SESSION-ATTENTION",
@@ -985,7 +987,8 @@
           "src/webviewHtmlEscape.ts",
           "src/configuration.ts",
           "src/attentionSessionKeys.ts",
-          "src/runtimeOwnership.ts"
+          "src/runtimeOwnership.ts",
+          "src/uriStrings.ts"
         ],
         "exclude": []
       },
@@ -999,7 +1002,8 @@
         "src/webviewHtmlEscape.ts",
         "src/configuration.ts",
         "src/attentionSessionKeys.ts",
-        "src/runtimeOwnership.ts"
+        "src/runtimeOwnership.ts",
+        "src/uriStrings.ts"
       ],
       "mayDependOn": [
         "MOD-AI-SESSION-PROVIDER",
@@ -1022,7 +1026,8 @@
             "src/webviewHtmlEscape.ts",
             "src/configuration.ts",
             "src/attentionSessionKeys.ts",
-            "src/runtimeOwnership.ts"
+            "src/runtimeOwnership.ts",
+            "src/uriStrings.ts"
           ]
         }
       ],

--- a/docs/testing/architecture-program.json
+++ b/docs/testing/architecture-program.json
@@ -37,10 +37,13 @@
             }
         },
         "MOD-DASHBOARD-SHELL": {
-            "state": "legacy",
-            "since": "initial coarse registry (Stage 1A/2)",
-            "evidence": [],
-            "nextAction": "awaiting its Stage 5 wave"
+            "state": "strict",
+            "since": "Stage 5 wave (2026-08-21): composition-root hygiene pass — provider executable probing moved to the provider capability, the git API acquisition moved to the worktree monitor, and the triple-copied isUriString converged into the kernel, dissolving the last SCC cluster; the waiver ledger is empty; entrypoints narrowed to the composition root plus the five consumed type surfaces",
+            "evidence": [
+                "scripts/run-dashboard-webview-checks.js",
+                "tests/contract/dashboardBoundaries.test.js"
+            ],
+            "nextAction": "initializeDashboard decomposition and webview-globals reduction remain optional follow-up slices (behavior-preserving, separately planned)"
         },
         "MOD-AI-SESSION-CONVERSATION": {
             "state": "strict",

--- a/docs/testing/architecture-waivers.json
+++ b/docs/testing/architecture-waivers.json
@@ -7,19 +7,5 @@
         "Strict-mode blocking: a module cannot go strict while a 2-cycle fingerprint names it; the SCC cluster entry is cluster-level debt and blocks only whole-program acceptance.",
         "ARCH-CHANGE-002 retired ARCH-WAIVER-003 (the workspace↔worktree pair dissolved when the shared assignment utilities moved to the kernel) and updated ARCH-WAIVER-004 to the shrunken cluster (MOD-WORKTREE-LIFECYCLE is cycle-free)."
     ],
-    "waivers": [
-        {
-            "id": "ARCH-WAIVER-004",
-            "rule": "module-cycle",
-            "fingerprints": [
-                "scc:MOD-AI-SESSION-ATTENTION|MOD-AI-SESSION-RUNTIME|MOD-PROJECT-CATALOG"
-            ],
-            "owner": "hzcheng",
-            "reason": "Cluster-level symptom of the coarse registry phase: 12 modules form one cyclic component through the composition root. MOD-WORKTREE-LIFECYCLE left the cluster in ARCH-CHANGE-002. Tracked at cluster level; it does not block per-module strict mode but must be gone for program acceptance.",
-            "tracking": "architecture program acceptance (Stage 6)",
-            "createdAt": "2026-08-17",
-            "retiresWith": "WAVE-FINAL",
-            "expiresAt": null
-        }
-    ]
+    "waivers": []
 }

--- a/src/aiSessions/providerDirectoryCapability.ts
+++ b/src/aiSessions/providerDirectoryCapability.ts
@@ -1,5 +1,8 @@
 'use strict';
 
+import * as childProcess from 'child_process';
+import { existsSync } from 'fs';
+import * as path from 'path';
 import type { AiSessionProviderId } from '../models';
 
 export type ProviderDirectoryCapabilityStatus = 'supported' | 'unsupported' | 'unavailable';
@@ -110,4 +113,56 @@ export class ProviderDirectoryCapabilityProbe {
         const output = boundedHelpOutput(help);
         return result(ADD_DIRECTORY_OPTION.test(output) ? 'supported' : 'unsupported');
     }
+}
+
+export function resolveAiProviderExecutable(commandName: string): string | null {
+    if (!commandName) {
+        return null;
+    }
+    if (path.isAbsolute(commandName)) {
+        return existsSync(commandName) ? commandName : null;
+    }
+
+    const windows = process.platform === 'win32';
+    const pathValue = process.env.PATH || process.env.Path || '';
+    const extensions = windows
+        ? (process.env.PATHEXT || '.COM;.EXE;.BAT;.CMD').split(';').filter(Boolean)
+        : [''];
+    for (const directory of pathValue.split(path.delimiter).filter(Boolean)) {
+        for (const extension of extensions) {
+            const candidate = path.join(directory, `${commandName}${extension}`);
+            if (existsSync(candidate)) {
+                return candidate;
+            }
+        }
+    }
+    return null;
+}
+
+export function runBoundedAiProviderHelp(
+    executable: string,
+    args: readonly string[],
+    options: BoundedChildProcessOptions
+): Promise<BoundedChildProcessResult> {
+    return new Promise(resolve => {
+        childProcess.execFile(executable, [...args], {
+            timeout: options.timeoutMs,
+            maxBuffer: options.maxOutputBytes,
+            encoding: 'utf8',
+            windowsHide: true,
+        }, (error, stdout, stderr) => {
+            const childError = error as unknown as NodeJS.ErrnoException & {
+                code?: string | number;
+                killed?: boolean;
+            };
+            resolve({
+                exitCode: error
+                    ? (typeof childError.code === 'number' ? childError.code : null)
+                    : 0,
+                stdout: typeof stdout === 'string' ? stdout : '',
+                stderr: typeof stderr === 'string' ? stderr : '',
+                timedOut: Boolean(error && childError.killed),
+            });
+        });
+    });
 }

--- a/src/aiSessions/terminalCwd.ts
+++ b/src/aiSessions/terminalCwd.ts
@@ -2,7 +2,7 @@
 
 import * as path from 'path';
 import { lstatSync } from 'fs';
-import { isUriString } from '../projects/openProjectService';
+import { isUriString } from '../uriStrings';
 
 export function getUsableTerminalCwd(cwd: string): string {
     if (!cwd || isUriString(cwd)) {

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -104,6 +104,7 @@ import {
 } from './dashboard/runningSessionJump';
 import { createSessionNavigationCoordinator } from './dashboard/sessionNavigationCoordinator';
 import { buildAiSessionsUpdatedMessage, buildOpenWorkspacesUpdatedMessage } from './dashboard/webviewUpdateMessages';
+import { getVsCodeGitApiForWorktreeMonitoring } from './dashboard/gitApiAcquisition';
 import { createSessionNavigationFocusExecutor } from './dashboard/sessionNavigationFocusExecutor';
 import {
     createSessionStatusCycleHandler,
@@ -126,7 +127,11 @@ import {
 } from './aiSessions/runningQueue';
 import { getAiSessionKey } from './aiSessions/sessionHelpers';
 import { createAiSessionProviderRegistry } from './aiSessions/providers';
-import { ProviderDirectoryCapabilityProbe } from './aiSessions/providerDirectoryCapability';
+import {
+    ProviderDirectoryCapabilityProbe,
+    resolveAiProviderExecutable,
+    runBoundedAiProviderHelp,
+} from './aiSessions/providerDirectoryCapability';
 import type {
     BoundedChildProcessOptions,
     BoundedChildProcessResult,
@@ -350,73 +355,6 @@ const DASHBOARD_BOOTSTRAP_PHASE_ORDER = [
 const DASHBOARD_MODULE_LOADED_AT_MS = performance.now();
 let activeAiSessionAttentionBridgeClient: AttentionBridgeClient | null = null;
 let activeOpenWorkspaceBridgeClient: OpenWorkspaceBridgeClient | null = null;
-
-function resolveAiProviderExecutable(commandName: string): string | null {
-    if (!commandName) {
-        return null;
-    }
-    if (path.isAbsolute(commandName)) {
-        return existsSync(commandName) ? commandName : null;
-    }
-
-    const windows = process.platform === 'win32';
-    const pathValue = process.env.PATH || process.env.Path || '';
-    const extensions = windows
-        ? (process.env.PATHEXT || '.COM;.EXE;.BAT;.CMD').split(';').filter(Boolean)
-        : [''];
-    for (const directory of pathValue.split(path.delimiter).filter(Boolean)) {
-        for (const extension of extensions) {
-            const candidate = path.join(directory, `${commandName}${extension}`);
-            if (existsSync(candidate)) {
-                return candidate;
-            }
-        }
-    }
-    return null;
-}
-
-function runBoundedAiProviderHelp(
-    executable: string,
-    args: readonly string[],
-    options: BoundedChildProcessOptions
-): Promise<BoundedChildProcessResult> {
-    return new Promise(resolve => {
-        childProcess.execFile(executable, [...args], {
-            timeout: options.timeoutMs,
-            maxBuffer: options.maxOutputBytes,
-            encoding: 'utf8',
-            windowsHide: true,
-        }, (error, stdout, stderr) => {
-            const childError = error as unknown as NodeJS.ErrnoException & {
-                code?: string | number;
-                killed?: boolean;
-            };
-            resolve({
-                exitCode: error
-                    ? (typeof childError.code === 'number' ? childError.code : null)
-                    : 0,
-                stdout: typeof stdout === 'string' ? stdout : '',
-                stderr: typeof stderr === 'string' ? stderr : '',
-                timedOut: Boolean(error && childError.killed),
-            });
-        });
-    });
-}
-
-async function getVsCodeGitApiForWorktreeMonitoring(): Promise<GitApiLike | undefined> {
-    const extension = vscode.extensions.getExtension('vscode.git');
-    if (!extension) {
-        return undefined;
-    }
-    const exports = extension.isActive ? extension.exports : await extension.activate();
-    const api = (exports as { getAPI?: (version: number) => unknown } | undefined)
-        ?.getAPI?.(1) as GitApiLike | undefined;
-    return api && Array.isArray(api.repositories)
-        && typeof api.onDidOpenRepository === 'function'
-        && typeof api.onDidCloseRepository === 'function'
-        ? api
-        : undefined;
-}
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
     const monotonicNowMs = () => performance.now();

--- a/src/dashboard/gitApiAcquisition.ts
+++ b/src/dashboard/gitApiAcquisition.ts
@@ -1,0 +1,24 @@
+'use strict';
+
+import * as vscode from 'vscode';
+import type { GitApiLike } from '../worktrees';
+
+/**
+ * Acquires the built-in vscode.git API for worktree monitoring. Lives in the
+ * shell (not the worktree module) because it touches the host extension API;
+ * the worktree module stays loadable without vscode.
+ */
+export async function getVsCodeGitApiForWorktreeMonitoring(): Promise<GitApiLike | undefined> {
+    const extension = vscode.extensions.getExtension('vscode.git');
+    if (!extension) {
+        return undefined;
+    }
+    const exports = extension.isActive ? extension.exports : await extension.activate();
+    const api = (exports as { getAPI?: (version: number) => unknown } | undefined)
+        ?.getAPI?.(1) as GitApiLike | undefined;
+    return api && Array.isArray(api.repositories)
+        && typeof api.onDidOpenRepository === 'function'
+        && typeof api.onDidCloseRepository === 'function'
+        ? api
+        : undefined;
+}

--- a/src/projects/gitRepositoryDetector.ts
+++ b/src/projects/gitRepositoryDetector.ts
@@ -2,6 +2,7 @@
 
 import * as path from 'path';
 import { existsSync, lstatSync } from 'fs';
+import { isUriString } from '../uriStrings';
 
 export default class GitRepositoryDetector {
     private readonly cache = new Map<string, boolean>();
@@ -30,7 +31,7 @@ export default class GitRepositoryDetector {
     }
 
     private getLocalStartDir(projectPath: string): string {
-        if (!projectPath || this.isUriString(projectPath)) {
+        if (!projectPath || isUriString(projectPath)) {
             return null;
         }
 
@@ -58,9 +59,5 @@ export default class GitRepositoryDetector {
         }
 
         return false;
-    }
-
-    private isUriString(projectPath: string): boolean {
-        return projectPath && projectPath.includes("://");
     }
 }

--- a/src/projects/openProjectMatcher.ts
+++ b/src/projects/openProjectMatcher.ts
@@ -1,5 +1,6 @@
 'use strict';
 
+import { isUriString } from '../uriStrings';
 import * as vscode from 'vscode';
 
 import { getRemoteType, getRemoteTypeFromRemoteName, Project, ProjectRemoteType } from '../models';
@@ -123,8 +124,4 @@ export function getProjectPathPart(projectPath: string): string {
 
 export function uriToProjectPath(uri: vscode.Uri): string {
     return uri.scheme === "file" ? uri.fsPath.trim() : uri.toString().trim();
-}
-
-function isUriString(projectPath: string): boolean {
-    return projectPath && projectPath.includes("://");
 }

--- a/src/projects/openProjectService.ts
+++ b/src/projects/openProjectService.ts
@@ -35,9 +35,8 @@ export function getLastPartOfPath(projectPath: string): string {
     return projectPath.replace(/^[\\\/]|[\\\/]$/g, '').replace(/^.*[\\\/]/, '');
 }
 
-export function isUriString(projectPath: string): boolean {
-    return projectPath && projectPath.includes("://");
-}
+import { isUriString } from '../uriStrings';
+export { isUriString };
 
 export function parsePathAsUri(projectPath: string): vscode.Uri {
     return isUriString(projectPath) ? vscode.Uri.parse(projectPath) : vscode.Uri.file(projectPath);

--- a/src/uriStrings.ts
+++ b/src/uriStrings.ts
@@ -1,0 +1,11 @@
+'use strict';
+
+/**
+ * URI-shape predicates (MOD-SHARED-KERNEL): the canonical "is this string a
+ * URI rather than a filesystem path" check. Three local copies drifted across
+ * projects and aiSessions; the single owner lives here at the module-graph
+ * bottom so runtime, projects, and the shell share one encoding.
+ */
+export function isUriString(projectPath: string): boolean {
+    return Boolean(projectPath) && projectPath.includes('://');
+}

--- a/tests/unit/aiSessions/providerExecutable.test.js
+++ b/tests/unit/aiSessions/providerExecutable.test.js
@@ -1,0 +1,54 @@
+'use strict';
+
+// Characterization tests for the provider executable probe helpers that moved
+// from the composition root into the provider directory capability. They pin
+// the current behavior: absolute-path probing, PATH walking with PATHEXT
+// semantics, and bounded child-process execution results.
+
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const test = require('node:test');
+const {
+    resolveAiProviderExecutable,
+    runBoundedAiProviderHelp,
+} = require('../../../out/aiSessions/providerDirectoryCapability');
+
+test('resolveAiProviderExecutable blanks and absolute paths', () => {
+    assert.equal(resolveAiProviderExecutable(''), null);
+    assert.equal(resolveAiProviderExecutable('/definitely/not/here/codex'), null);
+    assert.equal(resolveAiProviderExecutable(process.execPath), process.execPath);
+});
+
+test('resolveAiProviderExecutable finds node on PATH', () => {
+    const found = resolveAiProviderExecutable(process.platform === 'win32' ? 'node.exe' : 'node');
+    assert.ok(found, 'node must resolve via PATH');
+    assert.ok(path.isAbsolute(found));
+});
+
+test('resolveAiProviderExecutable returns null for unknown commands', () => {
+    assert.equal(resolveAiProviderExecutable('definitely-not-a-real-command-xyz'), null);
+});
+
+test('runBoundedAiProviderHelp captures a successful run', async () => {
+    const result = await runBoundedAiProviderHelp(
+        process.execPath, ['-e', 'process.stdout.write("ok")'], { timeoutMs: 5000, maxOutputBytes: 1024 }
+    );
+    assert.equal(result.exitCode, 0);
+    assert.equal(result.stdout, 'ok');
+    assert.equal(result.timedOut, false);
+});
+
+test('runBoundedAiProviderHelp maps spawn failure to a null exit code', async () => {
+    const result = await runBoundedAiProviderHelp(
+        '/definitely/not/here', [], { timeoutMs: 1000, maxOutputBytes: 1024 }
+    );
+    assert.equal(result.exitCode, null);
+    assert.equal(result.timedOut, false);
+});
+
+test('runBoundedAiProviderHelp flags timeouts', async () => {
+    const result = await runBoundedAiProviderHelp(
+        process.execPath, ['-e', 'setTimeout(() => {}, 5000)'], { timeoutMs: 50, maxOutputBytes: 1024 }
+    );
+    assert.equal(result.timedOut, true);
+});

--- a/tests/unit/dashboard/gitApiAcquisition.test.js
+++ b/tests/unit/dashboard/gitApiAcquisition.test.js
@@ -1,0 +1,60 @@
+'use strict';
+
+// Characterization tests for the shell-owned vscode.git API acquisition
+// helper. The fake-vscode Module hook mirrors the other dashboard tests.
+
+const assert = require('node:assert/strict');
+const Module = require('node:module');
+const test = require('node:test');
+
+function loadAcquisition(vscode) {
+    const previousLoad = Module._load;
+    try {
+        Module._load = function (request, parent, isMain) {
+            if (request === 'vscode') return vscode;
+            return previousLoad.call(this, request, parent, isMain);
+        };
+        delete require.cache[require.resolve('../../../out/dashboard/gitApiAcquisition')];
+        return require('../../../out/dashboard/gitApiAcquisition');
+    } finally {
+        Module._load = previousLoad;
+    }
+}
+
+test('getVsCodeGitApiForWorktreeMonitoring returns undefined without the git extension', async () => {
+    const { getVsCodeGitApiForWorktreeMonitoring } = loadAcquisition({
+        extensions: { getExtension: () => undefined },
+    });
+    assert.equal(await getVsCodeGitApiForWorktreeMonitoring(), undefined);
+});
+
+test('getVsCodeGitApiForWorktreeMonitoring activates an inactive extension', async () => {
+    let activations = 0;
+    const api = {
+        repositories: [],
+        onDidOpenRepository: () => ({ dispose() {} }),
+        onDidCloseRepository: () => ({ dispose() {} }),
+    };
+    const { getVsCodeGitApiForWorktreeMonitoring } = loadAcquisition({
+        extensions: {
+            getExtension: () => ({
+                isActive: false,
+                activate: async () => { activations += 1; return { getAPI: () => api }; },
+            }),
+        },
+    });
+    assert.equal(await getVsCodeGitApiForWorktreeMonitoring(), api);
+    assert.equal(activations, 1);
+});
+
+test('getVsCodeGitApiForWorktreeMonitoring rejects a malformed API surface', async () => {
+    const { getVsCodeGitApiForWorktreeMonitoring } = loadAcquisition({
+        extensions: {
+            getExtension: () => ({
+                isActive: true,
+                exports: { getAPI: () => ({ repositories: 'not-an-array' }) },
+            }),
+        },
+    });
+    assert.equal(await getVsCodeGitApiForWorktreeMonitoring(), undefined);
+});


### PR DESCRIPTION
## Summary

Stage 5 final wave, PR A: **MOD-DASHBOARD-SHELL** close-out — and with it the architecture debt ledger hits zero.

Three structural cuts:

1. **`isUriString` converges into the kernel** (`src/uriStrings.ts`). Three drifting copies (openProjectService's export, openProjectMatcher's local, gitRepositoryDetector's private method) collapse into one owner. The `RUNTIME → PROJECT-CATALOG` edge dies with it, **dissolving the last SCC cluster**. Cycle baseline: 0 fingerprints. Waiver ledger: empty (ARCH-WAIVER-004 retired).
2. **Provider executable probing moves to its owning capability**: `resolveAiProviderExecutable` + `runBoundedAiProviderHelp` leave `dashboard.ts` for `providerDirectoryCapability.ts`, which already defined their adapter interface.
3. **The vscode.git API acquisition moves to `src/dashboard/gitApiAcquisition.ts`** — deliberately shell-internal: the worktree module must stay loadable without the vscode runtime (its unit tests load it bare), so host-API acquisition belongs to the shell. (First attempt put it in the worktree module; the bare-loader suites caught it immediately.)

`dashboard.ts` sheds its three top-level business helpers (3993 → 3927 lines). Shell entrypoints narrow to the composition root plus the five consumed type surfaces; `sponsor.ts` becomes module-internal. Ledger flips MOD-DASHBOARD-SHELL to strict — **all 16 modules are now strict**.

Not in this PR (per the agreed staging): the `initializeDashboard` decomposition (~3.4k-line orchestration function) and the webview-globals reduction are follow-up slices, separately planned.

## Skill harvest

none — but one in-PR lesson is encoded in the fix itself: host-API acquisition may not live in the worktree module (bare-loader tests enforce it).

## Owner approvals

Copy the line below into a PR comment (binds the exact head SHA and expires when the head moves):

```
approve f2ea87b63b6ef980b1926741c07eb0c85e9e9234
```

## Verification

- `npm run test-compile` — pass
- `node --test tests/unit/**` 1172 / `tests/contract/**` 1182 / `tests/browser/**` 322 — all pass
- `npm run test:architecture-policy` / `test:architecture-guards` / `test:safety:run` / `run-dashboard-webview-checks.js` — pass
- `npm run test:behavior-contracts` / `lint:ci` / `test:release-packaging` — pass (new files are not in the shipped `out/` closure)
- changed-line coverage 100% (96/96) — the extracted helpers gained direct characterization tests after the first CI round flagged them
- `git diff --check` — clean
