### PR TITLE
chore: release Agent Pivot 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to the "Agent Pivot" extension will be documented in this fi
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-08-27
+
+### Added
+
+- Page indexed AI Conversation history so long sessions load incrementally
+  instead of blocking the viewer, and support remote worktree baselines for
+  remote repository setups.
+- Publish Agent Pivot to the VS Code Marketplace automatically with every
+  minor or major release tag; patch releases stay on GitHub Releases.
+
+### Changed
+
+- Make AI Conversation switches feel immediate: cached transcripts render
+  first, heavy conversations render progressively with a bounded backfill,
+  and superseded navigation settles safely without resending state.
+- Declare limited Workspace Trust support: the custom CSS and custom color
+  settings now apply only in trusted workspaces, matching the agent and
+  worktree features that already require trust.
+- Sanitize settings-sourced styles (custom CSS, custom theme colors, and
+  project colors) before they reach the webview, so workspace settings
+  cannot break out of the style context or load remote resources.
+
+### Fixed
+
+- Keep IME composition alive through the worktree group creation form
+  lifecycle and close replay-ordering gaps.
+- Ship complete third-party license notices for every bundled dependency,
+  generated from the production dependency closure.
+
 ## [1.1.4] - 2026-08-26
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "agent-pivot",
-    "version": "1.1.4",
+    "version": "1.2.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "agent-pivot",
-            "version": "1.1.4",
+            "version": "1.2.0",
             "license": "MIT",
             "dependencies": {
                 "dom-autoscroller": "^2.3.4",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "agent-pivot",
     "displayName": "Agent Pivot",
     "description": "Switch, monitor, and resume Codex, Claude, and Kimi sessions across VS Code workspaces. Project manager and prompt library for AI coding agents.",
-    "version": "1.1.4",
+    "version": "1.2.0",
     "publisher": "hzcheng",
     "license": "MIT",
     "icon": "media/extension_icon.png",

--- a/scripts/lib/brandIdentity.js
+++ b/scripts/lib/brandIdentity.js
@@ -10,7 +10,7 @@ const BRAND_IDENTITY = Object.freeze({
     publisher: 'hzcheng',
     mainPackageName: 'agent-pivot',
     mainExtensionId: 'hzcheng.agent-pivot',
-    mainVersion: '1.1.4',
+    mainVersion: '1.2.0',
     bridgePackageName: 'agent-pivot-attention-ui-bridge',
     bridgeExtensionId: 'hzcheng.agent-pivot-attention-ui-bridge',
     bridgeVersion: '1.0.3',

--- a/scripts/run-release-notes-checks.js
+++ b/scripts/run-release-notes-checks.js
@@ -14,13 +14,13 @@ const workflowPath = path.join(repositoryRoot, '.github', 'workflows', 'release-
 function validateReleaseContent({ readme, changelog, packageMetadata }) {
     assert.strictEqual(packageMetadata.displayName, 'Agent Pivot',
         'release metadata must use the Agent Pivot display name');
-    assert.strictEqual(packageMetadata.version, '1.1.4',
-        'the current Agent Pivot release must be version 1.1.4');
+    assert.strictEqual(packageMetadata.version, '1.2.0',
+        'the current Agent Pivot release must be version 1.2.0');
     const currentRelease = extractReleaseNotes(changelog, packageMetadata.version);
     const requiredReleaseFacts = [
-        ['the local Active Chat command', /Active Chat in This Window/i],
-        ['the local Attention Chat command', /Attention Chat in This Window/i],
-        ['the Session status order', /Attention,[\s\S]*Running,[\s\S]*Idle/i],
+        ['the Marketplace release channel', /VS Code Marketplace/i],
+        ['the Workspace Trust declaration', /Workspace Trust/i],
+        ['the progressive conversation rendering', /progressively/i],
     ];
 
     for (const [label, pattern] of requiredReleaseFacts) {

--- a/scripts/run-release-packaging-checks.js
+++ b/scripts/run-release-packaging-checks.js
@@ -433,7 +433,7 @@ function runRealVsixArchiveChecks(mainPackage, bridgePackage) {
     );
     assert.strictEqual(
         path.basename(mainArtifact),
-        'agent-pivot-1.1.4.vsix',
+        'agent-pivot-1.2.0.vsix',
         'main release artifact name must remain exact',
     );
     assert.strictEqual(

--- a/tests/unit/tooling/brandIdentity.test.js
+++ b/tests/unit/tooling/brandIdentity.test.js
@@ -50,7 +50,7 @@ function manifests() {
             name: 'agent-pivot',
             displayName: 'Agent Pivot',
             publisher: 'hzcheng',
-            version: '1.1.4',
+            version: '1.2.0',
             icon: 'media/extension_icon.png',
             repository: {
                 type: 'git',
@@ -281,7 +281,7 @@ test('brand identity exposes the exact approved public contract', () => {
         publisher: 'hzcheng',
         mainPackageName: 'agent-pivot',
         mainExtensionId: 'hzcheng.agent-pivot',
-        mainVersion: '1.1.4',
+        mainVersion: '1.2.0',
         bridgePackageName: 'agent-pivot-attention-ui-bridge',
         bridgeExtensionId: 'hzcheng.agent-pivot-attention-ui-bridge',
         bridgeVersion: '1.0.3',

--- a/tests/unit/tooling/extensionHostLauncher.test.js
+++ b/tests/unit/tooling/extensionHostLauncher.test.js
@@ -150,7 +150,7 @@ test('RELEASE-SCHEDULED-EXTENSION-HOST-001 launches both extensions with pinned 
         ]);
         assert.deepEqual(packagePlan.map(item => path.basename(item.artifactPath)), [
             'agent-pivot-attention-ui-bridge-1.0.3.vsix',
-            'agent-pivot-1.1.4.vsix',
+            'agent-pivot-1.2.0.vsix',
         ]);
         assert.equal(options.extensionTestsPath,
             path.join(environment.testHarness, 'index.js'));

--- a/tests/unit/tooling/releaseNotes.test.js
+++ b/tests/unit/tooling/releaseNotes.test.js
@@ -14,7 +14,7 @@ test('release content validation cannot satisfy current facts from historical no
     const changelog = [
         '# Changelog',
         '',
-        '## [1.1.4] - 2026-08-26',
+        '## [1.2.0] - 2026-08-27',
         '',
         '- An unrelated documentation fix.',
         '',
@@ -37,10 +37,10 @@ test('release content validation cannot satisfy current facts from historical no
             changelog,
             packageMetadata: {
                 displayName: 'Agent Pivot',
-                version: '1.1.4',
+                version: '1.2.0',
                 description: 'Workspace command center.',
             },
         }),
-        /1\.1\.4 CHANGELOG release must document the local Active Chat command/,
+        /1\.2\.0 CHANGELOG release must document the Marketplace release channel/,
     );
 });


### PR DESCRIPTION
## Summary

Release preparation for **Agent Pivot 1.2.0** (first Marketplace release):

- `CHANGELOG.md`: new `[1.2.0] - 2026-08-27` section covering immediate-feeling AI Conversation switches (cached transcript first, progressive rendering, bounded backfill), indexed conversation history paging, remote worktree baselines, the limited Workspace Trust declaration with sanitized settings-sourced styles, complete generated third-party notices, IME composition fixes, and automatic Marketplace publishing on minor/major release tags.
- Version synchronized to `1.2.0` in `package.json`, `package-lock.json`, and `scripts/lib/brandIdentity.js`.
- Pinned assertions updated: `run-release-notes-checks.js` (version + 1.2.0 required facts), `run-release-packaging-checks.js` and `extensionHostLauncher.test.js` (1.2.0 VSIX artifact name), `brandIdentity.test.js`, `releaseNotes.test.js`.

**After merge**: tag `v1.2.0` on the merge commit and push it. The release workflow will verify, build, create the GitHub Release, and — since 1.1.x → 1.2.0 is a minor bump — auto-publish both extensions to the VS Code Marketplace using `VSCE_PAT`.

## Verification

- `npm run test-compile`, `node --test 'tests/unit/**/*.test.js'` (1348 pass)
- `npm run test:release-notes`, `npm run test:behavior-contracts`
- `npm run brand:verify`, `npm run brand:check`
- `npm run test:release-packaging` (builds `agent-pivot-1.2.0.vsix` + bridge)
- `npm run test:coverage:ci` (baseline + changed-line 100%)
- `npm run lint` (0 errors), `git diff --check`

## Skill harvest

No skill change justified; mechanical release-prep bump executed under the existing review-fix-commit-loop flow with no new friction.

## Owner approvals

```
approve 75e55a9564c7473dd84e6fb9dd5df7f44263823a
```
