### PR TITLE
fix: install local extensions through the worktree dependency guard

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -2394,6 +2394,20 @@
     ]
   },
   {
+    "id": "LOCAL-INSTALL-WORKTREE-DEPENDENCIES-001",
+    "domain": "release",
+    "title": "Local install prepares dependencies through the worktree guard",
+    "priority": "P2",
+    "status": "automated",
+    "owners": [
+      "tests/unit/tooling/buildTestPackageInstall.test.js"
+    ],
+    "evidence": [
+      "scripts/build-test-package-install.sh",
+      "scripts/with-worktree-dependencies.js"
+    ]
+  },
+  {
     "id": "OPEN-BRIDGE-CLIENT-001",
     "domain": "open-project",
     "title": "Bridge Client behavior",

--- a/scripts/build-test-package-install.sh
+++ b/scripts/build-test-package-install.sh
@@ -24,10 +24,17 @@ run_step() {
 }
 
 if [[ "$SKIP_NPM_CI" != "1" ]]; then
-    run_step npm ci
+    # Delegate to the worktree dependency guard rather than running `npm ci`
+    # directly. Every line of work runs in a worktree, where a bare
+    # project-scoped `npm ci` fails against an inherited user-level
+    # allow-scripts config, and would delete node_modules while another command
+    # in the same worktree is compiling or testing. The guard neutralizes that
+    # config, takes the per-worktree lock, and skips the install entirely when
+    # the dependencies are already current.
+    run_step npm run worktree:bootstrap
 else
     echo
-    echo "==> skipping npm ci because SKIP_NPM_CI=1"
+    echo "==> skipping dependency installation because SKIP_NPM_CI=1"
 fi
 
 run_step npm run test-compile

--- a/tests/unit/tooling/buildTestPackageInstall.test.js
+++ b/tests/unit/tooling/buildTestPackageInstall.test.js
@@ -1,0 +1,115 @@
+'use strict';
+
+// Owner for LOCAL-INSTALL-WORKTREE-DEPENDENCIES-001.
+//
+// scripts/build-test-package-install.sh is the documented local install path,
+// and AGENTS.md requires every line of work to run inside a worktree. The
+// script therefore must install dependencies through the worktree dependency
+// guard rather than a bare `npm ci`: the guard skips the install when the
+// worktree is already current, serializes against concurrent commands in the
+// same worktree, and neutralizes the inherited user-level allow-scripts config
+// that makes a bare project-scoped `npm ci` fail.
+//
+// The script is exercised, not pattern-matched: `npm` and `node` are replaced
+// with recording shims on PATH so the real invocation sequence is observed.
+
+const assert = require('node:assert/strict');
+const childProcess = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const { makeTempDirectory } = require('../../helpers/tempDirectory');
+
+const repositoryRoot = path.resolve(__dirname, '../../..');
+const installScript = path.join(repositoryRoot, 'scripts', 'build-test-package-install.sh');
+
+/** Run the install script with recording shims for npm and node. */
+function runScript(t, { environment = {} } = {}) {
+    const directory = makeTempDirectory(t, 'install-local-');
+    const binDirectory = path.join(directory, 'bin');
+    const logPath = path.join(directory, 'invocations.log');
+    fs.mkdirSync(binDirectory, { recursive: true });
+    for (const executable of ['npm', 'node']) {
+        const shim = path.join(binDirectory, executable);
+        fs.writeFileSync(shim,
+            `#!/usr/bin/env bash\nprintf '%s\\n' "${executable} $*" >> ${JSON.stringify(logPath)}\nexit 0\n`);
+        fs.chmodSync(shim, 0o755);
+    }
+    const result = childProcess.spawnSync('bash', [installScript], {
+        cwd: repositoryRoot,
+        encoding: 'utf8',
+        env: {
+            ...process.env,
+            ...environment,
+            PATH: `${binDirectory}${path.delimiter}${process.env.PATH}`,
+        },
+    });
+    const invocations = fs.existsSync(logPath)
+        ? fs.readFileSync(logPath, 'utf8').split('\n').filter(Boolean)
+        : [];
+    return { result, invocations };
+}
+
+test('LOCAL-INSTALL-WORKTREE-DEPENDENCIES-001 installs dependencies through the worktree guard', t => {
+    const { result, invocations } = runScript(t);
+
+    assert.equal(result.status, 0,
+        `the install script must succeed with stubbed tools: ${result.stderr}`);
+    assert.ok(
+        invocations.some(line => /^npm run worktree:bootstrap$/.test(line)),
+        'the dependency step must delegate to the worktree guard, which handles the '
+            + `allow-scripts config and the worktree lock. Saw: ${JSON.stringify(invocations)}`
+    );
+    assert.ok(
+        !invocations.some(line => /^npm ci\b/.test(line)),
+        'a bare `npm ci` bypasses the guard: it fails under an inherited allow-scripts '
+            + 'config and can delete node_modules while another worktree command runs. '
+            + `Saw: ${JSON.stringify(invocations)}`
+    );
+});
+
+test('LOCAL-INSTALL-WORKTREE-DEPENDENCIES-001 still honours SKIP_NPM_CI for an already-prepared tree', t => {
+    const { result, invocations } = runScript(t, { environment: { SKIP_NPM_CI: '1' } });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.ok(
+        !invocations.some(line => /^npm (ci\b|run worktree:bootstrap$)/.test(line)),
+        `SKIP_NPM_CI=1 must skip the dependency step entirely. Saw: ${JSON.stringify(invocations)}`
+    );
+});
+
+test('LOCAL-INSTALL-WORKTREE-DEPENDENCIES-001 keeps the build, package, and install steps in order', t => {
+    const { invocations } = runScript(t, { environment: { SKIP_NPM_CI: '1' } });
+
+    assert.deepEqual(
+        invocations.filter(line => line !== 'npm run worktree:bootstrap'),
+        [
+            'npm run test-compile',
+            'npm run lint',
+            'npm run package:release',
+            'node scripts/install-local-extensions.js',
+        ],
+        'the install script must build, lint, package, and then route the artifacts'
+    );
+});
+
+test('LOCAL-INSTALL-WORKTREE-DEPENDENCIES-001 fails loudly when a step fails', t => {
+    const directory = makeTempDirectory(t, 'install-local-');
+    const binDirectory = path.join(directory, 'bin');
+    fs.mkdirSync(binDirectory, { recursive: true });
+    // npm fails; node would succeed. The script must not reach node.
+    fs.writeFileSync(path.join(binDirectory, 'npm'),
+        '#!/usr/bin/env bash\necho "boom" >&2\nexit 7\n');
+    fs.chmodSync(path.join(binDirectory, 'npm'), 0o755);
+    fs.writeFileSync(path.join(binDirectory, 'node'), '#!/usr/bin/env bash\nexit 0\n');
+    fs.chmodSync(path.join(binDirectory, 'node'), 0o755);
+
+    const result = childProcess.spawnSync('bash', [installScript], {
+        cwd: repositoryRoot,
+        encoding: 'utf8',
+        env: { ...process.env, PATH: `${binDirectory}${path.delimiter}${process.env.PATH}` },
+    });
+
+    assert.notEqual(result.status, 0,
+        'a failing dependency step must abort the install rather than report success');
+});


### PR DESCRIPTION
## Summary

- Prepare dependencies in `scripts/build-test-package-install.sh` through the
  worktree dependency guard instead of a bare `npm ci`.

Every line of work runs in a worktree, but the local install script ran
`npm ci` directly. Under an inherited user-level allow-scripts config that
fails outright — `EALLOWSCRIPTS`, because project-scoped installs reject
`--allow-scripts` — so `npm run install-local` could not complete in a worktree
without setting `SKIP_NPM_CI=1` and preparing dependencies separately. A bare
`npm ci` also deletes `node_modules`, which the guard exists to prevent while
another command in the same worktree is compiling or testing.

`scripts/with-worktree-dependencies.js` already handles all three concerns: it
strips the inherited allow-scripts config, holds the per-worktree lock, and
skips the install when dependencies are current.

## Verification

- `npm run test:ci:linux:core` (includes coverage gates)
- `npm run test:behavior-contracts`
- `npm run lint:ci`
- `git diff --check`
- End-to-end: `npm run install-local` in a fresh worktree, with no
  `SKIP_NPM_CI` workaround, exits 0 and installs both extensions with verified
  bytes. Before this change the same command exited 1 at the dependency step.

The new owner runs the script with recording shims for `npm` and `node` rather
than pattern-matching its source, so the real invocation sequence is asserted.

## Skill harvest

No skill change. This PR corrects a claim I made while shipping #408: I reported
that `install-local` exits 0 when its dependency step fails. It does not — it
exits 1, and a new owner test now pins that. The wrong reading came from
inspecting `$?` after a compound shell command, where it reported the exit
status of the trailing `tail`, not of npm.

`verification-before-completion` already requires confirming command output
before asserting an outcome, so this was a compliance gap rather than a missing
rule. The durable protection is the executable owner added here, which pins the
real exit-code behaviour instead of relying on a one-off shell reading.

## Owner approvals

```
approve 83fdd16b6f697d6c5bd98ac43c54b6db01758d71
```
