### PR TITLE
perf: complete cached conversation preview chrome

### DIFF
--- a/media/conversationViewerScripts.js
+++ b/media/conversationViewerScripts.js
@@ -392,6 +392,11 @@
     // speculation resumes it instead of incorrectly making the old document
     // interactive while its Host transition is still pending.
     var preflightLoadingRestore;
+    // Telemetry belongs to the authoritative subscription and can therefore
+    // describe a different provider/model than a cached preview. Mask only
+    // those target-specific values while keeping the surrounding toolbar
+    // (position, comments, and controls) stable and usable for reading.
+    var preflightTelemetryPresentation;
     // Detached conversation frames keyed by session: switching back to a
     // session whose content token is unchanged reattaches the already-built
     // DOM — no HTML transfer, sanitize, parse, or reconcile at all. Bounded
@@ -1261,8 +1266,10 @@
                     framePreview: document.body.getAttribute(
                         'data-conversation-frame-preview'
                     ) === 'true',
+                    telemetryMasked: !!preflightTelemetryPresentation,
                 };
             }
+            hideTelemetryForPreflight();
         } else if (loadingPreflight) {
             if (message.subscriptionGeneration < loadingGeneration) {
                 // A still-running older Host load must not displace a newer
@@ -1359,6 +1366,9 @@
                 document.body.removeAttribute('data-conversation-frame-preview');
             }
             status.textContent = 'Loading conversation…';
+            if (!restore.telemetryMasked) {
+                restoreTelemetryAfterPreflight();
+            }
             return;
         }
         clearConversationLoading();
@@ -1375,12 +1385,54 @@
         loadingStatusText = undefined;
         loadingPreflight = false;
         preflightLoadingRestore = undefined;
+        restoreTelemetryAfterPreflight();
         document.body.removeAttribute('data-conversation-loading');
         document.body.removeAttribute('data-conversation-frame-preview');
         document.body.removeAttribute('aria-busy');
         document.body.removeAttribute('aria-disabled');
         messages.removeAttribute('aria-busy');
         // The applied page recomputes the status line right below.
+    }
+
+    function hideTelemetryForPreflight() {
+        if (preflightTelemetryPresentation) {
+            return;
+        }
+        preflightTelemetryPresentation = [
+            telemetryProvider,
+            telemetryModel,
+            telemetryContext,
+            telemetryLimits,
+        ].filter(function (element) {
+            return !!element;
+        }).map(function (element) {
+            var presentation = {
+                element: element,
+                ariaHidden: element.getAttribute('aria-hidden'),
+                visibility: element.style.visibility,
+            };
+            element.style.visibility = 'hidden';
+            element.setAttribute('aria-hidden', 'true');
+            return presentation;
+        });
+    }
+
+    function restoreTelemetryAfterPreflight() {
+        if (!preflightTelemetryPresentation) {
+            return;
+        }
+        preflightTelemetryPresentation.forEach(function (presentation) {
+            presentation.element.style.visibility = presentation.visibility;
+            if (presentation.ariaHidden === null) {
+                presentation.element.removeAttribute('aria-hidden');
+            } else {
+                presentation.element.setAttribute(
+                    'aria-hidden',
+                    presentation.ariaHidden
+                );
+            }
+        });
+        preflightTelemetryPresentation = undefined;
     }
 
     function applySessionGeneration(message) {
@@ -1783,6 +1835,114 @@
             + '\u0001' + target.sessionId;
     }
 
