### PR TITLE
fix: count and review untracked files in worktree task result (+ v2 panel PRD/plan)

### DIFF
--- a/docs/worktree-changes-panel-prd.md
+++ b/docs/worktree-changes-panel-prd.md
@@ -1,8 +1,10 @@
 # Worktree Changes Panel（会话内改动查看）PRD
 
-日期：2026-08-17（v3，第二轮 subagent 产品评审后修订）
+日期：2026-08-17（v3，第二轮 subagent 产品评审后修订）；2026-08-22（v4 并入 Part II；v4.1 吸收 owner 评审修订）
 
-状态：v1 经五轮批注闭环；v2 吸收第一轮评审（双层模型、SCM 口径、baseline 契约、解析路径）；v3 吸收第二轮评审，修正五个实现前必须修复项（净结果语义、baseline 捕获事务、聚合完整性三态、解析顺序、刷新正确性）并砍减 P0 范围。**v3 确认后可进入 P0 实现。** 依赖的 worktree 组模型见 `docs/worktree-tasks-prd.md`。
+状态：v1 经五轮批注闭环；v2 吸收第一轮评审（双层模型、SCM 口径、baseline 契约、解析路径）；v3 吸收第二轮评审，修正五个实现前必须修复项（净结果语义、baseline 捕获事务、聚合完整性三态、解析顺序、刷新正确性）并砍减 P0 范围。**v3 P0 已上线；Part I（§0–§9）现为 Current shipped contract（现状真源），§9 的 P0/P1/P2 为历史规划存档，条目去向以 §19/§20 为准。** 依赖的 worktree 组模型见 `docs/worktree-tasks-prd.md`。
+
+v4（2026-08-22）：新增 **Part II（§10–§19）**——v2 功能代际增量：两行式 member 头部、‹ › 循环切换、Collapse/Expand All、Commits 子 tab、vs upstream 标识。四项关键口径经 owner 当面确认 + 产品/可用性/技术三路评审 + owner 评审修订（决策记录 §20 追加三轮，冲突时以后轮为准）。**Part I（§0–§9）内容不变**，仍描述已上线行为与 v3 纪律；Part II 未明确修改的行为，一律以 Part I 及"v3 后体验迭代"为准。命名说明：Part II 的 "v2" 指面板的**功能代际**，Part I 的 "v3" 指本 PRD 的修订轮次，两者不冲突。实施拆解（工作项、commit 切分、验证矩阵）见 `docs/worktree-changes-panel-v2-plan.md`。
 
 ## 0. 核心产品承诺
 
@@ -10,7 +12,7 @@
 
 1. **改动信息属于 AI Conversation 视图，不进 open tab 卡片。** 入口是 telemetry 条的 Changes 按钮，详情是右侧边栏的 Changes tab。
 2. **面板呈现"相对 task 起点的当前净结果"（Task result）及其中"当前未提交的子集"（Working changes）。** 两者是包含关系而非并列关系；Task result 是 `baseline → 当前工作树` 的净差异，不承诺还原"历史上碰过的所有文件"。
-3. **Working changes 的分组、状态字母与点击行为对齐 VS Code Source Control**（Merge / Staged / Changes / Untracked 四组）；Task result 是本产品自有的视角，不承诺与 SCM 角标数字一致；未知状态显式标注，绝不把未知显示为 0。
+3. **Working changes 的状态字母与点击行为对齐 VS Code Source Control。** 数据分类四类（Merge / Staged / Changes / Untracked），UI 分组三组——Untracked 并入 Changes 组、行内以 `U` 徽标区分（见 §5.3 与“v3 后体验迭代”）；Task result 是本产品自有的视角，不承诺与 SCM 角标数字一致；未知状态显式标注，绝不把未知显示为 0。
 4. **面板只读。** 暂存、提交、回滚仍在 Source Control 完成；本面板回答"这个 task 现在变成了什么样、要不要去看"，并提供一键深入（diff / multi-diff / SCM）。
 
 ## 1. 背景
@@ -269,7 +271,9 @@ P0 采用可证明正确的事件驱动方案，自定义 watcher 优化后置�
 - 刷新 P95 延迟、Partial / Error 态占比；
 - `0 · ↑0` 长期占位是否值得保留的使用数据。
 
-## 9. 里程碑切分（v3 砍减版）
+## 9. 里程碑切分（v3 历史规划 · 存档）
+
+> P0 已上线；本节 P1/P2 为历史规划存档，各条目去向（提前至 Part II / 保留 P1 / 取消）以 §19 里程碑与 §20 决策记录为准。
 
 - **P0 前置（数据契约）**：`MemberBaseline` 持久化 + 捕获事务（§4.2）；session→group 权威解析（§4.1，含 resolver 的 Windows 路径与完整 WorktreeKey 修复）。
 - **P0**：完整性三态聚合；telemetry Changes 按钮（双维度 + partial 标注 + 准确 tooltip）；基础 member selector（默认=上次选择或 primary）；Task result 摘要 + Review this repository（含 capability fallback）；Working 四组（自采集 porcelain `-z -uall`）；文件点击矩阵的常见项；Git API 事件 + 打开/可见/切换强制刷新 + 手动 Refresh；Loading/Partial/Error 三态；Open this worktree in Source Control；基础键盘/焦点/ARIA。
@@ -287,7 +291,331 @@ P0 采用可证明正确的事件驱动方案，自定义 watcher 优化后置�
 | 文件列表 | 按目录的 tree view（对齐 SCM view as tree），行内只显示 basename，hover 显示完整路径 |
 | diff 协议 bug | open-file 的 porcelain XY 校验曾拒绝带空格的 ' M'/'M '（最常见状态）导致点击静默失败；已修复并锁定全部 XY 形态 |
 
