### PR TITLE
feat: page indexed conversation history

### DIFF
--- a/src/aiSessions/conversation/claudeAdapter.ts
+++ b/src/aiSessions/conversation/claudeAdapter.ts
@@ -141,6 +141,7 @@ interface LoadedConversation {
         restartRecordEndOffset?: number;
         restartRecordDigest?: string;
         restartSegmentDigest?: string;
+        completeSegmentDigest?: string;
         complete: boolean;
         blocked?: boolean;
     };
@@ -429,7 +430,30 @@ async function continuesHistoryIndex(
         }
         expectedOffset = segment.endOffset;
     }
-    return expectedOffset === previous.restartOffset;
+    return expectedOffset === (previous.complete
+        ? previous.sourceSize
+        : previous.restartOffset);
+}
+
+/** See the Kimi adapter for why this is a bounded scheduling suppression. */
+async function keepsSaturatedHistoryIndex(
+    source: OpenConversationSource,
+    previous: ConversationHistoryIndexState,
+    signal?: ConversationAbortSignal
+): Promise<boolean> {
+    if (!previous.saturated || signal?.aborted
+        || source.size < previous.sourceSize
+        || historyIndexSourceEpoch(source) !== previous.sourceEpoch
+        || source.portableFirstHash !== previous.sourceFirstHash) {
+        return false;
+    }
+    const edgeBytes = Math.min(64 * 1024, previous.sourceSize);
+    return await digestConversationSourceRange(
+        source,
+        Math.max(0, previous.sourceSize - edgeBytes),
+        previous.sourceSize,
+        signal
+    ) === previous.sourceLastHash;
 }
 
 export class ClaudeConversationAdapter implements ConversationProviderAdapter {
@@ -725,6 +749,9 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
             if (source.identity !== entry.source.identity) {
                 return undefined;
             }
+            if (indexed && await keepsSaturatedHistoryIndex(source, indexed, signal)) {
+                return undefined;
+            }
             const points = await verifyConversationHistoryRestartPoints(
                 source,
                 entry.restartPoints,
@@ -791,6 +818,9 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
                 ...(loaded.historySlice.restartSegmentDigest === undefined ? {} : {
                     restartSegmentDigest: loaded.historySlice.restartSegmentDigest,
                 }),
+                ...(loaded.historySlice.completeSegmentDigest === undefined ? {} : {
+                    completeSegmentDigest: loaded.historySlice.completeSegmentDigest,
+                }),
                 interactions: cloneInteractions(loaded.interactions),
                 complete: loaded.historySlice.complete,
                 ...(loaded.historySlice.blocked ? { blocked: true } : {}),
@@ -808,8 +838,11 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
         sessionId: string,
         loaded: LoadedConversation
     ): LoadedConversation {
-        const indexed = this.historyIndex.state(sessionId);
-        if (!indexed?.complete || indexed.sourceRevision !== loaded.sourceRevision) {
+        const interactions = this.historyIndex.completedInteractions(
+            sessionId,
+            loaded.sourceRevision
+        );
+        if (!interactions) {
             return loaded;
         }
         // The completed index is an independent, continuous paging source.
@@ -817,7 +850,7 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
         // page boundary and can be either a gap or a duplicate.
         return {
             ...loaded,
-            interactions: indexed.interactions,
+            interactions,
             partial: false,
         };
     }
@@ -828,6 +861,10 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
         settled = false
     ): void {
         if (this.disposed) {
+            return;
+        }
+        const indexed = this.historyIndex.status(sessionId);
+        if (indexed?.saturated && indexed.sourceRevision === loaded.sourceRevision) {
             return;
         }
         const running = this.historyIndexTasks.get(sessionId);
@@ -852,6 +889,19 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
             this.scheduleHistoryIndex(sessionId, loaded);
             return;
         }
+        // Indexing is explicitly low priority. The most recently viewed
+        // session wins; never let A→B→C create three concurrent 4 MiB scans.
+        this.historyIndexTasks.forEach((task, activeSessionId) => {
+            if (activeSessionId !== sessionId) {
+                task.controller.abort();
+                this.pendingHistoryIndexes.delete(activeSessionId);
+                const scheduled = this.historyIndexStartTimers.get(activeSessionId);
+                if (scheduled?.timer !== undefined) {
+                    this.options.clearTimeout(scheduled.timer);
+                }
+                this.historyIndexStartTimers.delete(activeSessionId);
+            }
+        });
         const controller = new ConversationAbortController();
         this.historyIndexTasks.set(sessionId, {
             controller,
@@ -1020,6 +1070,7 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
                 interactionId: string;
                 recordEndOffset: number;
                 recordDigest: string;
+                segmentDigest: string;
             } | undefined;
             const historySliceEndOffset = historySlice
                 ? Math.min(
@@ -1046,6 +1097,7 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
                         interactionId: point.interactionId,
                         recordEndOffset: point.recordEndOffset,
                         recordDigest: point.recordDigest,
+                        segmentDigest: point.prefixDigest,
                     };
                 }
             };
@@ -1182,8 +1234,9 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
                             <= CONVERSATION_LIMITS.maxHistoryRestartPointIdLength) {
                         addRestartPoint({
                             offset: record.offset,
-                            recordEndOffset: record.endOffset,
-                            recordDigest: record.recordDigest,
+                            recordEndOffset: record.proofEndOffset,
+                            recordDigest: record.proofDigest,
+                            prefixDigest: record.prefixDigest,
                             interactionId: event.uuid,
                         });
                     }
@@ -1303,7 +1356,10 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
                     ...(historySlice ? {
                         endOffset: Math.min(
                             source.size,
-                            startOffset + CONVERSATION_LIMITS.historyIndexSliceBytes
+                            // Target a 4 MiB segment, but permit one bounded
+                            // 4 MiB extension to reach a reducer-safe turn.
+                            startOffset
+                                + CONVERSATION_LIMITS.historyIndexSliceBytes * 2
                         ),
                         collectRecords: false,
                     } : {}),
@@ -1338,24 +1394,6 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
             }
             if (historySlice) {
                 if (historyBoundary) {
-                    const restartSegmentDigest = await digestConversationSourceSegment(
-                        source,
-                        historySlice.startOffset,
-                        historyBoundary.offset,
-                        signal
-                    );
-                    if (!restartSegmentDigest) {
-                        return {
-                            interactions: [],
-                            sourceRevision: historySlice.sourceRevision,
-                            partial: false,
-                            telemetryModel,
-                            telemetryContext,
-                            telemetryCwd,
-                            telemetryGitBranch,
-                            historySlice: { complete: false, blocked: true },
-                        };
-                    }
                     return {
                         interactions: interactions.slice(
                             0,
@@ -1372,7 +1410,7 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
                             restartInteractionId: historyBoundary.interactionId,
                             restartRecordEndOffset: historyBoundary.recordEndOffset,
                             restartRecordDigest: historyBoundary.recordDigest,
-                            restartSegmentDigest,
+                            restartSegmentDigest: historyBoundary.segmentDigest,
                             complete: false,
                         },
                     };
@@ -1398,7 +1436,10 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
                     telemetryContext,
                     telemetryCwd,
                     telemetryGitBranch,
-                    historySlice: { complete: result.nextOffset >= source.size },
+                    historySlice: {
+                        complete: result.nextOffset >= source.size,
+                        completeSegmentDigest: result.consumedDigest,
+                    },
                 };
             }
             const appendInteractionIndex = openInteractionIndex;