+    // A detached transcript frame is only visually credible when it brings
+    // its identity with it. Before this, a cache-hit preflight replaced beta's
+    // messages while leaving alpha's title/workspace/task in the sticky
+    // header until the slower authoritative page arrived. That mismatch made
+    // an otherwise instant handoff still feel stalled.
+    function captureFramePresentation() {
+        return {
+            displayName: conversationDisplayName
+                ? conversationDisplayName.textContent
+                : undefined,
+            workspaceName: conversationWorkspaceName
+                ? conversationWorkspaceName.textContent
+                : undefined,
+            taskName: conversationTaskName
+                ? conversationTaskName.textContent
+                : undefined,
+            taskNameHidden: conversationTaskName
+                ? conversationTaskName.hidden
+                : undefined,
+            taskSeparatorHidden: conversationTaskSeparator
+                ? conversationTaskSeparator.hidden
+                : undefined,
+            positionText: position ? position.textContent : undefined,
+            positionTitle: position ? position.getAttribute('title') : undefined,
+            positionAriaLabel: position
+                ? position.getAttribute('aria-label')
+                : undefined,
+            positionTooltip: position
+                ? position.getAttribute('data-tooltip')
+                : undefined,
+            previousDisabled: previous ? previous.disabled : undefined,
+            nextDisabled: next ? next.disabled : undefined,
+            latestDisabled: latest ? latest.disabled : undefined,
+            workingHidden: working ? working.hidden : undefined,
+        };
+    }
+
+    function restoreOptionalAttribute(element, name, value) {
+        if (!element) {
+            return;
+        }
+        if (typeof value === 'string') {
+            element.setAttribute(name, value);
+        } else {
+            element.removeAttribute(name);
+        }
+    }
+
+    function restoreFramePresentation(frame) {
+        var presentation = frame && frame.presentation;
+        if (!presentation) {
+            return;
+        }
+        if (conversationDisplayName
+            && typeof presentation.displayName === 'string') {
+            conversationDisplayName.textContent = presentation.displayName;
+        }
+        if (conversationWorkspaceName
+            && typeof presentation.workspaceName === 'string') {
+            conversationWorkspaceName.textContent = presentation.workspaceName;
+        }
+        if (conversationTaskName) {
+            if (typeof presentation.taskName === 'string') {
+                conversationTaskName.textContent = presentation.taskName;
+            }
+            if (typeof presentation.taskNameHidden === 'boolean') {
+                conversationTaskName.hidden = presentation.taskNameHidden;
+            }
+        }
+        if (conversationTaskSeparator
+            && typeof presentation.taskSeparatorHidden === 'boolean') {
+            conversationTaskSeparator.hidden = presentation.taskSeparatorHidden;
+        }
+        if (position && typeof presentation.positionText === 'string') {
+            var value = position.querySelector(
+                '[data-conversation-position-value]'
+            );
+            if (value) {
+                value.textContent = presentation.positionText;
+            } else {
+                position.textContent = presentation.positionText;
+            }
+            restoreOptionalAttribute(position, 'title', presentation.positionTitle);
+            restoreOptionalAttribute(
+                position,
+                'aria-label',
+                presentation.positionAriaLabel
+            );
+            restoreOptionalAttribute(
+                position,
+                'data-tooltip',
+                presentation.positionTooltip
+            );
+        }
+        if (previous && typeof presentation.previousDisabled === 'boolean') {
+            previous.disabled = presentation.previousDisabled;
+        }
+        if (next && typeof presentation.nextDisabled === 'boolean') {
+            next.disabled = presentation.nextDisabled;
+        }
+        if (latest && typeof presentation.latestDisabled === 'boolean') {
+            latest.disabled = presentation.latestDisabled;
+        }
+        if (working && typeof presentation.workingHidden === 'boolean') {
+            working.hidden = presentation.workingHidden;
+        }
+    }
+
     // Stash the live conversation as a detached frame before a session
     // switch resets the viewer state. Only a fully applied page is
     // stashable; the content token is what makes the frame trustworthy.
@@ -1832,6 +1992,7 @@
             scrollTop: scrollTop,
             anchor: anchor,
             followingEnd: followingEnd,
+            presentation: captureFramePresentation(),
             selectedInteractionId: restoreTarget
                 ? restoreTarget.interactionId
                 : undefined,
@@ -1868,6 +2029,7 @@
         if (outgoing) {
             // A rapid B -> C handoff arrived while B was only a preview.
             // Put the actual A document back before stashing it under A.
+            restoreFramePresentation(outgoing);
             messages.replaceChildren.apply(messages, outgoing.nodes);
         }
         frameCache.set(previewFrame.key, previewFrame.frame);
