### PR TITLE
perf: overlap conversation snapshot warmup

### DIFF
--- a/src/aiSessions/conversation/composition.ts
+++ b/src/aiSessions/conversation/composition.ts
@@ -549,10 +549,15 @@ function createAvailableConversationCapability(
             if (!viewer.isOpen()) {
                 return 'closed';
             }
-            const followed = await viewer.follow(
+            const follow = viewer.follow(
                 resolution.viewerTarget,
                 resolution.snapshot
             );
+            snapshotWarmup?.prepareAfterTargetSet(
+                resolution.viewerTarget,
+                viewer
+            );
+            const followed = await follow;
             if (followed) {
                 snapshotWarmup?.afterLoad(
                     resolution.viewerTarget,
@@ -810,7 +815,9 @@ async function openLatestConversation(
     if (!resolution.viewerTarget) {
         return resolution.result;
     }
-    await viewer.open(resolution.viewerTarget, resolution.snapshot);
+    const opening = viewer.open(resolution.viewerTarget, resolution.snapshot);
+    snapshotWarmup?.prepareAfterTargetSet(resolution.viewerTarget, viewer);
+    await opening;
     snapshotWarmup?.afterLoad(
         resolution.viewerTarget,
         resolution.prefetchedSnapshot === true,
@@ -911,10 +918,12 @@ async function followAdjacentConversation(
     if (!viewer.isOpen()) {
         return 'closed';
     }
-    const followed = await viewer.follow(
+    const follow = viewer.follow(
         resolution.viewerTarget,
         resolution.snapshot
     );
+    snapshotWarmup?.prepareAfterTargetSet(resolution.viewerTarget, viewer);
+    const followed = await follow;
     if (!isCurrent()) {
         return 'superseded';
     }
@@ -1063,23 +1072,33 @@ class ConversationSnapshotWarmup implements AiSessionDisposable {
         prefetchedSnapshot: boolean,
         viewer: ConversationViewerApi
     ): void {
-        // One serialized task instead of two racing ones: prefetching the
-        // adjacent sessions keeps a rapid follow-up switch instant, while
-        // revalidating the just-opened warm snapshot is hygiene that can
-        // wait until the prefetches are under way.
+        if (!prefetchedSnapshot) {
+            return;
+        }
+        // Revalidation is hygiene for a warm snapshot. It must wait for the
+        // authoritative page, but adjacent prefetching starts much earlier
+        // in prepareAfterTargetSet so it overlaps the visible load.
         this.schedule(async () => {
-            try {
-                this.prefetchAdjacent(target, viewer);
-            } catch (_error) {
-                // A prefetch hiccup must not skip the warm-snapshot
-                // revalidation below; warmup remains best effort.
-            }
-            if (!prefetchedSnapshot) {
-                return;
-            }
             const current = viewer.getCurrentTarget();
             if (current && hasSameConversationSession(current, target)) {
                 await viewer.revalidateLatest?.(target.interactionId);
+            }
+        });
+    }
+
+    prepareAfterTargetSet(
+        target: ConversationViewerTarget,
+        viewer: ConversationViewerApi
+    ): void {
+        // The target is committed before Viewer metadata restoration and the
+        // first authoritative page complete. Start the bounded, best-effort
+        // adjacent reads now so the next user switch can share them instead
+        // of waiting for this Viewer load to finish.
+        this.schedule(() => {
+            try {
+                this.prefetchAdjacent(target, viewer);
+            } catch (_error) {
+                // Speculative reads never affect the active Conversation.
             }
         });
     }

--- a/src/aiSessions/conversation/composition.ts
+++ b/src/aiSessions/conversation/composition.ts
@@ -1072,13 +1072,22 @@ class ConversationSnapshotWarmup implements AiSessionDisposable {
         prefetchedSnapshot: boolean,
         viewer: ConversationViewerApi
     ): void {
-        if (!prefetchedSnapshot) {
-            return;
-        }
-        // Revalidation is hygiene for a warm snapshot. It must wait for the
-        // authoritative page, but adjacent prefetching starts much earlier
-        // in prepareAfterTargetSet so it overlaps the visible load.
         this.schedule(async () => {
+            // Keep a post-load fallback for Viewer implementations that do
+            // not expose the new target until their async load settles. The
+            // cache deduplicates this with the early prepareAfterTargetSet
+            // prefetch in the usual path.
+            try {
+                this.prefetchAdjacent(target, viewer);
+            } catch (_error) {
+                // Speculative reads never affect the active Conversation.
+            }
+            if (!prefetchedSnapshot) {
+                return;
+            }
+            // Revalidation is hygiene for a warm snapshot. It must wait for
+            // the authoritative page, while adjacent prefetching normally
+            // starts much earlier in prepareAfterTargetSet.
             const current = viewer.getCurrentTarget();
             if (current && hasSameConversationSession(current, target)) {
                 await viewer.revalidateLatest?.(target.interactionId);

--- a/tests/integration/dashboard/conversationOpenLatest.test.js
+++ b/tests/integration/dashboard/conversationOpenLatest.test.js
@@ -491,6 +491,46 @@ test('CONVERSATION-OPEN-LATEST-001 retries an empty speculative snapshot before 
     harness.capability.dispose();
 });
 
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 starts adjacent warmup before the current Viewer load settles', async () => {
+    const sessions = ['codex', 'kimi'].map((provider, index) => makeSession({
+        key: `${provider}:overlap-${index}`,
+        provider,
+        sessionId: `overlap-${index}`,
+        name: `${provider} Session`,
+    }));
+    const delayedViewerLoad = deferred();
+    const harness = createHarness({
+        enableSnapshots: true,
+        requireSnapshot: true,
+        viewerOpen: true,
+        session: sessions[0],
+        resolveTarget: (_projectId, provider, sessionId) =>
+            sessions.find(session => session.provider === provider
+                && session.sessionId === sessionId) || null,
+        resolveActiveTargets: () => sessions,
+        openViewer: () => delayedViewerLoad.promise,
+    });
+
+    let opened = false;
+    const opening = harness.capability.openLatestConversation({
+        projectId: 'project-a',
+        provider: 'codex',
+        sessionId: 'overlap-0',
+    }).then(result => {
+        opened = true;
+        return result;
+    });
+    while (!harness.snapshotReadTargets.includes('kimi:overlap-1')) {
+        await new Promise(resolve => setImmediate(resolve));
+    }
+    assert.equal(opened, false,
+        'the current Viewer load remains pending while warmup begins');
+
+    delayedViewerLoad.resolve();
+    assert.equal(await opening, 'opened');
+    harness.capability.dispose();
+});
+
 test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 shares a slow in-flight warmup instead of starting a duplicate provider read', async () => {
     const sessions = ['codex', 'kimi'].map((provider, index) => makeSession({
         key: `${provider}:slow-${index}`,

--- a/tests/integration/dashboard/conversationOpenLatest.test.js
+++ b/tests/integration/dashboard/conversationOpenLatest.test.js
@@ -28,6 +28,16 @@ function deferred() {
     return { promise, resolve };
 }
 
+async function waitFor(condition, description, maxTurns = 100) {
+    for (let turn = 0; turn < maxTurns; turn += 1) {
+        if (condition()) {
+            return;
+        }
+        await new Promise(resolve => setTimeout(resolve, 0));
+    }
+    assert.fail(`Timed out waiting for ${description}`);
+}
+
 function loadConversationComposition() {
     const fakeVscode = {
         ViewColumn: { Beside: 2 },
@@ -141,7 +151,7 @@ function createHarness(options = {}) {
     let snapshotReads = 0;
     const snapshotReadTargets = [];
     let viewerRefreshes = 0;
-    let currentViewerTarget;
+    let currentViewerTarget = options.initialViewerTarget;
     const session = 'session' in options ? options.session : makeSession({
         conversationDisplayName: options.conversationDisplayName,
         duplicateConversationDisplayName:
@@ -267,6 +277,9 @@ function createHarness(options = {}) {
                 follow: async (target, snapshot) => {
                     followedViewerTargets.push(target);
                     viewerSnapshots.push(snapshot);
+                    if (options.commitFollowTargetImmediately === true) {
+                        currentViewerTarget = target;
+                    }
                     const followed = options.followViewer
                         ? options.followViewer(target)
                         : true;
@@ -520,14 +533,131 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 starts adjacent warmup before t
         opened = true;
         return result;
     });
-    while (!harness.snapshotReadTargets.includes('kimi:overlap-1')) {
-        await new Promise(resolve => setImmediate(resolve));
-    }
+    await waitFor(
+        () => harness.snapshotReadTargets.includes('kimi:overlap-1'),
+        'the adjacent snapshot warmup to start'
+    );
     assert.equal(opened, false,
         'the current Viewer load remains pending while warmup begins');
 
     delayedViewerLoad.resolve();
     assert.equal(await opening, 'opened');
+    harness.capability.dispose();
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 starts active and adjacent follow warmup before their Viewer load settles', async () => {
+    const sessions = ['codex', 'kimi', 'claude'].map((provider, index) =>
+        makeSession({
+            key: `${provider}:follow-overlap-${index}`,
+            provider,
+            sessionId: `follow-overlap-${index}`,
+            name: `${provider} Session`,
+        })
+    );
+    const initialTarget = {
+        projectId: 'project-a',
+        provider: 'codex',
+        sessionId: 'follow-overlap-0',
+    };
+    const delayedActiveFollow = deferred();
+    const activeHarness = createHarness({
+        enableSnapshots: true,
+        requireSnapshot: true,
+        viewerOpen: true,
+        initialViewerTarget: initialTarget,
+        commitFollowTargetImmediately: true,
+        session: sessions[0],
+        resolveTarget: (_projectId, provider, sessionId) =>
+            sessions.find(session => session.provider === provider
+                && session.sessionId === sessionId) || null,
+        resolveActiveTargets: () => sessions,
+        followViewer: () => delayedActiveFollow.promise,
+    });
+    let activeFollowed = false;
+    const activeFollow = activeHarness.capability.followActiveConversation({
+        projectId: 'project-a',
+        provider: 'kimi',
+        sessionId: 'follow-overlap-1',
+    }).then(result => {
+        activeFollowed = true;
+        return result;
+    });
+    await waitFor(
+        () => activeHarness.snapshotReadTargets.includes(
+            'claude:follow-overlap-2'
+        ),
+        'the active-follow adjacent snapshot warmup to start'
+    );
+    assert.equal(activeFollowed, false);
+    delayedActiveFollow.resolve(true);
+    assert.equal(await activeFollow, 'opened');
+    activeHarness.capability.dispose();
+
+    const delayedAdjacentFollow = deferred();
+    const adjacentHarness = createHarness({
+        enableSnapshots: true,
+        requireSnapshot: true,
+        viewerOpen: true,
+        initialViewerTarget: initialTarget,
+        commitFollowTargetImmediately: true,
+        session: sessions[0],
+        resolveTarget: (_projectId, provider, sessionId) =>
+            sessions.find(session => session.provider === provider
+                && session.sessionId === sessionId) || null,
+        resolveActiveTargets: () => sessions,
+        followViewer: () => delayedAdjacentFollow.promise,
+    });
+    const adjacentFollow = adjacentHarness.viewerOptions
+        .followAdjacentConversation('next', initialTarget);
+    await waitFor(
+        () => adjacentHarness.snapshotReadTargets.includes(
+            'claude:follow-overlap-2'
+        ),
+        'the adjacent-command warmup to start'
+    );
+    delayedAdjacentFollow.resolve(true);
+    assert.equal(await adjacentFollow, 'opened');
+    adjacentHarness.capability.dispose();
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 falls back to post-load warmup when Viewer commits its target asynchronously', async () => {
+    const sessions = ['codex', 'kimi'].map((provider, index) => makeSession({
+        key: `${provider}:fallback-${index}`,
+        provider,
+        sessionId: `fallback-${index}`,
+        name: `${provider} Session`,
+    }));
+    const delayedFollow = deferred();
+    const harness = createHarness({
+        enableSnapshots: true,
+        requireSnapshot: true,
+        viewerOpen: true,
+        initialViewerTarget: {
+            projectId: 'project-a',
+            provider: 'codex',
+            sessionId: 'fallback-0',
+        },
+        session: sessions[0],
+        resolveTarget: (_projectId, provider, sessionId) =>
+            sessions.find(session => session.provider === provider
+                && session.sessionId === sessionId) || null,
+        resolveActiveTargets: () => sessions,
+        followViewer: () => delayedFollow.promise,
+    });
+    const following = harness.capability.followActiveConversation({
+        projectId: 'project-a',
+        provider: 'kimi',
+        sessionId: 'fallback-1',
+    });
+    await new Promise(resolve => setImmediate(resolve));
+    assert.equal(harness.snapshotReadTargets.includes('codex:fallback-0'), false,
+        'early warmup must not read against the old Viewer target');
+    delayedFollow.resolve(true);
+    assert.equal(await following, 'opened');
+    await waitFor(
+        () => harness.snapshotReadTargets.includes('codex:fallback-0'),
+        'the post-load fallback warmup to start'
+    );
     harness.capability.dispose();
 });
 


### PR DESCRIPTION
## Summary

- Start bounded adjacent conversation snapshot warmup as soon as the Viewer target is committed.
- Retain a deduplicated post-load fallback for asynchronous Viewer target commits.
- Cover open, active follow, adjacent command follow, and delayed target commit timing.

## Verification

- npm run test-compile
- node --test --test-concurrency=1 tests/integration/dashboard/conversationOpenLatest.test.js
- npm run test:behavior-contracts
- SKIP_NPM_CI=1 npm run install-local
- git diff --check

## Skill harvest

No skill change: the review findings were product timing and coverage issues, now captured by focused tests; no reusable workflow guidance gap was identified.

## Owner approvals

After CI is green, comment:

```text
approve 69b6109acbed450bba825d0fb8f7eec65640bf73
```