### PR TITLE
perf: shorten conversation switch apply path

### DIFF
--- a/media/conversationViewerScripts.js
+++ b/media/conversationViewerScripts.js
@@ -1685,6 +1685,42 @@
         });
     }
 
+    // Keep the first applied frame narrow: transcript content, selection,
+    // scroll position, and the header must be ready before the Host is told
+    // the target is usable. The secondary surfaces below are independent of
+    // that first frame and can run in the next animation frame instead of
+    // extending the visible Chat-switch pause. Both the request id and the
+    // render generation are checked so an A -> B -> C sequence cannot let
+    // deferred work for A or B repaint C.
+    function scheduleDeferredPagePresentation(message, renderGeneration) {
+        var subscriptionGeneration = message.subscriptionGeneration;
+        var requestId = message.requestId;
+        var apply = function () {
+            if (state.subscriptionGeneration !== subscriptionGeneration
+                || state.latestRequestId !== requestId
+                || state.renderGeneration !== renderGeneration) {
+                return;
+            }
+            applyCopyButtonLabels();
+            applyRunCommandButtonLabels();
+            outlineController.applyOutline(message);
+            if (subagentsController) {
+                subagentsController.apply(
+                    message.subagents,
+                    message.activeSubagent
+                );
+            }
+            commentsController.updateHighlights();
+            if (findController) findController.refresh();
+            renderMermaidDiagrams(renderGeneration);
+        };
+        if (typeof window.requestAnimationFrame === 'function') {
+            window.requestAnimationFrame(apply);
+            return;
+        }
+        window.setTimeout(apply, 0);
+    }
+
     function applyPage(message) {
         if (!validPage(message)
             || !applySessionGeneration(message)
@@ -1755,8 +1791,6 @@
                 }
             );
             applyWorklogStates();
-            applyCopyButtonLabels();
-            applyRunCommandButtonLabels();
             state.messageIds = reconciled.ids;
             state.messageSignatures = reconciled.signatures;
         }
@@ -1775,15 +1809,6 @@
             delete nextRestoreTarget.subagentId;
         }
         saveRestoreTarget(nextRestoreTarget);
-        outlineController.applyOutline(message);
-        if (subagentsController) {
-            subagentsController.apply(
-                message.subagents,
-                message.activeSubagent
-            );
-        }
-        commentsController.updateHighlights();
-        if (findController) findController.refresh();
         hideFollowNotice();
         if (conversationDisplayName
             && (typeof message.displayName === 'string'
@@ -1866,8 +1891,6 @@
                 }
             }
         }
-        renderMermaidDiagrams(renderGeneration);
-
         if (!isLiveRefresh) {
             var openingAtLatest = message.atLatest
                 && message.updateKind === 'initial';
@@ -1899,6 +1922,7 @@
                 reconcileController.trackEnd();
             }
             acknowledgePage(message);
+            scheduleDeferredPagePresentation(message, renderGeneration);
             return;
         }
 
@@ -1912,6 +1936,7 @@
             reconcileController.trackEnd();
         }
         acknowledgePage(message);
+        scheduleDeferredPagePresentation(message, renderGeneration);
     }
 
     function postNavigation(type) {

--- a/media/conversationViewerScripts.js
+++ b/media/conversationViewerScripts.js
@@ -1685,14 +1685,18 @@
         });
     }
 
