### PR TITLE
refactor(dashboard): extract the composition sections (B1)

### DIFF
--- a/scripts/lib/compositionSources.js
+++ b/scripts/lib/compositionSources.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+/**
+ * The composition root's source surface: src/dashboard.ts plus every
+ * composition section extracted under src/dashboard/sections/. Content
+ * anchors that pin the composition (constructor wiring, callback shape) must
+ * read this combined text so section extractions stay refactorable.
+ */
+function readCompositionSource(root) {
+    const dashboardPath = path.join(root, 'src', 'dashboard.ts');
+    const sectionsDirectory = path.join(root, 'src', 'dashboard', 'sections');
+    const sources = [fs.readFileSync(dashboardPath, 'utf8')];
+    if (fs.existsSync(sectionsDirectory)) {
+        for (const entry of fs.readdirSync(sectionsDirectory).sort()) {
+            if (entry.endsWith('.ts')) {
+                sources.push(fs.readFileSync(path.join(sectionsDirectory, entry), 'utf8'));
+            }
+        }
+    }
+    return sources.join('\n');
+}
+
+module.exports = { readCompositionSource };

--- a/scripts/run-ai-session-safety-checks.js
+++ b/scripts/run-ai-session-safety-checks.js
@@ -4977,7 +4977,7 @@ function runWebviewContentChecks() {
     const sessionReducedMotionStyles = extractExactScssBlock(styles, '@media (prefers-reduced-motion: reduce)');
     assert.ok(sessionReducedMotionStyles.includes('.codex-sessions'));
     assert.ok(sessionReducedMotionStyles.includes('transition: none !important'));
-    const dashboard = fs.readFileSync(path.join(__dirname, '..', 'src', 'dashboard.ts'), 'utf8');
+    const dashboard = require('./lib/compositionSources').readCompositionSource(path.join(__dirname, '..'));
     const presentationMessageSource = fs.readFileSync(
         path.join(__dirname, '..', 'src', 'aiSessions', 'presentationMessage.ts'),
         'utf8'
@@ -7385,7 +7385,7 @@ function runBatchAiSessionWebviewChecks() {
 
 function runAiSessionIncrementalRefreshSourceChecks() {
     const root = path.join(__dirname, '..');
-    const dashboard = fs.readFileSync(path.join(root, 'src', 'dashboard.ts'), 'utf8');
+    const dashboard = require('./lib/compositionSources').readCompositionSource(root);
     const readCoordinatorSource = fs.readFileSync(
         path.join(root, 'src', 'aiSessions', 'readCoordinator.ts'), 'utf8'
     );

--- a/scripts/run-ai-session-tmux-checks.js
+++ b/scripts/run-ai-session-tmux-checks.js
@@ -9661,7 +9661,7 @@ async function runRuntimeControllerChecks() {
 }
 
 function runHostRuntimeCompositionChecks() {
-    const dashboardSource = fs.readFileSync(path.join(__dirname, '..', 'src', 'dashboard.ts'), 'utf8');
+    const dashboardSource = require('./lib/compositionSources').readCompositionSource(path.join(__dirname, '..'));
     const compositionSource = fs.readFileSync(
         path.join(__dirname, '..', 'src', 'aiSessions', 'sessionControllerComposition.ts'), 'utf8'
     );

--- a/scripts/run-architecture-guards.js
+++ b/scripts/run-architecture-guards.js
@@ -658,15 +658,13 @@ const guards = {
         }
 
         const conversationSectionPath = 'src/dashboard/sections/conversationStack.ts';
+        const runtimeSectionPath = 'src/dashboard/sections/runtimeStack.ts';
         const dashboardSource = dashboard.getFullText()
-            + (fs.existsSync(path.join(root, conversationSectionPath))
-                ? '\n' + parseTypescript(
-                    root,
-                    conversationSectionPath,
-                    this.id,
-                    risk
-                ).getFullText()
-                : '');
+            + [conversationSectionPath, runtimeSectionPath]
+                .filter(sectionPath => fs.existsSync(path.join(root, sectionPath)))
+                .map(sectionPath => parseTypescript(root, sectionPath, this.id, risk).getFullText())
+                .map(text => '\n' + text)
+                .join('');
         if ((dashboardSource.match(/new CurrentWorkspaceSessionAuthority\s*\(/g) || []).length !== 1
             || (dashboardSource.match(
                 /currentWorkspaceSessionAuthority\.getProjectId\s*\(/g

--- a/scripts/run-architecture-guards.js
+++ b/scripts/run-architecture-guards.js
@@ -657,7 +657,16 @@ const guards = {
                 'the current card must consume the shared navigation-scoped authority exactly once');
         }
 
-        const dashboardSource = dashboard.getFullText();
+        const conversationSectionPath = 'src/dashboard/sections/conversationStack.ts';
+        const dashboardSource = dashboard.getFullText()
+            + (fs.existsSync(path.join(root, conversationSectionPath))
+                ? '\n' + parseTypescript(
+                    root,
+                    conversationSectionPath,
+                    this.id,
+                    risk
+                ).getFullText()
+                : '');
         if ((dashboardSource.match(/new CurrentWorkspaceSessionAuthority\s*\(/g) || []).length !== 1
             || (dashboardSource.match(
                 /currentWorkspaceSessionAuthority\.getProjectId\s*\(/g

--- a/scripts/run-dashboard-webview-checks.js
+++ b/scripts/run-dashboard-webview-checks.js
@@ -4733,8 +4733,9 @@ function runSourceContractChecks(source) {
     assert.ok(todoPanelCapabilitySource.includes('getMaxVisibleTodosPerGroup('));
     assert.ok(extensionHostSource.includes("from './todos/todoPanelCapability'"),
         'dashboard must import the extracted TODO panel capability');
-    assert.ok(extensionHostSource.includes('createTodoPanelCapability({'),
-        'dashboard must construct the extracted TODO panel capability');
+    const panelStackSource = fs.readFileSync(path.join(root, 'src', 'dashboard', 'sections', 'panelStack.ts'), 'utf8');
+    assert.ok(panelStackSource.includes('createTodoPanelCapability({'),
+        'the panel section must construct the extracted TODO panel capability');
     assert.ok(extensionHostSource.includes('...todoPanel.handlers,'),
         'dashboard must spread the TODO panel handlers into the message router');
     assert.ok(extensionHostSource.includes('todoPanel.setStorageMigrationReady('),

--- a/scripts/run-open-project-safety-checks.js
+++ b/scripts/run-open-project-safety-checks.js
@@ -3260,9 +3260,12 @@ function runDashboardBridgeLifecycleChecks() {
     assert.ok(!dashboard.includes('async function queryProjectPath('));
     assert.ok(!dashboard.includes('async function queryProjectColor('));
     assert.ok(!dashboard.includes("import { createOpenProjectRecords } from './openProjects/projection';"));
-    assert.ok(dashboard.includes('const projectManualEditController = new ProjectManualEditController({'));
-    assert.ok(dashboard.includes('const projectMutationController = new ProjectMutationController({'));
-    assert.ok(dashboard.includes('const projectPromptController = new ProjectPromptController({'));
+    const projectControllersSection = fs.readFileSync(
+        path.join(__dirname, '..', 'src', 'dashboard', 'sections', 'projectControllers.ts'), 'utf8'
+    );
+    assert.ok(projectControllersSection.includes('const projectManualEditController = new ProjectManualEditController({'));
+    assert.ok(projectControllersSection.includes('const projectMutationController = new ProjectMutationController({'));
+    assert.ok(projectControllersSection.includes('const projectPromptController = new ProjectPromptController({'));
     assert.ok(dashboard.includes('new DashboardCommandRegistration<vscode.Disposable>({'));
     assert.ok(dashboard.includes(
         'openWorkspaceDashboardController = new OpenWorkspaceDashboardController<vscode.Terminal>({'
@@ -3361,15 +3364,15 @@ function runDashboardBridgeLifecycleChecks() {
     assert.ok(dashboard.includes(
         'removeGroup: () => runAfterStorageMigration(() => groupCommandController.removeGroupPerCommand())'
     ));
-    assert.ok(dashboard.includes(
-        'postCommandRemoval: () => { void dashboardRuntimeController.revealAgentPivotDashboard(); },'
+    assert.ok(projectControllersSection.includes(
+        'postCommandRemoval: () => { deps.revealDashboard(); },'
     ), 'command-driven removal must focus the sidebar without forcing a complete Webview refresh');
-    const manualEditWiring = dashboard.slice(
-        dashboard.indexOf('const projectManualEditController = new ProjectManualEditController({'),
-        dashboard.indexOf('const addProjectsFromFolderController = new AddProjectsFromFolderController({')
+    const manualEditWiring = projectControllersSection.slice(
+        projectControllersSection.indexOf('const projectManualEditController = new ProjectManualEditController({'),
+        projectControllersSection.indexOf('const addProjectsFromFolderController = new AddProjectsFromFolderController({')
     );
     assert.ok(manualEditWiring.includes('refreshAfterMutation();'));
-    assert.ok(manualEditWiring.includes('dashboardRuntimeController.revealAgentPivotDashboard();'));
+    assert.ok(manualEditWiring.includes('deps.revealDashboard();'));
     assert.strictEqual(manualEditWiring.includes('showAgentPivot()'), false,
         'manual project saves must use the partial Projects surface before focusing the sidebar');
     assert.ok(projectMutationControllerSource.includes('this.options.prompt.queryProjectFields('));
@@ -3393,8 +3396,8 @@ function runDashboardBridgeLifecycleChecks() {
         'saved project metadata mutations must republish even when configuration storage is disabled');
     assert.ok(dashboard.includes('publishOpenWorkspace: () => openWorkspaceController.publish()'),
         'the dashboard wires the workspace publication into the extracted project surface refresh');
-    assert.ok(dashboard.includes('createProjectSurfaceRefresh({'),
-        'the dashboard constructs the extracted project surface refresh');
+    assert.ok(projectControllersSection.includes('createProjectSurfaceRefresh({'),
+        'the project controllers section constructs the extracted project surface refresh');
     assert.ok(dashboard.includes('createProjectMessageHandlers({'),
         'the dashboard constructs the extracted project message handlers');
     assert.strictEqual(

--- a/scripts/run-performance-architecture-baseline-checks.js
+++ b/scripts/run-performance-architecture-baseline-checks.js
@@ -89,7 +89,7 @@ for (const relativePath of productionSources.filter(relativePath =>
     );
 }
 
-const dashboard = read('src/dashboard.ts');
+const dashboard = require('./lib/compositionSources').readCompositionSource(root);
 const viewProvider = read('src/dashboard/viewProvider.ts');
 const aiSessionController = read('src/aiSessions/dashboardController.ts');
 const terminalService = read('src/aiSessions/terminalService.ts');

--- a/scripts/run-skill-management-checks.js
+++ b/scripts/run-skill-management-checks.js
@@ -608,8 +608,11 @@ function runSkillWiringChecks() {
         path.join(__dirname, '..', 'src', 'skills', 'skillPanelCapability.ts'), 'utf8'
     );
     assert.ok(skillPanel.includes('new SkillDashboardController('));
-    assert.ok(dashboard.includes('createSkillPanelCapability({'),
-        'the dashboard constructs the extracted skill panel capability');
+    const panelStack = fs.readFileSync(
+        path.join(__dirname, '..', 'src', 'dashboard', 'sections', 'panelStack.ts'), 'utf8'
+    );
+    assert.ok(panelStack.includes('createSkillPanelCapability({'),
+        'the panel section constructs the extracted skill panel capability');
     assert.ok(dashboard.includes('...skillPanel.handlers,'),
         'the dashboard spreads the extracted skill handlers into the message router');
     assert.ok(skillPanel.includes("'delete-skill'"));

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -30,6 +30,7 @@ import { createPanelStack } from './dashboard/sections/panelStack';
 import { createProjectControllers } from './dashboard/sections/projectControllers';
 import { createAiSessionStack } from './dashboard/sections/aiSessionStack';
 import { createConversationStack } from './dashboard/sections/conversationStack';
+import { createRuntimeStack } from './dashboard/sections/runtimeStack';
 import { PromptTerminalCommandController } from './prompts/terminalCommandController';
 import CodexSessionService from './services/codexSessionService';
 import { ProcCodexRootThreadObserver } from './aiSessions/codexRootThreadObserver';
@@ -717,26 +718,27 @@ async function initializeDashboard(
     let freezeConversationSessionMetadata = (
         _target: { projectId: string; provider: AiSessionProviderId; sessionId: string }
     ): Promise<boolean> => Promise.resolve(false);
-    const aiSessionTerminalBindingStore = new AiSessionTerminalBindingStore(context.workspaceState, error =>
-        logError('Failed to persist AI session terminal ownership.', error)
-    );
-    const aiSessionTerminalService = new AiSessionTerminalService(
-        context.globalStoragePath,
+    const {
+        aiSessionTerminalBindingStore,
+        aiSessionTerminalService,
+        aiSessionRuntimeConfiguration: initialAiSessionRuntimeConfiguration,
+        tmuxRuntimeStore,
+        tmuxAttachBindingStore,
+        tmuxClient,
+        tmuxRuntimeDiscovery,
+    } = createRuntimeStack({
+        context,
+        logError,
+        logAiSessionRuntimeFailure,
         aiSessionProviders,
-        undefined,
-        undefined,
-        aiSessionTerminalBindingStore
-    );
-    let aiSessionRuntimeConfiguration = readAiSessionRuntimeConfiguration(getAgentPivotConfiguration());
-    const tmuxRuntimeStore = new TmuxRuntimeBindingStore(
-        path.join(context.globalStoragePath, 'ai-session-tmux-runtimes'),
-        () => Date.now(),
-        operation => withTmuxCreationLock(
-            context.globalStoragePath,
-            'runtime-binding-final-records',
-            operation
-        )
-    );
+        aiSessionAliasController,
+        aiSessionProfileController,
+        currentWorkspaceSessionAuthority,
+        getConversationSessionRebindCoordinator: () => conversationSessionRebindCoordinator,
+        getFollowConversationSessionRebind: () => followConversationSessionRebind,
+        getFreezeConversationSessionMetadata: () => freezeConversationSessionMetadata,
+    });
+    let aiSessionRuntimeConfiguration = initialAiSessionRuntimeConfiguration;
     const {
         conversationCommentStore,
         projectCommentStore,
@@ -751,94 +753,6 @@ async function initializeDashboard(
         logAiSessionRuntimeFailure,
         tmuxRuntimeStore,
         currentWorkspaceSessionAuthority,
-    });
-    const tmuxAttachBindingStore = new TmuxAttachBindingStore(context.workspaceState, error => {
-        logAiSessionRuntimeFailure('persist-attach-binding', error);
-    });
-    const tmuxClient = new TmuxClient(aiSessionRuntimeConfiguration.tmuxPath);
-    const tmuxRuntimeDiscovery = new TmuxRuntimeDiscovery({
-        client: tmuxClient,
-        bindingStore: tmuxRuntimeStore,
-        codexRootThreadObserver: new ProcCodexRootThreadObserver(),
-        onSessionRebinding: async (previous, next) => {
-            const projectId = currentWorkspaceSessionAuthority.getProjectId(
-                previous
-            );
-            if (!projectId || !previous.sessionId || !next.sessionId
-                || previous.provider !== next.provider
-                || previous.workspaceNavigationIdentity
-                    !== next.workspaceNavigationIdentity) {
-                throw new Error('Invalid conversation Session rebind identity.');
-            }
-            await conversationSessionRebindCoordinator.prepare({
-                projectId,
-                provider: previous.provider,
-                sessionId: previous.sessionId,
-            }, {
-                projectId,
-                provider: next.provider,
-                sessionId: next.sessionId,
-            });
-        },
-        onSessionRebound: async (previous, next) => {
-            aiSessionAliasController.copyForRebind(
-                previous.provider,
-                previous.sessionId || '',
-                next.sessionId || ''
-            );
-            aiSessionProfileController.copyForRebind(
-                previous.provider,
-                previous.sessionId || '',
-                next.sessionId || ''
-            );
-            const projectId = currentWorkspaceSessionAuthority.getProjectId(
-                previous
-            );
-            if (!projectId || !previous.sessionId || !next.sessionId
-                || previous.provider !== next.provider
-                || previous.workspaceNavigationIdentity
-                    !== next.workspaceNavigationIdentity) {
-                return;
-            }
-            const previousTarget = {
-                projectId,
-                provider: previous.provider,
-                sessionId: previous.sessionId,
-            };
-            const nextTarget = {
-                projectId,
-                provider: next.provider,
-                sessionId: next.sessionId,
-            };
-            await freezeConversationSessionMetadata(previousTarget);
-            try {
-                await conversationSessionRebindCoordinator.commit(
-                    previousTarget,
-                    nextTarget
-                );
-            } catch (error) {
-                logAiSessionRuntimeFailure(
-                    'migrate-conversation-session-rebind',
-                    error
-                );
-            }
-            if (conversationSessionRebindCoordinator.resolve(previousTarget)
-                .sessionId !== nextTarget.sessionId) {
-                return;
-            }
-            try {
-                await followConversationSessionRebind(
-                    previousTarget,
-                    nextTarget
-                );
-            } catch (error) {
-                logAiSessionRuntimeFailure(
-                    'follow-conversation-session-rebind',
-                    error
-                );
-            }
-        },
-        markerIsCurrent: isCurrentRuntimeMarker,
     });
     const persistedInactiveRestoreTask = (async (): Promise<void> => {
         try {

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -27,6 +27,7 @@ import { createProjectServices } from './dashboard/sections/projectServices';
 import { createTodoPanelCapability } from './todos/todoPanelCapability';
 import { initializePromptMementoStore } from './prompts/service';
 import { createPanelStack } from './dashboard/sections/panelStack';
+import { createProjectControllers } from './dashboard/sections/projectControllers';
 import { PromptTerminalCommandController } from './prompts/terminalCommandController';
 import CodexSessionService from './services/codexSessionService';
 import { ProcCodexRootThreadObserver } from './aiSessions/codexRootThreadObserver';
@@ -642,133 +643,38 @@ async function initializeDashboard(
         promptStore,
         getOpenWorkspaceCards,
     });
-    const projectSurface = createProjectSurfaceRefresh({
+    const {
+        projectSurface,
+        groupCollapseController,
+        groupCommandController,
+        projectOpenController,
+        projectPromptController,
+        projectMutationController,
+        favoriteProjectController,
+        projectOrderController,
+        projectRemovalController,
+        projectManualEditController,
+        addProjectsFromFolderController,
+        remoteProjectResolver,
+        currentProjectDetailsResolver,
+    } = createProjectControllers({
+        context,
+        logError,
+        colorService,
+        projectService,
+        fileService,
+        gitRepositoryDetector,
+        getStewardInfos: () => stewardInfos,
         getProjectsPanelController: () => projectsPanelController,
         getOpenWorkspaceDashboardController: () => openWorkspaceDashboardController,
         publishOpenWorkspace: () => openWorkspaceController.publish(),
-        syncProjectColorToCurrentWindow: project =>
+        applyProjectColorToCurrentWindow: project =>
             dashboardRuntimeController.applyProjectColorToCurrentWindow(project),
-    });
-    const groupCollapseController = new GroupCollapseController({
-        state: context.globalState,
-        projectService,
-    });
-    const groupCommandController = new GroupCommandController({
-        projectService,
-        promptGroupName: defaultText => queryGroupName(vscode.window, defaultText),
-        promptGroupToRemove: () => projectPromptController.queryGroup(),
-        confirmRemoveGroup: groupName => vscode.window.showWarningMessage(`Remove ${groupName}?`, { modal: true }, 'Remove'),
-        showErrorMessage: message => vscode.window.showErrorMessage(message),
-        refreshAfterMutation: projectSurface.refreshAfterMutation,
-        userCanceledToken: USER_CANCELED,
-    });
-    const projectOpenController = new ProjectOpenController({
-        getWorkspaceFile: () => vscode.workspace.workspaceFile,
-        getWorkspaceFolders: () => vscode.workspace.workspaceFolders,
-        getPrependVscodeUrlToWslRemotes: () => stewardInfos.config.prependVscodeUrlToWslRemotes,
-        getProjectPathType: projectPath => fileService.getProjectPathType(projectPath),
-        getFoldersFromWorkspaceFile: workspaceFilePath => fileService.getFoldersFromWorkspaceFile(workspaceFilePath),
-        showWarningMessage: message => vscode.window.showWarningMessage(message),
-        showInformationMessage: message => vscode.window.showInformationMessage(message),
-        showErrorMessage: message => vscode.window.showErrorMessage(message),
-        executeCommand: (command, ...args) => vscode.commands.executeCommand(command, ...args),
-        updateWorkspaceFolders: (start, deleteCount, ...workspaceFoldersToAdd) => vscode.workspace.updateWorkspaceFolders(start, deleteCount, ...workspaceFoldersToAdd),
-        updateReopenReason: reason => context.globalState.update(REOPEN_KEY, reason),
-        fileUri: projectPath => vscode.Uri.file(projectPath),
-        parseUri: projectPath => vscode.Uri.parse(projectPath),
-    });
-    const projectPromptController = new ProjectPromptController({
-        getGroups: () => projectService.getGroups(),
-        addGroup: name => projectService.addGroup(name),
-        removeGroup: (groupId, skipConfirmation) => projectService.removeGroup(groupId, skipConfirmation),
-        isFile: projectPath => fileService.isFile(projectPath),
-        isFolderGitRepo: projectPath => isFolderGitRepo(projectPath),
-        getRandomColor: () => colorService.getRandomColor(),
-        getColorName: colorCode => colorService.getColorName(colorCode),
-        getRecentColors: () => colorService.getRecentColors(),
-        getRemoteSshExtensionInstalled: () => stewardInfos.relevantExtensionsInstalls.remoteSSH,
-        showInputBox: options => vscode.window.showInputBox(options),
-        showQuickPick: (items, options) => vscode.window.showQuickPick(items, options),
-        showOpenDialog: options => vscode.window.showOpenDialog(options),
-    });
-    const projectMutationController = new ProjectMutationController({
-        getCurrentWorkspacePath: () => resolveWorkspacePath(vscode.workspace.workspaceFile, vscode.workspace.workspaceFolders),
-        getCurrentProjectDetailsForSave: () => currentProjectDetailsResolver.getCurrentProjectDetailsForSave(),
-        getProjectDetailsForSave: uri => currentProjectDetailsResolver.getProjectDetailsForSave(uri),
-        getProjectsFlat: () => projectService.getProjectsFlat(),
-        getProjectAndGroup: projectId => projectService.getProjectAndGroup(projectId),
-        addProjectToGroup: (project, groupId) => projectService.addProject(project, groupId),
-        updateProject: (projectId, project) => projectService.updateProject(projectId, project),
-        removeGroup: (groupId, skipConfirmation) => projectService.removeGroup(groupId, skipConfirmation),
-        getRandomColor: () => colorService.getRandomColor(),
-        isFolderGitRepo,
-        prompt: projectPromptController,
-        showInputBox: options => vscode.window.showInputBox(options),
-        showWarningMessage: message => vscode.window.showWarningMessage(message),
-        showInformationMessage: message => vscode.window.showInformationMessage(message),
-        showErrorMessage: message => vscode.window.showErrorMessage(message),
-        refreshAfterMutation: projectSurface.refreshAfterMutation,
-    });
-    const favoriteProjectController = new FavoriteProjectController({
-        getGroups: () => projectService.getGroups(),
-        saveGroups: groups => projectService.saveGroups(groups),
-        refreshAfterMutation: projectSurface.refreshAfterMutation,
-    });
-    const projectOrderController = new ProjectOrderController({
-        getGroups: () => projectService.getGroups(),
-        saveGroups: groups => projectService.saveGroups(groups),
-        showInformationMessage: message => vscode.window.showInformationMessage(message),
-        refreshAfterMutation: projectSurface.refreshAfterMutation,
-    });
-    const projectRemovalController = new ProjectRemovalController({
-        getProject: projectId => projectService.getProject(projectId),
-        getProjectsFlat: () => projectService.getProjectsFlat(),
-        showProjectPicker: projectPicks => vscode.window.showQuickPick(projectPicks),
-        confirmRemoveProject: projectName => vscode.window.showWarningMessage(`Remove ${projectName}?`, { modal: true }, 'Remove'),
-        removeProject: projectId => projectService.removeProject(projectId),
-        refreshAfterMutation: projectSurface.refreshAfterMutation,
-        postCommandRemoval: () => { void dashboardRuntimeController.revealAgentPivotDashboard(); },
-    });
-    const projectManualEditController = new ProjectManualEditController({
-        getGroups: () => projectService.getGroups(),
-        getTempFilePath: () => `${context.globalStoragePath}/Agent Pivot Projects.json`,
-        writeTextFile: (filePath, content) => fileService.writeTextFile(filePath, content),
-        fileUri: filePath => vscode.Uri.file(filePath),
-        openTextDocument: uri => vscode.workspace.openTextDocument(uri),
-        showTextDocument: document => vscode.window.showTextDocument(document),
-        onWillSaveTextDocument: listener => vscode.workspace.onWillSaveTextDocument(listener),
-        saveGroups: (groups, baselineGroups) =>
-            projectService.saveGroupsFromManualEdit(groups, baselineGroups),
-        executeCommand: command => vscode.commands.executeCommand(command),
-        showErrorMessage: message => vscode.window.showErrorMessage(message),
-        postSave: () => {
-            projectSurface.refreshAfterMutation();
-            void dashboardRuntimeController.revealAgentPivotDashboard();
-        },
-    });
-    const addProjectsFromFolderController = new AddProjectsFromFolderController({
-        getCurrentWorkspacePath: () => resolveWorkspacePath(vscode.workspace.workspaceFile, vscode.workspace.workspaceFolders),
-        parsePathAsUri,
-        showOpenDialog: options => vscode.window.showOpenDialog(options),
-        getFolders: folderPath => fileService.getFolders(folderPath),
-        addGroup: groupName => projectService.addGroup(groupName),
-        addProject: (project, groupId) => projectService.addProject(project, groupId),
-        getRandomColor: () => colorService.getRandomColor(),
-        isFolderGitRepo,
-        showErrorMessage: message => vscode.window.showErrorMessage(message),
-        refreshAfterMutation: projectSurface.refreshAfterMutation,
-        userCanceledToken: USER_CANCELED,
+        revealDashboard: () => { void dashboardRuntimeController.revealAgentPivotDashboard(); },
     });
     const codexSessionService = new CodexSessionService();
     const kimiSessionService = new KimiSessionService();
     const claudeSessionService = new ClaudeSessionService();
-    const remoteProjectResolver = new RemoteProjectResolver(logError);
-    const currentProjectDetailsResolver = new CurrentProjectDetailsResolver({
-        getWorkspaceFile: () => vscode.workspace.workspaceFile,
-        getWorkspaceFolders: () => vscode.workspace.workspaceFolders,
-        getRemoteName: () => vscode.env.remoteName,
-        getProjectDetailsForSave: (workspaceUri, remoteName) => remoteProjectResolver.getProjectDetailsForSave(workspaceUri, remoteName),
-    });
     const aiSessionServices: Record<AiSessionProviderId, AiSessionService> = {
         codex: codexSessionService,
         kimi: kimiSessionService,

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -13,7 +13,6 @@ import {
     getEffectiveRunningCardAnimation,
     getEffectiveRunningIconAnimation,
 } from './webview/runningAnimationImages';
-import { getSkillsPanelContent } from './skills/webviewSkillContent';
 import {
     AGENT_PIVOT_CONFIG_SECTION,
     AGENT_PIVOT_CONVERSATION_VIEW_TYPE,
@@ -25,14 +24,10 @@ import {
 } from './constants';
 
 import { createProjectServices } from './dashboard/sections/projectServices';
-import { TodoService } from './todos/service';
 import { createTodoPanelCapability } from './todos/todoPanelCapability';
-import { PromptDashboardController } from './prompts/dashboardController';
-import { initializePromptMementoStore, PromptService } from './prompts/service';
+import { initializePromptMementoStore } from './prompts/service';
+import { createPanelStack } from './dashboard/sections/panelStack';
 import { PromptTerminalCommandController } from './prompts/terminalCommandController';
-import { getAiPanelContent, getPromptSurfaceContent } from './prompts/webviewContent';
-import { createSkillPanelCapability } from './skills/skillPanelCapability';
-import { SkillGroupStore } from './skills/skillGroupStore';
 import CodexSessionService from './services/codexSessionService';
 import { ProcCodexRootThreadObserver } from './aiSessions/codexRootThreadObserver';
 import KimiSessionService from './services/kimiSessionService';
@@ -622,7 +617,6 @@ async function initializeDashboard(
         fileService,
         gitRepositoryDetector,
     } = createProjectServices({ context, logDashboardDiagnostic });
-    const todoService = new TodoService(context);
     const promptConfiguration = getAgentPivotConfiguration();
     const promptStore = await initializePromptMementoStore({
         globalState: context.globalState,
@@ -630,84 +624,24 @@ async function initializeDashboard(
             promptConfiguration.inspect<unknown>('promptData')?.globalValue,
     });
     resources.assertActive();
-    const promptService = new PromptService({
-        readSetting: promptStore.readSetting,
-        writeGlobalSetting: promptStore.writeGlobalSetting,
-        createId: () => randomBytes(16).toString('hex'),
-        logDiagnostic: event => logDashboardDiagnostic({ event: 'prompt-store', ...event }),
-    });
-    const getWorkspaceRootPaths = (): string[] =>
-        (vscode.workspace.workspaceFolders || []).map(folder => folder.uri.fsPath);
-    const promptDashboardController = new PromptDashboardController({
-        service: promptService,
-        confirmDelete: async prompt => {
-            const choice = await vscode.window.showWarningMessage(
-                `Delete Prompt "${prompt.name}"?`,
-                { modal: true },
-                'Delete'
-            );
-            return choice === 'Delete';
-        },
-        renderPromptSurface: getPromptSurfaceContent,
-        renderAiPanel: snapshot => getAiPanelContent(
-            snapshot,
-            getSkillsPanelContent(
-                skillPanel.getRecords(),
-                skillPanel.getPanelView(),
-            ),
-        ),
-    });
-    const skillPanel = ownResource(() => createSkillPanelCapability({
-        getHomeDir: () => os.homedir(),
-        getWorkspaceRoot: () => vscode.workspace.workspaceFolders?.[0]?.uri.fsPath,
-        getWorkspaceRoots: getWorkspaceRootPaths,
-        hasWorkspace: () => Boolean(vscode.workspace.workspaceFolders?.length),
-        groupStore: new SkillGroupStore(context.globalState),
-        readGlobalStorePath: () => getAgentPivotConfiguration().get<string>(
-            'skills.globalStorePath',
-            '~/.skills',
-        ),
-        writeGlobalStorePath: value => getAgentPivotConfiguration().update(
-            'skills.globalStorePath',
-            value,
-            vscode.ConfigurationTarget.Global,
-        ),
-        postMessage: message => provider.postMessage(message),
-        refreshDashboard: () => provider.refresh(),
-        isVisible: () => provider.visible,
-        showInputBox: options => vscode.window.showInputBox(options),
-        showQuickPickMany: <T extends vscode.QuickPickItem>(
-            items: readonly T[],
-            quickPickOptions: vscode.QuickPickOptions
-        ) => vscode.window.showQuickPick(
-            [...items],
-            { ...quickPickOptions, canPickMany: true } as vscode.QuickPickOptions & { canPickMany: true }
-        ),
-        showWarningMessage: (message, messageOptions, ...items) => messageOptions
-            ? vscode.window.showWarningMessage(message, messageOptions, ...items)
-            : vscode.window.showWarningMessage(message),
-        showInformationMessage: message => vscode.window.showInformationMessage(message),
-        showErrorMessage: message => vscode.window.showErrorMessage(message),
-        openTextFile: fsPath => vscode.window.showTextDocument(vscode.Uri.file(fsPath)),
-        logError,
-    }));
-    timeBootstrapPhase('skill-scan', () => skillPanel.start());
-    const todoPanel = ownResource(() => createTodoPanelCapability({
-        provider,
+    const {
         todoService,
-        getSearchCatalog: () => buildWorkspaceDashboardSearchCatalog(
-            projectService.getGroups(),
-            getOpenWorkspaceCards(),
-            todoService.getSearchItems(),
-            skillPanel.getRecords(),
-        ),
-        getConfiguration: () => getAgentPivotConfiguration(),
-        showInputBox: options => vscode.window.showInputBox(options),
-        showWarningMessage: (message, messageOptions, ...items) =>
-            vscode.window.showWarningMessage(message, messageOptions, ...items),
-        showErrorMessage: message => vscode.window.showErrorMessage(message),
+        promptService,
+        promptDashboardController,
+        skillPanel,
+        todoPanel,
+    } = createPanelStack({
+        context,
+        provider,
+        resources,
+        ownResource,
+        timeBootstrapPhase,
         logError,
-    }));
+        logDashboardDiagnostic,
+        projectService,
+        promptStore,
+        getOpenWorkspaceCards,
+    });
     const projectSurface = createProjectSurfaceRefresh({
         getProjectsPanelController: () => projectsPanelController,
         getOpenWorkspaceDashboardController: () => openWorkspaceDashboardController,

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -29,6 +29,7 @@ import { initializePromptMementoStore } from './prompts/service';
 import { createPanelStack } from './dashboard/sections/panelStack';
 import { createProjectControllers } from './dashboard/sections/projectControllers';
 import { createAiSessionStack } from './dashboard/sections/aiSessionStack';
+import { createConversationStack } from './dashboard/sections/conversationStack';
 import { PromptTerminalCommandController } from './prompts/terminalCommandController';
 import CodexSessionService from './services/codexSessionService';
 import { ProcCodexRootThreadObserver } from './aiSessions/codexRootThreadObserver';
@@ -687,9 +688,6 @@ async function initializeDashboard(
         aiSessionProfileController,
         codexProfileSupportProbe,
     } = createAiSessionStack({ context, logError, logAiSessionDiagnostic });
-    const conversationCommentStore = new ConversationCommentFileStore(
-        context.globalStoragePath
-    );
     const workspaceContextResolver = new WorkspaceContextResolver();
     const currentWorkspaceSessionAuthority =
         new CurrentWorkspaceSessionAuthority(
@@ -712,12 +710,6 @@ async function initializeDashboard(
             workspaceScopeIdentity: activationWorkspace.scopeIdentity,
         });
     }
-    const projectCommentStore = new ProjectCommentFileStore(
-        context.globalStoragePath
-    );
-    const conversationBookmarkStore = new ConversationBookmarkFileStore(
-        context.globalStoragePath
-    );
     let followConversationSessionRebind = (
         _previous: { projectId: string; provider: AiSessionProviderId; sessionId: string },
         _next: { projectId: string; provider: AiSessionProviderId; sessionId: string }
@@ -745,69 +737,21 @@ async function initializeDashboard(
             operation
         )
     );
-    const conversationSessionRebindCoordinator =
-        new ConversationSessionRebindCoordinator({
-            globalStoragePath: context.globalStoragePath,
-            commentStore: conversationCommentStore,
-            bookmarkStore: conversationBookmarkStore,
-            isRuntimeRebindCommitted: async (previous, next) =>
-                hasCommittedConversationSessionRuntimeRebind(
-                    (await tmuxRuntimeStore.listKnown()).map(binding => ({
-                        provider: binding.provider,
-                        sessionId: binding.sessionId,
-                        projectId: currentWorkspaceSessionAuthority.getProjectId({
-                            workspaceScopeIdentity:
-                                binding.workspaceScopeIdentity,
-                            workspaceNavigationIdentity:
-                                binding.workspaceNavigationIdentity,
-                        }),
-                    })),
-                    previous,
-                    next
-                ),
-            onResult: (kind, result) => logAiSessionDiagnostic({
-                event: 'conversation-session-rebind-metadata',
-                kind,
-                result,
-            }),
-            onFailure: (kind, error) => logAiSessionRuntimeFailure(
-                `copy-conversation-${kind}-for-rebind`,
-                error
-            ),
-        });
-    const conversationViewerCommentStore = {
-        load: (target: { projectId: string; provider: AiSessionProviderId; sessionId: string }) =>
-            conversationCommentStore.load(
-                conversationSessionRebindCoordinator.resolve(target)
-            ),
-        save: (
-            target: { projectId: string; provider: AiSessionProviderId; sessionId: string },
-            snapshot: Parameters<typeof conversationCommentStore.save>[1]
-        ) => conversationCommentStore.save(
-            conversationSessionRebindCoordinator.resolve(target),
-            snapshot
-        ),
-    };
-    const conversationViewerBookmarkStore = {
-        load: (target: { projectId: string; provider: AiSessionProviderId; sessionId: string }) =>
-            conversationBookmarkStore.load(
-                conversationSessionRebindCoordinator.resolve(target)
-            ),
-        save: (
-            target: { projectId: string; provider: AiSessionProviderId; sessionId: string },
-            snapshot: Parameters<typeof conversationBookmarkStore.save>[1]
-        ) => conversationBookmarkStore.save(
-            conversationSessionRebindCoordinator.resolve(target),
-            snapshot
-        ),
-    };
-    const conversationSessionRebindRestoreTask =
-        conversationSessionRebindCoordinator.restore().catch(error => {
-            logAiSessionRuntimeFailure(
-                'restore-conversation-session-rebinds',
-                error
-            );
-        });
+    const {
+        conversationCommentStore,
+        projectCommentStore,
+        conversationBookmarkStore,
+        conversationSessionRebindCoordinator,
+        conversationViewerCommentStore,
+        conversationViewerBookmarkStore,
+        conversationSessionRebindRestoreTask,
+    } = createConversationStack({
+        context,
+        logAiSessionDiagnostic,
+        logAiSessionRuntimeFailure,
+        tmuxRuntimeStore,
+        currentWorkspaceSessionAuthority,
+    });
     const tmuxAttachBindingStore = new TmuxAttachBindingStore(context.workspaceState, error => {
         logAiSessionRuntimeFailure('persist-attach-binding', error);
     });

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -31,6 +31,7 @@ import { createProjectControllers } from './dashboard/sections/projectController
 import { createAiSessionStack } from './dashboard/sections/aiSessionStack';
 import { createConversationStack } from './dashboard/sections/conversationStack';
 import { createRuntimeStack } from './dashboard/sections/runtimeStack';
+import { createWorktreeStack } from './dashboard/sections/worktreeStack';
 import { PromptTerminalCommandController } from './prompts/terminalCommandController';
 import CodexSessionService from './services/codexSessionService';
 import { ProcCodexRootThreadObserver } from './aiSessions/codexRootThreadObserver';
@@ -911,35 +912,21 @@ async function initializeDashboard(
     const getCurrentOpenWorkspace = (): OpenWorkspace | null => openWorkspaceController
         ? openWorkspaceController.getCurrentWorkspace()
         : resolveCurrentOpenWorkspace();
-    const worktreeBaseRefStore = new WorktreeBaseRefStore(context.globalState);
-    const worktreeProvisioningStore = new WorktreeProvisioningStore(
-        context.globalState,
-        () => normalizeWorktreeDirectory(
-            getAgentPivotConfiguration().get<unknown>('worktreeDirectory', '.worktrees'))
-    );
-    const worktreeSetupRunner = new WorktreeSetupRunner();
-    const worktreeGroupManifestStore = createWorktreeGroupManifestStore(context.globalState);
-    const worktreeGroupManifestReader = worktreeGroupManifestReaderOf(worktreeGroupManifestStore);
-    const worktreeGroupManifestWriter = worktreeGroupManifestWriterOf(worktreeGroupManifestStore);
-    const worktreeMemberLifecycle = new WorktreeMemberLifecycle(worktreeGroupManifestStore);
-    const gitWorktreeDiscovery = new GitWorktreeDiscovery({
-        getBaseRef: repositoryKey => worktreeBaseRefStore.get(repositoryKey),
+    const {
+        worktreeBaseRefStore,
+        worktreeProvisioningStore,
+        worktreeSetupRunner,
+        worktreeGroupManifestStore,
+        worktreeGroupManifestReader,
+        worktreeGroupManifestWriter,
+        worktreeMemberLifecycle,
+        gitWorktreeDiscovery,
+        getPriorityWorktreeKeys,
+        getWorktreePrioritySignature,
+    } = createWorktreeStack({
+        context,
+        getAiSessionRuntimeCoordinator: () => aiSessionRuntimeCoordinator,
     });
-    const getPriorityWorktreeKeys = (): import('./worktrees').WorktreeKey[] => [
-        ...aiSessionRuntimeCoordinator.getActive(),
-        ...aiSessionRuntimeCoordinator.getPending(),
-    ].reduce((keys, runtime) => {
-        const key = runtime.identity.worktreeKey;
-        if (key && !keys.some(candidate => worktreeKeysEqual(candidate, key))) {
-            keys.push({ ...key });
-        }
-        return keys;
-    }, [] as import('./worktrees').WorktreeKey[]);
-    const getWorktreePrioritySignature = (): string => JSON.stringify(
-        getPriorityWorktreeKeys()
-            .map(key => [key.repositoryKey, key.canonicalWorktreePath])
-            .sort((left, right) => JSON.stringify(left).localeCompare(JSON.stringify(right)))
-    );
     let requestedWorktreePrioritySignature = getWorktreePrioritySignature();
     const worktreeSnapshotCoordinator = ownResource(() =>
         new WorktreeSnapshotCoordinator({

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -24,8 +24,7 @@ import {
     WSL_DEFAULT_REGEX,
 } from './constants';
 
-import ColorService from './services/colorService';
-import ProjectService from './services/projectService';
+import { createProjectServices } from './dashboard/sections/projectServices';
 import { TodoService } from './todos/service';
 import { createTodoPanelCapability } from './todos/todoPanelCapability';
 import { PromptDashboardController } from './prompts/dashboardController';
@@ -34,7 +33,6 @@ import { PromptTerminalCommandController } from './prompts/terminalCommandContro
 import { getAiPanelContent, getPromptSurfaceContent } from './prompts/webviewContent';
 import { createSkillPanelCapability } from './skills/skillPanelCapability';
 import { SkillGroupStore } from './skills/skillGroupStore';
-import FileService from './services/fileService';
 import CodexSessionService from './services/codexSessionService';
 import { ProcCodexRootThreadObserver } from './aiSessions/codexRootThreadObserver';
 import KimiSessionService from './services/kimiSessionService';
@@ -46,7 +44,6 @@ import {
     openWorkingChangeDiff,
     registerGitDiffContentProvider,
 } from './services/gitChangesDiff';
-import ProjectWindowColorService from './services/projectWindowColorService';
 import AiSessionAliasStore from './aiSessions/aliasStore';
 import AiSessionProfileStore from './aiSessions/sessionProfileStore';
 import AiSessionProfileController from './aiSessions/sessionProfileController';
@@ -199,7 +196,6 @@ import {
 import { findSavedProjectForOpenProject } from './projects/openProjectMatcher';
 import { getWorkspacePath as resolveWorkspacePath } from './projects/workspaceHelpers';
 import RemoteProjectResolver from './projects/remoteProjectResolver';
-import GitRepositoryDetector from './projects/gitRepositoryDetector';
 import { AddProjectsFromFolderController } from './projects/addProjectsFromFolderController';
 import { CurrentProjectDetailsResolver } from './projects/currentProjectDetails';
 import { FavoriteProjectController } from './projects/favoriteProjectController';
@@ -619,19 +615,13 @@ async function initializeDashboard(
                 || storageMutationMessageTypes.has(messageType));
     };
 
-    const colorService = new ColorService(context);
-    const projectService = new ProjectService(context, colorService, {
-        onDiagnostic: event => logDashboardDiagnostic(event),
-        onConflict: projectIds => {
-            logDashboardDiagnostic({
-                event: 'project-catalog-sync-conflict-recovered',
-                projectIds,
-            });
-            void vscode.window.showInformationMessage(
-                'Agent Pivot recovered projects from a sync conflict.'
-            );
-        },
-    });
+    const {
+        colorService,
+        projectService,
+        projectWindowColorService,
+        fileService,
+        gitRepositoryDetector,
+    } = createProjectServices({ context, logDashboardDiagnostic });
     const todoService = new TodoService(context);
     const promptConfiguration = getAgentPivotConfiguration();
     const promptStore = await initializePromptMementoStore({
@@ -738,9 +728,6 @@ async function initializeDashboard(
         refreshAfterMutation: projectSurface.refreshAfterMutation,
         userCanceledToken: USER_CANCELED,
     });
-    const projectWindowColorService = new ProjectWindowColorService(context);
-    const fileService = new FileService(context);
-    const gitRepositoryDetector = new GitRepositoryDetector();
     const projectOpenController = new ProjectOpenController({
         getWorkspaceFile: () => vscode.workspace.workspaceFile,
         getWorkspaceFolders: () => vscode.workspace.workspaceFolders,

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -28,6 +28,7 @@ import { createTodoPanelCapability } from './todos/todoPanelCapability';
 import { initializePromptMementoStore } from './prompts/service';
 import { createPanelStack } from './dashboard/sections/panelStack';
 import { createProjectControllers } from './dashboard/sections/projectControllers';
+import { createAiSessionStack } from './dashboard/sections/aiSessionStack';
 import { PromptTerminalCommandController } from './prompts/terminalCommandController';
 import CodexSessionService from './services/codexSessionService';
 import { ProcCodexRootThreadObserver } from './aiSessions/codexRootThreadObserver';
@@ -672,43 +673,20 @@ async function initializeDashboard(
             dashboardRuntimeController.applyProjectColorToCurrentWindow(project),
         revealDashboard: () => { void dashboardRuntimeController.revealAgentPivotDashboard(); },
     });
-    const codexSessionService = new CodexSessionService();
-    const kimiSessionService = new KimiSessionService();
-    const claudeSessionService = new ClaudeSessionService();
-    const aiSessionServices: Record<AiSessionProviderId, AiSessionService> = {
-        codex: codexSessionService,
-        kimi: kimiSessionService,
-        claude: claudeSessionService,
-    };
-    const aiSessionProviderRegistry = createAiSessionProviderRegistry(aiSessionServices);
-    const aiSessionProviders = aiSessionProviderRegistry.providers();
-    const aiSessionReadCoordinator = new AiSessionReadCoordinator(
+    const {
+        codexSessionService,
+        kimiSessionService,
+        claudeSessionService,
+        aiSessionServices,
+        aiSessionProviderRegistry,
         aiSessionProviders,
-        logAiSessionDiagnostic
-    );
-    const aiSessionAliasStore = new AiSessionAliasStore(context.globalStoragePath);
-    const aiSessionAliasController = new AiSessionAliasController({
-        store: aiSessionAliasStore,
-        isProviderId: isAiSessionProviderId,
-        getSessionKey: getAiSessionPinKey,
-        getProviderResult: (providerId, options) => aiSessionReadCoordinator.getProviderResult(providerId, options),
-        logError,
-        showSaveError: () => vscode.window.showErrorMessage("Could not save the chat name."),
-    });
-    const aiSessionProfileStore = new AiSessionProfileStore(context.globalStoragePath);
-    const aiSessionProfileController = new AiSessionProfileController({
-        store: aiSessionProfileStore,
-        isProviderId: isAiSessionProviderId,
-        getSessionKey: getAiSessionPinKey,
-        logError,
-        showSaveError: () => vscode.window.showErrorMessage('Could not save the Codex session profile.'),
-        lastUsedMemento: context.globalState,
-        isProfileAvailable: name => codexProfileFileExists(name),
-    });
-    const codexProfileSupportProbe = new CodexProfileSupportProbe({
-        executable: resolveAiProviderExecutable('codex') || 'codex',
-        memento: context.globalState,
-    });
+        aiSessionReadCoordinator,
+        aiSessionAliasStore,
+        aiSessionAliasController,
+        aiSessionProfileStore,
+        aiSessionProfileController,
+        codexProfileSupportProbe,
+    } = createAiSessionStack({ context, logError, logAiSessionDiagnostic });
     const conversationCommentStore = new ConversationCommentFileStore(
         context.globalStoragePath
     );

--- a/src/dashboard/sections/aiSessionStack.ts
+++ b/src/dashboard/sections/aiSessionStack.ts
@@ -1,0 +1,93 @@
+'use strict';
+
+import * as vscode from 'vscode';
+
+import CodexSessionService from '../../services/codexSessionService';
+import KimiSessionService from '../../services/kimiSessionService';
+import ClaudeSessionService from '../../services/claudeSessionService';
+import AiSessionAliasStore from '../../aiSessions/aliasStore';
+import AiSessionAliasController from '../../aiSessions/aliasController';
+import AiSessionProfileStore from '../../aiSessions/sessionProfileStore';
+import AiSessionProfileController from '../../aiSessions/sessionProfileController';
+import {
+    CodexProfileSupportProbe,
+    codexProfileFileExists,
+} from '../../aiSessions/codexProfiles';
+import { AiSessionReadCoordinator } from '../../aiSessions/readCoordinator';
+import { createAiSessionProviderRegistry } from '../../aiSessions/providers';
+import { getAiSessionKey } from '../../aiSessions/sessionHelpers';
+import { resolveAiProviderExecutable } from '../../aiSessions/providerDirectoryCapability';
+import { isAiSessionProviderId } from '../../models';
+import type { AiSessionProviderId } from '../../models';
+import type { AiSessionService } from '../../aiSessions/types';
+
+/**
+ * Composition section (MOD-DASHBOARD-SHELL): the AI session provider
+ * services, registry, read coordinator, and the alias/profile stores and
+ * controllers. Extracted from the composition root; construction order is
+ * unchanged.
+ */
+export interface AiSessionStackDeps {
+    context: vscode.ExtensionContext;
+    logError: (message: string, error: unknown) => void;
+    logAiSessionDiagnostic: (event: Record<string, unknown>) => void;
+}
+
+export function createAiSessionStack(deps: AiSessionStackDeps) {
+    const { context, logError, logAiSessionDiagnostic } = deps;
+    const getSessionKey = (providerId: AiSessionProviderId, sessionId: string) =>
+        getAiSessionKey(providerId, sessionId);
+
+    const codexSessionService = new CodexSessionService();
+    const kimiSessionService = new KimiSessionService();
+    const claudeSessionService = new ClaudeSessionService();
+    const aiSessionServices: Record<AiSessionProviderId, AiSessionService> = {
+        codex: codexSessionService,
+        kimi: kimiSessionService,
+        claude: claudeSessionService,
+    };
+    const aiSessionProviderRegistry = createAiSessionProviderRegistry(aiSessionServices);
+    const aiSessionProviders = aiSessionProviderRegistry.providers();
+    const aiSessionReadCoordinator = new AiSessionReadCoordinator(
+        aiSessionProviders,
+        logAiSessionDiagnostic
+    );
+    const aiSessionAliasStore = new AiSessionAliasStore(context.globalStoragePath);
+    const aiSessionAliasController = new AiSessionAliasController({
+        store: aiSessionAliasStore,
+        isProviderId: isAiSessionProviderId,
+        getSessionKey,
+        getProviderResult: (providerId, options) => aiSessionReadCoordinator.getProviderResult(providerId, options),
+        logError,
+        showSaveError: () => vscode.window.showErrorMessage("Could not save the chat name."),
+    });
+    const aiSessionProfileStore = new AiSessionProfileStore(context.globalStoragePath);
+    const aiSessionProfileController = new AiSessionProfileController({
+        store: aiSessionProfileStore,
+        isProviderId: isAiSessionProviderId,
+        getSessionKey,
+        logError,
+        showSaveError: () => vscode.window.showErrorMessage('Could not save the Codex session profile.'),
+        lastUsedMemento: context.globalState,
+        isProfileAvailable: name => codexProfileFileExists(name),
+    });
+    const codexProfileSupportProbe = new CodexProfileSupportProbe({
+        executable: resolveAiProviderExecutable('codex') || 'codex',
+        memento: context.globalState,
+    });
+
+    return {
+        codexSessionService,
+        kimiSessionService,
+        claudeSessionService,
+        aiSessionServices,
+        aiSessionProviderRegistry,
+        aiSessionProviders,
+        aiSessionReadCoordinator,
+        aiSessionAliasStore,
+        aiSessionAliasController,
+        aiSessionProfileStore,
+        aiSessionProfileController,
+        codexProfileSupportProbe,
+    };
+}

--- a/src/dashboard/sections/conversationStack.ts
+++ b/src/dashboard/sections/conversationStack.ts
@@ -1,0 +1,116 @@
+'use strict';
+
+import * as vscode from 'vscode';
+
+import { ConversationCommentFileStore } from '../../aiSessions/conversation/commentStore';
+import { ProjectCommentFileStore } from '../../aiSessions/conversation/projectCommentStore';
+import { ConversationBookmarkFileStore } from '../../aiSessions/conversation/bookmarkStore';
+import {
+    ConversationSessionRebindCoordinator,
+    hasCommittedConversationSessionRuntimeRebind,
+} from '../../aiSessions/conversation/sessionRebindCoordinator';
+import type { AiSessionProviderId } from '../../models';
+import type { TmuxRuntimeBindingStore } from '../../aiSessions/tmuxRuntimeBindingStore';
+import type { CurrentWorkspaceSessionAuthority } from '../../workspaces/currentWorkspaceSessionAuthority';
+
+/**
+ * Composition section (MOD-DASHBOARD-SHELL): conversation persistence stores
+ * and the session-rebind coordinator with its viewer-facing store adapters.
+ * Extracted from the composition root; the rebind restore task starts at the
+ * same point in bootstrap (this section is invoked where the comment store
+ * was constructed).
+ */
+export interface ConversationStackDeps {
+    context: vscode.ExtensionContext;
+    logAiSessionDiagnostic: (event: Record<string, unknown>) => void;
+    logAiSessionRuntimeFailure: (operation: string, error: unknown) => void;
+    tmuxRuntimeStore: TmuxRuntimeBindingStore;
+    currentWorkspaceSessionAuthority: CurrentWorkspaceSessionAuthority;
+}
+
+export function createConversationStack(deps: ConversationStackDeps) {
+    const { context, logAiSessionDiagnostic, logAiSessionRuntimeFailure } = deps;
+
+    const conversationCommentStore = new ConversationCommentFileStore(
+        context.globalStoragePath
+    );
+    const projectCommentStore = new ProjectCommentFileStore(
+        context.globalStoragePath
+    );
+    const conversationBookmarkStore = new ConversationBookmarkFileStore(
+        context.globalStoragePath
+    );
+    const conversationSessionRebindCoordinator =
+        new ConversationSessionRebindCoordinator({
+            globalStoragePath: context.globalStoragePath,
+            commentStore: conversationCommentStore,
+            bookmarkStore: conversationBookmarkStore,
+            isRuntimeRebindCommitted: async (previous, next) =>
+                hasCommittedConversationSessionRuntimeRebind(
+                    (await deps.tmuxRuntimeStore.listKnown()).map(binding => ({
+                        provider: binding.provider,
+                        sessionId: binding.sessionId,
+                        projectId: deps.currentWorkspaceSessionAuthority.getProjectId({
+                            workspaceScopeIdentity:
+                                binding.workspaceScopeIdentity,
+                            workspaceNavigationIdentity:
+                                binding.workspaceNavigationIdentity,
+                        }),
+                    })),
+                    previous,
+                    next
+                ),
+            onResult: (kind, result) => logAiSessionDiagnostic({
+                event: 'conversation-session-rebind-metadata',
+                kind,
+                result,
+            }),
+            onFailure: (kind, error) => logAiSessionRuntimeFailure(
+                `copy-conversation-${kind}-for-rebind`,
+                error
+            ),
+        });
+    const conversationViewerCommentStore = {
+        load: (target: { projectId: string; provider: AiSessionProviderId; sessionId: string }) =>
+            conversationCommentStore.load(
+                conversationSessionRebindCoordinator.resolve(target)
+            ),
+        save: (
+            target: { projectId: string; provider: AiSessionProviderId; sessionId: string },
+            snapshot: Parameters<typeof conversationCommentStore.save>[1]
+        ) => conversationCommentStore.save(
+            conversationSessionRebindCoordinator.resolve(target),
+            snapshot
+        ),
+    };
+    const conversationViewerBookmarkStore = {
+        load: (target: { projectId: string; provider: AiSessionProviderId; sessionId: string }) =>
+            conversationBookmarkStore.load(
+                conversationSessionRebindCoordinator.resolve(target)
+            ),
+        save: (
+            target: { projectId: string; provider: AiSessionProviderId; sessionId: string },
+            snapshot: Parameters<typeof conversationBookmarkStore.save>[1]
+        ) => conversationBookmarkStore.save(
+            conversationSessionRebindCoordinator.resolve(target),
+            snapshot
+        ),
+    };
+    const conversationSessionRebindRestoreTask =
+        conversationSessionRebindCoordinator.restore().catch(error => {
+            logAiSessionRuntimeFailure(
+                'restore-conversation-session-rebinds',
+                error
+            );
+        });
+
+    return {
+        conversationCommentStore,
+        projectCommentStore,
+        conversationBookmarkStore,
+        conversationSessionRebindCoordinator,
+        conversationViewerCommentStore,
+        conversationViewerBookmarkStore,
+        conversationSessionRebindRestoreTask,
+    };
+}

--- a/src/dashboard/sections/panelStack.ts
+++ b/src/dashboard/sections/panelStack.ts
@@ -1,0 +1,141 @@
+'use strict';
+
+import * as os from 'os';
+import * as vscode from 'vscode';
+import { randomBytes } from 'crypto';
+
+import { PromptService } from '../../prompts/service';
+import { PromptDashboardController } from '../../prompts/dashboardController';
+import { getPromptSurfaceContent, getAiPanelContent } from '../../prompts/webviewContent';
+import { createSkillPanelCapability } from '../../skills/skillPanelCapability';
+import { SkillGroupStore } from '../../skills/skillGroupStore';
+import { getSkillsPanelContent } from '../../skills/webviewSkillContent';
+import { createTodoPanelCapability } from '../../todos/todoPanelCapability';
+import { TodoService } from '../../todos/service';
+import { buildWorkspaceDashboardSearchCatalog } from '../../webview/dashboardViewModel';
+import { getAgentPivotConfiguration } from '../../configuration';
+import type { WorkspaceCardViewModel } from '../../models';
+import type { AgentPivotViewProvider } from '../viewProvider';
+import type ProjectService from '../../services/projectService';
+import type { DashboardBootstrapResources } from '../bootstrapResources';
+
+/**
+ * Composition section (MOD-DASHBOARD-SHELL): the prompt, skill, and todo
+ * panel stack. Extracted from the composition root; construction and
+ * ownResource registration order are unchanged.
+ */
+export interface PanelStackDeps {
+    context: vscode.ExtensionContext;
+    provider: AgentPivotViewProvider;
+    resources: DashboardBootstrapResources;
+    ownResource: <T extends { dispose(): unknown }>(factory: () => T) => T;
+    timeBootstrapPhase: <T>(phase: string, run: () => T | Promise<T>) => Promise<T>;
+    logError: (message: string, error: unknown) => void;
+    logDashboardDiagnostic: (event: Record<string, unknown>) => void;
+    projectService: ProjectService;
+    promptStore: { readSetting: () => unknown; writeGlobalSetting: (value: unknown) => Promise<void> };
+    getOpenWorkspaceCards: () => WorkspaceCardViewModel[];
+}
+
+export interface PanelStack {
+    todoService: TodoService;
+    promptService: PromptService;
+    promptDashboardController: PromptDashboardController;
+    skillPanel: ReturnType<typeof createSkillPanelCapability>;
+    todoPanel: ReturnType<typeof createTodoPanelCapability>;
+}
+
+export function createPanelStack(deps: PanelStackDeps): PanelStack {
+    const {
+        context, provider, ownResource, timeBootstrapPhase,
+        logError, logDashboardDiagnostic, projectService, promptStore, getOpenWorkspaceCards,
+    } = deps;
+
+    const todoService = new TodoService(context);
+    const promptService = new PromptService({
+        readSetting: promptStore.readSetting,
+        writeGlobalSetting: promptStore.writeGlobalSetting,
+        createId: () => randomBytes(16).toString('hex'),
+        logDiagnostic: event => logDashboardDiagnostic({ event: 'prompt-store', ...event }),
+    });
+    const getWorkspaceRootPaths = (): string[] =>
+        (vscode.workspace.workspaceFolders || []).map(folder => folder.uri.fsPath);
+    const skillPanel = ownResource(() => createSkillPanelCapability({
+        getHomeDir: () => os.homedir(),
+        getWorkspaceRoot: () => vscode.workspace.workspaceFolders?.[0]?.uri.fsPath,
+        getWorkspaceRoots: getWorkspaceRootPaths,
+        hasWorkspace: () => Boolean(vscode.workspace.workspaceFolders?.length),
+        groupStore: new SkillGroupStore(context.globalState),
+        readGlobalStorePath: () => getAgentPivotConfiguration().get<string>(
+            'skills.globalStorePath',
+            '~/.skills',
+        ),
+        writeGlobalStorePath: value => getAgentPivotConfiguration().update(
+            'skills.globalStorePath',
+            value,
+            vscode.ConfigurationTarget.Global,
+        ),
+        postMessage: message => provider.postMessage(message),
+        refreshDashboard: () => provider.refresh(),
+        isVisible: () => provider.visible,
+        showInputBox: options => vscode.window.showInputBox(options),
+        showQuickPickMany: <T extends vscode.QuickPickItem>(
+            items: readonly T[],
+            quickPickOptions: vscode.QuickPickOptions
+        ) => vscode.window.showQuickPick(
+            [...items],
+            { ...quickPickOptions, canPickMany: true } as vscode.QuickPickOptions & { canPickMany: true }
+        ),
+        showWarningMessage: (message, messageOptions, ...items) => messageOptions
+            ? vscode.window.showWarningMessage(message, messageOptions, ...items)
+            : vscode.window.showWarningMessage(message),
+        showInformationMessage: message => vscode.window.showInformationMessage(message),
+        showErrorMessage: message => vscode.window.showErrorMessage(message),
+        openTextFile: fsPath => vscode.window.showTextDocument(vscode.Uri.file(fsPath)),
+        logError,
+    }));
+    timeBootstrapPhase('skill-scan', () => skillPanel.start());
+    const promptDashboardController = new PromptDashboardController({
+        service: promptService,
+        confirmDelete: async prompt => {
+            const choice = await vscode.window.showWarningMessage(
+                `Delete Prompt "${prompt.name}"?`,
+                { modal: true },
+                'Delete'
+            );
+            return choice === 'Delete';
+        },
+        renderPromptSurface: getPromptSurfaceContent,
+        renderAiPanel: snapshot => getAiPanelContent(
+            snapshot,
+            getSkillsPanelContent(
+                skillPanel.getRecords(),
+                skillPanel.getPanelView(),
+            ),
+        ),
+    });
+    const todoPanel = ownResource(() => createTodoPanelCapability({
+        provider,
+        todoService,
+        getSearchCatalog: () => buildWorkspaceDashboardSearchCatalog(
+            projectService.getGroups(),
+            getOpenWorkspaceCards(),
+            todoService.getSearchItems(),
+            skillPanel.getRecords(),
+        ),
+        getConfiguration: () => getAgentPivotConfiguration(),
+        showInputBox: options => vscode.window.showInputBox(options),
+        showWarningMessage: (message, messageOptions, ...items) =>
+            vscode.window.showWarningMessage(message, messageOptions, ...items),
+        showErrorMessage: message => vscode.window.showErrorMessage(message),
+        logError,
+    }));
+
+    return {
+        todoService,
+        promptService,
+        promptDashboardController,
+        skillPanel,
+        todoPanel,
+    };
+}

--- a/src/dashboard/sections/projectControllers.ts
+++ b/src/dashboard/sections/projectControllers.ts
@@ -1,0 +1,199 @@
+'use strict';
+
+import * as vscode from 'vscode';
+
+import { AddProjectsFromFolderController } from '../../projects/addProjectsFromFolderController';
+import { CurrentProjectDetailsResolver } from '../../projects/currentProjectDetails';
+import { FavoriteProjectController } from '../../projects/favoriteProjectController';
+import { GroupCommandController } from '../../projects/groupCommandController';
+import { queryGroupName } from '../../projects/groupPrompts';
+import { ProjectManualEditController } from '../../projects/projectManualEditController';
+import { ProjectMutationController } from '../../projects/projectMutationController';
+import { ProjectOpenController } from '../../projects/projectOpenController';
+import { ProjectOrderController } from '../../projects/projectOrderController';
+import { ProjectPromptController } from '../../projects/projectPromptController';
+import { ProjectRemovalController } from '../../projects/projectRemovalController';
+import RemoteProjectResolver from '../../projects/remoteProjectResolver';
+import { createProjectSurfaceRefresh } from '../../projects/projectMessageHandlers';
+import { parsePathAsUri } from '../../projects/openProjectService';
+import { getWorkspacePath as resolveWorkspacePath } from '../../projects/workspaceHelpers';
+import { GroupCollapseController } from '../groupCollapseController';
+import { USER_CANCELED, REOPEN_KEY } from '../../constants';
+import type { Project, StewardInfos } from '../../models';
+import type ColorService from '../../services/colorService';
+import type ProjectService from '../../services/projectService';
+import type FileService from '../../services/fileService';
+import type GitRepositoryDetector from '../../projects/gitRepositoryDetector';
+import type { OpenWorkspaceController } from '../../openWorkspaces/workspaceController';
+import type { OpenWorkspaceDashboardController } from '../../openWorkspaces/dashboardController';
+import type { ProjectsPanelController } from '../projectsPanelController';
+import type { DashboardRuntimeController } from '../runtimeController';
+
+/**
+ * Composition section (MOD-DASHBOARD-SHELL): the project catalog controllers
+ * and resolvers. Extracted from the composition root; construction order and
+ * closure timing are unchanged (late-bound collaborators arrive as getters).
+ */
+export interface ProjectControllersDeps {
+    context: vscode.ExtensionContext;
+    logError: (message: string, error: unknown) => void;
+    colorService: ColorService;
+    projectService: ProjectService;
+    fileService: FileService;
+    gitRepositoryDetector: GitRepositoryDetector;
+    getStewardInfos: () => StewardInfos;
+    getProjectsPanelController: () => ProjectsPanelController | undefined;
+    getOpenWorkspaceDashboardController: () => OpenWorkspaceDashboardController;
+    publishOpenWorkspace: () => void;
+    applyProjectColorToCurrentWindow: (project: Project | null) => void;
+    revealDashboard: () => void;
+}
+
+export function createProjectControllers(deps: ProjectControllersDeps) {
+    const {
+        context, logError, colorService, projectService, fileService, gitRepositoryDetector,
+    } = deps;
+    const isFolderGitRepo = (projectPath: string) =>
+        gitRepositoryDetector.isGitRepositoryPath(projectPath);
+
+    const projectSurface = createProjectSurfaceRefresh({
+        getProjectsPanelController: deps.getProjectsPanelController,
+        getOpenWorkspaceDashboardController: deps.getOpenWorkspaceDashboardController,
+        publishOpenWorkspace: deps.publishOpenWorkspace,
+        syncProjectColorToCurrentWindow: project =>
+            deps.applyProjectColorToCurrentWindow(project),
+    });
+    const groupCollapseController = new GroupCollapseController({
+        state: context.globalState,
+        projectService,
+    });
+    const groupCommandController = new GroupCommandController({
+        projectService,
+        promptGroupName: defaultText => queryGroupName(vscode.window, defaultText),
+        promptGroupToRemove: () => projectPromptController.queryGroup(),
+        confirmRemoveGroup: groupName => vscode.window.showWarningMessage(`Remove ${groupName}?`, { modal: true }, 'Remove'),
+        showErrorMessage: message => vscode.window.showErrorMessage(message),
+        refreshAfterMutation: projectSurface.refreshAfterMutation,
+        userCanceledToken: USER_CANCELED,
+    });
+    const projectOpenController = new ProjectOpenController({
+        getWorkspaceFile: () => vscode.workspace.workspaceFile,
+        getWorkspaceFolders: () => vscode.workspace.workspaceFolders,
+        getPrependVscodeUrlToWslRemotes: () => deps.getStewardInfos().config.prependVscodeUrlToWslRemotes,
+        getProjectPathType: projectPath => fileService.getProjectPathType(projectPath),
+        getFoldersFromWorkspaceFile: workspaceFilePath => fileService.getFoldersFromWorkspaceFile(workspaceFilePath),
+        showWarningMessage: message => vscode.window.showWarningMessage(message),
+        showInformationMessage: message => vscode.window.showInformationMessage(message),
+        showErrorMessage: message => vscode.window.showErrorMessage(message),
+        executeCommand: (command, ...args) => vscode.commands.executeCommand(command, ...args),
+        updateWorkspaceFolders: (start, deleteCount, ...workspaceFoldersToAdd) => vscode.workspace.updateWorkspaceFolders(start, deleteCount, ...workspaceFoldersToAdd),
+        updateReopenReason: reason => context.globalState.update(REOPEN_KEY, reason),
+        fileUri: projectPath => vscode.Uri.file(projectPath),
+        parseUri: projectPath => vscode.Uri.parse(projectPath),
+    });
+    const projectPromptController = new ProjectPromptController({
+        getGroups: () => projectService.getGroups(),
+        addGroup: name => projectService.addGroup(name),
+        removeGroup: (groupId, skipConfirmation) => projectService.removeGroup(groupId, skipConfirmation),
+        isFile: projectPath => fileService.isFile(projectPath),
+        isFolderGitRepo: projectPath => isFolderGitRepo(projectPath),
+        getRandomColor: () => colorService.getRandomColor(),
+        getColorName: colorCode => colorService.getColorName(colorCode),
+        getRecentColors: () => colorService.getRecentColors(),
+        getRemoteSshExtensionInstalled: () => deps.getStewardInfos().relevantExtensionsInstalls.remoteSSH,
+        showInputBox: options => vscode.window.showInputBox(options),
+        showQuickPick: (items, options) => vscode.window.showQuickPick(items, options),
+        showOpenDialog: options => vscode.window.showOpenDialog(options),
+    });
+    const projectMutationController = new ProjectMutationController({
+        getCurrentWorkspacePath: () => resolveWorkspacePath(vscode.workspace.workspaceFile, vscode.workspace.workspaceFolders),
+        getCurrentProjectDetailsForSave: () => currentProjectDetailsResolver.getCurrentProjectDetailsForSave(),
+        getProjectDetailsForSave: uri => currentProjectDetailsResolver.getProjectDetailsForSave(uri),
+        getProjectsFlat: () => projectService.getProjectsFlat(),
+        getProjectAndGroup: projectId => projectService.getProjectAndGroup(projectId),
+        addProjectToGroup: (project, groupId) => projectService.addProject(project, groupId),
+        updateProject: (projectId, project) => projectService.updateProject(projectId, project),
+        removeGroup: (groupId, skipConfirmation) => projectService.removeGroup(groupId, skipConfirmation),
+        getRandomColor: () => colorService.getRandomColor(),
+        isFolderGitRepo,
+        prompt: projectPromptController,
+        showInputBox: options => vscode.window.showInputBox(options),
+        showWarningMessage: message => vscode.window.showWarningMessage(message),
+        showInformationMessage: message => vscode.window.showInformationMessage(message),
+        showErrorMessage: message => vscode.window.showErrorMessage(message),
+        refreshAfterMutation: projectSurface.refreshAfterMutation,
+    });
+    const favoriteProjectController = new FavoriteProjectController({
+        getGroups: () => projectService.getGroups(),
+        saveGroups: groups => projectService.saveGroups(groups),
+        refreshAfterMutation: projectSurface.refreshAfterMutation,
+    });
+    const projectOrderController = new ProjectOrderController({
+        getGroups: () => projectService.getGroups(),
+        saveGroups: groups => projectService.saveGroups(groups),
+        showInformationMessage: message => vscode.window.showInformationMessage(message),
+        refreshAfterMutation: projectSurface.refreshAfterMutation,
+    });
+    const projectRemovalController = new ProjectRemovalController({
+        getProject: projectId => projectService.getProject(projectId),
+        getProjectsFlat: () => projectService.getProjectsFlat(),
+        showProjectPicker: projectPicks => vscode.window.showQuickPick(projectPicks),
+        confirmRemoveProject: projectName => vscode.window.showWarningMessage(`Remove ${projectName}?`, { modal: true }, 'Remove'),
+        removeProject: projectId => projectService.removeProject(projectId),
+        refreshAfterMutation: projectSurface.refreshAfterMutation,
+        postCommandRemoval: () => { deps.revealDashboard(); },
+    });
+    const projectManualEditController = new ProjectManualEditController({
+        getGroups: () => projectService.getGroups(),
+        getTempFilePath: () => `${context.globalStoragePath}/Agent Pivot Projects.json`,
+        writeTextFile: (filePath, content) => fileService.writeTextFile(filePath, content),
+        fileUri: filePath => vscode.Uri.file(filePath),
+        openTextDocument: uri => vscode.workspace.openTextDocument(uri),
+        showTextDocument: document => vscode.window.showTextDocument(document),
+        onWillSaveTextDocument: listener => vscode.workspace.onWillSaveTextDocument(listener),
+        saveGroups: (groups, baselineGroups) =>
+            projectService.saveGroupsFromManualEdit(groups, baselineGroups),
+        executeCommand: command => vscode.commands.executeCommand(command),
+        showErrorMessage: message => vscode.window.showErrorMessage(message),
+        postSave: () => {
+            projectSurface.refreshAfterMutation();
+            deps.revealDashboard();
+        },
+    });
+    const addProjectsFromFolderController = new AddProjectsFromFolderController({
+        getCurrentWorkspacePath: () => resolveWorkspacePath(vscode.workspace.workspaceFile, vscode.workspace.workspaceFolders),
+        parsePathAsUri,
+        showOpenDialog: options => vscode.window.showOpenDialog(options),
+        getFolders: folderPath => fileService.getFolders(folderPath),
+        addGroup: groupName => projectService.addGroup(groupName),
+        addProject: (project, groupId) => projectService.addProject(project, groupId),
+        getRandomColor: () => colorService.getRandomColor(),
+        isFolderGitRepo,
+        showErrorMessage: message => vscode.window.showErrorMessage(message),
+        refreshAfterMutation: projectSurface.refreshAfterMutation,
+        userCanceledToken: USER_CANCELED,
+    });
+    const remoteProjectResolver = new RemoteProjectResolver(logError);
+    const currentProjectDetailsResolver = new CurrentProjectDetailsResolver({
+        getWorkspaceFile: () => vscode.workspace.workspaceFile,
+        getWorkspaceFolders: () => vscode.workspace.workspaceFolders,
+        getRemoteName: () => vscode.env.remoteName,
+        getProjectDetailsForSave: (workspaceUri, remoteName) => remoteProjectResolver.getProjectDetailsForSave(workspaceUri, remoteName),
+    });
+
+    return {
+        projectSurface,
+        groupCollapseController,
+        groupCommandController,
+        projectOpenController,
+        projectPromptController,
+        projectMutationController,
+        favoriteProjectController,
+        projectOrderController,
+        projectRemovalController,
+        projectManualEditController,
+        addProjectsFromFolderController,
+        remoteProjectResolver,
+        currentProjectDetailsResolver,
+    };
+}

--- a/src/dashboard/sections/projectServices.ts
+++ b/src/dashboard/sections/projectServices.ts
@@ -1,0 +1,54 @@
+'use strict';
+
+import * as vscode from 'vscode';
+
+import ColorService from '../../services/colorService';
+import ProjectService from '../../services/projectService';
+import ProjectWindowColorService from '../../services/projectWindowColorService';
+import FileService from '../../services/fileService';
+import GitRepositoryDetector from '../../projects/gitRepositoryDetector';
+
+/**
+ * Composition section (MOD-DASHBOARD-SHELL): the leaf project/catalog
+ * services with no inter-module wiring. Extracted from the composition root
+ * so dashboard.ts keeps ordering and cross-domain wiring only.
+ */
+export interface ProjectServicesDeps {
+    context: vscode.ExtensionContext;
+    logDashboardDiagnostic: (event: Record<string, unknown>) => void;
+}
+
+export interface ProjectServices {
+    colorService: ColorService;
+    projectService: ProjectService;
+    projectWindowColorService: ProjectWindowColorService;
+    fileService: FileService;
+    gitRepositoryDetector: GitRepositoryDetector;
+}
+
+export function createProjectServices(deps: ProjectServicesDeps): ProjectServices {
+    const { context, logDashboardDiagnostic } = deps;
+    const colorService = new ColorService(context);
+    const projectService = new ProjectService(context, colorService, {
+        onDiagnostic: event => logDashboardDiagnostic(event),
+        onConflict: projectIds => {
+            logDashboardDiagnostic({
+                event: 'project-catalog-sync-conflict-recovered',
+                projectIds,
+            });
+            void vscode.window.showInformationMessage(
+                'Agent Pivot recovered projects from a sync conflict.'
+            );
+        },
+    });
+    const projectWindowColorService = new ProjectWindowColorService(context);
+    const fileService = new FileService(context);
+    const gitRepositoryDetector = new GitRepositoryDetector();
+    return {
+        colorService,
+        projectService,
+        projectWindowColorService,
+        fileService,
+        gitRepositoryDetector,
+    };
+}

--- a/src/dashboard/sections/runtimeStack.ts
+++ b/src/dashboard/sections/runtimeStack.ts
@@ -1,0 +1,179 @@
+'use strict';
+
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+import AiSessionTerminalBindingStore from '../../aiSessions/terminalBindingStore';
+import AiSessionTerminalService from '../../aiSessions/terminalService';
+import { TmuxRuntimeBindingStore } from '../../aiSessions/tmuxRuntimeBindingStore';
+import { TmuxAttachBindingStore } from '../../aiSessions/tmuxAttachBindingStore';
+import { TmuxClient } from '../../aiSessions/tmuxClient';
+import {
+    TmuxRuntimeDiscovery,
+    isCurrentRuntimeMarker,
+} from '../../aiSessions/tmuxRuntimeDiscovery';
+import { withTmuxCreationLock } from '../../aiSessions/tmuxCreationLock';
+import { ProcCodexRootThreadObserver } from '../../aiSessions/codexRootThreadObserver';
+import { readAiSessionRuntimeConfiguration } from '../../aiSessions/runtimeConfiguration';
+import { getAgentPivotConfiguration } from '../../configuration';
+import type { AiSessionProviderId } from '../../models';
+import type { AiSessionProvider } from '../../aiSessions/types';
+import type AiSessionAliasController from '../../aiSessions/aliasController';
+import type AiSessionProfileController from '../../aiSessions/sessionProfileController';
+import type { CurrentWorkspaceSessionAuthority } from '../../workspaces/currentWorkspaceSessionAuthority';
+import type { ConversationSessionRebindCoordinator } from '../../aiSessions/conversation/sessionRebindCoordinator';
+
+type ConversationSessionTarget = {
+    projectId: string;
+    provider: AiSessionProviderId;
+    sessionId: string;
+};
+
+/**
+ * Composition section (MOD-DASHBOARD-SHELL): the runtime stores, terminal
+ * service, tmux client, and runtime discovery with its rebind wiring.
+ * Extracted from the composition root; construction order is unchanged and
+ * the section is invoked where the terminal binding store was constructed.
+ */
+export interface RuntimeStackDeps {
+    context: vscode.ExtensionContext;
+    logError: (message: string, error: unknown) => void;
+    logAiSessionRuntimeFailure: (operation: string, error: unknown) => void;
+    aiSessionProviders: readonly AiSessionProvider[];
+    aiSessionAliasController: AiSessionAliasController;
+    aiSessionProfileController: AiSessionProfileController;
+    currentWorkspaceSessionAuthority: CurrentWorkspaceSessionAuthority;
+    getConversationSessionRebindCoordinator: () => ConversationSessionRebindCoordinator;
+    getFollowConversationSessionRebind: () => (
+        previous: ConversationSessionTarget,
+        next: ConversationSessionTarget
+    ) => Promise<boolean>;
+    getFreezeConversationSessionMetadata: () => (
+        target: ConversationSessionTarget
+    ) => Promise<boolean>;
+}
+
+export function createRuntimeStack(deps: RuntimeStackDeps) {
+    const { context, logError, logAiSessionRuntimeFailure } = deps;
+
+    const aiSessionTerminalBindingStore = new AiSessionTerminalBindingStore(context.workspaceState, error =>
+        logError('Failed to persist AI session terminal ownership.', error)
+    );
+    const aiSessionTerminalService = new AiSessionTerminalService(
+        context.globalStoragePath,
+        deps.aiSessionProviders,
+        undefined,
+        undefined,
+        aiSessionTerminalBindingStore
+    );
+    const aiSessionRuntimeConfiguration = readAiSessionRuntimeConfiguration(
+        getAgentPivotConfiguration()
+    );
+    const tmuxRuntimeStore = new TmuxRuntimeBindingStore(
+        path.join(context.globalStoragePath, 'ai-session-tmux-runtimes'),
+        () => Date.now(),
+        operation => withTmuxCreationLock(
+            context.globalStoragePath,
+            'runtime-binding-final-records',
+            operation
+        )
+    );
+    const tmuxAttachBindingStore = new TmuxAttachBindingStore(context.workspaceState, error => {
+        logAiSessionRuntimeFailure('persist-attach-binding', error);
+    });
+    const tmuxClient = new TmuxClient(aiSessionRuntimeConfiguration.tmuxPath);
+    const tmuxRuntimeDiscovery = new TmuxRuntimeDiscovery({
+        client: tmuxClient,
+        bindingStore: tmuxRuntimeStore,
+        codexRootThreadObserver: new ProcCodexRootThreadObserver(),
+        onSessionRebinding: async (previous, next) => {
+            const projectId = deps.currentWorkspaceSessionAuthority.getProjectId(
+                previous
+            );
+            if (!projectId || !previous.sessionId || !next.sessionId
+                || previous.provider !== next.provider
+                || previous.workspaceNavigationIdentity
+                    !== next.workspaceNavigationIdentity) {
+                throw new Error('Invalid conversation Session rebind identity.');
+            }
+            await deps.getConversationSessionRebindCoordinator().prepare({
+                projectId,
+                provider: previous.provider,
+                sessionId: previous.sessionId,
+            }, {
+                projectId,
+                provider: next.provider,
+                sessionId: next.sessionId,
+            });
+        },
+        onSessionRebound: async (previous, next) => {
+            deps.aiSessionAliasController.copyForRebind(
+                previous.provider,
+                previous.sessionId || '',
+                next.sessionId || ''
+            );
+            deps.aiSessionProfileController.copyForRebind(
+                previous.provider,
+                previous.sessionId || '',
+                next.sessionId || ''
+            );
+            const projectId = deps.currentWorkspaceSessionAuthority.getProjectId(
+                previous
+            );
+            if (!projectId || !previous.sessionId || !next.sessionId
+                || previous.provider !== next.provider
+                || previous.workspaceNavigationIdentity
+                    !== next.workspaceNavigationIdentity) {
+                return;
+            }
+            const previousTarget = {
+                projectId,
+                provider: previous.provider,
+                sessionId: previous.sessionId,
+            };
+            const nextTarget = {
+                projectId,
+                provider: next.provider,
+                sessionId: next.sessionId,
+            };
+            await deps.getFreezeConversationSessionMetadata()(previousTarget);
+            try {
+                await deps.getConversationSessionRebindCoordinator().commit(
+                    previousTarget,
+                    nextTarget
+                );
+            } catch (error) {
+                logAiSessionRuntimeFailure(
+                    'migrate-conversation-session-rebind',
+                    error
+                );
+            }
+            if (deps.getConversationSessionRebindCoordinator().resolve(previousTarget)
+                .sessionId !== nextTarget.sessionId) {
+                return;
+            }
+            try {
+                await deps.getFollowConversationSessionRebind()(
+                    previousTarget,
+                    nextTarget
+                );
+            } catch (error) {
+                logAiSessionRuntimeFailure(
+                    'follow-conversation-session-rebind',
+                    error
+                );
+            }
+        },
+        markerIsCurrent: isCurrentRuntimeMarker,
+    });
+
+    return {
+        aiSessionTerminalBindingStore,
+        aiSessionTerminalService,
+        aiSessionRuntimeConfiguration,
+        tmuxRuntimeStore,
+        tmuxAttachBindingStore,
+        tmuxClient,
+        tmuxRuntimeDiscovery,
+    };
+}

--- a/src/dashboard/sections/worktreeStack.ts
+++ b/src/dashboard/sections/worktreeStack.ts
@@ -1,0 +1,77 @@
+'use strict';
+
+import * as vscode from 'vscode';
+
+import {
+    GitWorktreeDiscovery,
+    WorktreeBaseRefStore,
+    WorktreeMemberLifecycle,
+    WorktreeProvisioningStore,
+    WorktreeSetupRunner,
+    createWorktreeGroupManifestStore,
+    normalizeWorktreeDirectory,
+    worktreeGroupManifestReaderOf,
+    worktreeGroupManifestWriterOf,
+    worktreeKeysEqual,
+} from '../../worktrees';
+import type { WorktreeKey } from '../../worktrees';
+import { getAgentPivotConfiguration } from '../../configuration';
+import type { AiSessionRuntimeCoordinator } from '../../aiSessions/runtimeCoordinator';
+import type { AiSessionRuntimeSnapshot } from '../../aiSessions/runtimeTypes';
+
+/**
+ * Composition section (MOD-DASHBOARD-SHELL): the worktree lifecycle stores,
+ * discovery, and the runtime-priority helpers. Extracted from the
+ * composition root; construction order is unchanged.
+ */
+export interface WorktreeStackDeps {
+    context: vscode.ExtensionContext;
+    getAiSessionRuntimeCoordinator: () => AiSessionRuntimeCoordinator<vscode.Terminal>;
+}
+
+export function createWorktreeStack(deps: WorktreeStackDeps) {
+    const { context } = deps;
+
+    const worktreeBaseRefStore = new WorktreeBaseRefStore(context.globalState);
+    const worktreeProvisioningStore = new WorktreeProvisioningStore(
+        context.globalState,
+        () => normalizeWorktreeDirectory(
+            getAgentPivotConfiguration().get<unknown>('worktreeDirectory', '.worktrees'))
+    );
+    const worktreeSetupRunner = new WorktreeSetupRunner();
+    const worktreeGroupManifestStore = createWorktreeGroupManifestStore(context.globalState);
+    const worktreeGroupManifestReader = worktreeGroupManifestReaderOf(worktreeGroupManifestStore);
+    const worktreeGroupManifestWriter = worktreeGroupManifestWriterOf(worktreeGroupManifestStore);
+    const worktreeMemberLifecycle = new WorktreeMemberLifecycle(worktreeGroupManifestStore);
+    const gitWorktreeDiscovery = new GitWorktreeDiscovery({
+        getBaseRef: repositoryKey => worktreeBaseRefStore.get(repositoryKey),
+    });
+    const getPriorityWorktreeKeys = (): WorktreeKey[] => [
+        ...deps.getAiSessionRuntimeCoordinator().getActive(),
+        ...deps.getAiSessionRuntimeCoordinator().getPending(),
+    ].reduce((keys: WorktreeKey[], runtime: AiSessionRuntimeSnapshot<vscode.Terminal>) => {
+        const key = runtime.identity.worktreeKey;
+        if (key && !keys.some(candidate => worktreeKeysEqual(candidate, key))) {
+            keys.push({ ...key });
+        }
+        return keys;
+    }, []);
+    const getWorktreePrioritySignature = (): string => JSON.stringify(
+        getPriorityWorktreeKeys()
+            .map(key => [key.repositoryKey, key.canonicalWorktreePath])
+            .sort((left, right) => JSON.stringify(left).localeCompare(JSON.stringify(right)))
+    );
+
+    return {
+        worktreeBaseRefStore,
+        worktreeProvisioningStore,
+        worktreeSetupRunner,
+        worktreeGroupManifestStore,
+        worktreeGroupManifestReader,
+        worktreeGroupManifestWriter,
+        worktreeMemberLifecycle,
+        gitWorktreeDiscovery,
+        getPriorityWorktreeKeys,
+        getWorktreePrioritySignature,
+    };
+}

--- a/tests/contract/todos/commandController.test.js
+++ b/tests/contract/todos/commandController.test.js
@@ -257,6 +257,10 @@ test('TODO-TODO-COMMAND-CONTROLLER-001 routes versioned commands through the pro
     assert.match(capabilitySource, /'todo-command': async e =>/);
     assert.match(capabilitySource, /todoCommandController\.handle\(e\)/);
     assert.match(capabilitySource, /provider\.postMessage\(\{\s*\.\.\.result,\s*searchCatalog:/);
-    assert.match(dashboardSource, /createTodoPanelCapability\(\{/);
+    const panelStackSource = fs.readFileSync(
+        path.join(__dirname, '../../../src/dashboard/sections/panelStack.ts'),
+        'utf8'
+    );
+    assert.match(panelStackSource, /createTodoPanelCapability\(\{/);
     assert.match(dashboardSource, /\.\.\.todoPanel\.handlers,/);
 });

--- a/tests/fixtures/aiSessions/runtimeHostActivationHarness.js
+++ b/tests/fixtures/aiSessions/runtimeHostActivationHarness.js
@@ -323,10 +323,15 @@ async function main() {
         prototype[name] = replacement;
         restores.push(() => { prototype[name] = original; });
     };
+    const compositionSectionsPath = path.join(root, 'out', 'dashboard', 'sections');
+    const isCompositionSource = filename => filename === dashboardPath
+        || (filename && filename.startsWith(compositionSectionsPath + path.sep));
     Module._load = function (request, parent, isMain) {
         if (request === 'vscode') return vscode;
+        const isCompositionRequest = moduleName => isCompositionSource(parent?.filename)
+            && request.endsWith(`/${moduleName}`);
         const loaded = previousLoad.call(this, request, parent, isMain);
-        if (parent?.filename === dashboardPath && request === './workspaces/sessionHydrationController') {
+        if (isCompositionRequest('workspaces/sessionHydrationController')) {
             const Original = loaded.WorkspaceSessionHydrationController;
             return {
                 ...loaded,
@@ -361,7 +366,7 @@ async function main() {
                 },
             };
         }
-        if (parent?.filename === dashboardPath && request === './aiSessions/tmuxRuntimeBindingStore') {
+        if (isCompositionRequest('aiSessions/tmuxRuntimeBindingStore')) {
             const Original = loaded.TmuxRuntimeBindingStore;
             return {
                 ...loaded,
@@ -374,7 +379,7 @@ async function main() {
                 },
             };
         }
-        if (parent?.filename === dashboardPath && request === './aiSessions/tmuxCreationLock') {
+        if (isCompositionRequest('aiSessions/tmuxCreationLock')) {
             return {
                 ...loaded,
                 withTmuxCreationLock: (root, key, operation) => {

--- a/tests/integration/dashboard/helpers/todoPanelHarness.js
+++ b/tests/integration/dashboard/helpers/todoPanelHarness.js
@@ -97,7 +97,7 @@ async function runTodoPanelContract(transform) {
     };
     Module._load = function (request, parent, isMain) {
         if (request === 'vscode') return vscode;
-        if (request === './todos/todoPanelCapability') {
+        if (request.endsWith('/todos/todoPanelCapability')) {
             return loadTransformedModule(todoPanelCapabilityPath, transform);
         }
         return previousLoad.call(this, request, parent, isMain);

--- a/tests/integration/dashboard/todoContent.test.js
+++ b/tests/integration/dashboard/todoContent.test.js
@@ -23,8 +23,8 @@ const styles = fs.readFileSync(
     path.join(__dirname, '../../../media/styles.scss'),
     'utf8'
 );
-const dashboardSource = fs.readFileSync(
-    path.join(__dirname, '../../../src/dashboard.ts'),
+const panelStackSource = fs.readFileSync(
+    path.join(__dirname, '../../../src/dashboard/sections/panelStack.ts'),
     'utf8'
 );
 const todoPanelCapabilitySource = fs.readFileSync(
@@ -116,7 +116,7 @@ test('TODO-MAX-VISIBLE-PER-GROUP-001 applies the configured per-group viewport a
         todoPanelCapabilitySource,
         /maxVisibleTodosPerGroup:\s*getMaxVisibleTodosPerGroup\(config\)/
     );
-    assert.match(dashboardSource, /createTodoPanelCapability\(\{/);
+    assert.match(panelStackSource, /createTodoPanelCapability\(\{/);
     assert.match(
         packageJson,
         /Maximum number of TODO cards visible in each group before the group list scrolls\./

--- a/tests/unit/tooling/architectureGuards.test.js
+++ b/tests/unit/tooling/architectureGuards.test.js
@@ -23,6 +23,7 @@ function writeFixture(t, files) {
 function copyGuardFixture(t, mutationPath, mutate = source => source) {
     const relativePaths = [
         'src/dashboard.ts',
+        'src/dashboard/sections/conversationStack.ts',
         'src/workspaces/currentWorkspaceSessionAuthority.ts',
         'src/openWorkspaces/dashboardController.ts',
         'src/workspaces/sessionHydrationController.ts',

--- a/tests/unit/tooling/architectureGuards.test.js
+++ b/tests/unit/tooling/architectureGuards.test.js
@@ -24,6 +24,7 @@ function copyGuardFixture(t, mutationPath, mutate = source => source) {
     const relativePaths = [
         'src/dashboard.ts',
         'src/dashboard/sections/conversationStack.ts',
+        'src/dashboard/sections/runtimeStack.ts',
         'src/workspaces/currentWorkspaceSessionAuthority.ts',
         'src/openWorkspaces/dashboardController.ts',
         'src/workspaces/sessionHydrationController.ts',

--- a/tests/unit/tooling/compositionSources.test.js
+++ b/tests/unit/tooling/compositionSources.test.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const { readCompositionSource } = require('../../../scripts/lib/compositionSources');
+
+function writeFixture(root, files) {
+    for (const [relative, content] of Object.entries(files)) {
+        const target = path.join(root, relative);
+        fs.mkdirSync(path.dirname(target), { recursive: true });
+        fs.writeFileSync(target, content);
+    }
+}
+
+test('composition source reads the root plus sorted section files', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'composition-sources-'));
+    writeFixture(root, {
+        'src/dashboard.ts': '// root',
+        'src/dashboard/sections/bSection.ts': '// b',
+        'src/dashboard/sections/aSection.ts': '// a',
+        'src/dashboard/sections/readme.md': '// not typescript',
+    });
+    const combined = readCompositionSource(root);
+    assert.equal(combined, '// root\n// a\n// b');
+});
+
+test('composition source tolerates a missing sections directory', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'composition-sources-'));
+    writeFixture(root, { 'src/dashboard.ts': '// root only' });
+    assert.equal(readCompositionSource(root), '// root only');
+});


### PR DESCRIPTION
## Summary

B1 of the shell decomposition series: `initializeDashboard` sheds its leaf construction stacks into composition sections under `src/dashboard/sections/`, so the composition root keeps ordering and cross-domain wiring only.

Seven sections, one commit each (pure moves, every commit compiles and passes its focused tests):

1. `projectServices.ts` — the five leaf catalog services.
2. `panelStack.ts` — prompt/skill/todo panels.
3. `projectControllers.ts` — the ten project controllers + two resolvers.
4. `aiSessionStack.ts` — provider services, registry, read coordinator, alias/profile stores.
5. `conversationStack.ts` — conversation stores, the rebind coordinator, viewer adapters.
6. `runtimeStack.ts` — terminal/tmux stores, client, discovery with rebind wiring.
7. `worktreeStack.ts` — worktree lifecycle stores, manifest facades, discovery, priority helpers.

`dashboard.ts`: 3993 → 3581 lines (the composition root still holds the cross-domain wiring, the logic-heavy passes reserved for B2, and the message-handler tables that are the composition root's legitimate content).

Two extraction disciplines landed as durable infrastructure:

- **Tick parity**: async acquisitions (the prompt memento store) stay at the root; section functions are synchronous. The two-stage-startup diagnostics contract pins the exact event order, and an extra microtask in the composition path observably changed it — caught by `runtimeComposition.test.js`.
- **Content anchors follow composition**: the activation harness's module interceptions now match by resolved location (`out/dashboard/sections/**` included), and check scripts read the combined composition surface via the new `scripts/lib/compositionSources.js` instead of pinning `src/dashboard.ts` alone.

## Skill harvest

none

## Owner approvals

Copy the line below into a PR comment (binds the exact head SHA and expires when the head moves):

```
approve 12813acd26970e288e5e96f4e7ed75660c92891e
```

## Verification

- `npm run test-compile` — pass
- `node --test tests/unit/**` 1181 / `tests/contract/**` 1182 / `tests/browser/**` 322 / `tests/integration/**` 438 — all pass
- `npm run test:safety:run` / `run-dashboard-webview-checks.js` / `test:architecture-policy` / `test:architecture-guards` — pass
- changed-line coverage gate — pass
- `npm run test:behavior-contracts` / `lint:ci` — pass; `git diff --check` — clean
