### PR TITLE
feat: prefer tmux with automatic terminal fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,10 +260,12 @@ logs a `status=...` line per sink — then inspect the delivery log with
 - Install and authenticate the Codex, Claude, or Kimi command-line tools you
   intend to use. Provider accounts and access are not included with Agent
   Pivot.
-- tmux is optional. To use it, install tmux on the extension host: locally for
-  a local window, on the SSH host, inside WSL, or inside the Dev Container.
-  Native Windows extension hosts can use Direct Terminal mode; the tmux
-  backend requires a POSIX extension host.
+- tmux is optional. Automatic terminal mode prefers tmux when it is installed
+  on the extension host, then falls back to a VS Code terminal and offers an
+  installation link when it is unavailable. Install tmux locally for a local
+  window, on the SSH host, inside WSL, or inside the Dev Container. Native
+  Windows extension hosts use VS Code Terminal; the tmux backend requires a
+  POSIX extension host.
 
 ## Getting started
 
@@ -290,8 +292,9 @@ Configure Agent Pivot in VS Code settings. Common settings include:
 
 - `agentPivot.storeProjectsInSettings`: store projects in user
   settings so VS Code Settings Sync can synchronize them.
-- `agentPivot.aiSessionTerminalMode`: use `vscode` (default) or `tmux` when
-  creating a runtime.
+- `agentPivot.aiSessionTerminalMode`: use `auto` (default) to prefer tmux and
+  fall back to VS Code Terminal, `vscode` to always use VS Code Terminal, or
+  `tmux` to require tmux and confirm any fallback.
 - `agentPivot.aiSessionTmuxLayout`: use one managed tmux session per project or
   one per AI session.
 - `agentPivot.aiSessionTmuxPath`: set one tmux executable name or absolute

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -4262,6 +4262,24 @@
     ]
   },
   {
+    "id": "RUNTIME-AUTO-TMUX-FALLBACK-001",
+    "domain": "runtime",
+    "title": "Automatic terminal mode prefers tmux and starts in VS Code Terminal when tmux is unavailable",
+    "priority": "P1",
+    "status": "automated",
+    "owners": [
+      "tests/contract/aiSessions/runtimePrimitives.test.js",
+      "tests/contract/aiSessions/runtimeCoordinator.test.js",
+      "tests/contract/aiSessions/runtimeComposition.test.js"
+    ],
+    "evidence": [
+      "package.json",
+      "src/aiSessions/runtimeConfiguration.ts",
+      "src/aiSessions/runtimeCoordinator.ts",
+      "src/dashboard.ts"
+    ]
+  },
+  {
     "id": "RUNTIME-RUNTIME-CONTROLLER-001",
     "domain": "runtime",
     "title": "Runtime Controller behavior",

--- a/package.json
+++ b/package.json
@@ -305,12 +305,18 @@
                 "agentPivot.aiSessionTerminalMode": {
                     "type": "string",
                     "enum": [
+                        "auto",
                         "vscode",
                         "tmux"
                     ],
-                    "default": "vscode",
+                    "enumDescriptions": [
+                        "Prefer managed tmux sessions when available, otherwise start in a VS Code terminal.",
+                        "Always run AI sessions directly in VS Code terminals.",
+                        "Require managed tmux sessions and ask before falling back when tmux is unavailable."
+                    ],
+                    "default": "auto",
                     "scope": "machine",
-                    "description": "Choose whether new AI sessions run in VS Code terminals or managed tmux sessions. tmux preserves a process only while its execution host remains awake and running."
+                    "description": "Choose how new AI sessions run. Automatic mode prefers managed tmux sessions and uses VS Code Terminal when tmux is unavailable. tmux preserves a process only while its execution host remains awake and running."
                 },
                 "agentPivot.aiSessionYoloMode": {
                     "type": "boolean",

--- a/scripts/run-ai-session-safety-checks.js
+++ b/scripts/run-ai-session-safety-checks.js
@@ -5602,7 +5602,7 @@ function runWebviewContentChecks() {
     assert.ok(styles.includes('calc(3 * 42px + 2 * 2px)'));
     assert.deepStrictEqual(
         packageJson.contributes.configuration.properties['agentPivot.aiSessionTerminalMode'].enum,
-        ['vscode', 'tmux']
+        ['auto', 'vscode', 'tmux']
     );
     const runningAnimation = packageJson.contributes.configuration.properties[
         'agentPivot.aiSessionRunningCardAnimation'

--- a/scripts/run-ai-session-tmux-checks.js
+++ b/scripts/run-ai-session-tmux-checks.js
@@ -778,21 +778,22 @@ function runtimeRecordFilename(record) {
 
 function runRuntimeConfigurationChecks() {
     assert.deepStrictEqual(runtimeConfiguration.readAiSessionRuntimeConfiguration(config({})), {
-        mode: 'vscode', tmuxLayout: 'project', tmuxPath: 'tmux',
+        mode: 'auto', tmuxLayout: 'project', tmuxPath: 'tmux',
     });
     assert.deepStrictEqual(runtimeConfiguration.readAiSessionRuntimeConfiguration(config({
         aiSessionTerminalMode: 'tmux', aiSessionTmuxLayout: 'session', aiSessionTmuxPath: '/opt/bin/tmux',
     })), { mode: 'tmux', tmuxLayout: 'session', tmuxPath: '/opt/bin/tmux' });
     assert.deepStrictEqual(runtimeConfiguration.readAiSessionRuntimeConfiguration(config({
         aiSessionTerminalMode: 'bad', aiSessionTmuxLayout: 'bad', aiSessionTmuxPath: '   ',
-    })), { mode: 'vscode', tmuxLayout: 'project', tmuxPath: 'tmux' });
+    })), { mode: 'auto', tmuxLayout: 'project', tmuxPath: 'tmux' });
     assert.deepStrictEqual(runtimeConfiguration.readAiSessionRuntimeConfiguration(config({
         aiSessionTerminalMode: null, aiSessionTmuxLayout: 1, aiSessionTmuxPath: false,
-    })), { mode: 'vscode', tmuxLayout: 'project', tmuxPath: 'tmux' });
+    })), { mode: 'auto', tmuxLayout: 'project', tmuxPath: 'tmux' });
 
     const manifest = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8'));
     const properties = manifest.contributes.configuration.properties;
