### PR TITLE
fix(chats): prevent attention updates from jumping worktree rows

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -3711,6 +3711,21 @@
     ]
   },
   {
+    "id": "WORKTREE-GROUPS-ORDER-001",
+    "domain": "session",
+    "title": "Worktree group order is stable across attention and activity status updates",
+    "priority": "P1",
+    "status": "automated",
+    "owners": [
+      "tests/unit/workspaces/worktreeGroupProjection.test.js",
+      "tests/browser/worktreeGroups.test.js"
+    ],
+    "evidence": [
+      "src/workspaces/worktreeGroupProjection.ts",
+      "src/webview/webviewAiSessionContent.ts"
+    ]
+  },
+  {
     "id": "WORKTREE-GROUPS-UI-001",
     "domain": "webview",
     "title": "The Worktree surface unifies row behavior: every row carries the same actions menu (no standalone + or surface-level New-worktree button), the Current anchor menu offers session creation and new-worktree creation but never removal, group rows show chips and merge affordances, legacy-scope badges, and the surface stays usable at the minimum sidebar width",

--- a/media/webviewAiSessionViewStateScripts.js
+++ b/media/webviewAiSessionViewStateScripts.js
@@ -478,25 +478,12 @@ function restoreAiSessionListAnchor(list, anchor) {
     });
 }
 
-function getFocusedAiSessionCardIdentity(projectDiv) {
-    if (!projectDiv || typeof projectDiv.querySelector !== 'function') return null;
-    var row = projectDiv.querySelector(
-        '.codex-sessions .codex-session-row'
-        + '[data-session-focused][data-session-provider][data-session-id]'
-    );
-    return row ? {
-        provider: row.getAttribute('data-session-provider') || '',
-        sessionId: row.getAttribute('data-session-id') || '',
-    } : null;
-}
-
 function captureAiSessionViewState(projectDiv) {
     // M2 panels: CHATS (tree) scrolls its worktree list; ALL scrolls the
     // history list. Both anchors ride every authoritative replacement.
     var chatsList = projectDiv.querySelector('.ai-session-chats-panel .ai-session-worktree-list');
     var allList = projectDiv.querySelector('.ai-session-history-panel .codex-sessions-list');
     var focused = typeof document !== 'undefined' ? document.activeElement : null;
-    var focusedSession = getFocusedAiSessionCardIdentity(projectDiv);
     var focusedInside = focused && typeof focused.closest === 'function'
         && (focused.closest('.project[data-id]')
             || focused.closest('[data-open-session-surface][data-id]')) === projectDiv;
@@ -515,7 +502,6 @@ function captureAiSessionViewState(projectDiv) {
         pendingCount: projectDiv.querySelectorAll('.active-ai-session-row[data-session-pending]').length,
         activeCount: projectDiv.querySelectorAll('.active-ai-session-row[data-session-active]').length,
         restoreFocus: !!focusedInside,
-        focusedSession: focusedSession,
         focusedTab: focusedTab && focusedTab.getAttribute('data-ai-session-tab'),
         focusedRow: focusedRow ? {
             provider: focusedRow.getAttribute('data-session-provider') || '',
@@ -622,34 +608,6 @@ function restoreAiSessionViewState(projectDiv, viewState, requestedTab, options)
         restoreAiSessionViewFocus(projectDiv, viewState, selectedTab);
     }
     return selectedTab;
-}
-
-function revealChangedFocusedAiSessionCard(root, states) {
-    if (!root || typeof root.querySelectorAll !== 'function'
-        || !states || typeof states.get !== 'function') return;
-    root.querySelectorAll('[data-open-session-surface][data-current-workspace][data-id]').forEach(projectDiv => {
-        var state = states.get(projectDiv.getAttribute('data-id'));
-        var previous = state && state.view ? state.view.focusedSession : null;
-        var row = projectDiv.querySelector(
-            '.ai-session-chats-panel .codex-session-row[data-session-focused]'
-            + '[data-session-provider][data-session-id]'
-        );
-        if (!row) return;
-        var provider = row.getAttribute('data-session-provider') || '';
-        var sessionId = row.getAttribute('data-session-id') || '';
-        if (previous && previous.provider === provider && previous.sessionId === sessionId) {
-            return;
-        }
-        // Session focus moved to this card during the authoritative refresh:
-        // surface it instead of preserving the stale scroll position.
-        var panel = row.closest('[data-ai-session-panel]');
-        if (panel && panel.hidden) {
-            selectAiSessionTabDom(projectDiv, 'chats');
-            writeAiSessionTabState(window.vscode, projectDiv.getAttribute('data-id'), 'chats');
-            postSelectedAiSessionViewTab(projectDiv.getAttribute('data-id'), 'chats');
-        }
-        row.scrollIntoView({ block: 'nearest' });
-    });
 }
 
 function captureAiSessionProviderMenuState(projectDiv) {

--- a/media/webviewDashboardBundle.js
+++ b/media/webviewDashboardBundle.js
@@ -560,25 +560,12 @@ function restoreAiSessionListAnchor(list, anchor) {
     });
 }
 
