### PR TITLE
fix: keep AI Conversation readers pinned to the tail

### DIFF
--- a/.skills/resilient-webview-mutation-protocols/SKILL.md
+++ b/.skills/resilient-webview-mutation-protocols/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: resilient-webview-mutation-protocols
-description: Use when Agent Pivot VS Code Webviews submit Host-owned mutations or authoritative HTML replacement, mirrored persistence, stale acknowledgements, stuck pending UI, focus loss, or partial batch failures are in scope.
+description: Use when editing any Agent Pivot Webview script under `src/webview/` or its `media/` runtime copy, and when Webviews submit Host-owned mutations or authoritative HTML replacement, mirrored persistence, stale acknowledgements, stuck pending UI, focus loss, or partial batch failures are in scope.
 ---
 
 # Resilient Webview Mutation Protocols

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -1995,6 +1995,20 @@
     ]
   },
   {
+    "id": "CONVERSATION-TAIL-FOLLOW-001",
+    "domain": "webview",
+    "title": "AI Conversation keeps a reader who is following the conversation tail pinned to it across deferred history backfill, live refreshes, and a Session switch away and back, including when lazily decoded images or late diagram renders grow the transcript beneath them without emitting a scroll event",
+    "priority": "P0",
+    "status": "automated",
+    "owners": [
+      "tests/browser/conversationViewer.test.js"
+    ],
+    "evidence": [
+      "src/webview/conversationViewerScripts.js",
+      "src/webview/conversationReconcileScripts.js"
+    ]
+  },
+  {
     "id": "CONVERSATION-SEEK-LATEST-COMMAND-001",
     "domain": "session",
     "title": "Seek to Latest Conversation Interaction command reveals the open AI Conversation editor and navigates to its latest interaction exactly like the Latest navigation button, and points the user to open an editor when none is open",

--- a/media/conversationReconcileScripts.js
+++ b/media/conversationReconcileScripts.js
@@ -101,12 +101,22 @@
         function attach() {
             scroll.addEventListener('scroll', trackConversationEnd, { passive: true });
             if (typeof ResizeObserver === 'function') {
-                var viewportObserver = new ResizeObserver(function () {
+                var followObserver = new ResizeObserver(function () {
                     if (state.followingEnd) scrollToConversationEnd();
                 });
-                viewportObserver.observe(scroll);
+                followObserver.observe(scroll);
+                // The transcript growing under a reader who is following
+                // the end moves the end away from them exactly like the
+                // viewport shrinking does, and it happens long after the
+                // page applied: images decode lazily and Mermaid diagrams
+                // render asynchronously. Growth emits no scroll event, so
+                // without this the physical offset silently drifts past the
+                // auto-scroll threshold while the reader never moved, and
+                // every later check that reads that offset — live refresh
+                // follow, frame stashing — concludes they walked away.
+                followObserver.observe(messages);
                 window.addEventListener('unload', function () {
-                    viewportObserver.disconnect();
+                    followObserver.disconnect();
                 });
             }
         }

--- a/media/conversationViewerScripts.js
+++ b/media/conversationViewerScripts.js
@@ -2864,6 +2864,7 @@
         }
         var previousScrollHeight = scroll.scrollHeight;
         var previousScrollTop = scroll.scrollTop;
+        var previousScrollRange = previousScrollHeight - scroll.clientHeight;
         placeholder.after(template.content);
         if (message.complete) {
             placeholder.remove();
@@ -2895,10 +2896,15 @@
         );
         applyWorklogStates();
         // Content grew above the viewport: compensate so the same messages
-        // stay under the reader's eyes. A reader parked at the very top is
-        // waiting for this history, so keep that offset untouched.
+        // stay under the reader's eyes. A reader who scrolled to the very
+        // top is waiting for this history, so keep that offset untouched.
+        // Offset 0 alone does not prove that: a progressive first screen
+        // shorter than the viewport cannot scroll, so a reader looking at
+        // the tail also reports 0, and skipping the compensation there
+        // strands them on the oldest interaction the backfill delivers.
         var heightDelta = scroll.scrollHeight - previousScrollHeight;
-        if (heightDelta > 0 && previousScrollTop > 0) {
+        var parkedAtTop = previousScrollTop <= 0 && previousScrollRange > 0;
+        if (heightDelta > 0 && !parkedAtTop) {
             scroll.scrollTop = previousScrollTop + heightDelta;
         }
         reconcileController.trackEnd();

--- a/src/webview/conversationReconcileScripts.js
+++ b/src/webview/conversationReconcileScripts.js
@@ -101,12 +101,22 @@
         function attach() {
             scroll.addEventListener('scroll', trackConversationEnd, { passive: true });
             if (typeof ResizeObserver === 'function') {
-                var viewportObserver = new ResizeObserver(function () {
+                var followObserver = new ResizeObserver(function () {
                     if (state.followingEnd) scrollToConversationEnd();
                 });
-                viewportObserver.observe(scroll);
+                followObserver.observe(scroll);
+                // The transcript growing under a reader who is following
+                // the end moves the end away from them exactly like the
+                // viewport shrinking does, and it happens long after the
+                // page applied: images decode lazily and Mermaid diagrams
+                // render asynchronously. Growth emits no scroll event, so
+                // without this the physical offset silently drifts past the
+                // auto-scroll threshold while the reader never moved, and
+                // every later check that reads that offset — live refresh
+                // follow, frame stashing — concludes they walked away.
+                followObserver.observe(messages);
                 window.addEventListener('unload', function () {
-                    viewportObserver.disconnect();
+                    followObserver.disconnect();
                 });
             }
         }

--- a/src/webview/conversationViewerScripts.js
+++ b/src/webview/conversationViewerScripts.js
@@ -2864,6 +2864,7 @@
         }
         var previousScrollHeight = scroll.scrollHeight;
         var previousScrollTop = scroll.scrollTop;
+        var previousScrollRange = previousScrollHeight - scroll.clientHeight;
         placeholder.after(template.content);
         if (message.complete) {
             placeholder.remove();
@@ -2895,10 +2896,15 @@
         );
         applyWorklogStates();
         // Content grew above the viewport: compensate so the same messages
-        // stay under the reader's eyes. A reader parked at the very top is
-        // waiting for this history, so keep that offset untouched.
+        // stay under the reader's eyes. A reader who scrolled to the very
+        // top is waiting for this history, so keep that offset untouched.
+        // Offset 0 alone does not prove that: a progressive first screen
+        // shorter than the viewport cannot scroll, so a reader looking at
+        // the tail also reports 0, and skipping the compensation there
+        // strands them on the oldest interaction the backfill delivers.
         var heightDelta = scroll.scrollHeight - previousScrollHeight;
-        if (heightDelta > 0 && previousScrollTop > 0) {
+        var parkedAtTop = previousScrollTop <= 0 && previousScrollRange > 0;
+        if (heightDelta > 0 && !parkedAtTop) {
             scroll.scrollTop = previousScrollTop + heightDelta;
         }
         reconcileController.trackEnd();

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -18897,6 +18897,281 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-002 applies history chunks in place
         '[data-conversation-messages] [data-message-id]').count(), 12);
 });
 
+// A progressively rendered page opens on its tail. When that tail is short
+// enough that the viewport cannot scroll yet, the reader sits at the end
+// with scrollTop 0 — by offset alone indistinguishable from a reader who
+// deliberately scrolled to the very top to wait for older history. The
+// backfill must not strand them on the oldest interaction.
+test('CONVERSATION-TAIL-FOLLOW-001 keeps the tail in view when deferred history backfills below a first screen that cannot scroll yet', async t => {
+    const page = await openViewerPage(t);
+    await page.addStyleTag({
+        content: '.tail-block { height: 30px; margin: 0; }',
+    });
+    const article = index => `<article data-message-id="tail-${index}" `
+        + `data-interaction-id="tail-input-${index}">`
+        + '<section class="conversation-markdown">'
+        + `<p class="tail-block">tail block ${index}</p>`
+        + '</section></article>';
+    await sendPage(page, {
+        type: 'conversation-viewer-page',
+        version: 1,
+        requestId: 1,
+        subscriptionGeneration: 1,
+        updateKind: 'initial',
+        html: '<section class="conversation-deferred-messages">'
+            + 'Loading earlier messages…</section>'
+            + [6, 7, 8].map(article).join(''),
+        htmlSignature: 'tail-partial',
+        outline: Array.from({ length: 9 }, (_item, index) => ({
+            interactionId: `tail-input-${index}`,
+            userPreview: `input ${index}`,
+            responseState: 'complete',
+        })),
+        selectedInteractionId: 'tail-input-8',
+        selectedInput: 9,
+        totalInputs: 9,
+        partial: false,
+        atLatest: true,
+        stale: false,
+        subagents: [],
+        activeSubagent: null,
+    });
+    await page.waitForFunction(() => window.__postedMessages.some(message =>
+        message.type === 'conversation-viewer-applied'
+            && message.htmlSignature === 'tail-partial'
+    ));
+
+    const opened = await page.evaluate(() => {
+        const scroll = document.querySelector('[data-conversation-scroll]');
+        return {
+            scrollTop: scroll.scrollTop,
+            scrollRange: scroll.scrollHeight - scroll.clientHeight,
+        };
+    });
+    assert.equal(opened.scrollTop, 0);
+    assert.ok(opened.scrollRange <= 0,
+        'the short first screen must not be scrollable for this check, got'
+            + ` a range of ${opened.scrollRange}px`);
+
+    await sendPage(page, {
+        type: 'conversation-viewer-history-chunk',
+        version: 1,
+        subscriptionGeneration: 1,
+        requestId: 2,
+        html: [3, 4, 5].map(article).join(''),
+        htmlSignature: 'tail-mid',
+        complete: false,
+    });
+    await sendPage(page, {
+        type: 'conversation-viewer-history-chunk',
+        version: 1,
+        subscriptionGeneration: 1,
+        requestId: 3,
+        html: [0, 1, 2].map(article).join(''),
+        htmlSignature: 'tail-full',
+        complete: true,
+    });
+
+    const settled = await page.evaluate(() => {
+        const scroll = document.querySelector('[data-conversation-scroll]');
+        const viewport = scroll.getBoundingClientRect();
+        const newest = document.querySelector('[data-message-id="tail-8"]')
+            .getBoundingClientRect();
+        return {
+            count: document.querySelectorAll(
+                '[data-conversation-messages] [data-message-id]'
+            ).length,
+            placeholder: document.querySelectorAll(
+                '.conversation-deferred-messages'
+            ).length,
+            distanceToEnd: scroll.scrollHeight - scroll.clientHeight
+                - scroll.scrollTop,
+            newestFullyVisible: newest.top >= viewport.top - 1
+                && newest.bottom <= viewport.bottom + 1,
+        };
+    });
+    assert.equal(settled.count, 9, 'every backfilled slice is applied');
+    assert.equal(settled.placeholder, 0, 'the completing slice clears it');
+    assert.ok(settled.distanceToEnd <= 8,
+        'backfilling below a not-yet-scrollable first screen must keep the'
+            + ` reader on the tail, got ${settled.distanceToEnd}px to the end`);
+    assert.equal(settled.newestFullyVisible, true,
+        'the newest interaction stays rendered inside the viewport');
+});
+
+// Lazily decoded images and late Mermaid renders grow the transcript after
+// the reader settled on its end. No scroll event fires, so nothing tells
+// the viewer the reader is still there — the end must come back to them,
+// or every later check that reads the physical offset (live refresh follow,
+// frame stashing) concludes they walked away into the history.
+const asyncGrowthPage = (generation, sessionId, marker, signature,
+    options = {}) => {
+    const message = {
+        type: 'conversation-viewer-page',
+        version: 1,
+        requestId: options.requestId || generation * 10,
+        subscriptionGeneration: generation,
+        updateKind: options.updateKind || 'initial',
+        html: Array.from({ length: 8 }, (_item, index) =>
+            `<article data-message-id="${marker}-${index}" `
+                + `data-interaction-id="${marker}-input-${index}">`
+                + '<section class="conversation-markdown">'
+                + `<p class="grow-block">${marker} block ${index}</p>`
+                + '</section></article>').join(''),
+        htmlSignature: signature,
+        outline: Array.from({ length: 8 }, (_item, index) => ({
+            interactionId: `${marker}-input-${index}`,
+            userPreview: `${marker} ${index}`,
+            responseState: 'complete',
+        })),
+        selectedInteractionId: `${marker}-input-7`,
+        selectedInput: 8,
+        totalInputs: 8,
+        partial: false,
+        atLatest: true,
+        stale: false,
+        subagents: [],
+        activeSubagent: null,
+        target: {
+            projectId: 'project-1',
+            provider: 'codex',
+            sessionId,
+            interactionId: `${marker}-input-7`,
+            displayName: `${marker} session`,
+        },
+        comments: { revision: 0, comments: [] },
+        projectComments: { revision: 0, comments: [] },
+        bookmarks: { revision: 0, interactionIds: [] },
+    };
+    if (options.restoreFrame) {
+        delete message.html;
+        message.restoreFrame = true;
+    }
+    return message;
+};
+
+// Grows the last interaction the way a lazily decoded image does: below
+// the reader, after the page applied, without any scroll event.
+async function growTranscriptTail(page, marker) {
+    const before = await page.evaluate(() => document.querySelector(
+        '[data-conversation-scroll]').scrollHeight);
+    await page.evaluate(id => {
+        const block = document.createElement('p');
+        block.className = 'grown-block';
+        block.textContent = 'late image';
+        document.querySelector(`[data-message-id="${id}"] section`)
+            .append(block);
+    }, `${marker}-7`);
+    await page.evaluate(() => new Promise(resolve => requestAnimationFrame(
+        () => requestAnimationFrame(resolve))));
+    return page.evaluate(previous => {
+        const scroll = document.querySelector('[data-conversation-scroll]');
+        return {
+            growth: scroll.scrollHeight - previous,
+            distanceToEnd: scroll.scrollHeight - scroll.clientHeight
+                - scroll.scrollTop,
+        };
+    }, before);
+}
+
+async function openGrownTail(t, marker) {
+    const page = await openViewerPage(t);
+    await page.addStyleTag({
+        content: '.grow-block { height: 120px; margin: 0; }'
+            + ' .grown-block { height: 300px; margin: 0; }',
+    });
+    await sendPage(page, asyncGrowthPage(2, 'session-grow', marker, 'sig-g1'));
+    await page.waitForFunction(() => window.__postedMessages.some(message =>
+        message.type === 'conversation-viewer-applied'
+            && message.htmlSignature === 'sig-g1'
+    ));
+    assert.equal(await page.evaluate(() => {
+        const scroll = document.querySelector('[data-conversation-scroll]');
+        return scroll.scrollHeight - scroll.clientHeight - scroll.scrollTop;
+    }), 0, 'opening at the latest interaction lands on the end');
+
+    const grown = await growTranscriptTail(page, marker);
+    assert.equal(grown.growth, 300,
+        `the growth must move the end out of reach, got ${grown.growth}px`);
+    assert.ok(grown.distanceToEnd <= 8,
+        'growth beneath a reader who is following the end keeps them on the'
+            + ` end, got ${grown.distanceToEnd}px to the end`);
+    return page;
+}
+
+test('CONVERSATION-TAIL-FOLLOW-001 still follows the tail on a live refresh after the transcript grew asynchronously beneath the reader', async t => {
+    const page = await openGrownTail(t, 'grow');
+
+    await sendPage(page, asyncGrowthPage(2, 'session-grow', 'grow', 'sig-g2', {
+        updateKind: 'refresh',
+        requestId: 21,
+    }));
+    await page.waitForFunction(() => window.__postedMessages.some(message =>
+        message.type === 'conversation-viewer-applied'
+            && message.htmlSignature === 'sig-g2'
+    ));
+
+    const refreshed = await page.evaluate(() => {
+        const scroll = document.querySelector('[data-conversation-scroll]');
+        const viewport = scroll.getBoundingClientRect();
+        const newest = document.querySelector('[data-message-id="grow-7"]')
+            .getBoundingClientRect();
+        return {
+            distanceToEnd: scroll.scrollHeight - scroll.clientHeight
+                - scroll.scrollTop,
+            newestVisible: newest.bottom > viewport.top
+                && newest.top < viewport.bottom,
+        };
+    });
+    assert.ok(refreshed.distanceToEnd <= 8,
+        'a reader who never scrolled away keeps following the end across a'
+            + ` refresh, got ${refreshed.distanceToEnd}px to the end`);
+    assert.equal(refreshed.newestVisible, true,
+        'the newest interaction is rendered inside the viewport');
+});
+
+test('CONVERSATION-TAIL-FOLLOW-001 returns to the tail when a Session is reopened after the transcript grew asynchronously beneath the reader', async t => {
+    const page = await openGrownTail(t, 'grow');
+
+    await sendPage(page, asyncGrowthPage(3, 'session-other', 'other',
+        'sig-o1'));
+    await page.waitForFunction(() => window.__postedMessages.some(message =>
+        message.type === 'conversation-viewer-applied'
+            && message.htmlSignature === 'sig-o1'
+    ));
+    await sendPage(page, asyncGrowthPage(4, 'session-grow', 'grow', 'sig-g1', {
+        restoreFrame: true,
+    }));
+    await page.waitForFunction(() => window.__postedMessages.some(message =>
+        message.type === 'conversation-viewer-applied'
+            && message.requestId === 40
+    ));
+
+    const returned = await page.evaluate(() => {
+        const scroll = document.querySelector('[data-conversation-scroll]');
+        const viewport = scroll.getBoundingClientRect();
+        const newest = document.querySelector('[data-message-id="grow-7"]')
+            .getBoundingClientRect();
+        const oldest = document.querySelector('[data-message-id="grow-0"]')
+            .getBoundingClientRect();
+        return {
+            distanceToEnd: scroll.scrollHeight - scroll.clientHeight
+                - scroll.scrollTop,
+            newestVisible: newest.bottom > viewport.top
+                && newest.top < viewport.bottom,
+            oldestVisible: oldest.bottom > viewport.top
+                && oldest.top < viewport.bottom,
+        };
+    });
+    assert.ok(returned.distanceToEnd <= 8,
+        'reopening the Session returns the reader to the end they were'
+            + ` following, got ${returned.distanceToEnd}px to the end`);
+    assert.equal(returned.newestVisible, true,
+        'the newest interaction is rendered inside the viewport');
+    assert.equal(returned.oldestVisible, false,
+        'the reader is not stranded back on the oldest interaction');
+});
+
 test('CONVERSATION-LARGE-SESSION-PERFORMANCE-002 clears a stalled progressive loading notice', async t => {
     const page = await openViewerPage(t);
     await page.evaluate(() => {


### PR DESCRIPTION
## Problem

Returning to a Session repeatedly landed on a very old interaction, and a
long-running Session drifted away from its newest output — both forcing a
manual scroll to the bottom every time. Two independent defects produced that,
and the second one made the first permanent.

## Defect A — deferred history backfill skipped its scroll compensation

`applyHistoryChunkContent` skipped compensation whenever the reader's offset
was 0, on the theory that offset 0 means "scrolled to the top, waiting for this
history". A progressive first screen shorter than the viewport cannot scroll at
all, so a reader looking at the tail also reports 0. Every backfilled slice then
pushed the tail further out of view and left them on the oldest interaction the
backfill delivered.

Compensate unless the transcript was actually scrollable and the reader was at
its top.

## Defect B — the follow-the-end ResizeObserver watched only the viewport

A transcript growing under a settled reader — lazily decoded images, late
Mermaid renders — moves the end away from them exactly like the viewport
shrinking does, but emits no scroll event. The physical offset silently drifted
past the auto-scroll threshold while the reader never moved, and every later
check reading that offset concluded they had walked away: live refreshes
restored a reading anchor instead of following, and a Session switch stashed a
mid-transcript anchor that each return then faithfully restored.

Observe the transcript as well, so growth beneath a follower brings the end back
to them and the offset stays truthful for those checks.

A first attempt instead overrode the physical check with the tracked follow
intent. That broke two existing `CONVERSATION-READING-FOCUS-001` contracts: a
reader parked 9px from the end must keep their position, and the tracked intent
is stale at message-processing time because the scroll event has not dispatched
yet. Keeping the offset accurate is the correct fix and needed no change to the
stash or refresh logic.

## Verification

- New behavior `CONVERSATION-TAIL-FOLLOW-001` owns all three paths (backfill,
  live refresh, Session switch away and back) in `tests/browser/conversationViewer.test.js`.
- All three tests observed RED first against the unfixed source, failing for the
  reported reason at 110px / 300px / 300px off the tail.
- Mutation-checked each defect independently: reintroducing A fails only the
  backfill test; reintroducing B fails only the refresh and switch-back tests.
- Full `npm run test:ci:linux` green, including the browser suite (447/447 at
  the time of that run), `test:behavior-contracts`, and the integration viewer
  suite (156/156).
- Built and installed locally as `hzcheng.agent-pivot@1.2.1`; both changed
  webview scripts byte-verified against the VSIX in the active Server
  extensions directory.

## Skill harvest

Updated `.skills/resilient-webview-mutation-protocols` (description only). Its
Repository Layout section already owns the rule that `media/` holds
byte-identical copies of `src/webview/*.js` and that both sides must move in one
commit, but the description only triggered on mutation-protocol concerns
(Host-owned mutations, stale acknowledgements, stuck pending UI, focus loss,
partial batch failures). A scroll-position fix in `src/webview/` matches none of
those, so the skill never surfaced, the `media/` mirror was left stale, and the
packaged byte-identity check failed a full verification cycle later. The
description now triggers on the edit itself. Validated with
`tests/unit/tooling/repositorySkills.test.js` (10/10) and
`scripts/run-skill-management-checks.js`.

## Owner approvals

```
approve ca512c642d16a7142dd2a3fd120c452e7b2c0332
```