### PR TITLE
perf: make cached conversation switches instant

### DIFF
--- a/media/conversationViewerScripts.js
+++ b/media/conversationViewerScripts.js
@@ -388,6 +388,10 @@
     // cannot balloon Webview memory.
     var frameCache = new Map();
     var frameCacheNodes = 0;
+    // A cached frame can be shown as a non-authoritative preview as soon as
+    // the Host announces a target switch. The eventual page still validates
+    // its token and remains the only authoritative state transition.
+    var previewFrame;
     var FRAME_CACHE_LIMIT = 4;
     var FRAME_CACHE_NODE_BUDGET = 600;
     var state = {
@@ -1197,6 +1201,7 @@
         setLoadingInteractivity(true);
         messages.setAttribute('aria-busy', 'true');
         status.textContent = 'Loading conversation…';
+        previewCachedFrame(message.target);
         return true;
     }
 
@@ -1247,8 +1252,12 @@
         }
         // The session is really switching: stash the outgoing conversation
         // as a detached frame before any state is reset, so a later switch
-        // back can reattach it whole.
-        stashCurrentFrame();
+        // back can reattach it whole. A matching preview already stashed the
+        // outgoing frame when the loading notice arrived.
+        if (!previewFrame
+            || previewFrame.key !== frameSessionKey(nextCommentTarget)) {
+            stashCurrentFrame();
+        }
         telemetryController.resetSession(
             nextCommentTarget,
             message.subscriptionGeneration
@@ -1674,6 +1683,54 @@
         }
     }
 
+    function returnPreviewFrameToCache() {
+        if (!previewFrame) {
+            return;
+        }
+        var outgoingKey = frameSessionKey(commentTarget);
+        var outgoing = outgoingKey ? frameCache.get(outgoingKey) : undefined;
+        if (outgoing) {
+            // A rapid B -> C handoff arrived while B was only a preview.
+            // Put the actual A document back before stashing it under A.
+            messages.replaceChildren.apply(messages, outgoing.nodes);
+            // Its nodes are live again. Remove the old cache entry so the
+            // following stash does not release and re-cache those same nodes.
+            frameCache.delete(outgoingKey);
+            frameCacheNodes -= outgoing.nodeCount;
+        }
+        frameCache.set(previewFrame.key, previewFrame.frame);
+        frameCacheNodes += previewFrame.frame.nodeCount;
+        previewFrame = undefined;
+    }
+
+    function previewCachedFrame(target) {
+        var key = frameSessionKey(target);
+        if (!key) {
+            return;
+        }
+        if (previewFrame && previewFrame.key === key) {
+            return;
+        }
+        returnPreviewFrameToCache();
+        // Preserve the outgoing document before moving the cached incoming
+        // nodes into the live tree. Its semantic state remains authoritative
+        // until the incoming page applies, and all controls are disabled.
+        stashCurrentFrame();
+        var frame = frameCache.get(key);
+        if (!frame) {
+            return;
+        }
+        frameCache.delete(key);
+        frameCacheNodes -= frame.nodeCount;
+        previewFrame = { key: key, frame: frame };
+        messages.replaceChildren.apply(messages, frame.nodes);
+        if (frame.followingEnd) {
+            reconcileController.scrollToEnd();
+        } else {
+            restoreViewportReadingPosition(frame.anchor, frame.scrollTop);
+        }
+    }
+
     // A frame is restorable only when its content token matches the page's
     // signature — the token equality proves the DOM is byte-identical to
     // what the Host just published. Restoring takes the frame out of the
@@ -1682,6 +1739,13 @@
         var key = frameSessionKey(message.target);
         if (!key || typeof message.htmlSignature !== 'string') {
             return undefined;
+        }
+        if (previewFrame && previewFrame.key === key) {
+            var preview = previewFrame.frame;
+            previewFrame = undefined;
+            return preview.token === message.htmlSignature
+                ? preview
+                : undefined;
         }
         var frame = frameCache.get(key);
         if (!frame || frame.token !== message.htmlSignature) {

--- a/media/conversationViewerScripts.js
+++ b/media/conversationViewerScripts.js
@@ -1198,10 +1198,13 @@
         }
         conversationLoading = true;
         document.body.setAttribute('data-conversation-loading', 'true');
