### PR TITLE
feat(worktrees): merge fold actions into one toggle and move refresh/SCM to row 3

### DIFF
--- a/media/conversationChangesScripts.js
+++ b/media/conversationChangesScripts.js
@@ -1303,16 +1303,27 @@
         }
 
         // One toggle: anything expanded ⇒ Collapse all; fully collapsed ⇒
-        // Expand all. Always visible; inert in the Commits tab.
+        // Expand all. Both views share it — Commits folds commit rows
+        // instead of group/folder rows (same look, same discipline).
         function updateFoldActions() {
             if (!foldToggleButton) {
                 return;
             }
-            var empty = !latestState || !latestState.detail
-                || latestState.detail.items.length === 0;
-            foldToggleButton.disabled = empty
-                || activeSubTab === 'commits';
-            var expand = !empty && allCollapsedNow();
+            var empty;
+            var expand;
+            if (activeSubTab === 'commits') {
+                var member = latestState && selectedMemberOf(latestState);
+                var cache = member
+                    ? commitsCaches.get(member.memberId) : null;
+                empty = !cache
+                    || (!cache.commits.length && !cache.earlierCommits.length);
+                expand = !empty && !!cache && cache.expandedOrder.length === 0;
+            } else {
+                empty = !latestState || !latestState.detail
+                    || latestState.detail.items.length === 0;
+                expand = !empty && allCollapsedNow();
+            }
+            foldToggleButton.disabled = !!empty;
             var label = expand ? 'Expand all' : 'Collapse all';
             foldToggleButton.setAttribute('aria-label', label);
             foldToggleButton.setAttribute('data-tooltip', label);
@@ -1455,7 +1466,7 @@
         // Bounds (panel-lifetime memory discipline): at most 16 member
         // caches, at most 32 expanded commit details per member.
         var COMMITS_CACHE_MEMBER_LIMIT = 16;
-        var COMMITS_EXPANDED_LIMIT = 32;
+        var COMMITS_EXPANDED_LIMIT = 64;
         // Roving-focus identity across re-renders: '<sha>' for a commit
         // row, '<sha>\0<file path>' for a file row, '<sha>\0review' for
         // the review action row.
@@ -2076,9 +2087,42 @@
             renderCommitsIfVisible();
         }
 
+        // The shared fold toggle in the Commits view (§15.4): anything
+        // expanded ⇒ collapse every row (cancelling in-flight details);
+        // nothing expanded ⇒ expand every loaded commit.
+        function toggleAllCommitsCollapsed() {
+            var member = latestState && selectedMemberOf(latestState);
+            var cache = member && commitsCaches.get(member.memberId);
+            if (!member || !cache) {
+                return;
+            }
+            if (cache.expandedOrder.length) {
+                cache.expandedOrder.forEach(function (sha) {
+                    delete cache.latestDetailRequestIds[sha];
+                });
+                cache.expanded = Object.create(null);
+                cache.expandedOrder = [];
+            } else {
+                cache.commits.concat(cache.earlierCommits)
+                    .forEach(function (commit) {
+                        cache.expanded[commit.sha] = { status: 'loading' };
+                        cache.expandedOrder.push(commit.sha);
+                        while (cache.expandedOrder.length
+                            > COMMITS_EXPANDED_LIMIT) {
+                            var evicted = cache.expandedOrder.shift();
+                            delete cache.expanded[evicted];
+                            delete cache.latestDetailRequestIds[evicted];
+                        }
+                        requestCommitDetail(member.memberId, commit.sha);
+                    });
+            }
+            renderCommitsIfVisible();
+        }
+
         function renderCommitsIfVisible() {
             if (activeSubTab === 'commits' && latestState) {
                 renderCommits(latestState);
+                updateFoldActions();
             }
         }
 
@@ -2469,7 +2513,11 @@
             }
             if (foldToggleButton) {
                 foldToggleButton.addEventListener('click', function () {
-                    setAllCollapsed(!allCollapsedNow());
+                    if (activeSubTab === 'commits') {
+                        toggleAllCommitsCollapsed();
+                    } else {
+                        setAllCollapsed(!allCollapsedNow());
+                    }
                 });
             }
             if (groupsRoot) {

--- a/media/conversationChangesScripts.js
+++ b/media/conversationChangesScripts.js
@@ -601,11 +601,16 @@
             if (branchRoot) branchRoot.hidden = !member;
             if (refreshButton) refreshButton.disabled = false;
             if (openScmButton) openScmButton.disabled = false;
+            // ‹ › stay visible for a single member — disabled, not
+            // hidden, so row 1 looks identical across member counts
+            // (owner UX decision).
             if (prevButton) {
-                prevButton.hidden = !multi;
+                prevButton.hidden = false;
+                prevButton.disabled = !multi;
             }
             if (nextButton) {
-                nextButton.hidden = !multi;
+                nextButton.hidden = false;
+                nextButton.disabled = !multi;
             }
             if (positionIndicator) {
                 positionIndicator.hidden = !multi;

--- a/media/conversationChangesScripts.js
+++ b/media/conversationChangesScripts.js
@@ -178,8 +178,7 @@
         var taskSummary = options.taskSummary;
         var taskTracking = options.taskTracking;
         var reviewButton = options.reviewButton;
-        var collapseAllButton = options.collapseAllButton;
-        var expandAllButton = options.expandAllButton;
+        var foldToggleButton = options.foldToggle;
         var groupsRoot = options.groupsRoot;
         var emptyRoot = options.emptyRoot;
         var unavailableRoot = options.unavailableRoot;
@@ -1277,19 +1276,48 @@
                 });
             });
             renderGroups(detail);
+            updateFoldActions();
         }
 
         // The fold actions die when there is nothing to fold (PRD §15.3:
         // the no-changes empty state disables both buttons).