@@ -1900,6 +2062,10 @@
             return false;
         }
         previewFrame = { key: key, frame: frame };
+        // A preflight is visual only. Its cached transcript/header may be
+        // shown immediately, but the live cursors and reconciliation maps
+        // remain owned by the authoritative session until its page applies.
+        restoreFramePresentation(frame);
         messages.replaceChildren.apply(messages, frame.nodes);
         if (frame.followingEnd) {
             reconcileController.scrollToEnd();
@@ -1939,6 +2105,7 @@
         state.messageIds = frame.messageIds;
         state.messageSignatures = frame.messageSignatures;
         state.worklogExpanded = frame.worklogExpanded;
+        restoreFramePresentation(frame);
     }
 
     function acknowledgePage(message) {

--- a/src/webview/conversationViewerScripts.js
+++ b/src/webview/conversationViewerScripts.js
@@ -392,6 +392,11 @@
     // speculation resumes it instead of incorrectly making the old document
     // interactive while its Host transition is still pending.
     var preflightLoadingRestore;
+    // Telemetry belongs to the authoritative subscription and can therefore
+    // describe a different provider/model than a cached preview. Mask only
+    // those target-specific values while keeping the surrounding toolbar
+    // (position, comments, and controls) stable and usable for reading.
+    var preflightTelemetryPresentation;
     // Detached conversation frames keyed by session: switching back to a
     // session whose content token is unchanged reattaches the already-built
     // DOM — no HTML transfer, sanitize, parse, or reconcile at all. Bounded
@@ -1261,8 +1266,10 @@
                     framePreview: document.body.getAttribute(
                         'data-conversation-frame-preview'
                     ) === 'true',
+                    telemetryMasked: !!preflightTelemetryPresentation,
                 };
             }
+            hideTelemetryForPreflight();
         } else if (loadingPreflight) {
             if (message.subscriptionGeneration < loadingGeneration) {
                 // A still-running older Host load must not displace a newer
@@ -1359,6 +1366,9 @@
                 document.body.removeAttribute('data-conversation-frame-preview');
             }
             status.textContent = 'Loading conversation…';
+            if (!restore.telemetryMasked) {
+                restoreTelemetryAfterPreflight();
+            }
             return;
         }
         clearConversationLoading();
@@ -1375,12 +1385,54 @@
         loadingStatusText = undefined;
         loadingPreflight = false;
         preflightLoadingRestore = undefined;
+        restoreTelemetryAfterPreflight();
         document.body.removeAttribute('data-conversation-loading');
         document.body.removeAttribute('data-conversation-frame-preview');
         document.body.removeAttribute('aria-busy');
         document.body.removeAttribute('aria-disabled');
         messages.removeAttribute('aria-busy');
         // The applied page recomputes the status line right below.
+    }
+
+    function hideTelemetryForPreflight() {
+        if (preflightTelemetryPresentation) {
+            return;
+        }
+        preflightTelemetryPresentation = [
+            telemetryProvider,
+            telemetryModel,
+            telemetryContext,
+            telemetryLimits,
+        ].filter(function (element) {
+            return !!element;
+        }).map(function (element) {
+            var presentation = {
+                element: element,
+                ariaHidden: element.getAttribute('aria-hidden'),
+                visibility: element.style.visibility,
+            };
+            element.style.visibility = 'hidden';
+            element.setAttribute('aria-hidden', 'true');
+            return presentation;
+        });
+    }
+
+    function restoreTelemetryAfterPreflight() {
+        if (!preflightTelemetryPresentation) {
+            return;
+        }
+        preflightTelemetryPresentation.forEach(function (presentation) {
+            presentation.element.style.visibility = presentation.visibility;
+            if (presentation.ariaHidden === null) {
+                presentation.element.removeAttribute('aria-hidden');
+            } else {
+                presentation.element.setAttribute(
+                    'aria-hidden',
+                    presentation.ariaHidden
+                );
+            }
+        });
+        preflightTelemetryPresentation = undefined;
     }
 
     function applySessionGeneration(message) {
@@ -1783,6 +1835,114 @@
             + '\u0001' + target.sessionId;
     }
 