-## 10. 决策记录
+---
+
+# Part II · v2 功能代际（成员导航 · 折叠控制 · 提交历史）
+
+日期：2026-08-22（v2.2，经三路评审 + owner 评审修订）
+
+状态：四项关键口径已经 owner 当面确认（§20 第一轮）；三路评审 + owner 评审修订已吸收（§20 第二、三轮）。
+
+Part II 是 Part I 的增量增强；凡 Part II 未明确修改的行为，一律以 Part I 及"v3 后体验迭代"为准。设计素材回收自会话 `01a00960` 的未实施设计稿，并补上该稿缺失的 Collapse/Expand All。
+
+## 10. 核心产品承诺（Part II）
+
+1. **Task 视角优先于仓库考古视角。** Commits 子 tab 默认口径 `baseline..HEAD`（Since start），其计数与**同一 member** 的 Files tab 摘要行 commits 数同源同数；多 member 时 telemetry 按钮数字为**全 member 聚合值**（Part I §4.4），逐 member 分解见按钮 tooltip 与各 tab 摘要行——三处数字各有明确归属，绝不互相冒充。
+2. **每个数字都有明确参考系且可解释。** baseline（task 起点）、upstream（远端跟踪分支）、base 分支是三个不同参考系，绝不混排；未知 ≠ 0，降级显式标注（沿用 Part I 纪律）。
+3. **导航效率可验收。** 相邻 member 切换 1 次点击；任意 member ≤ 2 次点击（‹ › 循环或下拉直达）；commit 的文件改动在 Commits tab 内 ≤ 2 次点击（展开 → 点文件），从 Files tab 出发 ≤ 3 次（切 tab → 展开 → 点文件）。
+4. **面板只读。** 不新增任何写操作（含 push/fetch/commit/revert/cherry-pick）；深度操作仍交还 Source Control 与用户自装的 Git Graph / GitLens。
+
+## 11. 背景：四个可复现的痛点（Part II）
+
+2026-08-22 owner 反馈的四个痛点，根因均已代码核实：
+
+| # | 痛点 | 根因（现状实现） |
+| --- | --- | --- |
+| P1 | 看不到完整分支名 | 第一行是原生 `<select>`，`repo · ⎇ branch` 单行挤压；侧边栏默认 240px 下截断后只剩 repo 名；tooltip 只给 worktree 路径 |
+| P2 | 多仓库切换繁琐 | 唯一切换手段是下拉：点开 → 扫描 → 点选，≥2 次点击 + 视觉扫描 |
+| P3 | 无法一键合上/展开全部改动 | 折叠能力只到单目录行；组头（Merge/Staged/Changes）是纯文本 `<div>` 不可折叠；无全局折叠 |
+| P4 | 看不到提交记录及每个提交的文件改动 | 数据层只有 `rev-list --count`（数量），无任何 `git log` 能力；无 commit 视图 |
+
+会话 `01a00960`（2026-08-19）已就 P1/P2/P4 形成完整设计稿但未实施，Part II 整体回收该稿并修订；P3 为该稿缺失项，本文新设计（§15.3）。
+
+## 12. 目标（Part II）
+
+- 分支名在任何面板宽度下可辨认：独占一行 + 中间省略 + tooltip 给全名。
+- 相邻 member 切换一次点击完成，当前位置 `(i/n)` 始终可见。
+- 一键把文件树合到组头 / 全部展开。
+- 在面板内查看**当前分支中自 task start 以来保留下来的提交**及每个提交的文件变化：commit 列表 → 单个 commit 的文件级改动 → 原生 diff / multi-diff，全程不跳窗口。能力边界：`baseline..HEAD` 只展示当前 HEAD 可达的提交，**不还原**被 squash / amend / rebase 丢弃的历史，也不覆盖未提交过程。
+- 不破坏 Part I 已上线的任何行为（分组、点击矩阵、Review、刷新策略、降级文案、Open in Source Control 出口）。
+
+## 13. 非目标（Part II）
+
+- 不做 graph 自研渲染；不做 commit 级写操作（cherry-pick / revert / checkout / reset）。
+- 不做 push / fetch / pull 按钮；tracking 标识仅展示，不可点击触发任何写操作；数字反映**本地 remote-tracking refs 的状态**（不主动 fetch，tooltip 注明）。
+- **不持久化 task branch 的发布目标**，因此不给 pushed / not pushed 结论——只陈述 tracking 事实（§14.1）。
+- 不做 base 分支 moved / behind 标识（Part I P1 顺延，见 §20 第二轮决策）。
+- 不做"正在写入"live 脉冲标识（P1）。
+- 不做 commit 搜索 / 过滤 / 多选 diff（P1 评估）。
+- Commits 子 tab 不提供跨 member 聚合视图；严格跟随当前选中 member。
+
+## 14. 核心概念与数据模型（Part II）
+
+### 14.1 三个参考系与标识口径（验收标准）
+
+标识统一为**两行明确语言**——不用 `↑`/`⇡` 箭头符号区分参考系（双箭头要求用户记忆符号语义，且在 192–240px 宽度下必然截断）：
+
+| 文案 | 参考系 | 语义 | 数据来源 | 降级 |
+| --- | --- | --- | --- | --- |
+| `Since start · N files · M commits`（Files 摘要区第一行）/ `Since start · M commits`（Commits 标题区第一行） | baseline（冻结 SHA） | 自 task 起点以来的净文件数与 commit 数（已有口径） | `rev-list --count baseline..HEAD` 等 | Part I 完整性三态沿用 |
+| `Tracking <upstream> · N ahead · M behind`（摘要区第二行） | upstream（远端跟踪分支） | 本地与 tracking branch 的分叉计数 | 事实查询链（四命令，§14.1 附注） | 无 tracking → `No tracking branch`；采集失败 → `Tracking unknown` |
+| `No tracking branch` | — | 分支未设置跟踪分支（agent worktree 分支的常态） | upstream 配置查询成功但为空 | 本身即事实陈述态 |
+
+纪律：
+
+- **只陈述 tracking 事实，不给 pushed / not pushed 结论。** 无 tracking branch ≠ 从未推送；commit 不在当前 upstream ≠ 未推送到其他 branch / remote；upstream 甚至可能指向 `origin/main` 而非 task branch 的远端副本。除非持久化"task branch 发布目标"（非目标，§13），禁止任何 pushed 语义文案。
+- 分叉计数照常显示 `0 ahead · 0 behind`（空间稳定纪律，与 Part I `0 · ↑0` 一致）。
+- `<upstream>` 显示实际解析出的短名（如 `origin/fix-x`；fork / 多 remote 场景不写死 origin）；tooltip（§17 可聚焦机制）给完整 ref + "Based on local remote-tracking refs; no fetch was performed"。
+- 标识**显示在各 tab 的摘要区**（§15.4/§15.5），与同一参考系的数字同处，不单独占头部行。
+- 采集挂在现有 member 采集链路上；upstream 采集失败独立降级，不影响 baseline 数字。
+
+附注（三态采集链，`rev-parse @{upstream}` 失败无法区分 none/unknown，不可用）：① `git symbolic-ref -q HEAD` 取当前分支 ref（空 = detached HEAD → `none`）；② `git for-each-ref --format=%(upstream) <branchRef>`——**成功且为空 = `none`，命令失败/超时 = `unknown`**；③ 有 upstream 时 `git rev-parse HEAD <fullRef>`（单进程取 headSha + upstream sha）；④ `git rev-list --left-right --count <fullRef>...HEAD`（**左数 = behind，右数 = ahead**，实现别写反）。③④ 失败同样归 `unknown`。每 member 新增 ≤4 个 git 进程。
+
+### 14.2 Member 顺序与位置指示（验收标准）
+
+- ‹ › 循环顺序 = **manifest member 固定顺序**（仅 `state === 'ready'` 且有 `worktreeKey` 者，与 Part I §6.3 一致；detached member 保留在序列中并标注 Outside workspace）。`filter` 保持 manifest 数组顺序、消息序列化保序、webview 不重排——webview 端持有的 members 数组顺序即 manifest 顺序。
+- 顺序在**两次刷新之间**稳定；手动/事件刷新会按新 manifest 重解析（add-repo、组合并后顺序可变），切换逻辑始终按最新数组计算，不缓存下标。
+- unmanaged 兜底会话产生单个 `unmanaged-<hash>` 合成 member，‹ › 与 `(i/n)` 本就隐藏，不受影响。
+- 位置指示 `(i/n)` 在 n>1 时恒显；到达端点循环回转（末位按 › 回到首位），`aria-live` 报读 "api, 2 of 3"。
+- 默认选中沿用 Part I（上次选择可用则恢复，否则 primary）；‹ › 切换与下拉选择完全等价，复用同一 `changes-select` 消息与 `lastSelectionBySession` 记忆——webview 侧已持有完整有序 members 列表，自行算出目标 memberId 后发既有消息，**协议无需新增 next/prev 命令**。
+
+### 14.3 Commit 数据契约（新增）
+
+Commits 数据**不走** Part I 的单一权威状态推送（`conversation-viewer-changes`），改为**请求/响应式懒加载**，避免加重常态刷新链路。
+
+**消息集（四类；请求全部携带 `version: 1` + `requestId`，响应另带 `subscriptionGeneration` + `memberId` 并回传 `requestId`）**：
+
+```
+webview → host:
+  conversation-viewer-commits-list      { version, requestId, memberId, scope: 'since-start' | 'full', offset, historyHead? }
+  conversation-viewer-commit-detail     { version, requestId, memberId, sha }
+  conversation-viewer-commit-open-file  { version, requestId, memberId, sha, path, oldPath? }
+  conversation-viewer-commit-review     { version, requestId, memberId, sha }
+
+host → webview:
+  conversation-viewer-commits           { version, requestId, subscriptionGeneration, memberId, scope, offset, historyHead,
+                                          commits: CommitSummary[], hasMore, sectionComplete?, baselineRow?, degraded? }
+  conversation-viewer-commit-detail     { version, requestId, subscriptionGeneration, memberId, sha,
+                                          files: CommitFile[], totalFiles, filesTruncated, degraded? }
+```
+
+- `requestId`：webview 生成的单调 id，同 member 同 scope 只认最新请求——**旧列表响应不得覆盖新刷新结果**（`subscriptionGeneration` 只覆盖跨 session，盖不住同 member 的新旧请求竞态）。
+- `open-file` / `review` 为动作消息、无响应：host 先 `git cat-file -e <sha>` 验证，commit 已消失（rebase 改写）→ host 侧 toast "Commit no longer exists (history rewritten)" 并推送最新 changes-state（经失效签名比对自然触发重取）；diff/review 打开失败同样 host 侧 toast——与现有 `changes-open-file` 的静默失败处理同路径。
+
+```ts
+interface CommitSummary {
+  sha: string;            // 全 SHA，UI 显示短 7 位
+  subject: string;        // ≤1024 字符，超出 host 截断
+  authorName: string;     // ≤256 字符；原样展示（不做 you/agent 映射——agent 与用户共用 git config，无可靠区分依据）
+  authorTime: number;     // unix 秒，%at（author time，rebase 保留）
+  inTrackingBranch?: boolean;  // 仅 tracking=tracked 时有值；undefined = 不显示行级徽标
+}
+interface CommitFile {
+  path: string; oldPath?: string;   // ≤4096 字符；oldPath 仅 rename
+  status: 'A' | 'M' | 'D' | 'R' | 'C' | 'T' | 'U';
+  additions?: number; deletions?: number;  // 非负整数 ≤1e7；binary 文件缺省（numstat 输出 '-'）
+}
+interface BaselineRow {
+  sha: string;            // member baseline 冻结 SHA
+  subject?: string;       // `git log -1 --format=%s <sha>` 采集；失败时缺省，UI 仅显示短 SHA
+}
+type CommitsDegraded =
+  | 'unreadable'       // member 不可读
+  | 'timeout'          // git 超时（5s）
+  | 'history-moved'    // historyHead 与当前 HEAD 不一致（分页期间历史已变）
+  | 'unknown-commit'   // sha 不存在（rebase 改写）
+  | 'error';           // 其他 git 失败
+```
+
+**分页模型（消灭"空翻页"与"缺失中段"）：**
+
+- **冻结历史头**：每个 scope 的第一页响应携带 `historyHead`（当时的 HEAD）；后续页请求必须回传同一 `historyHead`，host 比对当前 HEAD 不一致 → 响应 `degraded: 'history-moved'`，webview 丢弃已分页数据并回到该 scope 第一页（不展示陈旧列表）。
+- **since-start 段**（baseline 有效）：范围 `<baseline>..<historyHead>`，页大小 50（`--max-count=51 --skip=<offset>`，多取 1 条判 `hasMore`）；最后一页 `sectionComplete: true` 并携带 `baselineRow`——**baseline 收尾行只在真实边界出现**，分页中途不渲染。
+- **full（Earlier commits）段**：前置条件 = since-start 已 `sectionComplete`。范围 = **baseline 的祖先**（`git log <baselineSha>`；首条为 baseline 本身，webview 按 sha 去重跳过，因 baseline 行已渲染）——**直接从边界继续，不从 HEAD 翻页**，无空翻页、无缺失中段。
+- **baseline 缺失 / 历史改写**：无分段，整 tab 为 `Current branch history` 单流（范围 = `historyHead` 分页），顶部保留 Baseline unavailable / History rewritten 说明条；无 Show full 按钮（列表本身即完整历史）。
+- webview 按 sha 维护已渲染集合，跨页去重防御。
+
+采集命令（实现锚点；以下均已经本仓库 git 2.51.1 实测验证）：
+
+- since-start 页：`git log --no-decorate --format=%H%x00%s%x00%an%x00%at --max-count=51 --skip=<offset> <baseline>..<historyHead>`；Earlier 页：同式对 `<baselineSha>`（baseline 缺失时对 `<historyHead>`）；记录 `\n` 分隔、字段 NUL 分隔；**按新到旧排序**。
+- **列表口径 = 完整可达 DAG**（不加 `--first-parent`）：与 aheadCount 的 `rev-list --count baseline..HEAD` 严格同口径，守住"同源同数"纪律；merge 合入的支线提交属于"自 baseline 以来进入该分支的提交"的事实陈述（task 分支常态为线性，merge flood 是边缘场景）。merge commit 行的文件明细永远按 first-parent（相对主线的净变化）。P1 评估：若 dogfooding 出现 merge flood 痛点，提供 first-parent 过滤视图。
+- inTrackingBranch 集合：tracking=tracked 时 `rev-list @{upstream}..HEAD` 一次求"未进入 tracking"集合，逐 commit 回填 `inTrackingBranch`（集合外 = true）。
+- commit 文件明细**必须拆两条命令**（一条命令同时给 `--name-status --numstat` 时 numstat 会被静默丢弃）：
+  - `git diff-tree --no-commit-id -r -z -M --name-status <sha>`（root commit 加 `--root`；merge commit 改 `-m --first-parent`——单独 `--first-parent` 输出为空）
+  - `git diff-tree --no-commit-id -r -z -M --numstat <sha>`（同上）
+  - `-M` 不可省：diff-tree 是 plumbing，不适用 `diff.renames=true` 默认，无 `-M` 时 rename 输出为 D+A 两条。
+  - rename 的 `-z` 字节格式为 `R100\0<oldPath>\0<newPath>\0`（**old 在前**，与 porcelain status `-z` 的 "to-path first" 正好相反，解析器别写反）。
+- 超时口径与 changesCollector 一致：**5s**。
+
+**失效与刷新纪律（验收标准——懒加载数据不得静默过期）：**
+
+1. 行 2 的 `⟳` 同时重采 changes 快照与当前 member 的 commits 列表（两路独立降级）。
+2. changes-state 推送到达时，比对**失效签名**——`HEAD sha`、`baseline sha / availability`、`upstream fullRef`、`upstream resolved sha`、`upstream ahead/behind` 任一分量变化 → 该 member 的 commits 缓存作废。**push / fetch / tracking 变更即使不改变 commit 列表，也会改变标题区分叉计数与行级 tracking 徽标**，必须覆盖（member 视图需携带上述字段，见 §14.4）；若 Commits tab 正在展示该 member，**静默重取**（不抢焦点、不清空展开状态以外的滚动位置；数据量小，直接重取而非"N new commits"提示条）。
+3. 切换 member：Commits 区**立即清空并进入列表级 loading**，绝不残留上一 member 的列表（张冠李戴比空白更糟）；commits 缓存按 member 保留，切回时若未失效则即时渲染。
+4. 所有 commits 响应纳入 **`requestId` + `subscriptionGeneration` 双重丢弃**：同 member 同 scope 仅最新 requestId 的响应生效；generation 覆盖 session / member 切换的在途请求（沿用 Part I 保护）。
+5. webview 校验上限（与现状 validState 纪律一致，`exactKeys` 拒绝多余字段）：requestId `[A-Za-z0-9-]{1,64}`；sha / historyHead 为 40 位 hex；offset 为非负整数 ≤1e6；commits ≤200/响应（页大小 50，上限为防御值）；files ≤400 + totalFiles ≤1e6；scope / degraded / status 枚举白名单；subject ≤1024、authorName ≤256、path ≤4096。
+
+### 14.4 协议与接线同步点（实现提示，已代码核实）
+
+member 视图新增字段时同步 **3 处**：`types.ts`（`ConversationChangesMemberView`）→ `conversationChangesController.ts`（memberView）→ `conversationChangesScripts.js`（`validMember` 白名单，`exactKeys` 会拒绝多余字段导致整个 state 消息校验失败）。本次新增字段：`headSha?: string`（unreadable member 缺省）与 `upstream` **三态判别联合**：`{ status: 'tracked'; fullRef: string; sha: string; ahead: number; behind: number } | { status: 'none' } | { status: 'unknown' }`——`none` = 未设置 tracking（摘要区 `No tracking branch`），`unknown` = 采集失败（摘要区 `Tracking unknown`；未知 ≠ 事实陈述，§10 第 2 条），fullRef 经 `git rev-parse --symbolic-full-name @{upstream}` 采集；失效签名所需字段同源携带（§14.3 第 2 条）。`viewerProtocol.ts` 只校验 webview→host 消息，**仅在新增 commits 四类消息时涉及**。
+
+隐性第 4 处：`src/webview/conversationChangesScripts.js` 与 `media/conversationChangesScripts.js` **字节级双份镜像**（WEBVIEW-ASSET-IDENTITY-001 强制），改一处不改另一处 CI 直接红。
+
+完整接线面（新功能一次列全）：`viewerDocument.ts` 面板 markup → `media/conversationViewerScripts.js` 的 `changes.create({...})` 传 DOM 句柄 → `viewerProtocol.ts` 新消息校验（含 §14.3 上限）→ `viewer.ts` 分发 → `conversationChangesController.ts` 新方法 → 样式走 `media/conversationViewer.scss` 编译出 css（入库）→ 重写受影响的 `WORKTREE-CHANGES-PANEL-001` browser 测试（select 与组头断言）→ `docs/testing/behavior-contracts.json` 登记新行为。
+
+## 15. 产品行为（Part II）
+
+### 15.1 Member 头部：两行 + 子 tab 行
+
+```
+┌─ Changes ──────────────────────────────┐
+│  ‹  [api ▾]                     (2/3) › │ ← 行 1：repo 行
+│  ⎇ fix/harness-registry…nsumption  ⟳ ↗ │ ← 行 2：分支独占行 + 刷新 + SCM 出口
+│  2 more changes in web, infra · Go to web →  │ ← 跨 member 提示（条件渲染，可点击）
+│  [ Files | Commits ]           ⤒ ⤓     │ ← 行 3：子 tab + 折叠控制（§15.3/§15.4）
+```
+
+- **行 1**：`‹` `›` 为图标按钮（chevron-left/right）。中间 repo 名的可实现形态 = **可见 label + 透明原生 `<select>` 覆盖层**（select 绝对定位覆盖 label、`opacity: 0`、宽 100%）——原生 select 的闭合文本就是 selected option 文本，CSS 无法让闭合态与 popup 用两套 label；覆盖层方案下：闭合态是自定义 DOM（repo 名 + `▾`，可自由截断/灰化），popup 是原生 option（键盘方向键 / type-ahead / Esc / listbox 语义与读屏能力保留，且不被面板 `overflow: hidden` 裁剪）。option 文案维持现行 `repo · ⎇ branch` 并**保留 `(outside workspace)` 后缀**（popup 内可预先辨认 detached member；计数按现行纪律活在 tooltip 与面板，不进选项文本）。
+- **行 1 退化**：单 member 时 ‹ › 与 `(i/n)` 隐藏，**repo 名渲染为普通文本标题**而非 disabled select——禁用态的语义是"不可用"且会退出 Tab 序，与"静态标题"不符（改变现状行为，见 §20 第三轮）。多 member 才渲染 select。
+- **行 2**：分支名独占一行，中间省略；完整分支名 + worktree 路径经 §17 tooltip overlay 展示（不依赖原生 `title`）；branchName 缺失（unmanaged 合成 member）时显示 `(no branch)`。右侧 `⟳` 刷新与 **Source Control 图标**（不用 `↗`——动作发生在当前窗口，↗ 易被理解为外部打开）并排——SCM 出口沿用 Part I"v3 后体验迭代"的定位，视觉位置贴近现行工具栏，肌肉记忆损耗最小。
+- **行 3 与标识条**：v2 草案曾有独立的第三行标识条，评审后与各 tab 摘要行合并（见 §15.4/§15.5）——`↑n since start` 与 Task result 行的 commits 数本是同一数字，同参考系的信息同行展示，头部省一整行。
+- **跨 member 提示行**：从纯文本升级为**可点击**，文案直接说明动作与目标：`<N> more changes in <repo 列表> · Go to <目标 repo>`——现行 `+N in <repo 列表>` 只汇总量不说明点击目的，视觉承诺与实际动作不一致（Part I 文字稿的 "N changes in M other repositories" 从未实现，不采用）。repo 列表超过 2 个时截断为 `<a>, <b> +M more`，完整分解经 §17 tooltip 展示；**计数与跳转候选同一集合：`availability !== 'unreadable'` 的 readable member**（baselineUnavailable / historyRewritten 的 Working changes 仍可读，必须计入；unreadable 的状态由按钮 partial 标注承载）；计数 = 其他 readable member 的未提交改动 item 数之和；点击目标 = 固定顺序下一个 `workingItemCount > 0` 的 readable member；若改动全部来自当前 member 则不渲染（闭环 Part I P1 的 next-member 导航）。
+- **detached 标注**：闭合态在行 1 label 旁的**独立小字元素** "Outside workspace"；popup option 文本同时保留 `(outside workspace)` 后缀（双承载：闭合态可见、popup 内其他 detached member 可预先辨认）。沿用 Part I §6.3 语义。
+- **键盘与 ARIA**：详见 §17。
+
+### 15.2 ‹ › 循环切换
+
+- 顺序与默认选中见 §14.2；切换与子 tab **正交**：在 Commits tab 切 repo 即看另一个 repo 的提交，不弹回 Files。
+- 每 member 的 UI 上下文（折叠态、滚动位置、Commits 展开项）在面板生命周期内独立记忆，来回切换不丢；commits **数据缓存**按 member 保留、按 §14.3 失效规则作废；`resetSession` 沿用现状清空。
+- 切换不触发新增 git 采集（members 摘要已在聚合态里），但仍是一次完整 state 推送（含选中 member 的 detail items）——成本为"无新增 git 进程的状态推送"。
+- `‹`/`›` 激活后**焦点驻留**，可连续 Enter 循环；切换后 `aria-live="polite"` 报读位置。
+
+### 15.3 组头可折叠 + Collapse / Expand All（P3 新设计）
+
+现状修正：组头（Merge / Staged / Changes）从纯文本升级为**可折叠按钮**（chevron + 标题 + 计数），这是 Collapse All 的前置能力。
+
+- **组头行**：展开 `▾ Staged Changes · 2`，折叠 `▸ Staged Changes · 2`；计数恒显，口径为 **item 行数**（同文件 staged+unstaged 计 2，与 Part I `workingItemCount` 一致——防止误读为文件数）。空组不渲染（沿用 Part I）。
+- **Collapse All**：当前 member 的所有目录 + 所有组头收起 → 只剩组头行列表，一屏看清改动分布。
+- **Expand All**：所有组 + 所有目录展开。
+- 两个按钮常驻行 3 右侧，图标用 VS Code 用户已认识的 collapse-all / expand-all 图形（内联 SVG，与现有 ⟳ 同风格）；可见提示用 §17 可聚焦 tooltip（"Collapse all" / "Expand all"，键盘可达），`aria-label` 承载可访问名称——二者分工、不互相替代，不依赖原生 `title`。
+- **Commits tab 下隐藏按钮内容但保留固定宽度的 action slot**——布局不抖动，也不暴露与当前 tab 无关的死操作（disabled 按钮通常不可聚焦，其 tooltip 解释难以触达，不如不渲染）；Files tab 无改动空态下按钮禁用。
+- 作用域 = 当前选中 member；折叠状态沿用内存态（`collapsedFolders` + 新增 `collapsedGroups`），不持久化，`resetSession` 清空——与现状纪律一致。
+- ARIA：组头 button 带 `aria-expanded`。
+
+### 15.4 子 tab 框架：Files | Commits
+
+- **命名**：内层 tab 命名为 `Files | Commits`——外层 sidebar 视图已叫 "Changes"（telemetry 按钮），内层再叫 Changes 会形成"Changes 里的 Changes"两级同名，评审、测试、读屏报读三层都会绕。
+- **定位说明**：这是**面板内二级分段控件**，是一个新范式——Part I 体验迭代删除的是侧边栏 tab 行（视图切换器上收到 telemetry 按钮），本子 tab 不构成该决策的回退。规格：`role="tablist"` + `role="tab"` + `aria-selected`，`←`/`→` 方向键切换 tab。
+- 选中态持久化进 webview state（`conversationSidebar.changesSubTab`，新增键向后兼容），reload 后恢复；切 session 不重置（与 sidebar view 行为一致）。
+- **Files tab** 内容 = Part I §5.3 全部现状，唯一修改是 **Task result 摘要区扩展为两行明确语言**（§14.1 口径）：
+  ```
+  Since start · 5 files · 2 commits
+  Tracking origin/fix-x · 1 ahead · 3 behind
+  [Review this repository]
+  ```
+  （"Includes committed and uncommitted" 说明保留；tracking 行按 §14.1 降级。）
+
+### 15.5 Commits 子 tab
+
+```
+│  [ Files | Commits ]                      │
+│  ───────────────────────────────────────  │
+│  Since start · 3 commits                    │
+│  Tracking origin/fix-x · 1 ahead · 3 behind │
+│  ▾ ● a1b2c3d  fix: token refresh race     │
+│      hzcheng · 2h ago                     │
+│      M  src/auth/login.ts        +12 −3   │
+│      M  src/auth/session.ts       +4 −1   │
+│      [Review this commit]                 │
+│  ▸ ● b2c3d4e  chore: setup script         │
+│      hzcheng · 3h ago                     │
+│  ○ c3d4e5f  (baseline) main · merged #241 │ ← 收尾行，不可展开
+│  ───────────────────────────────────────  │
+│  [Show full branch history]               │
+```
+
+行为明细（验收标准）：
+
+1. **默认口径 Since start**（`<baseline>..<historyHead>`，完整可达 DAG，§14.3），按新到旧排序，**50 条/页分页**：范围未穷尽时底部 `Load more`，穷尽（`sectionComplete`）后才渲染 baseline 收尾行——未达真实边界不渲染（不暗示中间无遗漏）。标题区两行（§14.1 口径）：`Since start · N commits` + `Tracking origin/fix-x · 1 ahead · 3 behind`——N 是**该 member** 的 ahead 数，与 Files tab 摘要区的 commits 数同源同数；多 member 时 telemetry 按钮为聚合值，二者参考系不同、不互相比对（§10 第 1 条）。
+2. **commit 行**：chevron + tracking 徽标 + 短 SHA + subject（尾部省略）+ 第二行 `authorName · 相对时间`。**行级 tracking 徽标显示矩阵**（只陈述事实，§14.1 纪律；tooltip 用 §17 可聚焦机制）：
+   | upstream | inTrackingBranch | 行级显示 |
+   | --- | --- | --- |
+   | 存在 | `false` | `●`（tooltip: "Not in tracking branch"） |
+   | 存在 | `true` | `✓`（tooltip: "In tracking branch"） |
+   | 缺失 | `undefined` | **不显示**（分支级 `No tracking branch` 已由标题区承载，逐行重复是噪音） |
+
+   徽标为非聚焦元素，其语义**折叠进 commit 行的 `aria-label`**（如 "a1b2c3d, fix: token refresh race, not in tracking branch"），tooltip 随行级元素经 §17 机制展示——不依赖徽标自身可聚焦。
+3. **点击 commit = 行内展开文件列表**（非跳转）：状态徽标 + basename（全路径经 §17 tooltip overlay 展示）+ `+a −d` numstat；再点收起。文件明细懒加载（§14.3），展开中显示行内 loading；单 commit 文件明细上限沿用 `MAX_DIFF_FILES = 400`：超出时响应带 `totalFiles` + `filesTruncated`，UI 显示 `Showing 400 of N files`——**Review this commit 同受此上限，不暗示 Review 能看到全部**；超大 commit 的完整审阅出口是 Source Control / 外部 Git 工具（§13 不做自研增强）。
+4. **点击文件 = `parent ↔ commit` 原生 diff**（当前窗口打开，不跳窗；added/deleted 的空侧复用 Review 链路的 EMPTY_REF 模式）；merge commit 按 first parent；点击瞬间 commit 已消失（rebase 改写）→ toast 提示并触发刷新，不报错弹窗（沿用文件点击矩阵纪律）。
+5. **Review this commit**：该 commit 的 multi-diff——**新增 `openCommitReview` 兄弟函数**（`openTaskResultReview` 的语义固定为 baseline→工作区，不能直接复用），共享其三样零件：`GitDiffContentProvider`（任意 ref 内容）、`vscode.changes` 三元组结构、capability fallback。
+6. **baseline 收尾行**：空心 `○`、灰色、不可展开，文案 `(baseline) + subject`；**仅当 since-start 段分页到达真实边界（`sectionComplete`）时渲染**——让 Since start 的边界可见，避免"为什么只有 3 条"的疑惑；分页中途不渲染（不暗示中间无遗漏）。
+7. **Show full branch history**：前置条件 = since-start 段已分页到边界（`sectionComplete`，baseline 行已渲染）。点击后在 baseline 收尾行下方追加 "Earlier commits" 段，**直接从 baseline 祖先继续分页**（不从 HEAD 翻页——无空翻页、无缺失中段，§14.3 分页模型）；分页按钮 `Load earlier commits`，加载中禁用 + 行内 spinner，防重复点击。baseline 缺失 / 历史改写时**无此按钮**（整 tab 即 `Current branch history` 单流）。**scope 恢复**：切 member 再切回，恢复该 member 的 scope（since-start / full）与滚动位置（§15.2 UI 上下文记忆），数据按 §14.3 失效纪律重取。
+8. **空态**：无 ahead → "No commits since start" + baseline 行仍显示。
+9. **降级**（`degraded` 枚举，§14.3）：`unreadable` → 整 tab 提示态且不影响 Files tab；`timeout` / `error` → Error 态 + 手动重试；`history-moved` → 丢弃已分页数据、回首行重取；`unknown-commit`（明细/打开时）→ host 侧 toast + 触发刷新（**不报错弹窗**，沿用文件点击矩阵纪律）；baseline 缺失 / 历史改写 → `Current branch history` 单流 + 顶部 Baseline unavailable / History rewritten 说明条（**不伪造 Since start 边界**，与第 7 条同一流程）。
+10. **状态反馈（评审补充，验收标准）**：首次进入 = 列表级 loading；切 member = 立即清空 + loading（§14.3 第 3 条）；commit 明细加载失败 = 行内 "Failed · Retry"；列表重取不抢焦点。
+
+### 15.6 宽度策略（P1 根因修复之一）
+
+- Changes 视图**首开一次性推荐 320px**。现状 state 在任何持久化动作时都会写入 width=240，`Number.isFinite(saved.width)` 无法区分"系统自动保存的默认 240"与"用户明确拖到 240"——因此新增两个显式状态位：`widthUserResized: boolean`（新代码首次持久化时写 `false`，**仅在拖拽 handler 内置 `true`**）与 `changesWidthRecommendationApplied?: boolean`。规则：首次打开 Changes 视图时，若 `widthUserResized === false && changesWidthRecommendationApplied !== true` → 设为 320、持久化、置 applied=true；用户拖拽永久优先（不做"按 tab 记忆"——per-view 宽度会在每次切视图时引发主对话区 reflow 振荡，监控场景下是持续干扰；全视图共享单一宽度）。
+- 存量用户（存档中 `widthUserResized` 为 undefined）视为已有布局偏好，**不触发推荐**、不迁移、不弹提示；首开推荐只对新代码下产生的 state 生效。
+- 截断规范：分支名中间省略；repo 名尾部省略；commit subject 尾部省略；**所有截断处的全文必须经 §17 可聚焦 tooltip 可达**（键盘 / 读屏可靠，不依赖原生 `title`）。
+
+## 16. 边界与降级汇总（Part II）
+
+| 场景 | 行为 |
+| --- | --- |
+| 单 member（多数派场景） | ‹ › 与 `(i/n)` 隐藏、repo 名渲染为普通文本标题（非 disabled select，§15.1）；头部为行 1 标题 + 行 2 + 行 3 共三行——**记录决策：接受该垂直成本**，换取单/多仓库信息架构统一（行 2 分支恒可见对单仓库同样是 P1 修复） |
+| detached member | 保留可切换，行 1 标注 Outside workspace；upstream 标识独立降级 |
+| unmanaged 合成 member | 单 member 退化同上；branchName 缺失时行 2 显示 `(no branch)` |
+| 无 tracking branch | 摘要区第二行显示 `No tracking branch`；commit 行不显示徽标；**不推断"从未推送"**（§14.1 纪律） |
+| tracking 指向不同名分支（如 origin/main） | 照常按事实显示 `Tracking origin/main · N ahead · M behind`——语义依然成立（"相对跟踪分支的分叉"） |
+| upstream 分叉（diverged） | ahead / behind 双非零照常显示 |
+| baseline 缺失 / 改写 | Commits 的 Since start 段降级文案；full history 仍可用 |
+| member unreadable | Files 沿用 Part I partial 标注；Commits tab 提示态 |
+| retired session | 沿用 Part I retired 降级，查看对话不受影响 |
+| git 命令失败 / 超时（5s） | Commits 区独立 Error 态 + 重试，不拖垮 Files tab |
+| 面板极端窄（<240px） | 头部各行各自省略，不换行不溢出；子 tab 文字不压缩 |
+| 多窗口同 workspace | 各窗口 webview state 与 host controller 天然独立，无须特殊处理 |
+
+## 17. 视觉与交互规范（Part II，UI 摘要）
+
+- 图标：‹ › = chevron-left/right；Collapse/Expand All = VS Code collapse-all / expand-all 图形（内联 SVG，与现有 ⟳ 同风格）；SCM 出口 = **Source Control 图标**（不用 `↗`——动作发生在当前窗口，↗ 易被理解为外部打开）；commit 徽标 ●/○/✓。
+- **Tooltip 基础设施 = 面板级 JS overlay（新组件）**：纯 CSS 伪元素方案（`conversation-telemetry-tooltip`）**逃不出面板与文件列表的 `overflow: hidden/auto` 裁剪容器**（滚动区顶部/底部文件行、右侧按钮、192px 窄宽都会截断），且 `content: attr(data-tooltip)` 不是可靠的读屏描述——因此实现 JS tooltip overlay：单一节点挂 body、`position: fixed` 逃出所有裁剪容器、按触发元素 JS 定位、`data-tooltip` 属性驱动、hover/focus 触发、Esc/blur/滚动/面板关闭时关闭、`aria-describedby` 关联触发元素（**可见提示与读屏描述同源**）。`aria-label` 承载可访问名称，tooltip 承载视觉提示，二者分工、不互相替代；**不依赖原生 `title`**；现状 ⟳/SCM 按钮的原生 `title` 一并迁移。
+- 色彩：全部沿用 vscode 主题变量；`No tracking branch` 与 `●`（Not in tracking branch）用中性 `descriptionForeground`，**不用 warning 色**（无 tracking 是 agent task 的常态，不应被误读为告警）。
+- 密度：头部行与子 tab 行均为紧凑行高（≈22px）；Commits 文件行与 Files 文件行同高、同缩进体系。
+- 动画：不做布局动画（沿用现状即时重排）；‹ › 切换不做滑动动画（兼容老 Chromium webview，不引入超出现状用法的 CSS 特性）。
+- **完整 Tab 序**：‹ → repo select → › → ⟳ → SCM 按钮 → 跨 member 提示（渲染时）→ 子 tab → Collapse/Expand All → 内容区（Review → 组头/目录/文件行）。
+- **内容区键盘模型（对齐 VS Code 树形惯例，验收标准）**：
+  - roving tabindex：整个内容区一个 Tab 停靠点，`↑`/`↓` 在可见项间移动；
+  - `←`：已展开节点 → 折叠，已折叠或叶子节点 → 移到父节点；`→`：已折叠节点 → 展开，已展开节点 → 移到第一个子节点；
+  - `Home`/`End`：第一个 / 最后一个可见项；
+  - `Enter`/`Space`：激活当前项（目录 / 组头 = 切换折叠；commit 行 = 切换展开；文件行 = 打开 diff）；
+  - **焦点恢复**：刷新后原焦点项消失 → 落最近的同级或父级可见项；Collapse All 后焦点位于被隐藏子项 → 移到所属组头；
+  - 子 tab：tablist 自身 roving tabindex，`←`/`→` 移动并激活（automatic activation），tab 以 `aria-controls` 关联对应 `tabpanel`。
+  现状每行一个 Tab 停靠点在 Commits 长列表下是键盘灾难，Part II 上线时按 PR 切分一并改造（§19）。
+- ‹ › 激活后焦点驻留可连续 Enter；Esc 行为沿用现状（原生 select 的 Esc 由控件自身处理，无分层冲突）。
+- 样式走 `media/conversationViewer.scss` 编译链路，产物 css 入库（webview checks 强制）。
+
+## 18. 验证与成功指标（Part II）
+
+**本仓库当前没有任何事件埋点设施**，量化指标依赖的基础设施不存在，不写成承诺。本期验证方式为 dogfooding 人工验收清单：
+
+- 多仓库 task（n≥3）：相邻切换 1 次点击、任意切换 ≤2 次点击达成；`(i/n)` 始终正确；
+- 分支名在 240px / 320px / 420px 三档宽度下均可辨认（截断处全文经 tooltip overlay 可达）；
+- Collapse All 后只剩组头行；Expand All 完整还原；切 member 再切回折叠态保留；
+- Commits tab：挂着监控期间 agent 新提交 commit，列表随推送静默更新、与摘要行数字始终一致；
+- commit → 展开 → 点文件 → parent↔commit diff；Review this commit 开 multi-diff；
+- tracking 语义：无 tracking branch / tracking 指向不同名分支（如 origin/main）/ diverged 三态文案正确；push 或 fetch 后（HEAD 不变）分叉计数与行级徽标随失效签名刷新；
+- 边界提交：baseline 缺失、history rewritten、merge commit（first-parent 明细）、root commit；
+- 上限：since-start 200 条截断标注；单 commit 超 400 files 走 Review；
+- 显示：192px / 200% zoom / 高对比度主题下摘要两行与头部无溢出；
+- 键盘与读屏：全键盘完成 §17 全部操作；所有图标按钮与徽标的可访问名称正确；
+- tooltip overlay：滚动区顶部/底部文件行、192px 窄宽、头部右侧按钮均无裁剪/错位；
+- 性能实测：tracking 采集增量 P95 ≤150ms（每 member ≤4 个新增 git 进程）；commits 首屏 P95 ≤300ms；
+- 焦点恢复：Collapse All、刷新、member 切换后焦点落点符合 §17 规则；
+- full history：分页期间 HEAD 变化 → 重置回 Since start 并重取；
+- 量化指标（切换点击数分布、Commits tab 打开率、懒加载 P95、首开宽度分布）列为 **P1 埋点设施探索项**的输入，设施就位后再采集。
+
+## 19. 里程碑（Part II）
+
+- **本期，拆两个串行 PR**（每个都是完整产品增量，无半成品态），外加一个前置缺陷修复小 PR：
+  - **PR-0（前置缺陷修复，独立小 PR）**：Task result 目前**排除 untracked**——`taskFileCount` 只跑 `git diff --name-only <baseline>`（tracked 差异），Review 同样只读 tracked diff——与 Part I §4.3"Task result ⊃ Working changes（含 untracked）"的承诺矛盾（Working 里看得到的 untracked 文件，Task result 数字与 Review 里没有）。修复为 tracked diff ∪ untracked 并集（Review 中 untracked 的 original 侧用 EMPTY_REF），含回归测试。**修实现，不改承诺**。
+  - **PR-A（头部 + Files 完成态）**：最终头部结构（行 1 repo 行：可见 label + 透明 select 覆盖层 / 行 2 分支行）、tracking 采集与 3 处协议同步（§14.4 字段）、Files 摘要区两行（§15.4）、‹ › 循环 + `(i/n)`、跨 member 提示升级（readable 口径）、组头可折叠 + Collapse/Expand All、**Files 内容区完整键盘模型（§17）**、**Files 滚动位置按 member 记忆（§15.2）**、**tooltip overlay 基础设施（§17，含现状 `title` 迁移）**、首开 320px 推荐（双状态位）。**PR-A 中间态定义**：行 3 仅渲染右侧 action slot（Collapse/Expand All），不渲染子 tab 控件，Files 为唯一视图；markup / 样式 / browser 测试按最终结构一次到位，避免两个 PR 重复重写；含受影响的 WORKTREE-CHANGES-PANEL-001 browser 测试重写与 behavior-contracts 登记。
+  - **PR-B（Commits tab）**：子 tab 框架（Files | Commits，装入行 3 左槽）、§14.3 数据契约（四类消息 + requestId/generation 双重丢弃 + 分页模型）与失效纪律、Commits 列表 / 展开 / 分页 / 降级、parent↔commit 单文件 diff 与 `openCommitReview`、Commits 内容区键盘行为（§17 模型在 Commits 列表的实例化）、Commits 滚动位置与展开项按 member 记忆。
+- **P1**：base moved 标识（Part I 顺延）；live 脉冲标识；Graph ↗ 出口（探测 git-graph / GitLens 命令，缺失隐藏）；commit 搜索；目录搜索（Part I P1 保留）；Files 文件行 numstat（Part I P1 保留）；MRU / 智能切换顺序评估（先用固定顺序的 dogfooding 反馈验证）；跨 member Review all；事件埋点设施探索（§18）。
+- **P2**：commits 与 worktree 清理流程联动——"可清理"信号需先持久化 task branch 的 publication target 再评估（tracking 事实不足以推断 pushed，§14.1 纪律）。
+
+## 20. 决策记录
 
 ### v1 批注闭环（2026-08-16）
 