+        // Live fold state comes from the DOM (aria-expanded), never from
+        // render-time captures — refresh and member switches re-render.
+        function foldRows() {
+            if (!groupsRoot) return [];
+            return Array.prototype.slice.call(groupsRoot.querySelectorAll(
+                '.conversation-changes-group-header, '
+                    + '.conversation-changes-folder'));
+        }
+
+        function allCollapsedNow() {
+            var rows = foldRows();
+            return rows.length > 0 && rows.every(function (row) {
+                return row.getAttribute('aria-expanded') === 'false';
+            });
+        }
+
+        // One toggle: anything expanded ⇒ Collapse all; fully collapsed ⇒
+        // Expand all. Always visible; inert in the Commits tab.
         function updateFoldActions() {
+            if (!foldToggleButton) {
+                return;
+            }
             var empty = !latestState || !latestState.detail
                 || latestState.detail.items.length === 0;
-            if (collapseAllButton) {
-                collapseAllButton.disabled = empty;
-            }
-            if (expandAllButton) {
-                expandAllButton.disabled = empty;
-            }
+            foldToggleButton.disabled = empty
+                || activeSubTab === 'commits';
+            var expand = !empty && allCollapsedNow();
+            var label = expand ? 'Expand all' : 'Collapse all';
+            foldToggleButton.setAttribute('aria-label', label);
+            foldToggleButton.setAttribute('data-tooltip', label);
+            Array.prototype.forEach.call(
+                foldToggleButton.querySelectorAll('[data-fold-icon]'),
+                function (icon) {
+                    var show = icon.getAttribute('data-fold-icon')
+                        === (expand ? 'expand' : 'collapse');
+                    icon.style.display = show ? '' : 'none';
+                });
         }
 
         function renderPanel(state) {
@@ -1405,8 +1433,8 @@
                 pendingMemberId = null;
             }
             renderButton(latestState);
-            updateFoldActions();
             renderPanel(latestState);
+            updateFoldActions();
             return true;
         }
 
@@ -2267,14 +2295,9 @@
                         tab.tabIndex = selected ? 0 : -1;
                     });
             }
-            // Commits view keeps the action slot's width but hides the
-            // fold buttons' content (PRD §15.3/§15.4).
-            [collapseAllButton, expandAllButton].forEach(function (button) {
-                if (button) {
-                    button.style.visibility = commitsActive
-                        ? 'hidden' : '';
-                }
-            });
+            // The fold toggle stays visible in the Commits tab but is
+            // inert there (PRD §15.3/§15.4); refresh and SCM keep working.
+            updateFoldActions();
         }
 
         function setActiveSubTab(tab, focusTab) {
@@ -2439,14 +2462,9 @@
                     }
                 });
             }