-    // Keep the first applied frame narrow: transcript content, selection,
-    // scroll position, and the header must be ready before the Host is told
-    // the target is usable. The secondary surfaces below are independent of
-    // that first frame and can run in the next animation frame instead of
-    // extending the visible Chat-switch pause. Both the request id and the
-    // render generation are checked so an A -> B -> C sequence cannot let
-    // deferred work for A or B repaint C.
-    function scheduleDeferredPagePresentation(message, renderGeneration) {
+    // Keep the first painted frame narrow: transcript content, selection,
+    // scroll position, and the header are ready before the secondary
+    // surfaces run. Two animation frames make the browser present that
+    // content first; a single requestAnimationFrame would still run before
+    // the first paint. Both the request id and render generation are checked
+    // so an A -> B -> C sequence cannot let deferred work for A or B repaint
+    // C.
+    function scheduleDeferredPagePresentation(
+        message,
+        renderGeneration,
+        needsActionDecoration
+    ) {
         var subscriptionGeneration = message.subscriptionGeneration;
         var requestId = message.requestId;
         var apply = function () {
@@ -1701,24 +1705,37 @@
                 || state.renderGeneration !== renderGeneration) {
                 return;
             }
-            applyCopyButtonLabels();
-            applyRunCommandButtonLabels();
-            outlineController.applyOutline(message);
-            if (subagentsController) {
-                subagentsController.apply(
-                    message.subagents,
-                    message.activeSubagent
-                );
+            try {
+                if (needsActionDecoration) {
+                    applyCopyButtonLabels();
+                    applyRunCommandButtonLabels();
+                }
+                outlineController.applyOutline(message);
+                commentsController.updateHighlights();
+                if (findController) findController.refresh();
+                renderMermaidDiagrams(renderGeneration);
+                acknowledgePage(message);
+            } catch (_presentationError) {
+                requestConversationResync(message, _presentationError);
             }
-            commentsController.updateHighlights();
-            if (findController) findController.refresh();
-            renderMermaidDiagrams(renderGeneration);
         };
-        if (typeof window.requestAnimationFrame === 'function') {
-            window.requestAnimationFrame(apply);
+        // A retained, hidden Viewer has no user-visible frame to protect and
+        // Chromium can pause animation frames indefinitely. Finish it now so
+        // Host correlation, transition cleanup, and delta publication remain
+        // live while the user is working in another Dashboard surface.
+        if (document.visibilityState === 'hidden') {
+            apply();
             return;
         }
-        window.setTimeout(apply, 0);
+        if (typeof window.requestAnimationFrame === 'function') {
+            window.requestAnimationFrame(function () {
+                window.requestAnimationFrame(apply);
+            });
+            return;
+        }
+        window.setTimeout(function () {
+            window.setTimeout(apply, 0);
+        }, 0);
     }
 
     function applyPage(message) {
@@ -1827,6 +1844,15 @@
             applyConversationTaskName(message.target);
         }
         updatePosition(message);
+        // This controller owns visible identity and actionable subagent IDs,
+        // so it must agree with the transcript in the first painted frame.
+        // The remaining sidebar decoration is safely deferrable below.
+        if (subagentsController) {
+            subagentsController.apply(
+                message.subagents,
+                message.activeSubagent
+            );
+        }
         var latestInteraction = message.outline[message.outline.length - 1];
         var latestInteractionRendered = latestInteraction
             && Array.prototype.some.call(
@@ -1921,8 +1947,11 @@
             if (!openingAtLatest && !resumeFramePosition) {
                 reconcileController.trackEnd();
             }
-            acknowledgePage(message);
-            scheduleDeferredPagePresentation(message, renderGeneration);
+            scheduleDeferredPagePresentation(
+                message,
+                renderGeneration,
+                hasHtml || !!frame
+            );
             return;
         }
 
@@ -1935,8 +1964,11 @@
             );
             reconcileController.trackEnd();
         }
-        acknowledgePage(message);
-        scheduleDeferredPagePresentation(message, renderGeneration);
+        scheduleDeferredPagePresentation(
+            message,
+            renderGeneration,
+            hasHtml || !!frame
+        );
     }
 
     function postNavigation(type) {

--- a/src/webview/conversationViewerScripts.js
+++ b/src/webview/conversationViewerScripts.js
@@ -1685,6 +1685,42 @@
         });
     }
 
+    // Keep the first applied frame narrow: transcript content, selection,
+    // scroll position, and the header must be ready before the Host is told
+    // the target is usable. The secondary surfaces below are independent of
+    // that first frame and can run in the next animation frame instead of
+    // extending the visible Chat-switch pause. Both the request id and the
+    // render generation are checked so an A -> B -> C sequence cannot let
+    // deferred work for A or B repaint C.
+    function scheduleDeferredPagePresentation(message, renderGeneration) {
+        var subscriptionGeneration = message.subscriptionGeneration;
+        var requestId = message.requestId;
+        var apply = function () {
+            if (state.subscriptionGeneration !== subscriptionGeneration
+                || state.latestRequestId !== requestId
+                || state.renderGeneration !== renderGeneration) {
+                return;
+            }
+            applyCopyButtonLabels();
+            applyRunCommandButtonLabels();
+            outlineController.applyOutline(message);
+            if (subagentsController) {
+                subagentsController.apply(
+                    message.subagents,
+                    message.activeSubagent
+                );
+            }
+            commentsController.updateHighlights();
+            if (findController) findController.refresh();
+            renderMermaidDiagrams(renderGeneration);
+        };
+        if (typeof window.requestAnimationFrame === 'function') {
+            window.requestAnimationFrame(apply);
+            return;
+        }
+        window.setTimeout(apply, 0);
+    }
+
     function applyPage(message) {
         if (!validPage(message)
             || !applySessionGeneration(message)
@@ -1755,8 +1791,6 @@
                 }
             );
             applyWorklogStates();
-            applyCopyButtonLabels();
-            applyRunCommandButtonLabels();
             state.messageIds = reconciled.ids;
             state.messageSignatures = reconciled.signatures;
         }
