### PR TITLE
perf: make conversation switching feel immediate

### DIFF
--- a/media/conversationViewerScripts.js
+++ b/media/conversationViewerScripts.js
@@ -386,6 +386,12 @@
     var loadingTarget;
     var loadingGeneration = 0;
     var loadingStatusText;
+    var loadingPreflight = false;
+    // A speculative target can temporarily cover an already-authoritative
+    // load. Keep the underlying load presentation so cancelling the
+    // speculation resumes it instead of incorrectly making the old document
+    // interactive while its Host transition is still pending.
+    var preflightLoadingRestore;
     // Detached conversation frames keyed by session: switching back to a
     // session whose content token is unchanged reattaches the already-built
     // DOM — no HTML transfer, sanitize, parse, or reconcile at all. Bounded
@@ -1239,13 +1245,32 @@
                 && previewFrame.key === preflightKey;
             if (!preflightKey || (!alreadyPreviewed
                 && !frameCache.has(preflightKey))) {
-                // Do not make a cache miss look slower than it did before
-                // preflight existed. If this supersedes a prior hit, return
-                // that detached frame before keeping the outgoing document
-                // readable while the new Host read proceeds.
-                restoreCancelledPreflight();
+                // A cache miss cannot replace the document, but it must still
+                // make the click visible immediately. Keep the outgoing
+                // content in place under the same reversible loading state
+                // used for a committed target; cancellation restores it.
+                if (loadingPreflight) {
+                    restoreCancelledPreflight();
+                }
+            }
+            if (!loadingPreflight && conversationLoading) {
+                preflightLoadingRestore = {
+                    target: loadingTarget && Object.assign({}, loadingTarget),
+                    generation: loadingGeneration,
+                    statusText: loadingStatusText,
+                    framePreview: document.body.getAttribute(
+                        'data-conversation-frame-preview'
+                    ) === 'true',
+                };
+            }
+        } else if (loadingPreflight) {
+            if (message.subscriptionGeneration < loadingGeneration) {
+                // A still-running older Host load must not displace a newer
+                // optimistic target before its terminal focus resolves.
                 return true;
             }
+            returnPreviewFrameToCache();
+            preflightLoadingRestore = undefined;
         }
         if (!conversationLoading) {
             loadingStatusText = status.textContent;
@@ -1257,6 +1282,7 @@
             sessionId: message.target.sessionId,
         };
         loadingGeneration = message.subscriptionGeneration;
+        loadingPreflight = message.preflight === true;
         document.body.setAttribute('data-conversation-loading', 'true');
         document.body.setAttribute('aria-busy', 'true');
         document.body.setAttribute('aria-disabled', 'true');
@@ -1315,6 +1341,26 @@
         }
         var restoreStatusText = loadingStatusText;
         returnPreviewFrameToCache();
+        var restore = loadingPreflight ? preflightLoadingRestore : undefined;
+        if (restore && restore.target) {
+            conversationLoading = true;
+            loadingTarget = restore.target;
+            loadingGeneration = restore.generation;
+            loadingStatusText = restore.statusText;
+            loadingPreflight = false;
+            preflightLoadingRestore = undefined;
+            document.body.setAttribute('data-conversation-loading', 'true');
+            document.body.setAttribute('aria-busy', 'true');
+            document.body.setAttribute('aria-disabled', 'true');
+            messages.setAttribute('aria-busy', 'true');
+            if (restore.framePreview) {
+                document.body.setAttribute('data-conversation-frame-preview', 'true');
+            } else {
+                document.body.removeAttribute('data-conversation-frame-preview');
+            }
+            status.textContent = 'Loading conversation…';
+            return;
+        }
         clearConversationLoading();
         status.textContent = restoreStatusText || '';
     }
@@ -1327,6 +1373,8 @@
         loadingTarget = undefined;
         loadingGeneration = 0;
         loadingStatusText = undefined;
+        loadingPreflight = false;
+        preflightLoadingRestore = undefined;
         document.body.removeAttribute('data-conversation-loading');
         document.body.removeAttribute('data-conversation-frame-preview');
         document.body.removeAttribute('aria-busy');
@@ -2094,7 +2142,16 @@
         }
         state.atLatest = message.atLatest;
         state.initialized = true;
-        clearConversationLoading();
+        var retainsNewerPreflight = loadingPreflight
+            && loadingGeneration > message.subscriptionGeneration;
+        if (!retainsNewerPreflight) {
+            clearConversationLoading();
+        } else {
+            // The older authoritative page is now complete beneath the
+            // preview. If the preview is cancelled later, reveal that stable
+            // page interactively rather than resurrecting its old spinner.
+            preflightLoadingRestore = undefined;
+        }
         var nextRestoreTarget = Object.assign({}, restoreTarget || {}, {
             interactionId: message.selectedInteractionId,
         });
@@ -2154,6 +2211,19 @@
         }
         baseTranscriptStatus = statusMessages.join(' ');
         updateTranscriptStatus();
