### PR TITLE
perf: make chat navigation responsive

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -874,7 +874,7 @@
   {
     "id": "ATTENTION-STATUS-BAR-QUEUE-001",
     "domain": "attention",
-    "title": "A right-aligned status bar entry surfaces the cross-window attention count with a per-session tooltip and serially cycles a resilient cursor through the oldest-first queue on click: manual focus changes re-anchor the cursor, local sessions use the shared navigation transaction to focus their terminal and open their conversation while staying unread by default, one active transaction settles safely while rapid pending navigation input coalesces to the latest intent, an opt-in setting acknowledges only after the conversation really opens, unfocusable sessions warn and stay unread without trapping the cursor, and remote sessions use an exact-target delivered mailbox hand-off before switching to the owning window",
+    "title": "A right-aligned status bar entry surfaces the cross-window attention count with a per-session tooltip and serially cycles a resilient cursor through the oldest-first queue on click: manual focus changes re-anchor the cursor, local sessions use the shared navigation transaction to focus their terminal and open their conversation while staying unread by default, interleaved Running and Attention commands settle in invocation order, an opt-in setting acknowledges only after the conversation really opens, unfocusable sessions warn and stay unread without trapping the cursor, and remote sessions use an exact-target delivered mailbox hand-off before switching to the owning window",
     "priority": "P1",
     "status": "automated",
     "owners": [
@@ -903,7 +903,7 @@
   {
     "id": "AI-SESSION-NEXT-RUNNING-COMMAND-001",
     "domain": "session",
-    "title": "The Next Running Session command cycles every running AI session one jump per invocation with independent local-session and cross-window cursors: manual focus changes re-anchor the cursor, local jumps use the shared navigation transaction to focus the session terminal and open its conversation, one active transaction settles safely while rapid pending navigation input coalesces to the latest intent, sessions that ended mid-cycle are skipped with a warning, and remote jumps switch windows only after a v3 delivered source-to-target hand-off supplies an authoritative ring anchor so incomplete snapshots cannot starve a session or window",
+    "title": "The Next Running Session command cycles every running AI session one jump per invocation with independent local-session and cross-window cursors: manual focus changes re-anchor the cursor, local jumps use the shared navigation transaction to focus the session terminal and open its conversation, interleaved Running and Attention commands settle in invocation order, sessions that ended mid-cycle are skipped with a warning, and remote jumps switch windows only after a v3 delivered source-to-target hand-off supplies an authoritative ring anchor so incomplete snapshots cannot starve a session or window",
     "priority": "P1",
     "status": "automated",
     "owners": [

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -874,7 +874,7 @@
   {
     "id": "ATTENTION-STATUS-BAR-QUEUE-001",
     "domain": "attention",
-    "title": "A right-aligned status bar entry surfaces the cross-window attention count with a per-session tooltip and serially cycles a resilient cursor through the oldest-first queue on click: manual focus changes re-anchor the cursor, local sessions use the shared navigation transaction to focus their terminal and open their conversation while staying unread by default, interleaved Running and Attention commands settle in invocation order, an opt-in setting acknowledges only after the conversation really opens, unfocusable sessions warn and stay unread without trapping the cursor, and remote sessions use an exact-target delivered mailbox hand-off before switching to the owning window",
+    "title": "A right-aligned status bar entry surfaces the cross-window attention count with a per-session tooltip and serially cycles a resilient cursor through the oldest-first queue on click: manual focus changes re-anchor the cursor, local sessions use the shared navigation transaction to focus their terminal and open their conversation while staying unread by default, one active transaction settles safely while rapid pending navigation input coalesces to the latest intent, an opt-in setting acknowledges only after the conversation really opens, unfocusable sessions warn and stay unread without trapping the cursor, and remote sessions use an exact-target delivered mailbox hand-off before switching to the owning window",
     "priority": "P1",
     "status": "automated",
     "owners": [
@@ -903,7 +903,7 @@
   {
     "id": "AI-SESSION-NEXT-RUNNING-COMMAND-001",
     "domain": "session",
-    "title": "The Next Running Session command cycles every running AI session one jump per invocation with independent local-session and cross-window cursors: manual focus changes re-anchor the cursor, local jumps use the shared navigation transaction to focus the session terminal and open its conversation, interleaved Running and Attention commands settle in invocation order, sessions that ended mid-cycle are skipped with a warning, and remote jumps switch windows only after a v3 delivered source-to-target hand-off supplies an authoritative ring anchor so incomplete snapshots cannot starve a session or window",
+    "title": "The Next Running Session command cycles every running AI session one jump per invocation with independent local-session and cross-window cursors: manual focus changes re-anchor the cursor, local jumps use the shared navigation transaction to focus the session terminal and open its conversation, one active transaction settles safely while rapid pending navigation input coalesces to the latest intent, sessions that ended mid-cycle are skipped with a warning, and remote jumps switch windows only after a v3 delivered source-to-target hand-off supplies an authoritative ring anchor so incomplete snapshots cannot starve a session or window",
     "priority": "P1",
     "status": "automated",
     "owners": [

--- a/media/conversationViewerScripts.js
+++ b/media/conversationViewerScripts.js
@@ -380,6 +380,7 @@
     // switch that misses twice must still escalate the latest miss.
     var resyncRequestedGeneration = 0;
     var conversationLoading = false;
+    var loadingDisabledElements = [];
     // Detached conversation frames keyed by session: switching back to a
     // session whose content token is unchanged reattaches the already-built
     // DOM — no HTML transfer, sanitize, parse, or reconcile at all. Bounded
@@ -1084,8 +1085,49 @@
 
     // A reused panel keeps the outgoing conversation on screen while the
     // incoming session loads. The Host's loading notice arms a lightweight
-    // indicator — status text plus a dimmed, aria-busy message list —
-    // which the first applied page of the incoming generation clears.
+    // indicator and disables outgoing controls, while keeping the live
+    // loading status available to assistive technology.
+    function setLoadingInteractivity(disabled) {
+        if (disabled) {
+            loadingDisabledElements = Array.prototype.slice.call(
+                document.querySelectorAll('button, input, select, textarea, [tabindex]')
+            ).map(function (element) {
+                return {
+                    element: element,
+                    disabled: 'disabled' in element ? element.disabled : undefined,
+                    tabindex: element.getAttribute('tabindex'),
+                    ariaDisabled: element.getAttribute('aria-disabled'),
+                };
+            });
+            loadingDisabledElements.forEach(function (entry) {
+                if (entry.disabled !== undefined) {
+                    entry.element.disabled = true;
+                }
+                if (entry.tabindex !== null) {
+                    entry.element.setAttribute('tabindex', '-1');
+                }
+                entry.element.setAttribute('aria-disabled', 'true');
+            });
+            return;
+        }
+        loadingDisabledElements.forEach(function (entry) {
+            if (entry.disabled !== undefined) {
+                entry.element.disabled = entry.disabled;
+            }
+            if (entry.tabindex === null) {
+                entry.element.removeAttribute('tabindex');
+            } else {
+                entry.element.setAttribute('tabindex', entry.tabindex);
+            }
+            if (entry.ariaDisabled === null) {
+                entry.element.removeAttribute('aria-disabled');
+            } else {
+                entry.element.setAttribute('aria-disabled', entry.ariaDisabled);
+            }
+        });
+        loadingDisabledElements = [];
+    }
+
     function applyLoadingNotice(message) {
         if (!message || typeof message !== 'object'
             || message.type !== 'conversation-viewer-loading') {
@@ -1111,6 +1153,7 @@
         }
         conversationLoading = true;
         document.body.setAttribute('data-conversation-loading', 'true');
+        setLoadingInteractivity(true);
         messages.setAttribute('aria-busy', 'true');
         status.textContent = 'Loading conversation…';
         return true;
@@ -1122,6 +1165,7 @@
         }
         conversationLoading = false;
         document.body.removeAttribute('data-conversation-loading');
+        setLoadingInteractivity(false);
         messages.removeAttribute('aria-busy');
         // The applied page recomputes the status line right below.
     }

--- a/scripts/run-architecture-guards.js
+++ b/scripts/run-architecture-guards.js
@@ -1748,7 +1748,8 @@ const guards = {
                     'every direct session command must use the shared local focus executor');
             }
         }
-        if (callArguments(quickSwitch, 'navigationCoordinator.enqueueLatest').length !== 3
+        if (callArguments(quickSwitch, 'navigationCoordinator.enqueueLatest').length !== 2
+            || callArguments(quickSwitch, 'navigationCoordinator.enqueue').length !== 1
             || callArguments(quickSwitch, 'options.navigateSession').length !== 1
             || callArguments(quickSwitch, 'options.focusSession').length !== 0
             || callArguments(quickSwitch, 'options.openConversation').length !== 0) {
@@ -1774,10 +1775,10 @@ const guards = {
             if (!handler || !ts.isPropertyAssignment(handler)
                 || callArguments(
                     handler.initializer,
-                    'sessionNavigationCoordinator.enqueueLatest',
+                    'beginConversationNavigationIntent',
                 ).length !== 1) {
                 fail(this.id, risk,
-                    'Previous and Next Active Session commands must use the shared navigation coordinator');
+                    'Previous and Next Active Session commands must invalidate an older row navigation');
             }
             const followCalls = callArguments(
                 handler.initializer,

--- a/scripts/run-architecture-guards.js
+++ b/scripts/run-architecture-guards.js
@@ -1748,7 +1748,7 @@ const guards = {
                     'every direct session command must use the shared local focus executor');
             }
         }
-        if (callArguments(quickSwitch, 'navigationCoordinator.enqueue').length !== 3
+        if (callArguments(quickSwitch, 'navigationCoordinator.enqueueLatest').length !== 3
             || callArguments(quickSwitch, 'options.navigateSession').length !== 1
             || callArguments(quickSwitch, 'options.focusSession').length !== 0
             || callArguments(quickSwitch, 'options.openConversation').length !== 0) {
@@ -1774,7 +1774,7 @@ const guards = {
             if (!handler || !ts.isPropertyAssignment(handler)
                 || callArguments(
                     handler.initializer,
-                    'sessionNavigationCoordinator.enqueue',
+                    'sessionNavigationCoordinator.enqueueLatest',
                 ).length !== 1) {
                 fail(this.id, risk,
                     'Previous and Next Active Session commands must use the shared navigation coordinator');
@@ -1788,6 +1788,28 @@ const guards = {
                 fail(this.id, risk,
                     'Previous and Next Active Session commands must preserve their direction');
             }
+        }
+        const dashboardClickNavigator = findVariable(
+            dashboard,
+            'focusAiSessionAndFollowConversation',
+            this.id,
+            risk,
+        );
+        if (!dashboardClickNavigator.initializer
+            || callArguments(
+                dashboardClickNavigator.initializer,
+                'sessionNavigationCoordinator.enqueueLatest',
+            ).length !== 1
+            || callArguments(
+                dashboardClickNavigator.initializer,
+                'aiSessionTerminalCommandController.focusActive',
+            ).length !== 1
+            || callArguments(
+                dashboardClickNavigator.initializer,
+                'conversationCapability.followActiveConversation',
+            ).length !== 1) {
+            fail(this.id, risk,
+                'Dashboard Chat-row clicks must use the shared latest-intent navigation transaction');
         }
     },
 

--- a/src/aiSessions/conversation/composition.ts
+++ b/src/aiSessions/conversation/composition.ts
@@ -166,6 +166,12 @@ export interface ConversationCapabilityOptions {
     syncSession?: (
         target: ConversationSessionOpenTarget
     ) => boolean | void | PromiseLike<boolean | void>;
+    /** Serializes terminal focus with dashboard-level session navigation.
+     * The caller owns the queue; this capability only supplies the exact
+     * focus operation for one already-resolved target. */
+    enqueueTerminalFocus?: (
+        operation: () => Promise<void>
+    ) => Promise<void>;
     commentStore?: ConversationCommentStore;
     projectCommentStore?: ProjectCommentStore;
     bookmarkStore?: ConversationBookmarkStore;
@@ -174,6 +180,7 @@ export interface ConversationCapabilityOptions {
     cycleLocalSessionStatus?: ConversationViewerOptions['cycleLocalSessionStatus'];
     acknowledgeSessionAttention?: ConversationViewerOptions['acknowledgeSessionAttention'];
     switchAdjacentWindow?: ConversationViewerOptions['switchAdjacentWindow'];
+    onConversationNavigationIntent?: ConversationViewerOptions['onNavigationIntent'];
     /**
      * The context window declared by the Codex profile overlay a session runs
      * with, if any. Injected for the codex adapter's telemetry display: the
@@ -381,11 +388,18 @@ function createAvailableConversationCapability(
         isCurrent: () => boolean
     ): Promise<boolean> => queueFocus(
         async () => {
-            const focused = await (options.syncSession || options.focusSession)?.(
-                target
-            );
-            if (focused === false) {
-                throw new Error('AI session terminal focus was rejected');
+            const focus = async (): Promise<void> => {
+                const focused = await (options.syncSession || options.focusSession)?.(
+                    target
+                );
+                if (focused === false) {
+                    throw new Error('AI session terminal focus was rejected');
+                }
+            };
+            if (options.enqueueTerminalFocus) {
+                await options.enqueueTerminalFocus(focus);
+            } else {
+                await focus();
             }
         },
         isCurrent
@@ -411,6 +425,7 @@ function createAvailableConversationCapability(
         cycleLocalSessionStatus: options.cycleLocalSessionStatus,
         acknowledgeSessionAttention: options.acknowledgeSessionAttention,
         switchAdjacentWindow: options.switchAdjacentWindow,
+        onNavigationIntent: options.onConversationNavigationIntent,
         submitPrompt: options.submitPrompt,
         focusSession: options.focusSession,
         commentStore: options.commentStore,

--- a/src/aiSessions/conversation/viewer.ts
+++ b/src/aiSessions/conversation/viewer.ts
@@ -129,6 +129,9 @@ export interface ConversationViewerOptions {
     switchAdjacentWindow?: (
         direction: ConversationSessionSwitchDirection
     ) => PromiseLike<void> | Promise<void> | void;
+    /** Invalidates an older dashboard navigation before the Viewer begins a
+     * user-requested session change of its own. */
+    onNavigationIntent?: () => void;
     watch: (
         provider: AiSessionProviderId,
         sessionId: string,
@@ -312,6 +315,10 @@ export class ConversationViewer implements ConversationViewerApi {
     private subagents: ConversationSubagentEntry[] = [];
     private mainInteractionId?: string;
     private subscriptionGeneration = 0;
+    // The target can change before its first authoritative document is
+    // applied. This is set only for a reused panel, where an outgoing
+    // Webview document could still have queued an action.
+    private transitioningGeneration?: number;
     private nextRequestId = CONVERSATION_LIMITS.minRequestId;
     private currentRequestId = 0;
     private stale = false;
@@ -639,20 +646,23 @@ export class ConversationViewer implements ConversationViewerApi {
         if (reveal) {
             panel.reveal(vscode.ViewColumn.Active);
         }
+        const targetChanged = !previousTarget
+            || previousTarget.projectId !== activeTarget.projectId
+            || previousTarget.provider !== activeTarget.provider
+            || previousTarget.sessionId !== activeTarget.sessionId;
+        if (hadPanel && targetChanged) {
+            this.transitioningGeneration = generation;
+        }
         const replaceDocument = forceDocumentReplacement || !hadPanel;
         if (replaceDocument) {
             panel.webview.html = this.renderDocument(
                 undefined,
                 'Loading conversation…'
             );
-        } else if (!previousTarget
-            || previousTarget.projectId !== activeTarget.projectId
-            || previousTarget.provider !== activeTarget.provider
-            || previousTarget.sessionId !== activeTarget.sessionId) {
-            // Surface the target transition before optional local metadata
-            // (comments, project notes, bookmarks) finishes loading. The
-            // generation guard below still prevents stale metadata from ever
-            // reaching the newly selected session.
+        } else if (targetChanged) {
+            // Keep the existing document for a fast, scroll-stable handoff,
+            // but make its outgoing controls inert until the new target has
+            // an authoritative publication.
             this.postLoadingNotice(panel, activeTarget, generation);
         }
         await Promise.all([
@@ -877,6 +887,7 @@ export class ConversationViewer implements ConversationViewerApi {
         };
         this.suspended = false;
         this.subscriptionGeneration += 1;
+        this.transitioningGeneration = undefined;
         this.currentRequestId = 0;
         return this.subscriptionGeneration;
     }
@@ -979,6 +990,7 @@ export class ConversationViewer implements ConversationViewerApi {
         this.publishKeyboardFocus(false);
         this.suspended = false;
         this.subscriptionGeneration += 1;
+        this.transitioningGeneration = undefined;
         this.currentRequestId = 0;
     }
 
@@ -992,6 +1004,16 @@ export class ConversationViewer implements ConversationViewerApi {
             return;
         }
         if (!this.target) {
+            return;
+        }
+        if (this.transitioningGeneration === this.subscriptionGeneration
+            && parsed.type !== 'conversation-viewer-applied'
+            && parsed.type !== 'conversation-viewer-request-sync') {
+            // A panel replacement is asynchronous at the Webview boundary.
+            // Ignore any outgoing-document action until the authoritative
+            // incoming document is ready, rather than applying it to the
+            // already-replaced Host target.
+            this.emitDiagnostic('message-dropped-target-transition');
             return;
         }
         if (parsed.type === 'conversation-viewer-open-link') {
@@ -1116,6 +1138,7 @@ export class ConversationViewer implements ConversationViewerApi {
             return;
         }
         if (parsed.type === 'conversation-viewer-switch-session') {
+            this.options.onNavigationIntent?.();
             const currentTarget = this.target;
             await this.options.followAdjacentConversation?.(
                 parsed.direction,
@@ -2155,6 +2178,9 @@ export class ConversationViewer implements ConversationViewerApi {
             return;
         }
         this.appliedContentSignature = publication.htmlSignature;
+        if (this.transitioningGeneration === message.subscriptionGeneration) {
+            this.transitioningGeneration = undefined;
+        }
     }
 
     private rebuildLatestDocument(): void {
@@ -2171,10 +2197,9 @@ export class ConversationViewer implements ConversationViewerApi {
         target: ConversationViewerTarget,
         generation: number
     ): void {
-        // A reused panel keeps the outgoing conversation visible while the
-        // incoming session loads; the Webview dims it and announces the
-        // load until the first publication of the new target lands. The
-        // notice is cosmetic, so a lost post never blocks the load.
+        // The notice is cosmetic and must never delay the load. The Webview
+        // makes all outgoing controls inert; Host-side transition gating
+        // below is the matching defense for any already-queued message.
         try {
             void Promise.resolve(panel.webview.postMessage({
                 type: 'conversation-viewer-loading',
@@ -2187,7 +2212,7 @@ export class ConversationViewer implements ConversationViewerApi {
                 },
             })).catch(() => undefined);
         } catch (_error) {
-            // See above: the indicator is best-effort only.
+            // Best-effort visual state only.
         }
     }
 

--- a/src/aiSessions/conversation/viewer.ts
+++ b/src/aiSessions/conversation/viewer.ts
@@ -630,15 +630,6 @@ export class ConversationViewer implements ConversationViewerApi {
         if (!activeTarget) {
             return false;
         }
-        await Promise.all([
-            this.commentController.restore(activeTarget, generation),
-            this.projectCommentController.restore(activeTarget, generation),
-            this.bookmarkController.restore(activeTarget, generation),
-        ]);
-        if (this.target !== activeTarget
-            || this.subscriptionGeneration !== generation) {
-            return false;
-        }
         const panel = reveal ? this.ensurePanel() : this.panel;
         if (!panel || (!reveal && panel !== followedPanel)) {
             this.emitDiagnostic('load-target-no-panel');
@@ -658,7 +649,20 @@ export class ConversationViewer implements ConversationViewerApi {
             || previousTarget.projectId !== activeTarget.projectId
             || previousTarget.provider !== activeTarget.provider
             || previousTarget.sessionId !== activeTarget.sessionId) {
+            // Surface the target transition before optional local metadata
+            // (comments, project notes, bookmarks) finishes loading. The
+            // generation guard below still prevents stale metadata from ever
+            // reaching the newly selected session.
             this.postLoadingNotice(panel, activeTarget, generation);
+        }
+        await Promise.all([
+            this.commentController.restore(activeTarget, generation),
+            this.projectCommentController.restore(activeTarget, generation),
+            this.bookmarkController.restore(activeTarget, generation),
+        ]);
+        if (this.target !== activeTarget
+            || this.subscriptionGeneration !== generation) {
+            return false;
         }
         this.ensureWatch(generation);
         const loaded = await this.loadAuthoritative(

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1730,6 +1730,26 @@ async function initializeDashboard(
         conversationCommandRunner.forget(terminal);
     }));
 
+    // One queue owns terminal focus across commands, Chat rows, and the
+    // Conversation Viewer. It prevents a Viewer next/previous action from
+    // racing a dashboard-row terminal activation.
+    const sessionNavigationCoordinator = createSessionNavigationCoordinator({
+        onTiming: timing => logAiSessionDiagnostic({
+            event: 'session-navigation-queue-latency',
+            phase: timing.event,
+            latest: timing.latest,
+            queueMs: timing.queueMs,
+            ...(timing.executionMs === undefined
+                ? {}
+                : { executionMs: timing.executionMs }),
+            ...(timing.outcome === undefined ? {} : { outcome: timing.outcome }),
+        }),
+    });
+    let conversationNavigationIntent = 0;
+    const beginConversationNavigationIntent = (): number => {
+        conversationNavigationIntent += 1;
+        return conversationNavigationIntent;
+    };
     conversationCapability = ownResource(() => createConversationCapability({
         services: aiSessionServices,
         cycleLocalSessionStatus: (kind, currentTarget) =>
@@ -2055,6 +2075,11 @@ async function initializeDashboard(
                 viewerTarget.sessionId,
                 { revealTerminal: false }
             ),
+        enqueueTerminalFocus: operation =>
+            sessionNavigationCoordinator.enqueue(operation),
+        onConversationNavigationIntent: () => {
+            beginConversationNavigationIntent();
+        },
         setConversationFocusContext: focused =>
             vscode.commands.executeCommand(
                 'setContext',
@@ -2074,34 +2099,44 @@ async function initializeDashboard(
             conversationSessionRebindRestoreTask,
         ])
     ));
-    const sessionNavigationCoordinator = createSessionNavigationCoordinator({
-        onTiming: timing => logAiSessionDiagnostic({
-            event: 'session-navigation-queue-latency',
-            ...timing,
-        }),
-    });
     const focusAiSessionAndFollowConversation = (target: {
         projectId: string;
         provider: AiSessionProviderId;
         sessionId: string;
-    }): Promise<void> => sessionNavigationCoordinator.enqueueLatest(async () => {
+    }): Promise<void> => {
+        const intent = beginConversationNavigationIntent();
+        return sessionNavigationCoordinator.enqueueLatest(async () => {
         const startedAt = Date.now();
         let focusMs = 0;
         let conversationMs = 0;
         let outcome = 'focus-failed';
         try {
             const focusStartedAt = Date.now();
-            const focused = await aiSessionTerminalCommandController.focusActive(
-                target.projectId,
-                target.provider,
-                target.sessionId,
-            );
+            let focused: boolean;
+            try {
+                focused = await aiSessionTerminalCommandController.focusActive(
+                    target.projectId,
+                    target.provider,
+                    target.sessionId,
+                );
+            } catch (error) {
+                outcome = 'focus-error';
+                throw error;
+            }
             focusMs = Date.now() - focusStartedAt;
-            if (focused) {
+            if (focused && intent === conversationNavigationIntent) {
                 const conversationStartedAt = Date.now();
-                await conversationCapability.followActiveConversation(target);
+                try {
+                    await conversationCapability.followActiveConversation(target);
+                } catch (error) {
+                    conversationMs = Date.now() - conversationStartedAt;
+                    outcome = 'conversation-error';
+                    throw error;
+                }
                 conversationMs = Date.now() - conversationStartedAt;
                 outcome = 'conversation-followed';
+            } else if (focused) {
+                outcome = 'superseded';
             } else {
                 void vscode.window.showWarningMessage(
                     'Agent Pivot: the selected AI session is no longer active.'
@@ -2117,7 +2152,8 @@ async function initializeDashboard(
                 totalMs: Math.max(0, Date.now() - startedAt),
             });
         }
-    });
+        });
+    };
     const conversationHandlers = {
         'open-active-ai-session-conversation': async (e: Record<string, unknown>) => {
             if (e.version !== 1
@@ -2974,6 +3010,9 @@ async function initializeDashboard(
             vscode.window.showInformationMessage(message),
         showWarningMessage: message =>
             vscode.window.showWarningMessage(message),
+        onNavigationIntent: () => {
+            beginConversationNavigationIntent();
+        },
     });
     const switchWorktreeOrSession = createWorktreeOrSessionSwitchHandler({
         getWorkspaceTarget: getCurrentWorkspaceActionTargetWithoutCardId,
@@ -3255,21 +3294,26 @@ async function initializeDashboard(
             skillPanel.changeGlobalStoreLocation(),
         openCurrentAiSessionConversation: () => openCurrentAiSessionConversation(),
         seekLatestConversationInteraction: () => seekLatestConversationInteractionWithFeedback(),
-        previousActiveSession: () => sessionNavigationCoordinator.enqueueLatest(
-            () => followAdjacentActiveConversationWithFeedback('previous')
-        ),
-        nextActiveSession: () => sessionNavigationCoordinator.enqueueLatest(
-            () => followAdjacentActiveConversationWithFeedback('next')
-        ),
+        previousActiveSession: () => {
+            beginConversationNavigationIntent();
+            return followAdjacentActiveConversationWithFeedback('previous');
+        },
+        nextActiveSession: () => {
+            beginConversationNavigationIntent();
+            return followAdjacentActiveConversationWithFeedback('next');
+        },
         nextAttentionSession: async () => {
+            beginConversationNavigationIntent();
             await jumpToNextAttentionSession();
             revealFocusedAiSessionInDashboard();
         },
         nextRunningSession: async () => {
+            beginConversationNavigationIntent();
             await runningSessionJumpHandler.jumpToNextRunningSession();
             revealFocusedAiSessionInDashboard();
         },
         nextActiveChatInWindow: async () => {
+            beginConversationNavigationIntent();
             await sessionStatusCycleHandler.cycleToNext(
                 'running',
                 getFocusedSessionStatusCycleAnchor,
@@ -3277,6 +3321,7 @@ async function initializeDashboard(
             revealFocusedAiSessionInDashboard();
         },
         nextAttentionChatInWindow: async () => {
+            beginConversationNavigationIntent();
             await sessionStatusCycleHandler.cycleToNext(
                 'attention',
                 getFocusedSessionStatusCycleAnchor,
@@ -3289,6 +3334,7 @@ async function initializeDashboard(
         },
         switchWorktreeOrSession: () => switchWorktreeOrSession(),
         toggleLastAiSession: async () => {
+            beginConversationNavigationIntent();
             await aiSessionQuickSwitchHandlers.toggleLastAiSession();
             revealFocusedAiSessionInDashboard();
         },
@@ -3496,6 +3542,7 @@ async function initializeDashboard(
         provider: AiSessionProviderId;
         sessionId: string;
     }, terminalAuthoritative = false): Promise<boolean> {
+        beginConversationNavigationIntent();
         const result = terminalAuthoritative
             ? await conversationCapability.openLatestActiveConversation(target)
             : await conversationCapability.openLatestConversation(target);

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -2074,6 +2074,50 @@ async function initializeDashboard(
             conversationSessionRebindRestoreTask,
         ])
     ));
+    const sessionNavigationCoordinator = createSessionNavigationCoordinator({
+        onTiming: timing => logAiSessionDiagnostic({
+            event: 'session-navigation-queue-latency',
+            ...timing,
+        }),
+    });
+    const focusAiSessionAndFollowConversation = (target: {
+        projectId: string;
+        provider: AiSessionProviderId;
+        sessionId: string;
+    }): Promise<void> => sessionNavigationCoordinator.enqueueLatest(async () => {
+        const startedAt = Date.now();
+        let focusMs = 0;
+        let conversationMs = 0;
+        let outcome = 'focus-failed';
+        try {
+            const focusStartedAt = Date.now();
+            const focused = await aiSessionTerminalCommandController.focusActive(
+                target.projectId,
+                target.provider,
+                target.sessionId,
+            );
+            focusMs = Date.now() - focusStartedAt;
+            if (focused) {
+                const conversationStartedAt = Date.now();
+                await conversationCapability.followActiveConversation(target);
+                conversationMs = Date.now() - conversationStartedAt;
+                outcome = 'conversation-followed';
+            } else {
+                void vscode.window.showWarningMessage(
+                    'Agent Pivot: the selected AI session is no longer active.'
+                );
+            }
+        } finally {
+            logAiSessionDiagnostic({
+                event: 'session-navigation-latency',
+                source: 'dashboard-row',
+                outcome,
+                focusMs: Math.max(0, focusMs),
+                conversationMs: Math.max(0, conversationMs),
+                totalMs: Math.max(0, Date.now() - startedAt),
+            });
+        }
+    });
     const conversationHandlers = {
         'open-active-ai-session-conversation': async (e: Record<string, unknown>) => {
             if (e.version !== 1
@@ -2115,7 +2159,7 @@ async function initializeDashboard(
         getPromptTerminalCommandController: () => promptTerminalCommandController,
         aiSessionCommandController,
         aiSessionTerminalCommandController,
-        conversationCapability,
+        focusAiSessionAndFollowConversation,
         aiSessionArchiveController,
         acknowledgeAiSessionAttentionEventIds,
         logOpenWorkspaceDiagnostic,
@@ -2140,7 +2184,6 @@ async function initializeDashboard(
         openOpenTabLayoutMigrationGuide: () => vscode.env.openExternal(vscode.Uri.parse(
             'https://github.com/hzcheng/agent-pivot/blob/main/docs/open-tab-window-switcher-migration.md',
         )),
-        showWarningMessage: message => vscode.window.showWarningMessage(message),
     });
     // Idempotency cache for group rename settlements (PRD §6.4 protocol
     // rules): replays re-receive the recorded terminal settlement and are
@@ -2694,7 +2737,6 @@ async function initializeDashboard(
         return null;
     };
     const aiSessionMru = createAiSessionMruTracker({ now: () => Date.now() });
-    const sessionNavigationCoordinator = createSessionNavigationCoordinator();
     const sessionNavigationFocusExecutor = createSessionNavigationFocusExecutor({
         getProjectId: () => getCurrentWorkspaceActionTargetWithoutCardId()?.cardId || null,
         focusActive: (projectId, provider, sessionId) =>
@@ -2706,6 +2748,11 @@ async function initializeDashboard(
         openConversation: request => openAiSessionConversationWithFeedback(request),
         onFocused: target =>
             aiSessionMru.record(target.provider, target.sessionId),
+        onTiming: timing => logAiSessionDiagnostic({
+            event: 'session-navigation-latency',
+            source: 'command',
+            ...timing,
+        }),
     });
     const jumpToNextAttentionSession = createAttentionQueueJumpHandler({
         navigationCoordinator: sessionNavigationCoordinator,
@@ -3208,10 +3255,10 @@ async function initializeDashboard(
             skillPanel.changeGlobalStoreLocation(),
         openCurrentAiSessionConversation: () => openCurrentAiSessionConversation(),
         seekLatestConversationInteraction: () => seekLatestConversationInteractionWithFeedback(),
-        previousActiveSession: () => sessionNavigationCoordinator.enqueue(
+        previousActiveSession: () => sessionNavigationCoordinator.enqueueLatest(
             () => followAdjacentActiveConversationWithFeedback('previous')
         ),
-        nextActiveSession: () => sessionNavigationCoordinator.enqueue(
+        nextActiveSession: () => sessionNavigationCoordinator.enqueueLatest(
             () => followAdjacentActiveConversationWithFeedback('next')
         ),
         nextAttentionSession: async () => {

--- a/src/dashboard/attentionQueueJump.ts
+++ b/src/dashboard/attentionQueueJump.ts
@@ -225,10 +225,13 @@ export function createAttentionQueueJumpHandler(
         await jumpToLocal(local);
     }
 
-    const handler = (() => navigationCoordinator.enqueueLatest(
+    const handler = (() => navigationCoordinator.enqueue(
         jumpToNextAttentionSession
     )) as AttentionQueueJumpHandler;
-    handler.jumpToAttentionSession = item => navigationCoordinator.enqueueLatest(
+    // Mailbox deliveries are exact target requests. They acknowledge a
+    // cross-window hand-off, so dropping one would make the source window
+    // switch without the requested session ever receiving focus.
+    handler.jumpToAttentionSession = item => navigationCoordinator.enqueue(
         () => jumpToAttentionSession(item)
     );
     return handler;

--- a/src/dashboard/attentionQueueJump.ts
+++ b/src/dashboard/attentionQueueJump.ts
@@ -225,10 +225,10 @@ export function createAttentionQueueJumpHandler(
         await jumpToLocal(local);
     }
 
-    const handler = (() => navigationCoordinator.enqueue(
+    const handler = (() => navigationCoordinator.enqueueLatest(
         jumpToNextAttentionSession
     )) as AttentionQueueJumpHandler;
-    handler.jumpToAttentionSession = item => navigationCoordinator.enqueue(
+    handler.jumpToAttentionSession = item => navigationCoordinator.enqueueLatest(
         () => jumpToAttentionSession(item)
     );
     return handler;

--- a/src/dashboard/messageHandlers.ts
+++ b/src/dashboard/messageHandlers.ts
@@ -3,7 +3,6 @@
 import type * as vscode from 'vscode';
 import type { AiSessionArchiveController } from '../aiSessions/archiveController';
 import type { AiSessionCommandController } from '../aiSessions/commandController';
-import type { ConversationCapability } from '../aiSessions/conversation/composition';
 import type { AiSessionRuntimeSnapshot } from '../aiSessions/runtimeTypes';
 import type { AiSessionTerminalCommandController } from '../aiSessions/terminalCommandController';
 import { isAiSessionProviderId } from '../models';
@@ -24,7 +23,11 @@ export interface DashboardMessageHandlersOptions {
     getPromptTerminalCommandController: () => PromptTerminalCommandController;
     aiSessionCommandController: AiSessionCommandController;
     aiSessionTerminalCommandController: AiSessionTerminalCommandController<vscode.Terminal>;
-    conversationCapability: ConversationCapability;
+    focusAiSessionAndFollowConversation(target: {
+        projectId: string;
+        provider: AiSessionProviderId;
+        sessionId: string;
+    }): Promise<void>;
     aiSessionArchiveController: AiSessionArchiveController<AiSessionRuntimeSnapshot<vscode.Terminal>>;
     acknowledgeAiSessionAttentionEventIds: (
         eventIds: string[],
@@ -44,7 +47,6 @@ export interface DashboardMessageHandlersOptions {
     showSponsorOptions: () => Promise<void>;
     dismissOpenTabLayoutNotice: () => Thenable<unknown>;
     openOpenTabLayoutMigrationGuide: () => Thenable<unknown>;
-    showWarningMessage: (message: string) => void;
 }
 
 /**
@@ -68,7 +70,7 @@ export function createDashboardMessageHandlers(
     const getPromptTerminalCommandController = options.getPromptTerminalCommandController;
     const aiSessionCommandController = options.aiSessionCommandController;
     const aiSessionTerminalCommandController = options.aiSessionTerminalCommandController;
-    const conversationCapability = options.conversationCapability;
+    const focusAiSessionAndFollowConversation = options.focusAiSessionAndFollowConversation;
     const aiSessionArchiveController = options.aiSessionArchiveController;
     const acknowledgeAiSessionAttentionEventIds = options.acknowledgeAiSessionAttentionEventIds;
     const logOpenWorkspaceDiagnostic = options.logOpenWorkspaceDiagnostic;
@@ -80,7 +82,6 @@ export function createDashboardMessageHandlers(
     const showSponsorOptions = options.showSponsorOptions;
     const dismissOpenTabLayoutNotice = options.dismissOpenTabLayoutNotice;
     const openOpenTabLayoutMigrationGuide = options.openOpenTabLayoutMigrationGuide;
-    const showWarningMessage = options.showWarningMessage;
     const attentionAcknowledgementFlights = new Map<string, {
         eventIdsFingerprint: string;
         flight: Promise<'committed' | 'degraded-local' | 'rejected'>;
@@ -226,21 +227,7 @@ export function createDashboardMessageHandlers(
                 provider: e.provider as AiSessionProviderId,
                 sessionId: e.sessionId as string,
             };
-            const focused =
-                await aiSessionTerminalCommandController.focusActive(
-                    target.projectId,
-                    target.provider,
-                    target.sessionId
-                );
-            if (focused) {
-                await conversationCapability.followActiveConversation(
-                    target
-                );
-            } else {
-                showWarningMessage(
-                    'Agent Pivot: the selected AI session is no longer active.'
-                );
-            }
+            await focusAiSessionAndFollowConversation(target);
         },
         'focus-pending-ai-session': async e => {
             await aiSessionTerminalCommandController.focusPending(

--- a/src/dashboard/runningSessionJump.ts
+++ b/src/dashboard/runningSessionJump.ts
@@ -210,9 +210,9 @@ export function createRunningSessionJumpHandler(
     return {
         jumpToNextRunningSession: () => {
             lastDirectInvocationAtMs = Math.max(lastDirectInvocationAtMs, nowMs());
-            return navigationCoordinator.enqueue(() => jump('all'));
+            return navigationCoordinator.enqueueLatest(() => jump('all'));
         },
         jumpToNextLocalRunningSession: handoff =>
-            navigationCoordinator.enqueue(() => jump('local', handoff)),
+            navigationCoordinator.enqueueLatest(() => jump('local', handoff)),
     };
 }

--- a/src/dashboard/runningSessionJump.ts
+++ b/src/dashboard/runningSessionJump.ts
@@ -210,9 +210,15 @@ export function createRunningSessionJumpHandler(
     return {
         jumpToNextRunningSession: () => {
             lastDirectInvocationAtMs = Math.max(lastDirectInvocationAtMs, nowMs());
-            return navigationCoordinator.enqueueLatest(() => jump('all'));
+            // This is a relative operation: every key press advances one
+            // place from the cursor that the preceding operation establishes.
+            // It therefore must remain lossless rather than latest-wins.
+            return navigationCoordinator.enqueue(() => jump('all'));
         },
         jumpToNextLocalRunningSession: handoff =>
-            navigationCoordinator.enqueueLatest(() => jump('local', handoff)),
+            // A bridge hand-off names one exact remote request. The source
+            // may switch windows as soon as this resolves, so it cannot be
+            // coalesced into a successful no-op.
+            navigationCoordinator.enqueue(() => jump('local', handoff)),
     };
 }

--- a/src/dashboard/sessionNavigationCoordinator.ts
+++ b/src/dashboard/sessionNavigationCoordinator.ts
@@ -2,8 +2,29 @@
 
 export type SessionNavigationTask = () => Promise<void>;
 
+export interface SessionNavigationQueueTiming {
+    event: 'started' | 'settled' | 'superseded';
+    latest: boolean;
+    queueMs: number;
+    executionMs?: number;
+    outcome?: 'succeeded' | 'failed';
+}
+
 export interface SessionNavigationCoordinator {
     enqueue(task: SessionNavigationTask): Promise<void>;
+    /**
+     * Enqueues a user navigation intent while retaining only the newest
+     * not-yet-started intent. Running terminal work is allowed to settle so
+     * runtime focus never interleaves, but stale queued hops cannot make a
+     * rapid command sequence feel delayed or land on an obsolete target.
+     */
+    enqueueLatest(task: SessionNavigationTask): Promise<void>;
+}
+
+export interface SessionNavigationCoordinatorOptions {
+    now?(): number;
+    /** Receives aggregate timings only; no navigation target identity. */
+    onTiming?(timing: SessionNavigationQueueTiming): void;
 }
 
 /**
@@ -11,13 +32,92 @@ export interface SessionNavigationCoordinator {
  * in one extension host. A failed transaction does not poison later commands,
  * while a later command never starts before the earlier transaction settles.
  */
-export function createSessionNavigationCoordinator(): SessionNavigationCoordinator {
-    let tail: Promise<void> = Promise.resolve();
+export function createSessionNavigationCoordinator(
+    options: SessionNavigationCoordinatorOptions = {}
+): SessionNavigationCoordinator {
+    interface QueuedTask {
+        task: SessionNavigationTask;
+        resolve(): void;
+        reject(error: unknown): void;
+        latest: boolean;
+        queuedAt: number;
+    }
+
+    const queue: QueuedTask[] = [];
+    let running = false;
+    const now = options.now || (() => Date.now());
+    const report = (timing: SessionNavigationQueueTiming): void => {
+        try {
+            options.onTiming?.(timing);
+        } catch (_error) {
+            // Diagnostics must not affect user navigation.
+        }
+    };
+
+    const runNext = (): void => {
+        const next = queue.shift();
+        if (!next) {
+            running = false;
+            return;
+        }
+        running = true;
+        const startedAt = now();
+        const queueMs = Math.max(0, startedAt - next.queuedAt);
+        report({ event: 'started', latest: next.latest, queueMs });
+        void Promise.resolve()
+            .then(next.task)
+            .then(
+                () => {
+                    next.resolve();
+                    report({
+                        event: 'settled',
+                        latest: next.latest,
+                        queueMs,
+                        executionMs: Math.max(0, now() - startedAt),
+                        outcome: 'succeeded',
+                    });
+                },
+                error => {
+                    next.reject(error);
+                    report({
+                        event: 'settled',
+                        latest: next.latest,
+                        queueMs,
+                        executionMs: Math.max(0, now() - startedAt),
+                        outcome: 'failed',
+                    });
+                },
+            )
+            .then(runNext);
+    };
+
+    const add = (task: SessionNavigationTask, latest: boolean): Promise<void> =>
+        new Promise<void>((resolve, reject) => {
+            if (latest) {
+                // Preserve ordinary queued work, but replace older pending
+                // navigation intents. Their callers see a settled no-op;
+                // only the final requested target runs after the current
+                // transaction has safely finished.
+                for (let index = queue.length - 1; index >= 0; index -= 1) {
+                    if (queue[index].latest) {
+                        const superseded = queue.splice(index, 1)[0];
+                        superseded.resolve();
+                        report({
+                            event: 'superseded',
+                            latest: true,
+                            queueMs: Math.max(0, now() - superseded.queuedAt),
+                        });
+                    }
+                }
+            }
+            queue.push({ task, resolve, reject, latest, queuedAt: now() });
+            if (!running) {
+                runNext();
+            }
+        });
+
     return {
-        enqueue(task: SessionNavigationTask): Promise<void> {
-            const result = tail.then(task, task);
-            tail = result.then(() => undefined, () => undefined);
-            return result;
-        },
+        enqueue: task => add(task, false),
+        enqueueLatest: task => add(task, true),
     };
 }

--- a/src/dashboard/sessionNavigationFocusExecutor.ts
+++ b/src/dashboard/sessionNavigationFocusExecutor.ts
@@ -16,6 +16,13 @@ export interface SessionNavigationFocusExecutionOptions {
     onFocused?(): void;
 }
 
+export interface SessionNavigationTiming {
+    outcome: 'unavailable' | 'focus-failed' | 'conversation-opened' | 'conversation-unavailable';
+    focusMs: number;
+    conversationMs: number;
+    totalMs: number;
+}
+
 export interface SessionNavigationFocusExecutor {
     execute(
         target: SessionNavigationFocusTarget,
@@ -36,6 +43,9 @@ export interface SessionNavigationFocusExecutorOptions {
         sessionId: string;
     }): Promise<boolean>;
     onFocused?(target: SessionNavigationFocusTarget): void;
+    /** Receives timing only; no workspace, provider, or session identity. */
+    onTiming?(timing: SessionNavigationTiming): void;
+    now?(): number;
 }
 
 /**
@@ -51,25 +61,53 @@ export function createSessionNavigationFocusExecutor(
             target: SessionNavigationFocusTarget,
             executionOptions: SessionNavigationFocusExecutionOptions = {},
         ): Promise<SessionNavigationFocusResult> {
+            const now = options.now || (() => Date.now());
+            const startedAt = now();
+            const report = (
+                outcome: SessionNavigationTiming['outcome'],
+                focusMs: number,
+                conversationMs: number,
+            ): void => {
+                try {
+                    options.onTiming?.({
+                        outcome,
+                        focusMs: Math.max(0, focusMs),
+                        conversationMs: Math.max(0, conversationMs),
+                        totalMs: Math.max(0, now() - startedAt),
+                    });
+                } catch (_error) {
+                    // Diagnostics must not affect user navigation.
+                }
+            };
             const projectId = options.getProjectId();
             if (!projectId) {
+                report('unavailable', 0, 0);
                 return { focused: false, conversationOpened: false };
             }
+            const focusStartedAt = now();
             const focused = await options.focusActive(
                 projectId,
                 target.provider,
                 target.sessionId,
             );
+            const focusMs = now() - focusStartedAt;
             if (!focused) {
+                report('focus-failed', focusMs, 0);
                 return { focused: false, conversationOpened: false };
             }
             options.onFocused?.(target);
             executionOptions.onFocused?.();
+            const conversationStartedAt = now();
             const conversationOpened = await options.openConversation({
                 projectId,
                 provider: target.provider,
                 sessionId: target.sessionId,
             });
+            report(
+                conversationOpened ? 'conversation-opened' : 'conversation-unavailable',
+                focusMs,
+                now() - conversationStartedAt,
+            );
             return { focused: true, conversationOpened };
         },
     };

--- a/src/dashboard/sessionNavigationFocusExecutor.ts
+++ b/src/dashboard/sessionNavigationFocusExecutor.ts
@@ -17,7 +17,8 @@ export interface SessionNavigationFocusExecutionOptions {
 }
 
 export interface SessionNavigationTiming {
-    outcome: 'unavailable' | 'focus-failed' | 'conversation-opened' | 'conversation-unavailable';
+    outcome: 'unavailable' | 'focus-failed' | 'focus-error' | 'conversation-opened'
+        | 'conversation-unavailable' | 'conversation-error';
     focusMs: number;
     conversationMs: number;
     totalMs: number;
@@ -85,11 +86,17 @@ export function createSessionNavigationFocusExecutor(
                 return { focused: false, conversationOpened: false };
             }
             const focusStartedAt = now();
-            const focused = await options.focusActive(
-                projectId,
-                target.provider,
-                target.sessionId,
-            );
+            let focused: boolean;
+            try {
+                focused = await options.focusActive(
+                    projectId,
+                    target.provider,
+                    target.sessionId,
+                );
+            } catch (error) {
+                report('focus-error', now() - focusStartedAt, 0);
+                throw error;
+            }
             const focusMs = now() - focusStartedAt;
             if (!focused) {
                 report('focus-failed', focusMs, 0);
@@ -98,11 +105,17 @@ export function createSessionNavigationFocusExecutor(
             options.onFocused?.(target);
             executionOptions.onFocused?.();
             const conversationStartedAt = now();
-            const conversationOpened = await options.openConversation({
-                projectId,
-                provider: target.provider,
-                sessionId: target.sessionId,
-            });
+            let conversationOpened: boolean;
+            try {
+                conversationOpened = await options.openConversation({
+                    projectId,
+                    provider: target.provider,
+                    sessionId: target.sessionId,
+                });
+            } catch (error) {
+                report('conversation-error', focusMs, now() - conversationStartedAt);
+                throw error;
+            }
             report(
                 conversationOpened ? 'conversation-opened' : 'conversation-unavailable',
                 focusMs,

--- a/src/dashboard/sessionQuickSwitch.ts
+++ b/src/dashboard/sessionQuickSwitch.ts
@@ -163,6 +163,7 @@ export interface AiSessionQuickSwitchOptions {
     openNavigationCard: (cardId: string) => Promise<void>;
     showInformationMessage: (message: string) => void;
     showWarningMessage: (message: string) => void;
+    onNavigationIntent?: () => void;
 }
 
 export interface AiSessionQuickSwitchHandlers {
@@ -232,6 +233,7 @@ export function createAiSessionQuickSwitchHandlers(
         if (!picked) {
             return;
         }
+        options.onNavigationIntent?.();
         if (picked.target.kind === 'local') {
             const target = picked.target;
             await navigationCoordinator.enqueueLatest(() => jumpToLocal(target));
@@ -267,7 +269,9 @@ export function createAiSessionQuickSwitchHandlers(
     }
 
     async function toggleLastAiSession(): Promise<void> {
-        await navigationCoordinator.enqueueLatest(toggleLastAiSessionTransaction);
+        // Toggle is relative to current MRU/focus state, so every press must
+        // run in order rather than be dropped as a stale absolute target.
+        await navigationCoordinator.enqueue(toggleLastAiSessionTransaction);
     }
 
     return {

--- a/src/dashboard/sessionQuickSwitch.ts
+++ b/src/dashboard/sessionQuickSwitch.ts
@@ -234,11 +234,11 @@ export function createAiSessionQuickSwitchHandlers(
         }
         if (picked.target.kind === 'local') {
             const target = picked.target;
-            await navigationCoordinator.enqueue(() => jumpToLocal(target));
+            await navigationCoordinator.enqueueLatest(() => jumpToLocal(target));
             return;
         }
         const target = picked.target;
-        await navigationCoordinator.enqueue(() => jumpToRemote(target));
+        await navigationCoordinator.enqueueLatest(() => jumpToRemote(target));
     }
 
     async function toggleLastAiSessionTransaction(): Promise<void> {
@@ -267,7 +267,7 @@ export function createAiSessionQuickSwitchHandlers(
     }
 
     async function toggleLastAiSession(): Promise<void> {
-        await navigationCoordinator.enqueue(toggleLastAiSessionTransaction);
+        await navigationCoordinator.enqueueLatest(toggleLastAiSessionTransaction);
     }
 
     return {

--- a/src/dashboard/sessionStatusCycle.ts
+++ b/src/dashboard/sessionStatusCycle.ts
@@ -132,7 +132,7 @@ export function createSessionStatusCycleHandler(
     }
 
     return {
-        cycleToNext: (kind, anchor) => navigationCoordinator.enqueue(
+        cycleToNext: (kind, anchor) => navigationCoordinator.enqueueLatest(
             () => cycleToNext(kind, anchor)
         ),
     };

--- a/src/dashboard/sessionStatusCycle.ts
+++ b/src/dashboard/sessionStatusCycle.ts
@@ -132,7 +132,8 @@ export function createSessionStatusCycleHandler(
     }
 
     return {
-        cycleToNext: (kind, anchor) => navigationCoordinator.enqueueLatest(
+        // Status cycling is relative to the cursor; preserve every press.
+        cycleToNext: (kind, anchor) => navigationCoordinator.enqueue(
             () => cycleToNext(kind, anchor)
         ),
     };

--- a/src/webview/conversationViewerScripts.js
+++ b/src/webview/conversationViewerScripts.js
@@ -380,6 +380,7 @@
     // switch that misses twice must still escalate the latest miss.
     var resyncRequestedGeneration = 0;
     var conversationLoading = false;
+    var loadingDisabledElements = [];
     // Detached conversation frames keyed by session: switching back to a
     // session whose content token is unchanged reattaches the already-built
     // DOM — no HTML transfer, sanitize, parse, or reconcile at all. Bounded
@@ -1084,8 +1085,49 @@
 
     // A reused panel keeps the outgoing conversation on screen while the
     // incoming session loads. The Host's loading notice arms a lightweight
-    // indicator — status text plus a dimmed, aria-busy message list —
-    // which the first applied page of the incoming generation clears.
+    // indicator and disables outgoing controls, while keeping the live
+    // loading status available to assistive technology.
+    function setLoadingInteractivity(disabled) {
+        if (disabled) {
+            loadingDisabledElements = Array.prototype.slice.call(
+                document.querySelectorAll('button, input, select, textarea, [tabindex]')
+            ).map(function (element) {
+                return {
+                    element: element,
+                    disabled: 'disabled' in element ? element.disabled : undefined,
+                    tabindex: element.getAttribute('tabindex'),
+                    ariaDisabled: element.getAttribute('aria-disabled'),
+                };
+            });
+            loadingDisabledElements.forEach(function (entry) {
+                if (entry.disabled !== undefined) {
+                    entry.element.disabled = true;
+                }
+                if (entry.tabindex !== null) {
+                    entry.element.setAttribute('tabindex', '-1');
+                }
+                entry.element.setAttribute('aria-disabled', 'true');
+            });
+            return;
+        }
+        loadingDisabledElements.forEach(function (entry) {
+            if (entry.disabled !== undefined) {
+                entry.element.disabled = entry.disabled;
+            }
+            if (entry.tabindex === null) {
+                entry.element.removeAttribute('tabindex');
+            } else {
+                entry.element.setAttribute('tabindex', entry.tabindex);
+            }
+            if (entry.ariaDisabled === null) {
+                entry.element.removeAttribute('aria-disabled');
+            } else {
+                entry.element.setAttribute('aria-disabled', entry.ariaDisabled);
+            }
+        });
+        loadingDisabledElements = [];
+    }
+
     function applyLoadingNotice(message) {
         if (!message || typeof message !== 'object'
             || message.type !== 'conversation-viewer-loading') {
@@ -1111,6 +1153,7 @@
         }
         conversationLoading = true;
         document.body.setAttribute('data-conversation-loading', 'true');
+        setLoadingInteractivity(true);
         messages.setAttribute('aria-busy', 'true');
         status.textContent = 'Loading conversation…';
         return true;
@@ -1122,6 +1165,7 @@
         }
         conversationLoading = false;
         document.body.removeAttribute('data-conversation-loading');
+        setLoadingInteractivity(false);
         messages.removeAttribute('aria-busy');
         // The applied page recomputes the status line right below.
     }

--- a/tests/browser/activeSessionCardInteraction.test.js
+++ b/tests/browser/activeSessionCardInteraction.test.js
@@ -691,7 +691,7 @@ function createAttentionAcknowledgementHandler(acknowledgeEventIds, postMessage)
             closeTerminal: ignored,
             stopSession: ignored,
         },
-        conversationCapability: { followActiveConversation: ignored },
+        focusAiSessionAndFollowConversation: ignored,
         aiSessionArchiveController: { archiveSessions: ignored },
         acknowledgeAiSessionAttentionEventIds: acknowledgeEventIds,
         logOpenWorkspaceDiagnostic() {},
@@ -701,7 +701,6 @@ function createAttentionAcknowledgementHandler(acknowledgeEventIds, postMessage)
         showAgentPivotSettings: ignored,
         showBridgeExtension: ignored,
         showSponsorOptions: ignored,
-        showWarningMessage() {},
     })['acknowledge-ai-session-attention'];
 }
 

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -5590,7 +5590,7 @@ test('CONVERSATION-OUTLINE-NAVIGATION-001 keeps every side-panel view usable acr
         .digest('hex');
     assert.equal(
         sha256(previousViewerScript),
-        '3440365e5e72ee635395d528feea38051e3a2e962a119bb193b4a686e11b1d93',
+        'f7657ccc53891ef780421bb56928b949c7cba10df5e464ff69b335193d8b73a8',
         'the previous Viewer fixture must stay byte-exact'
     );
     assert.equal(

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -1521,6 +1521,7 @@ async function renderHostViewerDocument(options = {}) {
             Array.from(listeners.dispose).forEach(listener => listener());
         },
     };
+    options.onPanel?.(panel);
     const viewer = new ConversationViewer({
         createPanel: () => panel,
         readOutline: async () => ({
@@ -1588,6 +1589,39 @@ async function renderHostViewerDocument(options = {}) {
     });
     return panel.webview.html;
 }
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 surfaces the loading shell before local metadata restoration settles', async () => {
+    let panel;
+    let releaseCommentRestore;
+    const commentRestore = new Promise(resolve => {
+        releaseCommentRestore = resolve;
+    });
+    const opening = renderHostViewerDocument({
+        onPanel: value => { panel = value; },
+        commentStore: {
+            load: async () => commentRestore,
+            save: async () => {},
+        },
+        projectCommentStore: {
+            load: async () => ({ revision: 0, comments: [] }),
+            save: async () => {},
+        },
+        bookmarkStore: {
+            load: async () => ({ revision: 0, interactionIds: [] }),
+            save: async () => {},
+        },
+    });
+
+    await new Promise(resolve => setImmediate(resolve));
+    assert.ok(panel, 'the Viewer panel is created immediately');
+    assert.match(
+        panel.webview.html,
+        /Loading conversation…/,
+        'slow optional metadata cannot delay visible switch feedback',
+    );
+    releaseCommentRestore({ revision: 0, comments: [] });
+    await opening;
+});
 
 async function openHostViewerDocument(t, options = {}) {
     const page = await browser.newPage({

--- a/tests/contract/aiSessions/attentionStatusBar.test.js
+++ b/tests/contract/aiSessions/attentionStatusBar.test.js
@@ -691,7 +691,7 @@ test('ATTENTION-STATUS-BAR-QUEUE-001 hands a remote target to its owning window 
     ], 'each remote press must complete the exact target before switching windows');
 });
 
-test('ATTENTION-STATUS-BAR-QUEUE-001 serializes rapid invocations so the last press wins', async () => {
+test('ATTENTION-STATUS-BAR-QUEUE-001 preserves every rapid relative invocation', async () => {
     const items = ['a', 'b', 'c'].map((sessionId, index) => ({
         provider: 'codex', sessionId, projectId: 'A', eventIds: [`e${index}`],
         reasons: ['completed'], observedAtMs: index, local: true,
@@ -721,6 +721,7 @@ test('ATTENTION-STATUS-BAR-QUEUE-001 serializes rapid invocations so the last pr
 
     const first = jump();
     const second = jump();
+    const third = jump();
     await Promise.resolve();
     assert.deepEqual(picked, ['b'], 'the second invocation waits for the first focus');
     releases.shift()();
@@ -728,8 +729,12 @@ test('ATTENTION-STATUS-BAR-QUEUE-001 serializes rapid invocations so the last pr
     await new Promise(resolve => setImmediate(resolve));
     assert.deepEqual(picked, ['b', 'c']);
     releases.shift()();
-    await Promise.all([first, second]);
-    assert.equal(focused, 'c');
+    await Promise.resolve();
+    await new Promise(resolve => setImmediate(resolve));
+    assert.deepEqual(picked, ['b', 'c', 'a']);
+    releases.shift()();
+    await Promise.all([first, second, third]);
+    assert.equal(focused, 'a');
 });
 
 test('ATTENTION-STATUS-BAR-QUEUE-001 AI-SESSION-NEXT-RUNNING-COMMAND-001 serializes interleaved navigation commands so the last invocation wins', async () => {

--- a/tests/contract/aiSessions/runningSessionJump.test.js
+++ b/tests/contract/aiSessions/runningSessionJump.test.js
@@ -602,7 +602,7 @@ test('AI-SESSION-NEXT-RUNNING-COMMAND-001 re-anchors after a manual detour with 
         'manual focus changes must re-anchor the next press regardless of queue length');
 });
 
-test('AI-SESSION-NEXT-RUNNING-COMMAND-001 serializes rapid invocations without duplicating a target', async () => {
+test('AI-SESSION-NEXT-RUNNING-COMMAND-001 preserves every rapid relative invocation', async () => {
     const queue = buildRunningSessionQueue({
         localSessions: ['a', 'b', 'c'].map(sessionId => local('codex', sessionId)),
         remoteWindows: [],
@@ -623,6 +623,7 @@ test('AI-SESSION-NEXT-RUNNING-COMMAND-001 serializes rapid invocations without d
 
     const first = handler.jumpToNextRunningSession();
     const second = handler.jumpToNextRunningSession();
+    const third = handler.jumpToNextRunningSession();
     await Promise.resolve();
     assert.deepEqual(picked, ['b'], 'the second invocation waits for the first focus');
     releases.shift()();
@@ -630,8 +631,12 @@ test('AI-SESSION-NEXT-RUNNING-COMMAND-001 serializes rapid invocations without d
     await new Promise(resolve => setImmediate(resolve));
     assert.deepEqual(picked, ['b', 'c']);
     releases.shift()();
-    await Promise.all([first, second]);
-    assert.equal(focused, 'c');
+    await Promise.resolve();
+    await new Promise(resolve => setImmediate(resolve));
+    assert.deepEqual(picked, ['b', 'c', 'a']);
+    releases.shift()();
+    await Promise.all([first, second, third]);
+    assert.equal(focused, 'a');
 });
 
 test('AI-SESSION-NEXT-RUNNING-COMMAND-001 retains only the newest pending navigation intent', async () => {

--- a/tests/contract/aiSessions/runningSessionJump.test.js
+++ b/tests/contract/aiSessions/runningSessionJump.test.js
@@ -634,6 +634,66 @@ test('AI-SESSION-NEXT-RUNNING-COMMAND-001 serializes rapid invocations without d
     assert.equal(focused, 'c');
 });
 
+test('AI-SESSION-NEXT-RUNNING-COMMAND-001 retains only the newest pending navigation intent', async () => {
+    const coordinator = createSessionNavigationCoordinator();
+    const calls = [];
+    let releaseFirst;
+    const first = coordinator.enqueueLatest(() => new Promise(resolve => {
+        calls.push('first');
+        releaseFirst = resolve;
+    }));
+    const stale = coordinator.enqueueLatest(async () => {
+        calls.push('stale');
+    });
+    const latest = coordinator.enqueueLatest(async () => {
+        calls.push('latest');
+    });
+
+    await Promise.resolve();
+    assert.deepEqual(calls, ['first']);
+    await stale;
+    assert.deepEqual(calls, ['first'], 'a superseded pending intent settles as a no-op');
+    releaseFirst();
+    await Promise.all([first, latest]);
+    assert.deepEqual(calls, ['first', 'latest']);
+});
+
+test('AI-SESSION-NEXT-RUNNING-COMMAND-001 emits target-free queue timing for started, superseded, and settled intents', async () => {
+    let now = 100;
+    const timings = [];
+    const coordinator = createSessionNavigationCoordinator({
+        now: () => now,
+        onTiming: timing => timings.push(timing),
+    });
+    let releaseFirst;
+    const first = coordinator.enqueueLatest(() => new Promise(resolve => {
+        releaseFirst = resolve;
+    }));
+    await Promise.resolve();
+    now = 125;
+    const stale = coordinator.enqueueLatest(async () => {});
+    now = 140;
+    const latest = coordinator.enqueueLatest(async () => {});
+    await stale;
+    now = 200;
+    releaseFirst();
+    await Promise.all([first, latest]);
+
+    assert.deepEqual(timings, [
+        { event: 'started', latest: true, queueMs: 0 },
+        { event: 'superseded', latest: true, queueMs: 15 },
+        {
+            event: 'settled', latest: true, queueMs: 0,
+            executionMs: 100, outcome: 'succeeded',
+        },
+        { event: 'started', latest: true, queueMs: 60 },
+        {
+            event: 'settled', latest: true, queueMs: 60,
+            executionMs: 0, outcome: 'succeeded',
+        },
+    ]);
+});
+
 test('AI-SESSION-NEXT-RUNNING-COMMAND-001 makes a late handoff idempotent with a newer local jump', async () => {
     const queue = buildRunningSessionQueue({
         localSessions: [local('codex', 'b1'), local('codex', 'b2')],
@@ -703,6 +763,33 @@ test('AI-SESSION-NEXT-RUNNING-COMMAND-001 executes terminal focus and conversati
         ['focus', 'project-before-focus', 'codex', 'target'],
         ['open', 'project-before-focus', 'codex', 'target'],
     ], 'one transaction cannot focus and open against different workspace cards');
+});
+
+test('AI-SESSION-NEXT-RUNNING-COMMAND-001 reports target-free focus and conversation timings', async () => {
+    let now = 50;
+    const timings = [];
+    const executor = createSessionNavigationFocusExecutor({
+        getProjectId: () => 'project-a',
+        focusActive: async () => {
+            now = 70;
+            return true;
+        },
+        openConversation: async () => {
+            now = 95;
+            return true;
+        },
+        now: () => now,
+        onTiming: timing => timings.push(timing),
+    });
+
+    await executor.execute({ provider: 'codex', sessionId: 'sensitive-session-id' });
+
+    assert.deepEqual(timings, [{
+        outcome: 'conversation-opened',
+        focusMs: 20,
+        conversationMs: 25,
+        totalMs: 45,
+    }], 'performance diagnostics deliberately omit all target identity');
 });
 
 test('AI-SESSION-NEXT-RUNNING-COMMAND-001 does not open a conversation when local focus cannot be established', async () => {

--- a/tests/contract/dashboard/messageHandlers.test.js
+++ b/tests/contract/dashboard/messageHandlers.test.js
@@ -63,7 +63,17 @@ function createFixture(overrides = {}) {
             closeTerminal: record('closeTerminal'),
             stopSession: record('stopSession'),
         },
-        conversationCapability: { followActiveConversation: record('followActiveConversation') },
+        focusAiSessionAndFollowConversation: async target => {
+            calls.push(['focusActive', target.projectId, target.provider, target.sessionId]);
+            if (overrides.focused !== false) {
+                calls.push(['followActiveConversation', target]);
+            } else {
+                calls.push([
+                    'showWarningMessage',
+                    'Agent Pivot: the selected AI session is no longer active.',
+                ]);
+            }
+        },
         aiSessionArchiveController: { archiveSessions: record('archiveSessions') },
         acknowledgeAiSessionAttentionEventIds: overrides.acknowledgeAttention
             || record('acknowledgeAttention'),
@@ -77,7 +87,6 @@ function createFixture(overrides = {}) {
         dismissOpenTabLayoutNotice: overrides.dismissOpenTabLayoutNotice
             || (async () => { calls.push(['dismissOpenTabLayoutNotice']); }),
         openOpenTabLayoutMigrationGuide: async () => { calls.push(['openOpenTabLayoutMigrationGuide']); },
-        showWarningMessage: message => calls.push(['showWarningMessage', message]),
     });
     return { handlers, calls, posted };
 }

--- a/tests/contract/dashboardBoundaries.test.js
+++ b/tests/contract/dashboardBoundaries.test.js
@@ -657,8 +657,8 @@ test('AI-SESSION-QUICK-SWITCH-COMMANDS-001 CONVERSATION-ACTIVE-SESSION-NAVIGATIO
         assert.match(
             source,
             new RegExp(
-                `${direction}ActiveSession: \\(\\) => sessionNavigationCoordinator\\.enqueueLatest\\(`
-                    + `[\\s\\S]*?\\(\\) => followAdjacentActiveConversationWithFeedback\\('${direction}'\\)`
+                `${direction}ActiveSession: \\(\\) => \\{[\\s\\S]*?beginConversationNavigationIntent\\(\\);`
+                    + `[\\s\\S]*?followAdjacentActiveConversationWithFeedback\\('${direction}'\\)`
             )
         );
     }

--- a/tests/contract/dashboardBoundaries.test.js
+++ b/tests/contract/dashboardBoundaries.test.js
@@ -657,7 +657,7 @@ test('AI-SESSION-QUICK-SWITCH-COMMANDS-001 CONVERSATION-ACTIVE-SESSION-NAVIGATIO
         assert.match(
             source,
             new RegExp(
-                `${direction}ActiveSession: \\(\\) => sessionNavigationCoordinator\\.enqueue\\(`
+                `${direction}ActiveSession: \\(\\) => sessionNavigationCoordinator\\.enqueueLatest\\(`
                     + `[\\s\\S]*?\\(\\) => followAdjacentActiveConversationWithFeedback\\('${direction}'\\)`
             )
         );

--- a/tests/integration/dashboard/conversationOpenLatest.test.js
+++ b/tests/integration/dashboard/conversationOpenLatest.test.js
@@ -940,7 +940,7 @@ test('CONVERSATION-FOLLOW-ACTIVE-SESSION-001 follows the latest interaction only
     closedHarness.capability.dispose();
 });
 
-test('CONVERSATION-FOLLOW-ACTIVE-SESSION-001 routes a successful Active Session card focus into Conversation following', () => {
+test('CONVERSATION-FOLLOW-ACTIVE-SESSION-001 delegates Active Session card focus to the shared Conversation-aware navigation path', () => {
     const handlersSource = fs.readFileSync(
         path.join(__dirname, '../../../src/dashboard/messageHandlers.ts'),
         'utf8'
@@ -949,10 +949,20 @@ test('CONVERSATION-FOLLOW-ACTIVE-SESSION-001 routes a successful Active Session 
         /'focus-ai-session-terminal': async e => \{[\s\S]*?\n\s*\},\n\s*'focus-pending-ai-session'/
     );
     assert.ok(handler, 'Active Session focus handler must remain inspectable');
-    assert.match(handler[0], /focusActive\(/);
+    assert.match(handler[0], /focusAiSessionAndFollowConversation\(target\)/);
+
+    const dashboardSource = fs.readFileSync(
+        path.join(__dirname, '../../../src/dashboard.ts'),
+        'utf8'
+    );
+    const navigationPath = dashboardSource.match(
+        /const focusAiSessionAndFollowConversation[\s\S]*?\n\s*};\n\s*const conversationHandlers/
+    );
+    assert.ok(navigationPath, 'shared Active Session navigation path must remain inspectable');
+    assert.match(navigationPath[0], /focusActive\(/);
     assert.match(
-        handler[0],
-        /if \(focused\) \{[\s\S]*followActiveConversation\(/
+        navigationPath[0],
+        /if \(focused(?: && [^)]+)?\) \{[\s\S]*followActiveConversation\(/
     );
 });
 

--- a/tests/integration/dashboard/conversationViewer.test.js
+++ b/tests/integration/dashboard/conversationViewer.test.js
@@ -411,6 +411,65 @@ test('CONVERSATION-VIEWER-RENAME-001 forwards the rename intent for the current 
         'malformed or spoofed envelopes are dropped by the protocol validator');
 });
 
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 makes an outgoing document inert before a slow target transition becomes interactive', async () => {
+    const restore = deferred();
+    const renamed = [];
+    let loads = 0;
+    const { viewer, panel } = createViewer({
+        commentStore: {
+            async load() {
+                loads += 1;
+                return loads === 1
+                    ? { revision: 0, comments: [] }
+                    : restore.promise;
+            },
+            async save() {},
+        },
+        renameSession: async renameTarget => {
+            renamed.push(renameTarget.sessionId);
+        },
+    });
+    await viewer.open(target('session-a'));
+
+    const switching = viewer.follow(target('session-b'));
+    await new Promise(resolve => setImmediate(resolve));
+    assert.equal(panel.postedMessages.some(message =>
+        message.type === 'conversation-viewer-loading'
+            && message.target?.sessionId === 'session-b'
+    ), true, 'the reused panel must make session-a controls inert while session-b restores');
+    await panel.receive({
+        type: 'conversation-viewer-rename-session',
+        version: 1,
+    });
+    assert.deepEqual(renamed, [],
+        'an outgoing document action cannot apply to the already-replaced target');
+
+    restore.resolve({ revision: 0, comments: [] });
+    assert.equal(await switching, true);
+    await panel.receive({
+        type: 'conversation-viewer-rename-session',
+        version: 1,
+    });
+    assert.deepEqual(renamed, [],
+        'postMessage delivery alone cannot unlock the incoming target');
+    const publication = panel.postedMessages.filter(message =>
+        message.type === 'conversation-viewer-page'
+    ).at(-1);
+    await panel.receive({
+        type: 'conversation-viewer-applied',
+        version: 1,
+        subscriptionGeneration: publication.subscriptionGeneration,
+        requestId: publication.requestId,
+        htmlSignature: publication.htmlSignature,
+    });
+    await panel.receive({
+        type: 'conversation-viewer-rename-session',
+        version: 1,
+    });
+    assert.deepEqual(renamed, ['session-b']);
+    viewer.dispose();
+});
+
 test('CONVERSATION-TELEMETRY-CONTROLLER-001 refreshes telemetry while the visible conversation is otherwise idle', async () => {
     const timers = new Map();
     let nextTimer = 1;

--- a/tests/unit/tooling/architectureGuards.test.js
+++ b/tests/unit/tooling/architectureGuards.test.js
@@ -488,11 +488,12 @@ for (const mutation of [
     {
         id: 'ARCH-AI-SESSION-NAVIGATION-OWNERSHIP-001',
         file: 'src/dashboard.ts',
-        expectedDetail: 'Previous and Next Active Session commands must use the shared navigation coordinator',
+        expectedDetail: 'Previous and Next Active Session commands must invalidate an older row navigation',
         mutate: source => source.replace(
-            "previousActiveSession: () => sessionNavigationCoordinator.enqueueLatest(\n"
-                + "            () => followAdjacentActiveConversationWithFeedback('previous')\n"
-                + '        ),',
+            "previousActiveSession: () => {\n"
+                + '            beginConversationNavigationIntent();\n'
+                + "            return followAdjacentActiveConversationWithFeedback('previous');\n"
+                + '        },',
             "previousActiveSession: () => followAdjacentActiveConversationWithFeedback('previous'),",
         ),
     },
@@ -501,8 +502,8 @@ for (const mutation of [
         file: 'src/dashboard.ts',
         expectedDetail: 'Dashboard Chat-row clicks must use the shared latest-intent navigation transaction',
         mutate: source => source.replace(
-            '}): Promise<void> => sessionNavigationCoordinator.enqueueLatest(async () => {',
-            '}): Promise<void> => (async () => {',
+            'return sessionNavigationCoordinator.enqueueLatest(async () => {',
+            'return (async () => {',
         ),
     },
     {

--- a/tests/unit/tooling/architectureGuards.test.js
+++ b/tests/unit/tooling/architectureGuards.test.js
@@ -460,7 +460,7 @@ for (const mutation of [
         file: 'src/dashboard/sessionQuickSwitch.ts',
         expectedDetail: 'Quick Switch and Toggle must own no navigation path outside the shared transaction',
         mutate: source => source.replace(
-            'await navigationCoordinator.enqueue(() => jumpToLocal(target));',
+            'await navigationCoordinator.enqueueLatest(() => jumpToLocal(target));',
             'await jumpToLocal(target);',
         ),
     },
@@ -490,10 +490,19 @@ for (const mutation of [
         file: 'src/dashboard.ts',
         expectedDetail: 'Previous and Next Active Session commands must use the shared navigation coordinator',
         mutate: source => source.replace(
-            "previousActiveSession: () => sessionNavigationCoordinator.enqueue(\n"
+            "previousActiveSession: () => sessionNavigationCoordinator.enqueueLatest(\n"
                 + "            () => followAdjacentActiveConversationWithFeedback('previous')\n"
                 + '        ),',
             "previousActiveSession: () => followAdjacentActiveConversationWithFeedback('previous'),",
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-NAVIGATION-OWNERSHIP-001',
+        file: 'src/dashboard.ts',
+        expectedDetail: 'Dashboard Chat-row clicks must use the shared latest-intent navigation transaction',
+        mutate: source => source.replace(
+            '}): Promise<void> => sessionNavigationCoordinator.enqueueLatest(async () => {',
+            '}): Promise<void> => (async () => {',
         ),
     },
     {


### PR DESCRIPTION
## Summary

- Keep relative and cross-window Chat navigation lossless while coalescing only superseded absolute row selections.
- Serialize terminal focus across dashboard and Conversation navigation, and prevent stale Conversation content from accepting actions during a target transition.
- Add target-free navigation latency diagnostics and regression coverage for queue, focus, and Viewer transitions.

## Validation

- `npm run test-compile`
- Focused dashboard, conversation, navigation, contract, and architecture suites (351 passing before the CI-only test compatibility update)
- `tests/integration/dashboard/conversationOpenLatest.test.js` (43 passing after the update)
- Focused Conversation Viewer browser checks (2 passing)
- `npm run lint` (existing warnings only)
- `npm run test:behavior-contracts`
- `node scripts/run-dashboard-webview-checks.js`
- `SKIP_NPM_CI=1 npm run install-local`

## Skill harvest

- Keep relative navigation and delivered cross-window requests FIFO; latest-wins is safe only for already-resolved absolute targets.
- Treat Webview `postMessage` as delivery rather than visual application, and wait for a correlated applied acknowledgement before releasing transition actions.

## Owner approvals

After checks pass, comment:

```text
approve af8668618068a763c91828acf0aff1287a12ed66
```