### PR TITLE
perf: overlap conversation snapshots with terminal focus

### DIFF
--- a/scripts/run-architecture-guards.js
+++ b/scripts/run-architecture-guards.js
@@ -1807,14 +1807,18 @@ const guards = {
             ).length !== 1
             || callArguments(
                 dashboardClickNavigator.initializer,
-                'conversationCapability.followActiveConversation',
+                'conversationCapability.prepareActiveConversation',
             ).length !== 1
             || callArguments(
                 dashboardClickNavigator.initializer,
-                'conversationCapability.openLatestActiveConversation',
+                'preparedConversation.apply',
+            ).length !== 1
+            || callArguments(
+                dashboardClickNavigator.initializer,
+                'preparedConversation.cancel',
             ).length !== 1) {
             fail(this.id, risk,
-                'Dashboard Chat-row clicks must use the shared latest-intent navigation transaction');
+                'Dashboard Chat-row clicks must prepare once, then commit only through the shared latest-intent navigation transaction');
         }
     },
 

--- a/scripts/run-architecture-guards.js
+++ b/scripts/run-architecture-guards.js
@@ -1820,6 +1820,68 @@ const guards = {
             fail(this.id, risk,
                 'Dashboard Chat-row clicks must prepare once, then commit only through the shared latest-intent navigation transaction');
         }
+        const focusCall = uniqueAstNode(
+            dashboardClickNavigator.initializer,
+            node => ts.isCallExpression(node)
+                && node.expression.getText(dashboard) === 'aiSessionTerminalCommandController.focusActive',
+            this.id,
+            risk,
+            'Dashboard Chat-row terminal focus call'
+        );
+        const preparedApply = uniqueAstNode(
+            dashboardClickNavigator.initializer,
+            node => ts.isCallExpression(node)
+                && node.expression.getText(dashboard) === 'preparedConversation.apply',
+            this.id,
+            risk,
+            'Dashboard Chat-row prepared Viewer apply'
+        );
+        let guardedBySuccessfulFocus = false;
+        for (let parent = preparedApply.parent; parent; parent = parent.parent) {
+            if (ts.isIfStatement(parent)
+                && normalizedAstText(parent.expression, dashboard)
+                    === 'focused && intent === conversationNavigationIntent') {
+                guardedBySuccessfulFocus = true;
+                break;
+            }
+        }
+        if (!guardedBySuccessfulFocus
+            || focusCall.getStart(dashboard) >= preparedApply.getStart(dashboard)) {
+            fail(this.id, risk,
+                'Dashboard Chat-row prepared Viewer apply must occur after successful current-intent terminal focus');
+        }
+        const preparedCancel = uniqueAstNode(
+            dashboardClickNavigator.initializer,
+            node => ts.isCallExpression(node)
+                && node.expression.getText(dashboard) === 'preparedConversation.cancel',
+            this.id,
+            risk,
+            'Dashboard Chat-row prepared Viewer cancel'
+        );
+        let cancelGuardedByUncommittedFinally = false;
+        for (let parent = preparedCancel.parent; parent; parent = parent.parent) {
+            if (!ts.isIfStatement(parent)
+                || normalizedAstText(parent.expression, dashboard)
+                    !== '!conversationApplied') {
+                continue;
+            }
+            for (let ancestor = parent.parent; ancestor; ancestor = ancestor.parent) {
+                if (ts.isTryStatement(ancestor)
+                    && ancestor.finallyBlock
+                    && ancestor.finallyBlock.pos <= parent.pos
+                    && parent.end <= ancestor.finallyBlock.end) {
+                    cancelGuardedByUncommittedFinally = true;
+                    break;
+                }
+            }
+            if (cancelGuardedByUncommittedFinally) {
+                break;
+            }
+        }
+        if (!cancelGuardedByUncommittedFinally) {
+            fail(this.id, risk,
+                'Dashboard Chat-row prepared Viewer cancel must remain in the uncommitted finally branch');
+        }
     },
 
     // ARCH-OPEN-WORKSPACE-FOCUS-TRANSPORT-OWNERSHIP-001

--- a/src/aiSessions/conversation/composition.ts
+++ b/src/aiSessions/conversation/composition.ts
@@ -86,6 +86,16 @@ export type FollowActiveConversationResult =
 export type FollowAdjacentConversationResult =
     FollowActiveConversationResult | 'inactive' | 'noAdjacentSession';
 
