### PR TITLE
perf: unify conversation navigation handoff

### DIFF
--- a/media/webviewDashboardBundle.js
+++ b/media/webviewDashboardBundle.js
@@ -7523,28 +7523,20 @@ function getAiSessionCardActivation(target, projectId) {
             };
         }
         // A single click on an active-but-unfocused card both brings its
-        // terminal to the front and opens the conversation: the previous
-        // two-step (focus first, open on the next click) left users who
-        // closed the panel wondering why nothing opened. The focus message
-        // comes first so the terminal is visible before the panel reveals.
+        // terminal to the front and opens the conversation. Keep this as one
+        // correlated host transaction: two independent messages could race
+        // and the trailing open needlessly replace the Conversation document.
         return {
             handled: true,
             sessionRow: activationSessionRow,
-            message: [
-                {
-                    type: 'focus-ai-session-terminal',
-                    projectId: projectId,
-                    provider: provider,
-                    sessionId: sessionId,
-                },
-                {
-                    type: 'open-active-ai-session-conversation',
-                    version: 1,
-                    projectId: projectId,
-                    provider: provider,
-                    sessionId: sessionId,
-                },
-            ],
+            message: {
+                type: 'open-active-ai-session-conversation',
+                version: 2,
+                projectId: projectId,
+                provider: provider,
+                sessionId: sessionId,
+                focusTerminal: true,
+            },
         };
     }
     return {

--- a/media/webviewProjectScripts.js
+++ b/media/webviewProjectScripts.js
@@ -52,28 +52,20 @@ function getAiSessionCardActivation(target, projectId) {
             };
         }
         // A single click on an active-but-unfocused card both brings its
