### PR TITLE
Fix Remove worktree click after an authoritative refresh

### DIFF
--- a/.skills/resilient-webview-mutation-protocols/SKILL.md
+++ b/.skills/resilient-webview-mutation-protocols/SKILL.md
@@ -205,6 +205,7 @@ not once per provider.
 | Mistake | Correction |
 |---|---|
 | Update persistent controls optimistically | Show pending only; render committed state from the Host |
+| Keep an activation bound to the origin control a shared menu was opened from | Shared body-level menus outlive the authoritative HTML replacement that detaches their origin control; rebind from the refreshed DOM (or close the menu with a live-region announcement) before activating, or the click silently dies with the menu left open |
 | Require every selected provider to be available | Enforce domain invariants, not transient availability |
 | Clear pending on a generic acknowledgement | Wait for correlated failure or applied authoritative replacement |
 | Send popup or focus state to the Host | Capture and restore it locally around replacement |

--- a/media/webviewDashboardBundle.js
+++ b/media/webviewDashboardBundle.js
@@ -5248,8 +5248,24 @@ function initProjectAiSessionControls(options) {
             var group = projectDiv && projectDiv.querySelector(
                 '.ai-session-worktree-group[data-worktree-path="' + CSS.escape(context.worktreePath) + '"]'
             );
-            if (!group || !originButton || !originButton.isConnected) return;
-            submitManagedWorktreeRemoval(context.projectId, group, originButton);
+            // An authoritative refresh may have replaced the row while the
+            // menu was open, detaching the origin button; rebind to the
+            // refreshed row's trigger so the click still reaches the host
+            // instead of silently dying with the menu left open.
+            var removalButton = originButton && originButton.isConnected
+                ? originButton
+                : group && group.querySelector('.ai-session-worktree-more');
+            if (!group || !removalButton
+                || removalButton.getAttribute('data-can-remove') !== 'true') {
+                var staleLiveRegion = projectDiv
+                    && projectDiv.querySelector('[data-ai-session-live-region]');
+                if (staleLiveRegion) {
+                    staleLiveRegion.textContent = 'This worktree can no longer be removed.';
+                }
+                closeAiSessionWorktreeMenu();
+                return;
+            }
+            submitManagedWorktreeRemoval(context.projectId, group, removalButton);
         } else {
             return;
         }

--- a/media/webviewProjectAiSessionControlsScripts.js
+++ b/media/webviewProjectAiSessionControlsScripts.js
@@ -1044,8 +1044,24 @@ function initProjectAiSessionControls(options) {
             var group = projectDiv && projectDiv.querySelector(
                 '.ai-session-worktree-group[data-worktree-path="' + CSS.escape(context.worktreePath) + '"]'
             );
-            if (!group || !originButton || !originButton.isConnected) return;
-            submitManagedWorktreeRemoval(context.projectId, group, originButton);
+            // An authoritative refresh may have replaced the row while the
+            // menu was open, detaching the origin button; rebind to the
+            // refreshed row's trigger so the click still reaches the host
+            // instead of silently dying with the menu left open.
+            var removalButton = originButton && originButton.isConnected
+                ? originButton
+                : group && group.querySelector('.ai-session-worktree-more');
+            if (!group || !removalButton
+                || removalButton.getAttribute('data-can-remove') !== 'true') {
+                var staleLiveRegion = projectDiv
+                    && projectDiv.querySelector('[data-ai-session-live-region]');
+                if (staleLiveRegion) {
+                    staleLiveRegion.textContent = 'This worktree can no longer be removed.';
+                }
+                closeAiSessionWorktreeMenu();
+                return;
+            }
+            submitManagedWorktreeRemoval(context.projectId, group, removalButton);
         } else {
             return;
         }

--- a/src/webview/webviewProjectAiSessionControlsScripts.js
+++ b/src/webview/webviewProjectAiSessionControlsScripts.js
@@ -1044,8 +1044,24 @@ function initProjectAiSessionControls(options) {
             var group = projectDiv && projectDiv.querySelector(
                 '.ai-session-worktree-group[data-worktree-path="' + CSS.escape(context.worktreePath) + '"]'
             );
-            if (!group || !originButton || !originButton.isConnected) return;
-            submitManagedWorktreeRemoval(context.projectId, group, originButton);
+            // An authoritative refresh may have replaced the row while the
+            // menu was open, detaching the origin button; rebind to the
+            // refreshed row's trigger so the click still reaches the host
+            // instead of silently dying with the menu left open.
+            var removalButton = originButton && originButton.isConnected
+                ? originButton
+                : group && group.querySelector('.ai-session-worktree-more');
+            if (!group || !removalButton
+                || removalButton.getAttribute('data-can-remove') !== 'true') {
+                var staleLiveRegion = projectDiv
+                    && projectDiv.querySelector('[data-ai-session-live-region]');
+                if (staleLiveRegion) {
+                    staleLiveRegion.textContent = 'This worktree can no longer be removed.';
+                }
+                closeAiSessionWorktreeMenu();
+                return;
+            }
+            submitManagedWorktreeRemoval(context.projectId, group, removalButton);
         } else {
             return;
         }

--- a/tests/browser/quickSessionCreate.test.js
+++ b/tests/browser/quickSessionCreate.test.js
@@ -497,6 +497,62 @@ test('WORKTREE-MANAGED-CLEANUP-PROTOCOL-001 ignores a late removal settlement fr
     assert.equal(await reloadedButton.getAttribute('aria-busy'), 'true');
 });
 