+        if (retainsNewerPreflight && loadingTarget) {
+            // The covered authoritative page has recomputed its own status.
+            // Keep that text for a later preview cancellation instead of
+            // restoring a warning that belonged to the outgoing session.
+            loadingStatusText = status.textContent;
+            var preservedPreviewHit = previewCachedFrame(loadingTarget);
+            if (preservedPreviewHit) {
+                document.body.setAttribute('data-conversation-frame-preview', 'true');
+            } else {
+                document.body.removeAttribute('data-conversation-frame-preview');
+            }
+            status.textContent = 'Loading conversation…';
+        }
         scheduleDeferredMessagesWatchdog();
 
         var selectedMessages = Array.prototype.filter.call(

--- a/scripts/run-architecture-guards.js
+++ b/scripts/run-architecture-guards.js
@@ -1820,6 +1820,23 @@ const guards = {
             fail(this.id, risk,
                 'Dashboard Chat-row clicks must prepare once, then commit only through the shared latest-intent navigation transaction');
         }
+        const rowIntentCalls = callArguments(
+            dashboardClickNavigator.initializer,
+            'beginConversationNavigationIntent',
+        );
+        const rowIntentOptions = rowIntentCalls.length === 1
+            ? rowIntentCalls[0][0]
+            : undefined;
+        const preservePreview = rowIntentOptions
+            && ts.isObjectLiteralExpression(rowIntentOptions)
+            ? rowIntentOptions.properties.find(property =>
+                property.name?.getText(dashboard) === 'preservePreparedPreview')
+            : undefined;
+        if (!preservePreview || !ts.isPropertyAssignment(preservePreview)
+            || preservePreview.initializer.kind !== ts.SyntaxKind.TrueKeyword) {
+            fail(this.id, risk,
+                'Dashboard Chat-row intent must preserve the prior reversible preview until its replacement prepare starts');
+        }
         const focusCall = uniqueAstNode(
             dashboardClickNavigator.initializer,
             node => ts.isCallExpression(node)
@@ -1881,6 +1898,43 @@ const guards = {
         if (!cancelGuardedByUncommittedFinally) {
             fail(this.id, risk,
                 'Dashboard Chat-row prepared Viewer cancel must remain in the uncommitted finally branch');
+        }
+        const composition = parseTypescript(
+            root,
+            'src/aiSessions/conversation/composition.ts',
+            this.id,
+            risk,
+        );
+        const preparedNavigation = findVariable(
+            composition,
+            'prepareActiveConversation',
+            this.id,
+            risk,
+        );
+        if (!preparedNavigation.initializer) {
+            fail(this.id, risk,
+                'Conversation preparation must retain an initializer');
+        }
+        const preparedPreview = uniqueAstNode(
+            preparedNavigation.initializer,
+            node => ts.isCallExpression(node)
+                && node.expression.getText(composition) === 'viewer.previewSession',
+            this.id,
+            risk,
+            'Conversation preparation reversible Viewer preflight',
+        );
+        const preparedApplyMethod = uniqueAstNode(
+            preparedNavigation.initializer,
+            node => ts.isMethodDeclaration(node)
+                && node.name.getText(composition) === 'apply',
+            this.id,
+            risk,
+            'Conversation preparation apply method',
+        );
+        if (preparedPreview.getStart(composition)
+            >= preparedApplyMethod.getStart(composition)) {
+            fail(this.id, risk,
+                'Conversation preparation must start its reversible Viewer preflight before terminal focus can call apply');
         }
     },
 

--- a/src/aiSessions/conversation/composition.ts
+++ b/src/aiSessions/conversation/composition.ts
@@ -104,7 +104,9 @@ export interface ConversationCapability {
      * user-visible navigation intent wins, before that later intent reaches
      * the terminal-focus queue.
      */
-    cancelPendingNavigation(): void;
+    cancelPendingNavigation(options?: {
+        preservePreparedPreview?: boolean;
+    }): void;
     prepareActiveConversation(
         target: ConversationSessionOpenTarget,
         openWhenClosed: boolean
@@ -430,6 +432,11 @@ function createAvailableConversationCapability(
     );
     let viewerIntentGeneration = 0;
     let viewerIntentAbortController: ConversationAbortController | undefined;
+    // A Dashboard row can start a reversible Renderer preflight before its
+    // terminal focus is admitted. Unlike an authoritative Viewer load, this
+    // handle is always safe to cancel for a non-Conversation intent (for
+    // example a worktree switch) without leaving the panel loading.
+    let pendingPreparedPreview: AiSessionDisposable | undefined;
     let disposed = false;
     const beginViewerIntent = (): {
         isCurrent: () => boolean;
@@ -690,6 +697,39 @@ function createAvailableConversationCapability(
     ): PreparedActiveConversationNavigation => {
         const intent = beginViewerIntent();
         const currentTarget = viewer.getCurrentTarget();
+        // This is deliberately non-authoritative: previewSession only posts
+        // the reversible loading/cache-frame protocol. It lets a click feel
+        // immediate while terminal focus and the authoritative read run in
+        // parallel below. follow/open still own the eventual Viewer target.
+        const shouldPreflight = viewer.isOpen()
+            && !(currentTarget && hasSameConversationSession(
+                currentTarget,
+                target
+            ));
+        // Let Viewer hand one preview directly to the next. It retains a
+        // cached frame through rapid B → C clicks without a momentary return
+        // to the old authoritative document. A same-target or unavailable
+        // preflight instead restores the old document immediately.
+        if (!shouldPreflight) {
+            pendingPreparedPreview?.dispose();
+            pendingPreparedPreview = undefined;
+        }
+        const preparedPreview = shouldPreflight
+            ? viewer.previewSession?.(target)
+            : undefined;
+        if (preparedPreview) {
+            pendingPreparedPreview = preparedPreview;
+        } else if (shouldPreflight) {
+            pendingPreparedPreview?.dispose();
+            pendingPreparedPreview = undefined;
+        }
+        const releasePreparedPreview = (): void => {
+            if (pendingPreparedPreview !== preparedPreview) {
+                return;
+            }
+            pendingPreparedPreview = undefined;
+            preparedPreview?.dispose();
+        };
         const shouldResolve = openWhenClosed || viewer.isOpen();
         const resolution = shouldResolve && !(viewer.isOpen() && currentTarget
             && hasSameConversationSession(currentTarget, target))
@@ -709,6 +749,7 @@ function createAvailableConversationCapability(
         void resolution?.catch(() => undefined);
         let applied = false;
         const cancel = (): void => {
+            releasePreparedPreview();
             // A stale queued focus task must not cancel the newer target that
             // replaced it while it was waiting for terminal serialization.
             if (intent.isCurrent()) {
@@ -726,14 +767,6 @@ function createAvailableConversationCapability(
                     cancel();
                     return 'closed';
                 }
-                const currentTarget = viewer.getCurrentTarget();
-                const preparedPreview = viewer.isOpen()
-                    && !(currentTarget && hasSameConversationSession(
-                        currentTarget,
-                        target
-                    ))
-                    ? viewer.previewSession?.(target)
-                    : undefined;
                 let previewTransferred = false;
                 try {
                     let resolutionForApply = resolution;
@@ -767,6 +800,12 @@ function createAvailableConversationCapability(
                         preview: preparedPreview,
                     };
                     if (viewer.isOpen()) {
+                        // Viewer.loadTarget adopts the matching preflight
+                        // synchronously. From this point a generic navigation
+                        // intent must not cancel the authoritative load.
+                        if (pendingPreparedPreview === preparedPreview) {
+                            pendingPreparedPreview = undefined;
+                        }
                         previewTransferred = true;
                         return followOpenConversation(
                             target,
@@ -811,8 +850,15 @@ function createAvailableConversationCapability(
     return {
         viewer,
         availability: 'available',
-        cancelPendingNavigation: () => {
+        cancelPendingNavigation: navigationOptions => {
             if (!disposed) {
+                // Only release an uncommitted visual preflight. Do not abort
+                // the Viewer itself here: a worktree-only intent may have no
+                // replacement Conversation transaction to settle it.
+                if (!navigationOptions?.preservePreparedPreview) {
+                    pendingPreparedPreview?.dispose();
+                    pendingPreparedPreview = undefined;
+                }
                 beginViewerIntent();
             }
         },
@@ -973,6 +1019,8 @@ function createAvailableConversationCapability(
             viewerIntentGeneration += 1;
             viewerIntentAbortController?.abort();
             viewerIntentAbortController = undefined;
+            pendingPreparedPreview?.dispose();
+            pendingPreparedPreview = undefined;
             ownership.dispose();
         },
     };

--- a/src/aiSessions/conversation/viewer.ts
+++ b/src/aiSessions/conversation/viewer.ts
@@ -1543,13 +1543,24 @@ export class ConversationViewer implements ConversationViewerApi {
         }
         if (parsed.type === 'conversation-viewer-frame-cache-preview') {
             const target = this.target;
-            if (target
+            const authoritativeMatch = target
                 && parsed.subscriptionGeneration === this.subscriptionGeneration
                 && parsed.projectId === target.projectId
                 && parsed.provider === target.provider
-                && parsed.sessionId === target.sessionId) {
+                && parsed.sessionId === target.sessionId;
+            const preflight = this.preflightPreview;
+            const preflightMatch = preflight
+                && parsed.subscriptionGeneration === preflight.subscriptionGeneration
+                && parsed.projectId === preflight.target.projectId
+                && parsed.provider === preflight.target.provider
+                && parsed.sessionId === preflight.target.sessionId;
+            if (authoritativeMatch || preflightMatch) {
                 this.emitDiagnostic('frame-cache-preview', {
                     outcome: parsed.outcome,
+                    ...(preflightMatch ? {
+                        preflightSessionId: parsed.sessionId,
+                        preflightProvider: parsed.provider,
+                    } : {}),
                 });
             }
             return;

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1751,13 +1751,15 @@ async function initializeDashboard(
         }),
     });
     let conversationNavigationIntent = 0;
-    const beginConversationNavigationIntent = (): number => {
+    const beginConversationNavigationIntent = (options?: {
+        preservePreparedPreview?: boolean;
+    }): number => {
         conversationNavigationIntent += 1;
         // The coordinator can discard queued target switches, but a slow
         // foreground provider read has already left that queue. Cancel it at
         // the moment the newer user intent arrives so it cannot hold the
         // latest target behind its full read timeout.
-        conversationCapability?.cancelPendingNavigation();
+        conversationCapability?.cancelPendingNavigation(options);
         return conversationNavigationIntent;
     };
     conversationCapability = ownResource(() => createConversationCapability({
@@ -2124,7 +2126,12 @@ async function initializeDashboard(
         provider: AiSessionProviderId;
         sessionId: string;
     }, openWhenClosed: boolean): Promise<void> => {
-        const intent = beginConversationNavigationIntent();
+        const intent = beginConversationNavigationIntent({
+            // The following prepare call synchronously hands this reversible
+            // frame to the next row target. Keep it alive across that tiny
+            // gap so rapid clicks never flash back to the old conversation.
+            preservePreparedPreview: true,
+        });
         // Resolve the provider snapshot immediately. Terminal focus must stay
         // serialized, but it is independent of the read and should not make
         // a slow focus plus a slow snapshot feel like two consecutive waits.

--- a/src/webview/conversationViewerScripts.js
+++ b/src/webview/conversationViewerScripts.js
@@ -386,6 +386,12 @@
     var loadingTarget;
     var loadingGeneration = 0;
     var loadingStatusText;
+    var loadingPreflight = false;
+    // A speculative target can temporarily cover an already-authoritative
+    // load. Keep the underlying load presentation so cancelling the
+    // speculation resumes it instead of incorrectly making the old document
+    // interactive while its Host transition is still pending.
+    var preflightLoadingRestore;
     // Detached conversation frames keyed by session: switching back to a
     // session whose content token is unchanged reattaches the already-built
     // DOM — no HTML transfer, sanitize, parse, or reconcile at all. Bounded
@@ -1239,13 +1245,32 @@
                 && previewFrame.key === preflightKey;
             if (!preflightKey || (!alreadyPreviewed
                 && !frameCache.has(preflightKey))) {
-                // Do not make a cache miss look slower than it did before
-                // preflight existed. If this supersedes a prior hit, return
-                // that detached frame before keeping the outgoing document
-                // readable while the new Host read proceeds.
-                restoreCancelledPreflight();
+                // A cache miss cannot replace the document, but it must still
+                // make the click visible immediately. Keep the outgoing
+                // content in place under the same reversible loading state
+                // used for a committed target; cancellation restores it.
+                if (loadingPreflight) {
+                    restoreCancelledPreflight();
+                }
+            }
+            if (!loadingPreflight && conversationLoading) {
+                preflightLoadingRestore = {
+                    target: loadingTarget && Object.assign({}, loadingTarget),
+                    generation: loadingGeneration,
+                    statusText: loadingStatusText,
+                    framePreview: document.body.getAttribute(
+                        'data-conversation-frame-preview'
+                    ) === 'true',
+                };
+            }
+        } else if (loadingPreflight) {
+            if (message.subscriptionGeneration < loadingGeneration) {
+                // A still-running older Host load must not displace a newer
+                // optimistic target before its terminal focus resolves.
                 return true;
             }
+            returnPreviewFrameToCache();
+            preflightLoadingRestore = undefined;
         }
         if (!conversationLoading) {
             loadingStatusText = status.textContent;
@@ -1257,6 +1282,7 @@
             sessionId: message.target.sessionId,
         };
         loadingGeneration = message.subscriptionGeneration;
+        loadingPreflight = message.preflight === true;
         document.body.setAttribute('data-conversation-loading', 'true');
         document.body.setAttribute('aria-busy', 'true');
         document.body.setAttribute('aria-disabled', 'true');
@@ -1315,6 +1341,26 @@
         }
         var restoreStatusText = loadingStatusText;
         returnPreviewFrameToCache();
+        var restore = loadingPreflight ? preflightLoadingRestore : undefined;
+        if (restore && restore.target) {
+            conversationLoading = true;
+            loadingTarget = restore.target;
+            loadingGeneration = restore.generation;
+            loadingStatusText = restore.statusText;
+            loadingPreflight = false;
+            preflightLoadingRestore = undefined;
+            document.body.setAttribute('data-conversation-loading', 'true');
+            document.body.setAttribute('aria-busy', 'true');
+            document.body.setAttribute('aria-disabled', 'true');
+            messages.setAttribute('aria-busy', 'true');
+            if (restore.framePreview) {
+                document.body.setAttribute('data-conversation-frame-preview', 'true');
+            } else {
+                document.body.removeAttribute('data-conversation-frame-preview');
+            }
+            status.textContent = 'Loading conversation…';
+            return;
+        }
         clearConversationLoading();
         status.textContent = restoreStatusText || '';
     }
@@ -1327,6 +1373,8 @@
         loadingTarget = undefined;
         loadingGeneration = 0;
         loadingStatusText = undefined;
+        loadingPreflight = false;
+        preflightLoadingRestore = undefined;
         document.body.removeAttribute('data-conversation-loading');
         document.body.removeAttribute('data-conversation-frame-preview');
         document.body.removeAttribute('aria-busy');
@@ -2094,7 +2142,16 @@
         }
         state.atLatest = message.atLatest;
         state.initialized = true;
-        clearConversationLoading();
+        var retainsNewerPreflight = loadingPreflight
+            && loadingGeneration > message.subscriptionGeneration;
+        if (!retainsNewerPreflight) {
+            clearConversationLoading();
+        } else {
+            // The older authoritative page is now complete beneath the
+            // preview. If the preview is cancelled later, reveal that stable
+            // page interactively rather than resurrecting its old spinner.
+            preflightLoadingRestore = undefined;
+        }
         var nextRestoreTarget = Object.assign({}, restoreTarget || {}, {
             interactionId: message.selectedInteractionId,
         });
@@ -2154,6 +2211,19 @@
         }
         baseTranscriptStatus = statusMessages.join(' ');
         updateTranscriptStatus();
+        if (retainsNewerPreflight && loadingTarget) {
+            // The covered authoritative page has recomputed its own status.
+            // Keep that text for a later preview cancellation instead of
+            // restoring a warning that belonged to the outgoing session.
+            loadingStatusText = status.textContent;
+            var preservedPreviewHit = previewCachedFrame(loadingTarget);
+            if (preservedPreviewHit) {
+                document.body.setAttribute('data-conversation-frame-preview', 'true');
+            } else {
+                document.body.removeAttribute('data-conversation-frame-preview');
+            }
+            status.textContent = 'Loading conversation…';
+        }
         scheduleDeferredMessagesWatchdog();
 
         var selectedMessages = Array.prototype.filter.call(

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -1199,18 +1199,30 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 shows a lightweight loading sta
 
     await sendPage(page, sessionPage(2, 'session-alpha', 'alpha', 'sig-a1'));
 
-    // A speculative cache miss leaves the outgoing conversation alone. The
-    // ordinary loading notice still owns the visual state once the Host has
-    // resolved the target, so uncached sessions do not feel slower.
+    // A speculative cache miss keeps the outgoing conversation in place, but
+    // immediately exposes the same reversible loading state as a cache hit.
+    // Terminal focus may still fail, in which case the Host cancels it.
     await sendPage(page, loadingNotice(3, 'session-beta', true));
+    assert.deepEqual(await loadingState(), {
+        status: 'Loading conversation…', loading: 'true', preview: null,
+        ariaBusy: 'true', ariaDisabled: 'true', busy: 'true', content: 'alpha',
+    });
+
+    await sendPage(page, {
+        type: 'conversation-viewer-loading-cancel',
+        version: 1,
+        subscriptionGeneration: 3,
+        target: {
+            projectId: 'project-1', provider: 'codex', sessionId: 'session-beta',
+        },
+    });
     assert.deepEqual(await loadingState(), {
         status: '', loading: null, preview: null, ariaBusy: null,
         ariaDisabled: null, busy: null, content: 'alpha',
-    });
+    }, 'an uncached cancelled preflight must restore the interactive alpha frame');
 
-    // The Host reuses the panel for a different session: the outgoing
-    // content stays visible under a lightweight loading state until the
-    // incoming session's first publication lands.
+    // The authoritative application reuses the existing loading state until
+    // the incoming session's first publication lands.
     await sendPage(page, loadingNotice(3, 'session-beta'));
     assert.deepEqual(await loadingState(), {
         status: 'Loading conversation…',
@@ -1251,6 +1263,34 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 shows a lightweight loading sta
         busy: null,
         content: 'beta',
     });
+
+    // A newer preflight can overlay an older authoritative page that is
+    // still in flight. That old page must neither clear the newer loading
+    // state nor evict its cached frame; cancelling the newer intent resumes
+    // the original authoritative loading state.
+    await sendPage(page, loadingNotice(4, 'session-gamma'));
+    await sendPage(page, loadingNotice(5, 'session-alpha', true));
+    await sendPage(page, {
+        ...sessionPage(4, 'session-gamma', 'gamma', 'sig-g1'),
+        stale: true,
+    });
+    assert.deepEqual(await loadingState(), {
+        status: 'Loading conversation…', loading: 'true', preview: 'true',
+        ariaBusy: 'true', ariaDisabled: 'true', busy: 'true', content: 'alpha',
+    }, 'an older page cannot erase a newer cached preflight');
+    await sendPage(page, {
+        type: 'conversation-viewer-loading-cancel',
+        version: 1,
+        subscriptionGeneration: 5,
+        target: {
+            projectId: 'project-1', provider: 'codex', sessionId: 'session-alpha',
+        },
+    });
+    assert.deepEqual(await loadingState(), {
+        status: 'Conversation history may be out of date.',
+        loading: null, preview: null,
+        ariaBusy: null, ariaDisabled: null, busy: null, content: 'gamma',
+    }, 'cancelling the overlay reveals the now-complete authoritative page interactively');
 });
 
 test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 previews a cached session before its Host page returns', async t => {
@@ -4831,7 +4871,13 @@ test('CONVERSATION-OUTLINE-NAVIGATION-001 keeps every side-panel view usable acr
                 + '    // document if that speculative read is superseded or fails.\n'
                 + '    var loadingTarget;\n'
                 + '    var loadingGeneration = 0;\n'
-                + '    var loadingStatusText;\n',
+                + '    var loadingStatusText;\n'
+                + '    var loadingPreflight = false;\n'
+                + '    // A speculative target can temporarily cover an already-authoritative\n'
+                + '    // load. Keep the underlying load presentation so cancelling the\n'
+                + '    // speculation resumes it instead of incorrectly making the old document\n'
+                + '    // interactive while its Host transition is still pending.\n'
+                + '    var preflightLoadingRestore;\n',
             "    var conversationLoading = false;\n"
         )
         .replace(
@@ -4848,7 +4894,8 @@ test('CONVERSATION-OUTLINE-NAVIGATION-001 keeps every side-panel view usable acr
                 + '            provider: message.target.provider,\n'
                 + '            sessionId: message.target.sessionId,\n'
                 + '        };\n'
-                + '        loadingGeneration = message.subscriptionGeneration;\n',
+                + '        loadingGeneration = message.subscriptionGeneration;\n'
+                + '        loadingPreflight = message.preflight === true;\n',
             '        conversationLoading = true;\n'
         )
         .replace(
@@ -4862,13 +4909,32 @@ test('CONVERSATION-OUTLINE-NAVIGATION-001 keeps every side-panel view usable acr
                 + '                && previewFrame.key === preflightKey;\n'
                 + '            if (!preflightKey || (!alreadyPreviewed\n'
                 + '                && !frameCache.has(preflightKey))) {\n'
-                + '                // Do not make a cache miss look slower than it did before\n'
-                + '                // preflight existed. If this supersedes a prior hit, return\n'
-                + '                // that detached frame before keeping the outgoing document\n'
-                + '                // readable while the new Host read proceeds.\n'
-                + '                restoreCancelledPreflight();\n'
+                + '                // A cache miss cannot replace the document, but it must still\n'
+                + '                // make the click visible immediately. Keep the outgoing\n'
+                + '                // content in place under the same reversible loading state\n'
+                + '                // used for a committed target; cancellation restores it.\n'
+                + '                if (loadingPreflight) {\n'
+                + '                    restoreCancelledPreflight();\n'
+                + '                }\n'
+                + '            }\n'
+                + '            if (!loadingPreflight && conversationLoading) {\n'
+                + '                preflightLoadingRestore = {\n'
+                + '                    target: loadingTarget && Object.assign({}, loadingTarget),\n'
+                + '                    generation: loadingGeneration,\n'
+                + '                    statusText: loadingStatusText,\n'
+                + "                    framePreview: document.body.getAttribute(\n"
+                + "                        'data-conversation-frame-preview'\n"
+                + "                    ) === 'true',\n"
+                + '                };\n'
+                + '            }\n'
+                + '        } else if (loadingPreflight) {\n'
+                + '            if (message.subscriptionGeneration < loadingGeneration) {\n'
+                + '                // A still-running older Host load must not displace a newer\n'
+                + '                // optimistic target before its terminal focus resolves.\n'
                 + '                return true;\n'
                 + '            }\n'
+                + '            returnPreviewFrameToCache();\n'
+                + '            preflightLoadingRestore = undefined;\n'
                 + '        }\n',
             ''
         )
@@ -4880,8 +4946,39 @@ test('CONVERSATION-OUTLINE-NAVIGATION-001 keeps every side-panel view usable acr
             '        conversationLoading = false;\n'
                 + '        loadingTarget = undefined;\n'
                 + '        loadingGeneration = 0;\n'
-                + '        loadingStatusText = undefined;\n',
+                + '        loadingStatusText = undefined;\n'
+                + '        loadingPreflight = false;\n'
+                + '        preflightLoadingRestore = undefined;\n',
             '        conversationLoading = false;\n'
+        )
+        .replace(
+            '        var retainsNewerPreflight = loadingPreflight\n'
+                + '            && loadingGeneration > message.subscriptionGeneration;\n'
+                + '        if (!retainsNewerPreflight) {\n'
+                + '            clearConversationLoading();\n'
+                + '        } else {\n'
+                + '            // The older authoritative page is now complete beneath the\n'
+                + '            // preview. If the preview is cancelled later, reveal that stable\n'
+                + '            // page interactively rather than resurrecting its old spinner.\n'
+                + '            preflightLoadingRestore = undefined;\n'
+                + '        }\n',
+            '        clearConversationLoading();\n'
+        )
+        .replace(
+            '        if (retainsNewerPreflight && loadingTarget) {\n'
+                + '            // The covered authoritative page has recomputed its own status.\n'
+                + '            // Keep that text for a later preview cancellation instead of\n'
+                + '            // restoring a warning that belonged to the outgoing session.\n'
+                + '            loadingStatusText = status.textContent;\n'
+                + '            var preservedPreviewHit = previewCachedFrame(loadingTarget);\n'
+                + '            if (preservedPreviewHit) {\n'
+                + "                document.body.setAttribute('data-conversation-frame-preview', 'true');\n"
+                + '            } else {\n'
+                + "                document.body.removeAttribute('data-conversation-frame-preview');\n"
+                + '            }\n'
+                + "            status.textContent = 'Loading conversation…';\n"
+                + '        }\n',
+            ''
         )
         .replace(
             '        if (applyFollowNotice(event.data)) return;\n'
@@ -7130,7 +7227,7 @@ test('CONVERSATION-OUTLINE-NAVIGATION-001 keeps every side-panel view usable acr
         .digest('hex');
     assert.equal(
         sha256(previousViewerScriptWithoutAuxiliarySnapshots),
-        '12480eccea0518e9e134be1bd485460986570da5c7c5de9c46b3c89f0f281ab5',
+        '557834a9b3cc2135ace599b6968061ae5b9c5969055a65549f4993ac7e1c91a1',
         'the previous Viewer fixture must stay byte-exact'
     );
     assert.equal(

--- a/tests/integration/dashboard/conversationOpenLatest.test.js
+++ b/tests/integration/dashboard/conversationOpenLatest.test.js
@@ -981,7 +981,7 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 releases an obsolete Viewer wai
     harness.capability.dispose();
 });
 
-test('CONVERSATION-SWITCH-LATENCY-002 starts a prepared snapshot before terminal focus releases its Viewer apply', async () => {
+test('CONVERSATION-SWITCH-LATENCY-002 starts a reversible Viewer preflight and snapshot before terminal focus releases its Viewer apply', async () => {
     const delayedSnapshot = deferred();
     const delayedFocus = deferred();
     const harness = createHarness({
@@ -1012,14 +1012,12 @@ test('CONVERSATION-SWITCH-LATENCY-002 starts a prepared snapshot before terminal
     );
     assert.deepEqual(harness.viewerTargets, [],
         'a prepared snapshot must not mutate the Viewer before terminal focus succeeds');
-    assert.deepEqual(harness.previewedViewerTargets, [],
-        'preparing must not preflight the Viewer before terminal focus succeeds');
+    assert.deepEqual(harness.previewedViewerTargets.map(target => target.sessionId), ['session-a'],
+        'the reversible Viewer preflight makes the click visible before terminal focus succeeds');
+    assert.deepEqual(harness.followedViewerTargets, [],
+        'only the later apply may authoritatively follow the prepared target');
 
     delayedFocus.resolve();
-    await waitFor(
-        () => harness.previewedViewerTargets.some(target => target.sessionId === 'session-a'),
-        'the Viewer preflight to begin only after terminal focus releases apply'
-    );
     delayedSnapshot.resolve({
         outline: makeOutline('codex', 'session-a', ['input-a']),
         page: makePage('codex', 'session-a', 'input-a'),
@@ -1052,6 +1050,13 @@ test('CONVERSATION-SWITCH-LATENCY-002 cancels a prepared snapshot when terminal 
     const harness = createHarness({
         enableSnapshots: true,
         requireSnapshot: true,
+        viewerOpen: true,
+        initialViewerTarget: {
+            projectId: 'project-a', provider: 'kimi', workspaceName: '',
+            sessionId: 'session-before', interactionId: 'input-before', expectedRevision: 'r1',
+            displayName: 'session-before', duplicateDisplayName: false,
+        },
+        previewSession: () => ({ dispose() {} }),
         readSnapshot: (_provider, _sessionId, _preferredInteractionId, signal) => {
             signal.onAbort(() => { readAborted = true; });
             return slowSnapshot.promise;
@@ -1064,15 +1069,93 @@ test('CONVERSATION-SWITCH-LATENCY-002 cancels a prepared snapshot when terminal 
         () => harness.snapshotReadTargets.includes('codex:session-a'),
         'the prepared snapshot to start before terminal focus'
     );
+    assert.deepEqual(harness.previewedViewerTargets.map(target => target.sessionId), ['session-a'],
+        'the failed terminal focus begins with a reversible visual preflight');
 
     prepared.cancel();
     assert.equal(readAborted, true,
         'a rejected terminal focus must abort its uncommitted provider read');
+    assert.deepEqual(harness.cancelledViewerPreviews.map(target => target.sessionId), ['session-a'],
+        'a rejected terminal focus restores the previous Viewer presentation');
     assert.equal(await prepared.apply(), 'superseded');
     slowSnapshot.resolve({
         outline: makeOutline('codex', 'session-a', ['input-a']),
         page: makePage('codex', 'session-a', 'input-a'),
     });
+    harness.capability.dispose();
+});
+
+test('CONVERSATION-SWITCH-LATENCY-002 releases an uncommitted preflight for a non-Conversation navigation intent', async () => {
+    const slowSnapshot = deferred();
+    let readAborted = false;
+    const harness = createHarness({
+        enableSnapshots: true,
+        requireSnapshot: true,
+        viewerOpen: true,
+        initialViewerTarget: {
+            projectId: 'project-a', provider: 'kimi', workspaceName: '',
+            sessionId: 'session-before', interactionId: 'input-before', expectedRevision: 'r1',
+            displayName: 'session-before', duplicateDisplayName: false,
+        },
+        previewSession: () => ({ dispose() {} }),
+        readSnapshot: (_provider, _sessionId, _preferredInteractionId, signal) => {
+            signal.onAbort(() => { readAborted = true; });
+            return slowSnapshot.promise;
+        },
+    });
+    const prepared = harness.capability.prepareActiveConversation({
+        projectId: 'project-a', provider: 'codex', sessionId: 'session-a',
+    }, false);
+    await waitFor(
+        () => harness.previewedViewerTargets.length === 1,
+        'the uncommitted preflight'
+    );
+
+    harness.capability.cancelPendingNavigation();
+    assert.equal(readAborted, true,
+        'the superseded provider resolution is still released immediately');
+    assert.deepEqual(harness.cancelledViewerPreviews.map(target => target.sessionId), ['session-a'],
+        'a worktree-only intent cannot strand a reversible loading presentation');
+    assert.equal(await prepared.apply(), 'superseded');
+    slowSnapshot.resolve({
+        outline: makeOutline('codex', 'session-a', ['input-a']),
+        page: makePage('codex', 'session-a', 'input-a'),
+    });
+    harness.capability.dispose();
+});
+
+test('CONVERSATION-SWITCH-LATENCY-002 hands rapid prepared previews directly to the newest target', () => {
+    const harness = createHarness({
+        viewerOpen: true,
+        initialViewerTarget: {
+            projectId: 'project-a', provider: 'kimi', workspaceName: '',
+            sessionId: 'session-before', interactionId: 'input-before', expectedRevision: 'r1',
+            displayName: 'session-before', duplicateDisplayName: false,
+        },
+        previewSession: () => ({ dispose() {} }),
+    });
+    const stale = harness.capability.prepareActiveConversation({
+        projectId: 'project-a', provider: 'codex', sessionId: 'session-b',
+    }, false);
+    harness.capability.cancelPendingNavigation({
+        preservePreparedPreview: true,
+    });
+    harness.capability.prepareActiveConversation({
+        projectId: 'project-a', provider: 'kimi', sessionId: 'session-c',
+    }, false);
+
+    assert.deepEqual(harness.previewedViewerTargets.map(target => target.sessionId), [
+        'session-b', 'session-c',
+    ]);
+    assert.deepEqual(harness.cancelledViewerPreviews, [],
+        'the newest preview replaces the prior frame without a visible rollback');
+    stale.cancel();
+    assert.deepEqual(harness.cancelledViewerPreviews, [],
+        'a stale focus cleanup cannot cancel the newest preflight');
+
+    harness.capability.cancelPendingNavigation();
+    assert.deepEqual(harness.cancelledViewerPreviews.map(target => target.sessionId), ['session-c'],
+        'a later non-Conversation intent still returns to the authoritative frame');
     harness.capability.dispose();
 });
 
@@ -1149,7 +1232,7 @@ test('CONVERSATION-SWITCH-LATENCY-002 revalidates a prepared snapshot after View
     harness.capability.dispose();
 });
 
-test('CONVERSATION-SWITCH-LATENCY-002 previews an open Viewer while a prepared snapshot still resolves', async () => {
+test('CONVERSATION-SWITCH-LATENCY-002 previews an open Viewer before its prepared snapshot is applied', async () => {
     const slowSnapshot = deferred();
     const harness = createHarness({
         enableSnapshots: true,
@@ -1170,12 +1253,12 @@ test('CONVERSATION-SWITCH-LATENCY-002 previews an open Viewer while a prepared s
         projectId: 'project-a', provider: 'kimi', sessionId: 'session-b',
     }, false);
 
-    const applying = prepared.apply();
     await waitFor(
         () => harness.previewedViewerTargets.some(target => target.sessionId === 'session-b'),
-        'the Viewer preflight to begin before the slow prepared snapshot resolves'
+        'the Viewer preflight to begin before terminal focus can call apply'
     );
     assert.deepEqual(harness.followedViewerTargets, []);
+    const applying = prepared.apply();
     slowSnapshot.resolve({
         outline: makeOutline('kimi', 'session-b', ['input-b']),
         page: makePage('kimi', 'session-b', 'input-b'),
@@ -1929,11 +2012,11 @@ test('CONVERSATION-FOLLOW-ACTIVE-SESSION-001 delegates Active Session card focus
     );
     assert.match(
         dashboardSource,
-        /const beginConversationNavigationIntent = \(\): number => \{[\s\S]*conversationCapability\?\.cancelPendingNavigation\(\)/,
+        /const beginConversationNavigationIntent = \(options\?: \{[\s\S]*conversationCapability\?\.cancelPendingNavigation\(options\)/,
         'a new Dashboard intent must cancel a foreground read before the shared queue runs it'
     );
     const intentStart = navigationPath[0].indexOf(
-        'const intent = beginConversationNavigationIntent();'
+        'const intent = beginConversationNavigationIntent({'
     );
     const enqueueStart = navigationPath[0].indexOf(
         'sessionNavigationCoordinator.enqueueLatest('
@@ -1970,6 +2053,8 @@ test('CONVERSATION-FOLLOW-ACTIVE-SESSION-001 delegates Active Session card focus
         preparedStart < enqueueStart,
         'a row click must begin snapshot resolution before terminal focus enters the queue'
     );
+    assert.match(navigationPath[0], /preservePreparedPreview: true/,
+        'a row-to-row intent must hand off its visual preflight without a rollback flicker');
     assert.ok(
         focusStart < applyStart,
         'a row click must not apply Viewer state before terminal focus succeeds'

--- a/tests/integration/dashboard/conversationViewer.test.js
+++ b/tests/integration/dashboard/conversationViewer.test.js
@@ -2508,6 +2508,52 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 preflights a cached frame befor
     viewer.dispose();
 });
 
+test('CONVERSATION-SWITCH-LATENCY-002 records a preflight cache outcome before terminal focus commits Viewer authority', async () => {
+    const diagnostics = [];
+    const { viewer, panel } = createViewer({
+        onDiagnostic: event => diagnostics.push(event),
+    });
+    await viewer.open(target('session-a'));
+    const initial = decodeInitialPublication(panel.webview.html);
+    await panel.receive({
+        type: 'conversation-viewer-capabilities',
+        version: 1,
+        documentId: decodeDocumentId(panel.webview.html),
+        capabilities: ['tail-patch', 'frame-preflight'],
+    });
+    viewer.previewSession({
+        projectId: 'project-a', provider: 'codex', sessionId: 'session-b',
+    });
+    await panel.receive({
+        type: 'conversation-viewer-frame-cache-preview',
+        version: 1,
+        subscriptionGeneration: initial.subscriptionGeneration + 1,
+        outcome: 'hit',
+        projectId: 'project-a', provider: 'codex', sessionId: 'session-b',
+    });
+    assert.ok(diagnostics.some(event =>
+        event.reason === 'frame-cache-preview'
+            && event.preflightSessionId === 'session-b'
+            && event.outcome === 'hit'
+    ), 'a slow terminal focus must not hide its preflight cache outcome');
+
+    viewer.previewSession({
+        projectId: 'project-a', provider: 'codex', sessionId: 'session-c',
+    });
+    await panel.receive({
+        type: 'conversation-viewer-frame-cache-preview',
+        version: 1,
+        subscriptionGeneration: initial.subscriptionGeneration + 1,
+        outcome: 'miss',
+        projectId: 'project-a', provider: 'codex', sessionId: 'session-b',
+    });
+    assert.equal(diagnostics.filter(event =>
+        event.reason === 'frame-cache-preview'
+            && event.preflightSessionId === 'session-b'
+    ).length, 1, 'a superseded preflight must reject B\'s late cache outcome');
+    viewer.dispose();
+});
+
 test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 records document timing after a message-delivery fallback', async () => {
     let now = 100;
     const timings = [];

--- a/tests/unit/tooling/architectureGuards.test.js
+++ b/tests/unit/tooling/architectureGuards.test.js
@@ -509,6 +509,15 @@ for (const mutation of [
     {
         id: 'ARCH-AI-SESSION-NAVIGATION-OWNERSHIP-001',
         file: 'src/dashboard.ts',
+        expectedDetail: 'Dashboard Chat-row intent must preserve the prior reversible preview until its replacement prepare starts',
+        mutate: source => source.replace(
+            'preservePreparedPreview: true,',
+            'preservePreparedPreview: false,',
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-NAVIGATION-OWNERSHIP-001',
+        file: 'src/dashboard.ts',
         expectedDetail: 'Dashboard Chat-row clicks must prepare once, then commit only through the shared latest-intent navigation transaction',
         mutate: source => source.replace(
             'conversationCapability.prepareActiveConversation(target, openWhenClosed)',
@@ -546,6 +555,15 @@ for (const mutation of [
         ).replace(
             'if (!conversationApplied) {\n                preparedConversation.cancel();\n            }\n',
             '',
+        ),
+    },
+    {
+        id: 'ARCH-AI-SESSION-NAVIGATION-OWNERSHIP-001',
+        file: 'src/aiSessions/conversation/composition.ts',
+        expectedDetail: 'Conversation preparation reversible Viewer preflight must exist exactly once',
+        mutate: source => source.replace(
+            '? viewer.previewSession?.(target)\n            : undefined;',
+            '? undefined\n            : undefined;',
         ),
     },
     {


### PR DESCRIPTION
## Summary

- Start a reversible Conversation Viewer preflight as soon as a Dashboard row is clicked, while terminal focus and snapshot resolution run in parallel.
- Show explicit loading feedback for cache misses and preserve cache handoffs across rapid row clicks.
- Harden preflight rollback, older-page races, and pre-authority cache diagnostics.

## Validation

- `npm run test-compile`
- `node --test tests/integration/dashboard/conversationOpenLatest.test.js tests/integration/dashboard/conversationViewer.test.js tests/unit/tooling/architectureGuards.test.js`
- `node --test tests/browser/conversationViewer.test.js`
- `git diff --check`
- Verified `src/webview/conversationViewerScripts.js` equals `media/conversationViewerScripts.js`.

## Skill harvest

No skill changes. The existing resilient Webview mutation protocol guidance already covers reversible preflight and cancellation; multi-angle review plus browser race gates validated this implementation.

## Owner approvals

```text
approve cce0811840b5f8066b258a9a1f25c81210a018a3
```