+    // A detached transcript frame is only visually credible when it brings
+    // its identity with it. Before this, a cache-hit preflight replaced beta's
+    // messages while leaving alpha's title/workspace/task in the sticky
+    // header until the slower authoritative page arrived. That mismatch made
+    // an otherwise instant handoff still feel stalled.
+    function captureFramePresentation() {
+        return {
+            displayName: conversationDisplayName
+                ? conversationDisplayName.textContent
+                : undefined,
+            workspaceName: conversationWorkspaceName
+                ? conversationWorkspaceName.textContent
+                : undefined,
+            taskName: conversationTaskName
+                ? conversationTaskName.textContent
+                : undefined,
+            taskNameHidden: conversationTaskName
+                ? conversationTaskName.hidden
+                : undefined,
+            taskSeparatorHidden: conversationTaskSeparator
+                ? conversationTaskSeparator.hidden
+                : undefined,
+            positionText: position ? position.textContent : undefined,
+            positionTitle: position ? position.getAttribute('title') : undefined,
+            positionAriaLabel: position
+                ? position.getAttribute('aria-label')
+                : undefined,
+            positionTooltip: position
+                ? position.getAttribute('data-tooltip')
+                : undefined,
+            previousDisabled: previous ? previous.disabled : undefined,
+            nextDisabled: next ? next.disabled : undefined,
+            latestDisabled: latest ? latest.disabled : undefined,
+            workingHidden: working ? working.hidden : undefined,
+        };
+    }
+
+    function restoreOptionalAttribute(element, name, value) {
+        if (!element) {
+            return;
+        }
+        if (typeof value === 'string') {
+            element.setAttribute(name, value);
+        } else {
+            element.removeAttribute(name);
+        }
+    }
+
+    function restoreFramePresentation(frame) {
+        var presentation = frame && frame.presentation;
+        if (!presentation) {
+            return;
+        }
+        if (conversationDisplayName
+            && typeof presentation.displayName === 'string') {
+            conversationDisplayName.textContent = presentation.displayName;
+        }
+        if (conversationWorkspaceName
+            && typeof presentation.workspaceName === 'string') {
+            conversationWorkspaceName.textContent = presentation.workspaceName;
+        }
+        if (conversationTaskName) {
+            if (typeof presentation.taskName === 'string') {
+                conversationTaskName.textContent = presentation.taskName;
+            }
+            if (typeof presentation.taskNameHidden === 'boolean') {
+                conversationTaskName.hidden = presentation.taskNameHidden;
+            }
+        }
+        if (conversationTaskSeparator
+            && typeof presentation.taskSeparatorHidden === 'boolean') {
+            conversationTaskSeparator.hidden = presentation.taskSeparatorHidden;
+        }
+        if (position && typeof presentation.positionText === 'string') {
+            var value = position.querySelector(
+                '[data-conversation-position-value]'
+            );
+            if (value) {
+                value.textContent = presentation.positionText;
+            } else {
+                position.textContent = presentation.positionText;
+            }
+            restoreOptionalAttribute(position, 'title', presentation.positionTitle);
+            restoreOptionalAttribute(
+                position,
+                'aria-label',
+                presentation.positionAriaLabel
+            );
+            restoreOptionalAttribute(
+                position,
+                'data-tooltip',
+                presentation.positionTooltip
+            );
+        }
+        if (previous && typeof presentation.previousDisabled === 'boolean') {
+            previous.disabled = presentation.previousDisabled;
+        }
+        if (next && typeof presentation.nextDisabled === 'boolean') {
+            next.disabled = presentation.nextDisabled;
+        }
+        if (latest && typeof presentation.latestDisabled === 'boolean') {
+            latest.disabled = presentation.latestDisabled;
+        }
+        if (working && typeof presentation.workingHidden === 'boolean') {
+            working.hidden = presentation.workingHidden;
+        }
+    }
+
     // Stash the live conversation as a detached frame before a session
     // switch resets the viewer state. Only a fully applied page is
     // stashable; the content token is what makes the frame trustworthy.
