### PR TITLE
Fix stale worktree group removal action

### DIFF
--- a/src/webview/webviewAiSessionContent.ts
+++ b/src/webview/webviewAiSessionContent.ts
@@ -1046,8 +1046,11 @@ function getWorktreeGroupRowHtml(
                 : '';
             // M3 batch 4 (PRD §6.4): the member-level inverse of Add repo —
             // remove one worktree from the group through the journaled
-            // deletion confirmation card. Only ready members are removable.
-            const removeAction = member.status === 'ready'
+            // deletion confirmation card. A missing member still carries an
+            // authoritative worktree key, so deletion can retire its stale
+            // group record even though its directory is already gone.
+            const removeAction = (member.status === 'ready'
+                || (member.status === 'missing' && !!member.worktreeKey))
                 ? `<button type="button" class="ai-session-worktree-member-remove" data-action="preview-group-member-deletion" data-group-id="${escapeAttribute(group.groupId)}" data-member-id="${escapeAttribute(member.memberId)}" aria-label="Remove the ${escapeAttribute(member.repositoryLabel)} worktree from ${escapeAttribute(name)} (keeps the local branch)" data-tooltip="Remove this worktree from the group…">${Icons.trash}</button>`
                 : '';
             return `<div class="ai-session-worktree-member-detail" data-member-id="${escapeAttribute(member.memberId)}" data-member-detail-status="${escapeAttribute(member.status)}">`

--- a/tests/browser/worktreeGroups.test.js
+++ b/tests/browser/worktreeGroups.test.js
@@ -1524,6 +1524,21 @@ test('WORKTREE-GROUPS-MEMBER-DELETE-001 removes a member through the card settle
     }), true, 'focus parks on the group header after the deletion');
 });
 
+test('WORKTREE-GROUPS-MEMBER-DELETE-001 offers removal for a missing worktree record', async t => {
+    const sessionHtml = () => surface({
+        worktreeGroups: [groupRow({
+            members: [member({ status: 'missing' })],
+        })],
+    });
+    const { page } = await openGroupActionsPage(t, sessionHtml);
+
+    await expandMemberDetails(page, 'g-1');
+    const removeButton = page.locator(
+        '[data-action="preview-group-member-deletion"][data-member-id="m-1"]');
+    assert.equal(await removeButton.count(), 1,
+        'a missing worktree still offers removal of its stale group record');
+});
+
 test('WORKTREE-GROUPS-MEMBER-DELETE-001 a blocked preview disables confirm and cancel restores focus', async t => {
     const sessionHtml = () => surface({
         worktreeGroups: [twoMemberGroup()],


### PR DESCRIPTION
## Summary

Expose the member removal action when a grouped worktree is missing on disk but retains its authoritative worktree key.

## Verification

- `npm run test-compile`
- `node --test tests/browser/worktreeGroups.test.js`
- `npm run test:behavior-contracts`
- `npm run lint`
- `git diff --check`

## Skill harvest

No skill change: this was a product rendering-state regression, not a reusable agent workflow gap.

## Owner approvals

```
approve 10d429c08dc057eab4fe69a4bce7c4f93d588acb
```