### PR TITLE
feat(open-tab): persist the window view state host-side with legacy migration (M2 PR-C)

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -2977,6 +2977,26 @@
     ]
   },
   {
+    "id": "OPEN-WINDOW-VIEW-STATE-PERSISTENCE-001",
+    "domain": "persistence",
+    "title": "Window-scoped AI session view state (CHATS/ALL tab, CHATS view mode, collapsed worktree groups) persists Host-side keyed by workspace scope identity through a versioned webview protocol, with legacy surface/sub-tab migration mapped per the OPEN tab PRD",
+    "priority": "P1",
+    "status": "automated",
+    "owners": [
+      "tests/contract/persistence/stores.test.js",
+      "tests/contract/dashboard/messageHandlers.test.js",
+      "tests/contract/aiSessions/controllerBoundaries.test.js",
+      "tests/browser/worktreeGrouping.test.js"
+    ],
+    "evidence": [
+      "src/aiSessions/workspaceStateStore.ts",
+      "src/aiSessions/commandController.ts",
+      "src/dashboard/messageHandlers.ts",
+      "src/webview/webviewAiSessionViewStateScripts.js",
+      "src/webview/webviewProjectAiSessionControlsScripts.js"
+    ]
+  },
+  {
     "id": "WEBVIEW-CURRENT-WINDOW-SESSION-FIT-001",
     "domain": "webview",
     "title": "Expanded current-window card fits its OPEN tab region below the persistent WINDOWS switcher with the visible AI session panel filling the card and the session list as the only inner scroll surface",

--- a/media/webviewAiSessionViewStateScripts.js
+++ b/media/webviewAiSessionViewStateScripts.js
@@ -158,6 +158,18 @@ function writeAiSessionWorktreeCollapseState(vscodeApi, projectDiv) {
         aiSessionCollapsedWorktrees: projects,
         aiSessionExpandedGroupMembers: memberDetails,
     }));
+    // M2 transition: mirror the collapsed set into the host-persisted window
+    // view state so the PR-D tree view restores it across reloads. Every
+    // caller is a user-intent path (toggle / collapse-all / reveal-expand),
+    // never a replacement replay, so this posts exactly once per gesture.
+    if (typeof vscodeApi.postMessage === 'function') {
+        vscodeApi.postMessage({
+            type: 'set-ai-session-collapsed-worktree-groups',
+            version: 1,
+            projectId: projectId,
+            collapsedKeys: projects[projectId],
+        });
+    }
     syncAiSessionWorktreeCollapseAllButton(projectDiv);
 }
 
@@ -487,6 +499,39 @@ function getSelectedAiSessionTab(projectDiv) {
     if (!projectDiv || typeof projectDiv.querySelector !== 'function') return null;
     var selected = projectDiv.querySelector('[data-ai-session-tab][aria-selected="true"]');
     return selected ? normalizeAiSessionTab(selected.getAttribute('data-ai-session-tab')) : null;
+}
+
+// M2 transition: import the webview-held legacy sub-tab selection into the
+// host-persisted window view state exactly once per boot ('sessions' → ALL;
+// anything else is the CHATS default). The host first-writer-wins per scope,
+// so a live post-upgrade selection is never clobbered by a stale boot import.
+var legacyAiSessionTabImportDone = false;
+
+function maybeImportLegacyAiSessionViewState(vscodeApi, root) {
+    if (legacyAiSessionTabImportDone) {
+        return;
+    }
+    legacyAiSessionTabImportDone = true;
+    if (!vscodeApi || typeof vscodeApi.postMessage !== 'function') {
+        return;
+    }
+    var tabs = readAiSessionTabState(vscodeApi);
+    var currentCard = (root || document).querySelector(
+        '.workspace-card[data-current-workspace][data-id]'
+    );
+    var projectId = currentCard && currentCard.getAttribute('data-id');
+    var legacyTab = projectId && Object.prototype.hasOwnProperty.call(tabs, projectId)
+        ? tabs[projectId]
+        : null;
+    if (!legacyTab) {
+        return;
+    }
+    vscodeApi.postMessage({
+        type: 'migrate-ai-session-view-state',
+        version: 1,
+        projectId: projectId,
+        tab: legacyTab === 'sessions' ? 'all' : 'chats',
+    });
 }
 
 function getAiSessionScrollItemKey(row) {

--- a/media/webviewDashboardBundle.js
+++ b/media/webviewDashboardBundle.js
@@ -240,6 +240,18 @@ function writeAiSessionWorktreeCollapseState(vscodeApi, projectDiv) {
         aiSessionCollapsedWorktrees: projects,
         aiSessionExpandedGroupMembers: memberDetails,
     }));
+    // M2 transition: mirror the collapsed set into the host-persisted window
+    // view state so the PR-D tree view restores it across reloads. Every
+    // caller is a user-intent path (toggle / collapse-all / reveal-expand),
+    // never a replacement replay, so this posts exactly once per gesture.
+    if (typeof vscodeApi.postMessage === 'function') {
+        vscodeApi.postMessage({
+            type: 'set-ai-session-collapsed-worktree-groups',
+            version: 1,
+            projectId: projectId,
+            collapsedKeys: projects[projectId],
+        });
+    }
     syncAiSessionWorktreeCollapseAllButton(projectDiv);
 }
 
@@ -569,6 +581,39 @@ function getSelectedAiSessionTab(projectDiv) {
     if (!projectDiv || typeof projectDiv.querySelector !== 'function') return null;
     var selected = projectDiv.querySelector('[data-ai-session-tab][aria-selected="true"]');
     return selected ? normalizeAiSessionTab(selected.getAttribute('data-ai-session-tab')) : null;
+}
+
+// M2 transition: import the webview-held legacy sub-tab selection into the
+// host-persisted window view state exactly once per boot ('sessions' → ALL;
+// anything else is the CHATS default). The host first-writer-wins per scope,
+// so a live post-upgrade selection is never clobbered by a stale boot import.
+var legacyAiSessionTabImportDone = false;
+
+function maybeImportLegacyAiSessionViewState(vscodeApi, root) {
+    if (legacyAiSessionTabImportDone) {
+        return;
+    }
+    legacyAiSessionTabImportDone = true;
+    if (!vscodeApi || typeof vscodeApi.postMessage !== 'function') {
+        return;
+    }
+    var tabs = readAiSessionTabState(vscodeApi);
+    var currentCard = (root || document).querySelector(
+        '.workspace-card[data-current-workspace][data-id]'
+    );
+    var projectId = currentCard && currentCard.getAttribute('data-id');
+    var legacyTab = projectId && Object.prototype.hasOwnProperty.call(tabs, projectId)
+        ? tabs[projectId]
+        : null;
+    if (!legacyTab) {
+        return;
+    }
+    vscodeApi.postMessage({
+        type: 'migrate-ai-session-view-state',
+        version: 1,
+        projectId: projectId,
+        tab: legacyTab === 'sessions' ? 'all' : 'chats',
+    });
 }
 
 function getAiSessionScrollItemKey(row) {
@@ -5088,6 +5133,17 @@ function initProjectAiSessionControls(options) {
                 projectId: projectId,
                 surface: selectedSurface,
             });
