### PR TITLE
fix: recover stalled conversation history loading

### DIFF
--- a/media/conversationViewerScripts.js
+++ b/media/conversationViewerScripts.js
@@ -430,10 +430,17 @@
     var baseTranscriptStatus = '';
     function updateTranscriptStatus() {
         var messagesToShow = [];
+        var deferredMessages = messages.querySelector(
+            '.conversation-deferred-messages'
+        );
         [
             baseTranscriptStatus,
-            messages.querySelector('.conversation-deferred-messages')
-                ? 'Loading earlier messages.'
+            deferredMessages
+                ? deferredMessages.getAttribute(
+                    'data-history-backfill-stalled'
+                ) === 'true'
+                    ? deferredMessages.textContent.trim()
+                    : 'Loading earlier messages.'
                 : '',
             state.earlierPageStatus,
         ].forEach(function (text) {
@@ -442,6 +449,72 @@
             }
         });
         status.textContent = messagesToShow.join(' ');
+    }
+
+    // The Host has its own correlated delivery watchdog, but a Webview can
+    // still be left with a visible spinner when that lifecycle is interrupted
+    // (for example during a renderer restart or a delayed extension-host
+    // message). Keep the current transcript readable and turn the spinner
+    // into an honest, recoverable status instead of claiming perpetual
+    // progress. A later chunk or page naturally re-arms or clears it.
+    var deferredMessagesWatchdog;
+    var deferredMessagesWatchdogToken = 0;
+    var historyLoadWatchdog;
+    var historyLoadWatchdogToken = 0;
+    var HISTORY_LOADING_STALL_TIMEOUT_MS = 8_000;
+
+    function clearDeferredMessagesWatchdog() {
+        deferredMessagesWatchdogToken += 1;
+        if (deferredMessagesWatchdog !== undefined) {
+            window.clearTimeout(deferredMessagesWatchdog);
+            deferredMessagesWatchdog = undefined;
+        }
+    }
+
+    function scheduleDeferredMessagesWatchdog() {
+        clearDeferredMessagesWatchdog();
+        var placeholder = messages.querySelector(
+            '.conversation-deferred-messages'
+        );
+        if (!placeholder) {
+            return;
+        }
+        var token = ++deferredMessagesWatchdogToken;
+        deferredMessagesWatchdog = window.setTimeout(function () {
+            if (token !== deferredMessagesWatchdogToken
+                || !placeholder.isConnected
+                || !messages.contains(placeholder)) {
+                return;
+            }
+            placeholder.textContent =
+                'Earlier messages are taking longer than expected.';
+            placeholder.setAttribute('data-history-backfill-stalled', 'true');
+            updateTranscriptStatus();
+        }, HISTORY_LOADING_STALL_TIMEOUT_MS);
+    }
+
+    function clearHistoryLoadWatchdog() {
+        historyLoadWatchdogToken += 1;
+        if (historyLoadWatchdog !== undefined) {
+            window.clearTimeout(historyLoadWatchdog);
+            historyLoadWatchdog = undefined;
+        }
+    }
+
+    function scheduleHistoryLoadWatchdog(requestId) {
+        clearHistoryLoadWatchdog();
+        var token = ++historyLoadWatchdogToken;
+        historyLoadWatchdog = window.setTimeout(function () {
+            if (token !== historyLoadWatchdogToken
+                || state.earlierPageRequestId !== requestId) {
+                return;
+            }
+            state.earlierPageRequested = false;
+            state.earlierPageRequestId = undefined;
+            state.earlierPageStatus =
+                'Loading earlier messages timed out. Try again.';
+            updateTranscriptStatus();
+        }, HISTORY_LOADING_STALL_TIMEOUT_MS);
     }
     var readingAnchorController =
         window.__agentPivotConversation.readingAnchor.create({
@@ -2004,6 +2077,7 @@
         state.earlierPageRequested = false;
         state.earlierPageRequestId = undefined;
         state.earlierPageStatus = '';
+        clearHistoryLoadWatchdog();
         // A content-first Host load delivers restored side state later in a
         // same-generation, HTML-free refresh. These snapshots are still
         // authoritative and must update without resetting the transcript.
@@ -2080,6 +2154,7 @@
         }
         baseTranscriptStatus = statusMessages.join(' ');
         updateTranscriptStatus();
+        scheduleDeferredMessagesWatchdog();
 
         var selectedMessages = Array.prototype.filter.call(
             messages.querySelectorAll('[data-interaction-id]'),
@@ -2270,6 +2345,11 @@
         placeholder.after(template.content);
         if (message.complete) {
             placeholder.remove();
+            clearDeferredMessagesWatchdog();
+        } else {
+            placeholder.textContent = 'Loading earlier messages…';
+            placeholder.removeAttribute('data-history-backfill-stalled');
+            scheduleDeferredMessagesWatchdog();
         }
         var addedIds = [];
         inserted.forEach(function (candidate) {
@@ -2300,9 +2380,7 @@
             scroll.scrollTop = previousScrollTop + heightDelta;
         }
         reconcileController.trackEnd();
-        if (message.complete) {
-            updateTranscriptStatus();
-        }
+        updateTranscriptStatus();
         // Acknowledge before the deferred decoration pass: the Host paces
         // the next slice on this receipt, and the decoration is idempotent.
         post({
@@ -2495,6 +2573,7 @@
         }
         state.earlierPageRequested = false;
         state.earlierPageRequestId = undefined;
+        clearHistoryLoadWatchdog();
         state.earlierPageStatus = message.outcome === 'stalled'
             ? 'Earlier messages could not be loaded.'
             : message.outcome === 'timed-out'
@@ -2577,6 +2656,7 @@
         state.earlierPageRequested = true;
         state.earlierPageRequestId = ++state.nextEarlierPageRequestId;
         state.earlierPageStatus = 'Loading earlier messages.';
+        scheduleHistoryLoadWatchdog(state.earlierPageRequestId);
         updateTranscriptStatus();
         post({
             type: 'conversation-viewer-load-earlier',

--- a/src/webview/conversationViewerScripts.js
+++ b/src/webview/conversationViewerScripts.js
@@ -430,10 +430,17 @@
     var baseTranscriptStatus = '';
     function updateTranscriptStatus() {
         var messagesToShow = [];
+        var deferredMessages = messages.querySelector(
+            '.conversation-deferred-messages'
+        );
         [
             baseTranscriptStatus,
-            messages.querySelector('.conversation-deferred-messages')
-                ? 'Loading earlier messages.'
+            deferredMessages
+                ? deferredMessages.getAttribute(
+                    'data-history-backfill-stalled'
+                ) === 'true'
+                    ? deferredMessages.textContent.trim()
+                    : 'Loading earlier messages.'
                 : '',
             state.earlierPageStatus,
         ].forEach(function (text) {
@@ -442,6 +449,72 @@
             }
         });
         status.textContent = messagesToShow.join(' ');
+    }
+
+    // The Host has its own correlated delivery watchdog, but a Webview can
+    // still be left with a visible spinner when that lifecycle is interrupted
+    // (for example during a renderer restart or a delayed extension-host
+    // message). Keep the current transcript readable and turn the spinner
+    // into an honest, recoverable status instead of claiming perpetual
+    // progress. A later chunk or page naturally re-arms or clears it.
+    var deferredMessagesWatchdog;
+    var deferredMessagesWatchdogToken = 0;
+    var historyLoadWatchdog;
+    var historyLoadWatchdogToken = 0;
+    var HISTORY_LOADING_STALL_TIMEOUT_MS = 8_000;
+
+    function clearDeferredMessagesWatchdog() {
+        deferredMessagesWatchdogToken += 1;
+        if (deferredMessagesWatchdog !== undefined) {
+            window.clearTimeout(deferredMessagesWatchdog);
+            deferredMessagesWatchdog = undefined;
+        }
+    }
+
+    function scheduleDeferredMessagesWatchdog() {
+        clearDeferredMessagesWatchdog();
+        var placeholder = messages.querySelector(
+            '.conversation-deferred-messages'
+        );
+        if (!placeholder) {
+            return;
+        }
+        var token = ++deferredMessagesWatchdogToken;
+        deferredMessagesWatchdog = window.setTimeout(function () {
+            if (token !== deferredMessagesWatchdogToken
+                || !placeholder.isConnected
+                || !messages.contains(placeholder)) {
+                return;
+            }
+            placeholder.textContent =
+                'Earlier messages are taking longer than expected.';
+            placeholder.setAttribute('data-history-backfill-stalled', 'true');
+            updateTranscriptStatus();
+        }, HISTORY_LOADING_STALL_TIMEOUT_MS);
+    }
+
+    function clearHistoryLoadWatchdog() {
+        historyLoadWatchdogToken += 1;
+        if (historyLoadWatchdog !== undefined) {
+            window.clearTimeout(historyLoadWatchdog);
+            historyLoadWatchdog = undefined;
+        }
+    }
+
+    function scheduleHistoryLoadWatchdog(requestId) {
+        clearHistoryLoadWatchdog();
+        var token = ++historyLoadWatchdogToken;
+        historyLoadWatchdog = window.setTimeout(function () {
+            if (token !== historyLoadWatchdogToken
+                || state.earlierPageRequestId !== requestId) {
+                return;
+            }
+            state.earlierPageRequested = false;
+            state.earlierPageRequestId = undefined;
+            state.earlierPageStatus =
+                'Loading earlier messages timed out. Try again.';
+            updateTranscriptStatus();
+        }, HISTORY_LOADING_STALL_TIMEOUT_MS);
     }
     var readingAnchorController =
         window.__agentPivotConversation.readingAnchor.create({
@@ -2004,6 +2077,7 @@
         state.earlierPageRequested = false;
         state.earlierPageRequestId = undefined;
         state.earlierPageStatus = '';
+        clearHistoryLoadWatchdog();
         // A content-first Host load delivers restored side state later in a
         // same-generation, HTML-free refresh. These snapshots are still
         // authoritative and must update without resetting the transcript.
@@ -2080,6 +2154,7 @@
         }
         baseTranscriptStatus = statusMessages.join(' ');
         updateTranscriptStatus();
+        scheduleDeferredMessagesWatchdog();
 
         var selectedMessages = Array.prototype.filter.call(
             messages.querySelectorAll('[data-interaction-id]'),
@@ -2270,6 +2345,11 @@
         placeholder.after(template.content);
         if (message.complete) {
             placeholder.remove();
+            clearDeferredMessagesWatchdog();
+        } else {
+            placeholder.textContent = 'Loading earlier messages…';
+            placeholder.removeAttribute('data-history-backfill-stalled');
+            scheduleDeferredMessagesWatchdog();
         }
         var addedIds = [];
         inserted.forEach(function (candidate) {
@@ -2300,9 +2380,7 @@
             scroll.scrollTop = previousScrollTop + heightDelta;
         }
         reconcileController.trackEnd();
-        if (message.complete) {
-            updateTranscriptStatus();
-        }
+        updateTranscriptStatus();
         // Acknowledge before the deferred decoration pass: the Host paces
         // the next slice on this receipt, and the decoration is idempotent.
         post({
@@ -2495,6 +2573,7 @@
         }
         state.earlierPageRequested = false;
         state.earlierPageRequestId = undefined;
+        clearHistoryLoadWatchdog();
         state.earlierPageStatus = message.outcome === 'stalled'
             ? 'Earlier messages could not be loaded.'
             : message.outcome === 'timed-out'
@@ -2577,6 +2656,7 @@
         state.earlierPageRequested = true;
         state.earlierPageRequestId = ++state.nextEarlierPageRequestId;
         state.earlierPageStatus = 'Loading earlier messages.';
+        scheduleHistoryLoadWatchdog(state.earlierPageRequestId);
         updateTranscriptStatus();
         post({
             type: 'conversation-viewer-load-earlier',

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -18368,6 +18368,59 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-002 settles an unavailable earlier-
     ).length, 1, 'an unavailable boundary must not re-enter a loading loop');
 });
 
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-002 releases an unanswered earlier-page request for retry', async t => {
+    const page = await openViewerPage(t);
+    await sendPage(page, {
+        type: 'conversation-viewer-page',
+        version: 1,
+        requestId: 1,
+        subscriptionGeneration: 1,
+        updateKind: 'initial',
+        html: messageHtml('msg', 30, 0),
+        htmlSignature: 'sig-unanswered-earlier-page',
+        previousCursor: 'cursor-1',
+        earlierPageCursor: 'cursor-1',
+        outline: progressiveOutline(30),
+        selectedInteractionId: 'msg-29',
+        selectedInput: 29,
+        totalInputs: 30,
+        partial: false,
+        atLatest: true,
+        stale: false,
+        subagents: [],
+        activeSubagent: null,
+    });
+    await page.waitForFunction(() => window.__postedMessages.some(message =>
+        message.type === 'conversation-viewer-applied'
+            && message.htmlSignature === 'sig-unanswered-earlier-page'
+    ));
+    await page.evaluate(() => {
+        const scroll = document.querySelector('[data-conversation-scroll]');
+        scroll.scrollTop = 0;
+        scroll.dispatchEvent(new Event('scroll'));
+    });
+    await page.waitForFunction(() => window.__postedMessages.some(message =>
+        message.type === 'conversation-viewer-load-earlier'
+    ));
+
+    // This deliberately uses the real Webview timer. Replacing window's
+    // global timers changes unrelated presentation scheduling and cannot
+    // prove that a user-visible request is actually released.
+    await page.waitForFunction(() => document.querySelector(
+        '[data-conversation-status]'
+    ).textContent === 'Loading earlier messages timed out. Try again.', {
+        timeout: 10_000,
+    });
+    await page.evaluate(() => {
+        document.querySelector('[data-conversation-scroll]').dispatchEvent(
+            new Event('wheel')
+        );
+    });
+    assert.equal((await postedMessages(page)).filter(message =>
+        message.type === 'conversation-viewer-load-earlier'
+    ).length, 2, 'the timeout must release the request for a retry');
+});
+
 test('CONVERSATION-LARGE-SESSION-PERFORMANCE-002 requests earlier history when a short page starts at top', async t => {
     const page = await openViewerPage(t);
     await sendPage(page, {

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -18368,62 +18368,6 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-002 settles an unavailable earlier-
     ).length, 1, 'an unavailable boundary must not re-enter a loading loop');
 });
 
-test('CONVERSATION-LARGE-SESSION-PERFORMANCE-002 releases a lost earlier-page request for retry', async t => {
-    const page = await openViewerPage(t);
-    await page.evaluate(() => {
-        window.__historyLoadingTimers = [];
-        window.setTimeout = function (callback, delayMs) {
-            window.__historyLoadingTimers.push({ callback, delayMs });
-            return window.__historyLoadingTimers.length;
-        };
-        window.clearTimeout = function () {};
-    });
-    await sendPage(page, {
-        type: 'conversation-viewer-page',
-        version: 1,
-        requestId: 1,
-        subscriptionGeneration: 1,
-        updateKind: 'initial',
-        html: messageHtml('msg', 30, 0),
-        htmlSignature: 'sig-lost-earlier-page',
-        previousCursor: 'cursor-1',
-        earlierPageCursor: 'cursor-1',
-        outline: progressiveOutline(30),
-        selectedInteractionId: 'msg-29',
-        selectedInput: 29,
-        totalInputs: 30,
-        partial: false,
-        atLatest: true,
-        stale: false,
-        subagents: [],
-        activeSubagent: null,
-    });
-    await page.waitForFunction(() => window.__postedMessages.some(message =>
-        message.type === 'conversation-viewer-applied'
-            && message.htmlSignature === 'sig-lost-earlier-page'
-    ));
-    await page.evaluate(() => {
-        const scroll = document.querySelector('[data-conversation-scroll]');
-        scroll.scrollTop = 0;
-        scroll.dispatchEvent(new Event('scroll'));
-        const timer = window.__historyLoadingTimers.find(candidate =>
-            candidate.delayMs === 8_000
-        );
-        if (!timer) throw new Error('expected earlier-page watchdog');
-        timer.callback();
-    });
-    assert.equal(await page.locator('[data-conversation-status]').textContent(),
-    'Loading earlier messages timed out. Try again.');
-    await page.evaluate(() => {
-        document.querySelector('[data-conversation-scroll]').dispatchEvent(
-            new Event('wheel')
-        );
-    });
-    assert.equal((await postedMessages(page)).filter(message =>
-        message.type === 'conversation-viewer-load-earlier'
-    ).length, 2, 'the watchdog must release the request for a retry');
-});
-
 test('CONVERSATION-LARGE-SESSION-PERFORMANCE-002 requests earlier history when a short page starts at top', async t => {
     const page = await openViewerPage(t);
     await sendPage(page, {

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -4685,6 +4685,141 @@ test('CONVERSATION-OUTLINE-NAVIGATION-001 keeps every side-panel view usable acr
     }
 
     const previousViewerScript = viewerScript
+        // The current script carries independent Webview-side history
+        // watchdogs. The adjacent generation predates them; remove every
+        // coupled state transition before asserting the frozen fixture.
+        .replace(
+            "        var messagesToShow = [];\n"
+                + "        var deferredMessages = messages.querySelector(\n"
+                + "            '.conversation-deferred-messages'\n"
+                + "        );\n"
+                + '        [\n'
+                + '            baseTranscriptStatus,\n'
+                + '            deferredMessages\n'
+                + "                ? deferredMessages.getAttribute(\n"
+                + "                    'data-history-backfill-stalled'\n"
+                + "                ) === 'true'\n"
+                + '                    ? deferredMessages.textContent.trim()\n'
+                + "                    : 'Loading earlier messages.'\n"
+                + "                : '',\n"
+                + '            state.earlierPageStatus,\n',
+            "        var messagesToShow = [];\n"
+                + '        [\n'
+                + '            baseTranscriptStatus,\n'
+                + "            messages.querySelector('.conversation-deferred-messages')\n"
+                + "                ? 'Loading earlier messages.'\n"
+                + "                : '',\n"
+                + '            state.earlierPageStatus,\n'
+        )
+        .replace(
+            "\n    // The Host has its own correlated delivery watchdog, but a Webview can\n"
+                + "    // still be left with a visible spinner when that lifecycle is interrupted\n"
+                + "    // (for example during a renderer restart or a delayed extension-host\n"
+                + "    // message). Keep the current transcript readable and turn the spinner\n"
+                + "    // into an honest, recoverable status instead of claiming perpetual\n"
+                + "    // progress. A later chunk or page naturally re-arms or clears it.\n"
+                + "    var deferredMessagesWatchdog;\n"
+                + "    var deferredMessagesWatchdogToken = 0;\n"
+                + "    var historyLoadWatchdog;\n"
+                + "    var historyLoadWatchdogToken = 0;\n"
+                + "    var HISTORY_LOADING_STALL_TIMEOUT_MS = 8_000;\n\n"
+                + "    function clearDeferredMessagesWatchdog() {\n"
+                + "        deferredMessagesWatchdogToken += 1;\n"
+                + "        if (deferredMessagesWatchdog !== undefined) {\n"
+                + "            window.clearTimeout(deferredMessagesWatchdog);\n"
+                + "            deferredMessagesWatchdog = undefined;\n"
+                + "        }\n"
+                + "    }\n\n"
+                + "    function scheduleDeferredMessagesWatchdog() {\n"
+                + "        clearDeferredMessagesWatchdog();\n"
+                + "        var placeholder = messages.querySelector(\n"
+                + "            '.conversation-deferred-messages'\n"
+                + "        );\n"
+                + "        if (!placeholder) {\n"
+                + "            return;\n"
+                + "        }\n"
+                + "        var token = ++deferredMessagesWatchdogToken;\n"
+                + "        deferredMessagesWatchdog = window.setTimeout(function () {\n"
+                + "            if (token !== deferredMessagesWatchdogToken\n"
+                + "                || !placeholder.isConnected\n"
+                + "                || !messages.contains(placeholder)) {\n"
+                + "                return;\n"
+                + "            }\n"
+                + "            placeholder.textContent =\n"
+                + "                'Earlier messages are taking longer than expected.';\n"
+                + "            placeholder.setAttribute('data-history-backfill-stalled', 'true');\n"
+                + "            updateTranscriptStatus();\n"
+                + "        }, HISTORY_LOADING_STALL_TIMEOUT_MS);\n"
+                + "    }\n\n"
+                + "    function clearHistoryLoadWatchdog() {\n"
+                + "        historyLoadWatchdogToken += 1;\n"
+                + "        if (historyLoadWatchdog !== undefined) {\n"
+                + "            window.clearTimeout(historyLoadWatchdog);\n"
+                + "            historyLoadWatchdog = undefined;\n"
+                + "        }\n"
+                + "    }\n\n"
+                + "    function scheduleHistoryLoadWatchdog(requestId) {\n"
+                + "        clearHistoryLoadWatchdog();\n"
+                + "        var token = ++historyLoadWatchdogToken;\n"
+                + "        historyLoadWatchdog = window.setTimeout(function () {\n"
+                + "            if (token !== historyLoadWatchdogToken\n"
+                + "                || state.earlierPageRequestId !== requestId) {\n"
+                + "                return;\n"
+                + "            }\n"
+                + "            state.earlierPageRequested = false;\n"
+                + "            state.earlierPageRequestId = undefined;\n"
+                + "            state.earlierPageStatus =\n"
+                + "                'Loading earlier messages timed out. Try again.';\n"
+                + "            updateTranscriptStatus();\n"
+                + "        }, HISTORY_LOADING_STALL_TIMEOUT_MS);\n"
+                + "    }\n",
+            ''
+        )
+        .replace(
+            "        state.earlierPageStatus = '';\n"
+                + '        clearHistoryLoadWatchdog();\n',
+            "        state.earlierPageStatus = '';\n"
+        )
+        .replace(
+            '        baseTranscriptStatus = statusMessages.join(\' \');\n'
+                + '        updateTranscriptStatus();\n'
+                + '        scheduleDeferredMessagesWatchdog();\n',
+            '        baseTranscriptStatus = statusMessages.join(\' \');\n'
+                + '        updateTranscriptStatus();\n'
+        )
+        .replace(
+            '        if (message.complete) {\n'
+                + '            placeholder.remove();\n'
+                + '            clearDeferredMessagesWatchdog();\n'
+                + '        } else {\n'
+                + '            placeholder.textContent = \'Loading earlier messages…\';\n'
+                + "            placeholder.removeAttribute('data-history-backfill-stalled');\n"
+                + '            scheduleDeferredMessagesWatchdog();\n'
+                + '        }\n',
+            '        if (message.complete) {\n'
+                + '            placeholder.remove();\n'
+                + '        }\n'
+        )
+        .replace(
+            '        reconcileController.trackEnd();\n'
+                + '        updateTranscriptStatus();\n',
+            '        reconcileController.trackEnd();\n'
+                + '        if (message.complete) {\n'
+                + '            updateTranscriptStatus();\n'
+                + '        }\n'
+        )
+        .replace(
+            '        state.earlierPageRequestId = undefined;\n'
+                + '        clearHistoryLoadWatchdog();\n'
+                + "        state.earlierPageStatus = message.outcome === 'stalled'\n",
+            '        state.earlierPageRequestId = undefined;\n'
+                + "        state.earlierPageStatus = message.outcome === 'stalled'\n"
+        )
+        .replace(
+            "        state.earlierPageStatus = 'Loading earlier messages.';\n"
+                + '        scheduleHistoryLoadWatchdog(state.earlierPageRequestId);\n',
+            "        state.earlierPageStatus = 'Loading earlier messages.';\n"
+        )
         // Normalize the speculative preflight/cancel protocol back to the
         // previous cache-preview script. Older Webviews safely ignore these
         // outbound Host notices, but their historical fixture must remain
@@ -17871,6 +18006,58 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-002 applies history chunks in place
         '[data-conversation-messages] [data-message-id]').count(), 12);
 });
 
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-002 clears a stalled progressive loading notice', async t => {
+    const page = await openViewerPage(t);
+    await page.evaluate(() => {
+        window.__historyLoadingTimers = [];
+        window.setTimeout = function (callback, delayMs) {
+            window.__historyLoadingTimers.push({ callback, delayMs });
+            return window.__historyLoadingTimers.length;
+        };
+        window.clearTimeout = function () {};
+    });
+    await sendPage(page, {
+        type: 'conversation-viewer-page',
+        version: 1,
+        requestId: 1,
+        subscriptionGeneration: 1,
+        updateKind: 'initial',
+        html: '<section class="conversation-deferred-messages">'
+            + 'Loading earlier messages…</section>'
+            + messageHtml('msg', 4, 8),
+        htmlSignature: 'sig-partial-stalled',
+        outline: progressiveOutline(12),
+        selectedInteractionId: 'msg-11',
+        selectedInput: 11,
+        totalInputs: 12,
+        partial: false,
+        atLatest: true,
+        stale: false,
+        subagents: [],
+        activeSubagent: null,
+    });
+    await page.waitForFunction(() => window.__postedMessages.some(message =>
+        message.type === 'conversation-viewer-applied'
+            && message.htmlSignature === 'sig-partial-stalled'
+    ));
+    await page.evaluate(() => {
+        const timer = window.__historyLoadingTimers.find(candidate =>
+            candidate.delayMs === 8_000
+        );
+        if (!timer) throw new Error('expected history loading watchdog');
+        timer.callback();
+    });
+    assert.equal(await page.locator(
+        '.conversation-deferred-messages').textContent(),
+    'Earlier messages are taking longer than expected.');
+    assert.equal(await page.locator(
+        '[data-conversation-status]').textContent(),
+    'Earlier messages are taking longer than expected.');
+    assert.equal(await page.locator(
+        '.conversation-deferred-messages'
+    ).getAttribute('data-history-backfill-stalled'), 'true');
+});
+
 test('CONVERSATION-LARGE-SESSION-PERFORMANCE-002 ignores a history chunk after a full page superseded the partial one', async t => {
     const page = await openViewerPage(t);
     await sendPage(page, {
@@ -18179,6 +18366,62 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-002 settles an unavailable earlier-
     assert.equal((await postedMessages(page)).filter(message =>
         message.type === 'conversation-viewer-load-earlier'
     ).length, 1, 'an unavailable boundary must not re-enter a loading loop');
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-002 releases a lost earlier-page request for retry', async t => {
+    const page = await openViewerPage(t);
+    await page.evaluate(() => {
+        window.__historyLoadingTimers = [];
+        window.setTimeout = function (callback, delayMs) {
+            window.__historyLoadingTimers.push({ callback, delayMs });
+            return window.__historyLoadingTimers.length;
+        };
+        window.clearTimeout = function () {};
+    });
+    await sendPage(page, {
+        type: 'conversation-viewer-page',
+        version: 1,
+        requestId: 1,
+        subscriptionGeneration: 1,
+        updateKind: 'initial',
+        html: messageHtml('msg', 30, 0),
+        htmlSignature: 'sig-lost-earlier-page',
+        previousCursor: 'cursor-1',
+        earlierPageCursor: 'cursor-1',
+        outline: progressiveOutline(30),
+        selectedInteractionId: 'msg-29',
+        selectedInput: 29,
+        totalInputs: 30,
+        partial: false,
+        atLatest: true,
+        stale: false,
+        subagents: [],
+        activeSubagent: null,
+    });
+    await page.waitForFunction(() => window.__postedMessages.some(message =>
+        message.type === 'conversation-viewer-applied'
+            && message.htmlSignature === 'sig-lost-earlier-page'
+    ));
+    await page.evaluate(() => {
+        const scroll = document.querySelector('[data-conversation-scroll]');
+        scroll.scrollTop = 0;
+        scroll.dispatchEvent(new Event('scroll'));
+        const timer = window.__historyLoadingTimers.find(candidate =>
+            candidate.delayMs === 8_000
+        );
+        if (!timer) throw new Error('expected earlier-page watchdog');
+        timer.callback();
+    });
+    assert.equal(await page.locator('[data-conversation-status]').textContent(),
+    'Loading earlier messages timed out. Try again.');
+    await page.evaluate(() => {
+        document.querySelector('[data-conversation-scroll]').dispatchEvent(
+            new Event('wheel')
+        );
+    });
+    assert.equal((await postedMessages(page)).filter(message =>
+        message.type === 'conversation-viewer-load-earlier'
+    ).length, 2, 'the watchdog must release the request for a retry');
 });
 
 test('CONVERSATION-LARGE-SESSION-PERFORMANCE-002 requests earlier history when a short page starts at top', async t => {


### PR DESCRIPTION
## Summary

- add Webview watchdogs for progressive and on-demand earlier-history loading
- replace an unbounded spinner with an actionable timeout state and preserve retries
- cover stalled progressive history, unanswered requests, and prior script-generation compatibility

## Verification

- npm run test-compile
- node --test --test-concurrency=1 tests/integration/dashboard/conversationViewer.test.js
- npm run test:browser:run
- npm run test:behavior-contracts
- node scripts/run-dashboard-webview-checks.js
- npm run lint

## Skill harvest

No skill change: the historical Webview-fixture update followed the existing review-fix-commit-loop guidance; it did not reveal a reusable workflow gap.

## Owner approvals

```
approve b9d34441f17a0efe0fa3957bb4ddcbaab27a4830
```