@@ -1775,15 +1809,6 @@
             delete nextRestoreTarget.subagentId;
         }
         saveRestoreTarget(nextRestoreTarget);
-        outlineController.applyOutline(message);
-        if (subagentsController) {
-            subagentsController.apply(
-                message.subagents,
-                message.activeSubagent
-            );
-        }
-        commentsController.updateHighlights();
-        if (findController) findController.refresh();
         hideFollowNotice();
         if (conversationDisplayName
             && (typeof message.displayName === 'string'
@@ -1866,8 +1891,6 @@
                 }
             }
         }
-        renderMermaidDiagrams(renderGeneration);
-
         if (!isLiveRefresh) {
             var openingAtLatest = message.atLatest
                 && message.updateKind === 'initial';
@@ -1899,6 +1922,7 @@
                 reconcileController.trackEnd();
             }
             acknowledgePage(message);
+            scheduleDeferredPagePresentation(message, renderGeneration);
             return;
         }
 
@@ -1912,6 +1936,7 @@
             reconcileController.trackEnd();
         }
         acknowledgePage(message);
+        scheduleDeferredPagePresentation(message, renderGeneration);
     }
 
     function postNavigation(type) {

--- a/src/webview/conversationViewerScripts.js
+++ b/src/webview/conversationViewerScripts.js
@@ -1685,14 +1685,18 @@
         });
     }
 
-    // Keep the first applied frame narrow: transcript content, selection,
-    // scroll position, and the header must be ready before the Host is told
-    // the target is usable. The secondary surfaces below are independent of
-    // that first frame and can run in the next animation frame instead of
-    // extending the visible Chat-switch pause. Both the request id and the
-    // render generation are checked so an A -> B -> C sequence cannot let
-    // deferred work for A or B repaint C.
-    function scheduleDeferredPagePresentation(message, renderGeneration) {
+    // Keep the first painted frame narrow: transcript content, selection,
+    // scroll position, and the header are ready before the secondary
+    // surfaces run. Two animation frames make the browser present that
+    // content first; a single requestAnimationFrame would still run before
+    // the first paint. Both the request id and render generation are checked
+    // so an A -> B -> C sequence cannot let deferred work for A or B repaint
+    // C.
+    function scheduleDeferredPagePresentation(
+        message,
+        renderGeneration,
+        needsActionDecoration
+    ) {
         var subscriptionGeneration = message.subscriptionGeneration;
         var requestId = message.requestId;
         var apply = function () {
@@ -1701,24 +1705,37 @@
                 || state.renderGeneration !== renderGeneration) {
                 return;
             }
-            applyCopyButtonLabels();
-            applyRunCommandButtonLabels();
-            outlineController.applyOutline(message);
-            if (subagentsController) {
-                subagentsController.apply(
-                    message.subagents,
-                    message.activeSubagent
-                );
+            try {
+                if (needsActionDecoration) {
+                    applyCopyButtonLabels();
+                    applyRunCommandButtonLabels();
+                }
+                outlineController.applyOutline(message);
+                commentsController.updateHighlights();
+                if (findController) findController.refresh();
+                renderMermaidDiagrams(renderGeneration);
+                acknowledgePage(message);
+            } catch (_presentationError) {
+                requestConversationResync(message, _presentationError);
             }
-            commentsController.updateHighlights();
-            if (findController) findController.refresh();
-            renderMermaidDiagrams(renderGeneration);
         };
-        if (typeof window.requestAnimationFrame === 'function') {
-            window.requestAnimationFrame(apply);
+        // A retained, hidden Viewer has no user-visible frame to protect and
+        // Chromium can pause animation frames indefinitely. Finish it now so
+        // Host correlation, transition cleanup, and delta publication remain
+        // live while the user is working in another Dashboard surface.
+        if (document.visibilityState === 'hidden') {
+            apply();
             return;
         }
-        window.setTimeout(apply, 0);
+        if (typeof window.requestAnimationFrame === 'function') {
+            window.requestAnimationFrame(function () {
+                window.requestAnimationFrame(apply);
+            });
+            return;
+        }
+        window.setTimeout(function () {
+            window.setTimeout(apply, 0);
+        }, 0);
     }
 
     function applyPage(message) {
@@ -1827,6 +1844,15 @@
             applyConversationTaskName(message.target);
         }
         updatePosition(message);
+        // This controller owns visible identity and actionable subagent IDs,
+        // so it must agree with the transcript in the first painted frame.
+        // The remaining sidebar decoration is safely deferrable below.
+        if (subagentsController) {
+            subagentsController.apply(
+                message.subagents,
+                message.activeSubagent
+            );
+        }
         var latestInteraction = message.outline[message.outline.length - 1];
         var latestInteractionRendered = latestInteraction
             && Array.prototype.some.call(
@@ -1921,8 +1947,11 @@
             if (!openingAtLatest && !resumeFramePosition) {
                 reconcileController.trackEnd();
             }
-            acknowledgePage(message);
-            scheduleDeferredPagePresentation(message, renderGeneration);
+            scheduleDeferredPagePresentation(
+                message,
+                renderGeneration,
+                hasHtml || !!frame
+            );
             return;
         }
 
@@ -1935,8 +1964,11 @@
             );
             reconcileController.trackEnd();
         }
