### PR TITLE
fix: converge stranded progressive conversation history

### DIFF
--- a/.skills/fixing-regressions-with-ci/SKILL.md
+++ b/.skills/fixing-regressions-with-ci/SKILL.md
@@ -62,6 +62,13 @@ Turn every confirmed regression into a CI-owned behavior before changing product
      red run as green. Use `set -o pipefail` or read the stored log.
 7. **Keep the behavior catalog current**
    - In every automated owner file, use literal behavior IDs for the behaviors it owns. After any implementation, owner, or catalog change, run `npm run test:behavior-contracts`.
+   - That command validates catalog→owner only: every entry's owner files
+     exist and cite its ID. It never reads a test for IDs the catalog is
+     missing, so a behavior ID that appears in a test but in no catalog entry
+     passes every required check silently and the behavior ends up owned by
+     nothing. When putting an ID in a test, confirm the reverse direction
+     explicitly: `grep -c '<BEHAVIOR-ID>' docs/testing/behavior-contracts.json`
+     must be non-zero.
    - Classify commits by changed paths and protected behavior, never by a subject prefix. Treat `.skills/` and skill-owner tests as implementation paths.
    - In repositories with both `origin` and `upstream`, pass the intended `--repo <owner/name>` to every `gh pr checks`, `gh run view`, and Actions log command. Do not let local remote ordering select the repository.
 

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -4772,6 +4772,21 @@
     ]
   },
   {
+    "id": "CONVERSATION-LARGE-SESSION-PERFORMANCE-002",
+    "domain": "webview",
+    "title": "Progressively rendered large AI Conversations always converge on their deferred history instead of stranding a loading placeholder",
+    "priority": "P0",
+    "status": "automated",
+    "owners": [
+      "tests/browser/conversationViewer.test.js",
+      "tests/integration/dashboard/conversationViewer.test.js"
+    ],
+    "evidence": [
+      "src/aiSessions/conversation/viewer.ts",
+      "src/webview/conversationViewerScripts.js"
+    ]
+  },
+  {
     "id": "CONVERSATION-VIEWER-USER-EMPHASIS-001",
     "domain": "webview",
     "title": "AI Conversation presents User prompts as dominant full-width blocks",

--- a/src/aiSessions/conversation/viewer.ts
+++ b/src/aiSessions/conversation/viewer.ts
@@ -502,6 +502,15 @@ export class ConversationViewer implements ConversationViewerApi {
     // publication cancels the plan; a lost slice falls back to the normal
     // full-content refresh.
     private progressiveBackfill?: ConversationProgressiveBackfill;
+    // Every path that yields the backfill assumes a superseding load will
+    // publish the full document instead. A load can also be aborted, or
+    // resolve to "nothing changed", and publish nothing at all — which would
+    // leave the reader's deferred-history placeholder with no delivery and no
+    // timer left to retire it. This watchdog belongs to the open
+    // incomplete-content obligation itself, so a yielded backfill always
+    // converges on one full-content refresh.
+    private progressiveObligationTimer?: unknown;
+    private progressiveObligationTimerToken = 0;
     private pendingPublicationTiming?: {
         subscriptionGeneration: number;
         requestId: number;
@@ -1397,6 +1406,7 @@ export class ConversationViewer implements ConversationViewerApi {
         this.clearPublicationAckTimeout();
         this.progressivePublication = undefined;
         this.progressiveContentIncomplete = undefined;
+        this.clearProgressiveObligationWatchdog();
         this.cancelProgressiveBackfill();
         this.pendingPublicationTiming = undefined;
         this.pendingTargetLoadTiming = undefined;
@@ -1519,6 +1529,7 @@ export class ConversationViewer implements ConversationViewerApi {
         this.clearPublicationAckTimeout();
         this.progressivePublication = undefined;
         this.progressiveContentIncomplete = undefined;
+        this.clearProgressiveObligationWatchdog();
         this.cancelProgressiveBackfill();
         this.pendingPublicationTiming = undefined;
         this.pendingTargetLoadTiming = undefined;
@@ -2321,6 +2332,7 @@ export class ConversationViewer implements ConversationViewerApi {
         const subagentDiscoveryGeneration =
             ++this.subagentDiscoveryGeneration;
         const requestId = this.allocateRequestId();
+        const supersededRequestId = this.currentRequestId;
         this.currentRequestId = requestId;
         const previousSelectedInteractionId = this.outlineController.selection;
         const followLatest = updateKind === 'refresh'
@@ -2407,6 +2419,12 @@ export class ConversationViewer implements ConversationViewerApi {
                 if (retainedRevisionMatches
                     && !lifecycleChangedInteractionIds.length
                     && !pagingMetadataChanged) {
+                    // Nothing to publish: hand the request counter back so the
+                    // still-visible publication stays correlatable.
+                    this.releaseUnpublishedRequestId(
+                        requestId,
+                        supersededRequestId
+                    );
                     void this.telemetryController.refresh(
                         target,
                         generation,
@@ -2980,6 +2998,7 @@ export class ConversationViewer implements ConversationViewerApi {
                 !== publication.htmlSignature) {
             this.progressiveContentIncomplete = undefined;
             this.progressivePublication = undefined;
+            this.clearProgressiveObligationWatchdog();
         }
         this.reportPublicationApplication(publication);
         if (this.transitioningGeneration === message.subscriptionGeneration) {
@@ -2995,6 +3014,9 @@ export class ConversationViewer implements ConversationViewerApi {
     ): void {
         if (this.progressivePublication !== publication
             || !this.isCurrentPublication(publication)) {
+            // A superseding load claimed the counter before this receipt
+            // arrived. The obligation stays open, so watch it.
+            this.scheduleProgressiveObligationWatchdog();
             return;
         }
         this.progressivePublication = undefined;
@@ -3074,6 +3096,7 @@ export class ConversationViewer implements ConversationViewerApi {
         const plan = this.progressiveBackfill;
         const panel = this.panel;
         if (!plan || !panel || this.suspended) {
+            this.scheduleProgressiveObligationWatchdog();
             return;
         }
         if (plan.generation !== this.subscriptionGeneration
@@ -3081,6 +3104,7 @@ export class ConversationViewer implements ConversationViewerApi {
             // A newer load or publication owns the request counter now; it
             // supersedes the backfill (its own delivery cancels the plan).
             this.cancelProgressiveBackfill();
+            this.scheduleProgressiveObligationWatchdog();
             return;
         }
         const chunk = this.createNextProgressiveBackfillChunk(plan);
@@ -3181,6 +3205,7 @@ export class ConversationViewer implements ConversationViewerApi {
             // backfill, so the receipt must not allocate ids or publish.
             this.emitDiagnostic('backfill-stale-anchor');
             this.cancelProgressiveBackfill();
+            this.scheduleProgressiveObligationWatchdog();
             return;
         }
         this.clearProgressiveBackfillTimer(plan);
@@ -3212,6 +3237,8 @@ export class ConversationViewer implements ConversationViewerApi {
     private scheduleProgressiveBackfillTimeout(
         plan: ConversationProgressiveBackfill
     ): void {
+        // A slice is now the pending step and carries its own recovery.
+        this.clearProgressiveObligationWatchdog();
         const token = ++plan.timerToken;
         const recover = () => {
             if (token !== plan.timerToken) {
@@ -3270,12 +3297,14 @@ export class ConversationViewer implements ConversationViewerApi {
         this.emitDiagnostic(reason);
         this.cancelProgressiveBackfill();
         if (this.suspended || !this.panel) {
+            this.scheduleProgressiveObligationWatchdog();
             return;
         }
         if (plan.anchorRequestId !== this.currentRequestId) {
             // A newer load owns the request counter; its publication
             // supersedes the backfill, so a recovery refresh would kill it.
             this.emitDiagnostic('backfill-recovery-yielded');
+            this.scheduleProgressiveObligationWatchdog();
             return;
         }
         const requestId = this.allocateRequestId();
@@ -3294,6 +3323,91 @@ export class ConversationViewer implements ConversationViewerApi {
             return;
         }
         this.clearProgressiveBackfillTimer(plan);
+    }
+
+    /**
+     * Arm the open incomplete-content obligation's own watchdog. Safe to call
+     * from any yield path: it no-ops unless a partial page for the current
+     * generation is still waiting for its deferred history. Re-arming on each
+     * yield is intended — the obligation is only ever closed by a full-content
+     * receipt.
+     */
+    private scheduleProgressiveObligationWatchdog(): void {
+        if (this.progressiveContentIncomplete?.generation
+            !== this.subscriptionGeneration
+            || this.suspended
+            || !this.panel) {
+            return;
+        }
+        this.clearProgressiveObligationWatchdog();
+        const generation = this.subscriptionGeneration;
+        const token = ++this.progressiveObligationTimerToken;
+        const recover = () => {
+            if (token !== this.progressiveObligationTimerToken) {
+                return;
+            }
+            this.progressiveObligationTimer = undefined;
+            this.recoverProgressiveObligation(generation);
+        };
+        const handle = this.options.setTimer
+            ? this.options.setTimer(
+                recover,
+                CONVERSATION_LIMITS.viewerPublicationAckTimeoutMs
+            )
+            : setTimeout(
+                recover,
+                CONVERSATION_LIMITS.viewerPublicationAckTimeoutMs
+            );
+        if (token === this.progressiveObligationTimerToken) {
+            this.progressiveObligationTimer = handle;
+        } else if (this.options.clearTimer) {
+            this.options.clearTimer(handle);
+        } else {
+            clearTimeout(handle as NodeJS.Timeout);
+        }
+    }
+
+    private clearProgressiveObligationWatchdog(): void {
+        this.progressiveObligationTimerToken += 1;
+        const timer = this.progressiveObligationTimer;
+        this.progressiveObligationTimer = undefined;
+        if (timer === undefined) {
+            return;
+        }
+        if (this.options.clearTimer) {
+            this.options.clearTimer(timer);
+        } else {
+            clearTimeout(timer as NodeJS.Timeout);
+        }
+    }
+
+    /**
+     * Nothing has advanced the partial page since it yielded its backfill.
+     * Publish the full document once: it retires the placeholder, and its own
+     * delivery receipt closes the obligation. A load still in flight loses the
+     * request counter here and yields without publishing, which is the
+     * intended outcome — a stalled read must not outrank the reader's promised
+     * history, and the session watch reissues any genuinely newer content.
+     */
+    private recoverProgressiveObligation(generation: number): void {
+        if (this.progressiveContentIncomplete?.generation !== generation
+            || generation !== this.subscriptionGeneration
+            || this.suspended
+            || !this.panel
+            || !this.target
+            || !this.outlineController.snapshot
+            || this.progressiveBackfill?.pending) {
+            return;
+        }
+        this.emitDiagnostic('progressive-obligation-timeout');
+        this.cancelProgressiveBackfill();
+        const requestId = this.allocateRequestId();
+        this.currentRequestId = requestId;
+        void this.deliverPublication(this.createPublication(
+            requestId,
+            generation,
+            'refresh'
+        ), false);
     }
 
     private rebuildLatestDocument(): void {
@@ -3357,6 +3471,9 @@ export class ConversationViewer implements ConversationViewerApi {
         delivery: ConversationViewerApplicationTiming['delivery'],
         contentBytes = Buffer.byteLength(publication.html || '', 'utf8')
     ): void {
+        // A delivery is now the pending step, and its own ack watchdog covers
+        // an open incomplete-content obligation.
+        this.clearProgressiveObligationWatchdog();
         this.pendingPublicationTiming = {
             subscriptionGeneration: publication.subscriptionGeneration,
             requestId: publication.requestId,
@@ -3597,6 +3714,32 @@ export class ConversationViewer implements ConversationViewerApi {
             ? CONVERSATION_LIMITS.minRequestId
             : requestId + 1;
         return requestId;
+    }
+
+    /**
+     * A load claims the request counter before it can know whether it will
+     * publish. One that resolves to "nothing changed" replaces nothing, so it
+     * must hand the counter back to the publication still on screen —
+     * otherwise that publication's own correlated receipts (above all a
+     * progressive history slice's) are orphaned by a delivery that never
+     * happened, and the Webview's deferred-history placeholder is left with
+     * nothing in flight to converge it. Only the counter is restored: the
+     * caller has already published nothing.
+     */
+    private releaseUnpublishedRequestId(
+        claimed: number,
+        superseded: number
+    ): void {
+        if (this.currentRequestId !== claimed) {
+            // A newer load owns the counter; its delivery is authoritative.
+            return;
+        }
+        if (this.latestPublication?.requestId !== superseded) {
+            // Nothing authoritative to restore to, so leaving the claimed id
+            // in place keeps every stale receipt correctly rejected.
+            return;
+        }
+        this.currentRequestId = superseded;
     }
 
     private ensureWatch(

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -18366,6 +18366,41 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-002 clears a stalled progressive lo
     assert.equal(await page.locator(
         '.conversation-deferred-messages'
     ).getAttribute('data-history-backfill-stalled'), 'true');
+
+    // The notice is honest, not terminal: the Host owes this document a
+    // convergence, and when it arrives the reader is left with the full
+    // history and a clean status line — never a stranded placeholder.
+    await sendPage(page, {
+        type: 'conversation-viewer-page',
+        version: 1,
+        requestId: 2,
+        subscriptionGeneration: 1,
+        updateKind: 'refresh',
+        html: messageHtml('msg', 12, 0),
+        htmlSignature: 'sig-full-recovered',
+        outline: progressiveOutline(12),
+        selectedInteractionId: 'msg-11',
+        selectedInput: 11,
+        totalInputs: 12,
+        partial: false,
+        atLatest: true,
+        stale: false,
+        subagents: [],
+        activeSubagent: null,
+    });
+    await page.waitForFunction(() => window.__postedMessages.some(message =>
+        message.type === 'conversation-viewer-applied'
+            && message.htmlSignature === 'sig-full-recovered'
+    ));
+    assert.equal(await page.locator(
+        '.conversation-deferred-messages').count(), 0,
+    'the recovery retires the stalled placeholder');
+    assert.equal(await page.locator(
+        '[data-conversation-messages] [data-message-id]').count(), 12,
+    'the reader ends with the complete history');
+    assert.equal(await page.locator(
+        '[data-conversation-status]').textContent(), '',
+    'the stalled notice must not survive its own recovery');
 });
 
 test('CONVERSATION-LARGE-SESSION-PERFORMANCE-002 ignores a history chunk after a full page superseded the partial one', async t => {

--- a/tests/integration/dashboard/conversationViewer.test.js
+++ b/tests/integration/dashboard/conversationViewer.test.js
@@ -919,6 +919,218 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-002 defers post-load revalidation w
     viewer.dispose();
 });
 
+// A session-watch invalidation whose content turns out to be unchanged is the
+// most common event during a first paint: the provider rewrites its transcript
+// while the deferred history is still being backfilled. That refresh claims the
+// request counter before it can know it will publish nothing, so it must hand
+// the counter back — otherwise the in-flight slice's receipt is orphaned and
+// the reader is left with a "Loading earlier messages" placeholder forever.
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-002 keeps the deferred backfill alive across an unchanged session-watch refresh', async () => {
+    const sessionId = 'progressive-watch-noop';
+    const interactionIds = Array.from(
+        { length: 100 },
+        (_item, index) => `input-${index + 1}`
+    );
+    let invalidate;
+    const { viewer, panel } = createViewer({
+        readOutline: async () => outline(sessionId, interactionIds),
+        readPage: async () => page(sessionId, interactionIds[0], 'message', {
+            interactionIds,
+            anchorInteractionId: interactionIds.at(-1),
+        }),
+        watch: (_provider, _sessionId, onChange) => {
+            invalidate = onChange;
+            return { dispose() {} };
+        },
+    });
+
+    await viewer.open(target(sessionId, interactionIds.at(-1)));
+    const partial = decodeInitialPublication(panel.webview.html);
+    assert.match(partial.html, /Loading earlier messages/);
+    await panel.receive({
+        type: 'conversation-viewer-applied',
+        version: 1,
+        subscriptionGeneration: partial.subscriptionGeneration,
+        requestId: partial.requestId,
+        htmlSignature: partial.htmlSignature,
+    });
+    const firstChunk = panel.postedMessages.filter(message =>
+        message.type === 'conversation-viewer-history-chunk'
+    ).at(-1);
+    assert.ok(firstChunk, 'the partial receipt must anchor the backfill');
+
+    // The transcript is touched while that slice is in flight.
+    invalidate();
+    for (let attempt = 0; attempt < 12; attempt++) {
+        await new Promise(resolve => setImmediate(resolve));
+    }
+
+    // Drain the rest of the history. Every receipt must still be correlated,
+    // so each one releases the next slice through to the session start.
+    let applied = firstChunk;
+    for (let slice = 0; slice < 8 && !applied.complete; slice++) {
+        await panel.receive({
+            type: 'conversation-viewer-history-chunk-applied',
+            version: 1,
+            subscriptionGeneration: applied.subscriptionGeneration,
+            requestId: applied.requestId,
+            htmlSignature: applied.htmlSignature,
+        });
+        applied = panel.postedMessages.filter(message =>
+            message.type === 'conversation-viewer-history-chunk'
+        ).at(-1);
+    }
+    assert.equal(applied.complete, true,
+        'an unchanged refresh must not strand the deferred history');
+    viewer.dispose();
+});
+
+// The same invalidation can also land before the Webview reports its first
+// paint. The partial page is still the authoritative document, so its receipt
+// must still be able to plan the backfill.
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-002 plans the deferred backfill when an unchanged refresh precedes the first receipt', async () => {
+    const sessionId = 'progressive-watch-noop-preflight';
+    const interactionIds = Array.from(
+        { length: 100 },
+        (_item, index) => `input-${index + 1}`
+    );
+    let invalidate;
+    const { viewer, panel } = createViewer({
+        readOutline: async () => outline(sessionId, interactionIds),
+        readPage: async () => page(sessionId, interactionIds[0], 'message', {
+            interactionIds,
+            anchorInteractionId: interactionIds.at(-1),
+        }),
+        watch: (_provider, _sessionId, onChange) => {
+            invalidate = onChange;
+            return { dispose() {} };
+        },
+    });
+
+    await viewer.open(target(sessionId, interactionIds.at(-1)));
+    const partial = decodeInitialPublication(panel.webview.html);
+    assert.match(partial.html, /Loading earlier messages/);
+
+    invalidate();
+    for (let attempt = 0; attempt < 12; attempt++) {
+        await new Promise(resolve => setImmediate(resolve));
+    }
+
+    await panel.receive({
+        type: 'conversation-viewer-applied',
+        version: 1,
+        subscriptionGeneration: partial.subscriptionGeneration,
+        requestId: partial.requestId,
+        htmlSignature: partial.htmlSignature,
+    });
+    assert.ok(
+        panel.postedMessages.some(message =>
+            message.type === 'conversation-viewer-history-chunk'
+        ),
+        'the partial receipt must still plan the deferred backfill'
+    );
+    viewer.dispose();
+});
+
+// A superseding load that genuinely owns the counter can still stall before it
+// publishes. The incomplete-content obligation is the Webview's only promise
+// that its placeholder will resolve, so it carries its own watchdog: one
+// full-content refresh converges the document instead of stranding the reader.
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-002 recovers deferred history stranded by a load that never publishes', async () => {
+    const sessionId = 'progressive-obligation-watchdog';
+    const interactionIds = Array.from(
+        { length: 100 },
+        (_item, index) => `input-${index + 1}`
+    );
+    const timers = new Map();
+    let nextTimer = 1;
+    let invalidate;
+    let outlineReads = 0;
+    let stallPageReads = false;
+    const { viewer, panel } = createViewer({
+        setTimer(callback, delayMs) {
+            const handle = nextTimer++;
+            timers.set(handle, { callback, delayMs });
+            return handle;
+        },
+        clearTimer(handle) {
+            timers.delete(handle);
+        },
+        readOutline: async () => {
+            outlineReads += 1;
+            // The second read reports a completed turn, so the refresh cannot
+            // take its unchanged short-circuit and must re-read the page.
+            return outline(sessionId, interactionIds, outlineReads > 1
+                ? { responseStates: { [interactionIds.at(-1)]: 'inProgress' } }
+                : {});
+        },
+        readPage: async () => {
+            if (stallPageReads) {
+                await new Promise(() => {});
+            }
+            return page(sessionId, interactionIds[0], 'message', {
+                interactionIds,
+                anchorInteractionId: interactionIds.at(-1),
+            });
+        },
+        watch: (_provider, _sessionId, onChange) => {
+            invalidate = onChange;
+            return { dispose() {} };
+        },
+    });
+
+    await viewer.open(target(sessionId, interactionIds.at(-1)));
+    const partial = decodeInitialPublication(panel.webview.html);
+    assert.match(partial.html, /Loading earlier messages/);
+    await panel.receive({
+        type: 'conversation-viewer-applied',
+        version: 1,
+        subscriptionGeneration: partial.subscriptionGeneration,
+        requestId: partial.requestId,
+        htmlSignature: partial.htmlSignature,
+    });
+    const chunk = panel.postedMessages.filter(message =>
+        message.type === 'conversation-viewer-history-chunk'
+    ).at(-1);
+    assert.ok(chunk, 'the partial receipt must anchor the backfill');
+
+    // A refresh claims the counter and never returns from its page read.
+    stallPageReads = true;
+    invalidate();
+    for (let attempt = 0; attempt < 12; attempt++) {
+        await new Promise(resolve => setImmediate(resolve));
+    }
+    // The in-flight slice's receipt is orphaned by that load.
+    await panel.receive({
+        type: 'conversation-viewer-history-chunk-applied',
+        version: 1,
+        subscriptionGeneration: chunk.subscriptionGeneration,
+        requestId: chunk.requestId,
+        htmlSignature: chunk.htmlSignature,
+    });
+    for (let attempt = 0; attempt < 12; attempt++) {
+        await new Promise(resolve => setImmediate(resolve));
+    }
+
+    const watchdog = Array.from(timers.values()).find(candidate =>
+        candidate.delayMs === 4_000
+    );
+    assert.ok(watchdog,
+        'an open incomplete-content obligation must be watched');
+    watchdog.callback();
+    for (let attempt = 0; attempt < 12; attempt++) {
+        await new Promise(resolve => setImmediate(resolve));
+    }
+
+    const recovered = lastContentPublication(panel);
+    assert.equal(recovered.updateKind, 'refresh');
+    assert.doesNotMatch(recovered.html, /Loading earlier messages/,
+        'the recovery must retire the deferred-history placeholder');
+    assert.match(recovered.html, /message-0/);
+    assert.match(recovered.html, /message-99/);
+    viewer.dispose();
+});
+
 test('CONVERSATION-LARGE-SESSION-PERFORMANCE-002 continues across a page boundary to the session start', async () => {
     const sessionId = 'progressive-boundary';
     const olderInteractions = ['input-1', 'input-2'];


### PR DESCRIPTION
## Summary

Opening a large conversation renders the recent tail first and backfills older
history in ack-paced slices, correlating each slice against the partial page's
request id. Every path that yields that backfill assumed a superseding load
would publish the full document instead — but `performAuthoritativeLoad` claims
the request counter before it can know whether it will publish, and a refresh
that resolves to "nothing changed" publishes nothing at all.

So a single session-watch invalidation during the first paint — the provider
rewriting its transcript, or any touch that leaves the content identical —
orphaned the in-flight slice's receipt, cancelled the plan, and left the reader
with a `Loading earlier messages` placeholder that the Webview's 8s watchdog
relabelled `Earlier messages are taking longer than expected.` Nothing on the
Host was still armed: no slice, no publication, no timer. Earlier history never
arrived, and the transcript stayed stuck until the user switched sessions.

Reproduced deterministically against the unfixed build with the existing
integration harness, using fixtures that return a byte-identical outline and
page (a pure no-op refresh):

| Timing of one no-op watch tick | Result before this PR |
| --- | --- |
| Between slice send and slice receipt | 1 slice sent, `backfill-stale-anchor`, **zero** page publications, placeholder retained |
| Before the partial page's receipt | **zero** slices planned, no diagnostic at all, placeholder retained |
| No tick (control) | 4 slices, `complete: true` |

No Host timer remained armed in either failing case, so the state was terminal
rather than slow.

Two changes:

1. **Hand the request counter back when a load publishes nothing.**
   `releaseUnpublishedRequestId` restores the counter on the "nothing changed"
   short-circuit, but only while the counter is still the one that load claimed
   *and* `latestPublication` is exactly the publication being restored to — so
   it can never revive a load that a newer delivery already superseded.
2. **Give the open incomplete-content obligation the watchdog its callers
   already assumed.** The code comments referenced a "generation-level
   incomplete-content watchdog" that did not exist as an independent timer.
   Now any yield path arms it (`publishDeferredMessages` early return,
   `sendNextProgressiveBackfillChunk` suspended/anchor mismatch,
   `acknowledgeHistoryChunk` stale anchor, `recoverProgressiveBackfill`
   yield/suspended), any pending step clears it (`recordPublicationDelivery`,
   `scheduleProgressiveBackfillTimeout`), and on expiry one full-content
   refresh retires the placeholder. This covers the residual yield paths that
   fix 1 does not — for example a page read that stalls forever.

Also registers `CONVERSATION-LARGE-SESSION-PERFORMANCE-002` in
`docs/testing/behavior-contracts.json`. It was already cited by two owner test
files from #399/#400 but had no catalog entry, so the behavior was owned by
nothing.

Deliberately **not** included: deferring the session-watch `refresh()` behind an
open backfill (the way `revalidateLatest` already does). Once the counter stops
leaking it is unnecessary, and it would delay live streaming updates behind the
backfill. A genuine content change taking over the anchor and publishing the
full page is the existing design intent.

## Owner approvals

```
approve 57bcf8291b81740bc64c1a48c5c6afe6af444168
```

## Skill harvest

updated .skills/fixing-regressions-with-ci — `npm run test:behavior-contracts`
validates catalog→owner only (confirmed in `scripts/check-behavior-contracts.js`
and its own header comment), so `CONVERSATION-LARGE-SESSION-PERFORMANCE-002`
reached two owner test files with no catalog entry and no owner while every
required check stayed green; the skill now requires confirming the reverse
direction with `grep -c '<BEHAVIOR-ID>' docs/testing/behavior-contracts.json`.
Validated with `node scripts/run-skill-management-checks.js`,
`tests/contract/skills/*.test.js` (40/40), and
`tests/unit/tooling/repositorySkills.test.js` (10/10).

## Verification

RED first, against the unfixed implementation — each new test failed for the
reported regression:

- `an unchanged refresh must not strand the deferred history`
- `the partial receipt must still plan the deferred backfill`
- `an open incomplete-content obligation must be watched`

CI reachability traced before the production edit:
`tests/integration/dashboard/conversationViewer.test.js` →
`test:deterministic:run` → `test:coverage:run` → `test:ci:linux:core`
(`linux-core`); `tests/browser/conversationViewer.test.js` →
`test:ci:linux:browser` (`linux-browser`). Both are `pull_request` checks, so
PR-head files govern them.

All gates below were re-run fresh after rebasing onto `71b0ef4e`:

| Check | Result |
| --- | --- |
| `LARGE-SESSION-PERFORMANCE-002` focused (28 tests, 25 pre-existing) | 28/28 |
| `npm run test:deterministic:run` | unit 1348, contract 1195, integration 469 — all pass |
| `npm run test:browser:run` | 424/424 |
| `npm run test:conversation-performance` | pass, within budget |
| `npm run test:behavior-contracts` | pass, 11 release blockers |
| `npm run lint:ci`, `test:architecture-guards` | pass |
| coverage baseline + changed-coverage | pass, 86.01% (123/143) vs `71b0ef4e` |
| `git diff --check` | clean |

The browser assertions were added where the Webview code already behaved
correctly, so their mutation sensitivity was proven explicitly: injecting
"a stalled page refuses every later delivery" and "the stalled notice sticks
past its recovery" each failed the new assertions; both were reverted and the
test reconfirmed green with an empty `git diff`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
