### PR TITLE
feat: measure conversation application latency

### DIFF
--- a/src/aiSessions/conversation/composition.ts
+++ b/src/aiSessions/conversation/composition.ts
@@ -47,6 +47,7 @@ import {
 import {
     ConversationViewer,
     ConversationViewerApi,
+    ConversationViewerApplicationTiming,
     ConversationViewerOptions,
     ConversationViewerTarget,
 } from './viewer';
@@ -133,6 +134,7 @@ export interface ConversationCapabilityOptions {
     setTimer: typeof setTimeout;
     clearTimer: typeof clearTimeout;
     onDiagnostic: (event: SanitizedConversationDiagnostic) => void;
+    onViewerTiming?: (timing: ConversationViewerApplicationTiming) => void;
     getWorkspaceRootHostPaths?: () => readonly string[];
     /**
      * Changes-panel wiring (changes-panel PRD): session identity
@@ -461,6 +463,8 @@ function createAvailableConversationCapability(
         onDiagnostic: options.onDiagnostic
             ? event => options.onDiagnostic(event as never)
             : undefined,
+        onTiming: options.onViewerTiming,
+        now: options.now,
         setTimer: options.setTimer,
         clearTimer: options.clearTimer,
     }));

--- a/src/aiSessions/conversation/composition.ts
+++ b/src/aiSessions/conversation/composition.ts
@@ -135,6 +135,7 @@ export interface ConversationCapabilityOptions {
     clearTimer: typeof clearTimeout;
     onDiagnostic: (event: SanitizedConversationDiagnostic) => void;
     onViewerTiming?: (timing: ConversationViewerApplicationTiming) => void;
+    monotonicNow?: () => number;
     getWorkspaceRootHostPaths?: () => readonly string[];
     /**
      * Changes-panel wiring (changes-panel PRD): session identity
@@ -464,7 +465,7 @@ function createAvailableConversationCapability(
             ? event => options.onDiagnostic(event as never)
             : undefined,
         onTiming: options.onViewerTiming,
-        now: options.now,
+        now: options.monotonicNow,
         setTimer: options.setTimer,
         clearTimer: options.clearTimer,
     }));

--- a/src/aiSessions/conversation/viewer.ts
+++ b/src/aiSessions/conversation/viewer.ts
@@ -196,6 +196,9 @@ export interface ConversationViewerOptions {
     ) => PromiseLike<void> | Promise<void> | void;
     /** Diagnostics sink for load/switch failures (never throws). */
     onDiagnostic?: (event: Record<string, unknown>) => void;
+    /** Receives aggregate publication/application timing only. */
+    onTiming?: (timing: ConversationViewerApplicationTiming) => void;
+    now?: () => number;
     setTimer?: (callback: () => void, delayMs: number) => unknown;
     clearTimer?: (handle: unknown) => void;
 }
@@ -300,6 +303,19 @@ export interface ConversationViewerPageMessage {
     bookmarks: ConversationBookmarkSnapshot;
 }
 
+/**
+ * Aggregate timing for one authoritative Conversation publication. It never
+ * carries a workspace, provider, session, or other user content.
+ */
+export interface ConversationViewerApplicationTiming {
+    updateKind: ConversationViewerPageMessage['updateKind'];
+    delivery: 'document' | 'message';
+    /** Host publication to the Webview's correlated applied acknowledgement. */
+    applicationMs: number;
+    /** User target load to the first correlated Webview application. */
+    loadMs?: number;
+}
+
 export class ConversationViewer implements ConversationViewerApi {
     private panel?: vscode.WebviewPanel;
     private target?: ConversationViewerTarget;
@@ -323,6 +339,18 @@ export class ConversationViewer implements ConversationViewerApi {
     private currentRequestId = 0;
     private stale = false;
     private latestPublication?: ConversationViewerPageMessage;
+    private pendingPublicationTiming?: {
+        subscriptionGeneration: number;
+        requestId: number;
+        htmlSignature: string;
+        updateKind: ConversationViewerPageMessage['updateKind'];
+        delivery: 'document' | 'message';
+        publishedAt: number;
+    };
+    private pendingTargetLoadTiming?: {
+        subscriptionGeneration: number;
+        startedAt: number;
+    };
     // Advanced only by the Webview's correlated applied acknowledgement —
     // never by postMessage resolving, which proves queueing, not application.
     private appliedContentSignature?: string;
@@ -629,6 +657,7 @@ export class ConversationViewer implements ConversationViewerApi {
         snapshot?: ConversationSnapshot,
         forceDocumentReplacement = false
     ): Promise<boolean> {
+        const startedAt = this.now();
         const hadPanel = Boolean(this.panel);
         const followedPanel = reveal ? undefined : this.panel;
         const previousTarget = this.target;
@@ -650,6 +679,12 @@ export class ConversationViewer implements ConversationViewerApi {
             || previousTarget.projectId !== activeTarget.projectId
             || previousTarget.provider !== activeTarget.provider
             || previousTarget.sessionId !== activeTarget.sessionId;
+        if (targetChanged) {
+            this.pendingTargetLoadTiming = {
+                subscriptionGeneration: generation,
+                startedAt,
+            };
+        }
         if (hadPanel && targetChanged) {
             this.transitioningGeneration = generation;
         }
@@ -877,6 +912,8 @@ export class ConversationViewer implements ConversationViewerApi {
         this.telemetryController.reset();
         this.changesController?.reset();
         this.latestPublication = undefined;
+        this.pendingPublicationTiming = undefined;
+        this.pendingTargetLoadTiming = undefined;
         this.appliedContentSignature = undefined;
         this.commentController.reset();
         this.projectCommentController.reset();
@@ -984,6 +1021,8 @@ export class ConversationViewer implements ConversationViewerApi {
         this.telemetryController.reset();
         this.changesController?.reset();
         this.latestPublication = undefined;
+        this.pendingPublicationTiming = undefined;
+        this.pendingTargetLoadTiming = undefined;
         this.commentController.reset();
         this.projectCommentController.reset();
         this.bookmarkController.reset();
@@ -2124,6 +2163,7 @@ export class ConversationViewer implements ConversationViewerApi {
         }
         this.latestPublication = publication;
         if (replaceDocument) {
+            this.recordPublicationDelivery(publication, 'document');
             panel.webview.html = this.renderDocument(publication);
             return;
         }
@@ -2146,6 +2186,7 @@ export class ConversationViewer implements ConversationViewerApi {
                 : publication;
         let delivered = false;
         try {
+            this.recordPublicationDelivery(publication, 'message');
             delivered = await panel.webview.postMessage(wire);
         } catch (_error) {
             delivered = false;
@@ -2178,6 +2219,7 @@ export class ConversationViewer implements ConversationViewerApi {
             return;
         }
         this.appliedContentSignature = publication.htmlSignature;
+        this.reportPublicationApplication(publication);
         if (this.transitioningGeneration === message.subscriptionGeneration) {
             this.transitioningGeneration = undefined;
         }
@@ -2189,7 +2231,58 @@ export class ConversationViewer implements ConversationViewerApi {
         if (!panel || !publication || !this.isCurrentPublication(publication)) {
             return;
         }
+        this.recordPublicationDelivery(publication, 'document');
         panel.webview.html = this.renderDocument(publication);
+    }
+
+    private recordPublicationDelivery(
+        publication: ConversationViewerPageMessage,
+        delivery: ConversationViewerApplicationTiming['delivery']
+    ): void {
+        this.pendingPublicationTiming = {
+            subscriptionGeneration: publication.subscriptionGeneration,
+            requestId: publication.requestId,
+            htmlSignature: publication.htmlSignature,
+            updateKind: publication.updateKind,
+            delivery,
+            publishedAt: this.now(),
+        };
+    }
+
+    private reportPublicationApplication(
+        publication: ConversationViewerPageMessage
+    ): void {
+        const timing = this.pendingPublicationTiming;
+        if (!timing
+            || timing.subscriptionGeneration !== publication.subscriptionGeneration
+            || timing.requestId !== publication.requestId
+            || timing.htmlSignature !== publication.htmlSignature) {
+            return;
+        }
+        this.pendingPublicationTiming = undefined;
+        const now = this.now();
+        const loadTiming = this.pendingTargetLoadTiming;
+        const loadMs = loadTiming
+            && loadTiming.subscriptionGeneration === publication.subscriptionGeneration
+            ? Math.max(0, now - loadTiming.startedAt)
+            : undefined;
+        if (loadMs !== undefined) {
+            this.pendingTargetLoadTiming = undefined;
+        }
+        try {
+            this.options.onTiming?.({
+                updateKind: timing.updateKind,
+                delivery: timing.delivery,
+                applicationMs: Math.max(0, now - timing.publishedAt),
+                ...(loadMs === undefined ? {} : { loadMs }),
+            });
+        } catch (_error) {
+            // Timing must never affect the Conversation lifecycle.
+        }
+    }
+
+    private now(): number {
+        return this.options.now ? this.options.now() : Date.now();
     }
 
     private postLoadingNotice(

--- a/src/aiSessions/conversation/viewer.ts
+++ b/src/aiSessions/conversation/viewer.ts
@@ -308,6 +308,9 @@ export interface ConversationViewerPageMessage {
  * carries a workspace, provider, session, or other user content.
  */
 export interface ConversationViewerApplicationTiming {
+    /** Aggregate-only classification; it is not a cross-system trace id. */
+    source: 'open' | 'follow' | 'restore' | 'rebind'
+        | 'initial' | 'navigation' | 'refresh';
     updateKind: ConversationViewerPageMessage['updateKind'];
     delivery: 'document' | 'message';
     /** Host publication to the Webview's correlated applied acknowledgement. */
@@ -350,6 +353,7 @@ export class ConversationViewer implements ConversationViewerApi {
     private pendingTargetLoadTiming?: {
         subscriptionGeneration: number;
         startedAt: number;
+        source: 'open' | 'follow' | 'restore' | 'rebind';
     };
     // Advanced only by the Webview's correlated applied acknowledgement —
     // never by postMessage resolving, which proves queueing, not application.
@@ -515,7 +519,7 @@ export class ConversationViewer implements ConversationViewerApi {
         target: ConversationViewerTarget,
         snapshot?: ConversationSnapshot
     ): Promise<void> {
-        await this.loadTarget(target, true, snapshot);
+        await this.loadTarget(target, true, snapshot, false, 'open');
     }
 
     async restore(
@@ -529,7 +533,7 @@ export class ConversationViewer implements ConversationViewerApi {
         }
         panel.webview.options = this.webviewOptions();
         this.attachPanel(panel);
-        await this.loadTarget(target, false, snapshot, true);
+        await this.loadTarget(target, false, snapshot, true, 'restore');
     }
 
     async follow(
@@ -547,7 +551,7 @@ export class ConversationViewer implements ConversationViewerApi {
             && this.target.sessionId === target.sessionId) {
             return true;
         }
-        return this.loadTarget(target, false, snapshot);
+        return this.loadTarget(target, false, snapshot, false, 'follow');
     }
 
     async rebindSession(
@@ -603,7 +607,7 @@ export class ConversationViewer implements ConversationViewerApi {
             sessionId: next.sessionId,
             interactionId: selected.id,
             expectedRevision: outline.sourceRevision,
-        }, false, snapshot);
+        }, false, snapshot, false, 'rebind');
     }
 
     async freezeSessionMetadata(
@@ -655,7 +659,8 @@ export class ConversationViewer implements ConversationViewerApi {
         target: ConversationViewerTarget,
         reveal: boolean,
         snapshot?: ConversationSnapshot,
-        forceDocumentReplacement = false
+        forceDocumentReplacement = false,
+        source: 'open' | 'follow' | 'restore' | 'rebind' = 'follow'
     ): Promise<boolean> {
         const startedAt = this.now();
         const hadPanel = Boolean(this.panel);
@@ -683,6 +688,7 @@ export class ConversationViewer implements ConversationViewerApi {
             this.pendingTargetLoadTiming = {
                 subscriptionGeneration: generation,
                 startedAt,
+                source,
             };
         }
         if (hadPanel && targetChanged) {
@@ -2271,6 +2277,10 @@ export class ConversationViewer implements ConversationViewerApi {
         }
         try {
             this.options.onTiming?.({
+                source: loadTiming
+                    && loadTiming.subscriptionGeneration === publication.subscriptionGeneration
+                    ? loadTiming.source
+                    : timing.updateKind,
                 updateKind: timing.updateKind,
                 delivery: timing.delivery,
                 applicationMs: Math.max(0, now - timing.publishedAt),

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1981,6 +1981,7 @@ async function initializeDashboard(
         setTimer: setTimeout,
         clearTimer: clearTimeout,
         onDiagnostic: event => logAiSessionDiagnostic({ ...event }),
+        monotonicNow: () => performance.now(),
         onViewerTiming: timing => logAiSessionDiagnostic({
             event: 'session-navigation-viewer-application-latency',
             ...timing,

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1981,6 +1981,10 @@ async function initializeDashboard(
         setTimer: setTimeout,
         clearTimer: clearTimeout,
         onDiagnostic: event => logAiSessionDiagnostic({ ...event }),
+        onViewerTiming: timing => logAiSessionDiagnostic({
+            event: 'session-navigation-viewer-application-latency',
+            ...timing,
+        }),
         commentStore: conversationViewerCommentStore,
         projectCommentStore,
         bookmarkStore: conversationViewerBookmarkStore,

--- a/tests/integration/dashboard/conversationOpenLatest.test.js
+++ b/tests/integration/dashboard/conversationOpenLatest.test.js
@@ -223,6 +223,8 @@ function createHarness(options = {}) {
             || ((callback, delayMs) => setTimeout(callback, delayMs)),
         clearTimer: options.clearTimer || (handle => clearTimeout(handle)),
         onDiagnostic: options.onDiagnostic || (() => {}),
+        onViewerTiming: options.onViewerTiming,
+        monotonicNow: options.monotonicNow,
         resolveReboundTarget: options.resolveReboundTarget,
     }, {
         createCodexClient: options.createCodexClient || (() => ({ dispose() {} })),
@@ -339,6 +341,17 @@ test('CONVERSATION-OPEN-LATEST-001 opens the latest interaction of the resolved 
         duplicateDisplayName: false,
     }]);
     capability.dispose();
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 forwards the aggregate Viewer timing sink and monotonic clock', () => {
+    const onViewerTiming = () => undefined;
+    const harness = createHarness({
+        onViewerTiming,
+        monotonicNow: () => 42,
+    });
+    assert.equal(harness.viewerOptions.onTiming, onViewerTiming);
+    assert.equal(harness.viewerOptions.now(), 42);
+    harness.capability.dispose();
 });
 
 test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 opens Codex, Kimi, and Claude with one shared provider snapshot each', async () => {
@@ -963,6 +976,17 @@ test('CONVERSATION-FOLLOW-ACTIVE-SESSION-001 delegates Active Session card focus
     assert.match(
         navigationPath[0],
         /if \(focused(?: && [^)]+)?\) \{[\s\S]*followActiveConversation\(/
+    );
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 wires only aggregate Viewer application timing into dashboard diagnostics', () => {
+    const dashboardSource = fs.readFileSync(
+        path.join(__dirname, '../../../src/dashboard.ts'),
+        'utf8'
+    );
+    assert.match(
+        dashboardSource,
+        /monotonicNow: \(\) => performance\.now\(\),\n\s*onViewerTiming: timing => logAiSessionDiagnostic\(\{\n\s*event: 'session-navigation-viewer-application-latency',\n\s*\.\.\.timing,/
     );
 });
 

--- a/tests/integration/dashboard/conversationViewer.test.js
+++ b/tests/integration/dashboard/conversationViewer.test.js
@@ -413,8 +413,8 @@ test('CONVERSATION-VIEWER-RENAME-001 forwards the rename intent for the current 
         'malformed or spoofed envelopes are dropped by the protocol validator');
 });
 
-test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 records correlated, target-free Webview application timing for a reused-panel switch', async () => {
-    let now = 100;
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 records target-free timing for an initial document application', async () => {
+    let now = 10;
     const timings = [];
     const { viewer, panel } = createViewer({
         now: () => now,
@@ -422,13 +422,97 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 records correlated, target-free
     });
 
     await viewer.open(target('session-a'));
+    const publication = decodeInitialPublication(panel.webview.html);
+    now = 35;
+    await panel.receive({
+        type: 'conversation-viewer-applied',
+        version: 1,
+        subscriptionGeneration: publication.subscriptionGeneration,
+        requestId: publication.requestId,
+        htmlSignature: publication.htmlSignature,
+    });
+    assert.deepEqual(timings, [{
+        source: 'open',
+        updateKind: 'initial',
+        delivery: 'document',
+        applicationMs: 25,
+        loadMs: 25,
+    }]);
+    viewer.dispose();
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 records document timing after a message-delivery fallback', async () => {
+    let now = 100;
+    const timings = [];
+    const panel = fakePanel({ postMessageResult: false });
+    const { viewer } = createViewer({
+        panel,
+        now: () => now,
+        onTiming: timing => timings.push(timing),
+    });
+
+    await viewer.open(target('session-a'));
     now = 130;
     await viewer.follow(target('session-b'));
+    const publication = decodeInitialPublication(panel.webview.html);
+    now = 150;
+    await panel.receive({
+        type: 'conversation-viewer-applied',
+        version: 1,
+        subscriptionGeneration: publication.subscriptionGeneration,
+        requestId: publication.requestId,
+        htmlSignature: publication.htmlSignature,
+    });
+    assert.deepEqual(timings, [{
+        source: 'follow',
+        updateKind: 'initial',
+        delivery: 'document',
+        applicationMs: 20,
+        loadMs: 20,
+    }]);
+    viewer.dispose();
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 records correlated, target-free Webview application timing for a reused-panel switch', async () => {
+    let now = 100;
+    const timings = [];
+    const sessionBRead = deferred();
+    const { viewer, panel } = createViewer({
+        now: () => now,
+        onTiming: timing => timings.push(timing),
+        readPage: request => request.sessionId === 'session-b'
+            ? sessionBRead.promise
+            : Promise.resolve(page(request.sessionId, request.anchorInteractionId)),
+    });
+
+    await viewer.open(target('session-a'));
+    now = 130;
+    const switching = viewer.follow(target('session-b'));
+    await new Promise(resolve => setImmediate(resolve));
+    now = 175;
+    sessionBRead.resolve(page('session-b', 'input-1'));
+    await switching;
     const publication = panel.postedMessages.filter(message =>
         message.type === 'conversation-viewer-page'
     ).at(-1);
     assert.ok(publication, 'the reused panel must receive an authoritative page');
 
+    now = 140;
+    await panel.receive({
+        type: 'conversation-viewer-applied',
+        version: 1,
+        subscriptionGeneration: publication.subscriptionGeneration + 1,
+        requestId: publication.requestId,
+        htmlSignature: publication.htmlSignature,
+    });
+    now = 142;
+    await panel.receive({
+        type: 'conversation-viewer-applied',
+        version: 1,
+        subscriptionGeneration: publication.subscriptionGeneration,
+        requestId: publication.requestId,
+        htmlSignature: 'stale-signature',
+    });
     now = 145;
     await panel.receive({
         type: 'conversation-viewer-applied',
@@ -439,7 +523,7 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 records correlated, target-free
     });
     assert.deepEqual(timings, [], 'a stale acknowledgement must not produce timing');
 
-    now = 160;
+    now = 190;
     await panel.receive({
         type: 'conversation-viewer-applied',
         version: 1,
@@ -448,10 +532,11 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 records correlated, target-free
         htmlSignature: publication.htmlSignature,
     });
     assert.deepEqual(timings, [{
+        source: 'follow',
         updateKind: 'initial',
         delivery: 'message',
-        applicationMs: 30,
-        loadMs: 30,
+        applicationMs: 15,
+        loadMs: 60,
     }]);
     assert.equal('sessionId' in timings[0], false);
     assert.equal('provider' in timings[0], false);

--- a/tests/integration/dashboard/conversationViewer.test.js
+++ b/tests/integration/dashboard/conversationViewer.test.js
@@ -327,6 +327,8 @@ function createViewer(options = {}) {
         writeClipboardText: options.writeClipboardText,
         followAdjacentConversation: options.followAdjacentConversation,
         setKeyboardFocus: options.setKeyboardFocus,
+        onTiming: options.onTiming,
+        now: options.now,
         mediaUri: fileName => fakeUri(`file:///extension/media/${fileName}`),
         showThinking: options.showThinking,
         commentStore: options.commentStore,
@@ -409,6 +411,51 @@ test('CONVERSATION-VIEWER-RENAME-001 forwards the rename intent for the current 
     });
     assert.equal(renamed.length, 1,
         'malformed or spoofed envelopes are dropped by the protocol validator');
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 records correlated, target-free Webview application timing for a reused-panel switch', async () => {
+    let now = 100;
+    const timings = [];
+    const { viewer, panel } = createViewer({
+        now: () => now,
+        onTiming: timing => timings.push(timing),
+    });
+
+    await viewer.open(target('session-a'));
+    now = 130;
+    await viewer.follow(target('session-b'));
+    const publication = panel.postedMessages.filter(message =>
+        message.type === 'conversation-viewer-page'
+    ).at(-1);
+    assert.ok(publication, 'the reused panel must receive an authoritative page');
+
+    now = 145;
+    await panel.receive({
+        type: 'conversation-viewer-applied',
+        version: 1,
+        subscriptionGeneration: publication.subscriptionGeneration,
+        requestId: publication.requestId - 1,
+        htmlSignature: publication.htmlSignature,
+    });
+    assert.deepEqual(timings, [], 'a stale acknowledgement must not produce timing');
+
+    now = 160;
+    await panel.receive({
+        type: 'conversation-viewer-applied',
+        version: 1,
+        subscriptionGeneration: publication.subscriptionGeneration,
+        requestId: publication.requestId,
+        htmlSignature: publication.htmlSignature,
+    });
+    assert.deepEqual(timings, [{
+        updateKind: 'initial',
+        delivery: 'message',
+        applicationMs: 30,
+        loadMs: 30,
+    }]);
+    assert.equal('sessionId' in timings[0], false);
+    assert.equal('provider' in timings[0], false);
+    viewer.dispose();
 });
 
 test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 makes an outgoing document inert before a slow target transition becomes interactive', async () => {


### PR DESCRIPTION
## Summary

- Measure the elapsed time from a Chat target change to authoritative Conversation application, alongside the Webview-only application segment.
- Classify aggregate timing by open, follow, restore, rebind, or publication kind; use a monotonic clock and omit all target identity.
- Cover initial document delivery, reused-panel delivery, delivery fallback, stale acknowledgements, and dashboard/composition wiring.

## Validation

- `npm run test-compile`
- `node --test --test-concurrency=1 tests/integration/dashboard/conversationViewer.test.js tests/integration/dashboard/conversationOpenLatest.test.js` (152 passing)
- `npm run test:behavior-contracts`
- `node scripts/run-dashboard-webview-checks.js`
- `npm run test:architecture-guards`
- `npm run lint` (existing warnings only)
- `SKIP_NPM_CI=1 npm run install-local`

## Skill harvest

- No skill change: the existing Webview lifecycle and review-fix guidance covered this work. The review reinforced that publication delivery is not application, timing must use a monotonic clock, and aggregate telemetry must classify automatic restores separately from user navigation.

## Owner approvals

After checks pass, comment:

```text
approve f358c1c4061f905c62a43a9dd2215dcab2b2ff34
```