### PR TITLE
Fix delayed worktree removal confirmation

### DIFF
--- a/docs/testing/architecture-webview-manifest.json
+++ b/docs/testing/architecture-webview-manifest.json
@@ -214,6 +214,13 @@
       ]
     },
     {
+      "symbol": "window.__agentPivotManagedWorktreeRemoval",
+      "producer": "src/webview/webviewProjectAiSessionControlsScripts.js",
+      "consumers": [
+        "src/webview/webviewAiSessionViewStateScripts.js"
+      ]
+    },
+    {
       "symbol": "window.__stewardStickyHeaderObserver",
       "producer": "src/webview/webviewProjectScripts.js",
       "consumers": []

--- a/media/webviewAiSessionViewStateScripts.js
+++ b/media/webviewAiSessionViewStateScripts.js
@@ -525,6 +525,10 @@ function captureAiSessionViewState(projectDiv) {
             && typeof window.__agentPivotWorktreeAdopt.capture === 'function'
             ? window.__agentPivotWorktreeAdopt.capture(projectDiv)
             : null,
+        worktreeRemoval: window.__agentPivotManagedWorktreeRemoval
+            && typeof window.__agentPivotManagedWorktreeRemoval.capture === 'function'
+            ? window.__agentPivotManagedWorktreeRemoval.capture(projectDiv)
+            : null,
         worktreeKeys: Array.from(new Set(Array.from(projectDiv.querySelectorAll(
             '.ai-session-worktree-group'
         )).map(getAiSessionWorktreeGroupKey))),
@@ -583,6 +587,11 @@ function restoreAiSessionViewState(projectDiv, viewState, requestedTab, options)
         && window.__agentPivotWorktreeAdopt
         && typeof window.__agentPivotWorktreeAdopt.restore === 'function') {
         window.__agentPivotWorktreeAdopt.restore(projectDiv, viewState.worktreeAdopt);
+    }
+    if (viewState.worktreeRemoval
+        && window.__agentPivotManagedWorktreeRemoval
+        && typeof window.__agentPivotManagedWorktreeRemoval.restore === 'function') {
+        window.__agentPivotManagedWorktreeRemoval.restore(projectDiv, viewState.worktreeRemoval);
     }
     var currentWorktreeKeys = Array.from(new Set(Array.from(projectDiv.querySelectorAll(
         '.ai-session-worktree-group'

--- a/media/webviewDashboardBundle.js
+++ b/media/webviewDashboardBundle.js
@@ -5252,10 +5252,21 @@ function initProjectAiSessionControls(options) {
         var requestId = 'worktree-remove-' + nextManagedWorktreeRemovalRequestId.toString(36);
         button.disabled = true;
         button.setAttribute('aria-disabled', 'true');
+        button.setAttribute('aria-busy', 'true');
+        var pendingLabel = 'Preparing worktree removal…';
         pendingManagedWorktreeRemovalRequests.set(requestId, {
             button: button,
             projectId: projectId,
+            ariaLabel: button.getAttribute('aria-label'),
+            tooltip: button.getAttribute('data-tooltip'),
         });
+        button.setAttribute('aria-label', pendingLabel);
+        button.setAttribute('data-tooltip', pendingLabel);
+        var pendingProject = getAiSessionsUpdate().findCurrentWorkspaceDiv(projectId);
+        var pendingLiveRegion = pendingProject?.querySelector('[data-ai-session-live-region]');
+        if (pendingLiveRegion) {
+            pendingLiveRegion.textContent = pendingLabel;
+        }
         window.vscode.postMessage({
             type: 'remove-managed-worktree', version: 1,
             requestId: requestId, projectId: projectId,
@@ -5283,6 +5294,17 @@ function initProjectAiSessionControls(options) {
         if (pending.button && pending.button.isConnected) {
             pending.button.disabled = false;
             pending.button.removeAttribute('aria-disabled');
+            pending.button.removeAttribute('aria-busy');
+            if (pending.ariaLabel === null) {
+                pending.button.removeAttribute('aria-label');
+            } else {
+                pending.button.setAttribute('aria-label', pending.ariaLabel);
+            }
+            if (pending.tooltip === null) {
+                pending.button.removeAttribute('data-tooltip');
+            } else {
+                pending.button.setAttribute('data-tooltip', pending.tooltip);
+            }
         }
         var projectDiv = getAiSessionsUpdate().findCurrentWorkspaceDiv(pending.projectId);
         var liveRegion = projectDiv?.querySelector('[data-ai-session-live-region]');

--- a/media/webviewDashboardBundle.js
+++ b/media/webviewDashboardBundle.js
@@ -607,6 +607,10 @@ function captureAiSessionViewState(projectDiv) {
             && typeof window.__agentPivotWorktreeAdopt.capture === 'function'
             ? window.__agentPivotWorktreeAdopt.capture(projectDiv)
             : null,
+        worktreeRemoval: window.__agentPivotManagedWorktreeRemoval
+            && typeof window.__agentPivotManagedWorktreeRemoval.capture === 'function'
+            ? window.__agentPivotManagedWorktreeRemoval.capture(projectDiv)
+            : null,
         worktreeKeys: Array.from(new Set(Array.from(projectDiv.querySelectorAll(
             '.ai-session-worktree-group'
         )).map(getAiSessionWorktreeGroupKey))),
@@ -665,6 +669,11 @@ function restoreAiSessionViewState(projectDiv, viewState, requestedTab, options)
         && window.__agentPivotWorktreeAdopt
         && typeof window.__agentPivotWorktreeAdopt.restore === 'function') {
         window.__agentPivotWorktreeAdopt.restore(projectDiv, viewState.worktreeAdopt);
+    }
+    if (viewState.worktreeRemoval
+        && window.__agentPivotManagedWorktreeRemoval
+        && typeof window.__agentPivotManagedWorktreeRemoval.restore === 'function') {
+        window.__agentPivotManagedWorktreeRemoval.restore(projectDiv, viewState.worktreeRemoval);
     }
     var currentWorktreeKeys = Array.from(new Set(Array.from(projectDiv.querySelectorAll(
         '.ai-session-worktree-group'
@@ -4276,6 +4285,10 @@ function initProjectAiSessionControls(options) {
     var pendingIsolatedSessionRequests = new Map();
     var nextManagedWorktreeRemovalRequestId = 0;
     var pendingManagedWorktreeRemovalRequests = new Map();
+    // The Host's replay cache survives a Webview reload. Keep removal ids
+    // document-unique so a late settlement from the old document cannot
+    // release the new document's pending control.
+    var managedWorktreeRemovalDocumentNonce = Math.random().toString(36).slice(2, 10);
     var nextMergeWorktreeGroupsRequestId = 0;
     var pendingMergeWorktreeGroupsRequests = new Map();
     // A per-document nonce keeps merge request ids unique across webview
@@ -5249,19 +5262,19 @@ function initProjectAiSessionControls(options) {
         if (!repositoryKey || !worktreePath) return;
         nextManagedWorktreeRemovalRequestId = nextManagedWorktreeRemovalRequestId
             >= Number.MAX_SAFE_INTEGER ? 1 : nextManagedWorktreeRemovalRequestId + 1;
-        var requestId = 'worktree-remove-' + nextManagedWorktreeRemovalRequestId.toString(36);
-        button.disabled = true;
-        button.setAttribute('aria-disabled', 'true');
-        button.setAttribute('aria-busy', 'true');
+        var requestId = 'worktree-remove-' + managedWorktreeRemovalDocumentNonce
+            + '-' + nextManagedWorktreeRemovalRequestId.toString(36);
         var pendingLabel = 'Preparing worktree removal…';
-        pendingManagedWorktreeRemovalRequests.set(requestId, {
+        var pending = {
             button: button,
             projectId: projectId,
+            repositoryKey: repositoryKey,
+            worktreePath: worktreePath,
             ariaLabel: button.getAttribute('aria-label'),
             tooltip: button.getAttribute('data-tooltip'),
-        });
-        button.setAttribute('aria-label', pendingLabel);
-        button.setAttribute('data-tooltip', pendingLabel);
+        };
+        pendingManagedWorktreeRemovalRequests.set(requestId, pending);
+        setManagedWorktreeRemovalButtonPending(button, pendingLabel);
         var pendingProject = getAiSessionsUpdate().findCurrentWorkspaceDiv(projectId);
         var pendingLiveRegion = pendingProject?.querySelector('[data-ai-session-live-region]');
         if (pendingLiveRegion) {
@@ -5291,21 +5304,7 @@ function initProjectAiSessionControls(options) {
         if (!pending) return true;
         if (message.status === 'accepted') return true;
         pendingManagedWorktreeRemovalRequests.delete(message.requestId);
-        if (pending.button && pending.button.isConnected) {
-            pending.button.disabled = false;
-            pending.button.removeAttribute('aria-disabled');
-            pending.button.removeAttribute('aria-busy');
-            if (pending.ariaLabel === null) {
-                pending.button.removeAttribute('aria-label');
-            } else {
-                pending.button.setAttribute('aria-label', pending.ariaLabel);
-            }
-            if (pending.tooltip === null) {
-                pending.button.removeAttribute('data-tooltip');
-            } else {
-                pending.button.setAttribute('data-tooltip', pending.tooltip);
-            }
-        }
+        restoreManagedWorktreeRemovalButton(pending.button, pending);
         var projectDiv = getAiSessionsUpdate().findCurrentWorkspaceDiv(pending.projectId);
         var liveRegion = projectDiv?.querySelector('[data-ai-session-live-region]');
         if (liveRegion) {
@@ -5317,6 +5316,75 @@ function initProjectAiSessionControls(options) {
         }
         return true;
     }
+
+    function setManagedWorktreeRemovalButtonPending(button, label) {
+        if (!button) return;
+        button.disabled = true;
+        button.setAttribute('aria-disabled', 'true');
+        button.setAttribute('aria-busy', 'true');
+        button.setAttribute('aria-label', label);
+        button.setAttribute('data-tooltip', label);
+    }
+
+    function restoreManagedWorktreeRemovalButton(button, pending) {
+        if (!button || !pending || !button.isConnected) return;
+        button.disabled = false;
+        button.removeAttribute('aria-disabled');
+        button.removeAttribute('aria-busy');
+        if (pending.ariaLabel === null) {
+            button.removeAttribute('aria-label');
+        } else {
+            button.setAttribute('aria-label', pending.ariaLabel);
+        }
+        if (pending.tooltip === null) {
+            button.removeAttribute('data-tooltip');
+        } else {
+            button.setAttribute('data-tooltip', pending.tooltip);
+        }
+    }
+
+    function captureManagedWorktreeRemovalState(projectDiv) {
+        if (!projectDiv || typeof projectDiv.getAttribute !== 'function') return [];
+        var projectId = projectDiv.getAttribute('data-id');
+        var pending = [];
+        pendingManagedWorktreeRemovalRequests.forEach((entry, requestId) => {
+            if (entry.projectId === projectId) {
+                pending.push({
+                    requestId: requestId,
+                    repositoryKey: entry.repositoryKey,
+                    worktreePath: entry.worktreePath,
+                });
+            }
+        });
+        return pending;
+    }
+
+    function restoreManagedWorktreeRemovalState(projectDiv, state) {
+        if (!projectDiv || !Array.isArray(state)) return;
+        state.forEach(item => {
+            if (!item || typeof item.requestId !== 'string'
+                || typeof item.repositoryKey !== 'string' || typeof item.worktreePath !== 'string') {
+                return;
+            }
+            var pending = pendingManagedWorktreeRemovalRequests.get(item.requestId);
+            if (!pending || pending.repositoryKey !== item.repositoryKey
+                || pending.worktreePath !== item.worktreePath) return;
+            var group = projectDiv.querySelector(
+                '.ai-session-worktree-group[data-worktree-repository-key="'
+                + CSS.escape(item.repositoryKey) + '"][data-worktree-path="'
+                + CSS.escape(item.worktreePath) + '"]'
+            );
+            var button = group && group.querySelector('.ai-session-worktree-more');
+            if (!button) return;
+            pending.button = button;
+            setManagedWorktreeRemovalButtonPending(button, 'Preparing worktree removal…');
+        });
+    }
+
+    window.__agentPivotManagedWorktreeRemoval = {
+        capture: captureManagedWorktreeRemovalState,
+        restore: restoreManagedWorktreeRemovalState,
+    };
 
     function submitSetGroupPrimaryRequest(projectId, button) {
         var groupId = button && button.getAttribute('data-group-id');

--- a/media/webviewProjectAiSessionControlsScripts.js
+++ b/media/webviewProjectAiSessionControlsScripts.js
@@ -99,6 +99,10 @@ function initProjectAiSessionControls(options) {
     var pendingIsolatedSessionRequests = new Map();
     var nextManagedWorktreeRemovalRequestId = 0;
     var pendingManagedWorktreeRemovalRequests = new Map();
+    // The Host's replay cache survives a Webview reload. Keep removal ids
+    // document-unique so a late settlement from the old document cannot
+    // release the new document's pending control.
+    var managedWorktreeRemovalDocumentNonce = Math.random().toString(36).slice(2, 10);
     var nextMergeWorktreeGroupsRequestId = 0;
     var pendingMergeWorktreeGroupsRequests = new Map();
     // A per-document nonce keeps merge request ids unique across webview
@@ -1072,19 +1076,19 @@ function initProjectAiSessionControls(options) {
         if (!repositoryKey || !worktreePath) return;
         nextManagedWorktreeRemovalRequestId = nextManagedWorktreeRemovalRequestId
             >= Number.MAX_SAFE_INTEGER ? 1 : nextManagedWorktreeRemovalRequestId + 1;
-        var requestId = 'worktree-remove-' + nextManagedWorktreeRemovalRequestId.toString(36);
-        button.disabled = true;
-        button.setAttribute('aria-disabled', 'true');
-        button.setAttribute('aria-busy', 'true');
+        var requestId = 'worktree-remove-' + managedWorktreeRemovalDocumentNonce
+            + '-' + nextManagedWorktreeRemovalRequestId.toString(36);
         var pendingLabel = 'Preparing worktree removal…';
-        pendingManagedWorktreeRemovalRequests.set(requestId, {
+        var pending = {
             button: button,
             projectId: projectId,
+            repositoryKey: repositoryKey,
+            worktreePath: worktreePath,
             ariaLabel: button.getAttribute('aria-label'),
             tooltip: button.getAttribute('data-tooltip'),
-        });
-        button.setAttribute('aria-label', pendingLabel);
-        button.setAttribute('data-tooltip', pendingLabel);
+        };
+        pendingManagedWorktreeRemovalRequests.set(requestId, pending);
+        setManagedWorktreeRemovalButtonPending(button, pendingLabel);
         var pendingProject = getAiSessionsUpdate().findCurrentWorkspaceDiv(projectId);
         var pendingLiveRegion = pendingProject?.querySelector('[data-ai-session-live-region]');
         if (pendingLiveRegion) {
@@ -1114,21 +1118,7 @@ function initProjectAiSessionControls(options) {
         if (!pending) return true;
         if (message.status === 'accepted') return true;
         pendingManagedWorktreeRemovalRequests.delete(message.requestId);
-        if (pending.button && pending.button.isConnected) {
-            pending.button.disabled = false;
-            pending.button.removeAttribute('aria-disabled');
-            pending.button.removeAttribute('aria-busy');
-            if (pending.ariaLabel === null) {
-                pending.button.removeAttribute('aria-label');
-            } else {
-                pending.button.setAttribute('aria-label', pending.ariaLabel);
-            }
-            if (pending.tooltip === null) {
-                pending.button.removeAttribute('data-tooltip');
-            } else {
-                pending.button.setAttribute('data-tooltip', pending.tooltip);
-            }
-        }
+        restoreManagedWorktreeRemovalButton(pending.button, pending);
         var projectDiv = getAiSessionsUpdate().findCurrentWorkspaceDiv(pending.projectId);
         var liveRegion = projectDiv?.querySelector('[data-ai-session-live-region]');
         if (liveRegion) {
@@ -1140,6 +1130,75 @@ function initProjectAiSessionControls(options) {
         }
         return true;
     }
+
+    function setManagedWorktreeRemovalButtonPending(button, label) {
+        if (!button) return;
+        button.disabled = true;
+        button.setAttribute('aria-disabled', 'true');
+        button.setAttribute('aria-busy', 'true');
+        button.setAttribute('aria-label', label);
+        button.setAttribute('data-tooltip', label);
+    }
+
+    function restoreManagedWorktreeRemovalButton(button, pending) {
+        if (!button || !pending || !button.isConnected) return;
+        button.disabled = false;
+        button.removeAttribute('aria-disabled');
+        button.removeAttribute('aria-busy');
+        if (pending.ariaLabel === null) {
+            button.removeAttribute('aria-label');
+        } else {
+            button.setAttribute('aria-label', pending.ariaLabel);
+        }
+        if (pending.tooltip === null) {
+            button.removeAttribute('data-tooltip');
+        } else {
+            button.setAttribute('data-tooltip', pending.tooltip);
+        }
+    }
+
+    function captureManagedWorktreeRemovalState(projectDiv) {
+        if (!projectDiv || typeof projectDiv.getAttribute !== 'function') return [];
+        var projectId = projectDiv.getAttribute('data-id');
+        var pending = [];
+        pendingManagedWorktreeRemovalRequests.forEach((entry, requestId) => {
+            if (entry.projectId === projectId) {
+                pending.push({
+                    requestId: requestId,
+                    repositoryKey: entry.repositoryKey,
+                    worktreePath: entry.worktreePath,
+                });
+            }
+        });
+        return pending;
+    }
+
+    function restoreManagedWorktreeRemovalState(projectDiv, state) {
+        if (!projectDiv || !Array.isArray(state)) return;
+        state.forEach(item => {
+            if (!item || typeof item.requestId !== 'string'
+                || typeof item.repositoryKey !== 'string' || typeof item.worktreePath !== 'string') {
+                return;
+            }
+            var pending = pendingManagedWorktreeRemovalRequests.get(item.requestId);
+            if (!pending || pending.repositoryKey !== item.repositoryKey
+                || pending.worktreePath !== item.worktreePath) return;
+            var group = projectDiv.querySelector(
+                '.ai-session-worktree-group[data-worktree-repository-key="'
+                + CSS.escape(item.repositoryKey) + '"][data-worktree-path="'
+                + CSS.escape(item.worktreePath) + '"]'
+            );
+            var button = group && group.querySelector('.ai-session-worktree-more');
+            if (!button) return;
+            pending.button = button;
+            setManagedWorktreeRemovalButtonPending(button, 'Preparing worktree removal…');
+        });
+    }
+
+    window.__agentPivotManagedWorktreeRemoval = {
+        capture: captureManagedWorktreeRemovalState,
+        restore: restoreManagedWorktreeRemovalState,
+    };
 
     function submitSetGroupPrimaryRequest(projectId, button) {
         var groupId = button && button.getAttribute('data-group-id');

--- a/media/webviewProjectAiSessionControlsScripts.js
+++ b/media/webviewProjectAiSessionControlsScripts.js
@@ -1075,10 +1075,21 @@ function initProjectAiSessionControls(options) {
         var requestId = 'worktree-remove-' + nextManagedWorktreeRemovalRequestId.toString(36);
         button.disabled = true;
         button.setAttribute('aria-disabled', 'true');
+        button.setAttribute('aria-busy', 'true');
+        var pendingLabel = 'Preparing worktree removal…';
         pendingManagedWorktreeRemovalRequests.set(requestId, {
             button: button,
             projectId: projectId,
+            ariaLabel: button.getAttribute('aria-label'),
+            tooltip: button.getAttribute('data-tooltip'),
         });
+        button.setAttribute('aria-label', pendingLabel);
+        button.setAttribute('data-tooltip', pendingLabel);
+        var pendingProject = getAiSessionsUpdate().findCurrentWorkspaceDiv(projectId);
+        var pendingLiveRegion = pendingProject?.querySelector('[data-ai-session-live-region]');
+        if (pendingLiveRegion) {
+            pendingLiveRegion.textContent = pendingLabel;
+        }
         window.vscode.postMessage({
             type: 'remove-managed-worktree', version: 1,
             requestId: requestId, projectId: projectId,
@@ -1106,6 +1117,17 @@ function initProjectAiSessionControls(options) {
         if (pending.button && pending.button.isConnected) {
             pending.button.disabled = false;
             pending.button.removeAttribute('aria-disabled');
+            pending.button.removeAttribute('aria-busy');
+            if (pending.ariaLabel === null) {
+                pending.button.removeAttribute('aria-label');
+            } else {
+                pending.button.setAttribute('aria-label', pending.ariaLabel);
+            }
+            if (pending.tooltip === null) {
+                pending.button.removeAttribute('data-tooltip');
+            } else {
+                pending.button.setAttribute('data-tooltip', pending.tooltip);
+            }
         }
         var projectDiv = getAiSessionsUpdate().findCurrentWorkspaceDiv(pending.projectId);
         var liveRegion = projectDiv?.querySelector('[data-ai-session-live-region]');

--- a/src/webview/webviewAiSessionViewStateScripts.js
+++ b/src/webview/webviewAiSessionViewStateScripts.js
@@ -525,6 +525,10 @@ function captureAiSessionViewState(projectDiv) {
             && typeof window.__agentPivotWorktreeAdopt.capture === 'function'
             ? window.__agentPivotWorktreeAdopt.capture(projectDiv)
             : null,
+        worktreeRemoval: window.__agentPivotManagedWorktreeRemoval
+            && typeof window.__agentPivotManagedWorktreeRemoval.capture === 'function'
+            ? window.__agentPivotManagedWorktreeRemoval.capture(projectDiv)
+            : null,
         worktreeKeys: Array.from(new Set(Array.from(projectDiv.querySelectorAll(
             '.ai-session-worktree-group'
         )).map(getAiSessionWorktreeGroupKey))),
@@ -583,6 +587,11 @@ function restoreAiSessionViewState(projectDiv, viewState, requestedTab, options)
         && window.__agentPivotWorktreeAdopt
         && typeof window.__agentPivotWorktreeAdopt.restore === 'function') {
         window.__agentPivotWorktreeAdopt.restore(projectDiv, viewState.worktreeAdopt);
+    }
+    if (viewState.worktreeRemoval
+        && window.__agentPivotManagedWorktreeRemoval
+        && typeof window.__agentPivotManagedWorktreeRemoval.restore === 'function') {
+        window.__agentPivotManagedWorktreeRemoval.restore(projectDiv, viewState.worktreeRemoval);
     }
     var currentWorktreeKeys = Array.from(new Set(Array.from(projectDiv.querySelectorAll(
         '.ai-session-worktree-group'

--- a/src/webview/webviewProjectAiSessionControlsScripts.js
+++ b/src/webview/webviewProjectAiSessionControlsScripts.js
@@ -99,6 +99,10 @@ function initProjectAiSessionControls(options) {
     var pendingIsolatedSessionRequests = new Map();
     var nextManagedWorktreeRemovalRequestId = 0;
     var pendingManagedWorktreeRemovalRequests = new Map();
+    // The Host's replay cache survives a Webview reload. Keep removal ids
+    // document-unique so a late settlement from the old document cannot
+    // release the new document's pending control.
+    var managedWorktreeRemovalDocumentNonce = Math.random().toString(36).slice(2, 10);
     var nextMergeWorktreeGroupsRequestId = 0;
     var pendingMergeWorktreeGroupsRequests = new Map();
     // A per-document nonce keeps merge request ids unique across webview
@@ -1072,19 +1076,19 @@ function initProjectAiSessionControls(options) {
         if (!repositoryKey || !worktreePath) return;
         nextManagedWorktreeRemovalRequestId = nextManagedWorktreeRemovalRequestId
             >= Number.MAX_SAFE_INTEGER ? 1 : nextManagedWorktreeRemovalRequestId + 1;
-        var requestId = 'worktree-remove-' + nextManagedWorktreeRemovalRequestId.toString(36);
-        button.disabled = true;
-        button.setAttribute('aria-disabled', 'true');
-        button.setAttribute('aria-busy', 'true');
+        var requestId = 'worktree-remove-' + managedWorktreeRemovalDocumentNonce
+            + '-' + nextManagedWorktreeRemovalRequestId.toString(36);
         var pendingLabel = 'Preparing worktree removal…';
-        pendingManagedWorktreeRemovalRequests.set(requestId, {
+        var pending = {
             button: button,
             projectId: projectId,
+            repositoryKey: repositoryKey,
+            worktreePath: worktreePath,
             ariaLabel: button.getAttribute('aria-label'),
             tooltip: button.getAttribute('data-tooltip'),
-        });
-        button.setAttribute('aria-label', pendingLabel);
-        button.setAttribute('data-tooltip', pendingLabel);
+        };
+        pendingManagedWorktreeRemovalRequests.set(requestId, pending);
+        setManagedWorktreeRemovalButtonPending(button, pendingLabel);
         var pendingProject = getAiSessionsUpdate().findCurrentWorkspaceDiv(projectId);
         var pendingLiveRegion = pendingProject?.querySelector('[data-ai-session-live-region]');
         if (pendingLiveRegion) {
@@ -1114,21 +1118,7 @@ function initProjectAiSessionControls(options) {
         if (!pending) return true;
         if (message.status === 'accepted') return true;
         pendingManagedWorktreeRemovalRequests.delete(message.requestId);
-        if (pending.button && pending.button.isConnected) {
-            pending.button.disabled = false;
-            pending.button.removeAttribute('aria-disabled');
-            pending.button.removeAttribute('aria-busy');
-            if (pending.ariaLabel === null) {
-                pending.button.removeAttribute('aria-label');
-            } else {
-                pending.button.setAttribute('aria-label', pending.ariaLabel);
-            }
-            if (pending.tooltip === null) {
-                pending.button.removeAttribute('data-tooltip');
-            } else {
-                pending.button.setAttribute('data-tooltip', pending.tooltip);
-            }
-        }
+        restoreManagedWorktreeRemovalButton(pending.button, pending);
         var projectDiv = getAiSessionsUpdate().findCurrentWorkspaceDiv(pending.projectId);
         var liveRegion = projectDiv?.querySelector('[data-ai-session-live-region]');
         if (liveRegion) {
@@ -1140,6 +1130,75 @@ function initProjectAiSessionControls(options) {
         }
         return true;
     }
+
+    function setManagedWorktreeRemovalButtonPending(button, label) {
+        if (!button) return;
+        button.disabled = true;
+        button.setAttribute('aria-disabled', 'true');
+        button.setAttribute('aria-busy', 'true');
+        button.setAttribute('aria-label', label);
+        button.setAttribute('data-tooltip', label);
+    }
+
+    function restoreManagedWorktreeRemovalButton(button, pending) {
+        if (!button || !pending || !button.isConnected) return;
+        button.disabled = false;
+        button.removeAttribute('aria-disabled');
+        button.removeAttribute('aria-busy');
+        if (pending.ariaLabel === null) {
+            button.removeAttribute('aria-label');
+        } else {
+            button.setAttribute('aria-label', pending.ariaLabel);
+        }
+        if (pending.tooltip === null) {
+            button.removeAttribute('data-tooltip');
+        } else {
+            button.setAttribute('data-tooltip', pending.tooltip);
+        }
+    }
+
+    function captureManagedWorktreeRemovalState(projectDiv) {
+        if (!projectDiv || typeof projectDiv.getAttribute !== 'function') return [];
+        var projectId = projectDiv.getAttribute('data-id');
+        var pending = [];
+        pendingManagedWorktreeRemovalRequests.forEach((entry, requestId) => {
+            if (entry.projectId === projectId) {
+                pending.push({
+                    requestId: requestId,
+                    repositoryKey: entry.repositoryKey,
+                    worktreePath: entry.worktreePath,
+                });
+            }
+        });
+        return pending;
+    }
+
+    function restoreManagedWorktreeRemovalState(projectDiv, state) {
+        if (!projectDiv || !Array.isArray(state)) return;
+        state.forEach(item => {
+            if (!item || typeof item.requestId !== 'string'
+                || typeof item.repositoryKey !== 'string' || typeof item.worktreePath !== 'string') {
+                return;
+            }
+            var pending = pendingManagedWorktreeRemovalRequests.get(item.requestId);
+            if (!pending || pending.repositoryKey !== item.repositoryKey
+                || pending.worktreePath !== item.worktreePath) return;
+            var group = projectDiv.querySelector(
+                '.ai-session-worktree-group[data-worktree-repository-key="'
+                + CSS.escape(item.repositoryKey) + '"][data-worktree-path="'
+                + CSS.escape(item.worktreePath) + '"]'
+            );
+            var button = group && group.querySelector('.ai-session-worktree-more');
+            if (!button) return;
+            pending.button = button;
+            setManagedWorktreeRemovalButtonPending(button, 'Preparing worktree removal…');
+        });
+    }
+
+    window.__agentPivotManagedWorktreeRemoval = {
+        capture: captureManagedWorktreeRemovalState,
+        restore: restoreManagedWorktreeRemovalState,
+    };
 
     function submitSetGroupPrimaryRequest(projectId, button) {
         var groupId = button && button.getAttribute('data-group-id');

--- a/src/webview/webviewProjectAiSessionControlsScripts.js
+++ b/src/webview/webviewProjectAiSessionControlsScripts.js
@@ -1075,10 +1075,21 @@ function initProjectAiSessionControls(options) {
         var requestId = 'worktree-remove-' + nextManagedWorktreeRemovalRequestId.toString(36);
         button.disabled = true;
         button.setAttribute('aria-disabled', 'true');
+        button.setAttribute('aria-busy', 'true');
+        var pendingLabel = 'Preparing worktree removal…';
         pendingManagedWorktreeRemovalRequests.set(requestId, {
             button: button,
             projectId: projectId,
+            ariaLabel: button.getAttribute('aria-label'),
+            tooltip: button.getAttribute('data-tooltip'),
         });
+        button.setAttribute('aria-label', pendingLabel);
+        button.setAttribute('data-tooltip', pendingLabel);
+        var pendingProject = getAiSessionsUpdate().findCurrentWorkspaceDiv(projectId);
+        var pendingLiveRegion = pendingProject?.querySelector('[data-ai-session-live-region]');
+        if (pendingLiveRegion) {
+            pendingLiveRegion.textContent = pendingLabel;
+        }
         window.vscode.postMessage({
             type: 'remove-managed-worktree', version: 1,
             requestId: requestId, projectId: projectId,
@@ -1106,6 +1117,17 @@ function initProjectAiSessionControls(options) {
         if (pending.button && pending.button.isConnected) {
             pending.button.disabled = false;
             pending.button.removeAttribute('aria-disabled');
+            pending.button.removeAttribute('aria-busy');
+            if (pending.ariaLabel === null) {
+                pending.button.removeAttribute('aria-label');
+            } else {
+                pending.button.setAttribute('aria-label', pending.ariaLabel);
+            }
+            if (pending.tooltip === null) {
+                pending.button.removeAttribute('data-tooltip');
+            } else {
+                pending.button.setAttribute('data-tooltip', pending.tooltip);
+            }
         }
         var projectDiv = getAiSessionsUpdate().findCurrentWorkspaceDiv(pending.projectId);
         var liveRegion = projectDiv?.querySelector('[data-ai-session-live-region]');

--- a/src/worktrees/managedWorktreeRemovalController.ts
+++ b/src/worktrees/managedWorktreeRemovalController.ts
@@ -71,13 +71,25 @@ export class ManagedWorktreeRemovalController {
         const workspaceIdentity = this.options.getWorkspaceIdentity?.(projectId) ?? null;
         try {
             const initial = this.resolveTarget(key);
-            const blocked = await this.getBlocker(initial, key);
-            if (blocked) {
-                return { kind: 'rejected', errorCode: blocked };
+            // These in-memory guards are instantaneous and avoid presenting
+            // a destructive confirmation for a target the dashboard already
+            // knows cannot be removed. The Git-backed checks remain after
+            // confirmation below, where they also catch races.
+            if (this.options.isActive(key)) {
+                return { kind: 'rejected', errorCode: 'worktree-active' };
+            }
+            if (this.options.isOpenWorkspace(key)) {
+                return { kind: 'rejected', errorCode: 'worktree-open' };
+            }
+            if (this.options.isProvisioning(key)) {
+                return { kind: 'rejected', errorCode: 'worktree-provisioning' };
             }
             // The confirm label tolerates a stale/prunable snapshot entry:
             // a worktree whose directory is already gone still needs a
-            // readable name in the dialog.
+            // readable name in the dialog. Do not put the Git safety check
+            // ahead of this dialog: a slow filesystem or Git process made a
+            // click appear to do nothing for up to its timeout. The full
+            // check below remains immediately before the destructive command.
             const snapshotWorktree = this.options.getSnapshot()?.repositories
                 .find(candidate => candidate.repositoryKey === key.repositoryKey)
                 ?.worktrees.find(candidate => worktreeKeysEqual(candidate.key, key));

--- a/src/worktrees/managedWorktreeRemovalController.ts
+++ b/src/worktrees/managedWorktreeRemovalController.ts
@@ -71,6 +71,9 @@ export class ManagedWorktreeRemovalController {
         const workspaceIdentity = this.options.getWorkspaceIdentity?.(projectId) ?? null;
         try {
             const initial = this.resolveTarget(key);
+            const snapshotWorktree = this.options.getSnapshot()?.repositories
+                .find(candidate => candidate.repositoryKey === key.repositoryKey)
+                ?.worktrees.find(candidate => worktreeKeysEqual(candidate.key, key));
             // These in-memory guards are instantaneous and avoid presenting
             // a destructive confirmation for a target the dashboard already
             // knows cannot be removed. The Git-backed checks remain after
@@ -84,15 +87,21 @@ export class ManagedWorktreeRemovalController {
             if (this.options.isProvisioning(key)) {
                 return { kind: 'rejected', errorCode: 'worktree-provisioning' };
             }
+            // A confirmation may only describe a currently removable
+            // worktree, except for an explicitly discovered stale entry
+            // whose missing directory needs record cleanup. Do not let a
+            // protocol-valid but otherwise arbitrary absolute path produce a
+            // misleading destructive dialog.
+            if (!initial && (!isStaleMissingWorktree(snapshotWorktree)
+                || await this.pathExists(key.canonicalWorktreePath))) {
+                return { kind: 'rejected', errorCode: 'worktree-not-removable' };
+            }
             // The confirm label tolerates a stale/prunable snapshot entry:
             // a worktree whose directory is already gone still needs a
             // readable name in the dialog. Do not put the Git safety check
             // ahead of this dialog: a slow filesystem or Git process made a
             // click appear to do nothing for up to its timeout. The full
             // check below remains immediately before the destructive command.
-            const snapshotWorktree = this.options.getSnapshot()?.repositories
-                .find(candidate => candidate.repositoryKey === key.repositoryKey)
-                ?.worktrees.find(candidate => worktreeKeysEqual(candidate.key, key));
             const branch = (initial?.worktree || snapshotWorktree)?.branchRef
                 ?.replace(/^refs\/heads\//u, '')
                 || initial?.worktree.head.substring(0, 8)
@@ -106,7 +115,15 @@ export class ManagedWorktreeRemovalController {
                 return { kind: 'cancelled' };
             }
             const current = this.resolveTarget(key);
-            const currentBlocker = await this.getBlocker(current, key);
+            // Bind the destructive action to the exact snapshot identity the
+            // user confirmed. A refresh cannot substitute a different
+            // worktree at the same path while the native dialog is open.
+            if ((initial && (!current
+                || !sameWorktreeIdentity(initial.worktree, current.worktree)))
+                || (!initial && current)) {
+                return { kind: 'rejected', errorCode: 'worktree-identity-changed' };
+            }
+            const currentBlocker = await this.getBlocker(current, key, initial?.worktree);
             if (currentBlocker) {
                 return { kind: 'rejected', errorCode: currentBlocker };
             }
@@ -231,7 +248,11 @@ export class ManagedWorktreeRemovalController {
         } catch (_error) { /* best-effort */ }
     }
 
-    private async getBlocker(target: RemovalTarget | null, key: WorktreeKey): Promise<string | null> {
+    private async getBlocker(
+        target: RemovalTarget | null,
+        key: WorktreeKey,
+        expectedWorktree: WorktreeGitSnapshot | undefined = target?.worktree,
+    ): Promise<string | null> {
         if (!target) {
             // A physically absent directory is a certain observation:
             // nothing blocks the removal; only record cleanup remains.
@@ -251,11 +272,10 @@ export class ManagedWorktreeRemovalController {
         if (this.options.isProvisioning(key)) {
             return 'worktree-provisioning';
         }
-        const [status, topLevel, commonDir, branchRef] = await Promise.all([
-            this.runGit(key.canonicalWorktreePath, [
-                '-C', key.canonicalWorktreePath,
-                'status', '--porcelain=v1', '--untracked-files=normal',
-            ]),
+        if (!expectedWorktree || !sameWorktreeIdentity(target.worktree, expectedWorktree)) {
+            return 'worktree-identity-changed';
+        }
+        const [topLevel, commonDir] = await Promise.all([
             this.runGit(key.canonicalWorktreePath, [
                 '-C', key.canonicalWorktreePath,
                 'rev-parse', '--path-format=absolute', '--show-toplevel',
@@ -264,19 +284,9 @@ export class ManagedWorktreeRemovalController {
                 '-C', key.canonicalWorktreePath,
                 'rev-parse', '--path-format=absolute', '--git-common-dir',
             ]),
-            this.runGit(key.canonicalWorktreePath, [
-                '-C', key.canonicalWorktreePath,
-                'rev-parse', '--symbolic-full-name', 'HEAD',
-            ]),
         ]);
-        if (status.exitCode !== 0 || status.timedOut
-            || topLevel.exitCode !== 0 || commonDir.exitCode !== 0
-            || branchRef.exitCode !== 0) {
+        if (topLevel.exitCode !== 0 || commonDir.exitCode !== 0) {
             return 'worktree-status-failed';
-        }
-        const expectedBranchRef = target.worktree.branchRef || 'HEAD';
-        if (firstLine(branchRef.stdout) !== expectedBranchRef) {
-            return 'worktree-identity-changed';
         }
         try {
             const [actualPath, plannedPath, actualRepository, plannedRepository] =
@@ -301,7 +311,35 @@ export class ManagedWorktreeRemovalController {
         if (this.options.isProvisioning(key)) {
             return 'worktree-provisioning';
         }
-        return status.stdout.trim() ? 'worktree-dirty' : null;
+        // Read cleanliness, branch and HEAD together only after all slower
+        // path/runtime checks. A separate status + symbolic-ref + rev-parse
+        // sequence can splice observations from two checkouts when a user
+        // switches worktrees in the middle of the preflight.
+        const status = await this.runGit(key.canonicalWorktreePath, [
+            '-C', key.canonicalWorktreePath,
+            'status', '--porcelain=v2', '--branch', '--untracked-files=normal',
+        ]);
+        if (status.exitCode !== 0 || status.timedOut) {
+            return 'worktree-status-failed';
+        }
+        const observed = parseStatusIdentity(status.stdout, expectedWorktree.head);
+        const expectedBranchRef = expectedWorktree.branchRef || 'HEAD';
+        if (!observed) {
+            return 'worktree-status-failed';
+        }
+        if (observed.branchRef !== expectedBranchRef || observed.head !== expectedWorktree.head) {
+            return 'worktree-identity-changed';
+        }
+        if (this.options.isActive(key)) {
+            return 'worktree-active';
+        }
+        if (this.options.isOpenWorkspace(key)) {
+            return 'worktree-open';
+        }
+        if (this.options.isProvisioning(key)) {
+            return 'worktree-provisioning';
+        }
+        return observed.dirty ? 'worktree-dirty' : null;
     }
 }
 
@@ -323,4 +361,57 @@ async function canonicalizeExistingPath(candidatePath: string): Promise<string> 
 
 function firstLine(value: string): string {
     return (value || '').split(/\r?\n/u, 1)[0].trim();
+}
+
+function isStaleMissingWorktree(
+    worktree: WorktreeGitSnapshot | undefined
+): worktree is WorktreeGitSnapshot {
+    return !!worktree && !worktree.isMain && !worktree.isBare
+        && (worktree.health === 'missing' || worktree.health === 'prunable');
+}
+
+function sameWorktreeIdentity(
+    left: WorktreeGitSnapshot,
+    right: WorktreeGitSnapshot,
+): boolean {
+    return worktreeKeysEqual(left.key, right.key)
+        && left.branchRef === right.branchRef
+        && left.head === right.head
+        && left.headKind === right.headKind
+        && left.isMain === right.isMain
+        && left.isBare === right.isBare
+        && left.health === right.health;
+}
+
+function parseStatusIdentity(value: string, expectedHead: string): {
+    branchRef: string;
+    head: string;
+    dirty: boolean;
+} | null {
+    let branchHead: string | null = null;
+    let head: string | null = null;
+    let dirty = false;
+    for (const line of (value || '').split(/\r?\n/u)) {
+        if (line.startsWith('# branch.head ')) {
+            branchHead = line.slice('# branch.head '.length).trim();
+        } else if (line.startsWith('# branch.oid ')) {
+            head = line.slice('# branch.oid '.length).trim();
+        } else if (line && !line.startsWith('# ')) {
+            dirty = true;
+        }
+    }
+    if (head === '(initial)') {
+        if (!/^0{40}(?:0{24})?$/u.test(expectedHead)) {
+            return null;
+        }
+        head = '0'.repeat(expectedHead.length);
+    }
+    if (!branchHead || !/^[0-9a-f]{40}(?:[0-9a-f]{24})?$/u.test(head || '')) {
+        return null;
+    }
+    return {
+        branchRef: branchHead === '(detached)' ? 'HEAD' : `refs/heads/${branchHead}`,
+        head: head as string,
+        dirty,
+    };
 }

--- a/tests/browser/quickSessionCreate.test.js
+++ b/tests/browser/quickSessionCreate.test.js
@@ -349,6 +349,8 @@ test('WORKTREE-MANAGED-CLEANUP-PROTOCOL-001 managed removal stays correlated thr
     const button = project.locator('.ai-session-worktree-group[data-worktree-path="/repo/.agent-pivot/worktrees/cleanup"] .ai-session-worktree-more');
     const menu = page.locator('#aiSessionWorktreeMenu');
     const removeItem = menu.locator('[data-action="worktree-remove"]');
+    const originalAriaLabel = await button.getAttribute('aria-label');
+    const originalTooltip = await button.getAttribute('data-tooltip');
     await button.click();
     assert.equal(await removeItem.isVisible(), true,
         'a removable worktree offers removal inside its unified menu');
@@ -359,6 +361,11 @@ test('WORKTREE-MANAGED-CLEANUP-PROTOCOL-001 managed removal stays correlated thr
         repositoryKey: key.repositoryKey, worktreePath: key.canonicalWorktreePath,
     });
     assert.equal(await button.isDisabled(), true);
+    assert.equal(await button.getAttribute('aria-busy'), 'true');
+    assert.equal(await button.getAttribute('aria-label'), 'Preparing worktree removal…');
+    assert.equal(await button.getAttribute('data-tooltip'), 'Preparing worktree removal…');
+    assert.equal(await project.locator('[data-ai-session-live-region]').textContent(),
+        'Preparing worktree removal…');
 
     await page.evaluate(() => window.dispatchEvent(new MessageEvent('message', { data: {
         type: 'managed-worktree-removal-settlement', version: 1,
@@ -370,6 +377,9 @@ test('WORKTREE-MANAGED-CLEANUP-PROTOCOL-001 managed removal stays correlated thr
         requestId: 'worktree-remove-1', status: 'rejected', errorCode: 'worktree-dirty',
     } })));
     assert.equal(await button.isDisabled(), false);
+    assert.equal(await button.getAttribute('aria-busy'), null);
+    assert.equal(await button.getAttribute('aria-label'), originalAriaLabel);
+    assert.equal(await button.getAttribute('data-tooltip'), originalTooltip);
     assert.match(await project.locator('[data-ai-session-live-region]').textContent(),
         /uncommitted changes/);
 

--- a/tests/browser/quickSessionCreate.test.js
+++ b/tests/browser/quickSessionCreate.test.js
@@ -174,11 +174,19 @@ function postedMessages(page) {
     return page.evaluate(() => window.__postedMessages);
 }
 
-async function postAuthoritativeWorktreeRemoval(page, sequence) {
+async function postAuthoritativeWorktreeUpdate(page, sequence, options = {}) {
+    const surface = getSessionSurface('project-a', 'codex', {
+        ...(options.worktrees ? {
+            worktrees: options.worktrees,
+            worktreeSnapshotRevision: sequence,
+            worktreeRepositoryCount: 1,
+            bareWorktreeCount: 0,
+        } : {}),
+    });
     const html = `<div class="open-session-surface" data-open-session-surface data-id="project-a"
         data-current-workspace data-workspace-scope-identity="scope-project-a"
         data-workspace-navigation-identity="navigation-project-a">
-        ${getAiSessionsDiv(getSessionSurface('project-a', 'codex'))}
+        ${getAiSessionsDiv(surface)}
     </div>`;
     await page.evaluate(({ html, sequence }) => {
         window.dispatchEvent(new MessageEvent('message', { data: {
@@ -202,6 +210,10 @@ async function postAuthoritativeWorktreeRemoval(page, sequence) {
             },
         } }));
     }, { html, sequence });
+}
+
+async function postAuthoritativeWorktreeRemoval(page, sequence) {
+    await postAuthoritativeWorktreeUpdate(page, sequence);
 }
 
 test('AI-SESSION-QUICK-CREATE-001 the quick button posts a quick-create for the card provider', async t => {
@@ -355,9 +367,12 @@ test('WORKTREE-MANAGED-CLEANUP-PROTOCOL-001 managed removal stays correlated thr
     assert.equal(await removeItem.isVisible(), true,
         'a removable worktree offers removal inside its unified menu');
     await removeItem.click();
-    assert.deepEqual((await postedMessages(page))[0], {
+    const firstRequest = (await postedMessages(page))[0];
+    assert.match(firstRequest.requestId, /^worktree-remove-[a-z0-9]+-1$/,
+        'the request id carries a per-document nonce');
+    assert.deepEqual({ ...firstRequest, requestId: '<nonce>' }, {
         type: 'remove-managed-worktree', version: 1,
-        requestId: 'worktree-remove-1', projectId: 'project-a',
+        requestId: '<nonce>', projectId: 'project-a',
         repositoryKey: key.repositoryKey, worktreePath: key.canonicalWorktreePath,
     });
     assert.equal(await button.isDisabled(), true);
@@ -367,15 +382,15 @@ test('WORKTREE-MANAGED-CLEANUP-PROTOCOL-001 managed removal stays correlated thr
     assert.equal(await project.locator('[data-ai-session-live-region]').textContent(),
         'Preparing worktree removal…');
 
-    await page.evaluate(() => window.dispatchEvent(new MessageEvent('message', { data: {
+    await page.evaluate(requestId => window.dispatchEvent(new MessageEvent('message', { data: {
         type: 'managed-worktree-removal-settlement', version: 1,
-        requestId: 'worktree-remove-1', status: 'accepted',
-    } })));
+        requestId, status: 'accepted',
+    } })), firstRequest.requestId);
     assert.equal(await button.isDisabled(), true);
-    await page.evaluate(() => window.dispatchEvent(new MessageEvent('message', { data: {
+    await page.evaluate(requestId => window.dispatchEvent(new MessageEvent('message', { data: {
         type: 'managed-worktree-removal-settlement', version: 1,
-        requestId: 'worktree-remove-1', status: 'rejected', errorCode: 'worktree-dirty',
-    } })));
+        requestId, status: 'rejected', errorCode: 'worktree-dirty',
+    } })), firstRequest.requestId);
     assert.equal(await button.isDisabled(), false);
     assert.equal(await button.getAttribute('aria-busy'), null);
     assert.equal(await button.getAttribute('aria-label'), originalAriaLabel);
@@ -386,7 +401,7 @@ test('WORKTREE-MANAGED-CLEANUP-PROTOCOL-001 managed removal stays correlated thr
     await button.click();
     await removeItem.click();
     const retry = (await postedMessages(page)).at(-1);
-    assert.equal(retry.requestId, 'worktree-remove-2');
+    assert.match(retry.requestId, /^worktree-remove-[a-z0-9]+-2$/);
     await page.evaluate(requestId => window.dispatchEvent(new MessageEvent('message', { data: {
         type: 'managed-worktree-removal-settlement', version: 1,
         requestId, status: 'accepted',
@@ -400,6 +415,80 @@ test('WORKTREE-MANAGED-CLEANUP-PROTOCOL-001 managed removal stays correlated thr
     } })), retry.requestId);
     assert.match(await page.locator('[data-open-session-surface][data-id="project-a"] '
         + '[data-ai-session-live-region]').textContent(), /local branch kept/);
+});
+
+test('WORKTREE-MANAGED-CLEANUP-PROTOCOL-001 preserves pending removal through an authoritative replacement', async t => {
+    const key = {
+        repositoryKey: '/repo/.git',
+        canonicalWorktreePath: '/repo/.agent-pivot/worktrees/refresh-pending',
+    };
+    const worktree = {
+        kind: 'ready',
+        git: {
+            key, branchRef: 'refs/heads/agent-pivot/refresh-pending', head: 'a'.repeat(40),
+            isMain: false, isBare: false, health: 'normal', headKind: 'branch',
+        },
+        activity: 'idle', sessions: [], authority: { canResume: true, canRemove: true },
+    };
+    const page = await openQuickCreatePage(t, { worktrees: [worktree] });
+    const project = page.locator('[data-open-session-surface][data-id="project-a"]');
+    const button = project.locator('.ai-session-worktree-group[data-worktree-path="'
+        + key.canonicalWorktreePath + '"] .ai-session-worktree-more');
+    await button.click();
+    await page.locator('#aiSessionWorktreeMenu [data-action="worktree-remove"]').click();
+    const request = (await postedMessages(page)).at(-1);
+
+    await postAuthoritativeWorktreeUpdate(page, 2, { worktrees: [worktree] });
+    const replacement = project.locator('.ai-session-worktree-group[data-worktree-path="'
+        + key.canonicalWorktreePath + '"] .ai-session-worktree-more');
+    assert.equal(await replacement.isDisabled(), true);
+    assert.equal(await replacement.getAttribute('aria-busy'), 'true');
+    assert.equal(await replacement.getAttribute('aria-label'), 'Preparing worktree removal…');
+    await replacement.evaluate(element => element.click());
+    assert.equal((await postedMessages(page)).length, 1,
+        'the authoritative replacement must not allow a duplicate removal');
+
+    await page.evaluate(requestId => window.dispatchEvent(new MessageEvent('message', { data: {
+        type: 'managed-worktree-removal-settlement', version: 1,
+        requestId, status: 'rejected', errorCode: 'worktree-dirty',
+    } })), request.requestId);
+    assert.equal(await replacement.isDisabled(), false);
+    assert.equal(await replacement.getAttribute('aria-busy'), null);
+});
+
+test('WORKTREE-MANAGED-CLEANUP-PROTOCOL-001 ignores a late removal settlement from a reloaded document', async t => {
+    const key = {
+        repositoryKey: '/repo/.git',
+        canonicalWorktreePath: '/repo/.agent-pivot/worktrees/reload-pending',
+    };
+    const worktree = {
+        kind: 'ready',
+        git: {
+            key, branchRef: 'refs/heads/agent-pivot/reload-pending', head: 'a'.repeat(40),
+            isMain: false, isBare: false, health: 'normal', headKind: 'branch',
+        },
+        activity: 'idle', sessions: [], authority: { canResume: true, canRemove: true },
+    };
+    const first = await openQuickCreatePage(t, { worktrees: [worktree] });
+    const worktreeSelector = '[data-open-session-surface][data-id="project-a"] '
+        + '.ai-session-worktree-group[data-worktree-path="'
+        + key.canonicalWorktreePath + '"] .ai-session-worktree-more';
+    await first.locator(worktreeSelector).click();
+    await first.locator('#aiSessionWorktreeMenu [data-action="worktree-remove"]').click();
+    const oldRequest = (await postedMessages(first)).at(-1);
+
+    const reloaded = await openQuickCreatePage(t, { worktrees: [worktree] });
+    const reloadedButton = reloaded.locator(worktreeSelector);
+    await reloadedButton.click();
+    await reloaded.locator('#aiSessionWorktreeMenu [data-action="worktree-remove"]').click();
+    const currentRequest = (await postedMessages(reloaded)).at(-1);
+    assert.notEqual(currentRequest.requestId, oldRequest.requestId);
+    await reloaded.evaluate(requestId => window.dispatchEvent(new MessageEvent('message', { data: {
+        type: 'managed-worktree-removal-settlement', version: 1,
+        requestId, status: 'rejected', errorCode: 'worktree-dirty',
+    } })), oldRequest.requestId);
+    assert.equal(await reloadedButton.isDisabled(), true);
+    assert.equal(await reloadedButton.getAttribute('aria-busy'), 'true');
 });
 
 test('WORKTREE-SESSION-CREATE-TARGET-001 a worktree quick button posts its exact target and remembered provider', async t => {

--- a/tests/contract/worktrees/journaledDeletion.test.js
+++ b/tests/contract/worktrees/journaledDeletion.test.js
@@ -56,6 +56,7 @@ async function fixture(t) {
     const repositoryKey = await fs.promises.realpath(path.join(repositoryPath, '.git'));
     const worktreePath = await fs.promises.realpath(
         path.join(repositoryPath, '.agent-pivot', 'worktrees', 'cleanup-task'));
+    const head = git(repositoryPath, ['rev-parse', 'HEAD']);
     const key = { repositoryKey, canonicalWorktreePath: worktreePath };
     const mainKey = { repositoryKey, canonicalWorktreePath: repositoryPath };
     const snapshot = {
@@ -64,9 +65,9 @@ async function fixture(t) {
             repositoryKey, rootBindings: [{ workspaceRootId: 'root', repositoryRelativePath: '' }],
             baseRef: 'refs/heads/main',
             worktrees: [
-                { key: mainKey, branchRef: 'refs/heads/main', head: 'a'.repeat(40),
+                { key: mainKey, branchRef: 'refs/heads/main', head,
                     isMain: true, isBare: false, health: 'normal', headKind: 'branch' },
-                { key, branchRef: 'refs/heads/agent-pivot/cleanup-task', head: 'a'.repeat(40),
+                { key, branchRef: 'refs/heads/agent-pivot/cleanup-task', head,
                     isMain: false, isBare: false, health: 'normal', headKind: 'branch' },
             ],
         }],

--- a/tests/contract/worktrees/managedWorktreeRemovalController.test.js
+++ b/tests/contract/worktrees/managedWorktreeRemovalController.test.js
@@ -35,14 +35,16 @@ async function fixture(t) {
     ]);
     const key = { repositoryKey, canonicalWorktreePath: await fs.promises.realpath(worktreePath) };
     const mainKey = { repositoryKey, canonicalWorktreePath: repositoryPath };
+    const mainHead = git(repositoryPath, ['rev-parse', 'HEAD']);
+    const worktreeHead = git(worktreePath, ['rev-parse', 'HEAD']);
     const snapshot = {
         revision: 1, truncatedWorktreeCount: 0,
         repositories: [{
             repositoryKey, rootBindings: [{ workspaceRootId: 'root', repositoryRelativePath: '' }],
             baseRef: 'refs/heads/main',
-            worktrees: [{ key: mainKey, branchRef: 'refs/heads/main', head: 'a'.repeat(40),
+            worktrees: [{ key: mainKey, branchRef: 'refs/heads/main', head: mainHead,
                 isMain: true, isBare: false, health: 'normal', headKind: 'branch' },
-            { key, branchRef: 'refs/heads/agent-pivot/cleanup-task', head: 'a'.repeat(40),
+            { key, branchRef: 'refs/heads/agent-pivot/cleanup-task', head: worktreeHead,
                 isMain: false, isBare: false, health: 'normal', headKind: 'branch' }],
         }],
     };
@@ -165,10 +167,156 @@ test('WORKTREE-MANAGED-CLEANUP-001 opens confirmation before slow Git preflight 
     assert.equal(fs.existsSync(becameActive.worktreePath), true);
 });
 
+test('WORKTREE-MANAGED-CLEANUP-001 rejects a replacement snapshot after confirmation', async t => {
+    const current = await fixture(t);
+    current.setOnConfirm(() => {
+        current.snapshot.repositories[0].worktrees[1] = {
+            ...current.snapshot.repositories[0].worktrees[1],
+            branchRef: 'refs/heads/agent-pivot/replacement',
+            head: 'b'.repeat(40),
+        };
+    });
+
+    assert.deepEqual(await current.controller.remove('project', current.key), {
+        kind: 'rejected', errorCode: 'worktree-identity-changed',
+    });
+    assert.deepEqual(current.effects.map(effect => effect[0]), ['confirm']);
+    assert.equal(fs.existsSync(current.worktreePath), true);
+});
+
+test('WORKTREE-MANAGED-CLEANUP-001 rechecks runtime blockers that arise during Git preflight', async t => {
+    for (const [blocker, errorCode] of [
+        ['active', 'worktree-active'],
+        ['open', 'worktree-open'],
+        ['provisioning', 'worktree-provisioning'],
+    ]) {
+        const current = await fixture(t);
+        let active = false;
+        let open = false;
+        let provisioning = false;
+        let firstGitCall = true;
+        const controller = new ManagedWorktreeRemovalController({
+            getSnapshot: () => current.snapshot,
+            isProjectTarget: () => true,
+            isActive: () => active,
+            isOpenWorkspace: () => open,
+            isProvisioning: () => provisioning,
+            confirm: async () => 'Remove Worktree',
+            refresh: async () => { throw new Error('must not refresh'); },
+            runGit: async (_cwd, args) => {
+                if (firstGitCall) {
+                    firstGitCall = false;
+                    active = blocker === 'active';
+                    open = blocker === 'open';
+                    provisioning = blocker === 'provisioning';
+                }
+                const suffix = args.at(-1);
+                if (args.includes('status')) {
+                    return {
+                        exitCode: 0,
+                        stdout: '# branch.oid '
+                            + current.snapshot.repositories[0].worktrees[1].head + '\n'
+                            + '# branch.head agent-pivot/cleanup-task\n',
+                        stderr: '', timedOut: false,
+                    };
+                }
+                if (suffix === '--show-toplevel') {
+                    return { exitCode: 0, stdout: current.worktreePath + '\n', stderr: '', timedOut: false };
+                }
+                if (suffix === '--git-common-dir') {
+                    return { exitCode: 0, stdout: current.repositoryKey + '\n', stderr: '', timedOut: false };
+                }
+                if (suffix === 'HEAD' && args.includes('--symbolic-full-name')) {
+                    return {
+                        exitCode: 0,
+                        stdout: 'refs/heads/agent-pivot/cleanup-task\n', stderr: '', timedOut: false,
+                    };
+                }
+                return {
+                    exitCode: 0,
+                    stdout: current.snapshot.repositories[0].worktrees[1].head + '\n',
+                    stderr: '', timedOut: false,
+                };
+            },
+        });
+        assert.deepEqual(await controller.remove('project', current.key), {
+            kind: 'rejected', errorCode,
+        });
+        assert.equal(fs.existsSync(current.worktreePath), true);
+    }
+});
+
+test('WORKTREE-MANAGED-CLEANUP-001 rejects a branch switch during canonical path validation', async t => {
+    const current = await fixture(t);
+    let switched = false;
+    const controller = new ManagedWorktreeRemovalController({
+        getSnapshot: () => current.snapshot,
+        isProjectTarget: () => true,
+        isActive: () => false,
+        isOpenWorkspace: () => false,
+        isProvisioning: () => false,
+        confirm: async () => 'Remove Worktree',
+        refresh: async () => { throw new Error('must not refresh'); },
+        canonicalizeExistingPath: async candidate => {
+            if (!switched && candidate === current.worktreePath) {
+                switched = true;
+                // The replacement branch intentionally points to the same
+                // commit: only a coherent final branch+HEAD observation can
+                // distinguish it from the branch the user confirmed.
+                git(current.worktreePath, ['switch', '-c', 'agent-pivot/replaced-during-check']);
+            }
+            return fs.promises.realpath(candidate);
+        },
+    });
+
+    assert.deepEqual(await controller.remove('project', current.key), {
+        kind: 'rejected', errorCode: 'worktree-identity-changed',
+    });
+    assert.equal(switched, true);
+    assert.equal(fs.existsSync(current.worktreePath), true);
+});
+
+test('WORKTREE-MANAGED-CLEANUP-001 accepts clean tracking and SHA-256 status headers', async t => {
+    for (const [expectedHead, observedHead] of [
+        ['a'.repeat(64), 'a'.repeat(64)],
+        ['0'.repeat(64), '(initial)'],
+    ]) {
+        const current = await fixture(t);
+        current.snapshot.repositories[0].worktrees[1].head = expectedHead;
+        const controller = new ManagedWorktreeRemovalController({
+            getSnapshot: () => current.snapshot,
+            isProjectTarget: () => true,
+            isActive: () => false,
+            isOpenWorkspace: () => false,
+            isProvisioning: () => false,
+            confirm: async () => 'Remove Worktree',
+            refresh: async () => { throw new Error('must not refresh'); },
+            runGit: async (_cwd, args) => {
+                if (args.includes('--show-toplevel')) {
+                    return { exitCode: 0, stdout: current.worktreePath + '\n', stderr: '', timedOut: false };
+                }
+                if (args.includes('--git-common-dir')) {
+                    return { exitCode: 0, stdout: current.repositoryKey + '\n', stderr: '', timedOut: false };
+                }
+                return {
+                    exitCode: 0,
+                    stdout: '# branch.oid ' + observedHead + '\n'
+                        + '# branch.head agent-pivot/cleanup-task\n'
+                        + '# branch.upstream origin/agent-pivot/cleanup-task\n'
+                        + '# branch.ab +0 -0\n',
+                    stderr: '', timedOut: false,
+                };
+            },
+        });
+        assert.equal(await controller.getRemovalBlocker(current.key), null);
+    }
+});
+
 test('WORKTREE-MANAGED-CLEANUP-001 rejects main, wrong-project, and cancelled removal', async t => {
     const current = await fixture(t);
     assert.equal((await current.controller.remove('project', current.mainKey)).errorCode,
         'worktree-not-removable');
+    assert.deepEqual(current.effects, [], 'a non-removable main checkout must not prompt');
     assert.equal((await current.controller.remove('other', current.key)).errorCode,
         'project-unavailable');
     current.setConfirmation(undefined);
@@ -186,7 +334,7 @@ test('WORKTREE-MANAGED-CLEANUP-001 removes a clean idle worktree outside the man
     };
     current.snapshot.repositories[0].worktrees.push({
         key: unmanagedKey,
-        branchRef: 'refs/heads/unmanaged', head: 'a'.repeat(40), isMain: false,
+        branchRef: 'refs/heads/unmanaged', head: git(unmanagedPath, ['rev-parse', 'HEAD']), isMain: false,
         isBare: false, health: 'normal', headKind: 'branch',
     });
 

--- a/tests/contract/worktrees/managedWorktreeRemovalController.test.js
+++ b/tests/contract/worktrees/managedWorktreeRemovalController.test.js
@@ -90,14 +90,21 @@ test('WORKTREE-MANAGED-CLEANUP-001 removes a confirmed clean idle managed worktr
     assert.deepEqual(current.effects.map(effect => effect[0]), ['confirm', 'refresh']);
 });
 
-test('WORKTREE-MANAGED-CLEANUP-001 rejects dirty and active worktrees before confirmation', async t => {
+test('WORKTREE-MANAGED-CLEANUP-001 confirms before Git-only blockers, then rejects them safely', async t => {
     const dirty = await fixture(t);
     await fs.promises.writeFile(path.join(dirty.worktreePath, 'untracked.txt'), 'dirty');
     assert.deepEqual(await dirty.controller.remove('project', dirty.key), {
         kind: 'rejected', errorCode: 'worktree-dirty',
     });
-    assert.deepEqual(dirty.effects, []);
+    assert.deepEqual(dirty.effects.map(effect => effect[0]), ['confirm']);
     assert.equal(fs.existsSync(dirty.worktreePath), true);
+
+    const branchChanged = await fixture(t);
+    git(branchChanged.worktreePath, ['switch', '-c', 'agent-pivot/replaced']);
+    assert.deepEqual(await branchChanged.controller.remove('project', branchChanged.key), {
+        kind: 'rejected', errorCode: 'worktree-identity-changed',
+    });
+    assert.deepEqual(branchChanged.effects.map(effect => effect[0]), ['confirm']);
 
     const active = await fixture(t);
     active.setActive(true);
@@ -121,13 +128,34 @@ test('WORKTREE-MANAGED-CLEANUP-001 rejects dirty and active worktrees before con
     assert.deepEqual(provisioning.effects, []);
 });
 
-test('WORKTREE-MANAGED-CLEANUP-001 revalidates identity and activity after confirmation', async t => {
-    const branchChanged = await fixture(t);
-    git(branchChanged.worktreePath, ['switch', '-c', 'agent-pivot/replaced']);
-    assert.deepEqual(await branchChanged.controller.remove('project', branchChanged.key), {
-        kind: 'rejected', errorCode: 'worktree-identity-changed',
+test('WORKTREE-MANAGED-CLEANUP-001 opens confirmation before slow Git preflight and revalidates after it', async t => {
+    const current = await fixture(t);
+    let settleConfirmation;
+    const confirmation = new Promise(resolve => { settleConfirmation = resolve; });
+    let gitCalls = 0;
+    const controller = new ManagedWorktreeRemovalController({
+        getSnapshot: () => current.snapshot,
+        isProjectTarget: () => true,
+        isActive: () => false,
+        isOpenWorkspace: () => false,
+        isProvisioning: () => false,
+        confirm: async () => {
+            current.effects.push(['confirm']);
+            return confirmation;
+        },
+        refresh: async () => { current.effects.push(['refresh']); },
+        runGit: async () => {
+            gitCalls += 1;
+            throw new Error('Git must not start before the confirmation settles');
+        },
     });
-    assert.deepEqual(branchChanged.effects, []);
+    const removal = controller.remove('project', current.key);
+
+    await new Promise(resolve => setImmediate(resolve));
+    assert.deepEqual(current.effects.map(effect => effect[0]), ['confirm']);
+    assert.equal(gitCalls, 0);
+    settleConfirmation(undefined);
+    assert.deepEqual(await removal, { kind: 'cancelled' });
 
     const becameActive = await fixture(t);
     becameActive.setOnConfirm(() => becameActive.setActive(true));


### PR DESCRIPTION
## Summary

- show a busy removal confirmation promptly, before expensive Git checks
- bind the confirmation to a stable worktree identity and fail closed on conflicting state
- preserve pending removal feedback across webview updates and document reloads
- align the journaled-deletion fixture with the verified Git identity

## Skill harvest

No skill change: these fixes are product-specific applications of the existing resilient webview mutation and review/fix workflow guidance.

## Owner approvals

```text
approve 9e633498fed23fd9fc04f60755ce42371d2df7c5
```