### PR TITLE
fix: follow the conversation's active worktree

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -6177,7 +6177,7 @@
   {
     "id": "WORKTREE-CHANGES-PANEL-001",
     "domain": "webview",
-    "title": "Conversation Changes button and sidebar tab render a two-row member header (repo picker overlay with \u2039 \u203a cycling, position indicator, detached marker, branch row with tracking line) plus the task result and SCM-grouped working changes with collapsible group headers, a complete Files keyboard tree, row-3 collapse/expand-all actions, per-member fold/scroll memory, and a one-time 320px recommendation, with explicit partial/retired degradation, and post exact select/refresh/open/review/SCM intents",
+    "title": "Conversation Changes button and sidebar tab follow the latest resolvable telemetry worktree (with persisted session identity fallback), render a two-row member header (repo picker overlay with \u2039 \u203a cycling, position indicator, detached marker, branch row with tracking line) plus the task result and SCM-grouped working changes with collapsible group headers, a complete Files keyboard tree, row-3 collapse/expand-all actions, per-member fold/scroll memory, and a one-time 320px recommendation, with explicit partial/retired degradation, and post exact select/refresh/open/review/SCM intents",
     "priority": "P0",
     "status": "automated",
     "owners": [

--- a/docs/worktree-changes-panel-prd.md
+++ b/docs/worktree-changes-panel-prd.md
@@ -53,11 +53,12 @@ Worktree 组模型上线后，一个 task（组）对应一到多个物理 workt
 
 权威解析规则（验收标准，顺序不可交换）：
 
-1. 读取 session 持久化的 `worktreeKey`（runtime binding / hydration 结果）；session 运行中 agent 临时 `cd` 产生的工具调用 cwd **不得**覆盖此身份。
-2. 用该 key 查当前 manifest：命中则改动集合 = 该组全部 `ready` member（`worktreeKey` 存在者）。
-3. manifest 未命中 → 查 **retired identity**（含 generation 判断）：命中则走 retired 降级（§7.3）。
-4. 无持久化身份时，用 session 初始 `cwd` 经 `ConversationWorktreeResolver` 做 live fallback：解析出则走**退化单 member 视图**。
-5. 以上皆无（非 git 会话）：按钮 `hidden`。
+1. 遥测报告的最新工作目录经 `ConversationWorktreeResolver` 解析为有效 `worktreeKey` 时，它代表 conversation 当前正在操作的 worktree，优先用于本次 Git 视图；初始 identity 解析期间收到的该遥测必须在激活后重放。
+2. 遥测目录缺失、不是 Git worktree 或解析失败时，读取 session 持久化的 `worktreeKey`（runtime binding / hydration 结果）作为稳定回退身份。
+3. 用上述 key 查当前 manifest：命中则改动集合 = 该组全部 `ready` member（`worktreeKey` 存在者），并默认显示该 key 对应的 member。
+4. manifest 未命中 → 查 **retired identity**（含 generation 判断）：命中则走 retired 降级（§7.3）。
+5. 无持久化身份时，用 session 初始 `cwd` 经 `ConversationWorktreeResolver` 做 live fallback：解析出则走**退化单 member 视图**。
+6. 以上皆无（非 git 会话）：按钮 `hidden`。
 
 跨平台与键值契约（实现前必须修复的现存缺陷）：
 

--- a/src/aiSessions/conversation/conversationChangesController.ts
+++ b/src/aiSessions/conversation/conversationChangesController.ts
@@ -3,6 +3,7 @@
 import * as path from 'path';
 import { createHash } from 'crypto';
 import type * as vscode from 'vscode';
+import { worktreeKeysEqual } from '../../worktreeIdentity';
 import {
     aggregateMemberChanges,
     ChangesCollector,
@@ -43,12 +44,15 @@ interface ChangesMemberSource {
     repoLabel: string;
     branchName: string;
     worktreePath: string;
+    worktreeKey?: WorktreeKey;
     baseline?: MemberBaseline;
     detached?: boolean;
 }
 
 interface ResolvedChangeSet {
     kind: 'ready' | 'retired' | 'unavailable';
+    /** The worktree that determined this view's member set. */
+    worktreeKey?: WorktreeKey;
     members: ChangesMemberSource[];
     /** Primary member of the owning group (default selection anchor). */
     primaryMemberId?: string;
@@ -213,10 +217,20 @@ export class ConversationChangesController {
         await this.collectAndPublish(target);
     }
 
-    /** Piggyback refresh (telemetry cycle fallback, PRD §5.4). */
-    async onTelemetryRefreshed(target: ConversationViewerTarget): Promise<void> {
+    /**
+     * Piggyback refresh (telemetry cycle fallback, PRD §5.4). A resolved
+     * telemetry worktree is the conversation's latest working location and
+     * supersedes its launch-time identity for this live Git view.
+     */
+    async onTelemetryRefreshed(
+        target: ConversationViewerTarget,
+        activeWorktreePath?: string
+    ): Promise<void> {
         if (!this.matchesActive(target)) {
             return;
+        }
+        if (activeWorktreePath) {
+            await this.rebindToActiveWorktree(target, activeWorktreePath);
         }
         await this.collectAndPublish(target);
     }
@@ -596,15 +610,60 @@ export class ConversationChangesController {
 
     /**
      * Authoritative resolution order (PRD §4.1): persisted identity →
-     * manifest → retired identity → live fallback → hidden. A tool
-     * call's cwd never overrides the session's persisted identity.
+     * manifest → retired identity → live fallback → hidden. A resolved
+     * telemetry worktree, when supplied, is the current working location;
+     * otherwise the persisted session identity remains authoritative.
      */
+    private async rebindToActiveWorktree(
+        target: ConversationViewerTarget,
+        activeWorktreePath: string
+    ): Promise<void> {
+        const active = this.active;
+        if (!active || !this.matchesActive(target)) {
+            return;
+        }
+        let worktreeKey: WorktreeKey | undefined;
+        try {
+            worktreeKey = await this.options.resolveWorktreeKey(activeWorktreePath);
+        } catch (_error) {
+            return;
+        }
+        if (!worktreeKey || (active.changeSet.worktreeKey
+            && worktreeKeysEqual(active.changeSet.worktreeKey, worktreeKey))) {
+            return;
+        }
+        const changeSet = await this.resolveChangeSet(target, worktreeKey);
+        if (this.active !== active || !this.matchesActive(target)) {
+            return;
+        }
+        active.watcher?.dispose();
+        active.changeSet = changeSet;
+        active.snapshots.clear();
+        active.selectedMemberId = changeSet.members.find(member =>
+            member.worktreeKey
+            && worktreeKeysEqual(member.worktreeKey, worktreeKey))?.memberId
+            ?? (changeSet.primaryMemberId && changeSet.members.some(member =>
+                member.memberId === changeSet.primaryMemberId)
+                ? changeSet.primaryMemberId
+                : undefined)
+            ?? changeSet.members[0]?.memberId;
+        active.watcher = changeSet.kind === 'ready' && changeSet.members.length
+            ? this.options.watchRepositoryChanges?.(
+                changeSet.members.map(member => member.worktreePath),
+                () => this.handleExternalChange(target))
+            : undefined;
+        if (changeSet.kind !== 'ready') {
+            this.publishState(active);
+        }
+    }
+
     private async resolveChangeSet(
-        target: ConversationViewerTarget
+        target: ConversationViewerTarget,
+        activeWorktreeKey?: WorktreeKey
     ): Promise<ResolvedChangeSet> {
         const identity = await this.options.resolveSessionIdentity(target);
         const navigationIdentity = identity?.navigationIdentity;
-        let key = identity?.worktreeKey;
+        let key = activeWorktreeKey || identity?.worktreeKey;
         if (!key && identity?.cwd) {
             key = await this.options.resolveWorktreeKey(identity.cwd);
         }
@@ -620,12 +679,13 @@ export class ConversationChangesController {
             return members.length
                 ? {
                     kind: 'ready',
+                    worktreeKey: key,
                     members,
                     ...(group.primaryMemberId
                         ? { primaryMemberId: group.primaryMemberId }
                         : {}),
                 }
-                : { kind: 'unavailable', members: [] };
+                : { kind: 'unavailable', worktreeKey: key, members: [] };
         }
         // Retired check must precede the live fallback (PRD §4.1): a
         // deleted worktree's session is retired, not unmanaged.
@@ -634,11 +694,12 @@ export class ConversationChangesController {
                 record.repositoryKey === key!.repositoryKey
                 && record.canonicalWorktreePath === key!.canonicalWorktreePath);
         if (retired) {
-            return { kind: 'retired', members: [] };
+            return { kind: 'retired', worktreeKey: key, members: [] };
         }
         // Degraded single-member view for unmanaged / legacy sessions.
         return {
             kind: 'ready',
+            worktreeKey: key,
             members: [{
                 // Protocol member ids are charset-restricted; hash the
                 // repository key (paths contain separators).
@@ -758,6 +819,7 @@ function memberSource(member: WorktreeGroupMember): ChangesMemberSource {
         repoLabel: repoLabelFromKey(member.repositoryKey),
         branchName: member.branchName,
         worktreePath: member.worktreeKey!.canonicalWorktreePath,
+        worktreeKey: member.worktreeKey,
         ...(member.baseline ? { baseline: member.baseline } : {}),
         ...(member.detached ? { detached: true } : {}),
     };

--- a/src/aiSessions/conversation/conversationChangesController.ts
+++ b/src/aiSessions/conversation/conversationChangesController.ts
@@ -149,6 +149,13 @@ export class ConversationChangesController {
     private pendingCollect = false;
     private state?: ConversationChangesState;
     private activationEpoch = 0;
+    /** Invalidates an older telemetry rebind before it can replace the view. */
+    private rebindEpoch = 0;
+    /** Telemetry can arrive while the initial session identity resolves. */
+    private pendingTelemetryWorktree?: {
+        target: ConversationViewerTarget;
+        path: string;
+    };
     /** Last selected member per session identity (PRD §5.3 选中持久化). */
     private readonly lastSelectionBySession = new Map<string, string>();
     private readonly collector: ChangesCollector;
@@ -167,10 +174,12 @@ export class ConversationChangesController {
 
     reset(): void {
         this.activationEpoch += 1;
+        this.rebindEpoch += 1;
         this.active?.watcher?.dispose();
         this.active = undefined;
         this.state = undefined;
         this.pendingCollect = false;
+        this.pendingTelemetryWorktree = undefined;
     }
 
     /** Target switch / initial load: resolve, collect, publish (PRD §5.4). */
@@ -183,6 +192,7 @@ export class ConversationChangesController {
         }
         this.active?.watcher?.dispose();
         const activationEpoch = ++this.activationEpoch;
+        this.rebindEpoch += 1;
         const changeSet = await this.resolveChangeSet(target);
         if (activationEpoch !== this.activationEpoch) {
             return;
@@ -203,15 +213,25 @@ export class ConversationChangesController {
             ?? changeSet.members[0]?.memberId;
         this.active = active;
         this.state = undefined;
-        if (changeSet.kind !== 'ready') {
+        const pending = this.pendingTelemetryWorktree;
+        if (pending && targetsEqual(pending.target, target)) {
+            this.pendingTelemetryWorktree = undefined;
+            await this.rebindToActiveWorktree(target, pending.path);
+        }
+        const current = this.active;
+        if (!current || !this.matchesActive(target)) {
+            return;
+        }
+        if (current.changeSet.kind !== 'ready') {
             // Terminal kinds publish immediately; a ready change set first
             // collects real snapshots so transient unknown states never
             // render as misleading counts (PRD §4.3).
-            this.publishState(active);
+            this.publishState(current);
         }
-        if (changeSet.kind === 'ready' && changeSet.members.length) {
-            active.watcher = this.options.watchRepositoryChanges?.(
-                changeSet.members.map(member => member.worktreePath),
+        if (current.changeSet.kind === 'ready'
+            && current.changeSet.members.length && !current.watcher) {
+            current.watcher = this.options.watchRepositoryChanges?.(
+                current.changeSet.members.map(member => member.worktreePath),
                 () => this.handleExternalChange(target));
         }
         await this.collectAndPublish(target);
@@ -227,6 +247,12 @@ export class ConversationChangesController {
         activeWorktreePath?: string
     ): Promise<void> {
         if (!this.matchesActive(target)) {
+            if (activeWorktreePath) {
+                this.pendingTelemetryWorktree = {
+                    target,
+                    path: activeWorktreePath,
+                };
+            }
             return;
         }
         if (activeWorktreePath) {
@@ -250,7 +276,8 @@ export class ConversationChangesController {
         }
         // Membership is re-resolved on refresh: add-repo, group merge, or
         // adopt changes the member set without any session switch.
-        const changeSet = await this.resolveChangeSet(active.target);
+        const changeSet = await this.resolveChangeSet(
+            active.target, active.changeSet.worktreeKey);
         if (this.active !== active) {
             return;
         }
@@ -602,10 +629,7 @@ export class ConversationChangesController {
     }
 
     private matchesActive(target: ConversationViewerTarget): boolean {
-        return !!this.active
-            && this.active.target.projectId === target.projectId
-            && this.active.target.provider === target.provider
-            && this.active.target.sessionId === target.sessionId;
+        return !!this.active && targetsEqual(this.active.target, target);
     }
 
     /**
@@ -622,24 +646,30 @@ export class ConversationChangesController {
         if (!active || !this.matchesActive(target)) {
             return;
         }
+        const rebindEpoch = ++this.rebindEpoch;
         let worktreeKey: WorktreeKey | undefined;
         try {
             worktreeKey = await this.options.resolveWorktreeKey(activeWorktreePath);
         } catch (_error) {
             return;
         }
-        if (!worktreeKey || (active.changeSet.worktreeKey
+        if (rebindEpoch !== this.rebindEpoch || this.active !== active
+            || !worktreeKey || (active.changeSet.worktreeKey
             && worktreeKeysEqual(active.changeSet.worktreeKey, worktreeKey))) {
             return;
         }
         const changeSet = await this.resolveChangeSet(target, worktreeKey);
-        if (this.active !== active || !this.matchesActive(target)) {
+        if (rebindEpoch !== this.rebindEpoch || this.active !== active
+            || !this.matchesActive(target)) {
             return;
         }
         active.watcher?.dispose();
-        active.changeSet = changeSet;
-        active.snapshots.clear();
-        active.selectedMemberId = changeSet.members.find(member =>
+        const rebound: ActiveChanges = {
+            target,
+            changeSet,
+            snapshots: new Map(),
+        };
+        rebound.selectedMemberId = changeSet.members.find(member =>
             member.worktreeKey
             && worktreeKeysEqual(member.worktreeKey, worktreeKey))?.memberId
             ?? (changeSet.primaryMemberId && changeSet.members.some(member =>
@@ -647,13 +677,14 @@ export class ConversationChangesController {
                 ? changeSet.primaryMemberId
                 : undefined)
             ?? changeSet.members[0]?.memberId;
-        active.watcher = changeSet.kind === 'ready' && changeSet.members.length
+        rebound.watcher = changeSet.kind === 'ready' && changeSet.members.length
             ? this.options.watchRepositoryChanges?.(
                 changeSet.members.map(member => member.worktreePath),
                 () => this.handleExternalChange(target))
             : undefined;
+        this.active = rebound;
         if (changeSet.kind !== 'ready') {
-            this.publishState(active);
+            this.publishState(rebound);
         }
     }
 
@@ -900,4 +931,13 @@ function isContainedIn(root: string, candidate: string): boolean {
 
 function sessionKey(target: ConversationViewerTarget): string {
     return `${target.projectId}:${target.provider}:${target.sessionId}`;
+}
+
+function targetsEqual(
+    left: ConversationViewerTarget,
+    right: ConversationViewerTarget
+): boolean {
+    return left.projectId === right.projectId
+        && left.provider === right.provider
+        && left.sessionId === right.sessionId;
 }

--- a/src/aiSessions/conversation/conversationTelemetryController.ts
+++ b/src/aiSessions/conversation/conversationTelemetryController.ts
@@ -39,7 +39,10 @@ export interface ConversationTelemetryControllerOptions {
     rebuildLatestDocument: () => void;
     /** Fires after each successful telemetry publish (changes-panel PRD
      * §5.4: the telemetry cycle is the changes collector's fallback). */
-    onDidPublish?: (target: ConversationViewerTarget) => void;
+    onDidPublish?: (
+        target: ConversationViewerTarget,
+        telemetry: ConversationTelemetry | undefined
+    ) => void;
     setTimer?: (callback: () => void, delayMs: number) => TimerHandle;
     clearTimer?: (handle: TimerHandle) => void;
 }
@@ -186,7 +189,7 @@ export class ConversationTelemetryController {
             && this.options.getSubscriptionGeneration() === generation) {
             this.options.rebuildLatestDocument();
         }
-        this.options.onDidPublish?.(target);
+        this.options.onDidPublish?.(target, telemetry);
     }
 
     private scheduleRefresh(): void {

--- a/src/aiSessions/conversation/viewer.ts
+++ b/src/aiSessions/conversation/viewer.ts
@@ -576,8 +576,11 @@ export class ConversationViewer implements ConversationViewerApi {
             getCurrentRequestId: () => this.currentRequestId,
             isSuspended: () => this.suspended,
             rebuildLatestDocument: () => this.rebuildLatestDocument(),
-            onDidPublish: target => {
-                void this.changesController?.onTelemetryRefreshed(target);
+            onDidPublish: (target, telemetry) => {
+                void this.changesController?.onTelemetryRefreshed(
+                    target,
+                    telemetry?.worktree?.worktreeRoot
+                );
             },
             setTimer: options.setTimer,
             clearTimer: options.clearTimer,

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1920,9 +1920,9 @@ async function initializeDashboard(
             }
         },
         changes: {
-            // PRD §4.1: the session's persisted identity first — view
-            // models carry worktreeKey/cwd; a tool call's transient cwd
-            // never participates.
+            // PRD §4.1 fallback identity: a valid telemetry worktree takes
+            // precedence in the live Changes view; this persisted session
+            // worktree/cwd remains the stable fallback.
             resolveSessionIdentity: async target => {
                 const actionTarget = getCurrentWorkspaceActionTarget(target.projectId);
                 if (!actionTarget) {

--- a/tests/unit/aiSessions/conversationChangesController.test.js
+++ b/tests/unit/aiSessions/conversationChangesController.test.js
@@ -13,6 +13,7 @@ const {
 const REPO_KEY = '/repos/api/.git';
 const WT_PATH = '/repos/api/.worktrees/fix-login';
 const ACTIVE_WT_PATH = '/repos/api/.worktrees/refactor-auth';
+const OLDER_WT_PATH = '/repos/api/.worktrees/older-task';
 const BASELINE = {
     commitSha: 'a'.repeat(40),
     capturedAt: 1724000000000,
@@ -573,30 +574,37 @@ test('WORKTREE-CHANGES-PANEL-001 follows the worktree currently modified by the 
     const { posted, controller } = fixture({
         resolveWorktreeKey: async candidate =>
             candidate === ACTIVE_WT_PATH ? activeKey : undefined,
-        findGroupByWorktreeKey: () => ({
-            groupId: 'group-1',
-            primaryMemberId: 'member-1',
-            members: [{
-                memberId: 'member-1',
-                repositoryKey: REPO_KEY,
-                worktreeKey: {
-                    repositoryKey: REPO_KEY,
-                    canonicalWorktreePath: WT_PATH,
+        findGroupByWorktreeKey: (_navigationIdentity, key) =>
+            key.canonicalWorktreePath === ACTIVE_WT_PATH
+                ? {
+                    groupId: 'group-2',
+                    primaryMemberId: 'member-2',
+                    members: [{
+                        memberId: 'member-2',
+                        repositoryKey: REPO_KEY,
+                        worktreeKey: activeKey,
+                        branchName: 'agent-pivot/refactor-auth',
+                        path: ACTIVE_WT_PATH,
+                        state: 'ready',
+                        baseline: BASELINE,
+                    }],
+                }
+                : {
+                    groupId: 'group-1',
+                    primaryMemberId: 'member-1',
+                    members: [{
+                        memberId: 'member-1',
+                        repositoryKey: REPO_KEY,
+                        worktreeKey: {
+                            repositoryKey: REPO_KEY,
+                            canonicalWorktreePath: WT_PATH,
+                        },
+                        branchName: 'agent-pivot/fix-login',
+                        path: WT_PATH,
+                        state: 'ready',
+                        baseline: BASELINE,
+                    }],
                 },
-                branchName: 'agent-pivot/fix-login',
-                path: WT_PATH,
-                state: 'ready',
-                baseline: BASELINE,
-            }, {
-                memberId: 'member-2',
-                repositoryKey: REPO_KEY,
-                worktreeKey: activeKey,
-                branchName: 'agent-pivot/refactor-auth',
-                path: ACTIVE_WT_PATH,
-                state: 'ready',
-                baseline: BASELINE,
-            }],
-        }),
     });
 
     await controller.activate(TARGET);
@@ -609,6 +617,218 @@ test('WORKTREE-CHANGES-PANEL-001 follows the worktree currently modified by the 
     assert.equal(state.selectedMemberId, 'member-2');
     assert.equal(state.detail.memberId, 'member-2',
         'the Git sidebar switches to the worktree where the conversation is working');
+
+    await controller.handleRefresh();
+    assert.equal(lastChanges(posted).selectedMemberId, 'member-2',
+        'a manual refresh retains the telemetry-derived active worktree');
+});
+
+test('WORKTREE-CHANGES-PANEL-001 replays telemetry received during initial changes activation', async () => {
+    let releaseIdentity;
+    let identityCalls = 0;
+    const activeKey = {
+        repositoryKey: REPO_KEY,
+        canonicalWorktreePath: ACTIVE_WT_PATH,
+    };
+    const { posted, controller } = fixture({
+        resolveSessionIdentity: () => {
+            identityCalls += 1;
+            if (identityCalls > 1) {
+                return Promise.resolve({
+                    worktreeKey: {
+                        repositoryKey: REPO_KEY,
+                        canonicalWorktreePath: WT_PATH,
+                    },
+                    navigationIdentity: 'nav',
+                });
+            }
+            return new Promise(resolve => {
+                releaseIdentity = resolve;
+            });
+        },
+        resolveWorktreeKey: async candidate =>
+            candidate === ACTIVE_WT_PATH ? activeKey : undefined,
+        findGroupByWorktreeKey: (_navigationIdentity, key) =>
+            key.canonicalWorktreePath === ACTIVE_WT_PATH
+                ? {
+                    groupId: 'group-2',
+                    primaryMemberId: 'member-2',
+                    members: [{
+                        memberId: 'member-2',
+                        repositoryKey: REPO_KEY,
+                        worktreeKey: activeKey,
+                        branchName: 'agent-pivot/refactor-auth',
+                        path: ACTIVE_WT_PATH,
+                        state: 'ready',
+                        baseline: BASELINE,
+                    }],
+                }
+                : {
+                    groupId: 'group-1',
+                    primaryMemberId: 'member-1',
+                    members: [{
+                        memberId: 'member-1',
+                        repositoryKey: REPO_KEY,
+                        worktreeKey: {
+                            repositoryKey: REPO_KEY,
+                            canonicalWorktreePath: WT_PATH,
+                        },
+                        branchName: 'agent-pivot/fix-login',
+                        path: WT_PATH,
+                        state: 'ready',
+                        baseline: BASELINE,
+                    }],
+                },
+    });
+
+    const activation = controller.activate(TARGET);
+    await new Promise(resolve => setImmediate(resolve));
+    await controller.onTelemetryRefreshed(TARGET, ACTIVE_WT_PATH);
+    releaseIdentity({
+        worktreeKey: {
+            repositoryKey: REPO_KEY,
+            canonicalWorktreePath: WT_PATH,
+        },
+        navigationIdentity: 'nav',
+    });
+    await activation;
+
+    assert.equal(lastChanges(posted).selectedMemberId, 'member-2',
+        'the first visible Changes state honors the already-resolved worktree');
+});
+
+test('WORKTREE-CHANGES-PANEL-001 discards an old collection when telemetry changes worktrees', async () => {
+    let releaseOldCollection;
+    const oldCollection = new Promise(resolve => {
+        releaseOldCollection = resolve;
+    });
+    let oldCollectionStarted = false;
+    const activeKey = {
+        repositoryKey: REPO_KEY,
+        canonicalWorktreePath: ACTIVE_WT_PATH,
+    };
+    const { posted, controller } = fixture({
+        resolveWorktreeKey: async candidate =>
+            candidate === ACTIVE_WT_PATH ? activeKey : undefined,
+        findGroupByWorktreeKey: (_navigationIdentity, key) =>
+            key.canonicalWorktreePath === ACTIVE_WT_PATH
+                ? {
+                    groupId: 'group-2', primaryMemberId: 'member-2', members: [{
+                        memberId: 'member-2', repositoryKey: REPO_KEY,
+                        worktreeKey: activeKey,
+                        branchName: 'agent-pivot/refactor-auth',
+                        path: ACTIVE_WT_PATH, state: 'ready', baseline: BASELINE,
+                    }],
+                }
+                : {
+                    groupId: 'group-1', primaryMemberId: 'member-1', members: [{
+                        memberId: 'member-1', repositoryKey: REPO_KEY,
+                        worktreeKey: {
+                            repositoryKey: REPO_KEY,
+                            canonicalWorktreePath: WT_PATH,
+                        },
+                        branchName: 'agent-pivot/fix-login',
+                        path: WT_PATH, state: 'ready', baseline: BASELINE,
+                    }],
+                },
+        collector: new ChangesCollector({
+            execGit: async (args, cwd) => {
+                if (args.includes('status')) {
+                    if (cwd === WT_PATH && !oldCollectionStarted) {
+                        oldCollectionStarted = true;
+                        await oldCollection;
+                        return { stdout: ' M stale.ts\0', stderr: '' };
+                    }
+                    return {
+                        stdout: cwd === ACTIVE_WT_PATH
+                            ? ' M active.ts\0' : '',
+                        stderr: '',
+                    };
+                }
+                if (args.includes('merge-base')) return { stdout: '', stderr: '' };
+                if (args.includes('rev-list')) return { stdout: '0\n', stderr: '' };
+                if (args.includes('diff')) return { stdout: '', stderr: '' };
+                return { stdout: '', stderr: '' };
+            },
+            now: () => 1724000000000,
+        }),
+    });
+
+    const activation = controller.activate(TARGET);
+    for (let attempt = 0; attempt < 20 && !oldCollectionStarted; attempt += 1) {
+        await new Promise(resolve => setImmediate(resolve));
+    }
+    assert.equal(oldCollectionStarted, true, 'the old worktree collection began');
+
+    await controller.onTelemetryRefreshed(TARGET, ACTIVE_WT_PATH);
+    releaseOldCollection();
+    await activation;
+
+    const states = posted.filter(message =>
+        message.type === 'conversation-viewer-changes' && message.version === 2
+    ).map(message => message.changes);
+    assert.ok(states.length > 0, 'the rebound worktree publishes a new state');
+    assert.ok(states.every(state => state.selectedMemberId === 'member-2'),
+        'no result collected for the old worktree is published after the rebind');
+    assert.deepEqual(lastChanges(posted).detail.items.map(item => item.path),
+        ['active.ts']);
+});
+
+test('WORKTREE-CHANGES-PANEL-001 keeps the newest telemetry worktree when resolutions finish out of order', async () => {
+    let releaseOlder;
+    let releaseActive;
+    const olderResolution = new Promise(resolve => { releaseOlder = resolve; });
+    const activeResolution = new Promise(resolve => { releaseActive = resolve; });
+    const olderKey = {
+        repositoryKey: REPO_KEY,
+        canonicalWorktreePath: OLDER_WT_PATH,
+    };
+    const activeKey = {
+        repositoryKey: REPO_KEY,
+        canonicalWorktreePath: ACTIVE_WT_PATH,
+    };
+    const groupFor = (memberId, key) => ({
+        groupId: `group-${memberId}`,
+        primaryMemberId: memberId,
+        members: [{
+            memberId,
+            repositoryKey: REPO_KEY,
+            worktreeKey: key,
+            branchName: `agent-pivot/${memberId}`,
+            path: key.canonicalWorktreePath,
+            state: 'ready',
+            baseline: BASELINE,
+        }],
+    });
+    const { posted, controller } = fixture({
+        resolveWorktreeKey: candidate => {
+            if (candidate === OLDER_WT_PATH) return olderResolution;
+            if (candidate === ACTIVE_WT_PATH) return activeResolution;
+            return Promise.resolve(undefined);
+        },
+        findGroupByWorktreeKey: (_navigationIdentity, key) =>
+            key.canonicalWorktreePath === OLDER_WT_PATH
+                ? groupFor('member-older', olderKey)
+                : key.canonicalWorktreePath === ACTIVE_WT_PATH
+                    ? groupFor('member-active', activeKey)
+                    : groupFor('member-launch', {
+                        repositoryKey: REPO_KEY,
+                        canonicalWorktreePath: WT_PATH,
+                    }),
+    });
+    await controller.activate(TARGET);
+
+    const older = controller.onTelemetryRefreshed(TARGET, OLDER_WT_PATH);
+    await new Promise(resolve => setImmediate(resolve));
+    const active = controller.onTelemetryRefreshed(TARGET, ACTIVE_WT_PATH);
+    await new Promise(resolve => setImmediate(resolve));
+    releaseActive(activeKey);
+    await active;
+    releaseOlder(olderKey);
+    await older;
+
+    assert.equal(lastChanges(posted).selectedMemberId, 'member-active',
+        'a late resolution cannot replace the newer worktree selection');
 });
 
 test('WORKTREE-CHANGES-COMMITS-001 commits list responds with the stamped generation and member correlation', async () => {

--- a/tests/unit/aiSessions/conversationChangesController.test.js
+++ b/tests/unit/aiSessions/conversationChangesController.test.js
@@ -12,6 +12,7 @@ const {
 
 const REPO_KEY = '/repos/api/.git';
 const WT_PATH = '/repos/api/.worktrees/fix-login';
+const ACTIVE_WT_PATH = '/repos/api/.worktrees/refactor-auth';
 const BASELINE = {
     commitSha: 'a'.repeat(40),
     capturedAt: 1724000000000,
@@ -562,6 +563,52 @@ test('WORKTREE-CHANGES-PANEL-001 refresh re-resolves membership changes', async 
         'a member swap surfaces without reopening the conversation');
     assert.equal(state.selectedMemberId, 'member-2',
         'a vanished selection falls back to a live member');
+});
+
+test('WORKTREE-CHANGES-PANEL-001 follows the worktree currently modified by the conversation', async () => {
+    const activeKey = {
+        repositoryKey: REPO_KEY,
+        canonicalWorktreePath: ACTIVE_WT_PATH,
+    };
+    const { posted, controller } = fixture({
+        resolveWorktreeKey: async candidate =>
+            candidate === ACTIVE_WT_PATH ? activeKey : undefined,
+        findGroupByWorktreeKey: () => ({
+            groupId: 'group-1',
+            primaryMemberId: 'member-1',
+            members: [{
+                memberId: 'member-1',
+                repositoryKey: REPO_KEY,
+                worktreeKey: {
+                    repositoryKey: REPO_KEY,
+                    canonicalWorktreePath: WT_PATH,
+                },
+                branchName: 'agent-pivot/fix-login',
+                path: WT_PATH,
+                state: 'ready',
+                baseline: BASELINE,
+            }, {
+                memberId: 'member-2',
+                repositoryKey: REPO_KEY,
+                worktreeKey: activeKey,
+                branchName: 'agent-pivot/refactor-auth',
+                path: ACTIVE_WT_PATH,
+                state: 'ready',
+                baseline: BASELINE,
+            }],
+        }),
+    });
+
+    await controller.activate(TARGET);
+    assert.equal(lastChanges(posted).selectedMemberId, 'member-1',
+        'the persisted session worktree supplies the initial selection');
+
+    await controller.onTelemetryRefreshed(TARGET, ACTIVE_WT_PATH);
+
+    const state = lastChanges(posted);
+    assert.equal(state.selectedMemberId, 'member-2');
+    assert.equal(state.detail.memberId, 'member-2',
+        'the Git sidebar switches to the worktree where the conversation is working');
 });
 
 test('WORKTREE-CHANGES-COMMITS-001 commits list responds with the stamped generation and member correlation', async () => {

--- a/tests/unit/aiSessions/conversationTelemetryController.test.js
+++ b/tests/unit/aiSessions/conversationTelemetryController.test.js
@@ -38,6 +38,7 @@ function target(sessionId = 'session-telemetry') {
 
 test('CONVERSATION-TELEMETRY-CONTROLLER-001 publishes only current correlated reads', async () => {
     const posted = [];
+    const published = [];
     const activeTarget = target();
     let resolveRead;
     let generation = 2;
@@ -59,6 +60,9 @@ test('CONVERSATION-TELEMETRY-CONTROLLER-001 publishes only current correlated re
         getCurrentRequestId: () => requestId,
         isSuspended: () => false,
         rebuildLatestDocument() {},
+        onDidPublish: (publishedTarget, telemetry) => {
+            published.push({ publishedTarget, telemetry });
+        },
     });
     const refresh = controller.refresh(activeTarget, generation);
     requestId = 8;
@@ -78,6 +82,10 @@ test('CONVERSATION-TELEMETRY-CONTROLLER-001 publishes only current correlated re
         subscriptionGeneration: 2,
         telemetry: controller.snapshot,
     }]);
+    assert.deepEqual(published, [{
+        publishedTarget: activeTarget,
+        telemetry: controller.snapshot,
+    }], 'consumers receive the resolved telemetry worktree with the refresh');
 
     generation = 3;
     controller.reset();


### PR DESCRIPTION
## Summary

- Bind the Conversation Changes sidebar to the latest resolvable telemetry worktree.
- Preserve that selection through refreshes, delayed activation, in-flight collection, and out-of-order telemetry.
- Document the telemetry-first identity rule and its persisted-session fallback.

## Verification

- `npm run test-compile`
- Focused Conversation Changes and telemetry unit tests
- `npm run test:behavior-contracts`
- `node --test tests/integration/dashboard/conversationViewer.test.js`
- `npm run install-local` (package and remote workspace-extension byte verification)

## Skill harvest

No skill change: the multi-perspective review findings were product-specific, and the existing review and publishing skills already prescribe the applicable review, verification, and PR-body steps.

## Owner approvals

```
approve 9b792cf1de99a7bac898a27245c5df3afedb8d1d
```