### PR TITLE
Release 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to the "Agent Pivot" extension will be documented in this fi
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-08-29
+
+### Added
+
+- Make an AI Conversation's Changes sidebar follow the worktree currently
+  being modified, while safely falling back to the conversation's persisted
+  worktree when live telemetry is unavailable.
+
+### Changed
+
+- Publish this minor release through the VS Code Marketplace while retaining
+  the Workspace Trust boundary and progressively rendered AI Conversations.
+
 ## [1.2.1] - 2026-08-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,29 @@ All notable changes to the "Agent Pivot" extension will be documented in this fi
 - Make an AI Conversation's Changes sidebar follow the worktree currently
   being modified, while safely falling back to the conversation's persisted
   worktree when live telemetry is unavailable.
+- Add controlled rich AI Conversation rendering, including safe structured
+  content, side-by-side diffs, per-file line wrapping, and accessible local
+  controls that survive live refreshes.
+- Redesign Agent Pivot's Projects panel with compact grouped rows, tag
+  filtering, and inline project editing that stays available through updates.
+- Add a Save action to unsaved workspace rows in the OPEN window switcher.
 
 ### Changed
 
 - Publish this minor release through the VS Code Marketplace while retaining
   the Workspace Trust boundary and progressively rendered AI Conversations.
+- Keep AI Conversation readers pinned to the transcript tail only while they
+  are following it, while preserving a reader's deliberate position during
+  Worklog disclosure and live layout changes.
+
+### Fixed
+
+- Keep Agent Pivot dashboard tab and project-panel scrollports stable during refreshes,
+  filtering, and layout changes.
+- Keep unsaved-window save actions and inline project editing focused and
+  usable after authoritative Agent Pivot updates.
+- Preserve Conversation diff, chart, and rich-markup layout and accessibility
+  at narrow widths without allowing one pane to overlap another.
 
 ## [1.2.1] - 2026-08-28
 

--- a/media/conversationViewerScripts.js
+++ b/media/conversationViewerScripts.js
@@ -3276,12 +3276,26 @@
             ? row.getAttribute('data-interaction-id')
             : null;
         if (!interactionId) return;
+        // Revealing a hidden work entry can cause native scroll anchoring to
+        // move the toggle out from under the pointer. Disable it for this
+        // one layout change and retain the reader's exact scroll position.
+        var scrollTop = scroll.scrollTop;
+        var overflowAnchor = scroll.style.overflowAnchor;
+        scroll.style.overflowAnchor = 'none';
         if (state.worklogExpanded.get(interactionId) === true) {
             state.worklogExpanded.delete(interactionId);
         } else {
             state.worklogExpanded.set(interactionId, true);
         }
         applyWorklogStates();
