### PR TITLE
fix: unify chat session tooltips

### DIFF
--- a/media/webviewDashboardBundle.js
+++ b/media/webviewDashboardBundle.js
@@ -2518,11 +2518,12 @@ function initAiSessionPresentationDom(options) {
                 var actionAriaLabel = primaryAction.getAttribute(
                     'data-' + actionState + '-aria-label'
                 );
-                var actionTitle = primaryAction.getAttribute(
-                    'data-' + actionState + '-title'
+                var actionTooltip = primaryAction.getAttribute(
+                    'data-' + actionState + '-tooltip'
                 );
                 if (actionAriaLabel) primaryAction.setAttribute('aria-label', actionAriaLabel);
-                if (actionTitle) primaryAction.setAttribute('title', actionTitle);
+                if (actionTooltip) primaryAction.setAttribute('data-tooltip', actionTooltip);
+                primaryAction.removeAttribute('title');
             }
             var conversationHint = row.querySelector('.ai-session-open-conversation-hint');
             if (focusedConversation && primaryAction && !conversationHint) {
@@ -2552,7 +2553,7 @@ function initAiSessionPresentationDom(options) {
         if (needsAttention && primaryAction && !indicator) {
             indicator = document.createElement('span');
             indicator.className = 'ai-session-attention-indicator';
-            indicator.title = 'AI session needs attention';
+            indicator.setAttribute('data-tooltip', 'AI session needs attention');
             indicator.setAttribute('aria-label', 'AI session needs attention');
             primaryAction.insertBefore(indicator, primaryAction.firstChild);
         } else if (!needsAttention && indicator) {
@@ -2641,19 +2642,21 @@ function initAiSessionPresentationDom(options) {
             return;
         }
         projectDiv.setAttribute('data-has-ai-session-badge', '');
-        summary.title = parts.join(', ');
-        summary.setAttribute('aria-label', parts.join(', '));
+        var summaryLabel = parts.join(', ');
+        summary.setAttribute('data-tooltip', summaryLabel);
+        summary.setAttribute('aria-label', summaryLabel);
     }
     function setCurrentWorkspaceRunningDom(projectDiv, message) {
         var running = message.runningSessionCount > 0;
         projectDiv.classList.toggle('session-running', running);
+        // A title on the Workspace container is inherited by every session
+        // and worktree descendant, stacking a delayed native tooltip on top
+        // of their fast data-tooltip overlay.
+        projectDiv.removeAttribute('title');
         if (running) {
             projectDiv.setAttribute('data-session-fx', message.runningCardAnimation);
-            projectDiv.title = 'Workspace — ' + message.runningSessionCount + ' active session'
-                + (message.runningSessionCount === 1 ? '' : 's') + ' running';
         } else {
             projectDiv.removeAttribute('data-session-fx');
-            projectDiv.removeAttribute('title');
         }
         var effect = projectDiv.querySelector('.project-session-fx');
         var showEffect = running && message.runningCardAnimation !== 'none';
@@ -2684,7 +2687,7 @@ function initAiSessionPresentationDom(options) {
             runningBadge.setAttribute(
                 'data-ai-session-active-count', String(message.runningSessionCount)
             );
-            runningBadge.title = runningLabel;
+            runningBadge.setAttribute('data-tooltip', runningLabel);
             runningBadge.setAttribute('aria-label', runningLabel);
             var runningCount = runningBadge.querySelector('.ai-session-active-count');
             runningCount.textContent = '●' + message.runningSessionCount;
@@ -2704,7 +2707,7 @@ function initAiSessionPresentationDom(options) {
                 + (message.attentionCount === 1 ? '' : 's') + ' need'
                 + (message.attentionCount === 1 ? 's' : '') + ' attention';
             attentionBadge.textContent = String(message.attentionCount);
-            attentionBadge.title = attentionLabel;
+            attentionBadge.setAttribute('data-tooltip', attentionLabel);
             attentionBadge.setAttribute('aria-label', attentionLabel);
         }
         projectDiv.toggleAttribute(

--- a/media/webviewProjectAiUpdateScripts.js
+++ b/media/webviewProjectAiUpdateScripts.js
@@ -273,11 +273,12 @@ function initAiSessionPresentationDom(options) {
                 var actionAriaLabel = primaryAction.getAttribute(
                     'data-' + actionState + '-aria-label'
                 );
-                var actionTitle = primaryAction.getAttribute(
-                    'data-' + actionState + '-title'
+                var actionTooltip = primaryAction.getAttribute(
+                    'data-' + actionState + '-tooltip'
                 );
                 if (actionAriaLabel) primaryAction.setAttribute('aria-label', actionAriaLabel);
-                if (actionTitle) primaryAction.setAttribute('title', actionTitle);
+                if (actionTooltip) primaryAction.setAttribute('data-tooltip', actionTooltip);
+                primaryAction.removeAttribute('title');
             }
             var conversationHint = row.querySelector('.ai-session-open-conversation-hint');
             if (focusedConversation && primaryAction && !conversationHint) {
@@ -307,7 +308,7 @@ function initAiSessionPresentationDom(options) {
         if (needsAttention && primaryAction && !indicator) {
             indicator = document.createElement('span');
             indicator.className = 'ai-session-attention-indicator';
-            indicator.title = 'AI session needs attention';
+            indicator.setAttribute('data-tooltip', 'AI session needs attention');
             indicator.setAttribute('aria-label', 'AI session needs attention');
             primaryAction.insertBefore(indicator, primaryAction.firstChild);
         } else if (!needsAttention && indicator) {
@@ -396,19 +397,21 @@ function initAiSessionPresentationDom(options) {
             return;
         }
         projectDiv.setAttribute('data-has-ai-session-badge', '');
-        summary.title = parts.join(', ');
-        summary.setAttribute('aria-label', parts.join(', '));
+        var summaryLabel = parts.join(', ');
+        summary.setAttribute('data-tooltip', summaryLabel);
+        summary.setAttribute('aria-label', summaryLabel);
     }
     function setCurrentWorkspaceRunningDom(projectDiv, message) {
         var running = message.runningSessionCount > 0;
         projectDiv.classList.toggle('session-running', running);
+        // A title on the Workspace container is inherited by every session
+        // and worktree descendant, stacking a delayed native tooltip on top
+        // of their fast data-tooltip overlay.
+        projectDiv.removeAttribute('title');
         if (running) {
             projectDiv.setAttribute('data-session-fx', message.runningCardAnimation);
-            projectDiv.title = 'Workspace — ' + message.runningSessionCount + ' active session'
-                + (message.runningSessionCount === 1 ? '' : 's') + ' running';
         } else {
             projectDiv.removeAttribute('data-session-fx');
-            projectDiv.removeAttribute('title');
         }
         var effect = projectDiv.querySelector('.project-session-fx');
         var showEffect = running && message.runningCardAnimation !== 'none';
@@ -439,7 +442,7 @@ function initAiSessionPresentationDom(options) {
             runningBadge.setAttribute(
                 'data-ai-session-active-count', String(message.runningSessionCount)
             );
-            runningBadge.title = runningLabel;
+            runningBadge.setAttribute('data-tooltip', runningLabel);
             runningBadge.setAttribute('aria-label', runningLabel);
             var runningCount = runningBadge.querySelector('.ai-session-active-count');
             runningCount.textContent = '●' + message.runningSessionCount;
@@ -459,7 +462,7 @@ function initAiSessionPresentationDom(options) {
                 + (message.attentionCount === 1 ? '' : 's') + ' need'
                 + (message.attentionCount === 1 ? 's' : '') + ' attention';
             attentionBadge.textContent = String(message.attentionCount);
-            attentionBadge.title = attentionLabel;
+            attentionBadge.setAttribute('data-tooltip', attentionLabel);
             attentionBadge.setAttribute('aria-label', attentionLabel);
         }
         projectDiv.toggleAttribute(

--- a/src/webview/webviewAiSessionContent.ts
+++ b/src/webview/webviewAiSessionContent.ts
@@ -53,8 +53,15 @@ function getAiSessionProfileBadge(
         return '';
     }
     var escapedProfile = escapeAttribute(profile);
-    var tooltip = `Codex config profile: ${escapedProfile}${profileUnavailable ? ' (unavailable)' : ''}`;
-    return `<span class="ai-session-profile-badge${profileUnavailable ? ' ai-session-profile-unavailable' : ''}" title="${tooltip}" aria-label="${tooltip}">${escapedProfile}${profileUnavailable ? ' · unavailable' : ''}</span>`;
+    var tooltip = getAiSessionProfileTooltip(profile, profileUnavailable);
+    return `<span class="ai-session-profile-badge${profileUnavailable ? ' ai-session-profile-unavailable' : ''}" data-tooltip="${tooltip}" aria-label="${tooltip}">${escapedProfile}${profileUnavailable ? ' · unavailable' : ''}</span>`;
+}
+
+function getAiSessionProfileTooltip(
+    profile: string | undefined,
+    profileUnavailable: boolean | undefined
+): string {
+    return `Profile: ${profile ? escapeAttribute(profile) : 'default'}${profileUnavailable ? ' (unavailable)' : ''}`;
 }
 
 export interface AiSessionSurfaceViewModel {
@@ -1158,7 +1165,7 @@ function getCodexSessionRow(
     var needsAttention = runtime ? runtime.needsAttention : !!session.attention?.unread;
     var attentionEventId = runtime?.attentionEventId || session.attention?.eventId || '';
     var attentionIndicator = needsAttention
-        ? '<span class="ai-session-attention-indicator" title="AI session needs attention" aria-label="AI session needs attention"></span>'
+        ? '<span class="ai-session-attention-indicator" data-tooltip="AI session needs attention" aria-label="AI session needs attention"></span>'
         : '';
     var pinTitle = pinned ? 'Unpin Session' : 'Pin Session';
     var active = session.active === true;
@@ -1167,8 +1174,8 @@ function getCodexSessionRow(
     var conflict = runtime?.conflict === true;
     var runtimeAttributes = ` data-session-backend="${backend}" data-session-attached="${attached ? 'true' : 'false'}"${runtime?.tmuxLayout ? ` data-tmux-layout="${runtime.tmuxLayout}"` : ''}${runtime?.conflict ? ' data-session-conflict' : ''}${runtime?.stale ? ' data-session-stale' : ''}`;
     var batchCheckbox = `<input type="checkbox" class="ai-session-batch-checkbox" aria-label="Select ${sessionName}"${active ? ' disabled' : ''}>`;
-    var pinAction = `<button type="button" class="codex-session-pin ${pinned ? 'active' : ''}" data-action="toggle-ai-session-pin" title="${pinTitle}" aria-label="${pinTitle}">${Icons.pin}</button>`;
-    const contextMenuAction = `<button type="button" class="codex-session-more" data-action="open-ai-session-context-menu" aria-haspopup="menu" aria-expanded="false" aria-controls="aiSessionContextMenu" aria-label="More actions" title="More actions">&#8943;</button>`;
+    var pinAction = `<button type="button" class="codex-session-pin ${pinned ? 'active' : ''}" data-action="toggle-ai-session-pin" data-tooltip="${pinTitle}" aria-label="${pinTitle}">${Icons.pin}</button>`;
+    const contextMenuAction = `<button type="button" class="codex-session-more" data-action="open-ai-session-context-menu" aria-haspopup="menu" aria-expanded="false" aria-controls="aiSessionContextMenu" aria-label="More actions" data-tooltip="More actions">&#8943;</button>`;
     var worktreeGone = !active && session.worktreeUnavailable === true;
     var primaryAction = conflict ? 'Choose runtime'
         : active && backend === 'tmux' && !attached ? 'Attach or focus'
@@ -1197,7 +1204,10 @@ function getCodexSessionRow(
             : 'stopped';
     const statusLabel = getSessionStatusLabel(statusState);
     const statusMarker = getSessionStatusMarker(statusState);
+    const profileTooltip = getAiSessionProfileTooltip(session.profile, session.profileUnavailable);
     const rowDetails = [
+        `Provider: ${providerLabel}`,
+        profileTooltip,
         `Title ${sessionName}`,
         `Status ${statusLabel}`,
         updatedAt ? `Last activity ${updatedAt}` : '',
@@ -1217,18 +1227,16 @@ function getCodexSessionRow(
         ? `<span class="ai-session-root-chip">${escapeAttribute(sanitizeProjectName(primaryRootLabel))}</span>`
         : '';
     var worktreeChip = worktreeLabel
-        ? `<span class="ai-session-worktree-chip" title="Worktree ${escapeAttribute(worktreeLabel)}">${escapeAttribute(worktreeLabel)}</span>`
+        ? `<span class="ai-session-worktree-chip" data-tooltip="Worktree ${escapeAttribute(worktreeLabel)}">${escapeAttribute(worktreeLabel)}</span>`
         : '';
     var providerBadge = `<span class="ai-session-provider-badge">${providerLabel}</span>`;
     var profileBadge = getAiSessionProfileBadge(session.profile, session.profileUnavailable);
-    var profileAriaLabel = session.profile
-        ? `, Codex config profile ${escapeAttribute(session.profile)}${session.profileUnavailable ? ' (unavailable)' : ''}`
-        : '';
+    var profileAriaLabel = `, ${profileTooltip}`;
 
     return `
 <div class="codex-session-row" role="group" aria-label="${providerLabel} session ${sessionName}${profileAriaLabel}"${runtimeAttributes}${rootAttributes}${pinned ? ' data-session-pinned' : ''}${active ? ' data-session-active' : ''}${needsAttention ? ' data-ai-session-attention data-session-event-id="' + escapeAttribute(attentionEventId) + '"' : ''} data-session-id="${sessionId}" data-session-provider="${provider}"${getFlatOrderAttributes(flatOrder)}>
     ${batchCheckbox}
-    <button type="button" class="ai-session-primary-action" data-action="activate-ai-session" aria-label="${primaryAriaLabel}" title="${primaryTooltip}"${worktreeGone ? ' disabled data-session-worktree-unavailable' : ''}>
+    <button type="button" class="ai-session-primary-action" data-action="activate-ai-session" aria-label="${primaryAriaLabel}" data-tooltip="${primaryTooltip}"${worktreeGone ? ' disabled data-session-worktree-unavailable' : ''}>
         ${attentionIndicator}
         <span class="codex-session-icon">${getAiProviderIcon(provider)}</span>
         <span class="codex-session-text">
@@ -1236,7 +1244,7 @@ function getCodexSessionRow(
         </span>
     </button>
     <span class="codex-session-actions">
-        ${!active ? `<button type="button" class="codex-session-view" data-action="view-ai-session-conversation" title="View Conversation" aria-label="View conversation for ${providerLabel} session ${sessionName}">${Icons.viewConversation}</button>` : ''}
+        ${!active ? `<button type="button" class="codex-session-view" data-action="view-ai-session-conversation" data-tooltip="View Conversation" aria-label="View conversation for ${providerLabel} session ${sessionName}">${Icons.viewConversation}</button>` : ''}
         ${pinAction}
         ${contextMenuAction}
     </span>
@@ -1268,19 +1276,19 @@ function getActiveAiSessionRow(
         ? 'Legacy workspace scope; restart the session to confine it to its worktree'
         : '';
     var legacyScopeBadge = model.legacyScope
-        ? '<span class="ai-session-legacy-scope" title="Runs with the pre-isolation workspace scope; restart the session to confine it to its worktree." aria-label="Legacy workspace scope">legacy scope</span>'
+        ? '<span class="ai-session-legacy-scope" data-tooltip="Runs with the pre-isolation workspace scope; restart the session to confine it to its worktree." aria-label="Legacy workspace scope">legacy scope</span>'
         : '';
     var attentionIndicator = model.needsAttention
-        ? '<span class="ai-session-attention-indicator" title="AI session needs attention" aria-label="AI session needs attention"></span>'
+        ? '<span class="ai-session-attention-indicator" data-tooltip="AI session needs attention" aria-label="AI session needs attention"></span>'
         : '';
     var pinTitle = model.pinned ? 'Unpin Session' : 'Pin Session';
     var pinAction = model.pending
         ? ''
-        : `<button type="button" class="codex-session-pin ${model.pinned ? 'active' : ''}" data-action="toggle-ai-session-pin" title="${pinTitle}" aria-label="${pinTitle}">${Icons.pin}</button>`;
+        : `<button type="button" class="codex-session-pin ${model.pinned ? 'active' : ''}" data-action="toggle-ai-session-pin" data-tooltip="${pinTitle}" aria-label="${pinTitle}">${Icons.pin}</button>`;
     var conflict = model.conflict === true;
     const contextMenuAction = model.pending
         ? ''
-        : `<button type="button" class="codex-session-more" data-action="open-ai-session-context-menu" aria-haspopup="menu" aria-expanded="false" aria-controls="aiSessionContextMenu" aria-label="More actions" title="More actions">&#8943;</button>`;
+        : `<button type="button" class="codex-session-more" data-action="open-ai-session-context-menu" aria-haspopup="menu" aria-expanded="false" aria-controls="aiSessionContextMenu" aria-label="More actions" data-tooltip="More actions">&#8943;</button>`;
     var pendingAttributes = model.pending
         ? ` data-session-pending data-pending-id="${escapeAttribute(model.pendingId || '')}" data-pending-created-at="${escapeAttribute(model.createdAt || '')}"`
         : ` data-session-active data-session-id="${sessionId}"`;
@@ -1309,7 +1317,6 @@ function getActiveAiSessionRow(
     var primaryAriaLabel = hasOpenConversationHint
         ? conversationAriaLabel
         : focusAriaLabel;
-    var primaryTitle = hasOpenConversationHint ? conversationTitle : focusTitle;
     var rootAttributes = showRootChip && model.primaryRootId
         ? ` data-primary-root-id="${escapeAttribute(model.primaryRootId)}"`
         : '';
@@ -1317,12 +1324,11 @@ function getActiveAiSessionRow(
         ? `<span class="ai-session-root-chip">${escapeAttribute(sanitizeProjectName(model.primaryRootLabel))}</span>`
         : '';
     var worktreeChip = worktreeLabel
-        ? `<span class="ai-session-worktree-chip" title="Worktree ${escapeAttribute(worktreeLabel)}">${escapeAttribute(worktreeLabel)}</span>`
+        ? `<span class="ai-session-worktree-chip" data-tooltip="Worktree ${escapeAttribute(worktreeLabel)}">${escapeAttribute(worktreeLabel)}</span>`
         : '';
     var profileBadge = getAiSessionProfileBadge(model.profile, model.profileUnavailable);
-    var profileAriaLabel = model.profile
-        ? `, Codex config profile ${escapeAttribute(model.profile)}${model.profileUnavailable ? ' (unavailable)' : ''}`
-        : '';
+    const profileTooltip = getAiSessionProfileTooltip(model.profile, model.profileUnavailable);
+    var profileAriaLabel = `, ${profileTooltip}`;
     var openConversationHint = hasOpenConversationHint
         ? '<span class="ai-session-open-conversation-hint" aria-hidden="true">›</span>'
         : '';
@@ -1334,6 +1340,8 @@ function getActiveAiSessionRow(
     const statusLabel = getSessionStatusLabel(statusState);
     const statusMarker = getSessionStatusMarker(statusState);
     const rowDetails = [
+        `Provider: ${providerLabel}`,
+        profileTooltip,
         `Title ${sessionName}`,
         `Status ${statusLabel}`,
         createdAt ? `Last activity ${createdAt}` : '',
@@ -1349,9 +1357,11 @@ function getActiveAiSessionRow(
         + `${runtimeStatusLabel ? `, runtime conflict` : ''}`
         + `${staleStatus ? ', runtime status is stale' : ''}`
         + `${legacyScopeBadge ? ', legacy workspace scope' : ''}`;
-    const primaryTooltip = `${primaryTitle}\n${rowDetails}`;
+    const focusTooltip = `${focusTitle}\n${rowDetails}`;
+    const conversationTooltip = `${conversationTitle}\n${rowDetails}`;
+    const primaryTooltip = hasOpenConversationHint ? conversationTooltip : focusTooltip;
     return `<div class="codex-session-row active-ai-session-row" role="group" aria-label="${providerLabel} session ${sessionName}${profileAriaLabel}" data-session-provider="${model.provider}" data-execution-state="${model.executionState}"${iconFx ? ` data-session-icon-fx="${iconFx}"` : ''}${runtimeAttributes}${rootAttributes}${pendingAttributes}${model.pinned ? ' data-session-pinned' : ''}${model.focused ? ' data-session-focused' : ''}${model.needsAttention ? ' data-session-needs-attention' : ''}${attentionAttributes}${getFlatOrderAttributes(flatOrder)}>
-        <button type="button" class="ai-session-primary-action" data-action="activate-ai-session" aria-label="${primaryAriaLabel}" title="${primaryTooltip}" data-focus-aria-label="${focusAriaLabel}" data-focus-title="${focusTitle}" data-conversation-aria-label="${conversationAriaLabel}" data-conversation-title="${conversationTitle}">
+        <button type="button" class="ai-session-primary-action" data-action="activate-ai-session" aria-label="${primaryAriaLabel}" data-tooltip="${primaryTooltip}" data-focus-aria-label="${focusAriaLabel}" data-focus-tooltip="${focusTooltip}" data-conversation-aria-label="${conversationAriaLabel}" data-conversation-tooltip="${conversationTooltip}">
             ${attentionIndicator}
             <span class="codex-session-icon">${getAiProviderIcon(model.provider)}</span>
             <span class="codex-session-text">

--- a/src/webview/webviewProjectAiUpdateScripts.js
+++ b/src/webview/webviewProjectAiUpdateScripts.js
@@ -273,11 +273,12 @@ function initAiSessionPresentationDom(options) {
                 var actionAriaLabel = primaryAction.getAttribute(
                     'data-' + actionState + '-aria-label'
                 );
-                var actionTitle = primaryAction.getAttribute(
-                    'data-' + actionState + '-title'
+                var actionTooltip = primaryAction.getAttribute(
+                    'data-' + actionState + '-tooltip'
                 );
                 if (actionAriaLabel) primaryAction.setAttribute('aria-label', actionAriaLabel);
-                if (actionTitle) primaryAction.setAttribute('title', actionTitle);
+                if (actionTooltip) primaryAction.setAttribute('data-tooltip', actionTooltip);
+                primaryAction.removeAttribute('title');
             }
             var conversationHint = row.querySelector('.ai-session-open-conversation-hint');
             if (focusedConversation && primaryAction && !conversationHint) {
@@ -307,7 +308,7 @@ function initAiSessionPresentationDom(options) {
         if (needsAttention && primaryAction && !indicator) {
             indicator = document.createElement('span');
             indicator.className = 'ai-session-attention-indicator';
-            indicator.title = 'AI session needs attention';
+            indicator.setAttribute('data-tooltip', 'AI session needs attention');
             indicator.setAttribute('aria-label', 'AI session needs attention');
             primaryAction.insertBefore(indicator, primaryAction.firstChild);
         } else if (!needsAttention && indicator) {
@@ -396,19 +397,21 @@ function initAiSessionPresentationDom(options) {
             return;
         }
         projectDiv.setAttribute('data-has-ai-session-badge', '');
-        summary.title = parts.join(', ');
-        summary.setAttribute('aria-label', parts.join(', '));
+        var summaryLabel = parts.join(', ');
+        summary.setAttribute('data-tooltip', summaryLabel);
+        summary.setAttribute('aria-label', summaryLabel);
     }
     function setCurrentWorkspaceRunningDom(projectDiv, message) {
         var running = message.runningSessionCount > 0;
         projectDiv.classList.toggle('session-running', running);
+        // A title on the Workspace container is inherited by every session
+        // and worktree descendant, stacking a delayed native tooltip on top
+        // of their fast data-tooltip overlay.
+        projectDiv.removeAttribute('title');
         if (running) {
             projectDiv.setAttribute('data-session-fx', message.runningCardAnimation);
-            projectDiv.title = 'Workspace — ' + message.runningSessionCount + ' active session'
-                + (message.runningSessionCount === 1 ? '' : 's') + ' running';
         } else {
             projectDiv.removeAttribute('data-session-fx');
-            projectDiv.removeAttribute('title');
         }
         var effect = projectDiv.querySelector('.project-session-fx');
         var showEffect = running && message.runningCardAnimation !== 'none';
@@ -439,7 +442,7 @@ function initAiSessionPresentationDom(options) {
             runningBadge.setAttribute(
                 'data-ai-session-active-count', String(message.runningSessionCount)
             );
-            runningBadge.title = runningLabel;
+            runningBadge.setAttribute('data-tooltip', runningLabel);
             runningBadge.setAttribute('aria-label', runningLabel);
             var runningCount = runningBadge.querySelector('.ai-session-active-count');
             runningCount.textContent = '●' + message.runningSessionCount;
@@ -459,7 +462,7 @@ function initAiSessionPresentationDom(options) {
                 + (message.attentionCount === 1 ? '' : 's') + ' need'
                 + (message.attentionCount === 1 ? 's' : '') + ' attention';
             attentionBadge.textContent = String(message.attentionCount);
-            attentionBadge.title = attentionLabel;
+            attentionBadge.setAttribute('data-tooltip', attentionLabel);
             attentionBadge.setAttribute('aria-label', attentionLabel);
         }
         projectDiv.toggleAttribute(

--- a/tests/browser/activeSessionCardInteraction.test.js
+++ b/tests/browser/activeSessionCardInteraction.test.js
@@ -949,7 +949,9 @@ test('ACTIVE-SESSION-FOCUS-REVEAL-001 keeps the focused card highlight when anot
     await postHostMessage(page, presentationMessage(initial, 2, { revealFocused: true }));
     assert.equal(await focusedRow.getAttribute('data-session-focused'), '');
     assert.equal(await focusedRow.getAttribute('data-ai-session-active-terminal'), '');
-    assert.equal(await primaryAction.getAttribute('title'), 'Open AI conversation for Codex Session');
+    assert.equal(await primaryAction.getAttribute('title'), null);
+    assert.match(await primaryAction.getAttribute('data-tooltip'),
+        /^Open AI conversation for Codex Session\nProvider: Codex\nProfile: default/);
     assert.match(
         await focusedRow.evaluate(element => getComputedStyle(element).boxShadow),
         /rgba?\(0, 127, 212/
@@ -970,7 +972,9 @@ test('ACTIVE-SESSION-FOCUS-REVEAL-001 keeps the focused card highlight when anot
     assert.equal(await focusedRow.getAttribute('data-session-focused'), '');
     assert.equal(await focusedRow.getAttribute('data-ai-session-active-terminal'), '');
     assert.equal(await focusedRow.locator('.ai-session-open-conversation-hint').count(), 1);
-    assert.equal(await primaryAction.getAttribute('title'), 'Open AI conversation for Codex Session');
+    assert.equal(await primaryAction.getAttribute('title'), null);
+    assert.match(await primaryAction.getAttribute('data-tooltip'),
+        /^Open AI conversation for Codex Session\nProvider: Codex\nProfile: default/);
     assert.match(
         await focusedRow.evaluate(element => getComputedStyle(element).boxShadow),
         /rgba?\(0, 127, 212/
@@ -2441,10 +2445,9 @@ test('ACTIVE-SESSION-FOCUS-REVEAL-001 transfers pending focus through the comple
             revealFocused: true,
         }
     ));
-    assert.equal(
-        await pendingRow.locator('.ai-session-primary-action').getAttribute('title'),
-        'Focus pending Codex Session'
-    );
+    assert.equal(await pendingRow.locator('.ai-session-primary-action').getAttribute('title'), null);
+    assert.match(await pendingRow.locator('.ai-session-primary-action').getAttribute('data-tooltip'),
+        /^Focus pending Codex Session\nProvider: Codex\nProfile: default/);
     assert.equal(
         await pendingRow.locator('.ai-session-open-conversation-hint').count(),
         0
@@ -2685,7 +2688,12 @@ test('ACTIVE-SESSION-FOCUS-REVEAL-001 reveals a newer direct focus projection in
     assert.equal(await isRowFullyVisibleInList(row(page, 'codex', 'active-7')), true);
     assert.equal(
         await row(page, 'codex', 'active-7').locator('.ai-session-primary-action').getAttribute('title'),
-        'Open AI conversation for Codex Session'
+        null
+    );
+    assert.match(
+        await row(page, 'codex', 'active-7').locator('.ai-session-primary-action')
+            .getAttribute('data-tooltip'),
+        /^Open AI conversation for Codex Session\nProvider: Codex\nProfile: default/
     );
     assert.equal(
         await row(page, 'codex', 'active-7').locator('.ai-session-primary-action').getAttribute('aria-label'),
@@ -2693,7 +2701,12 @@ test('ACTIVE-SESSION-FOCUS-REVEAL-001 reveals a newer direct focus projection in
     );
     assert.equal(
         await row(page, 'codex', 'active-1').locator('.ai-session-primary-action').getAttribute('title'),
-        'Focus Codex Session'
+        null
+    );
+    assert.match(
+        await row(page, 'codex', 'active-1').locator('.ai-session-primary-action')
+            .getAttribute('data-tooltip'),
+        /^Focus Codex Session\nProvider: Codex\nProfile: default/
     );
     assert.equal(
         await row(page, 'codex', 'active-1').locator('.ai-session-primary-action').getAttribute('aria-label'),
@@ -2908,6 +2921,7 @@ test('OPEN-TAB-SESSION-SINGLE-LINE-001 renders CHATS and ALL session rows with o
         [{
             ...session('codex', 'session-running', false),
             updatedAt: now.toISOString(),
+            profile: 'review',
         }],
         { width: 360, height: 700 },
         `<div class="open-session-surface" data-open-session-surface data-id="project-a" data-current-workspace>
@@ -2915,6 +2929,7 @@ test('OPEN-TAB-SESSION-SINGLE-LINE-001 renders CHATS and ALL session rows with o
                 [{
                     ...session('codex', 'session-running', false),
                     updatedAt: now.toISOString(),
+                    profile: 'review',
                 }],
                 [{
                     ...historySession('codex', 'history-stopped'),
@@ -2940,6 +2955,7 @@ test('OPEN-TAB-SESSION-SINGLE-LINE-001 renders CHATS and ALL session rows with o
             metaCount: el.querySelectorAll('.codex-session-meta').length,
             ariaLabel: el.querySelector('.ai-session-primary-action').getAttribute('aria-label'),
             title: el.querySelector('.ai-session-primary-action').getAttribute('title'),
+            tooltip: el.querySelector('.ai-session-primary-action').getAttribute('data-tooltip'),
         };
     });
 
@@ -2952,9 +2968,17 @@ test('OPEN-TAB-SESSION-SINGLE-LINE-001 renders CHATS and ALL session rows with o
     assert.match(activeMetrics.ariaLabel, /Running/);
     assert.match(activeMetrics.ariaLabel, new RegExp(`last activity ${expectedTime}`));
     assert.match(activeMetrics.ariaLabel, /session #session-/);
-    assert.match(activeMetrics.title, /^Focus Codex Session\nTitle codex session-running\nStatus Running/);
-    assert.match(activeMetrics.title, new RegExp(`Last activity ${expectedTime}`));
-    assert.match(activeMetrics.title, /Session #session-/);
+    assert.equal(activeMetrics.title, null,
+        'the chat row uses one fast tooltip rather than a delayed native title');
+    assert.match(activeMetrics.tooltip, /^Focus Codex Session\nProvider: Codex\nProfile: review\nTitle codex session-running\nStatus Running/);
+    assert.match(activeMetrics.tooltip, new RegExp(`Last activity ${expectedTime}`));
+    assert.match(activeMetrics.tooltip, /Session #session-/);
+    const activeAction = activeRow.locator('.ai-session-primary-action');
+    await activeAction.hover();
+    const fastTooltip = page.locator('.ai-session-fast-tooltip');
+    await fastTooltip.waitFor({ state: 'visible' });
+    assert.match(await fastTooltip.textContent(), /^Focus Codex Session\nProvider: Codex\nProfile: review/,
+        'hover renders the provider and profile through the fast tooltip overlay');
     assert.equal(await activeRow.locator('.codex-session-archive, .ai-session-close-terminal').count(), 0,
         'destructive actions must be available from the row menu, not the hover pill');
 
@@ -3001,6 +3025,24 @@ test('OPEN-TAB-SESSION-SINGLE-LINE-001 renders CHATS and ALL session rows with o
     assert.match(historyMetrics.ariaLabel, /session #history-/);
     assert.equal(await historyRow.locator('.codex-session-archive').count(), 0,
         'archive stays behind the ALL row menu');
+});
+
+test('OPEN-TAB-SESSION-SINGLE-LINE-001 keeps Workspace running status out of chat tooltips', async t => {
+    const active = [session('codex', 'tooltip-scope', false)];
+    const page = await openCardPage(t, active, { width: 360, height: 700 },
+        currentWorkspaceGroupMarkup(active));
+    const workspace = page.locator('[data-open-session-surface][data-current-workspace]');
+
+    await postHostMessage(page, presentationMessage(active, 1));
+
+    assert.equal(await workspace.getAttribute('title'), null,
+        'the running-state title must not be inherited by every chat and worktree descendant');
+    const action = workspace.locator('.active-ai-session-row[data-session-id="tooltip-scope"] .ai-session-primary-action');
+    assert.equal(await action.getAttribute('title'), null,
+        'the chat action also avoids a second delayed native tooltip');
+    assert.match(await action.getAttribute('data-tooltip'),
+        /^Focus Codex Session\nProvider: Codex\nProfile: default\nTitle codex tooltip-scope/);
+
 });
 
 test('OPEN-TAB-SESSION-SINGLE-LINE-001 hides secondary chips before sacrificing the title at narrow widths', async t => {

--- a/tests/contract/aiSessions/sessionProfileHydration.test.js
+++ b/tests/contract/aiSessions/sessionProfileHydration.test.js
@@ -122,9 +122,10 @@ test('SESSION-CODEX-PROFILE-BADGE-001 rows render badges with tooltips and aria 
         claudeSessions: [],
         activeAiSessions: [],
     });
-    assert.match(html, /ai-session-profile-badge[^>]*title="Codex config profile: deepseek"/);
-    assert.match(html, /aria-label="Codex config profile: deepseek"/);
-    assert.match(html, /Codex session Profiled, Codex config profile deepseek/);
+    assert.match(html, /ai-session-profile-badge[^>]*data-tooltip="Profile: deepseek"/);
+    assert.match(html, /ai-session-profile-badge[^>]*aria-label="Profile: deepseek"/);
+    assert.match(html, /Codex session Profiled, Profile: deepseek/);
+    assert.match(html, /ai-session-primary-action[^>]*data-tooltip="[^"]*Provider: Codex\nProfile: deepseek/);
     assert.match(html, /ai-session-profile-unavailable/);
     assert.match(html, /deleted-profile · unavailable/);
     assert.doesNotMatch(html, /Base configuration \(no profile\)/, 'base decisions render no badge');
@@ -150,8 +151,9 @@ test('SESSION-CODEX-PROFILE-BADGE-001 rows render badges with tooltips and aria 
             attached: true,
         }],
     });
-    assert.match(activeHtml, /ai-session-profile-badge[^>]*title="Codex config profile: deepseek"/);
-    assert.match(activeHtml, /Codex session Active run, Codex config profile deepseek/);
+    assert.match(activeHtml, /ai-session-profile-badge[^>]*data-tooltip="Profile: deepseek"/);
+    assert.match(activeHtml, /Codex session Active run, Profile: deepseek/);
+    assert.match(activeHtml, /ai-session-primary-action[^>]*data-tooltip="[^"]*Provider: Codex\nProfile: deepseek/);
 });
 
 test('SESSION-CODEX-PROFILE-BADGE-001 profile names are HTML-escaped in badges', () => {


### PR DESCRIPTION
## Summary

- Stop Workspace running-state tooltips from being inherited by chat and worktree rows.
- Render chat session metadata through one fast tooltip, including provider and profile.
- Migrate chat-row actions and badges away from delayed native titles.
- Align the profile tooltip contract with the rendered fast-tooltip behavior.

## Verification

- `npm run test:ci:linux`
- `node --test --test-concurrency=1 tests/browser/activeSessionCardInteraction.test.js`
- `node --test --test-concurrency=1 tests/integration/dashboard/webviewState.test.js`
- `npm run test:behavior-contracts`
- `npm run lint`

## Skill harvest

No skill change: the applicable regression, worktree, review, packaging, and publishing skills already prescribe the workflow used here; no reusable process gap emerged.

## Owner approvals

```text
approve 6827d77cf6ee4d6318b2d450c35ab9c6db309eff
```