### PR TITLE
perf: stop auxiliary state from resending switched conversations

### DIFF
--- a/.skills/protecting-main-with-worktrees/SKILL.md
+++ b/.skills/protecting-main-with-worktrees/SKILL.md
@@ -57,3 +57,17 @@ job.
 - Never assume `origin/main` when the repo also has `upstream` or the user named a different target.
 - If a feature branch tracks a deleted remote after merge, that is expected; remove the worktree after checking it is clean.
 - If a command accidentally affects the primary checkout, stop and inspect before continuing.
+- An absolute path is the main way edits leak into the primary checkout: the
+  two trees differ only by the `/.worktrees/<topic>` infix, so a path
+  reconstructed from memory silently targets the primary checkout and the edit
+  appears to succeed. Build every absolute path from the worktree root, and
+  after editing check `git -C <primary> status --short` for files you did not
+  intend to touch.
+- A worktree can vanish underneath a session (a parallel agent, a cleanup, a
+  removed directory). `npm run` from the emptied path then walks up to the
+  primary checkout's `package.json` and silently operates on it — a build
+  script such as `test-compile` will clean and rebuild the primary `out/`.
+  Before running builds or tests, confirm the cwd is still a live worktree
+  (`git rev-parse --show-toplevel` matches it, and it appears in
+  `git worktree list`); if it does not, re-create the worktree instead of
+  running anything from that path.

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -4787,6 +4787,21 @@
     ]
   },
   {
+    "id": "CONVERSATION-LARGE-SESSION-PERFORMANCE-003",
+    "domain": "webview",
+    "title": "Auxiliary AI Conversation state never discards a progressive render or resends unchanged conversation content",
+    "priority": "P0",
+    "status": "automated",
+    "owners": [
+      "tests/browser/conversationViewer.test.js",
+      "tests/integration/dashboard/conversationViewer.test.js"
+    ],
+    "evidence": [
+      "src/aiSessions/conversation/viewer.ts",
+      "src/webview/conversationViewerScripts.js"
+    ]
+  },
+  {
     "id": "CONVERSATION-VIEWER-USER-EMPHASIS-001",
     "domain": "webview",
     "title": "AI Conversation presents User prompts as dominant full-width blocks",

--- a/src/aiSessions/conversation/viewer.ts
+++ b/src/aiSessions/conversation/viewer.ts
@@ -2172,6 +2172,14 @@ export class ConversationViewer implements ConversationViewerApi {
         if (!pending || this.suspended || this.target !== pending.target
             || this.subscriptionGeneration !== pending.generation
             || this.progressiveBackfill
+            // A partial page owes the reader its deferred history. Auxiliary
+            // state is not content, so it must never buy its way onto the wire
+            // by re-rendering the whole conversation: wait for the obligation
+            // to close and ride the state-only envelope below instead. Without
+            // this, every switch into a session with comments, bookmarks, or
+            // subagents discards the progressive first paint.
+            || this.progressiveContentIncomplete?.generation
+                === this.subscriptionGeneration
             || !publication || !this.isCurrentPublication(publication)) {
             return;
         }
@@ -2202,7 +2210,8 @@ export class ConversationViewer implements ConversationViewerApi {
             && publication.projectComments.revision
                 === this.projectCommentController.snapshot.revision
             && publication.bookmarks.revision
-                === this.bookmarkController.snapshot.revision;
+                === this.bookmarkController.snapshot.revision
+            && sameSubagents(publication.subagents, this.subagents);
     }
 
     async navigateLatest(): Promise<void> {
@@ -2668,13 +2677,14 @@ export class ConversationViewer implements ConversationViewerApi {
                 return;
             }
             this.subagents = subagents.map(entry => ({ ...entry }));
-            const requestId = this.allocateRequestId();
-            this.currentRequestId = requestId;
-            await this.deliverPublication(this.createPublication(
-                requestId,
-                generation,
-                'refresh'
-            ), false);
+            // The list is sidebar metadata, so it publishes the same way as
+            // restored comments and bookmarks: deferred behind any open
+            // deferred-history obligation and then delivered as a state-only
+            // envelope. Publishing a page for it directly would resend the
+            // whole transcript, because a fresh publication's content
+            // signature cannot match what the Webview already applied.
+            this.pendingRestoredAuxiliaryState = { target, generation };
+            this.publishRestoredAuxiliaryState();
         }).catch(() => undefined);
     }
 

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -456,6 +456,69 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 adds late subagents without rep
     );
 });
 
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-003 fills the subagents panel from a state-only envelope', async t => {
+    const { page } = await openHostViewerDocument(t);
+    const html = messageHtml('kept-across-subagent-state', 2);
+    const base = {
+        ...hostileConversationPage,
+        requestId: 60,
+        updateKind: 'initial',
+        html,
+        htmlSignature: 'sig-subagent-state',
+        subagents: [],
+    };
+    await sendPage(page, base);
+    await page.evaluate(() => {
+        window.__keptNodes = Array.from(document.querySelectorAll(
+            '[data-conversation-messages] [data-message-id]'
+        ));
+        window.__sanitizeCalls = 0;
+        const sanitize = window.DOMPurify.sanitize;
+        window.DOMPurify.sanitize = function () {
+            window.__sanitizeCalls += 1;
+            return sanitize.apply(window.DOMPurify, arguments);
+        };
+    });
+
+    // The Host discovered the session's subagents. That is sidebar state, so
+    // it arrives with no HTML on the wire: the transcript must not be
+    // re-sanitized, re-parsed, or re-laid-out to show it.
+    const { html: _omitted, ...stateOnly } = base;
+    await sendPage(page, {
+        ...stateOnly,
+        requestId: 61,
+        updateKind: 'refresh',
+        subagents: [{
+            id: 'a11111111',
+            label: 'Late provider worker',
+            status: 'running',
+            updatedAt: 1_780_000_000_000,
+        }],
+    });
+
+    assert.equal(
+        await page.locator('[data-subagent-id="a11111111"]').count(), 1,
+        'the panel must list the discovered subagent'
+    );
+    assert.equal(
+        await page.locator('[data-telemetry-subagents]').innerText(), '1/1',
+        'the telemetry pill must count it'
+    );
+    assert.deepEqual(await page.evaluate(() => ({
+        nodesRetained: Array.from(document.querySelectorAll(
+            '[data-conversation-messages] [data-message-id]'
+        )).every((node, index) => node === window.__keptNodes[index]),
+        messageCount: document.querySelectorAll(
+            '[data-conversation-messages] [data-message-id]'
+        ).length,
+        sanitizeCalls: window.__sanitizeCalls,
+    })), {
+        nodesRetained: true,
+        messageCount: 2,
+        sanitizeCalls: 0,
+    }, 'a state-only envelope must not touch the transcript DOM');
+});
+
 test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 applies delta publications without resending or re-sanitizing HTML', async t => {
     const page = await openViewerPage(t);
     const fullPage = {

--- a/tests/integration/dashboard/conversationViewer.test.js
+++ b/tests/integration/dashboard/conversationViewer.test.js
@@ -195,6 +195,27 @@ function lastContentPublication(panel) {
     return publication;
 }
 
+// A real Webview acknowledges every publication it applies. State-only
+// envelopes — restored auxiliary revisions and the subagent list — are
+// withheld until that receipt proves the base content is actually on screen,
+// so a harness asserting them has to model the receipt.
+async function acknowledgeLatestPublication(panel) {
+    const publication = panel.postedMessages.filter(message =>
+        message.type === 'conversation-viewer-page'
+    ).at(-1) || decodeInitialPublication(panel.webview.html);
+    assert.ok(publication, 'a publication must exist to acknowledge');
+    await panel.receive({
+        type: 'conversation-viewer-applied',
+        version: 1,
+        subscriptionGeneration: publication.subscriptionGeneration,
+        requestId: publication.requestId,
+        htmlSignature: publication.htmlSignature,
+    });
+    for (let attempt = 0; attempt < 6; attempt++) {
+        await new Promise(resolve => setImmediate(resolve));
+    }
+}
+
 test('CONVERSATION-LARGE-SESSION-PERFORMANCE-002 renders a modest latest page in one publication', async () => {
     const sessionId = 'progressive-page';
     const interactionIds = Array.from(
@@ -1962,7 +1983,7 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-002 keeps interaction groups intact
     viewer.dispose();
 });
 
-test('CONVERSATION-LARGE-SESSION-PERFORMANCE-002 completes through an auxiliary refresh that lands before the first receipt', async () => {
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-003 keeps the progressive render when an auxiliary restore lands before the first receipt', async () => {
     const sessionId = 'progressive-chunk-early-auxiliary';
     const interactionIds = Array.from(
         { length: 100 },
@@ -1987,7 +2008,9 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-002 completes through an auxiliary 
     assert.equal(recent.comments.revision, 0,
         'the readable page must not wait for the auxiliary restore');
     // The auxiliary restore settles after the publication but before its
-    // receipt: the restore wins the race against the backfill.
+    // receipt. It must not win that race by re-rendering the whole
+    // conversation: restoring comments is a state change, so it waits for the
+    // deferred history instead of discarding the progressive first paint.
     restoredComments.resolve({ revision: 7, comments: [] });
     await new Promise(resolve => setImmediate(resolve));
     await panel.receive({
@@ -1998,16 +2021,176 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-002 completes through an auxiliary 
         htmlSignature: recent.htmlSignature,
     });
 
-    // The restored auxiliary state rides a full-content refresh, which
-    // completes the progressive page directly instead of chunking.
-    const complete = lastContentPublication(panel);
-    assert.equal(complete.updateKind, 'refresh');
-    assert.doesNotMatch(complete.html, /Loading earlier messages/);
-    assert.match(complete.html, /message-0/);
-    assert.equal(complete.comments.revision, 7);
-    assert.equal(panel.postedMessages.filter(message =>
+    assert.equal(
+        panel.postedMessages.filter(message =>
+            message.type === 'conversation-viewer-page'
+        ).length,
+        0,
+        'the auxiliary restore must not supersede the progressive page'
+    );
+
+    // The backfill runs to the session start in ack-paced slices.
+    let applied = panel.postedMessages.filter(message =>
         message.type === 'conversation-viewer-history-chunk'
-    ).length, 0);
+    ).at(-1);
+    assert.ok(applied, 'the receipt must still plan the deferred backfill');
+    for (let slice = 0; slice < 8 && !applied.complete; slice++) {
+        await panel.receive({
+            type: 'conversation-viewer-history-chunk-applied',
+            version: 1,
+            subscriptionGeneration: applied.subscriptionGeneration,
+            requestId: applied.requestId,
+            htmlSignature: applied.htmlSignature,
+        });
+        applied = panel.postedMessages.filter(message =>
+            message.type === 'conversation-viewer-history-chunk'
+        ).at(-1);
+    }
+    assert.equal(applied.complete, true, 'the backfill must reach history start');
+    await panel.receive({
+        type: 'conversation-viewer-history-chunk-applied',
+        version: 1,
+        subscriptionGeneration: applied.subscriptionGeneration,
+        requestId: applied.requestId,
+        htmlSignature: applied.htmlSignature,
+    });
+
+    // History is whole, so the completion publication needs no HTML. Its
+    // receipt closes the obligation and releases the restored comments as a
+    // state-only envelope — the reader pays nothing for them.
+    const completion = panel.postedMessages.filter(message =>
+        message.type === 'conversation-viewer-page'
+    ).at(-1);
+    assert.ok(completion, 'the completion publication must exist');
+    assert.equal(completion.html, undefined,
+        'a converged document must not be resent');
+    await panel.receive({
+        type: 'conversation-viewer-applied',
+        version: 1,
+        subscriptionGeneration: completion.subscriptionGeneration,
+        requestId: completion.requestId,
+        htmlSignature: completion.htmlSignature,
+    });
+    for (let attempt = 0; attempt < 12; attempt++) {
+        await new Promise(resolve => setImmediate(resolve));
+    }
+
+    const auxiliary = panel.postedMessages.filter(message =>
+        message.type === 'conversation-viewer-page'
+            && message.comments.revision === 7
+    ).at(-1);
+    assert.ok(auxiliary, 'the restored comments must still reach the Webview');
+    assert.equal(auxiliary.html, undefined,
+        'auxiliary state must ride a state-only envelope, never a re-render');
+    viewer.dispose();
+});
+
+// A conversation's subagent list is sidebar metadata, not content. Discovering
+// it must never cost the reader a full-document re-render: switching into any
+// session that has subagents would otherwise throw away the progressive first
+// paint and resend the whole transcript, which is the dominant cost of a switch.
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-003 keeps the progressive render when a session has subagents', async () => {
+    const sessionId = 'progressive-subagent-switch';
+    const interactionIds = Array.from(
+        { length: 100 },
+        (_item, index) => `input-${index + 1}`
+    );
+    const { viewer, panel } = createViewer({
+        readOutline: async () => outline(sessionId, interactionIds),
+        readPage: async () => page(sessionId, interactionIds[0], 'message', {
+            interactionIds,
+            anchorInteractionId: interactionIds.at(-1),
+        }),
+        readSubagents: async () => ([{
+            id: 'sub-1',
+            label: 'explorer',
+            agentType: 'Explore',
+            status: 'idle',
+            createdAt: 1,
+            updatedAt: 2,
+        }]),
+    });
+
+    await viewer.open(target(sessionId, interactionIds.at(-1)));
+    const partial = decodeInitialPublication(panel.webview.html);
+    assert.match(partial.html, /Loading earlier messages/);
+    await panel.receive({
+        type: 'conversation-viewer-applied',
+        version: 1,
+        subscriptionGeneration: partial.subscriptionGeneration,
+        requestId: partial.requestId,
+        htmlSignature: partial.htmlSignature,
+    });
+    for (let attempt = 0; attempt < 12; attempt++) {
+        await new Promise(resolve => setImmediate(resolve));
+    }
+
+    assert.equal(
+        panel.postedMessages.filter(message =>
+            message.type === 'conversation-viewer-page'
+                && typeof message.html === 'string'
+        ).length,
+        0,
+        'discovering subagents must not resend the conversation'
+    );
+
+    // The deferred history still backfills in ack-paced slices.
+    let applied = panel.postedMessages.filter(message =>
+        message.type === 'conversation-viewer-history-chunk'
+    ).at(-1);
+    assert.ok(applied, 'the partial receipt must plan the deferred backfill');
+    for (let slice = 0; slice < 8 && !applied.complete; slice++) {
+        await panel.receive({
+            type: 'conversation-viewer-history-chunk-applied',
+            version: 1,
+            subscriptionGeneration: applied.subscriptionGeneration,
+            requestId: applied.requestId,
+            htmlSignature: applied.htmlSignature,
+        });
+        applied = panel.postedMessages.filter(message =>
+            message.type === 'conversation-viewer-history-chunk'
+        ).at(-1);
+    }
+    assert.equal(applied.complete, true, 'the backfill must reach history start');
+    await panel.receive({
+        type: 'conversation-viewer-history-chunk-applied',
+        version: 1,
+        subscriptionGeneration: applied.subscriptionGeneration,
+        requestId: applied.requestId,
+        htmlSignature: applied.htmlSignature,
+    });
+    const completion = panel.postedMessages.filter(message =>
+        message.type === 'conversation-viewer-page'
+    ).at(-1);
+    assert.ok(completion, 'the completion publication must exist');
+    await panel.receive({
+        type: 'conversation-viewer-applied',
+        version: 1,
+        subscriptionGeneration: completion.subscriptionGeneration,
+        requestId: completion.requestId,
+        htmlSignature: completion.htmlSignature,
+    });
+    for (let attempt = 0; attempt < 12; attempt++) {
+        await new Promise(resolve => setImmediate(resolve));
+    }
+
+    // The list still reaches the sidebar — as state, with no HTML on the wire.
+    const withSubagents = panel.postedMessages.filter(message =>
+        message.type === 'conversation-viewer-page'
+            && message.subagents?.length === 1
+    ).at(-1);
+    assert.ok(withSubagents, 'the subagent list must still reach the Webview');
+    assert.equal(withSubagents.subagents[0].id, 'sub-1');
+    assert.equal(withSubagents.html, undefined,
+        'the subagent list must ride a state-only envelope');
+    assert.equal(
+        panel.postedMessages.filter(message =>
+            message.type === 'conversation-viewer-page'
+                && typeof message.html === 'string'
+        ).length,
+        0,
+        'no publication in the whole switch may carry conversation HTML'
+    );
     viewer.dispose();
 });
 
@@ -4029,6 +4212,7 @@ test('WEBVIEW-AI-SESSION-SUBAGENT-VIEWER-001 opens a subagent transcript in plac
 
     await viewer.open(target('session-a', 'input-a'));
     await new Promise(resolve => setImmediate(resolve));
+    await acknowledgeLatestPublication(panel);
     const initial = panel.postedMessages.at(-1)
         || decodeInitialPublication(panel.webview.html);
     assert.deepEqual(
@@ -4083,6 +4267,8 @@ test('WEBVIEW-AI-SESSION-SUBAGENT-VIEWER-001 opens a subagent transcript in plac
         version: 1,
     });
     assert.equal(panel.postedMessages.length, settledCount);
+
+    await acknowledgeLatestPublication(panel);
 
     // A dashboard follow for the same session preserves the subagent view.
     const beforeFollow = panel.postedMessages.length;
@@ -4179,6 +4365,7 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 keeps late subagents after same
         status: 'running',
     }]);
     await new Promise(resolve => setImmediate(resolve));
