### PR TITLE
Perf: render recent conversation messages first

### DIFF
--- a/media/conversationViewerScripts.js
+++ b/media/conversationViewerScripts.js
@@ -1893,6 +1893,9 @@
         if (message.partial) {
             statusMessages.push('Partial history — showing newest inputs.');
         }
+        if (messages.querySelector('.conversation-deferred-messages')) {
+            statusMessages.push('Loading earlier messages.');
+        }
         status.textContent = statusMessages.join(' ');
 
         var selectedMessages = Array.prototype.filter.call(

--- a/src/aiSessions/conversation/viewer.ts
+++ b/src/aiSessions/conversation/viewer.ts
@@ -344,6 +344,19 @@ export class ConversationViewer implements ConversationViewerApi {
     private currentRequestId = 0;
     private stale = false;
     private latestPublication?: ConversationViewerPageMessage;
+    // A large, latest-at-tail page first sends its recent messages. Once the
+    // Webview has applied that lightweight page, it receives the complete
+    // retained window through the normal, correlated publication channel.
+    // Keeping this state on the publication (rather than an unbound timer)
+    // makes a target change or user navigation naturally cancel the follow-up.
+    private progressivePublication?: ConversationViewerPageMessage;
+    // A partial page remains incomplete until a different full-content page
+    // applies. Auxiliary and subagent publications may supersede either
+    // phase, so this is bound to the generation instead of one request id.
+    private progressiveContentIncomplete?: {
+        generation: number;
+        partialHtmlSignature: string;
+    };
     private pendingPublicationTiming?: {
         subscriptionGeneration: number;
         requestId: number;
@@ -823,7 +836,15 @@ export class ConversationViewer implements ConversationViewerApi {
             this.abortController = undefined;
             this.watch?.dispose();
             this.watch = undefined;
+            const previousGeneration = this.subscriptionGeneration;
             this.subscriptionGeneration += 1;
+            if (this.progressiveContentIncomplete?.generation
+                === previousGeneration) {
+                this.progressiveContentIncomplete = {
+                    ...this.progressiveContentIncomplete,
+                    generation: this.subscriptionGeneration,
+                };
+            }
             this.pendingRestoredAuxiliaryState = undefined;
             this.currentRequestId = this.allocateRequestId();
             if (this.pages.length && this.outlineController.snapshot) {
@@ -928,6 +949,8 @@ export class ConversationViewer implements ConversationViewerApi {
         this.changesController?.reset();
         this.latestPublication = undefined;
         this.clearPublicationAckTimeout();
+        this.progressivePublication = undefined;
+        this.progressiveContentIncomplete = undefined;
         this.pendingPublicationTiming = undefined;
         this.pendingTargetLoadTiming = undefined;
         this.pendingRestoredAuxiliaryState = undefined;
@@ -1042,6 +1065,8 @@ export class ConversationViewer implements ConversationViewerApi {
         this.changesController?.reset();
         this.latestPublication = undefined;
         this.clearPublicationAckTimeout();
+        this.progressivePublication = undefined;
+        this.progressiveContentIncomplete = undefined;
         this.pendingPublicationTiming = undefined;
         this.pendingTargetLoadTiming = undefined;
         this.pendingRestoredAuxiliaryState = undefined;
@@ -2017,11 +2042,21 @@ export class ConversationViewer implements ConversationViewerApi {
             if (!this.canPublish(panel, target, generation, requestId)) {
                 return false;
             }
+            const progressive = updateKind === 'initial'
+                && this.shouldProgressivelyRender();
             const publication = this.createPublication(
                 requestId,
                 generation,
-                updateKind
+                updateKind,
+                progressive
             );
+            if (progressive) {
+                this.progressivePublication = publication;
+                this.progressiveContentIncomplete = {
+                    generation,
+                    partialHtmlSignature: publication.htmlSignature,
+                };
+            }
             await this.deliverPublication(publication, replaceDocument);
             this.refreshSubagentsAfterPublication(
                 panel,
@@ -2321,11 +2356,38 @@ export class ConversationViewer implements ConversationViewerApi {
         // healthy again, so a later independent failure may use recovery.
         this.publicationRecoveryGeneration = undefined;
         this.clearPublicationAckTimeout();
+        if (this.progressiveContentIncomplete
+            && this.progressiveContentIncomplete.generation
+                === publication.subscriptionGeneration
+            && this.progressiveContentIncomplete.partialHtmlSignature
+                !== publication.htmlSignature) {
+            this.progressiveContentIncomplete = undefined;
+            this.progressivePublication = undefined;
+        }
         this.reportPublicationApplication(publication);
         if (this.transitioningGeneration === message.subscriptionGeneration) {
             this.transitioningGeneration = undefined;
         }
         this.publishRestoredAuxiliaryState();
+        this.publishDeferredMessages(publication);
+    }
+
+    private publishDeferredMessages(
+        publication: ConversationViewerPageMessage
+    ): void {
+        if (this.progressivePublication !== publication
+            || !this.isCurrentPublication(publication)) {
+            return;
+        }
+        this.progressivePublication = undefined;
+        const requestId = this.allocateRequestId();
+        this.currentRequestId = requestId;
+        const complete = this.createPublication(
+            requestId,
+            publication.subscriptionGeneration,
+            'refresh'
+        );
+        void this.deliverPublication(complete, false);
     }
 
     private rebuildLatestDocument(): void {
@@ -2355,6 +2417,11 @@ export class ConversationViewer implements ConversationViewerApi {
                 ? { restoreFocus: true }
                 : {}),
         };
+        if (this.progressivePublication === publication) {
+            // Recovery owns a fresh object and request id. Preserve the
+            // deferred-content lifecycle on that authoritative retry.
+            this.progressivePublication = recovery;
+        }
         this.currentRequestId = recovery.requestId;
         this.latestPublication = recovery;
         this.publicationRecoveryAttemptRequestId = recovery.requestId;
@@ -2381,9 +2448,14 @@ export class ConversationViewer implements ConversationViewerApi {
         publication: ConversationViewerPageMessage
     ): void {
         this.clearPublicationAckTimeout();
-        // A fresh document has no outgoing controls to strand. This watchdog
-        // only protects a reused panel held in its loading handoff.
-        if (this.transitioningGeneration !== publication.subscriptionGeneration) {
+        const protectsProgressiveContent = this.progressiveContentIncomplete
+            ?.generation === publication.subscriptionGeneration;
+        // A fresh document has no outgoing controls to strand. The normal
+        // watchdog protects a reused-panel handoff; every publication in a
+        // progressive generation inherits it until a full-content receipt
+        // closes the incomplete-content obligation.
+        if (this.transitioningGeneration !== publication.subscriptionGeneration
+            && !protectsProgressiveContent) {
             return;
         }
         const token = ++this.publicationAckTimerToken;
@@ -2394,8 +2466,10 @@ export class ConversationViewer implements ConversationViewerApi {
             this.publicationAckTimer = undefined;
             if (!this.isCurrentPublication(publication)
                 || this.appliedContentSignature === publication.htmlSignature
-                || this.transitioningGeneration
+                || (this.transitioningGeneration
                     !== publication.subscriptionGeneration
+                    && this.progressiveContentIncomplete?.generation
+                        !== publication.subscriptionGeneration)
                 || this.publicationRecoveryRebuildRequestId
                     === publication.requestId
                 || this.publicationRecoveryAttemptRequestId
@@ -2797,7 +2871,8 @@ export class ConversationViewer implements ConversationViewerApi {
     private createPublication(
         requestId: number,
         generation: number,
-        updateKind: ConversationViewerPageMessage['updateKind']
+        updateKind: ConversationViewerPageMessage['updateKind'],
+        recentOnly = false
     ): ConversationViewerPageMessage {
         const target = this.target;
         const outline = this.outlineController.snapshot;
@@ -2825,13 +2900,21 @@ export class ConversationViewer implements ConversationViewerApi {
         );
         const first = this.pages[0]?.page;
         const last = this.pages[this.pages.length - 1]?.page;
+        const allMessages = this.messages();
+        const deferredMessageCount = recentOnly && projection.atLatest
+            && !projection.partial
+            ? deferredConversationMessageCount(allMessages)
+            : 0;
         const rendered = renderMessages(
-            this.messages(),
+            deferredMessageCount
+                ? allMessages.slice(deferredMessageCount)
+                : allMessages,
             this.showThinking(),
             interactionInfo,
             this.renderCache,
             this.contentSignatures,
-            this.effectiveSessionId(target)
+            this.effectiveSessionId(target),
+            deferredMessageCount
         );
         return {
             type: 'conversation-viewer-page',
@@ -2867,6 +2950,13 @@ export class ConversationViewer implements ConversationViewerApi {
             projectComments: this.projectCommentController.snapshot,
             bookmarks: this.bookmarkController.snapshot,
         };
+    }
+
+    private shouldProgressivelyRender(): boolean {
+        const projection = this.outlineController.createPublication();
+        return projection.atLatest
+            && !projection.partial
+            && deferredConversationMessageCount(this.messages()) > 0;
     }
 
     private renderDocument(
@@ -3276,7 +3366,8 @@ function renderMessages(
     interactionInfo: Map<string, ConversationInteractionRenderInfo>,
     renderCache: ConversationMessageRenderCache,
     contentSignatures: ConversationContentSignatureRegistry,
-    sessionId: string
+    sessionId: string,
+    deferredMessageCount = 0
 ): RenderedConversationMessages {
     const groups: ConversationMessage[][] = [];
     messages.forEach(message => {
@@ -3348,9 +3439,31 @@ function renderMessages(
         return rendered.join('');
     }).join('');
     return {
-        html,
+        html: deferredMessageCount
+            ? `<section class="conversation-deferred-messages">Loading earlier messages…</section>${html}`
+            : html,
         contentSignature: contentSignatures.tokenFor(
-            contentStream.toString()
+            `${deferredMessageCount}\u0001${contentStream.toString()}`
         ),
     };
+}
+
+const CONVERSATION_PROGRESSIVE_RENDER_THRESHOLD = 24;
+const CONVERSATION_PROGRESSIVE_RENDER_RECENT_COUNT = 12;
+
+function deferredConversationMessageCount(
+    messages: readonly ConversationMessage[]
+): number {
+    if (messages.length <= CONVERSATION_PROGRESSIVE_RENDER_THRESHOLD) {
+        return 0;
+    }
+    // Do not split one interaction's message group (tool/progress/thinking
+    // entries can precede its final assistant response).
+    let firstVisible = messages.length - CONVERSATION_PROGRESSIVE_RENDER_RECENT_COUNT;
+    const interactionId = messages[firstVisible]?.interactionId;
+    while (firstVisible > 0
+        && messages[firstVisible - 1].interactionId === interactionId) {
+        firstVisible -= 1;
+    }
+    return firstVisible;
 }

--- a/src/webview/conversationViewerScripts.js
+++ b/src/webview/conversationViewerScripts.js
@@ -1893,6 +1893,9 @@
         if (message.partial) {
             statusMessages.push('Partial history — showing newest inputs.');
         }
+        if (messages.querySelector('.conversation-deferred-messages')) {
+            statusMessages.push('Loading earlier messages.');
+        }
         status.textContent = statusMessages.join(' ');
 
         var selectedMessages = Array.prototype.filter.call(

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -5987,6 +5987,12 @@ test('CONVERSATION-OUTLINE-NAVIGATION-001 keeps every side-panel view usable acr
                 + '            );\n'
                 + '        }\n',
             ''
+        )
+        .replace(
+            "        if (messages.querySelector('.conversation-deferred-messages')) {\n"
+                + "            statusMessages.push('Loading earlier messages.');\n"
+                + '        }\n',
+            ''
         );
     const previousOutlineScript = conversationOutlineScript
         .replace(

--- a/tests/integration/dashboard/conversationViewer.test.js
+++ b/tests/integration/dashboard/conversationViewer.test.js
@@ -189,6 +189,254 @@ function lastContentPublication(panel) {
     return publication;
 }
 
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-002 publishes recent messages before completing a long latest page', async () => {
+    const sessionId = 'progressive-page';
+    const interactionIds = Array.from(
+        { length: 30 },
+        (_item, index) => `input-${index + 1}`
+    );
+    const { viewer, panel } = createViewer({
+        readOutline: async () => outline(sessionId, interactionIds),
+        readPage: async () => page(sessionId, interactionIds[0], 'message', {
+            interactionIds,
+            anchorInteractionId: interactionIds.at(-1),
+        }),
+    });
+
+    await viewer.open(target(sessionId, interactionIds.at(-1)));
+
+    const recent = decodeInitialPublication(panel.webview.html);
+    assert.match(recent.html, /Loading earlier messages/);
+    assert.match(recent.html, /message-29/);
+    assert.doesNotMatch(recent.html, /message-0/);
+
+    await panel.receive({
+        type: 'conversation-viewer-applied',
+        version: 1,
+        subscriptionGeneration: recent.subscriptionGeneration,
+        requestId: recent.requestId,
+        htmlSignature: recent.htmlSignature,
+    });
+
+    const complete = lastContentPublication(panel);
+    assert.equal(complete.updateKind, 'refresh');
+    assert.doesNotMatch(complete.html, /Loading earlier messages/);
+    assert.match(complete.html, /message-0/);
+    assert.match(complete.html, /message-29/);
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-002 completes a recovered recent-message page', async () => {
+    const sessionId = 'progressive-recovery';
+    const interactionIds = Array.from(
+        { length: 30 },
+        (_item, index) => `input-${index + 1}`
+    );
+    const { viewer, panel } = createViewer({
+        readOutline: async () => outline(sessionId, interactionIds),
+        readPage: async () => page(sessionId, interactionIds[0], 'message', {
+            interactionIds,
+            anchorInteractionId: interactionIds.at(-1),
+        }),
+    });
+
+    await viewer.open(target(sessionId, interactionIds.at(-1)));
+    const partial = decodeInitialPublication(panel.webview.html);
+    await panel.receive({
+        type: 'conversation-viewer-request-sync',
+        version: 1,
+        subscriptionGeneration: partial.subscriptionGeneration,
+        requestId: partial.requestId,
+        htmlSignature: partial.htmlSignature,
+        projectId: 'project-a',
+        provider: 'codex',
+        sessionId,
+    });
+    const recovered = decodeInitialPublication(panel.webview.html);
+    assert.notEqual(recovered.requestId, partial.requestId);
+    assert.match(recovered.html, /Loading earlier messages/);
+
+    await panel.receive({
+        type: 'conversation-viewer-applied',
+        version: 1,
+        subscriptionGeneration: recovered.subscriptionGeneration,
+        requestId: recovered.requestId,
+        htmlSignature: recovered.htmlSignature,
+    });
+    const complete = lastContentPublication(panel);
+    assert.doesNotMatch(complete.html, /Loading earlier messages/);
+    assert.match(complete.html, /message-0/);
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-002 recovers a dropped complete progressive page', async () => {
+    const sessionId = 'progressive-completion-timeout';
+    const interactionIds = Array.from(
+        { length: 30 },
+        (_item, index) => `input-${index + 1}`
+    );
+    const timers = new Map();
+    let nextTimer = 1;
+    const { viewer, panel } = createViewer({
+        setTimer(callback, delayMs) {
+            const handle = nextTimer++;
+            timers.set(handle, { callback, delayMs });
+            return handle;
+        },
+        clearTimer(handle) {
+            timers.delete(handle);
+        },
+        readOutline: async () => outline(sessionId, interactionIds),
+        readPage: async () => page(sessionId, interactionIds[0], 'message', {
+            interactionIds,
+            anchorInteractionId: interactionIds.at(-1),
+        }),
+    });
+
+    await viewer.open(target(sessionId, interactionIds.at(-1)));
+    const partial = decodeInitialPublication(panel.webview.html);
+    await panel.receive({
+        type: 'conversation-viewer-applied',
+        version: 1,
+        subscriptionGeneration: partial.subscriptionGeneration,
+        requestId: partial.requestId,
+        htmlSignature: partial.htmlSignature,
+    });
+    const timer = Array.from(timers.values()).find(candidate =>
+        candidate.delayMs === 4_000
+    );
+    assert.ok(timer, 'the complete progressive page must be acknowledged');
+
+    timer.callback();
+    const recovered = decodeInitialPublication(panel.webview.html);
+    assert.doesNotMatch(recovered.html, /Loading earlier messages/);
+    assert.match(recovered.html, /message-0/);
+    viewer.dispose();
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-002 recovers a lost first progressive acknowledgement', async () => {
+    const sessionId = 'progressive-first-ack-timeout';
+    const interactionIds = Array.from(
+        { length: 30 },
+        (_item, index) => `input-${index + 1}`
+    );
+    const timers = new Map();
+    let nextTimer = 1;
+    const { viewer, panel } = createViewer({
+        setTimer(callback, delayMs) {
+            const handle = nextTimer++;
+            timers.set(handle, { callback, delayMs });
+            return handle;
+        },
+        clearTimer(handle) {
+            timers.delete(handle);
+        },
+        readOutline: async () => outline(sessionId, interactionIds),
+        readPage: async () => page(sessionId, interactionIds[0], 'message', {
+            interactionIds,
+            anchorInteractionId: interactionIds.at(-1),
+        }),
+    });
+
+    await viewer.open(target(sessionId, interactionIds.at(-1)));
+    const partial = decodeInitialPublication(panel.webview.html);
+    const timer = Array.from(timers.values()).find(candidate =>
+        candidate.delayMs === 4_000
+    );
+    assert.ok(timer, 'the initial progressive page must be acknowledged');
+
+    timer.callback();
+    const recovered = decodeInitialPublication(panel.webview.html);
+    assert.notEqual(recovered.requestId, partial.requestId);
+    await panel.receive({
+        type: 'conversation-viewer-applied',
+        version: 1,
+        subscriptionGeneration: recovered.subscriptionGeneration,
+        requestId: recovered.requestId,
+        htmlSignature: recovered.htmlSignature,
+    });
+    assert.match(lastContentPublication(panel).html, /message-0/);
+    viewer.dispose();
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-002 transfers the incomplete-content watchdog across authority suspension', async () => {
+    const sessionId = 'progressive-authority-rollover';
+    const interactionIds = Array.from(
+        { length: 30 },
+        (_item, index) => `input-${index + 1}`
+    );
+    const timers = new Map();
+    let nextTimer = 1;
+    const { viewer, panel } = createViewer({
+        setTimer(callback, delayMs) {
+            const handle = nextTimer++;
+            timers.set(handle, { callback, delayMs });
+            return handle;
+        },
+        clearTimer(handle) {
+            timers.delete(handle);
+        },
+        readOutline: async () => outline(sessionId, interactionIds),
+        readPage: async () => page(sessionId, interactionIds[0], 'message', {
+            interactionIds,
+            anchorInteractionId: interactionIds.at(-1),
+        }),
+    });
+
+    await viewer.open(target(sessionId, interactionIds.at(-1)));
+    await viewer.reconcileAuthority(() => false);
+    const staleFull = lastContentPublication(panel);
+    assert.doesNotMatch(staleFull.html, /Loading earlier messages/);
+    const timer = Array.from(timers.values()).find(candidate =>
+        candidate.delayMs === 4_000
+    );
+    assert.ok(timer, 'the authority-rollover full page must be acknowledged');
+
+    timer.callback();
+    const recovered = decodeInitialPublication(panel.webview.html);
+    assert.doesNotMatch(recovered.html, /Loading earlier messages/);
+    assert.match(recovered.html, /message-0/);
+    viewer.dispose();
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-002 keeps an interaction group intact at the progressive boundary', async () => {
+    const sessionId = 'progressive-group-boundary';
+    const interactionIds = Array.from(
+        { length: 30 },
+        (_item, index) => `input-${index + 1}`
+    );
+    const { viewer, panel } = createViewer({
+        readOutline: async () => outline(sessionId, interactionIds),
+        readPage: async () => {
+            const result = page(sessionId, interactionIds[0], 'message', {
+                interactionIds,
+                anchorInteractionId: interactionIds.at(-1),
+            });
+            result.messages.splice(19, 0,
+                {
+                    id: 'input-19:progress',
+                    interactionId: 'input-19',
+                    role: 'progress',
+                    markdown: 'group-progress',
+                },
+                {
+                    id: 'input-19:assistant',
+                    interactionId: 'input-19',
+                    role: 'assistant',
+                    markdown: 'group-answer',
+                }
+            );
+            return result;
+        },
+    });
+
+    await viewer.open(target(sessionId, interactionIds.at(-1)));
+    const recent = decodeInitialPublication(panel.webview.html);
+    assert.match(recent.html, /message-18/);
+    assert.match(recent.html, /group-progress/);
+    assert.match(recent.html, /group-answer/);
+    assert.doesNotMatch(recent.html, /message-17/);
+    viewer.dispose();
+});
+
 function decodeInitialBookmarks(html) {
     const match = html.match(/data-initial-bookmarks="([^"]+)"/);
     assert.ok(match, 'Host document must contain bookmark state');


### PR DESCRIPTION
## Summary
- Render the recent portion of a long latest conversation first, then deliver the complete transcript after acknowledgement.
- Keep progressive delivery resilient across recovery, authority rollover, and superseding publications.
- Announce deferred content through the existing trusted live status region.

## Testing
- `npm run test-compile`
- `node --test tests/integration/dashboard/conversationViewer.test.js`
- `node scripts/run-dashboard-webview-checks.js`
- `git diff --check origin/main --`

## Skill harvest
No skill change: the review-driven protocol fixes followed the existing resilient Webview mutation and review/commit-loop guidance; no reusable instruction gap was found.

## Owner approvals
```text
approve 67d75ba98385e90c458e062bfd98bc08143209ec
```