@@ -327,3 +655,85 @@ P0 采用可证明正确的事件驱动方案，自定义 watcher 优化后置�
 | Review 命名 | "Review this repository"（选中 member）；跨仓库统一版移 P1 |
 | 版本兼容 | Git API 字段与 `vscode.changes` 做 capability detection + fallback，不提升最低 VS Code 版本 |
 | P0 砍范围 | numstat、智能选中、tab 宽度、自建 watcher、live-region、精细截断、跨仓库 Review 全部移 P1 |
+
+### 2026-08-22 Part II 第一轮（owner 当面确认）
+
+| 决策点 | 结论 |
+| --- | --- |
+| Commits 默认口径 | **Since start 优先**（baseline..HEAD）；完整历史走底部入口分页加载 |
+| 领先/落后标识 | **只做 vs upstream**；upstream 缺失显示 `not pushed`；base moved / behind 顺延 P1 |
+| Collapse All 范围 | **合到组头**；组头因此从纯文本升级为可折叠按钮（前置能力） |
+| ‹ › 切换顺序 | **manifest 固定顺序**循环 + `(i/n)` 位置指示；智能排序移 P1 评估 |
+| 会话 01a00960 设计稿 | 整体回收：两行式头部、‹ › 切换、子 tab、commit 行内展开 + numstat、Review this commit、baseline 收尾行；其中 Graph ↗ 与 live 标识按原稿顺延 P1 |
+| Collapse/Expand All | 01a00960 稿缺失，Part II 新设计（§15.3） |
+| Commits 数据通道 | 请求/响应式懒加载，不进 Part I 的单一权威状态推送，避免加重常态刷新链路 |
+
+### 2026-08-22 Part II 第二轮（三路评审修订：产品 / 可用性 / 技术）
+
+| 决策点 | 结论 |
+| --- | --- |
+| "任意切换 ≤1 次点击"不可验收 | 改为"相邻 1 次、任意 ≤2 次（循环或下拉直达）"（§10 第 3 条/§18） |
+| "N 与按钮 ↑n 同源同数"参考系错误 | 按钮 = 全 member 聚合；Commits N 对齐**同 member** 的 Files 摘要行 commits 数（§10 第 1 条/§15.5 第 1 条） |
+| Commits 懒加载失效语义缺失 | 新增失效纪律五条：⟳ 双路重采、推送变化作废缓存并静默重取、切 member 即清不残留、响应纳入 generation 丢弃、校验上限（§14.3） |
+| SCM 出口失踪 | 落位行 2 右侧（⟳ ↗ 并排），进完整 Tab 序（§15.1/§17） |
+| 自绘 member 浮层三缺口（裁剪/键盘/Esc） | **保留原生 `<select>`** 样式化为"repo 名 ▾"按钮，不换自绘浮层（§15.1） |
+| git 命令实测错误 | diff-tree 拆两条、`-M` 必带、rename `-z` old-path-first、merge 用 `-m --first-parent`、root 显式 `--root`、`%at` 替代 `%ct`、left-right 左=⇣右=⇡（§14.3） |
+| "4 处协议同步"不准确 | 实为 3 处 + 双份文件镜像；补全完整接线面清单（§14.4） |
+| "复用 openTaskResultReview" | 改为新增 `openCommitReview` 共享三零件；文件上限对齐 `MAX_DIFF_FILES=400`（§15.5 第 3、5 条） |
+| 头部 5 行 chrome 过重 | 独立标识条取消，标识并入各 tab 摘要行（同参考系数字同行），头部收敛为 2 行 + 子 tab 行（§15.1） |
+| 子 tab 命名撞车 | 内层命名 `Files | Commits`；定位为面板内新范式并补 tablist ARIA 规格（§15.4） |
+| 宽度按 tab 记忆 → reflow 振荡 | 改首开一次性推荐 320px + 全视图共享单宽度 + 用户拖拽优先（§15.6） |
+| "vs origin" 文案 | 改 "vs upstream"（fork/多 remote 场景 upstream 未必是 origin）（§14.1） |
+| you/agent 作者映射无数据支撑 | 直接显示 authorName；行级 push 状态按 upstream 存在与否的显示矩阵（§15.5 第 2 条） |
+| ⤒⤓ 纯图标无可发现性 | 用 VS Code collapse-all/expand-all 图形 + `title` 可见提示；Commits tab 下禁用而非隐藏（§15.3） |
+| 成功指标无埋点载体 | 降级为 dogfooding 验收清单；量化指标列 P1 埋点探索输入（§18） |
+| 键盘流不完整 | 完整 Tab 序 + 内容区 roving tabindex + 子 tab ←→ + ‹ › 焦点驻留（§17） |
+| 跨 member 提示文案 | 以现行实现（`+N in <repo 列表>`）为准，仅升级为可点击（§15.1） |
+| 基线 P1 条目去向 | last commit 行由 Commits tab 首条取代（取消）；behind vs baseRef 随"只做 vs upstream"取消；目录搜索、Files 行 numstat 保留 P1（§13/§19） |
+
+### 2026-08-22 Part II 第三轮（owner 评审修订）
+
+| 决策点 | 结论 |
+| --- | --- |
+| `not pushed` 语义不成立 | 无 tracking ≠ 从未推送；commit 不在当前 upstream ≠ 未推送到其他 branch/remote；upstream 可能指向 origin/main。统一改事实型文案：`No tracking branch` / `In tracking branch` / `Not in tracking branch`，tooltip 注明 "Based on local remote-tracking refs; no fetch was performed"；字段 `pushed` 更名 `inTrackingBranch`。**取代第一轮的 `not pushed` 文案决策**（§13/§14.1/§15.5） |
+| "一步步长出来"过度承诺 | 目标改述为"自 task start 以来**保留下来的**提交"（不还原被 squash/amend/rebase 丢弃的历史）；列表口径 = **完整可达 DAG**（与 aheadCount 同口径，守同源同数），merge 明细按 first-parent；first-parent 过滤视图列 P1（§12/§14.3） |
+| Part I 基线自相冲突 | §0 修正为"数据分类四类 / UI 分组三组（Untracked 并入 Changes，行内 U 徽标）"；Part I 定位改为 **Current shipped contract**，§9 标注历史规划存档（文首状态/§0/§9） |
+| PR-A/PR-B 半成品态 | PR-A 含最终头部结构 + Files 内容区**完整键盘模型**；行 3 中间态 = 仅右侧 action slot、不渲染子 tab 控件；markup/样式/测试一次到位避免重复重写。PR-B 只做 Commits 增量（§19） |
+| full history IA/协议未闭环 | 模型闭环：Since start 段保留 + baseline 行下方追加 Earlier commits 段；baseline 缺失/改写 → `Current branch history` 单列表；新增 `BaselineRow` 类型与采集；分页 = 冻结 `historyHead` + `--skip` + sha 去重 + HEAD 变化即重置；scope 按 member 记忆恢复（§14.3/§15.5） |
+| Commits 失效签名漏 upstream | 签名 = HEAD sha + baseline sha/availability + upstream fullRef + upstream resolved sha + ahead/behind；member 视图新增 `headSha` 与 `upstream` 字段（§14.3/§14.4） |
+| 摘要行符号不可读 | 放弃 ↑/⇡ 箭头区分参考系，改两行明确语言 `Since start · …` / `Tracking <upstream> · N ahead · M behind`（§14.1/§15.4/§15.5） |
+| 原生 `title` 不可靠 | 可见提示一律复用现有可聚焦 tooltip 机制（`conversation-telemetry-tooltip` 模式）；`aria-label` 与 tooltip 分工、不互相替代；全文禁止依赖原生 `title`（§17 及各处分发） |
+| disabled select 当静态标题 | 单 member 渲染普通文本标题，多 member 才渲染 select（改变现状行为，§15.1/§16） |
+| Commits 下禁用折叠按钮 | 改隐藏按钮内容、保留固定宽度 action slot（§15.3） |
+| 键盘树规范不完整 | 补 ←/→、Home/End、Enter/Space、焦点恢复规则、tablist roving tabindex + automatic activation + `aria-controls`/`tabpanel`（§17） |
+| 跨 member 提示文案不说明动作 | 改 `<N> more changes in <repo 列表> · Go to <repo>`，含截断规则、完整 tooltip、available 口径（§15.1） |
+| 验收清单扩充 | 补 tracking 三态、push/fetch 后刷新、边界提交（baseline 缺失/rewritten/merge/root）、200/400 上限、192px/zoom/高对比、全键盘与读屏、焦点恢复、分页期间 HEAD 变化（§18） |
+
+### 2026-08-22 Part II 第四轮（实施计划评审修订）
+
+| 决策点 | 结论 |
+| --- | --- |
+| `upstream` 二态字段无法表达 `Tracking unknown` | 改**三态判别联合** `tracked / none / unknown`（§14.4）；`none`=未设置、`unknown`=采集失败，未知不冒充事实 |
+| `headSha` 对 unreadable member 无定义 | 改 `headSha?: string`，unreadable 时缺省（§14.4） |
+| detached "Outside workspace" 与原生 select 冲突 | 行 1 select 旁加**独立小字元素**（原生 select 闭合态无法局部灰化；不沿用 option 文本后缀）（§15.1） |
+| commit 徽标 tooltip 键盘不可达 | 徽标语义折叠进 commit 行 `aria-label`；tooltip 随行级元素展示（§15.5 第 2 条/§17） |
+| 现状 ⟳/↗ 按钮用原生 `title` | PR-A 中一并替换为可聚焦 tooltip 机制（§17 纪律的现状清理） |
+| 截图宽度档口径 | 自动截图 192/240/320 三档（需扩展截图脚本）+ 420px 档留人工 dogfooding（§18 实施注记） |
+
+### 2026-08-22 Part II 第五轮（owner 评审修订：协议 / 接线 / 可实现性）
+
+| 决策点 | 结论 |
+| --- | --- |
+| Commits 协议只有列表/明细两类消息 | 补齐四类：`commits-list` / `commit-detail` / `commit-open-file` / `commit-review`；全部携带 `version` + `requestId`，响应回传 `requestId` + `subscriptionGeneration`——requestId 解决同 member 新旧请求竞态（generation 只覆盖跨 session）（§14.3） |
+| 响应 schema 不完整 | §14.3 给出完整 TS interface：`degraded` 五枚举（unreadable/timeout/history-moved/unknown-commit/error）、`historyHead` 回传、`offset` 回传、`sectionComplete`、`totalFiles`/`filesTruncated`、全部字段长度与数值上限 |
+| Earlier commits 从 HEAD 翻页产生"空翻页"；200 截断后 baseline 行误暗示无遗漏 | 分页模型重写：since-start 段 50/页，未达边界不渲染 baseline 行；Earlier 段**从 baseline 祖先直接继续**（不从 HEAD 翻页）；`historyHead` 回传比对，不一致即 `history-moved` 重置；撤销 200 硬上限（§14.3/§15.5 第 1/6/7 条） |
+| Task result 排除 untracked（现存实现缺陷） | `taskFileCount` 与 Review 均只读 tracked diff，破坏"Task result ⊃ Working changes"。列为 **PR-0 前置修复**：tracked ∪ untracked 并集（untracked original 侧 EMPTY_REF）——修实现，不改承诺（§19） |
+| 原生 select 闭合态无法两套 label | 可见 label + 透明原生 select 覆盖层（闭合态自定义 DOM，popup 原生 option）；option 保留 `(outside workspace)` 后缀，闭合态独立小字——双承载（§15.1） |
+| 纯 CSS tooltip 逃不出 overflow 裁剪 | 改**面板级 JS tooltip overlay**（`position: fixed` 挂 body、JS 定位、`aria-describedby` 同源）；现状 ⟳/SCM 的原生 `title` 一并迁移（§17） |
+| 跨 member 提示只统计 `available` | 改 `readable = availability !== 'unreadable'`（baselineUnavailable / historyRewritten 的 Working changes 仍可读）；计数与 Go to 候选同一集合（§15.1） |
+| Files 滚动位置记忆落在 PR-B | 前移到 PR-A（PR-A 即"Files 完成态"，§15.2 承诺）；PR-B 只补 Commits 侧滚动/展开项（§19） |
+| 首开 320px 无法区分"系统保存的 240"与"用户拖的 240" | 新增显式状态位 `widthUserResized` + `changesWidthRecommendationApplied`；存量用户（标志位 undefined）不触发推荐（§15.6） |
+| 400 files 降级出口自相矛盾 | 明细响应带 `totalFiles` + `filesTruncated`，UI 显示 `Showing 400 of N files`；Review 同受 400 上限、不暗示完整；超大 commit 完整审阅出口 = SCM / 外部 Git 工具（§15.5 第 3 条） |
+| tracking 三态采集不可区分 none/unknown | 弃用 `rev-parse @{upstream}` 单判，改事实查询链：`symbolic-ref -q HEAD` → `for-each-ref --format=%(upstream)`（成功且空 = none；失败 = unknown）→ `rev-parse HEAD <fullRef>`（单进程双 sha）→ `rev-list --left-right --count`；性能口径修正为 ≤4 新增进程/member + P95 目标（§14.1 附注/§18） |
+| baseline 缺失流程第 7/9 条矛盾 | 统一：`Current branch history` 单流 + 顶部说明条，无 Show full 按钮（§15.5 第 7/9 条） |
+| 文档残留 | §18 "title 全文"改 tooltip overlay 口径；§19 P2 "全部已推送"改"持久化 publication target 后再评估"；SCM 出口图标 ↗ 改 Source Control 图形（§15.1/§17） |