-        setLoadingInteractivity(true);
         messages.setAttribute('aria-busy', 'true');
         status.textContent = 'Loading conversation…';
         previewCachedFrame(message.target);
+        // Preview nodes are attached synchronously above. Disable the live
+        // controls only after that attachment, otherwise a cached target
+        // could become interactive while the Host still owns the old target.
+        setLoadingInteractivity(true);
         return true;
     }
 
@@ -1254,6 +1257,13 @@
         // as a detached frame before any state is reset, so a later switch
         // back can reattach it whole. A matching preview already stashed the
         // outgoing frame when the loading notice arrived.
+        if (previewFrame
+            && previewFrame.key !== frameSessionKey(nextCommentTarget)) {
+            // Loading notices are best-effort. If this page supersedes the
+            // previewed target, put the real outgoing frame back before it is
+            // stashed under its authoritative identity.
+            returnPreviewFrameToCache();
+        }
         if (!previewFrame
             || previewFrame.key !== frameSessionKey(nextCommentTarget)) {
             stashCurrentFrame();
@@ -1693,10 +1703,6 @@
             // A rapid B -> C handoff arrived while B was only a preview.
             // Put the actual A document back before stashing it under A.
             messages.replaceChildren.apply(messages, outgoing.nodes);
-            // Its nodes are live again. Remove the old cache entry so the
-            // following stash does not release and re-cache those same nodes.
-            frameCache.delete(outgoingKey);
-            frameCacheNodes -= outgoing.nodeCount;
         }
         frameCache.set(previewFrame.key, previewFrame.frame);
         frameCacheNodes += previewFrame.frame.nodeCount;
@@ -1712,16 +1718,21 @@
             return;
         }
         returnPreviewFrameToCache();
+        // Take the requested frame before stashing the outgoing one. At the
+        // cache limit, stashing first could evict this least-recently-used
+        // target and turn an otherwise instant switch into a full resync.
+        var frame = frameCache.get(key);
+        if (frame) {
+            frameCache.delete(key);
+            frameCacheNodes -= frame.nodeCount;
+        }
         // Preserve the outgoing document before moving the cached incoming
         // nodes into the live tree. Its semantic state remains authoritative
         // until the incoming page applies, and all controls are disabled.
         stashCurrentFrame();
-        var frame = frameCache.get(key);
         if (!frame) {
             return;
         }
-        frameCache.delete(key);
-        frameCacheNodes -= frame.nodeCount;
         previewFrame = { key: key, frame: frame };
         messages.replaceChildren.apply(messages, frame.nodes);
         if (frame.followingEnd) {

--- a/media/conversationViewerScripts.js
+++ b/media/conversationViewerScripts.js
@@ -1196,6 +1196,13 @@
             // Stale or same-session notices never dim the live content.
             return true;
         }
+        // A new notice can supersede a cached preview. Restore that preview's
+        // controls before moving its nodes back into the cache; otherwise the
+        // next call overwrites the tracked entries and leaves that frame inert
+        // when it is later restored.
+        if (conversationLoading) {
+            setLoadingInteractivity(false);
+        }
         conversationLoading = true;
         document.body.setAttribute('data-conversation-loading', 'true');
         messages.setAttribute('aria-busy', 'true');

--- a/src/webview/conversationViewerScripts.js
+++ b/src/webview/conversationViewerScripts.js
@@ -388,6 +388,10 @@
     // cannot balloon Webview memory.
     var frameCache = new Map();
     var frameCacheNodes = 0;
+    // A cached frame can be shown as a non-authoritative preview as soon as
+    // the Host announces a target switch. The eventual page still validates
+    // its token and remains the only authoritative state transition.
+    var previewFrame;
     var FRAME_CACHE_LIMIT = 4;
     var FRAME_CACHE_NODE_BUDGET = 600;
     var state = {
@@ -1197,6 +1201,7 @@
         setLoadingInteractivity(true);
         messages.setAttribute('aria-busy', 'true');
         status.textContent = 'Loading conversation…';
+        previewCachedFrame(message.target);
         return true;
     }
 