-        // terminal to the front and opens the conversation: the previous
-        // two-step (focus first, open on the next click) left users who
-        // closed the panel wondering why nothing opened. The focus message
-        // comes first so the terminal is visible before the panel reveals.
+        // terminal to the front and opens the conversation. Keep this as one
+        // correlated host transaction: two independent messages could race
+        // and the trailing open needlessly replace the Conversation document.
         return {
             handled: true,
             sessionRow: activationSessionRow,
-            message: [
-                {
-                    type: 'focus-ai-session-terminal',
-                    projectId: projectId,
-                    provider: provider,
-                    sessionId: sessionId,
-                },
-                {
-                    type: 'open-active-ai-session-conversation',
-                    version: 1,
-                    projectId: projectId,
-                    provider: provider,
-                    sessionId: sessionId,
-                },
-            ],
+            message: {
+                type: 'open-active-ai-session-conversation',
+                version: 2,
+                projectId: projectId,
+                provider: provider,
+                sessionId: sessionId,
+                focusTerminal: true,
+            },
         };
     }
     return {

--- a/scripts/run-architecture-guards.js
+++ b/scripts/run-architecture-guards.js
@@ -1792,7 +1792,7 @@ const guards = {
         }
         const dashboardClickNavigator = findVariable(
             dashboard,
-            'focusAiSessionAndFollowConversation',
+            'focusAiSessionAndNavigateConversation',
             this.id,
             risk,
         );
@@ -1808,6 +1808,10 @@ const guards = {
             || callArguments(
                 dashboardClickNavigator.initializer,
                 'conversationCapability.followActiveConversation',
+            ).length !== 1
+            || callArguments(
+                dashboardClickNavigator.initializer,
+                'conversationCapability.openLatestActiveConversation',
             ).length !== 1) {
             fail(this.id, risk,
                 'Dashboard Chat-row clicks must use the shared latest-intent navigation transaction');

--- a/src/aiSessions/conversation/composition.ts
+++ b/src/aiSessions/conversation/composition.ts
@@ -502,34 +502,126 @@ function createAvailableConversationCapability(
     ): Promise<boolean> => queueFocus(() => {
         viewer.focus();
     }, isCurrent);
+    const followOpenConversation = async (
+        target: ConversationSessionOpenTarget,
+        reveal: boolean,
+        showFollowFailure: boolean
+    ): Promise<FollowActiveConversationResult> => {
+        if (!viewer.isOpen()) {
+            return 'closed';
+        }
+        const intent = beginViewerIntent();
+        const currentTarget = viewer.getCurrentTarget();
+        if (currentTarget
+            && hasSameConversationSession(currentTarget, target)) {
+            // This is a new navigation intent, even though it resolves to
+            // the already-authoritative session. Let the Viewer cancel a
+            // pending preflight for another session, then keep the retained
+            // document without waiting for or parsing a second snapshot.
+            viewer.previewSession?.(target);
+            terminalAuthority.confirmedTarget =
+                cloneConversationViewerTarget(currentTarget);
+            if (reveal) {
+                viewer.focus();
+            }
+            return 'opened';
+        }
+        const preview = viewer.previewSession?.(target);
+        let followedSuccessfully = false;
+        try {
+            const resolution = await resolveLatestConversationTarget(
+                options,
+                coordinator,
+                target,
+                undefined,
+                undefined,
+                snapshotWarmup,
+                intent.signal
+            );
+            if (!intent.isCurrent()) {
+                return 'superseded';
+            }
+            if (resolution.result !== 'opened') {
+                if (showFollowFailure) {
+                    reportFollowFailure(
+                        options.onDiagnostic,
+                        target.provider,
+                        resolution.result,
+                        resolution.diagnostic
+                    );
+                    viewer.showNotice(
+                        conversationFollowNoticeText(resolution.result)
+                    );
+                }
+                return resolution.result;
+            }
+            if (!viewer.isOpen()) {
+                return 'closed';
+            }
+            const follow = viewer.follow(
+                resolution.viewerTarget,
+                resolution.snapshot
+            );
+            snapshotWarmup?.prepareAfterTargetSet(
+                resolution.viewerTarget,
+                viewer
+            );
+            const followed = await follow;
+            if (followed) {
+                snapshotWarmup?.afterLoad(
+                    resolution.viewerTarget,
+                    resolution.prefetchedSnapshot === true,
+                    viewer
+                );
+                const current = viewer.getCurrentTarget();
+                terminalAuthority.confirmedTarget =
+                    cloneConversationViewerTarget(
+                        current
+                            && hasSameConversationSession(
+                                current,
+                                resolution.viewerTarget
+                            )
+                            ? current
+                            : resolution.viewerTarget
+                    );
+                followedSuccessfully = true;
+                if (reveal) {
+                    viewer.focus();
+                }
+            }
+            return followed ? 'opened' : 'closed';
+        } finally {
+            if (!followedSuccessfully) {
+                preview?.dispose();
+            }
+        }
+    };
+    const openConversation = async (
+        target: ConversationSessionOpenTarget
+    ): Promise<OpenLatestConversationResult> => {
+        if (viewer.isOpen() && viewer.getCurrentTarget()) {
+            const result = await followOpenConversation(target, true, false);
+            return result === 'closed' ? 'superseded' : result;
+        }
+        const intent = beginViewerIntent();
+        return openLatestConversation(
+            options,
+            coordinator,
+            viewer,
+            target,
+            intent.isCurrent,
+            snapshotWarmup,
+            intent.signal
+        );
+    };
     return {
         viewer,
         availability: 'available',
-        openLatestConversation: target => {
-            const intent = beginViewerIntent();
-            return openLatestConversation(
-                options,
-                coordinator,
-                viewer,
-                target,
-                intent.isCurrent,
-                snapshotWarmup,
-                intent.signal
-            );
-        },
+        openLatestConversation: target => openConversation(target),
         async openLatestActiveConversation(
             target: ConversationSessionOpenTarget
         ): Promise<OpenLatestConversationResult> {
-            const intent = beginViewerIntent();
-            const result = await openLatestConversation(
-                options,
-                coordinator,
-                viewer,
-                target,
-                intent.isCurrent,
-                snapshotWarmup,
-                intent.signal
-            );
+            const result = await openConversation(target);
             if (result === 'opened') {
                 const currentTarget = viewer.getCurrentTarget();
                 if (currentTarget
@@ -543,87 +635,7 @@ function createAvailableConversationCapability(
         async followActiveConversation(
             target: ConversationSessionOpenTarget
         ): Promise<FollowActiveConversationResult> {
-            if (!viewer.isOpen()) {
-                return 'closed';
-            }
-            const intent = beginViewerIntent();
-            const currentTarget = viewer.getCurrentTarget();
-            if (currentTarget
-                && hasSameConversationSession(currentTarget, target)) {
-                // This is a new navigation intent, even though it resolves to
-                // the already-authoritative session. Let the Viewer cancel a
-                // pending preflight for another session, then keep the
-                // retained document without waiting for or parsing a second
-                // snapshot.
-                viewer.previewSession?.(target);
-                terminalAuthority.confirmedTarget =
-                    cloneConversationViewerTarget(currentTarget);
-                return 'opened';
-            }
-            const preview = viewer.previewSession?.(target);
-            let followedSuccessfully = false;
-            try {
-                const resolution = await resolveLatestConversationTarget(
-                    options,
-                    coordinator,
-                    target,
-                    undefined,
-                    undefined,
-                    snapshotWarmup,
-                    intent.signal
-                );
-                if (!intent.isCurrent()) {
-                    return 'superseded';
-                }
-                if (resolution.result !== 'opened') {
-                    reportFollowFailure(
-                        options.onDiagnostic,
-                        target.provider,
-                        resolution.result,
-                        resolution.diagnostic
-                    );
-                    viewer.showNotice(
-                        conversationFollowNoticeText(resolution.result)
-                    );
-                    return resolution.result;
-                }
-                if (!viewer.isOpen()) {
-                    return 'closed';
-                }
-                const follow = viewer.follow(
-                    resolution.viewerTarget,
-                    resolution.snapshot
-                );
-                snapshotWarmup?.prepareAfterTargetSet(
-                    resolution.viewerTarget,
-                    viewer
-                );
-                const followed = await follow;
-                if (followed) {
-                    snapshotWarmup?.afterLoad(
-                        resolution.viewerTarget,
-                        resolution.prefetchedSnapshot === true,
-                        viewer
-                    );
-                    const currentTarget = viewer.getCurrentTarget();
-                    terminalAuthority.confirmedTarget =
-                        cloneConversationViewerTarget(
-                            currentTarget
-                                && hasSameConversationSession(
-                                    currentTarget,
-                                    resolution.viewerTarget
-                                )
-                                ? currentTarget
-                                : resolution.viewerTarget
-                        );
-                    followedSuccessfully = true;
-                }
-                return followed ? 'opened' : 'closed';
-            } finally {
-                if (!followedSuccessfully) {
-                    preview?.dispose();
-                }
-            }
+            return followOpenConversation(target, false, true);
         },
         async followAdjacentActiveConversation(
             direction: ConversationSessionSwitchDirection

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -2112,11 +2112,11 @@ async function initializeDashboard(
             conversationSessionRebindRestoreTask,
         ])
     ));
-    const focusAiSessionAndFollowConversation = (target: {
+    const focusAiSessionAndNavigateConversation = (target: {
         projectId: string;
         provider: AiSessionProviderId;
         sessionId: string;
-    }): Promise<void> => {
+    }, openWhenClosed: boolean): Promise<void> => {
         const intent = beginConversationNavigationIntent();
         return sessionNavigationCoordinator.enqueueLatest(async () => {
         const startedAt = Date.now();
@@ -2140,14 +2140,20 @@ async function initializeDashboard(
             if (focused && intent === conversationNavigationIntent) {
                 const conversationStartedAt = Date.now();
                 try {
-                    await conversationCapability.followActiveConversation(target);
+                    if (openWhenClosed) {
+                        await conversationCapability.openLatestActiveConversation(target);
+                    } else {
+                        await conversationCapability.followActiveConversation(target);
+                    }
                 } catch (error) {
                     conversationMs = Date.now() - conversationStartedAt;
                     outcome = 'conversation-error';
                     throw error;
                 }
                 conversationMs = Date.now() - conversationStartedAt;
-                outcome = 'conversation-followed';
+                outcome = openWhenClosed
+                    ? 'conversation-opened'
+                    : 'conversation-followed';
             } else if (focused) {
                 outcome = 'superseded';
             } else {
@@ -2167,19 +2173,39 @@ async function initializeDashboard(
         }
         });
     };
+    const focusAiSessionAndFollowConversation = (target: {
+        projectId: string;
+        provider: AiSessionProviderId;
+        sessionId: string;
+    }): Promise<void> => focusAiSessionAndNavigateConversation(target, false);
+    const focusAiSessionAndOpenConversation = (target: {
+        projectId: string;
+        provider: AiSessionProviderId;
+        sessionId: string;
+    }): Promise<void> => focusAiSessionAndNavigateConversation(target, true);
     const conversationHandlers = {
         'open-active-ai-session-conversation': async (e: Record<string, unknown>) => {
-            if (e.version !== 1
+            const focusTerminal = e.version === 2 && e.focusTerminal === true;
+            if ((e.version !== 1 && !focusTerminal)
                 || (e.provider !== 'codex' && e.provider !== 'kimi' && e.provider !== 'claude')
                 || typeof e.projectId !== 'string' || !e.projectId.trim()
                 || typeof e.sessionId !== 'string' || !e.sessionId.trim()) {
                 return;
             }
-            await openAiSessionConversationWithFeedback({
+            const target: {
+                projectId: string;
+                provider: AiSessionProviderId;
+                sessionId: string;
+            } = {
                 projectId: e.projectId,
                 provider: e.provider,
                 sessionId: e.sessionId,
-            });
+            };
+            if (focusTerminal) {
+                await focusAiSessionAndOpenConversation(target);
+                return;
+            }
+            await openAiSessionConversationWithFeedback(target);
         },
     };
     const projectHandlers = createProjectMessageHandlers({

--- a/src/webview/webviewProjectScripts.js
+++ b/src/webview/webviewProjectScripts.js
@@ -52,28 +52,20 @@ function getAiSessionCardActivation(target, projectId) {
             };
         }
         // A single click on an active-but-unfocused card both brings its
-        // terminal to the front and opens the conversation: the previous
-        // two-step (focus first, open on the next click) left users who
-        // closed the panel wondering why nothing opened. The focus message
-        // comes first so the terminal is visible before the panel reveals.
+        // terminal to the front and opens the conversation. Keep this as one
+        // correlated host transaction: two independent messages could race
+        // and the trailing open needlessly replace the Conversation document.
         return {
             handled: true,
             sessionRow: activationSessionRow,
-            message: [
-                {
-                    type: 'focus-ai-session-terminal',
-                    projectId: projectId,
-                    provider: provider,
-                    sessionId: sessionId,
-                },
-                {
-                    type: 'open-active-ai-session-conversation',
-                    version: 1,
-                    projectId: projectId,
-                    provider: provider,
-                    sessionId: sessionId,
-                },
-            ],
+            message: {
+                type: 'open-active-ai-session-conversation',
+                version: 2,
+                projectId: projectId,
+                provider: provider,
+                sessionId: sessionId,
+                focusTerminal: true,
+            },
         };
     }
     return {

--- a/tests/browser/activeSessionCardInteraction.test.js
+++ b/tests/browser/activeSessionCardInteraction.test.js
@@ -2816,18 +2816,14 @@ test('ACTIVE-SESSION-CONVERSATION-OPEN-001 a single click focuses and opens an a
     ]);
 
     await row(page, 'kimi', 'session-b').locator('.ai-session-primary-action').click();
-    assert.deepEqual((await postedMessages(page)).slice(-2), [{
-        type: 'focus-ai-session-terminal',
-        projectId: 'project-a',
-        provider: 'kimi',
-        sessionId: 'session-b',
-    }, {
+    assert.deepEqual((await postedMessages(page)).at(-1), {
         type: 'open-active-ai-session-conversation',
-        version: 1,
+        version: 2,
         projectId: 'project-a',
         provider: 'kimi',
         sessionId: 'session-b',
-    }], 'a single click focuses the terminal and opens the conversation');
+        focusTerminal: true,
+    }, 'a single click sends one atomic terminal-and-Conversation navigation request');
 
     await row(page, 'codex', 'session-a').locator('.ai-session-primary-action').click();
     assert.deepEqual((await postedMessages(page)).at(-1), {

--- a/tests/integration/dashboard/conversationOpenLatest.test.js
+++ b/tests/integration/dashboard/conversationOpenLatest.test.js
@@ -379,6 +379,68 @@ test('CONVERSATION-OPEN-LATEST-001 opens the latest interaction of the resolved 
     capability.dispose();
 });
 
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 retains an already open Conversation for the same session', async () => {
+    const currentTarget = {
+        projectId: 'project-a',
+        provider: 'codex',
+        workspaceName: '',
+        sessionId: 'session-a',
+        interactionId: 'input-b',
+        expectedRevision: 'r1',
+        displayName: 'Focused session',
+        duplicateDisplayName: false,
+    };
+    const harness = createHarness({
+        viewerOpen: true,
+        initialViewerTarget: currentTarget,
+        readOutline: () => {
+            throw new Error('the retained Conversation must not resolve another outline');
+        },
+    });
+
+    assert.equal(await harness.capability.openLatestConversation({
+        projectId: 'project-a', provider: 'codex', sessionId: 'session-a',
+    }), 'opened');
+    assert.equal(harness.outlineReads, 0);
+    assert.deepEqual(harness.viewerTargets, []);
+    assert.deepEqual(harness.followedViewerTargets, []);
+    assert.equal(harness.viewerFocuses, 1,
+        'an explicit open still reveals the retained Conversation editor');
+    harness.capability.dispose();
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 follows an open Conversation instead of replacing its document', async () => {
+    const harness = createHarness({
+        viewerOpen: true,
+        initialViewerTarget: {
+            projectId: 'project-a',
+            provider: 'codex',
+            workspaceName: '',
+            sessionId: 'session-a',
+            interactionId: 'input-a',
+            expectedRevision: 'r1',
+            displayName: 'Focused session',
+            duplicateDisplayName: false,
+        },
+        resolveTarget: (_projectId, provider, sessionId) => makeSession({
+            key: `${provider}:${sessionId}`,
+            provider,
+            sessionId,
+            name: sessionId,
+        }),
+    });
+
+    assert.equal(await harness.capability.openLatestConversation({
+        projectId: 'project-a', provider: 'kimi', sessionId: 'session-b',
+    }), 'opened');
+    assert.equal(harness.viewerTargets.length, 0,
+        'an open viewer must not receive a document-replacing open');
+    assert.equal(harness.followedViewerTargets.length, 1);
+    assert.equal(harness.followedViewerTargets[0].sessionId, 'session-b');
+    assert.equal(harness.viewerFocuses, 1);
+    harness.capability.dispose();
+});
+
 test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 forwards the aggregate Viewer timing sink and monotonic clock', () => {
     const onViewerTiming = () => undefined;
     const harness = createHarness({
@@ -1162,13 +1224,17 @@ test('CONVERSATION-FOLLOW-ACTIVE-SESSION-001 delegates Active Session card focus
         'utf8'
     );
     const navigationPath = dashboardSource.match(
-        /const focusAiSessionAndFollowConversation[\s\S]*?\n\s*};\n\s*const conversationHandlers/
+        /const focusAiSessionAndNavigateConversation[\s\S]*?\n\s*};\n\s*const focusAiSessionAndFollowConversation/
     );
     assert.ok(navigationPath, 'shared Active Session navigation path must remain inspectable');
     assert.match(navigationPath[0], /focusActive\(/);
     assert.match(
         navigationPath[0],
-        /if \(focused(?: && [^)]+)?\) \{[\s\S]*followActiveConversation\(/
+        /if \(openWhenClosed\) \{[\s\S]*openLatestActiveConversation\([\s\S]*?followActiveConversation\(/
+    );
+    assert.match(
+        dashboardSource,
+        /const focusTerminal = e\.version === 2 && e\.focusTerminal === true;[\s\S]*focusAiSessionAndOpenConversation\(target\)/
     );
 });
 

--- a/tests/integration/dashboard/conversationRouting.test.js
+++ b/tests/integration/dashboard/conversationRouting.test.js
@@ -327,6 +327,7 @@ function createDashboardConversationHarness(options = {}) {
                 createViewer: () => {
                     let disposed = false;
                     return {
+                        isOpen: () => false,
                         open: async target => {
                             viewerTargets.push(target);
                         },

--- a/tests/integration/dashboard/sessionCardInteraction.test.js
+++ b/tests/integration/dashboard/sessionCardInteraction.test.js
@@ -75,18 +75,14 @@ test('WEBVIEW-AI-SESSION-CARD-ACTIVATION-001 maps card bodies and the primary ac
 
     assert.deepEqual(
         normalizeRealmValue(getAiSessionCardActivation(createTarget(active), 'project-a').message),
-        [{
-            type: 'focus-ai-session-terminal',
-            projectId: 'project-a',
-            provider: 'codex',
-            sessionId: 'active-session',
-        }, {
+        {
             type: 'open-active-ai-session-conversation',
-            version: 1,
+            version: 2,
             projectId: 'project-a',
             provider: 'codex',
             sessionId: 'active-session',
-        }]
+            focusTerminal: true,
+        }
     );
     assert.deepEqual(
         normalizeRealmValue(getAiSessionCardActivation(createTarget(inactive), 'project-a').message),
@@ -109,18 +105,14 @@ test('WEBVIEW-AI-SESSION-CARD-ACTIVATION-001 maps card bodies and the primary ac
         normalizeRealmValue(
             getAiSessionCardActivation(createTarget(active, { primary: true }), 'project-a').message
         ),
-        [{
-            type: 'focus-ai-session-terminal',
-            projectId: 'project-a',
-            provider: 'codex',
-            sessionId: 'active-session',
-        }, {
+        {
             type: 'open-active-ai-session-conversation',
-            version: 1,
+            version: 2,
             projectId: 'project-a',
             provider: 'codex',
             sessionId: 'active-session',
-        }]
+            focusTerminal: true,
+        }
     );
 });
 
@@ -165,18 +157,14 @@ test('ACTIVE-SESSION-CONVERSATION-OPEN-001 opens the conversation for every acti
         createTarget(nonFocused),
         'project-a'
     );
-    assert.deepEqual(normalizeRealmValue(nonFocusedActivation.message), [{
-        type: 'focus-ai-session-terminal',
-        projectId: 'project-a',
-        provider: 'kimi',
-        sessionId: 'non-focused-session',
-    }, {
+    assert.deepEqual(normalizeRealmValue(nonFocusedActivation.message), {
         type: 'open-active-ai-session-conversation',
-        version: 1,
+        version: 2,
         projectId: 'project-a',
         provider: 'kimi',
         sessionId: 'non-focused-session',
-    }]);
+        focusTerminal: true,
+    });
 
     const pendingActivation = getAiSessionCardActivation(
         createTarget(pending, { primary: true }),


### PR DESCRIPTION
## Summary

- reuse the open Conversation document for every card and command navigation path
- serialize terminal focus and Conversation opening from an unfocused session card into one request
- preserve legacy card requests while avoiding duplicate outline reads and document replacement
- keep the navigation architecture guard, generated Webview asset, and legacy integration fixtures aligned with the unified transaction

## Validation

- `npm run worktree:run -- npm run test-compile`
- `npm run worktree:run -- node --test tests/integration/dashboard/conversationOpenLatest.test.js tests/contract/dashboard/messageHandlers.test.js`
- `npm run worktree:run -- node --test tests/browser/activeSessionCardInteraction.test.js`
- `npm run worktree:run -- node scripts/run-dashboard-webview-checks.js`
- `npm run worktree:run -- node --test tests/integration/dashboard/webviewState.test.js tests/unit/tooling/architectureGuards.test.js`
- `npm run worktree:run -- node --test --test-concurrency=2 tests/integration/dashboard/conversationRouting.test.js tests/integration/dashboard/sessionCardInteraction.test.js`
- `npm run worktree:run -- npm run test:coverage:run`
- `npm run worktree:run -- npm run lint`
- `npm run worktree:run -- npm run test:behavior-contracts`
- `npm run worktree:run -- env SKIP_NPM_CI=1 npm run install-local`

## Skill harvest

No skill change: the worktree dependency skill already requires bootstrap and guarded verification; the observed stale build was resolved by following its documented producer-before-consumer sequence.

## Owner approvals

```text
approve 8c27bcccc3f136067b823c26bb3c2976654012dd
```