### PR TITLE
fix: restore Kimi Code conversations

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -4683,6 +4683,7 @@
       "tests/contract/aiSessions/codexConversationAdapter.test.js",
       "tests/contract/aiSessions/kimiConversationAdapter.test.js",
       "tests/contract/aiSessions/claudeConversationAdapter.test.js",
+      "tests/integration/dashboard/conversationViewer.test.js",
       "tests/unit/aiSessions/codexRolloutContentSignature.test.js"
     ],
     "evidence": [

--- a/src/aiSessions/conversation/kimiAdapter.ts
+++ b/src/aiSessions/conversation/kimiAdapter.ts
@@ -244,6 +244,28 @@ function visibleMessage(value: string): string {
         );
 }
 
+function visibleKimiCodeInput(value: unknown): string {
+    if (!Array.isArray(value)) {
+        return '';
+    }
+    return buildVisibleUserInput(value.reduce(
+        (parts: VisibleUserInputPart[], rawPart: unknown) => {
+            const part = asRecord(rawPart);
+            if (part?.type === 'text' && typeof part.text === 'string') {
+                parts.push({ kind: 'text', text: part.text });
+            } else if (part && (
+                part.type === 'image'
+                || part.type === 'file'
+                || part.type === 'attachment'
+            )) {
+                parts.push({ kind: 'attachment' });
+            }
+            return parts;
+        },
+        []
+    ));
+}
+
 function interactionId(
     sessionId: string,
     offset: number,
@@ -1207,6 +1229,106 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
             };
             const normalizeRecord = (record: ConversationJsonlRecord): boolean | void => {
                 const envelope = asRecord(record.value);
+                const kimiCodeRecordType = envelope?.type;
+                if (typeof kimiCodeRecordType === 'string') {
+                    if (kimiCodeRecordType === 'turn.prompt'
+                        || kimiCodeRecordType === 'turn.steer') {
+                        const origin = asRecord(envelope.origin);
+                        if (origin?.kind !== 'user') {
+                            return;
+                        }
+                        flushThinking();
+                        flushText();
+                        const normalizedInput = visibleMessage(
+                            visibleKimiCodeInput(envelope.input)
+                        );
+                        if (!normalizedInput) {
+                            return;
+                        }
+                        if (openInteractionIndex !== undefined) {
+                            interactions[openInteractionIndex].responseState =
+                                'interrupted';
+                            openInteractionIndex = undefined;
+                        }
+                        toolTracker.discardPending();
+                        questionTracker.clear();
+                        approvalTracker.clear();
+                        const id = interactionId(
+                            sessionId,
+                            record.offset,
+                            envelope.time
+                        );
+                        if (interactions.some(interaction => interaction.id === id)) {
+                            return;
+                        }
+                        if (!toolTracker.hasPending()
+                            && questionTracker.size === 0
+                            && approvalTracker.size === 0) {
+                            addRestartPoint({
+                                offset: record.offset,
+                                recordEndOffset: record.proofEndOffset,
+                                recordDigest: record.proofDigest,
+                                prefixDigest: record.prefixDigest,
+                                interactionId: id,
+                            });
+                        }
+                        interactions.push({
+                            id,
+                            timestamp: timestampValue(envelope.time),
+                            userMarkdown: normalizedInput,
+                            userPreview: buildUserPreview(normalizedInput),
+                            userGraphemeCount: countGraphemes(normalizedInput),
+                            assistantMarkdown: [],
+                            responseState: 'inProgress',
+                        });
+                        openInteractionIndex = interactions.length - 1;
+                    } else if (kimiCodeRecordType === 'context.append_loop_event') {
+                        const loopEvent = asRecord(envelope.event);
+                        const part = asRecord(loopEvent?.part);
+                        stampActivity({ timestamp: envelope.time });
+                        if (loopEvent?.type === 'content.part'
+                            && openInteractionIndex !== undefined
+                            && part?.type === 'think'
+                            && typeof part.think === 'string') {
+                            if (part.think === '') {
+                                return;
+                            }
+                            flushText();
+                            if (!pendingThinking) {
+                                pendingThinking = {
+                                    position: interactions[openInteractionIndex]
+                                        .assistantMarkdown.length,
+                                    text: '',
+                                };
+                            }
+                            pendingThinking.text += part.think;
+                            return;
+                        }
+                        flushThinking();
+                        if (loopEvent?.type === 'content.part'
+                            && openInteractionIndex !== undefined
+                            && part?.type === 'text'
+                            && typeof part.text === 'string') {
+                            if (!pendingText) {
+                                pendingText = { text: '' };
+                            }
+                            pendingText.text += part.text;
+                            return;
+                        }
+                        flushText();
+                    } else if (kimiCodeRecordType === 'turn.ended') {
+                        stampActivity({ timestamp: envelope.time });
+                        const completed = envelope.reason === 'completed';
+                        finishInteraction(completed ? 'complete' : 'interrupted');
+                        if (!completed) {
+                            toolTracker.discardPending();
+                            questionTracker.clear();
+                            approvalTracker.clear();
+                        }
+                    }
+                    return Boolean(historySlice && historyBoundary
+                        && record.endOffset >= historySliceEndOffset);
+                }
                 const event = asRecord(envelope?.message);
                 if (!event) {
                     return;
@@ -1646,7 +1768,7 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                 if (!envelope || openInteractionIndex === undefined) {
                     return;
                 }
-                const value = timestampValue(envelope.timestamp);
+                const value = timestampValue(envelope.timestamp ?? envelope.time);
                 if (value !== undefined) {
                     interactions[openInteractionIndex].completedAt = value;
                 }

--- a/src/aiSessions/conversation/kimiAdapter.ts
+++ b/src/aiSessions/conversation/kimiAdapter.ts
@@ -261,6 +261,9 @@ function visibleKimiCodeInput(value: unknown): string {
                 parts.push({ kind: 'text', text: part.text });
             } else if (part && (
                 part.type === 'image'
+                || part.type === 'image_url'
+                || part.type === 'audio_url'
+                || part.type === 'video_url'
                 || part.type === 'file'
                 || part.type === 'attachment'
             )) {
@@ -270,6 +273,14 @@ function visibleKimiCodeInput(value: unknown): string {
         },
         []
     ));
+}
+
+function isKimiCodeUserOrigin(value: unknown): boolean {
+    const origin = asRecord(value);
+    return origin?.kind === 'user'
+        || origin?.kind === 'skill_activation'
+        || origin?.kind === 'plugin_command'
+        || origin?.kind === 'shell_command';
 }
 
 function interactionId(
@@ -678,6 +689,7 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
             return [];
         }
         const now = Date.now();