+    await acknowledgeLatestPublication(panel);
     assert.deepEqual(
         panel.postedMessages.at(-1).subagents.map(entry => entry.id),
         ['a11111111']
@@ -4236,6 +4423,7 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 prevents an older subagent resu
         status: 'running',
     }]);
     await new Promise(resolve => setImmediate(resolve));
+    await acknowledgeLatestPublication(panel);
 
     assert.deepEqual(
         panel.postedMessages.at(-1).subagents.map(entry => entry.id),
@@ -4299,6 +4487,7 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 prevents an older subagent resu
         status: 'running',
     }]);
     await new Promise(resolve => setImmediate(resolve));
+    await acknowledgeLatestPublication(panel);
 
     assert.equal(panel.postedMessages.at(-1).selectedInteractionId, 'input-1');
     assert.match(lastContentPublication(panel).html, /navigated/);


### PR DESCRIPTION
## Summary

Switching conversations paints the recent tail first and backfills older
history in ack-paced slices. Auxiliary state — restored comments, bookmarks,
and the subagent list — was published as an ordinary page. A fresh
publication's content signature can never match what the Webview already
applied, so that page carried the **entire transcript**.

Worse, it also claimed the request counter, so the partial page's receipt then
failed `isCurrentPublication` and the slice-paced backfill never started at
all. Any switch into a session that has a subagent — or whose comment restore
won the race — therefore discarded the progressive first paint and
re-sanitized, re-parsed, and re-laid-out the whole history in one blocking
Webview task.

