### PR TITLE
perf: backfill long conversation history in ack-paced chunks

### DIFF
--- a/media/conversationViewerScripts.js
+++ b/media/conversationViewerScripts.js
@@ -406,6 +406,9 @@
         renderGeneration: 0,
         appliedHtmlSignature: undefined,
     };
+    // The status text without the deferred-history notice, so a completing
+    // backfill chunk can clear that notice without a full page message.
+    var baseTranscriptStatus = '';
     var readingAnchorController =
         window.__agentPivotConversation.readingAnchor.create({
             scroll: scroll,
@@ -1893,6 +1896,7 @@
         if (message.partial) {
             statusMessages.push('Partial history — showing newest inputs.');
         }
+        baseTranscriptStatus = statusMessages.join(' ');
         if (messages.querySelector('.conversation-deferred-messages')) {
             statusMessages.push('Loading earlier messages.');
         }
@@ -1992,6 +1996,196 @@
             renderGeneration,
             hasHtml || !!frame
         );
+    }
+
+    function validHistoryChunk(message) {
+        if (!message || typeof message !== 'object' || Array.isArray(message)) {
+            return false;
+        }
+        var requiredKeys = [
+            'type', 'version', 'subscriptionGeneration', 'requestId',
+            'html', 'htmlSignature', 'complete',
+        ];
+        if (Object.keys(message).length !== requiredKeys.length
+            || requiredKeys.some(function (key) {
+                return !Object.prototype.hasOwnProperty.call(message, key);
+            })) {
+            return false;
+        }
+        return message.type === 'conversation-viewer-history-chunk'
+            && message.version === 1
+            && Number.isSafeInteger(message.subscriptionGeneration)
+            && message.subscriptionGeneration >= 1
+            && Number.isSafeInteger(message.requestId)
+            && message.requestId >= 1
+            && typeof message.html === 'string'
+            && typeof message.htmlSignature === 'string'
+            && message.htmlSignature.length > 0
+            && message.htmlSignature.length <= 256
+            && typeof message.complete === 'boolean';
+    }
+
+    // One backfill slice of older history for a progressively rendered
+    // page. Slices arrive nearest-first and slot in directly below the
+    // placeholder, so the visible tail is never re-rendered and the
+    // reading position is preserved by compensating the scroll offset.
+    function applyHistoryChunk(message) {
+        if (!message
+            || message.type !== 'conversation-viewer-history-chunk') {
+            return false;
+        }
+        if (!validHistoryChunk(message)
+            || message.subscriptionGeneration !== state.subscriptionGeneration
+            || message.requestId <= state.latestRequestId) {
+            return true;
+        }
+        try {
+            applyHistoryChunkContent(message);
+        } catch (_chunkError) {
+            requestLegacyConversationResync(_chunkError);
+        }
+        return true;
+    }
+
+    function applyHistoryChunkContent(message) {
+        state.latestRequestId = message.requestId;
+        var placeholder = messages.querySelector(
+            '.conversation-deferred-messages'
+        );
+        if (!placeholder) {
+            // The visible document is no longer the partial page this chunk
+            // extends (a full publication superseded it). Ignoring is safe:
+            // the Host's incomplete-content watchdog converges the state.
+            return;
+        }
+        var clean = window.DOMPurify.sanitize(message.html, {
+            ALLOWED_TAGS: allowedTags,
+            ALLOWED_ATTR: allowedAttributes,
+            ALLOW_DATA_ATTR: false,
+            ALLOW_ARIA_ATTR: false,
+        });
+        var template = document.createElement('template');
+        template.innerHTML = clean;
+        var inserted = Array.prototype.slice.call(
+            template.content.querySelectorAll(conversationMessageSelector())
+        );
+        if (!inserted.length) {
+            // A content-free slice cannot be acknowledged: the Host would
+            // otherwise believe history it never rendered is visible.
+            requestLegacyConversationResync('empty-history-chunk');
+            return true;
+        }
+        var previousScrollHeight = scroll.scrollHeight;
+        var previousScrollTop = scroll.scrollTop;
+        placeholder.after(template.content);
+        if (message.complete) {
+            placeholder.remove();
+        }
+        var addedIds = [];
+        inserted.forEach(function (candidate) {
+            var id = conversationMessageId(candidate);
+            addedIds.push(id);
+            state.messageSignatures.set(id, candidate.outerHTML);
+        });
+        state.messageIds = addedIds.concat(state.messageIds);
+        state.appliedHtmlSignature = message.htmlSignature;
+        Array.prototype.forEach.call(
+            inserted.reduce(function (list, node) {
+                return list.concat(Array.prototype.slice.call(
+                    node.querySelectorAll('img')
+                ));
+            }, []),
+            function (image) {
+                image.loading = 'lazy';
+                image.decoding = 'async';
+                image.referrerPolicy = 'no-referrer';
+            }
+        );
+        applyWorklogStates();
+        // Content grew above the viewport: compensate so the same messages
+        // stay under the reader's eyes. A reader parked at the very top is
+        // waiting for this history, so keep that offset untouched.
+        var heightDelta = scroll.scrollHeight - previousScrollHeight;
+        if (heightDelta > 0 && previousScrollTop > 0) {
+            scroll.scrollTop = previousScrollTop + heightDelta;
+        }
+        reconcileController.trackEnd();
+        if (message.complete) {
+            status.textContent = baseTranscriptStatus;
+        }
+        // Acknowledge before the deferred decoration pass: the Host paces
+        // the next slice on this receipt, and the decoration is idempotent.
+        post({
+            type: 'conversation-viewer-history-chunk-applied',
+            version: 1,
+            subscriptionGeneration: message.subscriptionGeneration,
+            requestId: message.requestId,
+            htmlSignature: message.htmlSignature,
+        });
+        scheduleDeferredChunkPresentation(message);
+        return true;
+    }
+
+    // Copy/run labels and comment highlights for the freshly prepended
+    // slice. Deferred so the backfill never blocks the chunk pipeline. The
+    // decoration is idempotent, so a pass orphaned by a session switch is
+    // harmless. Mermaid waits for the completing slice: the renderer caps
+    // diagrams per invocation, and one final pass covers every slice
+    // instead of multiplying the budget by the chunk count.
+    function scheduleDeferredChunkPresentation(message) {
+        var subscriptionGeneration = message.subscriptionGeneration;
+        var apply = function () {
+            if (state.subscriptionGeneration !== subscriptionGeneration) {
+                return;
+            }
+            try {
+                applyCopyButtonLabels();
+                applyRunCommandButtonLabels();
+                commentsController.updateHighlights();
+                if (findController) findController.refresh();
+                if (message.complete) {
+                    renderMermaidDiagrams(state.renderGeneration);
+                }
+            } catch (_decorationError) {
+                // Decoration is idempotent: the next slice or page pass
+                // covers anything this pass missed.
+            }
+        };
+        if (document.visibilityState === 'hidden') {
+            apply();
+            return;
+        }
+        if (typeof window.requestAnimationFrame === 'function') {
+            window.requestAnimationFrame(function () {
+                window.requestAnimationFrame(apply);
+            });
+            return;
+        }
+        window.setTimeout(function () {
+            window.setTimeout(apply, 0);
+        }, 0);
+    }
+
+    // A chunk carries no page identity, so an apply failure falls back to
+    // the legacy resync shape: the Host rebuilds from its latest
+    // publication, which restarts the progressive lifecycle.
+    function requestLegacyConversationResync(applyError) {
+        if (!validCommentTarget(commentTarget)) {
+            return;
+        }
+        var message = {
+            type: 'conversation-viewer-request-sync',
+            version: 1,
+            subscriptionGeneration: state.subscriptionGeneration,
+            projectId: commentTarget.projectId,
+            provider: commentTarget.provider,
+            sessionId: commentTarget.sessionId,
+            applyError: String(applyError || 'history-chunk-apply-failed')
+                .split('\n')[0].slice(0, 200),
+        };
+        // Dropped content must not suppress the rebuilt full publication.
+        state.appliedHtmlSignature = undefined;
+        post(message);
     }
 
     function postNavigation(type) {
@@ -2316,6 +2510,7 @@
         if (applySessionStatusMessage(event.data)) return;
         if (applyFollowNotice(event.data)) return;
         if (applyLoadingNotice(event.data)) return;
+        if (applyHistoryChunk(event.data)) return;
         try {
             applyPage(event.data);
         } catch (_applyError) {

--- a/src/aiSessions/conversation/viewer.ts
+++ b/src/aiSessions/conversation/viewer.ts
@@ -48,6 +48,7 @@ import type {
     ConversationSessionSwitchDirection,
     ConversationViewerAppliedMessage,
     ConversationViewerCopyMessage,
+    ConversationViewerHistoryChunkAppliedMessage,
 } from './viewerProtocol';
 import type { ConversationViewerTarget } from './viewerTarget';
 export type { ConversationViewerTarget } from './viewerTarget';
@@ -306,6 +307,39 @@ export interface ConversationViewerPageMessage {
 }
 
 /**
+ * One slice of older history prepended above a progressively rendered
+ * partial page. Slices arrive nearest-first; `complete` marks the oldest
+ * slice, after which the visible document equals the full content whose
+ * cumulative signature is `htmlSignature`.
+ */
+export interface ConversationViewerHistoryChunkMessage {
+    type: 'conversation-viewer-history-chunk';
+    version: 1;
+    subscriptionGeneration: number;
+    requestId: number;
+    html: string;
+    htmlSignature: string;
+    complete: boolean;
+}
+
+interface ConversationProgressiveBackfill {
+    generation: number;
+    /** Request id of the partial publication this backfill extends. A newer
+     * publication or in-flight load moves `currentRequestId` past it, which
+     * invalidates the plan: a stale slice receipt must never allocate
+     * request ids or publish over the newer work. */
+    anchorRequestId: number;
+    /** Remaining slices, in send order (nearest the visible tail first). */
+    chunks: { html: string; htmlSignature: string }[];
+    pending?: {
+        requestId: number;
+        htmlSignature: string;
+    };
+    timerToken: number;
+    timer?: unknown;
+}
+
+/**
  * Aggregate timing for one authoritative Conversation publication. It never
  * carries a workspace, provider, session, or other user content.
  */
@@ -357,6 +391,12 @@ export class ConversationViewer implements ConversationViewerApi {
         generation: number;
         partialHtmlSignature: string;
     };
+    // Older history for a progressive page is backfilled in ack-paced
+    // slices instead of one full-document refresh, so the Webview never
+    // renders the whole history in a single task. Any superseding page
+    // publication cancels the plan; a lost slice falls back to the normal
+    // full-content refresh.
+    private progressiveBackfill?: ConversationProgressiveBackfill;
     private pendingPublicationTiming?: {
         subscriptionGeneration: number;
         requestId: number;
@@ -845,6 +885,9 @@ export class ConversationViewer implements ConversationViewerApi {
                     generation: this.subscriptionGeneration,
                 };
             }
+            // The full-content refresh published below supersedes any
+            // in-flight history backfill.
+            this.cancelProgressiveBackfill();
             this.pendingRestoredAuxiliaryState = undefined;
             this.currentRequestId = this.allocateRequestId();
             if (this.pages.length && this.outlineController.snapshot) {
@@ -951,6 +994,7 @@ export class ConversationViewer implements ConversationViewerApi {
         this.clearPublicationAckTimeout();
         this.progressivePublication = undefined;
         this.progressiveContentIncomplete = undefined;
+        this.cancelProgressiveBackfill();
         this.pendingPublicationTiming = undefined;
         this.pendingTargetLoadTiming = undefined;
         this.pendingRestoredAuxiliaryState = undefined;
@@ -1067,6 +1111,7 @@ export class ConversationViewer implements ConversationViewerApi {
         this.clearPublicationAckTimeout();
         this.progressivePublication = undefined;
         this.progressiveContentIncomplete = undefined;
+        this.cancelProgressiveBackfill();
         this.pendingPublicationTiming = undefined;
         this.pendingTargetLoadTiming = undefined;
         this.pendingRestoredAuxiliaryState = undefined;
@@ -1256,6 +1301,10 @@ export class ConversationViewer implements ConversationViewerApi {
         }
         if (parsed.type === 'conversation-viewer-applied') {
             this.acknowledgePublication(parsed);
+            return;
+        }
+        if (parsed.type === 'conversation-viewer-history-chunk-applied') {
+            this.acknowledgeHistoryChunk(parsed);
             return;
         }
         if (parsed.type === 'conversation-viewer-request-sync') {
@@ -1463,6 +1512,7 @@ export class ConversationViewer implements ConversationViewerApi {
         this.stale = false;
         this.telemetryController.reset();
         this.latestPublication = undefined;
+        this.cancelProgressiveBackfill();
         this.pendingRestoredAuxiliaryState = undefined;
         this.commentController.reset();
         this.projectCommentController.reset();
@@ -1645,6 +1695,7 @@ export class ConversationViewer implements ConversationViewerApi {
         const publication = this.latestPublication;
         if (!pending || this.suspended || this.target !== pending.target
             || this.subscriptionGeneration !== pending.generation
+            || this.progressiveBackfill
             || !publication || !this.isCurrentPublication(publication)) {
             return;
         }
@@ -2292,6 +2343,10 @@ export class ConversationViewer implements ConversationViewerApi {
         if (!panel || !this.isCurrentPublication(publication)) {
             return;
         }
+        // Any page publication supersedes an in-flight history backfill:
+        // it either carries the full content itself or is the backfill's
+        // own completion refresh (whose plan is already detached).
+        this.cancelProgressiveBackfill();
         this.publicationRecoveryRebuildRequestId = 0;
         this.publicationRecoveryAttemptRequestId = 0;
         this.latestPublication = publication;
@@ -2380,6 +2435,13 @@ export class ConversationViewer implements ConversationViewerApi {
             return;
         }
         this.progressivePublication = undefined;
+        this.cancelProgressiveBackfill();
+        const backfill = this.createProgressiveBackfill(publication);
+        if (backfill) {
+            this.progressiveBackfill = backfill;
+            this.sendNextProgressiveBackfillChunk();
+            return;
+        }
         const requestId = this.allocateRequestId();
         this.currentRequestId = requestId;
         const complete = this.createPublication(
@@ -2388,6 +2450,268 @@ export class ConversationViewer implements ConversationViewerApi {
             'refresh'
         );
         void this.deliverPublication(complete, false);
+    }
+
+    /**
+     * Plan an ack-paced history backfill for a progressively rendered page.
+     * Returns undefined when the deferred window is small enough for one
+     * full refresh or when the rendered content drifted from the published
+     * partial page (chunk prepending is only valid against that exact
+     * document).
+     */
+    private createProgressiveBackfill(
+        publication: ConversationViewerPageMessage
+    ): ConversationProgressiveBackfill | undefined {
+        const generation = publication.subscriptionGeneration;
+        if (this.progressiveContentIncomplete?.generation !== generation
+            || this.progressiveContentIncomplete.partialHtmlSignature
+                !== publication.htmlSignature) {
+            return undefined;
+        }
+        const target = this.target;
+        if (!target || !this.outlineController.snapshot) {
+            return undefined;
+        }
+        const allMessages = this.messages();
+        const deferredCount = deferredConversationMessageCount(allMessages);
+        if (deferredCount <= CONVERSATION_PROGRESSIVE_CHUNK_MIN_DEFERRED) {
+            return undefined;
+        }
+        const interactionInfo = this.createInteractionInfo();
+        const sessionId = this.effectiveSessionId(target);
+        // Chunks prepend blindly above the placeholder, so they are valid
+        // only while the visible tail is byte-identical to this render. Any
+        // drift (a streamed message, a clock rollover) falls back to the
+        // single full refresh, which reconciles the whole document.
+        const partial = renderMessages(
+            allMessages.slice(deferredCount),
+            this.showThinking(),
+            interactionInfo,
+            this.renderCache,
+            this.contentSignatures,
+            sessionId,
+            deferredCount
+        );
+        if (partial.contentSignature !== publication.htmlSignature) {
+            return undefined;
+        }
+        const slices = conversationHistoryChunkSlices(
+            allMessages.slice(0, deferredCount),
+            CONVERSATION_PROGRESSIVE_CHUNK_SIZE
+        );
+        if (slices.length < 2) {
+            return undefined;
+        }
+        const chunks: { html: string; htmlSignature: string }[] = [];
+        let covered = 0;
+        slices.forEach(slice => {
+            // The cumulative signature after this slice applies: the
+            // document then shows messages[start..] with `start` messages
+            // still deferred, matching the partial publication's scheme.
+            const start = deferredCount - covered - slice.length;
+            const cumulative = renderMessages(
+                allMessages.slice(start),
+                this.showThinking(),
+                interactionInfo,
+                this.renderCache,
+                this.contentSignatures,
+                sessionId,
+                start
+            );
+            covered += slice.length;
+            chunks.push({
+                html: renderMessages(
+                    slice,
+                    this.showThinking(),
+                    interactionInfo,
+                    this.renderCache,
+                    this.contentSignatures,
+                    sessionId
+                ).html,
+                htmlSignature: cumulative.contentSignature,
+            });
+        });
+        return {
+            generation,
+            anchorRequestId: publication.requestId,
+            chunks,
+            timerToken: 0,
+        };
+    }
+
+    private sendNextProgressiveBackfillChunk(): void {
+        const plan = this.progressiveBackfill;
+        const panel = this.panel;
+        const chunk = plan?.chunks[0];
+        if (!plan || !chunk || !panel || this.suspended) {
+            return;
+        }
+        if (plan.generation !== this.subscriptionGeneration
+            || plan.anchorRequestId !== this.currentRequestId) {
+            // A newer load or publication owns the request counter now; it
+            // supersedes the backfill (its own delivery cancels the plan).
+            this.cancelProgressiveBackfill();
+            return;
+        }
+        plan.chunks.shift();
+        const requestId = this.allocateRequestId();
+        plan.pending = { requestId, htmlSignature: chunk.htmlSignature };
+        this.scheduleProgressiveBackfillTimeout(plan);
+        const wire: ConversationViewerHistoryChunkMessage = {
+            type: 'conversation-viewer-history-chunk',
+            version: 1,
+            subscriptionGeneration: plan.generation,
+            requestId,
+            html: chunk.html,
+            htmlSignature: chunk.htmlSignature,
+            complete: plan.chunks.length === 0,
+        };
+        void Promise.resolve(panel.webview.postMessage(wire)).then(
+            delivered => {
+                if (!delivered) {
+                    this.recoverProgressiveBackfill(
+                        plan,
+                        'backfill-chunk-delivery-failed'
+                    );
+                }
+            },
+            () => this.recoverProgressiveBackfill(
+                plan,
+                'backfill-chunk-delivery-failed'
+            )
+        );
+    }
+
+    private acknowledgeHistoryChunk(
+        message: ConversationViewerHistoryChunkAppliedMessage
+    ): void {
+        const plan = this.progressiveBackfill;
+        if (!plan || !plan.pending
+            || message.subscriptionGeneration !== this.subscriptionGeneration
+            || message.subscriptionGeneration !== plan.generation
+            || message.requestId !== plan.pending.requestId
+            || message.htmlSignature !== plan.pending.htmlSignature) {
+            return;
+        }
+        if (plan.anchorRequestId !== this.currentRequestId) {
+            // A newer load or publication allocated the request counter
+            // after this slice was sent. Its delivery supersedes the
+            // backfill, so the receipt must not allocate ids or publish.
+            this.emitDiagnostic('backfill-stale-anchor');
+            this.cancelProgressiveBackfill();
+            return;
+        }
+        this.clearProgressiveBackfillTimer(plan);
+        // The Webview is the authority on applied content: the cumulative
+        // signature it confirmed is what later publications may omit.
+        this.appliedContentSignature = plan.pending.htmlSignature;
+        plan.pending = undefined;
+        if (plan.chunks.length) {
+            this.sendNextProgressiveBackfillChunk();
+            return;
+        }
+        this.progressiveBackfill = undefined;
+        // History is fully visible. Close the loop with a normal refresh
+        // publication (HTML omitted while the content is unchanged) so the
+        // latest publication, deferred auxiliary state, and the
+        // incomplete-content obligation all converge on the full document.
+        if (!this.target || !this.outlineController.snapshot) {
+            return;
+        }
+        const requestId = this.allocateRequestId();
+        this.currentRequestId = requestId;
+        void this.deliverPublication(this.createPublication(
+            requestId,
+            plan.generation,
+            'refresh'
+        ), false);
+    }
+
+    private scheduleProgressiveBackfillTimeout(
+        plan: ConversationProgressiveBackfill
+    ): void {
+        const token = ++plan.timerToken;
+        const recover = () => {
+            if (token !== plan.timerToken) {
+                return;
+            }
+            plan.timer = undefined;
+            this.recoverProgressiveBackfill(plan, 'backfill-chunk-ack-timeout');
+        };
+        const handle = this.options.setTimer
+            ? this.options.setTimer(
+                recover,
+                CONVERSATION_LIMITS.viewerPublicationAckTimeoutMs
+            )
+            : setTimeout(
+                recover,
+                CONVERSATION_LIMITS.viewerPublicationAckTimeoutMs
+            );
+        if (token === plan.timerToken) {
+            plan.timer = handle;
+        } else if (this.options.clearTimer) {
+            this.options.clearTimer(handle);
+        } else {
+            clearTimeout(handle as NodeJS.Timeout);
+        }
+    }
+
+    private clearProgressiveBackfillTimer(
+        plan: ConversationProgressiveBackfill
+    ): void {
+        plan.timerToken += 1;
+        const timer = plan.timer;
+        plan.timer = undefined;
+        if (timer === undefined) {
+            return;
+        }
+        if (this.options.clearTimer) {
+            this.options.clearTimer(timer);
+        } else {
+            clearTimeout(timer as NodeJS.Timeout);
+        }
+    }
+
+    /**
+     * A lost or unacknowledged slice never strands the partial page: cancel
+     * the plan and deliver one full-content refresh. The generation-level
+     * incomplete-content watchdog still guards that publication.
+     */
+    private recoverProgressiveBackfill(
+        plan: ConversationProgressiveBackfill,
+        reason: string
+    ): void {
+        if (this.progressiveBackfill !== plan
+            || plan.generation !== this.subscriptionGeneration) {
+            return;
+        }
+        this.emitDiagnostic(reason);
+        this.cancelProgressiveBackfill();
+        if (this.suspended || !this.panel) {
+            return;
+        }
+        if (plan.anchorRequestId !== this.currentRequestId) {
+            // A newer load owns the request counter; its publication
+            // supersedes the backfill, so a recovery refresh would kill it.
+            this.emitDiagnostic('backfill-recovery-yielded');
+            return;
+        }
+        const requestId = this.allocateRequestId();
+        this.currentRequestId = requestId;
+        void this.deliverPublication(this.createPublication(
+            requestId,
+            plan.generation,
+            'refresh'
+        ), false);
+    }
+
+    private cancelProgressiveBackfill(): void {
+        const plan = this.progressiveBackfill;
+        this.progressiveBackfill = undefined;
+        if (!plan) {
+            return;
+        }
+        this.clearProgressiveBackfillTimer(plan);
     }
 
     private rebuildLatestDocument(): void {
@@ -2417,11 +2741,20 @@ export class ConversationViewer implements ConversationViewerApi {
                 ? { restoreFocus: true }
                 : {}),
         };
-        if (this.progressivePublication === publication) {
-            // Recovery owns a fresh object and request id. Preserve the
-            // deferred-content lifecycle on that authoritative retry.
+        // Recovery owns a fresh object and request id. Preserve the
+        // deferred-content lifecycle on that authoritative retry — both for
+        // a partial page whose first receipt never arrived and for one
+        // whose history backfill was already in flight (the rebuilt
+        // document restarts from the partial page, so its receipt must
+        // re-plan the backfill).
+        if (this.progressivePublication === publication
+            || (this.progressiveContentIncomplete?.generation
+                    === publication.subscriptionGeneration
+                && this.progressiveContentIncomplete.partialHtmlSignature
+                    === publication.htmlSignature)) {
             this.progressivePublication = recovery;
         }
+        this.cancelProgressiveBackfill();
         this.currentRequestId = recovery.requestId;
         this.latestPublication = recovery;
         this.publicationRecoveryAttemptRequestId = recovery.requestId;
@@ -2465,7 +2798,10 @@ export class ConversationViewer implements ConversationViewerApi {
             }
             this.publicationAckTimer = undefined;
             if (!this.isCurrentPublication(publication)
-                || this.appliedContentSignature === publication.htmlSignature
+                || (this.appliedContentSignature
+                        === publication.htmlSignature
+                    && this.progressiveContentIncomplete?.generation
+                        !== publication.subscriptionGeneration)
                 || (this.transitioningGeneration
                     !== publication.subscriptionGeneration
                     && this.progressiveContentIncomplete?.generation
@@ -2883,18 +3219,7 @@ export class ConversationViewer implements ConversationViewerApi {
         const interactionIds = outline.interactions.map(
             interaction => interaction.id
         );
-        const interactionInfo = new Map<string, {
-            responseState: ConversationResponseState;
-            timestamp?: number;
-            completedAt?: number;
-        }>();
-        this.pages.forEach(retained => {
-            retained.page.interactionStates.forEach(state => {
-                if (!interactionInfo.has(state.interactionId)) {
-                    interactionInfo.set(state.interactionId, state);
-                }
-            });
-        });
+        const interactionInfo = this.createInteractionInfo();
         const selectedIndex = interactionIds.indexOf(
             projection.selectedInteractionId
         );
@@ -2957,6 +3282,26 @@ export class ConversationViewer implements ConversationViewerApi {
         return projection.atLatest
             && !projection.partial
             && deferredConversationMessageCount(this.messages()) > 0;
+    }
+
+    private createInteractionInfo(): Map<string, {
+        responseState: ConversationResponseState;
+        timestamp?: number;
+        completedAt?: number;
+    }> {
+        const interactionInfo = new Map<string, {
+            responseState: ConversationResponseState;
+            timestamp?: number;
+            completedAt?: number;
+        }>();
+        this.pages.forEach(retained => {
+            retained.page.interactionStates.forEach(state => {
+                if (!interactionInfo.has(state.interactionId)) {
+                    interactionInfo.set(state.interactionId, state);
+                }
+            });
+        });
+        return interactionInfo;
     }
 
     private renderDocument(
@@ -3450,6 +3795,11 @@ function renderMessages(
 
 const CONVERSATION_PROGRESSIVE_RENDER_THRESHOLD = 24;
 const CONVERSATION_PROGRESSIVE_RENDER_RECENT_COUNT = 12;
+// Backfill slices above the visible recent window. Small deferred windows
+// are cheaper to deliver as one full refresh; larger ones arrive in
+// ack-paced slices so no single Webview task renders the whole history.
+const CONVERSATION_PROGRESSIVE_CHUNK_SIZE = 24;
+const CONVERSATION_PROGRESSIVE_CHUNK_MIN_DEFERRED = 48;
 
 function deferredConversationMessageCount(
     messages: readonly ConversationMessage[]
@@ -3466,4 +3816,29 @@ function deferredConversationMessageCount(
         firstVisible -= 1;
     }
     return firstVisible;
+}
+
+/**
+ * Split the deferred (not yet rendered) message prefix into backfill slices
+ * aligned to interaction-group boundaries, in send order: the slice nearest
+ * the visible tail first, the oldest slice (flagged complete) last.
+ */
+function conversationHistoryChunkSlices(
+    messages: ConversationMessage[],
+    chunkSize: number
+): ConversationMessage[][] {
+    const oldestFirst: ConversationMessage[][] = [];
+    let end = messages.length;
+    while (end > 0) {
+        let start = Math.max(0, end - chunkSize);
+        const interactionId = messages[start]?.interactionId;
+        // Do not split one interaction's message group across chunks.
+        while (start > 0
+            && messages[start - 1].interactionId === interactionId) {
+            start -= 1;
+        }
+        oldestFirst.unshift(messages.slice(start, end));
+        end = start;
+    }
+    return oldestFirst.reverse();
 }

--- a/src/aiSessions/conversation/viewerProtocol.ts
+++ b/src/aiSessions/conversation/viewerProtocol.ts
@@ -306,6 +306,17 @@ export interface ConversationViewerAppliedMessage {
     frames?: ConversationViewerAppliedFrame[];
 }
 
+/** Correlated receipt for one history backfill chunk. The signature is the
+ * cumulative content signature after the chunk was prepended, so the Host
+ * can pace the next chunk and know exactly how much history is visible. */
+export interface ConversationViewerHistoryChunkAppliedMessage {
+    type: 'conversation-viewer-history-chunk-applied';
+    version: 1;
+    subscriptionGeneration: number;
+    requestId: number;
+    htmlSignature: string;
+}
+
 export interface ConversationViewerFocusMessage {
     type: 'conversation-viewer-focus';
     version: 1;
@@ -350,6 +361,7 @@ export type ConversationViewerMessage =
     | ConversationViewerCycleStatusSessionMessage
     | ConversationViewerRequestSyncMessage
     | ConversationViewerAppliedMessage
+    | ConversationViewerHistoryChunkAppliedMessage
     | ConversationViewerFocusMessage
     | ConversationViewerOpenSubagentMessage
     | ConversationViewerCloseSubagentMessage
@@ -626,6 +638,22 @@ export function parseConversationViewerMessage(
             return undefined;
         }
         return value as unknown as ConversationViewerAppliedMessage;
+    }
+    if (value.type === 'conversation-viewer-history-chunk-applied') {
+        if (!hasExactKeys(value, [
+            'type', 'version', 'subscriptionGeneration', 'requestId',
+            'htmlSignature',
+        ])) {
+            return undefined;
+        }
+        if (!isPositiveSafeInteger(value.subscriptionGeneration)
+            || !isPositiveSafeInteger(value.requestId)
+            || typeof value.htmlSignature !== 'string'
+            || !value.htmlSignature
+            || value.htmlSignature.length > 256) {
+            return undefined;
+        }
+        return value as unknown as ConversationViewerHistoryChunkAppliedMessage;
     }
     if (value.type === 'conversation-viewer-focus') {
         if (!hasExactKeys(value, ['type', 'version', 'focused'])

--- a/src/webview/conversationViewerScripts.js
+++ b/src/webview/conversationViewerScripts.js
@@ -406,6 +406,9 @@
         renderGeneration: 0,
         appliedHtmlSignature: undefined,
     };
+    // The status text without the deferred-history notice, so a completing
+    // backfill chunk can clear that notice without a full page message.
+    var baseTranscriptStatus = '';
     var readingAnchorController =
         window.__agentPivotConversation.readingAnchor.create({
             scroll: scroll,
@@ -1893,6 +1896,7 @@
         if (message.partial) {
             statusMessages.push('Partial history — showing newest inputs.');
         }
+        baseTranscriptStatus = statusMessages.join(' ');
         if (messages.querySelector('.conversation-deferred-messages')) {
             statusMessages.push('Loading earlier messages.');
         }
@@ -1992,6 +1996,196 @@
             renderGeneration,
             hasHtml || !!frame
         );
+    }
+
+    function validHistoryChunk(message) {
+        if (!message || typeof message !== 'object' || Array.isArray(message)) {
+            return false;
+        }
+        var requiredKeys = [
+            'type', 'version', 'subscriptionGeneration', 'requestId',
+            'html', 'htmlSignature', 'complete',
+        ];
+        if (Object.keys(message).length !== requiredKeys.length
+            || requiredKeys.some(function (key) {
+                return !Object.prototype.hasOwnProperty.call(message, key);
+            })) {
+            return false;
+        }
+        return message.type === 'conversation-viewer-history-chunk'
+            && message.version === 1
+            && Number.isSafeInteger(message.subscriptionGeneration)
+            && message.subscriptionGeneration >= 1
+            && Number.isSafeInteger(message.requestId)
+            && message.requestId >= 1
+            && typeof message.html === 'string'
+            && typeof message.htmlSignature === 'string'
+            && message.htmlSignature.length > 0
+            && message.htmlSignature.length <= 256
+            && typeof message.complete === 'boolean';
+    }
+
+    // One backfill slice of older history for a progressively rendered
+    // page. Slices arrive nearest-first and slot in directly below the
+    // placeholder, so the visible tail is never re-rendered and the
+    // reading position is preserved by compensating the scroll offset.
+    function applyHistoryChunk(message) {
+        if (!message
+            || message.type !== 'conversation-viewer-history-chunk') {
+            return false;
+        }
+        if (!validHistoryChunk(message)
+            || message.subscriptionGeneration !== state.subscriptionGeneration
+            || message.requestId <= state.latestRequestId) {
+            return true;
+        }
+        try {
+            applyHistoryChunkContent(message);
+        } catch (_chunkError) {
+            requestLegacyConversationResync(_chunkError);
+        }
+        return true;
+    }
+
+    function applyHistoryChunkContent(message) {
+        state.latestRequestId = message.requestId;
+        var placeholder = messages.querySelector(
+            '.conversation-deferred-messages'
+        );
+        if (!placeholder) {
+            // The visible document is no longer the partial page this chunk
+            // extends (a full publication superseded it). Ignoring is safe:
+            // the Host's incomplete-content watchdog converges the state.
+            return;
+        }
+        var clean = window.DOMPurify.sanitize(message.html, {
+            ALLOWED_TAGS: allowedTags,
+            ALLOWED_ATTR: allowedAttributes,
+            ALLOW_DATA_ATTR: false,
+            ALLOW_ARIA_ATTR: false,
+        });
+        var template = document.createElement('template');
+        template.innerHTML = clean;
+        var inserted = Array.prototype.slice.call(
+            template.content.querySelectorAll(conversationMessageSelector())
+        );
+        if (!inserted.length) {
+            // A content-free slice cannot be acknowledged: the Host would
+            // otherwise believe history it never rendered is visible.
+            requestLegacyConversationResync('empty-history-chunk');
+            return true;
+        }
+        var previousScrollHeight = scroll.scrollHeight;
+        var previousScrollTop = scroll.scrollTop;
+        placeholder.after(template.content);
+        if (message.complete) {
+            placeholder.remove();
+        }
+        var addedIds = [];
+        inserted.forEach(function (candidate) {
+            var id = conversationMessageId(candidate);
+            addedIds.push(id);
+            state.messageSignatures.set(id, candidate.outerHTML);
+        });
+        state.messageIds = addedIds.concat(state.messageIds);
+        state.appliedHtmlSignature = message.htmlSignature;
+        Array.prototype.forEach.call(
+            inserted.reduce(function (list, node) {
+                return list.concat(Array.prototype.slice.call(
+                    node.querySelectorAll('img')
+                ));
+            }, []),
+            function (image) {
+                image.loading = 'lazy';
+                image.decoding = 'async';
+                image.referrerPolicy = 'no-referrer';
+            }
+        );
+        applyWorklogStates();
+        // Content grew above the viewport: compensate so the same messages
+        // stay under the reader's eyes. A reader parked at the very top is
+        // waiting for this history, so keep that offset untouched.
+        var heightDelta = scroll.scrollHeight - previousScrollHeight;
+        if (heightDelta > 0 && previousScrollTop > 0) {
+            scroll.scrollTop = previousScrollTop + heightDelta;
+        }
+        reconcileController.trackEnd();
+        if (message.complete) {
+            status.textContent = baseTranscriptStatus;
+        }
+        // Acknowledge before the deferred decoration pass: the Host paces
+        // the next slice on this receipt, and the decoration is idempotent.
+        post({
+            type: 'conversation-viewer-history-chunk-applied',
+            version: 1,
+            subscriptionGeneration: message.subscriptionGeneration,
+            requestId: message.requestId,
+            htmlSignature: message.htmlSignature,
+        });
+        scheduleDeferredChunkPresentation(message);
+        return true;
+    }
+
+    // Copy/run labels and comment highlights for the freshly prepended
+    // slice. Deferred so the backfill never blocks the chunk pipeline. The
+    // decoration is idempotent, so a pass orphaned by a session switch is
+    // harmless. Mermaid waits for the completing slice: the renderer caps
+    // diagrams per invocation, and one final pass covers every slice
+    // instead of multiplying the budget by the chunk count.
+    function scheduleDeferredChunkPresentation(message) {
+        var subscriptionGeneration = message.subscriptionGeneration;
+        var apply = function () {
+            if (state.subscriptionGeneration !== subscriptionGeneration) {
+                return;
+            }
+            try {
+                applyCopyButtonLabels();
+                applyRunCommandButtonLabels();
+                commentsController.updateHighlights();
+                if (findController) findController.refresh();
+                if (message.complete) {
+                    renderMermaidDiagrams(state.renderGeneration);
+                }
+            } catch (_decorationError) {
+                // Decoration is idempotent: the next slice or page pass
+                // covers anything this pass missed.
+            }
+        };
+        if (document.visibilityState === 'hidden') {
+            apply();
+            return;
+        }
+        if (typeof window.requestAnimationFrame === 'function') {
+            window.requestAnimationFrame(function () {
+                window.requestAnimationFrame(apply);
+            });
+            return;
+        }
+        window.setTimeout(function () {
+            window.setTimeout(apply, 0);
+        }, 0);
+    }
+
+    // A chunk carries no page identity, so an apply failure falls back to
+    // the legacy resync shape: the Host rebuilds from its latest
+    // publication, which restarts the progressive lifecycle.
+    function requestLegacyConversationResync(applyError) {
+        if (!validCommentTarget(commentTarget)) {
+            return;
+        }
+        var message = {
+            type: 'conversation-viewer-request-sync',
+            version: 1,
+            subscriptionGeneration: state.subscriptionGeneration,
+            projectId: commentTarget.projectId,
+            provider: commentTarget.provider,
+            sessionId: commentTarget.sessionId,
+            applyError: String(applyError || 'history-chunk-apply-failed')
+                .split('\n')[0].slice(0, 200),
+        };
+        // Dropped content must not suppress the rebuilt full publication.
+        state.appliedHtmlSignature = undefined;
+        post(message);
     }
 
     function postNavigation(type) {
@@ -2316,6 +2510,7 @@
         if (applySessionStatusMessage(event.data)) return;
         if (applyFollowNotice(event.data)) return;
         if (applyLoadingNotice(event.data)) return;
+        if (applyHistoryChunk(event.data)) return;
         try {
             applyPage(event.data);
         } catch (_applyError) {

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -4340,6 +4340,24 @@ test('CONVERSATION-OUTLINE-NAVIGATION-001 keeps every side-panel view usable acr
             '\n    function applyPage(message) {'
         )
         .replace(
+            /\n    function validHistoryChunk\(message\) \{[\s\S]*?\n    \}\n(?=\n    function postNavigation)/,
+            ''
+        )
+        .replace(
+            '        if (applyHistoryChunk(event.data)) return;\n',
+            ''
+        )
+        .replace(
+            '        baseTranscriptStatus = statusMessages.join(\' \');\n',
+            ''
+        )
+        .replace(
+            '    // The status text without the deferred-history notice, so a completing\n'
+                + '    // backfill chunk can clear that notice without a full page message.\n'
+                + '    var baseTranscriptStatus = \'\';\n',
+            ''
+        )
+        .replace(
             '        updatePosition(message);\n'
                 + '        // This controller owns visible identity and actionable subagent IDs,\n'
                 + '        // so it must agree with the transcript in the first painted frame.\n'
@@ -16760,4 +16778,239 @@ test('WORKTREE-CHANGES-COMMITS-001 the fold toggle expands and collapses every l
             === document.querySelector('[data-changes-fold-toggle]')), true,
         'activating the toggle keeps focus on it');
     assert.equal(await toggle.getAttribute('aria-label'), 'Expand all');
+});
+
+function progressiveOutline(count) {
+    return Array.from({ length: count }, (_item, index) => ({
+        interactionId: `msg-${index}`,
+        userPreview: `input ${index}`,
+        responseState: 'complete',
+    }));
+}
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-002 applies history chunks in place and settles on the full signature', async t => {
+    const page = await openViewerPage(t);
+    await sendPage(page, {
+        type: 'conversation-viewer-page',
+        version: 1,
+        requestId: 1,
+        subscriptionGeneration: 1,
+        updateKind: 'initial',
+        html: '<section class="conversation-deferred-messages">'
+            + 'Loading earlier messages…</section>'
+            + messageHtml('msg', 4, 8),
+        htmlSignature: 'sig-partial',
+        outline: progressiveOutline(12),
+        selectedInteractionId: 'msg-11',
+        selectedInput: 11,
+        totalInputs: 12,
+        partial: false,
+        atLatest: true,
+        stale: false,
+        subagents: [],
+        activeSubagent: null,
+    });
+    await page.waitForFunction(() => window.__postedMessages.some(message =>
+        message.type === 'conversation-viewer-applied'
+            && message.htmlSignature === 'sig-partial'
+    ));
+    assert.equal(await page.locator(
+        '[data-conversation-status]').textContent(),
+        'Loading earlier messages.');
+
+    // The reader is parked mid-transcript; prepending must not move the
+    // messages under their eyes.
+    await page.evaluate(() => {
+        document.querySelector('[data-conversation-scroll]').scrollTop = 40;
+    });
+    const beforeChunk = await page.evaluate(() => ({
+        scrollTop: document.querySelector('[data-conversation-scroll]')
+            .scrollTop,
+        scrollHeight: document.querySelector('[data-conversation-scroll]')
+            .scrollHeight,
+    }));
+    assert.ok(beforeChunk.scrollTop > 0,
+        'the reader must be parked away from the top for this check');
+    await sendPage(page, {
+        type: 'conversation-viewer-history-chunk',
+        version: 1,
+        subscriptionGeneration: 1,
+        requestId: 2,
+        html: messageHtml('msg', 4, 4),
+        htmlSignature: 'sig-mid',
+        complete: false,
+    });
+    assert.deepEqual(await page.evaluate(() => ({
+        ids: Array.from(document.querySelectorAll(
+            '[data-conversation-messages] [data-message-id]'
+        )).map(node => node.getAttribute('data-message-id')),
+        placeholder: !!document.querySelector(
+            '.conversation-deferred-messages'
+        ),
+    })), {
+        ids: ['msg-4', 'msg-5', 'msg-6', 'msg-7',
+            'msg-8', 'msg-9', 'msg-10', 'msg-11'],
+        placeholder: true,
+    }, 'the slice slots in directly below the placeholder');
+    const afterChunk = await page.evaluate(() => ({
+        scrollTop: document.querySelector('[data-conversation-scroll]')
+            .scrollTop,
+        scrollHeight: document.querySelector('[data-conversation-scroll]')
+            .scrollHeight,
+    }));
+    assert.ok(afterChunk.scrollHeight > beforeChunk.scrollHeight,
+        'the prepended slice must grow the content');
+    assert.equal(
+        afterChunk.scrollTop - beforeChunk.scrollTop,
+        afterChunk.scrollHeight - beforeChunk.scrollHeight,
+        'prepending above the viewport compensates the scroll offset'
+    );
+    assert.ok((await postedMessages(page)).some(message =>
+        message.type === 'conversation-viewer-history-chunk-applied'
+            && message.requestId === 2
+            && message.htmlSignature === 'sig-mid'
+    ), 'the slice is acknowledged with its cumulative signature');
+
+    // A replayed (stale) slice is dropped without touching the document.
+    await page.evaluate(() => {
+        window.__postedMessages = [];
+    });
+    await sendPage(page, {
+        type: 'conversation-viewer-history-chunk',
+        version: 1,
+        subscriptionGeneration: 1,
+        requestId: 2,
+        html: messageHtml('msg', 4, 4),
+        htmlSignature: 'sig-mid',
+        complete: false,
+    });
+    assert.equal(await page.locator(
+        '[data-conversation-messages] [data-message-id]').count(), 8,
+        'a stale slice must not duplicate messages');
+    assert.equal((await postedMessages(page)).length, 0,
+        'a stale slice is never acknowledged');
+
+    // The oldest slice completes the backfill: the placeholder leaves and
+    // the status notice clears.
+    await sendPage(page, {
+        type: 'conversation-viewer-history-chunk',
+        version: 1,
+        subscriptionGeneration: 1,
+        requestId: 3,
+        html: messageHtml('msg', 4, 0),
+        htmlSignature: 'sig-full',
+        complete: true,
+    });
+    assert.equal(await page.locator(
+        '.conversation-deferred-messages').count(), 0);
+    assert.equal(await page.locator(
+        '[data-conversation-messages] [data-message-id]').count(), 12);
+    assert.equal(await page.locator(
+        '[data-conversation-status]').textContent(), '');
+    assert.ok((await postedMessages(page)).some(message =>
+        message.type === 'conversation-viewer-history-chunk-applied'
+            && message.requestId === 3
+            && message.htmlSignature === 'sig-full'
+    ), 'the completing slice is acknowledged');
+
+    // The cumulative signature chain lets the Host omit identical HTML.
+    await sendPage(page, {
+        type: 'conversation-viewer-page',
+        version: 1,
+        requestId: 4,
+        subscriptionGeneration: 1,
+        updateKind: 'refresh',
+        htmlSignature: 'sig-full',
+        outline: progressiveOutline(12),
+        selectedInteractionId: 'msg-11',
+        selectedInput: 11,
+        totalInputs: 12,
+        partial: false,
+        atLatest: true,
+        stale: false,
+        subagents: [],
+        activeSubagent: null,
+    });
+    await page.waitForFunction(() => window.__postedMessages.some(message =>
+        message.type === 'conversation-viewer-applied'
+            && message.requestId === 4
+    ));
+    assert.equal((await postedMessages(page)).filter(message =>
+        message.type === 'conversation-viewer-request-sync'
+    ).length, 0, 'the HTML-free delta matches the chunked content');
+    assert.equal(await page.locator(
+        '[data-conversation-messages] [data-message-id]').count(), 12);
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-002 ignores a history chunk after a full page superseded the partial one', async t => {
+    const page = await openViewerPage(t);
+    await sendPage(page, {
+        type: 'conversation-viewer-page',
+        version: 1,
+        requestId: 1,
+        subscriptionGeneration: 1,
+        updateKind: 'initial',
+        html: '<section class="conversation-deferred-messages">'
+            + 'Loading earlier messages…</section>'
+            + messageHtml('msg', 4, 8),
+        htmlSignature: 'sig-partial',
+        outline: progressiveOutline(12),
+        selectedInteractionId: 'msg-11',
+        selectedInput: 11,
+        totalInputs: 12,
+        partial: false,
+        atLatest: true,
+        stale: false,
+        subagents: [],
+        activeSubagent: null,
+    });
+    await page.waitForFunction(() => window.__postedMessages.some(message =>
+        message.type === 'conversation-viewer-applied'
+            && message.htmlSignature === 'sig-partial'
+    ));
+
+    // A full-content refresh supersedes the partial page.
+    await sendPage(page, {
+        type: 'conversation-viewer-page',
+        version: 1,
+        requestId: 2,
+        subscriptionGeneration: 1,
+        updateKind: 'refresh',
+        html: messageHtml('msg', 12, 0),
+        htmlSignature: 'sig-full',
+        outline: progressiveOutline(12),
+        selectedInteractionId: 'msg-11',
+        selectedInput: 11,
+        totalInputs: 12,
+        partial: false,
+        atLatest: true,
+        stale: false,
+        subagents: [],
+        activeSubagent: null,
+    });
+    await page.waitForFunction(() => window.__postedMessages.some(message =>
+        message.type === 'conversation-viewer-applied'
+            && message.htmlSignature === 'sig-full'
+    ));
+    await page.evaluate(() => {
+        window.__postedMessages = [];
+    });
+
+    // A chunk still in flight for the partial page must not duplicate
+    // history into the full document, and must not be acknowledged.
+    await sendPage(page, {
+        type: 'conversation-viewer-history-chunk',
+        version: 1,
+        subscriptionGeneration: 1,
+        requestId: 3,
+        html: messageHtml('msg', 4, 0),
+        htmlSignature: 'sig-full',
+        complete: true,
+    });
+    assert.equal(await page.locator(
+        '[data-conversation-messages] [data-message-id]').count(), 12,
+        'the superseded slice never lands');
+    assert.equal((await postedMessages(page)).filter(message =>
+        message.type === 'conversation-viewer-history-chunk-applied'
+    ).length, 0, 'the superseded slice is never acknowledged');
 });

--- a/tests/integration/dashboard/conversationViewer.test.js
+++ b/tests/integration/dashboard/conversationViewer.test.js
@@ -437,6 +437,576 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-002 keeps an interaction group inta
     viewer.dispose();
 });
 
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-002 backfills a long history in ack-paced chunks', async () => {
+    const sessionId = 'progressive-chunked-backfill';
+    const interactionIds = Array.from(
+        { length: 100 },
+        (_item, index) => `input-${index + 1}`
+    );
+    const { viewer, panel } = createViewer({
+        readOutline: async () => outline(sessionId, interactionIds),
+        readPage: async () => page(sessionId, interactionIds[0], 'message', {
+            interactionIds,
+            anchorInteractionId: interactionIds.at(-1),
+        }),
+    });
+
+    await viewer.open(target(sessionId, interactionIds.at(-1)));
+    const recent = decodeInitialPublication(panel.webview.html);
+    assert.match(recent.html, /Loading earlier messages/);
+    assert.match(recent.html, /message-99/);
+    assert.doesNotMatch(recent.html, /message-87/);
+
+    await panel.receive({
+        type: 'conversation-viewer-applied',
+        version: 1,
+        subscriptionGeneration: recent.subscriptionGeneration,
+        requestId: recent.requestId,
+        htmlSignature: recent.htmlSignature,
+    });
+
+    // 88 deferred messages arrive as four slices, nearest the visible tail
+    // first; each next slice is sent only after the previous one applied.
+    const chunkRanges = [[64, 88], [40, 64], [16, 40], [0, 16]];
+    for (const [index, [start, end]] of chunkRanges.entries()) {
+        const sentChunks = panel.postedMessages.filter(message =>
+            message.type === 'conversation-viewer-history-chunk'
+        );
+        assert.equal(sentChunks.length, index + 1,
+            'the next slice is sent only after the previous receipt');
+        const chunk = sentChunks.at(-1);
+        assert.ok(chunk, `chunk ${index + 1} must be published`);
+        assert.equal(
+            chunk.complete,
+            index === chunkRanges.length - 1,
+            'only the oldest slice completes the backfill'
+        );
+        assert.match(chunk.html, new RegExp(`message-${end - 1}`));
+        assert.match(chunk.html, new RegExp(`message-${start}`));
+        assert.doesNotMatch(chunk.html, new RegExp(`message-${start - 1}`));
+        assert.doesNotMatch(chunk.html, new RegExp(`message-${end}`));
+        await panel.receive({
+            type: 'conversation-viewer-history-chunk-applied',
+            version: 1,
+            subscriptionGeneration: chunk.subscriptionGeneration,
+            requestId: chunk.requestId,
+            htmlSignature: chunk.htmlSignature,
+        });
+    }
+
+    // History fully applied: a final refresh publication converges the
+    // session. The content is unchanged, so its HTML stays off the wire.
+    const completion = panel.postedMessages.filter(message =>
+        message.type === 'conversation-viewer-page'
+    ).at(-1);
+    assert.ok(completion, 'the completion publication must exist');
+    assert.equal(completion.updateKind, 'refresh');
+    assert.equal(completion.html, undefined);
+    assert.equal(typeof completion.htmlSignature, 'string');
+    await panel.receive({
+        type: 'conversation-viewer-applied',
+        version: 1,
+        subscriptionGeneration: completion.subscriptionGeneration,
+        requestId: completion.requestId,
+        htmlSignature: completion.htmlSignature,
+    });
+    assert.equal(
+        panel.postedMessages.filter(message =>
+            message.type === 'conversation-viewer-history-chunk'
+        ).length,
+        chunkRanges.length,
+        'no further chunks after completion'
+    );
+    viewer.dispose();
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-002 recovers a lost history chunk with a full refresh', async () => {
+    const sessionId = 'progressive-chunk-timeout';
+    const interactionIds = Array.from(
+        { length: 100 },
+        (_item, index) => `input-${index + 1}`
+    );
+    const timers = new Map();
+    let nextTimer = 1;
+    const { viewer, panel } = createViewer({
+        setTimer(callback, delayMs) {
+            const handle = nextTimer++;
+            timers.set(handle, { callback, delayMs });
+            return handle;
+        },
+        clearTimer(handle) {
+            timers.delete(handle);
+        },
+        readOutline: async () => outline(sessionId, interactionIds),
+        readPage: async () => page(sessionId, interactionIds[0], 'message', {
+            interactionIds,
+            anchorInteractionId: interactionIds.at(-1),
+        }),
+    });
+
+    await viewer.open(target(sessionId, interactionIds.at(-1)));
+    const recent = decodeInitialPublication(panel.webview.html);
+    await panel.receive({
+        type: 'conversation-viewer-applied',
+        version: 1,
+        subscriptionGeneration: recent.subscriptionGeneration,
+        requestId: recent.requestId,
+        htmlSignature: recent.htmlSignature,
+    });
+    const chunk = panel.postedMessages.filter(message =>
+        message.type === 'conversation-viewer-history-chunk'
+    ).at(-1);
+    assert.ok(chunk, 'the first history chunk must be published');
+    const timer = Array.from(timers.values()).find(candidate =>
+        candidate.delayMs === 4_000
+    );
+    assert.ok(timer, 'an unacknowledged chunk must be watched');
+
+    timer.callback();
+    const recovered = lastContentPublication(panel);
+    assert.equal(recovered.type, 'conversation-viewer-page');
+    assert.equal(recovered.updateKind, 'refresh');
+    assert.doesNotMatch(recovered.html, /Loading earlier messages/);
+    assert.match(recovered.html, /message-0/);
+    assert.match(recovered.html, /message-99/);
+    viewer.dispose();
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-002 defers restored auxiliary state until the backfill completes', async () => {
+    const sessionId = 'progressive-chunk-auxiliary';
+    const interactionIds = Array.from(
+        { length: 100 },
+        (_item, index) => `input-${index + 1}`
+    );
+    const commentStore = {
+        async load() {
+            return { revision: 7, comments: [] };
+        },
+        async save() {},
+    };
+    const { viewer, panel } = createViewer({
+        commentStore,
+        readOutline: async () => outline(sessionId, interactionIds),
+        readPage: async () => page(sessionId, interactionIds[0], 'message', {
+            interactionIds,
+            anchorInteractionId: interactionIds.at(-1),
+        }),
+    });
+
+    await viewer.open(target(sessionId, interactionIds.at(-1)));
+    const recent = decodeInitialPublication(panel.webview.html);
+    await panel.receive({
+        type: 'conversation-viewer-applied',
+        version: 1,
+        subscriptionGeneration: recent.subscriptionGeneration,
+        requestId: recent.requestId,
+        htmlSignature: recent.htmlSignature,
+    });
+    // Let the comment restore settle while the backfill is in flight.
+    await new Promise(resolve => setTimeout(resolve, 0));
+    const chunk = panel.postedMessages.filter(message =>
+        message.type === 'conversation-viewer-history-chunk'
+    ).at(-1);
+    assert.ok(chunk, 'the backfill must be in flight');
+    assert.equal(
+        panel.postedMessages.filter(message =>
+            message.type === 'conversation-viewer-page'
+        ).length,
+        0,
+        'auxiliary state must not supersede the in-flight backfill'
+    );
+
+    // Drain the backfill.
+    for (;;) {
+        const pendingChunk = panel.postedMessages.filter(message =>
+            message.type === 'conversation-viewer-history-chunk'
+        ).at(-1);
+        if (!pendingChunk) {
+            break;
+        }
+        await panel.receive({
+            type: 'conversation-viewer-history-chunk-applied',
+            version: 1,
+            subscriptionGeneration: pendingChunk.subscriptionGeneration,
+            requestId: pendingChunk.requestId,
+            htmlSignature: pendingChunk.htmlSignature,
+        });
+        if (pendingChunk.complete) {
+            break;
+        }
+    }
+    const completion = panel.postedMessages.filter(message =>
+        message.type === 'conversation-viewer-page'
+    ).at(-1);
+    assert.ok(completion, 'the completion publication must exist');
+    assert.equal(completion.comments.revision, 7);
+    viewer.dispose();
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-002 cancels the backfill when an authority rollover supersedes it', async () => {
+    const sessionId = 'progressive-chunk-rollover';
+    const interactionIds = Array.from(
+        { length: 100 },
+        (_item, index) => `input-${index + 1}`
+    );
+    const { viewer, panel } = createViewer({
+        readOutline: async () => outline(sessionId, interactionIds),
+        readPage: async () => page(sessionId, interactionIds[0], 'message', {
+            interactionIds,
+            anchorInteractionId: interactionIds.at(-1),
+        }),
+    });
+
+    await viewer.open(target(sessionId, interactionIds.at(-1)));
+    const recent = decodeInitialPublication(panel.webview.html);
+    await panel.receive({
+        type: 'conversation-viewer-applied',
+        version: 1,
+        subscriptionGeneration: recent.subscriptionGeneration,
+        requestId: recent.requestId,
+        htmlSignature: recent.htmlSignature,
+    });
+    const chunk = panel.postedMessages.filter(message =>
+        message.type === 'conversation-viewer-history-chunk'
+    ).at(-1);
+    assert.ok(chunk, 'the backfill must be in flight');
+
+    await viewer.reconcileAuthority(() => false);
+    const staleFull = lastContentPublication(panel);
+    assert.doesNotMatch(staleFull.html, /Loading earlier messages/);
+    assert.match(staleFull.html, /message-0/);
+
+    // A late receipt for the canceled chunk must not restart the backfill.
+    await panel.receive({
+        type: 'conversation-viewer-history-chunk-applied',
+        version: 1,
+        subscriptionGeneration: chunk.subscriptionGeneration,
+        requestId: chunk.requestId,
+        htmlSignature: chunk.htmlSignature,
+    });
+    await panel.receive({
+        type: 'conversation-viewer-applied',
+        version: 1,
+        subscriptionGeneration: staleFull.subscriptionGeneration,
+        requestId: staleFull.requestId,
+        htmlSignature: staleFull.htmlSignature,
+    });
+    assert.equal(
+        panel.postedMessages.filter(message =>
+            message.type === 'conversation-viewer-history-chunk'
+        ).length,
+        1,
+        'no further chunks after the rollover superseded the backfill'
+    );
+    viewer.dispose();
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-002 keeps the single full refresh for a modest deferred window', async () => {
+    const sessionId = 'progressive-chunk-boundary';
+    const interactionIds = Array.from(
+        { length: 60 },
+        (_item, index) => `input-${index + 1}`
+    );
+    const { viewer, panel } = createViewer({
+        readOutline: async () => outline(sessionId, interactionIds),
+        readPage: async () => page(sessionId, interactionIds[0], 'message', {
+            interactionIds,
+            anchorInteractionId: interactionIds.at(-1),
+        }),
+    });
+
+    await viewer.open(target(sessionId, interactionIds.at(-1)));
+    const recent = decodeInitialPublication(panel.webview.html);
+    assert.match(recent.html, /Loading earlier messages/);
+    await panel.receive({
+        type: 'conversation-viewer-applied',
+        version: 1,
+        subscriptionGeneration: recent.subscriptionGeneration,
+        requestId: recent.requestId,
+        htmlSignature: recent.htmlSignature,
+    });
+
+    // 48 deferred messages stay on the single-refresh path.
+    assert.equal(panel.postedMessages.filter(message =>
+        message.type === 'conversation-viewer-history-chunk'
+    ).length, 0);
+    const complete = lastContentPublication(panel);
+    assert.equal(complete.updateKind, 'refresh');
+    assert.doesNotMatch(complete.html, /Loading earlier messages/);
+    assert.match(complete.html, /message-0/);
+    viewer.dispose();
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-002 keeps interaction groups intact across chunk boundaries', async () => {
+    const sessionId = 'progressive-chunk-groups';
+    const interactionIds = Array.from(
+        { length: 100 },
+        (_item, index) => `input-${index + 1}`
+    );
+    const { viewer, panel } = createViewer({
+        readOutline: async () => outline(sessionId, interactionIds),
+        readPage: async () => {
+            const result = page(sessionId, interactionIds[0], 'message', {
+                interactionIds,
+                anchorInteractionId: interactionIds.at(-1),
+            });
+            // A group larger than one slice, plus a group straddling a
+            // nominal slice boundary (message index 88 starts the first
+            // slice; input-40's group spans the 64|65 boundary).
+            const grouped = [];
+            for (let index = 0; index < 30; index += 1) {
+                grouped.push({
+                    id: `input-40:extra-${index}`,
+                    interactionId: 'input-40',
+                    role: 'progress',
+                    markdown: `group-40-note-${index}`,
+                });
+            }
+            result.messages.splice(40, 0, ...grouped);
+            return result;
+        },
+    });
+
+    await viewer.open(target(sessionId, interactionIds.at(-1)));
+    const recent = decodeInitialPublication(panel.webview.html);
+    assert.match(recent.html, /Loading earlier messages/);
+    await panel.receive({
+        type: 'conversation-viewer-applied',
+        version: 1,
+        subscriptionGeneration: recent.subscriptionGeneration,
+        requestId: recent.requestId,
+        htmlSignature: recent.htmlSignature,
+    });
+
+    const seen = [];
+    for (;;) {
+        const chunk = panel.postedMessages.filter(message =>
+            message.type === 'conversation-viewer-history-chunk'
+        ).at(-1);
+        if (!chunk) {
+            break;
+        }
+        const notes = chunk.html.match(/group-40-note-\d+/g) ?? [];
+        assert.equal(
+            notes.length === 0 || notes.length === 30,
+            true,
+            'a group larger than a slice stays inside one chunk'
+        );
+        if (notes.length) {
+            assert.equal(seen.length, 0,
+                'the oversized group appears exactly once');
+        }
+        seen.push(...notes);
+        await panel.receive({
+            type: 'conversation-viewer-history-chunk-applied',
+            version: 1,
+            subscriptionGeneration: chunk.subscriptionGeneration,
+            requestId: chunk.requestId,
+            htmlSignature: chunk.htmlSignature,
+        });
+        if (chunk.complete) {
+            break;
+        }
+    }
+    assert.equal(seen.length, 30, 'every grouped message arrives once');
+    viewer.dispose();
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-002 completes through an auxiliary refresh that lands before the first receipt', async () => {
+    const sessionId = 'progressive-chunk-early-auxiliary';
+    const interactionIds = Array.from(
+        { length: 100 },
+        (_item, index) => `input-${index + 1}`
+    );
+    const restoredComments = deferred();
+    const { viewer, panel } = createViewer({
+        commentStore: {
+            load: () => restoredComments.promise,
+            async save() {},
+        },
+        readOutline: async () => outline(sessionId, interactionIds),
+        readPage: async () => page(sessionId, interactionIds[0], 'message', {
+            interactionIds,
+            anchorInteractionId: interactionIds.at(-1),
+        }),
+    });
+
+    await viewer.open(target(sessionId, interactionIds.at(-1)));
+    const recent = decodeInitialPublication(panel.webview.html);
+    assert.match(recent.html, /Loading earlier messages/);
+    assert.equal(recent.comments.revision, 0,
+        'the readable page must not wait for the auxiliary restore');
+    // The auxiliary restore settles after the publication but before its
+    // receipt: the restore wins the race against the backfill.
+    restoredComments.resolve({ revision: 7, comments: [] });
+    await new Promise(resolve => setImmediate(resolve));
+    await panel.receive({
+        type: 'conversation-viewer-applied',
+        version: 1,
+        subscriptionGeneration: recent.subscriptionGeneration,
+        requestId: recent.requestId,
+        htmlSignature: recent.htmlSignature,
+    });
+
+    // The restored auxiliary state rides a full-content refresh, which
+    // completes the progressive page directly instead of chunking.
+    const complete = lastContentPublication(panel);
+    assert.equal(complete.updateKind, 'refresh');
+    assert.doesNotMatch(complete.html, /Loading earlier messages/);
+    assert.match(complete.html, /message-0/);
+    assert.equal(complete.comments.revision, 7);
+    assert.equal(panel.postedMessages.filter(message =>
+        message.type === 'conversation-viewer-history-chunk'
+    ).length, 0);
+    viewer.dispose();
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-002 ignores a stale chunk receipt while a refresh load is in flight', async () => {
+    const sessionId = 'progressive-chunk-anchor-race';
+    const interactionIds = Array.from(
+        { length: 100 },
+        (_item, index) => `input-${index + 1}`
+    );
+    let watchCallback;
+    let reads = 0;
+    const pageRequested = deferred();
+    const refreshedPage = deferred();
+    const { viewer, panel } = createViewer({
+        watch: (_provider, _sessionId, onChange) => {
+            watchCallback = onChange;
+            return { dispose() {} };
+        },
+        readOutline: async () => outline(sessionId, interactionIds, {
+            sourceRevision: reads > 0 ? 'r2' : 'r1',
+        }),
+        readPage: async () => {
+            reads += 1;
+            if (reads === 1) {
+                return page(sessionId, interactionIds[0], 'message', {
+                    interactionIds,
+                    anchorInteractionId: interactionIds.at(-1),
+                });
+            }
+            // The refresh load allocated its request id already; it now
+            // blocks on the page read.
+            pageRequested.resolve();
+            return refreshedPage.promise;
+        },
+    });
+
+    await viewer.open(target(sessionId, interactionIds.at(-1)));
+    const recent = decodeInitialPublication(panel.webview.html);
+    await panel.receive({
+        type: 'conversation-viewer-applied',
+        version: 1,
+        subscriptionGeneration: recent.subscriptionGeneration,
+        requestId: recent.requestId,
+        htmlSignature: recent.htmlSignature,
+    });
+    const chunk = panel.postedMessages.filter(message =>
+        message.type === 'conversation-viewer-history-chunk'
+    ).at(-1);
+    assert.ok(chunk, 'the backfill must be in flight');
+
+    // A refresh load starts, allocates the request counter, and blocks on
+    // the page read. The stale chunk receipt must not publish a completion
+    // over it nor move the request counter.
+    watchCallback();
+    await pageRequested.promise;
+    await panel.receive({
+        type: 'conversation-viewer-history-chunk-applied',
+        version: 1,
+        subscriptionGeneration: chunk.subscriptionGeneration,
+        requestId: chunk.requestId,
+        htmlSignature: chunk.htmlSignature,
+    });
+    assert.equal(panel.postedMessages.filter(message =>
+        message.type === 'conversation-viewer-page'
+    ).length, 0, 'the stale receipt must not publish over the load');
+
+    refreshedPage.resolve(page(sessionId, interactionIds[0], 'message', {
+        interactionIds,
+        anchorInteractionId: interactionIds.at(-1),
+        sourceRevision: 'r2',
+    }));
+    await new Promise(resolve => setImmediate(resolve));
+    await new Promise(resolve => setImmediate(resolve));
+    const refreshed = lastContentPublication(panel);
+    assert.equal(refreshed.updateKind, 'refresh');
+    assert.match(refreshed.html, /message-0/);
+    viewer.dispose();
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-002 recovers a lost backfill completion publication', async () => {
+    const sessionId = 'progressive-chunk-completion-loss';
+    const interactionIds = Array.from(
+        { length: 100 },
+        (_item, index) => `input-${index + 1}`
+    );
+    const timers = new Map();
+    let nextTimer = 1;
+    const { viewer, panel } = createViewer({
+        setTimer(callback, delayMs) {
+            const handle = nextTimer++;
+            timers.set(handle, { callback, delayMs });
+            return handle;
+        },
+        clearTimer(handle) {
+            timers.delete(handle);
+        },
+        readOutline: async () => outline(sessionId, interactionIds),
+        readPage: async () => page(sessionId, interactionIds[0], 'message', {
+            interactionIds,
+            anchorInteractionId: interactionIds.at(-1),
+        }),
+    });
+
+    await viewer.open(target(sessionId, interactionIds.at(-1)));
+    const recent = decodeInitialPublication(panel.webview.html);
+    await panel.receive({
+        type: 'conversation-viewer-applied',
+        version: 1,
+        subscriptionGeneration: recent.subscriptionGeneration,
+        requestId: recent.requestId,
+        htmlSignature: recent.htmlSignature,
+    });
+    // Drain the whole backfill; the completion publication then goes
+    // unacknowledged (lost between Host queue and Webview application).
+    for (;;) {
+        const chunk = panel.postedMessages.filter(message =>
+            message.type === 'conversation-viewer-history-chunk'
+        ).at(-1);
+        if (!chunk) {
+            break;
+        }
+        await panel.receive({
+            type: 'conversation-viewer-history-chunk-applied',
+            version: 1,
+            subscriptionGeneration: chunk.subscriptionGeneration,
+            requestId: chunk.requestId,
+            htmlSignature: chunk.htmlSignature,
+        });
+        if (chunk.complete) {
+            break;
+        }
+    }
+    const completion = panel.postedMessages.filter(message =>
+        message.type === 'conversation-viewer-page'
+    ).at(-1);
+    assert.ok(completion, 'the completion publication must exist');
+    const timer = Array.from(timers.values()).find(candidate =>
+        candidate.delayMs === 4_000
+    );
+    assert.ok(timer, 'the completion publication must be watched');
+
+    timer.callback();
+    const recovered = decodeInitialPublication(panel.webview.html);
+    assert.doesNotMatch(recovered.html, /Loading earlier messages/);
+    assert.match(recovered.html, /message-0/);
+    assert.match(recovered.html, /message-99/);
+    viewer.dispose();
+});
+
 function decodeInitialBookmarks(html) {
     const match = html.match(/data-initial-bookmarks="([^"]+)"/);
     assert.ok(match, 'Host document must contain bookmark state');


### PR DESCRIPTION
## Summary

After a progressively rendered partial page (recent messages first, PR #373), long sessions still hit a second jank when the entire older history arrived as one full-document refresh. This change backfills that history in ack-paced slices instead.

- The Host splits the deferred prefix into `conversation-viewer-history-chunk` slices (nearest the visible tail first, aligned to interaction-group boundaries), sending each only after the previous slice's correlated receipt. Each slice carries the cumulative content signature, so once the oldest slice lands the Webview's applied signature equals the full content's and later delta publications still omit HTML.
- The Webview prepends each slice directly below the `Loading earlier messages…` placeholder, compensates the scroll offset so the reader's viewport is stable, updates per-message signature bookkeeping for later reconciles, and clears the loading notice on the completing slice. Mermaid decoration runs once on the completing slice instead of once per slice.
- Deferred auxiliary state (comments / project comments / bookmarks) no longer supersedes an in-flight backfill with a full-document refresh; it rides the completion publication, which is HTML-free when the content is unchanged.

Safety properties:

- Stale slices (lower request id, wrong generation, no placeholder) are dropped without acknowledgement; a stale *receipt* can never cancel an in-flight navigation or refresh because the plan is anchored to the partial publication's request id.
- Any page publication supersedes the plan; a lost or unacknowledged slice falls back to a single full-content refresh, still guarded by the generation-level incomplete-content watchdog. The watchdog now also recovers a lost completion publication even when its signature matches the applied content, so deferred auxiliary state cannot strand.
- Previous-generation Webview scripts ignore the new message type and are healed by the same watchdog; the byte-exact compatibility fixture stays green with explicit strips for the new code.

## Verification

- `npm run test-compile`
- `node --test tests/integration/dashboard/conversationViewer.test.js` — 127/127, including new coverage: ack pacing and slice ranges, group-boundary integrity (including a group larger than one slice), the 48-message single-refresh boundary, chunk watchdog recovery, auxiliary-state deferral and early-restore supersede, stale-receipt anchor race against an in-flight refresh, and lost-completion recovery
- `node --test tests/browser/conversationViewer.test.js` — 162/162, including in-place prepend order, scroll compensation (with non-vacuous preconditions), stale slice drops, completion status/signature settle, and HTML-free delta after chunks
- `node scripts/run-dashboard-webview-checks.js`, `scripts/run-conversation-performance-checks.js`, `npm run test:behavior-contracts`, `npm run lint` (only pre-existing warnings), architecture guards, `git diff --check`
- Three independent read-only review passes plus a final integration re-review; all P1 findings were fixed and pinned by tests, final pass reports clean

## Skill harvest

No skill change. The one workflow wrinkle — the byte-exact previous-version fixture derivation broke because a legacy strip anchored on adjacency to `function postNavigation`, which the new functions displaced — is resolved in the test itself (the new strips run before the adjacency-anchored one), and the pinned SHA makes any future drift fail loudly.

## Owner approvals

```
approve 4b0378165b040475b4305b258a78f3527b9a5955
```