--- a/docs/worktree-changes-panel-v2-plan.md
+++ b/docs/worktree-changes-panel-v2-plan.md
@@ -1,0 +1,136 @@
+# Worktree Changes Panel v2 实施计划
+
+日期：2026-08-22（v1.2，经技术准确性 / 完整性 / 流程合规 / 协议与可实现性四路评审修订）
+
+状态：待 owner 确认后开工。本文是 `docs/worktree-changes-panel-prd.md` **Part II（§10–§19，v4.1）** 的实施拆解；行为口径、降级纪律、验收标准一律以 PRD 为准，本文不重复定义，只回答"怎么落地、按什么顺序、每步怎么验证"。
+
+范围：**PR-0（前置缺陷修复）** → **PR-A（头部 + Files 完成态）** → **PR-B（Commits tab）**。按 AGENTS.md 规矩在同一 worktree 分支上串行切 PR，后者等前者合并后 rebase 再开。
+
+v1.1 → v1.2 修订摘要：新增 PR-0（Task result untracked 现存缺陷修复）；Commits 协议补齐四类消息（open-file/review）+ requestId 双重丢弃；分页模型按 PRD §14.3 新版落地（sectionComplete、Earlier 从 baseline 祖先继续）；补全 Host 接线面（index.ts 导出、composition 注入、controller 四类 handler、单文件 diff 函数、viewer.ts 分发）；行 1 改"可见 label + 透明 select 覆盖层"；tooltip 改 JS overlay 基础设施；Files 滚动记忆前移 PR-A；320px 推荐改双状态位；tracking 采集改四命令事实查询链。
+
+## 1. 实施纪律（全程适用）
+
+- **RED → GREEN**：先写锚定新行为的失败测试，再改生产代码。每个新测试开工前指认其 CI 路径（unit/contract → `test:deterministic` → `test:ci:linux`；browser → `test:browser:run` → `test:ci:linux`）——本地可跑的孤儿测试不算 CI 覆盖（skill: fixing-regressions-with-ci）。
+- **commit 自洽**：Host markup ↔ Webview script 契约对（元素、消息、校验）必须在同一个 commit 内；锚定旧 DOM 的 browser 断言随 DOM 改动同 commit 重写，不留红 commit。
+- **双份镜像（泛化）**：canonical 源是 `src/webview/*.js`，`media/*.js` 是 gulp 再生镜像；先改 src/webview，`npx gulp --production` 再生后 `diff` 双份确认。WEBVIEW-ASSET-IDENTITY-001 对 `src/webview/*.js` **全量自动枚举**，本计划触及的 conversationChanges / conversationViewer / conversationSidebar 三个脚本均受约束。
+- **webview 闭世界登记**：新增/变更任何 `window.*` / `globalThis.*` 符号、跨脚本 producer→consumer 关系或加载顺序时，**同 commit** 更新 `docs/testing/architecture-webview-manifest.json`，验证跑 `npm run test:architecture-policy`（checkWebviewManifest 闭世界：未声明即 CI 红）。
+- **样式链路**：面板样式只改 `media/conversationViewer.scss`，`npx gulp --production` 一次性构建（dev 模式进 watch 不退出），编译产物 `media/conversationViewer.css` 已入库、与 scss 同 commit；构建后 grep 产物确认新选择器存在且未误配嵌套。tooltip overlay 的样式新建在 conversationViewer.scss（不进手写 telemetry css）。
+- **tooltip 伪元素纪律**：带 tooltip 的元素不要用 `::before/::after` 画装饰（chevron、徽标）；装饰用 `box-shadow`/`outline`（skill: resilient-webview-mutation-protocols）。
+- **无 capability audit**：该机制已在 PR #309 剪除，`main-capability-coverage.json` 为历史记录，不要新增 audit 提交。
+- **行为契约登记**：新行为进 `docs/testing/behavior-contracts.json`——文本定向编辑（防整文件格式化 churn）；新条目沿用现有 ID 体系与 `domain` 约定，automated owner 文件须含字面 ID；重写 WORKTREE-CHANGES-PANEL-001 断言时保持 ID 稳定。
+- **PR 门禁**：默认开 **draft**；每个 `gh` 命令带 `--repo hzcheng/agent-pivot`；PR body 必带 `## Skill harvest` 与 `## Owner approvals`（`approve <full-head-sha>` 就绪命令，`check-pr-body.js` 强制）；head 移动后**先改 body 再 push**；建/更新 PR 后核验 mergeable + checks 在跑，不留 conflict/red；合并需 owner 在 PR 页面对当前 head 发批准评论 + 对话内明确指示；`gh pr merge --merge` 不删远程分支。
+
+## 2. PR-0（前置缺陷修复，独立小 PR）
+
+对应 PRD §19 PR-0。现存缺陷：Task result 排除 untracked（`taskFileCount` 只跑 `git diff --name-only <baseline>`；`openTaskResultReview` 同口径），与 Part I §4.3 包含关系承诺矛盾。
+
+| WI | 内容与 DoD | 主要文件 | 测试 |
+| --- | --- | --- | --- |
+| Z1 | **taskFileCount ∪ untracked**：task 文件数 = `git diff --name-only -z <baseline>` 与 porcelain status 中 untracked 路径的并集计数 | `src/worktrees/changesCollector.ts` | `tests/unit/worktrees/changesCollector.test.js` + `tests/contract/worktrees/changesCollector.test.js`（真实 git fixture：untracked 文件计入、已跟踪文件不重复计） |
+| Z2 | **Review 包含 untracked**：`openTaskResultReview` 文件列表同上并集；untracked 的 original 侧用 EMPTY_REF（与 deleted 的空侧模式一致） | `src/services/gitChangesDiff.ts` | `tests/unit/services/gitChangesDiff.test.js`（untracked 三元组形状、不影响 tracked 行为） |
+
+建议单 commit：`fix: include untracked files in task result counts and review`。
+
+## 3. PR-A 工作分解（头部 + Files 完成态）
+
+对应 PRD：§14.1/§14.2/§14.4（数据面）、§15.1–§15.3、§15.4（仅摘要区两行部分）、§15.6、§16（Files 相关行）、§17（Files 部分 + tooltip 基础设施）。前置：PR-0 已合并。
+
+| WI | 内容与 DoD | 主要文件 | 测试 |
+| --- | --- | --- | --- |
+| A1 | **tracking 数据贯通**（四命令事实查询链）：`symbolic-ref -q HEAD`（空 = detached → none）→ `for-each-ref --format=%(upstream) <branchRef>`（成功且空 = none；失败/超时 = unknown）→ `rev-parse HEAD <fullRef>`（单进程取 headSha + upstream sha）→ `rev-list --left-right --count <fullRef>...HEAD`（左=behind 右=ahead）；**三态判别联合** `tracked / none / unknown`（§14.4）；`headSha?` unreadable 缺省；member 视图同步 3 处 + 双份镜像 | `src/worktrees/changesCollector.ts`、`src/aiSessions/conversation/types.ts`、`conversationChangesController.ts`、`src/webview/conversationChangesScripts.js`（+media 镜像） | unit + contract（真实 git fixture：tracked/none/unknown/detached HEAD、diverged）、`conversationChangesController.test.js`、`tests/integration/dashboard/conversationViewer.test.js`（member 视图字段断言同步） |
+| A2 | **头部 markup + 样式**：行 1（‹ › + **可见 repo label + 透明原生 select 覆盖层**（select 绝对定位、opacity 0、宽 100%；option 文案维持 `repo · ⎇ branch` 并保留 `(outside workspace)` 后缀）+ `(i/n)` + detached 独立小字元素）、行 2（分支独占 + `(no branch)` 兜底 + ⟳ + **Source Control 图标**）、行 3 中间态（仅右侧 action slot）；单 member 渲染普通文本标题（非 disabled select）；scss → 编译 css 同 commit | `src/aiSessions/conversation/viewerDocument.ts`、`media/conversationViewer.scss`（→ `media/conversationViewer.css`） | browser 测试重写（见 A9）；覆盖层点击穿透/聚焦/assert select 值同步 |
+| A3 | **头部行为**：‹ › 循环（复用 `conversation-viewer-changes-select`）、位置指示 + aria-live、单 member 退化、跨 member 提示升级（`N more changes in … · Go to <repo>`；**计数与跳转候选同集合 = readable（`availability !== 'unreadable'`）**；点击目标 = 固定顺序下一个 `workingItemCount > 0` 的 readable member）、分支行渲染（中间省略 + tooltip）；**window.* 符号变更同步 architecture-webview-manifest** | `src/webview/conversationChangesScripts.js`（+镜像）、`src/webview/conversationViewerScripts.js`（+镜像，create 句柄）、`docs/testing/architecture-webview-manifest.json` | browser 测试（循环/wrap/(i/n)/退化/提示行文案与点击目标/readable 口径、**完整 Tab 序 + ‹ › 焦点驻留连续 Enter**） |
+| A4 | **Files 摘要区两行**：`Since start · N files · M commits` + `Tracking <upstream> · N ahead · M behind` / `No tracking branch` / `Tracking unknown`（与 A1 三态一一对应）；样式纪律：`No tracking branch` 中性 `descriptionForeground`，不用 warning 色 | `src/webview/conversationChangesScripts.js`（+镜像）、scss | browser 测试（三态文案） |
+| A5 | **组头可折叠 + Collapse/Expand All + Files 上下文记忆**：组头改 button（chevron + 标题 + item 计数 + aria-expanded）、`collapsedGroups` 内存态、两个全局按钮（VS Code 图标 + tooltip overlay）、无改动空态禁用；**每 member 折叠态 + 滚动位置记忆（PRD §15.2，PR-A 即完成态）** | `src/webview/conversationChangesScripts.js`（+镜像）、`viewerDocument.ts`、scss | browser 测试（组头折叠、全合/全展、**切 member 再切回折叠态与滚动位置保留**、resetSession 清空） |
+| A6 | **Files 内容区键盘模型**：roving tabindex、↑↓/←→/Home/End/Enter/Space 全规则、焦点恢复（刷新失焦落同级/父级、Collapse All 落组头） | `src/webview/conversationChangesScripts.js`（+镜像） | browser 测试（逐键行为 + 焦点恢复） |
+| A7 | **首开 320px 推荐（双状态位）**：新增 `widthUserResized`（新代码首次持久化写 false，仅拖拽 handler 置 true）+ `changesWidthRecommendationApplied`；首开 Changes 且 `widthUserResized === false && !applied` → 320 并置 applied；存量用户（标志位 undefined）不触发；其余视图默认 240 不变 | `src/webview/conversationSidebarScripts.js`（+镜像） | browser/unit（新 state 推荐/拖拽后不推荐/存量 undefined 不推荐 三路径） |
+| A8 | **tooltip overlay 基础设施（新组件）**：面板级 JS 控制器——单一节点挂 body、`position: fixed`、`data-tooltip` 驱动、hover/focus 触发、Esc/blur/滚动/面板关闭关闭、`aria-describedby` 关联；**替换现状 ⟳/SCM 按钮的原生 `title`**；徽标语义折叠进行级 `aria-label`；window.* 符号同步 manifest | 新模块（`src/webview/conversationTooltipScripts.js` 或并入现有脚本，实现时按 manifest 最小化原则定）+镜像、`src/webview/conversationChangesScripts.js`（+镜像）、`docs/testing/architecture-webview-manifest.json`、scss | browser 测试（hover/focus 展示、Esc 关闭、**滚动区顶/底与 192px 无裁剪**、aria-describedby 关联） |
+| A9 | **测试重写与登记（残余兜底）**：WORKTREE-CHANGES-PANEL-001 锚定旧 DOM 的 5 个测试（L12232/12359/12401/12457/12496 区域）**随 DOM 改动同 commit 重写**；本项仅兜底契约登记 + 截图扩展；`scripts/dev/changes-panel-screenshot.js` 扩展 320px 档（现仅 240/192） | `tests/browser/conversationViewer.test.js`、`docs/testing/behavior-contracts.json`、`scripts/dev/changes-panel-screenshot.js` | — |
+
+**建议 commit 切分（5 个，自前而后依赖）：**
+
+1. `feat: surface tracking-branch state in changes members` — A1（纯数据面 + 校验，无 UI 消费）。
+2. `feat: add focusable tooltip overlay for conversation panels` — A8（基础设施先行，含现状 `title` 迁移；后续 commit 直接消费）。
+3. `feat: two-row worktree header with repo cycling` — A2+A3+A4（契约对同 commit；锚定 DOM 断言同 commit 重写）。
+4. `feat: collapsible change groups, collapse all, and per-member files context` — A5+A6（组头是键盘节点，必须同 commit）。
+5. `feat: recommend 320px on first changes-panel open` — A7+A9 收尾。
+
+**PR-A 中间态验收**（PRD §19）：行 1/行 2 最终结构就位；行 3 仅右侧 action slot（Collapse/Expand All 需要这一行，不留空行）、无子 tab 控件，Files 为唯一视图；⟳ 单路重采是正确中间态（commits 尚不存在，双路改造在 B5b）；markup/样式/测试按最终结构一次到位，PR-B 不重写。
+
+## 4. PR-B 工作分解（Commits tab）
+
+对应 PRD：§14.3/§14.4（协议面）、§15.4（子 tab 框架）、§15.5、§16（Commits 相关行）、§17（Commits 部分）。前置：PR-A 已合并。
+
+| WI | 内容与 DoD | 主要文件 | 测试 |
+| --- | --- | --- | --- |
+| B1 | **协议（四类消息 + 完整 schema）**：`commits-list` / `commit-detail` / `commit-open-file` / `commit-review`；请求带 `version` + `requestId`，响应回传 `requestId` + `subscriptionGeneration`；webview→host 校验在 viewerProtocol.ts；**host→webview 响应校验在 webview 脚本**（§14.3 第 5 条全部上限 + degraded 五枚举白名单）；`viewer.ts` 四条分发分支 | `viewerProtocol.ts`、`src/aiSessions/conversation/viewer.ts`、`types.ts`（CommitSummary/CommitFile/BaselineRow/CommitsDegraded）、`src/webview/conversationChangesScripts.js`（+镜像，响应校验器） | protocol 单测（正反例含 requestId/offset/historyHead/degraded 枚举） |
+| B2 | **commits 采集器 + Host 接线**：新增 `src/worktrees/commitsCollector.ts`（since-start 分页 `--max-count=51 --skip` 于 `<baseline>..<historyHead>`、`sectionComplete` + `baselineRow`、Earlier 段从 `<baselineSha>` 祖先续页、historyHead 回传比对 → `history-moved`、inTrackingBranch 集合、明细双 diff-tree 命令、5s 超时独立降级）；`src/worktrees/index.ts` 导出；`conversation/composition.ts`（或 dashboard.ts 对应组合根）实例化注入；`conversationChangesController.ts` 新增四类 handler（解析 member、校验 sha/member、调 collector/diff、发送响应与降级）；**新文件补进 `architecture-modules.json` worktrees infrastructure role** | 见左 + `src/worktrees/index.ts`、`conversation/composition.ts`、`conversationChangesController.ts`、`docs/testing/architecture-modules.json` | unit + contract（真实 git fixture：merge commit、root commit、rename `-z` old-path-first、分页 hasMore/sectionComplete、history-moved、baseline 缺失/改写） |
+| B3 | **diff 打开链路**：`openCommitFileDiff`（单文件 parent↔commit；root commit 与 added/deleted 侧用 EMPTY_REF；merge 按 first parent；binary/submodule 明确跳 SCM）；`openCommitReview`（multi-diff，共享 GitDiffContentProvider / 三元组 / capability fallback；`MAX_DIFF_FILES=400` 上限与 `totalFiles` 诚实展示）；open-file/review 前 `cat-file -e` 验证，unknown-commit → host toast + 推送刷新 | `src/services/gitChangesDiff.ts`、`conversationChangesController.ts`（接线） | `tests/unit/services/gitChangesDiff.test.js`（**root/rename/added/deleted/binary/submodule 六态** + 400 截断） |
+| B4 | **子 tab 框架**：`Files | Commits` 分段控件（tablist/tab/tabpanel/aria-selected、←→ automatic activation；装入行 3 左槽后 **Tab 序插入子 tab 停靠点**，PR-A 的 Tab 序断言需可扩展）；`conversationSidebar.changesSubTab` 持久化（新增键向后兼容）；**Commits 态下 action slot 保留宽度、隐藏折叠按钮内容**（§15.3）；window.* 变更同步 manifest | `viewerDocument.ts`、`src/webview/conversationChangesScripts.js`（+镜像）、`src/webview/conversationSidebarScripts.js`（+镜像）、`docs/testing/architecture-webview-manifest.json` | browser（tab 切换、键盘、reload 恢复、Commits 态折叠按钮隐藏） |
+| B5a | **Commits 渲染与交互**：标题区两行；commit 行（徽标矩阵 + aria-label 折叠语义）；行内展开 + numstat（行内 loading、明细失败行内 `Failed · Retry`、**`Showing 400 of N files`**）；`Load more` / `Load earlier commits`（加载中禁用 + 行内 spinner）；**baseline 行仅 sectionComplete 时渲染**；baseline 缺失 → `Current branch history` 单流 + 说明条、无 Show full 按钮；列表级 loading；切 member 即清 | `src/webview/conversationChangesScripts.js`（+镜像）、scss → css | browser（逐子项断言） |
+| B5b | **失效、记忆与状态反馈**：失效签名五元组比对 + 静默重取（不抢焦点）；**⟳ 双路重采**（§14.3 第 1 条）；**requestId + generation 双重丢弃**（§14.3 第 4 条：同 member 旧响应不得覆盖新刷新；迟到的跨 member/跨 session 响应丢弃）；Commits 滚动位置与展开项按 member 记忆；scope 按 member 恢复；`history-moved` → 回首行重取 | `src/webview/conversationChangesScripts.js`（+镜像） | browser（**ahead 不变但 upstream 变化也重取**；⟳ 双路；旧 requestId 响应丢弃；切 member 无残留） |
+| B6 | **Commits 键盘行为**：§17 模型在 Commits 列表的实例化（commit 行 = 可展开节点，文件行 = 叶子） | `src/webview/conversationChangesScripts.js`（+镜像） | browser |
+| B7 | **契约登记 + 截图**：behavior-contracts 登记；192/240/320px 自动截图含 Commits 态（420px 档留人工 dogfooding） | `docs/testing/behavior-contracts.json` | — |
+
+**建议 commit 切分（3 个）：**
+
+1. `feat: commits data channel for worktree changes panel` — B1+B2+B3（host 数据面 + 校验先行 + 单测；webview 尚未消费是 PR 内可接受中间态）。
+2. `feat: commits tab with inline file changes` — B4+B5a+B5b+B6（契约对同 commit + browser 测试）。
+3. `test: register commits-tab behavior contracts` — B7（契约登记 + 截图验证）。
+
+## 5. 验证矩阵
+
+每个 PR 提交前按序执行（凡清理/重建 `out/` 的命令先于消费 `out/` 的检查；长套件用后台任务 + 显式 timeout）：
+
+| 步骤 | 命令 | 时机 |
+| --- | --- | --- |
+| 编译 | `npm run test-compile` | 每个 commit 前 |
+| 焦点测试 | 本 WI 对应测试文件（见上表） | 每个 commit 前 |
+| Webview 检查 | `node scripts/run-dashboard-webview-checks.js` | 涉及 media/ 的 commit |
+| 架构策略 | `npm run test:architecture-policy` | 触碰 window.* / 加载顺序 / architecture-modules.json 的 commit |
+| Lint | `npm run lint` | 涉及 ts 的 commit |
+| 行为契约 | `npm run test:behavior-contracts` | **含契约变更的 commit 前** + push 前 |
+| 空白检查 | `git diff --check` | 每个 commit 前 |
+| 渲染验证 | `node scripts/dev/changes-panel-screenshot.js <outDir>`，192/240/320px 三档目检（420px 留人工 dogfooding） | UI 变化的 PR 收尾 |
+| 覆盖率门 | `npm run test:coverage:ci`（或 `npm run test:coverage:run && node scripts/check-changed-coverage.js`；需先 fetch origin/main 或设 `COVERAGE_DIFF_BASE`） | PR 前 |
+| 分支级 CI 等价 | `npm run test:ci:linux`（后台任务 + 足量 timeout） | PR 前 |
+
+## 6. 风险与缓解
+
+| 风险 | 影响 | 缓解 |
+| --- | --- | --- |
+| browser 测试锚定旧 DOM（5 个测试、多处断言 + fixture 搭建） | PR-A 最大隐性工作量 | RED 先行；断言随 DOM 改动同 commit 重写（契约对纪律优先），A9 仅兜底 |
+| 双份镜像漏改一边（含 conversationViewer/conversationSidebar/新 tooltip 模块） | CI WEBVIEW-ASSET-IDENTITY-001 红；测试与运行时行为分裂 | 先改 src/webview、gulp 再生、提交前 diff 双份 |
+| window.* 闭世界未登记 | CI checkWebviewManifest 红 | A3/A8/B4 同 commit 更新 architecture-webview-manifest + `test:architecture-policy` |
+| scss 锚点误配；tooltip 伪元素串样式 | 样式错乱且测试不一定抓到 | 构建后 grep 编译产物；装饰不用 ::before/::after；截图目检 |
+| tooltip overlay 是新组件（定位/滚动关闭/焦点管理） | 实现复杂度与边界 bug | A8 独立 commit 先行；browser 测试覆盖滚动区顶/底 + 192px；不追求自动翻转等高级定位（钉在触发元素下方、越界钳制即可） |
+| select 透明覆盖层的可测性 | browser 测试断言不到 opacity 0 的元素交互 | 断言 select 值同步 + focus 行为；视觉交叠由截图目检兜底 |
+| tracking 采集每 member ≤4 个新增 git 进程 | 刷新延迟 | 并入现有采集周期与 5s 超时；独立降级（unknown）不影响 baseline 数字；P95 目标：tracking 增量 ≤150ms、commits 首屏 ≤300ms（dogfooding 实测，§18） |
+| 失效签名/requestId 比对遗漏 | 陈旧 commits 列表（PRD 核心痛点） | B5b 测试显式覆盖"ahead 不变 upstream 变"、"旧 requestId 响应丢弃"、"⟳ 双路" |
+| 截图脚本无 320px 档 | 验证矩阵无法执行 | A9 先扩展脚本再谈三档目检 |
+| 老 Chromium 兼容 | 布局/语法不兼容 | 不引入超出现状用法的 CSS/JS 特性；无布局动画 |
+
+## 7. 验收映射（PRD §18 dogfooding 清单 → PR）
+
+| 验收项 | PR |
+| --- | --- |
+| Task result 数字与 Review 含 untracked（与 Working 一致） | PR-0 |
+| 多仓库切换点击数、(i/n) 正确；跨 member 提示文案、readable 口径与 Go to 目标 | PR-A |
+| 分支名 240/320/420px 可辨认（自动截图 192/240/320 + 420 人工）；192px/zoom/高对比无溢出 | PR-A |
+| Collapse All 只剩组头；Expand All 还原；**切 member 再切回折叠态与滚动位置保留（Files）** | PR-A |
+| 全键盘操作与读屏名称（Files）；Collapse All/刷新/切换后焦点恢复 | PR-A |
+| tooltip overlay 无裁剪（滚动区顶/底、192px、头部按钮） | PR-A |
+| Commits 监控静默更新与摘要同数；⟳ 双路重采；tracking 三态与 push/fetch 后刷新（失效签名）；P95 实测 | PR-B |
+| commit → diff / Review；边界提交（baseline 缺失/rewritten/merge/root）；400-of-N 诚实展示；分页期间 HEAD 变化 → history-moved 重置 | PR-B |
+| 键盘与焦点恢复（Commits）；192px/zoom/高对比（Commits） | PR-B |
+
+注：PRD §18 的截断全文验收以 tooltip overlay 为准（不查原生 `title`）。
+
+## 8. 开工前检查单
+
+1. 本计划 v1.2 与 PRD v4.1（含第五轮修订）经 owner 确认；
+2. worktree 内 `npm ci` 已跑（npm 会从主 checkout 静默解析二进制）；
+3. 分支基于最新 `origin/main`（先 fetch + rebase）；
+4. **PR-A / PR-B 前置**：前一 PR 合并后 rebase → **重跑 `npm ci`** → 按 §5 矩阵全量重验后再 push（不发布 rebase 前构建的产物）；
+5. 若实施中新增 package.json script 或改变 AGENTS.md 所列命令语义，触发 AGENTS.md 更新义务；
+6. 按 §2 从 Z1 的 RED 测试开始。