+            if (selectedSurface === 'chats') {
+                // M2 transition: entering the legacy CHATS surface maps the
+                // current sub-tab onto the host-persisted window view tab.
+                var currentSubTab = getSelectedAiSessionTab(projectDiv);
+                window.vscode.postMessage({
+                    type: 'select-ai-session-view-tab',
+                    version: 1,
+                    projectId: projectId,
+                    tab: currentSubTab === 'sessions' ? 'all' : 'chats',
+                });
+            }
             return true;
         }
         var tabAction = target.closest('[data-action="select-ai-session-tab"][data-tab]');
@@ -5095,6 +5151,15 @@ function initProjectAiSessionControls(options) {
             var selectedTab = normalizeAiSessionTab(tabAction.getAttribute('data-tab'));
             selectAiSessionTabDom(projectDiv, selectedTab);
             writeAiSessionTabState(window.vscode, projectId, selectedTab);
+            // M2 transition: mirror the sub-tab selection into the
+            // host-persisted window view state (ACTIVE → chats, ALL → all) so
+            // the PR-D cutover reads live values instead of a migration.
+            window.vscode.postMessage({
+                type: 'select-ai-session-view-tab',
+                version: 1,
+                projectId: projectId,
+                tab: selectedTab === 'active' ? 'chats' : 'all',
+            });
             return true;
         }
 
@@ -8693,6 +8758,10 @@ function initProjects() {
         documentGeneration: window.__agentPivotReadyDocumentGeneration,
     });
     restoreAiSessionTabsFromState(document, window.vscode);
+    // M2 transition: import the legacy webview-held sub-tab selection into the
+    // host-persisted window view state once per boot (first-writer-wins host
+    // side), right after the in-session restore above consumed the same map.
+    maybeImportLegacyAiSessionViewState(window.vscode, document);
     window.vscode.postMessage({ type: 'request-active-ai-session-terminal' });
 
     observeStickyGroupHeaderOffset();

--- a/media/webviewProjectAiSessionControlsScripts.js
+++ b/media/webviewProjectAiSessionControlsScripts.js
@@ -441,6 +441,17 @@ function initProjectAiSessionControls(options) {
                 projectId: projectId,
                 surface: selectedSurface,
             });
+            if (selectedSurface === 'chats') {
+                // M2 transition: entering the legacy CHATS surface maps the
+                // current sub-tab onto the host-persisted window view tab.
+                var currentSubTab = getSelectedAiSessionTab(projectDiv);
+                window.vscode.postMessage({
+                    type: 'select-ai-session-view-tab',
+                    version: 1,
+                    projectId: projectId,
+                    tab: currentSubTab === 'sessions' ? 'all' : 'chats',
+                });
+            }
             return true;
         }
         var tabAction = target.closest('[data-action="select-ai-session-tab"][data-tab]');
@@ -448,6 +459,15 @@ function initProjectAiSessionControls(options) {
             var selectedTab = normalizeAiSessionTab(tabAction.getAttribute('data-tab'));
             selectAiSessionTabDom(projectDiv, selectedTab);
             writeAiSessionTabState(window.vscode, projectId, selectedTab);
+            // M2 transition: mirror the sub-tab selection into the
+            // host-persisted window view state (ACTIVE → chats, ALL → all) so
+            // the PR-D cutover reads live values instead of a migration.
+            window.vscode.postMessage({
+                type: 'select-ai-session-view-tab',
+                version: 1,
+                projectId: projectId,
+                tab: selectedTab === 'active' ? 'chats' : 'all',
+            });
             return true;
         }
 

--- a/media/webviewProjectScripts.js
+++ b/media/webviewProjectScripts.js
@@ -1045,6 +1045,10 @@ function initProjects() {
         documentGeneration: window.__agentPivotReadyDocumentGeneration,
     });
     restoreAiSessionTabsFromState(document, window.vscode);
+    // M2 transition: import the legacy webview-held sub-tab selection into the
+    // host-persisted window view state once per boot (first-writer-wins host
+    // side), right after the in-session restore above consumed the same map.
+    maybeImportLegacyAiSessionViewState(window.vscode, document);
     window.vscode.postMessage({ type: 'request-active-ai-session-terminal' });
 
     observeStickyGroupHeaderOffset();

--- a/src/aiSessions/commandController.ts
+++ b/src/aiSessions/commandController.ts
@@ -191,6 +191,22 @@ export interface AiSessionCommandControllerOptions {
         workspaceScopeIdentity: string,
         surface: 'worktree' | 'chats'
     ) => Thenable<unknown>;
