### PR TITLE
chore: release 1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to the "Agent Pivot" extension will be documented in this fi
 
 ## [Unreleased]
 
+## [1.1.2] - 2026-08-23
+
+### Added
+
+- Worktree group Sessions gain a Changes view in the AI Conversation
+  sidebar: a per-repository two-row header with ‹ › cycling between member
+  worktrees, the branch name with its tracking state (ahead/behind against
+  the upstream, or an explicit "No tracking branch"), a task-result summary
+  with a one-click Review multi-diff (untracked files included), collapsible
+  Source-Control-style change groups with a complete keyboard tree, and a
+  focusable tooltip overlay for every truncated label. New installations get
+  a one-time 320px panel width recommendation.
+- The Changes view carries a Files | Commits sub-tab. Commits lists the
+  history since the task started with frozen-head pagination, per-commit
+  tracking badges, inline file expansion with +/- counts, per-commit Review
+  and file diff actions, a baseline boundary row, and an optional full
+  branch history continuation. Refresh, Source Control, and a single
+  collapse/expand toggle live in one shared action row across both tabs.
+
 ### Changed
 
 - The OPEN tab now keeps a fixed WINDOWS switcher above the current window's

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "agent-pivot",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "agent-pivot",
-            "version": "1.1.1",
+            "version": "1.1.2",
             "license": "MIT",
             "dependencies": {
                 "dom-autoscroller": "^2.3.4",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "agent-pivot",
     "displayName": "Agent Pivot",
     "description": "Switch, monitor, and resume Codex, Claude, and Kimi sessions across VS Code workspaces. Project manager and prompt library for AI coding agents.",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "publisher": "hzcheng",
     "license": "MIT",
     "icon": "media/extension_icon.png",

--- a/scripts/lib/brandIdentity.js
+++ b/scripts/lib/brandIdentity.js
@@ -10,7 +10,7 @@ const BRAND_IDENTITY = Object.freeze({
     publisher: 'hzcheng',
     mainPackageName: 'agent-pivot',
     mainExtensionId: 'hzcheng.agent-pivot',
-    mainVersion: '1.1.1',
+    mainVersion: '1.1.2',
     bridgePackageName: 'agent-pivot-attention-ui-bridge',
     bridgeExtensionId: 'hzcheng.agent-pivot-attention-ui-bridge',
     bridgeVersion: '1.0.2',

--- a/scripts/run-release-notes-checks.js
+++ b/scripts/run-release-notes-checks.js
@@ -14,14 +14,14 @@ const workflowPath = path.join(repositoryRoot, '.github', 'workflows', 'release-
 function validateReleaseContent({ readme, changelog, packageMetadata }) {
     assert.strictEqual(packageMetadata.displayName, 'Agent Pivot',
         'release metadata must use the Agent Pivot display name');
-    assert.strictEqual(packageMetadata.version, '1.1.1',
-        'the current Agent Pivot release must be version 1.1.1');
+    assert.strictEqual(packageMetadata.version, '1.1.2',
+        'the current Agent Pivot release must be version 1.1.2');
     const currentRelease = extractReleaseNotes(changelog, packageMetadata.version);
     const requiredReleaseFacts = [
-        ['one-click session creation', /one click\s+starts a new Session/i],
-        ['Codex profile support', /Codex configuration profiles/i],
-        ['large Codex conversation performance', /large Codex conversations/i],
-        ['global Session status', /global Session status dots/i],
+        ['the fixed WINDOWS switcher', /fixed WINDOWS switcher/i],
+        ['the worktree Changes view', /Changes view/i],
+        ['the Commits sub-tab history', /Commits sub-tab/i],
+        ['the Session lifecycle badges', /lifecycle/i],
     ];
 
     for (const [label, pattern] of requiredReleaseFacts) {

--- a/scripts/run-release-packaging-checks.js
+++ b/scripts/run-release-packaging-checks.js
@@ -412,7 +412,7 @@ function runRealVsixArchiveChecks(mainPackage, bridgePackage) {
     );
     assert.strictEqual(
         path.basename(mainArtifact),
-        'agent-pivot-1.1.1.vsix',
+        'agent-pivot-1.1.2.vsix',
         'main release artifact name must remain exact',
     );
     assert.strictEqual(

--- a/tests/unit/tooling/brandIdentity.test.js
+++ b/tests/unit/tooling/brandIdentity.test.js
@@ -50,7 +50,7 @@ function manifests() {
             name: 'agent-pivot',
             displayName: 'Agent Pivot',
             publisher: 'hzcheng',
-            version: '1.1.1',
+            version: '1.1.2',
             icon: 'media/extension_icon.png',
             repository: {
                 type: 'git',
@@ -281,7 +281,7 @@ test('brand identity exposes the exact approved public contract', () => {
         publisher: 'hzcheng',
         mainPackageName: 'agent-pivot',
         mainExtensionId: 'hzcheng.agent-pivot',
-        mainVersion: '1.1.1',
+        mainVersion: '1.1.2',
         bridgePackageName: 'agent-pivot-attention-ui-bridge',
         bridgeExtensionId: 'hzcheng.agent-pivot-attention-ui-bridge',
         bridgeVersion: '1.0.2',

--- a/tests/unit/tooling/extensionHostLauncher.test.js
+++ b/tests/unit/tooling/extensionHostLauncher.test.js
@@ -150,7 +150,7 @@ test('RELEASE-SCHEDULED-EXTENSION-HOST-001 launches both extensions with pinned 
         ]);
         assert.deepEqual(packagePlan.map(item => path.basename(item.artifactPath)), [
             'agent-pivot-attention-ui-bridge-1.0.2.vsix',
-            'agent-pivot-1.1.1.vsix',
+            'agent-pivot-1.1.2.vsix',
         ]);
         assert.equal(options.extensionTestsPath,
             path.join(environment.testHarness, 'index.js'));

--- a/tests/unit/tooling/releaseNotes.test.js
+++ b/tests/unit/tooling/releaseNotes.test.js
@@ -14,6 +14,10 @@ test('release content validation cannot satisfy current facts from historical no
     const changelog = [
         '# Changelog',
         '',
+        '## [1.1.2] - 2026-08-23',
+        '',
+        '- An unrelated documentation fix.',
+        '',
         '## [1.1.1] - 2026-08-13',
         '',
         '- AI Conversation renders provider tool calls as collapsible entries.',
@@ -33,10 +37,10 @@ test('release content validation cannot satisfy current facts from historical no
             changelog,
             packageMetadata: {
                 displayName: 'Agent Pivot',
-                version: '1.1.1',
+                version: '1.1.2',
                 description: 'Workspace command center.',
             },
         }),
-        /1\.1\.1 CHANGELOG release must document one-click session creation/,
+        /1\.1\.2 CHANGELOG release must document the fixed WINDOWS switcher/,
     );
 });


### PR DESCRIPTION
## Summary

Release 1.1.2: version bump (package.json, package-lock, brand identity, release checks, tooling test pins) and the CHANGELOG section for everything since 1.1.1 — the fixed WINDOWS switcher / CHATS+ALL session surface, Session lifecycle badges, and the worktree Changes view with its Files | Commits sub-tab.

## Test plan

- `node scripts/run-release-notes-checks.js` ✔ (new requiredFacts for 1.1.2)
- tooling unit tests (releaseNotes / brandIdentity / extensionHostLauncher) 26/26 ✔
- `npm run test-compile` ✔, unit 1258/1258 ✔, lint ✔, `git diff --check` ✔

## Skill harvest

none — followed the established release-prep shape from the 1.1.1 commit.

## Owner approvals

```
approve ea60eb9001f065adcb93ec525132d1a671a3f135
```
