### PR TITLE
refactor(webview): converge the conversation viewer globals into one registry namespace (B3)

### DIFF
--- a/docs/testing/architecture-webview-manifest.json
+++ b/docs/testing/architecture-webview-manifest.json
@@ -53,6 +53,7 @@
         "media/mermaid.min.js"
       ],
       "scripts": [
+        "src/webview/conversationRegistryScripts.js",
         "src/webview/conversationReadingAnchorScripts.js",
         "src/webview/conversationMermaidScripts.js",
         "src/webview/conversationOutlineScripts.js",
@@ -97,76 +98,6 @@
       "producer": "src/webview/webviewProjectScripts.js",
       "consumers": [
         "src/webview/webviewProjectAiSessionControlsScripts.js"
-      ]
-    },
-    {
-      "symbol": "window.__agentPivotConversationChanges",
-      "producer": "src/webview/conversationChangesScripts.js",
-      "consumers": [
-        "src/webview/conversationViewerScripts.js"
-      ]
-    },
-    {
-      "symbol": "window.__agentPivotConversationComments",
-      "producer": "src/webview/conversationCommentsScripts.js",
-      "consumers": [
-        "src/webview/conversationViewerScripts.js"
-      ]
-    },
-    {
-      "symbol": "window.__agentPivotConversationFind",
-      "producer": "src/webview/conversationFindScripts.js",
-      "consumers": [
-        "src/webview/conversationViewerScripts.js"
-      ]
-    },
-    {
-      "symbol": "window.__agentPivotConversationMermaid",
-      "producer": "src/webview/conversationMermaidScripts.js",
-      "consumers": [
-        "src/webview/conversationViewerScripts.js"
-      ]
-    },
-    {
-      "symbol": "window.__agentPivotConversationOutline",
-      "producer": "src/webview/conversationOutlineScripts.js",
-      "consumers": [
-        "src/webview/conversationViewerScripts.js"
-      ]
-    },
-    {
-      "symbol": "window.__agentPivotConversationReadingAnchor",
-      "producer": "src/webview/conversationReadingAnchorScripts.js",
-      "consumers": [
-        "src/webview/conversationViewerScripts.js"
-      ]
-    },
-    {
-      "symbol": "window.__agentPivotConversationReconcile",
-      "producer": "src/webview/conversationReconcileScripts.js",
-      "consumers": [
-        "src/webview/conversationViewerScripts.js"
-      ]
-    },
-    {
-      "symbol": "window.__agentPivotConversationSidebar",
-      "producer": "src/webview/conversationSidebarScripts.js",
-      "consumers": [
-        "src/webview/conversationViewerScripts.js"
-      ]
-    },
-    {
-      "symbol": "window.__agentPivotConversationSubagents",
-      "producer": "src/webview/conversationSubagentsScripts.js",
-      "consumers": [
-        "src/webview/conversationViewerScripts.js"
-      ]
-    },
-    {
-      "symbol": "window.__agentPivotConversationTelemetry",
-      "producer": "src/webview/conversationTelemetryScripts.js",
-      "consumers": [
-        "src/webview/conversationViewerScripts.js"
       ]
     },
     {
@@ -343,6 +274,23 @@
     {
       "symbol": "window.vscode",
       "producer": "host"
+    },
+    {
+      "symbol": "window.__agentPivotConversation",
+      "producer": "src/webview/conversationRegistryScripts.js",
+      "consumers": [
+        "src/webview/conversationReadingAnchorScripts.js",
+        "src/webview/conversationMermaidScripts.js",
+        "src/webview/conversationOutlineScripts.js",
+        "src/webview/conversationSubagentsScripts.js",
+        "src/webview/conversationChangesScripts.js",
+        "src/webview/conversationTelemetryScripts.js",
+        "src/webview/conversationCommentsScripts.js",
+        "src/webview/conversationSidebarScripts.js",
+        "src/webview/conversationReconcileScripts.js",
+        "src/webview/conversationFindScripts.js",
+        "src/webview/conversationViewerScripts.js"
+      ]
     }
   ]
 }

