### PR TITLE
fix: skip attention sessions from closed windows

### DIFF
--- a/src/aiSessions/attentionQueue.ts
+++ b/src/aiSessions/attentionQueue.ts
@@ -128,6 +128,27 @@ export function buildAttentionQueue(input: {
     };
 }
 
+/**
+ * Omits remote items whose owning window is no longer in the authoritative
+ * open-window roster. This is a presentation/navigation filter only: it does
+ * not acknowledge or alter the bridge aggregate, so a transient lookup miss
+ * cannot discard an attention event.
+ */
+export function filterAttentionQueueToReachableWindows(
+    queue: AttentionQueue,
+    isRemoteProjectReachable: (projectId: string) => boolean,
+): AttentionQueue {
+    const items = queue.items.filter(item => item.local
+        || isRemoteProjectReachable(item.projectId));
+    const localCount = items.filter(item => item.local).length;
+    return {
+        items,
+        localCount,
+        remoteCount: items.length - localCount,
+        total: items.length,
+    };
+}
+
 function attentionProviderLabel(provider: AiSessionProviderId): string {
     if (provider === 'kimi') {
         return 'Kimi';

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -84,7 +84,10 @@ import {
     getAttentionSummaryForProjectKeys,
     getLogicalAttentionSessionKey,
 } from './aiSessions/attentionProject';
-import { buildAttentionQueue } from './aiSessions/attentionQueue';
+import {
+    buildAttentionQueue,
+    filterAttentionQueueToReachableWindows,
+} from './aiSessions/attentionQueue';
 import type {
     AttentionQueue,
     AttentionQueueWorkspace,
@@ -2552,10 +2555,14 @@ async function initializeDashboard(
                 sessions,
             };
         }
-        return buildAttentionQueue({
+        const queue = buildAttentionQueue({
             aggregate: aiSessionAttentionController.getEffectiveAggregate(),
             workspace,
         });
+        return filterAttentionQueueToReachableWindows(
+            queue,
+            projectId => !!findAttentionNavigationCardId(projectId)
+        );
     };
     attentionStatusBarController = ownResource(() =>
         createAttentionStatusBarController({
@@ -2851,7 +2858,14 @@ async function initializeDashboard(
         onAggregate: aggregate => {
             latestOpenWorkspaceAggregate = aggregate;
             const statusChanged = openWorkspaceDashboardController.setBridgeStatus('ready');
-            if (openWorkspaceDashboardController.setAggregate(aggregate) || statusChanged) {
+            const aggregateChanged = openWorkspaceDashboardController.setAggregate(aggregate);
+            if (aggregateChanged || statusChanged) {
+                // The attention bridge and the open-window bridge settle
+                // independently. Rebuild the presentation queue whenever the
+                // authoritative window roster changes so a normally closed
+                // window disappears immediately rather than waiting for an
+                // attention lease to expire.
+                attentionStatusBarController?.refresh(buildCurrentAttentionQueue());
                 postOpenWorkspacesUpdated();
             }
             void conversationCapability.viewer.publishSessionStatus();
@@ -2859,6 +2873,7 @@ async function initializeDashboard(
         onError: error => logOpenWorkspaceBridgeError(error),
         onStatusChange: status => {
             if (openWorkspaceDashboardController.setBridgeStatus(status)) {
+                attentionStatusBarController?.refresh(buildCurrentAttentionQueue());
                 postOpenWorkspacesUpdated();
             }
         },

--- a/src/dashboard/attentionQueueJump.ts
+++ b/src/dashboard/attentionQueueJump.ts
@@ -161,36 +161,54 @@ export function createAttentionQueueJumpHandler(
             // session before hopping to another window.
             next = items.find(item => item.local) || items[0];
         }
-        if (next.local) {
-            await jumpToLocal(next);
-            return;
-        }
-        lastKey = attentionQueueItemKey(next);
-        const cardId = options.findNavigationCardId(next.projectId);
-        if (!cardId) {
-            options.showWarningMessage(
-                'Agent Pivot: the session that needs attention is in a window'
-                    + ' that is no longer open.'
-            );
-            return;
-        }
-        if (options.requestRemoteFocus) {
-            let handedOff = false;
-            try {
-                handedOff = await options.requestRemoteFocus(next);
-            } catch (_error) {
-                handedOff = false;
+        let candidate = next;
+        for (let attempts = 0; attempts < items.length; attempts += 1) {
+            const candidateKey = attentionQueueItemKey(candidate);
+            const candidateIndex = items.findIndex(item =>
+                attentionQueueItemKey(item) === candidateKey);
+            if (candidateIndex < 0) {
+                break;
             }
-            await options.openNavigationCard(cardId);
-            if (!handedOff) {
-                options.showInformationMessage(
-                    'Agent Pivot: switched to the window with the session that needs attention;'
-                        + ' run Next Attention Session again to finish the jump.'
-                );
+            if (currentKey !== null
+                && items.length > 1
+                && candidateKey === currentKey) {
+                // A closed remote window may force us to advance farther than
+                // the initial selection. Preserve the existing guarantee that
+                // one press never returns to the session already in view.
+                candidate = items[(candidateIndex + 1) % items.length];
+                continue;
             }
-            return;
+            if (candidate.local) {
+                await jumpToLocal(candidate);
+                return;
+            }
+            lastKey = candidateKey;
+            const cardId = options.findNavigationCardId(candidate.projectId);
+            if (cardId) {
+                if (options.requestRemoteFocus) {
+                    let handedOff = false;
+                    try {
+                        handedOff = await options.requestRemoteFocus(candidate);
+                    } catch (_error) {
+                        handedOff = false;
+                    }
+                    await options.openNavigationCard(cardId);
+                    if (!handedOff) {
+                        options.showInformationMessage(
+                            'Agent Pivot: switched to the window with the session that needs attention;'
+                                + ' run Next Attention Session again to finish the jump.'
+                        );
+                    }
+                    return;
+                }
+                await options.openNavigationCard(cardId);
+                return;
+            }
+            candidate = items[(candidateIndex + 1) % items.length];
         }
-        await options.openNavigationCard(cardId);
+        options.showInformationMessage(
+            'Agent Pivot: no reachable AI sessions need attention.'
+        );
     }
 
     async function jumpToAttentionSession(item: AttentionQueueJumpTarget): Promise<void> {

--- a/tests/contract/aiSessions/attentionStatusBar.test.js
+++ b/tests/contract/aiSessions/attentionStatusBar.test.js
@@ -24,6 +24,7 @@ const {
 } = require('../../../out/aiSessions/attentionProject');
 const {
     buildAttentionQueue,
+    filterAttentionQueueToReachableWindows,
     formatAttentionStatusBar,
 } = require('../../../out/aiSessions/attentionQueue');
 const {
@@ -130,6 +131,24 @@ test('ATTENTION-STATUS-BAR-QUEUE-001 matches logical session keys and missing ro
     assert.equal(queue.localCount, 2, 'logical keys and primary-root fallback still match');
     assert.equal(buildAttentionQueue({ aggregate: input.aggregate, workspace: null }).localCount, 0);
     assert.deepEqual(buildAttentionQueue({ aggregate: null, workspace: makeWorkspace() }).items, []);
+});
+
+test('ATTENTION-STATUS-BAR-QUEUE-001 removes attention from closed remote windows before presenting the queue', () => {
+    const queue = buildAttentionQueue(makeQueueInput());
+    const reachable = filterAttentionQueueToReachableWindows(
+        queue,
+        projectId => projectId !== projectKeyOf('file:///work/other')
+    );
+
+    assert.deepEqual(reachable.items.map(item => `${item.provider}:${item.sessionId}`), [
+        'kimi:sess-1',
+        'codex:sess-2',
+    ]);
+    assert.equal(reachable.total, 2);
+    assert.equal(reachable.localCount, 2);
+    assert.equal(reachable.remoteCount, 0);
+    assert.equal(queue.total, 3,
+        'filtering an unreachable window does not acknowledge or mutate its source aggregate');
 });
 
 test('ATTENTION-STATUS-BAR-QUEUE-001 formats the status bar text and tooltip', () => {
@@ -344,7 +363,102 @@ test('ATTENTION-STATUS-BAR-QUEUE-001 jump hops to the window owning a remote ses
     ], 'remote jumps switch windows; the remote window drains its own queue');
 });
 
-test('ATTENTION-STATUS-BAR-QUEUE-001 jump reports an unmatchable remote session and an empty queue', async () => {
+test('ATTENTION-STATUS-BAR-QUEUE-001 skips a window that closes during Next Attention and reaches the next live session', async () => {
+    const closedProject = projectKeyOf('file:///work/closed');
+    const liveProject = projectKeyOf('file:///work/live');
+    const queue = {
+        items: [
+            {
+                provider: 'claude', sessionId: 'closed-session', projectId: closedProject,
+                eventIds: ['closed-event'], reasons: ['failed'], observedAtMs: 1, local: false,
+            },
+            {
+                provider: 'codex', sessionId: 'live-session', projectId: liveProject,
+                eventIds: ['live-event'], reasons: ['input-required'], observedAtMs: 2, local: false,
+            },
+        ],
+        localCount: 0,
+        remoteCount: 2,
+        total: 2,
+    };
+    const calls = [];
+    const jump = createAttentionQueueJumpHandler({
+        buildQueue: () => queue,
+        focusSession: async () => true,
+        openConversation: async () => true,
+        acknowledge: async () => {},
+        shouldAcknowledge: () => false,
+        findNavigationCardId: projectId => {
+            calls.push(['findNavigationCardId', projectId]);
+            return projectId === liveProject ? 'live-card' : null;
+        },
+        openNavigationCard: async cardId => { calls.push(['openNavigationCard', cardId]); },
+        showInformationMessage: message => { calls.push(['info', message]); },
+        showWarningMessage: message => { calls.push(['warning', message]); },
+    });
+
+    await jump();
+
+    assert.deepEqual(calls, [
+        ['findNavigationCardId', closedProject],
+        ['findNavigationCardId', liveProject],
+        ['openNavigationCard', 'live-card'],
+    ]);
+});
+
+test('ATTENTION-STATUS-BAR-QUEUE-001 skips a closed window without re-landing on the watched session', async () => {
+    const currentProject = projectKeyOf('file:///work/current');
+    const closedProject = projectKeyOf('file:///work/closed');
+    const liveProject = projectKeyOf('file:///work/live');
+    const queue = {
+        items: [
+            {
+                provider: 'codex', sessionId: 'current-session', projectId: currentProject,
+                eventIds: ['current-event'], reasons: ['input-required'], observedAtMs: 1, local: true,
+            },
+            {
+                provider: 'claude', sessionId: 'closed-session', projectId: closedProject,
+                eventIds: ['closed-event'], reasons: ['failed'], observedAtMs: 2, local: false,
+            },
+            {
+                provider: 'kimi', sessionId: 'live-session', projectId: liveProject,
+                eventIds: ['live-event'], reasons: ['completed'], observedAtMs: 3, local: false,
+            },
+        ],
+        localCount: 1,
+        remoteCount: 2,
+        total: 3,
+    };
+    const calls = [];
+    const jump = createAttentionQueueJumpHandler({
+        buildQueue: () => queue,
+        focusSession: async item => {
+            calls.push(['focusSession', item.sessionId]);
+            return true;
+        },
+        openConversation: async () => true,
+        acknowledge: async () => {},
+        shouldAcknowledge: () => false,
+        getCurrentIdentity: () => ({ provider: 'codex', sessionId: 'current-session' }),
+        findNavigationCardId: projectId => {
+            calls.push(['findNavigationCardId', projectId]);
+            return projectId === liveProject ? 'live-card' : null;
+        },
+        openNavigationCard: async cardId => { calls.push(['openNavigationCard', cardId]); },
+        showInformationMessage: message => { calls.push(['info', message]); },
+        showWarningMessage: message => { calls.push(['warning', message]); },
+    });
+
+    await jump();
+
+    assert.deepEqual(calls, [
+        ['findNavigationCardId', closedProject],
+        ['findNavigationCardId', liveProject],
+        ['openNavigationCard', 'live-card'],
+    ]);
+});
+
+test('ATTENTION-STATUS-BAR-QUEUE-001 reports no reachable attention when every remote window has closed', async () => {
     const remoteQueue = buildAttentionQueue({
         aggregate: makeQueueInput().aggregate,
         workspace: null,
@@ -353,7 +467,9 @@ test('ATTENTION-STATUS-BAR-QUEUE-001 jump reports an unmatchable remote session 
     await remote.options();
     assert.deepEqual(remote.calls, [
         ['findNavigationCardId', projectKeyOf('file:///work/other')],
-        ['warning', 'Agent Pivot: the session that needs attention is in a window that is no longer open.'],
+        ['findNavigationCardId', projectKeyOf('file:///work/alpha')],
+        ['findNavigationCardId', projectKeyOf('file:///work/alpha')],
+        ['info', 'Agent Pivot: no reachable AI sessions need attention.'],
     ]);
 
     const empty = makeJumpOptions({


### PR DESCRIPTION
## Summary

- remove closed-window attention from the actionable queue and status count using the live open-window roster
- skip a window that closes during Next Attention and continue to the next reachable session
- preserve the current-session skip guarantee while recovering from stale remote entries

## Verification

- `npm run test:ci:linux`
- `SKIP_NPM_CI=1 npm run install-local`

## Skill harvest

No skill change: the stale cross-window state was a product race covered by the existing regression, verification, and PR workflow guidance; no reusable workflow gap was found.

## Owner approvals

```text
approve e34e03a7f7909c27e97aa12c726e9f26228b0c1d
```