### PR TITLE
fix: make webview tooltips intentional

### DIFF
--- a/media/conversationChangesScripts.js
+++ b/media/conversationChangesScripts.js
@@ -28,8 +28,11 @@
     function createTooltipOverlay(panelRoot) {
         var OVERLAY_ID = 'conversation-changes-tooltip-overlay';
         var VIEWPORT_GAP = 4;
+        var HOVER_DELAY_MS = 400;
         var overlay = null;
         var activeTrigger = null;
+        var pendingTrigger = null;
+        var showTimer = null;
 
         function ensureOverlay() {
             if (!overlay) {
@@ -43,7 +46,16 @@
             return overlay;
         }
 
+        function clearPendingShow() {
+            if (showTimer) {
+                clearTimeout(showTimer);
+                showTimer = null;
+            }
+            pendingTrigger = null;
+        }
+
         function hide() {
+            clearPendingShow();
             if (!activeTrigger) {
                 return;
             }
@@ -55,6 +67,7 @@
         }
 
         function show(trigger) {
+            clearPendingShow();
             var text = trigger.getAttribute('data-tooltip');
             if (!text) {
                 if (activeTrigger === trigger) {
@@ -84,6 +97,27 @@
                 Math.min(rect.bottom + VIEWPORT_GAP, maxTop)) + 'px';
         }
 
+        function scheduleShow(trigger) {
+            if (!trigger.getAttribute('data-tooltip')
+                || activeTrigger === trigger
+                || pendingTrigger === trigger) {
+                return;
+            }
+            hide();
+            pendingTrigger = trigger;
+            showTimer = setTimeout(function () {
+                showTimer = null;
+                if (pendingTrigger !== trigger) {
+                    return;
+                }
+                pendingTrigger = null;
+                if (!trigger.isConnected || panelRoot.offsetParent === null) {
+                    return;
+                }
+                show(trigger);
+            }, HOVER_DELAY_MS);
+        }
+
         function eventTrigger(event) {
             return event.target && event.target.closest
                 ? event.target.closest('[data-tooltip]')
@@ -96,20 +130,23 @@
         panelRoot.addEventListener('mouseover', function (event) {
             var trigger = eventTrigger(event);
             if (trigger) {
-                show(trigger);
+                scheduleShow(trigger);
             }
         });
         panelRoot.addEventListener('mouseout', function (event) {
-            if (!activeTrigger || eventTrigger(event) !== activeTrigger) {
+            var trigger = eventTrigger(event);
+            if (!trigger || (trigger !== activeTrigger
+                && trigger !== pendingTrigger)) {
                 return;
             }
             if (event.relatedTarget
-                && activeTrigger.contains(event.relatedTarget)) {
+                && trigger.contains(event.relatedTarget)) {
                 return;
             }
             // A focused trigger keeps its hint until blur — keyboard users
             // never move the mouse.
-            if (document.activeElement === activeTrigger) {
+            if (trigger === activeTrigger
+                && document.activeElement === activeTrigger) {
                 return;
             }
             hide();
@@ -121,7 +158,7 @@
             }
         });
         panelRoot.addEventListener('focusout', function (event) {
-            if (activeTrigger && event.target === activeTrigger) {
+            if (event.target === activeTrigger || event.target === pendingTrigger) {
                 hide();
             }
         });

--- a/media/conversationCommentsScripts.js
+++ b/media/conversationCommentsScripts.js
@@ -575,7 +575,7 @@
                     + ' open workspace note'
                     + (workspaceOpenCount === 1 ? '' : 's')
                     + ' — click to review';
-                telemetryComments.title = telemetryCommentLabel;
+                telemetryComments.removeAttribute('title');
                 telemetryComments.setAttribute(
                     'aria-label', telemetryCommentLabel
                 );

--- a/media/conversationSubagentsScripts.js
+++ b/media/conversationSubagentsScripts.js
@@ -153,7 +153,7 @@
                 + lastSubagents.length
                 + (lastSubagents.length === 1 ? ' subagent' : ' subagents')
                 + ' — click to view';
-            telemetrySubagents.title = telemetrySubagentsLabel;
+            telemetrySubagents.removeAttribute('title');
             telemetrySubagents.setAttribute(
                 'aria-label', telemetrySubagentsLabel
             );

--- a/media/conversationTelemetry.css
+++ b/media/conversationTelemetry.css
@@ -402,6 +402,12 @@
 }
 
 .conversation-telemetry-tooltip:hover::before,
+.conversation-telemetry-tooltip:hover::after {
+    /* Pointer hints wait for intentional hover; keyboard focus is immediate. */
+    transition-delay: 400ms;
+}
+
+.conversation-telemetry-tooltip:hover::before,
 .conversation-telemetry-tooltip:hover::after,
 .conversation-telemetry-tooltip:focus-visible::before,
 .conversation-telemetry-tooltip:focus-visible::after {
@@ -413,6 +419,11 @@
 .conversation-telemetry-tooltip:hover::before,
 .conversation-telemetry-tooltip:focus-visible::before {
     transform: translateY(-.25rem) rotate(45deg);
+}
+
+.conversation-telemetry-tooltip:focus-visible::before,
+.conversation-telemetry-tooltip:focus-visible::after {
+    transition-delay: 0ms;
 }
 
 .conversation-telemetry .conversation-telemetry-tooltip:focus-visible {

--- a/media/conversationTelemetryScripts.js
+++ b/media/conversationTelemetryScripts.js
@@ -157,7 +157,7 @@
         }
 
         function setTooltip(element, label) {
-            element.title = label;
+            element.removeAttribute('title');
             element.setAttribute('aria-label', label);
             element.setAttribute('data-tooltip', label);
         }
@@ -260,6 +260,7 @@
             }
             telemetryModel.hidden = !telemetry.model;
             telemetryModelValue.textContent = telemetry.model || '';
+            setTooltip(telemetryProvider, providerTooltip());
             setTooltip(
                 telemetryModel,
                 telemetry.model ? 'Model · ' + telemetry.model : 'Model'

--- a/media/conversationViewerScripts.js
+++ b/media/conversationViewerScripts.js
@@ -1217,9 +1217,10 @@
         var value = position.querySelector('[data-conversation-position-value]');
         if (value) {
             value.textContent = message.selectedInput + '/' + total;
-            position.title = label + ' — click to open the outline';
-            position.setAttribute('aria-label', position.title);
-            position.setAttribute('data-tooltip', position.title);
+            var tooltip = label + ' — click to open the outline';
+            position.removeAttribute('title');
+            position.setAttribute('aria-label', tooltip);
+            position.setAttribute('data-tooltip', tooltip);
         } else {
             position.textContent = label;
         }

--- a/media/webviewDashboardBundle.js
+++ b/media/webviewDashboardBundle.js
@@ -4183,8 +4183,10 @@ function initProjectAiSessionControls(options) {
     var getAiSessionPresentationStateStore = options.getAiSessionPresentationStateStore;
     var updateStickyGroupHeaderOffset = options.updateStickyGroupHeaderOffset;
 
-    // Native title tooltips take over a second to appear; icon-only buttons
-    // get a shared fast tooltip instead (150ms), driven by data-tooltip.
+    // Native title tooltips take over a second to appear. Hover tooltips wait
+    // long enough to avoid firing while the pointer is merely scanning rows;
+    // keyboard focus remains immediate.
+    var FAST_TOOLTIP_HOVER_DELAY_MS = 400;
     var fastTooltip = null;
     var fastTooltipTimer = null;
     var fastTooltipTarget = null;
@@ -4201,12 +4203,17 @@ function initProjectAiSessionControls(options) {
         }
     }
 
-    function showFastTooltip(target) {
+    function getTooltipTarget(node) {
+        return node && node.closest ? node.closest('[data-tooltip]') : null;
+    }
+
+    function showFastTooltip(target, delayMs) {
         var label = target.getAttribute('data-tooltip');
         if (!label || !target.isConnected) return;
         hideFastTooltip();
         fastTooltipTarget = target;
-        fastTooltipTimer = setTimeout(() => {
+        var render = () => {
+            fastTooltipTimer = null;
             if (fastTooltipTarget !== target || !target.isConnected) return;
             fastTooltip = document.createElement('div');
             fastTooltip.className = 'ai-session-fast-tooltip';
@@ -4225,22 +4232,34 @@ function initProjectAiSessionControls(options) {
             }
             fastTooltip.style.left = left + 'px';
             fastTooltip.style.top = top + 'px';
-        }, 150);
+        };
+        if (delayMs > 0) {
+            fastTooltipTimer = setTimeout(render, delayMs);
+        } else {
+            render();
+        }
     }
 
     document.addEventListener('mouseover', event => {
-        var target = event.target && event.target.closest
-            ? event.target.closest('[data-tooltip]') : null;
+        var target = getTooltipTarget(event.target);
         if (target === fastTooltipTarget) return;
         hideFastTooltip();
-        if (target) showFastTooltip(target);
+        if (target) showFastTooltip(target, FAST_TOOLTIP_HOVER_DELAY_MS);
+    });
+    document.addEventListener('mouseout', event => {
+        var target = getTooltipTarget(event.target);
+        if (target !== fastTooltipTarget) return;
+        // Moving between an icon and its containing tooltip trigger must not
+        // dismiss the overlay. A null relatedTarget is the Webview boundary.
+        if (getTooltipTarget(event.relatedTarget) !== target) {
+            hideFastTooltip();
+        }
     });
     document.addEventListener('pointerdown', hideFastTooltip, true);
     document.addEventListener('focusin', event => {
-        var target = event.target && event.target.closest
-            ? event.target.closest('[data-tooltip]') : null;
+        var target = getTooltipTarget(event.target);
         hideFastTooltip();
-        if (target) showFastTooltip(target);
+        if (target) showFastTooltip(target, 0);
     });
     document.addEventListener('focusout', hideFastTooltip);
 

--- a/media/webviewProjectAiSessionControlsScripts.js
+++ b/media/webviewProjectAiSessionControlsScripts.js
@@ -6,8 +6,10 @@ function initProjectAiSessionControls(options) {
     var getAiSessionPresentationStateStore = options.getAiSessionPresentationStateStore;
     var updateStickyGroupHeaderOffset = options.updateStickyGroupHeaderOffset;
 
-    // Native title tooltips take over a second to appear; icon-only buttons
-    // get a shared fast tooltip instead (150ms), driven by data-tooltip.
+    // Native title tooltips take over a second to appear. Hover tooltips wait
+    // long enough to avoid firing while the pointer is merely scanning rows;
+    // keyboard focus remains immediate.
+    var FAST_TOOLTIP_HOVER_DELAY_MS = 400;
     var fastTooltip = null;
     var fastTooltipTimer = null;
     var fastTooltipTarget = null;
@@ -24,12 +26,17 @@ function initProjectAiSessionControls(options) {
         }
     }
 
-    function showFastTooltip(target) {
+    function getTooltipTarget(node) {
+        return node && node.closest ? node.closest('[data-tooltip]') : null;
+    }
+
+    function showFastTooltip(target, delayMs) {
         var label = target.getAttribute('data-tooltip');
         if (!label || !target.isConnected) return;
         hideFastTooltip();
         fastTooltipTarget = target;
-        fastTooltipTimer = setTimeout(() => {
+        var render = () => {
+            fastTooltipTimer = null;
             if (fastTooltipTarget !== target || !target.isConnected) return;
             fastTooltip = document.createElement('div');
             fastTooltip.className = 'ai-session-fast-tooltip';
@@ -48,22 +55,34 @@ function initProjectAiSessionControls(options) {
             }
             fastTooltip.style.left = left + 'px';
             fastTooltip.style.top = top + 'px';
-        }, 150);
+        };
+        if (delayMs > 0) {
+            fastTooltipTimer = setTimeout(render, delayMs);
+        } else {
+            render();
+        }
     }
 
     document.addEventListener('mouseover', event => {
-        var target = event.target && event.target.closest
-            ? event.target.closest('[data-tooltip]') : null;
+        var target = getTooltipTarget(event.target);
         if (target === fastTooltipTarget) return;
         hideFastTooltip();
-        if (target) showFastTooltip(target);
+        if (target) showFastTooltip(target, FAST_TOOLTIP_HOVER_DELAY_MS);
+    });
+    document.addEventListener('mouseout', event => {
+        var target = getTooltipTarget(event.target);
+        if (target !== fastTooltipTarget) return;
+        // Moving between an icon and its containing tooltip trigger must not
+        // dismiss the overlay. A null relatedTarget is the Webview boundary.
+        if (getTooltipTarget(event.relatedTarget) !== target) {
+            hideFastTooltip();
+        }
     });
     document.addEventListener('pointerdown', hideFastTooltip, true);
     document.addEventListener('focusin', event => {
-        var target = event.target && event.target.closest
-            ? event.target.closest('[data-tooltip]') : null;
+        var target = getTooltipTarget(event.target);
         hideFastTooltip();
-        if (target) showFastTooltip(target);
+        if (target) showFastTooltip(target, 0);
     });
     document.addEventListener('focusout', hideFastTooltip);
 

--- a/src/aiSessions/conversation/conversationTelemetryController.ts
+++ b/src/aiSessions/conversation/conversationTelemetryController.ts
@@ -385,7 +385,6 @@ export function renderConversationTelemetry(
             data-telemetry-limit data-telemetry-limit-id="${escapeAttribute(limit.id)}"
             role="meter" tabindex="0" aria-valuemin="0" aria-valuemax="100"
             aria-valuenow="${usedPercent}" aria-label="${escapeAttribute(details)}"
-            title="${escapeAttribute(details)}"
             data-tooltip="${escapeAttribute(details)}">
             ${renderProgressRing(
                 'data-telemetry-limit-progress',
@@ -408,14 +407,12 @@ export function renderConversationTelemetry(
             ${sessionKind === 'attention' ? 'role="button"' : ''}
             tabindex="0"
             aria-label="${escapeAttribute(providerTitle)}"
-            title="${escapeAttribute(providerTitle)}"
             data-tooltip="${escapeAttribute(providerTitle)}">
             ${PROVIDER_ICON_CODEX_SVG}${PROVIDER_ICON_KIMI_SVG}${PROVIDER_ICON_CLAUDE_SVG}
         </div>
         <div class="conversation-telemetry-model conversation-telemetry-tooltip"
             data-telemetry-model tabindex="0"
             aria-label="${escapeAttribute(modelTitle)}"
-            title="${escapeAttribute(modelTitle)}"
             data-tooltip="${escapeAttribute(modelTitle)}"${hasModel ? '' : ' hidden'}>
             ${MODEL_ICON_SVG}
             <strong data-telemetry-model-value>${escapeHtml(
@@ -427,7 +424,6 @@ export function renderConversationTelemetry(
             data-telemetry-context role="meter" aria-valuemin="0"
             tabindex="0" aria-valuemax="100" aria-valuenow="${contextPercent}"
             aria-label="${escapeAttribute(contextDetails)}"
-            title="${escapeAttribute(contextDetails)}"
             data-tooltip="${escapeAttribute(contextDetails)}"${hasContext ? '' : ' hidden'}>
             ${renderProgressRing(
                 'data-telemetry-context-progress',
@@ -446,7 +442,6 @@ export function renderConversationTelemetry(
             data-conversation-position
             aria-pressed="false"
             aria-label="Input 0 of 0 — click to open the outline"
-            title="Input 0 of 0 — click to open the outline"
             data-tooltip="Input 0 of 0 — click to open the outline">
             ${POSITION_ICON_SVG}<span data-conversation-position-value>0/0</span>
         </button>
@@ -455,7 +450,6 @@ export function renderConversationTelemetry(
             data-telemetry-comments
             aria-pressed="false"
             aria-label="0 open session comments · 0 open workspace notes — click to review"
-            title="0 open session comments · 0 open workspace notes — click to review"
             data-tooltip="0 open session comments · 0 open workspace notes — click to review">
             ${COMMENTS_ICON_SVG}<span data-telemetry-comments-value>0 · 0</span>
         </button>
@@ -464,7 +458,6 @@ export function renderConversationTelemetry(
             data-telemetry-subagents
             aria-pressed="false"
             aria-label="0 running of 0 subagents — click to view"
-            title="0 running of 0 subagents — click to view"
             data-tooltip="0 running of 0 subagents — click to view">
             ${SUBAGENTS_ICON_SVG}<span data-telemetry-subagents-value>0/0</span>
         </button>

--- a/src/webview/conversationChangesScripts.js
+++ b/src/webview/conversationChangesScripts.js
@@ -28,8 +28,11 @@
     function createTooltipOverlay(panelRoot) {
         var OVERLAY_ID = 'conversation-changes-tooltip-overlay';
         var VIEWPORT_GAP = 4;
+        var HOVER_DELAY_MS = 400;
         var overlay = null;
         var activeTrigger = null;
+        var pendingTrigger = null;
+        var showTimer = null;
 
         function ensureOverlay() {
             if (!overlay) {
@@ -43,7 +46,16 @@
             return overlay;
         }
 
+        function clearPendingShow() {
+            if (showTimer) {
+                clearTimeout(showTimer);
+                showTimer = null;
+            }
+            pendingTrigger = null;
+        }
+
         function hide() {
+            clearPendingShow();
             if (!activeTrigger) {
                 return;
             }
@@ -55,6 +67,7 @@
         }
 
         function show(trigger) {
+            clearPendingShow();
             var text = trigger.getAttribute('data-tooltip');
             if (!text) {
                 if (activeTrigger === trigger) {
@@ -84,6 +97,27 @@
                 Math.min(rect.bottom + VIEWPORT_GAP, maxTop)) + 'px';
         }
 
+        function scheduleShow(trigger) {
+            if (!trigger.getAttribute('data-tooltip')
+                || activeTrigger === trigger
+                || pendingTrigger === trigger) {
+                return;
+            }
+            hide();
+            pendingTrigger = trigger;
+            showTimer = setTimeout(function () {
+                showTimer = null;
+                if (pendingTrigger !== trigger) {
+                    return;
+                }
+                pendingTrigger = null;
+                if (!trigger.isConnected || panelRoot.offsetParent === null) {
+                    return;
+                }
+                show(trigger);
+            }, HOVER_DELAY_MS);
+        }
+
         function eventTrigger(event) {
             return event.target && event.target.closest
                 ? event.target.closest('[data-tooltip]')
@@ -96,20 +130,23 @@
         panelRoot.addEventListener('mouseover', function (event) {
             var trigger = eventTrigger(event);
             if (trigger) {
-                show(trigger);
+                scheduleShow(trigger);
             }
         });
         panelRoot.addEventListener('mouseout', function (event) {
-            if (!activeTrigger || eventTrigger(event) !== activeTrigger) {
+            var trigger = eventTrigger(event);
+            if (!trigger || (trigger !== activeTrigger
+                && trigger !== pendingTrigger)) {
                 return;
             }
             if (event.relatedTarget
-                && activeTrigger.contains(event.relatedTarget)) {
+                && trigger.contains(event.relatedTarget)) {
                 return;
             }
             // A focused trigger keeps its hint until blur — keyboard users
             // never move the mouse.
-            if (document.activeElement === activeTrigger) {
+            if (trigger === activeTrigger
+                && document.activeElement === activeTrigger) {
                 return;
             }
             hide();
@@ -121,7 +158,7 @@
             }
         });
         panelRoot.addEventListener('focusout', function (event) {
-            if (activeTrigger && event.target === activeTrigger) {
+            if (event.target === activeTrigger || event.target === pendingTrigger) {
                 hide();
             }
         });

--- a/src/webview/conversationCommentsScripts.js
+++ b/src/webview/conversationCommentsScripts.js
@@ -575,7 +575,7 @@
                     + ' open workspace note'
                     + (workspaceOpenCount === 1 ? '' : 's')
                     + ' — click to review';
-                telemetryComments.title = telemetryCommentLabel;
+                telemetryComments.removeAttribute('title');
                 telemetryComments.setAttribute(
                     'aria-label', telemetryCommentLabel
                 );

--- a/src/webview/conversationSubagentsScripts.js
+++ b/src/webview/conversationSubagentsScripts.js
@@ -153,7 +153,7 @@
                 + lastSubagents.length
                 + (lastSubagents.length === 1 ? ' subagent' : ' subagents')
                 + ' — click to view';
-            telemetrySubagents.title = telemetrySubagentsLabel;
+            telemetrySubagents.removeAttribute('title');
             telemetrySubagents.setAttribute(
                 'aria-label', telemetrySubagentsLabel
             );

--- a/src/webview/conversationTelemetryScripts.js
+++ b/src/webview/conversationTelemetryScripts.js
@@ -157,7 +157,7 @@
         }
 
         function setTooltip(element, label) {
-            element.title = label;
+            element.removeAttribute('title');
             element.setAttribute('aria-label', label);
             element.setAttribute('data-tooltip', label);
         }
@@ -260,6 +260,7 @@
             }
             telemetryModel.hidden = !telemetry.model;
             telemetryModelValue.textContent = telemetry.model || '';
+            setTooltip(telemetryProvider, providerTooltip());
             setTooltip(
                 telemetryModel,
                 telemetry.model ? 'Model · ' + telemetry.model : 'Model'

--- a/src/webview/conversationViewerScripts.js
+++ b/src/webview/conversationViewerScripts.js
@@ -1217,9 +1217,10 @@
         var value = position.querySelector('[data-conversation-position-value]');
         if (value) {
             value.textContent = message.selectedInput + '/' + total;
-            position.title = label + ' — click to open the outline';
-            position.setAttribute('aria-label', position.title);
-            position.setAttribute('data-tooltip', position.title);
+            var tooltip = label + ' — click to open the outline';
+            position.removeAttribute('title');
+            position.setAttribute('aria-label', tooltip);
+            position.setAttribute('data-tooltip', tooltip);
         } else {
             position.textContent = label;
         }

--- a/src/webview/webviewProjectAiSessionControlsScripts.js
+++ b/src/webview/webviewProjectAiSessionControlsScripts.js
@@ -6,8 +6,10 @@ function initProjectAiSessionControls(options) {
     var getAiSessionPresentationStateStore = options.getAiSessionPresentationStateStore;
     var updateStickyGroupHeaderOffset = options.updateStickyGroupHeaderOffset;
 
-    // Native title tooltips take over a second to appear; icon-only buttons
-    // get a shared fast tooltip instead (150ms), driven by data-tooltip.
+    // Native title tooltips take over a second to appear. Hover tooltips wait
+    // long enough to avoid firing while the pointer is merely scanning rows;
+    // keyboard focus remains immediate.
+    var FAST_TOOLTIP_HOVER_DELAY_MS = 400;
     var fastTooltip = null;
     var fastTooltipTimer = null;
     var fastTooltipTarget = null;
@@ -24,12 +26,17 @@ function initProjectAiSessionControls(options) {
         }
     }
 
-    function showFastTooltip(target) {
+    function getTooltipTarget(node) {
+        return node && node.closest ? node.closest('[data-tooltip]') : null;
+    }
+
+    function showFastTooltip(target, delayMs) {
         var label = target.getAttribute('data-tooltip');
         if (!label || !target.isConnected) return;
         hideFastTooltip();
         fastTooltipTarget = target;
-        fastTooltipTimer = setTimeout(() => {
+        var render = () => {
+            fastTooltipTimer = null;
             if (fastTooltipTarget !== target || !target.isConnected) return;
             fastTooltip = document.createElement('div');
             fastTooltip.className = 'ai-session-fast-tooltip';
@@ -48,22 +55,34 @@ function initProjectAiSessionControls(options) {
             }
             fastTooltip.style.left = left + 'px';
             fastTooltip.style.top = top + 'px';
-        }, 150);
+        };
+        if (delayMs > 0) {
+            fastTooltipTimer = setTimeout(render, delayMs);
+        } else {
+            render();
+        }
     }
 
     document.addEventListener('mouseover', event => {
-        var target = event.target && event.target.closest
-            ? event.target.closest('[data-tooltip]') : null;
+        var target = getTooltipTarget(event.target);
         if (target === fastTooltipTarget) return;
         hideFastTooltip();
-        if (target) showFastTooltip(target);
+        if (target) showFastTooltip(target, FAST_TOOLTIP_HOVER_DELAY_MS);
+    });
+    document.addEventListener('mouseout', event => {
+        var target = getTooltipTarget(event.target);
+        if (target !== fastTooltipTarget) return;
+        // Moving between an icon and its containing tooltip trigger must not
+        // dismiss the overlay. A null relatedTarget is the Webview boundary.
+        if (getTooltipTarget(event.relatedTarget) !== target) {
+            hideFastTooltip();
+        }
     });
     document.addEventListener('pointerdown', hideFastTooltip, true);
     document.addEventListener('focusin', event => {
-        var target = event.target && event.target.closest
-            ? event.target.closest('[data-tooltip]') : null;
+        var target = getTooltipTarget(event.target);
         hideFastTooltip();
-        if (target) showFastTooltip(target);
+        if (target) showFastTooltip(target, 0);
     });
     document.addEventListener('focusout', hideFastTooltip);
 

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -12109,7 +12109,7 @@ test('CONVERSATION-SESSION-STATUS-002 mirrors the viewed session kind on the tel
         'attention'
     );
     assert.equal(
-        await provider.getAttribute('title'),
+        await provider.getAttribute('data-tooltip'),
         'Provider · Codex · Needs attention — click to clear'
     );
     assert.equal(await provider.getAttribute('aria-label'),
@@ -12173,7 +12173,7 @@ test('CONVERSATION-SESSION-STATUS-002 mirrors the viewed session kind on the tel
         'running'
     );
     assert.equal(
-        await provider.getAttribute('title'),
+        await provider.getAttribute('data-tooltip'),
         'Provider · Codex · Running'
     );
     await provider.click();
@@ -12235,7 +12235,7 @@ test('CONVERSATION-SESSION-STATUS-002 mirrors the viewed session kind on the tel
         'a missing kind removes the ring'
     );
     assert.equal(
-        await provider.getAttribute('title'),
+        await provider.getAttribute('data-tooltip'),
         'Provider · Codex'
     );
     assert.equal(await provider.getAttribute('role'), null,
@@ -13677,7 +13677,10 @@ test('WORKTREE-CHANGES-PANEL-001 renders a two-row member header with a repo pic
 });
 
 test('WORKTREE-CHANGES-PANEL-001 cycles members with ‹ ›, wraps at the ends, announces the position, and keeps focus', async t => {
-    const { page } = await openHostViewerDocument(t, {});
+    const { page } = await openHostViewerDocument(t, {
+        includeStyles: true,
+        themeFixture: viewerThemeFixtures[0],
+    });
     const state = changesFixture();
     state.members.push({
         memberId: 'm-infra', repoLabel: 'infra',
@@ -14005,6 +14008,7 @@ test('WORKTREE-CHANGES-PANEL-001 puts selected-member tracking facts in the Revi
             'Tracking origin/agent-pivot/fix-login · 2 ahead · 1 behind'), true);
     await review.hover();
     const overlay = page.locator('.conversation-tooltip-overlay');
+    await overlay.waitFor({ state: 'visible', timeout: 900 });
     assert.ok((await overlay.innerText()).includes(
         'Tracking origin/agent-pivot/fix-login · 2 ahead · 1 behind'));
 
@@ -14025,6 +14029,7 @@ test('WORKTREE-CHANGES-PANEL-001 puts selected-member tracking facts in the Revi
         'a state refresh closes a visible hint instead of leaving stale details');
     await page.mouse.move(0, 0);
     await review.hover();
+    await overlay.waitFor({ state: 'visible', timeout: 900 });
     assert.ok((await overlay.innerText()).includes('No tracking branch'),
         'the next hover reads the refreshed selected member');
     assert.equal((await overlay.innerText()).includes('origin/agent-pivot'),
@@ -14961,7 +14966,7 @@ test('CONVERSATION-COMMENTS-PILL-001 shows session · workspace open counts refr
 
     // The tooltip spells out both counts.
     assert.equal(
-        await pill.getAttribute('title'),
+        await pill.getAttribute('data-tooltip'),
         '1 open session comment · 0 open workspace notes — click to review'
     );
 });
@@ -15410,6 +15415,7 @@ test('WORKTREE-CHANGES-PANEL-001 tooltip overlay stays fixed inside the viewport
         hasText: 'file-59.ts',
     });
     await lastRow.hover();
+    await overlay.waitFor({ state: 'visible', timeout: 900 });
     assert.equal(await overlay.isVisible(), true);
     assert.equal(await overlay.innerText(),
         'src/deeply/nested/directory/structure/file-59.ts');
@@ -15427,6 +15433,7 @@ test('WORKTREE-CHANGES-PANEL-001 tooltip overlay stays fixed inside the viewport
         hasText: 'file-00.ts',
     });
     await firstRow.hover();
+    await overlay.waitFor({ state: 'visible', timeout: 900 });
     assert.equal(await overlay.isVisible(), true);
     assertInsideViewport(await overlayBox());
 
@@ -15434,6 +15441,7 @@ test('WORKTREE-CHANGES-PANEL-001 tooltip overlay stays fixed inside the viewport
     // horizontally into the viewport.
     const refresh = page.locator('[data-changes-refresh]');
     await refresh.hover();
+    await overlay.waitFor({ state: 'visible', timeout: 900 });
     assert.equal(await overlay.isVisible(), true);
     assert.equal(await overlay.innerText(), 'Refresh');
     assertInsideViewport(await overlayBox());

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -399,7 +399,7 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 applies an authoritative cross-
             .getAttribute('data-provider'),
         telemetryProviderTitle: document
             .querySelector('[data-telemetry-provider]')
-            .getAttribute('title'),
+            .getAttribute('data-tooltip'),
         displayName: document.querySelector('[data-conversation-display-name]')
             .textContent,
         response: document.querySelector('[data-conversation-messages]')
@@ -1286,8 +1286,14 @@ test('CONVERSATION-TELEMETRY-001 CONVERSATION-TELEMETRY-CONTROLLER-001 renders c
         'codex'
     );
     assert.equal(
-        await page.locator('[data-telemetry-provider]').getAttribute('title'),
+        await page.locator('[data-telemetry-provider]')
+            .getAttribute('data-tooltip'),
         'Provider · Codex'
+    );
+    assert.equal(
+        await page.locator('[data-telemetry-provider]').getAttribute('title'),
+        null,
+        'the CSS tooltip is the only pointer popup'
     );
     assert.equal(
         await page.locator('[data-telemetry-model-value]').textContent(),
@@ -1307,11 +1313,13 @@ test('CONVERSATION-TELEMETRY-001 CONVERSATION-TELEMETRY-CONTROLLER-001 renders c
         '75'
     );
     assert.match(
-        await page.locator('[data-telemetry-context]').getAttribute('title'),
+        await page.locator('[data-telemetry-context]')
+            .getAttribute('data-tooltip'),
         /Context window · 25% used.*32\.0k \/ 128k tokens/s
     );
     assert.match(
-        await page.locator('[data-telemetry-limit]').getAttribute('title'),
+        await page.locator('[data-telemetry-limit]')
+            .getAttribute('data-tooltip'),
         /Week · 40% used · resets in/
     );
 
@@ -2243,7 +2251,7 @@ test('WEBVIEW-AI-SESSION-SUBAGENT-VIEWER-001 lists subagents, opens a transcript
     const counter = rebuilt.page.locator('[data-telemetry-subagents]');
     assert.equal(await counter.isVisible(), true);
     assert.equal(await counter.innerText(), '1/2');
-    assert.match(await counter.getAttribute('title'), /1 running of 2/);
+    assert.match(await counter.getAttribute('data-tooltip'), /1 running of 2/);
     assert.equal(
         await rebuilt.page.locator('[data-conversation-telemetry]').isVisible(),
         true,
@@ -5548,7 +5556,7 @@ test('CONVERSATION-OUTLINE-NAVIGATION-001 keeps every side-panel view usable acr
         .digest('hex');
     assert.equal(
         sha256(previousViewerScript),
-        'd307adde02b9df614873571a3881c1ee96d605eb2b43c36b25ab2e4b684283de',
+        '3440365e5e72ee635395d528feea38051e3a2e962a119bb193b4a686e11b1d93',
         'the previous Viewer fixture must stay byte-exact'
     );
     assert.equal(
@@ -12360,13 +12368,28 @@ test('CONVERSATION-CHROME-LAYOUT-001 keeps header, telemetry, and the message vi
 
     await page.setViewportSize({ width: 700, height: 500 });
     await page.locator('[data-telemetry-context]').hover();
+    await page.waitForTimeout(250);
+    const tooltipBeforeDelay = await page.locator(
+        '[data-telemetry-context]'
+    ).evaluate(element => {
+        const style = getComputedStyle(element, '::after');
+        return { opacity: style.opacity, visibility: style.visibility };
+    });
+    assert.equal(tooltipBeforeDelay.opacity, '0',
+        'brief pointer passes must not immediately show telemetry hints');
+    await page.waitForTimeout(300);
     const tooltipState = await page.locator(
         '[data-telemetry-context]'
     ).evaluate(element => {
         const style = getComputedStyle(element, '::after');
-        return { content: style.content, visibility: style.visibility };
+        return {
+            content: style.content,
+            opacity: style.opacity,
+            visibility: style.visibility,
+        };
     });
     assert.equal(tooltipState.visibility, 'visible');
+    assert.equal(tooltipState.opacity, '1');
     assert.match(tooltipState.content, /Context window/);
     assert.deepEqual(
         await page.locator(
@@ -15255,6 +15278,10 @@ test('WORKTREE-CHANGES-PANEL-001 tooltip overlay opens on hover and focus, and c
     // panel. aria-describedby ties the trigger to it so the visible hint
     // and the spoken description share one source (PRD §17).
     await refresh.hover();
+    await page.waitForTimeout(250);
+    assert.equal(await overlay.count(), 0,
+        'brief pointer passes do not create a tooltip overlay');
+    await overlay.waitFor({ state: 'visible', timeout: 900 });
     assert.equal(await overlay.isVisible(), true);
     assert.equal(await overlay.innerText(), 'Refresh');
     assert.equal(await overlay.getAttribute('role'), 'tooltip');
@@ -15274,8 +15301,11 @@ test('WORKTREE-CHANGES-PANEL-001 tooltip overlay opens on hover and focus, and c
     assert.ok(overlayId, 'the overlay carries an id');
     assert.equal(await refresh.getAttribute('aria-describedby'), overlayId);
 
-    // Moving the mouse away closes the hint and drops the description link.
-    await page.locator('.conversation-changes-group-header').first().hover();
+    // Leaving the Webview itself closes the hint and drops the description
+    // link; no following mouseover event is available to clean it up.
+    await refresh.evaluate(button => button.dispatchEvent(new MouseEvent(
+        'mouseout', { bubbles: true, relatedTarget: null }
+    )));
     assert.equal(await overlay.isHidden(), true);
     assert.equal(await refresh.getAttribute('aria-describedby'), null);
 
@@ -15326,6 +15356,7 @@ test('WORKTREE-CHANGES-PANEL-001 tooltip overlay opens on hover and focus, and c
     await page.locator('[data-telemetry-changes]').click();
     assert.equal(await panel.isVisible(), true);
     await refresh.hover();
+    await overlay.waitFor({ state: 'visible', timeout: 900 });
     assert.equal(await overlay.isVisible(), true);
     await page.locator('[data-telemetry-changes]').click();
     await overlay.waitFor({ state: 'hidden' });

--- a/tests/browser/quickSessionCreate.test.js
+++ b/tests/browser/quickSessionCreate.test.js
@@ -982,7 +982,7 @@ test('AI-SESSION-QUICK-CREATE-001 outside clicks close the dropdown without post
     assert.deepEqual(await postedMessages(page), []);
 });
 
-test('AI-SESSION-QUICK-CREATE-001 the fast tooltip appears promptly on hover and focus', async t => {
+test('AI-SESSION-QUICK-CREATE-001 fast tooltips wait for hover but appear on focus', async t => {
     const page = await openQuickCreatePage(t, { profile: 'deepseek' });
     const quickButton = page.locator(
         '[data-open-session-surface][data-id="project-a"] [data-action="create-ai-session-quick"]'
@@ -990,14 +990,27 @@ test('AI-SESSION-QUICK-CREATE-001 the fast tooltip appears promptly on hover and
     const tip = page.locator('.ai-session-fast-tooltip');
 
     await quickButton.hover();
+    await page.waitForTimeout(250);
+    assert.equal(await tip.count(), 0,
+        'brief pointer passes do not open a tooltip');
     await tip.waitFor({ state: 'visible', timeout: 800 });
     assert.equal(await tip.textContent(), 'Codex · deepseek',
-        'the tooltip must appear well ahead of the native title delay');
+        'the tooltip appears after a deliberate hover pause');
     await page.locator('#outside').hover();
     assert.equal(await tip.count(), 0, 'leaving the button dismisses the tooltip');
 
     await quickButton.focus();
-    await tip.waitFor({ state: 'visible', timeout: 800 });
+    assert.equal(await tip.count(), 1, 'keyboard focus shows the tooltip immediately');
+    await quickButton.evaluate(button => button.dispatchEvent(new MouseEvent('mouseout', {
+        bubbles: true,
+        relatedTarget: null,
+    })));
+    assert.equal(await tip.count(), 0,
+        'leaving the Webview dismisses the tooltip without a follow-up mouseover');
+
+    await page.locator('#outside').focus();
+    await quickButton.focus();
+    assert.equal(await tip.count(), 1);
     await page.locator('#outside').click();
     assert.equal(await tip.count(), 0, 'clicking elsewhere dismisses the tooltip');
 });


### PR DESCRIPTION
## Summary
- Delay Dashboard, Conversation Changes, and Conversation Telemetry pointer tooltips by 400ms.
- Dismiss pending and visible tooltips immediately when the pointer leaves, including when it exits the Webview.
- Keep keyboard focus hints immediate and remove duplicate native telemetry titles.

## Validation
- npm run test-compile
- npm run test:browser:run
- node scripts/run-dashboard-webview-checks.js
- npm run test:architecture-guards
- npm run test:behavior-contracts
- npm run lint
- git diff --check

## Skill harvest
No skill change: the CI failure was a product-specific expectation mismatch after changing tooltip timing. The existing verification workflow was followed; regression coverage now waits for the intentional delay and checks tooltip data rather than removed native titles.

## Owner approvals
~~~text
approve 84cdfe7a67afdd4757e36dd369700a432fbcc9e2
~~~