--- a/src/services/gitChangesDiff.ts
+++ b/src/services/gitChangesDiff.ts
@@ -137,10 +137,8 @@ export async function openTaskResultReview(
     title: string,
     onError?: (message: string, error: unknown) => void
 ): Promise<void> {
-    const files = await new Promise<string[]>(resolve => {
-        execFile('git', [
-            '-C', worktreePath, 'diff', '--name-only', '-z', baselineSha,
-        ], {
+    const listFiles = (args: string[]) => new Promise<string[]>(resolve => {
+        execFile('git', ['-C', worktreePath, ...args], {
             cwd: worktreePath,
             timeout: GIT_SHOW_TIMEOUT_MS,
             maxBuffer: GIT_SHOW_MAX_OUTPUT_BYTES,
@@ -148,10 +146,18 @@ export async function openTaskResultReview(
         }, (error, stdout) => {
             resolve(error
                 ? []
-                : stdout.split('\0').filter(token => token)
-                    .slice(0, MAX_DIFF_FILES));
+                : stdout.split('\0').filter(token => token));
         });
     });
+    // Task result ⊃ Working changes (PRD §4.3): untracked files join the
+    // tracked diff, otherwise files visible in Working changes would be
+    // missing from the review.
+    const tracked = await listFiles(['diff', '--name-only', '-z', baselineSha]);
+    const untracked = await listFiles(
+        ['ls-files', '--others', '--exclude-standard', '-z']);
+    const untrackedSet = new Set(untracked);
+    const files = [...new Set([...tracked, ...untracked])]
+        .slice(0, MAX_DIFF_FILES);
     if (!files.length) {
         return;
     }
@@ -159,7 +165,11 @@ export async function openTaskResultReview(
         const fileUri = vscode.Uri.file(path.join(worktreePath, file));
         return [
             fileUri,
-            gitContentUri(worktreePath, baselineSha, file),
+            // An untracked file has no baseline side: render it as an
+            // empty original, like an added file.
+            untrackedSet.has(file)
+                ? gitContentUri(worktreePath, EMPTY_REF, file)
+                : gitContentUri(worktreePath, baselineSha, file),
             // A deleted file has no working-tree document: render the
             // modified side as empty content instead of a missing file.
             existsSync(fileUri.fsPath)

--- a/src/worktrees/changesCollector.ts
+++ b/src/worktrees/changesCollector.ts
@@ -49,7 +49,8 @@ export interface MemberChangesSnapshot {
     /**
      * Task-result file count (changes-panel PRD §5.3): files whose net
      * content differs between the baseline and the current worktree
-     * (committed + uncommitted, untracked excluded). Absent when unknown.
+     * (committed + uncommitted + untracked — Task result ⊃ Working
+     * changes, PRD §4.3). Absent when unknown.
      */
     taskFileCount?: number;
     collectedAt: number;
@@ -241,9 +242,22 @@ export class ChangesCollector {
                 '-C', worktreePath,
                 'diff', '--name-only', '-z', baseline.commitSha,
             ], worktreePath);
-            snapshot.taskFileCount = diff.stdout.split('\0')
-                .filter(token => token && token.length <= MAX_PATH_LENGTH)
-                .length;
+            const others = await this.execGit([
+                '-C', worktreePath,
+                'ls-files', '--others', '--exclude-standard', '-z',
+            ], worktreePath);
+            // Task result ⊃ Working changes (PRD §4.3): the tracked diff
+            // alone silently drops untracked files. Both listings must
+            // succeed — a tracked-only count would fake completeness.
+            const paths = new Set<string>();
+            for (const output of [diff.stdout, others.stdout]) {
+                for (const token of output.split('\0')) {
+                    if (token && token.length <= MAX_PATH_LENGTH) {
+                        paths.add(token);
+                    }
+                }
+            }
+            snapshot.taskFileCount = paths.size;
         } catch (_error) {
             // taskFileCount stays unknown; the task layer hides itself.
         }

--- a/tests/contract/worktrees/changesCollector.test.js
+++ b/tests/contract/worktrees/changesCollector.test.js
@@ -81,3 +81,32 @@ test('WORKTREE-CHANGES-COLLECT-001 reads a real repository end to end', async t 
     const rewritten = await collector.collect(repo, unrelated);
     assert.equal(rewritten.availability, 'historyRewritten');
 });
+
+test('WORKTREE-CHANGES-COLLECT-001 task file count unions the tracked diff and untracked files', async t => {
+    const { repo } = await repositoryFixture(t);
+    const baselineSha = git(repo, ['rev-parse', 'HEAD']);
+    const baseline = {
+        commitSha: baselineSha,
+        capturedAt: Date.now(),
+        source: { kind: 'branch', fullRef: 'refs/heads/main' },
+    };
+    const collector = new ChangesCollector();
+
+    // One committed file ahead, one modified tracked file, and untracked
+    // files (an ignored one must stay out).
+    await fs.promises.writeFile(path.join(repo, 'committed.ts'), 'committed\n');
+    git(repo, ['add', 'committed.ts']);
+    git(repo, ['commit', '-m', 'intermediate', '-q']);
+    await fs.promises.writeFile(path.join(repo, 'tracked.ts'), 'two\n');
+    await fs.promises.writeFile(path.join(repo, 'scratch.txt'), 'untracked\n');
+    await fs.promises.writeFile(path.join(repo, '.gitignore'), 'ignored.log\n');
+    await fs.promises.writeFile(path.join(repo, 'ignored.log'), 'ignored\n');
+
+    const snapshot = await collector.collect(repo, baseline);
+    assert.equal(snapshot.availability, 'available');
+    // Tracked diff: committed.ts + tracked.ts = 2; untracked: scratch.txt
+    // + .gitignore = 2 (ignored.log excluded); Task result ⊃ Working
+    // changes (PRD §4.3) — untracked must join the count.
+    assert.equal(snapshot.taskFileCount, 4,
+        'task result counts committed + modified + untracked files');
+});

--- a/tests/unit/services/gitChangesDiff.test.js
+++ b/tests/unit/services/gitChangesDiff.test.js
@@ -192,3 +192,26 @@ test('WORKTREE-CHANGES-PANEL-001 task result review falls back to a per-file lis
     assert.equal(diffQuery(diff[2]).ref, '~empty~');
     assert.equal(diff[3], 'c.txt');
 });
+
+test('WORKTREE-CHANGES-PANEL-001 task result review includes untracked files with an empty baseline side', async t => {
+    const repo = await repoFixture(t);
+    await fs.promises.writeFile(path.join(repo.dir, 'new.txt'), 'new\n');
+    const executed = [];
+    const service = loadService(executed, { failChanges: false });
+
+    await service.openTaskResultReview(repo.dir, repo.baseline, 'Task result');
+
+    assert.equal(executed.length, 1, 'the multi-diff opens without a diff fallback');
+    const [command, , resources] = executed[0];
+    assert.equal(command, 'vscode.changes');
+    // Task result ⊃ Working changes (PRD §4.3): the untracked file joins
+    // the tracked diff (a.txt modified + c.txt deleted + new.txt untracked).
+    assert.equal(resources.length, 3);
+    const byName = Object.fromEntries(
+        resources.map(entry => [path.basename(entry[0].fsPath), entry]));
+    assert.ok(byName['new.txt'], 'the untracked file is part of the review');
+    assert.equal(diffQuery(byName['new.txt'][1]).ref, '~empty~',
+        'an untracked file has no baseline side — empty original');
+    assert.equal(byName['new.txt'][2].scheme, 'file',
+        'an untracked file renders its working-tree document');
+});


### PR DESCRIPTION
## Summary

Two commits on top of `origin/main`:

1. **docs**: Worktree Changes Panel v2 PRD (merged into `worktree-changes-panel-prd.md` as Part II, five reviewed decision rounds) + implementation plan (`worktree-changes-panel-v2-plan.md` v1.2). Covers the four owner-reported pain points: truncated branch name, dropdown-only repo switching, no collapse/expand-all, and no commit history view.
2. **fix (PR-0 of the plan)**: `taskFileCount` and `openTaskResultReview` only read the tracked diff (`git diff --name-only <baseline>`), so untracked files appeared in Working changes but were missing from the Task result count and the Review multi-diff — breaking the PRD §4.3 promise that Task result ⊃ Working changes. Now both use tracked diff ∪ untracked (`git ls-files --others --exclude-standard`), with untracked files rendered against an `EMPTY_REF` original side.

## Test plan

- RED → GREEN: new contract test (`changesCollector` real-repo fixture: committed + modified + untracked + gitignored) and unit test (`openTaskResultReview` triples include the untracked file with an empty baseline side) failed before, pass after.
- Focused suites: unit/worktrees + unit/services + contract/worktrees 338/338; conversationChangesController 9/9; integration conversationViewer 99/99; browser conversationViewer 115/115.
- `npm run test-compile`, `npm run lint` (touched files clean), `npm run test:behavior-contracts`, `git diff --check` all green.

## Skill harvest

none — no process friction worth harvesting (one self-caught `node --test` directory-invocation slip, fixed immediately; no skill gap).

## Owner approvals

```
approve 2674e2b01fcfa94bb5b6ae36f861d64f768b906f
```
