### PR TITLE
chore: prepare 1.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,23 +4,23 @@ All notable changes to the "Agent Pivot" extension will be documented in this fi
 
 ## [Unreleased]
 
-## [1.3.2] - 2026-08-30
+## [1.4.0] - 2026-08-30
 
 ### Fixed
 
-- Keep AI Conversation tool-call summaries concise and truthful: collapsed
-  groups now describe the action type while expanded entries retain the exact
-  command or file detail.
-- Keep tool-heavy, progressively rendered AI Conversations on the local tail
-  update path, preserving responsive session switching and disclosure state.
+- Keep side-by-side Conversation diff code columns aligned, including wrapped
+  added and removed lines.
+- Restore Kimi Code Conversation availability and remove the obsolete
+  open-tab migration notice.
+- Keep Conversation navigation stable when rendering changes are rebased.
 
 ### Changed
 
-- Group completed-turn work behind a single Worked-for disclosure with nested,
-  independently expandable tool-action groups.
 - Continue publishing through the VS Code Marketplace with the existing
   Workspace Trust declaration and progressively rendered AI Conversation
   experience.
+- Prefer tmux when it is available while retaining an automatic terminal
+  fallback when it is not.
 
 ## [1.3.1] - 2026-08-30
 
@@ -28,6 +28,11 @@ All notable changes to the "Agent Pivot" extension will be documented in this fi
 
 - Give the question controls a clear visual gutter around the status dots and
   remove the infrequently used previous-window and next-window controls.
+- Keep AI Conversation tool-call summaries concise and truthful: collapsed
+  groups now describe the action type while expanded entries retain the exact
+  command or file detail.
+- Keep tool-heavy, progressively rendered AI Conversations on the local tail
+  update path, preserving responsive session switching and disclosure state.
 
 ### Changed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "agent-pivot",
