### PR TITLE
perf: progressively render heavy conversations

### DIFF
--- a/src/aiSessions/conversation/viewer.ts
+++ b/src/aiSessions/conversation/viewer.ts
@@ -387,6 +387,10 @@ export interface ConversationViewerApplicationTiming {
     applicationMs: number;
     /** User target load to the first correlated Webview application. */
     loadMs?: number;
+    /** Bytes of HTML carried by the actual Host-to-Webview delivery (zero for a frame/delta reuse). */
+    contentBytes: number;
+    /** Whether the first visible page deferred older history for backfill. */
+    progressive: boolean;
 }
 
 export class ConversationViewer implements ConversationViewerApi {
@@ -489,6 +493,8 @@ export class ConversationViewer implements ConversationViewerApi {
         updateKind: ConversationViewerPageMessage['updateKind'];
         delivery: 'document' | 'message';
         publishedAt: number;
+        contentBytes: number;
+        progressive: boolean;
     };
     private pendingTargetLoadTiming?: {
         subscriptionGeneration: number;
@@ -2897,7 +2903,13 @@ export class ConversationViewer implements ConversationViewerApi {
                     : publication;
         let delivered = false;
         try {
-            this.recordPublicationDelivery(publication, 'message');
+            this.recordPublicationDelivery(
+                publication,
+                'message',
+                wire.html === undefined
+                    ? Buffer.byteLength(wire.tailHtml || '', 'utf8')
+                    : Buffer.byteLength(wire.html, 'utf8')
+            );
             delivered = await panel.webview.postMessage(wire);
         } catch (_error) {
             delivered = false;
@@ -3004,8 +3016,12 @@ export class ConversationViewer implements ConversationViewerApi {
             return undefined;
         }
         const allMessages = this.messages();
-        const deferredCount = deferredConversationMessageCount(allMessages);
-        if (deferredCount <= CONVERSATION_PROGRESSIVE_CHUNK_MIN_DEFERRED) {
+        const progressivePlan = createProgressiveRenderPlan(
+            allMessages,
+            this.showThinking()
+        );
+        const deferredCount = progressivePlan.deferredCount;
+        if (!shouldProgressivelyRenderPlan(progressivePlan)) {
             return undefined;
         }
         const interactionInfo = this.createInteractionInfo();
@@ -3028,9 +3044,10 @@ export class ConversationViewer implements ConversationViewerApi {
         }
         const slices = conversationHistoryChunkSlices(
             allMessages.slice(0, deferredCount),
-            CONVERSATION_PROGRESSIVE_CHUNK_SIZE
+            CONVERSATION_PROGRESSIVE_CHUNK_SIZE,
+            this.showThinking()
         );
-        if (slices.length < 2) {
+        if (!slices.length) {
             return undefined;
         }
         const chunks: { html: string; htmlSignature: string }[] = [];
@@ -3295,7 +3312,8 @@ export class ConversationViewer implements ConversationViewerApi {
 
     private recordPublicationDelivery(
         publication: ConversationViewerPageMessage,
-        delivery: ConversationViewerApplicationTiming['delivery']
+        delivery: ConversationViewerApplicationTiming['delivery'],
+        contentBytes = Buffer.byteLength(publication.html || '', 'utf8')
     ): void {
         this.pendingPublicationTiming = {
             subscriptionGeneration: publication.subscriptionGeneration,
@@ -3304,6 +3322,11 @@ export class ConversationViewer implements ConversationViewerApi {
             updateKind: publication.updateKind,
             delivery,
             publishedAt: this.now(),
+            contentBytes,
+            progressive: this.progressiveContentIncomplete?.generation
+                === publication.subscriptionGeneration
+                && this.progressiveContentIncomplete.partialHtmlSignature
+                    === publication.htmlSignature,
         };
         this.schedulePublicationAckTimeout(publication);
     }
@@ -3433,6 +3456,8 @@ export class ConversationViewer implements ConversationViewerApi {
                 updateKind: timing.updateKind,
                 delivery: timing.delivery,
                 applicationMs: Math.max(0, now - timing.publishedAt),
+                contentBytes: timing.contentBytes,
+                progressive: timing.progressive,
                 ...(loadMs === undefined ? {} : { loadMs }),
             });
         } catch (_error) {
@@ -3845,7 +3870,10 @@ export class ConversationViewer implements ConversationViewerApi {
         const allMessages = this.messages();
         const deferredMessageCount = recentOnly && projection.atLatest
             && !projection.partial
-            ? deferredConversationMessageCount(allMessages)
+            ? createProgressiveRenderPlan(
+                allMessages,
+                this.showThinking()
+            ).deferredCount
             : 0;
         const rendered = renderMessages(
             deferredMessageCount
@@ -3905,16 +3933,13 @@ export class ConversationViewer implements ConversationViewerApi {
 
     private shouldProgressivelyRender(): boolean {
         const projection = this.outlineController.createPublication();
-        return projection.atLatest
-            && !projection.partial
-            // A small deferred prefix used to paint a partial page, wait for
-            // its receipt, and immediately repaint the full transcript. That
-            // two-step path made ordinary 25+ message conversations visibly
-            // pause on “Loading earlier messages” without reducing work.
-            // Enter the progressive protocol only when it can send at least
-            // two bounded history chunks.
-            && deferredConversationMessageCount(this.messages())
-                > CONVERSATION_PROGRESSIVE_CHUNK_MIN_DEFERRED;
+        if (!projection.atLatest || projection.partial) {
+            return false;
+        }
+        return shouldProgressivelyRenderPlan(createProgressiveRenderPlan(
+            this.messages(),
+            this.showThinking()
+        ));
     }
 
     private createInteractionInfo(): Map<string, {
@@ -4486,27 +4511,139 @@ function renderMessages(
 
 const CONVERSATION_PROGRESSIVE_RENDER_THRESHOLD = 24;
 const CONVERSATION_PROGRESSIVE_RENDER_RECENT_COUNT = 12;
+// A single page can contain only a few messages yet still be expensive to
+// parse and lay out (for example, a tool result or a long reasoning turn).
+// In that case rendering the most recent conversational window first is a
+// material first-paint win even when the deferred history is small.
+const CONVERSATION_PROGRESSIVE_RENDER_BYTES_THRESHOLD = 96 * 1024;
+// The first visible window deliberately has its own smaller byte budget.
+// Keeping the newest complete interaction group is more useful than an
+// arbitrary character truncation, while capping adjacent older groups keeps
+// a heavy page from monopolising the Webview main thread before first paint.
+const CONVERSATION_PROGRESSIVE_RECENT_BYTES_BUDGET = 64 * 1024;
 // Backfill slices above the visible recent window. Small deferred windows
 // are cheaper to deliver as one full refresh; larger ones arrive in
 // ack-paced slices so no single Webview task renders the whole history.
 const CONVERSATION_PROGRESSIVE_CHUNK_SIZE = 24;
 const CONVERSATION_PROGRESSIVE_CHUNK_MIN_DEFERRED = 48;
 
-function deferredConversationMessageCount(
-    messages: readonly ConversationMessage[]
-): number {
-    if (messages.length <= CONVERSATION_PROGRESSIVE_RENDER_THRESHOLD) {
-        return 0;
+interface ConversationProgressiveRenderPlan {
+    deferredCount: number;
+    renderedBytes: number;
+}
+
+function createProgressiveRenderPlan(
+    messages: readonly ConversationMessage[],
+    showThinking: boolean
+): ConversationProgressiveRenderPlan {
+    const messageBytes = messages.map(message =>
+        renderedConversationMessageBytes(message, showThinking)
+    );
+    const totalBytes = messageBytes.reduce((total, bytes) => total + bytes, 0);
+    const visibleMessageCount = messageBytes.filter(bytes => bytes > 0).length;
+    if (visibleMessageCount <= CONVERSATION_PROGRESSIVE_RENDER_THRESHOLD
+        && totalBytes < CONVERSATION_PROGRESSIVE_RENDER_BYTES_THRESHOLD) {
+        return { deferredCount: 0, renderedBytes: totalBytes };
     }
     // Do not split one interaction's message group (tool/progress/thinking
     // entries can precede its final assistant response).
-    let firstVisible = messages.length - CONVERSATION_PROGRESSIVE_RENDER_RECENT_COUNT;
-    const interactionId = messages[firstVisible]?.interactionId;
-    while (firstVisible > 0
-        && messages[firstVisible - 1].interactionId === interactionId) {
-        firstVisible -= 1;
+    let firstVisible = interactionGroupStart(messages, Math.max(
+        0,
+        messages.length - CONVERSATION_PROGRESSIVE_RENDER_RECENT_COUNT
+    ));
+    if (totalBytes >= CONVERSATION_PROGRESSIVE_RENDER_BYTES_THRESHOLD) {
+        let visibleBytes = 0;
+        let byteBoundedStart = messages.length;
+        while (byteBoundedStart > 0) {
+            const groupStart = interactionGroupStart(
+                messages,
+                byteBoundedStart - 1
+            );
+            const groupBytes = sumMessageBytes(
+                messageBytes,
+                groupStart,
+                byteBoundedStart
+            );
+            // Always retain the latest complete interaction group, even if
+            // that one group exceeds the budget. It is the selected/latest
+            // conversational context and cannot be split safely here.
+            if (byteBoundedStart !== messages.length
+                && visibleBytes + groupBytes
+                    > CONVERSATION_PROGRESSIVE_RECENT_BYTES_BUDGET) {
+                break;
+            }
+            visibleBytes += groupBytes;
+            byteBoundedStart = groupStart;
+        }
+        firstVisible = Math.max(firstVisible, byteBoundedStart);
     }
-    return firstVisible;
+    return {
+        deferredCount: firstVisible,
+        renderedBytes: totalBytes,
+    };
+}
+
+function interactionGroupStart(
+    messages: readonly ConversationMessage[],
+    index: number
+): number {
+    let start = index;
+    const interactionId = messages[start]?.interactionId;
+    while (start > 0 && messages[start - 1].interactionId === interactionId) {
+        start -= 1;
+    }
+    return start;
+}
+
+function renderedConversationMessageBytes(
+    message: ConversationMessage,
+    showThinking: boolean
+): number {
+    if (message.role === 'thinking' && !showThinking) {
+        return 0;
+    }
+    // This intentionally estimates the rendered source instead of
+    // serialising the full message array. It keeps heavy hidden Thinking
+    // payloads out of the decision and avoids a multi-megabyte temporary
+    // allocation on the first-paint critical path.
+    return Buffer.byteLength(
+        `${message.id}\u0001${message.interactionId}\u0001${message.role}\u0001${message.markdown}`,
+        'utf8'
+    ) + optionalStructuredBytes(message.tool)
+        + optionalStructuredBytes(message.thinking)
+        + optionalStructuredBytes(message.plan)
+        + optionalStructuredBytes(message.question);
+}
+
+function optionalStructuredBytes(value: unknown): number {
+    return value === undefined
+        ? 0
+        : Buffer.byteLength(JSON.stringify(value), 'utf8');
+}
+
+function sumMessageBytes(
+    messageBytes: readonly number[],
+    start: number,
+    end: number
+): number {
+    let total = 0;
+    for (let index = start; index < end; index++) {
+        total += messageBytes[index] || 0;
+    }
+    return total;
+}
+
+function shouldProgressivelyRenderPlan(
+    plan: ConversationProgressiveRenderPlan
+): boolean {
+    if (!plan.deferredCount) {
+        return false;
+    }
+    // Preserve the old multi-chunk behaviour for very large histories, and
+    // extend it to heavy-but-shorter pages where the all-at-once Webview DOM
+    // application dominates switch latency.
+    return plan.deferredCount > CONVERSATION_PROGRESSIVE_CHUNK_MIN_DEFERRED
+        || plan.renderedBytes >= CONVERSATION_PROGRESSIVE_RENDER_BYTES_THRESHOLD;
 }
 
 /**
@@ -4516,17 +4653,28 @@ function deferredConversationMessageCount(
  */
 function conversationHistoryChunkSlices(
     messages: ConversationMessage[],
-    chunkSize: number
+    chunkSize: number,
+    showThinking: boolean
 ): ConversationMessage[][] {
+    const messageBytes = messages.map(message =>
+        renderedConversationMessageBytes(message, showThinking)
+    );
     const oldestFirst: ConversationMessage[][] = [];
     let end = messages.length;
     while (end > 0) {
-        let start = Math.max(0, end - chunkSize);
-        const interactionId = messages[start]?.interactionId;
-        // Do not split one interaction's message group across chunks.
-        while (start > 0
-            && messages[start - 1].interactionId === interactionId) {
-            start -= 1;
+        let start = end;
+        let chunkBytes = 0;
+        while (start > 0) {
+            const groupStart = interactionGroupStart(messages, start - 1);
+            const groupBytes = sumMessageBytes(messageBytes, groupStart, start);
+            if (start !== end
+                && (end - groupStart > chunkSize
+                    || chunkBytes + groupBytes
+                        > CONVERSATION_PROGRESSIVE_RECENT_BYTES_BUDGET)) {
+                break;
+            }
+            chunkBytes += groupBytes;
+            start = groupStart;
         }
         oldestFirst.unshift(messages.slice(start, end));
         end = start;

--- a/tests/integration/dashboard/conversationViewer.test.js
+++ b/tests/integration/dashboard/conversationViewer.test.js
@@ -220,6 +220,239 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-002 renders a modest latest page in
     ).length, 0, 'the modest page must not wait for a second full refresh');
 });
 
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-002 paints the recent window before backfilling a heavy short page', async () => {
+    const sessionId = 'progressive-heavy-short-page';
+    let now = 10;
+    const timings = [];
+    const interactionIds = Array.from(
+        { length: 30 },
+        (_item, index) => `input-${index + 1}`
+    );
+    const { viewer, panel } = createViewer({
+        now: () => now,
+        onTiming: timing => timings.push(timing),
+        readOutline: async () => outline(sessionId, interactionIds),
+        readPage: async () => page(sessionId, interactionIds[0], 'message', {
+            interactionIds,
+            anchorInteractionId: interactionIds.at(-1),
+            padding: 'x'.repeat(4 * 1024),
+        }),
+    });
+
+    await viewer.open(target(sessionId, interactionIds.at(-1)));
+
+    const partial = decodeInitialPublication(panel.webview.html);
+    assert.match(partial.html, /Loading earlier messages/);
+    assert.doesNotMatch(partial.html, /message-0/);
+    assert.match(partial.html, /message-29/);
+
+    now = 35;
+    await panel.receive({
+        type: 'conversation-viewer-applied',
+        version: 1,
+        subscriptionGeneration: partial.subscriptionGeneration,
+        requestId: partial.requestId,
+        htmlSignature: partial.htmlSignature,
+    });
+    assert.deepEqual(timings, [{
+        source: 'open',
+        updateKind: 'initial',
+        delivery: 'document',
+        applicationMs: 25,
+        contentBytes: Buffer.byteLength(partial.html, 'utf8'),
+        progressive: true,
+        loadMs: 25,
+    }], 'diagnostics must identify the lightweight first paint, without session data');
+    const chunk = panel.postedMessages.filter(message =>
+        message.type === 'conversation-viewer-history-chunk'
+    ).at(-1);
+    assert.ok(chunk, 'the deferred prefix must backfill after the first paint');
+    assert.match(chunk.html, /message-3/);
+    assert.doesNotMatch(chunk.html, /message-0/);
+    assert.doesNotMatch(chunk.html, /message-2/,
+        'a heavy deferred prefix must not return in one long Webview task');
+    let nextChunk = chunk;
+    while (!nextChunk.complete) {
+        await panel.receive({
+            type: 'conversation-viewer-history-chunk-applied',
+            version: 1,
+            subscriptionGeneration: nextChunk.subscriptionGeneration,
+            requestId: nextChunk.requestId,
+            htmlSignature: nextChunk.htmlSignature,
+        });
+        nextChunk = panel.postedMessages.filter(message =>
+            message.type === 'conversation-viewer-history-chunk'
+        ).at(-1);
+    }
+    await panel.receive({
+        type: 'conversation-viewer-history-chunk-applied',
+        version: 1,
+        subscriptionGeneration: nextChunk.subscriptionGeneration,
+        requestId: nextChunk.requestId,
+        htmlSignature: nextChunk.htmlSignature,
+    });
+    const completion = panel.postedMessages.filter(message =>
+        message.type === 'conversation-viewer-page'
+    ).at(-1);
+    assert.equal(completion?.html, undefined,
+        'the final reconciliation must reuse the fully backfilled content');
+    viewer.dispose();
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-002 bounds the first paint of an unusually heavy latest window', async () => {
+    const sessionId = 'progressive-heavy-latest-window';
+    const interactionIds = Array.from(
+        { length: 30 },
+        (_item, index) => `input-${index + 1}`
+    );
+    const { viewer, panel } = createViewer({
+        readOutline: async () => outline(sessionId, interactionIds),
+        readPage: async () => page(sessionId, interactionIds[0], 'message', {
+            interactionIds,
+            anchorInteractionId: interactionIds.at(-1),
+            padding: 'x'.repeat(16 * 1024),
+        }),
+    });
+
+    await viewer.open(target(sessionId, interactionIds.at(-1)));
+
+    const partial = decodeInitialPublication(panel.webview.html);
+    assert.match(partial.html, /message-29/);
+    assert.doesNotMatch(partial.html, /message-26/,
+        'the first paint must stay within its byte budget, not always render twelve messages');
+    viewer.dispose();
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-002 byte-triggers below the count threshold without splitting a visible interaction', async () => {
+    const sessionId = 'progressive-utf8-short-page';
+    const latestInteractionId = 'input-latest';
+    const interactionIds = [
+        ...Array.from({ length: 8 }, (_item, index) => `input-${index}`),
+        latestInteractionId,
+    ];
+    const messages = Array.from({ length: 10 }, (_item, index) => ({
+        id: `message-${index}`,
+        interactionId: index >= 8 ? latestInteractionId : `input-${index}`,
+        role: 'user',
+        markdown: `marker-${index}-${'界'.repeat(10_000)}`,
+    }));
+    const { viewer, panel } = createViewer({
+        readOutline: async () => outline(sessionId, interactionIds),
+        readPage: async () => ({
+            provider: 'codex',
+            sessionId,
+            sourceRevision: 'r1',
+            anchorInteractionId: latestInteractionId,
+            messages,
+            interactionStates: interactionIds.map(interactionId => ({
+                interactionId,
+                responseState: 'complete',
+            })),
+            isStart: true,
+            isEnd: true,
+        }),
+    });
+
+    await viewer.open(target(sessionId, latestInteractionId));
+
+    const partial = decodeInitialPublication(panel.webview.html);
+    assert.match(partial.html, /marker-8-/,
+        'the first member of the final interaction must remain visible');
+    assert.match(partial.html, /marker-9-/,
+        'the final interaction must remain whole at a byte boundary');
+    assert.doesNotMatch(partial.html, /marker-7-/,
+        'a short-by-count but heavy UTF-8 page must defer older history');
+    assert.match(partial.html, /Loading earlier messages/);
+    viewer.dispose();
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-002 ignores hidden Thinking payloads when choosing a first paint', async () => {
+    const sessionId = 'progressive-hidden-thinking';
+    const interactionIds = Array.from(
+        { length: 30 },
+        (_item, index) => `input-${index}`
+    );
+    const { viewer, panel } = createViewer({
+        readOutline: async () => outline(sessionId, interactionIds),
+        readPage: async () => ({
+            provider: 'codex',
+            sessionId,
+            sourceRevision: 'r1',
+            anchorInteractionId: interactionIds.at(-1),
+            messages: interactionIds.map((interactionId, index) => ({
+                id: `thinking-${index}`,
+                interactionId,
+                role: 'thinking',
+                markdown: 'hidden-thinking',
+                thinking: { text: 'x'.repeat(8 * 1024) },
+            })),
+            interactionStates: interactionIds.map(interactionId => ({
+                interactionId,
+                responseState: 'complete',
+            })),
+            isStart: true,
+            isEnd: true,
+        }),
+    });
+
+    await viewer.open(target(sessionId, interactionIds.at(-1)));
+
+    const initial = decodeInitialPublication(panel.webview.html);
+    assert.doesNotMatch(initial.html, /Loading earlier messages/,
+        'hidden Thinking must not create a visible progressive-loading detour');
+    viewer.dispose();
+});
+
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-002 keeps an oversized latest interaction atomic', async () => {
+    const sessionId = 'progressive-oversized-latest-atomic';
+    const latestInteractionId = 'input-latest';
+    const messages = [
+        {
+            id: 'latest-user', interactionId: latestInteractionId,
+            role: 'user', markdown: 'Inspect the long worklog',
+        },
+        ...Array.from({ length: 6 }, (_item, index) => ({
+            id: `latest-tool-${index}`, interactionId: latestInteractionId,
+            role: 'tool', markdown: '',
+            tool: {
+                name: 'Shell', summary: `command-${index}`,
+                detail: 'x'.repeat(16 * 1024),
+            },
+        })),
+        {
+            id: 'latest-answer', interactionId: latestInteractionId,
+            role: 'assistant', markdown: 'Final answer.',
+        },
+    ];
+    const { viewer, panel } = createViewer({
+        readOutline: async () => outline(sessionId, [
+            'input-earlier',
+            latestInteractionId,
+        ]),
+        readPage: async () => ({
+            provider: 'codex', sessionId, sourceRevision: 'r1',
+            anchorInteractionId: latestInteractionId, messages,
+            interactionStates: [{
+                interactionId: latestInteractionId,
+                responseState: 'complete',
+            }],
+            isStart: true, isEnd: true,
+        }),
+    });
+
+    await viewer.open(target(sessionId, latestInteractionId));
+
+    const initial = decodeInitialPublication(panel.webview.html);
+    assert.doesNotMatch(initial.html, /Loading earlier messages/);
+    assert.match(initial.html, /command-0/);
+    assert.match(initial.html, /Final answer/);
+    assert.equal(panel.postedMessages.filter(message =>
+        message.type === 'conversation-viewer-history-chunk'
+    ).length, 0,
+        'a group-derived worklog must never be reconstructed by blind prepends');
+    viewer.dispose();
+});
+
 test('CONVERSATION-LARGE-SESSION-PERFORMANCE-002 completes a recovered recent-message page', async () => {
     const sessionId = 'progressive-recovery';
     const interactionIds = Array.from(
@@ -1671,6 +1904,7 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 patches only the trailing inter
     let revision = 1;
     let tailText = 'answer part';
     let watchCallback;
+    const timings = [];
     const streamingPage = () => ({
         provider: 'codex',
         sessionId,
@@ -1700,6 +1934,7 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 patches only the trailing inter
         isEnd: true,
     });
     const { viewer, panel } = createViewer({
+        onTiming: timing => timings.push(timing),
         watch: (_provider, _sessionId, onChange) => {
             watchCallback = onChange;
             return { dispose() {} };
@@ -1753,6 +1988,11 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 patches only the trailing inter
         requestId: patch.requestId,
         htmlSignature: patch.htmlSignature,
     });
+    assert.equal(timings.at(-1)?.delivery, 'message');
+    assert.equal(timings.at(-1)?.contentBytes,
+        Buffer.byteLength(patch.tailHtml, 'utf8'),
+        'tail timing must count only the HTML that crossed the wire');
+    assert.equal(timings.at(-1)?.progressive, false);
 
     // After the patched receipt, an unchanged refresh omits HTML entirely.
     revision = 3;
@@ -1771,6 +2011,8 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 patches only the trailing inter
         requestId: idle.requestId,
         htmlSignature: idle.htmlSignature,
     });
+    assert.equal(timings.at(-1)?.contentBytes, 0,
+        'an unchanged delta must report no HTML transfer');
 
     // A new interaction changes the prefix: back to a full refresh.
     interactionIds.push('input-4');
@@ -2413,13 +2655,16 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 records target-free timing for 
         requestId: publication.requestId,
         htmlSignature: publication.htmlSignature,
     });
-    assert.deepEqual(timings, [{
+    assert.equal(timings.length, 1);
+    assert.deepEqual(timings[0], {
         source: 'open',
         updateKind: 'initial',
         delivery: 'document',
         applicationMs: 25,
+        contentBytes: Buffer.byteLength(publication.html, 'utf8'),
+        progressive: false,
         loadMs: 25,
-    }]);
+    });
     viewer.dispose();
 });
 
@@ -2576,13 +2821,16 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 records document timing after a
         requestId: publication.requestId,
         htmlSignature: publication.htmlSignature,
     });
-    assert.deepEqual(timings, [{
+    assert.equal(timings.length, 1);
+    assert.deepEqual(timings[0], {
         source: 'follow',
         updateKind: 'initial',
         delivery: 'document',
         applicationMs: 20,
+        contentBytes: Buffer.byteLength(publication.html, 'utf8'),
+        progressive: false,
         loadMs: 20,
-    }]);
+    });
     viewer.dispose();
 });
 
@@ -2644,13 +2892,16 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 records correlated, target-free
         requestId: publication.requestId,
         htmlSignature: publication.htmlSignature,
     });
-    assert.deepEqual(timings, [{
+    assert.equal(timings.length, 1);
+    assert.deepEqual(timings[0], {
         source: 'follow',
         updateKind: 'initial',
         delivery: 'message',
         applicationMs: 15,
+        contentBytes: Buffer.byteLength(publication.html, 'utf8'),
+        progressive: false,
         loadMs: 60,
-    }]);
+    });
     assert.equal('sessionId' in timings[0], false);
     assert.equal('provider' in timings[0], false);
     viewer.dispose();
@@ -5557,7 +5808,9 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 rebuilds a stalled reused-panel
 
 test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 offers a frame restore only for acknowledged session content', async () => {
     let changed = false;
+    const timings = [];
     const { viewer, panel } = createViewer({
+        onTiming: timing => timings.push(timing),
         readOutline: async (_provider, sessionId) => outline(
             sessionId,
             ['input-1', 'input-2'],
@@ -5617,6 +5870,10 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 offers a frame restore only for
 
     // Content changed while away: the switch back must carry full HTML.
     await ack(latest, [frameEntry('session-b', sessionBToken)]);
+    assert.equal(timings.at(-1)?.delivery, 'message');
+    assert.equal(timings.at(-1)?.contentBytes, 0,
+        'a frame restore must report no HTML retransmission');
+    assert.equal(timings.at(-1)?.progressive, false);
     await viewer.follow(target('session-b', 'input-1'));
     latest = lastPage();
     assert.equal(latest.restoreFrame, true,


### PR DESCRIPTION
## Summary

- Render the newest complete interaction groups first for byte-heavy conversation pages, then backfill older groups after Webview acknowledgements.
- Keep interaction groups atomic so worklog structure and incremental signatures remain correct.
- Add delivered-payload timing fields to distinguish full HTML, patches, and frame reuse.

## Verification

- npm run test-compile
- node --test tests/integration/dashboard/conversationViewer.test.js
- npm run lint
- npm run test:behavior-contracts
- git diff --check

## Skill harvest

No skill change: the existing review, verification, and publication workflows already covered the reusable lessons from this change.

## Owner approvals

approve 2cd3c1096f6c088befc81fb3e94217bda6c38149