### PR TITLE
fix: stop acknowledging session attention on card activation

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -4333,7 +4333,7 @@
   {
     "id": "ATTENTION-SESSION-CARD-ACKNOWLEDGEMENT-001",
     "domain": "attention",
-    "title": "A stopped Active Session card clears attention through one correlated authoritative acknowledgement transaction",
+    "title": "An explicit Active Session acknowledgement clears attention through one correlated authoritative transaction, while card activation only switches to the session and never acknowledges",
     "priority": "P0",
     "status": "automated",
     "owners": [

--- a/media/webviewDashboardBundle.js
+++ b/media/webviewDashboardBundle.js
@@ -5018,11 +5018,9 @@ function initProjectAiSessionControls(options) {
         var activation = getAiSessionCardActivation(target, projectId);
         if (!activation.handled)
             return false;
-        if (activation.sessionRow
-            && !activation.sessionRow.hasAttribute('data-session-pending')
-            && activation.sessionRow.getAttribute('data-session-id')) {
-            acknowledgeAiSessionRow(activation.sessionRow);
-        }
+        // Activating a card only switches to the session; attention stays
+        // until an explicit acknowledgement (archive, search resume,
+        // conversation viewer, terminal/session close, attention-queue jump).
         if (activation.message) {
             window.vscode.postMessage(activation.message);
         }

--- a/media/webviewProjectAiSessionControlsScripts.js
+++ b/media/webviewProjectAiSessionControlsScripts.js
@@ -814,11 +814,9 @@ function initProjectAiSessionControls(options) {
         var activation = getAiSessionCardActivation(target, projectId);
         if (!activation.handled)
             return false;
-        if (activation.sessionRow
-            && !activation.sessionRow.hasAttribute('data-session-pending')
-            && activation.sessionRow.getAttribute('data-session-id')) {
-            acknowledgeAiSessionRow(activation.sessionRow);
-        }
+        // Activating a card only switches to the session; attention stays
+        // until an explicit acknowledgement (archive, search resume,
+        // conversation viewer, terminal/session close, attention-queue jump).
         if (activation.message) {
             window.vscode.postMessage(activation.message);
         }

--- a/scripts/run-ai-session-safety-checks.js
+++ b/scripts/run-ai-session-safety-checks.js
@@ -7129,9 +7129,17 @@ function runBatchAiSessionWebviewChecks() {
     messages.length = 0;
     eventListeners.click({ button: 0, target: attentionRow.primaryAction });
     assert.deepStrictEqual(JSON.parse(JSON.stringify(messages[0])), {
+        type: 'resume-codex-session', projectId: 'project-a', sessionId: 'attention-session',
+    }, 'card activation only switches to the session and must not acknowledge attention');
+    assert.strictEqual(messages.filter(message =>
+        message.type === 'acknowledge-ai-session-attention'
+    ).length, 0,
+        'clicking an attention session card must not post an acknowledgement');
+    context.window.__agentPivotAcknowledgeSession('codex', 'attention-session');
+    assert.deepStrictEqual(JSON.parse(JSON.stringify(messages[1])), {
         type: 'acknowledge-ai-session-attention',
         eventIds: ['full-owner-event-a', 'full-owner-event-b'],
-    }, 'a fresh full render must acknowledge every current owner event before an incremental update');
+    }, 'an explicit acknowledgement must cover every current owner event before an incremental update');
     messages.length = 0;
     activeRow.setAttribute('data-session-focused', '');
     context.applyWorkspaceUpdate = message => message.type === 'workspace-updated'

--- a/src/webview/webviewProjectAiSessionControlsScripts.js
+++ b/src/webview/webviewProjectAiSessionControlsScripts.js
@@ -814,11 +814,9 @@ function initProjectAiSessionControls(options) {
         var activation = getAiSessionCardActivation(target, projectId);
         if (!activation.handled)
             return false;
-        if (activation.sessionRow
-            && !activation.sessionRow.hasAttribute('data-session-pending')
-            && activation.sessionRow.getAttribute('data-session-id')) {
-            acknowledgeAiSessionRow(activation.sessionRow);
-        }
+        // Activating a card only switches to the session; attention stays
+        // until an explicit acknowledgement (archive, search resume,
+        // conversation viewer, terminal/session close, attention-queue jump).
         if (activation.message) {
             window.vscode.postMessage(activation.message);
         }

--- a/tests/browser/activeSessionCardInteraction.test.js
+++ b/tests/browser/activeSessionCardInteraction.test.js
@@ -1409,7 +1409,9 @@ test('ACTIVE-SESSION-INCREMENTAL-PRESENTATION-ENVELOPE-001 applies AI HTML and c
     });
     assert.equal(await page.locator('[data-ai-session-live-region]').textContent(), '',
         'replaying already announced attention event IDs stays silent');
-    await row(page, 'codex', 'session-a').locator('.ai-session-primary-action').click();
+    await page.evaluate(() => {
+        window.__agentPivotAcknowledgeSession('codex', 'session-a');
+    });
     const acknowledgements = (await postedMessages(page)).filter(message =>
         message.type === 'acknowledge-ai-session-attention'
     );
@@ -1458,7 +1460,9 @@ test('ACTIVE-SESSION-INCREMENTAL-PRESENTATION-ENVELOPE-001 applies OPEN HTML and
         await row(page, 'codex', 'session-a').getAttribute('data-ai-session-attention'),
         ''
     );
-    await row(page, 'codex', 'session-a').locator('.ai-session-primary-action').click();
+    await page.evaluate(() => {
+        window.__agentPivotAcknowledgeSession('codex', 'session-a');
+    });
     const acknowledgements = (await postedMessages(page)).filter(message =>
         message.type === 'acknowledge-ai-session-attention'
     );
@@ -1507,7 +1511,9 @@ test('ACTIVE-SESSION-INCREMENTAL-PRESENTATION-ENVELOPE-001 closes an AI envelope
     assert.equal(await row(page, 'codex', 'session-a').getAttribute('data-session-focused'), '');
     assert.equal(await row(page, 'codex', 'session-b').getAttribute('data-session-focused'), null);
     assert.equal(await row(page, 'codex', 'session-a').getAttribute('data-ai-session-attention'), '');
-    await row(page, 'codex', 'session-a').locator('.ai-session-primary-action').click();
+    await page.evaluate(() => {
+        window.__agentPivotAcknowledgeSession('codex', 'session-a');
+    });
     const acknowledgements = (await postedMessages(page)).filter(message =>
         message.type === 'acknowledge-ai-session-attention'
     );
@@ -1561,7 +1567,9 @@ test('ACTIVE-SESSION-INCREMENTAL-PRESENTATION-ENVELOPE-001 closes an OPEN envelo
     assert.equal(await row(page, 'codex', 'session-a').getAttribute('data-session-focused'), '');
     assert.equal(await row(page, 'codex', 'session-b').getAttribute('data-session-focused'), null);
     assert.equal(await row(page, 'codex', 'session-a').getAttribute('data-ai-session-attention'), '');
-    await row(page, 'codex', 'session-a').locator('.ai-session-primary-action').click();
+    await page.evaluate(() => {
+        window.__agentPivotAcknowledgeSession('codex', 'session-a');
+    });
     const acknowledgements = (await postedMessages(page)).filter(message =>
         message.type === 'acknowledge-ai-session-attention'
     );
@@ -1626,7 +1634,9 @@ test('ACTIVE-SESSION-INCREMENTAL-PRESENTATION-ENVELOPE-001 applies and closes AI
     await postHostMessage(page, conflictingPresentation);
     assert.equal(await row(page, 'codex', 'session-a').getAttribute('data-ai-session-attention'), '');
     assert.equal(await row(page, 'codex', 'session-a').getAttribute('data-session-focused'), '');
-    await row(page, 'codex', 'session-a').locator('.ai-session-primary-action').click();
+    await page.evaluate(() => {
+        window.__agentPivotAcknowledgeSession('codex', 'session-a');
+    });
     const acknowledgements = (await postedMessages(page)).filter(message =>
         message.type === 'acknowledge-ai-session-attention'
     );
@@ -1696,7 +1706,9 @@ test('ACTIVE-SESSION-INCREMENTAL-PRESENTATION-ENVELOPE-001 applies and closes OP
     await postHostMessage(page, conflictingPresentation);
     assert.equal(await row(page, 'codex', 'session-a').getAttribute('data-ai-session-attention'), '');
     assert.equal(await row(page, 'codex', 'session-a').getAttribute('data-session-focused'), '');
-    await row(page, 'codex', 'session-a').locator('.ai-session-primary-action').click();
+    await page.evaluate(() => {
+        window.__agentPivotAcknowledgeSession('codex', 'session-a');
+    });
     const acknowledgements = (await postedMessages(page)).filter(message =>
         message.type === 'acknowledge-ai-session-attention'
     );
@@ -1856,7 +1868,9 @@ test('ACTIVE-SESSION-FULL-RENDER-TRANSACTION-001 seeds the full document revisio
         await row(page, 'codex', 'session-a').getAttribute('data-session-event-id'),
         'event-a'
     );
-    await row(page, 'codex', 'session-a').locator('.ai-session-primary-action').click();
+    await page.evaluate(() => {
+        window.__agentPivotAcknowledgeSession('codex', 'session-a');
+    });
     const acknowledgements = (await postedMessages(page)).filter(message =>
         message.type === 'acknowledge-ai-session-attention'
     );
@@ -1918,11 +1932,23 @@ test('ATTENTION-SESSION-CARD-ACKNOWLEDGEMENT-001 keeps acknowledgement pending u
     await primaryAction.click();
     await primaryAction.click();
     const posted = await postedMessages(page);
-    const acknowledgements = posted.filter(message =>
+    assert.equal(posted.filter(message =>
+        message.type === 'acknowledge-ai-session-attention'
+    ).length, 0,
+        'card activation must not acknowledge attention; it only switches to the session');
+    assert.equal(posted.filter(message =>
+        message.type === 'open-active-ai-session-conversation'
+    ).length, 2, 'card activation still performs the independent open action');
+
+    await page.evaluate(() => {
+        window.__agentPivotAcknowledgeSession('codex', 'session-a');
+        window.__agentPivotAcknowledgeSession('codex', 'session-a');
+    });
+    const acknowledgements = (await postedMessages(page)).filter(message =>
         message.type === 'acknowledge-ai-session-attention'
     );
     assert.equal(acknowledgements.length, 1,
-        'rapid activation must share the pending acknowledgement request');
+        'rapid explicit acknowledgement must share the pending request');
     const request = acknowledgements[0];
     assert.deepEqual(request, {
         type: 'acknowledge-ai-session-attention',
@@ -1936,9 +1962,6 @@ test('ATTENTION-SESSION-CARD-ACKNOWLEDGEMENT-001 keeps acknowledgement pending u
     });
     assert.ok(Number.isSafeInteger(request.requestId) && request.requestId > 0,
         'the acknowledgement requestId must be a safe positive integer');
-    assert.equal(posted.filter(message =>
-        message.type === 'open-active-ai-session-conversation'
-    ).length, 2, 'pending acknowledgement must not suppress the independent open action');
 
     const result = overrides => ({
         type: 'ai-session-attention-acknowledgement-result',
@@ -1998,7 +2021,9 @@ test('ATTENTION-SESSION-CARD-ACKNOWLEDGEMENT-001 keeps acknowledgement pending u
         ...attentionSession,
         attentionEventId: nextEventIds[0],
     }, nextEventIds);
-    await row(page, 'codex', 'session-a').locator('.ai-session-primary-action').click();
+    await page.evaluate(() => {
+        window.__agentPivotAcknowledgeSession('codex', 'session-a');
+    });
     let finalAcknowledgements = (await postedMessages(page)).filter(message =>
         message.type === 'acknowledge-ai-session-attention'
     );
@@ -2418,7 +2443,9 @@ test('ATTENTION-SESSION-CARD-ACKNOWLEDGEMENT-001 clears a stopped Kimi card thro
         };
     }, exposedName);
 
-    await row(page, 'kimi', sessionId).locator('.ai-session-primary-action').click();
+    await page.evaluate(id => {
+        window.__agentPivotAcknowledgeSession('kimi', id);
+    }, sessionId);
     await page.evaluate(() => Promise.all(window.__hostAttentionSettlements));
     const waitForEnvelope = (promise, label) => {
         let timeout;


### PR DESCRIPTION
## Summary

Clicking an AI session card in the Dashboard webview no longer clears its
attention state. Card activation only switches to the session (focus terminal,
open conversation, or resume); attention now stays until an explicit
acknowledgement.

## Behavior after this change

- Clicking an attention session card only navigates; it never posts
  `acknowledge-ai-session-attention`.
- Acknowledgement still happens through the explicit paths: archiving the
  session, resuming from search results, the conversation viewer provider
  icon, the attention-queue jump with `aiSessionAttention.clearOnNextSession`,
  closing the terminal, or explicitly ending the session.
- The transactional acknowledgement machinery (pending entries, committed /
  rejected / degraded-local outcomes, timeout refresh) is unchanged and is
  still exercised by archive and search-resume.

## Tests

- `tests/browser/activeSessionCardInteraction.test.js`: activation no longer
  acknowledges (new assertion); acknowledgement-transaction tests now drive
  the explicit `__agentPivotAcknowledgeSession` path and still cover
  pending/committed/rejected/degraded/timeout flows.
- `scripts/run-ai-session-safety-checks.js`: harness asserts clicking an
  attention card posts only the activation message, then explicit
  acknowledgement covers every owner event.
- `docs/testing/behavior-contracts.json`: updated the
  `ATTENTION-SESSION-CARD-ACKNOWLEDGEMENT-001` title to the new contract.

## Verification

- `npm run test-compile` passed.
- Browser `activeSessionCardInteraction.test.js`: 51/51 passed.
- `node scripts/run-ai-session-safety-checks.js` passed.
- `node scripts/run-dashboard-webview-checks.js` passed.
- Contract tests (`messageHandlers`, `attentionEventCapability`): 27/27 passed.
- `npm run test:behavior-contracts` passed.
- `lint:ci` baseline and `git diff --check` passed.
- `SKIP_NPM_CI=1 npm run install-local` packaged and installed
  `agent-pivot-1.1.3.vsix` + `agent-pivot-attention-ui-bridge-1.0.3.vsix`
  into the active VS Code Server with byte verification (task-critical
  `media/webviewProjectAiSessionControlsScripts.js` and
  `media/webviewDashboardBundle.js` hashes match the VSIX). A window reload is
  still required to activate the new build.

## Skill harvest

No skill change justified. The only task-local friction was a `perl` literal
replacement that silently matched zero sites (`\x27` inside `\Q...\E` is
literal); the existing `review-fix-commit-loop` pitfall already requires
comparing applied vs. matched replacement counts and grepping anchors before
running tests, and that guard caught it. The sub-agent review's Minor finding
(`getAiSessionCardActivation` returning `sessionRow`) was evaluated and kept
because the integration test `sessionCardInteraction.test.js` asserts the
resolved row; no workflow gap.

## Owner approvals

To approve this PR for merge, the repository owner posts this exact comment on
the PR:

```
approve 9c632e4289767200197eb2cf10327d1c379004e5
```
