### PR TITLE
fix: make Marketplace release retries safe

### DIFF
--- a/.github/workflows/release-vsix.yml
+++ b/.github/workflows/release-vsix.yml
@@ -41,13 +41,57 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 15
     steps:
-      - name: Checkout
+      - name: Checkout workflow source
         uses: actions/checkout@v4
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: 22.12.0
           cache: npm
+      - name: Resolve release source
+        id: source
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          requested_version="${{ inputs.version }}"
+          trigger_ref_type="${{ github.ref_type }}"
+          trigger_ref_name="${{ github.ref_name }}"
+          workflow_version="$(node -p "require('./package.json').version")"
+
+          if [[ -n "$requested_version" && "$requested_version" != "$workflow_version" ]]; then
+            echo "Requested version $requested_version does not match package.json version $workflow_version." >&2
+            exit 1
+          fi
+
+          version="${requested_version:-$workflow_version}"
+          tag="v${version}"
+          if [[ "$trigger_ref_type" == "tag" && "$trigger_ref_name" != "$tag" ]]; then
+            echo "Tag $trigger_ref_name does not match the requested release version $version." >&2
+            exit 1
+          fi
+
+          if git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null; then
+            ref="refs/tags/$tag"
+          else
+            ls_remote_status="$?"
+            if [[ "$ls_remote_status" -ne 2 ]]; then
+              echo "Unable to resolve release tag $tag from origin." >&2
+              exit 1
+            elif [[ "$trigger_ref_type" == "tag" ]]; then
+              echo "Release tag $tag is not available from origin." >&2
+              exit 1
+            else
+              ref="${{ github.sha }}"
+            fi
+          fi
+
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout release source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.source.outputs.ref }}
       - name: Install dependencies
         run: npm ci
       - name: Install and activate release VSIX files
@@ -77,6 +121,58 @@ jobs:
           node-version: 22
           cache: npm
 
+      - name: Resolve release source
+        id: source
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          requested_version="${{ inputs.version }}"
+          trigger_ref_type="${{ github.ref_type }}"
+          trigger_ref_name="${{ github.ref_name }}"
+          workflow_version="$(node -p "require('./package.json').version")"
+
+          if [[ -n "$requested_version" && "$requested_version" != "$workflow_version" ]]; then
+            echo "Requested version $requested_version does not match package.json version $workflow_version." >&2
+            echo "Run the workflow from the release version's current branch instead." >&2
+            exit 1
+          fi
+
+          version="${requested_version:-$workflow_version}"
+          tag="v${version}"
+
+          if [[ "$trigger_ref_type" == "tag" && "$trigger_ref_name" != "$tag" ]]; then
+            echo "Tag $trigger_ref_name does not match the requested release version $version." >&2
+            echo "Expected tag: $tag" >&2
+            exit 1
+          fi
+
+          if git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null; then
+            ref="refs/tags/$tag"
+            source_ref="$tag"
+          else
+            ls_remote_status="$?"
+            if [[ "$ls_remote_status" -ne 2 ]]; then
+              echo "Unable to resolve release tag $tag from origin." >&2
+              exit 1
+            elif [[ "$trigger_ref_type" == "tag" ]]; then
+              echo "Release tag $tag is not available from origin." >&2
+              exit 1
+            else
+              ref="${{ github.sha }}"
+              source_ref="$ref"
+            fi
+          fi
+
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+          echo "source_ref=$source_ref" >> "$GITHUB_OUTPUT"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout release source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.source.outputs.ref }}
+
       - name: Read package metadata
         id: meta
         shell: bash
@@ -89,22 +185,12 @@ jobs:
           bridge_name="$(node -p "require('./extensions/attention-ui-bridge/package.json').name")"
           bridge_version="$(node -p "require('./extensions/attention-ui-bridge/package.json').version")"
           bridge_publisher="$(node -p "require('./extensions/attention-ui-bridge/package.json').publisher")"
