### PR TITLE
fix: show live Git branches in changes sidebar

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -6186,6 +6186,7 @@
     ],
     "evidence": [
       "src/aiSessions/conversation/conversationChangesController.ts",
+      "src/worktrees/changesCollector.ts",
       "src/aiSessions/conversation/conversationTelemetryController.ts",
       "src/aiSessions/conversation/viewer.ts",
       "src/aiSessions/conversation/viewerDocument.ts",

--- a/src/aiSessions/conversation/conversationChangesController.ts
+++ b/src/aiSessions/conversation/conversationChangesController.ts
@@ -863,7 +863,10 @@ function memberView(
     return {
         memberId: member.memberId,
         repoLabel: member.repoLabel.slice(0, MAX_MEMBER_LABEL_LENGTH),
-        branchName: member.branchName,
+        // The manifest's planned branch is a fallback only. A readable Git
+        // snapshot is authoritative so unmanaged and switched worktrees do
+        // not render a permanent '(no branch)' or a stale planned branch.
+        branchName: snapshot?.branchName ?? member.branchName,
         worktreePath: member.worktreePath,
         availability: snapshot?.availability
             ?? (member.baseline ? 'unreadable' : 'baselineUnavailable'),

--- a/src/aiSessions/conversation/conversationChangesController.ts
+++ b/src/aiSessions/conversation/conversationChangesController.ts
@@ -391,7 +391,7 @@ export class ConversationChangesController {
         await this.options.openTaskResultReview(
             member.worktreePath,
             baselineSha,
-            `Task result · ${member.repoLabel} (${member.branchName})`);
+            `Task result · ${memberReviewLabel(member, snapshot)}`);
     }
 
     async handleOpenScm(memberId: string): Promise<void> {
@@ -591,11 +591,12 @@ export class ConversationChangesController {
             return;
         }
         try {
+            const snapshot = active.snapshots.get(member.memberId);
             await this.options.openCommitReview(
                 member.worktreePath,
                 input.sha,
                 detail.parentSha,
-                `Commit ${input.sha.slice(0, 7)} · ${member.repoLabel} (${member.branchName})`,
+                `Commit ${input.sha.slice(0, 7)} · ${memberReviewLabel(member, snapshot)}`,
                 detail.files,
                 detail.totalFiles);
         } catch (error) {
@@ -866,7 +867,7 @@ function memberView(
         // The manifest's planned branch is a fallback only. A readable Git
         // snapshot is authoritative so unmanaged and switched worktrees do
         // not render a permanent '(no branch)' or a stale planned branch.
-        branchName: snapshot?.branchName ?? member.branchName,
+        branchName: memberBranchName(member, snapshot),
         worktreePath: member.worktreePath,
         availability: snapshot?.availability
             ?? (member.baseline ? 'unreadable' : 'baselineUnavailable'),
@@ -885,6 +886,22 @@ function memberView(
         ...(snapshot?.upstream ? { upstream: snapshot.upstream } : {}),
         ...(member.detached ? { detached: true } : {}),
     };
+}
+
+/** A known live branch wins; an unavailable query falls back to the plan. */
+function memberBranchName(
+    member: ChangesMemberSource,
+    snapshot: MemberChangesSnapshot | undefined
+): string {
+    return snapshot?.branchName ?? member.branchName;
+}
+
+function memberReviewLabel(
+    member: ChangesMemberSource,
+    snapshot: MemberChangesSnapshot | undefined
+): string {
+    const branchName = memberBranchName(member, snapshot);
+    return branchName ? `${member.repoLabel} (${branchName})` : member.repoLabel;
 }
 
 function legacyMemberView(

--- a/src/worktrees/changesCollector.ts
+++ b/src/worktrees/changesCollector.ts
@@ -229,11 +229,17 @@ export class ChangesCollector {
             ], worktreePath);
             statusOutput = result.stdout;
         } catch (_error) {
+            // A status failure makes SCM details unreadable, but it need not
+            // hide the independently-readable branch in the member header.
+            const branch = await this.collectCurrentBranch(worktreePath);
             return {
                 availability: 'unreadable',
                 workingItems: [],
                 workingItemCount: 0,
                 truncated: false,
+                ...(branch.branchName !== undefined
+                    ? { branchName: branch.branchName }
+                    : {}),
                 collectedAt,
             };
         }
@@ -259,9 +265,8 @@ export class ChangesCollector {
             truncated,
             collectedAt,
         };
-        // Tracking state rides the same readability gate as the status
-        // but is independent of the baseline (PRD §14.1): a member with
-        // no recorded task start still reports its upstream facts.
+        // Tracking state is independent of the baseline (PRD §14.1): a
+        // member with no recorded task start still reports its upstream facts.
         const tracking = await this.collectTracking(worktreePath);
         if (tracking.headSha !== undefined) {
             snapshot.headSha = tracking.headSha;
@@ -333,6 +338,39 @@ export class ChangesCollector {
      * alone when no upstream ref exists) so every readable member reports
      * it. Never throws; ≤4 extra git processes per member.
      */
+    private async collectCurrentBranch(worktreePath: string): Promise<{
+        branchRef?: string;
+        branchName?: string;
+    }> {
+        try {
+            const symbolic = await this.execGit([
+                '-C', worktreePath, 'symbolic-ref', '-q', 'HEAD',
+            ], worktreePath);
+            const branchRef = symbolic.stdout.trim();
+            if (!branchRef) {
+                // Git normally exits 1 for detached HEAD. A success with no
+                // ref is malformed output, so retain the planned fallback.
+                return {};
+            }
+            if (!branchRef.startsWith('refs/heads/')) {
+                // A successful non-local ref is a known absence, never a
+                // reason to show a stale plan.
+                return { branchName: '' };
+            }
+            return {
+                branchRef,
+                branchName: branchRef.slice('refs/heads/'.length),
+            };
+        } catch (error) {
+            // `symbolic-ref -q` exits 1 quietly on detached HEAD.
+            return exitCode(error) === 1 ? { branchName: '' } : {};
+        }
+    }
+
+    /**
+     * Tracking facts reuse the current-branch query. A branch read failure
+     * remains distinct from a known detached or non-local HEAD.
+     */
     private async collectTracking(
         worktreePath: string
     ): Promise<{
@@ -340,27 +378,13 @@ export class ChangesCollector {
         headSha?: string;
         upstream: MemberUpstreamState;
     }> {
-        // ① Current branch ref. `symbolic-ref -q` exits 1 quietly on a
-        // detached HEAD — that is the fact "no branch" (→ none), while a
-        // genuine failure (timeout, git gone) degrades to unknown.
-        let branchRef: string | undefined;
-        let branchName: string | undefined;
-        try {
-            const symbolic = await this.execGit([
-                '-C', worktreePath, 'symbolic-ref', '-q', 'HEAD',
-            ], worktreePath);
-            branchRef = symbolic.stdout.trim() || undefined;
-            branchName = branchRef?.startsWith('refs/heads/')
-                ? branchRef.slice('refs/heads/'.length)
-                : undefined;
-        } catch (error) {
-            if (exitCode(error) !== 1) {
-                return {
-                    headSha: await this.revParseHead(worktreePath),
-                    upstream: { status: 'unknown' },
-                };
-            }
-            branchName = '';
+        const { branchRef, branchName } = await this.collectCurrentBranch(
+            worktreePath);
+        if (branchName === undefined) {
+            return {
+                headSha: await this.revParseHead(worktreePath),
+                upstream: { status: 'unknown' },
+            };
         }
         // ② Upstream full ref for the branch; empty output = none.
         let fullRef: string | undefined;

--- a/src/worktrees/changesCollector.ts
+++ b/src/worktrees/changesCollector.ts
@@ -82,6 +82,11 @@ export interface MemberChangesSnapshot {
      */
     headSha?: string;
     /**
+     * Current local branch short name. An empty string is the known detached
+     * HEAD state; an absent value means the branch query itself failed.
+     */
+    branchName?: string;
+    /**
      * Tracking-branch state (changes-panel PRD §14.1 three-state chain),
      * collected independently of the baseline; absent only when the
      * member is unreadable.
@@ -261,6 +266,9 @@ export class ChangesCollector {
         if (tracking.headSha !== undefined) {
             snapshot.headSha = tracking.headSha;
         }
+        if (tracking.branchName !== undefined) {
+            snapshot.branchName = tracking.branchName;
+        }
         snapshot.upstream = tracking.upstream;
         if (!baseline) {
             return snapshot;
@@ -327,16 +335,24 @@ export class ChangesCollector {
      */
     private async collectTracking(
         worktreePath: string
-    ): Promise<{ headSha?: string; upstream: MemberUpstreamState }> {
+    ): Promise<{
+        branchName?: string;
+        headSha?: string;
+        upstream: MemberUpstreamState;
+    }> {
         // ① Current branch ref. `symbolic-ref -q` exits 1 quietly on a
         // detached HEAD — that is the fact "no branch" (→ none), while a
         // genuine failure (timeout, git gone) degrades to unknown.
         let branchRef: string | undefined;
+        let branchName: string | undefined;
         try {
             const symbolic = await this.execGit([
                 '-C', worktreePath, 'symbolic-ref', '-q', 'HEAD',
             ], worktreePath);
             branchRef = symbolic.stdout.trim() || undefined;
+            branchName = branchRef?.startsWith('refs/heads/')
+                ? branchRef.slice('refs/heads/'.length)
+                : undefined;
         } catch (error) {
             if (exitCode(error) !== 1) {
                 return {
@@ -344,6 +360,7 @@ export class ChangesCollector {
                     upstream: { status: 'unknown' },
                 };
             }
+            branchName = '';
         }
         // ② Upstream full ref for the branch; empty output = none.
         let fullRef: string | undefined;
@@ -356,6 +373,7 @@ export class ChangesCollector {
                 fullRef = refs.stdout.trim() || undefined;
             } catch (_error) {
                 return {
+                    ...(branchName !== undefined ? { branchName } : {}),
                     headSha: await this.revParseHead(worktreePath),
                     upstream: { status: 'unknown' },
                 };
@@ -363,6 +381,7 @@ export class ChangesCollector {
         }
         if (!fullRef) {
             return {
+                ...(branchName !== undefined ? { branchName } : {}),
                 headSha: await this.revParseHead(worktreePath),
                 upstream: { status: 'none' },
             };
@@ -381,10 +400,17 @@ export class ChangesCollector {
             upstreamSha = FULL_SHA_PATTERN.test(lines[1] || '')
                 ? lines[1] : undefined;
         } catch (_error) {
-            return { upstream: { status: 'unknown' } };
+            return {
+                ...(branchName !== undefined ? { branchName } : {}),
+                upstream: { status: 'unknown' },
+            };
         }
         if (!headSha || !upstreamSha) {
-            return { headSha, upstream: { status: 'unknown' } };
+            return {
+                ...(branchName !== undefined ? { branchName } : {}),
+                ...(headSha ? { headSha } : {}),
+                upstream: { status: 'unknown' },
+            };
         }
         // ④ Fork counts: left = behind, right = ahead (PRD §14.1 — the
         // order is easy to swap; the assertion message lives in tests).
@@ -396,9 +422,14 @@ export class ChangesCollector {
             ], worktreePath);
             const match = /^(\d+)\t(\d+)$/u.exec(counts.stdout.trim());
             if (!match) {
-                return { headSha, upstream: { status: 'unknown' } };
+                return {
+                    ...(branchName !== undefined ? { branchName } : {}),
+                    headSha,
+                    upstream: { status: 'unknown' },
+                };
             }
             return {
+                ...(branchName !== undefined ? { branchName } : {}),
                 headSha,
                 upstream: {
                     status: 'tracked',
@@ -409,7 +440,11 @@ export class ChangesCollector {
                 },
             };
         } catch (_error) {
-            return { headSha, upstream: { status: 'unknown' } };
+            return {
+                ...(branchName !== undefined ? { branchName } : {}),
+                headSha,
+                upstream: { status: 'unknown' },
+            };
         }
     }
 

--- a/tests/contract/worktrees/changesCollector.test.js
+++ b/tests/contract/worktrees/changesCollector.test.js
@@ -73,6 +73,7 @@ test('WORKTREE-CHANGES-COLLECT-001 a tracked branch reports sha and diverged ahe
     const clean = await collector.collect(repo);
     assert.equal(clean.availability, 'baselineUnavailable',
         'tracking collection is independent of the baseline (PRD §14.1)');
+    assert.equal(clean.branchName, 'main');
     assert.equal(clean.headSha, git(repo, ['rev-parse', 'HEAD']));
     assert.deepEqual(clean.upstream, {
         status: 'tracked',

--- a/tests/unit/aiSessions/conversationChangesController.test.js
+++ b/tests/unit/aiSessions/conversationChangesController.test.js
@@ -342,6 +342,48 @@ test('WORKTREE-CHANGES-PANEL-001 review requires a verified baseline and open-sc
     assert.deepEqual(scm, [WT_PATH]);
 });
 
+test('WORKTREE-CHANGES-PANEL-001 review titles use the live branch shown in the sidebar', async () => {
+    const taskReviews = [];
+    const commitReviews = [];
+    const sha = 'c'.repeat(40);
+    const { controller } = fixture({
+        collector: new ChangesCollector({
+            execGit: async args => {
+                if (args.includes('status')) return { stdout: '', stderr: '' };
+                if (args.includes('symbolic-ref')) {
+                    return { stdout: 'refs/heads/main\n', stderr: '' };
+                }
+                if (args.includes('for-each-ref')) return { stdout: '', stderr: '' };
+                if (args.includes('rev-parse')) {
+                    return { stdout: `${sha}\n`, stderr: '' };
+                }
+                if (args.includes('merge-base')) return { stdout: '', stderr: '' };
+                if (args.includes('rev-list')) return { stdout: '0\n', stderr: '' };
+                if (args.includes('diff')) return { stdout: '', stderr: '' };
+                return { stdout: '', stderr: '' };
+            },
+            now: () => 1724000000000,
+        }),
+        openTaskResultReview: async (...args) => taskReviews.push(args),
+        openCommitReview: async (...args) => commitReviews.push(args),
+        commitsCollector: {
+            list: async () => ({
+                commits: [], hasMore: false, historyHead: sha,
+            }),
+            detail: async () => ({
+                files: [], totalFiles: 0, filesTruncated: false,
+            }),
+            commitExists: async () => true,
+        },
+    });
+    await controller.activate(TARGET);
+    await controller.handleReview('member-1');
+    await controller.handleCommitReview({ memberId: 'member-1', sha });
+
+    assert.equal(taskReviews[0][2], 'Task result · api (main)');
+    assert.equal(commitReviews[0][3], 'Commit ccccccc · api (main)');
+});
+
 test('WORKTREE-CHANGES-PANEL-001 remembers the selected member across reactivation', async () => {
     const { posted, controller } = fixture();
     await controller.activate(TARGET);

--- a/tests/unit/aiSessions/conversationChangesController.test.js
+++ b/tests/unit/aiSessions/conversationChangesController.test.js
@@ -185,6 +185,30 @@ test('WORKTREE-CHANGES-PANEL-001 member views carry headSha and the upstream tra
     });
 });
 
+test('WORKTREE-CHANGES-PANEL-001 member views prefer the current Git branch over the saved worktree plan', async () => {
+    const { posted, controller } = fixture({
+        collector: new ChangesCollector({
+            execGit: async args => {
+                if (args.includes('status')) {
+                    return { stdout: '', stderr: '' };
+                }
+                if (args.includes('symbolic-ref')) {
+                    return { stdout: 'refs/heads/main\n', stderr: '' };
+                }
+                if (args.includes('rev-parse')) {
+                    return { stdout: `${'c'.repeat(40)}\n`, stderr: '' };
+                }
+                return { stdout: '', stderr: '' };
+            },
+            now: () => 1724000000000,
+        }),
+    });
+    await controller.activate(TARGET);
+
+    assert.equal(lastChanges(posted).members[0].branchName, 'main',
+        'a manual branch switch must not leave the header on the stale plan');
+});
+
 test('WORKTREE-CHANGES-PANEL-001 unreadable member views omit headSha and upstream', async () => {
     const { posted, controller } = fixture({
         collector: new ChangesCollector({
@@ -231,6 +255,21 @@ test('WORKTREE-CHANGES-PANEL-001 unmanaged sessions degrade to a single-member v
                 ? { repositoryKey: REPO_KEY, canonicalWorktreePath: WT_PATH }
                 : undefined,
         findGroupByWorktreeKey: () => undefined,
+        collector: new ChangesCollector({
+            execGit: async args => {
+                if (args.includes('status')) {
+                    return { stdout: '', stderr: '' };
+                }
+                if (args.includes('symbolic-ref')) {
+                    return { stdout: 'refs/heads/main\n', stderr: '' };
+                }
+                if (args.includes('rev-parse')) {
+                    return { stdout: `${'c'.repeat(40)}\n`, stderr: '' };
+                }
+                return { stdout: '', stderr: '' };
+            },
+            now: () => 1724000000000,
+        }),
     });
     await controller.activate(TARGET);
     const state = lastChanges(posted);
@@ -240,6 +279,8 @@ test('WORKTREE-CHANGES-PANEL-001 unmanaged sessions degrade to a single-member v
         'the synthesized member id fits the protocol charset');
     assert.equal(state.members[0].availability, 'baselineUnavailable',
         'an unmanaged worktree never pretends a task start');
+    assert.equal(state.members[0].branchName, 'main',
+        'the header reports the live Git branch instead of its empty fallback');
 });
 
 test('WORKTREE-CHANGES-PANEL-001 non-git sessions publish nothing actionable', async () => {

--- a/tests/unit/worktrees/changesCollector.test.js
+++ b/tests/unit/worktrees/changesCollector.test.js
@@ -170,6 +170,7 @@ test('WORKTREE-CHANGES-COLLECT-001 collects headSha and a tracked upstream in fo
     // No baseline: tracking collection is independent of it (PRD §14.1).
     const snapshot = await collector.collect('/worktrees/task');
     assert.equal(snapshot.availability, 'baselineUnavailable');
+    assert.equal(snapshot.branchName, 'fix-x');
     assert.equal(snapshot.headSha, HEAD_SHA);
     assert.deepEqual(snapshot.upstream, {
         status: 'tracked',
@@ -200,6 +201,7 @@ test('WORKTREE-CHANGES-COLLECT-001 no tracking branch is an explicit none, headS
     const snapshot = await collector.collect('/worktrees/task', BASELINE);
     assert.deepEqual(snapshot.upstream, { status: 'none' },
         'a successful but empty upstream query is a fact, not a failure');
+    assert.equal(snapshot.branchName, 'local-only');
     assert.equal(snapshot.headSha, HEAD_SHA);
     assert.ok(!seen.some(args => args.includes('--left-right')),
         'no upstream means no fork-count process');
@@ -210,6 +212,8 @@ test('WORKTREE-CHANGES-COLLECT-001 detached HEAD reports none via the quiet exit
     const { collector } = trackingCollector({ symbolicRef: detached });
     const snapshot = await collector.collect('/worktrees/task', BASELINE);
     assert.deepEqual(snapshot.upstream, { status: 'none' });
+    assert.equal(snapshot.branchName, '',
+        'a detached HEAD is a known absence, not a failed branch query');
     assert.equal(snapshot.headSha, HEAD_SHA,
         'a detached worktree still has a HEAD');
 });
@@ -254,6 +258,8 @@ test('WORKTREE-CHANGES-COLLECT-001 tracking failures degrade to unknown, never t
     });
     const fromGarbage = await garbageCount.collector.collect('/worktrees/task', BASELINE);
     assert.deepEqual(fromGarbage.upstream, { status: 'unknown' });
+    assert.equal(fromGarbage.branchName, 'fix-x',
+        'an upstream count failure must not discard a known current branch');
 });
 
 test('WORKTREE-CHANGES-COLLECT-001 unreadable members omit headSha and upstream entirely', async () => {

--- a/tests/unit/worktrees/changesCollector.test.js
+++ b/tests/unit/worktrees/changesCollector.test.js
@@ -218,6 +218,39 @@ test('WORKTREE-CHANGES-COLLECT-001 detached HEAD reports none via the quiet exit
         'a detached worktree still has a HEAD');
 });
 
+test('WORKTREE-CHANGES-COLLECT-001 non-local symbolic HEAD never falls back to a planned branch', async () => {
+    const { collector } = trackingCollector({
+        symbolicRef: 'refs/meta/custom\n',
+    });
+    const snapshot = await collector.collect('/worktrees/task', BASELINE);
+    assert.equal(snapshot.branchName, '',
+        'a readable symbolic target outside refs/heads has no local branch label');
+});
+
+test('WORKTREE-CHANGES-COLLECT-001 retains a readable branch when SCM status fails', async () => {
+    const calls = [];
+    const collector = new ChangesCollector({
+        execGit: async args => {
+            calls.push(args);
+            if (args.includes('status')) {
+                throw new Error('status timed out');
+            }
+            if (args.includes('symbolic-ref')) {
+                return { stdout: 'refs/heads/main\n', stderr: '' };
+            }
+            throw new Error(`unexpected Git query: ${args.join(' ')}`);
+        },
+        now: () => 1724000000000,
+    });
+    const snapshot = await collector.collect('/worktrees/task', BASELINE);
+    assert.equal(snapshot.availability, 'unreadable');
+    assert.equal(snapshot.branchName, 'main');
+    assert.ok(!('headSha' in snapshot));
+    assert.ok(!('upstream' in snapshot));
+    assert.equal(calls.length, 2,
+        'a degraded snapshot needs only status and the independent branch fact');
+});
+
 test('WORKTREE-CHANGES-COLLECT-001 tracking failures degrade to unknown, never to zero', async () => {
     // symbolic-ref itself fails (not the quiet detached exit).
     const brokenRef = trackingCollector({


### PR DESCRIPTION
## Summary

- Show the current Git branch for managed and unmanaged Changes sidebar members.
- Keep review titles aligned with the live branch and preserve branch labels when SCM status is degraded.

## Verification

- `npm run install-local` (with the active remote VS Code Server explicitly selected)
- Focused unit and Git contract tests
- `npm run test:behavior-contracts`
- `npm run test:dashboard:run`

## Skill harvest

No skill change: the applicable installation skill already required active-server verification; an explicit active Server override was used after the repository selector chose a non-active installation.

## Owner approvals

```
approve 6aeede98deaa0e1c2f307ea720865e5089f35012
```