-    "version": "1.3.2",
+    "version": "1.4.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "agent-pivot",
-            "version": "1.3.2",
+            "version": "1.4.0",
             "license": "MIT",
             "dependencies": {
                 "dom-autoscroller": "^2.3.4",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "agent-pivot",
     "displayName": "Agent Pivot",
     "description": "Switch, monitor, and resume Codex, Claude, and Kimi sessions across VS Code workspaces. Project manager and prompt library for AI coding agents.",
-    "version": "1.3.2",
+    "version": "1.4.0",
     "publisher": "hzcheng",
     "license": "MIT",
     "icon": "media/extension_icon.png",

--- a/scripts/lib/brandIdentity.js
+++ b/scripts/lib/brandIdentity.js
@@ -10,7 +10,7 @@ const BRAND_IDENTITY = Object.freeze({
     publisher: 'hzcheng',
     mainPackageName: 'agent-pivot',
     mainExtensionId: 'hzcheng.agent-pivot',
-    mainVersion: '1.3.2',
+    mainVersion: '1.4.0',
     bridgePackageName: 'agent-pivot-attention-ui-bridge',
     bridgeExtensionId: 'hzcheng.agent-pivot-attention-ui-bridge',
     bridgeVersion: '1.0.3',

--- a/scripts/run-release-notes-checks.js
+++ b/scripts/run-release-notes-checks.js
@@ -14,8 +14,8 @@ const workflowPath = path.join(repositoryRoot, '.github', 'workflows', 'release-
 function validateReleaseContent({ readme, changelog, packageMetadata }) {
     assert.strictEqual(packageMetadata.displayName, 'Agent Pivot',
         'release metadata must use the Agent Pivot display name');
-    assert.strictEqual(packageMetadata.version, '1.3.2',
-        'the current Agent Pivot release must be version 1.3.2');
+    assert.strictEqual(packageMetadata.version, '1.4.0',
+        'the current Agent Pivot release must be version 1.4.0');
     const currentRelease = extractReleaseNotes(changelog, packageMetadata.version);
     const requiredReleaseFacts = [
         ['the Marketplace release channel', /VS Code Marketplace/i],
@@ -26,6 +26,11 @@ function validateReleaseContent({ readme, changelog, packageMetadata }) {
     for (const [label, pattern] of requiredReleaseFacts) {
         assert.match(currentRelease, pattern,
             `${packageMetadata.version} CHANGELOG release must document ${label}`);
+    }
+    const previousRelease = extractReleaseNotes(changelog, '1.3.1');
+    for (const pattern of [/question controls/i, /tool-call summaries/i, /local tail/i]) {
+        assert.match(previousRelease, pattern,
+            'the tagged 1.3.1 CHANGELOG release must remain available verbatim');
     }
     assert.match(readme, /Agent Pivot/i, 'README must document the current product name');
     assert.match(packageMetadata.description, /workspace/i,

--- a/scripts/run-release-packaging-checks.js
+++ b/scripts/run-release-packaging-checks.js
@@ -455,7 +455,7 @@ function runRealVsixArchiveChecks(mainPackage, bridgePackage) {
     );
     assert.strictEqual(
         path.basename(mainArtifact),
-        'agent-pivot-1.3.2.vsix',
+        'agent-pivot-1.4.0.vsix',
         'main release artifact name must remain exact',
     );
     assert.strictEqual(

--- a/tests/unit/tooling/brandIdentity.test.js
+++ b/tests/unit/tooling/brandIdentity.test.js
@@ -50,7 +50,7 @@ function manifests() {
             name: 'agent-pivot',
             displayName: 'Agent Pivot',
             publisher: 'hzcheng',
-            version: '1.3.2',
+            version: '1.4.0',
             icon: 'media/extension_icon.png',
             repository: {
                 type: 'git',
@@ -281,7 +281,7 @@ test('brand identity exposes the exact approved public contract', () => {
         publisher: 'hzcheng',
         mainPackageName: 'agent-pivot',
         mainExtensionId: 'hzcheng.agent-pivot',
-        mainVersion: '1.3.2',
+        mainVersion: '1.4.0',
         bridgePackageName: 'agent-pivot-attention-ui-bridge',
         bridgeExtensionId: 'hzcheng.agent-pivot-attention-ui-bridge',
         bridgeVersion: '1.0.3',

--- a/tests/unit/tooling/extensionHostLauncher.test.js
+++ b/tests/unit/tooling/extensionHostLauncher.test.js
@@ -150,7 +150,7 @@ test('RELEASE-SCHEDULED-EXTENSION-HOST-001 launches both extensions with pinned 
         ]);
         assert.deepEqual(packagePlan.map(item => path.basename(item.artifactPath)), [
             'agent-pivot-attention-ui-bridge-1.0.3.vsix',
-            'agent-pivot-1.3.2.vsix',
+            'agent-pivot-1.4.0.vsix',
         ]);
         assert.equal(options.extensionTestsPath,
             path.join(environment.testHarness, 'index.js'));

--- a/tests/unit/tooling/releaseNotes.test.js
+++ b/tests/unit/tooling/releaseNotes.test.js
@@ -14,7 +14,7 @@ test('release content validation cannot satisfy current facts from historical no
     const changelog = [
         '# Changelog',
         '',
-        '## [1.3.2] - 2026-08-30',
+        '## [1.4.0] - 2026-08-30',
         '',
         '- An unrelated documentation fix.',
         '',
@@ -37,10 +37,34 @@ test('release content validation cannot satisfy current facts from historical no
             changelog,
             packageMetadata: {
                 displayName: 'Agent Pivot',
-                version: '1.3.2',
+                version: '1.4.0',
                 description: 'Workspace command center.',
             },
         }),
-        /1\.3\.2 CHANGELOG release must document the Marketplace release channel/,
+        /1\.4\.0 CHANGELOG release must document the Marketplace release channel/,
+    );
+});
+
+test('release content validation preserves the tagged previous release', () => {
+    const changelog = [
+        '# Changelog',
+        '',
+        '## [1.4.0] - 2026-08-30',
+        '',
+        '- VS Code Marketplace release with Workspace Trust and progressively rendered Conversation content.',
+        '',
+    ].join('\n');
+
+    assert.throws(
+        () => releaseNotesChecks.validateReleaseContent({
+            readme: '# Agent Pivot\n',
+            changelog,
+            packageMetadata: {
+                displayName: 'Agent Pivot',
+                version: '1.4.0',
+                description: 'Workspace command center.',
+            },
+        }),
+        /No non-empty CHANGELOG\.md section found for version 1\.3\.1/,
     );
 });


### PR DESCRIPTION
## Summary

Prepare Agent Pivot 1.4.0 from the latest main branch. Align the extension manifest, lockfile, brand identity, release artifact checks, and release notes; preserve the tagged 1.3.1 release history with a regression guard.

## Verification

- `npm run test:release-notes`
- `npm run test:release-packaging`
- `node --test --test-concurrency=1 tests/browser/conversationViewer.test.js`

## Skill harvest

No skill change: the release-version correction and tagged-history review are covered by the updated release-note regression check; existing worktree, publishing, and review skills already describe the required workflow.

## Owner approvals

```text
approve a473613606693afa3741ea352d869b8ee10cdab3
```