Confirmed from a user's real diagnostics: every `follow` event was immediately
followed by a non-progressive `refresh` of 338–695KB, with observed Webview
application times of 150–2671ms (and 10019ms on the previous build). Isolated
in the harness — same 100-interaction session, the only difference being one
subagent:

```
no subagents:  first paint 11KB -> 1 history chunk       -> backfill runs
one subagent:  first paint 11KB -> 0 history chunks      -> refresh html=91KB
```

### Fix

Auxiliary state is not content, so the subagent list now travels the same
deferred `pendingRestoredAuxiliaryState` path that comments and bookmarks
already use, and that path is held back while a deferred-history obligation is
open. It lands once as a state-only envelope with the HTML omitted.

Measured on a 120-interaction session with one subagent and restored comments:

| | before | after |
| --- | --- | --- |
| first paint (blocking) | 19KB | 19KB |
| **largest single Webview task** | **189KB** | **38KB** |
| page publications carrying HTML | 1 (189KB) | **0** |
| history slices | 0 | 5 (170KB, ack-paced) |
| subagents + comments delivered | yes | yes (0-byte envelope) |

Total content is unchanged — the win is that the largest blocking parse drops
5x and the rest arrives in slices that yield between each, so the transcript
stays readable and scrollable throughout the switch.