+    setWindowViewTab: (
+        workspaceScopeIdentity: string,
+        tab: 'chats' | 'all'
+    ) => Thenable<unknown>;
+    setChatsViewMode: (
+        workspaceScopeIdentity: string,
+        viewMode: 'tree' | 'list'
+    ) => Thenable<unknown>;
+    setCollapsedWorktreeGroups: (
+        workspaceScopeIdentity: string,
+        collapsedKeys: readonly string[]
+    ) => Thenable<unknown>;
+    importLegacyWindowViewTab: (
+        workspaceScopeIdentity: string,
+        tab: 'chats' | 'all'
+    ) => Thenable<boolean>;
     setProviderSelection: (
         workspaceScopeIdentity: string,
         selection: AiSessionProviderSelection
@@ -354,6 +370,64 @@ export class AiSessionCommandController {
             return;
         }
         await this.options.setSelectedSurface(workspaceTarget.workspace.scopeIdentity, surface);
+        // M2 transition dual-write: the legacy WORKTREE surface maps onto
+        // CHATS + tree in the window view-state store, so the PR-D cutover
+        // reads live values instead of a one-shot migration. The 'chats'
+        // surface carries no view state — the sub-tab writes it directly.
+        if (surface === 'worktree') {
+            await this.options.setWindowViewTab(workspaceTarget.workspace.scopeIdentity, 'chats');
+            await this.options.setChatsViewMode(workspaceTarget.workspace.scopeIdentity, 'tree');
+        }
+    }
+
+    async selectWindowViewTab(projectId: unknown, tab: unknown): Promise<void> {
+        if (typeof projectId !== 'string' || !projectId
+            || (tab !== 'chats' && tab !== 'all')) {
+            return;
+        }
+        const workspaceTarget = this.options.getWorkspaceTarget(projectId);
+        if (!workspaceTarget) {
+            return;
+        }
+        await this.options.setWindowViewTab(workspaceTarget.workspace.scopeIdentity, tab);
+    }
+
+    async selectChatsViewMode(projectId: unknown, viewMode: unknown): Promise<void> {
+        if (typeof projectId !== 'string' || !projectId
+            || (viewMode !== 'tree' && viewMode !== 'list')) {
+            return;
+        }
+        const workspaceTarget = this.options.getWorkspaceTarget(projectId);
+        if (!workspaceTarget) {
+            return;
+        }
+        await this.options.setChatsViewMode(workspaceTarget.workspace.scopeIdentity, viewMode);
+    }
+
+    async setCollapsedWorktreeGroups(projectId: unknown, collapsedKeys: unknown): Promise<void> {
+        if (typeof projectId !== 'string' || !projectId || !Array.isArray(collapsedKeys)) {
+            return;
+        }
+        const workspaceTarget = this.options.getWorkspaceTarget(projectId);
+        if (!workspaceTarget) {
+            return;
+        }
+        await this.options.setCollapsedWorktreeGroups(
+            workspaceTarget.workspace.scopeIdentity,
+            collapsedKeys.filter((key): key is string => typeof key === 'string')
+        );
+    }
+
+    async importLegacyWindowViewTab(projectId: unknown, tab: unknown): Promise<void> {
+        if (typeof projectId !== 'string' || !projectId
+            || (tab !== 'chats' && tab !== 'all')) {
+            return;
+        }
+        const workspaceTarget = this.options.getWorkspaceTarget(projectId);
+        if (!workspaceTarget) {
+            return;
+        }
+        await this.options.importLegacyWindowViewTab(workspaceTarget.workspace.scopeIdentity, tab);
     }
 
     async selectProviders(

--- a/src/aiSessions/sessionControllerComposition.ts
+++ b/src/aiSessions/sessionControllerComposition.ts
@@ -427,6 +427,14 @@ export function createSessionControllerComposition(
         setExpanded: (workspaceScopeIdentity, expanded) => aiSessionWorkspaceStateStore.setExpanded(workspaceScopeIdentity, expanded),
         setSelectedSurface: (workspaceScopeIdentity, surface) =>
             aiSessionWorkspaceStateStore.setSelectedSurface(workspaceScopeIdentity, surface),
+        setWindowViewTab: (workspaceScopeIdentity, tab) =>
+            aiSessionWorkspaceStateStore.setWindowViewTab(workspaceScopeIdentity, tab),
+        setChatsViewMode: (workspaceScopeIdentity, viewMode) =>
+            aiSessionWorkspaceStateStore.setChatsViewMode(workspaceScopeIdentity, viewMode),
+        setCollapsedWorktreeGroups: (workspaceScopeIdentity, collapsedKeys) =>
+            aiSessionWorkspaceStateStore.setCollapsedWorktreeGroups(workspaceScopeIdentity, collapsedKeys),
+        importLegacyWindowViewTab: (workspaceScopeIdentity, tab) =>
+            aiSessionWorkspaceStateStore.importLegacyWindowViewTab(workspaceScopeIdentity, tab),
         setProviderSelection: (workspaceScopeIdentity, selection) =>
             aiSessionWorkspaceStateStore.setProviderSelection(workspaceScopeIdentity, selection),
         postProviderSelectionResult: result => postMessage(result),

--- a/src/aiSessions/workspaceStateStore.ts
+++ b/src/aiSessions/workspaceStateStore.ts
@@ -5,6 +5,7 @@ import {
     WORKSPACE_ACTIVE_AI_SESSION_PROVIDER_KEY,
     WORKSPACE_AI_SESSION_PROVIDER_SELECTION_KEY,
     WORKSPACE_AI_SESSION_SURFACE_KEY,
+    WORKSPACE_AI_SESSION_VIEW_STATE_KEY,
     WORKSPACE_EXPANDED_AI_SESSIONS_KEY,
     WORKSPACE_QUICK_CREATE_AI_SESSION_PROVIDER_KEY,
 } from '../constants';
@@ -18,6 +19,18 @@ interface MementoLike {
 }
 
 export type AiSessionSurfaceId = 'worktree' | 'chats';
+
+/** M2 window-scoped OPEN tab view state (PRD 状态模型: CHATS/ALL tab, CHATS 视图模式, worktree 组折叠集合). */
+export type AiSessionWindowViewTab = 'chats' | 'all';
+export type AiSessionChatsViewMode = 'tree' | 'list';
+export interface AiSessionWindowViewState {
+    tab?: AiSessionWindowViewTab;
+    chatsViewMode?: AiSessionChatsViewMode;
+    collapsedWorktreeGroups?: string[];
+}
+
+const MAX_COLLAPSED_WORKTREE_GROUPS = 500;
+const MAX_WORKTREE_GROUP_KEY_LENGTH = 1024;
 
 export default class AiSessionWorkspaceStateStore {
     constructor(
@@ -123,6 +136,150 @@ export default class AiSessionWorkspaceStateStore {
         const surfaces = this.getSelectedSurfaces();
         surfaces[workspaceScopeIdentity] = surface;
         await this.state.update(WORKSPACE_AI_SESSION_SURFACE_KEY, surfaces);
+    }
+
+    // --- M2 window view state (additive; PR-D makes it the render source) ---
+
+    private readWindowViewStates(): Record<string, AiSessionWindowViewState> {
+        const stored = this.state.get<unknown>(WORKSPACE_AI_SESSION_VIEW_STATE_KEY);
+        if (!stored || typeof stored !== 'object' || Array.isArray(stored)) {
+            return {};
+        }
+        const result: Record<string, AiSessionWindowViewState> = {};
+        for (const [scopeIdentity, value] of Object.entries(stored as Record<string, unknown>)) {
+            if (!scopeIdentity || !value || typeof value !== 'object' || Array.isArray(value)) {
+                continue;
+            }
+            const record = value as Record<string, unknown>;
+            const entry: AiSessionWindowViewState = {};
+            if (record.tab === 'chats' || record.tab === 'all') {
+                entry.tab = record.tab;
+            }
+            if (record.chatsViewMode === 'tree' || record.chatsViewMode === 'list') {
+                entry.chatsViewMode = record.chatsViewMode;
+            }
+            if (Array.isArray(record.collapsedWorktreeGroups)) {
+                const keys = record.collapsedWorktreeGroups
+                    .filter((key): key is string =>
+                        typeof key === 'string'
+                        && key.length > 0
+                        && key.length <= MAX_WORKTREE_GROUP_KEY_LENGTH)
+                    .slice(0, MAX_COLLAPSED_WORKTREE_GROUPS);
+                entry.collapsedWorktreeGroups = Array.from(new Set(keys));
+            }
+            result[scopeIdentity] = entry;
+        }
+        return result;
+    }
+
+    /**
+     * The window's resolved view state. Unstored fields fall to the CHATS +
+     * tree defaults, which double as the存量迁移 mapping: a legacy 'worktree'
+     * surface lands on CHATS + tree, and a legacy 'chats' surface refines the
+     * tab through the webview's one-time legacy sub-tab import
+     * (`importLegacyWindowViewTab`: sub-tab 'sessions' → ALL).
+     */
+    getWindowViewState(workspaceScopeIdentity: string): AiSessionWindowViewState {
+        if (!workspaceScopeIdentity) {
+            return {};
+        }
+        const stored = this.readWindowViewStates()[workspaceScopeIdentity];
+        if (stored?.tab && stored?.chatsViewMode) {
+            return stored;
+        }
+        return {
+            tab: stored?.tab ?? 'chats',
+            chatsViewMode: stored?.chatsViewMode ?? 'tree',
+            ...(stored?.collapsedWorktreeGroups
+                ? { collapsedWorktreeGroups: stored.collapsedWorktreeGroups }
+                : {}),
+        };
+    }
+
+    private async updateWindowViewState(
+        workspaceScopeIdentity: string,
+        patch: (current: AiSessionWindowViewState) => AiSessionWindowViewState,
+    ): Promise<void> {
+        if (!workspaceScopeIdentity) {
+            return;
+        }
+        const states = this.readWindowViewStates();
+        states[workspaceScopeIdentity] = patch(states[workspaceScopeIdentity] || {});
+        await this.state.update(WORKSPACE_AI_SESSION_VIEW_STATE_KEY, states);
+    }
+
+    async setWindowViewTab(
+        workspaceScopeIdentity: string,
+        tab: AiSessionWindowViewTab
+    ): Promise<void> {
+        if (tab !== 'chats' && tab !== 'all') {
+            return;
+        }
+        await this.updateWindowViewState(workspaceScopeIdentity, current => ({
+            ...current,
+            tab,
+        }));
+    }
+
+    async setChatsViewMode(
+        workspaceScopeIdentity: string,
+        viewMode: AiSessionChatsViewMode
+    ): Promise<void> {
+        if (viewMode !== 'tree' && viewMode !== 'list') {
+            return;
+        }
+        await this.updateWindowViewState(workspaceScopeIdentity, current => ({
+            ...current,
+            chatsViewMode: viewMode,
+        }));
+    }
+
+    async setCollapsedWorktreeGroups(
+        workspaceScopeIdentity: string,
+        collapsedKeys: readonly string[]
+    ): Promise<void> {
+        // A non-array payload is junk, not a clear-all: only an explicit
+        // (possibly empty) array replaces the collapsed set.
+        if (!Array.isArray(collapsedKeys)) {
+            return;
+        }
+        const keys = collapsedKeys
+            .filter((key): key is string =>
+                typeof key === 'string'
+                && key.length > 0
+                && key.length <= MAX_WORKTREE_GROUP_KEY_LENGTH)
+            .slice(0, MAX_COLLAPSED_WORKTREE_GROUPS);
+        await this.updateWindowViewState(workspaceScopeIdentity, current => ({
+            ...current,
+            collapsedWorktreeGroups: Array.from(new Set(keys)),
+        }));
+    }
+
+    /**
+     * One-time legacy import from the webview-held sub-tab state: fills the
+     * window's tab only when no new tab was persisted yet. A legacy 'worktree'
+     * surface migrates to CHATS regardless of the hidden sub-tab (PRD 存量迁移),
+     * so the import stays out of that case; 'chats' + sub-tab 'sessions' maps
+     * to ALL through the import.
+     */
+    async importLegacyWindowViewTab(
+        workspaceScopeIdentity: string,
+        tab: AiSessionWindowViewTab
+    ): Promise<boolean> {
+        if (!workspaceScopeIdentity || (tab !== 'chats' && tab !== 'all')) {
+            return false;
+        }
+        if (this.readWindowViewStates()[workspaceScopeIdentity]?.tab) {
+            return false;
+        }
+        if (this.getSelectedSurfaces()[workspaceScopeIdentity] === 'worktree') {
+            return false;
+        }
+        await this.updateWindowViewState(workspaceScopeIdentity, current => ({
+            ...current,
+            tab,
+        }));
+        return true;
     }
 
     private readProviderSelections(): Record<string, AiSessionProviderSelection> {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -45,6 +45,12 @@ export const WORKSPACE_QUICK_CREATE_AI_SESSION_PROVIDER_KEY =
 export const WORKSPACE_AI_SESSION_PROVIDER_SELECTION_KEY =
     'workspaceAiSessionProviderSelection.v1';
 export const WORKSPACE_AI_SESSION_SURFACE_KEY = 'workspaceAiSessionSurface.v1';
+// Per-window (scopeIdentity-keyed) OPEN tab view state for the M2 CHATS/ALL
+// restructure: selected top tab, CHATS view mode, and collapsed worktree
+// groups. The legacy surface key above stays the write target for the
+// pre-M2 surface tabs; this record is backfilled from it until PR-D retires
+// the surface model.
+export const WORKSPACE_AI_SESSION_VIEW_STATE_KEY = 'workspaceAiSessionViewState.v1';
 
 export enum StorageOption {
     GlobalState,

--- a/src/dashboard/messageHandlers.ts
+++ b/src/dashboard/messageHandlers.ts
@@ -144,6 +144,42 @@ export function createDashboardMessageHandlers(
             }
             await aiSessionCommandController.selectSurface(e.projectId, e.surface);
         },
+        // M2 window view-state protocol (additive until the PR-D cutover).
+        // Same fire-and-forget semantics as the surface route: strict envelope
+        // shape, controller resolves the workspace scope, store validates.
+        'select-ai-session-view-tab': async e => {
+            const keys = Object.keys(e).sort();
+            if (e.version !== 1
+                || keys.join('\n') !== ['projectId', 'tab', 'type', 'version'].sort().join('\n')) {
+                return;
+            }
+            await aiSessionCommandController.selectWindowViewTab(e.projectId, e.tab);
+        },
+        'select-ai-session-chats-view-mode': async e => {
+            const keys = Object.keys(e).sort();
+            if (e.version !== 1
+                || keys.join('\n') !== ['projectId', 'type', 'version', 'viewMode'].sort().join('\n')) {
+                return;
+            }
+            await aiSessionCommandController.selectChatsViewMode(e.projectId, e.viewMode);
+        },
+        'set-ai-session-collapsed-worktree-groups': async e => {
+            const keys = Object.keys(e).sort();
+            if (e.version !== 1
+                || keys.join('\n')
+                    !== ['collapsedKeys', 'projectId', 'type', 'version'].sort().join('\n')) {
+                return;
+            }
+            await aiSessionCommandController.setCollapsedWorktreeGroups(e.projectId, e.collapsedKeys);
+        },
+        'migrate-ai-session-view-state': async e => {
+            const keys = Object.keys(e).sort();
+            if (e.version !== 1
+                || keys.join('\n') !== ['projectId', 'tab', 'type', 'version'].sort().join('\n')) {
+                return;
+            }
+            await aiSessionCommandController.importLegacyWindowViewTab(e.projectId, e.tab);
+        },
         'select-ai-session-providers': async e => {
             await aiSessionCommandController.selectProviders(
                 e.projectId as string,

--- a/src/webview/webviewAiSessionViewStateScripts.js
+++ b/src/webview/webviewAiSessionViewStateScripts.js
@@ -158,6 +158,18 @@ function writeAiSessionWorktreeCollapseState(vscodeApi, projectDiv) {
         aiSessionCollapsedWorktrees: projects,
         aiSessionExpandedGroupMembers: memberDetails,
     }));
+    // M2 transition: mirror the collapsed set into the host-persisted window
+    // view state so the PR-D tree view restores it across reloads. Every
+    // caller is a user-intent path (toggle / collapse-all / reveal-expand),
+    // never a replacement replay, so this posts exactly once per gesture.
+    if (typeof vscodeApi.postMessage === 'function') {
+        vscodeApi.postMessage({
+            type: 'set-ai-session-collapsed-worktree-groups',
+            version: 1,
+            projectId: projectId,
+            collapsedKeys: projects[projectId],
+        });
+    }
     syncAiSessionWorktreeCollapseAllButton(projectDiv);
 }
 
@@ -487,6 +499,39 @@ function getSelectedAiSessionTab(projectDiv) {
     if (!projectDiv || typeof projectDiv.querySelector !== 'function') return null;
     var selected = projectDiv.querySelector('[data-ai-session-tab][aria-selected="true"]');
     return selected ? normalizeAiSessionTab(selected.getAttribute('data-ai-session-tab')) : null;
+}
+
+// M2 transition: import the webview-held legacy sub-tab selection into the
+// host-persisted window view state exactly once per boot ('sessions' → ALL;
+// anything else is the CHATS default). The host first-writer-wins per scope,
+// so a live post-upgrade selection is never clobbered by a stale boot import.
+var legacyAiSessionTabImportDone = false;
+
+function maybeImportLegacyAiSessionViewState(vscodeApi, root) {
+    if (legacyAiSessionTabImportDone) {
+        return;
+    }
+    legacyAiSessionTabImportDone = true;
+    if (!vscodeApi || typeof vscodeApi.postMessage !== 'function') {
+        return;
+    }
+    var tabs = readAiSessionTabState(vscodeApi);
+    var currentCard = (root || document).querySelector(
+        '.workspace-card[data-current-workspace][data-id]'
+    );
+    var projectId = currentCard && currentCard.getAttribute('data-id');
+    var legacyTab = projectId && Object.prototype.hasOwnProperty.call(tabs, projectId)
+        ? tabs[projectId]
+        : null;
+    if (!legacyTab) {
+        return;
+    }
+    vscodeApi.postMessage({
+        type: 'migrate-ai-session-view-state',
+        version: 1,
+        projectId: projectId,
+        tab: legacyTab === 'sessions' ? 'all' : 'chats',
+    });
 }
 
 function getAiSessionScrollItemKey(row) {

--- a/src/webview/webviewProjectAiSessionControlsScripts.js
+++ b/src/webview/webviewProjectAiSessionControlsScripts.js
@@ -441,6 +441,17 @@ function initProjectAiSessionControls(options) {
                 projectId: projectId,
                 surface: selectedSurface,
             });
+            if (selectedSurface === 'chats') {
+                // M2 transition: entering the legacy CHATS surface maps the
+                // current sub-tab onto the host-persisted window view tab.
+                var currentSubTab = getSelectedAiSessionTab(projectDiv);
+                window.vscode.postMessage({
+                    type: 'select-ai-session-view-tab',
+                    version: 1,
+                    projectId: projectId,
+                    tab: currentSubTab === 'sessions' ? 'all' : 'chats',
+                });
+            }
             return true;
         }
         var tabAction = target.closest('[data-action="select-ai-session-tab"][data-tab]');
@@ -448,6 +459,15 @@ function initProjectAiSessionControls(options) {
             var selectedTab = normalizeAiSessionTab(tabAction.getAttribute('data-tab'));
             selectAiSessionTabDom(projectDiv, selectedTab);
             writeAiSessionTabState(window.vscode, projectId, selectedTab);
+            // M2 transition: mirror the sub-tab selection into the
+            // host-persisted window view state (ACTIVE → chats, ALL → all) so
+            // the PR-D cutover reads live values instead of a migration.
+            window.vscode.postMessage({
+                type: 'select-ai-session-view-tab',
+                version: 1,
+                projectId: projectId,
+                tab: selectedTab === 'active' ? 'chats' : 'all',
+            });
             return true;
         }
 

--- a/src/webview/webviewProjectScripts.js
+++ b/src/webview/webviewProjectScripts.js
@@ -1045,6 +1045,10 @@ function initProjects() {
         documentGeneration: window.__agentPivotReadyDocumentGeneration,
     });
     restoreAiSessionTabsFromState(document, window.vscode);
+    // M2 transition: import the legacy webview-held sub-tab selection into the
+    // host-persisted window view state once per boot (first-writer-wins host
+    // side), right after the in-session restore above consumed the same map.
+    maybeImportLegacyAiSessionViewState(window.vscode, document);
     window.vscode.postMessage({ type: 'request-active-ai-session-terminal' });
 
     observeStickyGroupHeaderOffset();

--- a/tests/browser/activeSessionCardInteraction.test.js
+++ b/tests/browser/activeSessionCardInteraction.test.js
@@ -2998,7 +2998,7 @@ test('ACTIVE-SESSION-CONVERSATION-FOCUS-001 closing a conversation keeps the wor
     assert.equal(await worktreeTab.getAttribute('aria-selected'), 'true',
         'closing the conversation keeps the worktree surface');
     assert.equal(await chatsTab.getAttribute('aria-selected'), 'false');
-    assert.deepEqual((await postedMessages(page)).at(-1), {
+    assert.deepEqual((await postedMessages(page)).find(message => message.type === 'select-ai-session-surface'), {
         type: 'select-ai-session-surface',
         version: 1,
         projectId: 'project-a',
@@ -3047,4 +3047,67 @@ test('ACTIVE-SESSION-CONVERSATION-FOCUS-002 falls back to ACTIVE for a stale sam
         await sessionsTab.evaluate(tab => document.activeElement === tab),
         true
     );
+});
+
+test('OPEN-WINDOW-VIEW-STATE-PERSISTENCE-001 sub-tab and surface clicks mirror into the window view-state protocol', async t => {
+    const active = [session('codex', 'active-1', true)];
+    const page = await openCardPage(t, active);
+
+    await page.locator('[data-ai-session-tab="sessions"]').click();
+    await page.locator('[data-ai-session-tab="active"]').click();
+    let posts = await page.evaluate(() =>
+        window.__postedMessages.filter(message => message.type === 'select-ai-session-view-tab'));
+    assert.deepEqual(posts, [
+        { type: 'select-ai-session-view-tab', version: 1, projectId: 'project-a', tab: 'all' },
+        { type: 'select-ai-session-view-tab', version: 1, projectId: 'project-a', tab: 'chats' },
+    ], 'sub-tab clicks mirror ACTIVE→chats / ALL→all into the host-persisted view state');
+
+    // Switching to the CHATS surface mirrors the current sub-tab; the WORKTREE
+    // surface maps host-side instead (no webview view-tab post).
+    await page.locator('[data-action="select-ai-session-surface"][data-surface="worktree"]').click();
+    await page.locator('[data-action="select-ai-session-surface"][data-surface="chats"]').click();
+    posts = await page.evaluate(() =>
+        window.__postedMessages.filter(message => message.type === 'select-ai-session-view-tab'));
+    assert.equal(posts.length, 3);
+    assert.equal(posts[2].tab, 'chats', 'the current ACTIVE sub-tab maps to the CHATS view tab');
+    const surfaces = await page.evaluate(() =>
+        window.__postedMessages.filter(message => message.type === 'select-ai-session-surface'));
+    assert.equal(surfaces.length, 2, 'the legacy surface message still posts for both clicks');
+});
+
+test('OPEN-WINDOW-VIEW-STATE-PERSISTENCE-001 boot imports the legacy webview sub-tab selection once', async t => {
+    const active = [session('codex', 'active-1', true)];
+    const page = await browser.newPage({ viewport: { width: 360, height: 900 } });
+    t.after(() => page.close());
+    page.setDefaultTimeout(BROWSER_CONDITION_TIMEOUT_MS);
+    await page.setContent(documentMarkup(active));
+    await page.evaluate(() => {
+        window.__postedMessages = [];
+        window.normalizeDashboardSearchCatalog = catalog => catalog;
+        let state = { aiSessionTabs: { 'project-a': 'sessions' } };
+        window.vscode = {
+            getState: () => state,
+            setState(next) { state = next; },
+            postMessage: message => window.__postedMessages.push(message),
+        };
+    });
+    for (const source of [
+        scrollStateScript, viewStateScript, workspaceUpdateScript, todoGroupScript,
+        projectCollapseScript, todoControlScript, projectContextMenuScript,
+        projectAiUpdateScript, groupFormScript, aiSessionControlsScript, projectScript,
+    ]) {
+        await page.addScriptTag({ content: source });
+    }
+    await page.evaluate(() => initProjects());
+    const migrations = await page.evaluate(() =>
+        window.__postedMessages.filter(message => message.type === 'migrate-ai-session-view-state'));
+    assert.deepEqual(migrations, [{
+        type: 'migrate-ai-session-view-state', version: 1, projectId: 'project-a', tab: 'all',
+    }], "the legacy 'sessions' sub-tab imports as the ALL view tab at boot");
+
+    // The once-per-boot guard blocks repeat imports (e.g. a second init pass).
+    await page.evaluate(() => maybeImportLegacyAiSessionViewState(window.vscode, document));
+    const after = await page.evaluate(() =>
+        window.__postedMessages.filter(message => message.type === 'migrate-ai-session-view-state'));
+    assert.equal(after.length, 1);
 });

--- a/tests/browser/quickSessionCreate.test.js
+++ b/tests/browser/quickSessionCreate.test.js
@@ -634,7 +634,7 @@ test('WORKTREE-GROUPING-UI-001 revealing a switched session follows it into its 
         true,
         'the group expands so the session row is visible'
     );
-    assert.deepEqual((await postedMessages(page)).at(-1), {
+    assert.deepEqual((await postedMessages(page)).find(message => message.type === 'select-ai-session-surface'), {
         type: 'select-ai-session-surface',
         version: 1,
         projectId: 'project-a',
@@ -767,7 +767,9 @@ test('WORKTREE-GROUPING-UI-001 selecting a surface reports it for authoritative 
     );
 
     await project.locator('[data-ai-session-surface-tab="chats"]').click();
-    assert.deepEqual((await postedMessages(page)).at(-1), {
+    assert.deepEqual((await postedMessages(page)).find(
+        message => message.type === 'select-ai-session-surface' && message.surface === 'chats'
+    ), {
         type: 'select-ai-session-surface',
         version: 1,
         projectId: 'project-a',

--- a/tests/browser/worktreeGrouping.test.js
+++ b/tests/browser/worktreeGrouping.test.js
@@ -268,3 +268,35 @@ test('WORKTREE-GROUPING-UI-001 renders Worktree and Chats at the default sidebar
     assert.ok(chatsScreenshot.length > 1_000,
         'default-width Chats screenshot must contain rendered pixels');
 });
+
+test('WORKTREE-GROUPING-UI-001 OPEN-WINDOW-VIEW-STATE-PERSISTENCE-001 collapse gestures mirror the group keys into the window view-state protocol', async t => {
+    const page = await openSurfacePage(320);
+    t.after(() => page.close());
+    await page.evaluate(() => {
+        window.__postedMessages = [];
+        let state = {};
+        window.vscode = {
+            getState: () => state,
+            setState(next) { state = next; },
+            postMessage: message => window.__postedMessages.push(message),
+        };
+        selectAiSessionSurfaceDom(document.querySelector('.project'), 'worktree');
+    });
+
+    // Collapse-everything via the collapse-all affordance path.
+    await page.evaluate(() => toggleAllAiSessionWorktrees(document.querySelector('.project')));
+    let posts = await page.evaluate(() =>
+        window.__postedMessages.filter(message => message.type === 'set-ai-session-collapsed-worktree-groups'));
+    assert.equal(posts.length, 1, 'one mirror post per collapse gesture');
+    assert.equal(posts[0].version, 1);
+    assert.equal(posts[0].projectId, 'project-a');
+    assert.equal(posts[0].collapsedKeys.length, 2,
+        'both unmanaged worktree groups are reported collapsed');
+
+    // Expanding again mirrors the empty set.
+    await page.evaluate(() => toggleAllAiSessionWorktrees(document.querySelector('.project')));
+    posts = await page.evaluate(() =>
+        window.__postedMessages.filter(message => message.type === 'set-ai-session-collapsed-worktree-groups'));
+    assert.equal(posts.length, 2);
+    assert.deepEqual(posts[1].collapsedKeys, []);
+});

--- a/tests/contract/aiSessions/controllerBoundaries.test.js
+++ b/tests/contract/aiSessions/controllerBoundaries.test.js
@@ -118,7 +118,7 @@ test('SESSION-ALIAS-THREAD-SWITCH-001 copies an old alias without removing it or
     assert.equal(saveErrors, 1);
 });
 
-test('SESSION-AI-SESSION-COMMAND-CONTROLLER-001 exposes validated command effects without mutating invalid targets', async () => {
+test('SESSION-AI-SESSION-COMMAND-CONTROLLER-001 OPEN-WINDOW-VIEW-STATE-PERSISTENCE-001 exposes validated command effects without mutating invalid targets', async () => {
     const effects = [];
     const workspaceTarget = {
         cardId: 'project',
@@ -137,6 +137,13 @@ test('SESSION-AI-SESSION-COMMAND-CONTROLLER-001 exposes validated command effect
         isProviderId: value => value === 'codex',
         setExpanded: async (key, value) => effects.push(['expanded', key, value]),
         setSelectedSurface: async (key, value) => effects.push(['surface', key, value]),
+        setWindowViewTab: async (key, value) => effects.push(['view-tab', key, value]),
+        setChatsViewMode: async (key, value) => effects.push(['view-mode', key, value]),
+        setCollapsedWorktreeGroups: async (key, value) => effects.push(['collapsed-groups', key, value]),
+        importLegacyWindowViewTab: async (key, value) => {
+            effects.push(['import-tab', key, value]);
+            return true;
+        },
         setProviderSelection: async (scope, selection) =>
             effects.push(['providers', scope, selection]),
         postProviderSelectionResult: async result => effects.push(['provider-result', result]),
@@ -152,12 +159,29 @@ test('SESSION-AI-SESSION-COMMAND-CONTROLLER-001 exposes validated command effect
     await controller.selectSurface('project', 'worktree');
     await controller.selectSurface('project', 'grid');
     await controller.selectSurface('missing', 'chats');
+    await controller.selectSurface('project', 'chats');
+    await controller.selectWindowViewTab('project', 'all');
+    await controller.selectWindowViewTab('project', 'grid');
+    await controller.selectChatsViewMode('project', 'list');
+    await controller.setCollapsedWorktreeGroups('project', ['["__anchor__"]', 7, null]);
+    await controller.setCollapsedWorktreeGroups('missing', ['x']);
+    await controller.importLegacyWindowViewTab('project', 'all');
     await controller.selectProviders('project', ['claude', 'codex', 'claude', 'unknown'], 7, 1);
     await controller.renameSession('codex', 'session');
     await controller.copySessionId('session');
     assert.deepEqual(effects, [
         ['expanded', 'scope:/work', true],
         ['surface', 'scope:/work', 'worktree'],
+        // M2 transition dual-write: the worktree surface maps to CHATS + tree.
+        ['view-tab', 'scope:/work', 'chats'],
+        ['view-mode', 'scope:/work', 'tree'],
+        // The 'chats' surface carries no view-state dual-write.
+        ['surface', 'scope:/work', 'chats'],
+        ['view-tab', 'scope:/work', 'all'],
+        ['view-mode', 'scope:/work', 'list'],
+        // Non-string group keys are filtered before reaching the store.
+        ['collapsed-groups', 'scope:/work', ['["__anchor__"]']],
+        ['import-tab', 'scope:/work', 'all'],
         ['providers', 'scope:/work', {
             primaryProvider: 'codex',
             selectedProviders: ['codex', 'claude'],

--- a/tests/contract/dashboard/messageHandlers.test.js
+++ b/tests/contract/dashboard/messageHandlers.test.js
@@ -45,6 +45,10 @@ function createFixture(overrides = {}) {
         aiSessionCommandController: {
             toggleSessionsExpanded: record('toggleSessionsExpanded'),
             selectSurface: record('selectSurface'),
+            selectWindowViewTab: record('selectWindowViewTab'),
+            selectChatsViewMode: record('selectChatsViewMode'),
+            setCollapsedWorktreeGroups: record('setCollapsedWorktreeGroups'),
+            importLegacyWindowViewTab: record('importLegacyWindowViewTab'),
             selectProviders: record('selectProviders'),
             togglePin: record('togglePin'),
             renameSession: record('renameSession'),
@@ -85,6 +89,11 @@ test('WEBVIEW-DASHBOARD-MESSAGE-ROUTER-001 exposes every extracted handler key',
         'prompt-insert-terminal',
         'toggle-codex-sessions',
         'select-ai-session-surface',
+        // M2 window view-state protocol (PR-C; the PR-D cutover consumes it).
+        'select-ai-session-view-tab',
+        'select-ai-session-chats-view-mode',
+        'set-ai-session-collapsed-worktree-groups',
+        'migrate-ai-session-view-state',
         'select-ai-session-providers',
         'focus-ai-session-terminal',
         'focus-pending-ai-session',
@@ -437,6 +446,48 @@ test('WORKTREE-GROUPING-UI-001 stores the surface selection only from exact enve
         projectId: 'p1', surface: 'chats',
     });
     assert.equal(calls.length, 1, 'extra keys and wrong versions must be rejected');
+});
+
+test('OPEN-WINDOW-VIEW-STATE-PERSISTENCE-001 routes the window view-state protocol only from exact envelopes', async () => {
+    const { handlers, calls } = createFixture();
+
+    await handlers['select-ai-session-view-tab']({
+        type: 'select-ai-session-view-tab', version: 1, projectId: 'p1', tab: 'all',
+    });
+    await handlers['select-ai-session-chats-view-mode']({
+        type: 'select-ai-session-chats-view-mode', version: 1, projectId: 'p1', viewMode: 'tree',
+    });
+    await handlers['set-ai-session-collapsed-worktree-groups']({
+        type: 'set-ai-session-collapsed-worktree-groups', version: 1, projectId: 'p1',
+        collapsedKeys: ['["__anchor__"]'],
+    });
+    await handlers['migrate-ai-session-view-state']({
+        type: 'migrate-ai-session-view-state', version: 1, projectId: 'p1', tab: 'chats',
+    });
+    assert.deepEqual(calls, [
+        ['selectWindowViewTab', 'p1', 'all'],
+        ['selectChatsViewMode', 'p1', 'tree'],
+        ['setCollapsedWorktreeGroups', 'p1', ['["__anchor__"]']],
+        ['importLegacyWindowViewTab', 'p1', 'chats'],
+    ]);
+
+    calls.length = 0;
+    await handlers['select-ai-session-view-tab']({
+        type: 'select-ai-session-view-tab', version: 2, projectId: 'p1', tab: 'all',
+    });
+    await handlers['select-ai-session-view-tab']({
+        type: 'select-ai-session-view-tab', version: 1, projectId: 'p1', tab: 'all', extra: true,
+    });
+    await handlers['select-ai-session-chats-view-mode']({
+        type: 'select-ai-session-chats-view-mode', version: 1, projectId: 'p1',
+    });
+    await handlers['set-ai-session-collapsed-worktree-groups']({
+        type: 'set-ai-session-collapsed-worktree-groups', version: 1, projectId: 'p1',
+    });
+    await handlers['migrate-ai-session-view-state']({
+        type: 'migrate-ai-session-view-state', version: 1, projectId: 'p1',
+    });
+    assert.equal(calls.length, 0, 'wrong versions and missing/extra keys must be rejected');
 });
 
 test('PERSIST-MULTI-PROVIDER-BATCH-ARCHIVE-001 delegates archive, provider, and pin mutations', async () => {

--- a/tests/contract/persistence/stores.test.js
+++ b/tests/contract/persistence/stores.test.js
@@ -153,6 +153,91 @@ test('PERSIST-PROJECT-STATE-STORE-001 AI-SESSION-QUICK-CREATE-001 quick-create p
     assert.equal(store.getActiveProviders()['scope-a'], 'codex');
 });
 
+test('PERSIST-PROJECT-STATE-STORE-001 OPEN-WINDOW-VIEW-STATE-PERSISTENCE-001 window view state round-trips validated writes and resolves CHATS+tree defaults', async () => {
+    const state = makeState({});
+    const store = new AiSessionWorkspaceStateStore(
+        state.memento,
+        value => value === 'codex'
+    );
+
+    // Nothing stored: the resolved state is the PRD migration landing
+    // (CHATS tab + tree view), with no collapse memory.
+    assert.deepEqual(store.getWindowViewState('scope-a'), { tab: 'chats', chatsViewMode: 'tree' });
+    assert.deepEqual(store.getWindowViewState(''), {});
+
+    await store.setWindowViewTab('scope-a', 'all');
+    await store.setChatsViewMode('scope-a', 'list');
+    await store.setCollapsedWorktreeGroups('scope-a', [
+        '["__anchor__"]',
+        '["group","g1"]',
+        '["__anchor__"]',
+        '',
+        7,
+    ]);
+    assert.deepEqual(store.getWindowViewState('scope-a'), {
+        tab: 'all',
+        chatsViewMode: 'list',
+        collapsedWorktreeGroups: ['["__anchor__"]', '["group","g1"]'],
+    }, 'writes persist per scope with junk keys filtered and duplicates removed');
+
+    // Invalid writes are ignored without touching the stored record.
+    await store.setWindowViewTab('scope-a', 'grid');
+    await store.setChatsViewMode('scope-a', 'grid');
+    await store.setWindowViewTab('', 'chats');
+    await store.setCollapsedWorktreeGroups('scope-a', 'not-an-array');
+    assert.deepEqual(store.getWindowViewState('scope-a'), {
+        tab: 'all',
+        chatsViewMode: 'list',
+        collapsedWorktreeGroups: ['["__anchor__"]', '["group","g1"]'],
+    });
+
+    // Junk in the persisted record is dropped field by field on read.
+    const junkState = makeState({
+        'workspaceAiSessionViewState.v1': {
+            'scope-b': {
+                tab: 'all',
+                chatsViewMode: 'grid',
+                collapsedWorktreeGroups: ['k', '', 7, 'k'],
+            },
+            'scope-c': 'garbage',
+            '': { tab: 'all' },
+        },
+    });
+    const junkStore = new AiSessionWorkspaceStateStore(junkState.memento, () => true);
+    assert.deepEqual(junkStore.getWindowViewState('scope-b'), {
+        tab: 'all',
+        chatsViewMode: 'tree',
+        collapsedWorktreeGroups: ['k'],
+    });
+    assert.deepEqual(junkStore.getWindowViewState('scope-c'), { tab: 'chats', chatsViewMode: 'tree' });
+    assert.deepEqual(junkStore.getWindowViewState(''), {});
+});
+
+test('PERSIST-PROJECT-STATE-STORE-001 OPEN-WINDOW-VIEW-STATE-PERSISTENCE-001 legacy sub-tab import is first-writer-wins and stays out of the worktree-surface migration', async () => {
+    const state = makeState({
+        'workspaceAiSessionSurface.v1': { 'scope-worktree': 'worktree' },
+    });
+    const store = new AiSessionWorkspaceStateStore(state.memento, () => true);
+
+    // 'sessions' → ALL when nothing has decided the window's tab yet.
+    assert.equal(await store.importLegacyWindowViewTab('scope-a', 'all'), true);
+    assert.equal(store.getWindowViewState('scope-a').tab, 'all');
+
+    // A second import must not clobber the recorded selection.
+    assert.equal(await store.importLegacyWindowViewTab('scope-a', 'chats'), false);
+    assert.equal(store.getWindowViewState('scope-a').tab, 'all');
+
+    // The legacy 'worktree' surface migrates to CHATS regardless of the hidden
+    // legacy sub-tab, so the import leaves it to the default resolution.
+    assert.equal(await store.importLegacyWindowViewTab('scope-worktree', 'all'), false);
+    assert.equal(store.getWindowViewState('scope-worktree').tab, 'chats');
+
+    // Invalid values and empty scopes are ignored.
+    assert.equal(await store.importLegacyWindowViewTab('scope-b', 'grid'), false);
+    assert.equal(await store.importLegacyWindowViewTab('', 'all'), false);
+    assert.deepEqual(store.getWindowViewState('scope-b'), { tab: 'chats', chatsViewMode: 'tree' });
+});
+
 test('PERSIST-PROJECT-STATE-STORE-001 sanitizes workspace state and ignores invalid writes', async () => {
     const state = makeState({
         'workspaceExpandedAiSessions.v2': ['scope-a', '', 7, 'scope-a', 'scope-b'],


### PR DESCRIPTION
## Summary

M2 PR-C (additive state plane) of the OPEN tab restructure ([PRD](../blob/main/docs/open-tab-window-switcher-prd.md), 状态模型与持久化). Stacked on #332 (merged). No UI changes — the new store is written live by existing gestures and read starting with the PR-D cutover.

- **New `workspaceAiSessionViewState.v1` host record** keyed by workspace scope identity: CHATS/ALL tab, CHATS view mode (tree/list), and the collapsed worktree group set. Reads and writes are validated (junk fields dropped, non-array payloads rejected, empty scopes ignored).
- **Versioned webview → host protocol**: `select-ai-session-view-tab`, `select-ai-session-chats-view-mode`, `set-ai-session-collapsed-worktree-groups`, plus a one-time `migrate-ai-session-view-state` boot import — all strict-envelope, fire-and-forget like the existing surface route.
- **Live mirroring instead of a cutover migration**: legacy ACTIVE/ALL sub-tab clicks, CHATS surface entries, and worktree collapse gestures already write the new store, so PR-D reads live values. The legacy WORKTREE surface maps to CHATS + tree inside the existing surface handler (PRD 存量迁移).
- **Legacy import is first-writer-wins per scope** and stays out of the worktree-surface migration: a stale boot import can never clobber a live post-upgrade selection, and a `worktree` surface still lands on CHATS + tree regardless of the hidden legacy sub-tab.
- New behavior contract `OPEN-WINDOW-VIEW-STATE-PERSISTENCE-001` covering the store, controller, router, and webview mirrors.

## Verification

- `npm run test:ci:linux` green (compile, brand, behavior contracts, lint baseline, coverage — changed lines 96.2%, browser, safety, dashboard webview checks, architecture gates, release notes, release packaging).
- Focused: store/controller/router contract suites, `worktreeGrouping` + `activeSessionCardInteraction` browser suites with new protocol coverage.
- Rebased onto `origin/main` after #332 merged; tree verified identical to the pre-merge head for the fix commits.

## Skill harvest

No skill change. The `.at(-1)` message assertions that broke under the new mirror posts were test-coupling issues fixed in place; the anchored-reader and manifest-consumer rules already cover the gate failures seen on this branch.

## Owner approvals

```
approve d4daaf37f1a13a6389eaa56c5c4dfed12e5b121b
```