+        const kimiCode = isKimiCodeMainWire(candidate.sourcePath);
         const entries: ConversationSubagentEntry[] = [];
         for (const dirent of dirents) {
             if (entries.length >= MAX_LISTED_SUBAGENTS) {
@@ -691,7 +703,8 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
             const entry = await readSubagentEntry(
                 path.join(subagentsRoot, dirent.name),
                 dirent.name,
-                now
+                now,
+                kimiCode
             );
             if (entry) {
                 entries.push(entry);
@@ -1239,14 +1252,26 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                 }
                 pendingThinking = null;
             };
+            const ensureOpenKimiCodeInteraction = (): boolean => {
+                if (openInteractionIndex !== undefined) {
+                    return true;
+                }
+                if (!interactions.length) {
+                    return false;
+                }
+                // Goal continuation can resume a completed turn without a
+                // second prompt; keep it with the task that started it.
+                openInteractionIndex = interactions.length - 1;
+                interactions[openInteractionIndex].responseState = 'inProgress';
+                return true;
+            };
             const normalizeRecord = (record: ConversationJsonlRecord): boolean | void => {
                 const envelope = asRecord(record.value);
                 const kimiCodeRecordType = envelope?.type;
                 if (typeof kimiCodeRecordType === 'string') {
                     if (kimiCodeRecordType === 'turn.prompt'
                         || kimiCodeRecordType === 'turn.steer') {
-                        const origin = asRecord(envelope.origin);
-                        if (origin?.kind !== 'user') {
+                        if (!isKimiCodeUserOrigin(envelope.origin)) {
                             return;
                         }
                         flushThinking();
@@ -1299,7 +1324,7 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                         const part = asRecord(loopEvent?.part);
                         stampActivity({ timestamp: envelope.time });
                         if (loopEvent?.type === 'tool.call'
-                            && openInteractionIndex !== undefined
+                            && ensureOpenKimiCodeInteraction()
                             && typeof loopEvent.name === 'string'
                             && loopEvent.name) {
                             flushThinking();
@@ -1320,10 +1345,10 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                             const result = asRecord(loopEvent.result);
                             const output = typeof result?.output === 'string'
                                 ? result.output
-                                : undefined;
-                            toolTracker.finish(loopEvent.toolCallId, output);
+                                : visibleKimiCodeInput(result?.output);
+                            toolTracker.finish(loopEvent.toolCallId, output || undefined);
                         } else if (loopEvent?.type === 'content.part'
-                            && openInteractionIndex !== undefined
+                            && ensureOpenKimiCodeInteraction()
                             && part?.type === 'think'
                             && typeof part.think === 'string') {
                             if (part.think === '') {
@@ -1342,7 +1367,7 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                         }
                         flushThinking();
                         if (loopEvent?.type === 'content.part'
-                            && openInteractionIndex !== undefined
+                            && ensureOpenKimiCodeInteraction()
                             && part?.type === 'text'
                             && typeof part.text === 'string') {
                             if (!pendingText) {
@@ -1357,7 +1382,7 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                         const content = visibleKimiCodeInput(message?.content);
                         stampActivity({ timestamp: envelope.time });
                         if (message?.role === 'assistant' && content
-                            && openInteractionIndex !== undefined) {
+                            && ensureOpenKimiCodeInteraction()) {
                             flushThinking();
                             if (!pendingText) {
                                 pendingText = { text: '' };
@@ -2027,11 +2052,13 @@ interface SubagentMeta {
 async function readSubagentEntry(
     directory: string,
     id: string,
-    now: number
+    now: number,
+    isKimiCode = false
 ): Promise<ConversationSubagentEntry | undefined> {
+    const wirePath = path.join(directory, 'wire.jsonl');
     let wireStat: fs.Stats;
     try {
-        wireStat = await fs.promises.stat(path.join(directory, 'wire.jsonl'));
+        wireStat = await fs.promises.stat(wirePath);
     } catch (_error) {
         return undefined;
     }
@@ -2040,12 +2067,39 @@ async function readSubagentEntry(
         id,
         label: subagentLabel(meta, id),
         ...(meta?.subagent_type ? { agentType: meta.subagent_type } : {}),
-        status: subagentStatus(meta?.status, wireStat.mtimeMs, now),
+        status: isKimiCode
+            ? await kimiCodeSubagentStatus(wirePath, wireStat.mtimeMs, now)
+            : subagentStatus(meta?.status, wireStat.mtimeMs, now),
         ...(Number.isFinite(meta?.created_at)
             ? { createdAt: Math.floor((meta?.created_at as number) * 1000) }
             : {}),
         updatedAt: Math.floor(wireStat.mtimeMs),
     };
+}
+
+async function kimiCodeSubagentStatus(
+    wirePath: string,
+    wireMtimeMs: number,
+    now: number
+): Promise<ConversationSubagentEntry['status']> {
+    try {
+        const lines = (await fs.promises.readFile(wirePath, 'utf8'))
+            .trim().split(/\r?\n/);
+        for (let index = lines.length - 1; index >= 0; index -= 1) {
+            const record = asRecord(JSON.parse(lines[index]));
+            if (record?.type === 'turn.ended') {
+                return 'idle';
+            }
+            if (record) {
+                break;
+            }
+        }
+    } catch (_error) {
+        return 'quiet';
+    }
+    return now - wireMtimeMs <= SUBAGENT_RUNNING_FRESHNESS_MS
+        ? 'running'
+        : 'quiet';
 }
 
 async function readSubagentMeta(

--- a/src/aiSessions/conversation/kimiAdapter.ts
+++ b/src/aiSessions/conversation/kimiAdapter.ts
@@ -91,6 +91,12 @@ const SUBAGENT_DIRECTORY_PATTERN = /^[0-9a-z][0-9a-z-]{0,63}$/i;
 const SUBAGENT_RUNNING_FRESHNESS_MS = 5 * 60 * 1000;
 const HISTORY_INDEX_SETTLE_MS = 250;
 
+function isKimiCodeMainWire(sourcePath: string): boolean {
+    return path.basename(sourcePath) === 'wire.jsonl'
+        && path.basename(path.dirname(sourcePath)) === 'main'
+        && path.basename(path.dirname(path.dirname(sourcePath))) === 'agents';
+}
+
 function extractShellWorkingDirectories(
     value: string,
     baseCwd?: string
@@ -660,10 +666,9 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
         if (!candidate) {
             return [];
         }
-        const subagentsRoot = path.join(
-            path.dirname(candidate.sourcePath),
-            'subagents'
-        );
+        const subagentsRoot = isKimiCodeMainWire(candidate.sourcePath)
+            ? path.dirname(path.dirname(candidate.sourcePath))
+            : path.join(path.dirname(candidate.sourcePath), 'subagents');
         let dirents: fs.Dirent[];
         try {
             dirents = await fs.promises.readdir(subagentsRoot, {
@@ -679,6 +684,7 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                 break;
             }
             if (!dirent.isDirectory()
+                || (isKimiCodeMainWire(candidate.sourcePath) && dirent.name === 'main')
                 || !SUBAGENT_DIRECTORY_PATTERN.test(dirent.name)) {
                 continue;
             }
@@ -1075,12 +1081,18 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
         const effectiveCandidate = split.subagentId
             ? {
                 providerHome: candidate.providerHome,
-                sourcePath: path.join(
-                    path.dirname(candidate.sourcePath),
-                    'subagents',
-                    split.subagentId,
-                    'wire.jsonl'
-                ),
+                sourcePath: isKimiCodeMainWire(candidate.sourcePath)
+                    ? path.join(
+                        path.dirname(path.dirname(candidate.sourcePath)),
+                        split.subagentId,
+                        'wire.jsonl'
+                    )
+                    : path.join(
+                        path.dirname(candidate.sourcePath),
+                        'subagents',
+                        split.subagentId,
+                        'wire.jsonl'
+                    ),
                 cwd: candidate.cwd,
             }
             : candidate;
@@ -1286,7 +1298,31 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                         const loopEvent = asRecord(envelope.event);
                         const part = asRecord(loopEvent?.part);
                         stampActivity({ timestamp: envelope.time });
-                        if (loopEvent?.type === 'content.part'
+                        if (loopEvent?.type === 'tool.call'
+                            && openInteractionIndex !== undefined
+                            && typeof loopEvent.name === 'string'
+                            && loopEvent.name) {
+                            flushThinking();
+                            flushText();
+                            const args = asRecord(loopEvent.args);
+                            toolTracker.begin(
+                                interactions[openInteractionIndex],
+                                typeof loopEvent.toolCallId === 'string'
+                                    ? loopEvent.toolCallId
+                                    : undefined,
+                                loopEvent.name,
+                                buildToolCallSummary(loopEvent.name, args),
+                                args ? capToolCallDetail(JSON.stringify(args)) : undefined
+                            );
+                        } else if (loopEvent?.type === 'tool.result') {
+                            flushThinking();
+                            flushText();
+                            const result = asRecord(loopEvent.result);
+                            const output = typeof result?.output === 'string'
+                                ? result.output
+                                : undefined;
+                            toolTracker.finish(loopEvent.toolCallId, output);
+                        } else if (loopEvent?.type === 'content.part'
                             && openInteractionIndex !== undefined
                             && part?.type === 'think'
                             && typeof part.think === 'string') {
@@ -1316,6 +1352,18 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                             return;
                         }
                         flushText();
+                    } else if (kimiCodeRecordType === 'context.append_message') {
+                        const message = asRecord(envelope.message);
+                        const content = visibleKimiCodeInput(message?.content);
+                        stampActivity({ timestamp: envelope.time });
+                        if (message?.role === 'assistant' && content
+                            && openInteractionIndex !== undefined) {
+                            flushThinking();
+                            if (!pendingText) {
+                                pendingText = { text: '' };
+                            }
+                            pendingText.text += content;
+                        }
                     } else if (kimiCodeRecordType === 'turn.ended') {
                         stampActivity({ timestamp: envelope.time });
                         const completed = envelope.reason === 'completed';

--- a/src/aiSessions/conversation/kimiAdapter.ts
+++ b/src/aiSessions/conversation/kimiAdapter.ts
@@ -275,12 +275,19 @@ function visibleKimiCodeInput(value: unknown): string {
     ));
 }
 
-function isKimiCodeUserOrigin(value: unknown): boolean {
+function isKimiCodeUserOrigin(value: unknown, allowSubagentTrigger = false): boolean {
     const origin = asRecord(value);
-    return origin?.kind === 'user'
-        || origin?.kind === 'skill_activation'
-        || origin?.kind === 'plugin_command'
-        || origin?.kind === 'shell_command';
+    if (origin?.kind === 'user') {
+        return true;
+    }
+    if (origin?.kind === 'skill_activation' || origin?.kind === 'plugin_command') {
+        return origin.trigger === 'user-slash';
+    }
+    if (origin?.kind === 'shell_command') {
+        return origin.phase === 'input';
+    }
+    return allowSubagentTrigger && origin?.kind === 'system_trigger'
+        && origin.name === 'subagent';
 }
 
 function interactionId(
@@ -1271,7 +1278,10 @@ export class KimiConversationAdapter implements ConversationProviderAdapter {
                 if (typeof kimiCodeRecordType === 'string') {
                     if (kimiCodeRecordType === 'turn.prompt'
                         || kimiCodeRecordType === 'turn.steer') {
-                        if (!isKimiCodeUserOrigin(envelope.origin)) {
+                        if (!isKimiCodeUserOrigin(
+                            envelope.origin,
+                            Boolean(split.subagentId && isKimiCodeMainWire(candidate.sourcePath))
+                        )) {
                             return;
                         }
                         flushThinking();
@@ -2083,12 +2093,31 @@ async function kimiCodeSubagentStatus(
     now: number
 ): Promise<ConversationSubagentEntry['status']> {
     try {
-        const lines = (await fs.promises.readFile(wirePath, 'utf8'))
-            .trim().split(/\r?\n/);
+        const handle = await fs.promises.open(wirePath, 'r');
+        let text: string;
+        try {
+            const stat = await handle.stat();
+            const start = Math.max(0, stat.size - 64 * 1024);
+            const buffer = Buffer.alloc(stat.size - start);
+            const result = await handle.read(buffer, 0, buffer.length, start);
+            text = buffer.subarray(0, result.bytesRead).toString('utf8');
+        } finally {
+            await handle.close();
+        }
+        const lines = text.split(/\r?\n/);
         for (let index = lines.length - 1; index >= 0; index -= 1) {
-            const record = asRecord(JSON.parse(lines[index]));
+            let record: Record<string, any> | undefined;
+            try {
+                record = asRecord(JSON.parse(lines[index]));
+            } catch (_error) {
+                // A streaming writer can leave only the final JSON line torn.
+                continue;
+            }
             if (record?.type === 'turn.ended') {
-                return 'idle';
+                return record.reason === 'failed' ? 'failed'
+                    : record.reason === 'cancelled' || record.reason === 'killed'
+                        ? 'killed'
+                        : 'idle';
             }
             if (record) {
                 break;

--- a/src/aiSessions/incrementalJsonlLifecycleReader.ts
+++ b/src/aiSessions/incrementalJsonlLifecycleReader.ts
@@ -32,14 +32,20 @@ export default class IncrementalJsonlLifecycleReader {
         key: string,
         filePath: string,
         runStartedAtMs: number,
-        createAccumulator: () => AiSessionLifecycleAccumulator
+        createAccumulator: () => AiSessionLifecycleAccumulator,
+        validateOpen?: (stat: fs.Stats) => boolean
     ): AiSessionLifecycleSignal | null {
         let previousCursor = this.cursors.get(key);
         let fd: number = null;
 
         try {
-            let stat = fs.statSync(filePath);
+            const noFollow = (fs.constants as any).O_NOFOLLOW || 0;
+            fd = fs.openSync(filePath, fs.constants.O_RDONLY | noFollow);
+            let stat = fs.fstatSync(fd);
             if (!stat.isFile()) {
+                return null;
+            }
+            if (validateOpen && !validateOpen(stat)) {
                 return null;
             }
 
@@ -69,7 +75,6 @@ export default class IncrementalJsonlLifecycleReader {
                 return cursor.accumulator.getSignal();
             }
 
-            fd = fs.openSync(filePath, 'r');
             while (cursor.offset < stat.size) {
                 let remaining = stat.size - cursor.offset;
                 let buffer = Buffer.alloc(Math.min(this.chunkBytes, remaining));

--- a/src/aiSessions/lifecycle.ts
+++ b/src/aiSessions/lifecycle.ts
@@ -39,7 +39,7 @@ function createAccumulator(
                     continue;
                 }
 
-                let occurredAtMs = getOccurredAtMs(event?.timestamp);
+                let occurredAtMs = getOccurredAtMs(event?.timestamp ?? event?.time);
                 if (!Number.isFinite(occurredAtMs) || occurredAtMs < runStartedAtMs
                     || (latest && occurredAtMs < latest.occurredAtMs)) {
                     continue;
@@ -180,6 +180,26 @@ export function createKimiLifecycleAccumulator(runStartedAtMs: number): AiSessio
     // therefore means "interrupted", not "completed".
     let interruptedTurnPending = false;
     return createAccumulator(runStartedAtMs, (event, occurredAtMs) => {
+        if (event?.type === 'turn.prompt' || event?.type === 'turn.steer') {
+            return event?.origin?.kind === 'user'
+                ? running('kimi', event.type, occurredAtMs, event.turnId)
+                : null;
+        }
+        if (event?.type === 'context.append_loop_event') {
+            return running('kimi', event.type, occurredAtMs, event?.event?.turnId);
+        }
+        if (event?.type === 'turn.ended') {
+            switch (event.reason) {
+                case 'completed':
+                    return attention('kimi', event.type, occurredAtMs, 'completed', event.turnId);
+                case 'failed':
+                    return attention('kimi', event.type, occurredAtMs, 'failed', event.turnId);
+                case 'blocked':
+                    return attention('kimi', event.type, occurredAtMs, 'input-required', event.turnId);
+                default:
+                    return idle('kimi', event.type, occurredAtMs, event.turnId);
+            }
+        }
         let message = event?.message || {};
         let payload = message.payload || {};
         if (KIMI_RUNNING_EVENTS.has(message.type)) {

--- a/src/services/kimiSessionService.ts
+++ b/src/services/kimiSessionService.ts
@@ -185,8 +185,8 @@ export default class KimiSessionService {
                 kimiCode ? opened => {
                     try {
                         const current = fs.lstatSync(sessionFile);
-                        return opened.dev === expectedWire?.dev && opened.ino === expectedWire?.ino
-                            && current.dev === expectedWire?.dev && current.ino === expectedWire?.ino
+                        return this.sameFileIdentity(expectedWire, opened)
+                            && this.sameFileIdentity(expectedWire, current)
                             && !current.isSymbolicLink()
                             && this.isKimiCodePathContained(location.kimiHome, sessionFile);
                     } catch (_error) {
@@ -217,31 +217,39 @@ export default class KimiSessionService {
             if (!statePath) {
                 return false;
             }
-            let beforeWrite = this.isKimiCodeHome(location.kimiHome)
+            const kimiCode = this.isKimiCodeHome(location.kimiHome);
+            let beforeWrite = kimiCode
                 ? fs.lstatSync(statePath)
                 : undefined;
             if (beforeWrite && (!beforeWrite.isFile() || beforeWrite.isSymbolicLink())) {
                 return false;
             }
-            let state = this.readJson<KimiSessionState>(statePath) || {};
-            state.archived = true;
-            state.archived_at = new Date().toISOString();
             const noFollow = (fs.constants as any).O_NOFOLLOW || 0;
             const descriptor = fs.openSync(
                 statePath,
-                fs.constants.O_WRONLY | fs.constants.O_CREAT | noFollow,
+                fs.constants.O_RDWR | fs.constants.O_CREAT | noFollow,
                 0o600
             );
             try {
                 if (beforeWrite) {
                     const opened = fs.fstatSync(descriptor);
-                    if (opened.dev !== beforeWrite.dev || opened.ino !== beforeWrite.ino
+                    const current = fs.lstatSync(statePath);
+                    if (!this.sameFileIdentity(beforeWrite, opened)
+                        || !this.sameFileIdentity(beforeWrite, current)
                         || !this.isKimiCodePathContained(location.kimiHome, statePath)) {
                         return false;
                     }
                 }
+                let state: KimiSessionState = {};
+                try {
+                    state = JSON.parse(fs.readFileSync(descriptor, 'utf8')) as KimiSessionState;
+                } catch (_error) {
+                    state = {};
+                }
+                state.archived = true;
+                state.archived_at = new Date().toISOString();
                 fs.ftruncateSync(descriptor, 0);
-                fs.writeFileSync(descriptor, JSON.stringify(state, null, 2));
+                fs.writeSync(descriptor, JSON.stringify(state, null, 2), 0, 'utf8');
             } finally {
                 fs.closeSync(descriptor);
             }
@@ -326,8 +334,8 @@ export default class KimiSessionService {
         let legacyOverride = process.env.KIMI_SHARE_DIR;
         let configuredCodeHome = process.env.KIMI_CODE_HOME;
         let kimiCodeHome = configuredCodeHome || path.join(os.homedir(), '.kimi-code');
-        let legacyHome = path.join(os.homedir(), '.kimi');
-        return Array.from(new Set([legacyOverride, kimiCodeHome, legacyHome].filter(Boolean))).filter(home =>
+        let legacyHome = legacyOverride || path.join(os.homedir(), '.kimi');
+        return Array.from(new Set([kimiCodeHome, legacyHome])).filter(home =>
             (this.isKimiCodeHome(home) || fs.existsSync(home))
         );
     }
@@ -667,15 +675,35 @@ export default class KimiSessionService {
             && !relative.startsWith(`..${path.sep}`) && relative !== '..';
     }
 
+    private sameFileIdentity(left: fs.Stats | undefined, right: fs.Stats | undefined): boolean {
+        return Boolean(left && right
+            && Number.isFinite(left.dev) && left.dev !== 0
+            && Number.isFinite(left.ino) && left.ino !== 0
+            && Number.isFinite(left.birthtimeMs)
+            && Number.isFinite(right.dev) && right.dev === left.dev
+            && Number.isFinite(right.ino) && right.ino === left.ino
+            && Number.isFinite(right.birthtimeMs) && right.birthtimeMs === left.birthtimeMs);
+    }
+
     private readKimiCodeSessionIndex(kimiHome: string): KimiCodeSessionIndexEntry[] {
         try {
             const indexPath = path.join(kimiHome, 'session_index.jsonl');
-            const stat = fs.statSync(indexPath);
-            if (!stat.isFile() || stat.size > MAX_KIMI_CODE_INDEX_BYTES) {
-                return [];
+            const noFollow = (fs.constants as any).O_NOFOLLOW || 0;
+            const descriptor = fs.openSync(indexPath, fs.constants.O_RDONLY | noFollow);
+            let contents: string;
+            try {
+                const stat = fs.fstatSync(descriptor);
+                if (!stat.isFile() || stat.size > MAX_KIMI_CODE_INDEX_BYTES) {
+                    return [];
+                }
+                const buffer = Buffer.alloc(stat.size);
+                const bytesRead = fs.readSync(descriptor, buffer, 0, buffer.length, 0);
+                contents = buffer.subarray(0, bytesRead).toString('utf8');
+            } finally {
+                fs.closeSync(descriptor);
             }
             const entries = new Map<string, KimiCodeSessionIndexEntry>();
-            for (const line of fs.readFileSync(indexPath, 'utf8')
+            for (const line of contents
                 .split(/\r?\n/)
                 .filter(Boolean)) {
                 try {

--- a/src/services/kimiSessionService.ts
+++ b/src/services/kimiSessionService.ts
@@ -13,6 +13,8 @@ import { createKimiLifecycleAccumulator, AiSessionLifecycleRequest, AiSessionLif
 import SessionFingerprint from '../aiSessions/sessionFingerprint';
 import { Disposable } from './codexSessionService';
 
+const MAX_KIMI_CODE_INDEX_BYTES = 16 * 1024 * 1024;
+
 interface KimiWorkDirEntry {
     path?: string;
     last_session_id?: string;
@@ -161,9 +163,17 @@ export default class KimiSessionService {
                 continue;
             }
             let sessionFile = this.getWirePath(location.kimiHome, location.sessionDir);
+            const kimiCode = this.isKimiCodeHome(location.kimiHome);
+            let expectedWire: fs.Stats | undefined;
+            try {
+                expectedWire = kimiCode ? fs.lstatSync(sessionFile) : undefined;
+            } catch (_error) {
+                this.lifecycleReader.delete(request.sessionId);
+                continue;
+            }
             if (!fs.existsSync(sessionFile)
-                || (this.isKimiCodeHome(location.kimiHome)
-                    && !this.isKimiCodePathContained(location.kimiHome, sessionFile))) {
+                || (kimiCode && (!expectedWire.isFile() || expectedWire.isSymbolicLink()
+                    || !this.isKimiCodePathContained(location.kimiHome, sessionFile)))) {
                 this.lifecycleReader.delete(request.sessionId);
                 continue;
             }
@@ -171,7 +181,18 @@ export default class KimiSessionService {
                 request.sessionId,
                 sessionFile,
                 request.runStartedAtMs,
-                () => createKimiLifecycleAccumulator(request.runStartedAtMs)
+                () => createKimiLifecycleAccumulator(request.runStartedAtMs),
+                kimiCode ? opened => {
+                    try {
+                        const current = fs.lstatSync(sessionFile);
+                        return opened.dev === expectedWire?.dev && opened.ino === expectedWire?.ino
+                            && current.dev === expectedWire?.dev && current.ino === expectedWire?.ino
+                            && !current.isSymbolicLink()
+                            && this.isKimiCodePathContained(location.kimiHome, sessionFile);
+                    } catch (_error) {
+                        return false;
+                    }
+                } : undefined
             );
             if (signal) {
                 signals[request.sessionId] = signal;
@@ -196,16 +217,30 @@ export default class KimiSessionService {
             if (!statePath) {
                 return false;
             }
+            let beforeWrite = this.isKimiCodeHome(location.kimiHome)
+                ? fs.lstatSync(statePath)
+                : undefined;
+            if (beforeWrite && (!beforeWrite.isFile() || beforeWrite.isSymbolicLink())) {
+                return false;
+            }
             let state = this.readJson<KimiSessionState>(statePath) || {};
             state.archived = true;
             state.archived_at = new Date().toISOString();
             const noFollow = (fs.constants as any).O_NOFOLLOW || 0;
             const descriptor = fs.openSync(
                 statePath,
-                fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_TRUNC | noFollow,
+                fs.constants.O_WRONLY | fs.constants.O_CREAT | noFollow,
                 0o600
             );
             try {
+                if (beforeWrite) {
+                    const opened = fs.fstatSync(descriptor);
+                    if (opened.dev !== beforeWrite.dev || opened.ino !== beforeWrite.ino
+                        || !this.isKimiCodePathContained(location.kimiHome, statePath)) {
+                        return false;
+                    }
+                }
+                fs.ftruncateSync(descriptor, 0);
                 fs.writeFileSync(descriptor, JSON.stringify(state, null, 2));
             } finally {
                 fs.closeSync(descriptor);
@@ -289,16 +324,10 @@ export default class KimiSessionService {
 
     private getKimiHomes(): string[] {
         let legacyOverride = process.env.KIMI_SHARE_DIR;
-        if (legacyOverride && fs.existsSync(legacyOverride)) {
-            return [legacyOverride];
-        }
-
         let configuredCodeHome = process.env.KIMI_CODE_HOME;
-        let kimiCodeHome = configuredCodeHome && fs.existsSync(configuredCodeHome)
-            ? configuredCodeHome
-            : path.join(os.homedir(), '.kimi-code');
+        let kimiCodeHome = configuredCodeHome || path.join(os.homedir(), '.kimi-code');
         let legacyHome = path.join(os.homedir(), '.kimi');
-        return Array.from(new Set([kimiCodeHome, legacyHome])).filter(home =>
+        return Array.from(new Set([legacyOverride, kimiCodeHome, legacyHome].filter(Boolean))).filter(home =>
             (this.isKimiCodeHome(home) || fs.existsSync(home))
         );
     }
@@ -441,16 +470,24 @@ export default class KimiSessionService {
 
     private findSessionLocations(sessionIds: readonly string[]): Map<string, { kimiHome: string; sessionDir: string }> {
         const homes = this.getKimiHomes();
-        const indexes = new Map<string, readonly KimiCodeSessionIndexEntry[]>();
+        const indexes = new Map<string, Map<string, KimiCodeSessionIndexEntry>>();
         for (const home of homes) {
             if (this.isKimiCodeHome(home)) {
-                indexes.set(home, this.readKimiCodeSessionIndex(home));
+                indexes.set(home, new Map(this.readKimiCodeSessionIndex(home).map(entry => [
+                    entry.sessionId,
+                    entry,
+                ])));
             }
         }
         const locations = new Map<string, { kimiHome: string; sessionDir: string }>();
         for (const sessionId of sessionIds) {
             for (const home of homes) {
-                const sessionDir = this.findSessionDir(home, sessionId, indexes.get(home));
+                const indexed = indexes.get(home)?.get(sessionId);
+                const sessionDir = indexed
+                    ? this.resolveKimiCodeSessionDir(home, indexed.sessionDir)
+                    : this.isKimiCodeHome(home)
+                        ? null
+                        : this.findSessionDir(home, sessionId);
                 if (sessionDir) {
                     locations.set(sessionId, { kimiHome: home, sessionDir });
                     break;
@@ -632,8 +669,13 @@ export default class KimiSessionService {
 
     private readKimiCodeSessionIndex(kimiHome: string): KimiCodeSessionIndexEntry[] {
         try {
+            const indexPath = path.join(kimiHome, 'session_index.jsonl');
+            const stat = fs.statSync(indexPath);
+            if (!stat.isFile() || stat.size > MAX_KIMI_CODE_INDEX_BYTES) {
+                return [];
+            }
             const entries = new Map<string, KimiCodeSessionIndexEntry>();
-            for (const line of fs.readFileSync(path.join(kimiHome, 'session_index.jsonl'), 'utf8')
+            for (const line of fs.readFileSync(indexPath, 'utf8')
                 .split(/\r?\n/)
                 .filter(Boolean)) {
                 try {

--- a/src/services/kimiSessionService.ts
+++ b/src/services/kimiSessionService.ts
@@ -24,6 +24,8 @@ interface KimiConfig {
 
 interface KimiSessionState {
     custom_title?: string;
+    title?: string;
+    cwd?: string;
     archived?: boolean;
     archived_at?: string;
     plan_mode?: boolean;
@@ -31,10 +33,17 @@ interface KimiSessionState {
 }
 
 interface KimiSessionCandidate {
+    kimiHome: string;
     workDir: string;
     sessionId: string;
     sessionDir: string;
     mtimeMs: number;
+}
+
+interface KimiCodeSessionIndexEntry {
+    sessionId?: string;
+    sessionDir?: string;
+    workDir?: string;
 }
 
 export interface KimiSessionReadResult {
@@ -56,13 +65,16 @@ export default class KimiSessionService {
     private changeFingerprint: string = null;
 
     resolveConversationSource(sessionId: string): AiSessionConversationSourceCandidate | null {
-        const kimiHome = this.getKimiHome();
-        const sessionDir = kimiHome && this.findSessionDir(kimiHome, sessionId);
-        const sourcePath = sessionDir && path.join(sessionDir, 'wire.jsonl');
+        const location = this.findSessionLocation(sessionId);
+        const kimiHome = location?.kimiHome;
+        const sessionDir = location?.sessionDir;
+        const sourcePath = sessionDir && this.getWirePath(kimiHome, sessionDir);
         const workDir = sessionDir
             ? this.findWorkDirForSessionDir(kimiHome, sessionDir)
             : null;
         return sourcePath && fs.existsSync(sourcePath)
+            && (!this.isKimiCodeHome(kimiHome)
+                || this.isKimiCodePathContained(kimiHome, sourcePath))
             ? {
                 providerHome: kimiHome,
                 sourcePath,
@@ -78,26 +90,25 @@ export default class KimiSessionService {
             return this.filterResult(this.cachedResult, candidatePaths);
         }
 
-        let kimiHome = this.getKimiHome();
-        if (!kimiHome) {
+        const kimiHomes = this.getKimiHomes();
+        if (!kimiHomes.length) {
             return this.cacheResult({ available: false, sessions: [], scannedFiles: 0, parsedFiles: 0 });
-        }
-
-        let workDirs = this.getWorkDirs(kimiHome);
-        if (!workDirs.length) {
-            return this.cacheResult({ available: false, sessions: [], scannedFiles: 0, parsedFiles: 0 });
-        }
-
-        if (candidatePaths.length) {
-            workDirs = workDirs.filter(workDir => candidatePaths.some(candidatePath => aiSessionPathContains(candidatePath, workDir)));
-            if (!workDirs.length) {
-                return { available: true, sessions: [], scannedFiles: 0, parsedFiles: 0 };
-            }
         }
 
         let candidates: KimiSessionCandidate[] = [];
-        for (let workDir of workDirs) {
-            candidates.push(...this.getSessionCandidatesForWorkDir(kimiHome, workDir));
+        for (const kimiHome of kimiHomes) {
+            if (this.isKimiCodeHome(kimiHome)) {
+                candidates.push(...this.getKimiCodeSessionCandidates(kimiHome));
+                continue;
+            }
+            for (const workDir of this.getWorkDirs(kimiHome)) {
+                candidates.push(...this.getSessionCandidatesForWorkDir(kimiHome, workDir));
+            }
+        }
+        if (candidatePaths.length) {
+            candidates = candidates.filter(candidate => candidatePaths.some(candidatePath =>
+                aiSessionPathContains(candidatePath, candidate.workDir)
+            ));
         }
 
         let parsedFiles = 0;
@@ -107,7 +118,12 @@ export default class KimiSessionService {
             .slice(0, maxFiles || undefined)) {
             parsedFiles++;
             this.sessionDirsById.set(candidate.sessionId, candidate.sessionDir);
-            let session = this.readSession(candidate.workDir, candidate.sessionId, candidate.sessionDir);
+            let session = this.readSession(
+                candidate.kimiHome,
+                candidate.workDir,
+                candidate.sessionId,
+                candidate.sessionDir
+            );
             if (session) {
                 sessions.push(session);
             }
@@ -120,8 +136,7 @@ export default class KimiSessionService {
 
     getLifecycleSignals(requests: readonly AiSessionLifecycleRequest[]): Record<string, AiSessionLifecycleSignal> {
         let activeSessionIds = new Set<string>();
-        let kimiHome = this.getKimiHome();
-        if (!kimiHome) {
+        if (!this.getKimiHomes().length) {
             this.lifecycleReader.retain(activeSessionIds);
             return {};
         }
@@ -134,12 +149,12 @@ export default class KimiSessionService {
             if (signals[request.sessionId]) {
                 continue;
             }
-            let sessionDir = this.findSessionDir(kimiHome, request.sessionId);
-            if (!sessionDir) {
+            const location = this.findSessionLocation(request.sessionId);
+            if (!location) {
                 this.lifecycleReader.delete(request.sessionId);
                 continue;
             }
-            let sessionFile = path.join(sessionDir, 'wire.jsonl');
+            let sessionFile = this.getWirePath(location.kimiHome, location.sessionDir);
             if (!fs.existsSync(sessionFile)) {
                 this.lifecycleReader.delete(request.sessionId);
                 continue;
@@ -163,18 +178,16 @@ export default class KimiSessionService {
             return false;
         }
 
-        let kimiHome = this.getKimiHome();
-        if (!kimiHome) {
-            return false;
-        }
-
-        let sessionDir = this.findSessionDir(kimiHome, sessionId);
-        if (!sessionDir) {
+        const location = this.findSessionLocation(sessionId);
+        if (!location) {
             return false;
         }
 
         try {
-            let statePath = path.join(sessionDir, 'state.json');
+            let statePath = this.getStatePath(location.kimiHome, location.sessionDir);
+            if (!statePath) {
+                return false;
+            }
             let state = this.readJson<KimiSessionState>(statePath) || {};
             state.archived = true;
             state.archived_at = new Date().toISOString();
@@ -256,14 +269,17 @@ export default class KimiSessionService {
         return filterAiSessionsByCandidatePaths(result, candidatePaths, session => session.workDir || session.cwd);
     }
 
-    private getKimiHome(): string {
+    private getKimiHomes(): string[] {
         let configuredHome = process.env.KIMI_SHARE_DIR;
         if (configuredHome && fs.existsSync(configuredHome)) {
-            return configuredHome;
+            return [configuredHome];
         }
 
-        let defaultHome = path.join(os.homedir(), '.kimi');
-        return fs.existsSync(defaultHome) ? defaultHome : null;
+        let kimiCodeHome = path.join(os.homedir(), '.kimi-code');
+        let legacyHome = path.join(os.homedir(), '.kimi');
+        return [kimiCodeHome, legacyHome].filter(home =>
+            (this.isKimiCodeHome(home) || fs.existsSync(home))
+        );
     }
 
     private getWorkDirs(kimiHome: string): string[] {
@@ -302,6 +318,7 @@ export default class KimiSessionService {
                 }
                 let sessionDir = path.join(sessionsDir, entry.name);
                 candidates.push({
+                    kimiHome,
                     workDir,
                     sessionId: entry.name,
                     sessionDir,
@@ -314,7 +331,46 @@ export default class KimiSessionService {
         }
     }
 
+    private getKimiCodeSessionCandidates(kimiHome: string): KimiSessionCandidate[] {
+        const candidates: KimiSessionCandidate[] = [];
+        const seenSessionIds = new Set<string>();
+        for (const entry of this.readKimiCodeSessionIndex(kimiHome)) {
+            const workDir = this.normalizePath(entry.workDir || '');
+            const sessionDir = this.resolveKimiCodeSessionDir(kimiHome, entry.sessionDir);
+            if (!workDir || !this.isKimiCodeSessionId(entry.sessionId)
+                || !sessionDir || path.basename(sessionDir) !== entry.sessionId
+                || seenSessionIds.has(entry.sessionId)) {
+                continue;
+            }
+            const wirePath = this.getWirePath(kimiHome, sessionDir);
+            if (!this.isKimiCodePathContained(kimiHome, wirePath)) {
+                continue;
+            }
+            seenSessionIds.add(entry.sessionId);
+            candidates.push({
+                kimiHome,
+                workDir,
+                sessionId: entry.sessionId,
+                sessionDir,
+                mtimeMs: this.getFileMtimeMs(wirePath),
+            });
+        }
+        return candidates;
+    }
+
     private findSessionDir(kimiHome: string, sessionId: string): string {
+        if (this.isKimiCodeHome(kimiHome)) {
+            const indexed = this.readKimiCodeSessionIndex(kimiHome).find(entry =>
+                entry.sessionId === sessionId
+                    && this.isKimiCodeSessionId(entry.sessionId)
+            );
+            const sessionDir = indexed
+                ? this.resolveKimiCodeSessionDir(kimiHome, indexed.sessionDir)
+                : null;
+            return sessionDir && path.basename(sessionDir) === sessionId
+                ? sessionDir
+                : null;
+        }
         if (!this.isSessionId(sessionId)) {
             return null;
         }
@@ -349,18 +405,41 @@ export default class KimiSessionService {
         return null;
     }
 
+    private findSessionLocation(sessionId: string): { kimiHome: string; sessionDir: string } | null {
+        for (const kimiHome of this.getKimiHomes()) {
+            const sessionDir = this.findSessionDir(kimiHome, sessionId);
+            if (sessionDir) {
+                return { kimiHome, sessionDir };
+            }
+        }
+        return null;
+    }
+
     private findWorkDirForSessionDir(
         kimiHome: string,
         sessionDir: string
     ): string {
+        if (this.isKimiCodeHome(kimiHome)) {
+            const normalizedSessionDir = path.resolve(sessionDir);
+            const indexed = this.readKimiCodeSessionIndex(kimiHome).find(entry =>
+                this.resolveKimiCodeSessionDir(kimiHome, entry.sessionDir)
+                    === normalizedSessionDir
+            );
+            return this.normalizePath(indexed?.workDir || '') || null;
+        }
         const workDirHash = path.basename(path.dirname(sessionDir));
         return this.getWorkDirs(kimiHome).find(workDir =>
             this.getWorkDirHash(workDir) === workDirHash
         ) || null;
     }
 
-    private readSession(workDir: string, sessionId: string, sessionDir: string): CodexSession {
-        let wirePath = path.join(sessionDir, 'wire.jsonl');
+    private readSession(
+        kimiHome: string,
+        workDir: string,
+        sessionId: string,
+        sessionDir: string
+    ): CodexSession {
+        let wirePath = this.getWirePath(kimiHome, sessionDir);
         if (!fs.existsSync(wirePath)) {
             return null;
         }
@@ -375,14 +454,14 @@ export default class KimiSessionService {
             return null;
         }
 
-        let state = this.readJson<KimiSessionState>(path.join(sessionDir, 'state.json'));
+        let state = this.readJson<KimiSessionState>(this.getStatePath(kimiHome, sessionDir));
         if (state?.archived) {
             return null;
         }
 
         return {
             id: sessionId,
-            name: state?.custom_title || state?.plan_slug || sessionId,
+            name: state?.custom_title || state?.title || state?.plan_slug || sessionId,
             updatedAt: new Date(wireStat.mtimeMs).toISOString(),
             cwd: workDir,
             workDir,
@@ -391,16 +470,28 @@ export default class KimiSessionService {
     }
 
     private getSessionFingerprint(): string {
-        let kimiHome = this.getKimiHome();
-        if (!kimiHome) {
+        const kimiHomes = this.getKimiHomes();
+        if (!kimiHomes.length) {
             return 'missing';
         }
 
         let fingerprint = new SessionFingerprint();
-        fingerprint.addEntry(kimiHome);
-        fingerprint.addEntry(getAiSessionFileSignature(path.join(kimiHome, 'kimi.json')));
-        for (let workDir of this.getWorkDirs(kimiHome)) {
-            this.addWorkDirFingerprint(fingerprint, kimiHome, workDir);
+        for (const kimiHome of kimiHomes) {
+            fingerprint.addEntry(kimiHome);
+            if (this.isKimiCodeHome(kimiHome)) {
+                fingerprint.addEntry(getAiSessionFileSignature(path.join(kimiHome, 'session_index.jsonl')));
+                for (const candidate of this.getKimiCodeSessionCandidates(kimiHome)) {
+                    fingerprint.addEntry(candidate.workDir);
+                    fingerprint.addEntry(candidate.sessionId);
+                    fingerprint.addEntry(getAiSessionFileSignature(this.getStatePath(kimiHome, candidate.sessionDir)));
+                    fingerprint.addEntry(getAiSessionFileSignature(this.getWirePath(kimiHome, candidate.sessionDir)));
+                }
+                continue;
+            }
+            fingerprint.addEntry(getAiSessionFileSignature(path.join(kimiHome, 'kimi.json')));
+            for (let workDir of this.getWorkDirs(kimiHome)) {
+                this.addWorkDirFingerprint(fingerprint, kimiHome, workDir);
+            }
         }
         return fingerprint.digest();
     }
@@ -443,6 +534,97 @@ export default class KimiSessionService {
 
     private isSessionId(value: string): boolean {
         return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value);
+    }
+
+    private isKimiCodeHome(kimiHome: string): boolean {
+        return fs.existsSync(path.join(kimiHome, 'session_index.jsonl'));
+    }
+
+    private isKimiCodeSessionId(value: unknown): value is string {
+        return typeof value === 'string'
+            && /^session_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value);
+    }
+
+    private getWirePath(kimiHome: string, sessionDir: string): string {
+        return path.join(sessionDir, this.isKimiCodeHome(kimiHome)
+            ? 'agents/main/wire.jsonl'
+            : 'wire.jsonl');
+    }
+
+    private getStatePath(kimiHome: string, sessionDir: string): string | null {
+        const statePath = path.join(sessionDir, 'state.json');
+        if (!this.isKimiCodeHome(kimiHome)) {
+            return statePath;
+        }
+        try {
+            const stat = fs.lstatSync(statePath);
+            if (!stat.isFile() && !stat.isSymbolicLink()) {
+                return null;
+            }
+            return this.isKimiCodePathContained(kimiHome, statePath)
+                ? statePath
+                : null;
+        } catch (error) {
+            return (error as NodeJS.ErrnoException).code === 'ENOENT'
+                ? statePath
+                : null;
+        }
+    }
+
+    private isKimiCodePathContained(kimiHome: string, value: string): boolean {
+        try {
+            return this.isPathContained(fs.realpathSync(kimiHome), fs.realpathSync(value));
+        } catch (_error) {
+            return false;
+        }
+    }
+
+    private isPathContained(home: string, value: string): boolean {
+        const relative = path.relative(home, value);
+        return Boolean(relative) && !relative.startsWith(`..${path.sep}`) && relative !== '..';
+    }
+
+    private readKimiCodeSessionIndex(kimiHome: string): KimiCodeSessionIndexEntry[] {
+        try {
+            const entries: KimiCodeSessionIndexEntry[] = [];
+            for (const line of fs.readFileSync(path.join(kimiHome, 'session_index.jsonl'), 'utf8')
+                .split(/\r?\n/)
+                .filter(Boolean)) {
+                try {
+                    const entry = JSON.parse(line) as KimiCodeSessionIndexEntry;
+                    if (entry && typeof entry === 'object') {
+                        entries.push(entry);
+                    }
+                } catch (_error) {
+                    // Ignore a partially-written trailing index entry.
+                }
+            }
+            return entries;
+        } catch (_error) {
+            return [];
+        }
+    }
+
+    private resolveKimiCodeSessionDir(kimiHome: string, value: unknown): string | null {
+        if (typeof value !== 'string' || !value) {
+            return null;
+        }
+        const resolvedHome = path.resolve(kimiHome);
+        const resolved = path.resolve(path.isAbsolute(value)
+            ? value
+            : path.join(kimiHome, value));
+        if (!this.isPathContained(resolvedHome, resolved)) {
+            return null;
+        }
+        try {
+            const canonicalHome = fs.realpathSync(kimiHome);
+            const canonicalSessionDir = fs.realpathSync(resolved);
+            return this.isPathContained(canonicalHome, canonicalSessionDir)
+                ? canonicalSessionDir
+                : null;
+        } catch (_error) {
+            return null;
+        }
     }
 
     private readJson<T>(filePath: string): T {

--- a/src/services/kimiSessionService.ts
+++ b/src/services/kimiSessionService.ts
@@ -99,14 +99,24 @@ export default class KimiSessionService {
         }
 
         let candidates: KimiSessionCandidate[] = [];
+        let available = false;
         for (const kimiHome of kimiHomes) {
             if (this.isKimiCodeHome(kimiHome)) {
+                available = true;
                 candidates.push(...this.getKimiCodeSessionCandidates(kimiHome));
                 continue;
             }
-            for (const workDir of this.getWorkDirs(kimiHome)) {
+            const workDirs = this.getWorkDirs(kimiHome);
+            if (!workDirs.length) {
+                continue;
+            }
+            available = true;
+            for (const workDir of workDirs) {
                 candidates.push(...this.getSessionCandidatesForWorkDir(kimiHome, workDir));
             }
+        }
+        if (!available) {
+            return this.cacheResult({ available: false, sessions: [], scannedFiles: 0, parsedFiles: 0 });
         }
         if (candidatePaths.length) {
             candidates = candidates.filter(candidate => candidatePaths.some(candidatePath =>

--- a/src/services/kimiSessionService.ts
+++ b/src/services/kimiSessionService.ts
@@ -41,9 +41,10 @@ interface KimiSessionCandidate {
 }
 
 interface KimiCodeSessionIndexEntry {
-    sessionId?: string;
-    sessionDir?: string;
-    workDir?: string;
+    sessionId: string;
+    sessionDir: string;
+    workDir: string;
+    deleted?: boolean;
 }
 
 export interface KimiSessionReadResult {
@@ -141,21 +142,28 @@ export default class KimiSessionService {
             return {};
         }
         let signals: Record<string, AiSessionLifecycleSignal> = {};
-        for (let request of requests || []) {
+        const requestsById = new Map<string, AiSessionLifecycleRequest>();
+        for (const request of requests || []) {
             if (!request?.sessionId || !Number.isFinite(request.runStartedAtMs)) {
                 continue;
             }
+            requestsById.set(request.sessionId, request);
+        }
+        const locations = this.findSessionLocations(Array.from(requestsById.keys()));
+        for (const request of requestsById.values()) {
             activeSessionIds.add(request.sessionId);
             if (signals[request.sessionId]) {
                 continue;
             }
-            const location = this.findSessionLocation(request.sessionId);
+            const location = locations.get(request.sessionId);
             if (!location) {
                 this.lifecycleReader.delete(request.sessionId);
                 continue;
             }
             let sessionFile = this.getWirePath(location.kimiHome, location.sessionDir);
-            if (!fs.existsSync(sessionFile)) {
+            if (!fs.existsSync(sessionFile)
+                || (this.isKimiCodeHome(location.kimiHome)
+                    && !this.isKimiCodePathContained(location.kimiHome, sessionFile))) {
                 this.lifecycleReader.delete(request.sessionId);
                 continue;
             }
@@ -191,7 +199,17 @@ export default class KimiSessionService {
             let state = this.readJson<KimiSessionState>(statePath) || {};
             state.archived = true;
             state.archived_at = new Date().toISOString();
-            fs.writeFileSync(statePath, JSON.stringify(state, null, 2));
+            const noFollow = (fs.constants as any).O_NOFOLLOW || 0;
+            const descriptor = fs.openSync(
+                statePath,
+                fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_TRUNC | noFollow,
+                0o600
+            );
+            try {
+                fs.writeFileSync(descriptor, JSON.stringify(state, null, 2));
+            } finally {
+                fs.closeSync(descriptor);
+            }
             this.lifecycleReader.delete(sessionId);
             this.invalidateCache();
             return true;
@@ -270,14 +288,17 @@ export default class KimiSessionService {
     }
 
     private getKimiHomes(): string[] {
-        let configuredHome = process.env.KIMI_SHARE_DIR;
-        if (configuredHome && fs.existsSync(configuredHome)) {
-            return [configuredHome];
+        let legacyOverride = process.env.KIMI_SHARE_DIR;
+        if (legacyOverride && fs.existsSync(legacyOverride)) {
+            return [legacyOverride];
         }
 
-        let kimiCodeHome = path.join(os.homedir(), '.kimi-code');
+        let configuredCodeHome = process.env.KIMI_CODE_HOME;
+        let kimiCodeHome = configuredCodeHome && fs.existsSync(configuredCodeHome)
+            ? configuredCodeHome
+            : path.join(os.homedir(), '.kimi-code');
         let legacyHome = path.join(os.homedir(), '.kimi');
-        return [kimiCodeHome, legacyHome].filter(home =>
+        return Array.from(new Set([kimiCodeHome, legacyHome])).filter(home =>
             (this.isKimiCodeHome(home) || fs.existsSync(home))
         );
     }
@@ -358,11 +379,14 @@ export default class KimiSessionService {
         return candidates;
     }
 
-    private findSessionDir(kimiHome: string, sessionId: string): string {
+    private findSessionDir(
+        kimiHome: string,
+        sessionId: string,
+        codeIndex?: readonly KimiCodeSessionIndexEntry[]
+    ): string {
         if (this.isKimiCodeHome(kimiHome)) {
-            const indexed = this.readKimiCodeSessionIndex(kimiHome).find(entry =>
+            const indexed = (codeIndex || this.readKimiCodeSessionIndex(kimiHome)).find(entry =>
                 entry.sessionId === sessionId
-                    && this.isKimiCodeSessionId(entry.sessionId)
             );
             const sessionDir = indexed
                 ? this.resolveKimiCodeSessionDir(kimiHome, indexed.sessionDir)
@@ -413,6 +437,27 @@ export default class KimiSessionService {
             }
         }
         return null;
+    }
+
+    private findSessionLocations(sessionIds: readonly string[]): Map<string, { kimiHome: string; sessionDir: string }> {
+        const homes = this.getKimiHomes();
+        const indexes = new Map<string, readonly KimiCodeSessionIndexEntry[]>();
+        for (const home of homes) {
+            if (this.isKimiCodeHome(home)) {
+                indexes.set(home, this.readKimiCodeSessionIndex(home));
+            }
+        }
+        const locations = new Map<string, { kimiHome: string; sessionDir: string }>();
+        for (const sessionId of sessionIds) {
+            for (const home of homes) {
+                const sessionDir = this.findSessionDir(home, sessionId, indexes.get(home));
+                if (sessionDir) {
+                    locations.set(sessionId, { kimiHome: home, sessionDir });
+                    break;
+                }
+            }
+        }
+        return locations;
     }
 
     private findWorkDirForSessionDir(
@@ -558,7 +603,7 @@ export default class KimiSessionService {
         }
         try {
             const stat = fs.lstatSync(statePath);
-            if (!stat.isFile() && !stat.isSymbolicLink()) {
+            if (!stat.isFile() || stat.isSymbolicLink()) {
                 return null;
             }
             return this.isKimiCodePathContained(kimiHome, statePath)
@@ -581,25 +626,38 @@ export default class KimiSessionService {
 
     private isPathContained(home: string, value: string): boolean {
         const relative = path.relative(home, value);
-        return Boolean(relative) && !relative.startsWith(`..${path.sep}`) && relative !== '..';
+        return Boolean(relative) && !path.isAbsolute(relative)
+            && !relative.startsWith(`..${path.sep}`) && relative !== '..';
     }
 
     private readKimiCodeSessionIndex(kimiHome: string): KimiCodeSessionIndexEntry[] {
         try {
-            const entries: KimiCodeSessionIndexEntry[] = [];
+            const entries = new Map<string, KimiCodeSessionIndexEntry>();
             for (const line of fs.readFileSync(path.join(kimiHome, 'session_index.jsonl'), 'utf8')
                 .split(/\r?\n/)
                 .filter(Boolean)) {
                 try {
-                    const entry = JSON.parse(line) as KimiCodeSessionIndexEntry;
-                    if (entry && typeof entry === 'object') {
-                        entries.push(entry);
+                    const entry = JSON.parse(line) as Partial<KimiCodeSessionIndexEntry>;
+                    if (!entry || typeof entry !== 'object'
+                        || typeof entry.sessionId !== 'string'
+                        || !this.isKimiCodeSessionId(entry.sessionId)) {
+                        continue;
+                    }
+                    if (entry.deleted === true) {
+                        entries.delete(entry.sessionId);
+                    } else if (typeof entry.sessionDir === 'string'
+                        && typeof entry.workDir === 'string') {
+                        entries.set(entry.sessionId, {
+                            sessionId: entry.sessionId,
+                            sessionDir: entry.sessionDir,
+                            workDir: entry.workDir,
+                        });
                     }
                 } catch (_error) {
                     // Ignore a partially-written trailing index entry.
                 }
             }
-            return entries;
+            return Array.from(entries.values());
         } catch (_error) {
             return [];
         }

--- a/tests/contract/aiSessions/incrementalJsonlLifecycleReader.test.js
+++ b/tests/contract/aiSessions/incrementalJsonlLifecycleReader.test.js
@@ -77,16 +77,16 @@ test('PERSIST-INCREMENTAL-JSONL-LIFECYCLE-READER-001 SESSION-AI-SESSION-EXECUTIO
     assert.deepEqual(monitor.evaluate([{ key, signal: readSignal() }]), []);
     assert.equal(monitor.getSnapshot()[key].state, 'running');
 
-    const originalStatSync = fs.statSync;
-    fs.statSync = () => { throw new Error('forced stat failure'); };
-    t.after(() => { fs.statSync = originalStatSync; });
+    const originalFstatSync = fs.fstatSync;
+    fs.fstatSync = () => { throw new Error('forced descriptor stat failure'); };
+    t.after(() => { fs.fstatSync = originalFstatSync; });
     now = 1500;
     assert.deepEqual(monitor.evaluate([{ key, signal: readSignal() }]), []);
     now = 2002;
     assert.deepEqual(monitor.evaluate([{ key, signal: readSignal() }]), [key]);
     assert.equal(monitor.getSnapshot()[key].state, 'stopped');
 
-    fs.statSync = originalStatSync;
+    fs.fstatSync = originalFstatSync;
     now = 2100;
     assert.deepEqual(monitor.evaluate([{ key, signal: readSignal() }]), [key]);
     assert.equal(monitor.getSnapshot()[key].state, 'running');
@@ -171,8 +171,8 @@ test('PERSIST-INCREMENTAL-JSONL-LIFECYCLE-READER-001 resets on truncation and is
     assert.equal(reader.read(
         'codex:stat-failure', statFailurePath, RUN_STARTED_AT_MS, createAccumulator
     ).executionState, 'stopped');
-    const originalStatSync = fs.statSync;
-    fs.statSync = () => { throw new Error('forced stat failure'); };
+    const originalFstatSync = fs.fstatSync;
+    fs.fstatSync = () => { throw new Error('forced descriptor stat failure'); };
     assert.equal(reader.read(
         'codex:stat-failure', statFailurePath, nextRunStartedAtMs,
         () => createAccumulator(nextRunStartedAtMs)
@@ -180,13 +180,13 @@ test('PERSIST-INCREMENTAL-JSONL-LIFECYCLE-READER-001 resets on truncation and is
     assert.equal(reader.read(
         'codex:stat-failure', statFailurePath, RUN_STARTED_AT_MS, createAccumulator
     ), null, 'a stat failure must expose unavailable authority even with an exact cursor');
-    fs.statSync = originalStatSync;
+    fs.fstatSync = originalFstatSync;
     assert.equal(reader.read(
         'codex:stat-failure', statFailurePath, RUN_STARTED_AT_MS, createAccumulator
     ).executionState, 'stopped', 'a recovered source may reuse its exact cursor');
     t.after(() => {
         fs.openSync = originalOpenSync;
-        fs.statSync = originalStatSync;
+        fs.fstatSync = originalFstatSync;
     });
 
     const sourcePath = path.join(root, 'non-file-source.jsonl');

--- a/tests/contract/aiSessions/kimiConversationAdapter.test.js
+++ b/tests/contract/aiSessions/kimiConversationAdapter.test.js
@@ -175,12 +175,14 @@ test('SESSION-AI-SESSION-CONVERSATION-ADAPTER-001 Kimi Code discovers and render
 test('SESSION-AI-SESSION-CONVERSATION-ADAPTER-001 Kimi Code retains tool activity and appended assistant messages', async t => {
     const source = await createFixture(t);
     await fs.promises.writeFile(source.sourcePath, [
-        { type: 'turn.prompt', input: [{ type: 'text', text: 'Run a tool.' }], origin: { kind: 'user' }, time: 1_784_073_611_000 },
+        { type: 'turn.prompt', input: [{ type: 'text', text: 'Run a tool.' }, { type: 'image_url' }], origin: { kind: 'plugin_command' }, time: 1_784_073_611_000 },
         { type: 'context.append_loop_event', event: { type: 'step.begin', turnId: 1, stepUuid: 'step' }, time: 1_784_073_611_001 },
         { type: 'context.append_loop_event', event: { type: 'tool.call', turnId: 1, stepUuid: 'step', toolCallId: 'call-1', name: 'Shell', args: { command: 'pwd' } }, time: 1_784_073_611_002 },
-        { type: 'context.append_loop_event', event: { type: 'tool.result', turnId: 1, toolCallId: 'call-1', result: { output: '/workspace' } }, time: 1_784_073_611_003 },
+        { type: 'context.append_loop_event', event: { type: 'tool.result', turnId: 1, toolCallId: 'call-1', result: { output: [{ type: 'text', text: '/workspace' }, { type: 'audio_url' }] } }, time: 1_784_073_611_003 },
         { type: 'context.append_message', message: { role: 'assistant', content: [{ type: 'text', text: 'Tool completed.' }] }, time: 1_784_073_611_004 },
         { type: 'turn.ended', turnId: 1, reason: 'completed', time: 1_784_073_611_005 },
+        { type: 'context.append_message', message: { role: 'assistant', content: [{ type: 'text', text: 'Goal continuation.' }] }, time: 1_784_073_611_006 },
+        { type: 'turn.ended', turnId: 2, reason: 'completed', time: 1_784_073_611_007 },
     ].map(record => JSON.stringify(record)).join('\n') + '\n');
     const adapter = createAdapter(source);
     t.after(() => adapter.dispose());
@@ -189,8 +191,11 @@ test('SESSION-AI-SESSION-CONVERSATION-ADAPTER-001 Kimi Code retains tool activit
         provider: 'kimi', sessionId, anchorInteractionId: outline.interactions[0].id,
         direction: 'around', expectedRevision: outline.sourceRevision,
     });
+    assert.equal(page.messages[0].markdown, 'Run a tool. [Attachment]');
     assert.equal(page.messages.some(message => message.role === 'tool'), true);
+    assert.match(page.messages.find(message => message.role === 'tool')?.tool?.detail || '', /workspace/);
     assert.equal(page.messages.some(message => message.markdown === 'Tool completed.'), true);
+    assert.equal(page.messages.some(message => message.markdown === 'Goal continuation.'), true);
 });
 
 test('WEBVIEW-AI-SESSION-SUBAGENT-VIEWER-001 Kimi Code reads agents beside main', async t => {
@@ -200,11 +205,12 @@ test('WEBVIEW-AI-SESSION-SUBAGENT-VIEWER-001 Kimi Code reads agents beside main'
     await fs.promises.writeFile(path.join(workerDir, 'wire.jsonl'), [
         { type: 'turn.prompt', input: [{ type: 'text', text: 'Worker task.' }], origin: { kind: 'user' }, time: 1_784_073_611_000 },
         { type: 'context.append_message', message: { role: 'assistant', content: [{ type: 'text', text: 'Worker result.' }] }, time: 1_784_073_611_001 },
-        { type: 'turn.ended', turnId: 1, reason: 'completed', time: 1_784_073_611_002 },
     ].map(record => JSON.stringify(record)).join('\n') + '\n');
     const adapter = createAdapter({ providerHome: fixture.providerHome, sourcePath: fixture.sourcePath });
     t.after(() => adapter.dispose());
-    assert.deepEqual((await adapter.readSubagents(fixture.sessionId)).map(entry => entry.id), ['worker-1']);
+    assert.deepEqual((await adapter.readSubagents(fixture.sessionId)).map(entry => [entry.id, entry.status]), [
+        ['worker-1', 'running'],
+    ]);
     const workerId = encodeSubagentSessionId(fixture.sessionId, 'worker-1');
     const outline = await adapter.readOutline(workerId);
     const page = await adapter.readPage({

--- a/tests/contract/aiSessions/kimiConversationAdapter.test.js
+++ b/tests/contract/aiSessions/kimiConversationAdapter.test.js
@@ -175,7 +175,7 @@ test('SESSION-AI-SESSION-CONVERSATION-ADAPTER-001 Kimi Code discovers and render
 test('SESSION-AI-SESSION-CONVERSATION-ADAPTER-001 Kimi Code retains tool activity and appended assistant messages', async t => {
     const source = await createFixture(t);
     await fs.promises.writeFile(source.sourcePath, [
-        { type: 'turn.prompt', input: [{ type: 'text', text: 'Run a tool.' }, { type: 'image_url' }], origin: { kind: 'plugin_command' }, time: 1_784_073_611_000 },
+        { type: 'turn.prompt', input: [{ type: 'text', text: 'Run a tool.' }, { type: 'image_url' }], origin: { kind: 'plugin_command', trigger: 'user-slash' }, time: 1_784_073_611_000 },
         { type: 'context.append_loop_event', event: { type: 'step.begin', turnId: 1, stepUuid: 'step' }, time: 1_784_073_611_001 },
         { type: 'context.append_loop_event', event: { type: 'tool.call', turnId: 1, stepUuid: 'step', toolCallId: 'call-1', name: 'Shell', args: { command: 'pwd' } }, time: 1_784_073_611_002 },
         { type: 'context.append_loop_event', event: { type: 'tool.result', turnId: 1, toolCallId: 'call-1', result: { output: [{ type: 'text', text: '/workspace' }, { type: 'audio_url' }] } }, time: 1_784_073_611_003 },
@@ -203,7 +203,7 @@ test('WEBVIEW-AI-SESSION-SUBAGENT-VIEWER-001 Kimi Code reads agents beside main'
     const workerDir = path.join(path.dirname(path.dirname(fixture.sourcePath)), 'worker-1');
     await fs.promises.mkdir(workerDir, { recursive: true });
     await fs.promises.writeFile(path.join(workerDir, 'wire.jsonl'), [
-        { type: 'turn.prompt', input: [{ type: 'text', text: 'Worker task.' }], origin: { kind: 'user' }, time: 1_784_073_611_000 },
+        { type: 'turn.prompt', input: [{ type: 'text', text: 'Worker task.' }], origin: { kind: 'system_trigger', name: 'subagent' }, time: 1_784_073_611_000 },
         { type: 'context.append_message', message: { role: 'assistant', content: [{ type: 'text', text: 'Worker result.' }] }, time: 1_784_073_611_001 },
     ].map(record => JSON.stringify(record)).join('\n') + '\n');
     const adapter = createAdapter({ providerHome: fixture.providerHome, sourcePath: fixture.sourcePath });

--- a/tests/contract/aiSessions/kimiConversationAdapter.test.js
+++ b/tests/contract/aiSessions/kimiConversationAdapter.test.js
@@ -9,6 +9,7 @@ const test = require('node:test');
 const { KimiConversationAdapter } = require('../../../out/aiSessions/conversation/kimiAdapter');
 const { CONVERSATION_LIMITS } = require('../../../out/aiSessions/conversation/types');
 const KimiSessionService = require('../../../out/services/kimiSessionService').default;
+const { encodeSubagentSessionId } = require('../../../out/aiSessions/conversation/subagentSessions');
 
 const fixturePath = path.resolve(
     __dirname,
@@ -169,6 +170,48 @@ test('SESSION-AI-SESSION-CONVERSATION-ADAPTER-001 Kimi Code discovers and render
         'Show the Kimi Code conversation.',
         'Kimi Code response.',
     ]);
+});
+
+test('SESSION-AI-SESSION-CONVERSATION-ADAPTER-001 Kimi Code retains tool activity and appended assistant messages', async t => {
+    const source = await createFixture(t);
+    await fs.promises.writeFile(source.sourcePath, [
+        { type: 'turn.prompt', input: [{ type: 'text', text: 'Run a tool.' }], origin: { kind: 'user' }, time: 1_784_073_611_000 },
+        { type: 'context.append_loop_event', event: { type: 'step.begin', turnId: 1, stepUuid: 'step' }, time: 1_784_073_611_001 },
+        { type: 'context.append_loop_event', event: { type: 'tool.call', turnId: 1, stepUuid: 'step', toolCallId: 'call-1', name: 'Shell', args: { command: 'pwd' } }, time: 1_784_073_611_002 },
+        { type: 'context.append_loop_event', event: { type: 'tool.result', turnId: 1, toolCallId: 'call-1', result: { output: '/workspace' } }, time: 1_784_073_611_003 },
+        { type: 'context.append_message', message: { role: 'assistant', content: [{ type: 'text', text: 'Tool completed.' }] }, time: 1_784_073_611_004 },
+        { type: 'turn.ended', turnId: 1, reason: 'completed', time: 1_784_073_611_005 },
+    ].map(record => JSON.stringify(record)).join('\n') + '\n');
+    const adapter = createAdapter(source);
+    t.after(() => adapter.dispose());
+    const outline = await adapter.readOutline(sessionId);
+    const page = await adapter.readPage({
+        provider: 'kimi', sessionId, anchorInteractionId: outline.interactions[0].id,
+        direction: 'around', expectedRevision: outline.sourceRevision,
+    });
+    assert.equal(page.messages.some(message => message.role === 'tool'), true);
+    assert.equal(page.messages.some(message => message.markdown === 'Tool completed.'), true);
+});
+
+test('WEBVIEW-AI-SESSION-SUBAGENT-VIEWER-001 Kimi Code reads agents beside main', async t => {
+    const fixture = await createKimiCodeFixture(t);
+    const workerDir = path.join(path.dirname(path.dirname(fixture.sourcePath)), 'worker-1');
+    await fs.promises.mkdir(workerDir, { recursive: true });
+    await fs.promises.writeFile(path.join(workerDir, 'wire.jsonl'), [
+        { type: 'turn.prompt', input: [{ type: 'text', text: 'Worker task.' }], origin: { kind: 'user' }, time: 1_784_073_611_000 },
+        { type: 'context.append_message', message: { role: 'assistant', content: [{ type: 'text', text: 'Worker result.' }] }, time: 1_784_073_611_001 },
+        { type: 'turn.ended', turnId: 1, reason: 'completed', time: 1_784_073_611_002 },
+    ].map(record => JSON.stringify(record)).join('\n') + '\n');
+    const adapter = createAdapter({ providerHome: fixture.providerHome, sourcePath: fixture.sourcePath });
+    t.after(() => adapter.dispose());
+    assert.deepEqual((await adapter.readSubagents(fixture.sessionId)).map(entry => entry.id), ['worker-1']);
+    const workerId = encodeSubagentSessionId(fixture.sessionId, 'worker-1');
+    const outline = await adapter.readOutline(workerId);
+    const page = await adapter.readPage({
+        provider: 'kimi', sessionId: workerId, anchorInteractionId: outline.interactions[0].id,
+        direction: 'around', expectedRevision: outline.sourceRevision,
+    });
+    assert.equal(page.messages.some(message => message.markdown === 'Worker result.'), true);
 });
 
 async function restartSuffix(t, sourcePath, offset) {

--- a/tests/contract/aiSessions/kimiConversationAdapter.test.js
+++ b/tests/contract/aiSessions/kimiConversationAdapter.test.js
@@ -48,6 +48,79 @@ function createAdapter(source, overrides = {}) {
     });
 }
 
+async function createKimiCodeFixture(t) {
+    const providerHome = await fs.promises.mkdtemp(
+        path.join(os.tmpdir(), 'steward-kimi-code-conversation-')
+    );
+    const sessionId = 'session_22222222-2222-4222-8222-222222222222';
+    const cwd = '/fixtures/kimi-code-project';
+    const sessionDir = path.join(
+        providerHome,
+        'sessions',
+        'wd_kimi-code-project_0123456789ab',
+        sessionId
+    );
+    const sourcePath = path.join(sessionDir, 'agents', 'main', 'wire.jsonl');
+    await fs.promises.mkdir(path.dirname(sourcePath), { recursive: true });
+    await fs.promises.writeFile(path.join(providerHome, 'session_index.jsonl'),
+        `${JSON.stringify({ sessionId, sessionDir, workDir: cwd })}\n`);
+    await fs.promises.writeFile(path.join(sessionDir, 'state.json'), JSON.stringify({
+        id: sessionId,
+        cwd,
+        title: 'Kimi Code conversation',
+        archived: false,
+    }));
+    await fs.promises.writeFile(sourcePath, [
+        {
+            type: 'turn.prompt',
+            agentId: 'main',
+            input: [{ type: 'text', text: 'Show the Kimi Code conversation.' }],
+            origin: { kind: 'user' },
+            time: 1_784_073_611_000,
+        },
+        {
+            type: 'context.append_loop_event',
+            agentId: 'main',
+            event: { type: 'step.begin', uuid: 'step-start', turnId: '1', step: 1 },
+            time: 1_784_073_611_001,
+        },
+        {
+            type: 'context.append_loop_event',
+            agentId: 'main',
+            event: {
+                type: 'content.part',
+                uuid: 'text-part',
+                turnId: '1',
+                step: 1,
+                stepUuid: 'step-start',
+                part: { type: 'text', text: 'Kimi Code response.' },
+            },
+            time: 1_784_073_611_002,
+        },
+        {
+            type: 'context.append_loop_event',
+            agentId: 'main',
+            event: {
+                type: 'step.end',
+                uuid: 'step-end',
+                turnId: '1',
+                step: 1,
+                finishReason: 'stop',
+            },
+            time: 1_784_073_611_003,
+        },
+        {
+            type: 'turn.ended',
+            agentId: 'main',
+            turnId: 1,
+            reason: 'completed',
+            time: 1_784_073_611_004,
+        },
+    ].map(record => JSON.stringify(record)).join('\n') + '\n');
+    t.after(() => fs.promises.rm(providerHome, { recursive: true, force: true }));
+    return { providerHome, sessionId, cwd, sourcePath };
+}
+
 async function readWholeConversation(adapter) {
     const outline = await adapter.readOutline(sessionId);
     const page = await adapter.readPage({
@@ -58,6 +131,45 @@ async function readWholeConversation(adapter) {
     });
     return { outline, page };
 }
+
+test('SESSION-AI-SESSION-CONVERSATION-ADAPTER-001 Kimi Code discovers and renders its main-agent wire transcript', async t => {
+    const fixture = await createKimiCodeFixture(t);
+    const previousHome = process.env.KIMI_SHARE_DIR;
+    process.env.KIMI_SHARE_DIR = fixture.providerHome;
+    t.after(() => {
+        if (previousHome === undefined) delete process.env.KIMI_SHARE_DIR;
+        else process.env.KIMI_SHARE_DIR = previousHome;
+    });
+    const service = new KimiSessionService();
+    const sessions = service.getSessions({ forceRefresh: true, candidatePaths: [fixture.cwd] });
+    assert.equal(sessions.available, true);
+    assert.deepEqual(sessions.sessions.map(session => ({
+        id: session.id,
+        name: session.name,
+        cwd: session.cwd,
+    })), [{
+        id: fixture.sessionId,
+        name: 'Kimi Code conversation',
+        cwd: fixture.cwd,
+    }]);
+    const source = service.resolveConversationSource(fixture.sessionId);
+    assert.equal(source?.sourcePath, fixture.sourcePath);
+    const adapter = createAdapter(source);
+    t.after(() => adapter.dispose());
+    const outline = await adapter.readOutline(fixture.sessionId);
+    assert.equal(outline.interactions.length, 1);
+    const page = await adapter.readPage({
+        provider: 'kimi',
+        sessionId: fixture.sessionId,
+        anchorInteractionId: outline.interactions[0].id,
+        direction: 'around',
+        expectedRevision: outline.sourceRevision,
+    });
+    assert.deepEqual(page.messages.map(message => message.markdown), [
+        'Show the Kimi Code conversation.',
+        'Kimi Code response.',
+    ]);
+});
 
 async function restartSuffix(t, sourcePath, offset) {
     const bytes = await fs.promises.readFile(sourcePath);

--- a/tests/contract/aiSessions/providerSpecificBehavior.test.js
+++ b/tests/contract/aiSessions/providerSpecificBehavior.test.js
@@ -324,13 +324,13 @@ test('SESSION-FINGERPRINT-HASH-001 Kimi Code reads its session index once per li
             `/work/kimi-code-${index}`
         );
     }
-    const originalReadFileSync = fs.readFileSync;
+    const originalOpenSync = fs.openSync;
     let indexReads = 0;
-    fs.readFileSync = function (filePath) {
+    fs.openSync = function (filePath) {
         if (filePath === indexPath) indexReads++;
-        return originalReadFileSync.apply(this, arguments);
+        return originalOpenSync.apply(this, arguments);
     };
-    t.after(() => { fs.readFileSync = originalReadFileSync; });
+    t.after(() => { fs.openSync = originalOpenSync; });
 
     const service = new KimiSessionService();
     assert.equal(service.getSessions({ forceRefresh: true }).sessions.length, 16);

--- a/tests/contract/aiSessions/providerSpecificBehavior.test.js
+++ b/tests/contract/aiSessions/providerSpecificBehavior.test.js
@@ -312,8 +312,11 @@ test('SESSION-PROVIDER-001 Kimi keeps legacy and Kimi Code sessions discoverable
 
 test('SESSION-FINGERPRINT-HASH-001 Kimi Code reads its session index once per listing and fingerprint', t => {
     const home = makeTempDirectory(t, 'provider-kimi-code-index-');
+    const isolatedOsHome = makeTempDirectory(t, 'provider-kimi-code-index-os-home-');
     const indexPath = path.join(home, 'session_index.jsonl');
     setEnvironment(t, 'KIMI_SHARE_DIR', home);
+    unsetEnvironment(t, 'KIMI_CODE_HOME');
+    setHomeDirectory(t, isolatedOsHome);
     for (let index = 0; index < 16; index += 1) {
         writeKimiCodeSession(
             home,
@@ -345,9 +348,10 @@ test('SESSION-FINGERPRINT-HASH-001 Kimi Code reads its session index once per li
 
 test('SESSION-PROVIDER-001 Kimi Code honors KIMI_CODE_HOME and last-write-wins index records', t => {
     const home = makeTempDirectory(t, 'provider-kimi-code-home-');
+    const legacyOverride = makeTempDirectory(t, 'provider-kimi-code-legacy-override-');
     const isolatedOsHome = makeTempDirectory(t, 'provider-kimi-code-os-home-');
     const sessionId = 'session_cccccccc-cccc-4ccc-8ccc-cccccccccccc';
-    unsetEnvironment(t, 'KIMI_SHARE_DIR');
+    setEnvironment(t, 'KIMI_SHARE_DIR', legacyOverride);
     setHomeDirectory(t, isolatedOsHome);
     setEnvironment(t, 'KIMI_CODE_HOME', home);
     writeKimiCodeSession(home, sessionId, '/work/stale', 'Stale location');
@@ -368,15 +372,26 @@ test('SESSION-PROVIDER-001 Kimi Code honors KIMI_CODE_HOME and last-write-wins i
     })}\n`, 'utf8');
     assert.equal(service.getSessions({ forceRefresh: true }).sessions.length, 0);
     assert.equal(service.resolveConversationSource(sessionId), null);
+
+    const staleDefaultHome = path.join(isolatedOsHome, '.kimi-code');
+    writeKimiCodeSession(staleDefaultHome,
+        'session_dddddddd-dddd-4ddd-8ddd-dddddddddddd', '/work/default', 'Default location');
+    setEnvironment(t, 'KIMI_CODE_HOME', path.join(isolatedOsHome, 'missing-kimi-code-home'));
+    const configuredHomeService = new KimiSessionService();
+    assert.equal(configuredHomeService.getSessions({ forceRefresh: true }).sessions.length, 0,
+        'a configured but absent KIMI_CODE_HOME must not fall back to the default home');
 });
 
 test('SECURITY-AI-SESSION-CONVERSATION-SOURCE-001 Kimi Code rejects an in-home symlinked session directory', t => {
     const home = makeTempDirectory(t, 'provider-kimi-code-symlink-');
+    const isolatedOsHome = makeTempDirectory(t, 'provider-kimi-code-symlink-os-home-');
     const outside = makeTempDirectory(t, 'provider-kimi-code-outside-');
     const sessionId = 'session_bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
     const outsideSessionDir = path.join(outside, sessionId);
     const linkedSessionDir = path.join(home, 'sessions', 'wd-link', sessionId);
     setEnvironment(t, 'KIMI_SHARE_DIR', home);
+    unsetEnvironment(t, 'KIMI_CODE_HOME');
+    setHomeDirectory(t, isolatedOsHome);
     fs.mkdirSync(path.join(outsideSessionDir, 'agents', 'main'), { recursive: true });
     fs.writeFileSync(path.join(outsideSessionDir, 'agents', 'main', 'wire.jsonl'), '{}\n', 'utf8');
     fs.writeFileSync(path.join(outsideSessionDir, 'state.json'), '{"outside":true}', 'utf8');

--- a/tests/contract/aiSessions/providerSpecificBehavior.test.js
+++ b/tests/contract/aiSessions/providerSpecificBehavior.test.js
@@ -335,6 +335,39 @@ test('SESSION-FINGERPRINT-HASH-001 Kimi Code reads its session index once per li
     indexReads = 0;
     assert.ok(service.getSessionFingerprint().length > 0);
     assert.equal(indexReads, 1, `expected one fingerprint index read, saw ${indexReads}`);
+    indexReads = 0;
+    service.getLifecycleSignals(Array.from({ length: 16 }, (_item, index) => ({
+        sessionId: `session_${String(index).padStart(8, '0')}-aaaa-4aaa-8aaa-aaaaaaaaaaaa`,
+        runStartedAtMs: 0,
+    })));
+    assert.equal(indexReads, 1, `expected one lifecycle index read, saw ${indexReads}`);
+});
+
+test('SESSION-PROVIDER-001 Kimi Code honors KIMI_CODE_HOME and last-write-wins index records', t => {
+    const home = makeTempDirectory(t, 'provider-kimi-code-home-');
+    const isolatedOsHome = makeTempDirectory(t, 'provider-kimi-code-os-home-');
+    const sessionId = 'session_cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+    unsetEnvironment(t, 'KIMI_SHARE_DIR');
+    setHomeDirectory(t, isolatedOsHome);
+    setEnvironment(t, 'KIMI_CODE_HOME', home);
+    writeKimiCodeSession(home, sessionId, '/work/stale', 'Stale location');
+    const current = writeKimiCodeSession(home, sessionId, '/work/current', 'Current location');
+    fs.appendFileSync(path.join(home, 'session_index.jsonl'), '{"sessionId":"bad","workDir":{}}\n', 'utf8');
+
+    const service = new KimiSessionService();
+    assert.deepEqual(service.getSessions({ forceRefresh: true }).sessions.map(session => ({
+        id: session.id,
+        cwd: session.cwd,
+        name: session.name,
+    })), [{ id: sessionId, cwd: '/work/current', name: 'Current location' }]);
+    assert.equal(service.resolveConversationSource(sessionId)?.sourcePath, current.wirePath);
+
+    fs.appendFileSync(path.join(home, 'session_index.jsonl'), `${JSON.stringify({
+        sessionId,
+        deleted: true,
+    })}\n`, 'utf8');
+    assert.equal(service.getSessions({ forceRefresh: true }).sessions.length, 0);
+    assert.equal(service.resolveConversationSource(sessionId), null);
 });
 
 test('SECURITY-AI-SESSION-CONVERSATION-SOURCE-001 Kimi Code rejects an in-home symlinked session directory', t => {

--- a/tests/contract/aiSessions/providerSpecificBehavior.test.js
+++ b/tests/contract/aiSessions/providerSpecificBehavior.test.js
@@ -4,6 +4,7 @@ const assert = require('node:assert/strict');
 const crypto = require('node:crypto');
 const fs = require('node:fs');
 const Module = require('node:module');
+const os = require('node:os');
 const path = require('node:path');
 const test = require('node:test');
 const { makeTempDirectory } = require('../../helpers/tempDirectory');
@@ -20,6 +21,34 @@ function setEnvironment(t, name, value) {
         if (previous === undefined) delete process.env[name];
         else process.env[name] = previous;
     });
+}
+
+function unsetEnvironment(t, name) {
+    const previous = process.env[name];
+    delete process.env[name];
+    t.after(() => {
+        if (previous !== undefined) process.env[name] = previous;
+    });
+}
+
+function setHomeDirectory(t, home) {
+    const originalHomedir = os.homedir;
+    os.homedir = () => home;
+    t.after(() => { os.homedir = originalHomedir; });
+}
+
+function writeKimiCodeSession(home, sessionId, workDir, title = sessionId) {
+    const sessionDir = path.join(home, 'sessions', `wd-${sessionId}`, sessionId);
+    const wirePath = path.join(sessionDir, 'agents', 'main', 'wire.jsonl');
+    fs.mkdirSync(path.dirname(wirePath), { recursive: true });
+    fs.writeFileSync(wirePath, '{"type":"turn.ended","reason":"completed"}\n', 'utf8');
+    fs.writeFileSync(path.join(sessionDir, 'state.json'), JSON.stringify({ title }), 'utf8');
+    fs.appendFileSync(path.join(home, 'session_index.jsonl'), `${JSON.stringify({
+        sessionId,
+        sessionDir,
+        workDir,
+    })}\n`, 'utf8');
+    return { sessionDir, wirePath };
 }
 
 function writeCodexSessionMetaFile(sessionsDir, sessionId, payload) {
@@ -246,6 +275,93 @@ test('SESSION-KIMI-NESTED-SUBAGENT-BOUNDARY-001 discovers only UUID directories 
     assert.equal(result.available, true);
     assert.deepEqual(result.sessions.map(session => session.id), [sessionId]);
     assert.equal(result.scannedFiles, 1);
+});
+
+test('SESSION-PROVIDER-001 Kimi keeps legacy and Kimi Code sessions discoverable together', t => {
+    const home = makeTempDirectory(t, 'provider-kimi-mixed-homes-');
+    const legacyHome = path.join(home, '.kimi');
+    const codeHome = path.join(home, '.kimi-code');
+    const legacyWorkDir = '/work/legacy';
+    const legacySessionId = '99999999-9999-4999-8999-999999999999';
+    const codeSessionId = 'session_aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+    unsetEnvironment(t, 'KIMI_SHARE_DIR');
+    setHomeDirectory(t, home);
+    fs.mkdirSync(legacyHome, { recursive: true });
+    fs.writeFileSync(path.join(legacyHome, 'kimi.json'), JSON.stringify({
+        work_dirs: [{ path: legacyWorkDir }],
+    }), 'utf8');
+    const legacySessionDir = path.join(legacyHome, 'sessions',
+        crypto.createHash('md5').update(legacyWorkDir, 'utf8').digest('hex'), legacySessionId);
+    fs.mkdirSync(legacySessionDir, { recursive: true });
+    fs.writeFileSync(path.join(legacySessionDir, 'wire.jsonl'), '{}\n', 'utf8');
+    fs.writeFileSync(path.join(legacySessionDir, 'state.json'), '{}', 'utf8');
+    fs.mkdirSync(codeHome, { recursive: true });
+    const code = writeKimiCodeSession(codeHome, codeSessionId, '/work/kimi-code', 'Kimi Code');
+
+    const service = new KimiSessionService();
+    const result = service.getSessions({ forceRefresh: true });
+    assert.deepEqual(new Set(result.sessions.map(session => session.id)), new Set([
+        legacySessionId,
+        codeSessionId,
+    ]));
+    assert.match(service.resolveConversationSource(legacySessionId)?.sourcePath, /wire\.jsonl$/);
+    assert.equal(service.resolveConversationSource(codeSessionId)?.sourcePath, code.wirePath);
+    assert.equal(service.archiveSession(legacySessionId), true);
+    assert.equal(JSON.parse(fs.readFileSync(path.join(legacySessionDir, 'state.json'), 'utf8')).archived, true);
+});
+
+test('SESSION-FINGERPRINT-HASH-001 Kimi Code reads its session index once per listing and fingerprint', t => {
+    const home = makeTempDirectory(t, 'provider-kimi-code-index-');
+    const indexPath = path.join(home, 'session_index.jsonl');
+    setEnvironment(t, 'KIMI_SHARE_DIR', home);
+    for (let index = 0; index < 16; index += 1) {
+        writeKimiCodeSession(
+            home,
+            `session_${String(index).padStart(8, '0')}-aaaa-4aaa-8aaa-aaaaaaaaaaaa`,
+            `/work/kimi-code-${index}`
+        );
+    }
+    const originalReadFileSync = fs.readFileSync;
+    let indexReads = 0;
+    fs.readFileSync = function (filePath) {
+        if (filePath === indexPath) indexReads++;
+        return originalReadFileSync.apply(this, arguments);
+    };
+    t.after(() => { fs.readFileSync = originalReadFileSync; });
+
+    const service = new KimiSessionService();
+    assert.equal(service.getSessions({ forceRefresh: true }).sessions.length, 16);
+    assert.equal(indexReads, 1, `expected one listing index read, saw ${indexReads}`);
+    indexReads = 0;
+    assert.ok(service.getSessionFingerprint().length > 0);
+    assert.equal(indexReads, 1, `expected one fingerprint index read, saw ${indexReads}`);
+});
+
+test('SECURITY-AI-SESSION-CONVERSATION-SOURCE-001 Kimi Code rejects an in-home symlinked session directory', t => {
+    const home = makeTempDirectory(t, 'provider-kimi-code-symlink-');
+    const outside = makeTempDirectory(t, 'provider-kimi-code-outside-');
+    const sessionId = 'session_bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+    const outsideSessionDir = path.join(outside, sessionId);
+    const linkedSessionDir = path.join(home, 'sessions', 'wd-link', sessionId);
+    setEnvironment(t, 'KIMI_SHARE_DIR', home);
+    fs.mkdirSync(path.join(outsideSessionDir, 'agents', 'main'), { recursive: true });
+    fs.writeFileSync(path.join(outsideSessionDir, 'agents', 'main', 'wire.jsonl'), '{}\n', 'utf8');
+    fs.writeFileSync(path.join(outsideSessionDir, 'state.json'), '{"outside":true}', 'utf8');
+    fs.mkdirSync(path.dirname(linkedSessionDir), { recursive: true });
+    fs.symlinkSync(outsideSessionDir, linkedSessionDir, 'dir');
+    fs.writeFileSync(path.join(home, 'session_index.jsonl'), `${JSON.stringify({
+        sessionId,
+        sessionDir: linkedSessionDir,
+        workDir: '/work/kimi-code-link',
+    })}\n`, 'utf8');
+
+    const service = new KimiSessionService();
+    assert.equal(service.getSessions({ forceRefresh: true }).sessions.length, 0);
+    assert.equal(service.resolveConversationSource(sessionId), null);
+    assert.equal(service.archiveSession(sessionId), false);
+    assert.deepEqual(JSON.parse(fs.readFileSync(path.join(outsideSessionDir, 'state.json'), 'utf8')), {
+        outside: true,
+    });
 });
 
 test('WORKTREE-GROUPS-HISTORY-IDENTITY-001 Claude derives createdAt from the first event and Kimi stays degradable', t => {

--- a/tests/helpers/providerContract.js
+++ b/tests/helpers/providerContract.js
@@ -2,6 +2,7 @@
 
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
+const os = require('node:os');
 const path = require('node:path');
 const test = require('node:test');
 const { makeTempDirectory } = require('./tempDirectory');
@@ -31,7 +32,13 @@ function withProviderHome(testContext, fixturesRoot, manifest, useFixtures, call
 
     const environmentVariable = manifest.environmentVariable;
     const previousValue = process.env[environmentVariable];
+    const previousKimiCodeHome = process.env.KIMI_CODE_HOME;
+    const originalHomedir = os.homedir;
     process.env[environmentVariable] = providerHome;
+    if (manifest.id === 'kimi') {
+        delete process.env.KIMI_CODE_HOME;
+        os.homedir = () => temporaryRoot;
+    }
     try {
         return callback(providerHome);
     } finally {
@@ -39,6 +46,14 @@ function withProviderHome(testContext, fixturesRoot, manifest, useFixtures, call
             delete process.env[environmentVariable];
         } else {
             process.env[environmentVariable] = previousValue;
+        }
+        if (manifest.id === 'kimi') {
+            if (previousKimiCodeHome === undefined) {
+                delete process.env.KIMI_CODE_HOME;
+            } else {
+                process.env.KIMI_CODE_HOME = previousKimiCodeHome;
+            }
+            os.homedir = originalHomedir;
         }
     }
 }

--- a/tests/integration/dashboard/conversationViewer.test.js
+++ b/tests/integration/dashboard/conversationViewer.test.js
@@ -78,6 +78,7 @@ const {
 const {
     KimiConversationAdapter,
 } = require('../../../out/aiSessions/conversation/kimiAdapter');
+const KimiSessionService = require('../../../out/services/kimiSessionService').default;
 const {
     CodexConversationAdapter,
 } = require('../../../out/aiSessions/conversation/codexAdapter');
@@ -7627,6 +7628,94 @@ test('CONVERSATION-VIEWER-PARTIAL-001 offsets capped-tail positions by omitted a
     assert.equal(publication.selectedInteractionId, 'input-2001');
     assert.equal(publication.selectedInput, 2_001);
     assert.equal(publication.totalInputs, 2_000);
+});
+
+test('SESSION-AI-SESSION-CONVERSATION-ADAPTER-001 renders a discovered Kimi Code session in the viewer', async t => {
+    const providerHome = await fs.promises.mkdtemp(
+        path.join(os.tmpdir(), 'steward-kimi-code-viewer-')
+    );
+    const sessionId = 'session_33333333-3333-4333-8333-333333333333';
+    const cwd = '/fixtures/kimi-code-viewer';
+    const sessionDir = path.join(
+        providerHome,
+        'sessions',
+        'wd_kimi-code-viewer_0123456789ab',
+        sessionId
+    );
+    const sourcePath = path.join(sessionDir, 'agents', 'main', 'wire.jsonl');
+    await fs.promises.mkdir(path.dirname(sourcePath), { recursive: true });
+    await fs.promises.writeFile(path.join(providerHome, 'session_index.jsonl'),
+        `${JSON.stringify({ sessionId, sessionDir, workDir: cwd })}\n`);
+    await fs.promises.writeFile(path.join(sessionDir, 'state.json'), JSON.stringify({
+        id: sessionId,
+        cwd,
+        title: 'Kimi Code viewer session',
+    }));
+    await fs.promises.writeFile(sourcePath, [
+        {
+            type: 'turn.prompt',
+            agentId: 'main',
+            input: [{ type: 'text', text: 'Render this Kimi Code session.' }],
+            origin: { kind: 'user' },
+            time: 1_784_073_611_000,
+        },
+        {
+            type: 'context.append_loop_event',
+            agentId: 'main',
+            event: {
+                type: 'content.part',
+                part: { type: 'text', text: 'Kimi Code is now visible.' },
+            },
+            time: 1_784_073_611_001,
+        },
+        {
+            type: 'turn.ended',
+            agentId: 'main',
+            turnId: 1,
+            reason: 'completed',
+            time: 1_784_073_611_002,
+        },
+    ].map(record => JSON.stringify(record)).join('\n') + '\n');
+    t.after(() => fs.promises.rm(providerHome, {
+        recursive: true,
+        force: true,
+    }));
+
+    const previousHome = process.env.KIMI_SHARE_DIR;
+    process.env.KIMI_SHARE_DIR = providerHome;
+    t.after(() => {
+        if (previousHome === undefined) delete process.env.KIMI_SHARE_DIR;
+        else process.env.KIMI_SHARE_DIR = previousHome;
+    });
+
+    const service = new KimiSessionService();
+    const sessions = service.getSessions({ forceRefresh: true, candidatePaths: [cwd] });
+    assert.equal(sessions.sessions[0]?.id, sessionId);
+    const adapter = new KimiConversationAdapter({
+        resolveSource: id => service.resolveConversationSource(id),
+        watchSessionChanges: () => ({ dispose() {} }),
+        now: Date.now,
+        setTimeout(callback) {
+            callback();
+            return 1;
+        },
+        clearTimeout() {},
+    });
+    t.after(() => adapter.dispose());
+    const outline = await adapter.readOutline(sessionId);
+    const { viewer, panel } = createViewer({
+        readOutline: (_provider, id, signal) => adapter.readOutline(id, signal),
+        readPage: (request, signal) => adapter.readPage(request, signal),
+        watch: (_provider, id, callback) => adapter.watch(id, callback),
+    });
+
+    await viewer.open(target(sessionId, outline.interactions[0].id, {
+        provider: 'kimi',
+        expectedRevision: outline.sourceRevision,
+    }));
+    const publication = decodeInitialPublication(panel.webview.html);
+    assert.ok(publication.html.includes('Render this Kimi Code session.'));
+    assert.ok(publication.html.includes('Kimi Code is now visible.'));
 });
 
 test('CONVERSATION-VIEWER-PARTIAL-001 derives first and latest capped positions from a real Kimi adapter', async t => {

--- a/tests/unit/aiSessions/lifecycle.test.js
+++ b/tests/unit/aiSessions/lifecycle.test.js
@@ -98,6 +98,35 @@ test('PERSIST-LIFECYCLE-PARSER-001 [kimi] treats subagent progress events as run
     assert.match(signal.token, /^kimi:SubagentEvent:/);
 });
 
+test('PERSIST-LIFECYCLE-PARSER-001 [kimi] maps Kimi Code turn records', () => {
+    const signal = lifecycle.parseKimiLifecycleLines([
+        JSON.stringify({
+            type: 'turn.prompt',
+            turnId: 7,
+            origin: { kind: 'user' },
+            time: Date.parse('2026-07-24T08:00:00.000Z'),
+        }),
+        JSON.stringify({
+            type: 'context.append_loop_event',
+            event: { type: 'content.part', turnId: 7 },
+            time: Date.parse('2026-07-24T08:01:00.000Z'),
+        }),
+        JSON.stringify({
+            type: 'turn.ended',
+            turnId: 7,
+            reason: 'completed',
+            time: Date.parse('2026-07-24T08:02:00.000Z'),
+        }),
+    ], runStartedAtMs);
+
+    assert.ok(signal);
+    assert.equal(signal.phase, 'needsAttention');
+    assert.equal(signal.reason, 'completed');
+    assert.equal(signal.executionState, 'stopped');
+    assert.equal(signal.occurredAtMs, Date.parse('2026-07-24T08:02:00.000Z'));
+    assert.match(signal.token, /^kimi:turn\.ended:/);
+});
+
 test('PERSIST-LIFECYCLE-PARSER-001 [codex] treats ordinary turn progress as a running lease renewal', () => {
     const signal = lifecycle.parseCodexLifecycleLines([
         JSON.stringify({


### PR DESCRIPTION
## Summary

- discover and route Kimi Code and legacy Kimi session homes safely
- parse Kimi Code transcript events, tools, continuations, and subagents
- harden session index, lifecycle, and archive file handling
- restore CI contracts for descriptor-based lifecycle reads and empty provider homes

## Verification

- `npm run test:ci:linux:core`
- `npm run test:behavior-contracts`
- final read-only integration review

## Skill harvest

No skill change: the applicable worktree, review, installation, and publishing skills already covered the observed review and packaging recovery steps; fresh verification confirmed compliance.

## Owner approvals

```text
approve 5155921537826feb0050134e5ade63b0d2e37dec
```