@@ -1832,6 +1992,7 @@
             scrollTop: scrollTop,
             anchor: anchor,
             followingEnd: followingEnd,
+            presentation: captureFramePresentation(),
             selectedInteractionId: restoreTarget
                 ? restoreTarget.interactionId
                 : undefined,
@@ -1868,6 +2029,7 @@
         if (outgoing) {
             // A rapid B -> C handoff arrived while B was only a preview.
             // Put the actual A document back before stashing it under A.
+            restoreFramePresentation(outgoing);
             messages.replaceChildren.apply(messages, outgoing.nodes);
         }
         frameCache.set(previewFrame.key, previewFrame.frame);
@@ -1900,6 +2062,10 @@
             return false;
         }
         previewFrame = { key: key, frame: frame };
+        // A preflight is visual only. Its cached transcript/header may be
+        // shown immediately, but the live cursors and reconciliation maps
+        // remain owned by the authoritative session until its page applies.
+        restoreFramePresentation(frame);
         messages.replaceChildren.apply(messages, frame.nodes);
         if (frame.followingEnd) {
             reconcileController.scrollToEnd();
@@ -1939,6 +2105,7 @@
         state.messageIds = frame.messageIds;
         state.messageSignatures = frame.messageSignatures;
         state.worklogExpanded = frame.worklogExpanded;
+        restoreFramePresentation(frame);
     }
 
     function acknowledgePage(message) {

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -1305,19 +1305,21 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 previews a cached session befor
         outline: [{
             interactionId: `${marker}-input`,
             userPreview: marker,
-            responseState: 'complete',
+            responseState: marker === 'alpha' ? 'inProgress' : 'complete',
         }],
         selectedInteractionId: `${marker}-input`,
-        selectedInput: 1,
-        totalInputs: 1,
-        previousCursor: undefined,
-        nextCursor: undefined,
+        selectedInput: marker === 'beta' ? 2 : 1,
+        totalInputs: marker === 'beta' ? 5 : 3,
+        previousCursor: marker === 'beta' ? 'previous' : undefined,
+        nextCursor: 'next',
         target: {
             projectId: 'project-1',
             provider: 'codex',
             sessionId,
             interactionId: `${marker}-input`,
             displayName: `${marker} session`,
+            workspaceName: `${marker} workspace`,
+            ...(marker === 'beta' ? { taskName: 'beta task' } : {}),
         },
         comments: { revision: 0, comments: [] },
         projectComments: { revision: 0, comments: [] },
@@ -1348,6 +1350,19 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 previews a cached session befor
     // switch. The following loading notice must reattach beta immediately,
     // before any Host page for generation five is delivered.
     await sendPage(page, sessionPage(4, 'session-alpha', 'alpha', 'sig-alpha'));
+    await page.evaluate(() => {
+        document.querySelector('[data-conversation-telemetry]').hidden = false;
+        [
+            '[data-telemetry-provider]',
+            '[data-telemetry-model]',
+            '[data-telemetry-context]',
+            '[data-telemetry-limits]',
+        ].forEach((selector, index) => {
+            const element = document.querySelector(selector);
+            element.hidden = false;
+            element.textContent = `alpha telemetry ${index}`;
+        });
+    });
     await sendPage(page, loadingNotice(5, 'session-beta', true));
     await page.evaluate(() =>
         document.querySelector('[data-preview-control]').click()
@@ -1390,6 +1405,37 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 previews a cached session befor
         preview: document.body.getAttribute('data-conversation-frame-preview'),
         ariaBusy: document.body.getAttribute('aria-busy'),
         ariaDisabled: document.body.getAttribute('aria-disabled'),
+        displayName: document.querySelector('[data-conversation-display-name]')
+            .textContent,
+        workspaceName: document.querySelector('[data-conversation-workspace-name]')
+            .textContent,
+        taskName: document.querySelector('[data-conversation-task-name]')
+            .textContent,
+        taskNameHidden: document.querySelector('[data-conversation-task-name]')
+            .hidden,
+        taskSeparatorHidden: document.querySelector(
+            '[data-conversation-task-separator]'
+        ).hidden,
+        position: document.querySelector('[data-conversation-position]')
+            .textContent,
+        previousDisabled: document.querySelector('[data-action="previous"]')
+            .disabled,
+        nextDisabled: document.querySelector('[data-action="next"]').disabled,
+        latestDisabled: document.querySelector('[data-action="latest"]')
+            .disabled,
+        workingHidden: document.querySelector('[data-conversation-working]')
+            .hidden,
+        telemetryHidden: document.querySelector('[data-conversation-telemetry]')
+            .hidden,
+        telemetryPresentation: [
+            '[data-telemetry-provider]',
+            '[data-telemetry-model]',
+            '[data-telemetry-context]',
+            '[data-telemetry-limits]',
+        ].map(selector => {
+            const element = document.querySelector(selector);
+            return [element.style.visibility, element.getAttribute('aria-hidden')];
+        }),
         clickCount: window.__previewControlClicks,
     })), {
         content: 'betabeta action',
@@ -1399,6 +1445,23 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 previews a cached session befor
         preview: 'true',
         ariaBusy: 'true',
         ariaDisabled: 'true',
+        displayName: 'beta session',
+        workspaceName: 'beta workspace',
+        taskName: 'beta task',
+        taskNameHidden: false,
+        taskSeparatorHidden: false,
+        position: 'Input 2 of 5',
+        previousDisabled: false,
+        nextDisabled: false,
+        latestDisabled: false,
+        workingHidden: true,
+        telemetryHidden: false,
+        telemetryPresentation: [
+            ['hidden', 'true'],
+            ['hidden', 'true'],
+            ['hidden', 'true'],
+            ['hidden', 'true'],
+        ],
         clickCount: 0,
     });
     assert.deepEqual(loadingKeyboardGate, {
@@ -1431,9 +1494,84 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 previews a cached session befor
         loading: document.body.getAttribute('data-conversation-loading'),
         preview: document.body.getAttribute('data-conversation-frame-preview'),
         ariaBusy: document.body.getAttribute('aria-busy'),
+        displayName: document.querySelector('[data-conversation-display-name]')
+            .textContent,
+        workspaceName: document.querySelector('[data-conversation-workspace-name]')
+            .textContent,
+        taskName: document.querySelector('[data-conversation-task-name]')
+            .textContent,
+        taskNameHidden: document.querySelector('[data-conversation-task-name]')
+            .hidden,
+        taskSeparatorHidden: document.querySelector(
+            '[data-conversation-task-separator]'
+        ).hidden,
+        position: document.querySelector('[data-conversation-position]')
+            .textContent,
+        previousDisabled: document.querySelector('[data-action="previous"]')
+            .disabled,
+        nextDisabled: document.querySelector('[data-action="next"]').disabled,
+        latestDisabled: document.querySelector('[data-action="latest"]')
+            .disabled,
+        workingHidden: document.querySelector('[data-conversation-working]')
+            .hidden,
+        telemetryHidden: document.querySelector('[data-conversation-telemetry]')
+            .hidden,
+        telemetryPresentation: [
+            '[data-telemetry-provider]',
+            '[data-telemetry-model]',
+            '[data-telemetry-context]',
+            '[data-telemetry-limits]',
+        ].map(selector => {
+            const element = document.querySelector(selector);
+            return [element.style.visibility, element.getAttribute('aria-hidden')];
+        }),
     })), {
         content: 'alpha', loading: null, preview: null, ariaBusy: null,
+        displayName: 'alpha session',
+        workspaceName: 'alpha workspace',
+        taskName: '',
+        taskNameHidden: true,
+        taskSeparatorHidden: true,
+        position: 'Input 1 of 3',
+        previousDisabled: true,
+        nextDisabled: false,
+        latestDisabled: false,
+        workingHidden: false,
+        telemetryHidden: false,
+        telemetryPresentation: [
+            ['', null],
+            ['', null],
+            ['', null],
+            ['', null],
+        ],
     }, 'a cancelled preflight restores the previous interactive conversation');