--- a/media/conversationChangesScripts.js
+++ b/media/conversationChangesScripts.js
@@ -634,5 +634,5 @@
         };
     }
 
-    window.__agentPivotConversationChanges = { create: create };
+    window.__agentPivotConversation.changes = { create: create };
 }());

--- a/media/conversationCommentsScripts.js
+++ b/media/conversationCommentsScripts.js
@@ -3299,5 +3299,5 @@
         });
     }
 
-    window.__agentPivotConversationComments = Object.freeze({ create: create });
+    window.__agentPivotConversation.comments = Object.freeze({ create: create });
 }());

--- a/media/conversationFindScripts.js
+++ b/media/conversationFindScripts.js
@@ -281,5 +281,5 @@
         });
     }
 
-    window.__agentPivotConversationFind = Object.freeze({ create: create });
+    window.__agentPivotConversation.find = Object.freeze({ create: create });
 }());

--- a/media/conversationMermaidScripts.js
+++ b/media/conversationMermaidScripts.js
@@ -376,5 +376,5 @@
         });
     }
 
-    window.__agentPivotConversationMermaid = Object.freeze({ create: create });
+    window.__agentPivotConversation.mermaid = Object.freeze({ create: create });
 })();

--- a/media/conversationOutlineScripts.js
+++ b/media/conversationOutlineScripts.js
@@ -601,5 +601,5 @@
         });
     }
 
-    window.__agentPivotConversationOutline = Object.freeze({ create: create });
+    window.__agentPivotConversation.outline = Object.freeze({ create: create });
 }());

--- a/media/conversationReadingAnchorScripts.js
+++ b/media/conversationReadingAnchorScripts.js
@@ -130,7 +130,7 @@
         });
     }
 
-    window.__agentPivotConversationReadingAnchor = Object.freeze({
+    window.__agentPivotConversation.readingAnchor = Object.freeze({
         create: create,
     });
 })();

--- a/media/conversationReconcileScripts.js
+++ b/media/conversationReconcileScripts.js
@@ -116,5 +116,5 @@
         });
     }
 
-    window.__agentPivotConversationReconcile = Object.freeze({ create: create });
+    window.__agentPivotConversation.reconcile = Object.freeze({ create: create });
 }());

--- a/media/conversationRegistryScripts.js
+++ b/media/conversationRegistryScripts.js
@@ -1,0 +1,9 @@
+(function () {
+    'use strict';
+
+    // Conversation viewer plugin registry (MOD-DASHBOARD-SHELL, webview
+    // manifest): one declared namespace that the conversation feature scripts
+    // register into and the viewer consumes. Replaces the per-feature
+    // window.__agentPivotConversation* globals.
+    window.__agentPivotConversation = window.__agentPivotConversation || {};
+}());

--- a/media/conversationSidebarScripts.js
+++ b/media/conversationSidebarScripts.js
@@ -263,5 +263,5 @@
         });
     }
 
-    window.__agentPivotConversationSidebar = Object.freeze({ create: create });
+    window.__agentPivotConversation.sidebar = Object.freeze({ create: create });
 }());

--- a/media/conversationSubagentsScripts.js
+++ b/media/conversationSubagentsScripts.js
@@ -178,7 +178,7 @@
         return Object.freeze({ apply: apply, refresh: render });
     }
 
-    window.__agentPivotConversationSubagents = Object.freeze({
+    window.__agentPivotConversation.subagents = Object.freeze({
         create: create,
     });
 }());

--- a/media/conversationTelemetryScripts.js
+++ b/media/conversationTelemetryScripts.js
@@ -284,5 +284,5 @@
         });
     }
 
-    window.__agentPivotConversationTelemetry = Object.freeze({ create: create });
+    window.__agentPivotConversation.telemetry = Object.freeze({ create: create });
 }());

--- a/media/conversationViewerScripts.js
+++ b/media/conversationViewerScripts.js
@@ -253,7 +253,7 @@
         && !!changesGroups && !!changesEmpty
         && !!changesUnavailable && !!changesOpenScm && !!changesCrossMember
         && !!telemetryChanges