@@ -1247,8 +1252,12 @@
         }
         // The session is really switching: stash the outgoing conversation
         // as a detached frame before any state is reset, so a later switch
-        // back can reattach it whole.
-        stashCurrentFrame();
+        // back can reattach it whole. A matching preview already stashed the
+        // outgoing frame when the loading notice arrived.
+        if (!previewFrame
+            || previewFrame.key !== frameSessionKey(nextCommentTarget)) {
+            stashCurrentFrame();
+        }
         telemetryController.resetSession(
             nextCommentTarget,
             message.subscriptionGeneration
@@ -1674,6 +1683,54 @@
         }
     }
 
+    function returnPreviewFrameToCache() {
+        if (!previewFrame) {
+            return;
+        }
+        var outgoingKey = frameSessionKey(commentTarget);
+        var outgoing = outgoingKey ? frameCache.get(outgoingKey) : undefined;
+        if (outgoing) {
+            // A rapid B -> C handoff arrived while B was only a preview.
+            // Put the actual A document back before stashing it under A.
+            messages.replaceChildren.apply(messages, outgoing.nodes);
+            // Its nodes are live again. Remove the old cache entry so the
+            // following stash does not release and re-cache those same nodes.
+            frameCache.delete(outgoingKey);
+            frameCacheNodes -= outgoing.nodeCount;
+        }
+        frameCache.set(previewFrame.key, previewFrame.frame);
+        frameCacheNodes += previewFrame.frame.nodeCount;
+        previewFrame = undefined;
+    }
+
+    function previewCachedFrame(target) {
+        var key = frameSessionKey(target);
+        if (!key) {
+            return;
+        }
+        if (previewFrame && previewFrame.key === key) {
+            return;
+        }
+        returnPreviewFrameToCache();
+        // Preserve the outgoing document before moving the cached incoming
+        // nodes into the live tree. Its semantic state remains authoritative
+        // until the incoming page applies, and all controls are disabled.
+        stashCurrentFrame();
+        var frame = frameCache.get(key);
+        if (!frame) {
+            return;
+        }
+        frameCache.delete(key);
+        frameCacheNodes -= frame.nodeCount;
+        previewFrame = { key: key, frame: frame };
+        messages.replaceChildren.apply(messages, frame.nodes);
+        if (frame.followingEnd) {
+            reconcileController.scrollToEnd();
+        } else {
+            restoreViewportReadingPosition(frame.anchor, frame.scrollTop);
+        }
+    }
+
     // A frame is restorable only when its content token matches the page's
     // signature — the token equality proves the DOM is byte-identical to
     // what the Host just published. Restoring takes the frame out of the
@@ -1682,6 +1739,13 @@
         var key = frameSessionKey(message.target);
         if (!key || typeof message.htmlSignature !== 'string') {
             return undefined;
+        }
+        if (previewFrame && previewFrame.key === key) {
+            var preview = previewFrame.frame;
+            previewFrame = undefined;
+            return preview.token === message.htmlSignature
+                ? preview
+                : undefined;
         }
         var frame = frameCache.get(key);
         if (!frame || frame.token !== message.htmlSignature) {

--- a/src/webview/conversationViewerScripts.js
+++ b/src/webview/conversationViewerScripts.js
@@ -1198,10 +1198,13 @@
         }
         conversationLoading = true;
         document.body.setAttribute('data-conversation-loading', 'true');
-        setLoadingInteractivity(true);
         messages.setAttribute('aria-busy', 'true');
         status.textContent = 'Loading conversation…';
         previewCachedFrame(message.target);
+        // Preview nodes are attached synchronously above. Disable the live
+        // controls only after that attachment, otherwise a cached target
+        // could become interactive while the Host still owns the old target.
+        setLoadingInteractivity(true);
         return true;
     }
 
@@ -1254,6 +1257,13 @@
         // as a detached frame before any state is reset, so a later switch
         // back can reattach it whole. A matching preview already stashed the
         // outgoing frame when the loading notice arrived.