-          requested_version="${{ inputs.version }}"
-          trigger_ref_type="${{ github.ref_type }}"
-          trigger_ref_name="${{ github.ref_name }}"
+          tag="${{ steps.source.outputs.tag }}"
+          version="${tag#v}"
+          source_sha="$(git rev-parse HEAD)"
 
-          if [[ -n "$requested_version" && "$requested_version" != "$package_version" ]]; then
-            echo "Requested version $requested_version does not match package.json version $package_version." >&2
-            echo "Update package.json first, then run this workflow again." >&2
-            exit 1
-          fi
-
-          version="${requested_version:-$package_version}"
-          tag="v${version}"
-
-          if [[ "$trigger_ref_type" == "tag" && "$trigger_ref_name" != "$tag" ]]; then
-            echo "Tag $trigger_ref_name does not match package.json version $package_version." >&2
-            echo "Expected tag: $tag" >&2
+          if [[ "$tag" != "v$package_version" ]]; then
+            echo "Release source package.json version $package_version does not match $tag." >&2
             exit 1
           fi
 
@@ -118,6 +204,7 @@ jobs:
           echo "bridge_version=$bridge_version" >> "$GITHUB_OUTPUT"
           echo "bridge_publisher=$bridge_publisher" >> "$GITHUB_OUTPUT"
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
           echo "vsix_file=$vsix_file" >> "$GITHUB_OUTPUT"
           echo "bridge_vsix_file=$bridge_vsix_file" >> "$GITHUB_OUTPUT"
 
@@ -165,6 +252,7 @@ jobs:
           VERSION: ${{ steps.meta.outputs.version }}
           MAIN_VSIX_FILE: ${{ steps.meta.outputs.vsix_file }}
           BRIDGE_VSIX_FILE: ${{ steps.meta.outputs.bridge_vsix_file }}
+          SOURCE_SHA: ${{ steps.meta.outputs.source_sha }}
           DRAFT: ${{ inputs.draft }}
           PRERELEASE: ${{ inputs.prerelease }}
         shell: bash
@@ -172,24 +260,25 @@ jobs:
           set -euo pipefail
 
           if gh release view "$TAG" >/dev/null 2>&1; then
-            echo "Release $TAG already exists. Delete it or bump package.json before publishing again." >&2
-            exit 1
+            echo "Release $TAG already exists; retaining it."
+          else
+            args=()
+            if [[ "$DRAFT" == "true" ]]; then
+              args+=(--draft)
+            fi
+            if [[ "$PRERELEASE" == "true" ]]; then
+              args+=(--prerelease)
+            fi
+
+            node scripts/extract-release-notes.js "$VERSION" > release-notes.md
+
+            gh release create "$TAG" --target "$SOURCE_SHA" \
+              --title "Agent Pivot ${VERSION}" \
+              --notes-file release-notes.md \
+              "${args[@]}"
           fi
 
-          args=()
-          if [[ "$DRAFT" == "true" ]]; then
-            args+=(--draft)
-          fi
-          if [[ "$PRERELEASE" == "true" ]]; then
-            args+=(--prerelease)
-          fi
-
-          node scripts/extract-release-notes.js "$VERSION" > release-notes.md
-
-          gh release create "$TAG" "$BRIDGE_VSIX_FILE" "$MAIN_VSIX_FILE" \
-            --title "Agent Pivot ${VERSION}" \
-            --notes-file release-notes.md \
-            "${args[@]}"
+          gh release upload "$TAG" "$BRIDGE_VSIX_FILE" "$MAIN_VSIX_FILE" --clobber
 
   publish-marketplace:
     name: publish-marketplace