+/**
+ * An already-started, but not yet Viewer-applicable, Conversation target.
+ * Dashboard navigation starts this while terminal focus is queued, then
+ * commits it only after that focus succeeds for the same user intent.
+ */
+export interface PreparedActiveConversationNavigation {
+    apply(): Promise<FollowActiveConversationResult>;
+    cancel(): void;
+}
+
 export interface ConversationCapability {
     viewer: ConversationViewerApi;
     availability: 'available' | 'unavailable';
@@ -95,6 +105,10 @@ export interface ConversationCapability {
      * the terminal-focus queue.
      */
     cancelPendingNavigation(): void;
+    prepareActiveConversation(
+        target: ConversationSessionOpenTarget,
+        openWhenClosed: boolean
+    ): PreparedActiveConversationNavigation;
     openLatestConversation(
         target: ConversationSessionOpenTarget
     ): Promise<OpenLatestConversationResult>;
@@ -508,15 +522,21 @@ function createAvailableConversationCapability(
     ): Promise<boolean> => queueFocus(() => {
         viewer.focus();
     }, isCurrent);
+    type PreparedViewerIntent = {
+        isCurrent(): boolean;
+        signal: ConversationAbortSignal;
+        resolution?: Promise<LatestConversationTargetResolution>;
+    };
     const followOpenConversation = async (
         target: ConversationSessionOpenTarget,
         reveal: boolean,
-        showFollowFailure: boolean
+        showFollowFailure: boolean,
+        preparedIntent?: PreparedViewerIntent
     ): Promise<FollowActiveConversationResult> => {
         if (!viewer.isOpen()) {
             return 'closed';
         }
-        const intent = beginViewerIntent();
+        const intent: PreparedViewerIntent = preparedIntent || beginViewerIntent();
         const currentTarget = viewer.getCurrentTarget();
         if (currentTarget
             && hasSameConversationSession(currentTarget, target)) {
@@ -535,15 +555,16 @@ function createAvailableConversationCapability(
         const preview = viewer.previewSession?.(target);
         let followedSuccessfully = false;
         try {
-            const resolution = await resolveLatestConversationTarget(
-                options,
-                coordinator,
-                target,
-                undefined,
-                undefined,
-                snapshotWarmup,
-                intent.signal
-            );
+            const resolution = await (intent.resolution
+                || resolveLatestConversationTarget(
+                    options,
+                    coordinator,
+                    target,
+                    undefined,
+                    undefined,
+                    snapshotWarmup,
+                    intent.signal
+                ));
             if (!intent.isCurrent()) {
                 return 'superseded';
             }
@@ -658,6 +679,72 @@ function createAvailableConversationCapability(
             intent.signal
         );
     };
+    const prepareActiveConversation = (
+        target: ConversationSessionOpenTarget,
+        openWhenClosed: boolean
+    ): PreparedActiveConversationNavigation => {
+        const intent = beginViewerIntent();
+        const currentTarget = viewer.getCurrentTarget();
+        const shouldResolve = openWhenClosed || viewer.isOpen();
+        const resolution = shouldResolve && !(viewer.isOpen() && currentTarget
+            && hasSameConversationSession(currentTarget, target))
+            ? resolveLatestConversationTarget(
+                options,
+                coordinator,
+                target,
+                undefined,
+                undefined,
+                snapshotWarmup,
+                intent.signal
+            )
+            : undefined;
+        // A failed terminal focus never calls apply(). Keep the rejected
+        // provider result observed in that case while retaining the original
+        // promise for a successful focus to consume.
+        void resolution?.catch(() => undefined);
+        let applied = false;
+        const cancel = (): void => {
+            // A stale queued focus task must not cancel the newer target that
+            // replaced it while it was waiting for terminal serialization.
+            if (intent.isCurrent()) {
+                beginViewerIntent();
+            }
+        };
+        return {
+            cancel,
+            async apply(): Promise<FollowActiveConversationResult> {
+                if (applied || !intent.isCurrent()) {
+                    return 'superseded';
+                }
+                applied = true;
+                const preparedIntent: PreparedViewerIntent = {
+                    ...intent,
+                    resolution,
+                };
+                if (viewer.isOpen()) {
+                    return followOpenConversation(
+                        target,
+                        openWhenClosed,
+                        !openWhenClosed,
+                        preparedIntent
+                    );
+                }
+                if (!openWhenClosed) {
+                    return 'closed';
+                }
+                return openLatestConversation(
+                    options,
+                    coordinator,
+                    viewer,
+                    target,
+                    intent.isCurrent,
+                    snapshotWarmup,
+                    intent.signal,
+                    resolution
+                );
+            },
+        };
+    };
     return {
         viewer,
         availability: 'available',
@@ -666,6 +753,7 @@ function createAvailableConversationCapability(
                 beginViewerIntent();
             }
         },
+        prepareActiveConversation,
         openLatestConversation: target => openConversation(target),
         async openLatestActiveConversation(
             target: ConversationSessionOpenTarget
@@ -863,6 +951,12 @@ function createUnavailableConversationCapability(): ConversationCapability {
         viewer,
         availability: 'unavailable',
         cancelPendingNavigation(): void {},
+        prepareActiveConversation(): PreparedActiveConversationNavigation {
+            return {
+                apply: async () => 'unavailable',
+                cancel() {},
+            };
+        },
         async openLatestConversation(): Promise<OpenLatestConversationResult> {
             return 'unavailable';
         },
@@ -902,20 +996,22 @@ async function openLatestConversation(
     target: ConversationSessionOpenTarget,
     isCurrent: () => boolean,
     snapshotWarmup?: ConversationSnapshotWarmup,
-    signal?: ConversationAbortSignal
+    signal?: ConversationAbortSignal,
+    preparedResolution?: Promise<LatestConversationTargetResolution>
 ): Promise<OpenLatestConversationResult> {
     const preview = viewer.previewSession?.(target);
     let opened = false;
     try {
-        let resolution = await resolveLatestConversationTarget(
-            options,
-            coordinator,
-            target,
-            undefined,
-            undefined,
-            snapshotWarmup,
-            signal
-        );
+        let resolution = await (preparedResolution
+            || resolveLatestConversationTarget(
+                options,
+                coordinator,
+                target,
+                undefined,
+                undefined,
+                snapshotWarmup,
+                signal
+            ));
         if (resolution.result === 'unavailable' && isCurrent()) {
             resolution = await resolveLatestConversationTarget(
                 options,

--- a/src/aiSessions/conversation/composition.ts
+++ b/src/aiSessions/conversation/composition.ts
@@ -526,6 +526,8 @@ function createAvailableConversationCapability(
         isCurrent(): boolean;
         signal: ConversationAbortSignal;
         resolution?: Promise<LatestConversationTargetResolution>;
+        revalidateAfterLoad?: boolean;
+        preview?: AiSessionDisposable;
     };
     const followOpenConversation = async (
         target: ConversationSessionOpenTarget,
@@ -534,12 +536,14 @@ function createAvailableConversationCapability(
         preparedIntent?: PreparedViewerIntent
     ): Promise<FollowActiveConversationResult> => {
         if (!viewer.isOpen()) {
+            preparedIntent?.preview?.dispose();
             return 'closed';
         }
         const intent: PreparedViewerIntent = preparedIntent || beginViewerIntent();
         const currentTarget = viewer.getCurrentTarget();
         if (currentTarget
             && hasSameConversationSession(currentTarget, target)) {
+            preparedIntent?.preview?.dispose();
             // This is a new navigation intent, even though it resolves to
             // the already-authoritative session. Let the Viewer cancel a
             // pending preflight for another session, then keep the retained
@@ -552,7 +556,7 @@ function createAvailableConversationCapability(
             }
             return 'opened';
         }
-        const preview = viewer.previewSession?.(target);
+        const preview = preparedIntent?.preview || viewer.previewSession?.(target);
         let followedSuccessfully = false;
         try {
             const resolution = await (intent.resolution
@@ -608,7 +612,8 @@ function createAvailableConversationCapability(
                 viewerLoadRecorded = true;
                 snapshotWarmup?.afterLoad(
                     resolution.viewerTarget,
-                    resolution.prefetchedSnapshot === true,
+                    resolution.prefetchedSnapshot === true
+                        || intent.revalidateAfterLoad === true,
                     viewer
                 );
             };
@@ -717,31 +722,89 @@ function createAvailableConversationCapability(
                     return 'superseded';
                 }
                 applied = true;
-                const preparedIntent: PreparedViewerIntent = {
-                    ...intent,
-                    resolution,
-                };
-                if (viewer.isOpen()) {
-                    return followOpenConversation(
-                        target,
-                        openWhenClosed,
-                        !openWhenClosed,
-                        preparedIntent
-                    );
-                }
-                if (!openWhenClosed) {
+                if (!viewer.isOpen() && !openWhenClosed) {
+                    cancel();
                     return 'closed';
                 }
-                return openLatestConversation(
-                    options,
-                    coordinator,
-                    viewer,
-                    target,
-                    intent.isCurrent,
-                    snapshotWarmup,
-                    intent.signal,
-                    resolution
-                );
+                const currentTarget = viewer.getCurrentTarget();
+                const preparedPreview = viewer.isOpen()
+                    && !(currentTarget && hasSameConversationSession(
+                        currentTarget,
+                        target
+                    ))
+                    ? viewer.previewSession?.(target)
+                    : undefined;
+                let previewTransferred = false;
+                try {
+                    let resolutionForApply = resolution;
+                    let retriedAtApply = false;
+                    if (resolution) {
+                        const preparedResolution = await resolution;
+                        if (!intent.isCurrent()) {
+                            return 'superseded';
+                        }
+                        // An early empty/unavailable response can become usable
+                        // while terminal focus is queued. Re-read only those
+                        // terminal outcomes at commit time; an opened snapshot
+                        // is revalidated after Viewer application below.
+                        if (preparedResolution.result !== 'opened') {
+                            retriedAtApply = true;
+                            resolutionForApply = resolveLatestConversationTarget(
+                                options,
+                                coordinator,
+                                target,
+                                undefined,
+                                undefined,
+                                snapshotWarmup,
+                                intent.signal
+                            );
+                        }
+                    }
+                    const preparedIntent: PreparedViewerIntent = {
+                        ...intent,
+                        resolution: resolutionForApply,
+                        revalidateAfterLoad: resolution !== undefined,
+                        preview: preparedPreview,
+                    };
+                    if (viewer.isOpen()) {
+                        previewTransferred = true;
+                        return followOpenConversation(
+                            target,
+                            openWhenClosed,
+                            !openWhenClosed,
+                            preparedIntent
+                        );
+                    }
+                    if (!openWhenClosed) {
+                        cancel();
+                        return 'closed';
+                    }
+                    const result = await openLatestConversation(
+                        options,
+                        coordinator,
+                        viewer,
+                        target,
+                        intent.isCurrent,
+                        snapshotWarmup,
+                        intent.signal,
+                        resolutionForApply,
+                        resolution !== undefined,
+                        retriedAtApply
+                    );
+                    if (result === 'opened') {
+                        const openedTarget = viewer.getCurrentTarget();
+                        if (openedTarget
+                            && hasSameConversationSession(openedTarget, target)) {
+                            terminalAuthority.confirmedTarget =
+                                cloneConversationViewerTarget(openedTarget);
+                        }
+                    }
+                    return result;
+                } finally {
+                    if (!previewTransferred) {
+                        preparedPreview?.dispose();
+                    }
+                }
             },
         };
     };
@@ -997,7 +1060,9 @@ async function openLatestConversation(
     isCurrent: () => boolean,
     snapshotWarmup?: ConversationSnapshotWarmup,
     signal?: ConversationAbortSignal,
-    preparedResolution?: Promise<LatestConversationTargetResolution>
+    preparedResolution?: Promise<LatestConversationTargetResolution>,
+    revalidateAfterLoad = false,
+    skipUnavailableRetry = false
 ): Promise<OpenLatestConversationResult> {
     const preview = viewer.previewSession?.(target);
     let opened = false;
@@ -1012,7 +1077,9 @@ async function openLatestConversation(
                 snapshotWarmup,
                 signal
             ));
-        if (resolution.result === 'unavailable' && isCurrent()) {
+        if (resolution.result === 'unavailable'
+            && isCurrent()
+            && !skipUnavailableRetry) {
             resolution = await resolveLatestConversationTarget(
                 options,
                 coordinator,
@@ -1049,7 +1116,7 @@ async function openLatestConversation(
             viewerLoadRecorded = true;
             snapshotWarmup?.afterLoad(
                 resolution.viewerTarget,
-                resolution.prefetchedSnapshot === true,
+                resolution.prefetchedSnapshot === true || revalidateAfterLoad,
                 viewer
             );
         };

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -2125,11 +2125,17 @@ async function initializeDashboard(
         sessionId: string;
     }, openWhenClosed: boolean): Promise<void> => {
         const intent = beginConversationNavigationIntent();
+        // Resolve the provider snapshot immediately. Terminal focus must stay
+        // serialized, but it is independent of the read and should not make
+        // a slow focus plus a slow snapshot feel like two consecutive waits.
+        const preparedConversation =
+            conversationCapability.prepareActiveConversation(target, openWhenClosed);
         return sessionNavigationCoordinator.enqueueLatest(async () => {
         const startedAt = Date.now();
         let focusMs = 0;
         let conversationMs = 0;
         let outcome = 'focus-failed';
+        let conversationApplied = false;
         try {
             const focusStartedAt = Date.now();
             let focused: boolean;
@@ -2147,11 +2153,8 @@ async function initializeDashboard(
             if (focused && intent === conversationNavigationIntent) {
                 const conversationStartedAt = Date.now();
                 try {
-                    if (openWhenClosed) {
-                        await conversationCapability.openLatestActiveConversation(target);
-                    } else {
-                        await conversationCapability.followActiveConversation(target);
-                    }
+                    conversationApplied = true;
+                    await preparedConversation.apply();
                 } catch (error) {
                     conversationMs = Date.now() - conversationStartedAt;
                     outcome = 'conversation-error';
@@ -2169,6 +2172,9 @@ async function initializeDashboard(
                 );
             }
         } finally {
+            if (!conversationApplied) {
+                preparedConversation.cancel();
+            }
             logAiSessionDiagnostic({
                 event: 'session-navigation-latency',
                 source: 'dashboard-row',

--- a/tests/integration/dashboard/conversationOpenLatest.test.js
+++ b/tests/integration/dashboard/conversationOpenLatest.test.js
@@ -61,6 +61,19 @@ function loadConversationComposition() {
     }
 }
 
+function loadDashboardModule() {
+    const previousLoad = Module._load;
+    try {
+        Module._load = function (request, parent, isMain) {
+            if (request === 'vscode') return {};
+            return previousLoad.call(this, request, parent, isMain);
+        };
+        return require('../../../out/dashboard');
+    } finally {
+        Module._load = previousLoad;
+    }
+}
+
 const {
     createConversationCapability,
 } = loadConversationComposition();
@@ -966,6 +979,134 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 releases an obsolete Viewer wai
     harness.capability.dispose();
 });
 
+test('CONVERSATION-SWITCH-LATENCY-002 starts a prepared snapshot before terminal focus releases its Viewer apply', async () => {
+    const delayedSnapshot = deferred();
+    const delayedFocus = deferred();
+    const harness = createHarness({
+        enableSnapshots: true,
+        requireSnapshot: true,
+        readSnapshot: () => delayedSnapshot.promise,
+    });
+    const prepared = harness.capability.prepareActiveConversation({
+        projectId: 'project-a',
+        provider: 'codex',
+        sessionId: 'session-a',
+    }, true);
+    const navigation = (async () => {
+        await delayedFocus.promise;
+        return prepared.apply();
+    })();
+
+    await waitFor(
+        () => harness.snapshotReadTargets.includes('codex:session-a'),
+        'the prepared foreground snapshot to start while terminal focus is pending'
+    );
+    assert.deepEqual(harness.viewerTargets, [],
+        'a prepared snapshot must not mutate the Viewer before terminal focus succeeds');
+
+    delayedFocus.resolve();
+    delayedSnapshot.resolve({
+        outline: makeOutline('codex', 'session-a', ['input-a']),
+        page: makePage('codex', 'session-a', 'input-a'),
+    });
+    assert.equal(await navigation, 'opened');
+    assert.equal(harness.viewerTargets.length, 1,
+        'the resolved snapshot applies only after the queued terminal focus completes');
+    harness.capability.dispose();
+});
+
+test('CONVERSATION-SWITCH-LATENCY-002 avoids a snapshot when a closed Viewer will not open', async () => {
+    const harness = createHarness({
+        enableSnapshots: true,
+        requireSnapshot: true,
+        viewerOpen: false,
+    });
+    const prepared = harness.capability.prepareActiveConversation({
+        projectId: 'project-a', provider: 'codex', sessionId: 'session-a',
+    }, false);
+
+    assert.equal(await prepared.apply(), 'closed');
+    assert.equal(harness.snapshotReads, 0,
+        'a terminal-only row focus must not spend provider work on a closed Viewer');
+    harness.capability.dispose();
+});
+
+test('CONVERSATION-SWITCH-LATENCY-002 cancels a prepared snapshot when terminal focus cannot proceed', async () => {
+    const slowSnapshot = deferred();
+    let readAborted = false;
+    const harness = createHarness({
+        enableSnapshots: true,
+        requireSnapshot: true,
+        readSnapshot: (_provider, _sessionId, _preferredInteractionId, signal) => {
+            signal.onAbort(() => { readAborted = true; });
+            return slowSnapshot.promise;
+        },
+    });
+    const prepared = harness.capability.prepareActiveConversation({
+        projectId: 'project-a', provider: 'codex', sessionId: 'session-a',
+    }, true);
+    await waitFor(
+        () => harness.snapshotReadTargets.includes('codex:session-a'),
+        'the prepared snapshot to start before terminal focus'
+    );
+
+    prepared.cancel();
+    assert.equal(readAborted, true,
+        'a rejected terminal focus must abort its uncommitted provider read');
+    assert.equal(await prepared.apply(), 'superseded');
+    slowSnapshot.resolve({
+        outline: makeOutline('codex', 'session-a', ['input-a']),
+        page: makePage('codex', 'session-a', 'input-a'),
+    });
+    harness.capability.dispose();
+});
+
+test('CONVERSATION-SWITCH-LATENCY-002 lets only the newest prepared target apply', async () => {
+    const slowSnapshot = deferred();
+    let staleReadAborted = false;
+    const harness = createHarness({
+        enableSnapshots: true,
+        requireSnapshot: true,
+        resolveTarget: (_projectId, provider, sessionId) => makeSession({
+            key: `${provider}:${sessionId}`,
+            provider,
+            sessionId,
+            name: sessionId,
+        }),
+        readSnapshot: (provider, sessionId, _preferredInteractionId, signal) => {
+            if (sessionId === 'session-a') {
+                signal.onAbort(() => { staleReadAborted = true; });
+                return slowSnapshot.promise;
+            }
+            return {
+                outline: makeOutline(provider, sessionId, ['input-b']),
+                page: makePage(provider, sessionId, 'input-b'),
+            };
+        },
+    });
+    const stale = harness.capability.prepareActiveConversation({
+        projectId: 'project-a', provider: 'codex', sessionId: 'session-a',
+    }, true);
+    await waitFor(
+        () => harness.snapshotReadTargets.includes('codex:session-a'),
+        'the first prepared snapshot to start'
+    );
+    const latest = harness.capability.prepareActiveConversation({
+        projectId: 'project-a', provider: 'kimi', sessionId: 'session-b',
+    }, true);
+
+    assert.equal(await stale.apply(), 'superseded');
+    assert.equal(staleReadAborted, true,
+        'a newer prepared target must abort the stale provider read immediately');
+    assert.equal(await latest.apply(), 'opened');
+    assert.deepEqual(harness.viewerTargets.map(target => target.sessionId), ['session-b']);
+    slowSnapshot.resolve({
+        outline: makeOutline('codex', 'session-a', ['input-a']),
+        page: makePage('codex', 'session-a', 'input-a'),
+    });
+    harness.capability.dispose();
+});
+
 test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 releases a claimed warmup as soon as its navigation is cancelled', async () => {
     const sessions = ['codex', 'kimi'].map((provider, index) => makeSession({
         key: `${provider}:claimed-cancel-${index}`,
@@ -1518,6 +1659,8 @@ test('CONVERSATION-FOLLOW-ACTIVE-SESSION-001 follows the latest interaction only
 });
 
 test('CONVERSATION-FOLLOW-ACTIVE-SESSION-001 delegates Active Session card focus to the shared Conversation-aware navigation path', () => {
+    assert.equal(typeof loadDashboardModule().activate, 'function',
+        'the Dashboard entrypoint must load before its row-navigation contract is inspected');
     const handlersSource = fs.readFileSync(
         path.join(__dirname, '../../../src/dashboard/messageHandlers.ts'),
         'utf8'
@@ -1539,8 +1682,11 @@ test('CONVERSATION-FOLLOW-ACTIVE-SESSION-001 delegates Active Session card focus
     assert.match(navigationPath[0], /focusActive\(/);
     assert.match(
         navigationPath[0],
-        /if \(openWhenClosed\) \{[\s\S]*openLatestActiveConversation\([\s\S]*?followActiveConversation\(/
+        /prepareActiveConversation\(target, openWhenClosed\)/,
+        'the shared row path must start the snapshot transaction itself'
     );
+    assert.match(navigationPath[0], /await preparedConversation\.apply\(\)/,
+        'only the queued, focused transaction may commit a prepared snapshot');
     assert.match(
         dashboardSource,
         /const focusTerminal = e\.version === 2 && e\.focusTerminal === true;[\s\S]*focusAiSessionAndOpenConversation\(target\)/
@@ -1556,13 +1702,22 @@ test('CONVERSATION-FOLLOW-ACTIVE-SESSION-001 delegates Active Session card focus
     const enqueueStart = navigationPath[0].indexOf(
         'sessionNavigationCoordinator.enqueueLatest('
     );
+    const preparedStart = navigationPath[0].indexOf(
+        'conversationCapability.prepareActiveConversation(target, openWhenClosed)'
+    );
     assert.ok(intentStart >= 0,
         'a row click must create a navigation intent in its own execution path');
     assert.ok(enqueueStart >= 0,
         'a row click must use the shared terminal-focus queue');
+    assert.ok(preparedStart >= 0,
+        'a row click must start a snapshot transaction in its own execution path');
     assert.ok(
         intentStart < enqueueStart,
         'a row click must cancel the old read before it joins the shared queue'
+    );
+    assert.ok(
+        preparedStart < enqueueStart,
+        'a row click must begin snapshot resolution before terminal focus enters the queue'
     );
 });
 

--- a/tests/integration/dashboard/conversationOpenLatest.test.js
+++ b/tests/integration/dashboard/conversationOpenLatest.test.js
@@ -259,7 +259,9 @@ function createHarness(options = {}) {
         createViewer: viewerOptions => {
             capturedViewerOptions = viewerOptions;
             return {
-                isOpen: () => options.viewerOpen === true,
+                isOpen: () => typeof options.getViewerOpen === 'function'
+                    ? options.getViewerOpen() === true
+                    : options.viewerOpen === true,
                 getCurrentTarget: () => (
                     options.getCurrentViewerTarget?.()
                     || options.getFocusedViewerTarget?.()
@@ -985,13 +987,20 @@ test('CONVERSATION-SWITCH-LATENCY-002 starts a prepared snapshot before terminal
     const harness = createHarness({
         enableSnapshots: true,
         requireSnapshot: true,
+        viewerOpen: true,
+        initialViewerTarget: {
+            projectId: 'project-a', provider: 'kimi', workspaceName: '',
+            sessionId: 'session-before', interactionId: 'input-before', expectedRevision: 'r1',
+            displayName: 'session-before', duplicateDisplayName: false,
+        },
         readSnapshot: () => delayedSnapshot.promise,
+        previewSession: () => ({ dispose() {} }),
     });
     const prepared = harness.capability.prepareActiveConversation({
         projectId: 'project-a',
         provider: 'codex',
         sessionId: 'session-a',
-    }, true);
+    }, false);
     const navigation = (async () => {
         await delayedFocus.promise;
         return prepared.apply();
@@ -1003,14 +1012,20 @@ test('CONVERSATION-SWITCH-LATENCY-002 starts a prepared snapshot before terminal
     );
     assert.deepEqual(harness.viewerTargets, [],
         'a prepared snapshot must not mutate the Viewer before terminal focus succeeds');
+    assert.deepEqual(harness.previewedViewerTargets, [],
+        'preparing must not preflight the Viewer before terminal focus succeeds');
 
     delayedFocus.resolve();
+    await waitFor(
+        () => harness.previewedViewerTargets.some(target => target.sessionId === 'session-a'),
+        'the Viewer preflight to begin only after terminal focus releases apply'
+    );
     delayedSnapshot.resolve({
         outline: makeOutline('codex', 'session-a', ['input-a']),
         page: makePage('codex', 'session-a', 'input-a'),
     });
     assert.equal(await navigation, 'opened');
-    assert.equal(harness.viewerTargets.length, 1,
+    assert.equal(harness.followedViewerTargets.length, 1,
         'the resolved snapshot applies only after the queued terminal focus completes');
     harness.capability.dispose();
 });
@@ -1061,9 +1076,226 @@ test('CONVERSATION-SWITCH-LATENCY-002 cancels a prepared snapshot when terminal 
     harness.capability.dispose();
 });
 
+test('CONVERSATION-SWITCH-LATENCY-002 cancels a prepared follow when its Viewer closes before apply', async () => {
+    const slowSnapshot = deferred();
+    let viewerOpen = true;
+    let readAborted = false;
+    const harness = createHarness({
+        enableSnapshots: true,
+        requireSnapshot: true,
+        getViewerOpen: () => viewerOpen,
+        initialViewerTarget: {
+            projectId: 'project-a', provider: 'codex', workspaceName: '',
+            sessionId: 'session-a', interactionId: 'input-a', expectedRevision: 'r1',
+            displayName: 'session-a', duplicateDisplayName: false,
+        },
+        resolveTarget: (_projectId, provider, sessionId) => makeSession({
+            key: `${provider}:${sessionId}`, provider, sessionId, name: sessionId,
+        }),
+        readSnapshot: (_provider, _sessionId, _preferredInteractionId, signal) => {
+            signal.onAbort(() => { readAborted = true; });
+            return slowSnapshot.promise;
+        },
+    });
+    const prepared = harness.capability.prepareActiveConversation({
+        projectId: 'project-a', provider: 'kimi', sessionId: 'session-b',
+    }, false);
+    await waitFor(
+        () => harness.snapshotReadTargets.includes('kimi:session-b'),
+        'the prepared follow read to start'
+    );
+
+    viewerOpen = false;
+    assert.equal(await prepared.apply(), 'closed');
+    assert.equal(readAborted, true,
+        'a closed Viewer must release an uncommitted prepared follow read');
+    slowSnapshot.resolve({
+        outline: makeOutline('kimi', 'session-b', ['input-b']),
+        page: makePage('kimi', 'session-b', 'input-b'),
+    });
+    harness.capability.dispose();
+});
+
+test('CONVERSATION-SWITCH-LATENCY-002 revalidates a prepared snapshot after Viewer application', async () => {
+    const releaseFollow = deferred();
+    const harness = createHarness({
+        enableSnapshots: true,
+        requireSnapshot: true,
+        viewerOpen: true,
+        initialViewerTarget: {
+            projectId: 'project-a', provider: 'codex', workspaceName: '',
+            sessionId: 'session-a', interactionId: 'input-a', expectedRevision: 'r1',
+            displayName: 'session-a', duplicateDisplayName: false,
+        },
+        resolveTarget: (_projectId, provider, sessionId) => makeSession({
+            key: `${provider}:${sessionId}`, provider, sessionId, name: sessionId,
+        }),
+        followViewer: () => releaseFollow.promise,
+    });
+    const prepared = harness.capability.prepareActiveConversation({
+        projectId: 'project-a', provider: 'kimi', sessionId: 'session-b',
+    }, false);
+
+    const applying = prepared.apply();
+    await new Promise(resolve => setImmediate(resolve));
+    assert.equal(harness.viewerRefreshes, 0,
+        'freshness revalidation must wait for the Viewer to commit its target');
+    releaseFollow.resolve(true);
+    assert.equal(await applying, 'opened');
+    await waitFor(
+        () => harness.viewerRefreshes === 1,
+        'the post-apply freshness revalidation'
+    );
+    harness.capability.dispose();
+});
+
+test('CONVERSATION-SWITCH-LATENCY-002 previews an open Viewer while a prepared snapshot still resolves', async () => {
+    const slowSnapshot = deferred();
+    const harness = createHarness({
+        enableSnapshots: true,
+        requireSnapshot: true,
+        viewerOpen: true,
+        initialViewerTarget: {
+            projectId: 'project-a', provider: 'codex', workspaceName: '',
+            sessionId: 'session-a', interactionId: 'input-a', expectedRevision: 'r1',
+            displayName: 'session-a', duplicateDisplayName: false,
+        },
+        resolveTarget: (_projectId, provider, sessionId) => makeSession({
+            key: `${provider}:${sessionId}`, provider, sessionId, name: sessionId,
+        }),
+        readSnapshot: () => slowSnapshot.promise,
+        previewSession: () => ({ dispose() {} }),
+    });
+    const prepared = harness.capability.prepareActiveConversation({
+        projectId: 'project-a', provider: 'kimi', sessionId: 'session-b',
+    }, false);
+
+    const applying = prepared.apply();
+    await waitFor(
+        () => harness.previewedViewerTargets.some(target => target.sessionId === 'session-b'),
+        'the Viewer preflight to begin before the slow prepared snapshot resolves'
+    );
+    assert.deepEqual(harness.followedViewerTargets, []);
+    slowSnapshot.resolve({
+        outline: makeOutline('kimi', 'session-b', ['input-b']),
+        page: makePage('kimi', 'session-b', 'input-b'),
+    });
+    assert.equal(await applying, 'opened');
+    harness.capability.dispose();
+});
+
+test('CONVERSATION-SWITCH-LATENCY-002 retries an early empty prepared result at apply', async () => {
+    let reads = 0;
+    const harness = createHarness({
+        enableSnapshots: true,
+        requireSnapshot: true,
+        viewerOpen: true,
+        initialViewerTarget: {
+            projectId: 'project-a', provider: 'codex', workspaceName: '',
+            sessionId: 'session-a', interactionId: 'input-a', expectedRevision: 'r1',
+            displayName: 'session-a', duplicateDisplayName: false,
+        },
+        resolveTarget: (_projectId, provider, sessionId) => makeSession({
+            key: `${provider}:${sessionId}`, provider, sessionId, name: sessionId,
+        }),
+        readSnapshot: (provider, sessionId) => {
+            reads += 1;
+            return reads === 1
+                ? {
+                    outline: makeOutline(provider, sessionId, []),
+                    page: makePage(provider, sessionId, 'input-a'),
+                }
+                : {
+                    outline: makeOutline(provider, sessionId, ['input-b']),
+                    page: makePage(provider, sessionId, 'input-b'),
+                };
+        },
+    });
+    const prepared = harness.capability.prepareActiveConversation({
+        projectId: 'project-a', provider: 'kimi', sessionId: 'session-b',
+    }, false);
+
+    assert.equal(await prepared.apply(), 'opened');
+    assert.equal(reads, 2,
+        'an early empty result must be checked again after terminal focus');
+    harness.capability.dispose();
+});
+
+test('CONVERSATION-SWITCH-LATENCY-002 does not double-retry a persistent unavailable prepared open', async () => {
+    let reads = 0;
+    const harness = createHarness({
+        enableSnapshots: true,
+        requireSnapshot: true,
+        viewerOpen: false,
+        resolveTarget: (_projectId, provider, sessionId) => makeSession({
+            key: `${provider}:${sessionId}`, provider, sessionId, name: sessionId,
+        }),
+        readSnapshot: () => {
+            reads += 1;
+            throw new Error('snapshot remains unavailable');
+        },
+    });
+    const prepared = harness.capability.prepareActiveConversation({
+        projectId: 'project-a', provider: 'kimi', sessionId: 'session-b',
+    }, true);
+
+    assert.equal(await prepared.apply(), 'unavailable');
+    assert.equal(reads, 2,
+        'one overlapped read plus one commit retry must bound an unavailable open');
+    harness.capability.dispose();
+});
+
+test('CONVERSATION-SWITCH-LATENCY-002 records terminal authority after a prepared closed-Viewer open', async () => {
+    const sessions = [
+        makeSession({ key: 'codex:session-a', sessionId: 'session-a' }),
+        makeSession({ key: 'codex:session-b', sessionId: 'session-b' }),
+        makeSession({ key: 'codex:session-c', sessionId: 'session-c' }),
+    ];
+    let viewerOpen = true;
+    const focusedSessions = [];
+    const harness = createHarness({
+        getViewerOpen: () => viewerOpen,
+        initialViewerTarget: {
+            projectId: 'project-a', provider: 'codex', workspaceName: '',
+            sessionId: 'session-a', interactionId: 'input-a', expectedRevision: 'r1',
+            displayName: 'session-a', duplicateDisplayName: false,
+        },
+        resolveTarget: (_projectId, provider, sessionId) =>
+            sessions.find(session =>
+                session.provider === provider && session.sessionId === sessionId
+            ) || null,
+        resolveActiveTargets: () => sessions,
+        focusSession: async target => {
+            focusedSessions.push(target.sessionId);
+            return target.sessionId !== 'session-c';
+        },
+    });
+    await harness.capability.followActiveConversation({
+        projectId: 'project-a', provider: 'codex', sessionId: 'session-a',
+    });
+    viewerOpen = false;
+    const prepared = harness.capability.prepareActiveConversation({
+        projectId: 'project-a', provider: 'codex', sessionId: 'session-b',
+    }, true);
+    assert.equal(await prepared.apply(), 'opened');
+
+    viewerOpen = true;
+    assert.equal(
+        await harness.capability.followAdjacentActiveConversation('next'),
+        'unavailable'
+    );
+    assert.deepEqual(focusedSessions, ['session-c', 'session-b'],
+        'a rejected B-to-C focus must return to the freshly opened B authority');
+    assert.deepEqual(harness.followedViewerTargets.map(target => target.sessionId), [
+        'session-c', 'session-b',
+    ]);
+    harness.capability.dispose();
+});
+
 test('CONVERSATION-SWITCH-LATENCY-002 lets only the newest prepared target apply', async () => {
     const slowSnapshot = deferred();
     let staleReadAborted = false;
+    let latestReadAborted = false;
     const harness = createHarness({
         enableSnapshots: true,
         requireSnapshot: true,
@@ -1078,6 +1310,7 @@ test('CONVERSATION-SWITCH-LATENCY-002 lets only the newest prepared target apply
                 signal.onAbort(() => { staleReadAborted = true; });
                 return slowSnapshot.promise;
             }
+            signal.onAbort(() => { latestReadAborted = true; });
             return {
                 outline: makeOutline(provider, sessionId, ['input-b']),
                 page: makePage(provider, sessionId, 'input-b'),
@@ -1095,9 +1328,12 @@ test('CONVERSATION-SWITCH-LATENCY-002 lets only the newest prepared target apply
         projectId: 'project-a', provider: 'kimi', sessionId: 'session-b',
     }, true);
 
+    stale.cancel();
     assert.equal(await stale.apply(), 'superseded');
     assert.equal(staleReadAborted, true,
         'a newer prepared target must abort the stale provider read immediately');
+    assert.equal(latestReadAborted, false,
+        'a stale focus cleanup must not abort the latest prepared read');
     assert.equal(await latest.apply(), 'opened');
     assert.deepEqual(harness.viewerTargets.map(target => target.sessionId), ['session-b']);
     slowSnapshot.resolve({
@@ -1705,12 +1941,27 @@ test('CONVERSATION-FOLLOW-ACTIVE-SESSION-001 delegates Active Session card focus
     const preparedStart = navigationPath[0].indexOf(
         'conversationCapability.prepareActiveConversation(target, openWhenClosed)'
     );
+    const focusStart = navigationPath[0].indexOf(
+        'focused = await aiSessionTerminalCommandController.focusActive('
+    );
+    const applyStart = navigationPath[0].indexOf(
+        'await preparedConversation.apply();'
+    );
+    const focusedBranch = navigationPath[0].match(
+        /if \(focused && intent === conversationNavigationIntent\) \{([\s\S]*?)\n\s*\} else if \(focused\)/
+    );
     assert.ok(intentStart >= 0,
         'a row click must create a navigation intent in its own execution path');
     assert.ok(enqueueStart >= 0,
         'a row click must use the shared terminal-focus queue');
     assert.ok(preparedStart >= 0,
         'a row click must start a snapshot transaction in its own execution path');
+    assert.ok(focusStart >= 0 && applyStart >= 0,
+        'the shared path must explicitly await focus and its prepared apply');
+    assert.ok(focusedBranch,
+        'a prepared apply must remain inside the successful current-intent focus branch');
+    assert.match(focusedBranch[1], /await preparedConversation\.apply\(\)/,
+        'only successful focus for the current intent may apply a prepared snapshot');
     assert.ok(
         intentStart < enqueueStart,
         'a row click must cancel the old read before it joins the shared queue'
@@ -1718,6 +1969,10 @@ test('CONVERSATION-FOLLOW-ACTIVE-SESSION-001 delegates Active Session card focus
     assert.ok(
         preparedStart < enqueueStart,
         'a row click must begin snapshot resolution before terminal focus enters the queue'
+    );
+    assert.ok(
+        focusStart < applyStart,
+        'a row click must not apply Viewer state before terminal focus succeeds'
     );
 });
 

--- a/tests/unit/tooling/architectureGuards.test.js
+++ b/tests/unit/tooling/architectureGuards.test.js
@@ -500,10 +500,28 @@ for (const mutation of [
     {
         id: 'ARCH-AI-SESSION-NAVIGATION-OWNERSHIP-001',
         file: 'src/dashboard.ts',
-        expectedDetail: 'Dashboard Chat-row clicks must use the shared latest-intent navigation transaction',
+        expectedDetail: 'Dashboard Chat-row clicks must prepare once, then commit only through the shared latest-intent navigation transaction',
         mutate: source => source.replace(
             'return sessionNavigationCoordinator.enqueueLatest(async () => {',
             'return (async () => {',
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-NAVIGATION-OWNERSHIP-001',
+        file: 'src/dashboard.ts',
+        expectedDetail: 'Dashboard Chat-row clicks must prepare once, then commit only through the shared latest-intent navigation transaction',
+        mutate: source => source.replace(
+            'conversationCapability.prepareActiveConversation(target, openWhenClosed)',
+            'conversationCapability.openLatestActiveConversation(target)',
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-NAVIGATION-OWNERSHIP-001',
+        file: 'src/dashboard.ts',
+        expectedDetail: 'Dashboard Chat-row clicks must prepare once, then commit only through the shared latest-intent navigation transaction',
+        mutate: source => source.replace(
+            'await preparedConversation.apply();',
+            'await conversationCapability.followActiveConversation(target);',
         ),
     },
     {

--- a/tests/unit/tooling/architectureGuards.test.js
+++ b/tests/unit/tooling/architectureGuards.test.js
@@ -525,6 +525,30 @@ for (const mutation of [
         ),
     },
     {
+        id: 'ARCH-AI-SESSION-NAVIGATION-OWNERSHIP-001',
+        file: 'src/dashboard.ts',
+        expectedDetail: 'Dashboard Chat-row prepared Viewer apply must occur after successful current-intent terminal focus',
+        mutate: source => source.replace(
+            'await preparedConversation.apply();\n',
+            '',
+        ).replace(
+            'const focusStartedAt = Date.now();',
+            'await preparedConversation.apply();\n            const focusStartedAt = Date.now();',
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-NAVIGATION-OWNERSHIP-001',
+        file: 'src/dashboard.ts',
+        expectedDetail: 'Dashboard Chat-row prepared Viewer cancel must remain in the uncommitted finally branch',
+        mutate: source => source.replace(
+            'return sessionNavigationCoordinator.enqueueLatest(async () => {',
+            'preparedConversation.cancel();\n        return sessionNavigationCoordinator.enqueueLatest(async () => {',
+        ).replace(
+            'if (!conversationApplied) {\n                preparedConversation.cancel();\n            }\n',
+            '',
+        ),
+    },
+    {
         id: 'ARCH-AI-SESSION-CONVERSATION-BOUNDARY-001',
         file: 'src/aiSessions/conversation/codexAdapter.ts',
         expectedDetail: 'Codex conversation adapter must not import filesystem or transcript JSONL readers',


### PR DESCRIPTION
## Summary

- Start the authoritative Conversation snapshot while the selected terminal waits for serialized focus.
- Commit the prepared target only after the same focus transaction succeeds; newer intents and failed focus cancel uncommitted reads.
- Preserve Viewer preview, post-apply freshness, retry bounds, and terminal authority across the prepare/commit boundary.
- Add behavior, architecture, mutation, and changed-line coverage gates for the parallel transaction.

## Verification

- `npm run test-compile`
- focused Conversation and architecture suites: 227 passing
- related dashboard, Viewer, and quick-switch suites: 172 passing
- `npm run lint:ci`
- `npm run test:behavior-contracts`
- changed-line coverage: 95.21%
- `SKIP_NPM_CI=1 npm run install-local` (will be refreshed after CI push)

## Skill harvest

No skill change: the review fixes were covered by the existing review-and-verification workflow; the new mutation gates make the latency transaction constraints executable.

## Owner approvals

```text
approve 8af09c17cda340ecc7325381eaaa138ad5893d18
```