+        if (previewFrame
+            && previewFrame.key !== frameSessionKey(nextCommentTarget)) {
+            // Loading notices are best-effort. If this page supersedes the
+            // previewed target, put the real outgoing frame back before it is
+            // stashed under its authoritative identity.
+            returnPreviewFrameToCache();
+        }
         if (!previewFrame
             || previewFrame.key !== frameSessionKey(nextCommentTarget)) {
             stashCurrentFrame();
@@ -1693,10 +1703,6 @@
             // A rapid B -> C handoff arrived while B was only a preview.
             // Put the actual A document back before stashing it under A.
             messages.replaceChildren.apply(messages, outgoing.nodes);
-            // Its nodes are live again. Remove the old cache entry so the
-            // following stash does not release and re-cache those same nodes.
-            frameCache.delete(outgoingKey);
-            frameCacheNodes -= outgoing.nodeCount;
         }
         frameCache.set(previewFrame.key, previewFrame.frame);
         frameCacheNodes += previewFrame.frame.nodeCount;
@@ -1712,16 +1718,21 @@
             return;
         }
         returnPreviewFrameToCache();
+        // Take the requested frame before stashing the outgoing one. At the
+        // cache limit, stashing first could evict this least-recently-used
+        // target and turn an otherwise instant switch into a full resync.
+        var frame = frameCache.get(key);
+        if (frame) {
+            frameCache.delete(key);
+            frameCacheNodes -= frame.nodeCount;
+        }
         // Preserve the outgoing document before moving the cached incoming
         // nodes into the live tree. Its semantic state remains authoritative
         // until the incoming page applies, and all controls are disabled.
         stashCurrentFrame();
-        var frame = frameCache.get(key);
         if (!frame) {
             return;
         }
-        frameCache.delete(key);
-        frameCacheNodes -= frame.nodeCount;
         previewFrame = { key: key, frame: frame };
         messages.replaceChildren.apply(messages, frame.nodes);
         if (frame.followingEnd) {

--- a/src/webview/conversationViewerScripts.js
+++ b/src/webview/conversationViewerScripts.js
@@ -1196,6 +1196,13 @@
             // Stale or same-session notices never dim the live content.
             return true;
         }
+        // A new notice can supersede a cached preview. Restore that preview's
+        // controls before moving its nodes back into the cache; otherwise the
+        // next call overwrites the tracked entries and leaves that frame inert
+        // when it is later restored.
+        if (conversationLoading) {
+            setLoadingInteractivity(false);
+        }
         conversationLoading = true;
         document.body.setAttribute('data-conversation-loading', 'true');
         messages.setAttribute('aria-busy', 'true');

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -1344,6 +1344,9 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 preserves cached frames across 
         window.__betaPreviewNode = document.querySelector(
             '[data-message-id="beta-0"]'
         );
+        window.__betaPreviewControl = document.createElement('button');
+        window.__betaPreviewControl.textContent = 'beta action';
+        window.__betaPreviewNode.appendChild(window.__betaPreviewControl);
     });
     await sendPage(page, sessionPage(4, 'session-gamma', 'gamma', 'sig-gamma'));
     await page.evaluate(() => {
@@ -1368,16 +1371,20 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 preserves cached frames across 
             .textContent.trim(),
         sameNode: document.querySelector('[data-message-id="beta-0"]')
             === window.__betaPreviewNode,
-    })), { content: 'beta', sameNode: true });
+    })), { content: 'betabeta action', sameNode: true });
 
     // This authoritative gamma page skips over the final beta preview. The
     // preview must be unwound so beta is not stashed under alpha's identity.
     await sendPage(page, sessionPage(9, 'session-gamma', 'gamma', 'sig-gamma'));
     await sendPage(page, sessionPage(10, 'session-beta', 'beta', 'sig-beta'));