--- a/src/aiSessions/conversation/claudeAdapter.ts
+++ b/src/aiSessions/conversation/claudeAdapter.ts
@@ -36,10 +36,13 @@ import {
 import { synthesizeFragmentDiff } from './diffs';
 import {
     CONVERSATION_LIMITS,
+    ConversationAbortController,
     ConversationAbortSignal,
     ConversationCacheDiagnostics,
     ConversationError,
     ConversationFileDiff,
+    ConversationHistoryIndexSlice,
+    ConversationHistoryIndexSliceRequest,
     ConversationHistoryRestartSnapshot,
     ConversationInteraction,
     ConversationOutline,
@@ -53,6 +56,12 @@ import {
     ConversationTelemetry,
 } from './types';
 import {
+    ConversationHistoryIndex,
+    ConversationHistoryIndexState,
+} from './historyIndex';
+import {
+    digestConversationSourceRange,
+    digestConversationSourceSegment,
     openValidatedConversationSource,
     OpenConversationSource,
 } from './source';
@@ -71,6 +80,7 @@ import type {
 } from './worktreeResolver';
 
 type TimerHandle = unknown;
+const HISTORY_INDEX_SETTLE_MS = 250;
 
 export interface ClaudeConversationAdapterOptions {
     resolveSource(
@@ -125,6 +135,15 @@ interface LoadedConversation {
     telemetryContext?: ConversationContextUsage;
     telemetryCwd?: string;
     telemetryGitBranch?: string;
+    historySlice?: {
+        nextOffset?: number;
+        restartInteractionId?: string;
+        restartRecordEndOffset?: number;
+        restartRecordDigest?: string;
+        restartSegmentDigest?: string;
+        complete: boolean;
+        blocked?: boolean;
+    };
 }
 
 function asRecord(value: unknown): Record<string, any> | undefined {
@@ -358,8 +377,72 @@ function settleClaudeQuestion(
     block.outcome = 'answered';
 }
 
+function historyIndexSourceEpoch(source: OpenConversationSource): string {
+    return source.device !== undefined && source.inode !== undefined
+        && source.birthtimeMs !== undefined
+        ? `inode:${source.canonicalPath}:${source.device}:${source.inode}:${source.birthtimeMs}`
+        : `portable:${source.canonicalPath}`;
+}
+
+async function continuesHistoryIndex(
+    source: OpenConversationSource,
+    previous: ConversationHistoryIndexState,
+    signal?: ConversationAbortSignal
+): Promise<boolean> {
+    if (signal?.aborted || source.size < previous.sourceSize
+        || historyIndexSourceEpoch(source) !== previous.sourceEpoch
+        || source.portableFirstHash !== previous.sourceFirstHash
+        || previous.restartInteractionId === undefined
+        || previous.restartRecordEndOffset === undefined
+        || previous.restartRecordDigest === undefined) {
+        return false;
+    }
+    const edgeBytes = Math.min(64 * 1024, previous.sourceSize);
+    const oldLastHash = await digestConversationSourceRange(
+        source,
+        Math.max(0, previous.sourceSize - edgeBytes),
+        previous.sourceSize,
+        signal
+    );
+    if (oldLastHash !== previous.sourceLastHash) {
+        return false;
+    }
+    if (await digestConversationSourceRange(
+        source,
+        previous.restartOffset,
+        previous.restartRecordEndOffset,
+        signal
+    ) !== previous.restartRecordDigest) {
+        return false;
+    }
+    let expectedOffset = 0;
+    for (const segment of previous.prefixSegments) {
+        if (signal?.aborted || segment.startOffset !== expectedOffset
+            || segment.endOffset <= segment.startOffset
+            || await digestConversationSourceSegment(
+                source,
+                segment.startOffset,
+                segment.endOffset,
+                signal
+            ) !== segment.digest) {
+            return false;
+        }
+        expectedOffset = segment.endOffset;
+    }
+    return expectedOffset === previous.restartOffset;
+}
+
 export class ClaudeConversationAdapter implements ConversationProviderAdapter {
     private readonly cache: ConversationIndexCache<ClaudeConversationIndex>;
+    private readonly historyIndex = new ConversationHistoryIndex();
+    private readonly historyIndexTasks = new Map<string, {
+        controller: ConversationAbortController;
+        sourceRevision: string;
+    }>();
+    private readonly pendingHistoryIndexes = new Map<string, LoadedConversation>();
+    private readonly historyIndexStartTimers = new Map<string, {
+        timer?: TimerHandle;
+    }>();
     private readonly subscriptions = new Map<string, Set<() => void>>();
     private readonly revisionCounters = new Map<string, number>();
     private readonly loadQueues = new Map<string, Promise<void>>();
@@ -376,7 +459,8 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
         preferredInteractionId?: string,
         signal?: ConversationAbortSignal
     ): Promise<ConversationSnapshot> {
-        const loaded = await this.load(sessionId, signal);
+        const loaded = this.withCompletedHistory(sessionId, await this.load(sessionId, signal));
+        this.startHistoryIndex(sessionId, loaded);
         const outline = buildConversationOutline(
             'claude',
             sessionId,
@@ -406,7 +490,8 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
         sessionId: string,
         signal?: ConversationAbortSignal
     ): Promise<ConversationOutline> {
-        const loaded = await this.load(sessionId, signal);
+        const loaded = this.withCompletedHistory(sessionId, await this.load(sessionId, signal));
+        this.startHistoryIndex(sessionId, loaded);
         return buildConversationOutline(
             'claude',
             sessionId,
@@ -420,7 +505,11 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
         request: ConversationPageRequest,
         signal?: ConversationAbortSignal
     ): Promise<ConversationPage> {
-        const loaded = await this.load(request.sessionId, signal);
+        const loaded = this.withCompletedHistory(
+            request.sessionId,
+            await this.load(request.sessionId, signal)
+        );
+        this.startHistoryIndex(request.sessionId, loaded);
         return buildConversationPage(
             loaded.interactions,
             { ...request, provider: 'claude' },
@@ -569,6 +658,15 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
             return;
         }
         this.disposed = true;
+        this.historyIndexTasks.forEach(task => task.controller.abort());
+        this.historyIndexTasks.clear();
+        this.pendingHistoryIndexes.clear();
+        this.historyIndexStartTimers.forEach(scheduled => {
+            if (scheduled.timer !== undefined) {
+                this.options.clearTimeout(scheduled.timer);
+            }
+        });
+        this.historyIndexStartTimers.clear();
         if (this.invalidationTimer !== undefined) {
             this.options.clearTimeout(this.invalidationTimer);
             this.invalidationTimer = undefined;
@@ -599,14 +697,16 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
 
     /** Provider-owned candidates for the persistent history indexer. */
     async getHistoryRestartPoints(
-        sessionId: string
+        sessionId: string,
+        indexed = this.historyIndex.state(sessionId),
+        signal?: ConversationAbortSignal
     ): Promise<ConversationHistoryRestartSnapshot | undefined> {
         const entry = this.cache.get(sessionId);
         const split = splitSubagentSessionId(sessionId);
         const candidate = entry && (!split.subagentId || isSubagentId(split.subagentId))
             ? this.options.resolveSource(split.sessionId)
             : null;
-        if (!entry || !candidate) {
+        if (!entry || !candidate || signal?.aborted) {
             return undefined;
         }
         const source = await openValidatedConversationSource(split.subagentId
@@ -627,13 +727,27 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
             }
             const points = await verifyConversationHistoryRestartPoints(
                 source,
-                entry.restartPoints
+                entry.restartPoints,
+                signal
             );
-            return {
+            const continuationOf = indexed
+                && await continuesHistoryIndex(source, indexed, signal)
+                ? {
+                    sourceIdentity: indexed.sourceIdentity,
+                    sourceSize: indexed.sourceSize,
+                    sourceRevision: indexed.sourceRevision,
+                    reducerVersion: indexed.reducerVersion,
+                }
+                : undefined;
+            return signal?.aborted ? undefined : {
                 sourceIdentity: source.identity,
                 sourceSize: source.size,
                 sourceRevision: `r${entry.revision}`,
                 reducerVersion: 1,
+                sourceEpoch: historyIndexSourceEpoch(source),
+                sourceFirstHash: source.portableFirstHash || '',
+                sourceLastHash: source.portableLastHash || '',
+                ...(continuationOf ? { continuationOf } : {}),
                 points: points.map(point => ({
                     offset: point.offset,
                     interactionId: point.interactionId,
@@ -642,6 +756,171 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
         } finally {
             await source.handle.close().catch(() => undefined);
         }
+    }
+
+    async readHistoryIndexSlice(
+        sessionId: string,
+        request: ConversationHistoryIndexSliceRequest,
+        signal?: ConversationAbortSignal
+    ): Promise<ConversationHistoryIndexSlice | undefined> {
+        try {
+            // This replay owns only staged reducer state. Do not let it sit
+            // in front of authoritative foreground reads in loadQueues.
+            const loaded = await this.loadExclusive(sessionId, signal, request);
+            if (!loaded.historySlice) {
+                return undefined;
+            }
+            return {
+                sourceIdentity: request.sourceIdentity,
+                sourceSize: request.sourceSize,
+                sourceRevision: request.sourceRevision,
+                reducerVersion: request.reducerVersion,
+                startOffset: request.startOffset,
+                ...(loaded.historySlice.nextOffset === undefined ? {} : {
+                    nextOffset: loaded.historySlice.nextOffset,
+                }),
+                ...(loaded.historySlice.restartInteractionId === undefined ? {} : {
+                    restartInteractionId: loaded.historySlice.restartInteractionId,
+                }),
+                ...(loaded.historySlice.restartRecordEndOffset === undefined ? {} : {
+                    restartRecordEndOffset: loaded.historySlice.restartRecordEndOffset,
+                }),
+                ...(loaded.historySlice.restartRecordDigest === undefined ? {} : {
+                    restartRecordDigest: loaded.historySlice.restartRecordDigest,
+                }),
+                ...(loaded.historySlice.restartSegmentDigest === undefined ? {} : {
+                    restartSegmentDigest: loaded.historySlice.restartSegmentDigest,
+                }),
+                interactions: cloneInteractions(loaded.interactions),
+                complete: loaded.historySlice.complete,
+                ...(loaded.historySlice.blocked ? { blocked: true } : {}),
+            };
+        } catch (error) {
+            if (error instanceof ConversationError
+                && error.code === 'staleRevision') {
+                return undefined;
+            }
+            throw error;
+        }
+    }
+
+    private withCompletedHistory(
+        sessionId: string,
+        loaded: LoadedConversation
+    ): LoadedConversation {
+        const indexed = this.historyIndex.state(sessionId);
+        if (!indexed?.complete || indexed.sourceRevision !== loaded.sourceRevision) {
+            return loaded;
+        }
+        // The completed index is an independent, continuous paging source.
+        // Never join it to the 64 MiB foreground tail: their seam is not a
+        // page boundary and can be either a gap or a duplicate.
+        return {
+            ...loaded,
+            interactions: indexed.interactions,
+            partial: false,
+        };
+    }
+
+    private startHistoryIndex(
+        sessionId: string,
+        loaded: LoadedConversation,
+        settled = false
+    ): void {
+        if (this.disposed) {
+            return;
+        }
+        const running = this.historyIndexTasks.get(sessionId);
+        if (!loaded.partial) {
+            this.pendingHistoryIndexes.delete(sessionId);
+            const scheduled = this.historyIndexStartTimers.get(sessionId);
+            if (scheduled?.timer !== undefined) {
+                this.options.clearTimeout(scheduled.timer);
+            }
+            this.historyIndexStartTimers.delete(sessionId);
+            running?.controller.abort();
+            return;
+        }
+        if (running) {
+            if (running.sourceRevision !== loaded.sourceRevision) {
+                this.pendingHistoryIndexes.set(sessionId, loaded);
+                running.controller.abort();
+            }
+            return;
+        }
+        if (!settled) {
+            this.scheduleHistoryIndex(sessionId, loaded);
+            return;
+        }
+        const controller = new ConversationAbortController();
+        this.historyIndexTasks.set(sessionId, {
+            controller,
+            sourceRevision: loaded.sourceRevision,
+        });
+        void (async () => {
+            try {
+                const source = await this.getHistoryRestartPoints(
+                    sessionId,
+                    this.historyIndex.state(sessionId),
+                    controller.signal
+                );
+                if (!source || controller.signal.aborted) {
+                    return;
+                }
+                for (;;) {
+                    const state = await this.historyIndex.advance(
+                        sessionId,
+                        source,
+                        request => this.readHistoryIndexSlice(
+                            sessionId,
+                            request,
+                            controller.signal
+                        ),
+                        controller.signal
+                    );
+                    if (!state || controller.signal.aborted || state.complete
+                        || state.saturated || state.blocked) {
+                        if (state?.complete && !controller.signal.aborted) {
+                            Array.from(this.subscriptions.get(sessionId) || [])
+                                .forEach(callback => callback());
+                        }
+                        return;
+                    }
+                    await new Promise<void>(resolve => setImmediate(resolve));
+                }
+            } finally {
+                if (this.historyIndexTasks.get(sessionId)?.controller === controller) {
+                    this.historyIndexTasks.delete(sessionId);
+                    const pending = this.pendingHistoryIndexes.get(sessionId);
+                    this.pendingHistoryIndexes.delete(sessionId);
+                    if (pending) {
+                        this.startHistoryIndex(sessionId, pending);
+                    }
+                }
+            }
+        })().catch(() => undefined);
+    }
+
+    /** Coalesce streaming appends before revalidating a potentially large prefix. */
+    private scheduleHistoryIndex(sessionId: string, loaded: LoadedConversation): void {
+        this.pendingHistoryIndexes.set(sessionId, loaded);
+        const previous = this.historyIndexStartTimers.get(sessionId);
+        if (previous?.timer !== undefined) {
+            this.options.clearTimeout(previous.timer);
+        }
+        const scheduled: { timer?: TimerHandle } = {};
+        this.historyIndexStartTimers.set(sessionId, scheduled);
+        scheduled.timer = this.options.setTimeout(() => {
+            if (this.historyIndexStartTimers.get(sessionId) !== scheduled) {
+                return;
+            }
+            this.historyIndexStartTimers.delete(sessionId);
+            const pending = this.pendingHistoryIndexes.get(sessionId);
+            this.pendingHistoryIndexes.delete(sessionId);
+            if (pending) {
+                this.startHistoryIndex(sessionId, pending, true);
+            }
+        }, HISTORY_INDEX_SETTLE_MS);
     }
 
     private load(
@@ -668,7 +947,8 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
 
     private async loadExclusive(
         sessionId: string,
-        signal?: ConversationAbortSignal
+        signal?: ConversationAbortSignal,
+        historySlice?: ConversationHistoryIndexSliceRequest
     ): Promise<LoadedConversation> {
         if (this.disposed) {
             throw new ConversationError('unavailable', 'missingSource');
@@ -698,6 +978,17 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
         }
         const isSubagentTranscript = Boolean(split.subagentId);
         const previous = this.cache.get(sessionId);
+        if (historySlice && (!previous
+            || historySlice.reducerVersion !== 1
+            || historySlice.sourceIdentity !== source.identity
+            || historySlice.sourceSize !== source.size
+            || historySlice.sourceRevision !== `r${previous.revision}`
+            || !Number.isSafeInteger(historySlice.startOffset)
+            || historySlice.startOffset < 0
+            || historySlice.startOffset >= source.size)) {
+            await source.handle.close().catch(() => undefined);
+            throw new ConversationError('staleRevision');
+        }
         let interactions: ConversationInteraction[] = [];
         let openInteractionIndex: number | undefined;
         let timeoutOpenInteractionIndex: number | undefined;
@@ -706,21 +997,37 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
         let telemetryCwd: string | undefined;
         let telemetryGitBranch: string | undefined;
         try {
-            const startOffset = await getConversationReadStart(
-                source,
-                previous && {
-                    source: previous.source,
-                    nextOffset: previous.nextOffset,
-                }
-            );
+            const startOffset = historySlice
+                ? historySlice.startOffset
+                : await getConversationReadStart(
+                    source,
+                    previous && {
+                        source: previous.source,
+                        nextOffset: previous.nextOffset,
+                    }
+                );
             const continuing = Boolean(previous)
-                && startOffset === previous.nextOffset;
+                && !historySlice && startOffset === previous.nextOffset;
             // See Kimi's equivalent guard. A continuation must also prove
             // each old physical record before its offset joins this source
             // snapshot.
             let restartPoints: CachedConversationHistoryRestartPoint[] = continuing
                 ? previous.restartPoints
                 : [];
+            let historyBoundary: {
+                offset: number;
+                interactionCount: number;
+                interactionId: string;
+                recordEndOffset: number;
+                recordDigest: string;
+            } | undefined;
+            const historySliceEndOffset = historySlice
+                ? Math.min(
+                    source.size,
+                    historySlice.startOffset
+                        + CONVERSATION_LIMITS.historyIndexSliceBytes
+                )
+                : 0;
             let ownsRestartPoints = !continuing;
             const addRestartPoint = (
                 point: CachedConversationHistoryRestartPoint
@@ -730,6 +1037,17 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
                     ownsRestartPoints = true;
                 }
                 appendConversationHistoryRestartPoint(restartPoints, point);
+                if (historySlice
+                    && point.offset > historySlice.startOffset
+                    && interactions.length > 0) {
+                    historyBoundary = {
+                        offset: point.offset,
+                        interactionCount: interactions.length,
+                        interactionId: point.interactionId,
+                        recordEndOffset: point.recordEndOffset,
+                        recordDigest: point.recordDigest,
+                    };
+                }
             };
             if (continuing) {
                 interactions = cloneInteractions(previous.interactions);
@@ -765,7 +1083,7 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
                     interactions[openInteractionIndex].completedAt = value;
                 }
             };
-            const normalizeRecord = (record: ConversationJsonlRecord): void => {
+            const normalizeRecord = (record: ConversationJsonlRecord): boolean | void => {
                 const event = asRecord(record.value);
                 // Subagent transcripts consist entirely of sidechain records;
                 // the sidechain filter only applies to the main conversation.
@@ -974,12 +1292,21 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
                         });
                     }
                 }
+                return Boolean(historySlice && historyBoundary
+                    && record.endOffset >= historySliceEndOffset);
             };
 
             let result;
             try {
                 result = await readConversationJsonl(source, {
                     startOffset,
+                    ...(historySlice ? {
+                        endOffset: Math.min(
+                            source.size,
+                            startOffset + CONVERSATION_LIMITS.historyIndexSliceBytes
+                        ),
+                        collectRecords: false,
+                    } : {}),
                     signal,
                     now: this.options.now,
                     onRecord: normalizeRecord,
@@ -1007,6 +1334,71 @@ export class ClaudeConversationAdapter implements ConversationProviderAdapter {
                     telemetryContext,
                     telemetryCwd,
                     telemetryGitBranch,
+                };
+            }
+            if (historySlice) {
+                if (historyBoundary) {
+                    const restartSegmentDigest = await digestConversationSourceSegment(
+                        source,
+                        historySlice.startOffset,
+                        historyBoundary.offset,
+                        signal
+                    );
+                    if (!restartSegmentDigest) {
+                        return {
+                            interactions: [],
+                            sourceRevision: historySlice.sourceRevision,
+                            partial: false,
+                            telemetryModel,
+                            telemetryContext,
+                            telemetryCwd,
+                            telemetryGitBranch,
+                            historySlice: { complete: false, blocked: true },
+                        };
+                    }
+                    return {
+                        interactions: interactions.slice(
+                            0,
+                            historyBoundary.interactionCount
+                        ),
+                        sourceRevision: historySlice.sourceRevision,
+                        partial: false,
+                        telemetryModel,
+                        telemetryContext,
+                        telemetryCwd,
+                        telemetryGitBranch,
+                        historySlice: {
+                            nextOffset: historyBoundary.offset,
+                            restartInteractionId: historyBoundary.interactionId,
+                            restartRecordEndOffset: historyBoundary.recordEndOffset,
+                            restartRecordDigest: historyBoundary.recordDigest,
+                            restartSegmentDigest,
+                            complete: false,
+                        },
+                    };
+                }
+                if (result.nextOffset < source.size) {
+                    return {
+                        interactions: [],
+                        sourceRevision: historySlice.sourceRevision,
+                        partial: false,
+                        telemetryModel,
+                        telemetryContext,
+                        telemetryCwd,
+                        telemetryGitBranch,
+                        historySlice: { complete: false, blocked: true },
+                    };
+                }
+                finishInteraction();
+                return {
+                    interactions,
+                    sourceRevision: historySlice.sourceRevision,
+                    partial: false,
+                    telemetryModel,
+                    telemetryContext,
+                    telemetryCwd,
+                    telemetryGitBranch,
+                    historySlice: { complete: result.nextOffset >= source.size },
                 };
             }
             const appendInteractionIndex = openInteractionIndex;

--- a/src/aiSessions/conversation/historyIndex.ts
+++ b/src/aiSessions/conversation/historyIndex.ts
@@ -40,6 +40,13 @@ export interface ConversationHistoryIndexSegmentProof {
     digest: string;
 }
 
+export interface ConversationHistoryIndexStatus {
+    sourceRevision: string;
+    complete: boolean;
+    saturated: boolean;
+    blocked: boolean;
+}
+
 export type ReadConversationHistoryIndexSlice = (
     request: ConversationHistoryIndexSliceRequest,
     signal?: ConversationAbortSignal
@@ -153,7 +160,43 @@ export class ConversationHistoryIndex {
 
     state(key: string): ConversationHistoryIndexState | undefined {
         const entry = this.entries.get(key);
+        if (entry) {
+            // Map insertion order is the LRU order. Reinsert the same object
+            // so in-flight token/object identity remains valid.
+            this.entries.delete(key);
+            this.entries.set(key, entry);
+        }
         return entry ? snapshot(entry) : undefined;
+    }
+
+    /** Lightweight foreground status; never clones indexed conversation data. */
+    status(key: string): ConversationHistoryIndexStatus | undefined {
+        const entry = this.entries.get(key);
+        if (!entry) {
+            return undefined;
+        }
+        this.entries.delete(key);
+        this.entries.set(key, entry);
+        return {
+            sourceRevision: entry.sourceRevision,
+            complete: entry.complete,
+            saturated: entry.saturated,
+            blocked: entry.blocked,
+        };
+    }
+
+    /** Internal immutable-by-convention source for foreground page builders. */
+    completedInteractions(
+        key: string,
+        sourceRevision: string
+    ): ConversationInteraction[] | undefined {
+        const entry = this.entries.get(key);
+        if (!entry || !entry.complete || entry.sourceRevision !== sourceRevision) {
+            return undefined;
+        }
+        this.entries.delete(key);
+        this.entries.set(key, entry);
+        return entry.interactions;
     }
 
     invalidate(key: string): void {
@@ -183,7 +226,8 @@ export class ConversationHistoryIndex {
                 && entry.restartOffset <= entry.sourceSize
                 && entry.restartInteractionCount <= entry.interactions.length
                 && hasContiguousPrefixProof(
-                    entry.prefixSegments,
+                    entry.prefixSegments.filter(segment =>
+                        segment.endOffset <= entry.restartOffset),
                     entry.restartOffset
                 );
             const retained = canContinue
@@ -222,6 +266,7 @@ export class ConversationHistoryIndex {
                 serializedBytes: serializedInteractionBytes(retained),
             };
             this.entries.set(key, entry);
+            this.evictEntries();
         }
         if (entry.complete || entry.saturated || entry.blocked || signal?.aborted) {
             return snapshot(entry);
@@ -248,10 +293,13 @@ export class ConversationHistoryIndex {
                 return undefined;
             }
             entry.blocked = true;
+            this.releaseUnusablePayload(entry);
             return snapshot(entry);
         }
         if (slice.complete) {
-            if (slice.nextOffset !== undefined) {
+            if (slice.nextOffset !== undefined
+                || typeof slice.completeSegmentDigest !== 'string'
+                || !slice.completeSegmentDigest) {
                 return undefined;
             }
         } else if (!Number.isSafeInteger(slice.nextOffset)
@@ -285,6 +333,7 @@ export class ConversationHistoryIndex {
             // source. The foreground tail remains authoritative until a
             // future, segment-backed protocol can page beyond this bound.
             entry.saturated = true;
+            this.releaseUnusablePayload(entry);
             return snapshot(entry);
         }
         entry.interactions.push(...cloneInteractions(additions));
@@ -292,7 +341,13 @@ export class ConversationHistoryIndex {
         entry.nextOffset = slice.complete
             ? source.sourceSize
             : slice.nextOffset as number;
-        if (!slice.complete) {
+        if (slice.complete) {
+            entry.prefixSegments.push({
+                startOffset,
+                endOffset: source.sourceSize,
+                digest: slice.completeSegmentDigest as string,
+            });
+        } else {
             entry.restartOffset = entry.nextOffset;
             entry.restartInteractionCount = entry.interactions.length;
             entry.restartInteractionId = slice.restartInteractionId;
@@ -306,5 +361,31 @@ export class ConversationHistoryIndex {
         }
         entry.complete = slice.complete;
         return snapshot(entry);
+    }
+
+    private releaseUnusablePayload(entry: ConversationHistoryIndexEntry): void {
+        entry.interactions = [];
+        entry.serializedBytes = 0;
+        entry.prefixSegments = [];
+        entry.nextOffset = 0;
+        entry.restartOffset = 0;
+        entry.restartInteractionCount = 0;
+        entry.restartInteractionId = undefined;
+        entry.restartRecordEndOffset = undefined;
+        entry.restartRecordDigest = undefined;
+    }
+
+    private evictEntries(): void {
+        while (this.entries.size > 8) {
+            const oldest = this.entries.keys().next().value as string | undefined;
+            if (oldest === undefined) {
+                return;
+            }
+            const entry = this.entries.get(oldest);
+            if (entry) {
+                entry.taskToken += 1;
+            }
+            this.entries.delete(oldest);
+        }
     }
 }

--- a/src/aiSessions/conversation/historyIndex.ts
+++ b/src/aiSessions/conversation/historyIndex.ts
@@ -1,0 +1,310 @@
+'use strict';
+
+import {
+    CONVERSATION_LIMITS,
+    ConversationAbortSignal,
+    ConversationHistoryIndexSlice,
+    ConversationHistoryIndexSliceRequest,
+    ConversationHistoryRestartSnapshot,
+    ConversationInteraction,
+} from './types';
+
+export interface ConversationHistoryIndexState {
+    sourceIdentity: string;
+    sourceSize: number;
+    sourceRevision: string;
+    reducerVersion: 1;
+    sourceEpoch: string;
+    sourceFirstHash: string;
+    sourceLastHash: string;
+    nextOffset: number;
+    /** Last reducer-safe restart retained by this entry. */
+    restartOffset: number;
+    restartInteractionCount: number;
+    restartInteractionId?: string;
+    restartRecordEndOffset?: number;
+    restartRecordDigest?: string;
+    /** Exact contiguous byte segments that prove the retained prefix. */
+    prefixSegments: ConversationHistoryIndexSegmentProof[];
+    interactions: ConversationInteraction[];
+    complete: boolean;
+    /** The bounded index cannot safely provide a complete paging source. */
+    saturated: boolean;
+    /** A range budget ended before a provider-proved restart boundary. */
+    blocked: boolean;
+}
+
+export interface ConversationHistoryIndexSegmentProof {
+    startOffset: number;
+    endOffset: number;
+    digest: string;
+}
+
+export type ReadConversationHistoryIndexSlice = (
+    request: ConversationHistoryIndexSliceRequest,
+    signal?: ConversationAbortSignal
+) => Promise<ConversationHistoryIndexSlice | undefined>;
+
+interface ConversationHistoryIndexEntry extends ConversationHistoryIndexState {
+    taskToken: number;
+    serializedBytes: number;
+}
+
+function sameSnapshot(
+    left: Pick<ConversationHistoryRestartSnapshot,
+        'sourceIdentity' | 'sourceSize' | 'sourceRevision' | 'reducerVersion'>,
+    right: Pick<ConversationHistoryRestartSnapshot,
+        'sourceIdentity' | 'sourceSize' | 'sourceRevision' | 'reducerVersion'>
+): boolean {
+    return left.sourceIdentity === right.sourceIdentity
+        && left.sourceSize === right.sourceSize
+        && left.sourceRevision === right.sourceRevision
+        && left.reducerVersion === right.reducerVersion;
+}
+
+function cloneInteractions(
+    interactions: readonly ConversationInteraction[]
+): ConversationInteraction[] {
+    return interactions.map(interaction => ({
+        ...interaction,
+        assistantMarkdown: interaction.assistantMarkdown.slice(),
+        ...(interaction.assistantPhases
+            ? { assistantPhases: interaction.assistantPhases.slice() }
+            : {}),
+        ...(interaction.toolCalls
+            ? { toolCalls: interaction.toolCalls.slice() }
+            : {}),
+        ...(interaction.thinking
+            ? { thinking: interaction.thinking.slice() }
+            : {}),
+        ...(interaction.plans
+            ? { plans: interaction.plans.slice() }
+            : {}),
+        ...(interaction.questions
+            ? { questions: interaction.questions.slice() }
+            : {}),
+    }));
+}
+
+function serializedInteractionBytes(
+    interactions: readonly ConversationInteraction[]
+): number {
+    return interactions.reduce((total, interaction) => total + Buffer.byteLength(
+        JSON.stringify(interaction),
+        'utf8'
+    ), 0);
+}
+
+function hasContiguousPrefixProof(
+    segments: readonly ConversationHistoryIndexSegmentProof[],
+    endOffset: number
+): boolean {
+    let expectedOffset = 0;
+    for (const segment of segments) {
+        if (!Number.isSafeInteger(segment.startOffset)
+            || !Number.isSafeInteger(segment.endOffset)
+            || segment.startOffset !== expectedOffset
+            || segment.endOffset <= segment.startOffset
+            || !segment.digest) {
+            return false;
+        }
+        expectedOffset = segment.endOffset;
+    }
+    return expectedOffset === endOffset;
+}
+
+function snapshot(entry: ConversationHistoryIndexEntry): ConversationHistoryIndexState {
+    return {
+        sourceIdentity: entry.sourceIdentity,
+        sourceSize: entry.sourceSize,
+        sourceRevision: entry.sourceRevision,
+        reducerVersion: entry.reducerVersion,
+        sourceEpoch: entry.sourceEpoch,
+        sourceFirstHash: entry.sourceFirstHash,
+        sourceLastHash: entry.sourceLastHash,
+        nextOffset: entry.nextOffset,
+        restartOffset: entry.restartOffset,
+        restartInteractionCount: entry.restartInteractionCount,
+        ...(entry.restartInteractionId !== undefined
+            ? { restartInteractionId: entry.restartInteractionId }
+            : {}),
+        ...(entry.restartRecordEndOffset !== undefined
+            ? { restartRecordEndOffset: entry.restartRecordEndOffset }
+            : {}),
+        ...(entry.restartRecordDigest !== undefined
+            ? { restartRecordDigest: entry.restartRecordDigest }
+            : {}),
+        prefixSegments: entry.prefixSegments.map(segment => ({ ...segment })),
+        interactions: cloneInteractions(entry.interactions),
+        complete: entry.complete,
+        saturated: entry.saturated,
+        blocked: entry.blocked,
+    };
+}
+
+/**
+ * Owns the non-provider-specific part of background history indexing.
+ * Reducers remain in their adapters; this class admits a completed immutable
+ * segment only when the original entry, source epoch, request frontier, and
+ * task token still all match.
+ */
+export class ConversationHistoryIndex {
+    private readonly entries = new Map<string, ConversationHistoryIndexEntry>();
+
+    state(key: string): ConversationHistoryIndexState | undefined {
+        const entry = this.entries.get(key);
+        return entry ? snapshot(entry) : undefined;
+    }
+
+    invalidate(key: string): void {
+        const entry = this.entries.get(key);
+        if (entry) {
+            entry.taskToken += 1;
+            this.entries.delete(key);
+        }
+    }
+
+    async advance(
+        key: string,
+        source: ConversationHistoryRestartSnapshot,
+        readSlice: ReadConversationHistoryIndexSlice,
+        signal?: ConversationAbortSignal
+    ): Promise<ConversationHistoryIndexState | undefined> {
+        let entry = this.entries.get(key);
+        if (!entry || !sameSnapshot(entry, source)) {
+            const continuation = entry && source.continuationOf;
+            const canContinue = !!continuation
+                && continuation.sourceIdentity === entry.sourceIdentity
+                && continuation.sourceSize === entry.sourceSize
+                && continuation.sourceRevision === entry.sourceRevision
+                && continuation.reducerVersion === entry.reducerVersion
+                && source.sourceEpoch === entry.sourceEpoch
+                && source.sourceSize >= entry.sourceSize
+                && entry.restartOffset <= entry.sourceSize
+                && entry.restartInteractionCount <= entry.interactions.length
+                && hasContiguousPrefixProof(
+                    entry.prefixSegments,
+                    entry.restartOffset
+                );
+            const retained = canContinue
+                ? entry.interactions.slice(0, entry.restartInteractionCount)
+                : [];
+            entry = {
+                sourceIdentity: source.sourceIdentity,
+                sourceSize: source.sourceSize,
+                sourceRevision: source.sourceRevision,
+                reducerVersion: source.reducerVersion,
+                sourceEpoch: source.sourceEpoch,
+                sourceFirstHash: source.sourceFirstHash,
+                sourceLastHash: source.sourceLastHash,
+                nextOffset: canContinue ? entry.restartOffset : 0,
+                restartOffset: canContinue ? entry.restartOffset : 0,
+                restartInteractionCount: retained.length,
+                ...(canContinue && entry.restartInteractionId !== undefined
+                    ? { restartInteractionId: entry.restartInteractionId }
+                    : {}),
+                ...(canContinue && entry.restartRecordEndOffset !== undefined
+                    ? { restartRecordEndOffset: entry.restartRecordEndOffset }
+                    : {}),
+                ...(canContinue && entry.restartRecordDigest !== undefined
+                    ? { restartRecordDigest: entry.restartRecordDigest }
+                    : {}),
+                prefixSegments: canContinue
+                    ? entry.prefixSegments
+                        .filter(segment => segment.endOffset <= entry.restartOffset)
+                        .map(segment => ({ ...segment }))
+                    : [],
+                interactions: retained,
+                complete: false,
+                saturated: false,
+                blocked: false,
+                taskToken: 0,
+                serializedBytes: serializedInteractionBytes(retained),
+            };
+            this.entries.set(key, entry);
+        }
+        if (entry.complete || entry.saturated || entry.blocked || signal?.aborted) {
+            return snapshot(entry);
+        }
+        const taskToken = ++entry.taskToken;
+        const startOffset = entry.nextOffset;
+        const slice = await readSlice({
+            sourceIdentity: source.sourceIdentity,
+            sourceSize: source.sourceSize,
+            sourceRevision: source.sourceRevision,
+            reducerVersion: source.reducerVersion,
+            startOffset,
+        }, signal);
+        if (!slice || signal?.aborted
+            || this.entries.get(key) !== entry
+            || entry.taskToken !== taskToken
+            || !sameSnapshot(slice, source)
+            || slice.startOffset !== startOffset) {
+            return undefined;
+        }
+        if (slice.blocked) {
+            if (slice.complete || slice.nextOffset !== undefined
+                || slice.interactions.length) {
+                return undefined;
+            }
+            entry.blocked = true;
+            return snapshot(entry);
+        }
+        if (slice.complete) {
+            if (slice.nextOffset !== undefined) {
+                return undefined;
+            }
+        } else if (!Number.isSafeInteger(slice.nextOffset)
+            || slice.nextOffset <= startOffset
+            || slice.nextOffset > source.sourceSize
+            || typeof slice.restartInteractionId !== 'string'
+            || !slice.restartInteractionId
+            || !Number.isSafeInteger(slice.restartRecordEndOffset)
+            || slice.restartRecordEndOffset <= slice.nextOffset
+            || slice.restartRecordEndOffset > source.sourceSize
+            || typeof slice.restartRecordDigest !== 'string'
+            || !slice.restartRecordDigest
+            || typeof slice.restartSegmentDigest !== 'string'
+            || !slice.restartSegmentDigest) {
+            return undefined;
+        }
+        const known = new Set(entry.interactions.map(interaction => interaction.id));
+        const additions = slice.interactions.filter(interaction => {
+            if (known.has(interaction.id)) {
+                return false;
+            }
+            known.add(interaction.id);
+            return true;
+        });
+        const additionBytes = serializedInteractionBytes(additions);
+        if (entry.interactions.length + additions.length
+            > CONVERSATION_LIMITS.maxHistoryIndexInteractions
+            || entry.serializedBytes + additionBytes
+                > CONVERSATION_LIMITS.maxHistoryIndexBytes) {
+            // Do not publish a prefix as though it were a contiguous history
+            // source. The foreground tail remains authoritative until a
+            // future, segment-backed protocol can page beyond this bound.
+            entry.saturated = true;
+            return snapshot(entry);
+        }
+        entry.interactions.push(...cloneInteractions(additions));
+        entry.serializedBytes += additionBytes;
+        entry.nextOffset = slice.complete
+            ? source.sourceSize
+            : slice.nextOffset as number;
+        if (!slice.complete) {
+            entry.restartOffset = entry.nextOffset;
+            entry.restartInteractionCount = entry.interactions.length;
+            entry.restartInteractionId = slice.restartInteractionId;
+            entry.restartRecordEndOffset = slice.restartRecordEndOffset;
+            entry.restartRecordDigest = slice.restartRecordDigest;
+            entry.prefixSegments.push({
+                startOffset,
+                endOffset: entry.restartOffset,
+                digest: slice.restartSegmentDigest,
+            });
+        }
+        entry.complete = slice.complete;
+        return snapshot(entry);
+    }
+}

--- a/src/aiSessions/conversation/historyRestartPoints.ts
+++ b/src/aiSessions/conversation/historyRestartPoints.ts
@@ -1,6 +1,10 @@
 'use strict';
 
-import { CONVERSATION_LIMITS, ConversationHistoryRestartPoint } from './types';
+import {
+    CONVERSATION_LIMITS,
+    ConversationAbortSignal,
+    ConversationHistoryRestartPoint,
+} from './types';
 import { digestConversationSourceRange, OpenConversationSource } from './source';
 
 /** Adapter-cache-only proof data; the provider API deliberately omits it. */
@@ -33,14 +37,19 @@ export function appendConversationHistoryRestartPoint<
  * the continuation source. Each point is independently restart-safe. */
 export async function verifyConversationHistoryRestartPoints(
     source: OpenConversationSource,
-    points: CachedConversationHistoryRestartPoint[]
+    points: CachedConversationHistoryRestartPoint[],
+    signal?: ConversationAbortSignal
 ): Promise<CachedConversationHistoryRestartPoint[]> {
     const verified: CachedConversationHistoryRestartPoint[] = [];
     for (const point of points) {
+        if (signal?.aborted) {
+            return [];
+        }
         const digest = await digestConversationSourceRange(
             source,
             point.offset,
-            point.recordEndOffset
+            point.recordEndOffset,
+            signal
         );
         if (digest === point.recordDigest) {
             verified.push(point);

--- a/src/aiSessions/conversation/historyRestartPoints.ts
+++ b/src/aiSessions/conversation/historyRestartPoints.ts
@@ -12,6 +12,8 @@ export interface CachedConversationHistoryRestartPoint
     extends ConversationHistoryRestartPoint {
     recordEndOffset: number;
     recordDigest: string;
+    /** Digest of this scan's bytes before the restart record. */
+    prefixDigest: string;
 }
 
 /** Retains only the recent in-memory discovery window; durable sparse points

--- a/src/aiSessions/conversation/jsonlReader.ts
+++ b/src/aiSessions/conversation/jsonlReader.ts
@@ -17,7 +17,8 @@ export interface ConversationJsonlReadOptions {
     resumeDiscard?: 'partial' | 'oversized';
     signal?: ConversationAbortSignal;
     now?: () => number;
-    onRecord?: (record: ConversationJsonlRecord) => void;
+    /** Return true only after a complete physical record to stop this slice. */
+    onRecord?: (record: ConversationJsonlRecord) => boolean | void;
     /** Background indexers normally consume onRecord and need no duplicate array. */
     collectRecords?: boolean;
 }
@@ -103,6 +104,7 @@ export async function readConversationJsonl(
     let oversized = false;
     let initialPartial = initialDiscard !== undefined;
     let discardKind = initialDiscard;
+    let stopped = false;
     const fragments: Buffer[] = [];
     let bytesSinceYield = 0;
 
@@ -165,15 +167,15 @@ export async function readConversationJsonl(
         if (collectRecords) {
             records.push(record);
         }
-        normalizedOptions.onRecord?.(record);
+        stopped = normalizedOptions.onRecord?.(record) === true;
         resetLine(readOffset);
     };
 
     // A valid record may straddle the requested boundary.  Finish at most one
     // such record (bounded by maxLineBytes); when it proves oversized, return
     // a resumable discard cursor instead of repeatedly rewinding to its start.
-    while (readOffset < endOffset
-        || (readOffset < source.size && lineBytes > 0 && !oversized)) {
+    while (!stopped && (readOffset < endOffset
+        || (readOffset < source.size && lineBytes > 0 && !oversized))) {
         checkAbort();
         checkDeadline();
         const extendingPastBoundary = readOffset >= endOffset;
@@ -199,7 +201,7 @@ export async function readConversationJsonl(
             ? rawChunk
             : rawChunk.subarray(0, boundaryNewline + 1);
         let chunkIndex = 0;
-        while (chunkIndex < chunk.length) {
+        while (!stopped && chunkIndex < chunk.length) {
             const newlineIndex = chunk.indexOf(0x0a, chunkIndex);
             if (newlineIndex < 0) {
                 if (!initialPartial) {
@@ -214,7 +216,7 @@ export async function readConversationJsonl(
             finishLine();
             chunkIndex = newlineIndex + 1;
         }
-        if (chunkIndex < chunk.length) {
+        if (!stopped && chunkIndex < chunk.length) {
             readOffset += chunk.length - chunkIndex;
         } else if (chunkIndex === chunk.length) {
             // The last byte was a newline and has already advanced readOffset.
@@ -228,7 +230,7 @@ export async function readConversationJsonl(
             bytesSinceYield = 0;
         }
     }
-    if (!initialPartial && lineBytes && readOffset === source.size) {
+    if (!stopped && !initialPartial && lineBytes && readOffset === source.size) {
         if (oversized) {
             // EOF is only the current source snapshot boundary. A bounded
             // caller keeps a resumable discard cursor for a later append.

--- a/src/aiSessions/conversation/jsonlReader.ts
+++ b/src/aiSessions/conversation/jsonlReader.ts
@@ -29,6 +29,11 @@ export interface ConversationJsonlRecord {
     endOffset: number;
     /** SHA-256 of the exact physical JSONL bytes parsed for this record. */
     recordDigest: string;
+    /** Includes the trailing LF when the record was newline-terminated. */
+    proofEndOffset: number;
+    proofDigest: string;
+    /** SHA-256 of bytes from this read's start through this record's start. */
+    prefixDigest: string;
     value: unknown;
 }
 
@@ -38,6 +43,8 @@ export interface ConversationJsonlReadResult {
     malformedLines: number;
     oversizedLines: number;
     partial: boolean;
+    /** SHA-256 of every byte consumed by this invocation. */
+    consumedDigest: string;
     /** Pass this to the next bounded slice until the physical line ends. */
     resumeDiscard?: 'partial' | 'oversized';
 }
@@ -107,6 +114,8 @@ export async function readConversationJsonl(
     let stopped = false;
     const fragments: Buffer[] = [];
     let bytesSinceYield = 0;
+    const prefixHash = createHash('sha256');
+    let lineStartPrefixDigest = prefixHash.copy().digest('hex');
 
     const checkAbort = (): void => {
         if (normalizedOptions.signal?.aborted) {
@@ -118,6 +127,7 @@ export async function readConversationJsonl(
         lineBytes = 0;
         oversized = false;
         fragments.length = 0;
+        lineStartPrefixDigest = prefixHash.copy().digest('hex');
     };
     const appendLineBytes = (fragment: Buffer): void => {
         if (!fragment.length || oversized) {
@@ -157,6 +167,10 @@ export async function readConversationJsonl(
                 offset: lineStart,
                 endOffset: readOffset - 1,
                 recordDigest: createHash('sha256').update(rawRecord).digest('hex'),
+                proofEndOffset: readOffset,
+                proofDigest: createHash('sha256')
+                    .update(rawRecord).update('\n').digest('hex'),
+                prefixDigest: lineStartPrefixDigest,
                 value: JSON.parse(rawRecord.toString('utf8')),
             };
         } catch (_error) {
@@ -204,14 +218,18 @@ export async function readConversationJsonl(
         while (!stopped && chunkIndex < chunk.length) {
             const newlineIndex = chunk.indexOf(0x0a, chunkIndex);
             if (newlineIndex < 0) {
+                const rawLineFragment = chunk.subarray(chunkIndex);
                 if (!initialPartial) {
-                    appendLineBytes(chunk.subarray(chunkIndex));
+                    appendLineBytes(rawLineFragment);
                 }
+                prefixHash.update(rawLineFragment);
                 break;
             }
+            const rawLineFragment = chunk.subarray(chunkIndex, newlineIndex + 1);
             if (!initialPartial) {
                 appendLineBytes(chunk.subarray(chunkIndex, newlineIndex));
             }
+            prefixHash.update(rawLineFragment);
             readOffset += newlineIndex + 1 - chunkIndex;
             finishLine();
             chunkIndex = newlineIndex + 1;
@@ -247,6 +265,9 @@ export async function readConversationJsonl(
                     offset: lineStart,
                     endOffset: readOffset,
                     recordDigest: createHash('sha256').update(rawRecord).digest('hex'),
+                    proofEndOffset: readOffset,
+                    proofDigest: createHash('sha256').update(rawRecord).digest('hex'),
+                    prefixDigest: lineStartPrefixDigest,
                     value: JSON.parse(rawRecord.toString('utf8')),
                 };
             } catch (_error) {
@@ -271,6 +292,7 @@ export async function readConversationJsonl(
         malformedLines,
         oversizedLines,
         partial: startOffset > 0,
+        consumedDigest: prefixHash.copy().digest('hex'),
         ...((initialPartial || oversized) && normalizedOptions.endOffset !== undefined
             ? { resumeDiscard: initialPartial ? discardKind : 'oversized' }
             : {}),

--- a/src/aiSessions/conversation/kimiAdapter.ts
+++ b/src/aiSessions/conversation/kimiAdapter.ts
@@ -39,10 +39,13 @@ import {
 import { synthesizeFragmentDiff, synthesizeFragmentDiffs } from './diffs';
 import {
     CONVERSATION_LIMITS,
+    ConversationAbortController,
     ConversationAbortSignal,
     ConversationCacheDiagnostics,
     ConversationError,
     ConversationFileDiff,
+    ConversationHistoryIndexSlice,
+    ConversationHistoryIndexSliceRequest,
     ConversationHistoryRestartSnapshot,
     ConversationInteraction,
     ConversationOutline,
@@ -58,10 +61,16 @@ import {
     ConversationTelemetry,
 } from './types';
 import {
+    ConversationHistoryIndex,
+    ConversationHistoryIndexState,
+} from './historyIndex';
+import {
     isSubagentId,
     splitSubagentSessionId,
 } from './subagentSessions';
 import {
+    digestConversationSourceRange,
+    digestConversationSourceSegment,
     openValidatedConversationSource,
     OpenConversationSource,
 } from './source';
@@ -80,6 +89,7 @@ const SHELL_CD_PATTERN = /(?:^|&&|\|\||;|\n)\s*cd(?:\s+--)?\s+(?:"([^"]+)"|'([^'
 const MAX_LISTED_SUBAGENTS = 64;
 const SUBAGENT_DIRECTORY_PATTERN = /^[0-9a-z][0-9a-z-]{0,63}$/i;
 const SUBAGENT_RUNNING_FRESHNESS_MS = 5 * 60 * 1000;
+const HISTORY_INDEX_SETTLE_MS = 250;
 
 function extractShellWorkingDirectories(
     value: string,
@@ -165,6 +175,15 @@ interface LoadedConversation {
     partial: boolean;
     telemetryContext?: ConversationContextUsage;
     telemetryPaths: string[];
+    historySlice?: {
+        nextOffset?: number;
+        restartInteractionId?: string;
+        restartRecordEndOffset?: number;
+        restartRecordDigest?: string;
+        restartSegmentDigest?: string;
+        complete: boolean;
+        blocked?: boolean;
+    };
 }
 
 function asRecord(value: unknown): Record<string, any> | undefined {
@@ -391,8 +410,72 @@ function applyKimiQuestionSettlement(
     }
 }
 
+function historyIndexSourceEpoch(source: OpenConversationSource): string {
+    return source.device !== undefined && source.inode !== undefined
+        && source.birthtimeMs !== undefined
+        ? `inode:${source.canonicalPath}:${source.device}:${source.inode}:${source.birthtimeMs}`
+        : `portable:${source.canonicalPath}`;
+}
+
+async function continuesHistoryIndex(
+    source: OpenConversationSource,
+    previous: ConversationHistoryIndexState,
+    signal?: ConversationAbortSignal
+): Promise<boolean> {
+    if (signal?.aborted || source.size < previous.sourceSize
+        || historyIndexSourceEpoch(source) !== previous.sourceEpoch
+        || source.portableFirstHash !== previous.sourceFirstHash
+        || previous.restartInteractionId === undefined
+        || previous.restartRecordEndOffset === undefined
+        || previous.restartRecordDigest === undefined) {
+        return false;
+    }
+    const edgeBytes = Math.min(64 * 1024, previous.sourceSize);
+    const oldLastHash = await digestConversationSourceRange(
+        source,
+        Math.max(0, previous.sourceSize - edgeBytes),
+        previous.sourceSize,
+        signal
+    );
+    if (oldLastHash !== previous.sourceLastHash) {
+        return false;
+    }
+    if (await digestConversationSourceRange(
+        source,
+        previous.restartOffset,
+        previous.restartRecordEndOffset,
+        signal
+    ) !== previous.restartRecordDigest) {
+        return false;
+    }
+    let expectedOffset = 0;
+    for (const segment of previous.prefixSegments) {
+        if (signal?.aborted || segment.startOffset !== expectedOffset
+            || segment.endOffset <= segment.startOffset
+            || await digestConversationSourceSegment(
+                source,
+                segment.startOffset,
+                segment.endOffset,
+                signal
+            ) !== segment.digest) {
+            return false;
+        }
+        expectedOffset = segment.endOffset;
+    }
+    return expectedOffset === previous.restartOffset;
+}
+
 export class KimiConversationAdapter implements ConversationProviderAdapter {
     private readonly cache: ConversationIndexCache<KimiConversationIndex>;
+    private readonly historyIndex = new ConversationHistoryIndex();
+    private readonly historyIndexTasks = new Map<string, {
+        controller: ConversationAbortController;
+        sourceRevision: string;
+    }>();
+    private readonly pendingHistoryIndexes = new Map<string, LoadedConversation>();
+    private readonly historyIndexStartTimers = new Map<string, {
+        timer?: TimerHandle;
+    }>();
     private readonly subscriptions = new Map<string, Set<() => void>>();
     private readonly revisionCounters = new Map<string, number>();
     private readonly loadQueues = new Map<string, Promise<void>>();
@@ -409,7 +492,8 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
         preferredInteractionId?: string,
         signal?: ConversationAbortSignal
     ): Promise<ConversationSnapshot> {
-        const loaded = await this.load(sessionId, signal);
+        const loaded = this.withCompletedHistory(sessionId, await this.load(sessionId, signal));
+        this.startHistoryIndex(sessionId, loaded);
         const outline = buildConversationOutline(
             'kimi',
             sessionId,
@@ -439,7 +523,8 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
         sessionId: string,
         signal?: ConversationAbortSignal
     ): Promise<ConversationOutline> {
-        const loaded = await this.load(sessionId, signal);
+        const loaded = this.withCompletedHistory(sessionId, await this.load(sessionId, signal));
+        this.startHistoryIndex(sessionId, loaded);
         return buildConversationOutline(
             'kimi',
             sessionId,
@@ -453,7 +538,11 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
         request: ConversationPageRequest,
         signal?: ConversationAbortSignal
     ): Promise<ConversationPage> {
-        const loaded = await this.load(request.sessionId, signal);
+        const loaded = this.withCompletedHistory(
+            request.sessionId,
+            await this.load(request.sessionId, signal)
+        );
+        this.startHistoryIndex(request.sessionId, loaded);
         return buildConversationPage(
             loaded.interactions,
             { ...request, provider: 'kimi' },
@@ -596,6 +685,15 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
             return;
         }
         this.disposed = true;
+        this.historyIndexTasks.forEach(task => task.controller.abort());
+        this.historyIndexTasks.clear();
+        this.pendingHistoryIndexes.clear();
+        this.historyIndexStartTimers.forEach(scheduled => {
+            if (scheduled.timer !== undefined) {
+                this.options.clearTimeout(scheduled.timer);
+            }
+        });
+        this.historyIndexStartTimers.clear();
         if (this.invalidationTimer !== undefined) {
             this.options.clearTimeout(this.invalidationTimer);
             this.invalidationTimer = undefined;
@@ -626,14 +724,16 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
 
     /** Provider-owned candidates for the persistent history indexer. */
     async getHistoryRestartPoints(
-        sessionId: string
+        sessionId: string,
+        indexed = this.historyIndex.state(sessionId),
+        signal?: ConversationAbortSignal
     ): Promise<ConversationHistoryRestartSnapshot | undefined> {
         const entry = this.cache.get(sessionId);
         const split = splitSubagentSessionId(sessionId);
         const candidate = entry && (!split.subagentId || isSubagentId(split.subagentId))
             ? this.options.resolveSource(split.sessionId)
             : null;
-        if (!entry || !candidate) {
+        if (!entry || !candidate || signal?.aborted) {
             return undefined;
         }
         const source = await openValidatedConversationSource(split.subagentId
@@ -652,13 +752,27 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
             }
             const points = await verifyConversationHistoryRestartPoints(
                 source,
-                entry.restartPoints
+                entry.restartPoints,
+                signal
             );
-            return {
+            const continuationOf = indexed
+                && await continuesHistoryIndex(source, indexed, signal)
+                ? {
+                    sourceIdentity: indexed.sourceIdentity,
+                    sourceSize: indexed.sourceSize,
+                    sourceRevision: indexed.sourceRevision,
+                    reducerVersion: indexed.reducerVersion,
+                }
+                : undefined;
+            return signal?.aborted ? undefined : {
                 sourceIdentity: source.identity,
                 sourceSize: source.size,
                 sourceRevision: `r${entry.revision}`,
                 reducerVersion: 1,
+                sourceEpoch: historyIndexSourceEpoch(source),
+                sourceFirstHash: source.portableFirstHash || '',
+                sourceLastHash: source.portableLastHash || '',
+                ...(continuationOf ? { continuationOf } : {}),
                 points: points.map(point => ({
                     offset: point.offset,
                     interactionId: point.interactionId,
@@ -667,6 +781,175 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
         } finally {
             await source.handle.close().catch(() => undefined);
         }
+    }
+
+    async readHistoryIndexSlice(
+        sessionId: string,
+        request: ConversationHistoryIndexSliceRequest,
+        signal?: ConversationAbortSignal
+    ): Promise<ConversationHistoryIndexSlice | undefined> {
+        try {
+            // History slices never mutate the foreground cache. Keeping them
+            // out of its serial queue prevents a low-priority 4 MiB replay
+            // from delaying a click, navigation, or live refresh.
+            const loaded = await this.loadExclusive(sessionId, signal, request);
+            if (!loaded.historySlice) {
+                return undefined;
+            }
+            return {
+                sourceIdentity: request.sourceIdentity,
+                sourceSize: request.sourceSize,
+                sourceRevision: request.sourceRevision,
+                reducerVersion: request.reducerVersion,
+                startOffset: request.startOffset,
+                ...(loaded.historySlice.nextOffset === undefined ? {} : {
+                    nextOffset: loaded.historySlice.nextOffset,
+                }),
+                ...(loaded.historySlice.restartInteractionId === undefined ? {} : {
+                    restartInteractionId: loaded.historySlice.restartInteractionId,
+                }),
+                ...(loaded.historySlice.restartRecordEndOffset === undefined ? {} : {
+                    restartRecordEndOffset: loaded.historySlice.restartRecordEndOffset,
+                }),
+                ...(loaded.historySlice.restartRecordDigest === undefined ? {} : {
+                    restartRecordDigest: loaded.historySlice.restartRecordDigest,
+                }),
+                ...(loaded.historySlice.restartSegmentDigest === undefined ? {} : {
+                    restartSegmentDigest: loaded.historySlice.restartSegmentDigest,
+                }),
+                interactions: cloneInteractions(loaded.interactions),
+                complete: loaded.historySlice.complete,
+                ...(loaded.historySlice.blocked ? { blocked: true } : {}),
+            };
+        } catch (error) {
+            if (error instanceof ConversationError
+                && error.code === 'staleRevision') {
+                return undefined;
+            }
+            throw error;
+        }
+    }
+
+    private withCompletedHistory(
+        sessionId: string,
+        loaded: LoadedConversation
+    ): LoadedConversation {
+        const indexed = this.historyIndex.state(sessionId);
+        if (!indexed?.complete || indexed.sourceRevision !== loaded.sourceRevision) {
+            return loaded;
+        }
+        // This replay is continuous from offset zero through this exact
+        // snapshot. It replaces the bounded foreground tail atomically;
+        // concatenating the two sources would create a hidden history gap.
+        return {
+            ...loaded,
+            interactions: indexed.interactions,
+            partial: false,
+        };
+    }
+
+    private startHistoryIndex(
+        sessionId: string,
+        loaded: LoadedConversation,
+        settled = false
+    ): void {
+        if (this.disposed) {
+            return;
+        }
+        const running = this.historyIndexTasks.get(sessionId);
+        if (!loaded.partial) {
+            this.pendingHistoryIndexes.delete(sessionId);
+            const scheduled = this.historyIndexStartTimers.get(sessionId);
+            if (scheduled?.timer !== undefined) {
+                this.options.clearTimeout(scheduled.timer);
+            }
+            this.historyIndexStartTimers.delete(sessionId);
+            running?.controller.abort();
+            return;
+        }
+        if (running) {
+            if (running.sourceRevision !== loaded.sourceRevision) {
+                // The old snapshot cannot be promoted after this foreground
+                // read. Let its abort settle, then start exactly one indexer
+                // for the newest partial revision.
+                this.pendingHistoryIndexes.set(sessionId, loaded);
+                running.controller.abort();
+            }
+            return;
+        }
+        if (!settled) {
+            this.scheduleHistoryIndex(sessionId, loaded);
+            return;
+        }
+        const controller = new ConversationAbortController();
+        this.historyIndexTasks.set(sessionId, {
+            controller,
+            sourceRevision: loaded.sourceRevision,
+        });
+        void (async () => {
+            try {
+                const source = await this.getHistoryRestartPoints(
+                    sessionId,
+                    this.historyIndex.state(sessionId),
+                    controller.signal
+                );
+                if (!source || controller.signal.aborted) {
+                    return;
+                }
+                for (;;) {
+                    const state = await this.historyIndex.advance(
+                        sessionId,
+                        source,
+                        request => this.readHistoryIndexSlice(
+                            sessionId,
+                            request,
+                            controller.signal
+                        ),
+                        controller.signal
+                    );
+                    if (!state || controller.signal.aborted || state.complete
+                        || state.saturated || state.blocked) {
+                        if (state?.complete && !controller.signal.aborted) {
+                            Array.from(this.subscriptions.get(sessionId) || [])
+                                .forEach(callback => callback());
+                        }
+                        return;
+                    }
+                    await new Promise<void>(resolve => setImmediate(resolve));
+                }
+            } finally {
+                if (this.historyIndexTasks.get(sessionId)?.controller === controller) {
+                    this.historyIndexTasks.delete(sessionId);
+                    const pending = this.pendingHistoryIndexes.get(sessionId);
+                    this.pendingHistoryIndexes.delete(sessionId);
+                    if (pending) {
+                        this.startHistoryIndex(sessionId, pending);
+                    }
+                }
+            }
+        })().catch(() => undefined);
+    }
+
+    /** Coalesce streaming appends before revalidating a potentially large prefix. */
+    private scheduleHistoryIndex(sessionId: string, loaded: LoadedConversation): void {
+        this.pendingHistoryIndexes.set(sessionId, loaded);
+        const previous = this.historyIndexStartTimers.get(sessionId);
+        if (previous?.timer !== undefined) {
+            this.options.clearTimeout(previous.timer);
+        }
+        const scheduled: { timer?: TimerHandle } = {};
+        this.historyIndexStartTimers.set(sessionId, scheduled);
+        scheduled.timer = this.options.setTimeout(() => {
+            if (this.historyIndexStartTimers.get(sessionId) !== scheduled) {
+                return;
+            }
+            this.historyIndexStartTimers.delete(sessionId);
+            const pending = this.pendingHistoryIndexes.get(sessionId);
+            this.pendingHistoryIndexes.delete(sessionId);
+            if (pending) {
+                this.startHistoryIndex(sessionId, pending, true);
+            }
+        }, HISTORY_INDEX_SETTLE_MS);
     }
 
     private load(
@@ -693,7 +976,8 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
 
     private async loadExclusive(
         sessionId: string,
-        signal?: ConversationAbortSignal
+        signal?: ConversationAbortSignal,
+        historySlice?: ConversationHistoryIndexSliceRequest
     ): Promise<LoadedConversation> {
         if (this.disposed) {
             throw new ConversationError('unavailable', 'missingSource');
@@ -725,6 +1009,17 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
             throw new ConversationError('unavailable', 'missingSource');
         }
         const previous = this.cache.get(sessionId);
+        if (historySlice && (!previous
+            || historySlice.reducerVersion !== 1
+            || historySlice.sourceIdentity !== source.identity
+            || historySlice.sourceSize !== source.size
+            || historySlice.sourceRevision !== `r${previous.revision}`
+            || !Number.isSafeInteger(historySlice.startOffset)
+            || historySlice.startOffset < 0
+            || historySlice.startOffset >= source.size)) {
+            await source.handle.close().catch(() => undefined);
+            throw new ConversationError('staleRevision');
+        }
         let interactions: ConversationInteraction[] = [];
         let openInteractionIndex: number | undefined;
         let telemetryContext: ConversationContextUsage | undefined;
@@ -732,15 +1027,17 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
             ? [effectiveCandidate.cwd]
             : [];
         try {
-            const startOffset = await getConversationReadStart(
-                source,
-                previous && {
-                    source: previous.source,
-                    nextOffset: previous.nextOffset,
-                }
-            );
+            const startOffset = historySlice
+                ? historySlice.startOffset
+                : await getConversationReadStart(
+                    source,
+                    previous && {
+                        source: previous.source,
+                        nextOffset: previous.nextOffset,
+                    }
+                );
             const continuing = Boolean(previous)
-                && startOffset === previous.nextOffset;
+                && !historySlice && startOffset === previous.nextOffset;
             // `continuing` verifies the old prefix before reducer state is
             // reused. Recheck each sparse point's complete physical record
             // before promoting it into the new source snapshot, so a middle
@@ -748,6 +1045,20 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
             let restartPoints: CachedConversationHistoryRestartPoint[] = continuing
                 ? previous.restartPoints
                 : [];
+            let historyBoundary: {
+                offset: number;
+                interactionCount: number;
+                interactionId: string;
+                recordEndOffset: number;
+                recordDigest: string;
+            } | undefined;
+            const historySliceEndOffset = historySlice
+                ? Math.min(
+                    source.size,
+                    historySlice.startOffset
+                        + CONVERSATION_LIMITS.historyIndexSliceBytes
+                )
+                : 0;
             let ownsRestartPoints = !continuing;
             const addRestartPoint = (
                 point: CachedConversationHistoryRestartPoint
@@ -757,6 +1068,17 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                     ownsRestartPoints = true;
                 }
                 appendConversationHistoryRestartPoint(restartPoints, point);
+                if (historySlice
+                    && point.offset > historySlice.startOffset
+                    && interactions.length > 0) {
+                    historyBoundary = {
+                        offset: point.offset,
+                        interactionCount: interactions.length,
+                        interactionId: point.interactionId,
+                        recordEndOffset: point.recordEndOffset,
+                        recordDigest: point.recordDigest,
+                    };
+                }
             };
             if (continuing) {
                 interactions = cloneInteractions(previous.interactions);
@@ -821,7 +1143,7 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                 }
                 pendingThinking = null;
             };
-            const normalizeRecord = (record: ConversationJsonlRecord): void => {
+            const normalizeRecord = (record: ConversationJsonlRecord): boolean | void => {
                 const envelope = asRecord(record.value);
                 const event = asRecord(envelope?.message);
                 if (!event) {
@@ -1241,6 +1563,8 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                     questionTracker.clear();
                     approvalTracker.clear();
                 }
+                return Boolean(historySlice && historyBoundary
+                    && record.endOffset >= historySliceEndOffset);
             };
             const finishInteraction = (
                 state: ConversationResponseState
@@ -1269,6 +1593,13 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
             try {
                 result = await readConversationJsonl(source, {
                     startOffset,
+                    ...(historySlice ? {
+                        endOffset: Math.min(
+                            source.size,
+                            startOffset + CONVERSATION_LIMITS.historyIndexSliceBytes
+                        ),
+                        collectRecords: false,
+                    } : {}),
                     signal,
                     now: this.options.now,
                     onRecord: normalizeRecord,
@@ -1293,6 +1624,65 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                     partial: true,
                     telemetryContext,
                     telemetryPaths,
+                };
+            }
+            if (historySlice) {
+                if (historyBoundary) {
+                    const restartSegmentDigest = await digestConversationSourceSegment(
+                        source,
+                        historySlice.startOffset,
+                        historyBoundary.offset,
+                        signal
+                    );
+                    if (!restartSegmentDigest) {
+                        return {
+                            interactions: [],
+                            sourceRevision: historySlice.sourceRevision,
+                            partial: false,
+                            telemetryContext,
+                            telemetryPaths,
+                            historySlice: { complete: false, blocked: true },
+                        };
+                    }
+                    return {
+                        interactions: interactions.slice(
+                            0,
+                            historyBoundary.interactionCount
+                        ),
+                        sourceRevision: historySlice.sourceRevision,
+                        partial: false,
+                        telemetryContext,
+                        telemetryPaths,
+                        historySlice: {
+                            nextOffset: historyBoundary.offset,
+                            restartInteractionId: historyBoundary.interactionId,
+                            restartRecordEndOffset: historyBoundary.recordEndOffset,
+                            restartRecordDigest: historyBoundary.recordDigest,
+                            restartSegmentDigest,
+                            complete: false,
+                        },
+                    };
+                }
+                if (result.nextOffset < source.size) {
+                    return {
+                        interactions: [],
+                        sourceRevision: historySlice.sourceRevision,
+                        partial: false,
+                        telemetryContext,
+                        telemetryPaths,
+                        historySlice: { complete: false, blocked: true },
+                    };
+                }
+                // Match foreground EOF semantics: Kimi keeps the active
+                // interaction in progress until its terminal event arrives.
+                publishText();
+                return {
+                    interactions,
+                    sourceRevision: historySlice.sourceRevision,
+                    partial: false,
+                    telemetryContext,
+                    telemetryPaths,
+                    historySlice: { complete: result.nextOffset >= source.size },
                 };
             }
             const partial = continuing ? previous.partial : result.partial;

--- a/src/aiSessions/conversation/kimiAdapter.ts
+++ b/src/aiSessions/conversation/kimiAdapter.ts
@@ -181,6 +181,7 @@ interface LoadedConversation {
         restartRecordEndOffset?: number;
         restartRecordDigest?: string;
         restartSegmentDigest?: string;
+        completeSegmentDigest?: string;
         complete: boolean;
         blocked?: boolean;
     };
@@ -462,7 +463,40 @@ async function continuesHistoryIndex(
         }
         expectedOffset = segment.endOffset;
     }
-    return expectedOffset === previous.restartOffset;
+    return expectedOffset === (previous.complete
+        ? previous.sourceSize
+        : previous.restartOffset);
+}
+
+/**
+ * A saturated index intentionally has no payload to continue.  Avoid
+ * repeatedly rebuilding it while a live transcript only grows: proving the
+ * two stable edges is bounded work, whereas restarting the index would read
+ * the entire retained prefix just to hit the same capacity limit again.
+ *
+ * This is deliberately only a scheduling suppression, never an authority
+ * decision.  A shrink, replacement epoch, or changed edge permits a fresh
+ * index attempt; an unprovable middle rewrite merely keeps the existing
+ * fallback (the bounded foreground tail) in place.
+ */
+async function keepsSaturatedHistoryIndex(
+    source: OpenConversationSource,
+    previous: ConversationHistoryIndexState,
+    signal?: ConversationAbortSignal
+): Promise<boolean> {
+    if (!previous.saturated || signal?.aborted
+        || source.size < previous.sourceSize
+        || historyIndexSourceEpoch(source) !== previous.sourceEpoch
+        || source.portableFirstHash !== previous.sourceFirstHash) {
+        return false;
+    }
+    const edgeBytes = Math.min(64 * 1024, previous.sourceSize);
+    return await digestConversationSourceRange(
+        source,
+        Math.max(0, previous.sourceSize - edgeBytes),
+        previous.sourceSize,
+        signal
+    ) === previous.sourceLastHash;
 }
 
 export class KimiConversationAdapter implements ConversationProviderAdapter {
@@ -750,6 +784,9 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
             if (source.identity !== entry.source.identity) {
                 return undefined;
             }
+            if (indexed && await keepsSaturatedHistoryIndex(source, indexed, signal)) {
+                return undefined;
+            }
             const points = await verifyConversationHistoryRestartPoints(
                 source,
                 entry.restartPoints,
@@ -817,6 +854,9 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                 ...(loaded.historySlice.restartSegmentDigest === undefined ? {} : {
                     restartSegmentDigest: loaded.historySlice.restartSegmentDigest,
                 }),
+                ...(loaded.historySlice.completeSegmentDigest === undefined ? {} : {
+                    completeSegmentDigest: loaded.historySlice.completeSegmentDigest,
+                }),
                 interactions: cloneInteractions(loaded.interactions),
                 complete: loaded.historySlice.complete,
                 ...(loaded.historySlice.blocked ? { blocked: true } : {}),
@@ -834,8 +874,11 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
         sessionId: string,
         loaded: LoadedConversation
     ): LoadedConversation {
-        const indexed = this.historyIndex.state(sessionId);
-        if (!indexed?.complete || indexed.sourceRevision !== loaded.sourceRevision) {
+        const interactions = this.historyIndex.completedInteractions(
+            sessionId,
+            loaded.sourceRevision
+        );
+        if (!interactions) {
             return loaded;
         }
         // This replay is continuous from offset zero through this exact
@@ -843,7 +886,7 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
         // concatenating the two sources would create a hidden history gap.
         return {
             ...loaded,
-            interactions: indexed.interactions,
+            interactions,
             partial: false,
         };
     }
@@ -854,6 +897,10 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
         settled = false
     ): void {
         if (this.disposed) {
+            return;
+        }
+        const indexed = this.historyIndex.status(sessionId);
+        if (indexed?.saturated && indexed.sourceRevision === loaded.sourceRevision) {
             return;
         }
         const running = this.historyIndexTasks.get(sessionId);
@@ -881,6 +928,19 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
             this.scheduleHistoryIndex(sessionId, loaded);
             return;
         }
+        // Indexing is explicitly low priority. The most recently viewed
+        // session wins; never let A→B→C create three concurrent 4 MiB scans.
+        this.historyIndexTasks.forEach((task, activeSessionId) => {
+            if (activeSessionId !== sessionId) {
+                task.controller.abort();
+                this.pendingHistoryIndexes.delete(activeSessionId);
+                const scheduled = this.historyIndexStartTimers.get(activeSessionId);
+                if (scheduled?.timer !== undefined) {
+                    this.options.clearTimeout(scheduled.timer);
+                }
+                this.historyIndexStartTimers.delete(activeSessionId);
+            }
+        });
         const controller = new ConversationAbortController();
         this.historyIndexTasks.set(sessionId, {
             controller,
@@ -1051,6 +1111,7 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                 interactionId: string;
                 recordEndOffset: number;
                 recordDigest: string;
+                segmentDigest: string;
             } | undefined;
             const historySliceEndOffset = historySlice
                 ? Math.min(
@@ -1077,6 +1138,7 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                         interactionId: point.interactionId,
                         recordEndOffset: point.recordEndOffset,
                         recordDigest: point.recordDigest,
+                        segmentDigest: point.prefixDigest,
                     };
                 }
             };
@@ -1201,8 +1263,9 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                             && approvalTracker.size === 0) {
                             addRestartPoint({
                                 offset: record.offset,
-                                recordEndOffset: record.endOffset,
-                                recordDigest: record.recordDigest,
+                                recordEndOffset: record.proofEndOffset,
+                                recordDigest: record.proofDigest,
+                                prefixDigest: record.prefixDigest,
                                 interactionId: id,
                             });
                         }
@@ -1596,7 +1659,10 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                     ...(historySlice ? {
                         endOffset: Math.min(
                             source.size,
-                            startOffset + CONVERSATION_LIMITS.historyIndexSliceBytes
+                            // Target a 4 MiB segment, but permit one bounded
+                            // 4 MiB extension to reach a reducer-safe turn.
+                            startOffset
+                                + CONVERSATION_LIMITS.historyIndexSliceBytes * 2
                         ),
                         collectRecords: false,
                     } : {}),
@@ -1628,22 +1694,6 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
             }
             if (historySlice) {
                 if (historyBoundary) {
-                    const restartSegmentDigest = await digestConversationSourceSegment(
-                        source,
-                        historySlice.startOffset,
-                        historyBoundary.offset,
-                        signal
-                    );
-                    if (!restartSegmentDigest) {
-                        return {
-                            interactions: [],
-                            sourceRevision: historySlice.sourceRevision,
-                            partial: false,
-                            telemetryContext,
-                            telemetryPaths,
-                            historySlice: { complete: false, blocked: true },
-                        };
-                    }
                     return {
                         interactions: interactions.slice(
                             0,
@@ -1658,7 +1708,7 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                             restartInteractionId: historyBoundary.interactionId,
                             restartRecordEndOffset: historyBoundary.recordEndOffset,
                             restartRecordDigest: historyBoundary.recordDigest,
-                            restartSegmentDigest,
+                            restartSegmentDigest: historyBoundary.segmentDigest,
                             complete: false,
                         },
                     };
@@ -1682,7 +1732,10 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                     partial: false,
                     telemetryContext,
                     telemetryPaths,
-                    historySlice: { complete: result.nextOffset >= source.size },
+                    historySlice: {
+                        complete: result.nextOffset >= source.size,
+                        completeSegmentDigest: result.consumedDigest,
+                    },
                 };
             }
             const partial = continuing ? previous.partial : result.partial;

--- a/src/aiSessions/conversation/source.ts
+++ b/src/aiSessions/conversation/source.ts
@@ -4,6 +4,7 @@ import { createHash } from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
 import type { AiSessionConversationSourceCandidate } from '../types';
+import type { ConversationAbortSignal } from './types';
 
 const NO_FOLLOW_FLAG =
     (fs.constants as Record<string, number>).O_NOFOLLOW || 0;
@@ -44,7 +45,8 @@ async function hashRange(
 export async function digestConversationSourceRange(
     source: OpenConversationSource,
     startOffset: number,
-    endOffset: number
+    endOffset: number,
+    signal?: ConversationAbortSignal
 ): Promise<string | undefined> {
     if (!Number.isSafeInteger(startOffset) || !Number.isSafeInteger(endOffset)
         || startOffset < 0 || endOffset <= startOffset
@@ -52,10 +54,49 @@ export async function digestConversationSourceRange(
         || endOffset - startOffset > CONVERSATION_RECORD_PROOF_MAX_BYTES) {
         return undefined;
     }
-    return hashRange(source.handle, startOffset, endOffset - startOffset);
+    if (signal?.aborted) {
+        return undefined;
+    }
+    const digest = await hashRange(source.handle, startOffset, endOffset - startOffset);
+    return signal?.aborted ? undefined : digest;
+}
+
+/** Hashes one bounded background-index segment without allocating it whole. */
+export async function digestConversationSourceSegment(
+    source: OpenConversationSource,
+    startOffset: number,
+    endOffset: number,
+    signal?: ConversationAbortSignal
+): Promise<string | undefined> {
+    if (!Number.isSafeInteger(startOffset) || !Number.isSafeInteger(endOffset)
+        || startOffset < 0 || endOffset <= startOffset
+        || endOffset > source.size
+        || endOffset - startOffset > CONVERSATION_HISTORY_SEGMENT_PROOF_MAX_BYTES) {
+        return undefined;
+    }
+    const hash = createHash('sha256');
+    const buffer = Buffer.alloc(64 * 1024);
+    let offset = startOffset;
+    while (offset < endOffset) {
+        if (signal?.aborted) {
+            return undefined;
+        }
+        const length = Math.min(buffer.length, endOffset - offset);
+        const result = await source.handle.read(buffer, 0, length, offset);
+        if (signal?.aborted || result.bytesRead <= 0) {
+            return undefined;
+        }
+        hash.update(buffer.subarray(0, result.bytesRead));
+        offset += result.bytesRead;
+    }
+    return hash.digest('hex');
 }
 
 const CONVERSATION_RECORD_PROOF_MAX_BYTES = 1024 * 1024 + 1;
+// A 4 MiB requested slice may complete the physical line straddling its
+// boundary. JSONL rejects lines over 1 MiB, so 8 MiB is a hard ceiling with
+// room for format evolution while keeping verification bounded.
+const CONVERSATION_HISTORY_SEGMENT_PROOF_MAX_BYTES = 8 * 1024 * 1024;
 
 function hasStableFileIdentity(stat: fs.Stats): boolean {
     return Number.isFinite(stat.dev) && stat.dev > 0

--- a/src/aiSessions/conversation/source.ts
+++ b/src/aiSessions/conversation/source.ts
@@ -96,7 +96,7 @@ const CONVERSATION_RECORD_PROOF_MAX_BYTES = 1024 * 1024 + 1;
 // A 4 MiB requested slice may complete the physical line straddling its
 // boundary. JSONL rejects lines over 1 MiB, so 8 MiB is a hard ceiling with
 // room for format evolution while keeping verification bounded.
-const CONVERSATION_HISTORY_SEGMENT_PROOF_MAX_BYTES = 8 * 1024 * 1024;
+const CONVERSATION_HISTORY_SEGMENT_PROOF_MAX_BYTES = 10 * 1024 * 1024;
 
 function hasStableFileIdentity(stat: fs.Stats): boolean {
     return Number.isFinite(stat.dev) && stat.dev > 0

--- a/src/aiSessions/conversation/types.ts
+++ b/src/aiSessions/conversation/types.ts
@@ -12,6 +12,12 @@ import type {
 export const CONVERSATION_LIMITS = Object.freeze({
     previewGraphemes: 160,
     maxOutlineInteractions: 2_000,
+    // Background history paging has its own bounded store. This is larger
+    // than the outline window because it backs older pages, but it must not
+    // turn a very large transcript into an unbounded host-memory cache.
+    maxHistoryIndexInteractions: 10_000,
+    maxHistoryIndexBytes: 32 * 1024 * 1024,
+    historyIndexSliceBytes: 4 * 1024 * 1024,
     maxHistoryRestartPointIdLength: 256,
     maxPageInteractions: 20,
     maxPageBytes: 512 * 1024,
@@ -457,7 +463,52 @@ export interface ConversationHistoryRestartSnapshot {
     sourceSize: number;
     sourceRevision: string;
     reducerVersion: 1;
+    /** Stable file-instance identity, excluding normal append metadata. */
+    sourceEpoch: string;
+    /** Hashes of the snapshot's old prefix edges for append verification. */
+    sourceFirstHash: string;
+    sourceLastHash: string;
+    /** Set only after the adapter proved this source extends this exact index. */
+    continuationOf?: {
+        sourceIdentity: string;
+        sourceSize: number;
+        sourceRevision: string;
+        reducerVersion: 1;
+    };
     points: ConversationHistoryRestartPoint[];
+}
+
+/** A provider-owned replay request. The generic indexer never interprets
+ * provider JSONL; it only asks a reducer to advance between proven points. */
+export interface ConversationHistoryIndexSliceRequest {
+    sourceIdentity: string;
+    sourceSize: number;
+    sourceRevision: string;
+    reducerVersion: 1;
+    /** Zero, or the offset of a restart point returned by the same snapshot. */
+    startOffset: number;
+}
+
+/** One immutable, restart-safe prefix segment produced by a provider reducer. */
+export interface ConversationHistoryIndexSlice {
+    sourceIdentity: string;
+    sourceSize: number;
+    sourceRevision: string;
+    reducerVersion: 1;
+    startOffset: number;
+    /** The next slice must start here; it is a proven restart point. */
+    nextOffset?: number;
+    /** Identity of that exact restart point, when nextOffset is present. */
+    restartInteractionId?: string;
+    /** Physical-record proof for that restart point, never sent to the UI. */
+    restartRecordEndOffset?: number;
+    restartRecordDigest?: string;
+    /** Digest of the entire committed byte segment for this slice. */
+    restartSegmentDigest?: string;
+    interactions: ConversationInteraction[];
+    complete: boolean;
+    /** The bounded reader reached its budget before another safe boundary. */
+    blocked?: boolean;
 }
 
 export interface ConversationAbortSignal {
@@ -533,6 +584,11 @@ export interface ConversationProviderAdapter extends AiSessionDisposable {
     getHistoryRestartPoints?(
         sessionId: string
     ): Promise<ConversationHistoryRestartSnapshot | undefined>;
+    readHistoryIndexSlice?(
+        sessionId: string,
+        request: ConversationHistoryIndexSliceRequest,
+        signal?: ConversationAbortSignal
+    ): Promise<ConversationHistoryIndexSlice | undefined>;
     readSubagents?(
         sessionId: string,
         signal?: ConversationAbortSignal

--- a/src/aiSessions/conversation/types.ts
+++ b/src/aiSessions/conversation/types.ts
@@ -505,6 +505,8 @@ export interface ConversationHistoryIndexSlice {
     restartRecordDigest?: string;
     /** Digest of the entire committed byte segment for this slice. */
     restartSegmentDigest?: string;
+    /** Digest of [startOffset, sourceSize) for a completed slice. */
+    completeSegmentDigest?: string;
     interactions: ConversationInteraction[];
     complete: boolean;
     /** The bounded reader reached its budget before another safe boundary. */

--- a/src/aiSessions/conversation/viewer.ts
+++ b/src/aiSessions/conversation/viewer.ts
@@ -2676,7 +2676,10 @@ export class ConversationViewer implements ConversationViewerApi {
             }
             this.stale = false;
             if (preserveSelection) {
-                if (!this.outlineController.contains(page.anchorInteractionId)) {
+                // A prepended page may be older than the bounded outline.
+                // Keep the current selection anchored in that outline rather
+                // than rejecting a perfectly valid, cursor-authorized page.
+                if (!this.outlineController.contains(preferredInteractionId)) {
                     await this.publishFailure(replaceDocument, updateKind);
                     return false;
                 }

--- a/src/aiSessions/conversation/viewer.ts
+++ b/src/aiSessions/conversation/viewer.ts
@@ -458,6 +458,8 @@ export class ConversationViewer implements ConversationViewerApi {
         token: number;
         request: ConversationViewerLoadEarlierMessage;
         target: ConversationViewerTarget;
+        /** A stale before-page retry had to refresh around the selection. */
+        staleFallback?: boolean;
         abortController?: ConversationAbortController;
         timer?: unknown;
     };
@@ -1123,7 +1125,7 @@ export class ConversationViewer implements ConversationViewerApi {
             cursor,
             expectedRevision: outline.sourceRevision,
             limit: CONVERSATION_LIMITS.maxPageInteractions,
-        }, 'before', false, 'refresh', this.outlineController.selection, true);
+        }, 'before', false, 'refresh', this.outlineController.selection, true, backfill);
         backfill.abortController = this.abortController;
         const timeout = () => {
             if (this.earlierPageBackfill !== backfill) {
@@ -1171,10 +1173,18 @@ export class ConversationViewer implements ConversationViewerApi {
                     // progress: remember this boundary so ack-triggered
                     // restarts stop retrying it forever.
                     this.earlierBackfillStuckAnchor = madeProgress
+                        || backfill.staleFallback
                         ? undefined
                         : oldestBefore;
                     if (!madeProgress) {
-                        this.settleEarlierPageBackfill(request, 'stalled');
+                        // A stale cursor retry intentionally falls back to
+                        // an around-selection page. It did not prepend, but
+                        // it also did not prove this cursor is terminal; keep
+                        // it available for the next user-requested attempt.
+                        this.settleEarlierPageBackfill(
+                            request,
+                            backfill.staleFallback ? 'busy' : 'stalled'
+                        );
                     }
                 },
                 () => {
@@ -2351,8 +2361,18 @@ export class ConversationViewer implements ConversationViewerApi {
                             !== interaction.responseState
                     ).map(interaction => interaction.id)
                     : [];
+                // A completed background history index can replace the
+                // bounded tail with a continuous source without changing
+                // either the source revision or the most recent outline
+                // IDs. Its total/partial metadata still changes the page
+                // boundary (and therefore its earlier cursor), so it must
+                // not take the lifecycle-only fast path.
+                const pagingMetadataChanged = retainedOutline.totalInteractions
+                    !== outline.totalInteractions
+                    || retainedOutline.partial !== outline.partial;
                 if (retainedRevisionMatches
-                    && !lifecycleChangedInteractionIds.length) {
+                    && !lifecycleChangedInteractionIds.length
+                    && !pagingMetadataChanged) {
                     void this.telemetryController.refresh(
                         target,
                         generation,
@@ -2375,7 +2395,8 @@ export class ConversationViewer implements ConversationViewerApi {
                     }
                 }
                 if (retainedRevisionMatches
-                    && !lifecycleProjectionInteractionId) {
+                    && !lifecycleProjectionInteractionId
+                    && !pagingMetadataChanged) {
                     if (this.outlineController.replace(
                         outline,
                         selectedInteractionId
@@ -2513,9 +2534,13 @@ export class ConversationViewer implements ConversationViewerApi {
             this.stale = false;
             if (updateKind === 'refresh') {
                 if (selectedRefreshPage) {
-                    this.mergeRefreshPage(selectedRefreshPage, outline);
+                    this.mergeRefreshPage(
+                        selectedRefreshPage,
+                        outline,
+                        retainedRevisionMatches
+                    );
                 }
-                this.mergeRefreshPage(page, outline);
+                this.mergeRefreshPage(page, outline, retainedRevisionMatches);
             } else {
                 this.retain(page, 'replace');
             }
@@ -2603,7 +2628,8 @@ export class ConversationViewer implements ConversationViewerApi {
         replaceDocument: boolean,
         updateKind: ConversationViewerPageMessage['updateKind'],
         preferredInteractionId: string,
-        preserveSelection = false
+        preserveSelection = false,
+        earlierBackfill?: NonNullable<ConversationViewer['earlierPageBackfill']>
     ): Promise<boolean> {
         const target = this.target;
         const panel = this.panel;
@@ -2655,6 +2681,9 @@ export class ConversationViewer implements ConversationViewerApi {
                     return false;
                 }
                 retriedStaleRevision = true;
+                if (placement === 'before' && earlierBackfill) {
+                    earlierBackfill.staleFallback = true;
+                }
                 page = await this.options.readPage({
                     provider: target.provider,
                     sessionId: this.effectiveSessionId(target),
@@ -2675,19 +2704,23 @@ export class ConversationViewer implements ConversationViewerApi {
                 return false;
             }
             this.stale = false;
+            if (retriedStaleRevision && outline) {
+                // A retry is a new authoritative snapshot even while the
+                // user reads an older page. Advance the outline revision
+                // before retaining the selection for later before-page reads.
+                if (!this.outlineController.replace(
+                    outline,
+                    preferredInteractionId
+                )) {
+                    await this.publishFailure(replaceDocument, updateKind);
+                    return false;
+                }
+            }
             if (preserveSelection) {
                 // A prepended page may be older than the bounded outline.
                 // Keep the current selection anchored in that outline rather
                 // than rejecting a perfectly valid, cursor-authorized page.
                 if (!this.outlineController.contains(preferredInteractionId)) {
-                    await this.publishFailure(replaceDocument, updateKind);
-                    return false;
-                }
-            } else if (retriedStaleRevision && outline) {
-                if (!this.outlineController.replace(
-                    outline,
-                    page.anchorInteractionId
-                )) {
                     await this.publishFailure(replaceDocument, updateKind);
                     return false;
                 }
@@ -2698,7 +2731,7 @@ export class ConversationViewer implements ConversationViewerApi {
                 }
             }
             if (retriedStaleRevision && outline) {
-                this.mergeRefreshPage(page, outline);
+                this.mergeRefreshPage(page, outline, false);
             } else {
                 this.retain(page, placement);
             }
@@ -3547,7 +3580,8 @@ export class ConversationViewer implements ConversationViewerApi {
 
     private mergeRefreshPage(
         page: ConversationPage,
-        outline: ConversationOutline
+        outline: ConversationOutline,
+        preserveOutOfOutline = true
     ): void {
         const outlineIds = new Set(
             outline.interactions.map(interaction => interaction.id)
@@ -3560,7 +3594,7 @@ export class ConversationViewer implements ConversationViewerApi {
         >();
         this.pages.forEach(retained => {
             retained.page.interactionStates.forEach(state => {
-                if (outlineIds.has(state.interactionId)) {
+                if (preserveOutOfOutline || outlineIds.has(state.interactionId)) {
                     loadedIds.add(state.interactionId);
                     if (!statesByInteraction.has(state.interactionId)) {
                         statesByInteraction.set(state.interactionId, {
@@ -3570,7 +3604,7 @@ export class ConversationViewer implements ConversationViewerApi {
                 }
             });
             retained.page.messages.forEach(message => {
-                if (!outlineIds.has(message.interactionId)) {
+                if (!preserveOutOfOutline && !outlineIds.has(message.interactionId)) {
                     return;
                 }
                 const messages = messagesByInteraction.get(message.interactionId)
@@ -3606,37 +3640,86 @@ export class ConversationViewer implements ConversationViewerApi {
             messages.push(copyMessage(message));
             messagesByInteraction.set(message.interactionId, messages);
         });
-        this.pages = outline.interactions.reduce(
-            (retainedPages: RetainedConversationPage[], interaction, index) => {
-                if (!loadedIds.has(interaction.id)) {
-                    return retainedPages;
-                }
-                const retainedState = statesByInteraction.get(interaction.id);
-                retainedPages.push({
-                    page: {
-                        provider: outline.provider,
-                        sessionId: outline.sessionId,
-                        sourceRevision: outline.sourceRevision,
-                        anchorInteractionId: interaction.id,
-                        messages: messagesByInteraction.get(interaction.id) || [],
-                        interactionStates: [{
-                            interactionId: interaction.id,
-                            responseState: interaction.responseState,
-                            ...(retainedState?.timestamp !== undefined
-                                ? { timestamp: retainedState.timestamp }
-                                : {}),
-                            ...(retainedState?.completedAt !== undefined
-                                ? { completedAt: retainedState.completedAt }
-                                : {}),
-                        }],
-                        isStart: index === 0,
-                        isEnd: index === outline.interactions.length - 1,
-                    },
-                });
-                return retainedPages;
-            },
-            []
-        );
+        const orderedIds: string[] = [];
+        const addOrderedId = (interactionId: string): void => {
+            if (loadedIds.has(interactionId) && !orderedIds.includes(interactionId)) {
+                orderedIds.push(interactionId);
+            }
+        };
+        if (preserveOutOfOutline) {
+            this.pages.forEach(retained => retained.page.interactionStates
+                .filter(state => !outlineIds.has(state.interactionId))
+                .forEach(state => addOrderedId(state.interactionId)));
+        }
+        outline.interactions.forEach(interaction => addOrderedId(interaction.id));
+        const outlineStates = new Map(outline.interactions.map(interaction => [
+            interaction.id,
+            interaction,
+        ]));
+        // Cursors describe the two outer edges only. Interior page cursors
+        // are already covered by retained interactions and must never be
+        // promoted to a rebuilt edge.
+        const oldestRetained = this.pages[0]?.page;
+        const newestRetained = this.pages[this.pages.length - 1]?.page;
+        // Overlap alone is not enough: an around page can include the last
+        // interaction of the oldest retained page while its cursor still
+        // starts later. Only an exact outer-boundary match can replace an
+        // existing edge cursor.
+        const refreshedOldestEdge = oldestRetained?.interactionStates[0]
+            ?.interactionId === page.interactionStates[0]?.interactionId;
+        const refreshedNewestEdge = newestRetained?.interactionStates[
+            newestRetained.interactionStates.length - 1
+        ]?.interactionId === page.interactionStates[
+            page.interactionStates.length - 1
+        ]?.interactionId;
+        const hadStart = refreshedOldestEdge
+            ? page.isStart
+            : (oldestRetained?.isStart ?? page.isStart);
+        const hadEnd = refreshedNewestEdge
+            ? page.isEnd
+            : (newestRetained?.isEnd ?? page.isEnd);
+        const previousCursor = refreshedOldestEdge
+            ? page.previousCursor
+            : (oldestRetained
+                ? oldestRetained.previousCursor
+                : page.previousCursor);
+        const nextCursor = refreshedNewestEdge
+            ? page.nextCursor
+            : (newestRetained
+                ? newestRetained.nextCursor
+                : page.nextCursor);
+        this.pages = orderedIds.map((interactionId, index) => {
+            const retainedState = statesByInteraction.get(interactionId);
+            const outlineState = outlineStates.get(interactionId);
+            return {
+                page: {
+                    provider: outline.provider,
+                    sessionId: outline.sessionId,
+                    sourceRevision: outline.sourceRevision,
+                    anchorInteractionId: interactionId,
+                    messages: messagesByInteraction.get(interactionId) || [],
+                    interactionStates: [{
+                        interactionId,
+                        responseState: outlineState?.responseState
+                            || retainedState?.responseState || 'complete',
+                        ...(retainedState?.timestamp !== undefined
+                            ? { timestamp: retainedState.timestamp }
+                            : {}),
+                        ...(retainedState?.completedAt !== undefined
+                            ? { completedAt: retainedState.completedAt }
+                            : {}),
+                    }],
+                    isStart: index === 0 && hadStart,
+                    isEnd: index === orderedIds.length - 1 && hadEnd,
+                    ...(index === 0 && previousCursor !== undefined
+                        ? { previousCursor }
+                        : {}),
+                    ...(index === orderedIds.length - 1 && nextCursor !== undefined
+                        ? { nextCursor }
+                        : {}),
+                },
+            };
+        });
         this.evict();
     }
 

--- a/tests/contract/aiSessions/claudeConversationAdapter.test.js
+++ b/tests/contract/aiSessions/claudeConversationAdapter.test.js
@@ -194,6 +194,62 @@ test('CONVERSATION-HISTORY-INDEX-SLICE-001 Claude advances immutable history sli
     }), undefined, 'a changed source snapshot must reject a late slice');
 });
 
+test('CONVERSATION-HISTORY-INDEX-SLICE-002 Claude proves a multi-slice prefix from the parsed bytes', async t => {
+    const source = await createFixture(t);
+    const filler = index => ({
+        type: 'summary',
+        index,
+        summary: 'x'.repeat(4096),
+    });
+    await fs.promises.writeFile(source.sourcePath, [
+        { type: 'user', uuid: 'first', message: { role: 'user', content: 'first' } },
+        ...Array.from({ length: 1_100 }, (_value, index) => filler(index)),
+        { type: 'user', uuid: 'second', message: { role: 'user', content: 'second' } },
+    ].map(record => JSON.stringify(record)).join('\n') + '\n');
+    const adapter = createAdapter(source);
+    t.after(() => adapter.dispose());
+    await adapter.readOutline(sessionId);
+    const snapshot = await adapter.getHistoryRestartPoints(sessionId);
+    const first = await adapter.readHistoryIndexSlice(sessionId, {
+        ...snapshot,
+        startOffset: 0,
+    });
+    assert.equal(first.complete, false);
+    assert.ok(first.restartRecordEndOffset > first.nextOffset, JSON.stringify(first));
+    assert.ok(first.restartRecordDigest);
+    assert.ok(first.restartSegmentDigest);
+    const second = await adapter.readHistoryIndexSlice(sessionId, {
+        ...snapshot,
+        startOffset: first.nextOffset,
+    });
+    assert.equal(second.complete, true);
+    assert.deepEqual(
+        [...first.interactions, ...second.interactions].map(item => item.userMarkdown),
+        ['first', 'second']
+    );
+    adapter.startHistoryIndex(sessionId, {
+        interactions: [],
+        sourceRevision: (await adapter.readOutline(sessionId)).sourceRevision,
+        partial: true,
+    }, true);
+    for (let attempt = 0; attempt < 40; attempt++) {
+        await new Promise(resolve => setTimeout(resolve, 10));
+        if (adapter.historyIndex.state(sessionId)?.complete) {
+            break;
+        }
+    }
+    assert.equal(adapter.historyIndex.state(sessionId)?.complete, true,
+        JSON.stringify(adapter.historyIndex.state(sessionId)));
+    assert.deepEqual((await adapter.readOutline(sessionId)).interactions
+        .map(item => item.userPreview), ['first', 'second']);
+    await fs.promises.appendFile(source.sourcePath, '\n');
+    await adapter.readOutline(sessionId);
+    assert.ok((await adapter.getHistoryRestartPoints(
+        sessionId,
+        adapter.historyIndex.state(sessionId)
+    ))?.continuationOf, 'a complete final proof must continue after an append');
+});
+
 test('CONVERSATION-HISTORY-RESTART-POINT-003 Claude seals an unsettled tool call before a later turn', async t => {
     const source = await createFixture(t);
     await fs.promises.writeFile(source.sourcePath, [

--- a/tests/contract/aiSessions/claudeConversationAdapter.test.js
+++ b/tests/contract/aiSessions/claudeConversationAdapter.test.js
@@ -156,6 +156,44 @@ test('CONVERSATION-HISTORY-RESTART-POINT-001 Claude restart points replay their 
     }
 });
 
+test('CONVERSATION-HISTORY-INDEX-SLICE-001 Claude advances immutable history slices only between proven restart points', async t => {
+    const source = await createFixture(t);
+    const adapter = createAdapter(source);
+    t.after(() => adapter.dispose());
+    const full = await readWholeConversation(adapter);
+    const snapshot = await adapter.getHistoryRestartPoints(sessionId);
+    assert.ok(snapshot);
+
+    const interactionIds = [];
+    let startOffset = 0;
+    for (;;) {
+        const slice = await adapter.readHistoryIndexSlice(sessionId, {
+            ...snapshot,
+            startOffset,
+        });
+        assert.ok(slice);
+        interactionIds.push(...slice.interactions.map(item => item.id));
+        if (slice.complete) {
+            assert.equal(slice.nextOffset, undefined);
+            break;
+        }
+        assert.ok(Number.isSafeInteger(slice.nextOffset));
+        assert.ok(slice.nextOffset > startOffset);
+        startOffset = slice.nextOffset;
+    }
+    assert.deepEqual(interactionIds, full.outline.interactions.map(item => item.id));
+    assert.deepEqual(
+        (await adapter.readOutline(sessionId)).interactions,
+        full.outline.interactions,
+        'background replay must not mutate the foreground cache'
+    );
+    await fs.promises.appendFile(source.sourcePath, '\n');
+    assert.equal(await adapter.readHistoryIndexSlice(sessionId, {
+        ...snapshot,
+        startOffset: 0,
+    }), undefined, 'a changed source snapshot must reject a late slice');
+});
+
 test('CONVERSATION-HISTORY-RESTART-POINT-003 Claude seals an unsettled tool call before a later turn', async t => {
     const source = await createFixture(t);
     await fs.promises.writeFile(source.sourcePath, [

--- a/tests/contract/aiSessions/conversationSources.test.js
+++ b/tests/contract/aiSessions/conversationSources.test.js
@@ -6,7 +6,12 @@ const os = require('node:os');
 const path = require('node:path');
 const test = require('node:test');
 
-const { openValidatedConversationSource, isConversationSourceContinuation } = require('../../../out/aiSessions/conversation/source');
+const {
+    digestConversationSourceSegment,
+    openValidatedConversationSource,
+    isConversationSourceContinuation,
+} = require('../../../out/aiSessions/conversation/source');
+const { ConversationAbortController } = require('../../../out/aiSessions/conversation/types');
 const KimiSessionService = require('../../../out/services/kimiSessionService').default;
 const CodexSessionService = require('../../../out/services/codexSessionService').default;
 const ClaudeSessionService = require('../../../out/services/claudeSessionService').default;
@@ -293,6 +298,49 @@ test('SECURITY-AI-SESSION-CONVERSATION-SOURCE-005 rejects an in-place same-inode
     assert.equal(before.birthtimeMs, after.birthtimeMs);
     assert.equal(after.size >= before.size, true);
     assert.equal(await isConversationSourceContinuation(before, after), false);
+    await before.handle.close();
+    await after.handle.close();
+});
+
+test('SECURITY-AI-SESSION-CONVERSATION-SOURCE-006 proves a whole retained prefix, not only its edges', async t => {
+    const sandbox = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'steward-conversation-prefix-proof-'));
+    t.after(() => fs.promises.rm(sandbox, { recursive: true, force: true }));
+    const providerHome = path.join(sandbox, 'provider-home');
+    const sourcePath = path.join(providerHome, 'conversation.jsonl');
+    const original = Buffer.concat([
+        Buffer.alloc(64 * 1024, 'a'),
+        Buffer.alloc(128 * 1024, 'b'),
+        Buffer.alloc(64 * 1024, 'c'),
+    ]);
+    await fs.promises.mkdir(providerHome, { recursive: true });
+    await fs.promises.writeFile(sourcePath, original);
+    const before = await openValidatedConversationSource({ providerHome, sourcePath });
+    const beforeDigest = await digestConversationSourceSegment(
+        before,
+        0,
+        before.size
+    );
+
+    const rewritten = Buffer.from(original);
+    rewritten.fill('x', 64 * 1024, 64 * 1024 + 128 * 1024);
+    await fs.promises.writeFile(sourcePath, rewritten);
+    await fs.promises.appendFile(sourcePath, Buffer.from('append'));
+    const after = await openValidatedConversationSource({ providerHome, sourcePath });
+    const afterDigest = await digestConversationSourceSegment(
+        after,
+        0,
+        before.size
+    );
+    const cancelled = new ConversationAbortController();
+    cancelled.abort();
+    assert.equal(await isConversationSourceContinuation(before, after), true);
+    assert.notEqual(afterDigest, beforeDigest);
+    assert.equal(await digestConversationSourceSegment(
+        after,
+        0,
+        before.size,
+        cancelled.signal
+    ), undefined);
     await before.handle.close();
     await after.handle.close();
 });

--- a/tests/contract/aiSessions/conversationSources.test.js
+++ b/tests/contract/aiSessions/conversationSources.test.js
@@ -7,6 +7,7 @@ const path = require('node:path');
 const test = require('node:test');
 
 const {
+    digestConversationSourceRange,
     digestConversationSourceSegment,
     openValidatedConversationSource,
     isConversationSourceContinuation,
@@ -336,6 +337,12 @@ test('SECURITY-AI-SESSION-CONVERSATION-SOURCE-006 proves a whole retained prefix
     assert.equal(await isConversationSourceContinuation(before, after), true);
     assert.notEqual(afterDigest, beforeDigest);
     assert.equal(await digestConversationSourceSegment(
+        after,
+        0,
+        before.size,
+        cancelled.signal
+    ), undefined);
+    assert.equal(await digestConversationSourceRange(
         after,
         0,
         before.size,

--- a/tests/contract/aiSessions/kimiConversationAdapter.test.js
+++ b/tests/contract/aiSessions/kimiConversationAdapter.test.js
@@ -235,6 +235,64 @@ test('CONVERSATION-HISTORY-INDEX-SLICE-001 Kimi advances immutable history slice
     }), undefined, 'a changed source snapshot must reject a late slice');
 });
 
+test('CONVERSATION-HISTORY-INDEX-SLICE-003 Kimi proves a multi-slice prefix from the parsed bytes', async t => {
+    const source = await createFixture(t);
+    const filler = index => ({
+        timestamp: index,
+        message: { type: 'StatusUpdate', payload: { text: 'x'.repeat(4096) } },
+    });
+    await fs.promises.writeFile(source.sourcePath, [
+        { timestamp: 1, message: { type: 'TurnBegin', payload: { user_input: 'first' } } },
+        ...Array.from({ length: 1_100 }, (_value, index) => filler(index)),
+        { timestamp: 2, message: { type: 'TurnBegin', payload: { user_input: 'second' } } },
+    ].map(record => JSON.stringify(record)).join('\n') + '\n');
+    const adapter = createAdapter(source);
+    t.after(() => adapter.dispose());
+    await adapter.readOutline(sessionId);
+    const snapshot = await adapter.getHistoryRestartPoints(sessionId);
+    const first = await adapter.readHistoryIndexSlice(sessionId, {
+        ...snapshot,
+        startOffset: 0,
+    });
+    assert.equal(first.complete, false);
+    assert.ok(first.restartRecordEndOffset > first.nextOffset, JSON.stringify(first));
+    assert.ok(first.restartRecordDigest);
+    assert.ok(first.restartSegmentDigest);
+    const second = await adapter.readHistoryIndexSlice(sessionId, {
+        ...snapshot,
+        startOffset: first.nextOffset,
+    });
+    assert.equal(second.complete, true);
+    assert.deepEqual(
+        [...first.interactions, ...second.interactions].map(item => item.userMarkdown),
+        ['first', 'second']
+    );
+    // Exercise the real low-priority scheduler as well as the slice protocol:
+    // a completed index must replace the bounded foreground source atomically.
+    adapter.startHistoryIndex(sessionId, {
+        interactions: [],
+        sourceRevision: (await adapter.readOutline(sessionId)).sourceRevision,
+        partial: true,
+        telemetryPaths: [],
+    }, true);
+    for (let attempt = 0; attempt < 40; attempt++) {
+        await new Promise(resolve => setTimeout(resolve, 10));
+        if (adapter.historyIndex.state(sessionId)?.complete) {
+            break;
+        }
+    }
+    assert.equal(adapter.historyIndex.state(sessionId)?.complete, true,
+        JSON.stringify(adapter.historyIndex.state(sessionId)));
+    assert.deepEqual((await adapter.readOutline(sessionId)).interactions
+        .map(item => item.userPreview), ['first', 'second']);
+    await fs.promises.appendFile(source.sourcePath, '\n');
+    await adapter.readOutline(sessionId);
+    assert.ok((await adapter.getHistoryRestartPoints(
+        sessionId,
+        adapter.historyIndex.state(sessionId)
+    ))?.continuationOf, 'a complete final proof must continue after an append');
+});
+
 test('CONVERSATION-HISTORY-INDEX-SLICE-002 Kimi preserves an active EOF interaction while indexing', async t => {
     const source = await createFixture(t);
     await fs.promises.writeFile(source.sourcePath, [

--- a/tests/contract/aiSessions/kimiConversationAdapter.test.js
+++ b/tests/contract/aiSessions/kimiConversationAdapter.test.js
@@ -197,6 +197,75 @@ test('CONVERSATION-HISTORY-RESTART-POINT-001 Kimi restart points replay their in
     }
 });
 
+test('CONVERSATION-HISTORY-INDEX-SLICE-001 Kimi advances immutable history slices only between proven restart points', async t => {
+    const source = await createFixture(t);
+    const adapter = createAdapter(source);
+    t.after(() => adapter.dispose());
+    const full = await readWholeConversation(adapter);
+    const snapshot = await adapter.getHistoryRestartPoints(sessionId);
+    assert.ok(snapshot);
+
+    const interactionIds = [];
+    let startOffset = 0;
+    for (;;) {
+        const slice = await adapter.readHistoryIndexSlice(sessionId, {
+            ...snapshot,
+            startOffset,
+        });
+        assert.ok(slice);
+        interactionIds.push(...slice.interactions.map(item => item.id));
+        if (slice.complete) {
+            assert.equal(slice.nextOffset, undefined);
+            break;
+        }
+        assert.ok(Number.isSafeInteger(slice.nextOffset));
+        assert.ok(slice.nextOffset > startOffset);
+        startOffset = slice.nextOffset;
+    }
+    assert.deepEqual(interactionIds, full.outline.interactions.map(item => item.id));
+    assert.deepEqual(
+        (await adapter.readOutline(sessionId)).interactions,
+        full.outline.interactions,
+        'background replay must not mutate the foreground cache'
+    );
+    await fs.promises.appendFile(source.sourcePath, '\n');
+    assert.equal(await adapter.readHistoryIndexSlice(sessionId, {
+        ...snapshot,
+        startOffset: 0,
+    }), undefined, 'a changed source snapshot must reject a late slice');
+});
+
+test('CONVERSATION-HISTORY-INDEX-SLICE-002 Kimi preserves an active EOF interaction while indexing', async t => {
+    const source = await createFixture(t);
+    await fs.promises.writeFile(source.sourcePath, [
+        {
+            timestamp: 1000,
+            message: {
+                type: 'TurnBegin',
+                payload: { user_input: 'Still working' },
+            },
+        },
+        {
+            timestamp: 1001,
+            message: {
+                type: 'ContentPart',
+                payload: { type: 'text', text: 'Partial answer' },
+            },
+        },
+    ].map(record => JSON.stringify(record)).join('\n') + '\n');
+    const adapter = createAdapter(source);
+    t.after(() => adapter.dispose());
+    await adapter.readOutline(sessionId);
+    const snapshot = await adapter.getHistoryRestartPoints(sessionId);
+    const slice = await adapter.readHistoryIndexSlice(sessionId, {
+        ...snapshot,
+        startOffset: 0,
+    });
+    assert.equal(slice.complete, true);
+    assert.equal(slice.interactions.at(-1).responseState, 'inProgress');
+    assert.deepEqual(slice.interactions.at(-1).assistantMarkdown, ['Partial answer']);
+});
+
 test('CONVERSATION-HISTORY-RESTART-POINT-003 Kimi seals an unsettled tool call before a later turn', async t => {
     const source = await createFixture(t);
     await fs.promises.writeFile(source.sourcePath, [

--- a/tests/integration/dashboard/conversationViewer.test.js
+++ b/tests/integration/dashboard/conversationViewer.test.js
@@ -729,13 +729,20 @@ test('CONVERSATION-HISTORY-PAGING-001 prepends an indexed page older than the ou
     const sessionId = 'indexed-history-boundary';
     const olderInteractions = ['input-1', 'input-2'];
     const recentInteractions = ['input-2001', 'input-2002'];
+    let onChange;
+    let responseState = 'inProgress';
     const { viewer, panel } = createViewer({
+        watch: (_provider, _sessionId, callback) => {
+            onChange = callback;
+            return { dispose() {} };
+        },
         // The outline deliberately retains only the most recent window. The
         // older page is valid via its opaque cursor but must not become the
         // selected outline item merely because it was prepended.
         readOutline: async () => outline(sessionId, recentInteractions, {
             totalInteractions: 2_002,
             partial: true,
+            responseStates: { 'input-2002': responseState },
         }),
         readPage: async request => request.direction === 'before'
             ? page(sessionId, 'input-1', 'message', {
@@ -746,6 +753,7 @@ test('CONVERSATION-HISTORY-PAGING-001 prepends an indexed page older than the ou
                 ...page(sessionId, 'input-2002', 'message', {
                     interactionIds: recentInteractions,
                     anchorInteractionId: 'input-2002',
+                    responseStates: { 'input-2002': responseState },
                 }),
                 previousCursor: 'indexed-cursor',
                 isStart: false,
@@ -781,6 +789,242 @@ test('CONVERSATION-HISTORY-PAGING-001 prepends an indexed page older than the ou
     ).at(-1);
     assert.match(publication.html, /data-message-id="input-1:user"/);
     assert.equal(publication.selectedInteractionId, 'input-2002');
+    // A same-revision lifecycle refresh must not rebuild retained pages only
+    // from the bounded outline and erase the older cursor-authorized page.
+    responseState = 'complete';
+    onChange();
+    for (let attempt = 0; attempt < 20; attempt++) {
+        await new Promise(resolve => setImmediate(resolve));
+        const latest = panel.postedMessages.filter(message =>
+            message.type === 'conversation-viewer-page'
+        ).at(-1);
+        if (latest?.interactionStates?.some(state =>
+            state.interactionId === 'input-2002'
+                && state.responseState === 'complete')) {
+            break;
+        }
+    }
+    const refreshed = panel.postedMessages.filter(message =>
+        message.type === 'conversation-viewer-page'
+    ).at(-1);
+    assert.match(refreshed.html, /data-message-id="input-1:user"/);
+    viewer.dispose();
+});
+
+test('CONVERSATION-HISTORY-PAGING-002 advances the outline revision after a stale earlier-page retry', async () => {
+    const requests = [];
+    let revision = 'r1';
+    const { viewer, panel } = createViewer({
+        readOutline: async (_provider, sessionId) => outline(
+            sessionId,
+            ['input-2001', 'input-2002'],
+            { sourceRevision: revision, totalInteractions: 2_002, partial: true }
+        ),
+        readPage: async request => {
+            requests.push(request);
+            if (request.direction === 'before' && request.expectedRevision === 'r1') {
+                revision = 'r2';
+                throw new ConversationError('staleRevision');
+            }
+            return request.direction === 'before'
+                ? page(request.sessionId, 'input-1', 'older', {
+                    interactionIds: ['input-1'],
+                    sourceRevision: request.expectedRevision,
+                })
+                : {
+                    ...page(request.sessionId, 'input-2002', 'recent', {
+                        interactionIds: ['input-2001', 'input-2002'],
+                        sourceRevision: request.expectedRevision,
+                    }),
+                    previousCursor: 'older-cursor',
+                    isStart: false,
+                };
+        },
+    });
+    await viewer.open(target('history-stale', 'input-2002'));
+    const initial = decodeInitialPublication(panel.webview.html);
+    await panel.receive({
+        type: 'conversation-viewer-applied',
+        version: 1,
+        subscriptionGeneration: initial.subscriptionGeneration,
+        requestId: initial.requestId,
+        htmlSignature: initial.htmlSignature,
+    });
+    await panel.receive({
+        type: 'conversation-viewer-load-earlier',
+        version: 1,
+        requestId: 1,
+        subscriptionGeneration: initial.subscriptionGeneration,
+    });
+    for (let attempt = 0; attempt < 20; attempt++) {
+        await new Promise(resolve => setImmediate(resolve));
+        if (panel.postedMessages.some(message =>
+            message.type === 'conversation-viewer-load-earlier-result'
+                && message.requestId === 1 && message.outcome === 'busy')) {
+            break;
+        }
+    }
+    assert.equal(viewer.outlineController.snapshot.sourceRevision, 'r2');
+    await panel.receive({
+        type: 'conversation-viewer-load-earlier',
+        version: 1,
+        requestId: 2,
+        subscriptionGeneration: initial.subscriptionGeneration,
+    });
+    for (let attempt = 0; attempt < 20; attempt++) {
+        await new Promise(resolve => setImmediate(resolve));
+        if (requests.some(request => request.direction === 'before'
+            && request.expectedRevision === 'r2')) {
+            break;
+        }
+    }
+    assert.ok(requests.some(request => request.direction === 'before'
+        && request.expectedRevision === 'r2'),
+    `a stale around fallback must leave the boundary retryable: ${JSON.stringify(requests)}`);
+    viewer.dispose();
+});
+
+test('CONVERSATION-HISTORY-PAGING-003 refreshes the page boundary after history indexing completes', async () => {
+    const sessionId = 'indexed-history-complete';
+    let indexed = false;
+    let onChange;
+    let beforeRequests = 0;
+    const { viewer, panel } = createViewer({
+        watch: (_provider, _sessionId, callback) => {
+            onChange = callback;
+            return { dispose() {} };
+        },
+        readOutline: async () => outline(sessionId, ['input-2001', 'input-2002'], {
+            sourceRevision: 'r1',
+            totalInteractions: indexed ? 2_002 : 2,
+            partial: !indexed,
+        }),
+        readPage: async request => {
+            if (request.direction === 'before') {
+                beforeRequests += 1;
+                return page(sessionId, 'input-1', 'older', {
+                    interactionIds: ['input-1'],
+                    sourceRevision: 'r1',
+                });
+            }
+            return {
+                ...page(sessionId, 'input-2002', 'recent', {
+                    interactionIds: ['input-2001', 'input-2002'],
+                    anchorInteractionId: 'input-2002',
+                    sourceRevision: 'r1',
+                }),
+                ...(indexed ? { previousCursor: 'complete-history-cursor' } : {}),
+                isStart: !indexed,
+            };
+        },
+    });
+    await viewer.open(target(sessionId, 'input-2002'));
+    const initial = decodeInitialPublication(panel.webview.html);
+    await panel.receive({
+        type: 'conversation-viewer-applied',
+        version: 1,
+        subscriptionGeneration: initial.subscriptionGeneration,
+        requestId: initial.requestId,
+        htmlSignature: initial.htmlSignature,
+    });
+    indexed = true;
+    onChange();
+    for (let attempt = 0; attempt < 20; attempt++) {
+        await new Promise(resolve => setImmediate(resolve));
+        const latest = panel.postedMessages.filter(message =>
+            message.type === 'conversation-viewer-page'
+        ).at(-1);
+        if (latest?.totalInteractions === 2_002) {
+            break;
+        }
+    }
+    await panel.receive({
+        type: 'conversation-viewer-load-earlier',
+        version: 1,
+        requestId: 1,
+        subscriptionGeneration: initial.subscriptionGeneration,
+    });
+    for (let attempt = 0; attempt < 20 && !beforeRequests; attempt++) {
+        await new Promise(resolve => setImmediate(resolve));
+    }
+    assert.equal(beforeRequests, 1,
+        `the completed index must refresh the cursor-authorized page boundary: ${JSON.stringify(panel.postedMessages)}`);
+    viewer.dispose();
+});
+
+test('CONVERSATION-HISTORY-PAGING-004 keeps an outer cursor when a refresh only overlaps its page', async () => {
+    const sessionId = 'history-partial-edge-refresh';
+    let responseState = 'inProgress';
+    let onChange;
+    let beforeRequests = 0;
+    const { viewer, panel } = createViewer({
+        watch: (_provider, _sessionId, callback) => {
+            onChange = callback;
+            return { dispose() {} };
+        },
+        readOutline: async () => outline(sessionId, ['input-1', 'input-2', 'input-3'], {
+            sourceRevision: 'r1',
+            responseStates: { 'input-2': responseState },
+        }),
+        readPage: async request => {
+            if (request.direction === 'before') {
+                beforeRequests += 1;
+                return page(sessionId, 'input-0', 'older', {
+                    interactionIds: ['input-0'],
+                    sourceRevision: 'r1',
+                });
+            }
+            return responseState === 'inProgress'
+                ? page(sessionId, 'input-1', 'initial', {
+                    interactionIds: ['input-1', 'input-2'],
+                    anchorInteractionId: 'input-2',
+                    sourceRevision: 'r1',
+                    responseStates: { 'input-2': responseState },
+                })
+                : {
+                    ...page(sessionId, 'input-2', 'refresh', {
+                        interactionIds: ['input-2', 'input-3'],
+                        anchorInteractionId: 'input-2',
+                        sourceRevision: 'r1',
+                        responseStates: { 'input-2': responseState },
+                    }),
+                    previousCursor: 'input-2-boundary',
+                    isStart: false,
+                };
+        },
+    });
+    await viewer.open(target(sessionId, 'input-2'));
+    const initial = decodeInitialPublication(panel.webview.html);
+    await panel.receive({
+        type: 'conversation-viewer-applied',
+        version: 1,
+        subscriptionGeneration: initial.subscriptionGeneration,
+        requestId: initial.requestId,
+        htmlSignature: initial.htmlSignature,
+    });
+    responseState = 'complete';
+    onChange();
+    for (let attempt = 0; attempt < 20; attempt++) {
+        await new Promise(resolve => setImmediate(resolve));
+        if (panel.postedMessages.some(message =>
+            message.type === 'conversation-viewer-page'
+                && message.outline?.some(item => item.interactionId === 'input-3'))) {
+            break;
+        }
+    }
+    const refreshed = panel.postedMessages.filter(message =>
+        message.type === 'conversation-viewer-page'
+    ).at(-1);
+    assert.equal(refreshed.previousCursor, '');
+    await panel.receive({
+        type: 'conversation-viewer-load-earlier',
+        version: 1,
+        requestId: 1,
+        subscriptionGeneration: initial.subscriptionGeneration,
+    });
+    await new Promise(resolve => setImmediate(resolve));
+    assert.equal(beforeRequests, 0,
+        'an interior cursor must not be promoted to the oldest retained boundary');
     viewer.dispose();
 });
 

--- a/tests/integration/dashboard/conversationViewer.test.js
+++ b/tests/integration/dashboard/conversationViewer.test.js
@@ -725,6 +725,65 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-002 continues across a page boundar
     viewer.dispose();
 });
 
+test('CONVERSATION-HISTORY-PAGING-001 prepends an indexed page older than the outline window', async () => {
+    const sessionId = 'indexed-history-boundary';
+    const olderInteractions = ['input-1', 'input-2'];
+    const recentInteractions = ['input-2001', 'input-2002'];
+    const { viewer, panel } = createViewer({
+        // The outline deliberately retains only the most recent window. The
+        // older page is valid via its opaque cursor but must not become the
+        // selected outline item merely because it was prepended.
+        readOutline: async () => outline(sessionId, recentInteractions, {
+            totalInteractions: 2_002,
+            partial: true,
+        }),
+        readPage: async request => request.direction === 'before'
+            ? page(sessionId, 'input-1', 'message', {
+                interactionIds: olderInteractions,
+                anchorInteractionId: 'input-1',
+            })
+            : {
+                ...page(sessionId, 'input-2002', 'message', {
+                    interactionIds: recentInteractions,
+                    anchorInteractionId: 'input-2002',
+                }),
+                previousCursor: 'indexed-cursor',
+                isStart: false,
+            },
+    });
+
+    await viewer.open(target(sessionId, 'input-2002'));
+    const initial = decodeInitialPublication(panel.webview.html);
+    await panel.receive({
+        type: 'conversation-viewer-applied',
+        version: 1,
+        subscriptionGeneration: initial.subscriptionGeneration,
+        requestId: initial.requestId,
+        htmlSignature: initial.htmlSignature,
+    });
+    await panel.receive({
+        type: 'conversation-viewer-load-earlier',
+        version: 1,
+        requestId: 1,
+        subscriptionGeneration: initial.subscriptionGeneration,
+    });
+    for (let attempt = 0; attempt < 20; attempt++) {
+        await new Promise(resolve => setImmediate(resolve));
+        const latest = panel.postedMessages.filter(message =>
+            message.type === 'conversation-viewer-page'
+        ).at(-1);
+        if (latest?.html?.includes('data-message-id="input-1:user"')) {
+            break;
+        }
+    }
+    const publication = panel.postedMessages.filter(message =>
+        message.type === 'conversation-viewer-page'
+    ).at(-1);
+    assert.match(publication.html, /data-message-id="input-1:user"/);
+    assert.equal(publication.selectedInteractionId, 'input-2002');
+    viewer.dispose();
+});
+
 test('CONVERSATION-LARGE-SESSION-PERFORMANCE-002 settles a stalled earlier-page read', async () => {
     const sessionId = 'progressive-boundary-timeout';
     const interactionIds = ['input-1', 'input-2'];

--- a/tests/unit/aiSessions/conversationHistoryIndex.test.js
+++ b/tests/unit/aiSessions/conversationHistoryIndex.test.js
@@ -37,7 +37,9 @@ function slice(request, interactions, options = {}) {
         ...request,
         interactions,
         complete: options.complete === true,
-        ...(options.complete === true ? {} : {
+        ...(options.complete === true ? {
+            completeSegmentDigest: options.completeSegmentDigest || 'complete-segment',
+        } : {
             nextOffset: options.nextOffset,
         }),
     };
@@ -132,6 +134,31 @@ test('CONVERSATION-HISTORY-INDEX-004 capacity never publishes a non-contiguous p
     assert.equal(repeated.saturated, true);
 });
 
+test('CONVERSATION-HISTORY-INDEX-008 exposes completed data without cloning and releases unusable payloads', async () => {
+    const index = new ConversationHistoryIndex();
+    await index.advance('kimi:complete', source, async request =>
+        slice(request, [interaction('complete')], { complete: true })
+    );
+    assert.deepEqual(index.status('kimi:complete'), {
+        sourceRevision: 'r1',
+        complete: true,
+        saturated: false,
+        blocked: false,
+    });
+    assert.deepEqual(index.completedInteractions('kimi:complete', 'r1')
+        .map(item => item.id), ['complete']);
+    assert.equal(index.completedInteractions('kimi:complete', 'r2'), undefined);
+
+    const blocked = await index.advance('kimi:blocked-payload', source, async request => ({
+        ...request,
+        interactions: [],
+        complete: false,
+        blocked: true,
+    }));
+    assert.deepEqual(blocked.interactions, []);
+    assert.deepEqual(blocked.prefixSegments, []);
+});
+
 test('CONVERSATION-HISTORY-INDEX-005 a proven append replays only from the last safe boundary', async () => {
     const index = new ConversationHistoryIndex();
     const first = await index.advance('kimi:append', source, async request =>
@@ -186,6 +213,18 @@ test('CONVERSATION-HISTORY-INDEX-007 refuses a slice without a whole-prefix segm
     }));
     assert.equal(state, undefined);
     assert.deepEqual(index.state('kimi:unproven').interactions, []);
+
+    const unprovenComplete = await index.advance(
+        'kimi:unproven-complete',
+        source,
+        async request => ({
+            ...request,
+            interactions: [interaction('unproven-complete')],
+            complete: true,
+        })
+    );
+    assert.equal(unprovenComplete, undefined);
+    assert.deepEqual(index.state('kimi:unproven-complete').interactions, []);
 });
 
 test('CONVERSATION-HISTORY-INDEX-006 a range without a safe boundary stays blocked', async () => {

--- a/tests/unit/aiSessions/conversationHistoryIndex.test.js
+++ b/tests/unit/aiSessions/conversationHistoryIndex.test.js
@@ -1,0 +1,201 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+    ConversationHistoryIndex,
+} = require('../../../out/aiSessions/conversation/historyIndex');
+const {
+    ConversationAbortController,
+} = require('../../../out/aiSessions/conversation/types');
+
+const source = Object.freeze({
+    sourceIdentity: 'source-a',
+    sourceSize: 100,
+    sourceRevision: 'r1',
+    reducerVersion: 1,
+    sourceEpoch: 'inode-a',
+    sourceFirstHash: 'first-a',
+    sourceLastHash: 'last-a',
+    points: [],
+});
+
+function interaction(id) {
+    return {
+        id,
+        userMarkdown: id,
+        userPreview: id,
+        userGraphemeCount: id.length,
+        assistantMarkdown: [],
+        responseState: 'complete',
+    };
+}
+
+function slice(request, interactions, options = {}) {
+    return {
+        ...request,
+        interactions,
+        complete: options.complete === true,
+        ...(options.complete === true ? {} : {
+            nextOffset: options.nextOffset,
+        }),
+    };
+}
+
+test('CONVERSATION-HISTORY-INDEX-001 commits only monotonic restart-safe slices', async () => {
+    const index = new ConversationHistoryIndex();
+    const first = await index.advance('kimi:s1', source, async request => ({
+            ...slice(request, [interaction('first')], { nextOffset: 40 }),
+            restartInteractionId: 'second',
+            restartRecordEndOffset: 50,
+            restartRecordDigest: 'record-second',
+            restartSegmentDigest: 'segment-first',
+        })
+    );
+    assert.deepEqual(first.interactions.map(item => item.id), ['first']);
+    assert.equal(first.nextOffset, 40);
+    const complete = await index.advance('kimi:s1', source, async request =>
+        slice(request, [interaction('second')], { complete: true })
+    );
+    assert.deepEqual(complete.interactions.map(item => item.id), ['first', 'second']);
+    assert.equal(complete.complete, true);
+    assert.equal(complete.nextOffset, 100);
+});
+
+test('CONVERSATION-HISTORY-INDEX-002 a cancelled or invalidated late slice cannot publish', async () => {
+    const index = new ConversationHistoryIndex();
+    let resolve;
+    const pending = index.advance('claude:s1', source, async request =>
+        new Promise(done => { resolve = () => done(slice(
+            request,
+            [interaction('late')],
+            { complete: true }
+        )); })
+    );
+    index.invalidate('claude:s1');
+    resolve();
+    assert.equal(await pending, undefined);
+    assert.equal(index.state('claude:s1'), undefined);
+
+    const controller = new ConversationAbortController();
+    const aborted = index.advance('claude:s2', source, async request => {
+        controller.abort();
+        return slice(request, [interaction('aborted')], { complete: true });
+    }, controller.signal);
+    assert.equal(await aborted, undefined);
+    assert.deepEqual(index.state('claude:s2').interactions, []);
+});
+
+test('CONVERSATION-HISTORY-INDEX-003 a replacement source wins over an older in-flight epoch', async () => {
+    const index = new ConversationHistoryIndex();
+    let resolve;
+    const old = index.advance('kimi:s1', source, async request =>
+        new Promise(done => { resolve = () => done(slice(
+            request,
+            [interaction('old')],
+            { complete: true }
+        )); })
+    );
+    const replacement = {
+        ...source,
+        sourceIdentity: 'source-b',
+        sourceSize: 120,
+        sourceRevision: 'r2',
+    };
+    const current = await index.advance('kimi:s1', replacement, async request =>
+        slice(request, [interaction('new')], { complete: true })
+    );
+    resolve();
+    assert.equal(await old, undefined);
+    assert.deepEqual(current.interactions.map(item => item.id), ['new']);
+    assert.deepEqual(index.state('kimi:s1').interactions.map(item => item.id), ['new']);
+});
+
+test('CONVERSATION-HISTORY-INDEX-004 capacity never publishes a non-contiguous paging source', async () => {
+    const index = new ConversationHistoryIndex();
+    const interactions = Array.from({ length: 10_001 }, (_, index) =>
+        interaction(`turn-${index}`));
+    const state = await index.advance('kimi:bounded', source, async request =>
+        slice(request, interactions, { complete: true })
+    );
+    assert.equal(state.complete, false);
+    assert.equal(state.saturated, true);
+    assert.deepEqual(state.interactions, []);
+
+    let called = false;
+    const repeated = await index.advance('kimi:bounded', source, async () => {
+        called = true;
+        throw new Error('a saturated index must not retry its dropped slice');
+    });
+    assert.equal(called, false);
+    assert.equal(repeated.saturated, true);
+});
+
+test('CONVERSATION-HISTORY-INDEX-005 a proven append replays only from the last safe boundary', async () => {
+    const index = new ConversationHistoryIndex();
+    const first = await index.advance('kimi:append', source, async request =>
+        ({
+            ...slice(request, [interaction('old-prefix')], { nextOffset: 80 }),
+            restartInteractionId: 'old-tail',
+            restartRecordEndOffset: 90,
+            restartRecordDigest: 'record-old-tail',
+            restartSegmentDigest: 'segment-old-prefix',
+        })
+    );
+    assert.equal(first.restartOffset, 80);
+    assert.deepEqual(first.prefixSegments, [{
+        startOffset: 0,
+        endOffset: 80,
+        digest: 'segment-old-prefix',
+    }]);
+    const complete = await index.advance('kimi:append', source, async request =>
+        slice(request, [interaction('old-tail')], { complete: true })
+    );
+    assert.equal(complete.complete, true);
+    const appended = {
+        ...source,
+        sourceIdentity: 'source-a-appended',
+        sourceSize: 120,
+        sourceRevision: 'r2',
+        sourceLastHash: 'last-b',
+        continuationOf: {
+            sourceIdentity: source.sourceIdentity,
+            sourceSize: source.sourceSize,
+            sourceRevision: source.sourceRevision,
+            reducerVersion: 1,
+        },
+    };
+    const resumed = await index.advance('kimi:append', appended, async request => {
+        assert.equal(request.startOffset, 80);
+        return slice(request, [interaction('new-tail')], { complete: true });
+    });
+    assert.deepEqual(resumed.interactions.map(item => item.id), [
+        'old-prefix', 'new-tail',
+    ]);
+    assert.equal(resumed.complete, true);
+});
+
+test('CONVERSATION-HISTORY-INDEX-007 refuses a slice without a whole-prefix segment proof', async () => {
+    const index = new ConversationHistoryIndex();
+    const state = await index.advance('kimi:unproven', source, async request => ({
+        ...slice(request, [interaction('unproven')], { nextOffset: 40 }),
+        restartInteractionId: 'tail',
+        restartRecordEndOffset: 50,
+        restartRecordDigest: 'tail-record',
+    }));
+    assert.equal(state, undefined);
+    assert.deepEqual(index.state('kimi:unproven').interactions, []);
+});
+
+test('CONVERSATION-HISTORY-INDEX-006 a range without a safe boundary stays blocked', async () => {
+    const index = new ConversationHistoryIndex();
+    const state = await index.advance('claude:blocked', source, async request => ({
+        ...request,
+        interactions: [],
+        complete: false,
+        blocked: true,
+    }));
+    assert.equal(state.blocked, true);
+    assert.equal(state.complete, false);
+});

--- a/tests/unit/aiSessions/conversationJsonlReader.test.js
+++ b/tests/unit/aiSessions/conversationJsonlReader.test.js
@@ -242,6 +242,31 @@ test('SESSION-AI-SESSION-CONVERSATION-JSONL-008 reports valid records to an inte
     }
 });
 
+test('SESSION-AI-SESSION-CONVERSATION-JSONL-009 stops only after the requested complete record', async t => {
+    const fixture = await createJsonlFixture(t, [
+        '{"kind":"first"}\n',
+        '{"kind":"second"}\n',
+        '{"kind":"third"}\n',
+    ]);
+    const source = await fixture.open();
+    try {
+        const result = await reader.readConversationJsonl(source, {
+            startOffset: 0,
+            onRecord(record) {
+                return record.value.kind === 'second';
+            },
+        });
+        assert.deepEqual(result.records.map(record => record.value.kind), [
+            'first', 'second',
+        ]);
+        assert.equal(result.nextOffset, Buffer.byteLength(
+            '{"kind":"first"}\n{"kind":"second"}\n'
+        ));
+    } finally {
+        await source.handle.close();
+    }
+});
+
 test('SESSION-AI-SESSION-CONVERSATION-JSONL-011 retains an invalid unterminated tail until an append completes it', async t => {
     const completePrefix = '{"kind":"first"}\n';
     const partialTail = '{"kind":"par';

--- a/tests/unit/aiSessions/conversationJsonlReader.test.js
+++ b/tests/unit/aiSessions/conversationJsonlReader.test.js
@@ -82,6 +82,31 @@ test('SESSION-AI-SESSION-CONVERSATION-JSONL-002 keeps byte offsets across UTF-8 
     await source.handle.close();
 });
 
+test('SESSION-AI-SESSION-CONVERSATION-JSONL-020 proves newline delimiters with the same bytes consumed by the reducer', async t => {
+    const firstLine = '{"kind":"first"}\n';
+    const secondLine = '{"kind":"second"}';
+    const fixture = await createJsonlFixture(t, [firstLine, secondLine]);
+    const source = await fixture.open();
+    try {
+        const result = await reader.readConversationJsonl(source, { startOffset: 0 });
+        const [first, second] = result.records;
+        assert.equal(first.endOffset, Buffer.byteLength(firstLine) - 1);
+        assert.equal(first.proofEndOffset, Buffer.byteLength(firstLine));
+        assert.equal(first.recordDigest, crypto.createHash('sha256')
+            .update(firstLine.slice(0, -1)).digest('hex'));
+        assert.equal(first.proofDigest, crypto.createHash('sha256')
+            .update(firstLine).digest('hex'));
+        assert.equal(first.prefixDigest, crypto.createHash('sha256').digest('hex'));
+        assert.equal(second.proofEndOffset, source.size);
+        assert.equal(second.proofDigest, crypto.createHash('sha256')
+            .update(secondLine).digest('hex'));
+        assert.equal(second.prefixDigest, crypto.createHash('sha256')
+            .update(firstLine).digest('hex'));
+    } finally {
+        await source.handle.close();
+    }
+});
+
 test('SESSION-AI-SESSION-CONVERSATION-JSONL-003 uses the exact 64 MiB boundary and discards only a bounded-start partial line', async t => {
     const fixture = await createJsonlFixture(t, ['x'.repeat(CONVERSATION_LIMITS.maxSourceBytes)]);
     const exact = await fixture.open();


### PR DESCRIPTION
## Summary

- Build a provider-owned, bounded background index for Kimi and Claude conversation history.
- Expose older pages beyond the foreground outline window without joining incompatible history sources.
- Preserve correct page cursors and revision recovery across stale retries, indexed-history completion, and lifecycle refreshes.
- Bind every indexed slice, including the final EOF slice, to bytes consumed during reducer parsing.

## Verification

- `npm ci`
- `npm run test:coverage` — 442 deterministic tests passed
- `node scripts/check-changed-coverage.js` — 89.27% changed-line coverage
- `npm run lint:ci`
- focused Kimi, Claude, source, JSONL, history-index, and viewer paging tests
- `git diff --check`

## Skill harvest

No skill change: the CI lint failure was a local implementation mistake, not a workflow ambiguity. Existing project instructions already require final verification; the fix was to run the CI lint gate locally before republishing.

## Owner approvals

```text
approve 7fdd091e36683b07b96853c29663fef227037f74
```