### PR TITLE
perf: skip duplicate conversation target loads

### DIFF
--- a/src/aiSessions/conversation/composition.ts
+++ b/src/aiSessions/conversation/composition.ts
@@ -547,6 +547,19 @@ function createAvailableConversationCapability(
                 return 'closed';
             }
             const intent = beginViewerIntent();
+            const currentTarget = viewer.getCurrentTarget();
+            if (currentTarget
+                && hasSameConversationSession(currentTarget, target)) {
+                // This is a new navigation intent, even though it resolves to
+                // the already-authoritative session. Let the Viewer cancel a
+                // pending preflight for another session, then keep the
+                // retained document without waiting for or parsing a second
+                // snapshot.
+                viewer.previewSession?.(target);
+                terminalAuthority.confirmedTarget =
+                    cloneConversationViewerTarget(currentTarget);
+                return 'opened';
+            }
             const preview = viewer.previewSession?.(target);
             let followedSuccessfully = false;
             try {

--- a/src/aiSessions/conversation/viewer.ts
+++ b/src/aiSessions/conversation/viewer.ts
@@ -741,6 +741,17 @@ export class ConversationViewer implements ConversationViewerApi {
         if (!this.panel) {
             return false;
         }
+        if (this.target && hasSameConversationViewerTarget(this.target, target)) {
+            // The target is already authoritative. A duplicate dashboard
+            // intent has no new state to apply, so do not re-read or
+            // re-render the retained conversation. It may arrive after a
+            // preflight for another target, however; cancel that preview so
+            // the authoritative document becomes interactive immediately.
+            if (this.preflightPreview) {
+                this.cancelPreflightPreview(this.preflightPreview);
+            }
+            return true;
+        }
         // A dashboard-driven follow for the same session must not yank the
         // user out of a subagent transcript they deliberately opened.
         if (this.target?.subagent
@@ -3876,6 +3887,21 @@ function hasSameConversationSessionTarget(
     return left.projectId === right.projectId
         && left.provider === right.provider
         && left.sessionId === right.sessionId;
+}
+
+function hasSameConversationViewerTarget(
+    left: ConversationViewerTarget,
+    right: ConversationViewerTarget
+): boolean {
+    return hasSameConversationSessionTarget(left, right)
+        && left.workspaceName === right.workspaceName
+        && left.interactionId === right.interactionId
+        && left.expectedRevision === right.expectedRevision
+        && left.displayName === right.displayName
+        && left.duplicateDisplayName === right.duplicateDisplayName
+        && left.taskName === right.taskName
+        && left.subagent?.id === right.subagent?.id
+        && left.subagent?.label === right.subagent?.label;
 }
 
 function sameSubagents(

--- a/tests/integration/dashboard/conversationOpenLatest.test.js
+++ b/tests/integration/dashboard/conversationOpenLatest.test.js
@@ -1307,6 +1307,67 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 previews a cached target before
     harness.capability.dispose();
 });
 
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 returns to the authoritative target without another snapshot read', async () => {
+    let abortedReads = 0;
+    const currentTarget = {
+        projectId: 'project-a',
+        provider: 'codex',
+        workspaceName: '',
+        sessionId: 'session-a',
+        interactionId: 'input-a',
+        expectedRevision: 'r1',
+        displayName: 'session-a',
+        duplicateDisplayName: false,
+    };
+    const harness = createHarness({
+        viewerOpen: true,
+        initialViewerTarget: currentTarget,
+        previewSession: target => target.sessionId === 'session-b'
+            ? { dispose() {} }
+            : undefined,
+        resolveTarget: (_projectId, provider, sessionId) => makeSession({
+            key: `${provider}:${sessionId}`,
+            provider,
+            sessionId,
+            name: sessionId,
+        }),
+        readOutline: (provider, sessionId, signal) => sessionId === 'session-b'
+            ? new Promise((_resolve, reject) => {
+                signal.onAbort(() => {
+                    abortedReads += 1;
+                    reject(new Error('superseded provider read'));
+                });
+            })
+            : makeOutline(provider, sessionId, ['input-a']),
+    });
+    const slowFollow = harness.capability.followActiveConversation({
+        projectId: 'project-a', provider: 'codex', sessionId: 'session-b',
+    });
+    await waitFor(
+        () => harness.previewedViewerTargets.length === 1,
+        'the B preflight before the reversal'
+    );
+
+    assert.equal(await harness.capability.followActiveConversation({
+        projectId: 'project-a', provider: 'codex', sessionId: 'session-a',
+    }), 'opened');
+    assert.equal(harness.outlineReads, 1,
+        'returning to the current session does not resolve another outline');
+    assert.equal(harness.followedViewerTargets.length, 0,
+        'the retained Viewer does not receive a redundant follow');
+    assert.equal(abortedReads, 1,
+        'the new current-session intent aborts the stale B snapshot read');
+    assert.equal(await slowFollow, 'superseded');
+    await waitFor(
+        () => harness.cancelledViewerPreviews.length === 1,
+        'the stale B preview cancellation'
+    );
+    assert.deepEqual(harness.cancelledViewerPreviews, [{
+        projectId: 'project-a', provider: 'codex', sessionId: 'session-b',
+    }]);
+    harness.capability.dispose();
+});
+
 test('CONVERSATION-FOLLOW-FEEDBACK-001 surfaces an in-panel notice and sanitized diagnostic when a follow finds no conversation', async () => {
     const diagnostics = [];
     const harness = createHarness({

--- a/tests/integration/dashboard/conversationViewer.test.js
+++ b/tests/integration/dashboard/conversationViewer.test.js
@@ -2187,9 +2187,8 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 preflights a cached frame befor
         preflight: true,
     }, 'the cache handoff does not wait for a resolved interaction target');
 
-    assert.equal(viewer.previewSession({
-        projectId: 'project-a', provider: 'codex', sessionId: 'session-a',
-    }), undefined, 'a rapid reversal restores the still-authoritative session');
+    assert.equal(await viewer.follow(target('session-a')), true,
+        'a duplicate follow restores the still-authoritative session');
     assert.deepEqual(panel.postedMessages.at(-1), {
         type: 'conversation-viewer-loading-cancel',
         version: 1,
@@ -2197,7 +2196,7 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 preflights a cached frame befor
         target: {
             projectId: 'project-a', provider: 'codex', sessionId: 'session-b',
         },
-    }, 'an A → B preview → A reversal restores the authoritative document immediately');
+    }, 'an A → B preview → A follow restores the authoritative document immediately');
     preview.dispose();
     assert.equal(panel.postedMessages.filter(message =>
         message.type === 'conversation-viewer-loading-cancel'
@@ -5003,6 +5002,77 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 announces a lightweight loading
     await viewer.follow(target('session-b', 'input-1'));
     assert.equal(loadingNotices().length, 1,
         're-following the visible session is not a switch either');
+    viewer.dispose();
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 retains an exact target without publishing another conversation page', async () => {
+    let outlineReads = 0;
+    let pageReads = 0;
+    const { viewer, panel } = createViewer({
+        readOutline: async (_provider, sessionId) => {
+            outlineReads += 1;
+            return outline(sessionId, ['input-1']);
+        },
+        readPage: async request => {
+            pageReads += 1;
+            return page(request.sessionId, request.anchorInteractionId);
+        },
+    });
+    const sameTarget = target('session-a', 'input-1');
+    await viewer.open(sameTarget);
+    const pageMessagesBefore = panel.postedMessages.filter(message =>
+        message.type === 'conversation-viewer-page').length;
+    const generationBefore = viewer.getCurrentTarget().expectedRevision;
+    const outlineReadsBefore = outlineReads;
+    const pageReadsBefore = pageReads;
+
+    assert.deepEqual(viewer.getCurrentTarget(), sameTarget,
+        'the follow input matches the authoritative target exactly');
+    assert.equal(await viewer.follow(sameTarget), true);
+    assert.equal(
+        panel.postedMessages.filter(message =>
+            message.type === 'conversation-viewer-page').length,
+        pageMessagesBefore,
+        'an unchanged exact target must not reapply the conversation page'
+    );
+    assert.equal(viewer.getCurrentTarget().expectedRevision, generationBefore,
+        'the retained target stays authoritative without a generation reset');
+    assert.equal(outlineReads, outlineReadsBefore,
+        'an unchanged target must not reread the conversation outline');
+    assert.equal(pageReads, pageReadsBefore,
+        'an unchanged target must not reparse the conversation page');
+    viewer.dispose();
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 completes an exact-target follow without waiting for an unrelated refresh', async () => {
+    const refreshStarted = deferred();
+    const releaseRefresh = deferred();
+    let outlineReads = 0;
+    let delayRefresh = false;
+    const { viewer } = createViewer({
+        readOutline: async (_provider, sessionId) => {
+            outlineReads += 1;
+            if (delayRefresh) {
+                refreshStarted.resolve();
+                await releaseRefresh.promise;
+            }
+            return outline(sessionId, ['input-1']);
+        },
+    });
+    const sameTarget = target('session-a', 'input-1');
+    await viewer.open(sameTarget);
+    delayRefresh = true;
+    const refresh = viewer.refresh();
+    await refreshStarted.promise;
+    assert.equal(await viewer.follow(sameTarget), true,
+        'the duplicate target is already authoritative while its refresh continues');
+    assert.equal(outlineReads, 2,
+        'the duplicate follow does not queue another outline read');
+    releaseRefresh.resolve();
+    await refresh;
+    await new Promise(resolve => setImmediate(resolve));
+    assert.equal(outlineReads, 2,
+        'the duplicate follow does not queue another read after refresh completion');
     viewer.dispose();
 });
 


### PR DESCRIPTION
## Summary

- keep an already-authoritative conversation document instead of rereading or rerendering an exact duplicate target
- short-circuit the dashboard follow path before snapshot resolution when it returns to the current session
- cancel a stale preflight/read on an A → B → A reversal and keep terminal authority bound to A

## Validation

- `npm run test-compile`
- `node --test tests/integration/dashboard/conversationOpenLatest.test.js`
- `node --test tests/integration/dashboard/conversationViewer.test.js`
- `npm run test:coverage && node scripts/check-changed-coverage.js`
- `git diff --check`

## Skill harvest

No skill change: this was a product-path optimization with no reusable agent workflow gap beyond the already-applied review and publishing guidance.

## Owner approvals

```
approve dab74545e0163053192a8457839e8a558648ab7e
```