-    assert.deepStrictEqual(properties['agentPivot.aiSessionTerminalMode'].enum, ['vscode', 'tmux']);
+    assert.deepStrictEqual(properties['agentPivot.aiSessionTerminalMode'].enum, ['auto', 'vscode', 'tmux']);
+    assert.strictEqual(properties['agentPivot.aiSessionTerminalMode'].default, 'auto');
     assert.strictEqual(properties['agentPivot.aiSessionTerminalMode'].scope, 'machine');
     assert.strictEqual(properties['agentPivot.aiSessionTmuxLayout'].default, 'project');
     assert.strictEqual(properties['agentPivot.aiSessionTmuxPath'].scope, 'machine');

--- a/scripts/run-ai-session-tmux-checks.js
+++ b/scripts/run-ai-session-tmux-checks.js
@@ -1293,6 +1293,27 @@ async function runTmuxClientChecks() {
     assert.strictEqual(calls.filter(call => call.args[0] === '-V').length, 1);
     assert.deepStrictEqual(await client.listWindows(), []);
 
+    let tmuxInstalledAfterFallback = false;
+    let postInstallAvailabilityProbes = 0;
+    const postInstallClient = new tmuxClientModule.TmuxClient('tmux', {
+        run: async (_file, args) => {
+            if (args[0] === '-V') {
+                postInstallAvailabilityProbes++;
+                return tmuxInstalledAfterFallback
+                    ? { exitCode: 0, stdout: 'tmux 3.2a\n', stderr: '' }
+                    : { exitCode: null, stdout: '', stderr: '', failureCategory: 'not-found' };
+            }
+            return { exitCode: 0, stdout: `${requiredCommands.join('\n')}\n`, stderr: '' };
+        },
+    });
+    assert.strictEqual((await postInstallClient.checkAvailability()).available, false);
+    tmuxInstalledAfterFallback = true;
+    assert.deepStrictEqual(await postInstallClient.checkAvailability(true), {
+        available: true, version: '3.2a',
+    });
+    assert.strictEqual(postInstallAvailabilityProbes, 2,
+        'a forced refresh must re-probe tmux after installation');
+
     const emptyServerClient = new tmuxClientModule.TmuxClient('/opt/bin/tmux', {
         run: async (_file, args) => {
             if (args[0] === '-V') {

--- a/src/aiSessions/runtimeConfiguration.ts
+++ b/src/aiSessions/runtimeConfiguration.ts
@@ -7,13 +7,13 @@ interface ConfigurationReader {
 }
 
 export function readAiSessionRuntimeConfiguration(configuration: ConfigurationReader): AiSessionRuntimeConfiguration {
-    const mode = configuration.get<unknown>('aiSessionTerminalMode', 'vscode');
+    const mode = configuration.get<unknown>('aiSessionTerminalMode', 'auto');
     const tmuxLayout = configuration.get<unknown>('aiSessionTmuxLayout', 'project');
     const configuredTmuxPath = configuration.get<unknown>('aiSessionTmuxPath', 'tmux');
     const tmuxPath = typeof configuredTmuxPath === 'string' ? configuredTmuxPath.trim() : '';
 
     return {
-        mode: mode === 'tmux' ? 'tmux' : 'vscode',
+        mode: mode === 'vscode' || mode === 'tmux' ? mode : 'auto',
         tmuxLayout: tmuxLayout === 'session' ? 'session' : 'project',
         tmuxPath: tmuxPath || 'tmux',
     };

--- a/src/aiSessions/runtimeCoordinator.ts
+++ b/src/aiSessions/runtimeCoordinator.ts
@@ -48,6 +48,7 @@ export interface AiSessionRuntimeCoordinatorDependencies<TTerminal> {
     tmux: ClosableRuntimeBackend<TTerminal>;
     getConfiguration(): AiSessionRuntimeConfiguration;
     chooseTmuxFallback(context: AiSessionTmuxFallbackContext): Promise<AiSessionTmuxFallbackChoice>;
+    notifyAutomaticTmuxFallback?(context: AiSessionTmuxFallbackContext): void;
     hasLiveTmuxOwnership?(): Promise<boolean>;
     hasKnownTmuxHint?(identity: AiSessionRuntimeIdentity): Promise<boolean>;
     clearKnownTmuxHint?(identity: AiSessionRuntimeIdentity): Promise<void>;
@@ -89,7 +90,7 @@ export class AiSessionRuntimeCoordinator<TTerminal = vscode.Terminal> {
         const persistedLiveOwnership = this.dependencies.hasLiveTmuxOwnership
             ? await this.dependencies.hasLiveTmuxOwnership()
             : true;
-        if (configuration.mode === 'vscode' && !cachedLiveOwnership && !persistedLiveOwnership
+        if (configuration.mode !== 'tmux' && !cachedLiveOwnership && !persistedLiveOwnership
             && this.isTmuxUnavailable(outcome.tmuxError)) {
             return;
         }
@@ -397,6 +398,9 @@ export class AiSessionRuntimeCoordinator<TTerminal = vscode.Terminal> {
             return { status: 'started', runtime: cloneRuntime(runtime) };
         }
         if (refresh.tmuxError && this.isTmuxUnavailable(refresh.tmuxError)) {
+            if (configuration.mode === 'auto') {
+                return this.resumeViaAutomaticDirect(request, refresh.tmuxError);
+            }
             return this.resumeViaExplicitDirect(request, refresh.tmuxError, false);
         }
 
@@ -415,7 +419,9 @@ export class AiSessionRuntimeCoordinator<TTerminal = vscode.Terminal> {
             }
             const hasKnownHint = !!this.dependencies.hasKnownTmuxHint
                 && await this.dependencies.hasKnownTmuxHint(cloneAiSessionRuntimeIdentity(request.identity));
-            return this.resumeViaExplicitDirect(request, error, hasKnownHint);
+            return configuration.mode === 'auto' && !hasKnownHint
+                ? this.resumeViaAutomaticDirect(request, error)
+                : this.resumeViaExplicitDirect(request, error, hasKnownHint);
         }
     }
 
@@ -449,6 +455,9 @@ export class AiSessionRuntimeCoordinator<TTerminal = vscode.Terminal> {
             throw refresh.tmuxError;
         }
         if (refresh.tmuxError && this.isTmuxUnavailable(refresh.tmuxError)) {
+            if (configuration.mode === 'auto') {
+                return this.createViaAutomaticDirect(request, refresh.tmuxError);
+            }
             return this.createViaExplicitDirect(request, refresh.tmuxError);
         }
         try {
@@ -461,8 +470,32 @@ export class AiSessionRuntimeCoordinator<TTerminal = vscode.Terminal> {
             if (!this.isTmuxUnavailable(error)) {
                 throw error;
             }
-            return this.createViaExplicitDirect(request, error);
+            return configuration.mode === 'auto'
+                ? this.createViaAutomaticDirect(request, error)
+                : this.createViaExplicitDirect(request, error);
         }
+    }
+
+    private async resumeViaAutomaticDirect(
+        request: AiSessionResumeRuntimeRequest,
+        error: unknown
+    ): Promise<AiSessionRuntimeActionResult<TTerminal>> {
+        this.dependencies.notifyAutomaticTmuxFallback?.({
+            operation: 'resume', knownHint: false, error,
+        });
+        const runtime = await this.dependencies.direct.ensureResume(request);
+        return { status: 'started', runtime: cloneRuntime(runtime) };
+    }
+
+    private async createViaAutomaticDirect(
+        request: AiSessionCreateRuntimeRequest,
+        error: unknown
+    ): Promise<AiSessionRuntimeActionResult<TTerminal>> {
+        this.dependencies.notifyAutomaticTmuxFallback?.({
+            operation: 'create', knownHint: false, error,
+        });
+        const runtime = await this.dependencies.direct.ensurePending(request);
+        return { status: 'started', runtime: cloneRuntime(runtime) };
     }
 
     private async resumeViaExplicitDirect(

--- a/src/aiSessions/runtimeCoordinator.ts
+++ b/src/aiSessions/runtimeCoordinator.ts
@@ -480,10 +480,10 @@ export class AiSessionRuntimeCoordinator<TTerminal = vscode.Terminal> {
         request: AiSessionResumeRuntimeRequest,
         error: unknown
     ): Promise<AiSessionRuntimeActionResult<TTerminal>> {
+        const runtime = await this.dependencies.direct.ensureResume(request);
         this.dependencies.notifyAutomaticTmuxFallback?.({
             operation: 'resume', knownHint: false, error,
         });
-        const runtime = await this.dependencies.direct.ensureResume(request);
         return { status: 'started', runtime: cloneRuntime(runtime) };
     }
 
@@ -491,10 +491,10 @@ export class AiSessionRuntimeCoordinator<TTerminal = vscode.Terminal> {
         request: AiSessionCreateRuntimeRequest,
         error: unknown
     ): Promise<AiSessionRuntimeActionResult<TTerminal>> {
+        const runtime = await this.dependencies.direct.ensurePending(request);
         this.dependencies.notifyAutomaticTmuxFallback?.({
             operation: 'create', knownHint: false, error,
         });
-        const runtime = await this.dependencies.direct.ensurePending(request);
         return { status: 'started', runtime: cloneRuntime(runtime) };
     }
 

--- a/src/aiSessions/runtimeTypes.ts
+++ b/src/aiSessions/runtimeTypes.ts
@@ -33,6 +33,7 @@ export function isValidAiSessionPromotionDisplayName(value: unknown): value is s
 }
 
 export type AiSessionRuntimeBackendId = 'vscode' | 'tmux';
+export type AiSessionTerminalMode = 'auto' | AiSessionRuntimeBackendId;
 export type AiSessionTmuxLayout = 'project' | 'session';
 export type AiSessionRuntimeState = 'pending' | 'active' | 'completed' | 'stopped' | 'conflict';
 
@@ -450,7 +451,7 @@ extends AiSessionPendingPromotionCandidate<TTerminal> {
 }
 
 export interface AiSessionRuntimeConfiguration {
-    mode: AiSessionRuntimeBackendId;
+    mode: AiSessionTerminalMode;
     tmuxLayout: AiSessionTmuxLayout;
     tmuxPath: string;
 }

--- a/src/aiSessions/tmuxClient.ts
+++ b/src/aiSessions/tmuxClient.ts
@@ -228,8 +228,8 @@ export class TmuxClient {
         this.executablePath = normalizeExecutablePath(executablePath);
     }
 
-    checkAvailability(): Promise<TmuxAvailability> {
-        if (!this.availabilityPromise) {
+    checkAvailability(force: boolean = false): Promise<TmuxAvailability> {
+        if (force || !this.availabilityPromise) {
             this.availabilityPromise = this.probeAvailability();
         }
         return this.availabilityPromise;

--- a/src/aiSessions/tmuxRuntimeBackend.ts
+++ b/src/aiSessions/tmuxRuntimeBackend.ts
@@ -158,7 +158,7 @@ implements AiSessionExecutableRuntimeBackend<TTerminal> {
     }
 
     async refresh(force: boolean = false): Promise<void> {
-        await this.requireAvailable();
+        await this.requireAvailable(force);
         try {
             await this.dependencies.discovery.refresh(force);
         } catch (error) {
@@ -1205,14 +1205,14 @@ implements AiSessionExecutableRuntimeBackend<TTerminal> {
         };
     }
 
-    private async requireAvailable(): Promise<void> {
+    private async requireAvailable(force: boolean = false): Promise<void> {
         if (this.dependencies.platform === 'win32') {
             throw new TmuxRuntimeUnavailableError(
                 'unsupported-platform',
                 'Managed tmux runtimes require a POSIX extension host.'
             );
         }
-        const availability = await this.dependencies.client.checkAvailability();
+        const availability = await this.dependencies.client.checkAvailability(force);
         if ('category' in availability) {
             throw new TmuxRuntimeUnavailableError(
                 unavailableReason(availability.category),

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -3666,16 +3666,36 @@ async function initializeDashboard(
             return;
         }
         automaticTmuxFallbackNoticeShown = true;
+        if (fallback.error instanceof TmuxRuntimeUnavailableError
+            && fallback.error.reason === 'unsupported-platform') {
+            void vscode.window.showWarningMessage(
+                'Managed tmux sessions require a POSIX extension host. Agent Pivot started the AI session in VS Code Terminal.'
+            ).then(undefined, error =>
+                logError('Could not show the tmux platform recommendation.', error)
+            );
+            return;
+        }
         const installAction = 'Install tmux';
+        const openSettingsAction = 'Open Settings';
+        const action = fallback.error instanceof TmuxRuntimeUnavailableError
+            && fallback.error.reason === 'not-found'
+            ? installAction
+            : openSettingsAction;
         void vscode.window.showWarningMessage(
             'tmux is unavailable in this extension host. Agent Pivot started the AI session in VS Code Terminal.',
-            installAction
+            action
         ).then(choice => {
             if (choice === installAction) {
                 void vscode.env.openExternal(
                     vscode.Uri.parse('https://github.com/tmux/tmux/wiki/Installing')
-                ).then(undefined, error =>
-                    logError('Could not open the tmux installation guide.', error)
+                ).then(opened => {
+                    if (!opened) {
+                        logError('Could not open the tmux installation guide.', new Error('VS Code declined the URI.'));
+                    }
+                }, error => logError('Could not open the tmux installation guide.', error));
+            } else if (choice === openSettingsAction) {
+                void showAgentPivotSettings().catch(error =>
+                    logError('Could not open Agent Pivot settings.', error)
                 );
             }
         }, error => logError('Could not show the tmux installation recommendation.', error));

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -748,6 +748,7 @@ async function initializeDashboard(
         getFreezeConversationSessionMetadata: () => freezeConversationSessionMetadata,
     });
     let aiSessionRuntimeConfiguration = initialAiSessionRuntimeConfiguration;
+    let automaticTmuxFallbackNoticeShown = false;
     const {
         conversationCommentStore,
         projectCommentStore,
@@ -831,6 +832,7 @@ async function initializeDashboard(
         tmux: tmuxRuntimeBackend,
         getConfiguration: () => ({ ...aiSessionRuntimeConfiguration }),
         chooseTmuxFallback: chooseAiSessionTmuxFallback,
+        notifyAutomaticTmuxFallback: notifyAutomaticTmuxFallback,
         hasLiveTmuxOwnership,
         hasKnownTmuxHint: async identity => Boolean(identity.sessionId
             && await tmuxRuntimeStore.getKnown(identity.provider, identity.sessionId,
@@ -3656,6 +3658,27 @@ async function initializeDashboard(
             return 'settings';
         }
         return choice === directAction ? 'direct' : 'cancel';
+    }
+
+    function notifyAutomaticTmuxFallback(fallback: AiSessionTmuxFallbackContext): void {
+        logAiSessionRuntimeFailure(`${fallback.operation}-automatic-fallback`, fallback.error);
+        if (automaticTmuxFallbackNoticeShown) {
+            return;
+        }
+        automaticTmuxFallbackNoticeShown = true;
+        const installAction = 'Install tmux';
+        void vscode.window.showWarningMessage(
+            'tmux is unavailable in this extension host. Agent Pivot started the AI session in VS Code Terminal.',
+            installAction
+        ).then(choice => {
+            if (choice === installAction) {
+                void vscode.env.openExternal(
+                    vscode.Uri.parse('https://github.com/tmux/tmux/wiki/Installing')
+                ).then(undefined, error =>
+                    logError('Could not open the tmux installation guide.', error)
+                );
+            }
+        }, error => logError('Could not show the tmux installation recommendation.', error));
     }
 
     async function handleAiSessionRuntimeConfigurationChanged(): Promise<void> {

--- a/tests/contract/aiSessions/runtimeComposition.test.js
+++ b/tests/contract/aiSessions/runtimeComposition.test.js
@@ -500,6 +500,29 @@ test('RUNTIME-AUTO-TMUX-FALLBACK-001 production automatic mode recommends tmux i
     );
 });
 
+test('RUNTIME-AUTO-TMUX-FALLBACK-001 does not offer a tmux installation on unsupported extension hosts', () => {
+    const result = runProductionActivation('automatic-unsupported-fallback');
+    assert.equal(result.failure, null);
+    assert.deepEqual(result.fallbackResumeStatuses, ['started', 'started']);
+    assert.deepEqual(result.warningMessages, [{
+        message: 'Managed tmux sessions require a POSIX extension host. Agent Pivot started the AI session in VS Code Terminal.',
+        modal: false,
+        items: [],
+    }]);
+});
+
+test('RUNTIME-AUTO-TMUX-FALLBACK-001 ignores an unsupported-host notification rejection after Direct fallback succeeds', () => {
+    const result = runProductionActivation('automatic-unsupported-notice-error');
+    assert.equal(result.failure, null);
+    assert.deepEqual(result.fallbackResumeStatuses, ['started', 'started']);
+});
+
+test('RUNTIME-AUTO-TMUX-FALLBACK-001 opens the tmux installation guide when selected', () => {
+    const result = runProductionActivation('automatic-install-link');
+    assert.equal(result.failure, null);
+    assert.deepEqual(result.openedExternalUris, ['https://github.com/tmux/tmux/wiki/Installing']);
+});
+
 test('RUNTIME-HOST-RUNTIME-COMPOSITION-001 RUNTIME-RUNTIME-CONFIGURATION-001 CONVERSATION-THINKING-VISIBILITY-001 production configuration change routes runtime and Conversation settings', () => {
     const result = runProductionActivation('configuration-change');
     assert.equal(result.failure, null);

--- a/tests/contract/aiSessions/runtimeComposition.test.js
+++ b/tests/contract/aiSessions/runtimeComposition.test.js
@@ -483,6 +483,23 @@ test('RUNTIME-HOST-RUNTIME-COMPOSITION-001 production tmux fallback prompt is mo
     );
 });
 
+test('RUNTIME-AUTO-TMUX-FALLBACK-001 production automatic mode recommends tmux installation without blocking VS Code terminal fallback', () => {
+    const result = runProductionActivation('automatic-fallback');
+    assert.equal(result.failure, null);
+    assert.deepEqual(result.fallbackResumeStatuses, ['started', 'started']);
+    assert.deepEqual(result.warningMessages, [{
+        message: 'tmux is unavailable in this extension host. Agent Pivot started the AI session in VS Code Terminal.',
+        modal: false,
+        items: ['Install tmux'],
+    }]);
+    assert.deepEqual(
+        result.tmuxRuntimeFailureDiagnostics.filter(
+            diagnostic => diagnostic.operation.endsWith('-automatic-fallback')
+        ).map(diagnostic => diagnostic.operation),
+        ['resume-automatic-fallback', 'create-automatic-fallback']
+    );
+});
+
 test('RUNTIME-HOST-RUNTIME-COMPOSITION-001 RUNTIME-RUNTIME-CONFIGURATION-001 CONVERSATION-THINKING-VISIBILITY-001 production configuration change routes runtime and Conversation settings', () => {
     const result = runProductionActivation('configuration-change');
     assert.equal(result.failure, null);

--- a/tests/contract/aiSessions/runtimeCoordinator.test.js
+++ b/tests/contract/aiSessions/runtimeCoordinator.test.js
@@ -131,6 +131,31 @@ test('RUNTIME-RUNTIME-COORDINATOR-001 maps tmux unavailable choices without hidi
     await assert.rejects(failing.resume(fakeResumeRequest('fail-closed')), error => error === unexpected);
 });
 
+test('RUNTIME-AUTO-TMUX-FALLBACK-001 automatically starts in a VS Code terminal when preferred tmux is unavailable', async () => {
+    const direct = createFakeRuntimeBackend('vscode');
+    const unavailable = new TmuxRuntimeUnavailableError('not-found', 'tmux unavailable');
+    const fallbackChoices = [];
+    const fallbackNotifications = [];
+    const coordinator = createCoordinator(
+        direct,
+        createFakeRuntimeBackend('tmux', { refreshError: unavailable }),
+        {
+            getConfiguration: () => ({ mode: 'auto', tmuxLayout: 'project', tmuxPath: 'tmux' }),
+            chooseTmuxFallback: async context => { fallbackChoices.push(context); return 'cancel'; },
+            notifyAutomaticTmuxFallback: context => fallbackNotifications.push(context),
+        }
+    );
+
+    const resumed = await coordinator.resume(fakeResumeRequest('automatic-fallback'));
+    const created = await coordinator.create(fakeCreateRequest('automatic-fallback'));
+
+    assert.deepEqual([resumed.runtime.backend, created.runtime.backend], ['vscode', 'vscode']);
+    assert.deepEqual(fallbackChoices.map(choice => choice.operation), []);
+    assert.deepEqual(fallbackNotifications.map(notification => notification.operation), ['resume', 'create']);
+    assert.equal(direct.ensureResumeCalls, 1);
+    assert.equal(direct.ensurePendingCalls, 1);
+});
+
 test('RUNTIME-DIRECT-CREATE-TMUX-FAULT-ISOLATION-001 creates directly when tmux refresh fails unexpectedly', async () => {
     const direct = createFakeRuntimeBackend('vscode');
     const tmuxFailure = new Error('stale tmux persistence lock');

--- a/tests/contract/aiSessions/runtimeCoordinator.test.js
+++ b/tests/contract/aiSessions/runtimeCoordinator.test.js
@@ -156,6 +156,86 @@ test('RUNTIME-AUTO-TMUX-FALLBACK-001 automatically starts in a VS Code terminal 
     assert.equal(direct.ensurePendingCalls, 1);
 });
 
+test('RUNTIME-AUTO-TMUX-FALLBACK-001 prefers available tmux and does not notify or start a Direct runtime', async () => {
+    const direct = createFakeRuntimeBackend('vscode');
+    const tmux = createFakeRuntimeBackend('tmux');
+    const notifications = [];
+    const coordinator = createCoordinator(direct, tmux, {
+        getConfiguration: () => ({ mode: 'auto', tmuxLayout: 'project', tmuxPath: 'tmux' }),
+        notifyAutomaticTmuxFallback: context => notifications.push(context),
+    });
+
+    const resumed = await coordinator.resume(fakeResumeRequest('automatic-tmux-resume'));
+    const created = await coordinator.create(fakeCreateRequest('automatic-tmux-create'));
+
+    assert.deepEqual([resumed.runtime.backend, created.runtime.backend], ['tmux', 'tmux']);
+    assert.equal(tmux.ensureResumeCalls, 1);
+    assert.equal(tmux.ensurePendingCalls, 1);
+    assert.equal(direct.ensureResumeCalls, 0);
+    assert.equal(direct.ensurePendingCalls, 0);
+    assert.deepEqual(notifications, []);
+});
+
+test('RUNTIME-AUTO-TMUX-FALLBACK-001 does not announce a Direct fallback until its launch succeeds', async () => {
+    const unavailable = new TmuxRuntimeUnavailableError('not-found', 'tmux unavailable');
+    const notifications = [];
+    const failing = createCoordinator(
+        createFakeRuntimeBackend('vscode', { ensureError: new Error('Direct launch failed') }),
+        createFakeRuntimeBackend('tmux', { refreshError: unavailable }),
+        {
+            getConfiguration: () => ({ mode: 'auto', tmuxLayout: 'project', tmuxPath: 'tmux' }),
+            notifyAutomaticTmuxFallback: context => notifications.push(context),
+        }
+    );
+
+    await assert.rejects(failing.resume(fakeResumeRequest('automatic-direct-failure')), /Direct launch failed/);
+    assert.deepEqual(notifications, []);
+
+    const succeeding = createCoordinator(
+        createFakeRuntimeBackend('vscode'),
+        createFakeRuntimeBackend('tmux', { refreshError: unavailable }),
+        {
+            getConfiguration: () => ({ mode: 'auto', tmuxLayout: 'project', tmuxPath: 'tmux' }),
+            notifyAutomaticTmuxFallback: context => notifications.push(context),
+        }
+    );
+    assert.equal((await succeeding.resume(fakeResumeRequest('automatic-direct-success'))).status, 'started');
+    assert.deepEqual(notifications.map(notification => notification.operation), ['resume']);
+});
+
+test('RUNTIME-AUTO-TMUX-FALLBACK-001 falls back after a late tmux-unavailable error without bypassing known runtime protection', async () => {
+    const unavailable = new TmuxRuntimeUnavailableError('not-found', 'tmux unavailable');
+    const direct = createFakeRuntimeBackend('vscode');
+    const notifications = [];
+    const coordinator = createCoordinator(
+        direct,
+        createFakeRuntimeBackend('tmux', { ensureError: unavailable }),
+        {
+            getConfiguration: () => ({ mode: 'auto', tmuxLayout: 'project', tmuxPath: 'tmux' }),
+            notifyAutomaticTmuxFallback: context => notifications.push(context),
+        }
+    );
+
+    assert.equal((await coordinator.resume(fakeResumeRequest('automatic-late-resume'))).runtime.backend, 'vscode');
+    assert.equal((await coordinator.create(fakeCreateRequest('automatic-late-create'))).runtime.backend, 'vscode');
+    assert.deepEqual(notifications.map(notification => notification.operation), ['resume', 'create']);
+
+    const protectedDirect = createFakeRuntimeBackend('vscode');
+    const protectedChoices = [];
+    const protectedCoordinator = createCoordinator(
+        protectedDirect,
+        createFakeRuntimeBackend('tmux', { ensureError: unavailable }),
+        {
+            getConfiguration: () => ({ mode: 'auto', tmuxLayout: 'project', tmuxPath: 'tmux' }),
+            hasKnownTmuxHint: async () => true,
+            chooseTmuxFallback: async context => { protectedChoices.push(context); return 'cancel'; },
+        }
+    );
+    assert.equal((await protectedCoordinator.resume(fakeResumeRequest('automatic-known-late'))).status, 'cancelled');
+    assert.equal(protectedDirect.ensureResumeCalls, 0);
+    assert.deepEqual(protectedChoices.map(choice => choice.knownHint), [true]);
+});
+
 test('RUNTIME-DIRECT-CREATE-TMUX-FAULT-ISOLATION-001 creates directly when tmux refresh fails unexpectedly', async () => {
     const direct = createFakeRuntimeBackend('vscode');
     const tmuxFailure = new Error('stale tmux persistence lock');

--- a/tests/contract/aiSessions/runtimePrimitives.test.js
+++ b/tests/contract/aiSessions/runtimePrimitives.test.js
@@ -48,9 +48,9 @@ function decodePowerShellPayload(command) {
     return Buffer.from(command.slice(prefix.length), 'base64').toString('utf16le');
 }
 
-test('RUNTIME-RUNTIME-CONFIGURATION-001 reads supported settings and fails closed to manifest defaults', () => {
+test('RUNTIME-RUNTIME-CONFIGURATION-001 RUNTIME-AUTO-TMUX-FALLBACK-001 defaults to automatic tmux preference and fails closed to manifest defaults', () => {
     assert.deepEqual(runtimeConfiguration.readAiSessionRuntimeConfiguration(configuration({})), {
-        mode: 'vscode', tmuxLayout: 'project', tmuxPath: 'tmux',
+        mode: 'auto', tmuxLayout: 'project', tmuxPath: 'tmux',
     });
     assert.deepEqual(runtimeConfiguration.readAiSessionRuntimeConfiguration(configuration({
         aiSessionTerminalMode: 'tmux',
@@ -63,7 +63,7 @@ test('RUNTIME-RUNTIME-CONFIGURATION-001 reads supported settings and fails close
         { aiSessionTerminalMode: null, aiSessionTmuxLayout: 1, aiSessionTmuxPath: false },
     ]) {
         assert.deepEqual(runtimeConfiguration.readAiSessionRuntimeConfiguration(configuration(invalid)), {
-            mode: 'vscode', tmuxLayout: 'project', tmuxPath: 'tmux',
+            mode: 'auto', tmuxLayout: 'project', tmuxPath: 'tmux',
         });
     }
 
@@ -72,7 +72,8 @@ test('RUNTIME-RUNTIME-CONFIGURATION-001 reads supported settings and fails close
     const mode = properties['agentPivot.aiSessionTerminalMode'];
     const layout = properties['agentPivot.aiSessionTmuxLayout'];
     const executable = properties['agentPivot.aiSessionTmuxPath'];
-    assert.deepEqual(mode.enum, ['vscode', 'tmux']);
+    assert.deepEqual(mode.enum, ['auto', 'vscode', 'tmux']);
+    assert.equal(mode.default, 'auto');
     assert.equal(mode.scope, 'machine');
     assert.equal(layout.default, 'project');
     assert.equal(layout.scope, 'machine');

--- a/tests/fixtures/aiSessions/runtimeHostActivationHarness.js
+++ b/tests/fixtures/aiSessions/runtimeHostActivationHarness.js
@@ -426,7 +426,7 @@ async function main() {
         const { TmuxRuntimeBindingStore } = require('../../../out/aiSessions/tmuxRuntimeBindingStore');
         const { TmuxRuntimeDiscovery } = require('../../../out/aiSessions/tmuxRuntimeDiscovery');
         const { TmuxRuntimeUnavailableError } = require('../../../out/aiSessions/runtimeTypes');
-        const { fakeResumeRequest } = require('../../helpers/runtimeContract');
+        const { fakeCreateRequest, fakeResumeRequest } = require('../../helpers/runtimeContract');
         const { AiSessionAttentionController } = require('../../../out/aiSessions/attentionController');
         const AttentionBridgeClient = require('../../../out/aiSessions/attentionBridgeClient').default;
         const AiSessionAliasController = require('../../../out/aiSessions/aliasController').default;
@@ -535,7 +535,7 @@ async function main() {
         });
         const originalTmuxRefresh = TmuxRuntimeBackend.prototype.refresh;
         patch(TmuxRuntimeBackend.prototype, 'refresh', async function (...args) {
-            if (mode === 'fallback-choice') {
+            if (mode === 'fallback-choice' || mode === 'automatic-fallback') {
                 throw new TmuxRuntimeUnavailableError('not-found', 'tmux is unavailable (fixture)');
             }
             return originalTmuxRefresh.apply(this, args);
@@ -853,6 +853,14 @@ async function main() {
                 fallbackResumeStatuses.push(hinted.status);
                 const unhinted = await coordinatorInstance.resume(fakeResumeRequest('fallback-unknown'));
                 fallbackResumeStatuses.push(unhinted.status);
+            }
+            if (mode === 'automatic-fallback') {
+                await waitFor(() => Boolean(coordinatorInstance), 'runtime coordinator capture');
+                const resumed = await coordinatorInstance.resume(fakeResumeRequest('automatic-fallback-resume'));
+                fallbackResumeStatuses.push(resumed.status);
+                const created = await coordinatorInstance.create(fakeCreateRequest('automatic-fallback-create'));
+                fallbackResumeStatuses.push(created.status);
+                await waitFor(() => lifecycle.warningMessages.length >= 1, 'automatic tmux fallback notice');
             }
             if (mode === 'opened-terminal-restore') {
                 refreshMessageBuildsBeforeOpenedTerminal = lifecycle.outputLines.filter(line =>

--- a/tests/fixtures/aiSessions/runtimeHostActivationHarness.js
+++ b/tests/fixtures/aiSessions/runtimeHostActivationHarness.js
@@ -153,7 +153,10 @@ function createVscode(lifecycle) {
                     modal: options?.modal === true,
                     items: (options ? items : rest).map(item => String(item)),
                 });
-                return undefined;
+                if (lifecycle.warningMessageError) {
+                    throw new Error('Warning notification rejected (fixture)');
+                }
+                return lifecycle.warningAction;
             },
             showInformationMessage: async () => undefined, showInputBox: async () => undefined,
             showQuickPick: async () => undefined, showOpenDialog: async () => undefined,
@@ -191,7 +194,11 @@ function createVscode(lifecycle) {
         executedCommands,
         env: {
             remoteName: undefined, machineId: 'fixture-machine',
-            clipboard: { writeText: async () => undefined }, openExternal: async () => true,
+            clipboard: { writeText: async () => undefined },
+            openExternal: async uri => {
+                lifecycle.openedExternalUris.push(uri.toString());
+                return lifecycle.openExternalResult;
+            },
         },
         extensions: { getExtension: () => undefined, all: [] },
     };
@@ -253,7 +260,11 @@ async function main() {
         postDisposePublications: [],
         postDisposeWebviewMessages: [],
         postedWebviewMessages: [],
+        openedExternalUris: [],
+        openExternalResult: true,
         warningMessages: [],
+        warningAction: mode === 'automatic-install-link' ? 'Install tmux' : undefined,
+        warningMessageError: mode === 'automatic-unsupported-notice-error',
         statusBarItems: [],
     };
     const vscode = createVscode(lifecycle);
@@ -535,8 +546,13 @@ async function main() {
         });
         const originalTmuxRefresh = TmuxRuntimeBackend.prototype.refresh;
         patch(TmuxRuntimeBackend.prototype, 'refresh', async function (...args) {
-            if (mode === 'fallback-choice' || mode === 'automatic-fallback') {
-                throw new TmuxRuntimeUnavailableError('not-found', 'tmux is unavailable (fixture)');
+            if (mode === 'fallback-choice' || mode === 'automatic-fallback'
+                || mode === 'automatic-unsupported-fallback' || mode === 'automatic-install-link'
+                || mode === 'automatic-unsupported-notice-error') {
+                throw new TmuxRuntimeUnavailableError(
+                    mode.startsWith('automatic-unsupported-') ? 'unsupported-platform' : 'not-found',
+                    'tmux is unavailable (fixture)'
+                );
             }
             return originalTmuxRefresh.apply(this, args);
         });
@@ -854,7 +870,8 @@ async function main() {
                 const unhinted = await coordinatorInstance.resume(fakeResumeRequest('fallback-unknown'));
                 fallbackResumeStatuses.push(unhinted.status);
             }
-            if (mode === 'automatic-fallback') {
+            if (mode === 'automatic-fallback' || mode === 'automatic-unsupported-fallback'
+                || mode === 'automatic-install-link' || mode === 'automatic-unsupported-notice-error') {
                 await waitFor(() => Boolean(coordinatorInstance), 'runtime coordinator capture');
                 const resumed = await coordinatorInstance.resume(fakeResumeRequest('automatic-fallback-resume'));
                 fallbackResumeStatuses.push(resumed.status);
@@ -996,6 +1013,7 @@ async function main() {
             directRestoreRefreshAfterSettlement,
             tmuxRuntimeFailureDiagnostics,
             warningMessages: lifecycle.warningMessages,
+            openedExternalUris: lifecycle.openedExternalUris,
             statusBarItems: lifecycle.statusBarItems.map(item => ({
                 alignment: item.alignment,
                 command: item.command,


### PR DESCRIPTION
## Summary

- make automatic terminal mode prefer tmux and safely fall back to VS Code Terminal
- guide missing-tmux users to installation, while routing unsupported or misconfigured hosts appropriately
- harden re-probing and fallback notification timing with runtime and Host contract coverage

## Verification

- `npm run test:tmux`
- `npm run test:behavior-contracts`
- `git diff --check`

## Skill harvest

No skill change: task-local review findings were covered by the existing review, regression, worktree, and PR-publishing workflows; the added contract tests provide the reusable protection.

## Owner approvals

```
approve d1e7bbb3d2d02b6ed2f7e62e4ae7692819efbdcf
```