-        acknowledgePage(message);
-        scheduleDeferredPagePresentation(message, renderGeneration);
+        scheduleDeferredPagePresentation(
+            message,
+            renderGeneration,
+            hasHtml || !!frame
+        );
     }
 
     function postNavigation(type) {

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -484,6 +484,9 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 applies delta publications with
         await page.locator('[data-conversation-position]').textContent(),
         'Input 1 of 2'
     );
+    await page.evaluate(() => new Promise(resolve => {
+        requestAnimationFrame(() => requestAnimationFrame(resolve));
+    }));
     await page.evaluate(() => {
         window.__deltaNode = document.querySelector(
             '[data-message-id="delta-0"]'
@@ -493,6 +496,19 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 applies delta publications with
         window.DOMPurify.sanitize = function () {
             window.__sanitizeCalls += 1;
             return sanitize.apply(window.DOMPurify, arguments);
+        };
+        const messageContainer = document.querySelector(
+            '[data-conversation-messages]'
+        );
+        const querySelectorAll = messageContainer.querySelectorAll.bind(
+            messageContainer
+        );
+        messageContainer.querySelectorAll = function (selector) {
+            if (selector === '.conversation-message-copy, .conversation-code-copy'
+                || selector === '[data-conversation-run-command]') {
+                throw new Error('delta must not rescan action controls');
+            }
+            return querySelectorAll(selector);
         };
     });
 
@@ -504,6 +520,9 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 applies delta publications with
         selectedInteractionId: 'input-2',
         selectedInput: 2,
     });
+    await page.evaluate(() => new Promise(resolve => {
+        requestAnimationFrame(() => requestAnimationFrame(resolve));
+    }));
 
     assert.deepEqual(await page.evaluate(() => ({
         nodeRetained: document.querySelector('[data-message-id="delta-0"]')
@@ -537,6 +556,9 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 applies delta publications with
         htmlSignature: 'sig-delta-1',
         frames: [],
     }]);
+    assert.equal((await postedMessages(page)).some(message =>
+        message.type === 'conversation-viewer-request-sync'
+    ), false, 'the delta must not recover from an unnecessary action scan');
 
     // A delta whose signature does not match the applied content is dropped
     // and answered with a resync request instead of staying silently stale.
@@ -568,6 +590,11 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 applies delta publications with
 test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 reuses the sanitized page when switching back to a recent session', async t => {
     const page = await openViewerPage(t);
     await page.evaluate(() => {
+        window.__deferredPagePresentation = [];
+        window.requestAnimationFrame = callback => {
+            window.__deferredPagePresentation.push(callback);
+            return window.__deferredPagePresentation.length;
+        };
         window.__sanitizeCalls = 0;
         const sanitize = window.DOMPurify.sanitize;
         window.DOMPurify.sanitize = function () {
@@ -580,7 +607,9 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 reuses the sanitized page when 
         requestId: generation * 10,
         subscriptionGeneration: generation,
         html: `<article data-message-id="${marker}-0" `
-            + `data-interaction-id="${marker}-input"><p>${marker}</p></article>`,
+            + `data-interaction-id="${marker}-input">`
+            + '<button class="conversation-message-copy"></button>'
+            + `<p>${marker}</p></article>`,
         htmlSignature: signature,
         outline: [{
             interactionId: `${marker}-input`,
@@ -616,9 +645,19 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 reuses the sanitized page when 
         3, 'session-beta', 'beta-content', 'sig-beta-1'
     ));
     // Switching back to alpha with unchanged content must not re-sanitize.
-    await sendPage(page, sessionPage(
+    const restorePage = sessionPage(
         4, 'session-alpha', 'alpha-content', 'sig-alpha-1'
-    ));
+    );
+    delete restorePage.html;
+    restorePage.restoreFrame = true;
+    await sendPage(page, restorePage);
+    await page.evaluate(() => {
+        for (let index = 0;
+            index < window.__deferredPagePresentation.length;
+            index += 1) {
+            window.__deferredPagePresentation[index](0);
+        }
+    });
 
     assert.deepEqual(await page.evaluate(() => ({
         sanitizeCalls: window.__sanitizeCalls,
@@ -627,10 +666,15 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 reuses the sanitized page when 
         nodeIdentity: document.querySelector(
             '[data-message-id="alpha-content-0"]'
         ) === window.__alphaNode,
+        copyLabel: document.querySelector('.conversation-message-copy')
+            .getAttribute('aria-label'),
+        copyIcon: !!document.querySelector('.conversation-message-copy svg'),
     })), {
         sanitizeCalls: 2,
         content: 'alpha-content',
         nodeIdentity: true,
+        copyLabel: 'Copy',
+        copyIcon: true,
     });
 });
 
@@ -725,7 +769,7 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 restores a stashed frame with s
         `scroll position should return to 240, got ${outcome.scrollTop}`);
 });
 