+
+    // B can be adopted as an authoritative (but still pending) target before
+    // another cached preview C covers it. Cancelling C must retain B's
+    // telemetry mask: the only values available until B's page arrives still
+    // belong to alpha.
+    await sendPage(page, loadingNotice(7, 'session-beta', true));
+    await sendPage(page, loadingNotice(7, 'session-beta'));
+    await sendPage(page, loadingNotice(8, 'session-alpha', true));
+    await sendPage(page, {
+        type: 'conversation-viewer-loading-cancel',
+        version: 1,
+        subscriptionGeneration: 8,
+        target: { projectId: 'project-1', provider: 'codex', sessionId: 'session-alpha' },
+    });
+    assert.deepEqual(await page.evaluate(() => ({
+        loading: document.body.getAttribute('data-conversation-loading'),
+        telemetryProviderVisibility: document.querySelector(
+            '[data-telemetry-provider]'
+        ).style.visibility,
+    })), {
+        loading: 'true',
+        telemetryProviderVisibility: 'hidden',
+    }, 'cancelling a nested preflight keeps the covered loading target masked');
+    await sendPage(page, sessionPage(7, 'session-beta', 'beta', 'sig-beta'));
+    assert.equal(await page.evaluate(() => document.querySelector(
+        '[data-telemetry-provider]'
+    ).style.visibility), '', 'the authoritative page releases the telemetry mask');
 });
 
 test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 preserves cached frames across rapid preview handoffs', async t => {
