### PR TITLE
perf: restore large conversations from their stashed Webview frame

### DIFF
--- a/src/aiSessions/conversation/viewer.ts
+++ b/src/aiSessions/conversation/viewer.ts
@@ -2610,7 +2610,13 @@ export class ConversationViewer implements ConversationViewerApi {
             }
             const progressiveCandidate = updateKind === 'initial'
                 && this.canProgressivelyRender();
-            const publication = this.createPublication(
+            const publication = this.restorableFramePublication(
+                requestId,
+                generation,
+                updateKind,
+                progressiveCandidate,
+                target
+            ) || this.createPublication(
                 requestId,
                 generation,
                 updateKind,
@@ -4173,6 +4179,43 @@ export class ConversationViewer implements ConversationViewerApi {
     private canProgressivelyRender(): boolean {
         const projection = this.outlineController.createPublication();
         return projection.atLatest && !projection.partial;
+    }
+
+    /**
+     * Reattaching the Webview's own detached frame is the cheapest switch
+     * there is: no HTML on the wire, no sanitize, no parse, no layout. A
+     * progressive publication can never be served that way — its signature
+     * describes the partial first paint, not the converged document the frame
+     * holds — so a progressive candidate whose session is on the reported
+     * frame list renders whole once to find out whether the frame still
+     * matches. When it does, that whole publication is the one to deliver and
+     * `deliverPublication` turns it into a frame restore. When it does not
+     * (the transcript moved on while away), the caller falls back to the
+     * progressive first paint and only the Host paid one extra render.
+     *
+     * Returns undefined whenever the frame cannot serve this content, so the
+     * caller keeps its normal publication path.
+     */
+    private restorableFramePublication(
+        requestId: number,
+        generation: number,
+        updateKind: ConversationViewerPageMessage['updateKind'],
+        progressiveCandidate: boolean,
+        target: ConversationViewerTarget
+    ): ConversationViewerPageMessage | undefined {
+        if (!progressiveCandidate) {
+            return undefined;
+        }
+        const token = this.webviewFrames.get(
+            conversationFrameTokenKey(target)
+        );
+        if (token === undefined || token === this.appliedContentSignature) {
+            // No reported frame, or the Webview already has this content live
+            // and the ordinary delta path is cheaper still.
+            return undefined;
+        }
+        const whole = this.createPublication(requestId, generation, updateKind);
+        return whole.htmlSignature === token ? whole : undefined;
     }
 
     private createInteractionInfo(): Map<string, {

--- a/tests/integration/dashboard/conversationViewer.test.js
+++ b/tests/integration/dashboard/conversationViewer.test.js
@@ -6336,6 +6336,123 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 offers a frame restore only for
     viewer.dispose();
 });
 
+// Returning to a conversation is the most common switch there is. The Webview
+// already holds that session's converged document detached, so reattaching it
+// must beat repainting: a progressive publication's signature describes only
+// the partial page, so it can never match the stashed frame's token, and
+// preferring it would replay the whole backfill on every return visit.
+test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 restores a large conversation from its stashed frame instead of repainting', async () => {
+    const bigIds = Array.from(
+        { length: 100 },
+        (_item, index) => `input-${index + 1}`
+    );
+    const smallIds = ['b-1', 'b-2'];
+    const { viewer, panel } = createViewer({
+        readOutline: async (_provider, sessionId) => outline(
+            sessionId,
+            sessionId === 'big-a' ? bigIds : smallIds
+        ),
+        readPage: async request => page(
+            request.sessionId,
+            request.sessionId === 'big-a' ? bigIds[0] : smallIds[0],
+            'message',
+            {
+                interactionIds: request.sessionId === 'big-a'
+                    ? bigIds
+                    : smallIds,
+                anchorInteractionId: request.sessionId === 'big-a'
+                    ? bigIds.at(-1)
+                    : smallIds.at(-1),
+            }
+        ),
+    });
+    const lastPage = () => panel.postedMessages.filter(message =>
+        message.type === 'conversation-viewer-page').at(-1);
+    const ack = (publication, frames) => panel.receive({
+        type: 'conversation-viewer-applied',
+        version: 1,
+        subscriptionGeneration: publication.subscriptionGeneration,
+        requestId: publication.requestId,
+        htmlSignature: publication.htmlSignature,
+        frames,
+    });
+
+    // Open the large conversation and converge it exactly as a Webview does:
+    // the applied token advances with every slice.
+    await viewer.open(target('big-a', bigIds.at(-1)));
+    const partial = decodeInitialPublication(panel.webview.html);
+    assert.match(partial.html, /Loading earlier messages/);
+    let appliedToken = partial.htmlSignature;
+    await ack(partial, []);
+    let slice = panel.postedMessages.filter(message =>
+        message.type === 'conversation-viewer-history-chunk').at(-1);
+    assert.ok(slice, 'the deferred history must backfill');
+    for (let guard = 0; guard < 10 && slice; guard++) {
+        appliedToken = slice.htmlSignature;
+        await panel.receive({
+            type: 'conversation-viewer-history-chunk-applied',
+            version: 1,
+            subscriptionGeneration: slice.subscriptionGeneration,
+            requestId: slice.requestId,
+            htmlSignature: slice.htmlSignature,
+        });
+        if (slice.complete) {
+            break;
+        }
+        slice = panel.postedMessages.filter(message =>
+            message.type === 'conversation-viewer-history-chunk').at(-1);
+    }
+    const completion = lastPage();
+    assert.ok(completion, 'the completion publication must exist');
+    appliedToken = completion.htmlSignature;
+    await ack(completion, []);
+
+    // Switch away; the Webview stashes the converged frame under that token.
+    await viewer.follow(target('small-b', smallIds[0]));
+    await ack(lastPage(), [{
+        projectId: 'project-a',
+        provider: 'codex',
+        sessionId: 'big-a',
+        token: appliedToken,
+    }]);
+
+    // Return. The frame is the cheapest possible switch, so take it.
+    const beforeReturn = panel.postedMessages.length;
+    await viewer.follow(target('big-a', bigIds.at(-1)));
+    for (let attempt = 0; attempt < 12; attempt++) {
+        await new Promise(resolve => setImmediate(resolve));
+    }
+    const returned = lastPage();
+    assert.equal(returned.restoreFrame, true,
+        'a reported frame for unchanged content must be restored');
+    assert.equal(returned.html, undefined,
+        'a frame restore must put no conversation HTML on the wire');
+    assert.equal(returned.htmlSignature, appliedToken,
+        'the restore must name the exact content the Webview still holds');
+    assert.doesNotMatch(
+        JSON.stringify(panel.postedMessages.slice(beforeReturn)),
+        /Loading earlier messages/,
+        'a restored frame must never reintroduce the deferred placeholder'
+    );
+    await ack(returned, [{
+        projectId: 'project-a',
+        provider: 'codex',
+        sessionId: 'big-a',
+        token: appliedToken,
+    }]);
+    for (let attempt = 0; attempt < 12; attempt++) {
+        await new Promise(resolve => setImmediate(resolve));
+    }
+    assert.equal(
+        panel.postedMessages.slice(beforeReturn).filter(message =>
+            message.type === 'conversation-viewer-history-chunk'
+        ).length,
+        0,
+        'a restored frame must not replay the backfill'
+    );
+    viewer.dispose();
+});
+
 test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 never offers a frame the Webview stopped reporting', async () => {
     const ids = ['s-a', 's-b', 's-c', 's-d', 's-e', 's-f'];
     const { viewer, panel } = createViewer({


### PR DESCRIPTION
## Summary

Switching away from a conversation detaches its DOM into the Webview's frame
cache so that returning can reattach it for nothing: no HTML on the wire, no
sanitize, no parse, no layout. The Host offers that restore only when the
publication's content signature equals the token the Webview reported for the
frame — and for any conversation large enough to render progressively, it never
can. The frame holds the **converged** document while an `initial` switch
publishes the **partial** first paint, so the two signatures describe different
content by construction.

Returning to a conversation is the most common switch there is, and the frame
cache exists precisely for it, so every return visit resent the first paint and
replayed the whole backfill. The preflight had already reattached the cached
frame as a visual preview, so the reader watched the conversation appear and
then get torn down and rebuilt behind the deferred-history placeholder.

Isolated with a harness that drives A (100 interactions) → B → A exactly as a
real Webview does, acknowledging each publication and slice:

```
before:  restoreFrame false | 158KB HTML on the wire | 4 slices replayed (139KB) | 7 messages
after:   restoreFrame true  |   0KB HTML             | 0 slices                  | 2 messages
```

### Fix

`restorableFramePublication` checks the reported frame first: a progressive
candidate whose session is on that list renders whole once to see whether the
frame still matches, and delivers that whole publication when it does —
`deliverPublication` then turns it into a `restoreFrame` with the HTML omitted.
A mismatch (the transcript moved on while away) falls back to the progressive
first paint, so the Host pays one extra render and nothing else changes.
`hostSessionSwitchMs` is unchanged at 2.7ms.

It also skips the probe when the reported token equals the live applied
signature, because the ordinary delta path is already free in that case.

Owned by `CONVERSATION-LARGE-SESSION-PERFORMANCE-001`, which already covers
session switching and the frame-restore contract; no catalog change needed.

This is the third slice of the switch-experience work, after #402
(stranded deferred history) and #403 (auxiliary state resending the
transcript). Host-side load time was measured and ruled out as a bottleneck:
`loadMs - applicationMs` on real switches is 6–70ms, and
`hostSessionSwitchMs` is 2.7ms.

## Owner approvals

```
approve db0acbf39de4eb61086e1fde1d72dbed6b0059f9
```

## Skill harvest

no skill change — the only near-miss on this branch was a scratch probe whose
size-threshold assertion (`> 100_000` bytes) would have passed on the observed
91KB defect; the committed tests already assert categorically instead
(`typeof message.html === 'string'` count must be 0, `restoreFrame === true`),
so the lesson is already embodied in the tests rather than being a missing
instruction. No existing skill proved wrong or incomplete here.

## Verification

RED first, against the unfixed implementation:
`a reported frame for unchanged content must be restored` (actual `undefined`,
expected `true`).

CI reachability traced before the production edit:
`tests/integration/dashboard/conversationViewer.test.js` →
`test:deterministic:run` → `test:coverage:run` → `test:ci:linux:core`
(`linux-core`), a `pull_request` check.

`origin/main` released 1.2.0 mid-branch. Because this branch had already been
pushed, it was brought current by merging `origin/main` rather than a
force-push, and every gate below was then re-run on the merged tree:

| Check | Result |
| --- | --- |
| `LARGE-SESSION-PERFORMANCE` focused (62 tests) | 62/62 |
| `npm run test:deterministic:run` | unit 1348, contract 1195, integration 471 — all pass |
| `npm run test:browser:run` | 425/425 |
| `npm run test:conversation-performance` | pass; `hostSessionSwitchMs` 2.689ms |
| `npm run test:dashboard:run`, `test:safety:run` | pass |
| `npm run test:behavior-contracts` | pass |
| `npm run lint:ci`, `test:architecture-guards` | pass |
| coverage baseline + changed-coverage | pass, 100.00% (44/44) vs `7168db2a` |
| `git diff --check` | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