### Changed expectations (deliberate)

- One test asserted `the restored auxiliary state rides a full-content
  refresh, which completes the progressive page directly instead of chunking`
  with `history-chunk` count `0`. That froze an accidental performance
  behavior; it now asserts the opposite and is renamed onto
  `CONVERSATION-LARGE-SESSION-PERFORMANCE-003`.
- Four subagent tests modelled a Webview that never acknowledges any
  publication, which no real Webview does. A state-only envelope requires an
  applied receipt (`A state-only envelope must never update an outgoing or
  unready document`), so they now send that receipt. Their supersession and
  in-place-switch assertions are unchanged.

Registers `CONVERSATION-LARGE-SESSION-PERFORMANCE-003`.

## Owner approvals

```
approve 70f1b99a4029d10ff655985c433b0fa916c531b1
```

## Skill harvest

updated .skills/protecting-main-with-worktrees — two preventable failures on
this branch: an absolute path rebuilt without the `/.worktrees/<topic>` infix
landed a skill edit in the primary checkout and reported success; later the
worktree vanished mid-task and `npm run test-compile` from the emptied path
walked up to the primary `package.json` and cleaned/rebuilt the primary
`out/`. The existing guardrail only covered inspecting after the fact, so the
skill now records how to avoid both. Validated with
`node scripts/run-skill-management-checks.js`,
`tests/contract/skills/*.test.js` (40/40), and
`tests/unit/tooling/repositorySkills.test.js` (10/10).