-    assert.equal(await page.evaluate(() =>
-        document.querySelector('[data-message-id="beta-0"]')
-            === window.__betaPreviewNode
-    ), true, 'the interrupted beta preview remains a reusable cached frame');
+    assert.deepEqual(await page.evaluate(() => ({
+        sameNode: document.querySelector('[data-message-id="beta-0"]')
+            === window.__betaPreviewNode,
+        controlEnabled: !window.__betaPreviewControl.disabled,
+    })), {
+        sameNode: true,
+        controlEnabled: true,
+    }, 'the interrupted beta preview remains reusable and interactive');
 });
 
 test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 correlates resyncs to each page that fails', async t => {
@@ -4517,6 +4524,16 @@ test('CONVERSATION-OUTLINE-NAVIGATION-001 keeps every side-panel view usable acr
                 + '    // the Host announces a target switch. The eventual page still validates\n'
                 + '    // its token and remains the only authoritative state transition.\n'
                 + '    var previewFrame;\n',
+            ''
+        )
+        .replace(
+            '        // A new notice can supersede a cached preview. Restore that preview\'s\n'
+                + '        // controls before moving its nodes back into the cache; otherwise the\n'
+                + '        // next call overwrites the tracked entries and leaves that frame inert\n'
+                + '        // when it is later restored.\n'
+                + '        if (conversationLoading) {\n'
+                + '            setLoadingInteractivity(false);\n'
+                + '        }\n',
             ''
         )
         .replace(

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -1231,6 +1231,138 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 shows a lightweight loading sta
     });
 });
 
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 previews a cached session before its Host page returns', async t => {
+    const page = await openViewerPage(t);
+    const sessionPage = (generation, sessionId, marker, signature) => ({
+        ...hostileConversationPage,
+        requestId: generation * 10,
+        subscriptionGeneration: generation,
+        html: `<article data-message-id="${marker}-0" `
+            + `data-interaction-id="${marker}-input"><p>${marker}</p></article>`,
+        htmlSignature: signature,
+        outline: [{
+            interactionId: `${marker}-input`,
+            userPreview: marker,
+            responseState: 'complete',
+        }],
+        selectedInteractionId: `${marker}-input`,
+        selectedInput: 1,
+        totalInputs: 1,
+        previousCursor: undefined,
+        nextCursor: undefined,
+        target: {
+            projectId: 'project-1',
+            provider: 'codex',
+            sessionId,
+            interactionId: `${marker}-input`,
+            displayName: `${marker} session`,
+        },
+        comments: { revision: 0, comments: [] },
+        projectComments: { revision: 0, comments: [] },
+        bookmarks: { revision: 0, interactionIds: [] },
+    });
+    const loadingNotice = (generation, sessionId) => ({
+        type: 'conversation-viewer-loading',
+        version: 1,
+        subscriptionGeneration: generation,
+        target: { projectId: 'project-1', provider: 'codex', sessionId },
+    });
+
+    await sendPage(page, sessionPage(2, 'session-alpha', 'alpha', 'sig-alpha'));
+    await sendPage(page, sessionPage(3, 'session-beta', 'beta', 'sig-beta'));
+    await page.evaluate(() => {
+        window.__betaNode = document.querySelector('[data-message-id="beta-0"]');
+    });
+    // This full publication returns to alpha and stashes beta for a later
+    // switch. The following loading notice must reattach beta immediately,
+    // before any Host page for generation five is delivered.
+    await sendPage(page, sessionPage(4, 'session-alpha', 'alpha', 'sig-alpha'));
+    await sendPage(page, loadingNotice(5, 'session-beta'));
+
+    assert.deepEqual(await page.evaluate(() => ({
+        content: document.querySelector('[data-conversation-messages]')
+            .textContent.trim(),
+        sameNode: document.querySelector('[data-message-id="beta-0"]')
+            === window.__betaNode,
+        loading: document.body.getAttribute('data-conversation-loading'),
+    })), {
+        content: 'beta',
+        sameNode: true,
+        loading: 'true',
+    });
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 preserves cached frames across rapid preview handoffs', async t => {
+    const page = await openViewerPage(t);
+    const sessionPage = (generation, sessionId, marker, signature) => ({
+        ...hostileConversationPage,
+        requestId: generation * 10,
+        subscriptionGeneration: generation,
+        html: `<article data-message-id="${marker}-0" `
+            + `data-interaction-id="${marker}-input"><p>${marker}</p></article>`,
+        htmlSignature: signature,
+        outline: [{
+            interactionId: `${marker}-input`,
+            userPreview: marker,
+            responseState: 'complete',
+        }],
+        selectedInteractionId: `${marker}-input`,
+        selectedInput: 1,
+        totalInputs: 1,
+        previousCursor: undefined,
+        nextCursor: undefined,
+        target: {
+            projectId: 'project-1',
+            provider: 'codex',
+            sessionId,
+            interactionId: `${marker}-input`,
+            displayName: `${marker} session`,
+        },
+        comments: { revision: 0, comments: [] },
+        projectComments: { revision: 0, comments: [] },
+        bookmarks: { revision: 0, interactionIds: [] },
+    });
+    const loadingNotice = (generation, sessionId) => ({
+        type: 'conversation-viewer-loading',
+        version: 1,
+        subscriptionGeneration: generation,
+        target: { projectId: 'project-1', provider: 'codex', sessionId },
+    });
+
+    // Populate frames for alpha, beta, and gamma, then interrupt a preview
+    // before either page arrives. Both previewed frames must remain usable.
+    await sendPage(page, sessionPage(2, 'session-alpha', 'alpha', 'sig-alpha'));
+    await sendPage(page, sessionPage(3, 'session-beta', 'beta', 'sig-beta'));
+    await page.evaluate(() => {
+        window.__betaPreviewNode = document.querySelector(
+            '[data-message-id="beta-0"]'
+        );
+    });
+    await sendPage(page, sessionPage(4, 'session-gamma', 'gamma', 'sig-gamma'));
+    await page.evaluate(() => {
+        window.__gammaPreviewNode = document.querySelector(
+            '[data-message-id="gamma-0"]'
+        );
+    });
+    await sendPage(page, sessionPage(5, 'session-alpha', 'alpha', 'sig-alpha'));
+    await sendPage(page, loadingNotice(6, 'session-beta'));
+    await sendPage(page, loadingNotice(7, 'session-gamma'));
+
+    assert.deepEqual(await page.evaluate(() => ({
+        content: document.querySelector('[data-conversation-messages]')
+            .textContent.trim(),
+        sameNode: document.querySelector('[data-message-id="gamma-0"]')
+            === window.__gammaPreviewNode,
+    })), { content: 'gamma', sameNode: true });
+
+    await sendPage(page, sessionPage(7, 'session-gamma', 'gamma', 'sig-gamma'));
+    await sendPage(page, sessionPage(8, 'session-beta', 'beta', 'sig-beta'));
+    assert.equal(await page.evaluate(() =>
+        document.querySelector('[data-message-id="beta-0"]')
+            === window.__betaPreviewNode
+    ), true, 'the interrupted beta preview remains a reusable cached frame');
+});
+
 test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 correlates resyncs to each page that fails', async t => {
     const page = await openViewerPage(t);
     await page.evaluate(() => {
@@ -4340,6 +4472,51 @@ test('CONVERSATION-OUTLINE-NAVIGATION-001 keeps every side-panel view usable acr
     }
 
     const previousViewerScript = viewerScript
+        // Undo the cached-frame preview before stepping back through the
+        // historical fixtures. Previewing is deliberately non-authoritative:
+        // the following page still validates the cached token.
+        .replace(
+            '    // A cached frame can be shown as a non-authoritative preview as soon as\n'
+                + '    // the Host announces a target switch. The eventual page still validates\n'
+                + '    // its token and remains the only authoritative state transition.\n'
+                + '    var previewFrame;\n',
+            ''
+        )
+        .replace(
+            "        status.textContent = 'Loading conversation…';\n"
+                + '        previewCachedFrame(message.target);\n'
+                + '        return true;\n',
+            "        status.textContent = 'Loading conversation…';\n"
+                + '        return true;\n'
+        )
+        .replace(
+            /\n    function returnPreviewFrameToCache\(\) \{[\s\S]*?\n    \}\n\n    function previewCachedFrame\(target\) \{[\s\S]*?\n    \}\n(?=\n    \/\/ A frame is restorable)/,
+            ''
+        )
+        .replace(
+            '        if (previewFrame && previewFrame.key === key) {\n'
+                + '            var preview = previewFrame.frame;\n'
+                + '            previewFrame = undefined;\n'
+                + '            return preview.token === message.htmlSignature\n'
+                + '                ? preview\n'
+                + '                : undefined;\n'
+                + '        }\n',
+            ''
+        )
+        .replace(
+            '        // The session is really switching: stash the outgoing conversation\n'
+                + '        // as a detached frame before any state is reset, so a later switch\n'
+                + '        // back can reattach it whole. A matching preview already stashed the\n'
+                + '        // outgoing frame when the loading notice arrived.\n'
+                + '        if (!previewFrame\n'
+                + '            || previewFrame.key !== frameSessionKey(nextCommentTarget)) {\n'
+                + '            stashCurrentFrame();\n'
+                + '        }\n',
+            '        // The session is really switching: stash the outgoing conversation\n'
+                + '        // as a detached frame before any state is reset, so a later switch\n'
+                + '        // back can reattach it whole.\n'
+                + '        stashCurrentFrame();\n'
+        )
         // Undo the current correlated earlier-page request/result protocol
         // before stepping back through the existing historical fixtures.
         .replace(

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -1272,6 +1272,10 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 previews a cached session befor
     await sendPage(page, sessionPage(3, 'session-beta', 'beta', 'sig-beta'));
     await page.evaluate(() => {
         window.__betaNode = document.querySelector('[data-message-id="beta-0"]');
+        var previewControl = document.createElement('button');
+        previewControl.setAttribute('data-preview-control', '');
+        previewControl.textContent = 'beta action';
+        window.__betaNode.appendChild(previewControl);
     });
     // This full publication returns to alpha and stashes beta for a later
     // switch. The following loading notice must reattach beta immediately,
@@ -1284,10 +1288,13 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 previews a cached session befor
             .textContent.trim(),
         sameNode: document.querySelector('[data-message-id="beta-0"]')
             === window.__betaNode,
+        previewControlDisabled: document.querySelector('[data-preview-control]')
+            .disabled,
         loading: document.body.getAttribute('data-conversation-loading'),
     })), {
-        content: 'beta',
+        content: 'betabeta action',
         sameNode: true,
+        previewControlDisabled: true,
         loading: 'true',
     });
 });