@@ -4860,6 +4998,25 @@ test('CONVERSATION-OUTLINE-NAVIGATION-001 keeps every side-panel view usable acr
                 + '        scheduleHistoryLoadWatchdog(state.earlierPageRequestId);\n',
             "        state.earlierPageStatus = 'Loading earlier messages.';\n"
         )
+        // Remove this presentation-only masking before the older preflight
+        // protocol transforms below, whose exact source shapes it would
+        // otherwise interrupt.
+        .replace(
+            '    // Telemetry belongs to the authoritative subscription and can therefore\n'
+                + '    // describe a different provider/model than a cached preview. Mask only\n'
+                + '    // those target-specific values while keeping the surrounding toolbar\n'
+                + '    // (position, comments, and controls) stable and usable for reading.\n'
+                + '    var preflightTelemetryPresentation;\n',
+            ''
+        )
+        .replace('            hideTelemetryForPreflight();\n', '')
+        .replaceAll('            restoreTelemetryAfterPreflight();\n', '')
+        .replaceAll('        restoreTelemetryAfterPreflight();\n', '')
+        .replace('                    telemetryMasked: !!preflightTelemetryPresentation,\n', '')
+        .replace(
+            /\n    function hideTelemetryForPreflight\(\) \{[\s\S]*?\n    \}\n\n    function restoreTelemetryAfterPreflight\(\) \{[\s\S]*?\n    \}\n(?=\n    function applySessionGeneration)/,
+            ''
+        )
         // Normalize the speculative preflight/cancel protocol back to the
         // previous cache-preview script. Older Webviews safely ignore these
         // outbound Host notices, but their historical fixture must remain