-        && !!window.__agentPivotConversationChanges;
+        && !!window.__agentPivotConversation.changes;
     var bookmarkUiAvailable = sidebarUiAvailable
         && validCommentTarget(commentTarget);
     var commentUiAvailable = sidebarUiAvailable
@@ -273,7 +273,7 @@
         && !!subagentsSummary && !!subagentBanner && !!subagentBannerLabel
         && !!subagentsRunningOnly && !!closeSubagent
         && !!telemetrySubagents && !!telemetrySection
-        && !!window.__agentPivotConversationSubagents;
+        && !!window.__agentPivotConversation.subagents;
     var projectCommentUiAvailable = commentUiAvailable
         && !!projectCommentsRoot && !!projectCommentsHeader
         && !!projectCommentsContent && !!projectCommentComposer
@@ -319,7 +319,7 @@
         appliedHtmlSignature: undefined,
     };
     var readingAnchorController =
-        window.__agentPivotConversationReadingAnchor.create({
+        window.__agentPivotConversation.readingAnchor.create({
             scroll: scroll,
             messages: messages,
             messageSelector: conversationMessageSelector,
@@ -329,7 +329,7 @@
     var restoreReadingPosition = readingAnchorController.restore;
     var restoreViewportReadingPosition =
         readingAnchorController.restoreViewport;
-    var mermaidRenderer = window.__agentPivotConversationMermaid.create({
+    var mermaidRenderer = window.__agentPivotConversation.mermaid.create({
         source: mermaidSource,
         nonce: scriptNonce,
         messages: messages,
@@ -341,7 +341,7 @@
     var releaseMermaidObjectUrls = mermaidRenderer.release;
     var renderMermaidDiagrams = mermaidRenderer.render;
     var preserveMermaidContent = mermaidRenderer.preserve;
-    var reconcileController = window.__agentPivotConversationReconcile.create({
+    var reconcileController = window.__agentPivotConversation.reconcile.create({
         scroll: scroll,
         messages: messages,
         messageSelector: conversationMessageSelector,
@@ -363,7 +363,7 @@
     });
     var outlineController;
     var commentsController;
-    var sidebarController = window.__agentPivotConversationSidebar.create({
+    var sidebarController = window.__agentPivotConversation.sidebar.create({
         available: sidebarUiAvailable,
         vscodeApi: vscodeApi,
         sidebarToggle: sidebarToggle,
@@ -386,7 +386,7 @@
         telemetryChanges: telemetryChanges,
     });
     var changesController = changesUiAvailable
-        ? window.__agentPivotConversationChanges.create({
+        ? window.__agentPivotConversation.changes.create({
             post: post,
             telemetryChanges: telemetryChanges,
             telemetryChangesValue: telemetryChangesValue,
@@ -404,7 +404,7 @@
             subscriptionGeneration: state.subscriptionGeneration,
         })
         : null;
-    var outlineController = window.__agentPivotConversationOutline.create({
+    var outlineController = window.__agentPivotConversation.outline.create({
         available: sidebarUiAvailable,
         bookmarkAvailable: bookmarkUiAvailable,
         target: commentTarget,
@@ -424,7 +424,7 @@
         updateToggle: sidebarController.updateToggle,
     });
     var subagentsController = subagentUiAvailable
-        ? window.__agentPivotConversationSubagents.create({
+        ? window.__agentPivotConversation.subagents.create({
             listRoot: subagentsList,
             emptyRoot: subagentsEmpty,
             summaryRoot: subagentsSummary,
@@ -487,7 +487,7 @@
             }
         });
     }
-    var telemetryController = window.__agentPivotConversationTelemetry.create({
+    var telemetryController = window.__agentPivotConversation.telemetry.create({
         target: commentTarget,
         subscriptionGeneration: state.subscriptionGeneration,
         latestRequestId: function () {
@@ -505,7 +505,7 @@
         captureAnchor: captureReadingAnchor,
         restoreViewport: restoreViewportReadingPosition,
     });
-    var commentsController = window.__agentPivotConversationComments.create({
+    var commentsController = window.__agentPivotConversation.comments.create({
         available: commentUiAvailable,
         target: commentTarget,
         subscriptionGeneration: state.subscriptionGeneration,
@@ -554,8 +554,8 @@
         setSidebarView: sidebarController.setView,
         updateToggle: sidebarController.updateToggle,
     });
-    var findController = window.__agentPivotConversationFind
-        ? window.__agentPivotConversationFind.create({
+    var findController = window.__agentPivotConversation.find
+        ? window.__agentPivotConversation.find.create({
             available: findUiAvailable,
             root: findRoot,
             input: findInput,

--- a/scripts/run-release-packaging-checks.js
+++ b/scripts/run-release-packaging-checks.js
@@ -49,6 +49,7 @@ const EXPECTED_MAIN_ENTRIES = Object.freeze([
     'extension/licenses/Mermaid-MIT.txt',
     'extension/media/conversationMermaidScripts.js',
     'extension/media/conversationReadingAnchorScripts.js',
+    'extension/media/conversationRegistryScripts.js',
     'extension/media/conversationOutlineScripts.js',
     'extension/media/conversationTelemetryScripts.js',
     'extension/media/conversationCommentsScripts.js',

--- a/src/aiSessions/conversation/viewerDocument.ts
+++ b/src/aiSessions/conversation/viewerDocument.ts
@@ -77,6 +77,9 @@ export function renderConversationViewerDocument(
     const mermaid = panel.webview.asWebviewUri(
         options.mediaUri('mermaid.min.js')
     );
+    const registryScript = panel.webview.asWebviewUri(
+        options.mediaUri('conversationRegistryScripts.js')
+    );
     const readingAnchorScript = panel.webview.asWebviewUri(
         options.mediaUri('conversationReadingAnchorScripts.js')
     );
@@ -575,6 +578,9 @@ export function renderConversationViewerDocument(
     </div>
     <script nonce="${escapeAttribute(nonce)}" src="${escapeAttribute(
         purify.toString()
+    )}"></script>
+    <script nonce="${escapeAttribute(nonce)}" src="${escapeAttribute(
+        registryScript.toString()
     )}"></script>
     <script nonce="${escapeAttribute(nonce)}" src="${escapeAttribute(
         readingAnchorScript.toString()

--- a/src/webview/conversationChangesScripts.js
+++ b/src/webview/conversationChangesScripts.js
@@ -634,5 +634,5 @@
         };
     }
 
-    window.__agentPivotConversationChanges = { create: create };
+    window.__agentPivotConversation.changes = { create: create };
 }());

--- a/src/webview/conversationCommentsScripts.js
+++ b/src/webview/conversationCommentsScripts.js
@@ -3299,5 +3299,5 @@
         });
     }
 
-    window.__agentPivotConversationComments = Object.freeze({ create: create });
+    window.__agentPivotConversation.comments = Object.freeze({ create: create });
 }());

--- a/src/webview/conversationFindScripts.js
+++ b/src/webview/conversationFindScripts.js
@@ -281,5 +281,5 @@
         });
     }
 
-    window.__agentPivotConversationFind = Object.freeze({ create: create });
+    window.__agentPivotConversation.find = Object.freeze({ create: create });
 }());

--- a/src/webview/conversationMermaidScripts.js
+++ b/src/webview/conversationMermaidScripts.js
@@ -376,5 +376,5 @@
         });
     }
 
-    window.__agentPivotConversationMermaid = Object.freeze({ create: create });
+    window.__agentPivotConversation.mermaid = Object.freeze({ create: create });
 })();

--- a/src/webview/conversationOutlineScripts.js
+++ b/src/webview/conversationOutlineScripts.js
@@ -601,5 +601,5 @@
         });
     }
 
-    window.__agentPivotConversationOutline = Object.freeze({ create: create });
+    window.__agentPivotConversation.outline = Object.freeze({ create: create });
 }());

--- a/src/webview/conversationReadingAnchorScripts.js
+++ b/src/webview/conversationReadingAnchorScripts.js
@@ -130,7 +130,7 @@
         });
     }
 