+        // Force the visibility change to settle before re-enabling anchoring.
+        void scroll.offsetHeight;
+        scroll.scrollTop = scrollTop;
+        scroll.style.overflowAnchor = overflowAnchor;
+        // A manual disclosure change is not asynchronous transcript growth.
+        // Re-evaluate follow state before the ResizeObserver runs so it does
+        // not scroll this reader back to the tail after an expansion.
+        reconcileController.trackEnd();
     });
     messages.addEventListener('click', function (event) {
         var star = event.target && event.target.closest

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "agent-pivot",
-    "version": "1.2.1",
+    "version": "1.3.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "agent-pivot",
-            "version": "1.2.1",
+            "version": "1.3.0",
             "license": "MIT",
             "dependencies": {
                 "dom-autoscroller": "^2.3.4",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "agent-pivot",
     "displayName": "Agent Pivot",
     "description": "Switch, monitor, and resume Codex, Claude, and Kimi sessions across VS Code workspaces. Project manager and prompt library for AI coding agents.",
-    "version": "1.2.1",
+    "version": "1.3.0",
     "publisher": "hzcheng",
     "license": "MIT",
     "icon": "media/extension_icon.png",

--- a/scripts/lib/brandIdentity.js
+++ b/scripts/lib/brandIdentity.js
@@ -10,7 +10,7 @@ const BRAND_IDENTITY = Object.freeze({
     publisher: 'hzcheng',
     mainPackageName: 'agent-pivot',
     mainExtensionId: 'hzcheng.agent-pivot',
-    mainVersion: '1.2.1',
+    mainVersion: '1.3.0',
     bridgePackageName: 'agent-pivot-attention-ui-bridge',
     bridgeExtensionId: 'hzcheng.agent-pivot-attention-ui-bridge',
     bridgeVersion: '1.0.3',

--- a/scripts/run-release-notes-checks.js
+++ b/scripts/run-release-notes-checks.js
@@ -14,8 +14,8 @@ const workflowPath = path.join(repositoryRoot, '.github', 'workflows', 'release-
 function validateReleaseContent({ readme, changelog, packageMetadata }) {
     assert.strictEqual(packageMetadata.displayName, 'Agent Pivot',
         'release metadata must use the Agent Pivot display name');
-    assert.strictEqual(packageMetadata.version, '1.2.1',
-        'the current Agent Pivot release must be version 1.2.1');
+    assert.strictEqual(packageMetadata.version, '1.3.0',
+        'the current Agent Pivot release must be version 1.3.0');
     const currentRelease = extractReleaseNotes(changelog, packageMetadata.version);
     const requiredReleaseFacts = [
         ['the Marketplace release channel', /VS Code Marketplace/i],

--- a/scripts/run-release-packaging-checks.js
+++ b/scripts/run-release-packaging-checks.js
@@ -455,7 +455,7 @@ function runRealVsixArchiveChecks(mainPackage, bridgePackage) {
     );
     assert.strictEqual(
         path.basename(mainArtifact),
-        'agent-pivot-1.2.1.vsix',
+        'agent-pivot-1.3.0.vsix',
         'main release artifact name must remain exact',
     );
     assert.strictEqual(

--- a/src/webview/conversationViewerScripts.js
+++ b/src/webview/conversationViewerScripts.js
@@ -3276,12 +3276,26 @@
             ? row.getAttribute('data-interaction-id')
             : null;
         if (!interactionId) return;
+        // Revealing a hidden work entry can cause native scroll anchoring to
+        // move the toggle out from under the pointer. Disable it for this
+        // one layout change and retain the reader's exact scroll position.
+        var scrollTop = scroll.scrollTop;
+        var overflowAnchor = scroll.style.overflowAnchor;
+        scroll.style.overflowAnchor = 'none';
         if (state.worklogExpanded.get(interactionId) === true) {
             state.worklogExpanded.delete(interactionId);
         } else {
             state.worklogExpanded.set(interactionId, true);
         }
         applyWorklogStates();
+        // Force the visibility change to settle before re-enabling anchoring.
+        void scroll.offsetHeight;
+        scroll.scrollTop = scrollTop;
+        scroll.style.overflowAnchor = overflowAnchor;
+        // A manual disclosure change is not asynchronous transcript growth.
+        // Re-evaluate follow state before the ResizeObserver runs so it does
+        // not scroll this reader back to the tail after an expansion.
+        reconcileController.trackEnd();
     });
     messages.addEventListener('click', function (event) {
         var star = event.target && event.target.closest

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -4977,6 +4977,31 @@ test('CONVERSATION-OUTLINE-NAVIGATION-001 keeps every side-panel view usable acr
     }
 
     const previousViewerScript = viewerScript
+        // Worklog disclosure now preserves the reader's scroll position and
+        // re-evaluates tail-following. That is newer than the adjacent
+        // generation reconstructed below, so remove the coupled statements
+        // before asserting its frozen source hash.
+        .replace(
+            '        // Revealing a hidden work entry can cause native scroll anchoring to\n'
+                + '        // move the toggle out from under the pointer. Disable it for this\n'
+                + '        // one layout change and retain the reader\'s exact scroll position.\n'
+                + '        var scrollTop = scroll.scrollTop;\n'
+                + '        var overflowAnchor = scroll.style.overflowAnchor;\n'
+                + "        scroll.style.overflowAnchor = 'none';\n",
+            ''
+        )
+        .replace(
+            '        applyWorklogStates();\n'
+                + '        // Force the visibility change to settle before re-enabling anchoring.\n'
+                + '        void scroll.offsetHeight;\n'
+                + '        scroll.scrollTop = scrollTop;\n'
+                + '        scroll.style.overflowAnchor = overflowAnchor;\n'
+                + '        // A manual disclosure change is not asynchronous transcript growth.\n'
+                + '        // Re-evaluate follow state before the ResizeObserver runs so it does\n'
+                + '        // not scroll this reader back to the tail after an expansion.\n'
+                + '        reconcileController.trackEnd();\n',
+            '        applyWorklogStates();\n'
+        )
         // Strip this generation's local rendering controls before replaying
         // the frozen adjacent Viewer generation below.
         .replace(
@@ -11627,6 +11652,16 @@ test('WEBVIEW-AI-SESSION-CONVERSATION-VIEWER-001 strips inline emphasis tags fro
 
 test('CONVERSATION-WORKLOG-COLLAPSE-001 collapses completed-turn work behind a Worked-for row that toggles and survives refresh', async t => {
     const page = await openViewerPage(t, {});
+    const earlierContextArticle = `<article class="conversation-message conversation-message-user"
+            data-message-id="input-earlier:user"
+            data-conversation-message-id="input-earlier%3Auser"
+            data-interaction-id="input-earlier">
+        <span class="conversation-role">User</span>
+        <section class="conversation-markdown">${Array.from(
+            { length: 24 },
+            (_unused, index) => `<p>Earlier reading context ${index + 1}</p>`
+        ).join('')}</section>
+    </article>`;
     const userArticle = `<article class="conversation-message conversation-message-user"
             data-message-id="input-4:user"
             data-conversation-message-id="input-4%3Auser"
@@ -11649,7 +11684,10 @@ test('CONVERSATION-WORKLOG-COLLAPSE-001 collapses completed-turn work behind a W
             data-interaction-id="input-4">
         <details class="conversation-tool-call">
             <summary><span class="conversation-tool-name">Shell</span> Shell npm test</summary>
-            <pre class="conversation-tool-detail"><code>9 passing</code></pre>
+            <pre class="conversation-tool-detail"><code>${Array.from(
+                { length: 32 },
+                (_unused, index) => `${index + 1} passing`
+            ).join('\n')}</code></pre>
         </details>
     </article>`;
     const assistantArticle = `<article class="conversation-message conversation-message-assistant"
@@ -11661,7 +11699,7 @@ test('CONVERSATION-WORKLOG-COLLAPSE-001 collapses completed-turn work behind a W
     </article>`;
     // The row heads the work group so expanding reveals entries below the
     // toggle and the toggle itself never moves under the pointer.
-    const turnHtml = userArticle + worklogArticle + toolArticle
+    const turnHtml = earlierContextArticle + userArticle + worklogArticle + toolArticle
         + assistantArticle;
     await sendPage(page, {
         ...hostileConversationPage,
@@ -11683,14 +11721,56 @@ test('CONVERSATION-WORKLOG-COLLAPSE-001 collapses completed-turn work behind a W
         'completed-turn work starts collapsed');
     assert.equal(await toggle.getAttribute('aria-expanded'), 'false');
 
+    const scrollTopBefore = await page.evaluate(async () => {
+        const scroll = document.querySelector('[data-conversation-scroll]');
+        scroll.scrollTop = scroll.scrollHeight;
+        scroll.dispatchEvent(new Event('scroll'));
+        await new Promise(resolve => requestAnimationFrame(
+            () => requestAnimationFrame(resolve)
+        ));
+        return scroll.scrollTop;
+    });
+    assert.ok(scrollTopBefore > 0,
+        'the reader must be at a genuinely scrollable transcript tail');
     const toggleYBefore = (await toggle.boundingBox()).y;
     await toggle.click();
+    // Let the tail-follow ResizeObserver settle. Worklog expansion is a
+    // reader-initiated visibility change, so it must not pull the reader to
+    // the transcript end or move the toggle from under the pointer.
+    await page.evaluate(() => new Promise(resolve => requestAnimationFrame(
+        () => requestAnimationFrame(resolve)
+    )));
     assert.equal(await tool.isVisible(), true, 'click expands the worklog');
     assert.equal(await toggle.getAttribute('aria-expanded'), 'true');
+    assert.equal(
+        await page.locator('[data-conversation-scroll]').evaluate(scroll => scroll.scrollTop),
+        scrollTopBefore,
+        'reader-initiated disclosure must retain the exact reading scroll position'
+    );
     assert.equal(
         (await toggle.boundingBox()).y,
         toggleYBefore,
         'expanding reveals entries below the toggle, never moving it'
+    );
+
+    const afterTailGrowth = await page.evaluate(async () => {
+        const messages = document.querySelector('[data-conversation-messages]');
+        const scroll = document.querySelector('[data-conversation-scroll]');
+        const tail = document.createElement('article');
+        tail.textContent = 'Later transcript growth';
+        tail.style.height = '240px';
+        messages.appendChild(tail);
+        await new Promise(resolve => requestAnimationFrame(
+            () => requestAnimationFrame(resolve)
+        ));
+        return scroll.scrollTop;
+    });
+    assert.equal(afterTailGrowth, scrollTopBefore,
+        'later tail growth must not re-enable following after a manual disclosure');
+    assert.equal(
+        (await toggle.boundingBox()).y,
+        toggleYBefore,
+        'later tail growth must leave the Worklog toggle at its reading position'
     );
 
     await sendPage(page, {

--- a/tests/browser/dashboardRefreshStability.test.js
+++ b/tests/browser/dashboardRefreshStability.test.js
@@ -428,8 +428,12 @@ test('WEBVIEW-PROJECTS-PANEL-SCROLL-001 restores the real Projects scrollport af
         html: longProjectsMarkup(projectIds), searchCatalog: catalog(),
         groupOrders: longProjectGroupOrders(projectIds), favoriteProjectIds: [],
     });
-    await waitForPageCondition(page, () => document.querySelector('#dashboard-tab-projects')
-        .getAttribute('data-header-fit-generation') === '2');
+    await waitForPageCondition(page, expectedScrollTop => {
+        const panel = document.querySelector('#dashboard-tab-projects');
+        return panel
+            && panel.getAttribute('data-header-fit-generation') === '2'
+            && panel.scrollTop === expectedScrollTop;
+    }, beforeScrollTop);
     assert.equal(await page.evaluate(() => document.querySelector('#dashboard-tab-projects').scrollTop), beforeScrollTop);
 });
 

--- a/tests/unit/tooling/brandIdentity.test.js
+++ b/tests/unit/tooling/brandIdentity.test.js
@@ -50,7 +50,7 @@ function manifests() {
             name: 'agent-pivot',
             displayName: 'Agent Pivot',
             publisher: 'hzcheng',
-            version: '1.2.1',
+            version: '1.3.0',
             icon: 'media/extension_icon.png',
             repository: {
                 type: 'git',
@@ -281,7 +281,7 @@ test('brand identity exposes the exact approved public contract', () => {
         publisher: 'hzcheng',
         mainPackageName: 'agent-pivot',
         mainExtensionId: 'hzcheng.agent-pivot',
-        mainVersion: '1.2.1',
+        mainVersion: '1.3.0',
         bridgePackageName: 'agent-pivot-attention-ui-bridge',
         bridgeExtensionId: 'hzcheng.agent-pivot-attention-ui-bridge',
         bridgeVersion: '1.0.3',

--- a/tests/unit/tooling/extensionHostLauncher.test.js
+++ b/tests/unit/tooling/extensionHostLauncher.test.js
@@ -150,7 +150,7 @@ test('RELEASE-SCHEDULED-EXTENSION-HOST-001 launches both extensions with pinned 
         ]);
         assert.deepEqual(packagePlan.map(item => path.basename(item.artifactPath)), [
             'agent-pivot-attention-ui-bridge-1.0.3.vsix',
-            'agent-pivot-1.2.1.vsix',
+            'agent-pivot-1.3.0.vsix',
         ]);
         assert.equal(options.extensionTestsPath,
             path.join(environment.testHarness, 'index.js'));

--- a/tests/unit/tooling/releaseNotes.test.js
+++ b/tests/unit/tooling/releaseNotes.test.js
@@ -14,7 +14,7 @@ test('release content validation cannot satisfy current facts from historical no
     const changelog = [
         '# Changelog',
         '',
-        '## [1.2.1] - 2026-08-28',
+        '## [1.3.0] - 2026-08-29',
         '',
         '- An unrelated documentation fix.',
         '',
@@ -37,10 +37,10 @@ test('release content validation cannot satisfy current facts from historical no
             changelog,
             packageMetadata: {
                 displayName: 'Agent Pivot',
-                version: '1.2.1',
+                version: '1.3.0',
                 description: 'Workspace command center.',
             },
         }),
-        /1\.2\.1 CHANGELOG release must document the Marketplace release channel/,
+        /1\.3\.0 CHANGELOG release must document the Marketplace release channel/,
     );
 });


### PR DESCRIPTION
## Summary

- Prepare Agent Pivot 1.3.0, including complete release notes for the changes since 1.2.1.
- Keep the AI Conversation Changes sidebar bound to the worktree currently being modified, with persisted-identity fallback.
- Preserve a reader's exact position when expanding Worklog while tail-following, and make Dashboard scroll restoration wait for the completed restore.

## Verification

- `npm run worktree:run -- npm run test:ci:linux:core` (472 passed)
- `npm run worktree:run -- npm run test:ci:linux:browser` (449 passed), Dashboard Webview checks, and Conversation performance checks
- `npm run worktree:run -- npm run test:release-packaging`
- `npm run worktree:run -- npm run test:behavior-contracts`
- `npm run worktree:run -- npm run lint:ci` and `git diff --check`

## Skill harvest

No skill change: the existing regression workflow already requires a cross-feature journey; the Worklog × ResizeObserver gap was a compliance/test-coverage gap, now covered by a scrollable tail-follow regression.

## Owner approvals

approve 16ba0d6ab202f03a3729381b51489518f284c1af