+test('WORKTREE-MANAGED-CLEANUP-PROTOCOL-001 removal rebinds to the refreshed row after an authoritative replacement', async t => {
+    const key = {
+        repositoryKey: '/repo/.git',
+        canonicalWorktreePath: '/repo/.agent-pivot/worktrees/stale-menu',
+    };
+    const worktree = {
+        kind: 'ready',
+        git: {
+            key, branchRef: 'refs/heads/agent-pivot/stale-menu', head: 'a'.repeat(40),
+            isMain: false, isBare: false, health: 'normal', headKind: 'branch',
+        },
+        activity: 'idle', sessions: [], authority: { canResume: true, canRemove: true },
+    };
+    const page = await openQuickCreatePage(t, { worktrees: [worktree] });
+    const project = page.locator('[data-open-session-surface][data-id="project-a"]');
+    const worktreeSelector = '.ai-session-worktree-group[data-worktree-path="'
+        + key.canonicalWorktreePath + '"] .ai-session-worktree-more';
+    const button = project.locator(worktreeSelector);
+    const menu = page.locator('#aiSessionWorktreeMenu');
+    const removeItem = menu.locator('[data-action="worktree-remove"]');
+    await button.click();
+    assert.equal(await removeItem.isVisible(), true,
+        'a removable worktree offers removal inside its unified menu');
+    const originalButton = await button.elementHandle();
+
+    // A live authoritative refresh replaces the row (detaching the ⋯ trigger
+    // the menu was opened from) while the shared menu stays open. The removal
+    // click must rebind to the refreshed row instead of silently dying.
+    await postAuthoritativeWorktreeUpdate(page, 2, { worktrees: [worktree] });
+    const refreshedButton = project.locator(worktreeSelector);
+    assert.equal(await refreshedButton.count(), 1,
+        'the refresh keeps the removable row in view');
+    assert.equal(await originalButton.evaluate(element => element.isConnected), false,
+        'the original trigger no longer lives in the document');
+
+    await removeItem.click();
+    const removal = (await postedMessages(page))
+        .filter(message => message.type === 'remove-managed-worktree');
+    assert.equal(removal.length, 1,
+        'removal must still post when the open menu outlived the row it was opened from');
+    assert.deepEqual({ ...removal[0], requestId: '<nonce>' }, {
+        type: 'remove-managed-worktree', version: 1,
+        requestId: '<nonce>', projectId: 'project-a',
+        repositoryKey: key.repositoryKey, worktreePath: key.canonicalWorktreePath,
+    });
+    // This harness loads no styles, so assert the closed class instead of
+    // computed visibility.
+    assert.ok(!(await menu.getAttribute('class')).includes('visible'),
+        'the menu closes after activation');
+    assert.equal(await refreshedButton.isDisabled(), true,
+        'pending state lands on the refreshed trigger, not the detached original');
+    assert.equal(await refreshedButton.getAttribute('aria-busy'), 'true');
+    assert.equal(await project.locator('[data-ai-session-live-region]').textContent(),
+        'Preparing worktree removal…');
+});
+
 test('WORKTREE-SESSION-CREATE-TARGET-001 a worktree quick button posts its exact target and remembered provider', async t => {
     const key = {
         repositoryKey: '/repo/.git',


### PR DESCRIPTION
## Summary

The **Remove worktree** item in the per-worktree ⋯ menu often did nothing. An AI-session dashboard refresh replaces the workspace row HTML while the shared body-level menu stays open, detaching the origin button the menu was opened from. The removal activation required that detached button and silently bailed: no host message was posted and the menu stayed open, looking exactly like a dead button.

The activation now rebinds to the refreshed row's `.ai-session-worktree-more` trigger, posts the `remove-managed-worktree` request, and lands the pending state on the refreshed button. If a refresh made the worktree unremovable in the meantime, the menu closes with a live-region announcement instead of a silent no-op.

## Owner approvals

```
approve e23fef14cca07400cc070cb60f001f6d065e7796
```

## Skill harvest

updated .skills/resilient-webview-mutation-protocols — added the "shared body-level menu activation must rebind from the refreshed DOM instead of staying bound to a detached origin control" rule to the Common Mistakes table; evidence: this bug's root cause; validated with quick_validate.py (Skill is valid!) and tests/unit/tooling/repositorySkills.test.js (10 pass).

## Verification

- New rendered-surface regression test `WORKTREE-MANAGED-CLEANUP-PROTOCOL-001 removal rebinds to the refreshed row after an authoritative replacement` in `tests/browser/quickSessionCreate.test.js`: opens the menu, applies an authoritative `ai-sessions-updated` replacement (detaching the origin trigger), clicks Remove worktree, and asserts the posted removal request, the pending state on the refreshed trigger, and the menu close. Observed RED (0 removal messages posted) on the unfixed implementation; GREEN after the fix.
- CI reachability: `tests/browser/**` runs under `npm run test:browser:run`, part of the required `quality-linux` lane (`npm run test:ci:linux`).
- `npm run test-compile`, focused browser suites (75 tests pass), `npm run test:behavior-contracts`, `node scripts/run-dashboard-webview-checks.js`, and `git diff --check` all pass.
- `media/` runtime copies regenerated via `npx gulp copyWebviewAssets` and `node scripts/build-dashboard-webview-bundle.js`, byte-identical with the `src/webview/` sources.