## Verification

RED first, against the unfixed implementation:

- `discovering subagents must not resend the conversation` (actual 1, expected 0)
- `the auxiliary restore must not supersede the progressive page` (actual 1, expected 0)

CI reachability traced before the production edit:
`tests/integration/dashboard/conversationViewer.test.js` →
`test:deterministic:run` → `test:coverage:run` → `test:ci:linux:core`
(`linux-core`); `tests/browser/conversationViewer.test.js` →
`test:ci:linux:browser` (`linux-browser`). Both are `pull_request` checks.

| Check | Result |
| --- | --- |
| `LARGE-SESSION-PERFORMANCE` focused (61 tests) | 61/61 |
| `npm run test:deterministic:run` | unit 1348, contract 1195, integration 470 — all pass |
| `npm run test:browser:run` | 425/425 |
| `npm run test:conversation-performance` | pass, within budget |
| `npm run test:dashboard:run`, `test:safety:run` | pass |
| `npm run test:behavior-contracts` | pass, 11 release blockers |
| `npm run lint:ci`, `test:architecture-guards` | pass |
| coverage baseline + changed-coverage | pass, 100.00% (18/18) vs `bf75713f` |
| `git diff --check` | clean |

The new browser assertion guards already-working Webview code, so its mutation
sensitivity was proven: making the Webview ignore `subagents` when `html` is
omitted failed it with `the panel must list the discovered subagent`; the
script was restored and the test reconfirmed green with an empty `git diff`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