@@ -5164,6 +5321,62 @@ test('CONVERSATION-OUTLINE-NAVIGATION-001 keeps every side-panel view usable acr
             '        while ((frameCache.size > FRAME_CACHE_LIMIT\n'
                 + '                || frameCacheNodes > FRAME_CACHE_NODE_BUDGET)\n'
                 + '            && frameCache.size > 1) {\n'
+        )
+        // Masking target-specific telemetry during a speculative preview is
+        // presentation-only. Strip it together with cached-frame identity
+        // capture before deriving the byte-identical previous Viewer.
+        .replace(
+            '    // Telemetry belongs to the authoritative subscription and can therefore\n'
+                + '    // describe a different provider/model than a cached preview. Mask only\n'
+                + '    // those target-specific values while keeping the surrounding toolbar\n'
+                + '    // (position, comments, and controls) stable and usable for reading.\n'
+                + '    var preflightTelemetryPresentation;\n',
+            ''
+        )
+        .replace('            hideTelemetryForPreflight();\n', '')
+        .replaceAll('            restoreTelemetryAfterPreflight();\n', '')
+        .replaceAll('        restoreTelemetryAfterPreflight();\n', '')
+        .replace('                    telemetryMasked: !!preflightTelemetryPresentation,\n', '')
+        .replace(
+            /\n    function hideTelemetryForPreflight\(\) \{[\s\S]*?\n    \}\n\n    function restoreTelemetryAfterPreflight\(\) \{[\s\S]*?\n    \}\n(?=\n    function applySessionGeneration)/,
+            ''
+        )
+        // A cached frame now preserves the sticky visual identity as well as
+        // its transcript. Remove that presentation-only addition before
+        // deriving the previous Viewer fixture.
+        .replace(
+            /\n    \/\/ A detached transcript frame is only visually credible[\s\S]*?\n    \}\n(?=\n    \/\/ Stash the live conversation)/,
+            ''
+        )
+        .replace(
+            '            presentation: captureFramePresentation(),\n',
+            ''
+        )
+        .replace(
+            '            restoreFramePresentation(outgoing);\n'
+                + '            messages.replaceChildren.apply(messages, outgoing.nodes);\n'
+                + '        }\n'
+                + '        frameCache.set(previewFrame.key, previewFrame.frame);\n',
+            '            messages.replaceChildren.apply(messages, outgoing.nodes);\n'
+                + '        }\n'
+                + '        frameCache.set(previewFrame.key, previewFrame.frame);\n'
+        )
+        .replace(
+            '        previewFrame = { key: key, frame: frame };\n'
+                + '        // A preflight is visual only. Its cached transcript/header may be\n'
+                + '        // shown immediately, but the live cursors and reconciliation maps\n'
+                + '        // remain owned by the authoritative session until its page applies.\n'
+                + '        restoreFramePresentation(frame);\n'
+                + '        messages.replaceChildren.apply(messages, frame.nodes);\n'
+                + '        if (frame.followingEnd) {\n',
+            '        previewFrame = { key: key, frame: frame };\n'
+                + '        messages.replaceChildren.apply(messages, frame.nodes);\n'
+                + '        if (frame.followingEnd) {\n'
+        )
+        .replace(
+            '        state.worklogExpanded = frame.worklogExpanded;\n'
+                + '        restoreFramePresentation(frame);\n',
+            '        state.worklogExpanded = frame.worklogExpanded;\n'
         )
         // Undo the cached-frame preview before stepping back through the
         // historical fixtures. Previewing is deliberately non-authoritative:


### PR DESCRIPTION
## Summary

- Restore the cached target’s visible header, position, navigation, and Working state during preflight.
- Mask stale target-specific telemetry without collapsing the toolbar, including nested preview rollback.
- Keep cached previews presentation-only so Host-owned Viewer state remains authoritative.

## Verification

- `npm run test-compile`
- `node --test tests/browser/conversationViewer.test.js`
- `node --test tests/integration/dashboard/conversationOpenLatest.test.js`
- `node scripts/run-dashboard-webview-checks.js`
- `git diff --check`

## Skill harvest

No skill change: the task-local retries were feature-test fixture mistakes caught by the existing review and final-verification workflow, which already prescribes the needed prevention.

## Owner approvals

```text
approve 00d6a7149b531ab48d04eb129f4ae4e6835b7209
```

<!-- Trigger Verify after ready-for-review. -->