-            if (collapseAllButton) {
-                collapseAllButton.addEventListener('click', function () {
-                    setAllCollapsed(true);
-                });
-            }
-            if (expandAllButton) {
-                expandAllButton.addEventListener('click', function () {
-                    setAllCollapsed(false);
+            if (foldToggleButton) {
+                foldToggleButton.addEventListener('click', function () {
+                    setAllCollapsed(!allCollapsedNow());
                 });
             }
             if (groupsRoot) {

--- a/media/conversationViewerScripts.js
+++ b/media/conversationViewerScripts.js
@@ -177,11 +177,8 @@
         '[data-changes-task-tracking]'
     );
     var changesReview = document.querySelector('[data-changes-review]');
-    var changesCollapseAll = document.querySelector(
-        '[data-changes-collapse-all]'
-    );
-    var changesExpandAll = document.querySelector(
-        '[data-changes-expand-all]'
+    var changesFoldToggle = document.querySelector(
+        '[data-changes-fold-toggle]'
     );
     var changesGroups = document.querySelector('[data-changes-groups]');
     var changesEmpty = document.querySelector('[data-changes-empty]');
@@ -341,7 +338,7 @@
         && !!changesBranchPrefix && !!changesBranchTail && !!changesLive
         && !!changesTask && !!changesTaskSummary && !!changesTaskTracking
         && !!changesReview
-        && !!changesCollapseAll && !!changesExpandAll
+        && !!changesFoldToggle
         && !!changesGroups && !!changesEmpty
         && !!changesUnavailable && !!changesOpenScm && !!changesCrossMember
         && !!changesCrossMemberSummary && !!changesCrossMemberGo
@@ -515,8 +512,7 @@
             taskSummary: changesTaskSummary,
             taskTracking: changesTaskTracking,
             reviewButton: changesReview,
-            collapseAllButton: changesCollapseAll,
-            expandAllButton: changesExpandAll,
+            foldToggle: changesFoldToggle,
             groupsRoot: changesGroups,
             emptyRoot: changesEmpty,
             unavailableRoot: changesUnavailable,

--- a/src/aiSessions/conversation/viewerDocument.ts
+++ b/src/aiSessions/conversation/viewerDocument.ts
@@ -585,33 +585,6 @@ export function renderConversationViewerDocument(
                                     data-changes-branch-prefix></span><span
                                     class="conversation-changes-branch-tail"
                                     data-changes-branch-tail></span></span></span>
-                        <button type="button"
-                            class="conversation-icon-button"
-                            data-changes-refresh
-                            data-tooltip="Refresh"
-                            aria-label="Refresh"
-                            ><svg viewBox="0 0 16 16" width="13" height="13"
-                                aria-hidden="true" fill="none"
-                                stroke="currentColor" stroke-width="1.3"
-                                stroke-linecap="round" stroke-linejoin="round">
-                                <path d="M13.4 8a5.4 5.4 0 1 1-1.5-3.7"/>
-                                <path d="M13.6 2.1v2.6h-2.6"/></svg>
-                        </button>
-                        <button type="button"
-                            class="conversation-icon-button"
-                            data-changes-open-scm
-                            data-tooltip="Open in Source Control"
-                            aria-label="Open in Source Control"
-                            ><svg viewBox="0 0 16 16" width="13" height="13"
-                                aria-hidden="true" fill="none"
-                                stroke="currentColor" stroke-width="1.3"
-                                stroke-linecap="round" stroke-linejoin="round">
-                                <circle cx="4" cy="3.3" r="1.4"/>
-                                <circle cx="4" cy="12.7" r="1.4"/>
-                                <circle cx="10" cy="5" r="1.4"/>
-                                <path d="M4 4.7v6.6"/>
-                                <path d="M4 10.3c0-2.1 1.9-3.5 4.5-3.9"/></svg>
-                        </button>
                     </div>
                     <span class="conversation-changes-live" data-changes-live
                         aria-live="polite"></span>
@@ -645,27 +618,48 @@ export function renderConversationViewerDocument(
                     <div class="conversation-changes-fold">
                         <button type="button"
                             class="conversation-icon-button"
-                            data-changes-collapse-all
+                            data-changes-fold-toggle
                             data-tooltip="Collapse all"
                             aria-label="Collapse all"
                             disabled><svg viewBox="0 0 16 16" width="13" height="13"
                                 aria-hidden="true" fill="none"
                                 stroke="currentColor" stroke-width="1.3"
                                 stroke-linecap="round" stroke-linejoin="round">
-                                <path d="M2.5 3h11"/>
-                                <path d="M5 12.5 8 9.5l3 3"/></svg>
+                                <path data-fold-icon="collapse"
+                                    d="M2.5 3h11"/>
+                                <path data-fold-icon="collapse"
+                                    d="M5 12.5 8 9.5l3 3"/>
+                                <path data-fold-icon="expand"
+                                    d="M5 6.5 8 9.5l3-3" style="display:none"/>
+                                <path data-fold-icon="expand"
+                                    d="M2.5 13h11" style="display:none"/></svg>
                         </button>
                         <button type="button"
                             class="conversation-icon-button"
-                            data-changes-expand-all
-                            data-tooltip="Expand all"
-                            aria-label="Expand all"
-                            disabled><svg viewBox="0 0 16 16" width="13" height="13"
+                            data-changes-refresh
+                            data-tooltip="Refresh"
+                            aria-label="Refresh"
+                            ><svg viewBox="0 0 16 16" width="13" height="13"
                                 aria-hidden="true" fill="none"
                                 stroke="currentColor" stroke-width="1.3"
                                 stroke-linecap="round" stroke-linejoin="round">
-                                <path d="M5 6.5 8 9.5l3-3"/>
-                                <path d="M2.5 13h11"/></svg>
+                                <path d="M13.4 8a5.4 5.4 0 1 1-1.5-3.7"/>
+                                <path d="M13.6 2.1v2.6h-2.6"/></svg>
+                        </button>
+                        <button type="button"
+                            class="conversation-icon-button"
+                            data-changes-open-scm
+                            data-tooltip="Open in Source Control"
+                            aria-label="Open in Source Control"
+                            ><svg viewBox="0 0 16 16" width="13" height="13"
+                                aria-hidden="true" fill="none"
+                                stroke="currentColor" stroke-width="1.3"
+                                stroke-linecap="round" stroke-linejoin="round">
+                                <circle cx="4" cy="3.3" r="1.4"/>
+                                <circle cx="4" cy="12.7" r="1.4"/>
+                                <circle cx="10" cy="5" r="1.4"/>
+                                <path d="M4 4.7v6.6"/>
+                                <path d="M4 10.3c0-2.1 1.9-3.5 4.5-3.9"/></svg>
                         </button>
                     </div>
                 </div>

--- a/src/aiSessions/conversation/viewerDocument.ts
+++ b/src/aiSessions/conversation/viewerDocument.ts
@@ -626,13 +626,13 @@ export function renderConversationViewerDocument(
                                 stroke="currentColor" stroke-width="1.3"
                                 stroke-linecap="round" stroke-linejoin="round">
                                 <path data-fold-icon="collapse"
-                                    d="M2.5 3h11"/>
+                                    d="M2.5 8.5 8 3l5.5 5.5"/>
                                 <path data-fold-icon="collapse"
-                                    d="M5 12.5 8 9.5l3 3"/>
+                                    d="M2.5 13.5 8 8l5.5 5.5"/>
                                 <path data-fold-icon="expand"
-                                    d="M5 6.5 8 9.5l3-3" style="display:none"/>
+                                    d="M2.5 3 8 8.5l5.5-5.5" style="display:none"/>
                                 <path data-fold-icon="expand"
-                                    d="M2.5 13h11" style="display:none"/></svg>
+                                    d="M2.5 8 8 13.5l5.5-5.5" style="display:none"/></svg>
                         </button>
                         <button type="button"
                             class="conversation-icon-button"

--- a/src/webview/conversationChangesScripts.js
+++ b/src/webview/conversationChangesScripts.js
@@ -1303,16 +1303,27 @@
         }
 
         // One toggle: anything expanded ⇒ Collapse all; fully collapsed ⇒
-        // Expand all. Always visible; inert in the Commits tab.
+        // Expand all. Both views share it — Commits folds commit rows
+        // instead of group/folder rows (same look, same discipline).
         function updateFoldActions() {
             if (!foldToggleButton) {
                 return;
             }
-            var empty = !latestState || !latestState.detail
-                || latestState.detail.items.length === 0;
-            foldToggleButton.disabled = empty
-                || activeSubTab === 'commits';
-            var expand = !empty && allCollapsedNow();
+            var empty;
+            var expand;
+            if (activeSubTab === 'commits') {
+                var member = latestState && selectedMemberOf(latestState);
+                var cache = member
+                    ? commitsCaches.get(member.memberId) : null;
+                empty = !cache
+                    || (!cache.commits.length && !cache.earlierCommits.length);
+                expand = !empty && !!cache && cache.expandedOrder.length === 0;
+            } else {
+                empty = !latestState || !latestState.detail
+                    || latestState.detail.items.length === 0;
+                expand = !empty && allCollapsedNow();
+            }
+            foldToggleButton.disabled = !!empty;
             var label = expand ? 'Expand all' : 'Collapse all';
             foldToggleButton.setAttribute('aria-label', label);
             foldToggleButton.setAttribute('data-tooltip', label);
@@ -1455,7 +1466,7 @@
         // Bounds (panel-lifetime memory discipline): at most 16 member
         // caches, at most 32 expanded commit details per member.
         var COMMITS_CACHE_MEMBER_LIMIT = 16;
-        var COMMITS_EXPANDED_LIMIT = 32;
+        var COMMITS_EXPANDED_LIMIT = 64;
         // Roving-focus identity across re-renders: '<sha>' for a commit
         // row, '<sha>\0<file path>' for a file row, '<sha>\0review' for
         // the review action row.
@@ -2076,9 +2087,42 @@
             renderCommitsIfVisible();
         }
 
+        // The shared fold toggle in the Commits view (§15.4): anything
+        // expanded ⇒ collapse every row (cancelling in-flight details);
+        // nothing expanded ⇒ expand every loaded commit.
+        function toggleAllCommitsCollapsed() {
+            var member = latestState && selectedMemberOf(latestState);
+            var cache = member && commitsCaches.get(member.memberId);
+            if (!member || !cache) {
+                return;
+            }
+            if (cache.expandedOrder.length) {
+                cache.expandedOrder.forEach(function (sha) {
+                    delete cache.latestDetailRequestIds[sha];
+                });
+                cache.expanded = Object.create(null);
+                cache.expandedOrder = [];
+            } else {
+                cache.commits.concat(cache.earlierCommits)
+                    .forEach(function (commit) {
+                        cache.expanded[commit.sha] = { status: 'loading' };
+                        cache.expandedOrder.push(commit.sha);
+                        while (cache.expandedOrder.length
+                            > COMMITS_EXPANDED_LIMIT) {
+                            var evicted = cache.expandedOrder.shift();
+                            delete cache.expanded[evicted];
+                            delete cache.latestDetailRequestIds[evicted];
+                        }
+                        requestCommitDetail(member.memberId, commit.sha);
+                    });
+            }
+            renderCommitsIfVisible();
+        }
+
         function renderCommitsIfVisible() {
             if (activeSubTab === 'commits' && latestState) {
                 renderCommits(latestState);
+                updateFoldActions();
             }
         }
 
@@ -2469,7 +2513,11 @@
             }
             if (foldToggleButton) {
                 foldToggleButton.addEventListener('click', function () {
-                    setAllCollapsed(!allCollapsedNow());
+                    if (activeSubTab === 'commits') {
+                        toggleAllCommitsCollapsed();
+                    } else {
+                        setAllCollapsed(!allCollapsedNow());
+                    }
                 });
             }
             if (groupsRoot) {

--- a/src/webview/conversationChangesScripts.js
+++ b/src/webview/conversationChangesScripts.js
@@ -601,11 +601,16 @@
             if (branchRoot) branchRoot.hidden = !member;
             if (refreshButton) refreshButton.disabled = false;
             if (openScmButton) openScmButton.disabled = false;
+            // ‹ › stay visible for a single member — disabled, not
+            // hidden, so row 1 looks identical across member counts
+            // (owner UX decision).
             if (prevButton) {
-                prevButton.hidden = !multi;
+                prevButton.hidden = false;
+                prevButton.disabled = !multi;
             }
             if (nextButton) {
-                nextButton.hidden = !multi;
+                nextButton.hidden = false;
+                nextButton.disabled = !multi;
             }
             if (positionIndicator) {
                 positionIndicator.hidden = !multi;

--- a/src/webview/conversationChangesScripts.js
+++ b/src/webview/conversationChangesScripts.js
@@ -178,8 +178,7 @@
         var taskSummary = options.taskSummary;
         var taskTracking = options.taskTracking;
         var reviewButton = options.reviewButton;
-        var collapseAllButton = options.collapseAllButton;
-        var expandAllButton = options.expandAllButton;
+        var foldToggleButton = options.foldToggle;
         var groupsRoot = options.groupsRoot;
         var emptyRoot = options.emptyRoot;
         var unavailableRoot = options.unavailableRoot;
@@ -1277,19 +1276,48 @@
                 });
             });
             renderGroups(detail);
+            updateFoldActions();
         }
 
         // The fold actions die when there is nothing to fold (PRD §15.3:
         // the no-changes empty state disables both buttons).
+        // Live fold state comes from the DOM (aria-expanded), never from
+        // render-time captures — refresh and member switches re-render.
+        function foldRows() {
+            if (!groupsRoot) return [];
+            return Array.prototype.slice.call(groupsRoot.querySelectorAll(
+                '.conversation-changes-group-header, '
+                    + '.conversation-changes-folder'));
+        }
+
+        function allCollapsedNow() {
+            var rows = foldRows();
+            return rows.length > 0 && rows.every(function (row) {
+                return row.getAttribute('aria-expanded') === 'false';
+            });
+        }
+
+        // One toggle: anything expanded ⇒ Collapse all; fully collapsed ⇒
+        // Expand all. Always visible; inert in the Commits tab.
         function updateFoldActions() {
+            if (!foldToggleButton) {
+                return;
+            }
             var empty = !latestState || !latestState.detail
                 || latestState.detail.items.length === 0;
-            if (collapseAllButton) {
-                collapseAllButton.disabled = empty;
-            }
-            if (expandAllButton) {
-                expandAllButton.disabled = empty;
-            }
+            foldToggleButton.disabled = empty
+                || activeSubTab === 'commits';
+            var expand = !empty && allCollapsedNow();
+            var label = expand ? 'Expand all' : 'Collapse all';
+            foldToggleButton.setAttribute('aria-label', label);
+            foldToggleButton.setAttribute('data-tooltip', label);
+            Array.prototype.forEach.call(
+                foldToggleButton.querySelectorAll('[data-fold-icon]'),
+                function (icon) {
+                    var show = icon.getAttribute('data-fold-icon')
+                        === (expand ? 'expand' : 'collapse');
+                    icon.style.display = show ? '' : 'none';
+                });
         }
 
         function renderPanel(state) {
@@ -1405,8 +1433,8 @@
                 pendingMemberId = null;
             }
             renderButton(latestState);
-            updateFoldActions();
             renderPanel(latestState);
+            updateFoldActions();
             return true;
         }
 
@@ -2267,14 +2295,9 @@
                         tab.tabIndex = selected ? 0 : -1;
                     });
             }