@@ -293,8 +382,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          npx --yes @vscode/vsce publish --packagePath "$BRIDGE_VSIX_FILE" --pat "$VSCE_PAT" --allow-star-activation
-          npx --yes @vscode/vsce publish --packagePath "$VSIX_FILE" --pat "$VSCE_PAT" --allow-star-activation
+          npx --yes @vscode/vsce publish --packagePath "$BRIDGE_VSIX_FILE" --pat "$VSCE_PAT" --allow-star-activation --skip-duplicate
+          npx --yes @vscode/vsce publish --packagePath "$VSIX_FILE" --pat "$VSCE_PAT" --allow-star-activation --skip-duplicate
 
       - name: Write marketplace publish summary
         if: always()

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -4026,7 +4026,7 @@
   {
     "id": "RELEASE-MARKETPLACE-PUBLISH-001",
     "domain": "release",
-    "title": "Tagged minor and major releases auto-publish the released VSIX artifacts to the VS Code Marketplace with VSCE_PAT, UI Bridge first, while patch-only bumps skip unless forced",
+    "title": "Tagged minor and major releases auto-publish tag-sourced VSIX artifacts to the VS Code Marketplace with VSCE_PAT, UI Bridge first; retries reconcile both GitHub Release assets and tolerate already-published companion versions while patch-only bumps skip unless forced",
     "priority": "P0",
     "status": "automated",
     "owners": [

--- a/scripts/lib/ciContracts.js
+++ b/scripts/lib/ciContracts.js
@@ -375,6 +375,19 @@ function validateReleaseWorkflow(releaseWorkflow) {
     );
     assert.equal(workflow.jobs['release-extension-host'].needs, 'verify',
         'release-extension-host must need verify');
+    const extensionHostSource = findStep(workflow.jobs['release-extension-host'],
+        step => isMapping(step) && step.name === 'Resolve release source');
+    assert.ok(extensionHostSource && extensionHostSource.id === 'source'
+        && typeof extensionHostSource.run === 'string'
+        && extensionHostSource.run.includes('git ls-remote --exit-code --tags origin "refs/tags/$tag"')
+        && extensionHostSource.run.includes('ls_remote_status="$?"'),
+    'release-extension-host must resolve the same release source before activation');
+    const extensionHostCheckout = findStep(workflow.jobs['release-extension-host'],
+        step => isMapping(step) && step.name === 'Checkout release source');
+    assert.ok(extensionHostCheckout && extensionHostCheckout.uses === 'actions/checkout@v4'
+        && extensionHostCheckout.with
+        && extensionHostCheckout.with.ref === '${{ steps.source.outputs.ref }}',
+    'release-extension-host must check out the resolved immutable source before activation');
     const release = workflow.jobs.release;
     assert.ok(isMapping(release), 'GitHub release workflow must define release');
     assert.deepEqual(release.needs, ['verify', 'release-extension-host'],
@@ -384,10 +397,32 @@ function validateReleaseWorkflow(releaseWorkflow) {
     assert.equal(containsKey(workflow, 'continue-on-error'), false,
         'GitHub release workflow must not define continue-on-error');
 
-    validateMarketplacePublishJob(workflow, releaseWorkflow);
+    const source = findStep(release,
+        step => isMapping(step) && step.name === 'Resolve release source');
+    assert.ok(source && source.id === 'source' && typeof source.run === 'string'
+        && source.run.includes('git ls-remote --exit-code --tags origin "refs/tags/$tag"')
+        && source.run.includes('source_ref="$tag"')
+        && source.run.includes('Requested version $requested_version does not match package.json version $workflow_version.')
+        && source.run.includes('ls_remote_status="$?"')
+        && source.run.includes('Unable to resolve release tag $tag from origin.'),
+    'release retries must resolve an existing version from its immutable tag');
+    const sourceCheckout = findStep(release,
+        step => isMapping(step) && step.name === 'Checkout release source');
+    assert.ok(sourceCheckout && sourceCheckout.uses === 'actions/checkout@v4'
+        && sourceCheckout.with && sourceCheckout.with.ref === '${{ steps.source.outputs.ref }}',
+    'release packaging must check out the resolved immutable source');
+    const metadata = findStep(release,
+        step => isMapping(step) && step.name === 'Read package metadata');
+    assert.ok(metadata && typeof metadata.run === 'string'
+        && metadata.run.includes('tag="${{ steps.source.outputs.tag }}"')
+        && metadata.run.includes('source_sha="$(git rev-parse HEAD)"')
+        && metadata.run.includes('Release source package.json version $package_version does not match $tag.'),
+    'release packaging must reject a source whose package version does not match the resolved tag');
+
+    validateMarketplacePublishJob(workflow);
 }
 
-function validateMarketplacePublishJob(workflow, source) {
+function validateMarketplacePublishJob(workflow) {
     const job = workflow.jobs['publish-marketplace'];
     assert.ok(isMapping(job), 'GitHub release workflow must define publish-marketplace');
     assert.equal(job.name, 'publish-marketplace',
@@ -427,18 +462,38 @@ function validateMarketplacePublishJob(workflow, source) {
         'agent-pivot-${{ needs.release.outputs.version }}-vsix',
     'publish-marketplace must download the artifact produced by the release job');
 
-    const bridgePublish = source.indexOf(
+    const publish = findStep(job,
+        step => isMapping(step) && step.name === 'Publish extensions to the VS Code Marketplace');
+    assert.ok(publish && typeof publish.run === 'string',
+        'publish-marketplace must define the Marketplace publish command step');
+    const bridgePublish = publish.run.indexOf(
         'npx --yes @vscode/vsce publish --packagePath "$BRIDGE_VSIX_FILE"');
-    const mainPublish = source.indexOf(
+    const mainPublish = publish.run.indexOf(
         'npx --yes @vscode/vsce publish --packagePath "$VSIX_FILE"');
     assert.ok(bridgePublish !== -1 && mainPublish !== -1,
         'publish-marketplace must publish both VSIX files with vsce');
     assert.ok(bridgePublish < mainPublish,
         'publish-marketplace must publish UI Bridge before the main extension');
-    assert.ok(source.includes('${{ secrets.VSCE_PAT }}'),
+    assert.ok(publish.run.includes(
+        'npx --yes @vscode/vsce publish --packagePath "$BRIDGE_VSIX_FILE" --pat "$VSCE_PAT" --allow-star-activation --skip-duplicate'
+    ) && publish.run.includes(
+        'npx --yes @vscode/vsce publish --packagePath "$VSIX_FILE" --pat "$VSCE_PAT" --allow-star-activation --skip-duplicate'
+    ), 'publish-marketplace must tolerate already-published VSIX versions when retrying a release');
+    assert.ok(String(publish.env && publish.env.VSCE_PAT).includes('${{ secrets.VSCE_PAT }}'),
         'publish-marketplace must authenticate with the VSCE_PAT repository secret');
-    assert.ok(source.includes('--allow-star-activation'),
+    assert.ok(publish.run.includes('--allow-star-activation'),
         'publish-marketplace must pass --allow-star-activation to vsce');
+    const createRelease = findStep(workflow.jobs.release,
+        step => isMapping(step) && step.name === 'Create GitHub release');
+    assert.ok(createRelease && typeof createRelease.run === 'string'
+        && createRelease.run.includes('Release $TAG already exists; retaining it.'),
+        'release retries must retain an existing GitHub Release');
+    assert.ok(createRelease.run.includes(
+        'gh release upload "$TAG" "$BRIDGE_VSIX_FILE" "$MAIN_VSIX_FILE" --clobber'
+    ), 'release retries must reconcile both VSIX assets after creating or retaining the GitHub Release');
+    assert.ok(createRelease.run.includes('gh release create "$TAG" --target "$SOURCE_SHA"')
+        && String(createRelease.env && createRelease.env.SOURCE_SHA).includes('${{ steps.meta.outputs.source_sha }}'),
+    'new releases must create their tag at the commit used to build the VSIX assets');
 }
 
 function includesShellCommand(script, command) {

--- a/scripts/run-release-notes-checks.js
+++ b/scripts/run-release-notes-checks.js
@@ -114,7 +114,8 @@ function runWorkflowChecks() {
     assert.match(workflow, /- name: Package and verify release VSIX files\n\s+run: npm run test:release-packaging/);
     assert.strictEqual(workflow.includes('run: npm run package:release'), false);
     assert.match(workflow, /bridge_vsix_file=/);
-    assert.match(workflow, /gh release create "\$TAG" "\$BRIDGE_VSIX_FILE" "\$MAIN_VSIX_FILE"/);
+    assert.match(workflow, /gh release create "\$TAG"/);
+    assert.match(workflow, /gh release upload "\$TAG" "\$BRIDGE_VSIX_FILE" "\$MAIN_VSIX_FILE" --clobber/);
     assert.strictEqual(
         workflow.includes('npx --yes @vscode/vsce package --allow-star-activation --out "${{ steps.meta.outputs.vsix_file }}"'),
         false

--- a/tests/unit/tooling/ciContracts.test.js
+++ b/tests/unit/tooling/ciContracts.test.js
@@ -516,13 +516,75 @@ test('RELEASE-MARKETPLACE-PUBLISH-001 publishes released VSIX files after the re
 
 test('RELEASE-MARKETPLACE-PUBLISH-001 publishes UI Bridge before the main extension', () => {
     const reordered = releaseWorkflow.replace(
-        '          npx --yes @vscode/vsce publish --packagePath "$BRIDGE_VSIX_FILE" --pat "$VSCE_PAT" --allow-star-activation\n' +
-        '          npx --yes @vscode/vsce publish --packagePath "$VSIX_FILE" --pat "$VSCE_PAT" --allow-star-activation',
-        '          npx --yes @vscode/vsce publish --packagePath "$VSIX_FILE" --pat "$VSCE_PAT" --allow-star-activation\n' +
-        '          npx --yes @vscode/vsce publish --packagePath "$BRIDGE_VSIX_FILE" --pat "$VSCE_PAT" --allow-star-activation'
+        '          npx --yes @vscode/vsce publish --packagePath "$BRIDGE_VSIX_FILE" --pat "$VSCE_PAT" --allow-star-activation --skip-duplicate\n' +
+        '          npx --yes @vscode/vsce publish --packagePath "$VSIX_FILE" --pat "$VSCE_PAT" --allow-star-activation --skip-duplicate',
+        '          npx --yes @vscode/vsce publish --packagePath "$VSIX_FILE" --pat "$VSCE_PAT" --allow-star-activation --skip-duplicate\n' +
+        '          npx --yes @vscode/vsce publish --packagePath "$BRIDGE_VSIX_FILE" --pat "$VSCE_PAT" --allow-star-activation --skip-duplicate'
     );
     assert.throws(
         () => validateReleaseWorkflow(reordered),
         /must publish UI Bridge before the main extension/
     );
+});
+
+test('RELEASE-MARKETPLACE-PUBLISH-001 retries a release without letting an unchanged UI Bridge block the main extension', () => {
+    assert.match(releaseWorkflow,
+        /- name: Resolve release source[\s\S]*?git ls-remote --exit-code --tags origin "refs\/tags\/\$tag"[\s\S]*?source_ref="\$tag"/,
+        'a retry must rebuild an existing version from its immutable tag');
+    assert.match(releaseWorkflow,
+        /requested_version="\$\{\{ inputs\.version \}\}"[\s\S]*?Requested version \$requested_version does not match package\.json version \$workflow_version\./,
+        'a manual retry must not turn a historical version into an implicit Marketplace release');
+    assert.match(releaseWorkflow,
+        /ls_remote_status="\$\?"[\s\S]*?Unable to resolve release tag \$tag from origin\./,
+        'a remote lookup failure must not be mistaken for a missing release tag');
+    assert.match(releaseWorkflow,
+        /- name: Checkout release source\n\s+uses: actions\/checkout@v4\n\s+with:\n\s+ref: \$\{\{ steps\.source\.outputs\.ref \}\}/,
+        'release packaging must check out the resolved immutable source before building artifacts');
+    assert.match(releaseWorkflow,
+        /if gh release view "\$TAG" >\/dev\/null 2>&1; then\n\s+echo "Release \$TAG already exists; retaining it\."\n\s+else\n[\s\S]*?gh release create/,
+        'a workflow-dispatch retry must retain an existing GitHub Release');
+    assert.match(releaseWorkflow,
+        /gh release upload "\$TAG" "\$BRIDGE_VSIX_FILE" "\$MAIN_VSIX_FILE" --clobber/,
+        'a retry must reconcile both GitHub Release VSIX assets after creating or retaining the release');
+    assert.match(releaseWorkflow,
+        /gh release create "\$TAG" --target "\$SOURCE_SHA"/,
+        'new releases must create their tag at the commit used to build the VSIX files');
+    assert.throws(
+        () => validateReleaseWorkflow(releaseWorkflow.replace(
+            '          ref: ${{ steps.source.outputs.ref }}',
+            '          ref: ${{ github.sha }}'
+        )),
+        /release-extension-host must check out the resolved immutable source/
+    );
+    assert.throws(
+        () => validateReleaseWorkflow(releaseWorkflow.replace(
+            '          gh release upload "$TAG" "$BRIDGE_VSIX_FILE" "$MAIN_VSIX_FILE" --clobber\n',
+            ''
+        )),
+        /must reconcile both VSIX assets/
+    );
+    assert.throws(
+        () => validateReleaseWorkflow(releaseWorkflow.replace(
+            '            ls_remote_status="$?"\n',
+            ''
+        )),
+        /release-extension-host must resolve the same release source/
+    );
+    assert.throws(
+        () => validateReleaseWorkflow(releaseWorkflow.replace(
+            '            gh release create "$TAG" --target "$SOURCE_SHA" \\\n',
+            '            gh release create "$TAG" \\\n'
+        )),
+        /must create their tag at the commit used to build the VSIX assets/
+    );
+    assert.match(releaseWorkflow,
+        /npx --yes @vscode\/vsce publish --packagePath "\$BRIDGE_VSIX_FILE" --pat "\$VSCE_PAT" --allow-star-activation --skip-duplicate/,
+        'an unchanged UI Bridge must not stop a main extension Marketplace publish');
+    assert.match(releaseWorkflow,
+        /npx --yes @vscode\/vsce publish --packagePath "\$VSIX_FILE" --pat "\$VSCE_PAT" --allow-star-activation --skip-duplicate/,
+        'a retry must also tolerate a main extension already present on the Marketplace');
+});
+
+test('RELEASE-MARKETPLACE-PUBLISH-001 survives the release packager YAML round-trip', () => {
+    validateReleaseWorkflow(yaml.safeDump(yaml.load(releaseWorkflow)));
 });


### PR DESCRIPTION
## Summary
- make release retries preserve tag provenance and reconcile both VSIX assets
- tolerate already-published Marketplace companion versions without blocking the main extension
- bind Extension Host validation to the same release source

## Verification
- `npm run worktree:run -- node --test --test-name-pattern="RELEASE-MARKETPLACE-PUBLISH-001|release publishing needs installed VSIX activation" tests/unit/tooling/ciContracts.test.js`
- `npm run worktree:run -- npm run test:release-notes`
- `npm run worktree:run -- npm run test:behavior-contracts`
- `npm run worktree:run -- npm run test-compile`
- Earlier fresh branch checks: `npm run worktree:run -- npm run test:ci:linux:core` (472/472; changed coverage 100%) and `npm run worktree:run -- npm run test:ci:linux:release`

## Skill harvest
No skill change: the existing regression/review workflow already required failure reproduction, CI ownership, final review, and release verification; this incident was a release-workflow idempotency defect now protected by RELEASE-MARKETPLACE-PUBLISH-001.

## Owner approvals

approve 9a1375c8ded666c5e0dd0f868fd224df277281fd