### PR TITLE
fix(windows): prioritize attention count

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -2934,7 +2934,7 @@
   {
     "id": "OPEN-WINDOW-SWITCHER-UI-001",
     "domain": "webview",
-    "title": "OPEN tab window switcher renders single-line rows with fixed slots (indicator/icon/name/running/attention/pin/more), a three-state current-row model (current/pending/error) with zero-displacement transitions, the responsive width matrix, and a one-time dismissible layout-migration notice",
+    "title": "OPEN tab window switcher renders single-line rows with fixed slots (indicator/icon/name/attention/running/pin/more), a three-state current-row model (current/pending/error) with zero-displacement transitions, the responsive width matrix, and a one-time dismissible layout-migration notice",
     "priority": "P1",
     "status": "automated",
     "owners": [

--- a/src/webview/webviewWindowSwitcherContent.ts
+++ b/src/webview/webviewWindowSwitcherContent.ts
@@ -71,8 +71,8 @@ export function getOpenWindowRowHtml(
         <span class="open-window-name">${escapedName}</span>
         <span class="open-window-jump-hint" aria-hidden="true">&#8599;</span>
     </button>
-    ${getCountSlot(row.runningCount, 'open-window-running', '\u25CF', count => `${count} session${count === 1 ? '' : 's'} running in this window`, 'No running sessions')}
     ${getCountSlot(row.attentionCount, 'open-window-attention', '<span class="open-window-attention-dot" aria-hidden="true"></span>', count => `${count} session${count === 1 ? '' : 's'} need${count === 1 ? 's' : ''} attention in this window`, 'Nothing needs attention')}
+    ${getCountSlot(row.runningCount, 'open-window-running', '\u25CF', count => `${count} session${count === 1 ? '' : 's'} running in this window`, 'No running sessions')}
     ${pinButton}
     <button type="button" class="open-window-more" data-action="open-window-menu" title="More actions" aria-label="More actions" aria-haspopup="menu" aria-expanded="false">${Icons.moreActions}</button>
     <button type="button" class="open-window-retry" data-action="retry-open-window-navigation" hidden>Retry</button>

--- a/tests/browser/dashboardWindowSwitcher.test.js
+++ b/tests/browser/dashboardWindowSwitcher.test.js
@@ -134,6 +134,9 @@ test('OPEN-WINDOW-SWITCHER-UI-001 renders single-line rows with the aria model',
                 attention: row.querySelector('.open-window-attention').textContent,
                 runningAria: row.querySelector('.open-window-running').getAttribute('aria-label'),
                 attentionAria: row.querySelector('.open-window-attention').getAttribute('aria-label'),
+                attentionBeforeRunning: Boolean(row.querySelector('.open-window-attention')
+                    .compareDocumentPosition(row.querySelector('.open-window-running'))
+                    & Node.DOCUMENT_POSITION_FOLLOWING),
             })),
             iconTitles: rows.map(row => row.querySelector('.open-window-icon').getAttribute('title')),
             environmentChipCount: document.querySelectorAll('.open-window-env-chip').length,
@@ -153,9 +156,9 @@ test('OPEN-WINDOW-SWITCHER-UI-001 renders single-line rows with the aria model',
     assert.match(structure.navigation.title, /^Focus window: beta/);
     // 运行/待处理为 0 时留空但保留槽位（含 aria-label）。
     assert.deepEqual(structure.counts, [
-        { running: '●2', attention: '1', runningAria: '2 sessions running in this window', attentionAria: '1 session needs attention in this window' },
-        { running: '●1', attention: '', runningAria: '1 session running in this window', attentionAria: 'Nothing needs attention' },
-        { running: '', attention: '', runningAria: 'No running sessions', attentionAria: 'Nothing needs attention' },
+        { running: '●2', attention: '1', runningAria: '2 sessions running in this window', attentionAria: '1 session needs attention in this window', attentionBeforeRunning: true },
+        { running: '●1', attention: '', runningAria: '1 session running in this window', attentionAria: 'Nothing needs attention', attentionBeforeRunning: true },
+        { running: '', attention: '', runningAria: 'No running sessions', attentionAria: 'Nothing needs attention', attentionBeforeRunning: true },
     ]);
     assert.deepEqual(structure.iconTitles, ['Local Project', 'SSH Project', 'Dev Container Project']);
     assert.equal(structure.environmentChipCount, 0);

--- a/tests/unit/webview/windowSwitcherContent.test.js
+++ b/tests/unit/webview/windowSwitcherContent.test.js
@@ -47,6 +47,11 @@ test('window switcher renderer: current row carries the triple encoding and aria
     assert.match(html, /●2/);
     assert.match(html, /open-window-attention-dot/);
     assert.match(html, /open-window-attention-dot[^>]*><\/span>3/);
+    const attentionIndex = html.indexOf('class="open-window-attention"');
+    const runningIndex = html.indexOf('class="open-window-running"');
+    assert.notEqual(attentionIndex, -1);
+    assert.notEqual(runningIndex, -1);
+    assert.ok(attentionIndex < runningIndex, 'attention count precedes the running count');
 });
 
 test('window switcher renderer: navigation row points at the focus affordance', () => {


### PR DESCRIPTION
## Summary

- Render attention counts before running-session counts in Windows rows.
- Keep the behavior catalog and unit/browser regression coverage aligned with the slot order.

## Validation

- `npm run test-compile`
- `npm run test:behavior-contracts`
- `node --test tests/unit/webview/windowSwitcherContent.test.js`
- `node --test tests/browser/dashboardWindowSwitcher.test.js`
- `npm run test:dashboard:run`
- `npm run install-local` (packaged and byte-verified both extensions)

## Skill harvest

No skill change: the task-local packaging timing observation is already covered by the existing verified-artifact and byte-verification guidance; no reusable instruction gap was found.

## Owner approvals

```text
approve a06c33bcbfcb1cf210425d5f438effd1c47fa628
```