-            // Commits view keeps the action slot's width but hides the
-            // fold buttons' content (PRD §15.3/§15.4).
-            [collapseAllButton, expandAllButton].forEach(function (button) {
-                if (button) {
-                    button.style.visibility = commitsActive
-                        ? 'hidden' : '';
-                }
-            });
+            // The fold toggle stays visible in the Commits tab but is
+            // inert there (PRD §15.3/§15.4); refresh and SCM keep working.
+            updateFoldActions();
         }
 
         function setActiveSubTab(tab, focusTab) {
@@ -2439,14 +2462,9 @@
                     }
                 });
             }
-            if (collapseAllButton) {
-                collapseAllButton.addEventListener('click', function () {
-                    setAllCollapsed(true);
-                });
-            }
-            if (expandAllButton) {
-                expandAllButton.addEventListener('click', function () {
-                    setAllCollapsed(false);
+            if (foldToggleButton) {
+                foldToggleButton.addEventListener('click', function () {
+                    setAllCollapsed(!allCollapsedNow());
                 });
             }
             if (groupsRoot) {

--- a/src/webview/conversationViewerScripts.js
+++ b/src/webview/conversationViewerScripts.js
@@ -177,11 +177,8 @@
         '[data-changes-task-tracking]'
     );
     var changesReview = document.querySelector('[data-changes-review]');
-    var changesCollapseAll = document.querySelector(
-        '[data-changes-collapse-all]'
-    );
-    var changesExpandAll = document.querySelector(
-        '[data-changes-expand-all]'
+    var changesFoldToggle = document.querySelector(
+        '[data-changes-fold-toggle]'
     );
     var changesGroups = document.querySelector('[data-changes-groups]');
     var changesEmpty = document.querySelector('[data-changes-empty]');
@@ -341,7 +338,7 @@
         && !!changesBranchPrefix && !!changesBranchTail && !!changesLive
         && !!changesTask && !!changesTaskSummary && !!changesTaskTracking
         && !!changesReview
-        && !!changesCollapseAll && !!changesExpandAll
+        && !!changesFoldToggle
         && !!changesGroups && !!changesEmpty
         && !!changesUnavailable && !!changesOpenScm && !!changesCrossMember
         && !!changesCrossMemberSummary && !!changesCrossMemberGo
@@ -515,8 +512,7 @@
             taskSummary: changesTaskSummary,
             taskTracking: changesTaskTracking,
             reviewButton: changesReview,
-            collapseAllButton: changesCollapseAll,
-            expandAllButton: changesExpandAll,
+            foldToggle: changesFoldToggle,
             groupsRoot: changesGroups,
             emptyRoot: changesEmpty,
             unavailableRoot: changesUnavailable,

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -15249,12 +15249,14 @@ test('WORKTREE-CHANGES-COMMITS-001 switching to Commits requests the first page 
         await page.locator('[data-changes-files-view]').isHidden(), true);
     assert.equal(
         await page.locator('[data-changes-commits-view]').isVisible(), true);
-    // The fold toggle stays visible in Commits but is inert (disabled);
-    // refresh and SCM keep working (§15.4).
+    // The fold toggle stays enabled in Commits — it folds commit rows
+    // instead of file groups (§15.4); refresh and SCM keep working too.
+    // Nothing is loaded yet, so there is nothing to fold.
     assert.equal(
         await page.locator('[data-changes-fold-toggle]').isVisible(), true);
     assert.equal(
-        await page.locator('[data-changes-fold-toggle]').isDisabled(), true);
+        await page.locator('[data-changes-fold-toggle]').isDisabled(), true,
+        'no commits loaded means nothing to fold');
     assert.equal(
         await page.locator('[data-changes-refresh]').isEnabled(), true);
     assert.equal(
@@ -15807,4 +15809,58 @@ test('WORKTREE-CHANGES-COMMITS-001 focus falls back to the parent commit or the 
         document.activeElement
             === document.querySelector('[data-changes-subtab="commits"]')),
         true);
+});
+
+test('WORKTREE-CHANGES-COMMITS-001 the fold toggle expands and collapses every loaded commit row', async t => {
+    const { page } = await openHostViewerDocument(t, {});
+    await openCommitsTab(page);
+    await sendCommitsList(page, commitsFixture());
+
+    const toggle = page.locator('[data-changes-fold-toggle]');
+    assert.equal(await toggle.isEnabled(), true);
+    assert.equal(await toggle.getAttribute('aria-label'), 'Expand all',
+        'nothing expanded yet — the toggle offers Expand all');
+
+    // Expand all: one detail request per loaded commit.
+    await toggle.click();
+    const details = (await postedIntents(page)).filter(message =>
+        message.type === 'conversation-viewer-commit-detail');
+    assert.deepEqual(details.map(message => message.sha),
+        ['c'.repeat(40), 'd'.repeat(40)],
+        'expand all fans out one detail request per commit');
+    assert.equal(await page.locator(
+        '.conversation-changes-commit-inline-note').count(), 2,
+        'every row shows its inline loading state');
+
+    const generation = await page.evaluate(() =>
+        Number(document.body.getAttribute('data-subscription-generation')));
+    for (const request of details) {
+        await sendPage(page, {
+            type: 'conversation-viewer-commit-detail',
+            version: 1,
+            requestId: request.requestId,
+            subscriptionGeneration: generation,
+            memberId: 'm-api',
+            sha: request.sha,
+            files: [{ path: 'src/a.ts', status: 'M', additions: 1,
+                deletions: 0 }],
+            totalFiles: 1,
+            filesTruncated: false,
+        });
+    }
+    assert.equal(await page.locator(
+        '.conversation-changes-commit-file-row').count(), 2);
+    assert.equal(await toggle.getAttribute('aria-label'), 'Collapse all',
+        'expanded rows flip the toggle to Collapse all');
+
+    // Collapse all clears every expansion; like the Files fold actions,
+    // activating the toggle keeps focus on the toggle itself (§15.3).
+    await toggle.click();
+    assert.equal(await page.locator(
+        '.conversation-changes-commit-file-row').count(), 0);
+    assert.equal(await page.evaluate(() =>
+        document.activeElement
+            === document.querySelector('[data-changes-fold-toggle]')), true,
+        'activating the toggle keeps focus on it');
+    assert.equal(await toggle.getAttribute('aria-label'), 'Expand all');
 });

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -13458,12 +13458,18 @@ test('WORKTREE-CHANGES-PANEL-001 degrades a single member to a static repo title
     }));
     await page.locator('[data-telemetry-changes]').click();
 