-    window.__agentPivotConversationReadingAnchor = Object.freeze({
+    window.__agentPivotConversation.readingAnchor = Object.freeze({
         create: create,
     });
 })();

--- a/src/webview/conversationReconcileScripts.js
+++ b/src/webview/conversationReconcileScripts.js
@@ -116,5 +116,5 @@
         });
     }
 
-    window.__agentPivotConversationReconcile = Object.freeze({ create: create });
+    window.__agentPivotConversation.reconcile = Object.freeze({ create: create });
 }());

--- a/src/webview/conversationRegistryScripts.js
+++ b/src/webview/conversationRegistryScripts.js
@@ -1,0 +1,9 @@
+(function () {
+    'use strict';
+
+    // Conversation viewer plugin registry (MOD-DASHBOARD-SHELL, webview
+    // manifest): one declared namespace that the conversation feature scripts
+    // register into and the viewer consumes. Replaces the per-feature
+    // window.__agentPivotConversation* globals.
+    window.__agentPivotConversation = window.__agentPivotConversation || {};
+}());

--- a/src/webview/conversationSidebarScripts.js
+++ b/src/webview/conversationSidebarScripts.js
@@ -263,5 +263,5 @@
         });
     }
 
-    window.__agentPivotConversationSidebar = Object.freeze({ create: create });
+    window.__agentPivotConversation.sidebar = Object.freeze({ create: create });
 }());

