### PR TITLE
Track safe conversation history restart points

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -19,8 +19,23 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  pr-metadata:
+    name: pr-metadata
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Check PR body conventions
+        if: github.event_name == 'pull_request'
+        run: node scripts/check-pr-body.js
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+
   quality-linux:
     name: quality-linux
+    needs: pr-metadata
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -50,13 +65,6 @@ jobs:
         run: npm run test:ci:linux
         env:
           COVERAGE_DIFF_BASE: ${{ github.event.pull_request.base.sha }}
-      - name: Check PR body conventions
-        if: github.event_name == 'pull_request'
-        run: node scripts/check-pr-body.js
-        env:
-          PR_BODY: ${{ github.event.pull_request.body }}
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-
   platform-windows:
     name: platform-windows
     runs-on: windows-latest

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -47,7 +47,6 @@ jobs:
           node --test tests/unit/tooling/conversationReleaseJourneys.test.js
           node scripts/check-conversation-release-journeys.js
           node scripts/run-performance-architecture-baseline-checks.js
-          node scripts/run-architecture-guards.js
           node scripts/run-release-notes-checks.js
 
   quality-linux:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -33,9 +33,26 @@ jobs:
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
 
+  static-preflight:
+    name: static-preflight
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Run static repository preflight
+        run: |
+          node scripts/check-brand-identity.js
+          node scripts/check-behavior-contracts.js
+          node --test tests/unit/tooling/conversationReleaseJourneys.test.js
+          node scripts/check-conversation-release-journeys.js
+          node scripts/run-performance-architecture-baseline-checks.js
+          node scripts/run-architecture-guards.js
+          node scripts/run-release-notes-checks.js
+
   quality-linux:
     name: quality-linux
-    needs: pr-metadata
+    needs: [pr-metadata, static-preflight]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/scripts/lib/ciContracts.js
+++ b/scripts/lib/ciContracts.js
@@ -125,6 +125,24 @@ function validateChromiumInstall(job) {
     'quality-linux must install only the Chromium headless shell with three bounded retries');
 }
 