@@ -1355,8 +1362,18 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 preserves cached frames across 
             === window.__gammaPreviewNode,
     })), { content: 'gamma', sameNode: true });
 
-    await sendPage(page, sessionPage(7, 'session-gamma', 'gamma', 'sig-gamma'));
-    await sendPage(page, sessionPage(8, 'session-beta', 'beta', 'sig-beta'));
+    await sendPage(page, loadingNotice(8, 'session-beta'));
+    assert.deepEqual(await page.evaluate(() => ({
+        content: document.querySelector('[data-conversation-messages]')
+            .textContent.trim(),
+        sameNode: document.querySelector('[data-message-id="beta-0"]')
+            === window.__betaPreviewNode,
+    })), { content: 'beta', sameNode: true });
+
+    // This authoritative gamma page skips over the final beta preview. The
+    // preview must be unwound so beta is not stashed under alpha's identity.
+    await sendPage(page, sessionPage(9, 'session-gamma', 'gamma', 'sig-gamma'));
+    await sendPage(page, sessionPage(10, 'session-beta', 'beta', 'sig-beta'));
     assert.equal(await page.evaluate(() =>
         document.querySelector('[data-message-id="beta-0"]')
             === window.__betaPreviewNode
@@ -1634,6 +1651,26 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 evicts the oldest frame beyond 
         'zeta'
     );
 
+    // Beta is the oldest retained frame. The loading preview must take it
+    // before stashing zeta, otherwise the cache-limit eviction picks beta and
+    // turns this switch into a resync.
+    await sendPage(page, {
+        type: 'conversation-viewer-loading',
+        version: 1,
+        subscriptionGeneration: 8,
+        target: {
+            projectId: 'project-1',
+            provider: 'codex',
+            sessionId: 'session-beta',
+        },
+    });
+    assert.equal(
+        await page.locator('[data-conversation-messages]').innerText(),
+        'beta',
+        'the oldest retained target is still available for an instant preview'
+    );
+    await sendPage(page, sessionPage(8, 'session-beta', 'beta', 'sig-beta'));
+
     // A restoreFrame offer for an evicted frame is answered with a resync.
     await sendPage(page, sessionPage(
         20, 'session-alpha', 'alpha', 'sig-alpha', { restoreFrame: true }
@@ -1653,7 +1690,7 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 evicts the oldest frame beyond 
     }]);
     assert.equal(
         await page.locator('[data-conversation-messages]').innerText(),
-        'zeta',
+        'beta',
         'the live session stays on screen until the resynced full page'
     );
 