--- a/src/webview/conversationSubagentsScripts.js
+++ b/src/webview/conversationSubagentsScripts.js
@@ -178,7 +178,7 @@
         return Object.freeze({ apply: apply, refresh: render });
     }
 
-    window.__agentPivotConversationSubagents = Object.freeze({
+    window.__agentPivotConversation.subagents = Object.freeze({
         create: create,
     });
 }());

--- a/src/webview/conversationTelemetryScripts.js
+++ b/src/webview/conversationTelemetryScripts.js
@@ -284,5 +284,5 @@
         });
     }
 
-    window.__agentPivotConversationTelemetry = Object.freeze({ create: create });
+    window.__agentPivotConversation.telemetry = Object.freeze({ create: create });
 }());

--- a/src/webview/conversationViewerScripts.js
+++ b/src/webview/conversationViewerScripts.js
@@ -253,7 +253,7 @@
         && !!changesGroups && !!changesEmpty
         && !!changesUnavailable && !!changesOpenScm && !!changesCrossMember
         && !!telemetryChanges
-        && !!window.__agentPivotConversationChanges;
+        && !!window.__agentPivotConversation.changes;
     var bookmarkUiAvailable = sidebarUiAvailable
         && validCommentTarget(commentTarget);
     var commentUiAvailable = sidebarUiAvailable
@@ -273,7 +273,7 @@
         && !!subagentsSummary && !!subagentBanner && !!subagentBannerLabel
         && !!subagentsRunningOnly && !!closeSubagent
         && !!telemetrySubagents && !!telemetrySection
-        && !!window.__agentPivotConversationSubagents;
+        && !!window.__agentPivotConversation.subagents;
     var projectCommentUiAvailable = commentUiAvailable
         && !!projectCommentsRoot && !!projectCommentsHeader
         && !!projectCommentsContent && !!projectCommentComposer
@@ -319,7 +319,7 @@
         appliedHtmlSignature: undefined,
     };
     var readingAnchorController =