+function validatePrMetadataPreflight(jobs) {
+    const job = jobs['pr-metadata'];
+    assert.ok(isMapping(job), 'GitHub verification workflow must define pr-metadata');
+    assert.equal(job.name, 'pr-metadata', 'pr-metadata must expose a stable check name');
+    assert.equal(job['runs-on'], 'ubuntu-latest', 'pr-metadata must use ubuntu-latest');
+    assert.equal(job['timeout-minutes'], 2, 'pr-metadata must have a short timeout');
+    assert.ok(findStep(job, step => isMapping(step) && step.uses === 'actions/checkout@v4'),
+        'pr-metadata must checkout the PR head');
+    assert.equal(findStep(job, step => isMapping(step)
+        && step.name === 'Check PR body conventions')?.run,
+    'node scripts/check-pr-body.js',
+    'pr-metadata must run the PR body validator directly');
+    assert.equal(findStep(job, step => isMapping(step) && step.run === 'npm ci'), undefined,
+        'pr-metadata must run before dependency installation');
+    assert.equal(jobs['quality-linux'].needs, 'pr-metadata',
+        'quality-linux must wait for the PR metadata preflight');
+}
+
 function validateVerifyWorkflow(verifyWorkflow) {
     const workflow = parseVerifyWorkflow(verifyWorkflow);
     validateTriggers(workflow);
@@ -137,6 +155,7 @@ function validateVerifyWorkflow(verifyWorkflow) {
     assert.equal(workflow.concurrency['cancel-in-progress'], true,
         'GitHub verification workflow must cancel in-progress runs');
     assert.ok(isMapping(workflow.jobs), 'GitHub verification workflow jobs must be a mapping');
+    validatePrMetadataPreflight(workflow.jobs);
     validateJob(
         workflow.jobs,
         'quality-linux',

--- a/scripts/lib/ciContracts.js
+++ b/scripts/lib/ciContracts.js
@@ -139,8 +139,35 @@ function validatePrMetadataPreflight(jobs) {
     'pr-metadata must run the PR body validator directly');
     assert.equal(findStep(job, step => isMapping(step) && step.run === 'npm ci'), undefined,
         'pr-metadata must run before dependency installation');
-    assert.equal(jobs['quality-linux'].needs, 'pr-metadata',
-        'quality-linux must wait for the PR metadata preflight');
+}
+
+function validateStaticPreflight(jobs) {
+    const job = jobs['static-preflight'];
+    assert.ok(isMapping(job), 'GitHub verification workflow must define static-preflight');
+    assert.equal(job.name, 'static-preflight', 'static-preflight must expose a stable check name');
+    assert.equal(job['runs-on'], 'ubuntu-latest', 'static-preflight must use ubuntu-latest');
+    assert.equal(job['timeout-minutes'], 3, 'static-preflight must have a short timeout');
+    assert.ok(findStep(job, step => isMapping(step) && step.uses === 'actions/checkout@v4'),
+        'static-preflight must checkout the PR head');
+    const command = findStep(job, step => isMapping(step)
+        && step.name === 'Run static repository preflight')?.run;
+    assert.equal(command, [
+        'node scripts/check-brand-identity.js',
+        'node scripts/check-behavior-contracts.js',
+        'node --test tests/unit/tooling/conversationReleaseJourneys.test.js',
+        'node scripts/check-conversation-release-journeys.js',
+        'node scripts/run-performance-architecture-baseline-checks.js',
+        'node scripts/run-architecture-guards.js',
+        'node scripts/run-release-notes-checks.js',
+        '',
+    ].join('\n'), 'static-preflight must run only checkout-safe repository checks');
+    assert.equal(findStep(job, step => isMapping(step) && step.run === 'npm ci'), undefined,
+        'static-preflight must run before dependency installation');
+    assert.equal(findStep(job, step => isMapping(step)
+        && step.uses === 'actions/setup-node@v4'), undefined,
+    'static-preflight must not wait for dependency setup');
+    assert.deepEqual(jobs['quality-linux'].needs, ['pr-metadata', 'static-preflight'],
+        'quality-linux must wait for both fast preflight jobs');
 }
 
 function validateVerifyWorkflow(verifyWorkflow) {
@@ -156,6 +183,7 @@ function validateVerifyWorkflow(verifyWorkflow) {
         'GitHub verification workflow must cancel in-progress runs');
     assert.ok(isMapping(workflow.jobs), 'GitHub verification workflow jobs must be a mapping');
     validatePrMetadataPreflight(workflow.jobs);
+    validateStaticPreflight(workflow.jobs);
     validateJob(
         workflow.jobs,
         'quality-linux',

--- a/scripts/lib/ciContracts.js
+++ b/scripts/lib/ciContracts.js
@@ -157,7 +157,6 @@ function validateStaticPreflight(jobs) {
         'node --test tests/unit/tooling/conversationReleaseJourneys.test.js',
         'node scripts/check-conversation-release-journeys.js',
         'node scripts/run-performance-architecture-baseline-checks.js',
-        'node scripts/run-architecture-guards.js',
         'node scripts/run-release-notes-checks.js',
         '',
     ].join('\n'), 'static-preflight must run only checkout-safe repository checks');

--- a/src/aiSessions/conversation/claudeAdapter.ts
+++ b/src/aiSessions/conversation/claudeAdapter.ts
@@ -41,6 +41,7 @@ import {
     ConversationError,
     ConversationFileDiff,
     ConversationHistoryRestartPoint,
+    ConversationHistoryRestartSnapshot,
     ConversationInteraction,
     ConversationOutline,
     ConversationPage,
@@ -596,10 +597,15 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
     /** Provider-owned candidates for the persistent history indexer. */
     getHistoryRestartPoints(
         sessionId: string
-    ): ConversationHistoryRestartPoint[] {
-        return this.cache.get(sessionId)?.restartPoints.map(point => ({
-            ...point,
-        })) || [];
+    ): ConversationHistoryRestartSnapshot | undefined {
+        const entry = this.cache.get(sessionId);
+        return entry && {
+            sourceIdentity: entry.source.identity,
+            sourceSize: entry.source.size,
+            sourceRevision: `r${entry.revision}`,
+            reducerVersion: 1,
+            points: entry.restartPoints.map(point => ({ ...point })),
+        };
     }
 
     private load(
@@ -673,14 +679,12 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
             );
             const continuing = Boolean(previous)
                 && startOffset === previous.nextOffset;
-            // See Kimi's equivalent guard: reducer continuation is safe for
-            // a verified append, while sparse restart offsets are not trusted
-            // after any source identity change.
+            // See Kimi's equivalent guard. `continuing` verifies the old
+            // prefix before reducer state and sparse candidates are reused.
             let restartPoints: ConversationHistoryRestartPoint[] = continuing
-                && previous?.source.identity === source.identity
                 ? previous.restartPoints
                 : [];
-            let ownsRestartPoints = restartPoints.length === 0;
+            let ownsRestartPoints = !continuing;
             const addRestartPoint = (
                 point: ConversationHistoryRestartPoint
             ): void => {
@@ -757,6 +761,8 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
                     && isUserInterrupt(message.content)) {
                     finishInteraction('interrupted');
                     timeoutOpenInteractionIndex = undefined;
+                    toolTracker.discardPending();
+                    questionTracker.clear();
                 } else if (event.type === 'user'
                     && message?.role === 'user'
                     && openInteractionIndex !== undefined
@@ -805,6 +811,11 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
                     }
                     finishInteraction();
                     timeoutOpenInteractionIndex = undefined;
+                    // A new visible user record seals the former turn. Any
+                    // still-unpaired tool/question is orphaned rather than a
+                    // dependency of this replay boundary.
+                    toolTracker.discardPending();
+                    questionTracker.clear();
                     if (interactions.some(
                         interaction => interaction.id === event.uuid
                     )) {

--- a/src/aiSessions/conversation/claudeAdapter.ts
+++ b/src/aiSessions/conversation/claudeAdapter.ts
@@ -657,7 +657,6 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
         const isSubagentTranscript = Boolean(split.subagentId);
         const previous = this.cache.get(sessionId);
         let interactions: ConversationInteraction[] = [];
-        let restartPoints: ConversationHistoryRestartPoint[] = [];
         let openInteractionIndex: number | undefined;
         let timeoutOpenInteractionIndex: number | undefined;
         let telemetryModel: string | undefined;
@@ -674,9 +673,25 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
             );
             const continuing = Boolean(previous)
                 && startOffset === previous.nextOffset;
+            // See Kimi's equivalent guard: reducer continuation is safe for
+            // a verified append, while sparse restart offsets are not trusted
+            // after any source identity change.
+            let restartPoints: ConversationHistoryRestartPoint[] = continuing
+                && previous?.source.identity === source.identity
+                ? previous.restartPoints
+                : [];
+            let ownsRestartPoints = restartPoints.length === 0;
+            const addRestartPoint = (
+                point: ConversationHistoryRestartPoint
+            ): void => {
+                if (!ownsRestartPoints) {
+                    restartPoints = restartPoints.slice();
+                    ownsRestartPoints = true;
+                }
+                appendConversationHistoryRestartPoint(restartPoints, point);
+            };
             if (continuing) {
                 interactions = cloneInteractions(previous.interactions);
-                restartPoints = previous.restartPoints.slice();
                 openInteractionIndex = previous.appendInteractionIndex;
                 telemetryModel = previous.telemetryModel;
                 telemetryContext = previous.telemetryContext;
@@ -764,6 +779,9 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
                                 : undefined;
                         if (questionBlock) {
                             settleClaudeQuestion(questionBlock, text);
+                            if (typeof block.tool_use_id === 'string') {
+                                questionTracker.delete(block.tool_use_id);
+                            }
                         } else {
                             toolTracker.finish(block.tool_use_id, text);
                         }
@@ -792,10 +810,15 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
                     )) {
                         return;
                     }
-                    appendConversationHistoryRestartPoint(restartPoints, {
-                        offset: record.offset,
-                        interactionId: event.uuid,
-                    });
+                    if (!toolTracker.hasPending()
+                        && questionTracker.size === 0
+                        && event.uuid.length
+                            <= CONVERSATION_LIMITS.maxHistoryRestartPointIdLength) {
+                        addRestartPoint({
+                            offset: record.offset,
+                            interactionId: event.uuid,
+                        });
+                    }
                     interactions.push({
                         id: event.uuid,
                         timestamp: timestampValue(event.timestamp),

--- a/src/aiSessions/conversation/claudeAdapter.ts
+++ b/src/aiSessions/conversation/claudeAdapter.ts
@@ -59,7 +59,6 @@ import {
 import {
     appendConversationHistoryRestartPoint,
     CachedConversationHistoryRestartPoint,
-    stampConversationHistoryRestartPoints,
     verifyConversationHistoryRestartPoints,
 } from './historyRestartPoints';
 import {
@@ -722,9 +721,14 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
             let restartPoints: CachedConversationHistoryRestartPoint[] = continuing
                 ? previous.restartPoints
                 : [];
+            let ownsRestartPoints = !continuing;
             const addRestartPoint = (
                 point: CachedConversationHistoryRestartPoint
             ): void => {
+                if (!ownsRestartPoints) {
+                    restartPoints = restartPoints.slice();
+                    ownsRestartPoints = true;
+                }
                 appendConversationHistoryRestartPoint(restartPoints, point);
             };
             if (continuing) {
@@ -861,7 +865,7 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
                         addRestartPoint({
                             offset: record.offset,
                             recordEndOffset: record.endOffset,
-                            recordDigest: '',
+                            recordDigest: record.recordDigest,
                             interactionId: event.uuid,
                         });
                     }
@@ -1008,10 +1012,6 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
             const appendInteractionIndex = openInteractionIndex;
             finishInteraction();
             const partial = continuing ? previous.partial : result.partial;
-            restartPoints = await stampConversationHistoryRestartPoints(
-                source,
-                restartPoints
-            );
             const changed = !previous
                 || previous.source.identity !== source.identity
                 || previous.source.portableFirstHash

--- a/src/aiSessions/conversation/claudeAdapter.ts
+++ b/src/aiSessions/conversation/claudeAdapter.ts
@@ -40,7 +40,6 @@ import {
     ConversationCacheDiagnostics,
     ConversationError,
     ConversationFileDiff,
-    ConversationHistoryRestartPoint,
     ConversationHistoryRestartSnapshot,
     ConversationInteraction,
     ConversationOutline,
@@ -57,7 +56,12 @@ import {
     openValidatedConversationSource,
     OpenConversationSource,
 } from './source';
-import { appendConversationHistoryRestartPoint } from './historyRestartPoints';
+import {
+    appendConversationHistoryRestartPoint,
+    CachedConversationHistoryRestartPoint,
+    stampConversationHistoryRestartPoints,
+    verifyConversationHistoryRestartPoints,
+} from './historyRestartPoints';
 import {
     isSubagentId,
     splitSubagentSessionId,
@@ -99,7 +103,7 @@ interface ClaudeConversationIndex extends AiSessionDisposable {
     source: OpenConversationSource;
     nextOffset: number;
     interactions: ConversationInteraction[];
-    restartPoints: ConversationHistoryRestartPoint[];
+    restartPoints: CachedConversationHistoryRestartPoint[];
     appendInteractionIndex?: number;
     telemetryModel?: string;
     telemetryContext?: ConversationContextUsage;
@@ -595,17 +599,50 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
     }
 
     /** Provider-owned candidates for the persistent history indexer. */
-    getHistoryRestartPoints(
+    async getHistoryRestartPoints(
         sessionId: string
-    ): ConversationHistoryRestartSnapshot | undefined {
+    ): Promise<ConversationHistoryRestartSnapshot | undefined> {
         const entry = this.cache.get(sessionId);
-        return entry && {
-            sourceIdentity: entry.source.identity,
-            sourceSize: entry.source.size,
-            sourceRevision: `r${entry.revision}`,
-            reducerVersion: 1,
-            points: entry.restartPoints.map(point => ({ ...point })),
-        };
+        const split = splitSubagentSessionId(sessionId);
+        const candidate = entry && (!split.subagentId || isSubagentId(split.subagentId))
+            ? this.options.resolveSource(split.sessionId)
+            : null;
+        if (!entry || !candidate) {
+            return undefined;
+        }
+        const source = await openValidatedConversationSource(split.subagentId
+            ? {
+                providerHome: candidate.providerHome,
+                sourcePath: path.join(
+                    subagentsRootFor(candidate.sourcePath),
+                    `agent-${split.subagentId}.jsonl`
+                ),
+            }
+            : candidate);
+        if (!source) {
+            return undefined;
+        }
+        try {
+            if (source.identity !== entry.source.identity) {
+                return undefined;
+            }
+            const points = await verifyConversationHistoryRestartPoints(
+                source,
+                entry.restartPoints
+            );
+            return {
+                sourceIdentity: source.identity,
+                sourceSize: source.size,
+                sourceRevision: `r${entry.revision}`,
+                reducerVersion: 1,
+                points: points.map(point => ({
+                    offset: point.offset,
+                    interactionId: point.interactionId,
+                })),
+            };
+        } finally {
+            await source.handle.close().catch(() => undefined);
+        }
     }
 
     private load(
@@ -679,19 +716,15 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
             );
             const continuing = Boolean(previous)
                 && startOffset === previous.nextOffset;
-            // See Kimi's equivalent guard. `continuing` verifies the old
-            // prefix before reducer state and sparse candidates are reused.
-            let restartPoints: ConversationHistoryRestartPoint[] = continuing
+            // See Kimi's equivalent guard. A continuation must also prove
+            // each old physical record before its offset joins this source
+            // snapshot.
+            let restartPoints: CachedConversationHistoryRestartPoint[] = continuing
                 ? previous.restartPoints
                 : [];
-            let ownsRestartPoints = !continuing;
             const addRestartPoint = (
-                point: ConversationHistoryRestartPoint
+                point: CachedConversationHistoryRestartPoint
             ): void => {
-                if (!ownsRestartPoints) {
-                    restartPoints = restartPoints.slice();
-                    ownsRestartPoints = true;
-                }
                 appendConversationHistoryRestartPoint(restartPoints, point);
             };
             if (continuing) {
@@ -827,6 +860,8 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
                             <= CONVERSATION_LIMITS.maxHistoryRestartPointIdLength) {
                         addRestartPoint({
                             offset: record.offset,
+                            recordEndOffset: record.endOffset,
+                            recordDigest: '',
                             interactionId: event.uuid,
                         });
                     }
@@ -973,6 +1008,10 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
             const appendInteractionIndex = openInteractionIndex;
             finishInteraction();
             const partial = continuing ? previous.partial : result.partial;
+            restartPoints = await stampConversationHistoryRestartPoints(
+                source,
+                restartPoints
+            );
             const changed = !previous
                 || previous.source.identity !== source.identity
                 || previous.source.portableFirstHash

--- a/src/aiSessions/conversation/claudeAdapter.ts
+++ b/src/aiSessions/conversation/claudeAdapter.ts
@@ -40,6 +40,7 @@ import {
     ConversationCacheDiagnostics,
     ConversationError,
     ConversationFileDiff,
+    ConversationHistoryRestartPoint,
     ConversationInteraction,
     ConversationOutline,
     ConversationPage,
@@ -96,6 +97,7 @@ interface ClaudeConversationIndex extends AiSessionDisposable {
     source: OpenConversationSource;
     nextOffset: number;
     interactions: ConversationInteraction[];
+    restartPoints: ConversationHistoryRestartPoint[];
     appendInteractionIndex?: number;
     telemetryModel?: string;
     telemetryContext?: ConversationContextUsage;
@@ -590,6 +592,15 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
         };
     }
 
+    /** Provider-owned candidates for the persistent history indexer. */
+    getHistoryRestartPoints(
+        sessionId: string
+    ): ConversationHistoryRestartPoint[] {
+        return this.cache.get(sessionId)?.restartPoints.map(point => ({
+            ...point,
+        })) || [];
+    }
+
     private load(
         sessionId: string,
         signal?: ConversationAbortSignal
@@ -645,6 +656,7 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
         const isSubagentTranscript = Boolean(split.subagentId);
         const previous = this.cache.get(sessionId);
         let interactions: ConversationInteraction[] = [];
+        let restartPoints: ConversationHistoryRestartPoint[] = [];
         let openInteractionIndex: number | undefined;
         let timeoutOpenInteractionIndex: number | undefined;
         let telemetryModel: string | undefined;
@@ -663,6 +675,7 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
                 && startOffset === previous.nextOffset;
             if (continuing) {
                 interactions = cloneInteractions(previous.interactions);
+                restartPoints = previous.restartPoints.slice();
                 openInteractionIndex = previous.appendInteractionIndex;
                 telemetryModel = previous.telemetryModel;
                 telemetryContext = previous.telemetryContext;
@@ -778,6 +791,10 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
                     )) {
                         return;
                     }
+                    restartPoints.push({
+                        offset: record.offset,
+                        interactionId: event.uuid,
+                    });
                     interactions.push({
                         id: event.uuid,
                         timestamp: timestampValue(event.timestamp),
@@ -937,6 +954,7 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
                 previous.source = source;
                 previous.nextOffset = result.nextOffset;
                 previous.interactions = interactions;
+                previous.restartPoints = restartPoints;
                 previous.appendInteractionIndex = appendInteractionIndex;
                 previous.telemetryModel = telemetryModel;
                 previous.telemetryContext = telemetryContext;
@@ -952,6 +970,7 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
                     source,
                     nextOffset: result.nextOffset,
                     interactions,
+                    restartPoints,
                     appendInteractionIndex,
                     telemetryModel,
                     telemetryContext,

--- a/src/aiSessions/conversation/claudeAdapter.ts
+++ b/src/aiSessions/conversation/claudeAdapter.ts
@@ -56,6 +56,7 @@ import {
     openValidatedConversationSource,
     OpenConversationSource,
 } from './source';
+import { appendConversationHistoryRestartPoint } from './historyRestartPoints';
 import {
     isSubagentId,
     splitSubagentSessionId,
@@ -791,7 +792,7 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
                     )) {
                         return;
                     }
-                    restartPoints.push({
+                    appendConversationHistoryRestartPoint(restartPoints, {
                         offset: record.offset,
                         interactionId: event.uuid,
                     });

--- a/src/aiSessions/conversation/historyRestartPoints.ts
+++ b/src/aiSessions/conversation/historyRestartPoints.ts
@@ -1,12 +1,22 @@
 'use strict';
 
 import { CONVERSATION_LIMITS, ConversationHistoryRestartPoint } from './types';
+import { digestConversationSourceRange, OpenConversationSource } from './source';
+
+/** Adapter-cache-only proof data; the provider API deliberately omits it. */
+export interface CachedConversationHistoryRestartPoint
+    extends ConversationHistoryRestartPoint {
+    recordEndOffset: number;
+    recordDigest: string;
+}
 
 /** Retains only the recent in-memory discovery window; durable sparse points
  * are owned by the later sidecar index, not by an adapter cache. */
-export function appendConversationHistoryRestartPoint(
-    points: ConversationHistoryRestartPoint[],
-    point: ConversationHistoryRestartPoint
+export function appendConversationHistoryRestartPoint<
+    T extends ConversationHistoryRestartPoint
+>(
+    points: T[],
+    point: T
 ): void {
     const previous = points[points.length - 1];
     if (previous?.offset === point.offset) {
@@ -17,4 +27,47 @@ export function appendConversationHistoryRestartPoint(
     if (excess >= 64) {
         points.splice(0, excess);
     }
+}
+
+/** Drops any candidate whose record boundary no longer proves identical in
+ * the continuation source. Each point is independently restart-safe. */
+export async function verifyConversationHistoryRestartPoints(
+    source: OpenConversationSource,
+    points: CachedConversationHistoryRestartPoint[]
+): Promise<CachedConversationHistoryRestartPoint[]> {
+    const verified: CachedConversationHistoryRestartPoint[] = [];
+    for (const point of points) {
+        const digest = await digestConversationSourceRange(
+            source,
+            point.offset,
+            point.recordEndOffset
+        );
+        if (digest === point.recordDigest) {
+            verified.push(point);
+        }
+    }
+    return verified;
+}
+
+/** Captures raw-record proofs only after the current source scan succeeded. */
+export async function stampConversationHistoryRestartPoints(
+    source: OpenConversationSource,
+    points: CachedConversationHistoryRestartPoint[]
+): Promise<CachedConversationHistoryRestartPoint[]> {
+    const stamped: CachedConversationHistoryRestartPoint[] = [];
+    for (const point of points) {
+        if (point.recordDigest) {
+            stamped.push(point);
+            continue;
+        }
+        const digest = await digestConversationSourceRange(
+            source,
+            point.offset,
+            point.recordEndOffset
+        );
+        if (digest) {
+            stamped.push({ ...point, recordDigest: digest });
+        }
+    }
+    return stamped;
 }

--- a/src/aiSessions/conversation/historyRestartPoints.ts
+++ b/src/aiSessions/conversation/historyRestartPoints.ts
@@ -1,0 +1,20 @@
+'use strict';
+
+import { CONVERSATION_LIMITS, ConversationHistoryRestartPoint } from './types';
+
+/** Retains only the recent in-memory discovery window; durable sparse points
+ * are owned by the later sidecar index, not by an adapter cache. */
+export function appendConversationHistoryRestartPoint(
+    points: ConversationHistoryRestartPoint[],
+    point: ConversationHistoryRestartPoint
+): void {
+    const previous = points[points.length - 1];
+    if (previous?.offset === point.offset) {
+        return;
+    }
+    points.push(point);
+    const excess = points.length - CONVERSATION_LIMITS.maxOutlineInteractions;
+    if (excess > 0) {
+        points.splice(0, excess);
+    }
+}

--- a/src/aiSessions/conversation/historyRestartPoints.ts
+++ b/src/aiSessions/conversation/historyRestartPoints.ts
@@ -14,7 +14,7 @@ export function appendConversationHistoryRestartPoint(
     }
     points.push(point);
     const excess = points.length - CONVERSATION_LIMITS.maxOutlineInteractions;
-    if (excess > 0) {
+    if (excess >= 64) {
         points.splice(0, excess);
     }
 }

--- a/src/aiSessions/conversation/historyRestartPoints.ts
+++ b/src/aiSessions/conversation/historyRestartPoints.ts
@@ -50,24 +50,3 @@ export async function verifyConversationHistoryRestartPoints(
 }
 
 /** Captures raw-record proofs only after the current source scan succeeded. */
-export async function stampConversationHistoryRestartPoints(
-    source: OpenConversationSource,
-    points: CachedConversationHistoryRestartPoint[]
-): Promise<CachedConversationHistoryRestartPoint[]> {
-    const stamped: CachedConversationHistoryRestartPoint[] = [];
-    for (const point of points) {
-        if (point.recordDigest) {
-            stamped.push(point);
-            continue;
-        }
-        const digest = await digestConversationSourceRange(
-            source,
-            point.offset,
-            point.recordEndOffset
-        );
-        if (digest) {
-            stamped.push({ ...point, recordDigest: digest });
-        }
-    }
-    return stamped;
-}

--- a/src/aiSessions/conversation/jsonlReader.ts
+++ b/src/aiSessions/conversation/jsonlReader.ts
@@ -1,5 +1,6 @@
 'use strict';
 
+import { createHash } from 'crypto';
 import type { AiSessionDisposable } from '../types';
 import { CONVERSATION_LIMITS, ConversationAbortError, ConversationAbortSignal, ConversationError } from './types';
 import { isConversationSourceContinuation, OpenConversationSource } from './source';
@@ -23,8 +24,10 @@ export interface ConversationJsonlReadOptions {
 
 export interface ConversationJsonlRecord {
     offset: number;
-    /** Exclusive byte end of this physical JSONL record. */
+    /** Exclusive byte end of the JSON payload (the trailing newline is excluded). */
     endOffset: number;
+    /** SHA-256 of the exact physical JSONL bytes parsed for this record. */
+    recordDigest: string;
     value: unknown;
 }
 
@@ -147,10 +150,12 @@ export async function readConversationJsonl(
         }
         let record: ConversationJsonlRecord;
         try {
+            const rawRecord = Buffer.concat(fragments);
             record = {
                 offset: lineStart,
-                endOffset: readOffset,
-                value: JSON.parse(Buffer.concat(fragments).toString('utf8')),
+                endOffset: readOffset - 1,
+                recordDigest: createHash('sha256').update(rawRecord).digest('hex'),
+                value: JSON.parse(rawRecord.toString('utf8')),
             };
         } catch (_error) {
             malformedLines += 1;
@@ -235,10 +240,12 @@ export async function readConversationJsonl(
         } else {
             let record: ConversationJsonlRecord;
             try {
+                const rawRecord = Buffer.concat(fragments);
                 record = {
                     offset: lineStart,
                     endOffset: readOffset,
-                    value: JSON.parse(Buffer.concat(fragments).toString('utf8')),
+                    recordDigest: createHash('sha256').update(rawRecord).digest('hex'),
+                    value: JSON.parse(rawRecord.toString('utf8')),
                 };
             } catch (_error) {
                 readOffset = lineStart;

--- a/src/aiSessions/conversation/jsonlReader.ts
+++ b/src/aiSessions/conversation/jsonlReader.ts
@@ -23,6 +23,8 @@ export interface ConversationJsonlReadOptions {
 
 export interface ConversationJsonlRecord {
     offset: number;
+    /** Exclusive byte end of this physical JSONL record. */
+    endOffset: number;
     value: unknown;
 }
 
@@ -147,6 +149,7 @@ export async function readConversationJsonl(
         try {
             record = {
                 offset: lineStart,
+                endOffset: readOffset,
                 value: JSON.parse(Buffer.concat(fragments).toString('utf8')),
             };
         } catch (_error) {
@@ -234,6 +237,7 @@ export async function readConversationJsonl(
             try {
                 record = {
                     offset: lineStart,
+                    endOffset: readOffset,
                     value: JSON.parse(Buffer.concat(fragments).toString('utf8')),
                 };
             } catch (_error) {

--- a/src/aiSessions/conversation/kimiAdapter.ts
+++ b/src/aiSessions/conversation/kimiAdapter.ts
@@ -43,6 +43,7 @@ import {
     ConversationCacheDiagnostics,
     ConversationError,
     ConversationFileDiff,
+    ConversationHistoryRestartPoint,
     ConversationInteraction,
     ConversationOutline,
     ConversationPage,
@@ -129,6 +130,7 @@ interface KimiConversationIndex extends AiSessionDisposable {
     source: OpenConversationSource;
     nextOffset: number;
     interactions: ConversationInteraction[];
+    restartPoints: ConversationHistoryRestartPoint[];
     openInteractionIndex?: number;
     telemetryContext?: ConversationContextUsage;
     telemetryPaths: string[];
@@ -617,6 +619,15 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
         };
     }
 
+    /** Provider-owned candidates for the persistent history indexer. */
+    getHistoryRestartPoints(
+        sessionId: string
+    ): ConversationHistoryRestartPoint[] {
+        return this.cache.get(sessionId)?.restartPoints.map(point => ({
+            ...point,
+        })) || [];
+    }
+
     private load(
         sessionId: string,
         signal?: ConversationAbortSignal
@@ -674,6 +685,7 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
         }
         const previous = this.cache.get(sessionId);
         let interactions: ConversationInteraction[] = [];
+        let restartPoints: ConversationHistoryRestartPoint[] = [];
         let openInteractionIndex: number | undefined;
         let telemetryContext: ConversationContextUsage | undefined;
         let telemetryPaths: string[] = effectiveCandidate.cwd
@@ -691,6 +703,7 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                 && startOffset === previous.nextOffset;
             if (continuing) {
                 interactions = cloneInteractions(previous.interactions);
+                restartPoints = previous.restartPoints.slice();
                 openInteractionIndex = previous.openInteractionIndex;
                 telemetryContext = previous.telemetryContext;
                 telemetryPaths = previous.telemetryPaths.slice();
@@ -799,6 +812,7 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                         if (interactions.some(interaction => interaction.id === id)) {
                             return;
                         }
+                        restartPoints.push({ offset: record.offset, interactionId: id });
                         interactions.push({
                             id,
                             timestamp: timestampValue(envelope?.timestamp),
@@ -1222,6 +1236,7 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                 previous.source = source;
                 previous.nextOffset = result.nextOffset;
                 previous.interactions = interactions;
+                previous.restartPoints = restartPoints;
                 previous.openInteractionIndex = openInteractionIndex;
                 previous.telemetryContext = telemetryContext;
                 previous.telemetryPaths = telemetryPaths;
@@ -1238,6 +1253,7 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                     source,
                     nextOffset: result.nextOffset,
                     interactions,
+                    restartPoints,
                     openInteractionIndex,
                     telemetryContext,
                     telemetryPaths,

--- a/src/aiSessions/conversation/kimiAdapter.ts
+++ b/src/aiSessions/conversation/kimiAdapter.ts
@@ -65,6 +65,7 @@ import {
     openValidatedConversationSource,
     OpenConversationSource,
 } from './source';
+import { appendConversationHistoryRestartPoint } from './historyRestartPoints';
 import type {
     ConversationWorktreeInfo,
     ResolveWorktree,
@@ -812,7 +813,10 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                         if (interactions.some(interaction => interaction.id === id)) {
                             return;
                         }
-                        restartPoints.push({ offset: record.offset, interactionId: id });
+                        appendConversationHistoryRestartPoint(restartPoints, {
+                            offset: record.offset,
+                            interactionId: id,
+                        });
                         interactions.push({
                             id,
                             timestamp: timestampValue(envelope?.timestamp),

--- a/src/aiSessions/conversation/kimiAdapter.ts
+++ b/src/aiSessions/conversation/kimiAdapter.ts
@@ -44,6 +44,7 @@ import {
     ConversationError,
     ConversationFileDiff,
     ConversationHistoryRestartPoint,
+    ConversationHistoryRestartSnapshot,
     ConversationInteraction,
     ConversationOutline,
     ConversationPage,
@@ -623,10 +624,15 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
     /** Provider-owned candidates for the persistent history indexer. */
     getHistoryRestartPoints(
         sessionId: string
-    ): ConversationHistoryRestartPoint[] {
-        return this.cache.get(sessionId)?.restartPoints.map(point => ({
-            ...point,
-        })) || [];
+    ): ConversationHistoryRestartSnapshot | undefined {
+        const entry = this.cache.get(sessionId);
+        return entry && {
+            sourceIdentity: entry.source.identity,
+            sourceSize: entry.source.size,
+            sourceRevision: `r${entry.revision}`,
+            reducerVersion: 1,
+            points: entry.restartPoints.map(point => ({ ...point })),
+        };
     }
 
     private load(
@@ -701,16 +707,14 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
             );
             const continuing = Boolean(previous)
                 && startOffset === previous.nextOffset;
-            // Restart offsets are only valid for the exact source snapshot
-            // that produced them. An append may reuse reducer state after the
-            // continuation check, but it must rediscover restart points: the
-            // source identity changed and cannot prove an arbitrary prefix
-            // was not rewritten in place.
+            // `continuing` verifies the old prefix before reducer state is
+            // reused, so its restart points remain valid across an append.
+            // A replacement or truncation fails that proof and starts a new
+            // discovery epoch.
             let restartPoints: ConversationHistoryRestartPoint[] = continuing
-                && previous?.source.identity === source.identity
                 ? previous.restartPoints
                 : [];
-            let ownsRestartPoints = restartPoints.length === 0;
+            let ownsRestartPoints = !continuing;
             const addRestartPoint = (
                 point: ConversationHistoryRestartPoint
             ): void => {
@@ -822,6 +826,12 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                                 'interrupted';
                             openInteractionIndex = undefined;
                         }
+                        // A following TurnBegin seals the former interaction.
+                        // Its late tool/question/approval results can no
+                        // longer affect this replay boundary.
+                        toolTracker.discardPending();
+                        questionTracker.clear();
+                        approvalTracker.clear();
                         const id = interactionId(
                             sessionId,
                             record.offset,
@@ -1191,6 +1201,9 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                     || event.type === 'TurnInterrupted') {
                     stampActivity(envelope);
                     finishInteraction('interrupted');
+                    toolTracker.discardPending();
+                    questionTracker.clear();
+                    approvalTracker.clear();
                 }
             };
             const finishInteraction = (

--- a/src/aiSessions/conversation/kimiAdapter.ts
+++ b/src/aiSessions/conversation/kimiAdapter.ts
@@ -686,7 +686,6 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
         }
         const previous = this.cache.get(sessionId);
         let interactions: ConversationInteraction[] = [];
-        let restartPoints: ConversationHistoryRestartPoint[] = [];
         let openInteractionIndex: number | undefined;
         let telemetryContext: ConversationContextUsage | undefined;
         let telemetryPaths: string[] = effectiveCandidate.cwd
@@ -702,9 +701,27 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
             );
             const continuing = Boolean(previous)
                 && startOffset === previous.nextOffset;
+            // Restart offsets are only valid for the exact source snapshot
+            // that produced them. An append may reuse reducer state after the
+            // continuation check, but it must rediscover restart points: the
+            // source identity changed and cannot prove an arbitrary prefix
+            // was not rewritten in place.
+            let restartPoints: ConversationHistoryRestartPoint[] = continuing
+                && previous?.source.identity === source.identity
+                ? previous.restartPoints
+                : [];
+            let ownsRestartPoints = restartPoints.length === 0;
+            const addRestartPoint = (
+                point: ConversationHistoryRestartPoint
+            ): void => {
+                if (!ownsRestartPoints) {
+                    restartPoints = restartPoints.slice();
+                    ownsRestartPoints = true;
+                }
+                appendConversationHistoryRestartPoint(restartPoints, point);
+            };
             if (continuing) {
                 interactions = cloneInteractions(previous.interactions);
-                restartPoints = previous.restartPoints.slice();
                 openInteractionIndex = previous.openInteractionIndex;
                 telemetryContext = previous.telemetryContext;
                 telemetryPaths = previous.telemetryPaths.slice();
@@ -813,10 +830,14 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                         if (interactions.some(interaction => interaction.id === id)) {
                             return;
                         }
-                        appendConversationHistoryRestartPoint(restartPoints, {
-                            offset: record.offset,
-                            interactionId: id,
-                        });
+                        if (!toolTracker.hasPending()
+                            && questionTracker.size === 0
+                            && approvalTracker.size === 0) {
+                            addRestartPoint({
+                                offset: record.offset,
+                                interactionId: id,
+                            });
+                        }
                         interactions.push({
                             id,
                             timestamp: timestampValue(envelope?.timestamp),
@@ -1036,6 +1057,9 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                             `Approval: ${response}${feedback}`
                         );
                     }
+                    if (requestId) {
+                        approvalTracker.delete(requestId);
+                    }
                 } else if (event.type === 'StatusUpdate') {
                     const payload = asRecord(event.payload);
                     const usedTokens = Number(payload?.context_tokens);
@@ -1153,6 +1177,9 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                         : undefined;
                     if (questionBlock) {
                         applyKimiQuestionSettlement(questionBlock, output);
+                        if (toolCallId) {
+                            questionTracker.delete(toolCallId);
+                        }
                     } else {
                         toolTracker.finish(payload?.tool_call_id, output);
                     }

--- a/src/aiSessions/conversation/kimiAdapter.ts
+++ b/src/aiSessions/conversation/kimiAdapter.ts
@@ -43,7 +43,6 @@ import {
     ConversationCacheDiagnostics,
     ConversationError,
     ConversationFileDiff,
-    ConversationHistoryRestartPoint,
     ConversationHistoryRestartSnapshot,
     ConversationInteraction,
     ConversationOutline,
@@ -66,7 +65,12 @@ import {
     openValidatedConversationSource,
     OpenConversationSource,
 } from './source';
-import { appendConversationHistoryRestartPoint } from './historyRestartPoints';
+import {
+    appendConversationHistoryRestartPoint,
+    CachedConversationHistoryRestartPoint,
+    stampConversationHistoryRestartPoints,
+    verifyConversationHistoryRestartPoints,
+} from './historyRestartPoints';
 import type {
     ConversationWorktreeInfo,
     ResolveWorktree,
@@ -132,7 +136,7 @@ interface KimiConversationIndex extends AiSessionDisposable {
     source: OpenConversationSource;
     nextOffset: number;
     interactions: ConversationInteraction[];
-    restartPoints: ConversationHistoryRestartPoint[];
+    restartPoints: CachedConversationHistoryRestartPoint[];
     openInteractionIndex?: number;
     telemetryContext?: ConversationContextUsage;
     telemetryPaths: string[];
@@ -622,17 +626,48 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
     }
 
     /** Provider-owned candidates for the persistent history indexer. */
-    getHistoryRestartPoints(
+    async getHistoryRestartPoints(
         sessionId: string
-    ): ConversationHistoryRestartSnapshot | undefined {
+    ): Promise<ConversationHistoryRestartSnapshot | undefined> {
         const entry = this.cache.get(sessionId);
-        return entry && {
-            sourceIdentity: entry.source.identity,
-            sourceSize: entry.source.size,
-            sourceRevision: `r${entry.revision}`,
-            reducerVersion: 1,
-            points: entry.restartPoints.map(point => ({ ...point })),
-        };
+        const split = splitSubagentSessionId(sessionId);
+        const candidate = entry && (!split.subagentId || isSubagentId(split.subagentId))
+            ? this.options.resolveSource(split.sessionId)
+            : null;
+        if (!entry || !candidate) {
+            return undefined;
+        }
+        const source = await openValidatedConversationSource(split.subagentId
+            ? {
+                providerHome: candidate.providerHome,
+                sourcePath: path.join(path.dirname(candidate.sourcePath), 'subagents', split.subagentId, 'wire.jsonl'),
+                cwd: candidate.cwd,
+            }
+            : candidate);
+        if (!source) {
+            return undefined;
+        }
+        try {
+            if (source.identity !== entry.source.identity) {
+                return undefined;
+            }
+            const points = await verifyConversationHistoryRestartPoints(
+                source,
+                entry.restartPoints
+            );
+            return {
+                sourceIdentity: source.identity,
+                sourceSize: source.size,
+                sourceRevision: `r${entry.revision}`,
+                reducerVersion: 1,
+                points: points.map(point => ({
+                    offset: point.offset,
+                    interactionId: point.interactionId,
+                })),
+            };
+        } finally {
+            await source.handle.close().catch(() => undefined);
+        }
     }
 
     private load(
@@ -708,20 +743,15 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
             const continuing = Boolean(previous)
                 && startOffset === previous.nextOffset;
             // `continuing` verifies the old prefix before reducer state is
-            // reused, so its restart points remain valid across an append.
-            // A replacement or truncation fails that proof and starts a new
-            // discovery epoch.
-            let restartPoints: ConversationHistoryRestartPoint[] = continuing
+            // reused. Recheck each sparse point's complete physical record
+            // before promoting it into the new source snapshot, so a middle
+            // rewrite plus append cannot rebind a stale offset.
+            let restartPoints: CachedConversationHistoryRestartPoint[] = continuing
                 ? previous.restartPoints
                 : [];
-            let ownsRestartPoints = !continuing;
             const addRestartPoint = (
-                point: ConversationHistoryRestartPoint
+                point: CachedConversationHistoryRestartPoint
             ): void => {
-                if (!ownsRestartPoints) {
-                    restartPoints = restartPoints.slice();
-                    ownsRestartPoints = true;
-                }
                 appendConversationHistoryRestartPoint(restartPoints, point);
             };
             if (continuing) {
@@ -845,6 +875,8 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                             && approvalTracker.size === 0) {
                             addRestartPoint({
                                 offset: record.offset,
+                                recordEndOffset: record.endOffset,
+                                recordDigest: '',
                                 interactionId: id,
                             });
                         }
@@ -1260,6 +1292,10 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                 };
             }
             const partial = continuing ? previous.partial : result.partial;
+            restartPoints = await stampConversationHistoryRestartPoints(
+                source,
+                restartPoints
+            );
             // Publish the in-progress text run so a streaming answer stays
             // visible between loads; the buffer itself stays open for later
             // deltas.

--- a/src/aiSessions/conversation/kimiAdapter.ts
+++ b/src/aiSessions/conversation/kimiAdapter.ts
@@ -68,7 +68,6 @@ import {
 import {
     appendConversationHistoryRestartPoint,
     CachedConversationHistoryRestartPoint,
-    stampConversationHistoryRestartPoints,
     verifyConversationHistoryRestartPoints,
 } from './historyRestartPoints';
 import type {
@@ -749,9 +748,14 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
             let restartPoints: CachedConversationHistoryRestartPoint[] = continuing
                 ? previous.restartPoints
                 : [];
+            let ownsRestartPoints = !continuing;
             const addRestartPoint = (
                 point: CachedConversationHistoryRestartPoint
             ): void => {
+                if (!ownsRestartPoints) {
+                    restartPoints = restartPoints.slice();
+                    ownsRestartPoints = true;
+                }
                 appendConversationHistoryRestartPoint(restartPoints, point);
             };
             if (continuing) {
@@ -876,7 +880,7 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                             addRestartPoint({
                                 offset: record.offset,
                                 recordEndOffset: record.endOffset,
-                                recordDigest: '',
+                                recordDigest: record.recordDigest,
                                 interactionId: id,
                             });
                         }
@@ -1292,10 +1296,6 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                 };
             }
             const partial = continuing ? previous.partial : result.partial;
-            restartPoints = await stampConversationHistoryRestartPoints(
-                source,
-                restartPoints
-            );
             // Publish the in-progress text run so a streaming answer stays
             // visible between loads; the buffer itself stays open for later
             // deltas.

--- a/src/aiSessions/conversation/source.ts
+++ b/src/aiSessions/conversation/source.ts
@@ -40,6 +40,23 @@ async function hashRange(
         .digest('hex');
 }
 
+/** Hashes an already validated physical JSONL record range. */
+export async function digestConversationSourceRange(
+    source: OpenConversationSource,
+    startOffset: number,
+    endOffset: number
+): Promise<string | undefined> {
+    if (!Number.isSafeInteger(startOffset) || !Number.isSafeInteger(endOffset)
+        || startOffset < 0 || endOffset <= startOffset
+        || endOffset > source.size
+        || endOffset - startOffset > CONVERSATION_RECORD_PROOF_MAX_BYTES) {
+        return undefined;
+    }
+    return hashRange(source.handle, startOffset, endOffset - startOffset);
+}
+
+const CONVERSATION_RECORD_PROOF_MAX_BYTES = 1024 * 1024 + 1;
+
 function hasStableFileIdentity(stat: fs.Stats): boolean {
     return Number.isFinite(stat.dev) && stat.dev > 0
         && Number.isFinite(stat.ino) && stat.ino > 0

--- a/src/aiSessions/conversation/toolCalls.ts
+++ b/src/aiSessions/conversation/toolCalls.ts
@@ -25,6 +25,11 @@ export class ToolCallTracker {
         return this.pending.size > 0;
     }
 
+    /** A provider-proved terminal boundary makes older pairings orphaned. */
+    discardPending(): void {
+        this.pending.clear();
+    }
+
     begin(
         interaction: ToolCallInteraction,
         key: string | undefined,

--- a/src/aiSessions/conversation/toolCalls.ts
+++ b/src/aiSessions/conversation/toolCalls.ts
@@ -21,6 +21,10 @@ interface ToolCallInteraction {
 export class ToolCallTracker {
     private readonly pending = new Map<string, ConversationToolCall>();
 
+    hasPending(): boolean {
+        return this.pending.size > 0;
+    }
+
     begin(
         interaction: ToolCallInteraction,
         key: string | undefined,

--- a/src/aiSessions/conversation/types.ts
+++ b/src/aiSessions/conversation/types.ts
@@ -439,6 +439,16 @@ export interface ConversationCacheDiagnostics {
     partial?: boolean;
 }
 
+/**
+ * A provider-proved record boundary from which its reducer can rebuild the
+ * following interactions without inheriting mutable state from earlier JSONL
+ * records. These stay host-local; offsets are never sent to the Webview.
+ */
+export interface ConversationHistoryRestartPoint {
+    offset: number;
+    interactionId: string;
+}
+
 export interface ConversationAbortSignal {
     readonly aborted: boolean;
     onAbort(listener: () => void): AiSessionDisposable;

--- a/src/aiSessions/conversation/types.ts
+++ b/src/aiSessions/conversation/types.ts
@@ -450,6 +450,16 @@ export interface ConversationHistoryRestartPoint {
     interactionId: string;
 }
 
+/** Sparse candidates atomically bound to the source snapshot that produced
+ * them. Consumers must not carry offsets across a different identity. */
+export interface ConversationHistoryRestartSnapshot {
+    sourceIdentity: string;
+    sourceSize: number;
+    sourceRevision: string;
+    reducerVersion: 1;
+    points: ConversationHistoryRestartPoint[];
+}
+
 export interface ConversationAbortSignal {
     readonly aborted: boolean;
     onAbort(listener: () => void): AiSessionDisposable;
@@ -519,10 +529,10 @@ export interface ConversationProviderAdapter extends AiSessionDisposable {
         request: ConversationPageRequest,
         signal?: ConversationAbortSignal
     ): Promise<ConversationPage>;
-    /** Host-local sparse restart candidates for local JSONL providers. */
+    /** Host-local sparse restart candidates bound to one source snapshot. */
     getHistoryRestartPoints?(
         sessionId: string
-    ): ConversationHistoryRestartPoint[];
+    ): ConversationHistoryRestartSnapshot | undefined;
     readSubagents?(
         sessionId: string,
         signal?: ConversationAbortSignal

--- a/src/aiSessions/conversation/types.ts
+++ b/src/aiSessions/conversation/types.ts
@@ -12,6 +12,7 @@ import type {
 export const CONVERSATION_LIMITS = Object.freeze({
     previewGraphemes: 160,
     maxOutlineInteractions: 2_000,
+    maxHistoryRestartPointIdLength: 256,
     maxPageInteractions: 20,
     maxPageBytes: 512 * 1024,
     maxSourceBytes: 64 * 1024 * 1024,
@@ -518,6 +519,10 @@ export interface ConversationProviderAdapter extends AiSessionDisposable {
         request: ConversationPageRequest,
         signal?: ConversationAbortSignal
     ): Promise<ConversationPage>;
+    /** Host-local sparse restart candidates for local JSONL providers. */
+    getHistoryRestartPoints?(
+        sessionId: string
+    ): ConversationHistoryRestartPoint[];
     readSubagents?(
         sessionId: string,
         signal?: ConversationAbortSignal

--- a/src/aiSessions/conversation/types.ts
+++ b/src/aiSessions/conversation/types.ts
@@ -532,7 +532,7 @@ export interface ConversationProviderAdapter extends AiSessionDisposable {
     /** Host-local sparse restart candidates bound to one source snapshot. */
     getHistoryRestartPoints?(
         sessionId: string
-    ): ConversationHistoryRestartSnapshot | undefined;
+    ): Promise<ConversationHistoryRestartSnapshot | undefined>;
     readSubagents?(
         sessionId: string,
         signal?: ConversationAbortSignal

--- a/tests/contract/aiSessions/claudeConversationAdapter.test.js
+++ b/tests/contract/aiSessions/claudeConversationAdapter.test.js
@@ -116,7 +116,7 @@ test('CONVERSATION-HISTORY-RESTART-POINT-001 Claude restart points replay their 
     const adapter = createAdapter(source);
     t.after(() => adapter.dispose());
     const full = await readWholeConversation(adapter);
-    const restartSnapshot = adapter.getHistoryRestartPoints(sessionId);
+    const restartSnapshot = await adapter.getHistoryRestartPoints(sessionId);
     assert.ok(restartSnapshot);
     const { points } = restartSnapshot;
     assert.ok(points.length >= 2);
@@ -201,7 +201,7 @@ test('CONVERSATION-HISTORY-RESTART-POINT-003 Claude seals an unsettled tool call
 
     await adapter.readOutline(sessionId);
     assert.deepEqual(
-        adapter.getHistoryRestartPoints(sessionId).points.map(point => point.interactionId),
+        (await adapter.getHistoryRestartPoints(sessionId)).points.map(point => point.interactionId),
         ['restart-before-tool', 'restart-after-tool']
     );
 });
@@ -212,14 +212,14 @@ test('CONVERSATION-HISTORY-RESTART-POINT-004 Claude keeps restart points across 
     t.after(() => adapter.dispose());
 
     await adapter.readOutline(sessionId);
-    const before = adapter.getHistoryRestartPoints(sessionId);
+    const before = await adapter.getHistoryRestartPoints(sessionId);
     assert.ok(before?.points.length);
     await fs.promises.appendFile(source.sourcePath, `${JSON.stringify({
         type: 'summary',
         summary: 'host-only status record',
     })}\n`);
     await adapter.readOutline(sessionId);
-    const after = adapter.getHistoryRestartPoints(sessionId);
+    const after = await adapter.getHistoryRestartPoints(sessionId);
     assert.ok(after);
     assert.notEqual(after.sourceIdentity, before.sourceIdentity);
     assert.deepEqual(after.points, before.points);
@@ -755,7 +755,7 @@ test('SESSION-AI-SESSION-CLAUDE-CONVERSATION-007 changes revision after a same-s
     assert.equal(rebuilt.interactions[0].userPreview, 'Bravo');
     assert.notEqual(rebuilt.sourceRevision, first.sourceRevision);
     assert.deepEqual(
-        adapter.getHistoryRestartPoints(sessionId).points,
+        (await adapter.getHistoryRestartPoints(sessionId)).points,
         [{
             offset: 0,
             interactionId: 'claude-rewritten-next',

--- a/tests/contract/aiSessions/claudeConversationAdapter.test.js
+++ b/tests/contract/aiSessions/claudeConversationAdapter.test.js
@@ -115,11 +115,13 @@ test('CONVERSATION-HISTORY-RESTART-POINT-001 Claude restart points replay their 
     const source = await createFixture(t);
     const adapter = createAdapter(source);
     t.after(() => adapter.dispose());
-    const full = await adapter.readOutline(sessionId);
+    const full = await readWholeConversation(adapter);
     const points = adapter.getHistoryRestartPoints(sessionId);
     assert.ok(points.length >= 2);
     const point = points[1];
-    const start = full.interactions.findIndex(item => item.id === point.interactionId);
+    const start = full.outline.interactions.findIndex(
+        item => item.id === point.interactionId
+    );
     assert.ok(start >= 0);
 
     const suffixPath = await restartSuffix(t, source.sourcePath, point.offset);
@@ -128,8 +130,68 @@ test('CONVERSATION-HISTORY-RESTART-POINT-001 Claude restart points replay their 
         sourcePath: suffixPath,
     });
     t.after(() => suffixAdapter.dispose());
-    const suffix = await suffixAdapter.readOutline(sessionId);
-    assert.deepEqual(suffix.interactions, full.interactions.slice(start));
+    const suffix = await readWholeConversation(suffixAdapter);
+    const suffixInteractionIds = new Set(
+        full.outline.interactions.slice(start).map(item => item.id)
+    );
+    assert.deepEqual(
+        suffix.outline.interactions,
+        full.outline.interactions.slice(start)
+    );
+    assert.deepEqual(
+        {
+            messages: suffix.page.messages,
+            interactionStates: suffix.page.interactionStates,
+        },
+        {
+            messages: full.page.messages.filter(message =>
+                suffixInteractionIds.has(message.interactionId)
+            ),
+            interactionStates: full.page.interactionStates.filter(state =>
+                suffixInteractionIds.has(state.interactionId)
+            ),
+        }
+    );
+});
+
+test('CONVERSATION-HISTORY-RESTART-POINT-003 Claude does not publish a point across an unsettled tool call', async t => {
+    const source = await createFixture(t);
+    await fs.promises.writeFile(source.sourcePath, [
+        {
+            type: 'user',
+            uuid: 'restart-before-tool',
+            message: { role: 'user', content: 'Start the tool call' },
+        },
+        {
+            type: 'assistant',
+            uuid: 'assistant-tool-call',
+            message: {
+                role: 'assistant',
+                content: [{
+                    type: 'tool_use',
+                    id: 'pending-tool',
+                    name: 'Bash',
+                    input: { command: 'pwd' },
+                }],
+            },
+        },
+        {
+            type: 'user',
+            uuid: 'restart-after-tool',
+            message: {
+                role: 'user',
+                content: 'Must replay from before the tool',
+            },
+        },
+    ].map(record => JSON.stringify(record)).join('\n') + '\n');
+    const adapter = createAdapter(source);
+    t.after(() => adapter.dispose());
+
+    await adapter.readOutline(sessionId);
+    assert.deepEqual(
+        adapter.getHistoryRestartPoints(sessionId).map(point => point.interactionId),
+        ['restart-before-tool']
+    );
 });
 
 test('SESSION-AI-SESSION-CONVERSATION-ADAPTER-001 Claude accepts canonical string content without exposing hidden records', async t => {
@@ -646,6 +708,7 @@ test('SESSION-AI-SESSION-CLAUDE-CONVERSATION-007 changes revision after a same-s
         source.sourcePath,
         `${JSON.stringify({
             ...firstRecord,
+            uuid: 'claude-rewritten-next',
             message: {
                 role: 'user',
                 content: [{ type: 'text', text: 'Bravo' }],
@@ -660,6 +723,13 @@ test('SESSION-AI-SESSION-CLAUDE-CONVERSATION-007 changes revision after a same-s
     const rebuilt = await adapter.readOutline(sessionId);
     assert.equal(rebuilt.interactions[0].userPreview, 'Bravo');
     assert.notEqual(rebuilt.sourceRevision, first.sourceRevision);
+    assert.deepEqual(
+        adapter.getHistoryRestartPoints(sessionId),
+        [{
+            offset: 0,
+            interactionId: 'claude-rewritten-next',
+        }]
+    );
 });
 
 test('CONVERSATION-TELEMETRY-001 Claude surfaces the latest assistant model and context window usage', async t => {

--- a/tests/contract/aiSessions/claudeConversationAdapter.test.js
+++ b/tests/contract/aiSessions/claudeConversationAdapter.test.js
@@ -61,6 +61,17 @@ async function readWholeConversation(adapter) {
     return { outline, page };
 }
 
+async function restartSuffix(t, sourcePath, offset) {
+    const bytes = await fs.promises.readFile(sourcePath);
+    const suffixPath = path.join(path.dirname(sourcePath), 'restart-suffix.jsonl');
+    await fs.promises.writeFile(suffixPath, Buffer.concat([
+        Buffer.alloc(offset, 0x0a),
+        bytes.subarray(offset),
+    ]));
+    t.after(() => fs.promises.rm(suffixPath, { force: true }));
+    return suffixPath;
+}
+
 test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 Claude returns one correlated outline and page snapshot', async t => {
     const source = await createFixture(t);
     const adapter = createAdapter(source);
@@ -98,6 +109,27 @@ test('SESSION-AI-SESSION-CONVERSATION-ADAPTER-001 Claude normalizes only top-lev
         ),
         false
     );
+});
+
+test('CONVERSATION-HISTORY-RESTART-POINT-001 Claude restart points replay their interaction suffix from empty state', async t => {
+    const source = await createFixture(t);
+    const adapter = createAdapter(source);
+    t.after(() => adapter.dispose());
+    const full = await adapter.readOutline(sessionId);
+    const points = adapter.getHistoryRestartPoints(sessionId);
+    assert.ok(points.length >= 2);
+    const point = points[1];
+    const start = full.interactions.findIndex(item => item.id === point.interactionId);
+    assert.ok(start >= 0);
+
+    const suffixPath = await restartSuffix(t, source.sourcePath, point.offset);
+    const suffixAdapter = createAdapter({
+        providerHome: source.providerHome,
+        sourcePath: suffixPath,
+    });
+    t.after(() => suffixAdapter.dispose());
+    const suffix = await suffixAdapter.readOutline(sessionId);
+    assert.deepEqual(suffix.interactions, full.interactions.slice(start));
 });
 
 test('SESSION-AI-SESSION-CONVERSATION-ADAPTER-001 Claude accepts canonical string content without exposing hidden records', async t => {

--- a/tests/contract/aiSessions/claudeConversationAdapter.test.js
+++ b/tests/contract/aiSessions/claudeConversationAdapter.test.js
@@ -116,45 +116,47 @@ test('CONVERSATION-HISTORY-RESTART-POINT-001 Claude restart points replay their 
     const adapter = createAdapter(source);
     t.after(() => adapter.dispose());
     const full = await readWholeConversation(adapter);
-    const points = adapter.getHistoryRestartPoints(sessionId);
+    const restartSnapshot = adapter.getHistoryRestartPoints(sessionId);
+    assert.ok(restartSnapshot);
+    const { points } = restartSnapshot;
     assert.ok(points.length >= 2);
-    const point = points[1];
-    const start = full.outline.interactions.findIndex(
-        item => item.id === point.interactionId
-    );
-    assert.ok(start >= 0);
-
-    const suffixPath = await restartSuffix(t, source.sourcePath, point.offset);
-    const suffixAdapter = createAdapter({
-        providerHome: source.providerHome,
-        sourcePath: suffixPath,
-    });
-    t.after(() => suffixAdapter.dispose());
-    const suffix = await readWholeConversation(suffixAdapter);
-    const suffixInteractionIds = new Set(
-        full.outline.interactions.slice(start).map(item => item.id)
-    );
-    assert.deepEqual(
-        suffix.outline.interactions,
-        full.outline.interactions.slice(start)
-    );
-    assert.deepEqual(
-        {
-            messages: suffix.page.messages,
-            interactionStates: suffix.page.interactionStates,
-        },
-        {
-            messages: full.page.messages.filter(message =>
-                suffixInteractionIds.has(message.interactionId)
-            ),
-            interactionStates: full.page.interactionStates.filter(state =>
-                suffixInteractionIds.has(state.interactionId)
-            ),
-        }
-    );
+    for (const point of points) {
+        const start = full.outline.interactions.findIndex(
+            item => item.id === point.interactionId
+        );
+        assert.ok(start >= 0);
+        const suffixPath = await restartSuffix(t, source.sourcePath, point.offset);
+        const suffixAdapter = createAdapter({
+            providerHome: source.providerHome,
+            sourcePath: suffixPath,
+        });
+        t.after(() => suffixAdapter.dispose());
+        const suffix = await readWholeConversation(suffixAdapter);
+        const suffixInteractionIds = new Set(
+            full.outline.interactions.slice(start).map(item => item.id)
+        );
+        assert.deepEqual(
+            suffix.outline.interactions,
+            full.outline.interactions.slice(start)
+        );
+        assert.deepEqual(
+            {
+                messages: suffix.page.messages,
+                interactionStates: suffix.page.interactionStates,
+            },
+            {
+                messages: full.page.messages.filter(message =>
+                    suffixInteractionIds.has(message.interactionId)
+                ),
+                interactionStates: full.page.interactionStates.filter(state =>
+                    suffixInteractionIds.has(state.interactionId)
+                ),
+            }
+        );
+    }
 });
 
-test('CONVERSATION-HISTORY-RESTART-POINT-003 Claude does not publish a point across an unsettled tool call', async t => {
+test('CONVERSATION-HISTORY-RESTART-POINT-003 Claude seals an unsettled tool call before a later turn', async t => {
     const source = await createFixture(t);
     await fs.promises.writeFile(source.sourcePath, [
         {
@@ -172,6 +174,16 @@ test('CONVERSATION-HISTORY-RESTART-POINT-003 Claude does not publish a point acr
                     id: 'pending-tool',
                     name: 'Bash',
                     input: { command: 'pwd' },
+                }, {
+                    type: 'tool_use',
+                    id: 'pending-question',
+                    name: 'AskUserQuestion',
+                    input: {
+                        questions: [{
+                            question: 'Continue?',
+                            options: [{ label: 'Yes' }],
+                        }],
+                    },
                 }],
             },
         },
@@ -189,9 +201,28 @@ test('CONVERSATION-HISTORY-RESTART-POINT-003 Claude does not publish a point acr
 
     await adapter.readOutline(sessionId);
     assert.deepEqual(
-        adapter.getHistoryRestartPoints(sessionId).map(point => point.interactionId),
-        ['restart-before-tool']
+        adapter.getHistoryRestartPoints(sessionId).points.map(point => point.interactionId),
+        ['restart-before-tool', 'restart-after-tool']
     );
+});
+
+test('CONVERSATION-HISTORY-RESTART-POINT-004 Claude keeps restart points across a verified non-turn append', async t => {
+    const source = await createFixture(t);
+    const adapter = createAdapter(source);
+    t.after(() => adapter.dispose());
+
+    await adapter.readOutline(sessionId);
+    const before = adapter.getHistoryRestartPoints(sessionId);
+    assert.ok(before?.points.length);
+    await fs.promises.appendFile(source.sourcePath, `${JSON.stringify({
+        type: 'summary',
+        summary: 'host-only status record',
+    })}\n`);
+    await adapter.readOutline(sessionId);
+    const after = adapter.getHistoryRestartPoints(sessionId);
+    assert.ok(after);
+    assert.notEqual(after.sourceIdentity, before.sourceIdentity);
+    assert.deepEqual(after.points, before.points);
 });
 
 test('SESSION-AI-SESSION-CONVERSATION-ADAPTER-001 Claude accepts canonical string content without exposing hidden records', async t => {
@@ -724,7 +755,7 @@ test('SESSION-AI-SESSION-CLAUDE-CONVERSATION-007 changes revision after a same-s
     assert.equal(rebuilt.interactions[0].userPreview, 'Bravo');
     assert.notEqual(rebuilt.sourceRevision, first.sourceRevision);
     assert.deepEqual(
-        adapter.getHistoryRestartPoints(sessionId),
+        adapter.getHistoryRestartPoints(sessionId).points,
         [{
             offset: 0,
             interactionId: 'claude-rewritten-next',

--- a/tests/contract/aiSessions/kimiConversationAdapter.test.js
+++ b/tests/contract/aiSessions/kimiConversationAdapter.test.js
@@ -59,6 +59,19 @@ async function readWholeConversation(adapter) {
     return { outline, page };
 }
 
+async function restartSuffix(t, sourcePath, offset) {
+    const bytes = await fs.promises.readFile(sourcePath);
+    const suffixPath = path.join(path.dirname(sourcePath), 'restart-suffix.jsonl');
+    // JSONL offsets are byte offsets. Newlines preserve each later record's
+    // original offset while remaining harmless malformed blank records.
+    await fs.promises.writeFile(suffixPath, Buffer.concat([
+        Buffer.alloc(offset, 0x0a),
+        bytes.subarray(offset),
+    ]));
+    t.after(() => fs.promises.rm(suffixPath, { force: true }));
+    return suffixPath;
+}
+
 test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 Kimi returns one correlated outline and page snapshot', async t => {
     const source = await createFixture(t);
     const adapter = createAdapter(source);
@@ -137,6 +150,27 @@ test('SESSION-AI-SESSION-CONVERSATION-ADAPTER-001 Kimi normalizes only visible t
         ]
     );
     assert.equal(new Set(appended.interactions.map(item => item.id)).size, 4);
+});
+
+test('CONVERSATION-HISTORY-RESTART-POINT-001 Kimi restart points replay their interaction suffix from empty state', async t => {
+    const source = await createFixture(t);
+    const adapter = createAdapter(source);
+    t.after(() => adapter.dispose());
+    const full = await adapter.readOutline(sessionId);
+    const points = adapter.getHistoryRestartPoints(sessionId);
+    assert.ok(points.length >= 2);
+    const point = points[1];
+    const start = full.interactions.findIndex(item => item.id === point.interactionId);
+    assert.ok(start >= 0);
+
+    const suffixPath = await restartSuffix(t, source.sourcePath, point.offset);
+    const suffixAdapter = createAdapter({
+        providerHome: source.providerHome,
+        sourcePath: suffixPath,
+    });
+    t.after(() => suffixAdapter.dispose());
+    const suffix = await suffixAdapter.readOutline(sessionId);
+    assert.deepEqual(suffix.interactions, full.interactions.slice(start));
 });
 
 test('SESSION-AI-SESSION-CONVERSATION-ADAPTER-001 Kimi merges streamed text deltas into one block across incremental loads', async t => {

--- a/tests/contract/aiSessions/kimiConversationAdapter.test.js
+++ b/tests/contract/aiSessions/kimiConversationAdapter.test.js
@@ -156,11 +156,13 @@ test('CONVERSATION-HISTORY-RESTART-POINT-001 Kimi restart points replay their in
     const source = await createFixture(t);
     const adapter = createAdapter(source);
     t.after(() => adapter.dispose());
-    const full = await adapter.readOutline(sessionId);
+    const full = await readWholeConversation(adapter);
     const points = adapter.getHistoryRestartPoints(sessionId);
     assert.ok(points.length >= 2);
     const point = points[1];
-    const start = full.interactions.findIndex(item => item.id === point.interactionId);
+    const start = full.outline.interactions.findIndex(
+        item => item.id === point.interactionId
+    );
     assert.ok(start >= 0);
 
     const suffixPath = await restartSuffix(t, source.sourcePath, point.offset);
@@ -169,8 +171,66 @@ test('CONVERSATION-HISTORY-RESTART-POINT-001 Kimi restart points replay their in
         sourcePath: suffixPath,
     });
     t.after(() => suffixAdapter.dispose());
-    const suffix = await suffixAdapter.readOutline(sessionId);
-    assert.deepEqual(suffix.interactions, full.interactions.slice(start));
+    const suffix = await readWholeConversation(suffixAdapter);
+    const suffixInteractionIds = new Set(
+        full.outline.interactions.slice(start).map(item => item.id)
+    );
+    assert.deepEqual(
+        suffix.outline.interactions,
+        full.outline.interactions.slice(start)
+    );
+    assert.deepEqual(
+        {
+            messages: suffix.page.messages,
+            interactionStates: suffix.page.interactionStates,
+        },
+        {
+            messages: full.page.messages.filter(message =>
+                suffixInteractionIds.has(message.interactionId)
+            ),
+            interactionStates: full.page.interactionStates.filter(state =>
+                suffixInteractionIds.has(state.interactionId)
+            ),
+        }
+    );
+});
+
+test('CONVERSATION-HISTORY-RESTART-POINT-003 Kimi does not publish a point across an unsettled tool call', async t => {
+    const source = await createFixture(t);
+    await fs.promises.writeFile(source.sourcePath, [
+        {
+            timestamp: 1000,
+            message: {
+                type: 'TurnBegin',
+                payload: { user_input: 'Start the tool call' },
+            },
+        },
+        {
+            timestamp: 1001,
+            message: {
+                type: 'ToolCall',
+                payload: {
+                    id: 'pending-tool',
+                    function: { name: 'Shell', arguments: '{"command":"pwd"}' },
+                },
+            },
+        },
+        {
+            timestamp: 1002,
+            message: {
+                type: 'TurnBegin',
+                payload: { user_input: 'Must replay from before the tool' },
+            },
+        },
+    ].map(record => JSON.stringify(record)).join('\n') + '\n');
+    const adapter = createAdapter(source);
+    t.after(() => adapter.dispose());
+
+    await adapter.readOutline(sessionId);
+    assert.deepEqual(
+        adapter.getHistoryRestartPoints(sessionId).map(point => point.offset),
+        [0]
+    );
 });
 
 test('SESSION-AI-SESSION-CONVERSATION-ADAPTER-001 Kimi merges streamed text deltas into one block across incremental loads', async t => {

--- a/tests/contract/aiSessions/kimiConversationAdapter.test.js
+++ b/tests/contract/aiSessions/kimiConversationAdapter.test.js
@@ -157,7 +157,7 @@ test('CONVERSATION-HISTORY-RESTART-POINT-001 Kimi restart points replay their in
     const adapter = createAdapter(source);
     t.after(() => adapter.dispose());
     const full = await readWholeConversation(adapter);
-    const restartSnapshot = adapter.getHistoryRestartPoints(sessionId);
+    const restartSnapshot = await adapter.getHistoryRestartPoints(sessionId);
     assert.ok(restartSnapshot);
     const { points } = restartSnapshot;
     assert.ok(points.length >= 2);
@@ -254,7 +254,7 @@ test('CONVERSATION-HISTORY-RESTART-POINT-003 Kimi seals an unsettled tool call b
     t.after(() => adapter.dispose());
 
     await adapter.readOutline(sessionId);
-    const points = adapter.getHistoryRestartPoints(sessionId).points;
+    const points = (await adapter.getHistoryRestartPoints(sessionId)).points;
     assert.equal(points.length, 2);
     assert.equal(points[0].offset, 0);
     assert.ok(points[1].offset > points[0].offset);
@@ -266,17 +266,64 @@ test('CONVERSATION-HISTORY-RESTART-POINT-004 Kimi keeps restart points across a 
     t.after(() => adapter.dispose());
 
     await adapter.readOutline(sessionId);
-    const before = adapter.getHistoryRestartPoints(sessionId);
+    const before = await adapter.getHistoryRestartPoints(sessionId);
     assert.ok(before?.points.length);
     await fs.promises.appendFile(source.sourcePath, `${JSON.stringify({
         timestamp: 9999,
         message: { type: 'StatusUpdate', payload: {} },
     })}\n`);
     await adapter.readOutline(sessionId);
-    const after = adapter.getHistoryRestartPoints(sessionId);
+    const after = await adapter.getHistoryRestartPoints(sessionId);
     assert.ok(after);
     assert.notEqual(after.sourceIdentity, before.sourceIdentity);
     assert.deepEqual(after.points, before.points);
+});
+
+test('CONVERSATION-HISTORY-RESTART-POINT-005 Kimi drops a rewritten middle-record point before an append promotion', async t => {
+    const source = await createFixture(t);
+    const filler = index => ({
+        timestamp: 1000 + index,
+        message: {
+            type: 'StatusUpdate',
+            payload: { filler: 'x'.repeat(2048) },
+        },
+    });
+    const records = [
+        {
+            timestamp: 1,
+            message: {
+                type: 'TurnBegin',
+                payload: { user_input: 'First restart point' },
+            },
+        },
+        ...Array.from({ length: 40 }, (_value, index) => filler(index)),
+        {
+            timestamp: 2,
+            message: {
+                type: 'TurnBegin',
+                payload: { user_input: 'Rewrite me' },
+            },
+        },
+        ...Array.from({ length: 40 }, (_value, index) => filler(index + 40)),
+    ];
+    const initial = `${records.map(record => JSON.stringify(record)).join('\n')}\n`;
+    assert.ok(Buffer.byteLength(initial) > 128 * 1024);
+    await fs.promises.writeFile(source.sourcePath, initial);
+    const adapter = createAdapter(source);
+    t.after(() => adapter.dispose());
+
+    await adapter.readOutline(sessionId);
+    const before = await adapter.getHistoryRestartPoints(sessionId);
+    assert.equal(before?.points.length, 2);
+    const rewritten = initial.replace('Rewrite me', 'Changed!!!');
+    assert.equal(Buffer.byteLength(rewritten), Buffer.byteLength(initial));
+    await fs.promises.writeFile(source.sourcePath, rewritten);
+    await fs.promises.appendFile(source.sourcePath, `${JSON.stringify(filler(99))}\n`);
+    await adapter.readOutline(sessionId);
+    const after = await adapter.getHistoryRestartPoints(sessionId);
+    assert.ok(after);
+    assert.notEqual(after.sourceIdentity, before.sourceIdentity);
+    assert.deepEqual(after.points, [before.points[0]]);
 });
 
 test('SESSION-AI-SESSION-CONVERSATION-ADAPTER-001 Kimi merges streamed text deltas into one block across incremental loads', async t => {

--- a/tests/contract/aiSessions/kimiConversationAdapter.test.js
+++ b/tests/contract/aiSessions/kimiConversationAdapter.test.js
@@ -157,45 +157,47 @@ test('CONVERSATION-HISTORY-RESTART-POINT-001 Kimi restart points replay their in
     const adapter = createAdapter(source);
     t.after(() => adapter.dispose());
     const full = await readWholeConversation(adapter);
-    const points = adapter.getHistoryRestartPoints(sessionId);
+    const restartSnapshot = adapter.getHistoryRestartPoints(sessionId);
+    assert.ok(restartSnapshot);
+    const { points } = restartSnapshot;
     assert.ok(points.length >= 2);
-    const point = points[1];
-    const start = full.outline.interactions.findIndex(
-        item => item.id === point.interactionId
-    );
-    assert.ok(start >= 0);
-
-    const suffixPath = await restartSuffix(t, source.sourcePath, point.offset);
-    const suffixAdapter = createAdapter({
-        providerHome: source.providerHome,
-        sourcePath: suffixPath,
-    });
-    t.after(() => suffixAdapter.dispose());
-    const suffix = await readWholeConversation(suffixAdapter);
-    const suffixInteractionIds = new Set(
-        full.outline.interactions.slice(start).map(item => item.id)
-    );
-    assert.deepEqual(
-        suffix.outline.interactions,
-        full.outline.interactions.slice(start)
-    );
-    assert.deepEqual(
-        {
-            messages: suffix.page.messages,
-            interactionStates: suffix.page.interactionStates,
-        },
-        {
-            messages: full.page.messages.filter(message =>
-                suffixInteractionIds.has(message.interactionId)
-            ),
-            interactionStates: full.page.interactionStates.filter(state =>
-                suffixInteractionIds.has(state.interactionId)
-            ),
-        }
-    );
+    for (const point of points) {
+        const start = full.outline.interactions.findIndex(
+            item => item.id === point.interactionId
+        );
+        assert.ok(start >= 0);
+        const suffixPath = await restartSuffix(t, source.sourcePath, point.offset);
+        const suffixAdapter = createAdapter({
+            providerHome: source.providerHome,
+            sourcePath: suffixPath,
+        });
+        t.after(() => suffixAdapter.dispose());
+        const suffix = await readWholeConversation(suffixAdapter);
+        const suffixInteractionIds = new Set(
+            full.outline.interactions.slice(start).map(item => item.id)
+        );
+        assert.deepEqual(
+            suffix.outline.interactions,
+            full.outline.interactions.slice(start)
+        );
+        assert.deepEqual(
+            {
+                messages: suffix.page.messages,
+                interactionStates: suffix.page.interactionStates,
+            },
+            {
+                messages: full.page.messages.filter(message =>
+                    suffixInteractionIds.has(message.interactionId)
+                ),
+                interactionStates: full.page.interactionStates.filter(state =>
+                    suffixInteractionIds.has(state.interactionId)
+                ),
+            }
+        );
+    }
 });
 
-test('CONVERSATION-HISTORY-RESTART-POINT-003 Kimi does not publish a point across an unsettled tool call', async t => {
+test('CONVERSATION-HISTORY-RESTART-POINT-003 Kimi seals an unsettled tool call before a later turn', async t => {
     const source = await createFixture(t);
     await fs.promises.writeFile(source.sourcePath, [
         {
@@ -216,6 +218,31 @@ test('CONVERSATION-HISTORY-RESTART-POINT-003 Kimi does not publish a point acros
             },
         },
         {
+            timestamp: 1001,
+            message: {
+                type: 'ToolCall',
+                payload: {
+                    id: 'pending-question',
+                    function: {
+                        name: 'AskUserQuestion',
+                        arguments: JSON.stringify({
+                            questions: [{ question: 'Continue?' }],
+                        }),
+                    },
+                },
+            },
+        },
+        {
+            timestamp: 1001,
+            message: {
+                type: 'ApprovalRequest',
+                payload: {
+                    id: 'pending-approval',
+                    tool_call_id: 'pending-tool',
+                },
+            },
+        },
+        {
             timestamp: 1002,
             message: {
                 type: 'TurnBegin',
@@ -227,10 +254,29 @@ test('CONVERSATION-HISTORY-RESTART-POINT-003 Kimi does not publish a point acros
     t.after(() => adapter.dispose());
 
     await adapter.readOutline(sessionId);
-    assert.deepEqual(
-        adapter.getHistoryRestartPoints(sessionId).map(point => point.offset),
-        [0]
-    );
+    const points = adapter.getHistoryRestartPoints(sessionId).points;
+    assert.equal(points.length, 2);
+    assert.equal(points[0].offset, 0);
+    assert.ok(points[1].offset > points[0].offset);
+});
+
+test('CONVERSATION-HISTORY-RESTART-POINT-004 Kimi keeps restart points across a verified non-turn append', async t => {
+    const source = await createFixture(t);
+    const adapter = createAdapter(source);
+    t.after(() => adapter.dispose());
+
+    await adapter.readOutline(sessionId);
+    const before = adapter.getHistoryRestartPoints(sessionId);
+    assert.ok(before?.points.length);
+    await fs.promises.appendFile(source.sourcePath, `${JSON.stringify({
+        timestamp: 9999,
+        message: { type: 'StatusUpdate', payload: {} },
+    })}\n`);
+    await adapter.readOutline(sessionId);
+    const after = adapter.getHistoryRestartPoints(sessionId);
+    assert.ok(after);
+    assert.notEqual(after.sourceIdentity, before.sourceIdentity);
+    assert.deepEqual(after.points, before.points);
 });
 
 test('SESSION-AI-SESSION-CONVERSATION-ADAPTER-001 Kimi merges streamed text deltas into one block across incremental loads', async t => {

--- a/tests/unit/aiSessions/conversationHistoryRestartPoints.test.js
+++ b/tests/unit/aiSessions/conversationHistoryRestartPoints.test.js
@@ -10,7 +10,7 @@ const {
 test('CONVERSATION-HISTORY-RESTART-POINT-002 bounds the in-memory restart discovery window', () => {
     const points = [];
     for (let index = 0;
-        index < CONVERSATION_LIMITS.maxOutlineInteractions + 2;
+        index < CONVERSATION_LIMITS.maxOutlineInteractions + 64;
         index++) {
         appendConversationHistoryRestartPoint(points, {
             offset: index,
@@ -19,9 +19,13 @@ test('CONVERSATION-HISTORY-RESTART-POINT-002 bounds the in-memory restart discov
     }
     assert.equal(points.length, CONVERSATION_LIMITS.maxOutlineInteractions);
     assert.deepEqual(points[0], {
-        offset: 2,
-        interactionId: 'interaction-2',
+        offset: 64,
+        interactionId: 'interaction-64',
     });
-    appendConversationHistoryRestartPoint(points, { offset: 2_001, interactionId: 'duplicate-offset' });
-    assert.equal(points.at(-1).interactionId, `interaction-${CONVERSATION_LIMITS.maxOutlineInteractions + 1}`);
+    appendConversationHistoryRestartPoint(points, {
+        offset: CONVERSATION_LIMITS.maxOutlineInteractions + 63,
+        interactionId: 'duplicate-offset',
+    });
+    assert.equal(points.at(-1).interactionId,
+        `interaction-${CONVERSATION_LIMITS.maxOutlineInteractions + 63}`);
 });

--- a/tests/unit/aiSessions/conversationHistoryRestartPoints.test.js
+++ b/tests/unit/aiSessions/conversationHistoryRestartPoints.test.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const { CONVERSATION_LIMITS } = require('../../../out/aiSessions/conversation/types');
+const {
+    appendConversationHistoryRestartPoint,
+} = require('../../../out/aiSessions/conversation/historyRestartPoints');
+
+test('CONVERSATION-HISTORY-RESTART-POINT-002 bounds the in-memory restart discovery window', () => {
+    const points = [];
+    for (let index = 0;
+        index < CONVERSATION_LIMITS.maxOutlineInteractions + 2;
+        index++) {
+        appendConversationHistoryRestartPoint(points, {
+            offset: index,
+            interactionId: `interaction-${index}`,
+        });
+    }
+    assert.equal(points.length, CONVERSATION_LIMITS.maxOutlineInteractions);
+    assert.deepEqual(points[0], {
+        offset: 2,
+        interactionId: 'interaction-2',
+    });
+    appendConversationHistoryRestartPoint(points, { offset: 2_001, interactionId: 'duplicate-offset' });
+    assert.equal(points.at(-1).interactionId, `interaction-${CONVERSATION_LIMITS.maxOutlineInteractions + 1}`);
+});

--- a/tests/unit/tooling/ciContracts.test.js
+++ b/tests/unit/tooling/ciContracts.test.js
@@ -76,6 +76,17 @@ test('RELEASE-VSIX-PACKAGING-001 requires PR metadata validation before dependen
     );
 });
 
+test('RELEASE-VSIX-PACKAGING-001 requires static repository checks before dependency installation', () => {
+    const noStaticPreflightWorkflow = verifyWorkflow.replace(
+        /\n  static-preflight:[\s\S]*?\n  quality-linux:/,
+        '\n  quality-linux:'
+    );
+    assert.throws(
+        () => validateVerifyWorkflow(noStaticPreflightWorkflow),
+        /must define static-preflight/
+    );
+});
+
 test('RUNTIME-REAL-TMUX-CI-GATE-001 requires a stable real-tmux smoke job', () => {
     const missingTmuxJobWorkflow = verifyWorkflow.replace(/\n  tmux-smoke-linux:[\s\S]*$/, '');
     assert.throws(
@@ -136,8 +147,8 @@ test('RELEASE-VSIX-PACKAGING-001 rejects workflow requirements that appear only 
 
 test('RELEASE-VSIX-PACKAGING-001 rejects a Linux gate assigned to the Windows runner', () => {
     const wrongRunnerWorkflow = verifyWorkflow.replace(
-        '  quality-linux:\n    name: quality-linux\n    needs: pr-metadata\n    runs-on: ubuntu-latest',
-        '  quality-linux:\n    name: quality-linux\n    needs: pr-metadata\n    runs-on: windows-latest'
+        '  quality-linux:\n    name: quality-linux\n    needs: [pr-metadata, static-preflight]\n    runs-on: ubuntu-latest',
+        '  quality-linux:\n    name: quality-linux\n    needs: [pr-metadata, static-preflight]\n    runs-on: windows-latest'
     );
 
     assert.throws(

--- a/tests/unit/tooling/ciContracts.test.js
+++ b/tests/unit/tooling/ciContracts.test.js
@@ -67,6 +67,15 @@ test('RELEASE-VSIX-PACKAGING-001 accepts the unquoted GitHub Actions on key', ()
     assert.doesNotThrow(() => validateVerifyWorkflow(verifyWorkflow));
 });
 
+test('RELEASE-VSIX-PACKAGING-001 requires PR metadata validation before dependency installation', () => {
+    const noPreflightWorkflow = verifyWorkflow.replace(/\n  pr-metadata:[\s\S]*?\n  quality-linux:/,
+        '\n  quality-linux:');
+    assert.throws(
+        () => validateVerifyWorkflow(noPreflightWorkflow),
+        /must define pr-metadata/
+    );
+});
+
 test('RUNTIME-REAL-TMUX-CI-GATE-001 requires a stable real-tmux smoke job', () => {
     const missingTmuxJobWorkflow = verifyWorkflow.replace(/\n  tmux-smoke-linux:[\s\S]*$/, '');
     assert.throws(
@@ -127,8 +136,8 @@ test('RELEASE-VSIX-PACKAGING-001 rejects workflow requirements that appear only 
 
 test('RELEASE-VSIX-PACKAGING-001 rejects a Linux gate assigned to the Windows runner', () => {
     const wrongRunnerWorkflow = verifyWorkflow.replace(
-        'runs-on: ubuntu-latest',
-        'runs-on: windows-latest'
+        '  quality-linux:\n    name: quality-linux\n    needs: pr-metadata\n    runs-on: ubuntu-latest',
+        '  quality-linux:\n    name: quality-linux\n    needs: pr-metadata\n    runs-on: windows-latest'
     );
 
     assert.throws(


### PR DESCRIPTION
## Summary

- discover provider-owned Kimi and Claude restart points in the live JSONL reducers
- bind restart candidates to an exact source snapshot and verify their raw JSONL records before an index consumer can use them
- preserve verified append candidates, while sealing interrupted tool/question/approval associations
- run PR metadata and checkout-only static validation before dependency installation and long quality checks
- prove suffix replay preserves complete messages and interaction state

## Verification

- npm run test-compile
- node --test tests/unit/tooling/ciContracts.test.js
- node --test tests/unit/aiSessions/conversationJsonlReader.test.js tests/unit/aiSessions/conversationHistoryRestartPoints.test.js tests/contract/aiSessions/kimiConversationAdapter.test.js tests/contract/aiSessions/claudeConversationAdapter.test.js
- npm run test:conversation-performance
- npm run test:behavior-contracts
- git diff --check

## Skill harvest

No skill change: the worktree, verification, review, and publishing instructions already covered this task; no reusable workflow gap was found.

## Owner approvals

```
approve 7465f21c8c0ed15bbc9bb091465a90810f780c33
```