### PR TITLE
refactor(worktrees): own the crash-recovery and member-freeze rules (B2)

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -296,6 +296,7 @@ import {
 } from './dashboard/worktreeGroupFormHandlers';
 import {
     normalizeWorktreeSetupCommand,
+    resolveMemberSetupCommand,
     WorktreeSetupRunner,
 } from './worktrees';
 import { ManagedWorktreeRemovalController } from './worktrees';
@@ -1367,20 +1368,14 @@ async function initializeDashboard(
         // Resource-scoped per repository (PRD §6.1): a cross-repo group can
         // mix Node/Java/Go stacks, so each member reads its own folder's
         // setup override.
-        getSetupCommand: repositoryKey => {
-            const workspace = getCurrentOpenWorkspace();
-            const repository = worktreeSnapshotCoordinator.getSnapshot()
-                ?.repositories.find(candidate =>
-                    candidate.repositoryKey === repositoryKey);
-            const binding = repository?.rootBindings.find(candidate =>
-                workspace?.roots.some(root => root.id === candidate.workspaceRootId));
-            const root = workspace?.roots.find(candidate =>
-                candidate.id === binding?.workspaceRootId);
-            return normalizeWorktreeSetupCommand(
-                getAgentPivotConfiguration(
-                    root ? vscode.Uri.parse(root.uri) : undefined
-                ).get<unknown>('worktreeSetupCommand', []));
-        },
+        getSetupCommand: repositoryKey => resolveMemberSetupCommand({
+            repositoryKey,
+            snapshot: worktreeSnapshotCoordinator.getSnapshot(),
+            workspaceRoots: getCurrentOpenWorkspace()?.roots || [],
+            readSetupCommand: scopeUri => getAgentPivotConfiguration(
+                scopeUri ? vscode.Uri.parse(scopeUri) : undefined
+            ).get<unknown>('worktreeSetupCommand', []),
+        }),
         getWorktreeDirectory: () => normalizeWorktreeDirectory(
             getAgentPivotConfiguration().get<unknown>('worktreeDirectory', '.worktrees')),
         getActiveEditorPath: () => vscode.window.activeTextEditor?.document.uri.fsPath,

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -325,7 +325,7 @@ import { fallbackRepositoryLabel } from './workspaces/worktreeGroupProjection';
 import { handleAdoptWorktrees } from './worktrees';
 import type { WorktreeAdoptSettlement } from './worktrees';
 import type { WorktreeGroupMergeSettlement } from './worktrees';
-import { createGenerationClaimRecovery } from './worktrees';
+import { createGenerationClaimRecovery, createMemberSessionFreeze } from './worktrees';
 import {
     acceptedIsolatedSessionSettlement,
     cancelledMutationSettlement,
@@ -1653,33 +1653,9 @@ async function initializeDashboard(
     // unavailable contribute nothing; their sessions still fail closed to
     // the retired generation through the creation-time/unknown rules, so
     // an incomplete snapshot never mislabels an old session as current.
-    const snapshotMemberAffectedSessions = async (member: {
-        worktreeKey?: { repositoryKey: string; canonicalWorktreePath: string };
-        path: string;
-    }) => {
-        const memberPath = normalizeWorkspaceHostPath(
-            member.worktreeKey?.canonicalWorktreePath || member.path);
-        if (!memberPath) {
-            return [];
-        }
-        const results = aiSessionReadCoordinator.getResults({
-            candidatePaths: [member.path],
-            reason: 'worktree-deletion-snapshot',
-        });
-        const frozen: { provider: string; sessionId: string }[] = [];
-        for (const [providerId, result] of Object.entries(results)) {
-            if (!result.available) {
-                continue;
-            }
-            for (const session of result.sessions) {
-                const cwd = normalizeWorkspaceHostPath(session.cwd || '');
-                if (cwd && isWorkspaceHostPathContained(memberPath, cwd)) {
-                    frozen.push({ provider: providerId, sessionId: session.id });
-                }
-            }
-        }
-        return frozen;
-    };
+    const snapshotMemberAffectedSessions = createMemberSessionFreeze({
+        getResults: input => aiSessionReadCoordinator.getResults(input),
+    });
     worktreeDeletionController = new WorktreeDeletionController({
         store: worktreeGroupManifestStore,
         recheckBlocker: (_group, member) => member.worktreeKey

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -325,7 +325,7 @@ import { fallbackRepositoryLabel } from './workspaces/worktreeGroupProjection';
 import { handleAdoptWorktrees } from './worktrees';
 import type { WorktreeAdoptSettlement } from './worktrees';
 import type { WorktreeGroupMergeSettlement } from './worktrees';
-import { resolveGenerationClaimDisposition } from './worktrees';
+import { createGenerationClaimRecovery } from './worktrees';
 import {
     acceptedIsolatedSessionSettlement,
     cancelledMutationSettlement,
@@ -1033,58 +1033,13 @@ async function initializeDashboard(
     // provider inventories cannot prove a negative), so claims are released
     // only by the in-process compensating delete, by promotion, or by
     // explicit retired-record cleanup.
-    const reconcilePendingGenerationClaims = async (workspace: OpenWorkspace) => {
-        const identity = workspace.navigationIdentity;
-        const pendingClaims = worktreeGroupManifestReader.listGenerationClaims(identity)
-            .filter(claim => claim.state === 'pending');
-        if (!pendingClaims.length) {
-            return;
-        }
-        const bindings = aiSessionTerminalBindingStore.listAll();
-        if (!bindings) {
-            // Enumeration failed: absence of evidence is not evidence.
-            return;
-        }
-        const boundByMarkerPath = new Map<string, {
-            provider: string;
-            sessionId: string;
-            navigationIdentity: string;
-            worktreeKey?: import('./worktrees').WorktreeKey;
-        }>();
-        let ambiguous = false;
-        for (const binding of bindings) {
-            if ((binding.state !== 'bound' && binding.state !== 'released')
-                || !binding.markerPath) {
-                continue;
-            }
-            const existing = boundByMarkerPath.get(binding.markerPath);
-            // Session identity is the composite {provider, sessionId} plus
-            // the owning bucket and worktree key: any half differing makes
-            // the marker ambiguous.
-            if (existing && (existing.sessionId !== binding.sessionId
-                || existing.provider !== binding.providerId
-                || existing.navigationIdentity !== binding.workspaceNavigationIdentity
-                || !worktreeKeysMatch(existing.worktreeKey, binding.worktreeKey))) {
-                ambiguous = true;
-                break;
-            }
-            boundByMarkerPath.set(binding.markerPath, {
-                provider: binding.providerId,
-                sessionId: binding.sessionId,
-                navigationIdentity: binding.workspaceNavigationIdentity,
-                ...(binding.worktreeKey ? { worktreeKey: binding.worktreeKey } : {}),
-            });
-        }
-        if (ambiguous) {
-            logError('Ambiguous terminal bindings skipped during claim reconciliation.', null);
-            return;
-        }
-        await worktreeGroupManifestWriter.reconcileGenerationClaims(identity, claim =>
-            resolveGenerationClaimDisposition(claim, {
-                navigationIdentity: identity,
-                boundSessionByMarkerPath: boundByMarkerPath,
-            }));
-    };
+    const reconcilePendingGenerationClaims = createGenerationClaimRecovery({
+        listGenerationClaims: identity => worktreeGroupManifestReader.listGenerationClaims(identity),
+        reconcileGenerationClaims: (identity, resolve) =>
+            worktreeGroupManifestWriter.reconcileGenerationClaims(identity, resolve),
+        listTerminalBindings: () => aiSessionTerminalBindingStore.listAll(),
+        logError,
+    });
     const workspacePendingSessionPromotionController =
         new WorkspacePendingSessionPromotionController<vscode.Terminal>({
             providers: aiSessionProviders,

--- a/src/worktrees/generationClaimRecovery.ts
+++ b/src/worktrees/generationClaimRecovery.ts
@@ -1,0 +1,105 @@
+'use strict';
+
+import type { GenerationClaim } from './retiredWorktrees';
+import type { WorktreeKey } from './types';
+import { worktreeKeysMatch } from '../worktreeIdentity';
+import { resolveGenerationClaimDisposition } from './generationClaimReconciliation';
+import type { GenerationClaimDisposition } from './generationClaimReconciliation';
+
+/**
+ * Crash-recovery pass for pending generation claims (PRD §6.4): the runtime
+ * promotion and the generation-claim promotion are separate writes, so a
+ * crash (or a transient memento failure) between them strands a pending
+ * claim whose runtime no longer exists. This idempotent pass re-attaches the
+ * session id from the durable terminal binding (same unique launch marker
+ * path). It never discards: no post-hoc channel can authoritatively prove a
+ * launch never happened (markers are cleaned up on terminal close and
+ * provider inventories cannot prove a negative), so claims are released only
+ * by the in-process compensating delete, by promotion, or by explicit
+ * retired-record cleanup.
+ *
+ * Extracted from the composition root (dashboard.ts) during the shell
+ * decomposition; behavior is byte-identical.
+ */
+/**
+ * The binding view the recovery pass reads. Structural on purpose: the
+ * worktree domain must not import the AI session module (red line
+ * ARCH-SESSION-WORKTREE-001), so the composition root adapts the real
+ * terminal-binding union onto this shape.
+ */
+export type GenerationClaimTerminalBinding = {
+    providerId: string;
+    workspaceNavigationIdentity: string;
+    markerPath?: string;
+    worktreeKey?: WorktreeKey;
+} & (
+    | { state: 'pending' }
+    | { state: 'bound' | 'released'; sessionId: string }
+);
+
+export interface GenerationClaimRecoveryDeps {
+    listGenerationClaims: (navigationIdentity: string) => GenerationClaim[];
+    reconcileGenerationClaims: (
+        navigationIdentity: string,
+        resolve: (claim: GenerationClaim) => GenerationClaimDisposition
+    ) => Promise<unknown>;
+    listTerminalBindings: () => readonly GenerationClaimTerminalBinding[] | null;
+    logError: (message: string, error: unknown) => void;
+}
+
+export function createGenerationClaimRecovery(
+    deps: GenerationClaimRecoveryDeps
+): (workspace: { navigationIdentity: string }) => Promise<void> {
+    return async workspace => {
+        const identity = workspace.navigationIdentity;
+        const pendingClaims = deps.listGenerationClaims(identity)
+            .filter(claim => claim.state === 'pending');
+        if (!pendingClaims.length) {
+            return;
+        }
+        const bindings = deps.listTerminalBindings();
+        if (!bindings) {
+            // Enumeration failed: absence of evidence is not evidence.
+            return;
+        }
+        const boundByMarkerPath = new Map<string, {
+            provider: string;
+            sessionId: string;
+            navigationIdentity: string;
+            worktreeKey?: WorktreeKey;
+        }>();
+        let ambiguous = false;
+        for (const binding of bindings) {
+            if ((binding.state !== 'bound' && binding.state !== 'released')
+                || !binding.markerPath) {
+                continue;
+            }
+            const existing = boundByMarkerPath.get(binding.markerPath);
+            // Session identity is the composite {provider, sessionId} plus
+            // the owning bucket and worktree key: any half differing makes
+            // the marker ambiguous.
+            if (existing && (existing.sessionId !== binding.sessionId
+                || existing.provider !== binding.providerId
+                || existing.navigationIdentity !== binding.workspaceNavigationIdentity
+                || !worktreeKeysMatch(existing.worktreeKey, binding.worktreeKey))) {
+                ambiguous = true;
+                break;
+            }
+            boundByMarkerPath.set(binding.markerPath, {
+                provider: binding.providerId,
+                sessionId: binding.sessionId,
+                navigationIdentity: binding.workspaceNavigationIdentity,
+                ...(binding.worktreeKey ? { worktreeKey: binding.worktreeKey } : {}),
+            });
+        }
+        if (ambiguous) {
+            deps.logError('Ambiguous terminal bindings skipped during claim reconciliation.', null);
+            return;
+        }
+        await deps.reconcileGenerationClaims(identity, claim =>
+            resolveGenerationClaimDisposition(claim, {
+                navigationIdentity: identity,
+                boundSessionByMarkerPath: boundByMarkerPath,
+            }));
+    };
+}

--- a/src/worktrees/index.ts
+++ b/src/worktrees/index.ts
@@ -31,6 +31,7 @@ export { WorktreeMemberLifecycle } from './memberLifecycle';
 export { reconcileWorktreeGroupManifest } from './groupManifestReconciliation';
 export { resolveGenerationClaimDisposition } from './generationClaimReconciliation';
 export { createGenerationClaimRecovery } from './generationClaimRecovery';
+export { createMemberSessionFreeze } from './memberSessionFreeze';
 export { createSettlementReplayCache } from './settlementReplayCache';
 export {
     findLatestRetirementForKey,

--- a/src/worktrees/index.ts
+++ b/src/worktrees/index.ts
@@ -55,7 +55,7 @@ export { GitWorktreeProvisioner } from './gitWorktreeProvisioner';
 export { GitWorktreeDiscovery } from './gitWorktreeDiscovery';
 export { GitRepositoryStateMonitor } from './gitRepositoryStateMonitor';
 export type { GitApiLike } from './gitRepositoryStateMonitor';
-export { WorktreeSetupRunner, normalizeWorktreeSetupCommand } from './worktreeSetupRunner';
+export { WorktreeSetupRunner, normalizeWorktreeSetupCommand, resolveMemberSetupCommand } from './worktreeSetupRunner';
 export { normalizeWorktreeDirectory } from './provisioningPlan';
 
 // Webview message handlers and their protocol settlements.

--- a/src/worktrees/index.ts
+++ b/src/worktrees/index.ts
@@ -30,6 +30,7 @@ export { WorktreeBaseRefStore } from './baseRefStore';
 export { WorktreeMemberLifecycle } from './memberLifecycle';
 export { reconcileWorktreeGroupManifest } from './groupManifestReconciliation';
 export { resolveGenerationClaimDisposition } from './generationClaimReconciliation';
+export { createGenerationClaimRecovery } from './generationClaimRecovery';
 export { createSettlementReplayCache } from './settlementReplayCache';
 export {
     findLatestRetirementForKey,

--- a/src/worktrees/memberSessionFreeze.ts
+++ b/src/worktrees/memberSessionFreeze.ts
@@ -1,0 +1,60 @@
+'use strict';
+
+import {
+    isWorkspaceHostPathContained,
+    normalizeWorkspaceHostPath,
+} from '../sessionAssignment';
+
+/**
+ * Member-freeze rule for worktree deletion (MOD-WORKTREE-LIFECYCLE): a
+ * session is frozen into the member's deletion snapshot when its working
+ * directory lies inside the member's canonical worktree path. Unavailable
+ * providers contribute nothing. Structural session/read types keep the
+ * worktree domain free of AI-session imports (ARCH-SESSION-WORKTREE-001).
+ *
+ * Extracted from the composition root (dashboard.ts) during the shell
+ * decomposition; behavior is byte-identical.
+ */
+export interface FrozenMemberSession {
+    provider: string;
+    sessionId: string;
+}
+
+export interface MemberSessionFreezeDeps {
+    getResults: (input: { candidatePaths: string[]; reason: string }) => Record<string, {
+        available?: boolean;
+        sessions: readonly { id: string; cwd?: string }[];
+    }>;
+}
+
+export function createMemberSessionFreeze(
+    deps: MemberSessionFreezeDeps
+): (member: {
+    worktreeKey?: { repositoryKey: string; canonicalWorktreePath: string };
+    path: string;
+}) => Promise<FrozenMemberSession[]> {
+    return async member => {
+        const memberPath = normalizeWorkspaceHostPath(
+            member.worktreeKey?.canonicalWorktreePath || member.path);
+        if (!memberPath) {
+            return [];
+        }
+        const results = deps.getResults({
+            candidatePaths: [member.path],
+            reason: 'worktree-deletion-snapshot',
+        });
+        const frozen: FrozenMemberSession[] = [];
+        for (const [providerId, result] of Object.entries(results)) {
+            if (!result.available) {
+                continue;
+            }
+            for (const session of result.sessions) {
+                const cwd = normalizeWorkspaceHostPath(session.cwd || '');
+                if (cwd && isWorkspaceHostPathContained(memberPath, cwd)) {
+                    frozen.push({ provider: providerId, sessionId: session.id });
+                }
+            }
+        }
+        return frozen;
+    };
+}

--- a/src/worktrees/worktreeSetupRunner.ts
+++ b/src/worktrees/worktreeSetupRunner.ts
@@ -71,6 +71,36 @@ export class WorktreeSetupRunner {
     }
 }
 
+/**
+ * Resource-scoped per repository (PRD §6.1): a cross-repo group can mix
+ * Node/Java/Go stacks, so each member reads its own folder's setup override.
+ * Resolves the member repository's bound workspace root and reads the setup
+ * command at that root's scope.
+ *
+ * Extracted from the composition root during the shell decomposition; the
+ * host URI plumbing stays with the caller.
+ */
+export function resolveMemberSetupCommand(input: {
+    repositoryKey: string;
+    snapshot: {
+        repositories: readonly {
+            repositoryKey: string;
+            rootBindings: readonly { workspaceRootId: string }[];
+        }[];
+    } | null;
+    workspaceRoots: readonly { id: string; uri: string }[] | null;
+    readSetupCommand: (scopeUri?: string) => unknown;
+}): string[] {
+    const workspaceRoots = input.workspaceRoots || [];
+    const repository = input.snapshot?.repositories.find(candidate =>
+        candidate.repositoryKey === input.repositoryKey);
+    const binding = repository?.rootBindings.find(candidate =>
+        workspaceRoots.some(root => root.id === candidate.workspaceRootId));
+    const root = workspaceRoots.find(candidate =>
+        candidate.id === binding?.workspaceRootId);
+    return normalizeWorktreeSetupCommand(input.readSetupCommand(root?.uri));
+}
+
 export function normalizeWorktreeSetupCommand(value: unknown): string[] {
     if (!Array.isArray(value) || value.length === 0 || value.length > MAX_SETUP_ARG_COUNT) {
         return [];

--- a/tests/unit/worktrees/generationClaimRecovery.test.js
+++ b/tests/unit/worktrees/generationClaimRecovery.test.js
@@ -1,0 +1,84 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const { createGenerationClaimRecovery } = require('../../../out/worktrees/generationClaimRecovery');
+
+const WORKSPACE = { navigationIdentity: 'nav:one' };
+const CLAIM = {
+    state: 'pending',
+    launchMarkerPath: '/markers/m1',
+    worktreeKey: { repositoryKey: '/repo/.git', canonicalWorktreePath: '/repo/wt' },
+};
+
+function createHarness(overrides = {}) {
+    const calls = { reconciled: [], errors: [] };
+    const recover = createGenerationClaimRecovery({
+        listGenerationClaims: () => overrides.claims ?? [CLAIM],
+        reconcileGenerationClaims: async (identity, resolve) => {
+            calls.reconciled.push((overrides.claims ?? [CLAIM]).map(claim => resolve(claim).kind));
+        },
+        listTerminalBindings: () => 'bindings' in overrides ? overrides.bindings : [],
+        logError: message => calls.errors.push(message),
+        ...overrides.deps,
+    });
+    return { recover, calls };
+}
+
+test('claim recovery keeps claims when bindings are absent, missing, or ambiguous', async () => {
+    // No bindings at all: enumeration failed is not evidence.
+    const none = createHarness({ bindings: null });
+    await none.recover(WORKSPACE);
+    assert.deepEqual(none.calls.reconciled, []);
+
+    // No claim has a launch marker path: nothing to resolve.
+    const noMarker = createHarness({ claims: [{ state: 'pending' }] });
+    await noMarker.recover(WORKSPACE);
+    assert.deepEqual(noMarker.calls.reconciled, [['keep']]);
+
+    // Duplicate marker paths across different sessions: ambiguous, fail closed.
+    const ambiguous = createHarness({
+        bindings: [
+            { state: 'bound', providerId: 'codex', sessionId: 'a', workspaceNavigationIdentity: 'nav:one', markerPath: '/markers/m1', worktreeKey: CLAIM.worktreeKey },
+            { state: 'released', providerId: 'kimi', sessionId: 'b', workspaceNavigationIdentity: 'nav:one', markerPath: '/markers/m1', worktreeKey: CLAIM.worktreeKey },
+        ],
+    });
+    await ambiguous.recover(WORKSPACE);
+    assert.deepEqual(ambiguous.calls.reconciled, []);
+    assert.equal(ambiguous.calls.errors.length, 1);
+});
+
+test('claim recovery promotes only the exactly matching bound session', async () => {
+    const exact = createHarness({
+        bindings: [{
+            state: 'bound',
+            providerId: 'codex',
+            sessionId: 'sess-1',
+            workspaceNavigationIdentity: 'nav:one',
+            markerPath: '/markers/m1',
+            worktreeKey: CLAIM.worktreeKey,
+        }],
+    });
+    await exact.recover(WORKSPACE);
+    assert.deepEqual(exact.calls.reconciled, [['promote']]);
+
+    const wrongBucket = createHarness({
+        bindings: [{
+            state: 'bound',
+            providerId: 'codex',
+            sessionId: 'sess-1',
+            workspaceNavigationIdentity: 'nav:other',
+            markerPath: '/markers/m1',
+            worktreeKey: CLAIM.worktreeKey,
+        }],
+    });
+    await wrongBucket.recover(WORKSPACE);
+    assert.deepEqual(wrongBucket.calls.reconciled, [['keep']]);
+});
+
+test('claim recovery is a no-op without pending claims', async () => {
+    const harness = createHarness({ claims: [] });
+    await harness.recover(WORKSPACE);
+    assert.deepEqual(harness.calls.reconciled, []);
+    assert.deepEqual(harness.calls.errors, []);
+});

--- a/tests/unit/worktrees/memberSessionFreeze.test.js
+++ b/tests/unit/worktrees/memberSessionFreeze.test.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const { createMemberSessionFreeze } = require('../../../out/worktrees/memberSessionFreeze');
+
+test('member session freeze prefers the canonical worktree key path and freezes contained sessions', async () => {
+    const freeze = createMemberSessionFreeze({
+        getResults: () => ({
+            codex: {
+                available: true,
+                sessions: [
+                    { id: 'in', cwd: '/repo/wt/src' },
+                    { id: 'out', cwd: '/elsewhere' },
+                    { id: 'nocwd', cwd: '' },
+                ],
+            },
+            kimi: { available: false, sessions: [{ id: 'skipped', cwd: '/repo/wt' }] },
+        }),
+    });
+    const frozen = await freeze({
+        worktreeKey: { repositoryKey: '/repo/.git', canonicalWorktreePath: '/repo/wt' },
+        path: '/ignored',
+    });
+    assert.deepEqual(frozen, [{ provider: 'codex', sessionId: 'in' }]);
+});
+
+test('member session freeze falls back to the member path and blanks missing paths', async () => {
+    const seen = [];
+    const freeze = createMemberSessionFreeze({
+        getResults: input => {
+            seen.push(input);
+            return {};
+        },
+    });
+    assert.deepEqual(await freeze({ path: '/repo/wt/' }), []);
+    assert.equal(seen[0].candidatePaths[0], '/repo/wt/');
+    assert.equal(seen[0].reason, 'worktree-deletion-snapshot');
+    assert.deepEqual(await freeze({ path: '' }), []);
+});

--- a/tests/unit/worktrees/resolveMemberSetupCommand.test.js
+++ b/tests/unit/worktrees/resolveMemberSetupCommand.test.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const { resolveMemberSetupCommand } = require('../../../out/worktrees/worktreeSetupRunner');
+
+const SNAPSHOT = {
+    repositories: [{
+        repositoryKey: '/repo/.git',
+        rootBindings: [{ workspaceRootId: 'api' }],
+    }],
+};
+const ROOTS = [
+    { id: 'api', uri: 'file:///repo/packages/api' },
+    { id: 'web', uri: 'file:///repo/packages/web' },
+];
+
+test('resolveMemberSetupCommand reads the command at the bound workspace root scope', () => {
+    const scopes = [];
+    const command = resolveMemberSetupCommand({
+        repositoryKey: '/repo/.git',
+        snapshot: SNAPSHOT,
+        workspaceRoots: ROOTS,
+        readSetupCommand: scopeUri => {
+            scopes.push(scopeUri);
+            return ['npm', 'run', 'setup'];
+        },
+    });
+    assert.deepEqual(command, ['npm', 'run', 'setup']);
+    assert.deepEqual(scopes, ['file:///repo/packages/api']);
+});
+
+test('resolveMemberSetupCommand falls back to the unscoped configuration', () => {
+    const scopes = [];
+    const command = resolveMemberSetupCommand({
+        repositoryKey: '/missing/.git',
+        snapshot: SNAPSHOT,
+        workspaceRoots: ROOTS,
+        readSetupCommand: scopeUri => {
+            scopes.push(scopeUri);
+            return 'not-an-array';
+        },
+    });
+    assert.deepEqual(command, []);
+    assert.deepEqual(scopes, [undefined]);
+});
+
+test('resolveMemberSetupCommand tolerates null snapshot and roots', () => {
+    const command = resolveMemberSetupCommand({
+        repositoryKey: '/repo/.git',
+        snapshot: null,
+        workspaceRoots: null,
+        readSetupCommand: () => ['make'],
+    });
+    assert.deepEqual(command, ['make']);
+});


### PR DESCRIPTION
## Summary

B2 of the shell decomposition series: the logic-heavy passes leave the composition root for their owning module (MOD-WORKTREE-LIFECYCLE).

Three extractions, one commit each, behavior byte-identical:

1. **`generationClaimRecovery.ts`** — the PRD §6.4 crash-recovery pass (re-attaching pending generation claims from durable terminal bindings) moves next to the disposition resolver it drives.
2. **`memberSessionFreeze.ts`** — the worktree-deletion session-freeze rule (freeze sessions whose cwd lies inside the member worktree).
3. **`resolveMemberSetupCommand`** — the PRD §6.1 per-repository setup-command rule joins `worktreeSetupRunner.ts`, its normalization owner.

Design note: the worktree domain's red line `ARCH-SESSION-WORKTREE-001` (no AI-session imports, enforced) forced structural binding/session views in the two new files — the composition root adapts the real unions. This caught and rejected my first draft which type-imported the binding store.

`dashboard.ts`: 3581 → 3507 lines; the remaining composition content is wiring, which the charter permits at the root.

## Skill harvest

none

## Owner approvals

Copy the line below into a PR comment (binds the exact head SHA and expires when the head moves):

```
approve 969fd2b91cfc92e89554ff143970684f8e246024
```

## Verification

- `npm run test-compile` — pass
- `node --test tests/unit/**` 1183 / `tests/contract/**` 1182 / `tests/browser/**` 322 — all pass
- `npm run test:safety:run` / `run-dashboard-webview-checks.js` / `test:architecture-policy` / `test:architecture-guards` — pass
- `npm run lint:ci` — pass; `git diff --check` — clean