@@ -4483,10 +4520,21 @@ test('CONVERSATION-OUTLINE-NAVIGATION-001 keeps every side-panel view usable acr
             ''
         )
         .replace(
-            "        status.textContent = 'Loading conversation…';\n"
+            '        conversationLoading = true;\n'
+                + "        document.body.setAttribute('data-conversation-loading', 'true');\n"
+                + "        messages.setAttribute('aria-busy', 'true');\n"
+                + "        status.textContent = 'Loading conversation…';\n"
                 + '        previewCachedFrame(message.target);\n'
+                + '        // Preview nodes are attached synchronously above. Disable the live\n'
+                + '        // controls only after that attachment, otherwise a cached target\n'
+                + '        // could become interactive while the Host still owns the old target.\n'
+                + '        setLoadingInteractivity(true);\n'
                 + '        return true;\n',
-            "        status.textContent = 'Loading conversation…';\n"
+            '        conversationLoading = true;\n'
+                + "        document.body.setAttribute('data-conversation-loading', 'true');\n"
+                + '        setLoadingInteractivity(true);\n'
+                + "        messages.setAttribute('aria-busy', 'true');\n"
+                + "        status.textContent = 'Loading conversation…';\n"
                 + '        return true;\n'
         )
         .replace(
@@ -4508,6 +4556,13 @@ test('CONVERSATION-OUTLINE-NAVIGATION-001 keeps every side-panel view usable acr
                 + '        // as a detached frame before any state is reset, so a later switch\n'
                 + '        // back can reattach it whole. A matching preview already stashed the\n'
                 + '        // outgoing frame when the loading notice arrived.\n'
+                + '        if (previewFrame\n'
+                + '            && previewFrame.key !== frameSessionKey(nextCommentTarget)) {\n'
+                + '            // Loading notices are best-effort. If this page supersedes the\n'
+                + '            // previewed target, put the real outgoing frame back before it is\n'
+                + '            // stashed under its authoritative identity.\n'
+                + '            returnPreviewFrameToCache();\n'
+                + '        }\n'
                 + '        if (!previewFrame\n'
                 + '            || previewFrame.key !== frameSessionKey(nextCommentTarget)) {\n'
                 + '            stashCurrentFrame();\n'


### PR DESCRIPTION
## Summary

- Preview a validated cached conversation frame immediately after a session-switch loading notice.
- Keep preview controls inert and preserve cache ownership through rapid handoffs and cache-limit eviction.
- Cover preview, superseding pages, control restoration, and version-skew behavior.

## Verification

- `npm run test-compile`
- `node --test tests/browser/conversationViewer.test.js`
- `node --test tests/integration/dashboard/conversationViewer.test.js`
- `node scripts/run-dashboard-webview-checks.js`
- `SKIP_NPM_CI=1 npm run install-local`

## Skill harvest

No skill change: the review/fix guidance already requires ownership and lifecycle checks; the cached-frame issues were feature-specific and are covered by focused regression tests.

## Owner approvals

```
approve 816faa377cc5dc77ba87df04325129f7619ed78e
```