-    // ‹ › and (i/n) hide; no select is rendered at all — the repo name is
-    // a plain text title, not a disabled dropdown (PRD §15.1/§16).
+    // ‹ › stay visible but disabled for a single member — row 1 keeps one
+    // consistent look across member counts; (i/n) still hides and no
+    // select is rendered at all — the repo name is a plain text title,
+    // not a disabled dropdown (PRD §15.1/§16).
     assert.equal(
-        await page.locator('[data-changes-prev]').isHidden(), true);
+        await page.locator('[data-changes-prev]').isVisible(), true);
     assert.equal(
-        await page.locator('[data-changes-next]').isHidden(), true);
+        await page.locator('[data-changes-prev]').isDisabled(), true);
+    assert.equal(
+        await page.locator('[data-changes-next]').isVisible(), true);
+    assert.equal(
+        await page.locator('[data-changes-next]').isDisabled(), true);
     assert.equal(
         await page.locator('[data-changes-position]').isHidden(), true);
     assert.equal(

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -3945,6 +3945,25 @@ test('CONVERSATION-OUTLINE-NAVIGATION-001 keeps every side-panel view usable acr
                 '        && !!window.__agentPivotConversation.changes\n' +
                 '        && validCommentTarget(commentTarget);\n',
                 '        && !!window.__agentPivotConversation.changes;\n')
+        // Restores the previous fold-action pair: the merged fold toggle
+        // (single button with refresh/SCM moved into row 3) did not exist.
+        .replace(
+                '    var changesFoldToggle = document.querySelector(\n' +
+                '        \'[data-changes-fold-toggle]\'\n' +
+                '    );\n',
+                '    var changesCollapseAll = document.querySelector(\n' +
+                '        \'[data-changes-collapse-all]\'\n' +
+                '    );\n' +
+                '    var changesExpandAll = document.querySelector(\n' +
+                '        \'[data-changes-expand-all]\'\n' +
+                '    );\n')
+        .replace(
+                '        && !!changesFoldToggle\n',
+                '        && !!changesCollapseAll && !!changesExpandAll\n')
+        .replace(
+                '            foldToggle: changesFoldToggle,\n',
+                '            collapseAllButton: changesCollapseAll,\n' +
+                '            expandAllButton: changesExpandAll,\n')
         // Strips the Commits sub-tab wiring (PRD §15.4): the
         // previous-generation script had no sub-tab handles, no commits
         // options, and no restoreSubTab call.
@@ -13303,15 +13322,28 @@ test('WORKTREE-CHANGES-PANEL-001 renders a two-row member header with a repo pic
     assert.ok(branchTooltip.includes('agent-pivot/fix-login'));
     assert.ok(branchTooltip.includes('/wt/api'));
 
-    // Row 2 right: refresh + Source Control exit moved out of the old
-    // toolbar; the SCM glyph is the branch-style Source Control icon, not
-    // the external-open arrow (PRD §17).
+    // Row 2 is branch-only: refresh, Source Control, and the merged fold
+    // toggle live together in row 3's right slot. The SCM glyph is the
+    // branch-style Source Control icon, not the external-open arrow
+    // (PRD §17).
     assert.equal(
         await page.locator('.conversation-changes-branch-row '
             + '[data-changes-refresh]').count(),
-        1);
+        0);
     assert.equal(
         await page.locator('.conversation-changes-branch-row '
+            + '[data-changes-open-scm]').count(),
+        0);
+    assert.equal(
+        await page.locator('.conversation-changes-fold '
+            + '[data-changes-fold-toggle]').count(),
+        1, 'one merged fold toggle replaces the collapse/expand pair');
+    assert.equal(
+        await page.locator('.conversation-changes-fold '
+            + '[data-changes-refresh]').count(),
+        1);
+    assert.equal(
+        await page.locator('.conversation-changes-fold '
             + '[data-changes-open-scm]').count(),
         1);
     assert.equal(
@@ -13791,7 +13823,7 @@ test('WORKTREE-CHANGES-PANEL-001 clears old member data on terminal and reset st
     assert.equal(await page.locator('.conversation-changes-file').count(), 0);
 });
 
-test('WORKTREE-CHANGES-PANEL-001 keeps the header tab order: ‹ → select → › → branch → refresh → SCM → hint → fold actions → summary → content', async t => {
+test('WORKTREE-CHANGES-PANEL-001 keeps the header tab order: ‹ → select → › → branch → hint → sub-tab → fold toggle → refresh → SCM → summary → content', async t => {
     const { page } = await openHostViewerDocument(t, {});
     await sendChanges(page, changesFixture());
     await page.locator('[data-telemetry-changes]').click();
@@ -13801,14 +13833,13 @@ test('WORKTREE-CHANGES-PANEL-001 keeps the header tab order: ‹ → select → 
         '[data-changes-member-select]',
         '[data-changes-next]',
         '[data-changes-branch]',
-        '[data-changes-refresh]',
-        '[data-changes-open-scm]',
         '[data-changes-cross-member]',
         // Row 3's left slot: the selected sub-tab is the tablist's single
-        // Tab stop (PRD §15.4); fold actions follow it.
+        // Tab stop (PRD §15.4); the fold toggle, refresh, and SCM follow.
         '[data-changes-subtab="files"]',
-        '[data-changes-collapse-all]',
-        '[data-changes-expand-all]',
+        '[data-changes-fold-toggle]',
+        '[data-changes-refresh]',
+        '[data-changes-open-scm]',
         '[data-changes-task-summary]',
         '[data-changes-review]',
     ];
@@ -13837,28 +13868,35 @@ test('WORKTREE-CHANGES-PANEL-001 keeps the header tab order: ‹ → select → 
         }],
         selectedMemberId: 'm-api',
     }));
-    await page.locator('[data-changes-open-scm]').focus();
+    await page.locator('[data-changes-branch]').focus();
     await page.keyboard.press('Tab');
     assert.equal(
         await page.evaluate(() =>
             document.activeElement
                 === document.querySelector('[data-changes-subtab="files"]')),
         true,
-        'with no hint rendered, SCM tabs into the sub-tab stop');
+        'with no hint rendered, the branch tabs into the sub-tab stop');
     await page.keyboard.press('Tab');
     assert.equal(
         await page.evaluate(() =>
             document.activeElement
-                === document.querySelector('[data-changes-collapse-all]')),
+                === document.querySelector('[data-changes-fold-toggle]')),
         true,