-test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 acknowledges Chat content before deferred decorations and drops stale work', async t => {
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 paints Chat content before deferred decorations and drops stale work', async t => {
     const page = await openViewerPage(t, { controlledMermaid: true });
     await page.evaluate(() => {
         window.__deferredPagePresentation = [];
@@ -772,8 +816,8 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 acknowledges Chat content befor
         (await postedMessages(page)).filter(message =>
             message.type === 'conversation-viewer-applied'
         ).map(message => message.requestId),
-        [2, 3],
-        'the Host can accept the new authoritative target before decorations run'
+        [],
+        'a page stays pending until its full presentation has settled'
     );
     assert.equal(
         await page.locator('[data-conversation-messages]').innerText(),
@@ -783,23 +827,167 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 acknowledges Chat content befor
     assert.equal(
         await page.evaluate(() => window.__mermaidRenders.length),
         0,
-        'Mermaid is outside the critical acknowledgement path'
+        'Mermaid is outside the first visible Chat frame'
     );
 
     await page.evaluate(() => window.__deferredPagePresentation[0](0));
+    await page.evaluate(() => window.__deferredPagePresentation[1](0));
+    assert.deepEqual(
+        (await postedMessages(page)).filter(message =>
+            message.type === 'conversation-viewer-applied'
+        ).map(message => message.requestId),
+        [],
+        'the first animation frame is reserved for the transcript paint'
+    );
+
+    await page.evaluate(() => window.__deferredPagePresentation[2](0));
     assert.equal(
         await page.evaluate(() => window.__mermaidRenders.length),
         0,
         'the stale Chat cannot decorate the newer target'
     );
 
-    await page.evaluate(() => window.__deferredPagePresentation[1](0));
+    await page.evaluate(() => window.__deferredPagePresentation[3](0));
     await page.waitForFunction(() => window.__mermaidRenders.length === 1);
     assert.match(
         await page.evaluate(() => window.__mermaidRenders[0].source),
         /beta/,
         'only the current Chat schedules deferred decoration'
     );
+    assert.deepEqual(
+        (await postedMessages(page)).filter(message =>
+            message.type === 'conversation-viewer-applied'
+        ).map(message => message.requestId),
+        [3],
+        'only the fully presented current Chat is acknowledged'
+    );
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 requests a resync when deferred presentation fails', async t => {
+    const page = await openViewerPage(t);
+    await page.evaluate(() => {
+        window.__deferredPagePresentation = [];
+        window.requestAnimationFrame = callback => {
+            window.__deferredPagePresentation.push(callback);
+            return window.__deferredPagePresentation.length;
+        };
+    });
+    await sendPage(page, {
+        ...hostileConversationPage,
+        requestId: 2,
+        subscriptionGeneration: 2,
+        html: '<article data-message-id="deferred-message" '
+            + 'data-interaction-id="deferred-input">'
+            + '<button class="conversation-message-copy"></button>'
+            + '<p>deferred</p></article>',
+        htmlSignature: 'signature-deferred-presentation',
+        outline: [{
+            interactionId: 'deferred-input',
+            userPreview: 'deferred',
+            responseState: 'complete',
+        }],
+        selectedInteractionId: 'deferred-input',
+        selectedInput: 1,
+        totalInputs: 1,
+        previousCursor: undefined,
+        nextCursor: undefined,
+        target: {
+            projectId: 'project-1',
+            provider: 'codex',
+            sessionId: 'session-deferred',
+            interactionId: 'deferred-input',
+            displayName: 'deferred',
+        },
+        comments: { revision: 0, comments: [] },
+        projectComments: { revision: 0, comments: [] },
+        bookmarks: { revision: 0, interactionIds: [] },
+    });
+    await page.evaluate(() => {
+        const createElementNS = document.createElementNS.bind(document);
+        document.createElementNS = function (namespace, name) {
+            if (name === 'svg') {
+                throw new Error('deferred decoration failure');
+            }
+            return createElementNS(namespace, name);
+        };
+    });
+
+    await page.evaluate(() => window.__deferredPagePresentation[0](0));
+    await page.evaluate(() => window.__deferredPagePresentation[1](0));
+    await page.waitForFunction(() => window.__postedMessages.some(message =>
+        message.type === 'conversation-viewer-request-sync'
+    ));
+
+    const messages = await postedMessages(page);
+    assert.equal(messages.some(message =>
+        message.type === 'conversation-viewer-applied'
+        && message.requestId === 2
+    ), false, 'a failed decoration must not acknowledge the page');
+    assert.deepEqual(messages.find(message =>
+        message.type === 'conversation-viewer-request-sync'
+    ), {
+        type: 'conversation-viewer-request-sync',
+        version: 1,
+        subscriptionGeneration: 2,
+        projectId: 'project-1',
+        provider: 'codex',
+        sessionId: 'session-deferred',
+        applyError: 'deferred decoration failure',
+    });
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 acknowledges a hidden retained Viewer without waiting for animation frames', async t => {
+    const page = await openViewerPage(t);
+    await page.evaluate(() => {
+        Object.defineProperty(document, 'visibilityState', {
+            configurable: true,
+            get: () => 'hidden',
+        });
+        window.__deferredFrameCalls = 0;
+        window.requestAnimationFrame = () => {
+            window.__deferredFrameCalls += 1;
+            throw new Error('hidden Viewer must not wait for a frame');
+        };
+    });
+    await sendPage(page, {
+        ...hostileConversationPage,
+        requestId: 2,
+        subscriptionGeneration: 2,
+        html: '<article data-message-id="hidden-message" '
+            + 'data-interaction-id="hidden-input"><p>hidden</p></article>',
+        htmlSignature: 'signature-hidden-presentation',
+        outline: [{
+            interactionId: 'hidden-input',
+            userPreview: 'hidden',
+            responseState: 'complete',
+        }],
+        selectedInteractionId: 'hidden-input',
+        selectedInput: 1,
+        totalInputs: 1,
+        previousCursor: undefined,
+        nextCursor: undefined,
+        target: {
+            projectId: 'project-1',
+            provider: 'codex',
+            sessionId: 'session-hidden',
+            interactionId: 'hidden-input',
+            displayName: 'hidden',
+        },
+        comments: { revision: 0, comments: [] },
+        projectComments: { revision: 0, comments: [] },
+        bookmarks: { revision: 0, interactionIds: [] },
+    });
+
+    const result = await page.evaluate(() => ({
+        frameCalls: window.__deferredFrameCalls,
+        applied: window.__postedMessages.filter(message =>
+            message.type === 'conversation-viewer-applied'
+        ).map(message => message.requestId),
+    }));
+    assert.deepEqual(result, {
+        frameCalls: 0,
+        applied: [2],
+    });
 });
 
 test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 requests a resync when a restoreFrame page has no cached frame', async t => {
