### PR TITLE
docs: define the Machine Agent product direction

### DIFF
--- a/docs/product/agent-pivot-platform-vision.md
+++ b/docs/product/agent-pivot-platform-vision.md
@@ -1,0 +1,420 @@
+# Agent Pivot Platform Vision
+
+> Status: product direction draft
+> Date: 2026-08-22
+> Horizon: long-term product direction, not an implementation commitment
+
+## Purpose Of This Document
+
+Agent Pivot today is a VS Code command surface for switching, monitoring, and
+resuming Codex, Claude, and Kimi sessions. This document describes the larger
+product that the current extension can grow into without making VS Code, one
+AI provider, or one machine the permanent system boundary.
+
+The document is intentionally stable and directional. It defines the product
+thesis, boundaries, shared domain model, trust model, and capability sequence.
+Individual releases must have narrower design specifications that state what
+is actually committed. The first such slice is
+[`Machine Agent v1: Reliable Background Attention Delivery`](../superpowers/specs/2026-08-22-machine-agent-v1-background-attention-design.md).
+
+## Product Thesis
+
+AI coding work is moving from one foreground chat to many concurrent tasks:
+
+- multiple providers work on different parts of one project;
+- tasks continue in tmux or on remote development machines after the visible
+  terminal disconnects;
+- users move between workspaces, machines, IDE windows, and mobile devices;
+- some tasks can proceed autonomously while others need a review, decision, or
+  approval;
+- the useful unit is no longer a chat tab, but a task with runtime state,
+  history, artifacts, and human checkpoints.
+
+Agent Pivot should become the local-first control layer for that work:
+
+> **Observe, resume, review, and orchestrate AI tasks across providers,
+> machines, and clients without losing user control or project context.**
+
+VS Code remains an important client and execution entry point. It is not the
+long-term owner of task state, background observation, or delivery guarantees.
+
+## User Outcomes
+
+The platform direction is successful when a user can:
+
+1. See which tasks are running, waiting, completed, or failed across their
+   machines.
+2. Leave VS Code or close a laptop while a task continues on an awake remote
+   host, and still receive a reliable attention notification.
+3. Open VS Code, a web dashboard, or a mobile client and see the same task
+   identity and current state.
+4. Review a bounded result or request, acknowledge it, and return to the exact
+   project and session that produced it.
+5. Allow providers to participate in a governed workflow, such as Kimi
+   proposing and implementing while Codex reviews, with explicit loop limits
+   and human approval gates.
+6. Understand what data leaves each machine and revoke a machine or client
+   without affecting provider-owned source and transcript storage.
+
+## Product Principles
+
+### IDE-independent, not IDE-absent
+
+VS Code should remain a first-class experience, but platform behavior must not
+depend on an Extension Host staying alive. The same machine and task model must
+be consumable by future web, mobile, CLI, and API clients.
+
+### Provider-neutral, with provider-specific adapters
+
+The shared product model describes sessions, runs, lifecycle signals,
+attention, and artifacts. Provider adapters translate Codex, Claude, Kimi, and
+future provider data into that model. Provider-specific facts must not leak
+into every client or workflow definition.
+
+### Session-host authority
+
+The machine on which a provider session runs is authoritative for observing
+that session. It owns the provider-local transcript access, runtime liveness,
+and unsynchronized event outbox. Remote clients receive projections and submit
+bounded commands; they do not infer lifecycle from stale UI state.
+
+### Local-first and metadata-minimal
+
+Code, complete transcripts, prompts, and responses remain on the session host
+by default. Cross-machine sync begins with metadata: identity, lifecycle,
+attention reason, timestamps, health, and explicitly approved summaries or
+artifacts. Additional content requires a visible product choice and a narrower
+authorization scope.
+
+### Event-driven and recoverable
+
+Important state transitions are durable events, not transient callbacks.
+Disconnects, process restarts, and temporary network failures must not erase an
+attention event or remote command. Components reconcile from persisted state
+after recovery.
+
+### Progressive trust
+
+The platform should expand in this order:
+
+1. observe;
+2. notify;
+3. acknowledge;
+4. execute a small set of structured remote actions;
+5. automate multi-step workflows under explicit policy.
+
+Arbitrary remote shell execution is not a baseline platform capability.
+
+### Human authority remains explicit
+
+Automation may advance through pre-approved low-risk states. Scope expansion,
+high-risk mutations, exhausted review loops, and ambiguous outcomes stop at a
+human gate. Every remote action and automated transition is attributable and
+auditable.
+
+### Capability is reported, not assumed
+
+A local sleeping laptop, an awake remote host, a tmux runtime, and a direct
+terminal have different guarantees. Clients must show the effective capability
+and degradation reason instead of presenting one misleading `enabled` flag.
+
+## Target Platform Shape
+
+```text
+Session host A                         Session host B
+┌─────────────────────┐               ┌─────────────────────┐
+│ Provider runtimes   │               │ Provider runtimes   │
+│ Machine Agent       │               │ Machine Agent       │
+│ Durable local state │               │ Durable local state │
+└──────────┬──────────┘               └──────────┬──────────┘
+           │ outbound authenticated connections │
+           └────────────────┬────────────────────┘
+                            ▼
+                  ┌─────────────────────┐
+                  │ Control Plane       │
+                  │ Identity and policy │
+                  │ State projections   │
+                  │ Command routing     │
+                  │ Audit and delivery  │
+                  └──────┬──────┬───────┘
+                         │      │
+                   ┌─────▼──┐ ┌─▼────────┐
+                   │ Web/PWA│ │ VS Code  │
+                   └────────┘ └──────────┘
+```
+
+The Control Plane is a future component, not a dependency of the first
+Machine Agent release. Until it exists, the Machine Agent can deliver directly
+to user-configured notification services.
+
+## External Architecture Patterns
+
+The platform shape follows recurring patterns in mature machine-agent systems;
+it does not require Agent Pivot to copy their product scope.
+
+| Product pattern | Relevant evidence | Lesson for Agent Pivot |
+| --- | --- | --- |
+| GitHub Actions self-hosted runners | A runner process on the execution machine connects outward over HTTPS, receives work, reports status, and can be installed as a service. See [GitHub's self-hosted runner reference](https://docs.github.com/en/actions/reference/runners/self-hosted-runners) and [service management guidance](https://docs.github.com/en/actions/how-tos/manage-runners/self-hosted-runners). | Put the durable execution-side process on the session host, use outbound connectivity, and treat service installation, health, and upgrades as product behavior. |
+| Elastic Agent and Fleet | Fleet centrally manages enrollment, versions, policies, status, and logs while also supporting a standalone Agent mode. See [Elastic Fleet management](https://www.elastic.co/guide/en/fleet/current/manage-agents-in-fleet.html/). | Keep a useful standalone Machine Agent now, then add optional central management without replacing the host process. |
+| OpenTelemetry Collector | The Collector explicitly supports agent and gateway deployment patterns that can be combined. See [Collector deployment patterns](https://opentelemetry.io/docs/collector/deploy/) and the [gateway pattern](https://opentelemetry.io/docs/collector/deploy/gateway/). | Separate host-local collection and buffering from future central routing and aggregation. Do not make the gateway authoritative for facts only the host can observe. |
+| HashiCorp Boundary | Boundary separates controllers, workers, and clients; workers report health and last-seen state, and outbound-only network policies are supported. See [Boundary workers](https://developer.hashicorp.com/boundary/docs/concepts/workers) and [worker TLS connections](https://developer.hashicorp.com/boundary/docs/secure/encryption/connections-tls). | Model Machine Agent identity, capability, heartbeat, and revocation separately from user clients, and avoid requiring public inbound access to development hosts. |
+
+These precedents support four decisions in this vision: a separately managed
+host process, outbound authenticated connectivity, explicit health and version
+reporting, and an optional control plane layered above a still-useful local
+agent. They do not justify importing CI job execution, telemetry collection,
+or network proxying into Agent Pivot's product scope.
+
+## Platform Components
+
+### Machine Agent
+
+The Machine Agent is an independently running process on each session host.
+It is the long-term foundation for capabilities that must survive an IDE
+disconnect.
+
+Its bounded responsibilities are:
+
+- discover or receive registrations for supported sessions;
+- observe provider lifecycle data through versioned adapters;
+- reconcile runtime liveness and lifecycle signals;
+- persist attention events and per-destination delivery work;
+- report its own health and supported capabilities;
+- synchronize projections to a future Control Plane;
+- validate and execute explicitly supported commands;
+- keep a local audit trail without storing complete conversation content by
+  default.
+
+Notification is its first capability, not its permanent product identity. The
+executable and package should therefore use `agent-pivot-agent`, rather than
+making `notifyd` the public architectural boundary.
+
+### VS Code Extension
+
+The extension remains the richest local project client. It launches and
+resumes sessions, renders project context, opens transcripts, and offers Agent
+installation, configuration, health, and diagnostics. It must consume shared
+task projections instead of being the only owner of background task truth.
+
+### Control Plane
+
+The future Control Plane provides an authenticated rendezvous point for
+machines and clients that cannot directly reach one another because of NAT,
+corporate networks, or offline periods. Machine Agents initiate outbound
+connections; machines do not expose public listener ports.
+
+The Control Plane owns:
+
+- user, organization, device, and client identity;
+- latest synchronized projections and bounded history;
+- capability-aware command routing;
+- authorization policy and audit records;
+- push notification fan-out when configured;
+- device revocation and protocol compatibility policy.
+
+It does not become the default store for complete provider transcripts or
+source repositories.
+
+### Web, Mobile, CLI, And API Clients
+
+Clients consume one versioned platform API and render capabilities appropriate
+to their surface. A mobile client may first show status and acknowledge an
+attention event; it does not need to reproduce a terminal or accept arbitrary
+commands. Web can later provide cross-machine task views and workflow
+administration. VS Code can continue to provide code-local navigation.
+
+### Workflow Engine
+
+The workflow engine coordinates typed steps, artifacts, reviews, policies, and
+human gates. It is a consumer of the shared task and command model, not logic
+embedded in one provider transcript or one webview.
+
+A future review loop may express:
+
+```text
+Kimi propose
+  → Codex review
+  → Kimi revise while Critical or Important findings remain
+  → human gate after the configured loop limit
+  → Kimi implement when approved
+  → Codex review implementation until no Critical findings remain
+```
+
+The engine must persist the state and evidence of each transition. A provider
+being idle means it is available for a new command; it is not itself a durable
+workflow scheduler.
+
+A `Task` is the user's durable objective, not a synonym for one provider
+session or one workflow. A task may begin as an unstructured session, use one
+workflow to produce a plan, use another workflow to implement it, and retain
+all of those runs and artifacts under one task history. Reusable workflow
+definitions and their concrete workflow runs are separate identities.
+
+## Shared Domain Model
+
+The platform should converge on these provider-neutral identities:
+
+| Entity | Meaning | Authority |
+| --- | --- | --- |
+| `Machine` | One registered execution host | Machine Agent and identity service |
+| `Workspace` | A project or multi-root execution scope on a machine | Session host |
+| `Task` | A durable user objective spanning sessions, runs, artifacts, and optional workflows | User or task service |
+| `Session` | A stable provider conversation identity | Provider adapter |
+| `Run` | One active execution interval within a session | Session host |
+| `LifecycleEvent` | Provider-derived transition such as running or stopped | Session host |
+| `AttentionEvent` | A durable item requiring awareness or action | Session host, synchronized outward |
+| `Artifact` | A typed, explicitly retained output such as a plan or review | Producing task/workflow |
+| `Command` | An authenticated, idempotent request for a supported action | Issuing client plus executing Agent |
+| `WorkflowDefinition` | A reusable versioned graph of steps, policies, and gates | Workflow service |
+| `WorkflowRun` | One execution of a workflow definition for a task | Workflow service |
+
+Identifiers must be globally unambiguous once data crosses a machine boundary.
+Events and commands carry schema versions, causal references, timestamps, and
+idempotency keys. Clients must tolerate unknown optional capabilities and
+reject incompatible required protocol versions visibly.
+
+## State And Connectivity Model
+
+The product must distinguish three layers:
+
+1. **Authoritative local state**: provider files, runtime liveness, the local
+   event log, pending deliveries, and pending commands.
+2. **Synchronized projections**: bounded task metadata and health that web or
+   mobile clients can query.
+3. **Ephemeral presence**: whether a VS Code window, web client, or phone is
+   currently connected.
+
+Presence must never be required to retain an event. Offline clients can miss a
+live update and reconcile later from the projection. A disconnected Machine
+Agent remains authoritative for local sessions and uploads its ordered changes
+after reconnection.
+
+## Trust, Security, And Privacy Boundaries
+
+The platform direction requires the following invariants:
+
+- Machine Agents make outbound connections; no public inbound machine port is
+  required.
+- Every machine has an independently revocable identity.
+- Credentials are encrypted or stored through platform-appropriate secret
+  facilities where available; plaintext configuration and Settings Sync are
+  not credential stores.
+- Commands are typed, scoped, expiring, signed or authenticated, idempotent,
+  and audited.
+- The Agent enforces its own command allowlist even if a client or Control
+  Plane is compromised.
+- High-impact operations require policy and, where appropriate, a local or
+  human confirmation.
+- Metadata redaction is the default. Uploading code, transcript content, or a
+  full filesystem path is a separate consent decision.
+- Self-hosted Control Plane deployment remains a viable enterprise direction.
+
+## Capability Sequence
+
+The sequence describes dependency order, not release dates.
+
+### Foundation: VS Code command surface
+
+The current product discovers provider sessions, manages direct and tmux
+runtimes, projects attention into the UI, and resumes work in context.
+
+### Machine Agent v1: reliable background attention
+
+Extract background observation and notification delivery from the Extension
+Host. Prove a remote tmux task can complete after VS Code disconnects and still
+produce one recoverable notification event.
+
+### Machine directory and read-only Control Plane
+
+Register Machine Agents, synchronize bounded task projections, and provide a
+cross-machine web view. This phase is read-only apart from device management.
+
+### Mobile attention handling
+
+Add PWA or mobile views for task status, push delivery, and attention
+acknowledgement. Acknowledgement synchronizes back to the authoritative host.
+
+### Structured remote actions
+
+Introduce a small capability-negotiated command set such as stop, continue,
+choose an offered option, or approve a workflow gate. Do not expose arbitrary
+terminal input as a generic remote API.
+
+### Workflow orchestration
+
+Add durable provider-neutral workflows, typed artifacts, bounded review loops,
+and human intervention policies. Workflow execution may live in a Control
+Plane or a self-hosted coordinator while provider actions execute through the
+appropriate Machine Agent.
+
+## Repository And Delivery Boundaries
+
+The Machine Agent should initially live in this repository because it shares
+provider lifecycle adapters, event identity, and release compatibility with
+the VS Code extension. It must still be a separately built, tested, versioned,
+and runnable package with no `vscode` dependency.
+
+The intended dependency direction is:
+
+```text
+runtime-core  ← VS Code extension
+runtime-core  ← machine-agent
+protocol      ← VS Code extension
+protocol      ← machine-agent
+
+machine-agent ✕ vscode
+runtime-core  ✕ vscode
+```
+
+A future hosted Control Plane belongs in a separate repository because its
+deployment, secrets, persistence, security review, and release cadence differ
+from desktop and machine software. The Machine Agent may be split later when
+it has an independent installer, release cadence, maintainership boundary, and
+stable protocol. Repository separation must follow a real product boundary,
+not create one prematurely.
+
+## Product Health Measures
+
+Future releases should measure outcomes rather than only feature presence:
+
+- percentage of registered running tasks whose final lifecycle state is
+  observed;
+- attention delivery latency and success by mode;
+- pending and expired delivery counts;
+- Machine Agent availability and protocol compatibility;
+- duplicate or unreconciled event incidence;
+- time from attention to acknowledgement;
+- percentage of remote commands completed, rejected, expired, or ambiguous;
+- workflow loops requiring human intervention and their resolution.
+
+Telemetry must remain opt-in and must not contain source or transcript content.
+Local diagnostics should expose the same health facts without requiring
+telemetry.
+
+## Long-Term Non-Goals
+
+Agent Pivot is not intended to:
+
+- provide, proxy, or resell model access;
+- replace provider-owned authentication or transcript storage;
+- become a general remote shell or endpoint-management product;
+- promise work continues while its actual execution host is asleep or powered
+  off;
+- silently upload repositories or complete conversations;
+- remove human accountability from high-impact development operations.
+
+## Open Product Decisions
+
+The following choices should be made before their dependent phase begins:
+
+1. Whether the Control Plane is hosted, self-hosted, or offered in both forms.
+2. Which task metadata and artifact types may synchronize by default.
+3. Whether web/mobile are PWA-first or require native applications.
+4. Which structured remote actions form the first write-capable release.
+5. Where workflow coordination runs in hosted and self-hosted deployments.
+6. Which organization, retention, compliance, and audit controls are required
+   before team use.
+
+These questions do not block Machine Agent v1. That release should establish
+the durable local event, capability, and identity foundations without
+pretending the future Control Plane already exists.

--- a/docs/superpowers/specs/2026-07-31-ai-session-stop-notification-design.md
+++ b/docs/superpowers/specs/2026-07-31-ai-session-stop-notification-design.md
@@ -1,6 +1,9 @@
 # AI 会话停止通知 —— 设计方案
 
-> Status: designed (2026-07-31)
+> Status: historical; the shipped in-process portion remains descriptive, but
+> the unimplemented background-daemon design is superseded by
+> [`Machine Agent v1: Reliable Background Attention Delivery`](2026-08-22-machine-agent-v1-background-attention-design.md).
+> Do not implement `notifyd` from this document as the current architecture.
 > Date: 2026-07-31
 > Worktree: `.worktree/notify-on-session-stop`(分支 `feat/notify-on-session-stop`)
 

--- a/docs/superpowers/specs/2026-08-22-machine-agent-v1-background-attention-design.md
+++ b/docs/superpowers/specs/2026-08-22-machine-agent-v1-background-attention-design.md
@@ -1,0 +1,642 @@
+# Machine Agent v1: Reliable Background Attention Delivery
+
+> Status: draft for product and technical review
+> Date: 2026-08-22
+> Parent direction: [`Agent Pivot Platform Vision`](../../product/agent-pivot-platform-vision.md)
+
+## Document Relationship
+
+This specification defines the next deliverable, not the entire Machine Agent
+platform. It supersedes the unimplemented background-daemon design in
+[`2026-07-31-ai-session-stop-notification-design.md`](2026-07-31-ai-session-stop-notification-design.md).
+The shipped in-process notification behavior and its historical implementation
+plan remain valid descriptions of the current product.
+
+An implementation plan and PR checklist should be written only after this
+specification is approved and its process-lifetime spike is resolved.
+
+## Summary
+
+Agent Pivot will add an independently running `agent-pivot-agent` process on
+the machine that hosts an AI session. Its first capability is to observe
+registered tmux-backed Codex, Claude, and Kimi sessions, persist attention
+events and delivery work, and send configured notifications after VS Code or
+the user's laptop disconnects.
+
+The release is intentionally narrower than a web platform:
+
+- VS Code remains the configuration and diagnostics client.
+- Notification services such as ntfy, Feishu, or Telegram remain the external
+  delivery surface.
+- There is no hosted Control Plane, web dashboard, mobile command channel, or
+  workflow engine in v1.
+- The process and protocols use the future Machine Agent boundary so those
+  capabilities can be added without replacing a notification-only daemon.
+
+## Problem
+
+The current notification pipeline is owned by the Extension Host:
+
+```text
+provider transcript
+  → Extension Host lifecycle evaluation
+  → Attention event
+  → in-memory NotifyDispatcher
+  → webhook
+```
+
+The Attention UI Bridge is a local UI extension. It cannot run while the
+laptop UI host is suspended. The in-process notification dispatcher also
+stops when the relevant Extension Host exits. A remote tmux session can
+therefore continue and finish while no process remains to observe or deliver
+its attention event.
+
+The current dispatcher has an additional reliability gap: its debounce queue
+is memory-only, and it records an event in the notified store before transport
+success. A wake-up race in which the Extension Host resumes before Wi-Fi or a
+proxy can cause a failed send to be treated as permanently delivered.
+
+The product currently exposes an enabled notification setting without being
+able to state whether delivery remains available after VS Code disconnects.
+
+## Product Promise
+
+When background mode reports `Protected`, Agent Pivot makes this promise:
+
+> If a registered tmux-backed session and its session host remain running,
+> Agent Pivot will durably observe a supported Attention event and retain each
+> configured delivery until it succeeds, is acknowledged before sending,
+> expires under visible policy, or is blocked by a visible configuration
+> error—even when VS Code and the user's laptop are disconnected.
+
+The promise is conditional on the session host remaining awake and able to
+reach the destination eventually. It does not claim that an asleep local
+laptop continues computing or sending.
+
+Transport-level exactly-once delivery is not promised. An HTTP request may be
+accepted by a destination and then time out before the Agent sees the response.
+Retrying that ambiguous request can duplicate a notification on services that
+do not support idempotency keys. Agent Pivot guarantees stable event identity,
+no duplicate local scheduling, and success-after-ack persistence; it reports
+the remaining transport limitation honestly.
+
+## Primary User Journey
+
+```text
+1. User enables Background notification mode on a Remote SSH host.
+2. Agent Pivot installs or activates the Machine Agent on that host.
+3. User starts a Codex, Claude, or Kimi task in managed tmux.
+4. VS Code registers the session with the Machine Agent.
+5. User closes the laptop; SSH and the remote Extension Host disappear.
+6. The provider completes or requires input on the remote host.
+7. The Machine Agent derives one Attention event and stores delivery work.
+8. The configured notification arrives on the user's phone or IM client.
+9. The user reopens VS Code; the same event appears as Attention, not a second
+   event, and no second successful delivery is scheduled.
+```
+
+## Goals
+
+1. Keep background observation and delivery alive after VS Code and SSH
+   disconnect from an awake session host.
+2. Reuse the same provider lifecycle semantics and event identity as the
+   existing Attention pipeline.
+3. Persist events and per-sink delivery state before asynchronous delivery.
+4. Retry recoverable failures across network interruption and Agent restart.
+5. Make the effective notification guarantee and degradation reason visible.
+6. Preserve the current foreground mode for users who do not opt in.
+7. Establish an independently runnable, zero-`vscode` Machine Agent package
+   suitable for future Control Plane synchronization.
+8. Preserve the current metadata-only notification privacy contract.
+
+## Non-Goals
+
+- A hosted Control Plane or user account system.
+- A Web dashboard or native mobile application.
+- Mobile replies, terminal input, or remote task control.
+- Workflow orchestration.
+- Keeping local work running while the local operating system sleeps.
+- Installing or configuring tmux.
+- Monitoring unmanaged arbitrary processes.
+- Uploading source code, prompts, responses, or complete transcripts.
+- Guaranteed exactly-once delivery by third-party notification services.
+- Making background mode the default before its environment matrix is proven.
+
+## Supported Environments
+
+The proposed v1 release gate is intentionally narrow:
+
+| Session environment | Runtime | v1 behavior |
+| --- | --- | --- |
+| Linux Remote SSH host | Managed tmux | Required `Protected` support |
+| Linux Dev Container whose host/container remains running | Managed tmux | Supported after the same survival tests pass |
+| macOS local host | Managed tmux | Agent may run; laptop sleep pauses task and Agent, then wake-up reconciliation applies |
+| WSL | Managed tmux | Preview until shutdown and process-lifetime behavior is proven |
+| Native Windows | Direct terminal | Foreground mode only in v1 |
+| Any host | Direct terminal | Foreground mode; the runtime normally ends with its VS Code terminal |
+
+The UI derives a capability result from the actual runtime and Agent health.
+It must not label an unsupported or unproven combination as protected.
+
+## Product Modes
+
+Replace the implicit boolean guarantee with an explicit mode:
+
+| Mode | Sender | User-visible guarantee |
+| --- | --- | --- |
+| `foreground` | VS Code Extension Host | Notifications only while the responsible Extension Host is running |
+| `sessionHost` | Machine Agent | Registered supported sessions remain observed after VS Code disconnects |
+
+`foreground` remains the default. Enabling `sessionHost` is explicit and
+machine-scoped because installation, credentials, connectivity, and runtime
+capabilities differ by local or remote host.
+
+The existing `agentPivot.notify.enabled` consent remains the master outbound
+network switch. A future implementation plan will decide whether mode is a new
+setting or a migration from a proposed daemon setting; the product behavior
+must not infer background protection from `enabled` alone.
+
+## Architecture
+
+```text
+Session host
+┌───────────────────────────────────────────────────────────────────┐
+│ Provider + managed tmux runtime                                   │
+│        │ writes provider-owned lifecycle data                     │
+│        ▼                                                          │
+│ agent-pivot-agent                                                 │
+│   Session Registry → Provider Observer → Attention Reconciler     │
+│                                             │                     │
+│                                             ▼                     │
+│                                    Durable Event Store            │
+│                                             │                     │
+│                                             ▼                     │
+│                                      Delivery Outbox              │
+│                                      ├─ sink A state              │
+│                                      └─ sink B state              │
+│                                             │                     │
+│                                             ▼                     │
+│                                  Notification Transports          │
+│                                             │                     │
+│                                             └── outbound HTTPS ───┼──►
+│                                                                   │
+│ VS Code Extension Host, when present                              │
+│   · installs/configures Agent                                     │
+│   · registers and retires sessions                                │
+│   · acknowledges Attention                                        │
+│   · shows capability, health, backlog, and diagnostics            │
+└───────────────────────────────────────────────────────────────────┘
+```
+
+When `sessionHost` mode is healthy, the Machine Agent is the only notification
+sender for sessions it owns. The Extension Host continues to render Attention
+but does not send the same event. A degraded Agent must not silently enable a
+second sender and create races; fallback to foreground sending requires an
+explicit, visible mode transition with shared event reconciliation.
+
+## Package And Repository Boundary
+
+V1 is implemented in this repository but as an independent product artifact.
+The target structure is conceptually:
+
+```text
+packages/
+  runtime-core/       provider lifecycle and Attention identity, no vscode
+  machine-agent/      executable, registry, reconciliation, outbox, health
+  protocol/           versioned records and capability contracts
+src/                  VS Code Extension and integration adapters
+```
+
+The implementation plan may introduce these directories incrementally rather
+than perform a broad repository migration first. The enforced dependency
+invariant is more important than the initial directory names:
+
+```text
+machine-agent ✕ vscode
+runtime-core  ✕ vscode
+```
+
+`agent-pivot-agent` has its own entry point, version, tests, build target,
+logs, and lifecycle commands. It is not an Extension Host worker thread or a
+child whose correctness depends on the parent remaining alive.
+
+## Responsibilities
+
+### Machine Agent owns
+
+- single-instance enforcement on one session host;
+- versioned session registration ingestion;
+- provider lifecycle observation and checkpointing;
+- runtime and transcript reconciliation after restart;
+- Attention event identity and durable event retention;
+- per-sink delivery state, retry, expiry, and diagnostics;
+- Agent health, capability, and version reporting;
+- local metadata redaction before transport;
+- safe retirement of sessions no longer alive.
+
+### VS Code Extension owns
+
+- informed consent and user-facing settings;
+- Agent installation, upgrade request, and uninstall entry points;
+- registering managed sessions with the Agent;
+- writing or brokering credentials through an approved local contract;
+- displaying Agent mode, location, heartbeat, version, and delivery health;
+- publishing the same Attention state in the current UI;
+- forwarding acknowledgement to the Agent when available;
+- foreground delivery when explicitly configured in foreground mode.
+
+### Provider adapters own
+
+- locating provider-owned session data;
+- parsing lifecycle signals with stable tokens;
+- mapping provider facts to provider-neutral Attention reasons;
+- exposing enough checkpoints to resume tailing after process restart;
+- remaining testable without VS Code or live provider processes.
+
+## Session Registration Contract
+
+V1 needs a versioned registration record per managed session. The exact IPC
+encoding is an implementation decision, but the semantic record includes:
+
+```jsonc
+{
+  "schemaVersion": 1,
+  "machineId": "local-stable-machine-id",
+  "sessionKey": "codex:provider-session-id",
+  "providerId": "codex",
+  "providerSessionId": "provider-session-id",
+  "workspaceId": "host-local-workspace-id",
+  "runtime": {
+    "backend": "tmux",
+    "locator": { "layout": "project", "sessionName": "...", "windowName": "..." }
+  },
+  "lifecycleSource": { "kind": "provider-jsonl", "path": "..." },
+  "runStartedAtMs": 0,
+  "labels": { "project": "vscode-dashboard", "session": "review notifications" },
+  "registrationOwnerId": "vscode-extension-instance-id",
+  "registeredAtMs": 0,
+  "registrationRevision": 1
+}
+```
+
+Paths and tmux locators are host-private and never included in outbound
+notifications or future synchronization by default. Registration updates are
+atomic and monotonic. A stale VS Code window cannot overwrite a newer revision
+or retire a live registration it does not own.
+
+V1 may use validated atomic files for local communication. The schema must be
+transport-neutral so a later local socket or Control Plane sync does not
+change the domain model.
+
+The Machine Agent, not an arbitrary file writer, is the revision authority. If
+the selected v1 transport uses files, it must provide request/acknowledgement
+semantics or an equivalent single-writer protocol rather than allowing several
+VS Code windows to replace one shared snapshot concurrently.
+
+## Attention Identity And Reconciliation
+
+The Extension and Agent must derive the same stable `eventId` from the same
+provider lifecycle signal. The algorithm is versioned. A component that does
+not support the required identity version reports incompatibility and stops
+sending; it must not invent a replacement event that could duplicate delivery.
+
+The existing `eventId` remains host-local for compatibility with current
+Attention acknowledgement. Any future cross-machine protocol identifies an
+event by the composite `(machineId, eventId)` unless a separately versioned
+global identity migration is approved.
+
+On start, restart, registration update, transcript rotation, and reconnect,
+the Agent reconciles from a persisted read checkpoint plus a bounded provider
+history window. It never assumes that a missed file-watch callback means no
+event occurred. File watching is an optimization; periodic reconciliation is
+the correctness fallback.
+
+The Agent records the event before creating delivery work. Event retention and
+delivery retention are separate so an event can remain visible after every
+sink has finished or expired.
+
+## Trigger Semantics
+
+V1 changes where lifecycle evaluation runs, not what provider output means.
+It uses the current provider adapters and reasons:
+
+| Reason | Current source behavior | Default delivery policy |
+| --- | --- | --- |
+| `completed` | Produced by the normal end-of-turn/task-complete signal for Codex, Claude, and Kimi | Included; this is the most common stop event |
+| `input-required` | Produced by supported structured question or approval requests | Included |
+| `failed` | Currently produced only for supported Claude API-error records | Included |
+
+Provider interruption signals that currently map to idle do not become
+Attention merely because the Machine Agent exists. Adding or changing a
+provider signal requires the normal adapter contract and fixture review; the
+background process must not infer completion from tmux inactivity alone.
+
+## Durable Delivery Outbox
+
+Delivery state is per `eventId + sinkId`, not one global notified bit.
+
+```text
+pending
+  → debounce
+  → sending
+      → delivered
+      → retry-wait → pending
+      → blocked
+  → cancelled
+  → expired
+```
+
+Required semantics:
+
+1. Persist `pending` before scheduling debounce or network work.
+2. Mark `delivered` only after the transport returns an accepted success
+   response.
+3. Persist an attempt number, timestamps, redacted result, and next retry time.
+4. Retry network errors, timeouts, HTTP 408, HTTP 429, and HTTP 5xx with bounded
+   exponential backoff and jitter; honor `Retry-After` where supported.
+5. Treat other HTTP 4xx responses as `blocked` configuration or authorization
+   failures and surface them in health diagnostics.
+6. Resume `pending`, `retry-wait`, and orphaned `sending` records after Agent
+   restart. An orphaned send is an ambiguous outcome and may be retried under
+   the documented at-least-once transport limitation.
+7. Never silently drop the oldest item because an in-memory queue is full.
+   Backpressure and storage limits create a visible degraded state.
+8. Keep sink outcomes independent. One successful sink never suppresses retry
+   for another sink.
+9. Use the stable event ID as an idempotency key when a transport supports it.
+10. Retain enough completed state to prevent replay during the configured
+    deduplication window.
+
+The storage engine is chosen during implementation planning after a focused
+crash-consistency evaluation. Whether it is an atomic local record store or an
+embedded database, tests must prove the state-machine semantics above. Storage
+format convenience must not weaken them.
+
+## Acknowledgement, Cancellation, And Freshness
+
+Acknowledgement and delivery are related but distinct:
+
+- acknowledgement removes Attention from the user's actionable queue;
+- if a delivery is still pending or in debounce, acknowledgement cancels it;
+- an in-flight or already delivered external message cannot be retracted;
+- acknowledging one event does not acknowledge a later run in the same
+  session;
+- acknowledgement is durable and uses the same versioned event ID.
+
+After a long offline period, the Agent should not flood a user with stale
+events. V1 proposes a default 24-hour delivery freshness window:
+
+- fresh unacknowledged events resume delivery;
+- expired events remain diagnosable but are not sent;
+- multiple fresh events released together may be summarized under the existing
+  rate-limit policy without losing their individual event identities.
+
+The default and configurability require product review before implementation.
+
+## Process Lifetime And Supervision
+
+Process survival is the highest-risk technical assumption and must be proven
+before the implementation plan is approved.
+
+The spike must run on a real Remote SSH Linux host and answer:
+
+1. Does a detached Node process survive VS Code Remote Server shutdown, SSH
+   disconnect, and terminal teardown in the supported environment?
+2. Which signals and process-group behavior occur during remote shutdown?
+3. Is `systemd --user` available, and does the user session remain alive after
+   logout without requiring an unsafe or surprising system change?
+4. What explicit degraded mode is available where no service manager exists?
+5. How are crash restart, version upgrade, log ownership, and uninstall
+   handled without two Agents running concurrently?
+
+The target lifecycle interface is stable regardless of the selected adapter:
+
+```text
+agent-pivot-agent start
+agent-pivot-agent stop
+agent-pivot-agent status
+agent-pivot-agent doctor
+agent-pivot-agent version
+```
+
+Preferred supervision order for the spike is:
+
+1. platform service manager when it can be installed with informed consent;
+2. proven detached-process mode with explicit limitations;
+3. foreground notification fallback when background survival cannot be
+   established.
+
+The product must never call a mode `Protected` solely because a PID exists.
+Health requires a current heartbeat, compatible protocol version, successful
+registry access, usable credential state, and a proven process-lifetime mode.
+
+## Installation And Upgrade
+
+The VS Code extension may bootstrap the Agent, but the Agent artifact is
+independently runnable and versioned. Installation must be atomic:
+
+- stage a versioned artifact;
+- verify its version and integrity;
+- request the old Agent to quiesce after persisting checkpoints;
+- acquire the single-instance lock;
+- start the new version;
+- verify heartbeat and protocol compatibility;
+- retain a diagnosable rollback path if activation fails.
+
+An extension update must not overwrite the executable of a running process in
+place. Multiple VS Code windows coordinate through the Agent lock and protocol
+rather than racing to install or restart it.
+
+Uninstall must remove service-manager registration when present, stop the
+Agent, and explain which retained diagnostic or delivery files will be
+deleted. Extension uninstall hooks are not guaranteed, so the Agent also needs
+a bounded idle-retirement policy and a documented manual cleanup command.
+
+## Credentials And Privacy
+
+Background delivery cannot depend on VS Code SecretStorage being readable
+after the Extension Host exits. V1 therefore needs a deliberate host-local
+credential handoff.
+
+Required behavior:
+
+- SecretStorage remains the VS Code-side source during configuration.
+- The Agent receives only credentials for enabled sinks on that machine.
+- Host-local credential material is never written to `settings.json`, Settings
+  Sync, logs, notifications, or future Control Plane projections.
+- If platform keychain integration is unavailable, an owner-only file is an
+  explicit documented compromise, written atomically with restrictive
+  permissions and redacted diagnostics.
+- Credential removal invalidates pending work for that sink visibly rather
+  than reporting successful delivery.
+- Notification payloads keep the current metadata-only default: provider,
+  reason, duration, hostname, basename project label, optional session label,
+  and correlation ID.
+
+Enabling background mode requires informed consent that identifies the machine
+on which the Agent and credentials will reside.
+
+## Health And Product Experience
+
+Settings and commands should expose one effective state:
+
+| State | Meaning |
+| --- | --- |
+| `Protected` | Agent is healthy and the current supported runtime remains observed after disconnect |
+| `Foreground only` | Extension can send, but closing it removes the sender |
+| `Recovering` | Agent is reconciling persisted state or retrying delivery |
+| `Blocked` | Configuration, credentials, protocol, storage, or supervision prevents the promise |
+| `Unsupported` | The current runtime or host cannot provide background observation |
+
+The status surface includes:
+
+- sending machine and hostname;
+- Agent version and protocol version;
+- supervision type and last heartbeat;
+- number of registered live sessions;
+- pending, retrying, blocked, and expired delivery counts;
+- last successful and failed delivery time with a redacted destination;
+- current guarantee in plain language;
+- `Send Test Notification`, `Doctor`, `Restart`, and `Open Logs` actions.
+
+Examples:
+
+```text
+Background notifications: Protected
+Sender: dev-server-03 · Linux user service
+3 sessions watched · heartbeat 8 seconds ago · no pending deliveries
+```
+
+```text
+Background notifications: Foreground only
+The Machine Agent is not running. Closing VS Code will stop notifications.
+```
+
+For a local laptop that can sleep:
+
+```text
+Background notifications pause while this computer sleeps. Local tasks also
+pause and will be reconciled after wake.
+```
+
+## Diagnostics And Metrics
+
+The Agent keeps bounded, rotating, redacted local logs and a structured health
+snapshot readable by VS Code. Every event and delivery attempt uses the short
+correlation ID already present in notification messages.
+
+Diagnostics distinguish:
+
+- event not observed;
+- event observed but policy-filtered;
+- waiting in debounce;
+- waiting for network retry;
+- blocked by credentials or HTTP response;
+- delivered with acknowledged response;
+- expired under freshness policy;
+- Agent or protocol unhealthy.
+
+No failure silently downgrades a protected session. Optional future telemetry
+must be separately consented and contain no project path, session label,
+provider transcript, URL credentials, or message body.
+
+## Failure Behavior
+
+| Failure | Required result |
+| --- | --- |
+| Extension exits | Healthy Agent continues observing registered supported sessions |
+| SSH disconnects | Healthy Agent and tmux session continue on the remote host |
+| Agent restarts | Checkpoints and unfinished deliveries reconcile from durable state |
+| File-watch event is missed | Periodic reconciliation finds the lifecycle transition |
+| Network is unavailable | Delivery remains retryable and visible; it is not marked delivered |
+| One sink succeeds, one fails | Successful sink remains delivered; failed sink retries independently |
+| Credentials are invalid | Sink becomes blocked with a visible remediation path |
+| Protocol versions conflict | Background sending stops visibly rather than risking duplicate identity |
+| Storage cannot persist | Agent enters blocked state before claiming the event is protected |
+| Host sleeps or powers off | No real-time guarantee; recovery begins after the host resumes |
+| Runtime disappears | Agent performs a final bounded reconciliation, then retires registration |
+| Agent cannot be supervised | UI reports foreground-only or unsupported; no silent protected claim |
+
+## Verification And Release Gates
+
+Deterministic tests cover:
+
+- provider lifecycle fixtures produce byte-identical event identity in the
+  Extension and Agent paths;
+- registration revisions reject stale writers;
+- crash points around every Outbox transition recover safely;
+- transport success is recorded only after accepted response;
+- retryable and blocked HTTP classifications;
+- per-sink independence, acknowledgement races, freshness, and summarization;
+- Agent single-instance, protocol mismatch, upgrade, and graceful shutdown;
+- logs and status snapshots contain no configured credentials or full paths.
+
+Real-environment acceptance is required for release. At minimum:
+
+1. Start a managed tmux provider task on a Remote SSH Linux host, close VS
+   Code, disconnect SSH, complete the task, and receive the notification.
+2. Repeat while the laptop is closed long enough for the remote VS Code Server
+   to shut down.
+3. Make the destination unreachable before completion, restore connectivity,
+   and verify the pending item delivers without being lost.
+4. Stop the Agent after the event is persisted, restart it through the
+   supported supervisor, and verify delivery resumes.
+5. Attach two VS Code windows to the same managed runtime and verify one local
+   event identity and no duplicate local scheduling.
+6. Reopen VS Code after delivery and verify the same Attention event appears
+   without a new delivery.
+7. Acknowledge during debounce and verify pending delivery is cancelled.
+8. Force invalid credentials and verify the UI reports `Blocked`, not
+   `Protected` or delivered.
+
+The completed environment, timestamps, process tree, Agent log, redacted
+delivery evidence, and phone/IM evidence are retained in the manual-test
+record. Existing sleep/disconnect manual coverage must be extended rather than
+treated as a deterministic CI substitute.
+
+## Rollout
+
+1. Ship the Machine Agent package and diagnostics behind an internal or
+   experimental setting; do not send notifications through it yet.
+2. Complete the real process-lifetime spike and publish the supported matrix.
+3. Enable background delivery for explicit test users with dual-send
+   prohibited by configuration and assertions.
+4. Measure local health and collect manual evidence for disconnect, retry, and
+   upgrade scenarios.
+5. Offer `sessionHost` mode as opt-in only after all release gates pass.
+6. Keep foreground mode available as a visible fallback and rollback path.
+
+## Implementation Slices After Approval
+
+The later implementation plan should produce small, serial, independently
+reviewable PRs from one feature branch:
+
+1. Process-lifetime spike report and final supervision decision.
+2. Shared protocol and event-identity boundaries with no behavior change.
+3. Independently runnable Agent skeleton, lock, health, and diagnostics.
+4. Versioned Session Registry and provider observation reconciliation.
+5. Durable per-sink Outbox and failure recovery.
+6. Extension installation, credential handoff, mode, and status integration.
+7. Real-environment acceptance records, documentation, and opt-in rollout.
+
+No PR should claim background reliability before the Outbox, health state, and
+real disconnect acceptance path are all present.
+
+## Decisions Required Before Implementation Planning
+
+1. Approve Linux Remote SSH + managed tmux as the required v1 protected
+   environment.
+2. Approve `agent-pivot-agent` as the product/process boundary while keeping it
+   in this repository for v1.
+3. Select the supervision strategy from the process-lifetime spike evidence.
+4. Select the crash-consistent local storage implementation without changing
+   the Outbox semantics.
+5. Confirm the proposed 24-hour delivery freshness default.
+6. Decide whether Agent installation is bundled with the extension artifact or
+   downloaded from a separately signed release artifact.
+7. Confirm which notification channels are release-gating; existing channels
+   may remain supported without all becoming background-mode gates.
+
+These decisions are intentionally explicit. They prevent the first delivery
+feature from accidentally defining an unsafe or incompatible long-term Machine
+Agent platform.


### PR DESCRIPTION
## Summary

- define Agent Pivot's long-term direction as an IDE-independent, local-first platform built around Machine Agents, an optional Control Plane, and shared task/workflow identities
- specify Machine Agent v1 as the narrow near-term slice for reliable background Attention delivery on Remote SSH and managed tmux sessions
- mark the unimplemented `notifyd` design as historical so future implementation follows the durable Outbox, health, supervision, and rollout contracts in the new specification

## Key decisions captured

- keep the Machine Agent in this repository initially, but build and run it as an independent zero-`vscode` product artifact
- distinguish Task, Session, Run, WorkflowDefinition, and WorkflowRun rather than binding one task to one provider session or workflow
- retain foreground notification mode while making background protection explicit, capability-aware, and opt-in
- require a real Remote SSH process-lifetime spike and disconnect acceptance matrix before implementation planning claims background reliability
- persist per-sink delivery work before sending and record success only after an accepted transport response

## Verification

- `npm run test-compile`
- Markdown parsing and local-link resolution for all three changed documents
- `git diff --check origin/main...HEAD`
- complete merge-base-to-head document review; no unresolved Critical or Important findings

## Skill harvest

No skill change — the only workflow friction was an initial relative lookup of worktree-local skill mirrors; the provided absolute skill locators and existing loading rules already cover the correct behavior, so this was a compliance error rather than a reusable instruction gap.

## Owner approvals

```text
approve 48769c001813bafc8bb5645d90f880ebcc8f14c8
```