-        'the sub-tab stop leads into the fold actions');
+        'the sub-tab stop leads into the fold toggle');
     await page.keyboard.press('Tab');
     assert.equal(
         await page.evaluate(() =>
             document.activeElement
-                === document.querySelector('[data-changes-expand-all]')),
+                === document.querySelector('[data-changes-refresh]')),
         true,
-        'the fold actions end at expand');
+        'refresh follows the fold toggle');
+    await page.keyboard.press('Tab');
+    assert.equal(
+        await page.evaluate(() =>
+            document.activeElement
+                === document.querySelector('[data-changes-open-scm]')),
+        true,
+        'SCM ends the action row');
     await page.keyboard.press('Tab');
     assert.equal(
         await page.evaluate(() =>
@@ -13925,24 +13963,25 @@ test('WORKTREE-CHANGES-PANEL-001 collapses and expands every group and folder fr
     await sendChanges(page, changesFixture());
     await page.locator('[data-telemetry-changes]').click();
 
-    // Row 3: an empty left slot (future subtabs) plus the two fold
-    // actions on the right — VS Code collapse-all/expand-all glyphs with
-    // aria-labels and overlay tooltips, never a native title (PRD §17).
-    const collapseAll = page.locator('[data-changes-collapse-all]');
-    const expandAll = page.locator('[data-changes-expand-all]');
-    assert.equal(await collapseAll.isVisible(), true);
-    assert.equal(await expandAll.isVisible(), true);
-    assert.equal(await collapseAll.isEnabled(), true);
-    assert.equal(await expandAll.isEnabled(), true);
-    assert.equal(await collapseAll.getAttribute('aria-label'), 'Collapse all');
-    assert.equal(await collapseAll.getAttribute('data-tooltip'), 'Collapse all');
-    assert.equal(await collapseAll.getAttribute('title'), null);
-    assert.equal(await expandAll.getAttribute('aria-label'), 'Expand all');
-    assert.equal(await expandAll.getAttribute('data-tooltip'), 'Expand all');
-    assert.equal(await expandAll.getAttribute('title'), null);
-    assert.equal(await collapseAll.locator('svg[aria-hidden="true"]').count(),
+    // Row 3: the sub-tabs on the left plus one merged fold toggle and
+    // the refresh/SCM actions on the right — a VS Code fold glyph with
+    // aria-label and overlay tooltip, never a native title (PRD §17).
+    const foldToggle = page.locator('[data-changes-fold-toggle]');
+    assert.equal(await foldToggle.isVisible(), true);
+    assert.equal(await foldToggle.isEnabled(), true);
+    assert.equal(await foldToggle.getAttribute('aria-label'),
+        'Collapse all');
+    assert.equal(await foldToggle.getAttribute('data-tooltip'),
+        'Collapse all');
+    assert.equal(await foldToggle.getAttribute('title'), null);
+    assert.equal(await foldToggle.locator('svg[aria-hidden="true"]').count(),
         1, 'the glyph is decorative — the name rides aria-label');
-    assert.equal(await expandAll.locator('svg[aria-hidden="true"]').count(), 1);
+    // Anything expanded ⇒ Collapse all; the icons swap with the label.
+    const visibleIcons = () => foldToggle.locator(
+        '[data-fold-icon]').evaluateAll(icons => icons
+            .filter(icon => icon.style.display !== 'none')
+            .map(icon => icon.getAttribute('data-fold-icon')));
+    assert.deepEqual(await visibleIcons(), ['collapse', 'collapse']);
 
     // Extremely narrow panel: the row stays on one line without
     // overflowing or compressing the buttons (PRD §16).
@@ -13963,8 +14002,9 @@ test('WORKTREE-CHANGES-PANEL-001 collapses and expands every group and folder fr
     assert.ok(row3.widths.every(width => width >= 22),
         'the icon buttons are never compressed');
 
-    // Collapse all: only the group header rows remain.
-    await collapseAll.click();
+    // Collapse all: only the group header rows remain, and the toggle
+    // flips to Expand all.
+    await foldToggle.click();
     assert.deepEqual(
         await page.locator('.conversation-changes-group-header')
             .allInnerTexts(),
@@ -13979,9 +14019,12 @@ test('WORKTREE-CHANGES-PANEL-001 collapses and expands every group and folder fr
     assert.equal(
         await page.locator('.conversation-changes-group-header[aria-expanded="false"]').count(),
         2);
+    assert.equal(await foldToggle.getAttribute('aria-label'), 'Expand all',
+        'fully collapsed flips the toggle to Expand all');
+    assert.deepEqual(await visibleIcons(), ['expand', 'expand']);
 
     // Expand all restores groups, folders, and files.
-    await expandAll.click();
+    await foldToggle.click();
     assert.deepEqual(
         await page.locator('.conversation-changes-group-header')
             .allInnerTexts(),
@@ -13993,7 +14036,10 @@ test('WORKTREE-CHANGES-PANEL-001 collapses and expands every group and folder fr
         await page.locator('.conversation-changes-file:visible').count(),
         3);
 
-    // No-changes empty state disables both actions (PRD §15.3).
+    assert.equal(await foldToggle.getAttribute('aria-label'),
+        'Collapse all', 'expanding flips the toggle back');
+
+    // No-changes empty state disables the toggle (PRD §15.3).
     await sendChanges(page, changesFixture({
         detail: {
             memberId: 'm-api', availability: 'available',
@@ -14001,12 +14047,10 @@ test('WORKTREE-CHANGES-PANEL-001 collapses and expands every group and folder fr
             items: [], truncated: false,
         },
     }));
-    assert.equal(await collapseAll.isDisabled(), true);
-    assert.equal(await expandAll.isDisabled(), true);
+    assert.equal(await foldToggle.isDisabled(), true);
     await sendChanges(page, changesFixture());
-    assert.equal(await collapseAll.isEnabled(), true,
-        'the actions wake up with the next non-empty state');
-    assert.equal(await expandAll.isEnabled(), true);
+    assert.equal(await foldToggle.isEnabled(), true,
+        'the toggle wakes up with the next non-empty state');
 });
 
 test('WORKTREE-CHANGES-PANEL-001 keeps folder clicks and authoritative refreshes in sync', async t => {
@@ -14237,32 +14281,33 @@ test('WORKTREE-CHANGES-PANEL-001 implements the Files tree keyboard model', asyn
     const changesHeader = page.locator(
         '.conversation-changes-group-header', { hasText: 'Changes · 2' })
         .last();
-    const collapseAll = page.locator('[data-changes-collapse-all]');
-    const expandAll = page.locator('[data-changes-expand-all]');
-    await collapseAll.focus();
+    const foldToggle = page.locator('[data-changes-fold-toggle]');
+    await foldToggle.focus();
     await page.keyboard.press('Space');
     assert.equal(await page.evaluate(() =>
         document.activeElement
-            === document.querySelector('[data-changes-collapse-all]')), true,
-        'keyboard activation leaves focus on the fold action');
-    await expandAll.focus();
+            === document.querySelector('[data-changes-fold-toggle]')), true,
+        'keyboard activation leaves focus on the fold toggle');
+    assert.equal(await foldToggle.getAttribute('aria-label'), 'Expand all');
     await page.keyboard.press('Space');
     assert.equal(await page.evaluate(() =>
         document.activeElement
-            === document.querySelector('[data-changes-expand-all]')), true,
-        'expanding also preserves the action button focus');
+            === document.querySelector('[data-changes-fold-toggle]')), true,
+        'expanding also preserves the toggle focus');
+    assert.equal(await foldToggle.getAttribute('aria-label'),
+        'Collapse all');
 
     await page.locator('.conversation-changes-file', {
         hasText: 'login.test.ts',
     }).focus();
     // Programmatic activation keeps the focused tree row active, unlike a
     // Playwright click which focuses the toolbar button first.
-    await collapseAll.evaluate(element => element.click());
+    await foldToggle.evaluate(element => element.click());
     assert.equal(await page.evaluate(() => document.activeElement),
         await changesHeader.evaluate(element => element),
         'folding a focused child away restores its group header');
 
-    await expandAll.evaluate(element => element.click());
+    await foldToggle.evaluate(element => element.click());
     const focusedFile = page.locator('.conversation-changes-file', {
         hasText: 'login.test.ts',
     });
@@ -14335,7 +14380,7 @@ test('WORKTREE-CHANGES-PANEL-001 clears remembered fold state on session reset',
         }),
     }, 'resetSession pulls the new session\'s state with its own binding');
     assert.equal(
-        await page.locator('[data-changes-collapse-all]').isDisabled(), true,
+        await page.locator('[data-changes-fold-toggle]').isDisabled(), true,
         'no state means nothing to fold');
 
     // The new session's state starts from clean fold defaults even though
@@ -14347,7 +14392,7 @@ test('WORKTREE-CHANGES-PANEL-001 clears remembered fold state on session reset',
     assert.equal(await headerAgain.getAttribute('aria-expanded'), 'true',
         'reset clears the remembered collapse');
     assert.equal(
-        await page.locator('[data-changes-collapse-all]').isEnabled(), true);
+        await page.locator('[data-changes-fold-toggle]').isEnabled(), true);
 });
 
 test('WORKTREE-CHANGES-PANEL-001 scrolls long change lists instead of clipping them', async t => {
@@ -15078,8 +15123,9 @@ test('WORKTREE-CHANGES-PANEL-001 migrates every native title in the Changes pane
         'Open in Source Control');
 
     for (const [selector, label] of [
-        ['[data-changes-collapse-all]', 'Collapse all'],
-        ['[data-changes-expand-all]', 'Expand all'],
+        ['[data-changes-fold-toggle]', 'Collapse all'],
+        ['[data-changes-refresh]', 'Refresh'],
+        ['[data-changes-open-scm]', 'Open in Source Control'],
     ]) {
         const foldAction = page.locator(selector);
         assert.equal(await foldAction.getAttribute('title'), null);
@@ -15197,11 +15243,16 @@ test('WORKTREE-CHANGES-COMMITS-001 switching to Commits requests the first page 
         await page.locator('[data-changes-files-view]').isHidden(), true);
     assert.equal(
         await page.locator('[data-changes-commits-view]').isVisible(), true);
-    // The fold actions keep their slot width but hide in Commits (§15.4).
+    // The fold toggle stays visible in Commits but is inert (disabled);
+    // refresh and SCM keep working (§15.4).
     assert.equal(
-        await page.locator('[data-changes-collapse-all]')
-            .evaluate(element => element.style.visibility),
-        'hidden');
+        await page.locator('[data-changes-fold-toggle]').isVisible(), true);
+    assert.equal(
+        await page.locator('[data-changes-fold-toggle]').isDisabled(), true);
+    assert.equal(
+        await page.locator('[data-changes-refresh]').isEnabled(), true);
+    assert.equal(
+        await page.locator('[data-changes-open-scm]').isEnabled(), true);
 
     // Header: the member's own ahead count + tracking line (§15.5.1).
     assert.equal(


### PR DESCRIPTION
## Summary

Changes panel action-row cleanup (owner-driven UX tweak, two rounds):

**Round 3 (review feedback):** the fold toggle is now functional in the Commits tab (collapses/expands all loaded commit rows with in-flight detail cancellation), so it never renders faded next to refresh/SCM; the expansion bound rises to 64 entries to cover full pages. **Round 2 (review feedback):** the fold toggle's glyph is now a light double-chevron pair matching the refresh/SCM single-stroke family, and row 1 keeps ‹ › visible-but-disabled for single-member sessions so the header looks identical across member counts.

- **Collapse all / Expand all merge into one fold toggle** in row 3's right slot. Anything expanded ⇒ the button is *Collapse all*; fully collapsed ⇒ *Expand all*. Icon, `aria-label`, and tooltip flip with the **live DOM fold state** (`aria-expanded`), never render-time captures.
- **Refresh and Open in Source Control move from the branch row into the same row-3 slot**: `[ Files | Commits ] … fold ⟳ SCM`. The branch row is now branch-only, doubling its truncation budget at narrow widths.
- The toggle **stays visible but inert (disabled) in the Commits tab**; refresh and SCM keep working there.
- New Tab order: ‹ → select → › → branch → hint → sub-tab → fold toggle → refresh → SCM → summary → review.

## Test plan

- Browser 153/153 ✔ — fold-action suite rewritten for the merged toggle (label/icon flip, empty-state disable, keyboard focus retention, Commits-tab inertness), header tab-order assertions updated, two-row header test now asserts branch-only row 2 + row-3 action slot membership
- Unit 1258/1258 ✔, integration 390/390 ✔
- sha256-pinned previous-generation script fixture: strip chain extended to restore the old button pair, pin unchanged ✔
- `run-dashboard-webview-checks` ✔, behavior-contracts ✔, architecture-policy ✔, lint ✔, `git diff --check` ✔, src/webview↔media byte-identity ✔
- `npm run test:coverage:ci` ✔ — changed-line 100%
- Screenshot script: Files + Commits at 192/240/320px, no horizontal overflow, icon parity holds

## Skill harvest

none — routine UI rework inside the existing harness patterns.

## Owner approvals

```
approve 6ddfe6c8c2cbabd2bc05c941b0ef034bd3e8119e
```
