### PR TITLE
perf: prevent stale reads from delaying conversation switches

### DIFF
--- a/src/aiSessions/conversation/composition.ts
+++ b/src/aiSessions/conversation/composition.ts
@@ -577,8 +577,8 @@ function createAvailableConversationCapability(
                 if (viewerLoadRecorded || !followed) {
                     return;
                 }
-                const current = viewer.getCurrentTarget();
-                if (!current || !hasSameConversationSession(
+                const current = viewer.getCurrentTarget?.();
+                if (current && !hasSameConversationSession(
                     current,
                     resolution.viewerTarget
                 )) {
@@ -943,8 +943,8 @@ async function openLatestConversation(
             if (viewerLoadRecorded) {
                 return;
             }
-            const current = viewer.getCurrentTarget();
-            if (!current || !hasSameConversationSession(
+            const current = viewer.getCurrentTarget?.();
+            if (current && !hasSameConversationSession(
                 current,
                 resolution.viewerTarget
             )) {

--- a/src/aiSessions/conversation/composition.ts
+++ b/src/aiSessions/conversation/composition.ts
@@ -89,6 +89,12 @@ export type FollowAdjacentConversationResult =
 export interface ConversationCapability {
     viewer: ConversationViewerApi;
     availability: 'available' | 'unavailable';
+    /**
+     * Cancels an in-flight foreground resolution as soon as a newer
+     * user-visible navigation intent wins, before that later intent reaches
+     * the terminal-focus queue.
+     */
+    cancelPendingNavigation(): void;
     openLatestConversation(
         target: ConversationSessionOpenTarget
     ): Promise<OpenLatestConversationResult>;
@@ -617,6 +623,11 @@ function createAvailableConversationCapability(
     return {
         viewer,
         availability: 'available',
+        cancelPendingNavigation: () => {
+            if (!disposed) {
+                beginViewerIntent();
+            }
+        },
         openLatestConversation: target => openConversation(target),
         async openLatestActiveConversation(
             target: ConversationSessionOpenTarget
@@ -813,6 +824,7 @@ function createUnavailableConversationCapability(): ConversationCapability {
     return {
         viewer,
         availability: 'unavailable',
+        cancelPendingNavigation(): void {},
         async openLatestConversation(): Promise<OpenLatestConversationResult> {
             return 'unavailable';
         },
@@ -1130,6 +1142,9 @@ function hasSameConversationSession(
 
 const CONVERSATION_SNAPSHOT_WARM_TTL_MS = 5_000;
 const CONVERSATION_SNAPSHOT_WARM_LIMIT = 4;
+// A speculative read is useful only when it is already almost complete. A
+// foreground switch must otherwise start its own abortable read promptly.
+const CONVERSATION_SNAPSHOT_WARM_CLAIM_BUDGET_MS = 120;
 
 interface WarmConversationSnapshot {
     completedAt?: number;
@@ -1186,7 +1201,10 @@ class ConversationSnapshotWarmup implements AiSessionDisposable {
             this.snapshots.delete(key);
             entry.cancel();
         }
-        return entry.promise;
+        if (entry.completedAt !== undefined) {
+            return entry.promise;
+        }
+        return this.claimWithinBudget(key, entry);
     }
 
     isDisposed(): boolean {
@@ -1408,6 +1426,43 @@ class ConversationSnapshotWarmup implements AiSessionDisposable {
             snapshot => settle(snapshot, false),
             () => settle(undefined, false)
         );
+    }
+
+    private claimWithinBudget(
+        key: string,
+        entry: WarmConversationSnapshot
+    ): Promise<ConversationSnapshot | undefined> {
+        return new Promise(resolve => {
+            let settled = false;
+            let timer: ReturnType<typeof setTimeout> | undefined;
+            const settle = (snapshot: ConversationSnapshot | undefined): void => {
+                if (settled) {
+                    return;
+                }
+                settled = true;
+                if (timer !== undefined) {
+                    this.options.clearTimer(timer);
+                    timer = undefined;
+                }
+                resolve(snapshot);
+            };
+            let budgetFiredSynchronously = false;
+            const budget = this.options.setTimer(() => {
+                budgetFiredSynchronously = true;
+                if (this.snapshots.get(key) === entry) {
+                    this.snapshots.delete(key);
+                }
+                // Release the speculative provider work before the
+                // authoritative foreground read starts. Adapters receive the
+                // abort signal and can give the new target priority.
+                entry.cancel();
+                settle(undefined);
+            }, CONVERSATION_SNAPSHOT_WARM_CLAIM_BUDGET_MS);
+            if (!budgetFiredSynchronously) {
+                timer = budget;
+            }
+            void entry.promise.then(snapshot => settle(snapshot));
+        });
     }
 
     private schedule(operation: () => void | PromiseLike<void>): void {

--- a/src/aiSessions/conversation/composition.ts
+++ b/src/aiSessions/conversation/composition.ts
@@ -572,13 +572,51 @@ function createAvailableConversationCapability(
                 resolution.viewerTarget,
                 viewer
             );
-            const followed = await follow;
-            if (followed) {
+            let viewerLoadRecorded = false;
+            const recordViewerLoad = (followed: boolean): void => {
+                if (viewerLoadRecorded || !followed) {
+                    return;
+                }
+                const current = viewer.getCurrentTarget();
+                if (!current || !hasSameConversationSession(
+                    current,
+                    resolution.viewerTarget
+                )) {
+                    return;
+                }
+                viewerLoadRecorded = true;
                 snapshotWarmup?.afterLoad(
                     resolution.viewerTarget,
                     resolution.prefetchedSnapshot === true,
                     viewer
                 );
+            };
+            // The caller's wait is supersedable, but the Viewer operation is
+            // deliberately allowed to finish when no replacement target ever
+            // arrives. Keep warm-snapshot revalidation attached to that
+            // underlying operation so a late successful application does not
+            // leave the retained snapshot permanently stale.
+            void follow.then(recordViewerLoad, () => undefined);
+            let followed: boolean;
+            try {
+                // A Viewer delivery can wait on the Webview while the next
+                // Dashboard target already has a newer intent. Release the
+                // terminal-focus queue now, but leave Viewer-owned work
+                // alone: the successor might fail to focus or might be a
+                // worktree-only switch, in which case the current Viewer
+                // load must still settle normally.
+                followed = await awaitAbortableRead(follow, intent.signal);
+            } catch (error) {
+                if (!intent.isCurrent()) {
+                    return 'superseded';
+                }
+                throw error;
+            }
+            if (!intent.isCurrent()) {
+                return 'superseded';
+            }
+            if (followed) {
+                recordViewerLoad(followed);
                 const current = viewer.getCurrentTarget();
                 terminalAuthority.confirmedTarget =
                     cloneConversationViewerTarget(
@@ -900,12 +938,42 @@ async function openLatestConversation(
             resolution.snapshot
         );
         snapshotWarmup?.prepareAfterTargetSet(resolution.viewerTarget, viewer);
-        await opening;
-        snapshotWarmup?.afterLoad(
-            resolution.viewerTarget,
-            resolution.prefetchedSnapshot === true,
-            viewer
-        );
+        let viewerLoadRecorded = false;
+        const recordViewerLoad = (): void => {
+            if (viewerLoadRecorded) {
+                return;
+            }
+            const current = viewer.getCurrentTarget();
+            if (!current || !hasSameConversationSession(
+                current,
+                resolution.viewerTarget
+            )) {
+                return;
+            }
+            viewerLoadRecorded = true;
+            snapshotWarmup?.afterLoad(
+                resolution.viewerTarget,
+                resolution.prefetchedSnapshot === true,
+                viewer
+            );
+        };
+        // See followOpenConversation: revalidation belongs to the Viewer
+        // operation, not solely to this supersedable caller's wait.
+        void opening.then(recordViewerLoad, () => undefined);
+        try {
+            // See followOpenConversation: supersede only this caller's wait,
+            // never a Viewer operation that could remain the active target.
+            await awaitAbortableRead(opening, signal);
+        } catch (error) {
+            if (!isCurrent()) {
+                return 'superseded';
+            }
+            throw error;
+        }
+        if (!isCurrent()) {
+            return 'superseded';
+        }
+        recordViewerLoad();
         opened = true;
         return 'opened';
     } finally {
@@ -1149,6 +1217,7 @@ const CONVERSATION_SNAPSHOT_WARM_CLAIM_BUDGET_MS = 120;
 interface WarmConversationSnapshot {
     completedAt?: number;
     claimed: boolean;
+    claimGeneration: number;
     abortController: ConversationAbortController;
     promise: Promise<ConversationSnapshot | undefined>;
     timeout?: ReturnType<typeof setTimeout>;
@@ -1182,8 +1251,12 @@ class ConversationSnapshotWarmup implements AiSessionDisposable {
 
     take(
         provider: AiSessionProviderId,
-        sessionId: string
+        sessionId: string,
+        signal?: ConversationAbortSignal
     ): Promise<ConversationSnapshot | undefined> | undefined {
+        if (signal?.aborted) {
+            return Promise.resolve(undefined);
+        }
         const key = getWarmSnapshotKey(provider, sessionId);
         const entry = this.snapshots.get(key);
         if (!entry) {
@@ -1204,7 +1277,13 @@ class ConversationSnapshotWarmup implements AiSessionDisposable {
         if (entry.completedAt !== undefined) {
             return entry.promise;
         }
-        return this.claimWithinBudget(key, entry);
+        entry.claimGeneration += 1;
+        return this.claimWithinBudget(
+            key,
+            entry,
+            entry.claimGeneration,
+            signal
+        );
     }
 
     isDisposed(): boolean {
@@ -1405,6 +1484,7 @@ class ConversationSnapshotWarmup implements AiSessionDisposable {
         entry = {
             abortController,
             claimed: false,
+            claimGeneration: 0,
             promise,
             cancel: () => {
                 clearEntryTimeout();
@@ -1430,11 +1510,14 @@ class ConversationSnapshotWarmup implements AiSessionDisposable {
 
     private claimWithinBudget(
         key: string,
-        entry: WarmConversationSnapshot
+        entry: WarmConversationSnapshot,
+        claimGeneration: number,
+        signal?: ConversationAbortSignal
     ): Promise<ConversationSnapshot | undefined> {
         return new Promise(resolve => {
             let settled = false;
             let timer: ReturnType<typeof setTimeout> | undefined;
+            let abortSubscription: AiSessionDisposable | undefined;
             const settle = (snapshot: ConversationSnapshot | undefined): void => {
                 if (settled) {
                     return;
@@ -1444,11 +1527,17 @@ class ConversationSnapshotWarmup implements AiSessionDisposable {
                     this.options.clearTimer(timer);
                     timer = undefined;
                 }
+                abortSubscription?.dispose();
+                abortSubscription = undefined;
                 resolve(snapshot);
             };
             let budgetFiredSynchronously = false;
             const budget = this.options.setTimer(() => {
                 budgetFiredSynchronously = true;
+                if (entry.claimGeneration !== claimGeneration) {
+                    settle(undefined);
+                    return;
+                }
                 if (this.snapshots.get(key) === entry) {
                     this.snapshots.delete(key);
                 }
@@ -1460,6 +1549,25 @@ class ConversationSnapshotWarmup implements AiSessionDisposable {
             }, CONVERSATION_SNAPSHOT_WARM_CLAIM_BUDGET_MS);
             if (!budgetFiredSynchronously) {
                 timer = budget;
+            }
+            if (signal) {
+                abortSubscription = signal.onAbort(() => {
+                    settle(undefined);
+                    // Queue handoff is itself asynchronous: a rapid repeat
+                    // of this target cannot reclaim until the current queue
+                    // task unwinds. Give that successor one event-loop turn
+                    // to claim the shared warmup. A different target still
+                    // releases it far ahead of the 120ms foreground budget.
+                    this.schedule(() => {
+                        if (entry.claimGeneration !== claimGeneration) {
+                            return;
+                        }
+                        if (this.snapshots.get(key) === entry) {
+                            this.snapshots.delete(key);
+                        }
+                        entry.cancel();
+                    });
+                });
             }
             void entry.promise.then(snapshot => settle(snapshot));
         });
@@ -1569,7 +1677,7 @@ async function resolveLatestConversationTarget(
     try {
         const warmSnapshot = preferredInteractionId === undefined
             && subagentId === undefined
-            ? snapshotWarmup?.take(target.provider, effectiveSessionId)
+            ? snapshotWarmup?.take(target.provider, effectiveSessionId, signal)
             : undefined;
         const resolvedWarmSnapshot = warmSnapshot
             ? await awaitAbortableRead(warmSnapshot, signal)

--- a/src/aiSessions/conversation/viewer.ts
+++ b/src/aiSessions/conversation/viewer.ts
@@ -1704,6 +1704,7 @@ export class ConversationViewer implements ConversationViewerApi {
             return;
         }
         if (parsed.type === 'conversation-viewer-cycle-status-session') {
+            this.options.onNavigationIntent?.();
             const currentTarget = this.target;
             await this.options.cycleLocalSessionStatus?.(
                 parsed.kind,

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1753,6 +1753,11 @@ async function initializeDashboard(
     let conversationNavigationIntent = 0;
     const beginConversationNavigationIntent = (): number => {
         conversationNavigationIntent += 1;
+        // The coordinator can discard queued target switches, but a slow
+        // foreground provider read has already left that queue. Cancel it at
+        // the moment the newer user intent arrives so it cannot hold the
+        // latest target behind its full read timeout.
+        conversationCapability?.cancelPendingNavigation();
         return conversationNavigationIntent;
     };
     conversationCapability = ownResource(() => createConversationCapability({

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -3159,6 +3159,7 @@ async function initializeDashboard(
         },
         showInformationMessage: message => vscode.window.showInformationMessage(message),
         showWarningMessage: message => vscode.window.showWarningMessage(message),
+        onNavigationIntent: () => beginConversationNavigationIntent(),
     });
     // The first paint happens after bootstrap settles (see the post-ready
     // startup timer below); earlier reads of the card projection are unsafe.

--- a/src/dashboard/worktreeQuickSwitch.ts
+++ b/src/dashboard/worktreeQuickSwitch.ts
@@ -166,6 +166,8 @@ export interface WorktreeOrSessionSwitchHandlerOptions {
     revealWorktree: (navigationIdentity: string, key: WorktreeKey) => Promise<unknown>;
     showInformationMessage: (message: string) => unknown;
     showWarningMessage: (message: string) => unknown;
+    /** Called after a picker selection commits a user-visible switch. */
+    onNavigationIntent?: () => void;
 }
 
 export function createWorktreeOrSessionSwitchHandler(
@@ -182,6 +184,7 @@ export function createWorktreeOrSessionSwitchHandler(
         if (!picked) {
             return;
         }
+        options.onNavigationIntent?.();
         if (picked.target.kind === 'worktree') {
             await options.revealWorktree(target.workspace.navigationIdentity, picked.target.key);
             return;

--- a/tests/contract/dashboard/worktreeQuickSwitch.test.js
+++ b/tests/contract/dashboard/worktreeQuickSwitch.test.js
@@ -16,6 +16,14 @@ const idleKey = {
     canonicalWorktreePath: '/managed/idle',
 };
 
+function deferred() {
+    let resolve;
+    const promise = new Promise(resolvePromise => {
+        resolve = resolvePromise;
+    });
+    return { promise, resolve };
+}
+
 function workspaceTarget() {
     return {
         cardId: 'workspace-card',
@@ -101,6 +109,34 @@ test('WORKTREE-QUICK-SWITCH-001 focuses active sessions, resumes ended sessions,
         ['resume', 'workspace-card', 'codex', 'ended'],
         ['reveal', 'navigation-1', attentionKey],
     ]);
+});
+
+test('WORKTREE-QUICK-SWITCH-001 emits a navigation intent only after a picker selection commits', async () => {
+    let picked;
+    let intents = 0;
+    const focused = deferred();
+    const handler = createWorktreeOrSessionSwitchHandler({
+        getWorkspaceTarget: workspaceTarget,
+        showPick: async items => picked === 'cancel' ? undefined : items[1],
+        focusSession: async () => focused.promise,
+        resumeSession: async () => undefined,
+        revealWorktree: async () => undefined,
+        showInformationMessage: () => undefined,
+        showWarningMessage: () => undefined,
+        onNavigationIntent: () => { intents += 1; },
+    });
+
+    picked = 'cancel';
+    await handler();
+    assert.equal(intents, 0, 'opening or cancelling the picker is not a switch');
+
+    picked = 'active';
+    const switching = handler();
+    await Promise.resolve();
+    assert.equal(intents, 1,
+        'a committed session selection must cancel an older conversation read before terminal focus settles');
+    focused.resolve(true);
+    await switching;
 });
 
 test('WORKTREE-QUICK-SWITCH-001 excludes bare worktrees and keeps branchless linked worktrees addressable', () => {

--- a/tests/integration/dashboard/conversationOpenLatest.test.js
+++ b/tests/integration/dashboard/conversationOpenLatest.test.js
@@ -811,6 +811,136 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 shares a slow in-flight warmup 
     harness.capability.dispose();
 });
 
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 abandons a slow claimed warmup before it delays a foreground switch', async () => {
+    const sessions = ['codex', 'kimi'].map((provider, index) => makeSession({
+        key: `${provider}:claim-${index}`,
+        provider,
+        sessionId: `claim-${index}`,
+        name: `${provider} Session`,
+    }));
+    const slowKimiSnapshot = deferred();
+    const timers = [];
+    let kimiReads = 0;
+    let warmupAborted = false;
+    const harness = createHarness({
+        enableSnapshots: true,
+        requireSnapshot: true,
+        viewerOpen: true,
+        session: sessions[0],
+        resolveTarget: (_projectId, provider, sessionId) =>
+            sessions.find(session => session.provider === provider
+                && session.sessionId === sessionId) || null,
+        resolveActiveTargets: () => sessions,
+        setTimer: (callback, delayMs) => {
+            const timer = { callback, delayMs, cleared: false };
+            timers.push(timer);
+            if (delayMs === 0) {
+                setImmediate(() => {
+                    if (!timer.cleared) callback();
+                });
+            }
+            return timer;
+        },
+        clearTimer: timer => { timer.cleared = true; },
+        readSnapshot: async (provider, sessionId, _preferredInteractionId, signal) => {
+            if (provider === 'kimi' && ++kimiReads === 1) {
+                signal.onAbort(() => { warmupAborted = true; });
+                return slowKimiSnapshot.promise;
+            }
+            return {
+                outline: makeOutline(provider, sessionId, ['input-a']),
+                page: makePage(provider, sessionId, 'input-a'),
+            };
+        },
+    });
+
+    assert.equal(await harness.capability.openLatestConversation({
+        projectId: 'project-a',
+        provider: 'codex',
+        sessionId: 'claim-0',
+    }), 'opened');
+    await waitFor(
+        () => harness.snapshotReadTargets.includes('kimi:claim-1'),
+        'the adjacent Kimi warmup to start'
+    );
+
+    const following = harness.capability.followActiveConversation({
+        projectId: 'project-a',
+        provider: 'kimi',
+        sessionId: 'claim-1',
+    });
+    await waitFor(
+        () => timers.some(timer => timer.delayMs === 120 && !timer.cleared),
+        'the foreground warmup claim budget'
+    );
+    timers.find(timer => timer.delayMs === 120 && !timer.cleared).callback();
+
+    assert.equal(await following, 'opened');
+    assert.equal(kimiReads, 2,
+        'the foreground switch must replace a warmup that misses its budget');
+    assert.equal(warmupAborted, true,
+        'the abandoned warmup must release its provider read before retrying');
+    slowKimiSnapshot.resolve({
+        outline: makeOutline('kimi', 'claim-1', ['input-a']),
+        page: makePage('kimi', 'claim-1', 'input-a'),
+    });
+    harness.capability.dispose();
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 cancels a foreground read when a newer navigation intent arrives', async () => {
+    const sessions = ['codex', 'kimi'].map((provider, index) => makeSession({
+        key: `${provider}:cancel-${index}`,
+        provider,
+        sessionId: `cancel-${index}`,
+        name: `${provider} Session`,
+    }));
+    const slowCodexSnapshot = deferred();
+    let codexAborted = false;
+    const harness = createHarness({
+        enableSnapshots: true,
+        requireSnapshot: true,
+        resolveTarget: (_projectId, provider, sessionId) =>
+            sessions.find(session => session.provider === provider
+                && session.sessionId === sessionId) || null,
+        resolveActiveTargets: () => sessions,
+        readSnapshot: async (provider, sessionId, _preferredInteractionId, signal) => {
+            if (provider === 'codex') {
+                signal.onAbort(() => { codexAborted = true; });
+                return slowCodexSnapshot.promise;
+            }
+            return {
+                outline: makeOutline(provider, sessionId, ['input-a']),
+                page: makePage(provider, sessionId, 'input-a'),
+            };
+        },
+    });
+
+    const stale = harness.capability.openLatestConversation({
+        projectId: 'project-a',
+        provider: 'codex',
+        sessionId: 'cancel-0',
+    });
+    await waitFor(
+        () => harness.snapshotReadTargets.includes('codex:cancel-0'),
+        'the first foreground read to start'
+    );
+    harness.capability.cancelPendingNavigation();
+
+    assert.equal(await harness.capability.openLatestConversation({
+        projectId: 'project-a',
+        provider: 'kimi',
+        sessionId: 'cancel-1',
+    }), 'opened');
+    assert.equal(await stale, 'superseded');
+    assert.equal(codexAborted, true,
+        'the stale foreground provider read must receive an abort signal');
+    slowCodexSnapshot.resolve({
+        outline: makeOutline('codex', 'cancel-0', ['input-a']),
+        page: makePage('codex', 'cancel-0', 'input-a'),
+    });
+    harness.capability.dispose();
+});
+
 test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 times out a hung speculative read before the user switches', async () => {
     const sessions = ['codex', 'kimi'].map((provider, index) => makeSession({
         key: `${provider}:hung-${index}`,
@@ -1235,6 +1365,11 @@ test('CONVERSATION-FOLLOW-ACTIVE-SESSION-001 delegates Active Session card focus
     assert.match(
         dashboardSource,
         /const focusTerminal = e\.version === 2 && e\.focusTerminal === true;[\s\S]*focusAiSessionAndOpenConversation\(target\)/
+    );
+    assert.match(
+        dashboardSource,
+        /const beginConversationNavigationIntent = \(\): number => \{[\s\S]*conversationCapability\?\.cancelPendingNavigation\(\)/,
+        'a new Dashboard intent must cancel a foreground read before the shared queue runs it'
     );
 });
 

--- a/tests/integration/dashboard/conversationOpenLatest.test.js
+++ b/tests/integration/dashboard/conversationOpenLatest.test.js
@@ -941,6 +941,185 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 cancels a foreground read when 
     harness.capability.dispose();
 });
 
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 releases an obsolete Viewer wait on cancellation', async () => {
+    const delayedOpen = deferred();
+    const harness = createHarness({
+        enableSnapshots: true,
+        requireSnapshot: true,
+        openViewer: () => delayedOpen.promise,
+    });
+    const stale = harness.capability.openLatestConversation({
+        projectId: 'project-a',
+        provider: 'codex',
+        sessionId: 'session-a',
+    });
+    await waitFor(
+        () => harness.viewerTargets.length === 1,
+        'the stale Viewer application to start'
+    );
+
+    harness.capability.cancelPendingNavigation();
+    assert.equal(await stale, 'superseded');
+    assert.equal(harness.viewerRefreshes, 0,
+        'an obsolete Viewer wait must not schedule post-load work');
+    delayedOpen.resolve();
+    harness.capability.dispose();
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 releases a claimed warmup as soon as its navigation is cancelled', async () => {
+    const sessions = ['codex', 'kimi'].map((provider, index) => makeSession({
+        key: `${provider}:claimed-cancel-${index}`,
+        provider,
+        sessionId: `claimed-cancel-${index}`,
+        name: `${provider} Session`,
+    }));
+    const slowKimiSnapshot = deferred();
+    const timers = [];
+    let warmupAborted = false;
+    const harness = createHarness({
+        enableSnapshots: true,
+        requireSnapshot: true,
+        viewerOpen: true,
+        session: sessions[0],
+        resolveTarget: (_projectId, provider, sessionId) =>
+            sessions.find(session => session.provider === provider
+                && session.sessionId === sessionId) || null,
+        resolveActiveTargets: () => sessions,
+        setTimer: (callback, delayMs) => {
+            const timer = { callback, delayMs, cleared: false };
+            timers.push(timer);
+            if (delayMs === 0) {
+                setImmediate(() => {
+                    if (!timer.cleared) callback();
+                });
+            }
+            return timer;
+        },
+        clearTimer: timer => { timer.cleared = true; },
+        readSnapshot: async (provider, sessionId, _preferredInteractionId, signal) => {
+            if (provider === 'kimi') {
+                signal.onAbort(() => { warmupAborted = true; });
+                return slowKimiSnapshot.promise;
+            }
+            return {
+                outline: makeOutline(provider, sessionId, ['input-a']),
+                page: makePage(provider, sessionId, 'input-a'),
+            };
+        },
+    });
+
+    assert.equal(await harness.capability.openLatestConversation({
+        projectId: 'project-a',
+        provider: 'codex',
+        sessionId: 'claimed-cancel-0',
+    }), 'opened');
+    await waitFor(
+        () => harness.snapshotReadTargets.includes('kimi:claimed-cancel-1'),
+        'the adjacent Kimi warmup to start'
+    );
+
+    const stale = harness.capability.followActiveConversation({
+        projectId: 'project-a',
+        provider: 'kimi',
+        sessionId: 'claimed-cancel-1',
+    });
+    await waitFor(
+        () => timers.some(timer => timer.delayMs === 120 && !timer.cleared),
+        'the foreground warmup claim budget'
+    );
+    harness.capability.cancelPendingNavigation();
+
+    assert.equal(await stale, 'superseded');
+    await waitFor(
+        () => warmupAborted,
+        'the claimed provider read to receive its cancellation'
+    );
+    assert.equal(warmupAborted, true,
+        'the claimed provider read must be released before its budget expires');
+    assert.equal(timers.some(timer => timer.delayMs === 120 && !timer.cleared), false,
+        'cancelling the claim must clear its budget timer');
+    slowKimiSnapshot.resolve({
+        outline: makeOutline('kimi', 'claimed-cancel-1', ['input-a']),
+        page: makePage('kimi', 'claimed-cancel-1', 'input-a'),
+    });
+    harness.capability.dispose();
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 transfers a cancelled warmup claim to an immediate same-target retry', async () => {
+    const sessions = ['codex', 'kimi'].map((provider, index) => makeSession({
+        key: `${provider}:claimed-retry-${index}`,
+        provider,
+        sessionId: `claimed-retry-${index}`,
+        name: `${provider} Session`,
+    }));
+    const slowKimiSnapshot = deferred();
+    const harness = createHarness({
+        enableSnapshots: true,
+        requireSnapshot: true,
+        viewerOpen: true,
+        session: sessions[0],
+        resolveTarget: (_projectId, provider, sessionId) =>
+            sessions.find(session => session.provider === provider
+                && session.sessionId === sessionId) || null,
+        resolveActiveTargets: () => sessions,
+        setTimer: (callback, delayMs) => {
+            const timer = { cleared: false };
+            if (delayMs === 0) {
+                setImmediate(() => {
+                    if (!timer.cleared) callback();
+                });
+            }
+            return timer;
+        },
+        clearTimer: timer => { timer.cleared = true; },
+        readSnapshot: async (provider, sessionId, _preferredInteractionId) => {
+            if (provider === 'kimi') {
+                return slowKimiSnapshot.promise;
+            }
+            return {
+                outline: makeOutline(provider, sessionId, ['input-a']),
+                page: makePage(provider, sessionId, 'input-a'),
+            };
+        },
+    });
+
+    assert.equal(await harness.capability.openLatestConversation({
+        projectId: 'project-a',
+        provider: 'codex',
+        sessionId: 'claimed-retry-0',
+    }), 'opened');
+    await waitFor(
+        () => harness.snapshotReadTargets.includes('kimi:claimed-retry-1'),
+        'the adjacent Kimi warmup to start'
+    );
+
+    const stale = harness.capability.followActiveConversation({
+        projectId: 'project-a',
+        provider: 'kimi',
+        sessionId: 'claimed-retry-1',
+    });
+    harness.capability.cancelPendingNavigation();
+    const retry = harness.capability.followActiveConversation({
+        projectId: 'project-a',
+        provider: 'kimi',
+        sessionId: 'claimed-retry-1',
+    });
+    slowKimiSnapshot.resolve({
+        outline: makeOutline('kimi', 'claimed-retry-1', ['input-a']),
+        page: makePage('kimi', 'claimed-retry-1', 'input-a'),
+    });
+
+    assert.equal(await stale, 'superseded');
+    assert.equal(await retry, 'opened');
+    assert.equal(
+        harness.snapshotReadTargets.filter(target =>
+            target === 'kimi:claimed-retry-1').length,
+        1,
+        'the queued same-target retry must retain the shared warm provider read'
+    );
+    harness.capability.dispose();
+});
+
 test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 times out a hung speculative read before the user switches', async () => {
     const sessions = ['codex', 'kimi'].map((provider, index) => makeSession({
         key: `${provider}:hung-${index}`,
@@ -1370,6 +1549,20 @@ test('CONVERSATION-FOLLOW-ACTIVE-SESSION-001 delegates Active Session card focus
         dashboardSource,
         /const beginConversationNavigationIntent = \(\): number => \{[\s\S]*conversationCapability\?\.cancelPendingNavigation\(\)/,
         'a new Dashboard intent must cancel a foreground read before the shared queue runs it'
+    );
+    const intentStart = navigationPath[0].indexOf(
+        'const intent = beginConversationNavigationIntent();'
+    );
+    const enqueueStart = navigationPath[0].indexOf(
+        'sessionNavigationCoordinator.enqueueLatest('
+    );
+    assert.ok(intentStart >= 0,
+        'a row click must create a navigation intent in its own execution path');
+    assert.ok(enqueueStart >= 0,
+        'a row click must use the shared terminal-focus queue');
+    assert.ok(
+        intentStart < enqueueStart,
+        'a row click must cancel the old read before it joins the shared queue'
     );
 });
 

--- a/tests/integration/dashboard/conversationViewer.test.js
+++ b/tests/integration/dashboard/conversationViewer.test.js
@@ -2286,6 +2286,7 @@ function createViewer(options = {}) {
         readTelemetry: options.readTelemetry,
         readSessionStatus: options.readSessionStatus,
         cycleLocalSessionStatus: options.cycleLocalSessionStatus,
+        onNavigationIntent: options.onNavigationIntent,
         acknowledgeSessionAttention: options.acknowledgeSessionAttention,
         switchAdjacentWindow: options.switchAdjacentWindow,
         watch: options.watch || ((_provider, sessionId) => ({
@@ -3002,22 +3003,32 @@ test('OPEN-WINDOW-CYCLE-RAILS-001 routes window rail clicks to the window cycle'
 
 test('CONVERSATION-SESSION-STATUS-001 routes status button clicks to the local session cycle', async () => {
     const cycles = [];
+    let navigationIntents = 0;
+    const cycle = deferred();
     const { viewer, panel } = createViewer({
+        onNavigationIntent: () => { navigationIntents += 1; },
         cycleLocalSessionStatus: async (kind, currentTarget) => {
             cycles.push({ kind, currentTarget });
+            await cycle.promise;
         },
     });
     await viewer.open(target('session-a', 'input-1'));
 
-    await panel.receive({
+    const receiving = panel.receive({
         type: 'conversation-viewer-cycle-status-session',
         version: 1,
         kind: 'attention',
     });
+    await Promise.resolve();
+    assert.equal(navigationIntents, 1,
+        'a valid status-cycle message must cancel an older navigation before its local cycle settles');
+    cycle.resolve();
+    await receiving;
     assert.deepEqual(cycles, [{
         kind: 'attention',
         currentTarget: target('session-a', 'input-1'),
     }]);
+    assert.equal(navigationIntents, 1);
 
     for (const message of [
         { type: 'conversation-viewer-cycle-status-session', version: 1 },
@@ -3037,6 +3048,8 @@ test('CONVERSATION-SESSION-STATUS-001 routes status button clicks to the local s
     }
     assert.equal(cycles.length, 1,
         'malformed or spoofed kinds are dropped by the protocol validator');
+    assert.equal(navigationIntents, 1,
+        'invalid status-cycle messages must not supersede a valid navigation');
 });
 
 test('CONVERSATION-SESSION-STATUS-001 republishes the status after a retarget even when unchanged', async () => {


### PR DESCRIPTION
## Summary

- cancel obsolete foreground reads and warmup claims as soon as a newer navigation intent wins
- release a superseded Viewer wait without aborting Viewer-owned state, while preserving its post-load revalidation
- trigger cancellation on committed worktree/session picks and Viewer status cycles, with race and ordering regressions

## Verification

- npm run worktree:run -- npm run test-compile
- npm run worktree:run -- node --test tests/integration/dashboard/conversationRouting.test.js tests/integration/dashboard/conversationOpenLatest.test.js tests/integration/dashboard/conversationViewer.test.js tests/contract/dashboard/worktreeQuickSwitch.test.js
- npm run worktree:run -- node --test tests/unit/tooling/architectureGuards.test.js
- git diff --check

## Skill harvest

No skill change: the task exposed product-level cancellation and warmup-priority gaps; the existing Webview protocol, verification, worktree, and PR skills already covered the required workflow.

## Owner approvals

~~~text
approve a233deb8c9df4fcfcb896dd4bbc878c7757ba6e6
~~~