-function getFocusedAiSessionCardIdentity(projectDiv) {
-    if (!projectDiv || typeof projectDiv.querySelector !== 'function') return null;
-    var row = projectDiv.querySelector(
-        '.codex-sessions .codex-session-row'
-        + '[data-session-focused][data-session-provider][data-session-id]'
-    );
-    return row ? {
-        provider: row.getAttribute('data-session-provider') || '',
-        sessionId: row.getAttribute('data-session-id') || '',
-    } : null;
-}
-
 function captureAiSessionViewState(projectDiv) {
     // M2 panels: CHATS (tree) scrolls its worktree list; ALL scrolls the
     // history list. Both anchors ride every authoritative replacement.
     var chatsList = projectDiv.querySelector('.ai-session-chats-panel .ai-session-worktree-list');
     var allList = projectDiv.querySelector('.ai-session-history-panel .codex-sessions-list');
     var focused = typeof document !== 'undefined' ? document.activeElement : null;
-    var focusedSession = getFocusedAiSessionCardIdentity(projectDiv);
     var focusedInside = focused && typeof focused.closest === 'function'
         && (focused.closest('.project[data-id]')
             || focused.closest('[data-open-session-surface][data-id]')) === projectDiv;
@@ -597,7 +584,6 @@ function captureAiSessionViewState(projectDiv) {
         pendingCount: projectDiv.querySelectorAll('.active-ai-session-row[data-session-pending]').length,
         activeCount: projectDiv.querySelectorAll('.active-ai-session-row[data-session-active]').length,
         restoreFocus: !!focusedInside,
-        focusedSession: focusedSession,
         focusedTab: focusedTab && focusedTab.getAttribute('data-ai-session-tab'),
         focusedRow: focusedRow ? {
             provider: focusedRow.getAttribute('data-session-provider') || '',
@@ -704,34 +690,6 @@ function restoreAiSessionViewState(projectDiv, viewState, requestedTab, options)
         restoreAiSessionViewFocus(projectDiv, viewState, selectedTab);
     }
     return selectedTab;
-}
-
-function revealChangedFocusedAiSessionCard(root, states) {
-    if (!root || typeof root.querySelectorAll !== 'function'
-        || !states || typeof states.get !== 'function') return;
-    root.querySelectorAll('[data-open-session-surface][data-current-workspace][data-id]').forEach(projectDiv => {
-        var state = states.get(projectDiv.getAttribute('data-id'));
-        var previous = state && state.view ? state.view.focusedSession : null;
-        var row = projectDiv.querySelector(
-            '.ai-session-chats-panel .codex-session-row[data-session-focused]'
-            + '[data-session-provider][data-session-id]'
-        );
-        if (!row) return;
-        var provider = row.getAttribute('data-session-provider') || '';
-        var sessionId = row.getAttribute('data-session-id') || '';
-        if (previous && previous.provider === provider && previous.sessionId === sessionId) {
-            return;
-        }
-        // Session focus moved to this card during the authoritative refresh:
-        // surface it instead of preserving the stale scroll position.
-        var panel = row.closest('[data-ai-session-panel]');
-        if (panel && panel.hidden) {
-            selectAiSessionTabDom(projectDiv, 'chats');
-            writeAiSessionTabState(window.vscode, projectDiv.getAttribute('data-id'), 'chats');
-            postSelectedAiSessionViewTab(projectDiv.getAttribute('data-id'), 'chats');
-        }
-        row.scrollIntoView({ block: 'nearest' });
-    });
 }
 
 function captureAiSessionProviderMenuState(projectDiv) {
@@ -996,7 +954,6 @@ function applyWorkspaceUpdate(message, options) {
             && options.canRestoreAiSessionProviderMenu(projectId)
     );
     restoreCurrentWorkspaceAiSessionAnchorsAndFocus(wrapper, aiSessionStates);
-    revealChangedFocusedAiSessionCard(wrapper, aiSessionStates);
     if (typeof window.__agentPivotSyncCollapseButton === 'function') {
         window.__agentPivotSyncCollapseButton();
     }
@@ -1299,7 +1256,6 @@ function applyOpenWorkspacesUpdate(message, options) {
     }
     restoreCurrentWorkspaceAiSessionViewStates(wrapper, aiSessionStates);
     restoreCurrentWorkspaceAiSessionAnchorsAndFocus(wrapper, aiSessionStates);
-    revealChangedFocusedAiSessionCard(wrapper, aiSessionStates);
     reconcilePendingOpenWorkspacePins(wrapper);
     // Replay the navigation pending/error row state before restoring focus so
     // an error row's Retry control is visible (focusable) again. The caller

--- a/media/webviewWorkspaceUpdateScripts.js
+++ b/media/webviewWorkspaceUpdateScripts.js
@@ -116,7 +116,6 @@ function applyWorkspaceUpdate(message, options) {
             && options.canRestoreAiSessionProviderMenu(projectId)
     );
     restoreCurrentWorkspaceAiSessionAnchorsAndFocus(wrapper, aiSessionStates);
-    revealChangedFocusedAiSessionCard(wrapper, aiSessionStates);
     if (typeof window.__agentPivotSyncCollapseButton === 'function') {
         window.__agentPivotSyncCollapseButton();
     }
@@ -419,7 +418,6 @@ function applyOpenWorkspacesUpdate(message, options) {
     }
     restoreCurrentWorkspaceAiSessionViewStates(wrapper, aiSessionStates);
     restoreCurrentWorkspaceAiSessionAnchorsAndFocus(wrapper, aiSessionStates);
-    revealChangedFocusedAiSessionCard(wrapper, aiSessionStates);
     reconcilePendingOpenWorkspacePins(wrapper);
     // Replay the navigation pending/error row state before restoring focus so
     // an error row's Retry control is visible (focusable) again. The caller

--- a/scripts/run-architecture-guards.js
+++ b/scripts/run-architecture-guards.js
@@ -1215,12 +1215,10 @@ const guards = {
         ) || !hasValidFocusedTargetReturn
             || webviewScriptSources.some(source =>
                 source.includes('activeAiSessionTerminalState'))
-            || focusMarkerReadOwners.length !== 4
+            || focusMarkerReadOwners.length !== 2
             || ![
                 'focusAiSessionConversationOrigin',
                 'getAiSessionCardActivation',
-                'getFocusedAiSessionCardIdentity',
-                'revealChangedFocusedAiSessionCard',
             ].every(owner => focusMarkerReadOwners.filter(candidate =>
                 candidate === owner).length === 1)) {
             fail(this.id, risk,

--- a/src/webview/webviewAiSessionContent.ts
+++ b/src/webview/webviewAiSessionContent.ts
@@ -695,17 +695,8 @@ function getReadyWorktrees(
     rows: readonly WorktreeRowViewModel[] | undefined,
 ): ReadyWorktreeRow[] {
     return (rows || [])
-        .map((row, index) => ({ row, index }))
-        .filter((candidate): candidate is { row: ReadyWorktreeRow; index: number } =>
-            candidate.row.kind === 'ready' && candidate.row.git.isBare !== true)
-        .sort((left, right) => activityPriority(left.row.activity)
-            - activityPriority(right.row.activity)
-            || left.index - right.index)
-        .map(candidate => candidate.row);
-}
-
-function activityPriority(activity: ReadyWorktreeRow['activity']): number {
-    return activity === 'attention' ? 0 : activity === 'active' ? 1 : 2;
+        .filter((row): row is ReadyWorktreeRow =>
+            row.kind === 'ready' && row.git.isBare !== true);
 }
 
 function worktreeLookupKey(key: WorktreeKey): string {

--- a/src/webview/webviewAiSessionViewStateScripts.js
+++ b/src/webview/webviewAiSessionViewStateScripts.js
@@ -478,25 +478,12 @@ function restoreAiSessionListAnchor(list, anchor) {
     });
 }
 
-function getFocusedAiSessionCardIdentity(projectDiv) {
-    if (!projectDiv || typeof projectDiv.querySelector !== 'function') return null;
-    var row = projectDiv.querySelector(
-        '.codex-sessions .codex-session-row'
-        + '[data-session-focused][data-session-provider][data-session-id]'
-    );
-    return row ? {
-        provider: row.getAttribute('data-session-provider') || '',
-        sessionId: row.getAttribute('data-session-id') || '',
-    } : null;
-}
-
 function captureAiSessionViewState(projectDiv) {
     // M2 panels: CHATS (tree) scrolls its worktree list; ALL scrolls the
     // history list. Both anchors ride every authoritative replacement.
     var chatsList = projectDiv.querySelector('.ai-session-chats-panel .ai-session-worktree-list');
     var allList = projectDiv.querySelector('.ai-session-history-panel .codex-sessions-list');
     var focused = typeof document !== 'undefined' ? document.activeElement : null;
-    var focusedSession = getFocusedAiSessionCardIdentity(projectDiv);
     var focusedInside = focused && typeof focused.closest === 'function'
         && (focused.closest('.project[data-id]')
             || focused.closest('[data-open-session-surface][data-id]')) === projectDiv;
@@ -515,7 +502,6 @@ function captureAiSessionViewState(projectDiv) {
         pendingCount: projectDiv.querySelectorAll('.active-ai-session-row[data-session-pending]').length,
         activeCount: projectDiv.querySelectorAll('.active-ai-session-row[data-session-active]').length,
         restoreFocus: !!focusedInside,
-        focusedSession: focusedSession,
         focusedTab: focusedTab && focusedTab.getAttribute('data-ai-session-tab'),
         focusedRow: focusedRow ? {
             provider: focusedRow.getAttribute('data-session-provider') || '',
@@ -622,34 +608,6 @@ function restoreAiSessionViewState(projectDiv, viewState, requestedTab, options)
         restoreAiSessionViewFocus(projectDiv, viewState, selectedTab);
     }
     return selectedTab;
-}
-
-function revealChangedFocusedAiSessionCard(root, states) {
-    if (!root || typeof root.querySelectorAll !== 'function'
-        || !states || typeof states.get !== 'function') return;
-    root.querySelectorAll('[data-open-session-surface][data-current-workspace][data-id]').forEach(projectDiv => {
-        var state = states.get(projectDiv.getAttribute('data-id'));
-        var previous = state && state.view ? state.view.focusedSession : null;
-        var row = projectDiv.querySelector(
-            '.ai-session-chats-panel .codex-session-row[data-session-focused]'
-            + '[data-session-provider][data-session-id]'
-        );
-        if (!row) return;
-        var provider = row.getAttribute('data-session-provider') || '';
-        var sessionId = row.getAttribute('data-session-id') || '';
-        if (previous && previous.provider === provider && previous.sessionId === sessionId) {
-            return;
-        }
-        // Session focus moved to this card during the authoritative refresh:
-        // surface it instead of preserving the stale scroll position.
-        var panel = row.closest('[data-ai-session-panel]');
-        if (panel && panel.hidden) {
-            selectAiSessionTabDom(projectDiv, 'chats');
-            writeAiSessionTabState(window.vscode, projectDiv.getAttribute('data-id'), 'chats');
-            postSelectedAiSessionViewTab(projectDiv.getAttribute('data-id'), 'chats');
-        }
-        row.scrollIntoView({ block: 'nearest' });
-    });
 }
 
 function captureAiSessionProviderMenuState(projectDiv) {

--- a/src/webview/webviewWorkspaceUpdateScripts.js
+++ b/src/webview/webviewWorkspaceUpdateScripts.js
@@ -116,7 +116,6 @@ function applyWorkspaceUpdate(message, options) {
             && options.canRestoreAiSessionProviderMenu(projectId)
     );
     restoreCurrentWorkspaceAiSessionAnchorsAndFocus(wrapper, aiSessionStates);
-    revealChangedFocusedAiSessionCard(wrapper, aiSessionStates);
     if (typeof window.__agentPivotSyncCollapseButton === 'function') {
         window.__agentPivotSyncCollapseButton();
     }
@@ -419,7 +418,6 @@ function applyOpenWorkspacesUpdate(message, options) {
     }
     restoreCurrentWorkspaceAiSessionViewStates(wrapper, aiSessionStates);
     restoreCurrentWorkspaceAiSessionAnchorsAndFocus(wrapper, aiSessionStates);
-    revealChangedFocusedAiSessionCard(wrapper, aiSessionStates);
     reconcilePendingOpenWorkspacePins(wrapper);
     // Replay the navigation pending/error row state before restoring focus so
     // an error row's Retry control is visible (focusable) again. The caller

--- a/src/workspaces/worktreeGroupProjection.ts
+++ b/src/workspaces/worktreeGroupProjection.ts
@@ -102,12 +102,6 @@ export interface WorktreeAdoptSuggestion {
     }[];
 }
 
-const ACTIVITY_ORDER: Record<WorktreeActivity, number> = {
-    attention: 0,
-    active: 1,
-    idle: 2,
-};
-
 /**
  * Pure projection from the raw Git snapshot + the authoritative group
  * manifest to the Worktree tab's row model (docs/worktree-tasks-prd.md §10).
@@ -279,10 +273,13 @@ export function buildWorktreeGroupProjection(
         }
     }
 
+    // Position is independent from volatile activity: clearing an attention
+    // badge must update only that group's state, never move the whole row.
+    // `groupId` is immutable, so it is a deterministic tie-breaker when two
+    // groups are created in the same clock tick (unlike a renameable label).
     groupRows.sort((left, right) =>
-        ACTIVITY_ORDER[left.activity] - ACTIVITY_ORDER[right.activity]
-        || createdAtOf(input.groups, right.groupId) - createdAtOf(input.groups, left.groupId)
-        || left.displayName.localeCompare(right.displayName));
+        createdAtOf(input.groups, right.groupId) - createdAtOf(input.groups, left.groupId)
+        || left.groupId.localeCompare(right.groupId));
 
     const unmanaged: ReadyWorktreeRow[] = [];
     for (const repository of repositories) {

--- a/tests/browser/activeSessionCardInteraction.test.js
+++ b/tests/browser/activeSessionCardInteraction.test.js
@@ -792,7 +792,7 @@ test('WEBVIEW-CURRENT-WINDOW-SESSION-FIT-001 keeps the lifted session surface pe
     assert.equal(await page.locator('.open-current-workspace-group').count(), 0);
 });
 
-test('ACTIVE-SESSION-FOCUS-REVEAL-001 reveals the newly focused card when an AI or open-workspaces refresh moves focus', async t => {
+test('ACTIVE-SESSION-FOCUS-REVEAL-001 preserves the selected panel when an atomic refresh changes focus', async t => {
     const active = Array.from({ length: 8 }, (_, index) => session(
         'codex', `active-${index + 1}`, index === 0
     ));
@@ -810,7 +810,8 @@ test('ACTIVE-SESSION-FOCUS-REVEAL-001 reveals the newly focused card when an AI 
         ...entry,
         focused: index === 6,
     })), history);
-    assert.equal(await isRowFullyVisibleInList(row(page, 'codex', 'active-7')), true);
+    assert.equal(await isRowFullyVisibleInList(row(page, 'codex', 'active-7')), false,
+        'a status refresh must preserve the CHATS viewport instead of revealing a new focus');
 
     await page.locator('[data-ai-session-tab="all"]').click();
     assert.equal(
@@ -822,10 +823,45 @@ test('ACTIVE-SESSION-FOCUS-REVEAL-001 reveals the newly focused card when an AI 
         focused: index === 1,
     })), history, 'active', 3);
     assert.equal(
-        await page.locator('[data-ai-session-tab="chats"]').getAttribute('aria-selected'),
+        await page.locator('[data-ai-session-tab="all"]').getAttribute('aria-selected'),
         'true'
     );
-    assert.equal(await isRowFullyVisibleInList(row(page, 'codex', 'active-2')), true);
+    assert.equal(await isRowFullyVisibleInList(row(page, 'codex', 'active-2')), false,
+        'an OPEN replacement must not switch tabs or scroll solely for a status focus change');
+});
+
+test('ATTENTION-SESSION-CARD-ACKNOWLEDGEMENT-001 keeps the CHATS anchor and focus when attention clears', async t => {
+    const active = Array.from({ length: 8 }, (_, index) => session(
+        'codex', `active-${index + 1}`, index === 4
+    ));
+    const page = await openListPage(t, active, []);
+    const attentionRow = row(page, 'codex', 'active-5');
+    await waitForPageCondition(page, () => {
+        const list = document.querySelector('[data-ai-session-panel="chats"] .ai-session-worktree-list');
+        return list && list.scrollHeight > list.clientHeight;
+    });
+    await postHostMessage(page, presentationMessage(active, 1, {
+        attention: { 'codex:active-5': ['event-attention'] },
+        revealFocused: true,
+    }));
+    const before = await attentionRow.evaluate(node => {
+        const list = node.closest('.ai-session-worktree-list');
+        list.scrollTop = node.offsetTop - list.offsetTop - 22;
+        node.querySelector('.ai-session-primary-action').focus();
+        return node.getBoundingClientRect().top - list.getBoundingClientRect().top;
+    });
+
+    await postListAiSessionsUpdate(page, active, [], 'active', 2);
+    const restored = row(page, 'codex', 'active-5');
+    assert.ok(Math.abs((await relativeTop(restored)) - before) <= 1,
+        'clearing the attention marker must retain the reader\'s CHATS anchor');
+    assert.equal(
+        await restored.locator('.ai-session-primary-action').evaluate(node => document.activeElement === node),
+        true,
+        'the replacement restores focus to the activated chat action',
+    );
+    assert.equal(await restored.locator('.ai-session-attention-indicator').count(), 0,
+        'the cleared presentation removes the attention marker in place');
 });
 
 test('ACTIVE-SESSION-FOCUS-REVEAL-001 keeps a newer complete presentation when older HTML arrives later', async t => {

--- a/tests/browser/worktreeGroups.test.js
+++ b/tests/browser/worktreeGroups.test.js
@@ -856,6 +856,77 @@ test('WORKTREE-GROUPS-UI-001 authoritative updates preserve the worktree list sc
         'a refresh must not snap the worktree panel back to the top');
 });
 
+test('WORKTREE-GROUPS-ORDER-001 preserves rendered group order when attention clears', async t => {
+    const renderedGroups = olderActivity => surface({
+        worktreeGroups: [
+            groupRow({ groupId: 'g-newer', displayName: 'newer task', activity: 'active' }),
+            groupRow({
+                groupId: 'g-older', displayName: 'older task', activity: olderActivity,
+                members: [member({
+                    memberId: 'm-older', path: '/alpha/.worktrees/older-task',
+                    worktreeKey: {
+                        repositoryKey: '/alpha/.git',
+                        canonicalWorktreePath: '/alpha/.worktrees/older-task',
+                    },
+                })],
+            }),
+        ],
+    });
+    const initial = () => renderedGroups('attention');
+    const settled = () => renderedGroups('active');
+    const { page, applyUpdate, replacement } = await openGroupActionsPage(t, initial, settled);
+    const groupIds = () => page.locator('.ai-session-worktree-task-group')
+        .evaluateAll(rows => rows.map(row => row.getAttribute('data-group-id')));
+
+    assert.deepEqual(await groupIds(), ['g-newer', 'g-older']);
+    assert.equal(await applyUpdate(replacement()), true);
+    assert.deepEqual(await groupIds(), ['g-newer', 'g-older']);
+});
+
+test('WORKTREE-GROUPS-ORDER-001 preserves unmanaged worktree order when attention clears', async t => {
+    const worktrees = secondActivity => [
+        {
+            kind: 'ready',
+            git: {
+                key: {
+                    repositoryKey: '/alpha/.git',
+                    canonicalWorktreePath: '/alpha/.worktrees/first',
+                },
+                branchRef: 'refs/heads/first', head: 'a'.repeat(40),
+                isMain: false, isBare: false, health: 'normal', headKind: 'branch',
+            },
+            activity: 'active', sessions: [], authority: { canResume: true, canRemove: true },
+        },
+        {
+            kind: 'ready',
+            git: {
+                key: {
+                    repositoryKey: '/beta/.git',
+                    canonicalWorktreePath: '/beta/.worktrees/second',
+                },
+                branchRef: 'refs/heads/second', head: 'b'.repeat(40),
+                isMain: false, isBare: false, health: 'normal', headKind: 'branch',
+            },
+            activity: secondActivity, sessions: [], authority: { canResume: true, canRemove: true },
+        },
+    ];
+    const initial = () => surface({ worktrees: worktrees('attention') });
+    const settled = () => surface({ worktrees: worktrees('active') });
+    const { page, applyUpdate, replacement } = await openGroupActionsPage(t, initial, settled);
+    const paths = () => page.locator('.ai-session-worktree-group:not(.ai-session-worktree-anchor)')
+        .evaluateAll(rows => rows.map(row => row.getAttribute('data-worktree-path')));
+
+    assert.deepEqual(await paths(), [
+        '/alpha/.worktrees/first',
+        '/beta/.worktrees/second',
+    ]);
+    assert.equal(await applyUpdate(replacement()), true);
+    assert.deepEqual(await paths(), [
+        '/alpha/.worktrees/first',
+        '/beta/.worktrees/second',
+    ]);
+});
+
 async function openGroupActionsPage(t, sessionHtml, replacementHtml) {
     const groupHtml = () =>
         `<div class="open-session-surface" data-open-session-surface data-id="project-a"`

--- a/tests/integration/dashboard/webviewState.test.js
+++ b/tests/integration/dashboard/webviewState.test.js
@@ -718,8 +718,8 @@ test('WORKTREE-GROUPING-UI-001 renders Worktree and Chats with worktree status r
     assert.doesNotMatch(treePanel, /data-session-id="feature-session"/,
         'the CHATS tree never duplicates history sessions');
     assert.match(html, /data-worktree-activity="attention"/);
-    assert.ok(html.indexOf('feature/auth') < html.indexOf('feature/idle'),
-        'attention worktrees render first while stable snapshot order breaks ties');
+    assert.ok(html.indexOf('feature/idle') < html.indexOf('feature/auth'),
+        'status changes retain the stable snapshot order instead of moving attention worktrees');
     assert.match(html, /feature\/idle[\s\S]*?locked[\s\S]*?\(no active sessions\)/);
     assert.match(html, /2 more worktrees not shown/);
     assert.match(html, /data-action="toggle-ai-session-worktree"/);

--- a/tests/unit/workspaces/worktreeGroupProjection.test.js
+++ b/tests/unit/workspaces/worktreeGroupProjection.test.js
@@ -402,23 +402,39 @@ test('WORKTREE-GROUPS-002 colliding display names get a stable branch discrimina
     assert.equal(byId['g-2'].discriminator, 'agent-pivot/fix-login');
 });
 
-test('WORKTREE-GROUPS-002 groups sort by activity then recency', () => {
-    const { groups } = project({
-        groups: [
-            group({ groupId: 'g-idle', createdAt: 300 }),
-            group({
-                groupId: 'g-busy', createdAt: 100,
-                members: [member('/beta/.git', 'fix-login', { memberId: 'm-beta' })],
-            }),
-        ],
-        activeSessions: [{
-            key: 'codex:s1', provider: 'codex', sessionId: 's1', name: 'Live',
+test('WORKTREE-GROUPS-ORDER-001 keeps group positions stable when attention clears', () => {
+    const newerGroup = group({
+        groupId: 'g-newer', createdAt: 300,
+        members: [member('/beta/.git', 'fix-login', { memberId: 'm-newer' })],
+    });
+    const olderGroup = group({ groupId: 'g-older', createdAt: 100 });
+    const sessions = needsAttention => [
+        {
+            key: 'codex:newer', provider: 'codex', sessionId: 'newer', name: 'Newer',
             executionState: 'running', focused: false, needsAttention: false,
             pending: false, backend: 'vscode', attached: true,
-            worktreeKey: member('/beta/.git', 'fix-login').worktreeKey,
-        }],
+            worktreeKey: newerGroup.members[0].worktreeKey,
+        },
+        {
+            key: 'codex:older', provider: 'codex', sessionId: 'older', name: 'Older',
+            executionState: 'running', focused: false, needsAttention,
+            pending: false, backend: 'vscode', attached: true,
+            worktreeKey: olderGroup.members[0].worktreeKey,
+        },
+    ];
+    const attention = project({
+        groups: [newerGroup, olderGroup],
+        activeSessions: sessions(true),
     });
-    assert.deepEqual(groups.map(row => row.groupId), ['g-busy', 'g-idle']);
+    const cleared = project({
+        groups: [newerGroup, olderGroup],
+        activeSessions: sessions(false),
+    });
+
+    assert.equal(attention.groups.find(row => row.groupId === 'g-older').activity, 'attention');
+    assert.equal(cleared.groups.find(row => row.groupId === 'g-older').activity, 'active');
+    assert.deepEqual(attention.groups.map(row => row.groupId), ['g-newer', 'g-older']);
+    assert.deepEqual(cleared.groups.map(row => row.groupId), ['g-newer', 'g-older']);
 });
 
 test('WORKTREE-GROUPS-002 chips use the shortest prefix unique across the workspace', () => {


### PR DESCRIPTION
## Summary

- preserve the Chats viewport across authoritative attention updates
- keep managed worktree groups ordered by creation time instead of volatile activity
- preserve unmanaged worktree order when attention clears
- update the integration expectation so CI enforces stable snapshot ordering
- retire architecture-guard allowances for the removed automatic focused-card reveal path

## Verification

- `npm run test-compile`
- `node --test tests/unit/workspaces/worktreeGroupProjection.test.js`
- `node --test --test-concurrency=1 tests/browser/worktreeGroups.test.js`
- `node --test --test-name-pattern='WORKTREE-GROUPING-UI-001 renders Worktree and Chats with worktree status rows' tests/integration/dashboard/webviewState.test.js`
- `node --test tests/unit/tooling/architectureGuards.test.js`
- `npm run test:coverage:run`
- `npm run test:architecture-guards`
- `npm run test:behavior-contracts`
- `node scripts/run-dashboard-webview-checks.js`
- `npm run lint`
- `npm run install-local` (packaged and byte-verified on the active SSH VS Code Server)

## Skill harvest

No skill change: the regression and CI workflows already require reproducing the failed gate and validating its exact CI-equivalent stage; this identified both stale assumptions without reintroducing automatic scrolling.

## Owner approvals

```text
approve a6d3f07c58cc05877d8d3d2d78a422f3c9161c5c
```