### PR TITLE
fix: keep IME composition alive in the worktree group creation form

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -3807,7 +3807,7 @@
   {
     "id": "WORKTREE-GROUPS-CREATE-UI-001",
     "domain": "webview",
-    "title": "The inline group creation form offers local and fetched remote base branches, previews every physical side effect in real time, gates confirm on preflight, offers the explicit available-subset action, and renders member Retry/Dismiss",
+    "title": "The inline group creation form offers local and fetched remote base branches, previews every physical side effect in real time, gates confirm on preflight, offers the explicit available-subset action, renders member Retry/Dismiss, and preserves in-progress IME compositions across previews, settlements, and authoritative updates",
     "priority": "P0",
     "status": "automated",
     "owners": [

--- a/media/webviewDashboardBundle.js
+++ b/media/webviewDashboardBundle.js
@@ -3120,6 +3120,15 @@ function initWorktreeGroupForm(options) {
     // slot; renderForm prefers it over the live DOM read (which can only see
     // document.body once the old slot is gone).
     var replacementFocusByProject = new Map();
+    // IME composition (CJK input): while a composition is active the preedit
+    // string lives inside the focused input, so ANY form rebuild — a preview
+    // response re-render or an authoritative surface replacement — detaches
+    // that input and aborts the composition (the candidate window dies and
+    // focus restore cannot resurrect it). Renders defer to compositionend,
+    // and the message dispatcher queues authoritative updates via
+    // onCompositionEnd.
+    var composition = { active: false, projectId: '' };
+    var compositionEndListeners = [];
 
     function nextRequestId(prefix) {
         nextRequestSerial = nextRequestSerial >= Number.MAX_SAFE_INTEGER
@@ -3152,6 +3161,7 @@ function initWorktreeGroupForm(options) {
                 confirming: false,
                 confirmRequestId: '',
                 formError: '',
+                renderDeferred: false,
                 pendingFocusGroupId: '',
                 pendingMemberRequests: {},
                 derive: null,
@@ -3446,6 +3456,7 @@ function initWorktreeGroupForm(options) {
     function confirmForm(projectId, availableOnly) {
         var state = getState(projectId);
         if (!state || !state.open || state.confirming || state.previewDirty
+            || composition.active
             || !state.preview || state.preview.formError || !state.previewId) {
             return;
         }
@@ -3873,6 +3884,16 @@ function initWorktreeGroupForm(options) {
         if (!slot) {
             return;
         }
+        // Never rebuild mid-composition: detaching the input that owns the
+        // IME preedit aborts the composition. The deferred render flushes
+        // on compositionend.
+        if (state && state.open && composition.projectId === projectId) {
+            state.renderDeferred = true;
+            return;
+        }
+        if (state) {
+            state.renderDeferred = false;
+        }
         if (!state || !state.open) {
             replacementFocusByProject.delete(projectId);
             slot.hidden = true;
@@ -4091,6 +4112,13 @@ function initWorktreeGroupForm(options) {
             return true;
         }
         state.name = nameInput.value;
+        if (composition.active) {
+            // The preedit text is not a committed name yet: previewing it
+            // would race the compositionend commit, and the preview
+            // response's re-render would abort the composition. The
+            // compositionend handler syncs the actions row.
+            return true;
+        }
         schedulePreview(projectId);
         return true;
     }
@@ -4142,6 +4170,12 @@ function initWorktreeGroupForm(options) {
         var form = event.target && event.target.closest
             ? event.target.closest('[data-worktree-group-form]') : null;
         if (!form) {
+            return false;
+        }
+        // Keystrokes owned by an in-progress IME composition (candidate
+        // navigation, Enter committing the candidate, Esc cancelling the
+        // preedit) must not drive form actions.
+        if (event.isComposing) {
             return false;
         }
         var projectId = form.getAttribute('data-project-id');
@@ -4203,12 +4237,66 @@ function initWorktreeGroupForm(options) {
         onKeydown(event);
     });
 
+    function compositionFormProjectId(target) {
+        if (!target || !target.closest
+            || !(target.hasAttribute('data-group-form-name')
+                || target.hasAttribute('data-group-form-base-filter'))) {
+            return '';
+        }
+        var form = target.closest('[data-worktree-group-form]');
+        return form ? form.getAttribute('data-project-id') || '' : '';
+    }
+
+    document.addEventListener('compositionstart', function (event) {
+        var projectId = compositionFormProjectId(event.target);
+        if (projectId) {
+            composition.active = true;
+            composition.projectId = projectId;
+        }
+    });
+
+    document.addEventListener('compositionend', function (event) {
+        var projectId = compositionFormProjectId(event.target)
+            || composition.projectId;
+        if (!projectId || !composition.active) {
+            return;
+        }
+        composition.active = false;
+        composition.projectId = '';
+        var state = getState(projectId);
+        if (state && state.open) {
+            if (event.target && event.target.hasAttribute
+                && event.target.hasAttribute('data-group-form-name')) {
+                state.name = event.target.value;
+            }
+            if (state.renderDeferred) {
+                state.renderDeferred = false;
+                renderForm(projectId);
+            }
+            // The preedit is now committed text: preview the real name.
+            schedulePreview(projectId);
+        }
+        // Release the authoritative host updates queued while composing;
+        // their replacements can no longer abort a composition.
+        compositionEndListeners.slice().forEach(function (listener) {
+            listener();
+        });
+    });
+
     return {
         openForm: openForm,
         closeForm: closeForm,
         isOpen: function (projectId) {
             var state = getState(projectId);
             return !!state && state.open;
+        },
+        isComposing: function () {
+            return composition.active;
+        },
+        onCompositionEnd: function (listener) {
+            if (typeof listener === 'function') {
+                compositionEndListeners.push(listener);
+            }
         },
         onClick: onClick,
         reconcileDom: reconcileDom,
@@ -7843,6 +7931,33 @@ function initProjects() {
     // window.__agentPivotWorktreeGroupRename).
     window.__agentPivotWorktreeGroupForm = worktreeGroupForm;
 
+    // Authoritative replacements detach the creation form's name input; an
+    // in-progress IME composition in that input would be aborted. While
+    // composing, queue the latest update per message type and replay them
+    // when the composition ends.
+    var deferredCompositionHostUpdates = [];
+
+    function queueDeferredCompositionHostUpdate(message) {
+        for (var index = 0; index < deferredCompositionHostUpdates.length; index++) {
+            if (deferredCompositionHostUpdates[index].type === message.type) {
+                deferredCompositionHostUpdates[index] = message;
+                return;
+            }
+        }
+        deferredCompositionHostUpdates.push(message);
+    }
+
+    worktreeGroupForm.onCompositionEnd(function () {
+        if (!deferredCompositionHostUpdates.length) {
+            return;
+        }
+        var pending = deferredCompositionHostUpdates;
+        deferredCompositionHostUpdates = [];
+        for (var index = 0; index < pending.length; index++) {
+            onWindowMessage({ data: pending[index] });
+        }
+    });
+
     function applyValidatedAiSessionPresentationState(message) {
         if (!aiSessionPresentationStateStore.adopt(message)) return;
         aiSessionPresentationDom.apply(message);
@@ -8071,6 +8186,12 @@ function initProjects() {
 
     function onWindowMessage(e) {
         var message = e && e.data;
+        if (message && (message.type === 'open-workspaces-updated'
+            || message.type === 'ai-sessions-updated')
+            && worktreeGroupForm.isComposing()) {
+            queueDeferredCompositionHostUpdate(message);
+            return;
+        }
         if (message && message.type === 'open-tab-layout-notice-dismissed') {
             var isNoticeSettlement = message.version === 1
                 && (message.outcome === 'dismissed' || message.outcome === 'failed')

--- a/media/webviewDashboardBundle.js
+++ b/media/webviewDashboardBundle.js
@@ -3162,6 +3162,7 @@ function initWorktreeGroupForm(options) {
                 confirmRequestId: '',
                 formError: '',
                 renderDeferred: false,
+                pendingClose: null,
                 pendingFocusGroupId: '',
                 pendingMemberRequests: {},
                 derive: null,
@@ -3255,9 +3256,16 @@ function initWorktreeGroupForm(options) {
         if (!state || !state.open) {
             return;
         }
+        if (composition.active && composition.projectId === projectId) {
+            // Tearing the form down now would detach the composing input
+            // and abort the IME session; close when the composition ends.
+            state.pendingClose = !!keepInput;
+            return;
+        }
         state.open = false;
         state.bootstrapping = false;
         state.confirming = false;
+        state.pendingClose = null;
         state.previewDirty = false;
         if (state.previewTimer) {
             clearTimeout(state.previewTimer);
@@ -3380,7 +3388,7 @@ function initWorktreeGroupForm(options) {
 
     function sendPreviewRequest(projectId) {
         var state = getState(projectId);
-        if (!state || !state.open) {
+        if (!state || !state.open || composition.active) {
             return;
         }
         var requestId = nextRequestId('group-preview');
@@ -4175,7 +4183,7 @@ function initWorktreeGroupForm(options) {
         // Keystrokes owned by an in-progress IME composition (candidate
         // navigation, Enter committing the candidate, Esc cancelling the
         // preedit) must not drive form actions.
-        if (event.isComposing) {
+        if (event.isComposing || composition.active) {
             return false;
         }
         var projectId = form.getAttribute('data-project-id');
@@ -4249,10 +4257,26 @@ function initWorktreeGroupForm(options) {
 
     document.addEventListener('compositionstart', function (event) {
         var projectId = compositionFormProjectId(event.target);
-        if (projectId) {
-            composition.active = true;
-            composition.projectId = projectId;
+        if (!projectId) {
+            return;
         }
+        composition.active = true;
+        composition.projectId = projectId;
+        var state = getState(projectId);
+        if (!state || !state.open) {
+            return;
+        }
+        // A preview debounced before the composition began must not send
+        // preedit text, and its in-flight response must not be accepted.
+        // previewDirty keeps confirm blocked until the committed text has
+        // been previewed.
+        if (state.previewTimer) {
+            clearTimeout(state.previewTimer);
+            state.previewTimer = 0;
+        }
+        state.previewRequestId = '';
+        state.previewDirty = true;
+        syncActionsDom(projectId);
     });
 
     document.addEventListener('compositionend', function (event) {
@@ -4265,16 +4289,36 @@ function initWorktreeGroupForm(options) {
         composition.projectId = '';
         var state = getState(projectId);
         if (state && state.open) {
-            if (event.target && event.target.hasAttribute
+            var isFilter = !!(event.target && event.target.hasAttribute
+                && event.target.hasAttribute('data-group-form-base-filter'));
+            if (isFilter) {
+                if (state.baseDropdown) {
+                    state.baseDropdown.filter = event.target.value;
+                }
+            } else if (event.target && event.target.hasAttribute
                 && event.target.hasAttribute('data-group-form-name')) {
                 state.name = event.target.value;
             }
-            if (state.renderDeferred) {
-                state.renderDeferred = false;
-                renderForm(projectId);
+            if (state.pendingClose !== null) {
+                // A close deferred while composing (e.g. the created
+                // settlement) lands now that no input can be aborted.
+                var keepInput = state.pendingClose;
+                state.pendingClose = null;
+                closeForm(projectId, keepInput);
+                reconcileDom();
+            } else {
+                if (state.renderDeferred) {
+                    state.renderDeferred = false;
+                    renderForm(projectId);
+                }
+                if (!isFilter || state.previewDirty) {
+                    // The preedit is now committed text: preview the real
+                    // name. Filtering branches needs no new preview, but a
+                    // preview dirtied mid-composition must be refreshed or
+                    // confirm stays blocked.
+                    schedulePreview(projectId);
+                }
             }
-            // The preedit is now committed text: preview the real name.
-            schedulePreview(projectId);
         }
         // Release the authoritative host updates queued while composing;
         // their replacements can no longer abort a composition.
@@ -7938,9 +7982,20 @@ function initProjects() {
     var deferredCompositionHostUpdates = [];
 
     function queueDeferredCompositionHostUpdate(message) {
+        // Keep only the newest envelope per message type; the host does not
+        // resend dropped updates (delivery, not the rendered ack, completes
+        // its send), so discarding anything but a superseded same-type
+        // message would leave the surface permanently stale.
         for (var index = 0; index < deferredCompositionHostUpdates.length; index++) {
             if (deferredCompositionHostUpdates[index].type === message.type) {
-                deferredCompositionHostUpdates[index] = message;
+                var queued = deferredCompositionHostUpdates[index];
+                var queuedRevision = typeof queued.projectionRevision === 'number'
+                    ? queued.projectionRevision : 0;
+                var messageRevision = typeof message.projectionRevision === 'number'
+                    ? message.projectionRevision : 0;
+                if (messageRevision >= queuedRevision) {
+                    deferredCompositionHostUpdates[index] = message;
+                }
                 return;
             }
         }
@@ -7953,8 +8008,27 @@ function initProjects() {
         }
         var pending = deferredCompositionHostUpdates;
         deferredCompositionHostUpdates = [];
+        // Replay oldest-first: ai-sessions-updated replaces only the current
+        // surface while open-workspaces-updated replaces the whole wrapper,
+        // so a newer current-surface update must land after an older
+        // whole-wrapper one.
+        pending.sort(function (a, b) {
+            var aRevision = typeof a.projectionRevision === 'number'
+                ? a.projectionRevision : 0;
+            var bRevision = typeof b.projectionRevision === 'number'
+                ? b.projectionRevision : 0;
+            return aRevision - bRevision;
+        });
         for (var index = 0; index < pending.length; index++) {
-            onWindowMessage({ data: pending[index] });
+            try {
+                onWindowMessage({ data: pending[index] });
+            } catch (error) {
+                // One poisoned envelope must not drop the rest of the queue.
+                // (console is absent in the dashboard VM checks.)
+                if (typeof console !== 'undefined' && console.error) {
+                    console.error('Failed to replay a deferred host update.', error);
+                }
+            }
         }
     });
 

--- a/media/webviewGroupFormScripts.js
+++ b/media/webviewGroupFormScripts.js
@@ -21,6 +21,15 @@ function initWorktreeGroupForm(options) {
     // slot; renderForm prefers it over the live DOM read (which can only see
     // document.body once the old slot is gone).
     var replacementFocusByProject = new Map();
+    // IME composition (CJK input): while a composition is active the preedit
+    // string lives inside the focused input, so ANY form rebuild — a preview
+    // response re-render or an authoritative surface replacement — detaches
+    // that input and aborts the composition (the candidate window dies and
+    // focus restore cannot resurrect it). Renders defer to compositionend,
+    // and the message dispatcher queues authoritative updates via
+    // onCompositionEnd.
+    var composition = { active: false, projectId: '' };
+    var compositionEndListeners = [];
 
     function nextRequestId(prefix) {
         nextRequestSerial = nextRequestSerial >= Number.MAX_SAFE_INTEGER
@@ -53,6 +62,7 @@ function initWorktreeGroupForm(options) {
                 confirming: false,
                 confirmRequestId: '',
                 formError: '',
+                renderDeferred: false,
                 pendingFocusGroupId: '',
                 pendingMemberRequests: {},
                 derive: null,
@@ -347,6 +357,7 @@ function initWorktreeGroupForm(options) {
     function confirmForm(projectId, availableOnly) {
         var state = getState(projectId);
         if (!state || !state.open || state.confirming || state.previewDirty
+            || composition.active
             || !state.preview || state.preview.formError || !state.previewId) {
             return;
         }
@@ -774,6 +785,16 @@ function initWorktreeGroupForm(options) {
         if (!slot) {
             return;
         }
+        // Never rebuild mid-composition: detaching the input that owns the
+        // IME preedit aborts the composition. The deferred render flushes
+        // on compositionend.
+        if (state && state.open && composition.projectId === projectId) {
+            state.renderDeferred = true;
+            return;
+        }
+        if (state) {
+            state.renderDeferred = false;
+        }
         if (!state || !state.open) {
             replacementFocusByProject.delete(projectId);
             slot.hidden = true;
@@ -992,6 +1013,13 @@ function initWorktreeGroupForm(options) {
             return true;
         }
         state.name = nameInput.value;
+        if (composition.active) {
+            // The preedit text is not a committed name yet: previewing it
+            // would race the compositionend commit, and the preview
+            // response's re-render would abort the composition. The
+            // compositionend handler syncs the actions row.
+            return true;
+        }
         schedulePreview(projectId);
         return true;
     }
@@ -1043,6 +1071,12 @@ function initWorktreeGroupForm(options) {
         var form = event.target && event.target.closest
             ? event.target.closest('[data-worktree-group-form]') : null;
         if (!form) {
+            return false;
+        }
+        // Keystrokes owned by an in-progress IME composition (candidate
+        // navigation, Enter committing the candidate, Esc cancelling the
+        // preedit) must not drive form actions.
+        if (event.isComposing) {
             return false;
         }
         var projectId = form.getAttribute('data-project-id');
@@ -1104,12 +1138,66 @@ function initWorktreeGroupForm(options) {
         onKeydown(event);
     });
 
+    function compositionFormProjectId(target) {
+        if (!target || !target.closest
+            || !(target.hasAttribute('data-group-form-name')
+                || target.hasAttribute('data-group-form-base-filter'))) {
+            return '';
+        }
+        var form = target.closest('[data-worktree-group-form]');
+        return form ? form.getAttribute('data-project-id') || '' : '';
+    }
+
+    document.addEventListener('compositionstart', function (event) {
+        var projectId = compositionFormProjectId(event.target);
+        if (projectId) {
+            composition.active = true;
+            composition.projectId = projectId;
+        }
+    });
+
+    document.addEventListener('compositionend', function (event) {
+        var projectId = compositionFormProjectId(event.target)
+            || composition.projectId;
+        if (!projectId || !composition.active) {
+            return;
+        }
+        composition.active = false;
+        composition.projectId = '';
+        var state = getState(projectId);
+        if (state && state.open) {
+            if (event.target && event.target.hasAttribute
+                && event.target.hasAttribute('data-group-form-name')) {
+                state.name = event.target.value;
+            }
+            if (state.renderDeferred) {
+                state.renderDeferred = false;
+                renderForm(projectId);
+            }
+            // The preedit is now committed text: preview the real name.
+            schedulePreview(projectId);
+        }
+        // Release the authoritative host updates queued while composing;
+        // their replacements can no longer abort a composition.
+        compositionEndListeners.slice().forEach(function (listener) {
+            listener();
+        });
+    });
+
     return {
         openForm: openForm,
         closeForm: closeForm,
         isOpen: function (projectId) {
             var state = getState(projectId);
             return !!state && state.open;
+        },
+        isComposing: function () {
+            return composition.active;
+        },
+        onCompositionEnd: function (listener) {
+            if (typeof listener === 'function') {
+                compositionEndListeners.push(listener);
+            }
         },
         onClick: onClick,
         reconcileDom: reconcileDom,

--- a/media/webviewGroupFormScripts.js
+++ b/media/webviewGroupFormScripts.js
@@ -63,6 +63,7 @@ function initWorktreeGroupForm(options) {
                 confirmRequestId: '',
                 formError: '',
                 renderDeferred: false,
+                pendingClose: null,
                 pendingFocusGroupId: '',
                 pendingMemberRequests: {},
                 derive: null,
@@ -156,9 +157,16 @@ function initWorktreeGroupForm(options) {
         if (!state || !state.open) {
             return;
         }
+        if (composition.active && composition.projectId === projectId) {
+            // Tearing the form down now would detach the composing input
+            // and abort the IME session; close when the composition ends.
+            state.pendingClose = !!keepInput;
+            return;
+        }
         state.open = false;
         state.bootstrapping = false;
         state.confirming = false;
+        state.pendingClose = null;
         state.previewDirty = false;
         if (state.previewTimer) {
             clearTimeout(state.previewTimer);
@@ -281,7 +289,7 @@ function initWorktreeGroupForm(options) {
 
     function sendPreviewRequest(projectId) {
         var state = getState(projectId);
-        if (!state || !state.open) {
+        if (!state || !state.open || composition.active) {
             return;
         }
         var requestId = nextRequestId('group-preview');
@@ -1076,7 +1084,7 @@ function initWorktreeGroupForm(options) {
         // Keystrokes owned by an in-progress IME composition (candidate
         // navigation, Enter committing the candidate, Esc cancelling the
         // preedit) must not drive form actions.
-        if (event.isComposing) {
+        if (event.isComposing || composition.active) {
             return false;
         }
         var projectId = form.getAttribute('data-project-id');
@@ -1150,10 +1158,26 @@ function initWorktreeGroupForm(options) {
 
     document.addEventListener('compositionstart', function (event) {
         var projectId = compositionFormProjectId(event.target);
-        if (projectId) {
-            composition.active = true;
-            composition.projectId = projectId;
+        if (!projectId) {
+            return;
         }
+        composition.active = true;
+        composition.projectId = projectId;
+        var state = getState(projectId);
+        if (!state || !state.open) {
+            return;
+        }
+        // A preview debounced before the composition began must not send
+        // preedit text, and its in-flight response must not be accepted.
+        // previewDirty keeps confirm blocked until the committed text has
+        // been previewed.
+        if (state.previewTimer) {
+            clearTimeout(state.previewTimer);
+            state.previewTimer = 0;
+        }
+        state.previewRequestId = '';
+        state.previewDirty = true;
+        syncActionsDom(projectId);
     });
 
     document.addEventListener('compositionend', function (event) {
@@ -1166,16 +1190,36 @@ function initWorktreeGroupForm(options) {
         composition.projectId = '';
         var state = getState(projectId);
         if (state && state.open) {
-            if (event.target && event.target.hasAttribute
+            var isFilter = !!(event.target && event.target.hasAttribute
+                && event.target.hasAttribute('data-group-form-base-filter'));
+            if (isFilter) {
+                if (state.baseDropdown) {
+                    state.baseDropdown.filter = event.target.value;
+                }
+            } else if (event.target && event.target.hasAttribute
                 && event.target.hasAttribute('data-group-form-name')) {
                 state.name = event.target.value;
             }
-            if (state.renderDeferred) {
-                state.renderDeferred = false;
-                renderForm(projectId);
+            if (state.pendingClose !== null) {
+                // A close deferred while composing (e.g. the created
+                // settlement) lands now that no input can be aborted.
+                var keepInput = state.pendingClose;
+                state.pendingClose = null;
+                closeForm(projectId, keepInput);
+                reconcileDom();
+            } else {
+                if (state.renderDeferred) {
+                    state.renderDeferred = false;
+                    renderForm(projectId);
+                }
+                if (!isFilter || state.previewDirty) {
+                    // The preedit is now committed text: preview the real
+                    // name. Filtering branches needs no new preview, but a
+                    // preview dirtied mid-composition must be refreshed or
+                    // confirm stays blocked.
+                    schedulePreview(projectId);
+                }
             }
-            // The preedit is now committed text: preview the real name.
-            schedulePreview(projectId);
         }
         // Release the authoritative host updates queued while composing;
         // their replacements can no longer abort a composition.

--- a/media/webviewProjectScripts.js
+++ b/media/webviewProjectScripts.js
@@ -360,9 +360,20 @@ function initProjects() {
     var deferredCompositionHostUpdates = [];
 
     function queueDeferredCompositionHostUpdate(message) {
+        // Keep only the newest envelope per message type; the host does not
+        // resend dropped updates (delivery, not the rendered ack, completes
+        // its send), so discarding anything but a superseded same-type
+        // message would leave the surface permanently stale.
         for (var index = 0; index < deferredCompositionHostUpdates.length; index++) {
             if (deferredCompositionHostUpdates[index].type === message.type) {
-                deferredCompositionHostUpdates[index] = message;
+                var queued = deferredCompositionHostUpdates[index];
+                var queuedRevision = typeof queued.projectionRevision === 'number'
+                    ? queued.projectionRevision : 0;
+                var messageRevision = typeof message.projectionRevision === 'number'
+                    ? message.projectionRevision : 0;
+                if (messageRevision >= queuedRevision) {
+                    deferredCompositionHostUpdates[index] = message;
+                }
                 return;
             }
         }
@@ -375,8 +386,27 @@ function initProjects() {
         }
         var pending = deferredCompositionHostUpdates;
         deferredCompositionHostUpdates = [];
+        // Replay oldest-first: ai-sessions-updated replaces only the current
+        // surface while open-workspaces-updated replaces the whole wrapper,
+        // so a newer current-surface update must land after an older
+        // whole-wrapper one.
+        pending.sort(function (a, b) {
+            var aRevision = typeof a.projectionRevision === 'number'
+                ? a.projectionRevision : 0;
+            var bRevision = typeof b.projectionRevision === 'number'
+                ? b.projectionRevision : 0;
+            return aRevision - bRevision;
+        });
         for (var index = 0; index < pending.length; index++) {
-            onWindowMessage({ data: pending[index] });
+            try {
+                onWindowMessage({ data: pending[index] });
+            } catch (error) {
+                // One poisoned envelope must not drop the rest of the queue.
+                // (console is absent in the dashboard VM checks.)
+                if (typeof console !== 'undefined' && console.error) {
+                    console.error('Failed to replay a deferred host update.', error);
+                }
+            }
         }
     });
 

--- a/media/webviewProjectScripts.js
+++ b/media/webviewProjectScripts.js
@@ -353,6 +353,33 @@ function initProjects() {
     // window.__agentPivotWorktreeGroupRename).
     window.__agentPivotWorktreeGroupForm = worktreeGroupForm;
 
+    // Authoritative replacements detach the creation form's name input; an
+    // in-progress IME composition in that input would be aborted. While
+    // composing, queue the latest update per message type and replay them
+    // when the composition ends.
+    var deferredCompositionHostUpdates = [];
+
+    function queueDeferredCompositionHostUpdate(message) {
+        for (var index = 0; index < deferredCompositionHostUpdates.length; index++) {
+            if (deferredCompositionHostUpdates[index].type === message.type) {
+                deferredCompositionHostUpdates[index] = message;
+                return;
+            }
+        }
+        deferredCompositionHostUpdates.push(message);
+    }
+
+    worktreeGroupForm.onCompositionEnd(function () {
+        if (!deferredCompositionHostUpdates.length) {
+            return;
+        }
+        var pending = deferredCompositionHostUpdates;
+        deferredCompositionHostUpdates = [];
+        for (var index = 0; index < pending.length; index++) {
+            onWindowMessage({ data: pending[index] });
+        }
+    });
+
     function applyValidatedAiSessionPresentationState(message) {
         if (!aiSessionPresentationStateStore.adopt(message)) return;
         aiSessionPresentationDom.apply(message);
@@ -581,6 +608,12 @@ function initProjects() {
 
     function onWindowMessage(e) {
         var message = e && e.data;
+        if (message && (message.type === 'open-workspaces-updated'
+            || message.type === 'ai-sessions-updated')
+            && worktreeGroupForm.isComposing()) {
+            queueDeferredCompositionHostUpdate(message);
+            return;
+        }
         if (message && message.type === 'open-tab-layout-notice-dismissed') {
             var isNoticeSettlement = message.version === 1
                 && (message.outcome === 'dismissed' || message.outcome === 'failed')

--- a/src/webview/webviewGroupFormScripts.js
+++ b/src/webview/webviewGroupFormScripts.js
@@ -21,6 +21,15 @@ function initWorktreeGroupForm(options) {
     // slot; renderForm prefers it over the live DOM read (which can only see
     // document.body once the old slot is gone).
     var replacementFocusByProject = new Map();
+    // IME composition (CJK input): while a composition is active the preedit
+    // string lives inside the focused input, so ANY form rebuild — a preview
+    // response re-render or an authoritative surface replacement — detaches
+    // that input and aborts the composition (the candidate window dies and
+    // focus restore cannot resurrect it). Renders defer to compositionend,
+    // and the message dispatcher queues authoritative updates via
+    // onCompositionEnd.
+    var composition = { active: false, projectId: '' };
+    var compositionEndListeners = [];
 
     function nextRequestId(prefix) {
         nextRequestSerial = nextRequestSerial >= Number.MAX_SAFE_INTEGER
@@ -53,6 +62,7 @@ function initWorktreeGroupForm(options) {
                 confirming: false,
                 confirmRequestId: '',
                 formError: '',
+                renderDeferred: false,
                 pendingFocusGroupId: '',
                 pendingMemberRequests: {},
                 derive: null,
@@ -347,6 +357,7 @@ function initWorktreeGroupForm(options) {
     function confirmForm(projectId, availableOnly) {
         var state = getState(projectId);
         if (!state || !state.open || state.confirming || state.previewDirty
+            || composition.active
             || !state.preview || state.preview.formError || !state.previewId) {
             return;
         }
@@ -774,6 +785,16 @@ function initWorktreeGroupForm(options) {
         if (!slot) {
             return;
         }
+        // Never rebuild mid-composition: detaching the input that owns the
+        // IME preedit aborts the composition. The deferred render flushes
+        // on compositionend.
+        if (state && state.open && composition.projectId === projectId) {
+            state.renderDeferred = true;
+            return;
+        }
+        if (state) {
+            state.renderDeferred = false;
+        }
         if (!state || !state.open) {
             replacementFocusByProject.delete(projectId);
             slot.hidden = true;
@@ -992,6 +1013,13 @@ function initWorktreeGroupForm(options) {
             return true;
         }
         state.name = nameInput.value;
+        if (composition.active) {
+            // The preedit text is not a committed name yet: previewing it
+            // would race the compositionend commit, and the preview
+            // response's re-render would abort the composition. The
+            // compositionend handler syncs the actions row.
+            return true;
+        }
         schedulePreview(projectId);
         return true;
     }
@@ -1043,6 +1071,12 @@ function initWorktreeGroupForm(options) {
         var form = event.target && event.target.closest
             ? event.target.closest('[data-worktree-group-form]') : null;
         if (!form) {
+            return false;
+        }
+        // Keystrokes owned by an in-progress IME composition (candidate
+        // navigation, Enter committing the candidate, Esc cancelling the
+        // preedit) must not drive form actions.
+        if (event.isComposing) {
             return false;
         }
         var projectId = form.getAttribute('data-project-id');
@@ -1104,12 +1138,66 @@ function initWorktreeGroupForm(options) {
         onKeydown(event);
     });
 
+    function compositionFormProjectId(target) {
+        if (!target || !target.closest
+            || !(target.hasAttribute('data-group-form-name')
+                || target.hasAttribute('data-group-form-base-filter'))) {
+            return '';
+        }
+        var form = target.closest('[data-worktree-group-form]');
+        return form ? form.getAttribute('data-project-id') || '' : '';
+    }
+
+    document.addEventListener('compositionstart', function (event) {
+        var projectId = compositionFormProjectId(event.target);
+        if (projectId) {
+            composition.active = true;
+            composition.projectId = projectId;
+        }
+    });
+
+    document.addEventListener('compositionend', function (event) {
+        var projectId = compositionFormProjectId(event.target)
+            || composition.projectId;
+        if (!projectId || !composition.active) {
+            return;
+        }
+        composition.active = false;
+        composition.projectId = '';
+        var state = getState(projectId);
+        if (state && state.open) {
+            if (event.target && event.target.hasAttribute
+                && event.target.hasAttribute('data-group-form-name')) {
+                state.name = event.target.value;
+            }
+            if (state.renderDeferred) {
+                state.renderDeferred = false;
+                renderForm(projectId);
+            }
+            // The preedit is now committed text: preview the real name.
+            schedulePreview(projectId);
+        }
+        // Release the authoritative host updates queued while composing;
+        // their replacements can no longer abort a composition.
+        compositionEndListeners.slice().forEach(function (listener) {
+            listener();
+        });
+    });
+
     return {
         openForm: openForm,
         closeForm: closeForm,
         isOpen: function (projectId) {
             var state = getState(projectId);
             return !!state && state.open;
+        },
+        isComposing: function () {
+            return composition.active;
+        },
+        onCompositionEnd: function (listener) {
+            if (typeof listener === 'function') {
+                compositionEndListeners.push(listener);
+            }
         },
         onClick: onClick,
         reconcileDom: reconcileDom,

--- a/src/webview/webviewGroupFormScripts.js
+++ b/src/webview/webviewGroupFormScripts.js
@@ -63,6 +63,7 @@ function initWorktreeGroupForm(options) {
                 confirmRequestId: '',
                 formError: '',
                 renderDeferred: false,
+                pendingClose: null,
                 pendingFocusGroupId: '',
                 pendingMemberRequests: {},
                 derive: null,
@@ -156,9 +157,16 @@ function initWorktreeGroupForm(options) {
         if (!state || !state.open) {
             return;
         }
+        if (composition.active && composition.projectId === projectId) {
+            // Tearing the form down now would detach the composing input
+            // and abort the IME session; close when the composition ends.
+            state.pendingClose = !!keepInput;
+            return;
+        }
         state.open = false;
         state.bootstrapping = false;
         state.confirming = false;
+        state.pendingClose = null;
         state.previewDirty = false;
         if (state.previewTimer) {
             clearTimeout(state.previewTimer);
@@ -281,7 +289,7 @@ function initWorktreeGroupForm(options) {
 
     function sendPreviewRequest(projectId) {
         var state = getState(projectId);
-        if (!state || !state.open) {
+        if (!state || !state.open || composition.active) {
             return;
         }
         var requestId = nextRequestId('group-preview');
@@ -1076,7 +1084,7 @@ function initWorktreeGroupForm(options) {
         // Keystrokes owned by an in-progress IME composition (candidate
         // navigation, Enter committing the candidate, Esc cancelling the
         // preedit) must not drive form actions.
-        if (event.isComposing) {
+        if (event.isComposing || composition.active) {
             return false;
         }
         var projectId = form.getAttribute('data-project-id');
@@ -1150,10 +1158,26 @@ function initWorktreeGroupForm(options) {
 
     document.addEventListener('compositionstart', function (event) {
         var projectId = compositionFormProjectId(event.target);
-        if (projectId) {
-            composition.active = true;
-            composition.projectId = projectId;
+        if (!projectId) {
+            return;
         }
+        composition.active = true;
+        composition.projectId = projectId;
+        var state = getState(projectId);
+        if (!state || !state.open) {
+            return;
+        }
+        // A preview debounced before the composition began must not send
+        // preedit text, and its in-flight response must not be accepted.
+        // previewDirty keeps confirm blocked until the committed text has
+        // been previewed.
+        if (state.previewTimer) {
+            clearTimeout(state.previewTimer);
+            state.previewTimer = 0;
+        }
+        state.previewRequestId = '';
+        state.previewDirty = true;
+        syncActionsDom(projectId);
     });
 
     document.addEventListener('compositionend', function (event) {
@@ -1166,16 +1190,36 @@ function initWorktreeGroupForm(options) {
         composition.projectId = '';
         var state = getState(projectId);
         if (state && state.open) {
-            if (event.target && event.target.hasAttribute
+            var isFilter = !!(event.target && event.target.hasAttribute
+                && event.target.hasAttribute('data-group-form-base-filter'));
+            if (isFilter) {
+                if (state.baseDropdown) {
+                    state.baseDropdown.filter = event.target.value;
+                }
+            } else if (event.target && event.target.hasAttribute
                 && event.target.hasAttribute('data-group-form-name')) {
                 state.name = event.target.value;
             }
-            if (state.renderDeferred) {
-                state.renderDeferred = false;
-                renderForm(projectId);
+            if (state.pendingClose !== null) {
+                // A close deferred while composing (e.g. the created
+                // settlement) lands now that no input can be aborted.
+                var keepInput = state.pendingClose;
+                state.pendingClose = null;
+                closeForm(projectId, keepInput);
+                reconcileDom();
+            } else {
+                if (state.renderDeferred) {
+                    state.renderDeferred = false;
+                    renderForm(projectId);
+                }
+                if (!isFilter || state.previewDirty) {
+                    // The preedit is now committed text: preview the real
+                    // name. Filtering branches needs no new preview, but a
+                    // preview dirtied mid-composition must be refreshed or
+                    // confirm stays blocked.
+                    schedulePreview(projectId);
+                }
             }
-            // The preedit is now committed text: preview the real name.
-            schedulePreview(projectId);
         }
         // Release the authoritative host updates queued while composing;
         // their replacements can no longer abort a composition.

--- a/src/webview/webviewProjectScripts.js
+++ b/src/webview/webviewProjectScripts.js
@@ -360,9 +360,20 @@ function initProjects() {
     var deferredCompositionHostUpdates = [];
 
     function queueDeferredCompositionHostUpdate(message) {
+        // Keep only the newest envelope per message type; the host does not
+        // resend dropped updates (delivery, not the rendered ack, completes
+        // its send), so discarding anything but a superseded same-type
+        // message would leave the surface permanently stale.
         for (var index = 0; index < deferredCompositionHostUpdates.length; index++) {
             if (deferredCompositionHostUpdates[index].type === message.type) {
-                deferredCompositionHostUpdates[index] = message;
+                var queued = deferredCompositionHostUpdates[index];
+                var queuedRevision = typeof queued.projectionRevision === 'number'
+                    ? queued.projectionRevision : 0;
+                var messageRevision = typeof message.projectionRevision === 'number'
+                    ? message.projectionRevision : 0;
+                if (messageRevision >= queuedRevision) {
+                    deferredCompositionHostUpdates[index] = message;
+                }
                 return;
             }
         }
@@ -375,8 +386,27 @@ function initProjects() {
         }
         var pending = deferredCompositionHostUpdates;
         deferredCompositionHostUpdates = [];
+        // Replay oldest-first: ai-sessions-updated replaces only the current
+        // surface while open-workspaces-updated replaces the whole wrapper,
+        // so a newer current-surface update must land after an older
+        // whole-wrapper one.
+        pending.sort(function (a, b) {
+            var aRevision = typeof a.projectionRevision === 'number'
+                ? a.projectionRevision : 0;
+            var bRevision = typeof b.projectionRevision === 'number'
+                ? b.projectionRevision : 0;
+            return aRevision - bRevision;
+        });
         for (var index = 0; index < pending.length; index++) {
-            onWindowMessage({ data: pending[index] });
+            try {
+                onWindowMessage({ data: pending[index] });
+            } catch (error) {
+                // One poisoned envelope must not drop the rest of the queue.
+                // (console is absent in the dashboard VM checks.)
+                if (typeof console !== 'undefined' && console.error) {
+                    console.error('Failed to replay a deferred host update.', error);
+                }
+            }
         }
     });
 

--- a/src/webview/webviewProjectScripts.js
+++ b/src/webview/webviewProjectScripts.js
@@ -353,6 +353,33 @@ function initProjects() {
     // window.__agentPivotWorktreeGroupRename).
     window.__agentPivotWorktreeGroupForm = worktreeGroupForm;
 
+    // Authoritative replacements detach the creation form's name input; an
+    // in-progress IME composition in that input would be aborted. While
+    // composing, queue the latest update per message type and replay them
+    // when the composition ends.
+    var deferredCompositionHostUpdates = [];
+
+    function queueDeferredCompositionHostUpdate(message) {
+        for (var index = 0; index < deferredCompositionHostUpdates.length; index++) {
+            if (deferredCompositionHostUpdates[index].type === message.type) {
+                deferredCompositionHostUpdates[index] = message;
+                return;
+            }
+        }
+        deferredCompositionHostUpdates.push(message);
+    }
+
+    worktreeGroupForm.onCompositionEnd(function () {
+        if (!deferredCompositionHostUpdates.length) {
+            return;
+        }
+        var pending = deferredCompositionHostUpdates;
+        deferredCompositionHostUpdates = [];
+        for (var index = 0; index < pending.length; index++) {
+            onWindowMessage({ data: pending[index] });
+        }
+    });
+
     function applyValidatedAiSessionPresentationState(message) {
         if (!aiSessionPresentationStateStore.adopt(message)) return;
         aiSessionPresentationDom.apply(message);
@@ -581,6 +608,12 @@ function initProjects() {
 
     function onWindowMessage(e) {
         var message = e && e.data;
+        if (message && (message.type === 'open-workspaces-updated'
+            || message.type === 'ai-sessions-updated')
+            && worktreeGroupForm.isComposing()) {
+            queueDeferredCompositionHostUpdate(message);
+            return;
+        }
         if (message && message.type === 'open-tab-layout-notice-dismissed') {
             var isNoticeSettlement = message.version === 1
                 && (message.outcome === 'dismissed' || message.outcome === 'failed')

--- a/tests/browser/worktreeGroupForm.test.js
+++ b/tests/browser/worktreeGroupForm.test.js
@@ -782,7 +782,7 @@ test('WORKTREE-GROUPS-CREATE-UI-001 IME composition defers previews and re-rende
     const input = page.locator('[data-group-form-name]');
     await input.evaluate(element => element.focus());
     await page.keyboard.type('Fix');
-    await page.waitForTimeout(350);
+    await page.waitForTimeout(500);
     const previewRequest = (await postedMessages(page))
         .filter(message => message.type === 'preview-worktree-group').at(-1);
     assert.ok(previewRequest, 'a preview request was sent for the committed text');
@@ -797,13 +797,15 @@ test('WORKTREE-GROUPS-CREATE-UI-001 IME composition defers previews and re-rende
             inputType: 'insertCompositionText', data: 'ni',
         }));
     });
-    await page.waitForTimeout(400);
+    await page.waitForTimeout(600);
     assert.equal((await postedMessages(page))
         .some(message => message.type === 'preview-worktree-group'
             && message.displayName === 'Fix ni'), false,
         'preedit text is never sent for preview');
 
-    // A preview response arriving mid-composition must not rebuild the form.
+    // A preview response arriving mid-composition must not rebuild the form
+    // (the composition start already invalidated the in-flight request, so
+    // the response is stale — it must be discarded, not rendered).
     await page.evaluate(() => {
         window.__composingNameInput = document.querySelector('[data-group-form-name]');
     });
@@ -818,7 +820,7 @@ test('WORKTREE-GROUPS-CREATE-UI-001 IME composition defers previews and re-rende
     });
     assert.equal(await page.evaluate(() =>
         document.querySelector('[data-group-form-name]') === window.__composingNameInput), true,
-        'a preview response mid-composition does not detach the composing input');
+        'a stale preview response mid-composition does not detach the composing input');
     assert.equal(await input.inputValue(), 'Fix ni',
         'the preedit text survives the deferred re-render');
 
@@ -831,15 +833,215 @@ test('WORKTREE-GROUPS-CREATE-UI-001 IME composition defers previews and re-rende
             bubbles: true, isComposing: false, inputType: 'insertText', data: '你',
         }));
     });
-    assert.match(await page.locator('.ai-session-group-form-plan').textContent(),
-        /\/alpha\/\.worktrees\/fix-login/,
-        'the deferred render flushed on compositionend');
-    await page.waitForTimeout(350);
+    await page.waitForTimeout(500);
     const committedPreview = (await postedMessages(page))
         .filter(message => message.type === 'preview-worktree-group').at(-1);
     assert.equal(committedPreview.displayName, 'Fix 你',
         'the committed composition text is previewed');
+    await postHostMessage(page, {
+        type: 'worktree-group-preview',
+        version: 1,
+        requestId: committedPreview.requestId,
+        projectId: 'project-a',
+        previewId: 'preview-host-2',
+        slug: 'fix',
+        members: okMembers(),
+    });
+    assert.match(await page.locator('.ai-session-group-form-plan').textContent(),
+        /\/alpha\/\.worktrees\/fix-login/,
+        'the post-composition preview renders normally');
     assert.equal(await page.locator('[data-group-form-name]').inputValue(), 'Fix 你');
+});
+
+test('WORKTREE-GROUPS-CREATE-UI-001 starting a composition cancels the pending debounced preview', async t => {
+    // Regression: a preview debounced before compositionstart still fired
+    // mid-composition, sending the preedit text, and its late response could
+    // be accepted after compositionend.
+    const page = await openFormPage(t);
+    await openBootstrappedForm(page);
+
+    const input = page.locator('[data-group-form-name]');
+    await input.evaluate(element => element.focus());
+    // The 300ms preview debounce is pending when the composition starts.
+    await page.keyboard.type('Fix');
+    await input.evaluate(element => {
+        element.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true, data: '' }));
+        element.value = 'Fix ni';
+        element.dispatchEvent(new InputEvent('input', {
+            bubbles: true, isComposing: true,
+            inputType: 'insertCompositionText', data: 'ni',
+        }));
+    });
+    await page.waitForTimeout(600);
+    assert.equal((await postedMessages(page))
+        .some(message => message.type === 'preview-worktree-group'
+            && typeof message.displayName === 'string'
+            && message.displayName.indexOf('Fix') === 0), false,
+        'neither the pending debounce nor the preedit text is previewed');
+
+    await input.evaluate(element => {
+        element.value = 'Fix 你';
+        element.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true, data: '你' }));
+    });
+    await page.waitForFunction(() =>
+        window.__postedMessages.some(message =>
+            message.type === 'preview-worktree-group'
+            && message.displayName === 'Fix 你'),
+        'the committed text is previewed after compositionend');
+});
+
+test('WORKTREE-GROUPS-CREATE-UI-001 a created settlement during composition closes the form on compositionend', async t => {
+    // Regression: confirm → user keeps typing while the request is in
+    // flight → the created settlement closed the form mid-composition and
+    // detached the composing input.
+    const page = await openFormPage(t);
+    await openBootstrappedForm(page);
+
+    const input = page.locator('[data-group-form-name]');
+    await input.evaluate(element => element.focus());
+    await page.keyboard.type('Fix login');
+    await page.waitForTimeout(500);
+    await answerPreview(page, okMembers());
+    await page.locator('[data-group-form-action="confirm"]')
+        .evaluate(button => button.click());
+    const confirmRequest = (await postedMessages(page))
+        .find(message => message.type === 'confirm-worktree-group');
+    assert.ok(confirmRequest);
+
+    // The user starts composing again while the confirm is in flight.
+    await input.evaluate(element => {
+        element.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true, data: '' }));
+        element.value = 'Fix login zai';
+        element.dispatchEvent(new InputEvent('input', {
+            bubbles: true, isComposing: true,
+            inputType: 'insertCompositionText', data: 'zai',
+        }));
+    });
+    await page.evaluate(() => {
+        window.__composingNameInput = document.querySelector('[data-group-form-name]');
+    });
+    await postHostMessage(page, {
+        type: 'worktree-group-creation-settlement',
+        version: 1,
+        requestId: confirmRequest.requestId,
+        status: 'created',
+        groupId: 'g-new',
+    });
+    assert.equal(await page.locator('[data-worktree-group-form]').count(), 1,
+        'the created settlement defers the close while composing');
+    assert.equal(await page.evaluate(() =>
+        document.querySelector('[data-group-form-name]') === window.__composingNameInput), true,
+        'the composing input is not detached by the settlement');
+
+    await input.evaluate(element => {
+        element.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true, data: '' }));
+    });
+    assert.equal(await page.locator('[data-worktree-group-form]').count(), 0,
+        'the deferred close lands on compositionend');
+});
+
+test('WORKTREE-GROUPS-CREATE-UI-001 composition keydowns do not confirm or close the form', async t => {
+    // Enter committing an IME candidate must not confirm the form; Esc
+    // cancelling the preedit must not close it.
+    const page = await openFormPage(t);
+    await openBootstrappedForm(page);
+
+    const input = page.locator('[data-group-form-name]');
+    await input.evaluate(element => element.focus());
+    await page.keyboard.type('Fix login');
+    await page.waitForTimeout(500);
+    await answerPreview(page, okMembers());
+
+    await input.evaluate(element => {
+        element.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true, data: '' }));
+        element.value = 'Fix login ni';
+        element.dispatchEvent(new InputEvent('input', {
+            bubbles: true, isComposing: true,
+            inputType: 'insertCompositionText', data: 'ni',
+        }));
+        element.dispatchEvent(new KeyboardEvent('keydown', {
+            bubbles: true, key: 'Enter', isComposing: true,
+        }));
+        element.dispatchEvent(new KeyboardEvent('keydown', {
+            bubbles: true, key: 'Escape', isComposing: true,
+        }));
+    });
+    assert.equal((await postedMessages(page))
+        .some(message => message.type === 'confirm-worktree-group'), false,
+        'Enter during composition does not confirm');
+    assert.equal(await page.locator('[data-worktree-group-form]').count(), 1,
+        'Escape during composition does not close the form');
+    assert.equal(await page.evaluate(() =>
+        document.activeElement
+        && document.activeElement.hasAttribute('data-group-form-name')), true,
+        'the composing input keeps focus');
+});
+
+test('WORKTREE-GROUPS-CREATE-UI-001 the base branch filter supports IME composition', async t => {
+    const page = await openFormPage(t);
+    await openBootstrappedForm(page);
+
+    await page.locator('[data-group-form-base="/alpha/.git"]')
+        .evaluate(button => button.click());
+    const filter = page.locator('[data-group-form-base-filter="/alpha/.git"]');
+    await filter.evaluate(element => element.focus());
+    await page.waitForFunction(() =>
+        window.__postedMessages.some(message =>
+            message.type === 'preview-worktree-group'),
+        'the bootstrap preview request was sent');
+    const previewCount = () => postedMessages(page)
+        .then(messages => messages
+            .filter(message => message.type === 'preview-worktree-group').length);
+    const previewsBefore = await previewCount();
+
+    await filter.evaluate(element => {
+        element.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true, data: '' }));
+        element.value = 'mai';
+        element.dispatchEvent(new InputEvent('input', {
+            bubbles: true, isComposing: true,
+            inputType: 'insertCompositionText', data: 'mai',
+        }));
+    });
+    // Candidate-navigation keys belong to the IME: the dropdown keyboard
+    // handler must stand down (no preventDefault, no activeIndex move).
+    const arrowDefaultPrevented = await filter.evaluate(element => {
+        const event = new KeyboardEvent('keydown', {
+            bubbles: true, cancelable: true, key: 'ArrowDown', isComposing: true,
+        });
+        element.dispatchEvent(event);
+        return event.defaultPrevented;
+    });
+    assert.equal(arrowDefaultPrevented, false,
+        'ArrowDown during composition is left to the IME');
+    await page.evaluate(() => {
+        window.__composingFilter = document.querySelector('[data-group-form-base-filter]');
+    });
+    // A re-render trigger arriving mid-composition (here: a refreshed form
+    // state) must not detach the composing filter.
+    await postHostMessage(page, {
+        type: 'worktree-group-form-state',
+        version: 1,
+        projectId: 'project-a',
+        repositories: repositoryOptions(),
+    });
+    assert.equal(await page.evaluate(() =>
+        document.querySelector('[data-group-form-base-filter]') === window.__composingFilter), true,
+        'the composing filter input survives a mid-composition re-render trigger');
+    await page.waitForTimeout(500);
+    assert.equal(await previewCount(), previewsBefore,
+        'no preview is sent while the composition is active');
+
+    await filter.evaluate(element => {
+        element.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true, data: 'mai' }));
+    });
+    await page.waitForFunction(() => {
+        const options = Array.from(
+            document.querySelectorAll('[data-group-form-base-option]'));
+        return options.length === 1 && options[0].textContent === 'main';
+    }, 'the committed filter text narrows the branch list');
+    assert.deepEqual(await page.locator('[data-group-form-base-option]').allTextContents(),
+        ['main'],
+        'the committed filter text narrows the branch list');
 });
 
 test('WORKTREE-GROUPS-CREATE-UI-001 authoritative replacements wait for the IME composition to end', async t => {
@@ -864,6 +1066,12 @@ test('WORKTREE-GROUPS-CREATE-UI-001 authoritative replacements wait for the IME 
         window.__composingNameInput = document.querySelector('[data-group-form-name]');
     });
 
+    const markedGroupHtml = rev => currentGroupHtml()
+        .replace('data-open-session-surface', `data-open-session-surface data-rev="${rev}"`);
+    // Interleave the channels so the whole-wrapper update is NOT the newest:
+    // the queue must keep the newest envelope per type and replay
+    // oldest-first, or the older whole-wrapper replacement would overwrite
+    // the newer current-surface update (and the host never resends).
     await postHostMessage(page, {
         type: 'ai-sessions-updated',
         version: 3,
@@ -871,7 +1079,7 @@ test('WORKTREE-GROUPS-CREATE-UI-001 authoritative replacements wait for the IME 
         projectionRevision: 1,
         generatedAt: '2026-08-17T00:00:00.000Z',
         currentWorkspaceCount: 1,
-        html: currentGroupHtml(),
+        html: markedGroupHtml(1),
         searchCatalog: {
             version: 3, sessions: [], worktrees: [], openWorkspaces: [],
             savedProjects: [], todos: [],
@@ -885,14 +1093,14 @@ test('WORKTREE-GROUPS-CREATE-UI-001 authoritative replacements wait for the IME 
     await postHostMessage(page, {
         type: 'open-workspaces-updated',
         version: 4,
-        semanticRevision: 'form-composition-1',
+        semanticRevision: 'form-composition-2',
         projectionRevision: 2,
         windowRowCount: 1,
         currentWindowRowCount: 1,
         navigationWindowRowCount: 0,
         currentDetailCount: 1,
         otherWindowsStatus: 'ready',
-        html: openWindowSwitcherHtml() + currentGroupHtml(),
+        html: openWindowSwitcherHtml() + markedGroupHtml(2),
         searchCatalog: {
             version: 3, sessions: [], worktrees: [],
             openWorkspaces: [{ identity: 'project-a' }], savedProjects: [], todos: [],
@@ -902,8 +1110,23 @@ test('WORKTREE-GROUPS-CREATE-UI-001 authoritative replacements wait for the IME 
     assert.equal(await page.evaluate(() =>
         document.querySelector('[data-group-form-name]') === window.__composingNameInput), true,
         'the open-workspaces replacement is deferred while composing');
+
+    await postHostMessage(page, {
+        type: 'ai-sessions-updated',
+        version: 3,
+        sequence: 3,
+        projectionRevision: 3,
+        generatedAt: '2026-08-17T00:00:02.000Z',
+        currentWorkspaceCount: 1,
+        html: markedGroupHtml(3),
+        searchCatalog: {
+            version: 3, sessions: [], worktrees: [], openWorkspaces: [],
+            savedProjects: [], todos: [],
+        },
+        presentation: presentationMessage(3),
+    });
     assert.equal(await input.inputValue(), 'Fix ni',
-        'the preedit text survives both deferred replacements');
+        'the preedit text survives all deferred replacements');
 
     await input.evaluate(element => {
         element.value = 'Fix 你好';
@@ -922,6 +1145,12 @@ test('WORKTREE-GROUPS-CREATE-UI-001 authoritative replacements wait for the IME 
         document.activeElement
         && document.activeElement.hasAttribute('data-group-form-name')), true,
         'the name input is focused again after the replayed replacements');
+    assert.equal(await page.evaluate(() =>
+        document.querySelector('.open-window-switcher-group') !== null), true,
+        'the whole-wrapper update replayed (WINDOWS switcher appeared)');
+    assert.equal(await page.evaluate(() =>
+        document.querySelector('[data-open-session-surface]').getAttribute('data-rev')), '3',
+        'the newest current-surface update replays after the older whole-wrapper one');
 });
 
 test('WORKTREE-GROUPS-CREATE-UI-001 the form survives external DOM replacement and its slot scrolls', async t => {

--- a/tests/browser/worktreeGroupForm.test.js
+++ b/tests/browser/worktreeGroupForm.test.js
@@ -772,6 +772,158 @@ test('WORKTREE-GROUPS-CREATE-UI-001 typing keeps focus and caret through authori
         'the caret survives the open-workspaces replacement');
 });
 
+test('WORKTREE-GROUPS-CREATE-UI-001 IME composition defers previews and re-renders until compositionend', async t => {
+    // Regression: typing a CJK name kept an in-flight IME composition in the
+    // name input; every debounced preview response rebuilt the form and
+    // detached that input, aborting the composition (candidate window died).
+    const page = await openFormPage(t);
+    await openBootstrappedForm(page);
+
+    const input = page.locator('[data-group-form-name]');
+    await input.evaluate(element => element.focus());
+    await page.keyboard.type('Fix');
+    await page.waitForTimeout(350);
+    const previewRequest = (await postedMessages(page))
+        .filter(message => message.type === 'preview-worktree-group').at(-1);
+    assert.ok(previewRequest, 'a preview request was sent for the committed text');
+
+    // Start an IME composition: the preedit lives in the input but is not
+    // committed yet.
+    await input.evaluate(element => {
+        element.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true, data: '' }));
+        element.value = 'Fix ni';
+        element.dispatchEvent(new InputEvent('input', {
+            bubbles: true, isComposing: true,
+            inputType: 'insertCompositionText', data: 'ni',
+        }));
+    });
+    await page.waitForTimeout(400);
+    assert.equal((await postedMessages(page))
+        .some(message => message.type === 'preview-worktree-group'
+            && message.displayName === 'Fix ni'), false,
+        'preedit text is never sent for preview');
+
+    // A preview response arriving mid-composition must not rebuild the form.
+    await page.evaluate(() => {
+        window.__composingNameInput = document.querySelector('[data-group-form-name]');
+    });
+    await postHostMessage(page, {
+        type: 'worktree-group-preview',
+        version: 1,
+        requestId: previewRequest.requestId,
+        projectId: 'project-a',
+        previewId: 'preview-host-1',
+        slug: 'fix',
+        members: okMembers(),
+    });
+    assert.equal(await page.evaluate(() =>
+        document.querySelector('[data-group-form-name]') === window.__composingNameInput), true,
+        'a preview response mid-composition does not detach the composing input');
+    assert.equal(await input.inputValue(), 'Fix ni',
+        'the preedit text survives the deferred re-render');
+
+    // Commit the composition (value updates before compositionend, as in
+    // Chromium) and finish with the real trailing input event.
+    await input.evaluate(element => {
+        element.value = 'Fix 你';
+        element.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true, data: '你' }));
+        element.dispatchEvent(new InputEvent('input', {
+            bubbles: true, isComposing: false, inputType: 'insertText', data: '你',
+        }));
+    });
+    assert.match(await page.locator('.ai-session-group-form-plan').textContent(),
+        /\/alpha\/\.worktrees\/fix-login/,
+        'the deferred render flushed on compositionend');
+    await page.waitForTimeout(350);
+    const committedPreview = (await postedMessages(page))
+        .filter(message => message.type === 'preview-worktree-group').at(-1);
+    assert.equal(committedPreview.displayName, 'Fix 你',
+        'the committed composition text is previewed');
+    assert.equal(await page.locator('[data-group-form-name]').inputValue(), 'Fix 你');
+});
+
+test('WORKTREE-GROUPS-CREATE-UI-001 authoritative replacements wait for the IME composition to end', async t => {
+    // Regression: ai-sessions-updated / open-workspaces-updated replace the
+    // subtree hosting the form slot; applying them mid-composition detached
+    // the composing input and aborted the IME session.
+    const page = await openFormPage(t);
+    await openBootstrappedForm(page);
+
+    const input = page.locator('[data-group-form-name]');
+    await input.evaluate(element => element.focus());
+    await page.keyboard.type('Fix');
+    await input.evaluate(element => {
+        element.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true, data: '' }));
+        element.value = 'Fix ni';
+        element.dispatchEvent(new InputEvent('input', {
+            bubbles: true, isComposing: true,
+            inputType: 'insertCompositionText', data: 'ni',
+        }));
+    });
+    await page.evaluate(() => {
+        window.__composingNameInput = document.querySelector('[data-group-form-name]');
+    });
+
+    await postHostMessage(page, {
+        type: 'ai-sessions-updated',
+        version: 3,
+        sequence: 1,
+        projectionRevision: 1,
+        generatedAt: '2026-08-17T00:00:00.000Z',
+        currentWorkspaceCount: 1,
+        html: currentGroupHtml(),
+        searchCatalog: {
+            version: 3, sessions: [], worktrees: [], openWorkspaces: [],
+            savedProjects: [], todos: [],
+        },
+        presentation: presentationMessage(1),
+    });
+    assert.equal(await page.evaluate(() =>
+        document.querySelector('[data-group-form-name]') === window.__composingNameInput), true,
+        'the ai-sessions replacement is deferred while composing');
+
+    await postHostMessage(page, {
+        type: 'open-workspaces-updated',
+        version: 4,
+        semanticRevision: 'form-composition-1',
+        projectionRevision: 2,
+        windowRowCount: 1,
+        currentWindowRowCount: 1,
+        navigationWindowRowCount: 0,
+        currentDetailCount: 1,
+        otherWindowsStatus: 'ready',
+        html: openWindowSwitcherHtml() + currentGroupHtml(),
+        searchCatalog: {
+            version: 3, sessions: [], worktrees: [],
+            openWorkspaces: [{ identity: 'project-a' }], savedProjects: [], todos: [],
+        },
+        presentation: presentationMessage(2),
+    });
+    assert.equal(await page.evaluate(() =>
+        document.querySelector('[data-group-form-name]') === window.__composingNameInput), true,
+        'the open-workspaces replacement is deferred while composing');
+    assert.equal(await input.inputValue(), 'Fix ni',
+        'the preedit text survives both deferred replacements');
+
+    await input.evaluate(element => {
+        element.value = 'Fix 你好';
+        element.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true, data: '你好' }));
+        element.dispatchEvent(new InputEvent('input', {
+            bubbles: true, isComposing: false, inputType: 'insertText', data: '你好',
+        }));
+    });
+    await page.waitForFunction(() =>
+        document.querySelector('[data-group-form-name]')
+        && document.querySelector('[data-group-form-name]') !== window.__composingNameInput,
+        'the queued replacements replay once the composition ends');
+    assert.equal(await page.locator('[data-group-form-name]').inputValue(), 'Fix 你好',
+        'the replayed replacements keep the committed name');
+    assert.equal(await page.evaluate(() =>
+        document.activeElement
+        && document.activeElement.hasAttribute('data-group-form-name')), true,
+        'the name input is focused again after the replayed replacements');
+});
+
 test('WORKTREE-GROUPS-CREATE-UI-001 the form survives external DOM replacement and its slot scrolls', async t => {
     const page = await openFormPage(t);
     await openBootstrappedForm(page);


### PR DESCRIPTION
## Problem

Typing a CJK name in the new-worktree-group form was interrupted constantly: the panel kept refreshing under the cursor. Two paths detached the name input mid-composition, and an aborted IME composition cannot be restored by re-focusing:

1. **Preview round-trip** — every debounced keystroke (including IME preedit updates) sent `preview-worktree-group`; the response re-rendered the whole form via `innerHTML`, killing the in-flight composition whenever the user paused >300 ms to pick a candidate.
2. **Authoritative surface replacements** — the host's 1s lifecycle/attention ticks push `ai-sessions-updated` / `open-workspaces-updated`, which replace the subtree hosting the form slot; the reconcile re-render recreated the input with the composition already gone.

## Fix

- `webviewGroupFormScripts.js` tracks `compositionstart`/`compositionend` on the form's text inputs. While composing: `renderForm` defers (flushed on `compositionend`), `onInput` never previews preedit text, keydown actions (Enter/arrows/Esc) stand down, confirm refuses to start, and `closeForm` defers so a `created` settlement cannot detach the composing input. `compositionstart` cancels any pending preview debounce and invalidates the in-flight request, so preedit text is never previewed and late preedit responses are discarded as stale.
- `webviewProjectScripts.js` queues deferred `ai-sessions-updated` / `open-workspaces-updated` while a composition is active, keeping the greatest `projectionRevision` per type, and replays them oldest-first on `compositionend` (a newer current-surface update must land after an older whole-wrapper replacement, which the host never resends). Replay failures no longer drop the rest of the queue.

## Review

Three independent read-only review passes (IME/DOM event sequencing, host-update protocol safety, test quality) all returned request-changes; their Important findings (pending-debounce race, settlement close during composition, cross-channel replay ordering, base-filter composition) are fixed in the follow-up commit, each covered by a regression test verified to fail when its fix is reverted (mutation-checked).

## Verification

- `npm run test-compile`
- `node --test tests/browser/worktreeGroupForm.test.js` — 22/22, including six composition tests
- Related suites: worktreeGroups / quickSessionCreate / dashboardWindowSwitcher / sessionProviderMenu / activeSessionCardInteraction / webviewState / worktreeGroupFormHandlers — 234/234
- `node scripts/run-dashboard-webview-checks.js`, `npm run lint` (97 pre-existing warnings, unchanged), `npm run test:behavior-contracts`, `git diff --check`
- Mutation checks: reverting each fix individually fails its dedicated test

## Skill harvest

No skill change: the task ran clean — no user corrections, no failed checks, no rediscovered steps; existing skills (`protecting-main-with-worktrees`, `resilient-webview-mutation-protocols`, `review-fix-commit-loop`) already cover the followed workflow.

## Owner approvals

```
approve b4628bf53529c8fdc8699cffa078e3c734d03bc0
```