-        window.__agentPivotConversationReadingAnchor.create({
+        window.__agentPivotConversation.readingAnchor.create({
             scroll: scroll,
             messages: messages,
             messageSelector: conversationMessageSelector,
@@ -329,7 +329,7 @@
     var restoreReadingPosition = readingAnchorController.restore;
     var restoreViewportReadingPosition =
         readingAnchorController.restoreViewport;
-    var mermaidRenderer = window.__agentPivotConversationMermaid.create({
+    var mermaidRenderer = window.__agentPivotConversation.mermaid.create({
         source: mermaidSource,
         nonce: scriptNonce,
         messages: messages,
@@ -341,7 +341,7 @@
     var releaseMermaidObjectUrls = mermaidRenderer.release;
     var renderMermaidDiagrams = mermaidRenderer.render;
     var preserveMermaidContent = mermaidRenderer.preserve;
-    var reconcileController = window.__agentPivotConversationReconcile.create({
+    var reconcileController = window.__agentPivotConversation.reconcile.create({
         scroll: scroll,
         messages: messages,
         messageSelector: conversationMessageSelector,
@@ -363,7 +363,7 @@
     });
     var outlineController;
     var commentsController;
-    var sidebarController = window.__agentPivotConversationSidebar.create({
+    var sidebarController = window.__agentPivotConversation.sidebar.create({
         available: sidebarUiAvailable,
         vscodeApi: vscodeApi,
         sidebarToggle: sidebarToggle,
@@ -386,7 +386,7 @@
         telemetryChanges: telemetryChanges,
     });
     var changesController = changesUiAvailable
-        ? window.__agentPivotConversationChanges.create({
+        ? window.__agentPivotConversation.changes.create({
             post: post,
             telemetryChanges: telemetryChanges,
             telemetryChangesValue: telemetryChangesValue,
@@ -404,7 +404,7 @@
             subscriptionGeneration: state.subscriptionGeneration,
         })
         : null;
-    var outlineController = window.__agentPivotConversationOutline.create({
+    var outlineController = window.__agentPivotConversation.outline.create({
         available: sidebarUiAvailable,
         bookmarkAvailable: bookmarkUiAvailable,
         target: commentTarget,
@@ -424,7 +424,7 @@
         updateToggle: sidebarController.updateToggle,
     });
     var subagentsController = subagentUiAvailable
-        ? window.__agentPivotConversationSubagents.create({
+        ? window.__agentPivotConversation.subagents.create({
             listRoot: subagentsList,
             emptyRoot: subagentsEmpty,
             summaryRoot: subagentsSummary,
@@ -487,7 +487,7 @@
             }
         });
     }
-    var telemetryController = window.__agentPivotConversationTelemetry.create({
+    var telemetryController = window.__agentPivotConversation.telemetry.create({
         target: commentTarget,
         subscriptionGeneration: state.subscriptionGeneration,
         latestRequestId: function () {
@@ -505,7 +505,7 @@
         captureAnchor: captureReadingAnchor,
         restoreViewport: restoreViewportReadingPosition,
     });
-    var commentsController = window.__agentPivotConversationComments.create({
+    var commentsController = window.__agentPivotConversation.comments.create({
         available: commentUiAvailable,
         target: commentTarget,
         subscriptionGeneration: state.subscriptionGeneration,
@@ -554,8 +554,8 @@
         setSidebarView: sidebarController.setView,
         updateToggle: sidebarController.updateToggle,
     });
-    var findController = window.__agentPivotConversationFind
-        ? window.__agentPivotConversationFind.create({
+    var findController = window.__agentPivotConversation.find
+        ? window.__agentPivotConversation.find.create({
             available: findUiAvailable,
             root: findRoot,
             input: findInput,

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -37,6 +37,10 @@ const readingAnchorScript = fs.readFileSync(
     ),
     'utf8'
 );
+const conversationRegistryScript = fs.readFileSync(
+    path.join(__dirname, '../../src/webview/conversationRegistryScripts.js'),
+    'utf8'
+);
 const conversationMermaidScript = fs.readFileSync(
     path.join(__dirname, '../../src/webview/conversationMermaidScripts.js'),
     'utf8'
@@ -317,6 +321,7 @@ async function openViewerPage(t, options = {}) {
     } else if (options.includeMermaid) {
         await page.addScriptTag({ content: mermaidScript });
     }
+    await page.addScriptTag({ content: conversationRegistryScript });
     await page.addScriptTag({ content: readingAnchorScript });
     await page.addScriptTag({ content: conversationMermaidScript });
     await page.addScriptTag({ content: conversationOutlineScript });
@@ -1011,7 +1016,7 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 mermaid releaseExcept keeps fig
             + '<section class="conversation-markdown"><pre><code '
             + 'class="language-mermaid">flowchart TB; C--&gt;D</code></pre>'
             + '</section></article>';
-        window.__mermaidController = window.__agentPivotConversationMermaid
+        window.__mermaidController = window.__agentPivotConversation.mermaid
             .create({
                 source: null,
                 nonce: null,
@@ -1601,6 +1606,13 @@ async function openHostViewerDocument(t, options = {}) {
             await route.fulfill({
                 contentType: 'text/javascript',
                 body: options.viewerScriptSource || viewerScript,
+            });
+            return;
+        }
+        if (pathname === '/conversationRegistryScripts.js') {
+            await route.fulfill({
+                contentType: 'text/javascript',
+                body: conversationRegistryScript,
             });
             return;
         }
@@ -5053,12 +5065,12 @@ test('CONVERSATION-OUTLINE-NAVIGATION-001 keeps every side-panel view usable acr
         .digest('hex');
     assert.equal(
         sha256(previousViewerScript),
-        '8bb72241064f277b57081af0ab80720bbefad27c8f0eea23fb7dbf6b0455c33f',
+        'ed11aa4ee20e9546b19599c6bdbfbe5f87e06e990e5c687711bc0cc39e6be413',
         'the previous Viewer fixture must stay byte-exact'
     );
     assert.equal(
         sha256(previousOutlineScript),
-        'ce8a54a5657c344b37d709fece61cf05af18cc4e2ab55c1e418b386b46e127b3',
+        'bf9c914c932eb222ebbc2134d80c2625740fdd04ac3ee89ea0438b9941484c0c',
         'the previous Outline fixture must stay byte-exact'
     );
 

--- a/tests/integration/dashboard/conversationViewer.test.js
+++ b/tests/integration/dashboard/conversationViewer.test.js
@@ -2289,6 +2289,7 @@ test('CONVERSATION-WORKING-INDICATOR-001 includes one polite hidden Working stat
 
 test('CONVERSATION-READING-FOCUS-001 keeps modular Webview controllers byte-identical in packaged media', () => {
     for (const fileName of [
+        'conversationRegistryScripts.js',
         'conversationReadingAnchorScripts.js',
         'conversationMermaidScripts.js',
         'conversationOutlineScripts.js',


### PR DESCRIPTION
## Summary

B3 (bounded slice): converge the conversation viewer's per-feature globals into one registry namespace.

Before: ten `window.__agentPivotConversation{ReadingAnchor,Mermaid,Outline,Subagents,Changes,Telemetry,Comments,Sidebar,Reconcile,Find}` globals, each with one producer script and the viewer as consumer. After: one declared namespace `window.__agentPivotConversation` — created by the new first-loaded `conversationRegistryScripts.js`, registered into by the ten feature scripts, consumed by the viewer. Declared webview globals: 47 → **38**.

The manifest's existing rules all hold unchanged: closed-world references, exactly-one producer (the registry), exact consumer set (the ten registrars + the viewer), shared bundle, and load-order fidelity (the registry loads first in `viewerDocument.ts`).

Anchors moved with the protocol change: the host-document browser harness serves the registry route, the byte-identity list and the release VSIX contents include the new media file, and the two adjacent-generation fixture SHA pins re-pinned deliberately (their derivation basis changed). The remaining 18 script-produced globals outside this family are single-producer/single-consumer and stay governed by the manifest — converging them further is marginal.

## Skill harvest

none

## Owner approvals

Copy the line below into a PR comment (binds the exact head SHA and expires when the head moves):

```
approve b08fc278c6e3da9a5a0b09d905f7443b170a5ff1
```

## Verification

- `npm run test-compile` — pass
- `node --test tests/unit/**` 1191 / `tests/contract/**` 1182 / `tests/browser/**` 322 / `tests/integration/**` 438 — all pass
- `npm run test:safety:run` / `run-dashboard-webview-checks.js` / `test:architecture-policy` / `lint:ci` / `test:release-packaging` — pass
- src/webview ↔ media byte-identity — verified (mirrored edits)
- `git diff --check` — clean