@@ -4122,8 +4310,53 @@ test('CONVERSATION-OUTLINE-NAVIGATION-001 keeps every side-panel view usable acr
 
     const previousViewerScript = viewerScript
         .replace(
-            /\n    \/\/ Keep the first applied frame narrow:[\s\S]*?\n    }\n\n    function applyPage\(message\) \{/,
+            /\n    \/\/ Keep the first painted frame narrow:[\s\S]*?\n    }\n\n    function applyPage\(message\) \{/,
             '\n    function applyPage(message) {'
+        )
+        .replace(
+            '        updatePosition(message);\n'
+                + '        // This controller owns visible identity and actionable subagent IDs,\n'
+                + '        // so it must agree with the transcript in the first painted frame.\n'
+                + '        // The remaining sidebar decoration is safely deferrable below.\n'
+                + '        if (subagentsController) {\n'
+                + '            subagentsController.apply(\n'
+                + '                message.subagents,\n'
+                + '                message.activeSubagent\n'
+                + '            );\n'
+                + '        }\n',
+            '        updatePosition(message);\n'
+        )
+        .replace(
+            '            scheduleDeferredPagePresentation(\n'
+                + '                message,\n'
+                + '                renderGeneration,\n'
+                + '                hasHtml || !!frame\n'
+                + '            );\n'
+                + '            return;',
+            '            acknowledgePage(message);\n'
+                + '            scheduleDeferredPagePresentation(\n'
+                + '                message,\n'
+                + '                renderGeneration,\n'
+                + '                hasHtml || !!frame\n'
+                + '            );\n'
+                + '            return;'
+        )
+        .replace(
+            '        scheduleDeferredPagePresentation(\n'
+                + '            message,\n'
+                + '            renderGeneration,\n'
+                + '            hasHtml || !!frame\n'
+                + '        );\n'
+                + '    }\n\n'
+                + '    function postNavigation(type) {',
+            '        acknowledgePage(message);\n'
+                + '        scheduleDeferredPagePresentation(\n'
+                + '            message,\n'
+                + '            renderGeneration,\n'
+                + '            hasHtml || !!frame\n'
+                + '        );\n'
+                + '    }\n\n'
+                + '    function postNavigation(type) {'
         )
         .replace(
             '            applyWorklogStates();\n'
@@ -4149,7 +4382,7 @@ test('CONVERSATION-OUTLINE-NAVIGATION-001 keeps every side-panel view usable acr
                 + '        hideFollowNotice();\n'
         )
         .replace(
-            /            scheduleDeferredPagePresentation\(message, renderGeneration\);\n/g,
+            /            scheduleDeferredPagePresentation\(\n                message,\n                renderGeneration,\n                hasHtml \|\| !!frame\n            \);\n/g,
             ''
         )
         .replace(
@@ -5680,7 +5913,11 @@ test('CONVERSATION-OUTLINE-NAVIGATION-001 keeps every side-panel view usable acr
         )
         .replace(
             '        acknowledgePage(message);\n'
-                + '        scheduleDeferredPagePresentation(message, renderGeneration);\n'
+                + '        scheduleDeferredPagePresentation(\n'
+                + '            message,\n'
+                + '            renderGeneration,\n'
+                + '            hasHtml || !!frame\n'
+                + '        );\n'
                 + '    }\n\n'
                 + '    function postNavigation(type) {\n',
             '    }\n\n'

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -725,6 +725,83 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 restores a stashed frame with s
         `scroll position should return to 240, got ${outcome.scrollTop}`);
 });
 
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 acknowledges Chat content before deferred decorations and drops stale work', async t => {
+    const page = await openViewerPage(t, { controlledMermaid: true });
+    await page.evaluate(() => {
+        window.__deferredPagePresentation = [];
+        window.requestAnimationFrame = callback => {
+            window.__deferredPagePresentation.push(callback);
+            return window.__deferredPagePresentation.length;
+        };
+    });
+    const sessionPage = (requestId, generation, sessionId, marker) => ({
+        ...hostileConversationPage,
+        requestId,
+        subscriptionGeneration: generation,
+        html: `<article data-message-id="${marker}-message" `
+            + `data-interaction-id="${marker}-input">`
+            + `<pre><code class="language-mermaid">flowchart TB\n${marker}</code></pre>`
+            + '</article>',
+        htmlSignature: `signature-${marker}`,
+        outline: [{
+            interactionId: `${marker}-input`,
+            userPreview: marker,
+            responseState: 'complete',
+        }],
+        selectedInteractionId: `${marker}-input`,
+        selectedInput: 1,
+        totalInputs: 1,
+        previousCursor: undefined,
+        nextCursor: undefined,
+        target: {
+            projectId: 'project-1',
+            provider: 'codex',
+            sessionId,
+            interactionId: `${marker}-input`,
+            displayName: marker,
+        },
+        comments: { revision: 0, comments: [] },
+        projectComments: { revision: 0, comments: [] },
+        bookmarks: { revision: 0, interactionIds: [] },
+    });
+
+    await sendPage(page, sessionPage(2, 2, 'session-alpha', 'alpha'));
+    await sendPage(page, sessionPage(3, 3, 'session-beta', 'beta'));
+
+    assert.deepEqual(
+        (await postedMessages(page)).filter(message =>
+            message.type === 'conversation-viewer-applied'
+        ).map(message => message.requestId),
+        [2, 3],
+        'the Host can accept the new authoritative target before decorations run'
+    );
+    assert.equal(
+        await page.locator('[data-conversation-messages]').innerText(),
+        'flowchart TB\nbeta',
+        'the newest Chat transcript is already usable'
+    );
+    assert.equal(
+        await page.evaluate(() => window.__mermaidRenders.length),
+        0,
+        'Mermaid is outside the critical acknowledgement path'
+    );
+
+    await page.evaluate(() => window.__deferredPagePresentation[0](0));
+    assert.equal(
+        await page.evaluate(() => window.__mermaidRenders.length),
+        0,
+        'the stale Chat cannot decorate the newer target'
+    );
+
+    await page.evaluate(() => window.__deferredPagePresentation[1](0));
+    await page.waitForFunction(() => window.__mermaidRenders.length === 1);
+    assert.match(
+        await page.evaluate(() => window.__mermaidRenders[0].source),
+        /beta/,
+        'only the current Chat schedules deferred decoration'
+    );
+});
+
 test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 requests a resync when a restoreFrame page has no cached frame', async t => {
     const page = await openViewerPage(t);
     const sessionPage = (generation, sessionId, marker, signature) => ({
@@ -2368,6 +2445,9 @@ test('WEBVIEW-AI-SESSION-SUBAGENT-VIEWER-001 lists subagents, opens a transcript
         subagents: [],
         activeSubagent: null,
     });
+    await rebuilt.page.evaluate(() => new Promise(resolve =>
+        requestAnimationFrame(() => requestAnimationFrame(resolve))
+    ));
     // The pill doubles as the Subagents quick entry and stays visible at
     // zero instead of disappearing.
     assert.equal(await counter.isVisible(), true);
@@ -4041,6 +4121,53 @@ test('CONVERSATION-OUTLINE-NAVIGATION-001 keeps every side-panel view usable acr
     }
 
     const previousViewerScript = viewerScript
+        .replace(
+            /\n    \/\/ Keep the first applied frame narrow:[\s\S]*?\n    }\n\n    function applyPage\(message\) \{/,
+            '\n    function applyPage(message) {'
+        )
+        .replace(
+            '            applyWorklogStates();\n'
+                + '            state.messageIds = reconciled.ids;\n',
+            '            applyWorklogStates();\n'
+                + '            applyCopyButtonLabels();\n'
+                + '            applyRunCommandButtonLabels();\n'
+                + '            state.messageIds = reconciled.ids;\n'
+        )
+        .replace(
+            '        saveRestoreTarget(nextRestoreTarget);\n'
+                + '        hideFollowNotice();\n',
+            '        saveRestoreTarget(nextRestoreTarget);\n'
+                + '        outlineController.applyOutline(message);\n'
+                + '        if (subagentsController) {\n'
+                + '            subagentsController.apply(\n'
+                + '                message.subagents,\n'
+                + '                message.activeSubagent\n'
+                + '            );\n'
+                + '        }\n'
+                + '        commentsController.updateHighlights();\n'
+                + '        if (findController) findController.refresh();\n'
+                + '        hideFollowNotice();\n'
+        )
+        .replace(
+            /            scheduleDeferredPagePresentation\(message, renderGeneration\);\n/g,
+            ''
+        )
+        .replace(
+            '        if (!isLiveRefresh) {\n',
+            '        renderMermaidDiagrams(renderGeneration);\n\n'
+                + '        if (!isLiveRefresh) {\n'
+        )
+        .replace(
+            '            reconcileController.trackEnd();\n'
+                + '        }\n'
+                + '        acknowledgePage(message);\n'
+                + '    }\n\n'
+                + '    function postNavigation(type) {\n',
+            '            reconcileController.trackEnd();\n'
+                + '        }\n'
+                + '    }\n\n'
+                + '    function postNavigation(type) {\n'
+        )
         // Strips the changes-panel tooltip overlay wiring (PRD §17) and the
         // action-binding target: the previous-generation script passed
         // neither a panelRoot nor a target to the changes controller.
@@ -5550,6 +5677,14 @@ test('CONVERSATION-OUTLINE-NAVIGATION-001 keeps every side-panel view usable acr
                 + '        var nextSignatures = reconciled.signatures;\n'
                 + '        state.messageIds = nextIds;\n'
                 + '        state.messageSignatures = nextSignatures;\n'
+        )
+        .replace(
+            '        acknowledgePage(message);\n'
+                + '        scheduleDeferredPagePresentation(message, renderGeneration);\n'
+                + '    }\n\n'
+                + '    function postNavigation(type) {\n',
+            '    }\n\n'
+                + '    function postNavigation(type) {\n'
         );
     const previousOutlineScript = conversationOutlineScript
         .replace(
@@ -8373,6 +8508,9 @@ test('CONVERSATION-COMMENTS-UI-001 filters cards, jumps from message markers, an
         subagents: [],
         activeSubagent: null,
     });
+    await page.evaluate(() => new Promise(resolve =>
+        requestAnimationFrame(() => requestAnimationFrame(resolve))
+    ));
     assert.equal(await page.locator('[data-comment-marker]').count(), 1);
 
     // Clear done empties the list in one correlated mutation.


### PR DESCRIPTION
## Summary
- paint the incoming Chat transcript before secondary Viewer decorations
- preserve applied acknowledgements, recovery, and hidden-panel liveness
- avoid redundant action-control scans for HTML-free updates

## Verification
- `npm run test-compile`
- `node --test --test-concurrency=1 tests/browser/conversationViewer.test.js`
- `npm run test:behavior-contracts`
- `SKIP_NPM_CI=1 npm run install-local`
- `git diff --check`

## Skill harvest
No skill change: the package build regenerated an unrelated stale stylesheet; the existing worktree guidance already requires preserving unrelated generated drift, so it was restored before publishing.

## Owner approvals
```text
approve 0d1bddbba71c0c5a9ef79e9f5fcd4e29b1b2bfea
```